### PR TITLE
Fix backslash-newline mid-word parsing, add .test extension, update editor docs

### DIFF
--- a/core/parsing/lexer.py
+++ b/core/parsing/lexer.py
@@ -677,6 +677,11 @@ class TclLexer:
                 ch = text[pos]
                 if ch == "\\":
                     if pos + 1 < _len:
+                        # Save position before advancing (for mid-word
+                        # backslash-newline rewind).
+                        bs_pos = pos
+                        bs_line = line
+                        bs_col = col
                         # Advance past backslash.
                         col += 1
                         pos += 1
@@ -686,16 +691,28 @@ class TclLexer:
                             col = 0
                             pos += 1
                             # Backslash-newline at the very start of a
-                            # new-word position is pure line-continuation
-                            # whitespace.  Emit it as a SEP so the *next*
-                            # token can recognise { or " as brace/quote
-                            # delimiters (and plain words start fresh).
-                            if newword and not insidequote and pos == self._start + 2:
+                            # token is pure line-continuation whitespace.
+                            # Emit it as a SEP so the *next* token can
+                            # recognise { or " as brace/quote delimiters
+                            # (and plain words start fresh).
+                            if not insidequote and pos == self._start + 2:
                                 self.pos = pos
                                 self._line = line
                                 self._col = col
                                 self._end = pos - 1
                                 self._type = TokenType.SEP
+                                return
+                            # Mid-word backslash-newline in unquoted
+                            # context: end the current word before the
+                            # backslash.  The next get_token() call will
+                            # see \<newline> at _start and emit SEP,
+                            # allowing { or " to start a new word.
+                            if not insidequote:
+                                self._end = bs_pos - 1
+                                self._type = TokenType.ESC
+                                self.pos = bs_pos
+                                self._line = bs_line
+                                self._col = bs_col
                                 return
                             continue
                         else:
@@ -777,19 +794,21 @@ class TclLexer:
             if ch == "\\":
                 if self.remaining >= 2:
                     next_ch = self.text[self.pos + 1] if self.pos + 1 < self._len else ""
-                    if (
-                        next_ch == "\n"
-                        and newword
-                        and not self.insidequote
-                        and self.pos == self._start
-                    ):
-                        # Backslash-newline at the very start of a
-                        # new-word position — emit as SEP so the next
-                        # token can recognise { or " delimiters.
-                        self._advance(2)
-                        self._end = self.pos - 1
-                        self._type = TokenType.SEP
-                        return
+                    if next_ch == "\n" and not self.insidequote:
+                        if self.pos == self._start:
+                            # Backslash-newline at the very start of a
+                            # token — emit as SEP so the next token can
+                            # recognise { or " delimiters.
+                            self._advance(2)
+                            self._end = self.pos - 1
+                            self._type = TokenType.SEP
+                            return
+                        else:
+                            # Mid-word backslash-newline: end current
+                            # word before the backslash.
+                            self._end = self.pos - 1
+                            self._type = TokenType.ESC
+                            return
                     # Handle backslash-newline continuation
                     self._advance()
             elif ch in ("$", "["):

--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -18,7 +18,7 @@ The server needs to be accessible via one of:
 
 ```sh
 # Option A — run from source (requires uv)
-uv run --directory /path/to/tcl-lsp --no-dev python -m server
+uv run --directory /path/to/tcl-lsp --no-dev python -m lsp
 
 # Option B — standalone zipapp (just needs Python 3.10+)
 python3 /path/to/tcl-lsp-server.pyz
@@ -35,7 +35,7 @@ Add to your `init.el`:
 (with-eval-after-load 'eglot
   (add-to-list 'eglot-server-programs
                '(tcl-mode . ("uv" "run" "--directory" "/path/to/tcl-lsp"
-                             "--no-dev" "python" "-m" "server"))))
+                             "--no-dev" "python" "-m" "lsp"))))
 
 ;; Auto-start on Tcl files
 (add-hook 'tcl-mode-hook #'eglot-ensure)
@@ -57,7 +57,7 @@ Or with the standalone zipapp:
    (make-lsp-client
     :new-connection (lsp-stdio-connection
                      '("uv" "run" "--directory" "/path/to/tcl-lsp"
-                       "--no-dev" "python" "-m" "server"))
+                       "--no-dev" "python" "-m" "lsp"))
     :activation-fn (lsp-activate-on "tcl")
     :server-id 'tcl-lsp)))
 
@@ -76,6 +76,56 @@ Pass settings via eglot workspace configuration:
 ;; Register .apl files for tcl-mode so eglot activates
 (add-to-list 'auto-mode-alist '("\\.apl\\'" . tcl-mode))
 ```
