### PR TITLE
Support Tcl 8.5+ argument expansion {*} in arity checks

### DIFF
--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -2632,8 +2632,16 @@ class Analyser:
                     has_auto_load = True
 
             elif isinstance(stmt, IRBarrier):
-                if stmt.command in self._CHAIN_TARGETS:
+                # ``exec $cmd {*}$args`` is lowered to IRBarrier (because
+                # argument expansion defeats specialised lowering), so
+                # recognise exec / auto_load / chain targets here too.
+                cmd = stmt.command
+                if cmd in self._CHAIN_TARGETS:
                     chains_original = True
+                elif cmd == "exec":
+                    has_exec = True
+                elif cmd == "auto_load":
+                    has_auto_load = True
 
         self.result.unknown_proc_info = UnknownProcInfo(
             dispatch_targets=frozenset(dispatch_targets),

--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -547,7 +547,14 @@ class Analyser:
                     self._record_var_read(tok.text, range_from_token(tok), scope)
                 elif tok.type is TokenType.CMD:
                     self._analyse_body(tok.text, scope, body_token=tok)
-            self._process_command(cmd.argv, cmd.texts, cmd.all_tokens, scope, source)
+            self._process_command(
+                cmd.argv,
+                cmd.texts,
+                cmd.all_tokens,
+                scope,
+                source,
+                expand_word=cmd.expand_word,
+            )
             cmd_idx += 1 + consumed
 
     def _set_const_string(
@@ -752,7 +759,14 @@ class Analyser:
                     self._record_var_read(tok.text, range_from_token(tok), scope)
                 elif tok.type is TokenType.CMD:
                     self._analyse_body(tok.text, scope, body_token=tok)
-            self._process_command(cmd.argv, cmd.texts, cmd.all_tokens, scope, source)
+            self._process_command(
+                cmd.argv,
+                cmd.texts,
+                cmd.all_tokens,
+                scope,
+                source,
+                expand_word=cmd.expand_word,
+            )
             cmd_idx += 1 + consumed
 
     def _recover_stray_close_bracket(
@@ -1296,8 +1310,16 @@ class Analyser:
         all_tokens: list[Token],
         scope: Scope,
         source: str,
+        expand_word: list[bool] | None = None,
     ) -> None:
-        """Process a single command (argv[0] is the command name)."""
+        """Process a single command (argv[0] is the command name).
+
+        ``expand_word`` (when provided) is a list parallel to ``argv`` whose
+        entries are ``True`` for words that were preceded by the Tcl 8.5+
+        ``{*}`` expansion prefix.  Arity checks must treat expanded words
+        as an unknown number of runtime arguments rather than counting
+        them as one.
+        """
         if not argv:
             return
 
@@ -1305,6 +1327,7 @@ class Analyser:
         cmd_name = argv_texts[0]
         args = argv_texts[1:]
         arg_tokens = argv[1:]
+        arg_expand = list(expand_word[1:]) if expand_word else None
         resolved_proc = self._resolve_proc_call(cmd_name, scope)
         self.result.command_invocations.append(
             CommandInvocation(
@@ -1528,7 +1551,14 @@ class Analyser:
         if resolved_sig is None:
             proc_def = self._resolve_proc_call(cmd_name, scope)
             if proc_def is not None:
-                self._check_proc_call_arity(proc_def, args, argv[0])
+                self._check_proc_call_arity(
+                    proc_def,
+                    args,
+                    argv[0],
+                    arg_expand=arg_expand,
+                    arg_tokens=arg_tokens,
+                    scope=scope,
+                )
 
         # iRules ``call``: arity-check the target proc against the
         # arguments *after* the proc name (args[1:], not args).
@@ -1539,6 +1569,9 @@ class Analyser:
                     call_target_proc,
                     args[1:],
                     arg_tokens[0],
+                    arg_expand=arg_expand[1:] if arg_expand else None,
+                    arg_tokens=arg_tokens[1:],
+                    scope=scope,
                 )
 
         # Use the resolved alias target for role-based lookups, then map
@@ -3027,13 +3060,69 @@ class Analyser:
                 return proc
         return None
 
+    def _resolve_expansion_count(
+        self,
+        tok: Token,
+        scope: Scope,
+    ) -> int | None:
+        """Return the static element count of an expanded ({*}-prefixed) word.
+
+        Inspects the token for the word after the ``{*}`` prefix:
+
+        - Braced literal ``{a b c}`` → the segmenter has already stripped
+          the outer braces; the token is a :class:`TokenType.STR` whose
+          text is the inner list (``"a b c"``), which we split.
+        - Pure variable reference ``$x`` → the token is a :class:`TokenType.VAR`;
+          if the variable has a known constant value in the current
+          scope chain, split that value.
+        - Anything else (command substitution, interpolated string,
+          dynamic value) → ``None``: the count is not statically known.
+
+        Returns ``None`` when the count cannot be determined.  The caller
+        must then treat the expansion as contributing an unknown number
+        of runtime arguments (0..∞), matching Tcl's runtime behaviour
+        where ``{*}`` coerces the value to a list via
+        ``Tcl_ListObjGetElements``.
+        """
+        from ..compiler.tcl_expr_eval import _split_tcl_list
+
+        if tok.type is TokenType.STR:
+            try:
+                return len(_split_tcl_list(tok.text))
+            except Exception:
+                return None
+        if tok.type is TokenType.VAR:
+            const_val = self._lookup_const_string(tok.text, scope)
+            if const_val is None:
+                return None
+            try:
+                return len(_split_tcl_list(const_val))
+            except Exception:
+                return None
+        return None
+
     def _check_proc_call_arity(
         self,
         proc_def: ProcDef,
         args: list[str],
         cmd_token: Token,
+        arg_expand: list[bool] | None = None,
+        arg_tokens: list[Token] | None = None,
+        scope: Scope | None = None,
     ) -> None:
-        """Check a proc call against the proc's parameter list."""
+        """Check a proc call against the proc's parameter list.
+
+        ``arg_expand`` is a list parallel to ``args`` whose entries are
+        ``True`` for arguments preceded by the ``{*}`` expansion prefix.
+        Each expanded argument may yield zero or more runtime arguments.
+
+        When ``arg_tokens`` and ``scope`` are provided, each expansion is
+        resolved to a static element count where possible (literal lists,
+        variables with known constant values).  When an expansion cannot
+        be resolved, it contributes an unknown number of arguments (0..∞)
+        and E002 is suppressed for that call; E003 only fires when the
+        minimum statically-known argument count still exceeds the max.
+        """
         required = 0
         variadic = False
         for i, param in enumerate(proc_def.params):
@@ -3044,26 +3133,65 @@ class Analyser:
                 required += 1
 
         arity = Arity(required, Arity.ANY if variadic else len(proc_def.params))
-        nargs = len(args)
+        nargs_min, nargs_max = self._arg_count_bounds(args, arg_expand, arg_tokens, scope)
         display_name = proc_def.qualified_name
-        if nargs < arity.min:
+        if nargs_max < arity.min:
             self.result.diagnostics.append(
                 Diagnostic(
                     range=range_from_token(cmd_token),
-                    message=f"Too few arguments for '{display_name}': expected at least {arity.min}, got {nargs}",
+                    message=f"Too few arguments for '{display_name}': expected at least {arity.min}, got {nargs_max}",
                     severity=Severity.ERROR,
                     code="E002",
                 )
             )
-        elif nargs > arity.max:
+        elif nargs_min > arity.max:
             self.result.diagnostics.append(
                 Diagnostic(
                     range=range_from_token(cmd_token),
-                    message=f"Too many arguments for '{display_name}': expected at most {arity.max}, got {nargs}",
+                    message=f"Too many arguments for '{display_name}': expected at most {arity.max}, got {nargs_min}",
                     severity=Severity.ERROR,
                     code="E003",
                 )
             )
+
+    def _arg_count_bounds(
+        self,
+        args: list[str],
+        arg_expand: list[bool] | None,
+        arg_tokens: list[Token] | None,
+        scope: Scope | None,
+    ) -> tuple[int, int]:
+        """Return the static (min, max) runtime argument count for a call.
+
+        For each positional argument word, if it is not ``{*}``-expanded
+        it contributes exactly one runtime argument.  If it is expanded,
+        :meth:`_resolve_expansion_count` is consulted: a known count
+        adds to both min and max; an unknown count adds 0 to min and
+        leaves max unbounded (``Arity.ANY``).
+        """
+        if not arg_expand or not any(arg_expand):
+            return len(args), len(args)
+        nargs_min = 0
+        nargs_max = 0
+        unbounded = False
+        for i, _ in enumerate(args):
+            expanded = i < len(arg_expand) and arg_expand[i]
+            if not expanded:
+                nargs_min += 1
+                nargs_max += 1
+                continue
+            tok = arg_tokens[i] if arg_tokens and i < len(arg_tokens) else None
+            count: int | None = None
+            if tok is not None and scope is not None:
+                count = self._resolve_expansion_count(tok, scope)
+            if count is None:
+                unbounded = True
+                continue
+            nargs_min += count
+            nargs_max += count
+        if unbounded:
+            nargs_max = Arity.ANY
+        return nargs_min, nargs_max
 
     def _record_var_read(self, name: str, read_range: Range, scope: Scope) -> None:
         """Record a variable read for go-to-definition / find-references."""

--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -554,6 +554,7 @@ class Analyser:
                 scope,
                 source,
                 expand_word=cmd.expand_word,
+                single_token_word=cmd.single_token_word,
             )
             cmd_idx += 1 + consumed
 
@@ -766,6 +767,7 @@ class Analyser:
                 scope,
                 source,
                 expand_word=cmd.expand_word,
+                single_token_word=cmd.single_token_word,
             )
             cmd_idx += 1 + consumed
 
@@ -1311,6 +1313,7 @@ class Analyser:
         scope: Scope,
         source: str,
         expand_word: list[bool] | None = None,
+        single_token_word: list[bool] | None = None,
     ) -> None:
         """Process a single command (argv[0] is the command name).
 
@@ -1319,6 +1322,13 @@ class Analyser:
         ``{*}`` expansion prefix.  Arity checks must treat expanded words
         as an unknown number of runtime arguments rather than counting
         them as one.
+
+        ``single_token_word`` (when provided) is a list parallel to
+        ``argv`` whose entries are ``True`` when the word consists of a
+        single atomic token.  Used to gate constant-folding of expanded
+        words: a multi-token word like ``$x$y`` exposes only its first
+        token in ``argv``, so refinement based on that single token
+        would be incorrect.
         """
         if not argv:
             return
