### PR TITLE
fix: noqa suppression now covers orphaned comments and noqa-before-comment cases (issue #306)

### DIFF
--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -245,6 +245,13 @@ class _AnalyserBase:
         file_codes = parse_file_suppression(source)
         if file_codes:
             self.result.suppressed_lines[_FILE_SUPPRESS_KEY] = file_codes
+        # Pre-scan for next-line noqa suppressions (see analyse() for rationale).
+        for ln, codes in parse_noqa_line_suppressions(source).items():
+            existing = self.result.suppressed_lines.get(ln)
+            if existing is not None:
+                self.result.suppressed_lines[ln] = existing | codes
+            else:
+                self.result.suppressed_lines[ln] = codes
 
         snapshots: list[AnalyserSnapshot] = []
         for cmds in chunk_commands:
@@ -282,6 +289,13 @@ class _AnalyserBase:
         file_codes = parse_file_suppression(source)
         if file_codes:
             self.result.suppressed_lines[_FILE_SUPPRESS_KEY] = file_codes
+        # Pre-scan for next-line noqa suppressions (see analyse() for rationale).
+        for ln, codes in parse_noqa_line_suppressions(source).items():
+            existing = self.result.suppressed_lines.get(ln)
+            if existing is not None:
+                self.result.suppressed_lines[ln] = existing | codes
+            else:
+                self.result.suppressed_lines[ln] = codes
         self._analyse_commands_inner(commands, self._current_scope, source)
         if finalise:
             self._emit_unresolved_command_diagnostics()

--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -31,7 +31,7 @@ from ..semantic_model import (
 )
 from ..stub_comments import scan_source_for_stubs
 from ._snapshot import AnalyserSnapshot
-from ._utils import parse_file_suppression
+from ._utils import parse_file_suppression, parse_noqa_line_suppressions
 
 log = logging.getLogger(__name__)
 
@@ -395,6 +395,15 @@ class _AnalyserBase:
         file_codes = parse_file_suppression(source)
         if file_codes:
             self.result.suppressed_lines[_FILE_SUPPRESS_KEY] = file_codes
+        # Pre-scan for next-line noqa suppressions.  Handles orphaned noqa
+        # comments at the tail of a brace body and noqa comments immediately
+        # before a comment line that itself generates a diagnostic (e.g. W115).
+        for ln, codes in parse_noqa_line_suppressions(source).items():
+            existing = self.result.suppressed_lines.get(ln)
+            if existing is not None:
+                self.result.suppressed_lines[ln] = existing | codes
+            else:
+                self.result.suppressed_lines[ln] = codes
         self._analyse_body(source, self._current_scope)
         self._emit_unresolved_command_diagnostics(cu=cu)
         self._emit_variable_usage_diagnostics()

--- a/core/analysis/_analyser/_utils.py
+++ b/core/analysis/_analyser/_utils.py
@@ -22,6 +22,7 @@ from ...parsing.argv import widen_argv_tokens_to_word_spans
 from ...parsing.tokens import Token
 from ..semantic_model import (
     ParamDef,
+    _NOQA_ALL,
 )
 
 log = logging.getLogger(__name__)
@@ -135,6 +136,42 @@ def parse_file_suppression(source: str) -> frozenset[str]:
             if token:
                 codes.add(token)
     return frozenset(codes)
+
+
+def parse_noqa_line_suppressions(source: str) -> dict[int, frozenset[str]]:
+    """Scan source for ``# noqa`` comments and record next-line suppressions.
+
+    For each ``# noqa`` / ``# noqa: CODE`` comment on line N, stores
+    suppression codes for line N+1.  This handles two cases the
+    command-level ``preceding_comment`` mechanism cannot reach:
+
+    * A noqa comment at the tail of a brace body (orphaned — no following
+      command in that scope), where the diagnostic fires on the immediately
+      following ``} elseif …`` or similar line.
+    * A noqa comment immediately before another comment line that itself
+      generates a diagnostic (e.g. W115 on a ``\\``-continued comment).
+    """
+    result: dict[int, frozenset[str]] = {}
+    for i, line in enumerate(source.split("\n")):
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            continue
+        lower = stripped.lower()
+        noqa_pos = lower.find("noqa")
+        if noqa_pos < 0:
+            continue
+        rest = stripped[noqa_pos + 4 :].strip()
+        if rest.startswith(":"):
+            codes: frozenset[str] = frozenset(c.strip() for c in rest[1:].split(",") if c.strip())
+        else:
+            codes = _NOQA_ALL
+        next_line = i + 1
+        existing = result.get(next_line)
+        if existing is not None:
+            result[next_line] = existing | codes
+        else:
+            result[next_line] = codes
+    return result
 
 
 def _possible_paste_fingerprint(stmt: IRStatement) -> tuple[str, str] | None:

--- a/core/analysis/_analyser/_utils.py
+++ b/core/analysis/_analyser/_utils.py
@@ -21,8 +21,8 @@ from ...compiler.ir import (
 from ...parsing.argv import widen_argv_tokens_to_word_spans
 from ...parsing.tokens import Token
 from ..semantic_model import (
-    ParamDef,
     _NOQA_ALL,
+    ParamDef,
 )
 
 log = logging.getLogger(__name__)

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -141,6 +141,22 @@ class TestNoqaNextLineSuppression:
         diags, _, _ = get_basic_diagnostics(source)
         assert "W306" not in _codes(diags)
 
+    def test_analyse_chunked_applies_next_line_suppression(self):
+        # analyse_chunked is the primary LSP incremental path and must also
+        # apply next-line noqa suppression.
+        source = "# noqa: W115\n## continued comment\\\n    next line\nset x 1\n"
+        commands = segment_commands(source)
+        result, _ = Analyser().analyse_chunked(source, [list(commands)])
+        assert 1 in result.suppressed_lines  # line 1 is the ##nagelfar line
+
+    def test_analyse_commands_applies_next_line_suppression(self):
+        # analyse_commands is the incremental restore path and must also apply
+        # next-line noqa suppression.
+        source = "# noqa: W115\n## continued comment\\\n    next line\nset x 1\n"
+        commands = segment_commands(source)
+        result = Analyser().analyse_commands(source, list(commands))
+        assert 1 in result.suppressed_lines  # line 1 is the ##nagelfar line
+
 
 # Layer 2: top-of-file ``# tcl-lsp: disable=...`` directive.
 

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -30,6 +30,7 @@ from core.analysis import Analyser, analyse
 from core.analysis._analyser._utils import (
     _FILE_DIRECTIVE_SCAN_LINES,
     parse_file_suppression,
+    parse_noqa_line_suppressions,
 )
 from core.analysis.semantic_model import _FILE_SUPPRESS_KEY
 from core.common.user_config import (
@@ -86,6 +87,59 @@ class TestInlineSuppression:
         source = "# noqa: W100\nset a 1\nexpr $x + 1\n"
         diags, _, _ = get_basic_diagnostics(source)
         assert "W100" in _codes(diags)
+
+
+class TestNoqaNextLineSuppression:
+    """``# noqa`` also suppresses the line immediately following the comment.
+
+    This covers two cases the command-level ``preceding_comment`` mechanism
+    cannot handle (issue #306):
+
+    1. A noqa comment orphaned at the tail of a brace body — the diagnostic
+       fires on the ``} elseif …`` line that immediately follows.
+    2. A noqa comment placed before another comment line that itself generates
+       a diagnostic (e.g. W115 on a ``\\``-continued comment).
+    """
+
+    def test_noqa_before_w115_comment_suppresses_it(self):
+        # W115 fires on the ##nagelfar line (a backslash-continued comment).
+        # The # noqa: W115 comment is on the line immediately before it.
+        source = "# noqa: W115\n## continued comment\\\n    next line\nset x 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W115" not in _codes(diags)
+
+    def test_noqa_before_w115_does_not_suppress_other_codes(self):
+        source = "# noqa: W115\n## continued comment\\\n    next line\nexpr $x + 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W115" not in _codes(diags)
+        assert "W100" in _codes(diags)
+
+    def test_bare_noqa_before_comment_suppresses_all(self):
+        source = "# noqa\n## continued comment\\\n    next line\nset x 1\n"
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W115" not in _codes(diags)
+
+    def test_parse_noqa_line_suppressions_unit(self):
+        source = "set x 1\n# noqa: W306\n} elseif {cond} {\n"
+        result = parse_noqa_line_suppressions(source)
+        assert 2 in result
+        assert "W306" in result[2]
+
+    def test_noqa_orphaned_in_if_body_suppresses_elseif_diagnostic(self):
+        # noqa inside the first body brace, W306 fires on the regexp in the
+        # elseif condition (next line in source). Issue #306 case 1.
+        source = (
+            'if {[regexp -nocase {^([^#]+)} $name -> nameParsed]} {\n'
+            '    set nameModif "result"\n'
+            '# noqa: W306\n'
+            '} elseif {[regexp -nocase "^i\\\\((\\\\[^)]+)\\\\)$" $name]} {\n'
+            '    set nameModif $name\n'
+            '} else {\n'
+            '    set nameModif $name\n'
+            '}\n'
+        )
+        diags, _, _ = get_basic_diagnostics(source)
+        assert "W306" not in _codes(diags)
 
 
 # Layer 2: top-of-file ``# tcl-lsp: disable=...`` directive.

--- a/tests/test_suppression_layers.py
+++ b/tests/test_suppression_layers.py
@@ -129,14 +129,14 @@ class TestNoqaNextLineSuppression:
         # noqa inside the first body brace, W306 fires on the regexp in the
         # elseif condition (next line in source). Issue #306 case 1.
         source = (
-            'if {[regexp -nocase {^([^#]+)} $name -> nameParsed]} {\n'
+            "if {[regexp -nocase {^([^#]+)} $name -> nameParsed]} {\n"
             '    set nameModif "result"\n'
-            '# noqa: W306\n'
+            "# noqa: W306\n"
             '} elseif {[regexp -nocase "^i\\\\((\\\\[^)]+)\\\\)$" $name]} {\n'
-            '    set nameModif $name\n'
-            '} else {\n'
-            '    set nameModif $name\n'
-            '}\n'
+            "    set nameModif $name\n"
+            "} else {\n"
+            "    set nameModif $name\n"
+            "}\n"
         )
         diags, _, _ = get_basic_diagnostics(source)
         assert "W306" not in _codes(diags)


### PR DESCRIPTION
Add `parse_noqa_line_suppressions` which scans the raw source line-by-line
for `# noqa` comments and pre-populates `suppressed_lines` for the
immediately-following line (N+1).  This covers two gaps the existing
`preceding_comment` mechanism could not reach:

* A `# noqa` comment at the tail of a brace body (orphaned — no following
  command in that scope), where the diagnostic fires on the `} elseif …`
  line immediately after the comment.
* A `# noqa` comment placed immediately before another comment line that
  itself generates a diagnostic (e.g. W115 on a backslash-continued comment).

The new scan is additive — it merges into `suppressed_lines` alongside the
existing command-level and file-level suppression passes.

Closes #306

https://claude.ai/code/session_01QUJBUJMhZsyoPAiNzEXAsF