### PR TITLE
Add tcl-lsp.showReferences wrapper command for code lens

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -36,6 +36,7 @@ import {
   runtimeValidationAdapterLabel,
   RuntimeValidationAdapterMode,
 } from "./runtimeValidation";
+import { convertShowReferencesArgs, JsonLocation, JsonPosition } from "./showReferences";
 import {
   buildPackageScaffold,
   packageDirectoryName,
@@ -736,32 +737,14 @@ export async function activate(context: ExtensionContext) {
     // raw strings/plain objects. Convert here before delegating.
     commands.registerCommand(
       "tcl-lsp.showReferences",
-      async (
-        uriString: string,
-        position: { line: number; character: number },
-        locations: ReadonlyArray<{
-          uri: string;
-          range: {
-            start: { line: number; character: number };
-            end: { line: number; character: number };
-          };
-        }>,
-      ) => {
-        const uri = Uri.parse(uriString);
-        const pos = new vscode.Position(position.line, position.character);
-        const locs = locations.map(
-          (loc) =>
-            new vscode.Location(
-              Uri.parse(loc.uri),
-              new Range(
-                loc.range.start.line,
-                loc.range.start.character,
-                loc.range.end.line,
-                loc.range.end.character,
-              ),
-            ),
+      async (uriString: string, position: JsonPosition, locations: ReadonlyArray<JsonLocation>) => {
+        const args = convertShowReferencesArgs(uriString, position, locations);
+        await commands.executeCommand(
+          "editor.action.showReferences",
+          args.uri,
+          args.position,
+          args.locations,
         );
-        await commands.executeCommand("editor.action.showReferences", uri, pos, locs);
       },
     ),
   );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -729,6 +729,41 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("tclLsp.copyFileAsBase64", copyFileAsBase64),
     commands.registerCommand("tclLsp.copyFileAsGzipBase64", copyFileAsGzipBase64),
     commands.registerCommand("tclLsp.translateXc", translateXc),
+    // Wrapper for the built-in editor.action.showReferences: the LSP server
+    // emits this command on its code lenses with URI/Position/Location args
+    // serialised as JSON primitives, but the built-in command validates its
+    // arguments against vscode.Uri/Position/Array constraints and rejects
+    // raw strings/plain objects. Convert here before delegating.
+    commands.registerCommand(
+      "tcl-lsp.showReferences",
+      async (
+        uriString: string,
+        position: { line: number; character: number },
+        locations: ReadonlyArray<{
+          uri: string;
+          range: {
+            start: { line: number; character: number };
+            end: { line: number; character: number };
+          };
+        }>,
+      ) => {
+        const uri = Uri.parse(uriString);
+        const pos = new vscode.Position(position.line, position.character);
+        const locs = locations.map(
+          (loc) =>
+            new vscode.Location(
+              Uri.parse(loc.uri),
+              new Range(
+                loc.range.start.line,
+                loc.range.start.character,
+                loc.range.end.line,
+                loc.range.end.character,
+              ),
+            ),
+        );
+        await commands.executeCommand("editor.action.showReferences", uri, pos, locs);
+      },
+    ),
   );
 
   context.subscriptions.push(

--- a/editors/vscode/src/showReferences.ts
+++ b/editors/vscode/src/showReferences.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+
+export interface JsonPosition {
+  line: number;
+  character: number;
+}
+
+export interface JsonLocation {
+  uri: string;
+  range: {
+    start: JsonPosition;
+    end: JsonPosition;
+  };
+}
+
+// Convert the JSON-RPC shapes that the LSP server serialises into the
+// ``vscode.Uri`` / ``vscode.Position`` / ``vscode.Location`` instances that
+// the built-in ``editor.action.showReferences`` command validates against.
+export function convertShowReferencesArgs(
+  uriString: string,
+  position: JsonPosition,
+  locations: ReadonlyArray<JsonLocation>,
+): {
+  uri: vscode.Uri;
+  position: vscode.Position;
+  locations: vscode.Location[];
+} {
+  return {
+    uri: vscode.Uri.parse(uriString),
+    position: new vscode.Position(position.line, position.character),
+    locations: locations.map(
+      (loc) =>
+        new vscode.Location(
+          vscode.Uri.parse(loc.uri),
+          new vscode.Range(
+            loc.range.start.line,
+            loc.range.start.character,
+            loc.range.end.line,
+            loc.range.end.character,
+          ),
+        ),
+    ),
+  };
+}

--- a/editors/vscode/src/test/showReferences.test.ts
+++ b/editors/vscode/src/test/showReferences.test.ts
@@ -1,0 +1,89 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { activate, getDocUri } from "./helper";
+import { convertShowReferencesArgs } from "../showReferences";
+
+suite("tcl-lsp.showReferences adapter", () => {
+  suite("convertShowReferencesArgs", () => {
+    test("parses the URI string into a vscode.Uri", () => {
+      const { uri } = convertShowReferencesArgs(
+        "file:///tmp/example.tcl",
+        { line: 0, character: 0 },
+        [],
+      );
+      assert.ok(uri instanceof vscode.Uri, "uri should be a vscode.Uri instance");
+      assert.strictEqual(uri.scheme, "file");
+      assert.strictEqual(uri.fsPath.replace(/\\/g, "/"), "/tmp/example.tcl");
+    });
+
+    test("rebuilds the position as a vscode.Position", () => {
+      const { position } = convertShowReferencesArgs(
+        "file:///tmp/example.tcl",
+        { line: 12, character: 7 },
+        [],
+      );
+      assert.ok(position instanceof vscode.Position, "position should be a vscode.Position");
+      assert.strictEqual(position.line, 12);
+      assert.strictEqual(position.character, 7);
+    });
+
+    test("maps each JSON location into a vscode.Location with a vscode.Range", () => {
+      const { locations } = convertShowReferencesArgs(
+        "file:///tmp/a.tcl",
+        { line: 0, character: 0 },
+        [
+          {
+            uri: "file:///tmp/a.tcl",
+            range: {
+              start: { line: 1, character: 2 },
+              end: { line: 1, character: 10 },
+            },
+          },
+          {
+            uri: "file:///tmp/b.tcl",
+            range: {
+              start: { line: 5, character: 0 },
+              end: { line: 5, character: 4 },
+            },
+          },
+        ],
+      );
+      assert.strictEqual(locations.length, 2);
+      for (const loc of locations) {
+        assert.ok(loc instanceof vscode.Location, "each location should be a vscode.Location");
+        assert.ok(loc.uri instanceof vscode.Uri, "location.uri should be a vscode.Uri");
+        assert.ok(loc.range instanceof vscode.Range, "location.range should be a vscode.Range");
+      }
+      assert.strictEqual(locations[0].uri.fsPath.replace(/\\/g, "/"), "/tmp/a.tcl");
+      assert.strictEqual(locations[0].range.start.line, 1);
+      assert.strictEqual(locations[0].range.start.character, 2);
+      assert.strictEqual(locations[0].range.end.line, 1);
+      assert.strictEqual(locations[0].range.end.character, 10);
+      assert.strictEqual(locations[1].uri.fsPath.replace(/\\/g, "/"), "/tmp/b.tcl");
+    });
+
+    test("returns an empty list when no locations are supplied", () => {
+      const { locations } = convertShowReferencesArgs(
+        "file:///tmp/example.tcl",
+        { line: 0, character: 0 },
+        [],
+      );
+      assert.deepStrictEqual(locations, []);
+    });
+  });
+
+  suite("command registration", () => {
+    suiteSetup(async function () {
+      this.timeout(60_000);
+      await activate(getDocUri("simple.tcl"));
+    });
+
+    test("tcl-lsp.showReferences is registered", async () => {
+      const registered = await vscode.commands.getCommands(true);
+      assert.ok(
+        registered.includes("tcl-lsp.showReferences"),
+        "tcl-lsp.showReferences should be registered by the extension",
+      );
+    });
+  });
+});

--- a/lsp/features/code_lens.py
+++ b/lsp/features/code_lens.py
@@ -27,9 +27,10 @@ class _WorkspaceLike(Protocol):
 
 
 # ``find_references(uri, qname) -> list[Location]`` — supplies the location
-# list for the VS Code built-in ``editor.action.showReferences`` command so
-# no client-side command has to exist. Optional for callers (e.g. unit
-# tests) that don't need a working peek.
+# list for the ``tcl-lsp.showReferences`` wrapper command, which converts
+# the arguments to vscode.Uri/Position/Location instances before delegating
+# to the built-in ``editor.action.showReferences``. Optional for callers
+# (e.g. unit tests) that don't need a working peek.
 FindReferences = Callable[[str, str], list[types.Location]]
 
 
@@ -89,8 +90,11 @@ def resolve_code_lens(
 ) -> types.CodeLens:
     """Populate ``title``/``command`` on ``lens`` using cached usage counts.
 
-    The command is VS Code's built-in ``editor.action.showReferences`` so
-    the peek opens without any client-side command registration. Passing
+    The command is ``tcl-lsp.showReferences``, a thin client-side wrapper
+    the VS Code extension registers to convert the URI, position, and
+    locations from their JSON-RPC shapes into the ``vscode.Uri``,
+    ``vscode.Position``, and ``vscode.Location`` instances that the
+    built-in ``editor.action.showReferences`` command requires. Passing
     ``find_references=None`` (e.g. in tests) yields an empty locations
     list but still produces a well-formed command.
     """
@@ -105,7 +109,7 @@ def resolve_code_lens(
             range=lens.range,
             command=types.Command(
                 title=title,
-                command="editor.action.showReferences",
+                command="tcl-lsp.showReferences",
                 arguments=[data.uri, lens.range.start, locations],
             ),
             data=lens.data,

--- a/tests/test_code_lens.py
+++ b/tests/test_code_lens.py
@@ -67,8 +67,10 @@ class TestResolveCodeLens:
         resolved = resolve_code_lens(lenses[0], ws)
         assert resolved.command is not None
         assert resolved.command.title == "3 references"
-        # VS Code built-in, so no client-side command registration is required.
-        assert resolved.command.command == "editor.action.showReferences"
+        # Thin client-side wrapper: it converts the JSON-RPC argument
+        # shapes into the vscode.Uri/Position/Location instances that the
+        # built-in ``editor.action.showReferences`` command requires.
+        assert resolved.command.command == "tcl-lsp.showReferences"
         assert resolved.command.arguments is not None
         assert resolved.command.arguments[0] == TEST_URI
         # The second argument is the position to display in the peek header —


### PR DESCRIPTION
## Summary

- Add a client-side `tcl-lsp.showReferences` command wrapper in the VS Code extension that converts JSON-RPC serialized arguments (strings and plain objects) into the `vscode.Uri`, `vscode.Position`, and `vscode.Location` instances required by the built-in `editor.action.showReferences` command
- Update the LSP server's code lens resolver to emit the `tcl-lsp.showReferences` command instead of directly calling the built-in command
- Update documentation and test assertions to reflect the new wrapper command

## Rationale

The LSP server was previously attempting to invoke VS Code's built-in `editor.action.showReferences` command directly via code lenses. However, the built-in command validates its arguments against strict VS Code type constraints (`vscode.Uri`, `vscode.Position`, `vscode.Location[]`), while JSON-RPC serialization produces plain strings and objects. This caused the command to be rejected at runtime.

The wrapper command acts as an adapter layer, accepting the JSON-RPC argument shapes and converting them to the proper VS Code types before delegating to the built-in command. This allows code lens references to work correctly.

## Validation

- [x] Existing unit test updated and passes: `tests/test_code_lens.py::test_populates_title_and_command`

https://claude.ai/code/session_01TwHgBaLjXQQsjZpVKhdj7A