### PR TITLE
runtime: render subnormal floats via Tcl_PrintDouble-style formatting

### DIFF
--- a/core/compiler/core_analyses.py
+++ b/core/compiler/core_analyses.py
@@ -292,9 +292,20 @@ def _parse_literal_value(text: str) -> int | str:
     stripped = text.strip()
     if _DECIMAL_INT_RE.fullmatch(stripped):
         try:
-            return int(stripped)
+            iv = int(stripped)
         except ValueError:
-            pass
+            return stripped
+        # Only collapse to int when the textual identity round-trips:
+        # ``"010"`` parses as int 10, but ``[expr {$a eq "10"}]`` for
+        # ``a == "010"`` must yield 0 (string compare).  Storing it as
+        # the canonical int would lose that string identity, and
+        # downstream constant-substitution then folds the comparison
+        # the wrong way.  ``" 5 "`` and ``+5`` round-trip differently
+        # too — keep them as strings so SCCP doesn't change observable
+        # behaviour.
+        if str(iv) != stripped:
+            return stripped
+        return iv
     return stripped
 
 

--- a/core/compiler/optimiser/_expr_simplify.py
+++ b/core/compiler/optimiser/_expr_simplify.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 
 from ...common.dialect import active_dialect
@@ -1009,16 +1010,46 @@ def _substitute_expr_constants(expr: str, constants: dict[str, str]) -> tuple[st
             if value is not None:
                 # Numeric values can be substituted directly; string values
                 # must be quoted to be valid in expr context.
+                #
+                # The round-trip check is load-bearing: "010" parses as
+                # int 10 but its string identity differs ("010" vs "10"),
+                # and ``$a eq "10"`` for ``a == "010"`` must yield 0
+                # (string compare), not 1 (numeric compare).  Substituting
+                # the bare numeric collapses the two — the downstream
+                # evaluator only sees the canonical integer and folds
+                # ``eq`` to ``str(10) == str(10)``.  Preserve the source
+                # spelling as a quoted string whenever it doesn't
+                # round-trip through ``str(int(value))`` /
+                # ``str(float(value))``.
+                substituted = False
+                stripped = value.strip()
                 try:
-                    int(value)
-                    pieces.append(value)
-                except (ValueError, OverflowError):
-                    try:
-                        float(value)
+                    iv = int(stripped)
+                    if str(iv) == stripped and stripped == value:
                         pieces.append(value)
+                        substituted = True
+                except (ValueError, OverflowError):
+                    pass
+                if not substituted:
+                    try:
+                        fv = float(stripped)
+                        # ``float()`` accepts ``"010"``/``"01.5"``/``" 1 "``
+                        # the same way ``int()`` does — same round-trip
+                        # guard so leading zeros and stripped whitespace
+                        # don't lose their string identity.
+                        if (
+                            stripped == value
+                            and not math.isinf(fv)
+                            and not math.isnan(fv)
+                            and repr(fv) == stripped
+                        ):
+                            pieces.append(value)
+                            substituted = True
                     except (ValueError, OverflowError):
-                        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-                        pieces.append(f'"{escaped}"')
+                        pass
+                if not substituted:
+                    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+                    pieces.append(f'"{escaped}"')
                 changed = True
                 substituted_names.add(name)
             else:

--- a/runtime/zig/test_tcl_arith.zig
+++ b/runtime/zig/test_tcl_arith.zig
@@ -328,6 +328,47 @@ test "obj_ensure_string — bignum renders to decimal string" {
     try testing.expectEqualStrings("9223372036854775808", sl[0..s.len]);
 }
 
+fn floatStr(v: f64) []const u8 {
+    const o = obj.obj_new_float(v);
+    const s = obj.obj_ensure_string(o);
+    const sl: [*]const u8 = @ptrFromInt(s.ptr);
+    return sl[0..s.len];
+}
+
+test "obj_ensure_string — float renders Tcl_PrintDouble F format" {
+    // Exponent in [-4, 16] → fixed decimal with ``.0`` for integers.
+    try testing.expectEqualStrings("1.0", floatStr(1.0));
+    try testing.expectEqualStrings("-1.0", floatStr(-1.0));
+    try testing.expectEqualStrings("1.5", floatStr(1.5));
+    try testing.expectEqualStrings("3.14", floatStr(3.14));
+    try testing.expectEqualStrings("100.0", floatStr(100.0));
+    try testing.expectEqualStrings("0.5", floatStr(0.5));
+    try testing.expectEqualStrings("0.0001", floatStr(0.0001));
+    try testing.expectEqualStrings("0.0", floatStr(0.0));
+}
+
+test "obj_ensure_string — float renders Tcl_PrintDouble E format for tiny / huge" {
+    // Exponent < -4 or > 16 → scientific with explicit-sign,
+    // un-padded exponent (mirroring upstream's ``e%+d``).
+    try testing.expectEqualStrings("1e-5", floatStr(1e-5));
+    try testing.expectEqualStrings("1e+20", floatStr(1e20));
+    try testing.expectEqualStrings("1e+308", floatStr(1e308));
+}
+
+test "obj_ensure_string — subnormal floats render as scientific (not flushed to zero)" {
+    // The 32-byte ftoa scratch buffer used to silently overflow on
+    // ``{d}`` decimal expansion of subnormals (``1e-320`` ≈ 322 chars)
+    // and fall back to a single stale byte — printing ``0.0``.  Render
+    // via shortest-roundtrip scientific so the subnormal value is
+    // preserved through the obj's string rep.
+    try testing.expectEqualStrings("1e-320", floatStr(1e-320));
+    // ``1e-320 / 0.9`` is a subnormal whose shortest-roundtrip mantissa
+    // is ``1.111`` at full f64 precision (``1.111e-320``); the deeper
+    // digits beyond that round-trip differently because the available
+    // mantissa bits shrink with the exponent.
+    try testing.expectEqualStrings("1.111e-320", floatStr(1e-320 / 0.9));
+}
+
 test "obj_ensure_string — caches the rendered buffer (str_ptr persists)" {
     const big: i128 = @as(i128, 1) << 100;
     const o = bignumObj(big);

--- a/runtime/zig/test_tcl_list_ops.zig
+++ b/runtime/zig/test_tcl_list_ops.zig
@@ -106,13 +106,15 @@ test "tcl_cmd_list_sort — duplicates preserved (stable enough for equal keys)"
     try testing.expectEqualStrings("a a b b c", bytes(list.tcl_cmd_list_sort(s("c a b a b"))));
 }
 
-test "tcl_cmd_list_sort — braced elements with internal whitespace preserve grouping" {
+test "tcl_cmd_list_sort — canonical output preserves grouping when value needs braces" {
     // tcltest stores compound constraint names like
     // ``"testexprparser && !ieeeFloatingPoint"`` as array keys; the
     // ``[lsort [array names ...]]`` over those keys must keep each
-    // element a single list element.  Without re-bracing the sorted
-    // output, ``foreach`` over the result iterates 7 fragments instead
-    // of 3 and ``[info exists arr($constraint)]`` then traps.
+    // element a single list element.  Canonical re-quoting preserves
+    // braces when the value contains list metacharacters (space, ``$``,
+    // ``[``, …) — without it ``foreach`` over the result iterates 7
+    // fragments instead of 3 and ``[info exists arr($constraint)]``
+    // traps.
     try testing.expectEqualStrings(
         "{a b c} {d e f}",
         bytes(list.tcl_cmd_list_sort(s("{d e f} {a b c}"))),
@@ -123,6 +125,15 @@ test "tcl_cmd_list_sort — braced elements with internal whitespace preserve gr
             "{testexprparser && !ieeeFloatingPoint} testexprparser {testexprparser && ieeeFloatingPoint}",
         ))),
     );
