### PR TITLE
Implement Tcl 9 expression semantics and fixes

### DIFF
--- a/core/compiler/cfg.py
+++ b/core/compiler/cfg.py
@@ -842,6 +842,13 @@ class _CFGBuilder:
                     # so that SSA/SCCP doesn't propagate stale pre-catch
                     # constants past the catch (an exception can leave
                     # variables partially modified).
+                    # Preserve ``stmt.tokens`` on the synthetic IRCall so
+                    # the codegen's eval-fallback can detect the braced
+                    # body word and re-wrap it in ``{…}`` when
+                    # reconstructing the script for ``tcl_eval``.
+                    # Without this, ``catch {$undef} msg`` becomes
+                    # ``catch $undef msg`` at runtime and the var-read
+                    # trap fires before catch can intercept it.
                     catch_defs: list[str] = _defs_from_ir_script(stmt.body)
                     if stmt.result_var:
                         catch_defs.append(stmt.result_var)
@@ -854,6 +861,7 @@ class _CFGBuilder:
                             canonical_command="::catch",
                             args=stmt.raw_args,
                             defs=tuple(dict.fromkeys(catch_defs)),
+                            tokens=stmt.tokens,
                         )
                     )
                 case IRTry():

--- a/core/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/core/compiler/codegen/wasm/_emitter/_expressions.py
@@ -970,8 +970,20 @@ class _WasmEmitterExprMixin(_Base):
         except ValueError:
             try:
                 float_val = float(value)
-                self._emit_i64_const(int(float_val))
-            except ValueError:
+                # Reject non-finite floats (``NaN`` / ``Inf``) — the
+                # i64 expression pipeline can't represent them.
+                # Falling through to ``int(float_val)`` would
+                # raise ``OverflowError`` on infinities; a 0
+                # placeholder lets the surrounding op fire its
+                # own non-numeric / domain-error diagnostic when
+                # it reaches the operand at runtime.
+                import math
+
+                if math.isfinite(float_val):
+                    self._emit_i64_const(int(float_val))
+                else:
+                    self._emit_i64_const(0)
+            except (ValueError, OverflowError):
                 # String literal in expr context — no meaningful integer value
                 self._emit_i64_const(0)
 

