### PR TITLE
fix: suppress false W210 for tcltest::test body arguments

### DIFF
--- a/core/commands/registry/stdlib/tcltest.py
+++ b/core/commands/registry/stdlib/tcltest.py
@@ -27,16 +27,27 @@ _TCLTEST_BODY_OPTIONS = frozenset({"-setup", "-body", "-cleanup"})
 def _test_arg_roles(args: list[str]) -> dict[int, ArgRole]:
     """Resolve argument roles for ``tcltest::test``.
 
-    Syntax: test name description ?option value ...?
+    Syntax:
+      - test name description ?option value ...?
+      - test name description ?constraints? body result
+
     Options whose values are Tcl script bodies: -setup, -body, -cleanup.
     """
     roles: dict[int, ArgRole] = {}
     # Skip name (0) and description (1), then scan option-value pairs.
+    has_body_option = False
     i = 2
     while i < len(args) - 1:
         if args[i] in _TCLTEST_BODY_OPTIONS:
             roles[i + 1] = ArgRole.BODY
+            has_body_option = True
         i += 2
+    # Legacy positional form: test name description ?constraints? body result
+    # Only apply when no body-related options were used.
+    if not has_body_option and len(args) >= 4:
+        # In the positional form, the body is always the penultimate argument.
+        body_index = len(args) - 2
+        roles[body_index] = ArgRole.BODY
     return roles
 
 

