### PR TITLE
Optimize hover requests with debouncing, caching, and async

### DIFF
--- a/lsp/features/hover.py
+++ b/lsp/features/hover.py
@@ -892,9 +892,19 @@ def get_hover(
     analysis: AnalysisResult | None = None,
     *,
     lines: list[str] | None = None,
+    analyse_if_missing: bool = True,
 ) -> types.Hover | None:
-    """Generate hover info for a position in source."""
+    """Generate hover info for a position in source.
+
+    When ``analyse_if_missing`` is true (default, used by tests and direct
+    callers) and ``analysis`` is None, the source is analysed synchronously.
+    The LSP server passes ``analyse_if_missing=False`` so that hover requests
+    that arrive while a fresh analysis is still pending in the background
+    return quickly without duplicating the analysis on the request thread.
+    """
     if analysis is None:
+        if not analyse_if_missing:
+            return None
         analysis = analyse(source)
 
     # Check for variable hover ($var)

--- a/lsp/lifecycle.py
+++ b/lsp/lifecycle.py
@@ -120,6 +120,12 @@ def did_close(params: types.DidCloseTextDocumentParams) -> None:
     uri = params.text_document.uri
     log.info("Closed %s", uri)
     _state.diagnostic_scheduler.cancel(uri)
+    # Drop cached hover entries so a reopen-with-version-reset (clients
+    # commonly reset to ``1``) cannot serve stale entries from the
+    # previous session keyed on a matching ``(uri, version, line, char)``.
+    from lsp.server import _invalidate_hover_cache
+
+    _invalidate_hover_cache(uri)
     if _dp._is_bigip_conf(uri):
         _state.background_scanner.remove_bigip_config(uri)
         _server.text_document_publish_diagnostics(  # type: ignore[union-attr]

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -562,8 +562,22 @@ async def on_hover(params: types.HoverParams) -> types.Hover | None:
         lines=lines,
         analyse_if_missing=False,
     )
+    # Cache regardless of supersession: the result is correctly keyed by
+    # ``(uri, version, line, character)`` and remains valid for any future
+    # hover at the same point until the document version changes.
     _hover_cache_put(cache_key, result)
     elapsed_ms = (time.perf_counter() - t0) * 1000
+    # Recheck supersession after the threaded compute. If a newer hover
+    # for this URI arrived while we were running, suppress this response
+    # so a slow hover can't race ahead of a newer cursor position.
+    with _hover_lock:
+        if _hover_seq.get(uri, 0) != seq:
+            log.debug(
+                "[timing] hover %.0fms (superseded post-compute, uri=%s)",
+                elapsed_ms,
+                uri,
+            )
+            return None
     log.debug(
         "[timing] hover %.0fms (uri=%s, line=%d, char=%d, hit=%s)",
         elapsed_ms,
@@ -573,6 +587,20 @@ async def on_hover(params: types.HoverParams) -> types.Hover | None:
         "yes" if result else "no",
     )
     return result
+
+
+def _invalidate_hover_cache(uri: str) -> None:
+    """Drop hover cache entries and the request counter for a URI.
+
+    Called from ``did_close`` so that a reopen-with-version-reset (clients
+    commonly reset to ``1`` after close) cannot serve stale hover content
+    keyed on the previous session's matching ``(uri, version, line, char)``.
+    """
+    with _hover_lock:
+        _hover_seq.pop(uri, None)
+        keys = [k for k in _hover_cache if k[0] == uri]
+        for k in keys:
+            _hover_cache.pop(k, None)
 
 
 # Go to definition

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -539,13 +539,13 @@ async def on_hover(params: types.HoverParams) -> types.Hover | None:
         )
         return cached
 
-    source = _get_doc_source(uri)
     analysis = state.analysis if state else None
-    lines = state.lines if state else None
     if analysis is None:
         # Fresh analysis is still pending in the diagnostics pipeline.
         # Return quickly instead of duplicating the parse on the request
         # thread; the next hover will pick up the cached analysis.
+        # ``_get_doc_source`` can fall back to a pygls workspace lookup,
+        # so it is only called once we know we are going to compute.
         log.debug(
             "[timing] hover %.0fms (no analysis, uri=%s)",
             (time.perf_counter() - t0) * 1000,
@@ -553,6 +553,8 @@ async def on_hover(params: types.HoverParams) -> types.Hover | None:
         )
         return None
 
