### PR TITLE
Add support for conf-wrapped iRules (ltm/gtm rule stanzas)

### DIFF
--- a/core/analysis/conf_wrapped.py
+++ b/core/analysis/conf_wrapped.py
@@ -33,56 +33,59 @@ from .semantic_model import (
 )
 
 
-def _shift_position(pos: SourcePosition, base_line: int, base_char: int) -> SourcePosition:
-    """Shift *pos* by a base line/character offset.
+def _shift_position(
+    pos: SourcePosition, base_line: int, base_char: int, base_offset: int
+) -> SourcePosition:
+    """Shift *pos* by a base line/character/offset.
 
     For line 0, column is shifted by *base_char*; subsequent lines
     only shift by *base_line* (their column is relative to the body,
     which already starts at column 0 on its own line).
+    The byte offset is always shifted by *base_offset*.
     """
     if pos.line == 0:
         return SourcePosition(
             line=pos.line + base_line,
             character=pos.character + base_char,
-            offset=pos.offset,
+            offset=pos.offset + base_offset,
         )
     return SourcePosition(
         line=pos.line + base_line,
         character=pos.character,
-        offset=pos.offset,
+        offset=pos.offset + base_offset,
     )
 
 
-def _shift_range(rng: Range, base_line: int, base_char: int) -> Range:
+def _shift_range(rng: Range, base_line: int, base_char: int, base_offset: int) -> Range:
     """Shift both endpoints of *rng*."""
     return Range(
-        start=_shift_position(rng.start, base_line, base_char),
-        end=_shift_position(rng.end, base_line, base_char),
+        start=_shift_position(rng.start, base_line, base_char, base_offset),
+        end=_shift_position(rng.end, base_line, base_char, base_offset),
     )
 
 
-def _shift_scope(scope: Scope, base_line: int, base_char: int) -> Scope:
+def _shift_scope(scope: Scope, base_line: int, base_char: int, base_offset: int) -> Scope:
     """Recursively shift all ranges inside a scope tree."""
     new_body_range = (
-        _shift_range(scope.body_range, base_line, base_char)
+        _shift_range(scope.body_range, base_line, base_char, base_offset)
         if scope.body_range is not None
         else None
     )
     new_vars: dict[str, VarDef] = {}
     for vname, vdef in scope.variables.items():
-        new_refs = [_shift_range(r, base_line, base_char) for r in vdef.references]
+        new_refs = [_shift_range(r, base_line, base_char, base_offset) for r in vdef.references]
         new_vars[vname] = VarDef(
             name=vdef.name,
-            definition_range=_shift_range(vdef.definition_range, base_line, base_char),
+            definition_range=_shift_range(vdef.definition_range, base_line, base_char, base_offset),
             references=new_refs,
             warn_if_unused=vdef.warn_if_unused,
         )
     new_procs: dict[str, ProcDef] = {}
     for pname, pdef in scope.procs.items():
-        new_procs[pname] = _shift_proc(pdef, base_line, base_char)
+        new_procs[pname] = _shift_proc(pdef, base_line, base_char, base_offset)
     new_classes: dict[str, ClassDef] = {}
     for cname, cdef in scope.classes.items():
-        new_classes[cname] = _shift_class(cdef, base_line, base_char)
+        new_classes[cname] = _shift_class(cdef, base_line, base_char, base_offset)
     new_scope = Scope(
         kind=scope.kind,
         name=scope.name,
@@ -92,32 +95,34 @@ def _shift_scope(scope: Scope, base_line: int, base_char: int) -> Scope:
         procs=new_procs,
         classes=new_classes,
     )
-    new_scope.children = [_shift_scope(child, base_line, base_char) for child in scope.children]
+    new_scope.children = [
+        _shift_scope(child, base_line, base_char, base_offset) for child in scope.children
+    ]
     for child in new_scope.children:
         child.parent = new_scope
     return new_scope
 
 
-def _shift_proc(pdef: ProcDef, base_line: int, base_char: int) -> ProcDef:
+def _shift_proc(pdef: ProcDef, base_line: int, base_char: int, base_offset: int) -> ProcDef:
     """Shift all ranges in a ProcDef."""
     return ProcDef(
         name=pdef.name,
         qualified_name=pdef.qualified_name,
         params=list(pdef.params),
-        name_range=_shift_range(pdef.name_range, base_line, base_char),
-        body_range=_shift_range(pdef.body_range, base_line, base_char),
+        name_range=_shift_range(pdef.name_range, base_line, base_char, base_offset),
+        body_range=_shift_range(pdef.body_range, base_line, base_char, base_offset),
         doc=pdef.doc,
         param_traits=dict(pdef.param_traits),
     )
 
 
-def _shift_method(mdef: MethodDef, base_line: int, base_char: int) -> MethodDef:
+def _shift_method(mdef: MethodDef, base_line: int, base_char: int, base_offset: int) -> MethodDef:
     """Shift all ranges in a MethodDef."""
     return MethodDef(
         name=mdef.name,
         params=mdef.params,
-        name_range=_shift_range(mdef.name_range, base_line, base_char),
-        body_range=_shift_range(mdef.body_range, base_line, base_char),
+        name_range=_shift_range(mdef.name_range, base_line, base_char, base_offset),
+        body_range=_shift_range(mdef.body_range, base_line, base_char, base_offset),
         visibility=mdef.visibility,
         kind=mdef.kind,
         doc=mdef.doc,
@@ -125,35 +130,44 @@ def _shift_method(mdef: MethodDef, base_line: int, base_char: int) -> MethodDef:
     )
 
 
-def _shift_property(pdef: PropertyDef, base_line: int, base_char: int) -> PropertyDef:
+def _shift_property(
+    pdef: PropertyDef, base_line: int, base_char: int, base_offset: int
+) -> PropertyDef:
     """Shift all ranges in a PropertyDef."""
     return PropertyDef(
         name=pdef.name,
-        name_range=_shift_range(pdef.name_range, base_line, base_char),
+        name_range=_shift_range(pdef.name_range, base_line, base_char, base_offset),
         kind=pdef.kind,
         has_getter=pdef.has_getter,
         has_setter=pdef.has_setter,
     )
 
 
-def _shift_class(cdef: ClassDef, base_line: int, base_char: int) -> ClassDef:
+def _shift_class(cdef: ClassDef, base_line: int, base_char: int, base_offset: int) -> ClassDef:
     """Shift all ranges in a ClassDef."""
-    new_methods = {n: _shift_method(m, base_line, base_char) for n, m in cdef.methods.items()}
-    new_class_methods = {
-        n: _shift_method(m, base_line, base_char) for n, m in cdef.class_methods.items()
+    new_methods = {
+        n: _shift_method(m, base_line, base_char, base_offset) for n, m in cdef.methods.items()
     }
-    new_constructors = [_shift_method(m, base_line, base_char) for m in cdef.constructors]
+    new_class_methods = {
+        n: _shift_method(m, base_line, base_char, base_offset)
+        for n, m in cdef.class_methods.items()
+    }
+    new_constructors = [
+        _shift_method(m, base_line, base_char, base_offset) for m in cdef.constructors
+    ]
     new_destructor = (
-        _shift_method(cdef.destructor, base_line, base_char) if cdef.destructor else None
+        _shift_method(cdef.destructor, base_line, base_char, base_offset)
+        if cdef.destructor
+        else None
     )
     new_properties = {
-        n: _shift_property(p, base_line, base_char) for n, p in cdef.properties.items()
+        n: _shift_property(p, base_line, base_char, base_offset) for n, p in cdef.properties.items()
     }
     return ClassDef(
         name=cdef.name,
         qualified_name=cdef.qualified_name,
-        name_range=_shift_range(cdef.name_range, base_line, base_char),
-        body_range=_shift_range(cdef.body_range, base_line, base_char),
+        name_range=_shift_range(cdef.name_range, base_line, base_char, base_offset),
+        body_range=_shift_range(cdef.body_range, base_line, base_char, base_offset),
         metaclass=cdef.metaclass,
         superclasses=list(cdef.superclasses),
         mixins=list(cdef.mixins),
@@ -170,21 +184,23 @@ def _shift_class(cdef: ClassDef, base_line: int, base_char: int) -> ClassDef:
     )
 
 
-def _shift_diagnostic(diag: Diagnostic, base_line: int, base_char: int) -> Diagnostic:
+def _shift_diagnostic(
+    diag: Diagnostic, base_line: int, base_char: int, base_offset: int
+) -> Diagnostic:
     """Shift all ranges in a Diagnostic (including fixes and related_ranges)."""
     new_fixes = tuple(
         CodeFix(
-            range=_shift_range(fix.range, base_line, base_char),
+            range=_shift_range(fix.range, base_line, base_char, base_offset),
             new_text=fix.new_text,
             description=fix.description,
         )
         for fix in diag.fixes
     )
     new_related = tuple(
-        (_shift_range(r, base_line, base_char), msg) for r, msg in diag.related_ranges
+        (_shift_range(r, base_line, base_char, base_offset), msg) for r, msg in diag.related_ranges
     )
     return Diagnostic(
-        range=_shift_range(diag.range, base_line, base_char),
+        range=_shift_range(diag.range, base_line, base_char, base_offset),
         message=diag.message,
         severity=diag.severity,
         code=diag.code,
@@ -198,11 +214,12 @@ def _merge_shifted_result(
     result: AnalysisResult,
     base_line: int,
     base_char: int,
+    base_offset: int,
 ) -> None:
     """Shift all ranges in *result* and merge into *merged*."""
     # Diagnostics
     for diag in result.diagnostics:
-        merged.diagnostics.append(_shift_diagnostic(diag, base_line, base_char))
+        merged.diagnostics.append(_shift_diagnostic(diag, base_line, base_char, base_offset))
 
     # Suppressed lines
     for line_no, codes in result.suppressed_lines.items():
@@ -212,7 +229,7 @@ def _merge_shifted_result(
     for rp in result.regex_patterns:
         merged.regex_patterns.append(
             RegexPattern(
-                range=_shift_range(rp.range, base_line, base_char),
+                range=_shift_range(rp.range, base_line, base_char, base_offset),
                 pattern=rp.pattern,
                 command=rp.command,
             )
@@ -223,7 +240,7 @@ def _merge_shifted_result(
         merged.command_invocations.append(
             CommandInvocation(
                 name=ci.name,
-                range=_shift_range(ci.range, base_line, base_char),
+                range=_shift_range(ci.range, base_line, base_char, base_offset),
                 resolved_qualified_name=ci.resolved_qualified_name,
             )
         )
@@ -234,7 +251,7 @@ def _merge_shifted_result(
             PackageRequire(
                 name=pr.name,
                 version=pr.version,
-                range=_shift_range(pr.range, base_line, base_char),
+                range=_shift_range(pr.range, base_line, base_char, base_offset),
                 conditional=pr.conditional,
             )
         )
@@ -243,7 +260,7 @@ def _merge_shifted_result(
             PackageProvide(
                 name=pp.name,
                 version=pp.version,
-                range=_shift_range(pp.range, base_line, base_char),
+                range=_shift_range(pp.range, base_line, base_char, base_offset),
             )
         )
 
@@ -252,7 +269,7 @@ def _merge_shifted_result(
         merged.source_targets.append(
             SourceTarget(
                 raw_path=st.raw_path,
-                range=_shift_range(st.range, base_line, base_char),
+                range=_shift_range(st.range, base_line, base_char, base_offset),
                 is_literal=st.is_literal,
             )
         )
@@ -262,8 +279,10 @@ def _merge_shifted_result(
         merged.stub_commands.append(
             StubCommandDef(
                 name=stub.name,
-                params=stub.params,
-                range=_shift_range(stub.range, base_line, base_char),
+                args=stub.args,
+                range=_shift_range(stub.range, base_line, base_char, base_offset),
+                barrier=stub.barrier,
+                loop=stub.loop,
                 pure=stub.pure,
                 mutator=stub.mutator,
                 unsafe=stub.unsafe,
@@ -277,21 +296,21 @@ def _merge_shifted_result(
                 kind=stub_expr.kind,
                 arity=stub_expr.arity,
                 pure=stub_expr.pure,
-                range=_shift_range(stub_expr.range, base_line, base_char),
+                range=_shift_range(stub_expr.range, base_line, base_char, base_offset),
             )
         )
 
     # Procs and classes (merged into global scope)
     for pname, pdef in result.all_procs.items():
-        merged.all_procs[pname] = _shift_proc(pdef, base_line, base_char)
+        merged.all_procs[pname] = _shift_proc(pdef, base_line, base_char, base_offset)
     for cname, cdef in result.all_classes.items():
-        merged.all_classes[cname] = _shift_class(cdef, base_line, base_char)
+        merged.all_classes[cname] = _shift_class(cdef, base_line, base_char, base_offset)
     # Variables
     for vname, vdef in result.all_variables.items():
-        new_refs = [_shift_range(r, base_line, base_char) for r in vdef.references]
+        new_refs = [_shift_range(r, base_line, base_char, base_offset) for r in vdef.references]
         merged.all_variables[vname] = VarDef(
             name=vdef.name,
-            definition_range=_shift_range(vdef.definition_range, base_line, base_char),
+            definition_range=_shift_range(vdef.definition_range, base_line, base_char, base_offset),
             references=new_refs,
             warn_if_unused=vdef.warn_if_unused,
         )
@@ -311,9 +330,22 @@ def _merge_shifted_result(
     # Scope tree: add the shifted per-body global scope as a child of
     # the merged global scope so features that walk the scope tree
     # (e.g. document symbols, variable lookup) find the right context.
-    shifted_scope = _shift_scope(result.global_scope, base_line, base_char)
+    shifted_scope = _shift_scope(result.global_scope, base_line, base_char, base_offset)
     shifted_scope.parent = merged.global_scope
     merged.global_scope.children.append(shifted_scope)
+
+
+def _diag_command_name(diag: Diagnostic) -> str | None:
+    """Extract the command name from a W123 diagnostic message.
+
+    W123 messages follow the pattern ``Unknown command 'name'``.
+    """
+    msg = diag.message
+    start = msg.find("'")
+    end = msg.find("'", start + 1) if start >= 0 else -1
+    if start >= 0 and end > start:
+        return msg[start + 1 : end]
+    return None
 
 
 def analyse_conf_wrapped(
@@ -331,8 +363,6 @@ def analyse_conf_wrapped(
     """
     embedded_rules = find_embedded_rules(source)
     if not embedded_rules:
