### PR TITLE
Update VS Code extension display name to "Tcl LSP/MCP"

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcl-lsp",
-  "displayName": "Tcl Language Support",
+  "displayName": "Tcl LSP/MCP",
   "description": "Tcl language support with semantic highlighting, diagnostics, completions, and more",
   "version": "1.1.1",
   "publisher": "bitwisecook",


### PR DESCRIPTION
## Changes

- Updated the VS Code extension's display name from "Tcl Language Support" to "Tcl LSP/MCP" in `package.json`

This change provides a more concise and descriptive name for the extension in the VS Code marketplace, better reflecting its LSP (Language Server Protocol) and MCP (Model Context Protocol) capabilities.