### PR TITLE
Add Claude skills for build and test automation

### DIFF
--- a/.claude/skills/run-build/SKILL.md
+++ b/.claude/skills/run-build/SKILL.md
@@ -69,24 +69,34 @@ report ONLY the following:
 
 1. **Result**: SUCCESS or FAILURE (one word)
 2. **Artefacts** (if any were produced): list file paths and sizes
-3. **Errors** (if any): for each error list:
-   - File path and line number
-   - Error message
-   - Brief context (1-2 lines)
+3. **Errors** (if any): reproduce each error **verbatim** — do not
+   paraphrase or shorten error messages, compiler diagnostics, or
+   tracebacks. Include:
+   - File path and line number exactly as printed
+   - The full error message exactly as printed
+   - The full traceback or compiler diagnostic chain (trim only
+     build-system boilerplate frames, keep everything from the
+     first project frame onward)
 4. **Warnings** (if any): list only actionable warnings, not standard
-   informational messages or deprecation noise
-5. **Key output**: any version numbers, package sizes, or notable
+   informational messages or deprecation noise. Reproduce warning
+   text verbatim.
+5. **Key output**: any version numbers, artefact sizes, or notable
    messages the user would want to know
 
+CRITICAL: All error messages, compiler diagnostics, and tracebacks
+must be copied character-for-character from the command output. Do
+not summarise, paraphrase, or truncate them — the caller needs exact
+text to locate and fix the issue.
+
 Do NOT include:
-- The raw command output
+- Successful compilation progress for individual files
 - Dependency resolution / download progress
-- Compilation progress for individual files
 - npm/pip install chatter
 - Successful step confirmations (only note the overall result)
 
-Keep your entire response under 200 words for a passing build, or under
-500 words for a failing build. Use markdown formatting.
+Keep your entire response under 200 words for a passing build. For a
+failing build there is no word limit — completeness of error context
+is more important than brevity. Use markdown formatting.
 ~~~
 
 $ARGUMENTS

--- a/.claude/skills/run-build/SKILL.md
+++ b/.claude/skills/run-build/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: build
+description: >
+  Run build targets and report results. Delegates to a Sonnet agent so
+  only errors, warnings, and build status enter the main context —
+  keeping Opus token usage low on routine builds.
+allowed-tools: Agent
+---
+
+# Run Build
+
+Run a build target and return a concise summary. The heavy lifting (running
+the command and parsing its output) is always delegated to a **Sonnet agent**
+so that verbose build output never enters the main Opus context.
+
+## How to execute
+
+1. Parse `$ARGUMENTS` to determine the make target. Use the mapping below;
+   default to `compile` when no argument is given.
+2. Spawn a **single** Agent with `model: "sonnet"` using the prompt template
+   below. Do **not** run the build command yourself.
+3. Relay the agent's summary to the user verbatim — do not embellish or
+   re-summarise.
+
+## Argument → make target mapping
+
+| Argument | Make target | Notes |
+|---|---|---|
+| *(none)* | `make compile` | TypeScript extension compilation (default) |
+| `compile` | `make compile` | TypeScript extension |
+| `vsix` | `make vsix` | Full VS Code extension package |
+| `rust` | `make rust-build` | Rust wheel (maturin + install) |
+| `zipapps` | `make zipapps` | All zipapps |
+| `zipapp-tcl` | `make zipapp-tcl` | Tcl tools zipapp |
+| `zipapp-cli` | `make zipapp-cli` | CLI compiler explorer zipapp |
+| `zipapp-lsp` | `make zipapp-lsp` | LSP server zipapp |
+| `zipapp-ai` | `make zipapp-ai` | AI analysis zipapp |
+| `zipapp-mcp` | `make zipapp-mcp` | MCP server zipapp |
+| `zipapp-wasm` | `make zipapp-wasm` | WASM compiler zipapp |
+| `jetbrains` | `make jetbrains` | JetBrains plugin (.zip) |
+| `sublime` | `make sublime` | Sublime Text package |
+| `zed` | `make zed` | Zed extension archive |
+| `release` | `make release` | All release artifacts |
+| `format` | `make format` | Auto-format Python, TypeScript, Rust |
+| `format-py` | `make format-py` | Auto-format Python only |
+| `format-ts` | `make format-ts` | Auto-format TypeScript only |
+| `codegen` | `make codegen` | Regenerate all generated files |
+| `gen-editor-settings` | `make gen-editor-settings` | Regenerate editor settings |
+| `kcs-db` | `make kcs-db` | Build KCS help database |
+| `skills` | `make claude-skills` | Claude skills release zip |
+| `smoke` | `make smoke-zipapps` | Build and smoke-test all zipapps |
+| `npm` | `make npm-env` | Install/update npm dependencies |
+
+## Sonnet agent prompt template
+
+Use this prompt, substituting `{COMMAND}` with the resolved command:
+
+~~~
+You are a build-output analyst. Run the following command and produce a
+concise summary of the results. Your working directory is the project root.
+
+Command:
+```bash
+{COMMAND}
+```
+
+Run the command with a 10 minute timeout. Then analyse the output and
+report ONLY the following:
+
+1. **Result**: SUCCESS or FAILURE (one word)
+2. **Artefacts** (if any were produced): list file paths and sizes
+3. **Errors** (if any): for each error list:
+   - File path and line number
+   - Error message
+   - Brief context (1-2 lines)
+4. **Warnings** (if any): list only actionable warnings, not standard
+   informational messages or deprecation noise
+5. **Key output**: any version numbers, package sizes, or notable
+   messages the user would want to know
+
+Do NOT include:
+- The raw command output
+- Dependency resolution / download progress
+- Compilation progress for individual files
+- npm/pip install chatter
+- Successful step confirmations (only note the overall result)
+
+Keep your entire response under 200 words for a passing build, or under
+500 words for a failing build. Use markdown formatting.
+~~~
+
+$ARGUMENTS

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -65,27 +65,38 @@ report ONLY the following:
 1. **Result**: PASS or FAIL (one word)
 2. **Stats**: total tests, passed, failed, skipped, errors, warnings
    (omit categories that are zero)
