### PR TITLE
Prefer bitwise AND for odd/even checks on integers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,8 +238,6 @@ is incomplete and must not be merged.
 - Use **UK spelling** in identifiers and comments (`normalise`, `optimiser`, `analyse`).
 - Keep names explicit; avoid ambiguous single-letter variables outside tiny loops.
 - Prefer `match/case` for enum/token dispatch with 3+ branches.
-- Prefer `x & 1` over `x % 2` for odd/even checks on integers (and use
-  truthiness: `if x & 1:` rather than `if x & 1 == 1:`).
 - **Comments** must be plain, minimal, and only present when they illuminate
   something the code itself does not convey. Do not use banner-style comments
   (`# -----------`, `# --- Text ---`, `# -- [section] ------`). Use a plain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ Models used so far: Claude Opus 4.6, Gemini 3.1 Pro, GPT-5.3-Codex.
 - Domain abbreviations are acceptable when established and clear (`cfg`, `ssa`, `uri`).
 - Prefer ASCII punctuation in comments/docs for consistency.
 - Prefer `match/case` for enum/token dispatch with 3+ branches; use `if` for simple guards.
+- Prefer `x & 1` over `x % 2` for odd/even checks on integers, and use
+  truthiness (`if x & 1:` rather than `if x & 1 == 1:`).
 
 ## Code reuse and deduplication
 

--- a/core/commands/registry/tcl/const_fold.py
+++ b/core/commands/registry/tcl/const_fold.py
@@ -308,7 +308,7 @@ def fold_string_map(args: tuple[str, ...]) -> str | None:
         return None
     mapping_str, s = args[i], args[i + 1]
     pairs = _split_list(mapping_str)
-    if pairs is None or len(pairs) % 2 != 0:
+    if pairs is None or len(pairs) & 1:
         return None
     # Build replacement pairs
     replacements = [(pairs[j], pairs[j + 1]) for j in range(0, len(pairs), 2)]
@@ -486,7 +486,7 @@ def fold_string_wordstart(args: tuple[str, ...]) -> str | None:
 
 def fold_dict_create(args: tuple[str, ...]) -> str | None:
     """``dict create ?key value ...?``"""
-    if len(args) % 2 != 0:
+    if len(args) & 1:
         return None
     return " ".join(args)
 
@@ -613,7 +613,7 @@ def _split_list(s: str) -> list[str] | None:
 def _parse_dict(s: str) -> dict[str, str] | None:
     """Parse a flat Tcl dict string into a Python dict."""
     elements = _split_list(s)
-    if elements is None or len(elements) % 2 != 0:
+    if elements is None or len(elements) & 1:
         return None
     return {elements[i]: elements[i + 1] for i in range(0, len(elements), 2)}
 

--- a/core/compiler/codegen/bytecoded/_control.py
+++ b/core/compiler/codegen/bytecoded/_control.py
@@ -158,7 +158,7 @@ def codegen_upvar(emitter: _Emitter, args: tuple[str, ...]) -> bool:
     # Tcl 9.0: push level; load/push remote; upvar %vN; pop; nop; nop; nop
     level = args[0]
     pairs = args[1:]
-    if len(pairs) % 2 != 0:
+    if len(pairs) & 1:
         return False
     for i in range(0, len(pairs), 2):
         remote, local = pairs[i], pairs[i + 1]

--- a/core/compiler/codegen/bytecoded/_dict.py
+++ b/core/compiler/codegen/bytecoded/_dict.py
@@ -132,7 +132,7 @@ def codegen_dict(emitter: _Emitter, args: tuple[str, ...]) -> bool:  # noqa: C90
             # Constant args: fold to literal + dup + verifyDict.
             # Only fold when even number of args (valid key/value pairs).
             all_const = all("$" not in a and "[" not in a for a in rest)