@@ -1328,6 +1338,7 @@ class Analyser:
         args = argv_texts[1:]
         arg_tokens = argv[1:]
         arg_expand = list(expand_word[1:]) if expand_word else None
+        arg_single_token = list(single_token_word[1:]) if single_token_word else None
         resolved_proc = self._resolve_proc_call(cmd_name, scope)
         self.result.command_invocations.append(
             CommandInvocation(
@@ -1557,6 +1568,7 @@ class Analyser:
                     argv[0],
                     arg_expand=arg_expand,
                     arg_tokens=arg_tokens,
+                    arg_single_token=arg_single_token,
                     scope=scope,
                 )
 
@@ -1571,6 +1583,7 @@ class Analyser:
                     arg_tokens[0],
                     arg_expand=arg_expand[1:] if arg_expand else None,
                     arg_tokens=arg_tokens[1:],
+                    arg_single_token=arg_single_token[1:] if arg_single_token else None,
                     scope=scope,
                 )
 
@@ -3071,6 +3084,7 @@ class Analyser:
     def _resolve_expansion_count(
         self,
         tok: Token,
+        single_token: bool,
         scope: Scope,
     ) -> int | None:
         """Return the static element count of an expanded ({*}-prefixed) word.
@@ -3079,12 +3093,20 @@ class Analyser:
 
         - Braced literal ``{a b c}`` → the segmenter has already stripped
           the outer braces; the token is a :class:`TokenType.STR` whose
-          text is the inner list (``"a b c"``), which we split.
+          text is the inner list (``"a b c"``), which we split.  Empty
+          braces ``{*}{}`` resolve to zero elements.
         - Pure variable reference ``$x`` → the token is a :class:`TokenType.VAR`;
           if the variable has a known constant value in the current
           scope chain, split that value.
-        - Anything else (command substitution, interpolated string,
-          dynamic value) → ``None``: the count is not statically known.
+        - Anything else (command substitution, interpolated/concatenated
+          word, dynamic value) → ``None``: the count is not statically
+          known.
+
+        Refinement is only attempted when ``single_token`` is true:
+        for concatenated words like ``{*}$x$y`` or ``{*}{a b}$suffix``
+        the segmenter exposes only the *first* token in ``argv[i]``,
+        which would otherwise be misinterpreted as a pure literal or
+        pure var ref.
 
         Returns ``None`` when the count cannot be determined.  The caller
         must then treat the expansion as contributing an unknown number
@@ -3094,6 +3116,8 @@ class Analyser:
         """
         from ..compiler.tcl_expr_eval import _split_tcl_list
 
+        if not single_token:
+            return None
         if tok.type is TokenType.STR:
             try:
                 return len(_split_tcl_list(tok.text))
@@ -3116,6 +3140,7 @@ class Analyser:
         cmd_token: Token,
         arg_expand: list[bool] | None = None,
         arg_tokens: list[Token] | None = None,
+        arg_single_token: list[bool] | None = None,
         scope: Scope | None = None,
     ) -> None:
         """Check a proc call against the proc's parameter list.
@@ -3124,12 +3149,14 @@ class Analyser:
         ``True`` for arguments preceded by the ``{*}`` expansion prefix.
         Each expanded argument may yield zero or more runtime arguments.
 
-        When ``arg_tokens`` and ``scope`` are provided, each expansion is
-        resolved to a static element count where possible (literal lists,
+        When ``arg_tokens``, ``arg_single_token`` and ``scope`` are
+        provided, each expansion is resolved to a static element count
+        where possible (single-token literal lists, single-token
         variables with known constant values).  When an expansion cannot
-        be resolved, it contributes an unknown number of arguments (0..∞)
-        and E002 is suppressed for that call; E003 only fires when the
-        minimum statically-known argument count still exceeds the max.
+        be resolved, it contributes an unknown number of arguments
+        (0..∞) and E002 is suppressed for that call; E003 only fires
+        when the minimum statically-known argument count still exceeds
+        the max.
         """
         required = 0
         variadic = False
@@ -3141,7 +3168,9 @@ class Analyser:
                 required += 1
 
         arity = Arity(required, Arity.ANY if variadic else len(proc_def.params))
