### PR TITLE
Fix memory leaks in TclObj reference counting (issue #317)

### DIFF
--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -23,7 +23,8 @@ fn eval_list(words: []const i32) i32 {
         max_total += s.len * 2 + 2;
         if (ei > 1) max_total += 1;
     }
-    const buf = obj_mod.alloc(max_total + 4);
+    const alloc_size: u32 = max_total + 4;
+    const buf = obj_mod.alloc(alloc_size);
     var off: u32 = 0;
     ei = 1;
     while (ei < words.len) : (ei += 1) {
@@ -39,7 +40,12 @@ fn eval_list(words: []const i32) i32 {
             off = obj_mod.list_elem_quote_nth(buf, off, s.ptr, s.len);
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    // Issue #317: own the result buffer so the caller's release
+    // reclaims it via ``free_sized``; without this every
+    // ``[list ...]`` invocation leaked one buf, and the
+    // resulting cap=0 also forced ``lappend``'s slow rebuild
+    // path on every subsequent append.
+    return obj_mod.obj_new_string_take(buf, off, alloc_size);
 }
 
 fn eval_lappend(words: []const i32) i32 {

--- a/runtime/zig/dispatch/tcl_dispatch.zig
+++ b/runtime/zig/dispatch/tcl_dispatch.zig
@@ -142,7 +142,8 @@ pub fn dispatch(bucket: i32, words: []const i32) i32 {
             for (0..proc_len) |k| d[prefix.len + k] = np[k];
         }
         for (suffix, 0..) |b, k| d[prefix.len + proc_len + k] = b;
-        const msg = obj.obj_new_string(@bitCast(buf), @bitCast(total));
+        // Issue #317: see ``build_args_list`` below.
+        const msg = obj.obj_new_string_take(buf, total, total);
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
@@ -249,5 +250,9 @@ fn build_args_list(words: []const i32, fixed: u32) i32 {
             off = obj.list_elem_quote_nth(buf, off, s.ptr, s.len);
         }
     }
-    return obj.obj_new_string(@bitCast(buf), @bitCast(off));
+    // Issue #317: ``obj_new_string_take`` so the args list owns
+    // ``buf`` (so its eventual release frees the slab).  The
+    // older borrowing form leaked one buf per compiled-proc
+    // dispatch with a tail ``args`` parameter.
+    return obj.obj_new_string_take(buf, off, total);
 }

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -213,16 +213,28 @@ pub export fn catch_has_error() i32 {
 // $::errorInfo`` without introspecting call frames.  ``::errorCode``
 // defaults to ``NONE`` for ``error msg`` with no explicit code.
 fn stamp_error_globals(msg: i32, info: i32, code: i32) void {
+    // Issue #317: ``global_set`` reads the name's byte span (the
+    // var subsystem stores its own copy) and retains the value
+    // for the slot.  Without these releases, every error event
+    // leaked one TclObj per name (``::errorInfo`` / ``::errorCode``)
+    // plus, on the default-code path, one ``NONE`` value TclObj —
+    // four fresh allocations per error.  tcltest exercises the
+    // catched-error path many times per test, so this scaled
+    // linearly with the suite size.
     const info_name = obj_new_string_copy(@intFromPtr("::errorInfo".ptr), 11);
     const info_val = if (info != 0) info else msg;
     _ = globals.global_set(info_name, info_val);
+    obj.tcl_obj_release(info_name);
 
     const code_name = obj_new_string_copy(@intFromPtr("::errorCode".ptr), 11);
-    const code_val = if (code != 0)
-        code
+    const default_code = code == 0;
+    const code_val = if (default_code)
+        obj_new_string_copy(@intFromPtr("NONE".ptr), 4)
     else
-        obj_new_string_copy(@intFromPtr("NONE".ptr), 4);
+        code;
     _ = globals.global_set(code_name, code_val);
+    obj.tcl_obj_release(code_name);
+    if (default_code) obj.tcl_obj_release(code_val);
 }
 
 // Exported: error — write message to stderr and trap, OR set error flag in catch.
@@ -292,7 +304,11 @@ pub fn error_unknown_command(cmd_obj: i32) void {
         const src: [*]const u8 = @ptrFromInt(s.ptr);
         for (0..s.len) |i| buf[prefix.len + i] = src[i];
     }
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // Issue #317: ``obj_new_string_take`` so the error TclObj
+    // owns ``buf_addr`` and ``release_now`` returns it via
+    // ``free_sized``; the older borrowing form leaked one buf per
+    // raised error inside a ``catch``.
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
     tcl_cmd_error(msg);
 }
 
@@ -326,6 +342,7 @@ pub export fn var_unset_error(name_obj: i32) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // Issue #317: see ``error_unknown_command`` above.
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
     tcl_cmd_error(msg);
 }

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -1004,7 +1004,18 @@ pub export fn var_exists(name: i32) i32 {
             const arr_name = obj.obj_new_string(@bitCast(sn.ptr), @bitCast(paren));
             const key_len = sn.len - paren - 2;
             const key = obj.obj_new_string(@bitCast(sn.ptr + paren + 1), @bitCast(key_len));
-            return tcl_array.array_element_exists(arr_name, key);
+            const exists = tcl_array.array_element_exists(arr_name, key);
+            // Issue #317: ``arr_name`` and ``key`` are scratch
+            // borrowing-form TclObjs (cap = 0, bytes belong to
+            // ``sn``).  ``array_element_exists`` only reads their
+            // bytes for the lookup; without these releases every
+            // ``info exists arr(idx)`` probe leaked two TclObj
+            // headers, and tcltest's constraint sweep
+            // (``info exists testConstraints($c)``) hits this path
+            // many times per test.
+            obj.tcl_obj_release(arr_name);
+            obj.tcl_obj_release(key);
+            return exists;
         }
     }
     if (current_frame()) |base| {

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -25,6 +25,7 @@ const obj_new_string = rt.obj_new_string;
 const obj_new_int = rt.obj_new_int;
 const obj_get_int = rt.obj_get_int;
 const obj_new_string_copy = rt.obj_new_string_copy;
+const obj_new_string_take = rt.obj_new_string_take;
 const copy_unbraced_elem = rt.copy_unbraced_elem;
 const obj_ensure_string = rt.obj_ensure_string;
 const list_count_elements = rt.list_count_elements;
@@ -649,9 +650,14 @@ pub fn eval_foreach(words: []const i32) i32 {
         else blk: {
             const buf = alloc(elem.len);
             const out_len = copy_unbraced_elem(buf, list_s.ptr + elem.start, elem.len);
-            break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
+            break :blk obj_new_string_take(buf, out_len, elem.len);
         };
+        // Issue #317: ``var_set`` retains ``elem_val`` for the
+        // frame slot; without dropping the creator-side ref here,
+        // every iteration leaked one TclObj (plus its bytes after
+        // the ``obj_new_string_take`` switch above).
         _ = frames.var_set(var_name, elem_val);
+        obj_mod.tcl_obj_release(elem_val);
         // Release the prior body result before overwriting (issue
         // #303 — same loop-leak pattern as ``eval_for`` /
         // ``eval_while``).
@@ -718,7 +724,9 @@ fn emit_child_arity_error(
     for (tail, 0..) |b, k| {
         d[prefix.len + child_name_len + suffix.len + k] = b;
     }
-    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    // Issue #317: see ``stubs.unsupported`` for the ownership
+    // rationale.
+    const msg = obj_mod.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -741,7 +749,8 @@ fn emit_child_bad_option(name_ptr: u32, name_len: u32) void {
     for (CHILD_SUBCOMMAND_LIST, 0..) |b, k| {
         d[prefix.len + name_len + infix.len + k] = b;
     }
-    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    // Issue #317: see ``stubs.unsupported``.
+    const msg = obj_mod.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -1115,7 +1124,15 @@ fn build_invocation_list(words: []const i32) i32 {
             off = obj_mod.list_elem_quote_nth(buf, off, s.ptr, s.len);
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    // Issue #317: ``obj_new_string_take`` so the resulting list
+    // owns its buffer; the older borrowing form leaked the buf
+    // every time the eval-fallback proc dispatcher pushed an
+    // argv list.  Combined with the un-released argv ref at the
+    // caller (see ``eval_proc_call_bucket``), this was the
+    // dominant io.test residual — every ``::tcltest::test`` call
+    // (578 invocations in the failing trace) leaked one TclObj
+    // header and one quoted-args buffer.
+    return obj_new_string_take(buf, off, total);
 }
 
 /// Internal: dispatch once the proc bucket is already resolved.
@@ -1201,7 +1218,16 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
     // Stash the invocation argv (proc name + all call args) so
     // ``info level 0`` inside the body returns the real list
     // rather than the placeholder emitted by legacy callers.
-    frames.frame_set_argv(build_invocation_list(words));
+    // Issue #317: ``frame_set_argv`` retains the list for the
+    // frame's argv slot; without dropping our creator-side ref
+    // here the list TclObj sits at rc=2 once the frame pops, the
+    // frame's release brings it to 1, and the orphan rc keeps
+    // the obj (and its quoted-args buffer) alive forever.  Each
+    // proc call leaked one TclObj + one buf — the dominant
+    // io.test residual.
+    const argv = build_invocation_list(words);
+    frames.frame_set_argv(argv);
+    obj_mod.tcl_obj_release(argv);
 
     // Stamp the proc's namespace onto ``current_ns`` for the
     // duration of the body so unqualified calls inside the body
@@ -1261,6 +1287,15 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
             const param_name_ptr = ps.ptr + param_elem.start;
             const param_name_len = param_elem.len;
             const param_name = obj_new_string_copy(param_name_ptr, param_name_len);
+            // Issue #317: ``local_set`` only reads ``param_name``'s byte
+            // span (the hash table copies the bytes into its own
+            // bucket); the TclObj itself is not retained anywhere
+            // afterwards.  Without this defer, every proc invocation
+            // leaked one TclObj per parameter — the dominant io.test
+            // residual leak source after #303 closed the eval-loop
+            // intermediate-result paths.  The same fix applies in
+            // ``eval_apply`` below.
+            defer obj_mod.tcl_obj_release(param_name);
             const param_name_s: [*]const u8 = @ptrFromInt(param_name_ptr);
             // argv[0] is the command name, so argv[pi+1] is the first arg
             const arg_idx = pi + 1;
@@ -1272,8 +1307,14 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
             if (is_args_param) {
                 // Collect all remaining arguments into a list
                 if (arg_idx >= words.len) {
-                    // No remaining args: set to empty list
-                    _ = frames.local_set(param_name, obj_new_string(0, 0));
+                    // No remaining args: set to empty list.  Drop the
+                    // creator-side ref after ``local_set`` retains so
+                    // the frame slot is the only owner — otherwise the
+                    // empty TclObj leaks at rc=1 once the frame pops
+                    // (issue #317).
+                    const empty = obj_new_string(0, 0);
+                    _ = frames.local_set(param_name, empty);
+                    obj_mod.tcl_obj_release(empty);
                 } else if (arg_idx + 1 == words.len) {
                     // Exactly one remaining arg: use it directly as a list
                     _ = frames.local_set(param_name, words[arg_idx]);
@@ -1286,7 +1327,8 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                         total += sv.len * 2 + 4; // generous quoting estimate
                         if (ai > arg_idx) total += 1;
                     }
-                    const buf = alloc(total + 4);
+                    const args_alloc_size: u32 = total + 4;
+                    const buf = alloc(args_alloc_size);
                     var off: u32 = 0;
                     ai = arg_idx;
                     while (ai < words.len) : (ai += 1) {
@@ -1305,12 +1347,29 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                             off = obj_mod.list_elem_quote_nth(buf, off, sv.ptr, sv.len);
                         }
                     }
-                    _ = frames.local_set(param_name, obj_new_string(@bitCast(buf), @bitCast(off)));
+                    // Issue #317: ``obj_new_string_take`` lets the
+                    // resulting TclObj own ``buf`` (so its release
+                    // frees the backing slab via ``free_sized``); the
+                    // matching ``tcl_obj_release`` after ``local_set``
+                    // drops our creator-side ref so the frame slot is
+                    // the only owner.
+                    const args_obj = obj_new_string_take(buf, off, args_alloc_size);
+                    _ = frames.local_set(param_name, args_obj);
+                    obj_mod.tcl_obj_release(args_obj);
                 }
                 break;
             } else {
-                const arg_val = if (arg_idx < words.len) words[arg_idx] else obj_new_string(0, 0);
-                _ = frames.local_set(param_name, arg_val);
+                if (arg_idx < words.len) {
+                    // Caller-owned TclObj — no creator-side ref to drop.
+                    _ = frames.local_set(param_name, words[arg_idx]);
+                } else {
+                    // Default-empty for missing positional args; drop
+                    // the creator-side ref the same way as the empty
+                    // ``args`` branch above.
+                    const empty = obj_new_string(0, 0);
+                    _ = frames.local_set(param_name, empty);
+                    obj_mod.tcl_obj_release(empty);
+                }
             }
         }
     }
