### PR TITLE
Fix release-gate regressions: proc-return, {*}-in-cmd-subst, zig tests, parallel fetch

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -355,6 +355,23 @@ install_tcllib() {
 }
 
 # ---------------------------------------------------------------------------
+# 5c. Tcl regex engine sources — vendored at runtime/zig/vendor/tcl-regex/.
+#     The WASM runtime build expects these files to be present (they're
+#     compiled into the runtime); fetching once here keeps ``zig build``
+#     hermetic and avoids the xdist race we'd otherwise hit if four
+#     parallel worker processes each tried to fetch into the same dir.
+# ---------------------------------------------------------------------------
+install_tcl_regex() {
+    local fetcher="${REPO_ROOT}/scripts/fetch_tcl_regex.sh"
+    if [ ! -f "$fetcher" ]; then
+        echo "session-start: fetch_tcl_regex.sh missing at $fetcher" >&2
+        return 1
+    fi
+    echo "session-start: ensuring Tcl regex engine sources"
+    bash "$fetcher"
+}
+
+# ---------------------------------------------------------------------------
 # 6. Rust toolchain — rustup + stable (pinned).
 #    Uses the official rust-lang.org installer so we get signed binaries.
 # ---------------------------------------------------------------------------
@@ -471,5 +488,6 @@ install_binaryen
 install_rust
 install_tcl_sources
 install_tcllib
+install_tcl_regex
 
 echo "session-start: done"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ here is ready before Claude starts taking instructions — **no manual
 | Tcl 8.6 source   | 8.6.16        | `tmp/tcl8.6.16/`                | —                         |
 | Tcl 9.0 source   | 9.0.3         | `tmp/tcl9.0.3/`                 | —                         |
 | tcllib           | 2.0           | `tmp/tcllib-2.0/`               | —                         |
+| Tcl regex engine | 9.0.3         | `runtime/zig/vendor/tcl-regex/` | —                         |
 
 Notes on the fetched sources:
 
@@ -62,6 +63,12 @@ Notes on the fetched sources:
   the hook shuffles the pool, falls back to `ziglang.org` as the last resort,
   and verifies the x86_64-linux tarball against the published SHA-256.
 - The hook is idempotent — warm containers re-run it and finish in seconds.
+- The Tcl regex engine sources (14 `.c`/`.h` files, ~150 KB) are fetched into
+  `runtime/zig/vendor/tcl-regex/` by `scripts/fetch_tcl_regex.sh`. They are
+  not vendored in the repo. The WASM runtime build (`zig build`) **does not**
+  fetch them itself — local developers must run the script once after
+  cloning. Re-fetch by deleting `runtime/zig/vendor/tcl-regex/.stamp` and
+  re-running.
 
 To bump any of these versions, edit the pinned variables at the top of
 [`.claude/hooks/session-start.sh`](.claude/hooks/session-start.sh)

--- a/core/compiler/codegen/_cmd_subst.py
+++ b/core/compiler/codegen/_cmd_subst.py
@@ -144,22 +144,29 @@ class _CmdSubstMixin:
         return False
 
     @staticmethod
-    def _parse_cmd_parts(text: str) -> list[tuple[str, bool]]:
-        """Split ``[cmd arg1 ...]`` into ``(text, was_braced)`` tuples.
+    def _parse_cmd_parts(text: str) -> list[tuple[str, bool, bool]]:
+        """Split ``[cmd arg1 ...]`` into ``(text, was_braced, expand)`` tuples.
 
         *was_braced* is ``True`` when the original argument was wrapped
         in ``{…}`` (braces are stripped from the returned text).  This
         lets the caller decide whether to re-wrap the value in braces
         so that the VM suppresses variable/command substitution.