+}
+
+test "tcl_cmd_list_sort — canonical output strips redundant braces" {
+    // Values that don't need quoting must not be re-braced just because
+    // the source spelled them braced — Codex review on PR #360 flagged
+    // ``lsort {{abc} d}`` producing ``{abc} d`` instead of the canonical
+    // ``abc d``, breaking byte-for-byte comparisons against tclsh.
+    try testing.expectEqualStrings("abc d", bytes(list.tcl_cmd_list_sort(s("{abc} d"))));
+    try testing.expectEqualStrings("d xyz", bytes(list.tcl_cmd_list_sort(s("{xyz} {d}"))));
 }
 
 // ---- search / contains ---------------------------------------------

--- a/runtime/zig/test_tcl_list_ops.zig
+++ b/runtime/zig/test_tcl_list_ops.zig
@@ -106,6 +106,25 @@ test "tcl_cmd_list_sort — duplicates preserved (stable enough for equal keys)"
     try testing.expectEqualStrings("a a b b c", bytes(list.tcl_cmd_list_sort(s("c a b a b"))));
 }
 
+test "tcl_cmd_list_sort — braced elements with internal whitespace preserve grouping" {
+    // tcltest stores compound constraint names like
+    // ``"testexprparser && !ieeeFloatingPoint"`` as array keys; the
+    // ``[lsort [array names ...]]`` over those keys must keep each
+    // element a single list element.  Without re-bracing the sorted
+    // output, ``foreach`` over the result iterates 7 fragments instead
+    // of 3 and ``[info exists arr($constraint)]`` then traps.
+    try testing.expectEqualStrings(
+        "{a b c} {d e f}",
+        bytes(list.tcl_cmd_list_sort(s("{d e f} {a b c}"))),
+    );
+    try testing.expectEqualStrings(
+        "testexprparser {testexprparser && !ieeeFloatingPoint} {testexprparser && ieeeFloatingPoint}",
+        bytes(list.tcl_cmd_list_sort(s(
+            "{testexprparser && !ieeeFloatingPoint} testexprparser {testexprparser && ieeeFloatingPoint}",
+        ))),
+    );
+}
+
 // ---- search / contains ---------------------------------------------
 
 test "tcl_cmd_list_search — exact match returns index" {

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1151,8 +1151,17 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
             const d: [*]u8 = @ptrFromInt(buf + off);
             d[0] = ' ';
             off += 1;
+            off = lq.list_elem_quote_nth(buf, off, ep, el);
+        } else {
+            // First element keeps the leading-``#`` quoting rule so a
+            // key starting with ``#`` round-trips through ``eval`` /
+            // canonical-list contexts without the rest of the list
+            // being parsed as a comment.  Subsequent elements pass
+            // ``FLAG_DONT_QUOTE_HASH`` (via ``list_elem_quote_nth``)
+            // because they can never sit at the script start.  Mirrors
+            // ``UpdateStringOfList`` in upstream Tcl.
+            off = lq.list_elem_quote(buf, off, ep, el);
         }
