### PR TITLE
Add namespace import tracking and factory-wrapper proc detection

### DIFF
--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -65,11 +65,13 @@ from ..parsing.tokens import SourcePosition, Token, TokenType
 from .proc_arg_traits import infer_param_traits
 from .semantic_model import (
     AnalysisResult,
+    AutoPathEntry,
     ClassDef,
     CodeFix,
     CommandInvocation,
     Diagnostic,
     MethodDef,
+    NamespaceImport,
     PackageProvide,
     PackageRequire,
     ParamDef,
@@ -1515,10 +1517,65 @@ class Analyser:
             self.result.has_dynamic_providers = True
         elif cmd_name in ("set", "lappend") and args and args[0] == "auto_path":
             self.result.has_dynamic_providers = True
+            # Record each path argument so ``_load_packages_if_needed`` can
+            # extend the package resolver's search paths for this document.
+            for i in range(1, len(args)):
+                if i >= len(arg_tokens):
+                    break
+                self.result.auto_path_entries.append(
+                    AutoPathEntry(
+                        resolved_path=None,
+                        raw=args[i],
+                        range=range_from_token(arg_tokens[i]),
+                    )
+                )
         elif cmd_name == "rename":
             self.result.has_dynamic_providers = True
         elif cmd_name == "namespace" and len(args) >= 2 and args[0] == "import":
             self.result.has_dynamic_providers = True
+            importing_ns = f"::{scope.name}" if scope.kind == "namespace" and scope.name else "::"
+            i = 1
+            while i < len(args):
+                pattern = args[i]
+                tok = arg_tokens[i] if i < len(arg_tokens) else None
+                if pattern == "-force":
+                    i += 1
+                    continue
+                # Ignore non-qualified or substituted patterns — we
+                # cannot statically resolve them to a source namespace.
+                if "::" not in pattern or "$" in pattern or "[" in pattern:
+                    i += 1
+                    continue
+                if not pattern.startswith("::"):
+                    pattern = f"::{pattern}"
+                if tok is not None:
+                    self.result.namespace_imports.append(
+                        NamespaceImport(
+                            ns=importing_ns,
+                            pattern=pattern,
+                            range=range_from_token(tok),
+                        )
+                    )
+                i += 1
+        elif cmd_name.endswith("::import") and len(args) == 1:
+            # tcllib-style ``some::ns::import <alias>`` wrapper: the proc
+            # body typically ``uplevel``s ``namespace import some::ns::*``
+            # into the given alias namespace.  Infer the import as a
+            # conjecture so ``alias::foo`` resolves to ``some::ns::foo``.
+            alias = args[0]
+            if alias and "$" not in alias and "[" not in alias:
+                source_ns = cmd_name[: -len("::import")]
+                if not source_ns.startswith("::"):
+                    source_ns = f"::{source_ns}"
+                alias_ns = alias if alias.startswith("::") else f"::{alias}"
+                self.result.namespace_imports.append(
+                    NamespaceImport(
+                        ns=alias_ns,
+                        pattern=f"{source_ns}::*",
+                        range=range_from_token(argv[0]),
+                        conjectured=True,
+                    )
+                )
 
         # Record source command targets for cross-file dependency tracking.
         if cmd_name == "source" and args:

--- a/core/analysis/analyser.py
+++ b/core/analysis/analyser.py
@@ -1533,7 +1533,12 @@ class Analyser:
             self.result.has_dynamic_providers = True
         elif cmd_name == "namespace" and len(args) >= 2 and args[0] == "import":
             self.result.has_dynamic_providers = True
-            importing_ns = f"::{scope.name}" if scope.kind == "namespace" and scope.name else "::"
+            # ``scope.name`` is only the *local* namespace segment, so
+            # walk the scope chain to get the fully-qualified prefix —
+            # otherwise nested ``namespace eval outer { namespace eval
+            # inner { namespace import … } }`` would record the import
+            # under ``::inner`` instead of ``::outer::inner``.
+            importing_ns = self._namespace_from_scope(scope)
             i = 1
             while i < len(args):
                 pattern = args[i]
@@ -1546,8 +1551,16 @@ class Analyser:
                 if "::" not in pattern or "$" in pattern or "[" in pattern:
                     i += 1
                     continue
+                # A pattern without a leading ``::`` is resolved
+                # relative to the *current* namespace, not the global
+                # one — Tcl's own rule for ``namespace import``.  So
+                # ``namespace eval foo { namespace import bar::* }``
+                # imports ``::foo::bar::*``, not ``::bar::*``.
                 if not pattern.startswith("::"):
-                    pattern = f"::{pattern}"
+                    if importing_ns == "::":
+                        pattern = f"::{pattern}"
+                    else:
+                        pattern = f"{importing_ns}::{pattern}"
                 if tok is not None:
                     self.result.namespace_imports.append(
                         NamespaceImport(
@@ -1567,7 +1580,16 @@ class Analyser:
                 source_ns = cmd_name[: -len("::import")]
                 if not source_ns.startswith("::"):
                     source_ns = f"::{source_ns}"
-                alias_ns = alias if alias.startswith("::") else f"::{alias}"
+                # Relative aliases live under the current namespace —
+                # ``namespace eval outer { some::ns::import vt }``
+                # creates ``::outer::vt``, not ``::vt``.
+                current_ns = self._namespace_from_scope(scope)
+                if alias.startswith("::"):
+                    alias_ns = alias
+                elif current_ns == "::":
+                    alias_ns = f"::{alias}"
+                else:
+                    alias_ns = f"{current_ns}::{alias}"
                 self.result.namespace_imports.append(
                     NamespaceImport(
                         ns=alias_ns,

--- a/core/analysis/auto_path_eval.py
+++ b/core/analysis/auto_path_eval.py
@@ -6,11 +6,15 @@ well-defined, side-effect-free behaviour:
 
     lappend auto_path [file join [file dirname [info script]] ..]
     lappend auto_path [file dirname [file dirname [info script]]]
-    set auto_path [linsert $auto_path 0 /abs/path]
+    lappend auto_path /abs/path
+    lappend auto_path ~/lib
 
-This module understands those forms well enough to produce a concrete
-absolute directory.  Unknown forms return ``None`` and the caller simply
-skips the entry — we never fall back to guessing.
+The supported subset is ``[info script]``, ``[file dirname …]``,
+``[file join …]``, literal words, and ``~``-prefixed paths (expanded
+via ``os.path.expanduser``).  Variable substitutions (``$auto_path``,
+``$env(…)``) and list-manipulation commands (``linsert``, ``lsort``…)
+are not evaluated — expressions that rely on them return ``None`` and
+the caller simply skips the entry.  We never fall back to guessing.
 """
 
 from __future__ import annotations
@@ -40,7 +44,9 @@ def evaluate_auto_path_expr(raw: str, info_script: str | None) -> str | None:
     result = _eval(parsed, info_script)
     if result is None:
         return None
-    return os.path.abspath(result)
+    # Expand ``~`` so ``lappend auto_path ~/lib`` resolves to the
+    # user's home directory rather than a cwd-relative ``~`` literal.
+    return os.path.abspath(os.path.expanduser(result))
 
 
 def _tokenise(text: str) -> list[str] | None:

--- a/core/analysis/auto_path_eval.py
+++ b/core/analysis/auto_path_eval.py
@@ -1,0 +1,166 @@
+"""Static mini-evaluator for ``lappend auto_path`` arguments.
+
+A common Tcl idiom for adding a sibling/parent directory to the package
+search path reuses only a handful of built-in commands that have
+well-defined, side-effect-free behaviour:
+
+    lappend auto_path [file join [file dirname [info script]] ..]
+    lappend auto_path [file dirname [file dirname [info script]]]
+    set auto_path [linsert $auto_path 0 /abs/path]
+
+This module understands those forms well enough to produce a concrete
+absolute directory.  Unknown forms return ``None`` and the caller simply
+skips the entry — we never fall back to guessing.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def evaluate_auto_path_expr(raw: str, info_script: str | None) -> str | None:
+    """Resolve *raw* (a ``lappend auto_path`` argument) to an absolute path.
+
+    *info_script* should be the filesystem path of the file being
+    analysed.  It substitutes for ``[info script]`` in evaluation — the
+    value Tcl itself would report while running the file.
+
+    Returns an absolute path on success, or ``None`` when any part of
+    the expression is outside the supported subset.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    tokens = _tokenise(raw)
+    if tokens is None:
+        return None
+    parsed, rest = _parse(tokens, 0)
+    if parsed is None or rest != len(tokens):
+        return None
+    result = _eval(parsed, info_script)
+    if result is None:
+        return None
+    return os.path.abspath(result)
+
+
+def _tokenise(text: str) -> list[str] | None:
+    """Split *text* into ``[`` / ``]`` / word tokens.
+
+    Brace groups are kept as a single word (brackets inside braces are
+    literal).  Anything we don't recognise aborts by returning ``None``.
+    """
+    tokens: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch in "[]":
+            tokens.append(ch)
+            i += 1
+            continue
+        if ch == "{":
+            depth = 1
+            j = i + 1
+            while j < n and depth > 0:
+                if text[j] == "{":
+                    depth += 1
+                elif text[j] == "}":
+                    depth -= 1
+                j += 1
+            if depth != 0:
+                return None
+            tokens.append(text[i + 1 : j - 1])
+            i = j
+            continue
+        if ch == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                j += 1
+            if j >= n:
+                return None
+            tokens.append(text[i + 1 : j])
+            i = j + 1
+            continue
+        j = i
+        while j < n and not text[j].isspace() and text[j] not in "[]":
+            j += 1
+        tokens.append(text[i:j])
+        i = j
+    return tokens
+
+
+# Parse tree node forms:
+#   ("lit", str)             — a literal word
+#   ("cmd", name, [args...]) — a command substitution [cmd arg ...]
+
+_Node = tuple
+
+
+def _parse(tokens: list[str], pos: int) -> tuple[_Node | None, int]:
+    """Parse a single word starting at *pos*.  Returns (node, next_pos)."""
+    if pos >= len(tokens):
+        return (None, pos)
+    tok = tokens[pos]
+    if tok == "[":
+        pos += 1
+        if pos >= len(tokens):
+            return (None, pos)
+        name = tokens[pos]
+        pos += 1
+        args: list[_Node] = []
+        while pos < len(tokens) and tokens[pos] != "]":
+            node, pos = _parse(tokens, pos)
+            if node is None:
+                return (None, pos)
+            args.append(node)
+        if pos >= len(tokens):
+            return (None, pos)
+        pos += 1  # consume ]
+        return (("cmd", name, args), pos)
+    if tok == "]":
+        return (None, pos)
+    return (("lit", tok), pos + 1)
+
+
+def _eval(node: _Node, info_script: str | None) -> str | None:
+    kind = node[0]
+    if kind == "lit":
+        value = node[1]
+        # Reject any word that still contains variable substitutions or
+        # nested brackets we did not tokenise — we refuse to guess.
+        if "$" in value:
+            return None
+        return value
+    if kind == "cmd":
+        name = node[1]
+        args = node[2]
+        if name == "info" and len(args) == 1:
+            sub = _eval(args[0], info_script)
+            if sub == "script":
+                return info_script
+            return None
+        if name == "file" and len(args) >= 2:
+            sub = _eval(args[0], info_script)
+            if sub == "dirname" and len(args) == 2:
+                inner = _eval(args[1], info_script)
+                if inner is None:
+                    return None
+                return os.path.dirname(inner)
+            if sub == "join" and len(args) >= 2:
+                parts: list[str] = []
+                for a in args[1:]:
+                    p = _eval(a, info_script)
+                    if p is None:
+                        return None
+                    parts.append(p)
+                if not parts:
+                    return None
+                return os.path.join(*parts)
+            return None
+    return None

--- a/core/analysis/namespace_imports.py
+++ b/core/analysis/namespace_imports.py
@@ -1,0 +1,80 @@
+"""Helpers for resolving namespace-imported command references.
+
+When a Tcl script contains ``namespace import ::foo::bar::*`` inside
+namespace ``baz`` (or at the global level), the command names in the
+source namespace become available in the importing namespace under
+their tail names.  So a later call to ``baz::thing`` actually invokes
+``::foo::bar::thing``.  This module rewrites a referenced word through
+a list of :class:`NamespaceImport` declarations so cross-file lookup
+can find the real target.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .semantic_model import NamespaceImport
+
+
+def rewrite_via_imports(word: str, imports: Iterable[NamespaceImport]) -> list[str]:
+    """Return candidate fully-qualified names for *word*.
+
+    The input *word* is the text the user wrote (e.g. ``vt::showat``).
+    Each candidate is a fully-qualified name derived by applying one of
+    the *imports* declarations.  Non-conjectured imports are listed
+    first so the caller can prefer them.
+    """
+    if not word:
+        return []
+    # Split the reference into ``(importing_ns, tail)``.  A bare name
+    # matches global imports (``namespace import`` at the ``::`` level),
+    # while a qualified name ``vt::showat`` matches imports into
+    # namespace ``::vt``.
+    if word.startswith("::"):
+        body = word[2:]
+    else:
+        body = word
+    if "::" in body:
+        alias_ns_body, tail = body.rsplit("::", 1)
+        alias_ns = f"::{alias_ns_body}" if alias_ns_body else "::"
+    else:
+        alias_ns = "::"
+        tail = body
+
+    non_conjectured: list[str] = []
+    conjectured: list[str] = []
+    for imp in imports:
+        if imp.ns != alias_ns:
+            continue
+        rewritten = _apply_pattern(imp.pattern, tail)
+        if rewritten is None:
+            continue
+        (conjectured if imp.conjectured else non_conjectured).append(rewritten)
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for cand in non_conjectured + conjectured:
+        if cand not in seen:
+            seen.add(cand)
+            out.append(cand)
+    return out
+
+
+def _apply_pattern(pattern: str, tail: str) -> str | None:
+    """Resolve ``namespace import`` *pattern* applied to *tail*.
+
+    ``::foo::bar::*`` + ``baz`` → ``::foo::bar::baz``.
+    ``::foo::bar::baz`` + ``baz`` → ``::foo::bar::baz`` (exact match).
+    Glob characters other than a trailing ``*`` are not supported; Tcl's
+    own ``namespace import`` accepts them but tcllib / user code almost
+    never uses that form.
+    """
+    if pattern.endswith("::*"):
+        return f"{pattern[:-1]}{tail}"
+    if "::" in pattern:
+        head, pat_tail = pattern.rsplit("::", 1)
+        if pat_tail == tail:
+            return pattern
+        if pat_tail == "*":
+            return f"{head}::{tail}"
+    return None

--- a/core/analysis/semantic_model.py
+++ b/core/analysis/semantic_model.py
@@ -287,11 +287,16 @@ class NamespaceImport:
 
 @dataclass(frozen=True, slots=True)
 class AutoPathEntry:
-    """A statically-resolved ``lappend auto_path`` / ``set auto_path`` entry.
+    """A raw ``lappend auto_path`` / ``set auto_path`` argument.
 
-    ``resolved_path`` is an absolute directory path when the argument
-    could be evaluated from static context (literals, ``[file dirname]``,
-    ``[file join]``, ``[info script]``); otherwise ``None``.
+    The extraction pass records every path element as-written, without
+    attempting to evaluate it — resolution requires the document's file
+    path (for ``[info script]``) and happens later in the LSP server
+    via :func:`core.analysis.auto_path_eval.evaluate_auto_path_expr`.
+
+    ``resolved_path`` is reserved for callers that want to cache the
+    evaluated directory back onto the entry; the extractor always sets
+    it to ``None``.
     """
 
     resolved_path: str | None

--- a/core/analysis/semantic_model.py
+++ b/core/analysis/semantic_model.py
@@ -264,6 +264,42 @@ class SourceTarget:
 
 
 @dataclass(frozen=True, slots=True)
+class NamespaceImport:
+    """A ``namespace import`` declaration observed during analysis.
+
+    ``ns`` is the importing namespace (``::`` at top level).  ``pattern``
+    is the fully-qualified import pattern, e.g. ``::term::ansi::send::*``
+    or ``::some::ns::specific_cmd``.  When Tcl runs ``namespace import``
+    it creates a local alias for every command in the source namespace
+    matching the pattern; the LSP records the declaration so qualified
+    references like ``vt::showat`` can be rewritten to the underlying
+    fully-qualified name.
+    """
+
+    ns: str  # importing namespace, e.g. "::" or "::vt"
+    pattern: str  # fully-qualified pattern, e.g. "::term::ansi::send::*"
+    range: Range
+    conjectured: bool = False
+    """True when inferred from a tcllib-style ``X::import`` wrapper call
+    rather than a direct ``namespace import`` — lower confidence, used
+    only as a fallback."""
+
+
+@dataclass(frozen=True, slots=True)
+class AutoPathEntry:
+    """A statically-resolved ``lappend auto_path`` / ``set auto_path`` entry.
+
+    ``resolved_path`` is an absolute directory path when the argument
+    could be evaluated from static context (literals, ``[file dirname]``,
+    ``[file join]``, ``[info script]``); otherwise ``None``.
+    """
+
+    resolved_path: str | None
+    raw: str
+    range: Range
+
+
+@dataclass(frozen=True, slots=True)
 class PackageContext:
     """Packages active in a file, with confidence levels.
 
@@ -409,6 +445,8 @@ class AnalysisResult:
     package_provides: list[PackageProvide] = field(default_factory=list)
     has_dynamic_providers: bool = False  # True if load/auto_path detected
     source_targets: list[SourceTarget] = field(default_factory=list)
+    namespace_imports: list[NamespaceImport] = field(default_factory=list)
+    auto_path_entries: list[AutoPathEntry] = field(default_factory=list)
     stub_commands: list[StubCommandDef] = field(default_factory=list)
     stub_expr_defs: list[StubExprDef] = field(default_factory=list)
     # Command aliases: maps qualified alias_name (e.g. ``::=``) to
@@ -483,6 +521,8 @@ class AnalysisResult:
             package_provides=self.package_provides[:],
             has_dynamic_providers=self.has_dynamic_providers,
             source_targets=self.source_targets[:],
+            namespace_imports=self.namespace_imports[:],
+            auto_path_entries=self.auto_path_entries[:],
             stub_commands=self.stub_commands[:],
             stub_expr_defs=self.stub_expr_defs[:],
             command_aliases=self.command_aliases.copy(),
@@ -513,6 +553,8 @@ class AnalysisResult:
             package_requires=self.package_requires,
             command_aliases=self.command_aliases,
             source_targets=self.source_targets,
+            namespace_imports=self.namespace_imports,
+            auto_path_entries=self.auto_path_entries,
         )
 
     def _ensure_bare_name_index(self) -> dict[str, ProcDef]:

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -24,11 +24,15 @@ and retains orders of magnitude less memory per file than ``analyse()``.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from core.analysis.analyser import parse_param_list
 from core.analysis.semantic_model import (
     AnalysisResult,
+    AutoPathEntry,
     ClassDef,
     CommandInvocation,
+    NamespaceImport,
     PackageRequire,
     ProcDef,
     SourceTarget,
@@ -38,11 +42,46 @@ from core.parsing.command_segmenter import segment_commands
 from core.parsing.tokens import Token, TokenType
 
 
+@dataclass
+class _FactoryCandidate:
+    """A 3-arg command call that might be a factory-wrapper proc definition.
+
+    Tcllib's ``DEFC name args body`` / ``DEF name esc value`` pattern
+    creates a proc at runtime via ``proc $name $args $body``.  We record
+    every call with that shape and resolve it against the set of procs
+    that actually behave as factories after the first pass finishes.
+    """
+
+    head: str  # the command name as written ("DEFC", "::foo::DEF", ...)
+    name: str
+    name_tok: Token
+    body_tok: Token
+    ns_prefix: str  # effective namespace at the call site (no leading ``::``)
+
+
+@dataclass
+class _ProcBodyInfo:
+    """Tracking data for factory-wrapper detection."""
+
+    qname: str
+    params: list[str]
+    body_text: str
+    ns_prefix: str
+
+
+@dataclass
+class _ScanCtx:
+    result: AnalysisResult
+    candidates: list[_FactoryCandidate] = field(default_factory=list)
+    proc_bodies: list[_ProcBodyInfo] = field(default_factory=list)
+
+
 def extract_signatures(source: str) -> AnalysisResult:
     """Return a minimal AnalysisResult for a background-indexed file."""
-    result = AnalysisResult()
-    _scan(source, body_token=None, ns_prefix="", conditional=False, result=result)
-    return result
+    ctx = _ScanCtx(result=AnalysisResult())
+    _scan(source, body_token=None, ns_prefix="", conditional=False, ctx=ctx)
+    _resolve_factory_defs(ctx)
+    return ctx.result
 
 
 def _qualify(ns_prefix: str, name: str) -> str:
@@ -64,12 +103,13 @@ def _scan(
     body_token: Token | None,
     ns_prefix: str,
     conditional: bool,
-    result: AnalysisResult,
+    ctx: _ScanCtx,
 ) -> None:
     # ``recovery=True`` (segmenter default) — an unclosed brace or bracket
     # high up in the file must not swallow the rest of it and silently
     # drop every later declaration.
     commands = segment_commands(source, body_token=body_token)
+    result = ctx.result
     for cmd in commands:
         if cmd.is_partial or not cmd.argv:
             continue
@@ -86,9 +126,9 @@ def _scan(
         )
         match head:
             case "proc":
-                _handle_proc(texts, argv, ns_prefix, result)
+                _handle_proc(texts, argv, ns_prefix, ctx)
             case "namespace":
-                _handle_namespace(texts, argv, ns_prefix, conditional, result)
+                _handle_namespace(texts, argv, ns_prefix, conditional, ctx)
             case "package":
                 _handle_package(texts, argv, conditional, result)
             case "source":
@@ -100,11 +140,16 @@ def _scan(
             case "itcl::class" | "::itcl::class":
                 _handle_itcl_class(texts, argv, ns_prefix, result)
             case "if":
-                _handle_if(texts, argv, ns_prefix, result)
+                _handle_if(texts, argv, ns_prefix, ctx)
             case "catch":
-                _handle_catch(texts, argv, ns_prefix, result)
+                _handle_catch(texts, argv, ns_prefix, ctx)
             case "try":
-                _handle_try(texts, argv, ns_prefix, result)
+                _handle_try(texts, argv, ns_prefix, ctx)
+            case "lappend" | "set":
+                _handle_auto_path(head, texts, argv, result)
+            case _:
+                _maybe_handle_import_wrapper(head, texts, argv, ns_prefix, result)
+                _maybe_record_factory_candidate(head, texts, argv, ns_prefix, ctx)
 
 
 def _maybe_recurse_body(
@@ -112,7 +157,7 @@ def _maybe_recurse_body(
     body_tok: Token,
     ns_prefix: str,
     conditional: bool,
-    result: AnalysisResult,
+    ctx: _ScanCtx,
 ) -> None:
     """Recurse into *body_tok* only when it is a braced script.
 
@@ -126,7 +171,7 @@ def _maybe_recurse_body(
             body_token=body_tok,
             ns_prefix=ns_prefix,
             conditional=conditional,
-            result=result,
+            ctx=ctx,
         )
 
 
@@ -134,7 +179,7 @@ def _handle_proc(
     texts: list[str],
     argv: list[Token],
     ns_prefix: str,
-    result: AnalysisResult,
+    ctx: _ScanCtx,
 ) -> None:
     if len(texts) < 4:
         return
@@ -143,13 +188,36 @@ def _handle_proc(
     simple = qualified.rsplit("::", 1)[-1]
     name_range = range_from_token(argv[1])
     body_range = range_from_token(argv[3]) if len(argv) > 3 else name_range
-    result.all_procs[qualified] = ProcDef(
+    params = parse_param_list(texts[2])
+    ctx.result.all_procs[qualified] = ProcDef(
         name=simple,
         qualified_name=qualified,
-        params=parse_param_list(texts[2]),
+        params=params,
         name_range=name_range,
         body_range=body_range,
     )
+    # Record the body text so ``_resolve_factory_defs`` can identify
+    # factory-wrapper procs (``proc $name $args $body`` idiom used by
+    # tcllib's ``DEFC``).  The namespace the factory creates procs in
+    # at call time is the one the wrapper itself belongs to, so keep
+    # that around too.
+    body_ns = qualified.rsplit("::", 1)[0].lstrip(":")
+    ctx.proc_bodies.append(
+        _ProcBodyInfo(
+            qname=qualified,
+            params=[p.name for p in params],
+            body_text=texts[3],
+            ns_prefix=body_ns,
+        )
+    )
+    # Factory calls (``DEFC foo …``) typically live inside an ``INIT``
+    # proc that populates a namespace at package-load time.  Walk the
+    # body looking only for candidate call sites — we deliberately skip
+    # the usual ``proc`` / ``namespace eval`` handlers here because
+    # those definitions only take effect when the enclosing proc runs,
+    # and recording them would confuse static resolution.
+    if len(argv) > 3 and argv[3].type is TokenType.STR:
+        _scan_factory_candidates(texts[3], argv[3], body_ns, ctx)
 
 
 def _handle_namespace(
@@ -157,20 +225,130 @@ def _handle_namespace(
     argv: list[Token],
     ns_prefix: str,
     conditional: bool,
+    ctx: _ScanCtx,
+) -> None:
+    if len(texts) < 2:
+        return
+    sub = texts[1]
+    if sub == "eval" and len(texts) >= 4:
+        raw_ns = texts[2]
+        # ``namespace eval ::foo {...}`` rebases the prefix rather than nesting
+        # under the surrounding namespace — Tcl treats leading ``::`` as absolute.
+        if raw_ns.startswith("::"):
+            inner_prefix = raw_ns.lstrip(":")
+        elif ns_prefix:
+            inner_prefix = f"{ns_prefix}::{raw_ns}"
+        else:
+            inner_prefix = raw_ns
+        _maybe_recurse_body(texts[3], argv[3], inner_prefix, conditional, ctx)
+        return
+    if sub == "import" and len(texts) >= 3:
+        _handle_namespace_import(texts, argv, ns_prefix, ctx.result)
+
+
+def _handle_namespace_import(
+    texts: list[str],
+    argv: list[Token],
+    ns_prefix: str,
     result: AnalysisResult,
 ) -> None:
-    if len(texts) < 4 or texts[1] != "eval":
+    # ``namespace import ?-force? pattern ?pattern ...?``
+    importing_ns = f"::{ns_prefix}" if ns_prefix else "::"
+    i = 2
+    while i < len(texts):
+        pattern = texts[i]
+        if pattern == "-force":
+            i += 1
+            continue
+        # Must be a fully-qualified pattern — Tcl's ``namespace import``
+        # only accepts qualified names, but users occasionally write bare
+        # ones in new code; drop those because we cannot resolve them.
+        if "::" not in pattern:
+            i += 1
+            continue
+        if not pattern.startswith("::"):
+            pattern = f"::{pattern}"
+        result.namespace_imports.append(
+            NamespaceImport(
+                ns=importing_ns,
+                pattern=pattern,
+                range=range_from_token(argv[i]),
+            )
+        )
+        i += 1
+
+
+def _maybe_handle_import_wrapper(
+    head: str,
+    texts: list[str],
+    argv: list[Token],
+    ns_prefix: str,
+    result: AnalysisResult,
+) -> None:
+    """Recognise the tcllib ``<NS>::import <ALIAS>`` wrapper idiom.
+
+    A common tcllib convention is a proc ``some::ns::import`` that
+    ``uplevel``s ``namespace eval <alias> {namespace import some::ns::*}``.
+    Statically detecting all such wrappers from their bodies is out of
+    scope, but the *call* is unambiguous — its qualified name ends in
+    ``::import`` and its single argument is a namespace identifier.
+    Record a conjectured import so ``vt::showat`` can resolve to
+    ``::term::ansi::send::showat`` when the user opens an example that
+    uses it.
+    """
+    if not head.endswith("::import"):
         return
-    raw_ns = texts[2]
-    # ``namespace eval ::foo {...}`` rebases the prefix rather than nesting
-    # under the surrounding namespace — Tcl treats leading ``::`` as absolute.
-    if raw_ns.startswith("::"):
-        inner_prefix = raw_ns.lstrip(":")
-    elif ns_prefix:
-        inner_prefix = f"{ns_prefix}::{raw_ns}"
-    else:
-        inner_prefix = raw_ns
-    _maybe_recurse_body(texts[3], argv[3], inner_prefix, conditional, result)
+    if len(texts) < 2:
+        return
+    alias = texts[1]
+    if not alias or "$" in alias or "[" in alias:
+        return
+    # Import wrapper typically takes a single namespace token as its
+    # first argument; remaining tokens would be pattern filters we can't
+    # evaluate statically, so we play it safe and only infer when the
+    # call is ``head alias``.
+    if len(texts) > 2:
+        return
+    source_ns = head[: -len("::import")]  # strip trailing ``::import``
+    if not source_ns.startswith("::"):
+        source_ns = f"::{source_ns}"
+    alias_ns = alias if alias.startswith("::") else f"::{alias}"
+    result.namespace_imports.append(
+        NamespaceImport(
+            ns=alias_ns,
+            pattern=f"{source_ns}::*",
+            range=range_from_token(argv[0]),
+            conjectured=True,
+        )
+    )
+
+
+def _handle_auto_path(
+    head: str,
+    texts: list[str],
+    argv: list[Token],
+    result: AnalysisResult,
+) -> None:
+    """Record ``lappend auto_path …`` / ``set auto_path …`` entries."""
+    if len(texts) < 3:
+        return
+    if texts[1] != "auto_path":
+        return
+    # ``set auto_path <expr>`` assigns the whole list; ``lappend
+    # auto_path <expr>`` appends.  Both forms: every word after the
+    # variable name is a path element.
+    for i in range(2, len(texts)):
+        raw = texts[i]
+        if not raw:
+            continue
+        result.auto_path_entries.append(
+            AutoPathEntry(
+                resolved_path=None,
+                raw=raw,
+                range=range_from_token(argv[i]),
+            )
+        )
+    _ = head  # currently no need to distinguish; reserved for future use
 
 
 def _handle_package(
@@ -272,7 +450,7 @@ def _handle_if(
     texts: list[str],
     argv: list[Token],
     ns_prefix: str,
-    result: AnalysisResult,
+    ctx: _ScanCtx,
 ) -> None:
     """Descend into every branch of an ``if`` chain.
 
@@ -301,7 +479,7 @@ def _handle_if(
             i += 1
             continue
         if expect_body:
-            _maybe_recurse_body(texts[i], argv[i], ns_prefix, True, result)
+            _maybe_recurse_body(texts[i], argv[i], ns_prefix, True, ctx)
             expect_body = False
         else:
             expect_body = True
@@ -312,19 +490,19 @@ def _handle_catch(
     texts: list[str],
     argv: list[Token],
     ns_prefix: str,
-    result: AnalysisResult,
+    ctx: _ScanCtx,
 ) -> None:
     # ``catch SCRIPT ?RESULTVAR? ?OPTIONSVAR?``
     if len(texts) < 2:
         return
-    _maybe_recurse_body(texts[1], argv[1], ns_prefix, True, result)
+    _maybe_recurse_body(texts[1], argv[1], ns_prefix, True, ctx)
 
 
 def _handle_try(
     texts: list[str],
     argv: list[Token],
     ns_prefix: str,
-    result: AnalysisResult,
+    ctx: _ScanCtx,
 ) -> None:
     """Descend into the main body, each ``on``/``trap`` handler, and ``finally``.
 
@@ -334,18 +512,293 @@ def _handle_try(
     """
     if len(texts) < 2:
         return
-    _maybe_recurse_body(texts[1], argv[1], ns_prefix, True, result)
+    _maybe_recurse_body(texts[1], argv[1], ns_prefix, True, ctx)
     i = 2
     while i < len(texts):
         clause = texts[i]
         if clause == "finally" and i + 1 < len(texts):
-            _maybe_recurse_body(texts[i + 1], argv[i + 1], ns_prefix, True, result)
+            _maybe_recurse_body(texts[i + 1], argv[i + 1], ns_prefix, True, ctx)
             return
         if clause in ("on", "trap") and i + 3 < len(texts):
-            _maybe_recurse_body(texts[i + 3], argv[i + 3], ns_prefix, True, result)
+            _maybe_recurse_body(texts[i + 3], argv[i + 3], ns_prefix, True, ctx)
             i += 4
         else:
             i += 1
+
+
+_FACTORY_SKIP_HEADS = frozenset(
+    {
+        # Commands that incidentally take the shape ``HEAD NAME BRACED BRACED``
+        # but definitely aren't proc factories — skip by name so they do not
+        # pollute the candidate list.
+        "proc",
+        "namespace",
+        "if",
+        "switch",
+        "while",
+        "for",
+        "foreach",
+        "try",
+        "catch",
+        "eval",
+        "apply",
+        "expr",
+        "uplevel",
+        "upvar",
+        "variable",
+        "set",
+        "lappend",
+        "dict",
+        "array",
+        "string",
+        "list",
+        "lindex",
+        "package",
+        "source",
+        "interp",
+        "oo::class",
+        "oo::define",
+        "oo::objdefine",
+        "method",
+        "classmethod",
+        "itcl::class",
+        "::itcl::class",
+    }
+)
+
+
+def _maybe_record_factory_candidate(
+    head: str,
+    texts: list[str],
+    argv: list[Token],
+    ns_prefix: str,
+    ctx: _ScanCtx,
+) -> None:
+    """Record a potential factory-wrapper call for post-scan resolution.
+
+    A tcllib factory call has the shape ``HEAD NAME ARGS BODY`` — four
+    tokens total where the last is a braced script.  We defer deciding
+    whether HEAD is a real factory until after the full scan, so filter
+    here only on the structural shape and a negative list of built-ins
+    that happen to share it.
+    """
+    if len(texts) != 4:
+        return
+    if head in _FACTORY_SKIP_HEADS:
+        return
+    # Name argument must be a plain word — variable and command
+    # substitutions mean the created proc has a runtime-computed name we
+    # cannot statically resolve.
+    name = texts[1]
+    if not name or "$" in name or "[" in name:
+        return
+    body_tok = argv[3]
+    if body_tok.type is not TokenType.STR:
+        return
+    ctx.candidates.append(
+        _FactoryCandidate(
+            head=head,
+            name=name,
+            name_tok=argv[1],
+            body_tok=body_tok,
+            ns_prefix=ns_prefix,
+        )
+    )
+
+
+def _scan_factory_candidates(
+    body_text: str,
+    body_tok: Token,
+    ns_prefix: str,
+    ctx: _ScanCtx,
+) -> None:
+    """Record factory-candidate calls inside a proc body.
+
+    Unlike :func:`_scan`, this pass walks a proc's body looking only
+    for ``HEAD NAME {ARGS} {BODY}`` shaped calls and descends into
+    structural-control bodies that commonly contain factory calls
+    (``if``/``catch``/``try``/``namespace eval``).  It deliberately
+    does not emit nested proc defs or namespace imports — those would
+    be incorrect because nested ``proc`` statements inside a proc body
+    only take effect when that proc is invoked.
+    """
+    try:
+        commands = segment_commands(body_text, body_token=body_tok)
+    except Exception:  # pragma: no cover - defensive
+        return
+    for cmd in commands:
+        if cmd.is_partial or not cmd.argv:
+            continue
+        texts = cmd.texts
+        argv = cmd.argv
+        head = texts[0] if texts else ""
+        if not head:
+            continue
+        if head in ("if", "catch", "try", "namespace"):
+            # Descend into braced bodies that commonly wrap factory calls.
+            _scan_factory_structural(head, texts, argv, ns_prefix, ctx)
+            continue
+        _maybe_record_factory_candidate(head, texts, argv, ns_prefix, ctx)
+
+
+def _scan_factory_structural(
+    head: str,
+    texts: list[str],
+    argv: list[Token],
+    ns_prefix: str,
+    ctx: _ScanCtx,
+) -> None:
+    """Recurse a structural command's braced bodies for factory candidates."""
+    if head == "namespace" and len(texts) >= 4 and texts[1] == "eval":
+        raw_ns = texts[2]
+        if raw_ns.startswith("::"):
+            inner = raw_ns.lstrip(":")
+        elif ns_prefix:
+            inner = f"{ns_prefix}::{raw_ns}"
+        else:
+            inner = raw_ns
+        if argv[3].type is TokenType.STR:
+            _scan_factory_candidates(texts[3], argv[3], inner, ctx)
+        return
+    if head == "if":
+        i = 1
+        expect_body = False
+        while i < len(texts):
+            w = texts[i]
+            if w == "then":
+                expect_body = True
+                i += 1
+                continue
+            if w == "elseif":
+                expect_body = False
+                i += 1
+                continue
+            if w == "else":
+                expect_body = True
+                i += 1
+                continue
+            if expect_body and argv[i].type is TokenType.STR:
+                _scan_factory_candidates(texts[i], argv[i], ns_prefix, ctx)
+                expect_body = False
+            else:
+                expect_body = True
+            i += 1
+        return
+    if head == "catch" and len(texts) >= 2 and argv[1].type is TokenType.STR:
+        _scan_factory_candidates(texts[1], argv[1], ns_prefix, ctx)
+        return
+    if head == "try" and len(texts) >= 2:
+        if argv[1].type is TokenType.STR:
+            _scan_factory_candidates(texts[1], argv[1], ns_prefix, ctx)
+        i = 2
+        while i < len(texts):
+            clause = texts[i]
+            if clause == "finally" and i + 1 < len(texts) and argv[i + 1].type is TokenType.STR:
+                _scan_factory_candidates(texts[i + 1], argv[i + 1], ns_prefix, ctx)
+                return
+            if (
+                clause in ("on", "trap")
+                and i + 3 < len(texts)
+                and argv[i + 3].type is TokenType.STR
+            ):
+                _scan_factory_candidates(texts[i + 3], argv[i + 3], ns_prefix, ctx)
+                i += 4
+            else:
+                i += 1
+        return
+
+
+def _is_factory_body(body_text: str, params: list[str]) -> bool:
+    """Return True when *body_text* matches the ``proc $p1 $p2 $p3`` idiom.
+
+    The canonical tcllib wrapper is::
+
+        proc foo {name args body} {
+            ...
+            proc $name $args $body
+            ...
+        }
+
+    We look for any top-level ``proc`` command whose three arguments
+    are ``$name $args $body`` in some order matching the wrapper's own
+    parameter list.  Non-variable arguments disqualify the match to
+    avoid treating ``proc $name foo body`` as a factory.
+    """
+    if len(params) < 3:
+        return False
+    try:
+        commands = segment_commands(body_text)
+    except Exception:  # pragma: no cover - defensive
+        return False
+    # The segmenter reconstructs substitutions as ``${name}``; accept the
+    # bare ``$name`` form too for robustness.
+    param_vars = set()
+    for p in params:
+        param_vars.add(f"${p}")
+        param_vars.add(f"${{{p}}}")
+    for cmd in commands:
+        if cmd.is_partial or not cmd.texts:
+            continue
+        t = cmd.texts
+        if t[0] != "proc" or len(t) != 4:
+            continue
+        if t[1] in param_vars and t[2] in param_vars and t[3] in param_vars:
+            return True
+    return False
+
+
+def _resolve_factory_defs(ctx: _ScanCtx) -> None:
+    """Emit synthetic ProcDefs for each factory-wrapper call site."""
+    if not ctx.candidates or not ctx.proc_bodies:
+        return
+    # Map every factory wrapper to ``(qualified_name, namespace_prefix)``.
+    # The namespace prefix is the namespace the wrapper itself belongs to,
+    # matching Tcl's runtime behaviour: ``proc NAME …`` executed inside
+    # a proc creates the new command in the wrapper's home namespace.
+    factories: dict[str, tuple[str, str]] = {}
+    for info in ctx.proc_bodies:
+        if not _is_factory_body(info.body_text, info.params):
+            continue
+        factories[info.qname] = (info.qname, info.ns_prefix)
+        # Also index by bare name so callers using the unqualified form
+        # (``DEFC showat``) resolve even without explicit qualification.
+        simple = info.qname.rsplit("::", 1)[-1]
+        factories.setdefault(simple, (info.qname, info.ns_prefix))
+    if not factories:
+        return
+    for cand in ctx.candidates:
+        target = factories.get(cand.head)
+        if target is None and cand.head.startswith("::"):
+            target = factories.get(cand.head.lstrip(":"))
+        if target is None:
+            # Unqualified head: also try resolving within the call-site
+            # namespace (``::ns::HEAD``) so a factory defined next to
+            # its callers still matches.
+            qualified_head = _qualify(cand.ns_prefix, cand.head)
+            target = factories.get(qualified_head)
+        if target is None:
+            continue
+        _factory_qname, factory_ns = target
+        # The emitted proc lives in the factory's own namespace unless
+        # the call supplied a fully-qualified name.
+        if cand.name.startswith("::"):
+            emitted_q = cand.name
+        elif factory_ns:
+            emitted_q = f"::{factory_ns}::{cand.name}"
+        else:
+            emitted_q = f"::{cand.name}"
+        simple = emitted_q.rsplit("::", 1)[-1]
+        if emitted_q in ctx.result.all_procs:
+            continue
+        ctx.result.all_procs[emitted_q] = ProcDef(
+            name=simple,
+            qualified_name=emitted_q,
+            params=[],  # factory callers supply params but we'd need
+            # the wrapper's mapping to know which token corresponds;
+            # leave empty — users still get a jump target.
+            name_range=range_from_token(cand.name_tok),
+            body_range=range_from_token(cand.body_tok),
+        )
 
 
 def _emit_class(

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -260,14 +260,23 @@ def _handle_namespace_import(
         if pattern == "-force":
             i += 1
             continue
-        # Must be a fully-qualified pattern — Tcl's ``namespace import``
-        # only accepts qualified names, but users occasionally write bare
-        # ones in new code; drop those because we cannot resolve them.
-        if "::" not in pattern:
+        # Must be a qualified pattern — ``namespace import`` requires
+        # a namespace segment; drop bare names or patterns that still
+        # carry variable / command substitutions, because we cannot
+        # statically resolve them to a source namespace.
+        if "::" not in pattern or "$" in pattern or "[" in pattern:
             i += 1
             continue
+        # A pattern without a leading ``::`` is resolved relative to
+        # the *current* namespace, not the global one — Tcl's own rule
+        # for ``namespace import``.  So
+        # ``namespace eval foo { namespace import bar::* }`` imports
+        # ``::foo::bar::*``, not ``::bar::*``.
         if not pattern.startswith("::"):
-            pattern = f"::{pattern}"
+            if importing_ns == "::":
+                pattern = f"::{pattern}"
+            else:
+                pattern = f"{importing_ns}::{pattern}"
         result.namespace_imports.append(
             NamespaceImport(
                 ns=importing_ns,
@@ -312,7 +321,15 @@ def _maybe_handle_import_wrapper(
     source_ns = head[: -len("::import")]  # strip trailing ``::import``
     if not source_ns.startswith("::"):
         source_ns = f"::{source_ns}"
-    alias_ns = alias if alias.startswith("::") else f"::{alias}"
+    # A relative alias lives under the current namespace — inside
+    # ``namespace eval outer { some::ns::import vt }``, Tcl would
+    # create ``::outer::vt``, not ``::vt``.
+    if alias.startswith("::"):
+        alias_ns = alias
+    elif ns_prefix:
+        alias_ns = f"::{ns_prefix}::{alias}"
+    else:
+        alias_ns = f"::{alias}"
     result.namespace_imports.append(
         NamespaceImport(
             ns=alias_ns,
@@ -748,37 +765,37 @@ def _is_factory_body(body_text: str, params: list[str]) -> bool:
 
 
 def _resolve_factory_defs(ctx: _ScanCtx) -> None:
-    """Emit synthetic ProcDefs for each factory-wrapper call site."""
+    """Emit synthetic ProcDefs for each factory-wrapper call site.
+
+    Factory wrappers are looked up following Tcl's command-resolution
+    order: an unqualified ``DEFC`` inside namespace ``::ns`` binds to
+    ``::ns::DEFC`` first, then falls back to ``::DEFC`` (global).  We
+    deliberately do *not* fall back to "any factory named DEFC
+    anywhere" — two unrelated namespaces can each define their own
+    ``DEFC`` wrapper and Tcl itself would refuse to cross those
+    boundaries, so we should not emit synthetic procs in the wrong
+    namespace.
+    """
     if not ctx.candidates or not ctx.proc_bodies:
         return
-    # Map every factory wrapper to ``(qualified_name, namespace_prefix)``.
-    # The namespace prefix is the namespace the wrapper itself belongs to,
-    # matching Tcl's runtime behaviour: ``proc NAME …`` executed inside
-    # a proc creates the new command in the wrapper's home namespace.
-    factories: dict[str, tuple[str, str]] = {}
+    # Map every factory wrapper's qualified name to the namespace its
+    # generated procs live in (the wrapper's own home namespace —
+    # ``proc $name …`` executed inside a proc creates the command in
+    # the caller's current namespace, which for a factory wrapper
+    # defined in ``::foo::bar`` and called from an init proc *also* in
+    # ``::foo::bar`` is unambiguously ``::foo::bar``).
+    factories: dict[str, str] = {}
     for info in ctx.proc_bodies:
         if not _is_factory_body(info.body_text, info.params):
             continue
-        factories[info.qname] = (info.qname, info.ns_prefix)
-        # Also index by bare name so callers using the unqualified form
-        # (``DEFC showat``) resolve even without explicit qualification.
-        simple = info.qname.rsplit("::", 1)[-1]
-        factories.setdefault(simple, (info.qname, info.ns_prefix))
+        factories[info.qname] = info.ns_prefix
     if not factories:
         return
     for cand in ctx.candidates:
-        target = factories.get(cand.head)
-        if target is None and cand.head.startswith("::"):
-            target = factories.get(cand.head.lstrip(":"))
-        if target is None:
-            # Unqualified head: also try resolving within the call-site
-            # namespace (``::ns::HEAD``) so a factory defined next to
-            # its callers still matches.
-            qualified_head = _qualify(cand.ns_prefix, cand.head)
-            target = factories.get(qualified_head)
-        if target is None:
+        factory_qname = _lookup_factory(cand, factories)
+        if factory_qname is None:
             continue
-        _factory_qname, factory_ns = target
+        factory_ns = factories[factory_qname]
         # The emitted proc lives in the factory's own namespace unless
         # the call supplied a fully-qualified name.
         if cand.name.startswith("::"):
@@ -799,6 +816,30 @@ def _resolve_factory_defs(ctx: _ScanCtx) -> None:
             name_range=range_from_token(cand.name_tok),
             body_range=range_from_token(cand.body_tok),
         )
+
+
+def _lookup_factory(
+    cand: _FactoryCandidate,
+    factories: dict[str, str],
+) -> str | None:
+    """Resolve *cand.head* to a factory qualified name.
+
+    Walks Tcl's command lookup path: absolute names match verbatim;
+    relative names try the call-site namespace first, then the global
+    namespace.  Never falls through to "any factory with this bare
+    name" — that would bind calls in one namespace to a wrapper in an
+    unrelated one.
+    """
+    head = cand.head
+    if head.startswith("::"):
+        return head if head in factories else None
+    qualified = _qualify(cand.ns_prefix, head)
+    if qualified in factories:
+        return qualified
+    global_q = f"::{head}"
+    if global_q != qualified and global_q in factories:
+        return global_q
+    return None
 
 
 def _emit_class(

--- a/core/packages/resolver.py
+++ b/core/packages/resolver.py
@@ -59,14 +59,16 @@ class PackageResolver:
         priority.  Pass ``prepend=True`` to place the new entries at the
         front of the effective order (for workspace-wins semantics).
         """
+        seen_new: set[str] = set()
         new_paths: list[str] = []
         for path in paths:
             if not path:
                 continue
             expanded = os.path.expanduser(path)
             abs_path = os.path.abspath(expanded)
-            if abs_path in self._scanned_paths:
+            if abs_path in self._scanned_paths or abs_path in seen_new:
                 continue
+            seen_new.add(abs_path)
             new_paths.append(abs_path)
         if not new_paths:
             return
@@ -74,7 +76,7 @@ class PackageResolver:
             self._search_paths = new_paths + [
                 p
                 for p in self._search_paths
-                if os.path.abspath(os.path.expanduser(p)) not in new_paths
+                if os.path.abspath(os.path.expanduser(p)) not in seen_new
             ]
         else:
             existing = {os.path.abspath(os.path.expanduser(p)) for p in self._search_paths}
@@ -111,9 +113,12 @@ class PackageResolver:
         """Walk *abs_path* recording pkgIndex.tcl and tclIndex entries."""
         if abs_path in self._scanned_paths:
             return
-        self._scanned_paths.add(abs_path)
+        # Don't mark a non-existent directory as scanned — a transient
+        # mount or a path created later should still get picked up on
+        # a subsequent call.
         if not os.path.isdir(abs_path):
             return
+        self._scanned_paths.add(abs_path)
         for root, _dirs, files in os.walk(abs_path):
             if "pkgIndex.tcl" in files:
                 pkg_index_path = os.path.join(root, "pkgIndex.tcl")

--- a/core/packages/resolver.py
+++ b/core/packages/resolver.py
@@ -33,30 +33,72 @@ class PackageResolver:
         self._packages: dict[str, list[PackageInfo]] = {}  # name -> versions
         self._auto_index: dict[str, list[str]] = {}  # proc_name -> [abs paths]
         self._search_paths: list[str] = []
+        self._scanned_paths: set[str] = set()
         self._scanned: bool = False
 
     def configure(self, search_paths: list[str]) -> None:
+        """Replace the search-path list and invalidate the scan cache.
+
+        Workspace roots should appear first so that a workspace-local
+        copy of a package wins over any copy provided by an installed
+        library path — matching Tcl's own ``auto_path`` order, where the
+        first ``pkgIndex.tcl`` that satisfies a ``package require`` is
+        the one that takes effect.
+        """
         self._search_paths = list(search_paths)
+        self._scanned_paths.clear()
         self._scanned = False
 
+    def add_search_paths(self, paths: list[str], *, prepend: bool = False) -> None:
+        """Incorporate additional search paths without discarding the scan cache.
+
+        Used to honour a document's own ``lappend auto_path`` declarations:
+        the new paths are merged in (deduplicated) and scanned immediately
+        for packages and tclIndex entries.  Existing ``_packages`` entries
+        are preserved, so the first provider already discovered keeps
+        priority.  Pass ``prepend=True`` to place the new entries at the
+        front of the effective order (for workspace-wins semantics).
+        """
+        new_paths: list[str] = []
+        for path in paths:
+            if not path:
+                continue
+            expanded = os.path.expanduser(path)
+            abs_path = os.path.abspath(expanded)
+            if abs_path in self._scanned_paths:
+                continue
+            new_paths.append(abs_path)
+        if not new_paths:
+            return
+        if prepend:
+            self._search_paths = new_paths + [
+                p
+                for p in self._search_paths
+                if os.path.abspath(os.path.expanduser(p)) not in new_paths
+            ]
+        else:
+            existing = {os.path.abspath(os.path.expanduser(p)) for p in self._search_paths}
+            self._search_paths.extend(p for p in new_paths if p not in existing)
+        for path in new_paths:
+            self._scan_single_path(path)
+
     def scan_packages(self) -> None:
-        """Walk search paths looking for pkgIndex.tcl and tclIndex files."""
+        """Walk search paths looking for pkgIndex.tcl and tclIndex files.
+
+        Paths are visited in ``_search_paths`` order and the first
+        ``package ifneeded`` entry for a given name wins — later
+        providers append to the version list but do not displace the
+        head.  This mirrors Tcl's own ``auto_path`` semantics.
+        """
         self._packages.clear()
         self._auto_index.clear()
+        self._scanned_paths.clear()
         for search_path in self._search_paths:
             expanded = os.path.expanduser(search_path)
             if not os.path.isdir(expanded):
                 log.warning("PackageResolver: directory not found: %s", search_path)
                 continue
-            for root, _dirs, files in os.walk(expanded):
-                if "pkgIndex.tcl" in files:
-                    pkg_index_path = os.path.join(root, "pkgIndex.tcl")
-                    self._parse_pkg_index(pkg_index_path, root)
-                # Also parse tclIndex files for auto-loading support.
-                files_lower = {f.lower(): f for f in files}
-                if "tclindex" in files_lower:
-                    tcl_index_path = os.path.join(root, files_lower["tclindex"])
-                    self._parse_auto_index(tcl_index_path)
+            self._scan_single_path(os.path.abspath(expanded))
         self._scanned = True
         log.info(
             "Package scan: found %d packages, %d auto-index procs in %d search paths",
@@ -64,6 +106,22 @@ class PackageResolver:
             len(self._auto_index),
             len(self._search_paths),
         )
+
+    def _scan_single_path(self, abs_path: str) -> None:
+        """Walk *abs_path* recording pkgIndex.tcl and tclIndex entries."""
+        if abs_path in self._scanned_paths:
+            return
+        self._scanned_paths.add(abs_path)
+        if not os.path.isdir(abs_path):
+            return
+        for root, _dirs, files in os.walk(abs_path):
+            if "pkgIndex.tcl" in files:
+                pkg_index_path = os.path.join(root, "pkgIndex.tcl")
+                self._parse_pkg_index(pkg_index_path, root)
+            files_lower = {f.lower(): f for f in files}
+            if "tclindex" in files_lower:
+                tcl_index_path = os.path.join(root, files_lower["tclindex"])
+                self._parse_auto_index(tcl_index_path)
 
     def resolve(self, package_name: str, version: str | None = None) -> list[str]:
         """Resolve a package name to its source file paths."""

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -787,10 +787,23 @@ def on_definition(
     col = params.position.character
     word = find_word_at_position(source, line, col)
     if word:
-        entries = workspace_index.find_proc(word)
-        for entry in entries:
-            if entry.proc:
-                locations.append(to_lsp_location(entry.uri, entry.proc.name_range))
+        # Prefer fully-qualified names synthesised from this file's
+        # ``namespace import`` (and tcllib ``X::import`` wrapper)
+        # declarations — that's how Tcl itself would resolve the call
+        # at runtime.  Only fall through to a tail-name search when no
+        # import rewrites produce a hit.
+        if analysis is not None and analysis.namespace_imports:
+            from core.analysis.namespace_imports import rewrite_via_imports
+
+            for candidate in rewrite_via_imports(word, analysis.namespace_imports):
+                for entry in workspace_index.find_proc(candidate):
+                    if entry.proc and entry.proc.qualified_name == candidate:
+                        locations.append(to_lsp_location(entry.uri, entry.proc.name_range))
+        if not locations:
+            entries = workspace_index.find_proc(word)
+            for entry in entries:
+                if entry.proc:
+                    locations.append(to_lsp_location(entry.uri, entry.proc.name_range))
         # Try cross-file RULE_INIT variables (e.g. $::varname)
         if not locations and word.startswith("::"):
             var_entries = workspace_index.find_rule_init_var(word)
@@ -2251,7 +2264,7 @@ def _update_workspace_index(uri: str, source: str, state: object) -> None:
         else:
             exports = extract_rule_init_vars(source, cu=state.compilation_unit)
             workspace_index.update_rule_init_vars(uri, exports)
-    _load_packages_if_needed(state.analysis)
+    _load_packages_if_needed(state.analysis, uri)
 
 
 def _publish_diagnostics_sync(
@@ -2639,12 +2652,34 @@ async def _publish_diagnostics(
     )
 
 
-def _load_packages_if_needed(analysis: object) -> None:
-    """Resolve and load packages referenced by ``package require``."""
+def _load_packages_if_needed(analysis: object, uri: str | None = None) -> None:
+    """Resolve and load packages referenced by ``package require``.
+
+    When the document carries ``lappend auto_path`` entries, resolve each
+    statically and register them with the package resolver so packages
+    provided by those directories become discoverable without requiring
+    an explicit workspace/library path setting — mirroring what Tcl
+    itself would do once the file has executed the ``lappend``.
+    """
     from core.analysis.semantic_model import AnalysisResult
 
     if not isinstance(analysis, AnalysisResult):
         return
+
+    if analysis.auto_path_entries and uri is not None:
+        import os
+
+        from core.analysis.auto_path_eval import evaluate_auto_path_expr
+
+        file_path = uri_to_path(uri)
+        extra_paths: list[str] = []
+        for entry in analysis.auto_path_entries:
+            resolved = evaluate_auto_path_expr(entry.raw, file_path)
+            if resolved and os.path.isdir(resolved) and resolved not in extra_paths:
+                extra_paths.append(resolved)
+        if extra_paths:
+            package_resolver.add_search_paths(extra_paths)
+
     if not analysis.package_requires:
         return
     for pkg_req in analysis.package_requires:
@@ -3334,6 +3369,15 @@ def on_initialized(params: types.InitializedParams) -> None:
         workspace_roots=roots,
         library_paths=library_paths if library_paths else None,
     )
+    # Prepend workspace roots to the package resolver's search paths so
+    # a workspace-local copy of a package (e.g. someone editing tcllib)
+    # wins over any copy provided by the configured library paths —
+    # matching Tcl's own ``auto_path`` semantics where the first
+    # provider found satisfies ``package require``.
+    resolver_paths = list(roots) + list(library_paths)
+    if resolver_paths:
+        package_resolver.configure(search_paths=resolver_paths)
+        _loaded_packages.clear()
 
     # Kick off the scan with optional progress reporting.  When the client
     # advertises window/workDoneProgress we emit begin/report/end notifications
@@ -3921,7 +3965,12 @@ def _apply_all_settings_now() -> None:
     if isinstance(library_paths_setting, list):
         library_paths = [str(p) for p in library_paths_setting]
         background_scanner.configure(library_paths=library_paths)
-        package_resolver.configure(search_paths=library_paths)
+        # Prepend workspace roots so a local copy of a package still
+        # wins over the configured library paths.  ``background_scanner
+        # ._workspace_roots`` is the authoritative list set in
+        # ``on_initialized`` and unchanged by this settings update.
+        resolver_paths = list(background_scanner._workspace_roots) + library_paths
+        package_resolver.configure(search_paths=resolver_paths)
         _loaded_packages.clear()
         threading.Thread(target=_run_background_scan, daemon=True).start()
 

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -2239,7 +2239,7 @@ def _update_workspace_index(uri: str, source: str, state: object) -> None:
         from core.analysis.source_resolver import resolve_source_target
 
         script_path = uri_to_path(uri) or ""
-        ws_roots = list(background_scanner._workspace_roots)
+        ws_roots = background_scanner.workspace_roots
         sourced: set[str] = set()
         for st in state.analysis.source_targets:
             resolved = resolve_source_target(st.raw_path, st.is_literal, script_path, ws_roots)
@@ -2652,6 +2652,26 @@ async def _publish_diagnostics(
     )
 
 
+def _is_unsafe_auto_path(path: str) -> bool:
+    """Return True when *path* is too broad to safely ``os.walk()``.
+
+    Filesystem roots, the user's home directory, and any directory
+    two levels or shallower are rejected — a script that appends
+    ``/`` or ``~`` to ``auto_path`` is almost certainly misusing the
+    idiom, and recursively walking a huge tree on the main LSP thread
+    would make the server unresponsive.
+    """
+    import os
+
+    norm = os.path.abspath(path)
+    if norm in ("/", os.path.sep) or norm == os.path.expanduser("~"):
+        return True
+    # Count meaningful path segments — reject depth < 2 so ``/tmp``
+    # or ``/Users`` never get swept, but ``/tmp/proj/lib`` is fine.
+    parts = [p for p in norm.split(os.sep) if p]
+    return len(parts) < 2
+
+
 def _load_packages_if_needed(analysis: object, uri: str | None = None) -> None:
     """Resolve and load packages referenced by ``package require``.
 
@@ -2675,7 +2695,22 @@ def _load_packages_if_needed(analysis: object, uri: str | None = None) -> None:
         extra_paths: list[str] = []
         for entry in analysis.auto_path_entries:
             resolved = evaluate_auto_path_expr(entry.raw, file_path)
-            if resolved and os.path.isdir(resolved) and resolved not in extra_paths:
+            if not resolved or not os.path.isdir(resolved):
+                continue
+            # Refuse to ``os.walk`` the filesystem root, the user's
+            # home directory, or any path shallow enough to sweep in
+            # unrelated trees.  A legitimate ``lappend auto_path``
+            # target is always a library subdirectory; anything at
+            # depth < 2 is almost certainly a mistake we shouldn't
+            # scan on the main thread.
+            if _is_unsafe_auto_path(resolved):
+                log.warning(
+                    "auto_path: refusing to scan overly broad directory %s (from %s)",
+                    resolved,
+                    file_path,
+                )
+                continue
+            if resolved not in extra_paths:
                 extra_paths.append(resolved)
         if extra_paths:
             package_resolver.add_search_paths(extra_paths)
@@ -3966,10 +4001,11 @@ def _apply_all_settings_now() -> None:
         library_paths = [str(p) for p in library_paths_setting]
         background_scanner.configure(library_paths=library_paths)
         # Prepend workspace roots so a local copy of a package still
-        # wins over the configured library paths.  ``background_scanner
-        # ._workspace_roots`` is the authoritative list set in
-        # ``on_initialized`` and unchanged by this settings update.
-        resolver_paths = list(background_scanner._workspace_roots) + library_paths
+        # wins over the configured library paths.  The scanner's
+        # ``workspace_roots`` accessor returns a snapshot of the list
+        # set in ``on_initialized``, which this settings update leaves
+        # unchanged.
+        resolver_paths = background_scanner.workspace_roots + library_paths
         package_resolver.configure(search_paths=resolver_paths)
         _loaded_packages.clear()
         threading.Thread(target=_run_background_scan, daemon=True).start()

--- a/lsp/workspace/scanner.py
+++ b/lsp/workspace/scanner.py
@@ -94,6 +94,11 @@ class BackgroundScanner:
         if library_paths is not None:
             self._library_paths = list(library_paths)
 
+    @property
+    def workspace_roots(self) -> list[str]:
+        """Return a snapshot of the currently configured workspace roots."""
+        return list(self._workspace_roots)
+
     def collect_files(self) -> list[tuple[str, str]]:
         """Discover all Tcl and BIG-IP config files without analysing them.
 

--- a/lsp/workspace/workspace_index.py
+++ b/lsp/workspace/workspace_index.py
@@ -240,9 +240,14 @@ class WorkspaceIndex:
         qualified = f"::{name}"
         if qualified in procs:
             return list(procs[qualified])
-        # O(1) tail-name lookup instead of O(n) scan
+        # O(1) tail-name lookup instead of O(n) scan.  The tail index
+        # keys on the simple (unqualified) name, so strip any namespace
+        # qualifier from the input before looking up — otherwise a
+        # reference like ``vt::showat`` would miss every
+        # ``::target::...::showat`` in the index.
+        tail = name.rsplit("::", 1)[-1] if "::" in name else name
         results: list[IndexEntry] = []
-        for qname in tail_index.get(name, ()):
+        for qname in tail_index.get(tail, ()):
             if qname in procs:
                 results.extend(procs[qname])
         return results

--- a/tests/test_namespace_imports.py
+++ b/tests/test_namespace_imports.py
@@ -1,0 +1,244 @@
+"""Tests for namespace-import rewriting and extraction."""
+
+from __future__ import annotations
+
+from core.analysis.analyser import analyse
+from core.analysis.auto_path_eval import evaluate_auto_path_expr
+from core.analysis.namespace_imports import rewrite_via_imports
+from core.analysis.semantic_model import NamespaceImport, Range
+from core.analysis.signature_scan import extract_signatures
+from core.parsing.tokens import SourcePosition
+
+
+def _zero_range() -> Range:
+    p = SourcePosition(line=0, character=0, offset=0)
+    return Range(start=p, end=p)
+
+
+# rewrite_via_imports
+
+
+class TestRewriteViaImports:
+    def test_glob_import_rewrites_qualified_ref(self):
+        imports = [
+            NamespaceImport(
+                ns="::vt",
+                pattern="::term::ansi::send::*",
+                range=_zero_range(),
+            )
+        ]
+        assert rewrite_via_imports("vt::showat", imports) == ["::term::ansi::send::showat"]
+        # Explicit ``::`` prefix on the source is accepted too.
+        assert rewrite_via_imports("::vt::showat", imports) == ["::term::ansi::send::showat"]
+
+    def test_global_import_rewrites_bare_name(self):
+        imports = [
+            NamespaceImport(
+                ns="::",
+                pattern="::foo::bar::*",
+                range=_zero_range(),
+            )
+        ]
+        assert rewrite_via_imports("baz", imports) == ["::foo::bar::baz"]
+
+    def test_specific_import_matches_only_its_tail(self):
+        imports = [
+            NamespaceImport(
+                ns="::my",
+                pattern="::other::baz",
+                range=_zero_range(),
+            )
+        ]
+        assert rewrite_via_imports("my::baz", imports) == ["::other::baz"]
+        assert rewrite_via_imports("my::quux", imports) == []
+
+    def test_mismatched_namespace_returns_nothing(self):
+        imports = [
+            NamespaceImport(
+                ns="::vt",
+                pattern="::term::ansi::send::*",
+                range=_zero_range(),
+            )
+        ]
+        # Importing namespace is ``::vt``, reference is ``other::showat``.
+        assert rewrite_via_imports("other::showat", imports) == []
+
+    def test_conjectured_sorts_after_explicit(self):
+        imports = [
+            NamespaceImport(
+                ns="::vt",
+                pattern="::tcllib::send::*",
+                range=_zero_range(),
+                conjectured=True,
+            ),
+            NamespaceImport(
+                ns="::vt",
+                pattern="::explicit::send::*",
+                range=_zero_range(),
+            ),
+        ]
+        assert rewrite_via_imports("vt::showat", imports) == [
+            "::explicit::send::showat",
+            "::tcllib::send::showat",
+        ]
+
+
+# evaluate_auto_path_expr
+
+
+class TestEvaluateAutoPathExpr:
+    def test_literal_path(self):
+        assert evaluate_auto_path_expr("/abs/lib", "/tmp/foo.tcl") == "/abs/lib"
+
+    def test_file_dirname_info_script(self):
+        assert (
+            evaluate_auto_path_expr("[file dirname [info script]]", "/tmp/foo/bar.tcl")
+            == "/tmp/foo"
+        )
+
+    def test_tcllib_idiom(self):
+        raw = "[file join [file dirname [file dirname [file dirname [info script]]]] modules]"
+        got = evaluate_auto_path_expr(raw, "/tmp/tcllib-2.0/examples/term/menu")
+        assert got == "/tmp/tcllib-2.0/modules"
+
+    def test_variable_substitution_is_refused(self):
+        assert evaluate_auto_path_expr("$env(PATH)", "/tmp/foo.tcl") is None
+
+    def test_unknown_command_is_refused(self):
+        assert evaluate_auto_path_expr("[glob *.tcl]", "/tmp/foo.tcl") is None
+
+
+# namespace import extraction
+
+
+class TestExtractNamespaceImports:
+    def test_direct_namespace_import_at_top_level(self):
+        src = "namespace import ::foo::bar::*\n"
+        result = extract_signatures(src)
+        assert len(result.namespace_imports) == 1
+        imp = result.namespace_imports[0]
+        assert imp.ns == "::"
+        assert imp.pattern == "::foo::bar::*"
+        assert not imp.conjectured
+
+    def test_namespace_import_inside_eval_block(self):
+        src = "namespace eval my { namespace import ::other::baz }\n"
+        result = extract_signatures(src)
+        assert len(result.namespace_imports) == 1
+        imp = result.namespace_imports[0]
+        assert imp.ns == "::my"
+        assert imp.pattern == "::other::baz"
+
+    def test_tcllib_import_wrapper_is_conjectured(self):
+        src = "term::ansi::send::import vt\n"
+        result = extract_signatures(src)
+        imports = [i for i in result.namespace_imports if i.conjectured]
+        assert len(imports) == 1
+        imp = imports[0]
+        assert imp.ns == "::vt"
+        assert imp.pattern == "::term::ansi::send::*"
+
+    def test_unqualified_pattern_is_ignored(self):
+        # ``namespace import foo`` without leading ``::`` can't be resolved.
+        src = "namespace import foo\n"
+        result = extract_signatures(src)
+        assert result.namespace_imports == []
+
+    def test_auto_path_entry_captured(self):
+        src = "lappend auto_path [file dirname [info script]] /abs/lib\n"
+        result = extract_signatures(src)
+        assert len(result.auto_path_entries) == 2
+        # Raw text is preserved verbatim so callers can static-evaluate.
+        raws = [e.raw for e in result.auto_path_entries]
+        assert "[file dirname [info script]]" in raws
+        assert "/abs/lib" in raws
+
+
+# factory-wrapper detection (DEFC-style)
+
+
+class TestFactoryWrapperDetection:
+    def test_defc_factory_emits_synthetic_proc(self):
+        src = """
+namespace eval ::x {}
+proc ::x::DEFC {name arguments script} {
+    proc $name $arguments $script
+}
+proc ::x::INIT {} {
+    DEFC showat {r c text} {
+        return "$r $c $text"
+    }
+}
+"""
+        result = extract_signatures(src)
+        assert "::x::showat" in result.all_procs
+        # Non-factory procs still indexed.
+        assert "::x::DEFC" in result.all_procs
+        assert "::x::INIT" in result.all_procs
+
+    def test_non_factory_wrapper_does_not_emit(self):
+        # A wrapper whose body doesn't call ``proc $p1 $p2 $p3`` must not
+        # turn every 3-arg call into a synthetic proc.
+        src = """
+namespace eval ::x {}
+proc ::x::frob {a b c} {
+    return "$a-$b-$c"
+}
+proc ::x::INIT {} {
+    frob showat {r c text} {
+        return "noop"
+    }
+}
+"""
+        result = extract_signatures(src)
+        assert "::x::showat" not in result.all_procs
+
+    def test_factory_call_with_dollar_braces_in_body(self):
+        # tcllib's ``DEFC`` body uses ``proc $name $arguments $script``.
+        src = """
+proc ::ns::DEFC {name arguments script} {
+    variable ctrl
+    proc ${name} ${arguments} ${script}
+    return
+}
+proc ::ns::INIT {} {
+    DEFC foo {a b} { return "$a-$b" }
+}
+"""
+        result = extract_signatures(src)
+        assert "::ns::foo" in result.all_procs
+
+    def test_factory_requires_three_params(self):
+        # A wrapper with only 2 params can't map to ``proc NAME ARGS BODY``.
+        src = """
+proc ::ns::two_arg {a b} {
+    proc $a $b ""
+}
+proc ::ns::INIT {} {
+    two_arg foo {r c}
+}
+"""
+        result = extract_signatures(src)
+        assert "::ns::foo" not in result.all_procs
+
+
+# full analyser picks up namespace imports
+
+
+class TestAnalyserNamespaceImports:
+    def test_direct_import_tracked(self):
+        src = "namespace eval my { namespace import ::foo::bar::* }\n"
+        result = analyse(src)
+        patterns = {(i.ns, i.pattern) for i in result.namespace_imports}
+        assert ("::my", "::foo::bar::*") in patterns
+
+    def test_tcllib_import_wrapper_conjectured(self):
+        src = "term::ansi::send::import vt\n"
+        result = analyse(src)
+        conj = [i for i in result.namespace_imports if i.conjectured]
+        assert any(i.ns == "::vt" and i.pattern == "::term::ansi::send::*" for i in conj)
+
+    def test_auto_path_entries_captured(self):
+        src = "lappend auto_path /tmp/lib\n"
+        result = analyse(src)
+        assert any(e.raw == "/tmp/lib" for e in result.auto_path_entries)

--- a/tests/test_namespace_imports.py
+++ b/tests/test_namespace_imports.py
@@ -144,6 +144,56 @@ class TestExtractNamespaceImports:
         result = extract_signatures(src)
         assert result.namespace_imports == []
 
+    def test_relative_pattern_resolves_against_current_namespace(self):
+        # Tcl resolves ``bar::*`` inside ``namespace eval foo`` as
+        # ``::foo::bar::*``, not ``::bar::*``.  The LSP must track the
+        # same target, otherwise cross-file lookup points at the wrong
+        # source namespace.
+        src = "namespace eval foo { namespace import bar::baz }\n"
+        result = extract_signatures(src)
+        assert len(result.namespace_imports) == 1
+        imp = result.namespace_imports[0]
+        assert imp.ns == "::foo"
+        assert imp.pattern == "::foo::bar::baz"
+
+    def test_relative_glob_pattern_resolves_against_current_namespace(self):
+        src = "namespace eval outer { namespace import inner::* }\n"
+        result = extract_signatures(src)
+        assert len(result.namespace_imports) == 1
+        assert result.namespace_imports[0].pattern == "::outer::inner::*"
+
+    def test_relative_pattern_at_global_still_absolute(self):
+        # At the global level ``foo::bar`` resolves to ``::foo::bar``.
+        src = "namespace import foo::bar\n"
+        result = extract_signatures(src)
+        assert len(result.namespace_imports) == 1
+        assert result.namespace_imports[0].pattern == "::foo::bar"
+
+    def test_substituted_pattern_is_ignored(self):
+        # ``namespace import $var::*`` can't be statically resolved.
+        src = "namespace import $mod::*\n"
+        result = extract_signatures(src)
+        assert result.namespace_imports == []
+
+    def test_nested_namespace_eval_uses_full_qualified_path(self):
+        # ``namespace eval outer { namespace eval inner { namespace
+        # import … } }`` records the import under ``::outer::inner``,
+        # not ``::inner``.
+        src = "namespace eval outer { namespace eval inner { namespace import ::foo::* } }\n"
+        result = extract_signatures(src)
+        assert len(result.namespace_imports) == 1
+        assert result.namespace_imports[0].ns == "::outer::inner"
+
+    def test_import_wrapper_alias_relative_to_current_namespace(self):
+        # tcllib ``X::import alias`` inside ``namespace eval outer``
+        # creates ``::outer::alias``, not ``::alias``.
+        src = "namespace eval outer { term::ansi::send::import vt }\n"
+        result = extract_signatures(src)
+        conj = [i for i in result.namespace_imports if i.conjectured]
+        assert len(conj) == 1
+        assert conj[0].ns == "::outer::vt"
+        assert conj[0].pattern == "::term::ansi::send::*"
+
     def test_auto_path_entry_captured(self):
         src = "lappend auto_path [file dirname [info script]] /abs/lib\n"
         result = extract_signatures(src)
@@ -220,6 +270,61 @@ proc ::ns::INIT {} {
 """
         result = extract_signatures(src)
         assert "::ns::foo" not in result.all_procs
+
+    def test_two_namespaces_with_identical_factory_do_not_cross(self):
+        # Two unrelated namespaces each define their own ``DEFC``
+        # wrapper.  An unqualified ``DEFC`` call inside ``::b`` must
+        # bind to ``::b::DEFC``, emitting the synthetic proc in
+        # ``::b`` — never to ``::a::DEFC``.  The call inside ``::a``
+        # stays in ``::a``.
+        src = """
+proc ::a::DEFC {name arguments script} {
+    proc $name $arguments $script
+}
+proc ::b::DEFC {name arguments script} {
+    proc $name $arguments $script
+}
+proc ::a::INIT {} {
+    DEFC from_a {r} { return $r }
+}
+proc ::b::INIT {} {
+    DEFC from_b {r} { return $r }
+}
+"""
+        result = extract_signatures(src)
+        assert "::a::from_a" in result.all_procs
+        assert "::b::from_b" in result.all_procs
+        # Cross-namespace leakage is the bug — assert both ways.
+        assert "::a::from_b" not in result.all_procs
+        assert "::b::from_a" not in result.all_procs
+
+    def test_factory_without_matching_namespace_is_skipped(self):
+        # A factory in ``::a`` and a call in ``::b`` (where ``::b``
+        # has no factory) must NOT bind — better to emit nothing than
+        # to bind into the wrong namespace.
+        src = """
+proc ::a::DEFC {name arguments script} {
+    proc $name $arguments $script
+}
+proc ::b::INIT {} {
+    DEFC stray {r} { return $r }
+}
+"""
+        result = extract_signatures(src)
+        assert "::a::stray" not in result.all_procs
+        assert "::b::stray" not in result.all_procs
+
+    def test_global_factory_matches_global_call(self):
+        # A factory defined at the global level matches bare calls at
+        # the global level.
+        src = """
+proc ::DEFC {name arguments script} {
+    proc $name $arguments $script
+}
+DEFC global_proc {r} { return $r }
+"""
+        result = extract_signatures(src)
+        assert "::global_proc" in result.all_procs
 
 
 # full analyser picks up namespace imports

--- a/tests/test_package_resolver.py
+++ b/tests/test_package_resolver.py
@@ -160,3 +160,61 @@ class TestPackageResolver:
         resolver.configure(search_paths=["/nonexistent/path/xyz"])
         resolver.scan_packages()
         assert resolver.all_package_names() == []
+
+    def test_first_search_path_wins(self):
+        # When the same package name is provided by two paths, the first
+        # one scanned takes priority — matching Tcl's ``auto_path``
+        # semantics where the first ``package ifneeded`` that matches
+        # satisfies the require.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = os.path.join(tmpdir, "ws")
+            libdir = os.path.join(tmpdir, "lib")
+            for base in (workspace, libdir):
+                pkg_dir = os.path.join(base, "mylib")
+                os.makedirs(pkg_dir)
+                Path(os.path.join(pkg_dir, "mylib.tcl")).write_text(f"# from {base}")
+                Path(os.path.join(pkg_dir, "pkgIndex.tcl")).write_text(
+                    "package ifneeded mylib 1.0 [list source [file join $dir mylib.tcl]]"
+                )
+            resolver = PackageResolver()
+            # Workspace first — its copy should win.
+            resolver.configure(search_paths=[workspace, libdir])
+            files = resolver.resolve("mylib")
+            assert len(files) == 1
+            assert files[0].startswith(workspace)
+
+    def test_add_search_paths_preserves_existing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first_dir = os.path.join(tmpdir, "first")
+            second_dir = os.path.join(tmpdir, "second")
+            for base, name in ((first_dir, "firstpkg"), (second_dir, "secondpkg")):
+                pkg_dir = os.path.join(base, f"{name}1.0")
+                os.makedirs(pkg_dir)
+                Path(os.path.join(pkg_dir, f"{name}.tcl")).write_text("")
+                Path(os.path.join(pkg_dir, "pkgIndex.tcl")).write_text(
+                    f"package ifneeded {name} 1.0 [list source [file join $dir {name}.tcl]]"
+                )
+            resolver = PackageResolver()
+            resolver.configure(search_paths=[first_dir])
+            resolver.scan_packages()
+            assert "firstpkg" in resolver.all_package_names()
+            resolver.add_search_paths([second_dir])
+            assert "firstpkg" in resolver.all_package_names()
+            assert "secondpkg" in resolver.all_package_names()
+
+    def test_add_search_paths_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = os.path.join(tmpdir, "pkg1.0")
+            os.makedirs(pkg_dir)
+            Path(os.path.join(pkg_dir, "pkg.tcl")).write_text("")
+            Path(os.path.join(pkg_dir, "pkgIndex.tcl")).write_text(
+                "package ifneeded pkg 1.0 [list source [file join $dir pkg.tcl]]"
+            )
+            resolver = PackageResolver()
+            resolver.configure(search_paths=[])
+            resolver.scan_packages()
+            resolver.add_search_paths([tmpdir])
+            first_count = len(resolver.resolve("pkg"))
+            resolver.add_search_paths([tmpdir])
+            second_count = len(resolver.resolve("pkg"))
+            assert first_count == second_count == 1


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for tracking Tcl namespace imports and detecting factory-wrapper proc definitions (tcllib's `DEFC` pattern), enabling more accurate cross-file command resolution in the LSP.

### Key Changes

**Namespace Import Tracking:**
- Extract `namespace import` declarations during signature scanning, recording both direct imports and tcllib-style `X::import` wrapper calls (marked as conjectured)
- Add `NamespaceImport` and `AutoPathEntry` semantic model types to represent these declarations
- Implement `rewrite_via_imports()` helper to resolve qualified command references through import patterns
- Update LSP definition lookup to prefer import-rewritten names over tail-name searches

**Factory-Wrapper Proc Detection:**
- Detect tcllib's `DEFC name args body` / `DEF name esc value` pattern where a wrapper proc calls `proc $name $args $body`
- Record factory candidates during initial scan and resolve them in a second pass after all proc bodies are collected
- Synthesize `ProcDef` entries for dynamically-created procs so they appear in the workspace index
- Refactor `_scan()` to use a `_ScanCtx` dataclass for threading context through recursive calls

**Auto-Path Resolution:**
- Add `auto_path_eval.py` module to statically evaluate `lappend auto_path` / `set auto_path` arguments
- Support common idioms: literal paths, `[file dirname]`, `[file join]`, `[info script]`
- Extend `PackageResolver` with `add_search_paths()` to incorporate document-local paths without discarding scan cache
- Update `_load_packages_if_needed()` to resolve and register auto-path entries from analyzed documents

**Refactoring:**
- Replace `result: AnalysisResult` parameter with `ctx: _ScanCtx` in recursive scan functions for cleaner context threading
- Add `_handle_namespace_import()` and `_maybe_handle_import_wrapper()` to separate import handling logic
- Extract `_handle_auto_path()` to centralize `lappend auto_path` / `set auto_path` recording

### Testing

- Added comprehensive test suite in `tests/test_namespace_imports.py` covering:
  - Glob and specific import pattern matching
  - Conjectured vs. explicit import ordering
  - Auto-path expression evaluation (literals, file operations, info script)
  - Factory-wrapper detection (DEFC pattern, parameter validation)
  - Full analyser integration
- Extended `tests/test_package_resolver.py` with tests for search-path priority and incremental path addition
- All new functionality is covered by unit tests

## Validation

- [x] Unit tests added and passing for namespace imports, auto-path evaluation, and factory detection
- [x] Integration tests verify LSP definition lookup respects import rewrites
- [x] Package resolver tests confirm search-path ordering and incremental updates work correctly

https://claude.ai/code/session_01KHr8XCQp6JcNgppYifYrsq