### PR TITLE
Add project-level config and diagnostic suppression layers

### DIFF
--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -30,7 +30,9 @@ from ..semantic_model import (
 from ..stub_comments import scan_source_for_stubs
 from ._snapshot import AnalyserSnapshot
 from ._utils import (
+    _FILE_SUPPRESS_KEY,
     _NOQA_ALL,
+    parse_file_suppression,
 )
 
 log = logging.getLogger(__name__)
@@ -362,6 +364,12 @@ class _AnalyserBase:
         self.result.stub_commands.extend(cmd_stubs)
         self.result.stub_expr_defs.extend(expr_stubs)
         self._check_stub_shadows()
+        # Pre-scan for top-of-file ``# tcl-lsp: disable=...`` directives.
+        # Stored in ``suppressed_lines`` under ``_FILE_SUPPRESS_KEY`` (-1) so
+        # the same per-code filter logic handles both inline and file scopes.
+        file_codes = parse_file_suppression(source)
+        if file_codes:
+            self.result.suppressed_lines[_FILE_SUPPRESS_KEY] = file_codes
         self._analyse_body(source, self._current_scope)
         self._emit_unresolved_command_diagnostics(cu=cu)
         self._emit_variable_usage_diagnostics()

--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -21,6 +21,8 @@ from ...parsing.expr_lexer import (
 from ...parsing.recovery import segment_with_recovery
 from ...parsing.tokens import Token, TokenType
 from ..semantic_model import (
+    _FILE_SUPPRESS_KEY,
+    _NOQA_ALL,
     AnalysisResult,
     Diagnostic,
     Range,
@@ -29,11 +31,7 @@ from ..semantic_model import (
 )
 from ..stub_comments import scan_source_for_stubs
 from ._snapshot import AnalyserSnapshot
-from ._utils import (
-    _FILE_SUPPRESS_KEY,
-    _NOQA_ALL,
-    parse_file_suppression,
-)
+from ._utils import parse_file_suppression
 
 log = logging.getLogger(__name__)
 

--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -224,6 +224,10 @@ class _AnalyserBase:
             self.result.stub_commands.extend(cmd_stubs)
             self.result.stub_expr_defs.extend(expr_stubs)
             self._check_stub_shadows()
+        # Pre-scan for top-of-file ``# tcl-lsp: disable=...`` directives.
+        file_codes = parse_file_suppression(source)
+        if file_codes:
+            self.result.suppressed_lines[_FILE_SUPPRESS_KEY] = file_codes
 
         snapshots: list[AnalyserSnapshot] = []
         for cmds in chunk_commands:
@@ -257,6 +261,10 @@ class _AnalyserBase:
         self._source = source
         self._unresolved_commands_emitted = False
         self._ns_cache.clear()
+        # Pre-scan for top-of-file ``# tcl-lsp: disable=...`` directives.
+        file_codes = parse_file_suppression(source)
+        if file_codes:
+            self.result.suppressed_lines[_FILE_SUPPRESS_KEY] = file_codes
         self._analyse_commands_inner(commands, self._current_scope, source)
         if finalise:
             self._emit_unresolved_command_diagnostics()

--- a/core/analysis/_analyser/_utils.py
+++ b/core/analysis/_analyser/_utils.py
@@ -7,6 +7,7 @@ detectable errors.
 
 from __future__ import annotations
 
+import io
 import logging
 import re
 
@@ -117,9 +118,10 @@ def parse_file_suppression(source: str) -> frozenset[str]:
     nor a ``#`` comment.  Multiple directives accumulate.
     """
     codes: set[str] = set()
-    for idx, raw in enumerate(source.splitlines()):
+    for idx, line in enumerate(io.StringIO(source)):
         if idx >= _FILE_DIRECTIVE_SCAN_LINES:
             break
+        raw = line.rstrip("\r\n")
         stripped = raw.strip()
         if not stripped:
             continue

--- a/core/analysis/_analyser/_utils.py
+++ b/core/analysis/_analyser/_utils.py
@@ -96,16 +96,6 @@ diag(
 
 _UNUSED_VAR_RE = re.compile(r"Variable '([^']+)' is set but never used")
 
-# Inline suppression via Tcl comments: bare form suppresses all diagnostics,
-# ``# <noqa>: W100,W101`` suppresses specific codes on the following command.
-_NOQA_ALL = frozenset({"*"})  # sentinel for "suppress everything"
-
-# ``AnalysisResult.suppressed_lines`` uses real line numbers (>= 0) for inline
-# ``# noqa`` suppression and the sentinel key below for file-wide suppression
-# from a top-of-file ``# tcl-lsp: disable=...`` directive.  Negative keys can
-# never collide with an actual source line.
-_FILE_SUPPRESS_KEY = -1
-
 # Matches ``# tcl-lsp: disable=CODE1,CODE2`` (or ``=*``) at the start of a line,
 # case-insensitive.  Commas and whitespace separate codes.
 _FILE_DIRECTIVE_RE = re.compile(

--- a/core/analysis/_analyser/_utils.py
+++ b/core/analysis/_analyser/_utils.py
@@ -100,6 +100,50 @@ _UNUSED_VAR_RE = re.compile(r"Variable '([^']+)' is set but never used")
 # ``# <noqa>: W100,W101`` suppresses specific codes on the following command.
 _NOQA_ALL = frozenset({"*"})  # sentinel for "suppress everything"
 
+# ``AnalysisResult.suppressed_lines`` uses real line numbers (>= 0) for inline
+# ``# noqa`` suppression and the sentinel key below for file-wide suppression
+# from a top-of-file ``# tcl-lsp: disable=...`` directive.  Negative keys can
+# never collide with an actual source line.
+_FILE_SUPPRESS_KEY = -1
+
+# Matches ``# tcl-lsp: disable=CODE1,CODE2`` (or ``=*``) at the start of a line,
+# case-insensitive.  Commas and whitespace separate codes.
+_FILE_DIRECTIVE_RE = re.compile(
+    r"^\s*#\s*tcl-lsp\s*:\s*disable\s*=\s*([^\r\n]+?)\s*$",
+    re.IGNORECASE,
+)
+
+# Cap on how many leading lines we scan for file-wide directives.  The loop
+# also stops at the first non-comment, non-blank line, so this only matters
+# for pathological files that are entirely comments.
+_FILE_DIRECTIVE_SCAN_LINES = 100
+
+
+def parse_file_suppression(source: str) -> frozenset[str]:
+    """Extract file-wide diagnostic suppression from top-of-file directives.
+
+    Scans leading comment/blank lines for ``# tcl-lsp: disable=CODE1,CODE2``
+    (or ``=*`` for all codes).  Stops at the first line that is neither blank
+    nor a ``#`` comment.  Multiple directives accumulate.
+    """
+    codes: set[str] = set()
+    for idx, raw in enumerate(source.splitlines()):
+        if idx >= _FILE_DIRECTIVE_SCAN_LINES:
+            break
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("#"):
+            break
+        match = _FILE_DIRECTIVE_RE.match(raw)
+        if not match:
+            continue
+        for token in match.group(1).replace(",", " ").split():
+            token = token.strip()
+            if token:
+                codes.add(token)
+    return frozenset(codes)
+
 
 def _possible_paste_fingerprint(stmt: IRStatement) -> tuple[str, str] | None:
     """Return (variable, static_value) for static assignments worth heuristic checks."""

--- a/core/analysis/conf_wrapped.py
+++ b/core/analysis/conf_wrapped.py
@@ -221,9 +221,10 @@ def _merge_shifted_result(
     for diag in result.diagnostics:
         merged.diagnostics.append(_shift_diagnostic(diag, base_line, base_char, base_offset))
 
-    # Suppressed lines
+    # Suppressed lines — negative keys are sentinels (e.g. _FILE_SUPPRESS_KEY)
+    # that must not be shifted; only real line numbers (>= 0) need an offset.
     for line_no, codes in result.suppressed_lines.items():
-        merged.suppressed_lines[line_no + base_line] = codes
+        merged.suppressed_lines[line_no if line_no < 0 else line_no + base_line] = codes
 
     # Regex patterns
     for rp in result.regex_patterns:

--- a/core/analysis/semantic_model.py
+++ b/core/analysis/semantic_model.py
@@ -441,8 +441,11 @@ class AnalysisResult:
     all_classes: dict[str, ClassDef] = field(default_factory=dict)
     all_variables: dict[str, VarDef] = field(default_factory=dict)
     diagnostics: list[Diagnostic] = field(default_factory=list)
-    # Inline suppression: line -> set of suppressed diagnostic codes.
-    # Populated from ``# tcl-lsp: disable=CODE,...`` comment directives.
+    # Suppressed diagnostic codes, keyed by line number.  Real line numbers
+    # (>= 0) hold inline ``# <noqa>`` / ``# <noqa>: CODE`` codes; the sentinel
+    # key ``-1`` holds codes from a top-of-file ``# tcl-lsp: disable=CODE``
+    # directive and applies file-wide.  See
+    # ``docs/kcs/kcs-howto-suppress-diagnostics.md``.
     suppressed_lines: dict[int, frozenset[str]] = field(default_factory=dict)
     regex_patterns: list[RegexPattern] = field(default_factory=list)
     command_invocations: list[CommandInvocation] = field(default_factory=list)

--- a/core/analysis/semantic_model.py
+++ b/core/analysis/semantic_model.py
@@ -432,6 +432,16 @@ class UnknownProcInfo:
 
 
 # Analysis result
+
+# Sentinel values for ``AnalysisResult.suppressed_lines``.
+# ``_NOQA_ALL`` is stored as the code-set value meaning "suppress every code
+# on this line".  ``_FILE_SUPPRESS_KEY`` is the dict key used for codes that
+# apply to the entire file (from a top-of-file ``# tcl-lsp: disable=`` directive).
+# Negative keys can never collide with a real source line number.
+_NOQA_ALL: frozenset[str] = frozenset({"*"})
+_FILE_SUPPRESS_KEY: int = -1
+
+
 @dataclass
 class AnalysisResult:
     """Complete analysis result for a single document."""

--- a/core/common/user_config.py
+++ b/core/common/user_config.py
@@ -208,6 +208,8 @@ def load_project_config(workspace_root: str | Path) -> configparser.ConfigParser
         log.info("Loaded project config from %s", path)
     except Exception:
         log.warning("Failed to parse %s, ignoring", path, exc_info=True)
+        config = configparser.ConfigParser()
+        config.optionxform = str  # type: ignore[assignment, invalid-assignment]  # preserve camelCase keys
     return config
 
 

--- a/core/common/user_config.py
+++ b/core/common/user_config.py
@@ -154,6 +154,12 @@ def _config_path() -> Path:
     return _config_dir() / "config.ini"
 
 
+# Filename for per-project config.  Uses the same ``.ini`` schema as the
+# user-level config so ``get_all_settings`` can parse either.  Conventionally
+# placed at the workspace root and checked in with the project source.
+PROJECT_CONFIG_FILENAME = ".tcl-lsp.ini"
+
+
 def load_user_config() -> configparser.ConfigParser:
     """Load the user configuration file.
 
@@ -170,6 +176,63 @@ def load_user_config() -> configparser.ConfigParser:
         except Exception:
             log.warning("Failed to parse %s, using defaults", path, exc_info=True)
     return config
+
+
+def find_project_config(workspace_root: str | Path) -> Path | None:
+    """Locate ``.tcl-lsp.ini`` for a workspace.
+
+    Returns the path if the file exists directly at *workspace_root* — we do
+    not walk upward because the LSP is always initialised with the workspace
+    root it should treat as authoritative.
+    """
+    root = Path(workspace_root)
+    candidate = root / PROJECT_CONFIG_FILENAME
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def load_project_config(workspace_root: str | Path) -> configparser.ConfigParser:
+    """Load ``.tcl-lsp.ini`` from *workspace_root* if it exists.
+
+    Returns an empty :class:`configparser.ConfigParser` when no file is
+    present or when the file fails to parse — never raises.
+    """
+    config = configparser.ConfigParser()
+    config.optionxform = str  # type: ignore[assignment, invalid-assignment]  # preserve camelCase keys
+    path = find_project_config(workspace_root)
+    if path is None:
+        return config
+    try:
+        config.read(str(path), encoding="utf-8")
+        log.info("Loaded project config from %s", path)
+    except Exception:
+        log.warning("Failed to parse %s, ignoring", path, exc_info=True)
+    return config
+
+
+def merge_settings_layers(*layers: dict) -> dict:
+    """Merge settings dicts with later layers overriding earlier ones.
+
+    Sections (nested dicts) are merged key-by-key rather than replaced
+    wholesale, so a project config that sets ``[optimiser] O109 = false``
+    still inherits ``[optimiser] profile = readability`` from global config.
+
+    Call order is lowest-priority first, highest-priority last, e.g.
+    ``merge_settings_layers(global_, editor, project)``.
+    """
+    result: dict = {}
+    for layer in layers:
+        if not isinstance(layer, dict):
+            continue
+        for key, value in layer.items():
+            if isinstance(value, dict) and isinstance(result.get(key), dict):
+                merged_section: dict = dict(result[key])
+                merged_section.update(value)
+                result[key] = merged_section
+            else:
+                result[key] = value
+    return result
 
 
 def get_generic_variable_patterns(

--- a/docs/design/contracts/xdg-config.md
+++ b/docs/design/contracts/xdg-config.md
@@ -65,12 +65,16 @@ The full chain, from lowest priority to highest:
    disabling a code always wins over whatever the editor sends.
 
 Two further layers, applied after server-level filtering and only to
-the document they appear in, override all four above:
+the document they appear in, override all four above.  Both layers only
+*add* suppressions — neither can re-enable a code suppressed by the
+other.  Inline is more specific (one command); file-level is broader
+(the whole file):
 
-5. **File-level** — a top-of-file ``# tcl-lsp: disable=CODE,CODE``
+5. **Inline** — a ``# noqa`` or ``# noqa: CODE`` comment on the line
+   before a command suppresses codes for that command only (highest
+   priority, most specific).
+6. **File-level** — a top-of-file ``# tcl-lsp: disable=CODE,CODE``
    comment suppresses the listed codes for the whole file.
-6. **Inline** — a ``# noqa`` or ``# noqa: CODE`` comment on the line
-   before a command suppresses codes for that command only.
 
 See [`../../kcs/kcs-howto-suppress-diagnostics.md`](../../kcs/kcs-howto-suppress-diagnostics.md)
 for the user-facing walkthrough of each scope.

--- a/docs/design/contracts/xdg-config.md
+++ b/docs/design/contracts/xdg-config.md
@@ -64,17 +64,20 @@ The full chain, from lowest priority to highest:
    most specific server-level source, so a project config enabling or
    disabling a code always wins over whatever the editor sends.
 
-Two further layers, applied after server-level filtering and only to
-the document they appear in, override all four above.  Both layers only
-*add* suppressions — neither can re-enable a code suppressed by the
-other.  Inline is more specific (one command); file-level is broader
+Two further document-local suppression scopes are applied after
+server-level filtering and only to the document they appear in.  Both
+scopes only *add* suppressions — neither can re-enable a code
+suppressed by the other.  They are not ordered relative to each other;
+inline is more specific (one command), while file-level is broader
 (the whole file):
 
-5. **Inline** — a ``# noqa`` or ``# noqa: CODE`` comment on the line
-   before a command suppresses codes for that command only (highest
-   priority, most specific).
-6. **File-level** — a top-of-file ``# tcl-lsp: disable=CODE,CODE``
-   comment suppresses the listed codes for the whole file.
+- **Inline** — a ``# noqa`` or ``# noqa: CODE`` comment on the line
+  before a command suppresses codes for that command only (most
+  specific scope).
+- **File-level** — a top-of-file ``# tcl-lsp: disable=CODE,CODE``
+  comment suppresses the listed codes for the whole file.
+
+Both scopes override all four server-level layers (1–4) above.
 
 See [`../../kcs/kcs-howto-suppress-diagnostics.md`](../../kcs/kcs-howto-suppress-diagnostics.md)
 for the user-facing walkthrough of each scope.

--- a/docs/design/contracts/xdg-config.md
+++ b/docs/design/contracts/xdg-config.md
@@ -2,10 +2,15 @@
 
 ## Summary
 
-tcl-lsp reads user-level settings from an INI-format configuration file.
-The file location follows platform-native conventions so it sits where
-users expect application config to live on each OS.  These settings
-provide baseline defaults that editor settings override.
+tcl-lsp reads settings from two INI-format configuration files: a
+**global** file per user and an optional **project** file at the
+workspace root.  Both use the same schema.  The global file sits at
+the platform-native config location on each OS; the project file is
+named `.tcl-lsp.ini` and is checked in with the source tree so every
+contributor on the project picks up the same rules.
+
+For the user-facing answer to "how do I silence a specific code?",
+see [`../../kcs/kcs-howto-suppress-diagnostics.md`](../../kcs/kcs-howto-suppress-diagnostics.md).
 
 ## File Location
 
@@ -28,17 +33,47 @@ Setting `$XDG_CONFIG_HOME` always takes precedence on every platform.
 - **Native Windows**: `sys.platform == "win32"` without `MSYSTEM`.  Uses
   `%APPDATA%`.
 
+## Project-level config file
+
+In addition to the global file above, tcl-lsp looks for a
+`.tcl-lsp.ini` in the workspace root when the server initialises.
+The schema is identical to the global file — every section documented
+below works in either place.  The project file is intended to be
+committed to source control so team conventions follow the code.
+
+| Location | Role |
+|----------|------|
+| `<workspace-root>/.tcl-lsp.ini` | Per-project overrides checked in with the source |
+| Global user config (above) | Per-user defaults across all projects |
+
+The server does not walk upward from the workspace root looking for
+ancestor config files.  Each workspace gets exactly one project file,
+directly at its root.
+
 ## Precedence
 
-Settings are applied in layers — later sources override earlier ones:
+Settings are applied in layers — later sources override earlier ones.
+The full chain, from lowest priority to highest:
 
-1. **Built-in defaults** — hardcoded in `FeatureConfig` and `FormatterConfig`
-2. **Config file** — loaded on server initialisation
-3. **Editor settings** — received via `workspace/didChangeConfiguration` or
-   `workspace/configuration`; always win over the config file
+1. **Built-in defaults** — hardcoded in `FeatureConfig` and `FormatterConfig`.
+2. **Global config file** — `~/.config/tcl-lsp/config.ini` (or the
+   platform equivalent).  Loaded once on server initialisation.
+3. **Editor settings** — received via `workspace/didChangeConfiguration`
+   or `workspace/configuration`.  Overwrite the global file layer.
+4. **Project config file** — `<workspace-root>/.tcl-lsp.ini`.  The
+   most specific server-level source, so a project config enabling or
+   disabling a code always wins over whatever the editor sends.
 
-This means you can set sensible defaults in the config file and then
-fine-tune per-project in your editor.
+Two further layers, applied after server-level filtering and only to
+the document they appear in, override all four above:
+
+5. **File-level** — a top-of-file ``# tcl-lsp: disable=CODE,CODE``
+   comment suppresses the listed codes for the whole file.
+6. **Inline** — a ``# noqa`` or ``# noqa: CODE`` comment on the line
+   before a command suppresses codes for that command only.
+
+See [`../../kcs/kcs-howto-suppress-diagnostics.md`](../../kcs/kcs-howto-suppress-diagnostics.md)
+for the user-facing walkthrough of each scope.
 
 ### Interaction with editor settings
 
@@ -165,8 +200,18 @@ line_length = 100
 
 ## Implementation
 
-- Config loading: `core/common/user_config.py`
+- Global + project config loading: `core/common/user_config.py`
+  (`load_user_config`, `load_project_config`, `merge_settings_layers`)
 - Platform detection: `_config_dir()` and `_is_posix_compat_windows()`
-- Server integration: `lsp/server.py` → `on_initialized()`
+- Layer storage: `lsp/state.py`
+  (`global_config_settings`, `editor_config_settings`, `project_config_settings`)
+- Layer merge + apply: `lsp/settings.py` (`_merged_settings`,
+  `_apply_merged_settings_now`)
+- Server integration: `lsp/workspace_init.py` → `on_initialized()`
+  loads global and project layers before any analysis runs
+- File-level directive parser: `core/analysis/_analyser/_utils.py`
+  (`parse_file_suppression`)
+- Per-document suppression filter: `lsp/features/diagnostics.py`
+  (`_is_suppressed`)
 - Export command: `lsp/server.py` → `_export_config()`
 - CLI config: `explorer/tcl_cli.py` → `_config_file_paths()`

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -70,6 +70,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-how-to-run-tcltest-bundles.md](kcs-how-to-run-tcltest-bundles.md)
   — run the Tcl 9 tcltest test files through the WASM runtime and
   interpret the triage roll-up.
+- [kcs-howto-suppress-diagnostics.md](kcs-howto-suppress-diagnostics.md)
+  — turn a diagnostic, warning, optimisation, or shimmer off inline,
+  file-wide, per-project, per-editor, or globally.
 
 ## Tcl 9 correctness
 

--- a/docs/kcs/kcs-howto-suppress-diagnostics.md
+++ b/docs/kcs/kcs-howto-suppress-diagnostics.md
@@ -127,14 +127,16 @@ a code overrules an editor or global config that disables it.
 ### Which codes can I disable?
 
 Every code the server emits has a page under
-[`docs/kcs/codes/`](codes/README.md). The four families are:
+[`docs/kcs/codes/`](codes/README.md). The six families are:
 
-- **Errors, warnings, security, taint, and iRule checks (E, W, S, T,
-  IRULE)** — [diagnostics feature page](features/kcs-feature-diagnostics.md).
+- **Errors (E)** and **warnings (W)** — general diagnostics, including
+  security and style checks; see the
+  [diagnostics feature page](features/kcs-feature-diagnostics.md).
+- **Shimmer (S)** — type-instability warnings.
+- **Taint (T)** — tainted-variable flow checks.
+- **iRule checks (IRULE)** — F5 iRule–specific diagnostics.
 - **Optimisations (O)** — automatic rewrite suggestions; see the
   [optimiser pages](codes/README.md).
-- **Shimmer (S)** — type-instability warnings.
-- **iRule flow (IRULE*)** — F5 iRule specific checks.
 
 Every one of these codes is a valid name in a `# noqa`, a file
 directive, or a config file.

--- a/docs/kcs/kcs-howto-suppress-diagnostics.md
+++ b/docs/kcs/kcs-howto-suppress-diagnostics.md
@@ -1,0 +1,161 @@
+# KCS: How do I turn a diagnostic, optimisation, or shimmer off?
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+all-editors, diagnostic, warning, optimisation
+
+## Question
+
+How do I silence a specific diagnostic, warning, optimisation, or
+shimmer report — on one line, in one file, for one project, for one
+editor, or everywhere?
+
+## Before you start
+
+- Know the code you want to silence (for example `W100`, `O111`,
+  `S101`, `T102`, `IRULE1005`). The full catalogue lives under
+  [`docs/kcs/codes/`](codes/README.md) — one page per code.
+- Decide **where** the silencing should apply. Smaller scope is always
+  better: turning a code off globally hides real problems in future
+  projects.
+
+## Answer
+
+The [Tcl Language Server](../GLOSSARY.md#lsp) gives you five places to
+turn a code off. Pick the **smallest scope** that solves your problem.
+The list below runs from most specific to least specific, which is
+also the precedence order: a match found higher in the list always
+wins.
+
+### 1. One command — inline `# noqa`
+
+Put the directive on the line **before** the command you want to
+silence. Bare `# noqa` silences every code on the next command;
+`# noqa: CODE1,CODE2` silences only the listed codes; `# noqa: *`
+is the explicit wildcard form.
+
+```tcl
+# noqa: W100
+expr $x + 1
+```
+
+Use this when exactly one command needs the exception and the reason
+is local — for example, a deliberate `eval` that the analyser cannot
+prove safe.
+
+### 2. One file — top-of-file `# tcl-lsp: disable=`
+
+Put the directive at the top of the file, before any command. Blank
+lines, shebangs, and copyright comments are allowed above it; the
+scanner stops at the first real command.
+
+```tcl
+#!/usr/bin/env tclsh
+# Copyright 2026 Example Corp.
+# tcl-lsp: disable=W100,O111
+
+package require Tcl 8.6
+expr $x + 1
+```
+
+Use this for generated files, test fixtures, or legacy code where a
+whole-file exception is clearer than annotating every line.
+
+### 3. One project — `.tcl-lsp.ini` at the workspace root
+
+Create a file named `.tcl-lsp.ini` next to the top-level folder of
+your project and commit it with the source. The format matches the
+[global config file](../design/contracts/xdg-config.md):
+
+```ini
+[diagnostics]
+disabled = W111, IRULE1005
+
+[optimiser]
+disabled = O109
+
+[shimmer]
+enabled = false
+```
+
+Use this for team-wide conventions — every developer who opens the
+project picks the same rules up automatically, and the rules survive
+switching editors.
+
+### 4. One editor — `settings.json` or equivalent
+
+Each editor ships its own way to send settings to the server. See the
+[configuration reference](../design/contracts/xdg-config.md#interaction-with-editor-settings)
+for the exact key path for VS Code, Neovim, Zed, Helix, Emacs, Sublime
+Text, and JetBrains.
+
+Use this for personal preference on a single machine — for example,
+disabling a hint style you find distracting while pairing with a team
+project that does not take a stance on it.
+
+### 5. Everywhere — global config file
+
+Create or edit the [platform-native global config file](../design/contracts/xdg-config.md#file-location):
+
+```ini
+[diagnostics]
+disabled = W111
+```
+
+Use this sparingly — rules turned off here follow you into every
+project you open.
+
+### Precedence, from highest priority to lowest
+
+When two layers disagree, the more specific layer wins. From highest
+to lowest:
+
+1. Inline `# noqa` on the command.
+2. Top-of-file `# tcl-lsp: disable=`.
+3. Project `.tcl-lsp.ini` at the workspace root.
+4. Editor settings (for example VS Code `tclLsp.diagnostics.*`).
+5. Global `~/.config/tcl-lsp/config.ini` (or the platform equivalent).
+
+Inline and file-level directives can only **turn codes off** for the
+document they appear in. Project, editor, and global config can both
+turn codes off and turn them back on — a project config that enables
+a code overrules an editor or global config that disables it.
+
+### Which codes can I disable?
+
+Every code the server emits has a page under
+[`docs/kcs/codes/`](codes/README.md). The four families are:
+
+- **Errors, warnings, security, taint, and iRule checks (E, W, S, T,
+  IRULE)** — [diagnostics feature page](features/kcs-feature-diagnostics.md).
+- **Optimisations (O)** — automatic rewrite suggestions; see the
+  [optimiser pages](codes/README.md).
+- **Shimmer (S)** — type-instability warnings.
+- **iRule flow (IRULE*)** — F5 iRule specific checks.
+
+Every one of these codes is a valid name in a `# noqa`, a file
+directive, or a config file.
+
+## How to tell it worked
+
+- For inline and file-level directives: the squiggle or hint
+  disappears as soon as you save. No server restart needed.
+- For project config changes: save the `.tcl-lsp.ini` file and run
+  **Tcl: Restart Language Server** (or the equivalent for your
+  editor) so the server reloads it. New documents opened after the
+  restart pick the rules up automatically.
+- For editor or global config changes: most editors re-send settings
+  to the server within a second; diagnostics refresh automatically.
+  When in doubt, see
+  [kcs-qa-when-to-restart-server.md](kcs-qa-when-to-restart-server.md).
+
+## Related
+
+- [KCS index](README.md)
+- [Per-code catalogue](codes/README.md)
+- [Global config file reference](../design/contracts/xdg-config.md)
+- [Diagnostics feature page](features/kcs-feature-diagnostics.md)
+- [Glossary](../GLOSSARY.md)

--- a/lsp/features/diagnostics.py
+++ b/lsp/features/diagnostics.py
@@ -80,13 +80,24 @@ _IRULES_FLOW_SEVERITY = {
 # Sentinel used by the analyser to mean "suppress all codes on this line".
 _NOQA_ALL = frozenset({"*"})
 
+# Negative key reserved for file-wide ``# tcl-lsp: disable=...`` directives.
+# Mirrors ``core.analysis._analyser._utils._FILE_SUPPRESS_KEY`` — kept in sync
+# here (not imported) so this module stays free of analyser-internal imports.
+_FILE_SUPPRESS_KEY = -1
+
 
 def _is_suppressed(
     code: str,
     line: int,
     suppressed_lines: dict[int, frozenset[str]],
 ) -> bool:
-    """Return True if *code* is suppressed on *line* by an inline ``# noqa`` directive."""
+    """Return True if *code* is suppressed by an inline ``# noqa`` or a
+    top-of-file ``# tcl-lsp: disable=...`` directive."""
+    file_codes = suppressed_lines.get(_FILE_SUPPRESS_KEY)
+    if file_codes is not None and (
+        file_codes is _NOQA_ALL or "*" in file_codes or code in file_codes
+    ):
+        return True
     codes = suppressed_lines.get(line)
     if codes is None:
         return False

--- a/lsp/features/diagnostics.py
+++ b/lsp/features/diagnostics.py
@@ -9,6 +9,8 @@ from lsprotocol import types
 
 from core.analysis import analyse
 from core.analysis.semantic_model import (
+    _FILE_SUPPRESS_KEY,
+    _NOQA_ALL,
     AnalysisResult,
     CodeFix,
     Diagnostic,
@@ -76,14 +78,6 @@ _IRULES_FLOW_SEVERITY = {
     "IRULE5002": types.DiagnosticSeverity.Warning,
     "IRULE5004": types.DiagnosticSeverity.Warning,
 }
-
-# Sentinel used by the analyser to mean "suppress all codes on this line".
-_NOQA_ALL = frozenset({"*"})
-
-# Negative key reserved for file-wide ``# tcl-lsp: disable=...`` directives.
-# Mirrors ``core.analysis._analyser._utils._FILE_SUPPRESS_KEY`` — kept in sync
-# here (not imported) so this module stays free of analyser-internal imports.
-_FILE_SUPPRESS_KEY = -1
 
 
 def _is_suppressed(

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -20,6 +20,7 @@ from core.common.optimisation_profiles import (
     profile_from_name,
     profile_to_disabled,
 )
+from core.common.user_config import merge_settings_layers
 from core.formatting import FormatterConfig
 
 if TYPE_CHECKING:
@@ -349,42 +350,73 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
 
 # Settings debounce
 
-_pending_settings: dict | None = None
-_pending_settings_handle: asyncio.TimerHandle | None = None
+_pending_apply_handle: asyncio.TimerHandle | None = None
 _SETTINGS_DEBOUNCE_S = 0.3
 
 
-def _apply_all_settings(tcl_settings: dict) -> None:
-    """Debounced settings application — leading-edge with trailing coalesce."""
-    global _pending_settings, _pending_settings_handle
+def _merged_settings() -> dict:
+    """Merge all configuration layers in precedence order.
 
-    first_in_burst = _pending_settings_handle is None
-    _pending_settings = tcl_settings
-    if _pending_settings_handle is not None:
-        _pending_settings_handle.cancel()
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        _apply_all_settings_now()
-        return
-    if first_in_burst:
-        _apply_all_settings_now()
-    _pending_settings_handle = loop.call_later(
-        _SETTINGS_DEBOUNCE_S,
-        _apply_all_settings_now,
+    Lowest to highest priority:
+      1. Global user config (``~/.config/tcl-lsp/config.ini``)
+      2. Editor settings (``workspace/didChangeConfiguration`` payload)
+      3. Project config (``<workspace>/.tcl-lsp.ini``)
+
+    Inline ``# noqa`` and top-of-file ``# tcl-lsp: disable=`` directives are
+    applied later, in the per-document diagnostics pipeline — they do not
+    feed into server-level ``feature_config``.
+    """
+    return merge_settings_layers(
+        _state.global_config_settings,
+        _state.editor_config_settings,
+        _state.project_config_settings,
     )
 
 
-def _apply_all_settings_now() -> None:
-    """Apply the most recent settings (called after debounce timer)."""
-    global _pending_settings, _pending_settings_handle
-    settings = _pending_settings
-    _pending_settings = None
-    _pending_settings_handle = None
-    if settings is None:
-        return
+def _apply_all_settings(tcl_settings: dict) -> None:
+    """Update the editor config layer and apply the merged settings (debounced)."""
+    _state.editor_config_settings = tcl_settings
+    _schedule_apply_merged()
 
-    tcl_settings = settings
+
+def apply_project_settings(tcl_settings: dict) -> None:
+    """Update the project-config layer and apply the merged settings."""
+    _state.project_config_settings = tcl_settings
+    _schedule_apply_merged()
+
+
+def apply_global_settings(tcl_settings: dict) -> None:
+    """Update the global user-config layer and apply the merged settings."""
+    _state.global_config_settings = tcl_settings
+    _schedule_apply_merged()
+
+
+def _schedule_apply_merged() -> None:
+    """Debounced merged-settings application — leading-edge with trailing coalesce."""
+    global _pending_apply_handle
+
+    first_in_burst = _pending_apply_handle is None
+    if _pending_apply_handle is not None:
+        _pending_apply_handle.cancel()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        _apply_merged_settings_now()
+        return
+    if first_in_burst:
+        _apply_merged_settings_now()
+    _pending_apply_handle = loop.call_later(
+        _SETTINGS_DEBOUNCE_S,
+        _apply_merged_settings_now,
+    )
+
+
+def _apply_merged_settings_now() -> None:
+    """Apply the merged configuration layers (called after debounce timer)."""
+    global _pending_apply_handle
+    _pending_apply_handle = None
+
+    tcl_settings = _merged_settings()
 
     formatting = tcl_settings.get("formatting")
     if isinstance(formatting, dict) and formatting:

--- a/lsp/state.py
+++ b/lsp/state.py
@@ -34,6 +34,18 @@ formatter_config = FormatterConfig()
 feature_config = FeatureConfig()
 diagnostic_scheduler = DiagnosticScheduler()
 
+# Configuration layers, merged on each apply in the order:
+#   global_config_settings  ← ``~/.config/tcl-lsp/config.ini`` (lowest priority)
+#   editor_config_settings  ← ``workspace/didChangeConfiguration`` payload
+#   project_config_settings ← ``<workspace>/.tcl-lsp.ini`` (highest priority)
+#
+# See ``docs/kcs/kcs-howto-suppress-diagnostics.md`` for the full precedence
+# chain including inline ``# <noqa>`` and file-level ``# tcl-lsp: disable=``
+# directives that override all server-level configuration.
+global_config_settings: dict = {}
+editor_config_settings: dict = {}
+project_config_settings: dict = {}
+
 _process_pool: ProcessPoolExecutor | None = None
 
 

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -14,7 +14,11 @@ from pygls.lsp.server import LanguageServer
 
 import lsp.state as _state
 from core.commands.registry.runtime import configure_signatures
-from core.common.user_config import get_all_settings, load_user_config
+from core.common.user_config import (
+    get_all_settings,
+    load_project_config,
+    load_user_config,
+)
 from core.formatting import FormatterConfig
 
 from .workspace.scanner import path_to_uri
@@ -244,20 +248,32 @@ def on_initialized(params: types.InitializedParams) -> None:
     """After client initialization, scan workspace for Tcl files."""
     from core.common.dialect import active_dialect
     from lsp.settings import (
-        _apply_feature_settings,
+        _apply_merged_settings_now,
         _normalise_formatter_settings,
         _pull_and_apply_configuration,
     )
 
-    user_config = load_user_config()
-    config_settings = get_all_settings(user_config)
-    if config_settings:
-        formatting = config_settings.get("formatting")
-        if isinstance(formatting, dict) and formatting:
-            _state.formatter_config = FormatterConfig.from_dict(
-                _normalise_formatter_settings(formatting)
-            )
-        _apply_feature_settings(config_settings)
+    _state.global_config_settings = get_all_settings(load_user_config())
+    # Formatter config is rebuilt fresh from global here rather than via the
+    # layered apply because the layered path only *updates* a dict — a baseline
+    # FormatterConfig instance needs to exist first.
+    formatting = _state.global_config_settings.get("formatting")
+    if isinstance(formatting, dict) and formatting:
+        _state.formatter_config = FormatterConfig.from_dict(
+            _normalise_formatter_settings(formatting)
+        )
+
+    # Discover the project-level config file under each workspace root.
+    ws = _server.workspace  # type: ignore[union-attr]
+    project_settings: dict = {}
+    if ws.root_path:
+        project_settings = get_all_settings(load_project_config(ws.root_path))
+    _state.project_config_settings = project_settings
+
+    # Editor settings arrive later via ``workspace/didChangeConfiguration``;
+    # apply the current (global + project) layers now so server state is
+    # populated before the first analysis pass.
+    _apply_merged_settings_now()
 
     process_start = getattr(_server, "_process_start_time", None)
     if process_start is not None:

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -263,7 +263,7 @@ def on_initialized(params: types.InitializedParams) -> None:
             _normalise_formatter_settings(formatting)
         )
 
-    # Discover the project-level config file under each workspace root.
+    # Discover the project-level config file at the workspace root.
     ws = _server.workspace  # type: ignore[union-attr]
     project_settings: dict = {}
     if ws.root_path:

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -26,7 +26,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from core.analysis import analyse
+from core.analysis import Analyser, analyse
 from core.analysis._analyser._utils import (
     _FILE_DIRECTIVE_SCAN_LINES,
     _FILE_SUPPRESS_KEY,
@@ -39,6 +39,7 @@ from core.common.user_config import (
     load_project_config,
     merge_settings_layers,
 )
+from core.parsing.command_segmenter import segment_commands
 from lsp.features.diagnostics import _is_suppressed, get_basic_diagnostics, get_deep_diagnostics
 
 
@@ -187,6 +188,20 @@ class TestFileLevelSuppression:
         _basic, _result, suppressed = get_basic_diagnostics(source)
         deep = get_deep_diagnostics(source, suppressed)
         assert _codes(deep) == []
+
+    def test_analyse_chunked_populates_sentinel_key(self):
+        # The LSP uses analyse_chunked; file directives must be respected there.
+        source = "# tcl-lsp: disable=W100\nexpr $x + 1\n"
+        commands = segment_commands(source)
+        result, _ = Analyser().analyse_chunked(source, [list(commands)])
+        assert result.suppressed_lines.get(_FILE_SUPPRESS_KEY) == frozenset({"W100"})
+
+    def test_analyse_commands_populates_sentinel_key(self):
+        # The incremental path (analyse_commands) must also parse file directives.
+        source = "# tcl-lsp: disable=W100\nexpr $x + 1\n"
+        commands = segment_commands(source)
+        result = Analyser().analyse_commands(source, list(commands))
+        assert result.suppressed_lines.get(_FILE_SUPPRESS_KEY) == frozenset({"W100"})
 
 
 # Layer 3 (unit): project config file discovery + parsing.

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -1,0 +1,442 @@
+"""Comprehensive tests for diagnostic suppression at every layer.
+
+The tcl-lsp precedence chain (highest priority first):
+
+    1. Inline       ``# noqa`` / ``# noqa: CODE``
+    2. File-level   ``# tcl-lsp: disable=CODE[,CODE...]`` (top of file)
+    3. Project      ``.tcl-lsp.ini`` at the workspace root
+    4. Editor       ``workspace/didChangeConfiguration`` payload
+    5. Global       ``~/.config/tcl-lsp/config.ini``
+
+Inline and file-level are per-document and applied after per-server
+``disabled_diagnostics`` filtering.  Project, editor, and global all feed
+into the same server-level filter via ``merge_settings_layers``; project
+wins because it is the most project-specific source of truth.
+
+See ``docs/kcs/kcs-howto-suppress-diagnostics.md``.
+"""
+
+from __future__ import annotations
+
+import configparser
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.analysis import analyse
+from core.analysis._analyser._utils import (
+    _FILE_DIRECTIVE_SCAN_LINES,
+    _FILE_SUPPRESS_KEY,
+    parse_file_suppression,
+)
+from core.common.user_config import (
+    PROJECT_CONFIG_FILENAME,
+    find_project_config,
+    get_all_settings,
+    load_project_config,
+    merge_settings_layers,
+)
+from lsp.features.diagnostics import _is_suppressed, get_basic_diagnostics, get_deep_diagnostics
+
+
+def _codes(diags) -> list[str]:
+    """Return the ``code`` attribute (str) of each diagnostic."""
+    return [str(d.code) for d in diags if d.code is not None]
+
+
+def _config_from_string(text: str) -> configparser.ConfigParser:
+    config = configparser.ConfigParser()
+    config.optionxform = str  # type: ignore[assignment, invalid-assignment]
+    config.read_string(text)
+    return config
+
+
+# Layer 1: inline ``# <noqa>`` — the existing mechanism.  We re-verify it
+# end-to-end here so the precedence tests below can cite it as a baseline.
+
+
+class TestInlineSuppression:
+    """``# <noqa>`` applies to the command on the following line only."""
+
+    def test_bare_noqa_suppresses_all_codes_on_next_command(self):
+        source = "# noqa\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W100" not in _codes(diags)
+
+    def test_noqa_with_codes_is_selective(self):
+        # ``expr $x + 1`` fires W100 (unbraced expr) and W210 ($x read before set).
+        # Targeting only W210 leaves W100 untouched.
+        source = "# noqa: W210\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W210" not in _codes(diags)
+        assert "W100" in _codes(diags)
+
+    def test_noqa_wildcard_equivalent_to_bare(self):
+        source = "# noqa: *\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        codes = _codes(diags)
+        assert "W100" not in codes
+        assert "W210" not in codes
+
+    def test_noqa_does_not_leak_to_next_command(self):
+        source = "# noqa: W100\nset a 1\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W100" in _codes(diags)
+
+
+# Layer 2: top-of-file ``# tcl-lsp: disable=...`` directive.
+
+
+class TestParseFileSuppression:
+    """Unit tests for the top-of-file directive parser."""
+
+    def test_empty_source_returns_empty_set(self):
+        assert parse_file_suppression("") == frozenset()
+
+    def test_no_directive_returns_empty_set(self):
+        assert parse_file_suppression("set x 1\nset y 2\n") == frozenset()
+
+    def test_single_code(self):
+        assert parse_file_suppression("# tcl-lsp: disable=W100\n") == frozenset({"W100"})
+
+    def test_multiple_codes_comma_separated(self):
+        got = parse_file_suppression("# tcl-lsp: disable=W100,W200,O109\n")
+        assert got == frozenset({"W100", "W200", "O109"})
+
+    def test_multiple_codes_with_whitespace(self):
+        got = parse_file_suppression("# tcl-lsp: disable = W100 , W200 ,  O109\n")
+        assert got == frozenset({"W100", "W200", "O109"})
+
+    def test_wildcard(self):
+        assert parse_file_suppression("# tcl-lsp: disable=*\n") == frozenset({"*"})
+
+    def test_case_insensitive(self):
+        assert parse_file_suppression("# TCL-LSP: DISABLE=W100\n") == frozenset({"W100"})
+
+    def test_allowed_before_shebang_and_copyright(self):
+        src = (
+            "#!/usr/bin/env tclsh\n"
+            "# Copyright notice.\n"
+            "# tcl-lsp: disable=W100\n"
+            "set x 1\n"
+        )
+        assert parse_file_suppression(src) == frozenset({"W100"})
+
+    def test_allowed_after_blank_lines(self):
+        src = "\n\n# tcl-lsp: disable=W100\n\nset x 1\n"
+        assert parse_file_suppression(src) == frozenset({"W100"})
+
+    def test_stops_at_first_non_comment_line(self):
+        src = "set y 2\n# tcl-lsp: disable=W100\n"
+        assert parse_file_suppression(src) == frozenset()
+
+    def test_multiple_directives_accumulate(self):
+        src = "# tcl-lsp: disable=W100\n# tcl-lsp: disable=O109\n"
+        assert parse_file_suppression(src) == frozenset({"W100", "O109"})
+
+    def test_scan_capped_at_line_limit(self):
+        # Deep below the scan window — the directive must not be found.
+        src = "\n" * (_FILE_DIRECTIVE_SCAN_LINES + 5) + "# tcl-lsp: disable=W100\n"
+        assert parse_file_suppression(src) == frozenset()
+
+
+class TestFileLevelSuppression:
+    """End-to-end: ``# tcl-lsp: disable=...`` suppresses across the file."""
+
+    def test_directive_populates_sentinel_key(self):
+        result = analyse("# tcl-lsp: disable=W100\nexpr $x + 1\n")
+        assert result.suppressed_lines.get(_FILE_SUPPRESS_KEY) == frozenset({"W100"})
+
+    def test_no_directive_leaves_sentinel_absent(self):
+        result = analyse("expr $x + 1\n")
+        assert _FILE_SUPPRESS_KEY not in result.suppressed_lines
+
+    def test_is_suppressed_honours_sentinel(self):
+        suppressed = {_FILE_SUPPRESS_KEY: frozenset({"W100"})}
+        assert _is_suppressed("W100", 0, suppressed)
+        assert _is_suppressed("W100", 42, suppressed)
+        assert not _is_suppressed("W200", 0, suppressed)
+
+    def test_wildcard_suppresses_everything(self):
+        suppressed = {_FILE_SUPPRESS_KEY: frozenset({"*"})}
+        assert _is_suppressed("W100", 0, suppressed)
+        assert _is_suppressed("IRULE1005", 999, suppressed)
+
+    def test_file_suppression_through_basic_pipeline(self):
+        source = "# tcl-lsp: disable=W100\nexpr $x + 1\nexpr $y + 2\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W100" not in _codes(diags)
+
+    def test_file_suppression_selective_leaves_other_codes(self):
+        # Disabling only W210 still leaves W100 emitted.
+        source = "# tcl-lsp: disable=W210\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        codes = _codes(diags)
+        assert "W210" not in codes
+        assert "W100" in codes
+
+    def test_file_wildcard_suppresses_multiple_lines(self):
+        source = "# tcl-lsp: disable=*\nexpr $x + 1\nexpr $y + 2\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        codes = _codes(diags)
+        assert "W100" not in codes
+        assert "W210" not in codes
+
+    def test_file_suppression_applies_to_deep_pass(self):
+        # Deep passes consume the same ``suppressed`` dict, so file-level
+        # suppression must transparently cover optimiser/shimmer/taint codes.
+        source = "# tcl-lsp: disable=*\nexpr $x + 1\n"
+        _basic, _result, suppressed = get_basic_diagnostics(source)
+        deep = get_deep_diagnostics(source, suppressed)
+        assert _codes(deep) == []
+
+
+# Layer 3 (unit): project config file discovery + parsing.
+
+
+class TestProjectConfigFile:
+    """Project config file is ``.tcl-lsp.ini`` at the workspace root."""
+
+    def test_filename_constant(self):
+        assert PROJECT_CONFIG_FILENAME == ".tcl-lsp.ini"
+
+    def test_find_returns_none_when_absent(self, tmp_path: Path):
+        assert find_project_config(tmp_path) is None
+
+    def test_find_returns_path_when_present(self, tmp_path: Path):
+        (tmp_path / PROJECT_CONFIG_FILENAME).write_text("[diagnostics]\ndisabled = W100\n")
+        found = find_project_config(tmp_path)
+        assert found is not None
+        assert found.name == PROJECT_CONFIG_FILENAME
+
+    def test_find_does_not_walk_upward(self, tmp_path: Path):
+        (tmp_path / PROJECT_CONFIG_FILENAME).write_text("[diagnostics]\ndisabled = W100\n")
+        nested = tmp_path / "src"
+        nested.mkdir()
+        # ``find_project_config`` is deliberately local; callers pass the
+        # canonical workspace root rather than relying on upward walking.
+        assert find_project_config(nested) is None
+
+    def test_load_empty_when_missing(self, tmp_path: Path):
+        config = load_project_config(tmp_path)
+        assert isinstance(config, configparser.ConfigParser)
+        assert config.sections() == []
+
+    def test_load_parses_diagnostics_section(self, tmp_path: Path):
+        (tmp_path / PROJECT_CONFIG_FILENAME).write_text(
+            "[diagnostics]\ndisabled = W100, O109\n"
+        )
+        config = load_project_config(tmp_path)
+        settings = get_all_settings(config)
+        assert settings["diagnostics"]["W100"] is False
+        assert settings["diagnostics"]["O109"] is False
+
+    def test_malformed_file_is_ignored(self, tmp_path: Path):
+        (tmp_path / PROJECT_CONFIG_FILENAME).write_text("not valid INI [[[[\n")
+        config = load_project_config(tmp_path)
+        # Should not raise; returns an empty-ish ConfigParser.
+        assert config.sections() == []
+
+
+# Layer-merge precedence: project > editor > global.
+
+
+class TestMergeSettingsLayers:
+    """Unit tests for ``merge_settings_layers`` — the precedence engine."""
+
+    def test_empty_inputs(self):
+        assert merge_settings_layers() == {}
+        assert merge_settings_layers({}, {}, {}) == {}
+
+    def test_single_layer_passthrough(self):
+        layer = {"diagnostics": {"W100": False}}
+        assert merge_settings_layers(layer) == layer
+
+    def test_second_layer_overrides_first(self):
+        a = {"diagnostics": {"W100": False}}
+        b = {"diagnostics": {"W100": True}}
+        assert merge_settings_layers(a, b) == {"diagnostics": {"W100": True}}
+
+    def test_later_layer_wins_per_key_not_section(self):
+        # The two layers touch different codes; the merge must keep both.
+        a = {"diagnostics": {"W100": False}}
+        b = {"diagnostics": {"W200": False}}
+        merged = merge_settings_layers(a, b)
+        assert merged == {"diagnostics": {"W100": False, "W200": False}}
+
+    def test_project_overrides_editor_overrides_global(self):
+        global_ = {"diagnostics": {"W100": False, "W200": False}}
+        editor = {"diagnostics": {"W100": True}}  # tries to re-enable
+        project = {"diagnostics": {"W100": False}}  # enforces off again
+        merged = merge_settings_layers(global_, editor, project)
+        assert merged["diagnostics"]["W100"] is False  # project wins
+        assert merged["diagnostics"]["W200"] is False  # inherited from global
+
+    def test_editor_wins_over_global_when_no_project(self):
+        global_ = {"diagnostics": {"W100": False}}
+        editor = {"diagnostics": {"W100": True}}
+        merged = merge_settings_layers(global_, editor, {})
+        assert merged["diagnostics"]["W100"] is True
+
+    def test_non_dict_section_is_replaced_wholesale(self):
+        # Sanity: a scalar or list value replaces whatever was there before.
+        a = {"dialect": "tcl8.6"}
+        b = {"dialect": "tcl9.0"}
+        assert merge_settings_layers(a, b)["dialect"] == "tcl9.0"
+
+    def test_ignores_non_dict_layers(self):
+        # Robustness: passing ``None`` or a non-dict layer should not crash.
+        merged = merge_settings_layers({"diagnostics": {"W100": False}}, None)  # type: ignore[arg-type]
+        assert merged == {"diagnostics": {"W100": False}}
+
+
+# Layer interactions: each pair of layers, walking the precedence chain.
+
+
+class TestPrecedenceInteractions:
+    """Smoke tests that walk the precedence chain one pair at a time."""
+
+    # 1. Inline overrides file-level by union: both disable the code, so the
+    #    diagnostic is suppressed even if only one directive is present.
+
+    def test_inline_suppresses_even_without_file_directive(self):
+        # Inline ``# <noqa>`` goes on the line *before* the command it suppresses.
+        source = "# noqa: W100\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W100" not in _codes(diags)
+
+    def test_file_suppresses_even_without_inline(self):
+        source = "# tcl-lsp: disable=W100\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W100" not in _codes(diags)
+
+    def test_inline_and_file_coexist(self):
+        # Both directives target W100 — no crash, still suppressed.
+        source = "# tcl-lsp: disable=W100\n# noqa: W100\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W100" not in _codes(diags)
+
+    # 2. File-level vs project-level: file suppresses regardless of project
+    #    config, because file is checked after server-level filtering.
+
+    def test_file_suppresses_even_when_project_enables(self):
+        # Simulate: project config has W100 enabled; file still disables it.
+        # File-level suppression happens in the per-doc pipeline, not via the
+        # server-level ``disabled_diagnostics`` set, so it always wins.
+        source = "# tcl-lsp: disable=W100\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(
+            source,
+            disabled_diagnostics=set(),  # project has nothing disabled
+        )
+        assert "W100" not in _codes(diags)
+
+    def test_project_disables_without_file_directive(self):
+        # Simulate: project config disables W100 via ``disabled_diagnostics``.
+        source = "expr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(
+            source,
+            disabled_diagnostics={"W100"},
+        )
+        assert "W100" not in _codes(diags)
+
+    # 3. Project vs editor: project wins.  Exercised via merge_settings_layers
+    #    above; here we just verify the same behavior at the settings level.
+
+    def test_project_wins_over_editor_in_merge(self):
+        global_ = {}
+        editor = {"diagnostics": {"W100": True}}
+        project = {"diagnostics": {"W100": False}}
+        assert merge_settings_layers(global_, editor, project)["diagnostics"]["W100"] is False
+
+    def test_editor_can_disable_when_project_silent(self):
+        global_ = {}
+        editor = {"diagnostics": {"W100": False}}
+        project = {}
+        assert merge_settings_layers(global_, editor, project)["diagnostics"]["W100"] is False
+
+    # 4. Editor vs global: editor wins.
+
+    def test_editor_wins_over_global_in_merge(self):
+        global_ = {"diagnostics": {"W100": False}}
+        editor = {"diagnostics": {"W100": True}}
+        project = {}
+        assert merge_settings_layers(global_, editor, project)["diagnostics"]["W100"] is True
+
+    def test_global_default_when_no_overrides(self):
+        global_ = {"diagnostics": {"W100": False}}
+        merged = merge_settings_layers(global_, {}, {})
+        assert merged["diagnostics"]["W100"] is False
+
+    # 5. Full chain: project > editor > global, and inline/file always
+    #    suppresses regardless of what the server-level layers say.
+
+    def test_full_chain_project_trumps_everything_below_it(self):
+        global_ = {"diagnostics": {"W100": True, "W200": True}}
+        editor = {"diagnostics": {"W100": True}}
+        project = {"diagnostics": {"W100": False, "W200": False}}
+        merged = merge_settings_layers(global_, editor, project)
+        assert merged["diagnostics"]["W100"] is False
+        assert merged["diagnostics"]["W200"] is False
+
+    def test_inline_overrides_an_enabled_code_from_project(self):
+        # Even if every server layer has W100 enabled, inline wins locally.
+        source = "# noqa: W100\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(
+            source,
+            disabled_diagnostics=set(),  # project+editor+global all enable W100
+        )
+        assert "W100" not in _codes(diags)
+
+
+# Deep-pass coverage: each suppression layer must reach the expensive passes
+# (optimiser, shimmer, taint, etc.) that run after basic diagnostics.
+
+
+class TestDeepPassRespectsSuppression:
+    """Deep diagnostics consume the same ``suppressed`` dict."""
+
+    def test_inline_suppresses_deep_pass(self):
+        source = "set x 1  ;# noqa: *\n"
+        suppressed = {0: frozenset({"*"})}
+        deep = get_deep_diagnostics(source, suppressed)
+        assert deep == []
+
+    def test_file_level_suppresses_deep_pass(self):
+        source = "# tcl-lsp: disable=*\nset x 1\nset y 2\n"
+        _basic, _result, suppressed = get_basic_diagnostics(source)
+        deep = get_deep_diagnostics(source, suppressed)
+        assert deep == []
+
+    def test_disabled_diagnostics_filter_propagates(self):
+        # Project/editor/global all funnel into this set for the deep pass.
+        source = "expr $x + 1\n"
+        _basic, _result, suppressed = get_basic_diagnostics(source)
+        deep = get_deep_diagnostics(
+            source,
+            suppressed,
+            disabled_diagnostics={"W100"},
+            disabled_optimisations={"O111"},
+        )
+        # Nothing we can reliably assert about *other* codes fired, just that
+        # the two we disabled don't show up.
+        codes = set(_codes(deep))
+        assert "W100" not in codes
+        assert "O111" not in codes
+
+
+@pytest.mark.parametrize(
+    "directive,expected_codes",
+    [
+        ("# tcl-lsp: disable=W100", {"W100"}),
+        ("# tcl-lsp: disable = W100, W200", {"W100", "W200"}),
+        ("# tcl-lsp: disable=*", {"*"}),
+        ("#  tcl-lsp:disable=W100", {"W100"}),
+        ("# tcl-lsp:disable= W100 ", {"W100"}),
+    ],
+)
+def test_file_directive_formats(directive: str, expected_codes: set[str]):
+    """Directive parser tolerates whitespace variants and spacing."""
+    assert parse_file_suppression(directive + "\n") == frozenset(expected_codes)

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -117,12 +117,7 @@ class TestParseFileSuppression:
         assert parse_file_suppression("# TCL-LSP: DISABLE=W100\n") == frozenset({"W100"})
 
     def test_allowed_before_shebang_and_copyright(self):
-        src = (
-            "#!/usr/bin/env tclsh\n"
-            "# Copyright notice.\n"
-            "# tcl-lsp: disable=W100\n"
-            "set x 1\n"
-        )
+        src = "#!/usr/bin/env tclsh\n# Copyright notice.\n# tcl-lsp: disable=W100\nset x 1\n"
         assert parse_file_suppression(src) == frozenset({"W100"})
 
     def test_allowed_after_blank_lines(self):
@@ -226,9 +221,7 @@ class TestProjectConfigFile:
         assert config.sections() == []
 
     def test_load_parses_diagnostics_section(self, tmp_path: Path):
-        (tmp_path / PROJECT_CONFIG_FILENAME).write_text(
-            "[diagnostics]\ndisabled = W100, O109\n"
-        )
+        (tmp_path / PROJECT_CONFIG_FILENAME).write_text("[diagnostics]\ndisabled = W100, O109\n")
         config = load_project_config(tmp_path)
         settings = get_all_settings(config)
         assert settings["diagnostics"]["W100"] is False

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -29,9 +29,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from core.analysis import Analyser, analyse
 from core.analysis._analyser._utils import (
     _FILE_DIRECTIVE_SCAN_LINES,
-    _FILE_SUPPRESS_KEY,
     parse_file_suppression,
 )
+from core.analysis.semantic_model import _FILE_SUPPRESS_KEY
 from core.common.user_config import (
     PROJECT_CONFIG_FILENAME,
     find_project_config,


### PR DESCRIPTION
## Summary

Implements a complete diagnostic suppression system with five precedence layers, from most to least specific:

1. **Inline `# noqa`** — suppresses codes on the following command only
2. **File-level `# tcl-lsp: disable=`** — suppresses codes for the entire file
3. **Project `.tcl-lsp.ini`** — workspace-root config checked in with source
4. **Editor settings** — `workspace/didChangeConfiguration` payload
5. **Global config** — `~/.config/tcl-lsp/config.ini`

### Key Changes

**Core suppression infrastructure:**
- Added `parse_file_suppression()` to extract top-of-file `# tcl-lsp: disable=CODE` directives
- Added `_FILE_SUPPRESS_KEY` sentinel to distinguish file-wide from inline suppression in `AnalysisResult.suppressed_lines`
- Updated `_is_suppressed()` to check both inline and file-level directives

**Project config support:**
- Added `PROJECT_CONFIG_FILENAME = ".tcl-lsp.ini"` constant
- Added `find_project_config()` to locate `.tcl-lsp.ini` at workspace root (no upward walking)
- Added `load_project_config()` to parse project config with graceful error handling
- Added `merge_settings_layers()` to implement precedence: global < editor < project

**Settings layer management:**
- Refactored `lsp/settings.py` to track three independent config layers in `lsp/state.py`
- Renamed `_apply_all_settings()` → `_apply_merged_settings_now()` to clarify it merges all layers
- Added `apply_project_settings()` and `apply_global_settings()` entry points
- Debouncing now applies to the merged result rather than buffering raw settings

**Initialization:**
- Updated `workspace_init.py` to load both global and project configs on server startup
- Project config is discovered once per workspace root

**Documentation:**
- Added comprehensive KCS how-to guide: `docs/kcs/kcs-howto-suppress-diagnostics.md`
- Updated `docs/design/contracts/xdg-config.md` with project config details and full precedence chain
- Updated `docs/kcs/README.md` to link the new how-to guide

## Validation

- [x] Added 442 lines of comprehensive test coverage in `tests/test_suppression_layers.py`:
  - `TestInlineSuppression` — verifies existing `# noqa` mechanism
  - `TestParseFileSuppression` — unit tests for directive parser (whitespace tolerance, scan limits, accumulation)
  - `TestProjectConfigFile` — project config discovery and loading
  - `TestMergeSettingsLayers` — precedence engine (project > editor > global)
  - `TestPrecedenceInteractions` — smoke tests for each pair of layers
  - `TestDeepPassRespectsSuppression` — ensures deep diagnostics respect all suppression layers
  - Parametrized tests for directive format variants

All tests pass locally. The test suite validates the full precedence chain end-to-end and confirms that inline/file-level suppression always wins over server-level config.

## Compiler/KCS checklist

- [x] This change alters diagnostic suppression contracts (adds new suppression mechanisms)
- [x] Added KCS how-to guide: `docs/kcs/kcs-howto-suppress-diagnostics.md`
- [x] Linked from `docs/kcs/README.md`
- [x] Updated design contract doc: `docs/design/contracts/xdg-config.md`

https://claude.ai/code/session_016NVkZ32zpUpZbeYDiLAPd8