### PR TITLE
runtime: namespace-aware array find_or_create — fixes #273

### DIFF
--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -388,6 +388,15 @@ fn find_or_create(name: i32) u32 {
             const total: u32 = ns_len + 2 + sn.len;
             const qbuf = obj.alloc(total);
             if (qbuf != 0) {
+                // ``qbuf`` is a *temporary* lookup key — ``dir_insert``
+                // copies the bytes into its own bucket-owned buffer
+                // (see :func:`dir_insert` above), and the find / scalar
+                // probe paths only read through it.  Free on every
+                // exit so a long-running script that keeps writing
+                // namespace arrays doesn't leak one allocation per
+                // ``set`` (Codex review on PR #297).  Mirrors the same
+                // ``defer obj.free_sized`` pattern in :func:`find_table`.
+                defer obj.free_sized(qbuf, total);
                 const dst: [*]u8 = @ptrFromInt(qbuf);
                 const ns_p: [*]const u8 = @ptrFromInt(ns_ptr);
                 for (0..ns_len) |i| dst[i] = ns_p[i];

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -364,6 +364,58 @@ fn find_or_create(name: i32) u32 {
         write_i32(bucket + 12, @bitCast(fresh));
         return fresh;
     }
+    // Namespace-aware fallback for unqualified names.  When *name* is
+    // unqualified and a non-root namespace is active, also probe the
+    // directory under ``<ns_full>::<name>`` and — when neither key
+    // exists — *create* under the qualified form.  Mirrors the read
+    // side in :func:`find_table` and the compile-time qualification
+    // performed by ``_emit_array_name_obj`` for script-level writes
+    // inside ``namespace eval``.  Required at runtime too because
+    // proc bodies emit unqualified array names (the proc's
+    // resolution namespace is only known once it's running), and a
+    // tcltest proc that does ``set errorInfo(body) ...`` inside
+    // ``::tcltest`` would otherwise collide with the global scalar
+    // ``::errorInfo`` that ``stamp_error_globals`` writes after
+    // every ``error`` — both keyed in root as ``errorInfo``, even
+    // though Tcl semantics keep the namespace's array variable
+    // disjoint from the global scalar.
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    const is_qualified = sn.len >= 2 and sp[0] == ':' and sp[1] == ':';
+    if (!is_qualified) {
+        const ns_ptr = current_ns_full_ptr();
+        const ns_len = current_ns_full_len();
+        if (ns_len > 2) {
+            const total: u32 = ns_len + 2 + sn.len;
+            const qbuf = obj.alloc(total);
+            if (qbuf != 0) {
+                const dst: [*]u8 = @ptrFromInt(qbuf);
+                const ns_p: [*]const u8 = @ptrFromInt(ns_ptr);
+                for (0..ns_len) |i| dst[i] = ns_p[i];
+                dst[ns_len] = ':';
+                dst[ns_len + 1] = ':';
+                for (0..sn.len) |i| dst[ns_len + 2 + i] = sp[i];
+                const qhash = fnv1a(qbuf, total);
+                if (dir_find(qbuf, total, qhash)) |bucket| {
+                    const existing: u32 = @bitCast(read_i32(bucket + 12));
+                    if (existing != 0) return existing;
+                    const fresh = ar_new();
+                    write_i32(bucket + 12, @bitCast(fresh));
+                    return fresh;
+                }
+                // Conflict check & insertion both keyed by the
+                // qualified form so a same-namespace scalar (e.g.
+                // ``::ns::errorInfo``) still raises while the bare
+                // root scalar ``::errorInfo`` does not.
+                if (ns_scalar_exists(qbuf, total) != 0) {
+                    stubs.raise("can't set: variable isn't array");
+                    return 0;
+                }
+                const t = ar_new();
+                dir_insert(qbuf, total, qhash, t);
+                return t;
+            }
+        }
+    }
     // No array with this name yet — but a *scalar* might exist.  Real
     // Tcl raises ``can't set "<name>(...)": variable isn't array`` in
     // that case.  Detect via ``ns_scalar_exists`` (probe into the var

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -1754,6 +1754,59 @@ return [main]
         assert ok, f"error: {err}"
         assert val == 111
 
+    def test_array_in_namespace_proc_after_global_scalar_stamp(self):
+        """Issue #273: ``set arr(idx) val`` inside a proc whose
+        resolution namespace is non-root must not collide with a
+        same-simple-name *global scalar* — e.g. tcltest's
+        ``set errorInfo(body) ...`` after ``catch`` has stamped
+        ``::errorInfo`` via ``stamp_error_globals``.
+
+        Real Tcl keeps the namespace-scoped array variable disjoint
+        from the global scalar, but our flat array directory and
+        unqualified-by-default proc emission collapsed both onto the
+        same key, so ``find_or_create`` raised
+        ``can't set "errorInfo(body)": variable isn't array``.
+
+        The runtime fix qualifies unqualified array names with the
+        proc's current namespace before consulting the directory
+        and the scalar-conflict probe — mirrors the script-level
+        qualification ``_emit_array_name_obj`` already performs in
+        ``namespace eval`` blocks.
+        """
+        src = """\
+catch { error boom }
+namespace eval ::myns {
+    proc do_set {} {
+        set errorInfo(body) hello
+        return $errorInfo(body)
+    }
+    puts [do_set]
+}
+"""
+        wasm, _ = _compile_tcl_with_diag(src)
+        _, stdout = _run_wasm(wasm, capture_stdout=True)
+        assert stdout == "hello\n"
+
+    def test_array_in_namespace_eval_after_global_scalar_stamp(self):
+        """Companion to the proc case: at script-level inside
+        ``namespace eval ::myns2 { ... }``, the array write must
+        also bypass the global ``::errorInfo`` scalar.  Pre-fix this
+        case worked because ``_emit_array_name_obj`` qualified the
+        name at compile time; this regression test guards against a
+        future emitter change that drops the script-level
+        qualification.
+        """
+        src = """\
+catch { error boom }
+namespace eval ::myns2 {
+    set errorInfo(stage) ready
+    puts $errorInfo(stage)
+}
+"""
+        wasm, _ = _compile_tcl_with_diag(src)
+        _, stdout = _run_wasm(wasm, capture_stdout=True)
+        assert stdout == "ready\n"
+
 
 class TestUplevel:
     """``uplevel`` runs a script in a caller's scope.


### PR DESCRIPTION
## Summary

Fixes #273 — the residual `can't set: variable isn't array` trap that aborted Tcl 9 `io.test` / `ioCmd.test` partway through their tcltest suites.

**Root cause:** `tcl_array.find_or_create` keyed unqualified array names directly into the flat global directory and probed `ns_scalar_exists` against the root namespace. When a proc inside `::tcltest` ran `set errorInfo(body) ...` after `catch { error … }` had already stamped `::errorInfo` (via `tcl_catch.stamp_error_globals`), the probe matched on the root-level `errorInfo` scalar and the array write trapped — even though Tcl semantics keep the namespace-scoped array variable disjoint from the global scalar.

**Fix:** `find_or_create` now mirrors the read-side fallback in `find_table` — when the name is unqualified and a non-root namespace is active, retry as `<current_ns_full>::<name>` and *create* under the qualified form if neither key exists. The scalar-conflict probe runs against the qualified form so `::errorInfo` (root) no longer collides with `::tcltest::errorInfo` (namespace var).

This also matches what `_emit_array_name_obj` already does at compile time for script-level writes inside `namespace eval`; the runtime fix extends the same qualification to proc bodies (whose resolution namespace is only known at call time).

## Test plan

- [x] New regression `TestArrays.test_array_in_namespace_proc_after_global_scalar_stamp` — proc inside `::myns` writes `set errorInfo(body) hello` after `catch { error boom }`; pre-fix this trapped, post-fix it returns `hello`.
- [x] New regression `TestNamespaceVariables.test_array_in_namespace_eval_after_global_scalar_stamp` — same scenario at script level inside a `namespace eval` body (belt-and-braces against a future emitter change).
- [x] `make prep-pr` clean apart from one pre-existing failure (`TestChannelTranslation::test_buffering_line_flushes_on_newline`, from PR #293, also fails on `origin/main`).
- [x] All 408 `test_wasm_real_tcl.py` cases continue to pass.

## Out of scope (separate follow-ups)

`io.test` / `ioCmd.test` still don't reach a tcltest summary — the array-conflict fix unblocks them past the point named in #273, but two further pre-existing traps in tcltest's init flow remain:

- `lappend OptionControlledVariables` traps because `_emit_lappend` uses the strict `_emit_var_read_obj` for the current-value read; `incr` already uses `_emit_var_read_obj_lenient` for the same auto-init contract and `lappend` should follow.
- `DebugPuts` reads an unset `debug` namespace variable.

Both are orthogonal to the array-conflict fix and deserve their own tickets.

https://claude.ai/code/session_01AKoUYcX21r3WEc62EejeEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKoUYcX21r3WEc62EejeEe)_