### PR TITLE
C40-followups #4: restore signature_scan dispatcher

### DIFF
--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -104,15 +104,14 @@ def extract_signatures(source: str) -> AnalysisResult:
     at DEBUG) so a binding regression cannot silently degrade
     workspace indexing.
     """
-    if _rust_extract is not None and rust_shim_enabled(
-        "TCL_LSP_RUST_SIGNATURE_SCAN", default=True
-    ):
+    if rust_shim_enabled("TCL_LSP_RUST_SIGNATURE_SCAN", default=True):
         try:
             raw = _rust_extract(source)
         except Exception:  # pragma: no cover — defensive fallback
             log.debug("rust signature_scan_extract raised; falling back to Python", exc_info=True)
         else:
-            return _materialise_rust_signatures(source, raw)
+            if raw is not None:
+                return _materialise_rust_signatures(source, raw)
     return _extract_signatures_python(source)
 
 

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -24,7 +24,9 @@ and retains orders of magnitude less memory per file than ``analyse()``.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
+from typing import Any
 
 from core.analysis import parse_param_list
 from core.analysis.semantic_model import (
@@ -34,12 +36,24 @@ from core.analysis.semantic_model import (
     CommandInvocation,
     NamespaceImport,
     PackageRequire,
+    ParamDef,
     ProcDef,
     SourceTarget,
 )
 from core.common.ranges import range_from_token
+from core.compiler.rust_spans import build_position_resolver, rust_shim_enabled
 from core.parsing.command_segmenter import segment_commands
 from core.parsing.tokens import Token, TokenType
+
+log = logging.getLogger(__name__)
+
+# Lazy binding for the Rust signature_scan extension.  Imported on
+# first call to keep the Python-only test environment clean (no
+# ``ImportError`` at module-import time when the wheel is absent).
+try:
+    from tcl_lsp_rust import signature_scan_extract as _rust_signature_scan_extract  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover — exercised in pure-Python CI envs
+    _rust_signature_scan_extract = None
 
 
 @dataclass
@@ -77,11 +91,147 @@ class _ScanCtx:
 
 
 def extract_signatures(source: str) -> AnalysisResult:
-    """Return a minimal AnalysisResult for a background-indexed file."""
+    """Return a minimal AnalysisResult for a background-indexed file.
+
+    Default-on dispatch: when the ``tcl_lsp_rust`` binding is
+    available and ``TCL_LSP_RUST_SIGNATURE_SCAN`` is not set to a
+    falsy value (``0`` / ``false`` / …), the Rust port runs and the
+    raw dict is materialised back into an :class:`AnalysisResult`.
+
+    Set ``TCL_LSP_RUST_SIGNATURE_SCAN=0`` to force the Python path,
+    which still lives in :func:`_extract_signatures_python`.  Any
+    exception raised by the Rust path falls back to Python (logged
+    at DEBUG) so a binding regression cannot silently degrade
+    workspace indexing.
+    """
+    if _rust_extract is not None and rust_shim_enabled(
+        "TCL_LSP_RUST_SIGNATURE_SCAN", default=True
+    ):
+        try:
+            raw = _rust_extract(source)
+        except Exception:  # pragma: no cover — defensive fallback
+            log.debug("rust signature_scan_extract raised; falling back to Python", exc_info=True)
+        else:
+            return _materialise_rust_signatures(source, raw)
+    return _extract_signatures_python(source)
+
+
+def _extract_signatures_python(source: str) -> AnalysisResult:
+    """Pure-Python implementation of :func:`extract_signatures`.
+
+    Kept as a module-private entry point so the dispatcher can
+    delegate to it on Rust failure / opt-out, and so the
+    differential test harness can exercise both implementations
+    side by side.
+    """
     ctx = _ScanCtx(result=AnalysisResult())
     _scan(source, body_token=None, ns_prefix="", conditional=False, ctx=ctx)
     _resolve_factory_defs(ctx)
     return ctx.result
+
+
+def _rust_extract(source: str) -> dict[str, Any] | None:
+    """Thin wrapper around the PyO3 binding.
+
+    Exists as a module-level symbol so the differential test harness
+    can monkeypatch it with a sentinel.  Returns ``None`` when the
+    binding is unavailable; callers consult that sentinel to decide
+    whether to dispatch to the Rust path.
+    """
+    if _rust_signature_scan_extract is None:
+        return None
+    return dict(_rust_signature_scan_extract(source))
+
+
+def _materialise_rust_signatures(source: str, raw: dict[str, Any]) -> AnalysisResult:
+    """Convert the Rust ``signature_scan_extract`` dict into an
+    :class:`AnalysisResult` populated with the same fields the
+    Python implementation populates.
+
+    See ``rust/tcl-lsp-py/src/signature_scan.rs`` for the dict shape.
+    Spans are encoded as ``(start, end)`` byte offsets; this helper
+    builds a position resolver against ``source`` once and reuses
+    it for every record.
+    """
+    _, range_at = build_position_resolver(source)
+
+    def _range(span: tuple[int, int]) -> Any:
+        return range_at(span[0], span[1])
+
+    result = AnalysisResult()
+
+    for qname, p in raw.get("procs", {}).items():
+        params: list[ParamDef] = [
+            ParamDef(
+                name=param["name"],
+                has_default=param["has_default"],
+                default_value=param.get("default_value") or "",
+            )
+            for param in p.get("params", [])
+        ]
+        result.all_procs[qname] = ProcDef(
+            name=p["name"],
+            qualified_name=p["qualified_name"],
+            params=params,
+            name_range=_range(tuple(p["name_range"])),
+            body_range=_range(tuple(p["body_range"])),
+        )
+
+    for qname, c in raw.get("classes", {}).items():
+        result.all_classes[qname] = ClassDef(
+            name=c["name"],
+            qualified_name=c["qualified_name"],
+            name_range=_range(tuple(c["name_range"])),
+            body_range=_range(tuple(c["body_range"])),
+        )
+
+    for inv in raw.get("command_invocations", []):
+        result.command_invocations.append(
+            CommandInvocation(name=inv["name"], range=_range(tuple(inv["range"])))
+        )
+
+    for pr in raw.get("package_requires", []):
+        result.package_requires.append(
+            PackageRequire(
+                name=pr["name"],
+                version=pr.get("version"),
+                range=_range(tuple(pr["range"])),
+                conditional=pr["conditional"],
+            )
+        )
+
+    for s in raw.get("source_targets", []):
+        result.source_targets.append(
+            SourceTarget(
+                raw_path=s["raw_path"],
+                range=_range(tuple(s["range"])),
+                is_literal=s["is_literal"],
+            )
+        )
+
+    for qname, alias in raw.get("command_aliases", {}).items():
+        result.command_aliases[qname] = (alias["target"], tuple(alias.get("extras", [])))
+
+    for imp in raw.get("namespace_imports", []):
+        result.namespace_imports.append(
+            NamespaceImport(
+                ns=imp["ns"],
+                pattern=imp["pattern"],
+                range=_range(tuple(imp["range"])),
+                conjectured=imp["conjectured"],
+            )
+        )
+
+    for entry in raw.get("auto_path_entries", []):
+        result.auto_path_entries.append(
+            AutoPathEntry(
+                resolved_path=None,
+                raw=entry["raw"],
+                range=_range(tuple(entry["range"])),
+            )
+        )
+
+    return result
 
 
 def _qualify(ns_prefix: str, name: str) -> str:

--- a/docs/rust-rewrite-test-audit.md
+++ b/docs/rust-rewrite-test-audit.md
@@ -675,16 +675,19 @@ follow-up since main hasn't seen this issue.
 
 ## C40-default-on — flip the C40 dispatcher to Rust by default
 
-> **Status banner — post-#241 reality (audited 2026-05-07).**
-> `core/analysis/signature_scan.py` is now pure Python — no Rust
-> dispatch shim, no `_extract_signatures_python` fallback, no
-> `TCL_LSP_RUST_SIGNATURE_SCAN` env-var read. The dispatcher
-> described below was removed in the same wave as the C41
-> shim removal at PR #241 (no commit-log entry tracks it). The
-> Rust signature-scan port (`tcl_compiler::signature_scan`)
-> still exists as a library but isn't invoked from production
-> Python. Closure path is the `S*` LSP-server port. The
-> two-commit chunk below is historical record only.
+> **Status banner — restored (audited 2026-05-07, restored in
+> the C40-followups #4 PR).** The dispatcher in
+> `core/analysis/signature_scan.py` was silently dropped during
+> PR #241's merge resolution; the `tests/test_rust_signature_
+> scan_differential.py` import errors made this visible during
+> the C* close-out audit. Restored here (default-on dispatch:
+> Rust path runs unless `TCL_LSP_RUST_SIGNATURE_SCAN` is set to
+> a falsy value, with try/except fallback to Python on any
+> binding regression). The four dispatcher tests now run green;
+> the 28-fixture corpus exercises both paths via `_assert_same`.
+> Final retirement of the Python implementation still waits on
+> the `S*` LSP-server port, at which point the dispatcher and
+> the Python body both retire together.
 
 Two-commit chunk:
 

--- a/tests/test_rust_signature_scan_differential.py
+++ b/tests/test_rust_signature_scan_differential.py
@@ -273,3 +273,19 @@ def test_dispatcher_rust_exception_falls_back_to_python(monkeypatch, caplog) -> 
     result = extract_signatures("proc foo {} {}")
     # Python path produced the proc — fallback worked.
     assert "::foo" in result.all_procs
+
+
+def test_dispatcher_falls_back_when_binding_returns_none(monkeypatch) -> None:
+    """When the ``tcl_lsp_rust`` wheel is not installed,
+    ``_rust_extract`` returns ``None`` (no exception) — the
+    dispatcher must treat that as "binding unavailable" and fall
+    through to Python rather than feeding ``None`` to the
+    materialiser. Regresses the P1 review finding on PR #352:
+    previously the always-True ``_rust_extract is not None`` gate
+    let the None return reach
+    ``_materialise_rust_signatures(source, None)`` which crashed."""
+    monkeypatch.delenv("TCL_LSP_RUST_SIGNATURE_SCAN", raising=False)
+    monkeypatch.setattr(signature_scan_module, "_rust_extract", lambda _src: None)
+    result = extract_signatures("proc foo {} {}")
+    # Python path produced the proc — fallback worked.
+    assert "::foo" in result.all_procs


### PR DESCRIPTION
## Summary

Closes the only remaining real-code item in `C40-followups`:
restores the `signature_scan` Rust dispatcher that PR #241 silently
dropped during its merge resolution. The
`tests/test_rust_signature_scan_differential.py` import failure
(`cannot import name '_extract_signatures_python'`) was the audit
signal — the dispatcher and its supporting symbols were never
reinstated.

The restoration is minimal and matches the contract the test file
already pinned:

- `_extract_signatures_python(source)` — pure-Python
  implementation, kept module-private so the dispatcher can fall
  back on opt-out / Rust failure.
- `_rust_extract(source)` — thin wrapper over the
  `tcl_lsp_rust.signature_scan_extract` PyO3 binding, exposed as a
  module-level symbol so the test harness can monkeypatch it.
- `_materialise_rust_signatures(source, raw)` — converts the raw
  Rust dict shape (see `rust/tcl-lsp-py/src/signature_scan.rs`)
  back into an `AnalysisResult` populated with the same fields
  Python populates. Uses `rust_spans.build_position_resolver` once
  per call.
- `extract_signatures(source)` — default-on dispatcher
  (`rust_shim_enabled("TCL_LSP_RUST_SIGNATURE_SCAN", default=True)`)
  with try/except fallback to Python on any binding exception
  (DEBUG-logged).

The `C40-default-on` banner in `docs/rust-rewrite-test-audit.md`
is refreshed from the post-#241 "historical record only" framing
to match the restored state.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `pytest tests/test_rust_signature_scan_differential.py` —
      32 passed (previously 0 collected due to `ImportError`).
- [x] `pytest tests/test_signature_scan.py` — 42 passed.
- [x] `pytest tests/test_workspace_index.py
      tests/test_workspace_symbols.py tests/test_scanner.py
      tests/test_progress.py tests/test_auto_index.py
      tests/test_rule_init_vars.py
      tests/test_workspace_file_ops.py` — 123 passed.

The pre-existing `test_param_used_in_dict_for_body_issue_236` W214
failure on rust HEAD is unaffected by this PR.

https://claude.ai/code/session_01PsAyQY8REG2o188rvCr6Cc

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsAyQY8REG2o188rvCr6Cc)_