### PR TITLE
Fix quoted string literals being misclassified as stray braces/brackets

### DIFF
--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -767,13 +767,23 @@ class Analyser:
         first known-command-name argument through the ``]`` are merged
         into a virtual CMD token.  This lets ``_handle_switch`` detect
         the compact form and properly parse pattern/body pairs.
+
+        A ``]`` inside a double-quoted string is a literal character, not
+        a stray bracket — quoted-context ESC tokens must be skipped.
         """
+        from ..parsing.token_positions import classify_quoted_contexts
+
         # Step 1: Find an ESC token containing ']' at its end.
+        # Skip ESC tokens whose ']' is inside a double-quoted string
+        # (e.g. `foo "bar]"`).
+        in_quoted = classify_quoted_contexts(list(cmd.all_tokens))
         bracket_tok: Token | None = None
         bracket_tok_idx = -1
         bracket_char_idx = -1
         for ti, tok in enumerate(cmd.all_tokens):
             if tok.type is not TokenType.ESC:
+                continue
+            if in_quoted[ti]:
                 continue
             idx = tok.text.find("]")
             if idx >= 0 and idx == len(tok.text) - 1:

--- a/core/analysis/checks/_syntax.py
+++ b/core/analysis/checks/_syntax.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...common.codes import diag
+from ...parsing.token_positions import classify_quoted_contexts
 from ...parsing.tokens import Token, TokenType
 from ..semantic_model import CodeFix, Diagnostic, Range, Severity
 from ._helpers import (
@@ -27,12 +28,22 @@ def check_unmatched_close_bracket(
     missing '[' (e.g. after a bad edit removed it).  When a known command
     name precedes the ']', a CodeFix is attached suggesting where to
     insert the missing '['.
+
+    A ']' inside a double-quoted string (e.g. ``puts "foo ]"``) is just a
+    literal character and must not trigger this diagnostic.  Quoted-context
+    detection is centralised in :func:`classify_quoted_contexts` —
+    see its docstring for the underlying lexer contract.
     """
     from ...parsing.tokens import SourcePosition
 
     diagnostics: list[Diagnostic] = []
+    in_quoted = classify_quoted_contexts(all_tokens)
     for tok_idx, tok in enumerate(all_tokens):
         if tok.type is not TokenType.ESC:
+            continue
+        # Skip ESC tokens that are part of a quoted word — a ']' inside
+        # a "..." string is a literal character, not an unmatched bracket.
+        if in_quoted[tok_idx]:
             continue
         # Find the first unescaped ']' in the token text.
         idx = -1
@@ -115,10 +126,15 @@ def check_unmatched_close_brace(
     A bare ``}`` outside of a brace-quoted string almost always indicates a
     missing ``{`` (e.g. a switch body that closed an enclosing scope).
     Attaches a CodeFix to remove the stray ``}`` line.
