### PR TITLE
Add per-channel write buffering and output translation

### DIFF
--- a/runtime/zig/cmds/io.zig
+++ b/runtime/zig/cmds/io.zig
@@ -188,18 +188,15 @@ fn eval_fcopy(words: []const i32) i32 {
     return chan.fcopy_limited(words[1], words[2], size_limit);
 }
 
-/// ``flush ?channelId?`` — under WASI our writes are synchronous /
-/// unbuffered so flush is a no-op that returns the empty string,
-/// matching tclsh's contract.  Without this entry the interpreter
-/// route (e.g. ``flush`` issued from inside a tcltest body
-/// uplevel'd by ``test``/``Eval``/``RunTest``) hits ``STUB_TRAP``
-/// and fails with ``unsupported command: flush``, breaking any
-/// script that explicitly flushes between writes.  The compiled
-/// fast path in the codegen calls ``tcl_cmd_flush`` directly and
-/// has always worked.
+/// ``flush ?channelId?`` — drain the named channel's write buffer
+/// to its fd and return the empty string.  Without an explicit
+/// channel argument we no-op rather than guess at stdout: the
+/// codegen fast path passes the channel id directly into
+/// ``tcl_cmd_flush``, so the eval route only sees ``flush`` calls
+/// from scripts that always supply the channel.
 fn eval_flush(words: []const i32) i32 {
-    _ = words;
-    return 0;
+    if (words.len < 2) return 0;
+    return chan.flush_chan_id(words[1]);
 }
 
 fn eval_append(words: []const i32) i32 {

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -111,6 +111,7 @@ pub const MODE_READ: u32 = 1;
 pub const MODE_WRITE: u32 = 2;
 
 const READ_BUF_SIZE: u32 = 4096;
+const WRITE_BUF_SIZE: u32 = 4096;
 const MAX_CHANNELS: u32 = 64;
 
 const Channel = struct {
@@ -127,6 +128,15 @@ const Channel = struct {
     buf_addr: u32,
     buf_pos: u32,
     buf_end: u32,
+    // Push-side buffer for puts/flush.  Allocated lazily on first
+    // write; sized by ``-buffersize`` (default 4096).  ``out_buf_pos``
+    // counts post-translation bytes accumulated so far.  CRLF/CR
+    // translation is applied byte-by-byte on the way in, so a ``\n``
+    // arriving when only one slot remains is split across two
+    // buffers (the ``savedLF > 0`` case from upstream io-2.2).
+    out_buf_addr: u32,
+    out_buf_size: u32,
+    out_buf_pos: u32,
 };
 
 var channels: [MAX_CHANNELS]Channel = init: {
@@ -145,6 +155,9 @@ var channels: [MAX_CHANNELS]Channel = init: {
             .buf_addr = 0,
             .buf_pos = 0,
             .buf_end = 0,
+            .out_buf_addr = 0,
+            .out_buf_size = WRITE_BUF_SIZE,
+            .out_buf_pos = 0,
         };
     }
     // Slots 0/1/2 are pre-populated for stdin/stdout/stderr so
@@ -161,6 +174,9 @@ var channels: [MAX_CHANNELS]Channel = init: {
         .buf_addr = 0,
         .buf_pos = 0,
         .buf_end = 0,
+        .out_buf_addr = 0,
+        .out_buf_size = WRITE_BUF_SIZE,
+        .out_buf_pos = 0,
     };
     arr[1] = .{
         .in_use = true,
@@ -174,6 +190,9 @@ var channels: [MAX_CHANNELS]Channel = init: {
         .buf_addr = 0,
         .buf_pos = 0,
         .buf_end = 0,
+        .out_buf_addr = 0,
+        .out_buf_size = WRITE_BUF_SIZE,
+        .out_buf_pos = 0,
     };
     arr[2] = .{
         .in_use = true,
@@ -187,6 +206,9 @@ var channels: [MAX_CHANNELS]Channel = init: {
         .buf_addr = 0,
         .buf_pos = 0,
         .buf_end = 0,
+        .out_buf_addr = 0,
+        .out_buf_size = WRITE_BUF_SIZE,
+        .out_buf_pos = 0,
     };
     break :init arr;
 };
@@ -373,17 +395,20 @@ pub export fn tcl_cmd_open(path: i32, access: i32) i32 {
         .buf_addr = 0,
         .buf_pos = 0,
         .buf_end = 0,
+        .out_buf_addr = 0,
+        .out_buf_size = WRITE_BUF_SIZE,
+        .out_buf_pos = 0,
     };
     return slot_name(slot);
 }
 
-/// ``close channelId`` — flush nothing (no per-channel write
-/// buffer), close the underlying fd, and free the slot.  Returns
-/// the empty string on success.  Closing stdin/stdout/stderr is
-/// silently treated as a no-op: the WASI host owns those fds, and
-/// shutting them mid-script would surprise the embedder.  This
-/// diverges from real tclsh (which would close the host stream)
-/// in the conservative direction.
+/// ``close channelId`` — flush any buffered output, close the
+/// underlying fd, and free the slot.  Returns the empty string on
+/// success.  Closing stdin/stdout/stderr is silently treated as a
+/// flush-only no-op: the WASI host owns those fds, and shutting
+/// them mid-script would surprise the embedder.  This diverges
+/// from real tclsh (which would close the host stream) in the
+/// conservative direction.
 pub export fn tcl_cmd_close(chan: i32) i32 {
     const slot = resolve(chan) orelse {
         stubs.raise("close: unknown channel");
@@ -392,13 +417,19 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
     if (slot < 3) {
         // Per Tcl, closing stdin/stdout/stderr is permitted but
         // would shut the host stream — surprising for a sandbox.
-        // Treat as no-op.
+        // We still drain the per-channel write buffer so anything
+        // queued via ``-buffering full`` lands on the host stream.
+        _ = flush_chan(&channels[slot]);
         return obj_new_string(0, 0);
     }
     const c = &channels[slot];
+    _ = flush_chan(c);
     _ = close_fn(c.fd);
     if (c.buf_addr != 0) {
         obj.free_sized(c.buf_addr, READ_BUF_SIZE);
+    }
+    if (c.out_buf_addr != 0) {
+        obj.free_sized(c.out_buf_addr, c.out_buf_size);
     }
     c.* = .{
         .in_use = false,
@@ -412,6 +443,9 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
         .buf_addr = 0,
         .buf_pos = 0,
         .buf_end = 0,
+        .out_buf_addr = 0,
+        .out_buf_size = WRITE_BUF_SIZE,
+        .out_buf_pos = 0,
     };
     return obj_new_string(0, 0);
 }
@@ -651,6 +685,13 @@ pub export fn tcl_cmd_seek(chan: i32, offset: i32, origin: i32) i32 {
             if (eq(rp, rs.len, "start")) whence = SEEK_SET;
         }
     }
+    // Drain pending writes before moving the fd offset; otherwise
+    // the buffered bytes would land at the new position rather than
+    // the position they were intended for.
+    if (!flush_chan(c)) {
+        stubs.raise("seek: write failed");
+        return 0;
+    }
     if (do_seek(c.fd, off_val, whence) == null) {
         stubs.raise("seek: fd_seek failed");
         return 0;
@@ -735,6 +776,15 @@ pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
     // bytes (or return them out of order).  We forward the buffer's
     // pending span verbatim — translation already happened on the
     // way into ``in_c.buf_*``.
+    // Drain anything still queued on the destination's write
+    // buffer first.  fcopy writes raw bytes straight to ``out_c.fd``
+    // (no per-byte translation here — that already happened on the
+    // input pull side), so any pending buffered output has to land
+    // first or it would appear *after* the freshly copied bytes.
+    if (!flush_chan(out_c)) {
+        stubs.raise("fcopy: write failed");
+        return 0;
+    }
     if (in_c.buf_pos < in_c.buf_end) {
         const pending: u32 = in_c.buf_end - in_c.buf_pos;
         var take: u32 = pending;
@@ -792,24 +842,88 @@ pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
     return obj_new_int(copied);
 }
 
-// Output translation — emits ``msg`` (followed optionally by a
-// trailing newline) onto ``c.fd``.  Currently honours TR_CRLF by
-// expanding LF → CRLF; everything else is byte-for-byte.  Returns
-// false on a write failure so the caller can raise.
-fn write_translated(c: *Channel, ptr: [*]const u8, len: u32) bool {
-    if (c.translation == TR_CRLF) {
-        var i: u32 = 0;
-        while (i < len) : (i += 1) {
-            if (ptr[i] == '\n') {
-                if (write_fn(c.fd, "\r\n", 2) < 0) return false;
-            } else {
-                if (write_fn(c.fd, @ptrCast(&ptr[i]), 1) < 0) return false;
-            }
-        }
+// Drain the per-channel write buffer to the underlying fd.  Returns
+// false on a write failure (caller raises).  Idempotent and safe to
+// call when no buffer has been allocated.
+pub fn flush_chan(c: *Channel) bool {
+    if (c.out_buf_addr == 0 or c.out_buf_pos == 0) {
+        c.out_buf_pos = 0;
         return true;
     }
-    if (len == 0) return true;
-    return write_fn(c.fd, ptr, len) >= 0;
+    const ptr: [*]const u8 = @ptrFromInt(c.out_buf_addr);
+    var off: usize = 0;
+    var rem: usize = c.out_buf_pos;
+    while (rem > 0) {
+        const w = write_fn(c.fd, ptr + off, rem);
+        if (w <= 0) return false;
+        off += @intCast(w);
+        rem -= @intCast(w);
+    }
+    c.out_buf_pos = 0;
+    return true;
+}
+
+// Append a single post-translation byte to the channel's write
+// buffer, flushing on a full buffer or when line-buffering hits a
+// newline.  Returns false on a write failure.  Allocates the buffer
+// lazily on first use.
+fn emit_byte(c: *Channel, byte: u8) bool {
+    if (c.out_buf_addr == 0) {
+        if (c.out_buf_size == 0) c.out_buf_size = WRITE_BUF_SIZE;
+        c.out_buf_addr = obj.alloc(c.out_buf_size);
+        c.out_buf_pos = 0;
+    }
+    const dst: [*]u8 = @ptrFromInt(c.out_buf_addr);
+    dst[c.out_buf_pos] = byte;
+    c.out_buf_pos += 1;
+    if (c.out_buf_pos >= c.out_buf_size) {
+        if (!flush_chan(c)) return false;
+    } else if (c.buffering == BUF_LINE and byte == '\n') {
+        if (!flush_chan(c)) return false;
+    }
+    return true;
+}
+
+// Output translation — append ``len`` bytes starting at ``ptr`` to
+// the channel's write buffer.  TR_CRLF expands LF → CRLF; TR_CR
+// rewrites LF → CR; everything else is byte-for-byte.  When the
+// channel is unbuffered (``BUF_NONE``) the call ends with a flush so
+// each ``puts`` lands on the fd immediately.  Returns false on a
+// write failure so the caller can raise.
+fn write_translated(c: *Channel, ptr: [*]const u8, len: u32) bool {
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        const b = ptr[i];
+        if (c.translation == TR_CRLF and b == '\n') {
+            if (!emit_byte(c, '\r')) return false;
+            if (!emit_byte(c, '\n')) return false;
+        } else if (c.translation == TR_CR and b == '\n') {
+            if (!emit_byte(c, '\r')) return false;
+        } else {
+            if (!emit_byte(c, b)) return false;
+        }
+    }
+    if (c.buffering == BUF_NONE) {
+        return flush_chan(c);
+    }
+    return true;
+}
+
+/// Resolve a channel id and flush its write buffer.  Used by
+/// ``tcl_cmd_flush`` (the runtime entry point) and indirectly by
+/// the ``flush`` eval shim.  Returns the empty string on success
+/// or 0 with a raised error on failure.
+pub fn flush_chan_id(chan_id: i32) i32 {
+    if (chan_id == 0) return obj_new_string(0, 0);
+    const slot = resolve(chan_id) orelse {
+        stubs.raise("flush: unknown channel");
+        return 0;
+    };
+    if (!flush_chan(&channels[slot])) {
+        stubs.raise("flush: write failed");
+        return 0;
+    }
+    return obj_new_string(0, 0);
 }
 
 /// Channel-aware puts.  ``chan`` is a TclObj channel id;
@@ -836,11 +950,8 @@ pub export fn tcl_cmd_puts_chan(chan: i32, msg: i32, nonewline: i32) i32 {
         }
     }
     if (nonewline == 0) {
-        const nl_ok = if (c.translation == TR_CRLF)
-            write_fn(c.fd, "\r\n", 2) >= 0
-        else
-            write_fn(c.fd, "\n", 1) >= 0;
-        if (!nl_ok) {
+        const nl: [1]u8 = .{'\n'};
+        if (!write_translated(c, &nl, 1)) {
             stubs.raise("puts: write failed");
             return 0;
         }
@@ -891,6 +1002,25 @@ fn apply_option(c: *Channel, name_p: [*]const u8, name_len: u32, val_p: [*]const
     }
     if (eq(name_p, name_len, "-encoding")) {
         c.encoding_binary = eq(val_p, val_len, "binary");
+        return;
+    }
+    if (eq(name_p, name_len, "-buffersize")) {
+        const n = parse_uint(val_p, val_len) orelse return;
+        // Tcl clamps -buffersize to ``[1, 1_000_000]``; mirror that
+        // so a hostile script can't request a 4 GiB allocation.
+        if (n == 0) return;
+        const clamped: u32 = if (n > 1_000_000) 1_000_000 else n;
+        if (clamped == c.out_buf_size) return;
+        // Drain any pending bytes at the old size before swapping
+        // the buffer; otherwise a partial write straddles the
+        // resize and the second flush would point at freed memory.
+        _ = flush_chan(c);
+        if (c.out_buf_addr != 0) {
+            obj.free_sized(c.out_buf_addr, c.out_buf_size);
+            c.out_buf_addr = 0;
+        }
+        c.out_buf_size = clamped;
+        c.out_buf_pos = 0;
         return;
     }
 }

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -418,12 +418,21 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
         // Per Tcl, closing stdin/stdout/stderr is permitted but
         // would shut the host stream — surprising for a sandbox.
         // We still drain the per-channel write buffer so anything
-        // queued via ``-buffering full`` lands on the host stream.
-        _ = flush_chan(&channels[slot]);
+        // queued via ``-buffering full`` lands on the host stream;
+        // a flush failure here is reported as an error so callers
+        // notice silent data loss (broken pipe, disk full, …).
+        if (!flush_chan(&channels[slot])) {
+            stubs.raise("close: write failed");
+            return 0;
+        }
         return obj_new_string(0, 0);
     }
     const c = &channels[slot];
-    _ = flush_chan(c);
+    // Drain pending writes before tearing the slot down.  If the
+    // flush fails the bytes are lost regardless — the fd has to be
+    // closed to reclaim the slot — but we still surface the error
+    // to the caller rather than masking it as a clean close.
+    const flush_ok = flush_chan(c);
     _ = close_fn(c.fd);
     if (c.buf_addr != 0) {
         obj.free_sized(c.buf_addr, READ_BUF_SIZE);
@@ -447,6 +456,10 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
         .out_buf_size = WRITE_BUF_SIZE,
         .out_buf_pos = 0,
     };
+    if (!flush_ok) {
+        stubs.raise("close: write failed");
+        return 0;
+    }
     return obj_new_string(0, 0);
 }
 
@@ -985,44 +998,53 @@ fn is_accepted_option(p: [*]const u8, len: u32) bool {
         eq(p, len, "-translation");
 }
 
-fn apply_option(c: *Channel, name_p: [*]const u8, name_len: u32, val_p: [*]const u8, val_len: u32) void {
+// Apply a single ``-name value`` pair to ``c``.  Returns false on a
+// resize-time flush failure so the caller can stop walking the
+// remaining option list and surface a real error; success returns
+// true regardless of whether the option name was recognised (mirrors
+// the prior void-return behaviour for unknown values).
+fn apply_option(c: *Channel, name_p: [*]const u8, name_len: u32, val_p: [*]const u8, val_len: u32) bool {
     if (eq(name_p, name_len, "-translation")) {
         if (eq(val_p, val_len, "auto")) c.translation = TR_AUTO;
         if (eq(val_p, val_len, "lf")) c.translation = TR_LF;
         if (eq(val_p, val_len, "cr")) c.translation = TR_CR;
         if (eq(val_p, val_len, "crlf")) c.translation = TR_CRLF;
         if (eq(val_p, val_len, "binary")) c.translation = TR_BINARY;
-        return;
+        return true;
     }
     if (eq(name_p, name_len, "-buffering")) {
         if (eq(val_p, val_len, "full")) c.buffering = BUF_FULL;
         if (eq(val_p, val_len, "line")) c.buffering = BUF_LINE;
         if (eq(val_p, val_len, "none")) c.buffering = BUF_NONE;
-        return;
+        return true;
     }
     if (eq(name_p, name_len, "-encoding")) {
         c.encoding_binary = eq(val_p, val_len, "binary");
-        return;
+        return true;
     }
     if (eq(name_p, name_len, "-buffersize")) {
-        const n = parse_uint(val_p, val_len) orelse return;
+        const n = parse_uint(val_p, val_len) orelse return true;
         // Tcl clamps -buffersize to ``[1, 1_000_000]``; mirror that
         // so a hostile script can't request a 4 GiB allocation.
-        if (n == 0) return;
+        if (n == 0) return true;
         const clamped: u32 = if (n > 1_000_000) 1_000_000 else n;
-        if (clamped == c.out_buf_size) return;
+        if (clamped == c.out_buf_size) return true;
         // Drain any pending bytes at the old size before swapping
         // the buffer; otherwise a partial write straddles the
         // resize and the second flush would point at freed memory.
-        _ = flush_chan(c);
+        // If the drain fails (broken pipe, ENOSPC, …) we must keep
+        // the old buffer intact so the queued bytes aren't silently
+        // discarded — the caller surfaces an error.
+        if (!flush_chan(c)) return false;
         if (c.out_buf_addr != 0) {
             obj.free_sized(c.out_buf_addr, c.out_buf_size);
             c.out_buf_addr = 0;
         }
         c.out_buf_size = clamped;
         c.out_buf_pos = 0;
-        return;
+        return true;
     }
+    return true;
 }
 
 /// ``fconfigure $fd ?option value …?`` — channel-option setter.
@@ -1085,7 +1107,10 @@ pub export fn tcl_cmd_fconfigure(fd: i32, args: i32) i32 {
             name_start = start;
             name_len = word_len;
         } else {
-            apply_option(c, ap + name_start, name_len, ap + start, word_len);
+            if (!apply_option(c, ap + name_start, name_len, ap + start, word_len)) {
+                stubs.raise("fconfigure: write failed");
+                return 0;
+            }
         }
         parity = 1 - parity;
     }

--- a/runtime/zig/stubs/tcl_io_stubs.zig
+++ b/runtime/zig/stubs/tcl_io_stubs.zig
@@ -12,24 +12,24 @@
 // gate (``scripts/check_wasm_command_parity.py``) enforces this.
 //
 // Coverage today (everything else has a real impl elsewhere):
-//   - flush  — synchronous wasi-libc writes; nothing to flush
 //   - chan   — top-level ensemble, not yet routed
 //   - fileevent, socket — needs an event loop
 //
-// ``puts`` lives in tcl_io.zig; ``open`` / ``close`` / ``read`` /
-// ``gets`` / ``eof`` / ``fblocked`` / ``tell`` / ``seek`` / ``fcopy``
-// live in tcl_chan.zig (real WASI-backed implementations).
+// ``puts`` lives in tcl_io.zig; ``flush`` / ``open`` / ``close`` /
+// ``read`` / ``gets`` / ``eof`` / ``fblocked`` / ``tell`` / ``seek``
+// / ``fcopy`` live in tcl_chan.zig (real WASI-backed implementations).
 
 const stubs = @import("tcl_stubs.zig");
+const chan = @import("../io/tcl_chan.zig");
 
-/// ``flush`` — WASI's ``fd_write`` is synchronous and unbuffered
-/// from our side (we don't maintain a per-channel write buffer),
-/// so ``flush`` has nothing to do beyond succeed.  Returns empty
-/// string, matching Tcl semantics.  Without this ``cleanupTests``
-/// traps at ``flush [outputChannel]`` during its per-file wrap-up.
+/// ``flush ?channelId?`` — drain the channel's per-write buffer
+/// to its underlying fd.  With no argument (``fd == 0``) the call
+/// is a no-op so the codegen's "flush stdout after a top-level
+/// puts" emission doesn't trap.  Without a real flush path,
+/// ``-buffering full`` writes would never reach the host stream
+/// before ``close`` ran.
 pub export fn tcl_cmd_flush(fd: i32) i32 {
-    _ = fd;
-    return 0;
+    return chan.flush_chan_id(fd);
 }
 
 pub export fn tcl_cmd_chan(sub: i32, arg: i32) i32 {

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3080,6 +3080,130 @@ class TestFconfigure:
             assert "unsupported command: fconfigure" in stderr, f"stderr: {stderr!r}"
 
 
+class TestChannelTranslation:
+    """Write-side translation + buffering edge cases.
+
+    Backs `runtime/zig/io/tcl_chan.zig` against the upstream
+    ``io-2.x`` scenarios (``WriteBytes: savedLF > 0`` and
+    ``WriteBytes: flush on line``).  Each case writes through a
+    real WASI fd into a host file under ``tmp_path`` and then
+    re-reads the bytes from the host side to bypass the
+    WASM-side translation that ``open ... r`` would apply.
+    """
+
+    def _run_then_read(self, tmp_path, tcl_source, target):
+        wasm, _ = _compile_tcl_with_diag(tcl_source, "t.tcl")
+        _run_wasm(
+            wasm,
+            capture_stdout=True,
+            capture_stderr=True,
+            preopen_tmpdir=str(tmp_path),
+        )
+        return (tmp_path / target).read_bytes()
+
+    def test_crlf_translation_basic(self, tmp_path):
+        """``-translation crlf`` expands LF → CRLF on flush/close."""
+        bytes_out = self._run_then_read(
+            tmp_path,
+            (
+                "set fd [open /out.txt w]\n"
+                "fconfigure $fd -translation crlf\n"
+                'puts -nonewline $fd "abc\ndef"\n'
+                "close $fd\n"
+            ),
+            "out.txt",
+        )
+        assert bytes_out == b"abc\r\ndef", f"got {bytes_out!r}"
+
+    def test_crlf_savedlf_boundary(self, tmp_path):
+        """The CRLF expansion must split cleanly across a buffer boundary.
+
+        Mirrors upstream ``io-2.2 {WriteBytes: savedLF > 0}``: the
+        ``\\r`` lands at the end of the first 16-byte buffer and the
+        ``\\n`` carries into the next refill.  Final bytes on disk
+        must still be the full 19-byte CRLF sequence.
+        """
+        bytes_out = self._run_then_read(
+            tmp_path,
+            (
+                "set fd [open /out.txt w]\n"
+                "fconfigure $fd -translation crlf -buffersize 16\n"
+                'puts -nonewline $fd "123456789012345\n12"\n'
+                "close $fd\n"
+            ),
+            "out.txt",
+        )
+        assert bytes_out == b"123456789012345\r\n12", f"got {bytes_out!r}"
+
+    def test_buffering_full_holds_until_close(self, tmp_path):
+        """``-buffering full`` keeps bytes in memory until flush/close."""
+        bytes_out = self._run_then_read(
+            tmp_path,
+            (
+                "set fd [open /out.txt w]\n"
+                "fconfigure $fd -translation lf -buffering full -buffersize 4096\n"
+                'puts -nonewline $fd "hello"\n'
+                # No flush here — close drains the buffer.
+                "close $fd\n"
+            ),
+            "out.txt",
+        )
+        assert bytes_out == b"hello", f"got {bytes_out!r}"
+
+    def test_buffering_line_flushes_on_newline(self, tmp_path):
+        """``-buffering line`` drains after each ``\\n``."""
+        # The script exits *without* closing the channel; the bytes
+        # before the ``\n`` must still reach disk because line
+        # buffering flushed them.  The ``\n`` itself flushes too;
+        # bytes after it stay buffered and are lost on exit (no
+        # atexit hook in the runtime), which is the difference
+        # between full and line buffering we're checking.
+        bytes_out = self._run_then_read(
+            tmp_path,
+            (
+                "set fd [open /out.txt w]\n"
+                "fconfigure $fd -translation lf -buffering line\n"
+                'puts $fd "first"\n'
+                'puts -nonewline $fd "tail"\n'
+                # Intentionally no close — the "first\n" line must
+                # have already landed on disk via the line flush.
+            ),
+            "out.txt",
+        )
+        assert bytes_out == b"first\n", f"got {bytes_out!r}"
+
+    def test_buffering_none_flushes_immediately(self, tmp_path):
+        """``-buffering none`` lands every ``puts`` straight on the fd."""
+        bytes_out = self._run_then_read(
+            tmp_path,
+            (
+                "set fd [open /out.txt w]\n"
+                "fconfigure $fd -translation lf -buffering none\n"
+                'puts -nonewline $fd "abc"\n'
+                # No close — nothing should be left to flush; the
+                # bytes already hit disk on the puts.
+            ),
+            "out.txt",
+        )
+        assert bytes_out == b"abc", f"got {bytes_out!r}"
+
+    def test_explicit_flush_drains_buffer(self, tmp_path):
+        """``flush $fd`` against a full-buffered channel drains it."""
+        bytes_out = self._run_then_read(
+            tmp_path,
+            (
+                "set fd [open /out.txt w]\n"
+                "fconfigure $fd -translation lf -buffering full\n"
+                'puts -nonewline $fd "queued"\n'
+                "flush $fd\n"
+                # Without close, the explicit flush is the only way
+                # for those bytes to reach disk.
+            ),
+            "out.txt",
+        )
+        assert bytes_out == b"queued", f"got {bytes_out!r}"
+
+
 class TestExternalTcllibCounter:
     """Compile and run the real tcllib counter module (pure Tcl).
 


### PR DESCRIPTION
## Summary

Implement per-channel write buffering with support for output translation modes (CRLF, CR, LF) and buffering strategies (none, line, full). This mirrors upstream Tcl's `io-2.x` behavior for the write side.

**Key changes:**

- Add `out_buf_addr`, `out_buf_size`, and `out_buf_pos` fields to the `Channel` struct to maintain a write buffer allocated lazily on first write
- Implement `flush_chan()` to drain buffered bytes to the underlying fd
- Implement `emit_byte()` to append translated bytes to the write buffer with automatic flushing on full buffer or line-buffering newlines
- Refactor `write_translated()` to use the new buffering infrastructure instead of direct fd writes, supporting TR_CRLF (LF→CRLF), TR_CR (LF→CR), and unbuffered modes
- Add `flush_chan_id()` entry point for the `flush` command to resolve a channel and drain its buffer
- Add `-buffersize` option support to `fconfigure` with clamping to `[1, 1_000_000]` and safe resizing
- Update `tcl_cmd_close()` to flush write buffers before closing (including stdin/stdout/stderr)
- Update `tcl_cmd_seek()` to flush pending writes before seeking to avoid bytes landing at the wrong position
- Update `fcopy_limited()` to flush the destination channel's write buffer before copying to preserve byte order
- Wire `tcl_cmd_flush()` stub to call `flush_chan_id()` instead of being a no-op
- Update `eval_flush()` to route flush commands through the channel infrastructure

**Test coverage:**

Added comprehensive test suite (`TestChannelTranslation`) covering:
- Basic CRLF translation on flush/close
- CRLF expansion split across buffer boundaries (upstream `io-2.2` `savedLF > 0` scenario)
- Full buffering holding bytes until close
- Line buffering flushing on newlines
- Unbuffered mode flushing immediately
- Explicit `flush` command draining buffers

All tests verify behavior by writing through WASI fds and re-reading from the host side to bypass WASM-side translation.

## Validation

- [x] Added 6 new test cases in `TestChannelTranslation` covering write buffering and translation edge cases
- [x] Existing channel tests continue to pass
- [x] Verified CRLF boundary split scenario matches upstream `io-2.2` behavior

https://claude.ai/code/session_017AW9Fbmpmz9matV8PB8ijm