+
+## Bracket matching and auto-pairs
+
+Emacs's `tcl-mode` provides bracket matching out of the box via
+`show-paren-mode` (enabled by default in Emacs 29+).  For automatic
+insertion of closing brackets and quotes, enable `electric-pair-mode`:
+
+```elisp
+(add-hook 'tcl-mode-hook #'electric-pair-mode)
+```
+
+This auto-closes `{}`, `[]`, `()`, and `""` as you type.
+
+## Debugging
+
+### Viewing LSP logs
+
+`M-x eglot-events-buffer` opens the `*EVENTS for <project>*` buffer
+showing all JSON-RPC messages between Emacs and the server.
+
+`M-x eglot-stderr-buffer` opens the `*STDERR for <project>*` buffer
+showing server-side log output.
+
+### Verbose logging
+
+By default eglot truncates large messages.  To capture full
+request/response payloads, add to your `init.el`:
+
+```elisp
+(setq eglot-events-buffer-config '(:size 2000000 :format full))
+```
+
+Or set it interactively in a running session:
+
+    M-x set-variable RET eglot-events-buffer-config RET (:size 2000000 :format full)
+
+### Viewing diagnostics
+
+- `C-h .` — show the diagnostic at point (hover)
+- `M-x flymake-show-buffer-diagnostics` — list all diagnostics in the
+  current buffer
+- `M-x flymake-show-project-diagnostics` — list diagnostics across the
+  project
+
+### Restarting the server
+
+If the server gets into a bad state:
+
+- `M-x eglot-shutdown` — stop the server for the current project
+- `M-x eglot-reconnect` — restart without closing buffers
 
 ## Configuration File
 

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -33,6 +33,7 @@ file-types = ["tcl", "tk", "itcl", "tm", "irul", "irule", "iapp", "iappimpl", "i
 comment-tokens = ["#"]
 indent = { tab-width = 4, unit = "    " }
 language-servers = ["tcl-lsp"]
+auto-pairs = { "{" = "}", "[" = "]", "(" = ")", "\"" = "\"" }
 ```
 
 ## Settings

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -30,7 +30,7 @@
         <fileType name="Tcl" language="Tcl"
             implementationClass="com.tcllsp.jetbrains.TclFileType"
             fieldName="INSTANCE"
-            extensions="tcl;tk;itcl;tm;iapp;iappimpl;impl;apl;exp"/>
+            extensions="tcl;tk;itcl;tm;test;iapp;iappimpl;impl;apl;exp"/>
         <fileType name="iRule" language="Tcl"
             implementationClass="com.tcllsp.jetbrains.TclIruleFileType"
             fieldName="INSTANCE"

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -90,6 +90,26 @@ vim.api.nvim_create_autocmd('FileType', {
 })
 ```
 
+## Bracket matching and auto-pairs
+
+Neovim's built-in `matchparen` plugin highlights matching `{}`, `[]`,
+and `()` pairs automatically — no configuration needed.
+
+For auto-closing brackets and quotes as you type, use a plugin such as
+[nvim-autopairs](https://github.com/windwp/nvim-autopairs):
+
+```lua
+require('nvim-autopairs').setup({})
+```
+
+Or with [mini.pairs](https://github.com/echasnovski/mini.pairs):
+
+```lua
+require('mini.pairs').setup()
+```
+
+Both handle `{}`, `[]`, `()`, and `""` out of the box.
+
 ## Settings reference
 
 Settings are sent under the `tclLsp` namespace. Key options:

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -54,7 +54,8 @@
           ".tcl",
           ".tk",
           ".itcl",
-          ".tm"
+          ".tm",
+          ".test"
         ],
         "configuration": "./language-configuration.json"
       },

--- a/editors/zed/languages/tcl/config.toml
+++ b/editors/zed/languages/tcl/config.toml
@@ -1,6 +1,6 @@
 name = "Tcl"
 grammar = "tcl"
-path_suffixes = ["tcl", "tk", "itcl", "tm"]
+path_suffixes = ["tcl", "tk", "itcl", "tm", "test"]
 line_comments = ["#"]
 tab_size = 4
 hard_tabs = false


### PR DESCRIPTION
## Summary

- **Lexer fix**: `\<newline>` mid-word in unquoted context now correctly ends the current word and emits a SEP, so `{` on the next line is recognized as a brace delimiter. Fixes false E003 diagnostics on tcltest `.test` files with multi-line braced arguments after backslash-newline continuation.
- **`.test` extension**: Registered as Tcl across VS Code, Zed, and JetBrains editors.
- **Emacs README**: Fixed `python -m server` → `python -m lsp` (3 occurrences), added debugging section (log viewing, verbose mode, diagnostics, server restart), added bracket matching/auto-pairs docs.
- **Neovim/Helix READMEs**: Added bracket matching and auto-pairs documentation.

## Test plan

- [x] All 8518 existing tests pass (4 pre-existing tclsh 8.6 compat failures unrelated)
- [x] Verified segmenter produces correct arg count for `testTemplateParse` calls with `\<newline>{braced-string}`
- [x] Verified E003 diagnostic no longer fires on the reproduction case
- [x] LSP server starts and responds correctly via stdio

🤖 Generated with [Claude Code](https://claude.com/claude-code)