--- a/core/compiler/ssa.py
+++ b/core/compiler/ssa.py
@@ -27,6 +27,7 @@ from ..common.naming import normalise_var_name as _normalise_var_name
 from .cfg import CFGBranch, CFGFunction, CFGGoto, CFGReturn, CFGTerminator
 from .expr_ast import ExprNode, vars_in_expr_node
 from .ir import (
+    CommandTokens,
     IRAssignConst,
     IRAssignExpr,
     IRAssignValue,
@@ -102,10 +103,31 @@ def _vars_in_script(source: str) -> frozenset[str]:
 _TCLTEST_BODY_OPTIONS = frozenset({"-setup", "-body", "-cleanup"})
 
 
-def _structural_body_indices(command: str, args: tuple[str, ...]) -> set[int]:
+def _is_braced_arg(tokens: CommandTokens | None, arg_index: int) -> bool:
+    """Return True when argument *arg_index* is a braced literal (STR token).
+
+    When token info is unavailable, conservatively returns True so that
+    the body is still excluded (the common case is braced scripts).
+    """
+    if tokens is None:
+        return True
+    # tokens.argv includes the command name at index 0; args are 1-based.
+    tok_index = arg_index + 1
+    if tok_index >= len(tokens.argv):
+        return True
+    from ..parsing.tokens import TokenType
+
+    return tokens.argv[tok_index].type is TokenType.STR
+
+
+def _structural_body_indices(
+    command: str,
+    args: tuple[str, ...],
+    tokens: CommandTokens | None = None,
+) -> set[int]:
     """Return BODY arg indices that should be excluded from local statement uses.
 
-    We only exclude handler-style bodies that are lowered/analyzed separately.
+    We only exclude handler-style bodies that are lowered/analysed separately.
     Dynamic evaluation commands like ``eval`` still need their args treated as
     ordinary dataflow inputs (for taint and read-before-set tracking).
 
@@ -113,17 +135,34 @@ def _structural_body_indices(command: str, args: tuple[str, ...]) -> set[int]:
     are excluded because the LSP does not inline them — variable references
     inside the braced scripts would otherwise appear as top-level
     reads-before-set (false W210).
+
+    To avoid dropping real top-level reads when the body is passed via
+    substitution (e.g. ``-body $script``), we only exclude arguments that
+    are literal/braced script words.  Non-literal body arguments are still
+    scanned for substitutions.
     """
     if command in ("when", "proc"):
-        return arg_indices_for_role(command, list(args), ArgRole.BODY)
+        candidate_indices = arg_indices_for_role(command, list(args), ArgRole.BODY)
+        return {
+            idx for idx in candidate_indices if 0 <= idx < len(args) and _is_braced_arg(tokens, idx)
+        }
     if command in ("test", "tcltest::test"):
-        # test name description ?option value ...?
+        # Option form: test name description ?option value ...?
         indices: set[int] = set()
+        has_body_option = False
         i = 2
         while i < len(args) - 1:
             if args[i] in _TCLTEST_BODY_OPTIONS:
-                indices.add(i + 1)
+                value_idx = i + 1
+                has_body_option = True
+                if _is_braced_arg(tokens, value_idx):
+                    indices.add(value_idx)
             i += 2
+        # Legacy positional form: test name desc ?constraints? body result
+        if not has_body_option and len(args) >= 4:
+            body_index = len(args) - 2
+            if _is_braced_arg(tokens, body_index):
+                indices.add(body_index)
         return indices
     return set()
 
@@ -149,10 +188,15 @@ def _uses(stmt: IRStatement) -> tuple[str, ...]:
             if amount is not None:
                 vars_found |= _vars_in_word(amount)
         case IRCall(
-            command=command, args=args, defs=call_defs, reads=call_reads, reads_own_defs=rod
+            command=command,
+            args=args,
+            defs=call_defs,
+            reads=call_reads,
+            reads_own_defs=rod,
+            tokens=call_tokens,
         ):
             vars_found |= _vars_in_word(command)
-            body_indices = _structural_body_indices(command, args)
+            body_indices = _structural_body_indices(command, args, call_tokens)
             for idx, arg in enumerate(args):
                 if idx in body_indices:
                     continue
@@ -170,9 +214,9 @@ def _uses(stmt: IRStatement) -> tuple[str, ...]:
                 vars_found |= _vars_in_word(value)
             if expr is not None:
                 vars_found |= _vars_in_expr(expr)
-        case IRBarrier(command=command, args=args):
+        case IRBarrier(command=command, args=args, tokens=barrier_tokens):
             vars_found |= _vars_in_word(command)
-            body_indices = _structural_body_indices(command, args)
+            body_indices = _structural_body_indices(command, args, barrier_tokens)
             for idx, arg in enumerate(args):
                 if idx in body_indices:
                     continue

--- a/tests/test_upstream_var.py
+++ b/tests/test_upstream_var.py
@@ -451,6 +451,8 @@ class TestTcltestW210:
     def test_tcltest_bare_test_no_w210(self):
         """Bare ``test`` (after namespace import) should also be handled."""
         source = textwrap.dedent("""\
+            package require tcltest
+            namespace import ::tcltest::*
             test mytest {description} -setup {
                 set data [list 1 2 3]
             } -body {
@@ -496,6 +498,18 @@ class TestTcltestW210:
         body_vars = {"freq", "s11", "s11Mag", "s11Re", "s11Im", "result"}
         false_positives = [d for d in diags if any(v in d.message for v in body_vars)]
         assert len(false_positives) == 0
+
+    def test_tcltest_legacy_positional_no_w210(self):
+        """Legacy positional form: test name desc ?constraints? body result."""
+        source = textwrap.dedent("""\
+            tcltest::test mytest {description} {
+                set x 1
+                return $x
+            } {1}
+        """)
+        diags = _diag_with_code(source, "W210")
+        x_diags = [d for d in diags if "x" in d.message]
+        assert len(x_diags) == 0
 
     def test_tcltest_top_level_var_still_warns(self):
         """A genuine top-level read-before-set should still trigger W210."""


### PR DESCRIPTION
## Summary

Fixes #62 — W210 "Variable read before set" false positives in `tcltest` `.test` files.

- **Add `arg_role_resolver` to `tcltest::test`** so the lowering phase recognises `-setup`, `-body`, and `-cleanup` option values as script bodies (`ArgRole.BODY`), plus the legacy positional form (`test name desc ?constraints? body result`)
- **Update `_structural_body_indices` in SSA** to exclude `test`/`tcltest::test` body arguments from variable-reference scanning, but only when the argument is a braced literal (STR token) — substituted bodies like `-body $script` are still tracked
- **Add `_is_braced_arg` helper** that inspects `CommandTokens` token types to distinguish braced scripts from variable substitutions

## Test plan

- [x] `test_tcltest_setup_body_no_w210` — var set in `-setup`, read in `-body` → no W210
- [x] `test_tcltest_bare_test_no_w210` — bare `test` after `namespace import ::tcltest::*`
- [x] `test_tcltest_cleanup_no_w210` — var read in `-cleanup`
- [x] `test_tcltest_lmap_in_setup_no_w210` — complex `lmap`/variable patterns in setup
- [x] `test_tcltest_legacy_positional_no_w210` — legacy positional form
- [x] `test_tcltest_top_level_var_still_warns` — genuine top-level read-before-set still fires
- [x] `make prep-pr` passes (8043 passed, 73 skipped)

https://claude.ai/code/session_014a5tEeg7dSyHAD7JGJcihv