### PR TITLE
Fix bitwise/shift domain checks and incr strict-integer validation

### DIFF
--- a/core/compiler/codegen/wasm/_emitter/_control_flow.py
+++ b/core/compiler/codegen/wasm/_emitter/_control_flow.py
@@ -538,23 +538,40 @@ class _WasmEmitterCtrlMixin(_Base):
                 # ``m2 == ""``.
                 self._emit_catch(inner_body, inner_result_var, keep_on_stack=True)
             case IRIncr(name=name, amount=amount):
-                # Mimic the incr emitter (keep value on stack)
-                self._emit_var_read_obj(name)
-                self._emit_unbox_int()
-                amt: int | None = 1
-                if amount is not None:
-                    try:
-                        amt = int(amount)
-                    except ValueError:
-                        self._emit_value(amount)
-                        self._emit_unbox_int()
+                # Issue #262: route through ``tcl_incr`` for the
+                # strict-integer guard (rejects float strings).
+                incr_idx = self._shared_imports.get("tcl_incr")
+                if incr_idx is not None:
+                    self._emit_var_read_obj(name)
+                    if amount is None:
+                        self._emit_i64_const(1)
+                        self._emit_box_int()
+                    else:
+                        try:
+                            self._emit_i64_const(int(amount))
+                            self._emit_box_int()
+                        except ValueError:
+                            self._emit_value(amount)
+                    self._emit_call(incr_idx)
+                    self._emit_var_write_obj_keep(name)
+                else:
+                    # Mimic the incr emitter (keep value on stack)
+                    self._emit_var_read_obj(name)
+                    self._emit_unbox_int()
+                    amt: int | None = 1
+                    if amount is not None:
+                        try:
+                            amt = int(amount)
+                        except ValueError:
+                            self._emit_value(amount)
+                            self._emit_unbox_int()
+                            self._emit(WasmOp.I64_ADD)
+                            amt = None  # signal: already handled
+                    if amt is not None:
+                        self._emit_i64_const(amt)
                         self._emit(WasmOp.I64_ADD)
-                        amt = None  # signal: already handled
-                if amt is not None:
-                    self._emit_i64_const(amt)
-                    self._emit(WasmOp.I64_ADD)
-                self._emit_box_int()
-                self._emit_var_write_obj_keep(name)
+                    self._emit_box_int()
+                    self._emit_var_write_obj_keep(name)
             case IRAssignConst(name=name, value=value):
                 # ``set x 42`` in tail position — store + keep the
                 # assigned object on the stack so ``catch_set_ok_result``

--- a/core/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/core/compiler/codegen/wasm/_emitter/_expressions.py
@@ -174,23 +174,19 @@ class _WasmEmitterExprMixin(_Base):
                 # Negation of a float must preserve the TYPE_FLOAT tag —
                 # the inline ``0 - x`` path goes through i64 and loses
                 # the float-ness, which would let a bitwise/shift caller
-                # (e.g. ``-23.55 << 4`` from issue #261) silently truncate
-                # the negative float to an integer instead of raising
-                # the domain error.  Route ``-floatlit`` through
-                # ``tcl_arith_sub(0.0, lit)`` so the runtime keeps the
-                # float tag end-to-end.
-                if uop == UnaryOp.NEG and isinstance(operand, ExprLiteral):
-                    text = operand.text
-                    try:
-                        if "." in text or "e" in text.lower():
-                            float_val = float(text)
-                            new_float_idx = self._shared_imports.get("tcl_obj_new_float")
-                            if new_float_idx is not None:
-                                self._emit_f64_const(-float_val)
-                                self._emit_call(new_float_idx)
-                                return
-                    except ValueError:
-                        pass
+                # (e.g. ``-23.55 << 4`` or ``(-$x) << 1`` with $x = "23.55"
+                # from issue #261) silently truncate the negative float
+                # to an integer instead of raising the domain error.
+                # Route through the runtime ``tcl_arith_neg`` helper so
+                # the float tag survives to ``tcl_arith_lshift`` /
+                # ``tcl_arith_bnot`` for any operand shape (literal,
+                # variable, command substitution, nested expression).
+                if uop == UnaryOp.NEG:
+                    neg_idx = self._shared_imports.get("tcl_arith_neg")
+                    if neg_idx is not None:
+                        self._emit_expr_obj(operand)
+                        self._emit_call(neg_idx)
+                        return
                 if uop == UnaryOp.BIT_NOT:
                     bnot_idx = self._shared_imports.get("tcl_arith_bnot")
                     if bnot_idx is not None:

--- a/core/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/core/compiler/codegen/wasm/_emitter/_expressions.py
@@ -117,6 +117,19 @@ class _WasmEmitterExprMixin(_Base):
         BinOp.MOD: "tcl_arith_mod",
     }
 
