### PR TITLE
runtime: route fixture/test catch_mod field access through state

### DIFF
--- a/runtime/zig/runtime_test_fixture.zig
+++ b/runtime/zig/runtime_test_fixture.zig
@@ -95,13 +95,13 @@ pub fn catch_enter() void {
 /// ``catch_result()`` call, which keys its return value on
 /// ``last_catch_had_error``.
 pub fn catch_leave() ?[]const u8 {
-    const had_error = catch_mod.error_flag;
-    const msg_obj = catch_mod.error_msg;
+    const had_error = catch_mod.state.error_flag;
+    const msg_obj = catch_mod.state.error_msg;
     _ = catch_mod.catch_leave();
-    catch_mod.error_flag = 0;
-    catch_mod.error_msg = 0;
-    catch_mod.last_catch_had_error = 0;
-    catch_mod.catch_ok_result = 0;
+    catch_mod.state.error_flag = 0;
+    catch_mod.state.error_msg = 0;
+    catch_mod.state.last_catch_had_error = 0;
+    catch_mod.state.catch_ok_result = 0;
     if (had_error == 0) return null;
     if (msg_obj == 0) {
         error_msg_len = 0;
@@ -182,10 +182,10 @@ pub fn with_interp(body: *const fn () void) void {
 }
 
 fn reset_loop_flags() void {
-    catch_mod.return_flag = 0;
-    catch_mod.return_val = 0;
-    catch_mod.break_flag = 0;
-    catch_mod.continue_flag = 0;
+    catch_mod.state.return_flag = 0;
+    catch_mod.state.return_val = 0;
+    catch_mod.state.break_flag = 0;
+    catch_mod.state.continue_flag = 0;
 }
 
 // -- Frame helpers ---------------------------------------------------

--- a/runtime/zig/test_tcl_catch.zig
+++ b/runtime/zig/test_tcl_catch.zig
@@ -42,8 +42,8 @@ fn body_clean_run() void {}
 test "catch_enter / catch_leave on a clean run leaves error_flag at 0" {
     const result = fixture.with_catch(&body_clean_run);
     try testing.expect(result == null);
-    try testing.expectEqual(@as(u32, 0), catch_mod.error_flag);
-    try testing.expectEqual(@as(i32, 0), catch_mod.error_msg);
+    try testing.expectEqual(@as(u32, 0), catch_mod.state.error_flag);
+    try testing.expectEqual(@as(i32, 0), catch_mod.state.error_msg);
 }
 
 fn body_raise() void {
@@ -55,8 +55,8 @@ test "raise inside a catch sets error_flag and error_msg" {
     body_raise();
     // ``error_flag`` and ``error_msg`` must be live BEFORE the leave —
     // the leave's job is to read + clear them.
-    try testing.expectEqual(@as(u32, 1), catch_mod.error_flag);
-    try testing.expect(catch_mod.error_msg != 0);
+    try testing.expectEqual(@as(u32, 1), catch_mod.state.error_flag);
+    try testing.expect(catch_mod.state.error_msg != 0);
 
     const had_error = catch_mod.catch_leave();
     try testing.expectEqual(@as(i64, 1), obj.obj_get_int(had_error));
@@ -64,13 +64,13 @@ test "raise inside a catch sets error_flag and error_msg" {
     // ``catch_leave`` clears ``error_flag`` for the surrounding
     // (non-catch) code; ``last_catch_had_error`` remains so
     // ``catch_result`` can still report.
-    try testing.expectEqual(@as(u32, 0), catch_mod.error_flag);
-    try testing.expectEqual(@as(u32, 1), catch_mod.last_catch_had_error);
+    try testing.expectEqual(@as(u32, 0), catch_mod.state.error_flag);
+    try testing.expectEqual(@as(u32, 1), catch_mod.state.last_catch_had_error);
 
     // Reset for subsequent tests.
-    catch_mod.last_catch_had_error = 0;
-    catch_mod.error_msg = 0;
-    catch_mod.catch_ok_result = 0;
+    catch_mod.state.last_catch_had_error = 0;
+    catch_mod.state.error_msg = 0;
+    catch_mod.state.catch_ok_result = 0;
 }
 
 test "catch_result returns error_msg after a caught error" {
@@ -82,8 +82,8 @@ test "catch_result returns error_msg after a caught error" {
     const s = obj.obj_ensure_string(r);
     const src: [*]const u8 = @ptrFromInt(s.ptr);
     try testing.expectEqualStrings("oops", src[0..s.len]);
-    catch_mod.last_catch_had_error = 0;
-    catch_mod.error_msg = 0;
+    catch_mod.state.last_catch_had_error = 0;
+    catch_mod.state.error_msg = 0;
 }
 
 test "catch_result returns ok_result on a clean run" {
@@ -92,7 +92,7 @@ test "catch_result returns ok_result on a clean run" {
     _ = catch_mod.catch_leave();
     const r = catch_mod.catch_result();
     try testing.expectEqual(@as(i64, 99), obj.obj_get_int(r));
-    catch_mod.catch_ok_result = 0;
+    catch_mod.state.catch_ok_result = 0;
 }
 
 test "catch_set_ok_result is ignored once an error has been raised" {
@@ -109,8 +109,8 @@ test "catch_set_ok_result is ignored once an error has been raised" {
     const s = obj.obj_ensure_string(r);
     const src: [*]const u8 = @ptrFromInt(s.ptr);
     try testing.expectEqualStrings("first", src[0..s.len]);
-    catch_mod.last_catch_had_error = 0;
-    catch_mod.error_msg = 0;
+    catch_mod.state.last_catch_had_error = 0;
+    catch_mod.state.error_msg = 0;
 }
 
 test "catch_has_error mirrors error_flag while inside the catch scope" {
@@ -119,22 +119,22 @@ test "catch_has_error mirrors error_flag while inside the catch scope" {
     stubs.raise("x");
     try testing.expectEqual(@as(i32, 1), catch_mod.catch_has_error());
     _ = catch_mod.catch_leave();
-    catch_mod.last_catch_had_error = 0;
-    catch_mod.error_msg = 0;
+    catch_mod.state.last_catch_had_error = 0;
+    catch_mod.state.error_msg = 0;
 }
 
 // -- nested catches --------------------------------------------------
 
 test "nested catch_enter increments catch_depth then decrements on leave" {
-    const depth0 = catch_mod.catch_depth;
+    const depth0 = catch_mod.state.catch_depth;
     catch_mod.catch_enter();
-    try testing.expectEqual(depth0 + 1, catch_mod.catch_depth);
+    try testing.expectEqual(depth0 + 1, catch_mod.state.catch_depth);
     catch_mod.catch_enter();
-    try testing.expectEqual(depth0 + 2, catch_mod.catch_depth);
+    try testing.expectEqual(depth0 + 2, catch_mod.state.catch_depth);
     _ = catch_mod.catch_leave();
-    try testing.expectEqual(depth0 + 1, catch_mod.catch_depth);
+    try testing.expectEqual(depth0 + 1, catch_mod.state.catch_depth);
     _ = catch_mod.catch_leave();
-    try testing.expectEqual(depth0, catch_mod.catch_depth);
+    try testing.expectEqual(depth0, catch_mod.state.catch_depth);
 }
 
 fn body_inner_raises_outer_does_not() void {
@@ -146,35 +146,35 @@ fn body_inner_raises_outer_does_not() void {
 test "inner catch absorbs the error; outer scope sees no pending error" {
     const result = fixture.with_catch(&body_inner_raises_outer_does_not);
     try testing.expect(result == null);
-    try testing.expectEqual(@as(u32, 0), catch_mod.error_flag);
+    try testing.expectEqual(@as(u32, 0), catch_mod.state.error_flag);
 }
 
 // -- loop-flow flags -------------------------------------------------
 
 test "flow_consume_break clears the flag and reports it once" {
-    catch_mod.break_flag = 1;
+    catch_mod.state.break_flag = 1;
     try testing.expectEqual(@as(i32, 1), catch_mod.flow_consume_break());
     // Second consume must report 0 — the previous call cleared the
     // flag.  Otherwise a single ``break`` could escape multiple
     // enclosing loops.
     try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_break());
-    try testing.expectEqual(@as(u32, 0), catch_mod.break_flag);
+    try testing.expectEqual(@as(u32, 0), catch_mod.state.break_flag);
 }
 
 test "flow_consume_break returns 0 when no break is pending" {
-    catch_mod.break_flag = 0;
+    catch_mod.state.break_flag = 0;
     try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_break());
 }
 
 test "flow_consume_continue clears the flag and reports it once" {
-    catch_mod.continue_flag = 1;
+    catch_mod.state.continue_flag = 1;
     try testing.expectEqual(@as(i32, 1), catch_mod.flow_consume_continue());
     try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_continue());
-    try testing.expectEqual(@as(u32, 0), catch_mod.continue_flag);
+    try testing.expectEqual(@as(u32, 0), catch_mod.state.continue_flag);
 }
 
 test "flow_consume_continue returns 0 when no continue is pending" {
-    catch_mod.continue_flag = 0;
+    catch_mod.state.continue_flag = 0;
     try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_continue());
 }
 


### PR DESCRIPTION
## Summary
- #332 collapsed the loose `tcl_catch` globals (`error_flag`, `error_msg`, `return_flag`, `return_val`, `break_flag`, `continue_flag`, `catch_ok_result`, `last_catch_had_error`, `catch_depth`) into a single `State` struct at `tcl_catch.state`, but missed two callers — `runtime/zig/runtime_test_fixture.zig` and `runtime/zig/test_tcl_catch.zig` — leaving `make test-zig` broken on main with errors like `error: root source file struct 'interp.tcl_catch' has no member named 'return_flag'`.
- Because every other zig test binary imports the fixture, the breakage transitively failed `tcl_subst`, `tcl_ns`, `tcl_procs`, `tcl_format`, `tcl_frames`, `tcl_regex`, and the fixture itself.
- Mechanical fix: every field access becomes `catch_mod.state.<field>`. Function calls (`catch_enter`/`catch_leave`/`catch_result`/`catch_has_error`/`catch_set_ok_result`/`flow_consume_*`/`error_unknown_command`/`var_unset_error`) are unaffected.

## Result
- Fixture compiles; the ~10 transitive-failure binaries now build and run.
- `test_tcl_catch` itself: was "did not compile" → now **62 pass, 1 fail**. The 1 remaining fail is unrelated and pre-existing — `error_unknown_command` now emits `invalid command name "X"` instead of `unknown command: X` (message-builder change without test update).

## Out of scope (pre-existing failures `make test-zig` exposes once this lands)
- `test_tcl_cmd_registry`: 4 compile errs from old `fn([]const i32) i32` handler signature vs new `InterpResult`.
- `test_valtypes-tcl_list_parse` / `test_valtypes-tcl_list_quote`: `import of file outside module path` for sibling files.
- `valtypes-tcl_bs`: `\xNN` and octal `\NNN` decoders return 195 instead of 255.
- `test_tcl_format`: `unknown conversion raises via stubs.unsupported_sub` runtime fail.
- `test_tcl_catch`: the `error_unknown_command` message change noted above.

## Test plan
- [x] `make test-zig` — fixture now compiles; previously transitive-failed binaries now build
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)