@@ -1694,17 +1753,26 @@ pub fn eval_apply(words: []const i32) i32 {
     const params_obj = if (params_elem.braced)
         obj_new_string_copy(lambda_s.ptr + params_elem.start, params_elem.len)
     else blk: {
-        const buf = alloc(params_elem.len + 4);
+        const alloc_size: u32 = params_elem.len + 4;
+        const buf = alloc(alloc_size);
         const out_len = copy_unbraced_elem(buf, lambda_s.ptr + params_elem.start, params_elem.len);
-        break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
+        break :blk obj_new_string_take(buf, out_len, alloc_size);
     };
+    // Issue #317: ``params_obj`` / ``body_obj`` are local copies of
+    // the lambda's two list elements; they're never stored in a
+    // frame slot or registered command, so without these defers
+    // every ``apply`` call leaks both TclObjs (and, before
+    // ``obj_new_string_take``, their backing bufs as well).
+    defer obj_mod.tcl_obj_release(params_obj);
     const body_obj = if (body_elem.braced)
         obj_new_string_copy(lambda_s.ptr + body_elem.start, body_elem.len)
     else blk: {
-        const buf = alloc(body_elem.len + 4);
+        const alloc_size: u32 = body_elem.len + 4;
+        const buf = alloc(alloc_size);
         const out_len = copy_unbraced_elem(buf, lambda_s.ptr + body_elem.start, body_elem.len);
-        break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
+        break :blk obj_new_string_take(buf, out_len, alloc_size);
     };
+    defer obj_mod.tcl_obj_release(body_obj);
 
     // Optional namespace from third lambda element
     const saved_ns: u32 = tcl_ns_mod.current_ns;
@@ -1723,6 +1791,8 @@ pub fn eval_apply(words: []const i32) i32 {
 
     // Bind parameters — same pattern as eval_proc_call_bucket but user
     // args start at words[2] (words[0]=apply, words[1]=lambda).
+    // Issue #317: refcount discipline matches eval_proc_call_bucket —
+    // see the comment block there for the per-branch leak rationale.
     const ps = obj_ensure_string(params_obj);
     const n_params: u32 = @intCast(list_count_elements(ps.ptr, ps.len));
     if (ps.len > 0 and n_params > 0) {
@@ -1732,6 +1802,7 @@ pub fn eval_apply(words: []const i32) i32 {
             const param_name_ptr = ps.ptr + param_elem.start;
             const param_name_len = param_elem.len;
             const param_name = obj_new_string_copy(param_name_ptr, param_name_len);
+            defer obj_mod.tcl_obj_release(param_name);
             const param_name_s: [*]const u8 = @ptrFromInt(param_name_ptr);
             const arg_idx = pi + 2; // skip words[0]=apply, words[1]=lambda
             const is_args_param = (pi == n_params - 1) and (param_name_len == 4) and
@@ -1739,7 +1810,9 @@ pub fn eval_apply(words: []const i32) i32 {
                 param_name_s[2] == 'g' and param_name_s[3] == 's';
             if (is_args_param) {
                 if (arg_idx >= words.len) {
-                    _ = frames.local_set(param_name, obj_new_string(0, 0));
+                    const empty = obj_new_string(0, 0);
+                    _ = frames.local_set(param_name, empty);
+                    obj_mod.tcl_obj_release(empty);
                 } else if (arg_idx + 1 == words.len) {
                     _ = frames.local_set(param_name, words[arg_idx]);
                 } else {
@@ -1750,7 +1823,8 @@ pub fn eval_apply(words: []const i32) i32 {
                         total += sv.len * 2 + 4;
                         if (ai > arg_idx) total += 1;
                     }
-                    const buf = alloc(total + 4);
+                    const args_alloc_size: u32 = total + 4;
+                    const buf = alloc(args_alloc_size);
                     var off: u32 = 0;
                     ai = arg_idx;
                     while (ai < words.len) : (ai += 1) {
@@ -1766,12 +1840,19 @@ pub fn eval_apply(words: []const i32) i32 {
                             off = obj_mod.list_elem_quote_nth(buf, off, sv.ptr, sv.len);
                         }
                     }
-                    _ = frames.local_set(param_name, obj_new_string(@bitCast(buf), @bitCast(off)));
+                    const args_obj = obj_new_string_take(buf, off, args_alloc_size);
+                    _ = frames.local_set(param_name, args_obj);
+                    obj_mod.tcl_obj_release(args_obj);
                 }
                 break;
             } else {
-                const arg_val = if (arg_idx < words.len) words[arg_idx] else obj_new_string(0, 0);
-                _ = frames.local_set(param_name, arg_val);
+                if (arg_idx < words.len) {
+                    _ = frames.local_set(param_name, words[arg_idx]);
+                } else {
+                    const empty = obj_new_string(0, 0);
+                    _ = frames.local_set(param_name, empty);
+                    obj_mod.tcl_obj_release(empty);
+                }
             }
         }
     }
@@ -1997,7 +2078,7 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
                 } else {
                     const buf = alloc(elem.len);
                     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
-                    expanded[ecount] = obj_new_string(@bitCast(buf), @bitCast(out_len));
+                    expanded[ecount] = obj_new_string_take(buf, out_len, elem.len);
                 }
                 ecount += 1;
             }
@@ -2011,12 +2092,17 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
     // MM-B.4 (slow path): release expanded[] elements after
     // dispatch, with the same alias-aware retain pattern as the
     // fast path.  Each ``{*}$args`` expansion element is a fresh
-    // TclObj — for braced elements, ``obj_new_string_copy``
-    // (cap > 0, owns its own bytes); for unbraced,
-    // ``obj_new_string`` borrowing into a freshly-alloced ``buf``
-    // (cap == 0, leaks the buf safely).  In both cases an element's
-    // release is independent of any peer; releasing one doesn't
-    // free a buffer another element borrows.
+    // TclObj that owns its bytes — braced elements via
+    // ``obj_new_string_copy`` (cap = rounded-up alloc), unbraced
+    // via ``obj_new_string_take`` (cap matches the per-element
+    // ``alloc(elem.len)`` that backed the backslash-decoded copy).
+    // Issue #317: the older ``obj_new_string`` borrowing form left
+    // ``cap = 0`` and leaked one buf per unbraced element on
+    // release — observed under io.test as the residual heap
+    // pressure that pushed the runtime past its 4 GiB ceiling.
+    // In both cases an element's release is independent of any
+    // peer; releasing one doesn't free a buffer another element
+    // borrows.
     const result = eval_command(expanded[0..ecount]);
     var result_is_word = false;
     if (result != 0) {

--- a/runtime/zig/stubs/tcl_stubs.zig
+++ b/runtime/zig/stubs/tcl_stubs.zig
@@ -33,7 +33,10 @@ pub fn unsupported(name: []const u8) void {
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (prefix, 0..) |c, i| buf[i] = c;
     for (name, 0..) |c, i| buf[prefix.len + i] = c;
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // Issue #317: ``obj_new_string_take`` so the error TclObj
+    // owns ``buf_addr`` — without it, every catched stub trap
+    // leaked the message buffer.
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -48,10 +51,12 @@ pub fn unsupported(name: []const u8) void {
 /// outside a catch the runtime writes the message to stderr and
 /// traps.
 pub fn raise(msg: []const u8) void {
-    const buf_addr: u32 = obj.alloc(@intCast(msg.len));
+    const alloc_size: u32 = @intCast(msg.len);
+    const buf_addr: u32 = obj.alloc(alloc_size);
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (msg, 0..) |c, i| buf[i] = c;
-    const msg_obj = obj.obj_new_string(@bitCast(buf_addr), @bitCast(msg.len));
+    // Issue #317: see ``unsupported`` above.
+    const msg_obj = obj.obj_new_string_take(buf_addr, alloc_size, alloc_size);
     catch_mod.tcl_cmd_error(msg_obj);
 }
 
@@ -82,6 +87,7 @@ pub fn unsupported_sub(cmd: []const u8, sub: []const u8) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // Issue #317: see ``unsupported`` above.
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
     catch_mod.tcl_cmd_error(msg);
 }

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -59,6 +59,7 @@ pub const obj_get_int = tcl_obj.obj_get_int;
 pub const obj_new_float = tcl_obj.obj_new_float;
 pub const obj_get_float = tcl_obj.obj_get_float;
 pub const obj_new_string_copy = tcl_obj.obj_new_string_copy;
+pub const obj_new_string_take = tcl_obj.obj_new_string_take;
 pub const obj_ensure_string = tcl_obj.obj_ensure_string;
 pub const list_count_elements = tcl_obj.list_count_elements;
 pub const list_element_at = tcl_obj.list_element_at;

--- a/runtime/zig/valtypes/parse_cache.zig
+++ b/runtime/zig/valtypes/parse_cache.zig
@@ -137,8 +137,17 @@ fn slab_size(slab_addr: u32) u32 {
 }
 
 /// Free the slab pointed at by *bucket* and zero the slot.  No-op
-/// when the bucket has no slab attached.
+/// when the bucket is empty / tombstoned or has no slab attached.
+///
+/// ``hash_table.Table.init`` / ``grow`` only zero each bucket's
+/// ``name_ptr`` slot — the rest of the bucket payload (including
+/// ``OFF_SLAB_ADDR``) carries whatever bytes ``alloc`` returned.
+/// Reading the slab pointer from an empty bucket and handing it to
+/// ``free_sized`` would be a wild free; gate on the occupied check
+/// instead (Codex review on PR #322).
 fn free_bucket_slab(bucket: u32) void {
+    const np: u32 = @bitCast(read_i32(bucket));
+    if (np == 0 or np == ht.TOMBSTONE) return;
     const slab: u32 = @bitCast(read_i32(bucket + OFF_SLAB_ADDR));
     if (slab == 0) return;
     write_i32(bucket + OFF_SLAB_ADDR, 0);

--- a/runtime/zig/valtypes/parse_cache.zig
+++ b/runtime/zig/valtypes/parse_cache.zig
@@ -37,6 +37,7 @@
 
 const obj = @import("tcl_obj.zig");
 const alloc = obj.alloc;
+const free_sized = obj.free_sized;
 const memcpy = obj.memcpy;
 const read_i32 = obj.read_i32;
 const write_i32 = obj.write_i32;
@@ -122,6 +123,28 @@ pub fn lookup(body_ptr: u32, body_len: u32) u32 {
     return 0;
 }
 
+/// Compute the byte size of an in-cache slab from its header.  Used
+/// by the invalidation paths to hand the slab back to ``free_sized``
+/// with the same size class ``alloc_slab`` requested — without this,
+/// every invalidated entry leaked one slab of up to ~1.6 KB
+/// (issue #317).
+fn slab_size(slab_addr: u32) u32 {
+    const n_commands: u32 = @bitCast(read_i32(slab_addr + OFF_SLAB_N_COMMANDS));
+    const total_tokens: u32 = @bitCast(read_i32(slab_addr + OFF_SLAB_TOTAL_TOKENS));
+    return SLAB_HEADER_SIZE
+        + n_commands * COMMAND_RECORD_SIZE
+        + total_tokens * TOKEN_SIZE;
+}
+
+/// Free the slab pointed at by *bucket* and zero the slot.  No-op
+/// when the bucket has no slab attached.
+fn free_bucket_slab(bucket: u32) void {
+    const slab: u32 = @bitCast(read_i32(bucket + OFF_SLAB_ADDR));
+    if (slab == 0) return;
+    write_i32(bucket + OFF_SLAB_ADDR, 0);
+    free_sized(slab, slab_size(slab));
+}
+
 /// Insert a fresh ``(body_ptr, body_len) -> slab_addr`` entry.
 /// Overwrites any existing entry for the same key (re-registering
 /// the same body ptr with a re-parsed slab).  Caller must own
@@ -132,6 +155,10 @@ pub fn insert(body_ptr: u32, body_len: u32, slab_addr: u32) void {
     const key = stage_key(body_ptr, body_len);
     const hash = ht.fnv1a(key, KEY_SIZE);
     if (cache.find(key, KEY_SIZE, hash)) |bucket| {
+        // Issue #317: free the old slab before overwriting; the
+        // older code dropped the pointer without ``free_sized``,
+        // leaking one slab on every re-parse for the same body.
+        free_bucket_slab(bucket);
         write_i32(bucket + OFF_SLAB_ADDR, @bitCast(slab_addr));
         return;
     }
@@ -163,9 +190,13 @@ pub fn invalidate_for_buffer(buf_ptr: u32) void {
         if (np == 0 or np == ht.TOMBSTONE) continue;
         const cached_body_ptr: u32 = @bitCast(read_i32(np));
         if (cached_body_ptr == buf_ptr) {
-            // Zero the slab pointer too so a stale read of the
-            // value payload can't be mistaken for a valid slab.
-            write_i32(bucket + OFF_SLAB_ADDR, 0);
+            // Issue #317: free the slab itself before tomb-stoning
+            // the bucket; the older code zeroed the slab pointer
+            // without handing the slab back to ``free_sized``, so
+            // every unique proc body the cache had ever held leaked
+            // one slab (~1.6 KB each) for the lifetime of the
+            // process.
+            free_bucket_slab(bucket);
             cache.delete_at(bucket);
         }
     }
@@ -183,13 +214,19 @@ pub fn invalidate_all() void {
     // isn't consulted by ``find`` (which stops at empty slots)
     // or ``needs_grow`` (which compares against cap).  Clearing
     // count lets future inserts start fresh.
+    //
+    // Issue #317: free each live slab before wiping the bucket.
+    // The bulk-eviction path (called from :func:`insert` when the
+    // cache hits ``MAX_ENTRIES``) and the proc-redefinition hook
+    // both reach here; without ``free_sized`` every wipe leaked
+    // up to ``MAX_ENTRIES * ~1.6 KB`` per call.
     var i: u32 = 0;
     while (i < cache.cap) : (i += 1) {
         const bucket = cache.buf + i * BUCKET_SIZE;
+        free_bucket_slab(bucket);
         write_i32(bucket, 0);
         write_i32(bucket + 4, 0);
         write_i32(bucket + 8, 0);
-        write_i32(bucket + OFF_SLAB_ADDR, 0);
     }
     cache.count = 0;
 }

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -223,7 +223,13 @@ fn raise_float_in_bitwise(o: i32, op_sym: []const u8, position: []const u8) void
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // Issue #317: ``obj_new_string_take`` so the error TclObj owns
+    // the message buffer; the older ``obj_new_string`` left
+    // ``OBJ_STR_CAP = 0`` and the buf was leaked on release inside
+    // a ``catch``.  Outside of ``catch`` ``tcl_cmd_error`` traps
+    // the process so the leak doesn't accumulate, but io.test
+    // exercises the catched path heavily through tcltest.
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
     @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
 }
 
@@ -264,7 +270,13 @@ fn raise_float_in_unary_bitwise(o: i32, op_sym: []const u8) void {
         buf[off] = c;
         off += 1;
     }
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // Issue #317: ``obj_new_string_take`` so the error TclObj owns
+    // the message buffer; the older ``obj_new_string`` left
+    // ``OBJ_STR_CAP = 0`` and the buf was leaked on release inside
+    // a ``catch``.  Outside of ``catch`` ``tcl_cmd_error`` traps
+    // the process so the leak doesn't accumulate, but io.test
+    // exercises the catched path heavily through tcltest.
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
     @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
 }
 

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -543,13 +543,32 @@ pub export fn array_set_list(arr: i32, pairs: i32) i32 {
         // the runtime's heap never mapped.
         const k_info = obj.list_element_at(sp.ptr, sp.len, i);
         const v_info = obj.list_element_at(sp.ptr, sp.len, i + 1);
-        const k_obj = obj_new_string(@bitCast(sp.ptr + k_info.start), @bitCast(k_info.len));
-        const v_obj = obj_new_string(@bitCast(sp.ptr + v_info.start), @bitCast(v_info.len));
+        // Issue #317: ``obj_new_string_copy`` so the per-pair
+        // TclObjs own their bytes.  Borrowing into ``sp`` (the
+        // source pairs list) is unsafe because ``array_set``
+        // stores ``v_obj`` in the array slot; once the source
+        // list is released the borrowed bytes go stale and the
+        // stored value reads as binary garbage on the next
+        // ``array get``.  Copying also lets ``release_now``
+        // reclaim the per-pair bufs cleanly.
+        const k_obj = obj.obj_new_string_copy(sp.ptr + k_info.start, k_info.len);
+        const v_obj = obj.obj_new_string_copy(sp.ptr + v_info.start, v_info.len);
         // ``array_set`` returns 0 when ``find_or_create`` flagged
         // a scalar/array name-conflict.  Stop iterating in that
         // case — every further call would re-raise the same
         // error and do no useful work.
-        if (array_set(arr, k_obj, v_obj) == 0) break;
+        if (array_set(arr, k_obj, v_obj) == 0) {
+            obj.tcl_obj_release(k_obj);
+            obj.tcl_obj_release(v_obj);
+            break;
+        }
+        // ``array_set`` retains ``v_obj`` for the slot via
+        // ``bucket_set_value``; ``k_obj``'s bytes are copied by
+        // the hash table.  Drop our creator-side refs so the
+        // array's retain is the only live owner of ``v_obj`` and
+        // ``k_obj`` can be freed at end of statement.
+        obj.tcl_obj_release(k_obj);
+        obj.tcl_obj_release(v_obj);
     }
     return obj_new_string(0, 0);
 }

--- a/runtime/zig/valtypes/tcl_format.zig
+++ b/runtime/zig/valtypes/tcl_format.zig
@@ -156,7 +156,12 @@ pub export fn tcl_cmd_format(fmt: i32, a1: i32, a2: i32, a3: i32) i32 {
         );
     }
 
-    return obj_new_string(@bitCast(buf_addr), @bitCast(off));
+    // Issue #317: claim ownership of the format buffer so the
+    // resulting TclObj's release frees it via ``free_sized``.
+    // The older borrowing form leaked one buf per ``format`` call;
+    // tcltest's progress / diagnostic output exercises this path
+    // heavily.
+    return obj.obj_new_string_take(buf_addr, off, bufsize);
 }
 
 fn emit_conversion(

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -129,9 +129,20 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
         if (elem.braced) {
             off = quoter(buf, off, sc_ptr + elem.start, elem.len);
         } else {
-            const tmp = alloc(elem.len + 1);
+            const tmp_size: u32 = elem.len + 1;
+            const tmp = alloc(tmp_size);
             const actual_len = copy_unbraced_elem(tmp, sc_ptr + elem.start, elem.len);
             off = quoter(buf, off, tmp, actual_len);
+            // Issue #317: ``tmp`` is a per-element scratch buffer
+            // for backslash decoding; ``quoter`` finishes copying
+            // its bytes into ``buf`` before this return, so the
+            // scratch is safe to reclaim immediately.  Without this
+            // ``free_sized`` every ``lappend`` against a list with
+            // unbraced elements leaked one buf per element per
+            // call — multiplied across tcltest's repeated
+            // ``lappend testResults …`` and equivalents this was
+            // a dominant per-test leak.
+            obj.free_sized(tmp, tmp_size);
         }
     }
     if (n > 0) {
@@ -164,19 +175,28 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
 pub export fn tcl_list(a: i32, b: i32) i32 {
     const sa = obj_ensure_string(a);
     const sb = obj_ensure_string(b);
+    // Issue #317: ``obj_new_string_take`` so each accumulator
+    // step owns its bytes — codegen emits one ``tcl_list`` call
+    // per element, so the older borrowing form leaked one buf
+    // per element on every list construction.  ``tcl_cmd_lappend``
+    // also looks up ``OBJ_STR_CAP > 0`` to decide whether the
+    // in-place fast path is safe; with cap=0 the slow rebuild
+    // ran every time (multiplying allocator pressure further).
     if (sa.len == 0) {
-        const buf = alloc(sb.len * 2 + 4);
+        const alloc_size: u32 = sb.len * 2 + 4;
+        const buf = alloc(alloc_size);
         const off = list_elem_quote(buf, 0, sb.ptr, sb.len);
-        return obj_new_string(@bitCast(buf), @bitCast(off));
+        return obj.obj_new_string_take(buf, off, alloc_size);
     }
-    const buf = alloc(sa.len + sb.len * 2 + 8);
+    const alloc_size: u32 = sa.len + sb.len * 2 + 8;
+    const buf = alloc(alloc_size);
     memcpy(buf, sa.ptr, sa.len);
     var off: u32 = sa.len;
     const d: [*]u8 = @ptrFromInt(buf + off);
     d[0] = ' ';
     off += 1;
     off = list_elem_quote_nth(buf, off, sb.ptr, sb.len);
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, alloc_size);
 }
 
 // Copy one list element into *buf* at offset *off*, re-adding the
