### PR TITLE
Fix folding range overlaps in if/else and nested bodies

### DIFF
--- a/lsp/features/folding.py
+++ b/lsp/features/folding.py
@@ -23,8 +23,19 @@ def _adjust_body_end_line(source: str, end_offset: int, end_line: int) -> int:
     collide with the next sibling body's fold range, producing the
     non-hierarchical overlap VS Code's folding tree-builder rejects.  Moving
     the fold end up one line in that case keeps siblings disjoint.
+
+    Incomplete bodies (no closing ``}`` yet -- common while the user is still
+    typing) don't need the adjustment: there is no separator line to preserve,
+    and decrementing would collapse the fold range away mid-edit.
     """
-    if 0 <= end_offset < len(source) and source[end_offset] != "\n":
+    if end_offset < 0 or end_offset >= len(source):
+        return end_line
+    if source[end_offset] == "\n":
+        return end_line
+    # Only adjust when there is an actual closing ``}`` right after the
+    # content -- otherwise the body is unterminated and the fold should span
+    # what the user has so far.
+    if end_offset + 1 < len(source) and source[end_offset + 1] == "}":
         return end_line - 1
     return end_line
 
@@ -178,6 +189,14 @@ def _normalise_overlaps(
     one containing the other).  The collectors already try to avoid this via
     ``_adjust_body_end_line``, but a belt-and-suspenders post-pass keeps the
     output well-formed even if a new collector forgets the invariant.
+
+    ``FoldingRange.end_line`` is inclusive, so two ranges that share a
+    boundary line (e.g. ``[0, 5]`` and ``[5, 10]``) both include the shared
+    line and are neither disjoint nor strictly nested.  When that pattern
+    slips past the collectors, we trim the earlier sibling's end so the two
+    become disjoint; when a range extends past the open parent, we trim
+    the range down to the parent's end.  A final pass drops any duplicate
+    ``(start, end, kind)`` triples produced by those adjustments.
     """
     if not ranges:
         return ranges
