### PR TITLE
Add `f5 grep` verb to find every BIG-IP object related to a name or regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,8 +737,22 @@ f5 cleanup --keep /Common/critical_pool bigip.conf
 f5 cleanup --json bigip.conf > report.json
 ```
 
-`f5` is a separate CLI from `tcl` and `irule`; today it ships two
-verbs (`cleanup`, `completion`).
+**`f5 grep` verb** — find every BIG-IP object related to a given
+object name (or regex) by walking the same forward-and-reverse
+reference graph the cleanup analysis uses.  By default the BFS
+traverses both directions, so a single command surfaces the seed's
+full neighbourhood: forward edges (objects the seed depends on) and
+reverse edges (objects that depend on the seed).
+
+```
+f5 grep /Common/web_pool bigip.conf
+f5 grep --direction reverse /Common/web1 bigip.conf
+f5 grep --regex '^/Common/(web|api)_pool$' bigip.conf
+f5 grep --json --max-depth 2 web_pool bigip.conf
+```
+
+`f5` is a separate CLI from `tcl` and `irule`; today it ships three
+verbs (`cleanup`, `grep`, `completion`).
 
 **Install the `f5` CLI** — the released artefact is a single-file
 zipapp (`f5-<version>.pyz`) that needs only Python 3.10+ on the host.

--- a/core/bigip/grep.py
+++ b/core/bigip/grep.py
@@ -71,13 +71,15 @@ class GrepReport:
     text_report: str = ""
 
 
-def _matches_pattern(identifier: str, pattern: str, *, use_regex: bool) -> bool:
+def _build_matcher(pattern: str, *, use_regex: bool):
+    """Return a ``(identifier) -> bool`` matcher; raises ValueError on bad regex."""
     if use_regex:
         try:
-            return re.search(pattern, identifier) is not None
-        except re.error:
-            return False
-    return pattern in identifier
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            raise ValueError(f"invalid regex pattern {pattern!r}: {exc}") from exc
+        return lambda identifier: compiled.search(identifier) is not None
+    return lambda identifier: pattern in identifier
 
 
 def _to_grep_object(node: BigipObjectNode, *, depth: int, is_seed: bool) -> GrepObject:
@@ -176,6 +178,14 @@ def compute_grep(
     """
     if direction not in DIRECTIONS:
         raise ValueError(f"direction must be one of {sorted(DIRECTIONS)}, got {direction!r}")
+    if max_nodes < 1:
+        raise ValueError(f"max_nodes must be >= 1, got {max_nodes}")
+    if max_depth is not None and max_depth < 0:
+        raise ValueError(f"max_depth must be >= 0 or None, got {max_depth}")
+
+    # Validate the pattern before walking the graph so a bad regex surfaces
+    # as a user error rather than a silent zero-match result.
+    matches = _build_matcher(pattern, use_regex=use_regex)
 
     saved = active_signature_profile()
     configure_signatures(dialect="f5-irules")
@@ -202,13 +212,15 @@ def compute_grep(
         return (node.kind or "", node.identifier)
 
     seed_ids: list[str] = sorted(
-        (
-            nid
-            for nid, node in all_nodes.items()
-            if _matches_pattern(node.identifier, pattern, use_regex=use_regex)
-        ),
+        (nid for nid, node in all_nodes.items() if matches(node.identifier)),
         key=_sort_key,
     )
+
+    # Honour max_nodes as a strict cap on total collected objects: when more
+    # seeds match the pattern than the cap allows, truncate before any BFS
+    # expansion so the cap is never silently exceeded.
+    if len(seed_ids) > max_nodes:
+        seed_ids = seed_ids[:max_nodes]
 
     depths: dict[str, int] = {sid: 0 for sid in seed_ids}
     queue: deque[str] = deque(seed_ids)
@@ -300,11 +312,16 @@ def compute_grep(
     )
 
 
-def report_to_dict(report: GrepReport) -> dict:
-    """Render *report* as a JSON-serialisable dict (LSP / CLI / AI consumers)."""
+def report_to_dict(report: GrepReport, *, include_body: bool = False) -> dict:
+    """Render *report* as a JSON-serialisable dict (LSP / CLI / AI consumers).
+
+    Pass ``include_body=True`` to embed each object's full body — this mirrors
+    the CLI's ``--full`` flag for callers that want JSON instead of the text
+    report.  Bodies are otherwise omitted to keep the JSON payload compact.
+    """
 
     def _obj_to_dict(obj: GrepObject) -> dict:
-        return {
+        d: dict = {
             "nodeId": obj.node_id,
             "uri": obj.uri,
             "module": obj.module,
@@ -325,6 +342,9 @@ def report_to_dict(report: GrepReport) -> dict:
                 },
             },
         }
+        if include_body:
+            d["body"] = obj.body
+        return d
 
     return {
         "pattern": report.pattern,

--- a/core/bigip/grep.py
+++ b/core/bigip/grep.py
@@ -1,0 +1,356 @@
+"""Find every BIG-IP object related to a given object name or regex.
+
+Walks the forward-and-reverse reference graph produced by
+:mod:`core.bigip.link_extract` from a set of *seed* objects whose
+identifiers match the user's pattern, and returns every object
+reachable from the seeds through reference edges in either direction.
+
+The same forward-edge engine that powers
+:func:`core.bigip.link_extract.extract_linked_bigip_objects` and
+:func:`core.bigip.cleanup.compute_cleanup` is reused here, so iRule
+body references (``pool ...``, ``persist ...``, ``class match ...``)
+count exactly as they do for the cleanup analysis.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+
+from ..analysis.semantic_model import Range
+from ..commands.registry.runtime import active_signature_profile, configure_signatures
+from .link_extract import (
+    BigipObjectEdge,
+    BigipObjectNode,
+    build_bigip_object_graph,
+)
+from .model import BigipConfig
+
+DIRECTIONS: frozenset[str] = frozenset({"forward", "reverse", "both"})
+
+
+@dataclass(frozen=True, slots=True)
+class GrepObject:
+    """One object in the grep result — a seed or a related object."""
+
+    node_id: str
+    uri: str
+    module: str
+    object_type: str
+    full_path: str
+    kind: str | None
+    header: str
+    body: str
+    depth: int
+    is_seed: bool
+    range: Range
+
+
+@dataclass(frozen=True, slots=True)
+class GrepEdge:
+    """One reference edge between two objects in the grep result."""
+
+    source_id: str
+    target_id: str
+    via_property: str
+    via_kind: str
+
+
+@dataclass(frozen=True, slots=True)
+class GrepReport:
+    """Result of :func:`compute_grep` — seeds, related objects, and edges."""
+
+    pattern: str
+    use_regex: bool
+    direction: str
+    seeds: tuple[GrepObject, ...] = ()
+    related: tuple[GrepObject, ...] = ()
+    edges: tuple[GrepEdge, ...] = ()
+    summary: dict[str, int] = field(default_factory=dict)
+    text_report: str = ""
+
+
+def _matches_pattern(identifier: str, pattern: str, *, use_regex: bool) -> bool:
+    if use_regex:
+        try:
+            return re.search(pattern, identifier) is not None
+        except re.error:
+            return False
+    return pattern in identifier
+
+
+def _to_grep_object(node: BigipObjectNode, *, depth: int, is_seed: bool) -> GrepObject:
+    return GrepObject(
+        node_id=node.node_id,
+        uri=node.uri,
+        module=node.module,
+        object_type=node.object_type,
+        full_path=node.identifier,
+        kind=node.kind,
+        header=node.header,
+        body=node.body,
+        depth=depth,
+        is_seed=is_seed,
+        range=node.range,
+    )
+
+
+def _format_text_report(
+    report_meta: dict,
+    seeds: tuple[GrepObject, ...],
+    related: tuple[GrepObject, ...],
+    summary: dict[str, int],
+    *,
+    include_body: bool,
+) -> str:
+    lines: list[str] = [
+        "# tcl-lsp BIG-IP grep",
+        f"# Pattern: {report_meta['pattern']}" + (" (regex)" if report_meta["use_regex"] else ""),
+        f"# Direction: {report_meta['direction']}",
+        f"# Sources: {', '.join(report_meta['source_uris']) or '(none)'}",
+        f"# Seeds: {len(seeds)} matched object(s)",
+        f"# Related: {len(related)} object(s)",
+    ]
+    if summary:
+        for kind in sorted(summary):
+            lines.append(f"#   {kind}: {summary[kind]}")
+    lines.append("")
+
+    if not seeds:
+        lines.append(f"# No objects match pattern: {report_meta['pattern']}")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _emit(obj: GrepObject) -> None:
+        marker = "*" if obj.is_seed else " "
+        lines.append(f"{marker} [{obj.kind or '?'}] {obj.full_path}  (depth {obj.depth})")
+        if include_body:
+            header_line = obj.header.rstrip()
+            lines.append(f"    {header_line} {{")
+            for body_line in obj.body.splitlines():
+                lines.append(f"    {body_line}".rstrip())
+            lines.append("    }")
+            lines.append("")
+
+    lines.append("# Seeds (matched by pattern):")
+    for obj in seeds:
+        _emit(obj)
+    lines.append("")
+
+    if related:
+        lines.append("# Related objects (reachable through reference edges):")
+        for obj in related:
+            _emit(obj)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def compute_grep(
+    *,
+    sources: dict[str, str],
+    configs: dict[str, BigipConfig],
+    pattern: str,
+    use_regex: bool = False,
+    direction: str = "both",
+    max_depth: int | None = None,
+    max_nodes: int = 1000,
+    include_body: bool = False,
+) -> GrepReport:
+    """Find every BIG-IP object related to seeds whose identifiers match *pattern*.
+
+    A seed is any object whose ``identifier`` (full path) matches *pattern* —
+    by substring when *use_regex* is ``False``, by :func:`re.search` when
+    ``True``.  Starting from the seeds the function walks the reference
+    graph in the requested *direction* (``forward``: outgoing edges only,
+    ``reverse``: incoming edges only, ``both``: union) until either every
+    reachable object has been visited, *max_depth* hops are exhausted (when
+    set), or *max_nodes* total objects have been collected.
+
+    The iRule body scan inside :mod:`core.bigip.link_extract` relies on
+    the ``f5-irules`` command registry being active; this function
+    configures the ``f5-irules`` profile for the duration of the call and
+    restores the previous active profile on exit, so callers do not need
+    to manage it.
+    """
+    if direction not in DIRECTIONS:
+        raise ValueError(f"direction must be one of {sorted(DIRECTIONS)}, got {direction!r}")
+
+    saved = active_signature_profile()
+    configure_signatures(dialect="f5-irules")
+    try:
+        nodes_by_uri, edges = build_bigip_object_graph(sources=sources, configs=configs)
+    finally:
+        configure_signatures(
+            dialect=saved["dialect"],  # type: ignore[arg-type]
+            extra_commands=saved["extra_commands"],  # type: ignore[arg-type]
+        )
+
+    all_nodes: dict[str, BigipObjectNode] = {}
+    for by_id in nodes_by_uri.values():
+        all_nodes.update(by_id)
+
+    outgoing: dict[str, list[BigipObjectEdge]] = defaultdict(list)
+    incoming: dict[str, list[BigipObjectEdge]] = defaultdict(list)
+    for edge in edges:
+        outgoing[edge.source_id].append(edge)
+        incoming[edge.target_id].append(edge)
+
+    def _sort_key(nid: str) -> tuple[str, str]:
+        node = all_nodes[nid]
+        return (node.kind or "", node.identifier)
+
+    seed_ids: list[str] = sorted(
+        (
+            nid
+            for nid, node in all_nodes.items()
+            if _matches_pattern(node.identifier, pattern, use_regex=use_regex)
+        ),
+        key=_sort_key,
+    )
+
+    depths: dict[str, int] = {sid: 0 for sid in seed_ids}
+    queue: deque[str] = deque(seed_ids)
+    while queue and len(depths) < max_nodes:
+        nid = queue.popleft()
+        depth = depths[nid]
+        if max_depth is not None and depth >= max_depth:
+            continue
+
+        neighbours: list[str] = []
+        if direction in {"forward", "both"}:
+            for edge in outgoing.get(nid, ()):
+                neighbours.append(edge.target_id)
+        if direction in {"reverse", "both"}:
+            for edge in incoming.get(nid, ()):
+                neighbours.append(edge.source_id)
+
+        for neighbour in neighbours:
+            if neighbour in depths:
+                continue
+            depths[neighbour] = depth + 1
+            queue.append(neighbour)
+            if len(depths) >= max_nodes:
+                break
+
+    seed_set = set(seed_ids)
+    visited = set(depths)
+
+    seeds_list = [
+        _to_grep_object(all_nodes[nid], depth=0, is_seed=True)
+        for nid in sorted(seed_ids, key=_sort_key)
+    ]
+
+    related_ids = sorted(
+        (nid for nid in visited if nid not in seed_set),
+        key=lambda nid: (depths[nid], _sort_key(nid)),
+    )
+    related_list = [
+        _to_grep_object(all_nodes[nid], depth=depths[nid], is_seed=False) for nid in related_ids
+    ]
+
+    summary: dict[str, int] = defaultdict(int)
+    for obj in (*seeds_list, *related_list):
+        summary[obj.kind or "<unknown>"] += 1
+
+    edge_items: list[GrepEdge] = []
+    seen_edges: set[tuple[str, str, str, str]] = set()
+    for edge in edges:
+        if edge.source_id not in visited or edge.target_id not in visited:
+            continue
+        key = (edge.source_id, edge.target_id, edge.via_property, edge.via_kind)
+        if key in seen_edges:
+            continue
+        seen_edges.add(key)
+        edge_items.append(
+            GrepEdge(
+                source_id=edge.source_id,
+                target_id=edge.target_id,
+                via_property=edge.via_property,
+                via_kind=edge.via_kind,
+            )
+        )
+
+    seeds_tuple = tuple(seeds_list)
+    related_tuple = tuple(related_list)
+    summary_dict = dict(summary)
+    text_report = _format_text_report(
+        {
+            "pattern": pattern,
+            "use_regex": use_regex,
+            "direction": direction,
+            "source_uris": tuple(sorted(sources)),
+        },
+        seeds_tuple,
+        related_tuple,
+        summary_dict,
+        include_body=include_body,
+    )
+
+    return GrepReport(
+        pattern=pattern,
+        use_regex=use_regex,
+        direction=direction,
+        seeds=seeds_tuple,
+        related=related_tuple,
+        edges=tuple(edge_items),
+        summary=summary_dict,
+        text_report=text_report,
+    )
+
+
+def report_to_dict(report: GrepReport) -> dict:
+    """Render *report* as a JSON-serialisable dict (LSP / CLI / AI consumers)."""
+
+    def _obj_to_dict(obj: GrepObject) -> dict:
+        return {
+            "nodeId": obj.node_id,
+            "uri": obj.uri,
+            "module": obj.module,
+            "objectType": obj.object_type,
+            "fullPath": obj.full_path,
+            "kind": obj.kind,
+            "header": obj.header,
+            "depth": obj.depth,
+            "isSeed": obj.is_seed,
+            "range": {
+                "start": {
+                    "line": obj.range.start.line,
+                    "character": obj.range.start.character,
+                },
+                "end": {
+                    "line": obj.range.end.line,
+                    "character": obj.range.end.character,
+                },
+            },
+        }
+
+    return {
+        "pattern": report.pattern,
+        "useRegex": report.use_regex,
+        "direction": report.direction,
+        "seeds": [_obj_to_dict(o) for o in report.seeds],
+        "related": [_obj_to_dict(o) for o in report.related],
+        "edges": [
+            {
+                "source": e.source_id,
+                "target": e.target_id,
+                "viaProperty": e.via_property,
+                "viaKind": e.via_kind,
+            }
+            for e in report.edges
+        ],
+        "summary": dict(report.summary),
+        "textReport": report.text_report,
+    }
+
+
+__all__ = [
+    "DIRECTIONS",
+    "GrepEdge",
+    "GrepObject",
+    "GrepReport",
+    "compute_grep",
+    "report_to_dict",
+]

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -113,6 +113,7 @@ combine them when more than one form helps:
 - [kcs-feature-control-flow-diagrams.md](kcs-feature-control-flow-diagrams.md)
 - [kcs-feature-irule-review.md](kcs-feature-irule-review.md)
 - [kcs-feature-bigip-cleanup.md](kcs-feature-bigip-cleanup.md)
+- [kcs-feature-bigip-grep.md](kcs-feature-bigip-grep.md)
 
 ## AI features
 

--- a/docs/kcs/features/kcs-feature-bigip-cleanup.md
+++ b/docs/kcs/features/kcs-feature-bigip-cleanup.md
@@ -30,7 +30,7 @@ The cleanup feature parses one or more `bigip.conf` / SCF files, treats every `l
 
 ### `f5` CLI
 
