### PR TITLE
Fix docstring raw string literals in subst_nocommands

### DIFF
--- a/core/parsing/subst_nocommands.py
+++ b/core/parsing/subst_nocommands.py
@@ -1,4 +1,4 @@
-"""Compile-time evaluator for ``[subst -nocommands {template}]``.
+r"""Compile-time evaluator for ``[subst -nocommands {template}]``.
 
 Used by P7.3's lowering hook when we see a ``proc \$var [subst
 -nocommands {…}]`` shape and want to materialise the body string
@@ -41,7 +41,7 @@ _NAME_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
 
 
 def subst_nocommands(template: str, const_map: Mapping[str, str]) -> str | None:
-    """Evaluate a ``subst -nocommands`` template at compile time.
+    r"""Evaluate a ``subst -nocommands`` template at compile time.
 
     Returns the substituted string on success, or ``None`` if any
     condition above refuses the evaluation.  Refusal is always safe


### PR DESCRIPTION
## Summary

- Changed docstrings in `core/parsing/subst_nocommands.py` to use raw string literals (`r"""`) to properly escape backticks and other special characters in the documentation text.

## Details

Updated two docstrings to use raw string prefixes:
1. Module-level docstring (line 1)
2. `subst_nocommands()` function docstring (line 44)

This ensures that backticks and other special characters in the docstrings are treated literally and not interpreted as escape sequences, improving documentation clarity and consistency.

## Validation

- No functional code changes; documentation-only update
- No testing required

https://claude.ai/code/session_011chkcRGJzW2PR1umvEqYmM