### PR TITLE
Fix micropip.install kwargs and move explorer-core.js to CDN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,6 +579,7 @@ explorer-build-cdn: $(UV_STAMP) $(BUILD_INFO_JSON) ## Build the CDN compiler exp
 	@mkdir -p $(EXPLORER_CDN_DIR)
 	cd $(ROOT) && $(UV) build --wheel --out-dir $(EXPLORER_CDN_DIR)
 	cp $(BUILD_INFO_JSON) $(EXPLORER_CDN_DIR)/
+	cp $(EXPLORER_STATIC)/explorer-core.js $(EXPLORER_CDN_DIR)/
 	sed 's|<script src="mermaid.min.js"></script>|<script src="$(MERMAID_CDN_URL)"></script>|' \
 		$(EXPLORER_STATIC)/index.html > $(EXPLORER_CDN_DIR)/index.html
 	sed -e 's|// All assets are local.*|// Pyodide loaded from CDN.|' \

--- a/explorer/static/worker.js
+++ b/explorer/static/worker.js
@@ -34,8 +34,11 @@ async function init() {
   const micropip = pyodide.pyimport("micropip");
 
   // Install our wheel without pulling pygls/lsprotocol (not needed in worker).
+  // NB: JS objects passed to Python functions become positional args; to pass
+  // Python kwargs we must use `callKwargs`, otherwise `deps=True` stays in
+  // effect and micropip tries to fetch every transitive dep.
   const wheelUrl = baseUrl + "tcl_lsp-1.7.1-py3-none-any.whl";
-  await micropip.install(wheelUrl, { deps: false });
+  await micropip.install.callKwargs(wheelUrl, { deps: false });
 
   postMessage({ type: "status", message: "Initialising compiler..." });
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.10"
 dependencies = [
     "pygls>=2.0",
     "lsprotocol>=2024.0.0",
-    "pytest-xdist[dev]>=3.8.0",
     "jinja2>=3.1",
 ]
 
@@ -14,6 +13,7 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-cov>=6.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.11",
     "ty>=0.0.24,<0.0.25",
     "wasmtime>=20.0",


### PR DESCRIPTION
## Summary

- Fixed `micropip.install()` call in worker.js to use `callKwargs()` to properly pass `deps=false` as a keyword argument instead of a positional argument
- Moved `pytest-xdist` from main dependencies to dev dependencies in pyproject.toml
- Added `explorer-core.js` to the CDN build output in Makefile

## Details

### Worker.js micropip fix
When calling Python functions from Pyodide's JavaScript API, JS objects are passed as positional arguments by default. To pass Python keyword arguments, we must use `callKwargs()`. The previous code was passing `{ deps: false }` as a positional argument, which meant `deps=True` remained in effect and micropip would attempt to fetch all transitive dependencies. This change ensures the `deps=false` kwarg is properly respected.

### Dependency reorganization
`pytest-xdist` is a development/testing tool and should not be in the main project dependencies. Moved it to the `[project.optional-dependencies]` dev section where it belongs.

### CDN build output
Added `explorer-core.js` to the files copied to the CDN directory during the `explorer-build-cdn` make target, ensuring the compiled explorer core is available in the CDN build.

## Validation

- No automated tests affected by these changes
- Changes are straightforward configuration and API call fixes

https://claude.ai/code/session_01DTFydZfP1du67fJdtRpPEe