--- a/core/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/core/compiler/codegen/wasm/_emitter/_expressions.py
@@ -17,6 +17,7 @@ from ....expr_ast import (
     ExprCommand,
     ExprLiteral,
     ExprNode,
+    ExprRaw,
     ExprString,
     ExprTernary,
     ExprUnary,
@@ -105,8 +106,29 @@ class _WasmEmitterExprMixin(_Base):
             case ExprString(text=text):
                 # Quoted string in expr context — try numeric parse
                 self._emit_literal(text)
+            case ExprRaw(text=text):
+                # ``ExprRaw`` carries an unparsed expr operand
+                # (e.g. ``\\"X\\"`` from ``[expr \\"X\\"]`` inside an
+                # outer ``"..."`` quote).  Apply backslash subst
+                # to recover the post-substitution source the
+                # interpreter would see, then route through the
+                # runtime ``tcl_eval_expr_str`` helper so the
+                # inner content gets parsed as an expression.
+                # Without this branch the catch-all below emits a
+                # silent ``i64.const 0`` and the test reports ``0``.
+                eval_idx = self._shared_imports.get("tcl_eval_expr_str")
+                if eval_idx is not None:
+                    substituted = _tcl_backslash_subst(text)
+                    offset = self._intern_string(substituted)
+                    encoded = substituted.encode("utf-8", errors="surrogatepass")
+                    self._emit_i32_const(offset + 4)
+                    self._emit_i32_const(len(encoded))
+                    self._emit_call(eval_idx)
+                    self._emit_unbox_int()
+                else:
+                    self._emit_i64_const(0)
             case _:
-                # Fallback for unsupported expression types (ExprRaw)
+                # Fallback for unsupported expression types
                 self._emit_i64_const(0)
 
     # --- Float-aware arithmetic path ---
@@ -1190,6 +1212,32 @@ class _WasmEmitterExprMixin(_Base):
                 # $m] {…}`` compared ``"[llength $m]"`` (the
                 # literal string) against each arm's pattern and
                 # always fell through to the ``default`` branch.
+                #
+                # When the text contains a backslash escape that
+                # produces an expr-grammar token (a quoted string
+                # literal ``\"…\"`` is the most common case from
+                # ``[expr \"…\"]`` inside an outer ``"…"`` quote),
+                # route through the runtime ``tcl_eval_expr_str``
+                # helper so the inner content gets parsed as an
+                # expression rather than emitted as the raw byte
+                # sequence.  ``_emit_value`` would dquote-subst
+                # ``\"`` to ``"`` and then emit the literal 6-byte
+                # string ``"0005"`` — Tcl 9 instead expects expr
+                # to *parse* that string and shimmer the result
+                # to a number (``5``).
+                if "\\" in text:
+                    eval_idx = self._shared_imports.get("tcl_eval_expr_str")
+                    if eval_idx is not None:
+                        # Apply backslash substitution to recover
+                        # the post-substitution expr source the
+                        # interpreter would see.
+                        substituted = _tcl_backslash_subst(text)
+                        offset = self._intern_string(substituted)
+                        encoded = substituted.encode("utf-8", errors="surrogatepass")
+                        self._emit_i32_const(offset + 4)
+                        self._emit_i32_const(len(encoded))
+                        self._emit_call(eval_idx)
+                        return
                 self._emit_value(text)
                 return
             case ExprLiteral(text=text):

--- a/core/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/core/compiler/codegen/wasm/_emitter/_expressions.py
@@ -519,6 +519,20 @@ class _WasmEmitterExprMixin(_Base):
         new_int_idx = self._shared_imports.get("tcl_obj_new_int")
         new_float_idx = self._shared_imports.get("tcl_obj_new_float")
         new_str_idx = self._shared_imports.get("tcl_obj_new_string")
+        # Strip outer braces / double-quotes that the expr parser
+        # left on the value.  ``ExprString(text='{-0x1234}')``
+        # carries the source spelling verbatim; the numeric
+        # detection below needs the unwrapped inner content.
+        # Quoted values get backslash subst applied so escapes
+        # like ``\n`` collapse before we try the int / float
+        # parse.
+        if len(value) >= 2:
+            if value[0] == "{" and value[-1] == "}":
+                value = value[1:-1]
+            elif value[0] == '"' and value[-1] == '"':
+                value = value[1:-1]
+                if "\\" in value:
+                    value = _tcl_backslash_subst(value)
         is_integer_literal = False
         try:
             int_val = int(value, 0) if not value.lstrip("+-").isdigit() else int(value)

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -1415,11 +1415,7 @@ class _WasmEmitterStmtMixin(_Base):
                 # this the runtime raises ``can't read "X(Y)": no
                 # such variable`` against the literal scalar.
                 cmd_emit = command
-                if (
-                    command.startswith("${")
-                    and command.endswith("}")
-                    and "(" in command
-                ):
+                if command.startswith("${") and command.endswith("}") and "(" in command:
                     inner = command[2:-1]
                     if inner.endswith(")") and "(" in inner:
                         cmd_emit = "$" + inner

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -1401,7 +1401,29 @@ class _WasmEmitterStmtMixin(_Base):
                         return False
                     return not tokens.single_token_word[tok_idx]
 
-                parts = [command]
+                # ``command`` arrives in canonical-var form when the
+                # user wrote a dollar substitution at the command
+                # position (``$Verify($option)`` → IRCall.command =
+                # ``${Verify($option)}``).  Reference Tcl's ``${name}``
+                # syntax does *not* support array element references
+                # — ``${arr(key)}`` looks up a SCALAR variable named
+                # literally ``arr(key)``.  When ``command`` looks
+                # like ``${X(Y)}`` we know the user intended the
+                # array form ``$X(Y)``; emit that so the interpreter
+                # parses it as an array element substitution and
+                # recursively substitutes the index span.  Without
+                # this the runtime raises ``can't read "X(Y)": no
+                # such variable`` against the literal scalar.
+                cmd_emit = command
+                if (
+                    command.startswith("${")
+                    and command.endswith("}")
+                    and "(" in command
+                ):
+                    inner = command[2:-1]
+                    if inner.endswith(")") and "(" in inner:
+                        cmd_emit = "$" + inner
+                parts = [cmd_emit]
                 for i, a in enumerate(args):
                     if _arg_was_braced(i):
                         # Braced token — IR holds the literal content

--- a/core/compiler/codegen/wasm/_emitter/_values.py
+++ b/core/compiler/codegen/wasm/_emitter/_values.py
@@ -987,6 +987,19 @@ class _WasmEmitterValuesMixin(_Base):
 
         try:
             int_val = int(value)
+            # Folding to ``int_val`` only round-trips the original
+            # source string when ``str(int_val)`` matches *value*.
+            # ``set arg 0005`` keeps the source ``0005`` (so
+            # ``string length $arg`` returns 4 and ``puts $arg``
+            # prints ``0005``); folding eagerly to ``5`` destroys
+            # the leading zeros.  Tcl shimmers values to int
+            # lazily — when used in arithmetic — but preserves the
+            # source string repr otherwise.  Same rule for
+            # ``+5`` / ``  5``: anything that doesn't already
+            # look like the canonical decimal output of
+            # ``str(int_val)`` falls through to the string path.
+            if str(int_val) != value:
+                raise ValueError("non-canonical integer literal")
             # Tcl 9 BigInt literal — fall through to the string path
             # so the runtime preserves the source bytes.  ``i64.const``
             # would saturate (or be rejected by wasmtime entirely) and

--- a/core/compiler/codegen/wasm/_emitter/_variables.py
+++ b/core/compiler/codegen/wasm/_emitter/_variables.py
@@ -258,6 +258,39 @@ class _WasmEmitterVarMixin(_Base):
         if name in self._params:
             self._emit_local_get(idx)
             return
+        # Read the WASM-local mirror; when it's null, probe the
+        # runtime frame before raising.  A callee that did
+        # ``uplevel N set <name> ...`` writes through the
+        # interpreter's ``var_set`` to the *frame* table, not the
+        # WASM-local mirror — so a same-name read here would
+        # otherwise raise even though the variable now exists at
+        # the runtime level.  Falls back to the original null-check
+        # path when ``tcl_local_get`` isn't imported.
+        lget_lenient = self._shared_imports.get("tcl_local_get")
+        unset_err_idx = self._shared_imports.get("tcl_var_unset_error")
+        if lget_lenient is not None and unset_err_idx is not None:
+            if self._var_unset_check_scratch is None:
+                self._var_unset_check_scratch = self._add_extra_local(
+                    prefix="_var_check", val_type=ValType.I32
+                )
+            tmp = self._var_unset_check_scratch
+            self._emit_local_get(idx)
+            self._emit_local_tee(tmp)
+            self._emit(WasmOp.I32_EQZ)
+            self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+            # WASM-local is null: probe the runtime frame in case
+            # an uplevel/upvar populated this slot.
+            self._emit_obj_literal(name)
+            self._emit_call(lget_lenient)
+            self._emit_local_tee(tmp)
+            self._emit(WasmOp.I32_EQZ)
+            self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+            self._emit_obj_literal(name)
+            self._emit_call(unset_err_idx)
+            self._emit(WasmOp.END)
+            self._emit(WasmOp.END)
+            self._emit_local_get(tmp)
+            return
         self._emit_local_get(idx)
         if not self._emit_unset_check_with_alias(name):
             # Runtime helper unavailable — leave the read as plain

--- a/core/compiler/codegen/wasm/_emitter/cmds/array_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/array_.py
@@ -58,11 +58,27 @@ def _emit_array_subcmd_value(emitter, args: tuple[str, ...]) -> None:
         emitter._emit_array_set_list(args[1], args[2])
         return
     elif subcmd == "get" and len(args) >= 2:
-        # ``array get arr`` — return a flat {key val key val ...}
-        # list.  Not implemented in the compiled runtime yet; fall
-        # back to tcl_eval so the interpreter handles it (returns
-        # empty for now, which degrades rather than mis-computes).
-        pass
+        # ``array get arr ?pattern?`` — return a flat ``{k v k v
+        # …}`` list, optionally glob-filtered.  Routed through
+        # ``tcl_array_get_all`` so the array-name resolution uses
+        # the same compile-time-emitted name path as the
+        # ``array set`` / ``array names`` / ``array exists``
+        # siblings.  Without this, ``array get`` fell into the
+        # eval-fallback whose ``frame_resolve_array_name`` builds
+        # a synthetic ``::__local::<depth>::arr`` lookup key — but
+        # the AOT writer side stores under the bare unqualified
+        # name, so the two halves of the read look at different
+        # directory entries and ``[array get arr]`` always came
+        # back empty inside a proc.
+        fidx = emitter._shared_imports.get("tcl_array_get_all")
+        if fidx is not None:
+            emitter._emit_array_name_obj(args[1])
+            if len(args) >= 3:
+                emitter._emit_value(args[2])
+            else:
+                emitter._emit_i32_const(0)
+            emitter._emit_call(fidx)
+            return
     emitter._emit_eval_fallback("array", args)
 
 

--- a/core/compiler/codegen/wasm/_emitter/cmds/info_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/info_.py
@@ -169,7 +169,17 @@ def _emit_info_value(emitter, args: tuple[str, ...]) -> None:
         # land through _emit_var_write_obj.
         idx = emitter._local_index.get(resolved)
         if idx is None:
-            # Never referenced — always non-existent.  Emit boxed 0.
+            # Never referenced through the static-name path — but
+            # a callee might still have written this name into the
+            # frame via ``uplevel N set <name> ...`` from an inner
+            # proc.  Dispatch through the runtime helper which
+            # probes the frame table; falls back to a boxed 0 only
+            # when the helper is unavailable.
+            info_exists_idx = emitter._shared_imports.get("tcl_info_exists")
+            if info_exists_idx is not None:
+                emitter._emit_obj_literal(resolved)
+                emitter._emit_call(info_exists_idx)
+                return
             emitter._emit_i64_const(0)
             emitter._emit_box_int()
             return

--- a/core/compiler/codegen/wasm/_emitter/cmds/list_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/list_.py
@@ -108,7 +108,16 @@ def _emit_list_value(emitter, args: tuple[str, ...]) -> None:
     runtime value they hold, changing semantics).
     """
     if not args:
-        emitter._emit_i32_const(0)
+        # ``[list]`` with no args produces the empty list — an
+        # *empty-string* TclObj, NOT the null handle.  Emitting
+        # ``i32_const(0)`` (null) made downstream ``set valid
+        # [list]`` store a null pointer, which the var-read path
+        # interprets as "variable unset" and traps with
+        # ``can't read "valid"`` — breaking tcltest's
+        # ``AcceptVerbose`` (and any user code following the
+        # idiomatic ``set xs [list]; foreach … { lappend xs … }``
+        # pattern with an empty seed).
+        emitter._emit_obj_literal("")
         return
     # Fast path: all literals → compile-time string.
     # _tcl_token_value expands each source token to its VALUE (strips

--- a/core/compiler/codegen/wasm/_emitter/cmds/uplevel_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/uplevel_.py
@@ -178,21 +178,19 @@ def _emit_cmd_uplevel(emitter, args: tuple[str, ...]) -> None:
     if not args:
         emitter._emit_i32_const(0)
         return
-    # Parse the level specifier.  ``#0`` → absolute 0 which clamps
-    # to global; a bare integer N → relative N; anything else means
+    # Parse the level specifier.  ``#N`` → absolute level N; a
+    # bare integer N → relative N frames up; anything else means
     # no level, default 1, and args[0] is the first body word.
     level_spec = args[0]
     up: int
     body_start = 1
+    use_abs = False
+    abs_level: int = 0
     if level_spec.startswith("#"):
         try:
             abs_level = int(level_spec[1:])
-            # "#N means N frames above global".  We approximate by
-            # stashing all the way to that absolute depth; frame_depth_stash
-            # subtracts, so ``up`` is (current_depth - abs_level), which
-            # we can't know at compile time.  For the common #0 case
-            # we stash "all the way" by passing a large relative shift.
-            up = 0 if abs_level == 0 else 1
+            use_abs = True
+            up = 0
         except ValueError:
             up = 1
     else:
@@ -211,6 +209,7 @@ def _emit_cmd_uplevel(emitter, args: tuple[str, ...]) -> None:
 
     eval_idx = emitter._shared_imports.get("tcl_eval")
     stash_idx = emitter._shared_imports.get("tcl_frame_depth_stash")
+    stash_abs_idx = emitter._shared_imports.get("tcl_frame_depth_stash_abs")
     restore_idx = emitter._shared_imports.get("tcl_frame_depth_restore")
     if eval_idx is None or stash_idx is None or restore_idx is None:
         # Missing runtime helpers — fall back to plain eval, which
@@ -223,9 +222,6 @@ def _emit_cmd_uplevel(emitter, args: tuple[str, ...]) -> None:
             emitter._emit_i32_const(0)
         return
 
-    # For ``#0`` we pass a large shift (INT32_MAX / 2) so
-    # frame_depth_stash clamps to zero regardless of the actual depth.
-    shift = 0x3FFF_FFFF if level_spec == "#0" else up
     saved_local = emitter._add_extra_local(prefix="_uplevel_saved", val_type=ValType.I32)
     body_local = emitter._add_extra_local(prefix="_uplevel_body", val_type=ValType.I32)
 
@@ -235,8 +231,23 @@ def _emit_cmd_uplevel(emitter, args: tuple[str, ...]) -> None:
     emitter._emit_uplevel_body(body_parts)
     emitter._emit_local_set(body_local)
 
-    emitter._emit_i32_const(shift)
-    emitter._emit_call(stash_idx)
+    # Choose the right stash variant.  ``#N`` is an *absolute*
+    # level — only resolvable at runtime (relative shift depends on
+    # the current call depth).  ``frame_depth_stash_abs`` does the
+    # ``frame_depth - abs_level`` arithmetic on the runtime side
+    # and routes through the relative path.  Bare integer ``N``
+    # uses the simple relative stash.
+    if use_abs and stash_abs_idx is not None:
+        emitter._emit_i32_const(abs_level)
+        emitter._emit_call(stash_abs_idx)
+    else:
+        # Fallback: ``#0`` gets the legacy "shift to zero" hack
+        # via INT32_MAX/2; other ``#N`` values without the abs
+        # helper degrade to relative-1 which matches the previous
+        # behaviour.
+        shift = 0x3FFF_FFFF if level_spec == "#0" else up
+        emitter._emit_i32_const(shift)
+        emitter._emit_call(stash_idx)
     emitter._emit_local_set(saved_local)
 
     emitter._emit_local_get(body_local)

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -350,6 +350,16 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
     "tcl_flow_check_signal_loop": ("tcl", "flow_check_signal_loop", [], [ValType.I32]),
     # Interpreter fallback — every eval-path command routes through this.
     "tcl_eval": ("tcl", "tcl_eval", [ValType.I32], [ValType.I32]),
+    # Runtime expression-source evaluator — used by the codegen's
+    # ``ExprRaw`` path when an operand needs re-parsing as expr
+    # source (e.g. backslash-substituted ``\\"…\\"`` from
+    # ``[expr \\"X\\"]`` inside an outer ``"…"``).
+    "tcl_eval_expr_str": (
+        "tcl",
+        "tcl_eval_expr_str",
+        [ValType.I32, ValType.I32],
+        [ValType.I32],
+    ),
     # Namespace context for eval-fallback calls — compiled procs set the
     # current namespace before ``tcl_eval`` so dynamic ``proc $name`` /
     # ``variable $name`` inside the fallback qualify into the enclosing

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -514,6 +514,12 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
         [ValType.I32],
     ),
     "tcl_array_get": ("tcl", "array_get", [ValType.I32, ValType.I32], [ValType.I32]),
+    "tcl_array_get_all": (
+        "tcl",
+        "array_get_all",
+        [ValType.I32, ValType.I32],
+        [ValType.I32],
+    ),
     "tcl_array_exists": ("tcl", "array_exists", [ValType.I32], [ValType.I32]),
     "tcl_array_element_exists": (
         "tcl",

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -360,6 +360,19 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
         [ValType.I32, ValType.I32],
         [ValType.I32],
     ),
+    # AOT strict logical-NOT — validates the operand is a
+    # boolean (numeric or yes/no/true/false/on/off keyword),
+    # raises ``cannot use non-numeric string "X" as operand of
+    # "!"`` otherwise.  Used by ``UnaryOp.NOT`` in
+    # ``_emit_unary`` so ``expr {!$v}`` for a non-boolean
+    # ``$v`` errors instead of silently coercing through
+    # ``obj_get_int``.
+    "tcl_expr_lnot": (
+        "tcl",
+        "tcl_expr_lnot",
+        [ValType.I32],
+        [ValType.I32],
+    ),
     # Namespace context for eval-fallback calls — compiled procs set the
     # current namespace before ``tcl_eval`` so dynamic ``proc $name`` /
     # ``variable $name`` inside the fallback qualify into the enclosing

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -502,6 +502,12 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
         [ValType.I32],
         [ValType.I32],
     ),
+    "tcl_frame_depth_stash_abs": (
+        "tcl",
+        "frame_depth_stash_abs",
+        [ValType.I32],
+        [ValType.I32],
+    ),
     "tcl_frame_depth_restore": ("tcl", "frame_depth_restore", [ValType.I32], []),
     # Arrays — dedicated per-array hash tables.  ``array`` subcommands
     # are spec-owned but the helpers the codegen calls are shared

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -18,6 +18,7 @@ from ...expr_ast import (
     ExprBinary,
     ExprCall,
     ExprCommand,
+    ExprRaw,
     ExprTernary,
     ExprUnary,
     ExprVar,
@@ -656,6 +657,19 @@ def _scan_needed_imports(
         match expr:
             case ExprCommand(text=text):
                 _scan_text_for_cmd_subst(text, needed)
+            case ExprRaw(text=text):
+                # ``ExprRaw`` carries unparsed expr operand text
+                # (e.g. ``\"X\"`` from ``[expr \"X\"]`` inside an
+                # outer ``"..."``).  When the text contains a
+                # backslash escape, the codegen routes through
+                # ``tcl_eval_expr_str`` so the inner content is
+                # parsed as expression source rather than a
+                # literal value.  Pull the import in only when the
+                # raw text actually needs it; pure-arith modules
+                # never trigger this branch and keep their
+                # minimal-import contract intact.
+                if "\\" in text:
+                    needed.add("tcl_eval_expr_str")
             case ExprVar(name=name, text=text):
                 # ``$::ns::var`` in an expression reads from the global
                 # table; ``$arr(key)`` reads via tcl_array_get.
@@ -1225,8 +1239,6 @@ def _scan_needed_imports(
     # that keeps ``::top`` writes visible to eval fallbacks.
     needed.add("tcl_error")
     needed.add("tcl_eval")
-    needed.add("tcl_eval_expr_str")
-    needed.add("tcl_expr_lnot")
     needed.add("tcl_ns_set")
     needed.add("tcl_ns_restore")
     needed.add("tcl_diag_set")

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -541,6 +541,10 @@ def _scan_text_for_cmd_subst(text: str, needed: set[str]) -> None:
                         # degrading to a raw literal (which would
                         # disable the glob filter).
                         needed.add("tcl_append")
+                    elif sub == "get":
+                        # ``array get arr ?pat?`` — see ``names``.
+                        needed.add("tcl_array_get_all")
+                        needed.add("tcl_append")
                     elif sub == "set":
                         needed.add("tcl_array_set")
                     elif sub == "get":

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1226,6 +1226,7 @@ def _scan_needed_imports(
     needed.add("tcl_error")
     needed.add("tcl_eval")
     needed.add("tcl_eval_expr_str")
+    needed.add("tcl_expr_lnot")
     needed.add("tcl_ns_set")
     needed.add("tcl_ns_restore")
     needed.add("tcl_diag_set")

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1225,6 +1225,7 @@ def _scan_needed_imports(
     # that keeps ``::top`` writes visible to eval fallbacks.
     needed.add("tcl_error")
     needed.add("tcl_eval")
+    needed.add("tcl_eval_expr_str")
     needed.add("tcl_ns_set")
     needed.add("tcl_ns_restore")
     needed.add("tcl_diag_set")

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -549,8 +549,6 @@ def _scan_text_for_cmd_subst(text: str, needed: set[str]) -> None:
                         needed.add("tcl_append")
                     elif sub == "set":
                         needed.add("tcl_array_set")
-                    elif sub == "get":
-                        needed.add("tcl_array_get")
                 elif cmd == "namespace" and len(parts) > 1 and parts[1] == "eval":
                     # ``[namespace eval ns arg1 arg2 ...]`` with dynamic
                     # script args: needs tcl_eval to run the assembled

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -510,6 +510,7 @@ def _scan_text_for_cmd_subst(text: str, needed: set[str]) -> None:
                 elif cmd == "uplevel":
                     needed.add("tcl_eval")
                     needed.add("tcl_frame_depth_stash")
+                    needed.add("tcl_frame_depth_stash_abs")
                     needed.add("tcl_frame_depth_restore")
                 elif cmd == "set" and len(parts) >= 2:
                     # ``[set arr(key)]`` reads through ``tcl_array_get``
@@ -987,6 +988,7 @@ def _scan_needed_imports(
                 elif command == "::uplevel":
                     needed.add("tcl_eval")
                     needed.add("tcl_frame_depth_stash")
+                    needed.add("tcl_frame_depth_stash_abs")
                     needed.add("tcl_frame_depth_restore")
                     # Multi-word bodies concat with spaces; also each body
                     # part is run through _emit_value which may need
@@ -1095,6 +1097,7 @@ def _scan_needed_imports(
                     needed.add("tcl_error_full")
                 elif barrier_cmd == "uplevel":
                     needed.add("tcl_frame_depth_stash")
+                    needed.add("tcl_frame_depth_stash_abs")
                     needed.add("tcl_frame_depth_restore")
                     # The body may contain ``$var``/``[cmd]`` references
                     # that have to be resolved BEFORE eval — scan for

--- a/core/compiler/ir.py
+++ b/core/compiler/ir.py
@@ -306,6 +306,13 @@ class IRCatch:
     result_var: str | None = None
     options_var: str | None = None
     raw_args: tuple[str, ...] = ()
+    # Original parsed tokens (incl. braced/quoted flags).  Threaded
+    # through so the cfg's IRCatch → IRCall lowering can preserve the
+    # ``{...}`` braces around the body when the codegen falls back
+    # to ``tcl_eval``.  Without this, ``catch {$undef} msg`` gets
+    # reconstructed as ``catch $undef msg`` and the unset-var read
+    # fires before catch can intercept it.
+    tokens: CommandTokens | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -1228,6 +1228,7 @@ class _Lowerer:
             result_var=result_var,
             options_var=options_var,
             raw_args=tuple(args),
+            tokens=cmd.cmd_tokens,
         )
 
     def _lower_try(self, cmd: _Command, *, namespace: str) -> IRTry | IRBarrier:

--- a/core/compiler/lowering_hooks/_var.py
+++ b/core/compiler/lowering_hooks/_var.py
@@ -95,6 +95,17 @@ def lower_set(lowerer: _LowererLike, cmd: _Command) -> object | None:
         if tok.type is TokenType.STR:
             return IRAssignConst(range=cmd.range, name=name, value=value)
         const_value = _parse_decimal_int(value) if tok.type is TokenType.ESC else None
+        # Only fold to the parsed numeric form when the source
+        # spelling already matches the canonical decimal form.
+        # ``set arg 0005`` must store ``0005`` verbatim (Tcl
+        # preserves the source string repr — the value only
+        # shimmers to int 5 when used as an integer); folding
+        # eagerly here destroys the leading zeros and breaks
+        # ``puts $arg``, ``string length $arg``, and
+        # ``expr "0005"`` which all care about the original
+        # spelling.
+        if const_value is not None and const_value != value.strip():
+            const_value = None
         if const_value is not None:
             return IRAssignConst(range=cmd.range, name=name, value=const_value)
         if tok.type is TokenType.CMD:

--- a/runtime/zig/cmds/array.zig
+++ b/runtime/zig/cmds/array.zig
@@ -52,8 +52,14 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
     const obj_mod = @import("../valtypes/tcl_obj.zig");
     defer if (resolved_name != words[2]) obj_mod.tcl_obj_release(resolved_name);
     if (str_eq(sp, sub.len, "get")) {
-        if (words.len >= 4) return result_mod.from_globals(array_mod.array_get(resolved_name, words[3]));
-        return result_mod.from_globals(array_mod.array_get(resolved_name, obj_new_string(0, 0)));
+        // ``array get arrName ?pattern?`` — returns the whole array as a
+        // flat ``{k v k v …}`` list.  ``words[3]`` is an optional glob
+        // *pattern* (filter) — *not* an element key.  Earlier wiring
+        // misused ``array_get`` (single-element lookup) here, which
+        // matched only the empty-string element and produced an empty
+        // result for every well-formed array.
+        const pat: i32 = if (words.len >= 4) words[3] else 0;
+        return result_mod.from_globals(array_mod.array_get_all(resolved_name, pat));
     }
     if (str_eq(sp, sub.len, "set") and words.len >= 4) {
         // ``array set arr pairlist`` — payload is a flat

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -26,6 +26,8 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
     const ReturnCode = enum { ok, err, ret, brk, cont };
     var code_kind: ReturnCode = .ok;
     var extra_levels: u32 = 0;
+    var level_explicit: bool = false;
+    var level_value: u32 = 1;
     var result_obj: i32 = 0;
     var wi: u32 = 1;
     while (wi < words.len) : (wi += 1) {
@@ -79,6 +81,12 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
                 if (str_eq(wp, w.len, "-level") and wi + 1 < words.len) {
                     // ``-level N`` adds (N-1) extra unwind levels on
                     // top of the implicit "exit this proc".
+                    // ``-level 0`` is special — it suppresses the implicit
+                    // unwind so ``return -level 0 X`` produces TCL_OK
+                    // with value X *without* exiting the surrounding
+                    // proc (used by ``lmap``/``foreach`` body sentinels
+                    // and by anything that wants the formal return-value
+                    // machinery without actually returning).
                     const lev = obj_ensure_string(words[wi + 1]);
                     if (lev.len >= 1) {
                         const lp: [*]const u8 = @ptrFromInt(lev.ptr);
@@ -88,8 +96,14 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
                             if (lp[k] < '0' or lp[k] > '9') { ok = false; break; }
                             nv = nv * 10 + @as(u32, @intCast(lp[k] - '0'));
                         }
-                        if (ok and nv > 0) {
-                            extra_levels = nv - 1;
+                        if (ok) {
+                            level_explicit = true;
+                            level_value = nv;
+                            if (nv > 0) {
+                                extra_levels = nv - 1;
+                            } else {
+                                extra_levels = 0;
+                            }
                         }
                     }
                     wi += 1;
@@ -135,6 +149,26 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
         // Suppress "unused .brk/.cont arm" while we leave the full
         // wire-up for the follow-up that adds the codegen-side
         // per-statement probes.
+    }
+    // ``return -level 0 …`` is the no-unwind form: the command
+    // produces the value with the requested status code but the
+    // current frame keeps running.  ``return -level 0 X`` is exactly
+    // ``set _ X`` for OK status (lmap-1.2a, opt-10.x).  Other status
+    // codes route directly to the matching break/continue/return
+    // flag.
+    if (level_explicit and level_value == 0) {
+        switch (code_kind) {
+            .ok => return result_mod.from_globals(result_obj),
+            .brk => {
+                result_mod.set_break();
+                return result_mod.from_globals(0);
+            },
+            .cont => {
+                result_mod.set_continue();
+                return result_mod.from_globals(0);
+            },
+            .ret, .err => {},
+        }
     }
     // MM-B.5: ``return_val`` slot holds the value until
     // ``eval_proc_call_bucket`` reads it back.  Retain so ``MM-B.4``'s

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -116,12 +116,72 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                 return result_mod.from_globals(0);
             }
             if (sp6[0] == 'i' and sp6[1] == 'm' and sp6[2] == 'p' and sp6[3] == 'o' and sp6[4] == 'r' and sp6[5] == 't') {
+                const catch_mod = @import("../interp/tcl_catch.zig");
                 var ii: u32 = 2;
                 while (ii < words.len) : (ii += 1) {
                     const is = obj_ensure_string(words[ii]);
                     if (is.len == 6 and is.ptr != 0) {
                         const isp: [*]const u8 = @ptrFromInt(is.ptr);
                         if (isp[0] == '-' and isp[1] == 'f' and isp[2] == 'o' and isp[3] == 'r' and isp[4] == 'c' and isp[5] == 'e') continue;
+                    }
+                    // Validate the import pattern.  Reference Tcl 9
+                    // raises specific diagnostics for two
+                    // user-visible misuses (namespace-9.1 / 9.2):
+                    //   * empty pattern → ``empty import pattern``
+                    //   * pattern names a namespace that doesn't
+                    //     exist → ``unknown namespace in import
+                    //     pattern "<pat>"``.
+                    if (is.len == 0) {
+                        const msg_text: []const u8 = "empty import pattern";
+                        const buf2 = alloc(@intCast(msg_text.len));
+                        const dst: [*]u8 = @ptrFromInt(buf2);
+                        for (msg_text, 0..) |b, k| dst[k] = b;
+                        const msg = obj_mod.obj_new_string_take(buf2, @intCast(msg_text.len), @intCast(msg_text.len));
+                        catch_mod.tcl_cmd_error(msg);
+                        return result_mod.from_globals(0);
+                    }
+                    // Locate the source namespace half of the
+                    // pattern and verify it exists.  Bare names
+                    // (no ``::``) are treated as patterns within
+                    // the current namespace, which always exists,
+                    // so the unknown-ns check only fires when the
+                    // pattern is qualified.
+                    const isp2: [*]const u8 = @ptrFromInt(is.ptr);
+                    var last_sep: i32 = -1;
+                    var k: u32 = 0;
+                    while (k + 1 < is.len) : (k += 1) {
+                        if (isp2[k] == ':' and isp2[k + 1] == ':') {
+                            last_sep = @intCast(k);
+                            k += 1; // skip second colon; loop adds the third increment
+                        }
+                    }
+                    if (last_sep >= 0) {
+                        const sep_at: u32 = @intCast(last_sep);
+                        // Source ns is the bytes up to (and not
+                        // including) the trailing ``::`` separator.
+                        // ``::pat`` (last_sep == 0) means the
+                        // pattern is anchored at root, which always
+                        // exists.
+                        if (sep_at > 0) {
+                            const src_ns_ptr = is.ptr;
+                            const src_ns_len = sep_at;
+                            const target = resolve_ns(src_ns_ptr, src_ns_len);
+                            if (target == 0) {
+                                const prefix: []const u8 = "unknown namespace in import pattern \"";
+                                const suffix: []const u8 = "\"";
+                                const total: u32 = @as(u32, @intCast(prefix.len)) + is.len + @as(u32, @intCast(suffix.len));
+                                const buf2 = alloc(total);
+                                const dst: [*]u8 = @ptrFromInt(buf2);
+                                var off2: u32 = 0;
+                                for (prefix) |b| { dst[off2] = b; off2 += 1; }
+                                const ip: [*]const u8 = @ptrFromInt(is.ptr);
+                                for (0..is.len) |kk| { dst[off2] = ip[kk]; off2 += 1; }
+                                for (suffix) |b| { dst[off2] = b; off2 += 1; }
+                                const msg = obj_mod.obj_new_string_take(buf2, total, total);
+                                catch_mod.tcl_cmd_error(msg);
+                                return result_mod.from_globals(0);
+                            }
+                        }
                     }
                     const created = tcl_ns.ns_import(tcl_ns.ns_current(), is.ptr, is.len);
                     var bk: u32 = 0;

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -134,6 +134,10 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                     if (is.len == 0) {
                         const msg_text: []const u8 = "empty import pattern";
                         const buf2 = alloc(@intCast(msg_text.len));
+                        if (buf2 == 0) {
+                            catch_mod.tcl_cmd_error(obj_mod.obj_new_string(0, 0));
+                            return result_mod.from_globals(0);
+                        }
                         const dst: [*]u8 = @ptrFromInt(buf2);
                         for (msg_text, 0..) |b, k| dst[k] = b;
                         const msg = obj_mod.obj_new_string_take(buf2, @intCast(msg_text.len), @intCast(msg_text.len));
@@ -171,6 +175,10 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                                 const suffix: []const u8 = "\"";
                                 const total: u32 = @as(u32, @intCast(prefix.len)) + is.len + @as(u32, @intCast(suffix.len));
                                 const buf2 = alloc(total);
+                                if (buf2 == 0) {
+                                    catch_mod.tcl_cmd_error(obj_mod.obj_new_string(0, 0));
+                                    return result_mod.from_globals(0);
+                                }
                                 const dst: [*]u8 = @ptrFromInt(buf2);
                                 var off2: u32 = 0;
                                 for (prefix) |b| { dst[off2] = b; off2 += 1; }
@@ -433,19 +441,27 @@ fn ns_children(ns_handle: u32, pat_ptr: u32, pat_len: u32) i32 {
             const sep_len: u32 = if (ns_root_only) 0 else 2;
             const prefixed_total: u32 = ns_full.len + sep_len + pat_len;
             const prefixed_buf_addr = alloc(prefixed_total);
-            const pbuf: [*]u8 = @ptrFromInt(prefixed_buf_addr);
-            const ns_p: [*]const u8 = @ptrFromInt(ns_full.ptr);
-            var off2: u32 = 0;
-            for (0..ns_full.len) |k| { pbuf[off2] = ns_p[k]; off2 += 1; }
-            if (!ns_root_only) {
-                pbuf[off2] = ':'; off2 += 1;
-                pbuf[off2] = ':'; off2 += 1;
+            if (prefixed_buf_addr != 0) {
+                const pbuf: [*]u8 = @ptrFromInt(prefixed_buf_addr);
+                const ns_p: [*]const u8 = @ptrFromInt(ns_full.ptr);
+                var off2: u32 = 0;
+                for (0..ns_full.len) |k| { pbuf[off2] = ns_p[k]; off2 += 1; }
+                if (!ns_root_only) {
+                    pbuf[off2] = ':'; off2 += 1;
+                    pbuf[off2] = ':'; off2 += 1;
+                }
+                for (0..pat_len) |k| { pbuf[off2] = psp[k]; off2 += 1; }
+                eff_pat_ptr = prefixed_buf_addr;
+                eff_pat_len = prefixed_total;
             }
-            for (0..pat_len) |k| { pbuf[off2] = psp[k]; off2 += 1; }
-            eff_pat_ptr = prefixed_buf_addr;
-            eff_pat_len = prefixed_total;
         }
     }
+    // Free the prefixed pattern buffer (if we allocated one) once
+    // both passes finish.  ``defer`` keeps the cleanup paired with
+    // the alloc so accidental early returns don't leak.
+    defer if (eff_pat_ptr != pat_ptr and eff_pat_ptr != 0) {
+        obj_mod.free_sized(eff_pat_ptr, eff_pat_len);
+    };
 
     const bucket_size: u32 = tcl_ns.NS_BUCKET_SIZE;
     // Two-pass: size then fill.

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -19,6 +19,33 @@ const obj_ensure_string   = rt.obj_ensure_string;
 const obj_new_int         = rt.obj_new_int;
 const obj_get_int         = rt.obj_get_int;
 
+/// Walk *name* (a relative ``::``-separated namespace path) starting
+/// from *parent* and create each missing component.  Used by
+/// ``namespace eval`` for unqualified targets so ``namespace eval
+/// foo {…}`` inside a ``::a::`` body creates ``::a::foo`` rather
+/// than ``::foo`` under the root.
+fn ns_create_relative(parent: u32, name_ptr: u32, name_len: u32) u32 {
+    if (name_len == 0) return parent;
+    // Defensive: when the current ns hasn't been initialised yet
+    // (early bootstrap, or top-level eval without a frame),
+    // fall back to the root so we don't dereference a null
+    // ns pointer in ``ns_create``.
+    var ns: u32 = if (parent == 0) tcl_ns.ns_root() else parent;
+    const src: [*]const u8 = @ptrFromInt(name_ptr);
+    var i: u32 = 0;
+    while (i < name_len) {
+        var j: u32 = i;
+        while (j < name_len and src[j] != ':') : (j += 1) {}
+        const comp_len: u32 = j - i;
+        if (comp_len > 0) {
+            ns = tcl_ns.ns_create(ns, name_ptr + i, comp_len);
+        }
+        i = j;
+        while (i < name_len and src[i] == ':') : (i += 1) {}
+    }
+    return ns;
+}
+
 fn eval_namespace(words: []const i32) result_mod.InterpResult {
     if (words.len >= 2) {
         const interp = @import("../interp/tcl_interp.zig");
@@ -28,7 +55,21 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
             if (sp[0] == 'e' and sp[1] == 'v' and sp[2] == 'a' and sp[3] == 'l') {
                 if (words.len < 4) return result_mod.from_globals(0);
                 const ns_obj_s = obj_ensure_string(words[2]);
-                const target_ns = tcl_ns.ns_create_from_fqn(ns_obj_s.ptr, ns_obj_s.len);
+                // Resolve the namespace name relative to the
+                // *current* namespace when it isn't FQ-anchored.
+                // Tcl 9 semantics: ``namespace eval foo`` inside a
+                // ``::a::`` body creates ``::a::foo`` (a child of the
+                // current ns).  ``namespace eval ::foo`` is absolute
+                // and creates a child of the root.  The previous
+                // wiring always anchored at root, so nested
+                // ``namespace eval`` chains lost the parent ns when
+                // dispatched through a multi-level uplevel chain.
+                const target_ns = if (ns_obj_s.len >= 2
+                    and @as([*]const u8, @ptrFromInt(ns_obj_s.ptr))[0] == ':'
+                    and @as([*]const u8, @ptrFromInt(ns_obj_s.ptr))[1] == ':')
+                    tcl_ns.ns_create_from_fqn(ns_obj_s.ptr, ns_obj_s.len)
+                else
+                    ns_create_relative(tcl_ns.current_ns, ns_obj_s.ptr, ns_obj_s.len);
                 const saved_ns = tcl_ns.current_ns;
                 tcl_ns.current_ns = target_ns;
                 defer tcl_ns.current_ns = saved_ns;
@@ -313,6 +354,39 @@ fn ns_children(ns_handle: u32, pat_ptr: u32, pat_len: u32) i32 {
     const ns: *const tcl_ns.Namespace = @ptrFromInt(ns_handle);
     if (ns.child_table.buf == 0) return obj_new_string(0, 0);
 
+    // Tcl 9 ``namespace children`` matches the pattern against
+    // each child's FULLY-QUALIFIED name.  When the supplied
+    // pattern doesn't already start with ``::`` it is prefixed
+    // with the queried namespace path: ``namespace children
+    // ::a::b foo*`` matches against ``::a::b::foo*``.  Without
+    // this, bare patterns like ``b*`` from inside a nested
+    // namespace would always miss because the children's FQNs
+    // start with ``::``.
+    var eff_pat_ptr: u32 = pat_ptr;
+    var eff_pat_len: u32 = pat_len;
+    if (pat_len > 0) {
+        const psp: [*]const u8 = @ptrFromInt(pat_ptr);
+        const pat_starts_qual = pat_len >= 2 and psp[0] == ':' and psp[1] == ':';
+        if (!pat_starts_qual) {
+            const ns_full = tcl_ns.ns_full_name(ns_handle);
+            const ns_root_only = ns_full.len == 2;
+            const sep_len: u32 = if (ns_root_only) 0 else 2;
+            const prefixed_total: u32 = ns_full.len + sep_len + pat_len;
+            const prefixed_buf_addr = alloc(prefixed_total);
+            const pbuf: [*]u8 = @ptrFromInt(prefixed_buf_addr);
+            const ns_p: [*]const u8 = @ptrFromInt(ns_full.ptr);
+            var off2: u32 = 0;
+            for (0..ns_full.len) |k| { pbuf[off2] = ns_p[k]; off2 += 1; }
+            if (!ns_root_only) {
+                pbuf[off2] = ':'; off2 += 1;
+                pbuf[off2] = ':'; off2 += 1;
+            }
+            for (0..pat_len) |k| { pbuf[off2] = psp[k]; off2 += 1; }
+            eff_pat_ptr = prefixed_buf_addr;
+            eff_pat_len = prefixed_total;
+        }
+    }
+
     const bucket_size: u32 = tcl_ns.NS_BUCKET_SIZE;
     // Two-pass: size then fill.
     var total_bytes: u32 = 0;
@@ -325,7 +399,7 @@ fn ns_children(ns_handle: u32, pat_ptr: u32, pat_len: u32) i32 {
         const child_handle: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
         if (child_handle == 0) continue;
         const fqn = tcl_ns.ns_full_name(child_handle);
-        if (pat_len > 0 and !tcl_string.glob_match(pat_ptr, pat_len, fqn.ptr, fqn.len)) continue;
+        if (eff_pat_len > 0 and !tcl_string.glob_match(eff_pat_ptr, eff_pat_len, fqn.ptr, fqn.len)) continue;
         if (total_bytes > 0) total_bytes += 1; // space
         total_bytes += fqn.len;
         count += 1;
@@ -342,7 +416,7 @@ fn ns_children(ns_handle: u32, pat_ptr: u32, pat_len: u32) i32 {
         const child_handle: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
         if (child_handle == 0) continue;
         const fqn = tcl_ns.ns_full_name(child_handle);
-        if (pat_len > 0 and !tcl_string.glob_match(pat_ptr, pat_len, fqn.ptr, fqn.len)) continue;
+        if (eff_pat_len > 0 and !tcl_string.glob_match(eff_pat_ptr, eff_pat_len, fqn.ptr, fqn.len)) continue;
         if (!first) {
             const d: [*]u8 = @ptrFromInt(buf + off);
             d[0] = ' ';

--- a/runtime/zig/cmds/subst.zig
+++ b/runtime/zig/cmds/subst.zig
@@ -104,6 +104,13 @@ fn eval_expr(words: []const i32) result_mod.InterpResult {
     if (total == 0) return result_mod.from_globals(expr_eval.eval(0, 0));
     const obj_mod = @import("../valtypes/tcl_obj.zig");
     const buf = obj_mod.alloc(total);
+    if (buf == 0) {
+        // Out-of-memory while building the join buffer.  Surface as
+        // a generic error and bail rather than dereferencing a null
+        // address inside ``rt.memcpy`` below.
+        @import("../interp/tcl_catch.zig").tcl_cmd_error(obj_new_string(0, 0));
+        return result_mod.from_globals(0);
+    }
     var off: u32 = 0;
     wi = 1;
     while (wi < words.len) : (wi += 1) {
@@ -116,7 +123,9 @@ fn eval_expr(words: []const i32) result_mod.InterpResult {
             off += 1;
         }
     }
-    return result_mod.from_globals(expr_eval.eval(buf, total));
+    const r = expr_eval.eval(buf, total);
+    obj_mod.free_sized(buf, total);
+    return result_mod.from_globals(r);
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/subst.zig
+++ b/runtime/zig/cmds/subst.zig
@@ -83,20 +83,40 @@ fn eval_subst(words: []const i32) result_mod.InterpResult {
 }
 
 fn eval_expr(words: []const i32) result_mod.InterpResult {
-    if (words.len >= 2) {
-        // Use the bignum-aware evaluator so the runtime ``expr``
-        // command produces the same result as the AOT-compiled
-        // ``expr {...}`` body.  Returns a TclObj directly — no i64
-        // round-trip — so TYPE_BIGNUM results survive intact for
-        // downstream callers (``puts`` / ``set`` / mathop).  Closes
-        // the gap where ``[expr {1 << 70}]`` returned ``1`` (the
-        // legacy ``eval_expr_str`` recursive descent didn't even
-        // recognise ``<<``).
-        const expr_eval = @import("../interp/tcl_expr_eval.zig");
+    if (words.len < 2) return result_mod.from_globals(0);
+    // Tcl ``expr`` concatenates all arguments with spaces and
+    // evaluates the joined string as a single expression.
+    // ``expr 20 - 5 +10 -7`` → ``20 - 5 +10 -7`` → 18.  The
+    // single-arg case takes the simple fast path; anything else
+    // builds a join buffer first.
+    const expr_eval = @import("../interp/tcl_expr_eval.zig");
+    if (words.len == 2) {
         const es = obj_ensure_string(words[1]);
         return result_mod.from_globals(expr_eval.eval(es.ptr, es.len));
     }
-    return result_mod.from_globals(0);
+    var total: u32 = 0;
+    var wi: u32 = 1;
+    while (wi < words.len) : (wi += 1) {
+        const ws = obj_ensure_string(words[wi]);
+        total += ws.len;
+        if (wi + 1 < words.len) total += 1; // separator space
+    }
+    if (total == 0) return result_mod.from_globals(expr_eval.eval(0, 0));
+    const obj_mod = @import("../valtypes/tcl_obj.zig");
+    const buf = obj_mod.alloc(total);
+    var off: u32 = 0;
+    wi = 1;
+    while (wi < words.len) : (wi += 1) {
+        const ws = obj_ensure_string(words[wi]);
+        rt.memcpy(buf + off, ws.ptr, ws.len);
+        off += ws.len;
+        if (wi + 1 < words.len) {
+            const d: [*]u8 = @ptrFromInt(buf + off);
+            d[0] = ' ';
+            off += 1;
+        }
+    }
+    return result_mod.from_globals(expr_eval.eval(buf, total));
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/interp/tcl_expr_eval.zig
+++ b/runtime/zig/interp/tcl_expr_eval.zig
@@ -793,6 +793,77 @@ fn parse_number(s: *State) i32 {
 fn finalize_num(s: *State, start: u32) i32 {
     const slen = s.pos - start;
     const sptr = @intFromPtr(s.src) + start;
+    // Tcl 9 ``expr`` canonicalises numeric literals: ``0005``
+    // collapses to ``5``, ``0x1234`` to ``4660``, ``1.5e2`` to
+    // ``150.0``.  Without this normalisation the returned obj
+    // keeps the source bytes and a top-level ``expr 0005`` prints
+    // the literal spelling instead of the canonical decimal
+    // form.  Detect base-prefixed forms first (``0x`` / ``0o`` /
+    // ``0b``) so hex / octal / binary literals collapse to
+    // their decimal int form; otherwise fall back to the
+    // ``try_parse_int`` / ``try_parse_float`` decimal path.
+    const src: [*]const u8 = @ptrFromInt(sptr);
+    if (slen >= 2 and src[0] == '0' and slen <= 18) {
+        const c = src[1];
+        if (c == 'x' or c == 'X') {
+            var v: u64 = 0;
+            var i: u32 = 2;
+            var ok = i < slen;
+            while (i < slen) : (i += 1) {
+                const ch = src[i];
+                const d: u8 = if (ch >= '0' and ch <= '9')
+                    ch - '0'
+                else if (ch >= 'a' and ch <= 'f')
+                    (ch - 'a') + 10
+                else if (ch >= 'A' and ch <= 'F')
+                    (ch - 'A') + 10
+                else blk: { ok = false; break :blk 0; };
+                if (!ok) break;
+                const m = @mulWithOverflow(v, @as(u64, 16));
+                if (m[1] != 0) { ok = false; break; }
+                const a = @addWithOverflow(m[0], @as(u64, d));
+                if (a[1] != 0) { ok = false; break; }
+                v = a[0];
+            }
+            if (ok and v <= @as(u64, @intCast(@as(i64, 9223372036854775807)))) {
+                return obj_new_int(@intCast(v));
+            }
+        } else if (c == 'o' or c == 'O') {
+            var v: u64 = 0;
+            var i: u32 = 2;
+            var ok = i < slen;
+            while (i < slen) : (i += 1) {
+                const ch = src[i];
+                if (ch < '0' or ch > '7') { ok = false; break; }
+                const m = @mulWithOverflow(v, @as(u64, 8));
+                if (m[1] != 0) { ok = false; break; }
+                const a = @addWithOverflow(m[0], @as(u64, ch - '0'));
+                if (a[1] != 0) { ok = false; break; }
+                v = a[0];
+            }
+            if (ok) return obj_new_int(@intCast(v));
+        } else if (c == 'b' or c == 'B') {
+            var v: u64 = 0;
+            var i: u32 = 2;
+            var ok = i < slen;
+            while (i < slen) : (i += 1) {
+                const ch = src[i];
+                if (ch != '0' and ch != '1') { ok = false; break; }
+                const m = @mulWithOverflow(v, @as(u64, 2));
+                if (m[1] != 0) { ok = false; break; }
+                v = m[0] + @as(u64, ch - '0');
+            }
+            if (ok) return obj_new_int(@intCast(v));
+        }
+    }
+    if (obj.try_parse_int(@bitCast(sptr), @bitCast(slen))) |iv| {
+        return obj_new_int(iv);
+    }
+    if (obj.try_parse_float(@bitCast(sptr), @bitCast(slen))) |fv| {
+        return obj.obj_new_float(fv);
+    }
+    // Bignum / unparseable — fall back to the source bytes so
+    // the caller sees the original spelling.
     return obj_new_string(ptr_as_i32(sptr), len_as_i32(slen));
 }
 

--- a/runtime/zig/interp/tcl_expr_eval.zig
+++ b/runtime/zig/interp/tcl_expr_eval.zig
@@ -644,14 +644,15 @@ fn parse_unary(s: *State) i32 {
             obj.tcl_obj_release(operand);
             return obj_new_int(0);
         }
-        // Tcl 9 ``!`` requires a boolean operand — raise
-        // ``expected boolean value but got "X"`` for non-boolean
-        // strings rather than silently returning 1.
+        // Tcl 9 ``!`` requires a boolean operand.  Unlike ``||`` /
+        // ``&&`` which raise ``expected boolean value but got
+        // "X"``, the unary form uses ``cannot use non-numeric
+        // string "X" as operand of "!"`` (expr-4.10 / 21.13–22).
         var b: bool = false;
         if (truthy_strict(operand)) |bv| {
             b = bv;
         } else {
-            raise_expected_boolean(operand);
+            raise_non_numeric_unary(operand, "!");
             obj.tcl_obj_release(operand);
             return obj_new_int(0);
         }
@@ -1057,11 +1058,14 @@ fn parse_func_or_word(s: *State) i32 {
         for (args[0..argc]) |arg| obj.tcl_obj_release(arg);
         return result;
     }
-    // Bare keyword: ``true`` / ``false`` / ``yes`` / ``no`` / ``on`` / ``off``.
-    if (parse_bool_keyword(name)) |v| return obj_new_int(v);
-    // Otherwise treat as a string literal — matches Tcl's handling
-    // of bare words in expressions when they don't match a known
-    // function name.
+    // Bare boolean keyword (``true`` / ``false`` / ``yes`` / ``no``
+    // / ``on`` / ``off``) — Tcl 9 returns the SOURCE spelling
+    // verbatim when the keyword is the whole expression
+    // (``expr false`` → ``false``, not ``0``).  Coercion to int
+    // only happens when the value flows into an arithmetic /
+    // logical operator.  ``parse_bool_keyword`` is still useful
+    // for identifying the operand class but we no longer use its
+    // numeric form for the bare-keyword case.
     if (s.skip) return obj_new_int(0);
     const sptr = @intFromPtr(s.src) + start;
     return obj_new_string(ptr_as_i32(sptr), len_as_i32(name_len));
@@ -1146,6 +1150,64 @@ fn truthy_strict(o: i32) ?bool {
     if (obj.try_parse_float(s.ptr, s.len)) |fv| return fv != 0.0;
     if (obj.try_parse_bool(s.ptr, s.len)) |bv| return bv != 0;
     return null;
+}
+
+/// Raise ``cannot use non-numeric string "<text>" as operand of
+/// "<op>"`` — used by the unary ``!`` and the AOT logical-not
+/// helper.  The wording differs from the binary logical
+/// operators which use ``expected boolean value but got "X"``.
+fn raise_non_numeric_unary(o: i32, op_sym: []const u8) void {
+    const catch_mod = @import("tcl_catch.zig");
+    if (@import("tcl_result.zig").snapshot(0).code == .ERROR) return;
+    const s = obj.obj_ensure_string(o);
+    const prefix: []const u8 = "cannot use non-numeric string \"";
+    const middle: []const u8 = "\" as operand of \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @intCast(prefix.len + s.len + middle.len + op_sym.len + suffix.len);
+    const buf = obj.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: usize = 0;
+    for (prefix) |c| { dst[off] = c; off += 1; }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| { dst[off] = sp[i]; off += 1; }
+    }
+    for (middle) |c| { dst[off] = c; off += 1; }
+    for (op_sym) |c| { dst[off] = c; off += 1; }
+    for (suffix) |c| { dst[off] = c; off += 1; }
+    const msg = obj.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
+/// Strict logical-NOT runtime helper exported for the AOT
+/// ``UnaryOp.NOT`` codegen.  Validates *operand* as a boolean,
+/// raises ``cannot use non-numeric string "X" as operand of
+/// "!"`` for non-boolean strings, and returns the boxed
+/// negation as a TclObj.  ``operand == 0`` (null TclObj) is
+/// treated as ``false`` so the caller can chain through the
+/// existing tagged-immediate handle path.
+pub export fn tcl_expr_lnot(operand: i32) i32 {
+    // Preserve the first error in a chain — when the operand
+    // expression already raised (e.g. a missing-variable read
+    // upstream), don't wrap the prior error message into a
+    // ``cannot use non-numeric string`` diagnostic.  Without
+    // this guard, ``info exists arr($x) && !$arr($x)`` whose
+    // first arm correctly returned 0 but left a partially
+    // populated TclObj on the stack lit up as the operand of
+    // ``!`` and produced the bizarre nested-quote diagnostic
+    // ``cannot use non-numeric string "can't read ..." as
+    // operand of "!"``.
+    const result_mod = @import("tcl_result.zig");
+    if (result_mod.snapshot(0).code == .ERROR) return obj_new_int(0);
+    if (truthy_strict(operand)) |b| {
+        return obj_new_int(if (b) @as(i64, 0) else 1);
+    }
+    raise_non_numeric_unary(operand, "!");
+    return obj_new_int(0);
 }
 
 /// Raise ``expected boolean value but got "<text>"`` and

--- a/runtime/zig/interp/tcl_expr_eval.zig
+++ b/runtime/zig/interp/tcl_expr_eval.zig
@@ -941,7 +941,7 @@ fn finalize_num(s: *State, start: u32) i32 {
     // their decimal int form; otherwise fall back to the
     // ``try_parse_int`` / ``try_parse_float`` decimal path.
     const src: [*]const u8 = @ptrFromInt(sptr);
-    if (slen >= 2 and src[0] == '0' and slen <= 18) {
+    if (slen >= 2 and src[0] == '0') {
         const c = src[1];
         if (c == 'x' or c == 'X') {
             var v: u64 = 0;
@@ -1128,7 +1128,11 @@ fn truthy(o: i32) bool {
 /// ``try_parse_bool`` so ``"0"`` / ``"1.5"`` / ``"true"`` all
 /// answer correctly.
 fn truthy_strict(o: i32) ?bool {
-    if (o == 0) return false;
+    // Empty / null operand: Tcl 9 ``expr {"" && 1}`` raises
+    // ``expected boolean value but got ""`` rather than treating
+    // ``""`` as ``false``.  Return ``null`` so callers route
+    // through ``raise_expected_boolean`` / ``raise_non_numeric_unary``.
+    if (o == 0) return null;
     // Tagged-immediate small ints and TYPE_INT / TYPE_FLOAT /
     // TYPE_BIGNUM all answer ``boolean`` directly via
     // ``obj_get_int``'s numeric-domain.  String / inline-string
@@ -1145,7 +1149,7 @@ fn truthy_strict(o: i32) ?bool {
         return obj.obj_get_int(o) != 0;
     }
     const s = obj.obj_ensure_string(o);
-    if (s.len == 0) return false;
+    if (s.len == 0) return null;
     if (obj.try_parse_int(s.ptr, s.len)) |iv| return iv != 0;
     if (obj.try_parse_float(s.ptr, s.len)) |fv| return fv != 0.0;
     if (obj.try_parse_bool(s.ptr, s.len)) |bv| return bv != 0;

--- a/runtime/zig/interp/tcl_expr_eval.zig
+++ b/runtime/zig/interp/tcl_expr_eval.zig
@@ -812,6 +812,65 @@ fn parse_braced(s: *State) i32 {
     const inner_len = s.pos - start;
     if (s.pos < s.len) s.pos += 1; // skip closing }
     const inner_ptr = @intFromPtr(s.src) + start;
+    // Tcl 9 ``expr {{X}}`` shimmers the brace-quoted operand
+    // toward its numeric form when the inner text parses as a
+    // number.  ``expr {{-0x1234}}`` returns ``-4660`` rather
+    // than the literal string ``"-0x1234"``.  Use the same
+    // detector ``finalize_num`` runs on bare numeric literals
+    // (base-prefix, decimal, float).
+    if (inner_len > 0) {
+        const sptr = inner_ptr;
+        const slen = inner_len;
+        const src: [*]const u8 = @ptrFromInt(sptr);
+        // Trim leading minus/plus to inspect base prefix.
+        var off: u32 = 0;
+        var sign_neg = false;
+        if (slen > 0 and (src[0] == '-' or src[0] == '+')) {
+            sign_neg = src[0] == '-';
+            off = 1;
+        }
+        if (off + 2 <= slen and src[off] == '0') {
+            const c = src[off + 1];
+            if (c == 'x' or c == 'X' or c == 'o' or c == 'O' or c == 'b' or c == 'B') {
+                // Re-use finalize_num's logic by funnelling the
+                // entire (possibly signed) source through
+                // ``try_parse_int`` first via a synthetic buffer.
+                // For simplicity, inline the base-prefix loop
+                // since ``try_parse_int`` only handles decimal.
+                var v: u64 = 0;
+                var base: u8 = 10;
+                if (c == 'x' or c == 'X') base = 16
+                else if (c == 'o' or c == 'O') base = 8
+                else base = 2;
+                var i: u32 = off + 2;
+                var ok = i < slen;
+                while (i < slen) : (i += 1) {
+                    const ch = src[i];
+                    var d: u32 = 16;
+                    if (ch >= '0' and ch <= '9') d = ch - '0'
+                    else if (ch >= 'a' and ch <= 'f') d = (ch - 'a') + 10
+                    else if (ch >= 'A' and ch <= 'F') d = (ch - 'A') + 10
+                    else { ok = false; break; }
+                    if (d >= @as(u32, base)) { ok = false; break; }
+                    const m = @mulWithOverflow(v, @as(u64, base));
+                    if (m[1] != 0) { ok = false; break; }
+                    const a = @addWithOverflow(m[0], @as(u64, d));
+                    if (a[1] != 0) { ok = false; break; }
+                    v = a[0];
+                }
+                if (ok and v <= @as(u64, 9223372036854775807)) {
+                    const iv: i64 = @intCast(v);
+                    return obj_new_int(if (sign_neg) -iv else iv);
+                }
+            }
+        }
+        if (obj.try_parse_int(@bitCast(sptr), @bitCast(slen))) |iv| {
+            return obj_new_int(iv);
+        }
+        if (obj.try_parse_float(@bitCast(sptr), @bitCast(slen))) |fv| {
+            return obj.obj_new_float(fv);
+        }
+    }
     return obj_new_string(ptr_as_i32(inner_ptr), len_as_i32(inner_len));
 }
 

--- a/runtime/zig/interp/tcl_expr_eval.zig
+++ b/runtime/zig/interp/tcl_expr_eval.zig
@@ -700,7 +700,27 @@ fn parse_quoted(s: *State) i32 {
     if (s.skip) return obj_new_int(0);
     const inner_ptr = @intFromPtr(s.src) + start;
     const subst = @import("../parse/tcl_subst.zig");
-    return subst.subst_flagged(ptr_as_u32(inner_ptr), inner_len, true, true, true);
+    const result = subst.subst_flagged(ptr_as_u32(inner_ptr), inner_len, true, true, true);
+    // Tcl 9 ``expr`` shimmers a quoted operand to its numeric
+    // form when the string parses as an integer or float — so
+    // ``expr "0005"`` returns ``5`` (canonical int), not ``"0005"``.
+    // Without this, an ``expr "0005"`` whose result is consumed
+    // verbatim by ``return`` / ``set`` keeps the leading zeroes
+    // and downstream comparisons against ``5`` mismatch.
+    if (result != 0) {
+        const rs = obj.obj_ensure_string(result);
+        if (rs.len > 0) {
+            if (obj.try_parse_int(rs.ptr, rs.len)) |iv| {
+                obj.tcl_obj_release(result);
+                return obj_new_int(iv);
+            }
+            if (obj.try_parse_float(rs.ptr, rs.len)) |fv| {
+                obj.tcl_obj_release(result);
+                return obj.obj_new_float(fv);
+            }
+        }
+    }
+    return result;
 }
 
 fn parse_braced(s: *State) i32 {

--- a/runtime/zig/interp/tcl_expr_eval.zig
+++ b/runtime/zig/interp/tcl_expr_eval.zig
@@ -148,10 +148,14 @@ fn match_kw_op(s: *State, kw: []const u8) bool {
         if (s.src[s.pos + i] != c) return false;
     }
     if (s.pos + kw.len == s.len) return true;
+    // Tcl 9 ``expr`` accepts ``3eq2`` as ``3 eq 2`` — after a
+    // keyword operator, only an alpha or underscore continues
+    // the identifier.  Digits and punctuation are valid
+    // boundaries (they cannot extend ``eq`` into a longer
+    // identifier).  The earlier rule lumped digits in with
+    // alpha and rejected ``3eq2`` outright.
     const next = s.src[s.pos + kw.len];
-    if ((next >= 'a' and next <= 'z') or (next >= 'A' and next <= 'Z') or
-        (next >= '0' and next <= '9') or next == '_')
-    {
+    if ((next >= 'a' and next <= 'z') or (next >= 'A' and next <= 'Z') or next == '_') {
         return false;
     }
     return true;
@@ -211,7 +215,16 @@ fn parse_ternary(s: *State) i32 {
         // recurse with skip set on both branches — the outer
         // parse_ternary already chose its result before the inner
         // ones were parsed.
-        const taken_true = if (s.skip) false else truthy(cond);
+        var taken_true: bool = false;
+        if (!s.skip) {
+            if (truthy_strict(cond)) |b| {
+                taken_true = b;
+            } else {
+                raise_expected_boolean(cond);
+                obj.tcl_obj_release(cond);
+                return obj_new_int(0);
+            }
+        }
         obj.tcl_obj_release(cond);
         const saved_skip = s.skip;
         s.skip = saved_skip or !taken_true;
@@ -242,12 +255,36 @@ fn parse_or(s: *State) i32 {
             // every side effect via ``s.skip``.  ``expr {1 || (1/0)}``
             // without the gate raised divide-by-zero on the dummy
             // RHS evaluation; with the gate it returns 1 cleanly.
-            const left_truthy = if (s.skip) false else truthy(left);
+            // Tcl 9 also requires both operands be valid booleans
+            // — ``expr {"a" || "b"}`` raises ``expected boolean
+            // value but got "a"`` rather than silently returning 0.
+            var left_truthy: bool = false;
+            if (!s.skip) {
+                if (truthy_strict(left)) |b| {
+                    left_truthy = b;
+                } else {
+                    raise_expected_boolean(left);
+                    obj.tcl_obj_release(left);
+                    return obj_new_int(0);
+                }
+            }
             const saved_skip = s.skip;
             s.skip = saved_skip or left_truthy;
             const right = parse_and(s);
             s.skip = saved_skip;
-            const result_val: i64 = if (saved_skip) 0 else if (left_truthy or truthy(right)) 1 else 0;
+            var result_val: i64 = 0;
+            if (!saved_skip) {
+                if (left_truthy) {
+                    result_val = 1;
+                } else if (truthy_strict(right)) |b| {
+                    result_val = if (b) 1 else 0;
+                } else {
+                    raise_expected_boolean(right);
+                    obj.tcl_obj_release(left);
+                    obj.tcl_obj_release(right);
+                    return obj_new_int(0);
+                }
+            }
             obj.tcl_obj_release(left);
             obj.tcl_obj_release(right);
             left = obj_new_int(result_val);
@@ -263,14 +300,35 @@ fn parse_and(s: *State) i32 {
         if (match2(s, '&', '&')) {
             // Short-circuit: if ``left`` is falsy we suppress the
             // RHS via ``s.skip`` so ``expr {0 && [error boom]}``
-            // doesn't trigger ``boom``.
-            const left_truthy = if (s.skip) false else truthy(left);
+            // doesn't trigger ``boom``.  Strict-boolean check
+            // mirrors ``||``.
+            var left_truthy: bool = false;
+            if (!s.skip) {
+                if (truthy_strict(left)) |b| {
+                    left_truthy = b;
+                } else {
+                    raise_expected_boolean(left);
+                    obj.tcl_obj_release(left);
+                    return obj_new_int(0);
+                }
+            }
             const saved_skip = s.skip;
             s.skip = saved_skip or !left_truthy;
             const right = parse_bit_or(s);
             s.skip = saved_skip;
-            const result_val: i64 =
-                if (saved_skip) 0 else if (left_truthy and truthy(right)) 1 else 0;
+            var result_val: i64 = 0;
+            if (!saved_skip) {
+                if (!left_truthy) {
+                    result_val = 0;
+                } else if (truthy_strict(right)) |b| {
+                    result_val = if (b) 1 else 0;
+                } else {
+                    raise_expected_boolean(right);
+                    obj.tcl_obj_release(left);
+                    obj.tcl_obj_release(right);
+                    return obj_new_int(0);
+                }
+            }
             obj.tcl_obj_release(left);
             obj.tcl_obj_release(right);
             left = obj_new_int(result_val);
@@ -586,7 +644,18 @@ fn parse_unary(s: *State) i32 {
             obj.tcl_obj_release(operand);
             return obj_new_int(0);
         }
-        const result = obj_new_int(if (truthy(operand)) @as(i64, 0) else 1);
+        // Tcl 9 ``!`` requires a boolean operand — raise
+        // ``expected boolean value but got "X"`` for non-boolean
+        // strings rather than silently returning 1.
+        var b: bool = false;
+        if (truthy_strict(operand)) |bv| {
+            b = bv;
+        } else {
+            raise_expected_boolean(operand);
+            obj.tcl_obj_release(operand);
+            return obj_new_int(0);
+        }
+        const result = obj_new_int(if (b) @as(i64, 0) else 1);
         obj.tcl_obj_release(operand);
         return result;
     }
@@ -782,9 +851,18 @@ fn parse_number(s: *State) i32 {
             has_dot = true;
             s.pos += 1;
         } else if ((ch == 'e' or ch == 'E') and !has_exp) {
+            // ``e``/``E`` only starts a float exponent when at
+            // least one digit follows (with an optional sign).
+            // ``expr 3eq2`` (string-equal operator) must NOT
+            // consume the ``e`` as exponent — without this guard
+            // ``parse_number`` greedily ate ``3e`` and the test
+            // got the literal ``"3e"`` back instead of comparing
+            // ``3 eq 2``.
+            var look = s.pos + 1;
+            if (look < s.len and (s.src[look] == '+' or s.src[look] == '-')) look += 1;
+            if (look >= s.len or s.src[look] < '0' or s.src[look] > '9') break;
             has_exp = true;
-            s.pos += 1;
-            if (s.pos < s.len and (s.src[s.pos] == '+' or s.src[s.pos] == '-')) s.pos += 1;
+            s.pos = look;
         } else break;
     }
     return finalize_num(s, start);
@@ -974,4 +1052,65 @@ fn dispatch_math_func(name: []const u8, args: []const i32) i32 {
 
 fn truthy(o: i32) bool {
     return obj.obj_get_int(o) != 0;
+}
+
+/// Strict ``truthy`` that returns null when *o*'s string repr
+/// isn't a valid Tcl boolean (a number, or the keywords ``yes`` /
+/// ``no`` / ``true`` / ``false`` / ``on`` / ``off``).  Used by
+/// the logical operators (``&&``, ``||``, ``!``) and the
+/// conditional (``?:``) which raise ``expected boolean value
+/// but got "X"`` for non-boolean operands.  Numeric types
+/// (TYPE_INT / TYPE_FLOAT / TYPE_BIGNUM) are always boolean;
+/// strings dispatch through ``try_parse_int`` / ``try_parse_float`` /
+/// ``try_parse_bool`` so ``"0"`` / ``"1.5"`` / ``"true"`` all
+/// answer correctly.
+fn truthy_strict(o: i32) ?bool {
+    if (o == 0) return false;
+    // Tagged-immediate small ints and TYPE_INT / TYPE_FLOAT /
+    // TYPE_BIGNUM all answer ``boolean`` directly via
+    // ``obj_get_int``'s numeric-domain.  String / inline-string
+    // forms route through the parse helpers so ``"true"`` /
+    // ``"0"`` / ``"1.5"`` all work.
+    const handle: u32 = @bitCast(o);
+    const is_immediate = (handle & obj.IMMEDIATE_TAG_BIT) != 0;
+    if (!is_immediate) {
+        const tag = obj.read_i32(handle + obj.OBJ_TYPE_TAG);
+        if (tag == obj.TYPE_INT or tag == obj.TYPE_FLOAT or tag == obj.TYPE_BIGNUM) {
+            return obj.obj_get_int(o) != 0;
+        }
+    } else {
+        return obj.obj_get_int(o) != 0;
+    }
+    const s = obj.obj_ensure_string(o);
+    if (s.len == 0) return false;
+    if (obj.try_parse_int(s.ptr, s.len)) |iv| return iv != 0;
+    if (obj.try_parse_float(s.ptr, s.len)) |fv| return fv != 0.0;
+    if (obj.try_parse_bool(s.ptr, s.len)) |bv| return bv != 0;
+    return null;
+}
+
+/// Raise ``expected boolean value but got "<text>"`` and
+/// return ``false``.  Caller must short-circuit the surrounding
+/// op after the call.
+fn raise_expected_boolean(o: i32) void {
+    const catch_mod = @import("tcl_catch.zig");
+    const s = obj.obj_ensure_string(o);
+    const prefix: []const u8 = "expected boolean value but got \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + s.len + @as(u32, @intCast(suffix.len));
+    const buf = obj.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| { dst[off] = c; off += 1; }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| { dst[off] = sp[i]; off += 1; }
+    }
+    for (suffix) |c| { dst[off] = c; off += 1; }
+    const msg = obj.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
 }

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -995,8 +995,13 @@ var parked_count_stack: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
 /// the WASM codegen lands here.
 pub export fn frame_depth_stash_abs(abs_level: i32) i32 {
     const lvl: u32 = if (abs_level < 0) 0 else @intCast(abs_level);
+    // ``lvl == frame_depth`` is the current frame: ``shift = 0``.
+    // ``lvl > frame_depth`` is over-deep; treat as the current
+    // frame too rather than aliasing to the global scope.
+    // ``lvl == 0`` (``#0`` global) clamps to ``shift = frame_depth``
+    // through the explicit subtract below.
     if (lvl >= frame_depth) {
-        return frame_depth_stash(@intCast(frame_depth));
+        return frame_depth_stash(0);
     }
     return frame_depth_stash(@intCast(frame_depth - lvl));
 }

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -984,6 +984,23 @@ var parked_count_stack: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
 /// clear — without parking, ``uplevel 1 [list CompiledCall]``
 /// would zero every populated bucket of the caller's frame on
 /// the inner push, losing all of its locals.
+/// Absolute-level variant of :func:`frame_depth_stash`.  ``abs_level``
+/// is the Tcl-style absolute level number (``#N``):
+///   * ``0`` → global scope (clamps shift to ``frame_depth``).
+///   * ``1`` → outermost proc frame (a in a→b→c).
+///   * ``frame_depth`` → current frame (no shift).
+/// Computes ``shift = frame_depth - abs_level`` and routes through
+/// the relative-form stash so callers don't need to know the
+/// runtime call depth at compile time.  ``uplevel #N body`` from
+/// the WASM codegen lands here.
+pub export fn frame_depth_stash_abs(abs_level: i32) i32 {
+    const lvl: u32 = if (abs_level < 0) 0 else @intCast(abs_level);
+    if (lvl >= frame_depth) {
+        return frame_depth_stash(@intCast(frame_depth));
+    }
+    return frame_depth_stash(@intCast(frame_depth - lvl));
+}
+
 pub export fn frame_depth_stash(relative_up: i32) i32 {
     const saved: i32 = @intCast(frame_depth);
     var up = relative_up;

--- a/runtime/zig/parse/tcl_parse.zig
+++ b/runtime/zig/parse/tcl_parse.zig
@@ -316,14 +316,19 @@ pub fn parse_command(
         }
         // After a brace-quoted or ``"..."``-quoted word, the next
         // byte must be a word separator (whitespace, ``;``, ``\n``,
-        // ``\r``) or end-of-source.  Anything else is a syntax error
-        // — reference Tcl raises ``extra characters after
-        // close-brace`` (parse-18.19 / 18.20 / 18.21).  Surface it
-        // via the ``extra_chars_after_close`` flag so the caller
+        // ``\r``) or end-of-source.  ``\<NL>`` is also acceptable —
+        // reference Tcl treats backslash-newline as a whitespace
+        // replacement everywhere (parseOld-7.4, var-7.9 trap fix:
+        // ``-result [list ... \<NL> ...]`` after braced ``{...}``).
+        // Anything else is a syntax error — reference Tcl raises
+        // ``extra characters after close-brace`` (parse-18.19 /
+        // 18.20 / 18.21).  Surface it via the
+        // ``extra_chars_after_close`` flag so the caller
         // (eval_script) can route the error through tcl_cmd_error.
         if (word_kind_brace_or_quote and p < len) {
             const c = src[p];
-            if (c != ' ' and c != '\t' and c != '\n' and c != '\r' and c != ';') {
+            const is_bs_nl = c == '\\' and p + 1 < len and src[p + 1] == '\n';
+            if (c != ' ' and c != '\t' and c != '\n' and c != '\r' and c != ';' and !is_bs_nl) {
                 return .{
                     .count = count,
                     .next = p,

--- a/runtime/zig/parse/tcl_subst.zig
+++ b/runtime/zig/parse/tcl_subst.zig
@@ -39,6 +39,26 @@ fn raise_subst_error(text: []const u8) i32 {
     return 0;
 }
 
+/// Cleanup helper used after a ``$var`` / ``$arr(idx)`` / ``${X}``
+/// substitution finds the referenced variable unset.  Releases any
+/// retained TclObjs and frees the per-piece arena allocations
+/// before the caller raises ``can't read "X": no such variable``
+/// and bails out of subst_flagged_full.
+fn release_pieces_for_bail(
+    retained_objs: u32,
+    n_retained: u32,
+    retained_alloc: arena.Allocation,
+    pieces_alloc: arena.Allocation,
+) void {
+    var rj: u32 = 0;
+    while (rj < n_retained) : (rj += 1) {
+        const r = read_i32(retained_objs + rj * 4);
+        if (r != 0) obj_mod.tcl_obj_release(r);
+    }
+    arena.arena_free(retained_alloc);
+    arena.arena_free(pieces_alloc);
+}
+
 /// Expand ``$var`` / ``[cmd]`` / ``\x`` in a raw byte span, with each
 /// substitution kind independently enabled.  ``do_vars`` / ``do_cmds``
 /// / ``do_bs`` correspond to the ``-novariables`` / ``-nocommands``
@@ -198,19 +218,29 @@ pub fn subst_flagged_full(
                 i += 1; // consume '}'
                 const name_obj = obj_new_string(@bitCast(wptr + vs), @bitCast(ve - vs));
                 const val = frames.var_resolve(name_obj);
-                // Release the temp name TclObj immediately — its
-                // bytes were borrowed from the source script and
-                // the lookup machinery doesn't retain a reference.
-                // Issue #303: each ``${var}`` substitution leaked
-                // one obj header per evaluation and pushed long-
-                // running scripts past the wasm32 4 GiB ceiling.
-                obj_mod.tcl_obj_release(name_obj);
                 if (val != 0) {
                     const sv = obj_ensure_string(val);
                     push_piece(pieces_buf, &n_pieces, &total_out, sv.ptr, sv.len);
                     obj_mod.tcl_obj_retain(val);
                     write_i32(retained_objs + n_retained * 4, val);
                     n_retained += 1;
+                    // Release the temp name TclObj — its bytes were
+                    // borrowed from the source script and the lookup
+                    // machinery doesn't retain a reference.  Issue
+                    // #303: each ``${var}`` substitution leaked one
+                    // obj header per evaluation and pushed long-
+                    // running scripts past the wasm32 4 GiB ceiling.
+                    obj_mod.tcl_obj_release(name_obj);
+                } else {
+                    // ``${X}`` where ``X`` is unset — reference Tcl
+                    // raises ``can't read "X": no such variable``.
+                    // ``var_unset_error`` reads ``name_obj``'s bytes
+                    // for the diagnostic, so release it after the
+                    // call.
+                    release_pieces_for_bail(retained_objs, n_retained, retained_alloc, pieces_alloc);
+                    catch_mod.var_unset_error(name_obj);
+                    obj_mod.tcl_obj_release(name_obj);
+                    return 0;
                 }
             } else {
                 // Variable-name scanner: bareword chars + ``::``
@@ -316,24 +346,66 @@ pub fn subst_flagged_full(
                         elem = frames.var_resolve(full_obj);
                         obj_mod.tcl_obj_release(full_obj);
                     }
-                    obj_mod.tcl_obj_release(name_obj);
-                    if (key_obj != 0) obj_mod.tcl_obj_release(key_obj);
                     if (elem != 0) {
                         const sv = obj_ensure_string(elem);
                         push_piece(pieces_buf, &n_pieces, &total_out, sv.ptr, sv.len);
                         obj_mod.tcl_obj_retain(elem);
                         write_i32(retained_objs + n_retained * 4, elem);
                         n_retained += 1;
+                        obj_mod.tcl_obj_release(name_obj);
+                        if (key_obj != 0) obj_mod.tcl_obj_release(key_obj);
+                    } else {
+                        // ``$arr(idx)`` element missing — reference
+                        // Tcl raises ``can't read "arr(idx)": no
+                        // such variable``.  Build the qualified
+                        // name ``arr(idx)`` from the post-subst
+                        // key bytes for the diagnostic.
+                        const arr_s2 = obj_ensure_string(name_obj);
+                        const key_len2: u32 = if (key_obj != 0) obj_ensure_string(key_obj).len else 0;
+                        const key_ptr2: u32 = if (key_obj != 0) obj_ensure_string(key_obj).ptr else 0;
+                        const qlen: u32 = arr_s2.len + 2 + key_len2;
+                        const qbuf = alloc(qlen);
+                        var qual_obj: i32 = 0;
+                        if (qbuf != 0) {
+                            const qd: [*]u8 = @ptrFromInt(qbuf);
+                            const ap: [*]const u8 = @ptrFromInt(arr_s2.ptr);
+                            for (0..arr_s2.len) |k| qd[k] = ap[k];
+                            qd[arr_s2.len] = '(';
+                            if (key_len2 > 0) {
+                                const kp: [*]const u8 = @ptrFromInt(key_ptr2);
+                                for (0..key_len2) |k| qd[arr_s2.len + 1 + k] = kp[k];
+                            }
+                            qd[arr_s2.len + 1 + key_len2] = ')';
+                            qual_obj = obj_mod.obj_new_string_take(qbuf, qlen, qlen);
+                        }
+                        obj_mod.tcl_obj_release(name_obj);
+                        if (key_obj != 0) obj_mod.tcl_obj_release(key_obj);
+                        release_pieces_for_bail(retained_objs, n_retained, retained_alloc, pieces_alloc);
+                        if (qual_obj != 0) {
+                            catch_mod.var_unset_error(qual_obj);
+                            obj_mod.tcl_obj_release(qual_obj);
+                        } else {
+                            catch_mod.tcl_cmd_error(0);
+                        }
+                        return 0;
                     }
                 } else {
                     const val = frames.var_resolve(name_obj);
-                    obj_mod.tcl_obj_release(name_obj);
                     if (val != 0) {
                         const sv = obj_ensure_string(val);
                         push_piece(pieces_buf, &n_pieces, &total_out, sv.ptr, sv.len);
                         obj_mod.tcl_obj_retain(val);
                         write_i32(retained_objs + n_retained * 4, val);
                         n_retained += 1;
+                        obj_mod.tcl_obj_release(name_obj);
+                    } else {
+                        // ``$X`` where ``X`` is unset — reference
+                        // Tcl raises ``can't read "X": no such
+                        // variable``.
+                        release_pieces_for_bail(retained_objs, n_retained, retained_alloc, pieces_alloc);
+                        catch_mod.var_unset_error(name_obj);
+                        obj_mod.tcl_obj_release(name_obj);
+                        return 0;
                     }
                 }
             }

--- a/runtime/zig/parse/tcl_subst.zig
+++ b/runtime/zig/parse/tcl_subst.zig
@@ -342,7 +342,15 @@ pub fn subst_flagged_full(
                             for (0..key_s.len) |k| fd[arr_s.len + 1 + k] = kp[k];
                         }
                         fd[arr_s.len + 1 + key_s.len] = ')';
-                        const full_obj = obj_new_string(@bitCast(fbuf), @bitCast(full_len));
+                        // ``obj_new_string_take`` so the qualifier
+                        // TclObj owns the buffer.  ``obj_new_string``
+                        // would borrow ``fbuf`` and leak it on the
+                        // ``tcl_obj_release`` below — outside of an
+                        // outer ``catch`` the leak doesn't accumulate
+                        // (proc returns reset the arena), but read-
+                        // heavy paths through subst exercise this
+                        // hundreds of times per command.
+                        const full_obj = obj_mod.obj_new_string_take(fbuf, full_len, full_len);
                         elem = frames.var_resolve(full_obj);
                         obj_mod.tcl_obj_release(full_obj);
                     }

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -863,3 +863,14 @@ pub export fn tcl_test_hidden_find_in(
     );
     return if (h != 0) 1 else 0;
 }
+
+/// Evaluate a raw expression source string and return its result
+/// as a TclObj.  Exposed for the WASM codegen's ``ExprRaw`` path
+/// where a backslash-substituted operand needs to be re-parsed
+/// by the runtime expression evaluator (matching reference Tcl's
+/// ``expr X`` behaviour, which treats *X* as expression source
+/// rather than a literal value).
+pub export fn tcl_eval_expr_str(src_ptr: i32, src_len: i32) i32 {
+    const expr_eval = @import("interp/tcl_expr_eval.zig");
+    return expr_eval.eval(@bitCast(src_ptr), @bitCast(src_len));
+}

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -160,6 +160,7 @@ pub const frame_local_at = tcl_frames.frame_local_at;
 pub const frame_local_set_at = tcl_frames.frame_local_set_at;
 pub const frame_alias_global = tcl_frames.frame_alias_global;
 pub const frame_depth_stash = tcl_frames.frame_depth_stash;
+pub const frame_depth_stash_abs = tcl_frames.frame_depth_stash_abs;
 pub const frame_depth_restore = tcl_frames.frame_depth_restore;
 pub const var_resolve = tcl_frames.var_resolve;
 pub const var_set = tcl_frames.var_set;
@@ -405,6 +406,7 @@ comptime {
     _ = &tcl_frames.frame_take_pending_argv0;
     _ = &tcl_frames.frame_get_depth;
     _ = &tcl_frames.frame_depth_stash;
+    _ = &tcl_frames.frame_depth_stash_abs;
     _ = &tcl_frames.frame_depth_restore;
     _ = &tcl_frames.local_set;
     _ = &tcl_frames.local_get;

--- a/runtime/zig/test_tcl_arith.zig
+++ b/runtime/zig/test_tcl_arith.zig
@@ -104,10 +104,14 @@ test "tcl_arith_mul — float promotion" {
 
 // ---- div ------------------------------------------------------------
 
-test "tcl_arith_div — int / int = trunc-int" {
+test "tcl_arith_div — int / int = floor-int" {
+    // Tcl 9 ``/`` rounds toward negative infinity (floor division)
+    // — see expr-11.3 ``expr -1/2 == -1``.  ``-7/2`` is ``-4``,
+    // not the C / @divTrunc value ``-3``.
     try expectInt(arith.tcl_arith_div(intObj(7), intObj(2)), 3);
-    try expectInt(arith.tcl_arith_div(intObj(-7), intObj(2)), -3); // truncation, NOT floor
-    try expectInt(arith.tcl_arith_div(intObj(7), intObj(-2)), -3);
+    try expectInt(arith.tcl_arith_div(intObj(-7), intObj(2)), -4);
+    try expectInt(arith.tcl_arith_div(intObj(7), intObj(-2)), -4);
+    try expectInt(arith.tcl_arith_div(intObj(-7), intObj(-2)), 3);
 }
 
 test "tcl_arith_div — float operand promotes the result" {
@@ -137,10 +141,23 @@ test "is_float — string with 'e' notation triggers float coercion" {
     try expectFloatClose(arith.tcl_arith_add(stringObj("1e2"), stringObj("0")), 100.0, 1e-9);
 }
 
-test "is_float — empty string is NOT float" {
-    // Empty strings parse as int 0; result stays in int domain.
-    const result = arith.tcl_arith_add(stringObj(""), intObj(5));
-    try expectInt(result, 5);
+test "is_float — empty string raises non-numeric error" {
+    // Tcl 9 ``expr {"" + 5}`` raises ``cannot use non-numeric
+    // string "" as left operand of "+"`` — the previous wiring
+    // silently parsed empty string as ``0`` and returned ``5``.
+    // The arith helper sets the error flag; the caller-side
+    // sweep below verifies the catch path picks it up.
+    const fixture = @import("runtime_test_fixture.zig");
+    const trap_msg = fixture.with_catch(&struct {
+        fn body() void {
+            _ = arith.tcl_arith_add(stringObj(""), intObj(5));
+        }
+    }.body);
+    try testing.expect(trap_msg != null);
+    try testing.expectEqualStrings(
+        "cannot use non-numeric string \"\" as left operand of \"+\"",
+        trap_msg.?,
+    );
 }
 
 // ---- math functions -------------------------------------------------

--- a/runtime/zig/test_tcl_subst.zig
+++ b/runtime/zig/test_tcl_subst.zig
@@ -139,22 +139,32 @@ test "subst_flagged — ${name} braced variable" {
 }
 
 const VarMissingCtx = struct {
-    var observed: []const u8 = &.{};
     fn body_missing() void {
-        // No ``frame.set`` for ``unset_var`` — ``var_resolve``
-        // returns 0 and subst_flagged drops the slot (matching
-        // the reference Tcl behaviour of leaving the unmatched
-        // text empty rather than raising mid-substitution).
-        observed = substAll("value=$unset_var!");
+        // ``$unset_var`` without a corresponding ``frame.set`` —
+        // reference Tcl raises ``can't read "unset_var": no such
+        // variable`` for word substitution of an undefined name.
+        const s = "value=$unset_var!";
+        _ = subst.subst_flagged(
+            @intCast(@intFromPtr(s.ptr)),
+            @intCast(s.len),
+            true,
+            true,
+            true,
+        );
     }
 };
 
-test "subst_flagged — unresolved $var contributes empty bytes" {
-    VarMissingCtx.observed = &.{};
-    fixture.with_interp(&VarMissingCtx.body_missing);
-    // The literal ``value=`` and trailing ``!`` pass through; the
-    // unresolved ``$unset_var`` slot drops out without raising.
-    try testing.expectEqualStrings("value=!", VarMissingCtx.observed);
+test "subst_flagged — unresolved $var raises can't read error" {
+    fixture.with_interp(&struct {
+        fn run() void {
+            const msg = fixture.with_catch(&VarMissingCtx.body_missing);
+            testing.expect(msg != null) catch unreachable;
+            testing.expectEqualStrings(
+                "can't read \"unset_var\": no such variable",
+                msg.?,
+            ) catch unreachable;
+        }
+    }.run);
 }
 
 const NoVarsCtx = struct {

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -797,6 +797,10 @@ fn raise_non_numeric(o: i32, op_sym: []const u8, position: []const u8) void {
     const suffix: []const u8 = "\"";
     const total: u32 = @intCast(prefix.len + s.len + middle.len + position.len + between.len + op_sym.len + suffix.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) {
+        stubs.raise("non-numeric operand");
+        return;
+    }
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |c| { buf[off] = c; off += 1; }

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -107,6 +107,7 @@ fn managed_binop(
 }
 
 pub export fn tcl_arith_add(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "+")) return obj.obj_new_int(0);
     if (is_float(a) or is_float(b))
         return obj.obj_new_float(obj.obj_get_float(a) + obj.obj_get_float(b));
     // Bignum operand → Managed path (arbitrary precision).  The
@@ -131,6 +132,7 @@ pub export fn tcl_arith_add(a: i32, b: i32) i32 {
 }
 
 pub export fn tcl_arith_sub(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "-")) return obj.obj_new_int(0);
     if (is_float(a) or is_float(b))
         return obj.obj_new_float(obj.obj_get_float(a) - obj.obj_get_float(b));
     if (is_bignum(a) or is_bignum(b)) {
@@ -144,6 +146,7 @@ pub export fn tcl_arith_sub(a: i32, b: i32) i32 {
 }
 
 pub export fn tcl_arith_mul(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "*")) return obj.obj_new_int(0);
     if (is_float(a) or is_float(b))
         return obj.obj_new_float(obj.obj_get_float(a) * obj.obj_get_float(b));
     if (is_bignum(a) or is_bignum(b)) {
@@ -159,6 +162,7 @@ pub export fn tcl_arith_mul(a: i32, b: i32) i32 {
 }
 
 pub export fn tcl_arith_div(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "/")) return obj.obj_new_int(0);
     if (is_float(a) or is_float(b)) {
         const bf = obj.obj_get_float(b);
         if (bf == 0.0) {
@@ -188,10 +192,19 @@ pub export fn tcl_arith_div(a: i32, b: i32) i32 {
     if (ai == std.math.minInt(i64) and bi == -1) {
         return obj.obj_new_bignum(-@as(i128, ai));
     }
-    return obj.obj_new_int(@divTrunc(ai, bi));
+    // Tcl 9 ``/`` uses floored division (rounds toward negative
+    // infinity).  ``-1 / 2`` is ``-1`` in Tcl (and Python), not
+    // ``0`` like C / ``@divTrunc``.  Compute via @divTrunc and
+    // adjust when the remainder is non-zero and the operand
+    // signs differ.
+    var q = @divTrunc(ai, bi);
+    const r = ai - q * bi;
+    if (r != 0 and ((r < 0) != (bi < 0))) q -= 1;
+    return obj.obj_new_int(q);
 }
 
 pub export fn tcl_arith_mod(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "%")) return obj.obj_new_int(0);
     // Tcl's ``%`` follows Python-like "result has same sign as
     // divisor" semantics — see ``tclExecute.c`` INST_MOD which does
     // ``remainder = w1 % w2;  if (remainder != 0 && (remainder ^ w2) < 0)
@@ -721,6 +734,65 @@ fn check_int_binary(a: i32, b: i32, op_sym: []const u8) bool {
     }
     if (is_float(b)) {
         raise_float_in_bitwise(b, op_sym, "right");
+        return false;
+    }
+    return true;
+}
+
+/// Return true iff *o* parses as a number (int / float / bignum
+/// keyword like ``Inf``).  Used by the arithmetic helpers to
+/// raise ``cannot use non-numeric string "X" as Y operand of
+/// "OP"`` rather than silently treating non-numeric operands as
+/// 0 (the legacy ``obj_get_int`` / ``obj_get_float`` fallback).
+fn obj_is_numeric(o: i32) bool {
+    if (o == 0) return false;
+    const tag = obj.obj_type(o);
+    if (tag == TYPE_INT or tag == TYPE_FLOAT or is_bignum(o)) return true;
+    const s = obj.obj_ensure_string(o);
+    if (s.len == 0) return false;
+    if (obj.try_parse_int(s.ptr, s.len) != null) return true;
+    if (obj.try_parse_float(s.ptr, s.len) != null) return true;
+    return false;
+}
+
+/// Build ``cannot use non-numeric string "X" as <position>
+/// operand of "<op>"`` and route it through the Tcl error path.
+fn raise_non_numeric(o: i32, op_sym: []const u8, position: []const u8) void {
+    if (@import("../interp/tcl_result.zig").snapshot(0).code == .ERROR) return;
+    const s = obj.obj_ensure_string(o);
+    const prefix: []const u8 = "cannot use non-numeric string \"";
+    const middle: []const u8 = "\" as ";
+    const between: []const u8 = " operand of \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @intCast(prefix.len + s.len + middle.len + position.len + between.len + op_sym.len + suffix.len);
+    const buf_addr: u32 = obj.alloc(total);
+    const buf: [*]u8 = @ptrFromInt(buf_addr);
+    var off: usize = 0;
+    for (prefix) |c| { buf[off] = c; off += 1; }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| { buf[off] = sp[i]; off += 1; }
+    }
+    for (middle) |c| { buf[off] = c; off += 1; }
+    for (position) |c| { buf[off] = c; off += 1; }
+    for (between) |c| { buf[off] = c; off += 1; }
+    for (op_sym) |c| { buf[off] = c; off += 1; }
+    for (suffix) |c| { buf[off] = c; off += 1; }
+    const msg = obj.obj_new_string_take(buf_addr, total, total);
+    @import("../interp/tcl_catch.zig").tcl_cmd_error(msg);
+}
+
+/// Validate both operands are numeric for an arithmetic op.
+/// Returns true when the call should proceed; raises the
+/// ``cannot use non-numeric string`` error and returns false
+/// when either operand is a non-numeric string.
+fn check_numeric_binary(a: i32, b: i32, op_sym: []const u8) bool {
+    if (!obj_is_numeric(a)) {
+        raise_non_numeric(a, op_sym, "left");
+        return false;
+    }
+    if (!obj_is_numeric(b)) {
+        raise_non_numeric(b, op_sym, "right");
         return false;
     }
     return true;

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -893,18 +893,21 @@ fn bitwise_managed(
 }
 
 pub export fn tcl_arith_band(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "&")) return obj.obj_new_int(0);
     if (!check_int_binary(a, b, "&")) return obj.obj_new_int(0);
     if (is_bignum(a) or is_bignum(b)) return bitwise_managed(a, b, .band);
     return obj.obj_new_int(obj.obj_get_int(a) & obj.obj_get_int(b));
 }
 
 pub export fn tcl_arith_bor(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "|")) return obj.obj_new_int(0);
     if (!check_int_binary(a, b, "|")) return obj.obj_new_int(0);
     if (is_bignum(a) or is_bignum(b)) return bitwise_managed(a, b, .bor);
     return obj.obj_new_int(obj.obj_get_int(a) | obj.obj_get_int(b));
 }
 
 pub export fn tcl_arith_bxor(a: i32, b: i32) i32 {
+    if (!check_numeric_binary(a, b, "^")) return obj.obj_new_int(0);
     if (!check_int_binary(a, b, "^")) return obj.obj_new_int(0);
     if (is_bignum(a) or is_bignum(b)) return bitwise_managed(a, b, .bxor);
     return obj.obj_new_int(obj.obj_get_int(a) ^ obj.obj_get_int(b));

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -755,12 +755,43 @@ fn obj_is_numeric(o: i32) bool {
     return false;
 }
 
+/// Return true when *o*'s string repr is a recognised
+/// non-numeric IEEE-754 keyword (``NaN`` / ``Inf`` / ``Infinity``,
+/// case-insensitive, with optional leading sign).  Tcl 9 routes
+/// these through a separate diagnostic
+/// (``cannot use non-numeric floating-point value "X"``) so the
+/// reader can tell the difference between an unrecognised
+/// string and a recognised-but-unrepresentable float.
+fn is_ieee_keyword_string(o: i32) bool {
+    const s = obj.obj_ensure_string(o);
+    if (s.len == 0 or s.len > 9) return false;
+    const sp: [*]const u8 = @ptrFromInt(s.ptr);
+    var off: u32 = 0;
+    if (sp[0] == '+' or sp[0] == '-') off = 1;
+    const remain = s.len - off;
+    if (remain != 3 and remain != 8) return false;
+    var buf: [9]u8 = undefined;
+    for (0..remain) |i| {
+        const c = sp[off + i];
+        buf[i] = if (c >= 'A' and c <= 'Z') c + 32 else c;
+    }
+    const lc = buf[0..remain];
+    return std.mem.eql(u8, lc, "nan") or std.mem.eql(u8, lc, "inf") or std.mem.eql(u8, lc, "infinity");
+}
+
 /// Build ``cannot use non-numeric string "X" as <position>
 /// operand of "<op>"`` and route it through the Tcl error path.
+/// IEEE-754 keyword operands (``NaN`` / ``Inf``) get the
+/// ``non-numeric floating-point value "X"`` wording instead —
+/// reference Tcl 9 distinguishes the two cases (expr-22.1 / 22.3).
 fn raise_non_numeric(o: i32, op_sym: []const u8, position: []const u8) void {
     if (@import("../interp/tcl_result.zig").snapshot(0).code == .ERROR) return;
     const s = obj.obj_ensure_string(o);
-    const prefix: []const u8 = "cannot use non-numeric string \"";
+    const ieee_kw = is_ieee_keyword_string(o);
+    const prefix: []const u8 = if (ieee_kw)
+        "cannot use non-numeric floating-point value \""
+    else
+        "cannot use non-numeric string \"";
     const middle: []const u8 = "\" as ";
     const between: []const u8 = " operand of \"";
     const suffix: []const u8 = "\"";

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -803,6 +803,83 @@ pub export fn array_get(arr: i32, key: i32) i32 {
     return 0;
 }
 
+/// array_get_all arrName ?pattern? — returns the array contents as a
+/// flat ``{k v k v …}`` Tcl list.  Optional glob *pattern* filters
+/// keys (empty/0 pattern => all keys).  Each key and value is
+/// quoted via ``list_elem_quote_nth`` so embedded spaces, braces,
+/// or backslashes survive the round-trip through ``foreach {k v}
+/// [array get arr] {…}``.  This is the runtime backing for
+/// ``array get arrName ?pattern?`` — the previous wiring used
+/// the single-element ``array_get`` lookup path which is the wrong
+/// semantics (``array get`` returns *all* matching pairs as a list).
+pub export fn array_get_all(arr: i32, pattern: i32) i32 {
+    const str_mod = @import("tcl_string.zig");
+    const lq = @import("tcl_list_quote.zig");
+    const use_filter = pattern != 0 and blk: {
+        const ps = obj_ensure_string(pattern);
+        break :blk ps.len > 0;
+    };
+    const t = find_table(arr);
+    if (t == 0) return obj_new_string(0, 0);
+    const cap = ar_cap(t);
+    // Two-pass build: pass 1 sums upper-bound bytes (worst case
+    // 2*len + 2 per element via ``list_elem_quote_nth`` plus one
+    // separator space per element after the first).  Pass 2 emits
+    // bytes via the quoter.
+    var total: u32 = 0;
+    var nonempty: u32 = 0;
+    var i: u32 = 0;
+    while (i < cap) : (i += 1) {
+        const bucket = t + AR_HEADER_SIZE + i * AR_BUCKET_SIZE;
+        const raw = read_i32(bucket);
+        if (raw == 0 or raw == AR_TOMBSTONE) continue;
+        const ep: u32 = @bitCast(raw);
+        const el: u32 = @bitCast(read_i32(bucket + 4));
+        if (use_filter) {
+            const k = obj_new_string(@bitCast(ep), @bitCast(el));
+            if (obj_get_int(str_mod.string_match(pattern, k)) == 0) continue;
+        }
+        const v = read_i32(bucket + 12);
+        const vs = obj_ensure_string(v);
+        // worst-case quoted length per element: 2*len + 2 (braces
+        // or backslashes) ; plus inter-element spaces (2 per pair —
+        // between key+value and between pairs) — over-allocate.
+        total += (el * 2 + 2) + (vs.len * 2 + 2) + 2;
+        nonempty += 1;
+    }
+    if (nonempty == 0) return obj_new_string(0, 0);
+    const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
+    var off: u32 = 0;
+    var written: u32 = 0;
+    i = 0;
+    while (i < cap) : (i += 1) {
+        const bucket = t + AR_HEADER_SIZE + i * AR_BUCKET_SIZE;
+        const raw = read_i32(bucket);
+        if (raw == 0 or raw == AR_TOMBSTONE) continue;
+        const ep: u32 = @bitCast(raw);
+        const el: u32 = @bitCast(read_i32(bucket + 4));
+        if (use_filter) {
+            const k = obj_new_string(@bitCast(ep), @bitCast(el));
+            if (obj_get_int(str_mod.string_match(pattern, k)) == 0) continue;
+        }
+        const v = read_i32(bucket + 12);
+        const vs = obj_ensure_string(v);
+        if (written > 0) {
+            const d: [*]u8 = @ptrFromInt(buf + off);
+            d[0] = ' ';
+            off += 1;
+        }
+        off = lq.list_elem_quote_nth(buf, off, ep, el);
+        const d2: [*]u8 = @ptrFromInt(buf + off);
+        d2[0] = ' ';
+        off += 1;
+        off = lq.list_elem_quote_nth(buf, off, vs.ptr, vs.len);
+        written += 1;
+    }
+    return obj_new_string(@bitCast(buf), @bitCast(off));
+}
+
 /// array_exists arrName — 1 if the array *variable* has ever been
 /// created, regardless of current element count.  This matches Tcl:
 /// ``set a(x) 1; unset a(x); array exists a`` returns 1 because the

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -815,8 +815,13 @@ pub export fn array_get(arr: i32, key: i32) i32 {
 pub export fn array_get_all(arr: i32, pattern: i32) i32 {
     const str_mod = @import("tcl_string.zig");
     const lq = @import("tcl_list_quote.zig");
-    const use_filter = pattern != 0 and blk: {
+    var pat_ptr: u32 = 0;
+    var pat_len: u32 = 0;
+    const use_filter = blk: {
+        if (pattern == 0) break :blk false;
         const ps = obj_ensure_string(pattern);
+        pat_ptr = ps.ptr;
+        pat_len = ps.len;
         break :blk ps.len > 0;
     };
     const t = find_table(arr);
@@ -836,8 +841,11 @@ pub export fn array_get_all(arr: i32, pattern: i32) i32 {
         const ep: u32 = @bitCast(raw);
         const el: u32 = @bitCast(read_i32(bucket + 4));
         if (use_filter) {
-            const k = obj_new_string(@bitCast(ep), @bitCast(el));
-            if (obj_get_int(str_mod.string_match(pattern, k)) == 0) continue;
+            // Match the raw key bytes via ``glob_match`` directly
+            // rather than allocating a TclObj per probe — the
+            // earlier ``string_match`` path leaked one key obj per
+            // entry across both passes.
+            if (!str_mod.glob_match(pat_ptr, pat_len, ep, el)) continue;
         }
         const v = read_i32(bucket + 12);
         const vs = obj_ensure_string(v);
@@ -860,8 +868,11 @@ pub export fn array_get_all(arr: i32, pattern: i32) i32 {
         const ep: u32 = @bitCast(raw);
         const el: u32 = @bitCast(read_i32(bucket + 4));
         if (use_filter) {
-            const k = obj_new_string(@bitCast(ep), @bitCast(el));
-            if (obj_get_int(str_mod.string_match(pattern, k)) == 0) continue;
+            // Match the raw key bytes via ``glob_match`` directly
+            // rather than allocating a TclObj per probe — the
+            // earlier ``string_match`` path leaked one key obj per
+            // entry across both passes.
+            if (!str_mod.glob_match(pat_ptr, pat_len, ep, el)) continue;
         }
         const v = read_i32(bucket + 12);
         const vs = obj_ensure_string(v);
@@ -877,7 +888,10 @@ pub export fn array_get_all(arr: i32, pattern: i32) i32 {
         off = lq.list_elem_quote_nth(buf, off, vs.ptr, vs.len);
         written += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    // ``obj_new_string_take`` so the returned TclObj owns the
+    // join buffer.  We over-allocated ``total`` bytes against the
+    // worst-case quote bound; ``off`` is the actual emitted size.
+    return obj.obj_new_string_take(buf, off, total);
 }
 
 /// array_exists arrName — 1 if the array *variable* has ever been
@@ -1010,8 +1024,13 @@ pub export fn array_unset_element(arr: i32, key: i32) i32 {
 /// returns every key.
 pub export fn array_names(arr: i32, pattern: i32) i32 {
     const str_mod = @import("tcl_string.zig");
-    const use_filter = pattern != 0 and blk: {
+    var pat_ptr: u32 = 0;
+    var pat_len: u32 = 0;
+    const use_filter = blk: {
+        if (pattern == 0) break :blk false;
         const ps = obj_ensure_string(pattern);
+        pat_ptr = ps.ptr;
+        pat_len = ps.len;
         break :blk ps.len > 0;
     };
     const t = find_table(arr);
@@ -1034,8 +1053,11 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
         const ep: u32 = @bitCast(raw);
         const el: u32 = @bitCast(read_i32(bucket + 4));
         if (use_filter) {
-            const k = obj_new_string(@bitCast(ep), @bitCast(el));
-            if (obj_get_int(str_mod.string_match(pattern, k)) == 0) continue;
+            // Match the raw key bytes via ``glob_match`` directly
+            // rather than allocating a TclObj per probe — the
+            // earlier ``string_match`` path leaked one key obj per
+            // entry across both passes.
+            if (!str_mod.glob_match(pat_ptr, pat_len, ep, el)) continue;
         }
         total += el;
         if (nonempty > 0) total += 1;
@@ -1053,8 +1075,11 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
         const ep: u32 = @bitCast(raw);
         const el: u32 = @bitCast(read_i32(bucket + 4));
         if (use_filter) {
-            const k = obj_new_string(@bitCast(ep), @bitCast(el));
-            if (obj_get_int(str_mod.string_match(pattern, k)) == 0) continue;
+            // Match the raw key bytes via ``glob_match`` directly
+            // rather than allocating a TclObj per probe — the
+            // earlier ``string_match`` path leaked one key obj per
+            // entry across both passes.
+            if (!str_mod.glob_match(pat_ptr, pat_len, ep, el)) continue;
         }
         if (written > 0) {
             const d: [*]u8 = @ptrFromInt(buf + off);


### PR DESCRIPTION
## Summary

This PR implements Tcl 9 expression evaluation semantics, including:

- **Numeric literal canonicalization**: Bare numeric literals (`0005`, `0x1234`, `1.5e2`) are normalized to their canonical forms (`5`, `4660`, `150.0`)
- **Quoted/braced operand shimmer**: Quoted strings and braced expressions that parse as numbers are converted to numeric form (e.g., `expr "0005"` returns `5`, not `"0005"`)
- **Strict boolean validation**: Logical operators (`||`, `&&`, `!`, ternary `?:`) now require boolean operands and raise `expected boolean value but got "X"` for non-boolean strings, matching Tcl 9 behavior
- **Keyword operator boundary fix**: String comparison operators like `eq` now correctly reject digits as identifier continuations, so `expr 3eq2` parses as `3 eq 2` instead of failing
- **Floor division semantics**: The `/` operator now uses floor division (rounds toward negative infinity) instead of truncation, so `-1 / 2` returns `-1` (not `0`)
- **Numeric operand validation**: Arithmetic operators (`+`, `-`, `*`, `/`, `%`) validate operands are numeric and raise appropriate errors for non-numeric strings
- **Exponent parsing guard**: The `e`/`E` in numeric literals only starts a float exponent when followed by a digit (with optional sign), preventing greedy consumption in expressions like `3eq2`
- **Namespace eval relative resolution**: `namespace eval` now resolves unqualified namespace names relative to the current namespace instead of always anchoring at root
- **Namespace import validation**: Added validation for empty import patterns and unknown namespaces in `namespace import`
- **Variable substitution error handling**: `${unset_var}` now properly raises `can't read "unset_var": no such variable` instead of silently dropping the slot
- **Array get implementation**: Implemented `array get arr ?pattern?` to return all matching key-value pairs as a flat list with optional glob filtering
- **Uplevel absolute levels**: Added support for `uplevel #N` syntax for absolute frame levels (e.g., `#0` for global scope)
- **Return -level 0 support**: `return -level 0` now suppresses the implicit proc exit, used by `lmap`/`foreach` body sentinels
- **Expression argument concatenation**: `expr` now concatenates multiple arguments with spaces before evaluation (e.g., `expr 20 - 5 +10 -7` → `18`)
- **ExprRaw codegen support**: Added handling for unparsed expression operands from backslash substitution in quoted contexts

## Validation

- Existing test suite passes (expr-*.test, namespace-*.test, array-*.test, etc.)
- New unit tests added for floor division, numeric canonicalization, and strict boolean validation
- Compiler codegen updated to handle new expression semantics and runtime helpers

https://claude.ai/code/session_01KujX3hzbADcY9WnoDUHmVA