### PR TITLE
Fix false E204 for backslash-newline after close-brace (#57)

### DIFF
--- a/core/parsing/lexer.py
+++ b/core/parsing/lexer.py
@@ -715,11 +715,7 @@ class TclLexer:
                     self._col = col
                     # After closing quote, next char must be separator or EOF.
                     if pos < _len and text[pos] not in _AFTER_CLOSE_QUOTE:
-                        if (
-                            text[pos] == "\\"
-                            and pos + 1 < _len
-                            and text[pos + 1] in ("\n", "\r")
-                        ):
+                        if text[pos] == "\\" and pos + 1 < _len and text[pos + 1] in ("\n", "\r"):
                             pass  # backslash-newline is a valid line continuation
                         elif _strict_quoting():
                             raise TclParseError("extra characters after close-quote")

--- a/tests/test_parser_edge_cases.py
+++ b/tests/test_parser_edge_cases.py
@@ -804,17 +804,17 @@ class TestErrorCases:
 
     def test_backslash_newline_after_close_brace_no_warning(self):
         """``{}\\<newline>`` — backslash-newline after close-brace is valid continuation."""
-        toks, warnings = lex_with_warnings("{hello}\\\n world")
+        _, warnings = lex_with_warnings("{hello}\\\n world")
         assert not any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_backslash_newline_after_close_brace_strict(self):
         """``{}\\<newline>`` — strict mode should not raise for line continuation."""
-        toks = lex_strict("{hello}\\\n world")
-        assert len(toks) > 0
+        result = lex_strict("{hello}\\\n world")
+        assert len(result) > 0
 
     def test_backslash_non_newline_after_close_brace_warns(self):
         """``{hello}\\world`` — backslash NOT followed by newline still warns."""
-        toks, warnings = lex_with_warnings("{hello}\\world")
+        _, warnings = lex_with_warnings("{hello}\\world")
         assert any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_spicegentcl_testtemplate_pattern(self):
@@ -824,49 +824,49 @@ class TestErrorCases:
             "{Resistor new 1 netp netm -r 1e3 -tc1 1 -ac 1e6 -temp 25}\\\n"
             "        {r1 netp netm 1e3 tc1=1 ac=1e6 temp=25}"
         )
-        toks, warnings = lex_with_warnings(source)
+        _, warnings = lex_with_warnings(source)
         assert not any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_multiple_backslash_continuations_after_braces(self):
         """Multiple ``}\\<newline>`` continuations on consecutive lines."""
         source = "cmd {arg1}\\\n        {arg2}\\\n        {arg3}"
-        toks, warnings = lex_with_warnings(source)
+        _, warnings = lex_with_warnings(source)
         assert not any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_empty_braces_backslash_continuation(self):
         """``{}\\<newline>`` — empty braces followed by continuation."""
         source = "cmd {}\\\n        {arg}"
-        toks, warnings = lex_with_warnings(source)
+        _, warnings = lex_with_warnings(source)
         assert not any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_backslash_crlf_after_close_brace_no_warning(self):
         """``}\\<CR><LF>`` — Windows line ending after backslash is valid."""
-        toks, warnings = lex_with_warnings("{hello}\\\r\n world")
+        _, warnings = lex_with_warnings("{hello}\\\r\n world")
         assert not any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_backslash_cr_after_close_brace_no_warning(self):
         """``}\\<CR>`` — classic Mac line ending after backslash is valid."""
-        toks, warnings = lex_with_warnings("{hello}\\\r world")
+        _, warnings = lex_with_warnings("{hello}\\\r world")
         assert not any("extra characters after close-brace" in msg for _, msg in warnings)
 
     def test_backslash_newline_after_close_quote_no_warning(self):
         """``"hello"\\<newline>`` — backslash-newline after close-quote is valid."""
-        toks, warnings = lex_with_warnings('"hello"\\\n world')
+        _, warnings = lex_with_warnings('"hello"\\\n world')
         assert not any("extra characters after close-quote" in msg for _, msg in warnings)
 
     def test_backslash_crlf_after_close_quote_no_warning(self):
         """``"hello"\\<CR><LF>`` — Windows line ending after close-quote is valid."""
-        toks, warnings = lex_with_warnings('"hello"\\\r\n world')
+        _, warnings = lex_with_warnings('"hello"\\\r\n world')
         assert not any("extra characters after close-quote" in msg for _, msg in warnings)
 
     def test_backslash_cr_after_close_quote_no_warning(self):
         """``"hello"\\<CR>`` — classic Mac line ending after close-quote is valid."""
-        toks, warnings = lex_with_warnings('"hello"\\\r world')
+        _, warnings = lex_with_warnings('"hello"\\\r world')
         assert not any("extra characters after close-quote" in msg for _, msg in warnings)
 
     def test_backslash_non_newline_after_close_quote_warns(self):
         """``"hello"\\world`` — backslash NOT followed by newline still warns."""
-        toks, warnings = lex_with_warnings('"hello"\\world')
+        _, warnings = lex_with_warnings('"hello"\\world')
         assert any("extra characters after close-quote" in msg for _, msg in warnings)
 
     def test_unclosed_braced_var_warns(self):


### PR DESCRIPTION
Backslash-newline line continuation after a closing brace (e.g.
`}\<newline>`) is valid Tcl and should not trigger E204. Add a
guard in both fast and slow lexer paths to skip the warning when the
character after `}` is `\` followed by `\n`. Apply the same fix to
E205 (close-quote) for consistency. Add 8 tests including the
real-world SpiceGenTcl pattern from the issue.

https://claude.ai/code/session_016TGjfwkWzoRTKxsQRPc4fL