### PR TITLE
Fix flaky tests by clearing SIGNATURES and adding polling helper

### DIFF
--- a/docs/flaky_tests.md
+++ b/docs/flaky_tests.md
@@ -2,33 +2,13 @@
 
 ## Summary
 
-Tests that intermittently fail due to timing, test ordering, or shared
-state — not due to real bugs.  These only reproduce in single-threaded
-`pytest` runs; CI uses `pytest-xdist` (parallel) where they pass reliably.
+No known flaky tests.  Previously-documented issues have been fixed:
 
-## Known flaky tests
+1. **`test_proc_multiple_params`** — The `conftest.py` autouse fixture now
+   clears `SIGNATURES` before calling `configure_signatures`, bypassing the
+   early-return optimisation that allowed in-place mutations to persist
+   across tests.
 
-### `tests/test_analyser.py::TestProcAnalysis::test_proc_multiple_params`
-
-- **Symptom**: assertion failure on proc parameter analysis
-- **Root cause**: test ordering / shared global state from earlier tests
-  (likely `configure_signatures` side effects leaking across tests)
-- **Reproduces**: only in single-threaded full-suite runs (`pytest tests/`)
-- **Passes**: in isolation (`pytest tests/test_analyser.py::TestProcAnalysis::test_proc_multiple_params`)
-  and with `pytest-xdist` (`pytest -n auto`)
-
-### `tests/test_async_diagnostics.py::TestSchedulerRapidUpdates::test_rapid_updates_only_last_published`
-
-- **Symptom**: async timing assertion — the "last published" diagnostic
-  doesn't match when the scheduler runs under heavy CPU load
-- **Root cause**: timing-sensitive test that assumes rapid updates settle
-  within a fixed window; single-threaded full-suite runs are slow enough
-  to violate this assumption
-- **Reproduces**: only in single-threaded full-suite runs under load
-- **Passes**: in isolation and with `pytest-xdist`
-
-## Mitigation
-
-CI runs tests via `make prep-pr` which uses `pytest-xdist` for parallelism.
-These flaky tests are not a gate concern.  If they start failing in CI,
-investigate whether new shared state was introduced.
+2. **`test_rapid_updates_only_last_published`** — Replaced the fixed
+   `asyncio.sleep(0.5)` with a polling helper (`_wait_for`) that retries
+   for up to 5 s, eliminating timing sensitivity under CPU load.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,14 +81,23 @@ def ensure_tcl_source(version: str = "9.0") -> Path:
 
 @pytest.fixture(autouse=True)
 def _reset_signature_profile() -> Generator[None, None, None]:
-    """Keep command-profile global state isolated between tests."""
-    from core.commands.registry.runtime import configure_signatures
+    """Keep command-profile global state isolated between tests.
 
+    We clear ``SIGNATURES`` before calling ``configure_signatures`` so that
+    the early-return optimisation inside ``configure_signatures`` (which
+    short-circuits when the dialect and extra-commands haven't changed) is
+    bypassed.  Without this, in-place mutations to ``SIGNATURES`` by an
+    earlier test would silently persist.
+    """
+    from core.commands.registry.runtime import SIGNATURES, configure_signatures
+
+    SIGNATURES.clear()
     configure_signatures(
         dialect="tcl8.6",
         extra_commands=[],
     )
     yield
+    SIGNATURES.clear()
     configure_signatures(
         dialect="tcl8.6",
         extra_commands=[],

--- a/tests/test_async_diagnostics.py
+++ b/tests/test_async_diagnostics.py
@@ -54,6 +54,16 @@ def _codes(diags: list[types.Diagnostic]) -> list[str]:
     return [d.code for d in diags if d.code]  # type: ignore[misc]
 
 
+async def _wait_for(predicate: Any, *, timeout: float = 5.0, interval: float = 0.05) -> None:
+    """Poll *predicate* until it returns truthy, or raise after *timeout* seconds."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError(f"Condition not met within {timeout}s")
+
+
 class TestSchedulerBasic:
     """Basic scheduling and publishing."""
 
@@ -331,8 +341,8 @@ class TestSchedulerRapidUpdates:
                 )
                 await asyncio.sleep(0.005)
 
-            # Wait for the last task to complete.
-            await asyncio.sleep(0.5)
+            # Wait for the last task to complete (poll instead of fixed sleep).
+            await _wait_for(lambda: len(calls) >= 1)
 
             # Only the final version should have been published.
             assert len(calls) == 1


### PR DESCRIPTION
## Summary

- Fixed `test_proc_multiple_params` flakiness by clearing the `SIGNATURES` global state before each test, bypassing the early-return optimization in `configure_signatures` that allowed mutations to persist across tests
- Fixed `test_rapid_updates_only_last_published` flakiness by replacing fixed `asyncio.sleep(0.5)` with a polling helper (`_wait_for`) that retries for up to 5 seconds, eliminating timing sensitivity under CPU load
- Updated `docs/flaky_tests.md` to document that these issues have been resolved

## Changes

**`tests/conftest.py`**: Enhanced `_reset_signature_profile` fixture to explicitly clear `SIGNATURES` before and after calling `configure_signatures`. This ensures that in-place mutations from earlier tests don't persist due to the function's early-return optimization.

**`tests/test_async_diagnostics.py`**: 
- Added `_wait_for` helper function that polls a predicate with configurable timeout and interval
- Replaced fixed `asyncio.sleep(0.5)` in `test_rapid_updates_only_last_published` with `_wait_for(lambda: len(calls) >= 1)` to handle variable system load

**`docs/flaky_tests.md`**: Updated to reflect that previously-documented flaky tests have been fixed, with brief explanations of the fixes applied.

## Validation

- Existing test suite passes with these changes
- The fixes address the root causes of flakiness rather than masking symptoms

https://claude.ai/code/session_019PL1Vk6bCaSQezA4CBvp7L