-`f5` is the BIG-IP-side CLI tool, separate from the `tcl` and `irule` CLIs.  Today it carries one verb — `cleanup` — and runs as a normal subcommand:
+`f5` is the BIG-IP-side CLI tool, separate from the `tcl` and `irule` CLIs.  It carries `cleanup` (this verb) plus [`grep`](kcs-feature-bigip-grep.md) (find every object related to a name or regex) and `completion` (print a shell completion script), and runs as a normal subcommand:
 
 ```
 f5 cleanup samples/bigip/bigip.conf

--- a/docs/kcs/features/kcs-feature-bigip-grep.md
+++ b/docs/kcs/features/kcs-feature-bigip-grep.md
@@ -1,0 +1,104 @@
+# KCS: feature — BIG-IP Related-Object Grep
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Summary
+
+`f5` CLI tool with a `grep` verb that finds every BIG-IP object related to a given object name (or regex), by walking the same forward-and-reverse reference graph the cleanup analysis uses.
+
+## Applies to
+
+tcl-lsp CLI
+
+## Question
+
+How do I find every BIG-IP object that is related to a given object — every pool that uses a node, every virtual that depends on a pool, every iRule that references a data-group?
+
+## How to use
+
+The grep feature parses one or more `bigip.conf` / SCF files and walks the BIG-IP object reference graph from a set of *seed* objects whose full path matches the user's pattern.  The reference graph is the same one [`f5 cleanup`](kcs-feature-bigip-cleanup.md) walks: configuration-property references plus iRule body references (`pool`, `persist`, `class match ... <data-group>`, `snatpool`, `virtual`, `node`).
+
+By default the BFS walks both directions — *forward* (objects the seed depends on) and *reverse* (objects that depend on the seed) — so a single command shows the seed's full neighbourhood.
+
+### `f5` CLI
+
+```
+f5 grep /Common/web_pool bigip.conf
+f5 grep --direction reverse /Common/web1 bigip.conf
+f5 grep --regex '^/Common/(web|api)_pool$' bigip.conf
+f5 grep --json --max-depth 2 web_pool bigip.conf
+```
+
+In dev, before the zipapp ships the bare `f5` script, invoke the same module directly: `python -m explorer.f5_cli grep …`.
+
+The `related` alias is provided for readability:
+
+```
+f5 related /Common/web_pool bigip.conf
+```
+
+## Options
+
+- `-e, --regex` — treat PATTERN as a Python regular expression (default: substring match against the object's full path).
+- `--direction {forward,reverse,both}` — which edges to walk from each seed.  `forward` follows outgoing references (what the seed depends on); `reverse` follows incoming references (what depends on the seed); `both` (default) walks both.
+- `--max-depth N` — stop the BFS after N hops from each seed.  Default: unlimited.
+- `--max-nodes N` — cap the result at N objects (default: 1000) to keep the output tractable on very large configurations.
+- `--full` — print each object's full body, not just its header / path.
+- `--json` — emit the report as JSON instead of the text report.
+- `-o FILE` — write the report to `FILE` instead of stdout.
+
+The exit code is `0` when at least one seed matched the pattern and `1` when no seeds matched, mirroring the standard `grep` convention.
+
+## Example
+
+### Input
+
+```
+ltm node /Common/n1 { address 10.0.0.1 }
+ltm monitor http /Common/m1 { defaults-from /Common/http }
+ltm pool /Common/web_pool {
+    members { /Common/n1:80 { address 10.0.0.1 } }
+    monitor /Common/m1
+}
+ltm virtual /Common/vs {
+    destination /Common/10.0.0.10:80
+    pool /Common/web_pool
+}
+```
+
+### Output (`f5 grep /Common/web_pool bigip.conf`)
+
+```
+# tcl-lsp BIG-IP grep
+# Pattern: /Common/web_pool
+# Direction: both
+# Sources: file:///bigip.conf
+# Seeds: 1 matched object(s)
+# Related: 3 object(s)
+#   ltm_monitor_http: 1
+#   ltm_node: 1
+#   ltm_pool: 1
+#   ltm_virtual: 1
+
+# Seeds (matched by pattern):
+* [ltm_pool] /Common/web_pool  (depth 0)
+
+# Related objects (reachable through reference edges):
+  [ltm_monitor_http] /Common/m1  (depth 1)
+  [ltm_node] /Common/n1  (depth 1)
+  [ltm_virtual] /Common/vs  (depth 1)
+```
+
+A seed line is prefixed with `*`; related lines start with two spaces.  The `(depth N)` annotation is the BFS distance from the nearest seed.
+
+## Out of scope
+
+- The grep verb does not modify the configuration — it only reports.
+- It uses *substring* matching by default; pass `--regex` for a Python regular expression.  There is no glob / shell-style matching.
+- The reference graph is the same one [`f5 cleanup`](kcs-feature-bigip-cleanup.md) walks; objects unreachable through that graph are not surfaced even if they share a name pattern.
+
+## Related
+
+- [BIG-IP Config Cleanup](kcs-feature-bigip-cleanup.md) — uses the same reference graph to flag unreachable objects.
+- [iRule Extraction](kcs-feature-irule-extraction.md) — pulls iRule bodies out of a `bigip.conf` for editing.

--- a/explorer/completions/f5.bash
+++ b/explorer/completions/f5.bash
@@ -21,9 +21,11 @@ _f5_complete() {
         cword=$COMP_CWORD
     fi
 
-    local verbs="cleanup clean completion"
+    local verbs="cleanup clean completion grep related"
     local global_opts="-h --help --help-all --version"
     local cleanup_opts="--json --keep --no-keep-common -o --output -h --help"
+    local grep_opts="-e --regex --direction --max-depth --max-nodes --full --json -o --output -h --help"
+    local grep_directions="forward reverse both"
     local completion_shells="bash fish zsh"
 
     # First positional after the command name: pick a verb.
@@ -63,6 +65,58 @@ _f5_complete() {
                     esac
                 done
                 COMPREPLY+=( "${dirs[@]}" )
+            fi
+            ;;
+        grep|related)
+            case "$prev" in
+                --direction)
+                    COMPREPLY=( $(compgen -W "$grep_directions" -- "$cur") )
+                    return
+                    ;;
+                --max-depth|--max-nodes)
+                    # Numeric — no completion candidates.
+                    COMPREPLY=()
+                    return
+                    ;;
+                -o|--output)
+                    COMPREPLY=( $(compgen -A file -- "$cur") )
+                    return
+                    ;;
+            esac
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "$grep_opts" -- "$cur") )
+            else
+                # First non-flag positional is the pattern (free-form).  Subsequent
+                # positionals are config files — restrict to .conf / .scf plus dirs.
+                local non_flag_count=0
+                local i
+                for ((i=2; i<cword; i++)); do
+                    case "${words[i]}" in
+                        -*) ;;  # flag
+                        *)
+                            case "${words[i-1]}" in
+                                --direction|--max-depth|--max-nodes|-o|--output)
+                                    ;;  # value of preceding flag
+                                *)
+                                    non_flag_count=$((non_flag_count+1))
+                                    ;;
+                            esac
+                            ;;
+                    esac
+                done
+                if [[ $non_flag_count -lt 1 ]]; then
+                    COMPREPLY=()
+                else
+                    local files=( $(compgen -A file -- "$cur") )
+                    local dirs=( $(compgen -A directory -- "$cur") )
+                    COMPREPLY=()
+                    for f in "${files[@]}"; do
+                        case "$f" in
+                            *.conf|*.scf|-) COMPREPLY+=( "$f" ) ;;
+                        esac
+                    done
+                    COMPREPLY+=( "${dirs[@]}" )
+                fi
             fi
             ;;
         completion)

--- a/explorer/completions/f5.fish
+++ b/explorer/completions/f5.fish
@@ -26,6 +26,8 @@ complete -c f5 -f
 complete -c f5 -n __f5_no_subcommand -a cleanup -d 'Generate tmsh delete commands for unreferenced objects'
 complete -c f5 -n __f5_no_subcommand -a clean -d 'Alias for cleanup'
 complete -c f5 -n __f5_no_subcommand -a completion -d 'Print shell completion script'
+complete -c f5 -n __f5_no_subcommand -a grep -d 'List every BIG-IP object related to a given object path or regex'
+complete -c f5 -n __f5_no_subcommand -a related -d 'Alias for grep'
 
 # Top-level help / version.
 complete -c f5 -n __f5_no_subcommand -s h -l help -d 'Show brief help and exit'
@@ -41,6 +43,19 @@ complete -c f5 -n '__f5_uses_subcommand cleanup clean' -s h -l help -d 'Show hel
 
 # Positional arguments for cleanup — restrict to .conf / .scf files.
 complete -c f5 -n '__f5_uses_subcommand cleanup clean' -F -k -a "(__fish_complete_suffix .conf; __fish_complete_suffix .scf)"
+
+# `grep` / `related` flags.
+complete -c f5 -n '__f5_uses_subcommand grep related' -s e -l regex -d 'Treat PATTERN as a Python regular expression'
+complete -c f5 -n '__f5_uses_subcommand grep related' -l direction -r -a 'forward reverse both' -d 'Which edges to traverse'
+complete -c f5 -n '__f5_uses_subcommand grep related' -l max-depth -r -d 'Stop BFS after N hops'
+complete -c f5 -n '__f5_uses_subcommand grep related' -l max-nodes -r -d 'Cap result at N objects'
+complete -c f5 -n '__f5_uses_subcommand grep related' -l full -d 'Print each object full body'
+complete -c f5 -n '__f5_uses_subcommand grep related' -l json -d 'Emit grep report as JSON'
+complete -c f5 -n '__f5_uses_subcommand grep related' -s o -l output -r -F -d 'Write output here (default: stdout)'
+complete -c f5 -n '__f5_uses_subcommand grep related' -s h -l help -d 'Show help'
+
+# Positional config files for grep — restrict to .conf / .scf files.
+complete -c f5 -n '__f5_uses_subcommand grep related' -F -k -a "(__fish_complete_suffix .conf; __fish_complete_suffix .scf)"
 
 # `completion` shell argument.
 complete -c f5 -n '__f5_uses_subcommand completion' -a 'bash fish zsh' -d 'Shell'

--- a/explorer/completions/f5.zsh
+++ b/explorer/completions/f5.zsh
@@ -34,6 +34,8 @@ _f5() {
                 'cleanup:Generate tmsh delete commands for objects unreferenced by any virtual'
                 'clean:Alias for cleanup'
                 'completion:Print shell completion script for bash/fish/zsh'
+                'grep:List every BIG-IP object related to a given object path or regex'
+                'related:Alias for grep'
             )
             _describe -t verbs 'verb' verbs
             ;;
@@ -46,6 +48,19 @@ _f5() {
                         '*--keep[Object full-path or partition prefix to retain]:keep:_files' \
                         '--no-keep-common[Do not auto-keep /Common/*]' \
                         '(-o --output)'{-o,--output}'[Write output here (default: stdout)]:output file:_files' \
+                        '*:bigip config:_files -g "*.{conf,scf}"'
+                    ;;
+                grep|related)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Show help]' \
+                        '(-e --regex)'{-e,--regex}'[Treat PATTERN as a Python regular expression]' \
+                        '--direction[Which edges to traverse]:direction:(forward reverse both)' \
+                        '--max-depth[Stop BFS after N hops]:max depth:' \
+                        '--max-nodes[Cap result at N objects]:max nodes:' \
+                        '--full[Print each object full body]' \
+                        '--json[Emit grep report as JSON]' \
+                        '(-o --output)'{-o,--output}'[Write output here (default: stdout)]:output file:_files' \
+                        '1:pattern:' \
                         '*:bigip config:_files -g "*.{conf,scf}"'
                     ;;
                 completion)

--- a/explorer/verbs/f5/__init__.py
+++ b/explorer/verbs/f5/__init__.py
@@ -8,4 +8,4 @@ which is independent of the ``tcl`` / ``irule`` registry under
 
 def load_verbs() -> None:
     """Import all ``@verb``-decorated f5 modules, triggering their registrations."""
-    from . import cleanup, completion  # noqa: F401
+    from . import cleanup, completion, grep  # noqa: F401

--- a/explorer/verbs/f5/grep.py
+++ b/explorer/verbs/f5/grep.py
@@ -1,0 +1,137 @@
+"""``f5 grep`` — find every BIG-IP object related to a name or regex."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from core.bigip.grep import DIRECTIONS, compute_grep, report_to_dict
+from core.bigip.parser import parse_bigip_conf
+
+from ._registry import verb
+
+
+@verb(
+    "grep",
+    aliases=("related",),
+    help="List every BIG-IP object related to a given object path or regex.",
+)
+def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: str) -> None:  # noqa: ARG001
+    p.description = (
+        "Find every BIG-IP object reachable through reference edges from "
+        "the seed objects whose full path matches PATTERN.  PATTERN is "
+        "a substring match by default; pass --regex to treat it as a "
+        "Python regular expression.  The reference graph is the same "
+        "one `f5 cleanup` walks — both configuration-property "
+        "references and iRule body references (`pool`, `persist`, "
+        "`class match ... <data-group>`) are tracked."
+    )
+    p.add_argument(
+        "pattern",
+        help="Object full-path or substring (or regex with --regex) to seed the search.",
+    )
+    p.add_argument(
+        "paths",
+        nargs="+",
+        help="bigip.conf / SCF files (one or more).  Pass `-` to read stdin.",
+    )
+    p.add_argument(
+        "-e",
+        "--regex",
+        action="store_true",
+        help="Treat PATTERN as a Python regular expression (default: substring match).",
+    )
+    p.add_argument(
+        "--direction",
+        choices=sorted(DIRECTIONS),
+        default="both",
+        help=(
+            "Which edges to traverse from each seed.  `forward` follows "
+            "outgoing references (what the seed depends on), `reverse` "
+            "follows incoming references (what depends on the seed), "
+            "`both` walks both (default)."
+        ),
+    )
+    p.add_argument(
+        "--max-depth",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Stop the BFS after N hops from each seed (default: unlimited).",
+    )
+    p.add_argument(
+        "--max-nodes",
+        type=int,
+        default=1000,
+        metavar="N",
+        help="Cap the result at N objects (default: 1000).",
+    )
+    p.add_argument(
+        "--full",
+        action="store_true",
+        help="Print each object's full body, not just its header / path.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the grep report as JSON instead of the text report.",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        metavar="FILE",
+        help="Write the report here (default: stdout).",
+    )
+    p.set_defaults(handler=_run_grep)
+
+
+def _read_path(path_str: str) -> tuple[str, str]:
+    """Return ``(uri, source)`` for *path_str*.  ``-`` reads stdin."""
+    if path_str == "-":
+        return ("stdin://input", sys.stdin.read())
+    path = Path(path_str).resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"not a file: {path_str}")
+    return (path.as_uri(), path.read_text(encoding="utf-8", errors="replace"))
+
+
+def _run_grep(args: argparse.Namespace) -> int:
+    sources: dict[str, str] = {}
+    configs = {}
+    for path_str in args.paths:
+        try:
+            uri, src = _read_path(path_str)
+        except OSError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        sources[uri] = src
+        configs[uri] = parse_bigip_conf(src)
+
+    report = compute_grep(
+        sources=sources,
+        configs=configs,
+        pattern=args.pattern,
+        use_regex=args.regex,
+        direction=args.direction,
+        max_depth=args.max_depth,
+        max_nodes=args.max_nodes,
+        include_body=args.full,
+    )
+
+    if args.json:
+        output = json.dumps(report_to_dict(report), indent=2) + "\n"
+    else:
+        output = report.text_report
+        if not output.endswith("\n"):
+            output += "\n"
+
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output)
+
+    # Exit code: 0 when at least one seed matched, 1 when no seeds matched
+    # (mirrors `grep` convention: empty match is a non-zero exit).
+    return 0 if report.seeds else 1

--- a/explorer/verbs/f5/grep.py
+++ b/explorer/verbs/f5/grep.py
@@ -71,7 +71,11 @@ def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: s
     p.add_argument(
         "--full",
         action="store_true",
-        help="Print each object's full body, not just its header / path.",
+        help=(
+            "Include each object's full body in the output.  In the text "
+            "report bodies appear under each header; in JSON output bodies "
+            "are embedded under the `body` key on every object."
+        ),
     )
     p.add_argument(
         "--json",
@@ -121,7 +125,7 @@ def _run_grep(args: argparse.Namespace) -> int:
     )
 
     if args.json:
-        output = json.dumps(report_to_dict(report), indent=2) + "\n"
+        output = json.dumps(report_to_dict(report, include_body=args.full), indent=2) + "\n"
     else:
         output = report.text_report
         if not output.endswith("\n"):

--- a/tests/test_bigip_grep.py
+++ b/tests/test_bigip_grep.py
@@ -210,6 +210,44 @@ def test_invalid_direction_raises() -> None:
         _run(source, "vs", direction="sideways")
 
 
+def test_invalid_regex_pattern_raises_value_error() -> None:
+    """Bad regex must surface as a user error, not a silent zero-match result."""
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError, match="invalid regex pattern"):
+        _run(source, "[unclosed", use_regex=True)
+
+
+def test_max_nodes_below_one_raises() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError):
+        _run(source, "vs", max_nodes=0)
+
+
+def test_max_depth_negative_raises() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError):
+        _run(source, "vs", max_depth=-1)
+
+
+def test_max_nodes_truncates_seeds_when_pattern_matches_too_many() -> None:
+    """When more seeds match than max_nodes allows, the result is capped strictly."""
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm pool /Common/p2 { members { /Common/n1:81 { address 10.0.0.1 } } }
+        ltm pool /Common/p3 { members { /Common/n1:82 { address 10.0.0.1 } } }
+        ltm pool /Common/p4 { members { /Common/n1:83 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    # Pattern matches every pool (4 seeds), but cap is 2.
+    report = _run(source, "/Common/p", direction="forward", max_nodes=2)
+    total = len(report.seeds) + len(report.related)
+    assert total <= 2
+    assert len(report.seeds) == 2
+
+
 def test_compute_grep_restores_signature_profile() -> None:
     saved = active_signature_profile()
     source = textwrap.dedent(
@@ -241,6 +279,27 @@ def test_report_to_dict_round_trips_through_json() -> None:
     assert {item["fullPath"] for item in again["seeds"]} == {"/Common/p1"}
     assert {item["fullPath"] for item in again["related"]} >= {"/Common/n1", "/Common/vs"}
     assert isinstance(again["edges"], list)
+    # By default, body is omitted to keep the JSON payload compact.
+    assert "body" not in again["seeds"][0]
+
+
+def test_report_to_dict_with_include_body_emits_object_bodies() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="both")
+    payload = report_to_dict(report, include_body=True)
+    assert "body" in payload["seeds"][0]
+    assert payload["seeds"][0]["body"]
+    for item in payload["related"]:
+        assert "body" in item
 
 
 def test_text_report_marks_seed_and_related_objects() -> None:
@@ -273,7 +332,7 @@ def test_include_body_emits_object_body_in_text_report() -> None:
     assert "address 10.0.0.1" in report.text_report
 
 
-def test_sample_bigip_conf_grep_returns_full_neighbourhood(tmp_path: Path) -> None:
+def test_sample_bigip_conf_grep_returns_full_neighbourhood() -> None:
     sample = Path(__file__).parent.parent / "samples" / "bigip" / "bigip.conf"
     src = sample.read_text(encoding="utf-8")
     cfg = parse_bigip_conf(src)
@@ -295,7 +354,7 @@ def test_sample_bigip_conf_grep_returns_full_neighbourhood(tmp_path: Path) -> No
 # CLI integration tests
 
 
-def test_cli_grep_prints_text_report(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_cli_grep_prints_text_report(tmp_path: Path, capsys) -> None:
     conf = tmp_path / "x.conf"
     conf.write_text(
         textwrap.dedent(
@@ -394,3 +453,39 @@ def test_cli_grep_alias_related_works(tmp_path: Path, capsys) -> None:
     captured = capsys.readouterr()
     assert rc == 0
     assert "/Common/vs" in captured.out
+
+
+def test_cli_grep_invalid_regex_reports_error(tmp_path: Path, capsys) -> None:
+    """A bad regex must fail loudly with a non-zero exit code."""
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n",
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--regex", "[unclosed", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "invalid regex pattern" in captured.err
+
+
+def test_cli_grep_full_json_emits_object_bodies(tmp_path: Path, capsys) -> None:
+    """`--full` with `--json` must include each object's body in the payload."""
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm virtual /Common/vs {
+                destination /Common/10.0.0.10:80
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--json", "--full", "/Common/n1", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    data = json.loads(captured.out)
+    assert data["seeds"][0]["fullPath"] == "/Common/n1"
+    assert "body" in data["seeds"][0]
+    assert "address 10.0.0.1" in data["seeds"][0]["body"]

--- a/tests/test_bigip_grep.py
+++ b/tests/test_bigip_grep.py
@@ -1,0 +1,396 @@
+"""Tests for BIG-IP related-object grep analysis."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from core.bigip.grep import compute_grep, report_to_dict
+from core.bigip.parser import parse_bigip_conf
+from core.commands.registry.runtime import active_signature_profile
+from explorer import f5_cli
+
+
+def _run(source: str, pattern: str, **kwargs):
+    cfg = parse_bigip_conf(source)
+    uri = "mem://test.conf"
+    return compute_grep(
+        sources={uri: source},
+        configs={uri: cfg},
+        pattern=pattern,
+        **kwargs,
+    )
+
+
+def _full_paths(items) -> list[str]:
+    return [item.full_path for item in items]
+
+
+def test_pattern_matches_seed_and_pulls_in_forward_neighbours() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm monitor http /Common/m1 { defaults-from /Common/http }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+            monitor /Common/m1
+        }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="forward")
+    assert _full_paths(report.seeds) == ["/Common/p1"]
+    assert set(_full_paths(report.related)) == {"/Common/n1", "/Common/m1"}
+
+
+def test_reverse_direction_reaches_referrers_only() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm monitor http /Common/m1 { defaults-from /Common/http }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+            monitor /Common/m1
+        }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/n1", direction="reverse")
+    assert _full_paths(report.seeds) == ["/Common/n1"]
+    # Reverse from the node reaches the pool, then the virtual that uses the pool.
+    related_paths = set(_full_paths(report.related))
+    assert "/Common/p1" in related_paths
+    assert "/Common/vs" in related_paths
+    # The monitor isn't reachable from the node via reverse edges alone.
+    assert "/Common/m1" not in related_paths
+
+
+def test_both_direction_collects_full_neighbourhood() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm monitor http /Common/m1 { defaults-from /Common/http }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+            monitor /Common/m1
+        }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="both")
+    related_paths = set(_full_paths(report.related))
+    assert related_paths == {"/Common/n1", "/Common/m1", "/Common/vs"}
+
+
+def test_substring_pattern_matches_multiple_seeds() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/web_pool { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm pool /Common/api_pool { members { /Common/n1:81 { address 10.0.0.1 } } }
+        ltm pool /Common/db_pool { members { /Common/n1:82 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    report = _run(source, "_pool", direction="forward")
+    assert set(_full_paths(report.seeds)) == {
+        "/Common/web_pool",
+        "/Common/api_pool",
+        "/Common/db_pool",
+    }
+
+
+def test_regex_pattern_anchors_match() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/web_pool { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm pool /Common/api_pool { members { /Common/n1:81 { address 10.0.0.1 } } }
+        ltm pool /Common/db_pool { members { /Common/n1:82 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    report = _run(source, r"^/Common/(web|api)_pool$", use_regex=True, direction="forward")
+    assert set(_full_paths(report.seeds)) == {"/Common/web_pool", "/Common/api_pool"}
+
+
+def test_no_match_yields_empty_report() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    report = _run(source, "nonexistent")
+    assert report.seeds == ()
+    assert report.related == ()
+    assert "No objects match" in report.text_report
+
+
+def test_max_depth_limits_bfs() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm monitor http /Common/m1 { defaults-from /Common/http }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+            monitor /Common/m1
+        }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    # depth-1 BFS from the virtual reaches the pool but not the node/monitor.
+    report = _run(source, "/Common/vs", direction="forward", max_depth=1)
+    assert _full_paths(report.related) == ["/Common/p1"]
+
+
+def test_max_nodes_caps_result_size() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm pool /Common/p2 { members { /Common/n1:81 { address 10.0.0.1 } } }
+        ltm pool /Common/p3 { members { /Common/n1:82 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    report = _run(source, "/Common/n1", direction="reverse", max_nodes=2)
+    assert len(report.seeds) + len(report.related) <= 2
+
+
+def test_irule_body_references_count_as_edges() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/used_pool {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+        }
+        ltm data-group internal /Common/used_dg {
+            type string
+            records { x { data y } }
+        }
+        ltm rule /Common/r1 {
+        when HTTP_REQUEST {
+            pool /Common/used_pool
+            if { [class match [HTTP::host] equals /Common/used_dg] } { reject }
+        }
+        }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            rules { /Common/r1 }
+        }
+        """
+    )
+    report = _run(source, "/Common/r1", direction="forward")
+    related = set(_full_paths(report.related))
+    assert "/Common/used_pool" in related
+    assert "/Common/used_dg" in related
+
+
+def test_invalid_direction_raises() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError):
+        _run(source, "vs", direction="sideways")
+
+
+def test_compute_grep_restores_signature_profile() -> None:
+    saved = active_signature_profile()
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    _run(source, "/Common/n1")
+    assert active_signature_profile() == saved
+
+
+def test_report_to_dict_round_trips_through_json() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="both")
+    payload = report_to_dict(report)
+    again = json.loads(json.dumps(payload))
+    assert again["pattern"] == "/Common/p1"
+    assert again["direction"] == "both"
+    assert {item["fullPath"] for item in again["seeds"]} == {"/Common/p1"}
+    assert {item["fullPath"] for item in again["related"]} >= {"/Common/n1", "/Common/vs"}
+    assert isinstance(again["edges"], list)
+
+
+def test_text_report_marks_seed_and_related_objects() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="forward")
+    text = report.text_report
+    assert "* [ltm_pool] /Common/p1" in text
+    assert "  [ltm_node] /Common/n1" in text
+
+
+def test_include_body_emits_object_body_in_text_report() -> None:
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+        }
+        """
+    )
+    report = _run(source, "/Common/n1", direction="forward", include_body=True)
+    assert "address 10.0.0.1" in report.text_report
+
+
+def test_sample_bigip_conf_grep_returns_full_neighbourhood(tmp_path: Path) -> None:
+    sample = Path(__file__).parent.parent / "samples" / "bigip" / "bigip.conf"
+    src = sample.read_text(encoding="utf-8")
+    cfg = parse_bigip_conf(src)
+    report = compute_grep(
+        sources={sample.as_uri(): src},
+        configs={sample.as_uri(): cfg},
+        pattern="/Common/web_pool",
+        direction="both",
+    )
+    assert any(s.full_path == "/Common/web_pool" for s in report.seeds)
+    related_paths = {r.full_path for r in report.related}
+    # The web_pool's nodes and monitor are forward neighbours, and the virtuals
+    # that use it are reverse neighbours.
+    assert "/Common/web1" in related_paths
+    assert "/Common/web2" in related_paths
+    assert any("vs" in path for path in related_paths)
+
+
+# CLI integration tests
+
+
+def test_cli_grep_prints_text_report(tmp_path: Path, capsys, monkeypatch) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+            ltm virtual /Common/vs {
+                destination /Common/10.0.0.10:80
+                pool /Common/p1
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "/Common/p1", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Pattern: /Common/p1" in captured.out
+    assert "/Common/n1" in captured.out
+    assert "/Common/vs" in captured.out
+
+
+def test_cli_grep_no_match_returns_exit_code_one(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n",
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "no_such_object", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "No objects match pattern: no_such_object" in captured.out
+
+
+def test_cli_grep_json_emits_valid_json(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm virtual /Common/vs {
+                destination /Common/10.0.0.10:80
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--json", "/Common/n1", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    data = json.loads(captured.out)
+    assert data["pattern"] == "/Common/n1"
+    assert data["direction"] == "both"
+    assert data["seeds"][0]["fullPath"] == "/Common/n1"
+
+
+def test_cli_grep_writes_to_output_file(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+            """
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.txt"
+    rc = f5_cli.main(["grep", "/Common/n1", str(conf), "-o", str(out)])
+    assert rc == 0
+    body = out.read_text(encoding="utf-8")
+    assert "Pattern: /Common/n1" in body
+
+
+def test_cli_grep_reads_stdin_with_dash(monkeypatch, capsys) -> None:
+    src = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }
+        """
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(src))
+    rc = f5_cli.main(["grep", "/Common/n1", "-"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "/Common/n1" in captured.out
+
+
+def test_cli_grep_alias_related_works(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n",
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["related", "/Common/vs", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "/Common/vs" in captured.out


### PR DESCRIPTION
Walks the same forward-and-reverse reference graph used by `f5 cleanup`
from a set of seed objects whose full path matches the user's PATTERN
(substring by default; `--regex` enables Python regex).  By default the
BFS traverses both directions, so a single command surfaces the seed's
full neighbourhood -- forward edges (objects the seed depends on) and
reverse edges (objects that depend on the seed).  iRule body references
are tracked exactly as the cleanup analysis tracks them.

Includes substring + regex matching, direction selection
(forward/reverse/both), depth/node caps, full-body output, and JSON
output, plus shell-completion entries for bash/fish/zsh and a `related`
alias.

https://claude.ai/code/session_018uboAeZ68onVd3sKsB2hot