@@ -186,29 +205,65 @@ def _normalise_overlaps(
     # children and equal-start ranges with larger spans come first.
     ordered = sorted(ranges, key=lambda r: (r.start_line, -r.end_line))
 
-    # Walk with a stack of open ranges; when a new range overlaps the top of
-    # the stack without being fully contained, shrink it so it nests properly.
-    stack: list[types.FoldingRange] = []
-    result: list[types.FoldingRange] = []
+    # working[i] may be replaced in-place (to trim a previously-emitted
+    # parent) or set to None to drop it outright.  stack holds indices of
+    # currently-open ancestors.
+    working: list[types.FoldingRange | None] = []
+    stack: list[int] = []
+
     for r in ordered:
-        # A stack entry is closed when it ends strictly before r starts OR
-        # exactly at r.start — in the latter case r is r's sibling, not a
-        # child, even though LSP spec permits either interpretation.
-        while stack and stack[-1].end_line <= r.start_line:
-            stack.pop()
-        if stack and stack[-1].end_line < r.end_line:
-            # r extends past its would-be parent — trim it.
-            new_end = stack[-1].end_line
-            if new_end > r.start_line:
+        # Close or trim ancestors that conflict with r's start.
+        while stack:
+            parent = working[stack[-1]]
+            assert parent is not None  # stack entries are always live
+            if parent.end_line < r.start_line:
+                stack.pop()
+                continue
+            if parent.end_line == r.start_line:
+                # Inclusive end_line: a shared boundary still overlaps, so
+                # trim the parent back by one line if that leaves a useful
+                # fold, otherwise drop it entirely.
+                if parent.end_line - 1 > parent.start_line:
+                    working[stack[-1]] = types.FoldingRange(
+                        start_line=parent.start_line,
+                        end_line=parent.end_line - 1,
+                        kind=parent.kind,
+                    )
+                else:
+                    working[stack[-1]] = None
+                stack.pop()
+                continue
+            break
+
+        # Trim r down to fit inside its (new) parent, if any.
+        if stack:
+            parent = working[stack[-1]]
+            assert parent is not None
+            if parent.end_line < r.end_line:
+                if parent.end_line <= r.start_line:
+                    # Trim would leave r degenerate or inverted — drop it.
+                    continue
                 r = types.FoldingRange(
                     start_line=r.start_line,
-                    end_line=new_end,
+                    end_line=parent.end_line,
                     kind=r.kind,
                 )
-            else:
-                continue
+
+        working.append(r)
+        stack.append(len(working) - 1)
+
+    # De-duplicate: trimming parents or ranges may have collapsed distinct
+    # inputs onto the same (start, end, kind) triple.
+    seen: set[tuple[int, int, types.FoldingRangeKind]] = set()
+    result: list[types.FoldingRange] = []
+    for r in working:
+        if r is None:
+            continue
+        key = (r.start_line, r.end_line, r.kind)
+        if key in seen:
+            continue
+        seen.add(key)
         result.append(r)
-        stack.append(r)
     return result
 
 

--- a/lsp/features/folding.py
+++ b/lsp/features/folding.py
@@ -212,10 +212,16 @@ def _normalise_overlaps(
     stack: list[int] = []
 
     for r in ordered:
-        # Close or trim ancestors that conflict with r's start.
+        # Close or trim ancestors that conflict with r's start.  Stack entries
+        # always reference a live (non-None) ``working`` slot: we only set an
+        # entry to None immediately before popping its index off the stack.
         while stack:
             parent = working[stack[-1]]
-            assert parent is not None  # stack entries are always live
+            if parent is None:
+                # Defensive: should never happen, but keep the loop safe under
+                # ``python -O`` where plain ``assert`` would be stripped.
+                stack.pop()
+                continue
             if parent.end_line < r.start_line:
                 stack.pop()
                 continue
@@ -238,8 +244,7 @@ def _normalise_overlaps(
         # Trim r down to fit inside its (new) parent, if any.
         if stack:
             parent = working[stack[-1]]
-            assert parent is not None
-            if parent.end_line < r.end_line:
+            if parent is not None and parent.end_line < r.end_line:
                 if parent.end_line <= r.start_line:
                     # Trim would leave r degenerate or inverted — drop it.
                     continue

--- a/lsp/features/folding.py
+++ b/lsp/features/folding.py
@@ -11,41 +11,64 @@ from core.parsing.command_segmenter import segment_commands
 from core.parsing.tokens import Token, TokenType
 
 
+def _adjust_body_end_line(source: str, end_offset: int, end_line: int) -> int:
+    """Return a fold end line that leaves the closing ``}`` visible.
+
+    A braced body token ends at the character immediately before its closing
+    ``}``.  When that character is a newline, ``}`` is on ``end_line + 1`` and
+    ``end_line`` is already the correct fold end (VS Code keeps the line after
+    ``end_line`` visible).  When ``}`` sits on the same line as the last byte
+    of content -- e.g. ``} else {`` or a trailing ``}`` on the same line as
+    inner text -- the unadjusted fold would cover the separator line and
+    collide with the next sibling body's fold range, producing the
+    non-hierarchical overlap VS Code's folding tree-builder rejects.  Moving
+    the fold end up one line in that case keeps siblings disjoint.
+    """
+    if 0 <= end_offset < len(source) and source[end_offset] != "\n":
+        return end_line - 1
+    return end_line
+
+
 def _collect_scope_folds(
     scope: Scope,
     seen: set[tuple[int, int]],
     ranges: list[types.FoldingRange],
+    source: str,
 ) -> None:
     """Emit folding ranges from the scope tree (procs and namespaces)."""
     for proc_def in scope.procs.values():
         br = proc_def.body_range
         if br.start.line < br.end.line:
-            key = (br.start.line, br.end.line)
-            if key not in seen:
-                seen.add(key)
-                ranges.append(
-                    types.FoldingRange(
-                        start_line=br.start.line,
-                        end_line=br.end.line,
-                        kind=types.FoldingRangeKind.Region,
-                    )
-                )
-
-    for child in scope.children:
-        if child.kind == "namespace" and child.body_range is not None:
-            br = child.body_range
-            if br.start.line < br.end.line:
-                key = (br.start.line, br.end.line)
+            end_line = _adjust_body_end_line(source, br.end.offset, br.end.line)
+            if end_line > br.start.line:
+                key = (br.start.line, end_line)
                 if key not in seen:
                     seen.add(key)
                     ranges.append(
                         types.FoldingRange(
                             start_line=br.start.line,
-                            end_line=br.end.line,
+                            end_line=end_line,
                             kind=types.FoldingRangeKind.Region,
                         )
                     )
-        _collect_scope_folds(child, seen, ranges)
+
+    for child in scope.children:
+        if child.kind == "namespace" and child.body_range is not None:
+            br = child.body_range
+            if br.start.line < br.end.line:
+                end_line = _adjust_body_end_line(source, br.end.offset, br.end.line)
+                if end_line > br.start.line:
+                    key = (br.start.line, end_line)
+                    if key not in seen:
+                        seen.add(key)
+                        ranges.append(
+                            types.FoldingRange(
+                                start_line=br.start.line,
+                                end_line=end_line,
+                                kind=types.FoldingRangeKind.Region,
+                            )
+                        )
+        _collect_scope_folds(child, seen, ranges, source)
 
 
 def _collect_comment_folds(
@@ -99,6 +122,8 @@ def _collect_body_folds(
     source: str,
     seen: set[tuple[int, int]],
     ranges: list[types.FoldingRange],
+    *,
+    original_source: str,
     body_token: Token | None = None,
     depth: int = 0,
 ) -> None:
@@ -113,24 +138,78 @@ def _collect_body_folds(
             if body.token.type is not TokenType.STR:
                 continue
             if body.token.start.line < body.token.end.line:
-                key = (body.token.start.line, body.token.end.line)
-                if key not in seen:
-                    seen.add(key)
-                    ranges.append(
-                        types.FoldingRange(
-                            start_line=body.token.start.line,
-                            end_line=body.token.end.line,
-                            kind=types.FoldingRangeKind.Region,
+                end_line = _adjust_body_end_line(
+                    original_source,
+                    body.token.end.offset,
+                    body.token.end.line,
+                )
+                if end_line > body.token.start.line:
+                    key = (body.token.start.line, end_line)
+                    if key not in seen:
+                        seen.add(key)
+                        ranges.append(
+                            types.FoldingRange(
+                                start_line=body.token.start.line,
+                                end_line=end_line,
+                                kind=types.FoldingRangeKind.Region,
+                            )
                         )
-                    )
-                # Recurse into the body
+                # Recurse into the body regardless of whether the outer fold
+                # was adjusted away -- inner multi-line bodies may still be
+                # foldable even when the enclosing token collapses to a
+                # single effective line.
                 _collect_body_folds(
                     body.text,
                     seen,
                     ranges,
+                    original_source=original_source,
                     body_token=body.token,
                     depth=depth + 1,
                 )
+
+
+def _normalise_overlaps(
+    ranges: list[types.FoldingRange],
+) -> list[types.FoldingRange]:
+    """Ensure folding ranges are disjoint or properly nested.
+
+    VS Code builds a folding tree from the returned ranges and silently drops
+    or misplaces ranges that partially overlap (share a boundary line without
+    one containing the other).  The collectors already try to avoid this via
+    ``_adjust_body_end_line``, but a belt-and-suspenders post-pass keeps the
+    output well-formed even if a new collector forgets the invariant.
+    """
+    if not ranges:
+        return ranges
+
+    # Sort by start ascending, end descending so that parents come before
+    # children and equal-start ranges with larger spans come first.
+    ordered = sorted(ranges, key=lambda r: (r.start_line, -r.end_line))
+
+    # Walk with a stack of open ranges; when a new range overlaps the top of
+    # the stack without being fully contained, shrink it so it nests properly.
+    stack: list[types.FoldingRange] = []
+    result: list[types.FoldingRange] = []
+    for r in ordered:
+        # A stack entry is closed when it ends strictly before r starts OR
+        # exactly at r.start — in the latter case r is r's sibling, not a
+        # child, even though LSP spec permits either interpretation.
+        while stack and stack[-1].end_line <= r.start_line:
+            stack.pop()
+        if stack and stack[-1].end_line < r.end_line:
+            # r extends past its would-be parent — trim it.
+            new_end = stack[-1].end_line
+            if new_end > r.start_line:
+                r = types.FoldingRange(
+                    start_line=r.start_line,
+                    end_line=new_end,
+                    kind=r.kind,
+                )
+            else:
+                continue
+        result.append(r)
+        stack.append(r)
+    return result
 
 
 def get_folding_ranges(
@@ -146,8 +225,8 @@ def get_folding_ranges(
     ranges: list[types.FoldingRange] = []
     seen: set[tuple[int, int]] = set()
 
-    _collect_scope_folds(analysis.global_scope, seen, ranges)
+    _collect_scope_folds(analysis.global_scope, seen, ranges, source)
     _collect_comment_folds(source, seen, ranges, lines=lines)
-    _collect_body_folds(source, seen, ranges)
+    _collect_body_folds(source, seen, ranges, original_source=source)
 
-    return ranges
+    return _normalise_overlaps(ranges)

--- a/lsp/features/folding.py
+++ b/lsp/features/folding.py
@@ -253,8 +253,9 @@ def _normalise_overlaps(
         stack.append(len(working) - 1)
 
     # De-duplicate: trimming parents or ranges may have collapsed distinct
-    # inputs onto the same (start, end, kind) triple.
-    seen: set[tuple[int, int, types.FoldingRangeKind]] = set()
+    # inputs onto the same (start, end, kind) triple.  ``kind`` is declared
+    # by lsprotocol as ``Optional[Union[FoldingRangeKind, str]]``.
+    seen: set[tuple[int, int, types.FoldingRangeKind | str | None]] = set()
     result: list[types.FoldingRange] = []
     for r in working:
         if r is None:

--- a/tests/test_folding.py
+++ b/tests/test_folding.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from lsprotocol import types
 
-from lsp.features.folding import get_folding_ranges
+from lsp.features.folding import _normalise_overlaps, get_folding_ranges
 
 
 class TestFoldingRanges:
@@ -190,22 +190,44 @@ class TestFoldingRanges:
         # Start line should be the ``{`` line.
         assert any(r.start_line == 0 for r in region_ranges)
 
+    def test_elseif_chain_disjoint(self):
+        """``if/elseif/elseif/else`` yields four disjoint sibling folds."""
+        source = textwrap.dedent("""\
+            if {1} {
+                puts a
+            } elseif {2} {
+                puts b
+            } elseif {3} {
+                puts c
+            } else {
+                puts d
+            }
+        """)
+        ranges = get_folding_ranges(source)
+        region_ranges = sorted(
+            (r for r in ranges if r.kind == types.FoldingRangeKind.Region),
+            key=lambda r: (r.start_line, r.end_line),
+        )
+        # One fold per branch, each spanning two lines; must be pairwise disjoint.
+        assert len(region_ranges) == 4, region_ranges
+        for a, b in zip(region_ranges, region_ranges[1:]):
+            assert a.end_line < b.start_line, (
+                f"elseif sibling folds {a.start_line}..{a.end_line} and "
+                f"{b.start_line}..{b.end_line} still share a line"
+            )
+
     def test_normalise_overlaps_shared_boundary_trims_earlier(self):
         """Two sibling ranges sharing a boundary line must become disjoint."""
-        from lsprotocol import types as lsp_types
-
-        from lsp.features.folding import _normalise_overlaps
-
         ranges = [
-            lsp_types.FoldingRange(
+            types.FoldingRange(
                 start_line=0,
                 end_line=5,
-                kind=lsp_types.FoldingRangeKind.Region,
+                kind=types.FoldingRangeKind.Region,
             ),
-            lsp_types.FoldingRange(
+            types.FoldingRange(
                 start_line=5,
                 end_line=10,
-                kind=lsp_types.FoldingRangeKind.Region,
+                kind=types.FoldingRangeKind.Region,
             ),
         ]
         normalised = _normalise_overlaps(ranges)
@@ -216,28 +238,24 @@ class TestFoldingRanges:
 
     def test_normalise_overlaps_dedups_after_trimming(self):
         """Trimming must not leave duplicate ``(start, end, kind)`` entries."""
-        from lsprotocol import types as lsp_types
-
-        from lsp.features.folding import _normalise_overlaps
-
         # Parent [0, 10] with child [3, 8]; a sibling [3, 12] trims to [3, 10]
         # and another collector emitting [3, 10] natively would otherwise
         # survive as a duplicate.
         ranges = [
-            lsp_types.FoldingRange(
+            types.FoldingRange(
                 start_line=0,
                 end_line=10,
-                kind=lsp_types.FoldingRangeKind.Region,
+                kind=types.FoldingRangeKind.Region,
             ),
-            lsp_types.FoldingRange(
+            types.FoldingRange(
                 start_line=3,
                 end_line=10,
-                kind=lsp_types.FoldingRangeKind.Region,
+                kind=types.FoldingRangeKind.Region,
             ),
-            lsp_types.FoldingRange(
+            types.FoldingRange(
                 start_line=3,
                 end_line=12,
-                kind=lsp_types.FoldingRangeKind.Region,
+                kind=types.FoldingRangeKind.Region,
             ),
         ]
         normalised = _normalise_overlaps(ranges)

--- a/tests/test_folding.py
+++ b/tests/test_folding.py
@@ -92,3 +92,92 @@ class TestFoldingRanges:
         ranges = get_folding_ranges(source)
         region_ranges = [r for r in ranges if r.kind == types.FoldingRangeKind.Region]
         assert len(region_ranges) >= 1
+
+    def test_if_else_bodies_are_disjoint(self):
+        """Regression for #182: `} else {` must not put body1 and body2 on the same line."""
+        source = textwrap.dedent("""\
+            if {1} {
+                puts "yes"
+                puts "really"
+            } else {
+                puts "no"
+                puts "nope"
+            }
+        """)
+        ranges = get_folding_ranges(source)
+        region_ranges = sorted(
+            (r for r in ranges if r.kind == types.FoldingRangeKind.Region),
+            key=lambda r: (r.start_line, r.end_line),
+        )
+        # Expect two sibling folds, one per branch, with no shared line.
+        body_ranges = [r for r in region_ranges if r.start_line in (0, 3)]
+        assert len(body_ranges) == 2
+        first, second = body_ranges
+        assert first.end_line < second.start_line, (
+            f"body1 fold {first.start_line}..{first.end_line} overlaps "
+            f"body2 fold {second.start_line}..{second.end_line}"
+        )
+
+    def test_nested_if_else_no_overlapping_siblings(self):
+        """Deeply nested if/else with ``} else {`` on the same line stays well-formed."""
+        source = textwrap.dedent("""\
+            proc demo {x} {
+                if {$x} {
+                    if {$x > 1} {
+                        puts "big"
+                        puts "really big"
+                    } else {
+                        puts "small"
+                        puts "really small"
+                    }
+                } else {
+                    puts "zero"
+                    puts "none"
+                }
+            }
+        """)
+        ranges = get_folding_ranges(source)
+
+        def contains(outer, inner):
+            return (
+                outer.start_line <= inner.start_line and inner.end_line <= outer.end_line
+            )
+
+        for i, a in enumerate(ranges):
+            for b in ranges[i + 1 :]:
+                if a.start_line == b.start_line and a.end_line == b.end_line:
+                    continue
+                if contains(a, b) or contains(b, a):
+                    continue
+                overlaps = a.end_line >= b.start_line and a.start_line <= b.end_line
+                assert not overlaps, (
+                    f"non-nested overlap between {a.start_line}..{a.end_line} "
+                    f"and {b.start_line}..{b.end_line}"
+                )
+
+    def test_if_else_proc_body_close_brace_visible(self):
+        """Proc fold end should leave the outer closing ``}`` line visible."""
+        source = textwrap.dedent("""\
+            proc demo {} {
+                if {1} {
+                    puts "yes"
+                } else {
+                    puts "no"
+                }
+            }
+        """)
+        ranges = get_folding_ranges(source)
+        proc_folds = [
+            r
+            for r in ranges
+            if r.kind == types.FoldingRangeKind.Region and r.start_line == 0
+        ]
+        assert proc_folds
+        # The source has 8 lines; the final ``}`` sits on line 6.
+        # Fold end must be <= 5 so that line 6 stays visible when folded.
+        lines = source.split("\n")
+        close_idx = next(i for i, line in enumerate(lines) if line == "}")
+        for r in proc_folds:
+            assert r.end_line < close_idx, (
+                f"proc fold end {r.end_line} hides closing brace on line {close_idx}"
+            )

--- a/tests/test_folding.py
+++ b/tests/test_folding.py
@@ -139,9 +139,7 @@ class TestFoldingRanges:
         ranges = get_folding_ranges(source)
 
         def contains(outer, inner):
-            return (
-                outer.start_line <= inner.start_line and inner.end_line <= outer.end_line
-            )
+            return outer.start_line <= inner.start_line and inner.end_line <= outer.end_line
 
         for i, a in enumerate(ranges):
             for b in ranges[i + 1 :]:
@@ -168,9 +166,7 @@ class TestFoldingRanges:
         """)
         ranges = get_folding_ranges(source)
         proc_folds = [
-            r
-            for r in ranges
-            if r.kind == types.FoldingRangeKind.Region and r.start_line == 0
+            r for r in ranges if r.kind == types.FoldingRangeKind.Region and r.start_line == 0
         ]
         assert proc_folds
         # The source has 8 lines; the final ``}`` sits on line 6.

--- a/tests/test_folding.py
+++ b/tests/test_folding.py
@@ -169,11 +169,77 @@ class TestFoldingRanges:
             r for r in ranges if r.kind == types.FoldingRangeKind.Region and r.start_line == 0
         ]
         assert proc_folds
-        # The source has 8 lines; the final ``}`` sits on line 6.
-        # Fold end must be <= 5 so that line 6 stays visible when folded.
+        # The proc's own closing ``}`` is the last line that is exactly ``}``
+        # at column 0 — the inner ``if``/``else`` braces are indented.
         lines = source.split("\n")
-        close_idx = next(i for i, line in enumerate(lines) if line == "}")
+        close_idx = max(i for i, line in enumerate(lines) if line == "}")
         for r in proc_folds:
             assert r.end_line < close_idx, (
                 f"proc fold end {r.end_line} hides closing brace on line {close_idx}"
             )
+
+    def test_incomplete_body_still_folds(self):
+        """Unterminated braced body (user mid-edit) must still produce a fold."""
+        # No closing ``}`` on the proc body.
+        source = "proc foo {} {\n    puts hi\n    puts there\n"
+        ranges = get_folding_ranges(source)
+        region_ranges = [r for r in ranges if r.kind == types.FoldingRangeKind.Region]
+        # The partial body should still be foldable so folding doesn't flicker
+        # off every time the user deletes the trailing brace.
+        assert region_ranges, "expected a fold range for an unterminated proc body"
+        # Start line should be the ``{`` line.
+        assert any(r.start_line == 0 for r in region_ranges)
+
+    def test_normalise_overlaps_shared_boundary_trims_earlier(self):
+        """Two sibling ranges sharing a boundary line must become disjoint."""
+        from lsprotocol import types as lsp_types
+
+        from lsp.features.folding import _normalise_overlaps
+
+        ranges = [
+            lsp_types.FoldingRange(
+                start_line=0,
+                end_line=5,
+                kind=lsp_types.FoldingRangeKind.Region,
+            ),
+            lsp_types.FoldingRange(
+                start_line=5,
+                end_line=10,
+                kind=lsp_types.FoldingRangeKind.Region,
+            ),
+        ]
+        normalised = _normalise_overlaps(ranges)
+        # Both ranges should survive, and they must not share any line.
+        assert len(normalised) == 2
+        a, b = sorted(normalised, key=lambda r: r.start_line)
+        assert a.end_line < b.start_line, f"{a} and {b} still overlap"
+
+    def test_normalise_overlaps_dedups_after_trimming(self):
+        """Trimming must not leave duplicate ``(start, end, kind)`` entries."""
+        from lsprotocol import types as lsp_types
+
+        from lsp.features.folding import _normalise_overlaps
+
+        # Parent [0, 10] with child [3, 8]; a sibling [3, 12] trims to [3, 10]
+        # and another collector emitting [3, 10] natively would otherwise
+        # survive as a duplicate.
+        ranges = [
+            lsp_types.FoldingRange(
+                start_line=0,
+                end_line=10,
+                kind=lsp_types.FoldingRangeKind.Region,
+            ),
+            lsp_types.FoldingRange(
+                start_line=3,
+                end_line=10,
+                kind=lsp_types.FoldingRangeKind.Region,
+            ),
+            lsp_types.FoldingRange(
+                start_line=3,
+                end_line=12,
+                kind=lsp_types.FoldingRangeKind.Region,
+            ),
+        ]
+        normalised = _normalise_overlaps(ranges)
+        keys = [(r.start_line, r.end_line, r.kind) for r in normalised]
+        assert len(keys) == len(set(keys)), f"duplicates in {keys}"


### PR DESCRIPTION
## Summary

- Fixed folding range generation to prevent non-hierarchical overlaps that VS Code's folding tree-builder rejects
- Added `_adjust_body_end_line()` to keep closing braces visible and prevent sibling body folds from sharing boundary lines
- Added `_normalise_overlaps()` post-processing to ensure all ranges are either disjoint or properly nested
- Updated `_collect_scope_folds()` and `_collect_body_folds()` to use the adjustment logic for proc and namespace bodies
- Added comprehensive regression tests for if/else bodies and deeply nested structures

## Details

The folding range collectors were generating overlapping ranges in cases like `} else {` where the closing brace of one body and opening brace of the next appear on the same line. This caused VS Code to silently drop or misplace ranges since it requires a proper folding tree (ranges must be either disjoint or one fully contains the other).

The fix uses two strategies:
1. **Preventive**: `_adjust_body_end_line()` adjusts fold end lines when the closing brace sits on the same line as the last content, moving the fold end up one line to keep siblings disjoint
2. **Defensive**: `_normalise_overlaps()` post-processes all ranges to trim any that partially overlap their parent, ensuring well-formed output even if a collector forgets the invariant

## Validation

- Added three new test cases covering the regression scenarios:
  - `test_if_else_bodies_are_disjoint`: Verifies `} else {` produces non-overlapping folds
  - `test_nested_if_else_no_overlapping_siblings`: Validates deeply nested if/else structures maintain proper nesting
  - `test_if_else_proc_body_close_brace_visible`: Ensures proc closing braces remain visible when folded
- Existing tests continue to pass

https://claude.ai/code/session_01BEX3LCCtciq9sTUFUnnLRS