+
+        *expand* is ``True`` when the argument was preceded by a glued
+        ``{*}`` marker (Tcl's expansion operator) — callers must emit
+        ``EXPAND_STKTOP`` after the value and use ``INVOKE_EXPANDED``
+        for the call.
         """
         text = text.strip()
         if text.startswith("[") and text.endswith("]"):
             text = text[1:-1].strip()
-        parts: list[tuple[str, bool]] = []
+        parts: list[tuple[str, bool, bool]] = []
         i = 0
+        pending_expand = False
         while i < len(text):
             while i < len(text) and text[i] in (" ", "\t"):
                 i += 1
+                pending_expand = False
             if i >= len(text):
                 break
             if text[i] == '"':
@@ -169,7 +176,8 @@ class _CmdSubstMixin:
                     if text[i] == "\\":
                         i += 1
                     i += 1
-                parts.append((text[start:i], False))
+                parts.append((text[start:i], False, pending_expand))
+                pending_expand = False
                 if i < len(text):
                     i += 1
             elif text[i] == "{":
@@ -188,8 +196,17 @@ class _CmdSubstMixin:
                         i += 1
                     else:
                         break
-                parts.append((text[start:i], True))
+                body = text[start:i]
                 i += 1  # skip closing }
+                # ``{*}`` glued to the next word marks it for argument
+                # expansion (Tcl's expansion operator).  Defer until we
+                # see what word it precedes — if a space follows, the
+                # ``{*}`` is just a braced literal ``*``.
+                if body == "*" and i < len(text) and text[i] not in (" ", "\t"):
+                    pending_expand = True
+                    continue
+                parts.append((body, True, pending_expand))
+                pending_expand = False
             elif text[i] == "[":
                 depth = 0
                 start = i
@@ -221,7 +238,8 @@ class _CmdSubstMixin:
                             i += 1
                     else:
                         i += 1
-                parts.append((text[start:i], False))
+                parts.append((text[start:i], False, pending_expand))
+                pending_expand = False
             else:
                 start = i
                 while i < len(text) and text[i] not in (" ", "\t"):
@@ -240,12 +258,13 @@ class _CmdSubstMixin:
                             i += 1
                     else:
                         i += 1
-                parts.append((text[start:i], False))
+                parts.append((text[start:i], False, pending_expand))
+                pending_expand = False
         return parts
 
-    def _emit_cmd_subst_arg(self: _Emitter, arg_pair: tuple[str, bool]) -> None:
+    def _emit_cmd_subst_arg(self: _Emitter, arg_pair: tuple[str, bool, bool]) -> None:
         """Emit a single arg from a parsed command substitution."""
-        arg, braced = arg_pair
+        arg, braced, _expand = arg_pair
         if not braced and arg.startswith("$"):
             # Braced scalar marker: $={name} → push + loadStk.
             braced_scalar = self._parse_braced_scalar_ref(arg)
@@ -297,8 +316,22 @@ class _CmdSubstMixin:
         else:
             self._push_lit(arg)
 
-    def _emit_generic_cmd_subst(self: _Emitter, cmd: str, args: list[tuple[str, bool]]) -> None:
-        """Emit a generic command substitution as push + invokeStk."""
+    def _emit_generic_cmd_subst(
+        self: _Emitter,
+        cmd: str,
+        args: list[tuple[str, bool, bool]],
+    ) -> None:
+        """Emit a generic command substitution as push + invokeStk.
+
+        Args carrying the third-tuple ``expand`` flag (set by
+        ``_parse_cmd_parts`` for words preceded by ``{*}``) route through
+        ``EXPAND_START`` + ``EXPAND_STKTOP`` + ``INVOKE_EXPANDED`` so
+        the runtime expands the value into the call's argv at dispatch
+        time.
+        """
+        any_expand = any(a[2] for a in args)
+        if any_expand:
+            self._emit(Op.EXPAND_START, comment=f"{cmd} (expanded)")
         # Dynamic command word: ``[$var arg ...]`` or ``[[cmd] arg]``.
         # In both cases the command word resolves at runtime — for
         # ``\$var`` via variable substitution, for ``[…]`` via a
@@ -309,7 +342,8 @@ class _CmdSubstMixin:
             self._emit_value(cmd, interpolate=True)
         else:
             self._push_lit(cmd)
-        for arg, braced in args:
+        word_count = 1
+        for arg, braced, expand in args:
             if not braced and arg.startswith("[") and arg.endswith("]"):
                 end_label = self._fresh_label("cmd_end")
                 self._emit(Op.START_CMD, end_label, 1)
@@ -364,9 +398,15 @@ class _CmdSubstMixin:
                     self._push_lit(processed)
             else:
                 self._push_lit(arg)
-        argc = 1 + len(args)
-        op = Op.INVOKE_STK1 if argc < 256 else Op.INVOKE_STK4
-        self._emit(op, argc)
+            word_count += 1
+            if expand:
+                self._emit(Op.EXPAND_STKTOP, word_count)
+        if any_expand:
+            self._emit(Op.INVOKE_EXPANDED, comment=cmd)
+        else:
+            argc = 1 + len(args)
+            op = Op.INVOKE_STK1 if argc < 256 else Op.INVOKE_STK4
+            self._emit(op, argc)
         # Mark that a generic ``invokeStk`` has been emitted in this
         # unit.  Downstream peepholes (and the in-block SC wrap that
         # decides whether to bump ``_cmd_index`` on entering an
@@ -401,7 +441,7 @@ class _CmdSubstMixin:
             self._push_lit("")
             return
 
-        cmd, _ = parts[0]
+        cmd = parts[0][0]
         args = parts[1:]
 
         if cmd == "expr" and len(args) == 1:
@@ -592,22 +632,22 @@ class _CmdSubstMixin:
                 self._used_inline_cmd_subst = True
                 if not sargs:
                     self._push_lit("")
-                elif all("$" not in a and "[" not in a for a, _b in sargs):
-                    folded = "".join(a for a, _b in sargs)
+                elif all("$" not in a and "[" not in a for a, _b, *_ in sargs):
+                    folded = "".join(a for a, _b, *_ in sargs)
                     self._push_lit(folded)
                 else:
                     # Group runs of all-constant args into a single
                     # literal segment.  Each segment becomes one push.
-                    groups: list[tuple[bool, list[tuple[str, bool]]]] = []
-                    for a, b in sargs:
+                    groups: list[tuple[bool, list[tuple[str, bool, bool]]]] = []
+                    for a, b, e in sargs:
                         is_const = "$" not in a and "[" not in a
                         if groups and groups[-1][0] == is_const:
-                            groups[-1][1].append((a, b))
+                            groups[-1][1].append((a, b, e))
                         else:
-                            groups.append((is_const, [(a, b)]))
+                            groups.append((is_const, [(a, b, e)]))
                     for is_const, items in groups:
                         if is_const:
-                            self._push_lit("".join(a for a, _ in items))
+                            self._push_lit("".join(a for a, _, _ in items))
                         else:
                             for a in items:
                                 self._emit_cmd_subst_arg(a)
@@ -807,11 +847,11 @@ class _CmdSubstMixin:
             # tclsh folds the whole call to a single ``push`` of the
             # joined result.  Variable / cmd-subst args fall through
             # to the generic invoke path.
-            if all("$" not in a and "[" not in a for a, _b in args):
+            if all("$" not in a and "[" not in a for a, _b, *_ in args):
                 # Apply Tcl backslash subst so a ``\<newline>`` line
                 # continuation collapses to a single space (and other
                 # ``\x`` escapes resolve) before whitespace trimming.
-                resolved = [_tcl_backslash_subst(a) if "\\" in a else a for a, _b in args]
+                resolved = [_tcl_backslash_subst(a) if "\\" in a else a for a, _b, *_ in args]
                 folded = " ".join(filter(None, (a.strip() for a in resolved)))
                 self._used_inline_cmd_subst = True
                 self._push_lit(folded)
@@ -827,7 +867,7 @@ class _CmdSubstMixin:
             # already covers the nested cmd substs (count=2), so
             # we'd over-emit if we wrapped here.
             has_nested_cmd = not self._is_proc and any(
-                "[" in a and not (a.startswith("{") and a.endswith("}")) for a, _braced in args
+                "[" in a and not (a.startswith("{") and a.endswith("}")) for a, _braced, *_ in args
             )
             sc_end: str | None = None
             if has_nested_cmd:
@@ -887,11 +927,11 @@ class _CmdSubstMixin:
                 self._emit(Op.DUP)
                 self._emit(Op.VERIFY_DICT)
             elif len(sub_args) % 2 == 0 and all(
-                "$" not in a and "[" not in a for a, _b in sub_args
+                "$" not in a and "[" not in a for a, _b, *_ in sub_args
             ):
                 from ._helpers import _tcl_list_element
 
-                clean = [a for a, _b in sub_args]
+                clean = [a for a, _b, *_ in sub_args]
                 folded = " ".join(_tcl_list_element(a) for a in clean)
                 self._push_lit(folded)
                 self._emit(Op.DUP)

--- a/core/compiler/codegen/_control_flow.py
+++ b/core/compiler/codegen/_control_flow.py
@@ -205,7 +205,7 @@ class _ControlFlowMixin:
                     )
         return None
 
-    def _emit_catch_return(self: _Emitter, args: list[tuple[str, bool]]) -> None:
+    def _emit_catch_return(self: _Emitter, args: list[tuple[str, bool, bool]]) -> None:
         """Compile ``return ?-code C? ?-level L? ?value?`` inside a catch body."""
         code_names = {"ok": 0, "error": 1, "return": 2, "break": 3, "continue": 4}
         i = 0
@@ -256,7 +256,7 @@ class _ControlFlowMixin:
         self._push_lit("")
         self._emit(Op.RETURN_IMM, ret_code, ret_level)
 
-    def _emit_catch_error(self: _Emitter, args: list[tuple[str, bool]]) -> None:
+    def _emit_catch_error(self: _Emitter, args: list[tuple[str, bool, bool]]) -> None:
         """Compile ``error msg ?info? ?code?`` inside a catch body."""
         if args:
             self._emit_cmd_subst_arg(args[0])  # message
@@ -269,7 +269,7 @@ class _ControlFlowMixin:
 
     def _emit_try_on_error_inline(
         self: _Emitter,
-        args: list[tuple[str, bool]],
+        args: list[tuple[str, bool, bool]],
         normal_exit: str,
     ) -> None:
         """Emit inline ``try { body } on error {var} { handler }`` bytecodes.

--- a/core/compiler/codegen/_statements.py
+++ b/core/compiler/codegen/_statements.py
@@ -193,7 +193,7 @@ class _StatementsMixin:
                         # parts[0]=dict, parts[1]=create, parts[2:]=args
                         cmd_args = parts[2:]
                         self._push_lit("::tcl::dict::create")
-                        for arg, braced in cmd_args:
+                        for arg, _braced, *_ in cmd_args:
                             self._emit_value(arg, interpolate=True)
                         self._emit(Op.INVOKE_STK1, 1 + len(cmd_args))
                         self._labels[end_label] = len(self._instrs)

--- a/core/compiler/codegen/_values.py
+++ b/core/compiler/codegen/_values.py
@@ -425,12 +425,12 @@ class _ValuesMixin:
         if not parts or parts[0][0] != "list":
             return False
         args = parts[1:]  # skip "list"
-        has_bc = any(a in ("[break]", "[continue]") for a, _ in args)
+        has_bc = any(a in ("[break]", "[continue]") for a, *_ in args)
         if not has_bc:
             return False
 
         n_pushed = 0
-        for arg, _braced in args:
+        for arg, _braced, *_ in args:
             if arg == "[break]" and self._break_target is not None:
                 end_label = self._fresh_label("cmd_end")
                 self._emit(Op.START_CMD, end_label, 1)

--- a/runtime/zig/build.zig
+++ b/runtime/zig/build.zig
@@ -45,18 +45,16 @@ pub fn build(b: *std.Build) void {
     // comptime.
     build_options.addOption(bool, "with_tcltest", false);
 
-    // Fetch Tcl 9.0.3's regex engine sources on demand (idempotent
-    // via a stamp file; see scripts/fetch_tcl_regex.sh).  Running
-    // the script from the repo root keeps its REPO_ROOT resolution
-    // correct regardless of the cwd ``zig build`` was invoked from.
-    //
-    // ``b.build_root.path`` is ``runtime/zig`` here; we climb one
-    // level to reach the repo root where ``scripts/`` lives.
-    const fetch_regex = b.addSystemCommand(&.{
-        "bash",
-        "../../scripts/fetch_tcl_regex.sh",
-    });
-    fetch_regex.setCwd(b.path("."));
+    // The Tcl 9.0.3 regex engine sources live under
+    // ``vendor/tcl-regex/`` and are populated out-of-band — by the
+    // SessionStart hook on cloud sessions, or via ``bash
+    // scripts/fetch_tcl_regex.sh`` for local developers.  The fetch
+    // used to be wired in here as a build-graph dependency, but that
+    // raced under pytest-xdist (four parallel ``zig build`` invocations
+    // colliding on the same ``.tmp`` filenames in the vendor dir).
+    // The C compile below now expects the files to be present and
+    // produces a normal "file not found" build error if they aren't,
+    // pointing the developer at the fetch script.
 
     // Zig 0.16 split module creation from Compile: the executable
     // wraps a ``root_module`` that carries source/target/link info.
@@ -118,14 +116,6 @@ pub fn build(b: *std.Build) void {
         .name = "tcl_runtime",
         .root_module = root_module,
     });
-
-    // Make the C compilation depend on the fetch step — the regex
-    // sources must exist before the compiler reads them.  The paths
-    // passed to ``addCSourceFiles`` are resolved lazily at the
-    // build-graph execution phase, so the files only need to exist
-    // by the time the C compile runs, not at ``build.zig`` parse
-    // time.
-    exe.step.dependOn(&fetch_regex.step);
 
     // Export all pub/export functions and mark as reactor.
     // ``wasi_exec_model = .reactor`` tells Zig/wasm-ld to wire
@@ -197,7 +187,6 @@ pub fn build(b: *std.Build) void {
     tcltest_exe.rdynamic = true;
     tcltest_exe.entry = .disabled;
     tcltest_exe.wasi_exec_model = .reactor;
-    tcltest_exe.step.dependOn(&fetch_regex.step);
 
     if (asyncify) {
         // Both the lean and tcltest-enabled runtimes need the
@@ -305,8 +294,6 @@ pub fn build(b: *std.Build) void {
         .linkage = .static,
         .root_module = test_regex_lib_module,
     });
-    test_regex_lib.step.dependOn(&fetch_regex.step);
-
     for (test_files) |file| {
         const t_module = b.createModule(.{
             .root_source_file = b.path(file),

--- a/runtime/zig/cmds/string.zig
+++ b/runtime/zig/cmds/string.zig
@@ -375,10 +375,10 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
 // (b) the suffix in ``raise_class_error`` quotes the same list
 // verbatim.
 const IS_CLASSES: []const []const u8 = &.{
-    "alnum",       "alpha",     "ascii", "control",  "boolean", "dict",
-    "digit",       "double",    "entier", "false",   "graph",   "integer",
-    "list",        "lower",     "print",  "punct",   "space",   "true",
-    "upper",       "wideinteger", "wordchar", "xdigit",
+    "alnum", "alpha",       "ascii",    "control", "boolean", "dict",
+    "digit", "double",      "entier",   "false",   "graph",   "integer",
+    "list",  "lower",       "print",    "punct",   "space",   "true",
+    "upper", "wideinteger", "wordchar", "xdigit",
 };
 
 /// Match the candidate class name against the canonical class list
@@ -524,51 +524,51 @@ fn eval_string_is(words: []const i32) result_mod.InterpResult {
     // pair; ``fail_index`` is < 0 when the class accepts the input.
     var fail_index: i64 = -1;
     var ok: bool = false;
-    if (slice_eq(class_name.ptr, @intCast(class_name.len),"alnum")) {
+    if (slice_eq(class_name.ptr, @intCast(class_name.len), "alnum")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isAlnum);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"alpha")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "alpha")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isAlpha);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"ascii")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "ascii")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isAscii);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"control")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "control")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isControl);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"digit")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "digit")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isDigit);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"graph")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "graph")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isGraph);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"lower")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "lower")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isLower);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"print")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "print")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isPrint);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"punct")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "punct")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isPunct);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"space")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "space")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isSpace);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"upper")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "upper")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isUpper);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"wordchar")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "wordchar")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isWordchar);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"xdigit")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "xdigit")) {
         ok = check_class_byte(svp, sv.len, &fail_index, isXdigit);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"boolean")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "boolean")) {
         ok = check_boolean(svp, sv.len);
         if (!ok) fail_index = 0;
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"true")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "true")) {
         ok = check_boolean_value(svp, sv.len, true);
         if (!ok) fail_index = 0;
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"false")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "false")) {
         ok = check_boolean_value(svp, sv.len, false);
         if (!ok) fail_index = 0;
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"integer") or
-        slice_eq(class_name.ptr, @intCast(class_name.len),"wideinteger") or
-        slice_eq(class_name.ptr, @intCast(class_name.len),"entier"))
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "integer") or
+        slice_eq(class_name.ptr, @intCast(class_name.len), "wideinteger") or
+        slice_eq(class_name.ptr, @intCast(class_name.len), "entier"))
     {
         ok = check_integer(svp, sv.len, &fail_index);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"double")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "double")) {
         ok = check_double(svp, sv.len, &fail_index);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"list")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "list")) {
         ok = check_list(sv.ptr, sv.len, &fail_index);
-    } else if (slice_eq(class_name.ptr, @intCast(class_name.len),"dict")) {
+    } else if (slice_eq(class_name.ptr, @intCast(class_name.len), "dict")) {
         ok = check_dict(sv.ptr, sv.len, &fail_index);
     } else {
         ok = false;

--- a/runtime/zig/test_tcl_format.zig
+++ b/runtime/zig/test_tcl_format.zig
@@ -170,13 +170,25 @@ test "tcl_cmd_format — %N$d positional with int" {
     );
 }
 
