### PR TITLE
fix(explorer): escape all control chars in ASM; rename tabs to Tcl ASM

### DIFF
--- a/core/compiler/codegen/format.py
+++ b/core/compiler/codegen/format.py
@@ -8,8 +8,12 @@ from .opcodes import _INDEX_END, _JUMP_OPS, _LVT_OPS, _STR_CLASS_NAMES, Op
 def _esc(text: str, limit: int = 40) -> str:
     """Escape a literal value for disassembly comments.
 
-    Matches Tcl's disassembler: backslashes are NOT doubled; control
-    characters and non-ASCII codepoints are escaped.
+    Matches Tcl's disassembler (``PrintSourceToObj`` in ``tclDisassemble.c``):
+    backslashes are NOT doubled; ``"`` and the named whitespace controls
+    (``\\n \\t \\r \\v \\f``) use short forms; every other codepoint below
+    0x20 or at/above 0x7F is escaped as ``\\uXXXX`` (or ``\\UXXXXXXXX`` for
+    supplementary planes). Without this, raw control bytes like STX leak
+    into the HTML pane and render as unprintable/tofu glyphs.
     """
     parts: list[str] = []
     for ch in text:
@@ -26,9 +30,9 @@ def _esc(text: str, limit: int = 40) -> str:
             parts.append("\\v")
         elif ch == "\f":
             parts.append("\\f")
-        elif cp == 0:
-            parts.append("\\u0000")
-        elif cp > 0x7E:
+        elif cp > 0xFFFF:
+            parts.append(f"\\U{cp:08x}")
+        elif cp < 0x20 or cp >= 0x7F:
             parts.append(f"\\u{cp:04x}")
         else:
             parts.append(ch)

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -618,7 +618,7 @@ body {
         <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
         <div class="tab" data-tab="asm-opt">Tcl ASM (opt)</div>
-        <div class="tab" data-tab="wasm-opt">WASM (Opt)</div>
+        <div class="tab" data-tab="wasm-opt">WASM (opt)</div>
       </div>
       <div class="output-content" id="outputContent">
         <div class="tab-pane active" id="pane-ir">

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -615,9 +615,9 @@ body {
         <div class="tab" data-tab="taint">Taint</div>
         <div class="tab" data-tab="irules-flow">iRules Flow</div>
         <div class="tab" data-tab="callouts">Callouts</div>
-        <div class="tab" data-tab="asm">ASM</div>
+        <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
-        <div class="tab" data-tab="asm-opt">ASM (Opt)</div>
+        <div class="tab" data-tab="asm-opt">Tcl ASM (opt)</div>
         <div class="tab" data-tab="wasm-opt">WASM (Opt)</div>
       </div>
       <div class="output-content" id="outputContent">

--- a/explorer/static/index.html
+++ b/explorer/static/index.html
@@ -762,7 +762,7 @@ puts $x"></textarea>
         <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
         <div class="tab" data-tab="asm-opt">Tcl ASM (opt)</div>
-        <div class="tab" data-tab="wasm-opt">WASM (Opt)</div>
+        <div class="tab" data-tab="wasm-opt">WASM (opt)</div>
       </div>
       <div class="output-content" id="outputContent">
         <div class="tab-pane active" id="pane-ir">

--- a/explorer/static/index.html
+++ b/explorer/static/index.html
@@ -759,9 +759,9 @@ puts $x"></textarea>
         <div class="tab" data-tab="taint">Taint</div>
         <div class="tab irules-only" data-tab="irules-flow">iRules Flow</div>
         <div class="tab" data-tab="callouts">Callouts</div>
-        <div class="tab" data-tab="asm">ASM</div>
+        <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
-        <div class="tab" data-tab="asm-opt">ASM (Opt)</div>
+        <div class="tab" data-tab="asm-opt">Tcl ASM (opt)</div>
         <div class="tab" data-tab="wasm-opt">WASM (Opt)</div>
       </div>
       <div class="output-content" id="outputContent">

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -19,6 +19,7 @@ from core.compiler.codegen import (
     format_function_asm,
     format_module_asm,
 )
+from core.compiler.codegen.format import _esc
 from core.compiler.lowering import lower_to_ir
 
 # Helpers
@@ -412,6 +413,54 @@ class TestFormatting:
         text = format_module_asm(ma)
         assert "ByteCode ::top" in text
         assert "ByteCode ::foo" in text
+
+
+# Disassembly escaping — matches Tcl 9's PrintSourceToObj.
+# Regression cover for control bytes (e.g. STX in synthesised literals like
+# "\x00\x02-") leaking through as raw glyphs and breaking the ASM pane.
+
+
+class TestEscEscaping:
+    def test_named_controls_use_short_forms(self):
+        assert _esc("a\nb\tc\rd\ve\ff") == "a\\nb\\tc\\rd\\ve\\ff"
+
+    def test_nul_escaped_as_uXXXX(self):
+        assert _esc("a\x00b") == "a\\u0000b"
+
+    def test_stx_and_other_c0_controls_escaped(self):
+        # STX (0x02) is the one that leaked in tcllib 2.0 installer.tcl.
+        assert _esc("\x01\x02\x03\x1f") == "\\u0001\\u0002\\u0003\\u001f"
+
+    def test_del_and_high_bmp_escaped(self):
+        assert _esc("\x7f") == "\\u007f"
+        assert _esc("ÿ") == "\\u00ff"
+        assert _esc("￿") == "\\uffff"
+
+    def test_supplementary_plane_uses_big_u(self):
+        assert _esc("\U0001f600") == "\\U0001f600"
+
+    def test_printable_ascii_unchanged(self):
+        assert _esc("hello world!") == "hello world!"
+
+    def test_quote_escaped(self):
+        assert _esc('a"b') == 'a\\"b'
+
+    def test_literal_with_embedded_stx_appears_escaped_in_disassembly(self):
+        """End-to-end: a literal interned with STX must render escaped in the
+        ``Literals:`` section — no raw control byte reaches the formatter output.
+        """
+        literals = LiteralTable()
+        literals.intern("\x00\x02-")
+        fa = FunctionAsm(
+            name="::top",
+            literals=literals,
+            lvt=LocalVarTable(),
+            instructions=[],
+            labels={},
+        )
+        text = format_function_asm(fa)
+        assert "\x02" not in text
+        assert '"\\u0000\\u0002-"' in text
 
 
 # Procedures


### PR DESCRIPTION
format._esc only escaped NUL, the named whitespace controls
(\n \t \r \v \f), and cp > 0x7E. Control bytes 0x01-0x1F (e.g. the
STX that appears in Tcl bytecode literals like " \x02-") leaked
through unescaped and rendered as tofu / zero-width glyphs in the
compiler-explorer ASM pane. For installer.tcl in tcllib 2.0 that
made the pane look "entirely broken". Match Tcl 9's
PrintSourceToObj: cp < 0x20 or cp >= 0x7F becomes \uXXXX,
cp > 0xFFFF becomes \UXXXXXXXX.

Also rename the ASM / ASM (Opt) tabs to "Tcl ASM" / "Tcl ASM (opt)"
in both the web explorer and the VS Code webview so the Tcl
bytecode tabs are distinguishable from the WASM tabs at a glance.

https://claude.ai/code/session_01SAQSeVg8Di7vAf6sbGzZaq