### PR TITLE
Add CIDR mode to `f5 grep` verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,13 @@ f5 grep --regex '^/Common/(web|api)_pool$' bigip.conf
 f5 grep --json --max-depth 2 web_pool bigip.conf
 f5 grep --cidr 10.0.0.0/8 bigip.conf
 f5 grep --cidr '10.0.0.0/8, 192.168.0.0/16' bigip.conf
+f5 grep --no-recurse --cidr 10.0.0.0/8 bigip.conf
 ```
+
+The related-object BFS is on by default; pass `--no-recurse` to
+skip it and return only the objects that directly match the
+pattern (`-r` / `--recurse` toggle it explicitly back on).  This
+applies to every match mode: substring, `--regex`, and `--cidr`.
 
 `f5` is a separate CLI from `tcl` and `irule`; today it ships three
 verbs (`cleanup`, `grep`, `completion`).

--- a/README.md
+++ b/README.md
@@ -738,17 +738,28 @@ f5 cleanup --json bigip.conf > report.json
 ```
 
 **`f5 grep` verb** — find every BIG-IP object related to a given
-object name (or regex) by walking the same forward-and-reverse
-reference graph the cleanup analysis uses.  By default the BFS
-traverses both directions, so a single command surfaces the seed's
-full neighbourhood: forward edges (objects the seed depends on) and
-reverse edges (objects that depend on the seed).
+object name (or regex, or CIDR) by walking the same
+forward-and-reverse reference graph the cleanup analysis uses.  By
+default the BFS traverses both directions, so a single command
+surfaces the seed's full neighbourhood: forward edges (objects the
+seed depends on) and reverse edges (objects that depend on the seed).
+
+`--cidr` switches the seed selector from "match the object's full
+path" to "match an IP address or CIDR mentioned anywhere inside the
+object — header, body, or iRule script".  Multiple networks may be
+passed at once as a comma- or whitespace-separated list, and an
+object qualifies when any IP/CIDR token in its text overlaps any
+requested network.  This catches addresses buried deep inside iRule
+bodies (`if { [IP::addr [IP::client_addr] equals "10.0.0.5"] }`,
+`class match … "10.0.0.0/8"`, …) that a plain path grep can't reach.
 
 ```
 f5 grep /Common/web_pool bigip.conf
 f5 grep --direction reverse /Common/web1 bigip.conf
 f5 grep --regex '^/Common/(web|api)_pool$' bigip.conf
 f5 grep --json --max-depth 2 web_pool bigip.conf
+f5 grep --cidr 10.0.0.0/8 bigip.conf
+f5 grep --cidr '10.0.0.0/8, 192.168.0.0/16' bigip.conf
 ```
 
 `f5` is a separate CLI from `tcl` and `irule`; today it ships three

--- a/core/bigip/grep.py
+++ b/core/bigip/grep.py
@@ -14,12 +14,15 @@ count exactly as they do for the cleanup analysis.
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from collections import defaultdict, deque
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 
 from ..analysis.semantic_model import Range
 from ..commands.registry.runtime import active_signature_profile, configure_signatures
