### PR TITLE
Fix logical AND/OR to preserve 0/1 result semantics in Tcl

### DIFF
--- a/core/compiler/optimiser/_expr_simplify.py
+++ b/core/compiler/optimiser/_expr_simplify.py
@@ -716,11 +716,15 @@ def _simplify_expr_node(node: ExprNode, *, bool_context: bool = False) -> ExprNo
                 if rv == 1:
                     if bool_context or _is_boolean_expr(simp_left):
                         return simp_left
-                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left))
+                    return ExprUnary(
+                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left)
+                    )
                 if lv == 1:
                     if bool_context or _is_boolean_expr(simp_right):
                         return simp_right
-                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right))
+                    return ExprUnary(
+                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right)
+                    )
 
             # Logical OR
             if op in (BinOp.OR, BinOp.WORD_OR):
@@ -732,11 +736,15 @@ def _simplify_expr_node(node: ExprNode, *, bool_context: bool = False) -> ExprNo
                 if rv == 0:
                     if bool_context or _is_boolean_expr(simp_left):
                         return simp_left
-                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left))
+                    return ExprUnary(
+                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left)
+                    )
                 if lv == 0:
                     if bool_context or _is_boolean_expr(simp_right):
                         return simp_right
-                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right))
+                    return ExprUnary(
+                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right)
+                    )
 
             # Self-comparison tautologies (safe for integers)
             if _nodes_equal(simp_left, simp_right):

--- a/core/compiler/optimiser/_expr_simplify.py
+++ b/core/compiler/optimiser/_expr_simplify.py
@@ -196,6 +196,10 @@ def _fold_binary_int_literals(op: BinOp, left: ExprNode, right: ExprNode) -> Exp
             value = lv << rv
         case BinOp.RSHIFT if rv >= 0:
             value = lv >> rv
+        case BinOp.AND | BinOp.WORD_AND:
+            value = 1 if lv != 0 and rv != 0 else 0
+        case BinOp.OR | BinOp.WORD_OR:
+            value = 1 if lv != 0 or rv != 0 else 0
         case _:
             return None
     return _make_int_literal(value)
@@ -705,19 +709,34 @@ def _simplify_expr_node(node: ExprNode, *, bool_context: bool = False) -> ExprNo
             if op in (BinOp.AND, BinOp.WORD_AND):
                 if rv == 0 or lv == 0:
                     return _make_int_literal(0)
+                # x && 1 / 1 && x: Tcl && always returns 0 or 1, not the operand value.
+                # Returning simp_left/simp_right directly would be wrong for non-boolean x
+                # (e.g. 2 && 1 == 1, not 2). Only safe when x is already boolean or the
+                # result is consumed in a boolean context (where truthiness suffices).
                 if rv == 1:
-                    return simp_left
+                    if bool_context or _is_boolean_expr(simp_left):
+                        return simp_left
+                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left))
                 if lv == 1:
-                    return simp_right
+                    if bool_context or _is_boolean_expr(simp_right):
+                        return simp_right
+                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right))
 
             # Logical OR
             if op in (BinOp.OR, BinOp.WORD_OR):
                 if rv == 1 or lv == 1:
                     return _make_int_literal(1)
+                # x || 0 / 0 || x: same reasoning as && identity above — result is always
+                # 0 or 1 in Tcl, not the operand value. Canonicalise to !!x outside of
+                # boolean context so the 0/1 result is preserved.
                 if rv == 0:
-                    return simp_left
+                    if bool_context or _is_boolean_expr(simp_left):
+                        return simp_left
+                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left))
                 if lv == 0:
-                    return simp_right
+                    if bool_context or _is_boolean_expr(simp_right):
+                        return simp_right
+                    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right))
 
             # Self-comparison tautologies (safe for integers)
             if _nodes_equal(simp_left, simp_right):

--- a/core/compiler/optimiser/_expr_simplify.py
+++ b/core/compiler/optimiser/_expr_simplify.py
@@ -278,9 +278,16 @@ def _is_boolean_expr(node: ExprNode) -> bool:
         case ExprUnary(op=UnaryOp.NOT | UnaryOp.WORD_NOT):
             return True
         case ExprLiteral(text=text):
-            return text in ("0", "1", "true", "false")
+            # Include all Tcl boolean words (true/false/yes/no/on/off/0/1),
+            # case-insensitively, matching Tcl_GetBoolean semantics.
+            return text in ("0", "1") or text.lower() in _BOOLEAN_WORDS
         case _:
             return False
+
+
+def _boolify(node: ExprNode) -> ExprUnary:
+    """Wrap *node* in !!x to canonicalise it to a 0/1 boolean result."""
+    return ExprUnary(op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=node))
 
 
 def _nodes_equal(a: ExprNode, b: ExprNode) -> bool:
