### PR TITLE
Resolve CFG-rewritten and namespace-exported commands through registry

### DIFF
--- a/core/commands/registry/irules/proc.py
+++ b/core/commands/registry/irules/proc.py
@@ -7,7 +7,7 @@ from ....compiler.side_effects import ConnectionSide, SideEffect, SideEffectTarg
 from .._base import CommandDef
 from ..models import CommandSpec, FormKind, FormSpec, HoverSnippet, ValidationSpec
 from ..namespace_models import EventRequires
-from ..signatures import ArgRole, Arity
+from ..signatures import ArgRole, Arity, BodyKind
 from ._base import _IRULES_ONLY, register
 
 _SOURCE = "https://clouddocs.f5.com/api/irules/proc.html"
@@ -45,6 +45,7 @@ class ProcCommand(CommandDef):
             ),
             event_requires=EventRequires(),
             arg_roles={0: ArgRole.NAME, 1: ArgRole.PARAM_LIST, 2: ArgRole.BODY},
+            body_kind=BodyKind.STRUCTURAL,
             defines_procedure=True,
             side_effect_hints=(
                 SideEffect(

--- a/core/commands/registry/irules/when.py
+++ b/core/commands/registry/irules/when.py
@@ -18,7 +18,7 @@ from ..namespace_data import (
     get_event_description,
     get_event_detail,
 )
-from ..signatures import ArgRole, Arity
+from ..signatures import ArgRole, Arity, BodyKind
 from ._base import _IRULES_ONLY, register
 
 _SOURCE = "https://clouddocs.f5.com/api/irules/when.html"
@@ -159,6 +159,7 @@ class WhenCommand(CommandDef):
                 arity=Arity(2, 6),
             ),
             arg_role_resolver=_when_arg_roles,
+            body_kind=BodyKind.STRUCTURAL,
             irules_top_level_only=True,
             is_language_keyword=True,
             side_effect_hints=(

--- a/core/commands/registry/models.py
+++ b/core/commands/registry/models.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .namespace_models import EventRequires
-from .signatures import ArgRole, Arity
+from .signatures import ArgRole, Arity, BodyKind
 
 if TYPE_CHECKING:
     from ...compiler.side_effects import SideEffect, StorageType
@@ -411,6 +411,21 @@ class SubCommand:
     arg_roles: dict[int, ArgRole] = field(default_factory=dict)
     arg_role_resolver: ArgRoleResolver | None = None
 
+    # Body kind for any ``ArgRole.BODY`` arguments on this subcommand.
+    # Defaults to ``INLINE`` (body executes in the caller's scope).
+    # Set to ``STRUCTURAL`` for subcommands whose body is analysed as a
+    # separate procedure/handler.
+    body_kind: BodyKind = BodyKind.INLINE
+
+    # CFG-lowered command name for ensemble subcommands that get rewritten.
+    # When set, the CFG lowering pass replaces ``<command> <subname>`` with
+    # this qualified name and drops the subcommand word from the argument
+    # list (so role indices on this :class:`SubCommand` still apply 0-based
+    # to the rewritten call).  The runtime registry derives a reverse lookup
+    # map so downstream queries on the rewritten name resolve back to this
+    # subcommand without each consumer hardcoding the correspondence.
+    cfg_rewrite_name: str | None = None
+
     # Type info (replaces type_hints() -> SubcommandTypeHint).
     return_type: TclType | None = None
     arg_types: dict[int, ArgTypeHint] = field(default_factory=dict)
@@ -666,6 +681,25 @@ class CommandSpec:
 
     # Arg-role resolution for variable-layout commands (if/try/switch/foreach).
     arg_role_resolver: ArgRoleResolver | None = None
+
+    # Body kind for any ``ArgRole.BODY`` arguments on this command.
+    # Defaults to ``INLINE`` (body executes in the caller's scope).
+    # Set to ``STRUCTURAL`` for commands whose body is analysed as a
+    # separate procedure/handler (``proc``, ``when``, ``tcltest::test``).
+    body_kind: BodyKind = BodyKind.INLINE
+
+    # Whether this command's source namespace exports it via
+    # ``namespace export <bare>``, making it eligible for retrieval as a
+    # short name after ``namespace import``.  This is a fact about the
+    # *command's source* — it does not claim any particular call site has
+    # imported it.  Registry helpers derive the bare name from the
+    # qualified ``name`` (last ``::`` segment) and build a static
+    # over-approximation alias map: callers that see the bare name will
+    # resolve it to this spec.  Per-call-site, namespace-scoped resolution
+    # requires IR-stage canonicalisation (issue #246's broader plan); the
+    # static approximation matches today's analysis behaviour for tcltest-
+    # style packages where the bare name is the conventional spelling.
+    is_namespace_exported: bool = False
 
     # Keyword+scaffold completions inside variable-layout commands.
     keyword_completions: KeywordCompletionProvider | None = None

--- a/core/commands/registry/runtime.py
+++ b/core/commands/registry/runtime.py
@@ -1001,6 +1001,16 @@ def _resolve_arg_roles(command: str, args: list[str]) -> tuple[dict[int, ArgRole
 
     Returns ``({}, 0)`` for unregistered or unmatched commands; callers
     should treat the empty role map as "no roles known" and skip output.
+
+    Resolution order matters: a direct registry hit on *command* always
+    wins over a namespace-export alias entry — so an explicit
+    ``configure_signatures(extra_commands=["test"])`` registration (or
+    any other dialect/extra-command spec for the bare name) shadows the
+    static ``test`` → ``tcltest::test`` over-approximation.  Only when
+    no spec exists for the user-written name does the alias map come
+    into play.  CFG-rewritten names (``::tcl::dict::for``) sit outside
+    this rule because they're qualified internal spellings that never
+    have a direct spec of their own.
     """
     alias = _REWRITE_ALIASES.get(command)
     if alias is not None:
@@ -1012,10 +1022,11 @@ def _resolve_arg_roles(command: str, args: list[str]) -> tuple[dict[int, ArgRole
                 return _resolved_role_map(sub_sig, args), 0
         return {}, 0
 
-    canonical = _canonicalise_command_name(command)
-    sig = SIGNATURES.get(canonical)
+    sig = SIGNATURES.get(command) or _ROLE_HINTS.get(command)
     if sig is None:
-        sig = _ROLE_HINTS.get(canonical)
+        canonical = _canonicalise_command_name(command)
+        if canonical != command:
+            sig = SIGNATURES.get(canonical) or _ROLE_HINTS.get(canonical)
     if isinstance(sig, SubcommandSig):
         if not args:
             return {}, 1
@@ -1070,8 +1081,17 @@ def body_kind_for_command(command: str, args: list[str]) -> BodyKind:
                 return sub.body_kind
         return BodyKind.INLINE
 
-    canonical = _canonicalise_command_name(command)
-    spec = REGISTRY.get_any(canonical)
+    # If the user-written name has any direct registration — a real
+    # spec, a role hint, or an ``extra_commands`` stub in SIGNATURES —
+    # commit to that name and never fall through to the namespace-export
+    # alias.  Otherwise an explicit ``configure_signatures(extra_commands=
+    # ["test"])`` would silently get tcltest::test's structural body kind.
+    if command in SIGNATURES or command in _ROLE_HINTS:
+        target = command
+    else:
+        target = _canonicalise_command_name(command)
+
+    spec = REGISTRY.get_any(target)
     if spec is None:
         return BodyKind.INLINE
     if spec.subcommands and args:

--- a/core/commands/registry/runtime.py
+++ b/core/commands/registry/runtime.py
@@ -16,7 +16,7 @@ from ...compiler.types import TclType
 from ...parsing.tokens import Token
 from .command_registry import REGISTRY
 from .models import CommandSpec, PatternType, ValidationSpec
-from .signatures import ArgRole, Arity, CommandSig, SubcommandSig
+from .signatures import ArgRole, Arity, BodyKind, CommandSig, SubcommandSig
 from .taint_hints import TaintColour, TaintHint
 from .type_hints import CommandTypeHint, SubcommandTypeHint
 
@@ -24,16 +24,19 @@ from .type_hints import CommandTypeHint, SubcommandTypeHint
 __all__ = [
     "ArgRole",
     "BodyArgument",
+    "BodyKind",
     "CommandSig",
     "SubcommandSig",
     "CommandTypeHint",
     "SubcommandTypeHint",
     "SwitchCase",
     "TaintHint",
+    "body_kind_for_command",
     "is_switch_case_list_form",
     "iter_switch_case_list",
     "options_with_value",
     "regexp_pattern_index",
+    "resolve_rewrite_alias",
     "skip_options",
 ]
 
@@ -196,6 +199,7 @@ def _invalidate_runtime_caches(loader_keys: list[str]) -> None:
     TYPE_HINTS.clear()
     TYPE_HINTS.update(_type_hints_from_registry())
     _rebuild_fold_hints()
+    _rebuild_alias_maps()
     canonical_list_commands.cache_clear()
     taint_transform_map.cache_clear()
     taint_double_encode_map.cache_clear()
@@ -889,6 +893,194 @@ def skip_options(
     return i
 
 
+# Rewrite-alias and exported-short-name maps.
+#
+# The CFG lowering pass rewrites a few ensemble-form commands (``dict for``,
+# ``dict map``) into qualified internal names so codegen can dispatch them
+# uniformly; ``namespace import`` brings exported short names into scope
+# (``test`` → ``::tcltest::test`` in any namespace that imports
+# ``::tcltest::*`` or ``::tcltest::test``).  Downstream registry consumers
+# see the alternative spelling and need a reverse-lookup map to recover the
+# canonical spec — without it, every consumer would have to hardcode the
+# correspondence (the regression mode that #234, #236, and #243 stemmed
+# from).
+#
+# Both maps are derived from declarative spec properties — never hardcoded
+# here — so adding a new rewritten name or exported short name is a single
+# edit on the source spec.  ``_invalidate_runtime_caches`` rebuilds the
+# maps whenever a dialect's specs are loaded.
+#
+# **Caveat for the exported-short-name map.**  ``namespace import`` is
+# dynamic and namespace-scoped in real Tcl — knowing whether a bare ``test``
+# at a given call site refers to ``::tcltest::test`` requires tracking the
+# imports active in the current namespace.  Issue #246's broader plan
+# stages this canonicalisation into the IR.  Until then, the map below is
+# a static over-approximation: it assumes every exported short name is
+# imported.  This matches today's analyser behaviour and avoids regressing
+# tcltest-style packages where the bare name is the conventional spelling,
+# but at the cost of treating a user-defined ``test`` proc as if it were
+# ``::tcltest::test`` for body-kind/role queries.
+_REWRITE_ALIASES: dict[str, tuple[str, str]] = {}
+_COMMAND_NAME_ALIASES: dict[str, str] = {}
+
+
+def _build_rewrite_aliases() -> dict[str, tuple[str, str]]:
+    """Collect ``cfg_rewrite_name`` declarations into a reverse-lookup map."""
+    result: dict[str, tuple[str, str]] = {}
+    for name, specs in REGISTRY.specs_by_name.items():
+        for spec in specs:
+            for sub_name, sub in spec.subcommands.items():
+                if sub.cfg_rewrite_name is not None:
+                    # Last writer wins on duplicates — there should only be
+                    # one rewriter per qualified name in practice.
+                    result[sub.cfg_rewrite_name] = (name, sub_name)
+    return result
+
+
+def _build_command_name_aliases() -> dict[str, str]:
+    """Collect bare names that ``is_namespace_exported`` specs may resolve to.
+
+    For each spec at qualified name ``<ns>::<bare>`` with
+    ``is_namespace_exported=True``, the bare ``<bare>`` is registered as
+    a possible alias for the qualified spec.  This is a static
+    over-approximation — see the module-level note for details.
+    """
+    result: dict[str, str] = {}
+    for name, specs in REGISTRY.specs_by_name.items():
+        for spec in specs:
+            if not spec.is_namespace_exported:
+                continue
+            if "::" not in name:
+                continue
+            bare = name.rsplit("::", 1)[-1]
+            if bare and bare != name:
+                # Last writer wins — duplicate exports across namespaces
+                # collapse to whichever spec was registered last.  The
+                # bare-name collision is a static-analysis ambiguity in
+                # any case; per-namespace IR canonicalisation resolves it.
+                result[bare] = name
+    return result
+
+
+def _rebuild_alias_maps() -> None:
+    global _REWRITE_ALIASES, _COMMAND_NAME_ALIASES
+    _REWRITE_ALIASES = _build_rewrite_aliases()
+    _COMMAND_NAME_ALIASES = _build_command_name_aliases()
+
+
+_rebuild_alias_maps()
+
+
+def resolve_rewrite_alias(command: str) -> tuple[str, str] | None:
+    """Resolve a CFG-rewritten command name to ``(source_cmd, subcommand)``.
+
+    Returns ``None`` for any command that is not a registered rewrite of an
+    ensemble-form command.  Callers that branch on the rewritten name should
+    consult this map first so a future rewrite addition is automatically
+    visible to every registry-driven query.
+    """
+    return _REWRITE_ALIASES.get(command)
+
+
+def _canonicalise_command_name(command: str) -> str:
+    """Resolve a :data:`_COMMAND_NAME_ALIASES` entry to its source spec name.
+
+    Returns *command* unchanged when no alias is registered.
+    """
+    return _COMMAND_NAME_ALIASES.get(command, command)
+
+
+def _resolve_arg_roles(command: str, args: list[str]) -> tuple[dict[int, ArgRole], int]:
+    """Return ``(role_map, base_index)`` for a *command* invocation.
+
+    *role_map* maps argument indices into ``args[base_index:]`` to their
+    :class:`ArgRole`.  ``base_index`` is the offset to add when expressing
+    the indices against the original *args* list — 1 for ensemble-form
+    commands (where ``args[0]`` is the subcommand word) and 0 for plain
+    commands and CFG-rewritten ensemble names.
+
+    Returns ``({}, 0)`` for unregistered or unmatched commands; callers
+    should treat the empty role map as "no roles known" and skip output.
+    """
+    alias = _REWRITE_ALIASES.get(command)
+    if alias is not None:
+        source_cmd, sub_name = alias
+        parent = SIGNATURES.get(source_cmd) or _ROLE_HINTS.get(source_cmd)
+        if isinstance(parent, SubcommandSig):
+            sub_sig = parent.subcommands.get(sub_name)
+            if sub_sig is not None:
+                return _resolved_role_map(sub_sig, args), 0
+        return {}, 0
+
+    canonical = _canonicalise_command_name(command)
+    sig = SIGNATURES.get(canonical)
+    if sig is None:
+        sig = _ROLE_HINTS.get(canonical)
+    if isinstance(sig, SubcommandSig):
+        if not args:
+            return {}, 1
+        sub_sig = sig.subcommands.get(args[0])
+        if sub_sig is None:
+            return {}, 1
+        return _resolved_role_map(sub_sig, args[1:]), 1
+    if isinstance(sig, CommandSig):
+        return _resolved_role_map(sig, args), 0
+    return {}, 0
+
+
+def _resolved_role_map(sig: CommandSig, args: list[str]) -> dict[int, ArgRole]:
+    """Resolve :class:`CommandSig` roles for *args*, dynamic resolver first."""
+    if sig.arg_role_resolver is not None:
+        resolved = sig.arg_role_resolver(list(args))
+        return {idx: r for idx, r in resolved.items() if idx < len(args)}
+    return {idx: r for idx, r in sig.arg_roles.items() if idx < len(args)}
+
+
+# Subsumption: a query for these "narrower" roles also matches the
+# "broader" :data:`ArgRole.VAR_READ_WRITE` role.  Keeping the map small
+# means new role additions are explicit; widen as needed when more
+# combined-semantic roles are added.
+_ROLE_SUBSUMES: dict[ArgRole, frozenset[ArgRole]] = {
+    ArgRole.VAR_READ: frozenset({ArgRole.VAR_READ_WRITE}),
+    ArgRole.VAR_WRITE: frozenset({ArgRole.VAR_READ_WRITE}),
+}
+
+
+def body_kind_for_command(command: str, args: list[str]) -> BodyKind:
+    """Return the :class:`BodyKind` for ``ArgRole.BODY`` arguments of *command*.
+
+    Subcommand-form invocations (``dict for``, ``namespace eval``, …) inherit
+    from the subcommand's ``body_kind``; CFG-rewritten ensemble forms
+    (``::tcl::dict::for``) resolve through :data:`_REWRITE_ALIASES` to the
+    source ensemble's subcommand; and bare names that match an
+    ``is_namespace_exported`` spec (``test`` → ``tcltest::test``) resolve
+    through :data:`_COMMAND_NAME_ALIASES`.  See the module note above for
+    the over-approximation in the latter case.
+
+    Defaults to :class:`BodyKind.INLINE` when the command has no body or
+    isn't registered.
+    """
+    alias = _REWRITE_ALIASES.get(command)
+    if alias is not None:
+        source_cmd, sub_name = alias
+        spec = REGISTRY.get_any(source_cmd)
+        if spec is not None:
+            sub = spec.subcommands.get(sub_name)
+            if sub is not None:
+                return sub.body_kind
+        return BodyKind.INLINE
+
+    canonical = _canonicalise_command_name(command)
+    spec = REGISTRY.get_any(canonical)
+    if spec is None:
+        return BodyKind.INLINE
+    if spec.subcommands and args:
+        sub = spec.subcommands.get(args[0])
+        if sub is not None:
+            return sub.body_kind
+    return spec.body_kind
+
+
 def arg_indices_for_role(command: str, args: list[str], role: ArgRole) -> set[int]:
     """Return argument indices (0-based, after command name) for a role."""
     if role is ArgRole.BODY:
@@ -905,39 +1097,12 @@ def arg_indices_for_role(command: str, args: list[str], role: ArgRole) -> set[in
                 return {idx}
             return set()
 
-    sig = SIGNATURES.get(command)
-    if sig is None:
-        sig = _ROLE_HINTS.get(command)
-    if sig is None:
+    role_map, base_index = _resolve_arg_roles(command, args)
+    if not role_map:
         return set()
 
-    if isinstance(sig, SubcommandSig):
-        if not args:
-            return set()
-        sub_sig = sig.subcommands.get(args[0])
-        if sub_sig is None:
-            return set()
-        sub_args = args[1:]
-        if sub_sig.arg_role_resolver is not None:
-            resolved = sub_sig.arg_role_resolver(sub_args)
-            return {idx + 1 for idx, r in resolved.items() if r is role and idx < len(sub_args)}
-        return {
-            idx + 1
-            for idx, arg_role in sub_sig.arg_roles.items()
-            if arg_role is role and (idx + 1) < len(args)
-        }
-
-    if isinstance(sig, CommandSig):
-        # Dynamic resolver takes priority for variable-layout commands.
-        if sig.arg_role_resolver is not None:
-            resolved = sig.arg_role_resolver(args)
-            return {idx for idx, r in resolved.items() if r is role and idx < len(args)}
-        result = {
-            idx for idx, arg_role in sig.arg_roles.items() if arg_role is role and idx < len(args)
-        }
-        return result
-
-    return set()
+    accept = _ROLE_SUBSUMES.get(role, frozenset()) | {role}
+    return {idx + base_index for idx, r in role_map.items() if r in accept}
 
 
 _SPECIAL_ROLES = frozenset({ArgRole.BODY, ArgRole.PATTERN})
@@ -969,46 +1134,13 @@ def arg_indices_for_roles(
     if not need_sig_roles:
         return tuple(results)
 
-    sig = SIGNATURES.get(command)
-    if sig is None:
-        sig = _ROLE_HINTS.get(command)
-    if sig is None:
+    role_map, base_index = _resolve_arg_roles(command, args)
+    if not role_map:
         return tuple(results)
 
-    if isinstance(sig, SubcommandSig):
-        if not args:
-            return tuple(results)
-        sub_sig = sig.subcommands.get(args[0])
-        if sub_sig is None:
-            return tuple(results)
-        sub_args = args[1:]
-        if sub_sig.arg_role_resolver is not None:
-            resolved = sub_sig.arg_role_resolver(sub_args)
-            for idx_in_result, role in need_sig_roles:
-                results[idx_in_result] = {
-                    idx + 1 for idx, r in resolved.items() if r is role and idx < len(sub_args)
-                }
-        else:
-            for idx_in_result, role in need_sig_roles:
-                results[idx_in_result] = {
-                    idx + 1
-                    for idx, arg_role in sub_sig.arg_roles.items()
-                    if arg_role is role and (idx + 1) < len(args)
-                }
-    elif isinstance(sig, CommandSig):
-        if sig.arg_role_resolver is not None:
-            resolved = sig.arg_role_resolver(args)
-            for idx_in_result, role in need_sig_roles:
-                results[idx_in_result] = {
-                    idx for idx, r in resolved.items() if r is role and idx < len(args)
-                }
-        else:
-            for idx_in_result, role in need_sig_roles:
-                results[idx_in_result] = {
-                    idx
-                    for idx, arg_role in sig.arg_roles.items()
-                    if arg_role is role and idx < len(args)
-                }
+    for idx_in_result, role in need_sig_roles:
+        accept = _ROLE_SUBSUMES.get(role, frozenset()) | {role}
+        results[idx_in_result] = {idx + base_index for idx, r in role_map.items() if r in accept}
 
     return tuple(results)
 

--- a/core/commands/registry/signatures.py
+++ b/core/commands/registry/signatures.py
@@ -20,6 +20,10 @@ class ArgRole(Enum):
     EXPR = auto()  # Expression (expr sub-language)
     VAR_WRITE = auto()  # A variable name written by the command (set, regexp, scan, lassign)
     VAR_READ = auto()  # A variable name read without modification (info exists, array get)
+    VAR_READ_WRITE = auto()  # A variable name read and written (dict with/update — body reads keys, dict is updated after)
+    LOOP_VAR_LIST = (
+        auto()
+    )  # Whitespace-separated list of loop variable names (dict for/map ``{key val}``)
     PARAM_LIST = auto()  # Procedure parameter list
     NAME = auto()  # A symbolic name (proc name, namespace name)
     PATTERN = auto()  # Pattern or regex
@@ -29,6 +33,24 @@ class ArgRole(Enum):
     OPTION_TERMINATOR = auto()  # The "--" option terminator
     CHANNEL = auto()  # Channel identifier (stdout, stdin, channelId)
     INDEX = auto()  # List/string index expression
+
+
+class BodyKind(Enum):
+    """How a ``BODY`` argument relates to its enclosing block.
+
+    ``INLINE`` — the body executes in the caller's scope as part of the
+    current control flow (``catch``, ``while``, ``foreach``, ``dict for``,
+    …).  Variable references inside it must be discovered by the SSA scan
+    so reads/writes are visible to the enclosing function's analysis.
+
+    ``STRUCTURAL`` — the body defines its own scope and is lowered/analysed
+    as a separate procedure or handler (``proc``, ``when``, ``tcltest::test``).
+    Variable references inside the body are not part of the enclosing
+    block's data flow and must be excluded from local statement scans.
+    """
+
+    INLINE = auto()
+    STRUCTURAL = auto()
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/commands/registry/stdlib/tcltest.py
+++ b/core/commands/registry/stdlib/tcltest.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from ....compiler.side_effects import ConnectionSide, SideEffect, SideEffectTarget
 from .._base import CommandDef
 from ..models import CommandSpec, FormKind, FormSpec, HoverSnippet, OptionSpec, ValidationSpec
-from ..signatures import ArgRole, Arity
+from ..signatures import ArgRole, Arity, BodyKind
 from ._base import register
 
 _PKG = "tcltest"
@@ -94,6 +94,8 @@ class TcltestTest(CommandDef):
             ),
             validation=ValidationSpec(arity=Arity(2)),
             arg_role_resolver=_test_arg_roles,
+            body_kind=BodyKind.STRUCTURAL,
+            is_namespace_exported=True,
             side_effect_hints=(
                 SideEffect(
                     target=SideEffectTarget.INTERP_STATE,

--- a/core/commands/registry/tcl/dict.py
+++ b/core/commands/registry/tcl/dict.py
@@ -33,9 +33,15 @@ _SOURCE = "Tcl man page dict.n"
 
 
 def _dict_last_arg_body(args: list[str]) -> dict[int, ArgRole]:
-    """Last argument is a body script (for dict update/with)."""
+    """Last argument is a body script (for dict update/with).
+
+    Argument 0 is the dict variable: it is both *written* (the dict is
+    rewritten when the body returns) and *read* (its keys are unpacked
+    into local variables of the same name for the body's duration), so
+    it carries the combined :class:`ArgRole.VAR_READ_WRITE` role.
+    """
     if len(args) >= 2:
-        return {len(args) - 1: ArgRole.BODY, 0: ArgRole.VAR_WRITE}
+        return {len(args) - 1: ArgRole.BODY, 0: ArgRole.VAR_READ_WRITE}
     return {}
 
 
@@ -231,9 +237,10 @@ class DictCommand(CommandDef):
                     arity=Arity(3, 3),
                     detail="This command takes three arguments, the first a two-element list of variable names (for the key and value respectively of each mapping in the dictionary), the second the dictionary value to iterate across, and the third…",
                     synopsis="dict for {keyVariable valueVariable} dictionaryValue body",
-                    arg_roles={2: ArgRole.BODY},
+                    arg_roles={0: ArgRole.LOOP_VAR_LIST, 2: ArgRole.BODY},
                     arg_types={1: ArgTypeHint(expected=TclType.DICT, shimmers=True)},
                     loop_list_header=True,
+                    cfg_rewrite_name="::tcl::dict::for",
                 ),
                 "get": SubCommand(
                     name="get",
@@ -302,9 +309,10 @@ class DictCommand(CommandDef):
                     arity=Arity(3, 3),
                     detail="This command applies a transformation to each element of a dictionary, returning a new dictionary.",
                     synopsis="dict map {keyVariable valueVariable} dictionaryValue body",
-                    arg_roles={2: ArgRole.BODY},
+                    arg_roles={0: ArgRole.LOOP_VAR_LIST, 2: ArgRole.BODY},
                     arg_types={1: ArgTypeHint(expected=TclType.DICT, shimmers=True)},
                     loop_list_header=True,
+                    cfg_rewrite_name="::tcl::dict::map",
                 ),
                 "merge": SubCommand(
                     name="merge",

--- a/core/commands/registry/tcl/proc_.py
+++ b/core/commands/registry/tcl/proc_.py
@@ -6,7 +6,7 @@ from ....compiler.side_effects import ConnectionSide, SideEffect, SideEffectTarg
 from ....compiler.types import TclType
 from .._base import CommandDef
 from ..models import CommandSpec, FormKind, FormSpec, HoverSnippet, ValidationSpec
-from ..signatures import ArgRole, Arity
+from ..signatures import ArgRole, Arity, BodyKind
 from ._base import register
 
 _SOURCE = "Tcl proc(1)"
@@ -39,6 +39,7 @@ class ProcCommand(CommandDef):
             ),
             wasm_emits_nothing=True,
             arg_roles={0: ArgRole.NAME, 1: ArgRole.PARAM_LIST, 2: ArgRole.BODY},
+            body_kind=BodyKind.STRUCTURAL,
             return_type=TclType.STRING,
             defines_procedure=True,
             irules_top_level_only=True,

--- a/core/compiler/cfg.py
+++ b/core/compiler/cfg.py
@@ -675,15 +675,26 @@ class _CFGBuilder:
                     if stmt.is_dict_iteration and stmt.raw_args:
                         # dict for/map: Tcl 9.0 compiles as a generic
                         # invoke to the ensemble implementation, not an
-                        # inlined loop.  Rewrite to qualified name and
-                        # drop the subcommand arg.
+                        # inlined loop.  Rewrite to the qualified name
+                        # declared on the source ``SubCommand`` and drop
+                        # the subcommand arg.  Reading the name from the
+                        # registry keeps it as the single source of truth
+                        # — the runtime alias map and downstream queries
+                        # (``::tcl::dict::for`` → ``dict for``) all
+                        # resolve through the same field.
                         sub = stmt.raw_args[0]  # "for" or "map"
-                        qual_cmd = f"::tcl::dict::{sub}"
+                        dict_spec = REGISTRY.get_any("dict")
+                        sub_spec = dict_spec.subcommands.get(sub) if dict_spec is not None else None
+                        if sub_spec is None or sub_spec.cfg_rewrite_name is None:
+                            raise RuntimeError(
+                                f"dict iteration ``dict {sub}`` has no cfg_rewrite_name "
+                                "in the registry — declare it on the SubCommand spec"
+                            )
                         block.statements.append(
                             IRBarrier(
                                 range=stmt.range,
                                 reason="dict for/map",
-                                command=qual_cmd,
+                                command=sub_spec.cfg_rewrite_name,
                                 args=stmt.raw_args[1:],  # skip subcommand
                                 tokens=None,
                             )

--- a/core/compiler/ssa.py
+++ b/core/compiler/ssa.py
@@ -22,7 +22,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypeAlias
 
-from ..commands.registry.runtime import ArgRole, arg_indices_for_role
+from ..commands.registry.runtime import (
+    ArgRole,
+    BodyKind,
+    arg_indices_for_role,
+    body_kind_for_command,
+)
 from ..common.naming import normalise_var_name as _normalise_var_name
 from .cfg import CFGBranch, CFGFunction, CFGGoto, CFGReturn, CFGTerminator
 from .expr_ast import ExprNode, vars_in_expr_node
@@ -77,16 +82,18 @@ def _defs(stmt: IRStatement) -> tuple[str, ...]:
     if isinstance(stmt, IRBarrier) and stmt.command == "trace" and len(stmt.args) >= 3:
         if stmt.args[0] == "add" and stmt.args[1] == "variable":
             return (_normalise_var_name(stmt.args[2]),)
-    # dict for/map barriers: extract iteration variable names from the
-    # varList arg so SSA sees them as definitions.  Match the rewritten
-    # command names exactly; a suffix test would also fire for unrelated
-    # commands like ``::my::for``.
-    if isinstance(stmt, IRBarrier) and stmt.command in (
-        "::tcl::dict::for",
-        "::tcl::dict::map",
-    ):
-        if stmt.args:
-            return tuple(stmt.args[0].split())
+    # Loop-variable lists (``dict for``/``dict map`` arg 0): the registry
+    # marks them with ``ArgRole.LOOP_VAR_LIST``; split each into individual
+    # iteration variables so SSA sees them as definitions.  The rewrite-alias
+    # map (``::tcl::dict::for`` → ``dict for``) makes the role visible on
+    # the CFG-rewritten name without re-deriving it here.
+    if isinstance(stmt, IRBarrier):
+        defs: list[str] = []
+        for idx in arg_indices_for_role(stmt.command, list(stmt.args), ArgRole.LOOP_VAR_LIST):
+            if 0 <= idx < len(stmt.args):
+                defs.extend(stmt.args[idx].split())
+        if defs:
+            return tuple(defs)
     return ()
 
 
@@ -128,9 +135,6 @@ def _vars_in_body_script(source: str) -> frozenset[str]:
     return _DEEP_VAR_REF_SCANNER.scan_script(source)
 
 
-_TCLTEST_BODY_OPTIONS = frozenset({"-setup", "-body", "-cleanup"})
-
-
 def _is_braced_arg(tokens: CommandTokens | None, arg_index: int) -> bool:
     """Return True when argument *arg_index* is a braced literal (STR token).
 
@@ -155,44 +159,24 @@ def _structural_body_indices(
 ) -> set[int]:
     """Return BODY arg indices that should be excluded from local statement uses.
 
-    We only exclude handler-style bodies that are lowered/analysed separately.
-    Dynamic evaluation commands like ``eval`` still need their args treated as
-    ordinary dataflow inputs (for taint and read-before-set tracking).
-
-    ``tcltest::test`` (and bare ``test`` after ``namespace import``) bodies
-    are excluded because the LSP does not inline them — variable references
-    inside the braced scripts would otherwise appear as top-level
-    reads-before-set (false W210).
+    We only exclude handler-style bodies that are lowered/analysed separately
+    — the registry marks these via :class:`BodyKind.STRUCTURAL` on the source
+    spec (``proc``, ``when``, ``tcltest::test``, …).  Dynamic-evaluation
+    commands like ``eval`` keep their args as ordinary dataflow inputs (for
+    taint and read-before-set tracking) because their body kind is
+    :class:`BodyKind.INLINE`.
 
     To avoid dropping real top-level reads when the body is passed via
     substitution (e.g. ``-body $script``), we only exclude arguments that
     are literal/braced script words.  Non-literal body arguments are still
     scanned for substitutions.
     """
-    if command in ("when", "proc"):
-        candidate_indices = arg_indices_for_role(command, list(args), ArgRole.BODY)
-        return {
-            idx for idx in candidate_indices if 0 <= idx < len(args) and _is_braced_arg(tokens, idx)
-        }
-    if command in ("test", "tcltest::test"):
-        # Option form: test name description ?option value ...?
-        indices: set[int] = set()
-        has_body_option = False
-        i = 2
-        while i < len(args) - 1:
-            if args[i] in _TCLTEST_BODY_OPTIONS:
-                value_idx = i + 1
-                has_body_option = True
-                if _is_braced_arg(tokens, value_idx):
-                    indices.add(value_idx)
-            i += 2
-        # Legacy positional form: test name desc ?constraints? body result
-        if not has_body_option and len(args) >= 4:
-            body_index = len(args) - 2
-            if _is_braced_arg(tokens, body_index):
-                indices.add(body_index)
-        return indices
-    return set()
+    if body_kind_for_command(command, list(args)) is not BodyKind.STRUCTURAL:
+        return set()
+    candidate_indices = arg_indices_for_role(command, list(args), ArgRole.BODY)
+    return {
+        idx for idx in candidate_indices if 0 <= idx < len(args) and _is_braced_arg(tokens, idx)
+    }
 
 
 def _uses(stmt: IRStatement) -> tuple[str, ...]:
@@ -245,29 +229,38 @@ def _uses(stmt: IRStatement) -> tuple[str, ...]:
         case IRBarrier(command=command, args=args, tokens=barrier_tokens):
             vars_found |= _vars_in_word(command)
             body_indices = _structural_body_indices(command, args, barrier_tokens)
-            # ``dict for/map`` barriers carry the loop body as args[-1] and
-            # the body never enters the CFG, so its variable references
-            # must be discovered here (recursing into nested braced bodies).
-            # Match the rewritten command names exactly — a suffix test
-            # would also catch unrelated namespaced commands like
-            # ``::my::for`` and silently scan their last arg as a script.
-            # See issues #234, #236.
-            is_dict_iter_barrier = (
-                command in ("::tcl::dict::for", "::tcl::dict::map") and len(args) >= 3
-            )
+            # Inline-body indices on a barrier carry a script that never
+            # enters the CFG (e.g. ``dict for``/``dict map`` lowered as
+            # ``::tcl::dict::for``/``::tcl::dict::map``).  We must
+            # discover variable references inside such bodies here,
+            # recursing into nested braced bodies; otherwise references
+            # like ``$count`` inside ``dict for {k v} $d {... $count ...}``
+            # would be invisible to the enclosing function's analysis
+            # (false W214 / W210 — see issues #234, #236).
+            inline_body_indices = {
+                idx
+                for idx in arg_indices_for_role(command, list(args), ArgRole.BODY)
+                if 0 <= idx < len(args) and idx not in body_indices
+            }
             for idx, arg in enumerate(args):
                 if idx in body_indices:
                     continue
-                if is_dict_iter_barrier and idx == len(args) - 1:
+                if idx in inline_body_indices:
                     vars_found |= _vars_in_body_script(arg)
                 else:
                     vars_found |= _vars_in_word(arg)
-            # dict with/update: the dict variable name is a plain string,
-            # not a $-substitution, so _vars_in_word misses it.
-            if command == "dict" and len(args) >= 2 and args[0] in ("with", "update"):
-                dict_var = _normalise_var_name(args[1])
-                if dict_var:
-                    vars_found.add(dict_var)
+            # ``dict with`` / ``dict update`` arg 0 is the dict variable: it
+            # is read as well as written (the body sees the keys unpacked
+            # into local variables of the same name), but the variable name
+            # is a plain string, not a $-substitution, so ``_vars_in_word``
+            # misses it.  The registry marks the arg as
+            # ``ArgRole.VAR_READ_WRITE``; ``arg_indices_for_role`` reports
+            # it under ``VAR_READ`` via the role-subsumption table.
+            for idx in arg_indices_for_role(command, list(args), ArgRole.VAR_READ):
+                if 0 <= idx < len(args):
+                    name = _normalise_var_name(args[idx])
+                    if name:
+                        vars_found.add(name)
         case _:
             pass
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -563,3 +563,204 @@ class TestLazyDialectLoading:
         assert "button" in registry.specs_by_name
         # SDC base commands should also be present.
         assert len(registry._loaded_loaders & {"tk", "sdc-base", "synopsys-eda-tcl"}) == 3
+
+
+class TestRewriteAliasResolution:
+    """Issue #246 — CFG-rewritten command names must resolve through the registry.
+
+    The CFG lowering pass rewrites ``dict for`` / ``dict map`` to the
+    qualified names ``::tcl::dict::for`` / ``::tcl::dict::map`` so they
+    can be dispatched as opaque barriers.  Downstream consumers (SSA,
+    optimisations, diagnostics) must be able to query the registry on
+    the rewritten name and get the same role, body-kind, and arity
+    information that the source ensemble form provides — otherwise each
+    caller has to hardcode the correspondence (the regression that
+    issues #234, #236, #243 all stemmed from).
+    """
+
+    def test_rewrite_alias_map_covers_dict_iteration(self):
+        from core.commands.registry.runtime import resolve_rewrite_alias
+
+        assert resolve_rewrite_alias("::tcl::dict::for") == ("dict", "for")
+        assert resolve_rewrite_alias("::tcl::dict::map") == ("dict", "map")
+
+    def test_rewrite_alias_is_derived_from_subcommand_property(self):
+        from core.commands.registry import REGISTRY
+        from core.commands.registry.runtime import resolve_rewrite_alias
+
+        # The rewrite alias is derived from ``SubCommand.cfg_rewrite_name``
+        # on the source spec, not a hardcoded table in ``runtime.py``.  The
+        # corresponding subcommand entry must declare the qualified name
+        # explicitly so a future ensemble rewrite is automatically visible
+        # to every registry-driven query.
+        dict_spec = REGISTRY.get_any("dict")
+        assert dict_spec is not None
+        for_sub = dict_spec.subcommands["for"]
+        map_sub = dict_spec.subcommands["map"]
+        assert for_sub.cfg_rewrite_name == "::tcl::dict::for"
+        assert map_sub.cfg_rewrite_name == "::tcl::dict::map"
+        # And those declarations must drive the runtime resolver.
+        assert resolve_rewrite_alias(for_sub.cfg_rewrite_name) == ("dict", "for")
+        assert resolve_rewrite_alias(map_sub.cfg_rewrite_name) == ("dict", "map")
+
+    def test_exported_short_name_resolves_via_registry_property(self):
+        from core.commands.registry import REGISTRY
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        # The bare ``test`` name only resolves to ``tcltest::test`` because
+        # the latter declares it is exported from its source namespace.
+        # The bare-name itself is derived from the qualified spec name —
+        # not duplicated as a separate field — so a future spec at
+        # ``foo::bar`` exporting ``bar`` automatically participates.
+        spec = REGISTRY.get_any("tcltest::test")
+        assert spec is not None
+        assert spec.is_namespace_exported is True
+        # ``body_kind_for_command`` resolves through the over-approximation
+        # alias map built from ``is_namespace_exported`` declarations.
+        assert (
+            body_kind_for_command("test", ["name", "desc", "-body", "body"]) is BodyKind.STRUCTURAL
+        )
+
+    def test_rewrite_alias_unrecognised_returns_none(self):
+        from core.commands.registry.runtime import resolve_rewrite_alias
+
+        assert resolve_rewrite_alias("dict") is None
+        assert resolve_rewrite_alias("::my::for") is None
+        assert resolve_rewrite_alias("foreach") is None
+
+    def test_loop_var_list_role_resolves_via_rewrite_alias(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        # Rewritten name: subcommand word already consumed, so the role
+        # index returned matches the original argument layout 1-for-1.
+        assert arg_indices_for_role(
+            "::tcl::dict::for", ["k v", "$d", "body"], ArgRole.LOOP_VAR_LIST
+        ) == {0}
+        assert arg_indices_for_role(
+            "::tcl::dict::map", ["k v", "$d", "body"], ArgRole.LOOP_VAR_LIST
+        ) == {0}
+
+    def test_body_role_resolves_via_rewrite_alias(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        assert arg_indices_for_role("::tcl::dict::for", ["k v", "$d", "body"], ArgRole.BODY) == {2}
+        assert arg_indices_for_role("::tcl::dict::map", ["k v", "$d", "body"], ArgRole.BODY) == {2}
+
+    def test_ensemble_form_and_rewrite_yield_matching_body_indices(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        # The ensemble-form ``dict for`` index is offset by one (subcommand
+        # word at args[0]); the rewritten form has no subcommand word so
+        # the body index decrements by one.  Both must reach the same
+        # ``args`` element after applying the natural offset.
+        ensemble_body = arg_indices_for_role("dict", ["for", "k v", "$d", "body"], ArgRole.BODY)
+        rewritten_body = arg_indices_for_role(
+            "::tcl::dict::for", ["k v", "$d", "body"], ArgRole.BODY
+        )
+        assert ensemble_body == {3}
+        assert rewritten_body == {2}
+        # In each case the body argument is the same final word.
+
+    def test_unknown_qualified_name_does_not_alias(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        # ``::my::for`` is a user-defined namespaced proc — it must not
+        # accidentally pick up ``dict for`` semantics.  This is the
+        # specific failure mode the suffix-test approach (now removed)
+        # would have triggered.
+        assert (
+            arg_indices_for_role("::my::for", ["k v", "$d", "body"], ArgRole.LOOP_VAR_LIST) == set()
+        )
+        assert arg_indices_for_role("::my::for", ["k v", "$d", "body"], ArgRole.BODY) == set()
+
+
+class TestVarReadWriteSubsumption:
+    """Issue #246 — ``VAR_READ_WRITE`` subsumes ``VAR_READ`` and ``VAR_WRITE``.
+
+    ``dict with`` / ``dict update`` arg 0 carries a variable name that
+    is both written (the dict is rewritten when the body returns) and
+    read (the body sees keys unpacked into local variables of the same
+    name).  The combined :class:`ArgRole.VAR_READ_WRITE` lets a single
+    declaration satisfy queries for either narrower role.
+    """
+
+    def test_dict_with_var_arg_is_read_and_written(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        args = ["with", "myDict", "body"]
+        assert arg_indices_for_role("dict", args, ArgRole.VAR_READ) == {1}
+        assert arg_indices_for_role("dict", args, ArgRole.VAR_WRITE) == {1}
+
+    def test_dict_update_var_arg_is_read_and_written(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        args = ["update", "myDict", "k", "v", "body"]
+        assert arg_indices_for_role("dict", args, ArgRole.VAR_READ) == {1}
+        assert arg_indices_for_role("dict", args, ArgRole.VAR_WRITE) == {1}
+
+    def test_dict_with_body_index_unaffected_by_var_role(self):
+        from core.commands.registry.runtime import ArgRole, arg_indices_for_role
+
+        args = ["with", "myDict", "body"]
+        assert arg_indices_for_role("dict", args, ArgRole.BODY) == {2}
+
+
+class TestBodyKind:
+    """Issue #246 — :class:`BodyKind` distinguishes structural from inline bodies.
+
+    ``proc`` / ``when`` / ``tcltest::test`` bodies are *structural* — the
+    body is analysed as its own scope/handler and must not be scanned by
+    SSA as part of the calling block's data flow.  ``catch`` / ``while``
+    / ``dict for`` bodies are *inline* — they share variables with the
+    caller and their references must be visible to the enclosing scan.
+
+    :func:`body_kind_for_command` resolves through the same
+    ``cfg_rewrite_name`` and ``is_namespace_exported`` maps used by role
+    queries so SSA has one consistent answer per call site.
+    """
+
+    def test_proc_body_is_structural(self):
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        assert body_kind_for_command("proc", ["name", "args", "body"]) is BodyKind.STRUCTURAL
+
+    def test_when_body_is_structural(self):
+        from core.commands.registry import REGISTRY
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        # ``when`` is iRules-only; ensure the dialect is loaded so the
+        # spec is visible to ``REGISTRY.get_any``.
+        REGISTRY.load_dialect_specs("f5-irules")
+        assert body_kind_for_command("when", ["HTTP_REQUEST", "body"]) is BodyKind.STRUCTURAL
+
+    def test_tcltest_test_body_is_structural(self):
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        assert (
+            body_kind_for_command("tcltest::test", ["name", "desc", "-body", "body"])
+            is BodyKind.STRUCTURAL
+        )
+
+    def test_namespace_imported_test_resolves_to_structural(self):
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        # ``test`` after ``namespace import ::tcltest::test`` shares the
+        # source spec's body kind.
+        assert (
+            body_kind_for_command("test", ["name", "desc", "-body", "body"]) is BodyKind.STRUCTURAL
+        )
+
+    def test_dict_iteration_bodies_are_inline(self):
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        # The dict iter body shares the caller's scope — variable
+        # references inside it must be visible to the enclosing function.
+        assert body_kind_for_command("::tcl::dict::for", ["k v", "$d", "body"]) is BodyKind.INLINE
+        assert body_kind_for_command("::tcl::dict::map", ["k v", "$d", "body"]) is BodyKind.INLINE
+
+    def test_unregistered_command_defaults_to_inline(self):
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        # Defensive default: unknown commands don't get treated as
+        # structural bodies and have their args silently dropped.
+        assert body_kind_for_command("::my::custom::cmd", ["body"]) is BodyKind.INLINE

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -764,3 +764,38 @@ class TestBodyKind:
         # Defensive default: unknown commands don't get treated as
         # structural bodies and have their args silently dropped.
         assert body_kind_for_command("::my::custom::cmd", ["body"]) is BodyKind.INLINE
+
+    def test_extra_command_registration_shadows_exported_alias(self):
+        from core.commands.registry.runtime import (
+            ArgRole,
+            BodyKind,
+            arg_indices_for_role,
+            body_kind_for_command,
+            configure_signatures,
+        )
+
+        # A user-defined ``test`` command (registered via extra_commands)
+        # must shadow the ``test`` → ``tcltest::test`` static over-
+        # approximation.  Otherwise CFG/SSA/check passes would
+        # misclassify a user proc named ``test`` as a structural-body
+        # tcltest test.
+        try:
+            configure_signatures(dialect="tcl8.6", extra_commands=["test"])
+            # Direct registration → no body, no alias spillover.
+            assert body_kind_for_command("test", ["a", "b", "-body", "x"]) is BodyKind.INLINE
+            assert arg_indices_for_role("test", ["a", "b", "-body", "x"], ArgRole.BODY) == set()
+            # And the qualified ``tcltest::test`` is unaffected.
+            assert (
+                body_kind_for_command("tcltest::test", ["a", "b", "-body", "x"])
+                is BodyKind.STRUCTURAL
+            )
+        finally:
+            configure_signatures(dialect="tcl8.6", extra_commands=[])
+
+    def test_bare_test_resolves_to_alias_when_no_direct_registration(self):
+        from core.commands.registry.runtime import BodyKind, body_kind_for_command
+
+        # With no ``extra_commands`` registration, the static alias still
+        # applies — preserving the behaviour for tcltest-style packages
+        # where the bare name is the conventional spelling.
+        assert body_kind_for_command("test", ["a", "b", "-body", "x"]) is BodyKind.STRUCTURAL


### PR DESCRIPTION
## Summary

Implement registry-driven resolution for CFG-rewritten ensemble commands (e.g., `::tcl::dict::for` → `dict for`) and namespace-exported short names (e.g., `test` → `tcltest::test`). This eliminates hardcoded command name mappings and ensures all downstream consumers (SSA, diagnostics, optimizations) see consistent role, body-kind, and arity information.

**Key changes:**

1. **New `BodyKind` enum** (`signatures.py`): Distinguishes `INLINE` bodies (execute in caller's scope: `catch`, `while`, `dict for`) from `STRUCTURAL` bodies (separate scope: `proc`, `when`, `tcltest::test`).

2. **Extended `ArgRole` enum** (`signatures.py`): Added `VAR_READ_WRITE` (for `dict with`/`dict update` dict variables that are both read and written) and `LOOP_VAR_LIST` (for `dict for`/`dict map` loop variable lists).

3. **Registry-driven alias maps** (`runtime.py`):
   - `_REWRITE_ALIASES`: Maps CFG-rewritten names (e.g., `::tcl::dict::for`) back to source ensemble specs via `SubCommand.cfg_rewrite_name`.
   - `_COMMAND_NAME_ALIASES`: Maps bare names (e.g., `test`) to qualified specs via `CommandSpec.is_namespace_exported`.
   - Both maps are derived from declarative spec properties, not hardcoded.

4. **New public functions** (`runtime.py`):
   - `resolve_rewrite_alias(command)`: Resolve CFG-rewritten names to `(source_cmd, subcommand)`.
   - `body_kind_for_command(command, args)`: Query body kind with automatic resolution through alias maps.

5. **Refactored role resolution** (`runtime.py`):
   - Extracted `_resolve_arg_roles()` to unify ensemble and plain command handling.
   - Added `_ROLE_SUBSUMES` table so `VAR_READ_WRITE` queries match `VAR_READ` and `VAR_WRITE` requests.
   - Simplified `arg_indices_for_role()` and `arg_indices_for_roles()` to use the new helpers.

6. **Updated SSA analysis** (`ssa.py`):
   - Replaced hardcoded `dict for`/`dict map` checks with registry-driven `ArgRole.LOOP_VAR_LIST` queries.
   - Replaced hardcoded `dict with`/`dict update` checks with `ArgRole.VAR_READ` queries (via subsumption).
   - Replaced hardcoded structural-body list (`when`, `proc`, `test`) with `body_kind_for_command()` queries.

7. **Updated CFG lowering** (`cfg.py`): Read `cfg_rewrite_name` from the registry instead of hardcoding `::tcl::dict::{sub}`.

8. **Updated specs**:
   - `dict.py`: Set `cfg_rewrite_name` on `for`/`map` subcommands; changed `dict with`/`dict update` var role to `VAR_READ_WRITE`.
   - `tcltest.py`, `proc_.py`, `when.py`: Set `body_kind=BodyKind.STRUCTURAL` on relevant commands.

## Validation

- Added comprehensive test suite (`TestRewriteAliasResolution`, `TestVarReadWriteSubsumption`, `TestBodyKind`) covering:
  - Rewrite alias resolution and derivation from specs
  - Exported short-name resolution
  - Role subsumption for `VAR_READ_WRITE`
  - Body-kind queries for structural vs. inline bodies
  - Consistency between ensemble and rewritten forms
- Existing tests pass; no regressions in role/body-kind queries.

https://claude.ai/code/session_01RQUjYJjdBSNLdw3hHwR94o