### PR TITLE
Fix unused parameter detection for dict with/update commands

### DIFF
--- a/core/compiler/ssa.py
+++ b/core/compiler/ssa.py
@@ -271,12 +271,15 @@ def _uses(stmt: IRStatement) -> tuple[str, ...]:
             # is a plain string, not a $-substitution, so ``_vars_in_word``
             # misses it.  The registry's resolver attaches both
             # ``ArgRole.VAR_READ`` and ``ArgRole.VAR_WRITE`` to the same
-            # index, so a plain ``VAR_READ`` query finds it.
+            # index, so a plain ``VAR_READ`` query finds it.  Mark it as
+            # ``reads_own_def`` so the final filter doesn't drop it on the
+            # grounds that it's also a barrier def (issue #307).
             for idx in arg_indices_for_role(command, list(args), ArgRole.VAR_READ):
                 if 0 <= idx < len(args):
                     name = _normalise_var_name(args[idx])
                     if name:
                         vars_found.add(name)
+                        reads_own_def.add(name)
         case _:
             pass
 

--- a/core/compiler/ssa.py
+++ b/core/compiler/ssa.py
@@ -265,15 +265,19 @@ def _uses(stmt: IRStatement) -> tuple[str, ...]:
                     vars_found |= _vars_in_body_script(arg)
                 else:
                     vars_found |= _vars_in_word(arg)
-            # ``dict with`` / ``dict update`` arg 0 is the dict variable: it
-            # is read as well as written (the body sees the keys unpacked
-            # into local variables of the same name), but the variable name
-            # is a plain string, not a $-substitution, so ``_vars_in_word``
-            # misses it.  The registry's resolver attaches both
-            # ``ArgRole.VAR_READ`` and ``ArgRole.VAR_WRITE`` to the same
-            # index, so a plain ``VAR_READ`` query finds it.  Mark it as
-            # ``reads_own_def`` so the final filter doesn't drop it on the
-            # grounds that it's also a barrier def (issue #307).
+            # For ``dict with`` / ``dict update`` the dict-variable argument
+            # (``args[1]`` of the full barrier args — ``args[0]`` is the
+            # subcommand word) is both read and written: the body sees the
+            # keys unpacked into local variables of the same name.  The
+            # variable name is a plain string, not a ``$``-substitution, so
+            # ``_vars_in_word`` misses it.  The registry's resolver attaches
+            # both ``ArgRole.VAR_READ`` and ``ArgRole.VAR_WRITE`` to that
+            # position, and ``arg_indices_for_role`` returns indices into
+            # the full ``args`` list (subcommand offset already applied), so
+            # a plain ``VAR_READ`` query yields the right slot.  Mark the
+            # resulting name as ``reads_own_def`` so the final filter
+            # doesn't drop it on the grounds that it's also a barrier def
+            # (issue #307).
             for idx in arg_indices_for_role(command, list(args), ArgRole.VAR_READ):
                 if 0 <= idx < len(args):
                     name = _normalise_var_name(args[idx])

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -1207,6 +1207,33 @@ class TestUnusedProcParameters:
         w214 = [d for d in result.diagnostics if d.code == "W214"]
         assert w214 == []
 
+    def test_param_used_only_by_dict_with_issue_307(self):
+        """Issue #307 — a parameter passed to ``dict with`` as the dict
+        variable must count as used.  The barrier marks the variable as
+        both VAR_READ and VAR_WRITE; the read must survive the
+        defs-filter in ``_uses``."""
+        source = textwrap.dedent("""\
+            proc f {pdata} {
+                dict with pdata {}
+            }
+        """)
+        result = analyse(source)
+        w214 = [d for d in result.diagnostics if d.code == "W214"]
+        assert w214 == []
+
+    def test_param_used_only_by_dict_update_issue_307(self):
+        """``dict update`` shares the same VAR_READ+VAR_WRITE shape as
+        ``dict with``; a parameter that is only the dict variable must
+        not be flagged as unused."""
+        source = textwrap.dedent("""\
+            proc f {d} {
+                dict update d k v {}
+            }
+        """)
+        result = analyse(source)
+        w214 = [d for d in result.diagnostics if d.code == "W214"]
+        assert w214 == []
+
     def test_pure_write_to_param_inside_body_still_flags(self):
         """A parameter that is only *written* (never read) inside an
         opaque body is still unused — the deep body scan must not count


### PR DESCRIPTION
## Summary

- Fixed issue #307 where parameters used only as the dict variable in `dict with` or `dict update` commands were incorrectly flagged as unused (W214)
- The fix marks variables that are both read and written by these commands as "reads_own_def" so they survive the defs-filter in the SSA analysis

## Details

The `dict with` and `dict update` commands have a special characteristic: they mark their dict variable argument with both `VAR_READ` and `VAR_WRITE` roles at the same index. The SSA analysis was correctly identifying these reads, but the final filter was dropping them because the variable was also marked as a barrier definition (VAR_WRITE).

The fix adds these variables to the `reads_own_def` set, which prevents the defs-filter from incorrectly removing them as unused.

## Validation

- [x] Added two new test cases covering `dict with` and `dict update` scenarios
- [x] Tests verify that parameters used only by these commands are not flagged as W214 (unused parameter)

## Compiler/KCS checklist

- [ ] Did this change alter a compiler fact contract? No, this is a bug fix to existing analysis behavior
- [ ] N/A

https://claude.ai/code/session_01ANTWnCm4iwYzU5jnqKoe2p