### PR TITLE
Make wheel filename discoverable at runtime via build_info.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,11 @@ GIT_HASH         := $(shell git rev-parse --short HEAD 2>/dev/null || echo unkno
 VERSION          := $(shell echo "$(GIT_DESCRIBE)" | sed 's/^v//')
 SEMVER_VERSION   := $(shell sh -c 'v="$(VERSION)"; if echo "$$v" | grep -Eq "^[0-9]+\\.[0-9]+\\.[0-9]+([-.][0-9A-Za-z.-]+)*$$"; then echo "$$v"; else echo "0.0.0-dev"; fi')
 FULL_VERSION     := $(VERSION)
+# Wheel filename tracks pyproject.toml's [project].version (what `uv build`
+# reads), not the git-describe VERSION above — so that worker.js can discover
+# the wheel at runtime via build_info.json rather than hard-coding a number.
+PYPROJECT_VERSION := $(shell grep -E '^version = ' $(ROOT)pyproject.toml | head -1 | sed 's/.*= *"//;s/".*//')
+WHEEL_FILENAME   := tcl_lsp-$(PYPROJECT_VERSION)-py3-none-any.whl
 BUILD_TIMESTAMP := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Derived paths
@@ -473,8 +478,8 @@ $(BUILD_INFO): .FORCE
 		"$(VERSION)" "$(GIT_DESCRIBE)" "$(GIT_HASH)" "$(FULL_VERSION)" "$(BUILD_TIMESTAMP)" > $@
 
 $(BUILD_INFO_JSON): .FORCE
-	@printf '{"version":"%s","git_describe":"%s","git_hash":"%s","full_version":"%s","build_timestamp":"%s"}\n' \
-		"$(VERSION)" "$(GIT_DESCRIBE)" "$(GIT_HASH)" "$(FULL_VERSION)" "$(BUILD_TIMESTAMP)" > $@
+	@printf '{"version":"%s","git_describe":"%s","git_hash":"%s","full_version":"%s","build_timestamp":"%s","wheel_filename":"%s"}\n' \
+		"$(VERSION)" "$(GIT_DESCRIBE)" "$(GIT_HASH)" "$(FULL_VERSION)" "$(BUILD_TIMESTAMP)" "$(WHEEL_FILENAME)" > $@
 
 # Generated editor catalogs
 #

--- a/explorer/static/worker.js
+++ b/explorer/static/worker.js
@@ -28,17 +28,36 @@ async function init() {
     indexURL: pyodideUrl,
   });
 
+  postMessage({ type: "status", message: "Fetching compiler wheel..." });
+
+  // Fetch the wheel and extract it directly into site-packages.
+  //
+  // We deliberately avoid micropip: the version shipped with Pyodide 0.27.3
+  // (micropip 0.8.0) has a race in its `deps=False` code path — it creates a
+  // download task with `asyncio.create_task` but never awaits it, so
+  // `install()` runs before the wheel bytes are loaded and fails with
+  // "Micropip internal error: attempted to install wheel before downloading
+  // it?". Fixed upstream in micropip 0.9.0 (pyodide/micropip#180).
+  //
+  // Our wheel is pure Python and the worker only imports modules under
+  // `core` and `explorer`, none of which need pygls/lsprotocol/jinja2 at
+  // import time, so we don't need a dependency resolver here.
+  const wheelUrl = baseUrl + "tcl_lsp-1.7.1-py3-none-any.whl";
+  const wheelResponse = await fetch(wheelUrl);
+  if (!wheelResponse.ok) {
+    throw new Error(
+      `Failed to fetch ${wheelUrl}: ${wheelResponse.status} ${wheelResponse.statusText}`,
+    );
+  }
+  const wheelBytes = new Uint8Array(await wheelResponse.arrayBuffer());
+
   postMessage({ type: "status", message: "Installing compiler package..." });
 
