### PR TITLE
Refactor WASM test fixtures and add regression test for #265

### DIFF
--- a/fuzzing/tests/test_wasm_backend.py
+++ b/fuzzing/tests/test_wasm_backend.py
@@ -26,9 +26,20 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 def _require_wasm_runtime() -> None:
-    """Skip if wasmtime + the Zig runtime aren't available."""
+    """Skip if wasmtime + the Zig runtime aren't available.
+
+    ``is_available()`` lazily triggers ``runtime_wasm_path()`` which
+    can shell out to ``zig build``; a missing zig toolchain or build
+    failure raises rather than returns ``False``.  Catch and skip so
+    runtime-build failures don't error the whole class — same posture
+    as the missing-wasmtime case.
+    """
     pytest.importorskip("wasmtime", reason="wasmtime not installed")
-    if not is_available():
+    try:
+        available = is_available()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"WASM runtime not available: {exc}")
+    if not available:
         pytest.skip("WASM runtime not available")
 
 
@@ -94,25 +105,42 @@ class TestStubFilter:
         # in the pattern must keep this from matching.
         assert not uses_stubbed_command("my_switch_proc arg1\n")
 
-    def test_seed_1774200003_is_filtered(self) -> None:
-        # Direct regression for issue #265.  The seed contains
-        # ``switch`` (TRAPPING_STUB) inside ``namespace eval util {…}``
-        # and again inside an ``if`` body — both nested in braced
-        # bodies.  The earlier lexer-walk filter treated the body as a
-        # single ESC token and missed every ``switch`` inside, so this
-        # script slipped past the corpus-load gate and the WASM
-        # backend then trapped on the stub, polluting other findings'
-        # categories.  ``uses_stubbed_command`` must return ``True``.
+    def test_stubbed_command_inside_nested_braced_bodies(self) -> None:
+        # Regression for issue #265.  The earlier lexer-walk filter
+        # treated each braced body as a single ESC token and missed
+        # every command word inside — so scripts that exercised a
+        # stubbed command (e.g. ``switch``) only inside an ``if`` body
+        # or a ``namespace eval`` slipped past the corpus-load gate
+        # and the WASM backend then trapped on the stub, polluting
+        # other findings' categories.  This snippet replicates the
+        # exact shapes from ``fuzzing/findings/seed_1774200003.tcl``
+        # (the literal example called out in the issue).
+        script = (
+            "namespace eval util {\n"
+            "    switch -- 65 {\n"
+            "        default { puts ok }\n"
+            "    }\n"
+            "}\n"
+            "if {1} {\n"
+            "    switch -- true {\n"
+            "        default { puts ok }\n"
+            "    }\n"
+            "}\n"
+        )
+        assert uses_stubbed_command(script)
+
+        # If the literal seed file is still in the tree, also verify
+        # against it — protects against the regression returning in a
+        # shape the synthetic snippet didn't anticipate.
         seed = _REPO_ROOT / "fuzzing" / "findings" / "seed_1774200003.tcl"
-        if not seed.exists():
-            pytest.skip(f"seed file not present: {seed}")
-        assert uses_stubbed_command(seed.read_text(encoding="utf-8"))
+        if seed.exists():
+            assert uses_stubbed_command(seed.read_text(encoding="utf-8"))
 
 
 class TestRunWasm:
     """The WASM backend must produce harness-compatible RunResult shapes."""
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def _runtime_required(self) -> None:
         _require_wasm_runtime()
 
@@ -150,7 +178,7 @@ class TestHarnessIntegration:
     alongside ``vm`` / ``vm_opt`` and produce no spurious mismatches on
     a trivially-correct script."""
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def _runtime_required(self) -> None:
         _require_wasm_runtime()
 

--- a/fuzzing/tests/test_wasm_backend.py
+++ b/fuzzing/tests/test_wasm_backend.py
@@ -3,23 +3,31 @@
 Verifies the WASM backend integrates with the harness — compiles +
 runs a tiny script, classifies a Tcl-level error, and filters out
 inputs that depend on WASM-stubbed commands.
+
+The stub-filter tests are pure regex over the parity baseline JSON
+and run independently of wasmtime / the Zig runtime — they must
+still execute in CI environments without those installed, since
+that's where stub-filter regressions would otherwise slip through
+unnoticed.
 """
 
 from __future__ import annotations
 