-        # Shouldn't normally happen (caller should check), but handle
-        # gracefully by falling through to empty result.
         return AnalysisResult(), []
 
     buf = DocumentBuffer.from_source(source)
@@ -344,17 +374,36 @@ def analyse_conf_wrapped(
         result = analyser.analyse(rule.body, file_path=file_path)
         per_rule.append((rule, result))
 
-    # Phase 2: Merge results with shifted ranges.
+    # Phase 2: Cross-rule proc sharing — collect all proc names from
+    # all rules, then suppress false W123 (unresolved command)
+    # diagnostics that reference procs defined in other rules.
+    all_proc_names: set[str] = set()
+    for _rule, result in per_rule:
+        for qname in result.all_procs:
+            all_proc_names.add(qname)
+            tail = qname.rsplit("::", 1)[-1]
+            if tail:
+                all_proc_names.add(tail)
+
+    if all_proc_names:
+        for _rule, result in per_rule:
+            local_procs = set(result.all_procs.keys())
+            local_tails = {qn.rsplit("::", 1)[-1] for qn in local_procs if "::" in qn}
+            cross_procs = all_proc_names - local_procs - local_tails
+            if cross_procs:
+                result.diagnostics = [
+                    d
+                    for d in result.diagnostics
+                    if not (d.code == "W123" and _diag_command_name(d) in cross_procs)
+                ]
+
+    # Phase 3: Merge results with shifted ranges.
     merged = AnalysisResult()
     for rule, result in per_rule:
         body_pos = buf.offset_to_position(rule.body_start_offset)
         base_line = body_pos.line
         base_char = body_pos.character
-        _merge_shifted_result(merged, result, base_line, base_char)
-
-    # Phase 3: Flat cross-rule sharing — collect all procs so they
-    # are visible across rules.  The merged result already has all
-    # procs in ``all_procs``; the workspace index layer will register
-    # them as globally available iRules procs.
+        base_offset = rule.body_start_offset
+        _merge_shifted_result(merged, result, base_line, base_char, base_offset)
 
     return merged, embedded_rules

--- a/core/analysis/conf_wrapped.py
+++ b/core/analysis/conf_wrapped.py
@@ -1,0 +1,360 @@
+"""Analyse conf-wrapped iRules files (``ltm rule`` / ``gtm rule`` stanzas).
+
+Extracts each rule body, analyses it independently at depth 0, then
+merges results with range-shifted positions so diagnostics, symbols,
+and scopes map back to the original file coordinates.  All rules in
+a single file share procs and RULE_INIT variables (flat sharing).
+"""
+
+from __future__ import annotations
+
+from ..bigip.rule_extract import EmbeddedRule, find_embedded_rules
+from ..common.document_buffer import DocumentBuffer
+from ..parsing.tokens import SourcePosition
+from .analyser import Analyser
+from .semantic_model import (
+    AnalysisResult,
+    ClassDef,
+    CodeFix,
+    CommandInvocation,
+    Diagnostic,
+    MethodDef,
+    PackageProvide,
+    PackageRequire,
+    ProcDef,
+    PropertyDef,
+    Range,
+    RegexPattern,
+    Scope,
+    SourceTarget,
+    StubCommandDef,
+    StubExprDef,
+    VarDef,
+)
+
+
+def _shift_position(pos: SourcePosition, base_line: int, base_char: int) -> SourcePosition:
+    """Shift *pos* by a base line/character offset.
+
+    For line 0, column is shifted by *base_char*; subsequent lines
+    only shift by *base_line* (their column is relative to the body,
+    which already starts at column 0 on its own line).
+    """
+    if pos.line == 0:
+        return SourcePosition(
+            line=pos.line + base_line,
+            character=pos.character + base_char,
+            offset=pos.offset,
+        )
+    return SourcePosition(
+        line=pos.line + base_line,
+        character=pos.character,
+        offset=pos.offset,
+    )
+
+
+def _shift_range(rng: Range, base_line: int, base_char: int) -> Range:
+    """Shift both endpoints of *rng*."""
+    return Range(
+        start=_shift_position(rng.start, base_line, base_char),
+        end=_shift_position(rng.end, base_line, base_char),
+    )
+
+
+def _shift_scope(scope: Scope, base_line: int, base_char: int) -> Scope:
+    """Recursively shift all ranges inside a scope tree."""
+    new_body_range = (
+        _shift_range(scope.body_range, base_line, base_char)
+        if scope.body_range is not None
+        else None
+    )
+    new_vars: dict[str, VarDef] = {}
+    for vname, vdef in scope.variables.items():
+        new_refs = [_shift_range(r, base_line, base_char) for r in vdef.references]
+        new_vars[vname] = VarDef(
+            name=vdef.name,
+            definition_range=_shift_range(vdef.definition_range, base_line, base_char),
+            references=new_refs,
+            warn_if_unused=vdef.warn_if_unused,
+        )
+    new_procs: dict[str, ProcDef] = {}
+    for pname, pdef in scope.procs.items():
+        new_procs[pname] = _shift_proc(pdef, base_line, base_char)
+    new_classes: dict[str, ClassDef] = {}
+    for cname, cdef in scope.classes.items():
+        new_classes[cname] = _shift_class(cdef, base_line, base_char)
+    new_scope = Scope(
+        kind=scope.kind,
+        name=scope.name,
+        parent=scope.parent,
+        body_range=new_body_range,
+        variables=new_vars,
+        procs=new_procs,
+        classes=new_classes,
+    )
+    new_scope.children = [_shift_scope(child, base_line, base_char) for child in scope.children]
+    for child in new_scope.children:
+        child.parent = new_scope
+    return new_scope
+
+
+def _shift_proc(pdef: ProcDef, base_line: int, base_char: int) -> ProcDef:
+    """Shift all ranges in a ProcDef."""
+    return ProcDef(
+        name=pdef.name,
+        qualified_name=pdef.qualified_name,
+        params=list(pdef.params),
+        name_range=_shift_range(pdef.name_range, base_line, base_char),
+        body_range=_shift_range(pdef.body_range, base_line, base_char),
+        doc=pdef.doc,
+        param_traits=dict(pdef.param_traits),
+    )
+
+
+def _shift_method(mdef: MethodDef, base_line: int, base_char: int) -> MethodDef:
+    """Shift all ranges in a MethodDef."""
+    return MethodDef(
+        name=mdef.name,
+        params=mdef.params,
+        name_range=_shift_range(mdef.name_range, base_line, base_char),
+        body_range=_shift_range(mdef.body_range, base_line, base_char),
+        visibility=mdef.visibility,
+        kind=mdef.kind,
+        doc=mdef.doc,
+        param_traits=dict(mdef.param_traits),
+    )
+
+
+def _shift_property(pdef: PropertyDef, base_line: int, base_char: int) -> PropertyDef:
+    """Shift all ranges in a PropertyDef."""
+    return PropertyDef(
+        name=pdef.name,
+        name_range=_shift_range(pdef.name_range, base_line, base_char),
+        kind=pdef.kind,
+        has_getter=pdef.has_getter,
+        has_setter=pdef.has_setter,
+    )
+
+
+def _shift_class(cdef: ClassDef, base_line: int, base_char: int) -> ClassDef:
+    """Shift all ranges in a ClassDef."""
+    new_methods = {n: _shift_method(m, base_line, base_char) for n, m in cdef.methods.items()}
+    new_class_methods = {
+        n: _shift_method(m, base_line, base_char) for n, m in cdef.class_methods.items()
+    }
+    new_constructors = [_shift_method(m, base_line, base_char) for m in cdef.constructors]
+    new_destructor = (
+        _shift_method(cdef.destructor, base_line, base_char) if cdef.destructor else None
+    )
+    new_properties = {
+        n: _shift_property(p, base_line, base_char) for n, p in cdef.properties.items()
+    }
+    return ClassDef(
+        name=cdef.name,
+        qualified_name=cdef.qualified_name,
+        name_range=_shift_range(cdef.name_range, base_line, base_char),
+        body_range=_shift_range(cdef.body_range, base_line, base_char),
+        metaclass=cdef.metaclass,
+        superclasses=list(cdef.superclasses),
+        mixins=list(cdef.mixins),
+        methods=new_methods,
+        class_methods=new_class_methods,
+        constructors=new_constructors,
+        destructor=new_destructor,
+        variables=list(cdef.variables),
+        properties=new_properties,
+        filters=list(cdef.filters),
+        exports=set(cdef.exports),
+        unexports=set(cdef.unexports),
+        doc=cdef.doc,
+    )
+
+
+def _shift_diagnostic(diag: Diagnostic, base_line: int, base_char: int) -> Diagnostic:
+    """Shift all ranges in a Diagnostic (including fixes and related_ranges)."""
+    new_fixes = tuple(
+        CodeFix(
+            range=_shift_range(fix.range, base_line, base_char),
+            new_text=fix.new_text,
+            description=fix.description,
+        )
+        for fix in diag.fixes
+    )
+    new_related = tuple(
+        (_shift_range(r, base_line, base_char), msg) for r, msg in diag.related_ranges
+    )
+    return Diagnostic(
+        range=_shift_range(diag.range, base_line, base_char),
+        message=diag.message,
+        severity=diag.severity,
+        code=diag.code,
+        fixes=new_fixes,
+        related_ranges=new_related,
+    )
+
+
+def _merge_shifted_result(
+    merged: AnalysisResult,
+    result: AnalysisResult,
+    base_line: int,
+    base_char: int,
+) -> None:
+    """Shift all ranges in *result* and merge into *merged*."""
+    # Diagnostics
+    for diag in result.diagnostics:
+        merged.diagnostics.append(_shift_diagnostic(diag, base_line, base_char))
+
+    # Suppressed lines
+    for line_no, codes in result.suppressed_lines.items():
+        merged.suppressed_lines[line_no + base_line] = codes
+
+    # Regex patterns
+    for rp in result.regex_patterns:
+        merged.regex_patterns.append(
+            RegexPattern(
+                range=_shift_range(rp.range, base_line, base_char),
+                pattern=rp.pattern,
+                command=rp.command,
+            )
+        )
+
+    # Command invocations
+    for ci in result.command_invocations:
+        merged.command_invocations.append(
+            CommandInvocation(
+                name=ci.name,
+                range=_shift_range(ci.range, base_line, base_char),
+                resolved_qualified_name=ci.resolved_qualified_name,
+            )
+        )
+
+    # Package requires/provides
+    for pr in result.package_requires:
+        merged.package_requires.append(
+            PackageRequire(
+                name=pr.name,
+                version=pr.version,
+                range=_shift_range(pr.range, base_line, base_char),
+                conditional=pr.conditional,
+            )
+        )
+    for pp in result.package_provides:
+        merged.package_provides.append(
+            PackageProvide(
+                name=pp.name,
+                version=pp.version,
+                range=_shift_range(pp.range, base_line, base_char),
+            )
+        )
+
+    # Source targets
+    for st in result.source_targets:
+        merged.source_targets.append(
+            SourceTarget(
+                raw_path=st.raw_path,
+                range=_shift_range(st.range, base_line, base_char),
+                is_literal=st.is_literal,
+            )
+        )
+
+    # Stub commands and expr defs
+    for stub in result.stub_commands:
+        merged.stub_commands.append(
+            StubCommandDef(
+                name=stub.name,
+                params=stub.params,
+                range=_shift_range(stub.range, base_line, base_char),
+                pure=stub.pure,
+                mutator=stub.mutator,
+                unsafe=stub.unsafe,
+                scope_alias=stub.scope_alias,
+            )
+        )
+    for stub_expr in result.stub_expr_defs:
+        merged.stub_expr_defs.append(
+            StubExprDef(
+                name=stub_expr.name,
+                kind=stub_expr.kind,
+                arity=stub_expr.arity,
+                pure=stub_expr.pure,
+                range=_shift_range(stub_expr.range, base_line, base_char),
+            )
+        )
+
+    # Procs and classes (merged into global scope)
+    for pname, pdef in result.all_procs.items():
+        merged.all_procs[pname] = _shift_proc(pdef, base_line, base_char)
+    for cname, cdef in result.all_classes.items():
+        merged.all_classes[cname] = _shift_class(cdef, base_line, base_char)
+    # Variables
+    for vname, vdef in result.all_variables.items():
+        new_refs = [_shift_range(r, base_line, base_char) for r in vdef.references]
+        merged.all_variables[vname] = VarDef(
+            name=vdef.name,
+            definition_range=_shift_range(vdef.definition_range, base_line, base_char),
+            references=new_refs,
+            warn_if_unused=vdef.warn_if_unused,
+        )
+
+    # Command aliases
+    for alias_name, alias_val in result.command_aliases.items():
+        merged.command_aliases[alias_name] = alias_val
+
+    # Dynamic providers
+    if result.has_dynamic_providers:
+        merged.has_dynamic_providers = True
+
+    # Unknown proc info
+    if result.unknown_proc_info is not None and merged.unknown_proc_info is None:
+        merged.unknown_proc_info = result.unknown_proc_info
+
+    # Scope tree: add the shifted per-body global scope as a child of
+    # the merged global scope so features that walk the scope tree
+    # (e.g. document symbols, variable lookup) find the right context.
+    shifted_scope = _shift_scope(result.global_scope, base_line, base_char)
+    shifted_scope.parent = merged.global_scope
+    merged.global_scope.children.append(shifted_scope)
+
+
+def analyse_conf_wrapped(
+    source: str,
+    *,
+    disabled_diagnostics: frozenset[str] | None = None,
+    file_path: str | None = None,
+) -> tuple[AnalysisResult, list[EmbeddedRule]]:
+    """Analyse all rule bodies in a conf-wrapped iRules file.
+
+    Returns ``(merged_result, embedded_rules)`` where *merged_result*
+    contains diagnostics, scopes, procs, and symbols from all rule
+    bodies with ranges shifted to file coordinates.  All rules share
+    procs and RULE_INIT variables via flat sharing.
+    """
+    embedded_rules = find_embedded_rules(source)
+    if not embedded_rules:
+        # Shouldn't normally happen (caller should check), but handle
+        # gracefully by falling through to empty result.
+        return AnalysisResult(), []
+
+    buf = DocumentBuffer.from_source(source)
+
+    # Phase 1: Analyse each rule body independently.
+    per_rule: list[tuple[EmbeddedRule, AnalysisResult]] = []
+    for rule in embedded_rules:
+        analyser = Analyser(disabled_diagnostics=disabled_diagnostics)
+        result = analyser.analyse(rule.body, file_path=file_path)
+        per_rule.append((rule, result))
+
+    # Phase 2: Merge results with shifted ranges.
+    merged = AnalysisResult()
+    for rule, result in per_rule:
+        body_pos = buf.offset_to_position(rule.body_start_offset)
+        base_line = body_pos.line
+        base_char = body_pos.character
+        _merge_shifted_result(merged, result, base_line, base_char)
+
+    # Phase 3: Flat cross-rule sharing — collect all procs so they
+    # are visible across rules.  The merged result already has all
+    # procs in ``all_procs``; the workspace index layer will register
+    # them as globally available iRules procs.
+
+    return merged, embedded_rules

--- a/core/bigip/rule_extract.py
+++ b/core/bigip/rule_extract.py
@@ -35,6 +35,11 @@ class EmbeddedRule:
     range: Range  # range covering the entire stanza
 
 
+def is_conf_wrapped_irules(source: str) -> bool:
+    """Return ``True`` if *source* contains ``ltm rule`` or ``gtm rule`` stanzas."""
+    return bool(_RULE_HEADER_RE.search(source))
+
+
 def find_embedded_rules(source: str) -> list[EmbeddedRule]:
     """Find all ``ltm rule`` and ``gtm rule`` blocks in *source*."""
     source_map = DocumentBuffer.from_source(source)

--- a/core/bigip/rule_extract.py
+++ b/core/bigip/rule_extract.py
@@ -57,6 +57,13 @@ def find_embedded_rules(source: str) -> list[EmbeddedRule]:
                 depth += 1
             elif ch == "}":
                 depth -= 1
+            elif ch == '"':
+                # Skip quoted string — braces inside quotes are not structural.
+                pos += 1
+                while pos < len(source) and source[pos] != '"':
+                    if source[pos] == "\\":
+                        pos += 1  # skip escaped char
+                    pos += 1
             elif ch == "\\":
                 pos += 1  # skip escaped char
             pos += 1

--- a/core/common/dialect.py
+++ b/core/common/dialect.py
@@ -90,4 +90,10 @@ def detect_dialect_from_source(source: str) -> str | None:
         if m:
             return _TCL_VERSION_MAP.get(m.group(1))
 
+    # Conf-wrapped iRules: ``ltm rule /path { ... }`` or ``gtm rule /path { ... }``
+    from ..bigip.rule_extract import is_conf_wrapped_irules
+
+    if is_conf_wrapped_irules(source):
+        return "f5-irules"
+
     return None

--- a/lsp/features/completion.py
+++ b/lsp/features/completion.py
@@ -226,6 +226,7 @@ def get_completions(
     formatter_config: FormatterConfig | None = None,
     *,
     lines: list[str] | None = None,
+    embedded_rules: list | None = None,
 ) -> list[types.CompletionItem]:
     """Generate completion items for a position in source."""
     if analysis is None:
@@ -431,7 +432,11 @@ def get_completions(
         # Event-aware ranking: boost commands valid in the current event.
         current_event: str | None = None
         if dialect == "f5-irules":
-            current_event, _ = find_enclosing_when_event(source, line)
+            current_event, _ = find_enclosing_when_event(
+                source,
+                line,
+                embedded_rules=embedded_rules,
+            )
         # Built-in commands — merge registry names (already package-filtered)
         # with SIGNATURES keys, but exclude SIGNATURES-only entries that are
         # package-gated and whose package is not active.

--- a/lsp/features/document_symbols.py
+++ b/lsp/features/document_symbols.py
@@ -273,6 +273,7 @@ def get_document_symbols(
     source: str,
     analysis: AnalysisResult | None = None,
     chunks: list | None = None,
+    embedded_rules: list | None = None,
 ) -> list[types.DocumentSymbol]:
     """Return the document symbol hierarchy for a Tcl source file.
 
@@ -280,8 +281,14 @@ def get_document_symbols(
     scope hierarchy.  When only *chunks* are available (analysis not yet
     complete), returns basic event/proc symbols extracted from command
     text — enough for a useful outline while the subprocess runs.
+
+    When *embedded_rules* is provided (conf-wrapped iRules mode), each
+    rule stanza becomes a top-level Module symbol containing the
+    per-body scope symbols.
     """
     if analysis is not None:
+        if embedded_rules:
+            return _conf_wrapped_symbols(analysis, embedded_rules)
         return _scope_symbols(analysis.global_scope)
 
     # Fast path: build symbols from chunks without running analysis.
@@ -291,3 +298,34 @@ def get_document_symbols(
     # Fallback: run analysis synchronously (legacy path).
     analysis = analyse(source)
     return _scope_symbols(analysis.global_scope)
+
+
+def _conf_wrapped_symbols(
+    analysis: AnalysisResult,
+    embedded_rules: list,
+) -> list[types.DocumentSymbol]:
+    """Build document symbols for conf-wrapped iRules.
+
+    Each ``ltm rule /path`` becomes a Module symbol containing the
+    scope symbols from its rule body.
+    """
+    rule_symbols: list[types.DocumentSymbol] = []
+    children = analysis.global_scope.children
+
+    for i, rule in enumerate(embedded_rules):
+        rule_range = to_lsp_range(rule.range)
+        # Get child scope symbols if available.
+        child_symbols: list[types.DocumentSymbol] = []
+        if i < len(children):
+            child_symbols = _scope_symbols(children[i])
+
+        rule_sym = types.DocumentSymbol(
+            name=rule.full_path,
+            detail=rule.header,
+            kind=types.SymbolKind.Module,
+            range=rule_range,
+            selection_range=rule_range,
+            children=child_symbols,
+        )
+        rule_symbols.append(rule_sym)
+    return rule_symbols

--- a/lsp/features/irules_context.py
+++ b/lsp/features/irules_context.py
@@ -11,14 +11,38 @@ def find_enclosing_when_event(
     line: int,
     *,
     lines: list[str] | None = None,
+    embedded_rules: list | None = None,
 ) -> tuple[str | None, int]:
-    """Find the enclosing ``when EVENT { ... }`` and return (event, anchor_line)."""
+    """Find the enclosing ``when EVENT { ... }`` and return (event, anchor_line).
+
+    When *embedded_rules* is provided (conf-wrapped mode), the search
+    is scoped to the rule body containing *line*.
+    """
     if lines is None:
         lines = source.split("\n")
     if not lines:
         return (None, 0)
 
     idx = max(0, min(line, len(lines) - 1))
+
+    # Conf-wrapped mode: scope to the rule body containing the cursor.
+    scan_source = source
+    scan_idx = idx
+    if embedded_rules:
+        from core.common.document_buffer import DocumentBuffer
+
+        buf = DocumentBuffer.from_source(source)
+        for rule in embedded_rules:
+            body_start = buf.offset_to_position(rule.body_start_offset)
+            body_end = buf.offset_to_position(max(rule.body_end_offset - 1, rule.body_start_offset))
+            if body_start.line <= idx <= body_end.line:
+                # Cursor is inside this rule body.
+                scan_source = rule.body
+                scan_idx = idx - body_start.line
+                break
+        else:
+            # Cursor is outside any rule body.
+            return (None, idx)
 
     def _scan_when_context(
         text: str,
@@ -34,7 +58,7 @@ def find_enclosing_when_event(
             body_tok = next((tok for tok in cmd.arg_tokens if tok.type is TokenType.STR), None)
             if body_tok is None:
                 continue
-            if not (body_tok.start.line <= idx <= body_tok.end.line):
+            if not (body_tok.start.line <= scan_idx <= body_tok.end.line):
                 continue
 
             best = (event_name, cmd.range.start.line)
@@ -44,8 +68,20 @@ def find_enclosing_when_event(
 
         return best
 
-    match = _scan_when_context(source)
+    match = _scan_when_context(scan_source)
     if match is not None:
+        if embedded_rules and scan_source != source:
+            # Shift the anchor line back to file coordinates.
+            from core.common.document_buffer import DocumentBuffer
+
+            buf = DocumentBuffer.from_source(source)
+            for rule in embedded_rules:
+                body_start = buf.offset_to_position(rule.body_start_offset)
+                body_end = buf.offset_to_position(
+                    max(rule.body_end_offset - 1, rule.body_start_offset)
+                )
+                if body_start.line <= idx <= body_end.line:
+                    return (match[0], match[1] + body_start.line)
         return match
 
     return (None, idx)

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -573,11 +573,12 @@ def on_semantic_tokens_full(
         else:
             cache_status = "no_cache"
     ls = state.buffer.line_starts if state is not None else None
+    is_cw = state is not None and state.conf_wrapped
     data = semantic_tokens_full(
         source,
         analysis=analysis,
-        is_bigip_conf=_is_bigip_conf(uri),
-        is_irules=_is_irules_source(uri),
+        is_bigip_conf=_is_bigip_conf(uri) or is_cw,
+        is_irules=_is_irules_source(uri) or is_cw,
         is_apl=_is_apl_source(uri),
         chunk_token_cache=chunk_token_cache,
         chunk_line_ranges=chunk_line_ranges,
@@ -636,11 +637,12 @@ def on_semantic_tokens_delta(
         if cache_info is not None:
             chunk_token_cache, chunk_line_ranges = cache_info
     ls = state.buffer.line_starts if state is not None else None
+    is_cw_delta = state is not None and state.conf_wrapped
     new_data = semantic_tokens_full(
         source,
         analysis=analysis,
-        is_bigip_conf=_is_bigip_conf(uri),
-        is_irules=_is_irules_source(uri),
+        is_bigip_conf=_is_bigip_conf(uri) or is_cw_delta,
+        is_irules=_is_irules_source(uri) or is_cw_delta,
         is_apl=_is_apl_source(uri),
         chunk_token_cache=chunk_token_cache,
         chunk_line_ranges=chunk_line_ranges,
@@ -714,6 +716,7 @@ def on_completion(
         workspace_proc_usage=workspace_index.proc_usage_counts(),
         formatter_config=formatter_config,
         lines=state.lines if state else None,
+        embedded_rules=state.embedded_rules if state and state.conf_wrapped else None,
     )
 
 
@@ -911,7 +914,12 @@ def on_document_symbol(
     state = workspace_state.get(uri)
     analysis = state.analysis if state else None
     chunks = state.chunks if state else None
-    return get_document_symbols(source, analysis=analysis, chunks=chunks)
+    return get_document_symbols(
+        source,
+        analysis=analysis,
+        chunks=chunks,
+        embedded_rules=state.embedded_rules if state and state.conf_wrapped else None,
+    )
 
 
 # Folding ranges
@@ -2205,7 +2213,7 @@ def _update_workspace_index(uri: str, source: str, state: object) -> None:
             if resolved:
                 sourced.add(path_to_uri(resolved))
         workspace_index.update_source_graph(uri, frozenset(sourced))
-    if _is_irules_source(uri):
+    if _is_irules_source(uri) or state.conf_wrapped:
         if state.analysis.all_procs:
             workspace_index.update_irules_globals(
                 uri,
@@ -2213,8 +2221,16 @@ def _update_workspace_index(uri: str, source: str, state: object) -> None:
             )
         from core.compiler.irules_flow import extract_rule_init_vars
 
-        exports = extract_rule_init_vars(source, cu=state.compilation_unit)
-        workspace_index.update_rule_init_vars(uri, exports)
+        if state.conf_wrapped and state.embedded_rules:
+            # For conf-wrapped files, extract RULE_INIT vars from each
+            # rule body independently and merge.
+            all_exports: list = []
+            for rule in state.embedded_rules:
+                all_exports.extend(extract_rule_init_vars(rule.body))
+            workspace_index.update_rule_init_vars(uri, all_exports)
+        else:
+            exports = extract_rule_init_vars(source, cu=state.compilation_unit)
+            workspace_index.update_rule_init_vars(uri, exports)
     _load_packages_if_needed(state.analysis)
 
 
@@ -2307,9 +2323,10 @@ async def _publish_diagnostics(
     # heavy analysis thread holds the GIL.  Only for newly opened files
     # that don't have a token cache yet.
     if state.get_semantic_token_cache() is None and state.chunks:
+        is_cw_pre = state.conf_wrapped
         state.precompute_syntax_tokens(
-            is_irules=_is_irules_source(uri),
-            is_bigip_conf=_is_bigip_conf(uri),
+            is_irules=_is_irules_source(uri) or is_cw_pre,
+            is_bigip_conf=_is_bigip_conf(uri) or is_cw_pre,
             is_apl=_is_apl_source(uri),
         )
 

--- a/lsp/workspace/document_state.py
+++ b/lsp/workspace/document_state.py
@@ -183,6 +183,63 @@ def _analyse_document_fresh(
     except Exception:
         pass
 
+    # Conf-wrapped iRules: analyse each rule body independently.
+    from core.bigip.rule_extract import is_conf_wrapped_irules
+
+    if is_irules_dialect() and is_conf_wrapped_irules(source):
+        from core.analysis.conf_wrapped import analyse_conf_wrapped
+
+        analysis, embedded_rules = analyse_conf_wrapped(
+            source,
+            disabled_diagnostics=default_disabled_diagnostics(),
+            file_path=uri,
+        )
+        all_profiles: set[str] = set()
+        for rule in embedded_rules:
+            all_profiles.update(EVENT_REGISTRY.compute_file_profiles(rule.body))
+        file_profiles = frozenset(all_profiles) | file_profiles
+
+        buf = DocumentBuffer.from_source(source, version)
+        basic_diags = []
+        suppressed: dict[int, frozenset[str]] = {}
+        try:
+            from lsp.features.diagnostics import get_basic_diagnostics
+
+            basic_diags, _analysis_out, suppressed = get_basic_diagnostics(
+                source,
+                analysis=analysis,
+                cu=None,
+                optimiser_enabled=False,
+                disabled_diagnostics=disabled_diagnostics or set(),
+                disabled_optimisations=disabled_optimisations or set(),
+                line_length=line_length,
+                cached_style_diagnostics=None,
+                workspace_context=None,
+                uri=uri,
+            )
+        except Exception:
+            log.debug("subprocess: conf-wrapped basic diagnostics failed", exc_info=True)
+
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        log.info(
+            "[timing] _analyse_document_fresh (conf-wrapped) %.0fms (rules=%d)",
+            elapsed_ms,
+            len(embedded_rules),
+        )
+        return {
+            "analysis": analysis,
+            "compilation_unit": None,
+            "chunks": chunks,
+            "has_partial": has_partial,
+            "chunk_caches": [],
+            "file_profiles": file_profiles,
+            "buffer": buf,
+            "basic_diags": basic_diags,
+            "suppressed": suppressed,
+            "conf_wrapped": True,
+            "embedded_rules": embedded_rules,
+        }
+
     compilation_unit: CompilationUnit | None = None
     try:
         compilation_unit = compile_source(source)
@@ -413,6 +470,10 @@ class _StateSnapshot:
     buffer: DocumentBuffer | None = None
     deep_diag_proc_key: frozenset[tuple[str, int]] | None = None
     deep_diag_result: list[Any] | None = None
+    # Conf-wrapped iRules mode: file contains ``ltm rule`` / ``gtm rule``
+    # stanzas rather than bare iRule bodies.
+    conf_wrapped: bool = False
+    embedded_rules: list[Any] = field(default_factory=list)
 
 
 @dataclass
@@ -540,6 +601,16 @@ class DocumentState:
     @_buffer.setter
     def _buffer(self, value: DocumentBuffer | None) -> None:
         self._snap.buffer = value
+
+    @property
+    def conf_wrapped(self) -> bool:
+        """Whether this document is a conf-wrapped iRules file."""
+        return self._snap.conf_wrapped
+
+    @property
+    def embedded_rules(self) -> list:
+        """The list of ``EmbeddedRule`` objects for conf-wrapped files."""
+        return self._snap.embedded_rules
 
     @property
     def _deep_diag_proc_key(self) -> frozenset[tuple[str, int]] | None:
@@ -683,6 +754,8 @@ class DocumentState:
             file_profiles=result.get("file_profiles", frozenset()),
             chunk_caches=result.get("chunk_caches", []),
             buffer=result.get("buffer"),
+            conf_wrapped=result.get("conf_wrapped", False),
+            embedded_rules=result.get("embedded_rules", []),
         )
 
     def precompute_syntax_tokens(
@@ -1182,6 +1255,28 @@ class DocumentState:
         self._snap._tokens = None  # invalidate — rebuilt lazily on access
         t_tok = time.perf_counter()
 
+        # Conf-wrapped iRules: extract rule bodies and analyse each
+        # independently, then merge.  Skips compilation and chunk caching
+        # since the outer structure is not Tcl.
+        if is_irules_dialect():
+            from core.bigip.rule_extract import is_conf_wrapped_irules
+
+            if is_conf_wrapped_irules(source):
+                self._update_full_conf_wrapped(
+                    source,
+                    version,
+                    new_chunks,
+                    has_partial,
+                    file_profiles=file_profiles,
+                    line_length=line_length,
+                )
+                t_cw = time.perf_counter()
+                log.info(
+                    "[timing] _update_full (conf-wrapped) %.0fms",
+                    (t_cw - t0) * 1000,
+                )
+                return
+
         prev_proc_cache = dict(self._proc_cache)
         prev_interproc_cache = dict(self._interproc_cache)
         compilation_unit: CompilationUnit | None = None
@@ -1249,6 +1344,48 @@ class DocumentState:
             (t_caches - t_analyse) * 1000,
             (t_caches - t0) * 1000,
             n_procs,
+        )
+
+    def _update_full_conf_wrapped(
+        self,
+        source: str,
+        version: int | None,
+        new_chunks: list[TopLevelChunk],
+        has_partial: bool,
+        *,
+        file_profiles: frozenset[str] = frozenset(),
+        line_length: int = 120,
+    ) -> None:
+        """Full rebuild for conf-wrapped iRules files.
+
+        Extracts each ``ltm rule`` / ``gtm rule`` body, analyses it as
+        a standalone iRule, and merges the results with shifted ranges.
+        """
+        from core.analysis.conf_wrapped import analyse_conf_wrapped
+
+        analysis, embedded_rules = analyse_conf_wrapped(
+            source,
+            disabled_diagnostics=default_disabled_diagnostics(),
+            file_path=self.uri,
+        )
+
+        # Compute file profiles from ALL embedded rule bodies.
+        all_profiles: set[str] = set()
+        for rule in embedded_rules:
+            all_profiles.update(EVENT_REGISTRY.compute_file_profiles(rule.body))
+        file_profiles = frozenset(all_profiles) | file_profiles
+
+        self._snap = _StateSnapshot(
+            source=source,
+            version=version,
+            analysis=analysis,
+            compilation_unit=None,
+            chunks=new_chunks,
+            has_partial_commands=has_partial,
+            file_profiles=file_profiles,
+            chunk_caches=[],
+            conf_wrapped=True,
+            embedded_rules=embedded_rules,
         )
 
     def _build_full_chunk_caches(

--- a/lsp/workspace/document_state.py
+++ b/lsp/workspace/document_state.py
@@ -1375,6 +1375,8 @@ class DocumentState:
             all_profiles.update(EVENT_REGISTRY.compute_file_profiles(rule.body))
         file_profiles = frozenset(all_profiles) | file_profiles
 
+        buf = DocumentBuffer.from_source(source, version)
+
         self._snap = _StateSnapshot(
             source=source,
             version=version,
@@ -1384,6 +1386,7 @@ class DocumentState:
             has_partial_commands=has_partial,
             file_profiles=file_profiles,
             chunk_caches=[],
+            buffer=buf,
             conf_wrapped=True,
             embedded_rules=embedded_rules,
         )

--- a/tests/test_conf_wrapped_irules.py
+++ b/tests/test_conf_wrapped_irules.py
@@ -1,0 +1,227 @@
+"""Tests for conf-wrapped iRules analysis (``ltm rule`` / ``gtm rule`` mode)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.analysis.conf_wrapped import analyse_conf_wrapped
+from core.bigip.rule_extract import is_conf_wrapped_irules
+from core.commands.registry.runtime import configure_signatures
+from core.common.dialect import detect_dialect_from_source
+
+# -- Detection ----------------------------------------------------------------
+
+
+class TestDetection:
+    """is_conf_wrapped_irules and detect_dialect_from_source."""
+
+    def test_standalone_irule_not_detected(self):
+        src = 'when HTTP_REQUEST {\n    log local0. "hi"\n}'
+        assert not is_conf_wrapped_irules(src)
+
+    def test_ltm_rule_detected(self):
+        src = 'ltm rule /Common/foo {\n    when HTTP_REQUEST {\n        log local0. "hi"\n    }\n}'
+        assert is_conf_wrapped_irules(src)
+
+    def test_gtm_rule_detected(self):
+        src = 'gtm rule /Common/bar {\n    when DNS_REQUEST {\n        log local0. "hi"\n    }\n}'
+        assert is_conf_wrapped_irules(src)
+
+    def test_multiple_rules_detected(self):
+        src = (
+            "ltm rule /Common/a {\n    when RULE_INIT { }\n}\n"
+            "ltm rule /Common/b {\n    when HTTP_REQUEST { }\n}\n"
+        )
+        assert is_conf_wrapped_irules(src)
+
+    def test_detect_dialect_returns_irules(self):
+        src = "ltm rule /Common/foo {\n    when HTTP_REQUEST { }\n}"
+        assert detect_dialect_from_source(src) == "f5-irules"
+
+
+# -- Analysis -----------------------------------------------------------------
+
+
+class TestAnalysis:
+    """analyse_conf_wrapped produces correct merged results."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def test_single_rule_diagnostics(self):
+        src = (
+            "ltm rule /Common/test {\n"
+            "    when HTTP_REQUEST {\n"
+            '        log local0. "hello"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 1
+        assert rules[0].name == "test"
+        # Should produce no IRULE5006/5007 errors — when is at top-level
+        # within the rule body.
+        depth_diags = [d for d in result.diagnostics if d.code in ("IRULE5006", "IRULE5007")]
+        assert len(depth_diags) == 0
+
+    def test_multiple_rules_all_analysed(self):
+        src = (
+            "ltm rule /Common/rule_a {\n"
+            "    when RULE_INIT {\n"
+            "        set static::app_debug 1\n"
+            "    }\n"
+            "}\n"
+            "ltm rule /Common/rule_b {\n"
+            "    when HTTP_REQUEST {\n"
+            '        log local0. "request"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 2
+        assert rules[0].name == "rule_a"
+        assert rules[1].name == "rule_b"
+
+    def test_gtm_rule_analysed(self):
+        src = (
+            "gtm rule /Common/dns_handler {\n"
+            "    when DNS_REQUEST {\n"
+            '        log local0. "dns"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 1
+        assert rules[0].name == "dns_handler"
+
+    def test_when_not_flagged_as_nested(self):
+        """``when`` at rule body top-level should NOT trigger IRULE5006."""
+        src = (
+            "ltm rule /Common/test {\n"
+            "    when HTTP_REQUEST {\n"
+            '        HTTP::respond 200 content "ok"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        irule5006 = [d for d in result.diagnostics if d.code == "IRULE5006"]
+        assert len(irule5006) == 0
+
+
+# -- Range shifting -----------------------------------------------------------
+
+
+class TestRangeShifting:
+    """Diagnostics have correct file-absolute line/column positions."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def test_diagnostic_line_offset(self):
+        """Diagnostic from rule body at line 3 in file maps to correct line."""
+        src = (
+            "ltm rule /Common/test {\n"  # line 0
+            "    when HTTP_REQUEST {\n"  # line 1
+            '        HTTP::respond 200 content "ok"\n'  # line 2
+            "    }\n"  # line 3
+            "}\n"  # line 4
+        )
+        result, rules = analyse_conf_wrapped(src)
+        # The rule body starts after the opening brace on line 0.
+        # Any diagnostics should have line >= 1 (the body starts after
+        # the opening brace of ltm rule).
+        for diag in result.diagnostics:
+            assert diag.range.start.line >= 0, (
+                f"Diagnostic {diag.code} at line {diag.range.start.line} is before the file start"
+            )
+
+    def test_second_rule_diagnostics_shifted(self):
+        """Diagnostics from the second rule have correct line numbers."""
+        src = (
+            "ltm rule /Common/first {\n"  # line 0
+            "    when RULE_INIT { }\n"  # line 1
+            "}\n"  # line 2
+            "ltm rule /Common/second {\n"  # line 3
+            "    when CLIENT_ACCEPTED {\n"  # line 4
+            '        HTTP::respond 200 content "ok"\n'  # line 5 — wrong event!
+            "    }\n"  # line 6
+            "}\n"  # line 7
+        )
+        result, rules = analyse_conf_wrapped(src)
+        # The second rule body starts at line 3 (after opening brace).
+        # HTTP::respond in CLIENT_ACCEPTED should generate IRULE1001
+        # and the line should be >= 4.
+        irule1001 = [d for d in result.diagnostics if d.code == "IRULE1001"]
+        if irule1001:
+            assert irule1001[0].range.start.line >= 4, (
+                f"IRULE1001 diagnostic at line {irule1001[0].range.start.line} "
+                f"should be >= 4 (in second rule body)"
+            )
+
+
+# -- Cross-rule proc sharing --------------------------------------------------
+
+
+class TestCrossRuleSharing:
+    """Procs defined in one rule are visible in merged result."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def test_procs_from_all_rules_in_merged(self):
+        src = (
+            "ltm rule /Common/utils {\n"
+            "    when RULE_INIT {\n"
+            "        proc helper { x } { return $x }\n"
+            "    }\n"
+            "}\n"
+            "ltm rule /Common/main {\n"
+            "    when HTTP_REQUEST {\n"
+            '        log local0. "req"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        # The helper proc from rule_a should be in all_procs.
+        assert "helper" in result.all_procs or "::helper" in result.all_procs
+
+
+# -- Empty / edge cases -------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases for conf-wrapped analysis."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def test_empty_rule_body(self):
+        src = "ltm rule /Common/empty {\n}\n"
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 1
+        assert rules[0].name == "empty"
+
+    def test_no_rules_returns_empty(self):
+        """Source with no rules should return empty results."""
+        src = "# just a comment\n"
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 0
+        assert len(result.diagnostics) == 0
+
+    def test_mixed_ltm_gtm_rules(self):
+        src = (
+            "ltm rule /Common/http_handler {\n"
+            "    when HTTP_REQUEST { }\n"
+            "}\n"
+            "gtm rule /Common/dns_handler {\n"
+            "    when DNS_REQUEST { }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 2
+        names = {r.name for r in rules}
+        assert "http_handler" in names
+        assert "dns_handler" in names

--- a/tests/test_conf_wrapped_irules.py
+++ b/tests/test_conf_wrapped_irules.py
@@ -7,10 +7,18 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from core.analysis.conf_wrapped import analyse_conf_wrapped
-from core.bigip.rule_extract import is_conf_wrapped_irules
+from core.analysis.conf_wrapped import (
+    _shift_position,
+    _shift_range,
+    analyse_conf_wrapped,
+)
+from core.analysis.semantic_model import Range
+from core.bigip.rule_extract import find_embedded_rules, is_conf_wrapped_irules
 from core.commands.registry.runtime import configure_signatures
 from core.common.dialect import detect_dialect_from_source
+from core.parsing.tokens import SourcePosition
+from lsp.features.document_symbols import get_document_symbols
+from lsp.features.irules_context import find_enclosing_when_event
 
 # -- Detection ----------------------------------------------------------------
 
@@ -40,6 +48,11 @@ class TestDetection:
     def test_detect_dialect_returns_irules(self):
         src = "ltm rule /Common/foo {\n    when HTTP_REQUEST { }\n}"
         assert detect_dialect_from_source(src) == "f5-irules"
+
+    def test_dialect_directive_takes_priority(self):
+        """Explicit ``# tcl-dialect:`` overrides conf-wrapped detection."""
+        src = "# tcl-dialect: tcl8.6\nltm rule /Common/foo {\n    when HTTP_REQUEST { }\n}"
+        assert detect_dialect_from_source(src) == "tcl8.6"
 
 
 # -- Analysis -----------------------------------------------------------------
@@ -110,56 +123,167 @@ class TestAnalysis:
         irule5006 = [d for d in result.diagnostics if d.code == "IRULE5006"]
         assert len(irule5006) == 0
 
+    def test_irule5007_fires_for_top_level_event_command(self):
+        """Event-context command outside ``when`` triggers IRULE5007."""
+        src = 'ltm rule /Common/bad {\n    HTTP::respond 200 content "ok"\n}\n'
+        result, rules = analyse_conf_wrapped(src)
+        irule5007 = [d for d in result.diagnostics if d.code == "IRULE5007"]
+        assert len(irule5007) == 1
+        assert "HTTP::respond" in irule5007[0].message
+
+    def test_multiple_when_blocks_in_one_rule(self):
+        """Multiple ``when`` blocks in a single rule are all analysed."""
+        src = (
+            "ltm rule /Common/multi {\n"
+            "    when RULE_INIT {\n"
+            "        set static::app_debug 1\n"
+            "    }\n"
+            "    when HTTP_REQUEST {\n"
+            '        log local0. "request"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        assert len(rules) == 1
+        depth_diags = [d for d in result.diagnostics if d.code in ("IRULE5006", "IRULE5007")]
+        assert len(depth_diags) == 0
+
 
 # -- Range shifting -----------------------------------------------------------
 
 
 class TestRangeShifting:
-    """Diagnostics have correct file-absolute line/column positions."""
+    """Diagnostics have correct file-absolute line/column/offset positions."""
 
     def setup_method(self):
         configure_signatures(dialect="f5-irules")
 
-    def test_diagnostic_line_offset(self):
-        """Diagnostic from rule body at line 3 in file maps to correct line."""
+    def test_shift_position_line_zero(self):
+        """Line 0 positions shift both line and character."""
+        pos = SourcePosition(line=0, character=4, offset=4)
+        shifted = _shift_position(pos, base_line=3, base_char=8, base_offset=100)
+        assert shifted.line == 3
+        assert shifted.character == 12  # 4 + 8
+        assert shifted.offset == 104  # 4 + 100
+
+    def test_shift_position_later_line(self):
+        """Lines > 0 shift only line (character is relative to line start)."""
+        pos = SourcePosition(line=2, character=6, offset=30)
+        shifted = _shift_position(pos, base_line=5, base_char=8, base_offset=100)
+        assert shifted.line == 7  # 2 + 5
+        assert shifted.character == 6  # unchanged
+        assert shifted.offset == 130  # 30 + 100
+
+    def test_shift_range_spans_lines(self):
+        """Range spanning multiple lines shifts both endpoints correctly."""
+        rng = Range(
+            start=SourcePosition(line=0, character=2, offset=2),
+            end=SourcePosition(line=3, character=5, offset=40),
+        )
+        shifted = _shift_range(rng, base_line=10, base_char=4, base_offset=200)
+        assert shifted.start.line == 10
+        assert shifted.start.character == 6  # 2 + 4
+        assert shifted.start.offset == 202  # 2 + 200
+        assert shifted.end.line == 13  # 3 + 10
+        assert shifted.end.character == 5  # unchanged
+        assert shifted.end.offset == 240  # 40 + 200
+
+    def test_diagnostic_offsets_are_absolute(self):
+        """Diagnostic offsets point to the correct position in the full file."""
         src = (
-            "ltm rule /Common/test {\n"  # line 0
+            "ltm rule /Common/test {\n"  # line 0, 24 chars
             "    when HTTP_REQUEST {\n"  # line 1
             '        HTTP::respond 200 content "ok"\n'  # line 2
             "    }\n"  # line 3
             "}\n"  # line 4
         )
         result, rules = analyse_conf_wrapped(src)
-        # The rule body starts after the opening brace on line 0.
-        # Any diagnostics should have line >= 1 (the body starts after
-        # the opening brace of ltm rule).
+        # Every diagnostic offset should be within the source bounds.
         for diag in result.diagnostics:
-            assert diag.range.start.line >= 0, (
-                f"Diagnostic {diag.code} at line {diag.range.start.line} is before the file start"
+            assert 0 <= diag.range.start.offset <= len(src), (
+                f"Diagnostic {diag.code} offset {diag.range.start.offset} "
+                f"is outside source bounds [0, {len(src)}]"
+            )
+            assert 0 <= diag.range.end.offset <= len(src), (
+                f"Diagnostic {diag.code} end offset {diag.range.end.offset} "
+                f"is outside source bounds [0, {len(src)}]"
             )
 
-    def test_second_rule_diagnostics_shifted(self):
-        """Diagnostics from the second rule have correct line numbers."""
+    def test_second_rule_diagnostic_exact_line(self):
+        """IRULE1001 in the second rule maps to the exact file line."""
         src = (
             "ltm rule /Common/first {\n"  # line 0
             "    when RULE_INIT { }\n"  # line 1
             "}\n"  # line 2
             "ltm rule /Common/second {\n"  # line 3
             "    when CLIENT_ACCEPTED {\n"  # line 4
-            '        HTTP::respond 200 content "ok"\n'  # line 5 — wrong event!
+            '        HTTP::respond 200 content "ok"\n'  # line 5
             "    }\n"  # line 6
             "}\n"  # line 7
         )
         result, rules = analyse_conf_wrapped(src)
-        # The second rule body starts at line 3 (after opening brace).
-        # HTTP::respond in CLIENT_ACCEPTED should generate IRULE1001
-        # and the line should be >= 4.
+        irule1001 = [d for d in result.diagnostics if d.code == "IRULE1001"]
+        assert len(irule1001) >= 1
+        # HTTP::respond is on line 5 in the file.
+        assert irule1001[0].range.start.line == 5
+
+    def test_second_rule_diagnostic_offset_in_range(self):
+        """Offsets from the second rule body are within the rule's range."""
+        src = (
+            "ltm rule /Common/first {\n"
+            "    when RULE_INIT { }\n"
+            "}\n"
+            "ltm rule /Common/second {\n"
+            "    when CLIENT_ACCEPTED {\n"
+            '        HTTP::respond 200 content "ok"\n'
+            "    }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
         irule1001 = [d for d in result.diagnostics if d.code == "IRULE1001"]
         if irule1001:
-            assert irule1001[0].range.start.line >= 4, (
-                f"IRULE1001 diagnostic at line {irule1001[0].range.start.line} "
-                f"should be >= 4 (in second rule body)"
-            )
+            # The diagnostic offset must be within the second rule body.
+            assert irule1001[0].range.start.offset >= rules[1].body_start_offset
+            assert irule1001[0].range.start.offset < rules[1].body_end_offset
+
+
+# -- Scope tree structure -----------------------------------------------------
+
+
+class TestScopeTree:
+    """Merged analysis has correct scope tree structure."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def test_scope_children_per_rule(self):
+        """Merged global scope has one child per rule."""
+        src = (
+            "ltm rule /Common/a {\n"
+            "    when RULE_INIT { }\n"
+            "}\n"
+            "ltm rule /Common/b {\n"
+            "    when HTTP_REQUEST { }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        assert len(result.global_scope.children) == 2
+
+    def test_proc_in_rule_has_shifted_range(self):
+        """Proc defined in rule body has ranges in file coordinates."""
+        src = (
+            "ltm rule /Common/with_proc {\n"  # line 0, 29 chars
+            "    proc helper { x } { return $x }\n"  # line 1
+            "    when HTTP_REQUEST { }\n"  # line 2
+            "}\n"  # line 3
+        )
+        result, rules = analyse_conf_wrapped(src)
+        proc = result.all_procs.get("helper") or result.all_procs.get("::helper")
+        assert proc is not None
+        # The proc is on line 1 in the file.
+        assert proc.name_range.start.line == 1
+        # The proc offset should be within the rule body.
+        assert proc.name_range.start.offset >= rules[0].body_start_offset
 
 
 # -- Cross-rule proc sharing --------------------------------------------------
@@ -187,6 +311,138 @@ class TestCrossRuleSharing:
         result, rules = analyse_conf_wrapped(src)
         # The helper proc from rule_a should be in all_procs.
         assert "helper" in result.all_procs or "::helper" in result.all_procs
+
+
+# -- find_enclosing_when_event with embedded_rules ----------------------------
+
+
+class TestEnclosingWhenEvent:
+    """find_enclosing_when_event respects conf-wrapped rule body boundaries."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def _rules(self, src: str):
+        return find_embedded_rules(src)
+
+    def test_cursor_in_first_rule(self):
+        src = (
+            "ltm rule /Common/a {\n"  # line 0
+            "    when HTTP_REQUEST {\n"  # line 1
+            '        log local0. "hi"\n'  # line 2
+            "    }\n"  # line 3
+            "}\n"  # line 4
+            "ltm rule /Common/b {\n"  # line 5
+            "    when DNS_REQUEST {\n"  # line 6
+            '        log local0. "dns"\n'  # line 7
+            "    }\n"  # line 8
+            "}\n"  # line 9
+        )
+        rules = self._rules(src)
+        event, _ = find_enclosing_when_event(src, 2, embedded_rules=rules)
+        assert event == "HTTP_REQUEST"
+
+    def test_cursor_in_second_rule(self):
+        src = (
+            "ltm rule /Common/a {\n"
+            "    when HTTP_REQUEST {\n"
+            '        log local0. "hi"\n'
+            "    }\n"
+            "}\n"
+            "ltm rule /Common/b {\n"
+            "    when DNS_REQUEST {\n"
+            '        log local0. "dns"\n'
+            "    }\n"
+            "}\n"
+        )
+        rules = self._rules(src)
+        event, _ = find_enclosing_when_event(src, 7, embedded_rules=rules)
+        assert event == "DNS_REQUEST"
+
+    def test_cursor_outside_all_rules(self):
+        src = "ltm rule /Common/a {\n    when HTTP_REQUEST { }\n}\n"
+        rules = self._rules(src)
+        # Line 2 is the closing brace + newline (outside rule body).
+        event, _ = find_enclosing_when_event(src, 2, embedded_rules=rules)
+        assert event is None
+
+    def test_cursor_in_rule_without_when(self):
+        src = "ltm rule /Common/empty {\n    set x 1\n}\n"
+        rules = self._rules(src)
+        event, _ = find_enclosing_when_event(src, 1, embedded_rules=rules)
+        assert event is None
+
+
+# -- Document symbols ---------------------------------------------------------
+
+
+class TestDocumentSymbols:
+    """get_document_symbols with embedded_rules produces rule containers."""
+
+    def setup_method(self):
+        configure_signatures(dialect="f5-irules")
+
+    def test_rule_symbols_are_modules(self):
+        from lsprotocol import types
+
+        src = "ltm rule /Common/my_rule {\n    when HTTP_REQUEST { }\n}\n"
+        result, rules = analyse_conf_wrapped(src)
+        symbols = get_document_symbols(src, analysis=result, embedded_rules=rules)
+        assert len(symbols) == 1
+        assert symbols[0].kind == types.SymbolKind.Module
+        assert symbols[0].name == "/Common/my_rule"
+
+    def test_multiple_rule_symbols(self):
+        src = (
+            "ltm rule /Common/a {\n"
+            "    when RULE_INIT { }\n"
+            "}\n"
+            "ltm rule /Common/b {\n"
+            "    when HTTP_REQUEST { }\n"
+            "}\n"
+        )
+        result, rules = analyse_conf_wrapped(src)
+        symbols = get_document_symbols(src, analysis=result, embedded_rules=rules)
+        assert len(symbols) == 2
+        names = [s.name for s in symbols]
+        assert "/Common/a" in names
+        assert "/Common/b" in names
+
+
+# -- Brace scanning robustness -----------------------------------------------
+
+
+class TestBraceScanning:
+    """find_embedded_rules handles braces inside quoted strings."""
+
+    def test_braces_in_quoted_string(self):
+        """Braces inside double-quoted strings don't terminate the rule body."""
+        src = (
+            "ltm rule /Common/quoted {\n"
+            "    when HTTP_REQUEST {\n"
+            '        set x "value with { braces }"\n'
+            "        log local0. $x\n"
+            "    }\n"
+            "}\n"
+        )
+        rules = find_embedded_rules(src)
+        assert len(rules) == 1
+        assert rules[0].name == "quoted"
+        # Body should contain the full when block including the quoted string.
+        assert "braces" in rules[0].body
+
+    def test_escaped_quote_in_string(self):
+        """Escaped quotes inside strings are handled correctly."""
+        src = (
+            "ltm rule /Common/escaped {\n"
+            "    when HTTP_REQUEST {\n"
+            '        set x "value \\"with\\" braces { }"\n'
+            "    }\n"
+            "}\n"
+        )
+        rules = find_embedded_rules(src)
+        assert len(rules) == 1
+        assert rules[0].name == "escaped"
 
 
 # -- Empty / edge cases -------------------------------------------------------


### PR DESCRIPTION
## Summary

Add comprehensive support for analyzing F5 BIG-IP conf-wrapped iRules files that use `ltm rule` and `gtm rule` stanzas instead of bare iRule bodies. This enables the language server to properly analyze, diagnose, and provide IDE features for configuration files containing embedded iRules.

### Key Changes

1. **New analysis module** (`core/analysis/conf_wrapped.py`):
   - Extracts each rule body from `ltm rule` / `gtm rule` stanzas
   - Analyzes each rule body independently at depth 0 (avoiding false "nested when" diagnostics)
   - Merges results with range-shifted positions so diagnostics and symbols map back to file coordinates
   - Implements flat sharing of procs and RULE_INIT variables across rules

2. **Rule extraction** (`core/bigip/rule_extract.py`):
   - Added `is_conf_wrapped_irules()` function to detect conf-wrapped files
   - Exports `EmbeddedRule` class with metadata (name, path, body offsets, range)

3. **Document state management** (`lsp/workspace/document_state.py`):
   - Added `_update_full_conf_wrapped()` method for full rebuild of conf-wrapped files
   - Skips compilation and chunk caching (outer structure is not Tcl)
   - Tracks `conf_wrapped` flag and `embedded_rules` list in state snapshot
   - Integrates conf-wrapped analysis into subprocess result handling

4. **IDE features**:
   - **Document symbols** (`lsp/features/document_symbols.py`): Each rule stanza becomes a Module symbol containing per-body scope symbols
   - **Completion** (`lsp/features/completion.py`): Passes embedded rules for context-aware suggestions
   - **iRules context** (`lsp/features/irules_context.py`): Scopes event detection to the rule body containing the cursor
   - **Semantic tokens** (`lsp/server.py`): Treats conf-wrapped files as iRules for proper tokenization

5. **Dialect detection** (`core/common/dialect.py`):
   - Detects `f5-irules` dialect from conf-wrapped file structure

### Testing

Added comprehensive test suite (`tests/test_conf_wrapped_irules.py`) covering:
- Detection of `ltm rule` and `gtm rule` stanzas
- Single and multiple rule analysis
- Correct range shifting for diagnostics
- Cross-rule proc sharing
- Edge cases (empty rules, mixed ltm/gtm)

## Validation

- [x] Added unit tests in `tests/test_conf_wrapped_irules.py` covering detection, analysis, range shifting, and cross-rule sharing
- [x] Existing iRules tests continue to pass (no regression)
- [x] Conf-wrapped analysis properly handles multiple rules with independent analysis and merged results

https://claude.ai/code/session_01LQ1SUzhHNBixVVxnKbkBF3