### PR TITLE
Sync rust rewrite branch onto main HEAD (post-rebase reset)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,8 +254,15 @@ lint-py: $(UV_STAMP) ## Lint Python code with Ruff (check, format, KCS docs)
 	@echo "==> Checking Python formatting with Ruff"
 	cd $(ROOT) && $(UV) run --extra dev ruff format --check .
 
-typecheck-py: $(UV_STAMP) $(BUILD_INFO) ## Type-check Python code with ty
-	@echo "==> Type-checking Python code with ty"
+typecheck-py: $(UV_STAMP) $(BUILD_INFO) ## Type-check Python code with ty (mirrors CI by hiding tcl_lsp_rust)
+	@echo "==> Type-checking Python code with ty (uninstalling tcl_lsp_rust first to mirror CI)"
+	@# CI's lint job runs ty without `make rust-build`, so the rust
+	@# wheel is absent and any `# ty: ignore[unresolved-import]`
+	@# directives on the wrong line surface as errors. Mirror that
+	@# environment locally by removing the wheel + stamp before ty
+	@# runs; the stamp gets rebuilt by the next `rust-build`.
+	@cd $(ROOT) && $(UV) pip uninstall --quiet tcl_lsp_rust >/dev/null 2>&1 || true
+	@rm -f $(RUST_STAMP)
 	cd $(ROOT) && $(UV) run --extra dev ty check --exclude 'lsp/server.py' --exclude 'lsp/commands.py' lsp core explorer tclpkg tests scripts/tcl_test_client.py
 
 typecheck-py-full: $(UV_STAMP) $(BUILD_INFO) ## Type-check all Python code with ty
@@ -369,13 +376,20 @@ snapshot-wasm-parity: $(UV_STAMP) ## Refresh tests/baselines/wasm_command_parity
 	@echo "==> Snapshotting WASM command parity baseline"
 	cd $(ROOT) && $(UV) run python scripts/check_wasm_command_parity.py --snapshot
 
-# Phase targets for parallel prep-pr execution
-_prep-pr-checks: lint-py typecheck-py lint-ts typecheck-ts check-editor-settings check-wasm-parity
-_prep-pr-tests: test-py test-opt
+# Phase targets for parallel prep-pr execution.
+#
+# typecheck-py uninstalls the rust wheel + clears the rust-build
+# stamp to mirror CI's lint job (which runs ty without ever
+# building the wheel). It must therefore be sequenced *before* the
+# parallel phase that runs tests — otherwise test-py-rust would
+# race with the wheel uninstall. rust-build is invoked between the
+# two phases to reinstall the wheel for the differential tests.
+_prep-pr-checks-noty: lint-py lint-ts typecheck-ts check-editor-settings check-wasm-parity
+_prep-pr-tests: test-py-rust test-opt
 _prep-pr-smoke: smoke-zipapps smoke-vsix
 
-prep-pr: format codegen ## Fast pre-PR gate (format + codegen + lint + typecheck + fast tests, no UI/smoke)
-	@$(MAKE) -j $(NPROC) _prep-pr-checks _prep-pr-tests
+prep-pr: format codegen typecheck-py rust-build ## Fast pre-PR gate (format + codegen + lint + typecheck + fast tests, no UI/smoke)
+	@$(MAKE) -j $(NPROC) _prep-pr-checks-noty _prep-pr-tests
 
 test-slow: ## Slow tests: VS Code extension tests + smoke tests (zipapp + VSIX)
 	@$(MAKE) -j $(NPROC) test-ext _prep-pr-smoke

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -34,12 +34,103 @@ from core.analysis.semantic_model import (
     CommandInvocation,
     NamespaceImport,
     PackageRequire,
+    ParamDef,
     ProcDef,
     SourceTarget,
 )
 from core.common.ranges import range_from_token
+from core.compiler.rust_spans import build_position_resolver
 from core.parsing.command_segmenter import segment_commands
 from core.parsing.tokens import Token, TokenType
+
+
+def _materialise_rust_signatures(source: str, raw: dict) -> AnalysisResult:
+    """Convert the dict returned by ``tcl_lsp_rust.signature_scan_extract``
+    into an :class:`AnalysisResult`.
+
+    Spans on the Rust side are ``(start, end)`` ``u32`` tuples; we
+    resolve them to LSP :class:`Range` values via
+    :func:`core.compiler.rust_spans.build_position_resolver`.
+    """
+    _, range_at = build_position_resolver(source)
+    result = AnalysisResult()
+
+    def _params(params_raw: list[dict]) -> list[ParamDef]:
+        return [
+            ParamDef(
+                name=p["name"],
+                has_default=p["has_default"],
+                default_value=p["default_value"] or "",
+            )
+            for p in params_raw
+        ]
+
+    for qname, p in raw.get("procs", {}).items():
+        name_range = range_at(*p["name_range"])
+        body_range = range_at(*p["body_range"])
+        result.all_procs[qname] = ProcDef(
+            name=p["name"],
+            qualified_name=p["qualified_name"],
+            params=_params(p["params"]),
+            name_range=name_range,
+            body_range=body_range,
+        )
+
+    for qname, c in raw.get("classes", {}).items():
+        result.all_classes[qname] = ClassDef(
+            name=c["name"],
+            qualified_name=c["qualified_name"],
+            name_range=range_at(*c["name_range"]),
+            body_range=range_at(*c["body_range"]),
+        )
+
+    for inv in raw.get("command_invocations", []):
+        result.command_invocations.append(
+            CommandInvocation(name=inv["name"], range=range_at(*inv["range"]))
+        )
+
+    for pr in raw.get("package_requires", []):
+        result.package_requires.append(
+            PackageRequire(
+                name=pr["name"],
+                version=pr["version"],
+                range=range_at(*pr["range"]),
+                conditional=pr["conditional"],
+            )
+        )
+
+    for s in raw.get("source_targets", []):
+        result.source_targets.append(
+            SourceTarget(
+                raw_path=s["raw_path"],
+                range=range_at(*s["range"]),
+                is_literal=s["is_literal"],
+            )
+        )
+
+    for qname, a in raw.get("command_aliases", {}).items():
+        result.command_aliases[qname] = (a["target"], tuple(a["extras"]))
+
+    for imp in raw.get("namespace_imports", []):
+        result.namespace_imports.append(
+            NamespaceImport(
+                ns=imp["ns"],
+                pattern=imp["pattern"],
+                range=range_at(*imp["range"]),
+                conjectured=imp["conjectured"],
+            )
+        )
+
+    for entry in raw.get("auto_path_entries", []):
+        result.auto_path_entries.append(
+            AutoPathEntry(
+                resolved_path=None,
+                raw=entry["raw"],
+                range=range_at(*entry["range"]),
+            )
+        )
+
+    return result
 
 
 @dataclass

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -25,7 +25,6 @@ and retains orders of magnitude less memory per file than ``analyse()``.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass, field
 
 from core.analysis import parse_param_list
@@ -41,7 +40,7 @@ from core.analysis.semantic_model import (
     SourceTarget,
 )
 from core.common.ranges import range_from_token
-from core.compiler.rust_spans import build_position_resolver
+from core.compiler.rust_spans import build_position_resolver, rust_shim_enabled
 from core.parsing.command_segmenter import segment_commands
 from core.parsing.tokens import Token, TokenType
 
@@ -188,7 +187,7 @@ def extract_signatures(source: str) -> AnalysisResult:
     and the Python path runs as a safety net — same fallback shape
     as `core.compiler.optimiser._manager`.
     """
-    if _rust_extract is not None and os.environ.get("TCL_LSP_RUST_SIGNATURE_SCAN"):
+    if _rust_extract is not None and rust_shim_enabled("TCL_LSP_RUST_SIGNATURE_SCAN"):
         try:
             return _materialise_rust_signatures(source, _rust_extract(source))
         except Exception:  # pragma: no cover - safety net

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -48,8 +48,8 @@ from core.parsing.tokens import Token, TokenType
 log = logging.getLogger(__name__)
 
 try:
-    from tcl_lsp_rust import (
-        signature_scan_extract as _rust_extract,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        signature_scan_extract as _rust_extract,
     )
 except ImportError:  # pragma: no cover - rust binding is optional
     _rust_extract = None

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -24,6 +24,8 @@ and retains orders of magnitude less memory per file than ``analyse()``.
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
 
 from core.analysis import parse_param_list
@@ -42,6 +44,15 @@ from core.common.ranges import range_from_token
 from core.compiler.rust_spans import build_position_resolver
 from core.parsing.command_segmenter import segment_commands
 from core.parsing.tokens import Token, TokenType
+
+log = logging.getLogger(__name__)
+
+try:
+    from tcl_lsp_rust import (
+        signature_scan_extract as _rust_extract,  # ty: ignore[unresolved-import]
+    )
+except ImportError:  # pragma: no cover - rust binding is optional
+    _rust_extract = None
 
 
 def _materialise_rust_signatures(source: str, raw: dict) -> AnalysisResult:
@@ -168,7 +179,27 @@ class _ScanCtx:
 
 
 def extract_signatures(source: str) -> AnalysisResult:
-    """Return a minimal AnalysisResult for a background-indexed file."""
+    """Return a minimal AnalysisResult for a background-indexed file.
+
+    Dispatches to the Rust port when ``TCL_LSP_RUST_SIGNATURE_SCAN``
+    is set in the environment **and** the ``tcl_lsp_rust`` binding
+    is importable; otherwise falls back to the Python implementation
+    below. Any exception raised by the Rust path is logged at DEBUG
+    and the Python path runs as a safety net — same fallback shape
+    as `core.compiler.optimiser._manager`.
+    """
+    if _rust_extract is not None and os.environ.get("TCL_LSP_RUST_SIGNATURE_SCAN"):
+        try:
+            return _materialise_rust_signatures(source, _rust_extract(source))
+        except Exception:  # pragma: no cover - safety net
+            log.debug("rust signature_scan failed, falling back to python", exc_info=True)
+    return _extract_signatures_python(source)
+
+
+def _extract_signatures_python(source: str) -> AnalysisResult:
+    """The original Python implementation. Kept as the default
+    behaviour and as a fallback when the Rust path is disabled or
+    fails."""
     ctx = _ScanCtx(result=AnalysisResult())
     _scan(source, body_token=None, ns_prefix="", conditional=False, ctx=ctx)
     _resolve_factory_defs(ctx)

--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -36,7 +36,6 @@ tracked value numbers; read-only/output commands do not.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from typing import TypeAlias
 
@@ -76,6 +75,7 @@ from .ir import (
     IRCall,
 )
 from .irules_flow import _find_when_bodies, _walk_body_commands
+from .rust_spans import rust_shim_enabled
 from .side_effects import EffectRegion, classify_side_effects
 from .ssa import BlockName, SSAFunction, SSAVersion
 from .var_refs import VarReferenceScanner, VarScanOptions
@@ -1356,7 +1356,7 @@ def find_redundant_computations(
         _rust_gvn_redundancies is not None
         and _rust_gvn_partial_redundancies is not None
         and _rust_gvn_loop_invariants is not None
-        and os.environ.get("TCL_LSP_RUST_GVN")
+        and rust_shim_enabled("TCL_LSP_RUST_GVN")
     ):
         try:
             dialect = active_dialect()

--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -43,14 +43,14 @@ from typing import TypeAlias
 from ..analysis.semantic_model import Range
 
 try:
-    from tcl_lsp_rust import (
-        gvn_loop_invariants as _rust_gvn_loop_invariants,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        gvn_loop_invariants as _rust_gvn_loop_invariants,
     )
-    from tcl_lsp_rust import (
-        gvn_partial_redundancies as _rust_gvn_partial_redundancies,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        gvn_partial_redundancies as _rust_gvn_partial_redundancies,
     )
-    from tcl_lsp_rust import (
-        gvn_redundancies as _rust_gvn_redundancies,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        gvn_redundancies as _rust_gvn_redundancies,
     )
 except ImportError:
     _rust_gvn_redundancies = None

--- a/core/compiler/interprocedural.py
+++ b/core/compiler/interprocedural.py
@@ -16,8 +16,8 @@ import re
 from dataclasses import dataclass, field
 
 try:
-    from tcl_lsp_rust import (
-        interprocedural_summaries as _rust_interprocedural_summaries,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        interprocedural_summaries as _rust_interprocedural_summaries,
     )
 except ImportError:
     _rust_interprocedural_summaries = None

--- a/core/compiler/interprocedural.py
+++ b/core/compiler/interprocedural.py
@@ -11,9 +11,10 @@ Conservative summaries are built per lowered proc to describe:
 from __future__ import annotations
 
 import logging
-import os
 import re
 from dataclasses import dataclass, field
+
+from .rust_spans import rust_shim_enabled
 
 try:
     from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
@@ -918,7 +919,7 @@ def analyse_interprocedural_source(source: str) -> InterproceduralAnalysis:
     the ``tcl_lsp_rust`` wheel is importable, delegates to the Rust
     implementation; otherwise uses the Python pipeline.
     """
-    if _rust_interprocedural_summaries is not None and os.environ.get("TCL_LSP_RUST_INTERPROC"):
+    if _rust_interprocedural_summaries is not None and rust_shim_enabled("TCL_LSP_RUST_INTERPROC"):
         try:
             from ..common.dialect import active_dialect
 

--- a/core/compiler/optimiser/_manager.py
+++ b/core/compiler/optimiser/_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 
 from ...common.naming import normalise_var_name as _NORMALISE
@@ -12,6 +11,7 @@ from ..compilation_unit import CompilationUnit, ensure_compilation_unit
 from ..execution_intent import FunctionExecutionIntent
 from ..interprocedural import InterproceduralAnalysis
 from ..ir import IRAssignConst, IRBarrier, IRCall, IRModule, IRScript
+from ..rust_spans import rust_shim_enabled
 
 # Optional Rust delegation (C32). When the `tcl_lsp_rust` wheel is
 # importable AND `TCL_LSP_RUST_OPTIMISER=1` is set in the
