### PR TITLE
lsp/rust: regroup folding under a features/ module

### DIFF
--- a/rust/tcl-lsp-rust/src/features/folding.rs
+++ b/rust/tcl-lsp-rust/src/features/folding.rs
@@ -8,8 +8,8 @@
 //! recurses through nested braced bodies.
 //!
 //! The result is a fully line-resolved `Vec<FoldingRange>`.  The
-//! `PyO3` binding (in `lib.rs`) emits these as plain dicts; the
-//! Python dispatcher in `lsp/features/folding.py` materialises
+//! `PyO3` binding (`super::folding_binding`) emits these as plain
+//! dicts; the Python dispatcher in `lsp/features/folding.py` materialises
 //! [`lsprotocol.types.FoldingRange`] values and runs
 //! `_normalise_overlaps` on them — keeping the overlap-normalisation
 //! algorithm in Python preserves the
@@ -655,7 +655,7 @@ mod tests {
                     continue;
                 }
                 let overlaps = a.end_line >= b.start_line && a.start_line <= b.end_line;
-                assert!(!overlaps, "non-nested overlap between {a:?} and {b:?}",);
+                assert!(!overlaps, "non-nested overlap between {a:?} and {b:?}");
             }
         }
     }

--- a/rust/tcl-lsp-rust/src/features/folding_binding.rs
+++ b/rust/tcl-lsp-rust/src/features/folding_binding.rs
@@ -7,7 +7,7 @@
 //! Exposes ``folding_ranges(source, dialect)`` to Python.  Returns
 //! a list of `{"start_line", "end_line", "kind"}` dicts where
 //! `start_line` / `end_line` are 0-based inclusive line numbers and
-//! `kind` is the lower-case wire form of [`crate::folding::FoldKind`]
+//! `kind` is the lower-case wire form of [`super::folding::FoldKind`]
 //! (`"region"` / `"comment"`) — the same string `lsprotocol`'s
 //! `FoldingRangeKind` enum uses.
 //!
@@ -21,7 +21,7 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
-use crate::folding::{folding_ranges as compute_folding_ranges, FoldingRange};
+use super::folding::{folding_ranges as compute_folding_ranges, FoldingRange};
 
 /// Compute folding ranges for a Tcl source document, returning a
 /// list of dicts.

--- a/rust/tcl-lsp-rust/src/features/mod.rs
+++ b/rust/tcl-lsp-rust/src/features/mod.rs
@@ -1,0 +1,23 @@
+//! LSP feature providers.
+//!
+//! Houses the per-feature ports of `lsp/features/*.py` together with
+//! their `PyO3` bindings.  Each feature lives in its own submodule:
+//! the pure provider (`<feature>.rs`) is `pyo3`-free so it can later
+//! lift cleanly into `tcl-lsp-core` per `ARCH0` in
+//! [`docs/rust-rewrite.md`], while the binding (`<feature>_binding.rs`)
+//! holds the Python-facing wrapper.
+//!
+//! `register_with` aggregates the per-feature `register_with` entry
+//! points so `lib.rs` only knows about `features::register_with`.
+
+use pyo3::prelude::*;
+
+pub mod folding;
+mod folding_binding;
+
+/// Register every feature provider's Python-facing functions on the
+/// extension module.
+pub fn register_with(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    folding_binding::register_with(m)?;
+    Ok(())
+}

--- a/rust/tcl-lsp-rust/src/lib.rs
+++ b/rust/tcl-lsp-rust/src/lib.rs
@@ -27,8 +27,7 @@ mod compilation_unit;
 mod compiler_checks;
 mod expr_lexer;
 mod expr_parser;
-pub mod folding;
-mod folding_binding;
+mod features;
 mod gvn;
 mod interprocedural;
 mod lexer;
@@ -95,6 +94,6 @@ fn tcl_lsp_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     compilation_unit::register_with(m)?;
     signature_scan::register_with(m)?;
     analyser::register_with(m)?;
-    folding_binding::register_with(m)?;
+    features::register_with(m)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Move `rust/tcl-lsp-rust/src/folding.rs` and `folding_binding.rs` under `src/features/`, and add a `features/mod.rs` that aggregates per-feature `register_with` hooks.  `lib.rs` now only knows about `features::register_with`, establishing the per-feature module convention the S* LSP-server port will fan out into.
- The pure provider stays `pyo3`-free so it can later lift cleanly into the planned `tcl-lsp-core` crate per ARCH0 in `docs/rust-rewrite.md`; the binding remains the only Python-facing layer.
- Drive-by: drop a clippy-1.95 `unnecessary_trailing_comma` in the nested-if-else cargo test.

## Notes

- The functional folding port already landed in #223 — this PR is the structural follow-up that puts the existing files where the per-feature module convention wants them.  No behavioural change: the cargo unit tests in `features::folding::tests` (16 tests) and the Python `tests/test_folding.py` suite all still pass unchanged.
- Targeting `rust` (not `main`) per the chunk's plan.

## Test plan

- [x] `rustup run 1.95.0 cargo clippy --workspace --all-targets -- -D warnings` (matching CI's clippy)
- [x] `cargo test -p tcl-lsp-rust --lib` — 16/16 tests in `features::folding::tests` pass
- [x] `make prep-pr` — 12,519 passed, 206 skipped, 2 xfailed (77s)

https://claude.ai/code/session_01UMj55qeeQdNJe7dzmRxiKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMj55qeeQdNJe7dzmRxiKW)_