### PR TITLE
Support per-folder configuration in multi-root workspaces (issue #230)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2931,18 +2931,21 @@
         "order": 0,
         "properties": {
           "tclLsp.pythonPath": {
+            "scope": "machine-overridable",
             "type": "string",
             "default": "auto",
             "description": "Python 3.10+ interpreter for the language server (latest stable recommended). The VSIX bundles all Python dependencies — only the interpreter is needed. Set to 'auto' (default) to search PATH and well-known locations, or provide a full path (e.g. /opt/homebrew/bin/python3.14). Install Python from python.org or via Homebrew (brew install python@3.14).",
             "order": 0
           },
           "tclLsp.serverPath": {
+            "scope": "machine-overridable",
             "type": "string",
             "default": "",
             "description": "Path to the tcl-lsp server directory. If empty, uses the bundled server.",
             "order": 1
           },
           "tclLsp.dialect": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "tcl8.6",
             "enum": [
@@ -2981,6 +2984,7 @@
             "order": 2
           },
           "tclLsp.extraCommands": {
+            "scope": "language-overridable",
             "type": "array",
             "default": [],
             "items": {
@@ -2990,6 +2994,7 @@
             "order": 3
           },
           "tclLsp.libraryPaths": {
+            "scope": "resource",
             "type": "array",
             "default": [],
             "items": {
@@ -3005,6 +3010,7 @@
         "order": 1,
         "properties": {
           "tclLsp.features.hover": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3014,6 +3020,7 @@
             "order": 0
           },
           "tclLsp.features.completion": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3023,6 +3030,7 @@
             "order": 1
           },
           "tclLsp.features.diagnostics": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3032,6 +3040,7 @@
             "order": 2
           },
           "tclLsp.features.semanticTokens": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3041,6 +3050,7 @@
             "order": 4
           },
           "tclLsp.features.codeActions": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3050,6 +3060,7 @@
             "order": 5
           },
           "tclLsp.features.definition": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3059,6 +3070,7 @@
             "order": 6
           },
           "tclLsp.features.references": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3068,6 +3080,7 @@
             "order": 7
           },
           "tclLsp.features.documentSymbols": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3077,6 +3090,7 @@
             "order": 8
           },
           "tclLsp.features.folding": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3086,6 +3100,7 @@
             "order": 9
           },
           "tclLsp.features.rename": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3095,6 +3110,7 @@
             "order": 10
           },
           "tclLsp.features.signatureHelp": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3104,6 +3120,7 @@
             "order": 11
           },
           "tclLsp.features.workspaceSymbols": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3113,6 +3130,7 @@
             "order": 12
           },
           "tclLsp.features.inlayHints": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3122,6 +3140,7 @@
             "order": 13
           },
           "tclLsp.features.callHierarchy": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3131,6 +3150,7 @@
             "order": 14
           },
           "tclLsp.features.documentLinks": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3140,6 +3160,7 @@
             "order": 15
           },
           "tclLsp.features.selectionRange": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3149,6 +3170,7 @@
             "order": 16
           },
           "tclLsp.features.documentHighlight": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3158,6 +3180,7 @@
             "order": 17
           },
           "tclLsp.features.codeLens": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3167,6 +3190,7 @@
             "order": 18
           },
           "tclLsp.features.workspaceFileOps": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3176,12 +3200,14 @@
             "order": 19
           },
           "tclLsp.features.pullDiagnostics": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": false,
             "description": "Enable pull-model diagnostics (textDocument/diagnostic, workspace/diagnostic). Off by default: turning this on causes most clients to stop honouring push notifications.",
             "order": 20
           },
           "tclLsp.features.progress": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3191,6 +3217,7 @@
             "order": 22
           },
           "tclLsp.features.implementation": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3200,6 +3227,7 @@
             "order": 23
           },
           "tclLsp.features.typeDefinition": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3209,6 +3237,7 @@
             "order": 24
           },
           "tclLsp.features.declaration": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3218,6 +3247,7 @@
             "order": 25
           },
           "tclLsp.features.linkedEditingRange": {
+            "scope": "language-overridable",
             "type": [
               "boolean",
               "null"
@@ -3233,6 +3263,7 @@
         "order": 2,
         "properties": {
           "tclLsp.formatting.indentSize": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 4,
             "markdownDescription": "Number of spaces per indentation level.",
@@ -3241,6 +3272,7 @@
             "order": 0
           },
           "tclLsp.formatting.indentStyle": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "spaces",
             "markdownDescription": "Use spaces or tabs for indentation.",
@@ -3251,6 +3283,7 @@
             "order": 1
           },
           "tclLsp.formatting.continuationIndent": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 4,
             "markdownDescription": "Extra indentation for continuation lines.",
@@ -3265,6 +3298,7 @@
         "order": 3,
         "properties": {
           "tclLsp.formatting.braceStyle": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "k_and_r",
             "markdownDescription": "Brace placement style. K&R places the opening brace at the end of the line.",
@@ -3274,18 +3308,21 @@
             "order": 0
           },
           "tclLsp.formatting.spaceBetweenBraces": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Insert spaces inside single-line braces: `{ body }` instead of `{body}`.",
             "order": 1
           },
           "tclLsp.formatting.enforceBracedVariables": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": false,
             "markdownDescription": "Rewrite `$var` as `${var}` for consistency.",
             "order": 2
           },
           "tclLsp.formatting.enforceBracedExpr": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": false,
             "markdownDescription": "Rewrite unbraced `expr` arguments as braced expressions.",
@@ -3298,6 +3335,7 @@
         "order": 4,
         "properties": {
           "tclLsp.formatting.maxLineLength": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 120,
             "markdownDescription": "Hard limit for line length. Lines exceeding this are wrapped.",
@@ -3305,6 +3343,7 @@
             "order": 0
           },
           "tclLsp.formatting.goalLineLength": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 100,
             "markdownDescription": "Soft target for line length. The formatter prefers to stay within this limit.",
@@ -3312,12 +3351,14 @@
             "order": 1
           },
           "tclLsp.formatting.expandSingleLineBodies": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": false,
             "markdownDescription": "Expand single-line command bodies onto multiple lines.",
             "order": 2
           },
           "tclLsp.formatting.minBodyCommandsForExpansion": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 2,
             "markdownDescription": "Minimum commands in a body before it is expanded to multiple lines.",
@@ -3331,24 +3372,28 @@
         "order": 5,
         "properties": {
           "tclLsp.formatting.spaceAfterCommentHash": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Ensure a space after `#` in comments.",
             "order": 0
           },
           "tclLsp.formatting.trimTrailingWhitespace": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Remove trailing whitespace from lines.",
             "order": 1
           },
           "tclLsp.formatting.alignCommentsToCode": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Align inline comments to a consistent column.",
             "order": 2
           },
           "tclLsp.formatting.replaceSemicolonsWithNewlines": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Replace `;` command separators with newlines.",
@@ -3361,6 +3406,7 @@
         "order": 6,
         "properties": {
           "tclLsp.formatting.blankLinesBetweenProcs": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 1,
             "markdownDescription": "Number of blank lines between proc definitions.",
@@ -3369,6 +3415,7 @@
             "order": 0
           },
           "tclLsp.formatting.blankLinesBetweenBlocks": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 1,
             "markdownDescription": "Number of blank lines between top-level blocks.",
@@ -3377,6 +3424,7 @@
             "order": 1
           },
           "tclLsp.formatting.maxConsecutiveBlankLines": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 2,
             "markdownDescription": "Maximum number of consecutive blank lines to keep.",
@@ -3385,6 +3433,7 @@
             "order": 2
           },
           "tclLsp.formatting.lineEnding": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "lf",
             "markdownDescription": "Line ending style for formatted output.",
@@ -3396,6 +3445,7 @@
             "order": 3
           },
           "tclLsp.formatting.ensureFinalNewline": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Ensure the file ends with a newline character.",
@@ -3408,6 +3458,7 @@
         "order": 7,
         "properties": {
           "tclLsp.formatting.docstringStyle": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "none",
             "markdownDescription": "Where docstrings are placed relative to `proc` definitions. Set to `none` to leave existing docstrings as-is.",
@@ -3424,6 +3475,7 @@
             "order": 0
           },
           "tclLsp.formatting.docstringTagStyle": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "doxygen",
             "markdownDescription": "Tag format used in docstrings for parameter and return documentation.",
@@ -3440,12 +3492,14 @@
             "order": 1
           },
           "tclLsp.formatting.docstringDecoration": {
+            "scope": "language-overridable",
             "type": "boolean",
             "default": false,
             "markdownDescription": "Add decoration border lines (e.g. `# ......`) around docstrings.",
             "order": 2
           },
           "tclLsp.formatting.docstringDecorationChar": {
+            "scope": "language-overridable",
             "type": "string",
             "default": ".",
             "markdownDescription": "Character used for docstring decoration borders.",
@@ -3459,6 +3513,7 @@
             "order": 3
           },
           "tclLsp.formatting.docstringDecorationWidth": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 70,
             "markdownDescription": "Width of docstring decoration border lines.",
@@ -3473,24 +3528,28 @@
         "order": 8,
         "properties": {
           "tclLsp.diagnostics.E001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**E001:** Missing subcommand — e.g. bare `string` without a subcommand.",
             "order": 0
           },
           "tclLsp.diagnostics.E002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**E002:** Too few arguments for command.",
             "order": 1
           },
           "tclLsp.diagnostics.E003": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**E003:** Too many arguments for command.",
             "order": 2
           },
           "tclLsp.diagnostics.E200": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**E200:** Shimmer parse error — internal representation cannot be determined.",
@@ -3503,6 +3562,7 @@
         "order": 9,
         "properties": {
           "tclLsp.style.lineLength": {
+            "scope": "language-overridable",
             "type": "integer",
             "default": 120,
             "minimum": 40,
@@ -3510,6 +3570,7 @@
             "order": -2
           },
           "tclLsp.style.nonAscii": {
+            "scope": "language-overridable",
             "type": "string",
             "default": "confusables",
             "enum": [
@@ -3528,174 +3589,203 @@
             "order": -1
           },
           "tclLsp.diagnostics.W001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W001:** Unknown subcommand.",
             "order": 0
           },
           "tclLsp.diagnostics.W002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W002:** Command is disabled in active dialect profile.",
             "order": 1
           },
           "tclLsp.diagnostics.W100": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W100:** Unbraced expression argument — prevents byte-compilation and risks double substitution.",
             "order": 2
           },
           "tclLsp.diagnostics.W104": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W104:** String concatenation for list building — use `lappend` instead.",
             "order": 3
           },
           "tclLsp.diagnostics.W105": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W105:** Unbraced code block or missing `variable` declaration in `namespace eval`.",
             "order": 4
           },
           "tclLsp.diagnostics.W106": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W106:** Dangerous unbraced `switch` body — risks double substitution.",
             "order": 5
           },
           "tclLsp.diagnostics.W108": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W108:** Non-ASCII characters in token content.",
             "order": 6
           },
           "tclLsp.diagnostics.W110": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W110:** Use `eq`/`ne` instead of `==`/`!=` for string comparison.",
             "order": 7
           },
           "tclLsp.diagnostics.W111": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W111:** Line exceeds maximum length (see `tclLsp.style.lineLength`).",
             "order": 8
           },
           "tclLsp.diagnostics.W112": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W112:** Trailing whitespace.",
             "order": 9
           },
           "tclLsp.diagnostics.W113": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W113:** Procedure shadows built-in command.",
             "order": 10
           },
           "tclLsp.diagnostics.W114": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W114:** Redundant nested `[expr {...}]` — already in expression context.",
             "order": 11
           },
           "tclLsp.diagnostics.W115": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W115:** Backslash-newline in comment silently swallows the next line.",
             "order": 12
           },
           "tclLsp.diagnostics.W116": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W116:** Stub command shadows built-in command.",
             "order": 13
           },
           "tclLsp.diagnostics.W117": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W117:** Stub expression definition shadows built-in function or operator.",
             "order": 14
           },
           "tclLsp.diagnostics.W118": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W118:** Inconsistent line endings.",
             "order": 15
           },
           "tclLsp.diagnostics.W120": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W120:** Command used without a corresponding `package require`.",
             "order": 16
           },
           "tclLsp.diagnostics.W121": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W121:** Subnet mask has non-contiguous bits.",
             "order": 17
           },
           "tclLsp.diagnostics.W122": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W122:** Mistyped IPv4 address (octet > 255 or leading zero).",
             "order": 18
           },
           "tclLsp.diagnostics.W124": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W124:** Invalid IP address literal.",
             "order": 19
           },
           "tclLsp.diagnostics.W125": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W125:** Orphaned control-flow keyword used as standalone command.",
             "order": 20
           },
           "tclLsp.diagnostics.W126": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W126:** Non-channel value in channel argument position.",
             "order": 21
           },
           "tclLsp.diagnostics.W200": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W200:** `exec` result not captured or binary format modifier requires newer Tcl.",
             "order": 22
           },
           "tclLsp.diagnostics.W201": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W201:** Manual path concatenation — use `file join` instead.",
             "order": 23
           },
           "tclLsp.diagnostics.W230": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W230:** Constant list index out of range — lindex/lrange/lreplace silently return empty or clamp.",
             "order": 24
           },
           "tclLsp.diagnostics.W231": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W231:** Constant list index out of range — lset raises a runtime error.",
             "order": 25
           },
           "tclLsp.diagnostics.W232": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W232:** Constant string index out of range — string index/range/replace/insert silently return empty or no-op.",
             "order": 26
           },
           "tclLsp.diagnostics.W240": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W240:** Loop condition is a constant false — body never executes.",
             "order": 27
           },
           "tclLsp.diagnostics.W241": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W241:** Loop is provably infinite — constant-true condition with no break/return, zero/wrong-direction counter step.",
@@ -3708,36 +3798,42 @@
         "order": 10,
         "properties": {
           "tclLsp.diagnostics.W210": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W210:** Variable read before set.",
             "order": 0
           },
           "tclLsp.diagnostics.W211": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W211:** Variable set but never used.",
             "order": 1
           },
           "tclLsp.diagnostics.W212": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W212:** Variable substitution where name expected (`set $x`, `incr $x`, `info exists $x`, etc.).",
             "order": 2
           },
           "tclLsp.diagnostics.W213": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W213:** Variable may not exist — use `unset -nocomplain` to suppress the error.",
             "order": 3
           },
           "tclLsp.diagnostics.W214": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W214:** Unused proc parameter — argument is declared but never read in the procedure body.",
             "order": 4
           },
           "tclLsp.diagnostics.W220": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W220:** Dead store — variable set but overwritten before use.",
@@ -3750,78 +3846,91 @@
         "order": 11,
         "properties": {
           "tclLsp.diagnostics.W101": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W101:** `eval` with string concatenation — code injection risk.",
             "order": 0
           },
           "tclLsp.diagnostics.W102": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W102:** `subst` on variable input — code injection risk.",
             "order": 1
           },
           "tclLsp.diagnostics.W103": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W103:** `open` with pipeline `|` — command injection risk.",
             "order": 2
           },
           "tclLsp.diagnostics.W300": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W300:** `source` with variable argument — code execution risk.",
             "order": 3
           },
           "tclLsp.diagnostics.W301": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W301:** `uplevel` with string-built script — injection risk.",
             "order": 4
           },
           "tclLsp.diagnostics.W302": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W302:** `catch` without result variable — errors are silently swallowed.",
             "order": 5
           },
           "tclLsp.diagnostics.W303": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W303:** Regexp vulnerable to catastrophic backtracking (ReDoS).",
             "order": 6
           },
           "tclLsp.diagnostics.W304": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W304:** Missing option terminator `--` on option-bearing commands.",
             "order": 7
           },
           "tclLsp.diagnostics.W306": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W306:** Substitution in literal-expected argument position.",
             "order": 8
           },
           "tclLsp.diagnostics.W307": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W307:** Non-literal command name — variable or command substitution as command.",
             "order": 9
           },
           "tclLsp.diagnostics.W308": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W308:** `subst` without `-nocommands` — risk of unintended command execution.",
             "order": 10
           },
           "tclLsp.diagnostics.W309": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W309:** `eval`/`uplevel` with `subst` — double substitution risk.",
             "order": 11
           },
           "tclLsp.diagnostics.W313": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W313:** Destructive file operation with variable path — path-traversal risk.",
@@ -3834,18 +3943,21 @@
         "order": 12,
         "properties": {
           "tclLsp.diagnostics.H300": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**H300:** Possible paste error — repeated assignment to same variable with same value.",
             "order": 0
           },
           "tclLsp.diagnostics.W123": {
+            "scope": "resource",
             "type": "boolean",
             "default": false,
             "markdownDescription": "**W123:** Unresolved command — not found in registry, user procs, or `unknown` handler.",
             "order": 1
           },
           "tclLsp.diagnostics.W242": {
+            "scope": "resource",
             "type": "boolean",
             "default": false,
             "markdownDescription": "**W242:** Loop termination cannot be proven — counter not provably modified by the loop body or step.",
@@ -3858,24 +3970,28 @@
         "order": 13,
         "properties": {
           "tclLsp.shimmer.enabled": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable shimmer detection (internal representation changes). When disabled, all S-series diagnostics are suppressed.",
             "order": -1
           },
           "tclLsp.diagnostics.S100": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**S100:** Single shimmer outside a loop — object internal representation changed.",
             "order": 0
           },
           "tclLsp.diagnostics.S101": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**S101:** Shimmer inside a loop body — per-iteration representation conversion cost.",
             "order": 1
           },
           "tclLsp.diagnostics.S102": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**S102:** Variable oscillates between two types across loop iterations.",
@@ -3888,18 +4004,21 @@
         "order": 14,
         "properties": {
           "tclLsp.diagnostics.T100": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**T100:** Tainted data flows into a dangerous code-execution sink (`eval`, `expr`, `exec`, `uplevel`, `subst`).",
             "order": 0
           },
           "tclLsp.diagnostics.T101": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**T101:** Tainted data flows into an output command (`puts`).",
             "order": 1
           },
           "tclLsp.diagnostics.T102": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**T102:** Tainted data in option position without `--` terminator — option injection risk.",
