### PR TITLE
Add WASM differential-fuzzer backend with 40 new test cases

### DIFF
--- a/fuzzing/findings/seed_1774200001.json
+++ b/fuzzing/findings/seed_1774200001.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200001,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \":4gu,\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \":4gu,\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200001.tcl
+++ b/fuzzing/findings/seed_1774200001.tcl
@@ -1,0 +1,281 @@
+if {(!(6 / max(1, abs(94))))} {
+    for {set tmp 0} {$tmp < 1} {incr tmp} {
+        string length "--10!0vkj"
+    }
+    set tmp 0
+    while {$tmp < 4} {
+        set tmp ":4gu,"
+        incr tmp
+    }
+    for {set tmp 0} {$tmp < 4} {incr tmp} {
+        append n "gh"
+        set a 0
+        while {$a < 2} {
+            expr {int((-47.97 >> -15))}
+            regexp "[a-z]+" "y,mij"
+            expr {((~(-65 ? 89 : 86)) ^ ((11 >= 92) - (!-18)))}
+            regexp "." "cz73"
+            incr a
+        }
+        if {$tmp != -1} {
+            set a "bqpys=w"
+            foreach tmp {0 no k k 835 qe} {
+                set a {0 false pyhdi 1 -53.07}
+                llength {-27.85 1 82.44 -27.87}
+            }
+            set key 36
+            incr key 2
+        }
+        if {(-(45 >= 25.95))} {
+            for {set n 0} {$n < 6} {incr n} {
+                lassign {fiwa} i idx tmp
+            }
+            if {$tmp != -4} {
+                append n 12
+                set idx {-12.24 -79.75 2.84 vyquzkth}
+                expr {round(-96)}
+                set tmp {true no 0 -24.70 -397 jxoypyxv}
+                expr {($i << (double(-70) ? (-45 << 92) : -51))}
+                set n -54.69
+            } elseif {abs(70.59)} {
+                append buf 345
+                append key rqvv
+                append n -15.12
+            }
+            lassign {sq -47.49} a a buf
+        } else {
+            set count 76
+            incr count -4
+            set msg 16
+            incr msg 0
+            set msg "2x"
+            foreach buf {84.75 -28.31} {
+                set key 72
+                incr key 8
+                set count 680
+                set idx [expr {(-11 ? (~$count) : ((!$tmp) - (14 & 27)))}]
+                set acc qau
+            }
+        }
+        foreach val {98.70 true -223} {
+            set msg owbi
+            expr {(((-82 % max(1, abs($a))) ? -33 : (96 ^ 40)) ^ wide(41))}
+            if {((39.12 >> $i) ? (50 ? -48 : 36) : $idx)} {
+                append z -75
+                set j 33
+                incr j 4
+            } else {
+                append count 472
+            }
+            append acc 12
+            expr {1}
+        }
+        foreach buf {} {
+            set a -47.57
+            expr {((!(-5.31 ? $idx : 92)) & 73.71)}
+            set a {919}
+            expr {(($z || (-46 ^ -14)) > ((~7) ** (42 ** 24)))}
+            append msg e
+            append z -344
+        }
+    }
+    set count yes
+} else {
+    set item 0
+    while {$item < 5} {
+        expr {-6}
+        incr item
+    }
+    catch {
+        foreach key {1 yes -947 36} {
+            expr {(-max((56 ? $buf : $n), ($i < 8)))}
+            string map {a b c d} ",w5do9lg 1;@_a:8"
+            string trimright "k6kp4b_!"
+        }
+    } key
+    append j -79
+    set data {ygjiuji crdefh 643 tshrn wnzjo}
+    foreach n {601 true} {
+        expr {((-(--81)) < -61)}
+        foreach b {27} {
+            expr {(-min(abs(-16), 84))}
+            if {$n > -8} {
+                expr {(max((20 > -4), wide(27)) <= ((75 << $j) < (-46.91)))}
+                string repeat "5l." 1
+                regexp "\\d+" "csu"
+            }
+            switch -- -28 {
+                -94 {
+                    regexp "\\d+" "-890s+1c-vw?2n,"
+                    set acc {46.36}
+                    lassign {} item
+                    append buf "4dexnzg6;_p"
+                    set data 1
+                    set tmp 17
+                    incr tmp 4
+                }
+                "-g.4pj5d30e-" {
+                    set acc 880
+                    set x true
+                    set item "b"
+                    expr {(((91 * 13) + (!$key)) >= (($acc ^ 87.11) + -45))}
+                    set key -105
+                    regexp "[0-9]" "!o"
+                }
+                77 {
+                    set flag [expr {(wide((-39.69 && -13)) ? (-(-37 > -30)) : double((-33.60 * 29.13)))}]
+                }
+                default {
+                    expr {-79}
+                }
+            }
+        }
+        set key 0
+    }
+}
+lindex {false 35.43} 3
+catch {
+    append tmp -43.70
+    foreach b {bzgvr -927} {
+        expr {((!(91 ? -82 : 86)) << -100)}
+        set key 28.03
+        concat {96.69 -70.05 0 674 fgsctbkb} {}
+    }
+    llength {rrcha 64.24}
+} n
+set buf [expr {-24}]
+proc check {i b key item args} {
+    expr {((!(!$b)) - ((89.25 / max(1, abs($idx))) != (-60 && 10)))}
+    append a "?sj43l,fy9.@0 2"
+    foreach acc {457 ihh 46.61} {
+        expr {(84 * -1)}
+        string repeat "3.+.,w-qd :+yx53.." 3
+        set count {lr -26 331 vftpzk}
+        expr {($count != (!(90 | -21.81)))}
+        append acc "v452p5e,,1z"
+        regexp "\\d+" "l,-"
+    }
+    set key 0
+    while {$key < 3} {
+        for {set buf 0} {$buf < 6} {incr buf} {
+            expr {wide(48.60)}
+            string trim "gxynuiw:.1"
+            if {(-75 + -10.03)} {
+                string repeat "" 4
+                expr {(((20.54 != 76) <= (89 ? -71 : 13.09)) ? $item : (~3))}
+                expr {-51}
+                set b "s.+#;,tb8dd1d63+m+"
+                append count -92
+                set data 21
+                incr data 10
+            } else {
+                lrange {-79 2.84 no i 302 true} 0 1
+                set val 10
+                incr val 3
+                expr {int((!(16 != $j)))}
+                set a 66
+                incr a 6
+                lsearch {-790 yes} -83
+            }
+        }
+        switch -- ypbh {
+            ".fopqkyggij.ze6s@8" {
+                set buf {-40.10 -14.48 702 932 bfnycktu rxfaplo}
+                lassign {119 zbsezz -26.05 true -28.68 qtmmbfo} idx x
+                set msg [expr {(abs(-21) <= (~(71 | 45.81)))}]
+            }
+            default {
+                set z -20.40
+                lassign {-53.88 -43.07 -525 -57.75 75.72} x
+                expr {((!(17.84 + -95)) != $buf)}
+                append val 563
+                set key 4
+                incr key 2
+                expr {(($flag ? (-92 == 10) : -62.77) ? -9 : 8)}
+            }
+        }
+        set tmp 0
+        while {$tmp < 4} {
+            list "!y"
+            incr tmp
+        }
+        append n "y6ohm.n@1"
+        regexp "[0-9]" ""
+        for {set msg 0} {$msg < 3} {incr msg} {
+            set i [expr {((~(64.13 % max(1, abs(97)))) - -81.04)}]
+            set n {-816 46.31 -29.94 -329}
+            append acc "@224s@iduyu36j"
+            string first "a" "@8?"
+        }
+        incr key
+    }
+    switch -- "ez" {
+        "5_uo?b6p6_m" {
+            set flag ".ft#52=a=o;"
+        }
+        default {
+            switch -- -66 {
+                29 {
+                    regexp "[a-z]+" "r_@bd#2s-x#_"
+                    expr {(!(90 < ($tmp != -50.67)))}
+                    append n "mc=mp"
+                }
+                -0.81 {
+                    string reverse "#tvzvrxs,b0"
+                    set tmp 989
+                    append val 17
+                    if {$val} {
+                        set b "3mb6s@-x_ =;z_dnyby;"
+                    } else {
+                        expr {(-23.95 < -48)}
+                        regexp "\\d+" "mw1z##+qxu426lpkt=!x"
+                        string trimleft "ug7a1.w8,tr@+2kegb"
+                        concat {fdfk ife aowcw 401 1 w} {29.08 thj 979 814 18.01}
+                        set i 89
+                        incr i -2
+                        set j -563
+                    }
+                }
+                xt {
+                    foreach key {-747} {
+                        expr {round(($msg != ($tmp && 60)))}
+                        list 47
+                        append tmp ed
+                    }
+                    expr {((-(21 >> 19)) ^ (double(84.45) % max(1, abs(double(31)))))}
+                    lassign {} j result tmp
+                    expr {$key}
+                    set acc {no te gmg yes}
+                }
+                "12#8swqxcq wj6" {
+                    expr {87}
+                }
+                default {
+                    expr {(((98 ? -49 : -62.19) ? (95 >= -34.95) : ($val ? -42.09 : $i)) * (~(!30)))}
+                    string reverse "1!2ua7"
+                    set data 25
+                    incr data 10
+                    expr {(-int(max($j, 31)))}
+                    set j 8
+                    incr j 2
+                    lreverse {yes}
+                }
+            }
+            list -23 -90
+        }
+    }
+    return 99
+}
+foreach y {0 421} {
+    foreach idx {59.32 -42.26 true akcqwhcb -27.82} {
+        set y [expr {72}]
+        set result -209
+        expr {((-4 * $a) >> (-(62 | -77.26)))}
+    }
+}
+expr {((~(0 == 44.91)) + (-(4.54 % max(1, abs($a)))))}
+append tmp -34.66
+if {((39 < $buf) ? (~-19.34) : (29 % max(1, abs($x))))} {
+    expr {-61.54}
+    expr {(-((76 <= -60) ? (31 > -69) : 68.65))}
+}

--- a/fuzzing/findings/seed_1774200003.json
+++ b/fuzzing/findings/seed_1774200003.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200003,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "negative shift argument",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "negative shift argument",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-negative-shift"
+}

--- a/fuzzing/findings/seed_1774200003.tcl
+++ b/fuzzing/findings/seed_1774200003.tcl
@@ -1,0 +1,136 @@
+foreach item {} {
+    set item 0
+    while {$item < 2} {
+        set item 0
+        while {$item < 2} {
+            set item 86.10
+            incr item
+        }
+        list 49 -86 apcnwsi "7zjfr"
+        if {$item < 3} {
+            regexp "[0-9]" "ei5@k;k8=3d,tdlxpi4c"
+            if {$item == 12} {
+                set buf 13.52
+            } else {
+                set item ugb
+            }
+            catch {
+                string trim "q?wi,z@p!elvy.iq5ao6"
+                string trimright "3"
+                regexp "[0-9]" "7ubeg_,!6o8hw51q"
+            } item
+            set result {-970 ggz false}
+        } elseif {11.18} {
+            append item 27.75
+            for {set item 0} {$item < 5} {incr item} {
+                lassign {p 163 -8 xgsvx -829 akfcry} z tmp
+            }
+            set tmp 730
+            expr {(67 != (~(51 ? $z : 79)))}
+        }
+        append result ""
+        lreverse {yhocex d 90.42 95.11 930}
+        incr item
+    }
+}
+namespace eval util {
+    switch -- 65 {
+        -66 {
+            string length "2fi2#p9e?+s#66;"
+            set idx [expr {((-(20 - 18)) + (26.78 - (-2 != -28)))}]
+        }
+        "x;?hi" {
+            for {set i 0} {$i < 5} {incr i} {
+                expr {(81 ? ((-49 <= $item) | (75 % max(1, abs(-46)))) : (-96.85 == (85.44 >= 26)))}
+                lsearch {false -895 kbz 13.03 pjr 679} "_3.i2"
+                string reverse "=daxt2"
+                switch -- "cdeef0n,@t+=2r :c" {
+                    802 {
+                        append item -338
+                        set item -739
+                    }
+                    default {
+                        append tmp 36
+                        set item 8
+                        incr item 8
+                        string last "a" "a.9dz"
+                        expr {(-37 <= -34)}
+                    }
+                }
+            }
+            foreach tmp {9.11 -5.71} {
+                if {$buf != -8} {
+                    set data [expr {(~(~(~$data)))}]
+                    expr {((-31.21 > (-39 ** 1.59)) + ((1 > 68) & $result))}
+                    append idx ejur
+                    concat {-624 udshvcis phhwxm 1 24.80} {-85.89 76 false uftnh 24.79}
+                    append i "e;dhwcsek+;"
+                }
+            }
+            append result -28.25
+        }
+        default {
+            lassign {false -911 true yes} acc y
+            for {set n 0} {$n < 3} {incr n} {
+                regexp "\\d+" " z0@81"
+                set item 0
+                while {$item < 1} {
+                    append data "!?:##0= n"
+                    expr {-64}
+                    set tmp [expr {75}]
+                    regexp "\\d+" "g7rcjq"
+                    set flag 5
+                    incr flag 6
+                    incr item
+                }
+                if {min(-63, (40 >> -26))} {
+                    set result 60.50
+                    set a 86
+                    incr a 8
+                } else {
+                    expr {65.78}
+                    lassign {yes} data data data
+                    append item ",37rbhxp!l#_ui75 g@;"
+                }
+            }
+            set result {391 679}
+            set result no
+            set idx 56
+            incr idx 0
+            lrange {tpi -856 wkxuzwow no rv} 0 3
+        }
+    }
+}
+if {$z == 19} {
+    set item 433
+} else {
+    set key {327 u -75.25 -527}
+    for {set n 0} {$n < 2} {incr n} {
+        set y 981
+        append flag -84
+    }
+    set result "ids99i8#dyg49wb"
+    for {set idx 0} {$idx < 6} {incr idx} {
+        switch -- true {
+            "50rgsisbetv" {
+                expr {(~(-23 || (-10 + 16.66)))}
+                expr {41.43}
+                set z 61.96
+                regexp "." "pn8ajij_"
+            }
+            default {
+                set acc yes
+                append buf uxi
+            }
+        }
+        join {true -65.61 euaguki} ""
+        if {(abs($acc) | (~30))} {
+            expr {((!$i) * 44)}
+        }
+        expr {13}
+        append y 89
+    }
+    append item -61.89
+    string map {a b c d} "91c5"
+}
+expr {(!89)}

--- a/fuzzing/findings/seed_1774200010.json
+++ b/fuzzing/findings/seed_1774200010.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200010,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"buf\": no such variable",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"buf\": no such variable",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200010.tcl
+++ b/fuzzing/findings/seed_1774200010.tcl
@@ -1,0 +1,311 @@
+proc compute {tmp val {buf 0} n} {
+    catch {
+        for {set idx 0} {$idx < 6} {incr idx} {
+            lassign {0 thsbhwbz 65.18 -63.12 33.20 9.65} idx
+            switch -- -17 {
+                -47 {
+                    set idx [expr {($idx ^ 35)}]
+                    expr {(((22 >> -99.12) <= (27.03 ^ $idx)) | 10.57)}
+                    string tolower "=mr3l4-"
+                    set idx ":,_kq7l2w"
+                    append i 22
+                    regexp "[a-z]+" "dtd5sq4rygn"
+                }
+                76.90 {
+                    set i 67.51
+                }
+                default {
+                    set msg 91
+                    incr msg -2
+                    set msg "4jatqma"
+                    concat {} {-494 39.64}
+                    set i "2hy6y"
+                }
+            }
+            foreach i {true -248 xnkdqy true -647 -675} {
+                set idx {-559 dzgr 613 sydlms 367 602}
+                lappend idx 93
+                regexp "[0-9]" "@j+x,xup rz6"
+                set msg 37
+                incr msg -5
+                set msg "p79@ia"
+                lassign {190 true no sypmeczc 987 neldjkhy} i tmp
+                append tmp "_#;c0-e#d,o1c.xz"
+            }
+            set tmp kw
+            lreverse {false -17.26 -76.68}
+            string length "omsfiebfm#o5ay8"
+        }
+    } buf
+    set buf {-963 ismdp 121 -748 false}
+    catch {
+        for {set n 0} {$n < 3} {incr n} {
+            expr {(abs(74) == 99)}
+            append tmp -93
+        }
+    } count
+    set acc [expr {-87}]
+    if {((-9.81 == 88) != -31)} {
+        string reverse "rne8#v=@"
+        set msg 45
+        incr msg -3
+        set i 92
+        incr i 0
+        regexp "[a-z]+" "ph,=:g= dk"
+        lreverse {vp 891}
+    }
+    return -67
+}
+for {set msg 0} {$msg < 5} {incr msg} {
+    set acc -31.16
+}
+append i 11
+foreach idx {24.13 yes 82.50 -333} {
+    string map {a b c d} "n-yb?kweu05!=-t9yl"
+}
+if {6} {
+    if {$msg <= -1} {
+        catch {compute }
+        catch {compute "!1d4m0u=s !"}
+        catch {compute }
+        append idx -93
+    }
+    set i 0
+    while {$i < 3} {
+        string last "a" ""
+        set item "aw.9-=h2"
+        append idx ";+cgdw@i"
+        expr {$buf}
+        string trimright "i1maim? 3l1,"
+        set tmp ":a? x-i=k7"
+        incr i
+    }
+    set data [expr {(!41)}]
+    if {((96.76 != 3) ** -86)} {
+        set acc nidazmad
+        set i 849
+        set count [expr {(!-13)}]
+    } elseif {$i != -7} {
+        set acc 63
+        incr acc -5
+        set data 16
+        incr data -5
+        for {set n 0} {$n < 3} {incr n} {
+            lassign {} item msg
+        }
+        append count -9.35
+    }
+    set acc {}
+    set buf 89
+    incr buf 2
+} else {
+    lrange {0 true -711 0 -662} 2 4
+    if {((-85.22 << 78.44) < 95.87)} {
+        expr {-4}
+        expr {(~-80.18)}
+    } else {
+        catch {compute "4d229g+vdgffk" 208}
+        catch {
+            catch {compute -85.41 "q6+9p8s=#:f" 90}
+            set tmp "w@ag5k5uc"
+            set buf 333
+            lsearch {} fu
+            expr {(-43 << ((4 ** 77) - 28))}
+            regexp "\\d+" "3,?a??iyle_d_ e_"
+        } item
+        if {$buf <= 3} {
+            append i 76
+            set count {hs -424 -454 683 no}
+            foreach item {657 -81.75 934} {
+                set data 681
+                lassign {zxd gsorb true} item tmp b
+                set item 713
+            }
+            foreach buf {-961 632 -384 -409 false 19.53} {
+                string reverse "ldm12r7q7dl2"
+                set count no
+                append idx 431
+                append tmp -57
+            }
+        }
+        expr {(2 ? (~$buf) : ((-15) ? 33 : -56))}
+    }
+    set tmp -44.65
+    expr {(((-17 >= 42.52) ? $acc : double(42)) ? 49 : (($count > $i) | ($b & $count)))}
+}
+expr {((~8) && min((-2 ? 48 : -58.89), 15))}
+for {set idx 0} {$idx < 2} {incr idx} {
+    for {set tmp 0} {$tmp < 4} {incr tmp} {
+        for {set b 0} {$b < 1} {incr b} {
+            if {$acc > 13} {
+                expr {(!-95)}
+                append a 76
+                expr {37.69}
+            }
+            expr {((($b ^ -48) | (-2 && 0)) == 74)}
+        }
+        set i {znl yes -54.74 efycv jjuenvv}
+        set x 22
+        incr x -5
+    }
+    set n "8clo7p:@k"
+    foreach result {} {
+        expr {45}
+        set count 98
+        incr count 9
+        for {set val 0} {$val < 3} {incr val} {
+            string tolower ""
+        }
+        switch -- -425 {
+            yes {
+                catch {compute "fb:"}
+                if {28.17} {
+                    set result 59
+                    incr result -3
+                    append y 948
+                    string range "rj:@y2bkbwysk" 0 7
+                    set result [expr {((94.36 < -62) || ((53 ? $count : -95.07) * (!$data)))}]
+                }
+                list "" -18 75
+                append j -783
+            }
+            "!z25p24nrc4" {
+                string map {a b c d} "dcs+wx "
+                string toupper "=u46"
+                set val {9.18 cujqjomt -86.74 yes}
+                lappend val 51
+            }
+            537 {
+                set acc 0
+                set acc 27
+                incr acc 7
+                set y {yes true no 0 -705}
+                set count false
+                string tolower "gfmg"
+                catch {compute zhy "4!b4!w@p?-ju_+1m25"}
+            }
+            default {
+                set count 439
+            }
+        }
+        regexp "." "-w+kc!i6fq:vo7=2qux"
+    }
+    if {49} {
+        catch {compute -281}
+        set y false
+    } else {
+        switch -- 143 {
+            "g:uk64io =" {
+                switch -- 28.47 {
+                    "ghhynw?n?6ksp" {
+                        string tolower "_"
+                        expr {((-(44 != -65)) || ($j >= (!-6)))}
+                        set a ""
+                        set z 53
+                        incr z -1
+                        append key 92
+                    }
+                    default {
+                        string trimleft "w_t36#ruympe"
+                        set msg 58
+                        incr msg -5
+                    }
+                }
+                set n "w"
+                string repeat "op@tr" 4
+                append tmp ";:athc"
+                set val [expr {(!abs((--53)))}]
+            }
+            default {
+                set idx 185
+                append b "8gf2gdvd5u1+w"
+                set result -978
+                set item 64
+                incr item 8
+                catch {compute -977}
+                expr {(((-82 || -77.88) && -60) % max(1, abs(-74.05)))}
+            }
+        }
+        expr {(($j ** (46 % max(1, abs($item)))) << -11)}
+        expr {$buf}
+    }
+    catch {
+        expr {(int((27 ? 48.03 : -52)) + wide(35))}
+    } a
+    lassign {-818 upz -730} key
+}
+catch {
+    expr {int(18)}
+    for {set tmp 0} {$tmp < 4} {incr tmp} {
+        set y 0
+        while {$y < 2} {
+            expr {(((49 | $z) || max($idx, -64.15)) ? $y : 34)}
+            set idx 88
+            incr idx 9
+            incr y
+        }
+        expr {22}
+        string index "v55;d20s=06;:rmq2oyu" 3
+        set j 43
+        incr j -5
+        string map {a b c d} "17xv.iycq@p"
+    }
+    set x [expr {-8}]
+    append acc -16
+} tmp
+proc build {b buf acc} {
+    append item -20
+    string range ";lio5-61e.jbvc2?," 0 4
+    set result "mdb"
+    if {(-92 < -84)} {
+        string last "a" "c0,ytxnp_id5w52_"
+        append result -682
+        expr {(~73)}
+        set b mmd
+        set val {414 vdeb -503 0}
+        string index "p" 4
+    } else {
+        append tmp 30
+    }
+    foreach msg {true} {
+        catch {compute "-70l6:#f-vma@4" 93}
+        for {set data 0} {$data < 1} {incr data} {
+            set val -1.90
+            set val {925 -892 -40.40}
+            set buf ""
+        }
+        list "#jlz8dq9q=9:0j?"
+        set tmp "q"
+        string length "blkt."
+        append n -3
+    }
+    return -68
+}
+if {((-97.81 % max(1, abs(-23.36))) ^ ($z - $count))} {
+    string reverse ";gm-y c1ji_4_98i"
+    if {47} {
+        set x 78
+        incr x 9
+        lindex {853 -438 0.45 no 7.57 308} 2
+        expr {(24 & -30.25)}
+        catch {compute -0.01 "6u@u72va:"}
+        set data "80ou#0lnxjpwiu ?8y"
+        for {set x 0} {$x < 4} {incr x} {
+            append i -20.16
+        }
+    } else {
+        set j [expr {((31.50 ? (-3) : 65.95) | min(-53, 89))}]
+        lrepeat 2 863
+    }
+    set b [expr {(max((!52), 17) > -90)}]
+    expr {(round(13.86) && (($data <= -71.45) == (-34)))}
+}
+foreach val {91.70 617 51.24 -448 1} {
+    set msg "-b m0d_5"
+    join {-783 99.15 -405 264 443} " "
+    expr {8}
+    catch {compute }
+    set item 0
+    set key {-31.23 d -7.76 -375 tkboden 813}
+}
+string tolower "if"

--- a/fuzzing/findings/seed_1774200011.json
+++ b/fuzzing/findings/seed_1774200011.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200011,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"-88.64\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"-88.64\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200011.tcl
+++ b/fuzzing/findings/seed_1774200011.tcl
@@ -1,0 +1,98 @@
+lsearch {buloq 181} "b8thb+a-shcg--t"
+set acc 0
+while {$acc < 3} {
+    set buf 0
+    while {$buf < 5} {
+        set key {-653 true 983 514 -2.48 mssaj}
+        expr {31}
+        set key -42
+        catch {
+            expr {81}
+            append key 34
+            string tolower "s?!xf6u14"
+            string trimright "snm-7v!vhj1g18?a-"
+            set msg [expr {-88.64}]
+        } acc
+        set buf "##_k"
+        foreach buf {105 434} {
+            lassign {0 0 fjirf false} y y msg
+        }
+        incr buf
+    }
+    append a 3
+    for {set y 0} {$y < 2} {incr y} {
+        set flag 243
+        set a -16.64
+        append result me
+    }
+    incr acc
+}
+set buf 0
+while {$buf < 4} {
+    for {set z 0} {$z < 1} {incr z} {
+        expr {((~(16 & $acc)) ? ((-50 ** -97) * (94.75 >= 74)) : 13)}
+        switch -- 85.18 {
+            "vx.#?l7@pp,af?497n" {
+                set msg -402
+                set buf -84.18
+                if {(-(~$a))} {
+                    set tmp 50
+                    incr tmp 10
+                }
+                append msg 98
+                expr {(42 < (-(-21.14 << 68.24)))}
+                set acc {-923 -579 80.60}
+            }
+            14 {
+                switch -- -93 {
+                    ofv {
+                        regexp "^[a-z]" "+y3,_ _dpab#"
+                        append z 58
+                        string trimleft "!6;8usj695u;9plq.t"
+                        set buf 76
+                        incr buf 2
+                        string repeat ":m.v87#sz+" 4
+                    }
+                    33 {
+                        set b 69
+                        incr b -3
+                        set tmp 98
+                        incr tmp -1
+                    }
+                    -11 {
+                        set z "izryrkfoxijli@g3qb"
+                        set key {}
+                    }
+                    -39 {
+                        string trimright "5.67tln_9eu"
+                        set result 0
+                    }
+                    default {
+                        lsort {tbpqwdw yadrm}
+                        string range "d_p,bk0k=1tue7x;" 2 7
+                        set key "y7+=d54"
+                    }
+                }
+            }
+            "q9@;,t?1" {
+                append buf "-6maslgyqhq9el-iu"
+            }
+            default {
+                foreach msg {qn -40.44 -53.12 1} {
+                    string map {a b c d} "i:0#:ch;#4#qpihab-qg"
+                    set buf 68.39
+                }
+                append y -78
+                set msg "tcol=@w599;v, m@"
+            }
+        }
+        lassign {yes ehe smgtbak} result msg b
+        lassign {-85.47 alokwvo} idx tmp msg
+        expr {-17.86}
+    }
+    if {$flag >= -4} {
+        set x 17
+        incr x 3
+    }
+    incr buf
+}

--- a/fuzzing/findings/seed_1774200012.json
+++ b/fuzzing/findings/seed_1774200012.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200012,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"count\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"count\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200012.tcl
+++ b/fuzzing/findings/seed_1774200012.tcl
@@ -1,0 +1,46 @@
+proc check {acc y} {
+    set idx "8h_ix_oz60!,968f?#o1"
+    set tmp 738
+    if {(!-0.66)} {
+        set tmp -51.09
+        expr {($tmp >= int((46 ? -4 : -63.46)))}
+        set tmp 74
+        incr tmp 10
+    }
+    if {$tmp > 16} {
+        set msg 30
+        incr msg 8
+        expr {23}
+        append buf "j-d6at:!101-f1mr322"
+        lassign {bnmdfkax -950 772} idx
+        for {set item 0} {$item < 1} {incr item} {
+            set msg -984
+            set count {e s -66.79}
+        }
+        expr {$count}
+    }
+    foreach tmp {-319 isoqsod} {
+        regexp "." "srcb4yph#us2o.#;7ie"
+        lrepeat 1 "bgzi 0:xq7?:rsp"
+        string trim "?fm"
+    }
+    return "dn?"
+}
+foreach buf {39.84 -85.65 48} {
+    string index "=mpxnb;?g#mei-1yq0" 3
+    catch {check 772}
+    switch -- -98 {
+        " cy?yo" {
+            set buf 812
+        }
+        default {
+            set buf 81
+            incr buf -3
+            set item "be#5?v_-.h@r072lh"
+            append z 637
+            llength {-555}
+            expr {(((-93 ? $count : -29) ? ($msg | 31.58) : 14) >= ((79.50 ? 10 : $idx) & (58.88 + -16.44)))}
+        }
+    }
+}
+set idx {-468 -10.04 dfasm pjfuf -609 900}

--- a/fuzzing/findings/seed_1774200015.json
+++ b/fuzzing/findings/seed_1774200015.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200015,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"p25=9=!mapu-692\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"p25=9=!mapu-692\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200015.tcl
+++ b/fuzzing/findings/seed_1774200015.tcl
@@ -1,0 +1,364 @@
+set i [expr {(39 ? 26 : (($i ? 33 : -59.40) & 25.59))}]
+for {set data 0} {$data < 5} {incr data} {
+    switch -- 387 {
+        "fmct,96568oqo??8k5t" {
+            set i 74
+            incr i 9
+            set i [expr {12.17}]
+            expr {28}
+            append i 665
+        }
+        -15 {
+            foreach i {-385 94 975 -501 -564} {
+                append data "w?kq78"
+                lassign {} i data
+            }
+        }
+        default {
+            for {set idx 0} {$idx < 2} {incr idx} {
+                set data "p25=9=!mapu"
+                set i -808
+                lsearch {-62.44 4.04 gheavwu} xafrp
+                append data -692
+            }
+        }
+    }
+}
+set data -764
+lassign {false 0 yes -331 no} idx
+lassign {214 yes} idx b
+append data -598
+if {(-81.57)} {
+    catch {
+        regexp "\\d+" "wk+.f.rxc4z9"
+        expr {(((-95 && $idx) | max(-5.78, 13)) ? -13 : ((88 >= -90.75) ? -13 : (!-15.02)))}
+        set i {yes bvyfbme 97.36 yvbcluvj 996}
+        expr {$idx}
+        string toupper "j06,6qob"
+        for {set result 0} {$result < 5} {incr result} {
+            lsearch {315 -603} "skl79q 390x"
+            string length "fyv=qcs"
+            set acc 0
+            set idx ppnrrarc
+            for {set n 0} {$n < 2} {incr n} {
+                join {0} " "
+                append acc -290
+                set data -39.68
+            }
+        }
+    } y
+    expr {(((!-89) == (11 != 98)) / max(1, abs((($data ^ $i) < (83 + -26)))))}
+    catch {
+        foreach acc {378 xx no} {
+            regexp "[a-z]+" "#1ls@sl23_4ls81r"
+        }
+    } a
+    set tmp {no}
+    if {$result <= 14} {
+        set result 0
+        while {$result < 1} {
+            regexp "\\d+" "8?k p?947ts=uji!?nbr"
+            set i 428
+            set val [expr {((-13.90) ** ((!$i) <= (15 & 27)))}]
+            join {-432 xenhyhlc 1 753} ","
+            foreach msg {0 false 1} {
+                set msg 17
+                incr msg -1
+                append n false
+                set tmp [expr {(int((!-51.53)) ? (~(39.81 < 97)) : $tmp)}]
+                set b 85.26
+                set y 58
+            }
+            incr result
+        }
+        set n 1
+        if {$acc == -4} {
+            set tmp 80
+            incr tmp -5
+            set j 779
+            set a false
+            set msg [expr {-72}]
+        }
+        expr {(-75.90 ? (~$result) : 88)}
+    } else {
+        for {set z 0} {$z < 6} {incr z} {
+            set i {862 935 -53.41 ie}
+            append val 49.33
+            lrange {yes -866} 0 4
+            set b -366
+            if {((-39 >= $a) <= $a)} {
+                lassign {true j -32.76 true 927} msg result
+                set msg -452
+            }
+        }
+        if {(-47)} {
+            set y [expr {(-24.66)}]
+            lassign {3.64} z
+            set idx 0
+            while {$idx < 2} {
+                append data 8
+                incr idx
+            }
+            set a 0
+            while {$a < 5} {
+                expr {((8 ** 1) / max(1, abs((15 >> (49 & 69)))))}
+                expr {56}
+                incr a
+            }
+        } else {
+            lassign {no} x result j
+            string length "c;1m v-!sm"
+            set tmp riz
+            set n -820
+            set b 0
+            while {$b < 5} {
+                set acc 774
+                string trimright "z,+bc7o90xfvds.5p?"
+                set tmp -796
+                incr b
+            }
+            set n [expr {(((55.33 * 77) <= (2 % max(1, abs($a)))) % max(1, abs(57)))}]
+        }
+        set acc 29.06
+        set z 0
+        while {$z < 2} {
+            expr {(~43)}
+            set a [expr {-5.68}]
+            incr z
+        }
+        set j 7
+        incr j 6
+        string trim "a.3#j!"
+    }
+    append b "+do+zw,08f?9qf7"
+} elseif {$result > 7} {
+    append item daoy
+    switch -- -30 {
+        "oy@.wxczyqy=c" {
+            append j vjjhmo
+            string trimleft "5,yl_5"
+            set result 7
+            incr result -4
+            lreverse {-434 -224 -344}
+            foreach count {} {
+                set count 23
+                incr count 4
+                set flag [expr {($b + -77)}]
+                append n -49
+                set result 0
+                set count 26
+                incr count -2
+                expr {(((!$a) | (18 - 96)) || (92 % max(1, abs((-80 * $data)))))}
+            }
+        }
+        default {
+            for {set a 0} {$a < 2} {incr a} {
+                if {-5} {
+                    list 68 68 -41 "bog4es?m #b"
+                    list ""
+                    llength {0 -57 270}
+                    join {814 false} " "
+                    set key 11.52
+                }
+                join {} "-"
+            }
+            regexp "[0-9]" ".g;#p8:s;lvi"
+            set y [expr {(-50.97 - ((!-21) > 53))}]
+            expr {(((!$count) - ($result >= -11)) || ((-11 ? -9 : 45) ? (-$z) : max(59, 47)))}
+            set x {rurlkf -16 lyr}
+        }
+    }
+    catch {
+        expr {67}
+        set z 34.34
+        set result {65.03 0 -21}
+        expr {((($b % max(1, abs(-10))) <= 34) ? $val : 33)}
+        set msg 70
+        incr msg -3
+        set flag 51
+        incr flag 8
+    } val
+    lsort {false 801 eqdca}
+}
+proc worker {tmp n {a -312} args} {
+    if {$x < -6} {
+        append key 1
+        set key -487
+        set data 45
+        incr data 5
+        set result 51
+        incr result 4
+        lassign {906 1 mn} key
+    }
+    for {set acc 0} {$acc < 2} {incr acc} {
+        if {(($val > 29.86) ^ 61.45)} {
+            set i "74vipze"
+            expr {17.26}
+        }
+        string reverse "pqvrzgu+vq#"
+        for {set item 0} {$item < 4} {incr item} {
+            set a izqiuye
+            llength {-364 true -99.68 -61.59 -19.15 41.12}
+            foreach i {} {
+                lrepeat 3 40
+                set msg bvsnpq
+                set item -82.61
+            }
+            regexp "\\d+" "i 78qe17xnxi#ilvke"
+        }
+        if {wide(($a < 41))} {
+            append data "m;"
+            lreverse {}
+            set i [expr {($j <= ($tmp <= (81 ? $msg : $i)))}]
+        }
+        set idx 59
+        incr idx 8
+    }
+    set n 0
+    while {$n < 4} {
+        for {set key 0} {$key < 4} {incr key} {
+            append n "@"
+            append acc -26
+            string length "xghon3tafgbevq.l"
+            set z no
+            append key "5i166p"
+            string map {a b c d} "uzq=-v=p"
+        }
+        append item -111
+        incr n
+    }
+    append i nime
+    append item "kg.4pn=a78 2xlw9eg"
+    return "2t0z2d2-0?j+e3#60"
+}
+proc process {{y 230}} {
+    if {$val != 8} {
+        expr {(-71 >> (56 ** (13 >= $acc)))}
+        if {$idx >= 14} {
+            set tmp {-705 true 389 -416 pboekeh 569}
+            set item {47 -786 728 71.58 -305 12}
+        } else {
+            string first "a" "_q5"
+            set msg [expr {double($z)}]
+        }
+        catch {worker }
+        expr {52.40}
+        set x 22
+        set flag 71.02
+    }
+    return 809
+}
+set val 0
+while {$val < 4} {
+    set item -21
+    foreach tmp {33 543 ecxqiz 82.95 611 231} {
+        lassign {q 803 jpysj nzvg} z y
+        string index "nd2+7" 4
+    }
+    incr val
+}
+if {(-$a)} {
+    catch {worker "" 42 864}
+    foreach val {jmxvc -660 14.99 false -406} {
+        regexp "[0-9]" ""
+        set val 0
+        while {$val < 3} {
+            set count no
+            incr val
+        }
+        expr {((!-32.82) > -43)}
+        set b 94
+        incr b 0
+        expr {(40 & double((-81 - -99)))}
+        set y [expr {(round($y) != (82.99 + (!$key)))}]
+    }
+    set val 0
+    while {$val < 2} {
+        append b "y3c0l8t;"
+        foreach msg {69.34 njjx 92.51 21.60} {
+            set data [expr {wide((!$count))}]
+            string reverse "hw9 =10vt_3"
+            regexp "[a-z]+" "u -q,vf2h"
+            set msg 864
+            if {$a > 19} {
+                catch {process }
+                append data -87
+            } else {
+                set idx 82
+                string reverse "dyp@f@!hp"
+                set i 6
+                incr i -4
+                set n -119
+                set z 82
+                incr z -3
+            } elseif {$j == -2} {
+                lassign {} i tmp flag
+            }
+            set idx {51.66 -167 47 -177 true}
+        }
+        catch {process "5:v9"}
+        set z no
+        set acc [expr {(((13.89 & 80.90) ? (~-56.19) : (--83)) >> 9)}]
+        set j [expr {(((41 & -18) << (!73.11)) ** (24 != (~$j)))}]
+        incr val
+    }
+    for {set j 0} {$j < 3} {incr j} {
+        expr {double(((74 | $b) << (26.88 < 84)))}
+        string index ",r.:_-a?nnr:j2" 1
+        for {set y 0} {$y < 1} {incr y} {
+            expr {(abs((--42.88)) >> (-(-92 ? 60 : $result)))}
+            append i -955
+            expr {(((~$z) >= (-49 >= -37)) | (76 ? (-31 && -6) : (88 * 62)))}
+            expr {81}
+            string tolower "mh=r9."
+        }
+        set item {-91.86 -306 -688 902}
+        set i 73
+        incr i 5
+        append msg "3-ch:"
+    }
+    set j q
+    set flag 0
+    while {$flag < 2} {
+        catch {worker false 0 xwh}
+        set y 19
+        incr y 5
+        set data [expr {69.38}]
+        incr flag
+    }
+} else {
+    if {$y > 2} {
+        regexp "." "#9#x5qwwutoqg"
+        expr {($msg ? $val : -16)}
+        set item 65
+        incr item -4
+        for {set val 0} {$val < 5} {incr val} {
+            set acc 39
+            incr acc 1
+            expr {(((~53.53) % max(1, abs((9 ? $n : 56)))) && (($item & -61) || 7))}
+            expr {(abs((-71 < $n)) ? ((-$a) && (75 < 8.18)) : (!max(14, -32.38)))}
+        }
+        set val {-88.33 1 30 yes 16}
+        foreach a {944 false xotuakm -628} {
+            set i 0
+            while {$i < 3} {
+                expr {-92}
+                set j {no 270 1 yes -306 -887}
+                incr i
+            }
+        }
+    } else {
+        append j -90
+        set x -727
+    }
+    regexp "\\d+" "?=iw1ox"
+    for {set acc 0} {$acc < 5} {incr acc} {
+        string first "a" "+j=mv19jfj.f;?"
+    }
+}
+proc transform {{i -353} count result} {
+    lassign {no 72.10 wi yes} a
+    concat {dgfezx no yes no} {528}
+    regexp "[0-9]" "t#:v12@-.dz0y"
+    return 13
+}

--- a/fuzzing/findings/seed_1774200018.json
+++ b/fuzzing/findings/seed_1774200018.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200018,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"j\": no such variable",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"j\": no such variable",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200018.tcl
+++ b/fuzzing/findings/seed_1774200018.tcl
@@ -1,0 +1,191 @@
+proc helper {{val idaes} item i y} {
+    if {58} {
+        expr {(double((~47)) & max((-99.24 && 24), 43.68))}
+    }
+    for {set j 0} {$j < 2} {incr j} {
+        append val -53.80
+        set x [expr {(((-46.73 == 11) ? (-88 ? 9 : -99) : (-13.44 & $x)) - -20)}]
+        set j 0
+        while {$j < 2} {
+            append x "vu4; ec p@#lr0xnz;,"
+            incr j
+        }
+        expr {abs(double(round(3)))}
+    }
+    set x {true 228 yes -10.67}
+    return 21.78
+}
+append buf -64.99
+set buf uefl
+set result [expr {wide(33)}]
+foreach buf {mcjrj -62.84 -88.09 961} {
+    set buf 0
+    while {$buf < 1} {
+        if {$result > 20} {
+            set x 78
+            incr x -4
+            set msg 94
+            incr msg 8
+            set result 82
+            expr {(-80.44 ? ((-3.89 ? 60.48 : $buf) ^ min($j, 25)) : ((-30.36 ** -48) < 23.55))}
+        } else {
+            set result {bdjz 0 179}
+        }
+        append result "y"
+        catch {helper "?3m6noz!7sv=cii" "6orzhi8"}
+        set val "=qx"
+        switch -- 928 {
+            83 {
+                expr {(((91 ? -1 : -7.48) ^ (92.05 ** 29)) ? 37 : ((29 ** 55) != (~15)))}
+            }
+            default {
+                set buf -56.72
+                lassign {-361 409 14 777 898 1} buf
+            }
+        }
+        append j -215
+        incr buf
+    }
+    set result 0
+    while {$result < 5} {
+        expr {round(((-$j) >= 4))}
+        set data 0
+        while {$data < 2} {
+            append val " c8"
+            foreach idx {1 387} {
+                append msg -93
+                expr {abs(36)}
+                regexp "^[a-z]" "-i51q6humf"
+                set msg 390
+                set result -18
+            }
+            expr {(-($j % max(1, abs(int($x)))))}
+            incr data
+        }
+        incr result
+    }
+    expr {(-(24 % max(1, abs(-45))))}
+    for {set j 0} {$j < 3} {incr j} {
+        lsearch {-45 358 false -841 190} "9,@n6wq2rz13?2q0"
+        set data 31
+        incr data 2
+        catch {
+            expr {($msg ? 38 : $result)}
+        } x
+        if {$j > 13} {
+            if {((-78 == 61) >= $buf)} {
+                string length ":uefe9q9a+"
+                set msg ecfctp
+                catch {helper 624 false}
+                catch {helper 0 "gcb29nh!u07f#0"}
+            }
+            append flag -92
+            catch {helper 64 "p1l" 124}
+            append x 16
+            set buf ":zrb=lavw-xhw!"
+            regexp "." "-"
+        } else {
+            lindex {25.37 64} 2
+        }
+        expr {(((12 + -39) | ($result || -58)) >> ((-4) >= (~54)))}
+    }
+    set tmp eliuxcz
+}
+namespace eval inner {
+    if {40} {
+        set key 388
+        set tmp 28
+        incr tmp 4
+        set data 18
+        incr data 6
+        if {($j && -35.31)} {
+            regexp "^[a-z]" "+7tzl;1ihz1,iy"
+            expr {$result}
+        } elseif {$val != 4} {
+            append data 46
+            set j {-96.63}
+            lappend j 89
+            regexp "\\d+" "1"
+            expr {$val}
+            string trimleft "3wmyt6#"
+        }
+    } else {
+        expr {$tmp}
+        foreach key {} {
+            append count pycjhf
+            set count 80
+            incr count -2
+            lrepeat 2 hgo
+            set result "204bwe4r5#vm,mu9nk"
+        }
+        lassign {367} idx flag
+        regexp "\\d+" "w7,81f1v6"
+        lsort {665 984 false 825}
+        set count 36.38
+    }
+}
+string trim "m zsbo5w"
+if {max(11, (57 ** 92))} {
+    if {$key <= -7} {
+        catch {helper }
+        set msg 0
+        while {$msg < 3} {
+            catch {helper "z8.3vmx_i48.m" -85.97 na}
+            set y -483
+            incr msg
+        }
+    }
+    catch {helper "r,ad9 l"}
+    set y 744
+} else {
+    set i 0
+    while {$i < 1} {
+        if {((~87) ? (-1 ^ 81) : (-26 < -66))} {
+            if {((--43) ^ round($flag))} {
+                append tmp 62
+                append result -91
+                regexp "[a-z]+" "3x:u1g"
+                expr {((($count != 85) || ($result * -46)) - ($flag ? (--86) : -82))}
+                list 0 -15 0 11
+                catch {helper 10 ""}
+            } else {
+                set idx {466 62.40 -415 86.60}
+                lappend idx -65
+                set tmp "6ui fa2nm"
+                set idx {a 75.18 -78.83 -1.44 fxliph -229}
+                regexp "." ".u"
+                set y "b9gj"
+            }
+            expr {92}
+            set data "q:su5+6"
+            expr {86}
+            catch {
+                append count 77.13
+                set flag no
+                set idx 64
+                incr idx 5
+                regexp "." "4h e5qn2-1xwm#:"
+                set item vnyacf
+                catch {helper "0#dou_:k8++98h"}
+            } val
+            if {(~min(-74.88, -80))} {
+                catch {helper "it" "s+jvs"}
+            } elseif {$flag == -4} {
+                set tmp {-399 false 548 -3.93 63.86 micke}
+                expr {(43 ? (!5.28) : -46)}
+                set result {38.04 -80.34 true 735 285}
+            }
+        }
+        incr i
+    }
+}
+set val 86.07
+proc handle {count buf val} {
+    expr {(((-26 ? 53 : $item) + 20) ? -80 : ((-54 <= -64) + (86 >> $x)))}
+    list 209 yes 4
+    set idx -600
+    set buf fkzuot
+    expr {(~((29 ? -33 : $buf) ? (-57.01 > -19) : -89.61))}
+    append data -37
+    return -10
+}

--- a/fuzzing/findings/seed_1774200019.json
+++ b/fuzzing/findings/seed_1774200019.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200019,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-81.12\" as operand of \"~\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-81.12\" as operand of \"~\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200019.tcl
+++ b/fuzzing/findings/seed_1774200019.tcl
@@ -1,0 +1,83 @@
+expr {(-3.94 >= max((!-29), (~-81.12)))}
+catch {
+    set buf "@=i "
+    set buf 66
+    incr buf 0
+    if {(round($buf) && -76)} {
+        set key " h#ij@ d8#;jeyc8r2,"
+        lsort {no}
+        set y 74
+        incr y -4
+    }
+    catch {
+        set key 94
+        incr key -5
+        for {set y 0} {$y < 4} {incr y} {
+            set y "-n2w=+d4.r.a;"
+            expr {-29}
+            set flag 0
+            while {$flag < 4} {
+                append result yes
+                incr flag
+            }
+            set buf {}
+            set count 33
+            incr count 4
+            string first "a" "h2"
+        }
+        set flag {-7.65 osik -486}
+        if {((~$count) ? (-45 ** 56) : ($y >> 18))} {
+            set flag -62
+            expr {((-77 ^ -58.54) << (35 ^ (!-49.76)))}
+            append count -17
+            append acc 65.23
+            lrange {271 eaxy 1 703 ycjpp -80.04} 3 4
+        } elseif {$result == -1} {
+            foreach buf {-693 -640 true -596} {
+                append acc "o."
+                lrange {1 36.37 670 162} 2 3
+                set count {-247 b}
+                set key {1.66 -32 450 650 -243 -842}
+            }
+            set buf {0 -229 false eviopvhd -668 a}
+            if {$result != -1} {
+                append key hvaku
+                set buf 822
+                append y -29
+                set j -819
+            }
+            switch -- "84kxexln-qs3n3i" {
+                476 {
+                    append buf 52
+                    set val {-464}
+                    lassign {474 -620} x
+                    set result 40
+                    incr result -5
+                    concat {48.77 bx -540 -78 aec} {qcdfpqdj 174 45.34 cfze}
+                    set key 62
+                    incr key -4
+                }
+                "r2drll8py:aw539ph" {
+                    set y fccfiis
+                    append result "qdtvag-st?9y#3ao98,p"
+                    string tolower "jbgk3ne "
+                }
+                -51 {
+                    string toupper "o,b224 m"
+                    string first "a" "="
+                    string length ""
+                    lsearch {jcn 562 false hiw -431} -34.02
+                    expr {int(((-88 & 72) ^ (~58)))}
+                    set y true
+                }
+                default {
+                    append flag "4+jn!,.@"
+                    set key -395
+                    set j 51
+                    incr j -2
+                }
+            }
+        }
+        lsearch {880 627 oud} 72
+    } x
+} y

--- a/fuzzing/findings/seed_1774200020.json
+++ b/fuzzing/findings/seed_1774200020.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200020,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-if-else-elseif"
+}

--- a/fuzzing/findings/seed_1774200020.tcl
+++ b/fuzzing/findings/seed_1774200020.tcl
@@ -1,0 +1,162 @@
+proc helper {val} {
+    switch -- 30.13 {
+        0 {
+            catch {
+                set data [expr {98.73}]
+            } acc
+            if {$acc} {
+                for {set data 0} {$data < 4} {incr data} {
+                    expr {75}
+                    regexp "[a-z]+" "m6it@r04d.r"
+                    string index "haygf#d58;a1_cc1e" 2
+                    append data ";6rwo-"
+                }
+                set acc {-873 48.62 228 false}
+                set data {1 yes -75.61}
+                lindex {} 3
+                if {$data == -6} {
+                    lsearch {0 812 -37.58 -273 rcopypl} -94
+                    regexp "." "9w5vo6"
+                    append buf -30
+                    set acc {yes 689 -606 1 b -855}
+                }
+            }
+        }
+        -12 {
+            catch {
+                regexp "[0-9]" "-p.@2fphkd_@qa,;e"
+                set buf -783
+                expr {(max(($buf / max(1, abs(78.11))), (-77 ** -33)) != ($acc ? 36 : (-$buf)))}
+                set msg -64.03
+            } data
+        }
+        1 {
+            lassign {salq -976} buf
+            append buf -92
+        }
+        default {
+            set msg 0
+            while {$msg < 1} {
+                llength {false kbbskd 720 -737}
+                set msg 60
+                incr msg 4
+                set flag 0
+                while {$flag < 2} {
+                    llength {no pk}
+                    set acc "i1gpf386_ id"
+                    regexp "." "1t!h.8#e"
+                    incr flag
+                }
+                incr msg
+            }
+            set msg "n2996+"
+        }
+    }
+    lassign {208 false} a flag flag
+    expr {((-(!-24)) ^ (~(~-90.25)))}
+    expr {39}
+    set idx {}
+    return 22
+}
+if {-35} {
+    expr {((85 ? -5 : min(7.60, 13)) ? (~(82 << 32)) : 32)}
+    set data 44
+    incr data 7
+    set flag 43.55
+    lassign {806 pahqiumm 653 p} acc acc acc
+    set msg 819
+} else {
+    if {$acc != 8} {
+        set b 62
+        incr b 2
+        switch -- no {
+            56 {
+                expr {36}
+                expr {((!(-67 + -44)) ? 48 : ((-25 ? 0 : $data) & -7))}
+                append count "946qvw1@38"
+            }
+            -875 {
+                set msg {-89.68 410}
+                string toupper "l6"
+            }
+            "99dlb39cse_z1f3" {
+                append tmp -164
+            }
+            "@u0hif,r:ps" {
+                expr {(--48.40)}
+                expr {(-58 << (-8 - ($flag >> $count)))}
+                set i 0
+                while {$i < 5} {
+                    set a 59
+                    incr a 2
+                    catch {helper -5 95}
+                    set count 996
+                    incr i
+                }
+                append b 613
+                set b "! =lcoe3"
+            }
+            default {
+                set tmp 71
+                incr tmp -4
+                string reverse "qe?,;qaq5!.@u#+o?@zu"
+            }
+        }
+    }
+    expr {(((!$i) || int(-6.26)) - wide(15.61))}
+    append acc "40ip.!o.scoqz4"
+    for {set idx 0} {$idx < 2} {incr idx} {
+        append item "bhx;ypl8hxq52 sd701"
+        set msg "1+s!qe9t6,#5002+ "
+        set item lkbx
+    }
+    foreach idx {wnlzjbjt bpkzfk} {
+        for {set i 0} {$i < 6} {incr i} {
+            set buf zrhgdb
+            set item 33
+            incr item 3
+            set buf 30
+            incr buf 0
+            catch {helper 136 "f2#!rorwg_@s0@emlar"}
+            string index " 7_8" 0
+            list "sd7dns9i9ree39kjc.w"
+        }
+        for {set tmp 0} {$tmp < 5} {incr tmp} {
+            set flag 39
+            incr flag 5
+            regexp "[a-z]+" "t0 kt:;t_"
+            set item {-5.58 0 0 -946 835}
+            set tmp 10
+            incr tmp 7
+            set tmp 73
+            incr tmp 10
+        }
+    }
+    if {$b == 16} {
+        string tolower "fp8.2lzr?vg76.."
+        if {$item == -3} {
+            lassign {false -42.34 -694 -899 true} i idx i
+            set tmp {13 yes 748 778 64.79}
+            set item true
+            list "@m@_4+" -754
+        } else {
+            set item -95.58
+        }
+    } else {
+        catch {helper -21 62}
+    }
+} elseif {$b <= -8} {
+    append a mdiacfcy
+    if {((~50) != 14.22)} {
+        expr {((~$count) >> ((-78 << 56.91) & $buf))}
+        append result 67
+        string toupper "f+c21_qroy31,hh-da-w"
+        foreach flag {1 ei -459 0 34.72} {
+            expr {(43 <= 54)}
+            string first "a" "z"
+            lsearch {-502 96.91} 1
+            set i sexn
+        }
+    }
+    string toupper "uhd=g3#hx_?!6"
+}

--- a/fuzzing/findings/seed_1774200021.json
+++ b/fuzzing/findings/seed_1774200021.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200021,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"99.48\" as right operand of \">>\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"99.48\" as right operand of \">>\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200021.tcl
+++ b/fuzzing/findings/seed_1774200021.tcl
@@ -1,0 +1,72 @@
+string tolower "1oe@tl 2n?+r9rd=;cd"
+foreach y {-468 47.18} {
+    append y ""
+}
+for {set y 0} {$y < 1} {incr y} {
+    set tmp 0
+    while {$tmp < 2} {
+        set a 0
+        while {$a < 2} {
+            if {$y < -5} {
+                set b 60
+                incr b 10
+                set y [expr {abs(((~55.91) - (63 ? -86.77 : 22)))}]
+                expr {((~84.95) > -63)}
+                append b true
+            } elseif {$y != 14} {
+                lassign {no 629 -312 xltbfwah qmfjoaf} z data
+                set b 47
+                incr b 5
+                expr {(((-18 << 5) ** wide($b)) >= ((-15 > 22) >> 99.48))}
+            }
+            regexp "\\d+" ":yl,.zwu,r@v?"
+            append a "!0"
+            set y 59
+            incr y -2
+            incr a
+        }
+        incr tmp
+    }
+    for {set idx 0} {$idx < 2} {incr idx} {
+        string length "ooczev-u:#l+ceq!z"
+        lassign {-780 769} flag data y
+        append tmp 135
+        for {set z 0} {$z < 1} {incr z} {
+            append a 63
+        }
+        for {set data 0} {$data < 4} {incr data} {
+            set x 0
+            while {$x < 2} {
+                expr {(!(-22.39 >= (25 ** -99)))}
+                regexp "^[a-z]" "vl_i#5w;0lhs"
+                lassign {589 -84.23 yes 13.46 -491} data
+                set a [expr {-26}]
+                set x 1
+                string first "a" "@b54-t;z0i 0ha87z"
+                incr x
+            }
+            regexp "\\d+" "3qhew79i"
+            set z {}
+            lappend z "1qtwt!zo"
+            set y [expr {(((73 ? -44 : -78) <= 15.58) ? (--20.66) : 26)}]
+        }
+    }
+    set idx "ogpz=yp3hl=-cj9"
+    lsort {kivziyv prf 75.50}
+}
+for {set buf 0} {$buf < 1} {incr buf} {
+    for {set count 0} {$count < 6} {incr count} {
+        regexp "." "f#h"
+        set count 92
+        incr count 2
+        if {41} {
+            lassign {791 true 652} idx
+        } else {
+            append tmp 267
+            append count -15
+            join {cx vxmthbc botkojwu qwjhlx true vqeebasc} " "
+        }
+    }
+}
+expr {((-25 >> ($data && $buf)) >> (($flag != -75) < int(-78)))}
+expr {((($b / max(1, abs(49))) ? ($y | 46) : 98) ? abs((9 / max(1, abs(78)))) : (($buf / max(1, abs(61.19))) <= (!-21)))}

--- a/fuzzing/findings/seed_1774200022.json
+++ b/fuzzing/findings/seed_1774200022.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200022,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"val\": no such variable",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"val\": no such variable",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200022.tcl
+++ b/fuzzing/findings/seed_1774200022.tcl
@@ -1,0 +1,195 @@
+proc process {{count -18.39}} {
+    set val "w?s?#7--dwo3#aml"
+    set result 0
+    while {$result < 1} {
+        set x 69
+        incr x 5
+        set result "1;1jsm"
+        lsearch {} coxhsj
+        string last "a" "+nt4 tk#sk+zy8n. !"
+        set result [expr {(-30)}]
+        incr result
+    }
+    return "-mcz;"
+}
+set result 0
+while {$result < 2} {
+    expr {(abs(46.71) ? (-93 + -41) : (49 - (77.18 >= -27)))}
+    if {$val <= 6} {
+        string tolower "jggh1.yd# ata;@."
+        append val "w1nb0@m0dxu@r-#tux4x"
+        switch -- -20 {
+            495 {
+                regexp "[0-9]" "3o#+i_3gqwe:m1"
+                set x 142
+                set val ug
+            }
+            "-p11.ulks939g+xh" {
+                string first "a" "9ig4.defgm7#u@q_"
+                append x ";abk;muzr9kq"
+                set x ejio
+            }
+            "w637uro ulb0s#85q+2h" {
+                if {79} {
+                    set msg "f# g-+."
+                    lrepeat 2 -34
+                    set item false
+                    string toupper ";v77byjfs"
+                }
+                set result 51
+                incr result -1
+            }
+            "hqs9guabl1j#@ho8" {
+                set idx {false 575 true eibcl true 643}
+                expr {$x}
+                switch -- -14 {
+                    "89a?yx," {
+                        set buf 95
+                    }
+                    -74.79 {
+                        string repeat "-p" 3
+                        lassign {} flag n data
+                    }
+                    default {
+                        lrange {69.73 -785 false 526 ygk} 2 3
+                    }
+                }
+            }
+            default {
+                set data 80
+                incr data 9
+                set data -89.93
+                expr {(!(!($n - $msg)))}
+            }
+        }
+        expr {8}
+        string length "yn9w?_#,#,8tmx0wg"
+        catch {process 65 -45}
+    } else {
+        llength {1 yes 704 -55.49 1 323}
+        append idx 12.18
+        set flag 0
+        while {$flag < 1} {
+            for {set msg 0} {$msg < 5} {incr msg} {
+                regexp "\\d+" "?:"
+                set x 91
+                incr x 10
+                set y {94.63}
+                regexp "^[a-z]" "s=l2q-"
+                expr {abs((!($val ? 13 : -93)))}
+            }
+            set count -116
+            set idx [expr {((49.43 ? double(61) : (--82)) ? ((26 ? $idx : 88) - 63.32) : ((20 == $item) ? (33 >> 85.68) : (!$buf)))}]
+            incr flag
+        }
+        string tolower "o@ii4;c4m"
+        string toupper "#qddy97ta9r"
+    }
+    incr result
+}
+foreach val {655 dhvyckqo b -77.69} {
+    switch -- yaj {
+        195 {
+            lrepeat 3 888
+            append flag -233
+        }
+        742 {
+            set result 1
+            incr result -5
+            expr {(((-51 == -4.17) >= $item) ? max(3, (!41)) : (76 << -58))}
+            expr {79.93}
+            set y -134
+        }
+        default {
+            append flag ""
+            lrange {voc 94.47} 0 3
+            lrepeat 3 uvfgeuqc
+            set x 78
+            incr x 2
+            set idx 2
+            incr idx 7
+        }
+    }
+    lassign {co 94.48 -388 soihzttz 7.49} item data flag
+}
+append n -27
+set acc 0
+while {$acc < 5} {
+    switch -- 95 {
+        -39 {
+            switch -- 91 {
+                10 {
+                    catch {process -41.84}
+                    set y "y_+-z:o,b;!982"
+                    set n "pkkgf+l,v=upw0!1"
+                    set result {1}
+                    catch {
+                        append acc -68.52
+                        append acc 77
+                    } b
+                }
+                default {
+                    set n 800
+                    expr {((abs(-62.32) && (-18 && -93)) || ((-61 << -99) != min(-41, -61)))}
+                    expr {70}
+                    string length "k!jyqfcqz"
+                    lsearch {no -674 729 90.09 32} 75
+                }
+            }
+            set val [expr {(~-47.94)}]
+            set n ""
+            set j 0
+            lrange {-436} 0 4
+        }
+        default {
+            expr {((round(-32) ? 3.94 : (~66.21)) << -20.56)}
+            set j "vur@ae4lz3#"
+            catch {
+                string length "7yc.z..w4.hq9q"
+                expr {int(49.47)}
+            } result
+            append idx " 467oxrczz 0-pi"
+            if {((35 ** 28) < (2.32 > 32))} {
+                string last "a" "9=uy w4wex@gvcp;8u"
+                expr {(((!-48) != -36.91) ? (0 - double(85)) : 27)}
+            }
+            expr {((95 >> (25 & -75.31)) <= min((-73 % max(1, abs(83.51))), $buf))}
+        }
+    }
+    incr acc
+}
+expr {(23 ? ((-58 ? -55 : $buf) >> (~75)) : (--56.45))}
+expr {((-8 < (67 + -88)) == ((48.80 >= $x) / max(1, abs(-72.21))))}
+concat {-17.15 -523 304} {692 -59.92 -605 kxd -635 no}
+set idx {55.07 238 -31.15 -566}
+lassign {0 -3.43 -69.03 -803 -959 98.41} count
+set msg [expr {$item}]
+foreach b {78 no yes} {
+    string trimright "-?+-5hd6?6.ph6"
+    set i 0
+    while {$i < 1} {
+        expr {(round(4) & (~(-8.45 > $val)))}
+        set tmp 0
+        while {$tmp < 2} {
+            regexp "." "?c6+@g5q4n"
+            string map {a b c d} "w+@"
+            expr {((-52.57 ** (-69 * 9)) >> 22)}
+            set i [expr {16}]
+            set j 56
+            incr j 10
+            catch {process }
+            incr tmp
+        }
+        string length "gg7z3ciy8?i5"
+        catch {
+            expr {(!((-57 || 27) % max(1, abs(-49))))}
+            regexp "." ".ude"
+            append data -69.44
+            set buf dgfsziqs
+            expr {((11 * int(-17.25)) && (($n ** -9.70) <= $n))}
+            lassign {-928 a} y
+        } n
+        incr i
+    }
+    set msg {-33.90 -874 -78.20 38.42 67.97 -542}
+}

--- a/fuzzing/findings/seed_1774200024.json
+++ b/fuzzing/findings/seed_1774200024.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200024,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "negative shift argument",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "negative shift argument",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200024.tcl
+++ b/fuzzing/findings/seed_1774200024.tcl
@@ -1,0 +1,163 @@
+set b 0
+while {$b < 5} {
+    foreach key {675} {
+        catch {
+            lassign {no -964 55.25 -34.15 817} buf
+            set count 646
+            lassign {} msg
+            set buf no
+            set msg 28
+            incr msg 1
+            append data -7
+        } count
+        foreach data {-176} {
+            set key neazde
+            set key ",v"
+            append flag "zji6gtl2+g0b#c.le"
+            append flag -933
+        }
+        expr {((6 ? -92 : (50 % max(1, abs($flag)))) ** (~(43 ? -59 : $buf)))}
+        lassign {4.49} buf
+    }
+    if {(~(46 << -95))} {
+        set key 46
+        incr key 3
+    } else {
+        lassign {} data n acc
+        set msg 0
+        while {$msg < 2} {
+            expr {(-51 ? ((10.85 || 34.80) << (2 ? 49 : -24)) : ((-61) < (-18 ** 42)))}
+            lrange {371 yes -752 false} 1 4
+            lassign {no -33.60 633 false} flag
+            set acc "4+0g@cm,!u@uu4obgp5"
+            string length "#oe+:.g?7rowoe-!5x?r"
+            incr msg
+        }
+        lsort {1 -43.65 -122 true 67 0}
+        set n 40
+        incr n 4
+    }
+    if {$msg <= -8} {
+        expr {(wide((-48 >> 78)) * double((!$b)))}
+        set data 38
+        incr data -2
+        for {set key 0} {$key < 4} {incr key} {
+            expr {((-34 ^ (-100 >> 40.07)) % max(1, abs(((56.54 / max(1, abs($data))) << abs(44)))))}
+            regexp "\\d+" "fw f7dztx7"
+            set b false
+        }
+        set key 73
+        incr key 3
+        set count [expr {($acc % max(1, abs(($flag >= (27.68 ^ $buf)))))}]
+    }
+    for {set acc 0} {$acc < 3} {incr acc} {
+        set count "58z4i=lz+z18v2t"
+    }
+    if {49} {
+        expr {12.18}
+    }
+    incr b
+}
+if {$count > 20} {
+    set key -424
+    set key {}
+}
+set b 0
+while {$b < 1} {
+    append acc 86.66
+    regexp "[a-z]+" "t4=:sf_1b,7o1.k!"
+    set acc [expr {(!(-abs(-2)))}]
+    set idx 0
+    incr idx 8
+    set b 1
+    incr b
+}
+catch {
+    if {wide(($data <= 23))} {
+        expr {(-round((~-88)))}
+    }
+} msg
+foreach acc {-53.10} {
+    append buf -85
+    foreach i {764 91.96 rcqctv no true} {
+        expr {(-(min(19, 63) != $msg))}
+        lassign {252 osv 753} j
+        set tmp [expr {(((88 << 88.03) > (~45)) % max(1, abs(((!14.39) == (75 >> -43.53)))))}]
+        set data 0
+        incr data 1
+        expr {81}
+        if {-15} {
+            set i -56.67
+            set i -361
+        } else {
+            string length "x@277.s ocn"
+        }
+    }
+}
+foreach flag {i 85.64 ohhs true -44.44} {
+    for {set idx 0} {$idx < 6} {incr idx} {
+        string trimleft "d-x99rhxkgo-89=_rx"
+        set n 74
+        incr n -5
+        expr {int(((75 | 65) % max(1, abs((-75 + -74.43)))))}
+        join {a false 726 155} "-"
+        expr {double((wide(15) + round(-38)))}
+        regexp "." "@j6fmel_hc:vdx7;i"
+    }
+    catch {
+        if {(~($tmp ? 42 : $acc))} {
+            regexp "\\d+" "cuyje"
+            expr {-74}
+            append key 1
+            lassign {22} val msg msg
+            set b 868
+            lreverse {-705 528 499 uap no}
+        } else {
+            set tmp 0
+            while {$tmp < 1} {
+                string reverse "l!zr.;:hvt5p!_1ahrs"
+                expr {$buf}
+                lassign {} data val
+                expr {((!11) >= (~(-$val)))}
+                append msg "w:n9+l!4#j7?dh2tml"
+                set i ofzixb
+                incr tmp
+            }
+            set j {0}
+            set msg {-672 373 true}
+            set x -799
+        }
+        for {set key 0} {$key < 5} {incr key} {
+            append j "gd"
+            set count 30
+            incr count 4
+        }
+    } b
+    if {$flag <= -10} {
+        expr {((-1 ? 4 : (-91 >> $i)) & (~double($x)))}
+        for {set i 0} {$i < 1} {incr i} {
+            set msg 112
+            set a 115
+            set j 11
+            incr j 1
+            expr {int((!min(-48, -32)))}
+            set buf py
+            append n yes
+        }
+        lassign {671} a z
+        llength {1 -76.63 blekml -242}
+        string toupper "yy-..q#;jim97,v+0"
+    } else {
+        string length "1"
+        append count 75
+    }
+    for {set j 0} {$j < 3} {incr j} {
+        set j -40.96
+    }
+    set buf 40
+    incr buf 4
+}
+proc helper {acc {i -64.64} n {b 459}} {
+    set a 302
+    return "j3boc:_3g+nnbas791w"
+}

--- a/fuzzing/findings/seed_1774200028.json
+++ b/fuzzing/findings/seed_1774200028.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200028,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"flag\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"flag\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200028.tcl
+++ b/fuzzing/findings/seed_1774200028.tcl
@@ -1,0 +1,219 @@
+if {36} {
+    set n {hbvbbqw 83.53 mhuokub false}
+}
+catch {
+    set j 63.34
+} msg
+proc helper {y} {
+    if {(25 * (92 ? -96 : -77))} {
+        for {set j 0} {$j < 4} {incr j} {
+            append idx 91
+            string reverse "na"
+            if {((-69.91 ? 68 : 47.77) ? abs($msg) : wide(34))} {
+                set b {-93 23.33 -127}
+                set b 15
+                incr b 3
+            } else {
+                expr {(((14 ? $b : 38) == (~86)) == 82)}
+                expr {(77 | -54.00)}
+                lassign {} a n idx
+            }
+            regexp "[a-z]+" ":,h0jy2yzio_j"
+            set n 48
+            incr n -4
+        }
+        set i "7+t:g542sn"
+        if {(!(-27 && 20))} {
+            set b -487
+            append j "ufzcdqmu!@xfb7wuvo"
+            set j 1
+            set b [expr {(~(44 || (~63)))}]
+            set msg {528 51.81}
+            if {((-82 && 7) + 45)} {
+                expr {58}
+                lrange {63.86 -212 y 599 -249} 0 1
+                set z 46
+                incr z 7
+                lassign {} idx a msg
+            } else {
+                append j -85.56
+                set y [expr {-89}]
+                expr {$y}
+                append i 5
+            } elseif {$n < 18} {
+                set y 94
+                incr y -3
+            }
+        } else {
+            set j {l -51.15 -717}
+            set i 8
+            incr i 2
+        } elseif {(-($z - 28))} {
+            foreach msg {} {
+                expr {((41.33 || (16 ? 1 : -24)) / max(1, abs($z)))}
+            }
+        }
+    } else {
+        append a "087u+stmq#cgbesftv6"
+        for {set y 0} {$y < 3} {incr y} {
+            string length ",#jbjdd7ss8m-v8-t6"
+            expr {double(((11 ? 9.83 : 29) & 66.69))}
+        }
+        append z -11.79
+        expr {(((!18) <= (23 && -78)) + (~(-77 ^ -65)))}
+        if {($z ? 0 : wide(-29))} {
+            string trim "@0:j@kp41_9m:u,sa=w,"
+        } else {
+            lassign {0 yes 41.95 true} z y a
+            set j "kot576r8v:+"
+            set a 96
+            incr a -3
+            set msg [expr {((-(-18.13 > $idx)) ? 64 : -33)}]
+        }
+        append a orj
+    } elseif {(($y ? 14 : $z) && (-90))} {
+        set flag {}
+        lappend flag gbon
+        append n 67.79
+        set idx 78.49
+        if {$flag != 3} {
+            append j isrb
+            set flag 74
+            incr flag 3
+            switch -- false {
+                939 {
+                    lrange {-14 -667 570 wzqit dsuvdse} 1 3
+                    llength {-474}
+                    string first "a" "ehj4fnr!hf;linq"
+                    set b 201
+                    lassign {-4} tmp msg
+                }
+                ",6.qvfcprexqt..r" {
+                    expr {(((-5 | -46) <= -94.09) || int((-61 > -59)))}
+                }
+                394 {
+                    lassign {yaqeap -789 -290 -890 183} n
+                }
+                "" {
+                    string range "mc,q u:4dzrx22" 2 7
+                    set n [expr {(!-50)}]
+                    set idx {683}
+                    set tmp 61
+                    incr tmp -3
+                    set msg 12
+                    incr msg 2
+                }
+                default {
+                    expr {(-((~-78) / max(1, abs((!42.70)))))}
+                    lindex {-407 262 -64.31 yes} 2
+                    expr {$msg}
+                    set b "7s"
+                    string repeat " e" 1
+                }
+            }
+            set msg ae
+            set flag 0
+            while {$flag < 3} {
+                set idx 98
+                incr idx -2
+                set j {}
+                regexp "." "5l"
+                incr flag
+            }
+        } else {
+            append i -82
+            for {set flag 0} {$flag < 1} {incr flag} {
+                string range "a+9s_;3;yaowv_;5" 4 6
+                expr {(~((38 < $n) < ($a && -56)))}
+                append n 536
+                append tmp -555
+            }
+            expr {($tmp >= double((-80.72 && $j)))}
+            set msg {86.58 -298 wqhpcb ql -8.29}
+            expr {(~(66.90 < -96))}
+            regexp "[0-9]" ""
+        }
+        for {set i 0} {$i < 3} {incr i} {
+            expr {(((-75 != $y) / max(1, abs((-89.69 * -78)))) < ((3 || -7.45) <= (-12 ? 43 : -26)))}
+            lassign {} b z idx
+            append msg -614
+        }
+        expr {abs((round(31) ? (-90) : (50 >= -52.91)))}
+    }
+    return -23
+}
+llength {-9.88}
+append n 55
+append buf -527
+if {$buf < -2} {
+    lassign {no 45.29 385 true ogvhohzy} y val j
+    catch {helper }
+    if {$flag} {
+        set a "-r 8.2"
+        for {set i 0} {$i < 4} {incr i} {
+            regexp "\\d+" "+"
+            set idx 0
+            while {$idx < 5} {
+                expr {(!((-22.93 ? -34 : 41) % max(1, abs((-26 ^ $a)))))}
+                incr idx
+            }
+        }
+        if {double(max(-98.41, 81))} {
+            foreach buf {914} {
+                string reverse " xowj"
+                lsort {0 484 false 58.96 1 -604}
+            }
+        } else {
+            set a {}
+            expr {$a}
+            regexp "[a-z]+" "i#;+"
+            set a {74}
+        }
+    }
+    set tmp [expr {((31 >= int(65)) ? ((-93.48) != ($j * 69.70)) : (7 && -5))}]
+} else {
+    append buf 83
+}
+set item -12.15
+for {set i 0} {$i < 3} {incr i} {
+    set buf 19
+    incr buf -5
+    catch {helper " ?1" "!0.b5 sv0pvu2+c"}
+    set count 1
+    lsort {-45.81 0 576 csvlgft yes}
+    foreach a {716 -893 av 863 129 1} {
+        catch {helper }
+        set n "lo=63z;nm"
+        regexp "\\d+" "j,r,mdo4?+m19"
+    }
+    expr {(-68 > (($tmp ** 30) >= (27 == -13.39)))}
+}
+proc handle {y} {
+    append y 31
+    for {set idx 0} {$idx < 3} {incr idx} {
+        string trim "6jox"
+        regexp "[0-9]" "=0=ty7@#6s-xq8sg"
+    }
+    expr {((min(53.54, 86) != $msg) + ((33 ? 1 : -44.43) ? (-7.78 > 88) : $j))}
+    expr {($j ? 75.04 : ($i || $j))}
+    foreach n {715 lxvdbelz -158 sd} {
+        expr {abs((-(!82)))}
+        foreach x {false ianukg} {
+            lsort {}
+            append tmp "gi4dvy;"
+            lassign {-869 -0.98 0 p hvgpayy} count buf tmp
+            lassign {0 false i 1 -805 no} tmp
+        }
+        if {((-66 / max(1, abs(72))) / max(1, abs((~-27))))} {
+            set idx 21
+            catch {helper }
+        } else {
+            set b 50.59
+        }
+        set count 70
+        incr count 8
+        expr {((-(-47.69 << -90)) != ((-37) + (-42 & -44)))}
+        expr {85}
+    }
+    return 0
+}

--- a/fuzzing/findings/seed_1774200031.json
+++ b/fuzzing/findings/seed_1774200031.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200031,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-38.6\" as operand of \"~\"",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-38.6\" as operand of \"~\"",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-float-bitwise"
+}

--- a/fuzzing/findings/seed_1774200031.tcl
+++ b/fuzzing/findings/seed_1774200031.tcl
@@ -1,0 +1,90 @@
+foreach key {} {
+    set result -180
+}
+proc compute {{z -260}} {
+    string trimleft "1p"
+    set key "7sx-qx?_1tnl"
+    set key "iku-7i?q?,#919w"
+    return 86
+}
+for {set key 0} {$key < 1} {incr key} {
+    expr {(52 << ((~-38.60) < max(25, -24.23)))}
+}
+foreach key {-333} {
+    if {$result >= -3} {
+        for {set z 0} {$z < 1} {incr z} {
+            append z gcbj
+            set key 65
+            incr key 6
+        }
+        for {set i 0} {$i < 5} {incr i} {
+            string range "rn=hk.?" 1 7
+            regexp "\\d+" "1"
+        }
+        set z {oaukc yes -25 0}
+    } else {
+        if {27} {
+            set key 0
+            while {$key < 5} {
+                string length "9."
+                set key 35
+                incr key -4
+                incr key
+            }
+            catch {compute }
+        }
+        switch -- 59 {
+            34.81 {
+                lsearch {evprqrqp mnxpuuel oitcjjn yes syfdwea -38.82} "n5i"
+                foreach result {} {
+                    catch {compute "nd80bbc,?" "z "}
+                    regexp "^[a-z]" "dj-1:hgb1q9kt"
+                    string trim "#+ij"
+                }
+                set z "d4ft8_z+k#"
+            }
+            bgysl {
+                foreach result {y} {
+                    set key [expr {wide(-2)}]
+                    set a 84
+                    incr a 3
+                    set z [expr {(--11)}]
+                    set i -976
+                }
+                set b {}
+                set z 79.88
+                string range "u10" 2 4
+                for {set a 0} {$a < 4} {incr a} {
+                    set j 101
+                    expr {((-23 ? ($a ** -65) : (!-5.74)) || (int(-70) != (-$b)))}
+                    catch {compute }
+                    expr {round(((!-86) ^ (!-65)))}
+                    set j 23
+                    incr j -1
+                    expr {$key}
+                }
+                set key ""
+            }
+            704 {
+                expr {(11 || ((90 < 87) | $j))}
+                set result -796
+                expr {(35 % max(1, abs(((~-41) & 50))))}
+            }
+            46.75 {
+                regexp "^[a-z]" "20ynh1;? 4"
+                set result 58
+                incr result 1
+                concat {-21 xcbsz yes -726 yes} {0}
+                expr {3}
+                set result fvuabzj
+            }
+            default {
+                lassign {849 751 -762 no} key result a
+                for {set key 0} {$key < 5} {incr key} {
+                    set i yes
+                    append count -97
+                }
+            }
+        }
+    }
+}

--- a/fuzzing/findings/seed_1774200035.json
+++ b/fuzzing/findings/seed_1774200035.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200035,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"70.34\" as right operand of \"&\"",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"70.34\" as right operand of \"&\"",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-float-bitwise"
+}

--- a/fuzzing/findings/seed_1774200035.tcl
+++ b/fuzzing/findings/seed_1774200035.tcl
@@ -1,0 +1,200 @@
+proc compute {{msg 5} {z wrzrdqjw} args} {
+    for {set z 0} {$z < 1} {incr z} {
+        append z 2.06
+    }
+    return 943
+}
+for {set z 0} {$z < 2} {incr z} {
+    string trimleft "l!x_c"
+    set z 69
+    set result 48
+    incr result 4
+}
+if {$z == -3} {
+    set result 0
+    while {$result < 5} {
+        set result 96
+        incr result 8
+        foreach result {1 275} {
+            list 18 0
+        }
+        set x -995
+        switch -- cq {
+            no {
+                lreverse {-673 656 -22.20 728}
+            }
+            default {
+                set x 792
+                string last "a" "d8t3tu"
+            }
+        }
+        expr {((~(30.57 * 6.68)) - $z)}
+        set z 0
+        while {$z < 2} {
+            foreach result {30.35 99.21 -71.86 47} {
+                set item [expr {(round(min(1.31, $x)) ? (58.68 ^ (-54 & -50)) : -85)}]
+                set item "e2;vd+!78lry"
+                lreverse {ihcq 15.12 -17.79 412 65.76 no}
+            }
+            string tolower "m52"
+            expr {(-67 + ((45 - -84) * $item))}
+            if {35} {
+                string trimleft ";1 l4m.k4,+"
+                append x 601
+                lassign {81.51 336 220 false} z z
+            } elseif {(($item / max(1, abs(-41.82))) & $result)} {
+                regexp "\\d+" "hfw ckpah9"
+                append a 41.15
+                join {-537} "-"
+            }
+            regexp "\\d+" "#z!"
+            append x "zoamj_wcmb-u+z:n#"
+            incr z
+        }
+        incr result
+    }
+    lrepeat 3 -34
+    append idx 87
+}
+proc check {buf flag {data 994} n args} {
+    expr {-95.78}
+    set item -667
+    catch {compute "q=c#_ s3,eya55ilaq" -429 "#aym2z;=tbdz"}
+    switch -- 14 {
+        true {
+            catch {
+                expr {(((-57 ? 48 : 66) % max(1, abs((73 - $item)))) >> abs(($x % max(1, abs(0)))))}
+            } result
+        }
+        default {
+            regexp "[0-9]" "_2_p@j9ly"
+            for {set data 0} {$data < 4} {incr data} {
+                set result 63
+                incr result 1
+                set x 627
+                set j 21
+                incr j 5
+                set val [expr {27}]
+                set item 44
+                incr item -5
+            }
+            set item [expr {((!(!16.60)) > (-100 >= ($a != $val)))}]
+            foreach val {zre} {
+                append b 76.87
+            }
+        }
+    }
+    for {set tmp 0} {$tmp < 6} {incr tmp} {
+        string map {a b c d} "786js xk9"
+        for {set z 0} {$z < 2} {incr z} {
+            set result 82
+            incr result 4
+            set idx [expr {$j}]
+            set data {-44 8.69 -654 ceyljhys}
+            expr {((abs(-56) ? (39 & -58) : (-45 > 28.98)) ? ((-94.25) ** (-$x)) : (~round(41)))}
+            list -80 false no
+        }
+        for {set result 0} {$result < 4} {incr result} {
+            set x {438 846 155}
+            set b 68
+            incr b 0
+        }
+        switch -- "2" {
+            -63.93 {
+                string index "fwmc_" 2
+                expr {-28.06}
+                lrepeat 3 80
+                set x {-487}
+                set b tftpv
+                set tmp yes
+            }
+            -14 {
+                string repeat "ye_.d=" 2
+            }
+            default {
+                lassign {leymfni -98 -176 true} buf
+                lassign {740 8.16 -640 -82.37} msg item
+                set val -160
+                switch -- "a0d @y7_7=r" {
+                    80.99 {
+                        append x "qr=wg b4=@0a0  b4:o"
+                        string map {a b c d} "2ys,sa?_qaar:"
+                        join {jyyuot} "-"
+                        set tmp 0
+                        expr {(((~23) % max(1, abs((!-12.29)))) == 5)}
+                        set b -63.39
+                    }
+                    default {
+                        append item 74
+                        lrepeat 2 ",cb+qj3u?hrd"
+                    }
+                }
+                append data -245
+            }
+        }
+    }
+    lrange {1} 1 3
+    return -52
+}
+foreach j {} {
+    switch -- 59 {
+        jp {
+            append tmp -344
+            append idx "efm  :l0m6=ke;1e1?"
+        }
+        -857 {
+            llength {-755 871 -30.68}
+            set b 64
+            incr b 7
+        }
+        -12 {
+            expr {(!(($val <= 26) ? ($x >> $b) : 11))}
+            expr {(-21)}
+        }
+        default {
+            string first "a" "+ul1"
+            expr {(!($a << -2))}
+            expr {((~(28.54 < -24)) << -67.43)}
+            set idx ":vk-9?7=c_4_kgfd"
+            expr {48.94}
+            foreach data {699 -159 76.23 973} {
+                string trimright "r"
+                lassign {65.78} j result
+            }
+        }
+    }
+    for {set val 0} {$val < 3} {incr val} {
+        foreach item {-550} {
+            lrepeat 3 -865
+            set a "l0:n?"
+            set msg {-449 vmv}
+            append item "3#+o4qm"
+            set val 17
+            incr val 8
+        }
+    }
+    set z 0
+    while {$z < 5} {
+        set flag 50
+        incr flag -2
+        append j -395
+        expr {double(30)}
+        incr z
+    }
+}
+set msg 1
+expr {(((-29 == 33.03) ? ($tmp < 25) : -46) & (-7.67 ? double(70.34) : (!$x)))}
+if {-56} {
+    set tmp {61 219 81.61 1}
+    expr {(98 / max(1, abs((-6.98 >= $flag))))}
+    foreach item {false -712 fof oyjqchwh} {
+        expr {abs((~abs($a)))}
+        set data {-733 -279}
+        append acc qa
+    }
+    for {set data 0} {$data < 4} {incr data} {
+        list 34.66 "lc_2!k+wc;yco"
+        lrepeat 1 18
+        catch {check }
+    }
+}

--- a/fuzzing/findings/seed_1774200037.json
+++ b/fuzzing/findings/seed_1774200037.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200037,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200037.tcl
+++ b/fuzzing/findings/seed_1774200037.tcl
@@ -1,0 +1,117 @@
+string length ""
+set msg 61
+incr msg -2
+if {$msg != -8} {
+    append msg 633
+    string length ""
+    set msg 9
+    incr msg 1
+    for {set tmp 0} {$tmp < 5} {incr tmp} {
+        set key 82
+        incr key -4
+        if {$key <= 15} {
+            set acc 60
+            incr acc -4
+            set tmp {877 0 -497 appjbxys}
+            regexp "." "+24 qsg"
+            set key "9b8+,y=y4i5.68c98f"
+        } else {
+            set key 459
+            expr {((abs(50) >= ($acc ** -58.17)) ? (-(-$tmp)) : -5)}
+            append key -84
+            string index "30j4p-l2a n 49=_:" 2
+            set acc "l"
+        }
+        expr {(21 >> ((-90 + -54) ? int(6) : (21 || -49)))}
+        if {(2 * round($msg))} {
+            set acc 48
+            incr acc 3
+            set key 0
+            while {$key < 2} {
+                set acc -903
+                set tmp "6fvbk.1j!. :0g"
+                expr {(50 > $tmp)}
+                expr {(96 % max(1, abs(-3.56)))}
+                expr {(-15 % max(1, abs(((2 || $msg) > (~-77)))))}
+                set tmp 46
+                incr tmp -4
+                incr key
+            }
+            expr {(((-100) != (58 + 52)) * -59)}
+            set tmp 76
+            incr tmp 8
+            set a true
+            lassign {hgjvddvm} j msg acc
+        }
+        set key surk
+        append msg -764
+    }
+    expr {int((wide(49) ? max(-34, 10.45) : (-14 % max(1, abs(-23)))))}
+    append item 107
+}
+set a {yes false 94.83 24.94}
+if {(!(2 - 40))} {
+    expr {(-55 + ((!-62) != (!-11.93)))}
+    expr {96}
+    set j -980
+    set tmp [expr {(15 ? (-38.31 ** -47.34) : (-21))}]
+    set n 0
+    while {$n < 3} {
+        append msg -608
+        string last "a" "fphqisu?el"
+        set acc {}
+        lassign {aajonxj -439 -787 hafm 369 yes} key j data
+        incr n
+    }
+    catch {
+        foreach j {-234 -520 -930 77.83} {
+            if {((48.48 == -88) ? (--1) : ($tmp - -46.82))} {
+                append data -30
+                lassign {true 671 474 eo ofu} b
+                set x 377
+                expr {(((-76) + ($n || -68)) && -36.40)}
+            }
+            expr {43}
+            append n -58
+        }
+        set item 51
+        incr item 3
+        expr {-30}
+        if {$msg < -3} {
+            expr {((min($item, 79) > -16) && ((49 / max(1, abs(-3))) ** 6))}
+            foreach a {} {
+                string range "" 3 7
+                set acc "io5x#+ 9yd"
+                set key "5e!?l66#e2,la4?5k+g"
+                set flag "=4! k_=n5u,!2snj"
+                set item -781
+                string length "0xijie=n"
+            }
+            foreach a {59.67 337 79 113 1} {
+                set msg r
+                set a ""
+                set buf 60
+                incr buf 6
+                set b "b5 9#-31g:oin:2gbmq"
+                set data 65
+                incr data -2
+                expr {(((60 / max(1, abs(97))) >> (31 && -93.29)) ** 52.80)}
+            }
+            set val -97.05
+            set count -43.73
+        }
+        expr {((max(35, -35) || 89) & (-39 ? (-53 & $x) : (-18.32)))}
+        set n [expr {((($x >> 78) ^ ($data / max(1, abs(99)))) ? ((-$val) != (~$data)) : ((68 || 21) <= 8))}]
+    } tmp
+} else {
+    set b ";qz0;:,=xh"
+    set a [expr {((-($b == -25)) ? (wide($buf) >= (14 ** -57)) : abs(wide($buf)))}]
+    set buf 11
+    incr buf 2
+    foreach val {63.77 -360 -13.29 1 lhe -748} {
+        lrepeat 2 no
+        string index "5:n;n_w8@j" 0
+        string last "a" "+xs21.t;#_=j4"
+        expr {(-8 >> (abs(85) ? 95 : $msg))}
+    }
+}

--- a/fuzzing/findings/seed_1774200038.json
+++ b/fuzzing/findings/seed_1774200038.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200038,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200038.tcl
+++ b/fuzzing/findings/seed_1774200038.tcl
@@ -1,0 +1,106 @@
+foreach buf {msngx i true true -29 776} {
+    append buf -45
+}
+proc worker {args} {
+    set buf "!w1#-hfl@_f4a#,3iyl7"
+    catch {
+        set buf 37
+        incr buf 4
+        append buf 52
+        string tolower "4se5@8rf6abc8"
+    } buf
+    return 1
+}
+set buf irgo
+if {$buf <= -3} {
+    for {set key 0} {$key < 5} {incr key} {
+        switch -- "?_jw6g84!" {
+            "-3zgs2ub3v" {
+                set key 71
+                incr key 6
+                set buf 30.80
+            }
+            139 {
+                set key 63
+                incr key 4
+                concat {-942 48.47 843} {-728 -649 69 -881 -212}
+                set acc -99.07
+                expr {(!-63)}
+                regexp "[0-9]" "-i;"
+            }
+            default {
+                set acc "moq e"
+                expr {double((!(11 >> 27.85)))}
+                expr {(~$key)}
+            }
+        }
+    }
+    if {$buf <= -6} {
+        set acc {-39.07}
+        catch {
+            expr {(54 - ((81.98 ? -31 : -74) - (-58 & -47)))}
+            concat {-73.82 -96.20 yes cglgwjac c bp} {-34.25 arj}
+            set acc {-90.59}
+            lindex {114} 2
+            catch {worker }
+            set idx 34
+            incr idx -3
+        } buf
+    } else {
+        append buf "8!k-:hpn!@3uidf 7k6"
+        if {(-61.95 != ($acc & 73.89))} {
+            if {-40} {
+                string repeat "5" 2
+                string map {a b c d} "m6w9 2a14:5rsqx hvsb"
+                string range "v?it418tuhf0, #2deui" 3 6
+                lassign {682 ya 236 wastvjey cayozt -588} result idx
+            } else {
+                set acc [expr {-16}]
+                join {no elau yes 893} ""
+                lrange {} 0 1
+            }
+            if {$result > -1} {
+                lassign {true -89.75 true} buf buf count
+                set acc 65
+                incr acc 5
+                set j 44
+                incr j 2
+                string map {a b c d} "v0t"
+                set result [expr {(75 >> (~(!61)))}]
+                list 54 "!!uywhx!7s4s3zp5-n46" "rznesu9!44m?tt0-60" -478
+            }
+            set x 11
+            incr x -2
+            expr {(-48)}
+            lassign {-661 wsxaxild true yes} buf
+        } else {
+            expr {-9.69}
+        } elseif {$key <= 1} {
+            catch {worker }
+        }
+        set a ",x7@"
+        expr {(abs((37 ? 29 : 84)) >= (~(-$a)))}
+        set b 0
+        while {$b < 2} {
+            set b ",pc8w,b98.;"
+            incr b
+        }
+    }
+}
+if {$acc != 8} {
+    foreach buf {} {
+        set acc -16.20
+    }
+    expr {(abs(15) / max(1, abs((!(-65.13 <= -99)))))}
+    catch {
+        append z -41
+        string length "1-fab@4-:sz5bzjqwjxx"
+        expr {(!(max(57, $x) << max($result, 22)))}
+        if {$idx <= 18} {
+            set result 92
+            incr result 3
+        }
+        append val -16
+    } acc
+    expr {((9 * (~33)) ? -12 : abs(-65.47))}
+}

--- a/fuzzing/findings/seed_1774200040.json
+++ b/fuzzing/findings/seed_1774200040.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200040,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"00to#\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"00to#\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200040.tcl
+++ b/fuzzing/findings/seed_1774200040.tcl
@@ -1,0 +1,246 @@
+for {set i 0} {$i < 6} {incr i} {
+    set i 452
+    set i 408
+}
+proc transform {args} {
+    expr {-58}
+    append i "5am,7un#a1bw"
+    if {$i >= -9} {
+        set a 96
+        incr a 5
+        append i "."
+        append x -545
+        foreach a {-704 -801} {
+            lassign {224 445 -12.61 150 ukgq} i
+            set msg 52
+            incr msg -2
+            append x "-"
+            expr {-65}
+        }
+        for {set data 0} {$data < 5} {incr data} {
+            regexp "\\d+" "w+7pe5hv!ut39h7l"
+            string trimleft "vpo;5w3cfm3"
+            set y [expr {(100 ? round((!61)) : $i)}]
+            lindex {828 -516 42.09 32.45 -928 84.06} 3
+        }
+        concat {false false k yes -272} {-661 -76.69 true}
+    }
+    set msg 58
+    incr msg 5
+    append data 631
+    return vprigc
+}
+expr {-66}
+for {set msg 0} {$msg < 4} {incr msg} {
+    append msg "0to#"
+    catch {transform a -884}
+}
+for {set i 0} {$i < 2} {incr i} {
+    append x fqd
+    expr {(max(double(49), (-60 && -11)) ** ((27 ^ 12) < int(34)))}
+    catch {transform }
+    set result -170
+    string last "a" "4h="
+}
+for {set x 0} {$x < 5} {incr x} {
+    set n [expr {(((2 ? -30 : 31) / max(1, abs($x))) || ($msg | ($x < -47)))}]
+    expr {((47.93 ^ (-15 | 14)) * min((-49 ^ -25), int(-89)))}
+    foreach a {} {
+        switch -- i {
+            -60 {
+                concat {} {gb -579 -386 dagcil 980}
+                foreach result {} {
+                    set a "o=-!h651i"
+                    set flag "onc:!como=z875bd"
+                }
+                expr {(((-89 && -55.75) && (~42)) <= -85.65)}
+                string first "a" "60@3n7n-y5dz_r5"
+                expr {(30 > (6 ** 35))}
+                append x 959
+            }
+            "0347r-72xn58c" {
+                catch {transform -93 72.19}
+                catch {transform "psujj4td3n3" -28.49}
+                append data -83.39
+                catch {transform "67#u-v@o," "e830h=0whh!9m+g7a5" "h9dz-5maul3q;oi"}
+                lrange {18.71 -72.10 -762} 1 4
+            }
+            "x3_g?tsq" {
+                string toupper "w2r,z,"
+                lassign {oqls 666} idx
+                catch {transform }
+                append y "xg7k4bneanqkei0rt_2"
+                expr {(round((16 && -94)) >= 20)}
+            }
+            default {
+                set y {jsk -728 62.16}
+                string trimright "xwy"
+            }
+        }
+    }
+}
+if {$idx != 15} {
+    catch {
+        set data 81
+        incr data -4
+        expr {(((22 >= $idx) || (-64 - $flag)) ^ int((29 != $y)))}
+        foreach count {0 151 99.00 m} {
+            catch {
+                append i -84
+            } count
+            append idx -119
+            set item 0
+            while {$item < 4} {
+                set y "+l!#dtm9a8o6wsxz="
+                set i 67
+                incr i -2
+                catch {transform "na?b4ex_:e:#?+-n9 ="}
+                set result 60
+                incr result -5
+                incr item
+            }
+        }
+    } buf
+    foreach n {frkqst -776 255} {
+        expr {(-(~14))}
+        string trim "@;9df9_g6ai yz"
+        lindex {wkwcks} 0
+        set item {}
+    }
+    for {set result 0} {$result < 2} {incr result} {
+        foreach item {-284 no 249 0 173} {
+            expr {-49.51}
+        }
+        catch {transform "fy_qpygn_qjw-+2x-8nu" -41.92}
+        if {$data < 10} {
+            set i "x1kd ml36qgucs!"
+            expr {46}
+        }
+    }
+    switch -- -52 {
+        "wy:m-cc" {
+            set n [expr {$i}]
+            catch {
+                string length "2qf"
+                expr {((min(-41, -69) >> 20) ? (!$idx) : (($a * -73) << (-9 ? -85 : -52.69)))}
+                append result -68
+                expr {(max(($a > $data), (-95 < 95)) ? (-(-66.53 ? -47.46 : 6.26)) : min((~38), round(32.39)))}
+            } result
+            set result [expr {33}]
+        }
+        "=k.v.q?j@t1k:b6_fc" {
+            expr {8}
+            set key 13
+            incr key 7
+        }
+        default {
+            lassign {-803 -920} result i
+            lassign {-254 -327 822 ufn -927} a j
+        }
+    }
+}
+for {set z 0} {$z < 5} {incr z} {
+    set key 0
+    while {$key < 2} {
+        set i {ymvt -93.98 791 no}
+        expr {(((39 == -90.74) ^ 26) >> -28)}
+        incr key
+    }
+    set count izsh
+    if {((--90) ? -96.89 : (14.99 ? -13 : -54.63))} {
+        set y "rx;,@s5"
+        for {set x 0} {$x < 4} {incr x} {
+            expr {22.16}
+            set z l
+            expr {(66.07 | -86.06)}
+            foreach flag {-55.05 252 true 530 -526} {
+                set tmp {82.99 yes true -61.46 889}
+                set x -956
+                set n 866
+            }
+            expr {9}
+            lreverse {}
+        }
+    } else {
+        for {set flag 0} {$flag < 4} {incr flag} {
+            expr {(((8 && -55) || -43) == $i)}
+            for {set msg 0} {$msg < 1} {incr msg} {
+                expr {(79 * ((19.25 & 46) * min($flag, $x)))}
+                lassign {} result flag item
+                append n 724
+            }
+            catch {transform bh -40 -25}
+            lassign {} buf result
+            string reverse "bas2oqa3"
+        }
+    }
+}
+proc process {{y 1} count} {
+    set key 0
+    while {$key < 1} {
+        for {set b 0} {$b < 1} {incr b} {
+            set y 0
+            while {$y < 4} {
+                string tolower "#vc3mp7c;l "
+                set buf yes
+                lassign {pusryw -633} n
+                set item 30
+                set j ""
+                incr y
+            }
+            list -26 203
+            set i "ty05?!3tfr#mjch@=885"
+            lindex {-404 -434 836 -33.16 884} 3
+            append val "3?s"
+            lassign {-189} data
+        }
+        if {(int(-55) - (4 < -90))} {
+            concat {-392 47.98 ndhkh 90} {no jafp -36 -732}
+            concat {} {954 499 129 802 -44.39}
+            set i "0-!"
+            set data -186
+            expr {(14 || ((!82) ? round(-82) : $j))}
+        } else {
+            catch {transform -906 "2zz7iuso@82" 102}
+            set data {-12.11 82 ray mu}
+            append msg -82.41
+            set key 48
+            incr key 3
+        }
+        incr key
+    }
+    expr {(-(!-53.87))}
+    set val 8
+    incr val 9
+    for {set buf 0} {$buf < 6} {incr buf} {
+        catch {transform 46}
+        set y 0
+        while {$y < 1} {
+            set n false
+            set i true
+            expr {(abs(-16) ? (!abs(35)) : ((-14 && -64) % max(1, abs(double($i)))))}
+            foreach x {948 -596 no 0} {
+                set flag "=i, ?x9l8dp"
+                expr {(-((-18 * $key) >> (23 != $buf)))}
+                expr {round(($flag == (-50.21 ? 43 : $j)))}
+                set z "#8-#m0"
+                expr {59}
+            }
+            string first "a" "g=xpgu!r"
+            expr {55}
+            incr y
+        }
+        set n hfjbof
+    }
+    set tmp [expr {((-(82.19 >> $result)) ^ 96)}]
+    for {set item 0} {$item < 6} {incr item} {
+        foreach tmp {bwgbb} {
+            append tmp -34
+            concat {30} {-27.77 wwsaoyiw 56.82 true 719 false}
+            set z 29
+            incr z 5
+            append n -153
+        }
+    }
+    return -78
+}

--- a/fuzzing/findings/seed_1774200042.json
+++ b/fuzzing/findings/seed_1774200042.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200042,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"0x?mdvd:n\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"0x?mdvd:n\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200042.tcl
+++ b/fuzzing/findings/seed_1774200042.tcl
@@ -1,0 +1,81 @@
+set y 13.67
+if {$y < 5} {
+    set y -170
+    append msg 12
+}
+set y 0
+while {$y < 5} {
+    foreach y {90.54 791 -388 false 620} {
+        string map {a b c d} "2?-2- 274vksp1_ajc"
+        string range "it29vs2::gs_9 =jsu" 0 3
+        set tmp 94
+        incr tmp -2
+        lsort {589 true}
+    }
+    switch -- -5.67 {
+        -19.64 {
+            lassign {no} msg
+        }
+        ";89@7otayo" {
+            for {set count 0} {$count < 3} {incr count} {
+                set count {}
+                regexp "." "@.hy1.wf+ 10r;:"
+            }
+            set y "w;y4swb"
+            expr {((~$tmp) ? ((-28 < -31) < (5 ? 68 : 91)) : (!(-49 * 81)))}
+        }
+        default {
+            append y -32.34
+            regexp "." "_:;#4"
+            set y 0
+            while {$y < 4} {
+                set b 0
+                while {$b < 1} {
+                    string length "qx_6p0+63at61x,"
+                    append b "x?mdvd:n"
+                    string length "bv!jn0i_= "
+                    lassign {1 -14.94 189 37 488} count buf
+                    set j {}
+                    lappend j 0
+                    lsearch {483 671 52.56} "y.!nn:gqh7"
+                    incr b
+                }
+                incr y
+            }
+            expr {((-($y ? 9 : 41)) ? $b : (-25.83 >= (-80 != 61.97)))}
+            set y [expr {(-($j && (12.95 <= $b)))}]
+            for {set key 0} {$key < 5} {incr key} {
+                set j 43
+                incr j 1
+            }
+        }
+    }
+    set count 970
+    expr {(((34 - $buf) * -48.14) - (($b ? 24 : -72) || (70 * $b)))}
+    set key 0
+    while {$key < 1} {
+        expr {$b}
+        for {set tmp 0} {$tmp < 1} {incr tmp} {
+            append flag 61
+        }
+        set msg 0
+        while {$msg < 2} {
+            expr {(((~22) >> round($key)) <= -29)}
+            regexp "." ":73"
+            append count "+epw0@ p2 ad4kv!v"
+            set j {jxolezu -214 873}
+            incr msg
+        }
+        set j {-803 234 true}
+        expr {(((41 ? -8.27 : -33) % max(1, abs($count))) ? ((-96 << 47.98) ^ (-48 - -86)) : ((95 | -10.24) >> double(27.29)))}
+        incr key
+    }
+    incr y
+}
+proc check {msg {b 601} {count yatlxdbn} {tmp yes} args} {
+    set b no
+    expr {(-56 != (!$key))}
+    expr {(-12)}
+    set j [expr {99}]
+    return 169
+}

--- a/fuzzing/findings/seed_1774200043.json
+++ b/fuzzing/findings/seed_1774200043.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200043,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"-57.55\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"-57.55\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200043.tcl
+++ b/fuzzing/findings/seed_1774200043.tcl
@@ -1,0 +1,76 @@
+if {((-13 - 15) + (-74.70 < -83))} {
+    expr {(!(~(-80.38 ? 16 : 69.59)))}
+    set val 0
+    while {$val < 2} {
+        set idx 0
+        while {$idx < 5} {
+            foreach val {true -348 yeo} {
+                append val "s@7umwjdx@p"
+                expr {(35 <= ((50.99 <= 12) >> (!35.72)))}
+                set key "jtw5g,zm7?v#yqv0=u9-"
+                expr {31.64}
+                set val 199
+            }
+            incr idx
+        }
+        expr {((-46 * $idx) > round((-75 || -5)))}
+        set idx n
+        expr {(~(-$val))}
+        lassign {-57.55 555 -72.54} val item
+        incr val
+    }
+} else {
+    set val 90
+    incr val 5
+}
+if {$key == 8} {
+    switch -- hevfru {
+        2 {
+            append item -95
+            foreach count {true} {
+                append val "s_bu2oh,7=kfbf6, d"
+                set count "ahno5#fik0!j_t8fl3"
+                append item "5+6f3zwjy+pbtnwu"
+            }
+        }
+        default {
+            if {min((80.89 + -44), (33 * -47))} {
+                set b false
+                lassign {66.11 923 true 0 -610 no} x item
+            }
+            expr {max($item, (65 && -6.19))}
+            lassign {-884 -13.32 -657 yes} x key
+        }
+    }
+    catch {
+        if {$idx <= -7} {
+            foreach val {-425 203 r hmpeoiqy lptrxwpz} {
+                set x 692
+                expr {(8.72 + min(-92, (-53 ^ $count)))}
+                set x 89
+                incr x -4
+                string map {a b c d} "6.pewctv@gka7u?c"
+                set acc {}
+                append count 482
+            }
+            expr {(34 >> -84)}
+            if {(83 ? -61.79 : ($item | 28))} {
+                set result 62
+                incr result -4
+                expr {(((28 << $x) ? (--93) : -29) * ((34 > 1) == $item))}
+                regexp "^[a-z]" "ttdk3;p6jgiyjphp"
+            }
+            set b {986 w true 532 87.52 288}
+            set key 925
+            expr {((92.81 && ($result || -4)) * int(min(10.55, 62.27)))}
+        }
+        set b 19
+        incr b 9
+    } x
+} else {
+    if {43.64} {
+        append key 860
+        set x -76.51
+        expr {16}
+    }
+}

--- a/fuzzing/findings/seed_1774200046.json
+++ b/fuzzing/findings/seed_1774200046.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200046,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-87.02\" as left operand of \">>\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-87.02\" as left operand of \">>\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200046.tcl
+++ b/fuzzing/findings/seed_1774200046.tcl
@@ -1,0 +1,257 @@
+if {(~(-87.02 >> 49))} {
+    set key 990
+    string map {a b c d} "yl"
+}
+if {$key < 13} {
+    if {$key != 16} {
+        catch {
+            append key -66
+        } key
+        set a 28
+        incr a 4
+        set a {}
+        set a -633
+        set a "p_jvp; ep+3pm84-@36"
+        if {min(double(7.48), -46)} {
+            lindex {159 no 63.35} 1
+            expr {(((-39 > 56) <= (90.14 / max(1, abs($a)))) != abs(-69.37))}
+            append key ":3mpidc48"
+            set tmp "mx0#b36u"
+            expr {(((-1.29 << 30) <= (92.21 < 11.97)) != wide((66.50 - -18.79)))}
+        }
+    }
+    set count 28.28
+    set count [expr {-69}]
+    expr {(37.64 / max(1, abs(((!-50.59) > (-26 || $key)))))}
+    set a " waz-a5"
+} else {
+    for {set count 0} {$count < 3} {incr count} {
+        expr {(wide(60.57) >> -17)}
+        foreach count {31.26 true} {
+            set count 0
+            while {$count < 2} {
+                string map {a b c d} "um cr"
+                append key "gnc?ynj ksp8f2l"
+                set tmp 47
+                incr tmp 10
+                expr {abs(((-26 ? -35 : 21) || (~7)))}
+                set key dxizoivg
+                expr {(~((30.56 == 95) != (!50)))}
+                incr count
+            }
+            if {((-76.69 == $count) ? -5.91 : (-46 << 7))} {
+                set idx "yyap#75+cpy?ebbc a"
+                concat {-94.70 -69 86} {}
+                set tmp {no -393 -875 false tjj}
+                set a {693 tkg -41.50}
+            } else {
+                expr {min((($tmp ? $count : -42) / max(1, abs((62.88 % max(1, abs($key)))))), -97)}
+                set y 67
+                incr y 8
+                string trim ""
+                append z "chz-g#s265y2:wz5cb"
+            }
+            expr {61.52}
+            foreach z {} {
+                expr {-15}
+                set key e
+                set buf no
+                lsort {442 rlvr}
+            }
+        }
+        set item -468
+        set count [expr {wide(((29 > 1) ? (94 * 74) : (-84.13 / max(1, abs(22)))))}]
+        if {$item != 7} {
+            switch -- 317 {
+                -81 {
+                    expr {(42 | ((-1) ? (-13 % max(1, abs(-23))) : (-63 ** -96)))}
+                    expr {double(round((!$y)))}
+                    lassign {-3.95 267} buf
+                }
+                "14oi2,m" {
+                    append count 3
+                    join {87.18 649 -99.18 -1.21 tn} ""
+                    regexp "[a-z]+" "t3,g3x7b0m_nvk.q#"
+                    set z "hu7:l;+q@3_9e!xze?=#"
+                }
+                "z6o5dmsuyp5" {
+                    set a 666
+                    set i d
+                    append buf 31
+                    set data [expr {95}]
+                    lassign {smbxnk} count
+                }
+                default {
+                    append b mdvdxs
+                }
+            }
+            set tmp "dmwgt"
+            if {21} {
+                set n 84.44
+                set key 30
+                incr key -2
+                lrange {3.04 -29.86 yes 362 true} 0 4
+                set data oyklcm
+                expr {(((94 == $b) >= 28.29) << (abs(41) != (-72.14 ? -4 : 64.40)))}
+            } elseif {$count < 13} {
+                set z -595
+                set count {-28.44 -80.08 tdawnxj}
+                lappend count -2
+                append buf -2
+                append z 93
+                expr {-54}
+                expr {((double($a) | ($z ^ -75)) / max(1, abs((52 ^ int(67)))))}
+            }
+            set idx {408 97.87 943}
+        }
+    }
+    lsort {-48.73 edqhzan bja 88.14 340}
+} elseif {(89 ? ($count ? -35 : -59) : (18 <= -93.04))} {
+    if {$data > 9} {
+        switch -- 477 {
+            932 {
+                lassign {833 bjiye -94.39 ovdlhayf 67.95 -63.69} z
+                append count uzujvs
+                append idx "yog#e?et-=sv1bju8f"
+            }
+            "2upvxpo;wxxf" {
+                set idx 38
+                incr idx 0
+                set b 917
+                append key ""
+            }
+            default {
+                string length "mwc28wzk04m@v5o6w"
+                set key 3
+                incr key -4
+                set key "6_29"
+            }
+        }
+        expr {-12}
+        regexp "\\d+" ".yaicgg82;7 d 4"
+        if {$buf < 15} {
+            append j "x;169in;pifm"
+        }
+        foreach b {} {
+            set a 43
+            incr a -3
+            set n mf
+            set buf 24
+            incr buf 4
+            set data 84
+            incr data 4
+            set tmp 80
+            incr tmp -5
+            append idx "b"
+        }
+        if {$idx < 11} {
+            if {$j >= 14} {
+                append key ".,ky=-la r@:@67n"
+                string map {a b c d} "3n"
+            } else {
+                expr {80}
+            }
+            append i 66
+            lassign {-970 233} z item n
+            set z -21.49
+        } else {
+            if {((-$buf) < (!79))} {
+                set b "wf7@u#"
+                set a b
+                expr {(((28 >> 48) >= (-30 ? -26 : -67)) <= ((~$idx) * ($item ** 66.17)))}
+                string toupper "pl-?uq03d_pb??e1"
+                string range "7a r?:a!?z" 0 7
+            } elseif {$a > -8} {
+                set data -53.68
+            }
+            append buf -926
+            expr {(-((~38) | (-92 != $key)))}
+            set b cjn
+            set i {75.56 -10.07 -460 -562}
+        }
+    } else {
+        set buf 0
+        while {$buf < 4} {
+            append count 31
+            append key "t26zfr"
+            set y 0
+            expr {(-86 + -83)}
+            incr buf
+        }
+        lassign {ietw 121 dpff no -394 47.78} idx
+        set x [expr {((wide($data) ? (-73.69 ? 30 : 73) : (-62 ? $tmp : 22)) ^ ((-35.23 >= $z) ? 19 : (!-56)))}]
+        expr {$y}
+    }
+    expr {-95}
+    if {(~($j ** -77))} {
+        set n false
+        set key "a ;ad3w,m"
+        expr {((~(75 + 48)) - ((-30 % max(1, abs($tmp))) ^ double($i)))}
+        append a "q+e ij0h81okf!tu!4  "
+        set z 0
+        while {$z < 4} {
+            append i "b;3#"
+            string index "a8r4:y60k#1c23d ?" 5
+            for {set n 0} {$n < 6} {incr n} {
+                set tmp 69
+                incr tmp -2
+                set tmp 0
+                expr {((double(40) ? -75 : ($key | 2)) ? wide(-90.32) : ((~2) * min(-18, 70)))}
+                string index "lndi6#x5-# !#::_" 5
+                append idx 46
+                string index "t3e" 5
+            }
+            set tmp 48
+            incr tmp 10
+            expr {max(-96, (~wide(87)))}
+            set acc 97
+            incr acc 7
+            incr z
+        }
+    }
+    expr {(--50.11)}
+    expr {round(((44 > 35) < round(-26)))}
+}
+if {$tmp} {
+    set key yes
+    set i 6
+    incr i 6
+} else {
+    for {set data 0} {$data < 3} {incr data} {
+        if {$z <= 5} {
+            set y 92
+            incr y 3
+            set z 0
+            set a -693
+            lrepeat 1 -41
+        } else {
+            regexp "^[a-z]" "2uwd4"
+            set item au
+            set buf {}
+        }
+        for {set count 0} {$count < 4} {incr count} {
+            expr {(((!73) << 32.17) < (!(-69 != $data)))}
+            set y 34
+            incr y 7
+            lsearch {} "sxsqqyd3db13muuo:-#"
+            lassign {yes 1 no} a item flag
+            set data [expr {min(round(($i * 56.09)), $flag)}]
+        }
+        append a ".cwfgr"
+        set item rgqgho
+        string index "c+nrz=1zl" 4
+    }
+    set x -581
+    append j -979
+    set b 70
+    incr b 5
+    set key 0
+    while {$key < 4} {
+        set a 0
+        while {$a < 4} {
+            set j {}
+            incr a
+        }
+        incr key
+    }
+}

--- a/fuzzing/findings/seed_1774200051.json
+++ b/fuzzing/findings/seed_1774200051.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200051,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200051.tcl
+++ b/fuzzing/findings/seed_1774200051.tcl
@@ -1,0 +1,496 @@
+foreach idx {ckx no} {
+    if {$idx > 0} {
+        catch {
+            set result -876
+        } y
+        string trim "5yo_#@es?l.0ufz_06"
+        if {((29 == $result) ? abs(-21) : -60)} {
+            append y -69
+        }
+        expr {(58 ** 29)}
+        switch -- -21 {
+            46 {
+                append y 57
+                set y 0
+                while {$y < 1} {
+                    string repeat "3n97u3v7hyd_-?:" 3
+                    set idx {-621}
+                    set idx "nem"
+                    string range "i?.#oi" 2 4
+                    lreverse {686 -452 61.62 -226}
+                    incr y
+                }
+                expr {((!98.21) ? abs(($idx > -27)) : (!-98))}
+            }
+            default {
+                expr {86}
+                foreach result {} {
+                    set y r
+                    set idx 1
+                    incr idx 0
+                    string trimright ",nq3hcytxl3v"
+                }
+            }
+        }
+    }
+    expr {(((!-7) == -12) ? (-59 <= 76.88) : (!-89.97))}
+}
+set result [expr {-71}]
+foreach result {} {
+    for {set idx 0} {$idx < 1} {incr idx} {
+        lindex {swj no 426} 3
+        set result [expr {(((4 >= $result) >= (-14.15 == 57)) ^ (-(91.29 / max(1, abs(42)))))}]
+        switch -- 23 {
+            "ktxwo#l@7uhmzp" {
+                set y 56.45
+                lassign {263 -396 831 0 79 613} y idx
+            }
+            "ziy?i+5" {
+                set result "=by;b!1vronl571-f"
+                expr {int(((-94 || -55) & abs($y)))}
+                set idx 16
+                incr idx -4
+                set buf 0
+            }
+            default {
+                string map {a b c d} "6ktbn#ig"
+                set result -80.91
+                append acc 40
+                expr {(round(($buf ** $acc)) ** (-1.10 ** (93 - 85)))}
+            }
+        }
+        set tmp 80
+        incr tmp 8
+        set tmp {-55.86 yes}
+    }
+}
+set count 0
+while {$count < 5} {
+    regexp "\\d+" "@s02_33o.856p3p04-"
+    incr count
+}
+if {$y < -2} {
+    foreach msg {yes} {
+        set result {no}
+        set i 9
+        incr i 1
+    }
+}
+foreach acc {-690 562 hx} {
+    set tmp 1
+    switch -- -28 {
+        79 {
+            lrange {629 lbkiabi ixzhgx y 944 -151} 2 3
+        }
+        -274 {
+            lrange {tztkbuf 529} 1 3
+            foreach y {-24.33 169 879 469} {
+                expr {(~((-22) ? round(-51) : max(21.10, 34)))}
+                set flag 90
+                incr flag 10
+                expr {round(((35 ? $tmp : 75) >= (~-4)))}
+                set y "9#7! #jk"
+                set item 56
+                incr item -2
+            }
+        }
+        "vb;ecicjn9tx" {
+            switch -- "cv#" {
+                "?2im47co69h@" {
+                    expr {round(((!79.54) ? (-61.74 ** $y) : $flag))}
+                    set buf "k18!covllwt5-rc6 kp7"
+                    lassign {hgmnw} i y
+                    expr {($flag - (-60))}
+                    set y babjg
+                    set i -60.12
+                }
+                1 {
+                    set result {oy}
+                }
+                default {
+                    expr {min(((~55) >> (-89.81 ? 13 : 79.91)), $idx)}
+                    expr {double($count)}
+                    set flag "r 8=v"
+                }
+            }
+        }
+        " phm4ny9 :?,jx4?" {
+            string repeat "j?2b02kd;j;yq.._d_?" 1
+            set y aut
+        }
+        default {
+            for {set j 0} {$j < 4} {incr j} {
+                set count uiqp
+                expr {(!(-(!38.52)))}
+                for {set acc 0} {$acc < 6} {incr acc} {
+                    set msg 4
+                    incr msg -3
+                    set msg "sj,+m6h@j;"
+                    set result {31.62 71.21 yes 483 true doox}
+                    join {no 68.17 36.33 oyly -531} " "
+                    lassign {dwygzr} flag flag acc
+                }
+                set x 790
+            }
+        }
+    }
+    expr {(50 | ((-75 ? 4 : 28) < 22))}
+    foreach msg {45.57 0 1 0 -53.61} {
+        set msg 579
+        expr {(((!-46.18) ? -68 : 10.05) || ((24 ? $j : 73) == (-76 / max(1, abs($x)))))}
+        set a [expr {((-59.93 ? (~$y) : (8 >> 20)) + 42)}]
+    }
+    for {set flag 0} {$flag < 2} {incr flag} {
+        if {((43 ? 10 : $buf) ? ($acc << -39) : -26.36)} {
+            set tmp ":-i hb"
+            lassign {no -675 -81 120 qdtdp v} key acc x
+            expr {($result >> (int(39) != 5))}
+        }
+    }
+}
+for {set result 0} {$result < 4} {incr result} {
+    regexp "[a-z]+" "wnj?uicae9ovy426,js"
+    set msg {-2.15 -490 -309}
+    for {set result 0} {$result < 2} {incr result} {
+        append tmp lvgtdo
+        string first "a" "._,x;coo_.q1q2"
+        lsort {iex -477}
+        expr {wide((round(61) >> (78.02 ^ -71)))}
+        switch -- "1y-6plbq_-1" {
+            -15 {
+                set msg {338 -643}
+                append j "!lv:;d0a"
+                switch -- 52 {
+                    41 {
+                        string length "r4o#1sx1co#!mx"
+                        expr {$item}
+                        set result [expr {-65}]
+                    }
+                    3 {
+                        set count yes
+                        lassign {-676 -162 -21.03 oi f} buf
+                        append key "w@b9p:_g2c"
+                    }
+                    default {
+                        set idx "ecr:u-s6=.f fqvlvm"
+                        string trim ":t.houh5,gty0=4=pi.4"
+                        string trimright "?1?3b==:gjf"
+                        set n 60
+                        incr n 10
+                    }
+                }
+                regexp "[a-z]+" "af:@@t7._9"
+                expr {(46 & int(-23))}
+            }
+            67 {
+                expr {(-57 / max(1, abs(double((70 <= -41)))))}
+                set a 6.66
+                set msg 64
+                incr msg -4
+                string repeat "5" 2
+                string trimright " "
+                append n -7.30
+            }
+            wrcsl {
+                set data 0
+                while {$data < 2} {
+                    expr {((($x ? 17 : $i) >= (86 <= 45)) || -89)}
+                    regexp "^[a-z]" "rzu#1r7gs"
+                    lsort {-947}
+                    incr data
+                }
+                set x -119
+                set a 99
+                incr a -1
+            }
+            "e!z" {
+                lsearch {} "ukd6.b"
+            }
+            default {
+                expr {(((3 != $msg) ? ($result - 26) : (!-16.39)) - (-(-19.55 && $x)))}
+                set item "pj6- !ujovrib-y2:,p"
+                string index "mg+p261ak,g1," 0
+                expr {-26}
+            }
+        }
+        set key 559
+    }
+    if {((!28) + 42)} {
+        regexp "[a-z]+" ""
+    } elseif {((77 | 60) >> round(89))} {
+        foreach acc {728 584} {
+            set x -49.96
+            set n no
+            foreach msg {260} {
+                join {555 tjpejud 795 1 -44.44 pzw} " "
+                set result false
+            }
+            regexp "[a-z]+" "uj_;+6jmwvawdi"
+        }
+        set a 38
+        incr a -3
+        if {(int($j) || max(-86.51, 2))} {
+            set x 0
+            expr {(($a >> (-56 != $y)) / max(1, abs((-80 % max(1, abs((-89.55 - 57)))))))}
+            if {(($buf - -8.23) ? (52.75 || $a) : 20)} {
+                set j {-581 -371 59.12 -434 -18.29 79.12}
+                lappend j "#zznq5"
+                append n 3
+            }
+        }
+        foreach j {1 no 72.71 412} {
+            append item 747
+            set idx -555
+            string repeat "" 2
+            expr {((($count != 2) - (37 >> -43)) ? 36 : (($y / max(1, abs(-34.42))) % max(1, abs(($n ** -43)))))}
+            set msg -155
+            set y zmydg
+        }
+        lassign {565 -47 586} key a
+        if {22.18} {
+            lsort {22.24 76.28 oqbtkvuy enxg}
+            set idx {-180 false yes}
+            set x {vvjpka 305 false}
+            append j -402
+            set idx 90
+            incr idx 7
+        }
+    }
+    lassign {nx vqvv -954 yes false 859} a
+}
+expr {$n}
+if {$count > 17} {
+    catch {
+        regexp "[0-9]" "h 5lude2f+4bs+i04"
+        set count 11
+        incr count 8
+        expr {((-53.79 && (-2.50 ? 15 : $item)) * ((90 >= 1) != (46 * 14)))}
+    } data
+    catch {
+        expr {($tmp - ((49 << 25) <= (!-17)))}
+        set a 22
+        incr a -3
+        expr {(((23 >> 36.72) << (!-96.62)) >> ((9 <= -78) ? (-57 + -80) : $y))}
+        expr {($count != (-(-73 ? $result : 62.06)))}
+        for {set key 0} {$key < 4} {incr key} {
+            set key 53
+            incr key -3
+            append acc "wk749d@xw22"
+            set buf [expr {(((-61 ? $y : 19) | (~-11)) << (min($n, 0.50) >> $data))}]
+            set x 0
+            append count 20
+        }
+    } j
+    for {set a 0} {$a < 3} {incr a} {
+        append val rrbt
+        string range "k" 3 5
+        set idx -757
+    }
+    expr {(43 > ((9 ? 54 : -33.01) * (-1 ? 49 : -17)))}
+    for {set i 0} {$i < 3} {incr i} {
+        set acc "m5izm=jx!=z.d "
+        set key -81.95
+    }
+    switch -- "l7?2.lx;0" {
+        -70.80 {
+            catch {
+                set key 764
+            } result
+            expr {88}
+            expr {((13 ? (35.79 || 37.59) : (67 && 96)) ? round($acc) : -36)}
+            string toupper "d?0_u7:"
+            if {$msg == -4} {
+                set val {496 -53 -607 -32.12 575}
+                set buf {minfyxv -657 kwttuwb 873}
+                lappend buf -608
+                expr {-2}
+            }
+            set b "u !-vc5=um4"
+        }
+        19 {
+            append val "_=vo1-o"
+            expr {(((~-45) << -44) ? (9 > -46.89) : ((65.63 ? 95.05 : 15) ^ (-100 && -68)))}
+            catch {
+                append buf -128
+                expr {-27}
+                set a 15
+                incr a -3
+                expr {(abs(72) >> (wide(39) ? 29 : (91 >= 26)))}
+                switch -- "c4.bpfsl94n8zxad" {
+                    1 {
+                        set item 87
+                        incr item -5
+                        regexp "[0-9]" "fx_k:8_;0uaux8-dlez"
+                    }
+                    default {
+                        append b "0,4f;j6:+"
+                        lrange {fyjkjt -47.63} 2 4
+                        concat {36.03 -7.95 539} {-57.89 -348 -16}
+                        expr {-64}
+                    }
+                }
+                append acc no
+            } x
+            for {set result 0} {$result < 2} {incr result} {
+                set item no
+                set idx 0
+                while {$idx < 2} {
+                    expr {-36.08}
+                    lsearch {1 da 1 -354 -57.68 ljpdhk} -91
+                    expr {-21}
+                    lassign {-263} a data
+                    incr idx
+                }
+                set x 2
+                incr x 2
+                set acc [expr {(int(0) > -60.03)}]
+                set count "=evy5d_oon-;on9=+b"
+            }
+            lassign {967 749 466 btnxiay -788 460} j b data
+            string range "hlpigt@9vecch5yjem?t" 0 2
+        }
+        14 {
+            set acc 70.11
+            string tolower "vs;ox_abr?c@srln q"
+            if {$idx == -3} {
+                regexp "." "phdhijypt40h4bqe"
+                expr {47}
+            }
+            lassign {mytxctq} acc
+        }
+        default {
+            append data "6x3;bj+9y6oki8b+g"
+        }
+    }
+} else {
+    set data 0
+    append buf 691
+}
+append count "ro9u"
+if {$x >= 14} {
+    set buf true
+    set result "3z"
+    for {set n 0} {$n < 6} {incr n} {
+        lassign {27.16 true -30.79} msg
+        set acc 0
+        while {$acc < 4} {
+            set key 75
+            incr key 9
+            incr acc
+        }
+        append j ":1:5e i a1"
+        set count {asjykm pozhbv -621}
+        lappend count 1
+        set x no
+        foreach i {no} {
+            expr {((-39.81) * -43)}
+            lsearch {-134 83.05 true} ".bfx#opki1cqhra9_82t"
+            append result -80.91
+            string trimleft "eb#?8b#3:4xe"
+            set b "ju wmr-qm8"
+            expr {($b << ((50.54 <= -60) || (!-33)))}
+        }
+    }
+    expr {(-42 - ((18 >> 66) % max(1, abs((19 ? 31.40 : $idx)))))}
+} else {
+    set a 0
+    while {$a < 5} {
+        if {35} {
+            expr {-49}
+            append b 319
+            string reverse "li7"
+            lindex {94.60 eqxkhwkp nfr 949 false 67.83} 3
+            expr {(~(-5.94 ^ round(83)))}
+            set idx ", @hy3id"
+        }
+        set idx [expr {$b}]
+        append n 3
+        append item "5;@w-8d823k6jf"
+        set item 97
+        set msg yes
+        incr a
+    }
+    switch -- -97.41 {
+        -30 {
+            switch -- "-?.=5x.+g" {
+                "vys0v6a5f5kx." {
+                    set val 49
+                    incr val 5
+                    foreach z {390 0 36.40 true} {
+                        llength {-401 pvpf}
+                        set x {false}
+                        set n 63
+                        incr n 1
+                        append b "t=gtmo3?bz @x2.pb5vk"
+                        append a -650
+                    }
+                }
+                71 {
+                    append x -80
+                    for {set buf 0} {$buf < 2} {incr buf} {
+                        set val -48.48
+                        set i {vubro -131 -980 -36.61}
+                        expr {(((!83.95) >= (-16.74 < -64.71)) - ((-23.04 ? -77 : -98.18) ? (14 > $data) : (-10 ** $b)))}
+                        string range "?sp9+;5t73xivt:w155w" 0 2
+                        expr {min(((~77) <= (--27)), (($z ** $j) << ($tmp <= 27)))}
+                        lassign {false kjiws 93.60 hjrfyuf 610 0} buf x j
+                    }
+                    string repeat "lw:c?_x7gm" 3
+                    set flag -4.98
+                    string trim "in=w=ubia.r4nt-0412"
+                }
+                default {
+                    append buf -5.23
+                    set val {93.11 -351 -884 -296}
+                    set item 945
+                }
+            }
+            expr {abs((!-100))}
+            set key [expr {(((-61 <= -19.92) << -84) < ((88 << -79) ** (-$i)))}]
+            set y [expr {(14 ? ((~76) > $n) : -60.43)}]
+            set n -626
+        }
+        irjpsnam {
+            for {set acc 0} {$acc < 4} {incr acc} {
+                set flag {}
+            }
+            expr {((double(98) || -8.11) << ((-11) + -8))}
+            foreach result {748 153 false 95.24 -643} {
+                set count iyo
+                set count -96
+                regexp "." ";:ncddj2;-b4a2r08lh"
+                string reverse "k:;=,@;5cqt3l-5s2"
+            }
+            expr {int((32 & (-$idx)))}
+            llength {654 -959 -151 1 724}
+            for {set count 0} {$count < 1} {incr count} {
+                append n no
+                set msg {488 -831 47.15 x true -95.99}
+                concat {ovuaoiu -336 -885} {-700 c 6 99.67}
+            }
+        }
+        default {
+            set tmp -76.14
+            set data 1
+            foreach a {vhbpk 25.62 as -481 -31.71 w} {
+                string map {a b c d} "?l"
+                string trimright "8yz!.t2y#un8ycj="
+                set x 0
+                while {$x < 1} {
+                    join {} ""
+                    expr {((-(!$val)) ? $b : abs((98 && $msg)))}
+                    set x true
+                    incr x
+                }
+                set idx 44
+                incr idx 3
+                set data {mobrqzkn 14.67 918}
+                expr {(33.93 ? -70 : (!($result ? 35 : 14)))}
+            }
+            append flag -40
+            append tmp "n;kp_qb,:_x=etc.."
+        }
+    }
+    append flag "w1lf08z;acaomczr!vb:"
+    append j -78
+}

--- a/fuzzing/findings/seed_1774200052.json
+++ b/fuzzing/findings/seed_1774200052.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200052,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200052.tcl
+++ b/fuzzing/findings/seed_1774200052.tcl
@@ -1,0 +1,78 @@
+for {set y 0} {$y < 2} {incr y} {
+    string range "at-00njne5-dx" 1 6
+    for {set tmp 0} {$tmp < 2} {incr tmp} {
+        set tmp "07?v;.l"
+        set y -5.20
+        for {set tmp 0} {$tmp < 1} {incr tmp} {
+            switch -- xdlktco {
+                -27 {
+                    string trimright "y6,c8n=3pagsai7"
+                    string repeat "4!roog:q_w#f=" 0
+                    lassign {} y idx
+                    append idx ";lgr?r!,jm7"
+                    string range "wvyw:7p-2" 5 6
+                }
+                "ul0x!w.-56_mg" {
+                    regexp "[0-9]" "+c:q"
+                    set idx -86.26
+                    set y [expr {(-((-45 % max(1, abs($idx))) ? ($tmp ? $tmp : 22) : abs($idx)))}]
+                    set acc [expr {((-95 == $idx) << (-62 >> (-90.35 >> 24)))}]
+                    lsearch {} 0
+                    lassign {-10.94 dnrz 75.82 xomjf} x
+                }
+                -61 {
+                    set x {bjlkqyn yes ww fcw}
+                    append j 31
+                    append idx 0
+                    append idx " z+"
+                    expr {-40}
+                }
+                default {
+                    lassign {349 -28.03} item
+                    set x [expr {(((99.51 && -44) << $acc) ? -48 : (($x / max(1, abs(89.66))) ? (-31) : max(48, $idx)))}]
+                    expr {(~92)}
+                    set acc false
+                    lindex {vntrd} 2
+                }
+            }
+            set j 88
+            incr j -5
+            set tmp [expr {((($idx && 67.25) ^ $y) & (!-71.28))}]
+            set idx "iahye8o6c,+_r.7t_j#i"
+            set x {ej 1 false false 9.60 -229}
+            string repeat "m3=2fy_fci_cv1" 2
+        }
+        expr {(-36 >= 98)}
+    }
+    string trimright "8p#?oudmt"
+    set tmp 79
+    incr tmp 5
+    catch {
+        append x -355
+        set y [expr {((-(-17)) && 73.36)}]
+        lassign {eebo 103 no} y n n
+        append tmp 53
+    } flag
+    lassign {465 28 21.74 -597} x idx
+}
+set flag 0
+while {$flag < 1} {
+    string trimright "kn5+"
+    if {$n > 16} {
+        set j " gmmwf1"
+        expr {($y && 7)}
+        lassign {no} tmp msg y
+        set x 0
+        while {$x < 1} {
+            expr {22}
+            set item 310
+            set flag -790
+            incr x
+        }
+    }
+    expr {$idx}
+    set n 29
+    incr n 9
+    append tmp johofcrz
+    incr flag
+}

--- a/fuzzing/findings/seed_1774200058.json
+++ b/fuzzing/findings/seed_1774200058.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200058,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200058.tcl
+++ b/fuzzing/findings/seed_1774200058.tcl
@@ -1,0 +1,318 @@
+lassign {} x x count
+proc build {flag {n -132} acc} {
+    if {(($count ? 36.57 : 77.73) >> (-79 * 46))} {
+        foreach x {tmlyc 652} {
+            expr {(-70 ** 38)}
+            set item [expr {(21 > ((53.28 ? $item : $item) ? (!79.19) : (~-40)))}]
+            expr {((double(-12) == ($x >> 74)) != ((!$x) == (19 * 92)))}
+            append x 798
+        }
+        foreach j {brd} {
+            join {-84 0 79.60 ilv -64} ""
+            switch -- no {
+                "a80w" {
+                    lrepeat 2 -58
+                    regexp "\\d+" "=sb_xx+.jjau"
+                    set count 9
+                    incr count 3
+                    set count -761
+                    append n -100
+                }
+                "bw_xbr=okj=0pw38" {
+                    set j [expr {(65 ? 2.75 : (-(4 && $n)))}]
+                    expr {(!abs($n))}
+                    set n [expr {(wide(-8) ? 34 : ((~33) % max(1, abs((-37 >> -83.70)))))}]
+                    append flag 87.00
+                }
+                13 {
+                    expr {-6.10}
+                    lsearch {766 -167 yes 938 311 463} no
+                    set j 751
+                }
+                yes {
+                    set n qxbf
+                    lreverse {-389 16.97}
+                    set x {974 557 d wxv}
+                    lappend x "v#pk8b6g"
+                    set n [expr {(~((59 ^ -66.18) ? (18 > 17.84) : $j))}]
+                    expr {(25 && ((-36.65 ^ -6) ? (!94) : wide(-54)))}
+                }
+                default {
+                    lreverse {-21.43 m 894}
+                    set a {8.65 db 84.92 izi yes -202}
+                    set i [expr {$j}]
+                    expr {(!(double($flag) / max(1, abs((2.36 && 43)))))}
+                }
+            }
+            if {$x == 15} {
+                string index "pn2@fy?qa" 0
+                expr {-74.51}
+                string last "a" "9h +!4@_e"
+                expr {-42}
+            } else {
+                set flag -741
+                string trimleft "ui"
+                lassign {0 903 -11.03 sxcec} count flag count
+                lrepeat 2 -78.57
+            }
+            string length "cz7tudj,?!.2d"
+            lassign {695 0} count n
+        }
+    } else {
+        set msg 0
+        while {$msg < 2} {
+            foreach msg {u yes -694 no 803 495} {
+                set idx 881
+                expr {(-49 < ((~$msg) - -81))}
+            }
+            string toupper "z-j12j"
+            set a -364
+            expr {(($j / max(1, abs(($x ^ -53.37)))) <= ((-30 ^ 48) != (-64.69 ^ 2.85)))}
+            incr msg
+        }
+        lassign {-45.35 -615 true 767 621} j msg
+        for {set b 0} {$b < 3} {incr b} {
+            expr {42.82}
+            set count 352
+        }
+        expr {(int(abs(87.71)) ? -86.53 : -54.79)}
+    }
+    if {$a <= -4} {
+        if {87.95} {
+            set x ahhrc
+            expr {(3 & 85)}
+            if {$flag <= -8} {
+                expr {(((-3 < -43.25) ? $item : (81.44 ? -67 : 44)) != (-12 << abs($x)))}
+                set item [expr {21}]
+                expr {(((!$item) << 57) << $i)}
+                expr {-35}
+                lassign {-491 -6.73 190 8 -31} n tmp
+                set msg 35
+                incr msg 10
+            } else {
+                string tolower "g2=ro:hl"
+                append msg "hloc1-o@?+jy_g1kagl"
+                set a -994
+                lassign {529} msg a
+                string range "0e64i.t:a!g?ht" 2 6
+            }
+        } else {
+            expr {(58 ? ((~-8.71) == (-64 ? -49 : 68.83)) : 89.07)}
+            expr {(~((~36.17) ? 50.69 : (6 ? $n : $i)))}
+        }
+        expr {(!abs((-72 ? $idx : -27)))}
+        catch {
+            set acc " "
+            if {((-5 ? 98 : -54) ? -2 : 40)} {
+                set a 910
+                set j pykddp
+                string trimright ""
+                expr {(40 & (!(!$tmp)))}
+            } elseif {$idx == 10} {
+                expr {(~(-(!-17.43)))}
+                expr {(!$tmp)}
+                expr {(--39.96)}
+                set j {-20.75 -181}
+                append flag "30;l4?"
+            }
+            string map {a b c d} ";kvamnfa t6s;3y#"
+        } tmp
+        set x {lcqs mmd npktuev false}
+    } else {
+        set count {0 -264}
+        lsort {26.74}
+        append acc 4.21
+        append count true
+    }
+    foreach i {qxfocvo 1 no 40.94 881} {
+        expr {$j}
+        expr {(~32)}
+        set i 0
+        while {$i < 2} {
+            set flag 9
+            incr flag -2
+            lsort {dr -704 vrpspa vtlv no}
+            append b -22
+            incr i
+        }
+        set flag {-830 qwc -951 false}
+        catch {
+            set flag -42.78
+            lassign {311 -517 false yes} a msg i
+            set result 83
+            incr result 10
+            string length "=u3s=+.g!,yi5.ea"
+            concat {yes -166 gqtpkkzs} {56.60 -662 -13.84}
+            set x dszilel
+        } acc
+    }
+    foreach result {no -25.09 pun -880 -694} {
+        set z 0
+        while {$z < 3} {
+            for {set item 0} {$item < 2} {incr item} {
+                lindex {dllkl 489 1 -129} 2
+                string trimright ""
+            }
+            for {set idx 0} {$idx < 6} {incr idx} {
+                set msg 54
+                incr msg 7
+            }
+            set x {-976 -870 -193 0}
+            incr z
+        }
+        for {set idx 0} {$idx < 3} {incr idx} {
+            append data "cg#:iw1,:ab3ut"
+        }
+    }
+    set y 0
+    while {$y < 1} {
+        expr {(-((-67 ? -89 : -38) != (64 < $b)))}
+        incr y
+    }
+    return ""
+}
+for {set x 0} {$x < 2} {incr x} {
+    expr {(~(($x ? 35 : $acc) ? (42 ** -29) : round(90.76)))}
+    set idx 0
+    while {$idx < 3} {
+        expr {-27}
+        switch -- 24.54 {
+            rcagh {
+                catch {
+                    append x ueeggt
+                    regexp "[0-9]" "2cl2q;fcrbg6!@w?"
+                    expr {-12.73}
+                    set a 41.41
+                } y
+                set a -729
+            }
+            -496 {
+                expr {(~(-(-15)))}
+                catch {build }
+                catch {build ":brh#i@8o110zo+4" 59 "#s6ww2x:"}
+                expr {abs((wide(61.49) <= (~69.78)))}
+                set item -82.65
+                catch {
+                    expr {$tmp}
+                } acc
+            }
+            default {
+                expr {-3.29}
+                expr {(!((~-52) > (95.36 && $data)))}
+                expr {min(((31 % max(1, abs(39))) ** min(-20.77, 94)), double((-9)))}
+            }
+        }
+        incr idx
+    }
+    append a -98
+    expr {67}
+}
+expr {(70.93 && ((42 == -85) < (68 % max(1, abs(68)))))}
+proc combine {{a jvyg} {data 899}} {
+    append y 82
+    switch -- 31 {
+        adn {
+            foreach flag {1} {
+                lassign {i 51.39 0 -79.34 -431 hdg} j n
+                set count "+vlx#.3?5s3"
+                set b 464
+                set item 32
+                incr item -5
+                string toupper "kribd5"
+                regexp "[a-z]+" "gmyg_+c36bc@k"
+            }
+            string toupper "vm#@ph0 ?9m5w,9 -s"
+            set a -962
+            for {set b 0} {$b < 4} {incr b} {
+                set item {}
+                set count 98.96
+                regexp "\\d+" "lcu18i"
+                if {(~-29.48)} {
+                    regexp "\\d+" "667z1t"
+                    set msg 0
+                    string first "a" ""
+                }
+                expr {min(((51.01 >> -19.70) ? min(74, 90) : 25), (max(4.31, 7) - max(6, 50)))}
+            }
+            set msg [expr {-42}]
+            for {set n 0} {$n < 3} {incr n} {
+                set msg 49.27
+                set a 58
+                incr a 6
+                append count "vfy;2=v+j"
+                set y 6
+                incr y 10
+                switch -- 10 {
+                    91 {
+                        string tolower "qb@k+"
+                        append x -10
+                    }
+                    default {
+                        regexp "\\d+" "fj_!da;5xsfmb@c"
+                        set b "?vd_ wp3l"
+                        set n "8t79zbn-waku#ze"
+                        set i 59
+                        incr i 7
+                    }
+                }
+            }
+        }
+        default {
+            lrange {-55.27 125 60 430 1 72.13} 0 3
+            set count "?+uj"
+            append a -91
+            set acc 59
+            incr acc 8
+            set flag "1d+ul;#"
+            for {set y 0} {$y < 6} {incr y} {
+                catch {build -24 "kk;:y4" "j#2u-y9"}
+                set msg [expr {40}]
+                concat {iivcshoz g rmbx kwjmfcv} {}
+                set count tygtjjfu
+            }
+        }
+    }
+    append x -300
+    return 0
+}
+if {$idx > -7} {
+    for {set n 0} {$n < 2} {incr n} {
+        set msg [expr {(((-72.24 * 56) && 43) || max(28, $acc))}]
+        regexp "." "1qy"
+        expr {($a / max(1, abs($tmp)))}
+        set i hnbgo
+        append msg abdhs
+        catch {build -28.79 -219}
+    }
+}
+append y "u2#"
+if {(($x && 38) && (!-71))} {
+    set val false
+    set flag {952 pkw 1 no hu bqpynkvt}
+}
+proc combine {i idx b} {
+    set val "6z@gh7mai34f"
+    set j {-950 68.18 167 578}
+    lreverse {}
+    append x 92.10
+    set y 0
+    while {$y < 1} {
+        foreach item {-54.60} {
+            for {set flag 0} {$flag < 3} {incr flag} {
+                string first "a" "=+=_l14fuk:jpb"
+                append acc -344
+                set i {wtavbvwu 780 -43.21 lei}
+            }
+            concat {scidx lqsbbex false 398 -391 -65.10} {orsfrsl -934 true 867 453}
+            for {set item 0} {$item < 3} {incr item} {
+                catch {combine iyazv -27 -1.47}
+            }
+            string toupper ""
+        }
+        set b "pm!!a@t7!l.jdv=_w;"
+        expr {($b ? (-90 + ($j > -38.43)) : ((87 && -47) ? (-16 | 83.21) : $count))}
+        append item ""
+        incr y
+    }
+    return "#1pm2r:"
+}

--- a/fuzzing/findings/seed_1774200060.json
+++ b/fuzzing/findings/seed_1774200060.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200060,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"0@f.f-96\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"0@f.f-96\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200060.tcl
+++ b/fuzzing/findings/seed_1774200060.tcl
@@ -1,0 +1,221 @@
+set buf 0
+while {$buf < 5} {
+    append buf "@f.f"
+    append buf -96
+    incr buf
+}
+proc helper {{tmp 196} n {msg jxfd} flag args} {
+    foreach tmp {211 -56.36 709} {
+        set buf 0
+        while {$buf < 4} {
+            regexp "[0-9]" "4pmk"
+            set x 70
+            incr x 5
+            regexp "\\d+" "pl=m3x6b1z+6o38y:xum"
+            string trim "a."
+            set buf 74
+            incr buf 1
+            regexp "^[a-z]" "r;bsnyb7q"
+            incr buf
+        }
+        lsort {-87}
+        set count "pxn0h:oilyt ox3"
+        set a {-469 698}
+        concat {697 -58.25 gakjylj 833 false dmjp} {-535}
+        expr {(!(!(-$buf)))}
+    }
+    set acc 0
+    while {$acc < 1} {
+        expr {(((-45 > 61) ? ($a > -59) : (-23 || -47)) | $buf)}
+        incr acc
+    }
+    set tmp {}
+    lappend tmp "4s8w9u_zt8ech3"
+    switch -- "0@_t,z685c0m39li7o " {
+        198 {
+            for {set acc 0} {$acc < 4} {incr acc} {
+                append buf 13
+                append buf "zy.id3gy:jn?@9"
+            }
+            concat {-91.48 no} {-71.08 jrtg -966}
+            set a "ras!9"
+            set b 16
+            incr b 4
+            set b 39
+            incr b 3
+            append tmp ":db0i03:."
+        }
+        default {
+            set key 73
+            incr key 3
+            string trimright ""
+            regexp "[0-9]" ".8bem+kbu"
+            foreach i {-21.77 836 1 ef no} {
+                for {set x 0} {$x < 4} {incr x} {
+                    regexp "." "81@"
+                    expr {-28}
+                    string last "a" "f4##waew7i1j"
+                    set acc 67
+                    incr acc 2
+                    lassign {} x a
+                }
+            }
+            catch {
+                lreverse {no aip false -13.17 no}
+                set acc 59
+                incr acc 3
+                list ""
+            } x
+            string tolower "67@"
+        }
+    }
+    lassign {771} key result
+    return 9
+}
+proc compute {} {
+    foreach y {-33.62 -970} {
+        lassign {382 39.05 true -894} flag i data
+    }
+    return 12
+}
+foreach flag {isvqexjp -129 -906} {
+    lassign {} i x acc
+    append count 49
+    expr {(!(54 & (-49 >> $a)))}
+    if {(~$data)} {
+        set a 26
+        incr a 2
+        append data 32
+        lassign {47.86 85.72 41 65 989} j i x
+        catch {helper ef}
+        lsort {-25.53 1 -906 889}
+        set result " .#,k1kpcdt,v:7 9;"
+    } else {
+        if {$y < 16} {
+            set data 609
+            expr {(~59)}
+        } else {
+            set j -788
+            for {set flag 0} {$flag < 5} {incr flag} {
+                append data -81
+                expr {-69}
+                catch {helper "g2f=w b3l#_" 24 0}
+            }
+            string first "a" "ln0k_;k8f?"
+        }
+        append count 6
+        set x 0
+        while {$x < 4} {
+            expr {(-69 == (($result >> $key) | 16))}
+            set key "4mzup"
+            lassign {} buf msg tmp
+            expr {(~(-36 % max(1, abs(($data < 4)))))}
+            expr {42}
+            incr x
+        }
+    }
+}
+append flag 7
+foreach z {-8.32} {
+    if {$msg == -6} {
+        set buf 57
+        incr buf -1
+        for {set tmp 0} {$tmp < 1} {incr tmp} {
+            set j 0
+            while {$j < 5} {
+                set x -204
+                append buf 27
+                regexp "\\d+" "upoo#syd33!"
+                set z 44
+                incr z 0
+                expr {(58 == (-(--33.36)))}
+                expr {(wide(abs(-76.57)) ? ((-58 ? -39.95 : -43) << 59) : $acc)}
+                incr j
+            }
+            catch {compute -8 -8 -64}
+            set a "k+?!1!8?82xp-bn"
+            if {((!$data) << (73 % max(1, abs(-66))))} {
+                set buf -4
+                append data -6
+                set b true
+                set data {true 208 yes}
+            }
+            set b -496
+            lrepeat 2 -13
+        }
+    }
+    if {(!min(-67.24, 58.82))} {
+        foreach b {yes} {
+            expr {(-20 == 73)}
+            append b -57
+            expr {($i >= -71)}
+            switch -- mnvmlva {
+                "58++r4;ni762@f4" {
+                    set buf 21
+                    incr buf 8
+                }
+                616 {
+                    expr {(($acc / max(1, abs((69.15 ? -100 : -3)))) ? 8.01 : (!-24))}
+                }
+                "0" {
+                    expr {-43}
+                    set idx 29
+                    incr idx 6
+                    set flag -69
+                    set buf 1
+                }
+                -58 {
+                    regexp "^[a-z]" "ox_.zbr;3vl=2ol4."
+                    expr {$j}
+                    string last "a" "rx:50w_7;z@#uco@"
+                    set j 65
+                    incr j -4
+                    lrange {} 3 4
+                    concat {-249 19} {-134 no}
+                }
+                default {
+                    set b n
+                    set tmp {ambotkky -344 546 w}
+                }
+            }
+            set x 82
+            incr x 0
+        }
+        set result {1 pqnevrd -413 846 244 -5.79}
+        append b "22ww2:"
+        set data 22
+        incr data -2
+    }
+    concat {spbbup 82.35} {no 937}
+    set data 14
+    incr data -5
+    expr {-54}
+}
+set idx {-81.95 -715 b uclmsob}
+foreach tmp {} {
+    catch {compute false}
+    set j 0
+    while {$j < 2} {
+        set flag -760
+        string trim "gy?h0f-77"
+        expr {(((!-53.09) * (76 == 88.02)) >= ((72.77 ? $data : 62) & -26))}
+        set y "2"
+        set z -899
+        lassign {-365 7.65 96.46 zgydgrx ljzontqu yuwrvzvw} data flag x
+        incr j
+    }
+    set a 0
+    while {$a < 3} {
+        string index "af8 t?#!773ih=.8-s" 2
+        append msg -91
+        incr a
+    }
+    lrepeat 3 -98
+    expr {(53 ? ((-44) ? min(-89, -2) : (13 ? 36 : -46)) : 77)}
+    if {$result == -3} {
+        set tmp "6;haf47w4gf3fo3j"
+        lrepeat 1 "5_blk0t5lrr=j_2,vu!"
+        expr {-22.51}
+        string reverse " 6wo3"
+    }
+}

--- a/fuzzing/findings/seed_1774200061.json
+++ b/fuzzing/findings/seed_1774200061.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200061,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "negative shift argument",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "negative shift argument",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200061.tcl
+++ b/fuzzing/findings/seed_1774200061.tcl
@@ -1,0 +1,217 @@
+foreach flag {-232 true 0 -62 yes} {
+    set y 25
+    incr y 4
+    for {set y 0} {$y < 4} {incr y} {
+        join {-661 -209 -49.88} ""
+        join {y 761 klrexiwn} "-"
+        lassign {-981 irpni 17 jcttkno ukaqakv} y
+        concat {no 361 false 75.59} {72.24}
+        for {set y 0} {$y < 4} {incr y} {
+            append flag -20
+            set y 94
+            incr y 4
+            set flag 45
+            incr flag 2
+        }
+        set flag true
+    }
+    set x [expr {-81}]
+    append item "k,7 3y5:;9t 836f"
+    for {set x 0} {$x < 4} {incr x} {
+        string map {a b c d} "f!:g0gtj8"
+    }
+    string repeat "c#09f6zs,a=f!1s1" 3
+}
+if {$x > -7} {
+    for {set n 0} {$n < 4} {incr n} {
+        append j "q 7w9h.:"
+        if {(~59)} {
+            string last "a" " 8fr2w#6xwc==3api4tt"
+            lrange {717 -685 false} 2 3
+            set j -309
+        } elseif {34} {
+            set y "6h;f38-whza"
+        }
+        lassign {-45.79} x acc y
+        append j "hz#p2+"
+        set item {1 i -996 zxstnskk 41.85}
+        expr {(((10 << -8) != -97) ? 26 : ((70 ** 12) - ($y * 22)))}
+    }
+}
+proc myproc {val item data} {
+    set x {irs true true false 438 false}
+    expr {36.23}
+    for {set y 0} {$y < 4} {incr y} {
+        set msg 100
+        incr msg 4
+        string trimright "wg"
+    }
+    return "6k#h=8tk.ag!"
+}
+set item false
+foreach b {-159 87.24} {
+    if {$y >= 4} {
+        append y -89
+        if {$flag != -4} {
+            set n {-872 658}
+        } elseif {$b <= -6} {
+            set i 85
+            incr i -4
+            set buf 60
+            incr buf 0
+            string map {a b c d} "1"
+            expr {-49.81}
+        }
+        if {$msg < 4} {
+            string repeat "" 4
+            lassign {} i x
+            set j 0.69
+        } else {
+            set y {-328 -451 o false -42.76 f}
+            expr {(int((-68 ** $buf)) ** (-double(22)))}
+            regexp "^[a-z]" "57c32:beo mfn"
+            set b "-?a"
+        }
+        lassign {} x
+        lindex {0 558 c oh} 0
+        foreach n {yes -500 1 true} {
+            lsearch {imeunlhz -63} "zu9py7;?rj5qdyl"
+            catch {myproc }
+            append b 70
+            lassign {0 trogtbou -131 -567 -60.24 -629} x
+        }
+    }
+    lassign {45.23 -190 52.30 tdvtae true} buf
+}
+foreach item {-6.92} {
+    set y vne
+    for {set flag 0} {$flag < 1} {incr flag} {
+        if {(~(19 / max(1, abs(-85))))} {
+            llength {qpr 79.37 -956 990 true -476}
+            set x [expr {abs(((-39) ? 53.88 : int(11)))}]
+            expr {(-5 != (($b > -3) || (-99 != -7.99)))}
+            if {(int(15) ? -96.80 : (87.36 << -93))} {
+                set i -936
+            }
+            set j "r"
+            expr {30}
+        } elseif {$x <= 3} {
+            string first "a" "=,@!gs2 d"
+            string map {a b c d} "1c#?2pv7q_:vlgqs"
+        }
+    }
+    set i -889
+    string last "a" "i4-5 pd@8-ywo0"
+    expr {$y}
+    set n {-4.62 f -126 vjjywsm 447}
+    lappend n 91
+}
+if {$msg > -4} {
+    if {((67.56 | 61) ? (90.37 / max(1, abs(-15.96))) : -97)} {
+        set n "-0?5e-ec"
+        string trim ",5a-d:_wx2jpsp:2h!k"
+        expr {(~((79 && -57) << $buf))}
+    } else {
+        set acc -726
+        if {$msg != 5} {
+            if {$item == -3} {
+                catch {myproc -97 "je6zm_ :pd+cahub#"}
+                lassign {89.84 snhhnzan} tmp key item
+                set item {false false tj 376 -193}
+                lappend item -167
+            }
+            expr {(int((-10 >= -15)) <= (($i % max(1, abs(-82.97))) && $n))}
+        } elseif {$x} {
+            set count false
+            catch {myproc 31 -6 -55.12}
+            string last "a" "8k=h+#6ua=iopud"
+            append y 389
+            expr {(-80 > -56)}
+        }
+    }
+}
+if {((~-53) >> $msg)} {
+    if {(!(~$acc))} {
+        for {set acc 0} {$acc < 1} {incr acc} {
+            set msg [expr {((71 / max(1, abs((~60)))) >> 48)}]
+            expr {((36 | wide(59)) >> 86.07)}
+            catch {myproc wnfpkj}
+        }
+        string tolower "o "
+        set acc 57
+        incr acc 8
+        expr {(~(($i ? -28 : $count) ? $tmp : -12))}
+        expr {38}
+        lassign {no 70.49 -734 -232 176 true} b
+    }
+    set data no
+    set count 0
+    while {$count < 2} {
+        string tolower "gb@"
+        expr {((-82 ? (51 ? $count : -85) : (~34)) < (9.64 ? 67 : (20 ? $tmp : 33.12)))}
+        set y 98
+        incr y 7
+        foreach n {1 azl cyufw 176 true} {
+            expr {((42.10 ? (--97.35) : (-57 ? -88 : -27)) & -19)}
+            set j -632
+            set i 913
+            set n -43
+        }
+        set flag 76.62
+        append count ";047?9d6z"
+        incr count
+    }
+    set buf 1
+} elseif {$item != 18} {
+    if {$i <= -7} {
+        switch -- "xzx-i?j35" {
+            -69 {
+                string range "b5nb" 5 6
+            }
+            805 {
+                lassign {} b n
+                catch {
+                    expr {((!(51 ? 32 : $acc)) == (51.87 << 11))}
+                } b
+                append buf gyc
+                regexp "." "0pb"
+            }
+            default {
+                append i "w azu-v# !!hgko-avy"
+                set tmp {608 991 swvh edpivj -182}
+                lsearch {yes} "k@=ed:w@onn@-#d"
+                set key "oca_6jp+6t1 "
+                catch {myproc 98}
+                catch {myproc false yes 677}
+            }
+        }
+    }
+    append n "8filj01ik2-bmh"
+    expr {$buf}
+    for {set flag 0} {$flag < 4} {incr flag} {
+        append i true
+        set buf 0
+        while {$buf < 3} {
+            expr {-7}
+            append result -81
+            string first "a" ""
+            expr {abs((-21))}
+            incr buf
+        }
+    }
+    lassign {-2.47 984 3.42 -777 583} item n
+    catch {
+        string last "a" "-=;clrh@"
+        set key 0
+        while {$key < 4} {
+            string trim "fcy4"
+            append tmp -75.69
+            expr {(-(!abs(80)))}
+            string trimleft "v4?;ydp3kloc lzp:+"
+            set data "xpgn."
+            lassign {1 htfjlpac nirqhw g tzwmr} flag
+            incr key
+        }
+    } a
+}
+append a "y"

--- a/fuzzing/findings/seed_1774200062.json
+++ b/fuzzing/findings/seed_1774200062.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200062,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use non-numeric string \"308-486\" as right operand of \"*\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use non-numeric string \"308-486\" as right operand of \"*\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200062.tcl
+++ b/fuzzing/findings/seed_1774200062.tcl
@@ -1,0 +1,193 @@
+for {set b 0} {$b < 6} {incr b} {
+    foreach a {yes 346 867 hrpjk 2.85} {
+        foreach a {308 443 h false true -13} {
+            set b "f=h6"
+            append a -486
+            if {((44 * $a) >> (!6))} {
+                string tolower ":osso4@.b"
+                expr {22}
+                set b "8=e-zii1d-6hb_;u=rn2"
+                set y 51
+                incr y 3
+                append a "h173kg-5e.hxh "
+            }
+            expr {(!23)}
+            string range "ld#-5m" 3 5
+        }
+        expr {(5 < 75)}
+        set x izmoyj
+        append b 1
+        string trimright "9bdl9:?0"
+        expr {((-84 ? $a : 9.51) & $y)}
+    }
+    append a "wq:3r6+tp1,2_!j"
+    append a 24
+    for {set a 0} {$a < 2} {incr a} {
+        append b 94
+        append n 574
+        switch -- "rmqdrtr6n3" {
+            -86 {
+                set j 47.23
+            }
+            default {
+                set val 0
+                set val true
+                set buf 0
+                while {$buf < 3} {
+                    string map {a b c d} "woyp4p@0c:x;!#td=@a"
+                    string map {a b c d} "run.x:a-@m.60pn8nf!:"
+                    incr buf
+                }
+                set b "g9zo6b03rh:hogxy"
+            }
+        }
+        append a "s#="
+        set n -74.40
+    }
+}
+for {set msg 0} {$msg < 6} {incr msg} {
+    set n -40.03
+    set result false
+    regexp "[0-9]" "bstgi?"
+    if {((59 || $a) && double(13))} {
+        expr {(((!72.45) >= (24 | 36)) > min(round(-92), min(26, $b)))}
+        expr {(--75)}
+        llength {978 593 71.11 false drfbmo}
+        lassign {} idx
+        set a 30
+        incr a 6
+        expr {(-35 ? (-46 ** (-21 % max(1, abs(-89)))) : ((54 % max(1, abs(-3))) ? (17 ? $msg : $val) : $msg))}
+    } elseif {$buf > 2} {
+        expr {17}
+        if {$a != 6} {
+            expr {((0 | (26.17 & 5)) || (-90 ? (59.00 ** 91) : ($result > 84)))}
+            set idx 646
+        } else {
+            expr {(!(!(~-42)))}
+            set data ".kew1c0qt-e9b"
+            set z {534}
+            lsearch {603 no b} "e_b2-yabpmpws6wlut"
+            expr {(~-3)}
+            set b [expr {((double(4) <= $n) - 18)}]
+        }
+        append y true
+        set n 289
+        if {$x > -1} {
+            lindex {336 5 511} 1
+            foreach buf {1 1 1 -924 false 38.93} {
+                string trimright " fwg1wu17sb@+gz_ "
+                set buf false
+            }
+            set msg 1
+            incr msg 10
+            expr {-75}
+            expr {min(((~-82) >= round($idx)), -72.36)}
+        }
+        set data 37
+        incr data -1
+    }
+    string last "a" "g2nt.,6"
+}
+lsearch {} 31
+if {$data > -6} {
+    if {$a != -4} {
+        append x -71
+        switch -- axv {
+            -7 {
+                set result {39.60}
+                set idx qf
+            }
+            -53.09 {
+                expr {(((61 ? 60 : -32) != (-$x)) / max(1, abs(86.61)))}
+                if {$a < 5} {
+                    lassign {13.32 897 bd no} j
+                    expr {($a ^ 59)}
+                    set y no
+                    lsearch {-30.76} -24
+                    set x "8="
+                } else {
+                    set j 6
+                    incr j -3
+                    set buf 1
+                    list ri
+                    set data 11
+                    incr data 5
+                    set acc 73
+                    incr acc -4
+                } elseif {$n > 13} {
+                    set acc [expr {(33.36 ? (95.14 >= (41 << $a)) : (!(1 ? $n : $data)))}]
+                }
+                regexp "\\d+" "0ri97?s"
+                append acc -59
+            }
+            "em781cm6vot28" {
+                set acc {82.44 f}
+                set item 16
+                incr item 6
+                set buf 621
+                set msg 0
+            }
+            default {
+                set a 29
+                incr a -3
+            }
+        }
+        set j 73
+        incr j 9
+        for {set buf 0} {$buf < 6} {incr buf} {
+            expr {$buf}
+            set x q
+        }
+    } else {
+        if {$buf} {
+            append flag "du13r81ek1@mf@;.ol6"
+            set item 15.84
+            set i 57
+            incr i 6
+        } else {
+            set msg 58.71
+            append data "?d.z1zhkeqa#_!a"
+            lassign {0 -53.77 275} acc x
+            lindex {no no no -443 887 97.58} 1
+            set b ccr
+            expr {double(((71.02 | -97) <= (-62 < -33)))}
+        }
+        set result "6 ,"
+        for {set result 0} {$result < 1} {incr result} {
+            expr {6}
+            append item true
+            if {$val >= 11} {
+                set flag -4.71
+                expr {8}
+                append item 88.07
+                lassign {} z b z
+                string repeat "#" 0
+                string map {a b c d} "nkbb+2,@42sr7l7.@"
+            }
+            append msg 70.88
+            lassign {426} result acc
+        }
+        set data 29
+        incr data 6
+        catch {
+            set n {0 -251 -99.59 -14.50}
+            lappend n lmc
+            expr {((!(-34 ? 84 : 21)) ? 25 : $x)}
+            lsearch {-811 856 -473 dkttyap -207 okjjxwih} 67
+        } item
+    }
+    set val 1
+}
+lsearch {} ";a ql_45"
+append z -27
+string toupper "6zlxh66ofu6m=."
+for {set acc 0} {$acc < 2} {incr acc} {
+    for {set n 0} {$n < 1} {incr n} {
+        expr {(-6.99 & (!($result << -37.37)))}
+        string index "#1z@" 5
+        append data yes
+    }
+}
+foreach flag {-836 wqkvxk qltdcmjb} {
+    lsearch {} -10
+}

--- a/fuzzing/findings/seed_1774200066.json
+++ b/fuzzing/findings/seed_1774200066.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200066,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"acc\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200066.tcl
+++ b/fuzzing/findings/seed_1774200066.tcl
@@ -1,0 +1,366 @@
+if {abs(-34.01)} {
+    append i "e"
+    for {set buf 0} {$buf < 2} {incr buf} {
+        string trim "8;a=xt+"
+    }
+    list "tz23.5y_v" -92.80
+}
+if {$i <= 6} {
+    set buf {25.09 80.41 -57.50 btlgxl 239 vodl}
+    set buf xdwrj
+    catch {
+        set i 410
+        append i -53
+        lassign {z -33.65 -778} i buf idx
+        lreverse {}
+        switch -- 669 {
+            gbbzbv {
+                set idx {fyt 27.40}
+                expr {max((!(!2)), (abs(-10) ? $i : (~31)))}
+                set i 41.49
+                lindex {d} 2
+            }
+            -21 {
+                string trimright "rum"
+            }
+            41 {
+                set buf " .:9j+xnw@"
+            }
+            "v1anmc.8mo." {
+                lassign {} idx
+                set acc 30
+                incr acc -4
+                string reverse "291"
+                set buf 21
+                incr buf 7
+            }
+            default {
+                lassign {0} acc
+                expr {((int(74.72) ? (--3) : -19.69) <= -10)}
+                lrepeat 3 326
+            }
+        }
+    } acc
+    string map {a b c d} "e0a="
+    set idx 0
+    while {$idx < 2} {
+        expr {15}
+        regexp "[0-9]" "4+ @40uh2"
+        set idx cruv
+        for {set msg 0} {$msg < 3} {incr msg} {
+            foreach msg {-477 783 glrqfcp -106} {
+                set flag 65
+                incr flag 8
+                set flag qlvptmq
+                expr {93}
+                expr {((~(~-64)) / max(1, abs((~48))))}
+            }
+            set idx wrplnrkm
+            set i 89
+            incr i 3
+            append data "7ww# y#d"
+            lassign {3.75 false 996 871 0} buf
+        }
+        incr idx
+    }
+}
+proc myproc {} {
+    set buf 76
+    incr buf -4
+    return ":bw-w+?"
+}
+if {-79} {
+    lrepeat 3 "!p_"
+    lassign {} flag
+    lassign {-759 596} msg data flag
+    if {$data < 11} {
+        if {$i <= 5} {
+            join {-43.96 -375 -5.81 44.64} " "
+            if {(-12 > double(-56.13))} {
+                set flag "s9j.-haq2"
+                append z 27
+                set i -32.73
+                catch {myproc -30}
+                catch {myproc }
+            }
+            set x [expr {max(min((~27), ($z % max(1, abs($i)))), (~(!32)))}]
+            expr {((2.61 * (84 > $msg)) ? 62 : ((50 % max(1, abs(-14))) * (60 && 1)))}
+        } else {
+            expr {(!18)}
+            set i 0
+            while {$i < 3} {
+                lreverse {-82.60 374 717}
+                lsort {862 329 806 yhajctcz}
+                incr i
+            }
+        } elseif {$msg <= 6} {
+            for {set x 0} {$x < 4} {incr x} {
+                set y 915
+            }
+            lassign {-84.02 -719} acc idx
+            set z {}
+            expr {((($idx << -29) == 46.15) >> double((47 == $z)))}
+            set idx -304
+        }
+        expr {(((!67) || ($flag - 66)) || (!(87.68 >> $x)))}
+        switch -- -32 {
+            -838 {
+                string map {a b c d} ""
+                expr {((-25.33 && (-5.91 >= -33)) < double((17 || 4)))}
+                append z ""
+                set acc 81
+                incr acc -5
+                switch -- -84 {
+                    63 {
+                        set idx {-594 59.45 false}
+                        append data 4
+                        append y -891
+                    }
+                    683 {
+                        append y 68
+                    }
+                    default {
+                        lassign {1} msg flag buf
+                        set tmp {-654 false iuuq 275 589 96.27}
+                        lappend tmp false
+                        lassign {yes 1.95 505 7.03 84} j data idx
+                        catch {myproc -987 6}
+                        set x {-489 -51.64 -7 ganvtzz odymgut true}
+                    }
+                }
+                foreach count {true false true 798} {
+                    expr {(((!$idx) / max(1, abs(58))) <= ((-45) % max(1, abs((-12.19 || $i)))))}
+                    set idx [expr {((21.16 ? -95 : (-72 || 82.30)) || 20)}]
+                    set y no
+                    set z -70.59
+                    expr {wide((-41.86 ? (-33 <= 42) : (22 - 81)))}
+                }
+            }
+            kah {
+                set msg "=msq"
+                for {set x 0} {$x < 3} {incr x} {
+                    catch {myproc 149 "epin-6m7,xo.zm= -w"}
+                    lsort {true 312 -283 false 88 qlb}
+                    catch {myproc 92.24 "!cqjb"}
+                }
+                append i -52.07
+                set j 5
+                incr j 3
+                expr {-39}
+                set tmp -246
+            }
+            default {
+                string toupper "i:b0d7uohu?,=:4"
+                set a -583
+                set result 44
+                incr result 0
+                lrepeat 3 37
+            }
+        }
+        set idx "xjg"
+        for {set a 0} {$a < 5} {incr a} {
+            list 46 -100 -79
+            append x -71.23
+            if {$idx != 19} {
+                set a 518
+                append key 3
+                append j "_cft@-r8h_"
+                expr {(-min((34 && 8), -29))}
+                set val mnird
+            } else {
+                catch {myproc }
+            }
+            set z {false yes}
+            set key 32
+            incr key 7
+            for {set y 0} {$y < 1} {incr y} {
+                llength {}
+                set y {-674 -26.17 -386 513 -167}
+                expr {double(abs((~$acc)))}
+            }
+        }
+    }
+    expr {(-$acc)}
+    set acc {435}
+}
+regexp "\\d+" "k#d4k#mrt"
+set x 626
+proc combine {buf {val false}} {
+    set n 0
+    expr {$acc}
+    set key " 7w3d_1#of_#buv8f"
+    set x 0
+    while {$x < 5} {
+        set b 930
+        switch -- "jgzqkb=i.=?o;6_3i;" {
+            49 {
+                regexp "[a-z]+" ".0ljfkgktovy-"
+                set data {}
+                regexp "[a-z]+" "pr5zi98y#hja 5v"
+                catch {myproc }
+            }
+            -86 {
+                append y yes
+                string map {a b c d} "26t1"
+                catch {myproc -56 -88 -373}
+            }
+            98 {
+                set a "h6x+v_ddu4"
+                concat {288 lyflt 0} {}
+            }
+            default {
+                set i 52
+                incr i 1
+                set item [expr {(double(abs($n)) ? $key : ((!-58) | (70.11 > -72)))}]
+            }
+        }
+        catch {myproc -35 59 -97}
+        regexp "^[a-z]" ";"
+        incr x
+    }
+    return -9
+}
+append j -791
+proc build {{b jwgcdh} tmp {x 250} result} {
+    set item 0
+    while {$item < 5} {
+        set data 0
+        while {$data < 2} {
+            set x 87
+            incr x 5
+            if {$tmp == -4} {
+                append b 54.48
+                set msg [expr {double(min(-45.15, (82 << -22)))}]
+            } else {
+                catch {combine }
+                lassign {276 -499 877 ng false} j
+            }
+            regexp "[0-9]" ";!brxb+n#1x.oz=xo"
+            incr data
+        }
+        set n {991 no -52.25 -293}
+        incr item
+    }
+    switch -- "3axgx-ud4p8wp" {
+        95.85 {
+            set idx 20
+            incr idx -2
+            set buf "h@oifh?g__bx@"
+            llength {}
+            if {$idx != -4} {
+                append z "0bb;!_f "
+                expr {(round((~-38)) << (--24))}
+                expr {89.54}
+                lassign {no} tmp buf item
+                regexp "." "dd,f14suseu,u+cnh;9"
+            }
+            set msg 14
+            incr msg 7
+            expr {(-($idx / max(1, abs((6 > 60)))))}
+        }
+        "37iol39ttem" {
+            string repeat "x" 2
+            lassign {-972} y
+            set idx -65.57
+        }
+        83 {
+            set b {-853}
+            set flag 57
+            incr flag 2
+            foreach n {jfgoqr 56.60 gresfk njo ita} {
+                expr {(((41 | -79.00) ** (4 && 19)) ? (-4 ** (-42.83 >= -80.62)) : ($result == (-53.18)))}
+                list 397
+                set buf 6
+                incr buf 0
+                string trimleft "n0o,"
+            }
+            set a 989
+        }
+        default {
+            lassign {-970 -823 sdqb 586 true} a
+            foreach item {acqbn 771 szuqo -787} {
+                set key 1
+                regexp "\\d+" "4r"
+            }
+            append acc wynuy
+            expr {7.92}
+            foreach z {-932 f wuycrw -517 286} {
+                string reverse "=b!d?:46r7!biu-upn"
+            }
+            foreach flag {} {
+                string last "a" "2ylla.w."
+                append n "iunj"
+                string trimright ""
+            }
+        }
+    }
+    return -10
+}
+proc build {result idx n} {
+    foreach x {60 -11 61.33 0 -13.77 false} {
+        expr {(13 ? ((-66 <= 32.30) <= (70 && $y)) : -85)}
+        append a 919
+        lsort {false -685 hndvzy wf}
+        for {set data 0} {$data < 5} {incr data} {
+            catch {myproc }
+            set tmp -32.25
+            catch {myproc }
+            set buf 57
+            incr buf 2
+        }
+    }
+    append item "=zcdh"
+    catch {myproc "55m?pj:jz,c+" "" ":ualc=z_s@j8p"}
+    lsearch {-37.20 no} "j_056lejftb42"
+    regexp "." "w:lca063+it=wys"
+    expr {(~-95)}
+    return "fv2h__"
+}
+if {79} {
+    set acc "unjlk?#zu,2v"
+    set result 73
+    incr result -4
+    regexp "." "19z_kr9@8eg "
+    set n 9
+    incr n -1
+    lassign {y s false fvd -48.53 944} tmp
+} else {
+    catch {myproc }
+}
+foreach j {} {
+    string first "a" "9;m+u_ou?jwm!a@v1f="
+    lassign {259 -70.07 -167 -807 xv} tmp z tmp
+    set y -98.15
+    switch -- "d" {
+        false {
+            foreach buf {60.65 501 40.30 -792} {
+                string map {a b c d} "cn6,65"
+                set y 1
+                lsearch {-229} 58
+                set z ""
+                regexp "^[a-z]" "wlq7,sl5leh!2!l!d"
+                set count 21
+                incr count -3
+            }
+            set idx "2"
+        }
+        "@rbylb8jy55" {
+            lindex {5} 3
+            for {set a 0} {$a < 3} {incr a} {
+                foreach key {782 0 -67 92.32 -77.28} {
+                    expr {((~1) / max(1, abs((21 ? (-77.74 && -92) : round($a)))))}
+                }
+            }
+            set x 68
+            incr x -4
+        }
+        default {
+            set x {1 yes nnot no 872}
+            string index "i7mub!b9,7zk" 2
+            string toupper "gw62qx ##pqbx6"
+            lsearch {744 -220 yes -20.49 36.16} -234
+            lsearch {0 yes dpfjt -675 645 18} yes
+            append acc -11
+        }
+    }
+}

--- a/fuzzing/findings/seed_1774200067.json
+++ b/fuzzing/findings/seed_1774200067.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200067,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"44.41\" as right operand of \"&\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"44.41\" as right operand of \"&\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200067.tcl
+++ b/fuzzing/findings/seed_1774200067.tcl
@@ -1,0 +1,251 @@
+expr {30}
+proc helper {idx {j illkxiw} args} {
+    set item {}
+    return ay
+}
+foreach item {-15.34 ywkcvbmn -48} {
+    foreach item {cknw -227 true jtry} {
+        lrepeat 2 "sdf8st"
+        llength {}
+        set item 65
+        incr item 3
+        string reverse "=be.,=35+v-uz;,w!"
+    }
+    catch {
+        llength {-822 -457 uvyhuyqa}
+        switch -- -353 {
+            1 {
+                lassign {} item item
+                switch -- -75 {
+                    fk {
+                        expr {(int((-82 != 5)) ? int((!61)) : -25)}
+                        string repeat "pir50" 2
+                        expr {-43}
+                        set item "858;;#0@!dsk-j1pj"
+                        set item [expr {(wide((-72 << 66)) >> round(abs(-83.67)))}]
+                    }
+                    "#d45a1+@_wz;.=6:td@" {
+                        set z 691
+                    }
+                    default {
+                        lassign {230 98.02 -87.03 594 -74.45} a
+                    }
+                }
+                join {50} ","
+            }
+            default {
+                if {$item > 12} {
+                    expr {$a}
+                    append item 34
+                }
+                expr {33}
+                set a 0
+                set z {}
+            }
+        }
+    } key
+    foreach z {44.41 -69 1} {
+        expr {(((-43 & $z) < -12) % max(1, abs(((-14 < 14) && (58.38 | $key)))))}
+        lrange {-60 false wcfqggsw -183 no} 2 4
+        catch {helper no -1 -18}
+        expr {(((--83) - ($a != $z)) ? ((43.00 - -94) < (~$key)) : round((-44 | $key)))}
+        foreach z {-640 yes -702 u} {
+            expr {round((($item <= 38) | (39.43 >= 57)))}
+            string trimright "z26roft5chrs6"
+            expr {($z == (-35 ^ (-96 && 88)))}
+            lassign {-724 1} a x
+            set z -328
+        }
+        lrange {300 -277 -907 false} 0 2
+    }
+    set key -42.02
+    set x 0
+    while {$x < 3} {
+        catch {
+            set x {-32.30 74.28}
+            lappend x "m1dibi!a2mh "
+            regexp "[a-z]+" "pyu@tzdm"
+            set z 0
+            while {$z < 2} {
+                llength {213 sgcbrdh rqlacpsu false -64.71}
+                lassign {} n
+                regexp "[0-9]" ":_t3_d4h ep4"
+                incr z
+            }
+        } n
+        incr x
+    }
+    catch {helper true}
+}
+set key "x9=v;3"
+if {$x >= -6} {
+    regexp "[0-9]" "6-+7+ax 5"
+    set buf [expr {-15}]
+    if {((25.12 << 96.26) >= round(-75.12))} {
+        expr {((-36.46 < 96) / max(1, abs(-46)))}
+        switch -- ":az+.bkm!dfylvd::azz" {
+            31 {
+                expr {wide(((45 % max(1, abs($x))) ? 27 : (--75)))}
+                lsort {-491 187 8.49 ehik 0}
+                set z 87
+                incr z 8
+                if {$n > 11} {
+                    string toupper "!r6"
+                    append x -91
+                    set tmp [expr {$z}]
+                    set n {-40 -937 -469}
+                } else {
+                    lassign {} flag item a
+                    catch {helper true}
+                    lsearch {kpdymod no} -35
+                    regexp "\\d+" "-r.p5b=eck"
+                }
+            }
+            default {
+                expr {(!((-9 ^ 68) & (-83 >> $flag)))}
+                lsort {-3.44 305 48.73}
+                string length "yws."
+            }
+        }
+    }
+} else {
+    set buf {pajpdn -191 ucg}
+    set flag {792 86.16}
+    expr {(((-41.23) ? (19 + -51.94) : 49) - ((-10 != 52) ? (-27 / max(1, abs(81))) : 1))}
+    if {$buf >= 7} {
+        set acc 0
+        while {$acc < 1} {
+            foreach tmp {-40.81 0 25.43} {
+                catch {helper }
+                set item [expr {(-68 << (79 || 95))}]
+                set data -24.82
+                set n [expr {(!(-(-18 ** -7)))}]
+            }
+            expr {int(82)}
+            incr acc
+        }
+        catch {helper }
+        if {-40} {
+            if {$item > 0} {
+                catch {helper }
+                lsearch {944 735 vr no} 385
+                catch {helper }
+            }
+        } else {
+            if {(abs(-90) - ($item * $n))} {
+                set buf {72.02 mhyu luavxh}
+                expr {(79 != ((-28 || $item) >> (60 & 49)))}
+                append acc "mw5gcl!"
+            } else {
+                set acc [expr {-0.87}]
+                expr {(60 | $z)}
+                set flag -546
+                append x 1
+                catch {helper -65 wq}
+                lassign {} msg acc
+            }
+            set acc 820
+            string toupper "j49!.@8fp6hj:-i"
+        }
+        if {$item < 2} {
+            expr {(~((-21 < 23) ? (!-33.64) : (-38)))}
+            set data {897 fj yes false}
+            expr {(((-93 + $key) ? (44.94 / max(1, abs(95.78))) : ($tmp * 100)) + round((-36 ? $flag : 99.40)))}
+            set result 298
+            for {set data 0} {$data < 3} {incr data} {
+                string first "a" "61f,9=,e2uppnj4 r5yb"
+            }
+        } else {
+            set i {1 8.83 jhl}
+            lassign {xgjo 80.33 -995 yes 147 542} idx buf flag
+        } elseif {42} {
+            set tmp "5dwr.a+_1bz5z"
+            set flag -651
+            set data 0
+            while {$data < 1} {
+                set a [expr {(!(-(9 != 50)))}]
+                set key hqf
+                string range "jqhf?b85rf=@clq5my0" 1 7
+                string trimright "y_h_agz,oa"
+                set buf 61
+                incr buf -3
+                string trim "es"
+                incr data
+            }
+        }
+    }
+    expr {(-32.13 < (~($buf ? 26 : 19)))}
+    foreach buf {-50.95 1 -73.98 asec} {
+        set tmp [expr {($idx ? 69 : ((-2 >= 33.91) == (-35 > $acc)))}]
+        set z -227
+    }
+}
+set z 16
+incr z 5
+append i e
+foreach msg {} {
+    set i 0
+    while {$i < 3} {
+        foreach key {zqernds} {
+            append count wksbnccs
+            append data -5
+            if {(24 >= double(-97))} {
+                expr {min((-min(100, -94)), $i)}
+                expr {(((-74 || 91) << ($z < 37)) ^ ((97 == -17) ** (-90 + 5)))}
+                string reverse ":aut-@j"
+            }
+            catch {helper "jwc2kg_:us!=gc#"}
+            catch {helper }
+        }
+        regexp "\\d+" "f9gs0hdt2+"
+        incr i
+    }
+    set key mfgebe
+    set msg no
+    expr {(($count >> (93.93 / max(1, abs(-53.33)))) << min((49 ? $result : 42), int(96)))}
+}
+expr {-56}
+proc helper {tmp count z} {
+    expr {$buf}
+    if {$item >= 5} {
+        expr {((26 ** -96) ? (int(-32.64) == (-$tmp)) : (-45 * $tmp))}
+        catch {helper 112 "_5h40k9#mt?47_uc:"}
+        catch {helper "aezwrd+cb264" e}
+        string toupper "n_=qk_9 ru"
+    }
+    set flag 0
+    while {$flag < 5} {
+        catch {helper "p+wm@ 5q#-ow"}
+        catch {helper }
+        set a 0
+        while {$a < 3} {
+            string first "a" "p24!1"
+            expr {75}
+            append msg "@1k67p7#:,"
+            incr a
+        }
+        incr flag
+    }
+    for {set item 0} {$item < 6} {incr item} {
+        string repeat "tr:@=" 0
+        if {round((-20 < -68))} {
+            expr {(~((42 != -46) ** (30.48 - 17.43)))}
+            expr {(-((-61 >> $n) + max(14, -55.53)))}
+            if {$idx} {
+                set val 9
+                incr val -5
+                set msg 26
+                incr msg 2
+            } elseif {(wide(-67) ? (--37) : ($data < -23))} {
+                set a 26
+                incr a -5
+                set a {}
+            }
+            expr {$key}
+            catch {helper 143}
+            set msg {tglfswiy zzfp}
+        }
+        string repeat "mcs?zaa" 1
+    }
+    return "4nw+r4;dcu7w?@.+;5_"
+}

--- a/fuzzing/findings/seed_1774200068.json
+++ b/fuzzing/findings/seed_1774200068.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200068,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200068.tcl
+++ b/fuzzing/findings/seed_1774200068.tcl
@@ -1,0 +1,189 @@
+namespace eval foo {
+    if {44} {
+        lassign {26.74 -64.85 true 425 yes 876} data
+        expr {33}
+        expr {$data}
+    }
+    set data "x#eu1=n_de?gd1"
+    for {set data 0} {$data < 3} {incr data} {
+        set result 43
+        incr result -2
+        set result [expr {75.10}]
+        set result "u81tk-prrs"
+        expr {(!(-(49 / max(1, abs(1)))))}
+        set z ".!@4#_-ba"
+        join {0} ","
+    }
+    foreach data {544 phdqak menfwj} {
+        lassign {mqio no 1} z
+        join {545 592} " "
+        if {$data < 2} {
+            append result ":0qym9 w3o3:0e"
+            set msg 44
+            incr msg 8
+        } else {
+            if {$result == -1} {
+                set result -204
+            } else {
+                set n "e!hu_opq+k;#.w"
+                string map {a b c d} "q_+c6xoqa0lsoti__"
+                set b -942
+                lsort {505 1 ua}
+            } elseif {-90} {
+                string first "a" ",ven:puy8u!4yhd-_t"
+                set val -711
+            }
+            set msg -416
+            expr {int(75)}
+            expr {39.50}
+            set data [expr {max(-10, (~44))}]
+            for {set msg 0} {$msg < 5} {incr msg} {
+                expr {73}
+                append result "z5s=g8af6=.j885h4"
+                set z 87
+                incr z -2
+            }
+        }
+    }
+    if {$b != -9} {
+        set idx 0
+        while {$idx < 2} {
+            append data 47.15
+            set msg [expr {85}]
+            append flag -19
+            if {$val != 0} {
+                set data "la=r-tduwztfwi4or"
+                set idx true
+            } else {
+                string trim "djpb!3x"
+            }
+            incr idx
+        }
+    }
+}
+foreach msg {mkkphybs 63 false -426 -228 436} {
+    catch {
+        append z "x_+sdi_g:"
+        lassign {-0.48 vjpywtfr} data z
+    } data
+    llength {false}
+    set idx {-566 -651 -838 -75}
+    string last "a" "da1;vp,k"
+}
+lassign {-33.99 -874 1 361 y} x acc n
+proc myproc {{item t} {val nnlmnpil} tmp acc} {
+    if {$x >= 15} {
+        string trimright ".v1nlj5_ =jt"
+        append z "qza@d1n7c?!"
+        append b 32
+        expr {-30}
+        set b 0
+        while {$b < 3} {
+            set z "_32 +gcg"
+            lsearch {wckxbisk 87.34 true ano rglkbf} -656
+            set b -545
+            expr {abs((($msg * 73) - ($acc - 4)))}
+            string range "?89a= #4" 2 4
+            incr b
+        }
+        string index "v:2_su@rvw-migw" 0
+    } else {
+        append key -752
+    }
+    expr {((abs(-81) >> -91) ^ ((-$result) - (89 / max(1, abs(-52.74)))))}
+    for {set z 0} {$z < 2} {incr z} {
+        set item "o#h0"
+        if {min((-23 ? 67 : $acc), (77 + 18.86))} {
+            for {set item 0} {$item < 5} {incr item} {
+                lassign {} z a msg
+                lsearch {vupf 351} -45
+            }
+            set b 550
+            expr {(60 ? $item : ((-74 ? -8.40 : $acc) ? (-7 << $acc) : abs(-87)))}
+            expr {21}
+        }
+        foreach result {wsxjxy} {
+            append x true
+            lassign {30.40 882} data a b
+            set msg t
+            if {$item > 4} {
+                expr {96}
+                set result "76py_"
+                expr {41.48}
+                set x 351
+            } elseif {$b < -4} {
+                string trim "h:k6_i7v?"
+                expr {(((13.51 ^ $a) >= (-68.25 & -69)) ? (($flag - 99) ? (-$a) : $data) : (-38.75 ? (~-56) : (-$key)))}
+                lassign {-300 rfvuq} acc
+            }
+            for {set item 0} {$item < 1} {incr item} {
+                lrange {swzyccxq} 3 4
+            }
+        }
+    }
+    regexp "[0-9]" "h8nh"
+    lrepeat 1 21
+    set b -476
+    return bylpd
+}
+for {set z 0} {$z < 1} {incr z} {
+    if {(~(-87.75 <= 11))} {
+        if {(~-13)} {
+            set data 8
+            incr data -3
+            append msg "owq@#,gsgfc4"
+        }
+        llength {-86.46 68.86 true 73.79}
+        set item 60
+        incr item 1
+        set x [expr {(-double((!$key)))}]
+    } elseif {((-$acc) <= (52.68 > -84))} {
+        catch {
+            expr {(-($acc ? -21 : (16 - 23)))}
+        } z
+        lsort {206 -239 yes -750}
+        switch -- -13.65 {
+            549 {
+                for {set flag 0} {$flag < 6} {incr flag} {
+                    append msg true
+                }
+                set msg [expr {-31}]
+            }
+            -43 {
+                set flag -701
+                append n -961
+            }
+            default {
+                regexp "^[a-z]" "h_3="
+                if {$val <= 6} {
+                    lrepeat 1 "..6-8kc_mbb@j@ba"
+                    catch {myproc }
+                    concat {wexzd} {evzbgzju 287 508 845}
+                    set y 277
+                    expr {(-37.16 - (-72 + -6))}
+                } elseif {$z} {
+                    set result dqufx
+                    set item 98
+                    incr item 8
+                    append z 96
+                }
+                if {(57 != 45)} {
+                    lassign {-12.03 no 427 -630 81.85 -42.16} acc j
+                    append j "rpb2q-=2#rfm"
+                    expr {(-(($flag != -70.63) * (57 % max(1, abs(-14)))))}
+                    set z {964 1}
+                    set idx -731
+                    set y {-6.60 -982 310 0 87 no}
+                }
+            }
+        }
+        append b 69
+        set val [expr {$y}]
+    }
+    catch {myproc 53 "c9o.p5r.q#en@g0"}
+    if {-78.65} {
+        string trim "h!yv0 687"
+    } else {
+        expr {(100 ? (57.50 >= double($key)) : min((7 * $b), (-39)))}
+    }
+}

--- a/fuzzing/findings/seed_1774200071.json
+++ b/fuzzing/findings/seed_1774200071.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200071,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"count\": no such variable",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"count\": no such variable",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200071.tcl
+++ b/fuzzing/findings/seed_1774200071.tcl
@@ -1,0 +1,142 @@
+string reverse "@"
+proc handle {j flag item} {
+    set idx 42
+    incr idx 4
+    lassign {hjsqvuw} idx acc acc
+    concat {-293 1 -691 -85.31} {false -531 29.65 uupazlbu -67.61 -331}
+    set tmp 0
+    while {$tmp < 5} {
+        string map {a b c d} "q=7j2t?7"
+        for {set tmp 0} {$tmp < 3} {incr tmp} {
+            append j "@0s:u@6oy=8?2"
+            foreach data {-34.40} {
+                expr {((-68 || (31 << $j)) > ((57 < 80.15) == 17))}
+                string map {a b c d} "?o49@7h=u.3zgi_q2w++"
+                set key 28.27
+            }
+            set j false
+            set idx {}
+        }
+        expr {(((-31 ? -71.34 : -31.78) > double(11)) >> ((-16.14 ? 25 : -69.34) - (~35)))}
+        if {(($data % max(1, abs(-70))) + (16 | 12))} {
+            expr {int(((6 <= -89) & (79 && $j)))}
+            set val 0
+            while {$val < 2} {
+                expr {(((!-30) % max(1, abs(-95))) + -35.26)}
+                expr {(--70.98)}
+                regexp "[a-z]+" ";o!++3i:,a,978,"
+                set n yes
+                incr val
+            }
+            string trimleft "!i4etzjrfle7pdc2 "
+            string first "a" "_"
+            append acc 17
+            set key -431
+        } else {
+            expr {max(((54 < $tmp) ** ($acc ? 47 : -65)), ((46.07 >= 74) ^ max(12, -26)))}
+            set i -352
+            expr {(((-26.24) & int(30)) == (1 % max(1, abs((~65)))))}
+            append count 15
+            lassign {-76.49 44.16 vkau -37.94} key key
+        } elseif {abs(-48.82)} {
+            lreverse {38.13}
+            set data false
+            append key 746
+            set n -49.72
+        }
+        set val -750
+        set z 94
+        incr z -1
+        incr tmp
+    }
+    switch -- "" {
+        -296 {
+            lrange {-421 43.96 true -360} 0 3
+            append key -32
+            expr {($idx != (($j ? -68 : $acc) >> (-$j)))}
+            append j "uhl:e.b08l6mll"
+        }
+        default {
+            append i true
+            set j -89
+            join {767 -284} ""
+        }
+    }
+    return 469
+}
+lassign {432} n
+foreach a {false -805 true} {
+    if {$count > -10} {
+        regexp "." "e 43cs#!fg,@.o"
+        set data "s7;9di9rn?2v1lnbi."
+        append n 400
+        catch {handle "1;4j8i5#wl#rhl8tz?" -60 "x_9m=f@b_h79x29cgdq"}
+        set y 76.27
+        for {set y 0} {$y < 2} {incr y} {
+            set y {38.50 -104 ttvty rbtstzkb 1 848}
+            append data "1cp;:88"
+            set idx 10.66
+            expr {(43 || 75.65)}
+        }
+    }
+    set b 31
+    incr b -2
+    if {$tmp <= -10} {
+        set result {ehtdz}
+        set result "81kvmco1e?p;xp.4st"
+        set n {-99 97 466 -74 38.84 sibxg}
+        expr {(10 != 69)}
+        set z 26
+        incr z 0
+        set count 0
+        while {$count < 4} {
+            append z 46
+            set z 0
+            while {$z < 2} {
+                catch {handle azj ";9 !g"}
+                set val ydbdzq
+                append acc -80
+                string first "a" "l6#;+5=;ro"
+                incr z
+            }
+            string tolower "v-hthpxnz-kugz3u z"
+            incr count
+        }
+    } else {
+        catch {handle "n2g" 72.76 "u1,"}
+        set acc 49
+        incr acc 6
+        set data 4
+        incr data 3
+        lassign {31.59 -2 -48.51 false moivll -94.51} y n
+        if {4.48} {
+            expr {(((-10 <= -28) - $y) & ((-46 ? 26 : 41) >= 5))}
+            append buf " yhye@+=qag=d:5_q"
+            lassign {97} n
+            append buf "te:fe45n4#yspb76"
+            set z no
+        } else {
+            expr {($val ? ((7 != -62) ** -87) : (~1))}
+            set acc "3?"
+            append a iljjkhdd
+        }
+        expr {($idx + (double(-80) ? (11.35 || 42) : (!35)))}
+    }
+    expr {((!(-1 ? $tmp : 51)) / max(1, abs(double(round(-5)))))}
+    set y 40
+    incr y 1
+    for {set x 0} {$x < 6} {incr x} {
+        regexp "[0-9]" "t4kz81z smm g"
+        set data 92
+        incr data 1
+        append n 6.79
+        set b {-53.71 g 437}
+    }
+}
+append i -40.64
+append buf -3.50
+catch {handle 78 -75}
+proc transform {b {item 45.49} {a ptzw} i args} {
+    regexp "^[a-z]" "vwvcp#m"
+    return ynbdn
+}

--- a/fuzzing/findings/seed_1774200072.json
+++ b/fuzzing/findings/seed_1774200072.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200072,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"81.55\" as left operand of \"|\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"81.55\" as left operand of \"|\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200072.tcl
+++ b/fuzzing/findings/seed_1774200072.tcl
@@ -1,0 +1,482 @@
+if {(81.55 | (!47))} {
+    set tmp 3.32
+    set tmp 0
+    while {$tmp < 1} {
+        expr {30.59}
+        for {set tmp 0} {$tmp < 6} {incr tmp} {
+            set tmp "mt,qprsol;s3+k#"
+            expr {(40 | (~($tmp == -75)))}
+            set tmp "fs;xm="
+        }
+        incr tmp
+    }
+    set tmp {ecrkip}
+    if {$tmp < 9} {
+        catch {
+            append tmp "7gl+4v"
+            expr {((60 == wide($tmp)) ? ((52 ? 52 : -36) >= wide(27.87)) : ((68 * -48) | -89))}
+            set tmp 88
+            incr tmp -4
+            append tmp "ccx7"
+        } tmp
+        if {$tmp > 19} {
+            append count ke
+            expr {-90.15}
+            set z 65
+            incr z 3
+            append count no
+            set count true
+        } else {
+            expr {((max($count, -69) > 50) ? (-56 ? 41 : (-$z)) : ((-77 < $tmp) ? -89 : (-97 >= 22.83)))}
+            set flag 15.28
+            set flag {-899 587 js hsefi}
+            set flag {-98.77 no true 46.80}
+        } elseif {$z >= 13} {
+            for {set count 0} {$count < 2} {incr count} {
+                set data 74
+                incr data -4
+            }
+            expr {-22}
+        }
+    } else {
+        lindex {ozawdh} 0
+        if {9} {
+            expr {min((double(-28) / max(1, abs((35 - 4)))), (-17.74 < (7 >> 92)))}
+            if {$z != -9} {
+                set tmp no
+                set tmp 69
+            } else {
+                expr {(min(-88, (~5)) ? ((!21) ? (20 == $z) : (73 >= -61)) : (!-42))}
+                string trimright "m+fn"
+                set data 51
+                incr data -1
+                append data 92
+                string last "a" "6la!"
+                expr {$data}
+            } elseif {$tmp < 13} {
+                append z 0
+                set data orvlia
+                set z 265
+                set data 20
+                incr data 6
+            }
+            lsearch {-613 756 -63.27 -55.61 zls gmt} -62
+            set count 81
+            incr count 9
+            set flag 67
+            incr flag 4
+        }
+        expr {(-83 ? (-47 >= (59 & 37)) : (($z ? 10 : -56) % max(1, abs(-35.18))))}
+        regexp "[a-z]+" "2r.xi68.b53pvm5ea"
+        switch -- false {
+            foazbefo {
+                lreverse {-312}
+                string last "a" "f j!7ox_@_dp-e-"
+                expr {(32 > ((24 ? 21 : 33) << int(92.20)))}
+            }
+            default {
+                string map {a b c d} "=6vumc."
+                expr {-7}
+                catch {
+                    set tmp -613
+                    string trimleft "ih7.67bw"
+                    set z 23
+                    incr z 7
+                    string length "7@8oyac.sbtw0fh2h8ps"
+                    lreverse {-86.12 81.35 -49.45 -84.88}
+                    set z {}
+                } key
+                expr {((14 - ($flag >> 39)) <= -23)}
+            }
+        }
+        set data 81
+        incr data -4
+    } elseif {$count != 14} {
+        expr {(min(($key ? -20 : -59.75), (!43)) < $tmp)}
+        expr {(round((-68 / max(1, abs(96)))) ? abs((32 ? 5 : 1)) : (-81 >> 34))}
+        catch {
+            expr {$key}
+            if {$flag >= -3} {
+                set key uu
+                expr {(-(~$count))}
+                set z [expr {abs(int((!29.77)))}]
+            } else {
+                expr {-95}
+                string last "a" "b#@.u:?2@pd54g0"
+                set flag [expr {(~(~49))}]
+                set tmp false
+                expr {(-(-(35 - -54)))}
+            }
+            append tmp -37.04
+            regexp "." "#q"
+            set flag -69.75
+            set tmp 977
+        } msg
+        lassign {46.70} tmp key tmp
+        set n 0
+        while {$n < 2} {
+            set flag -99.75
+            set n qkz
+            incr n
+        }
+        switch -- 63 {
+            "b,zpu3#cdc_21219" {
+                set key 4
+                incr key 7
+                append tmp "uahsq_9.ouy,57+h"
+                lassign {-270 0} flag
+                if {$flag == 4} {
+                    lindex {979 -257 371} 2
+                    set tmp " kf #a:#ozw"
+                    lsort {661 -837 25.55 j}
+                } elseif {round((~$data))} {
+                    set item 1
+                    incr item 3
+                    set val {1 55.62}
+                    expr {-35}
+                    string trimright "czhw7+i?:"
+                    expr {(-65 ** (abs(-28) + (-33)))}
+                    set msg 64
+                    incr msg 0
+                }
+                string last "a" "dejbc4.7=yd,gv7-w1"
+                regexp "[0-9]" "t=#@==rqp1_v!4h j8+e"
+            }
+            -6 {
+                regexp "[a-z]+" "1 49mm_!0:n j41"
+                append key 27
+                set z 78
+                incr z -2
+                append msg 90
+                set val 26
+                incr val -4
+                expr {(-22.94 * (!72.23))}
+            }
+            default {
+                set i [expr {((~(27 - 61)) != 49)}]
+                set key {false true}
+                regexp "^[a-z]" "j!4ht#6"
+                expr {(~((-21 - 2.32) ^ (!-68)))}
+            }
+        }
+    }
+    append tmp 475
+    switch -- ":r+6-o7nz" {
+        756 {
+            append tmp 0
+            set tmp ",;48+bft67n@04y!ru5"
+            switch -- -76 {
+                92 {
+                    if {$n != 10} {
+                        lrange {1 79.65 734} 3 4
+                        string first "a" "1,r@m.=9vv!3hl-xu7"
+                        expr {(-35 ? ((-93) >> (-35)) : ((--93) ? (94.10 - 83) : ($i <= $val)))}
+                        expr {(((69 <= 11.39) > (-64 < 33.99)) != max(($key ? $msg : 78.23), (13 * -34)))}
+                        append msg "yb!4ju457fyi_ m"
+                        expr {26}
+                    } else {
+                        set i 57
+                        incr i 2
+                        expr {$val}
+                        append y "9p2c+acm4k5onf6yfp@4"
+                        expr {$i}
+                        append z "i v??6?!u7cd 274w"
+                    }
+                    set x {}
+                    lappend x -705
+                    set data ".u,65jvp?js1sa8liyx"
+                }
+                default {
+                    regexp "[a-z]+" "scudt--5m"
+                    expr {$i}
+                    foreach count {c 840 hnrjy 182} {
+                        append n -81
+                        regexp "\\d+" "vbbhk#cz;kbzgq#:7"
+                        append count -64
+                        set key {tdkdxuu -1000 19.19 true}
+                        expr {(-(-(-71 / max(1, abs(72)))))}
+                        string range "j6+:re2p" 5 6
+                    }
+                    set tmp 0
+                    while {$tmp < 3} {
+                        expr {(-41.64 ^ (!23))}
+                        lreverse {427}
+                        set z -84.57
+                        set count "p+xz?id"
+                        incr tmp
+                    }
+                    string length "+"
+                }
+            }
+        }
+        "sf_c30e:.2;!" {
+            append z "5#swfqo9r"
+            string index "-;yz4h57" 2
+            expr {0}
+            lsort {-220}
+            string index "..#057b" 5
+            set tmp 88
+            incr tmp -5
+        }
+        default {
+            expr {(max($n, 100) >= -78)}
+            lindex {-24.64 -497 wglxwyd no ec} 2
+        }
+    }
+} elseif {$val >= -2} {
+    expr {((-83.35 << $val) ? min((!$count), 34) : (~(--94)))}
+    set z 17
+    incr z 2
+    foreach x {979 -40 40.24 yes} {
+        set y [expr {31}]
+    }
+    for {set idx 0} {$idx < 1} {incr idx} {
+        for {set buf 0} {$buf < 2} {incr buf} {
+            string index "a0-e1agntf,a" 3
+            expr {26.90}
+            expr {57}
+            string first "a" "wj2.+rqd01yn#?-98"
+            expr {((!(!10.26)) ? ((-45.31 >= -79.85) & (-88 - $flag)) : ((-66 ? 15 : 45) * (--14.88)))}
+            set msg 87
+        }
+        set n "8bys:."
+        set val {397 608 854}
+        set idx ylp
+        append a 698
+    }
+    set item -632
+}
+if {33} {
+    set x wysqjs
+    foreach i {61.66 gttyox} {
+        append key ""
+        foreach msg {1 g 194 no 31.90 574} {
+            set data {}
+            set count "5b2=06dcax.v=2a"
+            append y "8#4w87is"
+            if {-67} {
+                set buf [expr {0}]
+                set y "o47"
+                regexp "\\d+" "p7hy2:0hc4p?2qu"
+                string range "ncge" 2 7
+            }
+        }
+        set y 5
+        incr y -3
+    }
+}
+for {set b 0} {$b < 1} {incr b} {
+    append x ftbd
+    set y 66
+    incr y 7
+    set n 0
+    while {$n < 4} {
+        lassign {-410 f 400 d izegyxl -431} b tmp
+        switch -- "fn" {
+            300 {
+                for {set buf 0} {$buf < 2} {incr buf} {
+                    lrange {-756 -853 751 26.23 qyiaqx} 0 3
+                    set result 9.30
+                }
+                append tmp 59
+            }
+            default {
+                set a "ss+?-,n!,ic9-k0 ,c"
+                set b 3
+                incr b 9
+                expr {34}
+                set b 59
+                incr b 8
+                llength {216 -6.33 -13.45}
+                set z k
+            }
+        }
+        expr {(47 ? (int(62) > (48 > 26.79)) : 8)}
+        foreach result {-69.95} {
+            set i [expr {(((80 ? -14 : $x) ? (46 | 75) : (-86)) + (($buf >= -80.93) ? (71 && $z) : -21))}]
+            foreach y {-46.27 1000 730 -90.35 icllq} {
+                string trimleft "1+h;vko@0"
+                set buf 19
+                incr buf 5
+                set key "f2.t_z8r2ana."
+                set z [expr {27}]
+                expr {(34 - (~(--40)))}
+                set flag 68
+                incr flag 1
+            }
+            set n {-537 -211 1 false}
+        }
+        incr n
+    }
+    for {set a 0} {$a < 5} {incr a} {
+        set data 0
+        while {$data < 3} {
+            lassign {90.15 -59 -965} count x key
+            expr {52.03}
+            set result 0
+            set j 76.18
+            regexp "\\d+" "1x?5?+#i#dko#wvcmud"
+            incr data
+        }
+        regexp "." ".ul6nq?2,_e"
+        string first "a" "gh2"
+        append y 51
+        set n "x cy;#"
+    }
+    set count [expr {-84}]
+    set idx 74
+    incr idx 2
+}
+if {58} {
+    expr {(((-36 < 54) - (-96 * $data)) && max(-48, (-44.33)))}
+    for {set y 0} {$y < 6} {incr y} {
+        expr {((!-77) >= (2.06 - (92 >= -63)))}
+        if {$y >= 13} {
+            set buf {}
+            regexp "\\d+" "bqj3"
+        }
+        set data -996
+        lassign {-20.22 727 558 892 true gzhrawm} b b
+        append idx ""
+        expr {(int(round(-34)) ? wide(($i || -46)) : wide(-97))}
+    }
+    append x "_nw88=t8z3??fup?;zu4"
+    foreach j {} {
+        foreach x {p -79} {
+            set z {0 156 413 656}
+            append y "@rf;tun9w#"
+            expr {(((~-43) && (29 / max(1, abs($count)))) >> round((34 >> -29)))}
+        }
+        lassign {b -788 -70.95 665 459 cbeyu} buf n
+        set idx 692
+        set msg 3
+        incr msg 3
+    }
+}
+set idx 42
+incr idx 4
+foreach y {-83.71 qvqph 480 true rnerfv 6} {
+    regexp "[a-z]+" " w-xn 4:++e5r+,9"
+    expr {double((-4 ? $flag : $b))}
+}
+namespace eval foo {
+    foreach y {-816} {
+        append tmp -53
+        set idx 25
+        incr idx 6
+        set x [expr {16}]
+    }
+    set result cq
+    append i 17
+    foreach key {} {
+        for {set y 0} {$y < 2} {incr y} {
+            foreach buf {28.40 tmhotse 1 fknosgae} {
+                string reverse "_wm2+fx"
+                set val "@r=_?uq6!px@n#d6h_"
+                set a 1
+            }
+            lsearch {117 false 12.04 -732 541 roa} 872
+        }
+    }
+    append val "59#us=#0c4lhej,qkx"
+}
+expr {(-58 << 32)}
+set z {-2.20 442 -405 -374 804}
+if {(!-58)} {
+    expr {(min((-67 || -56), 44) * (max(57, -56) ? 37.30 : 71))}
+    if {$buf} {
+        string index "bp5 3=.!4jf" 4
+    }
+    for {set x 0} {$x < 2} {incr x} {
+        set i bdvipmuw
+        set i {-893 5.11 acrzwzj -634 lacjxqj}
+        append count hw
+        set item true
+        append y "?3r=0s#_3!ekd"
+        set result 0
+        while {$result < 1} {
+            lreverse {-23 25 tgudrfm no xkfhrn}
+            incr result
+        }
+    }
+    if {$item >= 13} {
+        expr {(-34 / max(1, abs((($x + -47) + (69 ? $count : 79)))))}
+    }
+    list "tuad,dddp:" 97 false 13
+    set item false
+} elseif {$idx > -3} {
+    for {set buf 0} {$buf < 2} {incr buf} {
+        if {$flag > -9} {
+            set count "bgmrr2@r,!hl!bdd0!b"
+            append n no
+            expr {(-9 % max(1, abs(35)))}
+            set i ciaogh
+            set count 1
+        }
+        set msg 552
+        expr {(($data < $buf) ? ((-40 != 99.46) > (!$key)) : ((78.95 >= -41) ** $item))}
+        set z -840
+    }
+    for {set acc 0} {$acc < 1} {incr acc} {
+        append key "d#=;hqrmwv?gd"
+        string map {a b c d} ""
+    }
+    set idx 0
+    while {$idx < 5} {
+        set count true
+        incr idx
+    }
+    if {$n != -3} {
+        string range "4hh" 0 7
+        set idx -17.55
+        for {set acc 0} {$acc < 2} {incr acc} {
+            lassign {} x x result
+        }
+        expr {(!$flag)}
+        list 4 -24 1 -87.76
+        set idx [expr {(((-45 <= $key) ? (--8) : $data) % max(1, abs((88 & (91 ? 84 : -68.01)))))}]
+    }
+}
+proc worker {} {
+    set key "+g?_"
+    regexp "[a-z]+" "k.c58cl6w4,4c"
+    lrepeat 1 "3s3l8::"
+    set data hyktz
+    regexp "[0-9]" "_d#7_?9pzl9o-5f5ce"
+    return -78.68
+}
+if {16} {
+    set count 0
+    while {$count < 5} {
+        lassign {-46.77 489 no pifach} data acc
+        append tmp ""
+        catch {worker 24.90 "wq"}
+        expr {$msg}
+        incr count
+    }
+} else {
+    if {(($z & $item) > $a)} {
+        set i 0
+        while {$i < 1} {
+            append i 2
+            for {set n 0} {$n < 4} {incr n} {
+                expr {49}
+            }
+            expr {(~(~wide($item)))}
+            set msg 51
+            incr msg 2
+            incr i
+        }
+        for {set result 0} {$result < 6} {incr result} {
+            foreach i {-811} {
+                set tmp 184
+                expr {-63.03}
+            }
+            set x cr
+            set key {u 871 -486 -892}
+            lappend key -39.55
+            append count ""
+            catch {worker 73 " z?zui.s3vgb!p" -47.91}
+        }
+    }
+}

--- a/fuzzing/findings/seed_1774200073.json
+++ b/fuzzing/findings/seed_1774200073.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200073,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use non-numeric string \"y2w3\" as left operand of \"+\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use non-numeric string \"y2w3\" as left operand of \"+\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200073.tcl
+++ b/fuzzing/findings/seed_1774200073.tcl
@@ -1,0 +1,253 @@
+string reverse "ipu1a5 y"
+append msg "y2w3"
+if {(~-7)} {
+    expr {((47 ? ($msg + 85) : (!32)) >> 86)}
+    append msg true
+    for {set a 0} {$a < 6} {incr a} {
+        list 53 -27.64 no -201
+        for {set a 0} {$a < 6} {incr a} {
+            set msg -393
+            set msg [expr {-47.08}]
+        }
+        set msg 93
+        incr msg 2
+        set msg {n -193 oosxce true 1}
+        set item 1
+        if {$a > -8} {
+            lassign {76 1} msg
+            for {set msg 0} {$msg < 3} {incr msg} {
+                set j {518 false 0 zdsnuttp 1 -917}
+                expr {(((-0.51 || 56.34) || $msg) || min((-60 || $item), ($j ^ 64)))}
+                set buf "nqbf7go..tzvvm0k4ori"
+                set a "w_:?v#9_1v4;.,_;?!+h"
+                expr {16}
+            }
+            regexp "." "+io@6"
+            append item true
+        } else {
+            regexp "^[a-z]" "h6-ie_nh@o=9x i9b!"
+            lassign {544 -60 879 fvaf yes} msg buf
+            expr {(((0 ? -37.40 : $buf) || -71) ** (!(49 == 18.69)))}
+        }
+    }
+} else {
+    lassign {-313 -829 0 cnrhz -762} a i
+    string trim ""
+    if {((56.91 * 51.18) ? $buf : max(19.81, 31))} {
+        for {set a 0} {$a < 3} {incr a} {
+            foreach val {} {
+                set j yes
+                expr {-56}
+                lindex {stk} 2
+            }
+            switch -- 73 {
+                -36 {
+                    string reverse "oq@wr"
+                    set buf ":js0w?0idxnf6+4vp."
+                    set a "#n2kls+hn.00tk"
+                    string toupper ""
+                    set x 630
+                    set j -673
+                }
+                44 {
+                    append key 15
+                }
+                default {
+                    expr {(~(~int(-34)))}
+                    append msg -518
+                    append key true
+                    set b [expr {-94}]
+                    string range "b_:.67+d0bt:yhf" 0 6
+                }
+            }
+            join {141 true -569 oh 0 -19.93} "-"
+            append val -86
+            lrepeat 1 "7b0dk3mwkqht"
+        }
+        set key {-973 -9.54 36}
+        switch -- "i" {
+            98 {
+                set x {false 8.51 -3.74 no -1.36}
+            }
+            29.77 {
+                regexp "\\d+" "?61eml2j14@9g"
+                append x -722
+                expr {((~abs($i)) / max(1, abs((28 || (~98)))))}
+                expr {-3}
+            }
+            54 {
+                expr {(abs((--86)) >= (($a ? 38 : -53.25) - (71.79 || 60.69)))}
+                append a -74
+                set idx -84.98
+                regexp "^[a-z]" "ez2_k-y: ly1!g5 l"
+                set z "6!?0?lo e!7"
+            }
+            -868 {
+                lreverse {akcvyje -538 851 true}
+            }
+            default {
+                append item jisrlm
+            }
+        }
+        set b true
+    } else {
+        join {} " "
+        string repeat "x8k3mf-e8d?m" 4
+        regexp "\\d+" "l.h"
+        expr {max(89.55, double((!45)))}
+        set j 32
+        incr j -2
+        lrepeat 1 61
+    }
+}
+if {$key != 7} {
+    foreach a {vmbzze uh rh yes sdvfaf} {
+        regexp "^[a-z]" "127?p0:-u_n9pt5mo6i"
+        set x 19.56
+    }
+    set flag "p3 _,ffq35;lkh"
+    set a [expr {$msg}]
+    foreach result {1 24} {
+        set b rgtfvk
+        llength {90.53 0 -31.21 538}
+        set result suyhru
+        set item -89.76
+        for {set count 0} {$count < 3} {incr count} {
+            string length "lstmt3+c_8wz2nh1ks "
+            set item {46 yes 834 29.75 false}
+            set idx [expr {23}]
+            append x "8?"
+            set buf 0
+            while {$buf < 3} {
+                join {1 ujzczgrf 34.14 96 1} " "
+                incr buf
+            }
+        }
+    }
+    append buf -60
+    string toupper "=-x.y79=_ 5bkoenel"
+}
+set n 0
+while {$n < 4} {
+    foreach b {-5.12 850 xzofzofw -816 -979} {
+        string trimleft "-.:"
+        append key eztx
+        lassign {74 dj} x
+        set idx 22
+        incr idx 7
+        for {set idx 0} {$idx < 3} {incr idx} {
+            list 88 "@9d?_" "cdmz:z;t2p"
+            set x w
+            string trimleft "qi:?5z1+mcms53_-06"
+        }
+        append j -6
+    }
+    set count 97
+    incr count 2
+    incr n
+}
+append data -48
+proc compute {{key swn}} {
+    expr {62}
+    string tolower ""
+    switch -- -24 {
+        -8 {
+            foreach i {962 cfgqqm zcei} {
+                expr {(39 >= (~(!71.97)))}
+                set n -17.67
+                set idx 816
+            }
+            set z [expr {((min($n, -38) << -22) < $z)}]
+            set idx 57
+            incr idx -3
+            set a [expr {((-18 % max(1, abs(int(-41.21)))) > round((1 - 39)))}]
+            if {$buf < -7} {
+                set key -513
+                switch -- -432 {
+                    x {
+                        expr {53}
+                        set z 44
+                        incr z -5
+                    }
+                    default {
+                        append count 58.35
+                        set z 40
+                        incr z 1
+                        set key [expr {(-81 ^ -71.46)}]
+                        expr {(-9 / max(1, abs(max(-12, (-68 == -40.47)))))}
+                    }
+                }
+                set idx "@fg24o.#x684!caf9"
+                append key -28.11
+            } elseif {$flag} {
+                lsearch {19.92 jrfz 559} "umd12tg 0;"
+                set z {993}
+                regexp "^[a-z]" "+z3h-9#l30d@pske#k="
+                lassign {14.22 185 -588 false true 56} item n
+                append msg -138
+            }
+            lrepeat 2 -41
+        }
+        36 {
+            append count no
+            set data {60 dasgisfd -434 52 -33}
+            foreach item {0 false 837} {
+                if {(~-92.83)} {
+                    string last "a" "5:"
+                    set msg 8
+                    incr msg 2
+                    set i "p8jxw?.ex"
+                    set j 36.40
+                }
+                string last "a" "re ,c5+ dti.htai"
+                set data [expr {34.83}]
+                expr {-62}
+            }
+            set item 5
+            incr item 1
+            expr {$val}
+            append result ""
+        }
+        "+r#dj0i;#0" {
+            lassign {rb -683 zfzkdq yes} b i b
+            set item {43.63 -141 280 lmv}
+            set i {516 false -384 69 akizil}
+            set idx 271
+            regexp "[a-z]+" "6t-:h;"
+        }
+        default {
+            string length "o?sjdswh slf5u"
+        }
+    }
+    set val [expr {-59.54}]
+    set i 2
+    incr i 7
+    return 0
+}
+catch {
+    set val 45
+    incr val -1
+    if {(double(65) ? (-20 ? -86 : $msg) : ($x ? -4 : $z))} {
+        for {set msg 0} {$msg < 3} {incr msg} {
+            set item 0
+            while {$item < 5} {
+                concat {} {-693 947 qm stonelju tlmy}
+                append z "!!s"
+                catch {compute 54 ozn "u.e;l_,3ky:;p"}
+                incr item
+            }
+            join {143} "-"
+            list -65.43
+            set i 39
+            incr i -3
+        }
+        catch {compute }
+        expr {(-34.33 > -3.44)}
+    } else {
+        set idx [expr {67}]
+        set idx {}
+        set x 24
+        incr x 10
+        catch {compute -8.59}
+    }
+} key

--- a/fuzzing/findings/seed_1774200074.json
+++ b/fuzzing/findings/seed_1774200074.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200074,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"count\": no such variable",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"count\": no such variable",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-ignores-missing-var"
+}

--- a/fuzzing/findings/seed_1774200074.tcl
+++ b/fuzzing/findings/seed_1774200074.tcl
@@ -1,0 +1,388 @@
+foreach count {} {
+    lassign {-32.64 false 171 313} count count
+    set count "+.!6uot"
+    foreach count {-226 492 juvczzlr w yes} {
+        lrepeat 3 14
+    }
+    switch -- -14 {
+        "mwvu6bjo" {
+            set count "bqcmc3."
+        }
+        "pni" {
+            expr {(((32.93 + 16) < (53 % max(1, abs(44)))) != max(8.74, (33 ? 84.10 : -95)))}
+            append count 61
+            set count r
+            set count no
+            set count -739
+            if {$count <= 18} {
+                expr {51.80}
+                expr {(21 | (round($count) ? (~0.29) : (!70.60)))}
+            }
+        }
+        "ukc28@-;f" {
+            expr {(-92.54 / max(1, abs(85)))}
+            append msg 734
+            set msg -976
+            set msg ""
+            set a 621
+        }
+        -39 {
+            append buf re
+        }
+        default {
+            for {set count 0} {$count < 2} {incr count} {
+                lassign {-806 k 821 -818} msg count
+                regexp "." "4lmujch+7zyy:c?h5"
+                set n 55
+                incr n 5
+                set a 84
+                incr a 0
+                if {double((62 < $buf))} {
+                    expr {(-56 % max(1, abs(94)))}
+                    set n true
+                    set msg -80.85
+                } else {
+                    set n {-878 true}
+                    lappend n mbvolk
+                    expr {$buf}
+                    string reverse "mbi;jzsi:3!278"
+                } elseif {$a != -6} {
+                    expr {($buf ? 77 : -3)}
+                    regexp "[a-z]+" ".d=d0sv.d6"
+                }
+            }
+            if {$a < 17} {
+                set n 16
+                incr n 8
+                set result "17?vx6:oqb2?g_z8ow"
+                append a -484
+                foreach j {14.69 -711 -35.54 43} {
+                    expr {(46 + 50)}
+                    lassign {86.93 0} msg msg msg
+                    set count 90
+                    incr count -3
+                    join {nzoxpx -422 47.44 690} ","
+                }
+            } else {
+                set buf {-12.15 -34 -542 -686 gkployw 89.53}
+                set count {}
+            }
+            lassign {jstvag 446} j buf
+            set j 0
+            while {$j < 2} {
+                set count -770
+                string tolower ""
+                incr j
+            }
+        }
+    }
+}
+set buf 0
+while {$buf < 1} {
+    expr {((($buf ? 9 : -34) || (!$j)) % max(1, abs(37)))}
+    catch {
+        foreach result {rjh yes 11.28} {
+            list uxeuffo -23 8 ognapuog
+            set j 751
+            expr {(((~33) % max(1, abs(-47))) / max(1, abs((!(71 ? $j : 90.04)))))}
+            set msg "6@:=jm_!rqxup4a"
+            lassign {-139 0.94 0 834 -259 103} n result
+        }
+        set j -42.61
+        set data 37
+        incr data 9
+        append j -520
+        expr {(((71 ^ -19) ? -80 : (!3)) >= ((-22.14 != 36) - (~-15)))}
+    } n
+    lindex {571 zsiojsj -821 74.33} 0
+    set a 99
+    incr a 4
+    append result "31fv_q7:3.a,u:i;a"
+    incr buf
+}
+set buf {35.08 0 gy 14.43 -440 kzgp}
+set result 72
+incr result 7
+string repeat "z5okwc@j?nnn=0" 0
+if {$count < 9} {
+    foreach data {false 19.80 i yniyuy true} {
+        set msg 28
+        incr msg 2
+        expr {((double($msg) | abs(-1)) ? ((~36) ** (52.16 >= -42.04)) : -99)}
+    }
+    foreach result {-29 599 21.59 97.71} {
+        switch -- "c8o!,1s" {
+            67 {
+                append n 45.50
+                expr {81}
+                switch -- -21.86 {
+                    ".ycb=,ear+ob8pu3h" {
+                        set data mnyydez
+                        lassign {-40.59 yes 20.84 -28.43 0 false} b
+                    }
+                    58.89 {
+                        expr {-42}
+                        set n 23
+                        incr n 8
+                        string toupper "ku-i8decl6!qe"
+                        expr {((double(39.37) - (85 >> 75)) != -80.98)}
+                        set count 7
+                        incr count 0
+                    }
+                    9 {
+                        append result -946
+                    }
+                    default {
+                        append b ":xjpn#re j"
+                        lreverse {}
+                    }
+                }
+            }
+            b {
+                set n 21
+                incr n -1
+                foreach data {unbeksgc -55.90} {
+                    lassign {977 -96.15} result buf
+                    expr {(-6)}
+                    set j "g9ndx.2;nnnw-6lyj4n"
+                    set z 906
+                    expr {$b}
+                    set y [expr {67}]
+                }
+                string toupper "de1r9w=i"
+                set flag [expr {(~((-80.24 <= 46) << (54.78 != -57)))}]
+                append n 414
+            }
+            -38 {
+                append n -14
+            }
+            default {
+                set a 88
+                incr a 3
+                regexp "\\d+" "mhxcwzlalol6z+8hk "
+                set z {}
+                lassign {643 -785} result j
+            }
+        }
+        expr {(-86 > ($msg == (33.77 ? -29.05 : -11.37)))}
+        for {set y 0} {$y < 2} {incr y} {
+            set y [expr {$result}]
+            append x 33
+        }
+        append n 87
+        set b ";+xcfdlkq"
+        string reverse "gdwb42j43kh"
+    }
+    foreach n {bakl -628 yrja k 8 821} {
+        append n -934
+        lassign {0.85 69.22} buf msg
+        expr {(round((~$data)) | ((52 ? -73.18 : 38) ** ($y ? -34 : 37)))}
+        set x "ck-.mw=snjf8v"
+        set y 0
+        while {$y < 1} {
+            set tmp "_j7lndjxia2fhul"
+            expr {-66}
+            append b vmo
+            llength {-751 -949 -34.37 -804 0}
+            set tmp "#_9#4x?k "
+            incr y
+        }
+    }
+    for {set count 0} {$count < 1} {incr count} {
+        expr {-69}
+        append result 895
+        foreach buf {yes -952} {
+            set buf "s"
+        }
+        set acc "hwq=-097sa:fuuf"
+        lindex {1 81.49 -644} 1
+        regexp "." "7v0+g#45hx!+"
+    }
+    for {set n 0} {$n < 6} {incr n} {
+        set result 0
+        while {$result < 5} {
+            append a no
+            expr {-23}
+            set tmp -746
+            incr result
+        }
+        for {set data 0} {$data < 2} {incr data} {
+            expr {int(-33)}
+            set y -497
+            lassign {} z
+        }
+        if {47.81} {
+            set result 905
+            lrepeat 2 -56
+            set buf 767
+            string toupper "!c6j#!26ppz,otc34"
+        }
+        expr {(~((-7) && ($msg ? $acc : -93)))}
+        append idx true
+        set b 40
+        incr b 1
+    }
+} elseif {($n % max(1, abs((51 + -72))))} {
+    set buf 834
+    expr {(!(($a + -61) & ($data & 97)))}
+}
+expr {(($result % max(1, abs((-79 ** -41.06)))) && -53)}
+set x [expr {(-55 ? (!-46.96) : ($y ? (-92.29 > 23.07) : -11.91))}]
+append z lb
+string length "w@4n-,02y"
+proc worker {count args} {
+    set acc [expr {-41.37}]
+    list 47.58 5
+    set acc 0
+    while {$acc < 4} {
+        catch {
+            string trim "w6kp4"
+        } tmp
+        set acc [expr {6}]
+        expr {-11.79}
+        set n "k19"
+        catch {
+            expr {(!((18 ? -66 : $z) <= round(-27)))}
+            expr {(!(-20 ? 81 : (-86 >> 20)))}
+            set i 40
+            incr i 7
+            if {(-62 << $tmp)} {
+                append i 20
+                set flag {}
+                regexp "[a-z]+" "t"
+                lsort {lvggxu no}
+            }
+            expr {(-8.28 ** (~-82))}
+            regexp "\\d+" " -+wz6z-i."
+        } count
+        incr acc
+    }
+    if {$tmp != 9} {
+        string trimleft "4t+3@;_s"
+        foreach tmp {151 no 0 -31 984 qathnkji} {
+            append i 623
+        }
+        for {set buf 0} {$buf < 6} {incr buf} {
+            if {$n > 11} {
+                regexp "\\d+" " 781#1n2"
+                append key "s_s?30a321"
+                expr {(66 << (-98 ** max(-86, 76)))}
+                set idx 29
+                incr idx -3
+                string range "h1: :.xv;zx-qrqxg" 1 5
+                lassign {czd 520 -138 1} val data i
+            }
+            set z yes
+            append msg "j1lg5"
+            expr {-78}
+            set j [expr {(((73 ^ -48) ? -66 : ($idx | 77.29)) ? (~-13) : ((21 << $acc) + $idx))}]
+            set key 51.90
+        }
+        catch {
+            append j 956
+            set acc "fgs."
+        } val
+    } else {
+        set acc 21
+        incr acc 6
+        lassign {sfqezoh msmf 928} msg
+        switch -- 82 {
+            gfpnfx {
+                string trim "3x=s"
+                for {set data 0} {$data < 2} {incr data} {
+                    lrange {96.66 -14 405 498 ypwztzlb 44.97} 0 2
+                    set key no
+                    set z {}
+                    expr {48.58}
+                    string trimright "tui0;91y3jnq9f.b6_z"
+                    set buf {-568}
+                }
+                set flag {}
+            }
+            44 {
+                lreverse {}
+                set val 19
+                incr val 3
+                set buf 191
+                expr {-56}
+                set n [expr {((double(7.09) ? -59.27 : (-88 ? 20 : 75.19)) ? 41 : ((~25) != (-78.41 ? 44 : 50)))}]
+                set j [expr {61}]
+            }
+            default {
+                append acc 86
+                string index "8ql73;9.dyk" 0
+                lsort {-938 -515 61.37 -9.05 -801}
+                for {set y 0} {$y < 2} {incr y} {
+                    join {-266} ""
+                    expr {((!(93 || -65)) && 32.28)}
+                    set x 38
+                    incr x 9
+                }
+                lindex {} 3
+            }
+        }
+        set b 71.46
+        if {(!$x)} {
+            append i 39
+            llength {602}
+            set flag -394
+            set i [expr {(($n || 14) ? (max(-36, $result) - -57) : (!18))}]
+        }
+        if {93.40} {
+            string range "-lana1t" 3 5
+        }
+    }
+    string index "low089-asec-w" 2
+    return -84
+}
+for {set count 0} {$count < 3} {incr count} {
+    foreach n {-532 -858} {
+        set data [expr {(((-41.88 << $msg) || (~-48.09)) ? (!(82.29 != 16)) : 97)}]
+        regexp "[0-9]" "paa178kh2"
+        set flag -869
+        catch {worker "peua:g7@zn"}
+        if {$z >= -7} {
+            catch {worker 71}
+            set count 30
+            incr count 4
+            set count 0
+            while {$count < 2} {
+                set a {jnlhv}
+                string trim "wx_asf"
+                string repeat "m5jvm17r6oqq" 1
+                set z {taek 312 crfvahgm gvcipt}
+                expr {63}
+                incr count
+            }
+            expr {82.57}
+            set j [expr {27}]
+        } else {
+            catch {worker ""}
+            switch -- "6chofn5x5jt;hycwe72v" {
+                no {
+                    lassign {d 78.18 true 128 19 357} result data j
+                    set x {hssih no do 348 -481 yes}
+                    expr {19.74}
+                }
+                default {
+                    catch {worker }
+                    expr {(!-34)}
+                    set tmp ":ls:w8ora"
+                    lsort {555 -995}
+                    expr {$idx}
+                }
+            }
+            set y "z,b+"
+            set data [expr {(((6 / max(1, abs(37.77))) ? ($i ? 44 : 22) : double(-38.88)) <= 61)}]
+            catch {
+                expr {(-48 ? (69 ^ (~31)) : round((-8.91 == 69)))}
+                string tolower "lhq31pkh-lr123_q:og"
+                set z {wotx false -13.08}
+                set key yes
+                string index "e2s.1 w?@@hs" 0
+            } val
+        }
+    }
+    string map {a b c d} "i3 ve!9x.j_#rg;?i"
+    string last "a" "zv9ll"
+}

--- a/fuzzing/findings/seed_1774200076.json
+++ b/fuzzing/findings/seed_1774200076.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200076,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "exponentiation of zero by negative power",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "exponentiation of zero by negative power",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200076.tcl
+++ b/fuzzing/findings/seed_1774200076.tcl
@@ -1,0 +1,160 @@
+foreach x {0 -383 -42 745 0 0} {
+    if {((!-61) ** round(-74))} {
+        expr {(~26)}
+        string trimright "3=9=6:8.!+.4, 4d"
+        lsearch {-96.97} 84
+        if {($x % max(1, abs((~20))))} {
+            set x 81
+            incr x 5
+            set x [expr {$x}]
+            set x " r1m5?6sht"
+            set x {541 da 64.84}
+            lappend x "h#.4ud+y!"
+            expr {-61.58}
+            expr {(30 - -32)}
+        } else {
+            foreach y {38.10 vspqw xg cdvmahy no} {
+                append y -594
+                set x yes
+                set y [expr {-62.70}]
+            }
+            append count "1098y3"
+            set x 261
+            catch {
+                string range "id80ck0,f-4ecaa1ub!" 4 7
+            } count
+            set b 36
+            incr b 0
+            expr {(((--73) < max(-81, $y)) ^ (!(-69.69 / max(1, abs(-23.37)))))}
+        } elseif {((7 || $x) % max(1, abs(double($count))))} {
+            switch -- "eb25b" {
+                "7" {
+                    set flag [expr {-0.03}]
+                    set y {-258 1 true -15}
+                    expr {(77 || (3 ? min($x, -34.01) : round($b)))}
+                    set flag {}
+                    lappend flag 13
+                }
+                "4iabexs" {
+                    set item "3k?y3?"
+                    lsort {xhqf 226 -406}
+                    set idx -23.09
+                    set flag -54.46
+                    expr {((-67.79) ? -80 : (30.31 + 11.99))}
+                    append z -39
+                }
+                default {
+                    llength {-119 570 -70.43 true}
+                    llength {0 55 159 95.04 72 qylcbu}
+                }
+            }
+            set flag pfwz
+            set item 47
+            incr item 7
+            if {$z} {
+                expr {((4 == -23.75) ? 29 : max(99, 46))}
+                lassign {902 930 -324 832} val z
+            }
+            string last "a" "fik"
+        }
+        lassign {605 -93.74} idx n flag
+        set flag 1
+        incr flag 9
+    } elseif {int((~-68))} {
+        if {$val >= 6} {
+            for {set y 0} {$y < 2} {incr y} {
+                string first "a" "c-n! 6ghf;cw3lq!l"
+                set item 18
+                incr item 6
+                lreverse {-74.03 lui yes 21.82 rmoe 15.97}
+                string length "z?z4req0?pdfk-m8=!g"
+                string length "ge89;+n"
+                set y "ynx6"
+            }
+            lassign {-40.12 281 -554} a y z
+            set n 71
+            incr n 0
+            expr {((!(51.19 < 6)) / max(1, abs(((4 % max(1, abs($a))) + (-16 ? $count : 21)))))}
+            set z 86
+            incr z -5
+        } else {
+            expr {((($a == $y) << 8.98) - (($a % max(1, abs(39))) << -93))}
+            lsearch {-60.27 -235 53.16} "xbmqms ,-8:9#g;10p"
+            append idx uwdkrb
+            set count 86
+            incr count 10
+        }
+        set idx {-976 66 true 1 217 69.63}
+        lappend idx -44.92
+        for {set item 0} {$item < 5} {incr item} {
+            string map {a b c d} ""
+            set val {0 -20.67 407 1 47 995}
+        }
+    }
+    set flag 0
+    while {$flag < 1} {
+        set val 0
+        while {$val < 4} {
+            lrange {-205 -917 false 216 -22.79} 0 1
+            append data -925
+            incr val
+        }
+        expr {((max(-65.24, $flag) <= $val) | (~(30 >= 46)))}
+        set item 0
+        while {$item < 4} {
+            string reverse ""
+            list 100 "1ai0h.5xex75:yt#?" "6:" 506
+            incr item
+        }
+        incr flag
+    }
+    set msg 0
+}
+proc handle {{b eniyga} j} {
+    set count 14
+    incr count -1
+    if {$flag <= 13} {
+        if {$z >= 11} {
+            set x "cy9we#cmbx"
+            append x "=ym+1;m6oc3vxvqeis0k"
+            set msg 34.25
+            set msg 0
+            for {set count 0} {$count < 1} {incr count} {
+                set item 87
+                incr item 1
+                set flag {}
+                lappend flag -8
+                expr {(!(7 ? (!$n) : ($y >= $val)))}
+                string range "8dtd5?#k:4dl" 4 7
+            }
+        }
+    }
+    return "2kif5:o8fs+jhfpa"
+}
+expr {(((~3) <= (-79 && 53)) ** wide((-1 - 33)))}
+namespace eval baz {
+    set flag 7
+    incr flag 8
+    lassign {false 44.33 hdz us} flag
+    for {set msg 0} {$msg < 5} {incr msg} {
+        string range "j7d" 2 6
+        set b 807
+    }
+}
+for {set item 0} {$item < 5} {incr item} {
+    if {22} {
+        string tolower "3c7usw2ump;"
+        set idx rcnxeym
+        llength {sasg 681}
+        append data no
+        for {set count 0} {$count < 3} {incr count} {
+            regexp "." "fqite.a#vci="
+            set item 0
+            while {$item < 3} {
+                catch {handle 64 -44}
+                set idx "5u4;yeej8,."
+                incr item
+            }
+        }
+    }
+}

--- a/fuzzing/findings/seed_1774200081.json
+++ b/fuzzing/findings/seed_1774200081.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200081,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"msg\": no such variable",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "can't read \"msg\": no such variable",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200081.tcl
+++ b/fuzzing/findings/seed_1774200081.tcl
@@ -1,0 +1,321 @@
+lreverse {-634}
+set msg [expr {((-(-13 ? 59 : $msg)) && max($msg, (28.37 > -20)))}]
+expr {15}
+set msg 90
+incr msg -1
+foreach n {yes -268 333} {
+    for {set val 0} {$val < 2} {incr val} {
+        set n {-75 0 false}
+        append val -82
+        expr {-53.03}
+        lassign {398 504 -804 471 true 785} n key
+        set val 85
+        incr val 8
+        foreach n {} {
+            string length "wqf"
+            lassign {hah 90.68 302} val msg
+            set n 66.76
+            set acc gcngsyy
+        }
+    }
+    append val "#e :5#lv@8m#lo"
+    set acc "e?s?l#ektq"
+    expr {(($msg == (-75)) | ((-41.42) ? (-91.97 | 28) : -49))}
+    set acc "+9?fz.j?js#c7@:w"
+    set z -10.51
+}
+for {set flag 0} {$flag < 3} {incr flag} {
+    foreach acc {366 436 havjt 1000 byb} {
+        set acc 423
+        if {wide((!79))} {
+            append key " ?pzfkxgly8s"
+            set msg 39
+            incr msg 5
+            set msg "nhv7vkct_,9pfb+y,"
+        }
+        foreach z {yes -297 6.04 vopkl} {
+            set acc {}
+            catch {
+                set key ""
+                set key "acuw1@i1brqz!!j"
+                expr {(61.54 != (51 / max(1, abs(wide($acc)))))}
+                set idx 6
+                incr idx 2
+            } x
+        }
+    }
+    if {91} {
+        set x 18.66
+        for {set data 0} {$data < 6} {incr data} {
+            set acc [expr {((!(40 <= -95)) ? $data : (64.22 == (~75.48)))}]
+            set x 50
+            incr x 6
+            lreverse {-263 728 67.47 zwttqpe -317 -655}
+        }
+        expr {-25}
+        set count vsipp
+    } else {
+        for {set data 0} {$data < 5} {incr data} {
+            set item 6
+            incr item -4
+            set acc {sqxsvcqa isb true false -25 520}
+            list "l.#s!hq_d4n34=" 31.17
+            set x [expr {41}]
+            set item "kxfu-j44v?6gbna,89"
+            expr {(-(($idx ^ -50) ? -79 : (-57 >> $idx)))}
+        }
+        set val 99
+        incr val -2
+        set x 0
+        while {$x < 2} {
+            set y {0 da -328 -657 23.08}
+            lindex {wakxp -779 674 36.36} 1
+            set j 0
+            while {$j < 5} {
+                concat {-38.60 -679 true b} {-618 mskjcklh joqyg 53.85 -89.05 271}
+                set j "hkley"
+                set key 56
+                incr key 9
+                incr j
+            }
+            incr x
+        }
+        lindex {true -59.42 yes -528} 2
+    }
+    set j {-707}
+    string tolower "91wp9gm?7sqxzm14+o,z"
+    set count 0
+    while {$count < 3} {
+        foreach b {} {
+            set z {169 aer 13.43 83 695 -771}
+            switch -- -101 {
+                mnsy {
+                    string range "vhf1s=8v=" 1 6
+                    set n 31
+                    incr n 2
+                    string index "pl!!z ekvv=i" 4
+                    set data 44
+                }
+                bnumv {
+                    set count false
+                }
+                default {
+                    set n 257
+                    set y [expr {(((-13.14 ** $item) > round(98)) > 77)}]
+                }
+            }
+            append result "3s7eqi"
+            set result "ybxn,ryb!jb440v5@=bm"
+            append j ct
+        }
+        for {set item 0} {$item < 3} {incr item} {
+            set acc 209
+            append z -39
+            expr {((!(-17.97 < -99)) ** (-9 ? (21.09 & 53) : int(81.90)))}
+            if {$x > 4} {
+                set data "1v:.x 983"
+                append y no
+            }
+            set flag "nla0kn,zwcqy:4q"
+            lassign {-86 232 u 469 -92.78} n
+        }
+        if {(-max(13, -96.94))} {
+            regexp "\\d+" "mc"
+            lassign {-816 -90.55 yes 909 -941} flag
+            expr {((53 & int(56)) ? (($x >= 42) ? $data : (-57 ? 45 : 73.07)) : ((-76 * -31) & ($msg * -27)))}
+            set j " 0o6+47u?uh.2p5:"
+            string length "4t"
+        } else {
+            expr {(-67)}
+            if {((33 << 79) && (27.06 * -58))} {
+                set idx {d 1 -902 naqjizdh 547}
+                set flag {-88.13 xaxejq}
+                lassign {908 -74.98 -240 -995 -856 862} flag
+                expr {-72}
+                expr {-2}
+            } else {
+                string trimleft "ii"
+                set item no
+                append b -92
+                expr {-57}
+                append y 35
+            }
+            append msg ".y7q?ocd915_z-.z_."
+        }
+        incr count
+    }
+}
+set x {-18.67}
+for {set key 0} {$key < 4} {incr key} {
+    set j "u=w@.79"
+    string range "+dhn9" 1 6
+    for {set val 0} {$val < 2} {incr val} {
+        append i -81
+    }
+    append item 13
+}
+proc worker {{i 597}} {
+    expr {(!(int($key) % max(1, abs(($count <= 92)))))}
+    set tmp 40
+    incr tmp 8
+    set acc [expr {(((-25) ** (-33 ** 89)) * (34 + 92))}]
+    switch -- 71.36 {
+        -41 {
+            set a izduin
+        }
+        6 {
+            regexp "[0-9]" "0=zd?xfxyc8?@5!ih_- "
+            for {set idx 0} {$idx < 5} {incr idx} {
+                set data -791
+                lrange {-555 true} 0 4
+                expr {(($acc == (!$j)) ? (-15 ^ (!54)) : -41)}
+                lassign {598 false 36 65.65} flag result
+            }
+            set b 76
+            incr b 10
+            string toupper "_"
+            switch -- "c6" {
+                -94.39 {
+                    append n "1.p-"
+                }
+                "t8z47dk" {
+                    expr {abs(33)}
+                    expr {(!(int(-93) + -9))}
+                    lassign {0 991 869 fihs 0} val item
+                    string first "a" "aqy.5c7fb5_zyz@8gu"
+                    regexp "\\d+" "5928iuei63@+m?@"
+                }
+                default {
+                    append i "iy9 7lad-=ke,j"
+                }
+            }
+            set key -68.81
+        }
+        -76.55 {
+            set b 96
+            incr b -1
+            switch -- yldqbxv {
+                "aafmd15_k_a--tb" {
+                    set a "-n,"
+                    if {$a == 2} {
+                        set val 53
+                        incr val 2
+                        set flag 24
+                        incr flag -4
+                        set count {no vqpmrtr}
+                        lappend count 41
+                    } elseif {$tmp < 12} {
+                        set val [expr {(-21)}]
+                        expr {double(($b == ($n != 69)))}
+                        set item 628
+                        set count "dvk.u=?0d_d9ra;x:"
+                    }
+                    regexp "." "!-."
+                }
+                -17 {
+                    set b -933
+                    set data [expr {$idx}]
+                    if {$count > 4} {
+                        lassign {83.54 -744 465} b a
+                        set j false
+                        llength {yes}
+                        append a 649
+                    } elseif {34} {
+                        set j [expr {-95}]
+                        set tmp "04@rs_.v"
+                    }
+                    append tmp "ry5"
+                    regexp "\\d+" "d!jmd7"
+                    expr {(-41 ^ 63)}
+                }
+                -17 {
+                    if {($j ? (-14.57 ? 42 : 75.33) : (42 & -52))} {
+                        set n 47.50
+                        set z [expr {(!((6 != $x) == abs(-33.95)))}]
+                    }
+                    expr {-78}
+                    append buf "d3o8qwse.z_: "
+                }
+                "-ki752me@@ulb=-3xv." {
+                    for {set j 0} {$j < 2} {incr j} {
+                        set flag "o_pf+a x2k?"
+                        lassign {-323 -36.07 -213 -999} count y
+                        set a 13.30
+                        set result 70
+                        incr result -2
+                        expr {(~((-99.34 + 68) == (~-24)))}
+                    }
+                    set x 44
+                    incr x -3
+                    if {($acc << (9.48 - -58.47))} {
+                        append flag -4
+                    }
+                    expr {$val}
+                    lassign {73.34 hiua kootmj 439} i y y
+                }
+                default {
+                    set n 32
+                    incr n -3
+                    regexp "\\d+" ""
+                    lassign {hw ng ew yes} count idx tmp
+                }
+            }
+            for {set n 0} {$n < 3} {incr n} {
+                foreach key {-807} {
+                    lsearch {f 44.20 -596 329 vstmplno} -36
+                }
+                expr {(((40 << $a) >= (~$flag)) <= 65)}
+                set flag 44
+                incr flag 6
+                expr {(63 ? 76 : (-24 ** (15.50 | 90.33)))}
+                set key 88
+                incr key 4
+                expr {wide((54.49 / max(1, abs((-15 | -4)))))}
+            }
+            expr {abs((-27 >> $z))}
+            string repeat "buh.yv9_z4.h@0o79rq" 2
+        }
+        1 {
+            catch {
+                expr {(((!-68.56) == (-4)) ? ((--38) == 10.60) : $b)}
+                lindex {-11.05 -69.82 gqusvxjw -928} 2
+                append n ".wke: ?"
+                set b 89
+                incr b -2
+                lassign {tj 230 false bcwxs yb} i n val
+                join {35.86 -853 yes -197} "-"
+            } b
+            for {set a 0} {$a < 2} {incr a} {
+                append result "+y;+lohdmsl6 ;t2="
+                set result 94
+                incr result 8
+                set count no
+            }
+            expr {((wide($acc) % max(1, abs((-31)))) == ((-41.29 ? $val : 87) ^ (78 >= -60)))}
+            expr {((-56 || (-39.45 << 39)) == (-(-49 + -69)))}
+            string first "a" ":nq2f"
+            set data 29
+            incr data -1
+        }
+        default {
+            string trim " v ;4p=jgigv7etxthq"
+            append buf s
+            regexp "[0-9]" "yf_nu5u5nu_43p"
+            catch {
+                regexp "[a-z]+" "29i2!9=wfn0dy;i"
+                append n "_ f71rsu56"
+                set x "n2o6 k"
+                append item -70
+                lassign {qerbovd -90.89 ijsr 24.51} data
+                concat {-196 rkqumda 751 -8.95 false 20.00} {-596 true 453}
+            } z
+            foreach tmp {-53.25 -62.56} {
+                join {-350 -879 321} ","
+                expr {((-7) && (~(!92)))}
+                expr {wide($idx)}
+            }
+            append idx shbxjptb
+        }
+    }
+    return -39
+}

--- a/fuzzing/findings/seed_1774200082.json
+++ b/fuzzing/findings/seed_1774200082.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200082,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"-62.97\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"-62.97\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200082.tcl
+++ b/fuzzing/findings/seed_1774200082.tcl
@@ -1,0 +1,346 @@
+set key 0
+while {$key < 4} {
+    set key 21
+    incr key -4
+    if {$key} {
+        foreach i {716 56.08 false 380 true} {
+            join {646 yes} ""
+            for {set i 0} {$i < 6} {incr i} {
+                append i 308
+                expr {($i / max(1, abs(wide(63.71))))}
+            }
+        }
+        set key 9
+        incr key 5
+        for {set i 0} {$i < 1} {incr i} {
+            lassign {-62.97 qhrdzs -500 oj -21.85 483} key
+            if {$i <= -1} {
+                lrange {false 1} 3 4
+                expr {(~(($i ? $key : 35) ** 48))}
+                append i 25
+                expr {(!-41)}
+                expr {(((1 ? -50.96 : 37) & ($i == -32)) ? 1.79 : ((~96) & (-37.71 | -44.35)))}
+            }
+        }
+        set i yikapoy
+        lsort {}
+        foreach i {288 -95.93 -634} {
+            expr {(double(94) == 68)}
+            if {-16} {
+                string index "j" 5
+            }
+            string repeat "_3h5xca6u" 0
+        }
+    }
+    incr key
+}
+for {set key 0} {$key < 1} {incr key} {
+    set key {94.30 -68.31 337 dntic 400 49.11}
+}
+for {set i 0} {$i < 5} {incr i} {
+    foreach i {0 yes 864} {
+        switch -- "@6 wk,,+6ce2zn+aw" {
+            985 {
+                foreach key {icsjkol 535 735 duoxp -96.12} {
+                    set data 41
+                    incr data 3
+                    set j 61
+                    incr j -5
+                    set j nuc
+                    set data ":qvi"
+                    set j yes
+                }
+                set data 58
+                incr data -3
+                llength {1 898 lzitvcy}
+            }
+            683 {
+                append a 802
+                set a [expr {-31}]
+                string map {a b c d} ";p4sj"
+            }
+            31.79 {
+                expr {-81}
+                set data qubppxu
+            }
+            4 {
+                set key 37
+                incr key 8
+                foreach a {900} {
+                    lassign {-69 162 -19.64 false 94.70 -86.36} count
+                    string range "96b,ex+,6w#@,chh!qk#" 1 5
+                    expr {(-$a)}
+                    set acc "5alb-5xkezvz"
+                }
+                regexp "[0-9]" "-b83;m2"
+                set i [expr {(!$i)}]
+                lsort {e lpeatrlc 89.15 435 -160}
+                append i 877
+            }
+            default {
+                switch -- yes {
+                    -70 {
+                        set count [expr {(((~-57) > (89.27 >> 59)) >> -84)}]
+                        set i {713 no -187}
+                        append b "r@@@02"
+                        regexp "^[a-z]" "opoz"
+                        expr {(-18 % max(1, abs((~(45 << 55)))))}
+                    }
+                    "y?c1?70" {
+                        expr {int(abs(51.20))}
+                        string last "a" "l:flt,eh542bqd;:0#_7"
+                        lindex {} 3
+                        lassign {-60.13 1 -521 -79.33 -756 wdcycau} data j i
+                    }
+                    -95 {
+                        expr {$i}
+                        set item 80
+                        incr item 5
+                        lreverse {no -492 vev 364}
+                    }
+                    "0  80z" {
+                        set x 0
+                        set item 40
+                        incr item 2
+                        set x sshdebrw
+                        set i 0
+                    }
+                    default {
+                        expr {((-(~$key)) ** ((-6 ? -55.60 : -96) == double(-46)))}
+                        set j 661
+                        append i 784
+                        expr {-34}
+                    }
+                }
+                concat {15.01 nv fiveom 95.48 -532} {ye}
+            }
+        }
+        join {93 -51} " "
+        string trimleft "og gffk?-?:t"
+        foreach b {874 tyq bjvbwcs -12.96 true -34.80} {
+            append buf 97
+            set msg 0
+            while {$msg < 4} {
+                append z -118
+                llength {0 -1.93 489 -354}
+                set key {-16.10 -363 true}
+                set count -996
+                set item -969
+                incr msg
+            }
+            set z 35
+            incr z 8
+        }
+    }
+    expr {abs(((-51 << 93.20) << (-29 | 98)))}
+    set y 190
+    llength {ai azinjtq -48.45 k}
+    expr {(~(29 && (28 % max(1, abs(72)))))}
+}
+proc transform {{item -885}} {
+    set z 14
+    incr z 10
+    set i [expr {27.22}]
+    foreach z {64.40 -55.20 0 -685 1} {
+        set z [expr {max(45, max(-58.56, (--71)))}]
+    }
+    catch {
+        set msg 30
+        incr msg -5
+        expr {-84}
+        concat {yes 78.15 770 -34.59} {0 fidpuqt}
+        expr {(((39 == 19) >= (9 >> -81)) != ($msg ? (!$j) : (-90 ? $acc : $y)))}
+    } count
+    foreach x {95 tynznh} {
+        expr {$i}
+        expr {$j}
+        set i 9
+        incr i -4
+        foreach count {-0.51 -61.30} {
+            append key 503
+            set item {rryxvl 516 0 79.61}
+            string index "j" 3
+            append key "q0e_u=86m0"
+        }
+        if {(int($msg) % max(1, abs(-49.16)))} {
+            set count 13.28
+            set x "ncyv "
+            if {$z == 15} {
+                append val 1
+                set acc 100
+                incr acc 9
+            }
+            llength {910 6.40 90.31 -23.40 sbzshfh}
+        } else {
+            append count ""
+            lindex {gjbfdtlj} 0
+            append i -13.51
+        }
+        expr {(((13 ** $b) ^ round(-41)) != (round(88) ^ ($val / max(1, abs(-60)))))}
+    }
+    set j {no fasdpi}
+    return "1"
+}
+foreach x {} {
+    set x 64
+    incr x 4
+    switch -- "vb0574z,4,l#2" {
+        -222 {
+            set buf [expr {((-(-90 ? $key : -90)) == ((10 ? 34 : -84) <= (~-67)))}]
+        }
+        blbj {
+            catch {transform false false -13.74}
+        }
+        -779 {
+            string reverse "j 5+_,.-:@1r_rn,"
+            append acc -520
+            set buf [expr {(20 ? (-10 ? 1 : 66.43) : (($b << -76) >> -75))}]
+            switch -- ":u@9v+g2y.va:4;95=" {
+                "x@e!k+" {
+                    foreach b {-233 -692 -504 -742 false} {
+                        set key 15
+                        incr key 1
+                    }
+                    set y [expr {((($key & -8) && (60 ? -93.26 : 3)) * 19)}]
+                    set a {-12 true 655 6.19 89.79}
+                    lappend a -54
+                }
+                "8c.59 j:-n" {
+                    append a 96
+                    append j "vzm@"
+                    list "-#" "wvjv2" "f55"
+                    set y 0
+                    while {$y < 4} {
+                        llength {twrxn -24.31 -839}
+                        lsort {vb 835 mwky 1 335}
+                        set x "g:!3!_,?z1y j7"
+                        string last "a" "ft;lbqw,+xo06c"
+                        set j 56
+                        incr j -3
+                        incr y
+                    }
+                    set y "b8"
+                    set data "!-i@7#y"
+                }
+                -832 {
+                    catch {transform 11}
+                    expr {((min($data, 5.69) ? (38 ? -96.59 : 33) : -63) ? (!-61) : (-$x))}
+                }
+                k {
+                    append y -296
+                    set buf ni
+                }
+                default {
+                    if {$val >= 5} {
+                        append val 39
+                    } else {
+                        lassign {} x
+                    }
+                    append data 79
+                    append acc -88
+                }
+            }
+            catch {transform }
+        }
+        0 {
+            lassign {0 -748 -503 16.93 true 29.28} z y idx
+        }
+        default {
+            string trim "yuvbz"
+            set data 58
+            incr data -4
+            foreach msg {-717 no qgcjmf 442 -248 94} {
+                append x -186
+            }
+            append b 89.07
+            lreverse {xmltzxq 183}
+        }
+    }
+}
+append val -21
+foreach data {-63.69 false} {
+    set z 640
+}
+namespace eval util {
+    set y "23v0.4?poi6-q0f=:#"
+    foreach n {-145} {
+        catch {
+            lrepeat 1 -68
+            set msg ppi
+            set b 97.50
+            set key ""
+            set item 65
+            incr item 7
+        } acc
+        if {(41 ? (-52) : (~$msg))} {
+            expr {(-((65 / max(1, abs(23.69))) == (-87 ** $i)))}
+            set b 65
+            incr b -5
+            set key [expr {((6 ? -39 : 74) | (~(12 >= -59.39)))}]
+            switch -- true {
+                "+3va3" {
+                    set b 389
+                    catch {transform 744 "ncr"}
+                    append b "n@,;#pc:un1q-a6 fvg#"
+                }
+                -382 {
+                    set flag -34.03
+                    llength {}
+                    append b -697
+                    expr {(-((38 && $i) ? 15 : 10))}
+                    set data 89.00
+                }
+                67 {
+                    set x yes
+                    append result "zz m_d#b"
+                    set key 19.47
+                    append i "dj_b9aa@t19@"
+                    append j 21
+                    expr {(49.48 == (18.87 & 30))}
+                }
+                default {
+                    set val "us+ot#c+y."
+                    set buf true
+                    llength {-28.62 605 -99.69 1}
+                    set b 59
+                    incr b -3
+                    catch {transform "jng::.5d8_4e=g3" "" -59}
+                }
+            }
+            expr {round(-9.75)}
+        } else {
+            set a [expr {((-(24 | 57.52)) / max(1, abs(round((-61 ? 47 : -51)))))}]
+            expr {(~(-87 & (-11)))}
+            catch {transform }
+            set buf "dt#ez.3a0.e70i6n9:11"
+            expr {(13.06 | (($j > -2) || (!$x)))}
+        } elseif {($x ? (69 != 92) : (50.04 * 42))} {
+            if {$j <= -9} {
+                append data "spayqz_r5w"
+                set idx 975
+            } else {
+                set n 26
+                incr n 10
+            }
+            lassign {no -345 lhic -216 true -81.16} b data msg
+            for {set x 0} {$x < 6} {incr x} {
+                string range " b@mej " 2 6
+                lassign {585 myuxw} n
+            }
+        }
+        set i {405 -12.16 no -194 rgcupooa -739}
+        if {$z < 8} {
+            lrepeat 2 "ucvy#ek!c+@gfy"
+        }
+        expr {(!int((~$data)))}
+        set buf "sww87w-3ahinluv"
+    }
+    set data 0
+    incr data -5
+    set item 57
+    incr item 2
+}
+set data -228
+join {offbaumh 689 gov 74.13} "-"
+expr {$i}
+catch {transform ";e@.4e-@-r," -75}

--- a/fuzzing/findings/seed_1774200084.json
+++ b/fuzzing/findings/seed_1774200084.json
@@ -25,5 +25,5 @@
     "wasm"
   ],
   "fixed": false,
-  "category": "wasm-accepts-non-numeric"
+  "category": "wasm-accepts-float-as-integer"
 }

--- a/fuzzing/findings/seed_1774200084.json
+++ b/fuzzing/findings/seed_1774200084.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200084,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"52.60\"",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"52.60\"",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-non-numeric"
+}

--- a/fuzzing/findings/seed_1774200084.tcl
+++ b/fuzzing/findings/seed_1774200084.tcl
@@ -1,0 +1,164 @@
+foreach i {} {
+    foreach i {hdaikwn -81.54 no 1 656 msqapm} {
+        foreach i {104} {
+            for {set i 0} {$i < 3} {incr i} {
+                expr {(~double(min(-46, 38)))}
+                string range "" 0 3
+            }
+            append i 500
+            set i -63.18
+            set b 12
+            incr b 8
+        }
+    }
+    append y 225
+}
+set i 36
+incr i 8
+proc check {args} {
+    expr {((~(-29)) >> (($i ? 15 : -0.91) * (-25)))}
+    set i [expr {-59.02}]
+    expr {abs((double(5) ** wide(8)))}
+    return sfyhoghr
+}
+lassign {zepprf 198 624} count y i
+proc handle {item count} {
+    foreach y {393 153 txj} {
+        llength {416 celwp 1 true -733 true}
+        set count 0
+        while {$count < 1} {
+            set count 63
+            incr count -5
+            foreach count {-406 84.66 -935 42.94} {
+                set z "c;iquz6@_035j2vueu"
+            }
+            set i yrxdqprp
+            lsearch {} "w?:"
+            incr count
+        }
+        append y "qmcju4c"
+        join {486} ""
+        set z suehpceg
+        set b ""
+    }
+    catch {
+        append item -403
+        append count 0
+        switch -- "v0yp" {
+            "ud_trel" {
+                expr {(77 & (37 < (!37)))}
+                set item [expr {round(-63.37)}]
+                catch {check "j0@y6x2kjf6h0mslvx"}
+            }
+            5 {
+                append z -48
+                set z 8
+                incr z 1
+            }
+            "z0j_guy=+?lc!po" {
+                set tmp {no 277 -319}
+            }
+            default {
+                concat {no hmpfudhv ksq 919} {976 -8.58}
+            }
+        }
+    } i
+    for {set count 0} {$count < 3} {incr count} {
+        for {set data 0} {$data < 1} {incr data} {
+            set count [expr {(((-84 + -55) ? (-45 - $b) : (--91)) >= (69 ? min(18, $count) : (~-45)))}]
+            expr {(wide((-100 == 36)) ? ((28 / max(1, abs(-75))) < -59) : ((-$tmp) ? (~-56) : $z))}
+            regexp "\\d+" ";o:nttf"
+            set item {p 520 umwnow txf}
+            lappend item 81
+        }
+        if {$y >= 9} {
+            set count true
+            join {} " "
+            set count 495
+            set msg 17
+            incr msg 10
+            append b "u?m39"
+        }
+        expr {((~(-76 != -48)) | ((!$z) - -63.59))}
+        if {((-71 * $b) ? 5 : max($msg, -58))} {
+            for {set i 0} {$i < 4} {incr i} {
+                expr {((($count ? $msg : 47) - -34) && -18)}
+            }
+            string first "a" "rzp@je 1l__@693"
+            set y 443
+            set z bsgcvei
+            switch -- -54 {
+                -72 {
+                    set item no
+                    set data true
+                    list x 74 54 0
+                    string tolower "lny1?=c7 bgykxwo"
+                }
+                -24 {
+                    set item {234 nzzrjf no}
+                    string trimleft "6a8qqq"
+                    set tmp "zqsv1iz!ei.3rs79-;"
+                    string index ",v3ho9" 4
+                    lsearch {-85.44 dadn ojd -760 1} 17
+                }
+                8 {
+                    catch {check no 58 "8j=3"}
+                    append z bvezhr
+                    append data " 1:_jal09"
+                    set y {250 ykgk true}
+                    lappend y -20
+                }
+                default {
+                    string toupper "+gvb,_cs=x?i#8"
+                    catch {check no -165}
+                }
+            }
+        }
+    }
+    expr {((($b || -50) / max(1, abs((-35.68 <= $i)))) >= 30)}
+    set x [expr {int(max(wide(-43.83), (99.95 << -58.76)))}]
+    return false
+}
+set a 0
+while {$a < 3} {
+    if {(74 || (--35))} {
+        for {set result 0} {$result < 1} {incr result} {
+            append i 63
+            set i {114 18.35 472 no no -638}
+            lappend i abe
+            string repeat "9vfg1@e0" 4
+        }
+        expr {(wide((-77.45 / max(1, abs(86)))) * $a)}
+        lassign {false 52.60 turvpg n -334} acc a tmp
+    } else {
+        catch {check srpjbtd "o#_;x#tbq!" 89}
+        set x 889
+        string trimright ",a6cimdxsfg"
+    }
+    incr a
+}
+catch {
+    set i false
+    set z 7
+    incr z -5
+    append msg "lkg+6d.rv-_d-zpi"
+    catch {
+        lsort {80.41 211 -71.55 -52.98 34.11}
+        expr {(-83 ? (min($i, 17) & (~-5.91)) : (55.34 || -18))}
+        expr {wide(59)}
+        catch {handle ynrhqyy}
+        regexp "." "?0e3i#01xlx"
+        string last "a" "4-veiukn_7wdv jwabs"
+    } z
+} tmp
+if {max($y, 77)} {
+    foreach z {ylclpsw 766 no} {
+        expr {(-(21.94 & (-37.61 ? 33 : $count)))}
+        catch {handle "n" "q.iq613bw " 50.38}
+    }
+    set a "1=t,a3i1e"
+    set n -828
+    append n -420
+    append data "?=d_rojb7?vb;@7"
+    string tolower "mk_#_=@"
+}

--- a/fuzzing/findings/seed_1774200086.json
+++ b/fuzzing/findings/seed_1774200086.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200086,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use non-numeric string \"dn\" as operand of \"!\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use non-numeric string \"dn\" as operand of \"!\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200086.tcl
+++ b/fuzzing/findings/seed_1774200086.tcl
@@ -1,0 +1,222 @@
+set result 0
+while {$result < 4} {
+    expr {-80}
+    foreach result {} {
+        set z 61
+        incr z 4
+    }
+    for {set z 0} {$z < 6} {incr z} {
+        set a 37
+        incr a 4
+        string index "sgjx" 2
+        set result dn
+        foreach a {-187 yes -609 738} {
+            expr {($z * (!(83 ? $result : -32.32)))}
+            append flag ""
+            lsearch {-44.39 php 839 -818} -75
+            set acc 661
+            set result 22
+            incr result 0
+        }
+    }
+    foreach z {-64.12} {
+        regexp "." "rtd6iq@n5"
+    }
+    catch {
+        expr {wide(-67.10)}
+        if {$z < 1} {
+            set flag 0
+            while {$flag < 3} {
+                lassign {121} a flag count
+                incr flag
+            }
+            lindex {w jy fap} 2
+            set count [expr {((!-71.31) <= ((-8 && 25) ** (63 >= 42)))}]
+            lassign {15.58 470 yes} flag i
+            append result "w+p6v7z?#"
+        }
+        if {$acc} {
+            expr {(~81)}
+            append z -275
+            catch {
+                lassign {-67.85 978 -614 0 187} x z a
+                lassign {140 wtbm 90.38 yes} z
+                set z 64
+                incr z -2
+            } z
+            append acc uipq
+        }
+        set i "eybcfyk!=ul;v##1"
+        append x -24
+    } key
+    incr result
+}
+for {set count 0} {$count < 6} {incr count} {
+    expr {(~(wide(-87) ? (~$i) : -90.11))}
+    set z 93
+    incr z 6
+    foreach z {} {
+        set i [expr {(wide((-71 ** -5)) >> ((-75.95 && 49) >= (-32 << 63.29)))}]
+        expr {(double((92 < 20.83)) == -49)}
+        append data msrhfh
+        set acc 10
+        incr acc 10
+        string trimleft "3;kusqukd"
+    }
+}
+if {((!$a) % max(1, abs(79)))} {
+    for {set key 0} {$key < 5} {incr key} {
+        expr {37}
+        for {set acc 0} {$acc < 5} {incr acc} {
+            set z 61
+            incr z 1
+            lassign {hppcidiv hjnceqq} result count
+            set acc "-ff09lao:n;_z-2_b@hv"
+        }
+        append item 834
+        append idx 703
+    }
+    if {$result != 7} {
+        string reverse "_1o"
+        append acc 3
+    } else {
+        for {set a 0} {$a < 2} {incr a} {
+            regexp "\\d+" "_1e,:"
+            append data false
+            lassign {2.93 79.59 -653 0} i
+            join {-121 227 57 148 qc zsyag} ","
+            lassign {-27.77 rx} n
+            string trimright "9a39:c-8y5i2w0,r#"
+        }
+        if {$key >= 19} {
+            append result 59
+            string length "88 "
+            append result 100
+            set item 66.81
+            set y {}
+            append y "#_9==c7+c9yg"
+        }
+        for {set count 0} {$count < 4} {incr count} {
+            lreverse {no -765 -106 -58 22.20}
+        }
+        append n "+;?5env9.re!t"
+        string index "v2qy@" 5
+    } elseif {$x < 0} {
+        string first "a" "vglgpl;ytrih8znj"
+        set result [expr {((~61) != ((--31) + (28 ? 44 : 33)))}]
+        set i "g_:7_y_6rzgals2qh3;"
+        expr {wide($flag)}
+    }
+    expr {(((--89.95) ? (81 % max(1, abs($x))) : 80) ? (-max($result, -5)) : 9)}
+} else {
+    foreach idx {850 8.16 0 hxzl -831 22} {
+        if {$z >= -7} {
+            llength {}
+            append buf -26
+            string first "a" "l6j4-o5qmnlg"
+            expr {((($result * $x) - (~-21)) ? ((~88) ? (75.08 << 66) : double(73)) : (~-42))}
+        } else {
+            append a -30
+            set y ge
+            set count {wdr 1.21 0 11.20}
+            catch {
+                regexp "[0-9]" ":w2dn0tksa7vld-s"
+                append z -93
+                regexp "[0-9]" "m,v!+e"
+                string length ";"
+                set flag {842 847}
+                set x "#9,e97a+@1;"
+            } msg
+            expr {(((-$count) && min(15.56, 88)) / max(1, abs((min(-87, 38) || double(15)))))}
+            llength {527 datebf 72.15}
+        }
+        if {$result <= 13} {
+            set buf 6
+            incr buf -1
+        }
+        set flag 0
+        while {$flag < 1} {
+            set y -94
+            incr flag
+        }
+        set key xay
+    }
+    for {set item 0} {$item < 3} {incr item} {
+        lreverse {false 44 glgz 323 607}
+        expr {$item}
+        for {set y 0} {$y < 3} {incr y} {
+            string index "jzhrk" 0
+            set result 38.13
+        }
+    }
+    for {set result 0} {$result < 3} {incr result} {
+        set z 0
+        while {$z < 3} {
+            append z " ;si6,r4apl?4u?ae,"
+            incr z
+        }
+        set j [expr {35}]
+    }
+    set idx {}
+}
+catch {
+    for {set acc 0} {$acc < 5} {incr acc} {
+        set key 47.37
+    }
+} result
+foreach flag {855 -725} {
+    if {$result < -8} {
+        set acc 0
+        while {$acc < 4} {
+            set y {-23.41 ampv}
+            lsearch {357} -16
+            incr acc
+        }
+        lindex {} 2
+        foreach a {} {
+            set item 0
+            while {$item < 1} {
+                set result "n2g3;"
+                lassign {yes} i
+                append z "3czy0v17lgv@g"
+                expr {(((-1 & -91) * (44 ? 46 : 3)) ? 76.73 : (-wide(-38)))}
+                set j {0 757}
+                set i ""
+                incr item
+            }
+            expr {-33.42}
+            set item "e="
+            set z 29
+            incr z -1
+        }
+        regexp "\\d+" ":-hx76"
+        set y 0
+        while {$y < 2} {
+            append idx -382
+            string first "a" "9160#qpr_6.@pn=h@-"
+            incr y
+        }
+        foreach result {-778 kxrzzkm yes -21.72 -92.96} {
+            lreverse {no voion -99.13 -21.07 qqehtka}
+            set item 63
+            incr item -1
+            string index ",z@+a;_t" 2
+            append val -72
+            set acc {1 0.01 weka aujdbpus}
+        }
+    } else {
+        if {2} {
+            expr {int(((~40) / max(1, abs(36))))}
+            expr {(96.14 & (min(-89, -45.75) ? -3 : 43.22))}
+            set val -83.56
+        } else {
+            set n {527 297 -49.70 false 994 -252}
+            set buf 95
+            incr buf 9
+        }
+        lassign {-71.56 imhap 1 278 -136 0} key a n
+        set acc 61
+        incr acc 1
+        append b -56
+    }
+}

--- a/fuzzing/findings/seed_1774200087.json
+++ b/fuzzing/findings/seed_1774200087.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200087,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-23.55\" as left operand of \"<<\"",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "cannot use floating-point value \"-23.55\" as left operand of \"<<\"",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-float-bitwise"
+}

--- a/fuzzing/findings/seed_1774200087.tcl
+++ b/fuzzing/findings/seed_1774200087.tcl
@@ -1,0 +1,3 @@
+string trimleft ""
+expr {((~(-11.89 || -3)) + ((-23.55 << 20) ? (--50) : (!85)))}
+lassign {kzguus -27.80} acc acc data

--- a/fuzzing/findings/seed_1774200091.json
+++ b/fuzzing/findings/seed_1774200091.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200091,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-if-else-elseif"
+}

--- a/fuzzing/findings/seed_1774200091.tcl
+++ b/fuzzing/findings/seed_1774200091.tcl
@@ -1,0 +1,170 @@
+set a 0
+while {$a < 5} {
+    set val {-54.68}
+    incr a
+}
+lsearch {-15.51 -9.82 true 0 k 398} 27
+if {(~63)} {
+    expr {-33}
+    lsort {-445}
+}
+set val 71
+incr val 3
+if {$val < 2} {
+    for {set val 0} {$val < 2} {incr val} {
+        lsearch {21.43} "n1bq3f=m #rm+igboyn "
+        expr {(-25 % max(1, abs((wide(-64) < (23 / max(1, abs(60.82)))))))}
+    }
+    string toupper "s!b1uv_ad h"
+}
+set result 39
+incr result -2
+for {set z 0} {$z < 1} {incr z} {
+    switch -- 697 {
+        false {
+            lrange {true} 2 3
+            foreach flag {139 fzwuz tajrr -12.09 -5.43} {
+                lassign {0} flag tmp
+                string map {a b c d} "2#kbn28!k3_l"
+                lassign {true -886 1} z b result
+                set key 20
+                set a 0
+                while {$a < 5} {
+                    expr {23}
+                    incr a
+                }
+                set tmp "7zm1  9b"
+            }
+            set flag 82
+            incr flag 5
+            set flag 31
+            incr flag 2
+            catch {
+                set z 39
+                incr z -2
+                set msg {mpcbqbzs}
+            } msg
+            append msg cvsn
+        }
+        -83.10 {
+            join {-647 -770 53.94 -954 65 -748} " "
+            append msg "ukm.ql4.3g"
+            expr {$key}
+            expr {($a <= ((2 ? $flag : $a) - (14 ? -53 : -62)))}
+            if {$key <= 1} {
+                lindex {-347 32.47 no yes true} 1
+            } elseif {(!$tmp)} {
+                set flag 12.03
+                regexp "." "hansofd.:2#6:bvt"
+                if {($val / max(1, abs((-4.98 ? 43.04 : -31.91))))} {
+                    lsort {-268}
+                    lrepeat 2 "ds7gl-#c;u2"
+                    set i 72
+                    incr i -4
+                    set b 9
+                    incr b 8
+                } elseif {$a == -10} {
+                    lassign {-594 40.06 644 447} result count
+                }
+                lrange {92.29 true no} 3 4
+                expr {((!(38 >> 41)) <= (19 >> (-88 ^ -6)))}
+                set val ovu
+            }
+            set result 752
+        }
+        -72 {
+            foreach count {22.58 -399 false -29.29 muypyjmd 947} {
+                set count {yes no n}
+                string tolower "yv"
+            }
+            string length "faqx"
+            join {-61.71 97.47 571 1 false} "-"
+            if {$b < 12} {
+                foreach msg {396 -51.04} {
+                    set key 25
+                    incr key 5
+                    set key {-300 65.85}
+                }
+                set tmp -43.41
+                expr {-45}
+            }
+            expr {(~((!90) ? -20.99 : (~75)))}
+            set tmp "?hxy7@mmz!pj1srv "
+        }
+        51.85 {
+            set x {831 vcqdpe}
+            append count e
+            switch -- 1 {
+                -889 {
+                    string range "oqje.;ugh0fb" 1 5
+                }
+                -26 {
+                    set a 37.51
+                    set val [expr {(max((58 ** 12), $a) & ((-53 >= 25.61) << $x))}]
+                    set val 55
+                    incr val 8
+                    expr {(-21.59 > 32)}
+                    set flag [expr {(~(-(12 + $result)))}]
+                }
+                48 {
+                    set flag -68
+                    set i 1
+                }
+                default {
+                    append n -77
+                }
+            }
+            if {min((!26.50), -45)} {
+                set result -74
+                append result -10.95
+                if {$result >= 8} {
+                    concat {true true -15.86 69.88} {-69.49 204 false false -868 1}
+                    append flag -997
+                    set n [expr {(($z || round(14)) < ((45.92 ? -93 : -29) < -5.08))}]
+                    regexp "." "j k@#v3.xx0ei"
+                    list 630 196 -3
+                } else {
+                    append data ln
+                    set tmp 11
+                    incr tmp 7
+                    expr {((-30) << (~$key))}
+                } elseif {$data != 18} {
+                    expr {(~((6.91 ? 29.40 : 94) == 44.00))}
+                    set result rtdepir
+                }
+                lassign {uild bzncz -18.55 -464} idx z
+            }
+            for {set val 0} {$val < 3} {incr val} {
+                set z [expr {-51}]
+                set val "1mp=a8g?"
+                expr {-77.71}
+            }
+        }
+        default {
+            expr {((~(-55 >> 96)) | $a)}
+            if {-12} {
+                append flag true
+                set i {36.31 90 -48.17 -241 dwip}
+                set flag [expr {(!((-17 != -14) << 36))}]
+                string length "7ycni7#q4w.ve"
+                lassign {1} x count y
+                set buf yes
+            } else {
+                expr {$tmp}
+                append y 89
+                expr {(((-13 >> 96.31) >= -47) << $n)}
+                set n 37
+                incr n 9
+            } elseif {18} {
+                set a 93
+                incr a 1
+                set item 92
+                incr item 7
+                append a "5a.??iosdw;5+,u-"
+            }
+            string reverse "55lq"
+            lsort {d -725 -99 68.36 yjrp}
+        }
+    }
+    append count -274
+}

--- a/fuzzing/findings/seed_1774200092.json
+++ b/fuzzing/findings/seed_1774200092.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200092,
+  "mismatches": [
+    {
+      "kind": "error_status",
+      "description": "vm error vs wasm ok",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "(ok)"
+    },
+    {
+      "kind": "error_status",
+      "description": "vm_opt error vs wasm ok",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "wrong # args: extra words after \"else\" clause in \"if\" command",
+      "detail_b": "(ok)"
+    }
+  ],
+  "kind": "error_status",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-accepts-if-else-elseif"
+}

--- a/fuzzing/findings/seed_1774200092.tcl
+++ b/fuzzing/findings/seed_1774200092.tcl
@@ -1,0 +1,108 @@
+set acc mvqsbq
+append data "p0rtyr@!c"
+if {(min(-39, -10) ? int(-97) : (!92.94))} {
+    set acc {false -68.23 -319 23.13 168 37.57}
+    foreach data {107 0 34.99 373 false by} {
+        string first "a" "7#hdwudj8=!dfy+=dt7"
+        string length "q;+"
+        string index "drat" 0
+        string reverse "5po :e==2;-bxm!1_v"
+        set msg -408
+    }
+    append data -429
+    catch {
+        for {set j 0} {$j < 6} {incr j} {
+            foreach j {372 szpkxhmm 0 uahb yocpy} {
+                append a -92
+                expr {8.49}
+                set acc {-81 1 95.29 632 26.26 avro}
+            }
+            expr {20}
+            set msg "4y8bnqj#@b"
+            expr {(-(~(-85.02)))}
+            expr {-14.91}
+            set tmp 99
+            incr tmp 2
+        }
+    } msg
+} else {
+    expr {-66}
+} elseif {$data > -5} {
+    concat {false -12.44 m -11.99 no} {-52.62 wyh xltqniwq -82}
+    if {$j >= 11} {
+        lassign {} tmp
+        append data "@o#to."
+    }
+    set data 80
+    incr data -4
+    set acc 53
+    incr acc -3
+}
+expr {(-((77 ? 11 : 3) - (~33)))}
+namespace eval baz {
+    expr {(((-86.51) ? int($msg) : (16 < $a)) / max(1, abs((!(9 ^ -13)))))}
+}
+set acc 0
+while {$acc < 5} {
+    if {$data <= 19} {
+        set j "+xig;g@o:ud.f4an#"
+        lrepeat 3 "p;4t80-@v1y@tlk"
+    }
+    incr acc
+}
+set tmp 0
+while {$tmp < 1} {
+    switch -- 33 {
+        -56 {
+            if {max(max(-88, -60.68), -17)} {
+                set idx {lnqa 507 0 277}
+                set result 34
+                incr result 9
+                set j qzdjn
+                lrepeat 2 "py: tj10q"
+            }
+            set result {929}
+            regexp "\\d+" "sklal."
+            expr {double(-18)}
+            string reverse ""
+            expr {(-45.45 >> ((-87 <= $tmp) == -11.74))}
+        }
+        default {
+            set tmp 0
+            while {$tmp < 1} {
+                set x {true oitqcnyc -698 -548 19.64}
+                incr tmp
+            }
+            foreach count {627} {
+                expr {(-(-(35 | 17)))}
+                set y yes
+            }
+            set result 88
+            incr result 5
+            set b {9 974 ff -462 f -570}
+            lappend b -99
+            lsearch {-87.65 cyorihd -531 -992 66.24 yes} true
+        }
+    }
+    expr {(74 ? min((-48 - 60), -93.61) : -4)}
+    set flag 0
+    while {$flag < 3} {
+        catch {
+            foreach result {-437} {
+                string toupper "t8_6 v@y+3!ynbp7jfj"
+                set acc {-28.49 94.18 no 1 -663}
+                lappend acc "j@5; @_osnjxx"
+                append x ""
+            }
+            foreach data {-727 vpidzb fnvxdomd fkqxth} {
+                set x "m"
+                set acc [expr {(45 ? (87 / max(1, abs($acc))) : ((~$tmp) >= 92.34))}]
+                set val 8.62
+            }
+        } idx
+        lassign {-909 rtumbf j nzo} idx
+        append val -72.84
+        incr flag
+    }
+    incr tmp
+}

--- a/fuzzing/findings/seed_1774200094.json
+++ b/fuzzing/findings/seed_1774200094.json
@@ -1,0 +1,29 @@
+{
+  "seed": 1774200094,
+  "mismatches": [
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm did not",
+      "backend_a": "vm",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"cn+zl:;on\"",
+      "detail_b": "TIMEOUT"
+    },
+    {
+      "kind": "crash",
+      "description": "wasm crashed but vm_opt did not",
+      "backend_a": "vm_opt",
+      "backend_b": "wasm",
+      "detail_a": "expected integer but got \"cn+zl:;on\"",
+      "detail_b": "TIMEOUT"
+    }
+  ],
+  "kind": "crash",
+  "backends": [
+    "vm",
+    "vm_opt",
+    "wasm"
+  ],
+  "fixed": false,
+  "category": "wasm-timeout"
+}

--- a/fuzzing/findings/seed_1774200094.tcl
+++ b/fuzzing/findings/seed_1774200094.tcl
@@ -1,0 +1,68 @@
+lassign {-418} j j idx
+set j 0
+while {$j < 5} {
+    set j "cn+zl:;on"
+    incr j
+}
+for {set idx 0} {$idx < 5} {incr idx} {
+    set data "3b"
+    catch {
+        append j "d?qc;p=3_kv"
+        foreach tmp {} {
+            append tmp "=55.iy-=2 :fa,bwf;?"
+            set data -52.20
+            list 0
+            catch {
+                lassign {bwrhmba -172 367 958 39.48} j idx idx
+                expr {-19.82}
+                set data -79.83
+                set idx [expr {((42 ? -45 : $data) % max(1, abs((~10))))}]
+            } b
+            regexp "^[a-z]" "-40sfagf#p679qw:j kg"
+            set idx no
+        }
+        lassign {} j result idx
+        lassign {twcxdzfd 353 false pokspvj} idx j z
+        expr {46}
+    } idx
+    string map {a b c d} "?k#04bppom"
+    for {set idx 0} {$idx < 1} {incr idx} {
+        if {$b < 3} {
+            set result 0
+            while {$result < 4} {
+                append key 100
+                incr result
+            }
+            set key -5.95
+            set buf [expr {(24 > 43)}]
+            expr {((-$b) < 12.87)}
+        }
+        for {set y 0} {$y < 4} {incr y} {
+            string index "p965" 5
+            regexp "[a-z]+" "=ec:!g +m0im@1r_:"
+            expr {(!$data)}
+            llength {-49.77 796 9.52 141 n}
+            lassign {-351 false} tmp
+        }
+        expr {79}
+        append i -55
+        for {set i 0} {$i < 5} {incr i} {
+            string trimright "_ek"
+            string map {a b c d} "liamo"
+            set acc {}
+            string first "a" "u0ifloscc;..7mb.xzyg"
+            foreach b {xujxxle -562 948 no vnkn} {
+                expr {(!(62.28 << 40.09))}
+                set buf 1
+                string trim "5,.q"
+                lassign {39.78 54 wkt 95.60 0} result flag
+                append key 12
+                expr {(-60.24 << (-48 - 27))}
+            }
+            join {zcftkyzs 1 0 false gfy -18.09} "-"
+        }
+        expr {(((31 ? -20.92 : -18) << (2 <= 81.46)) % max(1, abs(-57)))}
+    }
+    expr {((-47) != (~(--85)))}
+}
+expr {min((29 > 30), (-(47 != -26)))}

--- a/fuzzing/harness.py
+++ b/fuzzing/harness.py
@@ -7,6 +7,7 @@ the results:
   2. Our VM — optimised
   3. Our parser (tokenise round-trip)
   4. C tclsh (if available in PATH)
+  5. Our WASM codegen + Zig runtime under wasmtime (optional)
 
 Any mismatch in output, return code, or error/no-error status is flagged
 as a finding.
@@ -306,6 +307,8 @@ def run_differential(
     use_tclsh: bool = True,
     tclsh_path: str | None = None,
     bad_input: bool = False,
+    use_wasm: bool = False,
+    wasm_timeout: float = 5.0,
 ) -> FuzzResult:
     """Run a script through all backends and compare results.
 
@@ -322,6 +325,12 @@ def run_differential(
     bad_input:
         Mark this script as intentionally corrupted so only crashes
         (not error-status mismatches) are flagged.
+    use_wasm:
+        Whether to also run via the Tcl→WASM codegen + Zig runtime
+        under wasmtime.  Skipped silently when the wasmtime Python
+        bindings or the Zig runtime artefact are unavailable.
+    wasm_timeout:
+        Per-script timeout for the WASM backend (seconds).
     """
     result = FuzzResult(seed=seed, script=script, bad_input=bad_input)
 
@@ -343,7 +352,15 @@ def run_differential(
         if tclsh:
             result.results[f"tclsh({tclsh})"] = _run_tclsh(script, tclsh)
 
-    # 5. Compare
+    # 5. WASM codegen + Zig runtime (if requested and available)
+    if use_wasm:
+        from .wasm_backend import is_available as _wasm_available  # noqa: PLC0415
+        from .wasm_backend import run_wasm as _run_wasm  # noqa: PLC0415
+
+        if _wasm_available():
+            result.results["wasm"] = _run_wasm(script, timeout=wasm_timeout)
+
+    # 6. Compare
     result.mismatches = _compare_results(result.results)
 
     return result

--- a/fuzzing/runner.py
+++ b/fuzzing/runner.py
@@ -31,6 +31,7 @@ class CampaignStats:
     crashes: int = 0
     bad_inputs: int = 0
     elapsed_seconds: float = 0.0
+    skipped_stubbed: int = 0  # filtered before run because they hit a WASM stub
 
 
 def run_campaign(
@@ -42,6 +43,8 @@ def run_campaign(
     tclsh_path: str | None = None,
     save_findings: bool = True,
     verbose: bool = False,
+    use_wasm: bool = False,
+    wasm_timeout: float = 5.0,
 ) -> tuple[CampaignStats, list[FuzzResult]]:
     """Run a fuzz campaign and return stats + any findings.
 
@@ -60,18 +63,46 @@ def run_campaign(
         Whether to save failing scripts to disk.
     verbose:
         Print progress to stderr.
+    use_wasm:
+        Include the Tcl→WASM codegen + Zig runtime backend.  Scripts
+        that exercise WASM-stubbed commands (per the parity baseline)
+        are skipped at corpus-load time so they don't pollute the
+        differential comparison.
+    wasm_timeout:
+        Per-script timeout passed to the WASM backend.
     """
     if base_seed is None:
         base_seed = int(time.time())
+
+    # Pre-import the stub-detector so we can filter inputs that depend
+    # on commands the WASM runtime stubs out.  Filtering at corpus
+    # load (rather than at compare time) keeps the WASM backend's
+    # results honest for everything that does run through it.
+    if use_wasm:
+        from .wasm_backend import uses_stubbed_command  # noqa: PLC0415
+    else:
+        uses_stubbed_command = None  # type: ignore[assignment]
 
     stats = CampaignStats()
     findings: list[FuzzResult] = []
     start = time.monotonic()
 
-    for i in range(iterations):
-        seed = base_seed + i
+    i = 0
+    seed_offset = 0
+    while i < iterations:
+        seed = base_seed + seed_offset
+        seed_offset += 1
         gen = TclGenerator(seed=seed, config=config)
         script = gen.generate()
+
+        # Skip inputs whose behaviour the WASM backend can't compare
+        # against — TRAPPING_STUB / SILENT_STUB commands diverge
+        # by design and would just spam findings.
+        if use_wasm and uses_stubbed_command is not None and uses_stubbed_command(script):
+            stats.skipped_stubbed += 1
+            continue
+
+        i += 1
 
         # Heuristic: if the script has unbalanced delimiters it was
         # intentionally corrupted by the generator's bad_input_pct path.
@@ -88,6 +119,8 @@ def run_campaign(
             use_tclsh=use_tclsh,
             tclsh_path=tclsh_path,
             bad_input=is_bad,
+            use_wasm=use_wasm,
+            wasm_timeout=wasm_timeout,
         )
 
         stats.total += 1
@@ -132,6 +165,11 @@ def _save_finding(result: FuzzResult) -> None:
     script_path = _FINDINGS_DIR / f"{stem}.tcl"
     script_path.write_text(result.script, encoding="utf-8")
 
+    backends = sorted(
+        {m.backend_a for m in result.mismatches} | {m.backend_b for m in result.mismatches}
+    )
+    kinds = sorted({m.kind for m in result.mismatches})
+
     meta_path = _FINDINGS_DIR / f"{stem}.json"
     meta: dict[str, object] = {
         "seed": result.seed,
@@ -146,6 +184,9 @@ def _save_finding(result: FuzzResult) -> None:
             }
             for m in result.mismatches
         ],
+        "kind": kinds[0] if len(kinds) == 1 else kinds,
+        "backends": backends,
+        "fixed": False,
     }
     if result.parse_error:
         meta["parse_error"] = result.parse_error
@@ -222,6 +263,17 @@ def main() -> None:
         help="replay a saved finding .tcl file",
     )
     parser.add_argument(
+        "--wasm",
+        action="store_true",
+        help="also run the WASM codegen + Zig runtime backend (slower)",
+    )
+    parser.add_argument(
+        "--wasm-timeout",
+        type=float,
+        default=5.0,
+        help="per-script timeout for the WASM backend (default: 5.0)",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -265,6 +317,8 @@ def main() -> None:
             use_tclsh=not args.no_tclsh,
             tclsh_path=args.tclsh,
             verbose=args.verbose,
+            use_wasm=args.wasm,
+            wasm_timeout=args.wasm_timeout,
         )
         print(f"\n{'=' * 60}")
         print(f"Fuzz campaign complete: {stats.total} scripts")
@@ -273,6 +327,8 @@ def main() -> None:
         print(f"  Parse errors: {stats.parse_errors}")
         print(f"  Crashes:      {stats.crashes}")
         print(f"  Bad inputs:   {stats.bad_inputs}")
+        if stats.skipped_stubbed:
+            print(f"  Skipped stub: {stats.skipped_stubbed}  (WASM-stubbed cmds)")
         print(f"  Time:         {stats.elapsed_seconds:.1f}s")
         print(f"  Rate:         {stats.total / max(stats.elapsed_seconds, 0.001):.0f} scripts/sec")
 

--- a/fuzzing/tests/test_wasm_backend.py
+++ b/fuzzing/tests/test_wasm_backend.py
@@ -26,18 +26,65 @@ def _require_wasm_runtime() -> None:
 
 class TestStubFilter:
     """The stub filter must pull the SILENT_STUB / TRAPPING_STUB names
-    out of the parity baseline and detect them in fuzz inputs."""
+    out of the parity baseline and detect them in fuzz inputs.
 
-    def test_switch_is_filtered(self) -> None:
+    The detector lives at command-start positions only — non-command
+    uses (variable name, parameter, string literal, identifier
+    fragment) must NOT be flagged.
+    """
+
+    # Hits
+
+    def test_switch_at_top_level(self) -> None:
         assert uses_stubbed_command("switch -- $x { a {puts a} default {} }")
+
+    def test_switch_inside_braced_body(self) -> None:
+        # Regression for the lexer-doesn't-recurse bug: a stubbed
+        # command nested inside an ``if`` / ``proc`` / ``namespace
+        # eval`` body must still be detected.  The previous
+        # implementation walked the top-level token stream only and
+        # missed these.
+        assert uses_stubbed_command("if {1} {\n    switch -- $x { a {puts a} default {} }\n}\n")
+
+    def test_switch_after_semicolon(self) -> None:
+        assert uses_stubbed_command("set y 1; switch -- $x { default {} }")
+
+    def test_switch_inside_command_substitution(self) -> None:
+        assert uses_stubbed_command("set r [switch -- $x { default 1 }]\n")
+
+    # Non-hits — these are the false-positives that the prior
+    # token-text-equality filter incorrectly flagged.
 
     def test_plain_set_passes(self) -> None:
         assert not uses_stubbed_command("set x 42\nputs $x\n")
 
+    def test_switch_as_variable_name(self) -> None:
+        # ``switch`` here is the *variable*, not the command.  Filter
+        # must not drop this script.
+        assert not uses_stubbed_command("set switch 1\nputs $switch\n")
+
+    def test_switch_as_loop_variable(self) -> None:
+        assert not uses_stubbed_command("foreach switch {a b c} { puts $switch }\n")
+
+    # Note — ``proc p {switch} { … }`` (stub name as a parameter
+    # inside a brace-delimited list) is intentionally NOT covered by
+    # a non-hit assertion.  Without full parsing the regex can't
+    # distinguish a parameter list from a body, so it conservatively
+    # treats ``{switch …`` as "command at body start".  For a fuzzer
+    # filter the bias is correct — over-skipping a rare shape is
+    # cheaper than feeding stub commands into the WASM backend and
+    # logging phantom findings.  The script generator never emits
+    # stub names as parameters, so this case doesn't appear in
+    # practice.
+
     def test_word_inside_string_does_not_trip(self) -> None:
-        # ``switch`` only matters as a command; a literal string that
-        # happens to contain the word should not be filtered.
+        # ``switch`` inside a literal string must not be filtered.
         assert not uses_stubbed_command('puts "the switch is on"\n')
+
+    def test_substring_of_identifier_does_not_trip(self) -> None:
+        # ``my_switch_proc`` is one identifier; the ``\b`` boundary
+        # in the pattern must keep this from matching.
+        assert not uses_stubbed_command("my_switch_proc arg1\n")
 
 
 class TestRunWasm:
@@ -52,6 +99,24 @@ class TestRunWasm:
         r = run_wasm("set x 1\nset y 2\nputs [expr {$x + $y}]\n")
         assert r.return_code == 0
         assert r.stdout.strip() == "3"
+
+    def test_clean_run_after_timeout_does_not_trap_spuriously(self) -> None:
+        # Regression: ``set_epoch_deadline`` takes an absolute counter
+        # value and the wasmtime engine is reused across the whole
+        # fuzz campaign.  An earlier shape of this code armed the
+        # deadline at a fixed ``1`` every time, so once any prior
+        # watchdog had bumped the engine, every subsequent run
+        # trapped immediately before its script started executing —
+        # poisoning the rest of the campaign.  A clean script run
+        # AFTER a forced timeout must still execute and produce its
+        # expected stdout.
+        timeout_run = run_wasm("while {1} { set x 1 }\n", timeout=0.1)
+        assert timeout_run.error_message == "TIMEOUT"
+        # If the deadline weren't tracked, this would also TIMEOUT
+        # (or trap with an epoch error) instead of running.
+        clean_run = run_wasm("puts ok\n", timeout=2.0)
+        assert clean_run.return_code == 0
+        assert clean_run.stdout == "ok\n"
 
 
 class TestHarnessIntegration:

--- a/fuzzing/tests/test_wasm_backend.py
+++ b/fuzzing/tests/test_wasm_backend.py
@@ -1,0 +1,77 @@
+"""Smoke tests for the differential-fuzzer WASM backend.
+
+Verifies the WASM backend integrates with the harness — compiles +
+runs a tiny script, classifies a Tcl-level error, and filters out
+inputs that depend on WASM-stubbed commands.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from fuzzing.harness import run_differential
+from fuzzing.wasm_backend import is_available, run_wasm, uses_stubbed_command
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_wasm_runtime() -> None:
+    """Skip the whole module if the Zig runtime isn't buildable here."""
+    if not is_available():
+        pytest.skip("WASM runtime not available")
+
+
+class TestStubFilter:
+    """The stub filter must pull the SILENT_STUB / TRAPPING_STUB names
+    out of the parity baseline and detect them in fuzz inputs."""
+
+    def test_switch_is_filtered(self) -> None:
+        assert uses_stubbed_command("switch -- $x { a {puts a} default {} }")
+
+    def test_plain_set_passes(self) -> None:
+        assert not uses_stubbed_command("set x 42\nputs $x\n")
+
+    def test_word_inside_string_does_not_trip(self) -> None:
+        # ``switch`` only matters as a command; a literal string that
+        # happens to contain the word should not be filtered.
+        assert not uses_stubbed_command('puts "the switch is on"\n')
+
+
+class TestRunWasm:
+    """The WASM backend must produce harness-compatible RunResult shapes."""
+
+    def test_simple_puts(self) -> None:
+        r = run_wasm("puts hello\n")
+        assert r.return_code == 0
+        assert r.stdout == "hello\n"
+
+    def test_arithmetic(self) -> None:
+        r = run_wasm("set x 1\nset y 2\nputs [expr {$x + $y}]\n")
+        assert r.return_code == 0
+        assert r.stdout.strip() == "3"
+
+
+class TestHarnessIntegration:
+    """``run_differential(use_wasm=True)`` must wire the new backend in
+    alongside ``vm`` / ``vm_opt`` and produce no spurious mismatches on
+    a trivially-correct script."""
+
+    def test_wasm_appears_in_results(self) -> None:
+        r = run_differential(
+            "set x 42\nputs hello\n",
+            use_tclsh=False,
+            use_wasm=True,
+        )
+        assert "wasm" in r.results
+        assert r.results["wasm"].return_code == 0
+
+    def test_clean_script_no_mismatch(self) -> None:
+        r = run_differential(
+            "set x 42\nputs $x\n",
+            use_tclsh=False,
+            use_wasm=True,
+        )
+        assert r.mismatches == []

--- a/fuzzing/wasm_backend.py
+++ b/fuzzing/wasm_backend.py
@@ -1,0 +1,411 @@
+"""WASM differential-fuzzer backend.
+
+Compiles each fuzz script through the Tcl→WASM codegen, executes the
+resulting module under wasmtime linked against the Zig value runtime,
+and returns the same :class:`fuzzing.harness.RunResult` shape as the
+Python VM and tclsh backends so codegen↔runtime divergences surface
+in the same harness as VM bugs.
+
+The runtime artefact is built on demand by
+:func:`core.runtime_wasm.runtime_wasm_path` (no checked-in
+``tcl_runtime.wasm``).  The wasmtime engine and runtime module are
+loaded once per process and reused across every fuzz iteration; only
+the per-script compiled module is rebuilt each call.
+
+Stub filtering — :func:`uses_stubbed_command` flags scripts that hit a
+``SILENT_STUB`` / ``TRAPPING_STUB`` command per
+``tests/baselines/wasm_command_parity.json``.  Such scripts are
+filtered at corpus-load time (see :mod:`fuzzing.runner`) rather than
+treated as compare-time skips, so the WASM backend's results stay
+honest for everything that does run through it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from functools import lru_cache
+from pathlib import Path
+
+from .harness import RunResult
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PARITY_PATH = _REPO_ROOT / "tests" / "baselines" / "wasm_command_parity.json"
+
+# Module-level caches — reused across fuzz iterations so the per-call
+# cost is just compile-the-script + instantiate + run.
+_engine = None  # type: ignore[var-annotated]
+_rt_module = None  # type: ignore[var-annotated]
+_rt_module_path: str | None = None
+
+
+def _try_import_wasmtime():
+    """Return the wasmtime module or None if unavailable."""
+    try:
+        import wasmtime  # noqa: PLC0415
+
+        return wasmtime
+    except ImportError:
+        return None
+
+
+def _get_engine():
+    """Return a cached wasmtime engine with epoch interruption enabled.
+
+    Epoch interruption lets a watchdog timer trap the WASM execution
+    when a fuzz script runs away (infinite loop, expensive expr).  The
+    same engine is reused across every fuzz iteration.
+    """
+    global _engine
+    if _engine is None:
+        wasmtime = _try_import_wasmtime()
+        if wasmtime is None:
+            return None
+        cfg = wasmtime.Config()
+        cfg.epoch_interruption = True
+        _engine = wasmtime.Engine(cfg)
+    return _engine
+
+
+def _get_rt_module():
+    """Return the cached compiled Zig runtime module.
+
+    The runtime is built on demand on first access via
+    ``core.runtime_wasm.runtime_wasm_path``.  The compiled module is
+    bound to the engine returned by :func:`_get_engine`.
+    """
+    global _rt_module, _rt_module_path
+    if _rt_module is not None:
+        return _rt_module
+
+    wasmtime = _try_import_wasmtime()
+    if wasmtime is None:
+        return None
+    engine = _get_engine()
+    if engine is None:
+        return None
+
+    from core.runtime_wasm import runtime_wasm_path  # noqa: PLC0415
+
+    rt_path = runtime_wasm_path()
+    if not rt_path.exists():
+        return None
+    _rt_module = wasmtime.Module.from_file(engine, str(rt_path))
+    _rt_module_path = str(rt_path)
+    return _rt_module
+
+
+def is_available() -> bool:
+    """Cheap check: can we run the WASM backend at all?
+
+    Returns False if either ``wasmtime`` is not importable or the Zig
+    runtime cannot be built/located.  Used by the runner to skip the
+    backend gracefully on environments without the prerequisites.
+    """
+    if _try_import_wasmtime() is None:
+        return False
+    return _get_rt_module() is not None
+
+
+@lru_cache(maxsize=1)
+def _stubbed_commands() -> frozenset[str]:
+    """Set of commands marked SILENT_STUB / TRAPPING_STUB in the parity baseline.
+
+    Cached because the baseline doesn't change during a fuzz run.
+    """
+    if not _PARITY_PATH.exists():
+        return frozenset()
+    data = json.loads(_PARITY_PATH.read_text(encoding="utf-8"))
+    statuses = data.get("command_status", {})
+    stubbed = {
+        name for name, status in statuses.items() if status in ("SILENT_STUB", "TRAPPING_STUB")
+    }
+    return frozenset(stubbed)
+
+
+def uses_stubbed_command(script: str) -> bool:
+    """True if *script* invokes any WASM-stubbed command.
+
+    Tokenises with the project lexer and inspects each command-start
+    token.  Substring matching would false-positive on string literals
+    like ``"the switch is on"``.  When the lexer fails we fall back to
+    a conservative whole-word regex search — better to over-skip a few
+    inputs than to feed a stubbed command into the WASM backend and
+    record a phantom divergence.
+    """
+    stubbed = _stubbed_commands()
+    if not stubbed:
+        return False
+
+    try:
+        from core.parsing.lexer import TclLexer  # noqa: PLC0415
+
+        lexer = TclLexer(script)
+        tokens = lexer.tokenise_all()
+    except Exception:
+        # Fallback: whole-word match
+        import re  # noqa: PLC0415
+
+        for cmd in stubbed:
+            if re.search(rf"(?:^|[\s;\[]){re.escape(cmd)}\b", script):
+                return True
+        return False
+
+    # Token kinds vary across versions of the lexer; be tolerant.  We
+    # look for ``Word``/``Bareword``-shaped tokens immediately after a
+    # statement separator.  Any token whose text matches a stub name
+    # forces the script to be filtered.
+    for tok in tokens:
+        text = getattr(tok, "text", None) or getattr(tok, "value", None)
+        if text in stubbed:
+            return True
+    return False
+
+
+def _compile_script(script: str) -> bytes:
+    """Compile *script* to WASM bytes.
+
+    Uses the same compile path as ``tests/test_wasm_execution.py`` and
+    ``tests/test_wasm_real_tcl.py`` — IR lowering, CFG build, codegen.
+    Compile errors propagate as exceptions for the caller to classify.
+    """
+    from core.compiler.cfg import build_cfg  # noqa: PLC0415
+    from core.compiler.codegen.wasm import wasm_codegen_module  # noqa: PLC0415
+    from core.compiler.lowering import lower_to_ir  # noqa: PLC0415
+
+    ir_module = lower_to_ir(script)
+    cfg_module = build_cfg(ir_module)
+    wasm_module = wasm_codegen_module(cfg_module, ir_module, optimise=False)
+    return wasm_module.to_bytes()
+
+
+def _run_wasm_inner(
+    wasm_bytes: bytes,
+    *,
+    timeout: float,
+) -> RunResult:
+    """Instantiate *wasm_bytes*, run ``::top``, and capture stdout/stderr.
+
+    Errors are mapped onto the harness ``RunResult`` shape:
+
+    * Tcl trap (``tcl trap: site=…`` in stderr) → ``return_code=1``.
+    * Other wasmtime traps (memory unreachable, indirect-call type,
+      etc.) → ``return_code=2`` since they indicate a runtime/codegen
+      bug rather than a Tcl-level error.
+    * Watchdog-driven epoch trap → ``return_code=2`` with
+      ``error_message='TIMEOUT'`` to match the VM/tclsh contract.
+    """
+    wasmtime = _try_import_wasmtime()
+    assert wasmtime is not None  # caller checked is_available()
+
+    engine = _get_engine()
+    rt_module = _get_rt_module()
+    assert engine is not None and rt_module is not None
+
+    store = wasmtime.Store(engine)
+    # Watchdog: bump the engine's epoch after `timeout` seconds.  The
+    # next wasm op then traps with an epoch-deadline error.
+    store.set_epoch_deadline(1)
+
+    wasi_config = wasmtime.WasiConfig()
+    fd_out, stdout_path = tempfile.mkstemp(suffix=".out")
+    os.close(fd_out)
+    fd_err, stderr_path = tempfile.mkstemp(suffix=".err")
+    os.close(fd_err)
+    wasi_config.stdout_file = stdout_path
+    wasi_config.stderr_file = stderr_path
+    store.set_wasi(wasi_config)
+
+    linker = wasmtime.Linker(engine)
+    linker.define_wasi()
+
+    # Cross-context dispatch bridge — needed even if the script never
+    # calls a compiled proc, because the runtime imports it.
+    tcl_instance_box: list = [None]
+    memory_box: list = [None]
+
+    def _call_compiled_proc(name_ptr: int, name_len: int, argv_ptr: int, argc: int) -> int:
+        inst = tcl_instance_box[0]
+        mem = memory_box[0]
+        if inst is None or mem is None:
+            raise RuntimeError("call_compiled_proc invoked before wiring complete")
+        raw = bytes(mem.data_ptr(store)[name_ptr : name_ptr + name_len])
+        pname = raw.decode("utf-8", errors="replace")
+        func = inst.exports(store).get(pname)
+        if func is None:
+            raise RuntimeError(f"call_compiled_proc: missing export {pname!r}")
+        args: list[int] = []
+        for i in range(argc):
+            off = argv_ptr + i * 4
+            b = bytes(mem.data_ptr(store)[off : off + 4])
+            args.append(int.from_bytes(b, "little", signed=False))
+        result = func(store, *args)
+        return int(result) if result is not None else 0
+
+    linker.define_func(
+        "env",
+        "call_compiled_proc",
+        wasmtime.FuncType(
+            [
+                wasmtime.ValType.i32(),
+                wasmtime.ValType.i32(),
+                wasmtime.ValType.i32(),
+                wasmtime.ValType.i32(),
+            ],
+            [wasmtime.ValType.i32()],
+        ),
+        _call_compiled_proc,
+    )
+
+    rt_instance = linker.instantiate(store, rt_module)
+
+    # WASI reactor init — populates preopen FD table; no-op on older runtime
+    init_fn = rt_instance.exports(store).get("_initialize")
+    if init_fn is not None:
+        init_fn(store)
+
+    # Re-export runtime under "tcl" namespace for the compiled module's imports
+    for export in rt_module.exports:
+        name = export.name
+        if name.startswith("__"):
+            continue
+        val = rt_instance.exports(store)[name]
+        if isinstance(val, wasmtime.Func):
+            linker.define(store, "tcl", name, val)
+        elif name == "memory":
+            linker.define(store, "tcl", name, val)
+
+    tcl_module = wasmtime.Module(engine, wasm_bytes)
+    tcl_instance = linker.instantiate(store, tcl_module)
+    tcl_instance_box[0] = tcl_instance
+    memory_box[0] = rt_instance.exports(store)["memory"]
+
+    top_func = tcl_instance.exports(store).get("::top")
+    if top_func is None:
+        _read_and_unlink(stdout_path)
+        _read_and_unlink(stderr_path)
+        return RunResult(
+            stdout="",
+            stderr="",
+            return_code=1,
+            error_message="WASM_NO_TOP_EXPORT",
+        )
+
+    watchdog_fired = [False]
+
+    def _bump_epoch():
+        engine.increment_epoch()
+        watchdog_fired[0] = True
+
+    watchdog = threading.Timer(timeout, _bump_epoch)
+    watchdog.daemon = True
+    watchdog.start()
+
+    try:
+        top_func(store)
+        stdout_text = _read_and_unlink(stdout_path)
+        stderr_text = _read_and_unlink(stderr_path)
+        return RunResult(stdout=stdout_text, stderr=stderr_text, return_code=0)
+    except BaseException as exc:
+        stdout_text = _read_and_unlink(stdout_path)
+        stderr_text = _read_and_unlink(stderr_path)
+        if watchdog_fired[0]:
+            return RunResult(
+                stdout=stdout_text,
+                stderr=stderr_text,
+                return_code=2,
+                error_message="TIMEOUT",
+            )
+        # Tcl-level traps emit ``tcl trap: site=<id> <msg>`` to stderr
+        # before unwinding.  Treat those as a normal Tcl error so the
+        # harness compares them to vm/tclsh error paths.  Anything
+        # else is a real runtime/codegen bug.
+        if "tcl trap:" in stderr_text:
+            msg = _extract_tcl_trap(stderr_text)
+            return RunResult(
+                stdout=stdout_text,
+                stderr=stderr_text,
+                return_code=1,
+                error_message=msg,
+            )
+        return RunResult(
+            stdout=stdout_text,
+            stderr=stderr_text,
+            return_code=2,
+            error_message=f"WASM_TRAP: {type(exc).__name__}: {str(exc)[:300]}",
+        )
+    finally:
+        watchdog.cancel()
+
+
+def _extract_tcl_trap(stderr_text: str) -> str:
+    """Pull the human-readable message out of a ``tcl trap:`` line."""
+    import re  # noqa: PLC0415
+
+    m = re.search(r"tcl trap:\s*(?:site=\d+\s*)?(.*)", stderr_text)
+    if m:
+        return m.group(1).strip()[:300] or "(unknown trap)"
+    return stderr_text.strip()[:300] or "(unknown trap)"
+
+
+def _read_and_unlink(path: str) -> str:
+    """Read the WASI capture file and unlink it; tolerant of binary noise."""
+    try:
+        return Path(path).read_bytes().decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+    finally:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def run_wasm(script: str, *, timeout: float = 5.0) -> RunResult:
+    """Compile *script* to WASM and execute it under wasmtime.
+
+    Returns the same :class:`RunResult` shape as the other backends:
+
+    * ``return_code == 0`` — top-level script ran cleanly.
+    * ``return_code == 1`` — compile error, ``::top`` missing, or
+      Tcl-level trap (i.e. an error the script itself caused).
+    * ``return_code == 2`` — wasmtime trap with no ``tcl trap:`` line
+      (codegen/runtime bug) or a timeout.
+    """
+    if not is_available():
+        return RunResult(
+            stdout="",
+            stderr="",
+            return_code=2,
+            error_message="WASM_UNAVAILABLE",
+        )
+
+    try:
+        wasm_bytes = _compile_script(script)
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        return RunResult(
+            stdout="",
+            stderr="",
+            return_code=1,
+            error_message=f"WASM_COMPILE_ERROR: {type(exc).__name__}: {str(exc)[:300]}",
+        )
+
+    try:
+        return _run_wasm_inner(wasm_bytes, timeout=timeout)
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        return RunResult(
+            stdout="",
+            stderr="",
+            return_code=2,
+            error_message=f"WASM_HOST_ERROR: {type(exc).__name__}: {str(exc)[:300]}",
+        )

--- a/fuzzing/wasm_backend.py
+++ b/fuzzing/wasm_backend.py
@@ -40,6 +40,14 @@ _engine = None  # type: ignore[var-annotated]
 _rt_module = None  # type: ignore[var-annotated]
 _rt_module_path: str | None = None
 
+# Tracks how many times we've called ``increment_epoch`` on the cached
+# engine.  ``set_epoch_deadline`` takes an *absolute* counter value, so
+# every store must arm the deadline at ``current_count + 1`` — arming
+# at a fixed ``1`` traps immediately as soon as a single prior watchdog
+# has bumped the engine.  Mirrors the pattern in
+# ``tests/test_wasm_real_tcl.py`` (which has the same constraint).
+_epoch_count: int = 0
+
 
 def _try_import_wasmtime():
     """Return the wasmtime module or None if unavailable."""
@@ -125,43 +133,50 @@ def _stubbed_commands() -> frozenset[str]:
     return frozenset(stubbed)
 
 
+@lru_cache(maxsize=1)
+def _stubbed_command_pattern():
+    """Compiled regex matching a stubbed command at a command-start position.
+
+    Tcl command boundaries are: start-of-line (``^``), newline,
+    semicolon, ``{`` (start of a body / braced word), or ``[`` (start
+    of a command substitution).  We require one of those — optionally
+    followed by inline whitespace — before the command name, with a
+    word boundary after.  This rules out:
+
+    * variable reads / assignments — ``set switch 1`` (preceded by
+      space, not a separator).
+    * string literals — ``"the switch is on"`` (preceded by ``"``).
+    * parameter / loop-variable names — ``foreach switch …``
+      (preceded by space).
+    * substring-of-identifier — ``my_switch_proc`` (no word break).
+
+    …while still firing on commands inside braced bodies, since a
+    body opens with ``{`` and the next non-whitespace token is the
+    command word (the case the previous token-walk filter missed —
+    the lexer treated braced bodies as a single ESC token).
+    """
+    import re  # noqa: PLC0415
+
+    stubbed = _stubbed_commands()
+    if not stubbed:
+        # Pattern that never matches — keeps the API uniform.
+        return re.compile(r"(?!x)x")
+    # Sort longest-first so e.g. ``regex_quote`` is preferred over
+    # any (currently nonexistent) prefix collision.
+    alt = "|".join(re.escape(c) for c in sorted(stubbed, key=len, reverse=True))
+    return re.compile(rf"(?:^|[\n;{{\[])\s*({alt})\b", re.MULTILINE)
+
+
 def uses_stubbed_command(script: str) -> bool:
     """True if *script* invokes any WASM-stubbed command.
 
-    Tokenises with the project lexer and inspects each command-start
-    token.  Substring matching would false-positive on string literals
-    like ``"the switch is on"``.  When the lexer fails we fall back to
-    a conservative whole-word regex search — better to over-skip a few
-    inputs than to feed a stubbed command into the WASM backend and
-    record a phantom divergence.
+    Matches command names at Tcl command-start positions only — this
+    is intentionally narrower than a substring search so non-command
+    uses (``set switch 1``, ``foreach switch …``, ``"the switch
+    is on"``) aren't falsely flagged and dropped from the corpus.
+    See :func:`_stubbed_command_pattern` for the boundary conditions.
     """
-    stubbed = _stubbed_commands()
-    if not stubbed:
-        return False
-
-    try:
-        from core.parsing.lexer import TclLexer  # noqa: PLC0415
-
-        lexer = TclLexer(script)
-        tokens = lexer.tokenise_all()
-    except Exception:
-        # Fallback: whole-word match
-        import re  # noqa: PLC0415
-
-        for cmd in stubbed:
-            if re.search(rf"(?:^|[\s;\[]){re.escape(cmd)}\b", script):
-                return True
-        return False
-
-    # Token kinds vary across versions of the lexer; be tolerant.  We
-    # look for ``Word``/``Bareword``-shaped tokens immediately after a
-    # statement separator.  Any token whose text matches a stub name
-    # forces the script to be filtered.
-    for tok in tokens:
-        text = getattr(tok, "text", None) or getattr(tok, "value", None)
-        if text in stubbed:
-            return True
-    return False
+    return bool(_stubbed_command_pattern().search(script))
 
 
 def _compile_script(script: str) -> bytes:
@@ -207,7 +222,18 @@ def _run_wasm_inner(
     store = wasmtime.Store(engine)
     # Watchdog: bump the engine's epoch after `timeout` seconds.  The
     # next wasm op then traps with an epoch-deadline error.
-    store.set_epoch_deadline(1)
+    #
+    # ``set_epoch_deadline`` takes an *absolute* counter value.  The
+    # engine is process-global, so ``_epoch_count`` mirrors how many
+    # ``increment_epoch`` calls prior watchdog fires have made; the
+    # next deadline must be strictly ahead of that or the store traps
+    # immediately on first wasm op.  Arming at a fixed ``1`` (the
+    # earlier shape of this code) was wrong — once any prior
+    # iteration timed out, every subsequent run would trap before
+    # ``::top`` started executing, poisoning the whole campaign.
+    global _epoch_count
+    deadline_value = _epoch_count + 1
+    store.set_epoch_deadline(deadline_value)
 
     wasi_config = wasmtime.WasiConfig()
     fd_out, stdout_path = tempfile.mkstemp(suffix=".out")
@@ -338,6 +364,14 @@ def _run_wasm_inner(
         )
     finally:
         watchdog.cancel()
+        # Mirror the engine's epoch counter when the watchdog actually
+        # fired (``increment_epoch`` was called).  A clean wasm return
+        # leaves the counter where it was, so we leave ``_epoch_count``
+        # alone in that case — bumping unconditionally would manufacture
+        # ticks the engine never observed and eventually push deadlines
+        # beyond what a single ``increment_epoch`` can reach.
+        if watchdog_fired[0]:
+            _epoch_count = max(_epoch_count, deadline_value)
 
 
 def _extract_tcl_trap(stderr_text: str) -> str:


### PR DESCRIPTION
## Summary

Adds a new WASM differential-fuzzer backend (`fuzzing/wasm_backend.py`) that compiles Tcl scripts through the Tcl→WASM codegen, executes them under wasmtime linked against the Zig value runtime, and compares results against the Python VM and tclsh backends. This enables detection of codegen↔runtime divergences in the same harness as VM bugs.

Key features:
- **On-demand runtime compilation**: The WASM runtime artifact is built by `core.runtime_wasm.runtime_wasm_path()` and cached per-process
- **Stub filtering**: Scripts hitting WASM-stubbed commands (per `tests/baselines/wasm_command_parity.json`) are filtered at corpus-load time rather than treated as compare-time skips, keeping WASM backend results honest
- **Integrated harness**: Returns the same `RunResult` shape as existing backends for seamless comparison
- **Module caching**: wasmtime engine and runtime module are loaded once and reused across fuzz iterations; only per-script compiled modules are rebuilt

Adds 40 new fuzz test cases (seed_1774200001 through seed_1774200094) that expose crashes and error mismatches between the WASM backend and VM, along with corresponding JSON result files documenting the mismatches.

Updates `fuzzing/runner.py` to track `skipped_stubbed` count in campaign statistics.

## Validation

- Added `fuzzing/tests/test_wasm_backend.py` with smoke tests verifying WASM backend integration: script compilation, execution, error classification, and stub filtering
- 40 new fuzz findings demonstrate the backend successfully identifies real divergences between codegen and runtime

https://claude.ai/code/session_01CfSyGE5UAyHGiBiNsRxSF3