+    source = _get_doc_source(uri)
+    lines = state.lines if state else None
     result = await asyncio.to_thread(
         get_hover,
         source,
@@ -579,7 +581,7 @@ async def on_hover(params: types.HoverParams) -> types.Hover | None:
             )
             return None
     log.debug(
-        "[timing] hover %.0fms (uri=%s, line=%d, char=%d, hit=%s)",
+        "[timing] hover %.0fms (uri=%s, line=%d, char=%d, has_result=%s)",
         elapsed_ms,
         uri,
         line,

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
+from collections import OrderedDict
 
 from lsprotocol import types
 from pygls.lsp.server import LanguageServer
@@ -459,23 +461,118 @@ def on_completion(
 
 
 # Hover
+#
+# Eldoc-style clients (Eglot) issue ``textDocument/hover`` on every cursor
+# move, so the handler is structured to absorb bursts cheaply:
+#
+#   * a per-URI counter supersedes older requests when a newer one arrives
+#     for the same document — the older request returns ``None`` after a
+#     short debounce window without doing any work;
+#   * results are cached by ``(uri, version, line, character)`` so repeated
+#     requests at the same point return immediately;
+#   * the actual hover computation runs in a worker thread so a slow hover
+#     does not block the event loop;
+#   * if the cached analysis is not yet ready (fresh ``didChange`` still
+#     analysing in the process pool) we return ``None`` rather than running
+#     a duplicate synchronous parse on the request path.
+
+_HOVER_DEBOUNCE_S = 0.03
+_HOVER_CACHE_MAX = 256
+_hover_seq: dict[str, int] = {}
+_hover_cache: OrderedDict[tuple[str, int | None, int, int], types.Hover | None] = OrderedDict()
+_hover_lock = threading.Lock()
+
+
+def _hover_cache_get(
+    key: tuple[str, int | None, int, int],
+) -> tuple[bool, types.Hover | None]:
+    with _hover_lock:
+        if key in _hover_cache:
+            _hover_cache.move_to_end(key)
+            return True, _hover_cache[key]
+    return False, None
+
+
+def _hover_cache_put(key: tuple[str, int | None, int, int], value: types.Hover | None) -> None:
+    with _hover_lock:
+        _hover_cache[key] = value
+        _hover_cache.move_to_end(key)
+        while len(_hover_cache) > _HOVER_CACHE_MAX:
+            _hover_cache.popitem(last=False)
 
 
 @server.feature(types.TEXT_DOCUMENT_HOVER)
-def on_hover(params: types.HoverParams) -> types.Hover | None:
+async def on_hover(params: types.HoverParams) -> types.Hover | None:
     if not feature_config.hover_enabled:
         return None
+    t0 = time.perf_counter()
     uri = params.text_document.uri
-    source = _get_doc_source(uri)
+    line = params.position.line
+    character = params.position.character
+
+    with _hover_lock:
+        seq = _hover_seq.get(uri, 0) + 1
+        _hover_seq[uri] = seq
+
+    # Debounce: if another hover for the same URI arrives within the
+    # window, drop this one. This collapses Eldoc bursts on rapid cursor
+    # moves to a single computation for the final position.
+    await asyncio.sleep(_HOVER_DEBOUNCE_S)
+    with _hover_lock:
+        if _hover_seq.get(uri, 0) != seq:
+            log.debug(
+                "[timing] hover %.0fms (superseded, uri=%s)",
+                (time.perf_counter() - t0) * 1000,
+                uri,
+            )
+            return None
+
     state = workspace_state.get(uri)
+    version = state.version if state else None
+    cache_key = (uri, version, line, character)
+    hit, cached = _hover_cache_get(cache_key)
+    if hit:
+        log.debug(
+            "[timing] hover %.0fms (cache hit, uri=%s)",
+            (time.perf_counter() - t0) * 1000,
+            uri,
+        )
+        return cached
+
+    source = _get_doc_source(uri)
     analysis = state.analysis if state else None
-    return get_hover(
+    lines = state.lines if state else None
+    if analysis is None:
+        # Fresh analysis is still pending in the diagnostics pipeline.
+        # Return quickly instead of duplicating the parse on the request
+        # thread; the next hover will pick up the cached analysis.
+        log.debug(
+            "[timing] hover %.0fms (no analysis, uri=%s)",
+            (time.perf_counter() - t0) * 1000,
+            uri,
+        )
+        return None
+
+    result = await asyncio.to_thread(
+        get_hover,
         source,
-        params.position.line,
-        params.position.character,
+        line,
+        character,
         analysis=analysis,
-        lines=state.lines if state else None,
+        lines=lines,
+        analyse_if_missing=False,
     )
+    _hover_cache_put(cache_key, result)
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    log.debug(
+        "[timing] hover %.0fms (uri=%s, line=%d, char=%d, hit=%s)",
+        elapsed_ms,
+        uri,
+        line,
+        character,
+        "yes" if result else "no",
+    )
+    return result
 
 
 # Go to definition


### PR DESCRIPTION
## Summary

- Restructure the hover handler to efficiently handle rapid cursor movements from Eldoc-style clients (e.g., Eglot)
- Implement per-URI request debouncing to collapse bursts of hover requests to a single computation
- Add LRU caching of hover results by `(uri, version, line, character)` to avoid redundant computations
- Move hover computation to a worker thread using `asyncio.to_thread()` to prevent blocking the event loop
- Skip analysis when fresh analysis is still pending in the diagnostics pipeline, returning `None` instead of duplicating work
- Add timing instrumentation to debug hover performance

The hover handler now:
1. Tracks request sequences per URI to detect and drop superseded requests
2. Waits briefly (30ms) to allow newer requests to arrive before computing
3. Checks an LRU cache (max 256 entries) for previously computed results
4. Skips computation if analysis is not yet ready
5. Runs the actual hover computation asynchronously in a thread pool
6. Caches results for future requests at the same position

This significantly reduces latency and CPU usage when clients issue hover requests on every cursor movement.

## Validation

- Existing hover tests continue to pass (the `analyse_if_missing` parameter defaults to `True` for backward compatibility)
- New async handler integrates with pygls' async support
- Timing logs help verify debouncing and caching effectiveness in practice

https://claude.ai/code/session_013h6yZC6KCv4rURzDr6iYVu