### PR TITLE
Return folding ranges immediately without waiting for analysis

### DIFF
--- a/lsp/features/folding.py
+++ b/lsp/features/folding.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from lsprotocol import types
 
-from core.analysis.analyser import analyse
 from core.analysis.semantic_model import AnalysisResult, Scope
 from core.commands.registry.runtime import iter_body_arguments
 from core.parsing.command_segmenter import segment_commands
@@ -279,14 +278,21 @@ def get_folding_ranges(
     *,
     lines: list[str] | None = None,
 ) -> list[types.FoldingRange]:
-    """Return folding ranges for a Tcl source file."""
-    if analysis is None:
-        analysis = analyse(source)
+    """Return folding ranges for a Tcl source file.
 
+    When ``analysis`` is ``None`` the scope-based collector is skipped.
+    It's redundant with the syntactic body-argument walker for the
+    common proc/namespace/control-structure cases, so omitting it
+    lets the LSP handler serve fold ranges immediately after
+    ``didOpen`` — before the background analyse() task populates
+    ``state.analysis`` — without blocking the event loop on a
+    synchronous full analysis pass.
+    """
     ranges: list[types.FoldingRange] = []
     seen: set[tuple[int, int]] = set()
 
-    _collect_scope_folds(analysis.global_scope, seen, ranges, source)
+    if analysis is not None:
+        _collect_scope_folds(analysis.global_scope, seen, ranges, source)
     _collect_comment_folds(source, seen, ranges, lines=lines)
     _collect_body_folds(source, seen, ranges, original_source=source)
 

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -2453,10 +2453,18 @@ async def _publish_diagnostics(
     partial_mode = state.has_partial_commands
 
     # After analysis completes, ask the client to re-request semantic
-    # tokens so they benefit from analysis enrichment (regex_positions).
+    # tokens so they benefit from analysis enrichment (regex_positions),
+    # and folding ranges so that scope-based folds for quoted or
+    # substituted proc/namespace bodies (which the syntactic walker
+    # can't recover) get picked up on top of the syntactic folds that
+    # were served pre-analysis.
     if did_analyse and state.analysis is not None:
         try:
             server.workspace_semantic_tokens_refresh(None)
+        except Exception:
+            pass  # client may not support refresh
+        try:
+            server.workspace_folding_range_refresh(None)
         except Exception:
             pass  # client may not support refresh
 

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -933,8 +933,11 @@ def on_folding_range(
         return []
     uri = params.text_document.uri
     state = workspace_state.get(uri)
-    if state is not None and state.analysis is None:
-        return []
+    # Fold ranges don't require a full AnalysisResult: the comment and
+    # body-argument collectors work on source tokens alone and already
+    # cover proc/namespace/control-structure bodies.  Returning ``[]``
+    # while analysis is still running would leave VS Code with a cached
+    # empty result and no fold markers until the next didChange.
     source = _get_doc_source(uri)
     analysis = state.analysis if state else None
     return get_folding_ranges(source, analysis=analysis, lines=state.lines if state else None)


### PR DESCRIPTION
## Summary

- Remove the synchronous `analyse()` call from `get_folding_ranges()` to avoid blocking the LSP event loop
- Make the `analysis` parameter optional by skipping scope-based folding when it's `None`
- Update `on_folding_range()` handler to return folding ranges immediately after `didOpen`, before background analysis completes
- The syntactic collectors (comment and body-argument folds) are sufficient for common cases and don't require semantic analysis

## Details

Previously, `get_folding_ranges()` would perform a full synchronous analysis pass if the `analysis` parameter was `None`, which blocked the LSP event loop. This caused the `didOpen` handler to delay returning fold ranges until analysis completed.

The change recognizes that:
1. Comment folding and body-argument folding (for proc/namespace/control structures) work entirely on source tokens
2. These collectors already cover the common folding cases
3. Scope-based folding from semantic analysis is redundant for these cases
4. Returning fold ranges immediately provides better UX without blocking on background analysis

The scope-based collector is now only invoked when `analysis` is available, allowing the handler to serve fold ranges immediately while analysis runs asynchronously.

## Validation

- No new tests needed; this is a performance optimization that maintains existing folding behavior for the common cases
- Existing folding tests continue to pass with `analysis=None`

https://claude.ai/code/session_01ScjcrcvUpmujDjS357wAU9