### PR TITLE
Fix variable resolution and trace dispatch in namespace contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,15 +93,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Zig (needed for runtime auto-build)
-        run: |
-          set -eu
-          ZIG_VERSION=0.16.0
-          curl -fsSLo /tmp/zig.tar.xz \
-            "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
-          mkdir -p /opt/zig
-          tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
-          echo "/opt/zig" >> "$GITHUB_PATH"
-          /opt/zig/zig version
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Sync Python environment
         run: uv sync --extra dev

--- a/core/compiler/codegen/wasm/_emitter/_variables.py
+++ b/core/compiler/codegen/wasm/_emitter/_variables.py
@@ -1195,7 +1195,9 @@ class _WasmEmitterVarMixin(_Base):
                     # Single-evaluate via the resolved-name local
                     # ``_var_dyn_resolved`` and reference it from both
                     # paths (Codex review on PR #343).
-                    resolved_idx = self._add_extra_local(prefix="_var_dyn_resolved", val_type=ValType.I32)
+                    resolved_idx = self._add_extra_local(
+                        prefix="_var_dyn_resolved", val_type=ValType.I32
+                    )
                     self._emit_value(name)
                     self._emit_local_set(resolved_idx)
                     qname_idx = self._add_extra_local(prefix="_var_dyn_qname", val_type=ValType.I32)

--- a/core/compiler/codegen/wasm/_emitter/_variables.py
+++ b/core/compiler/codegen/wasm/_emitter/_variables.py
@@ -1183,9 +1183,24 @@ class _WasmEmitterVarMixin(_Base):
                 # landed).
                 if append_idx is not None and (alias_named_idx is not None or gset_idx is not None):
                     ns_prefix = f"{ns}::" if ns != "::" else "::"
+                    # Substitute the dynamic name *once* and stash both
+                    # the resolved local-name TclObj (used for the
+                    # alias install) and the qualified ``<ns>::<name>``
+                    # TclObj (used for the optional value write).  The
+                    # earlier shape called ``self._emit_value(name)``
+                    # twice — for ``[incr i]``-style names (Tcl
+                    # argument substitution is single-pass per word)
+                    # that incremented the counter twice and bound the
+                    # alias to a different name than the write target.
+                    # Single-evaluate via the resolved-name local
+                    # ``_var_dyn_resolved`` and reference it from both
+                    # paths (Codex review on PR #343).
+                    resolved_idx = self._add_extra_local(prefix="_var_dyn_resolved", val_type=ValType.I32)
+                    self._emit_value(name)
+                    self._emit_local_set(resolved_idx)
                     qname_idx = self._add_extra_local(prefix="_var_dyn_qname", val_type=ValType.I32)
                     self._emit_obj_literal(ns_prefix)
-                    self._emit_value(name)
+                    self._emit_local_get(resolved_idx)
                     self._emit_call(append_idx)
                     self._emit_local_set(qname_idx)
                     # Install local alias ``<name-value>`` ->
@@ -1197,7 +1212,7 @@ class _WasmEmitterVarMixin(_Base):
                     # KIND_GLOBAL_NAMED branch — no descriptor
                     # extension needed.
                     if alias_named_idx is not None:
-                        self._emit_value(name)
+                        self._emit_local_get(resolved_idx)
                         self._emit_local_get(qname_idx)
                         self._emit_call(alias_named_idx)
                     if has_value and gset_idx is not None:

--- a/core/compiler/codegen/wasm/_emitter/_variables.py
+++ b/core/compiler/codegen/wasm/_emitter/_variables.py
@@ -123,6 +123,18 @@ class _WasmEmitterVarMixin(_Base):
         array_ref = _parse_array_ref(name)
         if array_ref is not None:
             self._emit_array_element_read(*array_ref)
+            # Reference Tcl raises ``can't read "arr(key)": no such
+            # variable`` when the element is missing.  ``tcl_array_get``
+            # signals "missing" by returning the null TclObj handle;
+            # without this check the compiled ``return $arr(key)`` for
+            # an absent element silently propagated empty, so
+            # ``proc tcltest::ConstraintInitializer {... {script ""}}
+            # { return $ConstraintInitializer($constraint) }`` returned
+            # ``""`` instead of erroring — which let SafeFetch's outer
+            # ``catch`` succeed with rc=0 and leave
+            # ``testConstraints(valgrind)`` unset, so PR #341's strict-
+            # boolean ``!`` then trapped on the empty result.
+            self._emit_unset_check_with_alias(name)
             return
         binding = self._aliases.get(name)
         if binding is not None:
@@ -1155,46 +1167,57 @@ class _WasmEmitterVarMixin(_Base):
                 gset_idx = self._shared_imports.get("tcl_global_set")
                 append_idx = self._shared_imports.get("tcl_append")
                 gexist_idx = self._shared_imports.get("tcl_global_exists")
-                if has_value and gset_idx is not None and append_idx is not None:
-                    # Construct ``<ns>::<name>`` at runtime by
-                    # concatenating the namespace prefix with the
-                    # dynamic name value via ``tcl_append``.  Stash
-                    # the result in a hidden local so the existence
-                    # check and the write can reuse it without
-                    # recomputing the concat.
+                alias_named_idx = self._shared_imports.get("tcl_frame_alias_named")
+                # Build ``<ns>::<name>`` at runtime — needed for both
+                # the alias install (so later ``array set $n $v`` /
+                # ``$n(key)`` reads from the proc's own frame route to
+                # the namespace's array directory under the canonical
+                # FQ key) and the optional value write.  Without the
+                # alias install, tcltest's ``ArrayDefault`` /
+                # ``Default`` (``variable $varName ?value?``)
+                # populated a synthetic ``::__local::<depth>::<n>``
+                # array that no caller could observe — so
+                # ``cleanupTests``'s ``$numTests(Skipped)`` lookup
+                # came back empty (silent before PR #341, then a
+                # strict-check trap once the missing-element raise
+                # landed).
+                if append_idx is not None and (alias_named_idx is not None or gset_idx is not None):
                     ns_prefix = f"{ns}::" if ns != "::" else "::"
                     qname_idx = self._add_extra_local(prefix="_var_dyn_qname", val_type=ValType.I32)
                     self._emit_obj_literal(ns_prefix)
                     self._emit_value(name)
                     self._emit_call(append_idx)
                     self._emit_local_set(qname_idx)
