### PR TITLE
Compose trace execution effects into side-effect classification

### DIFF
--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -99,8 +99,16 @@ def _is_pure_command(
     args: tuple[str, ...],
     interproc: InterproceduralAnalysis | None = None,
     caller_name: str = "::top",
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> bool:
-    """Return True if the command invocation is pure for GVN purposes."""
+    """Return True if the command invocation is pure for GVN purposes.
+
+    ``traced_commands`` and ``has_dynamic_trace`` come from
+    :meth:`IRModule.traced_commands` / :meth:`IRModule.has_dynamic_trace`
+    — calls to a command with an active execution trace are never pure
+    because the trace body composes side-effects in (issue #251).
+    """
     callee_summary = None
     if interproc is not None:
         known = set(interproc.procedures)
@@ -108,7 +116,13 @@ def _is_pure_command(
         if target is None:
             target = _normalise_qualified_name(command)
         callee_summary = interproc.procedures.get(target)
-    effect = classify_side_effects(command, args, callee_summary=callee_summary)
+    effect = classify_side_effects(
+        command,
+        args,
+        callee_summary=callee_summary,
+        traced_commands=traced_commands,
+        has_dynamic_trace=has_dynamic_trace,
+    )
     return effect.pure
 
 
@@ -117,8 +131,16 @@ def _is_worth_reporting(
     interproc: InterproceduralAnalysis | None = None,
     caller_name: str = "::top",
     args: tuple[str, ...] = (),
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> bool:
-    """Return True if redundant use of this command is worth flagging."""
+    """Return True if redundant use of this command is worth flagging.
+
+    A traced command has unknowable per-call effects so CSE/reporting
+    must skip it (issue #251).
+    """
+    if has_dynamic_trace or (traced_commands is not None and command in traced_commands):
+        return False
     if REGISTRY.is_cse_candidate(command):
         return True
     # User-defined pure procs are always worth reporting.
@@ -271,6 +293,8 @@ def _statement_occurrences(
     *,
     interproc: InterproceduralAnalysis | None = None,
     caller_name: str = "::top",
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> list[_ExprOccurrence]:
     """Collect pure expression occurrences from one statement."""
     occurrences: list[_ExprOccurrence] = []
@@ -280,8 +304,17 @@ def _statement_occurrences(
         ir_stmt.args,
         interproc,
         caller_name,
+        traced_commands=traced_commands,
+        has_dynamic_trace=has_dynamic_trace,
     ):
-        if _is_worth_reporting(ir_stmt.command, interproc, caller_name, args=ir_stmt.args):
+        if _is_worth_reporting(
+            ir_stmt.command,
+            interproc,
+            caller_name,
+            args=ir_stmt.args,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
+        ):
             stmt_range = getattr(ir_stmt, "range", None)
             if stmt_range is not None:
                 occurrences.append(
@@ -300,7 +333,14 @@ def _statement_occurrences(
         if parsed is None:
             continue
         cmd_name, cmd_args = parsed
-        if not _is_pure_command(cmd_name, cmd_args, interproc, caller_name):
+        if not _is_pure_command(
+            cmd_name,
+            cmd_args,
+            interproc,
+            caller_name,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
+        ):
             continue
         occurrences.append(
             _ExprOccurrence(
@@ -322,6 +362,8 @@ def _statement_writes_state(
     *,
     interproc: InterproceduralAnalysis | None = None,
     caller_name: str = "::top",
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> bool:
     """Return True when statement effects must invalidate value numbering."""
     if isinstance(ir_stmt, IRBarrier):
@@ -339,6 +381,8 @@ def _statement_writes_state(
             ir_stmt.command,
             ir_stmt.args,
             callee_summary=callee_summary,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
         )
         _reads, writes = effect.to_effect_regions()
         if writes != EffectRegion.NONE:
@@ -356,7 +400,13 @@ def _statement_writes_state(
             if target is None:
                 target = _normalise_qualified_name(cmd_name)
             callee_summary = interproc.procedures.get(target)
-        effect = classify_side_effects(cmd_name, cmd_args, callee_summary=callee_summary)
+        effect = classify_side_effects(
+            cmd_name,
+            cmd_args,
+            callee_summary=callee_summary,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
+        )
         _reads, writes = effect.to_effect_regions()
         if writes != EffectRegion.NONE:
             return True
@@ -546,6 +596,8 @@ def _collect_function_occurrence_events(
     source: str,
     *,
     interproc: InterproceduralAnalysis | None = None,
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> tuple[dict[BlockName, tuple[_ExprOccurrence | None, ...]], list[_ExprOccurrence]]:
     """Collect per-block occurrence streams; ``None`` marks a barrier kill."""
     executable = set(cfg.blocks) - analysis.unreachable_blocks
@@ -571,6 +623,8 @@ def _collect_function_occurrence_events(
                 source,
                 interproc=interproc,
                 caller_name=cfg.name,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             ):
                 events.append(None)
                 continue
@@ -583,6 +637,8 @@ def _collect_function_occurrence_events(
                 idx,
                 interproc=interproc,
                 caller_name=cfg.name,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             )
             events.extend(occurrences)
             all_occurrences.extend(occurrences)
@@ -612,6 +668,8 @@ def _find_partial_redundancies(
     source: str,
     *,
     interproc: InterproceduralAnalysis | None = None,
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> list[RedundantComputation]:
     """Detect path-partial redundancies via may/must-availability."""
     executable = set(cfg.blocks) - analysis.unreachable_blocks
@@ -624,6 +682,8 @@ def _find_partial_redundancies(
         analysis,
         source,
         interproc=interproc,
+        traced_commands=traced_commands,
+        has_dynamic_trace=has_dynamic_trace,
     )
     if not all_occurrences:
         return []
@@ -784,6 +844,8 @@ def _find_loop_invariants(
     source: str,
     *,
     interproc: InterproceduralAnalysis | None = None,
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> list[RedundantComputation]:
     """Detect loop-invariant pure computations (LICM-style hints)."""
     executable = set(cfg.blocks) - analysis.unreachable_blocks
@@ -796,6 +858,8 @@ def _find_loop_invariants(
         analysis,
         source,
         interproc=interproc,
+        traced_commands=traced_commands,
+        has_dynamic_trace=has_dynamic_trace,
     )
     if not events_by_block:
         return []
@@ -847,7 +911,13 @@ def _find_loop_invariants(
                     continue
 
                 command = occ.key[1] if len(occ.key) > 1 else ""
-                if not _is_worth_reporting(command, interproc, cfg.name):
+                if not _is_worth_reporting(
+                    command,
+                    interproc,
+                    cfg.name,
+                    traced_commands=traced_commands,
+                    has_dynamic_trace=has_dynamic_trace,
+                ):
                     continue
 
                 results.append(
@@ -873,6 +943,8 @@ def _gvn_walk_function(
     source: str,
     *,
     interproc: InterproceduralAnalysis | None = None,
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> list[RedundantComputation]:
     """Walk one function in dominator-tree preorder, detecting CSE."""
     table = _ScopedValueTable()
@@ -903,6 +975,8 @@ def _gvn_walk_function(
                 source,
                 interproc=interproc,
                 caller_name=cfg.name,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             ):
                 table.kill_all()
                 continue
@@ -915,6 +989,8 @@ def _gvn_walk_function(
                 idx,
                 interproc=interproc,
                 caller_name=cfg.name,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             )
             for occ in occurrences:
                 existing = table.lookup(occ.key)
@@ -1306,6 +1382,9 @@ def find_redundant_computations(
     if cu is None:
         return []
 
+    traced_commands = cu.ir_module.traced_commands()
+    has_dynamic_trace = cu.ir_module.has_dynamic_trace()
+
     results: list[RedundantComputation] = []
     results.extend(
         _gvn_walk_function(
@@ -1314,6 +1393,8 @@ def find_redundant_computations(
             cu.top_level.analysis,
             source,
             interproc=cu.interproc,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
         )
     )
     results.extend(
@@ -1323,6 +1404,8 @@ def find_redundant_computations(
             cu.top_level.analysis,
             source,
             interproc=cu.interproc,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
         )
     )
     results.extend(
@@ -1332,6 +1415,8 @@ def find_redundant_computations(
             cu.top_level.analysis,
             source,
             interproc=cu.interproc,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
         )
     )
     for fu in cu.procedures.values():
@@ -1342,6 +1427,8 @@ def find_redundant_computations(
                 fu.analysis,
                 source,
                 interproc=cu.interproc,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             )
         )
         results.extend(
@@ -1351,6 +1438,8 @@ def find_redundant_computations(
                 fu.analysis,
                 source,
                 interproc=cu.interproc,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             )
         )
         results.extend(
@@ -1360,6 +1449,8 @@ def find_redundant_computations(
                 fu.analysis,
                 source,
                 interproc=cu.interproc,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
             )
         )
 

--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -1146,8 +1146,16 @@ def _shift_range(
 def _analyse_when_body_with_cfg(
     body_text: str,
     body_tok: Token,
+    *,
+    outer_traced_commands: frozenset[str] | None = None,
+    outer_has_dynamic_trace: bool = False,
 ) -> list[RedundantComputation]:
-    """Analyse one ``when`` body as standalone Tcl for GVN/PRE/LICM."""
+    """Analyse one ``when`` body as standalone Tcl for GVN/PRE/LICM.
+
+    ``outer_traced_commands`` / ``outer_has_dynamic_trace`` carry trace
+    state from the document containing this ``when`` block — execution
+    traces installed at top level apply inside event bodies too.
+    """
     from .compilation_unit import compile_source
 
     try:
@@ -1155,6 +1163,11 @@ def _analyse_when_body_with_cfg(
     except Exception:
         log.debug("gvn: compilation failed for when-body analysis", exc_info=True)
         return []
+
+    body_traced = body_cu.ir_module.traced_commands()
+    if outer_traced_commands:
+        body_traced = body_traced | outer_traced_commands
+    body_has_dynamic_trace = body_cu.ir_module.has_dynamic_trace() or outer_has_dynamic_trace
 
     local_results: list[RedundantComputation] = []
     local_results.extend(
@@ -1164,6 +1177,8 @@ def _analyse_when_body_with_cfg(
             body_cu.top_level.analysis,
             body_text,
             interproc=body_cu.interproc,
+            traced_commands=body_traced,
+            has_dynamic_trace=body_has_dynamic_trace,
         )
     )
     local_results.extend(
@@ -1173,6 +1188,8 @@ def _analyse_when_body_with_cfg(
             body_cu.top_level.analysis,
             body_text,
             interproc=body_cu.interproc,
+            traced_commands=body_traced,
+            has_dynamic_trace=body_has_dynamic_trace,
         )
     )
     local_results.extend(
@@ -1182,6 +1199,8 @@ def _analyse_when_body_with_cfg(
             body_cu.top_level.analysis,
             body_text,
             interproc=body_cu.interproc,
+            traced_commands=body_traced,
+            has_dynamic_trace=body_has_dynamic_trace,
         )
     )
     for fu in body_cu.procedures.values():
@@ -1192,6 +1211,8 @@ def _analyse_when_body_with_cfg(
                 fu.analysis,
                 body_text,
                 interproc=body_cu.interproc,
+                traced_commands=body_traced,
+                has_dynamic_trace=body_has_dynamic_trace,
             )
         )
         local_results.extend(
@@ -1201,6 +1222,8 @@ def _analyse_when_body_with_cfg(
                 fu.analysis,
                 body_text,
                 interproc=body_cu.interproc,
+                traced_commands=body_traced,
+                has_dynamic_trace=body_has_dynamic_trace,
             )
         )
         local_results.extend(
@@ -1210,6 +1233,8 @@ def _analyse_when_body_with_cfg(
                 fu.analysis,
                 body_text,
                 interproc=body_cu.interproc,
+                traced_commands=body_traced,
+                has_dynamic_trace=body_has_dynamic_trace,
             )
         )
 
@@ -1242,7 +1267,12 @@ def _analyse_when_body_with_cfg(
     ]
 
 
-def _scan_when_bodies(source: str) -> list[RedundantComputation]:
+def _scan_when_bodies(
+    source: str,
+    *,
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
+) -> list[RedundantComputation]:
     """Analyse iRules ``when`` bodies for repeated pure command calls.
 
     ``when`` bodies bypass the parent document CFG/SSA pipeline (they are
@@ -1264,16 +1294,33 @@ def _scan_when_bodies(source: str) -> list[RedundantComputation]:
     Within each event body we track ``(cmd_name, args_text)`` keys.
     Because there is no SSA, variable-versioned canonicalisation is not
     possible; we simply use raw argument text.
+
+    ``traced_commands`` / ``has_dynamic_trace`` come from the enclosing
+    module's :class:`IRModule` so commands that are traced at top level
+    (or in a sibling ``when`` body) are excluded from CSE/PRE hints
+    inside event bodies — see issue #251.
     """
     results: list[RedundantComputation] = []
 
     def _writes_tracked_state(command: str, args: tuple[str, ...]) -> bool:
-        _reads, writes = classify_side_effects(command, args).to_effect_regions()
+        _reads, writes = classify_side_effects(
+            command,
+            args,
+            traced_commands=traced_commands,
+            has_dynamic_trace=has_dynamic_trace,
+        ).to_effect_regions()
         return writes != EffectRegion.NONE
 
     for _event, _priority, body_text, body_tok, _event_tok in _find_when_bodies(source):
         # Path-sensitive pass first so it wins dedup ties over flat-scan hits.
-        results.extend(_analyse_when_body_with_cfg(body_text, body_tok))
+        results.extend(
+            _analyse_when_body_with_cfg(
+                body_text,
+                body_tok,
+                outer_traced_commands=traced_commands,
+                outer_has_dynamic_trace=has_dynamic_trace,
+            )
+        )
 
         # Track command-call keys seen so far within this body.
         seen: dict[tuple[str, ...], tuple[Range, str]] = {}
@@ -1294,9 +1341,18 @@ def _scan_when_bodies(source: str) -> list[RedundantComputation]:
 
             # Pattern 1: standalone pure command at top level
             # e.g. bare `HTTP::uri` or `HTTP::header value Host`
-            if _is_pure_command(cmd_name, top_args):
+            if _is_pure_command(
+                cmd_name,
+                top_args,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
+            ):
                 args = top_args
-                if _is_worth_reporting(cmd_name):
+                if _is_worth_reporting(
+                    cmd_name,
+                    traced_commands=traced_commands,
+                    has_dynamic_trace=has_dynamic_trace,
+                ):
                     key = ("call", cmd_name, *args)
                     _record_hit(
                         key,
@@ -1319,9 +1375,18 @@ def _scan_when_bodies(source: str) -> list[RedundantComputation]:
                     if _writes_tracked_state(inner_cmd, inner_args):
                         seen.clear()
                         continue
-                    if not _is_pure_command(inner_cmd, inner_args):
+                    if not _is_pure_command(
+                        inner_cmd,
+                        inner_args,
+                        traced_commands=traced_commands,
+                        has_dynamic_trace=has_dynamic_trace,
+                    ):
                         continue
-                    if not _is_worth_reporting(inner_cmd):
+                    if not _is_worth_reporting(
+                        inner_cmd,
+                        traced_commands=traced_commands,
+                        has_dynamic_trace=has_dynamic_trace,
+                    ):
                         continue
                     key = ("call", inner_cmd, *inner_args)
                     _record_hit(
@@ -1348,9 +1413,18 @@ def _scan_when_bodies(source: str) -> list[RedundantComputation]:
                         if _writes_tracked_state(inner_cmd, inner_args):
                             seen.clear()
                             continue
-                        if not _is_pure_command(inner_cmd, inner_args):
+                        if not _is_pure_command(
+                            inner_cmd,
+                            inner_args,
+                            traced_commands=traced_commands,
+                            has_dynamic_trace=has_dynamic_trace,
+                        ):
                             continue
-                        if not _is_worth_reporting(inner_cmd):
+                        if not _is_worth_reporting(
+                            inner_cmd,
+                            traced_commands=traced_commands,
+                            has_dynamic_trace=has_dynamic_trace,
+                        ):
                             continue
                         key = ("call", inner_cmd, *inner_args)
                         _record_hit(
@@ -1457,6 +1531,12 @@ def find_redundant_computations(
     # iRules ``when`` bodies bypass CFG/SSA -- scan them with a
     # flat token-level pass.
     if active_dialect() == "f5-irules":
-        results.extend(_scan_when_bodies(source))
+        results.extend(
+            _scan_when_bodies(
+                source,
+                traced_commands=traced_commands,
+                has_dynamic_trace=has_dynamic_trace,
+            )
+        )
 
     return _deduplicate(results)

--- a/core/compiler/ir.py
+++ b/core/compiler/ir.py
@@ -340,6 +340,40 @@ class IRMethodDef:
     range: Range | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class CommandTrace:
+    """A static record of a ``trace add/remove execution`` directive.
+
+    Captured at lowering time so downstream side-effect classification
+    can union the trace body's effects into every call to ``target``.
+    Variable / command traces are not captured here — only execution
+    traces, which are the form whose body composes into the traced
+    command's effective side-effects (issue #251).
+
+    ``body`` is ``None`` when the body argument is dynamic
+    (non-literal — e.g. a ``$variable`` or ``[command]`` substitution);
+    callers must treat dynamic bodies as worst-case.
+    """
+
+    target: str
+    """Command name being traced (e.g. ``"set"``, ``"::ns::proc"``)."""
+
+    ops: tuple[str, ...]
+    """Operations the trace fires on (``"enter"``/``"leave"``/``"enterstep"``/``"leavestep"``)."""
+
+    body: str | None
+    """Literal trace-body script, or ``None`` when the body is dynamic."""
+
+    body_range: Range | None = None
+    """Source range of the body argument (when known)."""
+
+    action: str = "add"
+    """``"add"`` or ``"remove"`` — distinguishes registration from removal."""
+
+    target_dynamic: bool = False
+    """True when the *target* command name itself is a non-literal."""
+
+
 @dataclass
 class IRModule:
     top_level: IRScript = field(default_factory=IRScript)
@@ -368,6 +402,46 @@ class IRModule:
     # path, where the interpreter can apply the correct
     # "unknown command" diagnostic.
     namespace_exports: tuple[tuple[str, str], ...] = ()
+
+    # ``trace add/remove execution`` directives captured at lowering
+    # time.  Traces installed on a command compose into that command's
+    # effective side-effects: a trace on a registry-pure command (e.g.
+    # ``set``) is no longer pure because the trace body runs around
+    # every call.  Side-effect classification consults
+    # :meth:`traced_commands` to gate purity / CSE on traced names.
+    # See ``docs/design/compiler/side-effects-system.md`` for the
+    # composition rule and ``docs/design/compiler/lowering-contracts.md``
+    # for the capture contract.  Out of scope here:
+    # ``trace add command`` and ``trace add variable`` (different
+    # semantics — handled, if at all, in their own captures).
+    command_traces: tuple["CommandTrace", ...] = ()
+
+    def traced_commands(self) -> frozenset[str]:
+        """Return the set of command names with a net active execution trace.
+
+        A trace is "net active" when there are more ``trace add execution``
+        directives for the target than ``trace remove execution`` directives
+        — modelling the global command-table state at end-of-script.
+        Dynamic targets (``target_dynamic=True``) are not folded into the
+        named set; callers that need the over-approximation must check
+        :meth:`has_dynamic_trace` separately.
+        """
+        counts: dict[str, int] = {}
+        for trace in self.command_traces:
+            if trace.target_dynamic:
+                continue
+            delta = 1 if trace.action == "add" else -1
+            counts[trace.target] = counts.get(trace.target, 0) + delta
+        return frozenset(name for name, count in counts.items() if count > 0)
+
+    def has_dynamic_trace(self) -> bool:
+        """True when any ``trace add execution`` had a non-literal target.
+
+        When this flag is set, downstream effect classification cannot
+        rule out *any* command being traced and must pessimise calls
+        whose purity matters for correctness.
+        """
+        return any(t.target_dynamic and t.action == "add" for t in self.command_traces)
 
 
 def when_event_name(qualified_name: str) -> str:

--- a/core/compiler/ir.py
+++ b/core/compiler/ir.py
@@ -419,20 +419,40 @@ class IRModule:
     def traced_commands(self) -> frozenset[str]:
         """Return the set of command names with a net active execution trace.
 
-        A trace is "net active" when there are more ``trace add execution``
-        directives for the target than ``trace remove execution`` directives
-        — modelling the global command-table state at end-of-script.
-        Dynamic targets (``target_dynamic=True``) are not folded into the
-        named set; callers that need the over-approximation must check
-        :meth:`has_dynamic_trace` separately.
+        Walks ``command_traces`` in source order, modelling the global
+        command-table state.  Tcl matches ``trace remove execution`` by
+        the full registration tuple (target, ops, command prefix); a
+        non-matching ``remove`` is a runtime no-op.  We mirror that
+        semantics conservatively:
+
+        - An ``add`` with a literal target appends ``(target, ops_set,
+          body)`` to the active list.
+        - A ``remove`` cancels at most one matching add — same target,
+          same ops set, same literal body.  Removes with a dynamic ops
+          list, dynamic body, or dynamic target leave the active list
+          alone (the safe over-approximation: the trace might still be
+          installed, so keep treating the command as traced).
+        - Dynamic-target adds are not folded into the named set;
+          callers that need the worst-case over-approximation must
+          check :meth:`has_dynamic_trace` separately.
         """
-        counts: dict[str, int] = {}
+        active: list[tuple[str, frozenset[str], str | None]] = []
         for trace in self.command_traces:
             if trace.target_dynamic:
                 continue
-            delta = 1 if trace.action == "add" else -1
-            counts[trace.target] = counts.get(trace.target, 0) + delta
-        return frozenset(name for name, count in counts.items() if count > 0)
+            if trace.action == "add":
+                active.append((trace.target, frozenset(trace.ops), trace.body))
+                continue
+            # ``remove`` — only cancel a matching add when target, ops,
+            # and body are all known.  Skip otherwise (over-pessimise).
+            if not trace.ops or trace.body is None:
+                continue
+            key = (trace.target, frozenset(trace.ops), trace.body)
+            try:
+                active.remove(key)
+            except ValueError:
+                continue
+        return frozenset(target for target, _ops, _body in active)
 
     def has_dynamic_trace(self) -> bool:
         """True when any ``trace add execution`` had a non-literal target.

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -44,6 +44,7 @@ from ..parsing.lexer import TclLexer, TclParseError
 from ..parsing.tokens import Token, TokenType
 from .ir import (
     CommandTokens,
+    CommandTrace,
     IRAssignConst,
     IRAssignExpr,
     IRAssignValue,
@@ -337,6 +338,13 @@ class _Lowerer:
         # the import filter, so the worst case is the pre-fix
         # behaviour (runtime would correctly reject the import).
         self._namespace_exports: list[tuple[str, str]] = []
+        # ``trace add execution`` / ``trace remove execution`` directives
+        # captured at lowering time.  See ``IRModule.command_traces``.
+        # Both adds and removes are recorded in source order so the net
+        # active set can be derived later (also reused by future
+        # interprocedural passes that need to know *where* a trace is
+        # installed).
+        self._command_traces: list[CommandTrace] = []
         # Per-script const-map stack: each scope tracks proc-local
         # variables assigned a braced-literal value.  Populated at
         # ``set var {literal}`` sites and consulted by the
@@ -400,6 +408,7 @@ class _Lowerer:
         self.module.top_level = self._lower_script(source, namespace="::")
         self.module.namespace_exports = tuple(self._namespace_exports)
         self.module.namespace_imports = tuple(self._namespace_imports)
+        self.module.command_traces = tuple(self._command_traces)
         return self.module
 
     def lower_commands(
@@ -1621,6 +1630,65 @@ class _Lowerer:
                 # current namespace.
                 self._namespace_exports.append((namespace, pat))
 
+        # Capture ``trace add execution cmdName ops body`` and the
+        # matching ``remove`` form.  Execution traces install a Tcl
+        # body that runs around every call to ``cmdName``, so the
+        # traced command's effective side-effects are no longer just
+        # whatever the registry declares — the trace body's effects
+        # compose in.  Side-effect classification consults
+        # :meth:`IRModule.traced_commands` to drop purity / CSE for
+        # any command with a net active execution trace.
+        # Out of scope here: ``trace add command`` (fires only on
+        # rename/delete; doesn't compose into the command's per-call
+        # effects) and ``trace add variable`` (handled separately —
+        # its effect is on the named variable, not on a command).
+        # Subscriptions on dialect-aliased ``::trace`` spellings are
+        # captured too because the rewrite-alias resolver normalises
+        # them to ``trace`` before the lowering hook runs.
+        if (
+            cmd_name in ("trace", "::trace")
+            and len(args) >= 5
+            and args[0] in ("add", "remove")
+            and args[1] == "execution"
+            and (cmd.expand_word is None or not any(cmd.expand_word))
+            and self._dead_code_depth == 0
+        ):
+            target_arg_tok = arg_tokens[2] if len(arg_tokens) > 2 else None
+            ops_arg_tok = arg_tokens[3] if len(arg_tokens) > 3 else None
+            body_arg_tok = arg_tokens[4] if len(arg_tokens) > 4 else None
+            target_dynamic = target_arg_tok is None or target_arg_tok.type not in (
+                TokenType.STR,
+                TokenType.ESC,
+            )
+            target_name = "" if target_dynamic else args[2]
+            ops_dynamic = ops_arg_tok is None or ops_arg_tok.type not in (
+                TokenType.STR,
+                TokenType.ESC,
+            )
+            if ops_dynamic:
+                ops_tuple: tuple[str, ...] = ()
+            else:
+                # The ops list is a Tcl list of {enter, leave, enterstep,
+                # leavestep}.  Splitting on whitespace covers the common
+                # literal form; non-literal ops fall through as ``()``
+                # which the consumer treats as "all ops".
+                ops_tuple = tuple(args[3].split())
+            body_literal = body_arg_tok is not None and body_arg_tok.type is TokenType.STR
+            body_text: str | None = args[4] if body_literal else None
+            body_range: Range | None = None
+            if body_arg_tok is not None:
+                body_range = Range(start=body_arg_tok.start, end=body_arg_tok.end)
+            self._command_traces.append(
+                CommandTrace(
+                    target=target_name,
+                    ops=ops_tuple,
+                    body=body_text,
+                    body_range=body_range,
+                    action=args[0],
+                    target_dynamic=target_dynamic,
+                )
+            )
+
         # Check for a registered lowering hook first.
         spec = REGISTRY.get_any(cmd_name)
         # If the command itself has no lowering hook, try the alias target.
@@ -2092,6 +2160,7 @@ def lower_to_ir(
     lowerer.module.top_level = IRScript(statements=tuple(all_stmts))
     lowerer.module.namespace_imports = tuple(lowerer._namespace_imports)
     lowerer.module.namespace_exports = tuple(lowerer._namespace_exports)
+    lowerer.module.command_traces = tuple(lowerer._command_traces)
     inline_uplevel_passthrough(lowerer.module)
     return lowerer.module
 

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -1653,18 +1653,29 @@ class _Lowerer:
             and (cmd.expand_word is None or not any(cmd.expand_word))
             and self._dead_code_depth == 0
         ):
-            target_arg_tok = arg_tokens[2] if len(arg_tokens) > 2 else None
-            ops_arg_tok = arg_tokens[3] if len(arg_tokens) > 3 else None
+            # An argument word is "literal" only when it is composed of a
+            # single non-substituting token: ``single_token_word`` is True
+            # AND the token type is STR (braced) or ESC (plain/escaped).
+            # ``foo$cmd`` lexes as ESC + VAR — its first token is ESC, but
+            # ``single_token_word`` is False, so it must be treated as
+            # dynamic.  Without the multi-token guard a target like
+            # ``foo$cmd`` would record as a literal ``foo`` and let
+            # purity/CSE checks proceed even though the actual traced
+            # command is runtime-dependent (issue #251 review).
+            def _arg_is_literal(arg_idx: int) -> bool:
+                word_idx = arg_idx + 1
+                if word_idx >= len(cmd.single_token_word):
+                    return False
+                if not cmd.single_token_word[word_idx]:
+                    return False
+                if word_idx >= len(cmd.argv):
+                    return False
+                return cmd.argv[word_idx].type in (TokenType.STR, TokenType.ESC)
+
             body_arg_tok = arg_tokens[4] if len(arg_tokens) > 4 else None
-            target_dynamic = target_arg_tok is None or target_arg_tok.type not in (
-                TokenType.STR,
-                TokenType.ESC,
-            )
+            target_dynamic = not _arg_is_literal(2)
             target_name = "" if target_dynamic else args[2]
-            ops_dynamic = ops_arg_tok is None or ops_arg_tok.type not in (
-                TokenType.STR,
-                TokenType.ESC,
-            )
+            ops_dynamic = not _arg_is_literal(3)
             if ops_dynamic:
                 ops_tuple: tuple[str, ...] = ()
             else:
@@ -1673,7 +1684,14 @@ class _Lowerer:
                 # literal form; non-literal ops fall through as ``()``
                 # which the consumer treats as "all ops".
                 ops_tuple = tuple(args[3].split())
-            body_literal = body_arg_tok is not None and body_arg_tok.type is TokenType.STR
+            # Body must be braced (STR) and single-token to be considered
+            # literal — an ESC body or a multi-token body could substitute.
+            body_literal = (
+                body_arg_tok is not None
+                and body_arg_tok.type is TokenType.STR
+                and len(cmd.single_token_word) > 5
+                and cmd.single_token_word[5]
+            )
             body_text: str | None = args[4] if body_literal else None
             body_range: Range | None = None
             if body_arg_tok is not None:

--- a/core/compiler/optimiser/_propagation.py
+++ b/core/compiler/optimiser/_propagation.py
@@ -777,6 +777,17 @@ def optimise_load_forwarding(
 
     executable_blocks = set(cfg.blocks) - set(analysis.unreachable_blocks)
 
+    # Hoist trace-aware classification context out of the per-statement
+    # loop: ``traced_commands()`` walks ``IRModule.command_traces`` on
+    # every call, and the answer is invariant across the def-use chain
+    # walk below.
+    if ctx.ir_module is not None:
+        traced_commands = ctx.ir_module.traced_commands()
+        has_dynamic_trace = ctx.ir_module.has_dynamic_trace()
+    else:
+        traced_commands = None
+        has_dynamic_trace = False
+
     # Build statement rewrite ranges for deletion.
     range_by_stmt, next_start_by_stmt = _statement_rewrite_context(source, cfg)
 
@@ -935,12 +946,6 @@ def optimise_load_forwarding(
                     )
                     if target is not None:
                         callee_summary = ctx.interproc.procedures.get(target)
-                traced_commands = (
-                    ctx.ir_module.traced_commands() if ctx.ir_module is not None else None
-                )
-                has_dynamic_trace = (
-                    ctx.ir_module.has_dynamic_trace() if ctx.ir_module is not None else False
-                )
                 effect = classify_side_effects(
                     between_stmt.command,
                     between_stmt.args,

--- a/core/compiler/optimiser/_propagation.py
+++ b/core/compiler/optimiser/_propagation.py
@@ -935,10 +935,18 @@ def optimise_load_forwarding(
                     )
                     if target is not None:
                         callee_summary = ctx.interproc.procedures.get(target)
+                traced_commands = (
+                    ctx.ir_module.traced_commands() if ctx.ir_module is not None else None
+                )
+                has_dynamic_trace = (
+                    ctx.ir_module.has_dynamic_trace() if ctx.ir_module is not None else False
+                )
                 effect = classify_side_effects(
                     between_stmt.command,
                     between_stmt.args,
                     callee_summary=callee_summary,
+                    traced_commands=traced_commands,
+                    has_dynamic_trace=has_dynamic_trace,
                 )
                 if not effect.pure:
                     unsafe = True

--- a/core/compiler/side_effects.py
+++ b/core/compiler/side_effects.py
@@ -565,9 +565,11 @@ def classify_side_effects(
     dialect: str | None = None,
     subcommand: str | None = None,
     callee_summary: object | None = None,
+    traced_commands: frozenset[str] | None = None,
+    has_dynamic_trace: bool = False,
 ) -> CommandSideEffects:
-    # Fast cache lookup for the common case (no callee_summary).
-    if callee_summary is None:
+    # Fast cache lookup for the common case (no callee_summary, no traces).
+    if callee_summary is None and not traced_commands and not has_dynamic_trace:
         cache_key = (command, args, dialect, subcommand)
         cached = _side_effect_cache.get(cache_key)
         if cached is not None:
@@ -581,12 +583,60 @@ def classify_side_effects(
         if len(_side_effect_cache) < _SIDE_EFFECT_CACHE_MAX:
             _side_effect_cache[cache_key] = result
         return result
-    return _classify_side_effects_impl(
+    base = _classify_side_effects_impl(
         command,
         args,
         dialect=dialect,
         subcommand=subcommand,
         callee_summary=callee_summary,
+    )
+    return _compose_with_traces(
+        base,
+        command,
+        traced_commands=traced_commands,
+        has_dynamic_trace=has_dynamic_trace,
+    )
+
+
+def _compose_with_traces(
+    base: CommandSideEffects,
+    command: str,
+    *,
+    traced_commands: frozenset[str] | None,
+    has_dynamic_trace: bool,
+) -> CommandSideEffects:
+    """Compose ``trace add execution`` body effects into a base classification.
+
+    The trace body runs around every call to ``command`` so its effects
+    union into the traced command's effective side-effects.  Today we
+    take the *conservative* upper bound: a traced command is treated
+    as if its body had unknown reads/writes (purity is dropped, a
+    catch-all UNKNOWN write is added).  A future pass can refine this
+    to the trace body's recursively-classified effects when the body
+    is statically known.
+
+    ``has_dynamic_trace`` widens the rule to all commands when *any*
+    trace was installed with a non-literal target — we cannot prove
+    a particular call isn't traced, so we must pessimise it.
+    """
+    if not has_dynamic_trace and (not traced_commands or command not in traced_commands):
+        return base
+    # Avoid double-pessimising commands that are already classified as
+    # dynamic barriers — they're already worst-case.
+    if base.dynamic_barrier:
+        return base
+    trace_effect = SideEffect(
+        target=SideEffectTarget.UNKNOWN,
+        reads=True,
+        writes=True,
+    )
+    composed_effects = (*base.effects, trace_effect)
+    return CommandSideEffects(
+        effects=composed_effects,
+        pure=False,
+        deterministic=False,
+        dynamic_barrier=base.dynamic_barrier,
+        dialect=base.dialect,
     )
 
 

--- a/docs/design/compiler/side-effects-system.md
+++ b/docs/design/compiler/side-effects-system.md
@@ -176,6 +176,38 @@ Key interaction: when a subcommand is marked `pure=True` and has a hint, the cla
 7. **Hint fallback** — if a hint exists, use it directly.
 8. **Conservative fallback** — `UNKNOWN` read+write.
 
+After the registry-based classification produces a base result, the
+**execution-trace composition rule** runs as a post-processing step
+(see issue #251):
+
+- `trace add execution cmdName ops body` registers a Tcl-language hook
+  that fires before/after every call to `cmdName`. The trace body's
+  effects compose into the traced command's effective per-call
+  side-effects: a registry-pure `set` is no longer pure once `set` is
+  traced, because the trace body runs around every invocation.
+- Captured at lowering time: `IRModule.command_traces` is a tuple of
+  `CommandTrace(target, ops, body, body_range, action, target_dynamic)`
+  records, one per syntactic `trace add execution` / `trace remove
+  execution` directive.
+- `IRModule.traced_commands()` returns the *net active* set: a target
+  is included when adds outnumber removes, modelling the global
+  command-table state at end-of-script. `IRModule.has_dynamic_trace()`
+  reports whether any `add` had a non-literal target — when true,
+  every command must be pessimised because we cannot prove a particular
+  call isn't traced.
+- Optimisation passes that consult purity (GVN, optimiser propagation)
+  pass `traced_commands` and `has_dynamic_trace` into
+  `classify_side_effects`. The composition is conservative today: a
+  matching command gets an extra `SideEffectTarget.UNKNOWN` read+write
+  effect appended, and `pure` / `deterministic` are forced to `False`.
+  A future refinement can replace the catch-all with the trace body's
+  recursively-classified effects.
+- `trace remove execution` undoes the propagation by cancelling the
+  matching `add` in the net count. `trace add command` and
+  `trace add variable` are **not** captured here — they have different
+  semantics (rename/delete and variable-access traces respectively)
+  and do not compose into the traced command's per-call effects.
+
 ## Examples of different side effect profiles
 
 ### Read-only data store access
@@ -275,14 +307,17 @@ SideEffect(
 
 ## File-path anchors
 
-- `core/compiler/side_effects.py` — enums, dataclasses, `classify_side_effects()`, `EffectRegion` bridge
+- `core/compiler/side_effects.py` — enums, dataclasses, `classify_side_effects()`, `_compose_with_traces()`, `EffectRegion` bridge
 - `core/commands/registry/models.py` — `CommandSpec.side_effect_hints`, `SubCommand.side_effect_hints`
 - `core/commands/registry/command_registry.py` — `REGISTRY.side_effect_hints()` lookup
-- `core/compiler/gvn.py` — GVN consumer (6 call sites)
+- `core/compiler/ir.py` — `CommandTrace`, `IRModule.command_traces`, `IRModule.traced_commands()`, `IRModule.has_dynamic_trace()`
+- `core/compiler/lowering.py` — `trace add/remove execution` capture (search "Capture ``trace add execution``")
+- `core/compiler/gvn.py` — GVN consumer (threads `traced_commands` from `IRModule`)
 - `core/compiler/interprocedural.py` — interprocedural consumer
 - `core/compiler/irules_flow.py` — response-commit and drop-command derivation
 - `core/compiler/execution_intent.py` — purity consumer
 - `core/compiler/core_analyses.py` — purity consumer
+- `core/compiler/optimiser/_propagation.py` — load-forwarding consumer (threads `traced_commands` via `ctx.ir_module`)
 
 ## Failure modes
 
@@ -295,6 +330,7 @@ SideEffect(
 ## Test anchors
 
 - `tests/test_side_effects.py`
+- `tests/test_trace_execution_effects.py` — `trace add/remove execution` capture and side-effect composition (issue #251)
 
 ## Discoverability
 

--- a/tests/test_trace_execution_effects.py
+++ b/tests/test_trace_execution_effects.py
@@ -41,6 +41,24 @@ class TestCommandTraceCapture:
         assert len(module.command_traces) == 1
         assert module.command_traces[0].target_dynamic
 
+    def test_multi_token_target_marked_dynamic(self) -> None:
+        # ``foo$cmd`` lexes as ESC + VAR — single_token_word[3] is False,
+        # so the target must be treated as dynamic even though the first
+        # token is ESC.  Otherwise purity/CSE checks would proceed against
+        # a fake literal name (issue #251 P1 review).
+        module = lower_to_ir("trace add execution foo$cmd {enter} {puts hi}")
+        assert len(module.command_traces) == 1
+        trace = module.command_traces[0]
+        assert trace.target_dynamic
+        assert trace.target == ""
+        assert module.has_dynamic_trace()
+
+    def test_multi_token_ops_marked_dynamic(self) -> None:
+        module = lower_to_ir("trace add execution set $ops {puts hi}")
+        assert len(module.command_traces) == 1
+        # Dynamic ops list — recorded as empty so removes can't match.
+        assert module.command_traces[0].ops == ()
+
     def test_traced_commands_net_set(self) -> None:
         module = lower_to_ir(
             "trace add execution set {enter} {puts a}\n"
@@ -49,6 +67,39 @@ class TestCommandTraceCapture:
         )
         # ``set`` cancelled, ``incr`` still active.
         assert module.traced_commands() == frozenset({"incr"})
+
+    def test_remove_with_mismatched_ops_does_not_cancel(self) -> None:
+        # Tcl only removes a trace when the full registration matches —
+        # mismatched ops on the ``remove`` is a no-op (issue #251 P1
+        # review).
+        module = lower_to_ir(
+            "trace add execution expr {enter} {puts a}\n"
+            "trace remove execution expr {leave} {puts a}\n"
+        )
+        assert module.traced_commands() == frozenset({"expr"})
+
+    def test_remove_with_mismatched_body_does_not_cancel(self) -> None:
+        module = lower_to_ir(
+            "trace add execution expr {enter} {puts a}\n"
+            "trace remove execution expr {enter} {puts b}\n"
+        )
+        assert module.traced_commands() == frozenset({"expr"})
+
+    def test_remove_with_matching_registration_cancels(self) -> None:
+        module = lower_to_ir(
+            "trace add execution expr {enter leave} {puts a}\n"
+            "trace remove execution expr {leave enter} {puts a}\n"
+        )
+        # Same ops set (order-independent) and same body — cancels.
+        assert module.traced_commands() == frozenset()
+
+    def test_remove_with_dynamic_body_does_not_cancel(self) -> None:
+        # Dynamic body on the remove can't be matched against the add
+        # — keep the trace active to over-pessimise safely.
+        module = lower_to_ir(
+            "trace add execution expr {enter} {puts a}\ntrace remove execution expr {enter} $body\n"
+        )
+        assert module.traced_commands() == frozenset({"expr"})
 
     def test_has_dynamic_trace_flag(self) -> None:
         module = lower_to_ir("trace add execution $cmd {enter} {puts hi}")

--- a/tests/test_trace_execution_effects.py
+++ b/tests/test_trace_execution_effects.py
@@ -15,13 +15,12 @@ from core.compiler.side_effects import (
     classify_side_effects,
 )
 
-
 # Lowering capture
 
 
 class TestCommandTraceCapture:
     def test_add_execution_literal_target(self) -> None:
-        module = lower_to_ir('trace add execution set {enter leave} {puts traced}')
+        module = lower_to_ir("trace add execution set {enter leave} {puts traced}")
         assert len(module.command_traces) == 1
         trace = module.command_traces[0]
         assert trace.target == "set"
@@ -32,41 +31,38 @@ class TestCommandTraceCapture:
 
     def test_remove_execution_literal_target(self) -> None:
         module = lower_to_ir(
-            'trace add execution set {enter} {puts hi}\n'
-            'trace remove execution set {enter} {puts hi}\n'
+            "trace add execution set {enter} {puts hi}\n"
+            "trace remove execution set {enter} {puts hi}\n"
         )
         assert [t.action for t in module.command_traces] == ["add", "remove"]
 
     def test_dynamic_target_marked(self) -> None:
-        module = lower_to_ir('trace add execution $cmd {enter} {puts hi}')
+        module = lower_to_ir("trace add execution $cmd {enter} {puts hi}")
         assert len(module.command_traces) == 1
         assert module.command_traces[0].target_dynamic
 
     def test_traced_commands_net_set(self) -> None:
         module = lower_to_ir(
-            'trace add execution set {enter} {puts a}\n'
-            'trace add execution incr {enter} {puts b}\n'
-            'trace remove execution set {enter} {puts a}\n'
+            "trace add execution set {enter} {puts a}\n"
+            "trace add execution incr {enter} {puts b}\n"
+            "trace remove execution set {enter} {puts a}\n"
         )
         # ``set`` cancelled, ``incr`` still active.
         assert module.traced_commands() == frozenset({"incr"})
 
     def test_has_dynamic_trace_flag(self) -> None:
-        module = lower_to_ir('trace add execution $cmd {enter} {puts hi}')
+        module = lower_to_ir("trace add execution $cmd {enter} {puts hi}")
         assert module.has_dynamic_trace()
 
     def test_no_capture_for_variable_or_command_subforms(self) -> None:
         # Out of scope: ``trace add variable`` / ``trace add command``.
         module = lower_to_ir(
-            'trace add variable foo write {puts $foo}\n'
-            'trace add command bar rename {puts $bar}\n'
+            "trace add variable foo write {puts $foo}\ntrace add command bar rename {puts $bar}\n"
         )
         assert module.command_traces == ()
 
     def test_dead_code_not_captured(self) -> None:
-        module = lower_to_ir(
-            'if {0} { trace add execution set {enter} {puts hi} }'
-        )
+        module = lower_to_ir("if {0} { trace add execution set {enter} {puts hi} }")
         assert module.command_traces == ()
 
 
@@ -110,8 +106,8 @@ class TestTraceComposition:
         # Module-level: an add+remove pair leaves traced_commands() empty,
         # so classification is unchanged from the registry baseline.
         module = lower_to_ir(
-            'trace add execution expr {enter} {puts a}\n'
-            'trace remove execution expr {enter} {puts a}\n'
+            "trace add execution expr {enter} {puts a}\n"
+            "trace remove execution expr {enter} {puts a}\n"
         )
         traced = module.traced_commands()
         composed = classify_side_effects(

--- a/tests/test_trace_execution_effects.py
+++ b/tests/test_trace_execution_effects.py
@@ -1,0 +1,146 @@
+"""Tests for ``trace add/remove execution`` capture and side-effect composition.
+
+Covers issue #251: a ``trace add execution`` directive composes the
+trace body's effects into every call to the target command, so a
+registry-pure command (like ``set``) is no longer pure once a trace
+fires around it.  ``trace remove execution`` cancels the propagation.
+"""
+
+from __future__ import annotations
+
+from core.compiler.ir import CommandTrace, IRModule
+from core.compiler.lowering import lower_to_ir
+from core.compiler.side_effects import (
+    SideEffectTarget,
+    classify_side_effects,
+)
+
+
+# Lowering capture
+
+
+class TestCommandTraceCapture:
+    def test_add_execution_literal_target(self) -> None:
+        module = lower_to_ir('trace add execution set {enter leave} {puts traced}')
+        assert len(module.command_traces) == 1
+        trace = module.command_traces[0]
+        assert trace.target == "set"
+        assert trace.action == "add"
+        assert trace.ops == ("enter", "leave")
+        assert trace.body == "puts traced"
+        assert not trace.target_dynamic
+
+    def test_remove_execution_literal_target(self) -> None:
+        module = lower_to_ir(
+            'trace add execution set {enter} {puts hi}\n'
+            'trace remove execution set {enter} {puts hi}\n'
+        )
+        assert [t.action for t in module.command_traces] == ["add", "remove"]
+
+    def test_dynamic_target_marked(self) -> None:
+        module = lower_to_ir('trace add execution $cmd {enter} {puts hi}')
+        assert len(module.command_traces) == 1
+        assert module.command_traces[0].target_dynamic
+
+    def test_traced_commands_net_set(self) -> None:
+        module = lower_to_ir(
+            'trace add execution set {enter} {puts a}\n'
+            'trace add execution incr {enter} {puts b}\n'
+            'trace remove execution set {enter} {puts a}\n'
+        )
+        # ``set`` cancelled, ``incr`` still active.
+        assert module.traced_commands() == frozenset({"incr"})
+
+    def test_has_dynamic_trace_flag(self) -> None:
+        module = lower_to_ir('trace add execution $cmd {enter} {puts hi}')
+        assert module.has_dynamic_trace()
+
+    def test_no_capture_for_variable_or_command_subforms(self) -> None:
+        # Out of scope: ``trace add variable`` / ``trace add command``.
+        module = lower_to_ir(
+            'trace add variable foo write {puts $foo}\n'
+            'trace add command bar rename {puts $bar}\n'
+        )
+        assert module.command_traces == ()
+
+    def test_dead_code_not_captured(self) -> None:
+        module = lower_to_ir(
+            'if {0} { trace add execution set {enter} {puts hi} }'
+        )
+        assert module.command_traces == ()
+
+
+# Side-effect composition
+
+
+class TestTraceComposition:
+    def test_set_pure_when_untraced(self) -> None:
+        # Sanity baseline: ``set x 1`` is registry-pure for our purposes.
+        # ``set`` writes a variable, so ``pure`` is False but it has no
+        # UNKNOWN write target.
+        effect = classify_side_effects("set", ("x", "1"))
+        assert SideEffectTarget.UNKNOWN not in effect.targets
+
+    def test_traced_command_loses_purity(self) -> None:
+        traced = frozenset({"::tcl::mathfunc::abs"})
+        # Pick a registry-pure expr command for the test.
+        baseline = classify_side_effects("expr", ("{1 + 1}",))
+        composed = classify_side_effects(
+            "expr",
+            ("{1 + 1}",),
+            traced_commands=frozenset({"expr"}),
+        )
+        assert baseline.pure
+        assert not composed.pure
+        assert SideEffectTarget.UNKNOWN in composed.targets
+        # Untraced commands in the same call retain their classification.
+        unaffected = classify_side_effects("expr", ("{1 + 1}",), traced_commands=traced)
+        assert unaffected.pure
+
+    def test_dynamic_trace_pessimises_all_calls(self) -> None:
+        composed = classify_side_effects(
+            "expr",
+            ("{1 + 1}",),
+            has_dynamic_trace=True,
+        )
+        assert not composed.pure
+        assert SideEffectTarget.UNKNOWN in composed.targets
+
+    def test_remove_undoes_propagation(self) -> None:
+        # Module-level: an add+remove pair leaves traced_commands() empty,
+        # so classification is unchanged from the registry baseline.
+        module = lower_to_ir(
+            'trace add execution expr {enter} {puts a}\n'
+            'trace remove execution expr {enter} {puts a}\n'
+        )
+        traced = module.traced_commands()
+        composed = classify_side_effects(
+            "expr",
+            ("{1 + 1}",),
+            traced_commands=traced,
+            has_dynamic_trace=module.has_dynamic_trace(),
+        )
+        assert composed.pure
+
+
+class TestIRModuleHelpers:
+    def test_traced_commands_skips_dynamic_target(self) -> None:
+        module = IRModule(
+            command_traces=(
+                CommandTrace(
+                    target="",
+                    ops=("enter",),
+                    body=None,
+                    action="add",
+                    target_dynamic=True,
+                ),
+                CommandTrace(
+                    target="set",
+                    ops=("enter",),
+                    body="puts hi",
+                    action="add",
+                ),
+            )
+        )
+        assert module.traced_commands() == frozenset({"set"})
+        assert module.has_dynamic_trace()


### PR DESCRIPTION
## Summary

Implement side-effect composition for `trace add/remove execution` directives (issue #251). When a `trace add execution` directive installs a hook on a command, the trace body's effects now compose into that command's effective side-effects, making registry-pure commands (like `set`) impure once traced.

### Changes

1. **IR and lowering** (`ir.py`, `lowering.py`):
   - Add `CommandTrace` dataclass to capture `trace add/remove execution` directives at lowering time
   - Add `command_traces` field to `IRModule` with helper methods:
     - `traced_commands()`: returns the net active set of traced commands (adds minus removes)
     - `has_dynamic_trace()`: detects when any trace has a non-literal target
   - Capture execution traces during lowering, excluding dead code and non-literal forms

2. **Side-effect composition** (`side_effects.py`):
   - Add `_compose_with_traces()` function that unions trace effects into base classification
   - Traced commands get an extra `UNKNOWN` read+write effect, forcing `pure=False`
   - Dynamic traces (non-literal targets) pessimise all commands
   - Update `classify_side_effects()` to accept `traced_commands` and `has_dynamic_trace` parameters

3. **GVN and optimisation** (`gvn.py`, `_propagation.py`):
   - Thread `traced_commands` and `has_dynamic_trace` through all purity checks
   - Update `_is_pure_command()` and `_is_worth_reporting()` to skip traced commands
   - Propagate trace information through CSE, loop-invariant, and load-forwarding analyses

4. **Tests** (`test_trace_execution_effects.py`):
   - Test capture of `trace add/remove execution` directives
   - Test dynamic target detection
   - Test net active set calculation
   - Test side-effect composition and purity loss
   - Test that `trace remove` undoes propagation

## Validation

- Added comprehensive test suite in `tests/test_trace_execution_effects.py` covering:
  - Lowering capture of execution traces
  - Dynamic target detection
  - Net active command set calculation
  - Side-effect composition and purity loss
  - Removal cancellation
- Existing GVN and side-effect tests continue to pass (no regressions)

## Compiler/KCS checklist

- [x] This change alters compiler side-effect classification contracts
- [x] Updated `docs/design/compiler/side-effects-system.md` with execution-trace composition rule
- [x] Updated file-path anchors and test anchors in the design doc

https://claude.ai/code/session_01V5rrhhNACQHBzPHSzBqVkB