### PR TITLE
Add OOM guards in hash table insertion paths

### DIFF
--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -311,7 +311,11 @@ fn frame_grow_at_base(base: u32) u32 {
     // Rehash every populated bucket from the old buffer into the
     // new (larger) buffer.  Use the new table's ``try_insert_header``
     // — its probe chain is bounded by the new capacity, which is
-    // strictly larger than the old, so insertion always succeeds.
+    // strictly larger than the old, so the only way insertion can
+    // fail is an OOM on the per-key heap copy ``try_insert_header``
+    // makes.  Silently skipping a null return would drop a live
+    // frame-local during growth (state corruption); trap loudly so
+    // the partially-populated new buffer never replaces the old.
     var new_table: FrameTable = .{ .buf = new_base, .cap = new_cap, .count = 0 };
     // Bucket header layout (see hash_table.zig:63):
     //   [0..3]   name_ptr  (0 or TOMBSTONE means skip)
@@ -329,6 +333,10 @@ fn frame_grow_at_base(base: u32) u32 {
         const value = read_i32(old_bucket + OFF_VALUE);
         if (new_table.try_insert_header(name_ptr, name_len, hash)) |new_bucket| {
             write_i32(new_bucket + OFF_VALUE, value);
+        } else {
+            const errmsg = "frame_grow: OOM during rehash";
+            rt_fd_write_stderr(errmsg);
+            @trap();
         }
     }
 

--- a/runtime/zig/valtypes/hash_table.zig
+++ b/runtime/zig/valtypes/hash_table.zig
@@ -176,6 +176,14 @@ pub fn Table(comptime bucket_size: u32) type {
                     // End of probe chain — fall through to insert.
                     const target = if (first_tombstone != 0) first_tombstone else base;
                     const nbuf = alloc(name_len);
+                    // ``alloc`` returns 0 on OOM (and raises ``oom_flag``).
+                    // Surface as ``null`` so the caller's existing
+                    // "table full" handling path covers OOM too — without
+                    // this guard, ``memcpy`` would call ``@ptrFromInt(0)``
+                    // and trip the debug "cast causes pointer to be null"
+                    // panic.  Leaves the bucket untouched so a retry after
+                    // the OOM clears can still place the entry.
+                    if (nbuf == 0 and name_len != 0) return null;
                     memcpy(nbuf, name_ptr, name_len);
                     write_i32(target, @bitCast(nbuf));
                     write_i32(target + 4, @bitCast(name_len));
@@ -214,6 +222,8 @@ pub fn Table(comptime bucket_size: u32) type {
             // if one was seen.
             if (first_tombstone != 0) {
                 const nbuf = alloc(name_len);
+                // OOM guard mirrors the end-of-probe-chain path above.
+                if (nbuf == 0 and name_len != 0) return null;
                 memcpy(nbuf, name_ptr, name_len);
                 write_i32(first_tombstone, @bitCast(nbuf));
                 write_i32(first_tombstone + 4, @bitCast(name_len));


### PR DESCRIPTION
## Summary

- Add null checks after `alloc()` calls in hash table insertion to properly handle out-of-memory conditions
- Prevent potential null pointer dereference in `memcpy()` by returning early when allocation fails
- Ensure OOM errors surface through the caller's existing "table full" handling path rather than triggering debug panics

## Details

The hash table's `insert()` function calls `alloc()` to allocate memory for entry names in two code paths:
1. At the end of a probe chain (when no matching key is found)
2. When reusing a tombstone slot

The `alloc()` function returns 0 on out-of-memory and sets an `oom_flag`, but the code was not checking for this condition. Without the guard, a subsequent `memcpy(0, ...)` call would invoke `@ptrFromInt(0)`, triggering a debug panic about null pointer creation.

This change adds OOM guards in both paths that return `null` when allocation fails, allowing the caller's existing error handling to treat OOM the same as other "table full" conditions. The bucket is left untouched, enabling a retry after OOM recovery.

## Validation

- No new tests needed; this is a defensive fix for an error path
- Existing hash table tests continue to pass

https://claude.ai/code/session_014eFPopiKrDcRXBhDMRpow9