### PR TITLE
sync(main): mirror ::tcl::unsupported::corotype command spec

### DIFF
--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -884,11 +884,21 @@ Two catch-up modes, picked per chunk:
 
 ### Outstanding
 
-Refreshed: 2026-05-07 against `origin/main`@`31d5d473`,
-`origin/rust`@`9205b90b`.
+Refreshed: 2026-05-07 (re-audited later same day against
+`origin/main`@`8b68af55`, `origin/rust`@`7364fd85`; previous audit
+was `31d5d473` / `9205b90b`).
 
-`main` carries 94 commits past the last rust-side rebase point
-(`SYNC-MAY26`).  Triage:
+`main` carries 97 commits past the last rust-side rebase point
+(`SYNC-MAY26`).  The 3 commits added since the morning audit
+(`#347` Zig dict iter / array upvar; `#348` regexp/regsub +
+coroutine semantics; `#349` WASM test-bucket categorisation) are
+all out of scope except for one new Python registry entry —
+`::tcl::unsupported::corotype` — added in `#348`.  That mirror
+landed in PR #355 (`rust/tcl-registry/src/commands/tcl/tcl_unsupported_corotype.rs`
++ `mod.rs` registration) and is not tracked in the Outstanding
+table.
+
+Triage:
 
 - **Out of scope (≈ 80 commits)** — Tcl 9 runtime semantics,
   WASM AOT staircase + emitter follow-ups, expr-bignum (i128 /

--- a/rust/tcl-registry/src/commands/tcl/mod.rs
+++ b/rust/tcl-registry/src/commands/tcl/mod.rs
@@ -98,6 +98,7 @@ mod string_;
 mod subst_;
 mod switch_;
 mod tailcall_;
+mod tcl_unsupported_corotype;
 mod tell_;
 mod throw_;
 mod time;
@@ -221,6 +222,7 @@ pub fn tcl_command_specs() -> Vec<CommandSpec> {
         subst_::spec(),
         switch_::spec(),
         tailcall_::spec(),
+        tcl_unsupported_corotype::spec(),
         tell_::spec(),
         throw_::spec(),
         time::spec(),

--- a/rust/tcl-registry/src/commands/tcl/tcl_unsupported_corotype.rs
+++ b/rust/tcl-registry/src/commands/tcl/tcl_unsupported_corotype.rs
@@ -1,0 +1,25 @@
+//! `::tcl::unsupported::corotype` — inspect a coroutine's suspension state.
+//!
+//! Tcl 9 ships `::tcl::unsupported::corotype CORONAME` as part of the
+//! `::tcl::unsupported::*` namespace — a documented-but-internal API
+//! exposed for tooling and the tcltest harness.  Mirror of the Python
+//! registry entry added in main commit `f8403101`
+//! (`core/commands/registry/tcl/tcl_unsupported_corotype.py`).
+//!
+//! Only the fully-qualified spelling is registered (matches the
+//! Python source and the WASM `ns_resolve_qualified` path).
+use crate::prelude::*;
+pub fn spec() -> CommandSpec {
+    CommandSpec {
+        name: "::tcl::unsupported::corotype",
+        dialects: Some(DialectSet::TCL86_PLUS),
+        arity: Arity::new(1, 1),
+        return_type: Some(TclType::String),
+        hover: Some(HoverSnippet::brief(
+            "Return the suspension state of a coroutine.",
+            &["::tcl::unsupported::corotype coroName"],
+            "Tcl ::tcl::unsupported::corotype (internal)",
+        )),
+        ..CommandSpec::DEFAULT
+    }
+}


### PR DESCRIPTION
## Summary

Re-audit of `origin/main` against `origin/rust` (this morning's
2026-05-07 audit covered up to `31d5d473`; `main` has since
advanced to `8b68af55` adding 3 new commits). Two of the three
new commits (#347 Zig dict iter / array upvar runtime fixes;
#349 WASM test-bucket categorisation) are out of scope — pure
runtime / WASM-test surface, no Rust mirror today. The third
(#348) is mostly out-of-scope WASM emitter / Zig regexp / Zig
coroutine work, **but** it added one new Python registry entry
for `::tcl::unsupported::corotype` that the Rust registry was
missing.

This PR mirrors that single registry entry:

* New `rust/tcl-registry/src/commands/tcl/tcl_unsupported_corotype.rs`
  with the same shape as the sibling `coroprobe` / `coroinject`
  specs (`Arity::new(1, 1)`, `TCL86_PLUS` dialect set, `String`
  return type, brief hover snippet). Only the fully-qualified
  spelling is registered, matching the Python source.
* `rust/tcl-registry/src/commands/tcl/mod.rs` registration in the
  alphabetical position between `tailcall_` and `tell_` (mirrors
  Python's `tcl_build_info` → `tcl_unsupported_corotype` ordering).
* `docs/rust-rewrite.md` Outstanding-table audit timestamp
  refreshed and triage extended to cover the 3 new commits.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all green; the registry crate's
      60 tests pass with the new spec.

https://claude.ai/code/session_01PsAyQY8REG2o188rvCr6Cc

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsAyQY8REG2o188rvCr6Cc)_