@@ -3912,186 +4031,217 @@
         "order": 15,
         "properties": {
           "tclLsp.diagnostics.IRULE1001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1001:** Command invalid or ineffective in this iRules event.",
             "order": 0
           },
           "tclLsp.diagnostics.IRULE1002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1002:** Unknown iRules event name.",
             "order": 1
           },
           "tclLsp.diagnostics.IRULE1003": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1003:** Deprecated iRules event.",
             "order": 2
           },
           "tclLsp.diagnostics.IRULE1004": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1004:** `when` block missing explicit `priority`.",
             "order": 3
           },
           "tclLsp.diagnostics.IRULE1005": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1005:** Data event without a matching `*::collect` call.",
             "order": 4
           },
           "tclLsp.diagnostics.IRULE1006": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1006:** `*::payload` without a matching `*::collect` call.",
             "order": 5
           },
           "tclLsp.diagnostics.IRULE1007": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1007:** `*::collect` without a matching `*::release` on the same connection side.",
             "order": 6
           },
           "tclLsp.diagnostics.IRULE1008": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1008:** `*::release` without a matching `*::collect` on the same connection side.",
             "order": 7
           },
           "tclLsp.diagnostics.IRULE1201": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1201:** HTTP command used after `HTTP::respond`/`HTTP::redirect`.",
             "order": 8
           },
           "tclLsp.diagnostics.IRULE1202": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1202:** Multiple `HTTP::respond`/`HTTP::redirect` on different branches.",
             "order": 9
           },
           "tclLsp.diagnostics.IRULE2001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE2001:** Deprecated `matchclass` — use `class match` instead.",
             "order": 10
           },
           "tclLsp.diagnostics.IRULE2002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE2002:** Deprecated iRules command.",
             "order": 11
           },
           "tclLsp.diagnostics.IRULE2003": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE2003:** Unsafe iRules command.",
             "order": 12
           },
           "tclLsp.diagnostics.IRULE2101": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE2101:** Heavy `regexp` in a high-frequency event — consider `string match` or data-group.",
             "order": 13
           },
           "tclLsp.diagnostics.IRULE5001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5001:** Ungated `log` in a high-frequency event.",
             "order": 14
           },
           "tclLsp.diagnostics.IRULE5002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5002:** `drop`/`reject`/`discard` without `event disable all` or `return`.",
             "order": 15
           },
           "tclLsp.diagnostics.IRULE5004": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5004:** `DNS::return` without `return`.",
             "order": 16
           },
           "tclLsp.diagnostics.IRULE5005": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5005:** Direct proc invocation without `call` — use `call proc_name`.",
             "order": 17
           },
           "tclLsp.diagnostics.IRULE5006": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5006:** Top-level-only command used inside a nested body.",
             "order": 18
           },
           "tclLsp.diagnostics.IRULE5007": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5007:** Event-context command used at top level outside a `when` block.",
             "order": 19
           },
           "tclLsp.diagnostics.IRULE3001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3001:** Tainted data in HTTP response body.",
             "order": 20
           },
           "tclLsp.diagnostics.IRULE3002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3002:** Tainted data in HTTP header or cookie value.",
             "order": 21
           },
           "tclLsp.diagnostics.IRULE3003": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3003:** Tainted data in `log` command — log injection risk.",
             "order": 22
           },
           "tclLsp.diagnostics.IRULE3101": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3101:** `HTTP::uri`/`HTTP::path` set to value not provably starting with `/`.",
             "order": 23
           },
           "tclLsp.diagnostics.IRULE3102": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3102:** `HTTP::path`/`HTTP::uri`/`HTTP::query` getter used without `-normalized`.",
             "order": 24
           },
           "tclLsp.diagnostics.IRULE4001": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4001:** Write to `static::` variable outside `RULE_INIT`.",
             "order": 25
           },
           "tclLsp.diagnostics.IRULE4002": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4002:** Generic `static::` variable name — collision likely across iRules.",
             "order": 26
           },
           "tclLsp.diagnostics.IRULE4003": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4003:** Variable scoping concern across events.",
             "order": 27
           },
           "tclLsp.diagnostics.IRULE4004": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4004:** Constant `set` in per-request event could be hoisted to an earlier once-per-connection event.",
             "order": 28
           },
           "tclLsp.diagnostics.IRULE4005": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4005:** Potential race — `static::` variable written outside `RULE_INIT` and read in another event.",
             "order": 29
           },
           "tclLsp.diagnostics.genericVariablePatterns": {
+            "scope": "resource",
             "type": "array",
             "items": {
               "type": "string"
@@ -4107,30 +4257,35 @@
         "order": 18,
         "properties": {
           "tclLsp.diagnostics.W130": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W130:** tclpkg.tcl requires package but it is not in tclpkg.lock — run 'tcl pkg install'.",
             "order": 0
           },
           "tclLsp.diagnostics.W131": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W131:** tclpkg.lock is out of sync with tclpkg.tcl — run 'tcl pkg install'.",
             "order": 1
           },
           "tclLsp.diagnostics.W132": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W132:** tclpkg.lock integrity mismatch — CAS hash differs from lockfile.",
             "order": 2
           },
           "tclLsp.diagnostics.W133": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W133:** tclpkg.tcl directive not permitted in safe mode.",
             "order": 3
           },
           "tclLsp.diagnostics.W134": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W134:** Package resolved but no pkgIndex.tcl found — 'package require' will fail at runtime.",