-import pytest
+from pathlib import Path
 
-pytest.importorskip("wasmtime", reason="wasmtime not installed")
+import pytest
 
 from fuzzing.harness import run_differential
 from fuzzing.wasm_backend import is_available, run_wasm, uses_stubbed_command
 
 pytestmark = pytest.mark.slow
 
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-@pytest.fixture(scope="module", autouse=True)
+
 def _require_wasm_runtime() -> None:
-    """Skip the whole module if the Zig runtime isn't buildable here."""
+    """Skip if wasmtime + the Zig runtime aren't available."""
+    pytest.importorskip("wasmtime", reason="wasmtime not installed")
     if not is_available():
         pytest.skip("WASM runtime not available")
 
@@ -86,9 +94,27 @@ class TestStubFilter:
         # in the pattern must keep this from matching.
         assert not uses_stubbed_command("my_switch_proc arg1\n")
 
+    def test_seed_1774200003_is_filtered(self) -> None:
+        # Direct regression for issue #265.  The seed contains
+        # ``switch`` (TRAPPING_STUB) inside ``namespace eval util {…}``
+        # and again inside an ``if`` body — both nested in braced
+        # bodies.  The earlier lexer-walk filter treated the body as a
+        # single ESC token and missed every ``switch`` inside, so this
+        # script slipped past the corpus-load gate and the WASM
+        # backend then trapped on the stub, polluting other findings'
+        # categories.  ``uses_stubbed_command`` must return ``True``.
+        seed = _REPO_ROOT / "fuzzing" / "findings" / "seed_1774200003.tcl"
+        if not seed.exists():
+            pytest.skip(f"seed file not present: {seed}")
+        assert uses_stubbed_command(seed.read_text(encoding="utf-8"))
+
 
 class TestRunWasm:
     """The WASM backend must produce harness-compatible RunResult shapes."""
+
+    @pytest.fixture(autouse=True)
+    def _runtime_required(self) -> None:
+        _require_wasm_runtime()
 
     def test_simple_puts(self) -> None:
         r = run_wasm("puts hello\n")
@@ -123,6 +149,10 @@ class TestHarnessIntegration:
     """``run_differential(use_wasm=True)`` must wire the new backend in
     alongside ``vm`` / ``vm_opt`` and produce no spurious mismatches on
     a trivially-correct script."""
+
+    @pytest.fixture(autouse=True)
+    def _runtime_required(self) -> None:
+        _require_wasm_runtime()
 
     def test_wasm_appears_in_results(self) -> None:
         r = run_differential(


### PR DESCRIPTION
## Summary

- Restructured WASM backend tests to decouple stub-filter regex tests from runtime availability requirements
- Moved `pytest.importorskip("wasmtime")` from module-level fixture into a reusable function that's only called by tests requiring the runtime
- Added regression test for issue #265 that validates `uses_stubbed_command()` correctly identifies stubbed commands in nested braced bodies
- Updated module docstring to clarify that stub-filter tests run independently of wasmtime/Zig runtime

## Validation

The changes enable stub-filter regex tests (like `TestUsesStubbed`) to run in CI environments without wasmtime installed, while runtime-dependent tests (`TestRunWasm`, `TestHarnessIntegration`) skip gracefully when the runtime is unavailable. The new regression test directly validates the fix for issue #265 where nested `switch` commands inside braced bodies were incorrectly missed by the earlier lexer-walk filter.

- Existing test suite passes with these structural changes
- New regression test validates the specific issue #265 scenario

https://claude.ai/code/session_0152f66ez9ZMrdKoTDHqmWjE