-                    # ``variable`` only initialises when the variable
-                    # does not already exist — check via
-                    # ``tcl_global_exists`` and skip the write on hit.
-                    if gexist_idx is not None:
+                    # Install local alias ``<name-value>`` ->
+                    # ``<ns>::<name-value>`` (KIND_GLOBAL_NAMED) so
+                    # subsequent ``array set $n …`` / ``$n(key)``
+                    # references inside this proc body resolve to the
+                    # namespace's array directory.  Routes through
+                    # ``frame_resolve_array_name``'s existing
+                    # KIND_GLOBAL_NAMED branch — no descriptor
+                    # extension needed.
+                    if alias_named_idx is not None:
+                        self._emit_value(name)
                         self._emit_local_get(qname_idx)
-                        self._emit_call(gexist_idx)
-                        self._emit_call(self._shared_imports["tcl_obj_get_int"])
-                        self._emit(WasmOp.I64_EQZ)
-                        self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
-                        self._emit_local_get(qname_idx)
-                        self._emit_value(args[i + 1])
-                        self._emit_call(gset_idx)
-                        self._emit(WasmOp.DROP)
-                        self._emit(WasmOp.END)
-                    else:
-                        self._emit_local_get(qname_idx)
-                        self._emit_value(args[i + 1])
-                        self._emit_call(gset_idx)
-                        self._emit(WasmOp.DROP)
-                    i += 2
-                else:
-                    # Bare ``variable $name`` declaration or missing
-                    # runtime helpers — nothing to emit at compile time;
-                    # reads of the local ``name`` won't route through a
-                    # namespace alias, but that's the same degraded
-                    # mode we had before dynamic support landed.
-                    i += 2 if has_value else 1
+                        self._emit_call(alias_named_idx)
+                    if has_value and gset_idx is not None:
+                        if gexist_idx is not None:
+                            self._emit_local_get(qname_idx)
+                            self._emit_call(gexist_idx)
+                            self._emit_call(self._shared_imports["tcl_obj_get_int"])
+                            self._emit(WasmOp.I64_EQZ)
+                            self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+                            self._emit_local_get(qname_idx)
+                            self._emit_value(args[i + 1])
+                            self._emit_call(gset_idx)
+                            self._emit(WasmOp.DROP)
+                            self._emit(WasmOp.END)
+                        else:
+                            self._emit_local_get(qname_idx)
+                            self._emit_value(args[i + 1])
+                            self._emit_call(gset_idx)
+                            self._emit(WasmOp.DROP)
+                i += 2 if has_value else 1
                 continue
 
             # Resolve the target name: ``::ns::name`` for unqualified

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -115,6 +115,74 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
     return result_mod.from_globals(trace_mod.tcl_cmd_trace_cmd(sub, arg_obj));
 }
 
+/// Resolve a user-supplied variable name to the canonical FQ form
+/// the trace directory keys against.  Mirrors what reference Tcl
+/// does when ``trace add variable NAME …`` runs inside a
+/// ``namespace eval`` body: an unqualified ``NAME`` resolves
+/// against the active namespace, so a later read via
+/// ``$::ns::NAME`` (or via a proc-local ``variable NAME`` alias)
+/// fires the trace.  Without this, ``trace add variable a …``
+/// inside ``namespace eval ::ns { … }`` registered against a bare
+/// ``a`` while the array module looked up traces under
+/// ``::ns::a`` — so ``tcltest::SafeFetch`` never fired and
+/// ``$testConstraints(valgrind)`` returned ``""`` instead of
+/// triggering the lazy initialiser, which our PR #341 strict-
+/// boolean ``!`` then rejected (regression that emptied
+/// ``string.test`` and friends).
+///
+/// Rules (in order):
+///   1. Names starting with ``::`` pass through unchanged.
+///   2. Names containing ``::`` but not starting with it get a
+///      leading ``::`` so ``ns::var`` becomes ``::ns::var``;
+///      mirrors :func:`tcl_array.normalize_ns_name`.
+///   3. Bare names at top level inside a non-root namespace
+///      (``frame_depth == 0`` and ``current_ns_full_len > 2``)
+///      get prefixed with ``<current_ns>::``.
+///   4. Anything else passes through unchanged.
+fn canonical_var_name(name: i32) i32 {
+    const sn = obj_ensure_string(name);
+    if (sn.ptr == 0 or sn.len == 0) return name;
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    if (sn.len >= 2 and sp[0] == ':' and sp[1] == ':') return name;
+    // Probe for an internal ``::`` — if present, ``ns::var`` form;
+    // prepend ``::`` to FQ-ify per :func:`tcl_array.normalize_ns_name`.
+    var i: u32 = 0;
+    while (i + 1 < sn.len) : (i += 1) {
+        if (sp[i] == ':' and sp[i + 1] == ':') {
+            const total: u32 = sn.len + 2;
+            const buf = rt.alloc(total);
+            if (buf == 0) return name;
+            const dst: [*]u8 = @ptrFromInt(buf);
+            dst[0] = ':';
+            dst[1] = ':';
+            for (0..sn.len) |k| dst[2 + k] = sp[k];
+            return obj_new_string(@bitCast(buf), @bitCast(total));
+        }
+    }
+    // Bare unqualified name — only top-level (frame_depth == 0)
+    // calls reach here, since ``is_local_trace_target`` already
+    // routed proc-local bare-name traces to the per-frame chain.
+    // When a ``namespace eval`` body is active, qualify against
+    // the running namespace so the canonical-name dir matches the
+    // ``::ns::name`` form used by the array fire path and by
+    // ``variable``-aliased proc-local reads.
+    if (frames.frame_depth != 0) return name;
+    const tcl_ns = @import("../interp/tcl_ns.zig");
+    const ns_ptr = tcl_ns.current_ns_full_ptr();
+    const ns_len = tcl_ns.current_ns_full_len();
+    if (ns_len <= 2) return name; // root namespace ``::`` — no qualification
+    const total: u32 = ns_len + 2 + sn.len;
+    const buf = rt.alloc(total);
+    if (buf == 0) return name;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    const ns_p: [*]const u8 = @ptrFromInt(ns_ptr);
+    for (0..ns_len) |k| dst[k] = ns_p[k];
+    dst[ns_len] = ':';
+    dst[ns_len + 1] = ':';
+    for (0..sn.len) |k| dst[ns_len + 2 + k] = sp[k];
+    return obj_new_string(@bitCast(buf), @bitCast(total));
+}
+
 /// Phase 6 follow-up: route a trace install to the per-frame chain
 /// when the target is a proc-local, otherwise to the canonical-name
 /// directory.  Centralised so all ``trace add variable`` /
@@ -124,7 +192,7 @@ fn install_var_trace(name: i32, ops: u32, cmd_prefix: i32) void {
         var_trace.add_to_list(&frames.frame_trace_heads[frames.frame_depth - 1], name, ops, cmd_prefix);
         return;
     }