-  await pyodide.loadPackage("micropip");
-  const micropip = pyodide.pyimport("micropip");
-
-  // Install our wheel without pulling pygls/lsprotocol (not needed in worker).
-  // NB: JS objects passed to Python functions become positional args; to pass
-  // Python kwargs we must use `callKwargs`, otherwise `deps=True` stays in
-  // effect and micropip tries to fetch every transitive dep.
-  const wheelUrl = baseUrl + "tcl_lsp-1.7.1-py3-none-any.whl";
-  await micropip.install.callKwargs(wheelUrl, { deps: false });
+  const sitePackages = pyodide.runPython(
+    "import site; site.getsitepackages()[0]",
+  );
+  pyodide.unpackArchive(wheelBytes, "zip", { extractDir: sitePackages });
+  pyodide.runPython("import importlib; importlib.invalidate_caches()");
 
   postMessage({ type: "status", message: "Initialising compiler..." });
 

--- a/explorer/static/worker.js
+++ b/explorer/static/worker.js
@@ -30,6 +30,20 @@ async function init() {
 
   postMessage({ type: "status", message: "Fetching compiler wheel..." });
 
+  // Discover the wheel filename from build_info.json (populated by the
+  // Makefile from pyproject.toml's version) so the worker doesn't need to
+  // be rewritten every time the package version bumps.
+  const buildInfoResponse = await fetch(baseUrl + "build_info.json");
+  if (!buildInfoResponse.ok) {
+    throw new Error(
+      `Failed to fetch build_info.json: ${buildInfoResponse.status} ${buildInfoResponse.statusText}`,
+    );
+  }
+  const buildInfo = await buildInfoResponse.json();
+  if (!buildInfo.wheel_filename) {
+    throw new Error("build_info.json is missing wheel_filename");
+  }
+
   // Fetch the wheel and extract it directly into site-packages.
   //
   // We deliberately avoid micropip: the version shipped with Pyodide 0.27.3
@@ -42,7 +56,7 @@ async function init() {
   // Our wheel is pure Python and the worker only imports modules under
   // `core` and `explorer`, none of which need pygls/lsprotocol/jinja2 at
   // import time, so we don't need a dependency resolver here.
-  const wheelUrl = baseUrl + "tcl_lsp-1.7.1-py3-none-any.whl";
+  const wheelUrl = baseUrl + buildInfo.wheel_filename;
   const wheelResponse = await fetch(wheelUrl);
   if (!wheelResponse.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary

- Modified the Pyodide worker initialization to discover the compiler wheel filename dynamically from `build_info.json` instead of hard-coding it
- Replaced micropip-based wheel installation with direct wheel extraction using `pyodide.unpackArchive()` to work around a race condition in micropip 0.8.0
- Updated the Makefile to extract the wheel version from `pyproject.toml` and include the wheel filename in `build_info.json`

## Motivation

Previously, the worker hard-coded the wheel filename (`tcl_lsp-1.7.1-py3-none-any.whl`), requiring manual updates whenever the package version changed. This change makes the worker version-agnostic by reading the wheel filename from a generated metadata file.

Additionally, the micropip installation approach had a known race condition in Pyodide 0.27.3's bundled micropip 0.8.0 that could cause installation failures. Since the wheel is pure Python with no import-time dependencies, direct extraction is simpler and more reliable.

## Technical Details

- The Makefile now extracts `version` from `pyproject.toml` to compute `WHEEL_FILENAME` and includes it in `build_info.json`
- The worker fetches `build_info.json` at startup to discover the wheel filename
- The wheel is fetched and extracted directly into site-packages using `pyodide.unpackArchive()` instead of micropip
- Import caches are invalidated after extraction to ensure modules are discoverable

## Validation

- No automated tests affected by this change
- Manual verification: Worker initialization should succeed and compiler should be available for use

https://claude.ai/code/session_014AdptrsqoiPV3u9DLRUSZB