@@ -428,7 +428,7 @@ def find_optimisations(
     overlap arbitration may differ from the Python pipeline).
     The Python pipeline is the default.
     """
-    if _rust_find_optimisations is not None and os.environ.get("TCL_LSP_RUST_OPTIMISER"):
+    if _rust_find_optimisations is not None and rust_shim_enabled("TCL_LSP_RUST_OPTIMISER"):
         try:
             from ...common.dialect import active_dialect
 

--- a/core/compiler/optimiser/_manager.py
+++ b/core/compiler/optimiser/_manager.py
@@ -19,8 +19,8 @@ from ..ir import IRAssignConst, IRBarrier, IRCall, IRModule, IRScript
 # manager. Default is off: the Python pipeline still runs so
 # existing tests observe the exact diagnostic shapes they expect.
 try:
-    from tcl_lsp_rust import (
-        optimiser_find_optimisations as _rust_find_optimisations,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        optimiser_find_optimisations as _rust_find_optimisations,
     )
 except ImportError:
     _rust_find_optimisations = None

--- a/core/compiler/rust_spans.py
+++ b/core/compiler/rust_spans.py
@@ -13,9 +13,33 @@ math and the exclusive/inclusive boundary).
 from __future__ import annotations
 
 import bisect
+import os
 
 from ..analysis.semantic_model import Range
 from ..parsing.tokens import SourcePosition
+
+# Truthy values that opt a `TCL_LSP_RUST_*` shim into the Rust path.
+# `os.environ.get(name)` alone treats any non-empty string as truthy
+# (including `"0"` / `"false"`), which contradicts the docstring
+# convention of `=1` and silently opts users into the experimental
+# path when they thought they were turning it off.
+_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on", "y", "t"})
+
+
+def rust_shim_enabled(env_var: str) -> bool:
+    """Return ``True`` when the named ``TCL_LSP_RUST_*`` env var is
+    set to a truthy value.
+
+    Treats `"1"`, `"true"`, `"yes"`, `"on"`, `"y"`, `"t"`
+    (case-insensitive, after stripping whitespace) as truthy. Any
+    other value — including an unset variable, the empty string,
+    `"0"`, `"false"`, `"no"`, `"off"` — counts as off.
+
+    Centralising the check here prevents silent divergence between
+    the four `TCL_LSP_RUST_*` dispatch shims (`OPTIMISER`,
+    `INTERPROC`, `GVN`, `SIGNATURE_SCAN`).
+    """
+    return os.environ.get(env_var, "").strip().lower() in _TRUTHY_VALUES
 
 
 def build_position_resolver(source: str):

--- a/core/parsing/expr_lexer.py
+++ b/core/parsing/expr_lexer.py
@@ -404,8 +404,8 @@ class ExprLexer:
 
 try:
     from tcl_lsp_rust import expr_tokenise as _rust_expr_tokenise  # ty: ignore[unresolved-import]
-    from tcl_lsp_rust import (
-        expr_tokenise_checked as _rust_expr_tokenise_checked,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        expr_tokenise_checked as _rust_expr_tokenise_checked,
     )
 except ImportError:
     _rust_expr_tokenise = None

--- a/core/parsing/lexer.py
+++ b/core/parsing/lexer.py
@@ -8,8 +8,8 @@ import threading
 from .tokens import SourcePosition, Token, TokenType
 
 try:
-    from tcl_lsp_rust import (
-        lexer_tokenise_with_config as _rust_lexer_tokenise_cfg,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        lexer_tokenise_with_config as _rust_lexer_tokenise_cfg,
     )
 except ImportError:
     _rust_lexer_tokenise_cfg = None

--- a/core/parsing/substitution.py
+++ b/core/parsing/substitution.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 from typing import Callable
 
 try:
-    from tcl_lsp_rust import (
-        backslash_subst as _backslash_subst_rust,  # ty: ignore[unresolved-import]
+    from tcl_lsp_rust import (  # ty: ignore[unresolved-import]
+        backslash_subst as _backslash_subst_rust,
     )
 except ImportError:
     _backslash_subst_rust = None

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -50,6 +50,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 
 - [kcs-qa-when-to-restart-server.md](kcs-qa-when-to-restart-server.md) —
   when (and when not) to restart the Tcl Language Server.
+- [kcs-qa-rust-shim-env-vars.md](kcs-qa-rust-shim-env-vars.md) — what
+  the `TCL_LSP_RUST_*` env vars do and when contributors should
+  set them.
 
 ## How-Tos
 

--- a/docs/kcs/kcs-qa-rust-shim-env-vars.md
+++ b/docs/kcs/kcs-qa-rust-shim-env-vars.md
@@ -22,8 +22,10 @@ Rust binding when an opt-in env var is set, falling back to the
 Python implementation if (a) the binding isn't installed or
 (b) the Rust path raises an exception.
 
-Setting one of the env vars to any non-empty value (the convention
-is `=1`) flips the corresponding subsystem to the Rust pipeline:
+Setting one of the env vars to a truthy value (`1`, `true`, `yes`,
+`on`, `y`, `t` — case-insensitive) flips the corresponding
+subsystem to the Rust pipeline. Empty / unset / `0` / `false` /
+`no` / `off` keep the Python pipeline active:
 
 | Env var                          | Subsystem                | Module wired                                   |
 |----------------------------------|--------------------------|------------------------------------------------|

--- a/docs/kcs/kcs-qa-rust-shim-env-vars.md
+++ b/docs/kcs/kcs-qa-rust-shim-env-vars.md
@@ -1,0 +1,68 @@
+# KCS: How do the `TCL_LSP_RUST_*` env vars work?
+
+> **Audience:** Contributor
+> **Type:** Q&A
+
+## Applies to
+
+all-editors, tcl-lsp-cli
+
+## Question
+
+What do the `TCL_LSP_RUST_*` environment variables do, and when
+should I set them?
+
+## Answer
+
+The Python-to-Rust rewrite (see
+[`docs/rust-rewrite.md`](../../docs/rust-rewrite.md)) is landing in
+chunks. As each chunk's Rust port becomes feature-complete, the
+Python side gains a small dispatch shim that routes work to the
+Rust binding when an opt-in env var is set, falling back to the
+Python implementation if (a) the binding isn't installed or
+(b) the Rust path raises an exception.
+
+Setting one of the env vars to any non-empty value (the convention
+is `=1`) flips the corresponding subsystem to the Rust pipeline:
+
+| Env var                          | Subsystem                | Module wired                                   |
+|----------------------------------|--------------------------|------------------------------------------------|
+| `TCL_LSP_RUST_SIGNATURE_SCAN`    | Background signature scan | `core/analysis/signature_scan.py`              |
+| `TCL_LSP_RUST_OPTIMISER`         | Optimiser pass manager    | `core/compiler/optimiser/_manager.py`          |
+| `TCL_LSP_RUST_INTERPROC`         | Interprocedural analysis  | `core/compiler/interprocedural.py`             |
+| `TCL_LSP_RUST_GVN`               | GVN redundancy detection  | `core/compiler/gvn.py`                         |
+
+Default is **off** for every var — the Python implementation is the
+shipping behaviour and remains the differential-test oracle. The
+Rust path is gated on (a) the binding being importable and (b) the
+env var being set; any exception from the Rust path is logged at
+DEBUG and the Python path runs as a safety net.
+
+You should set one of these vars when:
+
+- **Differential testing.** The `tests/test_rust_*_differential.py`
+  harnesses run with the env var set so they exercise the Rust
+  binding under realistic dispatch.
+- **Local benchmarking.** Profile-comparing Python vs Rust on a
+  workload before promoting a chunk to default-on.
+- **Reproducing a Rust-side bug.** Set the var, replay the
+  workload, observe the difference.
+
+You should **not** set them in production / CI runs that aren't
+exercising the Rust ports — the Python implementation is
+authoritative and the shipping default until each chunk's
+default-on flip lands.
+
+When a chunk's default-on flip lands, the env var inverts (becomes
+an opt-out under the same name with value `0`); after a release
+cycle the var is removed entirely along with the Python
+implementation. The chunk-log table in
+[`docs/rust-rewrite.md`](../../docs/rust-rewrite.md) tracks the
+status (`landed (default-off env-var gate)` vs `landed (default-on)`
+vs Python-retired).
+
+## Related
+
+- [Rust rewrite plan](../../docs/rust-rewrite.md)
+- [Test-port audit](../../docs/rust-rewrite-test-audit.md)
+- [KCS index](README.md)

--- a/docs/rust-rewrite-test-audit.md
+++ b/docs/rust-rewrite-test-audit.md
@@ -590,9 +590,12 @@ none are bridge-specific, none are marked for removal.
 
 ### Test-audit gaps tracked for C40
 
-- **Dispatcher tests missing** (C40-fu4): the three
-  `extract_signatures(source)` tests covering env-var off / on /
-  Rust-raises-fallback are not in the harness yet.
+- **Dispatcher coverage** (landed C40-fu4): four
+  `extract_signatures(source)` tests in
+  `tests/test_rust_signature_scan_differential.py` cover env var
+  unset / set to truthy `1` / set to `"0"` (must NOT enable, per
+  the `rust_shim_enabled` truthy-value contract) / Rust path
+  raising → Python fallback. No longer an open C40 gap.
 - **`command_aliases` corpus is thin**: only one fixture
   (single-`hello` extra). Multi-extras case (`interp alias {} a {}
   b c d e`) should land in a follow-up.

--- a/docs/rust-rewrite-test-audit.md
+++ b/docs/rust-rewrite-test-audit.md
@@ -525,3 +525,78 @@ a per-kind trailing-strip for the empty-degenerate clamp cases.
 - **bridge-only**: 17 pytest tests (new `test_quotes_are_no_longer_deferred` regression guard)
 - **remove-at-end**: 2 pytest tests
 - **deferred**: ~30 pytest tests — backslash-heavy (L9) and iRules dialect (L8) remain
+
+
+## Audit gap notice
+
+This audit has been dormant since L7 (the lexer's last sub-strip).
+Chunks C0–C39 + R2 + L8–L13 + Sync landed without per-chunk audit
+rows. A back-fill pass is outstanding; this doc should not be
+treated as a complete record of the test-port status until the
+back-fill lands.
+
+The C40 row below is added in the C40-fu5 follow-up to break the
+silence; subsequent chunks are expected to land their audit rows in
+the same commit that ships them.
+
+## C40 — `core/analysis/signature_scan.py`
+
+Commit range: C40a1 (`20d4357`) → C40e8 (`eaf9c09`); roadmap visibility
+fix `e0ead7a`. The work landed across 38 commits on the
+`claude/rust-signature-scan-c40-sdNaw` branch.
+
+### Pytest tests — `tests/test_signature_scan.py` (Python-side)
+
+The pre-existing Python test file is unchanged by C40 — every test
+runs against `_extract_signatures_python` in default-off mode and
+acts as the parity oracle the differential harness compares against.
+
+| Tests | Category | Rationale |
+|---|---|---|
+| Every `tests/test_signature_scan.py` test | Ported (oracle) | The Python implementation stays as the default behaviour and as the differential harness's "Python side" until the C40-default-on follow-up flips the gate; once the env var is gone the Python file + its tests can both retire. |
+
+### Pytest tests — `tests/test_rust_signature_scan_differential.py` (new)
+
+26 inline-corpus fixtures + 1 sanity test, all of category **Ported**
+(differential parity asserts the Rust binding produces the same
+`AnalysisResult` as the Python implementation on every fixture).
+
+The corpus is gated on `pytest.importorskip("tcl_lsp_rust", …)` so
+it stays green where the binding isn't built. One fixture is
+intentionally omitted — `source $script_dir/init.tcl` exposes a
+known segmenter-side parity gap (Seg1 in the chunk log) that lives
+in `rust/tcl-compiler/src/segmenter.rs`, not in `signature_scan`.
+
+### Pytest tests — `tests/test_rust_bindings_smoke.py` additions
+
+3 new smoke tests (C40e1 + C40e2 + C40e3), all **Ported** —
+they pin the PyO3 binding's dict shape so a Rust-side struct change
+that breaks the binding contract is caught immediately.
+
+### Rust unit tests
+
+| Module | Count | Notes |
+|---|---:|---|
+| `signature_scan/params.rs` | 7 | Plus 1 doc-test for `parse_param_list`. |
+| `signature_scan/types.rs` | 0 | Pure data types; covered transitively by handler / walker tests. |
+| `signature_scan/ctx.rs` | 3 | Skip-heads count + canonical-builtin presence + default empty. |
+| `signature_scan/handlers.rs` | 33 | Per-handler unit tests (3–5 per handler) + `qualify` / `emit_class` helpers. |
+| `signature_scan/walker.rs` | 15 | Top-level dispatch + body recursion (if / catch / try / namespace eval) + factory walker. |
+| `signature_scan/factory.rs` | 13 | `is_factory_body` + `lookup_factory` + `resolve_factory_defs`. |
+| `signature_scan/mod.rs` | 6 | End-to-end tests of `extract_signatures(source, registry)`. |
+
+All Rust unit tests exercise pure behaviour of the Rust functions —
+none are bridge-specific, none are marked for removal.
+
+### Test-audit gaps tracked for C40
+
+- **Dispatcher tests missing** (C40-fu4): the three
+  `extract_signatures(source)` tests covering env-var off / on /
+  Rust-raises-fallback are not in the harness yet.
+- **`command_aliases` corpus is thin**: only one fixture
+  (single-`hello` extra). Multi-extras case (`interp alias {} a {}
+  b c d e`) should land in a follow-up.
+- **Factory-wrapper cross-namespace negative is unit-only**: the
+  Rust `factory.rs::lookup_cross_namespace_never_falls_through`
+  test pins the rule, but the differential corpus has no
+  end-to-end fixture exercising it.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -711,7 +711,11 @@ tests/test_rust_bindings_smoke.py        end-to-end bridge smoke test
 | C32   | **Python shim retirement — optimiser entry points.** Landed: PyO3 bindings in `rust/tcl-lsp-rust/src/optimiser.rs` exposing `optimiser_find_optimisations(source, dialect)` / `optimiser_find_optimisations_raw(source, dialect)` / `optimiser_opt_priority(code)` — thin wrappers over `tcl_compiler::optimiser::{optimise_with_dialect, optimise_raw, opt_priority}`. The Python `core.compiler.optimiser._manager::find_optimisations` accepts delegation via `TCL_LSP_RUST_OPTIMISER=1` (opt-in — default keeps the Python pipeline so exact-message and overlap-arbitration tests do not regress during the parity-testing phase). `_materialise_rust_optimisations` helper converts the Rust `(code, message, start, end, replacement, group, hint_only)` tuples back to Python `Optimisation` dataclasses with `Range` / `SourcePosition` values built from a local line-start index. 2 new PyO3 smoke tests. Remaining Python-shim work (the `compiler_checks` / `find_*` analyser entry points, flipping the default once parity is verified) is tracked as a follow-up. **C32-shim (Phase 1)** — PyO3 binding `compiler_checks_run_all(source, dialect)` in `rust/tcl-lsp-rust/src/compiler_checks.rs` exposes `tcl_compiler::compiler_checks::run_all_checks`, returning diagnostic tuples `(code, category, severity, message, start_offset, end_offset)`. Infrastructure only: not wired into a Python consumer yet because (a) shimmer / taint Rust implementations are still stubs (C27d / C29 deferred), (b) the Python compiler-diagnostics pipeline is distributed across several modules (`semantic_graph.py`, `core_analyses.py`, per-check entry points) with no single aggregator to swap 1:1, and (c) the optimiser parity gap (~131 test_optimiser.py failures under `TCL_LSP_RUST_OPTIMISER=1`) indicates broader Rust-side analysis parity work is still pending. 2 new PyO3 smoke tests. Follow-ups: land shimmer / taint Rust bodies, add analyser-level entry points, then flip consumers behind per-class opt-in env vars. | landed |
 | C*    | **Compiler migration — deferred analysis bodies.** Remaining work on landed chunks: full shimmer use-site / phi-shimmer / thunking detection (C27d), interprocedural summary-building pipeline (C28), taint propagation + path-concat + URI-split + sink-specific checks (C29), ten optimiser passes (C30a-j), and `connection_scope` + iRules event-flow (C28 follow-up). Each is a focused strip that plugs into the already-landed type surface. | planned |
 | S*    | **LSP server migration.** `lsp/` (pygls handlers, workspace orchestration, feature providers) → `rust/tcl-lsp-server/` on `tower-lsp`. This is when `ropey` enters the picture as the document store, the whole pipeline becomes async, and the server ships as a standalone Rust binary. | planned |
-| R*    | **Remainder.** `vm/` (bytecode VM, interpreter, REPL), `core/commands/` (command registry), `core/analysis/` (analyser passes), `core/formatting/` (formatter engine), `core/minifier/`, `core/irule_test/`, `debugger/`, `fuzzing/`, `explorer/`, CLI tooling (`scripts/`). A Python interface is kept on top for Claude skills, the MCP server, and other integrations. | planned |
+| R*    | **Remainder.** `vm/` (bytecode VM, interpreter, REPL), `core/commands/` (command registry), the rest of `core/analysis/` (`_analyser/` package + `auto_path_eval` / `class_hierarchy` / `irules_checks` / `mro` / `namespace_imports` / `proc_arg_traits` / `proc_lookup` / `semantic_graph` / `semantic_model` / `source_resolver` / `stub_comments` / `var_scoping` — `signature_scan.py` already landed under C40), `core/formatting/` (formatter engine), `core/minifier/`, `core/irule_test/`, `debugger/`, `fuzzing/`, `explorer/`, CLI tooling (`scripts/`). A Python interface is kept on top for Claude skills, the MCP server, and other integrations. | planned |
+| C40-followups | **Follow-ups for the C40 `signature_scan` port.** Six items from the post-merge code review: (1) drop stale `#![allow(dead_code)]` from the four `signature_scan/` submodules now every type is wired; (2) sweep "filled in by Cnnnn" doc comments across `mod.rs` / `types.rs` / `ctx.rs` / `handlers.rs` / `walker.rs` / `factory.rs`; (3) cache `CommandRegistry::build_default()` in a `OnceLock` (also fixes the same waste in `interprocedural.rs`, `optimiser.rs`, `compiler_checks.rs`, `gvn.rs`, `compilation_unit.rs`); (4) three dispatcher tests (`extract_signatures` with binding absent / env-var on / Rust path raising); (5) add a row to `docs/rust-rewrite-test-audit.md`; (6) KCS Q&A note for `TCL_LSP_RUST_SIGNATURE_SCAN`. | planned |
+| C40-default-on | **Flip the C40 default.** Once the differential corpus has baked, change the `extract_signatures` default to dispatch to Rust by default; gate becomes `TCL_LSP_RUST_SIGNATURE_SCAN=0` opt-out. After a release cycle, delete `_extract_signatures_python` and the env var entirely. | planned |
+| Seg1  | **Segmenter argv-widening parity.** The Python `core/parsing/command_segmenter.py` widens `argv[i].end` to the end of the whole Tcl word for multi-token words (e.g. `$var/literal.tcl`); the Rust `rust/tcl-compiler/src/segmenter.rs` keeps it at the first sub-token's end. Surfaces as a `Range` mismatch on `source $script_dir/init.tcl`-style fixtures. The C40e7 differential corpus omits one fixture pending this fix. One-line change in the segmenter's `else if let Some(last_text) = …` branch (lines 227–238) plus a regression fixture in the differential harness. | planned |
+| C41   | **Analyser core port.** `core/analysis/_analyser/` package — ~5,000 LOC across ~12 sub-modules (`_core.py`, `_commands.py`, `_proc.py`, `_diagnostics.py` + 7 sub-files, `_class.py`, `_mixin.py`, `_var_scoping.py`, `_utils.py`, …). The natural next chunk after C40; signature_scan was the lead-in. Same default-off PyO3 env-var gate pattern (`TCL_LSP_RUST_ANALYSER=1`). | planned |
 | Sync  | **Rebase the rust rewrite branch onto main HEAD.** The rewrite branch had disjoint history from main; this sync hard-resets the branch pointer to `origin/main` and re-applies every rust-rewrite-unique file (the `rust/` workspace, `Cargo.{toml,lock}`, `rust-toolchain.toml`, the three rust docs, `core/compiler/rust_spans.py`, the `tests/test_rust_*.py` + `tests/test_tokens.py` set) plus the Python-side dispatch shims (`TCL_LSP_RUST_OPTIMISER` / `_GVN` / `_INTERPROC` envs in `core/compiler/{optimiser/_manager,gvn,interprocedural}.py`, the rust primary path in the four `core/parsing/` lexer-adjacent files), splices the `rust-build` / `rust-test` / `rust-lint` / `rust-format` targets into main's `Makefile`, and fixes a stale `core/analysis/analyser.py` reference (split into `_analyser/` on main) plus an out-of-date `core/irule_test/tcl/_registry_data.tcl` codegen output. Also ports main's IEEE 754 special-literal fix (`Inf` / `NaN` / `Infinity` tokenise as `NUMBER` not `FUNCTION`) into `rust/tcl-lexer/src/expr_lexer.rs::Lexer::ident` so the Rust expr-lexer stays parity with the Python fallback. `cargo fmt --check` + `cargo clippy -D warnings` + `cargo test --workspace` + `make rust-build` + `make prep-pr` all green at the sync commit. | landed |
 | R2    | **Registry deltas from main.** Adds the three new tcl command specs introduced in main (`registry`, `lseq`, `zlib`) under `rust/tcl-registry/src/commands/tcl/` (the `registry` spec lives in `registry_.rs` to avoid colliding with the crate-level `registry` module). Aligns top-level arity for `fcopy` (`Arity::at_least(2)` → `Arity::new(2, 6)`, matching C Tcl 9.0's two channels + four optional option-pair flags) and `tailcall` (`Arity::at_least(1)` → `Arity::any()`, matching C Tcl 9.0's "no args clears scheduled tailcall, with args replaces it" semantics). 118 tcl specs total (was 115). | landed |
 | C39   | **Small codegen fixes from main (audit + per-fix strips).** See the C39 sub-plan below. | landed |
@@ -830,6 +834,95 @@ in `tests/test_rust_signature_scan_differential.py`. Full
 Default-on flip is **deferred** to a follow-up commit: once the
 default-off path has baked, the env var becomes
 `TCL_LSP_RUST_SIGNATURE_SCAN=0` opt-out.
+
+### C40-followups — post-merge clean-up for the `signature_scan` port
+
+The post-merge code review for C40 surfaced six follow-up items. None
+are correctness-blocking; all are landable as one small commit each
+(continuing the strip-by-strip discipline).
+
+- **C40-fu1 — drop stale `#![allow(dead_code)]`.** `handlers.rs:12`,
+  `walker.rs:14`, `factory.rs:17`, `ctx.rs:13`. Every type these
+  attributes guarded is wired in by C40c7/d3/d4. The blanket allow
+  now silently masks any future genuinely-dead code.
+- **C40-fu2 — sweep "filled in by Cnnnn" doc rot.** `mod.rs:19–22`,
+  `types.rs:5`, `ctx.rs:7–9`, `handlers.rs:6–8`, `walker.rs:10–12`
+  (module doc) + `walker.rs:106–107` (section header), `factory.rs:15`.
+  Replace the strip-plan references with descriptions of the
+  current architecture.
+- **C40-fu3 — cache `CommandRegistry::build_default()` in a
+  `OnceLock`.** Currently rebuilds the full ~118-spec command
+  registry on every call across all five PyO3 bindings
+  (`signature_scan.rs`, `interprocedural.rs`, `optimiser.rs`,
+  `compiler_checks.rs`, `gvn.rs`, `compilation_unit.rs`). For the
+  signature scanner (called per non-OPEN document, 1000+ files in a
+  real workspace) this is the worst offender. Land as a shared
+  helper in `rust/tcl-lsp-rust/src/registry.rs` that all five
+  bindings consume.
+- **C40-fu4 — dispatcher tests.** `tests/test_rust_signature_scan_differential.py`
+  currently bypasses the env-var gate by calling
+  `_materialise_rust_signatures(source, signature_scan_extract(source))`
+  directly. Add three tests against `extract_signatures(source)`:
+  no-binding-fallback, env-var-on, exception-fallback (Rust path
+  raises → Python takes over).
+- **C40-fu5 — `docs/rust-rewrite-test-audit.md` C40 row.** The audit
+  has been dormant since L7; C40 should at minimum be listed even
+  if a full backfill of C0–C39 is deferred.
+- **C40-fu6 — KCS Q&A note for `TCL_LSP_RUST_SIGNATURE_SCAN`.**
+  Currently undocumented for users / contributors who grep for the
+  env var. Same gap exists for the other Rust shims
+  (`TCL_LSP_RUST_OPTIMISER`, `_INTERPROC`, `_GVN`); a single
+  `kcs-qa-rust-shim-env-vars.md` covering all five would be cheaper
+  than per-shim notes.
+
+### Seg1 — Segmenter argv-widening parity
+
+The Python `core/parsing/command_segmenter.py` widens
+`argv[-1].end = tok.end` whenever a sub-token is appended to the
+current word, so a multi-token word like `$var/literal.tcl` carries
+a single `argv` Token whose span covers the entire reconstructed
+word. The Rust `rust/tcl-compiler/src/segmenter.rs:227–238` only
+extends `texts[-1]` and `single[-1]`, leaving `argv[-1]` at the
+first sub-token's span.
+
+Visible symptom: `source $script_dir/init.tcl` produces different
+`SourceTarget.range.end` between Python (end-of-word) and Rust
+(end-of-`$script_dir`), surfaced by the C40e7 differential corpus.
+The corpus currently omits the fixture (documented inline at
+`tests/test_rust_signature_scan_differential.py:88–96`).
+
+Fix: in `segment_commands_local`, the `else if let Some(last_text)
+= texts.last_mut()` branch should also bump
+`argv.last_mut().unwrap().span` to a `Span::new(prev_start,
+tok.span.end())`. Add a regression fixture
+(`source_substituted_path`) to the differential corpus once landed.
+Also worth a Rust-side unit test in `segmenter.rs` pinning the
+multi-token-word argv span.
+
+### C41 — Analyser core port
+
+The natural next chunk after C40; `signature_scan` was the lead-in.
+Ports `core/analysis/_analyser/` (~5,000 LOC across ~12
+sub-modules). Likely sub-strip families:
+
+- **C41a** — `_core.py` skeleton + `Analyser` struct + dispatch
+  table.
+- **C41b** — per-command handlers in `_commands.py`. Mirrors the
+  C40b family shape but covers the full Tcl command set, not just
+  the signature subset.
+- **C41c** — `_proc.py` proc-body analysis: var-scoping integration,
+  per-statement walk, parameter / local / upvar tracking.
+- **C41d** — `_diagnostics.py` + the 7 sub-files. This is the
+  biggest sub-family; ports the W001…W242 diagnostic emitters.
+- **C41e** — `_class.py` / `_mixin.py` for OO class hierarchy +
+  method resolution.
+- **C41f** — `_utils.py` shared helpers + the `Analyser::analyse`
+  public entry + PyO3 binding + Python dispatch shim
+  (`TCL_LSP_RUST_ANALYSER=1`) + differential harness.
+
+Same env-var gate / default-off pattern as C40. Differential corpus
+will need to be much larger (the analyser has many more emit
+points). A test-audit row should land alongside.
 
 ### C39 — Small codegen fixes from main
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -715,6 +715,7 @@ tests/test_rust_bindings_smoke.py        end-to-end bridge smoke test
 | C38   | **Namespace-import compile-time resolution.** See the C38 sub-plan below. | landed (data layer; codegen consumer deferred) |
 | C36   | **Factory specialisation pass + `subst -nocommands`.** See the C36 sub-plan below. | landed |
 | C33   | **`var_escape` flow-sensitive analysis (5 strips).** See the C33 sub-plan below. | landed |
+| C40   | **`signature_scan.py` Rust port (5 sub-strip families, 37 strips).** See the C40 sub-plan below. | in progress |
 
 Keep this table current. Mark a row as `landed` in the same commit that
 lands the chunk.
@@ -725,6 +726,55 @@ The chunks below are scoped follow-ups to the `Sync` rebase. Each
 table row above maps to one of the sections here. The order
 matches the planned execution order: smaller / lower-risk chunks
 first to bank confidence, larger restructuring chunks last.
+
+### C40 — `signature_scan.py` Rust port
+
+Port `core/analysis/signature_scan.py` (~862 LOC, single
+self-contained module) to `rust/tcl-compiler/src/signature_scan/`.
+Mirrors the Python implementation 1:1 at the segmenter level —
+**not** the IR level — so the Rust port stays as fast as Python's
+"avoid the lowering pass for background-indexed files" design
+intent.
+
+The port is organised across five sub-strip families with one
+commit per strip; each commit is `≤100` LOC of source + tests and
+green under `cargo fmt --all && cargo clippy --workspace
+--all-targets -- -D warnings && cargo test -p tcl-compiler --lib
+&& make rust-build && make prep-pr`.
+
+Sub-strip families:
+
+- **C40a (7 strips)** — types: scaffold module, `ParamDef` +
+  `parse_param_list`, eight record types, `SignatureScanResult`
+  aggregator, internal `ScanCtx` + `FactoryCandidate` +
+  `ProcBodyInfo` + `FACTORY_SKIP_HEADS`.
+- **C40b (11 strips)** — per-command handlers: `qualify`,
+  `emit_class`, `handle_proc`, `handle_namespace` +
+  `handle_namespace_import`, `handle_package`, `handle_source`,
+  `handle_interp`, `handle_oo_class` + `handle_itcl_class`,
+  `handle_auto_path`, `maybe_handle_import_wrapper`,
+  `maybe_record_factory_candidate`.
+- **C40c (7 strips)** — walker: top-level `scan` +
+  `maybe_recurse_body` scaffold, namespace-eval body recursion,
+  `handle_if` body recursion, `handle_catch` body recursion,
+  `handle_try` body recursion (on/trap/finally),
+  `scan_factory_candidates` + `scan_factory_structural`, wire
+  factory walker into `handle_proc`.
+- **C40d (4 strips)** — factory resolution + entry: `is_factory_body`,
+  `lookup_factory`, `resolve_factory_defs`, public
+  `extract_signatures(source, registry)` entry point.
+- **C40e (8 strips)** — PyO3 binding + Python shim + differential
+  harness: PyO3 scaffold + `register_with` + smoke tests; PyDict
+  emission of every collection in two strips; Python
+  `_materialise_rust_signatures` helper; Python env-var dispatch
+  shim (`TCL_LSP_RUST_SIGNATURE_SCAN=1`); differential harness
+  scaffold; differential corpus (~25 fixtures); chunk-log row →
+  landed.
+
+The Rust signature `extract_signatures(source: &str, _registry:
+&CommandRegistry) -> SignatureScanResult` plumbs a registry param
+through (currently unused) for consistency with every other
+tcl-compiler analysis entry point.
 
 ### C39 — Small codegen fixes from main
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -41,6 +41,12 @@ We get there by porting the codebase bottom-up, in dependency order:
 4. **Remainder.** `vm/`, `core/commands/`, `core/analysis/`,
    `core/formatting/`, `core/minifier/`, `core/irule_test/`, the
    debugger, fuzzing harnesses, the compiler explorer, and CLI tooling.
+   First analysis chunk landed: **C40** ports
+   `core/analysis/signature_scan.py` (~862 LOC, used by every
+   non-OPEN document for cross-file workspace symbols, `package
+   require` resolution, and command-usage counts) to
+   `rust/tcl-compiler/src/signature_scan/` behind a default-off
+   `TCL_LSP_RUST_SIGNATURE_SCAN=1` env-var gate.
 5. **Python-facing surface** is reduced to the bits that genuinely want
    to stay in Python (AI skills, MCP, scripts).
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -715,7 +715,7 @@ tests/test_rust_bindings_smoke.py        end-to-end bridge smoke test
 | C38   | **Namespace-import compile-time resolution.** See the C38 sub-plan below. | landed (data layer; codegen consumer deferred) |
 | C36   | **Factory specialisation pass + `subst -nocommands`.** See the C36 sub-plan below. | landed |
 | C33   | **`var_escape` flow-sensitive analysis (5 strips).** See the C33 sub-plan below. | landed |
-| C40   | **`signature_scan.py` Rust port (5 sub-strip families, 37 strips).** See the C40 sub-plan below. | in progress |
+| C40   | **`signature_scan.py` Rust port (5 sub-strip families, 37 strips).** See the C40 sub-plan below. | landed (default-off env-var gate) |
 
 Keep this table current. Mark a row as `landed` in the same commit that
 lands the chunk.
@@ -775,6 +775,55 @@ The Rust signature `extract_signatures(source: &str, _registry:
 &CommandRegistry) -> SignatureScanResult` plumbs a registry param
 through (currently unused) for consistency with every other
 tcl-compiler analysis entry point.
+
+**Landed outcome.** All 37 strips landed across the C40a–C40e
+families. Final commit count: 37 (+ 1 amend on C40a2 + 1 fold of
+the lookup_factory return-type fix into C40d3).
+
+The Rust scanner ports every per-command handler the Python
+implementation has — `proc`, `oo::class create`, `itcl::class`,
+`namespace eval` / `namespace import`, `package require`,
+`source`, `interp alias`, `lappend auto_path` / `set auto_path`,
+the tcllib `<NS>::import <ALIAS>` wrapper idiom, and the tcllib
+`DEFC name args body` / `proc $name $args $body` factory-wrapper
+synthesis pattern (with two-pass `is_factory_body` / `lookup_factory`
+/ `resolve_factory_defs` resolution). Body recursion covers
+`namespace eval`, `if` (then/elseif/else), `catch`, and `try`
+(on/trap/finally) — all branches marked `conditional=true`.
+
+The PyO3 binding emits a `dict` keyed on the eight collection
+names (`procs`, `classes`, `command_invocations`,
+`package_requires`, `source_targets`, `command_aliases`,
+`namespace_imports`, `auto_path_entries`) with spans encoded as
+`(start, end)` `u32` tuples. The Python materialiser
+(`_materialise_rust_signatures` in `core/analysis/signature_scan.py`)
+converts those tuples back into LSP `Range` values via
+`core/compiler/rust_spans.py::build_position_resolver`. The Python
+dispatch shim gates the Rust path on
+`TCL_LSP_RUST_SIGNATURE_SCAN=1`, falling back to the Python
+implementation on any exception.
+
+The differential harness
+(`tests/test_rust_signature_scan_differential.py`) parametrises
+26 fixtures across every handler family; the Python and Rust
+paths produce field-equal `AnalysisResult` records on every
+fixture. One source-target fixture (a `source $script_dir/init.tcl`
+shape with a multi-token argv word) is intentionally omitted —
+the Python segmenter widens `argv[i].end` to the end of the whole
+word but the Rust segmenter doesn't, which surfaces as a `Range`
+mismatch. The fix lives in the segmenter
+(`rust/tcl-compiler/src/segmenter.rs`), not in `signature_scan`,
+and is tracked as a follow-up.
+
+Test counts: 70+ Rust unit tests across the `signature_scan/`
+sub-modules; 3 PyO3 smoke tests in
+`tests/test_rust_bindings_smoke.py`; 27 differential parity tests
+in `tests/test_rust_signature_scan_differential.py`. Full
+`make prep-pr` green at every commit.
+
+Default-on flip is **deferred** to a follow-up commit: once the
+default-off path has baked, the env var becomes
+`TCL_LSP_RUST_SIGNATURE_SCAN=0` opt-out.
 
 ### C39 — Small codegen fixes from main
 

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -6,7 +6,7 @@
 
 use crate::ir::Statement;
 
-use super::values::{is_array_ref, is_qualified, parse_simple_var_ref, split_array_ref};
+use super::values::{is_qualified, needs_stk_var_ref, parse_simple_var_ref, split_array_ref};
 use super::{CodegenCtx, Op, Operand};
 
 /// Tag used to identify `startCommand` instructions wrapping generic
@@ -82,7 +82,7 @@ impl CodegenCtx {
     pub fn emit_stmt(&mut self, stmt: &Statement, used_generic_invoke: &mut bool) {
         match stmt {
             Statement::AssignConst { name, value, .. } => {
-                if needs_stk_push(name, self.is_proc) {
+                if needs_stk_var_ref(name, self.is_proc) {
                     self.push_var_ref(name);
                 }
                 self.push_lit(value);
@@ -102,7 +102,7 @@ impl CodegenCtx {
                     value.clone()
                 };
 
-                if needs_stk_push(name, self.is_proc) {
+                if needs_stk_var_ref(name, self.is_proc) {
                     self.push_var_ref(name);
                 }
                 self.emit_value_interpolated(&value);
@@ -111,7 +111,7 @@ impl CodegenCtx {
             }
 
             Statement::AssignExpr { name, expr, .. } => {
-                if needs_stk_push(name, self.is_proc) {
+                if needs_stk_var_ref(name, self.is_proc) {
                     self.push_var_ref(name);
                 }
                 let inner_end = self.fresh_label("cmd_end");
@@ -366,17 +366,6 @@ impl CodegenCtx {
         self.emit(Op::POP, vec![]);
         *used_generic_invoke = true;
     }
-}
-
-/// Whether a store needs the name/key pushed first (stk-based ops).
-fn needs_stk_push(name: &str, is_proc: bool) -> bool {
-    if !is_proc {
-        return true;
-    }
-    if is_qualified(name) {
-        return true;
-    }
-    is_array_ref(name)
 }
 
 #[cfg(test)]

--- a/rust/tcl-compiler/src/execution_intent.rs
+++ b/rust/tcl-compiler/src/execution_intent.rs
@@ -265,7 +265,6 @@ fn token_intent_text<'src>(source: &'src str, tok: &tcl_lexer::Token) -> &'src s
     // Token spans already cover the full token text (including any
     // leading `$` / `[` and trailing `]` for wrapper tokens).
     // Returning the raw slice preserves the Python-side behaviour.
-    let _ = tok.kind;
     &source[start..end]
 }
 

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -96,6 +96,7 @@ pub mod sccp;
 pub mod segmenter;
 pub mod shimmer;
 pub mod side_effects;
+pub mod signature_scan;
 pub mod specialise_factories;
 pub mod ssa;
 pub mod static_loops;

--- a/rust/tcl-compiler/src/signature_scan/ctx.rs
+++ b/rust/tcl-compiler/src/signature_scan/ctx.rs
@@ -1,0 +1,146 @@
+//! Internal scan-state types used by the `signature_scan` walker.
+//!
+//! These are crate-private — they accumulate intermediate results
+//! during the walk and are consumed by the second-pass factory
+//! resolver before the public [`SignatureScanResult`] is returned.
+//!
+//! Fields carry `#[allow(dead_code)]` until the C40b/c/d sub-strips
+//! that consume them land; once those wire-ins are in place, the
+//! attributes can be removed.
+//!
+//! [`SignatureScanResult`]: super::types::SignatureScanResult
+
+#![allow(dead_code)]
+
+use tcl_lexer::Token;
+
+use super::types::SignatureScanResult;
+
+/// A factory-wrapper call captured during the first scan pass.
+///
+/// `signature_scan` recognises tcllib-style factory wrappers (e.g.
+/// `DEFC name args body`) by their canonical four-token shape and
+/// defers binding to a real factory until after the full source has
+/// been scanned. `FactoryCandidate` records the call-site data the
+/// second pass needs to attribute the synthetic proc to the right
+/// namespace.
+#[derive(Debug, Clone)]
+pub(super) struct FactoryCandidate {
+    /// The command head as written at the call site (e.g. `"DEFC"`,
+    /// `"::foo::DEF"`).
+    pub(super) head: String,
+    /// The proc-name argument as written.
+    pub(super) name: String,
+    /// Token of the name argument (used for the synthetic proc's
+    /// `name_range`).
+    pub(super) name_tok: Token,
+    /// Token of the body argument (used for the synthetic proc's
+    /// `body_range`).
+    pub(super) body_tok: Token,
+    /// Effective namespace at the call site, no leading `::`.
+    pub(super) ns_prefix: String,
+}
+
+/// First-pass record of a proc body, used to identify factory
+/// wrappers by their `proc $p1 $p2 $p3` body shape.
+///
+/// The wrapper's home namespace is the namespace any factory-emitted
+/// procs end up in at runtime — `proc $name …` executed inside a
+/// proc creates the command in the caller's current namespace, which
+/// for a factory-wrapper INIT path is unambiguously the wrapper's
+/// own home.
+#[derive(Debug, Clone)]
+pub(super) struct ProcBodyInfo {
+    /// Fully-qualified proc name with leading `::`.
+    pub(super) qname: String,
+    /// Parameter names (in declaration order) — the factory body
+    /// detector matches these against the `proc $a $b $c` body
+    /// shape.
+    pub(super) params: Vec<String>,
+    /// Verbatim proc body text.
+    pub(super) body_text: String,
+    /// Namespace any synthetic procs created by this wrapper live
+    /// in, no leading `::`.
+    pub(super) ns_prefix: String,
+}
+
+/// Mutable scan context threaded through the walker.
+#[derive(Debug, Default)]
+pub(super) struct ScanCtx {
+    /// Public result accumulator.
+    pub(super) result: SignatureScanResult,
+    /// Factory-call candidates collected during pass 1.
+    pub(super) candidates: Vec<FactoryCandidate>,
+    /// Proc-body records collected during pass 1, used to identify
+    /// real factory wrappers in pass 2.
+    pub(super) proc_bodies: Vec<ProcBodyInfo>,
+}
+
+/// Heads that incidentally match the `HEAD NAME BRACED BRACED`
+/// four-token shape but are definitely not factory wrappers.
+///
+/// Mirrors `_FACTORY_SKIP_HEADS` in `core/analysis/signature_scan.py`.
+pub(super) const FACTORY_SKIP_HEADS: &[&str] = &[
+    "proc",
+    "namespace",
+    "if",
+    "switch",
+    "while",
+    "for",
+    "foreach",
+    "try",
+    "catch",
+    "eval",
+    "apply",
+    "expr",
+    "uplevel",
+    "upvar",
+    "variable",
+    "set",
+    "lappend",
+    "dict",
+    "array",
+    "string",
+    "list",
+    "lindex",
+    "package",
+    "source",
+    "interp",
+    "oo::class",
+    "oo::define",
+    "oo::objdefine",
+    "method",
+    "classmethod",
+    "itcl::class",
+    "::itcl::class",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skip_heads_matches_python_count() {
+        // The Python list at signature_scan.py:546 has 32 entries.
+        assert_eq!(FACTORY_SKIP_HEADS.len(), 32);
+    }
+
+    #[test]
+    fn skip_heads_includes_canonical_builtins() {
+        for head in ["proc", "namespace", "if", "for", "package", "source"] {
+            assert!(
+                FACTORY_SKIP_HEADS.contains(&head),
+                "expected {head:?} in skip list"
+            );
+        }
+    }
+
+    #[test]
+    fn default_ctx_is_empty() {
+        let ctx = ScanCtx::default();
+        assert!(ctx.candidates.is_empty());
+        assert!(ctx.proc_bodies.is_empty());
+        assert!(ctx.result.procs.is_empty());
+        assert!(ctx.result.command_invocations.is_empty());
+    }
+}

--- a/rust/tcl-compiler/src/signature_scan/ctx.rs
+++ b/rust/tcl-compiler/src/signature_scan/ctx.rs
@@ -2,11 +2,21 @@
 //!
 //! These are crate-private — they accumulate intermediate results
 //! during the walk and are consumed by the second-pass factory
-//! resolver before the public [`SignatureScanResult`] is returned.
+//! resolver (see [`super::factory::resolve_factory_defs`]) before
+//! the public [`SignatureScanResult`] is returned.
 //!
-//! Fields carry `#[allow(dead_code)]` until the C40b/c/d sub-strips
-//! that consume them land; once those wire-ins are in place, the
-//! attributes can be removed.
+//! - [`ScanCtx`] is threaded as `&mut` through the walker and every
+//!   handler; it owns the public `result` accumulator plus the two
+//!   first-pass vectors `candidates` and `proc_bodies`.
+//! - [`FactoryCandidate`] records each four-token call (`HEAD NAME
+//!   ARGS BODY`) the walker spotted, deferring binding to a real
+//!   factory until pass two.
+//! - [`ProcBodyInfo`] records each proc body's text + params +
+//!   home namespace so the factory detector can spot the canonical
+//!   `proc $name $args $body` shape.
+//! - [`FACTORY_SKIP_HEADS`] is the negative list of built-in heads
+//!   that incidentally take the same four-token shape but are
+//!   definitely not factory wrappers.
 //!
 //! [`SignatureScanResult`]: super::types::SignatureScanResult
 

--- a/rust/tcl-compiler/src/signature_scan/ctx.rs
+++ b/rust/tcl-compiler/src/signature_scan/ctx.rs
@@ -10,8 +10,6 @@
 //!
 //! [`SignatureScanResult`]: super::types::SignatureScanResult
 
-#![allow(dead_code)]
-
 use tcl_lexer::Token;
 
 use super::types::SignatureScanResult;

--- a/rust/tcl-compiler/src/signature_scan/factory.rs
+++ b/rust/tcl-compiler/src/signature_scan/factory.rs
@@ -14,8 +14,6 @@
 //!
 //! Subsequent C40d sub-strips fill in items 2 and 3.
 
-#![allow(dead_code)]
-
 use std::collections::{HashMap, HashSet};
 
 use super::ctx::{FactoryCandidate, ScanCtx};

--- a/rust/tcl-compiler/src/signature_scan/factory.rs
+++ b/rust/tcl-compiler/src/signature_scan/factory.rs
@@ -1,0 +1,99 @@
+//! Second-pass factory-wrapper resolution.
+//!
+//! After the main walker collects every candidate four-token call
+//! (in `ctx.candidates`) and every proc body's text + params (in
+//! `ctx.proc_bodies`), the resolver:
+//!
+//! 1. classifies each proc body as a real factory wrapper iff its
+//!    body contains a `proc $a $b $c` shape using the wrapper's own
+//!    parameters ([`is_factory_body`]);
+//! 2. for each candidate, looks up the factory it binds to using
+//!    Tcl's command-resolution path ([`lookup_factory`]);
+//! 3. emits a synthetic [`SignatureProc`] under the factory's home
+//!    namespace ([`resolve_factory_defs`]).
+//!
+//! Subsequent C40d sub-strips fill in items 2 and 3.
+
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+
+use crate::segmenter::segment_commands;
+
+/// Return `true` when `body_text` contains a top-level
+/// `proc $p1 $p2 $p3` command using exactly the wrapper's three
+/// parameters in some order.
+///
+/// Mirrors `_is_factory_body` in
+/// `core/analysis/signature_scan.py`. Both `$name` and `${name}`
+/// substitution forms are accepted (the segmenter reconstructs
+/// substitutions as `${name}`, but bare `$name` still matches the
+/// equality check). Wrappers with fewer than three parameters
+/// cannot match the canonical `proc $name $args $body` shape.
+#[must_use]
+pub(super) fn is_factory_body(body_text: &str, params: &[String]) -> bool {
+    if params.len() < 3 {
+        return false;
+    }
+    let mut param_vars: HashSet<String> = HashSet::with_capacity(params.len() * 2);
+    for p in params {
+        param_vars.insert(format!("${p}"));
+        param_vars.insert(format!("${{{p}}}"));
+    }
+    let commands = segment_commands(body_text);
+    for cmd in commands {
+        if cmd.is_partial || cmd.texts.is_empty() {
+            continue;
+        }
+        let t = &cmd.texts;
+        if t[0] != "proc" || t.len() != 4 {
+            continue;
+        }
+        if param_vars.contains(&t[1]) && param_vars.contains(&t[2]) && param_vars.contains(&t[3]) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_factory_body_matches() {
+        let body = "proc $name $args $body";
+        let params = vec!["name".to_string(), "args".to_string(), "body".to_string()];
+        assert!(is_factory_body(body, &params));
+    }
+
+    #[test]
+    fn wrong_arity_rejected() {
+        // `proc $name $args` only — three tokens, not four.
+        let body = "proc $name $args";
+        let params = vec!["name".to_string(), "args".to_string(), "body".to_string()];
+        assert!(!is_factory_body(body, &params));
+    }
+
+    #[test]
+    fn non_variable_arg_disqualifies() {
+        // The middle arg is a literal `foo`, not a variable.
+        let body = "proc $name foo $body";
+        let params = vec!["name".to_string(), "args".to_string(), "body".to_string()];
+        assert!(!is_factory_body(body, &params));
+    }
+
+    #[test]
+    fn no_proc_statement_no_match() {
+        let body = "set x 1; return $x";
+        let params = vec!["name".to_string(), "args".to_string(), "body".to_string()];
+        assert!(!is_factory_body(body, &params));
+    }
+
+    #[test]
+    fn fewer_than_three_params_no_match() {
+        let body = "proc $name $args $body";
+        let params = vec!["name".to_string(), "args".to_string()];
+        assert!(!is_factory_body(body, &params));
+    }
+}

--- a/rust/tcl-compiler/src/signature_scan/factory.rs
+++ b/rust/tcl-compiler/src/signature_scan/factory.rs
@@ -18,8 +18,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use super::ctx::FactoryCandidate;
+use super::ctx::{FactoryCandidate, ScanCtx};
 use super::handlers::qualify;
+use super::types::SignatureProc;
 use crate::segmenter::segment_commands;
 
 /// Return `true` when `body_text` contains a top-level
@@ -58,8 +59,8 @@ pub(super) fn is_factory_body(body_text: &str, params: &[String]) -> bool {
     false
 }
 
-/// Resolve `cand.head` to a factory's qualified name, following
-/// Tcl's command-resolution order.
+/// Resolve `cand.head` to a factory's qualified name (the **key**
+/// in `factories`), following Tcl's command-resolution order.
 ///
 /// Mirrors `_lookup_factory` in
 /// `core/analysis/signature_scan.py`. Absolute heads (those
@@ -72,20 +73,82 @@ pub(super) fn is_factory_body(body_text: &str, params: &[String]) -> bool {
 pub(super) fn lookup_factory<'a>(
     cand: &FactoryCandidate,
     factories: &'a HashMap<String, String>,
-) -> Option<&'a String> {
+) -> Option<&'a str> {
     let head = &cand.head;
     if head.starts_with("::") {
-        return factories.get(head);
+        return factories
+            .get_key_value(head.as_str())
+            .map(|(k, _)| k.as_str());
     }
     let qualified = qualify(&cand.ns_prefix, head);
-    if let Some(v) = factories.get(&qualified) {
-        return Some(v);
+    if let Some((k, _)) = factories.get_key_value(qualified.as_str()) {
+        return Some(k.as_str());
     }
     let global_q = format!("::{head}");
     if global_q != qualified {
-        return factories.get(&global_q);
+        return factories
+            .get_key_value(global_q.as_str())
+            .map(|(k, _)| k.as_str());
     }
     None
+}
+
+/// Emit synthetic [`SignatureProc`] records for each factory-wrapper
+/// call site.
+///
+/// Mirrors `_resolve_factory_defs` in
+/// `core/analysis/signature_scan.py`. Builds a factory map from
+/// `ctx.proc_bodies` filtered through [`is_factory_body`]; for
+/// each candidate calls [`lookup_factory`], computes the emitted
+/// qualified name (honouring an explicit `::` prefix on the
+/// candidate name), and idempotently inserts a synthetic
+/// [`SignatureProc`] with empty params (the wrapper-to-factory
+/// argument-position map is not statically known, so we just
+/// record a jump target).
+pub(super) fn resolve_factory_defs(ctx: &mut ScanCtx) {
+    if ctx.candidates.is_empty() || ctx.proc_bodies.is_empty() {
+        return;
+    }
+    let mut factories: HashMap<String, String> = HashMap::new();
+    for info in &ctx.proc_bodies {
+        if !is_factory_body(&info.body_text, &info.params) {
+            continue;
+        }
+        factories.insert(info.qname.clone(), info.ns_prefix.clone());
+    }
+    if factories.is_empty() {
+        return;
+    }
+    // Snapshot candidates so we can mutate ctx.result.procs while
+    // iterating. Candidates is a small Vec; cloning is cheap.
+    let candidates = ctx.candidates.clone();
+    for cand in &candidates {
+        let Some(factory_qname) = lookup_factory(cand, &factories) else {
+            continue;
+        };
+        let factory_ns = &factories[factory_qname];
+        let emitted_q = if cand.name.starts_with("::") {
+            cand.name.clone()
+        } else if !factory_ns.is_empty() {
+            format!("::{factory_ns}::{}", cand.name)
+        } else {
+            format!("::{}", cand.name)
+        };
+        let simple = emitted_q.rsplit("::").next().unwrap_or("").to_string();
+        if ctx.result.procs.contains_key(&emitted_q) {
+            continue;
+        }
+        ctx.result.procs.insert(
+            emitted_q.clone(),
+            SignatureProc {
+                name: simple,
+                qualified_name: emitted_q,
+                params: Vec::new(),
+                name_range: cand.name_tok.span,
+                body_range: cand.body_tok.span,
+            },
+        );
+    }
 }
 
 #[cfg(test)]
@@ -152,7 +215,7 @@ mod tests {
     fn lookup_absolute_head_matches_verbatim() {
         let f = factories(&[("::foo::DEFC", "foo")]);
         let c = cand("::foo::DEFC", "anywhere");
-        assert_eq!(lookup_factory(&c, &f).map(String::as_str), Some("foo"));
+        assert_eq!(lookup_factory(&c, &f), Some("::foo::DEFC"));
     }
 
     #[test]
@@ -161,17 +224,14 @@ mod tests {
         // `ns` should resolve to the call-site one.
         let f = factories(&[("::ns::DEFC", "ns_home"), ("::DEFC", "global_home")]);
         let c = cand("DEFC", "ns");
-        assert_eq!(lookup_factory(&c, &f).map(String::as_str), Some("ns_home"));
+        assert_eq!(lookup_factory(&c, &f), Some("::ns::DEFC"));
     }
 
     #[test]
     fn lookup_global_fallback_when_call_ns_misses() {
         let f = factories(&[("::DEFC", "global_home")]);
         let c = cand("DEFC", "ns");
-        assert_eq!(
-            lookup_factory(&c, &f).map(String::as_str),
-            Some("global_home"),
-        );
+        assert_eq!(lookup_factory(&c, &f), Some("::DEFC"));
     }
 
     #[test]
@@ -181,5 +241,113 @@ mod tests {
         let f = factories(&[("::other::DEFC", "other_home")]);
         let c = cand("DEFC", "ns");
         assert!(lookup_factory(&c, &f).is_none());
+    }
+
+    use super::super::ctx::ProcBodyInfo;
+
+    fn proc_body(qname: &str, ns: &str, body: &str) -> ProcBodyInfo {
+        ProcBodyInfo {
+            qname: qname.to_string(),
+            params: vec!["name".to_string(), "args".to_string(), "body".to_string()],
+            body_text: body.to_string(),
+            ns_prefix: ns.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_emits_synthetic_proc_for_tcllib_defc() {
+        let mut ctx = ScanCtx::default();
+        ctx.proc_bodies.push(proc_body(
+            "::tcllib::DEFC",
+            "tcllib",
+            "proc $name $args $body",
+        ));
+        ctx.candidates.push(FactoryCandidate {
+            head: "DEFC".to_string(),
+            name: "Foo".to_string(),
+            name_tok: Token::with_content_offset(TokenType::Esc, Span::new(10, 13), 0),
+            body_tok: Token::with_content_offset(TokenType::Str, Span::new(20, 30), 1),
+            ns_prefix: "tcllib".to_string(),
+        });
+        resolve_factory_defs(&mut ctx);
+        let proc = ctx.result.procs.get("::tcllib::Foo").expect("emitted");
+        assert_eq!(proc.name, "Foo");
+        assert!(proc.params.is_empty());
+        assert_eq!(proc.name_range, Span::new(10, 13));
+        assert_eq!(proc.body_range, Span::new(20, 30));
+    }
+
+    #[test]
+    fn resolve_no_factories_no_op() {
+        let mut ctx = ScanCtx::default();
+        // proc_bodies present but no factory body shape.
+        ctx.proc_bodies
+            .push(proc_body("::ns::regular", "ns", "set x 1"));
+        ctx.candidates.push(FactoryCandidate {
+            head: "regular".to_string(),
+            name: "X".to_string(),
+            name_tok: Token::new(TokenType::Esc, Span::new(0, 0)),
+            body_tok: Token::with_content_offset(TokenType::Str, Span::new(0, 0), 1),
+            ns_prefix: "ns".to_string(),
+        });
+        resolve_factory_defs(&mut ctx);
+        assert!(ctx.result.procs.is_empty());
+    }
+
+    #[test]
+    fn resolve_idempotent_re_emit_guard() {
+        let mut ctx = ScanCtx::default();
+        ctx.proc_bodies
+            .push(proc_body("::DEFC", "", "proc $name $args $body"));
+        // Pre-populate the result with a `::Foo` proc — the synthetic
+        // emit must not overwrite it.
+        ctx.result.procs.insert(
+            "::Foo".to_string(),
+            SignatureProc {
+                name: "Foo".to_string(),
+                qualified_name: "::Foo".to_string(),
+                params: vec![super::super::types::ParamDef {
+                    name: "real".to_string(),
+                    has_default: false,
+                    default_value: None,
+                }],
+                name_range: Span::new(99, 102),
+                body_range: Span::new(110, 120),
+            },
+        );
+        ctx.candidates.push(FactoryCandidate {
+            head: "DEFC".to_string(),
+            name: "Foo".to_string(),
+            name_tok: Token::new(TokenType::Esc, Span::new(0, 3)),
+            body_tok: Token::with_content_offset(TokenType::Str, Span::new(10, 20), 1),
+            ns_prefix: String::new(),
+        });
+        resolve_factory_defs(&mut ctx);
+        // Original record preserved.
+        let proc = ctx.result.procs.get("::Foo").expect("present");
+        assert_eq!(proc.params.len(), 1);
+        assert_eq!(proc.name_range, Span::new(99, 102));
+    }
+
+    #[test]
+    fn resolve_candidate_with_absolute_name() {
+        let mut ctx = ScanCtx::default();
+        ctx.proc_bodies.push(proc_body(
+            "::tcllib::DEFC",
+            "tcllib",
+            "proc $name $args $body",
+        ));
+        ctx.candidates.push(FactoryCandidate {
+            head: "DEFC".to_string(),
+            name: "::Top::Foo".to_string(),
+            name_tok: Token::new(TokenType::Esc, Span::new(0, 10)),
+            body_tok: Token::with_content_offset(TokenType::Str, Span::new(11, 20), 1),
+            ns_prefix: "tcllib".to_string(),
+        });
+        resolve_factory_defs(&mut ctx);
+        // Absolute name preserved; not under tcllib::Foo.
+        let proc = ctx.result.procs.get("::Top::Foo").expect("present");
+        assert_eq!(proc.name, "Foo");
+        assert!(!ctx.result.procs.contains_key("::tcllib::Foo"));
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/factory.rs
+++ b/rust/tcl-compiler/src/signature_scan/factory.rs
@@ -2,7 +2,7 @@
 //!
 //! After the main walker collects every candidate four-token call
 //! (in `ctx.candidates`) and every proc body's text + params (in
-//! `ctx.proc_bodies`), the resolver:
+//! `ctx.proc_bodies`), [`resolve_factory_defs`]:
 //!
 //! 1. classifies each proc body as a real factory wrapper iff its
 //!    body contains a `proc $a $b $c` shape using the wrapper's own
@@ -10,9 +10,10 @@
 //! 2. for each candidate, looks up the factory it binds to using
 //!    Tcl's command-resolution path ([`lookup_factory`]);
 //! 3. emits a synthetic [`SignatureProc`] under the factory's home
-//!    namespace ([`resolve_factory_defs`]).
+//!    namespace, idempotently skipping any qualified name already
+//!    present in [`super::ctx::ScanCtx::result`]`.procs`.
 //!
-//! Subsequent C40d sub-strips fill in items 2 and 3.
+//! [`SignatureProc`]: super::types::SignatureProc
 
 use std::collections::{HashMap, HashSet};
 

--- a/rust/tcl-compiler/src/signature_scan/factory.rs
+++ b/rust/tcl-compiler/src/signature_scan/factory.rs
@@ -16,8 +16,10 @@
 
 #![allow(dead_code)]
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
+use super::ctx::FactoryCandidate;
+use super::handlers::qualify;
 use crate::segmenter::segment_commands;
 
 /// Return `true` when `body_text` contains a top-level
@@ -54,6 +56,36 @@ pub(super) fn is_factory_body(body_text: &str, params: &[String]) -> bool {
         }
     }
     false
+}
+
+/// Resolve `cand.head` to a factory's qualified name, following
+/// Tcl's command-resolution order.
+///
+/// Mirrors `_lookup_factory` in
+/// `core/analysis/signature_scan.py`. Absolute heads (those
+/// starting with `::`) match verbatim. Relative heads try the
+/// call-site qualified name first, then the global namespace —
+/// they never fall through to "any factory with this bare name",
+/// which would bind calls in one namespace to a wrapper in an
+/// unrelated one (Tcl itself refuses to cross those boundaries).
+#[must_use]
+pub(super) fn lookup_factory<'a>(
+    cand: &FactoryCandidate,
+    factories: &'a HashMap<String, String>,
+) -> Option<&'a String> {
+    let head = &cand.head;
+    if head.starts_with("::") {
+        return factories.get(head);
+    }
+    let qualified = qualify(&cand.ns_prefix, head);
+    if let Some(v) = factories.get(&qualified) {
+        return Some(v);
+    }
+    let global_q = format!("::{head}");
+    if global_q != qualified {
+        return factories.get(&global_q);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -95,5 +127,59 @@ mod tests {
         let body = "proc $name $args $body";
         let params = vec!["name".to_string(), "args".to_string()];
         assert!(!is_factory_body(body, &params));
+    }
+
+    use tcl_lexer::{Span, Token, TokenType};
+
+    fn cand(head: &str, ns: &str) -> FactoryCandidate {
+        FactoryCandidate {
+            head: head.to_string(),
+            name: "X".to_string(),
+            name_tok: Token::new(TokenType::Esc, Span::new(0, 0)),
+            body_tok: Token::with_content_offset(TokenType::Str, Span::new(0, 0), 1),
+            ns_prefix: ns.to_string(),
+        }
+    }
+
+    fn factories(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|&(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn lookup_absolute_head_matches_verbatim() {
+        let f = factories(&[("::foo::DEFC", "foo")]);
+        let c = cand("::foo::DEFC", "anywhere");
+        assert_eq!(lookup_factory(&c, &f).map(String::as_str), Some("foo"));
+    }
+
+    #[test]
+    fn lookup_call_namespace_qualified_first() {
+        // Both `::ns::DEFC` and `::DEFC` exist; relative call from
+        // `ns` should resolve to the call-site one.
+        let f = factories(&[("::ns::DEFC", "ns_home"), ("::DEFC", "global_home")]);
+        let c = cand("DEFC", "ns");
+        assert_eq!(lookup_factory(&c, &f).map(String::as_str), Some("ns_home"));
+    }
+
+    #[test]
+    fn lookup_global_fallback_when_call_ns_misses() {
+        let f = factories(&[("::DEFC", "global_home")]);
+        let c = cand("DEFC", "ns");
+        assert_eq!(
+            lookup_factory(&c, &f).map(String::as_str),
+            Some("global_home"),
+        );
+    }
+
+    #[test]
+    fn lookup_cross_namespace_never_falls_through() {
+        // A factory under `::other::DEFC` should NOT resolve a
+        // bare `DEFC` call from namespace `ns`.
+        let f = factories(&[("::other::DEFC", "other_home")]);
+        let c = cand("DEFC", "ns");
+        assert!(lookup_factory(&c, &f).is_none());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -13,7 +13,9 @@
 
 use tcl_lexer::Token;
 
-use super::types::{SignatureClass, SignatureScanResult};
+use super::ctx::{ProcBodyInfo, ScanCtx};
+use super::params::parse_param_list;
+use super::types::{SignatureClass, SignatureProc, SignatureScanResult};
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
 ///
@@ -60,6 +62,51 @@ pub(super) fn emit_class(
             body_range: body_tok.span,
         },
     );
+}
+
+/// Handler for `proc NAME PARAMS BODY`.
+///
+/// Mirrors `_handle_proc` in `core/analysis/signature_scan.py`.
+/// Records a `SignatureProc` in `ctx.result.procs` and a
+/// `ProcBodyInfo` in `ctx.proc_bodies` so the second-pass factory
+/// resolver can identify factory-wrapper procs by their
+/// `proc $a $b $c` body shape.
+///
+/// Body recursion (`scan_factory_candidates`) is **not** wired in
+/// this strip — it lands in `C40c7`, after the walker module
+/// exists. The proc is recorded; the body walk is deferred.
+pub(super) fn handle_proc(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCtx) {
+    if texts.len() < 4 {
+        return;
+    }
+    let raw_name = &texts[1];
+    let qualified = qualify(ns_prefix, raw_name);
+    let simple = qualified.rsplit("::").next().unwrap_or("").to_string();
+    let name_range = argv[1].span;
+    let body_range = argv[3].span;
+    let params = parse_param_list(&texts[2]);
+    let param_names: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
+    ctx.result.procs.insert(
+        qualified.clone(),
+        SignatureProc {
+            name: simple,
+            qualified_name: qualified.clone(),
+            params,
+            name_range,
+            body_range,
+        },
+    );
+    let body_ns = match qualified.rsplit_once("::") {
+        Some((parent, _)) => parent.trim_start_matches(':').to_string(),
+        None => String::new(),
+    };
+    ctx.proc_bodies.push(ProcBodyInfo {
+        qname: qualified,
+        params: param_names,
+        body_text: texts[3].clone(),
+        ns_prefix: body_ns,
+    });
+    // TODO(C40c7): scan factory candidates in body when argv[3] is `Str`.
 }
 
 #[cfg(test)]
@@ -110,5 +157,66 @@ mod tests {
             .expect("absolute name preserved");
         assert_eq!(cls.name, "Top");
         assert_eq!(cls.qualified_name, "::Top");
+    }
+
+    fn proc_inputs(name: &str) -> (Vec<String>, Vec<Token>) {
+        let texts = vec![
+            "proc".to_string(),
+            name.to_string(),
+            "a b".to_string(),
+            "set x 1".to_string(),
+        ];
+        let argv = vec![token(0, 4), token(5, 8), token(10, 13), token(15, 22)];
+        (texts, argv)
+    }
+
+    #[test]
+    fn handle_proc_records_bare_proc() {
+        let (texts, argv) = proc_inputs("foo");
+        let mut ctx = ScanCtx::default();
+        handle_proc(&texts, &argv, "", &mut ctx);
+        let proc = ctx.result.procs.get("::foo").expect("inserted");
+        assert_eq!(proc.name, "foo");
+        assert_eq!(proc.qualified_name, "::foo");
+        assert_eq!(proc.params.len(), 2);
+        assert_eq!(proc.params[0].name, "a");
+        assert_eq!(proc.name_range, Span::new(5, 8));
+        assert_eq!(proc.body_range, Span::new(15, 22));
+        assert_eq!(ctx.proc_bodies.len(), 1);
+        assert_eq!(ctx.proc_bodies[0].qname, "::foo");
+        assert_eq!(ctx.proc_bodies[0].body_text, "set x 1");
+        assert_eq!(ctx.proc_bodies[0].ns_prefix, "");
+    }
+
+    #[test]
+    fn handle_proc_under_namespace_indexes_qualified() {
+        let (texts, argv) = proc_inputs("bar");
+        let mut ctx = ScanCtx::default();
+        handle_proc(&texts, &argv, "ns::deep", &mut ctx);
+        let proc = ctx.result.procs.get("::ns::deep::bar").expect("inserted");
+        assert_eq!(proc.name, "bar");
+        assert_eq!(ctx.proc_bodies[0].ns_prefix, "ns::deep");
+    }
+
+    #[test]
+    fn handle_proc_with_absolute_name_records_at_global() {
+        let (texts, argv) = proc_inputs("::top::baz");
+        let mut ctx = ScanCtx::default();
+        handle_proc(&texts, &argv, "outer", &mut ctx);
+        let proc = ctx.result.procs.get("::top::baz").expect("inserted");
+        assert_eq!(proc.name, "baz");
+        assert_eq!(proc.qualified_name, "::top::baz");
+        // body_ns drops the leading colon and trailing simple name.
+        assert_eq!(ctx.proc_bodies[0].ns_prefix, "top");
+    }
+
+    #[test]
+    fn handle_proc_too_few_args_no_op() {
+        let texts = vec!["proc".to_string(), "name".to_string()];
+        let argv = vec![token(0, 4), token(5, 9)];
+        let mut ctx = ScanCtx::default();
+        handle_proc(&texts, &argv, "", &mut ctx);
+        assert!(ctx.result.procs.is_empty());
+        assert!(ctx.proc_bodies.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -125,7 +125,7 @@ pub(super) fn handle_namespace(
     texts: &[String],
     argv: &[Token],
     ns_prefix: &str,
-    _conditional: bool,
+    conditional: bool,
     ctx: &mut ScanCtx,
 ) {
     if texts.len() < 2 {
@@ -141,10 +141,7 @@ pub(super) fn handle_namespace(
         } else {
             raw_ns.clone()
         };
-        // TODO(C40c2): recurse into argv[3] body via maybe_recurse_body
-        // with the computed inner_prefix. For now, suppress the
-        // unused-variable lint.
-        let _ = inner_prefix;
+        super::walker::maybe_recurse_body(&texts[3], argv[3], &inner_prefix, conditional, ctx);
         return;
     }
     if sub == "import" && texts.len() >= 3 {

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -4,8 +4,10 @@
 //! command pieces (head text, per-arg texts, per-arg representative
 //! tokens, surrounding namespace prefix) and mutates a [`ScanCtx`].
 //! Handlers do not recurse into bodies themselves — body recursion
-//! lives in [`super::walker`] and is wired in when the walker sub-strips
-//! land.
+//! lives in [`super::walker`] (`handle_if` / `handle_catch` /
+//! `handle_try` / `maybe_recurse_body`) and the namespace-eval body
+//! recursion lives inside `handle_namespace` here, which calls back
+//! into `walker::maybe_recurse_body`.
 //!
 //! [`ScanCtx`]: super::ctx::ScanCtx
 

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -11,6 +11,10 @@
 
 #![allow(dead_code)]
 
+use tcl_lexer::Token;
+
+use super::types::{SignatureClass, SignatureScanResult};
+
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
 ///
 /// Mirrors `_qualify` in `core/analysis/signature_scan.py`. Absolute
@@ -31,9 +35,41 @@ pub(super) fn qualify(ns_prefix: &str, name: &str) -> String {
     }
 }
 
+/// Insert a class record under `result.classes`, computing the
+/// qualified name + simple-name split.
+///
+/// Mirrors `_emit_class` in `core/analysis/signature_scan.py`.
+/// Shared by `handle_oo_class` and `handle_itcl_class` so both
+/// `oo::class create NAME ?BODY?` and `itcl::class NAME BODY`
+/// produce identically-shaped records.
+pub(super) fn emit_class(
+    raw_name: &str,
+    name_tok: Token,
+    body_tok: Token,
+    ns_prefix: &str,
+    result: &mut SignatureScanResult,
+) {
+    let qualified = qualify(ns_prefix, raw_name);
+    let simple = qualified.rsplit("::").next().unwrap_or("").to_string();
+    result.classes.insert(
+        qualified.clone(),
+        SignatureClass {
+            name: simple,
+            qualified_name: qualified,
+            name_range: name_tok.span,
+            body_range: body_tok.span,
+        },
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tcl_lexer::{Span, TokenType};
+
+    fn token(start: u32, end: u32) -> Token {
+        Token::new(TokenType::Esc, Span::new(start, end))
+    }
 
     #[test]
     fn absolute_name_ignores_prefix() {
@@ -51,5 +87,28 @@ mod tests {
     #[test]
     fn empty_prefix_promotes_to_global() {
         assert_eq!(qualify("", "bar"), "::bar");
+    }
+
+    #[test]
+    fn emit_class_under_namespace_indexes_bare_name() {
+        let mut result = SignatureScanResult::default();
+        emit_class("MyCls", token(10, 15), token(20, 30), "ns", &mut result);
+        let cls = result.classes.get("::ns::MyCls").expect("inserted");
+        assert_eq!(cls.name, "MyCls");
+        assert_eq!(cls.qualified_name, "::ns::MyCls");
+        assert_eq!(cls.name_range, Span::new(10, 15));
+        assert_eq!(cls.body_range, Span::new(20, 30));
+    }
+
+    #[test]
+    fn emit_class_with_absolute_name_preserves_indexing() {
+        let mut result = SignatureScanResult::default();
+        emit_class("::Top", token(0, 5), token(6, 8), "ns", &mut result);
+        let cls = result
+            .classes
+            .get("::Top")
+            .expect("absolute name preserved");
+        assert_eq!(cls.name, "Top");
+        assert_eq!(cls.qualified_name, "::Top");
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -16,8 +16,8 @@ use tcl_lexer::Token;
 use super::ctx::{ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
 use super::types::{
-    SignatureClass, SignatureCommandAlias, SignatureNamespaceImport, SignaturePackageRequire,
-    SignatureProc, SignatureScanResult, SignatureSource,
+    SignatureAutoPathEntry, SignatureClass, SignatureCommandAlias, SignatureNamespaceImport,
+    SignaturePackageRequire, SignatureProc, SignatureScanResult, SignatureSource,
 };
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
@@ -306,6 +306,29 @@ pub(super) fn handle_oo_class(
     }
     let body_tok = if argv.len() > 3 { argv[3] } else { argv[2] };
     emit_class(&texts[2], argv[2], body_tok, ns_prefix, result);
+}
+
+/// Handler for `lappend auto_path …` / `set auto_path …`.
+///
+/// Mirrors `_handle_auto_path` in
+/// `core/analysis/signature_scan.py`. Both forms are accepted; every
+/// word after `auto_path` is recorded as a `SignatureAutoPathEntry`.
+/// Path-resolution to absolute filesystem paths happens later in
+/// the analyser pipeline.
+pub(super) fn handle_auto_path(texts: &[String], argv: &[Token], result: &mut SignatureScanResult) {
+    if texts.len() < 3 || texts[1] != "auto_path" {
+        return;
+    }
+    for i in 2..texts.len() {
+        let raw = &texts[i];
+        if raw.is_empty() {
+            continue;
+        }
+        result.auto_path_entries.push(SignatureAutoPathEntry {
+            raw: raw.clone(),
+            range: argv[i].span,
+        });
+    }
 }
 
 /// Handler for `itcl::class NAME BODY` (or `::itcl::class NAME BODY`).
@@ -679,5 +702,36 @@ mod tests {
         let cls = result.classes.get("::Foo").expect("inserted");
         assert_eq!(cls.name, "Foo");
         assert_eq!(cls.body_range, Span::new(16, 33));
+    }
+
+    #[test]
+    fn handle_auto_path_lappend_form() {
+        let texts = vec![
+            "lappend".to_string(),
+            "auto_path".to_string(),
+            "/usr/local/lib".to_string(),
+            "/opt/foo".to_string(),
+        ];
+        let argv = vec![token(0, 7), token(8, 17), token(18, 32), token(33, 41)];
+        let mut result = SignatureScanResult::default();
+        handle_auto_path(&texts, &argv, &mut result);
+        assert_eq!(result.auto_path_entries.len(), 2);
+        assert_eq!(result.auto_path_entries[0].raw, "/usr/local/lib");
+        assert_eq!(result.auto_path_entries[0].range, Span::new(18, 32));
+        assert_eq!(result.auto_path_entries[1].raw, "/opt/foo");
+    }
+
+    #[test]
+    fn handle_auto_path_set_form() {
+        let texts = vec![
+            "set".to_string(),
+            "auto_path".to_string(),
+            "/var/lib/tcl".to_string(),
+        ];
+        let argv = vec![token(0, 3), token(4, 13), token(14, 26)];
+        let mut result = SignatureScanResult::default();
+        handle_auto_path(&texts, &argv, &mut result);
+        assert_eq!(result.auto_path_entries.len(), 1);
+        assert_eq!(result.auto_path_entries[0].raw, "/var/lib/tcl");
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -9,8 +9,6 @@
 //!
 //! [`ScanCtx`]: super::ctx::ScanCtx
 
-#![allow(dead_code)]
-
 use tcl_lexer::{Token, TokenType};
 
 use super::ctx::{FactoryCandidate, ProcBodyInfo, ScanCtx, FACTORY_SKIP_HEADS};

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -15,7 +15,7 @@ use tcl_lexer::Token;
 
 use super::ctx::{ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
-use super::types::{SignatureClass, SignatureProc, SignatureScanResult};
+use super::types::{SignatureClass, SignatureNamespaceImport, SignatureProc, SignatureScanResult};
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
 ///
@@ -107,6 +107,94 @@ pub(super) fn handle_proc(texts: &[String], argv: &[Token], ns_prefix: &str, ctx
         ns_prefix: body_ns,
     });
     // TODO(C40c7): scan factory candidates in body when argv[3] is `Str`.
+}
+
+/// Handler for the `namespace` command — dispatches on the
+/// subcommand (`eval` vs `import`).
+///
+/// Mirrors `_handle_namespace` in
+/// `core/analysis/signature_scan.py`. The `eval` arm computes the
+/// inner namespace prefix (absolute names rebase via leading `::`,
+/// otherwise nest under the current prefix); body recursion into
+/// the eval body is a stub here and lands in C40c2 once the walker
+/// exists.
+pub(super) fn handle_namespace(
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    _conditional: bool,
+    ctx: &mut ScanCtx,
+) {
+    if texts.len() < 2 {
+        return;
+    }
+    let sub = &texts[1];
+    if sub == "eval" && texts.len() >= 4 {
+        let raw_ns = &texts[2];
+        let inner_prefix = if let Some(rest) = raw_ns.strip_prefix("::") {
+            rest.trim_start_matches(':').to_string()
+        } else if !ns_prefix.is_empty() {
+            format!("{ns_prefix}::{raw_ns}")
+        } else {
+            raw_ns.clone()
+        };
+        // TODO(C40c2): recurse into argv[3] body via maybe_recurse_body
+        // with the computed inner_prefix. For now, suppress the
+        // unused-variable lint.
+        let _ = inner_prefix;
+        return;
+    }
+    if sub == "import" && texts.len() >= 3 {
+        handle_namespace_import(texts, argv, ns_prefix, &mut ctx.result);
+    }
+}
+
+/// Handler for `namespace import ?-force? PATTERN ?PATTERN…?`.
+///
+/// Mirrors `_handle_namespace_import` in
+/// `core/analysis/signature_scan.py`. Records every static pattern;
+/// patterns that still carry a `$` / `[` substitution or that lack
+/// any `::` namespace segment are skipped (we cannot statically
+/// resolve them to a source namespace). Patterns without a leading
+/// `::` are resolved relative to the *current* namespace, mirroring
+/// Tcl's own rule.
+pub(super) fn handle_namespace_import(
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    result: &mut SignatureScanResult,
+) {
+    let importing_ns = if ns_prefix.is_empty() {
+        "::".to_string()
+    } else {
+        format!("::{ns_prefix}")
+    };
+    let mut i = 2;
+    while i < texts.len() {
+        let pattern_raw = &texts[i];
+        if pattern_raw == "-force" {
+            i += 1;
+            continue;
+        }
+        if !pattern_raw.contains("::") || pattern_raw.contains('$') || pattern_raw.contains('[') {
+            i += 1;
+            continue;
+        }
+        let pattern = if pattern_raw.starts_with("::") {
+            pattern_raw.clone()
+        } else if importing_ns == "::" {
+            format!("::{pattern_raw}")
+        } else {
+            format!("{importing_ns}::{pattern_raw}")
+        };
+        result.namespace_imports.push(SignatureNamespaceImport {
+            ns: importing_ns.clone(),
+            pattern,
+            range: argv[i].span,
+            conjectured: false,
+        });
+        i += 1;
+    }
 }
 
 #[cfg(test)]
@@ -218,5 +306,66 @@ mod tests {
         handle_proc(&texts, &argv, "", &mut ctx);
         assert!(ctx.result.procs.is_empty());
         assert!(ctx.proc_bodies.is_empty());
+    }
+
+    #[test]
+    fn handle_namespace_import_absolute_pattern() {
+        let texts = vec![
+            "namespace".to_string(),
+            "import".to_string(),
+            "::foo::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_import(&texts, &argv, "", &mut result);
+        assert_eq!(result.namespace_imports.len(), 1);
+        let imp = &result.namespace_imports[0];
+        assert_eq!(imp.ns, "::");
+        assert_eq!(imp.pattern, "::foo::*");
+        assert!(!imp.conjectured);
+    }
+
+    #[test]
+    fn handle_namespace_import_force_flag_skipped() {
+        let texts = vec![
+            "namespace".to_string(),
+            "import".to_string(),
+            "-force".to_string(),
+            "::foo::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 23), token(24, 32)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_import(&texts, &argv, "", &mut result);
+        assert_eq!(result.namespace_imports.len(), 1);
+        assert_eq!(result.namespace_imports[0].pattern, "::foo::*");
+    }
+
+    #[test]
+    fn handle_namespace_import_relative_under_nested_ns() {
+        let texts = vec![
+            "namespace".to_string(),
+            "import".to_string(),
+            "bar::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 23)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_import(&texts, &argv, "foo", &mut result);
+        assert_eq!(result.namespace_imports.len(), 1);
+        let imp = &result.namespace_imports[0];
+        assert_eq!(imp.ns, "::foo");
+        assert_eq!(imp.pattern, "::foo::bar::*");
+    }
+
+    #[test]
+    fn handle_namespace_import_substituted_pattern_skipped() {
+        let texts = vec![
+            "namespace".to_string(),
+            "import".to_string(),
+            "${ns}::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_import(&texts, &argv, "", &mut result);
+        assert!(result.namespace_imports.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -1,0 +1,55 @@
+//! Per-command handlers used by the `signature_scan` walker.
+//!
+//! Each handler is a small free function that takes the segmented
+//! command pieces (head text, per-arg texts, per-arg representative
+//! tokens, surrounding namespace prefix) and mutates a [`ScanCtx`].
+//! Handlers do not recurse into bodies themselves — body recursion
+//! lives in [`super::walker`] and is wired in when the walker sub-strips
+//! land.
+//!
+//! [`ScanCtx`]: super::ctx::ScanCtx
+
+#![allow(dead_code)]
+
+/// Fully qualify `name` within `ns_prefix` following Tcl scoping.
+///
+/// Mirrors `_qualify` in `core/analysis/signature_scan.py`. Absolute
+/// names (those starting with `::`) ignore the prefix entirely so a
+/// `proc ::foo::bar` declared inside `namespace eval baz` still
+/// indexes as `::foo::bar`.
+///
+/// `ns_prefix` is expected to be the call-site namespace **without**
+/// a leading `::` (the walker carries it that way to match the
+/// Python convention).
+pub(super) fn qualify(ns_prefix: &str, name: &str) -> String {
+    if name.starts_with("::") {
+        name.to_string()
+    } else if ns_prefix.is_empty() {
+        format!("::{name}")
+    } else {
+        format!("::{ns_prefix}::{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_name_ignores_prefix() {
+        assert_eq!(qualify("foo::bar", "::baz"), "::baz");
+        assert_eq!(qualify("", "::top"), "::top");
+        assert_eq!(qualify("nested", "::ns::deep"), "::ns::deep");
+    }
+
+    #[test]
+    fn relative_name_under_nested_ns() {
+        assert_eq!(qualify("foo", "bar"), "::foo::bar");
+        assert_eq!(qualify("foo::baz", "qux"), "::foo::baz::qux");
+    }
+
+    #[test]
+    fn empty_prefix_promotes_to_global() {
+        assert_eq!(qualify("", "bar"), "::bar");
+    }
+}

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -15,7 +15,10 @@ use tcl_lexer::Token;
 
 use super::ctx::{ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
-use super::types::{SignatureClass, SignatureNamespaceImport, SignatureProc, SignatureScanResult};
+use super::types::{
+    SignatureClass, SignatureNamespaceImport, SignaturePackageRequire, SignatureProc,
+    SignatureScanResult,
+};
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
 ///
@@ -197,6 +200,41 @@ pub(super) fn handle_namespace_import(
     }
 }
 
+/// Handler for `package require ?-exact? NAME ?VERSION?`.
+///
+/// Mirrors `_handle_package` in
+/// `core/analysis/signature_scan.py`. Records a
+/// `SignaturePackageRequire`; the optional `-exact` flag is parsed
+/// and skipped (we do not currently distinguish exact from
+/// minimum-version requires); the optional `VERSION` is captured
+/// when present.
+pub(super) fn handle_package(
+    texts: &[String],
+    argv: &[Token],
+    conditional: bool,
+    result: &mut SignatureScanResult,
+) {
+    if texts.len() < 3 || texts[1] != "require" {
+        return;
+    }
+    let mut idx = 2;
+    if texts[idx] == "-exact" && texts.len() > idx + 1 {
+        idx += 1;
+    }
+    let pkg_name = texts[idx].clone();
+    let version = if texts.len() > idx + 1 {
+        Some(texts[idx + 1].clone())
+    } else {
+        None
+    };
+    result.package_requires.push(SignaturePackageRequire {
+        name: pkg_name,
+        version,
+        range: argv[idx].span,
+        conditional,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -367,5 +405,66 @@ mod tests {
         let mut result = SignatureScanResult::default();
         handle_namespace_import(&texts, &argv, "", &mut result);
         assert!(result.namespace_imports.is_empty());
+    }
+
+    #[test]
+    fn handle_package_with_version() {
+        let texts = vec![
+            "package".to_string(),
+            "require".to_string(),
+            "Tcl".to_string(),
+            "8.6".to_string(),
+        ];
+        let argv = vec![token(0, 7), token(8, 15), token(16, 19), token(20, 23)];
+        let mut result = SignatureScanResult::default();
+        handle_package(&texts, &argv, false, &mut result);
+        assert_eq!(result.package_requires.len(), 1);
+        let req = &result.package_requires[0];
+        assert_eq!(req.name, "Tcl");
+        assert_eq!(req.version.as_deref(), Some("8.6"));
+        assert_eq!(req.range, Span::new(16, 19));
+        assert!(!req.conditional);
+    }
+
+    #[test]
+    fn handle_package_without_version() {
+        let texts = vec![
+            "package".to_string(),
+            "require".to_string(),
+            "Tcl".to_string(),
+        ];
+        let argv = vec![token(0, 7), token(8, 15), token(16, 19)];
+        let mut result = SignatureScanResult::default();
+        handle_package(&texts, &argv, true, &mut result);
+        assert_eq!(result.package_requires.len(), 1);
+        let req = &result.package_requires[0];
+        assert_eq!(req.name, "Tcl");
+        assert!(req.version.is_none());
+        assert!(req.conditional);
+    }
+
+    #[test]
+    fn handle_package_with_exact_flag() {
+        let texts = vec![
+            "package".to_string(),
+            "require".to_string(),
+            "-exact".to_string(),
+            "Tcl".to_string(),
+            "8.6".to_string(),
+        ];
+        let argv = vec![
+            token(0, 7),
+            token(8, 15),
+            token(16, 22),
+            token(23, 26),
+            token(27, 30),
+        ];
+        let mut result = SignatureScanResult::default();
+        handle_package(&texts, &argv, false, &mut result);
+        assert_eq!(result.package_requires.len(), 1);
+        let req = &result.package_requires[0];
+        assert_eq!(req.name, "Tcl");
+        assert_eq!(req.version.as_deref(), Some("8.6"));
+        assert_eq!(req.range, Span::new(23, 26));
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -291,6 +291,41 @@ pub(super) fn handle_interp(texts: &[String], result: &mut SignatureScanResult) 
     );
 }
 
+/// Handler for `oo::class create NAME ?BODY?`.
+///
+/// Mirrors `_handle_oo_class` in `core/analysis/signature_scan.py`.
+/// When `BODY` is absent the body span falls back to the name token.
+pub(super) fn handle_oo_class(
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    result: &mut SignatureScanResult,
+) {
+    if texts.len() < 3 || texts[1] != "create" {
+        return;
+    }
+    let body_tok = if argv.len() > 3 { argv[3] } else { argv[2] };
+    emit_class(&texts[2], argv[2], body_tok, ns_prefix, result);
+}
+
+/// Handler for `itcl::class NAME BODY` (or `::itcl::class NAME BODY`).
+///
+/// Mirrors `_handle_itcl_class` in
+/// `core/analysis/signature_scan.py`. Always requires a body
+/// argument — itcl's class statement is not optional like
+/// `oo::class create`.
+pub(super) fn handle_itcl_class(
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    result: &mut SignatureScanResult,
+) {
+    if texts.len() < 3 {
+        return;
+    }
+    emit_class(&texts[1], argv[1], argv[2], ns_prefix, result);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -597,5 +632,52 @@ mod tests {
         let mut result = SignatureScanResult::default();
         handle_interp(&texts, &mut result);
         assert!(result.command_aliases.is_empty());
+    }
+
+    #[test]
+    fn handle_oo_class_with_body() {
+        let texts = vec![
+            "oo::class".to_string(),
+            "create".to_string(),
+            "MyCls".to_string(),
+            "method foo {} {}".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 22), token(23, 39)];
+        let mut result = SignatureScanResult::default();
+        handle_oo_class(&texts, &argv, "ns", &mut result);
+        let cls = result.classes.get("::ns::MyCls").expect("inserted");
+        assert_eq!(cls.name, "MyCls");
+        assert_eq!(cls.body_range, Span::new(23, 39));
+    }
+
+    #[test]
+    fn handle_oo_class_with_absolute_name() {
+        let texts = vec![
+            "oo::class".to_string(),
+            "create".to_string(),
+            "::Top".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 22)];
+        let mut result = SignatureScanResult::default();
+        handle_oo_class(&texts, &argv, "ns", &mut result);
+        let cls = result.classes.get("::Top").expect("absolute preserved");
+        assert_eq!(cls.name, "Top");
+        // Body falls back to the name token when omitted.
+        assert_eq!(cls.body_range, Span::new(17, 22));
+    }
+
+    #[test]
+    fn handle_itcl_class_records_class() {
+        let texts = vec![
+            "itcl::class".to_string(),
+            "Foo".to_string(),
+            "constructor {} {}".to_string(),
+        ];
+        let argv = vec![token(0, 11), token(12, 15), token(16, 33)];
+        let mut result = SignatureScanResult::default();
+        handle_itcl_class(&texts, &argv, "", &mut result);
+        let cls = result.classes.get("::Foo").expect("inserted");
+        assert_eq!(cls.name, "Foo");
+        assert_eq!(cls.body_range, Span::new(16, 33));
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -17,7 +17,7 @@ use super::ctx::{ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
 use super::types::{
     SignatureClass, SignatureNamespaceImport, SignaturePackageRequire, SignatureProc,
-    SignatureScanResult,
+    SignatureScanResult, SignatureSource,
 };
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
@@ -235,6 +235,34 @@ pub(super) fn handle_package(
     });
 }
 
+/// Handler for `source ?-encoding ENC? PATH`.
+///
+/// Mirrors `_handle_source` in `core/analysis/signature_scan.py`.
+/// Walks past every leading `-FLAG` (consuming a follow-up word for
+/// `-encoding`); the remaining word is recorded as the path. The
+/// `is_literal` flag is set when the segmenter-reconstructed word
+/// contains no `$` or `[` substitution markers.
+pub(super) fn handle_source(texts: &[String], argv: &[Token], result: &mut SignatureScanResult) {
+    let mut idx = 1;
+    while idx < texts.len() && texts[idx].starts_with('-') {
+        if texts[idx] == "-encoding" && idx + 1 < texts.len() {
+            idx += 2;
+        } else {
+            idx += 1;
+        }
+    }
+    if idx >= texts.len() {
+        return;
+    }
+    let raw = texts[idx].clone();
+    let is_literal = !raw.contains('$') && !raw.contains('[');
+    result.source_targets.push(SignatureSource {
+        raw_path: raw,
+        range: argv[idx].span,
+        is_literal,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -441,6 +469,47 @@ mod tests {
         assert_eq!(req.name, "Tcl");
         assert!(req.version.is_none());
         assert!(req.conditional);
+    }
+
+    #[test]
+    fn handle_source_literal_path() {
+        let texts = vec!["source".to_string(), "/abs/path.tcl".to_string()];
+        let argv = vec![token(0, 6), token(7, 20)];
+        let mut result = SignatureScanResult::default();
+        handle_source(&texts, &argv, &mut result);
+        assert_eq!(result.source_targets.len(), 1);
+        let st = &result.source_targets[0];
+        assert_eq!(st.raw_path, "/abs/path.tcl");
+        assert!(st.is_literal);
+        assert_eq!(st.range, Span::new(7, 20));
+    }
+
+    #[test]
+    fn handle_source_substituted_path() {
+        let texts = vec!["source".to_string(), "${dir}/x.tcl".to_string()];
+        let argv = vec![token(0, 6), token(7, 19)];
+        let mut result = SignatureScanResult::default();
+        handle_source(&texts, &argv, &mut result);
+        assert_eq!(result.source_targets.len(), 1);
+        assert!(!result.source_targets[0].is_literal);
+    }
+
+    #[test]
+    fn handle_source_skips_encoding_option() {
+        let texts = vec![
+            "source".to_string(),
+            "-encoding".to_string(),
+            "utf-8".to_string(),
+            "/abs/path.tcl".to_string(),
+        ];
+        let argv = vec![token(0, 6), token(7, 16), token(17, 22), token(23, 36)];
+        let mut result = SignatureScanResult::default();
+        handle_source(&texts, &argv, &mut result);
+        assert_eq!(result.source_targets.len(), 1);
+        let st = &result.source_targets[0];
+        assert_eq!(st.raw_path, "/abs/path.tcl");
+        assert!(st.is_literal);
+        assert_eq!(st.range, Span::new(23, 36));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -11,9 +11,9 @@
 
 #![allow(dead_code)]
 
-use tcl_lexer::Token;
+use tcl_lexer::{Token, TokenType};
 
-use super::ctx::{ProcBodyInfo, ScanCtx};
+use super::ctx::{FactoryCandidate, ProcBodyInfo, ScanCtx, FACTORY_SKIP_HEADS};
 use super::params::parse_param_list;
 use super::types::{
     SignatureAutoPathEntry, SignatureClass, SignatureCommandAlias, SignatureNamespaceImport,
@@ -308,6 +308,47 @@ pub(super) fn handle_oo_class(
     emit_class(&texts[2], argv[2], body_tok, ns_prefix, result);
 }
 
+/// Record a potential factory-wrapper call for post-scan resolution.
+///
+/// Mirrors `_maybe_record_factory_candidate` in
+/// `core/analysis/signature_scan.py`. A tcllib-style factory call
+/// has the shape `HEAD NAME ARGS BODY` (four tokens total, last
+/// braced). HEADs in [`FACTORY_SKIP_HEADS`] are built-ins that
+/// happen to match the same shape; they are skipped. Names with
+/// `$` / `[` substitution markers cannot be statically resolved
+/// and are skipped. The body must be a `Str` token (braced
+/// literal); unbraced bodies cannot be re-scanned for the
+/// `proc $a $b $c` shape that confirms a real factory.
+pub(super) fn maybe_record_factory_candidate(
+    head: &str,
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    ctx: &mut ScanCtx,
+) {
+    if texts.len() != 4 {
+        return;
+    }
+    if FACTORY_SKIP_HEADS.contains(&head) {
+        return;
+    }
+    let name = &texts[1];
+    if name.is_empty() || name.contains('$') || name.contains('[') {
+        return;
+    }
+    let body_tok = argv[3];
+    if body_tok.kind != TokenType::Str {
+        return;
+    }
+    ctx.candidates.push(FactoryCandidate {
+        head: head.to_string(),
+        name: name.clone(),
+        name_tok: argv[1],
+        body_tok,
+        ns_prefix: ns_prefix.to_string(),
+    });
+}
+
 /// Recognise the tcllib `<NS>::import <ALIAS>` wrapper idiom and
 /// emit a conjectural `namespace import` record.
 ///
@@ -407,6 +448,10 @@ mod tests {
 
     fn token(start: u32, end: u32) -> Token {
         Token::new(TokenType::Esc, Span::new(start, end))
+    }
+
+    fn str_token(start: u32, end: u32) -> Token {
+        Token::with_content_offset(TokenType::Str, Span::new(start, end), 1)
     }
 
     #[test]
@@ -820,5 +865,62 @@ mod tests {
         let mut result = SignatureScanResult::default();
         maybe_handle_import_wrapper("foo::import", &texts, &argv, "", &mut result);
         assert!(result.namespace_imports.is_empty());
+    }
+
+    #[test]
+    fn factory_candidate_happy_path() {
+        let texts = vec![
+            "DEFC".to_string(),
+            "foo".to_string(),
+            "args".to_string(),
+            "body".to_string(),
+        ];
+        let argv = vec![token(0, 4), token(5, 8), token(9, 13), str_token(14, 20)];
+        let mut ctx = ScanCtx::default();
+        maybe_record_factory_candidate("DEFC", &texts, &argv, "ns", &mut ctx);
+        assert_eq!(ctx.candidates.len(), 1);
+    }
+
+    #[test]
+    fn factory_candidate_skip_head_filtered() {
+        let texts = vec![
+            "proc".to_string(),
+            "foo".to_string(),
+            "args".to_string(),
+            "body".to_string(),
+        ];
+        let argv = vec![token(0, 4), token(5, 8), token(9, 13), str_token(14, 20)];
+        let mut ctx = ScanCtx::default();
+        maybe_record_factory_candidate("proc", &texts, &argv, "", &mut ctx);
+        assert!(ctx.candidates.is_empty());
+    }
+
+    #[test]
+    fn factory_candidate_dynamic_name_skipped() {
+        let texts = vec![
+            "DEFC".to_string(),
+            "${name}".to_string(),
+            "args".to_string(),
+            "body".to_string(),
+        ];
+        let argv = vec![token(0, 4), token(5, 12), token(13, 17), str_token(18, 24)];
+        let mut ctx = ScanCtx::default();
+        maybe_record_factory_candidate("DEFC", &texts, &argv, "", &mut ctx);
+        assert!(ctx.candidates.is_empty());
+    }
+
+    #[test]
+    fn factory_candidate_unbraced_body_skipped() {
+        let texts = vec![
+            "DEFC".to_string(),
+            "foo".to_string(),
+            "args".to_string(),
+            "body".to_string(),
+        ];
+        // body argv[3] is plain ESC, not Str (not braced) — should skip.
+        let argv = vec![token(0, 4), token(5, 8), token(9, 13), token(14, 20)];
+        let mut ctx = ScanCtx::default();
+        maybe_record_factory_candidate("DEFC", &texts, &argv, "", &mut ctx);
+        assert!(ctx.candidates.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -103,13 +103,19 @@ pub(super) fn handle_proc(texts: &[String], argv: &[Token], ns_prefix: &str, ctx
         Some((parent, _)) => parent.trim_start_matches(':').to_string(),
         None => String::new(),
     };
+    let body_text = texts[3].clone();
     ctx.proc_bodies.push(ProcBodyInfo {
         qname: qualified,
         params: param_names,
-        body_text: texts[3].clone(),
-        ns_prefix: body_ns,
+        body_text: body_text.clone(),
+        ns_prefix: body_ns.clone(),
     });
-    // TODO(C40c7): scan factory candidates in body when argv[3] is `Str`.
+    // Walk the proc body for factory-wrapper candidate calls.
+    // Only braced bodies can be statically scanned; substituted
+    // bodies (`$body`, `[gen_body]`) cannot be re-segmented.
+    if argv[3].kind == TokenType::Str {
+        super::walker::scan_factory_candidates(&body_text, argv[3], &body_ns, ctx);
+    }
 }
 
 /// Handler for the `namespace` command — dispatches on the
@@ -449,6 +455,40 @@ mod tests {
 
     fn str_token(start: u32, end: u32) -> Token {
         Token::with_content_offset(TokenType::Str, Span::new(start, end), 1)
+    }
+
+    #[test]
+    fn handle_proc_with_braced_body_scans_factory_candidates() {
+        // Direct call into handle_proc with a synthetic INIT-proc
+        // shape: body is `DEFC bar args {body}` which should
+        // register one factory candidate.
+        let body_text = "DEFC bar args {body}";
+        let texts = vec![
+            "proc".to_string(),
+            "INIT".to_string(),
+            String::new(),
+            body_text.to_string(),
+        ];
+        let argv = vec![token(0, 4), token(5, 9), token(10, 12), str_token(13, 35)];
+        let mut ctx = ScanCtx::default();
+        handle_proc(&texts, &argv, "", &mut ctx);
+        assert_eq!(ctx.candidates.len(), 1);
+    }
+
+    #[test]
+    fn handle_proc_with_unbraced_body_does_not_scan() {
+        let texts = vec![
+            "proc".to_string(),
+            "INIT".to_string(),
+            String::new(),
+            "${dynamic}".to_string(),
+        ];
+        // Body is plain Esc (not Str), so factory walker should be
+        // skipped.
+        let argv = vec![token(0, 4), token(5, 9), token(10, 12), token(13, 23)];
+        let mut ctx = ScanCtx::default();
+        handle_proc(&texts, &argv, "", &mut ctx);
+        assert!(ctx.candidates.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -16,8 +16,8 @@ use tcl_lexer::Token;
 use super::ctx::{ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
 use super::types::{
-    SignatureClass, SignatureNamespaceImport, SignaturePackageRequire, SignatureProc,
-    SignatureScanResult, SignatureSource,
+    SignatureClass, SignatureCommandAlias, SignatureNamespaceImport, SignaturePackageRequire,
+    SignatureProc, SignatureScanResult, SignatureSource,
 };
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
@@ -261,6 +261,34 @@ pub(super) fn handle_source(texts: &[String], argv: &[Token], result: &mut Signa
         range: argv[idx].span,
         is_literal,
     });
+}
+
+/// Handler for `interp alias SLAVE-PATH NAME TARGET-PATH TARGET ?ARG…?`.
+///
+/// Mirrors `_handle_interp` in `core/analysis/signature_scan.py`.
+/// Records only **local-interpreter** aliases (slave path and
+/// target path both empty `{}`); cross-interpreter aliases install
+/// commands inside child interpreters and are not visible to
+/// workspace command resolution, so they are skipped.
+pub(super) fn handle_interp(texts: &[String], result: &mut SignatureScanResult) {
+    if texts.len() < 6 || texts[1] != "alias" {
+        return;
+    }
+    if texts[2] != *"" || texts[4] != *"" {
+        return;
+    }
+    let alias_name = texts[3].clone();
+    let target = texts[5].clone();
+    let extras: Vec<String> = texts.iter().skip(6).cloned().collect();
+    let qualified = qualify("", &alias_name);
+    result.command_aliases.insert(
+        qualified.clone(),
+        SignatureCommandAlias {
+            qualified_name: qualified,
+            target,
+            extras,
+        },
+    );
 }
 
 #[cfg(test)]
@@ -535,5 +563,39 @@ mod tests {
         assert_eq!(req.name, "Tcl");
         assert_eq!(req.version.as_deref(), Some("8.6"));
         assert_eq!(req.range, Span::new(23, 26));
+    }
+
+    #[test]
+    fn handle_interp_local_alias_emitted() {
+        let texts = vec![
+            "interp".to_string(),
+            "alias".to_string(),
+            String::new(),
+            "myalias".to_string(),
+            String::new(),
+            "puts".to_string(),
+            "hello".to_string(),
+        ];
+        let mut result = SignatureScanResult::default();
+        handle_interp(&texts, &mut result);
+        assert_eq!(result.command_aliases.len(), 1);
+        let alias = result.command_aliases.get("::myalias").expect("inserted");
+        assert_eq!(alias.target, "puts");
+        assert_eq!(alias.extras, ["hello".to_string()]);
+    }
+
+    #[test]
+    fn handle_interp_cross_interp_alias_skipped() {
+        let texts = vec![
+            "interp".to_string(),
+            "alias".to_string(),
+            "child".to_string(),
+            "foo".to_string(),
+            String::new(),
+            "puts".to_string(),
+        ];
+        let mut result = SignatureScanResult::default();
+        handle_interp(&texts, &mut result);
+        assert!(result.command_aliases.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -277,7 +277,7 @@ pub(super) fn handle_interp(texts: &[String], result: &mut SignatureScanResult) 
     if texts.len() < 6 || texts[1] != "alias" {
         return;
     }
-    if texts[2] != *"" || texts[4] != *"" {
+    if !texts[2].is_empty() || !texts[4].is_empty() {
         return;
     }
     let alias_name = texts[3].clone();

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -308,6 +308,57 @@ pub(super) fn handle_oo_class(
     emit_class(&texts[2], argv[2], body_tok, ns_prefix, result);
 }
 
+/// Recognise the tcllib `<NS>::import <ALIAS>` wrapper idiom and
+/// emit a conjectural `namespace import` record.
+///
+/// Mirrors `_maybe_handle_import_wrapper` in
+/// `core/analysis/signature_scan.py`. Statically detecting all
+/// such wrappers from their bodies is out of scope, but the *call*
+/// is unambiguous: head ends with `::import`, single argument, no
+/// substitution markers in the alias. The conjectured import is
+/// recorded with `conjectured = true` so consumers can weight it
+/// less heavily.
+pub(super) fn maybe_handle_import_wrapper(
+    head: &str,
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    result: &mut SignatureScanResult,
+) {
+    if !head.ends_with("::import") {
+        return;
+    }
+    if texts.len() < 2 {
+        return;
+    }
+    let alias = &texts[1];
+    if alias.is_empty() || alias.contains('$') || alias.contains('[') {
+        return;
+    }
+    if texts.len() > 2 {
+        return;
+    }
+    let source_ns_raw = &head[..head.len() - "::import".len()];
+    let source_ns = if source_ns_raw.starts_with("::") {
+        source_ns_raw.to_string()
+    } else {
+        format!("::{source_ns_raw}")
+    };
+    let alias_ns = if alias.starts_with("::") {
+        alias.clone()
+    } else if !ns_prefix.is_empty() {
+        format!("::{ns_prefix}::{alias}")
+    } else {
+        format!("::{alias}")
+    };
+    result.namespace_imports.push(SignatureNamespaceImport {
+        ns: alias_ns,
+        pattern: format!("{source_ns}::*"),
+        range: argv[0].span,
+        conjectured: true,
+    });
+}
+
 /// Handler for `lappend auto_path …` / `set auto_path …`.
 ///
 /// Mirrors `_handle_auto_path` in
@@ -733,5 +784,41 @@ mod tests {
         handle_auto_path(&texts, &argv, &mut result);
         assert_eq!(result.auto_path_entries.len(), 1);
         assert_eq!(result.auto_path_entries[0].raw, "/var/lib/tcl");
+    }
+
+    #[test]
+    fn maybe_import_wrapper_happy_path() {
+        let texts = vec!["term::ansi::send::import".to_string(), "vt".to_string()];
+        let argv = vec![token(0, 24), token(25, 27)];
+        let mut result = SignatureScanResult::default();
+        maybe_handle_import_wrapper("term::ansi::send::import", &texts, &argv, "", &mut result);
+        assert_eq!(result.namespace_imports.len(), 1);
+        let imp = &result.namespace_imports[0];
+        assert_eq!(imp.ns, "::vt");
+        assert_eq!(imp.pattern, "::term::ansi::send::*");
+        assert!(imp.conjectured);
+        assert_eq!(imp.range, Span::new(0, 24));
+    }
+
+    #[test]
+    fn maybe_import_wrapper_multi_arg_rejected() {
+        let texts = vec![
+            "foo::import".to_string(),
+            "vt".to_string(),
+            "extra".to_string(),
+        ];
+        let argv = vec![token(0, 11), token(12, 14), token(15, 20)];
+        let mut result = SignatureScanResult::default();
+        maybe_handle_import_wrapper("foo::import", &texts, &argv, "", &mut result);
+        assert!(result.namespace_imports.is_empty());
+    }
+
+    #[test]
+    fn maybe_import_wrapper_dynamic_alias_rejected() {
+        let texts = vec!["foo::import".to_string(), "${dyn}".to_string()];
+        let argv = vec![token(0, 11), token(12, 18)];
+        let mut result = SignatureScanResult::default();
+        maybe_handle_import_wrapper("foo::import", &texts, &argv, "", &mut result);
+        assert!(result.namespace_imports.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -1,0 +1,24 @@
+//! Signature-only scan for background-indexed Tcl files.
+//!
+//! Port of `core/analysis/signature_scan.py` (chunk **C40**). Walks
+//! the segmented command stream of a Tcl source and extracts a
+//! lightweight [`SignatureScanResult`] subset — proc / class
+//! definitions, package requires, source targets, command aliases,
+//! namespace imports, auto-path entries, and a flat command-invocation
+//! list — without running the full analyser pipeline.
+//!
+//! Used by cross-file LSP features (workspace symbols, `package
+//! require` resolution, command-usage counts) on every non-OPEN
+//! document; the full analyser still runs on `didOpen` /
+//! `didChange` so OPEN files are unaffected.
+//!
+//! The walker stays at the segmenter level (not the IR level) — the
+//! whole point of this module is to be fast for background-indexed
+//! files, so it deliberately avoids the lowering pass.
+//!
+//! Submodules are filled in by the C40 sub-strips (`C40a*` types,
+//! `C40b*` per-command handlers, `C40c*` walker, `C40d*` factory
+//! resolution + entry point, `C40e*` `PyO3` binding + Python shim +
+//! differential harness).
+
+// Submodules land in subsequent C40 strips.

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -25,3 +25,4 @@ mod ctx;
 mod handlers;
 pub mod params;
 pub mod types;
+mod walker;

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -21,5 +21,6 @@
 //! resolution + entry point, `C40e*` `PyO3` binding + Python shim +
 //! differential harness).
 
+mod ctx;
 pub mod params;
 pub mod types;

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -22,5 +22,6 @@
 //! differential harness).
 
 mod ctx;
+mod handlers;
 pub mod params;
 pub mod types;

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -21,4 +21,5 @@
 //! resolution + entry point, `C40e*` `PyO3` binding + Python shim +
 //! differential harness).
 
-// Submodules land in subsequent C40 strips.
+pub mod params;
+pub mod types;

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -16,10 +16,25 @@
 //! whole point of this module is to be fast for background-indexed
 //! files, so it deliberately avoids the lowering pass.
 //!
-//! Submodules are filled in by the C40 sub-strips (`C40a*` types,
-//! `C40b*` per-command handlers, `C40c*` walker, `C40d*` factory
-//! resolution + entry point, `C40e*` `PyO3` binding + Python shim +
-//! differential harness).
+//! Module layout:
+//!
+//! - [`types`] — public record types ([`SignatureScanResult`] +
+//!   per-collection records) plus [`ParamDef`].
+//! - [`params`] — `parse_param_list` for the proc parameter-list arg.
+//! - `ctx` (private) — internal scan state ([`ScanCtx`],
+//!   `FactoryCandidate`, `ProcBodyInfo`, `FACTORY_SKIP_HEADS`).
+//! - `handlers` (private) — per-command handlers
+//!   (`handle_proc`, `handle_namespace`, `handle_package`, …).
+//! - `walker` (private) — top-level `scan` plus the body-recursion
+//!   helpers (`maybe_recurse_body`, `handle_if` / `handle_catch` /
+//!   `handle_try`) and the factory-body sub-walker
+//!   (`scan_factory_candidates` / `scan_factory_structural`).
+//! - `factory` (private) — second-pass factory-wrapper resolver
+//!   (`is_factory_body`, `lookup_factory`, `resolve_factory_defs`).
+//!
+//! The public entry point is [`extract_signatures`].
+//!
+//! [`ParamDef`]: types::ParamDef
 
 mod ctx;
 mod factory;

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -22,6 +22,7 @@
 //! differential harness).
 
 mod ctx;
+mod factory;
 mod handlers;
 pub mod params;
 pub mod types;

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -27,3 +27,96 @@ mod handlers;
 pub mod params;
 pub mod types;
 mod walker;
+
+use tcl_registry::CommandRegistry;
+
+use ctx::ScanCtx;
+pub use types::SignatureScanResult;
+
+/// Extract a lightweight [`SignatureScanResult`] for a Tcl source.
+///
+/// The public entry point for the signature scanner. Mirrors
+/// `extract_signatures` in `core/analysis/signature_scan.py` —
+/// runs the main walker, then resolves factory-wrapper synthetic
+/// procs.
+///
+/// The `_registry` parameter is plumbed through but not currently
+/// consulted; it matches every other tcl-compiler analysis entry
+/// point's signature so future heuristics that need command-spec
+/// metadata can read it without an API change.
+#[must_use]
+pub fn extract_signatures(source: &str, _registry: &CommandRegistry) -> SignatureScanResult {
+    let mut ctx = ScanCtx::default();
+    walker::scan(source, None, "", false, &mut ctx);
+    factory::resolve_factory_defs(&mut ctx);
+    ctx.result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(src: &str) -> SignatureScanResult {
+        let registry = CommandRegistry::build_default();
+        extract_signatures(src, &registry)
+    }
+
+    #[test]
+    fn proc_only() {
+        let r = run("proc foo {} {}");
+        assert!(r.procs.contains_key("::foo"));
+        assert!(r.classes.is_empty());
+        assert_eq!(r.command_invocations.len(), 1);
+    }
+
+    #[test]
+    fn class_only() {
+        let r = run("oo::class create MyCls { method foo {} {} }");
+        assert!(r.classes.contains_key("::MyCls"));
+        assert!(r.procs.is_empty());
+    }
+
+    #[test]
+    fn namespace_eval_with_inner_proc() {
+        let r = run("namespace eval ns { proc inner {} {} }");
+        assert!(r.procs.contains_key("::ns::inner"));
+    }
+
+    #[test]
+    fn package_require_and_source() {
+        let r = run("package require Tcl 8.6\nsource /a/b.tcl");
+        assert_eq!(r.package_requires.len(), 1);
+        assert_eq!(r.package_requires[0].name, "Tcl");
+        assert_eq!(r.source_targets.len(), 1);
+        assert!(r.source_targets[0].is_literal);
+    }
+
+    #[test]
+    fn interp_alias_local_recorded() {
+        let r = run("interp alias {} myalias {} puts hello");
+        assert!(r.command_aliases.contains_key("::myalias"));
+    }
+
+    #[test]
+    fn tcllib_factory_wrapper_emits_synthetic_proc() {
+        let src = "
+            proc DEFC {name args body} {
+                proc $name $args $body
+            }
+            proc INIT {} {
+                DEFC ChildA {x} {return 1}
+                DEFC ChildB {y} {return 2}
+            }
+        ";
+        let r = run(src);
+        // The wrapper itself + the INIT proc are real.
+        assert!(r.procs.contains_key("::DEFC"));
+        assert!(r.procs.contains_key("::INIT"));
+        // Synthetic factory-emitted procs should be present too.
+        assert!(r.procs.contains_key("::ChildA"));
+        assert!(r.procs.contains_key("::ChildB"));
+        // Synthetic procs have empty params (per-call arg map is
+        // not statically known).
+        assert!(r.procs["::ChildA"].params.is_empty());
+    }
+}

--- a/rust/tcl-compiler/src/signature_scan/params.rs
+++ b/rust/tcl-compiler/src/signature_scan/params.rs
@@ -1,0 +1,172 @@
+//! Parameter-list parser for Tcl proc declarations.
+//!
+//! Port of `parse_param_list` in
+//! `core/analysis/_analyser/_utils.py`. Splits a parameter-list
+//! string (the literal `args` argument to `proc`) into [`ParamDef`]
+//! records, recognising the bare-word and `{name default}` forms.
+
+use super::types::ParamDef;
+
+/// Parse a Tcl proc argument list string into [`ParamDef`] records.
+///
+/// Handles both bare-word (`a b c`) and braced-with-default
+/// (`{name default}`) forms. The input is the verbatim text of the
+/// proc's parameter argument; outer whitespace is tolerated.
+///
+/// ```
+/// use tcl_compiler::signature_scan::params::parse_param_list;
+/// let params = parse_param_list("a {b 1} c");
+/// assert_eq!(params.len(), 3);
+/// assert_eq!(params[1].name, "b");
+/// assert_eq!(params[1].default_value.as_deref(), Some("1"));
+/// ```
+#[must_use]
+pub fn parse_param_list(param_str: &str) -> Vec<ParamDef> {
+    let mut params: Vec<ParamDef> = Vec::new();
+    let text = param_str.trim();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        while i < bytes.len() && is_whitespace_byte(bytes[i]) {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        if bytes[i] == b'{' {
+            let mut level: u32 = 1;
+            i += 1;
+            let start = i;
+            while i < bytes.len() && level > 0 {
+                match bytes[i] {
+                    b'{' => level += 1,
+                    b'}' => level -= 1,
+                    _ => {}
+                }
+                i += 1;
+            }
+            // `i` now points one past the matching '}' (or end-of-input
+            // for an unbalanced brace, which we tolerate by treating
+            // the entire remainder as the inner text).
+            let inner_end = if level == 0 { i - 1 } else { i };
+            let inner = text[start..inner_end].trim();
+            if inner.is_empty() {
+                continue;
+            }
+            if let Some((name, default)) = split_first_whitespace(inner) {
+                params.push(ParamDef {
+                    name: name.to_string(),
+                    has_default: true,
+                    default_value: Some(default.to_string()),
+                });
+            } else {
+                params.push(ParamDef {
+                    name: inner.to_string(),
+                    has_default: false,
+                    default_value: None,
+                });
+            }
+        } else {
+            let start = i;
+            while i < bytes.len() && !is_whitespace_byte(bytes[i]) {
+                i += 1;
+            }
+            let word = &text[start..i];
+            if !word.is_empty() {
+                params.push(ParamDef {
+                    name: word.to_string(),
+                    has_default: false,
+                    default_value: None,
+                });
+            }
+        }
+    }
+    params
+}
+
+#[inline]
+fn is_whitespace_byte(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+/// Split on the first run of whitespace, mirroring Python's
+/// `str.split(None, 1)`. Returns `None` when the input contains no
+/// whitespace.
+fn split_first_whitespace(s: &str) -> Option<(&str, &str)> {
+    let bytes = s.as_bytes();
+    let split_at = bytes.iter().position(|b| is_whitespace_byte(*b))?;
+    let name = &s[..split_at];
+    let rest = s[split_at..].trim_start();
+    Some((name, rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_yields_no_params() {
+        assert!(parse_param_list("").is_empty());
+        assert!(parse_param_list("   \t\n  ").is_empty());
+    }
+
+    #[test]
+    fn three_bare_names() {
+        let params = parse_param_list("a b c");
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0].name, "a");
+        assert!(!params[0].has_default);
+        assert_eq!(params[1].name, "b");
+        assert_eq!(params[2].name, "c");
+        assert!(params.iter().all(|p| p.default_value.is_none()));
+    }
+
+    #[test]
+    fn braced_with_default() {
+        let params = parse_param_list("{a default}");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "a");
+        assert!(params[0].has_default);
+        assert_eq!(params[0].default_value.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn braced_single_element_no_default() {
+        let params = parse_param_list("{a}");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "a");
+        assert!(!params[0].has_default);
+        assert!(params[0].default_value.is_none());
+    }
+
+    #[test]
+    fn mixed_bare_and_braced_default() {
+        let params = parse_param_list("a {b 1} c");
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0].name, "a");
+        assert!(!params[0].has_default);
+        assert_eq!(params[1].name, "b");
+        assert!(params[1].has_default);
+        assert_eq!(params[1].default_value.as_deref(), Some("1"));
+        assert_eq!(params[2].name, "c");
+        assert!(!params[2].has_default);
+    }
+
+    #[test]
+    fn whitespace_padding_tolerated() {
+        let params = parse_param_list("  a   b  ");
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].name, "a");
+        assert_eq!(params[1].name, "b");
+    }
+
+    #[test]
+    fn default_value_preserves_internal_whitespace() {
+        let params = parse_param_list("{name default with spaces}");
+        assert_eq!(params.len(), 1);
+        assert_eq!(
+            params[0].default_value.as_deref(),
+            Some("default with spaces")
+        );
+    }
+}

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -100,3 +100,53 @@ pub struct SignatureSource {
     /// `true` when the path is a plain literal (no `$` or `[`).
     pub is_literal: bool,
 }
+
+/// A local-interpreter `interp alias` recorded by the signature scanner.
+///
+/// Only the form `interp alias {} ALIAS {} TARGET ?ARG…?` (both
+/// slave and target paths empty) is recorded — cross-interpreter
+/// aliases do not affect command resolution in the current
+/// workspace and are skipped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureCommandAlias {
+    /// Fully-qualified alias name (the `ALIAS` argument with leading
+    /// `::` applied).
+    pub qualified_name: String,
+    /// The target command name (the `TARGET` argument).
+    pub target: String,
+    /// The optional pre-bound arguments appended after `TARGET`.
+    pub extras: Vec<String>,
+}
+
+/// A `namespace import` recorded by the signature scanner.
+///
+/// Records both direct `namespace import PATTERN` calls and the
+/// tcllib `<NS>::import <ALIAS>` wrapper idiom. The latter sets
+/// `conjectured` to `true`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureNamespaceImport {
+    /// Importing namespace, with leading `::`.
+    pub ns: String,
+    /// Imported pattern, fully-qualified (relative patterns are
+    /// resolved against `ns`).
+    pub pattern: String,
+    /// Source span of the pattern argument.
+    pub range: Span,
+    /// `true` when the import is inferred from a tcllib-style
+    /// `<NS>::import <ALIAS>` call rather than a direct `namespace
+    /// import` invocation.
+    pub conjectured: bool,
+}
+
+/// An `auto_path` mutation recorded by the signature scanner.
+///
+/// Covers both `lappend auto_path …` and `set auto_path …` forms.
+/// Each path element gets one record; resolution to absolute paths
+/// happens later in the analyser pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureAutoPathEntry {
+    /// Verbatim path-element text as reconstructed by the segmenter.
+    pub raw: String,
+    /// Source span of the path-element argument.
+    pub range: Span,
+}

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -1,0 +1,23 @@
+//! Public record types emitted by the signature scanner.
+//!
+//! Mirrors the subset of `core.analysis.semantic_model` populated by
+//! `signature_scan.py`. The remaining record types and the
+//! [`SignatureScanResult`] aggregator are added by later C40 sub-strips.
+//!
+//! [`SignatureScanResult`]: super::types::SignatureScanResult
+
+/// A single Tcl proc parameter declaration.
+///
+/// Mirrors `core.analysis.semantic_model.ParamDef`. The `default_value`
+/// is the literal text following the parameter name inside a braced
+/// `{name default}` form — whitespace before it is stripped, whitespace
+/// inside the default text is preserved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamDef {
+    /// Parameter name as written in the proc declaration.
+    pub name: String,
+    /// `true` when the parameter has a default value.
+    pub has_default: bool,
+    /// The default-value text when [`Self::has_default`] is `true`.
+    pub default_value: Option<String>,
+}

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -6,6 +6,8 @@
 //!
 //! [`SignatureScanResult`]: super::types::SignatureScanResult
 
+use std::collections::BTreeMap;
+
 use tcl_lexer::Span;
 
 /// A single Tcl proc parameter declaration.
@@ -149,4 +151,50 @@ pub struct SignatureAutoPathEntry {
     pub raw: String,
     /// Source span of the path-element argument.
     pub range: Span,
+}
+
+/// A single command invocation recorded by the signature scanner.
+///
+/// One record per command in the source — populated for every
+/// non-partial command the walker visits. Used by
+/// `WorkspaceIndex.command_usage_counts()` so background-scanned
+/// files still contribute to cross-file command-usage statistics.
+/// `resolved_qualified_name` is intentionally omitted (the full scope
+/// walk required to resolve it is what `signature_scan` skips for
+/// background files).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureCommandInvocation {
+    /// Command head as written at the call site (no namespace
+    /// resolution performed).
+    pub name: String,
+    /// Source span of the command-head token.
+    pub range: Span,
+}
+
+/// The full result returned by `extract_signatures`.
+///
+/// Mirrors the subset of `core.analysis.semantic_model.AnalysisResult`
+/// that `signature_scan.py` populates. Procs / classes / aliases
+/// use `BTreeMap` keyed by qualified name so iteration is
+/// deterministic — important for differential parity testing against
+/// the Python implementation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SignatureScanResult {
+    /// Every proc definition discovered, keyed by qualified name.
+    pub procs: BTreeMap<String, SignatureProc>,
+    /// Every class definition discovered, keyed by qualified name.
+    pub classes: BTreeMap<String, SignatureClass>,
+    /// Every `package require` invocation.
+    pub package_requires: Vec<SignaturePackageRequire>,
+    /// Every `source` invocation.
+    pub source_targets: Vec<SignatureSource>,
+    /// Every local-interpreter `interp alias`, keyed by alias
+    /// qualified name.
+    pub command_aliases: BTreeMap<String, SignatureCommandAlias>,
+    /// Every recorded `namespace import` (direct + conjectured).
+    pub namespace_imports: Vec<SignatureNamespaceImport>,
+    /// Every `auto_path` mutation (one record per path element).
+    pub auto_path_entries: Vec<SignatureAutoPathEntry>,
+    /// Every command invocation visited (lightweight: name + range).
+    pub command_invocations: Vec<SignatureCommandInvocation>,
 }

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -62,3 +62,41 @@ pub struct SignatureClass {
     /// body is absent — e.g. `oo::class create NAME` without a body).
     pub body_range: Span,
 }
+
+/// A `package require` invocation recorded by the signature scanner.
+///
+/// `version` is `None` when the call supplied no version constraint.
+/// `conditional` is `true` when the call lives inside a guarded
+/// branch (an `if`/`elseif`/`else` body, a `catch` script, or a
+/// `try`/`on`/`trap`/`finally` clause) so workspace-level Tcl-version
+/// inference does not promote a guarded `package require Tcl 8.6` to
+/// an unconditional minimum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignaturePackageRequire {
+    /// Package name (the `NAME` argument to `package require`).
+    pub name: String,
+    /// Optional version constraint (the `VERSION` argument); `None`
+    /// when no version is supplied.
+    pub version: Option<String>,
+    /// Source span of the name argument.
+    pub range: Span,
+    /// `true` when the call is inside a guarded branch.
+    pub conditional: bool,
+}
+
+/// A `source` invocation recorded by the signature scanner.
+///
+/// `is_literal` is `true` when the path argument contains no `$` or
+/// `[` — the segmenter reconstructs substituted words with the
+/// `${var}` / `[cmd]` markers preserved, so their absence is reliable
+/// evidence the path is a plain literal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureSource {
+    /// Verbatim path text as reconstructed by the segmenter (with
+    /// `${var}` / `[cmd]` markers preserved for substituted words).
+    pub raw_path: String,
+    /// Source span of the path argument.
+    pub range: Span,
+    /// `true` when the path is a plain literal (no `$` or `[`).
+    pub is_literal: bool,
+}

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -1,10 +1,18 @@
 //! Public record types emitted by the signature scanner.
 //!
 //! Mirrors the subset of `core.analysis.semantic_model` populated by
-//! `signature_scan.py`. The remaining record types and the
-//! [`SignatureScanResult`] aggregator are added by later C40 sub-strips.
+//! `signature_scan.py`: [`SignatureProc`], [`SignatureClass`],
+//! [`SignaturePackageRequire`], [`SignatureSource`],
+//! [`SignatureCommandAlias`], [`SignatureNamespaceImport`],
+//! [`SignatureAutoPathEntry`], [`SignatureCommandInvocation`], plus
+//! the [`SignatureScanResult`] aggregator returned by
+//! [`super::extract_signatures`] and the [`ParamDef`] used inside
+//! [`SignatureProc::params`].
 //!
-//! [`SignatureScanResult`]: super::types::SignatureScanResult
+//! Spans are [`tcl_lexer::Span`]; the `PyO3` binding in
+//! `rust/tcl-lsp-rust/src/signature_scan.rs` flattens them to
+//! `(start, end)` `u32` tuples for the materialiser on the Python
+//! side.
 
 use std::collections::BTreeMap;
 

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -6,6 +6,8 @@
 //!
 //! [`SignatureScanResult`]: super::types::SignatureScanResult
 
+use tcl_lexer::Span;
+
 /// A single Tcl proc parameter declaration.
 ///
 /// Mirrors `core.analysis.semantic_model.ParamDef`. The `default_value`
@@ -20,4 +22,43 @@ pub struct ParamDef {
     pub has_default: bool,
     /// The default-value text when [`Self::has_default`] is `true`.
     pub default_value: Option<String>,
+}
+
+/// A `proc` definition recorded by the signature scanner.
+///
+/// Mirrors `core.analysis.semantic_model.ProcDef` for the subset
+/// `signature_scan.py` populates: name, qualified name, parameter
+/// list, name-token range, body-token range. Diagnostics, scope-tree
+/// references, and other heavy analyser fields are intentionally
+/// absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureProc {
+    /// Unqualified proc name (the trailing component of the qualified
+    /// name).
+    pub name: String,
+    /// Fully-qualified proc name with leading `::`.
+    pub qualified_name: String,
+    /// Parsed parameter list.
+    pub params: Vec<ParamDef>,
+    /// Source span of the name argument.
+    pub name_range: Span,
+    /// Source span of the body argument.
+    pub body_range: Span,
+}
+
+/// A class definition recorded by the signature scanner.
+///
+/// Covers both `oo::class create NAME ?BODY?` and
+/// `itcl::class NAME BODY` forms — the surface fields are identical.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureClass {
+    /// Unqualified class name.
+    pub name: String,
+    /// Fully-qualified class name with leading `::`.
+    pub qualified_name: String,
+    /// Source span of the name argument.
+    pub name_range: Span,
+    /// Source span of the body argument (or the name span when the
+    /// body is absent — e.g. `oo::class create NAME` without a body).
+    pub body_range: Span,
 }

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -1,0 +1,159 @@
+//! Top-level walker for the `signature_scan` module.
+//!
+//! Walks segmented commands and dispatches them to per-command
+//! handlers in [`super::handlers`]. Body recursion into braced
+//! scripts (proc bodies, namespace eval bodies, structured-command
+//! branches) lives here too — it must not depend on the IR
+//! lowering pass, which is the whole reason the `signature_scan`
+//! module exists.
+//!
+//! Body recursion for `namespace eval`, `if`, `catch`, and `try`
+//! is added incrementally in C40c2-C40c5 sub-strips; the dispatch
+//! arms for those commands call no-op stubs in this scaffold strip.
+
+#![allow(dead_code)]
+
+use tcl_lexer::{Token, TokenType};
+
+use super::ctx::ScanCtx;
+use super::handlers;
+use super::types::SignatureCommandInvocation;
+use crate::segmenter::{segment_commands, segment_commands_with_offset};
+
+/// Walk *source* as a Tcl script, emitting records for every command
+/// the dispatcher recognises.
+///
+/// When `body_token` is `Some`, the spans on every record are
+/// relocated into the outer source buffer's offset space (the body
+/// token's content position is used as the base offset).
+pub(super) fn scan(
+    source: &str,
+    body_token: Option<Token>,
+    ns_prefix: &str,
+    conditional: bool,
+    ctx: &mut ScanCtx,
+) {
+    let commands = match body_token {
+        None => segment_commands(source),
+        Some(tok) => {
+            let base = tok.span.start() + u32::from(tok.content_offset);
+            segment_commands_with_offset(source, base)
+        }
+    };
+    for cmd in commands {
+        if cmd.is_partial || cmd.argv.is_empty() {
+            continue;
+        }
+        let head = cmd.name();
+        if head.is_empty() {
+            continue;
+        }
+        ctx.result
+            .command_invocations
+            .push(SignatureCommandInvocation {
+                name: head.to_string(),
+                range: cmd.argv[0].span,
+            });
+        let texts = &cmd.texts;
+        let argv = &cmd.argv;
+        match head {
+            "proc" => handlers::handle_proc(texts, argv, ns_prefix, ctx),
+            "namespace" => handlers::handle_namespace(texts, argv, ns_prefix, conditional, ctx),
+            "package" => handlers::handle_package(texts, argv, conditional, &mut ctx.result),
+            "source" => handlers::handle_source(texts, argv, &mut ctx.result),
+            "interp" => handlers::handle_interp(texts, &mut ctx.result),
+            "oo::class" => handlers::handle_oo_class(texts, argv, ns_prefix, &mut ctx.result),
+            "itcl::class" | "::itcl::class" => {
+                handlers::handle_itcl_class(texts, argv, ns_prefix, &mut ctx.result);
+            }
+            "if" => handle_if_stub(texts, argv, ns_prefix, ctx),
+            "catch" => handle_catch_stub(texts, argv, ns_prefix, ctx),
+            "try" => handle_try_stub(texts, argv, ns_prefix, ctx),
+            "lappend" | "set" => handlers::handle_auto_path(texts, argv, &mut ctx.result),
+            _ => {
+                handlers::maybe_handle_import_wrapper(
+                    head,
+                    texts,
+                    argv,
+                    ns_prefix,
+                    &mut ctx.result,
+                );
+                handlers::maybe_record_factory_candidate(head, texts, argv, ns_prefix, ctx);
+            }
+        }
+    }
+}
+
+/// Recurse into a braced body script.
+///
+/// Mirrors `_maybe_recurse_body` in
+/// `core/analysis/signature_scan.py`. Only `Str` (braced) bodies
+/// can be statically analysed; substituted bodies (`$body`,
+/// `[gen_body]`) cannot be re-segmented and are skipped.
+pub(super) fn maybe_recurse_body(
+    body_text: &str,
+    body_tok: Token,
+    ns_prefix: &str,
+    conditional: bool,
+    ctx: &mut ScanCtx,
+) {
+    if body_tok.kind != TokenType::Str {
+        return;
+    }
+    scan(body_text, Some(body_tok), ns_prefix, conditional, ctx);
+}
+
+// -- Body-recursion handler stubs ---------------------------------
+// Filled in by C40c3 (`if`), C40c4 (`catch`), C40c5 (`try`).
+
+fn handle_if_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
+    // TODO(C40c3): walk every then/elseif/else branch via maybe_recurse_body.
+}
+
+fn handle_catch_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
+    // TODO(C40c4): recurse into argv[1] body via maybe_recurse_body.
+}
+
+fn handle_try_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
+    // TODO(C40c5): main body + on/trap handlers + finally.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_level_proc_emits_invocation_and_record() {
+        let mut ctx = ScanCtx::default();
+        scan("proc foo {} { set x 1 }", None, "", false, &mut ctx);
+        assert!(ctx.result.procs.contains_key("::foo"));
+        // command_invocations should contain at least the top-level "proc"
+        // invocation; the body's "set" stays uninvoked since handle_proc
+        // does not yet recurse (C40c7).
+        let names: Vec<&str> = ctx
+            .result
+            .command_invocations
+            .iter()
+            .map(|inv| inv.name.as_str())
+            .collect();
+        assert_eq!(names, ["proc"]);
+    }
+
+    #[test]
+    fn multiple_handlers_dispatch_correctly() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "package require Tcl 8.6\nsource /abs/path.tcl\nproc bar {} {}",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert_eq!(ctx.result.package_requires.len(), 1);
+        assert_eq!(ctx.result.package_requires[0].name, "Tcl");
+        assert_eq!(ctx.result.source_targets.len(), 1);
+        assert_eq!(ctx.result.source_targets[0].raw_path, "/abs/path.tcl");
+        assert!(ctx.result.procs.contains_key("::bar"));
+        assert_eq!(ctx.result.command_invocations.len(), 3);
+    }
+}

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -67,7 +67,7 @@ pub(super) fn scan(
                 handlers::handle_itcl_class(texts, argv, ns_prefix, &mut ctx.result);
             }
             "if" => handle_if(texts, argv, ns_prefix, ctx),
-            "catch" => handle_catch_stub(texts, argv, ns_prefix, ctx),
+            "catch" => handle_catch(texts, argv, ns_prefix, ctx),
             "try" => handle_try_stub(texts, argv, ns_prefix, ctx),
             "lappend" | "set" => handlers::handle_auto_path(texts, argv, &mut ctx.result),
             _ => {
@@ -141,8 +141,14 @@ fn handle_if(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCt
     }
 }
 
-fn handle_catch_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
-    // TODO(C40c4): recurse into argv[1] body via maybe_recurse_body.
+fn handle_catch(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCtx) {
+    // `catch SCRIPT ?RESULTVAR? ?OPTIONSVAR?` — only the first argument
+    // is a body. Marked `conditional=true` since the body is guarded
+    // (it could throw before reaching subsequent statements).
+    if texts.len() < 2 {
+        return;
+    }
+    maybe_recurse_body(&texts[1], argv[1], ns_prefix, true, ctx);
 }
 
 fn handle_try_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
@@ -255,5 +261,26 @@ mod tests {
             &mut ctx,
         );
         assert!(ctx.result.procs.contains_key("::thenproc"));
+    }
+
+    #[test]
+    fn handle_catch_braced_body() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "catch { proc inner {} {} } result",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::inner"));
+    }
+
+    #[test]
+    fn handle_catch_unbraced_body_skipped() {
+        let mut ctx = ScanCtx::default();
+        scan("catch $script", None, "", false, &mut ctx);
+        // No procs since the body cannot be statically analysed.
+        assert!(ctx.result.procs.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -2,14 +2,23 @@
 //!
 //! Walks segmented commands and dispatches them to per-command
 //! handlers in [`super::handlers`]. Body recursion into braced
-//! scripts (proc bodies, namespace eval bodies, structured-command
+//! scripts (proc bodies, namespace-eval bodies, structured-command
 //! branches) lives here too — it must not depend on the IR
 //! lowering pass, which is the whole reason the `signature_scan`
 //! module exists.
 //!
-//! Body recursion for `namespace eval`, `if`, `catch`, and `try`
-//! is added incrementally in C40c2-C40c5 sub-strips; the dispatch
-//! arms for those commands call no-op stubs in this scaffold strip.
+//! Public-to-the-module entry points:
+//!
+//! - [`scan`] — the main walker; called by
+//!   [`super::extract_signatures`] for the top-level source and
+//!   recursively by [`maybe_recurse_body`] for braced bodies.
+//! - [`maybe_recurse_body`] — gates body recursion on `Str`
+//!   (braced) tokens; called from `handle_namespace` (eval arm),
+//!   `handle_if` / `handle_catch` / `handle_try` here.
+//! - [`scan_factory_candidates`] — secondary walker called from
+//!   `handle_proc`; only collects four-token factory candidates and
+//!   recurses into structural-control bodies via
+//!   `scan_factory_structural`.
 
 use tcl_lexer::{Token, TokenType};
 
@@ -101,8 +110,10 @@ pub(super) fn maybe_recurse_body(
     scan(body_text, Some(body_tok), ns_prefix, conditional, ctx);
 }
 
-// -- Body-recursion handler stubs ---------------------------------
-// Filled in by C40c3 (`if`), C40c4 (`catch`), C40c5 (`try`).
+// -- Body-recursion handlers --------------------------------------
+// Each port of a `_handle_*` function from
+// `core/analysis/signature_scan.py` whose Python equivalent recurses
+// into braced bodies.
 
 fn handle_if(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCtx) {
     // Tcl's `if` takes the shape:

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -176,6 +176,134 @@ fn handle_try(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanC
     }
 }
 
+/// Scan a proc body specifically for factory-wrapper candidate
+/// calls.
+///
+/// Mirrors `_scan_factory_candidates` in
+/// `core/analysis/signature_scan.py`. Unlike [`scan`], this walker
+/// only collects four-token `HEAD NAME ARGS BODY` shaped calls and
+/// recurses into structural-control bodies (`if` / `catch` / `try`
+/// / `namespace eval`) that commonly wrap factory calls. It
+/// deliberately does **not** emit nested proc / namespace-import
+/// records — those would be incorrect because nested `proc`
+/// statements inside a proc body only take effect when that proc
+/// is invoked.
+pub(super) fn scan_factory_candidates(
+    body_text: &str,
+    body_tok: Token,
+    ns_prefix: &str,
+    ctx: &mut ScanCtx,
+) {
+    let base = body_tok.span.start() + u32::from(body_tok.content_offset);
+    let commands = segment_commands_with_offset(body_text, base);
+    for cmd in commands {
+        if cmd.is_partial || cmd.argv.is_empty() {
+            continue;
+        }
+        let head = cmd.name();
+        if head.is_empty() {
+            continue;
+        }
+        let texts = &cmd.texts;
+        let argv = &cmd.argv;
+        match head {
+            "if" | "catch" | "try" | "namespace" => {
+                scan_factory_structural(head, texts, argv, ns_prefix, ctx);
+            }
+            _ => {
+                handlers::maybe_record_factory_candidate(head, texts, argv, ns_prefix, ctx);
+            }
+        }
+    }
+}
+
+/// Recurse into a structural command's braced bodies for factory
+/// candidates only.
+///
+/// Mirrors `_scan_factory_structural`. Same set of structural
+/// commands and same body offsets as the main `handle_if` /
+/// `handle_catch` / `handle_try` / `handle_namespace` (eval arm)
+/// walkers, but the recursive call is `scan_factory_candidates`
+/// (not `scan`) so only factory-shaped calls are collected.
+fn scan_factory_structural(
+    head: &str,
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    ctx: &mut ScanCtx,
+) {
+    if head == "namespace" && texts.len() >= 4 && texts[1] == "eval" {
+        let raw_ns = &texts[2];
+        let inner = if let Some(rest) = raw_ns.strip_prefix("::") {
+            rest.trim_start_matches(':').to_string()
+        } else if !ns_prefix.is_empty() {
+            format!("{ns_prefix}::{raw_ns}")
+        } else {
+            raw_ns.clone()
+        };
+        if argv[3].kind == TokenType::Str {
+            scan_factory_candidates(&texts[3], argv[3], &inner, ctx);
+        }
+        return;
+    }
+    if head == "if" {
+        let mut i = 1;
+        let mut expect_body = false;
+        while i < texts.len() {
+            let w = texts[i].as_str();
+            if w == "then" {
+                expect_body = true;
+                i += 1;
+                continue;
+            }
+            if w == "elseif" {
+                expect_body = false;
+                i += 1;
+                continue;
+            }
+            if w == "else" {
+                expect_body = true;
+                i += 1;
+                continue;
+            }
+            if expect_body && argv[i].kind == TokenType::Str {
+                scan_factory_candidates(&texts[i], argv[i], ns_prefix, ctx);
+                expect_body = false;
+            } else {
+                expect_body = true;
+            }
+            i += 1;
+        }
+        return;
+    }
+    if head == "catch" && texts.len() >= 2 && argv[1].kind == TokenType::Str {
+        scan_factory_candidates(&texts[1], argv[1], ns_prefix, ctx);
+        return;
+    }
+    if head == "try" && texts.len() >= 2 {
+        if argv[1].kind == TokenType::Str {
+            scan_factory_candidates(&texts[1], argv[1], ns_prefix, ctx);
+        }
+        let mut i = 2;
+        while i < texts.len() {
+            let clause = texts[i].as_str();
+            if clause == "finally" && i + 1 < texts.len() && argv[i + 1].kind == TokenType::Str {
+                scan_factory_candidates(&texts[i + 1], argv[i + 1], ns_prefix, ctx);
+                return;
+            }
+            if (clause == "on" || clause == "trap")
+                && i + 3 < texts.len()
+                && argv[i + 3].kind == TokenType::Str
+            {
+                scan_factory_candidates(&texts[i + 3], argv[i + 3], ns_prefix, ctx);
+                i += 4;
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -345,5 +473,45 @@ mod tests {
         );
         assert!(ctx.result.procs.contains_key("::tryproc"));
         assert!(ctx.result.procs.contains_key("::trapproc"));
+    }
+
+    fn extract_proc_body(src: &str) -> (String, Token) {
+        // Pluck the proc body from the segmenter so we get a real
+        // `Str` token with correct content_offset/span.
+        let cmds = crate::segmenter::segment_commands(src);
+        let proc_cmd = cmds.first().expect("one command");
+        let body_tok = proc_cmd.argv[3];
+        let span = body_tok.span;
+        let inner = &src[span.start() as usize + 1..span.end() as usize - 1];
+        (inner.to_string(), body_tok)
+    }
+
+    #[test]
+    fn factory_walker_records_bare_candidate() {
+        // DEFC's body argument must be a `Str` (braced) for the
+        // candidate to register.
+        let src = "proc factwrapper {a b c} { DEFC bar args {body} }";
+        let (body, body_tok) = extract_proc_body(src);
+        let mut ctx = ScanCtx::default();
+        scan_factory_candidates(&body, body_tok, "", &mut ctx);
+        assert_eq!(ctx.candidates.len(), 1);
+    }
+
+    #[test]
+    fn factory_walker_recurses_into_if() {
+        let src = "proc init {} { if {1} { DEFC bar args {body} } }";
+        let (body, body_tok) = extract_proc_body(src);
+        let mut ctx = ScanCtx::default();
+        scan_factory_candidates(&body, body_tok, "", &mut ctx);
+        assert_eq!(ctx.candidates.len(), 1);
+    }
+
+    #[test]
+    fn factory_walker_recurses_into_try_finally() {
+        let src = "proc init {} { try { DEFC a {x} {b} } finally { DEFC c {y} {d} } }";
+        let (body, body_tok) = extract_proc_body(src);
+        let mut ctx = ScanCtx::default();
+        scan_factory_candidates(&body, body_tok, "", &mut ctx);
+        assert_eq!(ctx.candidates.len(), 2);
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -66,7 +66,7 @@ pub(super) fn scan(
             "itcl::class" | "::itcl::class" => {
                 handlers::handle_itcl_class(texts, argv, ns_prefix, &mut ctx.result);
             }
-            "if" => handle_if_stub(texts, argv, ns_prefix, ctx),
+            "if" => handle_if(texts, argv, ns_prefix, ctx),
             "catch" => handle_catch_stub(texts, argv, ns_prefix, ctx),
             "try" => handle_try_stub(texts, argv, ns_prefix, ctx),
             "lappend" | "set" => handlers::handle_auto_path(texts, argv, &mut ctx.result),
@@ -106,8 +106,39 @@ pub(super) fn maybe_recurse_body(
 // -- Body-recursion handler stubs ---------------------------------
 // Filled in by C40c3 (`if`), C40c4 (`catch`), C40c5 (`try`).
 
-fn handle_if_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
-    // TODO(C40c3): walk every then/elseif/else branch via maybe_recurse_body.
+fn handle_if(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCtx) {
+    // Tcl's `if` takes the shape:
+    //   if EXPR ?then? BODY ?elseif EXPR ?then? BODY?... ?else? ?BODY?
+    // Alternate between expecting an expression and expecting a body,
+    // resetting the expectation whenever `then` / `elseif` / `else`
+    // appears. Every recursed body is marked `conditional=true`.
+    let mut i = 1;
+    let mut expect_body = false;
+    while i < texts.len() {
+        let word = texts[i].as_str();
+        if word == "then" {
+            expect_body = true;
+            i += 1;
+            continue;
+        }
+        if word == "elseif" {
+            expect_body = false;
+            i += 1;
+            continue;
+        }
+        if word == "else" {
+            expect_body = true;
+            i += 1;
+            continue;
+        }
+        if expect_body {
+            maybe_recurse_body(&texts[i], argv[i], ns_prefix, true, ctx);
+            expect_body = false;
+        } else {
+            expect_body = true;
+        }
+        i += 1;
+    }
 }
 
 fn handle_catch_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
@@ -182,5 +213,47 @@ mod tests {
         );
         // The inner ::abs eval should rebase, not nest under outer.
         assert!(ctx.result.procs.contains_key("::abs::foo"));
+    }
+
+    #[test]
+    fn handle_if_then_else_recurses_both_branches() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "if {$x} { proc thenproc {} {} } else { proc elseproc {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::thenproc"));
+        assert!(ctx.result.procs.contains_key("::elseproc"));
+    }
+
+    #[test]
+    fn handle_if_elseif_chain_recurses_each_body() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "if {$x} { proc a {} {} } elseif {$y} { proc b {} {} } elseif {$z} { proc c {} {} } else { proc d {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        for name in ["::a", "::b", "::c", "::d"] {
+            assert!(ctx.result.procs.contains_key(name), "missing {name}");
+        }
+    }
+
+    #[test]
+    fn handle_if_explicit_then_keyword() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "if {$x} then { proc thenproc {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::thenproc"));
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -11,8 +11,6 @@
 //! is added incrementally in C40c2-C40c5 sub-strips; the dispatch
 //! arms for those commands call no-op stubs in this scaffold strip.
 
-#![allow(dead_code)]
-
 use tcl_lexer::{Token, TokenType};
 
 use super::ctx::ScanCtx;

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -68,7 +68,7 @@ pub(super) fn scan(
             }
             "if" => handle_if(texts, argv, ns_prefix, ctx),
             "catch" => handle_catch(texts, argv, ns_prefix, ctx),
-            "try" => handle_try_stub(texts, argv, ns_prefix, ctx),
+            "try" => handle_try(texts, argv, ns_prefix, ctx),
             "lappend" | "set" => handlers::handle_auto_path(texts, argv, &mut ctx.result),
             _ => {
                 handlers::maybe_handle_import_wrapper(
@@ -151,8 +151,29 @@ fn handle_catch(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut Sca
     maybe_recurse_body(&texts[1], argv[1], ns_prefix, true, ctx);
 }
 
-fn handle_try_stub(_texts: &[String], _argv: &[Token], _ns_prefix: &str, _ctx: &mut ScanCtx) {
-    // TODO(C40c5): main body + on/trap handlers + finally.
+fn handle_try(texts: &[String], argv: &[Token], ns_prefix: &str, ctx: &mut ScanCtx) {
+    // `try BODY ?on CODE VARLIST BODY?... ?trap PATTERN VARLIST BODY?...
+    //  ?finally BODY?` — the main body sits at index 1; handler clauses
+    // (`on`/`trap`) take 4 words each with the body at +3; `finally`
+    // takes 2 words with the body at +1.
+    if texts.len() < 2 {
+        return;
+    }
+    maybe_recurse_body(&texts[1], argv[1], ns_prefix, true, ctx);
+    let mut i = 2;
+    while i < texts.len() {
+        let clause = texts[i].as_str();
+        if clause == "finally" && i + 1 < texts.len() {
+            maybe_recurse_body(&texts[i + 1], argv[i + 1], ns_prefix, true, ctx);
+            return;
+        }
+        if (clause == "on" || clause == "trap") && i + 3 < texts.len() {
+            maybe_recurse_body(&texts[i + 3], argv[i + 3], ns_prefix, true, ctx);
+            i += 4;
+        } else {
+            i += 1;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -282,5 +303,47 @@ mod tests {
         scan("catch $script", None, "", false, &mut ctx);
         // No procs since the body cannot be statically analysed.
         assert!(ctx.result.procs.is_empty());
+    }
+
+    #[test]
+    fn handle_try_with_finally() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "try { proc tryproc {} {} } finally { proc finallyproc {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::tryproc"));
+        assert!(ctx.result.procs.contains_key("::finallyproc"));
+    }
+
+    #[test]
+    fn handle_try_with_on_handler() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "try { proc tryproc {} {} } on error {res opts} { proc onproc {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::tryproc"));
+        assert!(ctx.result.procs.contains_key("::onproc"));
+    }
+
+    #[test]
+    fn handle_try_with_trap_handler() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "try { proc tryproc {} {} } trap {ARITH DIVZERO} {res opts} { proc trapproc {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::tryproc"));
+        assert!(ctx.result.procs.contains_key("::trapproc"));
     }
 }

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -156,4 +156,31 @@ mod tests {
         assert!(ctx.result.procs.contains_key("::bar"));
         assert_eq!(ctx.result.command_invocations.len(), 3);
     }
+
+    #[test]
+    fn namespace_eval_recurses_into_body() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "namespace eval ns { proc inner {} {} }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        assert!(ctx.result.procs.contains_key("::ns::inner"));
+    }
+
+    #[test]
+    fn namespace_eval_absolute_rebases_prefix() {
+        let mut ctx = ScanCtx::default();
+        scan(
+            "namespace eval outer { namespace eval ::abs { proc foo {} {} } }",
+            None,
+            "",
+            false,
+            &mut ctx,
+        );
+        // The inner ::abs eval should rebase, not nest under outer.
+        assert!(ctx.result.procs.contains_key("::abs::foo"));
+    }
 }

--- a/rust/tcl-lsp-rust/src/compilation_unit.rs
+++ b/rust/tcl-lsp-rust/src/compilation_unit.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 
 use tcl_compiler::compilation_unit::CompilationUnit;
-use tcl_registry::CommandRegistry;
 
 /// Opaque handle wrapping an `Arc<CompilationUnit>`.
 ///
@@ -73,9 +72,9 @@ impl CompilationUnitHandle {
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
 pub fn build_compilation_unit(source: &str, dialect: Option<&str>) -> CompilationUnitHandle {
-    let registry = CommandRegistry::build_default();
-    let cu = CompilationUnit::build_for(source, &registry, false)
-        .with_interprocedural(&registry, dialect);
+    let registry = crate::registry::default_registry();
+    let cu =
+        CompilationUnit::build_for(source, registry, false).with_interprocedural(registry, dialect);
     CompilationUnitHandle {
         inner: Arc::new(cu),
     }

--- a/rust/tcl-lsp-rust/src/compiler_checks.rs
+++ b/rust/tcl-lsp-rust/src/compiler_checks.rs
@@ -23,7 +23,6 @@ use pyo3::prelude::*;
 
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::compiler_checks::{run_all_checks, Severity};
-use tcl_registry::CommandRegistry;
 
 /// Run every landed compiler check against `source` and return a
 /// flat list of diagnostic tuples:
@@ -47,10 +46,10 @@ pub fn compiler_checks_run_all(
     source: &str,
     dialect: Option<&str>,
 ) -> Vec<(String, String, String, String, u32, u32, Option<String>)> {
-    let registry = CommandRegistry::build_default();
-    let cu = CompilationUnit::build_for(source, &registry, false)
-        .with_interprocedural(&registry, dialect);
-    let diagnostics = run_all_checks(&cu, &registry, dialect);
+    let registry = crate::registry::default_registry();
+    let cu =
+        CompilationUnit::build_for(source, registry, false).with_interprocedural(registry, dialect);
+    let diagnostics = run_all_checks(&cu, registry, dialect);
     diagnostics
         .into_iter()
         .map(|d| {

--- a/rust/tcl-lsp-rust/src/gvn.rs
+++ b/rust/tcl-lsp-rust/src/gvn.rs
@@ -22,7 +22,6 @@ use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::gvn::{
     find_loop_invariants, find_partial_redundancies, find_redundancies, RedundantComputation,
 };
-use tcl_registry::CommandRegistry;
 
 type GvnTuple = (String, u32, u32, u32, u32, String, String);
 
@@ -42,11 +41,11 @@ fn lift(r: RedundantComputation) -> GvnTuple {
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
 pub fn gvn_redundancies(source: &str, dialect: Option<&str>) -> Vec<GvnTuple> {
-    let registry = CommandRegistry::build_default();
-    let cu = CompilationUnit::build_for(source, &registry, false);
+    let registry = crate::registry::default_registry();
+    let cu = CompilationUnit::build_for(source, registry, false);
     let mut out = Vec::new();
     for fu in cu.functions() {
-        for r in find_redundancies(&registry, &fu.cfg, &fu.ssa, dialect) {
+        for r in find_redundancies(registry, &fu.cfg, &fu.ssa, dialect) {
             out.push(lift(r));
         }
     }
@@ -57,11 +56,11 @@ pub fn gvn_redundancies(source: &str, dialect: Option<&str>) -> Vec<GvnTuple> {
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
 pub fn gvn_partial_redundancies(source: &str, dialect: Option<&str>) -> Vec<GvnTuple> {
-    let registry = CommandRegistry::build_default();
-    let cu = CompilationUnit::build_for(source, &registry, false);
+    let registry = crate::registry::default_registry();
+    let cu = CompilationUnit::build_for(source, registry, false);
     let mut out = Vec::new();
     for fu in cu.functions() {
-        for r in find_partial_redundancies(&registry, &fu.cfg, &fu.ssa, dialect) {
+        for r in find_partial_redundancies(registry, &fu.cfg, &fu.ssa, dialect) {
             out.push(lift(r));
         }
     }
@@ -72,11 +71,11 @@ pub fn gvn_partial_redundancies(source: &str, dialect: Option<&str>) -> Vec<GvnT
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
 pub fn gvn_loop_invariants(source: &str, dialect: Option<&str>) -> Vec<GvnTuple> {
-    let registry = CommandRegistry::build_default();
-    let cu = CompilationUnit::build_for(source, &registry, false);
+    let registry = crate::registry::default_registry();
+    let cu = CompilationUnit::build_for(source, registry, false);
     let mut out = Vec::new();
     for fu in cu.functions() {
-        for r in find_loop_invariants(&registry, &fu.cfg, &fu.ssa, dialect) {
+        for r in find_loop_invariants(registry, &fu.cfg, &fu.ssa, dialect) {
             out.push(lift(r));
         }
     }

--- a/rust/tcl-lsp-rust/src/interprocedural.rs
+++ b/rust/tcl-lsp-rust/src/interprocedural.rs
@@ -25,7 +25,6 @@ use pyo3::types::{PyDict, PyList};
 
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::interprocedural::{ConstantReturn, ProcArgTrait, ProcSummary};
-use tcl_registry::CommandRegistry;
 
 /// Return the full interprocedural summary table for `source`.
 ///
@@ -54,9 +53,9 @@ pub fn interprocedural_summaries<'py>(
     source: &str,
     dialect: Option<&str>,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let registry = CommandRegistry::build_default();
-    let cu = CompilationUnit::build_for(source, &registry, false)
-        .with_interprocedural(&registry, dialect);
+    let registry = crate::registry::default_registry();
+    let cu =
+        CompilationUnit::build_for(source, registry, false).with_interprocedural(registry, dialect);
     let out = PyDict::new_bound(py);
     let Some(ia) = cu.interproc.as_ref() else {
         return Ok(out);

--- a/rust/tcl-lsp-rust/src/lib.rs
+++ b/rust/tcl-lsp-rust/src/lib.rs
@@ -31,6 +31,7 @@ mod interprocedural;
 mod lexer;
 mod optimiser;
 mod registry;
+mod signature_scan;
 mod tokens;
 
 /// Return the Rust-side greeting used by the smoke test.
@@ -89,5 +90,6 @@ fn tcl_lsp_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     interprocedural::register_with(m)?;
     gvn::register_with(m)?;
     compilation_unit::register_with(m)?;
+    signature_scan::register_with(m)?;
     Ok(())
 }

--- a/rust/tcl-lsp-rust/src/optimiser.rs
+++ b/rust/tcl-lsp-rust/src/optimiser.rs
@@ -15,7 +15,6 @@
 use pyo3::prelude::*;
 
 use tcl_compiler::optimiser;
-use tcl_registry::CommandRegistry;
 
 /// Run every landed optimisation pass against `source` and
 /// return the overlap-free list of suggestions as a tuple per
@@ -38,10 +37,10 @@ pub fn optimiser_find_optimisations(
     source: &str,
     dialect: Option<&str>,
 ) -> Vec<(String, String, u32, u32, String, Option<u32>, bool)> {
-    let registry = CommandRegistry::build_default();
+    let registry = crate::registry::default_registry();
     let opts = match dialect {
-        Some(d) => optimiser::optimise_with_dialect(source, &registry, Some(d)),
-        None => optimiser::optimise(source, &registry),
+        Some(d) => optimiser::optimise_with_dialect(source, registry, Some(d)),
+        None => optimiser::optimise(source, registry),
     };
     opts.into_iter()
         .map(|o| {
@@ -69,10 +68,10 @@ pub fn optimiser_find_optimisations_raw(
     source: &str,
     dialect: Option<&str>,
 ) -> Vec<(String, String, u32, u32, String, Option<u32>, bool)> {
-    let registry = CommandRegistry::build_default();
+    let registry = crate::registry::default_registry();
     // optimise_raw already constructs a CompilationUnit internally;
     // no need to build one here.
-    let opts = optimiser::optimise_raw(source, &registry, dialect);
+    let opts = optimiser::optimise_raw(source, registry, dialect);
     opts.into_iter()
         .map(|o| {
             (

--- a/rust/tcl-lsp-rust/src/registry.rs
+++ b/rust/tcl-lsp-rust/src/registry.rs
@@ -12,7 +12,14 @@ use tcl_registry::traits::Traits;
 use tcl_registry::ArgRole;
 
 /// Cached default registry — built once, reused across all `PyO3` calls.
-fn default_registry() -> &'static CommandRegistry {
+///
+/// The full registry has ~118 Tcl + stdlib + tcllib specs; building
+/// it eagerly (~100k `HashMap` inserts in aggregate when called per
+/// document on a large workspace) was a hot-path waste in every
+/// other binding module that consumed `CommandRegistry::build_default()`
+/// per call. This `OnceLock` is the shared cache; new bindings should
+/// call this rather than `build_default()` directly.
+pub(crate) fn default_registry() -> &'static CommandRegistry {
     static REGISTRY: OnceLock<CommandRegistry> = OnceLock::new();
     REGISTRY.get_or_init(CommandRegistry::build_default)
 }

--- a/rust/tcl-lsp-rust/src/signature_scan.rs
+++ b/rust/tcl-lsp-rust/src/signature_scan.rs
@@ -11,16 +11,27 @@
 //! resolve them to LSP `Range` via
 //! `core/compiler/rust_spans.py::build_position_resolver`.
 //!
-//! Collections are emitted incrementally by C40e2/e3 sub-strips;
-//! this scaffold strip wires up the binding shape and returns an
-//! empty dict.
+//! Dict shape:
+//!
+//! - `procs` — `{qualified_name: {name, qualified_name, params,
+//!   name_range, body_range}}` (params is a list of
+//!   `{name, has_default, default_value}` dicts)
+//! - `classes` — `{qualified_name: {name, qualified_name,
+//!   name_range, body_range}}`
+//! - `command_invocations` — list of `{name, range}` dicts
+//! - `package_requires`, `source_targets`, `command_aliases`,
+//!   `namespace_imports`, `auto_path_entries` — wired in C40e3
 //!
 //! [`SignatureScanResult`]: tcl_compiler::signature_scan::SignatureScanResult
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyList};
 
-use tcl_compiler::signature_scan::extract_signatures;
+use tcl_compiler::signature_scan::{
+    extract_signatures,
+    types::{ParamDef, SignatureClass, SignatureCommandInvocation, SignatureProc},
+};
+use tcl_lexer::Span;
 use tcl_registry::CommandRegistry;
 
 /// Extract a [`SignatureScanResult`] for `source` and serialise it
@@ -29,18 +40,77 @@ use tcl_registry::CommandRegistry;
 /// See the module-level docs for the dict shape.
 ///
 /// [`SignatureScanResult`]: tcl_compiler::signature_scan::SignatureScanResult
-// `PyResult` is the long-term shape; later strips populate the dict
-// via fallible `set_item` calls. Suppress the unnecessary-wraps lint
-// for the scaffold strip.
-#[allow(clippy::unnecessary_wraps)]
 #[pyfunction]
 #[pyo3(signature = (source, /))]
 pub fn signature_scan_extract<'py>(py: Python<'py>, source: &str) -> PyResult<Bound<'py, PyDict>> {
     let registry = CommandRegistry::build_default();
-    let _result = extract_signatures(source, &registry);
+    let result = extract_signatures(source, &registry);
     let out = PyDict::new_bound(py);
-    // Collections wired by C40e2 / C40e3.
+
+    let procs = PyDict::new_bound(py);
+    for (qname, p) in &result.procs {
+        procs.set_item(qname, proc_to_dict(py, p)?)?;
+    }
+    out.set_item("procs", procs)?;
+
+    let classes = PyDict::new_bound(py);
+    for (qname, c) in &result.classes {
+        classes.set_item(qname, class_to_dict(py, c)?)?;
+    }
+    out.set_item("classes", classes)?;
+
+    let invocations = PyList::empty_bound(py);
+    for inv in &result.command_invocations {
+        invocations.append(invocation_to_dict(py, inv)?)?;
+    }
+    out.set_item("command_invocations", invocations)?;
+
     Ok(out)
+}
+
+fn proc_to_dict<'py>(py: Python<'py>, p: &SignatureProc) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("name", &p.name)?;
+    d.set_item("qualified_name", &p.qualified_name)?;
+    let params = PyList::empty_bound(py);
+    for param in &p.params {
+        params.append(param_to_dict(py, param)?)?;
+    }
+    d.set_item("params", params)?;
+    d.set_item("name_range", span_tuple(p.name_range))?;
+    d.set_item("body_range", span_tuple(p.body_range))?;
+    Ok(d)
+}
+
+fn class_to_dict<'py>(py: Python<'py>, c: &SignatureClass) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("name", &c.name)?;
+    d.set_item("qualified_name", &c.qualified_name)?;
+    d.set_item("name_range", span_tuple(c.name_range))?;
+    d.set_item("body_range", span_tuple(c.body_range))?;
+    Ok(d)
+}
+
+fn invocation_to_dict<'py>(
+    py: Python<'py>,
+    inv: &SignatureCommandInvocation,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("name", &inv.name)?;
+    d.set_item("range", span_tuple(inv.range))?;
+    Ok(d)
+}
+
+fn param_to_dict<'py>(py: Python<'py>, p: &ParamDef) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("name", &p.name)?;
+    d.set_item("has_default", p.has_default)?;
+    d.set_item("default_value", p.default_value.clone())?;
+    Ok(d)
+}
+
+fn span_tuple(span: Span) -> (u32, u32) {
+    (span.start(), span.end())
 }
 
 /// Register `signature_scan_extract` on the Python module.

--- a/rust/tcl-lsp-rust/src/signature_scan.rs
+++ b/rust/tcl-lsp-rust/src/signature_scan.rs
@@ -1,0 +1,50 @@
+// The `?` operator in a `#[pyfunction]` returning `PyResult<_>` trips
+// `clippy::useless_conversion` inside the macro expansion.
+#![allow(clippy::useless_conversion)]
+
+//! `PyO3` binding for the `signature_scan` module.
+//!
+//! Exposes `signature_scan_extract(source)` to Python. Returns a
+//! dict with one key per collection in the underlying
+//! [`SignatureScanResult`]; spans are encoded as `(start, end)`
+//! `u32` tuples, leaving the materialiser on the Python side to
+//! resolve them to LSP `Range` via
+//! `core/compiler/rust_spans.py::build_position_resolver`.
+//!
+//! Collections are emitted incrementally by C40e2/e3 sub-strips;
+//! this scaffold strip wires up the binding shape and returns an
+//! empty dict.
+//!
+//! [`SignatureScanResult`]: tcl_compiler::signature_scan::SignatureScanResult
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use tcl_compiler::signature_scan::extract_signatures;
+use tcl_registry::CommandRegistry;
+
+/// Extract a [`SignatureScanResult`] for `source` and serialise it
+/// to a Python dict.
+///
+/// See the module-level docs for the dict shape.
+///
+/// [`SignatureScanResult`]: tcl_compiler::signature_scan::SignatureScanResult
+// `PyResult` is the long-term shape; later strips populate the dict
+// via fallible `set_item` calls. Suppress the unnecessary-wraps lint
+// for the scaffold strip.
+#[allow(clippy::unnecessary_wraps)]
+#[pyfunction]
+#[pyo3(signature = (source, /))]
+pub fn signature_scan_extract<'py>(py: Python<'py>, source: &str) -> PyResult<Bound<'py, PyDict>> {
+    let registry = CommandRegistry::build_default();
+    let _result = extract_signatures(source, &registry);
+    let out = PyDict::new_bound(py);
+    // Collections wired by C40e2 / C40e3.
+    Ok(out)
+}
+
+/// Register `signature_scan_extract` on the Python module.
+pub fn register_with(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(signature_scan_extract, m)?)?;
+    Ok(())
+}

--- a/rust/tcl-lsp-rust/src/signature_scan.rs
+++ b/rust/tcl-lsp-rust/src/signature_scan.rs
@@ -39,7 +39,6 @@ use tcl_compiler::signature_scan::{
     },
 };
 use tcl_lexer::Span;
-use tcl_registry::CommandRegistry;
 
 /// Extract a [`SignatureScanResult`] for `source` and serialise it
 /// to a Python dict.
@@ -50,8 +49,7 @@ use tcl_registry::CommandRegistry;
 #[pyfunction]
 #[pyo3(signature = (source, /))]
 pub fn signature_scan_extract<'py>(py: Python<'py>, source: &str) -> PyResult<Bound<'py, PyDict>> {
-    let registry = CommandRegistry::build_default();
-    let result = extract_signatures(source, &registry);
+    let result = extract_signatures(source, crate::registry::default_registry());
     let out = PyDict::new_bound(py);
 
     let procs = PyDict::new_bound(py);

--- a/rust/tcl-lsp-rust/src/signature_scan.rs
+++ b/rust/tcl-lsp-rust/src/signature_scan.rs
@@ -19,8 +19,11 @@
 //! - `classes` — `{qualified_name: {name, qualified_name,
 //!   name_range, body_range}}`
 //! - `command_invocations` — list of `{name, range}` dicts
-//! - `package_requires`, `source_targets`, `command_aliases`,
-//!   `namespace_imports`, `auto_path_entries` — wired in C40e3
+//! - `package_requires` — list of `{name, version, range, conditional}`
+//! - `source_targets` — list of `{raw_path, range, is_literal}`
+//! - `command_aliases` — `{qualified_name: {qualified_name, target, extras}}`
+//! - `namespace_imports` — list of `{ns, pattern, range, conjectured}`
+//! - `auto_path_entries` — list of `{raw, range}`
 //!
 //! [`SignatureScanResult`]: tcl_compiler::signature_scan::SignatureScanResult
 
@@ -29,7 +32,11 @@ use pyo3::types::{PyDict, PyList};
 
 use tcl_compiler::signature_scan::{
     extract_signatures,
-    types::{ParamDef, SignatureClass, SignatureCommandInvocation, SignatureProc},
+    types::{
+        ParamDef, SignatureAutoPathEntry, SignatureClass, SignatureCommandAlias,
+        SignatureCommandInvocation, SignatureNamespaceImport, SignaturePackageRequire,
+        SignatureProc, SignatureSource,
+    },
 };
 use tcl_lexer::Span;
 use tcl_registry::CommandRegistry;
@@ -64,6 +71,36 @@ pub fn signature_scan_extract<'py>(py: Python<'py>, source: &str) -> PyResult<Bo
         invocations.append(invocation_to_dict(py, inv)?)?;
     }
     out.set_item("command_invocations", invocations)?;
+
+    let packages = PyList::empty_bound(py);
+    for pr in &result.package_requires {
+        packages.append(package_require_to_dict(py, pr)?)?;
+    }
+    out.set_item("package_requires", packages)?;
+
+    let sources = PyList::empty_bound(py);
+    for s in &result.source_targets {
+        sources.append(source_to_dict(py, s)?)?;
+    }
+    out.set_item("source_targets", sources)?;
+
+    let aliases = PyDict::new_bound(py);
+    for (qname, a) in &result.command_aliases {
+        aliases.set_item(qname, alias_to_dict(py, a)?)?;
+    }
+    out.set_item("command_aliases", aliases)?;
+
+    let imports = PyList::empty_bound(py);
+    for imp in &result.namespace_imports {
+        imports.append(namespace_import_to_dict(py, imp)?)?;
+    }
+    out.set_item("namespace_imports", imports)?;
+
+    let autopath = PyList::empty_bound(py);
+    for entry in &result.auto_path_entries {
+        autopath.append(auto_path_entry_to_dict(py, entry)?)?;
+    }
+    out.set_item("auto_path_entries", autopath)?;
 
     Ok(out)
 }
@@ -106,6 +143,56 @@ fn param_to_dict<'py>(py: Python<'py>, p: &ParamDef) -> PyResult<Bound<'py, PyDi
     d.set_item("name", &p.name)?;
     d.set_item("has_default", p.has_default)?;
     d.set_item("default_value", p.default_value.clone())?;
+    Ok(d)
+}
+
+fn package_require_to_dict<'py>(
+    py: Python<'py>,
+    pr: &SignaturePackageRequire,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("name", &pr.name)?;
+    d.set_item("version", pr.version.clone())?;
+    d.set_item("range", span_tuple(pr.range))?;
+    d.set_item("conditional", pr.conditional)?;
+    Ok(d)
+}
+
+fn source_to_dict<'py>(py: Python<'py>, s: &SignatureSource) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("raw_path", &s.raw_path)?;
+    d.set_item("range", span_tuple(s.range))?;
+    d.set_item("is_literal", s.is_literal)?;
+    Ok(d)
+}
+
+fn alias_to_dict<'py>(py: Python<'py>, a: &SignatureCommandAlias) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("qualified_name", &a.qualified_name)?;
+    d.set_item("target", &a.target)?;
+    d.set_item("extras", PyList::new_bound(py, &a.extras))?;
+    Ok(d)
+}
+
+fn namespace_import_to_dict<'py>(
+    py: Python<'py>,
+    imp: &SignatureNamespaceImport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("ns", &imp.ns)?;
+    d.set_item("pattern", &imp.pattern)?;
+    d.set_item("range", span_tuple(imp.range))?;
+    d.set_item("conjectured", imp.conjectured)?;
+    Ok(d)
+}
+
+fn auto_path_entry_to_dict<'py>(
+    py: Python<'py>,
+    entry: &SignatureAutoPathEntry,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new_bound(py);
+    d.set_item("raw", &entry.raw)?;
+    d.set_item("range", span_tuple(entry.range))?;
     Ok(d)
 }
 

--- a/tests/test_rust_bindings_smoke.py
+++ b/tests/test_rust_bindings_smoke.py
@@ -164,3 +164,25 @@ def test_signature_scan_extract_proc_record() -> None:
     assert len(proc["name_range"]) == 2
     # And there should be one command_invocations entry for `proc`.
     assert any(inv["name"] == "proc" for inv in result["command_invocations"])
+
+
+def test_signature_scan_extract_full_collections() -> None:
+    """C40e3 smoke test: a multi-handler source populates every
+    collection key in the returned dict."""
+    src = """
+proc foo {} {}
+oo::class create MyCls {}
+package require Tcl 8.6
+source /a/b.tcl
+interp alias {} myalias {} puts hello
+namespace import ::tcl::mathfunc::*
+lappend auto_path /opt/tclpkgs
+"""
+    result = tcl_lsp_rust.signature_scan_extract(src)
+    assert "::foo" in result["procs"]
+    assert "::MyCls" in result["classes"]
+    assert any(p["name"] == "Tcl" for p in result["package_requires"])
+    assert any(s["raw_path"] == "/a/b.tcl" for s in result["source_targets"])
+    assert "::myalias" in result["command_aliases"]
+    assert any(i["pattern"] == "::tcl::mathfunc::*" for i in result["namespace_imports"])
+    assert any(e["raw"] == "/opt/tclpkgs" for e in result["auto_path_entries"])

--- a/tests/test_rust_bindings_smoke.py
+++ b/tests/test_rust_bindings_smoke.py
@@ -138,3 +138,11 @@ def test_build_compilation_unit_returns_handle() -> None:
     assert cu.has_interprocedural is True
     # Repr smoke test.
     assert "CompilationUnit" in repr(cu)
+
+
+def test_signature_scan_extract_returns_dict() -> None:
+    """C40e1 smoke test: ``signature_scan_extract`` returns a dict;
+    the empty source case yields an empty dict (collections wired in
+    later C40e sub-strips)."""
+    result = tcl_lsp_rust.signature_scan_extract("")
+    assert isinstance(result, dict)

--- a/tests/test_rust_bindings_smoke.py
+++ b/tests/test_rust_bindings_smoke.py
@@ -146,3 +146,21 @@ def test_signature_scan_extract_returns_dict() -> None:
     later C40e sub-strips)."""
     result = tcl_lsp_rust.signature_scan_extract("")
     assert isinstance(result, dict)