-3. **Failures** (if any): for each failure list:
+3. **Failures** (if any): for each failure, reproduce the error
+   context **verbatim** — do not paraphrase or shorten error messages,
+   assertion text, or tracebacks. Include:
    - Test name / identifier
    - File path and line number
-   - One-line cause (assertion message or exception)
-   - The key 3-5 lines of the traceback (not the full trace)
-4. **Errors** (if any): for each error list:
-   - Error type and message
+   - The assertion message or exception **exactly as printed**
+   - The full traceback from the first relevant frame to the error
+     line (trim only pytest/unittest framework frames at the top of
+     the stack, keep everything from the first project frame onward)
+4. **Errors** (if any): for each error, reproduce **verbatim**:
+   - The full error type and message exactly as printed
    - File path and line number
-   - Brief context
-5. **Warnings** (if any): list only novel or actionable warnings, not
+   - The full traceback (same trimming rule as above)
+5. **Lint / type-check diagnostics** (if any): reproduce each
+   diagnostic line verbatim (path:line:col: message)
+6. **Warnings** (if any): list only novel or actionable warnings, not
    standard deprecation noise
 
+CRITICAL: All error messages, assertion text, diagnostic lines, and
+tracebacks must be copied character-for-character from the command
+output. Do not summarise, paraphrase, or truncate them — the caller
+needs exact text to locate and fix the issue.
+
 Do NOT include:
-- The raw command output
-- Passing test names
+- Passing test names or passing test output
 - Timing information for individual tests
 - Import/collection output
 - Progress dots or percentage bars
 