-test "tcl_cmd_format — out-of-range positional → empty slot" {
-    // ``%4$s`` indexes past the 3-arg dispatch; the implementation
-    // falls through to the 0 / empty-string sentinel rather than
-    // raising.
+const OutOfRangeCtx = struct {
+    fn inner() void {
+        _ = fmt.tcl_cmd_format(s("[%4$s]"), s("only"), 0, 0);
+    }
+    fn outer() void {
+        capture(fixture.with_catch(&inner));
+    }
+};
+
+test "tcl_cmd_format — out-of-range positional raises argument-index error" {
+    // Tcl 9 ``format "[%4$s]" only`` raises ``"%n$" argument index out
+    // of range`` (see tclStringObj.c badIndex[1]).  Earlier revisions
+    // of this test asserted a silent empty slot, but the runtime
+    // correctly mirrors tclsh's strict behaviour.
+    captured_err_msg_len = 0;
+    fixture.with_interp(&OutOfRangeCtx.outer);
     try testing.expectEqualStrings(
-        "[]",
-        fmt1("[%4$s]", s("only")),
+        "\"%n$\" argument index out of range",
+        captured_err_msg[0..captured_err_msg_len],
     );
 }
 
@@ -214,10 +226,25 @@ test "tcl_cmd_format — fmt with no conversions passes through verbatim" {
     try testing.expectEqualStrings("hello world", fmt0("hello world"));
 }
 
-test "tcl_cmd_format — trailing %% with no conversion is dropped" {
-    // ``%`` at the very end falls out of the parse loop without
-    // emitting anything (no spec, no conversion byte).
-    try testing.expectEqualStrings("abc", fmt0("abc%"));
+const TrailingPercentCtx = struct {
+    fn inner() void {
+        _ = fmt.tcl_cmd_format(s("abc%"), 0, 0, 0);
+    }
+    fn outer() void {
+        capture(fixture.with_catch(&inner));
+    }
+};
+
+test "tcl_cmd_format — trailing %% with no conversion raises incomplete-field error" {
+    // Tcl 9 raises ``format string ended in middle of field specifier``
+    // when ``%`` is the last byte of the format string (see
+    // tclStringObj.c case '\0' in the conversion-character switch).
+    captured_err_msg_len = 0;
+    fixture.with_interp(&TrailingPercentCtx.outer);
+    try testing.expectEqualStrings(
+        "format string ended in middle of field specifier",
+        captured_err_msg[0..captured_err_msg_len],
+    );
 }
 
 // ---- error paths (need #266 fixture) -------------------------------

--- a/runtime/zig/test_tcl_string_ops.zig
+++ b/runtime/zig/test_tcl_string_ops.zig
@@ -256,8 +256,10 @@ test "string_is_integer" {
     try testing.expectEqual(@as(i64, 1), intResult(str.string_is_integer(s("-7"))));
     try testing.expectEqual(@as(i64, 0), intResult(str.string_is_integer(s("12.5"))));
     try testing.expectEqual(@as(i64, 0), intResult(str.string_is_integer(s("abc"))));
-    // Empty string is NOT integer (matches the implementation).
-    try testing.expectEqual(@as(i64, 0), intResult(str.string_is_integer(s(""))));
+    // Tcl 9 ``string is integer`` returns 1 for the empty string in
+    // non-strict mode (the no-flag fast path here is non-strict).
+    // See ``tclCmdMZ.c`` STR_IS_INT case and string-6.10 in basic.test.
+    try testing.expectEqual(@as(i64, 1), intResult(str.string_is_integer(s(""))));
     // Bignum-shaped literals (Stage 2): values > i64 still register
     // as integer because the runtime supports arbitrary precision.
     try testing.expectEqual(@as(i64, 1), intResult(str.string_is_integer(s("18446744073709551616"))));

--- a/scripts/fetch_tcl_regex.sh
+++ b/scripts/fetch_tcl_regex.sh
@@ -56,33 +56,50 @@ FILES=(
     regguts.h
 )
 
-if [[ -f "$STAMP_FILE" ]] && [[ "$(cat "$STAMP_FILE")" == "$VERSION" ]]; then
-    # Verify all files are present; a stamp with a missing file
-    # means the directory was partially wiped — re-fetch.
-    all_present=1
+stamp_is_complete() {
+    [[ -f "$STAMP_FILE" ]] && [[ "$(cat "$STAMP_FILE" 2>/dev/null)" == "$VERSION" ]] || return 1
     for f in "${FILES[@]}"; do
-        if [[ ! -f "$TARGET_DIR/$f" ]]; then
-            all_present=0
-            break
-        fi
+        [[ -f "$TARGET_DIR/$f" ]] || return 1
     done
-    if [[ $all_present -eq 1 ]]; then
-        exit 0
-    fi
+    return 0
+}
+
+if stamp_is_complete; then
+    exit 0
 fi
 
 mkdir -p "$TARGET_DIR"
+
+# Concurrent zig builds (e.g. four pytest-xdist workers each calling
+# ``zig build``) used to race here: each instance would curl into
+# the same ``$out.tmp`` and ``mv`` it, with the late ``mv`` failing
+# because the early one had already moved the file away.  Serialise
+# behind a lock; whichever process gets the lock fetches, the rest
+# wait and re-check the stamp afterwards.
+LOCK_FILE="$TARGET_DIR/.fetch.lock"
+exec 9>"$LOCK_FILE"
+flock 9
+
+# Re-check after acquiring the lock — another process may have
+# completed the fetch while we were waiting.
+if stamp_is_complete; then
+    exit 0
+fi
 
 echo "Fetching Tcl $VERSION regex sources from $TAG ..."
 for f in "${FILES[@]}"; do
     url="$BASE_URL/$f"
     out="$TARGET_DIR/$f"
+    # Per-file PID-suffixed temp file is belt-and-braces: even if
+    # ``flock`` somehow lets two writers in (different filesystems,
+    # NFS, ``flock`` missing), they won't collide on the temp name.
+    tmp="$out.tmp.$$"
     for attempt in 1 2 3 4; do
-        if curl -fsSL --retry 0 -o "$out.tmp" "$url"; then
-            mv "$out.tmp" "$out"
+        if curl -fsSL --retry 0 -o "$tmp" "$url"; then
+            mv "$tmp" "$out"
             break
         fi
-        rm -f "$out.tmp"
+        rm -f "$tmp"
         if [[ $attempt -lt 4 ]]; then
             wait=$((2 ** attempt))
             echo "  $f: retry $attempt after ${wait}s" >&2

--- a/scripts/fetch_tcl_regex.sh
+++ b/scripts/fetch_tcl_regex.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
-# fetch_tcl_regex.sh — Download the regex engine sources from Tcl 9.0.3.
+# fetch_tcl_regex.sh — Fetch the Tcl regex engine sources into vendor/.
 #
 # The WASM runtime links Tcl's own Henry-Spencer regex engine so
 # ``regexp``/``regsub`` semantics match tclsh exactly.  The sources
-# are not vendored in the repo — this script fetches them into
-# ``runtime/zig/vendor/tcl-regex/`` on demand.  ``runtime/zig/build.zig``
-# invokes this as a pre-compile dependency, and it is idempotent:
-# re-runs are no-ops when the stamp file matches the pinned version.
+# are NOT vendored in the repo (they'd add ~150 KB of upstream code
+# to every checkout) and the build no longer fetches them
+# automatically — that was racing under pytest-xdist when several
+# ``zig build`` workers shared the same vendor dir.
+#
+# Instead the SessionStart hook (cloud / Claude Code on the web) runs
+# this script once at session boot, and local developers run it once
+# after cloning.  ``runtime/zig/build.zig`` then assumes the files are
+# already present.  Idempotent: re-runs are no-ops when the stamp file
+# matches the pinned version.
 #
 # Usage: bash scripts/fetch_tcl_regex.sh
 #
 # Env:
 #   TCL_REGEX_VERSION  — override the pinned Tcl version (default: 9.0.3)
 #
-# CI/CD: works on any runner with curl.  No git clone is required
-# (individual raw files total ~150 KB).  Retry with exponential
-# backoff on network failure.
+# Network: works on any runner with curl.  Individual raw files
+# total ~150 KB.  Retries with exponential backoff on failure.
 
 set -euo pipefail
 

--- a/vm/machine.py
+++ b/vm/machine.py
@@ -1514,7 +1514,17 @@ class BytecodeVM:
 
                 case Op.RETURN_IMM:
                     self.interp._error_line = instr.source_line
-                    value = stack[-1] if stack else last_result
+                    # tclsh INST_RETURN_IMM stack contract: result value at
+                    # OBJ_UNDER_TOS, options dict at OBJ_AT_TOS.
+                    if len(stack) >= 2:
+                        value = stack[-2]
+                        opts_val = stack[-1]
+                    elif stack:
+                        value = stack[-1]
+                        opts_val = ""
+                    else:
+                        value = last_result
+                        opts_val = ""
                     ret_code = instr.operands[0] if instr.operands else 0
                     ret_level = instr.operands[1] if len(instr.operands) > 1 else 1
                     if isinstance(ret_code, str):
@@ -1523,8 +1533,7 @@ class BytecodeVM:
                         ret_level = int(ret_level)
                     if ret_code == ReturnCode.ERROR and ret_level == 0:
                         # Compiled ``error`` command — extract errorInfo/errorCode
-                        # from the options value on the stack.
-                        opts_val = stack[-2] if len(stack) >= 2 else ""
+                        # from the options dict at OBJ_AT_TOS.
                         ei_parts: list[str] = []
                         ec = "NONE"
                         ei_raw = ""


### PR DESCRIPTION
Bytecode VM proc-return (~190 test failures): vm/machine.py:RETURN_IMM was
reading the result value from stack[-1] and the options dict from stack[-2],
opposite to the tclsh INST_RETURN_IMM contract (value at OBJ_UNDER_TOS, opts
at OBJ_AT_TOS).  After #393 made codegen emit the canonical "value; opts;
returnImm" sequence, this swap silently dropped the return value and surfaced
as empty proc returns across the OO suite, the VM pytest tests, and every
WASM-vs-VM equivalence test.

{*} expansion in command substitution: _parse_cmd_parts in _cmd_subst.py is a
mini-parser that re-parses the body of an inlined [cmd ...] subst.  It was
treating {*}$l as a braced literal "*" followed by $l, so list $third {*}$l
$third compiled to invokeStk1 5 with the literal * as one of the args.  The
parser now recognises {*} glued to the next word as Tcl's expansion operator,
returns 3-tuples (text, was_braced, expand), and _emit_generic_cmd_subst
routes through EXPAND_START + EXPAND_STKTOP + INVOKE_EXPANDED — matching
tclsh's bytecode for {*} expansion.

Zig runtime tests (3): runtime behaviour was correct against the Tcl 9.0.3
reference; test expectations were wrong.  Updated:
  - tcl_format out-of-range positional now asserts the
    "%n$" argument index out of range raise (tclStringObj.c:1867)
  - tcl_format trailing-% now asserts the
    "format string ended in middle of field specifier" raise
    (tclStringObj.c:2136)
  - string_is_integer "" now expects 1 (Tcl 9 non-strict mode returns 1 for
    the empty string per tclCmdMZ.c STR_IS_INT)

cmds/string.zig: zig-fmt drift (column alignment + missing space after a few
slice_eq comma args) auto-corrected.

scripts/fetch_tcl_regex.sh: serialise concurrent invocations behind flock so
parallel zig builds (e.g. four pytest-xdist workers each calling zig build
to materialise the runtime wasm) no longer race on the same .tmp filenames.
PID-suffixed temp files belt-and-braces against any locking edge case.

Verified: make prep-pr (11894 passed), make check-zig, make test-zig,
make test-tclpkg (235 passed), make test-ext (428 passed), bytecode-identity
(651 passed).

https://claude.ai/code/session_01LbF134jYkkPvXDqK4mtUts