@@ -716,15 +723,11 @@ def _simplify_expr_node(node: ExprNode, *, bool_context: bool = False) -> ExprNo
                 if rv == 1:
                     if bool_context or _is_boolean_expr(simp_left):
                         return simp_left
-                    return ExprUnary(
-                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left)
-                    )
+                    return _boolify(simp_left)
                 if lv == 1:
                     if bool_context or _is_boolean_expr(simp_right):
                         return simp_right
-                    return ExprUnary(
-                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right)
-                    )
+                    return _boolify(simp_right)
 
             # Logical OR
             if op in (BinOp.OR, BinOp.WORD_OR):
@@ -736,15 +739,11 @@ def _simplify_expr_node(node: ExprNode, *, bool_context: bool = False) -> ExprNo
                 if rv == 0:
                     if bool_context or _is_boolean_expr(simp_left):
                         return simp_left
-                    return ExprUnary(
-                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_left)
-                    )
+                    return _boolify(simp_left)
                 if lv == 0:
                     if bool_context or _is_boolean_expr(simp_right):
                         return simp_right
-                    return ExprUnary(
-                        op=UnaryOp.NOT, operand=ExprUnary(op=UnaryOp.NOT, operand=simp_right)
-                    )
+                    return _boolify(simp_right)
 
             # Self-comparison tautologies (safe for integers)
             if _nodes_equal(simp_left, simp_right):

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -358,9 +358,17 @@ class TestOptimiser:
         assert "set v 0" in optimised
 
     def test_instcombine_and_one(self):
+        """$x && 1 → !!$x (boolean canonicalisation, not identity rewrite)."""
         source = "set v [expr {$x && 1}]"
-        _, rewrites = optimise_source(source)
+        optimised, rewrites = optimise_source(source)
         assert any(r.code == "O110" for r in rewrites)
+        assert "!!$x" in optimised
+
+    def test_instcombine_and_one_const_fold(self):
+        """2 && 1 → 1 (both non-zero; result is always 0 or 1, not the operand)."""
+        source = "set v [expr {2 && 1}]"
+        optimised, _ = optimise_source(source)
+        assert "set v 1" in optimised
 
     def test_instcombine_or_one(self):
         source = "set v [expr {$x || 1}]"
@@ -368,9 +376,17 @@ class TestOptimiser:
         assert "set v 1" in optimised
 
     def test_instcombine_or_zero(self):
+        """$x || 0 → !!$x (boolean canonicalisation, not identity rewrite)."""
         source = "set v [expr {$x || 0}]"
-        _, rewrites = optimise_source(source)
+        optimised, rewrites = optimise_source(source)
         assert any(r.code == "O110" for r in rewrites)
+        assert "!!$x" in optimised
+
+    def test_instcombine_or_zero_const_fold(self):
+        """3 || 0 → 1 (first operand non-zero; result is always 0 or 1, not the operand)."""
+        source = "set v [expr {3 || 0}]"
+        optimised, _ = optimise_source(source)
+        assert "set v 1" in optimised
 
     def test_instcombine_double_not_boolean_expr(self):
         """!!($a == $b) → $a == $b because == is already boolean."""


### PR DESCRIPTION
## Summary

- Fixed expression simplification for logical AND/OR operations to correctly preserve Tcl's semantics where these operators always return 0 or 1, not the operand value
- Added constant folding for AND/OR with integer literals (e.g., `2 && 1` → `1`, not `2`)
- When simplifying identity cases (e.g., `$x && 1`), now canonicalizes to `!!$x` outside boolean contexts to ensure the result is always 0 or 1
- Added helper logic to detect boolean expressions and avoid unnecessary double-negation canonicalization

## Changes

**core/compiler/optimiser/_expr_simplify.py:**
- Extended `_fold_binary_int_literals()` to handle `BinOp.AND`, `BinOp.WORD_AND`, `BinOp.OR`, and `BinOp.WORD_OR` cases with proper constant folding
- Updated `_simplify_expr_node()` to wrap identity simplifications in double-negation (`!!x`) when outside boolean context, ensuring results are always 0 or 1
- Added comments explaining the semantic difference between Tcl's logical operators and simple identity rewrites

**tests/test_optimiser.py:**
- Updated `test_instcombine_and_one()` to verify `!!$x` canonicalization
- Added `test_instcombine_and_one_const_fold()` to verify `2 && 1` → `1`
- Updated `test_instcombine_or_zero()` to verify `!!$x` canonicalization
- Added `test_instcombine_or_zero_const_fold()` to verify `3 || 0` → `1`

## Validation

- [x] Added unit tests covering the new constant folding behavior and canonicalization logic
- [x] Existing tests pass with the updated simplification rules

## Compiler/KCS checklist

- [ ] This change does not alter compiler fact contracts

https://claude.ai/code/session_01XKnGWbhJdrv35hZKBctE4n