### PR TITLE
Support implicit args in command-prefix bodies (fixes #308)

### DIFF
--- a/core/analysis/_analyser/_commands.py
+++ b/core/analysis/_analyser/_commands.py
@@ -15,6 +15,7 @@ from ...commands.registry.runtime import (
     CommandSig,
     SubcommandSig,
     arg_indices_for_role,
+    body_arg_implicit_args_for_command,
     iter_body_arguments,
 )
 from ...common.dialect import active_dialect
@@ -511,8 +512,14 @@ class _AnalyserCommandsMixin(_Base):
         is_conditional = cmd_name in ("if", "try")
         if is_conditional:
             self._conditional_depth += 1
+        body_implicit_args = body_arg_implicit_args_for_command(role_cmd, role_args)
         for body in iter_body_arguments(role_cmd, role_args, arg_tokens, prepend_n=prepend_n):
-            self._analyse_body(body.text, scope, body_token=body.token)
+            self._analyse_body(
+                body.text,
+                scope,
+                body_token=body.token,
+                implicit_appended_args=body_implicit_args,
+            )
         if is_conditional:
             self._conditional_depth -= 1
         if cmd_name == "when":

--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -77,6 +77,12 @@ class _AnalyserBase:
         self._conditional_depth: int = 0
         # Track body nesting depth for top-level-only command detection.
         self._body_depth: int = 0
+        # Implicit-args carry from a command-prefix body (e.g.
+        # ``fileutil::updateInPlace`` appends one arg).  Set just
+        # before processing the first top-level command of such a body
+        # and consumed by the arity check.  Always 0 outside that
+        # narrow window.
+        self._pending_implicit_args: int = 0
         # Command aliases: alias_name -> (target_cmd, prepended_args).
         # Populated from ``interp alias {} name {} target ?arg ...?``.
         self._command_aliases: dict[str, tuple[str, tuple[str, ...]]] = {}
@@ -434,16 +440,24 @@ class _AnalyserBase:
         source: str,
         scope: Scope,
         body_token: Token | None = None,
+        implicit_appended_args: int = 0,
     ) -> None:
         """Analyse a Tcl body (top-level or inside braces).
 
         When *body_token* is provided, the lexer is created with base offsets
         so that all positions in the sub-parse map back to the original source.
+
+        ``implicit_appended_args`` records how many arguments the runtime
+        appends to the body when it is invoked as a command prefix
+        (e.g. ``fileutil::updateInPlace`` appends the file contents).
+        Arity checks on the immediate top-level command of the body are
+        relaxed by this many positional arguments; nested bodies do not
+        inherit the offset.
         """
         if body_token is not None:
             self._body_depth += 1
         try:
-            self._analyse_body_inner(source, scope, body_token)
+            self._analyse_body_inner(source, scope, body_token, implicit_appended_args)
         finally:
             if body_token is not None:
                 self._body_depth -= 1
@@ -453,6 +467,7 @@ class _AnalyserBase:
         source: str,
         scope: Scope,
         body_token: Token | None = None,
+        implicit_appended_args: int = 0,
     ) -> None:
         """Inner implementation of _analyse_body, separated for try/finally."""
         commands, recovery_diags = segment_with_recovery(source, body_token)
@@ -525,15 +540,24 @@ class _AnalyserBase:
                     self._record_var_read(tok.text, range_from_token(tok), scope)
                 elif tok.type is TokenType.CMD:
                     self._analyse_body(tok.text, scope, body_token=tok)