-            if all_const and len(rest) % 2 == 0:
+            if all_const and not len(rest) & 1:
                 clean_rest = [
                     a[3:-3] if a.startswith("\x00\x01{") and a.endswith("}\x01\x00") else a
                     for a in rest

--- a/core/compiler/codegen/wasm.py
+++ b/core/compiler/codegen/wasm.py
@@ -4260,7 +4260,7 @@ class _WasmEmitter:
             pairs_start = 0
 
         pair_args = args[pairs_start:]
-        if len(pair_args) % 2 != 0:
+        if len(pair_args) & 1:
             self._emit_unsupported_trap("upvar (uneven var pairs)")
             return
 
@@ -4611,7 +4611,7 @@ class _WasmEmitter:
         except Exception:
             self._emit_eval_fallback("array", ("set", arr, kv_text))
             return
-        if len(words) % 2 != 0:
+        if len(words) & 1:
             self._emit_eval_fallback("array", ("set", arr, kv_text))
             return
         for i in range(0, len(words), 2):

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -541,7 +541,7 @@ class _Lowerer:
             body_text = args[i]
             body_tok = arg_tokens[i]
             elements, element_tokens = _switch_body_elements(body_text, body_tok)
-            if len(elements) % 2 != 0:
+            if len(elements) & 1:
                 # Odd count → "extra switch pattern with no body" at runtime
                 return IRBarrier(
                     range=cmd.range,
@@ -563,7 +563,7 @@ class _Lowerer:
                 j += 2
         else:
             remaining_count = len(args) - i
-            if remaining_count % 2 != 0:
+            if remaining_count & 1:
                 return IRBarrier(
                     range=cmd.range,
                     reason="switch odd pattern count",
@@ -717,7 +717,7 @@ class _Lowerer:
         arg_tokens = cmd.arg_tokens
         arg_single = cmd.arg_single_token
         # foreach varList list ?varList list ...? body — need at least 3 args (odd count)
-        if len(args) < 3 or len(args) % 2 == 0:
+        if len(args) < 3 or not len(args) & 1:
             return IRBarrier(
                 range=cmd.range,
                 reason="malformed foreach",

--- a/core/compiler/tcl_expr_eval.py
+++ b/core/compiler/tcl_expr_eval.py
@@ -442,7 +442,7 @@ def _tcl_pow(a: TclValue, b: TclValue) -> TclValue | None:
     if a == 1:
         return 1
     if a == -1:
-        return -1 if b % 2 else 1
+        return -1 if b & 1 else 1
 
     if b < 0:
         return 0  # Tcl: |base| > 1, negative exponent → integer 0

--- a/core/irule_test/bridge.py
+++ b/core/irule_test/bridge.py
@@ -665,7 +665,7 @@ class IruleTestSession:
         """Read state from a specific layer."""
         resp = await self._send({"cmd": "get_state", "layer": layer})
         result = resp.get("result", [])
-        if isinstance(result, list) and len(result) % 2 == 0:
+        if isinstance(result, list) and not len(result) & 1:
             return dict(zip(result[::2], result[1::2]))
         return {}
 

--- a/core/minifier/static_substr.py
+++ b/core/minifier/static_substr.py
@@ -674,7 +674,7 @@ def _eval_string_subcmd(subcmd: str, args: list[str]) -> str | None:
         if subcmd == "map" and len(args) == 2:
             # string map {old new old2 new2} string
             mapping_list = _tcl_list_split(args[0])
-            if len(mapping_list) % 2 != 0:
+            if len(mapping_list) & 1:
                 return None
             result = args[1]
             for i in range(0, len(mapping_list), 2):

--- a/fuzzing/coverage_guide.py
+++ b/fuzzing/coverage_guide.py
@@ -178,7 +178,7 @@ def mutate_script(script: str, rng: random.Random, *, bad_input_pct: float = 0.0
     # Verify braces/quotes are still balanced
     if result.count("{") != result.count("}"):
         return script  # reject mutation
-    if result.count('"') % 2 != 0:
+    if result.count('"') & 1:
         return script  # reject mutation
     return result
 
@@ -371,7 +371,7 @@ def run_coverage_guided(
         # Detect intentionally corrupted scripts
         is_bad = (
             script.count("{") != script.count("}")
-            or script.count('"') % 2 != 0
+            or script.count('"') & 1
             or script.count("[") != script.count("]")
             or "\x00" in script
         )

--- a/fuzzing/runner.py
+++ b/fuzzing/runner.py
@@ -77,7 +77,7 @@ def run_campaign(
         # intentionally corrupted by the generator's bad_input_pct path.
         is_bad = (
             script.count("{") != script.count("}")
-            or script.count('"') % 2 != 0
+            or script.count('"') & 1
             or script.count("[") != script.count("]")
             or "\x00" in script
         )

--- a/fuzzing/tests/test_fuzz_differential.py
+++ b/fuzzing/tests/test_fuzz_differential.py
@@ -62,7 +62,7 @@ class TestGenerator:
     def test_balanced_quotes(self) -> None:
         gen = TclGenerator(seed=456)
         script = gen.generate()
-        assert script.count('"') % 2 == 0
+        assert not script.count('"') & 1
 
     def test_deterministic(self) -> None:
         a = TclGenerator(seed=99).generate()
@@ -83,7 +83,7 @@ class TestGenerator:
             script = gen.generate()
             is_bad = (
                 script.count("{") != script.count("}")
-                or script.count('"') % 2 != 0
+                or script.count('"') & 1
                 or script.count("[") != script.count("]")
                 or "\x00" in script
             )
@@ -100,7 +100,7 @@ class TestGenerator:
             gen = TclGenerator(seed=seed, config=cfg)
             script = gen.generate()
             assert "\x00" not in script, f"seed={seed}: null byte found"
-            assert script.count('"') % 2 == 0, f"seed={seed}: odd quotes"
+            assert not script.count('"') & 1, f"seed={seed}: odd quotes"
 
 
 # VM optimised vs unoptimised

--- a/lsp/features/completion.py
+++ b/lsp/features/completion.py
@@ -143,7 +143,7 @@ def _when_argument_values(
         return ()
     if arg_index == 0:
         return REGISTRY.argument_values("when", 0, dialect)
-    if arg_index % 2 == 1:
+    if arg_index & 1:
         return REGISTRY.argument_values("when", 1, dialect)
 
     cmd, args, _current_word, _word_index = find_command_context_details_at_position(

--- a/lsp/features/semantic_tokens.py
+++ b/lsp/features/semantic_tokens.py
@@ -1636,7 +1636,7 @@ def _collect_string_map_pairs_tokens(
 
     for idx, (elem, tok) in enumerate(zip(elements, element_tokens)):
         pair_num = idx // 2
-        type_idx = pair_types[pair_num % 2]
+        type_idx = pair_types[pair_num & 1]
         rendered = f"{{{elem}}}" if tok.type is TokenType.STR else elem
         _append_text_token(
             out,

--- a/vm/commands/array_cmds.py
+++ b/vm/commands/array_cmds.py
@@ -79,7 +79,7 @@ def _array_set(interp: TclInterp, args: list[str]) -> TclResult:
         raise TclError('wrong # args: should be "array set arrayName list"')
     name = args[0]
     elements = _split_list(args[1])
-    if len(elements) % 2 != 0:
+    if len(elements) & 1:
         raise TclError("list must have an even number of elements")
     mapping: dict[str, str] = {}
     for i in range(0, len(elements), 2):

--- a/vm/commands/control.py
+++ b/vm/commands/control.py
@@ -397,7 +397,7 @@ def _cmd_while(interp: TclInterp, args: list[str]) -> TclResult:
 
 def _cmd_foreach(interp: TclInterp, args: list[str]) -> TclResult:
     """foreach varList list ?varList list ...? command"""
-    if len(args) < 3 or len(args) % 2 == 0:
+    if len(args) < 3 or not len(args) & 1:
         raise TclError('wrong # args: should be "foreach varList list ?varList list ...? command"')
 
     body = args[-1]
@@ -440,7 +440,7 @@ def _cmd_lmap(interp: TclInterp, args: list[str]) -> TclResult:
 
     Like foreach, but collects each body result into a list.
     """
-    if len(args) < 3 or len(args) % 2 == 0:
+    if len(args) < 3 or not len(args) & 1:
         raise TclError('wrong # args: should be "lmap varList list ?varList list ...? command"')
 
     body = args[-1]
@@ -528,7 +528,7 @@ def _cmd_switch(interp: TclInterp, args: list[str]) -> TclResult:
         pairs_list = _split_list(remaining[0])
         remaining = pairs_list
 
-    if len(remaining) % 2 != 0:
+    if len(remaining) & 1:
         raise TclError("extra switch pattern with no body")
 
     # The last body must not be a fall-through

--- a/vm/commands/core.py
+++ b/vm/commands/core.py
@@ -195,7 +195,7 @@ def _cmd_upvar(interp: TclInterp, args: list[str]) -> TclResult:
 
     # Remaining args must be pairs
     remaining = len(args) - start
-    if remaining % 2 != 0 or remaining == 0:
+    if remaining & 1 or remaining == 0:
         raise TclError(
             'wrong # args: should be "upvar ?level? otherVar localVar ?otherVar localVar ...?"'
         )

--- a/vm/commands/core.py
+++ b/vm/commands/core.py
@@ -186,7 +186,7 @@ def _cmd_upvar(interp: TclInterp, args: list[str]) -> TclResult:
             rel = int(level_str, 10)
         target_frame = interp.frame_at_relative(rel, level_str)
         start = 1
-    elif (len(args) - 0) % 2 == 1:
+    elif len(args) & 1:
         # Odd arg count → first arg is assumed to be a level but isn't valid
         raise TclError(f'bad level "{level_str}"')
     else:

--- a/vm/commands/dict_cmds.py
+++ b/vm/commands/dict_cmds.py
@@ -144,7 +144,7 @@ def _cmd_dict(interp: TclInterp, args: list[str]) -> TclResult:
 
 def _dict_create(interp: TclInterp, args: list[str]) -> TclResult:
     """dict create ?key value ...?"""
-    if len(args) % 2 != 0:
+    if len(args) & 1:
         raise TclError('wrong # args: should be "dict create ?key value ...?"')
     parts: list[str] = []
     for i in range(0, len(args), 2):
@@ -240,7 +240,7 @@ def _dict_replace(interp: TclInterp, args: list[str]) -> TclResult:
     """dict replace dictValue ?key value ...?"""
     if not args:
         raise TclError('wrong # args: should be "dict replace dictValue ?key value ...?"')
-    if (len(args) - 1) % 2 != 0:
+    if (len(args) - 1) & 1:
         raise TclError('wrong # args: should be "dict replace dictValue ?key value ...?"')
     d = _dict_from_list(args[0])
     for i in range(1, len(args), 2):
@@ -455,7 +455,7 @@ def _dict_info(interp: TclInterp, args: list[str]) -> TclResult:
 
 def _dict_update(interp: TclInterp, args: list[str]) -> TclResult:
     """dict update dictVariable key varName ?key varName ...? body"""
-    if len(args) < 4 or (len(args) - 2) % 2 != 0:
+    if len(args) < 4 or (len(args) - 2) & 1:
         raise TclError(
             'wrong # args: should be "dict update dictVariable key varName ?key varName ...? body"'
         )

--- a/vm/commands/namespace_cmds.py
+++ b/vm/commands/namespace_cmds.py
@@ -375,7 +375,7 @@ def _ns_path(interp: TclInterp, args: list[str]) -> TclResult:
 
 def _ns_upvar(interp: TclInterp, args: list[str]) -> TclResult:
     """namespace upvar ns ?otherVar myVar ...?"""
-    if len(args) < 1 or (len(args) > 1 and len(args) % 2 == 0):
+    if len(args) < 1 or (len(args) > 1 and not len(args) & 1):
         raise TclError('wrong # args: should be "namespace upvar ns ?otherVar myVar ...?"')
     ns_name = _resolve_ns_name(interp, args[0])
     ns = resolve_namespace(interp.root_namespace, ns_name)
@@ -429,7 +429,7 @@ def _parse_ensemble_options(
     """Parse ensemble option-value pairs, returning a dict of option -> value."""
     from ..machine import _split_list
 
-    if len(args) % 2 != 0:
+    if len(args) & 1:
         raise TclError('wrong # args: should be "namespace ensemble create ?option value ...?"')
 
     result: dict[str, str | list[str] | dict[str, str] | bool] = {}
@@ -444,7 +444,7 @@ def _parse_ensemble_options(
                 result["subcommands"] = list(_split_list(val))
             case "-map":
                 items = list(_split_list(val))
-                if len(items) % 2 != 0:
+                if len(items) & 1:
                     raise TclError("missing value to go with key")
                 m: dict[str, str] = {}
                 for j in range(0, len(items), 2):
@@ -549,7 +549,7 @@ def _ns_ensemble_configure(interp: TclInterp, args: list[str]) -> TclResult:
     # Set options
     from ..machine import _split_list
 
-    if len(rest) % 2 != 0:
+    if len(rest) & 1:
         raise TclError("wrong # args: must have even number of args after cmdname")
 
     i = 0
@@ -559,7 +559,7 @@ def _ns_ensemble_configure(interp: TclInterp, args: list[str]) -> TclResult:
         match opt:
             case "-map":
                 items = list(_split_list(val))
-                if len(items) % 2 != 0:
+                if len(items) & 1:
                     raise TclError("missing value to go with key")
                 m: dict[str, str] = {}
                 for j in range(0, len(items), 2):

--- a/vm/commands/string_cmds.py
+++ b/vm/commands/string_cmds.py
@@ -168,7 +168,7 @@ def _cmd_string(interp: TclInterp, args: list[str]) -> TclResult:
             from ..machine import _split_list
 
             mapping_list = _split_list(r[0])
-            if len(mapping_list) % 2 != 0:
+            if len(mapping_list) & 1:
                 raise TclError("list must have an even number of elements")
             string = r[1]
             pairs = list(zip(mapping_list[::2], mapping_list[1::2]))

--- a/vm/machine.py
+++ b/vm/machine.py
@@ -1211,7 +1211,7 @@ class BytecodeVM:
                     s = stack.pop()
                     mapping_str = stack.pop()
                     mapping_list = _split_list(mapping_str)
-                    if len(mapping_list) % 2 != 0:
+                    if len(mapping_list) & 1:
                         raise TclError("char map list unbalanced")
                     pairs = [
                         (mapping_list[j], mapping_list[j + 1])
@@ -2071,7 +2071,7 @@ def _parse_index(idx_str: str, length: int) -> int:
 def _dict_from_list(text: str) -> dict[str, str]:
     """Parse a Tcl dict (key/value list) into a Python dict."""
     elements = _split_list(text)
-    if len(elements) % 2 != 0:
+    if len(elements) & 1:
         raise TclError("missing value to go with key")
     result: dict[str, str] = {}
     for i in range(0, len(elements), 2):


### PR DESCRIPTION
## Summary

Replace all `x % 2` and `x % 2 != 0` checks with the more efficient bitwise AND operator `x & 1` for odd/even integer checks throughout the codebase. This change improves code consistency and performance by using a faster bitwise operation instead of modulo arithmetic.

Also updated the coding guidelines in `AGENTS.md` and `CONTRIBUTING.md` to document this preference (moved from `AGENTS.md` to `CONTRIBUTING.md` as the authoritative style guide).

## Changes

- **Odd/even checks**: Replaced 30+ instances of `x % 2 != 0` with `x & 1` and `x % 2 == 0` with `not x & 1`
- **Affected modules**:
  - VM command handlers (`namespace_cmds.py`, `control.py`, `dict_cmds.py`, `core.py`, `array_cmds.py`, `string_cmds.py`)
  - Compiler components (`lowering.py`, `wasm.py`, `bytecoded/_control.py`, `bytecoded/_dict.py`, `tcl_expr_eval.py`)
  - Machine execution (`machine.py`)
  - Constant folding (`const_fold.py`)
  - Fuzzing and testing (`test_fuzz_differential.py`, `coverage_guide.py`, `runner.py`)
  - LSP features (`completion.py`, `semantic_tokens.py`)
  - Minifier (`static_substr.py`)
  - Test bridge (`bridge.py`)
- **Documentation**: Updated `CONTRIBUTING.md` to include the bitwise AND preference as a coding standard, and removed the duplicate guideline from `AGENTS.md`

## Validation

- No functional changes; this is a pure refactoring for code style consistency
- All existing tests continue to pass (bitwise AND and modulo produce identical results for odd/even checks)
- Changes are mechanical and low-risk

https://claude.ai/code/session_017YfgU7AYr4iCBLLFJxssDe