@@ -247,10 +267,13 @@ pub export fn tcl_cmd_list_index(list: i32, idx: i32) i32 {
     if (i_val < 0 or i_val >= n) return obj_new_string(0, 0);
     const elem = list_element_at(s.ptr, s.len, i_val);
     if (elem.braced) return obj_new_string_copy(s.ptr + elem.start, elem.len);
-    // Unbraced element: process backslash escapes.
+    // Unbraced element: process backslash escapes.  Issue #317:
+    // ``obj_new_string_take`` so the resulting TclObj owns its
+    // bytes and ``release_now`` reclaims them — the older
+    // borrowing form leaked one buf per ``lindex`` call.
     const buf = alloc(elem.len);
     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
-    return obj_new_string(@bitCast(buf), @bitCast(out_len));
+    return obj.obj_new_string_take(buf, out_len, elem.len);
 }
 
 // Exported: list range — extract elements [first..last] (inclusive).
@@ -286,7 +309,9 @@ pub export fn tcl_cmd_list_range(list: i32, first: i32, last: i32) i32 {
             result_len += elem.len;
         }
     }
-    return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
+    // Issue #317: claim ownership of ``result_buf`` so its
+    // release frees the slab via ``free_sized``.
+    return obj.obj_new_string_take(result_buf, result_len, s.len);
 }
 
 // Exported: tail of a list — elements from *start* onwards.  Used by

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -906,11 +906,21 @@ pub fn obj_new_string_copy(src: u32, len: u32) i32 {
 /// stored cap is rounded symmetrically with ``alloc``'s own rounding so
 /// ``free_sized`` recycles the slab to the right free-list.
 pub fn obj_new_string_take(buf: u32, len: u32, alloc_size: u32) i32 {
-    const obj = obj_new_string(@bitCast(buf), @bitCast(len));
-    if (obj == 0) return 0;
-    if (buf == 0 or alloc_size == 0) return obj;
+    // Compute the symmetric size class up-front so the OOM cleanup
+    // path can hand ``buf`` back to ``free_sized`` with the same
+    // class the caller's ``alloc`` requested.  Without this the
+    // OOM exit (obj header alloc fails after we already own
+    // ``buf``) would leak the caller-provided buffer — defeating
+    // the whole point of the take-ownership helper (Copilot review
+    // on PR #322).
     const aligned = (alloc_size + 7) & ~@as(u32, 7);
     const cap = if (aligned <= 2048) round_up_to_class(aligned) else aligned;
+    const obj = obj_new_string(@bitCast(buf), @bitCast(len));
+    if (obj == 0) {
+        if (buf != 0 and alloc_size != 0) free_sized(buf, cap);
+        return 0;
+    }
+    if (buf == 0 or alloc_size == 0) return obj;
     write_i32(@as(u32, @bitCast(obj)) + OBJ_STR_CAP, @bitCast(cap));
     return obj;
 }

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -894,6 +894,27 @@ pub fn obj_new_string_copy(src: u32, len: u32) i32 {
     return obj;
 }
 
+/// Wrap an already-``alloc``-ed buffer in a fresh string TclObj that
+/// *owns* the buffer — ``release_now`` will hand the slab back via
+/// ``free_sized`` instead of leaking it.  The plain ``obj_new_string``
+/// stores ``cap = 0`` (the borrowing variant for buffers that live in
+/// the wasm data segment or in another obj's storage); callers that
+/// allocated a fresh ``buf`` and want the obj to claim ownership must
+/// go through this helper or set ``OBJ_STR_CAP`` themselves.
+///
+/// ``alloc_size`` is the original argument passed to ``alloc``; the
+/// stored cap is rounded symmetrically with ``alloc``'s own rounding so
+/// ``free_sized`` recycles the slab to the right free-list.
+pub fn obj_new_string_take(buf: u32, len: u32, alloc_size: u32) i32 {
+    const obj = obj_new_string(@bitCast(buf), @bitCast(len));
+    if (obj == 0) return 0;
+    if (buf == 0 or alloc_size == 0) return obj;
+    const aligned = (alloc_size + 7) & ~@as(u32, 7);
+    const cap = if (aligned <= 2048) round_up_to_class(aligned) else aligned;
+    write_i32(@as(u32, @bitCast(obj)) + OBJ_STR_CAP, @bitCast(cap));
+    return obj;
+}
+
 // Scratch buffer for integer-to-string conversion (no newline)
 var itoa_buf: [21]u8 = undefined;
 


### PR DESCRIPTION
## Summary

This PR fixes widespread memory leaks in the Tcl runtime caused by improper reference counting of TclObj instances. The primary issues are:

1. **Missing `obj_new_string_take` usage**: Many code paths were using `obj_new_string` (which creates borrowing references with `cap=0`) for freshly allocated buffers, causing those buffers to leak when the TclObj was released. Replaced with `obj_new_string_take` which marks the TclObj as owning the buffer so `free_sized` reclaims it on release.

2. **Missing `tcl_obj_release` calls**: When TclObjs are stored in frame slots, array elements, or other persistent locations via functions like `var_set`, `local_set`, `array_set`, and `frame_set_argv`, the storing function retains a reference. Creator-side code must drop its reference to avoid the object sitting at `rc > 1` after the frame/slot is released, causing permanent leaks.

3. **Parse cache slab leaks**: The parse cache was zeroing slab pointers without calling `free_sized`, leaking ~1.6 KB per cached proc body on invalidation or re-parse.

4. **Unbraced list element processing**: Temporary buffers used for backslash decoding in list operations were not being freed.

## Changes by file

- **tcl_interp.zig**: Fixed leaks in `eval_foreach`, `eval_proc_call_bucket`, `eval_apply`, `build_invocation_list`, `execute_parsed_command`, and error message generation by using `obj_new_string_take` and adding `tcl_obj_release` calls where TclObjs are stored in persistent locations.

- **parse_cache.zig**: Added `slab_size()` and `free_bucket_slab()` helpers to properly free parse cache slabs on insertion overwrites, invalidation, and bulk eviction.

- **tcl_list.zig**: Fixed leaks in `lappend_canonical`, `tcl_list`, `tcl_cmd_list_index`, and `tcl_cmd_list_range` by using `obj_new_string_take` and freeing temporary backslash-decode buffers.

- **tcl_catch.zig**: Fixed leaks in `stamp_error_globals` and `error_unknown_command` by using `obj_new_string_take` and releasing error-related TclObjs.

- **tcl_array.zig**: Fixed leaks in `array_set_list` by using `obj_new_string_copy` (to avoid stale borrowed pointers) and releasing per-pair TclObjs after storage.

- **tcl_obj.zig**: Added new `obj_new_string_take` function that wraps allocated buffers in TclObjs that claim ownership, with proper capacity tracking for `free_sized`.

- **tcl_arith.zig**: Fixed error message leaks by using `obj_new_string_take`.

- **tcl_stubs.zig**: Fixed stub error message leaks by using `obj_new_string_take`.

- **tcl_frames.zig**: Fixed leaks in `var_exists` by releasing scratch TclObjs used for array element lookups.

- **list.zig**: Fixed leaks in `eval_list` by using `obj_new_string_take`.

- **tcl_dispatch.zig**: Fixed leaks in error messages and args list building by using `obj_new_string_take`.

- **tcl_format.zig**: Fixed leaks in `tcl_cmd_format` by using `obj_new_string_take`.

- **tcl_runtime.zig**: Exported `obj_new_string_take` for use throughout the runtime.

## Impact

These fixes eliminate the dominant memory leak sources identified in io.test execution:
- Per-iteration leaks in `foreach` loops
- Per-call leaks in proc invocations (argv list + parameter binding)
- Per-element leaks in list operations
- Per-error leaks in exception handling
- Per-cache-entry leaks in parse cache invalidation

The runtime previously exceeded

https://claude.ai/code/session_011nf6LjpVRtoo3VJ9Y5vecZ