### PR TITLE
docs: update README with all diagnostic suppression layers and fix stale generated catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ domain-specific token types:
 ### Diagnostics
 
 Arity errors, unknown subcommands, best-practice violations, and security
-issues are reported with precise ranges.  All diagnostics support inline
-suppression with `# noqa: CODE` comments.
+issues are reported with precise ranges.  Diagnostics can be suppressed
+inline, per-file, per-project, or globally — see
+[Suppressing diagnostics](#suppressing-diagnostics).
 
 ```tcl
 string frobulate $x          ;# W001: unknown subcommand 'frobulate'
@@ -1486,10 +1487,51 @@ body) are supported as a fallback when no preceding comment exists.
 All options are exposed through `tclLsp.formatting.*` settings (see
 [Configuration](#formatter-settings) below).
 
-## Diagnostic codes
+## Suppressing diagnostics
 
-All diagnostics support inline suppression with `# noqa: CODE1,CODE2` comments.
-Use `# noqa: *` to suppress all diagnostics on a line.
+Diagnostics can be suppressed at five different scopes.  Smaller scope is
+always better — turning a code off globally hides real problems in future
+projects.
+
+| Scope | How |
+|-------|-----|
+| One command | `# noqa: CODE` on the line before the command |
+| One file | `# tcl-lsp: disable=CODE,CODE` near the top of the file |
+| One project | `[diagnostics]\ndisabled = CODE` in `.tcl-lsp.ini` at the workspace root |
+| One editor | `tclLsp.diagnostics.CODE: false` in editor settings |
+| Everywhere | `[diagnostics]\ndisabled = CODE` in the [global config file](#configuration-file) |
+
+**Inline** — put on the line *before* the command:
+
+```tcl
+# noqa: W100
+expr $x + 1
+
+# noqa: *
+eval $user_input
+```
+
+**Top-of-file** — before the first non-comment line:
+
+```tcl
+#!/usr/bin/env tclsh
+# tcl-lsp: disable=W100,O111
+```
+
+**Project config** — `.tcl-lsp.ini` at the workspace root (commit with source):
+
+```ini
+[diagnostics]
+disabled = W111, IRULE1005
+
+[optimiser]
+disabled = O109
+```
+
+For the complete reference, see
+[`docs/kcs/kcs-howto-suppress-diagnostics.md`](docs/kcs/kcs-howto-suppress-diagnostics.md).
+
+## Diagnostic codes
 
 ### Errors
 
@@ -2147,27 +2189,30 @@ All diagnostic codes can be toggled individually via
 
 ### Configuration File
 
-Settings can be stored in an INI file that follows platform-native
-conventions.  This is useful for editor-agnostic defaults that apply
-across all workspaces and editors.
+Settings can be stored in INI files.  Two files are read:
 
-| Platform | Default path |
-|----------|-------------|
-| **Linux / BSD / WSL2** | `~/.config/tcl-lsp/config.ini` |
-| **macOS** | `~/Library/Application Support/tcl-lsp/config.ini` |
-| **Windows** | `%APPDATA%\tcl-lsp\config.ini` |
-| **MSYS2 / Cygwin** | `~/.config/tcl-lsp/config.ini` |
+- **Global** — user-wide defaults, platform-native location:
 
-Setting `$XDG_CONFIG_HOME` overrides the default on every platform.
+  | Platform | Default path |
+  |----------|-------------|
+  | **Linux / BSD / WSL2** | `~/.config/tcl-lsp/config.ini` |
+  | **macOS** | `~/Library/Application Support/tcl-lsp/config.ini` |
+  | **Windows** | `%APPDATA%\tcl-lsp\config.ini` |
+  | **MSYS2 / Cygwin** | `~/.config/tcl-lsp/config.ini` |
+
+  Setting `$XDG_CONFIG_HOME` overrides the default on every platform.
+
+- **Project** — `.tcl-lsp.ini` at the workspace root, committed with the
+  source so every contributor picks up the same rules automatically.
 
 **Precedence** (applied in order — later entries override earlier):
 
 1. Built-in defaults
-2. Config file
+2. Global config file
 3. Editor settings (VS Code `settings.json`, Neovim `lspconfig`, etc.)
+4. Project config file (`.tcl-lsp.ini` — highest server-level priority)
 
-The file uses INI format with section names matching the `tclLsp.*`
-namespace:
+Both files use the same INI schema:
 
 ```ini
 [diagnostics]
@@ -2186,7 +2231,7 @@ inlayHints = false
 indent_size = 2
 ```
 
-See [`docs/kcs/kcs-xdg-config.md`](docs/kcs/kcs-xdg-config.md) for the
+See [`docs/design/contracts/xdg-config.md`](docs/design/contracts/xdg-config.md) for the
 full reference, including how settings interact with each editor.
 
 ### Export Settings

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ domain-specific token types:
 
 Arity errors, unknown subcommands, best-practice violations, and security
 issues are reported with precise ranges.  Diagnostics can be suppressed
-inline, per-file, per-project, or globally — see
+inline, per-file, per-project, per-editor, or globally — see
 [Suppressing diagnostics](#suppressing-diagnostics).
 
 ```tcl

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -46,6 +46,118 @@
       "summary": "Return compile-time build metadata for the Tcl runtime."
     },
     {
+      "name": "::tcl::mathop::!",
+      "summary": "logical NOT (unary)"
+    },
+    {
+      "name": "::tcl::mathop::!=",
+      "summary": "numeric inequality"
+    },
+    {
+      "name": "::tcl::mathop::%",
+      "summary": "modulo"
+    },
+    {
+      "name": "::tcl::mathop::&",
+      "summary": "bitwise AND"
+    },
+    {
+      "name": "::tcl::mathop::&&",
+      "summary": "logical AND"
+    },
+    {
+      "name": "::tcl::mathop::*",
+      "summary": "multiplication"
+    },
+    {
+      "name": "::tcl::mathop::**",
+      "summary": "exponentiation"
+    },
+    {
+      "name": "::tcl::mathop::+",
+      "summary": "addition"
+    },
+    {
+      "name": "::tcl::mathop::-",
+      "summary": "subtraction or negation"
+    },
+    {
+      "name": "::tcl::mathop::/",
+      "summary": "division"
+    },
+    {
+      "name": "::tcl::mathop::<",
+      "summary": "numeric less-than"
+    },
+    {
+      "name": "::tcl::mathop::<<",
+      "summary": "left shift"
+    },
+    {
+      "name": "::tcl::mathop::<=",
+      "summary": "numeric less-or-equal"
+    },
+    {
+      "name": "::tcl::mathop::==",
+      "summary": "numeric equality"
+    },
+    {
+      "name": "::tcl::mathop::>",
+      "summary": "numeric greater-than"
+    },
+    {
+      "name": "::tcl::mathop::>=",
+      "summary": "numeric greater-or-equal"
+    },
+    {
+      "name": "::tcl::mathop::>>",
+      "summary": "right shift"
+    },
+    {
+      "name": "::tcl::mathop::@",
+      "summary": "list index operator"
+    },
+    {
+      "name": "::tcl::mathop::^",
+      "summary": "bitwise XOR"
+    },
+    {
+      "name": "::tcl::mathop::eq",
+      "summary": "string equality"
+    },
+    {
+      "name": "::tcl::mathop::in",
+      "summary": "list membership"
+    },
+    {
+      "name": "::tcl::mathop::max",
+      "summary": "maximum of arguments"
+    },
+    {
+      "name": "::tcl::mathop::min",
+      "summary": "minimum of arguments"
+    },
+    {
+      "name": "::tcl::mathop::ne",
+      "summary": "string inequality"
+    },
+    {
+      "name": "::tcl::mathop::ni",
+      "summary": "list non-membership"
+    },
+    {
+      "name": "::tcl::mathop::|",
+      "summary": "bitwise OR"
+    },
+    {
+      "name": "::tcl::mathop::||",
+      "summary": "logical OR"
+    },
+    {
+      "name": "::tcl::mathop::~",
+      "summary": "bitwise NOT (unary)"
+    },
+    {
       "name": "<",
       "summary": "numeric less-than"
     },
@@ -338,6 +450,7 @@
         "filter",
         "for",
         "get",
+        "getd",
         "getdef",
         "getwithdefault",
         "incr",
@@ -1311,6 +1424,10 @@
       "pure": true
     },
     {
+      "name": "max",
+      "summary": "maximum of arguments"
+    },
+    {
       "name": "md5::md5",
       "summary": "Compute the MD5 hash of a string or file.",
       "pure": true
@@ -1405,6 +1522,10 @@
       "name": "mime::word_encode",
       "summary": "Encode a string per RFC 2047.",
       "pure": true
+    },
+    {
+      "name": "min",
+      "summary": "minimum of arguments"
     },
     {
       "name": "msgcat::mc",
@@ -1925,6 +2046,118 @@
       "name": "tcl::idna::encode",
       "summary": "Encode a hostname to IDNA (Internationalised Domain Names) format.",
       "pure": true
+    },
+    {
+      "name": "tcl::mathop::!",
+      "summary": "logical NOT (unary)"
+    },
+    {
+      "name": "tcl::mathop::!=",
+      "summary": "numeric inequality"
+    },
+    {
+      "name": "tcl::mathop::%",
+      "summary": "modulo"
+    },
+    {
+      "name": "tcl::mathop::&",
+      "summary": "bitwise AND"
+    },
+    {
+      "name": "tcl::mathop::&&",
+      "summary": "logical AND"
+    },
+    {
+      "name": "tcl::mathop::*",
+      "summary": "multiplication"
+    },
+    {
+      "name": "tcl::mathop::**",
+      "summary": "exponentiation"
+    },
+    {
+      "name": "tcl::mathop::+",
+      "summary": "addition"
+    },
+    {
+      "name": "tcl::mathop::-",
+      "summary": "subtraction or negation"
+    },
+    {
+      "name": "tcl::mathop::/",
+      "summary": "division"
+    },
+    {
+      "name": "tcl::mathop::<",
+      "summary": "numeric less-than"
+    },
+    {
+      "name": "tcl::mathop::<<",
+      "summary": "left shift"
+    },
+    {
+      "name": "tcl::mathop::<=",
+      "summary": "numeric less-or-equal"
+    },
+    {
+      "name": "tcl::mathop::==",
+      "summary": "numeric equality"
+    },
+    {
+      "name": "tcl::mathop::>",
+      "summary": "numeric greater-than"
+    },
+    {
+      "name": "tcl::mathop::>=",
+      "summary": "numeric greater-or-equal"
+    },
+    {
+      "name": "tcl::mathop::>>",
+      "summary": "right shift"
+    },
+    {
+      "name": "tcl::mathop::@",
+      "summary": "list index operator"
+    },
+    {
+      "name": "tcl::mathop::^",
+      "summary": "bitwise XOR"
+    },
+    {
+      "name": "tcl::mathop::eq",
+      "summary": "string equality"
+    },
+    {
+      "name": "tcl::mathop::in",
+      "summary": "list membership"
+    },
+    {
+      "name": "tcl::mathop::max",
+      "summary": "maximum of arguments"
+    },
+    {
+      "name": "tcl::mathop::min",
+      "summary": "minimum of arguments"
+    },
+    {
+      "name": "tcl::mathop::ne",
+      "summary": "string inequality"
+    },
+    {
+      "name": "tcl::mathop::ni",
+      "summary": "list non-membership"
+    },
+    {
+      "name": "tcl::mathop::|",
+      "summary": "bitwise OR"
+    },
+    {
+      "name": "tcl::mathop::||",
+      "summary": "logical OR"
+    },
+    {
+      "name": "tcl::mathop::~",
+      "summary": "bitwise NOT (unary)"
     },
     {
       "name": "tcl::tm::path",


### PR DESCRIPTION
- Add "Suppressing diagnostics" section with all five scopes (inline,
  top-of-file, project, editor, global) and usage examples
- Update "Diagnostics" overview paragraph to link to the new section
- Fix "Diagnostic codes" inline suppression mention (was inline-only)
- Fix "Configuration File" precedence list to include `.tcl-lsp.ini`
  project config file as the highest server-level layer
- Add project config file description alongside the global config file
- Fix broken link: `docs/kcs/kcs-xdg-config.md` →
  `docs/design/contracts/xdg-config.md` (actual file location)
- Commit stale Zed tcl_commands.json catalog (add mathop operators,
  missing commands — regenerated from registry, check-generated passes)

Closes #211

https://claude.ai/code/session_011zKkiJtwqH93FFQtrCQPgw