-    var_trace.add(name, ops, cmd_prefix);
+    var_trace.add(canonical_var_name(name), ops, cmd_prefix);
 }
 
 /// Mirror of :func:`install_var_trace` for the remove path.
@@ -132,7 +200,7 @@ fn uninstall_var_trace(name: i32, ops: u32, cmd_prefix: i32) bool {
     if (is_local_trace_target(name)) {
         return var_trace.remove_from_list(&frames.frame_trace_heads[frames.frame_depth - 1], name, ops, cmd_prefix);
     }
-    return var_trace.remove(name, ops, cmd_prefix);
+    return var_trace.remove(canonical_var_name(name), ops, cmd_prefix);
 }
 
 /// Mirror of :func:`install_var_trace` for the ``trace info`` query.
@@ -140,7 +208,7 @@ fn query_var_trace(name: i32) i32 {
     if (is_local_trace_target(name)) {
         return var_trace.info_for_list(frames.frame_trace_heads[frames.frame_depth - 1], name);
     }
-    return var_trace.info(name);
+    return var_trace.info(canonical_var_name(name));
 }
 
 /// Parse the ops list ``{read write unset array}`` (any subset, in
@@ -169,10 +237,15 @@ fn eval_pid(words: []const i32) result_mod.InterpResult {
 }
 
 /// Stub for ``tcl::build-info`` — returns a hard-coded string for the
-/// queries Tcl test suites actually use (``patchlevel``, ``version``,
-/// ``commit``).  The real C Tcl reads these from compile-time defines
-/// in ``tclConfig.sh``; for our WASM runtime, returning sensible
-/// strings is enough to keep tests like ``format.test`` running.
+/// known string queries (``patchlevel``, ``version``, ``commit``,
+/// ``compiler``).  Reference Tcl 9 (``BuildInfoObjCmd2`` in
+/// ``generic/tclBasic.c``) treats any other identifier as a boolean
+/// presence check against the build-info string and returns
+/// ``Tcl_NewBooleanObj(0)`` when the flag is absent — so callers like
+/// ``tcltests.tcl`` can write ``expr {![tcl::build-info no-deprecate]}``
+/// without tripping strict-boolean rules.  Our WASM build claims none of
+/// the optional flags (``no-deprecate``, ``debug``, ``purify``,
+/// ``memdebug``, …), so unknown keys must return ``0``, not ``""``.
 fn eval_tcl_build_info(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) {
         return result_mod.from_globals(obj_new_string_lit("9.0.3"));
@@ -182,11 +255,10 @@ fn eval_tcl_build_info(words: []const i32) result_mod.InterpResult {
     if (str_eq(sp, sub.len, "patchlevel")) return result_mod.from_globals(obj_new_string_lit("9.0.3"));
     if (str_eq(sp, sub.len, "version")) return result_mod.from_globals(obj_new_string_lit("9.0"));
     if (str_eq(sp, sub.len, "commit")) return result_mod.from_globals(obj_new_string_lit("0000000000000000000000000000000000000000"));
-    if (str_eq(sp, sub.len, "branch")) return result_mod.from_globals(obj_new_string_lit("core-9-0-3"));
     if (str_eq(sp, sub.len, "compiler")) return result_mod.from_globals(obj_new_string_lit("zig-wasm32"));
-    // Unknown sub-key — return empty rather than trapping; matches
-    // reference Tcl which returns "" for unknown build-info keys.
-    return result_mod.from_globals(obj_new_string(0, 0));
+    // Unknown sub-key: boolean presence check.  None of the optional
+    // build flags are set in our runtime, so always answer ``0``.
+    return result_mod.from_globals(obj_new_string_lit("0"));
 }
 
 /// Helper: allocate a TclObj wrapping a Zig string literal.  The

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -32,7 +32,9 @@ fn is_local_trace_target(name: i32) bool {
 }
 
 const str_eq            = @import("../valtypes/tcl_chars.zig").str_eq;
-const obj_new_string    = rt.obj_new_string;
+const obj_new_string      = rt.obj_new_string;
+const obj_new_string_take = rt.obj_new_string_take;
+const tcl_obj_release     = @import("../valtypes/tcl_obj.zig").tcl_obj_release;
 const obj_ensure_string = rt.obj_ensure_string;
 
 fn eval_info(words: []const i32) result_mod.InterpResult {
@@ -156,7 +158,12 @@ fn canonical_var_name(name: i32) i32 {
             dst[0] = ':';
             dst[1] = ':';
             for (0..sn.len) |k| dst[2 + k] = sp[k];
-            return obj_new_string(@bitCast(buf), @bitCast(total));
+            // ``obj_new_string_take`` so the freshly-allocated buffer
+            // is owned by the returned TclObj — releasing the obj
+            // reclaims the bytes.  The earlier ``obj_new_string``
+            // form left ``OBJ_STR_CAP=0`` and leaked the buffer
+            // (Copilot review on PR #343).
+            return obj_new_string_take(buf, total, total);
         }
     }
     // Bare unqualified name — only top-level (frame_depth == 0)
@@ -180,19 +187,29 @@ fn canonical_var_name(name: i32) i32 {
     dst[ns_len] = ':';
     dst[ns_len + 1] = ':';
     for (0..sn.len) |k| dst[ns_len + 2 + k] = sp[k];
-    return obj_new_string(@bitCast(buf), @bitCast(total));
+    return obj_new_string_take(buf, total, total);
 }
 
 /// Phase 6 follow-up: route a trace install to the per-frame chain
 /// when the target is a proc-local, otherwise to the canonical-name
 /// directory.  Centralised so all ``trace add variable`` /
 /// ``trace variable`` entry points stay in sync.
+///
+/// :func:`canonical_var_name` may return either the original
+/// *name* TclObj (no qualification needed) or a freshly-allocated
+/// owning TclObj.  Release the canonical handle when it's a fresh
+/// alloc (i.e., differs from the input handle) so the
+/// canonicalisation buffer doesn't leak — ``var_trace.add`` /
+/// ``remove`` / ``info`` only read the bytes through the handle
+/// and don't retain it (Copilot review on PR #343).
 fn install_var_trace(name: i32, ops: u32, cmd_prefix: i32) void {
     if (is_local_trace_target(name)) {
         var_trace.add_to_list(&frames.frame_trace_heads[frames.frame_depth - 1], name, ops, cmd_prefix);
         return;
     }
-    var_trace.add(canonical_var_name(name), ops, cmd_prefix);
+    const canon = canonical_var_name(name);
+    var_trace.add(canon, ops, cmd_prefix);
+    if (canon != name and canon != 0) tcl_obj_release(canon);
 }
 
 /// Mirror of :func:`install_var_trace` for the remove path.
@@ -200,7 +217,10 @@ fn uninstall_var_trace(name: i32, ops: u32, cmd_prefix: i32) bool {
     if (is_local_trace_target(name)) {
         return var_trace.remove_from_list(&frames.frame_trace_heads[frames.frame_depth - 1], name, ops, cmd_prefix);
     }
-    return var_trace.remove(canonical_var_name(name), ops, cmd_prefix);
+    const canon = canonical_var_name(name);
+    const result = var_trace.remove(canon, ops, cmd_prefix);
+    if (canon != name and canon != 0) tcl_obj_release(canon);
+    return result;
 }
 
 /// Mirror of :func:`install_var_trace` for the ``trace info`` query.
@@ -208,7 +228,10 @@ fn query_var_trace(name: i32) i32 {
     if (is_local_trace_target(name)) {
         return var_trace.info_for_list(frames.frame_trace_heads[frames.frame_depth - 1], name);
     }
-    return var_trace.info(canonical_var_name(name));
+    const canon = canonical_var_name(name);
+    const result = var_trace.info(canon);
+    if (canon != name and canon != 0) tcl_obj_release(canon);
+    return result;
 }
 
 /// Parse the ops list ``{read write unset array}`` (any subset, in

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -372,12 +372,31 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
             // Build ``::namespace inscope <ns> <script>`` via
             // ``tcl_list`` so each element is properly list-quoted
             // (handles braces, spaces, backslashes in ``<script>``).
-            var acc: i32 = obj_new_string_copy(0, 0);
-            acc = rt.tcl_list(acc, obj_new_string_copy(@bitCast(@intFromPtr("::namespace".ptr)), 11));
-            acc = rt.tcl_list(acc, obj_new_string_copy(@bitCast(@intFromPtr("inscope".ptr)), 7));
-            acc = rt.tcl_list(acc, obj_new_string_copy(@bitCast(nf.ptr), @bitCast(nf.len)));
-            acc = rt.tcl_list(acc, words[2]);
-            return result_mod.from_globals(acc);
+            // ``tcl_list(a, b)`` allocates a fresh accumulator each
+            // call without consuming either input — release the
+            // previous accumulator and the per-element TclObjs after
+            // each append so the only live owner is the current
+            // ``acc`` (Copilot review on PR #343).  ``words[2]`` is
+            // owned by the caller; do NOT release it here.
+            var acc: i32 = obj_mod.obj_new_string_copy(0, 0);
+            const e1 = obj_mod.obj_new_string_copy(@bitCast(@intFromPtr("::namespace".ptr)), 11);
+            const a1 = rt.tcl_list(acc, e1);
+            obj_mod.tcl_obj_release(acc);
+            obj_mod.tcl_obj_release(e1);
+            acc = a1;
+            const e2 = obj_mod.obj_new_string_copy(@bitCast(@intFromPtr("inscope".ptr)), 7);
+            const a2 = rt.tcl_list(acc, e2);
+            obj_mod.tcl_obj_release(acc);
+            obj_mod.tcl_obj_release(e2);
+            acc = a2;
+            const e3 = obj_mod.obj_new_string_copy(@bitCast(nf.ptr), @bitCast(nf.len));
+            const a3 = rt.tcl_list(acc, e3);
+            obj_mod.tcl_obj_release(acc);
+            obj_mod.tcl_obj_release(e3);
+            acc = a3;
+            const a4 = rt.tcl_list(acc, words[2]);
+            obj_mod.tcl_obj_release(acc);
+            return result_mod.from_globals(a4);
         }
     }
     return result_mod.from_globals(0);

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -328,11 +328,56 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
             }
             return result_mod.from_globals(interp.eval_script(buf, total));
         }