+
+    A ``}`` inside a double-quoted string (e.g. ``append result "}"``) is
+    just a string character and must not trigger this diagnostic — quoted
+    context is determined by :func:`classify_quoted_contexts`.
     """
     diagnostics: list[Diagnostic] = []
-    for tok in all_tokens:
-        if tok.type is TokenType.ESC and tok.text == "}":
+    in_quoted = classify_quoted_contexts(all_tokens)
+    for i, tok in enumerate(all_tokens):
+        if tok.type is TokenType.ESC and tok.text == "}" and not in_quoted[i]:
             fix = _stray_brace_fix(tok, source)
             diagnostics.append(
                 Diagnostic(

--- a/core/compiler/optimiser/_helpers.py
+++ b/core/compiler/optimiser/_helpers.py
@@ -15,6 +15,7 @@ from ...common.naming import (
 )
 from ...parsing.command_shapes import extract_single_expr_argument
 from ...parsing.lexer import TclLexer
+from ...parsing.token_positions import token_content_shift
 from ...parsing.tokens import SourcePosition, Token, TokenType
 from ..core_analyses import LatticeKind, LatticeValue
 from ..interprocedural import InterproceduralAnalysis
@@ -202,6 +203,7 @@ def _full_command_range(source: str, command_range: Range) -> Range | None:
 
     saw_word = False
     end_offset = start
+    prev_in_quote = False
 
     while True:
         tok = lexer.get_token()
@@ -213,20 +215,31 @@ def _full_command_range(source: str, command_range: Range) -> Range | None:
         if tok.type is TokenType.COMMENT:
             continue
         if tok.type is TokenType.SEP:
+            prev_in_quote = False
             continue
         if tok.type is TokenType.EOL:
             if not saw_word:
+                prev_in_quote = False
                 continue
             end_offset = tok.start.offset - 1
             break
         # A standalone "}" is a body-closing brace, not a command word.
-        if tok.text == "}":
+        # A "}" inside a double-quoted string (e.g. `append result "}"`) is
+        # just a string argument — it has shift>0 (leading quote delimiter)
+        # or follows a token that is still inside a quoted word.
+        if (
+            tok.text == "}"
+            and tok.type is TokenType.ESC
+            and not prev_in_quote
+            and token_content_shift(tok) == 0
+        ):
             if not saw_word:
                 return None
             # End the command range before the closing brace.
             end_offset = tok.start.offset - 1
             break
         saw_word = True
+        prev_in_quote = tok.in_quote
 
     if end_offset < start:
         return None

--- a/core/parsing/token_positions.py
+++ b/core/parsing/token_positions.py
@@ -3,12 +3,57 @@
 from __future__ import annotations
 
 from ..analysis.semantic_model import Range
-from .tokens import SourcePosition, Token
+from .tokens import SourcePosition, Token, TokenType
 
 
 def token_content_shift(token: Token) -> int:
     """Return delimiter shift (0 or 1) for token content start."""
     return 1 if (token.end.offset - token.start.offset + 1) > len(token.text) else 0
+
+
+def classify_quoted_contexts(all_tokens: list[Token]) -> list[bool]:
+    """Return a list parallel to *all_tokens* marking tokens in quoted words.
+
+    A token is "in a quoted word" when the source character sequence it
+    represents was enclosed by double quotes — for example the ``}`` ESC in
+    ``append result "}"`` or the ``}`` ESC in ``puts "[cmd]}"``.  Consumers
+    that treat bare ``}`` or ``]`` ESC tokens as stray punctuation must skip
+    these quoted-context tokens because they represent ordinary string
+    characters.
+
+    The lexer already exposes enough information to determine quoted
+    context, but not via a single field:
+
+    - The ``Token.in_quote`` flag is ``True`` for tokens parsed while the
+      lexer is still "inside" an unclosed quote — it tracks the open quote
+      *across* tokens that come between substitutions (VAR/CMD) and the
+      closing ``"``.  It is **False** on the token that consumes the
+      closing ``"`` because the lexer resets ``insidequote`` before
+      returning that token.
+    - For a single-token quoted ESC (e.g. ``"}"``), the token's source span
+      includes the leading ``"`` but excludes the trailing ``"``, so
+      ``token_content_shift`` returns 1.
+
+    Combining both signals lets us recognise every quoted ESC:
+
+    * Self-contained ``"}"`` — ESC with ``shift > 0`` and ``in_quote=False``.
+    * Leading part of ``"foo$x"`` — ESC with ``in_quote=True``.
+    * Trailing part of ``"[cmd]}"`` — ESC with ``shift=0`` but preceded by
+      a CMD/VAR token whose ``in_quote`` is ``True``.
+
+    Separator tokens (``SEP``/``EOL``) can only appear *between* Tcl words,
+    so they always reset the tracker.
+    """
+    result = [False] * len(all_tokens)
+    prev_in_quote = False
+    for i, tok in enumerate(all_tokens):
+        if tok.type is TokenType.SEP or tok.type is TokenType.EOL:
+            prev_in_quote = False
+            continue
+        self_opens = tok.type is TokenType.ESC and token_content_shift(tok) > 0
+        result[i] = prev_in_quote or self_opens
+        prev_in_quote = tok.in_quote
+    return result
 
 
 def token_content_base(token: Token) -> tuple[int, int, int]:

--- a/lsp/features/semantic_tokens.py
+++ b/lsp/features/semantic_tokens.py
@@ -2247,10 +2247,15 @@ def _recover_stray_close_bracket_in_flush(
     base_off = (body_token.start.offset + 1) if body_token else 0
 
     # Compute quoted-context flags on the full token stream, then look up
-    # each argv token by start offset to decide whether it is quoted.
-    in_quoted_by_offset = {
-        tok.start.offset: flag
-        for tok, flag in zip(all_tokens_buf, classify_quoted_contexts(all_tokens_buf))
+    # each argv token by object identity.  We must NOT key the dict by
+    # ``tok.start.offset`` because multiple tokens can legitimately share
+    # the same start offset — notably the zero-width synthetic SEP
+    # injected at the iRules ``}{`` word boundary, which sits at the same
+    # offset as the following STR/ESC token.  Object identity is safe
+    # because ``argv`` and ``all_tokens_buf`` hold the same ``Token``
+    # instances (see the flush loop below).
+    in_quoted_by_id = {
+        id(tok): flag for tok, flag in zip(all_tokens_buf, classify_quoted_contexts(all_tokens_buf))
     }
 
     # Step 1: Find an ESC token in argv containing ']' at its end.
@@ -2259,7 +2264,7 @@ def _recover_stray_close_bracket_in_flush(
     for i, tok in enumerate(argv):
         if tok.type is not TokenType.ESC:
             continue
-        if in_quoted_by_offset.get(tok.start.offset, False):
+        if in_quoted_by_id.get(id(tok), False):
             continue
         idx = tok.text.find("]")
         if idx >= 0 and idx == len(tok.text) - 1:

--- a/lsp/features/semantic_tokens.py
+++ b/lsp/features/semantic_tokens.py
@@ -2238,15 +2238,28 @@ def _recover_stray_close_bracket_in_flush(
     """Merge tokens around a stray ``]`` into a virtual CMD for recovery.
 
     Mirrors the analyser's ``_recover_stray_close_bracket`` so that the
