### PR TITLE
Fix layout overflow issues in Compiler Explorer HTML view

### DIFF
--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -80,16 +80,20 @@ body {
 .app {
   display: grid;
   grid-template-rows: auto 1fr;
+  grid-template-columns: minmax(0, 1fr);
   height: 100vh;
+  width: 100%;
 }
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
   padding: 8px 16px;
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   min-height: 42px;
+  min-width: 0;
 }
 .toolbar h1 {
   font-size: 14px;
@@ -125,12 +129,14 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-width: 0;
 }
 .output-panel {
   display: flex;
   flex-direction: column;
   flex: 1;
   overflow: hidden;
+  min-width: 0;
 }
 .tab-bar {
   display: flex;
@@ -138,6 +144,7 @@ body {
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  min-width: 0;
 }
 .tab {
   padding: 6px 10px;


### PR DESCRIPTION
## Summary

- Constrained the `.app` grid to `grid-template-columns: minmax(0, 1fr)` (plus `width: 100%`) so the single implicit column no longer auto-sizes to its widest content (the 15-tab row) and push past the webview column width
- Added `flex-wrap: wrap` to `.toolbar` so the title bar / dialect selector / stats can reflow when the column is narrow
- Added `min-width: 0` to `.toolbar`, `.main`, `.output-panel`, and `.tab-bar` so these flex/grid descendants can shrink below their content width, letting `flex-wrap: wrap` on the tab bar actually trigger instead of clipping tabs like WASM off the right edge while only WASM (Opt) wrapped

## Root cause

`.app` was `display: grid` with `grid-template-rows: auto 1fr` and no explicit columns. The single implicit auto column sized to max-content of the widest row (the tab bar), so the grid cell grew wider than the webview column. Flex descendants inherited `min-width: auto`, so they never shrank and `flex-wrap` on `.tab-bar` only kicked in for the very last tab.

## Validation

- `make typecheck-ts` — passes
- CI — all checks green (test-py, lint, test-ext, etc.)
- CSS-only change; no compiler or LSP behaviour affected

https://claude.ai/code/session_01LVwrNosuMtrirAigPfCpfg