-        // ``namespace code script`` — wrap with [namespace inscope current script]
-        // For our purposes, return the script unchanged (no-op approximation).
+        // ``namespace code script`` — return a script that evaluates
+        // *script* in the current namespace.  Reference Tcl
+        // (``NamespaceCodeCmd`` in ``generic/tclNamesp.c``) returns
+        // ``::namespace inscope <currentNs> <script>`` (with *script*
+        // properly list-quoted) so the resulting prefix is callable
+        // from any context — e.g. ``trace add variable v read
+        // [namespace code SafeFetch]`` registered against a callback
+        // that lives in ``::tcltest`` but isn't ``namespace export``-ed,
+        // so the trace fire path needs the inscope wrapping to find
+        // it.  When *script* already begins with ``::namespace
+        // inscope `` or ``namespace inscope `` it's returned
+        // unchanged (idempotent).  The previous "return the script
+        // unchanged (no-op approximation)" implementation registered
+        // bare callback names that the trace dispatcher looked up in
+        // root, so unexported ``::tcltest::SafeFetch`` traces silently
+        // failed and ``$testConstraints(valgrind)`` never populated —
+        // tcltests.tcl's ``expr {![testConstraint valgrind]}`` then
+        // tripped PR #341's strict-boolean ``!`` (string.test
+        // regression).
         if (str_eq(@ptrFromInt(sub.ptr), sub.len, "code")) {
             if (words.len < 3) return result_mod.from_globals(obj_new_string(0, 0));
-            return result_mod.from_globals(words[2]);
+            const ss = obj_ensure_string(words[2]);
+            // Idempotency check — already wrapped scripts pass
+            // through.  Match both the canonical ``::namespace
+            // inscope `` and the unqualified ``namespace inscope ``
+            // forms, mirroring reference Tcl.
+            if (ss.len >= 20) {
+                const sp: [*]const u8 = @ptrFromInt(ss.ptr);
+                const fq = "::namespace inscope ";
+                var ok: bool = true;
+                for (0..fq.len) |k| if (sp[k] != fq[k]) { ok = false; break; };
+                if (ok) return result_mod.from_globals(words[2]);
+            }
+            if (ss.len >= 18) {
+                const sp: [*]const u8 = @ptrFromInt(ss.ptr);
+                const bare = "namespace inscope ";
+                var ok: bool = true;
+                for (0..bare.len) |k| if (sp[k] != bare[k]) { ok = false; break; };
+                if (ok) return result_mod.from_globals(words[2]);
+            }
+            const nf = tcl_ns.ns_full_name(tcl_ns.ns_current());
+            // Build ``::namespace inscope <ns> <script>`` via
+            // ``tcl_list`` so each element is properly list-quoted
+            // (handles braces, spaces, backslashes in ``<script>``).
+            var acc: i32 = obj_new_string_copy(0, 0);
+            acc = rt.tcl_list(acc, obj_new_string_copy(@bitCast(@intFromPtr("::namespace".ptr)), 11));
+            acc = rt.tcl_list(acc, obj_new_string_copy(@bitCast(@intFromPtr("inscope".ptr)), 7));
+            acc = rt.tcl_list(acc, obj_new_string_copy(@bitCast(nf.ptr), @bitCast(nf.len)));
+            acc = rt.tcl_list(acc, words[2]);
+            return result_mod.from_globals(acc);
         }
     }
     return result_mod.from_globals(0);

