### PR TITLE
Update code folding markers to use #region/#endregion

### DIFF
--- a/editors/vscode/apl-language-configuration.json
+++ b/editors/vscode/apl-language-configuration.json
@@ -26,8 +26,8 @@
   "wordPattern": "[\\w.:]+",
   "folding": {
     "markers": {
-      "start": "^\\s*\\{",
-      "end": "^\\s*\\}"
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
     }
   }
 }

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -26,8 +26,8 @@
   "wordPattern": "[\\w:]+",
   "folding": {
     "markers": {
-      "start": "^\\s*\\{",
-      "end": "^\\s*\\}"
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Updated code folding markers in VS Code language configuration files from brace-based (`{`/`}`) to comment-based (`#region`/`#endregion`) syntax
- Applied changes to both `apl-language-configuration.json` and `language-configuration.json`

## Details

This change modifies how VS Code recognizes code folding regions in the editor. Instead of using curly braces at the start of a line, the folding markers now use the standard `#region` and `#endregion` directives, which is a more conventional approach for code folding in many languages and provides better compatibility with editor expectations.

## Validation

- N/A - Configuration file update with no runtime behavior changes

https://claude.ai/code/session_01JsBtP9YJnwrpf7JbPcbbcc