@@ -4143,12 +4298,14 @@
         "order": 19,
         "properties": {
           "tclLsp.optimiser.enabled": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "description": "Enable optimiser suggestions as diagnostics.",
             "order": 0
           },
           "tclLsp.optimiser.profile": {
+            "scope": "resource",
             "type": "string",
             "enum": [
               "off",
@@ -4169,6 +4326,7 @@
             "order": 1
           },
           "tclLsp.optimiser.O100": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4178,6 +4336,7 @@
             "order": 2
           },
           "tclLsp.optimiser.O101": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4187,6 +4346,7 @@
             "order": 3
           },
           "tclLsp.optimiser.O102": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4196,6 +4356,7 @@
             "order": 4
           },
           "tclLsp.optimiser.O103": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4205,6 +4366,7 @@
             "order": 5
           },
           "tclLsp.optimiser.O104": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4214,6 +4376,7 @@
             "order": 6
           },
           "tclLsp.optimiser.O105": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4223,6 +4386,7 @@
             "order": 7
           },
           "tclLsp.optimiser.O106": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4232,6 +4396,7 @@
             "order": 8
           },
           "tclLsp.optimiser.O107": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4241,6 +4406,7 @@
             "order": 9
           },
           "tclLsp.optimiser.O108": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4250,6 +4416,7 @@
             "order": 10
           },
           "tclLsp.optimiser.O109": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4259,6 +4426,7 @@
             "order": 11
           },
           "tclLsp.optimiser.O110": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4268,6 +4436,7 @@
             "order": 12
           },
           "tclLsp.optimiser.O111": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4277,6 +4446,7 @@
             "order": 13
           },
           "tclLsp.optimiser.O112": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4286,6 +4456,7 @@
             "order": 14
           },
           "tclLsp.optimiser.O113": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4295,6 +4466,7 @@
             "order": 15
           },
           "tclLsp.optimiser.O114": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4304,6 +4476,7 @@
             "order": 16
           },
           "tclLsp.optimiser.O115": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4313,6 +4486,7 @@
             "order": 17
           },
           "tclLsp.optimiser.O116": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4322,6 +4496,7 @@
             "order": 18
           },
           "tclLsp.optimiser.O117": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4331,6 +4506,7 @@
             "order": 19
           },
           "tclLsp.optimiser.O118": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4340,6 +4516,7 @@
             "order": 20
           },
           "tclLsp.optimiser.O119": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4349,6 +4526,7 @@
             "order": 21
           },
           "tclLsp.optimiser.O120": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4358,6 +4536,7 @@
             "order": 22
           },
           "tclLsp.optimiser.O121": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4367,6 +4546,7 @@
             "order": 23
           },
           "tclLsp.optimiser.O122": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4376,6 +4556,7 @@
             "order": 24
           },
           "tclLsp.optimiser.O123": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4385,6 +4566,7 @@
             "order": 25
           },
           "tclLsp.optimiser.O124": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4394,6 +4576,7 @@
             "order": 26
           },
           "tclLsp.optimiser.O125": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4403,6 +4586,7 @@
             "order": 27
           },
           "tclLsp.optimiser.O126": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4412,6 +4596,7 @@
             "order": 28
           },
           "tclLsp.optimiser.O127": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4421,6 +4606,7 @@
             "order": 29
           },
           "tclLsp.optimiser.O128": {
+            "scope": "resource",
             "type": [
               "boolean",
               "null"
@@ -4436,12 +4622,14 @@
         "order": 15,
         "properties": {
           "tclLsp.runtimeValidation.enabled": {
+            "scope": "resource",
             "type": "boolean",
             "default": false,
             "description": "Run runtime validation on save using dialect-aware adapters.",
             "order": 0
           },
           "tclLsp.runtimeValidation.adapter": {
+            "scope": "resource",
             "type": "string",
             "default": "auto",
             "enum": [
@@ -4458,12 +4646,14 @@
             "order": 1
           },
           "tclLsp.runtimeValidation.tclshPath": {
+            "scope": "machine-overridable",
             "type": "string",
             "default": "tclsh",
             "description": "Path to the tclsh executable used for runtime validation.",
             "order": 2
           },
           "tclLsp.runtimeValidation.timeoutMs": {
+            "scope": "resource",
             "type": "integer",
             "default": 5000,
             "minimum": 500,
@@ -4478,12 +4668,14 @@
         "order": 17,
         "properties": {
           "tclLsp.ai.enabled": {
+            "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable AI-powered chat participants (@irule and @tcl). When disabled, the chat participants will not respond to requests. Requires VS Code Copilot Chat.",
             "order": 0
           },
           "tclLsp.ai.extraPrompts": {
+            "scope": "resource",
             "type": "array",
             "items": {
               "type": "object",
@@ -4532,24 +4724,28 @@
         "order": 18,
         "properties": {
           "tclLsp.packageManager.registryUrl": {
+            "scope": "machine-overridable",
             "type": "string",
             "default": "https://raw.githubusercontent.com/tcltk-pkgs/registry/main/packages.json",
             "markdownDescription": "URL of the Tcl package registry (`packages.json`). Used for `tcl pkg search` and dependency discovery.",
             "order": 0
           },
           "tclLsp.packageManager.cacheDir": {
+            "scope": "machine-overridable",
             "type": "string",
             "default": "",
             "markdownDescription": "Override the tclpkg cache directory. Empty uses the platform-native cache path (`~/.cache/tcl-lsp/tclpkg/` on Linux).",
             "order": 1
           },
           "tclLsp.packageManager.autoInstallOnSave": {
+            "scope": "resource",
             "type": "boolean",
             "default": false,
             "markdownDescription": "When `tclpkg.tcl` is saved, automatically run `tcl pkg install` to refresh the lockfile.",
             "order": 2
           },
           "tclLsp.packageManager.offline": {
+            "scope": "resource",
             "type": "boolean",
             "default": false,
             "markdownDescription": "Never touch the network — tclpkg always operates against the local cache.",
@@ -4562,6 +4758,7 @@
         "order": 16,
         "properties": {
           "tclLsp.xcDiagnostics.enabled": {
+            "scope": "resource",
             "type": "boolean",
             "default": false,
             "markdownDescription": "Show F5 Distributed Cloud (XC) translatability diagnostics inline. Highlights which iRule constructs can be translated to XC-native routes, service policies, and header processing. Useful for migration planning.",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4833,6 +4833,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "pretest": "npm run compile",
     "test": "node ./out/test/runTest.js",
+    "test:multi-folder": "node ./out/test/runMultiFolderTest.js",
     "test:coverage": "mkdir -p ../../tmp/coverage/.v8-coverage-vscode ../../tmp/coverage/vscode && NODE_V8_COVERAGE=../../tmp/coverage/.v8-coverage-vscode node ./out/test/runTest.js && node scripts/coverage-report.cjs"
   },
   "devDependencies": {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -528,7 +528,11 @@ export async function activate(context: ExtensionContext) {
     },
     middleware: {
       workspace: {
-        // Pull path: server requests configuration via workspace/configuration.
+        // Pull path: server requests configuration via workspace/configuration
+        // for each workspace folder (plus an unscoped fallback request).
+        // The default LanguageClient implementation honours scopeUri and
+        // returns the folder's effective settings; we just resolve null
+        // feature toggles to booleans for each item.
         configuration: async (params, token, next) => {
           const result = await next(params, token);
           if (Array.isArray(result)) {
@@ -550,49 +554,13 @@ export async function activate(context: ExtensionContext) {
           }
           return result;
         },
-        // Push path: configurationSection auto-sync sends raw settings
-        // including null defaults that the server's _set_toggle ignores.
-        // We replace the default push with one where feature nulls are
-        // resolved to booleans.  We must send the COMPLETE settings (not
-        // just features) because the server's debounce replaces pending
-        // settings wholesale.
-        didChangeConfiguration: async (_sections, _next) => {
-          if (!client) {
-            return _next(_sections);
-          }
-          // Read the full tclLsp configuration and resolve feature nulls.
-          const allSettings: Record<string, unknown> = {};
-          const cfg = workspace.getConfiguration("tclLsp");
-          // Copy all top-level tclLsp keys.
-          for (const key of [
-            "dialect",
-            "pythonPath",
-            "serverPath",
-            "extraCommands",
-            "libraryPaths",
-            "formatting",
-            "diagnostics",
-            "style",
-            "optimiser",
-            "shimmer",
-            "xcDiagnostics",
-            "runtimeValidation",
-            "ai",
-          ]) {
-            const val = cfg.get(key);
-            if (val !== undefined) allSettings[key] = val;
-          }
-          // Resolve feature toggles.
-          const features = cfg.get<Record<string, unknown>>("features", {});
-          const resolved: Record<string, boolean> = {};
-          for (const [key, val] of Object.entries(features)) {
-            resolved[key] = typeof val === "boolean" ? val : resolveFeatureToggle(key, null);
-          }
-          allSettings.features = resolved;
-          void client.sendNotification("workspace/didChangeConfiguration", {
-            settings: { tclLsp: allSettings },
-          });
-        },
+        // Push path is intentionally NOT overridden.  The default
+        // LanguageClient behaviour sends an empty didChangeConfiguration
+        // notification when settings change, and the server then pulls
+        // per-folder via workspace/configuration — that's what we want for
+        // multi-folder workspaces (issue #230).  A custom push that reads
+        // workspace.getConfiguration("tclLsp") without a scopeUri would
+        // clobber per-folder settings with the workspace-merged value.
       },
     },
   };

--- a/editors/vscode/src/test/multiFolder/index.ts
+++ b/editors/vscode/src/test/multiFolder/index.ts
@@ -1,29 +1,18 @@
-import * as fs from "fs";
+// Mocha entry point for the multi-folder workspace test suite.
+// Picks up only ``*.test.js`` files under ``out/test/multiFolder/``.
 import * as path from "path";
 import Mocha from "mocha";
 import { glob } from "glob";
-
-// Register a require hook so tsc-compiled output can load .md files at runtime.
-// (In production the esbuild bundle uses --loader:.md=text to inline them.)
-require.extensions[".md"] = (mod: NodeJS.Module, filename: string) => {
-  (mod as NodeJS.Module & { exports: unknown }).exports = fs.readFileSync(filename, "utf8");
-};
 
 export async function run(): Promise<void> {
   const mocha = new Mocha({
     ui: "tdd",
     color: true,
-    timeout: 60_000, // LSP startup can be slow
+    timeout: 60_000,
   });
 
   const testsRoot = path.resolve(__dirname);
-
-  // The multiFolder/ subdirectory has its own runner (runMultiFolderTest)
-  // because those tests need the .code-workspace fixture.  Skip them here.
-  const files = await glob("**/*.test.js", {
-    cwd: testsRoot,
-    ignore: ["multiFolder/**"],
-  });
+  const files = await glob("**/*.test.js", { cwd: testsRoot });
   files.sort();
   for (const f of files) {
     mocha.addFile(path.resolve(testsRoot, f));
@@ -37,8 +26,6 @@ export async function run(): Promise<void> {
         resolve();
       }
     });
-    // Log failure details so they are visible even when the VS Code test
-    // host terminates before mocha prints its summary.
     runner.on("fail", (test: Mocha.Test, err: Error) => {
       console.error(`\nFAIL: ${test.fullTitle()}`);
       console.error(`  ${err.message}`);

--- a/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
+++ b/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
@@ -1,0 +1,165 @@
+// Multi-folder workspace tests for issue #230.  Verifies VS Code accepts
+// folder-level tclLsp.* settings (no "This setting cannot be applied in
+// this workspace" warning) and that the language server applies them
+// per-folder when formatting files in each folder.
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+
+suite("Multi-folder workspace configuration (#230)", () => {
+  suiteSetup(async () => {
+    // Wait for the extension to activate so the LSP client is ready.
+    const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
+    assert.ok(ext, "tcl-lsp extension not found");
+    if (!ext.isActive) {
+      await ext.activate();
+    }
+    // The server pulls per-folder config asynchronously after
+    // ``initialized``; give it a moment to settle so format requests
+    // see the resolved per-folder formatter config.
+    await new Promise((r) => setTimeout(r, 3000));
+  });
+
+  test("workspace is opened in multi-folder mode with two folders", () => {
+    const folders = vscode.workspace.workspaceFolders;
+    assert.ok(folders, "workspaceFolders is undefined");
+    assert.strictEqual(folders.length, 2, "expected exactly 2 workspace folders");
+    const names = folders.map((f) => f.name).sort();
+    assert.deepStrictEqual(names, ["proj-a", "proj-b"]);
+  });
+
+  test("VS Code accepts folder-level tclLsp.formatting.maxLineLength (#230 reproduction)", () => {
+    // The fixture's folder-level .vscode/settings.json sets:
+    //   proj-a -> tclLsp.formatting.maxLineLength = 160
+    //   proj-b -> tclLsp.formatting.maxLineLength = 60
+    //
+    // If the setting still had window scope (the original bug), VS Code
+    // would silently ignore the folder-level value and getConfiguration
+    // would return the default 120 for both folders.  The scope fix in
+    // PR A makes folder-level configuration take effect.
+    const folders = vscode.workspace.workspaceFolders!;
+    const folderA = folders.find((f) => f.name === "proj-a")!;
+    const folderB = folders.find((f) => f.name === "proj-b")!;
+
+    const valueA = vscode.workspace
+      .getConfiguration("tclLsp.formatting", folderA.uri)
+      .get<number>("maxLineLength");
+    const valueB = vscode.workspace
+      .getConfiguration("tclLsp.formatting", folderB.uri)
+      .get<number>("maxLineLength");
+
+    assert.strictEqual(valueA, 160, "folder A should see its folder-level override");
+    assert.strictEqual(valueB, 60, "folder B should see its folder-level override");
+  });
+
+  test("VS Code accepts folder-level tclLsp.diagnostics.W111 toggle", () => {
+    const folderA = vscode.workspace.workspaceFolders!.find((f) => f.name === "proj-a")!;
+    const folderB = vscode.workspace.workspaceFolders!.find((f) => f.name === "proj-b")!;
+
+    const a = vscode.workspace
+      .getConfiguration("tclLsp.diagnostics", folderA.uri)
+      .get<boolean>("W111");
+    const b = vscode.workspace
+      .getConfiguration("tclLsp.diagnostics", folderB.uri)
+      .get<boolean>("W111");
+
+    // proj-a explicitly disabled W111; proj-b inherits the default (true).
+    assert.strictEqual(a, false, "folder A should report W111 disabled");
+    assert.strictEqual(b, true, "folder B should report W111 enabled (default)");
+  });
+
+  // Set known content into the document and format it.  Returns the
+  // formatted text (post-edits applied) so callers can inspect the
+  // result.  Mirrors the flow in src/test/formatting.test.ts.
+  async function formatWithContent(folderName: string, content: string): Promise<string> {
+    const folder = vscode.workspace.workspaceFolders!.find((f) => f.name === folderName)!;
+    const fileUri = vscode.Uri.file(path.join(folder.uri.fsPath, "foo.tcl"));
+    const doc = await vscode.workspace.openTextDocument(fileUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // Replace whatever's in the doc with the known content.
+    await editor.edit((e) => {
+      const lastLine = doc.lineCount - 1;
+      const lastChar = doc.lineAt(lastLine).text.length;
+      e.replace(
+        new vscode.Range(new vscode.Position(0, 0), new vscode.Position(lastLine, lastChar)),
+        content,
+      );
+    });
+
+    // Lightweight LSP roundtrip so the server has analysed the doc.
+    await vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      fileUri,
+      new vscode.Position(0, 0),
+    );
+
+    const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
+      "vscode.executeFormatDocumentProvider",
+      fileUri,
+      { tabSize: 4, insertSpaces: true },
+    );
+    if (edits && edits.length > 0) {
+      const wsEdit = new vscode.WorkspaceEdit();
+      wsEdit.set(fileUri, edits);
+      await vscode.workspace.applyEdit(wsEdit);
+    }
+    return doc.getText();
+  }
+
+  test("folder A and folder B produce different formatted output for identical source", async () => {
+    // A long single-statement command line.  Folder A (160 col) should
+    // keep it on one line; folder B (60 col) should wrap it across
+    // multiple lines.  If the LSP server resolved per-folder formatter
+    // configs correctly, the outputs differ.
+    // Use a command call with many command-level args (wrappable at depth
+    // 0).  Long enough that:
+    //   folder A (160 col) wraps to a few lines around 160 chars,
+    //   folder B (60 col)  wraps to many lines around 60 chars.
+    // Different max widths => different wrap patterns => different line
+    // counts in the output.
+    const args = Array.from({ length: 30 }, (_, i) => `argument-number-${i + 1}`).join(" ");
+    const source = `my_long_command_name ${args}\n`;
+
+    const textA = await formatWithContent("proj-a", source);
+    const textB = await formatWithContent("proj-b", source);
+
+    // Source must have actually loaded — guards against silent empty docs.
+    assert.ok(textA.length > 0 && textB.length > 0, "fixtures must have content");
+
+    const linesA = textA.split("\n").filter((l) => l.length > 0).length;
+    const linesB = textB.split("\n").filter((l) => l.length > 0).length;
+    const longestA = Math.max(...textA.split("\n").map((l) => l.length));
+    const longestB = Math.max(...textB.split("\n").map((l) => l.length));
+
+    assert.notStrictEqual(
+      textA,
+      textB,
+      `same source should format differently per folder.\n` +
+        `A: lines=${linesA} longest=${longestA}\n` +
+        `B: lines=${linesB} longest=${longestB}\n` +
+        `--- A ---\n${textA}\n--- B ---\n${textB}`,
+    );
+    // Folder B (60 col) must wrap into more lines than folder A (160 col).
+    assert.ok(
+      linesB > linesA,
+      `folder B (60-col) should wrap into more lines than folder A (160-col): A=${linesA}, B=${linesB}`,
+    );
+  });
+
+  test("folder A formatter keeps long lines under 160 cols (not the 120 default)", async () => {
+    // Construct a line >120 but <160 chars.  Default 120-col cap would
+    // wrap it, but folder A's 160-col override should keep it intact.
+    const filler = "x".repeat(120);
+    const source = `set the_variable_name_here "${filler}"\n`;
+
+    const text = await formatWithContent("proj-a", source);
+    const longest = Math.max(...text.split("\n").map((l) => l.length));
+
+    assert.ok(longest > 120, `expected a >120-char line in source, got longest=${longest}`);
+    assert.ok(
+      longest <= 160,
+      `folder A formatter should respect 160-col limit (longest=${longest})`,
+    );
+  });
+});

--- a/editors/vscode/src/test/runMultiFolderTest.ts
+++ b/editors/vscode/src/test/runMultiFolderTest.ts
@@ -1,0 +1,93 @@
+// Variant of runTest.ts that opens the multi-root workspace fixture so
+// per-folder configuration tests can verify VS Code accepts and applies
+// folder-level tclLsp.* settings (issue #230).
+import * as path from "path";
+import { execSync } from "child_process";
+import { runTests } from "@vscode/test-electron";
+
+const DEFAULT_EXIT_TIMEOUT_MS = 180_000;
+
+function parseExitTimeoutMs(): number {
+  const raw = process.env.TCL_LSP_VSCODE_TEST_EXIT_TIMEOUT_MS;
+  if (!raw) return DEFAULT_EXIT_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_EXIT_TIMEOUT_MS;
+  return Math.floor(parsed);
+}
+
+function escapeSingleQuotes(text: string): string {
+  return text.split("'").join("'\"'\"'");
+}
+
+function cleanupStaleTestHosts(extensionDevelopmentPath: string, extensionTestsPath: string): void {
+  try {
+    const escapedDevPath = escapeSingleQuotes(extensionDevelopmentPath);
+    const escapedTestsPath = escapeSingleQuotes(extensionTestsPath);
+    execSync(
+      `pkill -f 'extensionDevelopmentPath=${escapedDevPath}' || true; pkill -f 'extensionTestsPath=${escapedTestsPath}' || true`,
+      { stdio: "ignore" },
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function main() {
+  const extensionDevelopmentPath = path.resolve(__dirname, "../../");
+  const extensionTestsPath = path.resolve(__dirname, "./multiFolder/index");
+  cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+
+  // Open the multi-root .code-workspace fixture so VS Code is in
+  // multi-folder mode and folder-level .vscode/settings.json files are
+  // honoured.
+  const codeWorkspace = path.resolve(
+    extensionDevelopmentPath,
+    "testFixtureMultiFolder",
+    "multiFolder.code-workspace",
+  );
+
+  // Clear persisted user settings between runs.
+  const userDataDir = path.resolve(extensionDevelopmentPath, ".vscode-test", "user-data");
+  const userSettingsFile = path.resolve(userDataDir, "User", "settings.json");
+  try {
+    const { writeFileSync, mkdirSync } = require("fs");
+    mkdirSync(path.dirname(userSettingsFile), { recursive: true });
+    writeFileSync(userSettingsFile, "{}\n", "utf8");
+  } catch {
+    /* best-effort */
+  }
+
+  const timeoutMs = parseExitTimeoutMs();
+  try {
+    const runPromise = runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [codeWorkspace, "--disable-extensions"],
+    });
+
+    if (timeoutMs <= 0) {
+      await runPromise;
+      return;
+    }
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`VS Code test runner did not exit within ${timeoutMs}ms after launch.`));
+      }, timeoutMs).unref();
+    });
+
+    await Promise.race([runPromise, timeoutPromise]);
+    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+    process.exit(0);
+  } catch (err) {
+    cleanupStaleTestHosts(extensionDevelopmentPath, extensionTestsPath);
+    if (err instanceof Error && err.message.includes("did not exit within")) {
+      console.warn("Multi-folder VS Code tests completed but runner did not exit; continuing.");
+      process.exit(0);
+    }
+    console.error("Failed to run multi-folder tests:", err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/editors/vscode/testFixtureMultiFolder/multiFolder.code-workspace
+++ b/editors/vscode/testFixtureMultiFolder/multiFolder.code-workspace
@@ -1,0 +1,13 @@
+{
+  "folders": [
+    {
+      "name": "proj-a",
+      "path": "proj-a"
+    },
+    {
+      "name": "proj-b",
+      "path": "proj-b"
+    }
+  ],
+  "settings": {}
+}

--- a/editors/vscode/testFixtureMultiFolder/proj-a/foo.tcl
+++ b/editors/vscode/testFixtureMultiFolder/proj-a/foo.tcl
@@ -1,0 +1,4 @@
+proc demonstrate {arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8} {
+    return "$arg1 $arg2 $arg3 $arg4 $arg5 $arg6 $arg7 $arg8"
+}
+demonstrate "value-one-here" "value-two-here" "value-three-here" "value-four" "five" "six" "seven" "eight"

--- a/editors/vscode/testFixtureMultiFolder/proj-b/foo.tcl
+++ b/editors/vscode/testFixtureMultiFolder/proj-b/foo.tcl
@@ -1,0 +1,4 @@
+proc demonstrate {arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8} {
+    return "$arg1 $arg2 $arg3 $arg4 $arg5 $arg6 $arg7 $arg8"
+}
+demonstrate "value-one-here" "value-two-here" "value-three-here" "value-four" "five" "six" "seven" "eight"

--- a/lsp/diagnostics_pipeline.py
+++ b/lsp/diagnostics_pipeline.py
@@ -201,29 +201,30 @@ def _publish_diagnostics_sync(
     *,
     force_reanalyse: bool = False,
 ) -> None:
+    cfg = _state.config_for_uri(uri)
     state = _state.workspace_state.update(
         uri,
         source,
         version,
         force_reanalyse=force_reanalyse,
-        line_length=_state.feature_config.line_length,
+        line_length=cfg.line_length,
     )
     partial_mode = state.has_partial_commands
 
-    if _state.feature_config.diagnostics_enabled:
+    if cfg.diagnostics_enabled:
         ws_ctx = _build_workspace_diagnostic_context()
         diagnostics = get_diagnostics(
             source,
             analysis=state.analysis,
             cu=state.compilation_unit,
-            optimiser_enabled=_state.feature_config.optimiser_enabled and not partial_mode,
-            shimmer_enabled=_state.feature_config.shimmer_enabled and not partial_mode,
+            optimiser_enabled=cfg.optimiser_enabled and not partial_mode,
+            shimmer_enabled=cfg.shimmer_enabled and not partial_mode,
             taint_enabled=not partial_mode,
-            xc_diagnostics_enabled=_state.feature_config.xc_diagnostics_enabled,
-            disabled_diagnostics=_state.feature_config.disabled_diagnostics,
-            disabled_optimisations=_state.feature_config.disabled_optimisations,
+            xc_diagnostics_enabled=cfg.xc_diagnostics_enabled,
+            disabled_diagnostics=cfg.disabled_diagnostics,
+            disabled_optimisations=cfg.disabled_optimisations,
             uri=uri,
-            line_length=_state.feature_config.line_length,
+            line_length=cfg.line_length,
             workspace_context=ws_ctx,
         )
     else:
@@ -268,10 +269,11 @@ async def _publish_diagnostics(
 
     await asyncio.sleep(0)
 
-    disabled_diagnostics = set(_state.feature_config.disabled_diagnostics)
-    line_length = _state.feature_config.line_length
-    optimiser_enabled = _state.feature_config.optimiser_enabled
-    disabled_optimisations = set(_state.feature_config.disabled_optimisations)
+    cfg = _state.config_for_uri(uri)
+    disabled_diagnostics = set(cfg.disabled_diagnostics)
+    line_length = cfg.line_length
+    optimiser_enabled = cfg.optimiser_enabled
+    disabled_optimisations = set(cfg.disabled_optimisations)
 
     t_update = time.perf_counter()
     did_analyse = needs_analysis or force_reanalyse
@@ -360,7 +362,7 @@ async def _publish_diagnostics(
         except Exception:
             pass
 
-    if not _state.feature_config.diagnostics_enabled:
+    if not cfg.diagnostics_enabled:
         basic_diags: list[types.Diagnostic] = []
         analysis_result = None
         suppressed: dict[int, frozenset[str]] = {}
@@ -376,6 +378,7 @@ async def _publish_diagnostics(
         )
 
         ws_ctx = _build_workspace_diagnostic_context()
+        formatter_cfg = _state.formatter_config_for_uri(uri)
 
         def _phase1():
             return get_basic_diagnostics(
@@ -386,7 +389,7 @@ async def _publish_diagnostics(
                 disabled_diagnostics=disabled_diagnostics,
                 disabled_optimisations=disabled_optimisations,
                 line_length=line_length,
-                line_ending=_state.formatter_config.line_ending,
+                line_ending=formatter_cfg.line_ending,
                 cached_style_diagnostics=cached_style,
                 workspace_context=ws_ctx,
                 uri=uri,
@@ -397,7 +400,7 @@ async def _publish_diagnostics(
         phase1_ms = (time.perf_counter() - t_phase1) * 1000
         log.info("[timing] phase1 diagnostics %.0fms (diags=%d)", phase1_ms, len(basic_diags))
 
-    if not _state.feature_config.diagnostics_enabled:
+    if not cfg.diagnostics_enabled:
         _publish_diags_to_client(uri, [], version)
         _update_workspace_index(uri, source, state)
         return
@@ -413,12 +416,12 @@ async def _publish_diagnostics(
     if not did_analyse and state.analysis is None:
         return
 
-    opt_enabled = _state.feature_config.optimiser_enabled and not partial_mode
-    shimmer_enabled = _state.feature_config.shimmer_enabled and not partial_mode
+    opt_enabled = cfg.optimiser_enabled and not partial_mode
+    shimmer_enabled = cfg.shimmer_enabled and not partial_mode
     taint_enabled = not partial_mode
-    xc_enabled = _state.feature_config.xc_diagnostics_enabled
-    disabled_diags = set(_state.feature_config.disabled_diagnostics)
-    disabled_opts = set(_state.feature_config.disabled_optimisations)
+    xc_enabled = cfg.xc_diagnostics_enabled
+    disabled_diags = set(cfg.disabled_diagnostics)
+    disabled_opts = set(cfg.disabled_optimisations)
     cu = state.compilation_unit
 
     cached_deep = state.get_cached_deep_diagnostics()
@@ -435,7 +438,7 @@ async def _publish_diagnostics(
 
     _dialect = active_dialect()
     _pool = _state._get_process_pool()
-    _generic_var_patterns = list(_state.feature_config.generic_variable_patterns)
+    _generic_var_patterns = list(cfg.generic_variable_patterns)
 
     async def _deep_coro() -> list[types.Diagnostic]:
         try:
@@ -621,10 +624,9 @@ def _publish_bigip_diagnostics(
         )
         return
 
-    if _state.feature_config.diagnostics_enabled:
-        diagnostics = get_bigip_diagnostics(
-            config, disabled_codes=_state.feature_config.disabled_diagnostics
-        )
+    cfg = _state.config_for_uri(uri)
+    if cfg.diagnostics_enabled:
+        diagnostics = get_bigip_diagnostics(config, disabled_codes=cfg.disabled_diagnostics)
     else:
         diagnostics = []
 
@@ -664,7 +666,8 @@ def _publish_apl_diagnostics(
         )
         return
 
-    if not _state.feature_config.diagnostics_enabled:
+    cfg = _state.config_for_uri(uri)
+    if not cfg.diagnostics_enabled:
         _server.text_document_publish_diagnostics(  # type: ignore[union-attr]
             types.PublishDiagnosticsParams(uri=uri, diagnostics=[], version=version)
         )
@@ -681,10 +684,7 @@ def _publish_apl_diagnostics(
     raw = validate_iapp_presentation(model, impl_var_refs)
     results: list[types.Diagnostic] = []
     for d in raw:
-        if (
-            _state.feature_config.disabled_diagnostics
-            and d.code in _state.feature_config.disabled_diagnostics
-        ):
+        if cfg.disabled_diagnostics and d.code in cfg.disabled_diagnostics:
             continue
         results.append(
             types.Diagnostic(

--- a/lsp/lifecycle.py
+++ b/lsp/lifecycle.py
@@ -254,15 +254,17 @@ def on_did_rename_files(params: types.RenameFilesParams) -> None:
 def on_did_change_workspace_folders(params: types.DidChangeWorkspaceFoldersParams) -> None:
     """Track folder add/remove and re-pull per-folder configuration."""
     from core.common.user_config import get_all_settings, load_project_config
-    from lsp.settings import _pull_and_apply_configuration
+    from lsp.settings import _pull_and_apply_configuration, _schedule_apply_merged
 
     from .workspace.scanner import uri_to_path as _uri_to_path
 
     event = params.event
+    removed_uris: list[str] = []
     for folder in getattr(event, "removed", None) or []:
         folder_uri = getattr(folder, "uri", "")
         if folder_uri:
             _state.drop_folder_configs(folder_uri)
+            removed_uris.append(folder_uri)
 
     for folder in getattr(event, "added", None) or []:
         folder_uri = getattr(folder, "uri", "")
@@ -276,6 +278,19 @@ def on_did_change_workspace_folders(params: types.DidChangeWorkspaceFoldersParam
             project_settings = get_all_settings(load_project_config(folder_path))
             _state.project_config_settings_per_folder[folder_uri] = project_settings
 
+    # If the fallback project layer was sourced from a removed folder
+    # (or any folder was removed at all), clear it so files outside every
+    # workspace folder don't see stale project settings.  ``on_initialized``
+    # arbitrarily picks the first folder's ``.tcl-lsp.ini`` as the fallback;
+    # rather than re-pick on every change, drop it back to "none" so the
+    # global user-config layer is the only fallback contributor.
+    if removed_uris:
+        _state.project_config_settings = {}
+
+    # Schedule a merged-settings apply now so per-folder analysis state
+    # reflects the new folder set even if ``_pull_and_apply_configuration``
+    # below fails (e.g. client without ``workspace/configuration`` support).
+    _schedule_apply_merged()
     _pull_and_apply_configuration()
 
 

--- a/lsp/lifecycle.py
+++ b/lsp/lifecycle.py
@@ -251,6 +251,34 @@ def on_did_rename_files(params: types.RenameFilesParams) -> None:
             )
 
 
+def on_did_change_workspace_folders(params: types.DidChangeWorkspaceFoldersParams) -> None:
+    """Track folder add/remove and re-pull per-folder configuration."""
+    from core.common.user_config import get_all_settings, load_project_config
+    from lsp.settings import _pull_and_apply_configuration
+
+    from .workspace.scanner import uri_to_path as _uri_to_path
+
+    event = params.event
+    for folder in getattr(event, "removed", None) or []:
+        folder_uri = getattr(folder, "uri", "")
+        if folder_uri:
+            _state.drop_folder_configs(folder_uri)
+
+    for folder in getattr(event, "added", None) or []:
+        folder_uri = getattr(folder, "uri", "")
+        folder_path = _uri_to_path(folder_uri) if folder_uri else None
+        if not folder_uri:
+            continue
+        # Initialise per-folder configs and load .tcl-lsp.ini if present.
+        _state.get_or_init_folder_feature_config(folder_uri)
+        _state.get_or_init_folder_formatter_config(folder_uri)
+        if folder_path:
+            project_settings = get_all_settings(load_project_config(folder_path))
+            _state.project_config_settings_per_folder[folder_uri] = project_settings
+
+    _pull_and_apply_configuration()
+
+
 # Registration
 
 
@@ -262,6 +290,9 @@ def register(server_instance: LanguageServer) -> None:
     server_instance.feature(types.TEXT_DOCUMENT_DID_CLOSE)(did_close)
     server_instance.feature(types.SHUTDOWN)(on_shutdown)
     server_instance.feature(types.WORKSPACE_DID_CHANGE_WATCHED_FILES)(did_change_watched_files)
+    server_instance.feature(types.WORKSPACE_DID_CHANGE_WORKSPACE_FOLDERS)(
+        on_did_change_workspace_folders
+    )
     server_instance.feature(types.WORKSPACE_WILL_RENAME_FILES, _RENAME_FILE_OPERATION_OPTIONS)(
         on_will_rename_files
     )

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -293,7 +293,7 @@ def on_semantic_tokens_full(
     params: types.SemanticTokensParams,
 ) -> types.SemanticTokens:
     t0 = time.perf_counter()
-    if not feature_config.semantic_tokens_enabled:
+    if not _state.config_for_uri(params.text_document.uri).semantic_tokens_enabled:
         return types.SemanticTokens(data=[])
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -351,7 +351,7 @@ def on_semantic_tokens_delta(
     uri = params.text_document.uri
     previous_result_id = params.previous_result_id
 
-    if not feature_config.semantic_tokens_enabled:
+    if not _state.config_for_uri(params.text_document.uri).semantic_tokens_enabled:
         return types.SemanticTokens(data=[])
 
     # Look up previous result for this URI.
@@ -439,7 +439,7 @@ def on_semantic_tokens_delta(
 def on_completion(
     params: types.CompletionParams,
 ) -> list[types.CompletionItem]:
-    if not feature_config.completion_enabled:
+    if not _state.config_for_uri(params.text_document.uri).completion_enabled:
         return []
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -503,7 +503,7 @@ def _hover_cache_put(key: tuple[str, int | None, int, int], value: types.Hover |
 
 @server.feature(types.TEXT_DOCUMENT_HOVER)
 async def on_hover(params: types.HoverParams) -> types.Hover | None:
-    if not feature_config.hover_enabled:
+    if not _state.config_for_uri(params.text_document.uri).hover_enabled:
         return None
     t0 = time.perf_counter()
     uri = params.text_document.uri
@@ -612,7 +612,7 @@ def _invalidate_hover_cache(uri: str) -> None:
 def on_definition(
     params: types.DefinitionParams,
 ) -> list[types.Location]:
-    if not feature_config.definition_enabled:
+    if not _state.config_for_uri(params.text_document.uri).definition_enabled:
         return []
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -685,7 +685,7 @@ def on_definition(
 def on_type_definition(
     params: types.TypeDefinitionParams,
 ) -> list[types.Location] | None:
-    if not feature_config.type_definition_enabled:
+    if not _state.config_for_uri(params.text_document.uri).type_definition_enabled:
         return None
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -713,7 +713,7 @@ def on_type_definition(
 def on_declaration(
     params: types.DeclarationParams,
 ) -> list[types.Location] | None:
-    if not feature_config.declaration_enabled:
+    if not _state.config_for_uri(params.text_document.uri).declaration_enabled:
         return None
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -737,7 +737,7 @@ def on_declaration(
 def on_references(
     params: types.ReferenceParams,
 ) -> list[types.Location]:
-    if not feature_config.references_enabled:
+    if not _state.config_for_uri(params.text_document.uri).references_enabled:
         return []
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -761,7 +761,7 @@ def on_references(
 def on_document_highlight(
     params: types.DocumentHighlightParams,
 ) -> list[types.DocumentHighlight] | None:
-    if not feature_config.document_highlight_enabled:
+    if not _state.config_for_uri(params.text_document.uri).document_highlight_enabled:
         return None
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -785,7 +785,7 @@ def on_document_highlight(
 def on_document_symbol(
     params: types.DocumentSymbolParams,
 ) -> list[types.DocumentSymbol]:
-    if not feature_config.document_symbols_enabled:
+    if not _state.config_for_uri(params.text_document.uri).document_symbols_enabled:
         return []
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -807,7 +807,7 @@ def on_document_symbol(
 def on_folding_range(
     params: types.FoldingRangeParams,
 ) -> list[types.FoldingRange]:
-    if not feature_config.folding_enabled:
+    if not _state.config_for_uri(params.text_document.uri).folding_enabled:
         return []
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -831,7 +831,7 @@ def on_folding_range(
 def on_rename(
     params: types.RenameParams,
 ) -> types.WorkspaceEdit | None:
-    if not feature_config.rename_enabled:
+    if not _state.config_for_uri(params.text_document.uri).rename_enabled:
         return None
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -851,7 +851,7 @@ def on_rename(
 def on_prepare_rename(
     params: types.PrepareRenameParams,
 ) -> types.PrepareRenamePlaceholder | None:
-    if not feature_config.rename_enabled:
+    if not _state.config_for_uri(params.text_document.uri).rename_enabled:
         return None
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -876,7 +876,7 @@ def on_prepare_rename(
 def on_signature_help(
     params: types.SignatureHelpParams,
 ) -> types.SignatureHelp | None:
-    if not feature_config.signature_help_enabled:
+    if not _state.config_for_uri(params.text_document.uri).signature_help_enabled:
         return None
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -909,7 +909,7 @@ def on_workspace_symbol(
 def on_inlay_hint(
     params: types.InlayHintParams,
 ) -> list[types.InlayHint]:
-    if not feature_config.inlay_hints_enabled:
+    if not _state.config_for_uri(params.text_document.uri).inlay_hints_enabled:
         return []
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -929,7 +929,7 @@ def on_inlay_hint(
 def on_prepare_call_hierarchy(
     params: types.CallHierarchyPrepareParams,
 ) -> list[types.CallHierarchyItem]:
-    if not feature_config.call_hierarchy_enabled:
+    if not _state.config_for_uri(params.text_document.uri).call_hierarchy_enabled:
         return []
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -948,7 +948,7 @@ def on_prepare_call_hierarchy(
 def on_incoming_calls(
     params: types.CallHierarchyIncomingCallsParams,
 ) -> list[types.CallHierarchyIncomingCall]:
-    if not feature_config.call_hierarchy_enabled:
+    if not _state.config_for_uri(params.item.uri).call_hierarchy_enabled:
         return []
     item = params.item
     uri = item.uri
@@ -962,7 +962,7 @@ def on_incoming_calls(
 def on_outgoing_calls(
     params: types.CallHierarchyOutgoingCallsParams,
 ) -> list[types.CallHierarchyOutgoingCall]:
-    if not feature_config.call_hierarchy_enabled:
+    if not _state.config_for_uri(params.item.uri).call_hierarchy_enabled:
         return []
     item = params.item
     uri = item.uri
@@ -1023,7 +1023,7 @@ def on_subtypes(
 def on_implementation(
     params: types.ImplementationParams,
 ) -> list[types.Location] | None:
-    if not feature_config.implementation_enabled:
+    if not _state.config_for_uri(params.text_document.uri).implementation_enabled:
         return None
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -1048,7 +1048,7 @@ def on_implementation(
 def on_document_link(
     params: types.DocumentLinkParams,
 ) -> list[types.DocumentLink]:
-    if not feature_config.document_links_enabled:
+    if not _state.config_for_uri(params.text_document.uri).document_links_enabled:
         return []
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -1068,7 +1068,7 @@ def on_document_link(
 def on_code_lens(
     params: types.CodeLensParams,
 ) -> list[types.CodeLens] | None:
-    if not feature_config.code_lens_enabled:
+    if not _state.config_for_uri(params.text_document.uri).code_lens_enabled:
         return None
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -1121,7 +1121,7 @@ if _state.feature_config.pull_diagnostics_enabled:
 def on_selection_range(
     params: types.SelectionRangeParams,
 ) -> list[types.SelectionRange] | None:
-    if not feature_config.selection_range_enabled:
+    if not _state.config_for_uri(params.text_document.uri).selection_range_enabled:
         return None
     uri = params.text_document.uri
     source = _get_doc_source(uri)
@@ -1139,7 +1139,7 @@ def on_selection_range(
 def on_linked_editing_range(
     params: types.LinkedEditingRangeParams,
 ) -> types.LinkedEditingRanges | None:
-    if not feature_config.linked_editing_range_enabled:
+    if not _state.config_for_uri(params.text_document.uri).linked_editing_range_enabled:
         return None
     uri = params.text_document.uri
     state = workspace_state.get(uri)
@@ -1174,7 +1174,7 @@ def on_linked_editing_range(
 def on_code_action(
     params: types.CodeActionParams,
 ) -> list[types.CodeAction] | None:
-    if not feature_config.code_actions_enabled:
+    if not _state.config_for_uri(params.text_document.uri).code_actions_enabled:
         return None
     uri = params.text_document.uri
     source = _get_doc_source(uri)

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -454,7 +454,7 @@ def on_completion(
         workspace_rule_init_vars=workspace_index.all_rule_init_var_names(),
         workspace_command_usage=workspace_index.command_usage_counts(),
         workspace_proc_usage=workspace_index.proc_usage_counts(),
-        formatter_config=_state.formatter_config,
+        formatter_config=_state.formatter_config_for_uri(uri),
         lines=state.lines if state else None,
         embedded_rules=state.embedded_rules if state and state.conf_wrapped else None,
     )
@@ -1221,7 +1221,10 @@ def on_formatting(
     source = _get_doc_source(uri)
     state = workspace_state.get(uri)
     edits = get_formatting(
-        source, params.options, _state.formatter_config, lines=state.lines if state else None
+        source,
+        params.options,
+        _state.formatter_config_for_uri(uri),
+        lines=state.lines if state else None,
     )
     return edits or None
 
@@ -1242,7 +1245,7 @@ def on_range_formatting(
         source,
         params.range,
         params.options,
-        _state.formatter_config,
+        _state.formatter_config_for_uri(uri),
         lines=state.lines if state else None,
     )
     return edits or None
@@ -1255,21 +1258,18 @@ def on_range_formatting(
 def on_will_save_wait_until(
     params: types.WillSaveTextDocumentParams,
 ) -> list[types.TextEdit] | None:
-    if not feature_config.will_save_wait_until_enabled:
-        return None
     uri = params.text_document.uri
+    cfg = _state.config_for_uri(uri)
+    if not cfg.will_save_wait_until_enabled:
+        return None
     state = workspace_state.get(uri)
     source = _get_doc_source(uri)
     from core.formatting.config import IndentStyle
 
+    fmt_cfg = _state.formatter_config_for_uri(uri)
     options = types.FormattingOptions(
-        tab_size=_state.formatter_config.indent_size,
-        insert_spaces=_state.formatter_config.indent_style == IndentStyle.SPACES,
+        tab_size=fmt_cfg.indent_size,
+        insert_spaces=fmt_cfg.indent_style == IndentStyle.SPACES,
     )
-    edits = get_formatting(
-        source,
-        options,
-        _state.formatter_config,
-        lines=state.lines if state else None,
-    )
+    edits = get_formatting(source, options, fmt_cfg, lines=state.lines if state else None)
     return edits or None

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -616,14 +616,28 @@ def register(server_instance: LanguageServer) -> None:
 
     @server_instance.feature(types.WORKSPACE_DID_CHANGE_CONFIGURATION)
     def did_change_configuration(params: types.DidChangeConfigurationParams) -> None:
-        # Always pull per-folder via workspace/configuration: the push
-        # payload (if any) is the workspace-merged value and cannot
-        # populate per-folder configs.  The pull also covers clients that
-        # send empty notifications as a "config changed" signal.
+        # Push payloads come from two sources:
+        #
+        # 1. ``vscode-languageclient`` ``synchronize.configurationSection``:
+        #    the workspace-merged value of ``tclLsp.*``.  We apply to the
+        #    fallback layer and then pull per-folder via
+        #    ``workspace/configuration`` for folder-scoped overrides.
+        #
+        # 2. The extension's ``setServerDialect`` notification: a hand-
+        #    crafted ``{tclLsp: {dialect: "..."}}`` payload that is *not*
+        #    backed by the client's configuration store (auto-detected
+        #    from shebang / file extension / directive).  Pulling after
+        #    applying it would clobber the dialect with whatever the
+        #    client has stored.
+        #
+        # Detect (2) by checking whether the extracted settings are a
+        # dialect-only payload — in that case skip the re-pull.  Empty
+        # payloads (e.g. clients that signal "something changed") fall
+        # through to the pull.
         settings = params.settings
         if isinstance(settings, dict) and settings:
-            # Apply the push payload to the fallback layer immediately
-            # (covers files outside every workspace folder), then pull
-            # for accurate per-folder values.
-            _apply_all_settings(_extract_tcl_lsp_settings(settings), folder_uri="")
+            extracted = _extract_tcl_lsp_settings(settings)
+            _apply_all_settings(extracted, folder_uri="")
+            if set(extracted.keys()) == {"dialect"}:
+                return
         _pull_and_apply_configuration()

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -503,6 +503,24 @@ def _apply_merged_settings_now() -> None:
             _state.feature_config.dialect_explicitly_set,
         )
 
+    # ``tclLsp.dialect`` is declared as ``language-overridable`` so VS Code
+    # accepts per-folder overrides, but the active dialect controls a
+    # process-global signature registry — only one dialect can be active
+    # at a time.  Warn the user when folder-level dialect overrides
+    # disagree with the workspace fallback so they understand why their
+    # folder setting "isn't applying".
+    for folder_uri in _state.editor_config_settings_per_folder:
+        folder_dialect = _state.editor_config_settings_per_folder[folder_uri].get("dialect")
+        if isinstance(folder_dialect, str) and folder_dialect and folder_dialect != dialect_setting:
+            log.warning(
+                "Folder %s configures tclLsp.dialect=%r but the workspace "
+                "dialect is %r — only the workspace value applies. "
+                "Per-folder dialects are not yet supported.",
+                folder_uri,
+                folder_dialect,
+                dialect_setting or "<auto>",
+            )
+
     # Per-folder + fallback feature/formatter application.
     diags_were_enabled = _state.feature_config.diagnostics_enabled
     features_changed = _apply_settings_to_target("", fallback_settings)
@@ -593,14 +611,23 @@ def _pull_and_apply_configuration() -> None:
         if not result:
             return
         # Result order matches request order: per-folder items first,
-        # then the fallback item last.
+        # then the fallback item last.  Update every editor layer in
+        # one batch so the merged-settings application runs once with
+        # all folders populated — calling ``_apply_all_settings`` per
+        # folder would fire the leading-edge debounce repeatedly and
+        # leave intermediate states briefly visible.
+        any_applied = False
         for folder_uri, item in zip(folder_uris, result, strict=False):
             if isinstance(item, dict):
-                _apply_all_settings(item, folder_uri=folder_uri)
+                _state.editor_config_settings_per_folder[folder_uri] = item
+                any_applied = True
         if len(result) > len(folder_uris):
             fallback_item = result[len(folder_uris)]
             if isinstance(fallback_item, dict):
-                _apply_all_settings(fallback_item, folder_uri="")
+                _state.editor_config_settings = fallback_item
+                any_applied = True
+        if any_applied:
+            _schedule_apply_merged()
 
     try:
         _server.workspace_configuration(params, callback=_on_result)  # type: ignore[union-attr]

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -26,6 +26,8 @@ from core.formatting import FormatterConfig
 if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
 
+    from .feature_config import FeatureConfig
+
 log = logging.getLogger(__name__)
 
 
@@ -179,20 +181,28 @@ def configure(server_instance: LanguageServer) -> None:
 # Feature settings application
 
 
-def _apply_feature_settings(tcl_settings: dict) -> bool:
-    """Apply feature toggles and diagnostic/optimiser filters.
+def _apply_feature_settings(tcl_settings: dict, target: "FeatureConfig | None" = None) -> bool:
+    """Apply feature toggles and diagnostic/optimiser filters to ``target``.
 
-    Returns True if diagnostics need to be republished.
+    Mutates ``target`` (defaulting to the workspace-level ``feature_config``)
+    in place and returns True if any diagnostics need republishing.
+
+    ``set_non_ascii_mode`` is a process-global side effect — applied for
+    every target since it cannot be made per-folder without restructuring
+    ``core.analysis.checks._style``.
     """
+    if target is None:
+        target = _state.feature_config
+
     changed = False
 
     def _set_toggle(attr: str, val: object) -> bool:
         nonlocal changed
         if not isinstance(val, bool):
             return False
-        if val == getattr(_state.feature_config, attr):
+        if val == getattr(target, attr):
             return False
-        setattr(_state.feature_config, attr, val)
+        setattr(target, attr, val)
         if attr in _RESTART_REQUIRED_TOGGLES:
             log.warning(
                 "Feature toggle %r changed at runtime but takes effect only "
@@ -235,8 +245,8 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
                     new_disabled.add(code)
                 else:
                     new_disabled.discard(code)
-        if new_disabled != _state.feature_config.disabled_diagnostics:
-            _state.feature_config.disabled_diagnostics = new_disabled
+        if new_disabled != target.disabled_diagnostics:
+            target.disabled_diagnostics = new_disabled
             changed = True
 
         _DIAG_NON_CODE_KEYS = {"genericVariablePatterns", "generic_variable_patterns"}
@@ -254,8 +264,8 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
     style_section = tcl_settings.get("style")
     if isinstance(style_section, dict):
         ll = style_section.get("lineLength")
-        if isinstance(ll, int) and ll > 0 and ll != _state.feature_config.line_length:
-            _state.feature_config.line_length = ll
+        if isinstance(ll, int) and ll > 0 and ll != target.line_length:
+            target.line_length = ll
             changed = True
         non_ascii = style_section.get("nonAscii")
         if isinstance(non_ascii, str) and non_ascii in ("strict", "confusables", "common", "off"):
@@ -268,44 +278,36 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
     shimmer_section = tcl_settings.get("shimmer")
     if isinstance(shimmer_section, dict):
         shimmer_master = shimmer_section.get("enabled")
-        if (
-            isinstance(shimmer_master, bool)
-            and shimmer_master != _state.feature_config.shimmer_enabled
-        ):
-            _state.feature_config.shimmer_enabled = shimmer_master
+        if isinstance(shimmer_master, bool) and shimmer_master != target.shimmer_enabled:
+            target.shimmer_enabled = shimmer_master
             changed = True
 
     # XC diagnostics toggle  (tclLsp.xcDiagnostics.enabled)
     xc_section = tcl_settings.get("xcDiagnostics")
     if isinstance(xc_section, dict):
         xc_enabled = xc_section.get("enabled")
-        if (
-            isinstance(xc_enabled, bool)
-            and xc_enabled != _state.feature_config.xc_diagnostics_enabled
-        ):
-            _state.feature_config.xc_diagnostics_enabled = xc_enabled
+        if isinstance(xc_enabled, bool) and xc_enabled != target.xc_diagnostics_enabled:
+            target.xc_diagnostics_enabled = xc_enabled
             changed = True
 
     # Optimiser master switch, profile, + per-code  (tclLsp.optimiser.*)
     optimiser_section = tcl_settings.get("optimiser")
     if isinstance(optimiser_section, dict):
         master = optimiser_section.get("enabled")
-        if isinstance(master, bool) and master != _state.feature_config.optimiser_enabled:
-            _state.feature_config.optimiser_enabled = master
+        if isinstance(master, bool) and master != target.optimiser_enabled:
+            target.optimiser_enabled = master
             changed = True
 
         profile_name = optimiser_section.get("profile")
         if isinstance(profile_name, str) and profile_name in PROFILE_NAMES:
-            if profile_name != _state.feature_config.optimiser_profile:
-                _state.feature_config.optimiser_profile = profile_name
+            if profile_name != target.optimiser_profile:
+                target.optimiser_profile = profile_name
                 changed = True
         elif isinstance(profile_name, str) and profile_name:
             log.warning("Unknown optimiser profile %r (ignored)", profile_name)
 
         try:
-            base_disabled = set(
-                profile_to_disabled(profile_from_name(_state.feature_config.optimiser_profile))
-            )
+            base_disabled = set(profile_to_disabled(profile_from_name(target.optimiser_profile)))
         except ValueError:
             base_disabled = set(profile_to_disabled(DEFAULT_EDITOR_PROFILE))
 
@@ -316,8 +318,8 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
             elif val is False:
                 base_disabled.add(code)
 
-        if base_disabled != _state.feature_config.disabled_optimisations:
-            _state.feature_config.disabled_optimisations = base_disabled
+        if base_disabled != target.disabled_optimisations:
+            target.disabled_optimisations = base_disabled
             changed = True
 
         unknown_opt = {
@@ -341,8 +343,8 @@ def _apply_feature_settings(tcl_settings: dict) -> bool:
             patterns = diagnostics_section.get("generic_variable_patterns")
         if has_generic_patterns and isinstance(patterns, list):
             new_patterns = [str(p) for p in patterns if isinstance(p, str)]
-            if new_patterns != _state.feature_config.generic_variable_patterns:
-                _state.feature_config.generic_variable_patterns = new_patterns
+            if new_patterns != target.generic_variable_patterns:
+                target.generic_variable_patterns = new_patterns
                 changed = True
 
     return changed
@@ -354,39 +356,55 @@ _pending_apply_handle: asyncio.TimerHandle | None = None
 _SETTINGS_DEBOUNCE_S = 0.3
 
 
-def _merged_settings() -> dict:
-    """Merge all configuration layers in precedence order.
+def _merged_settings(folder_uri: str = "") -> dict:
+    """Merge all configuration layers for ``folder_uri`` in precedence order.
 
     Lowest to highest priority:
-      1. Global user config (``~/.config/tcl-lsp/config.ini``)
-      2. Editor settings (``workspace/didChangeConfiguration`` payload)
-      3. Project config (``<workspace>/.tcl-lsp.ini``)
+      1. Global user config (``~/.config/tcl-lsp/config.ini``) — applies
+         everywhere, not per-folder.
+      2. Editor settings (``workspace/configuration`` pull payload, per
+         workspace folder).
+      3. Project config (``<folder>/.tcl-lsp.ini``, per workspace folder).
+
+    ``folder_uri=""`` selects the workspace/user-level fallback layers.
+    Per-folder layers fall back to the workspace-level layers when not
+    explicitly populated.
 
     Inline ``# noqa`` and top-of-file ``# tcl-lsp: disable=`` directives are
     applied later, in the per-document diagnostics pipeline — they do not
     feed into server-level ``feature_config``.
     """
+    editor = _state.editor_config_settings_per_folder.get(folder_uri, _state.editor_config_settings)
+    project = _state.project_config_settings_per_folder.get(
+        folder_uri, _state.project_config_settings
+    )
     return merge_settings_layers(
         _state.global_config_settings,
-        _state.editor_config_settings,
-        _state.project_config_settings,
+        editor,
+        project,
     )
 
 
-def _apply_all_settings(tcl_settings: dict) -> None:
-    """Update the editor config layer and apply the merged settings (debounced)."""
-    _state.editor_config_settings = tcl_settings
+def _apply_all_settings(tcl_settings: dict, folder_uri: str = "") -> None:
+    """Update the editor-config layer for ``folder_uri`` and re-apply (debounced)."""
+    if folder_uri == "":
+        _state.editor_config_settings = tcl_settings
+    else:
+        _state.editor_config_settings_per_folder[folder_uri] = tcl_settings
     _schedule_apply_merged()
 
 
-def apply_project_settings(tcl_settings: dict) -> None:
-    """Update the project-config layer and apply the merged settings."""
-    _state.project_config_settings = tcl_settings
+def apply_project_settings(tcl_settings: dict, folder_uri: str = "") -> None:
+    """Update the project-config layer for ``folder_uri`` and re-apply."""
+    if folder_uri == "":
+        _state.project_config_settings = tcl_settings
+    else:
+        _state.project_config_settings_per_folder[folder_uri] = tcl_settings
     _schedule_apply_merged()
 
 
 def apply_global_settings(tcl_settings: dict) -> None:
-    """Update the global user-config layer and apply the merged settings."""
+    """Update the global user-config layer (not per-folder) and re-apply."""
     _state.global_config_settings = tcl_settings
     _schedule_apply_merged()
 
@@ -411,22 +429,44 @@ def _schedule_apply_merged() -> None:
     )
 
 
-def _apply_merged_settings_now() -> None:
-    """Apply the merged configuration layers (called after debounce timer)."""
-    global _pending_apply_handle
-    _pending_apply_handle = None
+def _apply_settings_to_target(folder_uri: str, tcl_settings: dict) -> bool:
+    """Apply ``tcl_settings`` to the FeatureConfig/FormatterConfig for ``folder_uri``.
 
-    tcl_settings = _merged_settings()
+    ``folder_uri=""`` targets the workspace/user-level fallback (the
+    ``feature_config`` / ``formatter_config`` module attributes).  Returns
+    True if any feature settings changed.
+    """
+    if folder_uri == "":
+        feature_target = _state.feature_config
+    else:
+        feature_target = _state.get_or_init_folder_feature_config(folder_uri)
 
     formatting = tcl_settings.get("formatting")
     if isinstance(formatting, dict) and formatting:
-        current = _state.formatter_config.to_dict()
+        if folder_uri == "":
+            current = _state.formatter_config.to_dict()
+        else:
+            current = _state.get_or_init_folder_formatter_config(folder_uri).to_dict()
         current.update(_normalise_formatter_settings(formatting))
-        _state.formatter_config = FormatterConfig.from_dict(current)
+        _state.set_folder_formatter_config(folder_uri, FormatterConfig.from_dict(current))
 
-    extra_commands_setting = tcl_settings.get("extraCommands")
+    return _apply_feature_settings(tcl_settings, target=feature_target)
+
+
+def _apply_merged_settings_now() -> None:
+    """Apply merged config layers — workspace fallback + every known folder."""
+    global _pending_apply_handle
+    _pending_apply_handle = None
+
+    fallback_settings = _merged_settings()
+
+    # Process-wide settings: signatures (dialect / extraCommands), library
+    # paths, scanner configuration.  These are read from the workspace
+    # fallback layer — multi-folder per-dialect support would require the
+    # signature registry to be folder-aware, which is a larger refactor.
+    extra_commands_setting = fallback_settings.get("extraCommands")
     if extra_commands_setting is None:
-        extra_commands_setting = tcl_settings.get("extra_commands")
+        extra_commands_setting = fallback_settings.get("extra_commands")
     if extra_commands_setting is None:
         extra_commands = None
     elif isinstance(extra_commands_setting, list):
@@ -434,9 +474,9 @@ def _apply_merged_settings_now() -> None:
     else:
         extra_commands = []
 
-    library_paths_setting = tcl_settings.get("libraryPaths")
+    library_paths_setting = fallback_settings.get("libraryPaths")
     if library_paths_setting is None:
-        library_paths_setting = tcl_settings.get("library_paths")
+        library_paths_setting = fallback_settings.get("library_paths")
     if isinstance(library_paths_setting, list):
         library_paths = [str(p) for p in library_paths_setting]
         _state.background_scanner.configure(library_paths=library_paths)
@@ -447,7 +487,7 @@ def _apply_merged_settings_now() -> None:
 
         threading.Thread(target=_wi._run_background_scan, daemon=True).start()
 
-    dialect_setting = tcl_settings.get("dialect")
+    dialect_setting = fallback_settings.get("dialect")
     if isinstance(dialect_setting, str) and dialect_setting:
         _state.feature_config.dialect_explicitly_set = True
     signatures_changed = configure_signatures(
@@ -463,8 +503,21 @@ def _apply_merged_settings_now() -> None:
             _state.feature_config.dialect_explicitly_set,
         )
 
+    # Per-folder + fallback feature/formatter application.
     diags_were_enabled = _state.feature_config.diagnostics_enabled
-    features_changed = _apply_feature_settings(tcl_settings)
+    features_changed = _apply_settings_to_target("", fallback_settings)
+
+    folder_uris = sorted(
+        set(_state.editor_config_settings_per_folder.keys())
+        | set(_state.project_config_settings_per_folder.keys())
+        | set(_state.workspace_folder_uris())
+    )
+    for folder_uri in folder_uris:
+        if folder_uri == "":
+            continue
+        folder_settings = _merged_settings(folder_uri)
+        if _apply_settings_to_target(folder_uri, folder_settings):
+            features_changed = True
 
     if not signatures_changed and not features_changed:
         return
@@ -506,17 +559,37 @@ def _apply_merged_settings_now() -> None:
                 _publish_diags_to_client(uri, [], doc_state.version)
 
 
+def _workspace_folder_uris_from_server() -> list[str]:
+    """List workspace folder URIs from the pygls server (empty if none)."""
+    if _server is None:
+        return []
+    folders = getattr(_server.workspace, "workspace_folders", None) or []
+    return [getattr(f, "uri", "") for f in folders if getattr(f, "uri", "")]
+
+
 def _pull_and_apply_configuration() -> None:
-    """Pull configuration from the client via ``workspace/configuration``."""
-    params = types.ConfigurationParams(items=[types.ConfigurationItem(section="tclLsp")])
+    """Pull tclLsp config per workspace folder + the workspace fallback."""
+    folder_uris = _workspace_folder_uris_from_server()
+    items: list[types.ConfigurationItem] = [
+        types.ConfigurationItem(scope_uri=uri, section="tclLsp") for uri in folder_uris
+    ]
+    # Always include the unscoped fallback (workspace/user settings) — used
+    # for files outside any workspace folder.
+    items.append(types.ConfigurationItem(section="tclLsp"))
+    params = types.ConfigurationParams(items=items)
 
     def _on_result(result: list[object] | None) -> None:
         if not result:
             return
-        item = result[0]
-        if not isinstance(item, dict):
-            return
-        _apply_all_settings(item)
+        # Result order matches request order: per-folder items first,
+        # then the fallback item last.
+        for folder_uri, item in zip(folder_uris, result, strict=False):
+            if isinstance(item, dict):
+                _apply_all_settings(item, folder_uri=folder_uri)
+        if len(result) > len(folder_uris):
+            fallback_item = result[len(folder_uris)]
+            if isinstance(fallback_item, dict):
+                _apply_all_settings(fallback_item, folder_uri="")
 
     try:
         _server.workspace_configuration(params, callback=_on_result)  # type: ignore[union-attr]
@@ -532,9 +605,14 @@ def register(server_instance: LanguageServer) -> None:
 
     @server_instance.feature(types.WORKSPACE_DID_CHANGE_CONFIGURATION)
     def did_change_configuration(params: types.DidChangeConfigurationParams) -> None:
+        # Always pull per-folder via workspace/configuration: the push
+        # payload (if any) is the workspace-merged value and cannot
+        # populate per-folder configs.  The pull also covers clients that
+        # send empty notifications as a "config changed" signal.
         settings = params.settings
-        if not settings:
-            _pull_and_apply_configuration()
-            return
-        tcl_settings = _extract_tcl_lsp_settings(settings)
-        _apply_all_settings(tcl_settings)
+        if isinstance(settings, dict) and settings:
+            # Apply the push payload to the fallback layer immediately
+            # (covers files outside every workspace folder), then pull
+            # for accurate per-folder values.
+            _apply_all_settings(_extract_tcl_lsp_settings(settings), folder_uri="")
+        _pull_and_apply_configuration()

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -560,11 +560,22 @@ def _apply_merged_settings_now() -> None:
 
 
 def _workspace_folder_uris_from_server() -> list[str]:
-    """List workspace folder URIs from the pygls server (empty if none)."""
+    """List workspace folder URIs from the pygls server (empty if none).
+
+    pygls 2.x stores workspace folders in ``Workspace.folders`` as a
+    ``dict[str, WorkspaceFolder]`` keyed by URI.
+    """
     if _server is None:
         return []
-    folders = getattr(_server.workspace, "workspace_folders", None) or []
-    return [getattr(f, "uri", "") for f in folders if getattr(f, "uri", "")]
+    folders = getattr(_server.workspace, "folders", None)
+    if folders is None:
+        # Fall back to legacy attribute names from older pygls releases.
+        folders = getattr(_server.workspace, "workspace_folders", None) or []
+    if isinstance(folders, dict):
+        iterable = folders.values()
+    else:
+        iterable = folders
+    return [getattr(f, "uri", "") for f in iterable if getattr(f, "uri", "")]
 
 
 def _pull_and_apply_configuration() -> None:

--- a/lsp/state.py
+++ b/lsp/state.py
@@ -34,21 +34,102 @@ formatter_config = FormatterConfig()
 feature_config = FeatureConfig()
 diagnostic_scheduler = DiagnosticScheduler()
 
+# Per-folder configuration overrides (issue #230).
+#
+# Each workspace folder URI may have its own ``FeatureConfig`` and
+# ``FormatterConfig`` that override the workspace/user-level fallback
+# (``feature_config`` / ``formatter_config`` above).  Documents outside
+# every known folder, and workspace-wide queries with no URI, use the
+# fallback.
+_per_folder_feature_configs: dict[str, FeatureConfig] = {}
+_per_folder_formatter_configs: dict[str, FormatterConfig] = {}
 
-def config_for_uri(doc_uri: str | None) -> FeatureConfig:  # noqa: ARG001
+
+def _longest_folder_prefix(doc_uri: str, folders: list[str]) -> str | None:
+    """Return the longest workspace-folder URI that prefixes ``doc_uri``."""
+    best: str | None = None
+    for folder in folders:
+        normalised = folder.rstrip("/")
+        if doc_uri == normalised or doc_uri.startswith(normalised + "/"):
+            if best is None or len(normalised) > len(best.rstrip("/")):
+                best = folder
+    return best
+
+
+def workspace_folder_uris() -> list[str]:
+    """Workspace folder URIs that have per-folder config overrides."""
+    return list(_per_folder_feature_configs.keys())
+
+
+def config_for_uri(doc_uri: str | None) -> FeatureConfig:
     """Resolve the effective ``FeatureConfig`` for a document URI.
 
-    PR A introduces this seam as a shim that returns the global
-    ``feature_config``.  Per-folder resolution lands in the follow-up
-    refactor (issue #230 PR B), where this helper picks the longest
-    workspace-folder-prefix match from a folder→config map.
+    Picks the longest matching workspace-folder URI; falls back to the
+    workspace/user-level ``feature_config`` when the document is outside
+    every known folder or no URI was supplied.
     """
+    if doc_uri and _per_folder_feature_configs:
+        match = _longest_folder_prefix(doc_uri, list(_per_folder_feature_configs.keys()))
+        if match is not None:
+            return _per_folder_feature_configs[match]
     return feature_config
 
+
+def formatter_config_for_uri(doc_uri: str | None) -> FormatterConfig:
+    """Resolve the effective ``FormatterConfig`` for a document URI."""
+    if doc_uri and _per_folder_formatter_configs:
+        match = _longest_folder_prefix(doc_uri, list(_per_folder_formatter_configs.keys()))
+        if match is not None:
+            return _per_folder_formatter_configs[match]
+    return formatter_config
+
+
+def get_or_init_folder_feature_config(folder_uri: str) -> FeatureConfig:
+    """Initialise the FeatureConfig for ``folder_uri`` if missing, then return it.
+
+    A new folder inherits a deep copy of the fallback so it starts aligned
+    with workspace/user defaults.
+    """
+    from copy import deepcopy
+
+    if folder_uri not in _per_folder_feature_configs:
+        _per_folder_feature_configs[folder_uri] = deepcopy(feature_config)
+    return _per_folder_feature_configs[folder_uri]
+
+
+def get_or_init_folder_formatter_config(folder_uri: str) -> FormatterConfig:
+    """Initialise the FormatterConfig for ``folder_uri`` if missing, then return it."""
+    from copy import deepcopy
+
+    if folder_uri not in _per_folder_formatter_configs:
+        _per_folder_formatter_configs[folder_uri] = deepcopy(formatter_config)
+    return _per_folder_formatter_configs[folder_uri]
+
+
+def set_folder_formatter_config(folder_uri: str, config: FormatterConfig) -> None:
+    """Replace the FormatterConfig for ``folder_uri`` (or the fallback when "")."""
+    global formatter_config
+    if folder_uri == "":
+        formatter_config = config
+    else:
+        _per_folder_formatter_configs[folder_uri] = config
+
+
+def drop_folder_configs(folder_uri: str) -> None:
+    """Drop per-folder configs and editor/project layers for a closed folder."""
+    _per_folder_feature_configs.pop(folder_uri, None)
+    _per_folder_formatter_configs.pop(folder_uri, None)
+    editor_config_settings_per_folder.pop(folder_uri, None)
+    project_config_settings_per_folder.pop(folder_uri, None)
+
+
 # Configuration layers, merged on each apply in the order:
-#   global_config_settings  ← ``~/.config/tcl-lsp/config.ini`` (lowest priority)
-#   editor_config_settings  ← ``workspace/didChangeConfiguration`` payload
-#   project_config_settings ← ``<workspace>/.tcl-lsp.ini`` (highest priority)
+#   global_config_settings  ← ``~/.config/tcl-lsp/config.ini`` (lowest priority,
+#                              user-home — applies everywhere)
+#   editor_config_settings  ← ``workspace/configuration`` pull payload
+#                              (per workspace folder; fallback under "")
+#   project_config_settings ← ``<folder>/.tcl-lsp.ini`` (highest priority,
+#                              per workspace folder; fallback under "")
 #
 # See ``docs/kcs/kcs-howto-suppress-diagnostics.md`` for the full precedence
 # chain including inline ``# <noqa>`` and file-level ``# tcl-lsp: disable=``
@@ -56,6 +137,8 @@ def config_for_uri(doc_uri: str | None) -> FeatureConfig:  # noqa: ARG001
 global_config_settings: dict = {}
 editor_config_settings: dict = {}
 project_config_settings: dict = {}
+editor_config_settings_per_folder: dict[str, dict] = {}
+project_config_settings_per_folder: dict[str, dict] = {}
 
 _process_pool: ProcessPoolExecutor | None = None
 

--- a/lsp/state.py
+++ b/lsp/state.py
@@ -34,6 +34,17 @@ formatter_config = FormatterConfig()
 feature_config = FeatureConfig()
 diagnostic_scheduler = DiagnosticScheduler()
 
+
+def config_for_uri(doc_uri: str | None) -> FeatureConfig:  # noqa: ARG001
+    """Resolve the effective ``FeatureConfig`` for a document URI.
+
+    PR A introduces this seam as a shim that returns the global
+    ``feature_config``.  Per-folder resolution lands in the follow-up
+    refactor (issue #230 PR B), where this helper picks the longest
+    workspace-folder-prefix match from a folder→config map.
+    """
+    return feature_config
+
 # Configuration layers, merged on each apply in the order:
 #   global_config_settings  ← ``~/.config/tcl-lsp/config.ini`` (lowest priority)
 #   editor_config_settings  ← ``workspace/didChangeConfiguration`` payload

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -304,16 +304,11 @@ def on_initialized(params: types.InitializedParams) -> None:
         _state.project_config_settings = project_settings
 
     # Apply the current (global + project) layers so server state is
-    # populated before the first analysis pass.
+    # populated before the first analysis pass.  Editor settings are
+    # pulled per workspace folder near the end of this handler — the
+    # callback re-runs ``_apply_merged_settings_now`` with the populated
+    # editor layer.
     _apply_merged_settings_now()
-
-    # Pull the initial editor settings from the client per workspace
-    # folder.  Without this, per-folder ``.vscode/settings.json`` values
-    # only land after the client sends its first
-    # ``workspace/didChangeConfiguration`` notification — which some
-    # clients delay or batch, leaving formatting/diagnostics on initial
-    # requests using stale (default) configuration (issue #230).
-    _pull_and_apply_configuration()
 
     process_start = getattr(_server, "_process_start_time", None)
     if process_start is not None:

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -22,6 +22,7 @@ from core.common.user_config import (
 from core.formatting import FormatterConfig
 
 from .workspace.scanner import path_to_uri
+from .workspace.scanner import uri_to_path as _uri_to_path
 from .workspace.workspace_index import EntrySource
 
 if TYPE_CHECKING:
@@ -263,12 +264,36 @@ def on_initialized(params: types.InitializedParams) -> None:
             _normalise_formatter_settings(formatting)
         )
 
-    # Discover the project-level config file at the workspace root.
+    # Discover project-level config files: one per workspace folder for
+    # multi-root workspaces, plus the workspace fallback for files outside
+    # any folder.
     ws = _server.workspace  # type: ignore[union-attr]
-    project_settings: dict = {}
-    if ws.root_path:
-        project_settings = get_all_settings(load_project_config(ws.root_path))
-    _state.project_config_settings = project_settings
+    folders = getattr(ws, "workspace_folders", None) or []
+    folder_paths: list[tuple[str, str]] = []
+    for folder in folders:
+        folder_uri = getattr(folder, "uri", "")
+        folder_path = _uri_to_path(folder_uri)
+        if folder_uri and folder_path:
+            folder_paths.append((folder_uri, folder_path))
+
+    if folder_paths:
+        for folder_uri, folder_path in folder_paths:
+            project_settings = get_all_settings(load_project_config(folder_path))
+            _state.project_config_settings_per_folder[folder_uri] = project_settings
+            # Initialise per-folder configs so later pulls and lookups have
+            # somewhere to write into.
+            _state.get_or_init_folder_feature_config(folder_uri)
+            _state.get_or_init_folder_formatter_config(folder_uri)
+        # Fallback (no scope) uses the first folder's project config so
+        # files outside any folder still get a sensible default.
+        _state.project_config_settings = (
+            _state.project_config_settings_per_folder[folder_paths[0][0]] if folder_paths else {}
+        )
+    else:
+        project_settings: dict = {}
+        if ws.root_path:
+            project_settings = get_all_settings(load_project_config(ws.root_path))
+        _state.project_config_settings = project_settings
 
     # Editor settings arrive later via ``workspace/didChangeConfiguration``;
     # apply the current (global + project) layers now so server state is

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -268,7 +268,15 @@ def on_initialized(params: types.InitializedParams) -> None:
     # multi-root workspaces, plus the workspace fallback for files outside
     # any folder.
     ws = _server.workspace  # type: ignore[union-attr]
-    folders = getattr(ws, "workspace_folders", None) or []
+    # pygls 2.x exposes folders as ``Workspace.folders`` (dict keyed by URI);
+    # older releases used ``workspace_folders`` (list).  Support both.
+    _folders_attr = getattr(ws, "folders", None)
+    if _folders_attr is None:
+        _folders_attr = getattr(ws, "workspace_folders", None) or []
+    if isinstance(_folders_attr, dict):
+        folders = list(_folders_attr.values())
+    else:
+        folders = list(_folders_attr)
     folder_paths: list[tuple[str, str]] = []
     for folder in folders:
         folder_uri = getattr(folder, "uri", "")
@@ -295,10 +303,17 @@ def on_initialized(params: types.InitializedParams) -> None:
             project_settings = get_all_settings(load_project_config(ws.root_path))
         _state.project_config_settings = project_settings
 
-    # Editor settings arrive later via ``workspace/didChangeConfiguration``;
-    # apply the current (global + project) layers now so server state is
+    # Apply the current (global + project) layers so server state is
     # populated before the first analysis pass.
     _apply_merged_settings_now()
+
+    # Pull the initial editor settings from the client per workspace
+    # folder.  Without this, per-folder ``.vscode/settings.json`` values
+    # only land after the client sends its first
+    # ``workspace/didChangeConfiguration`` notification — which some
+    # clients delay or batch, leaving formatting/diagnostics on initial
+    # requests using stale (default) configuration (issue #230).
+    _pull_and_apply_configuration()
 
     process_start = getattr(_server, "_process_start_time", None)
     if process_start is not None:

--- a/scripts/generate_editor_settings.py
+++ b/scripts/generate_editor_settings.py
@@ -656,6 +656,59 @@ _GENERATED_TITLES = (
 )
 
 
+# Per-folder configuration scope categorisation (issue #230).
+#
+# Multi-folder VS Code workspaces reject ``window``-scoped settings in
+# folder ``.vscode/settings.json``.  Every generated ``tclLsp.*`` setting
+# must declare a non-``window`` scope.  Categorisation:
+#
+# - ``language-overridable`` for project + per-language settings
+#   (formatting, style — same toggles can vary per Tcl dialect).
+# - ``resource`` for per-folder analysis toggles
+#   (diagnostics, optimiser, shimmer).
+#
+# Hand-edited sections (General, Features, Runtime Validation, AI,
+# Package Manager, XC Migration, Trace) declare their own scopes —
+# pinned by ``tests/test_settings_scope.py``.
+_VSCODE_SCOPE_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("tclLsp.formatting.", "language-overridable"),
+    ("tclLsp.style.", "language-overridable"),
+    ("tclLsp.diagnostics.", "resource"),
+    ("tclLsp.optimiser.", "resource"),
+    ("tclLsp.shimmer.", "resource"),
+)
+
+
+def _resolve_vscode_scope(setting_key: str) -> str | None:
+    """Return the scope string for a generated ``tclLsp.*`` setting key."""
+    for prefix, scope in _VSCODE_SCOPE_PREFIXES:
+        if setting_key.startswith(prefix):
+            return scope
+    return None
+
+
+def _inject_vscode_scopes(sections: list[dict]) -> list[dict]:
+    """Insert ``scope`` as the first key on every generated property.
+
+    The position matters only for diff readability; VS Code accepts any
+    key order.  Generated sections are deterministic, so the resulting
+    package.json is stable across runs.
+    """
+    for section in sections:
+        properties = section.get("properties")
+        if not isinstance(properties, dict):
+            continue
+        new_props: dict[str, dict] = {}
+        for key, schema in properties.items():
+            scope = _resolve_vscode_scope(key)
+            if scope is not None and "scope" not in schema:
+                new_props[key] = {"scope": scope, **schema}
+            else:
+                new_props[key] = schema
+        section["properties"] = new_props
+    return sections
+
+
 def generate_vscode_package_json(*, dry_run: bool = False) -> tuple[Path, str]:
     """Regenerate VS Code package.json diagnostic/optimiser settings."""
     path = ROOT / "editors" / "vscode" / "package.json"
@@ -680,7 +733,9 @@ def generate_vscode_package_json(*, dry_run: bool = False) -> tuple[Path, str]:
     new_diag_sections = _build_vscode_diagnostic_sections()
     next_order = max(s["order"] for s in new_diag_sections) + 1 if new_diag_sections else 7
     new_opt_section = _build_vscode_optimiser_section(order=next_order)
-    new_generated = new_formatter_sections + new_diag_sections + [new_opt_section]
+    new_generated = _inject_vscode_scopes(
+        new_formatter_sections + new_diag_sections + [new_opt_section]
+    )
 
     # Reconstruct: before-generated + new-generated + after-generated
     before = config_groups[:first_gen_idx]

--- a/tests/test_per_folder_config.py
+++ b/tests/test_per_folder_config.py
@@ -1,0 +1,214 @@
+"""Per-workspace-folder configuration resolution (issue #230).
+
+Covers:
+
+- ``config_for_uri`` / ``formatter_config_for_uri`` longest-prefix
+  matching and fallback when a document is outside every folder.
+- ``_apply_settings_to_target`` writes feature toggles, formatter
+  fields, line length, and disabled diagnostics to the right folder.
+- The merged settings layers (``editor``, ``project``) honour the
+  folder URI when resolving merged settings.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+
+import lsp.settings as _lsp_settings
+import lsp.state as _lsp_state
+from core.formatting import FormatterConfig
+from lsp.feature_config import FeatureConfig
+
+
+@pytest.fixture
+def reset_per_folder_state():
+    """Snapshot/restore the module-level per-folder maps and fallback configs."""
+    snap_feature = _lsp_state.feature_config
+    snap_formatter = _lsp_state.formatter_config
+    snap_per_folder_feature = dict(_lsp_state._per_folder_feature_configs)
+    snap_per_folder_formatter = dict(_lsp_state._per_folder_formatter_configs)
+    snap_editor = dict(_lsp_state.editor_config_settings)
+    snap_project = dict(_lsp_state.project_config_settings)
+    snap_editor_pf = dict(_lsp_state.editor_config_settings_per_folder)
+    snap_project_pf = dict(_lsp_state.project_config_settings_per_folder)
+
+    _lsp_state.feature_config = FeatureConfig()
+    _lsp_state.formatter_config = FormatterConfig()
+    _lsp_state._per_folder_feature_configs.clear()
+    _lsp_state._per_folder_formatter_configs.clear()
+    _lsp_state.editor_config_settings.clear()
+    _lsp_state.project_config_settings.clear()
+    _lsp_state.editor_config_settings_per_folder.clear()
+    _lsp_state.project_config_settings_per_folder.clear()
+
+    yield
+
+    _lsp_state.feature_config = snap_feature
+    _lsp_state.formatter_config = snap_formatter
+    _lsp_state._per_folder_feature_configs.clear()
+    _lsp_state._per_folder_feature_configs.update(snap_per_folder_feature)
+    _lsp_state._per_folder_formatter_configs.clear()
+    _lsp_state._per_folder_formatter_configs.update(snap_per_folder_formatter)
+    _lsp_state.editor_config_settings.clear()
+    _lsp_state.editor_config_settings.update(snap_editor)
+    _lsp_state.project_config_settings.clear()
+    _lsp_state.project_config_settings.update(snap_project)
+    _lsp_state.editor_config_settings_per_folder.clear()
+    _lsp_state.editor_config_settings_per_folder.update(snap_editor_pf)
+    _lsp_state.project_config_settings_per_folder.clear()
+    _lsp_state.project_config_settings_per_folder.update(snap_project_pf)
+
+
+class TestConfigResolution:
+    """``config_for_uri`` / ``formatter_config_for_uri`` resolver behaviour."""
+
+    def test_falls_back_when_no_per_folder_configs(self, reset_per_folder_state):
+        cfg = _lsp_state.config_for_uri("file:///tmp/foo.tcl")
+        assert cfg is _lsp_state.feature_config
+
+    def test_falls_back_when_uri_outside_every_folder(self, reset_per_folder_state):
+        _lsp_state.get_or_init_folder_feature_config("file:///home/user/proj-a")
+        cfg = _lsp_state.config_for_uri("file:///elsewhere/foo.tcl")
+        assert cfg is _lsp_state.feature_config
+
+    def test_picks_matching_folder(self, reset_per_folder_state):
+        a = _lsp_state.get_or_init_folder_feature_config("file:///home/user/proj-a")
+        b = _lsp_state.get_or_init_folder_feature_config("file:///home/user/proj-b")
+        a.line_length = 160
+        b.line_length = 80
+
+        assert _lsp_state.config_for_uri("file:///home/user/proj-a/foo.tcl").line_length == 160
+        assert _lsp_state.config_for_uri("file:///home/user/proj-b/foo.tcl").line_length == 80
+
+    def test_longest_prefix_wins_for_nested_folders(self, reset_per_folder_state):
+        outer = _lsp_state.get_or_init_folder_feature_config("file:///home/user/repo")
+        inner = _lsp_state.get_or_init_folder_feature_config("file:///home/user/repo/sub")
+        outer.line_length = 100
+        inner.line_length = 200
+
+        outer_uri = "file:///home/user/repo/foo.tcl"
+        inner_uri = "file:///home/user/repo/sub/bar.tcl"
+        assert _lsp_state.config_for_uri(outer_uri).line_length == 100
+        assert _lsp_state.config_for_uri(inner_uri).line_length == 200
+
+    def test_does_not_match_sibling_path_with_shared_prefix(self, reset_per_folder_state):
+        """``/home/foo`` should not match a doc under ``/home/foobar/...``."""
+        _lsp_state.get_or_init_folder_feature_config("file:///home/foo").line_length = 99
+        cfg = _lsp_state.config_for_uri("file:///home/foobar/x.tcl")
+        assert cfg.line_length != 99
+        assert cfg is _lsp_state.feature_config
+
+    def test_uri_equal_to_folder_resolves_to_that_folder(self, reset_per_folder_state):
+        cfg = _lsp_state.get_or_init_folder_feature_config("file:///home/foo")
+        cfg.line_length = 77
+        assert _lsp_state.config_for_uri("file:///home/foo").line_length == 77
+
+    def test_none_uri_falls_back(self, reset_per_folder_state):
+        _lsp_state.get_or_init_folder_feature_config("file:///home/foo")
+        assert _lsp_state.config_for_uri(None) is _lsp_state.feature_config
+
+    def test_formatter_config_for_uri_picks_matching_folder(self, reset_per_folder_state):
+        a = _lsp_state.get_or_init_folder_formatter_config("file:///home/user/proj-a")
+        b = _lsp_state.get_or_init_folder_formatter_config("file:///home/user/proj-b")
+        a.max_line_length = 160
+        b.max_line_length = 80
+
+        a_uri = "file:///home/user/proj-a/foo.tcl"
+        b_uri = "file:///home/user/proj-b/foo.tcl"
+        assert _lsp_state.formatter_config_for_uri(a_uri).max_line_length == 160
+        assert _lsp_state.formatter_config_for_uri(b_uri).max_line_length == 80
+
+    def test_formatter_config_falls_back_outside_folders(self, reset_per_folder_state):
+        _lsp_state.get_or_init_folder_formatter_config("file:///home/user/proj-a")
+        cfg = _lsp_state.formatter_config_for_uri("file:///tmp/x.tcl")
+        assert cfg is _lsp_state.formatter_config
+
+
+class TestApplyToTarget:
+    """``_apply_settings_to_target`` writes to the right config object."""
+
+    def test_fallback_target_mutates_global_feature_config(self, reset_per_folder_state):
+        _lsp_settings._apply_settings_to_target(
+            "", {"style": {"lineLength": 90}, "shimmer": {"enabled": False}}
+        )
+        assert _lsp_state.feature_config.line_length == 90
+        assert _lsp_state.feature_config.shimmer_enabled is False
+
+    def test_folder_target_creates_isolated_config(self, reset_per_folder_state):
+        folder_uri = "file:///home/user/proj-a"
+        _lsp_settings._apply_settings_to_target(folder_uri, {"style": {"lineLength": 200}})
+
+        # Folder config sees the new value; fallback is unchanged.
+        assert _lsp_state.config_for_uri(f"{folder_uri}/foo.tcl").line_length == 200
+        assert _lsp_state.feature_config.line_length == 120
+
+    def test_two_folders_independent(self, reset_per_folder_state):
+        a_uri = "file:///home/user/proj-a"
+        b_uri = "file:///home/user/proj-b"
+        _lsp_settings._apply_settings_to_target(a_uri, {"style": {"lineLength": 200}})
+        _lsp_settings._apply_settings_to_target(b_uri, {"style": {"lineLength": 60}})
+
+        assert _lsp_state.config_for_uri(f"{a_uri}/x.tcl").line_length == 200
+        assert _lsp_state.config_for_uri(f"{b_uri}/x.tcl").line_length == 60
+        # Fallback untouched.
+        assert _lsp_state.feature_config.line_length == 120
+
+    def test_formatting_settings_applied_per_folder(self, reset_per_folder_state):
+        folder_uri = "file:///home/user/proj-a"
+        _lsp_settings._apply_settings_to_target(folder_uri, {"formatting": {"maxLineLength": 160}})
+
+        fmt_cfg = _lsp_state.formatter_config_for_uri(f"{folder_uri}/foo.tcl")
+        assert fmt_cfg.max_line_length == 160
+        # Fallback formatter unchanged.
+        assert _lsp_state.formatter_config.max_line_length == 120
+
+    def test_disabled_diagnostics_per_folder(self, reset_per_folder_state):
+        folder_uri = "file:///home/user/proj-a"
+        _lsp_settings._apply_settings_to_target(folder_uri, {"diagnostics": {"W111": False}})
+
+        a_cfg = _lsp_state.config_for_uri(f"{folder_uri}/foo.tcl")
+        assert "W111" in a_cfg.disabled_diagnostics
+        # Fallback should not have W111 disabled (default keeps it enabled).
+        assert "W111" not in _lsp_state.feature_config.disabled_diagnostics
+
+
+class TestMergedSettingsPerFolder:
+    """``_merged_settings`` resolves per-folder editor/project layers."""
+
+    def test_per_folder_layers_isolated_from_fallback(self, reset_per_folder_state):
+        folder_uri = "file:///home/user/proj-a"
+        _lsp_state.editor_config_settings_per_folder[folder_uri] = {"style": {"lineLength": 99}}
+        _lsp_state.editor_config_settings["style"] = {"lineLength": 50}
+
+        merged_folder = _lsp_settings._merged_settings(folder_uri)
+        merged_fallback = _lsp_settings._merged_settings("")
+
+        assert merged_folder["style"]["lineLength"] == 99
+        assert merged_fallback["style"]["lineLength"] == 50
+
+    def test_folder_layer_falls_back_when_unset(self, reset_per_folder_state):
+        """An unknown folder URI falls through to workspace-level editor/project."""
+        _lsp_state.editor_config_settings["style"] = {"lineLength": 50}
+        merged = _lsp_settings._merged_settings("file:///home/user/unknown")
+        assert merged["style"]["lineLength"] == 50
+
+
+class TestDropFolderConfigs:
+    def test_drop_clears_all_layers(self, reset_per_folder_state):
+        folder_uri = "file:///home/user/proj-a"
+        _lsp_state.get_or_init_folder_feature_config(folder_uri)
+        _lsp_state.get_or_init_folder_formatter_config(folder_uri)
+        _lsp_state.editor_config_settings_per_folder[folder_uri] = {"x": 1}
+        _lsp_state.project_config_settings_per_folder[folder_uri] = {"y": 2}
+
+        _lsp_state.drop_folder_configs(folder_uri)
+
+        assert folder_uri not in _lsp_state._per_folder_feature_configs
+        assert folder_uri not in _lsp_state._per_folder_formatter_configs
+        assert folder_uri not in _lsp_state.editor_config_settings_per_folder
+        assert folder_uri not in _lsp_state.project_config_settings_per_folder

--- a/tests/test_per_folder_config_e2e.py
+++ b/tests/test_per_folder_config_e2e.py
@@ -1,0 +1,205 @@
+"""End-to-end backend tests for per-folder config (issue #230).
+
+Drives the full chain that the LSP handlers execute:
+
+    1. Apply different ``tclLsp.*`` settings to two workspace folders.
+    2. Pull each handler's config via ``config_for_uri(uri)`` /
+       ``formatter_config_for_uri(uri)`` — the same calls the
+       ``server.on_formatting`` / ``server.on_completion`` /
+       diagnostics-pipeline handlers make.
+    3. Assert the resulting output (formatted text, diagnostics) actually
+       differs between folders for the same input source.
+
+These are heavier than the unit tests in ``test_per_folder_config.py``
+but pin the property "different folder settings produce different
+output" — which is the user-visible contract from issue #230.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from lsprotocol import types
+
+import lsp.settings as _lsp_settings
+import lsp.state as _lsp_state
+from core.formatting import FormatterConfig
+from lsp.feature_config import FeatureConfig
+from lsp.features.diagnostics import get_diagnostics
+from lsp.features.formatting import get_formatting
+
+FOLDER_A = "file:///home/user/proj-a"
+FOLDER_B = "file:///home/user/proj-b"
+
+
+@pytest.fixture
+def two_folder_setup():
+    """Snapshot/restore module state and provision two folders.
+
+    Folder A: 160-col formatting, W111 diagnostic disabled.
+    Folder B: 60-col formatting, W111 enabled (default).
+    """
+    snap_feature = _lsp_state.feature_config
+    snap_formatter = _lsp_state.formatter_config
+    snap_per_folder_feature = dict(_lsp_state._per_folder_feature_configs)
+    snap_per_folder_formatter = dict(_lsp_state._per_folder_formatter_configs)
+    snap_editor = dict(_lsp_state.editor_config_settings)
+    snap_project = dict(_lsp_state.project_config_settings)
+    snap_editor_pf = dict(_lsp_state.editor_config_settings_per_folder)
+    snap_project_pf = dict(_lsp_state.project_config_settings_per_folder)
+
+    _lsp_state.feature_config = FeatureConfig()
+    _lsp_state.formatter_config = FormatterConfig()
+    _lsp_state._per_folder_feature_configs.clear()
+    _lsp_state._per_folder_formatter_configs.clear()
+    _lsp_state.editor_config_settings.clear()
+    _lsp_state.project_config_settings.clear()
+    _lsp_state.editor_config_settings_per_folder.clear()
+    _lsp_state.project_config_settings_per_folder.clear()
+
+    # Apply per-folder configs through the same path the production
+    # pull-callback uses.
+    _lsp_settings._apply_settings_to_target(
+        FOLDER_A,
+        {
+            "formatting": {"maxLineLength": 160},
+            "diagnostics": {"W111": False},
+        },
+    )
+    _lsp_settings._apply_settings_to_target(
+        FOLDER_B,
+        {
+            "formatting": {"maxLineLength": 60},
+        },
+    )
+
+    yield
+
+    _lsp_state.feature_config = snap_feature
+    _lsp_state.formatter_config = snap_formatter
+    _lsp_state._per_folder_feature_configs.clear()
+    _lsp_state._per_folder_feature_configs.update(snap_per_folder_feature)
+    _lsp_state._per_folder_formatter_configs.clear()
+    _lsp_state._per_folder_formatter_configs.update(snap_per_folder_formatter)
+    _lsp_state.editor_config_settings.clear()
+    _lsp_state.editor_config_settings.update(snap_editor)
+    _lsp_state.project_config_settings.clear()
+    _lsp_state.project_config_settings.update(snap_project)
+    _lsp_state.editor_config_settings_per_folder.clear()
+    _lsp_state.editor_config_settings_per_folder.update(snap_editor_pf)
+    _lsp_state.project_config_settings_per_folder.clear()
+    _lsp_state.project_config_settings_per_folder.update(snap_project_pf)
+
+
+# Formatting end-to-end
+
+
+class TestFormattingEndToEnd:
+    """``on_formatting`` resolves config per folder and produces folder-specific edits."""
+
+    def test_max_line_length_differs_per_folder(self, two_folder_setup):
+        # A long line that fits within 160 cols but not 60.
+        long_line = (
+            "set my_long_variable_name [list one two three four five six seven eight nine ten]\n"
+        )
+        source = f"proc foo {{}} {{\n    {long_line}}}\n"
+
+        opts = types.FormattingOptions(tab_size=4, insert_spaces=True)
+
+        edits_a = get_formatting(
+            source, opts, _lsp_state.formatter_config_for_uri(f"{FOLDER_A}/foo.tcl")
+        )
+        edits_b = get_formatting(
+            source, opts, _lsp_state.formatter_config_for_uri(f"{FOLDER_B}/foo.tcl")
+        )
+
+        # Same source, different formatter configs -> different output.
+        a_text = edits_a[0].new_text if edits_a else source
+        b_text = edits_b[0].new_text if edits_b else source
+
+        # Folder B (60-col) wraps; folder A (160-col) does not.
+        a_max = max(len(line) for line in a_text.splitlines())
+        b_max = max(len(line) for line in b_text.splitlines())
+        assert a_max > 60, f"folder A should keep long line (got max={a_max})"
+        assert b_max <= 60 or b_max < a_max, (
+            f"folder B should wrap below folder A (a={a_max}, b={b_max})"
+        )
+
+    def test_outside_folder_uses_fallback_formatter(self, two_folder_setup):
+        # The fallback formatter has the default 120-col limit.
+        outside_cfg = _lsp_state.formatter_config_for_uri("file:///tmp/elsewhere/x.tcl")
+        assert outside_cfg.max_line_length == 120
+        assert outside_cfg is _lsp_state.formatter_config
+
+
+# Diagnostics end-to-end
+
+
+class TestDiagnosticsEndToEnd:
+    """``config_for_uri`` resolution drives folder-specific diagnostic codes."""
+
+    def test_w111_disabled_in_folder_a_enabled_in_folder_b(self, two_folder_setup):
+        # 200-character line — emits W111 (line too long) at default 120 col
+        # limit.  We use a separate ``style.lineLength`` for the W111 check
+        # to make this self-contained: folder A keeps the default 120, but
+        # folder B inherited the same 120 plus W111 enabled.  Both folders
+        # see a long line; only folder A has W111 silenced.
+        long_line = "set x " + "a" * 250
+        source = f"proc foo {{}} {{\n    {long_line}\n}}\n"
+
+        cfg_a = _lsp_state.config_for_uri(f"{FOLDER_A}/foo.tcl")
+        cfg_b = _lsp_state.config_for_uri(f"{FOLDER_B}/foo.tcl")
+
+        diags_a = get_diagnostics(
+            source,
+            optimiser_enabled=cfg_a.optimiser_enabled,
+            shimmer_enabled=cfg_a.shimmer_enabled,
+            disabled_diagnostics=cfg_a.disabled_diagnostics,
+            disabled_optimisations=cfg_a.disabled_optimisations,
+            line_length=cfg_a.line_length,
+            uri=f"{FOLDER_A}/foo.tcl",
+        )
+        diags_b = get_diagnostics(
+            source,
+            optimiser_enabled=cfg_b.optimiser_enabled,
+            shimmer_enabled=cfg_b.shimmer_enabled,
+            disabled_diagnostics=cfg_b.disabled_diagnostics,
+            disabled_optimisations=cfg_b.disabled_optimisations,
+            line_length=cfg_b.line_length,
+            uri=f"{FOLDER_B}/foo.tcl",
+        )
+
+        codes_a = {d.code for d in diags_a}
+        codes_b = {d.code for d in diags_b}
+
+        assert "W111" not in codes_a, "folder A disabled W111 — should not appear"
+        assert "W111" in codes_b, "folder B did not disable W111 — should appear"
+
+    def test_two_folders_produce_distinct_diagnostic_sets(self, two_folder_setup):
+        # The folder-A config and folder-B config differ — verify that's
+        # observable end-to-end.
+        cfg_a = _lsp_state.config_for_uri(f"{FOLDER_A}/foo.tcl")
+        cfg_b = _lsp_state.config_for_uri(f"{FOLDER_B}/foo.tcl")
+        assert cfg_a is not cfg_b
+        assert cfg_a.disabled_diagnostics != cfg_b.disabled_diagnostics
+
+
+# Cross-cutting: verify isolation
+
+
+class TestFolderIsolationEndToEnd:
+    def test_mutating_folder_a_does_not_leak_into_folder_b(self, two_folder_setup):
+        cfg_a = _lsp_state.config_for_uri(f"{FOLDER_A}/x.tcl")
+        cfg_b = _lsp_state.config_for_uri(f"{FOLDER_B}/x.tcl")
+
+        # Mutate A directly (would happen via a settings change for that
+        # folder).
+        cfg_a.line_length = 999
+
+        # B and the fallback are untouched.
+        assert cfg_b.line_length != 999
+        assert _lsp_state.feature_config.line_length != 999

--- a/tests/test_per_folder_config_integration.py
+++ b/tests/test_per_folder_config_integration.py
@@ -1,0 +1,336 @@
+"""Integration tests for per-folder config pull/dispatch (issue #230).
+
+Beyond the unit-level resolver coverage in
+``test_per_folder_config.py``, these tests pin the wiring between:
+
+- ``_pull_and_apply_configuration`` and the pygls
+  ``workspace_configuration`` request — request shape (one item per
+  folder + an unscoped fallback last) and result-handling order.
+- ``did_change_configuration`` dispatch (with and without a push
+  payload).
+- ``on_did_change_workspace_folders`` add/remove flows including
+  ``drop_folder_configs`` and ``.tcl-lsp.ini`` loading.
+
+A pygls ``LanguageServer`` is mocked: each test injects a fake whose
+``workspace.workspace_folders`` returns a chosen list and whose
+``workspace_configuration`` records calls and synchronously fires the
+callback with caller-supplied results.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from lsprotocol import types
+
+import lsp.lifecycle as _lifecycle
+import lsp.settings as _lsp_settings
+import lsp.state as _lsp_state
+from core.formatting import FormatterConfig
+from lsp.feature_config import FeatureConfig
+
+
+@pytest.fixture
+def reset_state(monkeypatch):
+    """Snapshot/restore the module-level state mutated by these tests."""
+    snap_feature = _lsp_state.feature_config
+    snap_formatter = _lsp_state.formatter_config
+    snap_per_folder_feature = dict(_lsp_state._per_folder_feature_configs)
+    snap_per_folder_formatter = dict(_lsp_state._per_folder_formatter_configs)
+    snap_editor_pf = dict(_lsp_state.editor_config_settings_per_folder)
+    snap_project_pf = dict(_lsp_state.project_config_settings_per_folder)
+    snap_editor = dict(_lsp_state.editor_config_settings)
+    snap_project = dict(_lsp_state.project_config_settings)
+
+    _lsp_state.feature_config = FeatureConfig()
+    _lsp_state.formatter_config = FormatterConfig()
+    _lsp_state._per_folder_feature_configs.clear()
+    _lsp_state._per_folder_formatter_configs.clear()
+    _lsp_state.editor_config_settings_per_folder.clear()
+    _lsp_state.project_config_settings_per_folder.clear()
+    _lsp_state.editor_config_settings.clear()
+    _lsp_state.project_config_settings.clear()
+
+    yield
+
+    _lsp_state.feature_config = snap_feature
+    _lsp_state.formatter_config = snap_formatter
+    _lsp_state._per_folder_feature_configs.clear()
+    _lsp_state._per_folder_feature_configs.update(snap_per_folder_feature)
+    _lsp_state._per_folder_formatter_configs.clear()
+    _lsp_state._per_folder_formatter_configs.update(snap_per_folder_formatter)
+    _lsp_state.editor_config_settings_per_folder.clear()
+    _lsp_state.editor_config_settings_per_folder.update(snap_editor_pf)
+    _lsp_state.project_config_settings_per_folder.clear()
+    _lsp_state.project_config_settings_per_folder.update(snap_project_pf)
+    _lsp_state.editor_config_settings.clear()
+    _lsp_state.editor_config_settings.update(snap_editor)
+    _lsp_state.project_config_settings.clear()
+    _lsp_state.project_config_settings.update(snap_project)
+
+
+def _make_fake_server(folder_uris: list[str]):
+    """Return a pygls-shaped MagicMock with the given workspace folders.
+
+    pygls 2.x exposes ``Workspace.folders`` as a dict keyed by URI.
+    Older releases used a ``workspace_folders`` list — populate both so
+    the production code's compatibility shim can be exercised.
+
+    ``workspace_configuration`` records its call args and exposes a
+    helper to fire the supplied callback synchronously, mirroring how
+    pygls dispatches the response from the client.
+    """
+    server = MagicMock(name="LanguageServer")
+    folder_objs = [SimpleNamespace(uri=uri, name=uri.rsplit("/", 1)[-1]) for uri in folder_uris]
+    server.workspace.folders = {uri: f for uri, f in zip(folder_uris, folder_objs, strict=False)}
+    server.workspace.workspace_folders = folder_objs
+
+    captured: dict[str, object] = {}
+
+    def _record(params, callback=None):
+        captured["params"] = params
+        captured["callback"] = callback
+
+    server.workspace_configuration.side_effect = _record
+    server._captured = captured
+    return server
+
+
+# _pull_and_apply_configuration
+
+
+class TestPullAndApplyConfiguration:
+    def test_request_one_item_per_folder_plus_unscoped_fallback(self, reset_state, monkeypatch):
+        folder_a = "file:///home/user/proj-a"
+        folder_b = "file:///home/user/proj-b"
+        server = _make_fake_server([folder_a, folder_b])
+        monkeypatch.setattr(_lsp_settings, "_server", server)
+
+        _lsp_settings._pull_and_apply_configuration()
+
+        params = server._captured["params"]
+        assert isinstance(params, types.ConfigurationParams)
+        assert len(params.items) == 3
+        assert params.items[0].scope_uri == folder_a
+        assert params.items[0].section == "tclLsp"
+        assert params.items[1].scope_uri == folder_b
+        assert params.items[1].section == "tclLsp"
+        # Last item is the unscoped fallback.
+        assert params.items[2].scope_uri is None
+        assert params.items[2].section == "tclLsp"
+
+    def test_no_workspace_folders_pulls_only_fallback(self, reset_state, monkeypatch):
+        server = _make_fake_server([])
+        monkeypatch.setattr(_lsp_settings, "_server", server)
+
+        _lsp_settings._pull_and_apply_configuration()
+
+        params = server._captured["params"]
+        assert len(params.items) == 1
+        assert params.items[0].scope_uri is None
+
+    def test_callback_routes_per_folder_results_to_their_targets(self, reset_state, monkeypatch):
+        folder_a = "file:///home/user/proj-a"
+        folder_b = "file:///home/user/proj-b"
+        server = _make_fake_server([folder_a, folder_b])
+        monkeypatch.setattr(_lsp_settings, "_server", server)
+        # Avoid debounced re-application reaching into asyncio.
+        monkeypatch.setattr(_lsp_settings, "_schedule_apply_merged", lambda: None)
+
+        _lsp_settings._pull_and_apply_configuration()
+        callback = server._captured["callback"]
+        assert callback is not None
+
+        callback(
+            [
+                {"style": {"lineLength": 200}},  # folder A
+                {"style": {"lineLength": 60}},  # folder B
+                {"style": {"lineLength": 100}},  # fallback
+            ]
+        )
+
+        assert _lsp_state.editor_config_settings_per_folder[folder_a] == {
+            "style": {"lineLength": 200}
+        }
+        assert _lsp_state.editor_config_settings_per_folder[folder_b] == {
+            "style": {"lineLength": 60}
+        }
+        # Fallback writes to the legacy attribute, not the per-folder map.
+        assert _lsp_state.editor_config_settings == {"style": {"lineLength": 100}}
+
+    def test_callback_handles_empty_result(self, reset_state, monkeypatch):
+        server = _make_fake_server(["file:///home/user/proj-a"])
+        monkeypatch.setattr(_lsp_settings, "_server", server)
+        monkeypatch.setattr(_lsp_settings, "_schedule_apply_merged", lambda: None)
+
+        _lsp_settings._pull_and_apply_configuration()
+        callback = server._captured["callback"]
+        # Empty result is a valid client response — must not crash.
+        callback([])
+        callback(None)
+
+    def test_callback_skips_non_dict_items(self, reset_state, monkeypatch):
+        folder_a = "file:///home/user/proj-a"
+        server = _make_fake_server([folder_a])
+        monkeypatch.setattr(_lsp_settings, "_server", server)
+        monkeypatch.setattr(_lsp_settings, "_schedule_apply_merged", lambda: None)
+
+        _lsp_settings._pull_and_apply_configuration()
+        callback = server._captured["callback"]
+        # Some clients return null for an unconfigured section.
+        callback([None, None])
+
+        assert folder_a not in _lsp_state.editor_config_settings_per_folder
+        assert _lsp_state.editor_config_settings == {}
+
+
+# did_change_configuration handler dispatch
+
+
+class TestDidChangeConfigurationDispatch:
+    def test_empty_payload_triggers_pull(self, reset_state, monkeypatch):
+        called: list[bool] = []
+        monkeypatch.setattr(
+            _lsp_settings,
+            "_pull_and_apply_configuration",
+            lambda: called.append(True),
+        )
+
+        # Build a minimal pygls-shaped server and grab the registered handler.
+        server = MagicMock()
+        registered: dict[str, object] = {}
+
+        def _feature(name, *_args, **_kwargs):
+            def _decorator(fn):
+                registered[name] = fn
+                return fn
+
+            return _decorator
+
+        server.feature.side_effect = _feature
+        _lsp_settings.register(server)
+
+        handler = registered[types.WORKSPACE_DID_CHANGE_CONFIGURATION]
+        handler(types.DidChangeConfigurationParams(settings=None))
+        assert called == [True]
+
+    def test_payload_applies_to_fallback_then_pulls(self, reset_state, monkeypatch):
+        called: list[bool] = []
+        monkeypatch.setattr(
+            _lsp_settings,
+            "_pull_and_apply_configuration",
+            lambda: called.append(True),
+        )
+        monkeypatch.setattr(_lsp_settings, "_schedule_apply_merged", lambda: None)
+
+        server = MagicMock()
+        registered: dict[str, object] = {}
+
+        def _feature(name, *_args, **_kwargs):
+            def _decorator(fn):
+                registered[name] = fn
+                return fn
+
+            return _decorator
+
+        server.feature.side_effect = _feature
+        _lsp_settings.register(server)
+
+        handler = registered[types.WORKSPACE_DID_CHANGE_CONFIGURATION]
+        handler(
+            types.DidChangeConfigurationParams(settings={"tclLsp": {"style": {"lineLength": 95}}})
+        )
+
+        # Fallback layer was updated from the push payload.
+        assert _lsp_state.editor_config_settings == {"style": {"lineLength": 95}}
+        # And we still pulled afterwards to populate per-folder configs.
+        assert called == [True]
+
+
+# on_did_change_workspace_folders
+
+
+def _folders_event(added: list[str] = None, removed: list[str] = None):
+    """Build a minimal DidChangeWorkspaceFoldersParams."""
+    added_folders = [types.WorkspaceFolder(uri=u, name=u.rsplit("/", 1)[-1]) for u in (added or [])]
+    removed_folders = [
+        types.WorkspaceFolder(uri=u, name=u.rsplit("/", 1)[-1]) for u in (removed or [])
+    ]
+    return types.DidChangeWorkspaceFoldersParams(
+        event=types.WorkspaceFoldersChangeEvent(added=added_folders, removed=removed_folders)
+    )
+
+
+class TestDidChangeWorkspaceFolders:
+    def test_added_folder_initialises_per_folder_configs(self, reset_state, monkeypatch, tmp_path):
+        folder_uri = f"file://{tmp_path}/proj-a"
+        monkeypatch.setattr(_lsp_settings, "_pull_and_apply_configuration", lambda: None)
+        monkeypatch.setattr("core.common.user_config.load_project_config", lambda _path: None)
+
+        _lifecycle.on_did_change_workspace_folders(_folders_event(added=[folder_uri]))
+
+        assert folder_uri in _lsp_state._per_folder_feature_configs
+        assert folder_uri in _lsp_state._per_folder_formatter_configs
+
+    def test_removed_folder_drops_all_layers(self, reset_state, monkeypatch):
+        folder_uri = "file:///home/user/proj-a"
+        _lsp_state.get_or_init_folder_feature_config(folder_uri)
+        _lsp_state.get_or_init_folder_formatter_config(folder_uri)
+        _lsp_state.editor_config_settings_per_folder[folder_uri] = {"x": 1}
+        _lsp_state.project_config_settings_per_folder[folder_uri] = {"y": 2}
+
+        monkeypatch.setattr(_lsp_settings, "_pull_and_apply_configuration", lambda: None)
+
+        _lifecycle.on_did_change_workspace_folders(_folders_event(removed=[folder_uri]))
+
+        assert folder_uri not in _lsp_state._per_folder_feature_configs
+        assert folder_uri not in _lsp_state._per_folder_formatter_configs
+        assert folder_uri not in _lsp_state.editor_config_settings_per_folder
+        assert folder_uri not in _lsp_state.project_config_settings_per_folder
+
+    def test_change_triggers_re_pull(self, reset_state, monkeypatch, tmp_path):
+        called: list[bool] = []
+        monkeypatch.setattr(
+            _lsp_settings,
+            "_pull_and_apply_configuration",
+            lambda: called.append(True),
+        )
+        monkeypatch.setattr("core.common.user_config.load_project_config", lambda _path: None)
+
+        _lifecycle.on_did_change_workspace_folders(
+            _folders_event(added=[f"file://{tmp_path}/added"])
+        )
+        assert called == [True]
+
+    def test_added_folder_loads_project_config_ini(self, reset_state, monkeypatch, tmp_path):
+        folder_path = tmp_path / "proj-a"
+        folder_path.mkdir()
+        (folder_path / ".tcl-lsp.ini").write_text("[style]\nline_length = 137\n", encoding="utf-8")
+        folder_uri = folder_path.as_uri()
+
+        monkeypatch.setattr(_lsp_settings, "_pull_and_apply_configuration", lambda: None)
+
+        _lifecycle.on_did_change_workspace_folders(_folders_event(added=[folder_uri]))
+
+        # Project layer for the new folder reflects the .ini contents.
+        # ``get_all_settings`` normalises ``line_length`` -> ``lineLength``.
+        proj = _lsp_state.project_config_settings_per_folder.get(folder_uri, {})
+        assert proj.get("style", {}).get("lineLength") == 137
+
+    def test_empty_event_is_a_noop(self, reset_state, monkeypatch):
+        called: list[bool] = []
+        monkeypatch.setattr(
+            _lsp_settings,
+            "_pull_and_apply_configuration",
+            lambda: called.append(True),
+        )
+        _lifecycle.on_did_change_workspace_folders(_folders_event())
+        # Even an empty change re-pulls — that's fine, the client is signalling
+        # that something might have changed.  Just verify we didn't blow up.
+        assert called == [True]

--- a/tests/test_per_folder_config_integration.py
+++ b/tests/test_per_folder_config_integration.py
@@ -20,6 +20,7 @@ callback with caller-supplied results.
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -204,7 +205,7 @@ class TestDidChangeConfigurationDispatch:
 
         # Build a minimal pygls-shaped server and grab the registered handler.
         server = MagicMock()
-        registered: dict[str, object] = {}
+        registered: dict[str, Callable] = {}
 
         def _feature(name, *_args, **_kwargs):
             def _decorator(fn):
@@ -230,7 +231,7 @@ class TestDidChangeConfigurationDispatch:
         monkeypatch.setattr(_lsp_settings, "_schedule_apply_merged", lambda: None)
 
         server = MagicMock()
-        registered: dict[str, object] = {}
+        registered: dict[str, Callable] = {}
 
         def _feature(name, *_args, **_kwargs):
             def _decorator(fn):
@@ -256,7 +257,9 @@ class TestDidChangeConfigurationDispatch:
 # on_did_change_workspace_folders
 
 
-def _folders_event(added: list[str] = None, removed: list[str] = None):
+def _folders_event(
+    added: list[str] | None = None, removed: list[str] | None = None
+) -> types.DidChangeWorkspaceFoldersParams:
     """Build a minimal DidChangeWorkspaceFoldersParams."""
     added_folders = [types.WorkspaceFolder(uri=u, name=u.rsplit("/", 1)[-1]) for u in (added or [])]
     removed_folders = [

--- a/tests/test_settings_scope.py
+++ b/tests/test_settings_scope.py
@@ -1,0 +1,172 @@
+"""VS Code ``package.json`` ``tclLsp.*`` scope regression (issue #230).
+
+Multi-folder VS Code workspaces reject any setting with the default
+``window`` scope when authored in folder-level ``.vscode/settings.json``.
+The fix for issue #230 was to declare an appropriate non-``window``
+scope on every ``tclLsp.*`` setting:
+
+- ``machine-overridable`` for host paths (interpreter/server/cache),
+- ``language-overridable`` for project + per-language settings
+  (dialect, formatting, features, style, ``extraCommands``),
+- ``resource`` for the rest (per-folder analysis toggles).
+
+The single exception is ``tcl-lsp.trace.server`` (the LSP transport
+trace level), which legitimately stays at the default ``window`` scope.
+
+This test pins the categorisation so a future setting addition that
+forgets ``scope`` re-introduces the original bug only if it's the
+trace key — every other setting will fail this check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_JSON = ROOT / "editors" / "vscode" / "package.json"
+
+
+# Settings legitimately allowed to keep the default ``window`` scope.
+# Adding to this set is a deliberate decision — keep it small.
+_WINDOW_SCOPE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "tcl-lsp.trace.server",  # LSP transport trace level
+    }
+)
+
+_VALID_SCOPES: frozenset[str] = frozenset(
+    {
+        "application",
+        "machine",
+        "machine-overridable",
+        "window",
+        "resource",
+        "language-overridable",
+    }
+)
+
+# Path prefixes — a host path that points at an executable or directory.
+_PATH_KEYS: frozenset[str] = frozenset(
+    {
+        "tclLsp.pythonPath",
+        "tclLsp.serverPath",
+        "tclLsp.runtimeValidation.tclshPath",
+        "tclLsp.packageManager.cacheDir",
+        "tclLsp.packageManager.registryUrl",
+    }
+)
+
+
+def _all_properties() -> dict[str, dict]:
+    """Return ``{key: schema}`` for every contributed configuration property."""
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    properties: dict[str, dict] = {}
+    for group in data["contributes"]["configuration"]:
+        for key, schema in group.get("properties", {}).items():
+            properties[key] = schema
+    return properties
+
+
+def test_every_tcl_lsp_setting_has_a_non_window_scope():
+    """Every ``tclLsp.*`` property must declare ``scope`` != ``window``.
+
+    Multi-folder VS Code workspaces reject ``window``-scoped settings in
+    folder ``.vscode/settings.json``.  The allowlist captures the few
+    settings (``tcl-lsp.trace.server``) where ``window`` is intentional.
+    """
+    properties = _all_properties()
+    offenders: list[str] = []
+    for key, schema in properties.items():
+        if key in _WINDOW_SCOPE_ALLOWLIST:
+            continue
+        scope = schema.get("scope")
+        if scope is None or scope == "window":
+            offenders.append(f"{key} (scope={scope!r})")
+
+    assert not offenders, (
+        "Settings without a non-window scope (would be rejected in "
+        "folder-level .vscode/settings.json — see issue #230):\n  " + "\n  ".join(sorted(offenders))
+    )
+
+
+def test_all_declared_scopes_are_valid_lsp_values():
+    """Every ``scope`` value must be a recognised VS Code scope."""
+    properties = _all_properties()
+    bad: list[str] = []
+    for key, schema in properties.items():
+        scope = schema.get("scope")
+        if scope is not None and scope not in _VALID_SCOPES:
+            bad.append(f"{key}: {scope!r}")
+    assert not bad, "Unknown scope values:\n  " + "\n  ".join(bad)
+
+
+def test_path_settings_are_machine_overridable():
+    """Host paths use ``machine-overridable`` so they can't vary per-folder.
+
+    A folder cannot meaningfully override the path to the Python
+    interpreter or the language server — those bind to a process and
+    must be set at workspace/user level.
+    """
+    properties = _all_properties()
+    wrong: list[str] = []
+    for key in _PATH_KEYS:
+        if key not in properties:
+            continue
+        scope = properties[key].get("scope")
+        if scope != "machine-overridable":
+            wrong.append(f"{key} (scope={scope!r}, expected machine-overridable)")
+    assert not wrong, "Path settings with wrong scope:\n  " + "\n  ".join(wrong)
+
+
+@pytest.mark.parametrize(
+    "prefix,expected_scopes",
+    [
+        # Per-folder + per-language settings.
+        ("tclLsp.formatting.", {"language-overridable"}),
+        ("tclLsp.features.", {"language-overridable"}),
+        ("tclLsp.style.", {"language-overridable"}),
+        # Per-folder analysis toggles (no language overrides needed).
+        ("tclLsp.diagnostics.", {"resource"}),
+        ("tclLsp.optimiser.", {"resource"}),
+        ("tclLsp.shimmer.", {"resource"}),
+        ("tclLsp.xcDiagnostics.", {"resource"}),
+        ("tclLsp.ai.", {"resource"}),
+    ],
+)
+def test_settings_under_prefix_share_scope(prefix: str, expected_scopes: set[str]):
+    """All settings under a section prefix must share one of the expected scopes."""
+    properties = _all_properties()
+    matching = {k: v for k, v in properties.items() if k.startswith(prefix)}
+    assert matching, f"No settings found under {prefix!r} — manifest may have been refactored"
+    wrong: list[str] = []
+    for key, schema in matching.items():
+        scope = schema.get("scope")
+        if scope not in expected_scopes:
+            wrong.append(f"{key} (scope={scope!r}, expected one of {sorted(expected_scopes)})")
+    assert not wrong, f"Mismatched scope under {prefix!r}:\n  " + "\n  ".join(wrong)
+
+
+def test_dialect_setting_is_language_overridable():
+    """``tclLsp.dialect`` is per-folder and per-language."""
+    properties = _all_properties()
+    dialect = properties.get("tclLsp.dialect")
+    assert dialect is not None
+    assert dialect.get("scope") == "language-overridable"
+
+
+def test_runtime_validation_path_separated_from_toggles():
+    """``runtimeValidation.tclshPath`` is a path; the rest are per-folder toggles."""
+    properties = _all_properties()
+    path_scope = properties["tclLsp.runtimeValidation.tclshPath"].get("scope")
+    assert path_scope == "machine-overridable"
+    for key in (
+        "tclLsp.runtimeValidation.enabled",
+        "tclLsp.runtimeValidation.adapter",
+        "tclLsp.runtimeValidation.timeoutMs",
+    ):
+        assert properties[key].get("scope") == "resource", (
+            f"{key} should be resource-scoped, got {properties[key].get('scope')!r}"
+        )


### PR DESCRIPTION
## Summary

Implements per-folder configuration support for multi-root VS Code workspaces, allowing different `tclLsp.*` settings to be applied to each workspace folder independently.

### Key Changes

**Backend (LSP Server)**
- Added per-folder configuration storage (`_per_folder_feature_configs`, `_per_folder_formatter_configs`) in `lsp/state.py`
- Implemented URI-based config resolution with longest-prefix matching (`config_for_uri`, `formatter_config_for_uri`) to select the appropriate folder's settings
- Modified `_pull_and_apply_configuration` in `lsp/settings.py` to request configuration for each workspace folder plus an unscoped fallback, routing results to the correct per-folder storage
- Updated `_apply_feature_settings` to accept an optional target config object, enabling per-folder application of feature toggles, diagnostics filters, and formatter settings
- Added `on_did_change_workspace_folders` handler in `lsp/lifecycle.py` to track folder add/remove events and reload per-folder configs
- Updated all feature handlers (`on_formatting`, `on_completion`, diagnostics pipeline) to resolve config per document URI instead of using workspace-level defaults

**Frontend (VS Code Extension)**
- Added explicit `scope` declarations to all `tclLsp.*` settings in `package.json`:
  - `machine-overridable` for host paths (Python interpreter, server path)
  - `language-overridable` for project settings (dialect, formatting, features, style)
  - `resource` for per-folder analysis toggles
- This fixes the original issue where folder-level settings were rejected in multi-folder workspaces due to default `window` scope

**Tests**
- Added comprehensive unit tests in `tests/test_per_folder_config.py` covering config resolution, longest-prefix matching, and per-folder setting application
- Added integration tests in `tests/test_per_folder_config_integration.py` verifying the wiring between `_pull_and_apply_configuration`, pygls `workspace_configuration` requests, and `did_change_configuration` dispatch
- Added end-to-end tests in `tests/test_per_folder_config_e2e.py` confirming that different folder settings produce different output (formatting, diagnostics)
- Added regression test in `tests/test_settings_scope.py` to ensure all `tclLsp.*` settings have appropriate non-`window` scope
- Added VS Code integration test in `editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts` verifying folder-level settings are accepted and applied

## Validation

- Added 3 new backend test modules with 40+ test cases covering resolution, application, and end-to-end behavior
- Added 1 regression test module pinning scope declarations
- Added 1 VS Code integration test suite verifying multi-folder workspace behavior
- All tests pass locally; existing tests remain unaffected

https://claude.ai/code/session_014GhziU4tGMDjBdcD6DWPGj