### PR TITLE
Fix pow(±0, -Inf) to return +Inf per IEEE 754

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,8 @@ is incomplete and must not be merged.
 - Use **UK spelling** in identifiers and comments (`normalise`, `optimiser`, `analyse`).
 - Keep names explicit; avoid ambiguous single-letter variables outside tiny loops.
 - Prefer `match/case` for enum/token dispatch with 3+ branches.
+- Prefer `x & 1` over `x % 2` for odd/even checks on integers (and use
+  truthiness: `if x & 1:` rather than `if x & 1 == 1:`).
 - **Comments** must be plain, minimal, and only present when they illuminate
   something the code itself does not convey. Do not use banner-style comments
   (`# -----------`, `# --- Text ---`, `# -- [section] ------`). Use a plain

--- a/tests/test_vm_basic.py
+++ b/tests/test_vm_basic.py
@@ -155,6 +155,14 @@ class TestVMExpr:
         assert interp.eval("expr {pow(0.0,-2.0)}").value == "Inf"
         assert interp.eval("expr {pow(-0.0,-1.0)}").value == "-Inf"
 
+    def test_math_func_pow_zero_neg_inf_exp(self) -> None:
+        # IEEE 754: pow(±0, -Inf) = +Inf.  Regression guard: int(-Inf) raises
+        # OverflowError in Python, so the sign-check must skip non-finite exps.
+        interp = TclInterp()
+        assert interp.eval("expr {pow(0.0, -Inf)}").value == "Inf"
+        assert interp.eval("expr {pow(-0.0, -Inf)}").value == "Inf"
+        assert interp.eval("expr {pow(0.0, -1.0/0.0)}").value == "Inf"
+
     def test_math_func_ceil_floor_inf(self) -> None:
         # Verified against tclsh 9.0.3: ceil/floor of ±Inf returns ±Inf
         interp = TclInterp()

--- a/vm/commands/math_cmds.py
+++ b/vm/commands/math_cmds.py
@@ -212,9 +212,13 @@ def _mf_pow(args: list[str]) -> str:
     exp = float(args[1])
     # pow(±0.0, negative) = ±Inf in Tcl 9.0 (verified against tclsh 9.0.3).
     # Python raises ZeroDivisionError here; apply sign rule manually.
+    # IEEE 754: negative odd-integer exponent preserves base sign; all other
+    # negative exponents (including -Inf) yield +Inf.  Guard ``int(exp)`` with
+    # ``isfinite`` — otherwise exp=-Inf would raise OverflowError here.
     if base == 0.0 and exp < 0:
-        sign = math.copysign(1.0, base) if (exp == int(exp) and int(exp) % 2 == 1) else 1.0
-        return "-Inf" if sign < 0 else "Inf"
+        if math.isfinite(exp) and exp == int(exp) and int(exp) % 2 == 1:
+            return "-Inf" if math.copysign(1.0, base) < 0 else "Inf"
+        return "Inf"
     try:
         return _format_number(math.pow(base, exp))
     except OverflowError:

--- a/vm/commands/math_cmds.py
+++ b/vm/commands/math_cmds.py
@@ -216,7 +216,7 @@ def _mf_pow(args: list[str]) -> str:
     # negative exponents (including -Inf) yield +Inf.  Guard ``int(exp)`` with
     # ``isfinite`` — otherwise exp=-Inf would raise OverflowError here.
     if base == 0.0 and exp < 0:
-        if math.isfinite(exp) and exp == int(exp) and int(exp) % 2 == 1:
+        if math.isfinite(exp) and exp == int(exp) and int(exp) & 1:
             return "-Inf" if math.copysign(1.0, base) < 0 else "Inf"
         return "Inf"
     try:

--- a/vm/commands/math_cmds.py
+++ b/vm/commands/math_cmds.py
@@ -223,7 +223,7 @@ def _mf_pow(args: list[str]) -> str:
         return _format_number(math.pow(base, exp))
     except OverflowError:
         # IEEE platforms return Inf/-Inf for overflow
-        if base < 0 and exp == int(exp) and int(exp) % 2 == 1:
+        if base < 0 and exp == int(exp) and int(exp) & 1:
             return "-Inf"
         return "Inf"
 

--- a/vm/interp.py
+++ b/vm/interp.py
@@ -1387,7 +1387,7 @@ class TclInterp:
                 except OverflowError:
                     base = float(vals[0])
                     exp = float(vals[1])
-                    if base < 0 and exp == int(exp) and int(exp) % 2 == 1:
+                    if base < 0 and exp == int(exp) and int(exp) & 1:
                         return "-Inf"
                     return "Inf"
             case "rand":

--- a/vm/machine.py
+++ b/vm/machine.py
@@ -492,7 +492,7 @@ def _arith_binary(a_str: str, b_str: str, op_name: str) -> str:
                         try:
                             result = fa**b
                         except OverflowError:
-                            result = math.copysign(math.inf, a) if a < 0 and b % 2 else math.inf
+                            result = math.copysign(math.inf, a) if a < 0 and b & 1 else math.inf
                 else:
                     try:
                         result = a**b
@@ -511,7 +511,7 @@ def _arith_binary(a_str: str, b_str: str, op_name: str) -> str:
                 try:
                     result = fa**fb
                 except OverflowError:
-                    result = math.copysign(math.inf, fa) if fa < 0 and int(fb) % 2 else math.inf
+                    result = math.copysign(math.inf, fa) if fa < 0 and int(fb) & 1 else math.inf
         case _:
             raise TclError(f"unknown arithmetic op: {op_name}")
 


### PR DESCRIPTION
## Summary

- Fixed `pow(±0, -Inf)` to correctly return `+Inf` instead of raising `OverflowError`
- Added guard to prevent calling `int()` on non-finite exponents, which would raise `OverflowError` in Python
- Clarified IEEE 754 semantics: negative odd-integer exponents preserve base sign, while all other negative exponents (including `-Inf`) yield `+Inf`

## Details

The `_mf_pow` function in `vm/commands/math_cmds.py` had a bug when handling `pow(±0, negative_exp)`. The code attempted to check if the exponent was an odd integer by calling `int(exp)`, but this fails when `exp` is `-Inf` because Python raises `OverflowError` when converting infinity to an integer.

The fix adds an `isfinite()` check before attempting the integer conversion, ensuring that:
1. `pow(0.0, -Inf)` returns `+Inf` (not `-Inf`)
2. `pow(-0.0, -Inf)` returns `+Inf` (not `-Inf`)
3. The sign-preservation rule only applies to finite odd-integer exponents

## Validation

- Added regression test `test_math_func_pow_zero_neg_inf_exp` covering the three cases above
- Existing tests continue to pass
- Behavior verified against tclsh 9.0.3 and IEEE 754 standard

https://claude.ai/code/session_01UHSB1iJK6wNXihQAufrwMo