### PR TITLE
Suppress W002 when user-defined proc shadows disallowed command

### DIFF
--- a/core/analysis/checks/_domain.py
+++ b/core/analysis/checks/_domain.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from ...commands.registry import REGISTRY
 from ...commands.registry.models import DialectStatus, FormKind
 from ...commands.registry.runtime import (
@@ -23,6 +25,8 @@ from ._helpers import (
 
 # W002: Disabled command in active dialect
 
+_EMPTY_USER_PROCS: Mapping[str, int] = {}
+
 
 @diag("W002", "Command is disabled in active dialect profile.", section="warning")
 def check_disabled_command(
@@ -31,25 +35,39 @@ def check_disabled_command(
     arg_tokens: list[Token],
     all_tokens: list[Token],
     source: str,
-    user_procs: frozenset[str] = frozenset(),
+    user_procs: Mapping[str, int] = _EMPTY_USER_PROCS,
 ) -> list[Diagnostic]:
     """W002: Warn when a command is disabled in the active dialect profile.
 
-    When the caller supplies ``user_procs`` — the set of qualified proc
-    names defined in the current translation unit — a command name that
-    resolves to a user-defined proc is treated as shadowing the disallowed
-    built-in and W002 is suppressed.
+    ``user_procs`` maps a qualified proc name to the source offset of its
+    earliest unconditional top-level definition. W002 is suppressed only
+    when the call site appears strictly after such a definition — this
+    mirrors Tcl's runtime command resolution, where a proc defined
+    earlier on the unconditional script path shadows the would-be
+    disallowed built-in. Procs defined inside conditionals, loops, or
+    another proc body are not counted, so their shadowing is not assumed.
     """
-    if cmd_name and normalise_qualified_name(cmd_name) in user_procs:
+    if not cmd_name or not all_tokens:
         return []
+
+    qualified = normalise_qualified_name(cmd_name)
+    def_offset = user_procs.get(qualified)
+    call_offset = all_tokens[0].start.offset
+    if def_offset is not None and def_offset < call_offset:
+        return []
+
+    # Registry is keyed without a leading ``::`` — strip it so both
+    # bare (``log``) and fully-qualified (``::log``) call sites
+    # resolve to the same spec.
+    lookup = qualified.lstrip(":")
+
     dialect = active_dialect()
-    status = REGISTRY.command_status(cmd_name, dialect)
+    status = REGISTRY.command_status(lookup, dialect)
     if status is DialectStatus.DISALLOWED:
         msg = f"'{cmd_name}' is disabled in the active dialect profile"
-        # If the command exists in iRules, suggest selecting that dialect.
-        if cmd_name == "when":
+        if lookup == "when":
             msg += ". Select iRules as the language to enable F5 iRules support"
-        elif REGISTRY.command_status(cmd_name, "f5-irules") is DialectStatus.EXISTS:
+        elif REGISTRY.command_status(lookup, "f5-irules") is DialectStatus.EXISTS:
             msg += " (available in the iRules dialect)"
         return [
             Diagnostic(

--- a/core/analysis/checks/_domain.py
+++ b/core/analysis/checks/_domain.py
@@ -11,6 +11,7 @@ from ...commands.registry.runtime import (
 )
 from ...common.codes import diag
 from ...common.dialect import active_dialect
+from ...common.naming import normalise_qualified_name
 from ...common.ranges import range_from_token
 from ...parsing.tokens import Token, TokenType
 from ..semantic_model import Diagnostic, Severity
@@ -30,8 +31,17 @@ def check_disabled_command(
     arg_tokens: list[Token],
     all_tokens: list[Token],
     source: str,
+    user_procs: frozenset[str] = frozenset(),
 ) -> list[Diagnostic]:
-    """W002: Warn when a command is disabled in the active dialect profile."""
+    """W002: Warn when a command is disabled in the active dialect profile.
+
+    When the caller supplies ``user_procs`` — the set of qualified proc
+    names defined in the current translation unit — a command name that
+    resolves to a user-defined proc is treated as shadowing the disallowed
+    built-in and W002 is suppressed.
+    """
+    if cmd_name and normalise_qualified_name(cmd_name) in user_procs:
+        return []
     dialect = active_dialect()
     status = REGISTRY.command_status(cmd_name, dialect)
     if status is DialectStatus.DISALLOWED:

--- a/core/analysis/checks/_orchestrator.py
+++ b/core/analysis/checks/_orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 
 from ...commands.registry import REGISTRY
 from ...parsing.tokens import Token
@@ -105,8 +106,10 @@ ALL_CHECKS = [
 ]
 
 # Checks that run unconditionally on every command (no command-name guard).
+# ``check_disabled_command`` (W002) is invoked explicitly by
+# ``run_all_checks`` because it requires extra context (the map of
+# unconditional user proc definitions) that other checks do not.
 _UNIVERSAL_CHECKS: list[_CheckFn] = [
-    check_disabled_command,
     check_non_literal_command,
     check_non_ascii,
     check_hardcoded_credentials,
@@ -196,6 +199,9 @@ def _get_targeted_checks() -> dict[str, list[_CheckFn]]:
     return _targeted_checks
 
 
+_EMPTY_USER_PROCS: Mapping[str, int] = {}
+
+
 def run_all_checks(
     cmd_name: str,
     args: list[str],
@@ -205,7 +211,7 @@ def run_all_checks(
     *,
     event: str | None = None,
     file_profiles: frozenset[str] = frozenset(),
-    user_procs: frozenset[str] = frozenset(),
+    user_procs: Mapping[str, int] = _EMPTY_USER_PROCS,
 ) -> list[Diagnostic]:
     """Run all registered checks on a single command and return diagnostics.
 
@@ -213,18 +219,21 @@ def run_all_checks(
     current command, reducing the number of function calls from ~35 to
     ~8-12 per command on average.
 
-    ``user_procs`` is the set of qualified proc names defined in the
-    current translation unit; used by W002 to recognise user procs that
-    shadow commands the active dialect disallows.
+    ``user_procs`` maps qualified user proc names to the source offset of
+    their earliest unconditional top-level definition. W002 uses it to
+    suppress the warning at call sites that appear after a shadowing
+    proc definition.
     """
     diagnostics: list[Diagnostic] = []
+    # W002 needs the user_procs context and must run on every command,
+    # so invoke it explicitly rather than through the universal loop.
+    diagnostics.extend(
+        check_disabled_command(
+            cmd_name, args, arg_tokens, all_tokens, source, user_procs=user_procs
+        )
+    )
     for check in _UNIVERSAL_CHECKS:
-        if check is check_disabled_command:
-            diagnostics.extend(
-                check(cmd_name, args, arg_tokens, all_tokens, source, user_procs=user_procs)
-            )
-        else:
-            diagnostics.extend(check(cmd_name, args, arg_tokens, all_tokens, source))
+        diagnostics.extend(check(cmd_name, args, arg_tokens, all_tokens, source))
     targeted = _get_targeted_checks().get(cmd_name)
     if targeted:
         for check in targeted:

--- a/core/analysis/checks/_orchestrator.py
+++ b/core/analysis/checks/_orchestrator.py
@@ -205,16 +205,26 @@ def run_all_checks(
     *,
     event: str | None = None,
     file_profiles: frozenset[str] = frozenset(),
+    user_procs: frozenset[str] = frozenset(),
 ) -> list[Diagnostic]:
     """Run all registered checks on a single command and return diagnostics.
 
     Uses command-name dispatch to skip checks that cannot apply to the
     current command, reducing the number of function calls from ~35 to
     ~8-12 per command on average.
+
+    ``user_procs`` is the set of qualified proc names defined in the
+    current translation unit; used by W002 to recognise user procs that
+    shadow commands the active dialect disallows.
     """
     diagnostics: list[Diagnostic] = []
     for check in _UNIVERSAL_CHECKS:
-        diagnostics.extend(check(cmd_name, args, arg_tokens, all_tokens, source))
+        if check is check_disabled_command:
+            diagnostics.extend(
+                check(cmd_name, args, arg_tokens, all_tokens, source, user_procs=user_procs)
+            )
+        else:
+            diagnostics.extend(check(cmd_name, args, arg_tokens, all_tokens, source))
     targeted = _get_targeted_checks().get(cmd_name)
     if targeted:
         for check in targeted:

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -10,6 +10,7 @@ proc-call arity validation.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 
 from ..analysis.checks import run_all_checks
 from ..analysis.semantic_model import Diagnostic, Range, Severity
@@ -26,6 +27,7 @@ from ..commands.registry.runtime import (
 )
 from ..common.codes import diag
 from ..common.dialect import active_dialect
+from ..common.naming import normalise_qualified_name
 from ..common.ranges import position_from_relative, range_from_token
 from ..common.text import suggest_similar as _suggest_similar_impl
 from ..parsing.argv import widen_argv_tokens_to_word_spans
@@ -35,6 +37,7 @@ from ..parsing.tokens import Token, TokenType
 from .ir import (
     CommandTokens,
     IRBarrier,
+    IRBlock,
     IRCall,
     IRCatch,
     IRFor,
@@ -139,7 +142,7 @@ class _CompilerCheckRunner:
         source: str,
         *,
         file_profiles: frozenset[str] | None = None,
-        user_procs: frozenset[str] = frozenset(),
+        user_procs: Mapping[str, int] | None = None,
     ) -> None:
         self._source = source
         self._seen_commands: set[tuple[int, int]] = set()
@@ -150,7 +153,7 @@ class _CompilerCheckRunner:
             if file_profiles is not None
             else EVENT_REGISTRY.compute_file_profiles(source)
         )
-        self._user_procs = user_procs
+        self._user_procs: Mapping[str, int] = user_procs if user_procs is not None else {}
 
     def process_statement(self, stmt: IRStatement) -> None:
         """Process an IR statement, using carried tokens when available."""
@@ -824,6 +827,52 @@ def _check_simple_arity(
         )
 
 
+def _qualify_proc_name(proc_name: str, namespace: str) -> str:
+    """Qualify a ``proc`` name against its enclosing namespace.
+
+    Mirrors the lowerer's ``_qualify_proc_name`` — an absolute name
+    (``::foo``) is returned as-is; a relative name is joined onto the
+    enclosing namespace (``::`` at top level, ``::ns`` inside
+    ``namespace eval ::ns { ... }``).
+    """
+    if proc_name.startswith("::"):
+        return normalise_qualified_name(proc_name)
+    if namespace == "::":
+        return normalise_qualified_name(f"::{proc_name}")
+    return normalise_qualified_name(f"{namespace}::{proc_name}")
+
+
+def _collect_unconditional_top_level_procs(ir_module: IRModule) -> dict[str, int]:
+    """Map qualified proc name → earliest unconditional top-level offset.
+
+    Walks ``ir_module.top_level`` and recurses into ``namespace eval``
+    bodies (``IRBlock``) which run unconditionally. Skips conditional and
+    looping constructs (``IRIf``/``IRWhile``/``IRFor``/``IRForeach``/
+    ``IRSwitch``/``IRCatch``/``IRTry``) and does not recurse into proc
+    bodies — a proc defined inside any of those is not guaranteed to
+    exist at an arbitrary call site, so W002 keeps its warning.
+
+    Each entry records the source offset of the defining ``proc``
+    command; W002 compares the call-site offset against this value to
+    decide whether the definition is statically known to precede the
+    call.
+    """
+    offsets: dict[str, int] = {}
+
+    def _walk(script: IRScript, namespace: str) -> None:
+        for stmt in script.statements:
+            if isinstance(stmt, IRBlock):
+                _walk(stmt.body, stmt.namespace)
+                continue
+            if isinstance(stmt, (IRCall, IRBarrier)) and stmt.command == "proc" and stmt.args:
+                qualified = _qualify_proc_name(stmt.args[0], namespace)
+                if qualified and qualified not in offsets:
+                    offsets[qualified] = stmt.range.start.offset
+
+    _walk(ir_module.top_level, "::")
+    return offsets
+
+
 def run_compiler_checks(
     source: str,
     *,
@@ -845,10 +894,11 @@ def run_compiler_checks(
         stmts.extend(iter_ir_statements(proc.body))
     stmts.sort(key=lambda s: (s.range.start.offset, s.range.end.offset))
 
-    # Procs keyed in ``ir_module.procedures`` carry the fully-qualified
-    # ``::ns::name`` form used by W002 to suppress warnings when a
-    # user-defined proc shadows a command the active dialect disallows.
-    user_procs = frozenset(ir_module.procedures.keys())
+    # Map qualified name → earliest unconditional top-level definition
+    # offset for W002. Restricting to unconditional definitions preserves
+    # the warning for call sites that would precede a (possibly
+    # conditional) proc at runtime.
+    user_procs = _collect_unconditional_top_level_procs(ir_module)
 
     runner = _CompilerCheckRunner(source, user_procs=user_procs)
     for stmt in stmts:

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -139,6 +139,7 @@ class _CompilerCheckRunner:
         source: str,
         *,
         file_profiles: frozenset[str] | None = None,
+        user_procs: frozenset[str] = frozenset(),
     ) -> None:
         self._source = source
         self._seen_commands: set[tuple[int, int]] = set()
@@ -149,6 +150,7 @@ class _CompilerCheckRunner:
             if file_profiles is not None
             else EVENT_REGISTRY.compute_file_profiles(source)
         )
+        self._user_procs = user_procs
 
     def process_statement(self, stmt: IRStatement) -> None:
         """Process an IR statement, using carried tokens when available."""
@@ -201,6 +203,7 @@ class _CompilerCheckRunner:
                 self._source,
                 event=self._current_event,
                 file_profiles=self._file_profiles,
+                user_procs=self._user_procs,
             )
         )
 
@@ -251,6 +254,7 @@ class _CompilerCheckRunner:
                     self._source,
                     event=self._current_event,
                     file_profiles=self._file_profiles,
+                    user_procs=self._user_procs,
                 )
             )
 
@@ -841,7 +845,12 @@ def run_compiler_checks(
         stmts.extend(iter_ir_statements(proc.body))
     stmts.sort(key=lambda s: (s.range.start.offset, s.range.end.offset))
 
-    runner = _CompilerCheckRunner(source)
+    # Procs keyed in ``ir_module.procedures`` carry the fully-qualified
+    # ``::ns::name`` form used by W002 to suppress warnings when a
+    # user-defined proc shadows a command the active dialect disallows.
+    user_procs = frozenset(ir_module.procedures.keys())
+
+    runner = _CompilerCheckRunner(source, user_procs=user_procs)
     for stmt in stmts:
         runner.process_statement(stmt)
 

--- a/tests/test_dialect_profiles.py
+++ b/tests/test_dialect_profiles.py
@@ -165,6 +165,28 @@ class TestDialectProfiles:
         result = analyse("open /tmp/x\ntime { puts ok }")
         assert all(d.code != "W002" for d in result.diagnostics)
 
+    def test_w002_suppressed_when_user_proc_shadows_disallowed_command(self):
+        # tcllib's installer.tcl defines its own ``::log`` proc, which
+        # shadows the iRules-only ``log`` built-in. W002 must not fire
+        # on calls to ``log`` when the user has defined it.
+        configure_signatures(dialect="tcl8.6")
+        src = 'proc ::log {text} { puts $text }\nlog "hello"\n'
+        result = analyse(src)
+        assert all(d.code != "W002" for d in result.diagnostics)
+
+    def test_w002_fires_without_user_proc(self):
+        configure_signatures(dialect="tcl8.6")
+        result = analyse('log "hello"\n')
+        w002 = [d for d in result.diagnostics if d.code == "W002"]
+        assert len(w002) == 1
+        assert "'log' is disabled" in w002[0].message
+
+    def test_w002_suppressed_for_namespaced_user_proc(self):
+        configure_signatures(dialect="tcl8.6")
+        src = 'namespace eval ::ns { proc log {text} { puts $text } }\n::ns::log "hi"\n'
+        result = analyse(src)
+        assert all(d.code != "W002" for d in result.diagnostics)
+
     def test_completion_hides_f5_irules_disabled_commands(self):
         configure_signatures(dialect="f5-irules")
         labels = {item.label for item in get_completions("", 0, 0)}

--- a/tests/test_dialect_profiles.py
+++ b/tests/test_dialect_profiles.py
@@ -168,7 +168,8 @@ class TestDialectProfiles:
     def test_w002_suppressed_when_user_proc_shadows_disallowed_command(self):
         # tcllib's installer.tcl defines its own ``::log`` proc, which
         # shadows the iRules-only ``log`` built-in. W002 must not fire
-        # on calls to ``log`` when the user has defined it.
+        # on calls to ``log`` when the user has defined it before the
+        # call site at an unconditional top-level position.
         configure_signatures(dialect="tcl8.6")
         src = 'proc ::log {text} { puts $text }\nlog "hello"\n'
         result = analyse(src)
@@ -182,10 +183,43 @@ class TestDialectProfiles:
         assert "'log' is disabled" in w002[0].message
 
     def test_w002_suppressed_for_namespaced_user_proc(self):
+        # ``namespace eval`` runs unconditionally, so a proc it defines
+        # counts as a shadowing definition for W002 purposes.
         configure_signatures(dialect="tcl8.6")
         src = 'namespace eval ::ns { proc log {text} { puts $text } }\n::ns::log "hi"\n'
         result = analyse(src)
         assert all(d.code != "W002" for d in result.diagnostics)
+
+    def test_w002_fires_when_call_precedes_user_proc(self):
+        # Command resolution is order-dependent at runtime: a call that
+        # executes before ``proc ::log`` runs would dispatch to the
+        # (disallowed) built-in, so W002 must still fire.
+        configure_signatures(dialect="tcl8.6")
+        src = 'log "hello"\nproc ::log {text} { puts $text }\n'
+        result = analyse(src)
+        w002 = [d for d in result.diagnostics if d.code == "W002"]
+        assert len(w002) == 1
+        assert "'log' is disabled" in w002[0].message
+
+    def test_w002_fires_when_user_proc_is_defined_conditionally(self):
+        # A proc defined inside an ``if`` body is not guaranteed to
+        # exist at an arbitrary call site, so W002 still fires.
+        configure_signatures(dialect="tcl8.6")
+        src = 'if {1} { proc ::log {text} { puts $text } }\nlog "hello"\n'
+        result = analyse(src)
+        w002 = [d for d in result.diagnostics if d.code == "W002"]
+        assert len(w002) == 1
+        assert "'log' is disabled" in w002[0].message
+
+    def test_w002_fires_for_fully_qualified_disallowed_command(self):
+        # The command registry is keyed without a leading ``::``; W002
+        # must strip it so ``::open`` under the iRules dialect is
+        # recognised as the disallowed ``open`` built-in.
+        configure_signatures(dialect="f5-irules")
+        result = analyse("::open /tmp/x\n")
+        w002 = [d for d in result.diagnostics if d.code == "W002"]
+        assert len(w002) == 1
+        assert "'::open' is disabled" in w002[0].message
 
     def test_completion_hides_f5_irules_disabled_commands(self):
         configure_signatures(dialect="f5-irules")


### PR DESCRIPTION
## Summary

- Fix W002 (disabled command warning) to recognize when a user-defined proc shadows a command that the active dialect disallows
- Pass the set of user-defined procedures through the analysis pipeline so that `check_disabled_command` can suppress W002 when appropriate
- Add test cases covering the suppression behavior for both simple and namespaced user procs

## Details

The W002 diagnostic warns when code calls a command that is disabled in the active dialect profile. However, it was incorrectly firing when a user had defined their own proc with the same name, effectively shadowing the disallowed built-in.

This change:
1. Collects all user-defined proc names (in fully-qualified form) from the IR module
2. Threads this set through the compiler check runner and orchestrator
3. Updates `check_disabled_command` to suppress W002 when the command name resolves to a user-defined proc

This resolves the issue where tcllib's `installer.tcl` defines its own `::log` proc, which shadows the iRules-only `log` built-in, but W002 was still firing on calls to `log`.

## Validation

- Added three new test cases:
  - `test_w002_suppressed_when_user_proc_shadows_disallowed_command`: Verifies W002 is suppressed when a user defines a proc with the same name as a disallowed command
  - `test_w002_fires_without_user_proc`: Confirms W002 still fires when no user proc exists
  - `test_w002_suppressed_for_namespaced_user_proc`: Verifies suppression works for namespaced procs

## Compiler/KCS checklist

- [ ] This change alters compiler behavior (W002 suppression logic)
- [ ] No KCS notes require updates; this is a bug fix to existing W002 behavior

https://claude.ai/code/session_01AKW4KAWgcBfCnW2F3tveHu