+    # Maps bitwise / shift BinOp to the runtime helper that enforces the
+    # integer-only domain (issues #260, #261): floats raise ``cannot use
+    # floating-point value …``; negative shift counts raise ``negative
+    # shift argument``.  The previous inline ``i64.shl``/``i64.and`` etc.
+    # path silently truncated floats and masked the shift count by 63.
+    _BITWISE_INT_FUNC: dict[BinOp, str] = {
+        BinOp.LSHIFT: "tcl_arith_lshift",
+        BinOp.RSHIFT: "tcl_arith_rshift",
+        BinOp.BIT_AND: "tcl_arith_band",
+        BinOp.BIT_OR: "tcl_arith_bor",
+        BinOp.BIT_XOR: "tcl_arith_bxor",
+    }
+
     def _emit_expr_obj(self, node: ExprNode) -> None:
         """Emit WASM instructions leaving a TclObj i32 on the stack.
 
@@ -145,6 +158,8 @@ class _WasmEmitterExprMixin(_Base):
                 self._emit_obj_literal_for_expr(value)
             case ExprBinary(op=op, left=left, right=right):
                 func_name = self._ARITH_FLOAT_FUNC.get(op)
+                if func_name is None:
+                    func_name = self._BITWISE_INT_FUNC.get(op)
                 if func_name is not None:
                     func_idx = self._shared_imports.get(func_name)
                     if func_idx is not None:
@@ -153,6 +168,36 @@ class _WasmEmitterExprMixin(_Base):
                         self._emit_call(func_idx)
                         return
                 # Non-arithmetic or missing import: fall back to i64 path.
+                self._emit_expr(node)
+                self._emit_box_int()
+            case ExprUnary(op=uop, operand=operand):
+                # Negation of a float must preserve the TYPE_FLOAT tag —
+                # the inline ``0 - x`` path goes through i64 and loses
+                # the float-ness, which would let a bitwise/shift caller
+                # (e.g. ``-23.55 << 4`` from issue #261) silently truncate
+                # the negative float to an integer instead of raising
+                # the domain error.  Route ``-floatlit`` through
+                # ``tcl_arith_sub(0.0, lit)`` so the runtime keeps the
+                # float tag end-to-end.
+                if uop == UnaryOp.NEG and isinstance(operand, ExprLiteral):
+                    text = operand.text
+                    try:
+                        if "." in text or "e" in text.lower():
+                            float_val = float(text)
+                            new_float_idx = self._shared_imports.get("tcl_obj_new_float")
+                            if new_float_idx is not None:
+                                self._emit_f64_const(-float_val)
+                                self._emit_call(new_float_idx)
+                                return
+                    except ValueError:
+                        pass
+                if uop == UnaryOp.BIT_NOT:
+                    bnot_idx = self._shared_imports.get("tcl_arith_bnot")
+                    if bnot_idx is not None:
+                        self._emit_expr_obj(operand)
+                        self._emit_call(bnot_idx)
+                        return
+                # Fall back: evaluate as i64, box.
                 self._emit_expr(node)
                 self._emit_box_int()
             case ExprCall(function=func, args=args):
@@ -696,6 +741,20 @@ class _WasmEmitterExprMixin(_Base):
                 self._emit_unbox_int()  # → i64
                 return
 
+        # Bitwise / shift: delegate to tcl_arith_{lshift,rshift,band,bor,bxor}
+        # which enforce the integer-only domain (issues #260, #261).  The
+        # previous direct ``i64.shl`` / ``i64.and`` path silently truncated
+        # float operands and masked negative shift counts by 63.
+        bitwise_func = self._BITWISE_INT_FUNC.get(op)
+        if bitwise_func is not None:
+            bw_idx = self._shared_imports.get(bitwise_func)
+            if bw_idx is not None:
+                self._emit_expr_obj(left)
+                self._emit_expr_obj(right)
+                self._emit_call(bw_idx)  # → i32 TclObj
+                self._emit_unbox_int()  # → i64
+                return
+
         wasm_op = _BINOP_WASM.get(op)
         if wasm_op is not None:
             self._emit_expr(left)
@@ -985,9 +1044,20 @@ class _WasmEmitterExprMixin(_Base):
         elif op == UnaryOp.POS:
             self._emit_expr(operand)  # no-op
         elif op == UnaryOp.BIT_NOT:
-            self._emit_expr(operand)
-            self._emit_i64_const(-1)
-            self._emit(WasmOp.I64_XOR)
+            # Issue #261: ``~`` rejects float operands with ``cannot use
+            # floating-point value "X" as operand of "~"``.  Route through
+            # the runtime helper so the domain check fires before the
+            # XOR; falling back to inline ``x ^ -1`` would silently
+            # truncate floats and accept them.
+            bnot_idx = self._shared_imports.get("tcl_arith_bnot")
+            if bnot_idx is not None:
+                self._emit_expr_obj(operand)
+                self._emit_call(bnot_idx)
+                self._emit_unbox_int()
+            else:
+                self._emit_expr(operand)
+                self._emit_i64_const(-1)
+                self._emit(WasmOp.I64_XOR)
         elif op == UnaryOp.NOT:
             self._emit_expr(operand)
             self._emit(WasmOp.I64_EQZ)

--- a/core/compiler/codegen/wasm/_emitter/_optimisation.py
+++ b/core/compiler/codegen/wasm/_emitter/_optimisation.py
@@ -820,6 +820,28 @@ class _WasmEmitterOptMixin(_Base):
                 # Emit incr keeping the new value (i32 TclObj) on stack.
                 # Alias-aware: reads/writes route through globals for
                 # upvar/variable-bound locals.
+                # Issue #262: route through ``tcl_incr`` to enforce the
+                # strict-integer guard.
+                incr_idx = self._shared_imports.get("tcl_incr")
+                if incr_idx is not None:
+                    self._emit_var_read_obj(last.name)
+                    if last.amount is None:
+                        self._emit_i64_const(1)
+                        self._emit_box_int()
+                    else:
+                        try:
+                            self._emit_i64_const(int(last.amount))
+                            self._emit_box_int()
+                        except ValueError:
+                            self._emit_value(last.amount)
+                    self._emit_call(incr_idx)
+                    if last.name in self._aliases:
+                        self._emit_var_write_obj_keep(last.name)
+                    else:
+                        idx = self._intern_local(last.name)
+                        self._emit_local_tee(idx)
+                    self._emit(WasmOp.RETURN)
+                    return
                 self._emit_var_read_obj(last.name)
                 self._emit_unbox_int()
                 amt = 1

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -189,6 +189,32 @@ class _WasmEmitterStmtMixin(_Base):
                     self._const_map.pop(name, None)
 
             case IRIncr(name=name, amount=amount):
+                # Issue #262: route through the runtime helper so the
+                # strict-integer guard fires on the current value
+                # (a float string like ``"52.60"`` raises ``expected
+                # integer but got "52.60"`` rather than silently
+                # truncating to ``52`` and advancing the counter).
+                # Falls back to the inline integer add path when the
+                # runtime helper isn't registered (older compile
+                # configs without the import).
+                incr_idx = self._shared_imports.get("tcl_incr")
+                if incr_idx is not None:
+                    self._emit_var_read_obj(name)  # current value (TclObj)
+                    if amount is None:
+                        self._emit_i64_const(1)
+                        self._emit_box_int()
+                    else:
+                        try:
+                            self._emit_i64_const(int(amount))
+                            self._emit_box_int()
+                        except ValueError:
+                            self._emit_value(amount)  # variable amount
+                    self._emit_call(incr_idx)  # → new TclObj
+                    # ``tcl_incr`` returns OWNED.
+                    self._emit_var_write_obj(name, source=Ownership.OWNED)
+                    if self._optimise:
+                        self._const_map.pop(name, None)
+                    return
                 self._emit_var_read_obj(name)
                 self._emit_unbox_int()
                 amt = 1

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -165,6 +165,11 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
     "tcl_arith_bor": ("tcl", "tcl_arith_bor", [ValType.I32, ValType.I32], [ValType.I32]),
     "tcl_arith_bxor": ("tcl", "tcl_arith_bxor", [ValType.I32, ValType.I32], [ValType.I32]),
     "tcl_arith_bnot": ("tcl", "tcl_arith_bnot", [ValType.I32], [ValType.I32]),
+    # Float-preserving unary negation — keeps TYPE_FLOAT tag through
+    # ``-$x`` so the bitwise / shift domain checks downstream observe
+    # the float and raise the canonical error (Codex review on
+    # PR #287; issue #261).
+    "tcl_arith_neg": ("tcl", "tcl_arith_neg", [ValType.I32], [ValType.I32]),
     # Strict ``incr`` helper — validates the variable's value as a
     # strict integer (rejects float strings like ``"52.60"`` and
     # boolean keywords) before adding the amount.  Issue #262.

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -156,6 +156,19 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
     "tcl_arith_mul": ("tcl", "tcl_arith_mul", [ValType.I32, ValType.I32], [ValType.I32]),
     "tcl_arith_div": ("tcl", "tcl_arith_div", [ValType.I32, ValType.I32], [ValType.I32]),
     "tcl_arith_mod": ("tcl", "tcl_arith_mod", [ValType.I32, ValType.I32], [ValType.I32]),
+    # Bitwise / shift — strict integer domain.  Float operands raise
+    # ``cannot use floating-point value …``; negative shift counts
+    # raise ``negative shift argument``.  See issues #260, #261.
+    "tcl_arith_lshift": ("tcl", "tcl_arith_lshift", [ValType.I32, ValType.I32], [ValType.I32]),
+    "tcl_arith_rshift": ("tcl", "tcl_arith_rshift", [ValType.I32, ValType.I32], [ValType.I32]),
+    "tcl_arith_band": ("tcl", "tcl_arith_band", [ValType.I32, ValType.I32], [ValType.I32]),
+    "tcl_arith_bor": ("tcl", "tcl_arith_bor", [ValType.I32, ValType.I32], [ValType.I32]),
+    "tcl_arith_bxor": ("tcl", "tcl_arith_bxor", [ValType.I32, ValType.I32], [ValType.I32]),
+    "tcl_arith_bnot": ("tcl", "tcl_arith_bnot", [ValType.I32], [ValType.I32]),
+    # Strict ``incr`` helper — validates the variable's value as a
+    # strict integer (rejects float strings like ``"52.60"`` and
+    # boolean keywords) before adding the amount.  Issue #262.
+    "tcl_incr": ("tcl", "tcl_incr", [ValType.I32, ValType.I32], [ValType.I32]),
     # Math functions — called from expr codegen by name.
     "tcl_math_double": ("tcl", "tcl_math_double", [ValType.I32], [ValType.I32]),
     "tcl_math_int": ("tcl", "tcl_math_int", [ValType.I32], [ValType.I32]),

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -137,6 +137,11 @@ def _scan_expr_body_imports(expr_text: str, needed: set[str]) -> None:
                     # falls back to ``int(70.34) = 70`` and the runtime
                     # never sees the float — issue #261.
                     needed.add("tcl_obj_new_float")
+                    # ``tcl_arith_neg`` preserves the float tag through
+                    # ``-$x`` so a downstream bitwise op still sees a
+                    # TYPE_FLOAT operand and raises the canonical
+                    # ``cannot use floating-point value …`` error.
+                    needed.add("tcl_arith_neg")
                 _walk(left)
                 _walk(right)
             case ExprUnary(op=uop, operand=operand):
@@ -148,6 +153,9 @@ def _scan_expr_body_imports(expr_text: str, needed: set[str]) -> None:
                     # needs the float-literal box import registered to
                     # observe the float tag.
                     needed.add("tcl_obj_new_float")
+                    # ``tcl_arith_neg`` keeps the float tag through
+                    # ``~(-$x)`` chains.
+                    needed.add("tcl_arith_neg")
                 _walk(operand)
             case ExprTernary(condition=cond, true_branch=t, false_branch=f):
                 _walk(cond)
@@ -437,6 +445,7 @@ def _scan_needed_imports(
                     # — float-literal box import is required for the
                     # bitwise helpers to observe a TYPE_FLOAT operand.
                     needed.add("tcl_obj_new_float")
+                    needed.add("tcl_arith_neg")
                 _scan_expr(left)
                 _scan_expr(right)
             case ExprUnary(op=uop, operand=operand):
@@ -445,6 +454,7 @@ def _scan_needed_imports(
                     needed.add("tcl_obj_get_int")
                     needed.add("tcl_obj_new_int")
                     needed.add("tcl_obj_new_float")
+                    needed.add("tcl_arith_neg")
                 _scan_expr(operand)
             case ExprTernary(condition=cond, true_branch=t, false_branch=f):
                 _scan_expr(cond)

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -19,6 +19,7 @@ from ...expr_ast import (
     ExprTernary,
     ExprUnary,
     ExprVar,
+    UnaryOp,
 )
 from ...ir import (
     IRAssignConst,
@@ -69,6 +70,23 @@ def _scan_expr_body_imports(expr_text: str, needed: set[str]) -> None:
         BinOp.DIV: "tcl_arith_div",
         BinOp.MOD: "tcl_arith_mod",
     }
+    # Bitwise / shift — strict integer domain (issues #260, #261).
+    _BITWISE_OPS = frozenset(
+        {
+            BinOp.LSHIFT,
+            BinOp.RSHIFT,
+            BinOp.BIT_AND,
+            BinOp.BIT_OR,
+            BinOp.BIT_XOR,
+        }
+    )
+    _BITWISE_IMPORT = {
+        BinOp.LSHIFT: "tcl_arith_lshift",
+        BinOp.RSHIFT: "tcl_arith_rshift",
+        BinOp.BIT_AND: "tcl_arith_band",
+        BinOp.BIT_OR: "tcl_arith_bor",
+        BinOp.BIT_XOR: "tcl_arith_bxor",
+    }
     _MATH_FUNC_IMPORT = {
         "log": "tcl_math_log",
         "sqrt": "tcl_math_sqrt",
@@ -104,11 +122,34 @@ def _scan_expr_body_imports(expr_text: str, needed: set[str]) -> None:
                     needed.add("tcl_obj_get_int")
                     needed.add("tcl_obj_new_int")
                     needed.add("tcl_obj_new_float")
+                if op in _BITWISE_OPS:
+                    imp = _BITWISE_IMPORT.get(op)
+                    if imp:
+                        needed.add(imp)
+                    needed.add("tcl_obj_get_int")
+                    needed.add("tcl_obj_new_int")
+                    # Bitwise helpers reject float operands by inspecting
+                    # the runtime tag — operands must be passed as
+                    # TYPE_FLOAT TclObjs (not silently truncated to int).
+                    # ``_emit_obj_literal_for_expr`` boxes a float literal
+                    # via ``tcl_obj_new_float`` when the import is
+                    # registered; without it, a literal like ``70.34``
+                    # falls back to ``int(70.34) = 70`` and the runtime
+                    # never sees the float — issue #261.
+                    needed.add("tcl_obj_new_float")
                 _walk(left)
                 _walk(right)
-            case ExprUnary(operand=operand):
+            case ExprUnary(op=uop, operand=operand):
+                if uop == UnaryOp.BIT_NOT:
+                    needed.add("tcl_arith_bnot")
+                    needed.add("tcl_obj_get_int")
+                    needed.add("tcl_obj_new_int")
+                    # See note above — ``~`` rejects float operands and
+                    # needs the float-literal box import registered to
+                    # observe the float tag.
+                    needed.add("tcl_obj_new_float")
                 _walk(operand)
-            case ExprTernary(cond=cond, true_expr=t, false_expr=f):
+            case ExprTernary(condition=cond, true_branch=t, false_branch=f):
                 _walk(cond)
                 _walk(t)
                 _walk(f)
@@ -379,11 +420,33 @@ def _scan_needed_imports(
                     needed.add("tcl_obj_get_int")
                     needed.add("tcl_obj_new_int")
                     needed.add("tcl_obj_new_float")
+                if op in (BinOp.LSHIFT, BinOp.RSHIFT, BinOp.BIT_AND, BinOp.BIT_OR, BinOp.BIT_XOR):
+                    _BITWISE_IMPORT2 = {
+                        BinOp.LSHIFT: "tcl_arith_lshift",
+                        BinOp.RSHIFT: "tcl_arith_rshift",
+                        BinOp.BIT_AND: "tcl_arith_band",
+                        BinOp.BIT_OR: "tcl_arith_bor",
+                        BinOp.BIT_XOR: "tcl_arith_bxor",
+                    }
+                    bimp2 = _BITWISE_IMPORT2.get(op)
+                    if bimp2:
+                        needed.add(bimp2)
+                    needed.add("tcl_obj_get_int")
+                    needed.add("tcl_obj_new_int")
+                    # See companion comment in ``_scan_expr_body_imports``
+                    # — float-literal box import is required for the
+                    # bitwise helpers to observe a TYPE_FLOAT operand.
+                    needed.add("tcl_obj_new_float")
                 _scan_expr(left)
                 _scan_expr(right)
-            case ExprUnary(operand=operand):
+            case ExprUnary(op=uop, operand=operand):
+                if uop == UnaryOp.BIT_NOT:
+                    needed.add("tcl_arith_bnot")
+                    needed.add("tcl_obj_get_int")
+                    needed.add("tcl_obj_new_int")
+                    needed.add("tcl_obj_new_float")
                 _scan_expr(operand)
-            case ExprTernary(cond=cond, true_expr=t, false_expr=f):
+            case ExprTernary(condition=cond, true_branch=t, false_branch=f):
                 _scan_expr(cond)
                 _scan_expr(t)
                 _scan_expr(f)
@@ -701,6 +764,11 @@ def _scan_needed_imports(
                 if isinstance(amount, str):
                     _scan_value(amount)
                     _scan_value_for_array_refs(amount)
+                # Issue #262: route through ``tcl_incr`` to get the
+                # strict-integer guard (rejects float strings like
+                # ``"52.60"`` rather than silently truncating).
+                needed.add("tcl_incr")
+                needed.add("tcl_obj_new_int")
             case IRExprEval(expr=expr):
                 _scan_expr(expr)
             case IRAssignExpr(name=name, expr=expr):

--- a/fuzzing/findings/seed_1774200003.json
+++ b/fuzzing/findings/seed_1774200003.json
@@ -24,6 +24,6 @@
     "vm_opt",
     "wasm"
   ],
-  "fixed": false,
+  "fixed": true,
   "category": "wasm-accepts-negative-shift"
 }

--- a/fuzzing/findings/seed_1774200031.json
+++ b/fuzzing/findings/seed_1774200031.json
@@ -24,6 +24,6 @@
     "vm_opt",
     "wasm"
   ],
-  "fixed": false,
+  "fixed": true,
   "category": "wasm-accepts-float-bitwise"
 }

--- a/fuzzing/findings/seed_1774200035.json
+++ b/fuzzing/findings/seed_1774200035.json
@@ -24,6 +24,6 @@
     "vm_opt",
     "wasm"
   ],
-  "fixed": false,
+  "fixed": true,
   "category": "wasm-accepts-float-bitwise"
 }

--- a/fuzzing/findings/seed_1774200084.json
+++ b/fuzzing/findings/seed_1774200084.json
@@ -24,6 +24,6 @@
     "vm_opt",
     "wasm"
   ],
-  "fixed": false,
+  "fixed": true,
   "category": "wasm-accepts-float-as-integer"
 }

--- a/fuzzing/findings/seed_1774200087.json
+++ b/fuzzing/findings/seed_1774200087.json
@@ -24,6 +24,6 @@
     "vm_opt",
     "wasm"
   ],
-  "fixed": false,
+  "fixed": true,
   "category": "wasm-accepts-float-bitwise"
 }

--- a/fuzzing/tests/test_fuzz_findings.py
+++ b/fuzzing/tests/test_fuzz_findings.py
@@ -1265,6 +1265,36 @@ class TestBatch7WasmAcceptsFloatBitwise:
             result.error_message or ""
         )
 
+    def test_lshift_rejects_negated_float_var(self) -> None:
+        """Codex review on PR #287 — ``(-$x) << 1`` with float-string var.
+
+        The earlier patch only preserved the float tag through ``-floatlit``
+        (a literal negation); ``-$x`` of a variable holding ``"23.55"``
+        was emitted as ``0 - x`` on i64 and re-boxed as TYPE_INT,
+        bypassing the float-operand domain check.  The fix routes the
+        ``ExprUnary(NEG)`` operand through ``tcl_arith_neg`` which
+        preserves the TYPE_FLOAT tag for any operand shape.
+        """
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("set x 23.55\nexpr {(-$x) << 1}\n")
+        assert result.return_code == 1
+        assert "floating-point" in (result.error_message or "")
+        assert '"-23.55"' in (result.error_message or "")
+
+    def test_bnot_rejects_negated_float_var(self) -> None:
+        """Codex review on PR #287 — ``~(-$x)`` with float-string var."""
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("set x 23.55\nexpr {~(-$x)}\n")
+        assert result.return_code == 1
+        assert "floating-point" in (result.error_message or "")
+        assert '"-23.55"' in (result.error_message or "")
+
 
 class TestBatch7WasmAcceptsFloatAsInteger:
     """WASM backend silently truncated float strings in strict-integer ops.

--- a/fuzzing/tests/test_fuzz_findings.py
+++ b/fuzzing/tests/test_fuzz_findings.py
@@ -1139,3 +1139,184 @@ class TestBatchWasmAcceptsIfElseElseif:
 
         data = json.loads((FINDINGS_DIR / f"seed_{seed}.json").read_text())
         assert data.get("fixed") is True, f"seed {seed}: finding JSON not marked fixed (issue #259)"
+
+
+class TestBatch7WasmAcceptsNegativeShift:
+    """WASM backend silently completed scripts with negative shift counts.
+
+    Issue #260.  The WASM expression emitter inlined ``i64.shl`` /
+    ``i64.shr_s`` directly, which mask the shift count by 63 — so
+    ``expr {91 >> -41}`` silently returned a wrap-around result
+    instead of raising ``negative shift argument`` like the VM and
+    reference Tcl do.  The fix added ``tcl_arith_lshift`` /
+    ``tcl_arith_rshift`` runtime helpers that validate the count and
+    routed the bitwise emit path through them.
+    """
+
+    SEEDS = (1774200003,)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_wasm_errors_on_negative_shift(self, seed: int) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        source = (FINDINGS_DIR / f"seed_{seed}.tcl").read_text()
+        result = run_wasm(source, timeout=5.0)
+        assert result.return_code == 1, (
+            f"seed {seed}: wasm did not surface a Tcl-level error on a "
+            f"script with a negative shift count — issue #260 (rc="
+            f"{result.return_code}, err={result.error_message!r})"
+        )
+
+    def test_rshift_negative(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("expr {91 >> -41}\n")
+        assert result.return_code == 1
+        assert "negative shift argument" in (result.error_message or "")
+
+    def test_lshift_negative(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("expr {37 << -25}\n")
+        assert result.return_code == 1
+        assert "negative shift argument" in (result.error_message or "")
+
+    def test_ternary_folded_negative_shift(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("expr {(-39 >> (98 ? -72 : -76))}\n")
+        assert result.return_code == 1
+        assert "negative shift argument" in (result.error_message or "")
+
+
+class TestBatch7WasmAcceptsFloatBitwise:
+    """WASM backend silently truncated floats in bitwise / shift ops.
+
+    Issue #261.  The expression emitter's inline ``i64.and`` / ``i64.or``
+    / ``i64.xor`` / ``i64.shl`` / ``i64.shr_s`` / ``x ^ -1`` paths
+    accepted any operand by silently truncating it to ``int(float)``;
+    the VM and reference Tcl reject floats with
+    ``cannot use floating-point value "X" as <position> operand of "OP"``.
+    The fix added ``tcl_arith_band`` / ``tcl_arith_bor`` /
+    ``tcl_arith_bxor`` / ``tcl_arith_lshift`` / ``tcl_arith_rshift`` /
+    ``tcl_arith_bnot`` helpers that check the operand tag.
+    """
+
+    SEEDS = (1774200031, 1774200035, 1774200087)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_wasm_errors_on_float_bitwise(self, seed: int) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        source = (FINDINGS_DIR / f"seed_{seed}.tcl").read_text()
+        result = run_wasm(source, timeout=5.0)
+        assert result.return_code == 1, (
+            f"seed {seed}: wasm did not surface a Tcl-level error on a "
+            f"script with a float bitwise/shift operand — issue #261 "
+            f"(rc={result.return_code}, err={result.error_message!r})"
+        )
+        # Some full-seed scripts hit an unrelated error (e.g. ``no such
+        # variable`` from the issue #263 fix) before reaching the
+        # bitwise op; the ``error_status`` match in the differential
+        # harness only requires both backends to error, not match
+        # message exactly.  The targeted unit tests below pin the
+        # specific message wording.
+
+    def test_unary_bitnot_rejects_float(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("expr {~ -38.6}\n")
+        assert result.return_code == 1
+        assert 'cannot use floating-point value "-38.6" as operand of "~"' in (
+            result.error_message or ""
+        )
+
+    def test_bitand_rejects_float_right(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("expr {99 & 70.34}\n")
+        assert result.return_code == 1
+        assert 'cannot use floating-point value "70.34" as right operand of "&"' in (
+            result.error_message or ""
+        )
+
+    def test_lshift_rejects_float_left(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("expr {-23.55 << 4}\n")
+        assert result.return_code == 1
+        assert 'cannot use floating-point value "-23.55" as left operand of "<<"' in (
+            result.error_message or ""
+        )
+
+
+class TestBatch7WasmAcceptsFloatAsInteger:
+    """WASM backend silently truncated float strings in strict-integer ops.
+
+    Issue #262.  ``incr`` is a strict-integer command; the VM rejects
+    a value whose string spells a float (``"52.60"``) with
+    ``expected integer but got "52.60"``.  The WASM emitter's inlined
+    ``IRIncr`` path called ``obj_get_int`` directly, which silently
+    truncates ``"52.60"`` to ``52`` and lets the counter advance — a
+    runaway-loop driver in the differential fuzzer's ``wasm-timeout``
+    cluster.  The fix routes ``IRIncr`` through ``tcl_incr`` and adds
+    a strict-integer guard there.
+    """
+
+    SEEDS = (1774200084,)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_wasm_errors_on_float_in_incr(self, seed: int) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        source = (FINDINGS_DIR / f"seed_{seed}.tcl").read_text()
+        result = run_wasm(source, timeout=5.0)
+        assert result.return_code == 1, (
+            f"seed {seed}: wasm did not surface a Tcl-level error on a "
+            f"script that runs ``incr`` against a float string — "
+            f"issue #262 (rc={result.return_code}, "
+            f"err={result.error_message!r})"
+        )
+        assert "expected integer" in (result.error_message or ""), (
+            f"seed {seed}: wasm errored but not on the float-as-integer "
+            f"path — issue #262 expects ``expected integer`` in the "
+            f"message (rc={result.return_code}, "
+            f"err={result.error_message!r})"
+        )
+
+    def test_incr_rejects_float_string(self) -> None:
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("set i 52.60\nincr i\n")
+        assert result.return_code == 1
+        assert 'expected integer but got "52.60"' in (result.error_message or "")
+
+    def test_incr_accepts_int_string(self) -> None:
+        """Non-regression: ordinary integer strings still increment cleanly."""
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("set i 5\nincr i\nputs $i\n")
+        assert result.return_code == 0
+        assert result.stdout.strip() == "6"

--- a/fuzzing/tests/test_fuzz_findings.py
+++ b/fuzzing/tests/test_fuzz_findings.py
@@ -1350,3 +1350,84 @@ class TestBatch7WasmAcceptsFloatAsInteger:
         result = run_wasm("set i 5\nincr i\nputs $i\n")
         assert result.return_code == 0
         assert result.stdout.strip() == "6"
+
+    def test_incr_rejects_empty_string(self) -> None:
+        """Copilot review on PR #287: ``incr ""`` must reject.
+
+        The earlier char-whitelist parser returned ``true`` for empty
+        strings because the post-whitespace digit-check loop ran zero
+        iterations and fell through to ``return true``.  ``obj_get_int``
+        then silently returned 0 and ``incr`` advanced — masking the
+        canonical ``expected integer but got ""`` error.
+        """
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm('set i ""\nincr i\n')
+        assert result.return_code == 1
+        assert 'expected integer but got ""' in (result.error_message or "")
+
+    def test_incr_rejects_alpha_string(self) -> None:
+        """Copilot review on PR #287: ``incr abc``/``incr deadbeef`` must reject.
+
+        The earlier char-whitelist accepted any byte in
+        ``[0-9a-fA-FxXoOb]`` unconditionally, so alpha-only strings
+        like ``"abc"`` and ``"deadbeef"`` (every byte is a hex digit)
+        slipped through and ``obj_get_int`` silently returned 0.
+        """
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        for value in ("abc", "deadbeef", "xyz"):
+            result = run_wasm(f"set i {value}\nincr i\n")
+            assert result.return_code == 1, (
+                f"incr {value!r} did not error (rc={result.return_code}, "
+                f"err={result.error_message!r})"
+            )
+            assert f'expected integer but got "{value}"' in (result.error_message or "")
+
+    def test_incr_rejects_whitespace_only(self) -> None:
+        """Copilot review on PR #287: whitespace-only string must reject."""
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm('set i "   "\nincr i\n')
+        assert result.return_code == 1
+        assert "expected integer" in (result.error_message or "")
+
+    def test_incr_rejects_boolean(self) -> None:
+        """Copilot review on PR #287 (also issue #262 family): boolean strings must reject."""
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        for value in ("yes", "no", "true", "false"):
+            result = run_wasm(f"set i {value}\nincr i\n")
+            assert result.return_code == 1, (
+                f"incr {value!r} did not error (rc={result.return_code}, "
+                f"err={result.error_message!r})"
+            )
+            assert f'expected integer but got "{value}"' in (result.error_message or "")
+
+    def test_incr_accepts_int_with_whitespace(self) -> None:
+        """Non-regression: integer with leading/trailing whitespace still increments."""
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm('set i "  5  "\nincr i\nputs $i\n')
+        assert result.return_code == 0
+        assert result.stdout.strip() == "6"
+
+    def test_incr_accepts_negative_int_string(self) -> None:
+        """Non-regression: negative integer strings still increment."""
+        from fuzzing.wasm_backend import is_available, run_wasm  # noqa: PLC0415
+
+        if not is_available():
+            pytest.skip("wasmtime / runtime WASM artefact not available")
+        result = run_wasm("set i -5\nincr i\nputs $i\n")
+        assert result.return_code == 0
+        assert result.stdout.strip() == "-4"

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1470,10 +1470,94 @@ pub export fn global_exists(name: i32) i32 {
 /// imports it under ``tcl_incr``); not a great architectural fit
 /// long-term but moving it is out of scope for the namespace-tree
 /// rework.
+///
+/// ``incr`` is a strict-integer command — Tcl rejects any value
+/// whose string form spells a float (decimal point or exponent) or
+/// is a boolean keyword with ``expected integer but got "X"``.  See
+/// issue #262 (and the regression battery in
+/// ``fuzzing/tests/test_fuzz_findings.py::TestIncrStrictParsing``).
+/// The previous implementation called ``obj_get_int`` directly,
+/// which silently truncates ``"52.60"`` to ``52`` and lets the
+/// counter advance — surfacing as either a wasm/vm divergence (the
+/// fuzzer's ``wasm-accepts-float-as-integer`` category) or a
+/// runaway loop when the float is the loop counter.
 pub export fn tcl_incr(o: i32, amount: i32) i32 {
+    if (!incr_is_strict_int(o)) {
+        raise_expected_integer(o);
+        return obj_new_int_pub(0);
+    }
+    if (!incr_is_strict_int(amount)) {
+        raise_expected_integer(amount);
+        return obj_new_int_pub(0);
+    }
     const val = obj_get_int_pub(o);
     const amt = obj_get_int_pub(amount);
     return obj_new_int_pub(val + amt);
+}
+
+fn incr_is_strict_int(o: i32) bool {
+    if (o == 0) return true;
+    const tag = obj.obj_type(o);
+    if (tag == obj.TYPE_INT) return true;
+    if (tag == obj.TYPE_FLOAT) return false;
+    // String / inline string — peek the bytes; reject if any
+    // ``.`` / ``e`` / ``E`` appears (Tcl's strict parser only
+    // accepts decimal/hex/octal/binary integers).  An empty
+    // string parses as 0 in Tcl strict-integer contexts.
+    const s = obj.obj_ensure_string(o);
+    if (s.len == 0) return true;
+    const sp: [*]const u8 = @ptrFromInt(s.ptr);
+    var i: u32 = 0;
+    // Skip leading whitespace + optional sign for the digit check.
+    while (i < s.len) : (i += 1) {
+        const c = sp[i];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '\x0b' or c == '\x0c') continue;
+        break;
+    }
+    if (i < s.len and (sp[i] == '+' or sp[i] == '-')) i += 1;
+    while (i < s.len) : (i += 1) {
+        const c = sp[i];
+        if (c == '.' or c == 'e' or c == 'E') return false;
+        if (c >= '0' and c <= '9') continue;
+        // Allow hex/octal/binary prefix tail (``0x...``, ``0o...``, ``0b...``)
+        // — every char accepted by Tcl's integer parser.
+        if (c == 'x' or c == 'X' or c == 'o' or c == 'O' or c == 'b' or c == 'B') continue;
+        if ((c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F')) continue;
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '\x0b' or c == '\x0c') continue;
+        // Anything else (alpha / punctuation) — let the int parser
+        // raise its own error via ``obj_get_int`` (we still return
+        // false here so ``raise_expected_integer`` produces the
+        // canonical message).
+        return false;
+    }
+    return true;
+}
+
+fn raise_expected_integer(o: i32) void {
+    const s = obj.obj_ensure_string(o);
+    const prefix: []const u8 = "expected integer but got \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @intCast(prefix.len + s.len + suffix.len);
+    const buf_addr: u32 = obj.alloc(total);
+    const buf: [*]u8 = @ptrFromInt(buf_addr);
+    var off: usize = 0;
+    for (prefix) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| {
+            buf[off] = sp[i];
+            off += 1;
+        }
+    }
+    for (suffix) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    @import("tcl_catch.zig").tcl_cmd_error(msg);
 }
 
 // -- Test scaffolding -------------------------------------------------------

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1500,37 +1500,35 @@ fn incr_is_strict_int(o: i32) bool {
     const tag = obj.obj_type(o);
     if (tag == obj.TYPE_INT) return true;
     if (tag == obj.TYPE_FLOAT) return false;
-    // String / inline string — peek the bytes; reject if any
-    // ``.`` / ``e`` / ``E`` appears (Tcl's strict parser only
-    // accepts decimal/hex/octal/binary integers).  An empty
-    // string parses as 0 in Tcl strict-integer contexts.
+    // String / inline string — delegate to the canonical strict-decimal
+    // parser used by ``obj_get_int``.  Keeping the validation and the
+    // read in lock-step means anything we accept here will round-trip
+    // cleanly to an int when ``tcl_incr`` calls ``obj_get_int`` next.
+    //
+    //   * empty / whitespace-only   → null → reject
+    //   * floats (``"52.60"``, ``"1e5"``)        → null → reject (issue #262)
+    //   * boolean keywords (``"yes"``, ``"true"``) → null → reject
+    //   * alpha-only (``"abc"``, ``"deadbeef"``)   → null → reject
+    //
+    // The earlier hand-rolled char-class whitelist accepted any string
+    // containing only ``[0-9a-fA-FxXoOb B]`` (so ``"abc"`` and
+    // ``"deadbeef"`` slipped through and ``obj_get_int`` silently
+    // returned 0 — Copilot review on PR #287).  Empty strings also
+    // returned ``true`` and let ``incr ""`` succeed instead of raising
+    // ``expected integer but got ""``.
+    //
+    // Note: ``try_parse_int`` is currently decimal-only.  Hex / octal /
+    // binary integer literals (``"0xff"``, ``"0o17"``, ``"0b1010"``)
+    // therefore round-trip through this validator as ``expected
+    // integer …``.  That's tighter than reference Tcl, but
+    // ``obj_get_int`` can't extract those bases either, so accepting
+    // them here would silently miscompute (``incr i`` with
+    // ``i = "0xFF"`` would yield ``1``, not ``256``).  Extending
+    // ``try_parse_int`` to cover non-decimal bases is tracked
+    // separately and out of scope for the bitwise/shift/incr domain
+    // fixes covered by issues #260–#262.
     const s = obj.obj_ensure_string(o);
-    if (s.len == 0) return true;
-    const sp: [*]const u8 = @ptrFromInt(s.ptr);
-    var i: u32 = 0;
-    // Skip leading whitespace + optional sign for the digit check.
-    while (i < s.len) : (i += 1) {
-        const c = sp[i];
-        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '\x0b' or c == '\x0c') continue;
-        break;
-    }
-    if (i < s.len and (sp[i] == '+' or sp[i] == '-')) i += 1;
-    while (i < s.len) : (i += 1) {
-        const c = sp[i];
-        if (c == '.' or c == 'e' or c == 'E') return false;
-        if (c >= '0' and c <= '9') continue;
-        // Allow hex/octal/binary prefix tail (``0x...``, ``0o...``, ``0b...``)
-        // — every char accepted by Tcl's integer parser.
-        if (c == 'x' or c == 'X' or c == 'o' or c == 'O' or c == 'b' or c == 'B') continue;
-        if ((c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F')) continue;
-        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '\x0b' or c == '\x0c') continue;
-        // Anything else (alpha / punctuation) — let the int parser
-        // raise its own error via ``obj_get_int`` (we still return
-        // false here so ``raise_expected_integer`` produces the
-        // canonical message).
-        return false;
-    }
-    return true;
+    return obj.try_parse_int(s.ptr, s.len) != null;
 }
 
 fn raise_expected_integer(o: i32) void {

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -422,6 +422,7 @@ comptime {
     _ = &tcl_arith.tcl_arith_bor;
     _ = &tcl_arith.tcl_arith_bxor;
     _ = &tcl_arith.tcl_arith_bnot;
+    _ = &tcl_arith.tcl_arith_neg;
     _ = &tcl_arith.tcl_math_double;
     _ = &tcl_arith.tcl_math_int;
     _ = &tcl_arith.tcl_math_round;

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -416,6 +416,12 @@ comptime {
     _ = &tcl_arith.tcl_arith_mul;
     _ = &tcl_arith.tcl_arith_div;
     _ = &tcl_arith.tcl_arith_mod;
+    _ = &tcl_arith.tcl_arith_lshift;
+    _ = &tcl_arith.tcl_arith_rshift;
+    _ = &tcl_arith.tcl_arith_band;
+    _ = &tcl_arith.tcl_arith_bor;
+    _ = &tcl_arith.tcl_arith_bxor;
+    _ = &tcl_arith.tcl_arith_bnot;
     _ = &tcl_arith.tcl_math_double;
     _ = &tcl_arith.tcl_math_int;
     _ = &tcl_arith.tcl_math_round;

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -336,3 +336,16 @@ pub export fn tcl_arith_bnot(a: i32) i32 {
     }
     return obj.obj_new_int(~obj.obj_get_int(a));
 }
+
+/// Float-preserving unary negation.  Mirrors ``tcl_arith_sub(0, x)``:
+/// int → int, any float → float.  Used by the WASM expression emitter
+/// in object-context paths (``_emit_expr_obj``) so that ``-$x`` of a
+/// float-string variable keeps its TYPE_FLOAT tag end-to-end and the
+/// bitwise / shift domain checks (``tcl_arith_lshift`` /
+/// ``tcl_arith_bnot``) observe the float on the operand chain.  Without
+/// this helper the inline ``0 - x`` i64 path silently truncates to int
+/// and the float check is bypassed (Codex review on PR #287).
+pub export fn tcl_arith_neg(a: i32) i32 {
+    if (is_float(a)) return obj.obj_new_float(-obj.obj_get_float(a));
+    return obj.obj_new_int(-%obj.obj_get_int(a));
+}

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -22,7 +22,7 @@ const std = @import("std");
 const obj = @import("tcl_obj.zig");
 const stubs = @import("../stubs/tcl_stubs.zig");
 
-const TYPE_INT   = obj.TYPE_INT;
+const TYPE_INT = obj.TYPE_INT;
 const TYPE_FLOAT = obj.TYPE_FLOAT;
 const TYPE_STRING = obj.TYPE_STRING;
 
@@ -152,4 +152,187 @@ pub export fn tcl_math_cos(a: i32) i32 {
 /// fabs(x) — absolute value as float.
 pub export fn tcl_math_fabs(a: i32) i32 {
     return obj.obj_new_float(@abs(obj.obj_get_float(a)));
+}
+
+// ----------------------------------------------------------------------
+// Bitwise / shift helpers — issues #260, #261, #262
+//
+// Tcl 9.0 rejects floating-point operands in bitwise (``&`` ``|`` ``^``
+// ``~``) and shift (``<<`` ``>>``) operators with errors of the form:
+//
+//   cannot use floating-point value "X" as operand of "OP"
+//   cannot use floating-point value "X" as left operand of "OP"
+//   cannot use floating-point value "X" as right operand of "OP"
+//
+// Shift counts must additionally be non-negative; a negative count
+// raises ``negative shift argument``.  The Python VM enforces both
+// rules in ``vm/machine.py::_bitwise_binary``; the WASM expression
+// emitter previously inlined ``i64.shl`` / ``i64.and`` / ``i64.or`` /
+// ``i64.xor`` directly, which silently truncated floats and accepted
+// negative shift counts (WASM masks the count by 63).  These helpers
+// are called from ``core/compiler/codegen/wasm/_emitter/_expressions.py``
+// to recover the missing domain checks.
+
+/// Build ``cannot use floating-point value "X" as <position> operand of "<op>"``
+/// and route it through the Tcl error path.
+fn raise_float_in_bitwise(o: i32, op_sym: []const u8, position: []const u8) void {
+    const s = obj.obj_ensure_string(o);
+    const prefix: []const u8 = "cannot use floating-point value \"";
+    const middle: []const u8 = "\" as ";
+    const between: []const u8 = " operand of \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @intCast(prefix.len + s.len + middle.len + position.len + between.len + op_sym.len + suffix.len);
+    const buf_addr: u32 = obj.alloc(total);
+    const buf: [*]u8 = @ptrFromInt(buf_addr);
+    var off: usize = 0;
+    for (prefix) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| {
+            buf[off] = sp[i];
+            off += 1;
+        }
+    }
+    for (middle) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    for (position) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    for (between) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    for (op_sym) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    for (suffix) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
+}
+
+/// Build ``cannot use floating-point value "X" as operand of "<op>"``
+/// (unary form — no left/right qualifier).
+fn raise_float_in_unary_bitwise(o: i32, op_sym: []const u8) void {
+    const s = obj.obj_ensure_string(o);
+    const prefix: []const u8 = "cannot use floating-point value \"";
+    const middle: []const u8 = "\" as operand of \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @intCast(prefix.len + s.len + middle.len + op_sym.len + suffix.len);
+    const buf_addr: u32 = obj.alloc(total);
+    const buf: [*]u8 = @ptrFromInt(buf_addr);
+    var off: usize = 0;
+    for (prefix) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| {
+            buf[off] = sp[i];
+            off += 1;
+        }
+    }
+    for (middle) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    for (op_sym) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    for (suffix) |c| {
+        buf[off] = c;
+        off += 1;
+    }
+    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
+}
+
+fn check_int_binary(a: i32, b: i32, op_sym: []const u8) bool {
+    if (is_float(a)) {
+        raise_float_in_bitwise(a, op_sym, "left");
+        return false;
+    }
+    if (is_float(b)) {
+        raise_float_in_bitwise(b, op_sym, "right");
+        return false;
+    }
+    return true;
+}
+
+pub export fn tcl_arith_lshift(a: i32, b: i32) i32 {
+    if (!check_int_binary(a, b, "<<")) return obj.obj_new_int(0);
+    const bi = obj.obj_get_int(b);
+    if (bi < 0) {
+        stubs.raise("negative shift argument");
+        return obj.obj_new_int(0);
+    }
+    const ai = obj.obj_get_int(a);
+    if (bi >= 64) {
+        // Tcl 9 raises ``integer value too large to represent`` for
+        // very large shift counts on non-zero values.  For simplicity
+        // we collapse to 0 for ``a == 0`` (mirrors ``0 << N == 0``)
+        // and rely on i64 wrap semantics for non-zero ``a`` (matches
+        // the previous inline ``i64.shl`` behaviour up to the count
+        // mask).  Tcl-style ``integer too large`` is out of scope.
+        if (ai == 0) return obj.obj_new_int(0);
+        // Use a safe default: shift by (bi & 63) — this matches what
+        // ``i64.shl`` did before.  Avoids a hard error for callers
+        // that previously relied on the implicit mask.
+        const shift: u6 = @intCast(@as(u64, @bitCast(bi)) & 63);
+        return obj.obj_new_int(ai << shift);
+    }
+    const shift: u6 = @intCast(bi);
+    return obj.obj_new_int(ai << shift);
+}
+
+pub export fn tcl_arith_rshift(a: i32, b: i32) i32 {
+    if (!check_int_binary(a, b, ">>")) return obj.obj_new_int(0);
+    const bi = obj.obj_get_int(b);
+    if (bi < 0) {
+        stubs.raise("negative shift argument");
+        return obj.obj_new_int(0);
+    }
+    const ai = obj.obj_get_int(a);
+    if (bi >= 64) {
+        // Arithmetic shift by 64+ produces 0 for non-negative ``a``
+        // and -1 for negative ``a``.  Match that exactly rather than
+        // letting WASM mask the count.
+        return obj.obj_new_int(if (ai < 0) -1 else 0);
+    }
+    const shift: u6 = @intCast(bi);
+    return obj.obj_new_int(ai >> shift);
+}
+
+pub export fn tcl_arith_band(a: i32, b: i32) i32 {
+    if (!check_int_binary(a, b, "&")) return obj.obj_new_int(0);
+    return obj.obj_new_int(obj.obj_get_int(a) & obj.obj_get_int(b));
+}
+
+pub export fn tcl_arith_bor(a: i32, b: i32) i32 {
+    if (!check_int_binary(a, b, "|")) return obj.obj_new_int(0);
+    return obj.obj_new_int(obj.obj_get_int(a) | obj.obj_get_int(b));
+}
+
+pub export fn tcl_arith_bxor(a: i32, b: i32) i32 {
+    if (!check_int_binary(a, b, "^")) return obj.obj_new_int(0);
+    return obj.obj_new_int(obj.obj_get_int(a) ^ obj.obj_get_int(b));
+}
+
+pub export fn tcl_arith_bnot(a: i32) i32 {
+    if (is_float(a)) {
+        raise_float_in_unary_bitwise(a, "~");
+        return obj.obj_new_int(0);
+    }
+    return obj.obj_new_int(~obj.obj_get_int(a));
 }

--- a/tests/test_wasm_codegen.py
+++ b/tests/test_wasm_codegen.py
@@ -326,10 +326,19 @@ def test_empty_script():
 
 
 def test_incr_command():
-    """incr should compile to i64.add."""
+    """``incr`` should route through the ``tcl_incr`` runtime helper.
+
+    Issue #262: the previous ``i64.add`` inline form silently truncated
+    float strings (``incr i`` with ``i = "52.60"`` advanced to 53
+    instead of raising ``expected integer but got "52.60"``); the
+    runtime helper enforces the strict-integer guard.  The earlier
+    inline-add path is retained as a fallback when the helper isn't
+    registered, but the standard scan path now imports ``tcl_incr``
+    on every ``IRIncr`` node.
+    """
     module = _compile("set x 0\nincr x\n")
     wat = module.to_wat()
-    assert "i64.add" in wat
+    assert "tcl_incr" in wat
 
 
 def test_multiple_procedures():


### PR DESCRIPTION
## Summary

This PR fixes three related issues in the WASM backend where runtime domain checks were missing or bypassed:

- **Issue #260**: Negative shift counts were silently accepted instead of raising `negative shift argument`
- **Issue #261**: Float operands in bitwise (`&`, `|`, `^`, `~`) and shift (`<<`, `>>`) operations were silently truncated instead of raising `cannot use floating-point value "X" as <position> operand of "OP"`
- **Issue #262**: Float strings in `incr` were silently truncated instead of raising `expected integer but got "X"`

### Changes

**Runtime helpers** (`runtime/zig/valtypes/tcl_arith.zig`):
- Added `tcl_arith_lshift`, `tcl_arith_rshift`, `tcl_arith_band`, `tcl_arith_bor`, `tcl_arith_bxor`, `tcl_arith_bnot` functions that enforce integer-only operands and validate shift counts
- Added helper functions `raise_float_in_bitwise`, `raise_float_in_unary_bitwise` to generate proper error messages

**Incr validation** (`runtime/zig/interp/tcl_ns.zig`):
- Modified `tcl_incr` to validate both operands are strict integers via `incr_is_strict_int`
- Added `incr_is_strict_int` function that rejects float strings (containing `.`, `e`, or `E`)
- Added `raise_expected_integer` helper for error messages

**WASM codegen** (`core/compiler/codegen/wasm/_emitter/_expressions.py`):
- Routed bitwise/shift binary operations through runtime helpers instead of inline `i64` instructions
- Added special handling for unary `~` operator to call `tcl_arith_bnot`
- Preserved float type through negation of float literals to prevent silent truncation in downstream bitwise operations

**Import registration** (`core/compiler/codegen/wasm/_scan.py`, `_imports.py`):
- Registered new bitwise/shift runtime imports in the scanner and import definitions
- Ensured `tcl_obj_new_float` is imported when bitwise operations are used (so float literals are properly tagged)

**Control flow** (`core/compiler/codegen/wasm/_emitter/_control_flow.py`, `_statements.py`, `_optimisation.py`):
- Routed `IRIncr` statements through `tcl_incr` runtime helper for strict-integer validation

**Tests** (`fuzzing/tests/test_fuzz_findings.py`):
- Added comprehensive test suites for all three issues with both seed-based and targeted unit tests
- Tests verify proper error messages and non-regression cases

## Validation

- All new test cases in `TestBatch7WasmAcceptsNegativeShift`, `TestBatch7WasmAcceptsFloatBitwise`, and `TestBatch7WasmAcceptsFloatAsInteger` pass
- Existing test `test_incr_command` updated to verify `tcl_incr` routing
- Fuzzing findings marked as fixed (seeds 1774200003, 1774200031, 1774200035, 1774200084, 1774200087)

https://claude.ai/code/session_01R4A6MeB6zYraF8NtCMjkX6