-        off = lq.list_elem_quote_nth(buf, off, ep, el);
         written += 1;
     }
     return obj.obj_new_string_take(buf, off, total);

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1086,6 +1086,7 @@ pub export fn array_unset_element(arr: i32, key: i32) i32 {
 /// returns every key.
 pub export fn array_names(arr: i32, pattern: i32) i32 {
     const str_mod = @import("tcl_string.zig");
+    const lq = @import("tcl_list_quote.zig");
     var pat_ptr: u32 = 0;
     var pat_len: u32 = 0;
     const use_filter = blk: {
@@ -1099,12 +1100,15 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
     if (t == 0) return obj_new_string(0, 0);
     const cap = ar_cap(t);
 
-    // Two-pass build: size, then assemble.  Phase 1 routes proc-local
-    // arrays through the same directory under ``::__local::*`` keys,
-    // so a single pass over the per-array element table covers every
-    // scope uniformly.  Raw byte concat (no list-element quoting)
-    // matches Tcl's ``lsort``-style output for elements that contain
-    // unescaped quotes or commas.
+    // Two-pass build: size, then assemble.  Each key is emitted via
+    // ``list_elem_quote_nth`` so keys containing whitespace, braces,
+    // backslashes or other list metacharacters round-trip through
+    // ``lsort`` / ``foreach`` as a single element.  Without quoting,
+    // a key like ``"testexprparser && !ieeeFloatingPoint"`` (added
+    // by ``::tcltest::AddToSkippedBecause`` for compound constraints)
+    // collapses into 4 list elements when callers pass the result
+    // through any list-aware command — and ``cleanupTests`` then
+    // traps with ``can't read "skippedBecause(!ieeeFloatingPoint)"``.
     var total: u32 = 0;
     var nonempty: u32 = 0;
     var i: u32 = 0;
@@ -1121,12 +1125,16 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
             // entry across both passes.
             if (!str_mod.glob_match(pat_ptr, pat_len, ep, el)) continue;
         }
-        total += el;
+        // Worst-case quoted length: ``2 * len + 2`` (matches
+        // ``list_elem_quote_nth``); plus one separator space per
+        // element after the first.
+        total += el * 2 + 2;
         if (nonempty > 0) total += 1;
         nonempty += 1;
     }
     if (nonempty == 0) return obj_new_string(0, 0);
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var written: u32 = 0;
     i = 0;
@@ -1137,10 +1145,6 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
         const ep: u32 = @bitCast(raw);
         const el: u32 = @bitCast(read_i32(bucket + 4));
         if (use_filter) {
-            // Match the raw key bytes via ``glob_match`` directly
-            // rather than allocating a TclObj per probe — the
-            // earlier ``string_match`` path leaked one key obj per
-            // entry across both passes.
             if (!str_mod.glob_match(pat_ptr, pat_len, ep, el)) continue;
         }
         if (written > 0) {
@@ -1148,11 +1152,10 @@ pub export fn array_names(arr: i32, pattern: i32) i32 {
             d[0] = ' ';
             off += 1;
         }
-        memcpy(buf + off, ep, el);
-        off += el;
+        off = lq.list_elem_quote_nth(buf, off, ep, el);
         written += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, total);
 }
 
 /// Scan the array directory for names matching the glob pattern

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -339,39 +339,58 @@ pub export fn list_tail(list: i32, start: i32) i32 {
 }
 
 // Exported: list sort — simple insertion sort on string comparison.