-Keep your entire response under 300 words for a passing run, or under
-800 words for a failing run. Use markdown formatting.
+Keep your entire response under 200 words for a passing run. For a
+failing run there is no word limit — completeness of error context
+is more important than brevity. Use markdown formatting.
 ~~~
 
 $ARGUMENTS

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: test
+description: >
+  Run tests and report results. Delegates to a Sonnet agent so only
+  failures, errors, and summary statistics enter the main context —
+  keeping Opus token usage low on routine test runs.
+allowed-tools: Agent
+---
+
+# Run Tests
+
+Run a test target and return a concise summary. The heavy lifting (running
+the command and parsing its output) is always delegated to a **Sonnet agent**
+so that verbose test output never enters the main Opus context.
+
+## How to execute
+
+1. Parse `$ARGUMENTS` to determine the make target. Use the mapping below;
+   default to `test-py` when no argument is given.
+2. Spawn a **single** Agent with `model: "sonnet"` using the prompt template
+   below. Do **not** run the test command yourself.
+3. Relay the agent's summary to the user verbatim — do not embellish or
+   re-summarise.
+
+## Argument → make target mapping
+
+| Argument | Make target | Notes |
+|---|---|---|
+| *(none)* | `make test-py` | Fast Python tests (default) |
+| `py` | `make test-py` | Python tests |
+| `all` | `make test` | Python + VS Code extension tests |
+| `ext` | `make test-ext` | VS Code extension integration tests |
+| `vm` | `make test-vm` | VM tcltest suite (slow) |
+| `fuzz` | `make test-fuzz` | Differential fuzz tests |
+| `slow` | `make test-slow` | Slow tests (extension + smoke) |
+| `opt` | `make test-opt` | Optimiser coverage tests |
+| `lint` | `make lint` | All lint and style checks |
+| `typecheck` | `make typecheck-py` | Python type-checking with ty |
+| `prep-pr` | `make prep-pr` | Full pre-PR gate (format + lint + typecheck + tests) |
+| `rust` | `make rust-test` | Rust workspace tests |
+| `rust-lint` | `make rust-lint` | Rust fmt check + clippy |
+| `tclpkg` | `make test-tclpkg` | tclpkg package manager tests |
+| `coverage` | `make coverage-py` | Python tests with coverage |
+| *path* | `uv run pytest <path> -q` | Run specific test file or directory |
+
+If the argument looks like a file path (contains `/` or ends in `.py`),
+treat it as a pytest path argument instead of a make target.
+
+## Sonnet agent prompt template
+
+Use this prompt, substituting `{COMMAND}` with the resolved command:
+
+~~~
+You are a test-output analyst. Run the following command and produce a
+concise summary of the results. Your working directory is the project root.
+
+Command:
+```bash
+{COMMAND}
+```
+
+Run the command with a 10 minute timeout. Then analyse the output and
+report ONLY the following:
+
+1. **Result**: PASS or FAIL (one word)
+2. **Stats**: total tests, passed, failed, skipped, errors, warnings
+   (omit categories that are zero)
+3. **Failures** (if any): for each failure list:
+   - Test name / identifier
+   - File path and line number
+   - One-line cause (assertion message or exception)
+   - The key 3-5 lines of the traceback (not the full trace)
+4. **Errors** (if any): for each error list:
+   - Error type and message
+   - File path and line number
+   - Brief context
+5. **Warnings** (if any): list only novel or actionable warnings, not
+   standard deprecation noise
+
+Do NOT include:
+- The raw command output
+- Passing test names
+- Timing information for individual tests
+- Import/collection output
+- Progress dots or percentage bars
+
+Keep your entire response under 300 words for a passing run, or under
+800 words for a failing run. Use markdown formatting.
+~~~
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Added two new Claude skills (`build` and `test`) to automate running build targets and tests
- Both skills delegate heavy lifting to Sonnet agents to keep verbose output out of the main Opus context, reducing token usage
- `build` skill supports 20+ build targets (compile, vsix, rust, zipapps, plugins, release, formatting, codegen, etc.)
- `test` skill supports 14+ test targets (Python, extension, VM, fuzz, lint, typecheck, Rust, coverage, etc.) plus arbitrary pytest paths
- Each skill includes comprehensive argument-to-make-target mappings and detailed Sonnet agent prompts for consistent output parsing

## Validation

- No testing needed — these are skill definition files that will be validated by the Claude skills system at runtime

https://claude.ai/code/session_0119hzo1MQsyLcM7UBrUNnTm