### PR TITLE
runtime: fix the six pre-existing zig test-suite failures

### DIFF
--- a/runtime/zig/test_tcl_catch.zig
+++ b/runtime/zig/test_tcl_catch.zig
@@ -178,16 +178,16 @@ test "flow_consume_continue returns 0 when no continue is pending" {
     try testing.expectEqual(@as(i32, 0), catch_mod.flow_consume_continue());
 }
 
-// -- error_unknown_command formatting ------------------------------
+// -- error_invalid_command_name formatting ----------------------------
 
 fn body_unknown_command() void {
-    catch_mod.error_unknown_command(name_obj("frobozz"));
+    catch_mod.error_invalid_command_name(name_obj("frobozz"));
 }
 
-test "error_unknown_command formats 'unknown command: <name>'" {
+test "error_invalid_command_name formats 'invalid command name \"<name>\"'" {
     const msg = fixture.with_catch(&body_unknown_command);
     try testing.expect(msg != null);
-    try testing.expectEqualStrings("unknown command: frobozz", msg.?);
+    try testing.expectEqualStrings("invalid command name \"frobozz\"", msg.?);
 }
 
 // -- var_unset_error formatting ------------------------------------

--- a/runtime/zig/test_tcl_cmd_registry.zig
+++ b/runtime/zig/test_tcl_cmd_registry.zig
@@ -13,41 +13,44 @@ const std = @import("std");
 const testing = std.testing;
 
 const reg = @import("dispatch/tcl_cmd_registry.zig");
+const result_mod = @import("interp/tcl_result.zig");
+const InterpResult = result_mod.InterpResult;
 
 // -- Handlers --------------------------------------------------------
 //
 // Each test handler returns a unique sentinel so we can confirm
 // ``lookup`` returned the right ``CmdEntry`` rather than just *some*
 // entry whose name happened to match.  Returning a fresh integer per
-// handler also keeps the test independent of the runtime's TclObj
-// allocator — these are pure i32 returns.
+// handler keeps the test independent of the runtime's TclObj
+// allocator — the sentinel rides the ``InterpResult.value`` field that
+// the dispatcher would otherwise treat as a TclObj handle.
 
-fn h_set(_: []const i32) i32 {
-    return 1;
+fn h_set(_: []const i32) InterpResult {
+    return result_mod.ok(1);
 }
 
-fn h_unset(_: []const i32) i32 {
-    return 2;
+fn h_unset(_: []const i32) InterpResult {
+    return result_mod.ok(2);
 }
 
-fn h_setvar(_: []const i32) i32 {
-    return 3;
+fn h_setvar(_: []const i32) InterpResult {
+    return result_mod.ok(3);
 }
 
-fn h_string(_: []const i32) i32 {
-    return 4;
+fn h_string(_: []const i32) InterpResult {
+    return result_mod.ok(4);
 }
 
-fn h_sub_length(_: []const i32) i32 {
-    return 100;
+fn h_sub_length(_: []const i32) InterpResult {
+    return result_mod.ok(100);
 }
 
-fn h_sub_index(_: []const i32) i32 {
-    return 101;
+fn h_sub_index(_: []const i32) InterpResult {
+    return result_mod.ok(101);
 }
 
-fn h_sub_match(_: []const i32) i32 {
-    return 102;
+fn h_sub_match(_: []const i32) InterpResult {
+    return result_mod.ok(102);
 }
 
 const TABLE = [_]reg.CmdEntry{
@@ -76,7 +79,7 @@ fn ptr_of(s: []const u8) u32 {
 test "lookup returns the registered handler on hit" {
     const name = "set";
     const h = reg.lookup(&TABLE, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
-    try testing.expectEqual(@as(i32, 1), h(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 1), h(&[_]i32{}).value);
 }
 
 test "lookup returns null on miss" {
@@ -102,8 +105,8 @@ test "lookup distinguishes names that share a prefix" {
     const h_for_set = reg.lookup(&TABLE, ptr_of(set_name), set_name.len) orelse return error.TestUnexpectedNull;
     const h_for_setvar = reg.lookup(&TABLE, ptr_of(setvar_name), setvar_name.len) orelse return error.TestUnexpectedNull;
 
-    try testing.expectEqual(@as(i32, 1), h_for_set(&[_]i32{}));
-    try testing.expectEqual(@as(i32, 3), h_for_setvar(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 1), h_for_set(&[_]i32{}).value);
+    try testing.expectEqual(@as(i32, 3), h_for_setvar(&[_]i32{}).value);
 }
 
 test "lookup is case-sensitive" {
@@ -120,7 +123,7 @@ test "lookup honours name_len boundary — does not over-read" {
     // walked beyond ``name_len``.
     const buf = "setvar";
     const h = reg.lookup(&TABLE, ptr_of(buf), 3) orelse return error.TestUnexpectedNull;
-    try testing.expectEqual(@as(i32, 1), h(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 1), h(&[_]i32{}).value);
 }
 
 test "lookup against an empty table is always null" {
@@ -162,7 +165,7 @@ test "lookup_sub matches a registered sub-command" {
     const s = reg.lookup_sub(&SUBS, ptr_of(name), name.len) orelse return error.TestUnexpectedNull;
     try testing.expectEqual(@as(u32, 1), s.arity_min);
     try testing.expectEqual(@as(?u32, 1), s.arity_max);
-    try testing.expectEqual(@as(i32, 100), s.handler(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 100), s.handler(&[_]i32{}).value);
 }
 
 test "lookup_sub returns null on miss" {
@@ -182,8 +185,8 @@ test "lookup_sub picks the correct entry across length-distinct names" {
     const len_entry = reg.lookup_sub(&SUBS, ptr_of(len_name), len_name.len) orelse return error.TestUnexpectedNull;
     const idx_entry = reg.lookup_sub(&SUBS, ptr_of(idx_name), idx_name.len) orelse return error.TestUnexpectedNull;
 
-    try testing.expectEqual(@as(i32, 100), len_entry.handler(&[_]i32{}));
-    try testing.expectEqual(@as(i32, 101), idx_entry.handler(&[_]i32{}));
+    try testing.expectEqual(@as(i32, 100), len_entry.handler(&[_]i32{}).value);
+    try testing.expectEqual(@as(i32, 101), idx_entry.handler(&[_]i32{}).value);
 }
 
 test "lookup_sub honours sub-arity range" {

--- a/runtime/zig/test_tcl_format.zig
+++ b/runtime/zig/test_tcl_format.zig
@@ -219,29 +219,67 @@ test "tcl_cmd_format — trailing %% with no conversion is dropped" {
 }
 
 // ---- error paths (need #266 fixture) -------------------------------
+//
+// ``stubs.unsupported_sub`` routes through ``tcl_cmd_error`` →
+// ``stamp_error_globals`` → ``ns.global_set``, which post-#334 reaches
+// into the xlinks / interp-registry machinery and needs the root
+// namespace to exist.  Each error-path test therefore nests
+// ``with_catch`` inside ``with_interp`` and stashes the captured
+// message in a module-level slot the test body asserts against —
+// the same shape used by ``var_unset_error`` in
+// ``test_tcl_catch.zig``.
+
+var captured_err_msg: [128]u8 = undefined;
+var captured_err_msg_len: usize = 0;
+
+fn capture(_msg: ?[]const u8) void {
+    if (_msg) |m| {
+        captured_err_msg_len = if (m.len > captured_err_msg.len) captured_err_msg.len else m.len;
+        var idx: usize = 0;
+        while (idx < captured_err_msg_len) : (idx += 1) captured_err_msg[idx] = m[idx];
+    } else {
+        captured_err_msg_len = 0;
+    }
+}
 
 const UnknownVerbCtx = struct {
-    var captured: ?i32 = null;
-    fn body() void {
-        captured = fmt.tcl_cmd_format(s("%z"), i(1), 0, 0);
+    fn inner() void {
+        // ``%y`` — not a recognised conversion verb and not in the
+        // C99 length-modifier set (``l h L j z t q``) so it falls
+        // through ``emit_conversion``'s ``else`` arm and raises via
+        // ``stubs.unsupported_sub``.  Earlier revisions of this test
+        // used ``%z`` which is now silently consumed as the size_t
+        // length modifier.
+        _ = fmt.tcl_cmd_format(s("%y"), i(1), 0, 0);
+    }
+    fn outer() void {
+        capture(fixture.with_catch(&inner));
     }
 };
 
 test "tcl_cmd_format — unknown conversion raises via stubs.unsupported_sub" {
-    UnknownVerbCtx.captured = null;
-    const msg = fixture.with_catch(&UnknownVerbCtx.body);
-    try testing.expect(msg != null);
-    try testing.expectEqualStrings("unsupported command: format %z", msg.?);
+    captured_err_msg_len = 0;
+    fixture.with_interp(&UnknownVerbCtx.outer);
+    try testing.expectEqualStrings(
+        "unsupported command: format %y",
+        captured_err_msg[0..captured_err_msg_len],
+    );
 }
 
 const UnknownVerbCapsCtx = struct {
-    fn body() void {
+    fn inner() void {
         _ = fmt.tcl_cmd_format(s("%Q"), i(1), 0, 0);
+    }
+    fn outer() void {
+        capture(fixture.with_catch(&inner));
     }
 };
 
 test "tcl_cmd_format — unknown uppercase conversion raises with verb" {
-    const msg = fixture.with_catch(&UnknownVerbCapsCtx.body);
-    try testing.expect(msg != null);
-    try testing.expectEqualStrings("unsupported command: format %Q", msg.?);
+    captured_err_msg_len = 0;
+    fixture.with_interp(&UnknownVerbCapsCtx.outer);
+    try testing.expectEqualStrings(
+        "unsupported command: format %Q",
+        captured_err_msg[0..captured_err_msg_len],
+    );
 }

--- a/runtime/zig/test_tcl_list_parse.zig
+++ b/runtime/zig/test_tcl_list_parse.zig
@@ -6,11 +6,19 @@
 // unterminated braces.  Reference oracle is ``Tcl_ListObjLength`` /
 // ``Tcl_ListObjIndex`` from upstream Tcl 9.0 (``generic/tclListObj.c``,
 // which delegates to ``TclFindElement``).
+//
+// File location: runtime/zig/ rather than valtypes/.  The module under
+// test reaches into ``../stubs/tcl_stubs.zig`` and
+// ``../interp/tcl_catch.zig`` for the error-raise paths, and Zig 0.16's
+// module system rejects ``@import`` of files above the test module's
+// root_source_file directory.  Rooting the test at runtime/zig/ keeps
+// every transitive import inside the module path — same constraint
+// that put ``runtime_test_fixture.zig`` here.
 
 const std = @import("std");
 const testing = std.testing;
 
-const lp = @import("tcl_list_parse.zig");
+const lp = @import("valtypes/tcl_list_parse.zig");
 
 // ---- helpers --------------------------------------------------------
 

--- a/runtime/zig/test_tcl_list_quote.zig
+++ b/runtime/zig/test_tcl_list_quote.zig
@@ -7,13 +7,20 @@
 // payload matches the original.  The reference oracle is ``Tcl_Merge``
 // in upstream Tcl 9.0; the expected outputs below were captured from
 // running ``puts [list $payload]`` under tclsh 9.0.
+//
+// File location: runtime/zig/ rather than valtypes/.  ``parse``
+// reaches into ``../stubs/tcl_stubs.zig`` and
+// ``../interp/tcl_catch.zig`` for the error-raise paths, and Zig
+// 0.16's module system rejects ``@import`` of files above the test
+// module's root_source_file directory.  See the same explanation in
+// ``runtime_test_fixture.zig``.
 
 const std = @import("std");
 const testing = std.testing;
 
-const quote = @import("tcl_list_quote.zig");
-const parse = @import("tcl_list_parse.zig");
-const bs = @import("tcl_bs.zig");
+const quote = @import("valtypes/tcl_list_quote.zig");
+const parse = @import("valtypes/tcl_list_parse.zig");
+const bs = @import("valtypes/tcl_bs.zig");
 
 // ---- helpers --------------------------------------------------------
 

--- a/runtime/zig/valtypes/test_tcl_bs.zig
+++ b/runtime/zig/valtypes/test_tcl_bs.zig
@@ -96,17 +96,21 @@ test "consume_bs_escape — \\xNN with 1 and 2 hex digits" {
     try testing.expectEqual(@as(u32, 1), r.written);
     try testing.expectEqual(@as(u8, 0x09), out[0]);
 
-    // \xFFExtra — only the first two hex digits are taken.
+    // \xFFExtra — only the first two hex digits are taken; Tcl 9
+    // emits the codepoint U+00FF as 2 UTF-8 bytes (0xC3 0xBF).
     r = one("xFFExtra", &out);
     try testing.expectEqual(@as(u32, 3), r.next_si);
-    try testing.expectEqual(@as(u8, 0xFF), out[0]);
+    try testing.expectEqual(@as(u32, 2), r.written);
+    try testing.expectEqual(@as(u8, 0xC3), out[0]);
+    try testing.expectEqual(@as(u8, 0xBF), out[1]);
 
-    // \x with no following hex digit at all → emits 0x00 and only
+    // \x with no following hex digit at all → emits the literal
+    // ``x`` byte (Tcl 9: unknown-escape rule, subst-3.1) and only
     // consumes the ``x``.
     r = one("xz", &out);
     try testing.expectEqual(@as(u32, 1), r.next_si);
     try testing.expectEqual(@as(u32, 1), r.written);
-    try testing.expectEqual(@as(u8, 0x00), out[0]);
+    try testing.expectEqual(@as(u8, 'x'), out[0]);
 }
 
 // ---- \uNNNN ---------------------------------------------------------
@@ -182,10 +186,13 @@ test "consume_bs_escape — octal \\NNN" {
     try testing.expectEqual(@as(u32, 1), r.next_si);
     try testing.expectEqual(@as(u8, 7), out[0]);
 
-    // \377 — max byte value.
+    // \377 — max byte value as codepoint U+00FF; Tcl 9 emits 2 UTF-8
+    // bytes (0xC3 0xBF).
     r = one("377", &out);
     try testing.expectEqual(@as(u32, 3), r.next_si);
-    try testing.expectEqual(@as(u8, 0xFF), out[0]);
+    try testing.expectEqual(@as(u32, 2), r.written);
+    try testing.expectEqual(@as(u8, 0xC3), out[0]);
+    try testing.expectEqual(@as(u8, 0xBF), out[1]);
 
     // ``8`` and ``9`` are NOT octal digits — Tcl treats ``\8`` and
     // ``\9`` as unknown escapes and emits the literal byte (cf.


### PR DESCRIPTION
## Summary

`make test-zig` had six unrelated failures left over from recent refactors and reference-Tcl alignment work — all stale test expectations or test-wiring drift, not source bugs. Each fix is small and mechanical, but together they were silently hiding regressions: `test-slow` couldn't go green until they all landed.

| # | Failure | Fix |
|---|---|---|
| 1 | `test_tcl_cmd_registry` (4 compile errs) | #332 changed handler return from `i32` → `InterpResult`. Wire test handlers to `result_mod.ok(N)`; read sentinel from `.value` in assertions. |
| 2 | `test_tcl_catch.error_unknown_command` (runtime) | Builder renamed to `error_invalid_command_name`, now emits `invalid command name "X"` (matches reference Tcl `TclEvalObjvInternal`). Update test to new name + wording. |
| 3 | `valtypes-tcl_bs.consume_bs_escape \xNN / \NNN` (2 runtime) | Tcl 9 semantics: `\xFF` / `\377` emit codepoint U+00FF as 2 UTF-8 bytes (0xC3 0xBF), not raw 0xFF. Also `\xz` (no hex digit) emits literal `x`, not 0x00. Update expectations. |
| 4 | `test_tcl_format.unknown conversion` (runtime) | Two issues: `%z` is now a C99 length modifier (silently consumed) — switch to `%y`. Post-#334, error path needs the root namespace via `with_interp`. Wrap test body. |
| 5 | `test_valtypes-tcl_list_parse` (3 compile errs) | Zig 0.16 rejects `@import` above the test module's root. `tcl_list_parse.zig` reaches `../stubs/` + `../interp/` — move test to `runtime/zig/` (same constraint that put `runtime_test_fixture.zig` there). |
| 6 | `test_valtypes-tcl_list_quote` (3 compile errs) | Same shape as #5; relocate. |

## Verification

Before:
```
Build Summary: 39/49 steps succeeded (6 failed); 1079/1083 tests passed (4 failed)
```

After:
- `make test-zig` → exit 0 silently (1101/1101 pass)
- `make clean test-slow install` → exit 0 end-to-end
- `npm audit` → 0 vulns
- VS Code extension tests → 399/399 passing
- Every smoke zipapp builds + VSIX packages + installs

## Test plan
- [x] `make clean test-slow install` clean
- [x] `make test-zig` standalone: 1101/1101 pass
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)