-    semantic token provider sees the same argument structure.
+    semantic token provider sees the same argument structure.  A ``]``
+    inside a double-quoted string (e.g. ``foo "bar]"``) is a literal
+    character, not a stray bracket — quoted-context ESCs are skipped.
     """
+    from core.parsing.token_positions import classify_quoted_contexts
+
     base_off = (body_token.start.offset + 1) if body_token else 0
+
+    # Compute quoted-context flags on the full token stream, then look up
+    # each argv token by start offset to decide whether it is quoted.
+    in_quoted_by_offset = {
+        tok.start.offset: flag
+        for tok, flag in zip(all_tokens_buf, classify_quoted_contexts(all_tokens_buf))
+    }
 
     # Step 1: Find an ESC token in argv containing ']' at its end.
     bracket_argv_idx = -1
     bracket_char_idx = -1
     for i, tok in enumerate(argv):
         if tok.type is not TokenType.ESC:
+            continue
+        if in_quoted_by_offset.get(tok.start.offset, False):
             continue
         idx = tok.text.find("]")
         if idx >= 0 and idx == len(tok.text) - 1:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -128,6 +128,27 @@ class TestSimpleCodegen:
         fa = _top_asm("set x 1")
         assert fa.instructions[-1].op == Op.DONE
 
+    def test_quoted_close_brace_is_string_literal_issue_130(self):
+        """Regression for bitwisecook/tcl-lsp#130.
+
+        ``append x "}"`` must compile with the bare character ``}`` in
+        the literal table — not as a body/bracket delimiter.  This
+        matches tclsh's ``::tcl::unsupported::disassemble`` output which
+        pushes ``"}"`` as a single literal before ``appendScalar``.
+        """
+        fa = _top_asm('append x "}"')
+        lits = fa.literals.entries()
+        assert "}" in lits, f"Expected '}}' literal, got {lits}"
+        # The ops must be PUSH + APPEND — not a stray syntax error path.
+        ops = _opcodes(fa)
+        assert Op.PUSH1 in ops
+
+    def test_quoted_close_bracket_is_string_literal(self):
+        """Mirror: ``puts "]"`` must compile with literal ``]`` pushed."""
+        fa = _top_asm('puts "]"')
+        lits = fa.literals.entries()
+        assert "]" in lits, f"Expected ']' literal, got {lits}"
+
 
 # Expression compilation
 

--- a/tests/test_command_segmenter.py
+++ b/tests/test_command_segmenter.py
@@ -540,6 +540,20 @@ class TestE100StrayCloseBracketRecovery:
         e100 = [d for d in result.diagnostics if d.code == "E100"]
         assert len(e100) >= 1
 
+    def test_no_stray_bracket_recovery_on_quoted_close_bracket(self):
+        """Analyser must not trigger recovery on a quoted ``"]"``.
+
+        Previously the analyser's ``_recover_stray_close_bracket``
+        merged any ESC ending in ``]`` into a virtual CMD, which would
+        have misclassified ``set x "foo bar]"`` as a command
+        substitution and corrupted argv.
+        """
+        source = 'set x "foo bar]"\n'
+        result = analyse(source)
+        assert not any(d.code == "E100" for d in result.diagnostics)
+        cmd_names = [ci.name for ci in result.command_invocations]
+        assert "set" in cmd_names
+
 
 class TestE101MissingOpenBrace:
     """E101: detect missing '{' on switch and recover orphaned case commands."""

--- a/tests/test_command_segmenter.py
+++ b/tests/test_command_segmenter.py
@@ -512,6 +512,34 @@ class TestE100StrayCloseBracketRecovery:
         cmd_names = [ci.name for ci in result.command_invocations]
         assert "set" in cmd_names
 
+    def test_e100_no_false_positive_on_quoted_close_bracket(self):
+        """A "]" string literal is a character, not an unmatched bracket."""
+        source = 'puts "]"\n'
+        result = analyse(source)
+        e100 = [d for d in result.diagnostics if d.code == "E100"]
+        assert len(e100) == 0
+
+    def test_e100_no_false_positive_on_close_bracket_in_quoted_string(self):
+        """ "foo ]" should not trigger E100."""
+        source = 'puts "foo ]"\n'
+        result = analyse(source)
+        e100 = [d for d in result.diagnostics if d.code == "E100"]
+        assert len(e100) == 0
+
+    def test_e100_no_false_positive_on_close_bracket_after_cmd_subst_in_quote(self):
+        """ "[cmd] ]" — trailing ']' after a CMD in the same quoted word."""
+        source = 'puts "[set x 1] ]"\n'
+        result = analyse(source)
+        e100 = [d for d in result.diagnostics if d.code == "E100"]
+        assert len(e100) == 0
+
+    def test_e100_still_fires_on_actual_stray_bracket(self):
+        """Genuine stray ']' must still produce E100."""
+        source = "set x foobar]\n"
+        result = analyse(source)
+        e100 = [d for d in result.diagnostics if d.code == "E100"]
+        assert len(e100) >= 1
+
 
 class TestE101MissingOpenBrace:
     """E101: detect missing '{' on switch and recover orphaned case commands."""
@@ -685,6 +713,41 @@ class TestE102StrayCloseBrace:
         # Applying the fix should remove the stray '}' line entirely.
         fixed = source[: fix.range.start.offset] + fix.new_text + source[fix.range.end.offset :]
         assert fixed == ("proc foo {} {\n    set x 1\n}\n")
+
+    def test_e102_no_false_positive_on_quoted_close_brace(self):
+        """A "}" string literal is a close brace character, not a stray brace."""
+        source = 'append result "}"\n'
+        result = analyse(source)
+        e102 = [d for d in result.diagnostics if d.code == "E102"]
+        assert len(e102) == 0
+
+    def test_e102_no_false_positive_on_quoted_close_brace_in_proc(self):
+        """String literals inside a proc body must not trigger E102."""
+        source = (
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}\n"
+        )
+        result = analyse(source)
+        e102 = [d for d in result.diagnostics if d.code == "E102"]
+        assert len(e102) == 0
+
+    def test_e102_no_false_positive_on_close_brace_after_cmd_subst_in_quote(self):
+        """A "[cmd]}" ESC token carries no delimiter but is still in-quote."""
+        source = 'puts "[set x 1]}"\n'
+        result = analyse(source)
+        e102 = [d for d in result.diagnostics if d.code == "E102"]
+        assert len(e102) == 0
+
+    def test_e102_no_false_positive_on_close_brace_after_var_in_quote(self):
+        """A "$var}" tail should not trigger E102 when text is bare '}'."""
+        source = 'set x 1; puts "$x}"\n'
+        result = analyse(source)
+        e102 = [d for d in result.diagnostics if d.code == "E102"]
+        assert len(e102) == 0
 
 
 class TestE103MissingCloseBrace:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -428,6 +428,39 @@ class TestInlineBodies:
         result = format_tcl(source)
         assert "    set x {value}" in result
 
+    def test_quoted_close_brace_preserved_issue_130(self):
+        """Regression for bitwisecook/tcl-lsp#130.
+
+        The formatter must treat ``"}"`` as a string literal, not as a
+        stray close brace to be stripped.
+        """
+        source = 'append result "}"\n'
+        result = format_tcl(source)
+        assert '"}"' in result
+
+    def test_quoted_close_bracket_preserved(self):
+        """Mirror: ``"]"`` is a string literal, not a stray bracket."""
+        source = 'puts "]"\n'
+        result = format_tcl(source)
+        assert '"]"' in result
+
+    def test_issue_130_full_proc_round_trips(self):
+        """The full proc from issue #130 formats without corruption."""
+        source = (
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}\n"
+        )
+        result = format_tcl(source)
+        # Every quoted literal from the source survives.
+        assert 'append result "proc $name {[info args $name]} {"' in result
+        assert "append result [info body $name]" in result
+        assert 'append result "}"' in result
+        assert "return $result" in result
+
 
 class TestConfigVariations:
     def test_indent_size_2(self):

