### PR TITLE
clippy-cleanup: drop tractable allows from Chunks A + E (7 removed)

### DIFF
--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -1124,7 +1124,10 @@ Consider capturing the result: catch {\u{2026}} result"
         // as literal inside ``"…"``) is not detected.  Real W101
         // shapes don't hit that pattern; documented for posterity.
         let has_substitution = arg_tokens.iter().enumerate().any(|(i, tok)| {
-            if matches!(tok.kind, tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd) {
+            if matches!(
+                tok.kind,
+                tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
+            ) {
                 return true;
             }
             if arg_single.get(i).copied() == Some(true) {

--- a/rust/tcl-compiler/src/analyser/mro.rs
+++ b/rust/tcl-compiler/src/analyser/mro.rs
@@ -67,69 +67,59 @@ impl std::error::Error for MroError {}
 /// 3. Recurse into superclasses (inheriting current mixin-path
 ///    status).
 ///
-/// `is_mixin_path` corresponds to Tcl's ``TRAVERSED_MIXIN``:
-/// `true` when the class was reached via a mixin edge.
+/// Per-pass context for [`tcloo_dfs`].
+///
+/// Bundles the immutable maps that drive the walk
+/// (`mixins_map` / `supers_map`), the mutable accumulator
+/// (`result` / `visiting`), and the per-pass `building_mixins`
+/// flag.  Only `cls` and `is_mixin_path` vary per recursive
+/// call — they stay as direct parameters.
 ///
 /// `building_mixins` corresponds to Tcl's ``BUILDING_MIXINS``:
 /// when set, only mixin-path classes are added; when clear,
 /// only non-mixin-path classes are added.
-#[allow(clippy::too_many_arguments)]
-fn tcloo_dfs(
-    cls: &str,
-    mixins_map: &HashMap<String, Vec<String>>,
-    supers_map: &HashMap<String, Vec<String>>,
-    result: &mut Vec<String>,
-    visiting: &mut HashSet<String>,
-    is_mixin_path: bool,
+struct DfsCtx<'a> {
+    mixins_map: &'a HashMap<String, Vec<String>>,
+    supers_map: &'a HashMap<String, Vec<String>>,
+    result: &'a mut Vec<String>,
+    visiting: &'a mut HashSet<String>,
     building_mixins: bool,
-) {
-    if visiting.contains(cls) {
+}
+
+/// `is_mixin_path` corresponds to Tcl's ``TRAVERSED_MIXIN``:
+/// `true` when the class was reached via a mixin edge.
+fn tcloo_dfs(cls: &str, ctx: &mut DfsCtx<'_>, is_mixin_path: bool) {
+    if ctx.visiting.contains(cls) {
         // Cycles through mixins are valid in TclOO; just skip.
         return;
     }
-    visiting.insert(cls.to_string());
+    ctx.visiting.insert(cls.to_string());
 
     // 1. Process class-level mixins (enter mixin path).
-    if let Some(mixins) = mixins_map.get(cls) {
-        for mixin in mixins {
-            tcloo_dfs(
-                mixin,
-                mixins_map,
-                supers_map,
-                result,
-                visiting,
-                true,
-                building_mixins,
-            );
+    if let Some(mixins) = ctx.mixins_map.get(cls) {
+        for mixin in mixins.clone() {
+            tcloo_dfs(&mixin, ctx, true);
         }
     }
 
     // 2. Add own class with MIXIN_CONSISTENT gate:
     //    Pass 1 (building_mixins=true):  only add if on mixin path
     //    Pass 2 (building_mixins=false): only add if NOT on mixin path
-    if building_mixins == is_mixin_path {
-        if let Some(pos) = result.iter().position(|c| c == cls) {
-            result.remove(pos);
+    if ctx.building_mixins == is_mixin_path {
+        if let Some(pos) = ctx.result.iter().position(|c| c == cls) {
+            ctx.result.remove(pos);
         }
-        result.push(cls.to_string());
+        ctx.result.push(cls.to_string());
     }
 
     // 3. Process superclasses (inherit mixin-path status).
-    if let Some(supers) = supers_map.get(cls) {
-        for parent in supers {
-            tcloo_dfs(
-                parent,
-                mixins_map,
-                supers_map,
-                result,
-                visiting,
-                is_mixin_path,
-                building_mixins,
-            );
+    if let Some(supers) = ctx.supers_map.get(cls) {
+        for parent in supers.clone() {
+            tcloo_dfs(&parent, ctx, is_mixin_path);
         }
     }
 
-    visiting.remove(cls);
+    ctx.visiting.remove(cls);
 }
 
 /// Detect a pure superclass cycle starting at `start`.
@@ -194,28 +184,26 @@ pub fn tcloo_linearise(
 
     // Pass 1: BUILDING_MIXINS — only collect mixin-path classes.
     let mut visiting = HashSet::new();
-    tcloo_dfs(
-        class_name,
+    let mut ctx = DfsCtx {
         mixins_map,
-        superclasses_map,
-        &mut result,
-        &mut visiting,
-        false,
-        true,
-    );
+        supers_map: superclasses_map,
+        result: &mut result,
+        visiting: &mut visiting,
+        building_mixins: true,
+    };
+    tcloo_dfs(class_name, &mut ctx, false);
 
     // Pass 2: collect non-mixin-path classes (shares result list
     // for late-placement dedup).
     let mut visiting = HashSet::new();
-    tcloo_dfs(
-        class_name,
+    let mut ctx = DfsCtx {
         mixins_map,
-        superclasses_map,
-        &mut result,
-        &mut visiting,
-        false,
-        false,
-    );
+        supers_map: superclasses_map,
+        result: &mut result,
+        visiting: &mut visiting,
+        building_mixins: false,
+    };
+    tcloo_dfs(class_name, &mut ctx, false);
 
     Ok(result)
 }

--- a/rust/tcl-compiler/src/segmenter.rs
+++ b/rust/tcl-compiler/src/segmenter.rs
@@ -303,55 +303,84 @@ where
     None
 }
 
-/// Flush the in-flight command on `Eol` / `Eof`, or — when no
-/// command is in flight — clear the accumulated
-/// preceding-comment state when the EOL spans a blank line.
-/// Mirrors the Python ``command_segmenter`` blank-line and
-/// EOL-flush behaviour and the corresponding doc-comment
-/// detachment heuristic for class definitions.
-#[allow(clippy::too_many_arguments)]
-fn handle_eol_or_eof(
-    tok: Token,
-    sm: &SourceMap<'_>,
-    commands: &mut Vec<SegmentedCommand>,
-    argv: &mut Vec<Token>,
-    texts: &mut Vec<String>,
-    single: &mut Vec<bool>,
-    expand: &mut Vec<bool>,
-    all_tokens: &mut Vec<Token>,
-    has_expand: &mut bool,
-    last_comment: &mut Option<String>,
-) {
-    if !argv.is_empty() {
-        commands.push(SegmentedCommand {
-            span: span_from_tokens(all_tokens),
-            argv: std::mem::take(argv),
-            texts: std::mem::take(texts),
-            single_token_word: std::mem::take(single),
-            all_tokens: std::mem::take(all_tokens),
-            is_partial: false,
-            expand_word: if *has_expand {
-                Some(std::mem::take(expand))
-            } else {
-                expand.clear();
-                None
-            },
-            preceding_comment: last_comment.take(),
-        });
-    } else if matches!(tok.kind, TokenType::Eol) {
-        // Blank-line EOL: clear any accumulated preceding-comment
-        // state so a comment block separated from its following
-        // declaration by a blank line doesn't get attached to
-        // that declaration.  Mirrors Python's
-        // ``command_segmenter.py`` lines 257-261 — an EOL token
-        // whose text contains more than one ``\n`` is the lexer's
-        // encoding of a run-of-empty-lines.
-        let eol_text = sm.token_text(tok);
-        if eol_text.bytes().filter(|&b| b == b'\n').count() > 1 {
-            *last_comment = None;
+/// Mutable accumulator state for the per-token segmenter loop.
+///
+/// Bundles the in-flight word/argv/expand/comment state plus the
+/// output `commands` vector so [`SegmenterState::flush_eol_or_eof`]
+/// can read and mutate them through a single `&mut self`.
+struct SegmenterState {
+    /// Output: completed commands so far.
+    commands: Vec<SegmentedCommand>,
+    /// In-flight argv tokens for the current command.
+    argv: Vec<Token>,
+    /// Per-argv-token rendered text (one entry per argv).
+    texts: Vec<String>,
+    /// Per-argv-token "single physical token" flag.
+    single: Vec<bool>,
+    /// Per-argv-token `{*}`-expansion flag.
+    expand: Vec<bool>,
+    /// All physical tokens that compose the in-flight command, in
+    /// source order — kept verbatim so downstream consumers can
+    /// see e.g. the `{*}` token even though it isn't an argv slot.
+    all_tokens: Vec<Token>,
+    /// Whether any `{*}` expansion appeared in the in-flight command.
+    has_expand: bool,
+    /// Buffered `#` comment block preceding the next command.
+    last_comment: Option<String>,
+}
+
+impl SegmenterState {
+    fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+            argv: Vec::new(),
+            texts: Vec::new(),
+            single: Vec::new(),
+            expand: Vec::new(),
+            all_tokens: Vec::new(),
+            has_expand: false,
+            last_comment: None,
         }
     }
-    *has_expand = false;
+
+    /// Flush the in-flight command on `Eol` / `Eof`, or — when no
+    /// command is in flight — clear the accumulated
+    /// preceding-comment state when the EOL spans a blank line.
+    /// Mirrors the Python ``command_segmenter`` blank-line and
+    /// EOL-flush behaviour and the corresponding doc-comment
+    /// detachment heuristic for class definitions.
+    fn flush_eol_or_eof(&mut self, tok: Token, sm: &SourceMap<'_>) {
+        if !self.argv.is_empty() {
+            self.commands.push(SegmentedCommand {
+                span: span_from_tokens(&self.all_tokens),
+                argv: std::mem::take(&mut self.argv),
+                texts: std::mem::take(&mut self.texts),
+                single_token_word: std::mem::take(&mut self.single),
+                all_tokens: std::mem::take(&mut self.all_tokens),
+                is_partial: false,
+                expand_word: if self.has_expand {
+                    Some(std::mem::take(&mut self.expand))
+                } else {
+                    self.expand.clear();
+                    None
+                },
+                preceding_comment: self.last_comment.take(),
+            });
+        } else if matches!(tok.kind, TokenType::Eol) {
+            // Blank-line EOL: clear any accumulated preceding-comment
+            // state so a comment block separated from its following
+            // declaration by a blank line doesn't get attached to
+            // that declaration.  Mirrors Python's
+            // ``command_segmenter.py`` lines 257-261 — an EOL token
+            // whose text contains more than one ``\n`` is the lexer's
+            // encoding of a run-of-empty-lines.
+            let eol_text = sm.token_text(tok);
+            if eol_text.bytes().filter(|&b| b == b'\n').count() > 1 {
+                self.last_comment = None;
+            }
+        }
+        self.has_expand = false;
+    }
 }
 
 fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
@@ -364,31 +393,16 @@ fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
         return Vec::new();
     };
 
-    let mut commands = Vec::new();
-    let mut argv: Vec<Token> = Vec::new();
-    let mut texts: Vec<String> = Vec::new();
-    let mut single: Vec<bool> = Vec::new();
-    let mut expand: Vec<bool> = Vec::new();
-    let mut all_tokens: Vec<Token> = Vec::new();
+    let mut state = SegmenterState::new();
     let mut prev_type = TokenType::Eol;
     let mut next_expand = false;
-    let mut has_expand = false;
-    // Accumulator for ``# ...`` lines preceding the next command.
-    // Mirrors `last_comment` in
-    // ``core/parsing/command_segmenter.py``: each new comment line
-    // is appended (joined by ``\n``); the leading ``#`` and a
-    // single space are stripped per Python's
-    // ``line.lstrip('#').strip()`` shape.  Reset to ``None`` once a
-    // command consumes it, or whenever a non-comment / non-EOL
-    // token interrupts the run.
-    let mut last_comment: Option<String> = None;
 
     for &tok in &tokens {
         match tok.kind {
             TokenType::Comment => {
                 let raw = sm.token_text(tok);
                 let line = raw.trim_start_matches('#').trim().to_string();
-                last_comment = Some(match last_comment.take() {
+                state.last_comment = Some(match state.last_comment.take() {
                     Some(prev) => format!("{prev}\n{line}"),
                     None => line,
                 });
@@ -407,26 +421,15 @@ fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
             }
 
             TokenType::Expand => {
-                all_tokens.push(tok);
+                state.all_tokens.push(tok);
                 next_expand = true;
-                has_expand = true;
+                state.has_expand = true;
                 prev_type = TokenType::Sep;
                 continue;
             }
 
             TokenType::Eol | TokenType::Eof => {
-                handle_eol_or_eof(
-                    tok,
-                    &sm,
-                    &mut commands,
-                    &mut argv,
-                    &mut texts,
-                    &mut single,
-                    &mut expand,
-                    &mut all_tokens,
-                    &mut has_expand,
-                    &mut last_comment,
-                );
+                state.flush_eol_or_eof(tok, &sm);
                 next_expand = false;
                 prev_type = tok.kind;
                 continue;
@@ -435,32 +438,32 @@ fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
             _ => {}
         }
 
-        all_tokens.push(tok);
+        state.all_tokens.push(tok);
         let piece = word_piece(&sm, tok);
 
         if prev_type == TokenType::Sep || prev_type == TokenType::Eol {
-            argv.push(tok);
-            texts.push(piece);
-            single.push(true);
-            expand.push(next_expand);
+            state.argv.push(tok);
+            state.texts.push(piece);
+            state.single.push(true);
+            state.expand.push(next_expand);
             next_expand = false;
-        } else if let Some(last_text) = texts.last_mut() {
+        } else if let Some(last_text) = state.texts.last_mut() {
             last_text.push_str(&piece);
-            if let Some(s) = single.last_mut() {
+            if let Some(s) = state.single.last_mut() {
                 *s = false;
             }
             // Widen argv[-1] to cover the full Tcl word, matching
             // Python's command_segmenter so multi-token words like
             // ``$var/literal.tcl`` carry one argv token whose span
             // ends at the last sub-token.
-            if let Some(prev) = argv.last_mut() {
+            if let Some(prev) = state.argv.last_mut() {
                 prev.span = Span::new(prev.span.start(), tok.span.end());
             }
         } else {
-            argv.push(tok);
-            texts.push(piece);
-            single.push(true);
-            expand.push(next_expand);
+            state.argv.push(tok);
+            state.texts.push(piece);
+            state.single.push(true);
+            state.expand.push(next_expand);
             next_expand = false;
         }
 
@@ -468,7 +471,19 @@ fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
     }
 
     // Trailing command without final EOL.
-    if !argv.is_empty() {
+    if state.argv.is_empty() {
+        state.commands
+    } else {
+        let SegmenterState {
+            mut commands,
+            argv,
+            texts,
+            single,
+            expand,
+            all_tokens,
+            has_expand,
+            mut last_comment,
+        } = state;
         commands.push(SegmentedCommand {
             span: span_from_tokens(&all_tokens),
             argv,
@@ -479,9 +494,8 @@ fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
             expand_word: if has_expand { Some(expand) } else { None },
             preceding_comment: last_comment.take(),
         });
+        commands
     }
-
-    commands
 }
 
 #[cfg(test)]

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -102,16 +102,16 @@ pub fn folding_ranges(
         &mut ranges,
     );
     collect_comment_folds(source, &mut seen, &mut ranges);
-    collect_body_folds(
-        source,
+    let mut ctx = FoldCtx {
         registry,
-        &line_index,
-        source,
-        0,
-        0,
-        false, // top-level body is not inside an OO definition
-        &mut seen,
-        &mut ranges,
+        line_index: &line_index,
+        original_source: source,
+        seen: &mut seen,
+        ranges: &mut ranges,
+    };
+    collect_body_folds(
+        source, 0, 0, false, // top-level body is not inside an OO definition
+        &mut ctx,
     );
 
     ranges
@@ -338,18 +338,28 @@ fn collect_comment_folds(
 /// context — outside it, a user proc named `method` must not be
 /// misidentified.
 ///
+/// Per-walk context for [`collect_body_folds`].
+///
+/// Bundles the immutable references that don't change across the
+/// recursive walk (`registry`, `line_index`, `original_source`)
+/// and the two mutable accumulators (`seen`, `ranges`).  Only
+/// `body_source`, `base_offset`, `depth`, and `inside_oo_body`
+/// vary per call — they stay as direct parameters.
+struct FoldCtx<'a> {
+    registry: &'a CommandRegistry,
+    line_index: &'a LineIndex,
+    original_source: &'a str,
+    seen: &'a mut HashSet<(u32, u32)>,
+    ranges: &'a mut Vec<FoldingRange>,
+}
+
 /// Recursion depth is capped at 20 to mirror the Python guard.
-#[allow(clippy::too_many_arguments)]
 fn collect_body_folds(
     body_source: &str,
-    registry: &CommandRegistry,
-    line_index: &LineIndex,
-    original_source: &str,
     base_offset: u32,
     depth: u32,
     inside_oo_body: bool,
-    seen: &mut HashSet<(u32, u32)>,
-    ranges: &mut Vec<FoldingRange>,
+    ctx: &mut FoldCtx<'_>,
 ) {
     if depth > 20 {
         return;
@@ -373,7 +383,8 @@ fn collect_body_folds(
             if inside_oo_body && is_inner_oo_definition_command(cmd.name()) {
                 inner_oo_body_indices(cmd.name(), &args_borrow)
             } else {
-                registry.arg_indices_for_role(cmd.name(), &args_borrow, ArgRole::Body)
+                ctx.registry
+                    .arg_indices_for_role(cmd.name(), &args_borrow, ArgRole::Body)
             };
 
         // What "inside_oo_body" should the recursion into THIS
@@ -404,7 +415,13 @@ fn collect_body_folds(
             if !matches!(body_tok.kind, TokenType::Str) {
                 continue;
             }
-            emit_body_span_fold(body_tok.span, original_source, line_index, seen, ranges);
+            emit_body_span_fold(
+                body_tok.span,
+                ctx.original_source,
+                ctx.line_index,
+                ctx.seen,
+                ctx.ranges,
+            );
 
             // Recurse into the body's content. The lexer's STR span
             // includes the opening ``{``; for closed non-empty bodies
@@ -415,7 +432,7 @@ fn collect_body_folds(
             let span = body_tok.span;
             let content_start = span.start() as usize + body_tok.content_offset as usize;
             let raw_end = span.end() as usize;
-            let bytes = original_source.as_bytes();
+            let bytes = ctx.original_source.as_bytes();
             // Strip the trailing ``}`` for the empty-body clamp case
             // so the sub-lexer doesn't see a stray close-brace.
             let content_end = if raw_end > content_start
@@ -429,17 +446,13 @@ fn collect_body_folds(
             if content_end <= content_start {
                 continue;
             }
-            let inner = &original_source[content_start..content_end];
+            let inner = &ctx.original_source[content_start..content_end];
             collect_body_folds(
                 inner,
-                registry,
-                line_index,
-                original_source,
                 u32::try_from(content_start).expect("content offset fits u32"),
                 depth + 1,
                 next_inside_oo_body,
-                seen,
-                ranges,
+                ctx,
             );
         }
     }

--- a/rust/tcl-lsp-py/src/compiler_checks.rs
+++ b/rust/tcl-lsp-py/src/compiler_checks.rs
@@ -24,6 +24,12 @@ use pyo3::prelude::*;
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::compiler_checks::run_all_checks;
 
+/// Tuple shape of one compiler-check diagnostic returned to
+/// Python: `(code, category, severity, message, start_offset,
+/// end_offset, replacement_or_none)`.  The Python caller wraps
+/// each row in its own `Diagnostic` dataclass.
+type DiagnosticRow = (String, String, String, String, u32, u32, Option<String>);
+
 /// Run every landed compiler check against `source` and return a
 /// flat list of diagnostic tuples:
 ///
@@ -42,11 +48,7 @@ use tcl_compiler::compiler_checks::run_all_checks;
 /// `dialect` is forwarded as-is; `None` selects plain Tcl.
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
-#[allow(clippy::type_complexity)]
-pub fn compiler_checks_run_all(
-    source: &str,
-    dialect: Option<&str>,
-) -> Vec<(String, String, String, String, u32, u32, Option<String>)> {
+pub fn compiler_checks_run_all(source: &str, dialect: Option<&str>) -> Vec<DiagnosticRow> {
     let registry = crate::registry::default_registry();
     let cu =
         CompilationUnit::build_for(source, registry, false).with_interprocedural(registry, dialect);

--- a/rust/tcl-lsp-py/src/expr_lexer.rs
+++ b/rust/tcl-lsp-py/src/expr_lexer.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::useless_conversion)]
 //! `PyO3` wrapper for `tcl_lexer::expr_lexer`.
 
 use pyo3::prelude::*;

--- a/rust/tcl-lsp-py/src/optimiser.rs
+++ b/rust/tcl-lsp-py/src/optimiser.rs
@@ -16,6 +16,25 @@ use pyo3::prelude::*;
 
 use tcl_compiler::optimiser;
 
+/// Tuple shape of one optimisation record returned to Python:
+/// `(code, message, start_offset, end_offset, replacement,
+///   group_or_none, hint_only)`.  The Python caller wraps each
+/// row in its own `Optimisation` dataclass so this crate
+/// doesn't need to know about Python-side types.
+type OptimisationRow = (String, String, u32, u32, String, Option<u32>, bool);
+
+fn lift_optimisation(o: optimiser::Optimisation) -> OptimisationRow {
+    (
+        o.code,
+        o.message,
+        o.span.start(),
+        o.span.end(),
+        o.replacement,
+        o.group,
+        o.hint_only,
+    )
+}
+
 /// Run every landed optimisation pass against `source` and
 /// return the overlap-free list of suggestions as a tuple per
 /// diagnostic:
@@ -32,25 +51,11 @@ use tcl_compiler::optimiser;
 /// plain Tcl.
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
-#[allow(clippy::type_complexity)]
-pub fn optimiser_find_optimisations(
-    source: &str,
-    dialect: Option<&str>,
-) -> Vec<(String, String, u32, u32, String, Option<u32>, bool)> {
+pub fn optimiser_find_optimisations(source: &str, dialect: Option<&str>) -> Vec<OptimisationRow> {
     let registry = crate::registry::default_registry();
     optimiser::optimise_with_dialect(source, registry, dialect)
         .into_iter()
-        .map(|o| {
-            (
-                o.code,
-                o.message,
-                o.span.start(),
-                o.span.end(),
-                o.replacement,
-                o.group,
-                o.hint_only,
-            )
-        })
+        .map(lift_optimisation)
         .collect()
 }
 
@@ -60,27 +65,16 @@ pub fn optimiser_find_optimisations(
 /// tests + tooling that want to inspect the raw per-pass output.
 #[pyfunction]
 #[pyo3(signature = (source, dialect = None, /))]
-#[allow(clippy::type_complexity)]
 pub fn optimiser_find_optimisations_raw(
     source: &str,
     dialect: Option<&str>,
-) -> Vec<(String, String, u32, u32, String, Option<u32>, bool)> {
+) -> Vec<OptimisationRow> {
     let registry = crate::registry::default_registry();
     // optimise_raw already constructs a CompilationUnit internally;
     // no need to build one here.
-    let opts = optimiser::optimise_raw(source, registry, dialect);
-    opts.into_iter()
-        .map(|o| {
-            (
-                o.code,
-                o.message,
-                o.span.start(),
-                o.span.end(),
-                o.replacement,
-                o.group,
-                o.hint_only,
-            )
-        })
+    optimiser::optimise_raw(source, registry, dialect)
+        .into_iter()
+        .map(lift_optimisation)
         .collect()
 }
 


### PR DESCRIPTION
## Summary

Phase 2 clippy-allow cleanup, combining the tractable subset of Chunks A
(`useless_conversion`) and E (small categories: `type_complexity`,
`too_many_arguments`).  7 `#[allow(clippy::…)]` lines removed across the
workspace (~7% of the ~100 total).

## Triage outcome

Empirically tested every allow in the targeted categories.  Of 13 total
in scope, **7 were tractable, 6 were load-bearing or intentional and
stay**:

| Category | Removed | Kept |
| --- | --- | --- |
| `useless_conversion` | 1 (`expr_lexer.rs` had no live trigger) | 6 (real PyO3 macro-expansion `?`-in-`#[pyfunction]` hits) |
| `type_complexity` | 3 (PyO3 boundary tuples → `OptimisationRow` / `DiagnosticRow` aliases) | 0 |
| `too_many_arguments` | 3 (recursion-state structs in segmenter / mro / folding) | 0 |
| `trivially_copy_pass_by_ref` | 0 | 2 (PyO3 macro requires `&self`) |
| `match_same_arms` | 0 | 2 (lookup-table style; collapsing arms hurts readability) |
| `cast_possible_truncation` | 0 | 2 (float→i64 after `is_finite` / `abs<1e16` guards; provably safe at the cast site) |

## Three commits

### 1. `clippy-cleanup: drop useless_conversion + type_complexity allows in tcl-lsp-py` (0f560f80)

- Drop the unneeded `#![allow(clippy::useless_conversion)]` from
  `expr_lexer.rs`.  Empirical check: removing the allows on the other
  six `tcl-lsp-py` modules each produces a real `useless conversion to
  the same type: pyo3::PyErr` clippy error, so those six stay
  documented.
- Replace the three `#[allow(clippy::type_complexity)]` allows on
  `optimiser_find_optimisations` / `optimiser_find_optimisations_raw` /
  `compiler_checks_run_all` with module-private `OptimisationRow` /
  `DiagnosticRow` type aliases.  Public Python-facing tuple shape is
  unchanged.  Drive-by: factored a `lift_optimisation` helper so the
  two optimiser functions don't duplicate the same `o.code, o.message,
  …` tuple build inline.
- Drive-by: applied `cargo fmt` to one pre-existing drift line in
  `tcl-compiler/src/analyser/diagnostics.rs` (a `matches!(…)` macro
  call that was just over the line-width limit on origin/rust HEAD).

### 2. `clippy-cleanup: bundle segmenter EOL/EOF accumulator state into a struct` (3dd60141)

`handle_eol_or_eof` in `tcl-compiler/src/segmenter.rs` took 9
parameters — 8 of them mutable references to per-command accumulator
state.  Bundled into a new `SegmenterState` struct and turned the
function into a `flush_eol_or_eof(&mut self, tok, sm)` method.  Net:
1 `too_many_arguments` allow removed, plus an `if !x` flipped to its
`clippy::if_not_else`-friendly shape.

### 3. `clippy-cleanup: bundle DFS / folding-walk recursion state into context structs` (b70e7e5a)

Two recursive walkers each took 8 parameters:

- `tcloo_dfs` (`tcl-compiler/src/analyser/mro.rs`) — bundled the per-pass
  invariants (`mixins_map`, `supers_map`, `building_mixins`) and the
  shared accumulators (`result`, `visiting`) into a new `DfsCtx<'_>`.
  Side effect of the borrow split: the inner `for mixin in
  ctx.mixins_map.get(cls)` loops now clone the `Vec<String>` once per
  recursion level so the `&mut DfsCtx` re-borrow doesn't conflict with
  the outer `&` borrow on the same field.  Acceptable cost for the
  typical class hierarchy depth.
- `collect_body_folds` (`tcl-lsp-core/src/folding.rs`) — same shape:
  bundled three invariant references and two accumulators into a new
  `FoldCtx<'_>`.  Top-level call site builds the ctx once and passes
  it forward.

Net: 2 `too_many_arguments` allows removed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1962 tests pass)

## Follow-up

Phase 2 chunks B (`implicit_hasher`, ~33), C (`struct_excessive_bools`,
~10), and D (`too_many_lines`, ~30) remain.  Each is independently
shippable and doesn't block the C41 override-flip graduation point.

https://claude.ai/code/session_01R5rCYTwFeXcseqJNsxUJQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5rCYTwFeXcseqJNsxUJQz)_