### PR TITLE
Channel I/O: Match upstream Tcl error wording (issue #272)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,13 @@ test-tcl9-full: $(UV_STAMP) ## Full Tcl 9 suite; requires upstream source (night
 	cd $(ROOT) && $(UV) run --extra dev pytest tests/external/run_tcl9_tests.py -q \
 		--tcl9-required --tcl9-report=tmp/tcl9-report-full.json
 
+check-tcl9-tcltest-io: $(UV_STAMP) ## Run the four upstream I/O tcltest suites against the baseline (issue #276)
+	@echo "==> Running Tcl 9 I/O tcltest suites (chan / chanio / io / ioCmd) against baseline"
+	@mkdir -p $(ROOT)tmp
+	cd $(ROOT) && $(UV) run --extra dev pytest tests/external/run_tcl9_tests.py -q \
+		--tcl9-required --tcl9-report=tmp/tcl9-report-io.json \
+		-k "TestTcl9_chan or TestTcl9_chanio or TestTcl9_io or TestTcl9_ioCmd"
+
 tcl9-triage: $(UV_STAMP) ## Refresh docs/kcs/kcs-tcl9-triage.md from tmp/tcl9-report.json
 	@echo "==> Refreshing Tcl 9 triage table"
 	cd $(ROOT) && $(UV) run python scripts/tcl9_triage_report.py tmp/tcl9-report.json

--- a/runtime/zig/cmds/chan.zig
+++ b/runtime/zig/cmds/chan.zig
@@ -65,7 +65,7 @@ pub fn eval_fconfigure(words: []const i32) i32 {
         const s = obj.obj_ensure_string(words[i]);
         off = list_quote.list_elem_quote_nth(buf, off, s.ptr, s.len);
     }
-    const args_obj = obj_new_string(@intCast(buf), @intCast(off));
+    const args_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     return chan.tcl_cmd_fconfigure(fd, args_obj);
 }
 

--- a/runtime/zig/cmds/eval.zig
+++ b/runtime/zig/cmds/eval.zig
@@ -1,6 +1,7 @@
 // ``eval``, ``uplevel`` — script evaluation commands.
 
 const rt  = @import("../tcl_runtime.zig");
+const obj = @import("../valtypes/tcl_obj.zig");
 const reg = @import("../dispatch/tcl_cmd_registry.zig");
 
 const alloc             = rt.alloc;
@@ -35,7 +36,15 @@ fn eval_eval(words: []const i32) i32 {
                 off += 1;
             }
         }
-        return interp.eval_script(buf, off);
+        // Reclaim the joined-script scratch after eval_script
+        // returns — the bytes only need to live during evaluation
+        // (parser copies tokens into its own structures).  Without
+        // this, every multi-arg ``eval`` leaks ``total`` bytes,
+        // which io.test's tcltest helpers exercised on every test
+        // body and contributed to the leak driving #303.
+        const result = interp.eval_script(buf, off);
+        obj.free_sized(buf, total);
+        return result;
     }
     return 0;
 }

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -325,7 +325,7 @@ fn eval_time(words: []const i32) i32 {
         const d: [*]u8 = @ptrFromInt(buf + pi_s.len + k);
         d[0] = suffix[k];
     }
-    return rt.obj_new_string(@intCast(buf), @intCast(total));
+    return rt.obj_new_string(@bitCast(buf), @bitCast(total));
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/fs.zig
+++ b/runtime/zig/cmds/fs.zig
@@ -172,7 +172,7 @@ fn list_concat(a: i32, b: i32) i32 {
     for (0..sa.len) |i| out[i] = ap[i];
     out[sa.len] = ' ';
     for (0..sb.len) |i| out[sa.len + 1 + i] = bp[i];
-    return obj.obj_new_string(@intCast(buf), @intCast(total));
+    return obj.obj_new_string(@bitCast(buf), @bitCast(total));
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -66,7 +66,7 @@ fn eval_tcl_build_info(words: []const i32) i32 {
 /// for the lifetime of the module — we point ``OBJ_STR_PTR`` at
 /// them with ``OBJ_STR_CAP == 0`` (not owned, not freeable).
 fn obj_new_string_lit(comptime s: []const u8) i32 {
-    return obj_new_string(@intCast(@intFromPtr(s.ptr)), @intCast(s.len));
+    return obj_new_string(@bitCast(@intFromPtr(s.ptr)), @bitCast(s.len));
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/io.zig
+++ b/runtime/zig/cmds/io.zig
@@ -96,7 +96,7 @@ pub fn eval_read(words: []const i32) i32 {
         if (s.len > 0) {
             const p: [*]const u8 = @ptrFromInt(s.ptr);
             if (p[s.len - 1] == '\n') {
-                return obj_new_string(@intCast(s.ptr), @intCast(s.len - 1));
+                return obj_new_string(@bitCast(s.ptr), @bitCast(s.len - 1));
             }
         }
     }

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -181,7 +181,7 @@ fn eval_join(words: []const i32) i32 {
         const sp = alloc(1);
         const d: [*]u8 = @ptrFromInt(sp);
         d[0] = ' ';
-        return rt.tcl_cmd_join(words[1], obj_new_string(@intCast(sp), 1));
+        return rt.tcl_cmd_join(words[1], obj_new_string(@bitCast(sp), 1));
     }
     return obj_new_string(0, 0);
 }
@@ -241,7 +241,7 @@ fn eval_lrepeat(words: []const i32) i32 {
         rt.memcpy(result_buf + off, cycle_buf, cycle_off);
         off += cycle_off;
     }
-    return obj_new_string(@intCast(result_buf), @intCast(off));
+    return obj_new_string(@bitCast(result_buf), @bitCast(off));
 }
 
 fn eval_lassign(words: []const i32) i32 {
@@ -259,7 +259,7 @@ fn eval_lassign(words: []const i32) i32 {
             } else {
                 const buf = alloc(elem.len + 4);
                 const out_len = rt.copy_unbraced_elem(buf, list_s.ptr + elem.start, elem.len);
-                break :blk obj_new_string(@intCast(buf), @intCast(out_len));
+                break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
             }
         } else obj_new_string(0, 0);
         _ = frames.var_set(words[pi], val);
@@ -286,7 +286,7 @@ fn eval_lmap(words: []const i32) i32 {
         else blk: {
             const buf = alloc(elem.len + 4);
             const out_len = rt.copy_unbraced_elem(buf, list_s.ptr + elem.start, elem.len);
-            break :blk obj_new_string(@intCast(buf), @intCast(out_len));
+            break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
         };
         _ = frames.var_set(var_name, elem_val);
         const item = interp.eval_script(body_s.ptr, body_s.len);

--- a/runtime/zig/dispatch/tcl_dispatch.zig
+++ b/runtime/zig/dispatch/tcl_dispatch.zig
@@ -249,5 +249,5 @@ fn build_args_list(words: []const i32, fixed: u32) i32 {
             off = obj.list_elem_quote_nth(buf, off, s.ptr, s.len);
         }
     }
-    return obj.obj_new_string(@intCast(buf), @intCast(off));
+    return obj.obj_new_string(@bitCast(buf), @bitCast(off));
 }

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -292,7 +292,7 @@ pub fn error_unknown_command(cmd_obj: i32) void {
         const src: [*]const u8 = @ptrFromInt(s.ptr);
         for (0..s.len) |i| buf[prefix.len + i] = src[i];
     }
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     tcl_cmd_error(msg);
 }
 
@@ -326,6 +326,6 @@ pub export fn var_unset_error(name_obj: i32) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     tcl_cmd_error(msg);
 }

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -929,9 +929,20 @@ pub export fn var_resolve(name: i32) i32 {
             // raw ``!= 0`` test always passed and we always returned
             // ``global_get(qname)`` even for non-existent names.  Check
             // the wrapped int.
-            if (obj.obj_get_int(globals.global_exists(qname)) != 0) {
-                return globals.global_get(qname);
+            const exists = obj.obj_get_int(globals.global_exists(qname)) != 0;
+            if (exists) {
+                const v = globals.global_get(qname);
+                // Reclaim the qname temp + its backing buffer.  Without
+                // this every ``$var`` read inside a namespace
+                // accumulated a small leak that pushed io.test past the
+                // 2 GiB linear-memory ceiling and tripped a u32→i32
+                // ``@intCast`` panic in ``obj_new_string``.
+                obj.tcl_obj_release(qname);
+                obj.free_sized(buf, total);
+                return v;
             }
+            obj.tcl_obj_release(qname);
+            obj.free_sized(buf, total);
         }
     }
     // Fall through to root global

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -213,7 +213,7 @@ fn expr_atom(ptr: u32, len: u32, pos: *u32, skip: bool) i64 {
             (src[pos.*] >= 'A' and src[pos.*] <= 'Z') or
             (src[pos.*] >= '0' and src[pos.*] <= '9') or src[pos.*] == '_'))
         { pos.* += 1; }
-        const name = obj_new_string(@intCast(ptr + vs), @intCast(pos.* - vs));
+        const name = obj_new_string(@bitCast(ptr + vs), @bitCast(pos.* - vs));
         const val = frames.var_resolve(name);
         if (val != 0) return obj_get_int(val);
         return 0;
@@ -396,7 +396,7 @@ pub fn qualify_name(name: i32) i32 {
     buf[ns_full.len] = ':';
     buf[ns_full.len + 1] = ':';
     for (0..s.len) |i| buf[ns_full.len + 2 + i] = sp[i];
-    return obj_mod.obj_new_string(@intCast(buf_addr), @intCast(total));
+    return obj_mod.obj_new_string(@bitCast(buf_addr), @bitCast(total));
 }
 
 // -- upvar / uplevel helpers --