-            self._process_command(
-                cmd.argv,
-                cmd.texts,
-                cmd.all_tokens,
-                scope,
-                source,
-                expand_word=cmd.expand_word,
-                single_token_word=cmd.single_token_word,
-            )
+            # Apply command-prefix implicit-args offset to the *first*
+            # top-level command of this body only (subsequent commands
+            # would not be reachable under command-prefix semantics, so
+            # we don't relax their arity).
+            self._pending_implicit_args = implicit_appended_args
+            implicit_appended_args = 0
+            try:
+                self._process_command(
+                    cmd.argv,
+                    cmd.texts,
+                    cmd.all_tokens,
+                    scope,
+                    source,
+                    expand_word=cmd.expand_word,
+                    single_token_word=cmd.single_token_word,
+                )
+            finally:
+                self._pending_implicit_args = 0
             cmd_idx += 1 + consumed
 
     def _analyse_expr(

--- a/core/analysis/_analyser/_proc.py
+++ b/core/analysis/_analyser/_proc.py
@@ -481,6 +481,16 @@ class _AnalyserProcMixin(_Base):
         nargs_min, nargs_max = self._arg_count_bounds(
             args, arg_expand, arg_tokens, arg_single_token, scope
         )
+        # Account for runtime-appended args when this proc call is the
+        # body of a command-prefix-style argument (e.g.
+        # ``fileutil::updateInPlace`` appends the file contents).  The
+        # carrying state is set by ``_analyse_body_inner`` only for the
+        # immediate top-level command of the body.
+        implicit = getattr(self, "_pending_implicit_args", 0)
+        if implicit:
+            nargs_min += implicit
+            if nargs_max != Arity.ANY:
+                nargs_max += implicit
         display_name = proc_def.qualified_name
         if nargs_max < arity.min:
             self.result.diagnostics.append(

--- a/core/commands/registry/models.py
+++ b/core/commands/registry/models.py
@@ -422,6 +422,11 @@ class SubCommand:
     # separate procedure/handler.
     body_kind: BodyKind = BodyKind.INLINE
 
+    # Number of arguments the runtime appends to a ``ArgRole.BODY``
+    # argument when invoking it as a command prefix.  See the matching
+    # field on :class:`CommandSpec` for details.
+    body_arg_implicit_args: int = 0
+
     # CFG-lowered command name for ensemble subcommands that get rewritten.
     # When set, the CFG lowering pass replaces ``<command> <subname>`` with
     # this qualified name and drops the subcommand word from the argument
@@ -694,6 +699,14 @@ class CommandSpec:
     # Set to ``STRUCTURAL`` for commands whose body is analysed as a
     # separate procedure/handler (``proc``, ``when``, ``tcltest::test``).
     body_kind: BodyKind = BodyKind.INLINE
+
+    # Number of arguments the runtime appends to a ``ArgRole.BODY``
+    # argument when invoking it as a command prefix (e.g.
+    # ``fileutil::updateInPlace`` appends the file contents).  When
+    # non-zero, the body is treated as a callback/command-prefix: the
+    # arity check on the first top-level command in the body is
+    # relaxed by this many positional arguments.
+    body_arg_implicit_args: int = 0
 
     # Whether this command's source namespace exports it via
     # ``namespace export <bare>``, making it eligible for retrieval as a

--- a/core/commands/registry/runtime.py
+++ b/core/commands/registry/runtime.py
@@ -1092,6 +1092,42 @@ def body_kind_for_command(command: str, args: list[str]) -> BodyKind:
     return spec.body_kind
 
 
+def body_arg_implicit_args_for_command(command: str, args: list[str]) -> int:
+    """Return the number of runtime-appended args for *command*'s BODY arg.
+
+    Mirrors the spec/subcommand resolution used by
+    :func:`body_kind_for_command`.  Returns 0 for unregistered
+    commands or commands whose ``BODY`` arg is a literal script (the
+    default).  A positive value signals that the body is invoked as a
+    command prefix with that many extra args appended at runtime —
+    arity checks on the first top-level command of the body should
+    account for the implicit args.
+    """
+    alias = _REWRITE_ALIASES.get(command)
+    if alias is not None:
+        source_cmd, sub_name = alias
+        spec = REGISTRY.get_any(source_cmd)
+        if spec is not None:
+            sub = spec.subcommands.get(sub_name)
+            if sub is not None:
+                return sub.body_arg_implicit_args
+        return 0
+
+    if command in SIGNATURES or command in _ROLE_HINTS:
+        target = command
+    else:
+        target = _canonicalise_command_name(command)
+
+    spec = REGISTRY.get_any(target)
+    if spec is None:
+        return 0
+    if spec.subcommands and args:
+        sub = spec.subcommands.get(args[0])
+        if sub is not None:
+            return sub.body_arg_implicit_args
+    return spec.body_arg_implicit_args
+
+
 def arg_indices_for_role(command: str, args: list[str], role: ArgRole) -> set[int]:
     """Return argument indices (0-based, after command name) for a role."""
     if role is ArgRole.BODY:

--- a/core/commands/registry/tcllib/fileutil.py
+++ b/core/commands/registry/tcllib/fileutil.py
@@ -205,6 +205,7 @@ _fu(
     "fileutil::updateInPlace ?options? fileName cmdOrBody",
     Arity(2),
     arg_role_resolver=_update_in_place_arg_roles,
+    body_arg_implicit_args=1,
     side_effect_hints=_fileutil_se(reads=True, writes=True),
 )
 _fu(

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -740,6 +740,44 @@ class TestDiagnostics:
         unreachable = [d for d in result.diagnostics if d.code == "I231"]
         assert len(unreachable) >= 1
 
+    def test_fileutil_update_in_place_command_prefix_no_e002(self):
+        """Regression test for issue #308.
+
+        ``fileutil::updateInPlace path cmd`` invokes *cmd* as a
+        command prefix with the file contents appended at runtime, so
+        the arity check on the proc passed by name must account for
+        that implicit appended argument and not fire E002 spuriously.
+        """
+        source = textwrap.dedent("""\
+            package require fileutil
+            proc processContents {contents} { return $contents }
+            fileutil::updateInPlace foo.html processContents
+        """)
+        result = analyse(source)
+        errors = [
+            d
+            for d in result.diagnostics
+            if d.code == "E002" and "::processContents" in d.message
+        ]
+        assert errors == [], f"unexpected E002 diagnostics: {errors}"
+
+    def test_fileutil_update_in_place_too_few_still_detected(self):
+        """The implicit-args relaxation must not mask a genuine arity
+        error: a callback that needs two extra parameters beyond the
+        appended contents argument should still fire E002."""
+        source = textwrap.dedent("""\
+            package require fileutil
+            proc processContents {a b contents} { return $contents }
+            fileutil::updateInPlace foo.html processContents
+        """)
+        result = analyse(source)
+        errors = [
+            d
+            for d in result.diagnostics
+            if d.code == "E002" and "::processContents" in d.message
+        ]
+        assert len(errors) == 1
+
 
 class TestControlFlow:
     def test_if_body_analysed(self):

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -755,9 +755,7 @@ class TestDiagnostics:
         """)
         result = analyse(source)
         errors = [
-            d
-            for d in result.diagnostics
-            if d.code == "E002" and "::processContents" in d.message
+            d for d in result.diagnostics if d.code == "E002" and "::processContents" in d.message
         ]
         assert errors == [], f"unexpected E002 diagnostics: {errors}"
 
@@ -772,9 +770,7 @@ class TestDiagnostics:
         """)
         result = analyse(source)
         errors = [
-            d
-            for d in result.diagnostics
-            if d.code == "E002" and "::processContents" in d.message
+            d for d in result.diagnostics if d.code == "E002" and "::processContents" in d.message
         ]
         assert len(errors) == 1
 

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -774,6 +774,23 @@ class TestDiagnostics:
         ]
         assert len(errors) == 1
 
+    def test_fileutil_update_in_place_builtin_callback_no_e002(self):
+        """A built-in command used as a command-prefix callback must
+        not produce a spurious arity diagnostic.  The built-in arity
+        checker (``_arity_checks`` in compiler_checks.py) currently
+        does not recurse into BODY arguments of unstructured commands
+        so no false positive fires today; this test guards against
+        regressions if the IR ever starts walking those bodies — at
+        that point ``body_arg_implicit_args`` should be threaded
+        through the IR-side arity check too."""
+        source = textwrap.dedent("""\
+            package require fileutil
+            fileutil::updateInPlace foo.html {string toupper}
+        """)
+        result = analyse(source)
+        arity_errors = [d for d in result.diagnostics if d.code in ("E001", "E002", "E003")]
+        assert arity_errors == [], f"unexpected arity diagnostics: {arity_errors}"
+
 
 class TestControlFlow:
     def test_if_body_analysed(self):


### PR DESCRIPTION
## Summary

- Add support for tracking and accounting for runtime-appended arguments in command-prefix bodies
- Implement `body_arg_implicit_args` field in `CommandSpec` and `SubCommand` to declare how many arguments a command appends when invoking a body as a command prefix
- Update arity checking to relax constraints on the first top-level command in such bodies by the number of implicit arguments
- Register `fileutil::updateInPlace` as appending 1 implicit argument (the file contents)
- Add regression tests to verify E002 arity errors are not spuriously fired for command-prefix callbacks

## Details

This change fixes issue #308 where `fileutil::updateInPlace` invokes a callback command with the file contents appended at runtime, but the analyzer was incorrectly flagging the callback's arity as wrong.

The implementation:
1. Adds `body_arg_implicit_args` metadata to command specs to declare implicit arguments
2. Introduces `_pending_implicit_args` state in the analyzer to track implicit args for the current body
3. Modifies `_analyse_body` to accept and propagate `implicit_appended_args` parameter
4. Updates arity checking in `_check_proc_call_arity` to account for implicit args
5. Ensures implicit args only apply to the first top-level command in a body (subsequent commands wouldn't be reachable under command-prefix semantics)

## Validation

- Added `test_fileutil_update_in_place_command_prefix_no_e002` to verify E002 is not fired for correctly-arity'd callbacks
- Added `test_fileutil_update_in_place_too_few_still_detected` to verify genuine arity errors are still caught
- Existing test suite passes

https://claude.ai/code/session_01R5uLutvV65VFAoJHTiYUWA