--- a/tests/test_minifier.py
+++ b/tests/test_minifier.py
@@ -138,6 +138,53 @@ class TestMinifyPreservation:
         assert "string" in result
         assert "length" in result
 
+    def test_quoted_close_brace_preserved_issue_130(self):
+        """Regression for bitwisecook/tcl-lsp#130.
+
+        The minifier previously crashed or corrupted commands like
+        ``append result "}"`` because the E102 / full-command-range
+        heuristics mistook the quoted ``}`` for a stray brace.  The
+        close-brace literal must survive minification (keeping the
+        quotes here because a bare ``}`` would close the enclosing
+        word / script).
+        """
+        result = minify_tcl('append result "}"\n')
+        assert '"}"' in result
+
+    def test_quoted_close_bracket_round_trips_via_tclsh_semantics(self):
+        """Mirror: the minifier may strip quotes from ``"]"`` because a
+        bare ``]`` outside a command substitution is a literal character
+        in Tcl — but the minified command must still mean exactly the
+        same thing.  We assert the minified form is one of the two
+        semantically-equivalent shapes.
+        """
+        result = minify_tcl('puts "]"\n')
+        assert result in ('puts "]"', "puts ]")
+
+    def test_mid_quote_brace_preserved(self):
+        """Braces mid-quote are literal and must be preserved."""
+        result = minify_tcl('set x "a}b"\n')
+        assert '"a}b"' in result
+
+    def test_issue_130_full_proc_minifies_without_corruption(self):
+        """The full proc from issue #130 minifies without dropping the
+        ``"}"`` literal (which would turn ``append result "}"`` into
+        ``append result`` and change the resulting string).
+        """
+        source = (
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}\n"
+        )
+        result = minify_tcl(source)
+        # The outer proc body is re-emitted as a single braced script.
+        # The ``append result "}"`` line must be present in some form
+        # that still appends the literal ``}`` character.
+        assert 'append result "}"' in result or "append result }" in result
+
 
 class TestMinifyRealWorld:
     """Realistic Tcl code patterns."""

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -9,6 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from core.analysis.analyser import analyse
+from core.analysis.semantic_model import Range
 from core.commands.registry.runtime import configure_signatures
 from core.compiler.optimiser import (
     demorgan_transform,
@@ -16,6 +17,8 @@ from core.compiler.optimiser import (
     invert_expression,
     optimise_source,
 )
+from core.compiler.optimiser._helpers import _full_command_range
+from core.parsing.tokens import SourcePosition
 
 
 class TestOptimiser:
@@ -496,6 +499,66 @@ class TestOptimiser:
         assert any(r.code == "O110" for r in rewrites)
         o110 = [r for r in rewrites if r.code == "O110"][0]
         assert o110.replacement == "{$x}"
+
+
+class TestFullCommandRange:
+    """Regression for bitwisecook/tcl-lsp#130: `_full_command_range` must
+    not truncate a command early when a quoted ``"}"`` argument appears.
+
+    The helper iterates tokens via ``lexer.get_token()`` and previously
+    treated **any** ESC token with ``text == "}"`` as a body-closing brace.
+    That broke commands like ``append result "}"`` because the quoted
+    close-brace literal looks identical to a stray brace at the text level.
+    """
+
+    def test_quoted_close_brace_does_not_truncate_command(self):
+        source = 'append result "}"\n'
+        start = SourcePosition(line=0, character=0, offset=0)
+        end = SourcePosition(line=0, character=5, offset=5)
+        r = _full_command_range(source, Range(start=start, end=end))
+        assert r is not None
+        assert source[r.start.offset : r.end.offset + 1] == 'append result "}"'
+
+    def test_quoted_close_bracket_does_not_truncate_command(self):
+        # Mirror case: a quoted "]" should also be preserved.
+        source = 'puts "]"\n'
+        start = SourcePosition(line=0, character=0, offset=0)
+        end = SourcePosition(line=0, character=3, offset=3)
+        r = _full_command_range(source, Range(start=start, end=end))
+        assert r is not None
+        assert source[r.start.offset : r.end.offset + 1] == 'puts "]"'
+
+    def test_quoted_close_brace_in_multiline_proc_body(self):
+        # Full user reproducer from the issue report.
+        source = (
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}\n"
+        )
+        # Point at the third append — after `    append result ` on line 4.
+        # Line offsets: line 0 len 24, line 1 len 50, line 2 len 36, line 3 start 112.
+        line3_start = source.find('    append result "}"')
+        assert line3_start > 0
+        # Start of the command word 'append'.
+        cmd_start = line3_start + 4
+        start = SourcePosition(line=3, character=4, offset=cmd_start)
+        end = SourcePosition(line=3, character=9, offset=cmd_start + 5)
+        r = _full_command_range(source, Range(start=start, end=end))
+        assert r is not None
+        assert source[r.start.offset : r.end.offset + 1] == 'append result "}"'
+
+    def test_stray_close_brace_still_terminates_range(self):
+        # Regression guard: an actual stray '}' must still terminate.
+        source = "set x 1\n}\nset y 2\n"
+        start = SourcePosition(line=0, character=0, offset=0)
+        end = SourcePosition(line=0, character=2, offset=2)
+        r = _full_command_range(source, Range(start=start, end=end))
+        assert r is not None
+        # Must end at 'set x 1', not include the stray '}'.
+        assert source[r.start.offset : r.end.offset + 1] == "set x 1"
 
 
 class TestUnusedVariableElimination:

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -560,6 +560,23 @@ class TestFullCommandRange:
         # Must end at 'set x 1', not include the stray '}'.
         assert source[r.start.offset : r.end.offset + 1] == "set x 1"
 
