### PR TITLE
Clean up code formatting and imports

### DIFF
--- a/core/bigip/iapp_vars.py
+++ b/core/bigip/iapp_vars.py
@@ -63,5 +63,3 @@ def extract_iapp_var_refs(source: str) -> list[IappVarRef]:
             )
         )
     return refs
-
-

--- a/core/compiler/irules_flow.py
+++ b/core/compiler/irules_flow.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import defaultdict
 from dataclasses import dataclass
 
 from ..analysis.semantic_model import CodeFix, Range
@@ -524,6 +525,7 @@ DATA_EVENT_REQUIREMENTS: dict[str, tuple[tuple[str, ...], str]] = {
     "SERVERSSL_DATA": (("SSL",), "server"),
 }
 
+
 def _default_collect_side(event: str) -> str:
     """Infer the default side context for commands in *event*."""
     props = EVENT_REGISTRY.get_props(event)
@@ -612,8 +614,13 @@ def _scan_ir_event(
     """Walk an IR event body and record collect/release/payload calls."""
     default_side = _default_collect_side(event)
     _scan_ir_body_with_side(
-        ir_body, default_side, collected, released,
-        collect_calls, release_calls, payload_calls,
+        ir_body,
+        default_side,
+        collected,
+        released,
+        collect_calls,
+        release_calls,
+        payload_calls,
     )
 
 
@@ -636,8 +643,13 @@ def _scan_ir_body_with_side(
                 inner_ir = _lower_side_switch_body(ir_stmt)
                 if inner_ir is not None:
                     _scan_ir_body_with_side(
-                        inner_ir, inner_side, collected, released,
-                        collect_calls, release_calls, payload_calls,
+                        inner_ir,
+                        inner_side,
+                        collected,
+                        released,
+                        collect_calls,
+                        release_calls,
+                        payload_calls,
                     )
             continue
         _classify_command(
@@ -1326,9 +1338,13 @@ def _iter_all_ir_statements(script: IRScript, *, lower_side_switches: bool = Tru
         yield stmt
         if isinstance(stmt, IRIf):
             for clause in stmt.clauses:
-                yield from _iter_all_ir_statements(clause.body, lower_side_switches=lower_side_switches)
+                yield from _iter_all_ir_statements(
+                    clause.body, lower_side_switches=lower_side_switches
+                )
             if stmt.else_body is not None:
-                yield from _iter_all_ir_statements(stmt.else_body, lower_side_switches=lower_side_switches)
+                yield from _iter_all_ir_statements(
+                    stmt.else_body, lower_side_switches=lower_side_switches
+                )
         elif isinstance(stmt, IRFor):
             yield from _iter_all_ir_statements(stmt.init, lower_side_switches=lower_side_switches)
             yield from _iter_all_ir_statements(stmt.body, lower_side_switches=lower_side_switches)
@@ -1336,9 +1352,13 @@ def _iter_all_ir_statements(script: IRScript, *, lower_side_switches: bool = Tru
         elif isinstance(stmt, IRSwitch):
             for arm in stmt.arms:
                 if arm.body is not None:
-                    yield from _iter_all_ir_statements(arm.body, lower_side_switches=lower_side_switches)
+                    yield from _iter_all_ir_statements(
+                        arm.body, lower_side_switches=lower_side_switches
+                    )
             if stmt.default_body is not None:
-                yield from _iter_all_ir_statements(stmt.default_body, lower_side_switches=lower_side_switches)
+                yield from _iter_all_ir_statements(
+                    stmt.default_body, lower_side_switches=lower_side_switches
+                )
         elif isinstance(stmt, IRWhile):
             yield from _iter_all_ir_statements(stmt.body, lower_side_switches=lower_side_switches)
         elif isinstance(stmt, IRForeach):
@@ -1348,13 +1368,23 @@ def _iter_all_ir_statements(script: IRScript, *, lower_side_switches: bool = Tru
         elif isinstance(stmt, IRTry):
             yield from _iter_all_ir_statements(stmt.body, lower_side_switches=lower_side_switches)
             for handler in stmt.handlers:
-                yield from _iter_all_ir_statements(handler.body, lower_side_switches=lower_side_switches)
+                yield from _iter_all_ir_statements(
+                    handler.body, lower_side_switches=lower_side_switches
+                )
             if stmt.finally_body is not None:
-                yield from _iter_all_ir_statements(stmt.finally_body, lower_side_switches=lower_side_switches)
-        elif lower_side_switches and isinstance(stmt, IRCall) and stmt.command in ("clientside", "serverside"):
+                yield from _iter_all_ir_statements(
+                    stmt.finally_body, lower_side_switches=lower_side_switches
+                )
+        elif (
+            lower_side_switches
+            and isinstance(stmt, IRCall)
+            and stmt.command in ("clientside", "serverside")
+        ):
             inner_ir = _lower_side_switch_body(stmt)
             if inner_ir is not None:
-                yield from _iter_all_ir_statements(inner_ir, lower_side_switches=lower_side_switches)
+                yield from _iter_all_ir_statements(
+                    inner_ir, lower_side_switches=lower_side_switches
+                )
 
 
 def find_irules_flow_warnings(
@@ -1439,8 +1469,6 @@ def extract_event_order(source: str) -> list[EventOrderEntry]:
         return []
 
     # Collect all handlers per event, preserving file order.
-    from collections import defaultdict
-
     per_event: dict[str, list[tuple[int, int, Range]]] = defaultdict(list)
     for idx, (event, priority, _body, _body_tok, event_tok) in enumerate(when_bodies):
         per_event[event].append((priority, idx, range_from_token(event_tok)))


### PR DESCRIPTION
## Summary

- Move `defaultdict` import to the top of the file in `irules_flow.py` (line 35) instead of importing it locally within a function
- Add blank line after `EVENT_REGISTRY` constant definition for better code organization
- Reformat multi-line function calls to improve readability by placing each argument on its own line in `_scan_ir_event()`, `_scan_ir_body_with_side()`, and `_iter_all_ir_statements()`
- Reformat multi-line conditional expression in `_iter_all_ir_statements()` for better readability
- Remove trailing blank lines from `iapp_vars.py`

## Validation

- [ ] I ran relevant tests/checks locally and listed the exact commands.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.
- [ ] If I added a new compiler KCS note, I linked it from both:
  - `docs/kcs/compiler/README.md`
  - `docs/kcs/README.md`

https://claude.ai/code/session_01E2gk1372hGqgTqmHDQTdjn