+
+
+def test_signature_scan_extract_proc_record() -> None:
+    """C40e2 smoke test: ``signature_scan_extract`` populates the
+    ``procs`` collection with name + qualified_name + params +
+    range tuples."""
+    result = tcl_lsp_rust.signature_scan_extract("proc foo {a b} { return $a }")
+    assert "::foo" in result["procs"]
+    proc = result["procs"]["::foo"]
+    assert proc["name"] == "foo"
+    assert proc["qualified_name"] == "::foo"
+    assert len(proc["params"]) == 2
+    assert proc["params"][0]["name"] == "a"
+    assert proc["params"][0]["has_default"] is False
+    assert isinstance(proc["name_range"], tuple)
+    assert len(proc["name_range"]) == 2
+    # And there should be one command_invocations entry for `proc`.
+    assert any(inv["name"] == "proc" for inv in result["command_invocations"])

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -52,3 +52,109 @@ def _assert_same(source: str) -> None:
 def test_simple_proc_parity() -> None:
     """Sanity check: a single bare proc round-trips identically."""
     _assert_same("proc foo {} {}")
+
+
+# Inline corpus — one tuple per fixture. Each tuple is
+# ``(label, source)``; the label drives the pytest test ID so
+# failures point at the offending shape directly.
+CORPUS: list[tuple[str, str]] = [
+    # -- procs / namespaces --
+    ("bare_proc", "proc foo {} {}"),
+    ("namespace_qualified_proc", "proc ::foo::bar {} {}"),
+    ("namespace_eval_with_inner", "namespace eval ns { proc inner {} {} }"),
+    (
+        "nested_namespace_eval",
+        "namespace eval outer { namespace eval inner { proc deep {} {} } }",
+    ),
+    (
+        "absolute_proc_under_namespace",
+        "namespace eval baz { proc ::foo::bar {} {} }",
+    ),
+    # -- classes --
+    ("oo_class_no_body", "oo::class create MyCls"),
+    ("oo_class_with_body", "oo::class create MyCls { method foo {} {} }"),
+    ("oo_class_absolute", "oo::class create ::Top"),
+    ("itcl_class", "itcl::class Foo { constructor {} {} }"),
+    # -- packages --
+    ("package_with_version", "package require Tcl 8.6"),
+    ("package_without_version", "package require Tcl"),
+    ("package_exact_flag", "package require -exact Tcl 8.6"),
+    (
+        "package_under_if_marked_conditional",
+        "if {[catch {package require Tcl 8.6}]} { proc fallback {} {} }",
+    ),
+    # -- sources --
+    ("source_literal_path", "source /abs/path.tcl"),
+    # NOTE: a `source $script_dir/init.tcl` fixture (multi-token word
+    # combining a `$var` substitution and a literal trailing path)
+    # currently diverges between the Python and Rust segmenters —
+    # Python widens `argv[i].end` to the end of the whole word, the
+    # Rust segmenter keeps it at the first sub-token's end. The
+    # divergence is in `rust/tcl-compiler/src/segmenter.rs` (the
+    # `else if let Some(last_text) = …` branch), not in
+    # `signature_scan` itself. Add a regression fixture once the
+    # segmenter fix lands.
+    ("source_with_encoding_option", "source -encoding utf-8 /a/b.tcl"),
+    # -- interp aliases --
+    (
+        "interp_alias_local",
+        "interp alias {} myalias {} puts hello",
+    ),
+    (
+        "interp_alias_cross_skipped",
+        "interp alias child foo {} puts",
+    ),
+    # -- namespace imports --
+    ("namespace_import_direct", "namespace import ::tcl::mathfunc::*"),
+    (
+        "namespace_import_tcllib_wrapper",
+        "term::ansi::send::import vt",
+    ),
+    # -- auto_path --
+    ("lappend_auto_path", "lappend auto_path /opt/tclpkgs"),
+    ("set_auto_path", "set auto_path /opt/tclpkgs"),
+    # -- structured-control body recursion --
+    (
+        "if_branch_with_inner_proc",
+        "if {$x} { proc thenproc {} {} } else { proc elseproc {} {} }",
+    ),
+    (
+        "try_finally_with_inner_proc",
+        "try { proc tryproc {} {} } finally { proc finallyproc {} {} }",
+    ),
+    (
+        "catch_with_inner_proc",
+        "catch { proc inner {} {} } result",
+    ),
+    # -- factory wrappers --
+    (
+        "tcllib_factory_wrapper",
+        """
+        proc DEFC {name args body} { proc $name $args $body }
+        proc INIT {} {
+            DEFC ChildA {x} {return 1}
+            DEFC ChildB {y} {return 2}
+        }
+        """,
+    ),
+    (
+        "factory_in_namespace",
+        """
+        namespace eval pkg {
+            proc DEFC {name args body} { proc $name $args $body }
+            proc INIT {} { DEFC Local {x} {return 1} }
+        }
+        """,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    CORPUS,
+    ids=[label for label, _ in CORPUS],
+)
+def test_signature_scan_matches_python(label: str, source: str) -> None:
+    """Field-by-field parity for every corpus fixture."""
+    del label  # only used as the pytest id
+    _assert_same(source)

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -17,9 +17,15 @@ import pytest
 
 pytest.importorskip("tcl_lsp_rust", reason="tcl_lsp_rust extension not built into this venv")
 
-from tcl_lsp_rust import (  # noqa: E402
-    signature_scan_extract,  # ty: ignore[unresolved-import]
-)
+# ty's `# ty: ignore` directive must sit on the diagnostic line —
+# the unresolved-import is reported on the `from tcl_lsp_rust`
+# token (this line), not on the symbol-line below. The
+# `core/analysis/signature_scan.py` shim wraps its import in
+# `try/except ImportError`, which ty treats as a runtime gate; we
+# can't do that here because `pytest.importorskip` already raises a
+# Skipped exception above, so the import block needs an explicit
+# inline suppression.
+from tcl_lsp_rust import signature_scan_extract  # noqa: E402  # ty: ignore[unresolved-import]
 
 from core.analysis.semantic_model import AnalysisResult  # noqa: E402
 from core.analysis.signature_scan import (  # noqa: E402

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -158,3 +158,65 @@ def test_signature_scan_matches_python(label: str, source: str) -> None:
     """Field-by-field parity for every corpus fixture."""
     del label  # only used as the pytest id
     _assert_same(source)
+
+
+# Dispatcher gating tests. The corpus tests above call the Rust path
+# directly; these assert the env-var-gated dispatcher in
+# ``core/analysis/signature_scan.py::extract_signatures`` behaves
+# correctly.
+
+import core.analysis.signature_scan as signature_scan_module  # noqa: E402
+from core.analysis.signature_scan import extract_signatures  # noqa: E402
+
+
+def test_dispatcher_default_off_uses_python(monkeypatch) -> None:
+    """With the env var unset, ``extract_signatures`` must use the
+    Python implementation regardless of binding availability."""
+    monkeypatch.delenv("TCL_LSP_RUST_SIGNATURE_SCAN", raising=False)
+
+    def _boom(_source):
+        raise AssertionError("rust path must not be called when env var unset")
+
+    monkeypatch.setattr(signature_scan_module, "_rust_extract", _boom)
+    result = extract_signatures("proc foo {} {}")
+    assert "::foo" in result.all_procs
+
+
+def test_dispatcher_env_var_on_uses_rust(monkeypatch) -> None:
+    """With ``TCL_LSP_RUST_SIGNATURE_SCAN=1``, the Rust path runs and
+    its result is materialised by ``_materialise_rust_signatures``.
+    A sentinel raw dict from a patched ``_rust_extract`` proves the
+    dispatcher consulted the binding rather than the Python
+    implementation."""
+    monkeypatch.setenv("TCL_LSP_RUST_SIGNATURE_SCAN", "1")
+    sentinel_raw = {
+        "procs": {
+            "::sentinel": {
+                "name": "sentinel",
+                "qualified_name": "::sentinel",
+                "params": [],
+                "name_range": (0, 8),
+                "body_range": (10, 20),
+            }
+        },
+        # Empty collections — exercise the materialiser's defaulting.
+    }
+    monkeypatch.setattr(signature_scan_module, "_rust_extract", lambda _src: sentinel_raw)
+    result = extract_signatures("source ignored — patched rust returns sentinel")
+    assert "::sentinel" in result.all_procs
+    # Python path would have produced no procs for that source.
+    assert "::foo" not in result.all_procs
+
+
+def test_dispatcher_rust_exception_falls_back_to_python(monkeypatch, caplog) -> None:
+    """If the Rust path raises, the dispatcher logs at DEBUG and the
+    Python implementation runs as a safety net."""
+    monkeypatch.setenv("TCL_LSP_RUST_SIGNATURE_SCAN", "1")
+
+    def _raise(_source):
+        raise RuntimeError("simulated rust crash")
+
+    monkeypatch.setattr(signature_scan_module, "_rust_extract", _raise)
+    result = extract_signatures("proc foo {} {}")
+    # Python path produced the proc — fallback worked.
+    assert "::foo" in result.all_procs

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -1,31 +1,43 @@
 """Differential parity harness for the C40 ``signature_scan`` Rust port.
 
-For each fixture in :data:`CORPUS`, both the Python implementation
+The **parity tests** exercise both the Python implementation
 (``_extract_signatures_python``) and the Rust path (via
 ``signature_scan_extract`` + the ``_materialise_rust_signatures``
-helper) are exercised and asserted to produce field-by-field
-equivalent :class:`AnalysisResult` records on the subset of fields
-``signature_scan`` populates.
+helper) and assert field-by-field equivalent :class:`AnalysisResult`
+records on the subset of fields ``signature_scan`` populates.
 
-Skipped wholesale when the ``tcl_lsp_rust`` binding cannot be
-imported.
+The **dispatcher gating tests** assert the env-var-gated
+dispatcher in ``core/analysis/signature_scan.py::extract_signatures``
+behaves correctly. They patch ``signature_scan_module._rust_extract``
+with a test double and never actually call the real binding, so
+they run in Python-only environments too.
+
+Tests that require the rust wheel call ``_require_rust_binding()``
+on entry; tests that don't are unconditional.
 """
 
 from __future__ import annotations
 
 import pytest
 
-# Capture the binding as a module object — ``from tcl_lsp_rust
-# import …`` would trip ``ty``'s ``unresolved-import`` check in
-# environments where the rust wheel isn't installed (CI lints
-# without building). Mirrors the pattern in
-# ``tests/test_rust_bindings_smoke.py``.
-tcl_lsp_rust = pytest.importorskip(
-    "tcl_lsp_rust",
-    reason="tcl_lsp_rust extension not built into this venv",
-)
+from core.analysis.semantic_model import AnalysisResult
 
-from core.analysis.semantic_model import AnalysisResult  # noqa: E402
+
+def _require_rust_binding():
+    """Skip the calling test when the ``tcl_lsp_rust`` wheel is
+    absent. Returns the module object on success.
+
+    Captured as a module object — ``from tcl_lsp_rust import …``
+    would trip ``ty``'s ``unresolved-import`` check in environments
+    where the wheel isn't installed (CI lints without building).
+    Mirrors the pattern in ``tests/test_rust_bindings_smoke.py``.
+    """
+    return pytest.importorskip(
+        "tcl_lsp_rust",
+        reason="tcl_lsp_rust extension not built into this venv",
+    )
+
+
 from core.analysis.signature_scan import (  # noqa: E402
     _extract_signatures_python,
     _materialise_rust_signatures,
@@ -47,7 +59,11 @@ def _compare_results(py: AnalysisResult, rust: AnalysisResult) -> None:
 
 
 def _assert_same(source: str) -> None:
-    """Run both implementations on ``source`` and assert parity."""
+    """Run both implementations on ``source`` and assert parity.
+
+    Skips the test when the rust binding isn't built.
+    """
+    tcl_lsp_rust = _require_rust_binding()
     py = _extract_signatures_python(source)
     rust = _materialise_rust_signatures(source, tcl_lsp_rust.signature_scan_extract(source))
     _compare_results(py, rust)

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -15,17 +15,15 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("tcl_lsp_rust", reason="tcl_lsp_rust extension not built into this venv")
-
-# ty's `# ty: ignore` directive must sit on the diagnostic line —
-# the unresolved-import is reported on the `from tcl_lsp_rust`
-# token (this line), not on the symbol-line below. The
-# `core/analysis/signature_scan.py` shim wraps its import in
-# `try/except ImportError`, which ty treats as a runtime gate; we
-# can't do that here because `pytest.importorskip` already raises a
-# Skipped exception above, so the import block needs an explicit
-# inline suppression.
-from tcl_lsp_rust import signature_scan_extract  # noqa: E402  # ty: ignore[unresolved-import]
+# Capture the binding as a module object — ``from tcl_lsp_rust
+# import …`` would trip ``ty``'s ``unresolved-import`` check in
+# environments where the rust wheel isn't installed (CI lints
+# without building). Mirrors the pattern in
+# ``tests/test_rust_bindings_smoke.py``.
+tcl_lsp_rust = pytest.importorskip(
+    "tcl_lsp_rust",
+    reason="tcl_lsp_rust extension not built into this venv",
+)
 
 from core.analysis.semantic_model import AnalysisResult  # noqa: E402
 from core.analysis.signature_scan import (  # noqa: E402
@@ -51,7 +49,7 @@ def _compare_results(py: AnalysisResult, rust: AnalysisResult) -> None:
 def _assert_same(source: str) -> None:
     """Run both implementations on ``source`` and assert parity."""
     py = _extract_signatures_python(source)
-    rust = _materialise_rust_signatures(source, signature_scan_extract(source))
+    rust = _materialise_rust_signatures(source, tcl_lsp_rust.signature_scan_extract(source))
     _compare_results(py, rust)
 
 

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -1,0 +1,54 @@
+"""Differential parity harness for the C40 ``signature_scan`` Rust port.
+
+For each fixture in :data:`CORPUS`, both the Python implementation
+(``_extract_signatures_python``) and the Rust path (via
+``signature_scan_extract`` + the ``_materialise_rust_signatures``
+helper) are exercised and asserted to produce field-by-field
+equivalent :class:`AnalysisResult` records on the subset of fields
+``signature_scan`` populates.
+
+Skipped wholesale when the ``tcl_lsp_rust`` binding cannot be
+imported.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tcl_lsp_rust", reason="tcl_lsp_rust extension not built into this venv")
+
+from tcl_lsp_rust import (  # noqa: E402
+    signature_scan_extract,  # ty: ignore[unresolved-import]
+)
+
+from core.analysis.semantic_model import AnalysisResult  # noqa: E402
+from core.analysis.signature_scan import (  # noqa: E402
+    _extract_signatures_python,
+    _materialise_rust_signatures,
+)
+
+
+def _compare_results(py: AnalysisResult, rust: AnalysisResult) -> None:
+    """Assert that ``py`` and ``rust`` are field-equal on the
+    subset of :class:`AnalysisResult` populated by signature_scan.
+    """
+    assert py.all_procs == rust.all_procs, "all_procs mismatch"
+    assert py.all_classes == rust.all_classes, "all_classes mismatch"
+    assert py.package_requires == rust.package_requires, "package_requires mismatch"
+    assert py.source_targets == rust.source_targets, "source_targets mismatch"
+    assert py.command_aliases == rust.command_aliases, "command_aliases mismatch"
+    assert py.namespace_imports == rust.namespace_imports, "namespace_imports mismatch"
+    assert py.auto_path_entries == rust.auto_path_entries, "auto_path_entries mismatch"
+    assert py.command_invocations == rust.command_invocations, "command_invocations mismatch"
+
+
+def _assert_same(source: str) -> None:
+    """Run both implementations on ``source`` and assert parity."""
+    py = _extract_signatures_python(source)
+    rust = _materialise_rust_signatures(source, signature_scan_extract(source))
+    _compare_results(py, rust)
+
+
+def test_simple_proc_parity() -> None:
+    """Sanity check: a single bare proc round-trips identically."""
+    _assert_same("proc foo {} {}")

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -212,6 +212,23 @@ def test_dispatcher_env_var_on_uses_rust(monkeypatch) -> None:
     assert "::foo" not in result.all_procs
 
 
+def test_dispatcher_env_var_zero_does_not_enable_rust(monkeypatch) -> None:
+    """``TCL_LSP_RUST_SIGNATURE_SCAN=0`` must NOT activate the rust
+    path. Pre-fix this regressed: ``os.environ.get(name)`` was truthy
+    for any non-empty string including ``"0"``, opting users into
+    the experimental path when they thought they were disabling it.
+    The shared ``rust_shim_enabled`` helper now recognises ``0`` /
+    ``false`` / ``no`` / ``off`` (and the empty string) as off."""
+    monkeypatch.setenv("TCL_LSP_RUST_SIGNATURE_SCAN", "0")
+
+    def _boom(_source):
+        raise AssertionError("rust path must not be called for env var = '0'")
+
+    monkeypatch.setattr(signature_scan_module, "_rust_extract", _boom)
+    result = extract_signatures("proc foo {} {}")
+    assert "::foo" in result.all_procs
+
+
 def test_dispatcher_rust_exception_falls_back_to_python(monkeypatch, caplog) -> None:
     """If the Rust path raises, the dispatcher logs at DEBUG and the
     Python implementation runs as a safety net."""


### PR DESCRIPTION
The rust rewrite branch had 89 chunks (C27a → C29) on a disjoint
history. This commit re-bases the rewrite onto main's tip by:

1. Hard-resetting the branch pointer to origin/main.
2. Restoring the rust-rewrite-unique tree from the pre-reset
   tip (5fe31ef2):
   - rust/ workspace (tcl-lexer, tcl-compiler, tcl-registry,
     tcl-lsp-rust)
   - Cargo.toml / Cargo.lock / rust-toolchain.toml
   - docs/rust-rewrite.md, docs/rust-rewrite-test-audit.md,
     docs/rust-optimiser-parity.md
   - core/compiler/rust_spans.py
   - tests/test_rust_*.py + tests/test_tokens.py
3. Re-applying Python-side Rust dispatch shims on top of main:
   - core/compiler/optimiser/_manager.py — TCL_LSP_RUST_OPTIMISER
   - core/compiler/gvn.py — TCL_LSP_RUST_GVN
   - core/compiler/interprocedural.py — TCL_LSP_RUST_INTERPROC
   - core/parsing/lexer.py / substitution.py / tokens.py /
     expr_lexer.py — Rust primary path with Python fallback
4. Splicing rust-* targets into main's Makefile
   (RUST_STAMP / rust-build / rust-test / rust-lint / rust-format
   / test-py-rust). Also wires rust-lint / rust-format into the
   composite lint / format targets.
5. Fixing a stale Makefile reference to core/analysis/analyser.py
   (split into core/analysis/_analyser/ on main) by replacing
   with an _analyser/*.py glob.
6. Regenerating core/irule_test/tcl/_registry_data.tcl after
   main added registry/lseq/zlib specs without a regen.
7. Preserving main's IEEE 754 special-literal fix in
   core/parsing/expr_lexer.py (Inf/NaN tokenisation, main
   commit ad81e67b) and porting the same fix into Rust
   rust/tcl-lexer/src/expr_lexer.rs::ident — adds a unit test
   covering all six spellings.
8. Adding #[allow(clippy::too_many_lines)] on
   codegen::values::emit_incr (now 115 LOC, exceeds the 100-LOC
   pedantic ceiling under current clippy).

Verification: cargo fmt --check + cargo clippy -D warnings + cargo
test --workspace + make rust-build + make prep-pr all green.
1148 cargo --lib tests passing; 12,214 Python tests passing.

The deferred porting work — var_escape (C33), uplevel-passthrough
inlining (C34), const-propagate-uplevel (C35), factory
specialisation (C36), parse-cache + namespace-import perf (C37/38),
small codegen fixes (C39), and registry deltas (lseq/registry/zlib
specs, fcopy/tailcall arity) — is tracked in the chunk log
extensions and lands as separate commits.

https://claude.ai/code/session_01Y321XDNQQjnn6jm12y2YJN