+//
+// Each entry in the working buffer stores the element's source ptr,
+// length and ``braced`` flag (12 bytes per slot).  The comparison key
+// is the unwrapped element content (matching Tcl's ``lsort`` which
+// orders by the element value, not the surrounding braces); the
+// emitted output re-adds braces when the source word was braced so
+// list-of-lists structure round-trips through ``foreach`` / ``llength``
+// instead of flattening (issue surfaced by ``tcltest`` storing
+// compound constraint names like ``"testexprparser && !ieeeFloatingPoint"``
+// as array keys, then iterating ``[lsort [array names skippedBecause]]``).
 pub export fn tcl_cmd_list_sort(list: i32) i32 {
     const s = obj_ensure_string(list);
     const n_i64 = list_count_elements(s.ptr, s.len);
     if (n_i64 <= 1) return list;
     const n: u32 = @intCast(n_i64);
-    const arr_buf = alloc(n * 8);
+    const arr_buf = alloc(n * 12);
+    if (arr_buf == 0) return obj_new_string(0, 0);
     var idx: u32 = 0;
     while (idx < n) : (idx += 1) {
         const elem = list_element_at(s.ptr, s.len, @intCast(idx));
-        write_i32(arr_buf + idx * 8, @intCast(s.ptr + elem.start));
-        write_i32(arr_buf + idx * 8 + 4, @intCast(elem.len));
+        write_i32(arr_buf + idx * 12, @intCast(s.ptr + elem.start));
+        write_i32(arr_buf + idx * 12 + 4, @intCast(elem.len));
+        write_i32(arr_buf + idx * 12 + 8, if (elem.braced) 1 else 0);
     }
     var i: u32 = 1;
     while (i < n) : (i += 1) {
-        const key_ptr: u32 = @intCast(read_i32(arr_buf + i * 8));
-        const key_len: u32 = @intCast(read_i32(arr_buf + i * 8 + 4));
+        const key_ptr: u32 = @intCast(read_i32(arr_buf + i * 12));
+        const key_len: u32 = @intCast(read_i32(arr_buf + i * 12 + 4));
+        const key_braced: i32 = read_i32(arr_buf + i * 12 + 8);
         var j: i32 = @as(i32, @intCast(i)) - 1;
         while (j >= 0) {
             const j_u: u32 = @intCast(j);
-            const cmp_ptr: u32 = @intCast(read_i32(arr_buf + j_u * 8));
-            const cmp_len: u32 = @intCast(read_i32(arr_buf + j_u * 8 + 4));
+            const cmp_ptr: u32 = @intCast(read_i32(arr_buf + j_u * 12));
+            const cmp_len: u32 = @intCast(read_i32(arr_buf + j_u * 12 + 4));
+            const cmp_braced: i32 = read_i32(arr_buf + j_u * 12 + 8);
             if (str_cmp(cmp_ptr, cmp_len, key_ptr, key_len) > 0) {
-                write_i32(arr_buf + (j_u + 1) * 8, @intCast(cmp_ptr));
-                write_i32(arr_buf + (j_u + 1) * 8 + 4, @intCast(cmp_len));
+                write_i32(arr_buf + (j_u + 1) * 12, @intCast(cmp_ptr));
+                write_i32(arr_buf + (j_u + 1) * 12 + 4, @intCast(cmp_len));
+                write_i32(arr_buf + (j_u + 1) * 12 + 8, cmp_braced);
                 j -= 1;
             } else break;
         }
         const ins: u32 = @intCast(j + 1);
-        write_i32(arr_buf + ins * 8, @intCast(key_ptr));
-        write_i32(arr_buf + ins * 8 + 4, @intCast(key_len));
+        write_i32(arr_buf + ins * 12, @intCast(key_ptr));
+        write_i32(arr_buf + ins * 12 + 4, @intCast(key_len));
+        write_i32(arr_buf + ins * 12 + 8, key_braced);
     }
+    // Worst-case output: every element gains 2 bytes of braces, plus
+    // one separator space per element after the first.
     var result_len: u32 = 0;
-    const result_buf = alloc(s.len + n);
+    const result_buf = alloc(s.len + n * 3 + 4);
+    if (result_buf == 0) return obj_new_string(0, 0);
     idx = 0;
     while (idx < n) : (idx += 1) {
         if (idx > 0) {
@@ -379,10 +398,24 @@ pub export fn tcl_cmd_list_sort(list: i32) i32 {
             d[0] = ' ';
             result_len += 1;
         }
-        const e_ptr: u32 = @intCast(read_i32(arr_buf + idx * 8));
-        const e_len: u32 = @intCast(read_i32(arr_buf + idx * 8 + 4));
-        memcpy(result_buf + result_len, e_ptr, e_len);
-        result_len += e_len;
+        const e_ptr: u32 = @intCast(read_i32(arr_buf + idx * 12));
+        const e_len: u32 = @intCast(read_i32(arr_buf + idx * 12 + 4));
+        const e_braced: bool = read_i32(arr_buf + idx * 12 + 8) != 0;
+        if (e_braced) {
+            const dl: [*]u8 = @ptrFromInt(result_buf + result_len);
+            dl[0] = '{';
+            result_len += 1;
+            if (e_len > 0) {
+                memcpy(result_buf + result_len, e_ptr, e_len);
+                result_len += e_len;
+            }
+            const dr: [*]u8 = @ptrFromInt(result_buf + result_len);
+            dr[0] = '}';
+            result_len += 1;
+        } else if (e_len > 0) {
+            memcpy(result_buf + result_len, e_ptr, e_len);
+            result_len += e_len;
+        }
     }
     return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
 }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -338,86 +338,114 @@ pub export fn list_tail(list: i32, start: i32) i32 {
     return tcl_cmd_list_range(list, start_obj, last_obj);
 }
 
-// Exported: list sort — simple insertion sort on string comparison.
-//
-// Each entry in the working buffer stores the element's source ptr,
-// length and ``braced`` flag (12 bytes per slot).  The comparison key
-// is the unwrapped element content (matching Tcl's ``lsort`` which
-// orders by the element value, not the surrounding braces); the
-// emitted output re-adds braces when the source word was braced so
-// list-of-lists structure round-trips through ``foreach`` / ``llength``
-// instead of flattening (issue surfaced by ``tcltest`` storing
-// compound constraint names like ``"testexprparser && !ieeeFloatingPoint"``
-// as array keys, then iterating ``[lsort [array names skippedBecause]]``).
+// Exported: list sort — insertion sort on the canonical (post-decode)
+// element value.  Output is fully re-canonicalised through
+// ``list_elem_quote`` / ``list_elem_quote_nth``: braces are added when
+// (and only when) the value's bytes need them, regardless of how the
+// source spelled the element.  ``lsort {{abc} d}`` therefore returns
+// the canonical ``abc d``, not ``{abc} d``.  Elements whose value
+// contains list metacharacters (whitespace, braces, ``$``, ``[``, …)
+// keep their grouping — that's the ``tcltest`` case where an
+// ``[array names skippedBecause]`` over keys like
+// ``"testexprparser && !ieeeFloatingPoint"`` must round-trip through
+// ``[lsort [...]]`` as a single element each.
 pub export fn tcl_cmd_list_sort(list: i32) i32 {
     const s = obj_ensure_string(list);
     const n_i64 = list_count_elements(s.ptr, s.len);
     if (n_i64 <= 1) return list;
     const n: u32 = @intCast(n_i64);
-    const arr_buf = alloc(n * 12);
+
+    // Decoded-content scratch: backslash-escaped bytes in unbraced
+    // source words decode to ``<= len`` bytes, so the whole input's
+    // worth of decoded bytes fits in ``s.len``.  ``+ n`` keeps room
+    // for any per-element NUL padding ``copy_unbraced_elem`` may
+    // place (matching the ``elem.len + 1`` allowance in
+    // ``lappend_canonical``).  Single shared buffer means one free at
+    // the end instead of n per-element scratch frees.
+    const decoded_size: u32 = if (s.len + n + 4 < 4) 4 else s.len + n + 4;
+    const decoded_buf = alloc(decoded_size);
+    if (decoded_buf == 0) return obj_new_string(0, 0);
+    defer obj.free_sized(decoded_buf, decoded_size);
+
+    // Slot table: (canonical-ptr, canonical-len) — 8 bytes per slot.
+    const arr_size: u32 = n * 8;
+    const arr_buf = alloc(arr_size);
     if (arr_buf == 0) return obj_new_string(0, 0);
+    defer obj.free_sized(arr_buf, arr_size);
+
+    var decoded_off: u32 = 0;
     var idx: u32 = 0;
     while (idx < n) : (idx += 1) {
         const elem = list_element_at(s.ptr, s.len, @intCast(idx));
-        write_i32(arr_buf + idx * 12, @intCast(s.ptr + elem.start));
-        write_i32(arr_buf + idx * 12 + 4, @intCast(elem.len));
-        write_i32(arr_buf + idx * 12 + 8, if (elem.braced) 1 else 0);
+        if (elem.braced) {
+            // Already raw bytes — point straight into the source.
+            write_i32(arr_buf + idx * 8, @intCast(s.ptr + elem.start));
+            write_i32(arr_buf + idx * 8 + 4, @intCast(elem.len));
+        } else {
+            // Decode backslash escapes into the shared scratch so the
+            // sort key (and the output quote pass) compare against the
+            // logical value, not the source spelling.  Empty elements
+            // produce a 0-length slice — store a stable pointer (any
+            // address inside the buffer) so the slot is well-formed.
+            const dst = decoded_buf + decoded_off;
+            const dec_len = if (elem.len == 0)
+                @as(u32, 0)
+            else
+                obj.copy_unbraced_elem(dst, s.ptr + elem.start, elem.len);
+            write_i32(arr_buf + idx * 8, @intCast(dst));
+            write_i32(arr_buf + idx * 8 + 4, @intCast(dec_len));
+            decoded_off += dec_len;
+        }
     }
+
+    // Insertion sort on the canonical content.
     var i: u32 = 1;
     while (i < n) : (i += 1) {
-        const key_ptr: u32 = @intCast(read_i32(arr_buf + i * 12));
-        const key_len: u32 = @intCast(read_i32(arr_buf + i * 12 + 4));
-        const key_braced: i32 = read_i32(arr_buf + i * 12 + 8);
+        const key_ptr: u32 = @intCast(read_i32(arr_buf + i * 8));
+        const key_len: u32 = @intCast(read_i32(arr_buf + i * 8 + 4));
         var j: i32 = @as(i32, @intCast(i)) - 1;
         while (j >= 0) {
             const j_u: u32 = @intCast(j);
-            const cmp_ptr: u32 = @intCast(read_i32(arr_buf + j_u * 12));
-            const cmp_len: u32 = @intCast(read_i32(arr_buf + j_u * 12 + 4));
-            const cmp_braced: i32 = read_i32(arr_buf + j_u * 12 + 8);
+            const cmp_ptr: u32 = @intCast(read_i32(arr_buf + j_u * 8));
+            const cmp_len: u32 = @intCast(read_i32(arr_buf + j_u * 8 + 4));
             if (str_cmp(cmp_ptr, cmp_len, key_ptr, key_len) > 0) {
-                write_i32(arr_buf + (j_u + 1) * 12, @intCast(cmp_ptr));
-                write_i32(arr_buf + (j_u + 1) * 12 + 4, @intCast(cmp_len));
-                write_i32(arr_buf + (j_u + 1) * 12 + 8, cmp_braced);
+                write_i32(arr_buf + (j_u + 1) * 8, @intCast(cmp_ptr));
+                write_i32(arr_buf + (j_u + 1) * 8 + 4, @intCast(cmp_len));
                 j -= 1;
             } else break;
         }
         const ins: u32 = @intCast(j + 1);
-        write_i32(arr_buf + ins * 12, @intCast(key_ptr));
-        write_i32(arr_buf + ins * 12 + 4, @intCast(key_len));
-        write_i32(arr_buf + ins * 12 + 8, key_braced);
+        write_i32(arr_buf + ins * 8, @intCast(key_ptr));
+        write_i32(arr_buf + ins * 8 + 4, @intCast(key_len));
     }
-    // Worst-case output: every element gains 2 bytes of braces, plus
-    // one separator space per element after the first.
-    var result_len: u32 = 0;
-    const result_buf = alloc(s.len + n * 3 + 4);
+
+    // Worst-case output: ``2 * len + 2`` per element via the quoter,
+    // plus one separator space per element after the first.
+    const result_size: u32 = s.len * 2 + n * 4 + 8;
+    const result_buf = alloc(result_size);
     if (result_buf == 0) return obj_new_string(0, 0);
+    var result_len: u32 = 0;
     idx = 0;
     while (idx < n) : (idx += 1) {
+        const e_ptr: u32 = @intCast(read_i32(arr_buf + idx * 8));
+        const e_len: u32 = @intCast(read_i32(arr_buf + idx * 8 + 4));
         if (idx > 0) {
             const d: [*]u8 = @ptrFromInt(result_buf + result_len);
             d[0] = ' ';
             result_len += 1;
-        }
-        const e_ptr: u32 = @intCast(read_i32(arr_buf + idx * 12));
-        const e_len: u32 = @intCast(read_i32(arr_buf + idx * 12 + 4));
-        const e_braced: bool = read_i32(arr_buf + idx * 12 + 8) != 0;
-        if (e_braced) {
-            const dl: [*]u8 = @ptrFromInt(result_buf + result_len);
-            dl[0] = '{';
-            result_len += 1;
-            if (e_len > 0) {
-                memcpy(result_buf + result_len, e_ptr, e_len);
-                result_len += e_len;
-            }
-            const dr: [*]u8 = @ptrFromInt(result_buf + result_len);
-            dr[0] = '}';
-            result_len += 1;
-        } else if (e_len > 0) {
-            memcpy(result_buf + result_len, e_ptr, e_len);
-            result_len += e_len;
+            result_len = list_elem_quote_nth(result_buf, result_len, e_ptr, e_len);
+        } else {
+            // First element keeps the leading-``#`` quoting rule so
+            // the canonical output works as a script when callers
+            // ``eval`` the result.
+            result_len = list_elem_quote(result_buf, result_len, e_ptr, e_len);
         }
     }
-    return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
+    // ``obj_new_string_take`` so the result obj records the buffer
+    // capacity in ``OBJ_STR_CAP``; without that, ``release_now``
+    // treats ``result_buf`` as alias-borrowed and skips the free,
+    // leaking one buffer per ``lsort`` call.
+    return obj.obj_new_string_take(result_buf, result_len, result_size);
 }
 
 // Exported: list search — default Tcl ``lsearch`` semantics, which
@@ -459,32 +487,54 @@ pub export fn tcl_cmd_list_contains(list: i32, value: i32) i32 {
     return obj_new_int(0);
 }
 
-// Exported: list reverse — return a new list with elements in reverse order.
+// Exported: list reverse — return a new list with elements in reverse
+// order, fully canonicalised (braces only where the value needs them).
+// Mirrors ``lsort``'s output strategy so callers comparing
+// ``[lreverse $x]`` against a literal string see canonical bytes.
 pub export fn tcl_cmd_list_reverse(list: i32) i32 {
     const s = obj_ensure_string(list);
     const n_i64 = list_count_elements(s.ptr, s.len);
     if (n_i64 <= 1) return list;
     const n: u32 = @intCast(n_i64);
-    // Over-allocate to fit braces around every element (2 extra bytes
-    // each) in the worst case; the bump allocator makes over-alloc
-    // free.
-    const result_buf = alloc(s.len + n * 3 + 4);
+    // Worst-case: every element doubles in size via ``list_elem_quote``
+    // (``2 * len + 2``) plus one separator space per element after
+    // the first.  Use ``obj_new_string_take`` at the end so the
+    // buffer is owned by the result obj and recycled on release.
+    const result_size: u32 = s.len * 2 + n * 4 + 8;
+    const result_buf = alloc(result_size);
+    if (result_buf == 0) return obj_new_string(0, 0);
     var result_len: u32 = 0;
+    var emitted: u32 = 0;
     var i: i32 = @as(i32, @intCast(n)) - 1;
     while (i >= 0) : (i -= 1) {
-        if (result_len > 0) {
+        const elem = list_element_at(s.ptr, s.len, @intCast(i));
+        // Decode unbraced source words so the quoter sees the logical
+        // value rather than the source spelling — same pattern as
+        // ``lappend_canonical`` and ``tcl_cmd_list_sort``.
+        var ep: u32 = s.ptr + elem.start;
+        var el: u32 = elem.len;
+        var tmp: u32 = 0;
+        var tmp_size: u32 = 0;
+        if (!elem.braced and elem.len > 0) {
+            tmp_size = elem.len + 1;
+            tmp = alloc(tmp_size);
+            if (tmp != 0) {
+                el = obj.copy_unbraced_elem(tmp, ep, elem.len);
+                ep = tmp;
+            }
+        }
+        if (emitted == 0) {
+            result_len = list_elem_quote(result_buf, result_len, ep, el);
+        } else {
             const d: [*]u8 = @ptrFromInt(result_buf + result_len);
             d[0] = ' ';
             result_len += 1;
+            result_len = list_elem_quote_nth(result_buf, result_len, ep, el);
         }
-        const elem = list_element_at(s.ptr, s.len, @intCast(i));
-        // ``append_list_element`` re-adds ``{...}`` when the source
-        // word was braced so nested lists (e.g. ``{a b}`` inside
-        // ``{{a b} c}``) keep their grouping instead of flattening
-        // into siblings.
-        result_len = append_list_element(result_buf, result_len, s.ptr, elem);
+        if (tmp != 0) obj.free_sized(tmp, tmp_size);
+        emitted += 1;
     }
-    return obj_new_string(@bitCast(result_buf), @bitCast(result_len));
+    return obj.obj_new_string_take(result_buf, result_len, result_size);
 }
 
 // Exported: list insert — ``linsert list index value1 ?value2 ...?``.

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -1276,14 +1276,16 @@ pub fn itoa(value: i64) struct { ptr: [*]u8, len: u32 } {
     return .{ .ptr = @as([*]u8, &itoa_buf) + i, .len = itoa_buf.len - i };
 }
 
-// Scratch buffer for float-to-string conversion (max 32 bytes).
-var ftoa_buf: [32]u8 = undefined;
+// Scratch buffer for float-to-string conversion.  Sized for the
+// worst-case Tcl-style "F" rendering (sign + up to 17 mantissa digits
+// + ``.`` + ``0`` for normal magnitudes), and "E" rendering (sign +
+// 17 digits + ``.`` + ``e`` + sign + 4-digit exponent for subnormals
+// down to ~5e-324).  64 bytes is comfortably above both.
+var ftoa_buf: [64]u8 = undefined;
 
 fn ftoa(value: f64) struct { ptr: [*]u8, len: u32 } {
     // Tcl 9 renders non-finite floats as ``Inf``, ``-Inf``, ``NaN``
-    // — not Zig's lowercase ``inf`` / ``nan``.  Special-case before
-    // the generic decimal path so the trailing ``.0`` fixup below
-    // doesn't append to ``inf`` and produce ``inf.0``.
+    // — not Zig's lowercase ``inf`` / ``nan``.
     if (std.math.isNan(value)) {
         const lit = "NaN";
         @memcpy(ftoa_buf[0..lit.len], lit);
@@ -1299,23 +1301,124 @@ fn ftoa(value: f64) struct { ptr: [*]u8, len: u32 } {
         @memcpy(ftoa_buf[0..lit.len], lit);
         return .{ .ptr = ftoa_buf[0..].ptr, .len = @intCast(lit.len) };
     }
-    const result = std.fmt.bufPrint(&ftoa_buf, "{d}", .{value}) catch ftoa_buf[0..1];
-    const len = result.len;
-    // Tcl requires floats to look like floats: ensure the string contains
-    // a '.', 'e', or 'E' so that "5.0" is not confused with integer "5".
-    var has_dot = false;
-    for (result) |c| {
-        if (c == '.' or c == 'e' or c == 'E') {
-            has_dot = true;
-            break;
+
+    // Render the shortest-roundtrip scientific form (always fits in
+    // 53 bytes — see ``std.fmt.float.bufferSize(.scientific, f64)``);
+    // then reformat into Tcl 9's ``Tcl_PrintDouble`` style.  Using
+    // ``{d}`` here directly is unsafe — for subnormals like ``1e-320``
+    // the decimal expansion is 322 characters, which previously
+    // overflowed a 32-byte buffer and silently rendered as ``0.0``
+    // (the ``catch`` fallback returned a single stale byte).
+    var sci_buf: [64]u8 = undefined;
+    const sci = std.fmt.float.render(&sci_buf, value, .{ .mode = .scientific }) catch {
+        // Should never fail at this buffer size; emit a safe fallback.
+        const lit = "0.0";
+        @memcpy(ftoa_buf[0..lit.len], lit);
+        return .{ .ptr = ftoa_buf[0..].ptr, .len = @intCast(lit.len) };
+    };
+
+    // Parse ``[-]<digits>[.<more>]e<sign?><exp>`` into a sign, a
+    // contiguous digit run, and the integer exponent.  Tcl's
+    // ``exponent`` is the position of the leading digit relative to
+    // the decimal point — equivalent to Zig scientific's exponent.
+    var sign_neg = false;
+    var i: usize = 0;
+    if (sci.len > 0 and sci[0] == '-') {
+        sign_neg = true;
+        i = 1;
+    }
+    var e_pos: usize = i;
+    while (e_pos < sci.len and sci[e_pos] != 'e') e_pos += 1;
+    var digits: [32]u8 = undefined;
+    var ndigits: usize = 0;
+    var j = i;
+    while (j < e_pos) : (j += 1) {
+        if (sci[j] != '.') {
+            if (ndigits < digits.len) {
+                digits[ndigits] = sci[j];
+                ndigits += 1;
+            }
         }
     }
-    if (!has_dot and len + 2 <= ftoa_buf.len) {
-        ftoa_buf[len] = '.';
-        ftoa_buf[len + 1] = '0';
-        return .{ .ptr = ftoa_buf[0..].ptr, .len = @intCast(len + 2) };
+    var exp: i32 = 0;
+    if (e_pos < sci.len) {
+        exp = std.fmt.parseInt(i32, sci[e_pos + 1 ..], 10) catch 0;
     }
-    return .{ .ptr = ftoa_buf[0..].ptr, .len = @intCast(len) };
+
+    var out: usize = 0;
+    if (sign_neg) {
+        ftoa_buf[out] = '-';
+        out += 1;
+    }
+
+    // Tcl 9 picks E format when ``exponent < -4`` or ``exponent > 16``
+    // (see ``Tcl_PrintDouble`` in ``generic/tclUtil.c``); otherwise F.
+    if (exp < -4 or exp > 16) {
+        // E format: ``<d>[.<more>]e<+/-><abs_exp>``.  Tcl always emits
+        // an explicit sign for the exponent, matching ``e%+d``.
+        ftoa_buf[out] = if (ndigits > 0) digits[0] else '0';
+        out += 1;
+        if (ndigits > 1) {
+            ftoa_buf[out] = '.';
+            out += 1;
+            var k: usize = 1;
+            while (k < ndigits) : (k += 1) {
+                ftoa_buf[out] = digits[k];
+                out += 1;
+            }
+        }
+        ftoa_buf[out] = 'e';
+        out += 1;
+        ftoa_buf[out] = if (exp >= 0) '+' else '-';
+        out += 1;
+        const abs_exp: u32 = if (exp < 0) @intCast(-exp) else @intCast(exp);
+        const er = std.fmt.bufPrint(ftoa_buf[out..], "{d}", .{abs_exp}) catch {
+            ftoa_buf[out] = '0';
+            out += 1;
+            return .{ .ptr = ftoa_buf[0..].ptr, .len = @intCast(out) };
+        };
+        out += er.len;
+    } else if (exp < 0) {
+        // F format with leading "0.<zeros><digits>".
+        ftoa_buf[out] = '0';
+        out += 1;
+        ftoa_buf[out] = '.';
+        out += 1;
+        var zeros: i32 = -exp - 1;
+        while (zeros > 0) : (zeros -= 1) {
+            ftoa_buf[out] = '0';
+            out += 1;
+        }
+        var k: usize = 0;
+        while (k < ndigits) : (k += 1) {
+            ftoa_buf[out] = digits[k];
+            out += 1;
+        }
+    } else {
+        // F format with ``<int_part>.<frac_part>``; pad the integer
+        // part with trailing zeros if exponent runs past ``ndigits``,
+        // and emit ``.0`` when there's no fractional part so the
+        // result stays distinguishable from an integer.
+        const int_len: usize = @as(usize, @intCast(exp)) + 1;
+        var k: usize = 0;
+        while (k < int_len) : (k += 1) {
+            ftoa_buf[out] = if (k < ndigits) digits[k] else '0';
+            out += 1;
+        }
+        ftoa_buf[out] = '.';
+        out += 1;
+        if (k >= ndigits) {
+            ftoa_buf[out] = '0';
+            out += 1;
+        } else {
+            while (k < ndigits) : (k += 1) {
+                ftoa_buf[out] = digits[k];
+                out += 1;
+            }
+        }
+    }
+
+    return .{ .ptr = ftoa_buf[0..].ptr, .len = @intCast(out) };
 }
 
 /// Render a TclObj to its string representation (integer, float, or string).


### PR DESCRIPTION
The 32-byte ``ftoa_buf`` scratch overflowed when ``{d}`` formatting a
subnormal — ``1e-320`` expands to a 322-character decimal — and the
``catch ftoa_buf[0..1]`` fallback returned a single stale byte that the
``has_dot`` fixup turned into ``"0.0"``.  Any ``expr {…}`` whose result
landed in subnormal range therefore flushed to zero before the value
ever reached ``fpclassify`` / ``issubnormal``.

Replace the ``{d}`` path with a shortest-roundtrip scientific render
(``std.fmt.float.render`` with ``.scientific`` mode — bounded at 53
bytes regardless of magnitude) and reformat into Tcl 9's
``Tcl_PrintDouble`` layout: F-format for ``-4 <= exponent <= 16``,
``e%+d``-style E-format otherwise.  Bumping the buffer to 64 bytes
covers both the 17-digit F worst case and the 4-digit-exponent
subnormal E worst case.

Pins ``expr.test`` ``expr-58.{1,6}`` (``fpclassify`` /
``issubnormal`` for ``1e-320/.9`` and friends), now in the must-pass
bucket.  Added unit tests for F / E switching and a subnormal
round-trip through ``obj_ensure_string``.