-        nargs_min, nargs_max = self._arg_count_bounds(args, arg_expand, arg_tokens, scope)
+        nargs_min, nargs_max = self._arg_count_bounds(
+            args, arg_expand, arg_tokens, arg_single_token, scope
+        )
         display_name = proc_def.qualified_name
         if nargs_max < arity.min:
             self.result.diagnostics.append(
@@ -3167,6 +3196,7 @@ class Analyser:
         args: list[str],
         arg_expand: list[bool] | None,
         arg_tokens: list[Token] | None,
+        arg_single_token: list[bool] | None,
         scope: Scope | None,
     ) -> tuple[int, int]:
         """Return the static (min, max) runtime argument count for a call.
@@ -3189,9 +3219,12 @@ class Analyser:
                 nargs_max += 1
                 continue
             tok = arg_tokens[i] if arg_tokens and i < len(arg_tokens) else None
+            single = (
+                arg_single_token[i] if arg_single_token and i < len(arg_single_token) else False
+            )
             count: int | None = None
             if tok is not None and scope is not None:
-                count = self._resolve_expansion_count(tok, scope)
+                count = self._resolve_expansion_count(tok, single, scope)
             if count is None:
                 unbounded = True
                 continue

--- a/core/commands/registry/runtime.py
+++ b/core/commands/registry/runtime.py
@@ -667,7 +667,13 @@ def configure_signatures(
     # Configure lexer flags for the active dialect.
     from core.parsing.lexer import TclLexer
 
+    from .dialects import dialects_since
+
     TclLexer.irules_brace_separator = next_dialect == "f5-irules"
+    # {*} argument expansion was introduced in Tcl 8.5.  Disable it for
+    # 8.4-based dialects (tcl8.4, f5-irules) so ``cmd {*}$args`` is
+    # lexed as a single ``*${args}`` word rather than an expansion.
+    TclLexer.expand_syntax = next_dialect in dialects_since("tcl8.5")
 
     return True
 

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -18,6 +18,7 @@ from ..commands.registry.namespace_registry import NAMESPACE_REGISTRY as EVENT_R
 from ..commands.registry.runtime import (
     SIGNATURES,
     ArgRole,
+    Arity,
     CommandSig,
     SubcommandSig,
     arg_indices_for_role,
@@ -526,10 +527,22 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
 
         args = list(stmt.args) if isinstance(stmt, IRCall) else list(getattr(stmt, "args", ()))
 
+        # Extract {*} expansion markers for the argument words (position 0
+        # in ``expand_word`` is the command name, 1..n are the arguments).
+        # When expansion is present, arity checks must treat the expanded
+        # word as an unknown count rather than a single positional arg.
+        arg_expand: list[bool] | None = None
+        if ct is not None and ct.expand_word is not None:
+            # If the command name itself is expanded ({*}$dispatch), we
+            # cannot resolve the actual command — skip arity checks.
+            if ct.expand_word and ct.expand_word[0]:
+                return
+            arg_expand = list(ct.expand_word[1:])
+
         # Built-in command arity checking
         sig = _resolve_signature(cmd_name)
         if sig is not None:
-            _check_arity(cmd_name, args, sig, cmd_token_range, diagnostics)
+            _check_arity(cmd_name, args, sig, cmd_token_range, diagnostics, arg_expand)
 
     def _walk_ir(script: IRScript) -> None:
         for stmt in iter_ir_statements(script):
@@ -550,8 +563,15 @@ def _check_arity(
     sig: CommandSig | SubcommandSig,
     diag_range: Range,
     diagnostics: list[Diagnostic],
+    arg_expand: list[bool] | None = None,
 ) -> None:
-    """Check argument count against a command signature."""
+    """Check argument count against a command signature.
+
+    ``arg_expand`` is a list parallel to ``args`` whose entries are
+    ``True`` for arguments preceded by the Tcl 8.5+ ``{*}`` expansion
+    prefix.  Expanded words contribute an unknown number of runtime
+    arguments and must not be counted as a single positional arg.
+    """
     if isinstance(sig, SubcommandSig):
         if not args:
             diagnostics.append(
@@ -564,6 +584,10 @@ def _check_arity(
             )
             return
         sub_name = args[0]
+        # If the subcommand position itself is {*}-expanded, the actual
+        # subcommand is unknown — skip subcommand resolution and arity.
+        if arg_expand and arg_expand[0]:
+            return
         # In the IR, $var and ${var} forms represent real substitutions
         # (braced literals are resolved during lowering).  A $ or [ in
         # an IR arg always indicates a dynamic value that cannot be
@@ -591,10 +615,33 @@ def _check_arity(
             return
         # Check arity of subcommand (args after subcommand name)
         sub_args = args[1:]
-        _check_simple_arity(f"{cmd_name} {sub_name}", sub_args, sub_sig, diag_range, diagnostics)
+        sub_expand = arg_expand[1:] if arg_expand else None
+        _check_simple_arity(
+            f"{cmd_name} {sub_name}", sub_args, sub_sig, diag_range, diagnostics, sub_expand
+        )
         return
 
-    _check_simple_arity(cmd_name, args, sig, diag_range, diagnostics)
+    _check_simple_arity(cmd_name, args, sig, diag_range, diagnostics, arg_expand)
+
+
+def _resolve_expansion_count(arg_text: str) -> int | None:
+    """Return the static element count of an IR argument word being expanded.
+
+    Uses the same literal-list extractor the constant-propagation pass
+    uses for ``foreach`` — handles braced literals, ``[list a b c]``
+    command substitutions, and bare literal lists.  Returns ``None`` when
+    the count cannot be statically determined (variable substitution,
+    dynamic command substitution, interpolation, etc.), in which case
+    the caller treats the expansion as contributing 0..∞ runtime args,
+    matching Tcl's runtime semantics (``Tcl_ListObjGetElements`` shimmers
+    the value to a list at call time).
+    """
+    from .core_analyses import _extract_foreach_elements
+
+    elements = _extract_foreach_elements(arg_text)
+    if elements is None:
+        return None
+    return len(elements)
 
 
 @diag("E002", "Too few arguments for command.", section="error")
@@ -605,6 +652,7 @@ def _check_simple_arity(
     sig: CommandSig,
     diag_range: Range,
     diagnostics: list[Diagnostic],
+    arg_expand: list[bool] | None = None,
 ) -> None:
     """Check argument count for a simple (non-subcommand) signature.
 
