### PR TITLE
Fix gets command EOF handling and scan whitespace skipping

### DIFF
--- a/vm/commands/format_cmds.py
+++ b/vm/commands/format_cmds.py
@@ -212,8 +212,10 @@ def _cmd_scan(interp: TclInterp, args: list[str]) -> TclResult:
             conv = fmt[fmt_pos]
             fmt_pos += 1
 
-            # All conversions except %c skip leading whitespace.
-            if conv != "c":
+            # All conversions except %c and %n skip leading whitespace.
+            # %c is character-exact; %n records position without consuming
+            # input, so neither should advance str_pos through whitespace.
+            if conv != "c" and conv != "n":
                 while str_pos < len(string) and string[str_pos].isspace():
                     str_pos += 1
 

--- a/vm/commands/format_cmds.py
+++ b/vm/commands/format_cmds.py
@@ -212,6 +212,11 @@ def _cmd_scan(interp: TclInterp, args: list[str]) -> TclResult:
             conv = fmt[fmt_pos]
             fmt_pos += 1
 
+            # All conversions except %c skip leading whitespace.
+            if conv != "c":
+                while str_pos < len(string) and string[str_pos].isspace():
+                    str_pos += 1
+
             if conv == "d" or conv == "i":
                 start = str_pos
                 if str_pos < len(string) and string[str_pos] in "+-":

--- a/vm/commands/io.py
+++ b/vm/commands/io.py
@@ -64,13 +64,16 @@ def _cmd_gets(interp: TclInterp, args: list[str]) -> TclResult:
     if ch is None:
         raise TclError(f'can not find channel named "{channel}"')
 
-    line = ch.readline()
-    if line.endswith("\n"):
-        line = line[:-1]
+    raw = ch.readline()
+    at_eof = not raw
+    nl = b"\n" if isinstance(raw, bytes) else "\n"
+    line = raw[:-1] if raw.endswith(nl) else raw
+    if isinstance(line, bytes):
+        line = line.decode("utf-8", errors="replace")
 
     if len(args) >= 2:
         interp.current_frame.set_var(args[1], line)
-        return TclResult(value=str(len(line)))
+        return TclResult(value="-1" if at_eof else str(len(line)))
     return TclResult(value=line)
 
 


### PR DESCRIPTION
## Summary

- Fixed `gets` command to properly detect EOF and return -1 when at end of file, matching Tcl behavior
- Added proper handling for binary vs text mode in `gets` command with UTF-8 decoding
- Fixed `scan` command to skip leading whitespace for all format conversions except `%c`, per Tcl specification

## Details

### gets command fixes
- Changed return value to -1 when EOF is reached (previously returned 0)
- Added detection of EOF condition (`at_eof = not raw`)
- Added support for both binary and text mode channels with proper UTF-8 decoding
- Improved newline handling to work with both bytes and string types

### scan command fixes
- Added leading whitespace skipping for all conversions except `%c` format specifier
- This aligns with standard Tcl `scan` behavior where whitespace is consumed before parsing numeric and string values

## Validation

- [ ] I ran relevant tests/checks locally and listed the exact commands.

https://claude.ai/code/session_01Nni3gX2KCzyxjWdgGeMLxV