### PR TITLE
Extract incr lowering hook to dedicated module

### DIFF
--- a/rust/tcl-compiler/src/lowering/hooks/incr.rs
+++ b/rust/tcl-compiler/src/lowering/hooks/incr.rs
@@ -17,7 +17,7 @@
 //! the unmodified word vector.
 
 use crate::ir::Statement;
-use crate::lowering_hooks::LoweringCommand;
+use crate::lowering_hooks::{make_call, LoweringCommand};
 
 /// Lower `incr` to [`Statement::Incr`] or fall back to
 /// [`Statement::Call`] when the call shape is not the
@@ -26,16 +26,7 @@ use crate::lowering_hooks::LoweringCommand;
 pub fn try_lower_incr(cmd: &LoweringCommand<'_>) -> Statement {
     let has_expansion = cmd.expand_word.is_some_and(|ew| ew.iter().any(|&e| e));
     if has_expansion || cmd.args.is_empty() || cmd.args.len() > 2 {
-        return Statement::Call {
-            span: cmd.span,
-            command: cmd.name.into(),
-            args: cmd.args.to_vec(),
-            defs: vec![],
-            reads: vec![],
-            reads_own_defs: false,
-            safe_on_uninit: false,
-            tokens: cmd.tokens.clone(),
-        };
+        return make_call(cmd);
     }
     Statement::Incr {
         span: cmd.span,

--- a/rust/tcl-compiler/src/lowering/hooks/incr.rs
+++ b/rust/tcl-compiler/src/lowering/hooks/incr.rs
@@ -1,0 +1,223 @@
+//! Lower the `incr` command to a typed IR statement.
+//!
+//! Mirrors `core/compiler/lowering_hooks/_var.py::lower_incr`.
+//!
+//! `incr name ?amount?` increments `name` by `amount` (default 1)
+//! and returns the new value. Specialises to [`Statement::Incr`]
+//! when:
+//!
+//! 1. There is no `{*}` argument expansion (otherwise the runtime
+//!    arg count is unknown and the specialised path is unsafe).
+//! 2. There is at least one positional argument (the variable name).
+//! 3. There are at most two positional arguments (name + optional
+//!    amount).
+//!
+//! Anything else falls back to a generic [`Statement::Call`] so the
+//! runtime sees the original argument list and arity checks fire on
+//! the unmodified word vector.
+
+use crate::ir::Statement;
+use crate::lowering_hooks::LoweringCommand;
+
+/// Lower `incr` to [`Statement::Incr`] or fall back to
+/// [`Statement::Call`] when the call shape is not the
+/// specialise-able `incr name ?amount?` form.
+#[must_use]
+pub fn try_lower_incr(cmd: &LoweringCommand<'_>) -> Statement {
+    let has_expansion = cmd.expand_word.is_some_and(|ew| ew.iter().any(|&e| e));
+    if has_expansion || cmd.args.is_empty() || cmd.args.len() > 2 {
+        return Statement::Call {
+            span: cmd.span,
+            command: cmd.name.into(),
+            args: cmd.args.to_vec(),
+            defs: vec![],
+            reads: vec![],
+            reads_own_defs: false,
+            safe_on_uninit: false,
+            tokens: cmd.tokens.clone(),
+        };
+    }
+    Statement::Incr {
+        span: cmd.span,
+        name: cmd.args[0].clone(),
+        amount: cmd.args.get(1).cloned(),
+        // The Python hook queries the registry's ``safe_on_uninit``
+        // trait via ``REGISTRY.is_safe_on_uninit``. The Rust port
+        // leaves this ``false`` until the registry trait surface is
+        // wired up; downstream passes treat ``incr`` as if it reads
+        // the variable first, which is the conservative choice.
+        safe_on_uninit: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lowering::lower_to_ir;
+    use crate::lowering_hooks::ArgTokenKind;
+    use tcl_lexer::Span;
+    use tcl_registry::CommandRegistry;
+
+    fn reg() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    #[test]
+    fn incr_single_arg_lowers_to_incr() {
+        let m = lower_to_ir("incr i", &reg());
+        assert_eq!(m.top_level.statements.len(), 1);
+        match &m.top_level.statements[0] {
+            Statement::Incr { name, amount, .. } => {
+                assert_eq!(name, "i");
+                assert!(amount.is_none());
+            }
+            other => panic!("expected Incr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn incr_with_amount_lowers_to_incr() {
+        let m = lower_to_ir("incr i 2", &reg());
+        match &m.top_level.statements[0] {
+            Statement::Incr { name, amount, .. } => {
+                assert_eq!(name, "i");
+                assert_eq!(amount.as_deref(), Some("2"));
+            }
+            other => panic!("expected Incr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn incr_negative_amount_lowers_to_incr() {
+        let m = lower_to_ir("incr counter -5", &reg());
+        match &m.top_level.statements[0] {
+            Statement::Incr { name, amount, .. } => {
+                assert_eq!(name, "counter");
+                assert_eq!(amount.as_deref(), Some("-5"));
+            }
+            other => panic!("expected Incr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn incr_no_args_falls_back_to_call() {
+        let m = lower_to_ir("incr", &reg());
+        assert!(matches!(
+            &m.top_level.statements[0],
+            Statement::Call { command, .. } if command == "incr"
+        ));
+    }
+
+    #[test]
+    fn incr_too_many_args_falls_back_to_call() {
+        let m = lower_to_ir("incr i 1 2", &reg());
+        assert!(matches!(
+            &m.top_level.statements[0],
+            Statement::Call { command, .. } if command == "incr"
+        ));
+    }
+
+    #[test]
+    fn incr_with_brace_expansion_falls_back_to_call() {
+        // {*} expansion hides the real arg count — must not take
+        // the specialised IRIncr path.
+        let m = lower_to_ir("incr {*}$args", &reg());
+        assert!(matches!(
+            &m.top_level.statements[0],
+            Statement::Call { command, .. } if command == "incr"
+        ));
+    }
+
+    #[test]
+    fn incr_dispatcher_routes_through_try_lower_hook() {
+        // The shared dispatcher in ``lowering_hooks::try_lower_hook``
+        // must route ``incr`` to this module.
+        let m = lower_to_ir("set a 1\nincr a\nputs $a", &reg());
+        let stmts = &m.top_level.statements;
+        assert_eq!(stmts.len(), 3);
+        assert!(matches!(stmts[0], Statement::AssignConst { .. }));
+        assert!(matches!(stmts[1], Statement::Incr { .. }));
+        assert!(matches!(stmts[2], Statement::Call { .. }));
+    }
+
+    // Unit-level coverage of try_lower_incr for shape combinations
+    // that lower_to_ir cannot easily reach (e.g. the no-args and
+    // expansion cases via direct LoweringCommand construction).
+
+    fn make_cmd<'a>(
+        args: &'a [String],
+        single: &'a [bool],
+        kinds: &'a [ArgTokenKind],
+        expand: Option<&'a [bool]>,
+    ) -> LoweringCommand<'a> {
+        LoweringCommand {
+            span: Span::new(0, 8),
+            name: "incr",
+            args,
+            single_token_word: single,
+            expand_word: expand,
+            tokens: None,
+            arg_kinds: kinds,
+        }
+    }
+
+    #[test]
+    fn unit_incr_basic() {
+        let args = vec!["i".to_string()];
+        let single = vec![true, true];
+        let kinds = vec![ArgTokenKind::Esc];
+        let cmd = make_cmd(&args, &single, &kinds, None);
+        match try_lower_incr(&cmd) {
+            Statement::Incr {
+                name,
+                amount,
+                safe_on_uninit,
+                ..
+            } => {
+                assert_eq!(name, "i");
+                assert!(amount.is_none());
+                assert!(!safe_on_uninit);
+            }
+            other => panic!("expected Incr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unit_incr_with_amount() {
+        let args = vec!["i".to_string(), "5".to_string()];
+        let single = vec![true, true, true];
+        let kinds = vec![ArgTokenKind::Esc, ArgTokenKind::Esc];
+        let cmd = make_cmd(&args, &single, &kinds, None);
+        match try_lower_incr(&cmd) {
+            Statement::Incr { amount, .. } => assert_eq!(amount.as_deref(), Some("5")),
+            other => panic!("expected Incr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unit_incr_empty_args_makes_call() {
+        let args: Vec<String> = vec![];
+        let single = vec![true];
+        let kinds: Vec<ArgTokenKind> = vec![];
+        let cmd = make_cmd(&args, &single, &kinds, None);
+        assert!(matches!(try_lower_incr(&cmd), Statement::Call { .. }));
+    }
+
+    #[test]
+    fn unit_incr_expansion_makes_call() {
+        let args = vec!["i".to_string()];
+        let single = vec![true, true];
+        let kinds = vec![ArgTokenKind::Var];
+        let expand = vec![false, true];
+        let cmd = make_cmd(&args, &single, &kinds, Some(&expand));
+        match try_lower_incr(&cmd) {
+            Statement::Call {
+                command, args: a, ..
+            } => {
+                assert_eq!(command, "incr");
+                assert_eq!(a, vec!["i"]);
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+}

--- a/rust/tcl-compiler/src/lowering/hooks/mod.rs
+++ b/rust/tcl-compiler/src/lowering/hooks/mod.rs
@@ -1,0 +1,14 @@
+//! Per-command lowering specialisations, one file per command.
+//!
+//! Each submodule exposes a `try_lower_<name>` entry point that takes
+//! a [`LoweringCommand`](crate::lowering_hooks::LoweringCommand) and
+//! returns a [`Statement`](crate::ir::Statement). The shared
+//! dispatcher in [`crate::lowering_hooks::try_lower_hook`] routes
+//! command names to the matching submodule.
+//!
+//! Mirrors the per-hook layout of `core/compiler/lowering_hooks/`,
+//! split out from the original monolithic
+//! `crate::lowering_hooks` module so each command's logic lives in
+//! its own file (chunk **C43**).
+
+pub mod incr;

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -17,7 +17,7 @@ use crate::lowering_hooks::{try_lower_hook, ArgTokenKind, LoweringCommand};
 use crate::naming::{normalise_qualified_name, normalise_var_name};
 use crate::segmenter::{segment_commands, segment_commands_with_offset, SegmentedCommand};
 
-pub mod hooks;
+pub(crate) mod hooks;
 mod structured;
 
 /// Map token kind to the simplified `ArgTokenKind` used by lowering hooks.

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -17,6 +17,7 @@ use crate::lowering_hooks::{try_lower_hook, ArgTokenKind, LoweringCommand};
 use crate::naming::{normalise_qualified_name, normalise_var_name};
 use crate::segmenter::{segment_commands, segment_commands_with_offset, SegmentedCommand};
 
+pub mod hooks;
 mod structured;
 
 /// Map token kind to the simplified `ArgTokenKind` used by lowering hooks.

--- a/rust/tcl-compiler/src/lowering_hooks.rs
+++ b/rust/tcl-compiler/src/lowering_hooks.rs
@@ -354,7 +354,12 @@ fn lower_upvar(cmd: &LoweringCommand<'_>) -> Option<Statement> {
 // ── Helpers ───────────────────────────────────────────────────────
 
 /// Build a generic `Statement::Call` from a lowering command.
-fn make_call(cmd: &LoweringCommand<'_>) -> Statement {
+///
+/// Shared with the per-command hook modules under
+/// [`crate::lowering::hooks`] so every fallback site produces the
+/// same `Call` shape and stays in sync if `Statement::Call` grows
+/// new fields.
+pub(crate) fn make_call(cmd: &LoweringCommand<'_>) -> Statement {
     Statement::Call {
         span: cmd.span,
         command: cmd.name.into(),

--- a/rust/tcl-compiler/src/lowering_hooks.rs
+++ b/rust/tcl-compiler/src/lowering_hooks.rs
@@ -64,7 +64,7 @@ pub fn try_lower_hook(cmd: &LoweringCommand<'_>, aliases: &CommandAliasMap) -> O
         "expr" => lower_expr(cmd),
         "return" => Some(lower_return(cmd, aliases)),
         "set" => Some(lower_set(cmd, aliases)),
-        "incr" => Some(lower_incr(cmd)),
+        "incr" => Some(crate::lowering::hooks::incr::try_lower_incr(cmd)),
         "append" | "lappend" => lower_append_lappend(cmd),
         "unset" => Some(lower_unset(cmd)),
         "global" => lower_global(cmd),
@@ -222,18 +222,10 @@ fn lower_set(cmd: &LoweringCommand<'_>, aliases: &CommandAliasMap) -> Statement 
 }
 
 // ── incr ──────────────────────────────────────────────────────────
-
-fn lower_incr(cmd: &LoweringCommand<'_>) -> Statement {
-    if has_expansion(cmd) || cmd.args.is_empty() || cmd.args.len() > 2 {
-        return make_call(cmd);
-    }
-    Statement::Incr {
-        span: cmd.span,
-        name: cmd.args[0].clone(),
-        amount: cmd.args.get(1).cloned(),
-        safe_on_uninit: false,
-    }
-}
+//
+// Moved to `crate::lowering::hooks::incr::try_lower_incr` (chunk
+// **C43**). The dispatcher above delegates the `"incr"` case to
+// the per-hook module.
 
 // ── append / lappend ──────────────────────────────────────────────
 
@@ -559,24 +551,6 @@ mod tests {
             matches!(result, Statement::AssignConst { .. }),
             "expected AssignConst for integer; got {result:?}"
         );
-    }
-
-    #[test]
-    fn lower_incr_basic() {
-        let args = vec!["i".to_string()];
-        let single = vec![true, true];
-        let kinds = vec![ArgTokenKind::Esc];
-        let cmd = LoweringCommand {
-            span: Span::new(0, 6),
-            name: "incr",
-            args: &args,
-            single_token_word: &single,
-            expand_word: None,
-            tokens: None,
-            arg_kinds: &kinds,
-        };
-        let result = lower_incr(&cmd);
-        assert!(matches!(result, Statement::Incr { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extracted the `incr` command lowering logic from the monolithic `lowering_hooks.rs` module into a dedicated `lowering/hooks/incr.rs` file
- Created a new `lowering/hooks/mod.rs` module to organize per-command lowering specializations
- Updated the dispatcher in `lowering_hooks::try_lower_hook` to delegate `incr` to the new module
- Moved all `incr`-related tests to the new module and added comprehensive unit-level test coverage

This refactoring mirrors the per-hook layout of the Python compiler (`core/compiler/lowering_hooks/`), improving code organization and maintainability by giving each command's lowering logic its own file.

## Validation

- [x] All existing tests pass (incr lowering tests migrated and expanded)
- [x] New unit tests added for edge cases (empty args, expansion, too many args)
- [x] Integration tests verify dispatcher routing through the new module

https://claude.ai/code/session_01MZHXr7VHbqoVjUofcTeQ3j