+    def test_issue_130_optimise_source_preserves_quoted_literals(self):
+        """End-to-end: ``optimise_source`` must not rewrite the issue proc
+        in a way that drops or mangles the ``"}"`` literal.
+        """
+        source = (
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}\n"
+        )
+        optimised, _rewrites = optimise_source(source)
+        assert 'append result "}"' in optimised
+        assert 'append result "proc $name {[info args $name]} {"' in optimised
+        assert "append result [info body $name]" in optimised
+
 
 class TestUnusedVariableElimination:
     """O126: remove unused variable assignments."""

--- a/tests/test_semantic_tokens.py
+++ b/tests/test_semantic_tokens.py
@@ -1127,6 +1127,51 @@ class TestE100StrayBracketRecovery:
         ]
         assert function_texts.count("append") == 3
 
+    def test_recovery_lookup_uses_identity_not_offset(self):
+        """Regression guard for PR #131 Copilot review feedback.
+
+        ``_recover_stray_close_bracket_in_flush`` used to key its
+        quoted-context lookup by ``tok.start.offset``, which collapses
+        when two tokens legitimately share an offset — notably the
+        zero-width synthetic SEP injected at the iRules ``}{`` word
+        boundary, which shares an offset with the next STR token.
+
+        Constructs the exact collision by hand, calls the recovery
+        helper on it, and verifies the helper does the right thing:
+        no stray ``]`` is present, so no virtual CMD should be
+        injected into argv.
+        """
+        from core.parsing.tokens import SourcePosition, Token, TokenType
+        from lsp.features.semantic_tokens import _recover_stray_close_bracket_in_flush
+
+        def pos(offset: int) -> SourcePosition:
+            return SourcePosition(line=0, character=offset, offset=offset)
+
+        # Model: when HTTP_REQUEST {set x 1}{set y 1}
+        # The iRules }{ boundary emits a zero-width SEP at offset 27
+        # sharing the same start.offset as the following STR.
+        all_tokens = [
+            Token(TokenType.ESC, "when", pos(0), pos(3)),
+            Token(TokenType.SEP, " ", pos(4), pos(4)),
+            Token(TokenType.ESC, "HTTP_REQUEST", pos(5), pos(16)),
+            Token(TokenType.SEP, " ", pos(17), pos(17)),
+            Token(TokenType.STR, "set x 1", pos(18), pos(25)),
+            # Zero-width synthetic SEP (collides with next token).
+            Token(TokenType.SEP, "", pos(27), pos(27)),
+            Token(TokenType.STR, "set y 1", pos(27), pos(34)),
+        ]
+        argv = [all_tokens[0], all_tokens[2], all_tokens[4], all_tokens[6]]
+        argv_texts = ["when", "HTTP_REQUEST", "set x 1", "set y 1"]
+        # Collision confirmed:
+        assert all_tokens[5].start.offset == all_tokens[6].start.offset == 27
+
+        before = list(argv)
+        _recover_stray_close_bracket_in_flush(
+            argv, argv_texts, all_tokens, source="", body_token=None
+        )
+        # No stray `]` in argv — helper must not inject a virtual CMD.
+        assert argv == before
+
 
 class TestE101MissingBraceRecovery:
     """E101: orphaned switch case semantic token recovery."""

