### PR TITLE
deps(vscode): pin @azure/msal-node to ^5.1.5 to fix uuid<14 vuln

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4844,7 +4844,7 @@
     "@types/mocha": "^10.0.0",
     "@types/glob": "^8.0.0",
     "@vscode/test-electron": "^2.4.0",
-    "@vscode/vsce": "^3.0.0",
+    "@vscode/vsce": "^3.9.1",
     "c8": "^9.1.0",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
@@ -4864,6 +4864,9 @@
     "mocha": {
       "diff": "^8.0.3",
       "serialize-javascript": "^7.0.5"
+    },
+    "@vscode/vsce": {
+      "@azure/msal-node": "^5.1.5"
     },
     "lodash": "^4.18.1"
   }


### PR DESCRIPTION
## Summary
- Adds an `overrides` entry forcing `@vscode/vsce > @azure/msal-node` to `^5.1.5`, fixing GHSA-w5hq-g745-h8pq (moderate, `uuid<14` missing buffer bounds check in v3/v5/v6 when `buf` is provided). The vulnerable path is `@vscode/vsce → @azure/identity → @azure/msal-node@5.1.1 → uuid@8.3.2`; msal-node 5.1.5+ no longer pulls vulnerable uuid.
- Pins via `overrides` rather than the lockfile because `editors/vscode/package-lock.json` is gitignored, so a fresh `npm install` would otherwise re-resolve the old transitive.
- Also bumps the `@vscode/vsce` floor from `^3.0.0` → `^3.9.1` (current latest) so fresh installs land on a recent release.

## Test plan
- [x] `cd editors/vscode && rm -rf node_modules package-lock.json && npm install && npm audit` → "found 0 vulnerabilities" (was 2 moderate)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)