### PR TITLE
Implement `chan` ensemble command with subcommand routing

### DIFF
--- a/core/commands/registry/tcl/chan.py
+++ b/core/commands/registry/tcl/chan.py
@@ -14,7 +14,6 @@ from ..models import (
     OptionSpec,
     SubCommand,
     ValidationSpec,
-    WasmRuntimeImport,
 )
 from ..signatures import ArgRole, Arity
 from ..taint_hints import TaintColour, TaintHint
@@ -470,12 +469,14 @@ class ChanCommand(CommandDef):
             ),
             configures_channel=True,
             has_destructive_ops=True,
-            wasm_runtime_import=WasmRuntimeImport(
-                import_key="tcl_chan",
-                argc=2,
-                params=("i32", "i32"),
-                results=("i32",),
-            ),
+            # No top-level ``wasm_runtime_import`` — the ``chan``
+            # ensemble routes through the interpreter's BUILTINS
+            # dispatch (``runtime/zig/cmds/chan.zig:eval_chan``), which
+            # forwards each subcommand to the matching bare-form
+            # handler.  A direct 2-arg ``tcl_cmd_chan(sub, arg)`` import
+            # couldn't carry the variadic tail (``chan configure $fd
+            # -opt val -opt val``) without a per-sub specialisation —
+            # the eval-fallback path handles every shape uniformly.
         )
 
     @classmethod

