### PR TITLE
runtime/zig: wave 5 dispatch + interp unit tests (#268)

### DIFF
--- a/runtime/zig/test_tcl_catch.zig
+++ b/runtime/zig/test_tcl_catch.zig
@@ -1,0 +1,240 @@
+// Unit tests for ``interp/tcl_catch.zig`` — the error-flag /
+// error-message state machine, the loop-flow flags
+// (``break_flag`` / ``continue_flag`` / ``return_flag``), and the
+// ``tcl_cmd_error`` / ``error_unknown_command`` / ``var_unset_error``
+// formatting helpers.
+//
+// Wave 5 of the WASM-runtime test suite (#268).
+//
+// Every error-raising case runs inside :func:`fixture.with_catch` so
+// the raise sets ``error_flag`` instead of trapping the WASM binary.
+// :func:`fixture.with_interp` is used for tests that need a frame
+// stack (``var_unset_error`` stamps ``::errorInfo`` /
+// ``::errorCode`` via the global table).
+//
+// We deliberately don't exercise the out-of-catch trap path here —
+// that's an integration concern and the trap formatter writes to
+// stderr, which the Zig test runner can't easily inspect.  The
+// in-catch path is what every Tcl-level ``catch { … }`` exercises,
+// so it's the highest-leverage behaviour to pin down.
+
+const std = @import("std");
+const testing = std.testing;
+
+const obj = @import("valtypes/tcl_obj.zig");
+const catch_mod = @import("interp/tcl_catch.zig");
+const stubs = @import("stubs/tcl_stubs.zig");
+const fixture = @import("runtime_test_fixture.zig");
+
+// -- helpers --------------------------------------------------------
+
+fn name_obj(s: []const u8) i32 {
+    return obj.obj_new_string_copy(
+        @intCast(@intFromPtr(s.ptr)),
+        @intCast(s.len),
+    );
+}
+
+// -- error_flag / error_msg state machine ---------------------------
+
+fn body_clean_run() void {}
+
+test "catch_enter / catch_leave on a clean run leaves error_flag at 0" {
+    const result = fixture.with_catch(&body_clean_run);
+    try testing.expect(result == null);
+    try testing.expectEqual(@as(u32, 0), catch_mod.error_flag);
+    try testing.expectEqual(@as(i32, 0), catch_mod.error_msg);
+}
+
+fn body_raise() void {
+    stubs.raise("boom");
+}
+
+test "raise inside a catch sets error_flag and error_msg" {
+    fixture.catch_enter();
+    body_raise();
+    // ``error_flag`` and ``error_msg`` must be live BEFORE the leave —
+    // the leave's job is to read + clear them.
+    try testing.expectEqual(@as(u32, 1), catch_mod.error_flag);
+    try testing.expect(catch_mod.error_msg != 0);
+
+    const had_error = catch_mod.catch_leave();
+    try testing.expectEqual(@as(i64, 1), obj.obj_get_int(had_error));
+
+    // ``catch_leave`` clears ``error_flag`` for the surrounding
+    // (non-catch) code; ``last_catch_had_error`` remains so
+    // ``catch_result`` can still report.
+    try testing.expectEqual(@as(u32, 0), catch_mod.error_flag);
+    try testing.expectEqual(@as(u32, 1), catch_mod.last_catch_had_error);
+
+    // Reset for subsequent tests.
+    catch_mod.last_catch_had_error = 0;
+    catch_mod.error_msg = 0;
+    catch_mod.catch_ok_result = 0;
+}
+
+test "catch_result returns error_msg after a caught error" {
+    fixture.catch_enter();
+    stubs.raise("oops");
+    _ = catch_mod.catch_leave();
+    const r = catch_mod.catch_result();
+    try testing.expect(r != 0);
+    const s = obj.obj_ensure_string(r);
+    const src: [*]const u8 = @ptrFromInt(s.ptr);
+    try testing.expectEqualStrings("oops", src[0..s.len]);
+    catch_mod.last_catch_had_error = 0;
+    catch_mod.error_msg = 0;
+}
+
+test "catch_result returns ok_result on a clean run" {
+    fixture.catch_enter();
+    catch_mod.catch_set_ok_result(obj.obj_new_int(99));
+    _ = catch_mod.catch_leave();
+    const r = catch_mod.catch_result();
+    try testing.expectEqual(@as(i64, 99), obj.obj_get_int(r));
+    catch_mod.catch_ok_result = 0;
+}
+
+test "catch_set_ok_result is ignored once an error has been raised" {
+    fixture.catch_enter();
+    stubs.raise("first");
+    // After the raise, ``error_flag`` is set; subsequent
+    // ``catch_set_ok_result`` calls must be no-ops so the body's
+    // last-statement value can't overwrite the captured error.
+    catch_mod.catch_set_ok_result(obj.obj_new_int(7));
+    _ = catch_mod.catch_leave();
+    const r = catch_mod.catch_result();
+    // Result must still be the error message, not 7.
+    try testing.expect(r != 0);
+    const s = obj.obj_ensure_string(r);
+    const src: [*]const u8 = @ptrFromInt(s.ptr);
+    try testing.expectEqualStrings("first", src[0..s.len]);
+    catch_mod.last_catch_had_error = 0;
+    catch_mod.error_msg = 0;
+}
+
+test "catch_has_error mirrors error_flag while inside the catch scope" {
+    fixture.catch_enter();
+    try testing.expectEqual(@as(i32, 0), catch_mod.catch_has_error());
+    stubs.raise("x");
+    try testing.expectEqual(@as(i32, 1), catch_mod.catch_has_error());
+    _ = catch_mod.catch_leave();
+    catch_mod.last_catch_had_error = 0;
+    catch_mod.error_msg = 0;
+}
+
+// -- nested catches --------------------------------------------------
+
+test "nested catch_enter increments catch_depth then decrements on leave" {
+    const depth0 = catch_mod.catch_depth;
+    catch_mod.catch_enter();
+    try testing.expectEqual(depth0 + 1, catch_mod.catch_depth);
+    catch_mod.catch_enter();
+    try testing.expectEqual(depth0 + 2, catch_mod.catch_depth);
+    _ = catch_mod.catch_leave();
+    try testing.expectEqual(depth0 + 1, catch_mod.catch_depth);
+    _ = catch_mod.catch_leave();
+    try testing.expectEqual(depth0, catch_mod.catch_depth);
+}
+
+fn body_inner_raises_outer_does_not() void {
+    const inner = fixture.with_catch(&body_raise);
+    // Inner catch saw ``boom``.  We're now back in the outer scope.
+    _ = inner;
+}
+
+test "inner catch absorbs the error; outer scope sees no pending error" {
+    const result = fixture.with_catch(&body_inner_raises_outer_does_not);
+    try testing.expect(result == null);
+    try testing.expectEqual(@as(u32, 0), catch_mod.error_flag);
+}
+
+// -- loop-flow flags -------------------------------------------------
+
+test "flow_consume_break clears the flag and reports it once" {
+    catch_mod.break_flag = 1;
+    try testing.expectEqual(@as(i32, 1), catch_mod.flow_consume_break());
+    // Second consume must report 0 — the previous call cleared the
+    // flag.  Otherwise a single ``break`` could escape multiple
+    // enclosing loops.
+    try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_break());
+    try testing.expectEqual(@as(u32, 0), catch_mod.break_flag);
+}
+
+test "flow_consume_break returns 0 when no break is pending" {
+    catch_mod.break_flag = 0;
+    try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_break());
+}
+
+test "flow_consume_continue clears the flag and reports it once" {
+    catch_mod.continue_flag = 1;
+    try testing.expectEqual(@as(i32, 1), catch_mod.flow_consume_continue());
+    try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_continue());
+    try testing.expectEqual(@as(u32, 0), catch_mod.continue_flag);
+}
+
+test "flow_consume_continue returns 0 when no continue is pending" {
+    catch_mod.continue_flag = 0;
+    try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_continue());
+}
+
+// -- error_unknown_command formatting ------------------------------
+
+fn body_unknown_command() void {
+    catch_mod.error_unknown_command(name_obj("frobozz"));
+}
+
+test "error_unknown_command formats 'unknown command: <name>'" {
+    const msg = fixture.with_catch(&body_unknown_command);
+    try testing.expect(msg != null);
+    try testing.expectEqualStrings("unknown command: frobozz", msg.?);
+}
+
+// -- var_unset_error formatting ------------------------------------
+
+fn body_var_unset_then_assert() void {
+    catch_mod.var_unset_error(name_obj("missingVar"));
+}
+
+fn body_var_unset_inside_interp() void {
+    // ``var_unset_error`` calls ``stamp_error_globals`` →
+    // ``ns.global_set``, which needs a live root namespace.  The
+    // interp fixture sets that up.
+    const _msg = fixture.with_catch(&body_var_unset_then_assert);
+    // Communicate the captured message back via a module slot so
+    // the outer test body can assert on it.
+    if (_msg) |m| {
+        captured_unset_msg_len = m.len;
+        var i: usize = 0;
+        while (i < m.len and i < captured_unset_msg.len) : (i += 1) {
+            captured_unset_msg[i] = m[i];
+        }
+    } else {
+        captured_unset_msg_len = 0;
+    }
+}
+
+var captured_unset_msg: [128]u8 = undefined;
+var captured_unset_msg_len: usize = 0;
+
+test "var_unset_error formats reference Tcl's exact wording" {
+    captured_unset_msg_len = 0;
+    fixture.with_interp(&body_var_unset_inside_interp);
+    try testing.expectEqualStrings(
+        "can't read \"missingVar\": no such variable",
+        captured_unset_msg[0..captured_unset_msg_len],
+    );
+}
+
+// -- consecutive catch / leave hygiene -----------------------------
+
+test "consecutive catches reset state cleanly between iterations" {
+    // Three back-to-back error catches; each one must see the prior
+    // raise cleared and report only its own message.
+    var i: u32 = 0;
+    while (i < 3) : (i += 1) {
+        const msg = fixture.with_catch(&body_raise);
+        try testing.expect(msg != null);
+        try testing.expectEqualStrings("boom", msg.?);
+    }
+}