+from ..common.ip_utils import IPV4_RE, IPV6_RE
 from .link_extract import (
     BigipObjectEdge,
     BigipObjectNode,
@@ -28,6 +31,8 @@ from .link_extract import (
 from .model import BigipConfig
 
 DIRECTIONS: frozenset[str] = frozenset({"forward", "reverse", "both"})
+
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,17 +74,101 @@ class GrepReport:
     edges: tuple[GrepEdge, ...] = ()
     summary: dict[str, int] = field(default_factory=dict)
     text_report: str = ""
+    use_cidr: bool = False
 
 
-def _build_matcher(pattern: str, *, use_regex: bool):
-    """Return a ``(identifier) -> bool`` matcher; raises ValueError on bad regex."""
+def _parse_cidr_pattern(pattern: str) -> tuple[_IPNetwork, ...]:
+    """Parse one or more whitespace/comma-separated IPs or CIDRs.
+
+    Each token is fed through :func:`ipaddress.ip_network` with
+    ``strict=False`` so host-address forms (``10.0.0.1`` →
+    ``10.0.0.1/32``) and network forms (``10.0.0.0/8``) are both
+    accepted.
+    """
+    tokens = [tok for tok in re.split(r"[,\s]+", pattern.strip()) if tok]
+    if not tokens:
+        raise ValueError("CIDR pattern must contain at least one IP address or network")
+    networks: list[_IPNetwork] = []
+    for token in tokens:
+        try:
+            networks.append(ipaddress.ip_network(token, strict=False))
+        except (ValueError, ipaddress.AddressValueError) as exc:
+            raise ValueError(f"invalid CIDR pattern {token!r}: {exc}") from exc
+    return tuple(networks)
+
+
+def _extract_ip_networks(text: str) -> Iterator[_IPNetwork]:
+    """Yield every IP/CIDR token found in *text* as an :mod:`ipaddress` network.
+
+    Scans for IPv4 and IPv6 literals (with an optional ``/prefix``) using
+    the shared :mod:`core.common.ip_utils` regexes and validates each
+    candidate via :func:`ipaddress.ip_network` (``strict=False``).
+    Tokens that fail validation are silently skipped — the regexes are
+    deliberately permissive so we lean on the stdlib parser as the
+    authority.
+    """
+    for match in IPV4_RE.finditer(text):
+        token = match.group(0)
+        try:
+            yield ipaddress.ip_network(token, strict=False)
+        except (ValueError, ipaddress.AddressValueError):
+            continue
+    for match in IPV6_RE.finditer(text):
+        token = match.group(0)
+        try:
+            yield ipaddress.ip_network(token, strict=False)
+        except (ValueError, ipaddress.AddressValueError):
+            continue
+
+
+def _node_matches_cidrs(
+    node: BigipObjectNode,
+    seed_networks: tuple[_IPNetwork, ...],
+) -> bool:
+    """Return True when any IP/CIDR mentioned by *node* overlaps a seed network.
+
+    The node's full path, header, and body are searched together so
+    that hits inside iRule scripts (``equals "10.0.0.0/8"``,
+    ``IP::addr 10.0.0.1`` …) and inside configuration bodies
+    (``destination /Common/10.0.0.10:80``) both qualify.
+    """
+    haystack = f"{node.identifier}\n{node.header}\n{node.body}"
+    for found in _extract_ip_networks(haystack):
+        for seed in seed_networks:
+            if found.version != seed.version:
+                continue
+            if seed.overlaps(found):
+                return True
+    return False
+
+
+def _build_matcher(
+    pattern: str,
+    *,
+    use_regex: bool,
+    use_cidr: bool = False,
+) -> Callable[[BigipObjectNode], bool]:
+    """Return a ``(node) -> bool`` matcher for the given pattern mode.
+
+    The substring and regex modes match against the node's identifier
+    (full path) only — preserving existing behaviour.  CIDR mode
+    inspects the node's path, header, and body so that IP/CIDR
+    references buried inside iRule script bodies are picked up.
+
+    Raises :class:`ValueError` on a bad regex or unparseable CIDR.
+    """
+    if use_cidr and use_regex:
+        raise ValueError("--cidr and --regex are mutually exclusive")
+    if use_cidr:
+        seed_networks = _parse_cidr_pattern(pattern)
+        return lambda node: _node_matches_cidrs(node, seed_networks)
     if use_regex:
         try:
             compiled = re.compile(pattern)
         except re.error as exc:
             raise ValueError(f"invalid regex pattern {pattern!r}: {exc}") from exc
-        return lambda identifier: compiled.search(identifier) is not None
-    return lambda identifier: pattern in identifier
+        return lambda node: compiled.search(node.identifier) is not None
+    return lambda node: pattern in node.identifier
 
 
 def _to_grep_object(node: BigipObjectNode, *, depth: int, is_seed: bool) -> GrepObject:
@@ -106,9 +195,15 @@ def _format_text_report(
     *,
     include_body: bool,
 ) -> str:
+    if report_meta.get("use_cidr"):
+        mode_suffix = " (cidr)"
+    elif report_meta["use_regex"]:
+        mode_suffix = " (regex)"
+    else:
+        mode_suffix = ""
     lines: list[str] = [
         "# tcl-lsp BIG-IP grep",
-        f"# Pattern: {report_meta['pattern']}" + (" (regex)" if report_meta["use_regex"] else ""),
+        f"# Pattern: {report_meta['pattern']}" + mode_suffix,
         f"# Direction: {report_meta['direction']}",
         f"# Sources: {', '.join(report_meta['source_uris']) or '(none)'}",
         f"# Seeds: {len(seeds)} matched object(s)",
@@ -155,6 +250,7 @@ def compute_grep(
     configs: dict[str, BigipConfig],
     pattern: str,
     use_regex: bool = False,
+    use_cidr: bool = False,
     direction: str = "both",
     max_depth: int | None = None,
     max_nodes: int = 1000,
@@ -162,10 +258,21 @@ def compute_grep(
 ) -> GrepReport:
     """Find every BIG-IP object related to seeds whose identifiers match *pattern*.
 
-    A seed is any object whose ``identifier`` (full path) matches *pattern* —
-    by substring when *use_regex* is ``False``, by :func:`re.search` when
-    ``True``.  Starting from the seeds the function walks the reference
-    graph in the requested *direction* (``forward``: outgoing edges only,
+    A seed is any object that matches *pattern*.  Three match modes are
+    supported and they are mutually exclusive:
+
+    - **Substring** (default): the pattern must appear as a substring of
+      the object's ``identifier`` (full path).
+    - **Regex** (*use_regex*): the pattern is compiled with :mod:`re` and
+      tested against the object's identifier with :func:`re.search`.
+    - **CIDR** (*use_cidr*): the pattern is parsed as one or more
+      whitespace/comma-separated IP addresses or CIDRs, and an object is
+      a seed when any IP literal or CIDR mentioned in its path, header,
+      or body overlaps any of the requested networks.  This includes
+      addresses buried deep inside iRule script bodies.
+
+    Starting from the seeds the function walks the reference graph in
+    the requested *direction* (``forward``: outgoing edges only,
     ``reverse``: incoming edges only, ``both``: union) until either every
     reachable object has been visited, *max_depth* hops are exhausted (when
     set), or *max_nodes* total objects have been collected.
@@ -183,9 +290,10 @@ def compute_grep(
     if max_depth is not None and max_depth < 0:
         raise ValueError(f"max_depth must be >= 0 or None, got {max_depth}")
 
-    # Validate the pattern before walking the graph so a bad regex surfaces
-    # as a user error rather than a silent zero-match result.
-    matches = _build_matcher(pattern, use_regex=use_regex)
+    # Validate the pattern before walking the graph so a bad regex or
+    # unparseable CIDR surfaces as a user error rather than a silent
+    # zero-match result.
+    matches = _build_matcher(pattern, use_regex=use_regex, use_cidr=use_cidr)
 
     saved = active_signature_profile()
     configure_signatures(dialect="f5-irules")
@@ -212,7 +320,7 @@ def compute_grep(
         return (node.kind or "", node.identifier)
 
     seed_ids: list[str] = sorted(
-        (nid for nid, node in all_nodes.items() if matches(node.identifier)),
+        (nid for nid, node in all_nodes.items() if matches(node)),
         key=_sort_key,
     )
 
@@ -291,6 +399,7 @@ def compute_grep(
         {
             "pattern": pattern,
             "use_regex": use_regex,
+            "use_cidr": use_cidr,
             "direction": direction,
             "source_uris": tuple(sorted(sources)),
         },
@@ -303,6 +412,7 @@ def compute_grep(
     return GrepReport(
         pattern=pattern,
         use_regex=use_regex,
+        use_cidr=use_cidr,
         direction=direction,
         seeds=seeds_tuple,
         related=related_tuple,
@@ -349,6 +459,7 @@ def report_to_dict(report: GrepReport, *, include_body: bool = False) -> dict:
     return {
         "pattern": report.pattern,
         "useRegex": report.use_regex,
+        "useCidr": report.use_cidr,
         "direction": report.direction,
         "seeds": [_obj_to_dict(o) for o in report.seeds],
         "related": [_obj_to_dict(o) for o in report.related],

--- a/core/bigip/grep.py
+++ b/core/bigip/grep.py
@@ -75,6 +75,7 @@ class GrepReport:
     summary: dict[str, int] = field(default_factory=dict)
     text_report: str = ""
     use_cidr: bool = False
+    recurse: bool = True
 
 
 def _parse_cidr_pattern(pattern: str) -> tuple[_IPNetwork, ...]:
@@ -201,13 +202,18 @@ def _format_text_report(
         mode_suffix = " (regex)"
     else:
         mode_suffix = ""
+    related_line = (
+        f"# Related: {len(related)} object(s)"
+        if report_meta.get("recurse", True)
+        else "# Related: 0 object(s) (skipped — --no-recurse)"
+    )
     lines: list[str] = [
         "# tcl-lsp BIG-IP grep",
         f"# Pattern: {report_meta['pattern']}" + mode_suffix,
         f"# Direction: {report_meta['direction']}",
         f"# Sources: {', '.join(report_meta['source_uris']) or '(none)'}",
         f"# Seeds: {len(seeds)} matched object(s)",
-        f"# Related: {len(related)} object(s)",
+        related_line,
     ]
     if summary:
         for kind in sorted(summary):
@@ -255,6 +261,7 @@ def compute_grep(
     max_depth: int | None = None,
     max_nodes: int = 1000,
     include_body: bool = False,
+    recurse: bool = True,
 ) -> GrepReport:
     """Find every BIG-IP object related to seeds whose identifiers match *pattern*.
 
@@ -276,6 +283,14 @@ def compute_grep(
     ``reverse``: incoming edges only, ``both``: union) until either every
     reachable object has been visited, *max_depth* hops are exhausted (when
     set), or *max_nodes* total objects have been collected.
+
+    *recurse* is ``True`` by default — the related-object BFS runs and
+    the report includes everything reachable from the seeds.  Pass
+    ``recurse=False`` to skip the BFS entirely and return only the
+    objects that directly match *pattern* — *direction* and *max_depth*
+    are then ignored, and the ``related`` tuple in the report is empty.
+    This is the right mode when the question is "which objects mention
+    X?" rather than "what is the neighbourhood around X?".
 
     The iRule body scan inside :mod:`core.bigip.link_extract` relies on
     the ``f5-irules`` command registry being active; this function
@@ -331,28 +346,29 @@ def compute_grep(
         seed_ids = seed_ids[:max_nodes]
 
     depths: dict[str, int] = {sid: 0 for sid in seed_ids}
-    queue: deque[str] = deque(seed_ids)
-    while queue and len(depths) < max_nodes:
-        nid = queue.popleft()
-        depth = depths[nid]
-        if max_depth is not None and depth >= max_depth:
-            continue
-
-        neighbours: list[str] = []
-        if direction in {"forward", "both"}:
-            for edge in outgoing.get(nid, ()):
-                neighbours.append(edge.target_id)
-        if direction in {"reverse", "both"}:
-            for edge in incoming.get(nid, ()):
-                neighbours.append(edge.source_id)
-
-        for neighbour in neighbours:
-            if neighbour in depths:
+    if recurse:
+        queue: deque[str] = deque(seed_ids)
+        while queue and len(depths) < max_nodes:
+            nid = queue.popleft()
+            depth = depths[nid]
+            if max_depth is not None and depth >= max_depth:
                 continue
-            depths[neighbour] = depth + 1
-            queue.append(neighbour)
-            if len(depths) >= max_nodes:
-                break
+
+            neighbours: list[str] = []
+            if direction in {"forward", "both"}:
+                for edge in outgoing.get(nid, ()):
+                    neighbours.append(edge.target_id)
+            if direction in {"reverse", "both"}:
+                for edge in incoming.get(nid, ()):
+                    neighbours.append(edge.source_id)
+
+            for neighbour in neighbours:
+                if neighbour in depths:
+                    continue
+                depths[neighbour] = depth + 1
+                queue.append(neighbour)
+                if len(depths) >= max_nodes:
+                    break
 
     seed_set = set(seed_ids)
     visited = set(depths)
@@ -401,6 +417,7 @@ def compute_grep(
             "use_regex": use_regex,
             "use_cidr": use_cidr,
             "direction": direction,
+            "recurse": recurse,
             "source_uris": tuple(sorted(sources)),
         },
         seeds_tuple,
@@ -419,6 +436,7 @@ def compute_grep(
         edges=tuple(edge_items),
         summary=summary_dict,
         text_report=text_report,
+        recurse=recurse,
     )
 
 
@@ -460,6 +478,7 @@ def report_to_dict(report: GrepReport, *, include_body: bool = False) -> dict:
         "pattern": report.pattern,
         "useRegex": report.use_regex,
         "useCidr": report.use_cidr,
+        "recurse": report.recurse,
         "direction": report.direction,
         "seeds": [_obj_to_dict(o) for o in report.seeds],
         "related": [_obj_to_dict(o) for o in report.related],

--- a/docs/kcs/features/kcs-feature-bigip-grep.md
+++ b/docs/kcs/features/kcs-feature-bigip-grep.md
@@ -44,6 +44,7 @@ f5 related /Common/web_pool bigip.conf
 
 - `-e, --regex` — treat PATTERN as a Python regular expression (default: substring match against the object's full path).  Mutually exclusive with `--cidr`.
 - `-c, --cidr` — treat PATTERN as one or more whitespace- or comma-separated IPv4/IPv6 addresses or CIDR ranges.  An object qualifies when any IP literal or CIDR mentioned in its full path, header, or body — including iRule script bodies — overlaps any requested network.  Mutually exclusive with `--regex`.
+- `-r, --recurse` / `--no-recurse` — walk the related-object BFS from each seed (the default), or skip the BFS and return only the objects that directly match PATTERN.  Applies to every match mode (substring, regex, CIDR).  When `--no-recurse` is in effect, `--direction` and `--max-depth` are ignored and the report's `related` list is empty.
 - `--direction {forward,reverse,both}` — which edges to walk from each seed.  `forward` follows outgoing references (what the seed depends on); `reverse` follows incoming references (what depends on the seed); `both` (default) walks both.
 - `--max-depth N` — stop the BFS after N hops from each seed.  Default: unlimited.
 - `--max-nodes N` — cap the result at N objects (default: 1000) to keep the output tractable on very large configurations.

--- a/docs/kcs/features/kcs-feature-bigip-grep.md
+++ b/docs/kcs/features/kcs-feature-bigip-grep.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-`f5` CLI tool with a `grep` verb that finds every BIG-IP object related to a given object name (or regex), by walking the same forward-and-reverse reference graph the cleanup analysis uses.
+`f5` CLI tool with a `grep` verb that finds every BIG-IP object related to a given object name, regex, or CIDR — by walking the same forward-and-reverse reference graph the cleanup analysis uses.  CIDR mode also scans IP literals buried inside iRule script bodies.
 
 ## Applies to
 
@@ -28,6 +28,8 @@ f5 grep /Common/web_pool bigip.conf
 f5 grep --direction reverse /Common/web1 bigip.conf
 f5 grep --regex '^/Common/(web|api)_pool$' bigip.conf
 f5 grep --json --max-depth 2 web_pool bigip.conf
+f5 grep --cidr 10.0.0.0/8 bigip.conf
+f5 grep --cidr '10.0.0.0/8, 192.168.0.0/16' bigip.conf
 ```
 
 In dev, before the zipapp ships the bare `f5` script, invoke the same module directly: `python -m explorer.f5_cli grep …`.
@@ -40,7 +42,8 @@ f5 related /Common/web_pool bigip.conf
 
 ## Options
 
-- `-e, --regex` — treat PATTERN as a Python regular expression (default: substring match against the object's full path).
+- `-e, --regex` — treat PATTERN as a Python regular expression (default: substring match against the object's full path).  Mutually exclusive with `--cidr`.
+- `-c, --cidr` — treat PATTERN as one or more whitespace- or comma-separated IPv4/IPv6 addresses or CIDR ranges.  An object qualifies when any IP literal or CIDR mentioned in its full path, header, or body — including iRule script bodies — overlaps any requested network.  Mutually exclusive with `--regex`.
 - `--direction {forward,reverse,both}` — which edges to walk from each seed.  `forward` follows outgoing references (what the seed depends on); `reverse` follows incoming references (what depends on the seed); `both` (default) walks both.
 - `--max-depth N` — stop the BFS after N hops from each seed.  Default: unlimited.
 - `--max-nodes N` — cap the result at N objects (default: 1000) to keep the output tractable on very large configurations.
@@ -92,10 +95,26 @@ ltm virtual /Common/vs {
 
 A seed line is prefixed with `*`; related lines start with two spaces.  The `(depth N)` annotation is the BFS distance from the nearest seed.
 
+### CIDR mode
+
+Use `--cidr` to ask "which BIG-IP objects touch a given network?".  The seed selector parses PATTERN as one or more IPv4/IPv6 addresses or CIDR ranges and scans every object's full path, header, and body for IP/CIDR tokens that overlap.  Bare host addresses are treated as `/32` (IPv4) or `/128` (IPv6), so `--cidr 10.0.0.5` also matches an object that contains the containing network `10.0.0.0/24`, and vice versa.
+
+```
+ltm rule /Common/r_block {
+when HTTP_REQUEST {
+    if { [matchclass [IP::client_addr] equals "10.10.0.0/16"] } { reject }
+    if { [IP::addr [IP::client_addr] equals "10.0.0.5"] } { reject }
+}
+}
+```
+
+`f5 grep --cidr 10.0.0.0/8 bigip.conf` returns `/Common/r_block` as a seed because both the literal `10.0.0.5` and the CIDR `10.10.0.0/16` mentioned in the iRule body fall inside `10.0.0.0/8`.  This is the only way to surface IP references buried inside Tcl logic — the substring and regex modes only match against an object's full path.
+
 ## Out of scope
 
 - The grep verb does not modify the configuration — it only reports.
-- It uses *substring* matching by default; pass `--regex` for a Python regular expression.  There is no glob / shell-style matching.
+- It uses *substring* matching by default; pass `--regex` for a Python regular expression or `--cidr` for IP/CIDR matching.  There is no glob / shell-style matching.
+- `--cidr` validates each candidate IP token via Python's `ipaddress` module and silently skips anything that doesn't parse — the regexes that find candidate tokens are intentionally permissive and lean on the stdlib parser as the source of truth.
 - The reference graph is the same one [`f5 cleanup`](kcs-feature-bigip-cleanup.md) walks; objects unreachable through that graph are not surfaced even if they share a name pattern.
 
 ## Related

--- a/explorer/verbs/f5/grep.py
+++ b/explorer/verbs/f5/grep.py
@@ -23,25 +23,45 @@ def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: s
         "Find every BIG-IP object reachable through reference edges from "
         "the seed objects whose full path matches PATTERN.  PATTERN is "
         "a substring match by default; pass --regex to treat it as a "
-        "Python regular expression.  The reference graph is the same "
-        "one `f5 cleanup` walks — both configuration-property "
-        "references and iRule body references (`pool`, `persist`, "
-        "`class match ... <data-group>`) are tracked."
+        "Python regular expression, or --cidr to match IP addresses and "
+        "CIDR ranges anywhere in an object — including deep inside iRule "
+        "script bodies.  The reference graph is the same one "
+        "`f5 cleanup` walks — both configuration-property references "
+        "and iRule body references (`pool`, `persist`, `class match ... "
+        "<data-group>`) are tracked."
     )
     p.add_argument(
         "pattern",
-        help="Object full-path or substring (or regex with --regex) to seed the search.",
+        help=(
+            "Object full-path or substring by default; a Python regex with "
+            "--regex; or one or more whitespace/comma-separated IP/CIDR "
+            "values with --cidr (for example `10.0.0.0/8` or "
+            "`10.0.0.0/8,192.168.0.0/16`)."
+        ),
     )
     p.add_argument(
         "paths",
         nargs="+",
         help="bigip.conf / SCF files (one or more).  Pass `-` to read stdin.",
     )
-    p.add_argument(
+    mode_group = p.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "-e",
         "--regex",
         action="store_true",
         help="Treat PATTERN as a Python regular expression (default: substring match).",
+    )
+    mode_group.add_argument(
+        "-c",
+        "--cidr",
+        action="store_true",
+        help=(
+            "Treat PATTERN as one or more IPv4/IPv6 addresses or CIDR "
+            "ranges (whitespace- or comma-separated).  An object matches "
+            "when any IP literal or CIDR mentioned in its path, header, "
+            "or body — including iRule script bodies — overlaps any "
+            "requested network."
+        ),
     )
     p.add_argument(
         "--direction",
@@ -118,6 +138,7 @@ def _run_grep(args: argparse.Namespace) -> int:
         configs=configs,
         pattern=args.pattern,
         use_regex=args.regex,
+        use_cidr=args.cidr,
         direction=args.direction,
         max_depth=args.max_depth,
         max_nodes=args.max_nodes,

--- a/explorer/verbs/f5/grep.py
+++ b/explorer/verbs/f5/grep.py
@@ -82,6 +82,19 @@ def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: s
         help="Stop the BFS after N hops from each seed (default: unlimited).",
     )
     p.add_argument(
+        "-r",
+        "--recurse",
+        dest="recurse",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "Walk the related-object BFS from each seed (default).  "
+            "Pass --no-recurse to skip the BFS and report only the "
+            "objects that directly match PATTERN; --direction and "
+            "--max-depth are then ignored."
+        ),
+    )
+    p.add_argument(
         "--max-nodes",
         type=int,
         default=1000,
@@ -143,6 +156,7 @@ def _run_grep(args: argparse.Namespace) -> int:
         max_depth=args.max_depth,
         max_nodes=args.max_nodes,
         include_body=args.full,
+        recurse=args.recurse,
     )
 
     if args.json:

--- a/tests/test_bigip_grep.py
+++ b/tests/test_bigip_grep.py
@@ -468,6 +468,218 @@ def test_cli_grep_invalid_regex_reports_error(tmp_path: Path, capsys) -> None:
     assert "invalid regex pattern" in captured.err
 
 
+# CIDR mode
+
+
+def test_cidr_matches_address_in_object_header() -> None:
+    """A virtual whose destination falls inside the seed CIDR is a seed."""
+    source = textwrap.dedent(
+        """\
+        ltm virtual /Common/vs_inside { destination /Common/10.5.5.10:80 }
+        ltm virtual /Common/vs_outside { destination /Common/192.168.1.1:80 }
+        """
+    )
+    report = _run(source, "10.0.0.0/8", use_cidr=True, direction="forward")
+    paths = set(_full_paths(report.seeds))
+    assert "/Common/vs_inside" in paths
+    assert "/Common/vs_outside" not in paths
+
+
+def test_cidr_matches_inside_irule_body() -> None:
+    """An IP literal buried in an iRule script body is matched."""
+    source = textwrap.dedent(
+        """\
+        ltm rule /Common/r_block {
+        when HTTP_REQUEST {
+            if { [IP::addr [IP::client_addr] equals "10.0.0.5"] } { reject }
+        }
+        }
+        ltm rule /Common/r_other {
+        when HTTP_REQUEST {
+            if { [IP::addr [IP::client_addr] equals "192.168.1.1"] } { reject }
+        }
+        }
+        """
+    )
+    report = _run(source, "10.0.0.0/8", use_cidr=True, direction="forward")
+    paths = set(_full_paths(report.seeds))
+    assert "/Common/r_block" in paths
+    assert "/Common/r_other" not in paths
+
+
+def test_cidr_matches_cidr_literal_inside_irule_body() -> None:
+    """A `/prefix` literal inside an iRule body is matched when it overlaps."""
+    source = textwrap.dedent(
+        """\
+        ltm rule /Common/r_subnet {
+        when HTTP_REQUEST {
+            if { [matchclass [IP::client_addr] equals "10.10.0.0/16"] } { reject }
+        }
+        }
+        """
+    )
+    report = _run(source, "10.0.0.0/8", use_cidr=True, direction="forward")
+    assert _full_paths(report.seeds) == ["/Common/r_subnet"]
+
+
+def test_cidr_host_address_seed_matches_containing_network() -> None:
+    """A bare host seed matches an object that mentions a containing CIDR."""
+    source = textwrap.dedent(
+        """\
+        ltm data-group internal /Common/dg_block {
+            type ip
+            records {
+                10.0.0.0/8 { }
+            }
+        }
+        """
+    )
+    report = _run(source, "10.5.5.5", use_cidr=True, direction="forward")
+    assert _full_paths(report.seeds) == ["/Common/dg_block"]
+
+
+def test_cidr_multiple_networks_are_unioned() -> None:
+    """Whitespace- and comma-separated CIDRs both seed the search."""
+    source = textwrap.dedent(
+        """\
+        ltm virtual /Common/vs_a { destination /Common/10.0.0.1:80 }
+        ltm virtual /Common/vs_b { destination /Common/192.168.1.1:80 }
+        ltm virtual /Common/vs_c { destination /Common/172.20.5.10:80 }
+        """
+    )
+    report = _run(source, "10.0.0.0/8, 192.168.0.0/16", use_cidr=True, direction="forward")
+    paths = set(_full_paths(report.seeds))
+    assert paths == {"/Common/vs_a", "/Common/vs_b"}
+
+
+def test_cidr_matches_ipv6_in_irule() -> None:
+    """IPv6 CIDR seeds match IPv6 literals inside iRule bodies."""
+    source = textwrap.dedent(
+        """\
+        ltm rule /Common/r_v6 {
+        when HTTP_REQUEST {
+            if { [IP::addr [IP::client_addr] equals "2001:db8::dead"] } { reject }
+        }
+        }
+        ltm rule /Common/r_v4_only {
+        when HTTP_REQUEST {
+            if { [IP::addr [IP::client_addr] equals "10.0.0.1"] } { reject }
+        }
+        }
+        """
+    )
+    report = _run(source, "2001:db8::/32", use_cidr=True, direction="forward")
+    paths = set(_full_paths(report.seeds))
+    assert "/Common/r_v6" in paths
+    assert "/Common/r_v4_only" not in paths
+
+
+def test_cidr_pulls_in_referenced_neighbours() -> None:
+    """CIDR seeds still expand to forward neighbours through reference edges."""
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+        }
+        ltm virtual /Common/vs_inside {
+            destination /Common/10.5.5.10:80
+            pool /Common/p1
+        }
+        ltm virtual /Common/vs_outside {
+            destination /Common/192.168.1.1:80
+        }
+        """
+    )
+    report = _run(source, "10.5.5.0/24", use_cidr=True, direction="forward")
+    assert _full_paths(report.seeds) == ["/Common/vs_inside"]
+    related = set(_full_paths(report.related))
+    # The pool (and through it the node) must be reachable from the seed.
+    assert "/Common/p1" in related
+    assert "/Common/n1" in related
+
+
+def test_cidr_invalid_pattern_raises_value_error() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError, match="invalid CIDR pattern"):
+        _run(source, "999.999.999.999/8", use_cidr=True)
+
+
+def test_cidr_empty_pattern_raises_value_error() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError, match="at least one IP"):
+        _run(source, "   ", use_cidr=True)
+
+
+def test_cidr_and_regex_are_mutually_exclusive() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _run(source, "10.0.0.0/8", use_cidr=True, use_regex=True)
+
+
+def test_cidr_text_report_marks_pattern_as_cidr() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    report = _run(source, "10.0.0.0/8", use_cidr=True)
+    assert "Pattern: 10.0.0.0/8 (cidr)" in report.text_report
+
+
+def test_cidr_report_to_dict_round_trips_use_cidr_flag() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    report = _run(source, "10.0.0.0/8", use_cidr=True)
+    payload = report_to_dict(report)
+    again = json.loads(json.dumps(payload))
+    assert again["useCidr"] is True
+    assert again["useRegex"] is False
+    assert {item["fullPath"] for item in again["seeds"]} == {"/Common/vs"}
+
+
+def test_cli_grep_cidr_finds_irule_match(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm rule /Common/r_block {
+            when HTTP_REQUEST {
+                if { [IP::addr [IP::client_addr] equals "10.0.0.5"] } { reject }
+            }
+            }
+            ltm virtual /Common/vs_outside { destination /Common/192.168.1.1:80 }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--cidr", "10.0.0.0/8", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Pattern: 10.0.0.0/8 (cidr)" in captured.out
+    assert "/Common/r_block" in captured.out
+    assert "/Common/vs_outside" not in captured.out
+
+
+def test_cli_grep_cidr_invalid_pattern_reports_error(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n",
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--cidr", "999.999.999.999/8", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "invalid CIDR pattern" in captured.err
+
+
+def test_cli_grep_cidr_and_regex_are_rejected(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit):
+        f5_cli.main(["grep", "--cidr", "--regex", "10.0.0.0/8", str(conf)])
+    captured = capsys.readouterr()
+    assert "not allowed with argument" in captured.err or "mutually exclusive" in captured.err
+
+
 def test_cli_grep_full_json_emits_object_bodies(tmp_path: Path, capsys) -> None:
     """`--full` with `--json` must include each object's body in the payload."""
     conf = tmp_path / "x.conf"

--- a/tests/test_bigip_grep.py
+++ b/tests/test_bigip_grep.py
@@ -468,6 +468,132 @@ def test_cli_grep_invalid_regex_reports_error(tmp_path: Path, capsys) -> None:
     assert "invalid regex pattern" in captured.err
 
 
+# Recurse / --no-recurse (skip related-object BFS)
+
+
+def test_recurse_default_includes_related_objects() -> None:
+    """The BFS is on by default — related objects are surfaced."""
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="forward")
+    assert _full_paths(report.seeds) == ["/Common/p1"]
+    assert _full_paths(report.related) == ["/Common/n1"]
+    assert report.recurse is True
+
+
+def test_no_recurse_returns_seeds_only() -> None:
+    """``recurse=False`` skips the BFS — only matching seeds are returned."""
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+        }
+        ltm virtual /Common/vs {
+            destination /Common/10.0.0.10:80
+            pool /Common/p1
+        }
+        """
+    )
+    report = _run(source, "/Common/p1", direction="both", recurse=False)
+    assert _full_paths(report.seeds) == ["/Common/p1"]
+    assert report.related == ()
+    assert report.recurse is False
+
+
+def test_no_recurse_with_cidr_keeps_only_directly_matching_objects() -> None:
+    """CIDR + recurse=False yields every object that mentions the network, no neighbours."""
+    source = textwrap.dedent(
+        """\
+        ltm node /Common/n1 { address 10.0.0.1 }
+        ltm pool /Common/p1 {
+            members { /Common/n1:80 { address 10.0.0.1 } }
+        }
+        ltm virtual /Common/vs_outside { destination /Common/192.168.1.1:80 }
+        """
+    )
+    report = _run(source, "10.0.0.0/8", use_cidr=True, recurse=False)
+    paths = set(_full_paths(report.seeds))
+    # Every node and pool member that mentions an address in 10.0.0.0/8.
+    assert "/Common/n1" in paths
+    assert "/Common/p1" in paths
+    assert "/Common/vs_outside" not in paths
+    assert report.related == ()
+
+
+def test_no_recurse_text_report_explains_skip() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    report = _run(source, "/Common/vs", recurse=False)
+    assert "(skipped — --no-recurse)" in report.text_report
+
+
+def test_recurse_round_trips_through_report_to_dict() -> None:
+    source = "ltm virtual /Common/vs { destination /Common/10.0.0.10:80 }\n"
+    payload_on = report_to_dict(_run(source, "/Common/vs"))
+    payload_off = report_to_dict(_run(source, "/Common/vs", recurse=False))
+    assert payload_on["recurse"] is True
+    assert payload_off["recurse"] is False
+
+
+def test_cli_grep_defaults_to_recursive(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--direction", "forward", "/Common/p1", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "/Common/n1" in captured.out
+
+
+def test_cli_grep_no_recurse_skips_bfs(tmp_path: Path, capsys) -> None:
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "--no-recurse", "--direction", "forward", "/Common/p1", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "/Common/n1" not in captured.out
+    assert "(skipped — --no-recurse)" in captured.out
+
+
+def test_cli_grep_recurse_short_flag_is_default(tmp_path: Path, capsys) -> None:
+    """``-r`` is the same as the default; provided for symmetry with --no-recurse."""
+    conf = tmp_path / "x.conf"
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            ltm node /Common/n1 { address 10.0.0.1 }
+            ltm pool /Common/p1 { members { /Common/n1:80 { address 10.0.0.1 } } }
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = f5_cli.main(["grep", "-r", "--direction", "forward", "/Common/p1", str(conf)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "/Common/n1" in captured.out
+
+
 # CIDR mode
 
 


### PR DESCRIPTION
`f5 grep --cidr 10.0.0.0/8 …` selects every BIG-IP object that
mentions an IP literal or CIDR overlapping any requested network
in its full path, header, or body — including IP references buried
deep inside iRule script bodies.  Multiple networks may be passed
as a comma- or whitespace-separated list, IPv4 and IPv6 are both
supported, and `--cidr` is mutually exclusive with `--regex`.

This fills a gap left by the existing substring/regex modes, which
only match against an object's full path: an iRule that references
`10.0.0.5` or `class match … "10.0.0.0/8"` was previously
unreachable through the grep verb.

https://claude.ai/code/session_01RN1z6VvkGyM3659DBuGem9