--- a/runtime/zig/cmds/chan.zig
+++ b/runtime/zig/cmds/chan.zig
@@ -88,9 +88,14 @@ fn name_eq(w: i32, literal: []const u8) bool {
 }
 
 fn eval_chan_names(words: []const i32) i32 {
+    // Distinguish "no pattern arg" (``chan names``) from "empty
+    // pattern arg" (``chan names ""``).  Tcl semantics: an empty
+    // pattern is a real glob that only matches the empty string,
+    // so the latter must filter out every (non-empty) channel name.
+    const has_pattern = words.len >= 2;
     var pattern_ptr: u32 = 0;
     var pattern_len: u32 = 0;
-    if (words.len >= 2) {
+    if (has_pattern) {
         const ps = obj_ensure_string(words[1]);
         pattern_ptr = ps.ptr;
         pattern_len = ps.len;
@@ -100,13 +105,28 @@ fn eval_chan_names(words: []const i32) i32 {
     while (slot < chan.channel_count) : (slot += 1) {
         if (!chan.slot_in_use(slot)) continue;
         const name = chan.channel_name(slot);
-        if (pattern_len > 0) {
+        if (has_pattern) {
             const ns = obj_ensure_string(name);
             if (!tcl_string.glob_match(pattern_ptr, pattern_len, ns.ptr, ns.len)) continue;
         }
         result = rt.tcl_cmd_lappend(result, name);
     }
     return result;
+}
+
+/// ``chan close $ch ?direction?`` — the optional direction word
+/// requests a half-close (``read`` or ``write``), which the WASI
+/// channel layer doesn't model.  Trap on the directional form
+/// rather than silently dropping the arg, matching the
+/// "no silent stubs" convention in :file:`tcl_stub_fallback.zig`.
+/// Plain ``chan close $ch`` (no direction) routes through the
+/// regular full-close path.
+fn eval_chan_close(words: []const i32) i32 {
+    if (words.len >= 3) {
+        stubs.unsupported("chan close (half-close direction not implemented)");
+        return 0;
+    }
+    return io_cmd.eval_close(words);
 }
 
 fn eval_chan(words: []const i32) i32 {
@@ -120,7 +140,7 @@ fn eval_chan(words: []const i32) i32 {
     // delegate, which never reads ``words[0]``).
     const tail = words[1..];
     if (name_eq(sub, "blocked")) return io_cmd.eval_fblocked(tail);
-    if (name_eq(sub, "close")) return io_cmd.eval_close(tail);
+    if (name_eq(sub, "close")) return eval_chan_close(tail);
     if (name_eq(sub, "configure")) return eval_fconfigure(tail);
     if (name_eq(sub, "copy")) return io_cmd.eval_fcopy(tail);
     if (name_eq(sub, "eof")) return io_cmd.eval_eof(tail);

--- a/runtime/zig/cmds/chan.zig
+++ b/runtime/zig/cmds/chan.zig
@@ -1,14 +1,28 @@
-// ``encoding``, ``fconfigure`` — channel/encoding commands.
+// ``encoding``, ``fconfigure``, ``chan`` — channel/encoding commands.
+//
+// The ``chan`` ensemble dispatches each subcommand back to the
+// corresponding bare-form handler in :file:`cmds/io.zig` /
+// :func:`eval_fconfigure`, so the two surfaces share one
+// implementation.  Sub-commands without a runtime impl
+// (``create`` / ``event`` / ``pipe`` / ``pop`` / ``postevent`` /
+// ``push`` / ``truncate`` / ``isbinary`` / ``pending``) trap with
+// ``unsupported command: chan <sub>`` rather than silently
+// returning empty — matches the convention in
+// :file:`tcl_stub_fallback.zig`.
 
 const rt  = @import("../tcl_runtime.zig");
 const enc = @import("../valtypes/tcl_encoding.zig");
 const chan = @import("../io/tcl_chan.zig");
+const io_cmd = @import("io.zig");
 const reg = @import("../dispatch/tcl_cmd_registry.zig");
+const stubs = @import("../stubs/tcl_stubs.zig");
 const obj = @import("../valtypes/tcl_obj.zig");
 const list_quote = @import("../valtypes/tcl_list_quote.zig");
+const tcl_string = @import("../valtypes/tcl_string.zig");
 
 const alloc          = rt.alloc;
 const obj_new_string = rt.obj_new_string;
+const obj_ensure_string = obj.obj_ensure_string;
 
 fn eval_encoding(words: []const i32) i32 {
     const sub  = if (words.len >= 2) words[1] else 0;
@@ -17,7 +31,7 @@ fn eval_encoding(words: []const i32) i32 {
     return enc.tcl_cmd_encoding(sub, arg1, arg2);
 }
 
-fn eval_fconfigure(words: []const i32) i32 {
+pub fn eval_fconfigure(words: []const i32) i32 {
     if (words.len < 2) return chan.tcl_cmd_fconfigure(0, 0);
     const fd = words[1];
     if (words.len < 3) return chan.tcl_cmd_fconfigure(fd, 0);
@@ -55,13 +69,128 @@ fn eval_fconfigure(words: []const i32) i32 {
     return chan.tcl_cmd_fconfigure(fd, args_obj);
 }
 
+// -- chan ensemble --
+//
+// ``chan <sub> <args…>`` routes to the bare-command handler for the
+// matching subcommand.  Each handler in ``io_cmd`` reads
+// ``words[0]`` purely as the command name (it never inspects the
+// string), so we can pass ``words[1..]`` verbatim — slot 0 is the
+// subcommand name (e.g. ``configure``), which is ignored by the
+// downstream handler the same way ``puts`` ignores ``words[0]``.
+
+fn name_eq(w: i32, literal: []const u8) bool {
+    if (w == 0) return literal.len == 0;
+    const s = obj_ensure_string(w);
+    if (s.len != literal.len) return false;
+    const p: [*]const u8 = @ptrFromInt(s.ptr);
+    for (0..literal.len) |i| if (p[i] != literal[i]) return false;
+    return true;
+}
+
+fn eval_chan_names(words: []const i32) i32 {
+    var pattern_ptr: u32 = 0;
+    var pattern_len: u32 = 0;
+    if (words.len >= 2) {
+        const ps = obj_ensure_string(words[1]);
+        pattern_ptr = ps.ptr;
+        pattern_len = ps.len;
+    }
+    var result: i32 = obj_new_string(0, 0);
+    var slot: u32 = 0;
+    while (slot < chan.channel_count) : (slot += 1) {
+        if (!chan.slot_in_use(slot)) continue;
+        const name = chan.channel_name(slot);
+        if (pattern_len > 0) {
+            const ns = obj_ensure_string(name);
+            if (!tcl_string.glob_match(pattern_ptr, pattern_len, ns.ptr, ns.len)) continue;
+        }
+        result = rt.tcl_cmd_lappend(result, name);
+    }
+    return result;
+}
+
+fn eval_chan(words: []const i32) i32 {
+    if (words.len < 2) {
+        stubs.raise("chan: missing subcommand");
+        return 0;
+    }
+    const sub = words[1];
+    // Forward the slice ``words[1..]`` to the bare-command handler:
+    // its ``words[0]`` becomes the subcommand name (ignored by the
+    // delegate, which never reads ``words[0]``).
+    const tail = words[1..];
+    if (name_eq(sub, "blocked")) return io_cmd.eval_fblocked(tail);
+    if (name_eq(sub, "close")) return io_cmd.eval_close(tail);
+    if (name_eq(sub, "configure")) return eval_fconfigure(tail);
+    if (name_eq(sub, "copy")) return io_cmd.eval_fcopy(tail);
+    if (name_eq(sub, "eof")) return io_cmd.eval_eof(tail);
+    if (name_eq(sub, "flush")) return io_cmd.eval_flush(tail);
+    if (name_eq(sub, "gets")) return io_cmd.eval_gets(tail);
+    if (name_eq(sub, "names")) return eval_chan_names(words[1..]);
+    if (name_eq(sub, "puts")) return io_cmd.eval_puts(tail);
+    if (name_eq(sub, "read")) return io_cmd.eval_read(tail);
+    if (name_eq(sub, "seek")) return io_cmd.eval_seek(tail);
+    if (name_eq(sub, "tell")) return io_cmd.eval_tell(tail);
+    // Out-of-scope subcommands (issue #270 explicitly defers these):
+    // create / event / pipe / pop / postevent / push / truncate need
+    // transformation channels, an event loop, or fd resizing that the
+    // WASM runtime doesn't model.  ``isbinary`` and ``pending`` are
+    // additional subcommands the Python registry advertises but that
+    // we don't yet implement.  Trap with ``unsupported command`` to
+    // match the convention in :file:`tcl_stub_fallback.zig`.
+    if (name_eq(sub, "create") or name_eq(sub, "event") or
+        name_eq(sub, "isbinary") or name_eq(sub, "pending") or
+        name_eq(sub, "pipe") or name_eq(sub, "pop") or
+        name_eq(sub, "postevent") or name_eq(sub, "push") or
+        name_eq(sub, "truncate"))
+    {
+        stubs.unsupported("chan (subcommand not implemented)");
+        return 0;
+    }
+    stubs.raise("chan: unknown subcommand");
+    return 0;
+}
+
 pub const registrations = [_]reg.CmdEntry{
     .{ .name = "encoding", .arity_min = 1, .arity_max = null, .handler = &eval_encoding },
     .{ .name = "fconfigure", .arity_min = 1, .arity_max = null, .handler = &eval_fconfigure },
+    .{ .name = "chan", .arity_min = 1, .arity_max = null, .handler = &eval_chan },
 };
 
-// Per-command sub-table — only ``encoding`` has sub-commands here;
-// ``fconfigure`` is variadic ``-option value`` pairs, not an ensemble.
+// Per-command sub-tables.  Arities mirror
+// ``core/commands/registry/tcl/chan.py``; the parity check enforces
+// every entry here matches the Python ``SubCommand.arity`` declaration.
+// The handler pointer is metadata-only — runtime dispatch happens
+// inside :func:`eval_chan` (and similarly inside the bare-command
+// handlers for fconfigure / encoding sub-forms).
+pub const chan_subcommands: []const reg.SubEntry = &.{
+    .{ .name = "blocked", .arity_min = 1, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "close", .arity_min = 1, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "configure", .arity_min = 1, .arity_max = null, .handler = &eval_chan },
+    .{ .name = "copy", .arity_min = 2, .arity_max = null, .handler = &eval_chan },
+    .{ .name = "create", .arity_min = 2, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "eof", .arity_min = 1, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "event", .arity_min = 2, .arity_max = 3, .handler = &eval_chan },
+    .{ .name = "flush", .arity_min = 1, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "gets", .arity_min = 1, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "isbinary", .arity_min = 1, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "names", .arity_min = 0, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "pending", .arity_min = 2, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "pipe", .arity_min = 0, .arity_max = 0, .handler = &eval_chan },
+    .{ .name = "pop", .arity_min = 1, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "postevent", .arity_min = 2, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "push", .arity_min = 2, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "puts", .arity_min = 1, .arity_max = 3, .handler = &eval_chan },
+    .{ .name = "read", .arity_min = 1, .arity_max = 2, .handler = &eval_chan },
+    .{ .name = "seek", .arity_min = 2, .arity_max = 3, .handler = &eval_chan },
+    .{ .name = "tell", .arity_min = 1, .arity_max = 1, .handler = &eval_chan },
+    .{ .name = "truncate", .arity_min = 1, .arity_max = 2, .handler = &eval_chan },
+};
+
+// ``encoding`` sub-table — kept after ``chan_subcommands`` so the
+// generic-vs-named lookup in ``check_wasm_command_parity.py`` resolves
+// cleanly.  ``fconfigure`` is variadic ``-option value`` pairs, not
+// an ensemble.
 pub const encoding_subcommands: []const reg.SubEntry = &.{
     .{ .name = "convertfrom", .arity_min = 1, .arity_max = null, .handler = &eval_encoding },
     .{ .name = "convertto", .arity_min = 1, .arity_max = null, .handler = &eval_encoding },

--- a/runtime/zig/cmds/io.zig
+++ b/runtime/zig/cmds/io.zig
@@ -35,7 +35,7 @@ fn word_eq(w: i32, literal: []const u8) bool {
 /// fall through here via :file:`codegen/wasm/_emitter/cmds/puts_.py`'s
 /// returning ``False`` so this handler can route through
 /// :func:`tcl_chan.tcl_cmd_puts_chan`.
-fn eval_puts(words: []const i32) i32 {
+pub fn eval_puts(words: []const i32) i32 {
     // words[0] = "puts"
     const argc = words.len - 1;
     if (argc == 0) return 0;
@@ -58,7 +58,7 @@ fn eval_puts(words: []const i32) i32 {
     return 0;
 }
 
-fn eval_open(words: []const i32) i32 {
+pub fn eval_open(words: []const i32) i32 {
     // open fileName ?access? ?permissions?
     const path = if (words.len >= 2) words[1] else 0;
     const access = if (words.len >= 3) words[2] else 0;
@@ -67,7 +67,7 @@ fn eval_open(words: []const i32) i32 {
     return chan.tcl_cmd_open(path, access);
 }
 
-fn eval_close(words: []const i32) i32 {
+pub fn eval_close(words: []const i32) i32 {
     if (words.len < 2) {
         stubs.raise("close: missing channelId");
         return 0;
@@ -75,7 +75,7 @@ fn eval_close(words: []const i32) i32 {
     return chan.tcl_cmd_close(words[1]);
 }
 
-fn eval_read(words: []const i32) i32 {
+pub fn eval_read(words: []const i32) i32 {
     // read ?-nonewline? channel | read channel ?numChars?
     var nonewline = false;
     var arg_idx: usize = 1;
@@ -103,7 +103,7 @@ fn eval_read(words: []const i32) i32 {
     return result;
 }
 
-fn eval_gets(words: []const i32) i32 {
+pub fn eval_gets(words: []const i32) i32 {
     if (words.len < 2) {
         stubs.raise("gets: missing channelId");
         return 0;
@@ -113,7 +113,7 @@ fn eval_gets(words: []const i32) i32 {
     return chan.tcl_cmd_gets(ch, var_name);
 }
 
-fn eval_seek(words: []const i32) i32 {
+pub fn eval_seek(words: []const i32) i32 {
     if (words.len < 3) {
         stubs.raise("seek: missing offset");
         return 0;
@@ -124,7 +124,7 @@ fn eval_seek(words: []const i32) i32 {
     return chan.tcl_cmd_seek(ch, off_obj, origin_obj);
 }
 
-fn eval_tell(words: []const i32) i32 {
+pub fn eval_tell(words: []const i32) i32 {
     if (words.len < 2) {
         stubs.raise("tell: missing channelId");
         return 0;
@@ -132,7 +132,7 @@ fn eval_tell(words: []const i32) i32 {
     return chan.tcl_cmd_tell(words[1]);
 }
 
-fn eval_eof(words: []const i32) i32 {
+pub fn eval_eof(words: []const i32) i32 {
     if (words.len < 2) {
         stubs.raise("eof: missing channelId");
         return 0;
@@ -140,7 +140,7 @@ fn eval_eof(words: []const i32) i32 {
     return chan.tcl_cmd_eof(words[1]);
 }
 
-fn eval_fblocked(words: []const i32) i32 {
+pub fn eval_fblocked(words: []const i32) i32 {
     if (words.len < 2) {
         stubs.raise("fblocked: missing channelId");
         return 0;
@@ -148,7 +148,7 @@ fn eval_fblocked(words: []const i32) i32 {
     return chan.tcl_cmd_fblocked(words[1]);
 }
 
-fn eval_fcopy(words: []const i32) i32 {
+pub fn eval_fcopy(words: []const i32) i32 {
     if (words.len < 3) {
         stubs.raise("fcopy: missing inputChan or outputChan");
         return 0;
@@ -194,7 +194,7 @@ fn eval_fcopy(words: []const i32) i32 {
 /// codegen fast path passes the channel id directly into
 /// ``tcl_cmd_flush``, so the eval route only sees ``flush`` calls
 /// from scripts that always supply the channel.
-fn eval_flush(words: []const i32) i32 {
+pub fn eval_flush(words: []const i32) i32 {
     if (words.len < 2) return 0;
     return chan.flush_chan_id(words[1]);
 }

--- a/runtime/zig/dispatch/tcl_stub_fallback.zig
+++ b/runtime/zig/dispatch/tcl_stub_fallback.zig
@@ -40,10 +40,10 @@ const STUB_TRAP: []const []const u8 = &.{
     // I/O + channel — fconfigure / flush / open / close / read /
     // gets / eof / fblocked / tell / seek / fcopy have real impls
     // dispatched by BUILTINS (cmds/io.zig + io/tcl_chan.zig).
-    // ``fileevent`` is now a real BUILTIN (cmds/fileevent.zig) too.
-    // Only ``chan`` (top-level ensemble) and ``socket`` remain
-    // trapping stubs here.
-    "chan", "socket",
+    // ``fileevent`` and the ``chan`` ensemble are now real BUILTINs
+    // too (cmds/fileevent.zig, cmds/chan.zig).  Only ``socket``
+    // remains a trapping stub here.
+    "socket",
     // Filesystem / process — file/pwd/cd/glob/exec have real impls
     // in BUILTINS (cmds/fs.zig + cmds/exec.zig).  ``glob`` and
     // ``exec`` are capability-gated through interp/tcl_caps.zig and

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -1477,3 +1477,21 @@ pub export fn tcl_cmd_fconfigure(fd: i32, args: i32) i32 {
     }
     return obj_new_string(0, 0);
 }
+
+/// Total number of channel slots — exposed so ``chan names`` can walk
+/// the slot array.
+pub const channel_count: u32 = MAX_CHANNELS;
+
+/// Whether slot ``n`` is currently allocated (bound to a real fd).
+pub fn slot_in_use(n: u32) bool {
+    if (n >= MAX_CHANNELS) return false;
+    return channels[n].in_use;
+}
+
+/// Render a channel-name TclObj for slot ``n``.  Public wrapper
+/// around the private :func:`slot_name` so the ``chan names`` ensemble
+/// (in :file:`cmds/chan.zig`) can mint each name without duplicating
+/// the ``stdin`` / ``stdout`` / ``stderr`` / ``fileN`` rendering.
+pub fn channel_name(n: u32) i32 {
+    return slot_name(n);
+}

--- a/runtime/zig/stubs/tcl_io_stubs.zig
+++ b/runtime/zig/stubs/tcl_io_stubs.zig
@@ -12,8 +12,10 @@
 // gate (``scripts/check_wasm_command_parity.py``) enforces this.
 //
 // Coverage today (everything else has a real impl elsewhere):
-//   - chan   — top-level ensemble, not yet routed
 //   - fileevent, socket — needs an event loop
+//
+// ``chan`` dispatches through ``cmds/chan.zig:eval_chan`` (no direct
+// codegen import); see issue #270.
 //
 // ``puts`` lives in tcl_io.zig; ``flush`` / ``open`` / ``close`` /
 // ``read`` / ``gets`` / ``eof`` / ``fblocked`` / ``tell`` / ``seek``
@@ -30,13 +32,6 @@ const chan = @import("../io/tcl_chan.zig");
 /// before ``close`` ran.
 pub export fn tcl_cmd_flush(fd: i32) i32 {
     return chan.flush_chan_id(fd);
-}
-
-pub export fn tcl_cmd_chan(sub: i32, arg: i32) i32 {
-    _ = sub;
-    _ = arg;
-    stubs.unsupported("chan");
-    return 0;
 }
 
 pub export fn tcl_cmd_fileevent(fd: i32, mode: i32) i32 {

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -316,7 +316,6 @@ comptime {
     _ = &tcl_chan.tcl_cmd_fcopy;
     _ = &tcl_chan.tcl_cmd_puts_chan;
     _ = &tcl_io_stubs.tcl_cmd_flush;
-    _ = &tcl_io_stubs.tcl_cmd_chan;
     _ = &tcl_io_stubs.tcl_cmd_fileevent;
     _ = &tcl_io_stubs.tcl_cmd_socket;
     // file has a real impl in tcl_fs.zig.

--- a/tests/baselines/wasm_command_parity.json
+++ b/tests/baselines/wasm_command_parity.json
@@ -37,7 +37,7 @@
     "break": "IMPLEMENTED",
     "catch": "IMPLEMENTED",
     "cd": "IMPLEMENTED",
-    "chan": "TRAPPING_STUB",
+    "chan": "IMPLEMENTED",
     "classvariable": "IMPLEMENTED",
     "clock": "IMPLEMENTED",
     "close": "IMPLEMENTED",

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3393,6 +3393,212 @@ class TestChannelTranslation:
         assert bytes_out == b"queued", f"got {bytes_out!r}"
 
 
+class TestChan:
+    """``chan <sub>`` ensemble — mirrors :class:`TestChannelIO` round-trips
+    using the ``chan`` ensemble form rather than the bare-command form.
+    Both forms route to the same handlers in ``cmds/io.zig`` /
+    ``cmds/chan.zig``, so this class exercises the dispatch wiring in
+    :func:`cmds/chan.zig:eval_chan`.
+    """
+
+    def _run(self, tmp_path, tcl_source):
+        wasm, _ = _compile_tcl_with_diag(tcl_source, "t.tcl")
+        _, stdout, _ = _run_wasm(
+            wasm,
+            capture_stdout=True,
+            capture_stderr=True,
+            preopen_tmpdir=str(tmp_path),
+        )
+        return stdout
+
+    def test_chan_puts_then_chan_read(self, tmp_path):
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /log.txt w]\n"
+                'chan puts $fd "hello"\n'
+                'chan puts $fd "world"\n'
+                "chan close $fd\n"
+                "set rfd [open /log.txt r]\n"
+                "set body [chan read $rfd]\n"
+                "chan close $rfd\n"
+                "puts $body\n"
+            ),
+        )
+        assert out == "hello\nworld\n\n", f"got {out!r}"
+        assert (tmp_path / "log.txt").read_text() == "hello\nworld\n"
+
+    def test_chan_gets_lines(self, tmp_path):
+        (tmp_path / "lines.txt").write_text("alpha\nbeta\ngamma\n")
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /lines.txt r]\n"
+                "puts [chan gets $fd]\n"
+                "puts [chan gets $fd]\n"
+                "puts [chan gets $fd]\n"
+                "chan close $fd\n"
+            ),
+        )
+        assert out == "alpha\nbeta\ngamma\n", f"got {out!r}"
+
+    def test_chan_gets_with_var(self, tmp_path):
+        (tmp_path / "lines.txt").write_text("hi\nworld\n")
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /lines.txt r]\n"
+                "set n [chan gets $fd line]\n"
+                "puts $n\n"
+                "puts $line\n"
+                "chan close $fd\n"
+            ),
+        )
+        assert out == "2\nhi\n", f"got {out!r}"
+
+    def test_chan_seek_and_tell(self, tmp_path):
+        (tmp_path / "data.bin").write_bytes(b"0123456789")
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /data.bin r]\n"
+                "chan seek $fd 4\n"
+                "puts [chan tell $fd]\n"
+                "puts [chan read $fd 3]\n"
+                "chan seek $fd 0 start\n"
+                "puts [chan tell $fd]\n"
+                "puts [chan read $fd 2]\n"
+                "chan close $fd\n"
+            ),
+        )
+        assert out == "4\n456\n0\n01\n", f"got {out!r}"
+
+    def test_chan_eof_after_full_read(self, tmp_path):
+        (tmp_path / "f.txt").write_text("xyz")
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /f.txt r]\n"
+                "puts [chan eof $fd]\n"
+                "puts [chan read $fd]\n"
+                "puts [chan eof $fd]\n"
+                "chan close $fd\n"
+            ),
+        )
+        lines = out.splitlines()
+        assert lines[0] == "0"
+        assert lines[1] == "xyz"
+        assert lines[2] == "1"
+
+    def test_chan_blocked_always_zero(self, tmp_path):
+        (tmp_path / "f.txt").write_text("data")
+        out = self._run(
+            tmp_path,
+            ("set fd [open /f.txt r]\nputs [chan blocked $fd]\nchan close $fd\n"),
+        )
+        assert out.strip() == "0"
+
+    def test_chan_copy_between_channels(self, tmp_path):
+        (tmp_path / "src.bin").write_bytes(b"copy-me-please")
+        out = self._run(
+            tmp_path,
+            (
+                "set in [open /src.bin r]\n"
+                "set out [open /dst.bin w]\n"
+                "set n [chan copy $in $out]\n"
+                "chan close $in\n"
+                "chan close $out\n"
+                "puts $n\n"
+            ),
+        )
+        assert out.strip() == "14"
+        assert (tmp_path / "dst.bin").read_bytes() == b"copy-me-please"
+
+    def test_chan_configure_translation(self, tmp_path):
+        # ``chan configure $fd -translation auto`` is the call
+        # ``chanio.test`` opens with — must not trap.
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /log.txt w]\n"
+                "chan configure $fd -translation auto\n"
+                'chan puts -nonewline $fd "hi"\n'
+                "chan close $fd\n"
+                "puts ok\n"
+            ),
+        )
+        assert out == "ok\n", f"got {out!r}"
+        assert (tmp_path / "log.txt").read_text() == "hi"
+
+    def test_chan_flush_is_noop(self, tmp_path):
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /log.txt w]\n"
+                'chan puts $fd "buffered"\n'
+                "chan flush $fd\n"
+                "chan close $fd\n"
+                "puts ok\n"
+            ),
+        )
+        assert out == "ok\n", f"got {out!r}"
+        assert (tmp_path / "log.txt").read_text() == "buffered\n"
+
+    def test_chan_names_includes_stdio(self, tmp_path):
+        # Pre-populated slots are stdin / stdout / stderr.  ``chan
+        # names`` must report at least those three when no user
+        # channel is open.
+        out = self._run(
+            tmp_path,
+            ("set names [chan names]\nputs [lsort $names]\n"),
+        )
+        names = out.strip().split()
+        assert "stdin" in names, f"got {names!r}"
+        assert "stdout" in names, f"got {names!r}"
+        assert "stderr" in names, f"got {names!r}"
+
+    def test_chan_names_includes_open_file(self, tmp_path):
+        (tmp_path / "x.txt").write_text("x")
+        out = self._run(
+            tmp_path,
+            (
+                "set fd [open /x.txt r]\n"
+                "puts $fd\n"
+                "puts [chan names]\n"
+                "chan close $fd\n"
+            ),
+        )
+        # The freshly-opened channel name should appear in
+        # ``chan names`` alongside the standard streams.
+        lines = out.splitlines()
+        fd_name = lines[0]
+        names = lines[1].split()
+        assert fd_name in names, f"fd={fd_name!r} not in {names!r}"
+
+    def test_chan_names_with_pattern(self, tmp_path):
+        out = self._run(
+            tmp_path,
+            ("puts [lsort [chan names std*]]\n"),
+        )
+        # Glob filter narrows to the std* slots.
+        assert out.strip().split() == ["stderr", "stdin", "stdout"]
+
+    def test_chan_unknown_subcommand_traps(self, tmp_path):
+        # Out-of-scope subcommand should trap with ``unsupported
+        # command: chan``.
+        wasm, _ = _compile_tcl_with_diag("chan create read foo\n", "t.tcl")
+        try:
+            _run_wasm(
+                wasm,
+                capture_stderr=True,
+                preopen_tmpdir=str(tmp_path),
+            )
+            pytest.fail("expected trap on out-of-scope chan subcommand")
+        except Exception as trap:
+            stderr = getattr(trap, "tcl_stderr", "")
+            assert "chan" in stderr and "unsupported" in stderr, f"stderr: {stderr!r}"
+
+
 class TestExternalTcllibCounter:
     """Compile and run the real tcllib counter module (pure Tcl).
 

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3561,12 +3561,7 @@ class TestChan:
         (tmp_path / "x.txt").write_text("x")
         out = self._run(
             tmp_path,
-            (
-                "set fd [open /x.txt r]\n"
-                "puts $fd\n"
-                "puts [chan names]\n"
-                "chan close $fd\n"
-            ),
+            ("set fd [open /x.txt r]\nputs $fd\nputs [chan names]\nchan close $fd\n"),
         )
         # The freshly-opened channel name should appear in
         # ``chan names`` alongside the standard streams.

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3593,6 +3593,40 @@ class TestChan:
             stderr = getattr(trap, "tcl_stderr", "")
             assert "chan" in stderr and "unsupported" in stderr, f"stderr: {stderr!r}"
 
+    def test_chan_names_empty_pattern_filters_all(self, tmp_path):
+        # ``chan names ""`` is a real glob that only matches the empty
+        # string — every actual channel name (``stdin`` / ``stdout`` /
+        # ``stderr`` / ``fileN``) is non-empty, so the result is the
+        # empty list.  Regression for codex P2: don't conflate
+        # "no pattern arg" with "empty pattern arg".
+        out = self._run(
+            tmp_path,
+            ('puts "[llength [chan names {}]]"\n'),
+        )
+        assert out.strip() == "0"
+
+    def test_chan_close_with_direction_traps(self, tmp_path):
+        # ``chan close $ch read`` requests a directional half-close
+        # which the WASI channel layer doesn't model.  Must trap
+        # rather than silently full-closing the channel.
+        (tmp_path / "x.txt").write_text("x")
+        wasm, _ = _compile_tcl_with_diag(
+            "set fd [open /x.txt r]\nchan close $fd read\n",
+            "t.tcl",
+        )
+        try:
+            _run_wasm(
+                wasm,
+                capture_stderr=True,
+                preopen_tmpdir=str(tmp_path),
+            )
+            pytest.fail("expected trap on directional chan close")
+        except Exception as trap:
+            stderr = getattr(trap, "tcl_stderr", "")
+            assert "chan close" in stderr or ("chan" in stderr and "unsupported" in stderr), (
+                f"stderr: {stderr!r}"
+            )
+
 
 class TestExternalTcllibCounter:
     """Compile and run the real tcllib counter module (pure Tcl).


### PR DESCRIPTION
## Summary

Implement the `chan` ensemble command by routing subcommands to existing bare-form handlers in `cmds/io.zig` and `cmds/chan.zig`. The `chan` ensemble provides an alternative surface to the bare commands (`puts`, `read`, `gets`, etc.) while sharing the same underlying implementation.

Key changes:
- Add `eval_chan()` dispatcher in `cmds/chan.zig` that routes subcommands (`blocked`, `close`, `configure`, `copy`, `eof`, `flush`, `gets`, `names`, `puts`, `read`, `seek`, `tell`) to their corresponding handlers
- Implement `eval_chan_names()` to enumerate open channels with optional glob pattern filtering
- Export previously-private I/O command handlers (`eval_puts`, `eval_open`, `eval_close`, `eval_read`, `eval_gets`, `eval_seek`, `eval_tell`, `eval_eof`, `eval_fblocked`, `eval_flush`, `eval_fcopy`) so they can be called from the `chan` dispatcher
- Add public accessors in `tcl_chan.zig` (`slot_in_use()`, `channel_name()`, `channel_count`) to support `chan names` enumeration
- Trap with "unsupported command: chan" for out-of-scope subcommands (`create`, `event`, `isbinary`, `pending`, `pipe`, `pop`, `postevent`, `push`, `truncate`) that require transformation channels, event loops, or fd resizing
- Remove the stub `tcl_cmd_chan()` export from `tcl_io_stubs.zig` (no longer needed; dispatch happens through BUILTINS)
- Update command registry metadata to reflect `chan` as IMPLEMENTED rather than TRAPPING_STUB

## Validation

- Added comprehensive test suite (`TestChan` class) covering:
  - Basic I/O operations: `chan puts`, `chan read`, `chan gets`, `chan close`
  - Positioning: `chan seek`, `chan tell`
  - Status queries: `chan eof`, `chan blocked`
  - Channel management: `chan copy`, `chan configure`, `chan flush`
  - Enumeration: `chan names` with and without glob patterns
  - Error handling: unsupported subcommands trap correctly
- All new tests pass; existing tests remain unaffected
- Command parity baseline updated to reflect `chan` as IMPLEMENTED

https://claude.ai/code/session_01WTDyLPQHgSMqc9b5hgV5UY