### PR TITLE
Improve proc docstring handling: multi-line, body-internal, doxygen tags

### DIFF
--- a/ai/claude/tcl_ai.py
+++ b/ai/claude/tcl_ai.py
@@ -2164,32 +2164,11 @@ def cmd_proc_docs(source: str, file_path: str) -> None:
     """Extract structured documentation from all procs."""
     _configure_dialect_from_path(file_path)
     from core.analysis.analyser import analyse
-    from core.formatting.docstring import parse_docstring
+
+    from ai.shared.docstring_ops import collect_proc_docs
 
     result = analyse(source)
-    procs = []
-    for qname, proc_def in result.all_procs.items():
-        entry: dict = {
-            "name": proc_def.name,
-            "qualified_name": proc_def.qualified_name,
-            "params": [
-                {"name": p.name, "default": p.default_value} if p.has_default else {"name": p.name}
-                for p in proc_def.params
-            ],
-        }
-        if proc_def.doc:
-            entry["doc_raw"] = proc_def.doc
-            parsed = parse_docstring(proc_def.doc)
-            entry["doc"] = parsed.to_dict()
-        else:
-            entry["doc"] = None
-        if proc_def.param_traits:
-            entry["param_traits"] = {
-                name: sorted(t.name for t in traits)
-                for name, traits in proc_def.param_traits.items()
-            }
-        procs.append(entry)
-    print(json.dumps({"procs": procs}, indent=2))
+    print(json.dumps({"procs": collect_proc_docs(result)}, indent=2))
 
 
 def cmd_generate_docstring(
@@ -2198,24 +2177,16 @@ def cmd_generate_docstring(
     """Generate a docstring stub for a specific proc."""
     _configure_dialect_from_path(file_path)
     from core.analysis.analyser import analyse
-    from core.formatting.docstring import DocstringTagStyle, generate_stub
+    from core.formatting.docstring import generate_stub_for_proc, resolve_tag_style
 
     result = analyse(source)
-    proc_def = result.all_procs.get(f"::{proc_name}") or result.all_procs.get(proc_name)
-    if proc_def is None:
-        for _qname, pd in result.all_procs.items():
-            if pd.name == proc_name:
-                proc_def = pd
-                break
+    proc_def = result.find_proc(proc_name)
     if proc_def is None:
         print(json.dumps({"error": f"Proc '{proc_name}' not found"}))
         return
 
-    tag = DocstringTagStyle.PLAIN if style == "plain" else DocstringTagStyle.DOXYGEN
-    param_names = [p.name for p in proc_def.params]
-    param_defaults = {p.name: p.default_value for p in proc_def.params if p.has_default}
-    stub = generate_stub(
-        proc_def.name, param_names, param_defaults, tag_style=tag, decoration=decoration
+    stub = generate_stub_for_proc(
+        proc_def, tag_style=resolve_tag_style(style), decoration=decoration
     )
     print(stub)
 
@@ -2224,24 +2195,15 @@ def cmd_update_docstrings(source: str, file_path: str, style: str, decoration: b
     """Add docstring stubs to all undocumented procs."""
     _configure_dialect_from_path(file_path)
     from core.analysis.analyser import analyse
-    from core.formatting.docstring import DocstringTagStyle, generate_stub
+    from core.formatting.docstring import resolve_tag_style
 
-    tag = DocstringTagStyle.PLAIN if style == "plain" else DocstringTagStyle.DOXYGEN
+    from ai.shared.docstring_ops import insert_docstring_stubs
+
     result = analyse(source)
-
-    procs_to_doc = [pd for pd in result.all_procs.values() if not pd.doc]
-    procs_to_doc.sort(key=lambda p: p.name_range.start.line, reverse=True)
-
-    lines = source.splitlines(keepends=True)
-    for proc_def in procs_to_doc:
-        param_names = [p.name for p in proc_def.params]
-        param_defaults = {p.name: p.default_value for p in proc_def.params if p.has_default}
-        stub = generate_stub(
-            proc_def.name, param_names, param_defaults, tag_style=tag, decoration=decoration
-        )
-        lines.insert(proc_def.name_range.start.line, stub + "\n")
-
-    print("".join(lines), end="")
+    modified, _count = insert_docstring_stubs(
+        source, result, tag_style=resolve_tag_style(style), decoration=decoration
+    )
+    print(modified, end="")
 
 
 def cmd_refactor(source: str, file_path: str) -> None:

--- a/ai/mcp/tcl_mcp_server.py
+++ b/ai/mcp/tcl_mcp_server.py
@@ -1450,29 +1450,16 @@ def _tool_generate_docstring(
     decoration: str = "false",
 ) -> str:
     from core.analysis.analyser import analyse
-    from core.formatting.docstring import DocstringTagStyle, generate_stub
+    from core.formatting.docstring import generate_stub_for_proc, resolve_tag_style
 
     result = analyse(source)
-    proc_def = result.all_procs.get(f"::{proc_name}") or result.all_procs.get(proc_name)
-    if proc_def is None:
-        for qname, pd in result.all_procs.items():
-            if pd.name == proc_name:
-                proc_def = pd
-                break
+    proc_def = result.find_proc(proc_name)
     if proc_def is None:
         return json.dumps({"error": f"Proc '{proc_name}' not found"})
 
-    tag = DocstringTagStyle.PLAIN if style.lower() == "plain" else DocstringTagStyle.DOXYGEN
+    tag = resolve_tag_style(style)
     dec = decoration.lower() in ("true", "1", "yes")
-    param_names = [p.name for p in proc_def.params]
-    param_defaults = {p.name: p.default_value for p in proc_def.params if p.has_default}
-    stub = generate_stub(
-        proc_def.name,
-        param_names,
-        param_defaults,
-        tag_style=tag,
-        decoration=dec,
-    )
+    stub = generate_stub_for_proc(proc_def, tag_style=tag, decoration=dec)
     return json.dumps({"proc": proc_name, "docstring": stub})
 
 
@@ -1487,32 +1474,11 @@ def _tool_generate_docstring(
 )
 def _tool_read_proc_docs(source: str) -> str:
     from core.analysis.analyser import analyse
-    from core.formatting.docstring import parse_docstring
+
+    from ai.shared.docstring_ops import collect_proc_docs
 
     result = analyse(source)
-    procs = []
-    for qname, proc_def in result.all_procs.items():
-        entry: dict[str, Any] = {
-            "name": proc_def.name,
-            "qualified_name": proc_def.qualified_name,
-            "params": [
-                {"name": p.name, "default": p.default_value} if p.has_default else {"name": p.name}
-                for p in proc_def.params
-            ],
-        }
-        if proc_def.doc:
-            entry["doc_raw"] = proc_def.doc
-            parsed = parse_docstring(proc_def.doc)
-            entry["doc"] = parsed.to_dict()
-        else:
-            entry["doc"] = None
-        if proc_def.param_traits:
-            entry["param_traits"] = {
-                name: sorted(t.name for t in traits)
-                for name, traits in proc_def.param_traits.items()
-            }
-        procs.append(entry)
-    return json.dumps({"procs": procs}, indent=2)
+    return json.dumps({"procs": collect_proc_docs(result)}, indent=2)
 
 
 @tool(
@@ -1538,39 +1504,20 @@ def _tool_update_docstrings(
     decoration: str = "false",
 ) -> str:
     from core.analysis.analyser import analyse
-    from core.formatting.docstring import DocstringTagStyle, generate_stub
+    from core.formatting.docstring import resolve_tag_style
 
-    tag = DocstringTagStyle.PLAIN if style.lower() == "plain" else DocstringTagStyle.DOXYGEN
+    from ai.shared.docstring_ops import insert_docstring_stubs
+
+    tag = resolve_tag_style(style)
     dec = decoration.lower() in ("true", "1", "yes")
     result = analyse(source)
 
-    # Collect procs that need docstrings, sorted by line descending
-    # (so we can insert from bottom to top without shifting offsets).
-    procs_to_doc = []
-    for proc_def in result.all_procs.values():
-        if not proc_def.doc:
-            procs_to_doc.append(proc_def)
-    procs_to_doc.sort(key=lambda p: p.name_range.start.line, reverse=True)
-
-    lines = source.splitlines(keepends=True)
-    documented = 0
-    for proc_def in procs_to_doc:
-        param_names = [p.name for p in proc_def.params]
-        param_defaults = {p.name: p.default_value for p in proc_def.params if p.has_default}
-        stub = generate_stub(
-            proc_def.name,
-            param_names,
-            param_defaults,
-            tag_style=tag,
-            decoration=dec,
-        )
-        insert_line = proc_def.name_range.start.line
-        lines.insert(insert_line, stub + "\n")
-        documented += 1
-
+    modified, documented = insert_docstring_stubs(
+        source, result, tag_style=tag, decoration=dec
+    )
     return json.dumps(
         {
-            "source": "".join(lines),
+            "source": modified,
             "procs_documented": documented,
             "total_procs": len(result.all_procs),
         }

--- a/ai/shared/docstring_ops.py
+++ b/ai/shared/docstring_ops.py
@@ -1,0 +1,70 @@
+"""Shared docstring operations for AI consumers (MCP server, tcl_ai CLI).
+
+Provides high-level helpers that combine core analysis with docstring
+utilities, so both the CLI and MCP entry points can share the same logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.analysis.semantic_model import AnalysisResult
+from core.formatting.docstring import (
+    DocstringTagStyle,
+    generate_stub_for_proc,
+    parse_docstring,
+)
+
+
+def collect_proc_docs(result: AnalysisResult) -> list[dict[str, Any]]:
+    """Build a list of structured documentation dicts for all procs.
+
+    Each entry contains ``name``, ``qualified_name``, ``params``,
+    ``doc_raw``/``doc`` (parsed), and ``param_traits`` where available.
+    """
+    procs: list[dict[str, Any]] = []
+    for _qname, proc_def in result.all_procs.items():
+        entry: dict[str, Any] = {
+            "name": proc_def.name,
+            "qualified_name": proc_def.qualified_name,
+            "params": [
+                {"name": p.name, "default": p.default_value} if p.has_default else {"name": p.name}
+                for p in proc_def.params
+            ],
+        }
+        if proc_def.doc:
+            entry["doc_raw"] = proc_def.doc
+            parsed = parse_docstring(proc_def.doc)
+            entry["doc"] = parsed.to_dict()
+        else:
+            entry["doc"] = None
+        if proc_def.param_traits:
+            entry["param_traits"] = {
+                name: sorted(t.name for t in traits)
+                for name, traits in proc_def.param_traits.items()
+            }
+        procs.append(entry)
+    return procs
+
+
+def insert_docstring_stubs(
+    source: str,
+    result: AnalysisResult,
+    *,
+    tag_style: DocstringTagStyle = DocstringTagStyle.DOXYGEN,
+    decoration: bool = False,
+) -> tuple[str, int]:
+    """Insert docstring stubs for all undocumented procs.
+
+    Returns ``(modified_source, documented_count)``.  Inserts from bottom
+    to top so that line offsets are not shifted by earlier insertions.
+    """
+    procs_to_doc = [pd for pd in result.all_procs.values() if not pd.doc]
+    procs_to_doc.sort(key=lambda p: p.name_range.start.line, reverse=True)
+
+    lines = source.splitlines(keepends=True)
+    for proc_def in procs_to_doc:
+        stub = generate_stub_for_proc(proc_def, tag_style=tag_style, decoration=decoration)
+        lines.insert(proc_def.name_range.start.line, stub + "\n")
+
+    return "".join(lines), len(procs_to_doc)

--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -162,16 +162,6 @@ def _argv_with_word_spans(argv: list[Token], all_tokens: list[Token]) -> list[To
     return widen_argv_tokens_to_word_spans(argv, all_tokens)
 
 
-def _extract_body_docstring(body: str) -> str:
-    """Extract the leading comment block from a proc body.
-
-    Delegates to the shared ``core.formatting.docstring`` module.
-    """
-    from core.formatting.docstring import extract_body_docstring
-
-    return extract_body_docstring(body)
-
-
 def _parse_param_list(param_str: str) -> list[ParamDef]:
     """Parse a Tcl proc argument list string into ParamDef objects.
 
@@ -1680,7 +1670,9 @@ class Analyser:
         # fallback docstring when there is no preceding comment.
         body_doc = ""
         if not preceding_doc and body:
-            body_doc = _extract_body_docstring(body)
+            from core.formatting.docstring import extract_body_docstring
+
+            body_doc = extract_body_docstring(body)
 
         proc_def = ProcDef(
             name=proc_name,

--- a/core/analysis/semantic_model.py
+++ b/core/analysis/semantic_model.py
@@ -269,6 +269,16 @@ class AnalysisResult:
     stub_commands: list[StubCommandDef] = field(default_factory=list)
     stub_expr_defs: list[StubExprDef] = field(default_factory=list)
 
+    def find_proc(self, name: str) -> ProcDef | None:
+        """Look up a proc by name, trying qualified and bare forms."""
+        result = self.all_procs.get(f"::{name}") or self.all_procs.get(name)
+        if result is not None:
+            return result
+        for pd in self.all_procs.values():
+            if pd.name == name:
+                return pd
+        return None
+
     def active_package_names(self) -> frozenset[str]:
         """Return the set of package names imported via ``package require``."""
         return frozenset(pr.name for pr in self.package_requires)

--- a/core/formatting/__init__.py
+++ b/core/formatting/__init__.py
@@ -7,9 +7,11 @@ from .docstring import (
     extract_body_docstring,
     format_docstring,
     generate_stub,
+    generate_stub_for_proc,
     parse_docstring,
     render_comment_block,
     render_markdown,
+    resolve_tag_style,
 )
 from .formatter import format_tcl
 
@@ -25,7 +27,9 @@ __all__ = [
     "format_docstring",
     "format_tcl",
     "generate_stub",
+    "generate_stub_for_proc",
     "parse_docstring",
     "render_comment_block",
     "render_markdown",
+    "resolve_tag_style",
 ]

--- a/core/formatting/config.py
+++ b/core/formatting/config.py
@@ -127,22 +127,15 @@ class FormatterConfig:
         return replace(self, **changes)
 
 
-# Enum lookup table used by from_dict (auto-discovered from type hints)
+# Enum lookup table used by from_dict.  Cannot be auto-discovered from
+# field type hints because ``from __future__ import annotations`` turns
+# them into strings.
 _ENUM_FIELDS: dict[str, type[Enum]] = {
-    f.name: f.type
-    for f in fields(FormatterConfig)
-    if isinstance(f.type, type) and issubclass(f.type, Enum)
+    "brace_style": BraceStyle,
+    "indent_style": IndentStyle,
+    "docstring_style": DocstringStyle,
+    "docstring_tag_style": DocstringTagStyle,
 }
-# Fallback: the above only works if type annotations are resolved.
-# Explicitly register for safety.
-_ENUM_FIELDS.update(
-    {
-        "brace_style": BraceStyle,
-        "indent_style": IndentStyle,
-        "docstring_style": DocstringStyle,
-        "docstring_tag_style": DocstringTagStyle,
-    }
-)
 
 
 # Editor settings catalogue

--- a/core/formatting/docstring.py
+++ b/core/formatting/docstring.py
@@ -8,8 +8,12 @@ formatter, LSP features (hover, completion, signature help), and AI tools.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from .config import DocstringTagStyle
+
+if TYPE_CHECKING:
+    from core.analysis.semantic_model import ProcDef
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,6 +101,9 @@ def parse_docstring(text: str) -> DocstringInfo:
             brief = stripped[7:].strip()
 
         else:
+            # Skip decoration-only lines (dots, dashes, hashes, etc.)
+            if stripped and all(ch in _DECORATION_CHARS for ch in stripped):
+                continue
             description_lines.append(stripped)
 
     desc = "\n".join(description_lines).strip()
@@ -186,7 +193,7 @@ def render_comment_block(
         if info.returns:
             lines.append(f"{indent}# @return {info.returns}")
     else:
-        # Plain style: brief + description as prose, params as list
+        # Plain style (also used for NONE — leave tags as-is falls through here).
         if info.brief:
             lines.append(f"{indent}# {info.brief}")
         if info.description:
@@ -283,3 +290,41 @@ def extract_body_docstring(body: str) -> str:
         else:
             break
     return "\n".join(lines)
+
+
+def resolve_tag_style(style: str) -> DocstringTagStyle:
+    """Resolve a tag-style string to the corresponding enum value.
+
+    Case-insensitive.  Unrecognised values default to ``DOXYGEN``.
+    """
+    if style.lower() == "plain":
+        return DocstringTagStyle.PLAIN
+    return DocstringTagStyle.DOXYGEN
+
+
+def generate_stub_for_proc(
+    proc_def: ProcDef,
+    *,
+    tag_style: DocstringTagStyle = DocstringTagStyle.DOXYGEN,
+    decoration: bool = False,
+    decoration_char: str = ".",
+    decoration_width: int = 70,
+    indent: str = "",
+) -> str:
+    """Generate a docstring stub from a ``ProcDef``.
+
+    Convenience wrapper around ``generate_stub`` that extracts parameter
+    names and defaults from the proc definition automatically.
+    """
+    param_names = [p.name for p in proc_def.params]
+    param_defaults = {p.name: p.default_value for p in proc_def.params if p.has_default}
+    return generate_stub(
+        proc_def.name,
+        param_names,
+        param_defaults,
+        tag_style=tag_style,
+        decoration=decoration,
+        decoration_char=decoration_char,
+        decoration_width=decoration_width,
+        indent=indent,
+    )

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
@@ -61,6 +61,11 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
     var formattingMaxConsecutiveBlankLines: Int = 2
     var formattingLineEnding: String = "lf"
     var formattingEnsureFinalNewline: Boolean = true
+    var formattingDocstringStyle: String = "none"
+    var formattingDocstringTagStyle: String = "doxygen"
+    var formattingDocstringDecoration: Boolean = false
+    var formattingDocstringDecorationChar: String = "."
+    var formattingDocstringDecorationWidth: Int = 70
 
     // @generated:diagnostic-vars:begin
     var diagnosticE001: Boolean = true
@@ -265,6 +270,11 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
                 "maxConsecutiveBlankLines" to formattingMaxConsecutiveBlankLines,
                 "lineEnding" to formattingLineEnding,
                 "ensureFinalNewline" to formattingEnsureFinalNewline,
+                "docstringStyle" to formattingDocstringStyle,
+                "docstringTagStyle" to formattingDocstringTagStyle,
+                "docstringDecoration" to formattingDocstringDecoration,
+                "docstringDecorationChar" to formattingDocstringDecorationChar,
+                "docstringDecorationWidth" to formattingDocstringDecorationWidth,
             ),
             "diagnostics" to mapOf(
                 // @generated:diagnostic-map:begin

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -59,6 +59,11 @@ class TclLspSettingsPanel {
     private val fmtMaxBlankLines = JSpinner(SpinnerNumberModel(2, 1, 10, 1))
     private val fmtLineEnding = JComboBox(arrayOf("lf", "crlf", "cr"))
     private val fmtFinalNewline = JBCheckBox("Ensure final newline")
+    private val fmtDocstringStyle = JComboBox(arrayOf("preceding", "body", "none"))
+    private val fmtDocstringTagStyle = JComboBox(arrayOf("doxygen", "plain", "none"))
+    private val fmtDocstringDecoration = JBCheckBox("Docstring decoration borders")
+    private val fmtDocstringDecorationChar = JComboBox(arrayOf(".", "-", "=", "*", "~"))
+    private val fmtDocstringDecorationWidth = JSpinner(SpinnerNumberModel(70, 20, 120, 10))
 
     // @generated:diag-checkboxes:begin
     // Diagnostics — Errors
@@ -268,6 +273,13 @@ class TclLspSettingsPanel {
         builder.addLabeledComponent(JBLabel("Line ending:"), fmtLineEnding)
         builder.addComponent(fmtFinalNewline)
 
+        builder.addComponent(TitledSeparator("Docstrings"))
+        builder.addLabeledComponent(JBLabel("Docstring style:"), fmtDocstringStyle)
+        builder.addLabeledComponent(JBLabel("Docstring tag style:"), fmtDocstringTagStyle)
+        builder.addComponent(fmtDocstringDecoration)
+        builder.addLabeledComponent(JBLabel("Decoration character:"), fmtDocstringDecorationChar)
+        builder.addLabeledComponent(JBLabel("Decoration width:"), fmtDocstringDecorationWidth)
+
         // @generated:diag-ui:begin
         builder.addComponent(TitledSeparator("Diagnostics — Errors"))
         val diagErrorPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
@@ -435,6 +447,11 @@ class TclLspSettingsPanel {
             (fmtMaxBlankLines.value as Int) != s.formattingMaxConsecutiveBlankLines ||
             fmtLineEnding.selectedItem != s.formattingLineEnding ||
             fmtFinalNewline.isSelected != s.formattingEnsureFinalNewline ||
+            fmtDocstringStyle.selectedItem != s.formattingDocstringStyle ||
+            fmtDocstringTagStyle.selectedItem != s.formattingDocstringTagStyle ||
+            fmtDocstringDecoration.isSelected != s.formattingDocstringDecoration ||
+            fmtDocstringDecorationChar.selectedItem != s.formattingDocstringDecorationChar ||
+            (fmtDocstringDecorationWidth.value as Int) != s.formattingDocstringDecorationWidth ||
             // @generated:diag-dirty:begin
             diagE001.isSelected != s.diagnosticE001 ||
             diagE002.isSelected != s.diagnosticE002 ||
@@ -610,6 +627,11 @@ class TclLspSettingsPanel {
         s.formattingMaxConsecutiveBlankLines = fmtMaxBlankLines.value as Int
         s.formattingLineEnding = fmtLineEnding.selectedItem as String
         s.formattingEnsureFinalNewline = fmtFinalNewline.isSelected
+        s.formattingDocstringStyle = fmtDocstringStyle.selectedItem as String
+        s.formattingDocstringTagStyle = fmtDocstringTagStyle.selectedItem as String
+        s.formattingDocstringDecoration = fmtDocstringDecoration.isSelected
+        s.formattingDocstringDecorationChar = fmtDocstringDecorationChar.selectedItem as String
+        s.formattingDocstringDecorationWidth = fmtDocstringDecorationWidth.value as Int
 
         // @generated:diag-apply:begin
         s.diagnosticE001 = diagE001.isSelected
@@ -783,6 +805,11 @@ class TclLspSettingsPanel {
         fmtMaxBlankLines.value = s.formattingMaxConsecutiveBlankLines
         fmtLineEnding.selectedItem = s.formattingLineEnding
         fmtFinalNewline.isSelected = s.formattingEnsureFinalNewline
+        fmtDocstringStyle.selectedItem = s.formattingDocstringStyle
+        fmtDocstringTagStyle.selectedItem = s.formattingDocstringTagStyle
+        fmtDocstringDecoration.isSelected = s.formattingDocstringDecoration
+        fmtDocstringDecorationChar.selectedItem = s.formattingDocstringDecorationChar
+        fmtDocstringDecorationWidth.value = s.formattingDocstringDecorationWidth
 
         // @generated:diag-reset:begin
         diagE001.isSelected = s.diagnosticE001

--- a/lsp/features/code_actions.py
+++ b/lsp/features/code_actions.py
@@ -1245,7 +1245,7 @@ def _generate_docstring_action(
 
     Offered when the cursor is on a proc definition that has no docstring.
     """
-    from core.formatting.docstring import generate_stub
+    from core.formatting.docstring import generate_stub_for_proc
 
     cursor_line = range_.start.line
     for proc_def in analysis.all_procs.values():
@@ -1255,10 +1255,7 @@ def _generate_docstring_action(
         if proc_def.doc:
             return None  # already has a docstring
 
-        param_names = [p.name for p in proc_def.params]
-        param_defaults = {p.name: p.default_value for p in proc_def.params if p.has_default}
-        stub = generate_stub(proc_def.name, param_names, param_defaults)
-        stub_text = stub + "\n"
+        stub_text = generate_stub_for_proc(proc_def) + "\n"
 
         insert_pos = types.Position(line=proc_line, character=0)
         return types.CodeAction(
@@ -1266,7 +1263,7 @@ def _generate_docstring_action(
             kind=types.CodeActionKind.Source,
             edit=types.WorkspaceEdit(
                 changes={
-                    "": [
+                    "__current__": [
                         types.TextEdit(
                             range=types.Range(start=insert_pos, end=insert_pos), new_text=stub_text
                         )

--- a/lsp/features/completion.py
+++ b/lsp/features/completion.py
@@ -15,7 +15,8 @@ from core.commands.registry.runtime import (
 from core.common.dialect import active_dialect
 from core.formatting.config import FormatterConfig, IndentStyle
 
-from .hover import _format_docstring
+from core.formatting.docstring import format_docstring
+
 from .irules_context import find_enclosing_when_event
 from .snippet_templates import SnippetContext, get_snippet_completions
 from .symbol_resolution import (
@@ -349,7 +350,7 @@ def get_completions(
                     documentation=(
                         types.MarkupContent(
                             kind=types.MarkupKind.Markdown,
-                            value=_format_docstring(proc_def.doc),
+                            value=format_docstring(proc_def.doc),
                         )
                         if proc_def.doc
                         else None
@@ -486,7 +487,7 @@ def get_completions(
                     documentation=(
                         types.MarkupContent(
                             kind=types.MarkupKind.Markdown,
-                            value=_format_docstring(proc_def.doc),
+                            value=format_docstring(proc_def.doc),
                         )
                         if proc_def.doc
                         else None

--- a/lsp/features/hover.py
+++ b/lsp/features/hover.py
@@ -45,18 +45,6 @@ from .symbol_resolution import (
 log = logging.getLogger(__name__)
 
 
-def _format_docstring(doc: str) -> str:
-    """Format a proc docstring for hover display.
-
-    Delegates to the shared ``core.formatting.docstring`` module which
-    parses ``@param``, ``@return``/``@returns``, and ``@brief`` tags
-    and renders them as readable markdown.
-    """
-    from core.formatting.docstring import format_docstring
-
-    return format_docstring(doc)
-
-
 def _proc_hover_text(proc_def: ProcDef) -> str:
     """Format hover text for a proc definition."""
     params = []
@@ -69,7 +57,9 @@ def _proc_hover_text(proc_def: ProcDef) -> str:
     sig = f"proc {proc_def.qualified_name} {{{' '.join(params)}}} {{...}}"
     parts = [f"```tcl\n{sig}\n```"]
     if proc_def.doc:
-        parts.append(_format_docstring(proc_def.doc))
+        from core.formatting.docstring import format_docstring
+
+        parts.append(format_docstring(proc_def.doc))
     return "\n\n".join(parts)
 
 

--- a/lsp/features/signature_help.py
+++ b/lsp/features/signature_help.py
@@ -12,7 +12,8 @@ from core.commands.registry.models import CommandSpec
 from core.commands.registry.runtime import SIGNATURES, SubcommandSig
 from core.common.dialect import active_dialect
 
-from .hover import _format_docstring
+from core.formatting.docstring import format_docstring
+
 from .symbol_resolution import find_command_context_details_at_position
 
 
@@ -67,7 +68,7 @@ def _proc_signature_help(
         documentation=(
             types.MarkupContent(
                 kind=types.MarkupKind.Markdown,
-                value=_format_docstring(proc_def.doc),
+                value=format_docstring(proc_def.doc),
             )
             if proc_def.doc
             else None

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -962,3 +962,45 @@ class TestIPConversionCodeActions:
         actions = get_code_actions(source, cursor, _NO_DIAG_CONTEXT)
         ra = _refactor_actions(actions)
         assert len(ra) == 0
+
+
+class TestGenerateDocstringAction:
+    def setup_method(self):
+        configure_signatures(dialect="tcl8.6")
+
+    def test_offered_for_undocumented_proc(self):
+        source = "proc greet {name} { puts $name }\n"
+        cursor = types.Range(
+            start=types.Position(line=0, character=0),
+            end=types.Position(line=0, character=0),
+        )
+        actions = get_code_actions(source, cursor, _NO_DIAG_CONTEXT)
+        sa = _source_actions(actions)
+        doc_actions = [a for a in sa if "docstring" in a.title.lower()]
+        assert len(doc_actions) == 1
+        assert "'greet'" in doc_actions[0].title
+
+    def test_not_offered_for_documented_proc(self):
+        source = "# Already documented\nproc greet {name} { puts $name }\n"
+        cursor = types.Range(
+            start=types.Position(line=1, character=0),
+            end=types.Position(line=1, character=0),
+        )
+        actions = get_code_actions(source, cursor, _NO_DIAG_CONTEXT)
+        sa = _source_actions(actions)
+        doc_actions = [a for a in sa if "docstring" in a.title.lower()]
+        assert len(doc_actions) == 0
+
+    def test_generated_edit_contains_param_tags(self):
+        source = "proc add {a b} { expr {$a + $b} }\n"
+        cursor = types.Range(
+            start=types.Position(line=0, character=0),
+            end=types.Position(line=0, character=0),
+        )
+        actions = get_code_actions(source, cursor, _NO_DIAG_CONTEXT)
+        sa = _source_actions(actions)
+        doc_actions = [a for a in sa if "docstring" in a.title.lower()]
+        assert len(doc_actions) == 1
+        snippets = _action_snippets(doc_actions)
+        assert any("@param a" in s for s in snippets)
+        assert any("@param b" in s for s in snippets)

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -11,9 +11,11 @@ from core.formatting.docstring import (
     extract_body_docstring,
     format_docstring,
     generate_stub,
+    generate_stub_for_proc,
     parse_docstring,
     render_comment_block,
     render_markdown,
+    resolve_tag_style,
 )
 
 
@@ -240,3 +242,106 @@ class TestDocstringInfoDict:
         info = DocstringInfo()
         d = info.to_dict()
         assert d == {}
+
+
+class TestResolveTagStyle:
+    def test_doxygen_default(self):
+        assert resolve_tag_style("doxygen") is DocstringTagStyle.DOXYGEN
+
+    def test_plain(self):
+        assert resolve_tag_style("plain") is DocstringTagStyle.PLAIN
+
+    def test_case_insensitive(self):
+        assert resolve_tag_style("Plain") is DocstringTagStyle.PLAIN
+        assert resolve_tag_style("PLAIN") is DocstringTagStyle.PLAIN
+
+    def test_unknown_defaults_to_doxygen(self):
+        assert resolve_tag_style("unknown") is DocstringTagStyle.DOXYGEN
+        assert resolve_tag_style("") is DocstringTagStyle.DOXYGEN
+
+
+class TestGenerateStubForProc:
+    def _make_proc(self, name, params):
+        from lsprotocol.types import Position, Range
+
+        from core.analysis.semantic_model import ProcDef
+
+        r = Range(start=Position(line=0, character=0), end=Position(line=0, character=0))
+        return ProcDef(
+            name=name, qualified_name=f"::{name}", params=params,
+            name_range=r, body_range=r,
+        )
+
+    def test_basic(self):
+        from core.analysis.semantic_model import ParamDef
+
+        pd = self._make_proc("greet", [ParamDef(name="name")])
+        stub = generate_stub_for_proc(pd)
+        assert "# @brief TODO: describe greet" in stub
+        assert "# @param name" in stub
+
+    def test_with_defaults(self):
+        from core.analysis.semantic_model import ParamDef
+
+        pd = self._make_proc("greet", [
+            ParamDef(name="name"),
+            ParamDef(name="greeting", has_default=True, default_value="Hello"),
+        ])
+        stub = generate_stub_for_proc(pd)
+        assert "(default: Hello)" in stub
+
+
+class TestParseDocstringEdgeCases:
+    def test_multi_return_accumulated(self):
+        doc = "@return First part\n@return Second part"
+        info = parse_docstring(doc)
+        assert info.returns == "First part Second part"
+
+    def test_param_no_name(self):
+        # @param with no text after it — should not crash
+        info = parse_docstring("@param")
+        assert info.params == []
+
+    def test_brief_no_text(self):
+        info = parse_docstring("@brief")
+        assert info.brief == ""
+
+    def test_decoration_lines_stripped_in_parse(self):
+        doc = "......\nHello world\n------"
+        info = parse_docstring(doc)
+        assert info.description == "Hello world"
+        assert "..." not in info.description
+        assert "---" not in info.description
+
+
+class TestFindProc:
+    def _make_result(self):
+        from lsprotocol.types import Position, Range
+
+        from core.analysis.semantic_model import AnalysisResult, ProcDef
+
+        r = Range(start=Position(line=0, character=0), end=Position(line=0, character=0))
+        result = AnalysisResult()
+        result.all_procs["::foo"] = ProcDef(
+            name="foo", qualified_name="::foo", params=[],
+            name_range=r, body_range=r,
+        )
+        result.all_procs["::ns::bar"] = ProcDef(
+            name="bar", qualified_name="::ns::bar", params=[],
+            name_range=r, body_range=r,
+        )
+        return result
+
+    def test_qualified_lookup(self):
+        result = self._make_result()
+        assert result.find_proc("foo") is not None
+        assert result.find_proc("foo").qualified_name == "::foo"
+
+    def test_bare_lookup(self):
+        result = self._make_result()
+        assert result.find_proc("bar") is not None
+        assert result.find_proc("bar").qualified_name == "::ns::bar"
+
+    def test_not_found(self):
+        result = self._make_result()
+        assert result.find_proc("nonexistent") is None

--- a/tests/test_docstring_ops.py
+++ b/tests/test_docstring_ops.py
@@ -1,0 +1,67 @@
+"""Tests for ai/shared/docstring_ops.py shared helpers."""
+
+from __future__ import annotations
+
+from core.analysis.semantic_model import AnalysisResult, ParamDef, ProcDef
+from lsprotocol.types import Position, Range
+
+from ai.shared.docstring_ops import collect_proc_docs, insert_docstring_stubs
+
+
+def _make_proc(name: str, line: int, doc: str = "", params: list | None = None) -> ProcDef:
+    _body_range = Range(start=Position(line=0, character=0), end=Position(line=0, character=0))
+    return ProcDef(
+        name=name,
+        qualified_name=f"::{name}",
+        params=params or [],
+        name_range=Range(start=Position(line=line, character=0), end=Position(line=line, character=len(name))),
+        body_range=_body_range,
+        doc=doc,
+    )
+
+
+class TestCollectProcDocs:
+    def test_basic(self):
+        result = AnalysisResult()
+        result.all_procs["::foo"] = _make_proc("foo", 0, doc="Hello")
+        result.all_procs["::bar"] = _make_proc("bar", 2)
+
+        docs = collect_proc_docs(result)
+        assert len(docs) == 2
+        foo_doc = next(d for d in docs if d["name"] == "foo")
+        bar_doc = next(d for d in docs if d["name"] == "bar")
+        assert foo_doc["doc_raw"] == "Hello"
+        assert foo_doc["doc"] is not None
+        assert bar_doc["doc"] is None
+
+    def test_params_included(self):
+        result = AnalysisResult()
+        result.all_procs["::f"] = _make_proc(
+            "f", 0, params=[ParamDef(name="x"), ParamDef(name="y", has_default=True, default_value="0")]
+        )
+        docs = collect_proc_docs(result)
+        assert docs[0]["params"] == [{"name": "x"}, {"name": "y", "default": "0"}]
+
+
+class TestInsertDocstringStubs:
+    def test_inserts_stubs(self):
+        source = "proc foo {} { puts hi }\nproc bar {} { puts bye }\n"
+        result = AnalysisResult()
+        result.all_procs["::foo"] = _make_proc("foo", 0)
+        result.all_procs["::bar"] = _make_proc("bar", 1)
+
+        modified, count = insert_docstring_stubs(source, result)
+        assert count == 2
+        assert "# @brief TODO: describe foo" in modified
+        assert "# @brief TODO: describe bar" in modified
+
+    def test_skips_documented_procs(self):
+        source = "# Existing doc\nproc foo {} { puts hi }\nproc bar {} { puts bye }\n"
+        result = AnalysisResult()
+        result.all_procs["::foo"] = _make_proc("foo", 1, doc="Existing doc")
+        result.all_procs["::bar"] = _make_proc("bar", 2)
+
+        modified, count = insert_docstring_stubs(source, result)
+        assert count == 1
+        assert "TODO: describe bar" in modified
+        assert "TODO: describe foo" not in modified


### PR DESCRIPTION
Fix three issues with proc docstring extraction and display:

1. Accumulate consecutive comment lines into multi-line docstrings instead
   of keeping only the last line. The segmenter now joins consecutive #
   comment lines with newlines.

2. Prevent comment bleed between procs by saving/restoring _last_comment
   around body analysis. Previously, a comment inside one proc's body
   could leak to the next proc if it had no preceding comment.

3. Extract body-internal docstrings as a fallback. When a proc has no
   preceding comment but starts with a comment block inside its body
   (a common Tcl convention), that block is used as the docstring.
   Decoration lines (dots, dashes, etc.) are stripped.

4. Parse @param, @return, and @brief doxygen-style tags in docstrings
   and render them as structured markdown in hover, completion, and
   signature help displays.

Closes #31

https://claude.ai/code/session_01VEa68WPCyuzYPY4jenP3FS