### PR TITLE
Fix catch error handling in nested bracket substitutions

### DIFF
--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -1053,6 +1053,27 @@ return [sum_list {1 2 3 4 5}]
         assert ok, f"error: {err}"
         assert val == 1
 
+    def test_catch_inside_bracket_substitution(self):
+        """``[catch …]`` nested inside another bracket substitution must not
+        propagate the error past its own catch.  Regression for issue #302:
+        the import scanner only walked ``parts[-1]`` of an outer ``[cmd …]``,
+        so ``[list [catch {error fail} msg] $msg]`` never registered
+        ``tcl_catch_enter`` and the inner ``error`` saw ``catch_depth == 0``
+        at runtime — trapping past the surrounding catch.
+        """
+        cases = [
+            ("puts [list [catch {error fail} msg] $msg]\n", "1 fail\n"),
+            ("puts [list [catch {error fail} msg]]\n", "1\n"),
+            (
+                "proc f {} { return [list [catch {error fail} msg] $msg] }\nputs [f]\n",
+                "1 fail\n",
+            ),
+        ]
+        for source, expected in cases:
+            ok, stdout, err = _run_tcl_for_stdout(source)
+            assert ok, f"error for {source!r}: {err}"
+            assert stdout == expected, f"for {source!r} got {stdout!r}"
+
     def test_switch_dispatch(self):
         source = """\
 set x "hello"


### PR DESCRIPTION
## Summary

- Fixed a bug in the import scanner where nested `[catch …]` inside other bracket substitutions were not being scanned for their required imports, causing runtime errors to escape the catch block.
- The scanner was only recursing into `parts[-1]` of a command split by `split(None, 2)`, which dropped middle arguments. Now it recurses over the full command text to catch all nested substitutions.
- Added regression test for issue #302.

## Details

The bug occurred because `_scan_text_for_cmd_subst()` in `core/compiler/codegen/wasm/_scan.py` was splitting command text with `split(None, 2)` (capping at 3 parts) and only recursing into the last part. This meant that nested bracket substitutions in middle argument positions were never scanned for their imports.

For example, in `[list [catch {error fail} msg] $msg]`:
- The outer `list` command was split into 3 parts: `"list"`, `"[catch {error fail} msg]"`, `"$msg"`
- Only `parts[-1]` (`"$msg"`) was recursed into
- The `[catch …]` in the middle was never scanned, so `tcl_catch_enter` was not added to needed imports
- At runtime, the inner `error` saw `catch_depth == 0` and the exception escaped the catch

The fix changes the recursion to scan the full `cmd_text` instead of just `parts[-1]`, ensuring all nested substitutions are properly analyzed regardless of argument position.

## Validation

- Added comprehensive test case `test_catch_inside_bracket_substitution()` covering three scenarios:
  - Simple catch with error and message variable
  - Catch without message variable
  - Catch inside a procedure return statement
- All test cases verify that errors are properly caught and don't propagate

https://claude.ai/code/session_01LyNxGJYmJEYR5CeodvSbZJ