### PR TITLE
deps(vscode): pin lodash to ^4.18.1 (security fix)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4666,6 +4666,7 @@
     "mocha": {
       "diff": "^8.0.3",
       "serialize-javascript": "^7.0.5"
-    }
+    },
+    "lodash": "^4.18.1"
   }
 }


### PR DESCRIPTION
## Summary
- Close two high-severity lodash advisories flagged by ``npm audit``:
  - GHSA-r5fr-rjxr-66jc — code injection via ``_.template`` import keys
  - GHSA-f23m-r3pf-42rh — prototype pollution via array path bypass in ``_.unset`` / ``_.omit``
- Lodash enters through ``@vscode/vsce > @secretlint/node > @secretlint/formatter > @textlint/linter-formatter``.
- ``editors/vscode/package-lock.json`` is gitignored here, so a one-off ``npm audit fix`` wouldn't protect a fresh install — we pin the safe minor via an ``overrides`` block in ``editors/vscode/package.json`` so every install resolves to the 4.18.x line.

## Test plan
- [x] ``npm audit`` reports 0 vulnerabilities
- [x] ``npm ls lodash`` resolves to 4.18.1 under the current dep tree
- [x] ``make compile`` passes with the new resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)