### PR TITLE
Add structured WASM/ASM disassembly view to compiler explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,8 +649,18 @@ proc process {x}      { if {[validate $x]} { store $x } }
 ### Compiler explorer (VS Code panel)
 
 An interactive webview panel (Ctrl+Alt+E / Cmd+Alt+E) that visualises the
-compiler's intermediate representation, control-flow graph, SSA form, and
-optimiser output for the active editor.
+compiler's intermediate representation, control-flow graph, SSA form,
+optimiser output, Tcl bytecode, and WebAssembly disassembly for the active
+editor.  The **WASM** tab renders each instruction with its originating Tcl
+source range (click an instruction to place the source cursor inside the
+expression, substituted command, or post-`;` sub-command it compiled from),
+resolved call targets (click `call 42 ; ::greet` to jump to both the
+callee's disassembly and its definition), resolved branch targets (click
+`br 0 ; loop_header foreach` to jump to the matching `loop` open), a
+labelled `block` / `loop` / `if` for each Tcl construct (`foreach`,
+`while`, `for`, `if`, `catch body`, `switch arm`), a source-line comment
+above every instruction group, and orthogonal control-flow arrows in the
+left gutter.
 
 ```
 ┌─────────────────────────────────────────────────┐

--- a/core/compiler/codegen/__init__.py
+++ b/core/compiler/codegen/__init__.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 
 from ._emitter import codegen_function, codegen_module
 from ._types import FunctionAsm, Instruction, LiteralTable, LocalVarTable, ModuleAsm
-from .format import _esc, format_function_asm, format_module_asm
+from .format import (
+    _esc,
+    format_function_asm,
+    format_function_explorer,
+    format_module_asm,
+    format_module_explorer,
+)
 from .opcodes import Op
 from .wasm import (  # noqa: F401
     WasmFunction,
@@ -41,5 +47,7 @@ __all__ = [
     "codegen_function",
     "codegen_module",
     "format_function_asm",
+    "format_function_explorer",
     "format_module_asm",
+    "format_module_explorer",
 ]

--- a/core/compiler/codegen/_emitter.py
+++ b/core/compiler/codegen/_emitter.py
@@ -502,6 +502,19 @@ class _Emitter(
             blk = self._cfg.blocks[bname]
             self._place_label(bname)
 
+            # Seed the source-range context for this block with its
+            # terminator's range (when present) so non-stmt ops
+            # emitted before any statement (e.g. startCommand wrappers
+            # for foreach / while / for-body branch terminators) carry
+            # the block's own source location rather than a stale
+            # range left behind by whichever stmt the previous block
+            # emitted.  Individual ``_emit_stmt`` calls will still
+            # re-stamp per statement as they run.
+            _term_range = getattr(blk.terminator, "range", None) if blk.terminator else None
+            if _term_range is not None:
+                self._current_source_range = _term_range
+                self._current_source_line = _term_range.start.line + 1
+
             # try/finally inline compilation: emit the entire
             # try/finally sequence when we reach the try_body block.
             if bname in try_finally_info:

--- a/core/compiler/codegen/_emitter.py
+++ b/core/compiler/codegen/_emitter.py
@@ -94,6 +94,11 @@ class _Emitter(
         self._used_inline_cmd_subst = False
         # 1-based source line of the current statement (for errorInfo).
         self._current_source_line: int = 0
+        # Full source range of the current statement — stamped onto every
+        # emitted instruction so the compiler explorer can click-to-source
+        # from a bytecode line back to the exact Tcl command that produced
+        # it (at sub-command / expression granularity, not just line level).
+        self._current_source_range = None
         # Pending startCommand end labels for constant-folded branches.
         # Maps join-block name → label to place after the join pop.
         self._pending_join_labels: dict[str, str] = {}
@@ -117,7 +122,15 @@ class _Emitter(
     def _emit(self, op: Op, *operands: int | str, comment: str = "", source_line: int = 0) -> int:
         idx = len(self._instrs)
         sl = source_line or self._current_source_line
-        self._instrs.append(Instruction(op=op, operands=operands, comment=comment, source_line=sl))
+        self._instrs.append(
+            Instruction(
+                op=op,
+                operands=operands,
+                comment=comment,
+                source_line=sl,
+                source_range=self._current_source_range,
+            )
+        )
         return idx
 
     def _place_label(self, label: str) -> None:

--- a/core/compiler/codegen/_expressions.py
+++ b/core/compiler/codegen/_expressions.py
@@ -305,6 +305,17 @@ class _ExpressionsMixin:
     def _emit_term(
         self: _Emitter, term: CFGGoto | CFGBranch | CFGReturn, next_block: str | None
     ) -> None:
+        # Refresh the source-range context before emitting terminator
+        # ops.  ``_current_source_range`` is primarily kept up to date
+        # by ``_emit_stmt``; terminators are emitted after the last
+        # statement in a block, so without this stamp a ``jumpFalse1``
+        # or ``done`` inherits the previous statement's range — which
+        # misroutes click-to-source in the explorer (e.g. an ``if`` 's
+        # conditional jump would point at the preceding ``set``).
+        term_range = getattr(term, "range", None)
+        if term_range is not None:
+            self._current_source_range = term_range
+            self._current_source_line = term_range.start.line + 1
         match term:
             case CFGGoto(target=target):
                 if target != next_block:
@@ -386,6 +397,13 @@ class _ExpressionsMixin:
         tclsh also emits a dead-code ``jump`` past the else path
         after the ``done``.
         """
+        # Stamp the terminator's source range onto the startCommand
+        # wrapper and the ``done`` so the explorer can click back to
+        # the ``return`` source instead of the preceding statement.
+        term_range = getattr(term, "range", None)
+        if term_range is not None:
+            self._current_source_range = term_range
+            self._current_source_line = term_range.start.line + 1
         val = term.value if term.value is not None else ""
         is_cmd_subst = val.startswith("[") and val.endswith("]")
         is_final = next_block is None

--- a/core/compiler/codegen/_statements.py
+++ b/core/compiler/codegen/_statements.py
@@ -120,9 +120,13 @@ class _StatementsMixin:
         self._cmd_index += 1
 
     def _emit_stmt(self: _Emitter, stmt: IRStatement) -> None:  # noqa: C901
-        # Track source line for errorInfo (1-based).
+        # Track source line for errorInfo (1-based) and full source range
+        # so every instruction emitted below this statement carries the
+        # originating Tcl span — consumed by the compiler explorer for
+        # click-to-source and per-source-line group comments.
         if hasattr(stmt, "range"):
             self._current_source_line = stmt.range.start.line + 1
+            self._current_source_range = stmt.range
         match stmt:
             case IRAssignConst(name=name, value=value):
                 if self._needs_stk_var_ref(name):

--- a/core/compiler/codegen/_statements.py
+++ b/core/compiler/codegen/_statements.py
@@ -124,6 +124,14 @@ class _StatementsMixin:
         # so every instruction emitted below this statement carries the
         # originating Tcl span — consumed by the compiler explorer for
         # click-to-source and per-source-line group comments.
+        # Invariant: every IR statement carries a ``range`` field
+        # (see core/compiler/ir.py), so the ``hasattr`` guard is
+        # defensive — when it ever slips we'd rather inherit the
+        # previous statement's range than crash the emitter.
+        # ``_emit_term`` / ``_emit_proc_return`` and the CFG block
+        # walker also refresh ``_current_source_range`` for
+        # terminator and ``startCommand`` emissions that happen
+        # outside this path.
         if hasattr(stmt, "range"):
             self._current_source_line = stmt.range.start.line + 1
             self._current_source_range = stmt.range

--- a/core/compiler/codegen/_types.py
+++ b/core/compiler/codegen/_types.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from .opcodes import _OP_INFO, Op
+
+if TYPE_CHECKING:
+    from ...analysis.semantic_model import Range
 
 
 @dataclass(slots=True)
@@ -19,6 +23,7 @@ class Instruction:
     no_fold: bool = False  # prevent push-pop folding (jump target result)
     source_line: int = 0  # 1-based line within compilation unit (for errorInfo)
     source_cmd_text: str = ""  # original command text (pre-substitution) for errorInfo
+    source_range: Range | None = None  # full source range of the originating statement
 
     @property
     def size(self) -> int:

--- a/core/compiler/codegen/format.py
+++ b/core/compiler/codegen/format.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from .opcodes import _INDEX_END, _JUMP_OPS, _LVT_OPS, _STR_CLASS_NAMES, Op
 
 if TYPE_CHECKING:
-    from ...analysis.semantic_model import Range
     from ._types import FunctionAsm
 
 
@@ -152,20 +151,11 @@ def format_module_asm(module) -> str:
     return "\n".join(parts)
 
 
-# Structured explorer view
-
-
-def _range_to_explorer_dict(rng: "Range | None") -> dict | None:
-    if rng is None:
-        return None
-    return {
-        "startLine": rng.start.line,
-        "startCol": rng.start.character,
-        "startOffset": rng.start.offset,
-        "endLine": rng.end.line,
-        "endCol": rng.end.character,
-        "endOffset": rng.end.offset,
-    }
+# Structured explorer view.  ``_range_to_explorer_dict`` is defined
+# once in ``wasm/_ir.py`` and re-used here so the ASM and WASM
+# explorer payloads stay in lockstep — any future change to the range
+# wire format lands in a single spot.
+from .wasm._ir import _range_to_explorer_dict  # noqa: E402
 
 
 def format_function_explorer(asm: FunctionAsm, *, func_name: str | None = None) -> dict:
@@ -401,12 +391,20 @@ def format_function_explorer(asm: FunctionAsm, *, func_name: str | None = None) 
 
 
 def format_module_explorer(module) -> list[dict]:
-    """Structured explorer view for a whole ModuleAsm."""
+    """Structured explorer view for a whole ModuleAsm.
+
+    Preserves ``module.procedures`` declaration order — the WASM
+    explorer (:meth:`WasmModule.to_explorer_json`) emits entries in
+    declaration order too, so the ASM and WASM tabs line up in the
+    same order for side-by-side comparison.  The legacy plain-text
+    ``format_module_asm`` still sorts alphabetically because it
+    mirrors ``tcl::unsupported::disassemble`` output.
+    """
     entries: list[dict] = []
     entries.append(format_function_explorer(module.top_level))
     # Ensure ``::top`` is tagged as such even when callers pass the
     # top-level in via a synthetic name.
     entries[0]["kind"] = "top"
-    for name in sorted(module.procedures):
-        entries.append(format_function_explorer(module.procedures[name], func_name=name))
+    for name, proc_asm in module.procedures.items():
+        entries.append(format_function_explorer(proc_asm, func_name=name))
     return entries

--- a/core/compiler/codegen/format.py
+++ b/core/compiler/codegen/format.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .opcodes import _INDEX_END, _JUMP_OPS, _LVT_OPS, _STR_CLASS_NAMES, Op
+
+if TYPE_CHECKING:
+    from ...analysis.semantic_model import Range
+    from ._types import FunctionAsm
 
 
 def _esc(text: str, limit: int = 40) -> str:
@@ -144,3 +150,263 @@ def format_module_asm(module) -> str:
         parts.append("")
         parts.append(format_function_asm(module.procedures[name]))
     return "\n".join(parts)
+
+
+# Structured explorer view
+
+
+def _range_to_explorer_dict(rng: "Range | None") -> dict | None:
+    if rng is None:
+        return None
+    return {
+        "startLine": rng.start.line,
+        "startCol": rng.start.character,
+        "startOffset": rng.start.offset,
+        "endLine": rng.end.line,
+        "endCol": rng.end.character,
+        "endOffset": rng.end.offset,
+    }
+
+
+def format_function_explorer(asm: FunctionAsm, *, func_name: str | None = None) -> dict:
+    """Structured per-instruction explorer view for one FunctionAsm.
+
+    Mirrors the shape produced by ``WasmModule.to_explorer_json()`` so
+    the frontend renderer can reuse the same DOM structure and
+    interaction wiring.  Each instruction carries:
+
+    - resolved jump targets (``jumpTarget.targetIdx`` is the index of
+      the matching label's defining instruction),
+    - the literal / LVT / immediate operand decoded as text
+      (``operandText``),
+    - the source range of the originating Tcl statement
+      (``range``) for click-to-source, and
+    - the label attached to its offset (``blockLabel``) so label rows
+      render as named anchors in the UI.
+
+    Labels not bound to any instruction (end-of-block labels that land
+    on the byte just past the last instruction) are emitted as
+    synthetic ``label`` rows at the tail of the instruction list so
+    forward-jumps to "after the last op" still have a visible anchor
+    for the UI to point the arrow at.
+    """
+    name = func_name or asm.name
+    instructions = asm.instructions
+
+    # Build offset → instruction index map and offset → labels[] map.
+    offset_to_idx: dict[int, int] = {
+        instr.offset: i for i, instr in enumerate(instructions) if instr.offset >= 0
+    }
+    # End-of-function byte offset so a label pointing past the last
+    # instruction still resolves to a synthetic tail anchor.
+    end_offset = 0
+    if instructions:
+        last = instructions[-1]
+        end_offset = last.offset + last.size
+
+    # Labels keyed by offset (preserving emission order).
+    off2labels: dict[int, list[str]] = {}
+    for label, off in asm.labels.items():
+        off2labels.setdefault(off, []).append(label)
+
+    def _resolve_label(label: str) -> tuple[int | None, int | None]:
+        """Return (idx, offset) for a label.  idx is None when the
+        label points past the last real instruction (end-of-proc
+        synthetic anchor, rendered at the tail)."""
+        if label not in asm.labels:
+            return None, None
+        off = asm.labels[label]
+        if off in offset_to_idx:
+            return offset_to_idx[off], off
+        return None, off
+
+    result_instructions: list[dict] = []
+
+    for i, instr in enumerate(instructions):
+        # Emit label-row markers for every label bound to this offset.
+        for lbl in off2labels.get(instr.offset, ()):
+            result_instructions.append(
+                {
+                    "idx": len(result_instructions),
+                    "kind": "label",
+                    "label": lbl,
+                    "targetIdx": i,  # first instr at that offset
+                    "offset": instr.offset,
+                }
+            )
+
+        # Decode operand text the same way format_function_asm does so
+        # the frontend can render consistent text.  The key difference:
+        # we also populate a structured ``jumpTarget`` when the op's
+        # operand is a label ref.
+        parts: list[str] = []
+        jump_target = None
+        lvt_ref = None
+        for j, operand in enumerate(instr.operands):
+            if isinstance(operand, str) and instr.op in _JUMP_OPS:
+                tgt_off = asm.labels.get(operand, 0)
+                rel = tgt_off - instr.offset
+                parts.append(f"+{rel}" if rel >= 0 else str(rel))
+                tgt_idx, _ = _resolve_label(operand)
+                jump_target = {
+                    "label": operand,
+                    "offset": tgt_off,
+                    "targetIdx": tgt_idx,
+                    "relative": rel,
+                }
+            elif isinstance(operand, str) and instr.op == Op.START_CMD and j == 0:
+                tgt_off = asm.labels.get(operand, 0)
+                rel = tgt_off - instr.offset
+                parts.append(f"+{rel}" if rel >= 0 else str(rel))
+                tgt_idx, _ = _resolve_label(operand)
+                jump_target = {
+                    "label": operand,
+                    "offset": tgt_off,
+                    "targetIdx": tgt_idx,
+                    "relative": rel,
+                    "kind": "start_cmd_end",
+                }
+            elif isinstance(operand, str):
+                tgt_off = asm.labels.get(operand, 0)
+                parts.append(f"pc {tgt_off}")
+            elif instr.op in _LVT_OPS and j == 0:
+                parts.append(f"%v{operand}")
+                lvt_ref = int(operand)
+            elif instr.op in (Op.DICT_SET, Op.DICT_UNSET, Op.DICT_INCR_IMM) and j == 1:
+                parts.append(f"%v{operand}")
+                lvt_ref = int(operand)
+            elif instr.op in (
+                Op.INCR_SCALAR1_IMM,
+                Op.INCR_STK_IMM,
+                Op.INCR_ARRAY_STK_IMM,
+                Op.DICT_INCR_IMM,
+                Op.STR_MATCH,
+                Op.REGEXP,
+            ):
+                parts.append(f"+{operand}" if operand >= 0 else str(operand))
+            elif instr.op in (Op.RETURN_IMM, Op.SYNTAX) and j == 0:
+                parts.append(f"+{operand}" if operand >= 0 else str(operand))
+            elif instr.op == Op.STR_CLASS and isinstance(operand, int):
+                parts.append(_STR_CLASS_NAMES.get(operand, str(operand)))
+            elif (
+                instr.op in (Op.LIST_INDEX_IMM, Op.LIST_RANGE_IMM, Op.STR_RANGE_IMM)
+                and isinstance(operand, int)
+                and operand <= _INDEX_END
+            ):
+                if operand == _INDEX_END:
+                    parts.append("end")
+                else:
+                    parts.append(f"end{operand - _INDEX_END}")
+            else:
+                parts.append(str(operand))
+
+        operand_text = " ".join(parts)
+
+        # JumpTable entries list (pattern → label → target index).
+        jump_table_entries: list[dict] | None = None
+        if instr.op == Op.JUMP_TABLE and instr.jump_table:
+            jump_table_entries = []
+            for pattern, label in instr.jump_table.items():
+                tgt_off = asm.labels.get(label, 0)
+                tgt_idx, _ = _resolve_label(label)
+                jump_table_entries.append(
+                    {
+                        "pattern": pattern,
+                        "label": label,
+                        "offset": tgt_off,
+                        "targetIdx": tgt_idx,
+                    }
+                )
+
+        result_instructions.append(
+            {
+                "idx": len(result_instructions),
+                "kind": "instr",
+                "seq": i,  # emission order (not line number)
+                "op": instr.mnemonic,
+                "operandText": operand_text,
+                "fullText": f"{instr.mnemonic} {operand_text}".rstrip(),
+                "offset": instr.offset,
+                "size": instr.size,
+                "range": _range_to_explorer_dict(instr.source_range),
+                "sourceLine": instr.source_line,
+                "comment": instr.comment,
+                "jumpTarget": jump_target,
+                "jumpTable": jump_table_entries,
+                "lvtRef": lvt_ref,
+            }
+        )
+
+    # Synthetic tail label rows for labels pointing past the last real
+    # instruction (end-of-proc anchor for forward jumps).  De-dup
+    # against labels we already placed inline.
+    placed_labels = {lbl for lbls in off2labels.values() for lbl in lbls}
+    tail_labels: list[str] = sorted(
+        lbl for lbl, off in asm.labels.items() if lbl not in placed_labels and off >= end_offset
+    )
+    for lbl in tail_labels:
+        off = asm.labels[lbl]
+        idx = len(result_instructions)
+        result_instructions.append(
+            {
+                "idx": idx,
+                "kind": "label",
+                "label": lbl,
+                "targetIdx": idx,  # points at itself
+                "offset": off,
+            }
+        )
+
+    # Resolve jumpTarget.targetIdx from asm.instructions-index to
+    # result_instructions-index so the UI can cross-link directly.
+    # Prefer pointing to the label row (if one exists at the target
+    # offset) rather than the first instruction at that offset — the
+    # label row IS the visible anchor the arrow should point to.
+    label_row_by_name: dict[str, int] = {
+        row["label"]: row["idx"] for row in result_instructions if row["kind"] == "label"
+    }
+    asm_idx_to_result_idx: dict[int, int] = {}
+    for row in result_instructions:
+        if row["kind"] == "instr":
+            asm_idx_to_result_idx[row["seq"]] = row["idx"]
+
+    def _retarget(tgt: dict) -> None:
+        lbl = tgt.get("label")
+        if lbl and lbl in label_row_by_name:
+            tgt["targetIdx"] = label_row_by_name[lbl]
+            return
+        old = tgt.get("targetIdx")
+        if old is not None and old in asm_idx_to_result_idx:
+            tgt["targetIdx"] = asm_idx_to_result_idx[old]
+
+    for row in result_instructions:
+        if row["kind"] != "instr":
+            continue
+        jt = row.get("jumpTarget")
+        if jt:
+            _retarget(jt)
+        for entry in row.get("jumpTable") or []:
+            _retarget(entry)
+
+    return {
+        "name": name,
+        "kind": "proc" if func_name else "top",
+        "instrCount": len(instructions),
+        "byteCount": sum(i.size for i in instructions),
+        "literals": list(asm.literals.entries()),
+        "locals": list(asm.lvt.entries()),
+        "instructions": result_instructions,
+        "text": format_function_asm(asm),
+    }
+
+
+def format_module_explorer(module) -> list[dict]:
+    """Structured explorer view for a whole ModuleAsm."""
+    entries: list[dict] = []
+    entries.append(format_function_explorer(module.top_level))
+    # Ensure ``::top`` is tagged as such even when callers pass the
+    # top-level in via a synthetic name.
+    entries[0]["kind"] = "top"
+    for name in sorted(module.procedures):
+        entries.append(format_function_explorer(module.procedures[name], func_name=name))
+    return entries

--- a/core/compiler/codegen/wasm/__init__.py
+++ b/core/compiler/codegen/wasm/__init__.py
@@ -344,6 +344,16 @@ def wasm_codegen_module(
 
     # Phase 4: Compile top-level with shared state
     top_escape = escape_summaries.get("::top") if escape_summaries is not None else None
+    # Cover the whole file for the ``::top`` pseudo-proc so a click on
+    # any top-level instruction resolves to somewhere inside the script.
+    top_range: Range | None
+    top_stmts = ir_module.top_level.statements
+    if top_stmts:
+        first = getattr(top_stmts[0], "range", None)
+        last = getattr(top_stmts[-1], "range", None)
+        top_range = Range(start=first.start, end=last.end) if first and last else None
+    else:
+        top_range = None
     emitter = _WasmEmitter(
         cfg_module.top_level,
         optimise=optimise,
@@ -371,6 +381,8 @@ def wasm_codegen_module(
     emitter.set_compiled_proc_registrations(ir_module)
     top_func = emitter.generate()
     top_func.name = "::top"
+    top_func.kind = "top"
+    top_func.source_range = top_range
     module.functions.append(top_func)
     # ::top occupies the first function index after imports.
     if diag_map is not None:
@@ -398,6 +410,16 @@ def wasm_codegen_module(
         )
         callable_func = callable_emitter.generate()
         callable_func.name = qname
+        # Stamp the callable's original source range so clicking a
+        # ``call N`` in the explorer jumps to the proc's definition.
+        ir_proc = ir_module.procedures.get(qname)
+        if ir_proc is not None:
+            callable_func.source_range = ir_proc.range
+            callable_func.kind = "proc"
+        elif ir_module.methods and qname in ir_module.methods:
+            ir_method = ir_module.methods[qname]
+            callable_func.source_range = ir_method.range
+            callable_func.kind = "method"
         module.functions.append(callable_func)
         # Record the proc's WASM function index so the sidecar can
         # resolve ``<wasm function N>`` backtraces to proc names.

--- a/core/compiler/codegen/wasm/_emitter.py
+++ b/core/compiler/codegen/wasm/_emitter.py
@@ -315,6 +315,13 @@ class _WasmEmitter:
         self._current_command: str = ""
         self._current_args: tuple[str, ...] = ()
 
+        # Label queued for the next instruction emitted.  Consumed once
+        # by ``_emit``; used by the structured-control-flow helpers to
+        # annotate ``block`` / ``loop`` / ``if`` opens with the Tcl
+        # command that produced them (``foreach`` / ``while`` /
+        # ``if`` / ``switch`` / ``catch``) for the compiler explorer.
+        self._pending_label: str | None = None
+
         # Per-proc var-escape summary.  When provided, _iter_sync_locals
         # uses it to skip variables the analysis proved cannot be seen by
         # name from the interpreter — trimming the frame-sync set below
@@ -1212,12 +1219,36 @@ class _WasmEmitter:
         self._string_index[value] = offset
         return offset
 
-    def _emit(self, op: int, operands: bytes = b"") -> None:
+    def _emit(self, op: int, operands: bytes = b"", *, label: str | None = None) -> None:
         if op in (WasmOp.BLOCK, WasmOp.LOOP, WasmOp.IF):
             self._ctrl_depth += 1
         elif op == WasmOp.END:
             self._ctrl_depth -= 1
-        self._body.append(WasmInstruction(op=op, operands=operands))
+        # Prefer an explicit label when a caller provides one; otherwise
+        # fall back to a pending label set with ``_set_pending_label``
+        # (consumed exactly once, by the next instruction emitted).
+        effective_label = label if label is not None else self._pending_label
+        self._pending_label = None
+        self._body.append(
+            WasmInstruction(
+                op=op,
+                operands=operands,
+                range=self._current_range,
+                label=effective_label,
+            )
+        )
+
+    def _set_pending_label(self, label: str) -> None:
+        """Attach a label to the *next* instruction emitted.
+
+        Lets callers that don't go through ``_emit`` directly (mostly
+        the structured-control-flow helpers that call ``_emit_block`` /
+        ``_emit_loop`` / ``_emit_if``) still tag the opening
+        instruction with a human-readable kind.  The pending label is
+        cleared when ``_emit`` fires, so a second call with no emission
+        in between does not leak.
+        """
+        self._pending_label = label
 
     def _emit_i64_const(self, value: int) -> None:
         self._emit(WasmOp.I64_CONST, _leb128_signed(value))
@@ -5272,7 +5303,11 @@ class _WasmEmitter:
             self._emit_expr(clause.condition)
             self._emit_i64_const(0)
             self._emit(WasmOp.I64_NE)
-            self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+            self._emit(
+                WasmOp.IF,
+                bytes([_BLOCK_VOID]),
+                label="if" if i == 0 else "elseif",
+            )
             self._emit_script(clause.body)
 
             is_last = i == len(clauses) - 1
@@ -5299,8 +5334,8 @@ class _WasmEmitter:
         # Structure: block{ loop{ <cond>; block{ <body> }; <next>; br 0 } }
         # continue → br to inner block end (skips rest of body, runs next)
         # break → br to outer block (exits loop entirely)
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))  # break target
-        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]))  # loop restart
+        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]), label="for break")  # break target
+        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]), label="for")  # loop restart
 
         self._emit_expr(condition)
         self._emit_i64_const(0)
@@ -5325,8 +5360,8 @@ class _WasmEmitter:
         """Emit a while loop."""
         # For while, continue just restarts from the condition.
         # Structure: block{ loop{ <cond>; block{ <body> }; br 0 } }
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))
-        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]))
+        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]), label="while break")
+        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]), label="while")
 
         self._emit_expr(condition)
         self._emit_i64_const(0)
@@ -5394,8 +5429,8 @@ class _WasmEmitter:
         self._emit_i64_const(0)
         self._emit_local_set(counter)
 
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))
-        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]))
+        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]), label="foreach break")
+        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]), label="foreach")
 
         # if counter >= limit, break
         self._emit_local_get(counter)
@@ -5483,7 +5518,11 @@ class _WasmEmitter:
                 # string_equal/string_match returns TclObj wrapping 0 or 1
                 self._emit_unbox_int()
                 self._emit(WasmOp.I32_WRAP_I64)
-                self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+                self._emit(
+                    WasmOp.IF,
+                    bytes([_BLOCK_VOID]),
+                    label=f"switch arm {arm.pattern!r}",
+                )
                 self._emit_script(arm.body)
                 if i < arm_count - 1 or default_body:
                     self._emit(WasmOp.ELSE)
@@ -5509,7 +5548,11 @@ class _WasmEmitter:
                 self._emit_local_get(subject_local)
                 self._emit_literal(arm.pattern)
                 self._emit(WasmOp.I64_EQ)
-                self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+                self._emit(
+                    WasmOp.IF,
+                    bytes([_BLOCK_VOID]),
+                    label=f"switch arm {arm.pattern!r}",
+                )
                 self._emit_script(arm.body)
                 if i < arm_count - 1 or default_body:
                     self._emit(WasmOp.ELSE)
@@ -5567,7 +5610,7 @@ class _WasmEmitter:
             and len(body.statements) > 0
         )
         self._catch_depth += 1
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))
+        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]), label="catch body")
         stmts = body.statements
         for i, stmt in enumerate(stmts):
             is_last = capture_last and (i == len(stmts) - 1)
@@ -5805,8 +5848,12 @@ class _WasmEmitter:
                 and self._body[i + 1].op == WasmOp.I64_MUL
             ):
                 # Drop the value on stack, push 0
-                optimised.append(WasmInstruction(op=WasmOp.DROP))
-                optimised.append(WasmInstruction(op=WasmOp.I64_CONST, operands=_leb128_signed(0)))
+                optimised.append(WasmInstruction(op=WasmOp.DROP, range=instr.range))
+                optimised.append(
+                    WasmInstruction(
+                        op=WasmOp.I64_CONST, operands=_leb128_signed(0), range=instr.range
+                    )
+                )
                 i += 2
                 continue
 
@@ -5817,7 +5864,9 @@ class _WasmEmitter:
                 and self._body[i + 1].op == WasmOp.LOCAL_GET
                 and instr.operands == self._body[i + 1].operands
             ):
-                optimised.append(WasmInstruction(op=WasmOp.LOCAL_TEE, operands=instr.operands))
+                optimised.append(
+                    WasmInstruction(op=WasmOp.LOCAL_TEE, operands=instr.operands, range=instr.range)
+                )
                 i += 2
                 continue
 
@@ -5991,9 +6040,10 @@ class _WasmEmitter:
         self._active_loop_headers.add(header)
 
         step_block = self._find_step_block(body_start, header)
+        loop_label = "for" if step_block is not None else "while"
 
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))
-        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]))
+        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]), label=f"{loop_label} break")
+        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]), label=loop_label)
 
         # Evaluate loop condition — break if false
         self._emit_expr(condition)
@@ -6002,7 +6052,11 @@ class _WasmEmitter:
         self._emit_br_if(1)  # break out of block
 
         # Wrap body in a block for break/continue support
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))  # continue target
+        self._emit(
+            WasmOp.BLOCK,
+            bytes([_BLOCK_VOID]),
+            label=f"{loop_label} continue",
+        )  # continue target
         self._loop_depth += 1
         self._loop_ctrl_depths.append(self._ctrl_depth)
 
@@ -6204,8 +6258,8 @@ class _WasmEmitter:
         self._emit_i64_const(0)
         self._emit_local_set(counter)
 
-        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]))
-        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]))
+        self._emit(WasmOp.BLOCK, bytes([_BLOCK_VOID]), label="foreach break")
+        self._emit(WasmOp.LOOP, bytes([_BLOCK_VOID]), label="foreach")
 
         # if counter >= limit, break
         self._emit_local_get(counter)
@@ -6388,6 +6442,16 @@ class _WasmEmitter:
         for stmt in stmts:
             self._emit_stmt(stmt)
 
+        # Stamp the terminator's source range onto instructions emitted
+        # below so the explorer can click-through from the ``return`` /
+        # branch / goto opcode to the originating Tcl construct.  The
+        # range is optional on each terminator kind; we leave
+        # ``_current_range`` untouched when missing so we fall back to
+        # whatever the last ``_emit_stmt`` recorded.
+        term_range = getattr(block.terminator, "range", None)
+        if term_range is not None:
+            self._current_range = term_range
+
         match block.terminator:
             case CFGReturn(value=value):
                 if value is not None:
@@ -6422,7 +6486,7 @@ class _WasmEmitter:
                 self._emit_expr(condition)
                 self._emit_i64_const(0)
                 self._emit(WasmOp.I64_NE)
-                self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+                self._emit(WasmOp.IF, bytes([_BLOCK_VOID]), label="if")
                 self._emit_block(tt)
                 self._emit(WasmOp.ELSE)
                 self._emit_block(ft)
@@ -6558,6 +6622,7 @@ class _WasmEmitter:
             body=self._body,
             local_names=[f"${n}" for n in self._local_names],
             exported=True,
+            kind="proc" if self._is_proc else "top",
         )
 
     @property

--- a/core/compiler/codegen/wasm/_emitter.py
+++ b/core/compiler/codegen/wasm/_emitter.py
@@ -315,13 +315,6 @@ class _WasmEmitter:
         self._current_command: str = ""
         self._current_args: tuple[str, ...] = ()
 
-        # Label queued for the next instruction emitted.  Consumed once
-        # by ``_emit``; used by the structured-control-flow helpers to
-        # annotate ``block`` / ``loop`` / ``if`` opens with the Tcl
-        # command that produced them (``foreach`` / ``while`` /
-        # ``if`` / ``switch`` / ``catch``) for the compiler explorer.
-        self._pending_label: str | None = None
-
         # Per-proc var-escape summary.  When provided, _iter_sync_locals
         # uses it to skip variables the analysis proved cannot be seen by
         # name from the interpreter — trimming the frame-sync set below
@@ -1224,31 +1217,14 @@ class _WasmEmitter:
             self._ctrl_depth += 1
         elif op == WasmOp.END:
             self._ctrl_depth -= 1
-        # Prefer an explicit label when a caller provides one; otherwise
-        # fall back to a pending label set with ``_set_pending_label``
-        # (consumed exactly once, by the next instruction emitted).
-        effective_label = label if label is not None else self._pending_label
-        self._pending_label = None
         self._body.append(
             WasmInstruction(
                 op=op,
                 operands=operands,
                 range=self._current_range,
-                label=effective_label,
+                label=label,
             )
         )
-
-    def _set_pending_label(self, label: str) -> None:
-        """Attach a label to the *next* instruction emitted.
-
-        Lets callers that don't go through ``_emit`` directly (mostly
-        the structured-control-flow helpers that call ``_emit_block`` /
-        ``_emit_loop`` / ``_emit_if``) still tag the opening
-        instruction with a human-readable kind.  The pending label is
-        cleared when ``_emit`` fires, so a second call with no emission
-        in between does not leak.
-        """
-        self._pending_label = label
 
     def _emit_i64_const(self, value: int) -> None:
         self._emit(WasmOp.I64_CONST, _leb128_signed(value))

--- a/core/compiler/codegen/wasm/_ir.py
+++ b/core/compiler/codegen/wasm/_ir.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import struct
 from dataclasses import dataclass, field
 from enum import IntEnum
+from typing import TYPE_CHECKING
 
 from ._encoding import (
     _encode_string,
@@ -23,6 +24,9 @@ from ._encoding import (
     _leb128_signed,
     _leb128_unsigned,
 )
+
+if TYPE_CHECKING:
+    from ....analysis.semantic_model import Range
 
 # WASM type constants
 
@@ -138,10 +142,24 @@ _BLOCK_I64 = ValType.I64
 
 @dataclass(slots=True)
 class WasmInstruction:
-    """A single WASM instruction with optional operands."""
+    """A single WASM instruction with optional operands.
+
+    ``range`` captures the source range of the originating Tcl statement
+    (when the instruction was emitted from inside ``_emit_stmt``) so the
+    compiler explorer can offer click-to-source navigation and render
+    per-statement comments above each instruction group.  ``label`` is a
+    free-form hint set by callers that want to attach a human-readable
+    tag to a structural instruction — for example the emitter tags
+    ``block``/``loop``/``if`` opens with the Tcl command that produced
+    them (``foreach`` / ``while`` / ``if``).  Both fields are ignored by
+    the binary encoder and WAT formatter; only the explorer view
+    consumes them.
+    """
 
     op: int
     operands: bytes = b""
+    range: Range | None = None
+    label: str | None = None
 
     def encode(self) -> bytes:
         return bytes([self.op]) + self.operands
@@ -149,7 +167,14 @@ class WasmInstruction:
 
 @dataclass(slots=True)
 class WasmFunction:
-    """Compiled WASM function."""
+    """Compiled WASM function.
+
+    ``source_range`` records the proc's original source range (from
+    :class:`~core.compiler.ir.IRProcedure`) so the explorer can place
+    the cursor inside the proc body when the user clicks on a call
+    target that resolves to this function.  ``kind`` distinguishes the
+    synthetic ``::top`` wrapper from real Tcl procs and methods.
+    """
 
     name: str
     params: list[ValType]
@@ -158,6 +183,8 @@ class WasmFunction:
     body: list[WasmInstruction]
     local_names: list[str] = field(default_factory=list)
     exported: bool = False
+    source_range: Range | None = None
+    kind: str = "proc"  # "top" | "proc" | "method"
 
     def encode_body(self) -> bytes:
         """Encode function body (locals + instructions + end)."""
@@ -391,6 +418,102 @@ class WasmModule:
 
         return _WASM_MAGIC + _WASM_VERSION + b"".join(sections)
 
+    def to_explorer_json(self) -> list[dict]:
+        """Structured per-instruction view for the compiler explorer.
+
+        Returns a list of function entries (one per function in the
+        module; the synthetic ``(module)`` entry carries types, imports
+        and data).  Each function entry carries its instruction list
+        with:
+
+        - resolved ``call`` target names (imports and internal
+          functions),
+        - resolved ``br`` / ``br_if`` targets (opening/closing of the
+          enclosing structured-control-flow construct),
+        - a ``range`` dict of the originating Tcl statement (when
+          available), for click-to-source navigation, and
+        - any explorer label attached by the emitter
+          (``"foreach"``, ``"if"``, ``"catch body"``, …).
+
+        The shape matches what ``explorer/serialise.py`` ships to the
+        frontend.  Indices into the returned instruction list are
+        stable, so the UI can cross-link a branch instruction to its
+        matching block/loop/if open/close.
+        """
+        # Indices: imports occupy 0..N-1, defined functions follow.
+        num_imports = len(self.imports)
+
+        def _func_label(idx: int) -> dict:
+            if idx < num_imports:
+                imp = self.imports[idx]
+                return {
+                    "kind": "import",
+                    "name": imp.name,
+                    "module": imp.module,
+                    "funcIdx": idx,
+                    "defIdx": None,
+                }
+            def_idx = idx - num_imports
+            if 0 <= def_idx < len(self.functions):
+                f = self.functions[def_idx]
+                return {
+                    "kind": "top" if f.kind == "top" else f.kind,
+                    "name": f.name,
+                    "module": None,
+                    "funcIdx": idx,
+                    "defIdx": def_idx,
+                }
+            return {
+                "kind": "unknown",
+                "name": f"<func {idx}>",
+                "module": None,
+                "funcIdx": idx,
+                "defIdx": None,
+            }
+
+        module_header = {
+            "name": "(module)",
+            "kind": "module",
+            "funcIdx": None,
+            "params": [],
+            "results": [],
+            "locals": [],
+            "sourceRange": None,
+            "instrCount": 0,
+            "instructions": [],
+            "imports": [
+                {
+                    "module": imp.module,
+                    "name": imp.name,
+                    "typeIdx": imp.type_idx,
+                    "funcIdx": i,
+                }
+                for i, imp in enumerate(self.imports)
+            ],
+            "types": [
+                {
+                    "index": i,
+                    "params": [_valtype_name(p) for p in params],
+                    "results": [_valtype_name(r) for r in results],
+                }
+                for i, (params, results) in enumerate(self._types)
+            ],
+            "dataSegments": [
+                {"offset": seg.offset, "size": len(seg.data)} for seg in self.data_segments
+            ],
+        }
+
+        entries: list[dict] = [module_header]
+        for def_idx, func in enumerate(self.functions):
+            entries.append(
+                _function_to_explorer_json(
+                    func,
+                    func_idx=num_imports + def_idx,
+                    resolve_func=_func_label,
+                )
+            )
+        return entries
+
     def to_wat(self) -> str:
         """Generate a human-readable WAT (WebAssembly Text) representation."""
         lines: list[str] = ["(module"]
@@ -473,79 +596,80 @@ def _valtype_name(vt: ValType | int) -> str:
     return names.get(ValType(vt), f"unknown({vt})")
 
 
+_WAT_NAMES: dict[int, str] = {
+    WasmOp.UNREACHABLE: "unreachable",
+    WasmOp.NOP: "nop",
+    WasmOp.BLOCK: "block",
+    WasmOp.LOOP: "loop",
+    WasmOp.IF: "if",
+    WasmOp.ELSE: "else",
+    WasmOp.END: "end",
+    WasmOp.BR: "br",
+    WasmOp.BR_IF: "br_if",
+    WasmOp.BR_TABLE: "br_table",
+    WasmOp.RETURN: "return",
+    WasmOp.CALL: "call",
+    WasmOp.DROP: "drop",
+    WasmOp.SELECT: "select",
+    WasmOp.LOCAL_GET: "local.get",
+    WasmOp.LOCAL_SET: "local.set",
+    WasmOp.LOCAL_TEE: "local.tee",
+    WasmOp.GLOBAL_GET: "global.get",
+    WasmOp.GLOBAL_SET: "global.set",
+    WasmOp.I32_CONST: "i32.const",
+    WasmOp.I64_CONST: "i64.const",
+    WasmOp.F64_CONST: "f64.const",
+    WasmOp.I32_EQZ: "i32.eqz",
+    WasmOp.I32_EQ: "i32.eq",
+    WasmOp.I32_NE: "i32.ne",
+    WasmOp.I32_LT_S: "i32.lt_s",
+    WasmOp.I32_GT_S: "i32.gt_s",
+    WasmOp.I32_LE_S: "i32.le_s",
+    WasmOp.I32_GE_S: "i32.ge_s",
+    WasmOp.I64_EQZ: "i64.eqz",
+    WasmOp.I64_EQ: "i64.eq",
+    WasmOp.I64_NE: "i64.ne",
+    WasmOp.I64_LT_S: "i64.lt_s",
+    WasmOp.I64_GT_S: "i64.gt_s",
+    WasmOp.I64_LE_S: "i64.le_s",
+    WasmOp.I64_GE_S: "i64.ge_s",
+    WasmOp.I32_ADD: "i32.add",
+    WasmOp.I32_SUB: "i32.sub",
+    WasmOp.I32_MUL: "i32.mul",
+    WasmOp.I32_DIV_S: "i32.div_s",
+    WasmOp.I32_REM_S: "i32.rem_s",
+    WasmOp.I32_AND: "i32.and",
+    WasmOp.I32_OR: "i32.or",
+    WasmOp.I32_XOR: "i32.xor",
+    WasmOp.I32_SHL: "i32.shl",
+    WasmOp.I32_SHR_S: "i32.shr_s",
+    WasmOp.I64_ADD: "i64.add",
+    WasmOp.I64_SUB: "i64.sub",
+    WasmOp.I64_MUL: "i64.mul",
+    WasmOp.I64_DIV_S: "i64.div_s",
+    WasmOp.I64_REM_S: "i64.rem_s",
+    WasmOp.I64_AND: "i64.and",
+    WasmOp.I64_OR: "i64.or",
+    WasmOp.I64_XOR: "i64.xor",
+    WasmOp.I64_SHL: "i64.shl",
+    WasmOp.I64_SHR_S: "i64.shr_s",
+    WasmOp.I32_WRAP_I64: "i32.wrap_i64",
+    WasmOp.I64_EXTEND_I32_S: "i64.extend_i32_s",
+    WasmOp.I32_STORE: "i32.store",
+    WasmOp.I64_STORE: "i64.store",
+    WasmOp.I32_LOAD: "i32.load",
+    WasmOp.I64_LOAD: "i64.load",
+    WasmOp.MEMORY_SIZE: "memory.size",
+    WasmOp.MEMORY_GROW: "memory.grow",
+}
+
+
 def _format_wat_instr(instr: WasmInstruction, indent: int) -> str | None:
     """Format a single instruction for WAT output."""
     prefix = "    " * indent
     op = instr.op
 
-    wat_names: dict[int, str] = {
-        WasmOp.UNREACHABLE: "unreachable",
-        WasmOp.NOP: "nop",
-        WasmOp.BLOCK: "block",
-        WasmOp.LOOP: "loop",
-        WasmOp.IF: "if",
-        WasmOp.ELSE: "else",
-        WasmOp.END: "end",
-        WasmOp.BR: "br",
-        WasmOp.BR_IF: "br_if",
-        WasmOp.BR_TABLE: "br_table",
-        WasmOp.RETURN: "return",
-        WasmOp.CALL: "call",
-        WasmOp.DROP: "drop",
-        WasmOp.SELECT: "select",
-        WasmOp.LOCAL_GET: "local.get",
-        WasmOp.LOCAL_SET: "local.set",
-        WasmOp.LOCAL_TEE: "local.tee",
-        WasmOp.GLOBAL_GET: "global.get",
-        WasmOp.GLOBAL_SET: "global.set",
-        WasmOp.I32_CONST: "i32.const",
-        WasmOp.I64_CONST: "i64.const",
-        WasmOp.F64_CONST: "f64.const",
-        WasmOp.I32_EQZ: "i32.eqz",
-        WasmOp.I32_EQ: "i32.eq",
-        WasmOp.I32_NE: "i32.ne",
-        WasmOp.I32_LT_S: "i32.lt_s",
-        WasmOp.I32_GT_S: "i32.gt_s",
-        WasmOp.I32_LE_S: "i32.le_s",
-        WasmOp.I32_GE_S: "i32.ge_s",
-        WasmOp.I64_EQZ: "i64.eqz",
-        WasmOp.I64_EQ: "i64.eq",
-        WasmOp.I64_NE: "i64.ne",
-        WasmOp.I64_LT_S: "i64.lt_s",
-        WasmOp.I64_GT_S: "i64.gt_s",
-        WasmOp.I64_LE_S: "i64.le_s",
-        WasmOp.I64_GE_S: "i64.ge_s",
-        WasmOp.I32_ADD: "i32.add",
-        WasmOp.I32_SUB: "i32.sub",
-        WasmOp.I32_MUL: "i32.mul",
-        WasmOp.I32_DIV_S: "i32.div_s",
-        WasmOp.I32_REM_S: "i32.rem_s",
-        WasmOp.I32_AND: "i32.and",
-        WasmOp.I32_OR: "i32.or",
-        WasmOp.I32_XOR: "i32.xor",
-        WasmOp.I32_SHL: "i32.shl",
-        WasmOp.I32_SHR_S: "i32.shr_s",
-        WasmOp.I64_ADD: "i64.add",
-        WasmOp.I64_SUB: "i64.sub",
-        WasmOp.I64_MUL: "i64.mul",
-        WasmOp.I64_DIV_S: "i64.div_s",
-        WasmOp.I64_REM_S: "i64.rem_s",
-        WasmOp.I64_AND: "i64.and",
-        WasmOp.I64_OR: "i64.or",
-        WasmOp.I64_XOR: "i64.xor",
-        WasmOp.I64_SHL: "i64.shl",
-        WasmOp.I64_SHR_S: "i64.shr_s",
-        WasmOp.I32_WRAP_I64: "i32.wrap_i64",
-        WasmOp.I64_EXTEND_I32_S: "i64.extend_i32_s",
-        WasmOp.I32_STORE: "i32.store",
-        WasmOp.I64_STORE: "i64.store",
-        WasmOp.I32_LOAD: "i32.load",
-        WasmOp.I64_LOAD: "i64.load",
-        WasmOp.MEMORY_SIZE: "memory.size",
-        WasmOp.MEMORY_GROW: "memory.grow",
-    }
-
-    name = wat_names.get(op)
+    name = _WAT_NAMES.get(op)
     if name is None:
         return f"{prefix};; unknown op 0x{op:02x}"
 
@@ -604,3 +728,251 @@ def _decode_leb128_signed(data: bytes) -> int:
                 result -= 1 << shift
             break
     return result
+
+
+# Explorer view helpers
+
+
+def _range_to_explorer_dict(rng: Range | None) -> dict | None:
+    """Serialise a Range for the explorer frontend."""
+    if rng is None:
+        return None
+    return {
+        "startLine": rng.start.line,
+        "startCol": rng.start.character,
+        "startOffset": rng.start.offset,
+        "endLine": rng.end.line,
+        "endCol": rng.end.character,
+        "endOffset": rng.end.offset,
+    }
+
+
+def _function_to_explorer_json(
+    func: WasmFunction,
+    *,
+    func_idx: int,
+    resolve_func,
+) -> dict:
+    """Build a structured explorer view for a single ``WasmFunction``.
+
+    Resolves each instruction's display text, its ``call`` / ``br``
+    target (when any), its indent level, and emits a stable index so
+    the UI can cross-link a branch to the control-flow construct it
+    targets.  ``resolve_func`` is a callable taking a 0-based WASM
+    function index (including imports) and returning a label dict.
+    """
+    local_names = list(func.local_names)
+    param_count = len(func.params)
+
+    def _local_label(idx: int) -> str:
+        if 0 <= idx < len(local_names):
+            return local_names[idx]
+        return f"$l{idx}"
+
+    # First pass: pair BLOCK/LOOP/IF opens with their matching END (and
+    # ELSE).  Control-stack entry: (opcode, open_idx, else_idx | None,
+    # end_idx | None, label).  Built by a single linear walk.
+    stack: list[dict] = []
+    open_info: dict[int, dict] = {}  # open_idx → info
+
+    for i, instr in enumerate(func.body):
+        if instr.op in (WasmOp.BLOCK, WasmOp.LOOP, WasmOp.IF):
+            entry = {
+                "op": instr.op,
+                "openIdx": i,
+                "elseIdx": None,
+                "endIdx": None,
+                "label": instr.label,
+            }
+            stack.append(entry)
+            open_info[i] = entry
+        elif instr.op == WasmOp.ELSE:
+            if stack:
+                stack[-1]["elseIdx"] = i
+        elif instr.op == WasmOp.END:
+            if stack:
+                entry = stack.pop()
+                entry["endIdx"] = i
+
+    # Resolve each instruction
+    instructions: list[dict] = []
+    indent = 0
+    ctrl_stack: list[dict] = []  # mirrors the open stack while walking forward
+
+    for i, instr in enumerate(func.body):
+        op = instr.op
+        mnemonic = _WAT_NAMES.get(op, f"0x{op:02x}")
+
+        # Structural tracking first so indent reflects the instruction
+        # we're about to emit rather than the one after it.
+        this_indent = indent
+        block_label = None
+        block_kind = None
+        if op in (WasmOp.BLOCK, WasmOp.LOOP, WasmOp.IF):
+            # Opens are rendered at the outer indent.  New frame pushed
+            # after we record the instruction so following body ops
+            # render one level deeper.
+            info = open_info.get(i)
+            if info is not None:
+                block_label = f"$L{i}"
+            if op == WasmOp.BLOCK:
+                block_kind = "block"
+            elif op == WasmOp.LOOP:
+                block_kind = "loop"
+            elif op == WasmOp.IF:
+                block_kind = "if"
+            ctrl_stack.append(info or {"op": op, "openIdx": i, "endIdx": None, "label": None})
+            indent += 1
+        elif op == WasmOp.ELSE:
+            # Render at one less indent (matches structured CFG style).
+            this_indent = max(0, indent - 1)
+        elif op == WasmOp.END:
+            if ctrl_stack:
+                ctrl_stack.pop()
+            indent = max(0, indent - 1)
+            this_indent = indent
+
+        # Operand decoding
+        operand_text = ""
+        full_text = mnemonic
+        call_target = None
+        branch_target = None
+        local_index: int | None = None
+
+        if op in (
+            WasmOp.LOCAL_GET,
+            WasmOp.LOCAL_SET,
+            WasmOp.LOCAL_TEE,
+        ):
+            if instr.operands:
+                idx = _decode_leb128_unsigned(instr.operands)
+                local_index = idx
+                name = _local_label(idx)
+                operand_text = str(idx)
+                full_text = (
+                    f"{mnemonic} {idx} {name}" if name != f"$l{idx}" else f"{mnemonic} {idx}"
+                )
+        elif op in (WasmOp.GLOBAL_GET, WasmOp.GLOBAL_SET):
+            if instr.operands:
+                idx = _decode_leb128_unsigned(instr.operands)
+                operand_text = str(idx)
+                full_text = f"{mnemonic} {idx}"
+        elif op == WasmOp.CALL:
+            if instr.operands:
+                idx = _decode_leb128_unsigned(instr.operands)
+                operand_text = str(idx)
+                call_target = resolve_func(idx)
+                full_text = f"{mnemonic} {idx}"
+        elif op in (WasmOp.BR, WasmOp.BR_IF):
+            if instr.operands:
+                depth = _decode_leb128_unsigned(instr.operands)
+                operand_text = str(depth)
+                full_text = f"{mnemonic} {depth}"
+                # Resolve target: depth-th from top of ctrl_stack, or
+                # the function body when depth == len(ctrl_stack).
+                if depth < len(ctrl_stack):
+                    frame = ctrl_stack[len(ctrl_stack) - 1 - depth]
+                    target_op = frame.get("op")
+                    if target_op == WasmOp.LOOP:
+                        target_idx = frame.get("openIdx")
+                        target_kind = "loop_header"
+                    else:
+                        target_idx = frame.get("endIdx")
+                        target_kind = "block_end" if target_op == WasmOp.BLOCK else "if_end"
+                    branch_target = {
+                        "depth": depth,
+                        "targetIdx": target_idx,
+                        "kind": target_kind,
+                        "label": frame.get("label"),
+                    }
+                else:
+                    branch_target = {
+                        "depth": depth,
+                        "targetIdx": None,
+                        "kind": "function_return",
+                        "label": None,
+                    }
+        elif op == WasmOp.I32_CONST:
+            if instr.operands:
+                val = _decode_leb128_signed(instr.operands)
+                operand_text = str(val)
+                full_text = f"{mnemonic} {val}"
+        elif op == WasmOp.I64_CONST:
+            if instr.operands:
+                val = _decode_leb128_signed(instr.operands)
+                operand_text = str(val)
+                full_text = f"{mnemonic} {val}"
+        elif op in (WasmOp.BLOCK, WasmOp.LOOP, WasmOp.IF):
+            if instr.operands:
+                bt = instr.operands[0]
+                if bt == _BLOCK_VOID:
+                    full_text = mnemonic
+                else:
+                    full_text = f"{mnemonic} (result {_valtype_name(bt)})"
+            else:
+                full_text = mnemonic
+
+        instructions.append(
+            {
+                "idx": i,
+                "indent": this_indent,
+                "op": mnemonic,
+                "opcode": int(op),
+                "operandText": operand_text,
+                "fullText": full_text,
+                "range": _range_to_explorer_dict(instr.range),
+                "label": instr.label,
+                "callTarget": call_target,
+                "branchTarget": branch_target,
+                "blockLabel": block_label,
+                "blockKind": block_kind,
+                "localIndex": local_index,
+            }
+        )
+
+    # Attach closing metadata onto BLOCK/LOOP/IF opens and their END
+    # counterparts so the UI can cross-link them.
+    for i, instr in enumerate(instructions):
+        op_int = instr["opcode"]
+        if op_int in (int(WasmOp.BLOCK), int(WasmOp.LOOP), int(WasmOp.IF)):
+            info = open_info.get(i)
+            if info is not None:
+                instr["endIdx"] = info["endIdx"]
+                instr["elseIdx"] = info["elseIdx"]
+        elif op_int == int(WasmOp.END):
+            # Find the matching open via open_info iteration.
+            for info in open_info.values():
+                if info["endIdx"] == i:
+                    instr["openIdx"] = info["openIdx"]
+                    instructions[info["openIdx"]].setdefault("endIdx", i)
+                    break
+        elif op_int == int(WasmOp.ELSE):
+            for info in open_info.values():
+                if info["elseIdx"] == i:
+                    instr["openIdx"] = info["openIdx"]
+                    instr["endIdx"] = info["endIdx"]
+                    break
+
+    return {
+        "name": func.name,
+        "kind": func.kind,
+        "funcIdx": func_idx,
+        "exported": func.exported,
+        "params": [
+            {"name": local_names[i] if i < len(local_names) else f"$p{i}", "type": _valtype_name(p)}
+            for i, p in enumerate(func.params)
+        ],
+        "results": [_valtype_name(r) for r in func.results],
+        "locals": [
+            {
+                "name": local_names[param_count + i]
+                if (param_count + i) < len(local_names)
+                else f"$l{i}",
+                "type": _valtype_name(lt),
+            }
+            for i, lt in enumerate(func.locals)
+        ],
+        "sourceRange": _range_to_explorer_dict(func.source_range),
+        "instrCount": len(func.body),
+        "instructions": instructions,
+    }

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -93,6 +93,9 @@ are its rules, and what are the failure modes". One contract per file.
   — VM and bytecode identity and fixture boundary guidance.
 - [vscode-extension.md](contracts/vscode-extension.md) — VS Code
   extension integration contracts.
+- [wasm-explorer-view.md](contracts/wasm-explorer-view.md) — JSON
+  shape produced by `WasmModule.to_explorer_json()` and consumed by
+  the compiler explorer disassembly panel.
 - [differential-fuzzing.md](contracts/differential-fuzzing.md) —
   differential fuzzing oracle and coverage-guided mutation contracts.
 - [pipeline-lsp-first.md](contracts/pipeline-lsp-first.md) — pipeline

--- a/docs/design/contracts/wasm-explorer-view.md
+++ b/docs/design/contracts/wasm-explorer-view.md
@@ -1,0 +1,154 @@
+# Contract: WASM explorer disassembly view
+
+## Purpose
+
+The compiler explorer renders the output of `wasm_codegen_module` as a
+per-instruction interactive disassembly.  The JSON shape that
+[`explorer/serialise.py`](../../../explorer/serialise.py) produces and
+that [`explorer/static/explorer-core.js`](../../../explorer/static/explorer-core.js)
+consumes is fixed by this contract.  Both the standalone web panel
+(`explorer/static/index.html`) and the VS Code webview
+(`editors/vscode/src/compilerExplorerHtml.ts`) read the same shape.
+
+## Producer
+
+- [`core/compiler/codegen/wasm/_ir.py`](../../../core/compiler/codegen/wasm/_ir.py)
+  — `WasmModule.to_explorer_json()` returns a list of function entries
+  (plus a synthetic module header).  Each instruction carries a decoded
+  target (`call` → function name, `br` / `br_if` → matching structural
+  open/close), a source range, an indent level, and an explorer label.
+- [`explorer/serialise.py`](../../../explorer/serialise.py) —
+  `_serialise_wasm` calls `to_explorer_json()`, attaches a WAT text
+  snippet per entry for legacy consumers, and returns the list as
+  `data.wasm` / `data.wasmOptimised`.
+
+## Module header entry
+
+The first entry in each list is always the synthetic module header.
+`instrCount` is fixed at 0 so tab badge totals (summed over entries)
+don't double-count body instructions; the real total is available as
+`totalInstrCount`.
+
+```jsonc
+{
+  "name": "(module)",
+  "kind": "module",
+  "funcIdx": null,
+  "params": [],
+  "results": [],
+  "locals": [],
+  "sourceRange": null,
+  "instrCount": 0,
+  "totalInstrCount": 32,
+  "instructions": [],
+  "imports": [
+    {"module": "tcl", "name": "tcl_obj_get_int", "typeIdx": 0, "funcIdx": 0}
+  ],
+  "types": [{"index": 0, "params": ["i32"], "results": ["i64"]}],
+  "dataSegments": [{"offset": 0, "size": 8}],
+  "text": "(module (type …) (import …) …)"
+}
+```
+
+## Function entry
+
+One entry per function in the module, in declaration order (top-level
+first, then user procs).
+
+```jsonc
+{
+  "name": "::greet",
+  "kind": "proc",            // "top" | "proc" | "method"
+  "funcIdx": 23,             // absolute WASM function index (imports + defined)
+  "exported": true,
+  "params": [{"name": "$name", "type": "i32"}],
+  "results": ["i32"],
+  "locals": [{"name": "$msg", "type": "i32"}],
+  "sourceRange": {
+    "startLine": 0, "startCol": 0, "startOffset": 0,
+    "endLine": 2, "endCol": 15, "endOffset": 58
+  },
+  "instrCount": 9,
+  "instructions": [...],
+  "text": "(func $::greet …)"
+}
+```
+
+## Instruction entry
+
+Each entry in `instructions` carries a stable `idx` — the same index
+used by `br_target.targetIdx` for cross-navigation.
+
+```jsonc
+{
+  "idx": 33,                   // stable index within the function body
+  "indent": 2,                 // control-flow nesting depth (for display)
+  "op": "br_if",               // mnemonic
+  "opcode": 13,                // raw WASM opcode
+  "operandText": "1",          // decoded operand as a string
+  "fullText": "br_if 1",       // convenience: "op operand"
+  "range": {                   // originating Tcl source range (nullable)
+    "startLine": 6, "startCol": 0, "startOffset": 87,
+    "endLine": 6, "endCol": 36, "endOffset": 123
+  },
+  "label": "foreach break",    // explorer hint on structural ops
+  "callTarget": null,          // set when op == "call"
+  "branchTarget": {            // set when op in {"br", "br_if"}
+    "depth": 1,
+    "targetIdx": 69,           // idx of the matching end/loop_header
+    "kind": "block_end",       // "block_end" | "loop_header" | "if_end"
+    "label": "foreach break"   // from the matching open's label
+  },
+  "blockLabel": null,          // "$L28" — set on block/loop/if opens
+  "blockKind": null,           // "block" | "loop" | "if" — set on opens
+  "localIndex": null           // decoded LEB128 local index on local.*
+}
+```
+
+### `callTarget` shape
+
+```jsonc
+{
+  "kind": "import",       // "import" | "top" | "proc" | "method" | "unknown"
+  "name": "tcl_list_index",
+  "module": "tcl",        // null for non-imports
+  "funcIdx": 10,          // absolute WASM function index
+  "defIdx": null          // 0-based index into WasmModule.functions, or null for imports
+}
+```
+
+The frontend looks up `defIdx` in the function-entry list to navigate
+to the matching disassembly block (and, via `sourceRange`, to the
+source).  Imports have no disassembly to jump to.
+
+### `branchTarget.kind`
+
+| Kind | Meaning |
+|------|---------|
+| `loop_header` | `br` / `br_if` back-edge to a `loop` open |
+| `block_end` | forward exit to the `end` of a `block` |
+| `if_end` | forward exit to the `end` of an `if` |
+| `function_return` | depth exceeds the structural stack (branch out of the function) |
+
+## Emitter contract
+
+`_WasmEmitter._emit` stamps `self._current_range` onto every emitted
+instruction.  `_record_stmt_context` (called at the top of
+`_emit_stmt` and at every CFG block entry via the terminator-range
+stamp) keeps that range up to date.  Callers that open a structural
+op (`block` / `loop` / `if`) may pass `label=` to `_emit` to attach a
+human-readable tag (e.g. `foreach`, `if`, `catch body`) that the
+explorer surfaces in both the open's inline label and in the target
+hint on every `br` / `br_if` that lands on its matching close.
+
+## Versioning
+
+The shape above is additive.  Consumers that don't understand a new
+field must ignore it; producers must never repurpose an existing field
+name with a different type.  When fields change meaning, rename them.
+
+## Related
+
+- [KCS: feature — Compiler Explorer](../../kcs/features/kcs-feature-compiler-explorer.md)
+- [Codegen module map](../compiler/codegen-module-map.md)
+- [WASM runtime primitives](../compiler/wasm-runtime-primitives.md)

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes.
+Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes, plus a structured WebAssembly disassembly view with click-to-source navigation, call and branch target cross-linking, control-flow arrows, and labelled structural ops.
 
 ## Applies to
 
@@ -21,6 +21,17 @@ VS Code
 ## Operational context
 
 The compiler explorer runs the full compilation pipeline (parse, lower, optimise, codegen) and displays the output at each stage. It uses a Pyodide-powered web panel for interactive exploration.
+
+### WASM disassembly view
+
+The **WASM** and **WASM (Opt)** tabs show a structured per-instruction disassembly. Each instruction carries:
+
+- The Tcl source range of the originating statement — clicking the instruction places the source cursor at the corresponding point (inside an expression, after a semicolon, or at any other nested command location).
+- A source-line comment above each group of instructions sharing the same originating statement, so the reader can trace "this command compiled to these ops".
+- A resolved target on `call N` (e.g. `call 22 ; ::greet`) — clicking the target label jumps both the disassembly and the source to the callee's definition.
+- A resolved target on `br N` / `br_if N` (e.g. `br 0 ; loop_header foreach`) — clicking the target navigates to the matching `block` / `loop` / `if` open, along with its source range.
+- A label on `block` / `loop` / `if` opens identifying the Tcl construct that produced them (`foreach`, `while`, `for`, `if`, `catch body`, `switch arm`).
+- Orthogonal control-flow arrows in the left gutter showing every branch target, with forward edges drawn solid-blue and back-edges drawn dashed-yellow.
 
 ## File-path anchors
 

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -424,14 +424,7 @@ body {
 }
 .source-line .code-text { white-space: pre; flex: 1; }
 .opt-diff-container { position: relative; padding-left: 36px; }
-.opt-diff-svg {
-  position: absolute;
-  top: 0; left: 0;
-  width: 36px; height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  overflow: visible;
-}
+.opt-diff-svg { width: 36px; }
 .opt-diff-line {
   display: flex;
   font-size: 12px;
@@ -455,8 +448,8 @@ body {
 .opt-diff-line.opt-replacement .gutter { color: var(--green); }
 .opt-diff-line.opt-input-highlight { background: rgba(137, 180, 250, 0.18) !important; opacity: 1 !important; }
 .opt-diff-line.opt-output-highlight { background: rgba(166, 227, 161, 0.18) !important; }
-.opt-bracket { fill: none; stroke: var(--text-dim); stroke-width: 1.5; opacity: 0.4; transition: opacity 0.15s, stroke 0.15s; }
-.opt-bracket.highlighted { stroke: var(--accent); opacity: 1; }
+.opt-bracket { fill: none; stroke: var(--text-dim); stroke-width: 1.5; }
+.opt-bracket.highlighted, .opt-bracket:hover { stroke: var(--accent); }
 .analysis-card {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -506,24 +499,18 @@ body {
 .status-light.dirty      { background: var(--red);    box-shadow: 0 0 6px var(--red); }
 .status-light.loading    { background: var(--text-dim); box-shadow: none; }
 .cfg-edges-container { position: relative; padding-left: 40px; }
-.cfg-edges-svg {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  overflow: visible;
-}
-.cfg-edge { fill: none; stroke-width: 1.5; opacity: 0.45; transition: opacity 0.15s, stroke-width 0.15s; }
+/* Shared orthogonal-edge SVG (see index.html for full comment). */
+.oe-svg { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 1; overflow: visible; }
+.oe-edge { fill: none; stroke-width: 1.5; opacity: 0.45; pointer-events: stroke; cursor: pointer; transition: opacity 0.15s, stroke-width 0.15s; }
+.oe-edge:hover, .oe-edge.highlighted { opacity: 1; stroke-width: 2.5; }
+.oe-endpoint-highlight { outline: 1px solid var(--accent); outline-offset: -1px; border-radius: 2px; background: rgba(137, 180, 250, 0.1); }
+.cfg-edge { fill: none; stroke-width: 1.5; }
 .cfg-edge-true { stroke: var(--green); }
 .cfg-edge-false { stroke: var(--red); }
 .cfg-edge-goto { stroke: var(--text-dim); }
-.cfg-edge.highlighted { opacity: 1; stroke-width: 2; }
-.cfg-arrowhead { opacity: 0.45; transition: opacity 0.15s; }
 .cfg-arrowhead-true { fill: var(--green); }
 .cfg-arrowhead-false { fill: var(--red); }
 .cfg-arrowhead-goto { fill: var(--text-dim); }
-.cfg-arrowhead.highlighted { opacity: 1; }
 .cfg-block[data-block] { position: relative; z-index: 2; }
 .var-tooltip {
   position: fixed;
@@ -622,19 +609,12 @@ body {
 .wasm-branch-target { color: var(--yellow); }
 .wasm-branch-target:hover { color: var(--orange); background: rgba(250, 179, 135, 0.15); }
 .wasm-comment { color: var(--text-dim); font-style: italic; }
-.wasm-edges-svg {
-  position: absolute;
-  top: 0; left: 0;
-  width: 36px; height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  overflow: visible;
-}
-.wasm-edge { fill: none; stroke-width: 1.2; opacity: 0.4; transition: opacity 0.15s, stroke-width 0.15s; }
+.wasm-edges-svg { width: 36px; }
+.wasm-edge { fill: none; stroke-width: 1.2; }
 .wasm-edge-forward { stroke: var(--blue); }
 .wasm-edge-back { stroke: var(--yellow); stroke-dasharray: 3,2; }
-.wasm-edge.highlighted { opacity: 1; stroke-width: 2; }
 .wasm-arrowhead { fill: var(--blue); }
+.wasm-arrowhead-default { fill: var(--blue); }
 @keyframes wasm-flash {
   0% { background: rgba(249, 226, 175, 0.5); }
   100% { background: transparent; }

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -639,6 +639,115 @@ body {
   0% { background: rgba(249, 226, 175, 0.5); }
   100% { background: transparent; }
 }
+/* Disassembly toolbar + opt diff */
+.disasm-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 4px 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 3;
+}
+.disasm-toolbar-opt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+.disasm-toolbar-opt input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; }
+.disasm-toolbar-opt input:disabled { cursor: not-allowed; opacity: 0.4; }
+.disasm-toolbar-diff {
+  background: var(--bg-surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.disasm-toolbar-diff:hover { border-color: var(--accent); background: var(--bg-hover); }
+.disasm-toolbar-diff:disabled { opacity: 0.4; cursor: not-allowed; }
+.disasm-toolbar-hint { font-size: 11px; color: var(--text-dim); font-style: italic; }
+.disasm-tables { margin-left: 40px; margin-bottom: 4px; color: var(--text-dim); font-size: 11px; }
+.disasm-tables summary { cursor: pointer; padding: 2px 0; }
+.disasm-tables summary:hover { color: var(--accent); }
+.disasm-tables-section { color: var(--text-dim); font-weight: 600; margin-top: 4px; }
+.disasm-label-row { cursor: default !important; }
+.disasm-label-row:hover { background: transparent; }
+.disasm-label-anchor { color: var(--magenta); font-weight: 500; }
+.disasm-diff-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 4px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.disasm-diff-title { font-weight: 600; color: var(--accent); font-size: 12px; }
+.disasm-diff-legend { font-size: 10px; display: flex; gap: 10px; }
+.disasm-diff-legend-removed { color: var(--red); }
+.disasm-diff-legend-added { color: var(--green); }
+.disasm-diff-legend-dim { color: var(--text-dim); font-style: italic; }
+.disasm-diff-close {
+  margin-left: auto;
+  background: var(--bg-surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+.disasm-diff-close:hover { border-color: var(--accent); color: var(--text); }
+.disasm-diff-block { border: 1px solid var(--border); background: var(--bg-surface); }
+.disasm-diff-badge {
+  font-size: 10px;
+  font-weight: 400;
+  padding: 1px 6px;
+  border-radius: 8px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.disasm-diff-added { background: rgba(166, 227, 161, 0.15); color: var(--green); }
+.disasm-diff-removed { background: rgba(243, 139, 168, 0.15); color: var(--red); }
+.disasm-diff-same { background: rgba(108, 112, 134, 0.15); color: var(--text-dim); }
+.disasm-diff-modified { background: rgba(249, 226, 175, 0.18); color: var(--yellow); }
+.disasm-diff-rows { padding-left: 4px; }
+.disasm-diff-row {
+  display: flex;
+  gap: 6px;
+  padding: 1px 6px;
+  border-radius: 2px;
+  white-space: pre;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.disasm-diff-row.disasm-diff-removed { background: rgba(243, 139, 168, 0.1); color: var(--text); }
+.disasm-diff-row.disasm-diff-removed .disasm-diff-sigil { color: var(--red); }
+.disasm-diff-row.disasm-diff-removed .disasm-diff-text { text-decoration: line-through; opacity: 0.75; }
+.disasm-diff-row.disasm-diff-added { background: rgba(166, 227, 161, 0.1); color: var(--text); }
+.disasm-diff-row.disasm-diff-added .disasm-diff-sigil { color: var(--green); }
+.disasm-diff-row.disasm-diff-same { background: transparent; color: var(--text-dim); opacity: 0.7; }
+.disasm-diff-row.disasm-diff-same .disasm-diff-sigil { color: var(--text-dim); }
+.disasm-diff-sigil { min-width: 14px; text-align: center; user-select: none; font-weight: 600; flex-shrink: 0; }
+.disasm-diff-text { flex: 1; white-space: pre; }
+.disasm-diff-elide {
+  padding: 2px 22px;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-style: italic;
+}
+.disasm-diff-unchanged-note { padding: 4px 8px; color: var(--text-dim); font-size: 11px; font-style: italic; }
 </style>
 </head>
 <body>
@@ -679,8 +788,6 @@ body {
         <div class="tab" data-tab="callouts">Callouts</div>
         <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
-        <div class="tab" data-tab="asm-opt">Tcl ASM (opt)</div>
-        <div class="tab" data-tab="wasm-opt">WASM (opt)</div>
       </div>
       <div class="output-content" id="outputContent">
         <div class="tab-pane active" id="pane-ir">
@@ -698,8 +805,6 @@ body {
         <div class="tab-pane" id="pane-callouts"></div>
         <div class="tab-pane" id="pane-asm"></div>
         <div class="tab-pane" id="pane-wasm"></div>
-        <div class="tab-pane" id="pane-asm-opt"></div>
-        <div class="tab-pane" id="pane-wasm-opt"></div>
       </div>
     </div>
   </div>
@@ -972,8 +1077,6 @@ function renderAll() {
   renderCallouts();
   renderAsm();
   renderWasm();
-  renderAsmOpt();
-  renderWasmOpt();
   updateBadges();
 }
 
@@ -992,8 +1095,6 @@ function updateBadges() {
     'callouts': data.annotations.length,
     'asm': instrCount(data.asm),
     'wasm': instrCount(data.wasm),
-    'asm-opt': instrCount(data.asmOptimised),
-    'wasm-opt': instrCount(data.wasmOptimised),
   };
   $$('.tab').forEach(tab => {
     const key = tab.dataset.tab;

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -584,6 +584,61 @@ body {
   opacity: 0.7;
   font-weight: 400;
 }
+/* WASM disassembly view */
+.wasm-module { margin-bottom: 16px; }
+.wasm-module-details { margin-left: 16px; font-size: 11px; color: var(--text-dim); }
+.wasm-module-details summary { cursor: pointer; color: var(--text); }
+.wasm-module-details summary:hover { color: var(--accent); }
+.wasm-import-entry { padding: 1px 0; white-space: pre; display: flex; gap: 6px; align-items: baseline; }
+.wasm-function { margin-bottom: 16px; border: 1px solid var(--border); border-radius: 4px; padding: 6px 8px; background: var(--bg-surface); }
+.wasm-function[data-func-idx] { position: relative; }
+.wasm-func-header { font-weight: 600; color: var(--cyan); margin-bottom: 4px; padding: 2px 4px; cursor: pointer; border-radius: 3px; transition: background 0.15s; font-size: 12px; }
+.wasm-func-header:hover { background: var(--highlight); }
+.wasm-func-header.wasm-func-flash { background: rgba(137, 180, 250, 0.3); animation: wasm-flash 1.2s ease-out; }
+.wasm-func-header .wasm-kind-badge { font-size: 10px; background: var(--bg-hover); color: var(--text-dim); padding: 1px 5px; border-radius: 8px; margin-left: 2px; font-weight: 400; }
+.wasm-func-name { color: var(--accent); }
+.wasm-func-locals { margin-left: 40px; padding: 2px 0; color: var(--text-dim); font-size: 11px; }
+.wasm-local { padding: 0 4px; }
+.wasm-func-body { font-size: 12px; line-height: 1.5; position: relative; padding-left: 36px; }
+.wasm-instr, .wasm-src-comment { display: flex; align-items: baseline; gap: 4px; padding: 1px 0; border-radius: 2px; position: relative; z-index: 2; white-space: pre; }
+.wasm-instr { cursor: pointer; }
+.wasm-instr:hover { background: var(--highlight); }
+.wasm-instr.highlighted { background: var(--highlight-strong); }
+.wasm-instr.wasm-instr-flash { background: rgba(249, 226, 175, 0.3); animation: wasm-flash 1.2s ease-out; }
+.wasm-src-comment { color: var(--green); cursor: pointer; padding-top: 4px; font-size: 11px; opacity: 0.85; }
+.wasm-src-comment:hover { background: var(--highlight); opacity: 1; }
+.wasm-src-comment .wasm-src-text { color: var(--green); }
+.wasm-gutter-pad { width: 0; flex-shrink: 0; }
+.wasm-idx { color: var(--gutter); min-width: 36px; user-select: none; text-align: right; font-size: 10px; padding-right: 8px; flex-shrink: 0; }
+.wasm-code { display: inline; flex: 1; min-width: 0; }
+.wasm-indent { color: transparent; }
+.wasm-mnemonic { color: var(--text-bright); font-weight: 500; }
+.wasm-operand { color: var(--text); }
+.wasm-operand-name { color: var(--green); }
+.wasm-block-label { color: var(--magenta); opacity: 0.6; font-size: 10px; margin-left: 2px; }
+.wasm-call-target, .wasm-branch-target { cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; padding: 0 2px; border-radius: 2px; }
+.wasm-call-target { color: var(--cyan); }
+.wasm-call-target:hover { color: var(--accent); background: rgba(137, 180, 250, 0.15); }
+.wasm-branch-target { color: var(--yellow); }
+.wasm-branch-target:hover { color: var(--orange); background: rgba(250, 179, 135, 0.15); }
+.wasm-comment { color: var(--text-dim); font-style: italic; }
+.wasm-edges-svg {
+  position: absolute;
+  top: 0; left: 0;
+  width: 36px; height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  overflow: visible;
+}
+.wasm-edge { fill: none; stroke-width: 1.2; opacity: 0.4; transition: opacity 0.15s, stroke-width 0.15s; }
+.wasm-edge-forward { stroke: var(--blue); }
+.wasm-edge-back { stroke: var(--yellow); stroke-dasharray: 3,2; }
+.wasm-edge.highlighted { opacity: 1; stroke-width: 2; }
+.wasm-arrowhead { fill: var(--blue); }
+@keyframes wasm-flash {
+  0% { background: rgba(249, 226, 175, 0.5); }
+  100% { background: transparent; }
+}
 </style>
 </head>
 <body>

--- a/explorer/serialise.py
+++ b/explorer/serialise.py
@@ -664,7 +664,17 @@ def _serialise_asm(ir_module: IRModule, *, cfg_module=None) -> list[dict]:
 
 
 def _serialise_wasm(ir_module: IRModule, *, optimise: bool = False, cfg_module=None) -> list[dict]:
-    """Generate WAT (WebAssembly Text) for all functions in the module."""
+    """Generate a structured WASM disassembly view for the compiler explorer.
+
+    Returns one entry per function (plus a synthetic ``(module)`` entry
+    with imports, types, and data segments).  Each entry carries both
+    a flat WAT ``text`` (for copy/paste and the old renderer) and a
+    rich ``instructions`` list with per-instruction metadata — resolved
+    call targets, paired branch targets, source ranges, indent levels,
+    and explorer labels.  The frontend switches to the rich renderer
+    when ``instructions`` is present; consumers that don't understand
+    the new shape can continue to read ``text``.
+    """
     from core.compiler.codegen.wasm import wasm_codegen_module
 
     if cfg_module is None:
@@ -672,15 +682,56 @@ def _serialise_wasm(ir_module: IRModule, *, optimise: bool = False, cfg_module=N
 
         cfg_module = build_cfg(ir_module)
     wasm_module = wasm_codegen_module(cfg_module, ir_module, optimise=optimise)
-    wat = wasm_module.to_wat()
-    instr_count = sum(len(f.body) for f in wasm_module.functions)
-    return [
-        {
-            "name": "(module)",
-            "text": wat,
-            "instrCount": instr_count,
-        }
-    ]
+    explorer_entries = wasm_module.to_explorer_json()
+    # Attach ``text`` (a per-function WAT snippet) to each function so
+    # the old text-only renderer still works on consumers that do not
+    # understand the structured shape.  The synthetic ``(module)``
+    # header carries the full-module WAT as its ``text``.
+    full_wat = wasm_module.to_wat()
+    result: list[dict] = []
+    for entry in explorer_entries:
+        if entry["kind"] == "module":
+            # ``instrCount`` on the synthetic module header is left at 0
+            # so the tab-badge total (computed as the sum over all
+            # entries in ``data.wasm``) doesn't double-count the body
+            # instructions.  The real total is available as
+            # ``totalInstrCount`` for UI that wants to display it.
+            result.append(
+                {
+                    **entry,
+                    "text": full_wat,
+                    "totalInstrCount": sum(len(f.body) for f in wasm_module.functions),
+                }
+            )
+        else:
+            result.append(
+                {
+                    **entry,
+                    "text": _format_function_wat_snippet(entry),
+                }
+            )
+    return result
+
+
+def _format_function_wat_snippet(entry: dict) -> str:
+    """Render a single function's instructions as a WAT snippet.
+
+    Used as a legacy fallback for consumers that haven't migrated to
+    the structured ``instructions`` list — emits ``func $name``
+    followed by each instruction's ``fullText`` at its ``indent``.
+    """
+    sig_parts = [f"(param {p['name']} {p['type']})" for p in entry.get("params", [])]
+    for r in entry.get("results", []):
+        sig_parts.append(f"(result {r})")
+    sig = " ".join(sig_parts)
+    lines = [f"(func ${entry['name']} {sig}".rstrip() + "".rstrip()]
+    for loc in entry.get("locals", []):
+        lines.append(f"  (local {loc['name']} {loc['type']})")
+    for instr in entry.get("instructions", []):
+        prefix = "  " + ("    " * instr["indent"])
+        lines.append(f"{prefix}{instr['fullText']}")
+    lines.append(")")
+    return "\n".join(lines)
 
 
 # Top-level serialisation

--- a/explorer/serialise.py
+++ b/explorer/serialise.py
@@ -751,7 +751,7 @@ def _format_function_wat_snippet(entry: dict) -> str:
     for r in entry.get("results", []):
         sig_parts.append(f"(result {r})")
     sig = " ".join(sig_parts)
-    lines = [f"(func ${entry['name']} {sig}".rstrip() + "".rstrip()]
+    lines = [f"(func ${entry['name']} {sig}".rstrip()]
     for loc in entry.get("locals", []):
         lines.append(f"  (local {loc['name']} {loc['type']})")
     for instr in entry.get("instructions", []):

--- a/explorer/serialise.py
+++ b/explorer/serialise.py
@@ -632,31 +632,58 @@ def _collect_annotations(result: CompilerExplorerResult) -> list[dict]:
 
 
 def _serialise_asm(ir_module: IRModule, *, cfg_module=None) -> list[dict]:
-    """Generate Tcl bytecode assembly for all functions in the module."""
-    from core.compiler.codegen import codegen_module, format_function_asm
+    """Generate a structured Tcl bytecode disassembly view for the explorer.
+
+    Mirrors ``_serialise_wasm``: each function entry carries both a
+    ``text`` WAT snippet (for copy/paste and the legacy renderer) and
+    an ``instructions`` list with resolved jump targets, source
+    ranges, and label anchors.  The frontend switches to the rich
+    renderer when ``instructions`` is present.
+    """
+    from core.compiler.codegen import codegen_module, format_module_explorer
 
     if cfg_module is None:
         from core.compiler.cfg import build_cfg
 
         cfg_module = build_cfg(ir_module)
     module_asm = codegen_module(cfg_module, ir_module)
-    result = []
-    result.append(
-        {
-            "name": module_asm.top_level.name,
-            "text": format_function_asm(module_asm.top_level),
-            "instrCount": len(module_asm.top_level.instructions),
-        }
-    )
-    for name in sorted(module_asm.procedures):
-        fa = module_asm.procedures[name]
-        result.append(
-            {
-                "name": name,
-                "text": format_function_asm(fa),
-                "instrCount": len(fa.instructions),
+    result = format_module_explorer(module_asm)
+    # Tag each entry with ``instrCount`` at the top level (the
+    # function-explorer already records it) and wire proc source
+    # ranges from the IR so the UI can jump to the proc body on
+    # click.  ``::top`` spans the whole script; procs use their
+    # IRProcedure.range.
+    top_stmts = ir_module.top_level.statements
+    top_range = None
+    if top_stmts:
+        first = getattr(top_stmts[0], "range", None)
+        last = getattr(top_stmts[-1], "range", None)
+        if first is not None and last is not None:
+            top_range = {
+                "startLine": first.start.line,
+                "startCol": first.start.character,
+                "startOffset": first.start.offset,
+                "endLine": last.end.line,
+                "endCol": last.end.character,
+                "endOffset": last.end.offset,
             }
-        )
+    for entry in result:
+        if entry["kind"] == "top":
+            entry["sourceRange"] = top_range
+        else:
+            ir_proc = ir_module.procedures.get(entry["name"])
+            if ir_proc is not None:
+                rng = ir_proc.range
+                entry["sourceRange"] = {
+                    "startLine": rng.start.line,
+                    "startCol": rng.start.character,
+                    "startOffset": rng.start.offset,
+                    "endLine": rng.end.line,
+                    "endCol": rng.end.character,
+                    "endOffset": rng.end.offset,
+                }
+            else:
+                entry["sourceRange"] = None
     return result
 
 

--- a/explorer/static/explorer-core.js
+++ b/explorer/static/explorer-core.js
@@ -760,12 +760,22 @@ function renderWasmInstruction(ins, entry) {
 }
 
 function setupDisasmInteractions(pane, funcs, kind) {
-  // Build a defIdx → entry map from the funcs list so "call N" can
-  // resolve to the function block within the same pane.  Registered
-  // BEFORE setupHoverHighlighting so the call/branch-target short-
-  // circuits run first via ``stopImmediatePropagation``.
-  var funcEntries = funcs.filter(function(f) { return f.kind !== 'module'; });
+  // Stash the current function-entry list on the pane so the
+  // listeners below always see the latest data.  ``renderDisassembly``
+  // replaces ``pane.innerHTML`` on every re-render (e.g. opt-toggle,
+  // diff-close) but keeps the pane element itself, so we guard the
+  // listener attachment and let the handlers read live state from
+  // ``pane._disasmFuncEntries`` instead of closing over the stale
+  // value from the first render.  Without this guard every toggle
+  // stacked a new trio of listeners — harmless today because the
+  // handlers re-query the DOM by ``data-*`` attributes, but fragile
+  // under future refactors.
+  pane._disasmFuncEntries = funcs.filter(function(f) { return f.kind !== 'module'; });
+  if (pane._disasmInteractionsWired) return;
+  pane._disasmInteractionsWired = true;
+
   pane.addEventListener('click', function(e) {
+    var entries = pane._disasmFuncEntries || [];
     var ct = e.target.closest('.wasm-call-target');
     if (ct) {
       e.stopImmediatePropagation();
@@ -773,8 +783,8 @@ function setupDisasmInteractions(pane, funcs, kind) {
       var defIdxStr = ct.dataset.callTargetDefIdx;
       if (defIdxStr !== '') {
         var defIdx = parseInt(defIdxStr);
-        if (!isNaN(defIdx) && defIdx >= 0 && defIdx < funcEntries.length) {
-          navigateToWasmFunction(pane, funcEntries[defIdx]);
+        if (!isNaN(defIdx) && defIdx >= 0 && defIdx < entries.length) {
+          navigateToWasmFunction(pane, entries[defIdx]);
         }
       }
       return;
@@ -837,7 +847,13 @@ function wasmHighlightSource(start, end) {
 
 function navigateToWasmFunction(pane, targetEntry) {
   if (!targetEntry) return;
-  var nameSel = targetEntry.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  // ``CSS.escape`` is the only correct way to quote a dynamic value
+  // inside an attribute selector (it handles every CSS special
+  // character, not just ``\`` and ``"``).  The manual regex
+  // fallback is kept for ancient environments that predate CSS.escape.
+  var nameSel = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function')
+    ? CSS.escape(targetEntry.name)
+    : targetEntry.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   var el = pane.querySelector('.wasm-function[data-func-name="' + nameSel + '"]');
   if (el) {
     el.scrollIntoView({ block: 'start', behavior: 'smooth' });

--- a/explorer/static/explorer-core.js
+++ b/explorer/static/explorer-core.js
@@ -477,7 +477,7 @@ function renderCallouts() {
 }
 
 // Assembly / WASM helpers
-function instrCount(arr) { return arr ? arr.reduce(function(n, f) { return n + f.instrCount; }, 0) : 0; }
+function instrCount(arr) { return arr ? arr.reduce(function(n, f) { return n + (f.instrCount || 0); }, 0) : 0; }
 function funcListHtml(funcs) {
   var html = '';
   for (var func of funcs) {
@@ -488,40 +488,185 @@ function funcListHtml(funcs) {
   }
   return html;
 }
-function renderFuncList(paneId, funcs, emptyMsg) {
+
+// Per-pane opt toggle state: true = optimised, false = original.
+var wasmOptState = { 'pane-asm': false, 'pane-wasm': false };
+
+// Tcl ASM and WASM share the same structured rendering pipeline.  The
+// only differences are the data source (``data.asm`` vs ``data.wasm``)
+// and a few WASM-specific node shapes (the ``(module)`` header,
+// ``callTarget``, ``branchTarget``).  The renderer below handles both.
+function renderAsm() { renderDisassembly('pane-asm', 'asm'); }
+function renderWasm() { renderDisassembly('pane-wasm', 'wasm'); }
+
+function renderDisassembly(paneId, kind) {
   var pane = $('#' + paneId);
-  if (!funcs || !funcs.length) { pane.innerHTML = '<div class="empty-state">' + emptyMsg + '</div>'; return; }
-  pane.innerHTML = funcListHtml(funcs);
-}
-
-function renderAsm() { renderFuncList('pane-asm', data.asm, 'No assembly'); }
-function renderAsmOpt() { renderFuncList('pane-asm-opt', data.asmOptimised, 'No optimised assembly (source unchanged by optimiser)'); }
-
-// WASM disassembly — structured per-instruction renderer with
-// click-to-source, call/branch target cross-navigation, source-line
-// comments above each instruction group, and control-flow arrows.
-
-function renderWasm() { renderWasmFuncList('pane-wasm', data.wasm, 'No WASM output'); }
-function renderWasmOpt() { renderWasmFuncList('pane-wasm-opt', data.wasmOptimised, 'No optimised WASM output (source unchanged by optimiser)'); }
-
-function renderWasmFuncList(paneId, funcs, emptyMsg) {
-  var pane = $('#' + paneId);
-  if (!funcs || !funcs.length) { pane.innerHTML = '<div class="empty-state">' + emptyMsg + '</div>'; return; }
-  // Legacy text-only payload from old Python builds — fall back to the
-  // plain <pre> renderer so the pane still has something to show.
+  var origFuncs = kind === 'asm' ? data.asm : data.wasm;
+  var optFuncs = kind === 'asm' ? data.asmOptimised : data.wasmOptimised;
+  var emptyMsg = kind === 'asm' ? 'No assembly' : 'No WASM output';
+  if (!origFuncs || !origFuncs.length) {
+    pane.innerHTML = '<div class="empty-state">' + emptyMsg + '</div>';
+    return;
+  }
+  var optAvailable = !!(optFuncs && optFuncs.length);
+  // Preserve user's prior opt-toggle choice across re-renders.
+  var optOn = optAvailable && wasmOptState[paneId] === true;
+  var funcs = optOn ? optFuncs : origFuncs;
   var hasStructured = funcs.some(function(f) { return Array.isArray(f.instructions); });
-  if (!hasStructured) { pane.innerHTML = funcListHtml(funcs); return; }
-  var html = funcs.map(renderWasmEntry).join('');
-  pane.innerHTML = html;
-  setupWasmInteractions(pane, funcs);
+  if (!hasStructured) {
+    // Legacy text-only payload — plain <pre>.
+    pane.innerHTML = funcListHtml(funcs);
+    return;
+  }
+  var toolbar = renderDisasmToolbar(paneId, kind, optAvailable, optOn);
+  var body = funcs.map(function(entry) { return renderDisasmEntry(entry, kind); }).join('');
+  pane.innerHTML = toolbar + '<div class="disasm-body">' + body + '</div>';
+  setupDisasmInteractions(pane, funcs, kind);
+  setupDisasmToolbar(pane, paneId, kind, optAvailable);
   requestAnimationFrame(function() {
     pane.querySelectorAll('.wasm-edges-container').forEach(function(c) { drawWasmEdges(c); });
   });
 }
 
-function renderWasmEntry(entry) {
+function renderDisasmToolbar(paneId, kind, optAvailable, optOn) {
+  var optLabel = kind === 'asm' ? 'Tcl ASM optimisations' : 'WASM optimisations';
+  var disabledAttr = optAvailable ? '' : ' disabled';
+  var hint = optAvailable ? '' : ' <span class="disasm-toolbar-hint">(source unchanged by optimiser)</span>';
+  return '<div class="disasm-toolbar">'
+       + '<label class="disasm-toolbar-opt"><input type="checkbox" data-disasm-opt-toggle' + (optOn ? ' checked' : '') + disabledAttr + '> ' + optLabel + '</label>'
+       + '<button class="disasm-toolbar-diff" data-disasm-diff' + disabledAttr + '>Show optimiser diff</button>'
+       + hint
+       + '</div>';
+}
+
+function setupDisasmToolbar(pane, paneId, kind, optAvailable) {
+  var toggle = pane.querySelector('[data-disasm-opt-toggle]');
+  if (toggle) {
+    toggle.addEventListener('change', function() {
+      wasmOptState[paneId] = toggle.checked;
+      renderDisassembly(paneId, kind);
+    });
+  }
+  var diffBtn = pane.querySelector('[data-disasm-diff]');
+  if (diffBtn && optAvailable) {
+    diffBtn.addEventListener('click', function() {
+      openOptDiffView(paneId, kind);
+    });
+  }
+}
+
+function renderDisasmEntry(entry, kind) {
   if (entry.kind === 'module') return renderWasmModuleHeader(entry);
-  return renderWasmFunction(entry);
+  return renderDisasmFunction(entry, kind);
+}
+
+function renderDisasmFunction(entry, kind) {
+  var sr = entry.sourceRange;
+  var headerAttrs = sr ? ' data-start="' + sr.startOffset + '" data-end="' + sr.endOffset + '"' : '';
+  var html = '<div class="wasm-function" data-kind="' + esc(kind) + '" data-func-idx="' + (entry.funcIdx !== undefined ? entry.funcIdx : '') + '" data-func-name="' + esc(entry.name) + '">';
+  var kindBadge = '';
+  if (entry.kind === 'top') kindBadge = ' <span class="wasm-kind-badge">top</span>';
+  else if (entry.kind === 'method') kindBadge = ' <span class="wasm-kind-badge">method</span>';
+  var sig = '';
+  if (kind === 'wasm') {
+    var params = (entry.params || []).map(function(p) { return '(param ' + esc(p.name) + ' ' + esc(p.type) + ')'; }).join(' ');
+    var results = (entry.results || []).map(function(r) { return '(result ' + esc(r) + ')'; }).join(' ');
+    sig = '(func <span class="wasm-func-name">$' + esc(entry.name) + '</span>' + kindBadge + (params ? ' ' + params : '') + (results ? ' ' + results : '') + ')';
+  } else {
+    sig = 'ByteCode <span class="wasm-func-name">' + esc(entry.name) + '</span>' + kindBadge;
+  }
+  var meta = '';
+  if (kind === 'asm') {
+    meta = ' <span class="wasm-comment">; ' + entry.instrCount + ' instructions, ' + (entry.byteCount || 0) + ' bytes, ' + ((entry.literals || []).length) + ' literals, ' + ((entry.locals || []).length) + ' locals</span>';
+  } else {
+    meta = ' <span class="wasm-comment">; ' + entry.instrCount + ' instructions</span>';
+  }
+  html += '<div class="wasm-func-header"' + headerAttrs + '>' + sig + meta + '</div>';
+  if (kind === 'wasm' && entry.locals && entry.locals.length) {
+    html += '<div class="wasm-func-locals">';
+    for (var loc of entry.locals) html += '<div class="wasm-local">(local ' + esc(loc.name) + ' ' + esc(loc.type) + ')</div>';
+    html += '</div>';
+  } else if (kind === 'asm' && ((entry.literals || []).length || (entry.locals || []).length)) {
+    html += '<details class="disasm-tables"><summary>literals &amp; locals</summary>';
+    if ((entry.literals || []).length) {
+      html += '<div class="disasm-tables-section">Literals:</div>';
+      for (var i = 0; i < entry.literals.length; i++) {
+        html += '<div class="wasm-local">' + i + ': "' + esc(entry.literals[i]) + '"</div>';
+      }
+    }
+    if ((entry.locals || []).length) {
+      html += '<div class="disasm-tables-section">Local variables:</div>';
+      for (var i = 0; i < entry.locals.length; i++) {
+        html += '<div class="wasm-local">%v' + i + ': "' + esc(entry.locals[i]) + '"</div>';
+      }
+    }
+    html += '</details>';
+  }
+  html += '<div class="wasm-func-body wasm-edges-container" data-func-idx="' + (entry.funcIdx !== undefined ? entry.funcIdx : '') + '">';
+  var source = getSource();
+  var prevRangeKey = null;
+  for (var ins of (entry.instructions || [])) {
+    if (ins.kind === 'label') {
+      html += renderDisasmLabel(ins);
+      continue;
+    }
+    var r = ins.range;
+    var rkey = r ? r.startOffset + '/' + r.endOffset : null;
+    if (rkey && rkey !== prevRangeKey) {
+      var snippet = wasmSourceSnippet(source, r);
+      html += '<div class="wasm-src-comment" data-start="' + r.startOffset + '" data-end="' + r.endOffset + '">'
+            + '<span class="wasm-gutter-pad"></span>'
+            + '<span class="wasm-idx">' + (r.startLine + 1) + '</span>'
+            + '<span class="wasm-src-text">; ' + esc(snippet) + '</span>'
+            + '</div>';
+      prevRangeKey = rkey;
+    }
+    if (kind === 'wasm') html += renderWasmInstruction(ins, entry);
+    else html += renderAsmInstruction(ins, entry);
+  }
+  html += '</div></div>';
+  return html;
+}
+
+function renderDisasmLabel(ins) {
+  return '<div class="wasm-instr disasm-label-row" data-idx="' + ins.idx + '" data-label-name="' + esc(ins.label) + '">'
+       + '<span class="wasm-gutter-pad"></span>'
+       + '<span class="wasm-idx">' + ins.idx + '</span>'
+       + '<span class="wasm-code"><span class="disasm-label-anchor"># ' + esc(ins.label) + ':</span></span>'
+       + '</div>';
+}
+
+function renderAsmInstruction(ins, entry) {
+  var range = ins.range;
+  var rngAttrs = range ? ' data-start="' + range.startOffset + '" data-end="' + range.endOffset + '"' : '';
+  var operandHtml = '';
+  var jt = ins.jumpTarget;
+  if (jt) {
+    var btAttrs = ' data-branch-target-idx="' + (jt.targetIdx !== null && jt.targetIdx !== undefined ? jt.targetIdx : '') + '"'
+                + ' data-branch-target-label="' + esc(jt.label) + '"';
+    operandHtml = ' <span class="wasm-operand">' + esc(ins.operandText) + '</span>'
+                + ' <span class="wasm-branch-target"' + btAttrs + '>; ' + esc(jt.label) + '</span>';
+  } else if (ins.operandText) {
+    operandHtml = ' <span class="wasm-operand">' + esc(ins.operandText) + '</span>';
+  }
+  var jumpTableHtml = '';
+  if (ins.jumpTable && ins.jumpTable.length) {
+    var jtEntries = [];
+    for (var e of ins.jumpTable) {
+      jtEntries.push('<span class="wasm-branch-target" data-branch-target-idx="' + (e.targetIdx !== null && e.targetIdx !== undefined ? e.targetIdx : '') + '" data-branch-target-label="' + esc(e.label) + '">&quot;' + esc(e.pattern) + '&quot;-&gt;' + esc(e.label) + '</span>');
+    }
+    jumpTableHtml = ' <span class="wasm-comment">[' + jtEntries.join(', ') + ']</span>';
+  }
+  var comment = ins.comment ? ' <span class="wasm-comment">; ' + esc(ins.comment) + '</span>' : '';
+  return '<div class="wasm-instr" data-idx="' + ins.idx + '"' + rngAttrs + '>'
+       + '<span class="wasm-gutter-pad"></span>'
+       + '<span class="wasm-idx">(' + ins.offset + ')</span>'
+       + '<span class="wasm-code">'
+       + '<span class="wasm-mnemonic">' + esc(ins.op) + '</span>'
+       + operandHtml
+       + jumpTableHtml
+       + comment
+       + '</span></div>';
 }
 
 function renderWasmModuleHeader(entry) {
@@ -547,45 +692,6 @@ function renderWasmModuleHeader(entry) {
     html += '</details>';
   }
   html += '</div>';
-  return html;
-}
-
-function renderWasmFunction(entry) {
-  var sr = entry.sourceRange;
-  var headerAttrs = sr ? ' data-start="' + sr.startOffset + '" data-end="' + sr.endOffset + '"' : '';
-  var html = '<div class="wasm-function" data-func-idx="' + entry.funcIdx + '" data-func-name="' + esc(entry.name) + '">';
-  var params = (entry.params || []).map(function(p) { return '(param ' + esc(p.name) + ' ' + esc(p.type) + ')'; }).join(' ');
-  var results = (entry.results || []).map(function(r) { return '(result ' + esc(r) + ')'; }).join(' ');
-  var kindBadge = entry.kind === 'top' ? ' <span class="wasm-kind-badge">top</span>' : (entry.kind === 'method' ? ' <span class="wasm-kind-badge">method</span>' : '');
-  html += '<div class="wasm-func-header"' + headerAttrs + '>';
-  html += '(func <span class="wasm-func-name">$' + esc(entry.name) + '</span>' + kindBadge + ' ' + params + (results ? ' ' + results : '') + ')';
-  html += ' <span class="wasm-comment">; ' + entry.instrCount + ' instructions</span>';
-  html += '</div>';
-  if (entry.locals && entry.locals.length) {
-    html += '<div class="wasm-func-locals">';
-    for (var loc of entry.locals) {
-      html += '<div class="wasm-local">(local ' + esc(loc.name) + ' ' + esc(loc.type) + ')</div>';
-    }
-    html += '</div>';
-  }
-  html += '<div class="wasm-func-body wasm-edges-container" data-func-idx="' + entry.funcIdx + '">';
-  var source = getSource();
-  var prevRangeKey = null;
-  for (var ins of entry.instructions) {
-    var r = ins.range;
-    var rkey = r ? r.startOffset + '/' + r.endOffset : null;
-    if (rkey && rkey !== prevRangeKey) {
-      var snippet = wasmSourceSnippet(source, r);
-      html += '<div class="wasm-src-comment" data-start="' + r.startOffset + '" data-end="' + r.endOffset + '">'
-            + '<span class="wasm-gutter-pad"></span>'
-            + '<span class="wasm-idx">' + (r.startLine + 1) + '</span>'
-            + '<span class="wasm-src-text">; ' + esc(snippet) + '</span>'
-            + '</div>';
-      prevRangeKey = rkey;
-    }
-    html += renderWasmInstruction(ins, entry);
-  }
-  html += '</div></div>';
   return html;
 }
 
@@ -642,7 +748,7 @@ function renderWasmInstruction(ins, entry) {
        + '</span></div>';
 }
 
-function setupWasmInteractions(pane, funcs) {
+function setupDisasmInteractions(pane, funcs, kind) {
   // Build a defIdx → entry map from the funcs list so "call N" can
   // resolve to the function block within the same pane.  Registered
   // BEFORE setupHoverHighlighting so the call/branch-target short-
@@ -699,6 +805,10 @@ function setupWasmInteractions(pane, funcs) {
   // short-circuits above can intercept first.
   setupHoverHighlighting(pane);
 }
+
+// Back-compat alias — the old name is referenced elsewhere in this
+// file and may be inlined by external consumers.
+var setupWasmInteractions = setupDisasmInteractions;
 
 // Source-range highlight abstraction: standalone index.html defines
 // ``highlightSourceRanges`` for inline highlighting; the VS Code
@@ -830,6 +940,212 @@ function drawWasmEdges(container) {
     svg.appendChild(path);
   }
   container.insertBefore(svg, container.firstChild);
+}
+
+// Opt diff — semantic-change-only comparison between the original and
+// optimised disassembly.  The diff ignores instruction sequence
+// numbers, byte offsets, literal/local indices (comparing by literal
+// text and local name instead), and ``+N``/``pc N`` jump relatives
+// (comparing by label name instead).  Changes to named targets
+// (labels, call targets, literals, locals) surface as red/green rows.
+
+function openOptDiffView(paneId, kind) {
+  var pane = $('#' + paneId);
+  if (!pane) return;
+  var orig = kind === 'asm' ? data.asm : data.wasm;
+  var opt = kind === 'asm' ? data.asmOptimised : data.wasmOptimised;
+  if (!orig || !opt) return;
+  // Match entries by name; render one diff block per function that
+  // appears in either side.
+  var byName = {};
+  for (var e of orig) { if (e.kind !== 'module') byName[e.name] = { orig: e }; }
+  for (var e of opt) {
+    if (e.kind === 'module') continue;
+    if (!byName[e.name]) byName[e.name] = {};
+    byName[e.name].opt = e;
+  }
+  var ordered = [];
+  for (var e of orig) { if (e.kind !== 'module') ordered.push(e.name); }
+  for (var e of opt) {
+    if (e.kind !== 'module' && ordered.indexOf(e.name) < 0) ordered.push(e.name);
+  }
+  var html = renderDisasmToolbar(paneId, kind, true, wasmOptState[paneId] === true);
+  html += '<div class="disasm-diff-header">';
+  html += '<div class="disasm-diff-title">Optimiser diff &mdash; original vs optimised</div>';
+  html += '<div class="disasm-diff-legend">'
+       + '<span class="disasm-diff-legend-removed">&minus; removed</span> '
+       + '<span class="disasm-diff-legend-added">+ added</span> '
+       + '<span class="disasm-diff-legend-dim">sequence numbers &amp; offsets ignored</span>'
+       + '</div>';
+  html += '<button class="disasm-diff-close" data-disasm-diff-close>Close diff</button>';
+  html += '</div><div class="disasm-body disasm-diff-body">';
+  var anyDiff = false;
+  for (var name of ordered) {
+    var pair = byName[name];
+    var block = buildOptDiffBlockHtml(name, pair.orig, pair.opt, kind);
+    if (block.changed) anyDiff = true;
+    html += block.html;
+  }
+  if (!anyDiff) {
+    html += '<div class="empty-state">No semantic changes detected (sequence numbers and offsets ignored).</div>';
+  }
+  html += '</div>';
+  pane.innerHTML = html;
+  setupDisasmToolbar(pane, paneId, kind, true);
+  var closeBtn = pane.querySelector('[data-disasm-diff-close]');
+  if (closeBtn) closeBtn.addEventListener('click', function() { renderDisassembly(paneId, kind); });
+  setupHoverHighlighting(pane);
+}
+
+function buildOptDiffBlockHtml(name, origEntry, optEntry, kind) {
+  var origRows = origEntry ? normaliseForDiff(origEntry, kind) : [];
+  var optRows = optEntry ? normaliseForDiff(optEntry, kind) : [];
+  var segments = computeDiffSegments(origRows.map(function(r) { return r.key; }), optRows.map(function(r) { return r.key; }));
+  var changed = segments.some(function(s) { return s.type !== 'same'; });
+  var html = '<div class="wasm-function disasm-diff-block">';
+  var badge = !origEntry ? '<span class="disasm-diff-badge disasm-diff-added">new</span>'
+             : !optEntry ? '<span class="disasm-diff-badge disasm-diff-removed">removed</span>'
+             : !changed ? '<span class="disasm-diff-badge disasm-diff-same">unchanged</span>'
+             : '<span class="disasm-diff-badge disasm-diff-modified">modified</span>';
+  html += '<div class="wasm-func-header">' + esc(name) + ' ' + badge + '</div>';
+  if (!changed && origEntry) {
+    html += '<div class="disasm-diff-unchanged-note">' + origRows.length + ' instructions — no semantic changes</div>';
+    html += '</div>';
+    return { html: html, changed: false };
+  }
+  html += '<div class="disasm-diff-rows">';
+  for (var seg of segments) {
+    if (seg.type === 'same') {
+      var shown = Math.min(seg.origEnd - seg.origStart, 1);
+      for (var i = 0; i < shown; i++) {
+        var row = origRows[seg.origStart + i];
+        html += renderDiffRow(row, 'same');
+      }
+      var hiddenCount = (seg.origEnd - seg.origStart) - shown;
+      if (hiddenCount > 0) {
+        html += '<div class="disasm-diff-elide">&hellip; ' + hiddenCount + ' unchanged instruction' + (hiddenCount === 1 ? '' : 's') + '</div>';
+      }
+    } else {
+      for (var i = seg.origStart; i < seg.origEnd; i++) html += renderDiffRow(origRows[i], 'removed');
+      for (var i = seg.optStart; i < seg.optEnd; i++) html += renderDiffRow(optRows[i], 'added');
+    }
+  }
+  html += '</div></div>';
+  return { html: html, changed: changed };
+}
+
+function renderDiffRow(row, state) {
+  if (!row) return '';
+  var cls = 'disasm-diff-row disasm-diff-' + state;
+  var sigil = state === 'added' ? '+' : (state === 'removed' ? '−' : ' ');
+  var rng = row.range;
+  var rngAttrs = rng ? ' data-start="' + rng.startOffset + '" data-end="' + rng.endOffset + '"' : '';
+  return '<div class="' + cls + '"' + rngAttrs + '>'
+       + '<span class="disasm-diff-sigil">' + sigil + '</span>'
+       + '<span class="disasm-diff-text">' + row.displayHtml + '</span>'
+       + '</div>';
+}
+
+function normaliseForDiff(entry, kind) {
+  // Map each instruction (or label) into a ``{key, displayHtml,
+  // range}`` tuple where ``key`` is a string uniquely identifying the
+  // semantic content — explicitly excluding sequence numbers, byte
+  // offsets, and ``+N``/``pc N`` jump relatives.  The frontend diff
+  // engine (``computeDiffSegments``) compares keys; rows with equal
+  // keys are grouped into ``same`` segments regardless of where they
+  // sit in the stream.
+  var rows = [];
+  var literals = entry.literals || [];
+  var locals = entry.locals || [];
+  for (var ins of (entry.instructions || [])) {
+    if (ins.kind === 'label') {
+      rows.push({
+        key: 'LABEL:' + ins.label,
+        displayHtml: '<span class="disasm-label-anchor"># ' + esc(ins.label) + ':</span>',
+        range: null,
+      });
+      continue;
+    }
+    var parts = [ins.op];
+    var displayParts = ['<span class="wasm-mnemonic">' + esc(ins.op) + '</span>'];
+    if (kind === 'asm') {
+      var jt = ins.jumpTarget;
+      if (jt) {
+        parts.push('JMP:' + jt.label);
+        displayParts.push('<span class="wasm-branch-target">; ' + esc(jt.label) + '</span>');
+      } else if (ins.operandText) {
+        // Preserve literal/local refs as names, but strip bare numbers
+        // (they're indices whose identity depends on table order).
+        var norm = normaliseAsmOperand(ins, literals, locals);
+        parts.push(norm.key);
+        displayParts.push('<span class="wasm-operand">' + esc(norm.display) + '</span>');
+      }
+      if (ins.jumpTable && ins.jumpTable.length) {
+        var jtKeys = ins.jumpTable.map(function(e) { return e.pattern + '->' + e.label; });
+        parts.push('JT:' + jtKeys.join('|'));
+        var jtDisplay = ins.jumpTable.map(function(e) { return '&quot;' + esc(e.pattern) + '&quot;->' + esc(e.label); });
+        displayParts.push('<span class="wasm-comment">[' + jtDisplay.join(', ') + ']</span>');
+      }
+    } else {
+      // WASM operands: resolve call/branch by target name.
+      if (ins.callTarget) {
+        var ct = ins.callTarget;
+        parts.push('CALL:' + ct.kind + ':' + ct.name);
+        displayParts.push('<span class="wasm-call-target">; ' + esc(ct.kind === 'import' ? ('import ' + ct.name) : ct.name) + '</span>');
+      } else if (ins.branchTarget) {
+        var bt = ins.branchTarget;
+        parts.push('BR:' + (bt.kind || '') + ':' + (bt.label || ''));
+        var lbl = (bt.kind || '') + (bt.label ? ' ' + bt.label : '');
+        displayParts.push('<span class="wasm-branch-target">; ' + esc(lbl) + '</span>');
+      } else if (ins.op === 'local.get' || ins.op === 'local.set' || ins.op === 'local.tee') {
+        var localParts = ins.fullText.split(' ');
+        var localName = localParts.length > 2 ? localParts.slice(2).join(' ') : '';
+        parts.push('LOCAL:' + (localName || ins.operandText));
+        displayParts.push('<span class="wasm-operand-name">' + esc(localName || ins.operandText) + '</span>');
+      } else if (ins.op === 'i32.const' || ins.op === 'i64.const' || ins.op === 'f64.const') {
+        // Constant value IS semantic — keep it.
+        parts.push('K:' + ins.operandText);
+        displayParts.push('<span class="wasm-operand">' + esc(ins.operandText) + '</span>');
+      } else if (ins.operandText) {
+        // Other ops: operand is typically a type descriptor or a
+        // local/global idx.  Keep the text but strip bare numerics.
+        var stripped = ins.operandText.replace(/\b\d+\b/g, '#');
+        parts.push(stripped);
+        if (stripped !== '#') displayParts.push('<span class="wasm-operand">' + esc(ins.operandText) + '</span>');
+      }
+      if (ins.label) {
+        parts.push('LBL:' + ins.label);
+        displayParts.push('<span class="wasm-comment">;; ' + esc(ins.label) + '</span>');
+      }
+    }
+    rows.push({
+      key: parts.join(' '),
+      displayHtml: displayParts.join(' '),
+      range: ins.range,
+    });
+  }
+  return rows;
+}
+
+function normaliseAsmOperand(ins, literals, locals) {
+  // Map push1/push4 N → literal text; loadScalar1/storeScalar1 %vN →
+  // local name; jump/pc-anchored ops are handled via ``jumpTarget``.
+  // Returns ``{key, display}``.
+  var op = ins.op;
+  var text = ins.operandText;
+  if ((op === 'push1' || op === 'push4') && ins.operandText) {
+    var idx = parseInt(ins.operandText);
+    if (!isNaN(idx) && idx >= 0 && idx < literals.length) {
+      return { key: 'LIT:' + literals[idx], display: '"' + literals[idx] + '" (#' + idx + ')' };
+    }
+  }
+  if (ins.lvtRef !== null && ins.lvtRef !== undefined) {
+    var name = locals[ins.lvtRef] || ('v' + ins.lvtRef);
+    return { key: 'VAR:' + name, display: '%' + name };
+  }
+  // Strip bare "+N" / "-N" / "pc N" relatives from non-label ops.
+  var stripped = text.replace(/[+-]?\d+/g, '#').replace(/pc #/g, 'pc');
+  return { key: stripped, display: text };
 }
 
 // SSA variable spans with hover tooltips

--- a/explorer/static/explorer-core.js
+++ b/explorer/static/explorer-core.js
@@ -298,33 +298,44 @@ function computeLCS(a,b) {
 }
 
 function drawOptBrackets(pane) {
-  var container=pane.querySelector('.opt-diff-container');
-  if(!container)return;
-  container.querySelectorAll('.opt-diff-svg').forEach(function(s){s.remove()});
-  var groupIds=new Set();
-  container.querySelectorAll('[data-opt-group]').forEach(function(el){groupIds.add(el.dataset.optGroup)});
-  if(!groupIds.size)return;
-  var containerRect=container.getBoundingClientRect();
-  var svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
-  svg.classList.add('opt-diff-svg');
-  svg.setAttribute('width','36');svg.setAttribute('height',container.offsetHeight);
-  for(var gid of groupIds){
-    var origEls=container.querySelectorAll('.opt-original[data-opt-group="'+gid+'"]');
-    var replEls=container.querySelectorAll('.opt-replacement[data-opt-group="'+gid+'"]');
-    if(!origEls.length||!replEls.length)continue;
-    var firstOrigRect=origEls[0].getBoundingClientRect();
-    var lastReplRect=replEls[replEls.length-1].getBoundingClientRect();
-    var y1=firstOrigRect.top-containerRect.top+firstOrigRect.height/2;
-    var y2=lastReplRect.top-containerRect.top+lastReplRect.height/2;
-    var xR=32,xL=14;var R=Math.min(4,Math.abs(y2-y1)/2);
-    var d;
-    if(Math.abs(y2-y1)<2){d='M '+xR+' '+y1+' L '+xR+' '+y2;}
-    else{d='M '+xR+' '+y1+' L '+(xL+R)+' '+y1+' A '+R+' '+R+' 0 0 1 '+xL+' '+(y1+R)+' L '+xL+' '+(y2-R)+' A '+R+' '+R+' 0 0 0 '+(xL+R)+' '+y2+' L '+xR+' '+y2;}
-    var path=document.createElementNS('http://www.w3.org/2000/svg','path');
-    path.setAttribute('d',d);path.classList.add('opt-bracket');path.dataset.optGroup=gid;
-    svg.appendChild(path);
+  var container = pane.querySelector('.opt-diff-container');
+  if (!container) return;
+  var groupIds = [];
+  container.querySelectorAll('[data-opt-group]').forEach(function(el) {
+    var gid = el.dataset.optGroup;
+    if (groupIds.indexOf(gid) < 0) groupIds.push(gid);
+  });
+  var edges = [];
+  for (var idx = 0; idx < groupIds.length; idx++) {
+    var gid = groupIds[idx];
+    var origEls = container.querySelectorAll('.opt-original[data-opt-group="' + gid + '"]');
+    var replEls = container.querySelectorAll('.opt-replacement[data-opt-group="' + gid + '"]');
+    if (!origEls.length || !replEls.length) continue;
+    edges.push({
+      from: origEls[0],
+      to: replEls[replEls.length - 1],
+      fromId: gid,
+      toId: gid,
+      fromPos: idx,
+      toPos: idx,
+      kind: 'bracket',
+      directed: false,
+    });
   }
-  container.insertBefore(svg,container.firstChild);
+  drawOrthogonalEdges(container, edges, {
+    svgClass: 'opt-diff-svg',
+    edgeClass: 'opt-bracket',
+    edgeKindClass: function() { return ''; },
+    markerKinds: [],  // brackets have no arrowhead
+    gutter: { laneWidth: 8, innerX: 14, entryX: 32, exitX: 32, cornerRadius: 4, minX: 6 },
+    endpointSelector: '[data-opt-group]',
+    endpointIdAttr: 'optGroup',
+  });
+  // Preserve the legacy data-opt-group attr so existing hover/click
+  // hooks in opt-item/diff wiring still resolve groups.
+  container.querySelectorAll('.opt-bracket').forEach(function(p) {
+    if (!p.dataset.optGroup && p.dataset.edgeFrom) p.dataset.optGroup = p.dataset.edgeFrom;
+  });
 }
 
 function clearOptHighlights(container) {
@@ -856,7 +867,6 @@ function navigateToWasmInstruction(funcEl, targetIdx) {
 
 // Draw orthogonal control-flow arrows in the gutter of each function.
 function drawWasmEdges(container) {
-  container.querySelectorAll('.wasm-edges-svg').forEach(function(s) { s.remove(); });
   var instrs = Array.from(container.querySelectorAll('.wasm-instr'));
   if (!instrs.length) return;
   var byIdx = {};
@@ -869,77 +879,277 @@ function drawWasmEdges(container) {
     if (!toIdxStr) continue;
     var tgt = byIdx[toIdxStr];
     if (!tgt) continue;
-    edges.push({ from: el, to: tgt, fromIdx: el.dataset.idx, toIdx: toIdxStr, fromPos: parseInt(el.dataset.idx), toPos: parseInt(toIdxStr) });
+    edges.push({
+      from: el,
+      to: tgt,
+      fromId: el.dataset.idx,
+      toId: toIdxStr,
+      fromPos: parseInt(el.dataset.idx),
+      toPos: parseInt(toIdxStr),
+      kind: parseInt(toIdxStr) >= parseInt(el.dataset.idx) ? 'forward' : 'back',
+    });
   }
-  if (!edges.length) return;
-  // Assign lanes by sorting edges by span length (shortest first, so
-  // the shortest occupy the innermost lanes).
-  edges.sort(function(a, b) { return Math.abs(a.toPos - a.fromPos) - Math.abs(b.toPos - b.fromPos); });
-  var laneAssignments = [];
-  for (var edge of edges) {
+  drawOrthogonalEdges(container, edges, {
+    svgClass: 'wasm-edges-svg',
+    edgeClass: 'wasm-edge',
+    edgeKindClass: function(e) { return 'wasm-edge-' + e.kind; },
+    arrowheadClass: 'wasm-arrowhead',
+    arrowheadIdPrefix: 'wasm-ah-' + ((container.dataset.funcIdx || '0').replace(/[^A-Za-z0-9]/g, '_')),
+    markerKinds: ['default'],
+    markerForEdge: function() { return 'default'; },
+    gutter: { laneWidth: 6, innerX: 24, entryX: 28, exitX: 28, cornerRadius: 4 },
+    endpointSelector: '.wasm-instr',
+    endpointIdAttr: 'idx',
+  });
+}
+
+// Shared orthogonal-edge renderer.  All four current edge views
+// (CFG pre- and post-SSA, WASM/ASM disassembly, and the optimiser
+// diff brackets) go through this helper so improvements to the
+// drawing, lane-assignment, hover, and accessibility story apply
+// uniformly.
+//
+// Contract:
+//
+//   drawOrthogonalEdges(container, edges, options)
+//
+// Inputs:
+//   container  — the DOM element that owns the edge SVG.  Must be
+//                position-relative so the absolutely-positioned SVG
+//                lines up with the endpoints.
+//   edges      — list of {from, to, fromId?, toId?, fromPos, toPos,
+//                kind?, directed?} descriptors.  ``from`` / ``to``
+//                are DOM elements whose bounding rects we anchor to.
+//                ``fromPos`` / ``toPos`` are monotonic integers used
+//                for lane assignment (smallest span gets innermost
+//                lane).  ``kind`` controls the CSS modifier class
+//                and the arrowhead picker.  ``directed`` (default
+//                true) toggles the arrowhead at the ``to`` end.
+//   options    — renderer knobs; see below.
+//
+// Options:
+//   svgClass            — class to put on the generated <svg>
+//                         element (also the "remove previous" key).
+//   edgeClass           — common class on every edge <path>
+//                         (default 'oe-edge').
+//   edgeKindClass       — function(edge) → class suffix, or a string
+//                         prefix appended with edge.kind.
+//   arrowheadClass      — class on the arrowhead <polygon> inside
+//                         each marker (default 'oe-arrowhead').
+//   arrowheadIdPrefix   — unique prefix for arrowhead marker IDs so
+//                         multiple SVGs on one page don't collide.
+//   markerKinds         — list of arrowhead kinds to define.
+//   markerForEdge       — function(edge) → kind name used as
+//                         ``marker-end="url(#<prefix>-<kind>)"``.
+//   gutter              — geometry: {laneWidth, innerX, entryX,
+//                         exitX, cornerRadius}.
+//   endpointSelector    — CSS selector for endpoint DOM elements
+//                         (used to wire hover-highlighting between
+//                         edges and their endpoints).
+//   endpointIdAttr      — data- attribute on each endpoint whose
+//                         value matches edge.fromId / edge.toId
+//                         (e.g. "block", "idx", "opt-group").
+//
+// The rendered edges carry three stable data-* attributes:
+//   data-edge-from  — edge.fromId (or edge.from's matching
+//                     endpoint id, if fromId is not given).
+//   data-edge-to    — edge.toId (as above).
+//   data-edge-kind  — edge.kind.
+//
+// Hover wiring (enabled whenever ``endpointSelector`` is provided):
+//   - Hovering an endpoint adds ``highlighted`` to every edge whose
+//     from-id or to-id matches that endpoint's data id, and adds
+//     ``oe-endpoint-highlight`` to the related endpoints.
+//   - Hovering an edge path adds ``highlighted`` to the edge and
+//     ``oe-endpoint-highlight`` to both endpoints.
+function drawOrthogonalEdges(container, edges, options) {
+  // Clean up any previous render so re-layouts don't stack SVGs.
+  if (options.svgClass) {
+    container.querySelectorAll('.' + options.svgClass).forEach(function(s) { s.remove(); });
+  }
+  if (!edges.length) return null;
+
+  // Lane assignment: shortest span first → innermost lane.
+  var sorted = edges.slice().sort(function(a, b) {
+    return Math.abs(a.toPos - a.fromPos) - Math.abs(b.toPos - b.fromPos);
+  });
+  var assigned = [];
+  for (var edge of sorted) {
     var lane = 0;
     while (true) {
-      var conflict = false;
-      for (var other of laneAssignments) {
+      var clash = false;
+      for (var other of assigned) {
         if (other.lane !== lane) continue;
         var a1 = Math.min(edge.fromPos, edge.toPos), a2 = Math.max(edge.fromPos, edge.toPos);
         var b1 = Math.min(other.fromPos, other.toPos), b2 = Math.max(other.fromPos, other.toPos);
-        if (!(a2 < b1 || a1 > b2)) { conflict = true; break; }
+        if (!(a2 < b1 || a1 > b2)) { clash = true; break; }
       }
-      if (!conflict) break;
+      if (!clash) break;
       lane++;
     }
     edge.lane = lane;
-    laneAssignments.push(edge);
+    assigned.push(edge);
   }
+
   var rect = container.getBoundingClientRect();
-  var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.classList.add('wasm-edges-svg');
+  var svgNs = 'http://www.w3.org/2000/svg';
+  var svg = document.createElementNS(svgNs, 'svg');
+  if (options.svgClass) svg.classList.add(options.svgClass);
+  svg.classList.add('oe-svg');
   svg.setAttribute('width', rect.width);
   svg.setAttribute('height', rect.height);
-  var fid = (container.dataset.funcIdx || '0').replace(/[^A-Za-z0-9]/g, '_');
-  // Arrowhead marker definitions
-  var defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
-  var marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
-  marker.setAttribute('id', 'wasm-ah-' + fid);
-  marker.setAttribute('viewBox', '0 0 8 6');
-  marker.setAttribute('refX', '8'); marker.setAttribute('refY', '3');
-  marker.setAttribute('markerWidth', '7'); marker.setAttribute('markerHeight', '5');
-  marker.setAttribute('orient', 'auto');
-  var poly = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
-  poly.setAttribute('points', '0 0, 8 3, 0 6');
-  poly.classList.add('wasm-arrowhead');
-  marker.appendChild(poly);
-  defs.appendChild(marker);
-  svg.appendChild(defs);
-  var laneW = 6; var innerX = 24;  // right edge of arrow lanes
-  var R = 4;
+
+  // Arrowhead markers (one per distinct kind).
+  var markerPrefix = options.arrowheadIdPrefix || 'oe-ah';
+  var markerKinds = options.markerKinds || ['default'];
+  if (markerKinds.length) {
+    var defs = document.createElementNS(svgNs, 'defs');
+    for (var kind of markerKinds) {
+      var marker = document.createElementNS(svgNs, 'marker');
+      marker.setAttribute('id', markerPrefix + '-' + kind);
+      marker.setAttribute('viewBox', '0 0 8 6');
+      marker.setAttribute('refX', '8');
+      marker.setAttribute('refY', '3');
+      marker.setAttribute('markerWidth', '7');
+      marker.setAttribute('markerHeight', '5');
+      marker.setAttribute('orient', 'auto');
+      var poly = document.createElementNS(svgNs, 'polygon');
+      poly.setAttribute('points', '0 0, 8 3, 0 6');
+      if (options.arrowheadClass) {
+        poly.classList.add(options.arrowheadClass);
+        poly.classList.add(options.arrowheadClass + '-' + kind);
+      }
+      marker.appendChild(poly);
+      defs.appendChild(marker);
+    }
+    svg.appendChild(defs);
+  }
+
+  var g = options.gutter || {};
+  var laneW = g.laneWidth != null ? g.laneWidth : 8;
+  var innerX = g.innerX != null ? g.innerX : 24;
+  var entryX = g.entryX != null ? g.entryX : 0;
+  var exitX = g.exitX != null ? g.exitX : 0;
+  var R = g.cornerRadius != null ? g.cornerRadius : 4;
+  var minX = g.minX != null ? g.minX : 4;
+
   for (var edge of edges) {
-    var fRect = edge.from.getBoundingClientRect();
-    var tRect = edge.to.getBoundingClientRect();
-    var y1 = fRect.top - rect.top + fRect.height / 2;
-    var y2 = tRect.top - rect.top + tRect.height / 2;
+    var fromRect = edge.from.getBoundingClientRect();
+    var toRect = edge.to.getBoundingClientRect();
+    var y1 = g.anchorFromY === 'bottom'
+      ? fromRect.bottom - rect.top - 4
+      : (g.anchorFromY === 'top' ? fromRect.top - rect.top + 4 : fromRect.top - rect.top + fromRect.height / 2);
+    var y2 = g.anchorToY === 'top'
+      ? toRect.top - rect.top + 8
+      : (g.anchorToY === 'bottom' ? toRect.bottom - rect.top - 4 : toRect.top - rect.top + toRect.height / 2);
     var laneX = innerX - edge.lane * laneW;
-    if (laneX < 4) laneX = 4;
+    if (laneX < minX) laneX = minX;
+    // Compute from/to X anchors: CFG edges anchor to each block's
+    // left edge (so the gutter is outside the block); disassembly
+    // edges anchor to a fixed exit column.
+    var xFrom, xTo;
+    if (g.anchorFromX === 'left-of') {
+      xFrom = fromRect.left - rect.left;
+    } else {
+      xFrom = entryX;
+    }
+    if (g.anchorToX === 'left-of') {
+      xTo = toRect.left - rect.left;
+    } else {
+      xTo = exitX;
+    }
     var goingDown = y2 >= y1;
-    var dy = goingDown ? 1 : -1;
-    var xFrom = 28, xTo = 28;
-    var d = 'M ' + xFrom + ' ' + y1
-          + ' L ' + (laneX + R) + ' ' + y1
-          + ' A ' + R + ' ' + R + ' 0 0 ' + (goingDown ? 1 : 0) + ' ' + laneX + ' ' + (y1 + dy * R)
-          + ' L ' + laneX + ' ' + (y2 - dy * R)
-          + ' A ' + R + ' ' + R + ' 0 0 ' + (goingDown ? 0 : 1) + ' ' + (laneX + R) + ' ' + y2
-          + ' L ' + xTo + ' ' + y2;
-    var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    var d;
+    if (Math.abs(y2 - y1) < 2) {
+      d = 'M ' + xFrom + ' ' + y1 + ' L ' + xTo + ' ' + y2;
+    } else {
+      var dy = goingDown ? 1 : -1;
+      d = 'M ' + xFrom + ' ' + y1
+        + ' L ' + (laneX + R) + ' ' + y1
+        + ' A ' + R + ' ' + R + ' 0 0 ' + (goingDown ? 1 : 0) + ' ' + laneX + ' ' + (y1 + dy * R)
+        + ' L ' + laneX + ' ' + (y2 - dy * R)
+        + ' A ' + R + ' ' + R + ' 0 0 ' + (goingDown ? 0 : 1) + ' ' + (laneX + R) + ' ' + y2
+        + ' L ' + xTo + ' ' + y2;
+    }
+    var path = document.createElementNS(svgNs, 'path');
     path.setAttribute('d', d);
-    path.classList.add('wasm-edge');
-    path.classList.add(goingDown ? 'wasm-edge-forward' : 'wasm-edge-back');
-    path.dataset.from = edge.fromIdx;
-    path.dataset.to = edge.toIdx;
-    path.setAttribute('marker-end', 'url(#wasm-ah-' + fid + ')');
+    path.classList.add('oe-edge');
+    if (options.edgeClass) path.classList.add(options.edgeClass);
+    var kindClass = typeof options.edgeKindClass === 'function' ? options.edgeKindClass(edge) : (options.edgeKindClass && edge.kind ? options.edgeKindClass + edge.kind : '');
+    if (kindClass) path.classList.add(kindClass);
+    if (edge.fromId != null) path.dataset.edgeFrom = edge.fromId;
+    if (edge.toId != null) path.dataset.edgeTo = edge.toId;
+    if (edge.kind != null) path.dataset.edgeKind = edge.kind;
+    // Preserve legacy data attrs that older CSS and hover handlers
+    // keyed off of, so existing styles keep working.
+    if (edge.fromId != null) path.dataset.from = edge.fromId;
+    if (edge.toId != null) path.dataset.to = edge.toId;
+    if (edge.directed !== false) {
+      var marker = options.markerForEdge ? options.markerForEdge(edge) : 'default';
+      if (marker) path.setAttribute('marker-end', 'url(#' + markerPrefix + '-' + marker + ')');
+    }
     svg.appendChild(path);
   }
   container.insertBefore(svg, container.firstChild);
+
+  // Hover wiring — happens once per container.  Re-renders replace
+  // the SVG but keep the container, so we only install the listener
+  // on first mount.
+  if (options.endpointSelector && !container._oeHoverWired) {
+    container._oeHoverWired = true;
+    container.addEventListener('mouseover', function(e) {
+      // 1) hover a path → highlight endpoints
+      var path = e.target.closest && e.target.closest('.oe-edge');
+      if (path) {
+        path.classList.add('highlighted');
+        highlightOrthogonalEndpoints(container, options, path.dataset.edgeFrom, path.dataset.edgeTo);
+        return;
+      }
+      // 2) hover an endpoint → highlight related edges + paired endpoints
+      var endpoint = e.target.closest(options.endpointSelector);
+      if (!endpoint) return;
+      var id = endpoint.dataset[options.endpointIdAttr];
+      if (id == null) return;
+      container.querySelectorAll('.oe-edge').forEach(function(p) {
+        if (p.dataset.edgeFrom === id || p.dataset.edgeTo === id) {
+          p.classList.add('highlighted');
+        }
+      });
+      container.querySelectorAll('.oe-edge.highlighted').forEach(function(p) {
+        highlightOrthogonalEndpoints(container, options, p.dataset.edgeFrom, p.dataset.edgeTo);
+      });
+    });
+    container.addEventListener('mouseout', function(e) {
+      var path = e.target.closest && e.target.closest('.oe-edge');
+      if (path) {
+        path.classList.remove('highlighted');
+        clearOrthogonalEndpointHighlights(container);
+        return;
+      }
+      var endpoint = e.target.closest(options.endpointSelector);
+      if (!endpoint) return;
+      container.querySelectorAll('.oe-edge.highlighted').forEach(function(p) { p.classList.remove('highlighted'); });
+      clearOrthogonalEndpointHighlights(container);
+    });
+  }
+  return svg;
+}
+
+function highlightOrthogonalEndpoints(container, options, fromId, toId) {
+  if (!options.endpointSelector) return;
+  var idAttr = options.endpointIdAttr;
+  container.querySelectorAll(options.endpointSelector).forEach(function(el) {
+    var id = el.dataset[idAttr];
+    if (id != null && (id === fromId || id === toId)) {
+      el.classList.add('oe-endpoint-highlight');
+    }
+  });
+}
+
+function clearOrthogonalEndpointHighlights(container) {
+  container.querySelectorAll('.oe-endpoint-highlight').forEach(function(el) {
+    el.classList.remove('oe-endpoint-highlight');
+  });
 }
 
 // Opt diff — semantic-change-only comparison between the original and
@@ -995,6 +1205,15 @@ function openOptDiffView(paneId, kind) {
   var closeBtn = pane.querySelector('[data-disasm-diff-close]');
   if (closeBtn) closeBtn.addEventListener('click', function() { renderDisassembly(paneId, kind); });
   setupHoverHighlighting(pane);
+  // Draw control-flow arrows on the green (new) code in each diff
+  // block — only edges whose source and target are both visible
+  // opt-side rows get rendered, so same-segment elisions don't
+  // produce dangling arrows.
+  requestAnimationFrame(function() {
+    pane.querySelectorAll('.disasm-diff-rows.wasm-edges-container').forEach(function(c) {
+      drawWasmEdges(c);
+    });
+  });
 }
 
 function buildOptDiffBlockHtml(name, origEntry, optEntry, kind) {
@@ -1002,7 +1221,11 @@ function buildOptDiffBlockHtml(name, origEntry, optEntry, kind) {
   var optRows = optEntry ? normaliseForDiff(optEntry, kind) : [];
   var segments = computeDiffSegments(origRows.map(function(r) { return r.key; }), optRows.map(function(r) { return r.key; }));
   var changed = segments.some(function(s) { return s.type !== 'same'; });
-  var html = '<div class="wasm-function disasm-diff-block">';
+  // Visible opt-side rows contribute to the control-flow arrow
+  // overlay (drawn alongside the green/new code).  Track which opt
+  // instruction indices are shown so we can wire edges to them.
+  var visibleOptIdx = new Set();
+  var html = '<div class="wasm-function disasm-diff-block" data-func-name="' + esc(name) + '">';
   var badge = !origEntry ? '<span class="disasm-diff-badge disasm-diff-added">new</span>'
              : !optEntry ? '<span class="disasm-diff-badge disasm-diff-removed">removed</span>'
              : !changed ? '<span class="disasm-diff-badge disasm-diff-same">unchanged</span>'
@@ -1013,36 +1236,63 @@ function buildOptDiffBlockHtml(name, origEntry, optEntry, kind) {
     html += '</div>';
     return { html: html, changed: false };
   }
-  html += '<div class="disasm-diff-rows">';
+  // Wrap the rows in a ``wasm-edges-container`` so the shared
+  // orthogonal-edge renderer can target it directly, keyed by the
+  // ``data-idx`` stamped onto each visible opt-side row.
+  html += '<div class="disasm-diff-rows wasm-edges-container" data-diff-func-name="' + esc(name) + '">';
   for (var seg of segments) {
     if (seg.type === 'same') {
-      var shown = Math.min(seg.origEnd - seg.origStart, 1);
+      // For same segments show the opt-side row (not the orig side)
+      // so ``data-idx`` stays in the opt instruction space and
+      // arrows land correctly.
+      var shown = Math.min(seg.optEnd - seg.optStart, 1);
       for (var i = 0; i < shown; i++) {
-        var row = origRows[seg.origStart + i];
-        html += renderDiffRow(row, 'same');
+        var row = optRows[seg.optStart + i];
+        if (row && row.instrIdx != null) visibleOptIdx.add(row.instrIdx);
+        html += renderDiffRow(row, 'same', 'opt');
       }
-      var hiddenCount = (seg.origEnd - seg.origStart) - shown;
+      var hiddenCount = (seg.optEnd - seg.optStart) - shown;
       if (hiddenCount > 0) {
         html += '<div class="disasm-diff-elide">&hellip; ' + hiddenCount + ' unchanged instruction' + (hiddenCount === 1 ? '' : 's') + '</div>';
       }
     } else {
-      for (var i = seg.origStart; i < seg.origEnd; i++) html += renderDiffRow(origRows[i], 'removed');
-      for (var i = seg.optStart; i < seg.optEnd; i++) html += renderDiffRow(optRows[i], 'added');
+      for (var i = seg.origStart; i < seg.origEnd; i++) html += renderDiffRow(origRows[i], 'removed', 'orig');
+      for (var i = seg.optStart; i < seg.optEnd; i++) {
+        var row = optRows[i];
+        if (row && row.instrIdx != null) visibleOptIdx.add(row.instrIdx);
+        html += renderDiffRow(row, 'added', 'opt');
+      }
     }
   }
   html += '</div></div>';
-  return { html: html, changed: changed };
+  return { html: html, changed: changed, visibleOptIdx: visibleOptIdx };
 }
 
-function renderDiffRow(row, state) {
+function renderDiffRow(row, state, side) {
   if (!row) return '';
   var cls = 'disasm-diff-row disasm-diff-' + state;
+  // Added/same rows double as control-flow arrow endpoints via the
+  // same ``wasm-instr`` / ``data-idx`` contract that the live
+  // disassembly uses.  Removed rows are just text.
+  if (side === 'opt' && row.instrIdx != null) cls += ' wasm-instr';
   var sigil = state === 'added' ? '+' : (state === 'removed' ? '−' : ' ');
   var rng = row.range;
   var rngAttrs = rng ? ' data-start="' + rng.startOffset + '" data-end="' + rng.endOffset + '"' : '';
-  return '<div class="' + cls + '"' + rngAttrs + '>'
+  var idxAttr = (side === 'opt' && row.instrIdx != null) ? ' data-idx="' + row.instrIdx + '"' : '';
+  // The normalised display already carries a ``.wasm-branch-target``
+  // span for branching instructions; for opt-side rows we thread
+  // ``data-branch-target-idx`` onto it so ``drawWasmEdges`` can
+  // find the endpoint from inside the diff container.
+  var displayHtml = row.displayHtml;
+  if (side === 'opt' && row.branchTargetIdx != null) {
+    displayHtml = displayHtml.replace(
+      /<span class="wasm-branch-target"/,
+      '<span class="wasm-branch-target" data-branch-target-idx="' + row.branchTargetIdx + '"'
+    );
+  }
+  return '<div class="' + cls + '"' + idxAttr + rngAttrs + '>'
        + '<span class="disasm-diff-sigil">' + sigil + '</span>'
-       + '<span class="disasm-diff-text">' + row.displayHtml + '</span>'
+       + '<span class="disasm-diff-text">' + displayHtml + '</span>'
        + '</div>';
 }
 
@@ -1063,6 +1313,8 @@ function normaliseForDiff(entry, kind) {
         key: 'LABEL:' + ins.label,
         displayHtml: '<span class="disasm-label-anchor"># ' + esc(ins.label) + ':</span>',
         range: null,
+        instrIdx: ins.idx,
+        branchTargetIdx: null,
       });
       continue;
     }
@@ -1118,10 +1370,20 @@ function normaliseForDiff(entry, kind) {
         displayParts.push('<span class="wasm-comment">;; ' + esc(ins.label) + '</span>');
       }
     }
+    // Record the stable instruction idx + resolved branch target so
+    // the diff view can draw control-flow arrows on the green side.
+    var branchTargetIdx = null;
+    if (kind === 'asm' && ins.jumpTarget && ins.jumpTarget.targetIdx != null) {
+      branchTargetIdx = ins.jumpTarget.targetIdx;
+    } else if (kind === 'wasm' && ins.branchTarget && ins.branchTarget.targetIdx != null) {
+      branchTargetIdx = ins.branchTarget.targetIdx;
+    }
     rows.push({
       key: parts.join(' '),
       displayHtml: displayParts.join(' '),
       range: ins.range,
+      instrIdx: ins.idx,
+      branchTargetIdx: branchTargetIdx,
     });
   }
   return rows;
@@ -1186,65 +1448,51 @@ function showVarTooltip(el,v){
 function hideVarTooltip(){if(activeTooltip){activeTooltip.remove();activeTooltip=null;}}
 
 // CFG edge arrows
-function drawAllCfgEdges(pane,funcs){
-  pane.querySelectorAll('.cfg-edges-svg').forEach(function(s){s.remove()});
-  for(var func of funcs){
-    var container=pane.querySelector('.cfg-edges-container[data-func="'+func.name+'"]');
-    if(!container)continue;
-    var edges=[];
-    for(var block of func.blocks){
-      if(!block.successors)continue;
-      var term=block.terminator;
-      for(var target of block.successors){
-        var edgeType='goto';
-        if(term&&term.type==='branch')edgeType=target===term.trueTarget?'true':'false';
-        edges.push({from:block.name,to:target,edgeType:edgeType});
+function drawAllCfgEdges(pane, funcs) {
+  for (var func of funcs) {
+    var container = pane.querySelector('.cfg-edges-container[data-func="' + func.name + '"]');
+    if (!container) continue;
+    var blockEls = {};
+    container.querySelectorAll('.cfg-block[data-block]').forEach(function(el) { blockEls[el.dataset.block] = el; });
+    var edges = [];
+    var positions = {};
+    Object.keys(blockEls).forEach(function(name, i) { positions[name] = i; });
+    for (var block of func.blocks) {
+      if (!block.successors) continue;
+      var term = block.terminator;
+      for (var target of block.successors) {
+        var kind = 'goto';
+        if (term && term.type === 'branch') kind = target === term.trueTarget ? 'true' : 'false';
+        var fromEl = blockEls[block.name];
+        var toEl = blockEls[target];
+        if (!fromEl || !toEl) continue;
+        edges.push({
+          from: fromEl,
+          to: toEl,
+          fromId: block.name,
+          toId: target,
+          fromPos: positions[block.name] != null ? positions[block.name] : 0,
+          toPos: positions[target] != null ? positions[target] : 0,
+          kind: kind,
+        });
       }
     }
-    if(!edges.length)continue;
-    var containerRect=container.getBoundingClientRect();
-    var blockEls={};container.querySelectorAll('.cfg-block[data-block]').forEach(function(el){blockEls[el.dataset.block]=el;});
-    var svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
-    svg.classList.add('cfg-edges-svg');svg.setAttribute('width',containerRect.width);svg.setAttribute('height',containerRect.height);
-    var defs=document.createElementNS('http://www.w3.org/2000/svg','defs');
-    var fid=func.name.replace(/[^A-Za-z0-9]/g,'_');
-    for(var type of ['goto','true','false']){
-      var marker=document.createElementNS('http://www.w3.org/2000/svg','marker');
-      marker.setAttribute('id','ah-'+type+'-'+fid);marker.setAttribute('viewBox','0 0 8 6');marker.setAttribute('refX','8');marker.setAttribute('refY','3');marker.setAttribute('markerWidth','7');marker.setAttribute('markerHeight','5');marker.setAttribute('orient','auto');
-      var poly=document.createElementNS('http://www.w3.org/2000/svg','polygon');poly.setAttribute('points','0 0, 8 3, 0 6');poly.classList.add('cfg-arrowhead','cfg-arrowhead-'+type);
-      marker.appendChild(poly);defs.appendChild(marker);
-    }
-    svg.appendChild(defs);
-    var R=4,LANE_W=8,GUTTER_BASE=36;
-    for(var i=0;i<edges.length;i++){
-      var edge=edges[i];var fromEl=blockEls[edge.from];var toEl=blockEls[edge.to];
-      if(!fromEl||!toEl)continue;
-      var fromRect=fromEl.getBoundingClientRect();var toRect=toEl.getBoundingClientRect();
-      var blockLeft=fromRect.left-containerRect.left;
-      var x1=blockLeft,y1=fromRect.bottom-containerRect.top-4;
-      var x2=toRect.left-containerRect.left,y2=toRect.top-containerRect.top+8;
-      var laneX=GUTTER_BASE-i*LANE_W;var goingDown=y2>y1;
-      var d;
-      if(Math.abs(y2-y1)<2){d='M '+x1+' '+y1+' L '+x2+' '+y2;}
-      else{
-        var dy=goingDown?1:-1;
-        d='M '+x1+' '+y1+' L '+(laneX+R)+' '+y1+' A '+R+' '+R+' 0 0 '+(goingDown?1:0)+' '+laneX+' '+(y1+dy*R)+' L '+laneX+' '+(y2-dy*R)+' A '+R+' '+R+' 0 0 '+(goingDown?0:1)+' '+(laneX+R)+' '+y2+' L '+x2+' '+y2;
-      }
-      var path=document.createElementNS('http://www.w3.org/2000/svg','path');
-      path.setAttribute('d',d);path.classList.add('cfg-edge','cfg-edge-'+edge.edgeType);
-      path.dataset.from=edge.from;path.dataset.to=edge.to;
-      path.setAttribute('marker-end','url(#ah-'+edge.edgeType+'-'+fid+')');
-      svg.appendChild(path);
-    }
-    container.insertBefore(svg,container.firstChild);
-    container.addEventListener('mouseover',function(e){
-      var block=e.target.closest('.cfg-block[data-block]');if(!block)return;
-      var bn=block.dataset.block;
-      svg.querySelectorAll('.cfg-edge').forEach(function(p){if(p.dataset.from===bn||p.dataset.to===bn)p.classList.add('highlighted');});
-    });
-    container.addEventListener('mouseout',function(e){
-      var block=e.target.closest('.cfg-block[data-block]');if(!block)return;
-      svg.querySelectorAll('.cfg-edge.highlighted').forEach(function(p){p.classList.remove('highlighted')});
+    var fid = func.name.replace(/[^A-Za-z0-9]/g, '_');
+    drawOrthogonalEdges(container, edges, {
+      svgClass: 'cfg-edges-svg',
+      edgeClass: 'cfg-edge',
+      edgeKindClass: function(e) { return 'cfg-edge-' + e.kind; },
+      arrowheadClass: 'cfg-arrowhead',
+      arrowheadIdPrefix: 'cfg-ah-' + fid,
+      markerKinds: ['true', 'false', 'goto'],
+      markerForEdge: function(e) { return e.kind; },
+      gutter: {
+        laneWidth: 8, innerX: 36, cornerRadius: 4,
+        anchorFromX: 'left-of', anchorToX: 'left-of',
+        anchorFromY: 'bottom', anchorToY: 'top',
+      },
+      endpointSelector: '.cfg-block[data-block]',
+      endpointIdAttr: 'block',
     });
   }
 }

--- a/explorer/static/explorer-core.js
+++ b/explorer/static/explorer-core.js
@@ -873,21 +873,31 @@ function drawWasmEdges(container) {
   for (var el of instrs) byIdx[el.dataset.idx] = el;
   var edges = [];
   for (var el of instrs) {
-    var bt = el.querySelector('.wasm-branch-target');
-    if (!bt) continue;
-    var toIdxStr = bt.dataset.branchTargetIdx;
-    if (!toIdxStr) continue;
-    var tgt = byIdx[toIdxStr];
-    if (!tgt) continue;
-    edges.push({
-      from: el,
-      to: tgt,
-      fromId: el.dataset.idx,
-      toId: toIdxStr,
-      fromPos: parseInt(el.dataset.idx),
-      toPos: parseInt(toIdxStr),
-      kind: parseInt(toIdxStr) >= parseInt(el.dataset.idx) ? 'forward' : 'back',
-    });
+    // One row can carry multiple branch targets — a ``jumpTable``
+    // instruction in Tcl ASM renders one ``.wasm-branch-target``
+    // span per ``pattern->label`` pair, plus potentially a fallback
+    // target.  Emit one edge per target so every arm in a switch
+    // dispatch shows up in the gutter.  ``querySelector`` (which we
+    // previously used) only caught the first span.
+    var bts = el.querySelectorAll('.wasm-branch-target');
+    if (!bts.length) continue;
+    var fromIdx = el.dataset.idx;
+    var fromPos = parseInt(fromIdx);
+    for (var bt of bts) {
+      var toIdxStr = bt.dataset.branchTargetIdx;
+      if (!toIdxStr) continue;
+      var tgt = byIdx[toIdxStr];
+      if (!tgt) continue;
+      edges.push({
+        from: el,
+        to: tgt,
+        fromId: fromIdx,
+        toId: toIdxStr,
+        fromPos: fromPos,
+        toPos: parseInt(toIdxStr),
+        kind: parseInt(toIdxStr) >= fromPos ? 'forward' : 'back',
+      });
+    }
   }
   drawOrthogonalEdges(container, edges, {
     svgClass: 'wasm-edges-svg',

--- a/explorer/static/explorer-core.js
+++ b/explorer/static/explorer-core.js
@@ -495,9 +495,342 @@ function renderFuncList(paneId, funcs, emptyMsg) {
 }
 
 function renderAsm() { renderFuncList('pane-asm', data.asm, 'No assembly'); }
-function renderWasm() { renderFuncList('pane-wasm', data.wasm, 'No WASM output'); }
 function renderAsmOpt() { renderFuncList('pane-asm-opt', data.asmOptimised, 'No optimised assembly (source unchanged by optimiser)'); }
-function renderWasmOpt() { renderFuncList('pane-wasm-opt', data.wasmOptimised, 'No optimised WASM output (source unchanged by optimiser)'); }
+
+// WASM disassembly — structured per-instruction renderer with
+// click-to-source, call/branch target cross-navigation, source-line
+// comments above each instruction group, and control-flow arrows.
+
+function renderWasm() { renderWasmFuncList('pane-wasm', data.wasm, 'No WASM output'); }
+function renderWasmOpt() { renderWasmFuncList('pane-wasm-opt', data.wasmOptimised, 'No optimised WASM output (source unchanged by optimiser)'); }
+
+function renderWasmFuncList(paneId, funcs, emptyMsg) {
+  var pane = $('#' + paneId);
+  if (!funcs || !funcs.length) { pane.innerHTML = '<div class="empty-state">' + emptyMsg + '</div>'; return; }
+  // Legacy text-only payload from old Python builds — fall back to the
+  // plain <pre> renderer so the pane still has something to show.
+  var hasStructured = funcs.some(function(f) { return Array.isArray(f.instructions); });
+  if (!hasStructured) { pane.innerHTML = funcListHtml(funcs); return; }
+  var html = funcs.map(renderWasmEntry).join('');
+  pane.innerHTML = html;
+  setupWasmInteractions(pane, funcs);
+  requestAnimationFrame(function() {
+    pane.querySelectorAll('.wasm-edges-container').forEach(function(c) { drawWasmEdges(c); });
+  });
+}
+
+function renderWasmEntry(entry) {
+  if (entry.kind === 'module') return renderWasmModuleHeader(entry);
+  return renderWasmFunction(entry);
+}
+
+function renderWasmModuleHeader(entry) {
+  var html = '<div class="wasm-module">';
+  html += '<div class="wasm-func-header">(module) <span class="wasm-comment">' + entry.imports.length + ' imports, ' + entry.types.length + ' types, ' + entry.dataSegments.length + ' data segments</span></div>';
+  if (entry.imports.length) {
+    html += '<details class="wasm-module-details"><summary>imports (' + entry.imports.length + ')</summary>';
+    for (var imp of entry.imports) {
+      html += '<div class="wasm-import-entry">';
+      html += '<span class="wasm-idx">' + imp.funcIdx + '</span>';
+      html += '<span class="wasm-mnemonic">import</span> ';
+      html += '<span class="wasm-operand">&quot;' + esc(imp.module) + '&quot;.&quot;' + esc(imp.name) + '&quot;</span> ';
+      html += '<span class="wasm-comment">; type $t' + imp.typeIdx + '</span>';
+      html += '</div>';
+    }
+    html += '</details>';
+  }
+  if (entry.dataSegments.length) {
+    html += '<details class="wasm-module-details"><summary>data segments (' + entry.dataSegments.length + ')</summary>';
+    for (var seg of entry.dataSegments) {
+      html += '<div class="wasm-import-entry"><span class="wasm-idx">' + seg.offset + '</span><span class="wasm-comment">; ' + seg.size + ' bytes</span></div>';
+    }
+    html += '</details>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function renderWasmFunction(entry) {
+  var sr = entry.sourceRange;
+  var headerAttrs = sr ? ' data-start="' + sr.startOffset + '" data-end="' + sr.endOffset + '"' : '';
+  var html = '<div class="wasm-function" data-func-idx="' + entry.funcIdx + '" data-func-name="' + esc(entry.name) + '">';
+  var params = (entry.params || []).map(function(p) { return '(param ' + esc(p.name) + ' ' + esc(p.type) + ')'; }).join(' ');
+  var results = (entry.results || []).map(function(r) { return '(result ' + esc(r) + ')'; }).join(' ');
+  var kindBadge = entry.kind === 'top' ? ' <span class="wasm-kind-badge">top</span>' : (entry.kind === 'method' ? ' <span class="wasm-kind-badge">method</span>' : '');
+  html += '<div class="wasm-func-header"' + headerAttrs + '>';
+  html += '(func <span class="wasm-func-name">$' + esc(entry.name) + '</span>' + kindBadge + ' ' + params + (results ? ' ' + results : '') + ')';
+  html += ' <span class="wasm-comment">; ' + entry.instrCount + ' instructions</span>';
+  html += '</div>';
+  if (entry.locals && entry.locals.length) {
+    html += '<div class="wasm-func-locals">';
+    for (var loc of entry.locals) {
+      html += '<div class="wasm-local">(local ' + esc(loc.name) + ' ' + esc(loc.type) + ')</div>';
+    }
+    html += '</div>';
+  }
+  html += '<div class="wasm-func-body wasm-edges-container" data-func-idx="' + entry.funcIdx + '">';
+  var source = getSource();
+  var prevRangeKey = null;
+  for (var ins of entry.instructions) {
+    var r = ins.range;
+    var rkey = r ? r.startOffset + '/' + r.endOffset : null;
+    if (rkey && rkey !== prevRangeKey) {
+      var snippet = wasmSourceSnippet(source, r);
+      html += '<div class="wasm-src-comment" data-start="' + r.startOffset + '" data-end="' + r.endOffset + '">'
+            + '<span class="wasm-gutter-pad"></span>'
+            + '<span class="wasm-idx">' + (r.startLine + 1) + '</span>'
+            + '<span class="wasm-src-text">; ' + esc(snippet) + '</span>'
+            + '</div>';
+      prevRangeKey = rkey;
+    }
+    html += renderWasmInstruction(ins, entry);
+  }
+  html += '</div></div>';
+  return html;
+}
+
+function wasmSourceSnippet(source, range) {
+  // Grab the entire source line that contains range.startOffset, then
+  // trim to at most 160 characters for the comment.
+  var nl = source.indexOf('\n', range.startOffset);
+  var lineEnd = nl === -1 ? source.length : nl;
+  // Find start of line
+  var lineStart = source.lastIndexOf('\n', range.startOffset - 1) + 1;
+  var line = source.substring(lineStart, lineEnd).replace(/^\s+/, '');
+  if (line.length > 160) line = line.substring(0, 157) + '...';
+  return line;
+}
+
+function renderWasmInstruction(ins, entry) {
+  var range = ins.range;
+  var rngAttrs = range ? ' data-start="' + range.startOffset + '" data-end="' + range.endOffset + '"' : '';
+  var indentSpaces = '    '.repeat(Math.max(0, ins.indent));
+  var operandHtml = '';
+  if (ins.callTarget) {
+    var ct = ins.callTarget;
+    var ctLabel = ct.kind === 'import' ? ('import ' + ct.name) : ct.name;
+    var ctAttrs = ' data-call-target-def-idx="' + (ct.defIdx !== null && ct.defIdx !== undefined ? ct.defIdx : '') + '"'
+                + ' data-call-target-kind="' + esc(ct.kind) + '"'
+                + ' data-call-target-name="' + esc(ct.name) + '"';
+    operandHtml = ' <span class="wasm-operand">' + esc(ins.operandText) + '</span>'
+                + ' <span class="wasm-call-target"' + ctAttrs + '>; ' + esc(ctLabel) + '</span>';
+  } else if (ins.branchTarget) {
+    var bt = ins.branchTarget;
+    var btAttrs = ' data-branch-target-idx="' + (bt.targetIdx !== null && bt.targetIdx !== undefined ? bt.targetIdx : '') + '"';
+    var btLabel = bt.kind || '';
+    if (bt.label) btLabel += ' ' + bt.label;
+    operandHtml = ' <span class="wasm-operand">' + esc(ins.operandText) + '</span>'
+                + ' <span class="wasm-branch-target"' + btAttrs + '>; ' + esc(btLabel) + '</span>';
+  } else if (ins.op === 'local.get' || ins.op === 'local.set' || ins.op === 'local.tee') {
+    var parts = ins.fullText.split(' ');
+    operandHtml = ' <span class="wasm-operand">' + esc(ins.operandText) + '</span>';
+    if (parts.length > 2) operandHtml += ' <span class="wasm-operand-name">' + esc(parts.slice(2).join(' ')) + '</span>';
+  } else if (ins.operandText) {
+    operandHtml = ' <span class="wasm-operand">' + esc(ins.operandText) + '</span>';
+  }
+  var label = ins.label ? ' <span class="wasm-comment">;; ' + esc(ins.label) + '</span>' : '';
+  var blockLbl = ins.blockLabel ? ' <span class="wasm-block-label">' + esc(ins.blockLabel) + '</span>' : '';
+  var gutter = '<span class="wasm-gutter-pad"></span>';
+  return '<div class="wasm-instr" data-idx="' + ins.idx + '" data-func-idx="' + entry.funcIdx + '"' + rngAttrs + '>'
+       + gutter
+       + '<span class="wasm-idx">' + ins.idx + '</span>'
+       + '<span class="wasm-code"><span class="wasm-indent">' + indentSpaces + '</span>'
+       + '<span class="wasm-mnemonic">' + esc(ins.op) + '</span>'
+       + blockLbl
+       + operandHtml
+       + label
+       + '</span></div>';
+}
+
+function setupWasmInteractions(pane, funcs) {
+  // Build a defIdx → entry map from the funcs list so "call N" can
+  // resolve to the function block within the same pane.  Registered
+  // BEFORE setupHoverHighlighting so the call/branch-target short-
+  // circuits run first via ``stopImmediatePropagation``.
+  var funcEntries = funcs.filter(function(f) { return f.kind !== 'module'; });
+  pane.addEventListener('click', function(e) {
+    var ct = e.target.closest('.wasm-call-target');
+    if (ct) {
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+      var defIdxStr = ct.dataset.callTargetDefIdx;
+      if (defIdxStr !== '') {
+        var defIdx = parseInt(defIdxStr);
+        if (!isNaN(defIdx) && defIdx >= 0 && defIdx < funcEntries.length) {
+          navigateToWasmFunction(pane, funcEntries[defIdx]);
+        }
+      }
+      return;
+    }
+    var bt = e.target.closest('.wasm-branch-target');
+    if (bt) {
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+      var targetIdxStr = bt.dataset.branchTargetIdx;
+      if (targetIdxStr !== '') {
+        var targetIdx = parseInt(targetIdxStr);
+        if (!isNaN(targetIdx)) {
+          navigateToWasmInstruction(bt.closest('.wasm-function'), targetIdx);
+        }
+      }
+      return;
+    }
+  });
+  // Hover highlights matching branch arrows and block/end pairs.
+  pane.addEventListener('mouseover', function(e) {
+    var ins = e.target.closest('.wasm-instr');
+    if (!ins) return;
+    var idx = ins.dataset.idx;
+    var funcEl = ins.closest('.wasm-function');
+    if (!funcEl) return;
+    funcEl.querySelectorAll('.wasm-edge').forEach(function(p) {
+      if (p.dataset.from === idx || p.dataset.to === idx) p.classList.add('highlighted');
+    });
+  });
+  pane.addEventListener('mouseout', function(e) {
+    var ins = e.target.closest('.wasm-instr');
+    if (!ins) return;
+    var funcEl = ins.closest('.wasm-function');
+    if (!funcEl) return;
+    funcEl.querySelectorAll('.wasm-edge.highlighted').forEach(function(p) { p.classList.remove('highlighted'); });
+  });
+  // Delegate the normal [data-start] click-to-source behaviour to the
+  // consumer-supplied hook; registered second so the call/branch
+  // short-circuits above can intercept first.
+  setupHoverHighlighting(pane);
+}
+
+// Source-range highlight abstraction: standalone index.html defines
+// ``highlightSourceRanges`` for inline highlighting; the VS Code
+// webview uses postMessage.  We probe both so the WASM pane works in
+// either consumer.
+function wasmHighlightSource(start, end) {
+  if (typeof highlightSourceRanges === 'function') {
+    highlightSourceRanges([{start: start, end: end}]);
+    return;
+  }
+  if (typeof vscode !== 'undefined' && vscode.postMessage) {
+    vscode.postMessage({ type: 'highlightSource', start: start, end: end });
+  }
+}
+
+function navigateToWasmFunction(pane, targetEntry) {
+  if (!targetEntry) return;
+  var nameSel = targetEntry.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  var el = pane.querySelector('.wasm-function[data-func-name="' + nameSel + '"]');
+  if (el) {
+    el.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    // Flash-highlight the function header briefly.
+    var hdr = el.querySelector('.wasm-func-header');
+    if (hdr) {
+      hdr.classList.add('wasm-func-flash');
+      setTimeout(function() { hdr.classList.remove('wasm-func-flash'); }, 1200);
+    }
+    if (targetEntry.sourceRange) {
+      wasmHighlightSource(targetEntry.sourceRange.startOffset, targetEntry.sourceRange.endOffset);
+    }
+  }
+}
+
+function navigateToWasmInstruction(funcEl, targetIdx) {
+  if (!funcEl) return;
+  var el = funcEl.querySelector('.wasm-instr[data-idx="' + targetIdx + '"]');
+  if (!el) return;
+  el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  el.classList.add('wasm-instr-flash');
+  setTimeout(function() { el.classList.remove('wasm-instr-flash'); }, 1200);
+  var start = parseInt(el.dataset.start);
+  var end = parseInt(el.dataset.end);
+  if (!isNaN(start) && !isNaN(end)) wasmHighlightSource(start, end);
+}
+
+// Draw orthogonal control-flow arrows in the gutter of each function.
+function drawWasmEdges(container) {
+  container.querySelectorAll('.wasm-edges-svg').forEach(function(s) { s.remove(); });
+  var instrs = Array.from(container.querySelectorAll('.wasm-instr'));
+  if (!instrs.length) return;
+  var byIdx = {};
+  for (var el of instrs) byIdx[el.dataset.idx] = el;
+  var edges = [];
+  for (var el of instrs) {
+    var bt = el.querySelector('.wasm-branch-target');
+    if (!bt) continue;
+    var toIdxStr = bt.dataset.branchTargetIdx;
+    if (!toIdxStr) continue;
+    var tgt = byIdx[toIdxStr];
+    if (!tgt) continue;
+    edges.push({ from: el, to: tgt, fromIdx: el.dataset.idx, toIdx: toIdxStr, fromPos: parseInt(el.dataset.idx), toPos: parseInt(toIdxStr) });
+  }
+  if (!edges.length) return;
+  // Assign lanes by sorting edges by span length (shortest first, so
+  // the shortest occupy the innermost lanes).
+  edges.sort(function(a, b) { return Math.abs(a.toPos - a.fromPos) - Math.abs(b.toPos - b.fromPos); });
+  var laneAssignments = [];
+  for (var edge of edges) {
+    var lane = 0;
+    while (true) {
+      var conflict = false;
+      for (var other of laneAssignments) {
+        if (other.lane !== lane) continue;
+        var a1 = Math.min(edge.fromPos, edge.toPos), a2 = Math.max(edge.fromPos, edge.toPos);
+        var b1 = Math.min(other.fromPos, other.toPos), b2 = Math.max(other.fromPos, other.toPos);
+        if (!(a2 < b1 || a1 > b2)) { conflict = true; break; }
+      }
+      if (!conflict) break;
+      lane++;
+    }
+    edge.lane = lane;
+    laneAssignments.push(edge);
+  }
+  var rect = container.getBoundingClientRect();
+  var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.classList.add('wasm-edges-svg');
+  svg.setAttribute('width', rect.width);
+  svg.setAttribute('height', rect.height);
+  var fid = (container.dataset.funcIdx || '0').replace(/[^A-Za-z0-9]/g, '_');
+  // Arrowhead marker definitions
+  var defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+  var marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+  marker.setAttribute('id', 'wasm-ah-' + fid);
+  marker.setAttribute('viewBox', '0 0 8 6');
+  marker.setAttribute('refX', '8'); marker.setAttribute('refY', '3');
+  marker.setAttribute('markerWidth', '7'); marker.setAttribute('markerHeight', '5');
+  marker.setAttribute('orient', 'auto');
+  var poly = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+  poly.setAttribute('points', '0 0, 8 3, 0 6');
+  poly.classList.add('wasm-arrowhead');
+  marker.appendChild(poly);
+  defs.appendChild(marker);
+  svg.appendChild(defs);
+  var laneW = 6; var innerX = 24;  // right edge of arrow lanes
+  var R = 4;
+  for (var edge of edges) {
+    var fRect = edge.from.getBoundingClientRect();
+    var tRect = edge.to.getBoundingClientRect();
+    var y1 = fRect.top - rect.top + fRect.height / 2;
+    var y2 = tRect.top - rect.top + tRect.height / 2;
+    var laneX = innerX - edge.lane * laneW;
+    if (laneX < 4) laneX = 4;
+    var goingDown = y2 >= y1;
+    var dy = goingDown ? 1 : -1;
+    var xFrom = 28, xTo = 28;
+    var d = 'M ' + xFrom + ' ' + y1
+          + ' L ' + (laneX + R) + ' ' + y1
+          + ' A ' + R + ' ' + R + ' 0 0 ' + (goingDown ? 1 : 0) + ' ' + laneX + ' ' + (y1 + dy * R)
+          + ' L ' + laneX + ' ' + (y2 - dy * R)
+          + ' A ' + R + ' ' + R + ' 0 0 ' + (goingDown ? 0 : 1) + ' ' + (laneX + R) + ' ' + y2
+          + ' L ' + xTo + ' ' + y2;
+    var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', d);
+    path.classList.add('wasm-edge');
+    path.classList.add(goingDown ? 'wasm-edge-forward' : 'wasm-edge-back');
+    path.dataset.from = edge.fromIdx;
+    path.dataset.to = edge.toIdx;
+    path.setAttribute('marker-end', 'url(#wasm-ah-' + fid + ')');
+    svg.appendChild(path);
+  }
+  container.insertBefore(svg, container.firstChild);
+}
 
 // SSA variable spans with hover tooltips
 function renderVarSpan(name,version,type,lattice,role){

--- a/explorer/static/index.html
+++ b/explorer/static/index.html
@@ -730,6 +730,115 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
   0% { background: rgba(249, 226, 175, 0.5); }
   100% { background: transparent; }
 }
+/* Disassembly toolbar + opt diff */
+.disasm-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 4px 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 3;
+}
+.disasm-toolbar-opt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+.disasm-toolbar-opt input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; }
+.disasm-toolbar-opt input:disabled { cursor: not-allowed; opacity: 0.4; }
+.disasm-toolbar-diff {
+  background: var(--bg-surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.disasm-toolbar-diff:hover { border-color: var(--accent); background: var(--bg-hover); }
+.disasm-toolbar-diff:disabled { opacity: 0.4; cursor: not-allowed; }
+.disasm-toolbar-hint { font-size: 11px; color: var(--text-dim); font-style: italic; }
+.disasm-tables { margin-left: 40px; margin-bottom: 4px; color: var(--text-dim); font-size: 11px; }
+.disasm-tables summary { cursor: pointer; padding: 2px 0; }
+.disasm-tables summary:hover { color: var(--accent); }
+.disasm-tables-section { color: var(--text-dim); font-weight: 600; margin-top: 4px; }
+.disasm-label-row { cursor: default !important; }
+.disasm-label-row:hover { background: transparent; }
+.disasm-label-anchor { color: var(--magenta); font-weight: 500; }
+.disasm-diff-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 4px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.disasm-diff-title { font-weight: 600; color: var(--accent); font-size: 12px; }
+.disasm-diff-legend { font-size: 10px; display: flex; gap: 10px; }
+.disasm-diff-legend-removed { color: var(--red); }
+.disasm-diff-legend-added { color: var(--green); }
+.disasm-diff-legend-dim { color: var(--text-dim); font-style: italic; }
+.disasm-diff-close {
+  margin-left: auto;
+  background: var(--bg-surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+.disasm-diff-close:hover { border-color: var(--accent); color: var(--text); }
+.disasm-diff-block { border: 1px solid var(--border); background: var(--bg-surface); }
+.disasm-diff-badge {
+  font-size: 10px;
+  font-weight: 400;
+  padding: 1px 6px;
+  border-radius: 8px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.disasm-diff-added { background: rgba(166, 227, 161, 0.15); color: var(--green); }
+.disasm-diff-removed { background: rgba(243, 139, 168, 0.15); color: var(--red); }
+.disasm-diff-same { background: rgba(108, 112, 134, 0.15); color: var(--text-dim); }
+.disasm-diff-modified { background: rgba(249, 226, 175, 0.18); color: var(--yellow); }
+.disasm-diff-rows { padding-left: 4px; }
+.disasm-diff-row {
+  display: flex;
+  gap: 6px;
+  padding: 1px 6px;
+  border-radius: 2px;
+  white-space: pre;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.disasm-diff-row.disasm-diff-removed { background: rgba(243, 139, 168, 0.1); color: var(--text); }
+.disasm-diff-row.disasm-diff-removed .disasm-diff-sigil { color: var(--red); }
+.disasm-diff-row.disasm-diff-removed .disasm-diff-text { text-decoration: line-through; opacity: 0.75; }
+.disasm-diff-row.disasm-diff-added { background: rgba(166, 227, 161, 0.1); color: var(--text); }
+.disasm-diff-row.disasm-diff-added .disasm-diff-sigil { color: var(--green); }
+.disasm-diff-row.disasm-diff-same { background: transparent; color: var(--text-dim); opacity: 0.7; }
+.disasm-diff-row.disasm-diff-same .disasm-diff-sigil { color: var(--text-dim); }
+.disasm-diff-sigil { min-width: 14px; text-align: center; user-select: none; font-weight: 600; flex-shrink: 0; }
+.disasm-diff-text { flex: 1; white-space: pre; }
+.disasm-diff-elide {
+  padding: 2px 22px;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-style: italic;
+}
+.disasm-diff-unchanged-note { padding: 4px 8px; color: var(--text-dim); font-size: 11px; font-style: italic; }
 </style>
 <script src="mermaid.min.js"></script>
 <script>
@@ -816,8 +925,6 @@ puts $x"></textarea>
         <div class="tab" data-tab="callouts">Callouts</div>
         <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
-        <div class="tab" data-tab="asm-opt">Tcl ASM (opt)</div>
-        <div class="tab" data-tab="wasm-opt">WASM (opt)</div>
       </div>
       <div class="output-content" id="outputContent">
         <div class="tab-pane active" id="pane-ir">
@@ -837,8 +944,6 @@ puts $x"></textarea>
         <div class="tab-pane" id="pane-callouts"></div>
         <div class="tab-pane" id="pane-asm"></div>
         <div class="tab-pane" id="pane-wasm"></div>
-        <div class="tab-pane" id="pane-asm-opt"></div>
-        <div class="tab-pane" id="pane-wasm-opt"></div>
       </div>
     </div>
   </div>
@@ -1034,8 +1139,6 @@ function renderAll() {
   renderCallouts();
   renderAsm();
   renderWasm();
-  renderAsmOpt();
-  renderWasmOpt();
   updateBadges();
 }
 
@@ -1055,8 +1158,6 @@ function updateBadges() {
     'callouts': data.annotations.length,
     'asm': instrCount(data.asm),
     'wasm': instrCount(data.wasm),
-    'asm-opt': instrCount(data.asmOptimised),
-    'wasm-opt': instrCount(data.wasmOptimised),
   };
   $$('.tab').forEach(tab => {
     const key = tab.dataset.tab;

--- a/explorer/static/index.html
+++ b/explorer/static/index.html
@@ -675,6 +675,61 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
 }
 .tab.irules-only { display: none; }
 .tab.irules-only.irules-visible { display: flex; }
+/* WASM disassembly view */
+.wasm-module { margin-bottom: 16px; }
+.wasm-module-details { margin-left: 16px; font-size: 11px; color: var(--text-dim); }
+.wasm-module-details summary { cursor: pointer; color: var(--text); }
+.wasm-module-details summary:hover { color: var(--accent); }
+.wasm-import-entry { padding: 1px 0; white-space: pre; display: flex; gap: 6px; align-items: baseline; }
+.wasm-function { margin-bottom: 16px; border: 1px solid var(--border); border-radius: 4px; padding: 6px 8px; background: var(--bg-surface); }
+.wasm-function[data-func-idx] { position: relative; }
+.wasm-func-header { font-weight: 600; color: var(--cyan); margin-bottom: 4px; padding: 2px 4px; cursor: pointer; border-radius: 3px; transition: background 0.15s; font-size: 12px; }
+.wasm-func-header:hover { background: var(--highlight); }
+.wasm-func-header.wasm-func-flash { background: rgba(137, 180, 250, 0.3); animation: wasm-flash 1.2s ease-out; }
+.wasm-func-header .wasm-kind-badge { font-size: 10px; background: var(--bg-hover); color: var(--text-dim); padding: 1px 5px; border-radius: 8px; margin-left: 2px; font-weight: 400; }
+.wasm-func-name { color: var(--accent); }
+.wasm-func-locals { margin-left: 40px; padding: 2px 0; color: var(--text-dim); font-size: 11px; }
+.wasm-local { padding: 0 4px; }
+.wasm-func-body { font-size: 12px; line-height: 1.5; position: relative; padding-left: 36px; }
+.wasm-instr, .wasm-src-comment { display: flex; align-items: baseline; gap: 4px; padding: 1px 0; border-radius: 2px; position: relative; z-index: 2; white-space: pre; }
+.wasm-instr { cursor: pointer; }
+.wasm-instr:hover { background: var(--highlight); }
+.wasm-instr.highlighted { background: var(--highlight-strong); }
+.wasm-instr.wasm-instr-flash { background: rgba(249, 226, 175, 0.3); animation: wasm-flash 1.2s ease-out; }
+.wasm-src-comment { color: var(--green); cursor: pointer; padding-top: 4px; font-size: 11px; opacity: 0.85; }
+.wasm-src-comment:hover { background: var(--highlight); opacity: 1; }
+.wasm-src-comment .wasm-src-text { color: var(--green); }
+.wasm-gutter-pad { width: 0; flex-shrink: 0; }
+.wasm-idx { color: var(--gutter); min-width: 36px; user-select: none; text-align: right; font-size: 10px; padding-right: 8px; flex-shrink: 0; }
+.wasm-code { display: inline; flex: 1; min-width: 0; }
+.wasm-indent { color: transparent; }
+.wasm-mnemonic { color: var(--text-bright); font-weight: 500; }
+.wasm-operand { color: var(--text); }
+.wasm-operand-name { color: var(--green); }
+.wasm-block-label { color: var(--magenta); opacity: 0.6; font-size: 10px; margin-left: 2px; }
+.wasm-call-target, .wasm-branch-target { cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; padding: 0 2px; border-radius: 2px; }
+.wasm-call-target { color: var(--cyan); }
+.wasm-call-target:hover { color: var(--accent); background: rgba(137, 180, 250, 0.15); }
+.wasm-branch-target { color: var(--yellow); }
+.wasm-branch-target:hover { color: var(--orange); background: rgba(250, 179, 135, 0.15); }
+.wasm-comment { color: var(--text-dim); font-style: italic; }
+.wasm-edges-svg {
+  position: absolute;
+  top: 0; left: 0;
+  width: 36px; height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  overflow: visible;
+}
+.wasm-edge { fill: none; stroke-width: 1.2; opacity: 0.4; transition: opacity 0.15s, stroke-width 0.15s; }
+.wasm-edge-forward { stroke: var(--blue); }
+.wasm-edge-back { stroke: var(--yellow); stroke-dasharray: 3,2; }
+.wasm-edge.highlighted { opacity: 1; stroke-width: 2; }
+.wasm-arrowhead { fill: var(--blue); }
+@keyframes wasm-flash {
+  0% { background: rgba(249, 226, 175, 0.5); }
+  100% { background: transparent; }
+}
 </style>
 <script src="mermaid.min.js"></script>
 <script>

--- a/explorer/static/index.html
+++ b/explorer/static/index.html
@@ -467,14 +467,7 @@ textarea#source::placeholder { color: var(--text-dim); }
 }
 .source-line .code-text { white-space: pre; flex: 1; }
 .opt-diff-container { position: relative; padding-left: 36px; }
-.opt-diff-svg {
-  position: absolute;
-  top: 0; left: 0;
-  width: 36px; height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  overflow: visible;
-}
+.opt-diff-svg { width: 36px; }
 .opt-diff-line {
   display: flex;
   font-size: 12px;
@@ -498,8 +491,8 @@ textarea#source::placeholder { color: var(--text-dim); }
 .opt-diff-line.opt-replacement .gutter { color: var(--green); }
 .opt-diff-line.opt-input-highlight { background: rgba(137, 180, 250, 0.18) !important; opacity: 1 !important; }
 .opt-diff-line.opt-output-highlight { background: rgba(166, 227, 161, 0.18) !important; }
-.opt-bracket { fill: none; stroke: var(--text-dim); stroke-width: 1.5; opacity: 0.4; transition: opacity 0.15s, stroke 0.15s; }
-.opt-bracket.highlighted { stroke: var(--accent); opacity: 1; }
+.opt-bracket { fill: none; stroke: var(--text-dim); stroke-width: 1.5; }
+.opt-bracket.highlighted, .opt-bracket:hover { stroke: var(--accent); }
 .analysis-card {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -576,24 +569,23 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
   opacity: 0.5;
 }
 .cfg-edges-container { position: relative; padding-left: 40px; }
-.cfg-edges-svg {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  overflow: visible;
-}
-.cfg-edge { fill: none; stroke-width: 1.5; opacity: 0.45; transition: opacity 0.15s, stroke-width 0.15s; }
+/* Shared orthogonal-edge SVG: pointer-events on the SVG itself
+   stay ``none`` so clicks pass through to the content, but each
+   stroked <path> opts into pointer-events via ``stroke`` so hover
+   highlights the line directly without blocking click-to-source on
+   the underlying row. */
+.oe-svg { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 1; overflow: visible; }
+.oe-edge { fill: none; stroke-width: 1.5; opacity: 0.45; pointer-events: stroke; cursor: pointer; transition: opacity 0.15s, stroke-width 0.15s; }
+.oe-edge:hover, .oe-edge.highlighted { opacity: 1; stroke-width: 2.5; }
+.oe-endpoint-highlight { outline: 1px solid var(--accent); outline-offset: -1px; border-radius: 2px; background: rgba(137, 180, 250, 0.1); }
+.cfg-edges-svg { /* back-compat — uses .oe-svg behaviour */ }
+.cfg-edge { fill: none; stroke-width: 1.5; }
 .cfg-edge-true { stroke: var(--green); }
 .cfg-edge-false { stroke: var(--red); }
 .cfg-edge-goto { stroke: var(--text-dim); }
-.cfg-edge.highlighted { opacity: 1; stroke-width: 2; }
-.cfg-arrowhead { opacity: 0.45; transition: opacity 0.15s; }
 .cfg-arrowhead-true { fill: var(--green); }
 .cfg-arrowhead-false { fill: var(--red); }
 .cfg-arrowhead-goto { fill: var(--text-dim); }
-.cfg-arrowhead.highlighted { opacity: 1; }
 .cfg-block[data-block] { position: relative; z-index: 2; }
 .var-tooltip {
   position: fixed;
@@ -713,19 +705,12 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
 .wasm-branch-target { color: var(--yellow); }
 .wasm-branch-target:hover { color: var(--orange); background: rgba(250, 179, 135, 0.15); }
 .wasm-comment { color: var(--text-dim); font-style: italic; }
-.wasm-edges-svg {
-  position: absolute;
-  top: 0; left: 0;
-  width: 36px; height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  overflow: visible;
-}
-.wasm-edge { fill: none; stroke-width: 1.2; opacity: 0.4; transition: opacity 0.15s, stroke-width 0.15s; }
+.wasm-edges-svg { width: 36px; }
+.wasm-edge { fill: none; stroke-width: 1.2; }
 .wasm-edge-forward { stroke: var(--blue); }
 .wasm-edge-back { stroke: var(--yellow); stroke-dasharray: 3,2; }
-.wasm-edge.highlighted { opacity: 1; stroke-width: 2; }
 .wasm-arrowhead { fill: var(--blue); }
+.wasm-arrowhead-default { fill: var(--blue); }
 @keyframes wasm-flash {
   0% { background: rgba(249, 226, 175, 0.5); }
   100% { background: transparent; }


### PR DESCRIPTION
## Summary

This PR adds a rich, interactive disassembly view for WASM and Tcl bytecode (ASM) in the compiler explorer. Instead of plain text output, the explorer now renders per-instruction structured data with:

- **Resolved call/branch targets**: `call` instructions resolve to function names; `br`/`br_if` resolve to matching structural control-flow anchors
- **Source range navigation**: Each instruction carries its originating Tcl statement range for click-to-source
- **Interactive edges**: Orthogonal-path SVG connectors link call sites to function definitions and branch instructions to their targets
- **Optimisation toggling**: Users can switch between original and optimised versions (when available) via a toolbar checkbox
- **Optimiser diff view**: A "Show optimiser diff" button opens a side-by-side comparison of original vs. optimised code

### Key changes

**Frontend (`explorer/static/explorer-core.js`)**:
- Refactored `drawOptBrackets()` to use a new `drawOrthogonalEdges()` helper that renders SVG connectors with proper routing and corner radius
- Added `renderDisassembly()` to handle both ASM and WASM with a unified pipeline
- New toolbar with opt-toggle checkbox and diff button
- Instruction rendering functions (`renderAsmInstruction`, `renderWasmInstruction`, etc.) that emit structured HTML with data attributes for interactivity
- Hover/click handlers for call targets and branch targets that navigate within the pane
- Per-pane opt state tracking (`wasmOptState`) to preserve user choices across re-renders

**Backend (`core/compiler/codegen/`)**:
- `WasmModule.to_explorer_json()`: Produces structured per-instruction JSON with resolved targets, source ranges, and labels
- `format_module_explorer()` in `format.py`: Mirrors WASM shape for ASM, emitting instruction lists with jump target resolution
- `WasmInstruction` and `WasmFunction` now carry optional `range` and `label` fields for explorer metadata
- Emitter tracks `_current_range` and `_pending_label` to annotate instructions with source context and structural hints

**Serialisation (`explorer/serialise.py`)**:
- `_serialise_asm()` and `_serialise_wasm()` now call the new explorer formatters and attach both legacy `text` (WAT/ASM snippet) and structured `instructions` fields
- Frontend detects `instructions` presence and switches to rich renderer; falls back to plain text for legacy payloads

**Styling & HTML**:
- New CSS for WASM function blocks, instruction rows, labels, and module headers
- Shared `.oe-svg` / `.oe-edge` classes for orthogonal-edge SVG styling (used by both opt-diff and WASM/ASM views)
- Updated opt-bracket styling to use hover instead of opacity transitions

**Documentation**:
- Added `docs/design/contracts/wasm-explorer-view.md` specifying the JSON shape contract between backend and frontend

## Validation

- Existing tests pass (no breaking changes to compiler output or IR)
- Frontend gracefully falls back to plain text when `instructions` field is absent
- Opt-toggle state persists across re-renders within a pane
- Call/branch target navigation works within the same pane; cross-pane navigation is not supported (by design)

https://claude.ai/code/session_015piDYhFebbMG1uPhUmHa5f