### PR TITLE
Lazy materialisation of BUILTIN namespaces for namespace import

### DIFF
--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -167,18 +167,27 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                         if (sep_at > 0) {
                             const src_ns_ptr = is.ptr;
                             const src_ns_len = sep_at;
-                            var target = resolve_ns(src_ns_ptr, src_ns_len);
-                            // BUILTIN-tier namespaces (``::tcl::mathop``,
-                            // ``::tcl::mathfunc``, …) live in the static
-                            // BUILTINS slice rather than the namespace
-                            // tree.  Materialise the namespace + its
-                            // forward Commands on demand so the
-                            // existence check (and the ``ns_import``
-                            // walk that follows) sees them.
-                            if (target == 0) {
-                                const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
-                                target = builtin_ns.materialise(src_ns_ptr, src_ns_len);
-                            }
+                            // Always run the BUILTINS materialiser
+                            // before resolving the source ns.  Two
+                            // shapes need it:
+                            //   * The namespace doesn't exist yet
+                            //     (``::tcl::mathop`` cold-start).
+                            //   * The namespace was created by a bare
+                            //     ``namespace eval ::tcl::mathop {}``
+                            //     and so has an empty ``cmd_table``
+                            //     even though the BUILTINS slice has
+                            //     entries under that prefix.
+                            // The materialiser is idempotent — it
+                            // skips slots already populated as
+                            // forwards and only stamps
+                            // ``namespace export *`` once.  When the
+                            // prefix doesn't match any BUILTINS
+                            // (``::myns::foo`` etc.), it returns 0
+                            // without touching the ns tree, and we
+                            // fall through to ``resolve_ns``.
+                            const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
+                            var target = builtin_ns.materialise(src_ns_ptr, src_ns_len);
+                            if (target == 0) target = resolve_ns(src_ns_ptr, src_ns_len);
                             if (target == 0) {
                                 const prefix: []const u8 = "unknown namespace in import pattern \"";
                                 const suffix: []const u8 = "\"";
@@ -247,21 +256,22 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                 var li: i64 = 0;
                 while (li < count) : (li += 1) {
                     const elt = obj_mod.list_element_at(ls.ptr, ls.len, li);
-                    const r = tcl_ns.ns_resolve_qualified(tcl_ns.ns_current(), elt.start, elt.len);
-                    var resolved: u32 = r.target_ns;
-                    if (r.simple_len > 0 and r.target_ns != 0) {
-                        const child = tcl_ns.ns_lookup(r.target_ns, r.simple_ptr, r.simple_len);
-                        resolved = child;
-                    }
-                    // Path target may name a BUILTIN-tier namespace
-                    // (``::tcl::mathop``) that hasn't been materialised
-                    // yet — populate from BUILTINS so the ns shows up
-                    // as a real path target with all its forwarder
-                    // commands in place.  Mirrors the same hook in
-                    // ``namespace import``.
+                    // Materialise BUILTIN-tier namespaces first so a
+                    // bare ``namespace path ::tcl::mathop`` finds the
+                    // populated ns regardless of whether anything
+                    // else has poked it yet (idempotent for
+                    // already-materialised entries; no-op for
+                    // non-BUILTINS prefixes).  Mirrors the same hook
+                    // in ``namespace import``.
+                    const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
+                    var resolved: u32 = builtin_ns.materialise(elt.start, elt.len);
                     if (resolved == 0) {
-                        const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
-                        resolved = builtin_ns.materialise(elt.start, elt.len);
+                        const r = tcl_ns.ns_resolve_qualified(tcl_ns.ns_current(), elt.start, elt.len);
+                        resolved = r.target_ns;
+                        if (r.simple_len > 0 and r.target_ns != 0) {
+                            const child = tcl_ns.ns_lookup(r.target_ns, r.simple_ptr, r.simple_len);
+                            resolved = child;
+                        }
                     }
                     obj_mod.write_i32(targets_buf + @as(u32, @intCast(li)) * 4, @bitCast(resolved));
                 }

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -167,7 +167,18 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                         if (sep_at > 0) {
                             const src_ns_ptr = is.ptr;
                             const src_ns_len = sep_at;
-                            const target = resolve_ns(src_ns_ptr, src_ns_len);
+                            var target = resolve_ns(src_ns_ptr, src_ns_len);
+                            // BUILTIN-tier namespaces (``::tcl::mathop``,
+                            // ``::tcl::mathfunc``, …) live in the static
+                            // BUILTINS slice rather than the namespace
+                            // tree.  Materialise the namespace + its
+                            // forward Commands on demand so the
+                            // existence check (and the ``ns_import``
+                            // walk that follows) sees them.
+                            if (target == 0) {
+                                const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
+                                target = builtin_ns.materialise(src_ns_ptr, src_ns_len);
+                            }
                             if (target == 0) {
                                 const prefix: []const u8 = "unknown namespace in import pattern \"";
                                 const suffix: []const u8 = "\"";
@@ -241,6 +252,16 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                     if (r.simple_len > 0 and r.target_ns != 0) {
                         const child = tcl_ns.ns_lookup(r.target_ns, r.simple_ptr, r.simple_len);
                         resolved = child;
+                    }
+                    // Path target may name a BUILTIN-tier namespace
+                    // (``::tcl::mathop``) that hasn't been materialised
+                    // yet — populate from BUILTINS so the ns shows up
+                    // as a real path target with all its forwarder
+                    // commands in place.  Mirrors the same hook in
+                    // ``namespace import``.
+                    if (resolved == 0) {
+                        const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
+                        resolved = builtin_ns.materialise(elt.start, elt.len);
                     }
                     obj_mod.write_i32(targets_buf + @as(u32, @intCast(li)) * 4, @bitCast(resolved));
                 }

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -256,6 +256,12 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                 var li: i64 = 0;
                 while (li < count) : (li += 1) {
                     const elt = obj_mod.list_element_at(ls.ptr, ls.len, li);
+                    // ``element_at`` returns ``start`` as a byte
+                    // *offset* into ``ls.ptr``, not an absolute
+                    // address — same convention as the dict / inspect
+                    // call sites.  Compute the absolute address before
+                    // handing the bytes to anything that derefs.
+                    const elt_ptr: u32 = ls.ptr + elt.start;
                     // Materialise BUILTIN-tier namespaces first so a
                     // bare ``namespace path ::tcl::mathop`` finds the
                     // populated ns regardless of whether anything
@@ -264,9 +270,9 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                     // non-BUILTINS prefixes).  Mirrors the same hook
                     // in ``namespace import``.
                     const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
-                    var resolved: u32 = builtin_ns.materialise(elt.start, elt.len);
+                    var resolved: u32 = builtin_ns.materialise(elt_ptr, elt.len);
                     if (resolved == 0) {
-                        const r = tcl_ns.ns_resolve_qualified(tcl_ns.ns_current(), elt.start, elt.len);
+                        const r = tcl_ns.ns_resolve_qualified(tcl_ns.ns_current(), elt_ptr, elt.len);
                         resolved = r.target_ns;
                         if (r.simple_len > 0 and r.target_ns != 0) {
                             const child = tcl_ns.ns_lookup(r.target_ns, r.simple_ptr, r.simple_len);

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -1031,11 +1031,20 @@ fn run_cmd_walk(kind: WalkKind, pattern: i32) i32 {
                 // ``::tcl::mathfunc::*``, …) aren't represented in
                 // the namespace tree until something pokes them, so
                 // a fresh ``info commands ::tcl::mathop::*`` would
-                // come back empty.  Materialise lazily.
-                if (qualified_target == 0 and ctx.kind == .commands) {
+                // come back empty.  Materialise unconditionally
+                // (not gated on ``qualified_target == 0``): the user
+                // may already have created the ns with
+                // ``namespace eval ::tcl::mathop {}``, in which case
+                // the resolver would return non-zero but the
+                // ``cmd_table`` would still be empty.  ``materialise``
+                // is idempotent on already-populated forwards and
+                // a no-op for non-BUILTINS prefixes, so the override
+                // only fires when there's something useful to
+                // populate.
+                if (ctx.kind == .commands) {
                     const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
                     // Reconstruct the namespace prefix: everything
-                    // up to (and including the second-to-last) ``::``
+                    // up to (and not including) the last ``::``
                     // before the trailing simple pattern.
                     var last_sep: i32 = -1;
                     var k: u32 = 0;
@@ -1047,7 +1056,8 @@ fn run_cmd_walk(kind: WalkKind, pattern: i32) i32 {
                     }
                     if (last_sep > 0) {
                         const prefix_len: u32 = @intCast(last_sep);
-                        qualified_target = builtin_ns.materialise(p.ptr, prefix_len);
+                        const materialised = builtin_ns.materialise(p.ptr, prefix_len);
+                        if (materialised != 0) qualified_target = materialised;
                     }
                 }
             }

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -1027,6 +1027,29 @@ fn run_cmd_walk(kind: WalkKind, pattern: i32) i32 {
                     // matches nothing.
                     return obj_new_string(0, 0);
                 }
+                // BUILTIN-tier namespaces (``::tcl::mathop::*``,
+                // ``::tcl::mathfunc::*``, …) aren't represented in
+                // the namespace tree until something pokes them, so
+                // a fresh ``info commands ::tcl::mathop::*`` would
+                // come back empty.  Materialise lazily.
+                if (qualified_target == 0 and ctx.kind == .commands) {
+                    const builtin_ns = @import("../dispatch/tcl_builtin_ns.zig");
+                    // Reconstruct the namespace prefix: everything
+                    // up to (and including the second-to-last) ``::``
+                    // before the trailing simple pattern.
+                    var last_sep: i32 = -1;
+                    var k: u32 = 0;
+                    while (k + 1 < p.len) : (k += 1) {
+                        if (src[k] == ':' and src[k + 1] == ':') {
+                            last_sep = @intCast(k);
+                            k += 1;
+                        }
+                    }
+                    if (last_sep > 0) {
+                        const prefix_len: u32 = @intCast(last_sep);
+                        qualified_target = builtin_ns.materialise(p.ptr, prefix_len);
+                    }
+                }
             }
         }
     }

--- a/runtime/zig/dispatch/tcl_builtin_ns.zig
+++ b/runtime/zig/dispatch/tcl_builtin_ns.zig
@@ -1,0 +1,136 @@
+// Lazy materialisation of qualified BUILTIN namespaces.
+//
+// The static :data:`BUILTINS` slice in ``tcl_cmd_table.zig`` is keyed
+// by fully-qualified name (e.g. ``::tcl::mathop::+``) and is queried
+// directly by :func:`tcl_cmd_table.lookup`.  Those entries are *not*
+// in any namespace's per-ns ``cmd_table``, so until a caller pokes at
+// the qualified prefix, the namespace tree contains no record that
+// ``::tcl::mathop`` (and friends) "exist".  That makes
+// ``namespace import ::tcl::mathop::*`` raise ``unknown namespace``,
+// ``info commands ::tcl::mathop::*`` return empty, and any other code
+// that walks the namespace tree miss the BUILTIN-tier commands.
+//
+// :func:`materialise` plugs the gap.  Given a qualified prefix ``P``,
+// it walks the BUILTINS slice once, creates the ``P`` namespace via
+// ``ns_create_from_fqn``, and registers each direct child of the
+// prefix (entries whose name is ``P::SIMPLE`` with no further ``::``
+// in ``SIMPLE``) as a ``CMD_BUILTIN_FORWARD`` Command in that
+// namespace's ``cmd_table`` via ``register_builtin_forward``.  It
+// then stamps ``namespace export *`` so the populated commands are
+// visible to ``namespace import``.  Idempotent: calling it twice is
+// harmless because ``register_builtin_forward`` overwrites with the
+// same handler address and the export-list guard skips re-stamping.
+//
+// This is the structural counterpart of C Tcl's ``Tcl_CreateNamespace``
+// hooks at startup — there, every ``Tcl_CreateObjCommand("::tcl::mathop::+", ...)``
+// implicitly populates the parent namespace.  Our static BUILTINS
+// table doesn't go through that path, so we materialise on demand.
+
+const reg = @import("tcl_cmd_registry.zig");
+const cmd_table = @import("tcl_cmd_table.zig");
+const tcl_ns = @import("../interp/tcl_ns.zig");
+const procs = @import("../interp/tcl_procs.zig");
+const obj = @import("../valtypes/tcl_obj.zig");
+
+/// True iff at least one BUILTIN entry's name is ``<prefix>::<simple>``
+/// — i.e. the prefix is a real namespace from the BUILTINS table's
+/// point of view.  Cheap O(N) over the ~few-hundred-entry BUILTINS
+/// slice.
+pub fn has_builtin_namespace(prefix_ptr: u32, prefix_len: u32) bool {
+    if (prefix_len == 0) return false;
+    const prefix: [*]const u8 = @ptrFromInt(prefix_ptr);
+    for (cmd_table.entries()) |e| {
+        if (entry_is_under_prefix(e.name, prefix, prefix_len)) return true;
+    }
+    return false;
+}
+
+/// Find-or-create the ``prefix`` namespace and populate its
+/// ``cmd_table`` with ``CMD_BUILTIN_FORWARD`` redirects for every
+/// direct-child BUILTIN entry.  Stamps ``namespace export *`` on
+/// the namespace the first time around so subsequent
+/// ``namespace import <prefix>::*`` finds the entries exported.
+///
+/// Returns the namespace handle on success, 0 if the prefix does not
+/// match any BUILTIN entries (caller should fall back to the regular
+/// "unknown namespace" diagnostic).
+pub fn materialise(prefix_ptr: u32, prefix_len: u32) u32 {
+    if (prefix_len == 0) return 0;
+    if (!has_builtin_namespace(prefix_ptr, prefix_len)) return 0;
+
+    const ns_addr = tcl_ns.ns_create_from_fqn(prefix_ptr, prefix_len);
+    if (ns_addr == 0) return 0;
+
+    const prefix: [*]const u8 = @ptrFromInt(prefix_ptr);
+    for (cmd_table.entries()) |e| {
+        if (!entry_is_under_prefix(e.name, prefix, prefix_len)) continue;
+        const simple_off = prefix_len + 2;
+        if (entry_has_deeper_separator(e.name, simple_off)) continue;
+        // Skip if some other path (a user proc, an alias, …) has
+        // already populated this slot in the ns cmd_table.  Don't
+        // clobber: a proc shadow is the user's deliberate override.
+        const simple_ptr = @intFromPtr(e.name.ptr) + simple_off;
+        const simple_len: u32 = @intCast(e.name.len - simple_off);
+        const existing = tcl_ns.ns_cmd_find(ns_addr, simple_ptr, simple_len);
+        if (existing != 0) {
+            // ``register_builtin_forward`` rewrites flags / handler
+            // unconditionally — that's the right shape when the
+            // existing entry is already a forward we placed earlier
+            // (idempotent re-stamp), but it would clobber a user
+            // proc.  Skip the rewrite when the slot is owned by
+            // something other than us.
+            if (!is_builtin_forward(existing)) continue;
+        }
+        const handler_addr: u32 = @intCast(@intFromPtr(e.handler));
+        // ``register_builtin_forward`` resolves the FQN itself via
+        // ``ns_resolve_qualified_creating``, so passing the full
+        // ``::tcl::mathop::+`` string lands the entry in the right
+        // namespace regardless of ``ns_current``.
+        const fqn_ptr: u32 = @intFromPtr(e.name.ptr);
+        const fqn_len: u32 = @intCast(e.name.len);
+        procs.register_builtin_forward(fqn_ptr, fqn_len, handler_addr);
+    }
+
+    // ``namespace export *`` — but only if no exports are registered
+    // yet.  Re-stamping would leak (the export list never shrinks)
+    // and the existing pattern set already covers ``*``.
+    const ns: *const tcl_ns.Namespace = @ptrFromInt(ns_addr);
+    if (ns.export_pattern_count == 0) {
+        const star = obj.alloc(1);
+        const star_p: [*]u8 = @ptrFromInt(star);
+        star_p[0] = '*';
+        tcl_ns.ns_export(ns_addr, star, 1);
+    }
+
+    return ns_addr;
+}
+
+/// True iff ``name`` is ``<prefix>::<rest>`` with non-empty ``rest``.
+fn entry_is_under_prefix(name: []const u8, prefix: [*]const u8, prefix_len: u32) bool {
+    if (name.len <= prefix_len + 2) return false;
+    var i: u32 = 0;
+    while (i < prefix_len) : (i += 1) {
+        if (name[i] != prefix[i]) return false;
+    }
+    if (name[prefix_len] != ':' or name[prefix_len + 1] != ':') return false;
+    return true;
+}
+
+/// True iff ``name[simple_off..]`` contains a further ``::`` —
+/// meaning this BUILTIN belongs to a deeper namespace, not a direct
+/// child of ``prefix``.
+fn entry_has_deeper_separator(name: []const u8, simple_off: u32) bool {
+    if (name.len < simple_off + 2) return false;
+    var k: u32 = simple_off;
+    while (k + 1 < name.len) : (k += 1) {
+        if (name[k] == ':' and name[k + 1] == ':') return true;
+    }
+    return false;
+}
+
+/// True iff the existing Command at ``cmd_addr`` is a
+/// ``CMD_BUILTIN_FORWARD`` we stamped earlier — safe to re-stamp.
+fn is_builtin_forward(cmd_addr: u32) bool {
+    const flags: u32 = @bitCast(obj.read_i32(cmd_addr + procs.OFF_FLAGS));
+    return (flags & procs.CMD_BUILTIN_FORWARD) != 0;
+}

--- a/runtime/zig/dispatch/tcl_builtin_ns.zig
+++ b/runtime/zig/dispatch/tcl_builtin_ns.zig
@@ -26,20 +26,32 @@
 // implicitly populates the parent namespace.  Our static BUILTINS
 // table doesn't go through that path, so we materialise on demand.
 
-const reg = @import("tcl_cmd_registry.zig");
 const cmd_table = @import("tcl_cmd_table.zig");
 const tcl_ns = @import("../interp/tcl_ns.zig");
 const procs = @import("../interp/tcl_procs.zig");
 const obj = @import("../valtypes/tcl_obj.zig");
 
+// Static ``*`` byte stamped into newly-materialised namespaces'
+// export pattern lists.  ``ns_export`` heap-copies the bytes, so the
+// pointer just needs to live somewhere stable in linear memory; the
+// constant data segment is the natural home.  Avoids the wasted
+// ``alloc(1)`` per materialised namespace that the bump allocator
+// would otherwise leak (it can't free).
+const STAR_BYTE: [1]u8 = .{'*'};
+
 /// True iff at least one BUILTIN entry's name is ``<prefix>::<simple>``
-/// — i.e. the prefix is a real namespace from the BUILTINS table's
-/// point of view.  Cheap O(N) over the ~few-hundred-entry BUILTINS
-/// slice.
+/// AND fully-qualified (``::``-prefixed) — i.e. the prefix is a real
+/// namespace from the BUILTINS table's point of view.  The
+/// fully-qualified filter mirrors what ``materialise`` actually
+/// registers; without it, a prefix that only matched the
+/// half-qualified BUILTIN spellings would produce an empty
+/// materialised namespace.  Cheap O(N) over the ~few-hundred-entry
+/// BUILTINS slice.
 pub fn has_builtin_namespace(prefix_ptr: u32, prefix_len: u32) bool {
     if (prefix_len == 0) return false;
     const prefix: [*]const u8 = @ptrFromInt(prefix_ptr);
     for (cmd_table.entries()) |e| {
+        if (e.name.len < 2 or e.name[0] != ':' or e.name[1] != ':') continue;
         if (entry_is_under_prefix(e.name, prefix, prefix_len)) return true;
     }
     return false;
@@ -64,6 +76,17 @@ pub fn materialise(prefix_ptr: u32, prefix_len: u32) u32 {
     const prefix: [*]const u8 = @ptrFromInt(prefix_ptr);
     for (cmd_table.entries()) |e| {
         if (!entry_is_under_prefix(e.name, prefix, prefix_len)) continue;
+        // Only register entries whose name is fully-qualified
+        // (``::``-prefixed).  ``cmds/tcl_mathop.zig`` also lists a
+        // half-qualified spelling (``tcl::mathop::+``) for the
+        // ``namespace eval ::tcl`` callers; passing that to
+        // ``register_builtin_forward`` would resolve relative to
+        // ``ns_current()`` and create the wrong tree (e.g.
+        // ``::caller::tcl::mathop::+`` when called from inside a
+        // non-root namespace).  Skipping the half-qualified shape
+        // means we register each operator exactly once, anchored
+        // at root via the ``::``-prefixed name.
+        if (e.name.len < 2 or e.name[0] != ':' or e.name[1] != ':') continue;
         const simple_off = prefix_len + 2;
         if (entry_has_deeper_separator(e.name, simple_off)) continue;
         // Skip if some other path (a user proc, an alias, …) has
@@ -96,10 +119,7 @@ pub fn materialise(prefix_ptr: u32, prefix_len: u32) u32 {
     // and the existing pattern set already covers ``*``.
     const ns: *const tcl_ns.Namespace = @ptrFromInt(ns_addr);
     if (ns.export_pattern_count == 0) {
-        const star = obj.alloc(1);
-        const star_p: [*]u8 = @ptrFromInt(star);
-        star_p[0] = '*';
-        tcl_ns.ns_export(ns_addr, star, 1);
+        tcl_ns.ns_export(ns_addr, @intFromPtr(&STAR_BYTE[0]), 1);
     }
 
     return ns_addr;

--- a/tests/test_wasm_mathop.py
+++ b/tests/test_wasm_mathop.py
@@ -12,7 +12,7 @@ import pytest
 
 wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
 
-from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm, _try_compile_and_run  # noqa: E402
 
 
 def _run(source: str) -> str:
@@ -186,3 +186,85 @@ def test_mathop_logical_boolean_keywords() -> None:
     # Numeric truth still works.
     assert _run("puts [::tcl::mathop::&& 1 1 1]") == "1"
     assert _run("puts [::tcl::mathop::|| 0 0 1]") == "1"
+
+
+# -- ``namespace import ::tcl::mathop::*`` materialisation -----------------
+#
+# The ``::tcl::mathop`` ensemble's commands live in the static BUILTINS
+# slice keyed by FQN (``::tcl::mathop::+`` and friends), not in any
+# namespace's ``cmd_table``.  Until the runtime materialises the
+# ensemble lazily via ``dispatch/tcl_builtin_ns.zig``, ``namespace
+# import ::tcl::mathop::*`` raises ``unknown namespace in import
+# pattern "::tcl::mathop::*"`` because the existence check at
+# ``cmds/namespace.zig`` doesn't know that the BUILTINS slice implies
+# the namespace exists.  ``mathop.test`` (Tcl 9 core slice) is the
+# canonical caller and trapped at line 22 before our fix.
+
+
+def test_namespace_import_mathop_glob() -> None:
+    """``namespace import ::tcl::mathop::*`` must succeed and pull every
+    operator into the destination namespace, where the bare names
+    dispatch through the import redirect to the BUILTIN handler."""
+    out = _run(
+        """
+namespace eval ::testmathop2 {
+    namespace import ::tcl::mathop::*
+}
+puts [::testmathop2::+ 1 2 3]
+puts [::testmathop2::== 1 1 1]
+puts [::testmathop2::eq abc abc abc]
+puts [::testmathop2::min 5 2 7 3]
+puts [::testmathop2::in b {a b c}]
+"""
+    )
+    assert out == "6\n1\n1\n2\n1"
+
+
+def test_namespace_import_mathop_single_name() -> None:
+    """A targeted ``namespace import ::tcl::mathop::min`` (no glob) must
+    also materialise the source namespace and import just the named
+    op."""
+    out = _run(
+        """
+namespace eval ::picker {
+    namespace import ::tcl::mathop::min
+    namespace import ::tcl::mathop::max
+}
+puts [::picker::min 5 2 7]
+puts [::picker::max 5 2 7]
+"""
+    )
+    assert out == "2\n7"
+
+
+def test_info_commands_lists_mathop_ensemble() -> None:
+    """``info commands ::tcl::mathop::*`` must enumerate every operator
+    even before any other code touches the ensemble — the
+    ``info commands`` walker materialises BUILTIN namespaces lazily."""
+    out = _run("puts [llength [info commands ::tcl::mathop::*]]")
+    assert out == "32"
+
+
+def test_materialise_only_for_builtin_backed_namespaces() -> None:
+    """Materialisation must only fire for namespaces backed by a
+    BUILTINS prefix.  An unknown prefix must remain unknown — i.e.
+    ``namespace exists`` against a name that has no BUILTINS entries
+    must still return 0 — so the materialise hook isn't degrading
+    into "any qualified ns is fine"."""
+    out = _run("puts [namespace exists ::nope::does_not_exist]")
+    assert out == "0"
+
+
+def test_materialise_does_not_create_unrelated_namespaces() -> None:
+    """After ``namespace import`` triggers materialisation of
+    ``::tcl::mathop``, a sibling whose name shares the prefix but
+    isn't backed by BUILTINS (``::tcl::mathop_BOGUS``) must NOT
+    spring into existence as a side-effect."""
+    out = _run(
+        """
+namespace import ::tcl::mathop::*
+puts [namespace exists ::tcl::mathop]
+puts [namespace exists ::tcl::mathop_BOGUS]
+"""
+    )
+    assert out == "1\n0"

--- a/tests/test_wasm_mathop.py
+++ b/tests/test_wasm_mathop.py
@@ -268,3 +268,43 @@ puts [namespace exists ::tcl::mathop_BOGUS]
 """
     )
     assert out == "1\n0"
+
+
+def test_namespace_import_mathop_partial_glob() -> None:
+    """The trailing simple-name component of an import spec is matched
+    by the standard Tcl ``string match`` glob — ``m*`` brings in
+    ``min``/``max`` only, not the rest of the ensemble."""
+    out = _run(
+        """
+namespace eval ::partial {
+    namespace import ::tcl::mathop::m*
+}
+puts [lsort [info commands ::partial::*]]
+puts [::partial::min 5 2 7]
+puts [::partial::max 5 2 7]
+"""
+    )
+    # ``info commands`` returns simple names from the queried ns.
+    assert out == "max min\n2\n7"
+
+
+def test_namespace_import_after_explicit_namespace_eval() -> None:
+    """A user that has already opened the source namespace explicitly
+    (``namespace eval ::tcl::mathop {}``) without populating it must
+    still see the BUILTINS forwards when they later import — the
+    materialiser fires unconditionally so the import isn't silently
+    a no-op against an empty cmd_table."""
+    out = _run(
+        """
+# Pre-create the ns the user-visible way (empty body).  Without
+# unconditional materialisation, the import below would walk an
+# empty cmd_table and bring nothing across.
+namespace eval ::tcl::mathop {}
+namespace eval ::dst {
+    namespace import ::tcl::mathop::*
+}
+puts [::dst::+ 1 2 3]
+puts [::dst::== 1 1 1]
+"""
+    )
+    assert out == "6\n1"

--- a/tests/test_wasm_mathop.py
+++ b/tests/test_wasm_mathop.py
@@ -12,7 +12,7 @@ import pytest
 
 wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
 
-from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm, _try_compile_and_run  # noqa: E402
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
 
 
 def _run(source: str) -> str:
@@ -286,6 +286,112 @@ puts [::partial::max 5 2 7]
     )
     # ``info commands`` returns simple names from the queried ns.
     assert out == "max min\n2\n7"
+
+
+def test_namespace_path_through_eval_materialises_mathop() -> None:
+    """When ``namespace path`` is dispatched at runtime (e.g. via
+    ``eval``), the path-setter hook in ``cmds/namespace.zig``
+    materialises the target.  The bare top-level form is currently
+    elided by codegen as a no-op, so this test goes through ``eval``
+    to exercise the runtime path that the hook actually owns."""
+    out = _run(
+        """
+puts [namespace exists ::tcl::mathop]
+eval namespace path ::tcl::mathop
+puts [namespace exists ::tcl::mathop]
+"""
+    )
+    # 0 (cold) → 1 (after path).
+    assert out == "0\n1"
+
+
+def test_info_commands_after_explicit_namespace_eval() -> None:
+    """If the user has pre-created the BUILTIN namespace explicitly
+    (``namespace eval ::tcl::mathop {}``) without populating it,
+    ``info commands ::tcl::mathop::*`` must still enumerate the
+    operators — verifies the unconditional materialise hook in
+    ``tcl_cmd_info.zig`` (was previously gated on
+    ``qualified_target == 0``)."""
+    out = _run(
+        """
+namespace eval ::tcl::mathop {}
+puts [llength [info commands ::tcl::mathop::*]]
+"""
+    )
+    assert out == "32"
+
+
+def test_mathfunc_namespace_materialises_too() -> None:
+    """The helper isn't mathop-specific.  ``::tcl::mathfunc``'s
+    BUILTIN entries (``::tcl::mathfunc::sin`` etc.) must also
+    materialise on demand."""
+    out = _run(
+        """
+puts [namespace exists ::tcl::mathfunc]
+puts [llength [info commands ::tcl::mathfunc::*]]
+puts [namespace exists ::tcl::mathfunc]
+"""
+    )
+    # Cold ``namespace exists`` returns 0; ``info commands`` triggers
+    # materialise; subsequent ``namespace exists`` is 1.  The exact
+    # count of mathfunc entries is registry-dependent, so just
+    # require "more than zero".
+    parts = out.split("\n")
+    assert parts[0] == "0", f"::tcl::mathfunc must not pre-exist before lookup: got {parts[0]!r}"
+    assert int(parts[1]) > 0, (
+        f"info commands ::tcl::mathfunc::* must enumerate after materialise: got {parts[1]!r}"
+    )
+    assert parts[2] == "1", f"::tcl::mathfunc must exist after materialise: got {parts[2]!r}"
+
+
+def test_materialise_idempotent_across_two_destinations() -> None:
+    """Importing the same source ensemble into two different
+    destinations must succeed for both — verifies that
+    ``materialise``'s "skip slots already populated as forwards"
+    path is a true no-op the second time around (no clobber, no
+    error)."""
+    out = _run(
+        """
+namespace eval ::a {
+    namespace import ::tcl::mathop::*
+}
+namespace eval ::b {
+    namespace import ::tcl::mathop::*
+}
+puts [::a::+ 1 2 3]
+puts [::b::+ 10 20 30]
+"""
+    )
+    assert out == "6\n60"
+
+
+def test_materialise_from_non_root_ns_does_not_pollute_tree() -> None:
+    """``register_builtin_forward`` resolves non-``::``-prefixed
+    names relative to ``ns_current()``.  ``cmds/tcl_mathop.zig``
+    registers each operator under both fully-qualified
+    (``::tcl::mathop::+``) and half-qualified (``tcl::mathop::+``)
+    spellings.  Without the ``::``-prefix filter in ``materialise``,
+    invoking the helper while ``ns_current`` is non-root would walk
+    the half-qualified names through the relative resolver and
+    create ``::caller::tcl::mathop::+`` etc., leaving the real
+    ``::tcl::mathop`` empty and polluting the caller's subtree.
+    Verify both halves: the canonical ns is populated, and no
+    ``tcl`` child appears under the caller's ns."""
+    out = _run(
+        """
+namespace eval ::caller {
+    # Force materialisation from inside ::caller — info commands
+    # is the cheapest reachable hook.
+    set _ [info commands ::tcl::mathop::*]
+    puts [namespace exists ::caller::tcl::mathop]
+    puts [namespace exists ::caller::tcl]
+    puts [namespace exists ::tcl::mathop]
+}
+"""
+    )
+    # No phantom ``::caller::tcl::mathop`` (or even ``::caller::tcl``);
+    # the canonical ``::tcl::mathop`` is the only target.
+    assert out == "0\n0\n1"
 
 
 def test_namespace_import_after_explicit_namespace_eval() -> None:


### PR DESCRIPTION
## Summary

Implement lazy materialisation of BUILTIN-tier namespaces (e.g., `::tcl::mathop`, `::tcl::mathfunc`) to support `namespace import` and other namespace operations on these ensembles.

The static `BUILTINS` slice in `tcl_cmd_table.zig` is keyed by fully-qualified command names (e.g., `::tcl::mathop::+`) and queried directly during command lookup. However, these entries are not registered in any namespace's `cmd_table`, so the namespace tree has no record that these namespaces "exist" until explicitly materialised. This caused operations like `namespace import ::tcl::mathop::*`, `info commands ::tcl::mathop::*`, and `namespace path` to fail or return empty results.

**Changes:**

1. **New module `runtime/zig/dispatch/tcl_builtin_ns.zig`**: Implements lazy materialisation of BUILTIN-backed namespaces:
   - `materialise(prefix_ptr, prefix_len)`: Creates the namespace and populates its `cmd_table` with `CMD_BUILTIN_FORWARD` redirects for each direct-child BUILTIN entry. Stamps `namespace export *` to make commands visible to imports. Idempotent.
   - `has_builtin_namespace()`: Checks if a prefix matches any BUILTIN entries.
   - Helper functions for prefix matching and separator detection.

2. **`runtime/zig/cmds/namespace.zig`**: Integrate materialisation into `namespace import` and `namespace path`:
   - Before resolving the source namespace in import patterns, call `materialise()` to ensure BUILTIN-backed namespaces are populated.
   - Handles both cold-start (namespace doesn't exist) and warm-start (namespace exists but is empty from a bare `namespace eval`) cases.
   - Falls back to regular namespace resolution for non-BUILTIN prefixes.

3. **`runtime/zig/cmds/tcl_cmd_info.zig`**: Integrate materialisation into `info commands`:
   - When walking commands with a qualified pattern like `::tcl::mathop::*`, materialise the namespace prefix before searching.
   - Ensures `info commands ::tcl::mathop::*` returns all operators even on first access.

4. **`tests/test_wasm_mathop.py`**: Add comprehensive test coverage:
   - `test_namespace_import_mathop_glob()`: Import all operators via glob pattern.
   - `test_namespace_import_mathop_single_name()`: Import specific operators.
   - `test_info_commands_lists_mathop_ensemble()`: Verify `info commands` enumerates all operators.
   - `test_materialise_only_for_builtin_backed_namespaces()`: Ensure non-BUILTIN namespaces remain unknown.
   - `test_materialise_does_not_create_unrelated_namespaces()`: Verify no spurious namespace creation.
   - `test_namespace_import_mathop_partial_glob()`: Test glob matching in import specs.
   - `test_namespace_import_after_explicit_namespace_eval()`: Handle pre-created empty namespaces.

## Validation

- [x] Added 7 new test cases covering namespace import, info commands, and edge cases for BUILTIN materialisation.
- [x] Tests verify idempotency, non-interference with user-defined namespaces, and glob pattern matching.

https://claude.ai/code/session_01VK3F59PAbxGUa4VE35xJot