--- a/tests/test_semantic_tokens.py
+++ b/tests/test_semantic_tokens.py
@@ -1091,6 +1091,42 @@ class TestE100StrayBracketRecovery:
         assert len(valid_tokens) == len(broken_tokens)
         assert [t["type"] for t in valid_tokens] == [t["type"] for t in broken_tokens]
 
+    def test_e100_no_recovery_on_quoted_close_bracket_issue_130(self):
+        """Regression for bitwisecook/tcl-lsp#130.
+
+        ``foo "bar]"`` is a valid call with a string literal ending in
+        ``]`` — the semantic-token provider must NOT invoke its stray-
+        bracket recovery and merge the literal into a virtual CMD.
+        """
+        source = 'puts "bar]"\n'
+        # Should produce tokens without raising; the "bar]" span must
+        # be classified as a string, not as a command substitution.
+        tokens = _decode_tokens(semantic_tokens_full(source))
+        types = [t["type"] for t in tokens]
+        assert "string" in types
+
+    def test_issue_130_full_proc_tokenises_cleanly(self):
+        """The full proc from issue #130 produces semantic tokens without
+        crashing or misclassifying the ``"}"`` literal.
+        """
+        source = (
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}\n"
+        )
+        tokens = _decode_tokens(semantic_tokens_full(source))
+        assert tokens  # non-empty, no crash
+        # All three `append` occurrences must be classified as function.
+        function_texts = [
+            source.split("\n")[t["line"]][t["char"] : t["char"] + t["length"]]
+            for t in tokens
+            if t["type"] == "function"
+        ]
+        assert function_texts.count("append") == 3
+
 
 class TestE101MissingBraceRecovery:
     """E101: orphaned switch case semantic token recovery."""

--- a/tests/test_token_positions.py
+++ b/tests/test_token_positions.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from core.parsing.lexer import TclLexer
-from core.parsing.token_positions import token_content_base, token_content_shift
+from core.parsing.token_positions import (
+    classify_quoted_contexts,
+    token_content_base,
+    token_content_shift,
+)
 from core.parsing.tokens import Token, TokenType
 
 
@@ -35,3 +39,73 @@ def test_token_content_base_offsets_and_columns() -> None:
 
     assert token_content_base(braced) == (braced.start.offset + 1, 0, braced.start.character + 1)
     assert token_content_base(plain) == (plain.start.offset, 0, plain.start.character)
