### PR TITLE
Add W123: unresolved command diagnostic with unknown proc analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,7 @@ Use `# noqa: *` to suppress all diagnostics on a line.
 | W120 | Package-gated command used without `package require` | Insert `package require` |
 | W121 | Subnet mask has non-contiguous bits | Replace with nearest valid mask |
 | W122 | Mistyped IPv4 address (octet > 255 or leading zero) | |
+| W123 | Unknown command — not found in registry, user procs, or `unknown` handler (opt-in) | Replace with suggestion |
 | W200 | Binary format modifier requires newer Tcl | |
 | W201 | Manual path concatenation (use `file join`) | Rewrite as `[file join]` |
 

--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -33,7 +33,7 @@ from ..common.naming import (
 from ..common.ranges import position_from_relative, range_from_token
 from ..compiler.cfg import CFGBranch, CFGFunction
 from ..compiler.compilation_unit import CompilationUnit, FunctionUnit, ensure_compilation_unit
-from ..compiler.compiler_checks import run_compiler_checks
+from ..compiler.compiler_checks import iter_ir_statements, run_compiler_checks
 from ..compiler.core_analyses import FunctionAnalysis
 from ..compiler.ir import (
     IRAssignConst,
@@ -41,7 +41,6 @@ from ..compiler.ir import (
     IRBarrier,
     IRCall,
     IRProcedure,
-    IRScript,
     IRStatement,
     IRSwitch,
     when_event_name,
@@ -262,6 +261,8 @@ class Analyser:
         self._conditional_depth: int = 0
         # Track body nesting depth for top-level-only command detection.
         self._body_depth: int = 0
+        # Guard against double W123 emission across analyse_commands/analyse_irule_event.
+        self._unresolved_commands_emitted: bool = False
 
     def snapshot(self) -> AnalyserSnapshot:
         """Capture the analyser state for later restoration.
@@ -1275,10 +1276,15 @@ class Analyser:
                         )
                     )
 
-        # Detect dynamic providers: load command or auto_path manipulation.
+        # Detect dynamic providers: commands that create or load commands
+        # at runtime, making static command resolution unreliable.
         if cmd_name == "load":
             self.result.has_dynamic_providers = True
-        elif cmd_name == "set" and args and args[0] == "auto_path":
+        elif cmd_name in ("set", "lappend") and args and args[0] == "auto_path":
+            self.result.has_dynamic_providers = True
+        elif cmd_name == "rename":
+            self.result.has_dynamic_providers = True
+        elif cmd_name == "namespace" and len(args) >= 2 and args[0] == "import":
             self.result.has_dynamic_providers = True
 
         # W002 and built-in arity (E001-E003, W001) are now emitted by
@@ -1726,7 +1732,9 @@ class Analyser:
                 pass  # trait inference is best-effort
 
         # Detect user-defined ``unknown`` proc and extract dispatch info.
-        if proc_name == "unknown" or qualified == "::unknown":
+        # Handle both bare ``unknown`` and qualified forms like ``::tcl::unknown``.
+        norm_qualified = qualified.lstrip(":")
+        if proc_name == "unknown" or norm_qualified in ("unknown", "tcl::unknown"):
             self._extract_unknown_proc_info(body, params)
 
     # ------------------------------------------------------------------
@@ -1775,48 +1783,40 @@ class Analyser:
         has_exec = False
         has_auto_load = False
         case_insensitive = False
+        has_pattern_dispatch = False
 
-        def _walk_stmts(script: IRScript) -> None:
-            nonlocal chains_original, has_exec, has_auto_load, case_insensitive
-
-            for stmt in script.statements:
-                if isinstance(stmt, IRSwitch):
-                    # Check if the switch subject references the first param.
-                    subj = stmt.subject
-                    if f"${first_param}" in subj or "${" + first_param + "}" in subj:
-                        # Check for case-insensitive pattern:
-                        # ``[string tolower $cmd]`` or ``[string toupper $cmd]``
-                        if "string tolower" in subj or "string toupper" in subj:
-                            case_insensitive = True
+        for stmt in iter_ir_statements(ir_module.top_level):
+            if isinstance(stmt, IRSwitch):
+                subj = stmt.subject
+                if f"${first_param}" in subj or "${" + first_param + "}" in subj:
+                    if "string tolower" in subj or "string toupper" in subj:
+                        case_insensitive = True
+                    if stmt.mode == "exact":
                         for arm in stmt.arms:
                             if arm.pattern != "default":
                                 dispatch_targets.add(arm.pattern)
-                            if arm.body is not None:
-                                _walk_stmts(arm.body)
-                        if stmt.default_body is not None:
-                            _walk_stmts(stmt.default_body)
+                    else:
+                        has_pattern_dispatch = True
 
-                elif isinstance(stmt, IRCall):
-                    cmd = stmt.command
-                    if cmd in self._CHAIN_TARGETS:
-                        chains_original = True
-                    elif cmd == "exec":
-                        has_exec = True
-                    elif cmd == "auto_load":
-                        has_auto_load = True
+            elif isinstance(stmt, IRCall):
+                cmd = stmt.command
+                if cmd in self._CHAIN_TARGETS:
+                    chains_original = True
+                elif cmd == "exec":
+                    has_exec = True
+                elif cmd == "auto_load":
+                    has_auto_load = True
 
-                elif isinstance(stmt, IRBarrier):
-                    # Barriers from eval/uplevel — check the command name.
-                    if stmt.command in self._CHAIN_TARGETS:
-                        chains_original = True
-
-        _walk_stmts(ir_module.top_level)
+            elif isinstance(stmt, IRBarrier):
+                if stmt.command in self._CHAIN_TARGETS:
+                    chains_original = True
 
         self.result.unknown_proc_info = UnknownProcInfo(
             dispatch_targets=frozenset(dispatch_targets),
             chains_original=chains_original,
             empty_stub=False,
             case_insensitive=case_insensitive,
+            has_pattern_dispatch=has_pattern_dispatch,
             has_exec=has_exec,
             has_auto_load=has_auto_load,
         )
@@ -1835,6 +1835,10 @@ class Analyser:
         analyser always emits the diagnostic; filtering is done
         downstream by the LSP layer via ``disabled_diagnostics``.
         """
+        if self._unresolved_commands_emitted:
+            return
+        self._unresolved_commands_emitted = True
+
         from ..common.text import suggest_similar
 
         dialect = active_dialect()
@@ -1851,12 +1855,21 @@ class Analyser:
         upi = self.result.unknown_proc_info
         # If unknown handler is opaque, suppress all W123.
         if upi is not None and (
-            upi.chains_original or upi.has_exec or upi.has_auto_load or upi.case_insensitive
+            upi.chains_original
+            or upi.has_exec
+            or upi.has_auto_load
+            or upi.case_insensitive
+            or upi.has_pattern_dispatch
         ):
             return
 
-        # If dynamic providers detected (load, auto_path), suppress all.
+        # If dynamic providers detected (load, rename, namespace import, etc.),
+        # suppress all.
         if self.result.has_dynamic_providers:
+            return
+
+        # If package require is present, external commands may be loaded.
+        if self.result.package_requires:
             return
 
         dispatch_targets = upi.dispatch_targets if upi is not None else frozenset()

--- a/core/analysis/semantic_model.py
+++ b/core/analysis/semantic_model.py
@@ -267,6 +267,8 @@ class UnknownProcInfo:
     """Body is empty — nothing resolves at all."""
     case_insensitive: bool = False
     """Normalises case before dispatch (all known commands are valid)."""
+    has_pattern_dispatch: bool = False
+    """Uses glob or regexp switch dispatch — opaque match semantics."""
     has_exec: bool = False
     """Calls ``exec`` — opaque external dispatch."""
     has_auto_load: bool = False

--- a/core/common/codes.py
+++ b/core/common/codes.py
@@ -167,6 +167,15 @@ def diagnostic_codes() -> frozenset[str]:
     )
 
 
+def default_disabled_diagnostics() -> frozenset[str]:
+    """Diagnostic codes that are opt-in (``default=False``)."""
+    return frozenset(
+        c
+        for c, info in _registry.items()
+        if info.kind is CodeKind.DIAGNOSTIC and not info.internal and not info.default
+    )
+
+
 def optimisation_codes() -> frozenset[str]:
     """All registered optimisation codes."""
     return frozenset(c for c, info in _registry.items() if info.kind is CodeKind.OPTIMISATION)

--- a/core/common/text.py
+++ b/core/common/text.py
@@ -6,6 +6,7 @@ Used by the analyser (W123 unknown command suggestions) and the compiler
 
 from __future__ import annotations
 
+import heapq
 from collections.abc import Iterable
 
 
@@ -36,8 +37,6 @@ def suggest_similar(
 
     Returns up to *max_suggestions* candidates within *max_distance*.
     """
-    scored = sorted(
-        ((name, edit_distance(attempted, name)) for name in candidates),
-        key=lambda x: x[1],
-    )
-    return [name for name, dist in scored[:max_suggestions] if dist <= max_distance]
+    scored = ((edit_distance(attempted, name), name) for name in candidates)
+    smallest = heapq.nsmallest(max_suggestions, scored)
+    return [name for dist, name in smallest if dist <= max_distance]

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -55,67 +55,50 @@ diag("E004", "Invalid argument count.", section="error", internal=True)
 diag("W302", "`catch` without result variable — errors are silently swallowed.", section="security")
 
 
-def _suggest_subcommands(
-    attempted: str,
-    available: dict[str, CommandSig],
-    max_suggestions: int = 3,
-    max_distance: int = 3,
-) -> list[str]:
-    """Suggest similar subcommands ranked by edit distance."""
-    if not available:
-        return []
-    return _suggest_similar_impl(
-        attempted,
-        available,
-        max_suggestions=max_suggestions,
-        max_distance=max_distance,
-    )
-
-
-def _iter_statements(script: IRScript):
+def iter_ir_statements(script: IRScript):
     """Yield every IR statement, recursing into structured bodies."""
     for stmt in script.statements:
         yield stmt
 
         if isinstance(stmt, IRIf):
             for clause in stmt.clauses:
-                yield from _iter_statements(clause.body)
+                yield from iter_ir_statements(clause.body)
             if stmt.else_body is not None:
-                yield from _iter_statements(stmt.else_body)
+                yield from iter_ir_statements(stmt.else_body)
             continue
 
         if isinstance(stmt, IRFor):
-            yield from _iter_statements(stmt.init)
-            yield from _iter_statements(stmt.body)
-            yield from _iter_statements(stmt.next)
+            yield from iter_ir_statements(stmt.init)
+            yield from iter_ir_statements(stmt.body)
+            yield from iter_ir_statements(stmt.next)
             continue
 
         if isinstance(stmt, IRSwitch):
             for arm in stmt.arms:
                 if arm.body is not None:
-                    yield from _iter_statements(arm.body)
+                    yield from iter_ir_statements(arm.body)
             if stmt.default_body is not None:
-                yield from _iter_statements(stmt.default_body)
+                yield from iter_ir_statements(stmt.default_body)
             continue
 
         if isinstance(stmt, IRWhile):
-            yield from _iter_statements(stmt.body)
+            yield from iter_ir_statements(stmt.body)
             continue
 
         if isinstance(stmt, IRForeach):
-            yield from _iter_statements(stmt.body)
+            yield from iter_ir_statements(stmt.body)
             continue
 
         if isinstance(stmt, IRCatch):
-            yield from _iter_statements(stmt.body)
+            yield from iter_ir_statements(stmt.body)
             continue
 
         if isinstance(stmt, IRTry):
-            yield from _iter_statements(stmt.body)
+            yield from iter_ir_statements(stmt.body)
             for handler in stmt.handlers:
-                yield from _iter_statements(handler.body)
+                yield from iter_ir_statements(handler.body)
             if stmt.finally_body is not None:
-                yield from _iter_statements(stmt.finally_body)
+                yield from iter_ir_statements(stmt.finally_body)
 
 
 def _switch_list_body_index(args: list[str]) -> int | None:
@@ -533,7 +516,7 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
             _check_arity(cmd_name, args, sig, cmd_token_range, diagnostics)
 
     def _walk_ir(script: IRScript) -> None:
-        for stmt in _iter_statements(script):
+        for stmt in iter_ir_statements(script):
             _check_statement(stmt)
 
     _walk_ir(ir_module.top_level)
@@ -570,7 +553,9 @@ def _check_arity(
             if sig.allow_unknown:
                 return
             msg = f"Unknown subcommand '{sub_name}' for '{cmd_name}'"
-            suggestions = _suggest_subcommands(sub_name, sig.subcommands)
+            suggestions = _suggest_similar_impl(
+                sub_name, sig.subcommands, max_suggestions=3, max_distance=3
+            )
             if suggestions:
                 msg += f"; did you mean '{suggestions[0]}'?"
             diagnostics.append(
@@ -637,9 +622,9 @@ def run_compiler_checks(
             return []
 
     stmts: list[IRStatement] = []
-    stmts.extend(_iter_statements(ir_module.top_level))
+    stmts.extend(iter_ir_statements(ir_module.top_level))
     for proc in ir_module.procedures.values():
-        stmts.extend(_iter_statements(proc.body))
+        stmts.extend(iter_ir_statements(proc.body))
     stmts.sort(key=lambda s: (s.range.start.offset, s.range.end.offset))
 
     runner = _CompilerCheckRunner(source)

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -30,6 +30,7 @@ Every file must follow this structure so the help parser can extract metadata:
 ## LSP features
 
 - [kcs-feature-diagnostics.md](kcs-feature-diagnostics.md)
+- [kcs-feature-unknown-command-resolution.md](kcs-feature-unknown-command-resolution.md)
 - [kcs-feature-unused-variables.md](kcs-feature-unused-variables.md)
 - [kcs-feature-completions.md](kcs-feature-completions.md)
 - [kcs-feature-hover.md](kcs-feature-hover.md)

--- a/docs/kcs/features/kcs-feature-unknown-command-resolution.md
+++ b/docs/kcs/features/kcs-feature-unknown-command-resolution.md
@@ -8,7 +8,7 @@ false positives.
 
 ## Surface
 
-lsp, all-editors
+lsp, vscode, jetbrains (other editors via XDG config)
 
 ## How to use
 
@@ -19,12 +19,14 @@ lsp, all-editors
 
 ### Recognised `unknown` proc patterns
 
-When the analyser encounters `proc unknown {cmd args} { ... }`, it inspects
-the body and adjusts W123 behaviour accordingly:
+When the analyser encounters `proc unknown {cmd args} { ... }` (or the
+qualified form `proc ::tcl::unknown ...`), it inspects the body and adjusts
+W123 behaviour accordingly:
 
 | Pattern | Example | Effect |
 |---------|---------|--------|
-| **switch dispatch** | `switch $cmd { foo {...} bar {...} }` | `foo`, `bar` are treated as known commands |
+| **switch -exact dispatch** | `switch $cmd { foo {...} bar {...} }` | `foo`, `bar` are treated as known commands |
+| **switch -glob/-regexp** | `switch -glob $cmd { fo* {...} }` | Conservative: W123 suppressed entirely |
 | **Empty stub** | `proc unknown {args} {}` | Nothing resolves; W123 fires for all unknown commands |
 | **Chain to original** | `_original_unknown $cmd {*}$args` | Conservative: W123 suppressed entirely |
 | **auto\_load** | `auto_load $cmd` | Conservative: W123 suppressed entirely |
@@ -33,7 +35,8 @@ the body and adjusts W123 behaviour accordingly:
 
 ### Other suppression mechanisms
 
-- **Dynamic providers**: If `load` or `auto_path` manipulation is detected, W123 is suppressed for the entire file.
+- **Dynamic providers**: If `load`, `set auto_path`, `lappend auto_path`, `rename`, or `namespace import` is detected, W123 is suppressed for the entire file.
+- **Package require**: If any `package require` is present, W123 is suppressed (external packages may define commands).
 - **Dialect stubs**: Commands declared via `# tcl-lsp: stub` are treated as known. See [Dialect Stubs](../kcs-dialect-stubs.md).
 - **User-defined procs**: Any `proc` defined in the file (or sourced via packages) is a known command.
 - **Namespace-qualified names**: Commands containing `::` are skipped (may come from `namespace import`).
@@ -57,7 +60,7 @@ and `unknown` dispatch targets.
 
 ## Failure modes
 
-- False positives in codebases using `interp alias`, `namespace import *`, or other dynamic command creation not detected by the gating logic.
+- False positives in codebases using `interp alias` or other dynamic command creation not detected by the gating logic.
 - Forward-defined `unknown` proc in a sourced file (cross-file) is not detected — analysis is single-file.
 
 ## Test anchors

--- a/explorer/tcl_cli.py
+++ b/explorer/tcl_cli.py
@@ -59,6 +59,12 @@ from core.commands.registry.namespace_data import (
     order_events_for_file,
 )
 from core.commands.registry.runtime import configure_signatures
+from core.common.codes import (
+    default_disabled_diagnostics as _default_disabled_diagnostics,
+)
+from core.common.codes import (
+    diagnostic_codes as _diagnostic_codes,
+)
 from core.compiler.cfg import build_cfg
 from core.compiler.codegen import format_module_asm
 from core.compiler.codegen.wasm import wasm_codegen_module
@@ -157,51 +163,7 @@ _HTML_HIGHLIGHT_STYLES: dict[str, str] = {
 
 # CLI configuration (INI file + flag cascade)
 
-_ALL_DIAGNOSTIC_CODES = frozenset(
-    {
-        "E001",
-        "E002",
-        "E003",
-        "E200",
-        "W001",
-        "W002",
-        "W100",
-        "W101",
-        "W102",
-        "W103",
-        "W104",
-        "W105",
-        "W106",
-        "W108",
-        "W110",
-        "W111",
-        "W112",
-        "W113",
-        "W114",
-        "W115",
-        "W120",
-        "W121",
-        "W122",
-        "W200",
-        "W201",
-        "H300",
-        "W210",
-        "W211",
-        "W212",
-        "W213",
-        "W214",
-        "W220",
-        "W300",
-        "W301",
-        "W302",
-        "W303",
-        "W304",
-        "W306",
-        "W307",
-        "W308",
-        "W309",
-    }
-)
+_ALL_DIAGNOSTIC_CODES = _diagnostic_codes()
 
 _ALL_OPTIMISATION_CODES = frozenset(
     {
@@ -295,10 +257,14 @@ def _load_config() -> _CliConfig:
         sec = cp["diagnostics"]
         enabled = sec.get("enabled", "true").strip().lower()
         cfg.diagnostics_enabled = enabled != "false"
+        cfg.disabled_diagnostics = set(_default_disabled_diagnostics())
         for code in _ALL_DIAGNOSTIC_CODES:
-            val = sec.get(code, "true").strip().lower()
+            default_val = "false" if code in cfg.disabled_diagnostics else "true"
+            val = sec.get(code, default_val).strip().lower()
             if val == "false":
                 cfg.disabled_diagnostics.add(code)
+            elif val == "true":
+                cfg.disabled_diagnostics.discard(code)
 
     # [optimiser]
     if cp.has_section("optimiser"):

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -19,7 +19,7 @@ from core.commands.registry import REGISTRY
 from core.commands.registry.info import effective_event_requires
 from core.commands.registry.namespace_registry import NAMESPACE_REGISTRY as EVENT_REGISTRY
 from core.commands.registry.runtime import configure_signatures, is_irules_dialect
-from core.common.codes import diagnostic_codes, optimisation_codes
+from core.common.codes import default_disabled_diagnostics, diagnostic_codes, optimisation_codes
 from core.common.lsp import to_lsp_location
 from core.common.source_map import SourceMap
 from core.common.user_config import (
@@ -97,7 +97,10 @@ class FeatureConfig:
     selection_range_enabled: bool = True
 
     # Per-code diagnostic filters -- codes present here are *disabled*.
-    disabled_diagnostics: set[str] = field(default_factory=set)
+    # Initialised from codes with ``default=False`` (opt-in diagnostics).
+    disabled_diagnostics: set[str] = field(
+        default_factory=lambda: set(default_disabled_diagnostics())
+    )
 
     # Optimiser master switch + per-code filters.
     optimiser_enabled: bool = True
@@ -2466,11 +2469,14 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
     # Per-diagnostic-code filters  (tclLsp.diagnostics.W100 etc.)
     diagnostics_section = tcl_settings.get("diagnostics")
     if isinstance(diagnostics_section, dict):
-        new_disabled: set[str] = set()
+        new_disabled: set[str] = set(default_disabled_diagnostics())
         for code in _ALL_DIAGNOSTIC_CODES:
             val = diagnostics_section.get(code)
-            if isinstance(val, bool) and not val:
-                new_disabled.add(code)
+            if isinstance(val, bool):
+                if not val:
+                    new_disabled.add(code)
+                else:
+                    new_disabled.discard(code)
         if new_disabled != feature_config.disabled_diagnostics:
             feature_config.disabled_diagnostics = new_disabled
             changed = True

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -852,3 +852,95 @@ class TestW123UnresolvedCommand:
     def test_no_unknown_proc_info_by_default(self):
         result = analyse("set x 1")
         assert result.unknown_proc_info is None
+
+    # --- new suppression patterns ---
+
+    def test_package_require_suppresses(self):
+        diags = self._w123("package require Tk\nbutton .b -text hi")
+        assert len(diags) == 0
+
+    def test_rename_suppresses(self):
+        diags = self._w123("rename puts myputs\nmyputs hello")
+        assert len(diags) == 0
+
+    def test_namespace_import_suppresses(self):
+        diags = self._w123("namespace import ::foo::*\nbar arg")
+        assert len(diags) == 0
+
+    def test_lappend_auto_path_suppresses(self):
+        diags = self._w123("lappend auto_path /opt/mylib\nmycmd arg")
+        assert len(diags) == 0
+
+    # --- unknown proc edge cases ---
+
+    def test_unknown_if_else_chains_original(self):
+        """Chain detection inside if/else body (not just top-level)."""
+        source = textwrap.dedent("""\
+            proc unknown {cmd args} {
+                if {$cmd eq "foo"} {
+                    puts foo
+                } else {
+                    _original_unknown $cmd {*}$args
+                }
+            }
+            baz x
+        """)
+        diags = self._w123(source)
+        assert len(diags) == 0
+        result = analyse(source)
+        assert result.unknown_proc_info is not None
+        assert result.unknown_proc_info.chains_original
+
+    def test_multiple_unknown_procs_last_wins(self):
+        """Second ``proc unknown`` definition overwrites the first."""
+        source = textwrap.dedent("""\
+            proc unknown {cmd args} {
+                _original_unknown $cmd {*}$args
+            }
+            proc unknown {cmd args} {
+                switch $cmd {
+                    foo { puts foo }
+                }
+            }
+            foo x
+            baz y
+        """)
+        result = analyse(source)
+        upi = result.unknown_proc_info
+        assert upi is not None
+        # Second definition does not chain — it only dispatches foo.
+        assert not upi.chains_original
+        assert "foo" in upi.dispatch_targets
+        diags = [d for d in result.diagnostics if d.code == "W123"]
+        assert any("baz" in d.message for d in diags)
+
+    def test_unknown_switch_glob_suppresses(self):
+        """switch -glob in unknown handler suppresses W123 entirely."""
+        source = textwrap.dedent("""\
+            proc unknown {cmd args} {
+                switch -glob $cmd {
+                    fo* { puts foo }
+                }
+            }
+            foobar x
+        """)
+        result = analyse(source)
+        upi = result.unknown_proc_info
+        assert upi is not None
+        assert upi.has_pattern_dispatch
+        diags = [d for d in result.diagnostics if d.code == "W123"]
+        assert len(diags) == 0
+
+    def test_tcl_unknown_qualified(self):
+        """``proc ::tcl::unknown`` is recognised as the unknown handler."""
+        source = textwrap.dedent("""\
+            proc ::tcl::unknown {cmd args} {
+                switch $cmd {
+                    foo { puts foo }
+                }
+            }
+        """)
+        result = analyse(source)
+        upi = result.unknown_proc_info
+        assert upi is not None
+        assert "foo" in upi.dispatch_targets


### PR DESCRIPTION
Statically analyses user-defined `unknown` procs to extract dispatch
targets (switch arm labels) and detect chaining, auto_load, exec, and
case-insensitive patterns. Emits W123 (opt-in, default=False) for
commands not found in the registry, user procs, stubs, or unknown
handler dispatch targets. Includes "did you mean?" suggestions via
shared Levenshtein edit-distance utility, with CodeFix quick-fix
replacements. Links diagnostic to KCS documentation via LSP
codeDescription.

https://claude.ai/code/session_0121vpVMaVsVBDJmuHSTsJSc