@@ -614,32 +662,64 @@ def _check_simple_arity(
     command explicitly declares it.  This lets ``puts -nonewline channel
     string`` (3 raw args) pass arity ``(1, 2)`` because only 2 are
     positional.
+
+    ``arg_expand`` marks arguments preceded by ``{*}``.  Each expanded
+    word may contribute zero or more runtime arguments; when the word is
+    a statically-resolvable literal list the exact count is used, and
+    otherwise the word contributes 0..∞ (so the upper bound becomes
+    unbounded and the lower bound remains the count of non-expanded
+    positional words).
     """
     # Count positional args by skipping leading declared options.
+    # An expanded word can't be reliably classified as an option, so
+    # option skipping stops at the first expanded or non-option arg.
     positional_start = 0
     if sig.leading_options:
         for i, arg in enumerate(args):
+            if arg_expand and i < len(arg_expand) and arg_expand[i]:
+                break
             if arg in sig.leading_options:
                 positional_start = i + 1
                 if arg == "--":
                     break  # -- terminates option parsing
             else:
                 break
-    nargs = len(args) - positional_start
-    if nargs < sig.arity.min:
+    positional = args[positional_start:]
+    positional_expand = arg_expand[positional_start:] if arg_expand else None
+    if positional_expand and any(positional_expand):
+        nargs_min = 0
+        nargs_max = 0
+        unbounded = False
+        for i, word in enumerate(positional):
+            if positional_expand[i]:
+                count = _resolve_expansion_count(word)
+                if count is None:
+                    unbounded = True
+                else:
+                    nargs_min += count
+                    nargs_max += count
+            else:
+                nargs_min += 1
+                nargs_max += 1
+        if unbounded:
+            nargs_max = Arity.ANY
+    else:
+        nargs_min = len(positional)
+        nargs_max = len(positional)
+    if nargs_max < sig.arity.min:
         diagnostics.append(
             Diagnostic(
                 range=diag_range,
-                message=f"Too few arguments for '{display_name}': expected at least {sig.arity.min}, got {nargs}",
+                message=f"Too few arguments for '{display_name}': expected at least {sig.arity.min}, got {nargs_max}",
                 severity=Severity.ERROR,
                 code="E002",
             )
         )
-    elif nargs > sig.arity.max:
+    elif nargs_min > sig.arity.max:
         diagnostics.append(
             Diagnostic(
                 range=diag_range,
-                message=f"Too many arguments for '{display_name}': expected at most {sig.arity.max}, got {nargs}",
+                message=f"Too many arguments for '{display_name}': expected at most {sig.arity.max}, got {nargs_min}",
                 severity=Severity.ERROR,
                 code="E003",
             )

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -532,17 +532,32 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
         # When expansion is present, arity checks must treat the expanded
         # word as an unknown count rather than a single positional arg.
         arg_expand: list[bool] | None = None
+        arg_tokens: list[Token] | None = None
+        arg_single: list[bool] | None = None
         if ct is not None and ct.expand_word is not None:
             # If the command name itself is expanded ({*}$dispatch), we
             # cannot resolve the actual command — skip arity checks.
             if ct.expand_word and ct.expand_word[0]:
                 return
             arg_expand = list(ct.expand_word[1:])
+            if ct.argv:
+                arg_tokens = list(ct.argv[1:])
+            if ct.single_token_word:
+                arg_single = list(ct.single_token_word[1:])
 
         # Built-in command arity checking
         sig = _resolve_signature(cmd_name)
         if sig is not None:
-            _check_arity(cmd_name, args, sig, cmd_token_range, diagnostics, arg_expand)
+            _check_arity(
+                cmd_name,
+                args,
+                sig,
+                cmd_token_range,
+                diagnostics,
+                arg_expand,
+                arg_tokens,
+                arg_single,
+            )
 
     def _walk_ir(script: IRScript) -> None:
         for stmt in iter_ir_statements(script):
@@ -564,6 +579,8 @@ def _check_arity(
     diag_range: Range,
     diagnostics: list[Diagnostic],
     arg_expand: list[bool] | None = None,
+    arg_tokens: list[Token] | None = None,
+    arg_single: list[bool] | None = None,
 ) -> None:
     """Check argument count against a command signature.
 
@@ -571,6 +588,11 @@ def _check_arity(
     ``True`` for arguments preceded by the Tcl 8.5+ ``{*}`` expansion
     prefix.  Expanded words contribute an unknown number of runtime
     arguments and must not be counted as a single positional arg.
+
+    ``arg_tokens`` and ``arg_single`` (when provided) carry the original
+    token and the single-token-word marker for each argument so that
+    literal-list expansions can be statically resolved to an exact
+    element count.
     """
     if isinstance(sig, SubcommandSig):
         if not args:
@@ -616,32 +638,85 @@ def _check_arity(
         # Check arity of subcommand (args after subcommand name)
         sub_args = args[1:]
         sub_expand = arg_expand[1:] if arg_expand else None
+        sub_tokens = arg_tokens[1:] if arg_tokens else None
+        sub_single = arg_single[1:] if arg_single else None
         _check_simple_arity(
-            f"{cmd_name} {sub_name}", sub_args, sub_sig, diag_range, diagnostics, sub_expand
+            f"{cmd_name} {sub_name}",
+            sub_args,
+            sub_sig,
+            diag_range,
+            diagnostics,
+            sub_expand,
+            sub_tokens,
+            sub_single,
         )
         return
 
-    _check_simple_arity(cmd_name, args, sig, diag_range, diagnostics, arg_expand)
+    _check_simple_arity(
+        cmd_name, args, sig, diag_range, diagnostics, arg_expand, arg_tokens, arg_single
+    )
 
 
-def _resolve_expansion_count(arg_text: str) -> int | None:
-    """Return the static element count of an IR argument word being expanded.
+def _resolve_expansion_elements(
+    arg_text: str,
+    tok: Token | None,
+    single_token: bool,
+) -> list[str] | None:
+    """Return the static element list of a ``{*}``-expanded IR argument word.
 
-    Uses the same literal-list extractor the constant-propagation pass
-    uses for ``foreach`` — handles braced literals, ``[list a b c]``
-    command substitutions, and bare literal lists.  Returns ``None`` when
-    the count cannot be statically determined (variable substitution,
-    dynamic command substitution, interpolation, etc.), in which case
-    the caller treats the expansion as contributing 0..∞ runtime args,
-    matching Tcl's runtime semantics (``Tcl_ListObjGetElements`` shimmers
-    the value to a list at call time).
+    The IR text alone is ambiguous — for the literal expansion
+    ``{*}{$x}`` the segmenter strips the braces, leaving the IR arg
+    text ``$x``, which is indistinguishable from a variable
+    substitution.  Disambiguation requires the original token type and
+    the single-token-word marker:
+
+    - **STR token, single-token word** — the word came from a braced
+      literal ``{...}``.  The IR text is the brace contents (which may
+      legitimately contain ``$`` or ``[``); split it directly with
+      :func:`_split_tcl_list`.  An empty word resolves to zero elements.
+    - **CMD token, single-token word, ``[list ...]`` form** — the
+      command substitution is a literal ``list`` call; reuse
+      :func:`_extract_foreach_elements` to fold it.
+    - **Concatenated word, variable substitution, command substitution
+      with non-list head, etc.** — return ``None``: the count is not
+      statically known and the caller treats the expansion as
+      contributing 0..∞ runtime arguments, matching Tcl's runtime
+      semantics where ``{*}`` calls ``Tcl_ListObjGetElements`` to
+      shimmer the value to a list at call time.
     """
+    from ..parsing.tokens import TokenType
     from .core_analyses import _extract_foreach_elements
+    from .tcl_expr_eval import _split_tcl_list
 
-    elements = _extract_foreach_elements(arg_text)
-    if elements is None:
+    if not single_token or tok is None:
         return None
-    return len(elements)
+    if tok.type is TokenType.STR:
+        # Empty braced literal ``{*}{}`` → zero elements (the segmenter
+        # strips the braces, so the IR text is empty).
+        if not arg_text:
+            return []
+        try:
+            return _split_tcl_list(arg_text)
+        except Exception:
+            return None
+    if tok.type is TokenType.CMD:
+        # Only refine when the command substitution is a literal list,
+        # i.e. ``[list a b c]``.  ``_extract_foreach_elements`` handles
+        # the bracketed form for us.
+        elements = _extract_foreach_elements(arg_text)
+        if elements is not None:
+            return elements
+    return None
+
+
+def _resolve_expansion_count(
+    arg_text: str,
+    tok: Token | None,
+    single_token: bool,
+) -> int | None:
+    """Convenience wrapper around :func:`_resolve_expansion_elements`."""
+    elements = _resolve_expansion_elements(arg_text, tok, single_token)
+    return None if elements is None else len(elements)
 
 
 @diag("E002", "Too few arguments for command.", section="error")
@@ -653,6 +728,8 @@ def _check_simple_arity(
     diag_range: Range,
     diagnostics: list[Diagnostic],
     arg_expand: list[bool] | None = None,
+    arg_tokens: list[Token] | None = None,
+    arg_single: list[bool] | None = None,
 ) -> None:
     """Check argument count for a simple (non-subcommand) signature.
 
@@ -670,13 +747,42 @@ def _check_simple_arity(
     unbounded and the lower bound remains the count of non-expanded
     positional words).
     """
+    # First, expand statically-resolvable ``{*}`` words inline so the
+    # leading-option scan and the positional count both see the real
+    # element list.  Words whose expansion count is unknown are kept as
+    # a single placeholder entry whose ``flat_expand`` flag stays True.
+    flat_args: list[str] = []
+    flat_expand: list[bool] = []
+    flat_tokens: list[Token | None] = []
+    flat_single: list[bool] = []
+    for i, word in enumerate(args):
+        expanded = bool(arg_expand and i < len(arg_expand) and arg_expand[i])
+        tok = arg_tokens[i] if arg_tokens and i < len(arg_tokens) else None
+        single = bool(arg_single and i < len(arg_single) and arg_single[i])
+        if expanded:
+            elements = _resolve_expansion_elements(word, tok, single)
+            if elements is not None:
+                # Resolved literal expansion — inline each element so
+                # leading_options scanning and positional counting both
+                # see real string values, not the brace text.
+                for element in elements:
+                    flat_args.append(element)
+                    flat_expand.append(False)
+                    flat_tokens.append(None)
+                    flat_single.append(True)
+                continue
+        flat_args.append(word)
+        flat_expand.append(expanded)
+        flat_tokens.append(tok)
+        flat_single.append(single)
+
     # Count positional args by skipping leading declared options.
-    # An expanded word can't be reliably classified as an option, so
-    # option skipping stops at the first expanded or non-option arg.
+    # An unresolved expanded word can't be reliably classified as an
+    # option, so option skipping stops at the first such word.
     positional_start = 0
     if sig.leading_options:
-        for i, arg in enumerate(args):
-            if arg_expand and i < len(arg_expand) and arg_expand[i]:
+        for i, arg in enumerate(flat_args):
+            if flat_expand[i]:
                 break
             if arg in sig.leading_options:
                 positional_start = i + 1
@@ -684,25 +790,13 @@ def _check_simple_arity(
                     break  # -- terminates option parsing
             else:
                 break
-    positional = args[positional_start:]
-    positional_expand = arg_expand[positional_start:] if arg_expand else None
-    if positional_expand and any(positional_expand):
-        nargs_min = 0
-        nargs_max = 0
-        unbounded = False
-        for i, word in enumerate(positional):
-            if positional_expand[i]:
-                count = _resolve_expansion_count(word)
-                if count is None:
-                    unbounded = True
-                else:
-                    nargs_min += count
-                    nargs_max += count
-            else:
-                nargs_min += 1
-                nargs_max += 1
-        if unbounded:
-            nargs_max = Arity.ANY
+    positional = flat_args[positional_start:]
+    positional_expand = flat_expand[positional_start:]
+    if any(positional_expand):
+        # Lower bound: non-expanded positional args.  Upper bound:
+        # unbounded once any unresolved expansion appears.
+        nargs_min = sum(1 for exp in positional_expand if not exp)
+        nargs_max = Arity.ANY
     else:
         nargs_min = len(positional)
         nargs_max = len(positional)

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -947,6 +947,35 @@ class _Lowerer:
             if result is not None:
                 return cast(IRStatement, result)
 
+        # {*} argument expansion hides the runtime arg list from the
+        # specialised structured lowerings below (proc, when, namespace
+        # eval, if, switch, for, while, foreach) which index args
+        # positionally.  Emit an IRBarrier so downstream analysis sees
+        # the original tokens (for codegen and arity checks) without
+        # assuming a particular arg shape.  Generic commands (e.g.
+        # ``list {*}{a b c}``) fall through to the default IRCall path,
+        # which preserves ``tokens.expand_word`` and lets the codegen's
+        # ``_try_list_expand_call`` / ``_emit_expanded_call`` handle it.
+        _structured_with_expansion = cmd_name in (
+            "proc",
+            "when",
+            "namespace",
+            "if",
+            "switch",
+            "for",
+            "while",
+            "foreach",
+            "foreach_in_collection",
+        )
+        if _structured_with_expansion and cmd.expand_word is not None and any(cmd.expand_word):
+            return IRBarrier(
+                range=cmd.range,
+                reason=f"{cmd_name} with argument expansion",
+                command=cmd_name,
+                args=tuple(args),
+                tokens=cmd.cmd_tokens,
+            )
+
         match cmd_name:
             case "proc" if len(args) == 3 and len(arg_tokens) >= 3:
                 proc_name = args[0]

--- a/core/compiler/lowering_hooks/_control.py
+++ b/core/compiler/lowering_hooks/_control.py
@@ -20,6 +20,11 @@ def lower_expr(lowerer: object, cmd: _Command) -> object | None:
 
     args = cmd.args
     arg_single = cmd.arg_single_token
+    # {*} expansion means the argument is not really ``args[0]`` — fall
+    # through to the default IRCall lowering so codegen sees the
+    # expansion and arity checks operate on the token list.
+    if cmd.expand_word is not None and any(cmd.expand_word):
+        return None
     if len(args) != 1 or not arg_single or not arg_single[0]:
         return None  # fall through to default
     return IRExprEval(range=cmd.range, expr=_parse_expr(args[0]))
@@ -34,6 +39,17 @@ def lower_return(lowerer: object, cmd: _Command) -> object | None:
     from ...parsing.tokens import TokenType
 
     args = cmd.args
+    # {*} expansion makes the argument list unknown at compile time —
+    # emit a barrier so downstream passes do not treat any particular
+    # arg slot as the return value.
+    if cmd.expand_word is not None and any(cmd.expand_word):
+        return IRBarrier(
+            range=cmd.range,
+            reason="return with expansion",
+            command=cmd.name,
+            args=tuple(args),
+            tokens=cmd.cmd_tokens,
+        )
     if args and args[0].startswith("-"):
         return IRBarrier(
             range=cmd.range,

--- a/core/compiler/lowering_hooks/_var.py
+++ b/core/compiler/lowering_hooks/_var.py
@@ -53,6 +53,12 @@ def lower_set(lowerer: _LowererLike, cmd: _Command) -> object | None:
     arg_tokens = cmd.arg_tokens
     arg_single = cmd.arg_single_token
 
+    # {*} argument expansion makes the runtime arg count indeterminate,
+    # so the ``set x value`` specialised lowering is unsafe — fall
+    # through to a generic IRCall so arity checks and the expanded
+    # codegen path see the full token list.
+    if cmd.expand_word is not None and any(cmd.expand_word):
+        return IRCall(range=cmd.range, command=cmd.name, args=tuple(args), tokens=cmd.cmd_tokens)
     if not args:
         return IRCall(range=cmd.range, command=cmd.name, args=tuple(args), tokens=cmd.cmd_tokens)
     name = args[0]
@@ -88,6 +94,10 @@ def lower_set(lowerer: _LowererLike, cmd: _Command) -> object | None:
 def lower_incr(lowerer: object, cmd: _Command) -> object | None:
     """Lower ``incr`` to IRIncr."""
     args = cmd.args
+    # {*} expansion hides the real arg count — keep as a generic call
+    # so the specialised IRIncr path isn't given wrong indices.
+    if cmd.expand_word is not None and any(cmd.expand_word):
+        return IRCall(range=cmd.range, command=cmd.name, args=tuple(args), tokens=cmd.cmd_tokens)
     if not args or len(args) > 2:
         return IRCall(range=cmd.range, command=cmd.name, args=tuple(args), tokens=cmd.cmd_tokens)
     name = args[0]

--- a/docs/kcs/compiler/kcs-lexing-segmentation.md
+++ b/docs/kcs/compiler/kcs-lexing-segmentation.md
@@ -98,13 +98,33 @@ sets the flag based on the active dialect:
 Arity checks at both the analyser (`_check_proc_call_arity` in
 `core/analysis/analyser.py`) and the IR layer (`_check_simple_arity` in
 `core/compiler/compiler_checks.py`) treat each expanded word as an
-unknown number of runtime arguments and try to refine the bound via
-constant folding: braced literal lists, `[list ...]` substitutions,
-and variables with known constant values resolve to an exact element
-count, so E002/E003 still fire when the count is statically wrong.
-Otherwise the expanded word contributes `0..∞` arguments, E002 is
-suppressed, and E003 only fires when the non-expanded arguments alone
-exceed the signature maximum.
+unknown number of runtime arguments and try to refine the bound by
+constant-folding the expanded word.  Refinement requires the word to
+be **single-token** (so concatenations like `{*}$x$y` or
+`{*}{a b}$suffix` stay unrefined) and depends on the layer:
+
+- **Analyser layer (user proc calls)** can refine
+  - braced literal lists (`{*}{a b c}` → 3, `{*}{}` → 0),
+  - pure variable references with a known constant string value
+    (`set rgb {255 255 255}; foo {*}$rgb` → 3) via the
+    `_const_strings` map.
+- **IR layer (built-in commands)** can refine
+  - braced literal lists (the segmenter strips the braces, so the
+    refinement uses the original `STR` token type to disambiguate
+    the resulting text from a variable substitution),
+  - literal `[list ...]` command substitutions via
+    `_extract_foreach_elements`.
+  IR-layer refinement does *not* yet resolve `$var` substitutions
+  back to their constant values — pure-var expansions in built-in
+  calls fall back to the `0..∞` range below.
+
+When refinement succeeds the leading-options scan and the positional
+count both see the inlined elements, so E002/E003 still fire when the
+count is statically wrong (and `puts {*}{-nonewline} chan msg` is
+correctly accepted because the literal list contributes a leading
+option).  Otherwise the expanded word contributes `0..∞` arguments,
+E002 is suppressed, and E003 only fires when the non-expanded
+arguments alone exceed the signature maximum.
 
 ### How segmented data feeds the compiler
 

--- a/docs/kcs/compiler/kcs-lexing-segmentation.md
+++ b/docs/kcs/compiler/kcs-lexing-segmentation.md
@@ -67,10 +67,44 @@ Key fields:
 - `single_token_word[i]` = `True` when word `i` is a single atomic token —
   tells the lowerer the value is a compile-time constant
 - `argv[i]` = first token of word `i` (for token-type pattern matching)
+- `expand_word[i]` = `True` when word `i` is preceded by the `{*}`
+  argument-expansion prefix (Tcl 8.5+).  `None` when no word in the
+  command uses expansion.
 - Multi-token words (e.g. `"hello $name"`) are concatenated into `texts[i]`
 
 **Variable references in texts:**
 VAR tokens are wrapped in `${…}` form: `$x` → `texts[i] = "${x}"`.
+
+### Argument expansion `{*}` and dialect gating
+
+`{*}` is the Tcl 8.5+ argument-expansion prefix.  When enabled, the
+lexer emits a zero-width `EXPAND` token at word start, and the
+segmenter records `expand_word[i] = True` for the following word so
+that downstream passes can distinguish `{*}$list` (expanded to zero or
+more runtime args) from a literal `*${list}` word.
+
+The `TclLexer.expand_syntax` flag controls whether `{*}` is recognised.
+`configure_signatures()` in
+[`core/commands/registry/runtime.py`](../../../core/commands/registry/runtime.py)
+sets the flag based on the active dialect:
+
+- **Enabled** for dialects in `dialects_since("tcl8.5")` — all Tcl
+  8.5 / 8.6 / 9.0 profiles and every dialect whose base Tcl version is
+  at least 8.5 (f5-iapps, f5-tmsh, EDA vendors, Expect).
+- **Disabled** for 8.4-based dialects (`tcl8.4`, `f5-irules`) because
+  `{*}` did not exist in Tcl 8.4 — the lexer must treat `{*}$x` as a
+  braced literal `{*}` concatenated with `$x`.
+
+Arity checks at both the analyser (`_check_proc_call_arity` in
+`core/analysis/analyser.py`) and the IR layer (`_check_simple_arity` in
+`core/compiler/compiler_checks.py`) treat each expanded word as an
+unknown number of runtime arguments and try to refine the bound via
+constant folding: braced literal lists, `[list ...]` substitutions,
+and variables with known constant values resolve to an exact element
+count, so E002/E003 still fire when the count is statically wrong.
+Otherwise the expanded word contributes `0..∞` arguments, E002 is
+suppressed, and E003 only fires when the non-expanded arguments alone
+exceed the signature maximum.
 
 ### How segmented data feeds the compiler
 

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -267,6 +267,174 @@ class TestDiagnostics:
         errors = [d for d in result.diagnostics if d.code == "E002" and "::math::add" in d.message]
         assert len(errors) >= 1
 
+    def test_proc_call_arg_expansion_suppresses_too_few(self):
+        """Regression test for issue #129.
+
+        ``{*}$var`` may expand to any number of arguments at runtime, so the
+        static arity check must not treat it as a single argument when the
+        required minimum is higher.
+        """
+        source = textwrap.dedent("""\
+            proc rgbToLab {r g b} { return 1 }
+            set rgb1 {255 255 255}
+            rgbToLab {*}$rgb1
+        """)
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E002" and "::rgbToLab" in d.message]
+        assert errors == [], f"unexpected E002 diagnostics: {errors}"
+
+    def test_proc_call_arg_expansion_only(self):
+        """A call whose only argument is ``{*}$x`` should not fire E002/E003."""
+        source = textwrap.dedent("""\
+            proc myproc {x y z} { return 1 }
+            set args {1 2 3}
+            myproc {*}$args
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::myproc" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_arg_expansion_mixed_literal_and_expansion(self):
+        """``foo a {*}$x`` where foo takes (a, b, c) is valid at runtime."""
+        source = textwrap.dedent("""\
+            proc myproc {a b c} { return 1 }
+            set rest {2 3}
+            myproc 1 {*}$rest
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::myproc" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_arg_expansion_still_detects_too_many(self):
+        """Non-expansion args alone exceeding the max arity → E003 still fires."""
+        source = textwrap.dedent("""\
+            proc myproc {x} { return 1 }
+            set args {}
+            myproc a b {*}$args
+        """)
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "::myproc" in d.message]
+        assert len(errors) >= 1
+
+    def test_builtin_call_arg_expansion_suppresses_too_many(self):
+        """``set x {*}$args`` should not fire E003 even when set's max is 2.
+
+        The runtime may expand ``{*}$args`` to zero or one elements, so
+        the static count ``(x, {*}$args)`` cannot be used to decide that
+        too many arguments are present.
+        """
+        source = textwrap.dedent("""\
+            set args {42}
+            set x y {*}$args
+        """)
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "'set'" in d.message]
+        assert errors == [], f"unexpected E003 diagnostics: {errors}"
+
+    def test_proc_call_expansion_constant_resolves_to_exact_count(self):
+        """``{*}$x`` with a known constant value should use the exact count.
+
+        If the variable's value is statically known (from a prior
+        constant ``set``), ``{*}$x`` contributes exactly that many
+        arguments — the call should be treated the same as writing
+        the elements inline.
+        """
+        # Exact count — clean
+        source = textwrap.dedent("""\
+            proc rgbToLab {r g b} { return 1 }
+            set rgb1 {255 255 255}
+            rgbToLab {*}$rgb1
+        """)
+        result = analyse(source)
+        arity_errors = [
+            d
+            for d in result.diagnostics
+            if d.code in ("E002", "E003") and "::rgbToLab" in d.message
+        ]
+        assert arity_errors == []
+
+    def test_proc_call_expansion_constant_too_few_still_reports(self):
+        """Constant expansion with fewer elements than required → E002."""
+        source = textwrap.dedent("""\
+            proc rgbToLab {r g b} { return 1 }
+            set rgb1 {255 255}
+            rgbToLab {*}$rgb1
+        """)
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E002" and "::rgbToLab" in d.message]
+        assert len(errors) == 1
+        assert "got 2" in errors[0].message
+
+    def test_proc_call_expansion_constant_too_many_still_reports(self):
+        """Constant expansion with more elements than allowed → E003."""
+        source = textwrap.dedent("""\
+            proc greet {name} { return $name }
+            set many {a b c}
+            greet {*}$many
+        """)
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "::greet" in d.message]
+        assert len(errors) == 1
+        assert "got 3" in errors[0].message
+
+    def test_proc_call_expansion_literal_list(self):
+        """``{*}{a b c}`` is a literal list with a statically known count."""
+        source = textwrap.dedent("""\
+            proc foo {a b c} { return 1 }
+            foo {*}{1 2 3}
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::foo" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_expansion_literal_list_wrong_count(self):
+        """Literal list expansion with wrong element count → E002/E003."""
+        source = textwrap.dedent("""\
+            proc foo {a b c} { return 1 }
+            foo {*}{1 2}
+        """)
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E002" and "::foo" in d.message]
+        assert len(errors) == 1
+
+    def test_proc_call_expansion_unknown_variable_is_barrier(self):
+        """Unknown dynamic ``$x`` in ``{*}$x`` contributes an unknown count."""
+        source = textwrap.dedent("""\
+            proc foo {a b c} { return 1 }
+            foo {*}$dynamic
+        """)
+        result = analyse(source)
+        # No arity errors — the expansion count is unknown.
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::foo" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_arg_expansion_disabled_for_tcl84(self):
+        """In Tcl 8.4 dialect ``{*}`` is not expansion — E002 should still fire."""
+        from core.commands.registry.runtime import configure_signatures
+
+        source = textwrap.dedent("""\
+            proc rgbToLab {r g b} { return 1 }
+            set rgb1 {255 255 255}
+            rgbToLab {*}$rgb1
+        """)
+        try:
+            configure_signatures(dialect="tcl8.4")
+            result = analyse(source)
+            errors = [
+                d for d in result.diagnostics if d.code == "E002" and "::rgbToLab" in d.message
+            ]
+            assert len(errors) >= 1
+        finally:
+            configure_signatures(dialect="tcl8.6")
+
     def test_multiline_diagnostics(self):
         source = "set x 1\nbreak extra\nset y 2"
         result = analyse(source)

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -435,6 +435,132 @@ class TestDiagnostics:
         finally:
             configure_signatures(dialect="tcl8.6")
 
+    def test_proc_call_arg_expansion_disabled_for_f5_irules(self):
+        """iRules is 8.4-based — ``{*}`` is not recognised as expansion."""
+        from core.commands.registry.runtime import configure_signatures
+
+        source = textwrap.dedent("""\
+            proc myproc {x y z} { return $x }
+            when HTTP_REQUEST {
+                set args {1 2 3}
+                call myproc {*}$args
+            }
+        """)
+        try:
+            configure_signatures(dialect="f5-irules")
+            result = analyse(source)
+            errors = [d for d in result.diagnostics if d.code == "E002" and "::myproc" in d.message]
+            assert len(errors) >= 1
+        finally:
+            configure_signatures(dialect="tcl8.6")
+
+    def test_configure_signatures_sets_lexer_expand_flag(self):
+        """``configure_signatures`` must toggle ``TclLexer.expand_syntax``
+        based on the active dialect's base Tcl version."""
+        from core.commands.registry.runtime import configure_signatures
+        from core.parsing.lexer import TclLexer
+
+        try:
+            configure_signatures(dialect="tcl8.4")
+            assert TclLexer.expand_syntax is False
+            configure_signatures(dialect="f5-irules")
+            assert TclLexer.expand_syntax is False
+            configure_signatures(dialect="tcl8.5")
+            assert TclLexer.expand_syntax is True
+            configure_signatures(dialect="tcl8.6")
+            assert TclLexer.expand_syntax is True
+            configure_signatures(dialect="tcl9.0")
+            assert TclLexer.expand_syntax is True
+            configure_signatures(dialect="f5-iapps")
+            assert TclLexer.expand_syntax is True
+        finally:
+            configure_signatures(dialect="tcl8.6")
+
+    def test_command_name_expansion_skips_arity_check(self):
+        """``{*}$cmd args`` expands the command name itself — we can't
+        resolve the command, so no arity diagnostic should fire."""
+        source = textwrap.dedent("""\
+            proc dispatch {name args} { return 1 }
+            set cmd dispatch
+            set args {a b c}
+            {*}$cmd $args
+        """)
+        result = analyse(source)
+        arity = [d for d in result.diagnostics if d.code in ("E001", "E002", "E003", "W001")]
+        assert arity == []
+
+    def test_proc_call_expansion_variadic_proc(self):
+        """``proc foo {level args}`` with ``{*}`` on trailing args is clean."""
+        source = textwrap.dedent("""\
+            proc logger {level args} { return $level }
+            set rest {a b c}
+            logger info {*}$rest
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::logger" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_expansion_proc_with_default_param(self):
+        """A call that fills the required arg via ``{*}`` still satisfies
+        defaults — no arity error for ``greet {*}$args`` when the value
+        is an unknown single name."""
+        source = textwrap.dedent("""\
+            proc greet {name {title Mr}} { return 1 }
+            greet {*}$dynamic
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::greet" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_expansion_constant_exactly_satisfies_variadic(self):
+        """Variadic proc with enough constant elements in expansion passes."""
+        source = textwrap.dedent("""\
+            proc foo {a b args} { return 1 }
+            set items {1 2}
+            foo {*}$items
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::foo" in d.message
+        ]
+        assert errors == []
+
+    def test_subcommand_position_expansion_skips_subcommand_check(self):
+        """``string {*}$sub text`` — the subcommand position is expanded,
+        so W001/E001 and arity checks must be skipped."""
+        source = textwrap.dedent("""\
+            set sub length
+            string {*}$sub hello
+        """)
+        result = analyse(source)
+        noise = [
+            d
+            for d in result.diagnostics
+            if d.code in ("E001", "E002", "E003", "W001") and "string" in d.message
+        ]
+        assert noise == []
+
+    def test_builtin_expansion_list_cmd_literal_refinement(self):
+        """``{*}[list a b]`` resolves to exactly two elements — ``set x {*}[list a b]``
+        is 1 + 2 = 3 positional args → E003 for ``set`` (max 2)."""
+        source = "set x {*}[list a b]"
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "'set'" in d.message]
+        assert len(errors) == 1
+        assert "got 3" in errors[0].message
+
+    def test_builtin_expansion_unknown_var_suppresses_set_arity(self):
+        """``set x y {*}$rest`` — ``{*}$rest`` contributes 0..∞ args,
+        so E003 must not fire based on the static count."""
+        source = "set x y {*}$rest"
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "'set'" in d.message]
+        assert errors == []
+
     def test_multiline_diagnostics(self):
         source = "set x 1\nbreak extra\nset y 2"
         result = analyse(source)

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -321,16 +321,17 @@ class TestDiagnostics:
         assert len(errors) >= 1
 
     def test_builtin_call_arg_expansion_suppresses_too_many(self):
-        """``set x {*}$args`` should not fire E003 even when set's max is 2.
+        """``set x {*}$dynamic`` should not fire E003 when ``$dynamic`` is
+        unresolvable.
 
-        The runtime may expand ``{*}$args`` to zero or one elements, so
-        the static count ``(x, {*}$args)`` cannot be used to decide that
-        too many arguments are present.
+        The IR-level arity check does not yet resolve variable references
+        back to constant values, so any ``{*}$var`` expansion is treated
+        as contributing 0..∞ arguments and the static count cannot be
+        used to decide that too many arguments are present.
         """
-        source = textwrap.dedent("""\
-            set args {42}
-            set x y {*}$args
-        """)
+        # Use a dynamic value (command substitution) so neither layer can
+        # statically resolve the element count.
+        source = "set x y {*}[exec true]"
         result = analyse(source)
         errors = [d for d in result.diagnostics if d.code == "E003" and "'set'" in d.message]
         assert errors == [], f"unexpected E003 diagnostics: {errors}"
@@ -559,6 +560,68 @@ class TestDiagnostics:
         source = "set x y {*}$rest"
         result = analyse(source)
         errors = [d for d in result.diagnostics if d.code == "E003" and "'set'" in d.message]
+        assert errors == []
+
+    def test_builtin_expansion_leading_options_through_literal(self):
+        """``puts {*}{-nonewline} stdout hello`` is valid: the literal
+        ``{*}{-nonewline}`` expansion contributes a leading option, not
+        a positional argument."""
+        source = "puts {*}{-nonewline} stdout hello"
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "'puts'" in d.message]
+        assert errors == []
+
+    def test_builtin_expansion_leading_options_too_many_positional(self):
+        """Too many positional arguments after a literal-option expansion
+        still produces E003."""
+        source = "puts {*}{-nonewline} stdout a b c"
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "'puts'" in d.message]
+        assert len(errors) == 1
+
+    def test_builtin_expansion_literal_with_dollar_in_brace(self):
+        """``pwd {*}{$x}`` — the braced literal contains the literal text
+        ``$x`` (no substitution because braces).  The list has one
+        element, and ``pwd`` takes none, so E003 must fire."""
+        source = "pwd {*}{$x}"
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E003" and "'pwd'" in d.message]
+        assert len(errors) == 1
+        assert "got 1" in errors[0].message
+
+    def test_builtin_expansion_empty_brace_resolves_to_zero(self):
+        """``set {*}{}`` expands to zero elements → E002 fires (set
+        requires at least one positional argument)."""
+        source = "set {*}{}"
+        result = analyse(source)
+        errors = [d for d in result.diagnostics if d.code == "E002" and "'set'" in d.message]
+        assert len(errors) == 1
+        assert "got 0" in errors[0].message
+
+    def test_builtin_expansion_empty_brace_combined_with_positional(self):
+        """``set foo {*}{}`` is valid: 1 positional + 0 expanded = 1 arg."""
+        source = "set foo {*}{}"
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "'set'" in d.message
+        ]
+        assert errors == []
+
+    def test_proc_call_expansion_concatenated_word_unknown(self):
+        """``foo {*}$y$z`` is a concatenated word (multi-token) — the
+        analyser must NOT refine via the first token alone, otherwise
+        ``y='a b'`` would falsely resolve to 2 elements when the actual
+        runtime count depends on ``$z``."""
+        source = textwrap.dedent("""\
+            proc foo {x} { return 1 }
+            set y "a b"
+            set z xyz
+            foo {*}$y$z
+        """)
+        result = analyse(source)
+        errors = [
+            d for d in result.diagnostics if d.code in ("E002", "E003") and "::foo" in d.message
+        ]
         assert errors == []
 
     def test_multiline_diagnostics(self):


### PR DESCRIPTION
## Summary

Implement proper handling of Tcl 8.5+ argument expansion syntax (`{*}`) in arity checking across both the analyser and compiler layers. The `{*}` prefix allows a single word to expand into zero or more runtime arguments at call time, which must be treated differently from a literal positional argument in static arity validation.

### Key Changes

1. **Analyser (`core/analysis/analyser.py`)**:
   - Thread `expand_word` metadata from the segmenter through `_process_command()` to track which arguments use `{*}` expansion
   - Enhance `_check_proc_call_arity()` to compute argument count bounds rather than exact counts
   - Add `_resolve_expansion_count()` to statically resolve expansion counts for:
     - Braced literal lists: `{*}{a b c}` → exactly 3 args
     - Variables with known constant values: `{*}$rgb` where `rgb = {255 255 255}` → exactly 3 args
     - Unknown/dynamic values: `{*}$dynamic` → 0..∞ args (suppresses E002, constrains E003)
   - Add `_arg_count_bounds()` to compute min/max argument counts accounting for expansions

2. **Compiler (`core/compiler/compiler_checks.py`)**:
   - Extract `expand_word` markers from IR command tokens
   - Skip arity checks when the command name itself is expanded (`{*}$dispatch`)
   - Skip subcommand resolution when the subcommand position is expanded
   - Implement `_resolve_expansion_count()` for IR-level constant folding (literal lists, `[list ...]` substitutions)
   - Update `_check_simple_arity()` to handle expansion with min/max bounds

3. **Lowering (`core/compiler/lowering.py`, `lowering_hooks/`)**:
   - Emit `IRBarrier` for structured commands (`proc`, `if`, `switch`, `for`, `while`, `foreach`, `when`, `namespace`) when they contain `{*}` expansion, preventing unsafe specialised lowerings that assume fixed argument positions
   - Fall through to generic `IRCall` for `set` and `expr` with expansion so arity checks and codegen see the full token list

4. **Dialect gating (`core/commands/registry/runtime.py`)**:
   - Add `configure_signatures()` logic to set `TclLexer.expand_syntax` based on dialect:
     - **Enabled** for Tcl 8.5+ dialects (tcl8.5, tcl8.6, tcl9.0, f5-iapps, f5-tmsh, etc.)
     - **Disabled** for 8.4-based dialects (tcl8.4, f5-irules) where `{*}` did not exist

5. **Documentation (`docs/kcs/compiler/kcs-lexing-segmentation.md`)**:
   - Document `expand_word` field in segmented command structure
   - Explain dialect gating and arity check semantics for expansions

### Arity Check Semantics

- **Non-expanded arguments**: contribute exactly 1 runtime argument each
- **Expanded arguments with known count** (literal lists, constant variables): contribute the exact element count
- **Expanded arguments with unknown count**: contribute 0..∞ runtime arguments
  - E002 (too few) is suppressed because the expansion might provide the missing arguments
  - E003 (too many) only fires if non-expanded arguments alone exceed the maximum

### Test Coverage

Added 20 comprehensive regression tests covering:
- Suppression of E002 when expansion might provide missing arguments
- Suppression of E003 when expansion count is unknown
- Detection of E002/E003 when expansion count is statically known and wrong
- Literal list expansion: `{*}{a b c}`
- Constant variable expansion: `{*}$rgb` with known value
- Unknown variable expansion: `{*}$dynamic`
- Mixed literal and expansion arguments
- Variadic procs with expansion
- Procs with

https://claude.ai/code/session_01GegPQFMkuSP6aNV4FYZSQm