+
+
+def _classify(source: str) -> list[tuple[str, str, bool]]:
+    """Return (token_type, token_text, in_quoted) triples for a source string."""
+    toks = TclLexer(source).tokenise_all()
+    flags = classify_quoted_contexts(toks)
+    return [(t.type.name, t.text, f) for t, f in zip(toks, flags)]
+
+
+def test_classify_quoted_contexts_self_contained_quoted_close_brace() -> None:
+    # "}" is a self-contained quoted ESC — shift=1, in_quote=False.
+    info = _classify('append result "}"')
+    esc_flags = [(name, text, flag) for name, text, flag in info if name == "ESC"]
+    # The bare "}" ESC must be marked as quoted, the others must not.
+    assert esc_flags == [
+        ("ESC", "append", False),
+        ("ESC", "result", False),
+        ("ESC", "}", True),
+    ]
+
+
+def test_classify_quoted_contexts_continuing_quoted_word_after_cmd() -> None:
+    # "[cmd]}" — the trailing '}' ESC has shift=0 but follows a CMD with
+    # in_quote=True, so it must be marked quoted.
+    info = _classify('puts "[set x 1]}"')
+    # Only interesting tokens: the trailing ESC '}' should be quoted.
+    names_and_quoted = [(text, flag) for name, text, flag in info if name in ("ESC", "CMD")]
+    assert ("}", True) in names_and_quoted
+
+
+def test_classify_quoted_contexts_continuing_quoted_word_after_var() -> None:
+    info = _classify('puts "$x}"')
+    names_and_quoted = [(text, flag) for name, text, flag in info if name in ("ESC", "VAR")]
+    assert ("}", True) in names_and_quoted
+
+
+def test_classify_quoted_contexts_actual_stray_brace() -> None:
+    # Bare '}' ESC at top level must NOT be marked quoted.
+    info = _classify("set x 1\n}\n")
+    esc_flags = [(text, flag) for name, text, flag in info if name == "ESC"]
+    assert ("}", False) in esc_flags
+
+
+def test_classify_quoted_contexts_sep_eol_reset_state() -> None:
+    # After a quoted word closes, the next token must not be marked quoted.
+    info = _classify('set x "a"; set y 1')
+    esc_flags = [(text, flag) for name, text, flag in info if name == "ESC"]
+    # 'y' comes after the quoted "a" plus a SEP/EOL — it must not be quoted.
+    assert ("y", False) in esc_flags
+    assert ("1", False) in esc_flags
+    # And the quoted "a" itself is quoted.
+    assert ("a", True) in esc_flags
+
+
+def test_classify_quoted_contexts_bracket_in_quoted_string() -> None:
+    # The ']' ESC inside a quoted string must be marked quoted.
+    info = _classify('puts "]"')
+    esc_flags = [(text, flag) for name, text, flag in info if name == "ESC"]
+    assert ("]", True) in esc_flags
+
+
+def test_classify_quoted_contexts_mid_quote_after_cmd_subst_bracket() -> None:
+    # "[cmd]]" — the trailing ']' ESC follows a CMD in_quote=True.
+    info = _classify('puts "[cmd] ]"')
+    names_and_quoted = [(text, flag) for name, text, flag in info if name in ("ESC", "CMD")]
+    # The ESC containing ' ]' (or just ']') should be quoted.
+    has_quoted_bracket = any(
+        "]" in text and flag for _text, flag in names_and_quoted for text in [_text]
+    )
+    assert has_quoted_bracket

--- a/tests/test_token_positions.py
+++ b/tests/test_token_positions.py
@@ -109,3 +109,40 @@ def test_classify_quoted_contexts_mid_quote_after_cmd_subst_bracket() -> None:
         "]" in text and flag for _text, flag in names_and_quoted for text in [_text]
     )
     assert has_quoted_bracket
+
+
+def test_classify_quoted_contexts_empty_list() -> None:
+    # Defensive: an empty token list yields an empty classification.
+    assert classify_quoted_contexts([]) == []
+
+
+def test_classify_quoted_contexts_parallel_length() -> None:
+    # The result list must always have exactly one entry per token.
+    for src in (
+        "puts hello",
+        'puts "hello"',
+        'puts "foo$bar"',
+        'puts "[cmd]}"',
+        "set x {}",
+        "set x 1\n}\n",
+        'append result "proc $name {[info args $name]} {"',
+    ):
+        toks = TclLexer(src).tokenise_all()
+        flags = classify_quoted_contexts(toks)
+        assert len(flags) == len(toks), f"length mismatch for {src!r}"
+
+
+def test_classify_quoted_contexts_empty_quoted_string() -> None:
+    # `""` — a zero-content quoted ESC must still be marked as quoted.
+    info = _classify('set x ""')
+    empty_esc = [flag for name, text, flag in info if name == "ESC" and text == ""]
+    assert empty_esc, "expected at least one empty ESC token"
+    assert all(empty_esc), "empty quoted ESC must be classified as in_quoted"
+
+
+def test_classify_quoted_contexts_braced_string_is_not_quoted() -> None:
+    # A STR token is a braced string, not a double-quoted word — it
+    # must NOT be marked as in_quoted even though its shift is > 0.
+    info = _classify("set x {foo}")
+    str_flags = [flag for name, text, flag in info if name == "STR"]
+    assert str_flags == [False]

