### PR TITLE
Fix incorrect extension ID in VS Code test files

### DIFF
--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -22,7 +22,7 @@ export async function activate(docUri: vscode.Uri): Promise<vscode.TextDocument>
   // Ensure the extension is activated first.
   // ext.activate() awaits client.start() which resolves after the LSP
   // initialise/initialised handshake -- the server is ready at that point.
-  const ext = vscode.extensions.getExtension("tcl-lsp.tcl-lsp");
+  const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
   if (ext && !ext.isActive) {
     await ext.activate();
   }

--- a/editors/vscode/src/test/screenshotIndex.ts
+++ b/editors/vscode/src/test/screenshotIndex.ts
@@ -10,7 +10,7 @@ import * as vscode from "vscode";
 export async function run(): Promise<void> {
   // Activate the extension (which registers the demo command when
   // __SCREENSHOT_MODE__ is true).
-  const ext = vscode.extensions.getExtension("tcl-lsp.tcl-lsp");
+  const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
   if (ext && !ext.isActive) {
     await ext.activate();
   }

--- a/editors/vscode/src/test/serverHealth.test.ts
+++ b/editors/vscode/src/test/serverHealth.test.ts
@@ -8,7 +8,7 @@ interface TclLspApi {
 }
 
 function getApi(): TclLspApi {
-  const ext = vscode.extensions.getExtension("tcl-lsp.tcl-lsp")!;
+  const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp")!;
   return ext.exports as TclLspApi;
 }
 
@@ -19,7 +19,7 @@ function getApi(): TclLspApi {
 // client.start() fails, and the whole test run aborts with a clear message.
 suiteSetup(async function () {
   this.timeout(60_000);
-  const ext = vscode.extensions.getExtension("tcl-lsp.tcl-lsp")!;
+  const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp")!;
   await ext.activate();
   assert.ok(ext.isActive, "Extension failed to activate – server may have crashed on startup");
 });


### PR DESCRIPTION
Update extension ID references in test files from `tcl-lsp.tcl-lsp` to `bitwisecook.tcl-lsp` to match the correct publisher namespace.

## Changes
- Updated extension ID in `helper.ts`
- Updated extension ID in `screenshotIndex.ts`
- Updated extension ID in `serverHealth.test.ts` (2 occurrences)