--- a/runtime/zig/test_tcl_cmd_registry.zig
+++ b/runtime/zig/test_tcl_cmd_registry.zig
@@ -1,0 +1,212 @@
+// Unit tests for ``dispatch/tcl_cmd_registry.zig`` — the linear-scan
+// command lookup helpers used by ``tcl_cmd_table.zig`` and the
+// per-command sub-dispatchers.
+//
+// Wave 5 of the WASM-runtime test suite (#268).  These cover the
+// cheapest entry point of the dispatch layer: pure functions that
+// consume a (name_ptr, name_len) byte slice and a static table,
+// returning either a handler / entry or ``null``.  No interpreter
+// state, no globals — keeps the test surface small enough to pin
+// down regressions in the linear-scan logic by name.
+
+const std = @import("std");
+const testing = std.testing;
+
+const reg = @import("dispatch/tcl_cmd_registry.zig");
+
+// -- Handlers --------------------------------------------------------
+//
+// Each test handler returns a unique sentinel so we can confirm
+// ``lookup`` returned the right ``CmdEntry`` rather than just *some*
+// entry whose name happened to match.  Returning a fresh integer per
+// handler also keeps the test independent of the runtime's TclObj
+// allocator — these are pure i32 returns.
+
+fn h_set(_: []const i32) i32 {
+    return 1;
+}
+
+fn h_unset(_: []const i32) i32 {
+    return 2;
+}
+
+fn h_setvar(_: []const i32) i32 {
+    return 3;
+}
+
+fn h_string(_: []const i32) i32 {
+    return 4;
+}
+
+fn h_sub_length(_: []const i32) i32 {
+    return 100;
+}
+
+fn h_sub_index(_: []const i32) i32 {
+    return 101;
+}
+
+fn h_sub_match(_: []const i32) i32 {
+    return 102;
+}
+
+const TABLE = [_]reg.CmdEntry{
+    .{ .name = "set", .arity_min = 1, .arity_max = 2, .handler = &h_set },
+    .{ .name = "unset", .arity_min = 1, .arity_max = null, .handler = &h_unset },
+    .{ .name = "setvar", .arity_min = 2, .arity_max = 2, .handler = &h_setvar },
+    .{ .name = "string", .arity_min = 1, .arity_max = null, .handler = &h_string },
+};
+
+const SUBS = [_]reg.SubEntry{
+    .{ .name = "length", .arity_min = 1, .arity_max = 1, .handler = &h_sub_length },
+    .{ .name = "index", .arity_min = 2, .arity_max = 2, .handler = &h_sub_index },
+    .{ .name = "match", .arity_min = 2, .arity_max = 3, .handler = &h_sub_match },
+};
+
+// Pass a slice's bytes via the (ptr, len) pair the lookup helpers
+// expect.  ``@intFromPtr`` over a string literal gives us a stable
+// address inside the test binary's data segment for the duration of
+// the call.
+fn ptr_of(s: []const u8) u32 {
+    return @intCast(@intFromPtr(s.ptr));
+}
+
+// -- lookup ----------------------------------------------------------
+
+test "lookup returns the registered handler on hit" {
+    const name = "set";
+    const h = reg.lookup(&TABLE, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
+    try testing.expectEqual(@as(i32, 1), h(&[_]i32{}));
+}
+
+test "lookup returns null on miss" {
+    const name = "nonexistent";
+    try testing.expect(reg.lookup(&TABLE, ptr_of(name), name.len) == null);
+}
+
+test "lookup returns null for empty name" {
+    // Without the early-exit guard a zero-length input would match
+    // any zero-length entry name (none exist today, but the guard
+    // makes the contract explicit).
+    const name = "set";
+    try testing.expect(reg.lookup(&TABLE, ptr_of(name), 0) == null);
+}
+
+test "lookup distinguishes names that share a prefix" {
+    // ``set`` and ``setvar`` are length-distinct.  The length-first
+    // skip in :func:`reg.lookup` should rule out the wrong one
+    // before any byte compare.
+    const set_name = "set";
+    const setvar_name = "setvar";
+
+    const h_for_set = reg.lookup(&TABLE, ptr_of(set_name), set_name.len) orelse return error.TestUnexpectedNull;
+    const h_for_setvar = reg.lookup(&TABLE, ptr_of(setvar_name), setvar_name.len) orelse return error.TestUnexpectedNull;
+
+    try testing.expectEqual(@as(i32, 1), h_for_set(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 3), h_for_setvar(&[_]i32{}));
+}
+
+test "lookup is case-sensitive" {
+    // Tcl command names are case-sensitive (``Set`` is not ``set``).
+    const upper = "Set";
+    try testing.expect(reg.lookup(&TABLE, ptr_of(upper), upper.len) == null);
+}
+
+test "lookup honours name_len boundary — does not over-read" {
+    // The table has ``"set"`` (length 3).  Pass the prefix of a longer
+    // buffer with len=3 and confirm the lookup matches without
+    // reading past the boundary.  Embedding the prefix inside a
+    // longer buffer catches a regression where the linear scan
+    // walked beyond ``name_len``.
+    const buf = "setvar";
+    const h = reg.lookup(&TABLE, ptr_of(buf), 3) orelse return error.TestUnexpectedNull;
+    try testing.expectEqual(@as(i32, 1), h(&[_]i32{}));
+}
+
+test "lookup against an empty table is always null" {
+    const empty = [_]reg.CmdEntry{};
+    const name = "set";
+    try testing.expect(reg.lookup(&empty, ptr_of(name), name.len) == null);
+}
+
+// -- lookup_entry ----------------------------------------------------
+
+test "lookup_entry surfaces arity bounds for an exact match" {
+    const name = "set";
+    const e = reg.lookup_entry(&TABLE, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
+    try testing.expectEqual(@as(u32, 1), e.arity_min);
+    try testing.expectEqual(@as(?u32, 2), e.arity_max);
+}
+
+test "lookup_entry exposes variadic upper bound as null" {
+    const name = "string";
+    const e = reg.lookup_entry(&TABLE, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
+    try testing.expect(e.arity_max == null);
+    try testing.expectEqual(@as(u32, 1), e.arity_min);
+}
+
+test "lookup_entry returns null on miss" {
+    const name = "nope";
+    try testing.expect(reg.lookup_entry(&TABLE, ptr_of(name), name.len) == null);
+}
+
+test "lookup_entry returns null on zero-length name" {
+    const name = "set";
+    try testing.expect(reg.lookup_entry(&TABLE, ptr_of(name), 0) == null);
+}
+
+// -- lookup_sub ------------------------------------------------------
+
+test "lookup_sub matches a registered sub-command" {
+    const name = "length";
+    const s = reg.lookup_sub(&SUBS, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
+    try testing.expectEqual(@as(u32, 1), s.arity_min);
+    try testing.expectEqual(@as(?u32, 1), s.arity_max);
+    try testing.expectEqual(@as(i32, 100), s.handler(&[_]i32{}));
+}
+
+test "lookup_sub returns null on miss" {
+    const name = "wibble";
+    try testing.expect(reg.lookup_sub(&SUBS, ptr_of(name), name.len) == null);
+}
+
+test "lookup_sub returns null on zero-length name" {
+    const name = "length";
+    try testing.expect(reg.lookup_sub(&SUBS, ptr_of(name), 0) == null);
+}
+
+test "lookup_sub picks the correct entry across length-distinct names" {
+    const len_name = "length";
+    const idx_name = "index";
+
+    const len_entry = reg.lookup_sub(&SUBS, ptr_of(len_name), len_name.len) orelse return error.TestUnexpectedNull;
+    const idx_entry = reg.lookup_sub(&SUBS, ptr_of(idx_name), idx_name.len) orelse return error.TestUnexpectedNull;
+
+    try testing.expectEqual(@as(i32, 100), len_entry.handler(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 101), idx_entry.handler(&[_]i32{}));
+}
+
+test "lookup_sub honours sub-arity range" {
+    const name = "match";
+    const s = reg.lookup_sub(&SUBS, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
+    try testing.expectEqual(@as(u32, 2), s.arity_min);
+    try testing.expectEqual(@as(?u32, 3), s.arity_max);
+}
+
+// -- defaults --------------------------------------------------------
+
+test "CmdEntry default arity is 0..variadic" {
+    // The defaults exist so unannotated registrations compile; the
+    // parity tool fills explicit values in.  This pins the contract
+    // so a future change to the defaults requires updating both
+    // sides intentionally.
+    const e = reg.CmdEntry{ .name = "x", .handler = &h_set };
+    try testing.expectEqual(@as(u32, 0), e.arity_min);
+    try testing.expect(e.arity_max == null);
+}
+
+test "SubEntry default arity is 0..variadic" {
+    const s = reg.SubEntry{ .name = "y", .handler = &h_sub_length };
+    try testing.expectEqual(@as(u32, 0), s.arity_min);
+    try testing.expect(s.arity_max == null);
+}

--- a/runtime/zig/test_tcl_diag.zig
+++ b/runtime/zig/test_tcl_diag.zig
@@ -1,0 +1,88 @@
+// Unit tests for ``dispatch/tcl_diag.zig`` — the source-location
+// diagnostic register the codegen pokes before each trap-able call.
+//
+// The module's surface is two single-slot registers (``current_site_id``
+// and the three-tuple ``current_eval_*``) plus their setters and the
+// two writers that emit them to a file descriptor.  We pin the
+// state-machine half here; the writer half is exercised end-to-end
+// by the trap-output regressions in the Python integration suite
+// (which can capture stderr while a wasmtime harness drives the
+// runtime).  The boolean return of :func:`diag.write_prefix` is
+// covered below — that's the part the trap formatter branches on,
+// and it doesn't depend on the fd actually accepting bytes.
+//
+// Wave 5 of the WASM-runtime test suite (#268).
+
+const std = @import("std");
+const testing = std.testing;
+
+const diag = @import("dispatch/tcl_diag.zig");
+
+// -- diag_set --------------------------------------------------------
+
+test "diag_set updates current_site_id" {
+    diag.current_site_id = 0;
+    diag.diag_set(42);
+    try testing.expectEqual(@as(u32, 42), diag.current_site_id);
+}
+
+test "diag_set overwrites — single-slot register, last wins" {
+    diag.diag_set(100);
+    diag.diag_set(200);
+    try testing.expectEqual(@as(u32, 200), diag.current_site_id);
+}
+
+test "diag_set with 0 clears the register" {
+    diag.diag_set(123);
+    diag.diag_set(0);
+    try testing.expectEqual(@as(u32, 0), diag.current_site_id);
+}
+
+// -- diag_set_eval_ctx ----------------------------------------------
+
+test "diag_set_eval_ctx fills all three slots" {
+    const buf = "set x 42";
+    const ptr: i32 = @intCast(@intFromPtr(buf.ptr));
+    diag.diag_set_eval_ctx(ptr, @intCast(buf.len), 4);
+    try testing.expectEqual(@as(u32, @intCast(ptr)), diag.current_eval_ptr);
+    try testing.expectEqual(@as(u32, buf.len), diag.current_eval_len);
+    try testing.expectEqual(@as(u32, 4), diag.current_eval_pos);
+}
+
+test "diag_set_eval_ctx with all zeros clears the slots" {
+    const buf = "x";
+    diag.diag_set_eval_ctx(@intCast(@intFromPtr(buf.ptr)), 1, 0);
+    diag.diag_set_eval_ctx(0, 0, 0);
+    try testing.expectEqual(@as(u32, 0), diag.current_eval_ptr);
+    try testing.expectEqual(@as(u32, 0), diag.current_eval_len);
+    try testing.expectEqual(@as(u32, 0), diag.current_eval_pos);
+}
+
+// -- write_prefix return value --------------------------------------
+//
+// ``write_prefix`` returns true iff a site was registered.  Trap
+// formatters branch on the return to decide whether to emit a
+// leading space.  We pin only the no-site-registered case in unit
+// tests — the registered-site path emits to a file descriptor and
+// is exercised end-to-end by the trap-output regressions in the
+// Python integration suite, which can capture stderr while a
+// wasmtime harness drives the runtime.
+
+test "write_prefix returns false when no site is registered" {
+    diag.current_site_id = 0;
+    // No site set means the writer takes the early-exit branch and
+    // never touches the fd — safe to pass an arbitrary value.
+    try testing.expect(!diag.write_prefix(2));
+}
+
+// -- write_eval_ctx no-ops on cleared state -------------------------
+//
+// The writer's contract is "do nothing if no eval context is set".
+// The cleared-state path takes the early-return without writing
+// to the fd — safe to call from a unit test; the actual write
+// path is exercised by the trap regressions in the Python suite.
+
+test "write_eval_ctx is a no-op when ptr/len are cleared" {
+    diag.diag_set_eval_ctx(0, 0, 0);
+    diag.write_eval_ctx(2);
+}

--- a/runtime/zig/test_tcl_frames.zig
+++ b/runtime/zig/test_tcl_frames.zig
@@ -1,0 +1,328 @@
+// Unit tests for ``interp/tcl_frames.zig`` — the call-frame stack
+// (push/pop, depth tracking, per-frame namespace context, argv) and
+// the local-variable / alias resolution machinery used by every
+// proc dispatch and ``upvar`` / ``global`` / ``variable`` chain.
+//
+// Wave 5 of the WASM-runtime test suite (#268).  Builds on the
+// fixture from #266 — every test runs inside ``with_interp`` so
+// the global frame is set up and torn down deterministically, and
+// the loop-flow flags are reset between cases.
+//
+// Coverage focus: frame depth boundaries, alias resolution
+// (ALIAS_GLOBAL via ``frame_alias_global`` and named globals via
+// ``frame_alias_named``), and the depth-stash / depth-restore
+// pair used by ``uplevel``.  These are the paths most likely to
+// drift when refactoring frame storage and the hardest to debug
+// from a Python-level integration failure.
+
+const std = @import("std");
+const testing = std.testing;
+
+const obj = @import("valtypes/tcl_obj.zig");
+const frames = @import("interp/tcl_frames.zig");
+const ns = @import("interp/tcl_ns.zig");
+const fixture = @import("runtime_test_fixture.zig");
+
+// ---- helpers ------------------------------------------------------
+
+fn name_obj(s: []const u8) i32 {
+    return obj.obj_new_string_copy(
+        @intCast(@intFromPtr(s.ptr)),
+        @intCast(s.len),
+    );
+}
+
+// Module-level slots for closure-style capture out of test bodies.
+// ``observed_int`` holds i64s returned by ``obj.obj_get_int``;
+// ``observed_handle`` holds raw TclObj IDs; ``observed_depth`` the
+// frame depth difference; ``observed_ns`` the per-frame ns slot.
+var observed_depth: u32 = 0;
+var observed_int: i64 = 0;
+var observed_int2: i64 = 0;
+var observed_handle: i32 = 0;
+var observed_handle2: i32 = 0;
+var observed_ns: u32 = 0;
+
+// ---- frame_push / frame_pop / frame_get_depth ---------------------
+
+fn body_push_pop_balance() void {
+    const before = frames.frame_depth;
+    _ = frames.frame_push();
+    _ = frames.frame_push();
+    _ = frames.frame_push();
+    observed_depth = frames.frame_depth - before;
+    frames.frame_pop();
+    frames.frame_pop();
+    frames.frame_pop();
+    observed_int = @intCast(frames.frame_depth - before);
+}
+
+test "frame_push/frame_pop balance — three nested pushes restore depth" {
+    observed_depth = 0;
+    observed_int = 0;
+    fixture.with_interp(&body_push_pop_balance);
+    try testing.expectEqual(@as(u32, 3), observed_depth);
+    try testing.expectEqual(@as(i64, 0), observed_int);
+}
+
+fn body_get_depth_matches() void {
+    const d1: i32 = frames.frame_get_depth();
+    _ = frames.frame_push();
+    const d2: i32 = frames.frame_get_depth();
+    observed_int = @as(i64, d2 - d1);
+    frames.frame_pop();
+    const d3: i32 = frames.frame_get_depth();
+    observed_int2 = @as(i64, d3 - d1);
+}
+
+test "frame_get_depth tracks live frame stack height" {
+    observed_int = 0;
+    observed_int2 = 0;
+    fixture.with_interp(&body_get_depth_matches);
+    try testing.expectEqual(@as(i64, 1), observed_int);
+    try testing.expectEqual(@as(i64, 0), observed_int2);
+}
+
+// ---- local_set / local_get isolation across frames ----------------
+
+fn body_locals_isolate_per_frame() void {
+    fixture.frame.set("x", obj.obj_new_int(1));
+    _ = frames.frame_push();
+    fixture.frame.set("x", obj.obj_new_int(2));
+    observed_int = obj.obj_get_int(frames.local_get(name_obj("x")));
+    frames.frame_pop();
+    observed_int2 = obj.obj_get_int(frames.local_get(name_obj("x")));
+}
+
+test "local_set/local_get isolate values across frame boundaries" {
+    observed_int = 0;
+    observed_int2 = 0;
+    fixture.with_interp(&body_locals_isolate_per_frame);
+    try testing.expectEqual(@as(i64, 2), observed_int);
+    try testing.expectEqual(@as(i64, 1), observed_int2);
+}
+
+fn body_local_get_misses_return_zero() void {
+    observed_handle = frames.local_get(name_obj("never_set"));
+}
+
+test "local_get returns 0 when name is missing" {
+    observed_handle = -1;
+    fixture.with_interp(&body_local_get_misses_return_zero);
+    try testing.expectEqual(@as(i32, 0), observed_handle);
+}
+
+// ---- local_exists -------------------------------------------------
+
+fn body_local_exists_true_false() void {
+    fixture.frame.set("present", obj.obj_new_int(99));
+    observed_int = obj.obj_get_int(frames.local_exists(name_obj("present")));
+    observed_int2 = obj.obj_get_int(frames.local_exists(name_obj("absent")));
+}
+
+test "local_exists distinguishes set vs unset" {
+    observed_int = -1;
+    observed_int2 = -1;
+    fixture.with_interp(&body_local_exists_true_false);
+    try testing.expectEqual(@as(i64, 1), observed_int);
+    try testing.expectEqual(@as(i64, 0), observed_int2);
+}
+
+// ---- ALIAS_GLOBAL via frame_alias_global --------------------------
+
+fn body_alias_global_propagates_to_global_table() void {
+    // Promote local ``g`` to alias the same-name global.  Subsequent
+    // local writes must land in globals.
+    frames.frame_alias_global(name_obj("g"));
+    _ = frames.local_set(name_obj("g"), obj.obj_new_int(42));
+    // Read via the global table directly to confirm propagation.
+    observed_int = obj.obj_get_int(ns.global_get(name_obj("g")));
+    // Read via the local alias — must mirror the global.
+    observed_int2 = obj.obj_get_int(frames.local_get(name_obj("g")));
+}
+
+test "frame_alias_global routes local writes to the global table" {
+    observed_int = 0;
+    observed_int2 = 0;
+    fixture.with_interp(&body_alias_global_propagates_to_global_table);
+    try testing.expectEqual(@as(i64, 42), observed_int);
+    try testing.expectEqual(@as(i64, 42), observed_int2);
+}
+
+// ---- ALIAS_EXT via frame_alias_named ------------------------------
+
+fn body_alias_named_remaps_local_to_other_global() void {
+    // Local ``alias_local`` aliases the global ``target_global``.
+    frames.frame_alias_named(name_obj("alias_local"), name_obj("target_global"));
+    _ = frames.local_set(name_obj("alias_local"), obj.obj_new_int(7));
+    // The aliased global should hold the value.
+    observed_int = obj.obj_get_int(ns.global_get(name_obj("target_global")));
+    // The local *name* should NOT show up in globals — only the
+    // aliased target does.
+    observed_int2 = obj.obj_get_int(ns.global_exists(name_obj("alias_local")));
+}
+
+test "frame_alias_named writes through to the aliased global name" {
+    observed_int = 0;
+    observed_int2 = -1;
+    fixture.with_interp(&body_alias_named_remaps_local_to_other_global);
+    try testing.expectEqual(@as(i64, 7), observed_int);
+    try testing.expectEqual(@as(i64, 0), observed_int2);
+}
+
+// ---- var_resolve precedence ---------------------------------------
+
+fn body_var_resolve_prefers_frame_over_global() void {
+    _ = ns.global_set(name_obj("collide"), obj.obj_new_int(99));
+    fixture.frame.set("collide", obj.obj_new_int(11));
+    observed_int = obj.obj_get_int(frames.var_resolve(name_obj("collide")));
+}
+
+test "var_resolve prefers a frame local over a same-name global" {
+    observed_int = 0;
+    fixture.with_interp(&body_var_resolve_prefers_frame_over_global);
+    try testing.expectEqual(@as(i64, 11), observed_int);
+}
+
+fn body_var_resolve_qualified_goes_global() void {
+    // ``::``-qualified names bypass the frame — even when a same-name
+    // local exists.  Important: this is what makes ``$::env(FOO)`` /
+    // ``$::someGlobal`` resolve correctly inside procs.
+    _ = ns.global_set(name_obj("only_global"), obj.obj_new_int(55));
+    fixture.frame.set("::only_global", obj.obj_new_int(0)); // would-be confusion
+    observed_int = obj.obj_get_int(frames.var_resolve(name_obj("::only_global")));
+}
+
+test "var_resolve sends ::-qualified names directly to globals" {
+    observed_int = 0;
+    fixture.with_interp(&body_var_resolve_qualified_goes_global);
+    try testing.expectEqual(@as(i64, 55), observed_int);
+}
+
+// ---- var_set in current frame -------------------------------------
+
+fn body_var_set_lands_in_frame_when_present() void {
+    _ = frames.var_set(name_obj("v"), obj.obj_new_int(3));
+    // The local must hold the value; the global must not.
+    observed_int = obj.obj_get_int(frames.local_get(name_obj("v")));
+    observed_int2 = obj.obj_get_int(ns.global_exists(name_obj("v")));
+}
+
+test "var_set targets the current frame when one is active" {
+    observed_int = 0;
+    observed_int2 = -1;
+    fixture.with_interp(&body_var_set_lands_in_frame_when_present);
+    try testing.expectEqual(@as(i64, 3), observed_int);
+    try testing.expectEqual(@as(i64, 0), observed_int2);
+}
+
+// ---- frame_set_argv / frame_get_argv ------------------------------
+
+fn body_argv_round_trip() void {
+    const argv = obj.obj_new_string_copy(
+        @intCast(@intFromPtr("foo bar baz".ptr)),
+        @intCast("foo bar baz".len),
+    );
+    frames.frame_set_argv(argv);
+    observed_handle = frames.frame_get_argv(0);
+}
+
+test "frame_set_argv / frame_get_argv round-trip the recorded list" {
+    observed_handle = 0;
+    fixture.with_interp(&body_argv_round_trip);
+    try testing.expect(observed_handle != 0);
+    const s = obj.obj_ensure_string(observed_handle);
+    try testing.expectEqual(@as(u32, "foo bar baz".len), s.len);
+}
+
+fn body_argv_unset_returns_zero() void {
+    // Fresh frame — no argv recorded.
+    observed_handle = frames.frame_get_argv(0);
+}
+
+test "frame_get_argv returns 0 when argv is unrecorded" {
+    observed_handle = -1;
+    fixture.with_interp(&body_argv_unset_returns_zero);
+    try testing.expectEqual(@as(i32, 0), observed_handle);
+}
+
+fn body_argv_offset_oob_returns_zero() void {
+    // Negative and out-of-range offsets must return 0, not trap.
+    observed_handle = frames.frame_get_argv(-1);
+    observed_handle2 = frames.frame_get_argv(@intCast(frames.frame_depth + 5));
+}
+
+test "frame_get_argv returns 0 for out-of-range offsets" {
+    observed_handle = -1;
+    observed_handle2 = -1;
+    fixture.with_interp(&body_argv_offset_oob_returns_zero);
+    try testing.expectEqual(@as(i32, 0), observed_handle);
+    try testing.expectEqual(@as(i32, 0), observed_handle2);
+}
+
+// ---- frame_set_ns / frame_get_ns ----------------------------------
+
+fn body_frame_ns_round_trip() void {
+    const fake_ns: u32 = 0xDEADBEEF; // just a stable sentinel — we
+    // never deref it; ``frame_set_ns`` stores u32 verbatim.
+    frames.frame_set_ns(fake_ns);
+    observed_ns = frames.frame_get_ns(0);
+}
+
+test "frame_set_ns / frame_get_ns store + read the per-frame ns slot" {
+    observed_ns = 0;
+    fixture.with_interp(&body_frame_ns_round_trip);
+    try testing.expectEqual(@as(u32, 0xDEADBEEF), observed_ns);
+}
+
+fn body_frame_ns_oob_zero() void {
+    observed_ns = frames.frame_get_ns(-1);
+}
+
+test "frame_get_ns returns 0 for negative offsets" {
+    observed_ns = 0xCAFEBABE;
+    fixture.with_interp(&body_frame_ns_oob_zero);
+    try testing.expectEqual(@as(u32, 0), observed_ns);
+}
+
+// ---- frame_depth_stash / frame_depth_restore ----------------------
+
+fn body_depth_stash_restore_cycles_depth() void {
+    _ = frames.frame_push();
+    _ = frames.frame_push();
+    const before = frames.frame_depth;
+    const saved = frames.frame_depth_stash(2);
+    observed_int = @intCast(before - frames.frame_depth);
+    frames.frame_depth_restore(saved);
+    observed_int2 = @intCast(frames.frame_depth - (before - 2));
+    // Drain the two extra pushes so ``with_interp`` can teardown
+    // cleanly back to its entry depth.
+    frames.frame_pop();
+    frames.frame_pop();
+}
+
+test "frame_depth_stash drops by relative_up; restore returns to saved" {
+    observed_int = 0;
+    observed_int2 = 0;
+    fixture.with_interp(&body_depth_stash_restore_cycles_depth);
+    try testing.expectEqual(@as(i64, 2), observed_int);
+    try testing.expectEqual(@as(i64, 2), observed_int2);
+}
+
+fn body_depth_stash_clamps_relative_up() void {
+    // Stashing further than the current depth must clamp to 0
+    // rather than wrap.  Without the clamp, an over-deep
+    // ``uplevel #N`` would underflow ``frame_depth``.
+    _ = frames.frame_push();
+    _ = frames.frame_depth_stash(99);
+    observed_int = @intCast(frames.frame_depth);
+    frames.frame_depth_restore(@intCast(frames.frame_depth));
+    // After restore we still need to drop the extra push.
+    if (frames.frame_depth > 1) frames.frame_pop();
+}
+
+test "frame_depth_stash clamps over-deep relative_up to zero" {
+    observed_int = -1;
+    fixture.with_interp(&body_depth_stash_clamps_relative_up);
+    try testing.expectEqual(@as(i64, 0), observed_int);
+}

--- a/runtime/zig/test_tcl_frames.zig
+++ b/runtime/zig/test_tcl_frames.zig
@@ -314,11 +314,17 @@ fn body_depth_stash_clamps_relative_up() void {
     // rather than wrap.  Without the clamp, an over-deep
     // ``uplevel #N`` would underflow ``frame_depth``.
     _ = frames.frame_push();
-    _ = frames.frame_depth_stash(99);
+    const saved = frames.frame_depth_stash(99);
+    // Inside the stash window: depth must be 0 (clamped).
     observed_int = @intCast(frames.frame_depth);
-    frames.frame_depth_restore(@intCast(frames.frame_depth));
-    // After restore we still need to drop the extra push.
-    if (frames.frame_depth > 1) frames.frame_pop();
+    // Restore using the saved value (the depth captured BEFORE
+    // ``frame_depth_stash`` ran), not the post-stash 0 — that's the
+    // contract ``uplevel`` relies on.
+    frames.frame_depth_restore(saved);
+    // After restore we're back at saved depth; drop the test's
+    // extra push so ``with_interp`` can teardown to its own entry
+    // depth without tripping the imbalance panic.
+    frames.frame_pop();
 }
 
 test "frame_depth_stash clamps over-deep relative_up to zero" {

--- a/runtime/zig/test_tcl_ns.zig
+++ b/runtime/zig/test_tcl_ns.zig
@@ -1,0 +1,271 @@
+// Unit tests for ``interp/tcl_ns.zig`` — the namespace tree
+// (root, ``ns_create`` find-or-create, ``ns_full_name`` FQN
+// materialisation, qualified-name resolution) and the export-pattern
+// machinery used by ``namespace export`` / ``namespace import``.
+//
+// Wave 5 of the WASM-runtime test suite (#268).
+//
+// The namespace tree is module-global state: every test binary that
+// touches ``ns_root`` shares the same root through the rest of the
+// suite.  We design each test to be order-independent by using
+// fresh, test-specific child names — the bump allocator never
+// recycles, so a leaked child from one case is harmless to the
+// next.
+
+const std = @import("std");
+const testing = std.testing;
+
+const obj = @import("valtypes/tcl_obj.zig");
+const ns = @import("interp/tcl_ns.zig");
+const fixture = @import("runtime_test_fixture.zig");
+
+// -- helpers --------------------------------------------------------
+
+fn ptr_of(s: []const u8) u32 {
+    return @intCast(@intFromPtr(s.ptr));
+}
+
+fn slice_at(p: u32, l: u32) []const u8 {
+    if (l == 0) return &[_]u8{};
+    const src: [*]const u8 = @ptrFromInt(p);
+    return src[0..l];
+}
+
+// -- ns_root --------------------------------------------------------
+
+test "ns_root is idempotent and returns a stable address" {
+    const r1 = ns.ns_root();
+    const r2 = ns.ns_root();
+    try testing.expect(r1 != 0);
+    try testing.expectEqual(r1, r2);
+}
+
+test "ns_root has empty simple name and no parent" {
+    const root = ns.ns_root();
+    const node: *ns.Namespace = @ptrFromInt(root);
+    try testing.expectEqual(@as(u32, 0), node.name_len);
+    try testing.expectEqual(@as(u32, 0), node.parent);
+}
+
+test "ns_full_name on root returns ::" {
+    const root = ns.ns_root();
+    const fq = ns.ns_full_name(root);
+    try testing.expectEqualStrings("::", slice_at(fq.ptr, fq.len));
+}
+
+// -- ns_create / ns_lookup -----------------------------------------
+
+test "ns_create on a fresh name allocates a child and links it" {
+    const root = ns.ns_root();
+    const name = "test_ns_create_fresh";
+    const child = ns.ns_create(root, ptr_of(name), name.len);
+    try testing.expect(child != 0);
+    try testing.expect(child != root);
+
+    const node: *ns.Namespace = @ptrFromInt(child);
+    try testing.expectEqual(@as(u32, root), node.parent);
+    try testing.expectEqualStrings(name, slice_at(node.name_ptr, node.name_len));
+}
+
+test "ns_create is find-or-create — same name returns the same child" {
+    const root = ns.ns_root();
+    const name = "test_ns_create_idempotent";
+    const c1 = ns.ns_create(root, ptr_of(name), name.len);
+    const c2 = ns.ns_create(root, ptr_of(name), name.len);
+    try testing.expectEqual(c1, c2);
+}
+
+test "ns_lookup returns the registered child" {
+    const root = ns.ns_root();
+    const name = "test_ns_lookup_hit";
+    const created = ns.ns_create(root, ptr_of(name), name.len);
+    const found = ns.ns_lookup(root, ptr_of(name), name.len);
+    try testing.expectEqual(created, found);
+}
+
+test "ns_lookup returns 0 on miss" {
+    const root = ns.ns_root();
+    const missing = "test_ns_lookup_no_such_child";
+    try testing.expectEqual(@as(u32, 0), ns.ns_lookup(root, ptr_of(missing), missing.len));
+}
+
+// -- ns_full_name on a child ---------------------------------------
+
+test "ns_full_name on a top-level child collapses ::name (not ::::name)" {
+    const root = ns.ns_root();
+    const name = "test_ns_full_name_top";
+    const child = ns.ns_create(root, ptr_of(name), name.len);
+    const fq = ns.ns_full_name(child);
+    try testing.expectEqualStrings("::test_ns_full_name_top", slice_at(fq.ptr, fq.len));
+}
+
+test "ns_full_name on a deep child concatenates with ::" {
+    const root = ns.ns_root();
+    const a = "test_ns_full_name_deep_a";
+    const b = "b";
+    const ns_a = ns.ns_create(root, ptr_of(a), a.len);
+    const ns_b = ns.ns_create(ns_a, ptr_of(b), b.len);
+    const fq = ns.ns_full_name(ns_b);
+    try testing.expectEqualStrings("::test_ns_full_name_deep_a::b", slice_at(fq.ptr, fq.len));
+}
+
+test "ns_full_name caches the result — repeat calls return the same buffer" {
+    const root = ns.ns_root();
+    const name = "test_ns_full_name_cache";
+    const child = ns.ns_create(root, ptr_of(name), name.len);
+    const fq1 = ns.ns_full_name(child);
+    const fq2 = ns.ns_full_name(child);
+    try testing.expectEqual(fq1.ptr, fq2.ptr);
+    try testing.expectEqual(fq1.len, fq2.len);
+}
+
+// -- ns_create_from_fqn --------------------------------------------
+
+test "ns_create_from_fqn walks ::-separated components" {
+    const name = "::test_create_from_fqn::level1::level2";
+    const target = ns.ns_create_from_fqn(ptr_of(name), name.len);
+    try testing.expect(target != 0);
+    const fq = ns.ns_full_name(target);
+    try testing.expectEqualStrings(
+        "::test_create_from_fqn::level1::level2",
+        slice_at(fq.ptr, fq.len),
+    );
+}
+
+test "ns_create_from_fqn on :: alone returns root" {
+    const name = "::";
+    const target = ns.ns_create_from_fqn(ptr_of(name), name.len);
+    try testing.expectEqual(ns.ns_root(), target);
+}
+
+test "ns_create_from_fqn collapses repeated colons (Tcl semantics)" {
+    // Three or more adjacent colons read as a single separator.
+    const name = "::test_create_from_fqn_collapse:::leaf";
+    const target = ns.ns_create_from_fqn(ptr_of(name), name.len);
+    const fq = ns.ns_full_name(target);
+    try testing.expectEqualStrings(
+        "::test_create_from_fqn_collapse::leaf",
+        slice_at(fq.ptr, fq.len),
+    );
+}
+
+// -- ns_resolve_qualified -------------------------------------------
+
+test "ns_resolve_qualified on a simple name anchors at the context" {
+    const root = ns.ns_root();
+    const cxt_name = "test_resolve_simple_cxt";
+    const cxt = ns.ns_create(root, ptr_of(cxt_name), cxt_name.len);
+    const target_name = "leaf";
+    const r = ns.ns_resolve_qualified(cxt, ptr_of(target_name), target_name.len);
+    // Simple name → ``target_ns`` is the cxt itself; ``simple_*``
+    // points back into the input.
+    try testing.expectEqual(cxt, r.target_ns);
+    try testing.expectEqualStrings(target_name, slice_at(r.simple_ptr, r.simple_len));
+}
+
+test "ns_resolve_qualified on a ::-prefixed name anchors at root" {
+    const cxt_name = "test_resolve_qualified_cxt";
+    const cxt = ns.ns_create(ns.ns_root(), ptr_of(cxt_name), cxt_name.len);
+    const name = "::cmd_at_root";
+    const r = ns.ns_resolve_qualified(cxt, ptr_of(name), name.len);
+    // ``::``-prefixed name resolves against root regardless of cxt.
+    try testing.expectEqual(ns.ns_root(), r.target_ns);
+    try testing.expectEqualStrings("cmd_at_root", slice_at(r.simple_ptr, r.simple_len));
+}
+
+test "ns_resolve_qualified on :: alone returns root + empty simple name" {
+    const name = "::";
+    const r = ns.ns_resolve_qualified(ns.ns_root(), ptr_of(name), name.len);
+    try testing.expectEqual(ns.ns_root(), r.target_ns);
+    try testing.expectEqual(@as(u32, 0), r.simple_len);
+}
+
+test "ns_resolve_qualified surfaces the alt-from-root path for unqualified cxt-anchored names" {
+    // Per ``tclNamesp.c:2370``-style behaviour, an unqualified name
+    // resolved in a non-root cxt also reports an alt anchor at root
+    // so callers can probe both spaces.
+    const cxt_name = "test_resolve_alt_cxt";
+    const cxt = ns.ns_create(ns.ns_root(), ptr_of(cxt_name), cxt_name.len);
+    const name = "leaf";
+    const r = ns.ns_resolve_qualified(cxt, ptr_of(name), name.len);
+    try testing.expectEqual(cxt, r.target_ns);
+    try testing.expectEqual(ns.ns_root(), r.alt_ns);
+}
+
+// -- ns_export / ns_export_matches ---------------------------------
+
+test "ns_export_matches returns false when no patterns are registered" {
+    const cxt_name = "test_export_empty";
+    const cxt = ns.ns_create(ns.ns_root(), ptr_of(cxt_name), cxt_name.len);
+    const probe = "anything";
+    try testing.expect(!ns.ns_export_matches(cxt, ptr_of(probe), probe.len));
+}
+
+test "ns_export + ns_export_matches honour glob semantics" {
+    const cxt_name = "test_export_glob";
+    const cxt = ns.ns_create(ns.ns_root(), ptr_of(cxt_name), cxt_name.len);
+    const pat = "foo*";
+    ns.ns_export(cxt, ptr_of(pat), pat.len);
+
+    const hit = "foobar";
+    const miss = "barfoo";
+    try testing.expect(ns.ns_export_matches(cxt, ptr_of(hit), hit.len));
+    try testing.expect(!ns.ns_export_matches(cxt, ptr_of(miss), miss.len));
+}
+
+test "ns_export accumulates across calls" {
+    const cxt_name = "test_export_multi";
+    const cxt = ns.ns_create(ns.ns_root(), ptr_of(cxt_name), cxt_name.len);
+    const pat_a = "a*";
+    const pat_b = "b*";
+    ns.ns_export(cxt, ptr_of(pat_a), pat_a.len);
+    ns.ns_export(cxt, ptr_of(pat_b), pat_b.len);
+
+    const hit_a = "alpha";
+    const hit_b = "beta";
+    const miss = "gamma";
+    try testing.expect(ns.ns_export_matches(cxt, ptr_of(hit_a), hit_a.len));
+    try testing.expect(ns.ns_export_matches(cxt, ptr_of(hit_b), hit_b.len));
+    try testing.expect(!ns.ns_export_matches(cxt, ptr_of(miss), miss.len));
+}
+
+test "ns_export with empty pattern is a no-op" {
+    const cxt_name = "test_export_empty_pattern";
+    const cxt = ns.ns_create(ns.ns_root(), ptr_of(cxt_name), cxt_name.len);
+    const empty = "";
+    ns.ns_export(cxt, ptr_of(empty), 0);
+    // No patterns were actually added, so any probe still misses.
+    const probe = "xyz";
+    try testing.expect(!ns.ns_export_matches(cxt, ptr_of(probe), probe.len));
+}
+
+// -- global_set / global_get / global_exists -----------------------
+
+fn body_global_set_get_round_trip() void {
+    const name = obj.obj_new_string_copy(@intCast(@intFromPtr("g_value".ptr)), 7);
+    _ = ns.global_set(name, obj.obj_new_int(123));
+    captured_int = obj.obj_get_int(ns.global_get(name));
+    captured_exists = obj.obj_get_int(ns.global_exists(name));
+}
+
+var captured_int: i64 = 0;
+var captured_exists: i64 = 0;
+
+test "global_set / global_get / global_exists round-trip" {
+    captured_int = 0;
+    captured_exists = 0;
+    fixture.with_interp(&body_global_set_get_round_trip);
+    try testing.expectEqual(@as(i64, 123), captured_int);
+    try testing.expectEqual(@as(i64, 1), captured_exists);
+}
+
+fn body_global_exists_misses() void {
+    const name = obj.obj_new_string_copy(@intCast(@intFromPtr("never_set_global".ptr)), 16);
+    captured_exists = obj.obj_get_int(ns.global_exists(name));
+}
+
+test "global_exists returns 0 on a missing variable" {
+    captured_exists = -1;
+    fixture.with_interp(&body_global_exists_misses);
+    try testing.expectEqual(@as(i64, 0), captured_exists);
+}

--- a/runtime/zig/test_tcl_procs.zig
+++ b/runtime/zig/test_tcl_procs.zig
@@ -323,22 +323,34 @@ test "proc_set_body_source attaches a body TclObj to a compiled proc" {
 
 // -- ns-resolution: qualified registration --------------------------
 
-fn body_register_qualified_lands_in_target_ns() void {
+fn body_register_qualified_then_unqualified_lookup_from_ns() void {
     // ``::myns::myproc`` should land in the ``::myns`` namespace's
-    // cmd_table, not in the root.  After registration ``proc_lookup``
-    // from inside that ns must find it.
-    _ = ns.ns_create_from_fqn(@intCast(@intFromPtr("::test_proc_qualified_ns".ptr)),
-                              @intCast("::test_proc_qualified_ns".len));
+    // cmd_table, not in the root.  Switching ``current_ns`` to the
+    // target namespace and probing the unqualified tail name then
+    // exercises the context-anchored lookup path — the one a proc
+    // body running inside ``::myns`` would take when it calls
+    // ``myproc`` without a qualifier.  Saving / restoring
+    // ``current_ns`` keeps the rest of the suite isolated from this
+    // test's mutation of the shared global.
+    const myns = ns.ns_create_from_fqn(
+        @intCast(@intFromPtr("::test_proc_qualified_ns".ptr)),
+        @intCast("::test_proc_qualified_ns".len),
+    );
     _ = procs.proc_register(
         name_obj("::test_proc_qualified_ns::myproc"),
         name_obj(""),
         name_obj("return ok"),
     );
-    captured_bucket = procs.proc_lookup(name_obj("::test_proc_qualified_ns::myproc"));
+
+    const saved_ns = ns.current_ns;
+    ns.current_ns = myns;
+    defer ns.current_ns = saved_ns;
+
+    captured_bucket = procs.proc_lookup(name_obj("myproc"));
 }
 
-test "proc_register on a ::-qualified name lands in the target namespace" {
+test "proc_register on a ::-qualified name is reachable via unqualified lookup from inside that ns" {
     captured_bucket = 0;
-    fixture.with_interp(&body_register_qualified_lands_in_target_ns);
+    fixture.with_interp(&body_register_qualified_then_unqualified_lookup_from_ns);
     try testing.expect(captured_bucket != 0);
 }

--- a/runtime/zig/test_tcl_procs.zig
+++ b/runtime/zig/test_tcl_procs.zig
@@ -1,0 +1,344 @@
+// Unit tests for ``interp/tcl_procs.zig`` — the proc registry that
+// every ``proc`` keyword and every compiled WASM proc register-at-
+// startup hook lands in.
+//
+// Wave 5 of the WASM-runtime test suite (#268).
+//
+// Coverage: proc_register / proc_register_compiled — both end up in
+// the same ``Command`` slot inside the namespace tree's cmd_table —
+// and the per-field accessors that the dispatcher reads
+// (``proc_get_n_params``, ``proc_get_n_required``,
+// ``proc_get_args_tail``, ``proc_get_func_idx``,
+// ``proc_get_params``, ``proc_get_body``, ``proc_get_name_*``).
+// ``proc_lookup`` round-trips registration → resolution.
+//
+// We pick test-specific proc names per case so leftover registrations
+// from earlier tests don't collide.  The bump allocator never
+// reclaims, so a stale slot is harmless.
+
+const std = @import("std");
+const testing = std.testing;
+
+const obj = @import("valtypes/tcl_obj.zig");
+const procs = @import("interp/tcl_procs.zig");
+const ns = @import("interp/tcl_ns.zig");
+const fixture = @import("runtime_test_fixture.zig");
+
+// -- helpers --------------------------------------------------------
+
+fn name_obj(s: []const u8) i32 {
+    return obj.obj_new_string_copy(
+        @intCast(@intFromPtr(s.ptr)),
+        @intCast(s.len),
+    );
+}
+
+fn slice_at(p: u32, l: u32) []const u8 {
+    if (l == 0) return &[_]u8{};
+    const src: [*]const u8 = @ptrFromInt(p);
+    return src[0..l];
+}
+
+// Module-level capture slots — the `with_interp` body callbacks need
+// somewhere to write their observations.  Reset at the top of each
+// test so a stale value from a previous case can't leak through.
+var captured_bucket: i32 = 0;
+var captured_int: i64 = 0;
+var captured_int2: i64 = 0;
+var captured_handle: i32 = 0;
+var captured_name: [128]u8 = undefined;
+var captured_name_len: usize = 0;
+
+// -- proc_register (interpreted procs) ------------------------------
+
+fn body_register_then_lookup() void {
+    _ = procs.proc_register(
+        name_obj("test_proc_register_basic"),
+        name_obj("a b c"),
+        name_obj("set x 1"),
+    );
+    captured_bucket = procs.proc_lookup(name_obj("test_proc_register_basic"));
+}
+
+test "proc_register followed by proc_lookup returns the registered Command" {
+    captured_bucket = 0;
+    fixture.with_interp(&body_register_then_lookup);
+    try testing.expect(captured_bucket != 0);
+}
+
+fn body_register_records_n_params() void {
+    _ = procs.proc_register(
+        name_obj("test_proc_n_params"),
+        name_obj("alpha beta gamma delta"),
+        name_obj("expr {1}"),
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_n_params"));
+    captured_int = @as(i64, procs.proc_get_n_params(bucket));
+}
+
+test "proc_register infers n_params from the params list length" {
+    captured_int = 0;
+    fixture.with_interp(&body_register_records_n_params);
+    try testing.expectEqual(@as(i64, 4), captured_int);
+}
+
+fn body_register_returns_body_handle() void {
+    const body = name_obj("set x 7");
+    _ = procs.proc_register(
+        name_obj("test_proc_body_round_trip"),
+        name_obj(""),
+        body,
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_body_round_trip"));
+    captured_handle = procs.proc_get_body(bucket);
+}
+
+test "proc_get_body returns a TclObj whose string is the registered body" {
+    captured_handle = 0;
+    fixture.with_interp(&body_register_returns_body_handle);
+    try testing.expect(captured_handle != 0);
+    const s = obj.obj_ensure_string(captured_handle);
+    try testing.expectEqualStrings("set x 7", slice_at(s.ptr, s.len));
+}
+
+fn body_register_returns_params_handle() void {
+    _ = procs.proc_register(
+        name_obj("test_proc_params_round_trip"),
+        name_obj("x y"),
+        name_obj("expr {$x + $y}"),
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_params_round_trip"));
+    captured_handle = procs.proc_get_params(bucket);
+}
+
+test "proc_get_params returns a TclObj whose string is the params list" {
+    captured_handle = 0;
+    fixture.with_interp(&body_register_returns_params_handle);
+    try testing.expect(captured_handle != 0);
+    const s = obj.obj_ensure_string(captured_handle);
+    try testing.expectEqualStrings("x y", slice_at(s.ptr, s.len));
+}
+
+fn body_register_redefine_overwrites_body() void {
+    _ = procs.proc_register(
+        name_obj("test_proc_redefine"),
+        name_obj("a"),
+        name_obj("set first 1"),
+    );
+    _ = procs.proc_register(
+        name_obj("test_proc_redefine"),
+        name_obj("a b"),
+        name_obj("set second 2"),
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_redefine"));
+    captured_int = @as(i64, procs.proc_get_n_params(bucket));
+    captured_handle = procs.proc_get_body(bucket);
+}
+
+test "proc_register on an existing name overwrites params + body" {
+    captured_int = 0;
+    captured_handle = 0;
+    fixture.with_interp(&body_register_redefine_overwrites_body);
+    // Second registration declared two params, so the slot reflects
+    // the new definition rather than the old.
+    try testing.expectEqual(@as(i64, 2), captured_int);
+    const s = obj.obj_ensure_string(captured_handle);
+    try testing.expectEqualStrings("set second 2", slice_at(s.ptr, s.len));
+}
+
+// -- proc_register_compiled ----------------------------------------
+
+fn body_register_compiled_records_func_idx() void {
+    _ = procs.proc_register_compiled(
+        name_obj("test_proc_compiled_func"),
+        3, // n_params
+        77, // func_idx
+        0, // args_tail
+        2, // n_required
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_compiled_func"));
+    captured_bucket = bucket;
+    captured_int = @as(i64, procs.proc_get_func_idx(bucket));
+    captured_int2 = @as(i64, procs.proc_get_n_required(bucket));
+}
+
+test "proc_register_compiled stamps func_idx and n_required" {
+    captured_bucket = 0;
+    captured_int = 0;
+    captured_int2 = 0;
+    fixture.with_interp(&body_register_compiled_records_func_idx);
+    try testing.expect(captured_bucket != 0);
+    try testing.expectEqual(@as(i64, 77), captured_int);
+    try testing.expectEqual(@as(i64, 2), captured_int2);
+}
+
+fn body_register_compiled_with_args_tail() void {
+    _ = procs.proc_register_compiled(
+        name_obj("test_proc_args_tail"),
+        2,
+        88,
+        1, // args_tail = true
+        1, // n_required (one fixed arg before the tail)
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_args_tail"));
+    captured_int = @as(i64, procs.proc_get_args_tail(bucket));
+    captured_int2 = @as(i64, procs.proc_get_n_params(bucket));
+}
+
+test "proc_register_compiled records the args-tail variadic flag" {
+    captured_int = -1;
+    captured_int2 = 0;
+    fixture.with_interp(&body_register_compiled_with_args_tail);
+    try testing.expectEqual(@as(i64, 1), captured_int);
+    try testing.expectEqual(@as(i64, 2), captured_int2);
+}
+
+fn body_register_compiled_stamps_export_name() void {
+    _ = procs.proc_register_compiled(
+        name_obj("test_proc_export_name"),
+        0,
+        12,
+        0,
+        0,
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_export_name"));
+    const en = procs.proc_get_export_name(@bitCast(bucket));
+    captured_name_len = if (en.len < captured_name.len) en.len else captured_name.len;
+    if (captured_name_len > 0) {
+        const src: [*]const u8 = @ptrFromInt(en.ptr);
+        var i: usize = 0;
+        while (i < captured_name_len) : (i += 1) captured_name[i] = src[i];
+    }
+}
+
+test "proc_register_compiled stamps the registration-time export name in the sidecar" {
+    captured_name_len = 0;
+    fixture.with_interp(&body_register_compiled_stamps_export_name);
+    try testing.expect(captured_name_len > 0);
+    try testing.expectEqualStrings(
+        "test_proc_export_name",
+        captured_name[0..captured_name_len],
+    );
+}
+
+// -- proc_lookup miss path -----------------------------------------
+
+fn body_lookup_unknown_returns_zero() void {
+    captured_bucket = procs.proc_lookup(name_obj("test_proc_truly_does_not_exist"));
+}
+
+test "proc_lookup returns 0 for an unregistered name" {
+    captured_bucket = 1; // sentinel — must be overwritten
+    fixture.with_interp(&body_lookup_unknown_returns_zero);
+    try testing.expectEqual(@as(i32, 0), captured_bucket);
+}
+
+// -- proc_exists ---------------------------------------------------
+
+fn body_proc_exists_round_trip() void {
+    _ = procs.proc_register(
+        name_obj("test_proc_exists_yes"),
+        name_obj(""),
+        name_obj("return 1"),
+    );
+    captured_int = obj.obj_get_int(procs.proc_exists(name_obj("test_proc_exists_yes")));
+    captured_int2 = obj.obj_get_int(procs.proc_exists(name_obj("test_proc_exists_no")));
+}
+
+test "proc_exists returns 1 for registered, 0 for unknown" {
+    captured_int = -1;
+    captured_int2 = -1;
+    fixture.with_interp(&body_proc_exists_round_trip);
+    try testing.expectEqual(@as(i64, 1), captured_int);
+    try testing.expectEqual(@as(i64, 0), captured_int2);
+}
+
+// -- proc_get_name_ptr / _len round-trip ---------------------------
+
+fn body_get_name_round_trip() void {
+    _ = procs.proc_register(
+        name_obj("test_proc_name_round_trip"),
+        name_obj(""),
+        name_obj(""),
+    );
+    const bucket = procs.proc_lookup(name_obj("test_proc_name_round_trip"));
+    const np: u32 = @bitCast(procs.proc_get_name_ptr(bucket));
+    const nl: u32 = @bitCast(procs.proc_get_name_len(bucket));
+    captured_name_len = if (nl < captured_name.len) nl else captured_name.len;
+    if (captured_name_len > 0) {
+        const src: [*]const u8 = @ptrFromInt(np);
+        var i: usize = 0;
+        while (i < captured_name_len) : (i += 1) captured_name[i] = src[i];
+    }
+}
+
+test "proc_get_name_ptr / _len return the heap-copied registered name" {
+    captured_name_len = 0;
+    fixture.with_interp(&body_get_name_round_trip);
+    // Top-level procs register with bare names; the FQN is materialised
+    // lazily by ``ns_full_name``.  Here we just confirm the simple
+    // name is round-tripped.
+    try testing.expectEqualStrings(
+        "test_proc_name_round_trip",
+        captured_name[0..captured_name_len],
+    );
+}
+
+// -- proc_get_* on a 0 bucket all return 0 (defensive) --------------
+
+test "proc_get_* accessors on a 0 bucket all return 0" {
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_func_idx(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_n_params(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_args_tail(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_n_required(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_params(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_body(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_name_ptr(0));
+    try testing.expectEqual(@as(i32, 0), procs.proc_get_name_len(0));
+}
+
+// -- proc_set_body_source ------------------------------------------
+
+fn body_set_body_source_overwrites() void {
+    _ = procs.proc_register_compiled(
+        name_obj("test_proc_set_body_source"),
+        0,
+        99,
+        0,
+        0,
+    );
+    const new_body = name_obj("set updated 1");
+    _ = procs.proc_set_body_source(name_obj("test_proc_set_body_source"), new_body);
+    const bucket = procs.proc_lookup(name_obj("test_proc_set_body_source"));
+    captured_handle = procs.proc_get_body(bucket);
+}
+
+test "proc_set_body_source attaches a body TclObj to a compiled proc" {
+    captured_handle = 0;
+    fixture.with_interp(&body_set_body_source_overwrites);
+    try testing.expect(captured_handle != 0);
+    const s = obj.obj_ensure_string(captured_handle);
+    try testing.expectEqualStrings("set updated 1", slice_at(s.ptr, s.len));
+}
+
+// -- ns-resolution: qualified registration --------------------------
+
+fn body_register_qualified_lands_in_target_ns() void {
+    // ``::myns::myproc`` should land in the ``::myns`` namespace's
+    // cmd_table, not in the root.  After registration ``proc_lookup``
+    // from inside that ns must find it.
+    _ = ns.ns_create_from_fqn(@intCast(@intFromPtr("::test_proc_qualified_ns".ptr)),
+                              @intCast("::test_proc_qualified_ns".len));
+    _ = procs.proc_register(
+        name_obj("::test_proc_qualified_ns::myproc"),
+        name_obj(""),
+        name_obj("return ok"),
+    );
+    captured_bucket = procs.proc_lookup(name_obj("::test_proc_qualified_ns::myproc"));
+}
+
+test "proc_register on a ::-qualified name lands in the target namespace" {
+    captured_bucket = 0;
+    fixture.with_interp(&body_register_qualified_lands_in_target_ns);
+    try testing.expect(captured_bucket != 0);
+}


### PR DESCRIPTION
## Summary

Adds the dispatch + interp-internals slice of issue #268's wave-5
test plan, building on the catch-context + interp-state fixture from
PR #278 (#266).

Six new test files at `runtime/zig/`, 94 new test cases — full
suite goes 205 → 299 with all green:

| File | Cases | Coverage |
|---|---|---|
| `test_tcl_cmd_registry.zig` | 18 | `lookup` / `lookup_entry` / `lookup_sub` name-collision and arity bounds |
| `test_tcl_diag.zig` | 7 | site-id register and eval-context state machine |
| `test_tcl_frames.zig` | 17 | push/pop balance, `ALIAS_GLOBAL` + `ALIAS_EXT` resolution, `var_resolve` precedence, `depth_stash`/`restore` clamping |
| `test_tcl_catch.zig` | 15 | `error_flag`/`error_msg` state machine, nested catches, loop-flow flag consumption, `error_unknown_command` + `var_unset_error` formatting |
| `test_tcl_ns.zig` | 23 | root + child tree, `ns_full_name` FQN materialisation, `ns_resolve_qualified` primary + alt paths, export glob matching |
| `test_tcl_procs.zig` | 14 | `proc_register` / `proc_register_compiled` round-trip via `proc_lookup`, per-field accessors, qualified-name registration |

Test files live at `runtime/zig/` root rather than under their sibling
subdirectories because Zig 0.16's test module system rejects
`@import()` of files above the test's `root_source_file` path —
matches the existing `test_fixture.zig` placement and the rationale
in `runtime_test_fixture.zig`'s header comment.

The "Command builtins" leg of the issue (`test_eval`, `test_proc`,
`test_namespace`, `test_oo`) is left as follow-up — those exercise
the full `eval_command` pipeline and need broader setup than the
dispatch + interp internals do.  Issue #268 explicitly notes "the
rest can be piecemeal."

## Test plan

- [x] `zig build test` — 299/299 pass
- [x] `make prep-pr` — full Python suite green (10914 pass, 217 skipped, 7 xfailed)

https://claude.ai/code/session_015GaiUUx1Kha2MrwLXmDTZ9

---
_Generated by [Claude Code](https://claude.ai/code/session_015GaiUUx1Kha2MrwLXmDTZ9)_