--- a/tests/test_vm_procs.py
+++ b/tests/test_vm_procs.py
@@ -175,6 +175,34 @@ class TestInfoCommand:
         result = interp.eval("f")
         assert result.value == "1"
 
+    def test_get_info_cmd_regression_issue_130(self) -> None:
+        """Regression for bitwisecook/tcl-lsp#130.
+
+        ``"}"`` must be treated as a literal close-brace character (a
+        string argument), not as a stray close brace.  The proc below is
+        taken verbatim from the reported issue and builds a serialised
+        proc definition by appending quoted literals together.  The VM
+        must produce the exact same output as real tclsh.
+        """
+        interp = TclInterp()
+        interp.eval(
+            "proc getInfoCmd {name} {\n"
+            '    append result "proc $name {[info args $name]} {"\n'
+            "    append result [info body $name]\n"
+            '    append result "}"\n'
+            "    return $result\n"
+            "}"
+        )
+        interp.eval("proc myTest {a b} { return [expr {$a + $b}] }")
+        result = interp.eval("getInfoCmd myTest")
+        # Tclsh output for this exact proc — captured from Tcl 8.6.
+        expected = "proc myTest {a b} { return [expr {$a + $b}] }"
+        assert result.value == expected, (
+            f"VM serialisation differs from tclsh.\n"
+            f"got:      {result.value!r}\n"
+            f"expected: {expected!r}"
+        )
+
 
 class TestNestedProcs:
     """Tests for procs calling other procs."""


### PR DESCRIPTION
## Summary

Fixes issue #130 where quoted string literals containing `}` or `]` characters were incorrectly treated as stray punctuation, causing false diagnostics (E100, E102) and corrupting analysis/minification/formatting of affected code.

The root cause was that multiple subsystems (analyser, optimiser, semantic tokens, formatter, minifier) checked for stray `}` and `]` characters at the token text level without distinguishing between:
- Actual stray punctuation (e.g., a bare `}` outside any quotes)
- Literal characters inside double-quoted strings (e.g., the `}` in `append result "}"`)

### Key Changes

1. **New `classify_quoted_contexts()` function** (`core/parsing/token_positions.py`):
   - Centralised logic to determine which ESC tokens represent content inside double-quoted strings
   - Combines two lexer signals: `token.in_quote` flag and `token_content_shift()` to handle all cases:
     - Self-contained quoted literals: `"}"` (shift > 0, in_quote=False)
     - Continuing quoted words: `"foo$x"` (in_quote=True)
     - Trailing quoted content: `"[cmd]}"` (shift=0 but preceded by in_quote=True)
   - Separator tokens (SEP/EOL) reset the quoted-context tracker

2. **Updated diagnostics checks** (`core/analysis/checks/_syntax.py`):
   - `check_unmatched_close_bracket()` and `check_unmatched_close_brace()` now skip ESC tokens marked as quoted
   - Prevents false E100/E102 diagnostics on string literals

3. **Updated analyser recovery** (`core/analysis/analyser.py`):
   - `_recover_stray_close_bracket()` skips quoted ESC tokens when searching for stray brackets
   - Prevents misclassification of `"bar]"` as a command substitution

4. **Updated optimiser** (`core/compiler/optimiser/_helpers.py`):
   - `_full_command_range()` now respects quoted context when detecting body-closing braces
   - Prevents premature truncation of commands like `append result "}"`

5. **Updated semantic tokens** (`lsp/features/semantic_tokens.py`):
   - `_recover_stray_close_bracket_in_flush()` skips quoted ESC tokens
   - Prevents virtual CMD injection for quoted literals

### Test Coverage

Added comprehensive regression tests across multiple test files:
- `test_token_positions.py`: 11 new tests for `classify_quoted_contexts()` covering all quoted-context patterns
- `test_command_segmenter.py`: 5 new tests for E100/E102 false positives on quoted literals
- `test_optimiser.py`: 5 new tests for `_full_command_range()` with quoted braces
- `test_minifier.py`: 4 new tests for quoted literal preservation
- `test_semantic_tokens.py`: 2 new tests for quoted bracket handling
- `test_formatter.py`: 3 new tests for quoted literal preservation
- `test_vm_procs.py`: 1 regression test with the exact proc from issue #130
- `test_codegen.py`: 2 new tests for quoted literals in bytecode

All tests pass; the fix handles the reported issue and related edge cases.

## Validation

- [x] Added 33 new unit tests covering quoted-context detection and downstream consumers
- [x] All existing tests continue to pass
- [x] Verified the exact proc from issue #130 now compiles, analyses, minifies, and formats correctly

https://claude.ai/code/session_01MGCkBp6t3cbt9BmciZRX8u