@@ -574,6 +574,12 @@ pub fn eval_while(words: []const i32) i32 {
     var result: i32 = 0;
     while (true) {
         if (eval_expr_str(cond_s.ptr, cond_s.len) == 0) break;
+        // Release the previous iteration's body result before
+        // overwriting (issue #303 — tight ``while`` loops on the
+        // interpreter path were leaking one TclObj per pass and
+        // pushing io.test past the wasm32 4 GiB linear-memory
+        // ceiling).
+        if (result != 0) obj_mod.tcl_obj_release(result);
         result = eval_script(body_s.ptr, body_s.len);
         if (rt.break_flag.* != 0) { rt.break_flag.* = 0; break; }
         if (rt.continue_flag.* != 0) { rt.continue_flag.* = 0; continue; }
@@ -588,16 +594,25 @@ pub fn eval_for(words: []const i32) i32 {
     const cond_s = obj_ensure_string(words[2]);
     const next_s = obj_ensure_string(words[3]);
     const body_s = obj_ensure_string(words[4]);
-    _ = eval_script(init_s.ptr, init_s.len);
+    // ``init`` and ``next`` clauses are evaluated for their side
+    // effects only — release any TclObj they produce so a tight
+    // ``for {set i 0} {$i < N} {incr i} {…}`` loop doesn't leak
+    // ``N`` per-iteration result objs.  Same handling for the
+    // body result on each subsequent overwrite (issue #303 root
+    // cause for the io.test 2 GiB cliff).
+    const init_res = eval_script(init_s.ptr, init_s.len);
+    if (init_res != 0) obj_mod.tcl_obj_release(init_res);
     if (has_signal()) return 0;
     var result: i32 = 0;
     while (true) {
         if (eval_expr_str(cond_s.ptr, cond_s.len) == 0) break;
+        if (result != 0) obj_mod.tcl_obj_release(result);
         result = eval_script(body_s.ptr, body_s.len);
         if (rt.break_flag.* != 0) { rt.break_flag.* = 0; break; }
         if (rt.continue_flag.* != 0) { rt.continue_flag.* = 0; }
         if (rt.error_flag.* != 0 or rt.return_flag.* != 0) return result;
-        _ = eval_script(next_s.ptr, next_s.len);
+        const next_res = eval_script(next_s.ptr, next_s.len);
+        if (next_res != 0) obj_mod.tcl_obj_release(next_res);
     }
     return result;
 }
@@ -617,9 +632,13 @@ pub fn eval_foreach(words: []const i32) i32 {
         else blk: {
             const buf = alloc(elem.len);
             const out_len = copy_unbraced_elem(buf, list_s.ptr + elem.start, elem.len);
-            break :blk obj_new_string(@intCast(buf), @intCast(out_len));
+            break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
         };
         _ = frames.var_set(var_name, elem_val);
+        // Release the prior body result before overwriting (issue
+        // #303 — same loop-leak pattern as ``eval_for`` /
+        // ``eval_while``).
+        if (result != 0) obj_mod.tcl_obj_release(result);
         result = eval_script(body_s.ptr, body_s.len);
         if (rt.break_flag.* != 0) { rt.break_flag.* = 0; break; }
         if (rt.continue_flag.* != 0) { rt.continue_flag.* = 0; continue; }
@@ -1079,7 +1098,7 @@ fn build_invocation_list(words: []const i32) i32 {
             off = obj_mod.list_elem_quote_nth(buf, off, s.ptr, s.len);
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 /// Internal: dispatch once the proc bucket is already resolved.
@@ -1809,6 +1828,13 @@ pub fn eval_script(script_ptr: u32, script_len: u32) i32 {
         pos = cmd.next;
         if (cmd.n_words == 0) continue;
 
+        // Release the previous command's result obj before
+        // overwriting (issue #303).  ``execute_parsed_command``
+        // hands the caller a +1-refcount handle — without this
+        // release, every script with N commands leaked N-1 result
+        // TclObjs and pushed long-lived test bundles past the
+        // wasm32 4 GiB linear-memory ceiling.
+        if (result != 0) obj_mod.tcl_obj_release(result);
         result = execute_parsed_command(cmd.src_ptr, cmd.tokens_ptr, cmd.tokens_len);
         if (has_signal()) return result;
     }
@@ -1838,6 +1864,9 @@ fn eval_cached_slab(slab: u32, body_ptr: u32, body_len: u32) i32 {
         // errors triggered inside the dispatched command.
         diag.current_eval_pos = if (i == 0) 0 else @bitCast(obj_mod.read_i32(parse_cache.command_record(slab, i - 1) + parse_cache.OFF_CR_NEXT_POS));
         const tokens_ptr = parse_cache.token_at(slab, tok_offset);
+        // Release prior command result before overwriting — same
+        // leak pattern as the cold path (issue #303).
+        if (result != 0) obj_mod.tcl_obj_release(result);
         result = execute_parsed_command(body_ptr, tokens_ptr, tok_len);
         if (has_signal()) return result;
         _ = next_pos;
@@ -1951,7 +1980,7 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
                 } else {
                     const buf = alloc(elem.len);
                     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
-                    expanded[ecount] = obj_new_string(@intCast(buf), @intCast(out_len));
+                    expanded[ecount] = obj_new_string(@bitCast(buf), @bitCast(out_len));
                 }
                 ecount += 1;
             }

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1565,7 +1565,7 @@ fn raise_expected_integer(o: i32) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     @import("tcl_catch.zig").tcl_cmd_error(msg);
 }
 

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -317,11 +317,16 @@ fn parse_uint(p: [*]const u8, len: u32) ?u32 {
 // having to special-case our wording.
 
 /// Concatenate a list of byte slices into a single heap buffer and
-/// raise it through the standard error path.
+/// raise it through the standard error path.  ``stubs.raise``
+/// internally copies the message into its own ``obj_new_string``-
+/// backed buffer, so we reclaim the scratch we built here once the
+/// call returns — otherwise every dynamic channel error in a long-
+/// running session leaked one slab (Codex review on PR #305).
 fn raise_parts(parts: []const []const u8) void {
     var total: u32 = 0;
     for (parts) |p| total += @intCast(p.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) return; // OOM — caller's diagnostic is already truncated.
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: u32 = 0;
     for (parts) |p| {
@@ -332,6 +337,7 @@ fn raise_parts(parts: []const []const u8) void {
     }
     const slice = @as([*]const u8, @ptrFromInt(buf_addr))[0..total];
     stubs.raise(slice);
+    obj.free_sized(buf_addr, total);
 }
 
 /// Render the bytes of a channel-name TclObj as an unowned slice.

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -882,7 +882,7 @@ fn buf_finish(b: ByteBuf) i32 {
         obj.free_sized(b.addr, b.cap);
         return obj_new_string(0, 0);
     }
-    const out = obj_new_string(@intCast(b.addr), @intCast(b.len));
+    const out = obj_new_string(@bitCast(b.addr), @bitCast(b.len));
     if (out != 0) {
         obj.write_i32(@as(u32, @intCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
     }

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -890,7 +890,7 @@ fn buf_finish(b: ByteBuf) i32 {
     }
     const out = obj_new_string(@bitCast(b.addr), @bitCast(b.len));
     if (out != 0) {
-        obj.write_i32(@as(u32, @intCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
+        obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
     }
     return out;
 }

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -308,6 +308,146 @@ fn parse_uint(p: [*]const u8, len: u32) ?u32 {
     return n;
 }
 
+// Channel-error wording helpers — issue #272.
+//
+// Each helper builds the upstream Tcl error message (matching
+// ``tmp/tcl9.0.3/generic/tclIO.c`` / ``tclIOCmd.c``) into a heap
+// buffer and routes it through ``stubs.raise`` so the per-suite
+// ``exact matching`` assertions in upstream ioCmd.test pass without
+// having to special-case our wording.
+
+/// Concatenate a list of byte slices into a single heap buffer and
+/// raise it through the standard error path.
+fn raise_parts(parts: []const []const u8) void {
+    var total: u32 = 0;
+    for (parts) |p| total += @intCast(p.len);
+    const buf_addr: u32 = obj.alloc(total);
+    const buf: [*]u8 = @ptrFromInt(buf_addr);
+    var off: u32 = 0;
+    for (parts) |p| {
+        for (p) |b| {
+            buf[off] = b;
+            off += 1;
+        }
+    }
+    const slice = @as([*]const u8, @ptrFromInt(buf_addr))[0..total];
+    stubs.raise(slice);
+}
+
+/// Render the bytes of a channel-name TclObj as an unowned slice.
+/// Returns an empty slice when the obj is null or empty so callers
+/// can still produce a well-formed quoted message.
+fn name_slice(name_obj: i32) []const u8 {
+    if (name_obj == 0) return "";
+    const s = obj_ensure_string(name_obj);
+    if (s.len == 0) return "";
+    const p: [*]const u8 = @ptrFromInt(s.ptr);
+    return p[0..s.len];
+}
+
+/// Recover the channel slot index from a ``*Channel`` pointer.
+/// Used by helper functions (``refill``, ``flush_chan``) that don't
+/// see the original name TclObj but still need to interpolate a
+/// channel name into an error message.
+fn slot_of(c: *const Channel) u32 {
+    const base = @intFromPtr(&channels[0]);
+    const off = @intFromPtr(c) - base;
+    return @intCast(off / @sizeOf(Channel));
+}
+
+/// Write the canonical name for ``slot`` (``stdin`` / ``stdout`` /
+/// ``stderr`` / ``fileN``) into ``dst`` and return how many bytes
+/// were written.  ``dst`` must be at least 16 bytes.
+fn write_slot_name(slot: u32, dst: []u8) u32 {
+    if (slot == 0) {
+        const s = "stdin";
+        for (s, 0..) |b, i| dst[i] = b;
+        return s.len;
+    }
+    if (slot == 1) {
+        const s = "stdout";
+        for (s, 0..) |b, i| dst[i] = b;
+        return s.len;
+    }
+    if (slot == 2) {
+        const s = "stderr";
+        for (s, 0..) |b, i| dst[i] = b;
+        return s.len;
+    }
+    dst[0] = 'f';
+    dst[1] = 'i';
+    dst[2] = 'l';
+    dst[3] = 'e';
+    var digits: [10]u8 = undefined;
+    var dlen: u32 = 0;
+    var v: u32 = slot;
+    if (v == 0) {
+        digits[0] = '0';
+        dlen = 1;
+    } else {
+        while (v > 0) : (v /= 10) {
+            digits[dlen] = '0' + @as(u8, @intCast(v % 10));
+            dlen += 1;
+        }
+    }
+    var i: u32 = 0;
+    while (i < dlen) : (i += 1) dst[4 + i] = digits[dlen - 1 - i];
+    return 4 + dlen;
+}
+
+/// ``can not find channel named "<name>"`` — matches
+/// ``tclIO.c::Tcl_GetChannel`` (``tmp/tcl9.0.3/generic/tclIO.c:1466``).
+fn raise_unknown_channel(name_obj: i32) void {
+    raise_parts(&.{ "can not find channel named \"", name_slice(name_obj), "\"" });
+}
+
+/// ``channel "<name>" wasn't opened for reading`` — matches
+/// ``tclIOCmd.c::Tcl_ReadObjCmd`` (``tclIOCmd.c:300``).
+fn raise_not_readable(name_obj: i32) void {
+    raise_parts(&.{ "channel \"", name_slice(name_obj), "\" wasn't opened for reading" });
+}
+
+/// ``channel "<name>" wasn't opened for writing`` — matches
+/// ``tclIOCmd.c::Tcl_PutsObjCmd`` (``tclIOCmd.c:161``).
+fn raise_not_writable(name_obj: i32) void {
+    raise_parts(&.{ "channel \"", name_slice(name_obj), "\" wasn't opened for writing" });
+}
+
+/// Build the ``can not find...`` / ``... wasn't opened...`` /
+/// ``error reading...`` family by slot when the caller doesn't have
+/// the original name TclObj (helpers like ``refill`` / ``flush_chan``
+/// see only ``*Channel``).
+fn raise_io_error_by_slot(c: *const Channel, prefix: []const u8, syscall: []const u8) void {
+    var name_buf: [16]u8 = undefined;
+    const nlen = write_slot_name(slot_of(c), &name_buf);
+    const name = name_buf[0..nlen];
+    raise_parts(&.{ prefix, "\"", name, "\": ", syscall });
+}
+
+fn raise_read_io_error(c: *const Channel, syscall: []const u8) void {
+    raise_io_error_by_slot(c, "error reading ", syscall);
+}
+
+fn raise_write_io_error(c: *const Channel, syscall: []const u8) void {
+    raise_io_error_by_slot(c, "error writing ", syscall);
+}
+
+fn raise_seek_io_error(name_obj: i32, syscall: []const u8) void {
+    raise_parts(&.{ "error during seek on \"", name_slice(name_obj), "\": ", syscall });
+}
+
+/// ``couldn't open "<path>": <syscall>`` — matches
+/// ``tclIOUtil.c::Tcl_FSOpenFileChannel`` (``tclIOUtil.c:2255``).
+fn raise_open_failed(path_obj: i32, syscall: []const u8) void {
+    raise_parts(&.{ "couldn't open \"", name_slice(path_obj), "\": ", syscall });
+}
+
+/// ``illegal access mode "<mode>"`` — matches
+/// ``tclIOUtil.c::TclGetOpenMode`` (``tclIOUtil.c:1518``).
+fn raise_illegal_access_mode(mode_obj: i32) void {
+    raise_parts(&.{ "illegal access mode \"", name_slice(mode_obj), "\"" });
+}
+
 /// Map a Tcl channel name to a slot index.  Accepts ``stdin`` /
 /// ``stdout`` / ``stderr`` (slots 0/1/2) and ``fileN`` (slot N if
 /// allocated).  Returns null on miss; callers raise via stubs.raise.
@@ -448,17 +588,17 @@ pub export fn tcl_cmd_open(path: i32, access: i32) i32 {
         return 0;
     }
     const parsed = parse_access(access) orelse {
-        stubs.raise("open: unrecognised access mode (use r/r+/w/w+/a/a+)");
+        raise_illegal_access_mode(access);
         return 0;
     };
     const fd = open_fn(path_cstr(path), parsed.flags, 0o644);
     if (fd < 0) {
-        stubs.raise("open: could not open file");
+        raise_open_failed(path, "i/o error");
         return 0;
     }
     const slot = alloc_slot() orelse {
         _ = close_fn(fd);
-        stubs.raise("open: too many channels");
+        stubs.raise("couldn't allocate channel");
         return 0;
     };
     channels[slot] = .{
@@ -499,7 +639,7 @@ pub export fn tcl_cmd_open(path: i32, access: i32) i32 {
 /// conservative direction.
 pub export fn tcl_cmd_close(chan: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("close: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     if (slot < 3) {
@@ -510,7 +650,7 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
         // a flush failure here is reported as an error so callers
         // notice silent data loss (broken pipe, disk full, …).
         if (!flush_chan(&channels[slot])) {
-            stubs.raise("close: write failed");
+            raise_write_io_error(&channels[slot], "i/o error");
             return 0;
         }
         return obj_new_string(0, 0);
@@ -561,7 +701,7 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
         .dec_raw = 0,
     };
     if (!flush_ok) {
-        stubs.raise("close: write failed");
+        raise_parts(&.{ "error writing \"", name_slice(chan), "\": i/o error" });
         return 0;
     }
     return obj_new_string(0, 0);
@@ -610,7 +750,7 @@ fn refill(c: *Channel) u32 {
         // become indistinguishable from a transport failure and
         // scripts loop forever waiting for a refill that's
         // already broken.
-        stubs.raise("read: I/O error");
+        raise_read_io_error(c, "i/o error");
         return 0;
     }
     c.buf_end = carry + @as(u32, @intCast(n));
@@ -778,12 +918,12 @@ fn translate_input(c: *Channel, byte: u8, prev_cr: *bool) struct { emit: bool, v
 /// string holding the bytes read (after CR/CRLF translation).
 pub export fn tcl_cmd_read(chan: i32, num_chars: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("read: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     const c = &channels[slot];
     if ((c.mode & MODE_READ) == 0) {
-        stubs.raise("read: channel not open for reading");
+        raise_not_readable(chan);
         return 0;
     }
     var want: i64 = -1;
@@ -791,15 +931,12 @@ pub export fn tcl_cmd_read(chan: i32, num_chars: i32) i32 {
         const ns = obj_ensure_string(num_chars);
         if (ns.len > 0) {
             const parsed = obj.try_parse_int(ns.ptr, ns.len) orelse {
-                // ``read $chan abc`` — Tcl reports
-                // ``expected integer but got "abc"``.  We surface a
-                // shorter message here; the upstream-wording sweep
-                // (#272) folds it into the canonical phrasing.
-                stubs.raise("read: expected integer but got non-integer numChars");
+                // Upstream wording: ``expected integer but got "<ns>"``.
+                raise_parts(&.{ "expected integer but got \"", name_slice(num_chars), "\"" });
                 return 0;
             };
             if (parsed < 0) {
-                stubs.raise("read: numChars must be non-negative");
+                raise_parts(&.{ "expected non-negative integer but got \"", name_slice(num_chars), "\"" });
                 return 0;
             }
             want = parsed;
@@ -825,12 +962,12 @@ pub export fn tcl_cmd_read(chan: i32, num_chars: i32) i32 {
 /// and the return value is the byte length (or -1 on EOF).
 pub export fn tcl_cmd_gets(chan: i32, var_name: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("gets: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     const c = &channels[slot];
     if ((c.mode & MODE_READ) == 0) {
-        stubs.raise("gets: channel not open for reading");
+        raise_not_readable(chan);
         return 0;
     }
     var line = buf_init(128);
@@ -872,7 +1009,7 @@ pub export fn tcl_cmd_gets(chan: i32, var_name: i32) i32 {
 /// position.
 pub export fn tcl_cmd_seek(chan: i32, offset: i32, origin: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("seek: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     const c = &channels[slot];
@@ -897,11 +1034,11 @@ pub export fn tcl_cmd_seek(chan: i32, offset: i32, origin: i32) i32 {
     // the buffered bytes would land at the new position rather than
     // the position they were intended for.
     if (!flush_chan(c)) {
-        stubs.raise("seek: write failed");
+        raise_write_io_error(c, "i/o error");
         return 0;
     }
     if (do_seek(c.fd, off_val, whence) == null) {
-        stubs.raise("seek: fd_seek failed");
+        raise_seek_io_error(chan, "i/o error");
         return 0;
     }
     c.buf_pos = 0;
@@ -920,7 +1057,7 @@ pub export fn tcl_cmd_seek(chan: i32, offset: i32, origin: i32) i32 {
 /// Subtracts any pre-read bytes still sitting in the pull buffer.
 pub export fn tcl_cmd_tell(chan: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("tell: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     const c = &channels[slot];
@@ -933,7 +1070,7 @@ pub export fn tcl_cmd_tell(chan: i32) i32 {
 /// otherwise.  Sticky: cleared by ``seek`` / ``close``.
 pub export fn tcl_cmd_eof(chan: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("eof: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     return obj_new_int(if (channels[slot].eof) 1 else 0);
@@ -944,7 +1081,7 @@ pub export fn tcl_cmd_eof(chan: i32) i32 {
 /// observed.  Always returns 0.
 pub export fn tcl_cmd_fblocked(chan: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("fblocked: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     _ = slot;
@@ -963,21 +1100,21 @@ pub export fn tcl_cmd_fcopy(in_chan: i32, out_chan: i32) i32 {
 
 pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
     const in_slot = resolve(in_chan) orelse {
-        stubs.raise("fcopy: unknown input channel");
+        raise_unknown_channel(in_chan);
         return 0;
     };
     const out_slot = resolve(out_chan) orelse {
-        stubs.raise("fcopy: unknown output channel");
+        raise_unknown_channel(out_chan);
         return 0;
     };
     const in_c = &channels[in_slot];
     const out_c = &channels[out_slot];
     if ((in_c.mode & MODE_READ) == 0) {
-        stubs.raise("fcopy: input channel not open for reading");
+        raise_not_readable(in_chan);
         return 0;
     }
     if ((out_c.mode & MODE_WRITE) == 0) {
-        stubs.raise("fcopy: output channel not open for writing");
+        raise_not_writable(out_chan);
         return 0;
     }
     var copied: i64 = 0;
@@ -996,7 +1133,7 @@ pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
     // input pull side), so any pending buffered output has to land
     // first or it would appear *after* the freshly copied bytes.
     if (!flush_chan(out_c)) {
-        stubs.raise("fcopy: write failed");
+        raise_write_io_error(out_c, "i/o error");
         return 0;
     }
     if (in_c.buf_pos < in_c.buf_end) {
@@ -1012,7 +1149,7 @@ pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
             while (rem > 0) {
                 const w = write_fn(out_c.fd, src + off, rem);
                 if (w <= 0) {
-                    stubs.raise("fcopy: write failed");
+                    raise_write_io_error(out_c, "i/o error");
                     return 0;
                 }
                 off += @intCast(w);
@@ -1037,7 +1174,7 @@ pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
             break;
         }
         if (n < 0) {
-            stubs.raise("fcopy: read failed");
+            raise_read_io_error(in_c, "i/o error");
             return 0;
         }
         var off: usize = 0;
@@ -1045,7 +1182,7 @@ pub fn fcopy_limited(in_chan: i32, out_chan: i32, max_bytes: i64) i32 {
         while (rem > 0) {
             const w = write_fn(out_c.fd, @ptrCast(&tmp[off]), rem);
             if (w <= 0) {
-                stubs.raise("fcopy: write failed");
+                raise_write_io_error(out_c, "i/o error");
                 return 0;
             }
             off += @intCast(w);
@@ -1170,11 +1307,11 @@ fn write_translated(c: *Channel, ptr: [*]const u8, len: u32) WriteResult {
 pub fn flush_chan_id(chan_id: i32) i32 {
     if (chan_id == 0) return obj_new_string(0, 0);
     const slot = resolve(chan_id) orelse {
-        stubs.raise("flush: unknown channel");
+        raise_unknown_channel(chan_id);
         return 0;
     };
     if (!flush_chan(&channels[slot])) {
-        stubs.raise("flush: write failed");
+        raise_write_io_error(&channels[slot], "i/o error");
         return 0;
     }
     return obj_new_string(0, 0);
@@ -1186,12 +1323,12 @@ pub fn flush_chan_id(chan_id: i32) i32 {
 /// when it sees a 2-arg form (``puts $fd "..."``).
 pub export fn tcl_cmd_puts_chan(chan: i32, msg: i32, nonewline: i32) i32 {
     const slot = resolve(chan) orelse {
-        stubs.raise("puts: unknown channel");
+        raise_unknown_channel(chan);
         return 0;
     };
     const c = &channels[slot];
     if ((c.mode & MODE_WRITE) == 0) {
-        stubs.raise("puts: channel not open for writing");
+        raise_not_writable(chan);
         return 0;
     }
     if (msg != 0) {
@@ -1201,7 +1338,7 @@ pub export fn tcl_cmd_puts_chan(chan: i32, msg: i32, nonewline: i32) i32 {
                 .ok => {},
                 .codec_err => return 0, // codec already raised a precise message
                 .io_err => {
-                    stubs.raise("puts: write failed");
+                    raise_write_io_error(c, "i/o error");
                     return 0;
                 },
             }
@@ -1213,7 +1350,7 @@ pub export fn tcl_cmd_puts_chan(chan: i32, msg: i32, nonewline: i32) i32 {
             .ok => {},
             .codec_err => return 0,
             .io_err => {
-                stubs.raise("puts: write failed");
+                raise_write_io_error(c, "i/o error");
                 return 0;
             },
         }
@@ -1418,7 +1555,7 @@ fn apply_option(c: *Channel, name_p: [*]const u8, name_len: u32, val_p: [*]const
         // arrive as a ``return false`` with a message already on
         // the error channel.
         if (!flush_chan(c)) {
-            stubs.raise("fconfigure: write failed");
+            raise_write_io_error(c, "i/o error");
             return false;
         }
         if (c.out_buf_addr != 0) {
@@ -1607,7 +1744,7 @@ pub export fn tcl_cmd_fconfigure(fd: i32, args: i32) i32 {
     const slot = resolve(fd) orelse {
         // Match the other channel commands' behaviour: an unknown
         // channel id is a hard error, not a silent no-op.
-        stubs.raise("fconfigure: unknown channel");
+        raise_unknown_channel(fd);
         return 0;
     };
     const c: *Channel = &channels[slot];

--- a/runtime/zig/io/tcl_clock.zig
+++ b/runtime/zig/io/tcl_clock.zig
@@ -617,12 +617,16 @@ fn render_format(
     if (buf == 0) return obj_new_string(0, 0);
     const out: [*]u8 = @ptrFromInt(buf);
     const off = expand_format(out, 0, fp[0..fmt_len], t, utoff, abbr, loc);
-    const out_obj = obj_new_string(@intCast(buf), @intCast(off));
+    // ``@bitCast`` (not ``@intCast``) — TclObj handles are opaque
+    // bit patterns; allocator addresses above 2 GiB are valid in
+    // wasm32 and would trip the saturating-narrow form's debug
+    // panic.  Issue #303.
+    const out_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     if (out_obj == 0) {
         obj.free_sized(buf, cap);
         return 0;
     }
-    obj.write_i32(@as(u32, @intCast(out_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
+    obj.write_i32(@as(u32, @bitCast(out_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
     return out_obj;
 }
 

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -341,7 +341,7 @@ pub export fn tcl_cmd_source(path: i32) i32 {
         stubs.raise("source: out of memory");
         return 0;
     }
-    obj.write_i32(@as(u32, @intCast(script_obj)) + obj.OBJ_STR_CAP, @bitCast(size));
+    obj.write_i32(@as(u32, @bitCast(script_obj)) + obj.OBJ_STR_CAP, @bitCast(size));
     const interp = @import("../interp/tcl_interp.zig");
     const result = interp.tcl_eval(script_obj);
     obj.tcl_obj_release(script_obj);

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -331,7 +331,7 @@ pub export fn tcl_cmd_source(path: i32) i32 {
     // bytes, then delegate to tcl_eval.  After eval returns, drop
     // our caller-owned reference; the deferred-free queue keeps
     // the buffer alive across any words still borrowing from it.
-    const script_obj = obj_new_string(@intCast(buf), @intCast(off));
+    const script_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     if (script_obj == 0) {
         // Header alloc OOM — free the read buffer ourselves (without
         // a TclObj header to attach it to, ``tcl_obj_release`` would
@@ -501,7 +501,7 @@ fn file_join(a: i32, b: i32) i32 {
     for (0..a_end) |i| buf[i] = ap[i];
     buf[a_end] = '/';
     for (0..bs.len) |i| buf[a_end + 1 + i] = bp[i];
-    return obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    return obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
 }
 
 fn file_dirname(a: i32) i32 {
@@ -516,7 +516,7 @@ fn file_dirname(a: i32) i32 {
     var end: u32 = i - 1;
     while (end > 0 and ap[end - 1] == '/') : (end -= 1) {}
     if (end == 0) return obj.obj_new_string_copy(@intFromPtr("/".ptr), 1);
-    return obj.obj_new_string(@intCast(as.ptr), @intCast(end));
+    return obj.obj_new_string(@bitCast(as.ptr), @bitCast(end));
 }
 
 fn file_tail(a: i32) i32 {
@@ -525,7 +525,7 @@ fn file_tail(a: i32) i32 {
     const ap: [*]const u8 = @ptrFromInt(as.ptr);
     var i: u32 = as.len;
     while (i > 0 and ap[i - 1] != '/') : (i -= 1) {}
-    return obj.obj_new_string(@intCast(as.ptr + i), @intCast(as.len - i));
+    return obj.obj_new_string(@bitCast(as.ptr + i), @bitCast(as.len - i));
 }
 
 fn file_rootname(a: i32) i32 {
@@ -536,7 +536,7 @@ fn file_rootname(a: i32) i32 {
     var i: u32 = as.len;
     while (i > 0 and ap[i - 1] != '/' and ap[i - 1] != '.') : (i -= 1) {}
     if (i == 0 or ap[i - 1] == '/') return a;
-    return obj.obj_new_string(@intCast(as.ptr), @intCast(i - 1));
+    return obj.obj_new_string(@bitCast(as.ptr), @bitCast(i - 1));
 }
 
 fn file_extension(a: i32) i32 {
@@ -547,7 +547,7 @@ fn file_extension(a: i32) i32 {
     while (i > 0 and ap[i - 1] != '/' and ap[i - 1] != '.') : (i -= 1) {}
     if (i == 0 or ap[i - 1] == '/') return obj.obj_new_string(0, 0);
     // Return ".ext" including the dot.
-    return obj.obj_new_string(@intCast(as.ptr + i - 1), @intCast(as.len - i + 1));
+    return obj.obj_new_string(@bitCast(as.ptr + i - 1), @bitCast(as.len - i + 1));
 }
 
 fn file_split(a: i32) i32 {
@@ -903,7 +903,7 @@ fn file_readlink(path: i32) i32 {
         stubs.raise("file readlink: path is not a symlink or is inaccessible");
         return 0;
     }
-    return obj.obj_new_string(@intCast(buf_addr), @intCast(n));
+    return obj.obj_new_string(@bitCast(buf_addr), @bitCast(n));
 }
 
 // --- glob ---
@@ -1078,7 +1078,7 @@ fn cstr_from_bytes(src: []const u8) [*:0]const u8 {
 /// caller doesn't have to construct intermediate TclObj wrappers.
 fn list_append(acc: i32, s_ptr: u32, s_len: u32) i32 {
     const list_mod = @import("../valtypes/tcl_list.zig");
-    const elem = obj_new_string(@intCast(s_ptr), @intCast(s_len));
+    const elem = obj_new_string(@bitCast(s_ptr), @bitCast(s_len));
     return list_mod.tcl_list(acc, elem);
 }
 

--- a/runtime/zig/parse/tcl_subst.zig
+++ b/runtime/zig/parse/tcl_subst.zig
@@ -46,7 +46,7 @@ pub fn subst_flagged(
         if (src[i] == '\\') has_backslash = true;
     }
     if (!has_dollar and !has_bracket and (!do_bs or !has_backslash)) {
-        return obj_new_string(@intCast(wptr), @intCast(wlen));
+        return obj_new_string(@bitCast(wptr), @bitCast(wlen));
     }
     // S6.3: route the two per-piece scratch buffers and every
     // ``esc_ptr`` escape allocation through the arena.  The
@@ -121,8 +121,15 @@ pub fn subst_flagged(
                 while (i < wlen and src[i] != '}') i += 1;
                 const ve = i;
                 if (i < wlen) i += 1;
-                const name_obj = obj_new_string(@intCast(wptr + vs), @intCast(ve - vs));
+                const name_obj = obj_new_string(@bitCast(wptr + vs), @bitCast(ve - vs));
                 const val = frames.var_resolve(name_obj);
+                // Release the temp name TclObj immediately — its
+                // bytes were borrowed from the source script and
+                // the lookup machinery doesn't retain a reference.
+                // Issue #303: each ``${var}`` substitution leaked
+                // one obj header per evaluation and pushed long-
+                // running scripts past the wasm32 4 GiB ceiling.
+                obj_mod.tcl_obj_release(name_obj);
                 if (val != 0) {
                     const sv = obj_ensure_string(val);
                     push_piece(pieces_buf, &n_pieces, &total_out, sv.ptr, sv.len);
@@ -137,7 +144,7 @@ pub fn subst_flagged(
                 {
                     i += 1;
                 }
-                const name_obj = obj_new_string(@intCast(wptr + vstart), @intCast(i - vstart));
+                const name_obj = obj_new_string(@bitCast(wptr + vstart), @bitCast(i - vstart));
                 // Array-element form ``$arr(idx)``: when the next byte
                 // is ``(`` we consume up to the matching ``)``,
                 // recursively substitute the index span (so
@@ -155,6 +162,12 @@ pub fn subst_flagged(
                     if (i < wlen) i += 1; // consume ')'
                     const key_obj = subst_flagged(wptr + ks, ke - ks, do_vars, do_cmds, do_bs);
                     const elem = tcl_array.array_get(name_obj, key_obj);
+                    // Release the per-substitution temps — both
+                    // ``name_obj`` (built from the source span) and
+                    // ``key_obj`` (returned by the recursive
+                    // subst) are scratch.  Issue #303 leak fix.
+                    obj_mod.tcl_obj_release(name_obj);
+                    if (key_obj != 0) obj_mod.tcl_obj_release(key_obj);
                     if (elem != 0) {
                         const sv = obj_ensure_string(elem);
                         push_piece(pieces_buf, &n_pieces, &total_out, sv.ptr, sv.len);
@@ -164,6 +177,7 @@ pub fn subst_flagged(
                     }
                 } else {
                     const val = frames.var_resolve(name_obj);
+                    obj_mod.tcl_obj_release(name_obj);
                     if (val != 0) {
                         const sv = obj_ensure_string(val);
                         push_piece(pieces_buf, &n_pieces, &total_out, sv.ptr, sv.len);
@@ -264,5 +278,5 @@ pub fn subst_flagged(
     // retain the source or copy bytes, subst_flagged keeps the
     // bytes alive (treated as a literal buffer) — same contract
     // the implementation had before this OOM-hardening pass.
-    return obj_new_string(@intCast(buf), @intCast(out));
+    return obj_new_string(@bitCast(buf), @bitCast(out));
 }

--- a/runtime/zig/sched/tcl_sched.zig
+++ b/runtime/zig/sched/tcl_sched.zig
@@ -116,7 +116,7 @@ fn format_id(id: u32) i32 {
     const dst: [*]u8 = @ptrFromInt(out);
     var i: u32 = 0;
     while (i < off) : (i += 1) dst[i] = buf[i];
-    return obj_new_string(@intCast(out), @intCast(off));
+    return obj_new_string(@bitCast(out), @bitCast(off));
 }
 
 /// Parse ``after#N``.  Returns the id, or 0 on miss.
@@ -246,7 +246,7 @@ pub fn info_all() i32 {
         off += 1;
     }
     if (off > 0) off -= 1; // strip trailing space
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 fn write_id(dst: [*]u8, off_in: u32, id: u32) u32 {
@@ -300,7 +300,7 @@ fn build_info_pair(script_obj: i32, kind: []const u8) i32 {
     const dst: [*]u8 = @ptrFromInt(buf);
     dst[off] = ' '; off += 1;
     for (kind) |c| { dst[off] = c; off += 1; }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // -- Dispatch -----------------------------------------------------------------

--- a/runtime/zig/stubs/tcl_env_stubs.zig
+++ b/runtime/zig/stubs/tcl_env_stubs.zig
@@ -76,7 +76,7 @@ pub export fn tcl_cmd_package_cmd(sub: i32, arg: i32) i32 {
             const buf = obj.alloc(1);
             const d: [*]u8 = @ptrFromInt(buf);
             d[0] = '1';
-            return obj.obj_new_string(@intCast(buf), 1);
+            return obj.obj_new_string(@bitCast(buf), 1);
         }
     }
     return obj.obj_new_string(0, 0);
@@ -117,7 +117,7 @@ pub export fn tcl_cmd_apply(lambda: i32, args: i32) i32 {
         else blk: {
             const buf = rt.alloc(elem.len + 4);
             const out_len = rt.copy_unbraced_elem(buf, args_s.ptr + elem.start, elem.len);
-            break :blk rt.obj_new_string(@intCast(buf), @intCast(out_len));
+            break :blk rt.obj_new_string(@bitCast(buf), @bitCast(out_len));
         };
         words_ptr[2 + ai] = elem_obj;
     }

--- a/runtime/zig/stubs/tcl_stubs.zig
+++ b/runtime/zig/stubs/tcl_stubs.zig
@@ -33,7 +33,7 @@ pub fn unsupported(name: []const u8) void {
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (prefix, 0..) |c, i| buf[i] = c;
     for (name, 0..) |c, i| buf[prefix.len + i] = c;
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -51,7 +51,7 @@ pub fn raise(msg: []const u8) void {
     const buf_addr: u32 = obj.alloc(@intCast(msg.len));
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (msg, 0..) |c, i| buf[i] = c;
-    const msg_obj = obj.obj_new_string(@intCast(buf_addr), @intCast(msg.len));
+    const msg_obj = obj.obj_new_string(@bitCast(buf_addr), @bitCast(msg.len));
     catch_mod.tcl_cmd_error(msg_obj);
 }
 
@@ -82,6 +82,6 @@ pub fn unsupported_sub(cmd: []const u8, sub: []const u8) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     catch_mod.tcl_cmd_error(msg);
 }

--- a/runtime/zig/test_tcl_arith.zig
+++ b/runtime/zig/test_tcl_arith.zig
@@ -27,7 +27,7 @@ fn floatObj(v: f64) i32 {
 }
 
 fn stringObj(s: []const u8) i32 {
-    return obj.obj_new_string(@intCast(@intFromPtr(s.ptr)), @intCast(s.len));
+    return obj.obj_new_string(@bitCast(@intFromPtr(s.ptr)), @bitCast(s.len));
 }
 
 fn expectInt(o: i32, expected: i64) !void {

--- a/runtime/zig/test_tcl_dict.zig
+++ b/runtime/zig/test_tcl_dict.zig
@@ -20,7 +20,7 @@ const dict = @import("valtypes/tcl_dict.zig");
 // ---- helpers --------------------------------------------------------
 
 fn s(v: []const u8) i32 {
-    return obj.obj_new_string(@intCast(@intFromPtr(v.ptr)), @intCast(v.len));
+    return obj.obj_new_string(@bitCast(@intFromPtr(v.ptr)), @bitCast(v.len));
 }
 
 fn bytes(o: i32) []const u8 {

--- a/runtime/zig/test_tcl_format.zig
+++ b/runtime/zig/test_tcl_format.zig
@@ -22,7 +22,7 @@ const fixture = @import("runtime_test_fixture.zig");
 // ---- helpers --------------------------------------------------------
 
 fn s(v: []const u8) i32 {
-    return obj.obj_new_string(@intCast(@intFromPtr(v.ptr)), @intCast(v.len));
+    return obj.obj_new_string(@bitCast(@intFromPtr(v.ptr)), @bitCast(v.len));
 }
 
 fn i(v: i64) i32 {

--- a/runtime/zig/test_tcl_list_ops.zig
+++ b/runtime/zig/test_tcl_list_ops.zig
@@ -17,7 +17,7 @@ const list = @import("valtypes/tcl_list.zig");
 // ---- helpers --------------------------------------------------------
 
 fn s(v: []const u8) i32 {
-    return obj.obj_new_string(@intCast(@intFromPtr(v.ptr)), @intCast(v.len));
+    return obj.obj_new_string(@bitCast(@intFromPtr(v.ptr)), @bitCast(v.len));
 }
 
 fn i(v: i64) i32 {

--- a/runtime/zig/test_tcl_ns.zig
+++ b/runtime/zig/test_tcl_ns.zig
@@ -242,7 +242,7 @@ test "ns_export with empty pattern is a no-op" {
 // -- global_set / global_get / global_exists -----------------------
 
 fn body_global_set_get_round_trip() void {
-    const name = obj.obj_new_string_copy(@intCast(@intFromPtr("g_value".ptr)), 7);
+    const name = obj.obj_new_string_copy(@bitCast(@intFromPtr("g_value".ptr)), 7);
     _ = ns.global_set(name, obj.obj_new_int(123));
     captured_int = obj.obj_get_int(ns.global_get(name));
     captured_exists = obj.obj_get_int(ns.global_exists(name));
@@ -260,7 +260,7 @@ test "global_set / global_get / global_exists round-trip" {
 }
 
 fn body_global_exists_misses() void {
-    const name = obj.obj_new_string_copy(@intCast(@intFromPtr("never_set_global".ptr)), 16);
+    const name = obj.obj_new_string_copy(@bitCast(@intFromPtr("never_set_global".ptr)), 16);
     captured_exists = obj.obj_get_int(ns.global_exists(name));
 }
 

--- a/runtime/zig/test_tcl_regex.zig
+++ b/runtime/zig/test_tcl_regex.zig
@@ -30,7 +30,7 @@ const fixture = @import("runtime_test_fixture.zig");
 // ---- helpers --------------------------------------------------------
 
 fn s(v: []const u8) i32 {
-    return obj.obj_new_string(@intCast(@intFromPtr(v.ptr)), @intCast(v.len));
+    return obj.obj_new_string(@bitCast(@intFromPtr(v.ptr)), @bitCast(v.len));
 }
 
 fn bytes(o: i32) []const u8 {

--- a/runtime/zig/test_tcl_string_ops.zig
+++ b/runtime/zig/test_tcl_string_ops.zig
@@ -19,7 +19,7 @@ const str = @import("valtypes/tcl_string.zig");
 // ---- helpers --------------------------------------------------------
 
 fn s(v: []const u8) i32 {
-    return obj.obj_new_string(@intCast(@intFromPtr(v.ptr)), @intCast(v.len));
+    return obj.obj_new_string(@bitCast(@intFromPtr(v.ptr)), @bitCast(v.len));
 }
 
 fn i(v: i64) i32 {

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -223,7 +223,7 @@ fn raise_float_in_bitwise(o: i32, op_sym: []const u8, position: []const u8) void
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
 }
 
@@ -264,7 +264,7 @@ fn raise_float_in_unary_bitwise(o: i32, op_sym: []const u8) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@intCast(buf_addr), @intCast(total));
+    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
     @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
 }
 

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -342,6 +342,11 @@ fn normalize_ns_name(name: i32) i32 {
     while (i + 1 < sn.len) : (i += 1) {
         if (sp[i] == ':' and sp[i + 1] == ':') {
             const buf = alloc(2 + sn.len);
+            // OOM — fall back to the unqualified form rather than a
+            // null-pointer trap.  Caller's directory probe will miss
+            // and either signal "no such array" cleanly or trip a
+            // Tcl-level error from a higher allocator.
+            if (buf == 0) return name;
             const d: [*]u8 = @ptrFromInt(buf);
             d[0] = ':';
             d[1] = ':';

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -644,7 +644,7 @@ fn dict_rebuild_without_pair(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64) 
         obj.free_sized(buf, cap);
         return 0;
     }
-    obj.write_i32(@as(u32, @intCast(out)) + obj.OBJ_STR_CAP, @bitCast(cap));
+    obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(cap));
     return out;
 }
 
@@ -695,7 +695,7 @@ fn dict_rebuild_with_value(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64, vp
         obj.free_sized(buf, cap);
         return 0;
     }
-    obj.write_i32(@as(u32, @intCast(out)) + obj.OBJ_STR_CAP, @bitCast(cap));
+    obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(cap));
     return out;
 }
 
@@ -726,7 +726,7 @@ fn dict_append_pair(sd_ptr: u32, sd_len: u32, kp: u32, kl: u32, vp: u32, vl: u32
     off = list_elem_quote_nth(buf, off, vp, vl);
     const new_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     if (new_obj != 0) {
-        obj.write_i32(@as(u32, @intCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
+        obj.write_i32(@as(u32, @bitCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
     }
     return new_obj;
 }

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -639,7 +639,7 @@ fn dict_rebuild_without_pair(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64) 
     // Without this the rebuilt-dict buffer would leak on every
     // ``dict unset`` (or any caller that releases the returned
     // dict TclObj).
-    const out = obj_new_string(@intCast(buf), @intCast(off));
+    const out = obj_new_string(@bitCast(buf), @bitCast(off));
     if (out == 0) {
         obj.free_sized(buf, cap);
         return 0;
@@ -690,7 +690,7 @@ fn dict_rebuild_with_value(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64, vp
             }
         }
     }
-    const out = obj_new_string(@intCast(buf), @intCast(off));
+    const out = obj_new_string(@bitCast(buf), @bitCast(off));
     if (out == 0) {
         obj.free_sized(buf, cap);
         return 0;
@@ -724,7 +724,7 @@ fn dict_append_pair(sd_ptr: u32, sd_len: u32, kp: u32, kl: u32, vp: u32, vl: u32
     d[0] = ' ';
     off += 1;
     off = list_elem_quote_nth(buf, off, vp, vl);
-    const new_obj = obj_new_string(@intCast(buf), @intCast(off));
+    const new_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     if (new_obj != 0) {
         obj.write_i32(@as(u32, @intCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
     }
@@ -806,7 +806,7 @@ pub export fn dict_keys(dict: i32) i32 {
             off += elem.len;
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // Exported: dict values — return a list of all values in the dict.
@@ -838,7 +838,7 @@ pub export fn dict_values(dict: i32) i32 {
             off += elem.len;
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // Exported: dict size — number of key-value pairs.

--- a/runtime/zig/valtypes/tcl_encoding.zig
+++ b/runtime/zig/valtypes/tcl_encoding.zig
@@ -252,7 +252,7 @@ pub fn buf_to_obj(b: ByteBuf) i32 {
     }
     const out = obj_new_string(@bitCast(b.addr), @bitCast(b.len));
     if (out != 0) {
-        obj.write_i32(@as(u32, @intCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
+        obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
     }
     return out;
 }

--- a/runtime/zig/valtypes/tcl_encoding.zig
+++ b/runtime/zig/valtypes/tcl_encoding.zig
@@ -70,6 +70,7 @@ pub const Enc = enum(u8) {
     utf16le,
     utf16be,
     utf16, // alias for utf16le on this build
+    koi8_r,
 };
 
 fn eq(a: [*]const u8, alen: u32, literal: []const u8) bool {
@@ -100,6 +101,7 @@ pub fn resolve_name(p: [*]const u8, len: u32) Resolved {
     if (eq(p, len, "utf-16")) return .{ .enc = .utf16, .known_unsupported = false };
     if (eq(p, len, "utf-16le")) return .{ .enc = .utf16le, .known_unsupported = false };
     if (eq(p, len, "utf-16be")) return .{ .enc = .utf16be, .known_unsupported = false };
+    if (eq(p, len, "koi8-r")) return .{ .enc = .koi8_r, .known_unsupported = false };
 
     // Tcl-core codecs we don't model yet.  Distinguishing these from
     // an accidental typo means we can trap with a precise
@@ -117,7 +119,7 @@ pub fn resolve_name(p: [*]const u8, len: u32) Resolved {
         eq(p, len, "euc-kr") or eq(p, len, "euc-cn") or
         eq(p, len, "gb2312") or eq(p, len, "gb12345") or
         eq(p, len, "gb1988") or eq(p, len, "big5") or
-        eq(p, len, "koi8-r") or eq(p, len, "koi8-u") or
+        eq(p, len, "koi8-u") or
         eq(p, len, "tis-620"))
     {
         return .{ .enc = null, .known_unsupported = true };
@@ -148,6 +150,42 @@ fn cp1252_encode_extra(cp: u32) ?u8 {
     while (i < 32) : (i += 1) {
         const v = cp1252_byte_to_cp[i];
         if (v != 0 and @as(u32, v) == cp) return 0x80 + i;
+    }
+    return null;
+}
+
+// -- koi8-r lookup table ----------------------------------------
+//
+// Single-byte cyrillic encoding.  Bytes 0x00–0x7F are ASCII; 0x80–0xFF
+// map to the codepoints in :data:`koi8r_byte_to_cp` (offset 0x80).
+// Source: ``tmp/tcl9.0.3/library/encoding/koi8-r.enc``.
+
+const koi8r_byte_to_cp = [_]u16{
+    0x2500, 0x2502, 0x250C, 0x2510, 0x2514, 0x2518, 0x251C, 0x2524,
+    0x252C, 0x2534, 0x253C, 0x2580, 0x2584, 0x2588, 0x258C, 0x2590,
+    0x2591, 0x2592, 0x2593, 0x2320, 0x25A0, 0x2219, 0x221A, 0x2248,
+    0x2264, 0x2265, 0x00A0, 0x2321, 0x00B0, 0x00B2, 0x00B7, 0x00F7,
+    0x2550, 0x2551, 0x2552, 0x0451, 0x2553, 0x2554, 0x2555, 0x2556,
+    0x2557, 0x2558, 0x2559, 0x255A, 0x255B, 0x255C, 0x255D, 0x255E,
+    0x255F, 0x2560, 0x2561, 0x0401, 0x2562, 0x2563, 0x2564, 0x2565,
+    0x2566, 0x2567, 0x2568, 0x2569, 0x256A, 0x256B, 0x256C, 0x00A9,
+    0x044E, 0x0430, 0x0431, 0x0446, 0x0434, 0x0435, 0x0444, 0x0433,
+    0x0445, 0x0438, 0x0439, 0x043A, 0x043B, 0x043C, 0x043D, 0x043E,
+    0x043F, 0x044F, 0x0440, 0x0441, 0x0442, 0x0443, 0x0436, 0x0432,
+    0x044C, 0x044B, 0x0437, 0x0448, 0x044D, 0x0449, 0x0447, 0x044A,
+    0x042E, 0x0410, 0x0411, 0x0426, 0x0414, 0x0415, 0x0424, 0x0413,
+    0x0425, 0x0418, 0x0419, 0x041A, 0x041B, 0x041C, 0x041D, 0x041E,
+    0x041F, 0x042F, 0x0420, 0x0421, 0x0422, 0x0423, 0x0416, 0x0412,
+    0x042C, 0x042B, 0x0417, 0x0428, 0x042D, 0x0429, 0x0427, 0x042A,
+};
+
+fn koi8r_encode_extra(cp: u32) ?u8 {
+    // Reverse lookup over the 128-entry table.  Linear scan — koi8-r
+    // is rarely exercised on the write side, so the table size /
+    // simplicity wins out over a hash.
+    var i: u8 = 0;
+    while (i < 128) : (i += 1) {
+        if (@as(u32, koi8r_byte_to_cp[i]) == cp) return 0x80 + i;
     }
     return null;
 }
@@ -352,6 +390,13 @@ pub fn decode_step(enc: Enc, src: u32, len: u32) StepResult {
             const m = cp1252_byte_to_cp[c - 0x80];
             return .{ .consumed = 1, .cp = if (m == 0) 0xFFFD else @as(u32, m), .needs_more = false };
         },
+        .koi8_r => {
+            const c = p[0];
+            if (c < 0x80) {
+                return .{ .consumed = 1, .cp = c, .needs_more = false };
+            }
+            return .{ .consumed = 1, .cp = @as(u32, koi8r_byte_to_cp[c - 0x80]), .needs_more = false };
+        },
         .utf16le, .utf16, .utf16be => {
             if (len < 2) return .{ .consumed = 0, .cp = 0, .needs_more = true };
             const be = (enc == .utf16be);
@@ -458,6 +503,17 @@ pub fn encode(enc: Enc, src: u32, len: u32) ?ByteBuf {
                     return null;
                 }
             },
+            .koi8_r => {
+                if (d.cp <= 0x7F) {
+                    buf_push(&out, @intCast(d.cp));
+                } else if (koi8r_encode_extra(d.cp)) |b| {
+                    buf_push(&out, b);
+                } else {
+                    buf_release(out);
+                    stubs.raise("encoding koi8-r: codepoint not representable");
+                    return null;
+                }
+            },
             .utf16le, .utf16, .utf16be => {
                 const be = (enc == .utf16be);
                 if (d.cp < 0x10000) {
@@ -524,6 +580,16 @@ pub fn decode(enc: Enc, src: u32, len: u32) ?ByteBuf {
         .iso8859_1 => {
             for (0..len) |i| utf8_emit(&out, sp[i]);
         },
+        .koi8_r => {
+            for (0..len) |i| {
+                const c = sp[i];
+                if (c < 0x80) {
+                    utf8_emit(&out, c);
+                } else {
+                    utf8_emit(&out, koi8r_byte_to_cp[c - 0x80]);
+                }
+            }
+        },
         .cp1252 => {
             for (0..len) |i| {
                 const c = sp[i];
@@ -571,7 +637,7 @@ pub fn decode(enc: Enc, src: u32, len: u32) ?ByteBuf {
 
 // -- ``encoding`` command dispatch -------------------------------
 
-const NAMES_LIST: []const u8 = "ascii cp1252 identity iso8859-1 utf-8 utf-16 utf-16be utf-16le";
+const NAMES_LIST: []const u8 = "ascii cp1252 identity iso8859-1 koi8-r utf-8 utf-16 utf-16be utf-16le";
 
 /// Dispatch ``encoding <subcmd> ?arg1? ?arg2?``.  Codegen always
 /// pushes three i32 slots; missing args are 0 (empty string).

--- a/runtime/zig/valtypes/tcl_encoding.zig
+++ b/runtime/zig/valtypes/tcl_encoding.zig
@@ -250,7 +250,7 @@ pub fn buf_to_obj(b: ByteBuf) i32 {
         obj.free_sized(b.addr, b.cap);
         return obj_new_string(0, 0);
     }
-    const out = obj_new_string(@intCast(b.addr), @intCast(b.len));
+    const out = obj_new_string(@bitCast(b.addr), @bitCast(b.len));
     if (out != 0) {
         obj.write_i32(@as(u32, @intCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
     }

--- a/runtime/zig/valtypes/tcl_format.zig
+++ b/runtime/zig/valtypes/tcl_format.zig
@@ -156,7 +156,7 @@ pub export fn tcl_cmd_format(fmt: i32, a1: i32, a2: i32, a3: i32) i32 {
         );
     }
 
-    return obj_new_string(@intCast(buf_addr), @intCast(off));
+    return obj_new_string(@bitCast(buf_addr), @bitCast(off));
 }
 
 fn emit_conversion(

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -144,7 +144,7 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
     }
     const new_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     if (new_obj != 0) {
-        obj.write_i32(@as(u32, @intCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
+        obj.write_i32(@as(u32, @bitCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
     }
     return new_obj;
 }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -142,7 +142,7 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
     } else {
         off = list_elem_quote(buf, off, sv_ptr, sv_len);
     }
-    const new_obj = obj_new_string(@intCast(buf), @intCast(off));
+    const new_obj = obj_new_string(@bitCast(buf), @bitCast(off));
     if (new_obj != 0) {
         obj.write_i32(@as(u32, @intCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
     }
@@ -167,7 +167,7 @@ pub export fn tcl_list(a: i32, b: i32) i32 {
     if (sa.len == 0) {
         const buf = alloc(sb.len * 2 + 4);
         const off = list_elem_quote(buf, 0, sb.ptr, sb.len);
-        return obj_new_string(@intCast(buf), @intCast(off));
+        return obj_new_string(@bitCast(buf), @bitCast(off));
     }
     const buf = alloc(sa.len + sb.len * 2 + 8);
     memcpy(buf, sa.ptr, sa.len);
@@ -176,7 +176,7 @@ pub export fn tcl_list(a: i32, b: i32) i32 {
     d[0] = ' ';
     off += 1;
     off = list_elem_quote_nth(buf, off, sb.ptr, sb.len);
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // Copy one list element into *buf* at offset *off*, re-adding the
@@ -250,7 +250,7 @@ pub export fn tcl_cmd_list_index(list: i32, idx: i32) i32 {
     // Unbraced element: process backslash escapes.
     const buf = alloc(elem.len);
     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
-    return obj_new_string(@intCast(buf), @intCast(out_len));
+    return obj_new_string(@bitCast(buf), @bitCast(out_len));
 }
 
 // Exported: list range — extract elements [first..last] (inclusive).
@@ -286,7 +286,7 @@ pub export fn tcl_cmd_list_range(list: i32, first: i32, last: i32) i32 {
             result_len += elem.len;
         }
     }
-    return obj_new_string(@intCast(result_buf), @intCast(result_len));
+    return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
 }
 
 // Exported: tail of a list — elements from *start* onwards.  Used by
@@ -350,7 +350,7 @@ pub export fn tcl_cmd_list_sort(list: i32) i32 {
         memcpy(result_buf + result_len, e_ptr, e_len);
         result_len += e_len;
     }
-    return obj_new_string(@intCast(result_buf), @intCast(result_len));
+    return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
 }
 
 // Exported: list search — default Tcl ``lsearch`` semantics, which
@@ -415,7 +415,7 @@ pub export fn tcl_cmd_list_reverse(list: i32) i32 {
         // into siblings.
         result_len = append_list_element(result_buf, result_len, s.ptr, elem);
     }
-    return obj_new_string(@intCast(result_buf), @intCast(result_len));
+    return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
 }
 
 // Exported: list insert — ``linsert list index value1 ?value2 ...?``.
@@ -482,7 +482,7 @@ pub export fn tcl_cmd_list_insert(list: i32, index: i32, value: i32) i32 {
         const quoter: *const fn (u32, u32, u32, u32) u32 = if (off == 0) &list_elem_quote else &list_elem_quote_nth;
         off = quoter(buf, off, sv.ptr, sv.len);
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // Exported: list replace — ``lreplace list first last ?value1 ...?``.
@@ -553,7 +553,7 @@ pub export fn tcl_cmd_list_replace(list: i32, first: i32, last: i32, value: i32)
         const quoter: *const fn (u32, u32, u32, u32) u32 = if (off == 0) &list_elem_quote else &list_elem_quote_nth;
         off = quoter(buf, off, sv_ptr, sv_len);
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // Exported: list set — ``lset varName ?index ...? newValue``.
@@ -672,7 +672,7 @@ fn lset_recurse(
             off = append_list_element(buf, off, src_ptr, elem);
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 // Exported: list repeat — ``lrepeat count value1 ?value2 ...?``.
@@ -719,5 +719,5 @@ pub export fn tcl_cmd_list_repeat(count: i32, value: i32) i32 {
             off += next_len;
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(off));
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -397,6 +397,12 @@ pub export fn tcl_test_finalize() i32 {
 // Allocate a new TclObj with refcount 1
 pub fn obj_alloc() u32 {
     const ptr = alloc(OBJ_SIZE);
+    // Out-of-memory at the slab layer surfaces as a 0 return.  The
+    // header writes below would panic on the null cast in debug
+    // builds; bail early so the caller's null-check (every
+    // ``obj_new_*`` site below) can convert the OOM into a
+    // catchable Tcl error rather than a hard trap.
+    if (ptr == 0) return 0;
     if (build_options.leak_check) g_alloc_count += 1;
     write_i32(ptr + OBJ_REFCOUNT, 1);
     write_i32(ptr + OBJ_TYPE_TAG, TYPE_STRING);
@@ -417,45 +423,54 @@ pub export fn obj_new_int(value: i64) i32 {
     // and small literals (0, 1, -1, …) take this path.
     if (immediate_box(value)) |tagged| return tagged;
     const ptr = obj_alloc();
+    if (ptr == 0) return 0; // OOM — alloc() set oom_flag.
     write_i32(ptr + OBJ_TYPE_TAG, TYPE_INT);
     write_i64(ptr + OBJ_INT_CACHE, value);
-    return @as(i32, @intCast(ptr));
+    // ``@bitCast`` (not ``@intCast``) — TclObj handles are opaque
+    // bit patterns; allocator addresses above 2 GiB are valid in
+    // wasm32 (4 GiB linear-memory range) and must round-trip
+    // through the i32 handle slot without a debug-build overflow
+    // panic.  Matches the reader sites which use ``@bitCast`` for
+    // ``i32 handle → u32 addr``.  See issue #303.
+    return @bitCast(ptr);
 }
 
 pub export fn obj_new_string(data_ptr: i32, length: i32) i32 {
     const ptr = obj_alloc();
+    if (ptr == 0) return 0; // OOM — alloc() set oom_flag.
     write_i32(ptr + OBJ_TYPE_TAG, TYPE_STRING);
     write_i32(ptr + OBJ_STR_PTR, data_ptr);
     write_i32(ptr + OBJ_STR_LEN, length);
-    return @as(i32, @intCast(ptr));
+    return @bitCast(ptr);
 }
 
 pub export fn obj_new_float(value: f64) i32 {
     const ptr = obj_alloc();
+    if (ptr == 0) return 0; // OOM — alloc() set oom_flag.
     write_i32(ptr + OBJ_TYPE_TAG, TYPE_FLOAT);
     write_i64(ptr + OBJ_INT_CACHE, @bitCast(value));
-    return @as(i32, @intCast(ptr));
+    return @bitCast(ptr);
 }
 
 pub export fn obj_get_float(obj: i32) f64 {
     if (obj == 0) return 0.0;
     // S6.4 — tagged immediate: convert int → float directly.
     if (is_immediate(obj)) return @floatFromInt(immediate_unbox(obj));
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     const tag = read_i32(addr + OBJ_TYPE_TAG);
     if (tag == TYPE_FLOAT) return @bitCast(read_i64(addr + OBJ_INT_CACHE));
     if (tag == TYPE_INT) return @floatFromInt(read_i64(addr + OBJ_INT_CACHE));
     if (tag == TYPE_STRING) {
-        const sptr: u32 = @intCast(read_i32(addr + OBJ_STR_PTR));
-        const slen: u32 = @intCast(read_i32(addr + OBJ_STR_LEN));
+        const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
+        const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (try_parse_float(sptr, slen)) |val| return val;
         if (try_parse_int(sptr, slen)) |val| return @floatFromInt(val);
     }
     // S6.2 — inline string parses the inline payload through the
     // obj-internal pointer in OBJ_STR_PTR.
     if (tag == TYPE_INLINE_STRING) {
-        const sptr: u32 = @intCast(read_i32(addr + OBJ_STR_PTR));
-        const slen: u32 = @intCast(read_i32(addr + OBJ_STR_LEN));
+        const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
+        const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (try_parse_float(sptr, slen)) |val| return val;
         if (try_parse_int(sptr, slen)) |val| return @floatFromInt(val);
     }
@@ -470,7 +485,7 @@ pub export fn obj_get_int(obj: i32) i64 {
     if (obj == 0) return 0;
     // S6.4 — tagged immediate: extract the value directly.
     if (is_immediate(obj)) return immediate_unbox(obj);
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     const tag = read_i32(addr + OBJ_TYPE_TAG);
     if (tag == TYPE_INT) return read_i64(addr + OBJ_INT_CACHE);
     if (tag == TYPE_FLOAT) {
@@ -478,8 +493,8 @@ pub export fn obj_get_int(obj: i32) i64 {
         return @intFromFloat(fval);
     }
     if (tag == TYPE_STRING) {
-        const sptr: u32 = @intCast(read_i32(addr + OBJ_STR_PTR));
-        const slen: u32 = @intCast(read_i32(addr + OBJ_STR_LEN));
+        const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
+        const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (try_parse_int(sptr, slen)) |val| {
             write_i32(addr + OBJ_TYPE_TAG, TYPE_INT);
             write_i64(addr + OBJ_INT_CACHE, val);
@@ -508,8 +523,8 @@ pub export fn obj_get_int(obj: i32) i64 {
     // clobber the string bytes the inline encoding shares the
     // OBJ_INT_CACHE slot with.
     if (tag == TYPE_INLINE_STRING) {
-        const sptr: u32 = @intCast(read_i32(addr + OBJ_STR_PTR));
-        const slen: u32 = @intCast(read_i32(addr + OBJ_STR_LEN));
+        const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
+        const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (try_parse_int(sptr, slen)) |val| return val;
         if (try_parse_float(sptr, slen)) |fval| return @intFromFloat(fval);
         if (try_parse_bool(sptr, slen)) |val| return val;
@@ -649,7 +664,7 @@ pub export fn tcl_obj_retain(obj: i32) void {
     if (obj == 0) return;
     // S6.4 — tagged immediates have no refcount header (immortal).
     if (is_immediate(obj)) return;
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     const rc = read_i32(addr + OBJ_REFCOUNT);
     // PR #237 second-pass review: refuse to retain a deferred-free-
     // queued obj (rc == 0 marker).  Without this guard, the sequence
@@ -756,7 +771,7 @@ pub export fn tcl_obj_release(obj: i32) void {
     // S6.4 — tagged immediates have no refcount and no buffer
     // to free; release is a no-op.
     if (is_immediate(obj)) return;
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     const rc = read_i32(addr + OBJ_REFCOUNT);
     if (rc == 0) {
         // Already on the deferred-free queue (rc==0 marker) or
@@ -804,23 +819,23 @@ pub fn obj_str_ptr(obj: i32) u32 {
     // S6.4 — tagged immediates have no string buffer; callers
     // expecting a buffer need ``obj_ensure_string`` first.
     if (is_immediate(obj)) return 0;
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     // S6.2 — inline strings populate ``OBJ_STR_PTR`` with the
     // inline buffer's address (= obj + OBJ_INT_CACHE), so this
     // path needs no special-casing.
-    return @intCast(read_i32(addr + OBJ_STR_PTR));
+    return @bitCast(read_i32(addr + OBJ_STR_PTR));
 }
 
 pub fn obj_str_len(obj: i32) u32 {
     if (is_immediate(obj)) return 0;
-    const addr: u32 = @intCast(obj);
-    return @intCast(read_i32(addr + OBJ_STR_LEN));
+    const addr: u32 = @bitCast(obj);
+    return @bitCast(read_i32(addr + OBJ_STR_LEN));
 }
 
 pub fn obj_type(obj: i32) i32 {
     // S6.4 — tagged immediates always represent integers.
     if (is_immediate(obj)) return TYPE_INT;
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     const tag = read_i32(addr + OBJ_TYPE_TAG);
     // S6.2 — inline-string encoding is a representational detail;
     // callers checking ``obj_type`` for ``TYPE_STRING`` shouldn't
@@ -858,9 +873,13 @@ pub fn obj_new_string_copy(src: u32, len: u32) i32 {
         // ``obj_str_ptr``) see a valid pointer transparently.
         // ``str_cap`` stays 0 so ``release_now`` doesn't try to
         // ``free`` an address that's part of the obj header.
-        write_i32(obj + OBJ_STR_PTR, @intCast(obj + OBJ_INT_CACHE));
-        write_i32(obj + OBJ_STR_LEN, @intCast(len));
-        return @intCast(obj);
+        // ``@bitCast`` rather than ``@intCast``: ``obj`` is a u32
+        // allocator address that we round-trip into the i32 obj
+        // handle slot.  Above 2 GiB the signed-narrow form panics in
+        // debug builds — see issue #303.
+        write_i32(obj + OBJ_STR_PTR, @bitCast(obj + OBJ_INT_CACHE));
+        write_i32(obj + OBJ_STR_LEN, @bitCast(len));
+        return @bitCast(obj);
     }
     // Round capacity up to the smallest size class so the recycler
     // can return the slab to the right free-list at end-of-life.
@@ -868,9 +887,9 @@ pub fn obj_new_string_copy(src: u32, len: u32) i32 {
     const buf = alloc(cap);
     if (buf == 0) return 0;
     memcpy(buf, src, len);
-    const obj = obj_new_string(@intCast(buf), @intCast(len));
+    const obj = obj_new_string(@bitCast(buf), @bitCast(len));
     if (obj != 0) {
-        write_i32(@as(u32, @intCast(obj)) + OBJ_STR_CAP, @intCast(cap));
+        write_i32(@as(u32, @bitCast(obj)) + OBJ_STR_CAP, @bitCast(cap));
     }
     return obj;
 }
@@ -979,12 +998,12 @@ pub fn obj_ensure_string(obj: i32) struct { ptr: u32, len: u32 } {
         memcpy(dst_ptr, @intFromPtr(result.ptr), result.len);
         return .{ .ptr = dst_ptr, .len = result.len };
     }
-    const addr: u32 = @intCast(obj);
+    const addr: u32 = @bitCast(obj);
     const tag = read_i32(addr + OBJ_TYPE_TAG);
     if (tag == TYPE_STRING) {
         return .{
-            .ptr = @intCast(read_i32(addr + OBJ_STR_PTR)),
-            .len = @intCast(read_i32(addr + OBJ_STR_LEN)),
+            .ptr = @bitCast(read_i32(addr + OBJ_STR_PTR)),
+            .len = @bitCast(read_i32(addr + OBJ_STR_LEN)),
         };
     }
     // S6.2 — inline strings populate OBJ_STR_PTR with the inline
@@ -992,15 +1011,15 @@ pub fn obj_ensure_string(obj: i32) struct { ptr: u32, len: u32 } {
     // itself; callers must not hold it past the obj's lifetime.
     if (tag == TYPE_INLINE_STRING) {
         return .{
-            .ptr = @intCast(read_i32(addr + OBJ_STR_PTR)),
-            .len = @intCast(read_i32(addr + OBJ_STR_LEN)),
+            .ptr = @bitCast(read_i32(addr + OBJ_STR_PTR)),
+            .len = @bitCast(read_i32(addr + OBJ_STR_LEN)),
         };
     }
-    const sptr: u32 = @intCast(read_i32(addr + OBJ_STR_PTR));
+    const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
     if (sptr != 0) {
         return .{
             .ptr = sptr,
-            .len = @intCast(read_i32(addr + OBJ_STR_LEN)),
+            .len = @bitCast(read_i32(addr + OBJ_STR_LEN)),
         };
     }
     if (tag == TYPE_FLOAT) {

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -500,7 +500,7 @@ pub fn do_regsub(pattern: i32, string: i32, subspec: i32, nocase: bool, all: boo
     result_off += tail_len;
 
     if (n_subs_out) |p| p.* = n_subs;
-    return rt.obj_new_string(@intCast(result_buf), @intCast(result_off));
+    return rt.obj_new_string(@bitCast(result_buf), @bitCast(result_off));
 }
 
 /// Interpreter-side ``regexp`` command handler.  Called from
@@ -695,7 +695,7 @@ pub fn eval_regexp_cmd(words: []const i32) i32 {
     if (!inline_mode and inline_buf != 0) obj.free_sized(inline_buf, inline_cap);
 
     if (inline_mode) {
-        return obj_new_string(@intCast(inline_buf), @intCast(inline_off));
+        return obj_new_string(@bitCast(inline_buf), @bitCast(inline_off));
     }
     if (all_mode) {
         return obj_new_int(match_count);
@@ -752,7 +752,7 @@ fn build_capture_value(
         for (0..start_len) |k| dst[k] = start_buf[k];
         dst[start_len] = ' ';
         for (0..end_str.len) |k| dst[start_len + 1 + k] = end_str.ptr[k];
-        return obj_new_string(@intCast(buf), @intCast(total));
+        return obj_new_string(@bitCast(buf), @bitCast(total));
     }
     // Substring mode: extract the bytes covering [start_cp, end_cp).
     const sb_start = codepoint_to_byte(sub_s.ptr, sub_s.len, start_cp);
@@ -763,7 +763,7 @@ fn build_capture_value(
     const dst: [*]u8 = @ptrFromInt(buf);
     const src: [*]const u8 = @ptrFromInt(sub_s.ptr + sb_start);
     for (0..len) |k| dst[k] = src[k];
-    return obj_new_string(@intCast(buf), @intCast(len));
+    return obj_new_string(@bitCast(buf), @bitCast(len));
 }
 
 /// Append one capture (already decoded into start/end codepoints) to
@@ -808,7 +808,7 @@ fn append_inline_capture(
 }
 
 fn obj_new_string_lit(comptime s: []const u8) i32 {
-    return obj_new_string(@intCast(@intFromPtr(s.ptr)), @intCast(s.len));
+    return obj_new_string(@bitCast(@intFromPtr(s.ptr)), @bitCast(s.len));
 }
 
 // ---------------------------------------------------------------------------
@@ -1123,7 +1123,7 @@ pub fn eval_regsub_cmd(words: []const i32) i32 {
 
     regfree_safe(re_ptr);
 
-    const result = obj_new_string(@intCast(out_addr), @intCast(out_len));
+    const result = obj_new_string(@bitCast(out_addr), @bitCast(out_len));
 
     if (has_var) {
         _ = frames.var_set(varname, result);

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -91,7 +91,7 @@ pub export fn tcl_cmd_append(current: i32, addition: i32) i32 {
     if (buf == 0) return obj_new_string(0, 0);
     if (a.len > 0) memcpy(buf, a.ptr, a.len);
     if (b.len > 0) memcpy(buf + a.len, b.ptr, b.len);
-    const new_obj = obj_new_string(@intCast(buf), @intCast(total));
+    const new_obj = obj_new_string(@bitCast(buf), @bitCast(total));
     if (new_obj != 0) {
         obj.write_i32(@as(u32, @intCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(new_cap));
     }
@@ -166,7 +166,7 @@ pub export fn string_index(value: i32, idx: i32) i32 {
     const buf = alloc(1);
     const dst: [*]u8 = @ptrFromInt(buf);
     dst[0] = src[pos];
-    return obj_new_string(@intCast(buf), 1);
+    return obj_new_string(@bitCast(buf), 1);
 }
 
 // Exported: string range — extract a substring [first..last] (inclusive).
@@ -248,7 +248,7 @@ fn string_map_impl(mapping: i32, value: i32, nocase: bool) i32 {
         out_len += 1;
         pos += 1;
     }
-    return obj_new_string(@intCast(buf), @intCast(out_len));
+    return obj_new_string(@bitCast(buf), @bitCast(out_len));
 }
 
 // Exported: string match — glob pattern matching (* and ? wildcards).
@@ -445,7 +445,7 @@ pub export fn string_repeat(value: i32, count: i32) i32 {
         memcpy(buf + off, sv.ptr, sv.len);
         off += sv.len;
     }
-    return obj_new_string(@intCast(buf), @intCast(total));
+    return obj_new_string(@bitCast(buf), @bitCast(total));
 }
 
 // Exported: string reverse — reverse a string.
@@ -459,7 +459,7 @@ pub export fn string_reverse(value: i32) i32 {
     while (i < sv.len) : (i += 1) {
         dst[i] = src[sv.len - 1 - i];
     }
-    return obj_new_string(@intCast(buf), @intCast(sv.len));
+    return obj_new_string(@bitCast(buf), @bitCast(sv.len));
 }
 
 // Exported: string toupper — convert to uppercase.
@@ -472,7 +472,7 @@ pub export fn string_toupper(value: i32) i32 {
     for (0..sv.len) |i| {
         dst[i] = if (src[i] >= 'a' and src[i] <= 'z') src[i] - 32 else src[i];
     }
-    return obj_new_string(@intCast(buf), @intCast(sv.len));
+    return obj_new_string(@bitCast(buf), @bitCast(sv.len));
 }
 
 // Exported: string tolower — convert to lowercase.
@@ -485,7 +485,7 @@ pub export fn string_tolower(value: i32) i32 {
     for (0..sv.len) |i| {
         dst[i] = if (src[i] >= 'A' and src[i] <= 'Z') src[i] + 32 else src[i];
     }
-    return obj_new_string(@intCast(buf), @intCast(sv.len));
+    return obj_new_string(@bitCast(buf), @bitCast(sv.len));
 }
 
 // Exported: string totitle — uppercase the first alphabetic byte and
@@ -511,7 +511,7 @@ pub export fn string_totitle(value: i32) i32 {
             dst[i] = c;
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(sv.len));
+    return obj_new_string(@bitCast(buf), @bitCast(sv.len));
 }
 
 // Exported: string replace — replace characters in range [first..last] with new string.
@@ -533,7 +533,7 @@ pub export fn string_replace(value: i32, first: i32, last: i32, new_str: i32) i3
     if (fst > 0) memcpy(buf, sv.ptr, fst);
     if (sn.len > 0) memcpy(buf + fst, sn.ptr, sn.len);
     if (tail_len > 0) memcpy(buf + fst + sn.len, sv.ptr + tail_start, tail_len);
-    return obj_new_string(@intCast(buf), @intCast(total));
+    return obj_new_string(@bitCast(buf), @bitCast(total));
 }
 
 // Exported: string is integer — check if a string is a valid integer.
@@ -610,7 +610,7 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
             }
             out = list_quote_elem(buf, out, sv.ptr + @as(u32, @intCast(i)), 1);
         }
-        return obj_new_string(@intCast(buf), @intCast(out));
+        return obj_new_string(@bitCast(buf), @bitCast(out));
     }
 
     // Single-char separator (common case)
@@ -635,7 +635,7 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
                 start = i + 1;
             }
         }
-        return obj_new_string(@intCast(buf), @intCast(out));
+        return obj_new_string(@bitCast(buf), @bitCast(out));
     }
 
     // Multi-char separator: split on any char in splitChars
@@ -666,7 +666,7 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
             continue;
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(out));
+    return obj_new_string(@bitCast(buf), @bitCast(out));
 }
 
 // Exported: join — join a Tcl list with a separator string.
@@ -701,7 +701,7 @@ pub export fn tcl_cmd_join(list: i32, separator: i32) i32 {
             out += elem.len;
         }
     }
-    return obj_new_string(@intCast(buf), @intCast(out));
+    return obj_new_string(@bitCast(buf), @bitCast(out));
 }
 
 // Exported: concat — concatenate two TclObj string representations with space.
@@ -736,5 +736,5 @@ pub export fn tcl_cmd_concat(a: i32, b: i32) i32 {
     const dst: [*]u8 = @ptrFromInt(buf + ta_len);
     dst[0] = ' ';
     memcpy(buf + ta_len + 1, sb.ptr + b_start, tb_len);
-    return obj_new_string(@intCast(buf), @intCast(total));
+    return obj_new_string(@bitCast(buf), @bitCast(total));
 }

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -93,7 +93,7 @@ pub export fn tcl_cmd_append(current: i32, addition: i32) i32 {
     if (b.len > 0) memcpy(buf + a.len, b.ptr, b.len);
     const new_obj = obj_new_string(@bitCast(buf), @bitCast(total));
     if (new_obj != 0) {
-        obj.write_i32(@as(u32, @intCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(new_cap));
+        obj.write_i32(@as(u32, @bitCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(new_cap));
     }
     return new_obj;
 }

--- a/tests/baselines/tcl9_tcltest_baseline.json
+++ b/tests/baselines/tcl9_tcltest_baseline.json
@@ -315,10 +315,10 @@
       "subsystem": "io",
       "tcl_passed": 0,
       "tcl_total": 0,
-      "wasm_failed": 0,
-      "wasm_passed": 0,
-      "wasm_status": "run-trap",
-      "wasm_total": 0
+      "wasm_failed": 22,
+      "wasm_passed": 734,
+      "wasm_status": "partial",
+      "wasm_total": 779
     },
     {
       "stem": "io",

--- a/tests/baselines/tcl9_tcltest_baseline.json
+++ b/tests/baselines/tcl9_tcltest_baseline.json
@@ -301,6 +301,46 @@
       "wasm_total": 23
     },
     {
+      "stem": "chan",
+      "subsystem": "io",
+      "tcl_passed": 0,
+      "tcl_total": 0,
+      "wasm_failed": 0,
+      "wasm_passed": 42,
+      "wasm_status": "pass",
+      "wasm_total": 42
+    },
+    {
+      "stem": "chanio",
+      "subsystem": "io",
+      "tcl_passed": 0,
+      "tcl_total": 0,
+      "wasm_failed": 0,
+      "wasm_passed": 0,
+      "wasm_status": "run-trap",
+      "wasm_total": 0
+    },
+    {
+      "stem": "io",
+      "subsystem": "io",
+      "tcl_passed": 0,
+      "tcl_total": 0,
+      "wasm_failed": 0,
+      "wasm_passed": 0,
+      "wasm_status": "run-trap",
+      "wasm_total": 0
+    },
+    {
+      "stem": "ioCmd",
+      "subsystem": "io",
+      "tcl_passed": 0,
+      "tcl_total": 0,
+      "wasm_failed": 0,
+      "wasm_passed": 0,
+      "wasm_status": "run-trap",
+      "wasm_total": 0
+    },
+    {
       "stem": "abstractlist",
       "subsystem": "list",
       "tcl_passed": 0,

--- a/tests/external/run_tcl9_tests.py
+++ b/tests/external/run_tcl9_tests.py
@@ -664,17 +664,25 @@ _IO_BASELINE: dict[str, dict[str, object]] = {
     # chan.test — 42/42, fully green after the issue #270 ensemble
     # work landed.
     "chan": {"min_passed": 42, "max_failed": 0},
-    # The remaining three suites still trap before tcltest summary in
-    # paths outside the umbrella's six sub-issues:
-    #   * ``chanio.test`` — depends on a koi8-r codec (encoding
-    #     subsystem only ships iso8859-1 / ascii / cp1252 / utf-16).
-    #   * ``io.test``     — integer-panic in a Zig-side cast.
-    #   * ``ioCmd.test``  — ``close`` arity check (``close: missing
-    #     channelId``) hits before ``Tcl_BadChannelOption`` rendering.
-    # Each of these is its own follow-up sub-issue; until they land,
-    # the gate only enforces "still compiles + still traps cleanly".
-    "chanio": {"trap_ok": True},
+    # chanio.test — now reaches the tcltest summary line after the
+    # koi8-r codec landed in this branch (734/779 passing locally).
+    # Residual failures are expected from missing multi-byte codecs
+    # (shiftjis / iso2022-jp / jis0208 / euc-jp …) and reflected-
+    # channel features that are explicit out-of-scope items in #270
+    # / #274.  Tolerance band is generous so a small wobble doesn't
+    # flap the gate.
+    "chanio": {"min_passed": 700, "max_failed": 50},
+    # io.test — still traps with a debug-build integer-overflow check
+    # in ``valtypes.tcl_obj.obj_new_string`` when linear memory grows
+    # past the 2 GiB boundary.  The leak underlying that growth is a
+    # separate ticket (recommended follow-up); the gate stays
+    # ``trap_ok`` until the leak is fully chased down.
     "io": {"trap_ok": True},
+    # ioCmd.test — bare ``close`` arity error goes through the
+    # interpreter's eval-script fallback in a way that bypasses the
+    # surrounding ``catch`` (catch+command-substitution interaction
+    # bug — recommended follow-up).  Until that lands the gate is
+    # ``trap_ok``.
     "ioCmd": {"trap_ok": True},
 }
 

--- a/tests/external/run_tcl9_tests.py
+++ b/tests/external/run_tcl9_tests.py
@@ -648,6 +648,37 @@ class TestTcltest9Init:
 # ---------------------------------------------------------------------------
 
 
+# Baseline for the I/O suites (subsystem ``"io"``).  These files are
+# wired into ``_IN_SCOPE`` so the sweep picks them up, but the strict
+# ``failed == 0`` assertion in :meth:`_TestClass.test_runs` is replaced
+# by a per-stem baseline gate: a regression is flagged when ``passed``
+# drops below or ``failed`` rises above the recorded snapshot.  Stems
+# whose entry sets ``trap_ok`` allow the file to trap before reaching a
+# tcltest summary — the residual blockers (encoding ``koi8-r``, integer
+# panic, missing-arg paths) are tracked as separate follow-up issues.
+#
+# Refresh after a runtime change by running
+# ``make check-tcl9-tcltest-io`` and updating the numbers if the new
+# snapshot is strictly better than the old one.
+_IO_BASELINE: dict[str, dict[str, object]] = {
+    # chan.test — 42/42, fully green after the issue #270 ensemble
+    # work landed.
+    "chan": {"min_passed": 42, "max_failed": 0},
+    # The remaining three suites still trap before tcltest summary in
+    # paths outside the umbrella's six sub-issues:
+    #   * ``chanio.test`` — depends on a koi8-r codec (encoding
+    #     subsystem only ships iso8859-1 / ascii / cp1252 / utf-16).
+    #   * ``io.test``     — integer-panic in a Zig-side cast.
+    #   * ``ioCmd.test``  — ``close`` arity check (``close: missing
+    #     channelId``) hits before ``Tcl_BadChannelOption`` rendering.
+    # Each of these is its own follow-up sub-issue; until they land,
+    # the gate only enforces "still compiles + still traps cleanly".
+    "chanio": {"trap_ok": True},
+    "io": {"trap_ok": True},
+    "ioCmd": {"trap_ok": True},
+}
+
+
 def _make_test_class(test_name: str, *, subsystem: str, deferred: bool = False):
     """Dynamically build a test class for a Tcl 9 .test file.
 
@@ -656,8 +687,14 @@ def _make_test_class(test_name: str, *, subsystem: str, deferred: bool = False):
     label; ``deferred`` marks files that exercise deferred-by-design
     primitives (I/O, threads, fs, encoding) and pre-categorises them
     as D.
+
+    For files registered in :data:`_IO_BASELINE`, the strict
+    ``failed == 0`` assertion is replaced with a baseline-relative
+    gate so partial-pass suites (``chan`` / ``chanio`` / ``io`` /
+    ``ioCmd``) are tracked without forcing a green sweep.
     """
     filename = f"{test_name}.test"
+    baseline_io = _IO_BASELINE.get(test_name) if subsystem == "io" else None
 
     class _TestClass:
         def test_compiles(self, request: pytest.FixtureRequest) -> None:
@@ -708,6 +745,21 @@ def _make_test_class(test_name: str, *, subsystem: str, deferred: bool = False):
                 wasm, diag = _compile_tcl_with_diag(src, filename)
                 compiled = True
                 with tempfile.TemporaryDirectory(prefix="tcl9test-") as host_tmp:
+                    # Stage common tcltest helper files into the
+                    # preopened tmpdir so tests that
+                    # ``source [file join [file dirname [info script]] X]``
+                    # can find them.  Mirrors the staging logic in
+                    # :func:`_run_bundle`.
+                    helpers_dir = _tcl9_tcltest().parent.parent.parent / "tests"
+                    for helper in (
+                        "tcltests.tcl",
+                        "internals.tcl",
+                        "encodingVectors.tcl",
+                        "pkgIndex.tcl",
+                    ):
+                        src_path = helpers_dir / helper
+                        if src_path.exists():
+                            shutil.copyfile(src_path, Path(host_tmp) / helper)
                     result = _run_wasm(
                         wasm,
                         capture_stdout=True,
@@ -756,18 +808,38 @@ def _make_test_class(test_name: str, *, subsystem: str, deferred: bool = False):
             if not compiled:
                 pytest.fail(f"{filename} bundle failed to compile: {stderr[-400:]}")
             if not ran:
+                # Baselined I/O suites are allowed to trap when their
+                # baseline entry sets ``trap_ok`` — the residual blockers
+                # are tracked as separate follow-up sub-issues.  A NEW
+                # compile/run failure on a previously-passing baseline is
+                # still a regression.
+                if baseline_io is not None and baseline_io.get("trap_ok"):
+                    return
                 pytest.fail(f"{filename} trapped: {trap_site or stderr[-400:]}")
             if summary is None:
+                if baseline_io is not None and baseline_io.get("trap_ok"):
+                    return
                 pytest.fail(
                     f"No tcltest summary line in stdout for {filename}.\n"
                     f"stdout tail:\n{stdout[-400:]}\nstderr tail:\n{stderr[-400:]}"
                 )
-            assert failed == 0, (
-                f"{filename}: {failed} test(s) FAILED "
-                f"(total={total}, passed={passed}, skipped={skipped}).\n"
-                f"first failing: {_first_failing(stdout)}\n"
-                f"stdout tail:\n{stdout[-400:]}"
-            )
+            if baseline_io is not None:
+                min_passed = int(baseline_io.get("min_passed", 0))  # type: ignore[arg-type]
+                max_failed = int(baseline_io.get("max_failed", 0))  # type: ignore[arg-type]
+                assert passed >= min_passed and failed <= max_failed, (
+                    f"{filename}: regression vs baseline — "
+                    f"got passed={passed} failed={failed}, "
+                    f"expected passed>={min_passed} failed<={max_failed}.\n"
+                    f"first failing: {_first_failing(stdout)}\n"
+                    f"stdout tail:\n{stdout[-400:]}"
+                )
+            else:
+                assert failed == 0, (
+                    f"{filename}: {failed} test(s) FAILED "
+                    f"(total={total}, passed={passed}, skipped={skipped}).\n"
+                    f"first failing: {_first_failing(stdout)}\n"
+                    f"stdout tail:\n{stdout[-400:]}"
+                )
 
     _TestClass.__name__ = f"TestTcl9_{test_name.replace('-', '_').replace('.', '_')}"
     _TestClass.__qualname__ = _TestClass.__name__
@@ -905,6 +977,16 @@ _IN_SCOPE: list[tuple[str, str]] = [
     ("brodnik", "misc"),
     ("range", "misc"),
     ("aaa_exit", "misc"),
+    # I/O — umbrella issue #276.  Sub-issues #270 (chan ensemble),
+    # #271 (fconfigure query forms), #272 (channel-error wording),
+    # #273 (array trap), #274 (encoding subsystem), #275 (write-side
+    # translation) all merged.  ``chan.test`` runs 42/42 green;
+    # ``chanio`` / ``io`` / ``ioCmd`` are gated by :data:`_IO_BASELINE`
+    # so their residual blockers don't break the sweep.
+    ("chan", "io"),
+    ("chanio", "io"),
+    ("io", "io"),
+    ("ioCmd", "io"),
 ]
 
 for _stem, _sub in _IN_SCOPE:

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -2017,11 +2017,12 @@ class TestDiagMap:
             # ``open`` / ``close`` / ``read`` / ``gets`` / ``seek`` /
             # ``tell`` / ``eof`` / ``fblocked`` / ``fcopy`` now have
             # WASI-backed implementations in :file:`io/tcl_chan.zig`.
-            # Failure paths surface through ``stubs.raise`` with a
-            # specific message (``open: could not open file``,
-            # ``close: unknown channel``, …) rather than the
+            # Failure paths surface through ``stubs.raise`` with the
+            # upstream Tcl wording (``can not find channel named "X"``,
+            # ``couldn't open "X": …``, …) rather than the
             # ``unsupported command:`` prefix.  See TestChannelIO
-            # for the positive cases.
+            # for the positive cases and TestChannelErrorWording for
+            # the per-error-shape regression test.
             # ``file`` now has real WASI-backed impls for mkdir /
             # delete / rename / copy / link / readlink / stat /
             # lstat / type — see TestFile for the positive cases.
@@ -3034,7 +3035,7 @@ class TestChannelIO:
             pytest.fail("expected trap on non-integer numChars")
         except Exception as trap:
             stderr = getattr(trap, "tcl_stderr", "")
-            assert "read" in stderr and "integer" in stderr, f"stderr: {stderr!r}"
+            assert 'expected integer but got "abc"' in stderr, f"stderr: {stderr!r}"
 
     def test_read_rejects_negative_numchars(self, tmp_path):
         """Regression for codex P2: ``read $fd -2`` must error."""
@@ -3049,7 +3050,7 @@ class TestChannelIO:
             pytest.fail("expected trap on negative numChars")
         except Exception as trap:
             stderr = getattr(trap, "tcl_stderr", "")
-            assert "read" in stderr and "non-negative" in stderr, f"stderr: {stderr!r}"
+            assert 'expected non-negative integer but got "-2"' in stderr, f"stderr: {stderr!r}"
 
     def test_fcopy_rejects_unknown_option(self, tmp_path):
         """Regression for codex P2: ``fcopy a b -foo 1`` must error."""
@@ -3086,6 +3087,104 @@ class TestChannelIO:
         except Exception as trap:
             stderr = getattr(trap, "tcl_stderr", "")
             assert "fcopy" in stderr and "integer" in stderr, f"stderr: {stderr!r}"
+
+
+class TestChannelErrorWording:
+    """Channel-command error wording matches upstream Tcl.
+
+    Issue #272 — the WASI-backed I/O implementations now report the
+    same string format as ``tmp/tcl9.0.3/generic/tclIO.c`` /
+    ``tclIOCmd.c``, so upstream tcltest cases that grep on ``exact
+    matching`` patterns (``can not find channel named "X"``,
+    ``couldn't open "X"``, ``channel "X" wasn't opened for
+    reading``, …) pass under the WASM runtime.
+    """
+
+    @staticmethod
+    def _trap_stderr(source: str, *, preopen: str | None = None) -> str:
+        wasm, _ = _compile_tcl_with_diag(source, "t.tcl")
+        try:
+            kwargs = {"capture_stderr": True}
+            if preopen is not None:
+                kwargs["preopen_tmpdir"] = preopen
+            _run_wasm(wasm, **kwargs)
+        except Exception as trap:
+            return getattr(trap, "tcl_stderr", "")
+        pytest.fail("expected trap")
+        return ""
+
+    def test_close_unknown_channel(self):
+        stderr = self._trap_stderr("close aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_read_unknown_channel(self):
+        stderr = self._trap_stderr("read aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_gets_unknown_channel(self):
+        stderr = self._trap_stderr("gets aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_seek_unknown_channel(self):
+        stderr = self._trap_stderr("seek aaa 0\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_tell_unknown_channel(self):
+        stderr = self._trap_stderr("tell aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_eof_unknown_channel(self):
+        stderr = self._trap_stderr("eof aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_fblocked_unknown_channel(self):
+        stderr = self._trap_stderr("fblocked aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_puts_unknown_channel(self):
+        stderr = self._trap_stderr("puts aaa hello\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_fconfigure_unknown_channel(self):
+        stderr = self._trap_stderr("fconfigure aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_flush_unknown_channel(self):
+        stderr = self._trap_stderr("flush aaa\n")
+        assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
+
+    def test_open_couldnt_open(self, tmp_path):
+        stderr = self._trap_stderr(
+            "open /no-such-file r\n", preopen=str(tmp_path)
+        )
+        assert 'couldn\'t open "/no-such-file"' in stderr, f"stderr: {stderr!r}"
+
+    def test_open_illegal_access_mode(self, tmp_path):
+        (tmp_path / "f.txt").write_text("hi")
+        stderr = self._trap_stderr(
+            "open /f.txt zzz\n", preopen=str(tmp_path)
+        )
+        assert 'illegal access mode "zzz"' in stderr, f"stderr: {stderr!r}"
+
+    def test_read_on_write_only_channel(self, tmp_path):
+        # ``stdout`` is a write-only channel in our preset.
+        stderr = self._trap_stderr("read stdout\n")
+        assert 'channel "stdout" wasn\'t opened for reading' in stderr, (
+            f"stderr: {stderr!r}"
+        )
+
+    def test_puts_on_read_only_channel(self, tmp_path):
+        # ``stdin`` is a read-only channel.
+        stderr = self._trap_stderr("puts stdin hello\n")
+        assert 'channel "stdin" wasn\'t opened for writing' in stderr, (
+            f"stderr: {stderr!r}"
+        )
+
+    def test_gets_on_write_only_channel(self, tmp_path):
+        stderr = self._trap_stderr("gets stdout\n")
+        assert 'channel "stdout" wasn\'t opened for reading' in stderr, (
+            f"stderr: {stderr!r}"
+        )
 
 
 class TestEncoding:

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3104,10 +3104,10 @@ class TestChannelErrorWording:
     def _trap_stderr(source: str, *, preopen: str | None = None) -> str:
         wasm, _ = _compile_tcl_with_diag(source, "t.tcl")
         try:
-            kwargs = {"capture_stderr": True}
             if preopen is not None:
-                kwargs["preopen_tmpdir"] = preopen
-            _run_wasm(wasm, **kwargs)
+                _run_wasm(wasm, capture_stderr=True, preopen_tmpdir=preopen)
+            else:
+                _run_wasm(wasm, capture_stderr=True)
         except Exception as trap:
             return getattr(trap, "tcl_stderr", "")
         pytest.fail("expected trap")

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3207,7 +3207,7 @@ class TestEncoding:
             ("puts [encoding system]\n", "utf-8\n"),
             (
                 "puts [encoding names]\n",
-                "ascii cp1252 identity iso8859-1 utf-8 utf-16 utf-16be utf-16le\n",
+                "ascii cp1252 identity iso8859-1 koi8-r utf-8 utf-16 utf-16be utf-16le\n",
             ),
             ("puts [encoding dirs]\n", "\n"),
         ],
@@ -3239,6 +3239,12 @@ class TestEncoding:
             ("encoding convertto utf-16 AB", "41004200"),
             # utf-16le with non-ASCII (é = U+00E9 → 0xE9 0x00)
             ("encoding convertto utf-16le café", "630061006600e900"),
+            # koi8-r: ASCII range passes through.
+            ("encoding convertto koi8-r abc", "616263"),
+            # koi8-r: cyrillic 'А' (U+0410) → 0xE1.
+            ("encoding convertto koi8-r \\u0410", "e1"),
+            # koi8-r: 'Русский' → 0xF2 0xD5 0xD3 0xD3 0xCB 0xC9 0xCA.
+            ("encoding convertto koi8-r \\u0420\\u0443\\u0441\\u0441\\u043A\\u0438\\u0439", "f2d5d3d3cbc9ca"),
         ],
     )
     def test_convertto_real_codec(self, script, expected_hex):
@@ -3262,6 +3268,13 @@ class TestEncoding:
             ('encoding convertfrom utf-16le [binary format H* "41004200"]', "AB"),
             # utf-16be
             ('encoding convertfrom utf-16be [binary format H* "00410042"]', "AB"),
+            # koi8-r: 0xE1 → 'А' (U+0410).
+            ('encoding convertfrom koi8-r [binary format H* "e1"]', "А"),
+            # koi8-r round-trip 'Русский'.
+            (
+                'encoding convertfrom koi8-r [binary format H* "f2d5d3d3cbc9ca"]',
+                "Русский",
+            ),
         ],
     )
     def test_convertfrom_real_codec(self, script, expected):

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -3154,37 +3154,27 @@ class TestChannelErrorWording:
         assert 'can not find channel named "aaa"' in stderr, f"stderr: {stderr!r}"
 
     def test_open_couldnt_open(self, tmp_path):
-        stderr = self._trap_stderr(
-            "open /no-such-file r\n", preopen=str(tmp_path)
-        )
+        stderr = self._trap_stderr("open /no-such-file r\n", preopen=str(tmp_path))
         assert 'couldn\'t open "/no-such-file"' in stderr, f"stderr: {stderr!r}"
 
     def test_open_illegal_access_mode(self, tmp_path):
         (tmp_path / "f.txt").write_text("hi")
-        stderr = self._trap_stderr(
-            "open /f.txt zzz\n", preopen=str(tmp_path)
-        )
+        stderr = self._trap_stderr("open /f.txt zzz\n", preopen=str(tmp_path))
         assert 'illegal access mode "zzz"' in stderr, f"stderr: {stderr!r}"
 
     def test_read_on_write_only_channel(self, tmp_path):
         # ``stdout`` is a write-only channel in our preset.
         stderr = self._trap_stderr("read stdout\n")
-        assert 'channel "stdout" wasn\'t opened for reading' in stderr, (
-            f"stderr: {stderr!r}"
-        )
+        assert 'channel "stdout" wasn\'t opened for reading' in stderr, f"stderr: {stderr!r}"
 
     def test_puts_on_read_only_channel(self, tmp_path):
         # ``stdin`` is a read-only channel.
         stderr = self._trap_stderr("puts stdin hello\n")
-        assert 'channel "stdin" wasn\'t opened for writing' in stderr, (
-            f"stderr: {stderr!r}"
-        )
+        assert 'channel "stdin" wasn\'t opened for writing' in stderr, f"stderr: {stderr!r}"
 
     def test_gets_on_write_only_channel(self, tmp_path):
         stderr = self._trap_stderr("gets stdout\n")
-        assert 'channel "stdout" wasn\'t opened for reading' in stderr, (
-            f"stderr: {stderr!r}"
-        )
+        assert 'channel "stdout" wasn\'t opened for reading' in stderr, f"stderr: {stderr!r}"
 
 
 class TestEncoding:
@@ -3244,7 +3234,10 @@ class TestEncoding:
             # koi8-r: cyrillic 'А' (U+0410) → 0xE1.
             ("encoding convertto koi8-r \\u0410", "e1"),
             # koi8-r: 'Русский' → 0xF2 0xD5 0xD3 0xD3 0xCB 0xC9 0xCA.
-            ("encoding convertto koi8-r \\u0420\\u0443\\u0441\\u0441\\u043A\\u0438\\u0439", "f2d5d3d3cbc9ca"),
+            (
+                "encoding convertto koi8-r \\u0420\\u0443\\u0441\\u0441\\u043A\\u0438\\u0439",
+                "f2d5d3d3cbc9ca",
+            ),
         ],
     )
     def test_convertto_real_codec(self, script, expected_hex):


### PR DESCRIPTION
## Summary

Implement upstream Tcl error message wording for channel I/O operations to enable exact-match assertions in upstream tcltest suites. This addresses issue #272 and is part of the larger I/O subsystem work (issue #276).

### Key Changes

**Error Message Helpers** (`runtime/zig/io/tcl_chan.zig`):
- Added helper functions to construct error messages matching upstream Tcl wording:
  - `raise_parts()`: Concatenate message fragments and raise via standard error path
  - `raise_unknown_channel()`: "can not find channel named \"<name>\""
  - `raise_not_readable()`: "channel \"<name>\" wasn't opened for reading"
  - `raise_not_writable()`: "channel \"<name>\" wasn't opened for writing"
  - `raise_open_failed()`: "couldn't open \"<path>\": <syscall>"
  - `raise_illegal_access_mode()`: "illegal access mode \"<mode>\""
  - `raise_read_io_error()`, `raise_write_io_error()`, `raise_seek_io_error()`: I/O error variants
- Added utility functions to recover channel names from pointers and format canonical names (stdin/stdout/stderr/fileN)

**Updated Error Sites**:
- Replaced all hardcoded error messages in channel commands (`open`, `close`, `read`, `gets`, `seek`, `tell`, `eof`, `fblocked`, `puts`, `fconfigure`, `flush`, `fcopy`) with calls to the new helpers
- Updated error messages for integer parsing failures in `read` command to match upstream wording

**Encoding Support** (`runtime/zig/valtypes/tcl_encoding.zig`):
- Added `koi8-r` (Cyrillic) single-byte encoding support with full encode/decode implementation
- Updated encoding names list to include `koi8-r` in alphabetical order

**Memory Leak Fix** (`runtime/zig/interp/tcl_frames.zig`):
- Fixed variable resolution leak in namespace context: now properly releases temporary qualified-name objects and buffers after lookup, preventing accumulation during repeated `$var` reads that was pushing io.test past 2 GiB memory ceiling

**Test Infrastructure** (`tests/external/run_tcl9_tests.py`):
- Added `_IO_BASELINE` dictionary to track partial-pass I/O test suites (chan/chanio/io/ioCmd) with min_passed/max_failed gates instead of strict zero-failure requirement
- Added helper file staging in preopened tmpdir for tcltest suites that source common utilities
- Updated test class generation to apply baseline gates for I/O subsystem tests

**Test Coverage** (`tests/test_wasm_real_tcl.py`):
- Added `TestChannelErrorWording` class with 13 regression tests verifying exact error message wording for all channel commands
- Updated existing error message assertions to match new upstream wording
- Added koi8-r encoding tests (convertto/convertfrom round-trips with Cyrillic text)

**Baseline Updates** (`tests/baselines/tcl9_tcltest_baseline.json`):
- Added baseline entries for four I/O tcltest suites:
  - `chan`: 42/42 passing (fully green)
  - `chanio`: 734/779 passing (residual failures from missing multi-byte codecs)
  - `io`: trap_ok (integer overflow on 2 GiB boundary — separate follow-up)
  - `ioCmd`: trap_ok (catch+command-substitution interaction bug — separate follow-up)

## Validation

- [x] Added 13 new regression tests in `TestChannelErrorWording` covering all error paths
- [x] Updated existing error message assertions to match upstream wording
- [x] Added koi8-r encoding tests with Cyrillic round-trips
- [x] Verified chan.test runs 42/42 green
- [x] Verified chanio.test reaches tcltest summary with 734/779 passing (residual

https://claude.ai/code/session_018NAss7sskY2kYGVu8N7dQ9