--- a/runtime/zig/cmds/scope.zig
+++ b/runtime/zig/cmds/scope.zig
@@ -30,7 +30,44 @@ fn eval_variable(words: []const i32) result_mod.InterpResult {
         if (r.target_ns == 0 or r.simple_len == 0) continue;
         const var_ptr = tcl_ns.ns_var_create(r.target_ns, r.simple_ptr, r.simple_len);
         const local_name = obj_new_string(@bitCast(r.simple_ptr), @bitCast(r.simple_len));
-        frames.frame_alias_ns_var(local_name, var_ptr);
+        // Build the FQ name ``<ns_full>::<simple>`` so
+        // :func:`frame_resolve_array_name` can route array writes /
+        // reads (``set arr(k) v`` from inside the proc body) to the
+        // namespace's array directory entry rather than synthesising
+        // a proc-local ``::__local::<depth>::<simple>`` array — which
+        // is the wrong storage and silently disconnects writes from
+        // the trace dispatch keyed on the FQ form.  Root-namespace
+        // case (``ns_full = "::"``) drops the trailing ``::`` so the
+        // result is ``::simple`` instead of ``::::simple``.
+        const ns_full = tcl_ns.ns_full_name(r.target_ns);
+        var full_name: i32 = 0;
+        if (ns_full.len == 2) {
+            // Root namespace — emit ``::simple``.
+            const total: u32 = 2 + r.simple_len;
+            const buf = rt.alloc(total);
+            if (buf != 0) {
+                const dst: [*]u8 = @ptrFromInt(buf);
+                dst[0] = ':';
+                dst[1] = ':';
+                const sp: [*]const u8 = @ptrFromInt(r.simple_ptr);
+                for (0..r.simple_len) |k| dst[2 + k] = sp[k];
+                full_name = obj_new_string(@bitCast(buf), @bitCast(total));
+            }
+        } else if (ns_full.len > 0) {
+            const total: u32 = ns_full.len + 2 + r.simple_len;
+            const buf = rt.alloc(total);
+            if (buf != 0) {
+                const dst: [*]u8 = @ptrFromInt(buf);
+                const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+                for (0..ns_full.len) |k| dst[k] = np[k];
+                dst[ns_full.len] = ':';
+                dst[ns_full.len + 1] = ':';
+                const sp: [*]const u8 = @ptrFromInt(r.simple_ptr);
+                for (0..r.simple_len) |k| dst[ns_full.len + 2 + k] = sp[k];
+                full_name = obj_new_string(@bitCast(buf), @bitCast(total));
+            }
+        }
+        frames.frame_alias_ns_var(local_name, var_ptr, full_name);
         if (i + 1 < words.len) {
             tcl_ns.var_set_scalar(var_ptr, @bitCast(words[i + 1]));
             i += 1;

--- a/runtime/zig/cmds/scope.zig
+++ b/runtime/zig/cmds/scope.zig
@@ -30,44 +30,22 @@ fn eval_variable(words: []const i32) result_mod.InterpResult {
         if (r.target_ns == 0 or r.simple_len == 0) continue;
         const var_ptr = tcl_ns.ns_var_create(r.target_ns, r.simple_ptr, r.simple_len);
         const local_name = obj_new_string(@bitCast(r.simple_ptr), @bitCast(r.simple_len));
-        // Build the FQ name ``<ns_full>::<simple>`` so
-        // :func:`frame_resolve_array_name` can route array writes /
-        // reads (``set arr(k) v`` from inside the proc body) to the
-        // namespace's array directory entry rather than synthesising
-        // a proc-local ``::__local::<depth>::<simple>`` array — which
-        // is the wrong storage and silently disconnects writes from
-        // the trace dispatch keyed on the FQ form.  Root-namespace
-        // case (``ns_full = "::"``) drops the trailing ``::`` so the
-        // result is ``::simple`` instead of ``::::simple``.
-        const ns_full = tcl_ns.ns_full_name(r.target_ns);
-        var full_name: i32 = 0;
-        if (ns_full.len == 2) {
-            // Root namespace — emit ``::simple``.
-            const total: u32 = 2 + r.simple_len;
-            const buf = rt.alloc(total);
-            if (buf != 0) {
-                const dst: [*]u8 = @ptrFromInt(buf);
-                dst[0] = ':';
-                dst[1] = ':';
-                const sp: [*]const u8 = @ptrFromInt(r.simple_ptr);
-                for (0..r.simple_len) |k| dst[2 + k] = sp[k];
-                full_name = obj_new_string(@bitCast(buf), @bitCast(total));
-            }
-        } else if (ns_full.len > 0) {
-            const total: u32 = ns_full.len + 2 + r.simple_len;
-            const buf = rt.alloc(total);
-            if (buf != 0) {
-                const dst: [*]u8 = @ptrFromInt(buf);
-                const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
-                for (0..ns_full.len) |k| dst[k] = np[k];
-                dst[ns_full.len] = ':';
-                dst[ns_full.len + 1] = ':';
-                const sp: [*]const u8 = @ptrFromInt(r.simple_ptr);
-                for (0..r.simple_len) |k| dst[ns_full.len + 2 + k] = sp[k];
-                full_name = obj_new_string(@bitCast(buf), @bitCast(total));
-            }
-        }
-        frames.frame_alias_ns_var(local_name, var_ptr, full_name);
+        // Pass the target namespace + simple-name span through to
+        // ``frame_alias_ns_var`` so :func:`frame_resolve_array_name`
+        // can synthesise a fresh ``<ns_full>::<simple>`` TclObj on
+        // demand (caller releases) — without the alias, ``set
+        // arr(k) v`` from inside the proc body would land in a
+        // synthetic ``::__local::<depth>::<simple>`` array and
+        // disconnect writes from the trace dispatch keyed on the
+        // FQ form (string.test SafeFetch path).  The earlier shape
+        // here built a TclObj for the FQ name and stashed its
+        // handle in the alias descriptor, but the namespace var's
+        // simple-name span — owned by the namespace's own
+        // ``var_table`` bucket — is stable for the namespace's
+        // lifetime, so we can defer the FQ-name materialisation
+        // and avoid descriptor-side TclObj lifetime questions
+        // (Copilot review on PR #343).
+        frames.frame_alias_ns_var(local_name, var_ptr, r.target_ns, r.simple_ptr, r.simple_len);
         if (i + 1 < words.len) {
             tcl_ns.var_set_scalar(var_ptr, @bitCast(words[i + 1]));
             i += 1;

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -1244,7 +1244,30 @@ fn resolve_ext_exists(desc: u32, local_name: i32) i32 {
         // initialiser branch — the bare ``variable $n`` had already
         // fabricated a Var entry and the previous "tgt non-zero ⇒
         // exists" rule reported it as initialised.
+        //
+        // Two shapes to distinguish:
+        //   * scalar var — ``var_get_scalar`` returns the stored
+        //     TclObj handle (or 0 for unset).
+        //   * array-shaped var (``VAR_ARRAY`` flag set) — the
+        //     storage lives in the array directory keyed by the
+        //     FQ name synthesised from the ``target_ns`` /
+        //     ``(simple_ptr, simple_len)`` triple we stashed at
+        //     ``desc+12 .. desc+24`` when ``frame_alias_ns_var``
+        //     ran.  ``var_get_scalar`` deliberately returns 0 for
+        //     arrays, so without the array-directory probe
+        //     ``info exists arr`` after ``array set arr {...}``
+        //     would falsely report 0 (Codex review on PR #343).
         if (tgt == 0) return obj_new_int(0);
+        const v: *const tcl_ns.Var = @ptrFromInt(@as(u32, @bitCast(tgt)));
+        if ((v.flags & tcl_ns.VAR_ARRAY) != 0) {
+            const tcl_array = @import("../valtypes/tcl_array.zig");
+            // Reuse ``frame_resolve_array_name`` to synthesise the
+            // FQ-name TclObj — same logic, shared cleanup pattern.
+            const arr_name = frame_resolve_array_name(local_name);
+            const present = tcl_array.array_exists(arr_name);
+            if (arr_name != local_name) obj.tcl_obj_release(arr_name);
+            return present;
+        }
         const val = tcl_ns.var_get_scalar(@bitCast(tgt));
         return if (val != 0) obj_new_int(1) else obj_new_int(0);
     }
@@ -1381,32 +1404,41 @@ pub export fn frame_alias_frame_var(local_name: i32, abs_depth: i32, target_name
 /// value is the negated descriptor address.  Reads / writes go
 /// through ``var_get_scalar`` / ``var_set_scalar`` which transparently
 /// chase ``VAR_LINK`` chains on the target side.
-pub fn frame_alias_ns_var(local_name: i32, var_ptr: u32, full_name: i32) void {
+pub fn frame_alias_ns_var(local_name: i32, var_ptr: u32, target_ns: u32, simple_ptr: u32, simple_len: u32) void {
     const cur = current_frame() orelse return;
-    // Descriptor layout (16 bytes — extended from the 12-byte form
+    // Descriptor layout (24 bytes — extended from the 12-byte form
     // for KIND_GLOBAL_NAMED / KIND_FRAME_VAR):
-    //   desc[0..4]  = kind
-    //   desc[4..8]  = unused (mirrors the GLOBAL_NAMED/FRAME_VAR
-    //                 ``param`` slot)
-    //   desc[8..12] = ``*Var`` for the namespace var (scalar fast path)
-    //   desc[12..16] = TclObj of the FQ name, used by
-    //                 :func:`frame_resolve_array_name` so a proc-local
-    //                 ``variable arr`` correctly routes ``set arr(k)``
-    //                 to the namespace's array directory entry rather
-    //                 than the synthetic ``::__local::<depth>::arr``
-    //                 form.  Without it, traces installed against the
-    //                 namespace array (e.g. tcltest's ``SafeFetch``
-    //                 read trace on ``::tcltest::testConstraints``)
-    //                 never fire from inside an interpreted proc body
-    //                 because the resolver landed on a different
-    //                 array — string.test's ``[testConstraint
-    //                 valgrind]`` returned ``""`` and PR #341's strict
-    //                 boolean ``!`` then trapped.
-    const desc = alloc(16);
+    //   desc[0..4]   = kind
+    //   desc[4..8]   = unused (mirrors GLOBAL_NAMED/FRAME_VAR ``param``)
+    //   desc[8..12]  = ``*Var`` for the namespace var (scalar fast path)
+    //   desc[12..16] = target ``*Namespace`` address — used to look
+    //                  up the cached FQ name on demand via
+    //                  :func:`tcl_ns.ns_full_name`.
+    //   desc[16..20] = simple-name byte pointer (interned in the
+    //                  namespace's own ``Var`` table key — stable for
+    //                  the namespace's lifetime).
+    //   desc[20..24] = simple-name byte length.
+    //
+    // Storing ``target_ns`` + ``(simple_ptr, simple_len)`` separately
+    // (rather than a TclObj handle to the FQ name) lets
+    // :func:`frame_resolve_array_name` synthesise a fresh, owned
+    // ``::ns::name`` TclObj on each call — the caller already
+    // releases the result when it differs from the input, so there's
+    // no descriptor-side TclObj that frame teardown would need to
+    // walk and release.  Without it, traces installed against the
+    // namespace array (e.g. tcltest's ``SafeFetch`` on
+    // ``::tcltest::testConstraints``) never fire from inside an
+    // interpreted proc body because the resolver landed on a
+    // different array — string.test's ``[testConstraint valgrind]``
+    // returned ``""`` and PR #341's strict-boolean ``!`` then
+    // trapped.  (Codex review on PR #343.)
+    const desc = alloc(24);
     write_i32(desc, KIND_NS_VAR_PTR);
     write_i32(desc + 4, 0);
     write_i32(desc + 8, @bitCast(var_ptr));
-    write_i32(desc + 12, full_name);
+    write_i32(desc + 12, @bitCast(target_ns));
+    write_i32(desc + 16, @bitCast(simple_ptr));
+    write_i32(desc + 20, @bitCast(simple_len));
     const encoded: i32 = -@as(i32, @intCast(desc));
     const sn = obj_ensure_string(local_name);
     const hash = fnv1a(sn.ptr, sn.len);
@@ -1949,16 +1981,43 @@ pub export fn frame_resolve_array_name(local_name: i32) i32 {
                     return tgt;
                 }
                 if (kind == KIND_NS_VAR_PTR) {
-                    // Descriptor layout is 16 bytes for this kind;
-                    // desc+12 holds the FQ-name TclObj stashed by
-                    // ``frame_alias_ns_var`` when ``variable`` ran.
-                    // Use it so array writes / reads land in the
-                    // namespace's array directory instead of the
-                    // proc-local synthetic key.  Falls back to
-                    // *local_name* when missing (e.g. ``frame_alias_ns_var``
-                    // was called with a 0 full_name during bootstrap).
-                    const full_name = read_i32(desc + 12);
-                    if (full_name != 0) return full_name;
+                    // Descriptor layout is 24 bytes for this kind:
+                    // desc+12 holds the target ``*Namespace`` and
+                    // desc+16/20 hold the simple-name byte span.
+                    // Synthesise a fresh ``<ns_full>::<simple>`` TclObj
+                    // here (caller already releases the result when it
+                    // differs from the input) so array writes / reads
+                    // land in the namespace's array directory instead
+                    // of the proc-local synthetic key.
+                    const target_ns: u32 = @bitCast(read_i32(desc + 12));
+                    const simple_ptr: u32 = @bitCast(read_i32(desc + 16));
+                    const simple_len: u32 = @bitCast(read_i32(desc + 20));
+                    if (target_ns != 0 and simple_ptr != 0 and simple_len != 0) {
+                        const ns_full = tcl_ns.ns_full_name(target_ns);
+                        // Root namespace ``::`` collapses to ``::name``
+                        // (no double colon).
+                        const ns_emit_len: u32 = if (ns_full.len == 2) 0 else ns_full.len;
+                        const total: u32 = 2 + ns_emit_len + simple_len;
+                        const buf = obj.alloc(total);
+                        if (buf != 0) {
+                            const dst: [*]u8 = @ptrFromInt(buf);
+                            var off: u32 = 0;
+                            if (ns_emit_len == 0) {
+                                dst[0] = ':';
+                                dst[1] = ':';
+                                off = 2;
+                            } else {
+                                const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+                                for (0..ns_full.len) |k| dst[k] = np[k];
+                                dst[ns_full.len] = ':';
+                                dst[ns_full.len + 1] = ':';
+                                off = ns_full.len + 2;
+                            }
+                            const sp: [*]const u8 = @ptrFromInt(simple_ptr);
+                            for (0..simple_len) |k| dst[off + k] = sp[k];
+                            return obj.obj_new_string_take(buf, total, total);
+                        }
+                    }
                 }
             }
             if (v == ALIAS_GLOBAL) return local_name; // global alias keeps the same name

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -1235,10 +1235,18 @@ fn resolve_ext_exists(desc: u32, local_name: i32) i32 {
     const tgt = read_i32(desc + 8);
     if (kind == KIND_GLOBAL_NAMED) return globals.global_exists(tgt);
     if (kind == KIND_NS_VAR_PTR) {
-        // The Var entry exists once we've created it; existence
-        // checks return 1 even if the value was never written.
-        // Matches the long-standing ``global_exists`` semantics.
-        return if (tgt != 0) obj_new_int(1) else obj_new_int(0);
+        // Reference Tcl's ``info exists`` returns 1 only when the
+        // variable has been *assigned* a value — declaring a
+        // namespace var via ``variable name`` (no initialiser) is
+        // not enough.  Without this, ``proc Default {n v} {
+        // variable $n; if {![info exists $n]} { variable $n $v } }``
+        // (tcltest's per-namespace lazy initialiser) skipped its
+        // initialiser branch — the bare ``variable $n`` had already
+        // fabricated a Var entry and the previous "tgt non-zero ⇒
+        // exists" rule reported it as initialised.
+        if (tgt == 0) return obj_new_int(0);
+        const val = tcl_ns.var_get_scalar(@bitCast(tgt));
+        return if (val != 0) obj_new_int(1) else obj_new_int(0);
     }
     const abs: u32 = @bitCast(read_i32(desc + 4));
     return if (frame_exists_at_depth(abs, tgt, local_name)) obj_new_int(1) else obj_new_int(0);
@@ -1373,12 +1381,32 @@ pub export fn frame_alias_frame_var(local_name: i32, abs_depth: i32, target_name
 /// value is the negated descriptor address.  Reads / writes go
 /// through ``var_get_scalar`` / ``var_set_scalar`` which transparently
 /// chase ``VAR_LINK`` chains on the target side.
-pub fn frame_alias_ns_var(local_name: i32, var_ptr: u32) void {
+pub fn frame_alias_ns_var(local_name: i32, var_ptr: u32, full_name: i32) void {
     const cur = current_frame() orelse return;
-    const desc = alloc(12);
+    // Descriptor layout (16 bytes — extended from the 12-byte form
+    // for KIND_GLOBAL_NAMED / KIND_FRAME_VAR):
+    //   desc[0..4]  = kind
+    //   desc[4..8]  = unused (mirrors the GLOBAL_NAMED/FRAME_VAR
+    //                 ``param`` slot)
+    //   desc[8..12] = ``*Var`` for the namespace var (scalar fast path)
+    //   desc[12..16] = TclObj of the FQ name, used by
+    //                 :func:`frame_resolve_array_name` so a proc-local
+    //                 ``variable arr`` correctly routes ``set arr(k)``
+    //                 to the namespace's array directory entry rather
+    //                 than the synthetic ``::__local::<depth>::arr``
+    //                 form.  Without it, traces installed against the
+    //                 namespace array (e.g. tcltest's ``SafeFetch``
+    //                 read trace on ``::tcltest::testConstraints``)
+    //                 never fire from inside an interpreted proc body
+    //                 because the resolver landed on a different
+    //                 array — string.test's ``[testConstraint
+    //                 valgrind]`` returned ``""`` and PR #341's strict
+    //                 boolean ``!`` then trapped.
+    const desc = alloc(16);
     write_i32(desc, KIND_NS_VAR_PTR);
     write_i32(desc + 4, 0);
     write_i32(desc + 8, @bitCast(var_ptr));
+    write_i32(desc + 12, full_name);
     const encoded: i32 = -@as(i32, @intCast(desc));
     const sn = obj_ensure_string(local_name);
     const hash = fnv1a(sn.ptr, sn.len);
@@ -1919,6 +1947,18 @@ pub export fn frame_resolve_array_name(local_name: i32) i32 {
                 const tgt = read_i32(desc + 8);
                 if (kind == KIND_GLOBAL_NAMED or kind == KIND_FRAME_VAR) {
                     return tgt;
+                }
+                if (kind == KIND_NS_VAR_PTR) {
+                    // Descriptor layout is 16 bytes for this kind;
+                    // desc+12 holds the FQ-name TclObj stashed by
+                    // ``frame_alias_ns_var`` when ``variable`` ran.
+                    // Use it so array writes / reads land in the
+                    // namespace's array directory instead of the
+                    // proc-local synthetic key.  Falls back to
+                    // *local_name* when missing (e.g. ``frame_alias_ns_var``
+                    // was called with a 0 full_name during bootstrap).
+                    const full_name = read_i32(desc + 12);
+                    if (full_name != 0) return full_name;
                 }
             }
             if (v == ALIAS_GLOBAL) return local_name; // global alias keeps the same name

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -2097,9 +2097,46 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
         var pi: u32 = 0;
         while (pi < n_params) : (pi += 1) {
             const param_elem = list_element_at(ps.ptr, ps.len, @intCast(pi));
-            const param_name_ptr = ps.ptr + param_elem.start;
-            const param_name_len = param_elem.len;
+            // Each parameter is either a bare name (``a``) or a
+            // 2-element list of ``{name default}``.  Detect the latter
+            // by re-parsing the post-brace span as a sub-list and
+            // checking the count.  Without this, an interpreted proc
+            // body whose params include defaults (e.g. tcltest's
+            // ``proc ConstraintInitializer {constraint {script ""}}``
+            // sourced at runtime) treated ``script ""`` as a single
+            // literal name — the first arg-less call wired up a local
+            // named ``script "" `` (with embedded space and quotes)
+            // and the body's ``$script`` reference then errored
+            // "no such variable".  In tcltest's SafeFetch path that
+            // error is caught silently and the read trace returns
+            // ``""``, which PR #341's strict-boolean ``!`` then
+            // trapped on (string.test regression).  Reference Tcl
+            // (``TclCreateProc``) parses the sub-list at proc-define
+            // time; doing it on every call keeps the binding cheap
+            // and matches the existing eval-fallback shape — the
+            // compiled-codegen path already does its own pre-parse
+            // via ``tcl_proc_register_compiled``.
+            var param_name_ptr = ps.ptr + param_elem.start;
+            var param_name_len = param_elem.len;
+            var param_default: i32 = 0;
+            var has_default: bool = false;
+            const sub_n = list_count_elements(param_name_ptr, param_name_len);
+            if (sub_n == 2) {
+                const name_elem = list_element_at(param_name_ptr, param_name_len, 0);
+                const default_elem = list_element_at(param_name_ptr, param_name_len, 1);
+                const default_ptr = param_name_ptr + default_elem.start;
+                const default_len = default_elem.len;
+                param_default = obj_new_string_copy(default_ptr, default_len);
+                obj_mod.tcl_obj_retain(param_default);
+                has_default = true;
+                // Narrow the name span before allocating ``param_name``.
+                const new_name_ptr = param_name_ptr + name_elem.start;
+                const new_name_len = name_elem.len;
+                param_name_ptr = new_name_ptr;
+                param_name_len = new_name_len;
+            }
             const param_name = obj_new_string_copy(param_name_ptr, param_name_len);
+            defer if (has_default) obj_mod.tcl_obj_release(param_default);
             // Issue #317: ``local_set`` only reads ``param_name``'s byte
             // span (the hash table copies the bytes into its own
             // bucket); the TclObj itself is not retained anywhere
@@ -2175,10 +2212,16 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                 if (arg_idx < words.len) {
                     // Caller-owned TclObj — no creator-side ref to drop.
                     _ = frames.local_set(param_name, words[arg_idx]);
+                } else if (has_default) {
+                    // Use the parsed default value when the caller
+                    // omitted this positional arg.
+                    _ = frames.local_set(param_name, param_default);
                 } else {
-                    // Default-empty for missing positional args; drop
-                    // the creator-side ref the same way as the empty
-                    // ``args`` branch above.
+                    // No default and no caller-supplied value —
+                    // reference Tcl raises ``wrong # args`` here, but
+                    // legacy tests (and our own existing baselines)
+                    // rely on the lenient empty-default behaviour, so
+                    // keep that for the no-default case.
                     const empty = obj_new_string(0, 0);
                     _ = frames.local_set(param_name, empty);
                     obj_mod.tcl_obj_release(empty);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -2126,8 +2126,18 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                 const default_elem = list_element_at(param_name_ptr, param_name_len, 1);
                 const default_ptr = param_name_ptr + default_elem.start;
                 const default_len = default_elem.len;
+                // ``obj_new_string_copy`` already returns rc=1 — the
+                // earlier extra ``tcl_obj_retain`` here pumped rc=2
+                // and the matching ``defer release`` only dropped it
+                // to 1, leaking one ref per defaulted parameter per
+                // call (Codex review on PR #343).  ``local_set``
+                // below retains independently when it stores the
+                // value in a frame slot, so the creator-side defer
+                // release alone is enough to free ``param_default``
+                // when the slot release fires at frame teardown
+                // (or immediately when the caller-supplied value
+                // overrides our default and we never store it).
                 param_default = obj_new_string_copy(default_ptr, default_len);
-                obj_mod.tcl_obj_retain(param_default);
                 has_default = true;
                 // Narrow the name span before allocating ``param_name``.
                 const new_name_ptr = param_name_ptr + name_elem.start;


### PR DESCRIPTION
## Summary

This PR fixes several interconnected issues with variable resolution, trace dispatch, and namespace handling that caused test failures in strict-boolean mode (PR #341):

1. **Canonical variable name resolution for traces**: Added `canonical_var_name()` function to resolve user-supplied variable names to their fully-qualified form before registering/querying traces. This ensures traces registered with bare names inside `namespace eval` blocks match the canonical keys used by the array module and `variable` aliases.

2. **Namespace variable aliasing with array support**: Extended `frame_alias_ns_var()` to accept and store the fully-qualified name, enabling `frame_resolve_array_name()` to route array element access (e.g., `set arr(k) v`) to the namespace's array directory instead of synthesizing proc-local storage. This fixes trace dispatch for namespace arrays accessed from proc bodies.

3. **Proc parameter default values**: Fixed interpreted proc calls to properly parse and apply default parameter values from `{name default}` syntax. Previously, parameters with defaults were treated as literal names with embedded spaces/quotes, causing variable lookup failures.

4. **Variable existence semantics**: Corrected `info exists` behavior for namespace variables to check actual assignment rather than just Var entry creation. A bare `variable name` declaration no longer reports the variable as existing.

5. **Array element missing-value errors**: Added null-check after array element reads in compiled code to raise proper "no such variable" errors instead of silently propagating empty strings.

6. **Build-info boolean queries**: Fixed `tcl::build-info` to return `0` (false) for unknown build flags instead of empty string, matching reference Tcl's strict-boolean semantics.

7. **Namespace code wrapping**: Implemented proper `namespace code` to wrap scripts with `::namespace inscope` so callbacks registered via traces can be found in their original namespace context.

These fixes resolve cascading failures in tcltest's constraint initialization and trace dispatch paths that were exposed by strict-boolean validation.

## Validation

- Existing test suite passes with these changes
- Fixes regressions in `string.test` and related tcltest-dependent tests caused by PR #341's strict-boolean enforcement
- Changes align with reference Tcl behavior for variable resolution, trace dispatch, and namespace handling

https://claude.ai/code/session_01TiXvyEgSgzN3BW1ZVsFyjs