### PR TITLE
Add LTM policy parser and evaluator for explain-flow

### DIFF
--- a/.claude/skills/explain-flow/SKILL.md
+++ b/.claude/skills/explain-flow/SKILL.md
@@ -165,13 +165,22 @@ The fields are designed so you can build the narrative directly:
    that matched (with the actual captured value beside the expected
    one), and the action(s) it produced.  Only **fired** rules are
    listed in the compact shape; an empty `fired` array means the
-   policy was evaluated but nothing matched (or only an unconditional
-   default exists and didn't run because of strategy).  Limited to
-   the medium-scope operand set (host / uri / method / header / SNI /
-   tcp address) and action set (forward / redirect / replace /
-   header insert+remove / reset).  For the full per-rule trace
-   including non-matched conditions, fall back to the verbose
-   `report_to_dict`.
+   policy was evaluated but no rule matched (every rule had at least
+   one condition that didn't match, or the policy had no rules at
+   all).  Note that a rule with zero conditions is treated as
+   unconditional and will always match — so if a "default" rule is
+   defined, it will be in `fired` for `first-match`/`all-match`
+   strategies whenever no earlier rule won.  Compact entries only
+   include the conditions that actually matched (`matched_on`); for
+   the full per-condition trace including non-matched and
+   unevaluable conditions, fall back to the verbose
+   `report_to_dict`.  Limited to the medium-scope operand set
+   (host / uri / method / header / SNI / tcp address) and action set
+   (forward / redirect / replace / header insert+remove / reset).
+   When a policy uses `best-match`, the reported `strategy` is
+   `best-match-approx` because we approximate F5's true best-match
+   as "rule with the most conditions wins" — operand-specificity
+   weighting isn't reproduced.
 6. **`flow.pool_member` + `flow.snat`** — observed values.  If
    `simulated.pool` differs from `flow.pool_member`, mention it
    ("the iRule would route to X, but the captured back-side went to

--- a/.claude/skills/explain-flow/SKILL.md
+++ b/.claude/skills/explain-flow/SKILL.md
@@ -106,6 +106,22 @@ Each session is the high-signal subset — empty fields are omitted:
   "captured_response": { "status": "200" },
   "profiles": ["tcp (lab_tcp)", "client_ssl (lab_clientssl_valid)", "http (lab_http)"],
   "ltm_policies": ["/partition/lab_policy_rewrite"],
+  "policy_decisions": [
+    { "policy": "/partition/lab_policy_rewrite", "strategy": "first-match",
+      "fired": [
+        { "rule": "api_route", "ordinal": 1,
+          "matched_on": [
+            { "field": "http-host.host", "operator": "equals",
+              "expected": ["api.example.com"], "actual": "api.example.com" },
+            { "field": "http-uri.path", "operator": "starts-with",
+              "expected": ["/v1/"], "actual": "/v1/health" }
+          ],
+          "actions": [
+            { "target": "forward", "verb": "select",
+              "value": "/partition/lab_pool_api" }
+          ] }
+      ] }
+  ],
   "events_fired": ["RULE_INIT", "CLIENT_ACCEPTED", "CLIENTSSL_CLIENTHELLO",
                     "HTTP_REQUEST", "LB_SELECTED", "SERVER_CONNECTED"],
   "irule_decisions": [
@@ -144,6 +160,18 @@ The fields are designed so you can build the narrative directly:
 5. **`irule_bodies`** — only consult these when you need to quote
    Tcl.  They're already truncated; don't ask for
    `max_event_body_lines>20` unless absolutely needed.
+5a. **`policy_decisions`** — answers "which LTM policy rule fired and
+   what did it do?".  Each entry shows the rule name, the conditions
+   that matched (with the actual captured value beside the expected
+   one), and the action(s) it produced.  Only **fired** rules are
+   listed in the compact shape; an empty `fired` array means the
+   policy was evaluated but nothing matched (or only an unconditional
+   default exists and didn't run because of strategy).  Limited to
+   the medium-scope operand set (host / uri / method / header / SNI /
+   tcp address) and action set (forward / redirect / replace /
+   header insert+remove / reset).  For the full per-rule trace
+   including non-matched conditions, fall back to the verbose
+   `report_to_dict`.
 6. **`flow.pool_member` + `flow.snat`** — observed values.  If
    `simulated.pool` differs from `flow.pool_member`, mention it
    ("the iRule would route to X, but the captured back-side went to
@@ -184,11 +212,20 @@ The fields are designed so you can build the narrative directly:
 - Path-through-iRule analysis is *static* unless `simulate=true`: the
   skill surfaces the relevant `when` block bodies; it does not follow
   `if`/`switch` branches based on payload bytes by itself.
-- LTM policy bodies / GTM probe results / APM session state aren't
-  retained in the parsed config (only headers).
-  `gtm_wide_ips_in_config` is therefore a *global* inventory at the
-  report level, not a per-session list — annotate accordingly when
-  citing it.
+- GTM probe results / APM session state aren't retained in the parsed
+  config (only headers).  `gtm_wide_ips_in_config` is therefore a
+  *global* inventory at the report level, not a per-session list —
+  annotate accordingly when citing it.
+- LTM policy evaluation covers a medium operand surface only:
+  `http-host`, `http-uri` (host/path/query), `http-method`,
+  `http-header` (with named target), `ssl-extension server-name`
+  (SNI), and `tcp address`.  Actions covered: `forward select`,
+  `http-reply redirect`, `http-uri replace`, `http-header
+  insert/remove`, `tcp reset`.  Operands outside this set (cookie,
+  geoip, ssl-cert, rate-limit) parse but evaluate as no-match with a
+  `note` explaining why.  `best-match` strategy is approximated as
+  "rule with the most conditions wins" — F5's true algorithm weights
+  operand specificity which we don't reproduce.
 
 ## When to use the verbose `report_to_dict` shape instead
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,43 @@ Commit any formatting changes that `make test-slow` applies before creating
 the PR (it runs `prep-pr` which auto-formats — re-running test-slow after
 any commits is required so the stamp matches the final tree).
 
+### When a PR is created, run test-slow locally
+
+When a PR is opened on this repository — whether by the agent, by the user,
+or by the Claude Code UI on the agent's behalf — the agent MUST kick off
+`make test-slow` **on its local machine** against the exact tip the PR is
+built from, without being asked.  This applies to PRs the agent didn't
+open: if the agent learns of a new PR (e.g. via `<github-webhook-activity>`
+subscription, a comment, or the user mentioning it), it must immediately
+verify the stamp and re-run test-slow locally if the worktree drifted, then
+act on whatever fails.
+
+**Do NOT add `test-slow` (or any subset of it beyond the existing
+`ci-fast`) to `.github/workflows/`.**  CI on this repo intentionally runs
+only the fast LSP-e2e subset; the rest of the gate is the agent's local
+responsibility.  Don't wire `test-slow` into a GitHub Action, don't trigger
+it via `workflow_dispatch`, and don't ask the user to enable it on the
+runner — run it on the local machine you're already working in.
+
+### Capturing build / test logs
+
+Long gates (`make test-slow`, `make test-py`, `make test-vm`, anything
+running for more than a few seconds) MUST have their full output captured
+to a file under `/tmp/` rather than only being read via `tail`.  Tailing
+loses signal: a failure in the middle of a 10-minute run won't appear in
+the last 50 lines if the harness keeps going, and pytest summary lines can
+get pushed off the bottom by skip-message spam.  The pattern:
+
+```
+make test-slow 2>&1 | tee /tmp/test-slow-<branch>.log
+# then, when investigating a failure:
+grep -nE 'FAIL|ERROR|Traceback|^E ' /tmp/test-slow-<branch>.log
+```
+
+For background runs use `tee` to a `/tmp/` path, then `grep` the file when
+you want a specific signal.  Keep the file around until the PR merges so
+you can re-investigate after a CI ping without having to re-run the gate.
+
 ## Knowledge base and documentation
 
 The project has two kinds of written content with different purposes, tones,

--- a/core/bigip/explain_flow.py
+++ b/core/bigip/explain_flow.py
@@ -57,6 +57,11 @@ from .pcap_remap import (
     _find_ip_offset,
     _ipv6_l4_locator,
 )
+from .policy_eval import (
+    PolicyDecision,
+    evaluate_policy,
+    request_state_from_session,
+)
 
 
 @dataclass(slots=True)
@@ -308,6 +313,10 @@ class SessionExplain:
     # Per event-block: (rule_path, event, [(line, command, captured_value), ...]).
     event_annotations: tuple[tuple[str, str, tuple[tuple[str, str, str], ...]], ...] = ()
     ltm_policies: tuple[str, ...] = ()
+    # Per-policy evaluation against the captured request state.  Empty
+    # when there are no policies attached, when the policy body wasn't
+    # parsed, or when the captured state was insufficient to evaluate.
+    policy_decisions: tuple[PolicyDecision, ...] = ()
     apm_profile: str = ""
     gtm_wide_ips: tuple[str, ...] = ()
     explain_text: str = ""
@@ -1634,6 +1643,31 @@ def _ltm_policies_for(cfg: BigipConfig, vs: BigipVirtualServer) -> list[str]:
     return out
 
 
+def _evaluate_attached_policies(
+    cfg: BigipConfig, attached_paths: list[str], session: Session
+) -> list[PolicyDecision]:
+    """Evaluate every parsed LTM policy attached to the matched VS.
+
+    Skips policies whose body wasn't parsed (e.g. attached by short
+    name we couldn't resolve, or a policy stanza absent from the
+    config slice we were handed).  The same evaluator runs under
+    static analysis and ``simulate=true`` — LTM policies are
+    declarative, so the captured state fully determines the outcome.
+    """
+    if not attached_paths:
+        return []
+    state = request_state_from_session(session)
+    out: list[PolicyDecision] = []
+    for path in attached_paths:
+        if path.endswith("(unresolved)"):
+            continue
+        policy = cfg.policies.get(path)
+        if policy is None:
+            continue
+        out.append(evaluate_policy(policy, state))
+    return out
+
+
 def _gtm_wide_ips_in_config(cfg: BigipConfig) -> list[str]:
     """Return every GTM wide-IP identifier in *cfg* (a global inventory).
 
@@ -2002,6 +2036,7 @@ def compute_explain_flow(
 
         vs_report = compute_explain(cfg_hit, vs.full_path, kind="virtual")
         ltm_policies = _ltm_policies_for(cfg_hit, vs)
+        policy_decisions = _evaluate_attached_policies(cfg_hit, ltm_policies, session)
         apm = _apm_profile_for(cfg_hit, vs)
         gtm = _gtm_wide_ips_in_config(cfg_hit)
 
@@ -2041,6 +2076,7 @@ def compute_explain_flow(
                 event_blocks=tuple(event_blocks),
                 event_annotations=tuple(event_annotations),
                 ltm_policies=tuple(ltm_policies),
+                policy_decisions=tuple(policy_decisions),
                 apm_profile=apm,
                 gtm_wide_ips=tuple(gtm),
                 explain_text=vs_report.text_report,
@@ -2172,6 +2208,32 @@ def _format_report(
             lines.append("  ltm policies:")
             for p in se.ltm_policies:
                 lines.append(f"    - {p}")
+        if se.policy_decisions:
+            lines.append("  ltm policy decisions:")
+            for pd in se.policy_decisions:
+                lines.append(f"    --- {pd.policy} (strategy: {pd.strategy}) ---")
+                for rd in pd.rules:
+                    state = "FIRED" if rd.fired else ("matched" if rd.matched else "no-match")
+                    lines.append(f"      rule {rd.rule!r} (ord {rd.ordinal}): {state}")
+                    for ct in rd.conditions:
+                        target = ct.operand
+                        if ct.name:
+                            target += f"[{ct.name}]"
+                        elif ct.selector:
+                            target += f".{ct.selector}"
+                        prefix = "      " + ("- " if ct.matched else "  ")
+                        if ct.note:
+                            lines.append(
+                                f"{prefix}{target} {ct.operator} {list(ct.expected)}"
+                                f" (skipped: {ct.note})"
+                            )
+                        else:
+                            lines.append(
+                                f"{prefix}{target} {ct.operator} {list(ct.expected)}"
+                                f" -> actual={ct.actual!r} match={ct.matched}"
+                            )
+                    for at in rd.actions:
+                        lines.append(f"        action: {at.target} {at.verb} {at.value}".rstrip())
         if se.apm_profile:
             lines.append(f"  apm: {se.apm_profile}")
         if se.gtm_wide_ips:
@@ -2297,6 +2359,7 @@ def report_to_dict(report: ExplainFlowReport) -> dict:
                     for r, e, anns in se.event_annotations
                 ],
                 "ltm_policies": list(se.ltm_policies),
+                "policy_decisions": [_policy_decision_to_dict(pd) for pd in se.policy_decisions],
                 "apm_profile": se.apm_profile,
                 "gtm_wide_ips": list(se.gtm_wide_ips),
                 "explain_text": se.explain_text,
@@ -2313,6 +2376,90 @@ def report_to_dict(report: ExplainFlowReport) -> dict:
             for se in report.sessions
         ],
     }
+
+
+def _policy_decision_to_dict(pd: PolicyDecision) -> dict:
+    """Verbose dict shape for ``report_to_dict`` — every condition / action."""
+    return {
+        "policy": pd.policy,
+        "strategy": pd.strategy,
+        "rules": [
+            {
+                "rule": rd.rule,
+                "ordinal": rd.ordinal,
+                "matched": rd.matched,
+                "fired": rd.fired,
+                "conditions": [
+                    {
+                        "operand": ct.operand,
+                        "selector": ct.selector,
+                        "operator": ct.operator,
+                        "expected": list(ct.expected),
+                        "actual": ct.actual,
+                        "matched": ct.matched,
+                        "name": ct.name,
+                        "negate": ct.negate,
+                        "event": ct.event,
+                        "note": ct.note,
+                    }
+                    for ct in rd.conditions
+                ],
+                "actions": [
+                    {"target": at.target, "verb": at.verb, "value": at.value}
+                    for at in rd.actions
+                ],
+            }
+            for rd in pd.rules
+        ],
+    }
+
+
+def _compact_policy_decision(pd: PolicyDecision) -> dict:
+    """Compact MCP shape — only fired rules with their action summaries.
+
+    The full per-rule trace is reachable via the verbose ``report_to_dict``
+    when needed; for LLM context we surface only the rule that won and
+    the action it produced — that's the answer to "what did the policy
+    do?".  If no rule fired, we still include the policy with an empty
+    ``fired`` list so the caller knows it was evaluated.
+    """
+    fired_entries: list[dict] = []
+    for rd in pd.rules:
+        if not rd.fired:
+            continue
+        entry: dict = {"rule": rd.rule, "ordinal": rd.ordinal}
+        # Compact condition trace: only matched conditions, just the
+        # operand/operator/value the LLM needs to retell the decision.
+        cond_trace: list[dict] = []
+        for ct in rd.conditions:
+            target = ct.operand
+            if ct.name:
+                target += f"[{ct.name}]"
+            elif ct.selector:
+                target += f".{ct.selector}"
+            cond_trace.append(
+                {
+                    "field": target,
+                    "operator": ct.operator,
+                    "expected": list(ct.expected),
+                    "actual": ct.actual,
+                }
+            )
+        if cond_trace:
+            entry["matched_on"] = cond_trace
+        if rd.actions:
+            entry["actions"] = [
+                {"target": at.target, "verb": at.verb, "value": at.value}
+                for at in rd.actions
+            ]
+        fired_entries.append(entry)
+    out: dict = {"policy": pd.policy, "strategy": pd.strategy}
+    if fired_entries:
+        out["fired"] = fired_entries
+    else:
+        # Surface the no-match case so the caller sees we did evaluate.
+        out["fired"] = []
+    return out
 
 
 def _profile_categories(profile_chain: tuple[str, ...]) -> list[str]:
@@ -2465,6 +2612,10 @@ def _compact_session(se: SessionExplain, *, max_event_body_lines: int = 8) -> di
         out["profiles"] = profiles
     if se.ltm_policies:
         out["ltm_policies"] = list(se.ltm_policies)
+    if se.policy_decisions:
+        out["policy_decisions"] = [
+            _compact_policy_decision(pd) for pd in se.policy_decisions
+        ]
     if se.apm_profile:
         out["apm_profile"] = se.apm_profile
     if se.event_sequence:

--- a/core/bigip/explain_flow.py
+++ b/core/bigip/explain_flow.py
@@ -314,8 +314,13 @@ class SessionExplain:
     event_annotations: tuple[tuple[str, str, tuple[tuple[str, str, str], ...]], ...] = ()
     ltm_policies: tuple[str, ...] = ()
     # Per-policy evaluation against the captured request state.  Empty
-    # when there are no policies attached, when the policy body wasn't
-    # parsed, or when the captured state was insufficient to evaluate.
+    # when no LTM policies are attached to the matched VS, when an
+    # attached path is unresolved (e.g. a short name we couldn't
+    # resolve to a full path), or when the policy body wasn't parsed
+    # into ``BigipConfig.policies``.  When evaluation runs, every
+    # parsed policy yields a ``PolicyDecision`` regardless of whether
+    # the captured state was sufficient — individual conditions
+    # surface their unevaluable-ness via ``ConditionTrace.note``.
     policy_decisions: tuple[PolicyDecision, ...] = ()
     apm_profile: str = ""
     gtm_wide_ips: tuple[str, ...] = ()
@@ -2405,8 +2410,7 @@ def _policy_decision_to_dict(pd: PolicyDecision) -> dict:
                     for ct in rd.conditions
                 ],
                 "actions": [
-                    {"target": at.target, "verb": at.verb, "value": at.value}
-                    for at in rd.actions
+                    {"target": at.target, "verb": at.verb, "value": at.value} for at in rd.actions
                 ],
             }
             for rd in pd.rules
@@ -2428,10 +2432,17 @@ def _compact_policy_decision(pd: PolicyDecision) -> dict:
         if not rd.fired:
             continue
         entry: dict = {"rule": rd.rule, "ordinal": rd.ordinal}
-        # Compact condition trace: only matched conditions, just the
-        # operand/operator/value the LLM needs to retell the decision.
+        # Compact condition trace: only conditions that actually
+        # matched.  For an unconditional default rule (zero
+        # conditions) ``matched_on`` is omitted entirely — there's
+        # nothing to attribute the firing to.  Unevaluable conditions
+        # (note set, matched=False) and non-matching conditions are
+        # also omitted; the verbose ``report_to_dict`` shape carries
+        # the full per-condition trace if a consumer needs it.
         cond_trace: list[dict] = []
         for ct in rd.conditions:
+            if not ct.matched:
+                continue
             target = ct.operand
             if ct.name:
                 target += f"[{ct.name}]"
@@ -2449,8 +2460,7 @@ def _compact_policy_decision(pd: PolicyDecision) -> dict:
             entry["matched_on"] = cond_trace
         if rd.actions:
             entry["actions"] = [
-                {"target": at.target, "verb": at.verb, "value": at.value}
-                for at in rd.actions
+                {"target": at.target, "verb": at.verb, "value": at.value} for at in rd.actions
             ]
         fired_entries.append(entry)
     out: dict = {"policy": pd.policy, "strategy": pd.strategy}
@@ -2613,9 +2623,7 @@ def _compact_session(se: SessionExplain, *, max_event_body_lines: int = 8) -> di
     if se.ltm_policies:
         out["ltm_policies"] = list(se.ltm_policies)
     if se.policy_decisions:
-        out["policy_decisions"] = [
-            _compact_policy_decision(pd) for pd in se.policy_decisions
-        ]
+        out["policy_decisions"] = [_compact_policy_decision(pd) for pd in se.policy_decisions]
     if se.apm_profile:
         out["apm_profile"] = se.apm_profile
     if se.event_sequence:

--- a/core/bigip/model.py
+++ b/core/bigip/model.py
@@ -198,8 +198,9 @@ class BigipPolicyAction:
     location: str = ""
     name: str = ""  # http-header / cookie target name
     value: str = ""
-    path: str = ""  # http-uri replace path / query
+    path: str = ""  # http-uri replace path / query / host component
     query: str = ""
+    host: str = ""
     event: str = ""
 
 

--- a/core/bigip/model.py
+++ b/core/bigip/model.py
@@ -166,6 +166,67 @@ class BigipVirtualServer:
 
 
 @dataclass(frozen=True, slots=True)
+class BigipPolicyCondition:
+    """A single ``conditions { N { … } }`` entry inside a policy rule.
+
+    Operand / selector / operator are bare positional flag tokens in
+    the source (``http-host host equals``); we classify them by
+    membership in a finite vocabulary at parse time.  ``name`` is the
+    targeted header / extension for ``http-header`` / ``ssl-extension``
+    operands, where the source carries it as ``name <value>``.
+    """
+
+    index: int
+    operand: str = ""  # http-host, http-uri, http-method, http-header, ssl-extension, tcp
+    selector: str = ""  # operand-specific (host, path, query, all, address, …)
+    operator: str = "equals"
+    values: tuple[str, ...] = ()
+    name: str = ""  # http-header / ssl-extension target name
+    negate: bool = False
+    case_insensitive: bool = False
+    event: str = ""  # request, response, ssl-client-hello, …
+
+
+@dataclass(frozen=True, slots=True)
+class BigipPolicyAction:
+    """A single ``actions { N { … } }`` entry inside a policy rule."""
+
+    index: int
+    target: str = ""  # forward, http-reply, http-uri, http-header, http-cookie, tcp, log
+    verb: str = ""  # select, redirect, replace, insert, remove, reset, drop
+    pool: str = ""
+    location: str = ""
+    name: str = ""  # http-header / cookie target name
+    value: str = ""
+    path: str = ""  # http-uri replace path / query
+    query: str = ""
+    event: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class BigipPolicyRule:
+    """A named rule inside a policy: ordered conditions + actions."""
+
+    name: str
+    ordinal: int = 0
+    conditions: tuple[BigipPolicyCondition, ...] = ()
+    actions: tuple[BigipPolicyAction, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class BigipPolicy:
+    """A ``ltm policy`` object."""
+
+    name: str
+    full_path: str
+    strategy: str = "first-match"  # first-match | all-match | best-match
+    requires: tuple[str, ...] = ()
+    controls: tuple[str, ...] = ()
+    rules: tuple[BigipPolicyRule, ...] = ()
+    range: Range | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class BigipGenericObject:
     """A generic BIG-IP stanza retained when no specialised model exists."""
 
@@ -192,6 +253,7 @@ class BigipConfig:
     snat_pools: dict[str, BigipSnatPool] = field(default_factory=dict)
     persistence: dict[str, BigipPersistence] = field(default_factory=dict)
     rules: dict[str, BigipRule] = field(default_factory=dict)
+    policies: dict[str, BigipPolicy] = field(default_factory=dict)
     generic_objects: dict[str, BigipGenericObject] = field(default_factory=dict)
 
     def resolve_name(self, name: str, objects: Mapping[str, object]) -> str | None:

--- a/core/bigip/parser.py
+++ b/core/bigip/parser.py
@@ -635,7 +635,14 @@ _POLICY_OPERANDS = frozenset(
         "ssl-extension",
         "ssl-cert",
         "geoip",
-        "client-accepted",
+        # NOTE: ``client-accepted`` is intentionally NOT here even though
+        # it appears in some operand documentation — it overlaps with
+        # the event vocabulary in _POLICY_EVENTS, and the bare-token
+        # classifier resolves operands before events.  Including it
+        # would silently turn an event tag into a (broken) operand,
+        # losing the event annotation.  If we ever need a real
+        # ``client-accepted`` operand, give it a distinct name or add
+        # disambiguation logic to the classifier first.
     }
 )
 
@@ -732,6 +739,48 @@ def _strip_quotes(text: str) -> str:
     return s
 
 
+def _parse_policy_values_block(braced: str) -> list[str]:
+    """Quote-aware tokeniser for policy condition ``values { … }`` lists.
+
+    ``_parse_list_block`` is whitespace-only and turns
+    ``values { "Mozilla/5.0 (iPhone; CPU)" }`` into four tokens — that
+    corrupts UA strings, regex literals, and any header value with
+    spaces.  Policy values therefore need their own parser that
+    respects double-quoted strings (with ``\\`` escapes), strips the
+    surrounding quotes from each emitted value, and otherwise behaves
+    like the list-block parser (whitespace-separated bare tokens).
+    """
+    inner = _strip_outer_braces(braced)
+    out: list[str] = []
+    pos = 0
+    length = len(inner)
+    while pos < length:
+        ch = inner[pos]
+        if ch in " \t\n\r":
+            pos += 1
+            continue
+        if ch == '"':
+            pos += 1
+            buf: list[str] = []
+            while pos < length and inner[pos] != '"':
+                if inner[pos] == "\\" and pos + 1 < length:
+                    buf.append(inner[pos + 1])
+                    pos += 2
+                    continue
+                buf.append(inner[pos])
+                pos += 1
+            if pos < length and inner[pos] == '"':
+                pos += 1  # consume closing quote
+            out.append("".join(buf))
+            continue
+        # Bare token: read until whitespace.
+        start = pos
+        while pos < length and inner[pos] not in " \t\n\r":
+            pos += 1
+        out.append(inner[start:pos])
+    return out
+
+
 def _parse_policy_condition(index: int, body: str) -> BigipPolicyCondition:
     """Parse a single ``conditions { N { … } }`` body."""
     props = _parse_properties(body)
@@ -746,7 +795,7 @@ def _parse_policy_condition(index: int, body: str) -> BigipPolicyCondition:
     for key, value in props.items():
         if value:
             if key == "values":
-                values = _parse_list_block(value)
+                values = _parse_policy_values_block(value)
             elif key in ("name", "tm-name"):
                 name = _strip_quotes(value)
             continue
@@ -787,6 +836,7 @@ def _parse_policy_action(index: int, body: str) -> BigipPolicyAction:
     value = ""
     path = ""
     query = ""
+    host = ""
     event = ""
     for key, val in props.items():
         if val:
@@ -802,6 +852,12 @@ def _parse_policy_action(index: int, body: str) -> BigipPolicyAction:
                 path = _strip_quotes(val)
             elif key == "query":
                 query = _strip_quotes(val)
+            elif key == "host":
+                # ``http-uri replace host www.example.com`` — TMSH puts
+                # the host component in the same key=value form as path
+                # / query.  Without this branch the token would be
+                # silently dropped from the parsed action.
+                host = _strip_quotes(val)
             continue
         if key in _POLICY_ACTION_TARGETS and not target:
             target = key
@@ -819,6 +875,7 @@ def _parse_policy_action(index: int, body: str) -> BigipPolicyAction:
         value=value,
         path=path,
         query=query,
+        host=host,
         event=event,
     )
 
@@ -841,9 +898,7 @@ def _parse_policy_rule(name: str, body: str) -> BigipPolicyRule:
                 idx = int(cond_idx_str)
             except ValueError:
                 continue
-            conditions.append(
-                _parse_policy_condition(idx, _strip_outer_braces(cond_prop.value))
-            )
+            conditions.append(_parse_policy_condition(idx, _strip_outer_braces(cond_prop.value)))
 
     actions: list[BigipPolicyAction] = []
     act_block = props.get("actions", "")
@@ -893,9 +948,7 @@ def _parse_policy(
         for rule_name, rule_prop in _parse_properties_with_spans(
             _strip_outer_braces(rules_block)
         ).items():
-            rules.append(
-                _parse_policy_rule(rule_name, _strip_outer_braces(rule_prop.value))
-            )
+            rules.append(_parse_policy_rule(rule_name, _strip_outer_braces(rule_prop.value)))
     rules.sort(key=lambda r: (r.ordinal, r.name))
 
     return BigipPolicy(

--- a/core/bigip/parser.py
+++ b/core/bigip/parser.py
@@ -33,6 +33,10 @@ from .model import (
     BigipMonitor,
     BigipNode,
     BigipPersistence,
+    BigipPolicy,
+    BigipPolicyAction,
+    BigipPolicyCondition,
+    BigipPolicyRule,
     BigipPool,
     BigipPoolMember,
     BigipProfile,
@@ -605,6 +609,306 @@ def _parse_rule(full_path: str, body: str, source_map: DocumentBuffer, block: _B
     )
 
 
+# LTM policy parsing
+#
+# F5 LTM policies have an unusual grammar: condition / action bodies
+# carry positional bare-flag tokens (operand, selector, operator,
+# modifiers) interleaved with key/value properties (``name``, ``pool``,
+# ``location``) and a ``values { … }`` list block.  We classify each
+# bare token by membership in a finite vocabulary rather than parsing
+# positionally, since TMSH itself reorders bare tokens between save
+# generations.
+
+
+_POLICY_OPERANDS = frozenset(
+    {
+        "http-host",
+        "http-uri",
+        "http-method",
+        "http-version",
+        "http-status",
+        "http-header",
+        "http-cookie",
+        "http-referer",
+        "http-user-agent",
+        "tcp",
+        "ssl-extension",
+        "ssl-cert",
+        "geoip",
+        "client-accepted",
+    }
+)
+
+_POLICY_SELECTORS = frozenset(
+    {
+        "host",
+        "port",
+        "path",
+        "query",
+        "all",
+        "address",
+        "version",
+        "extension",
+        "method",
+        "scheme",
+    }
+)
+
+_POLICY_OPERATORS = frozenset(
+    {
+        "equals",
+        "starts-with",
+        "ends-with",
+        "contains",
+        "matches",
+        "exists",
+        "missing",
+        "less",
+        "greater",
+        "less-or-equal",
+        "greater-or-equal",
+    }
+)
+
+_POLICY_EVENTS = frozenset(
+    {
+        "request",
+        "response",
+        "client-accepted",
+        "server-connected",
+        "ssl-client-hello",
+        "ssl-server-hello",
+        "proxy-request",
+        "proxy-response",
+        "websocket-request",
+        "websocket-response",
+    }
+)
+
+_POLICY_ACTION_TARGETS = frozenset(
+    {
+        "forward",
+        "http-reply",
+        "http-uri",
+        "http-host",
+        "http-header",
+        "http-cookie",
+        "tcp",
+        "log",
+        "shutdown",
+    }
+)
+
+_POLICY_ACTION_VERBS = frozenset(
+    {
+        "select",
+        "redirect",
+        "replace",
+        "insert",
+        "remove",
+        "reset",
+        "drop",
+        "rewrite",
+        "enable",
+        "disable",
+    }
+)
+
+
+def _strip_outer_braces(text: str) -> str:
+    """Remove the surrounding ``{ … }`` from a sub-block value, if present."""
+    s = text.strip()
+    if s.startswith("{"):
+        s = s[1:]
+    if s.endswith("}"):
+        s = s[:-1]
+    return s
+
+
+def _strip_quotes(text: str) -> str:
+    s = text.strip()
+    if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+        return s[1:-1]
+    return s
+
+
+def _parse_policy_condition(index: int, body: str) -> BigipPolicyCondition:
+    """Parse a single ``conditions { N { … } }`` body."""
+    props = _parse_properties(body)
+    operand = ""
+    selector = ""
+    operator = "equals"
+    negate = False
+    case_insensitive = False
+    event = ""
+    name = ""
+    values: list[str] = []
+    for key, value in props.items():
+        if value:
+            if key == "values":
+                values = _parse_list_block(value)
+            elif key in ("name", "tm-name"):
+                name = _strip_quotes(value)
+            continue
+        # Bare flag token: classify by vocabulary.
+        if key in _POLICY_OPERANDS and not operand:
+            operand = key
+        elif key in _POLICY_SELECTORS and not selector:
+            selector = key
+        elif key in _POLICY_OPERATORS:
+            operator = key
+        elif key in _POLICY_EVENTS:
+            event = key
+        elif key == "not":
+            negate = True
+        elif key == "case-insensitive":
+            case_insensitive = True
+    return BigipPolicyCondition(
+        index=index,
+        operand=operand,
+        selector=selector,
+        operator=operator,
+        values=tuple(values),
+        name=name,
+        negate=negate,
+        case_insensitive=case_insensitive,
+        event=event,
+    )
+
+
+def _parse_policy_action(index: int, body: str) -> BigipPolicyAction:
+    """Parse a single ``actions { N { … } }`` body."""
+    props = _parse_properties(body)
+    target = ""
+    verb = ""
+    pool = ""
+    location = ""
+    name = ""
+    value = ""
+    path = ""
+    query = ""
+    event = ""
+    for key, val in props.items():
+        if val:
+            if key == "pool":
+                pool = val.strip()
+            elif key == "location":
+                location = _strip_quotes(val)
+            elif key in ("name", "tm-name"):
+                name = _strip_quotes(val)
+            elif key == "value":
+                value = _strip_quotes(val)
+            elif key == "path":
+                path = _strip_quotes(val)
+            elif key == "query":
+                query = _strip_quotes(val)
+            continue
+        if key in _POLICY_ACTION_TARGETS and not target:
+            target = key
+        elif key in _POLICY_ACTION_VERBS and not verb:
+            verb = key
+        elif key in _POLICY_EVENTS:
+            event = key
+    return BigipPolicyAction(
+        index=index,
+        target=target,
+        verb=verb,
+        pool=pool,
+        location=location,
+        name=name,
+        value=value,
+        path=path,
+        query=query,
+        event=event,
+    )
+
+
+def _parse_policy_rule(name: str, body: str) -> BigipPolicyRule:
+    props_with_spans = _parse_properties_with_spans(body)
+    props = {key: prop.value for key, prop in props_with_spans.items()}
+    try:
+        ordinal = int(props.get("ordinal", "0").strip())
+    except ValueError:
+        ordinal = 0
+
+    conditions: list[BigipPolicyCondition] = []
+    cond_block = props.get("conditions", "")
+    if cond_block:
+        for cond_idx_str, cond_prop in _parse_properties_with_spans(
+            _strip_outer_braces(cond_block)
+        ).items():
+            try:
+                idx = int(cond_idx_str)
+            except ValueError:
+                continue
+            conditions.append(
+                _parse_policy_condition(idx, _strip_outer_braces(cond_prop.value))
+            )
+
+    actions: list[BigipPolicyAction] = []
+    act_block = props.get("actions", "")
+    if act_block:
+        for act_idx_str, act_prop in _parse_properties_with_spans(
+            _strip_outer_braces(act_block)
+        ).items():
+            try:
+                idx = int(act_idx_str)
+            except ValueError:
+                continue
+            actions.append(_parse_policy_action(idx, _strip_outer_braces(act_prop.value)))
+
+    conditions.sort(key=lambda c: c.index)
+    actions.sort(key=lambda a: a.index)
+    return BigipPolicyRule(
+        name=name,
+        ordinal=ordinal,
+        conditions=tuple(conditions),
+        actions=tuple(actions),
+    )
+
+
+def _parse_policy(
+    full_path: str, body: str, source_map: DocumentBuffer, block: _Block
+) -> BigipPolicy:
+    """Parse a ``ltm policy`` block."""
+    props = _parse_properties(body)
+    name = full_path.rsplit("/", 1)[-1]
+    strategy = (props.get("strategy", "") or "first-match").strip()
+    # ``first-match`` is canonicalised — TMSH sometimes prepends the
+    # path of a published strategy (``/Common/first-match``).
+    strategy = strategy.rsplit("/", 1)[-1]
+
+    requires: list[str] = []
+    requires_block = props.get("requires", "")
+    if requires_block:
+        requires = _parse_list_block(requires_block)
+    controls: list[str] = []
+    controls_block = props.get("controls", "")
+    if controls_block:
+        controls = _parse_list_block(controls_block)
+
+    rules: list[BigipPolicyRule] = []
+    rules_block = props.get("rules", "")
+    if rules_block:
+        for rule_name, rule_prop in _parse_properties_with_spans(
+            _strip_outer_braces(rules_block)
+        ).items():
+            rules.append(
+                _parse_policy_rule(rule_name, _strip_outer_braces(rule_prop.value))
+            )
+    rules.sort(key=lambda r: (r.ordinal, r.name))
+
+    return BigipPolicy(
+        name=name,
+        full_path=full_path,
+        strategy=strategy,
+        requires=tuple(requires),
+        controls=tuple(controls),
+        rules=tuple(rules),
+        range=_range_from_offsets(source_map, block.start_offset, block.end_offset),
+    )
+
+
 # Public API
 
 
@@ -666,6 +970,10 @@ def parse_bigip_conf(source: str) -> BigipConfig:
             case "rule":
                 rule = _parse_rule(full_path, block.body, source_map, block)
                 config.rules[full_path] = rule
+            case "policy":
+                if module == "ltm":
+                    policy = _parse_policy(full_path, block.body, source_map, block)
+                    config.policies[full_path] = policy
             case _ if obj_type.startswith("profile "):
                 profile_type_str = obj_type.split(" ", 1)[1]
                 profile = _parse_profile(full_path, profile_type_str, source_map, block)

--- a/core/bigip/policy_eval.py
+++ b/core/bigip/policy_eval.py
@@ -118,8 +118,9 @@ def evaluate_policy(policy: BigipPolicy, state: RequestState) -> PolicyDecision:
     * ``all-match`` — runs actions of every matched rule.
     * ``best-match`` (and unknown) — picks the matched rule with the
       largest condition count.  F5's true best-match weights operand
-      specificity; this is a deliberate approximation we surface in
-      :attr:`PolicyDecision.strategy` so consumers can warn.
+      specificity; this is a deliberate approximation we surface as
+      ``best-match-approx`` in :attr:`PolicyDecision.strategy` so
+      consumers can warn rather than assume F5-accurate semantics.
     """
     matched_indexes: list[int] = []
     rules_built: list[RuleDecision] = []
@@ -139,15 +140,17 @@ def evaluate_policy(policy: BigipPolicy, state: RequestState) -> PolicyDecision:
             )
         )
 
-    strategy = (policy.strategy or "first-match").lower()
-    if strategy == "first-match":
+    raw_strategy = (policy.strategy or "first-match").lower()
+    reported_strategy = raw_strategy
+    if raw_strategy == "first-match":
         for i, decision in enumerate(rules_built):
             if decision.matched:
                 matched_indexes.append(i)
                 break
-    elif strategy == "all-match":
+    elif raw_strategy == "all-match":
         matched_indexes = [i for i, d in enumerate(rules_built) if d.matched]
-    else:  # best-match approximation
+    else:  # best-match approximation (also used for unknown strategies)
+        reported_strategy = "best-match-approx"
         best_i = -1
         best_score = -1
         for i, decision in enumerate(rules_built):
@@ -178,7 +181,7 @@ def evaluate_policy(policy: BigipPolicy, state: RequestState) -> PolicyDecision:
         else:
             final.append(decision)
 
-    return PolicyDecision(policy=policy.full_path, strategy=strategy, rules=tuple(final))
+    return PolicyDecision(policy=policy.full_path, strategy=reported_strategy, rules=tuple(final))
 
 
 def request_state_from_session(session) -> RequestState:  # noqa: ANN001 — Session lives in explain_flow
@@ -209,13 +212,24 @@ def request_state_from_session(session) -> RequestState:  # noqa: ANN001 — Ses
 
 
 def _evaluate_condition(cond: BigipPolicyCondition, state: RequestState) -> ConditionTrace:
-    actual, note = _extract_actual(cond, state)
-    if cond.operator in ("exists", "missing"):
-        present = bool(actual)
-        raw = present if cond.operator == "exists" else not present
+    actual, present, note, unevaluable = _extract_actual(cond, state)
+    # Unevaluable conditions (unsupported operand, missing required
+    # `name`, etc.) must not be allowed to match.  Without this guard
+    # ``geoip missing`` would derive ``not bool("")`` = True and let
+    # an unsupported rule fire, contradicting the documented contract
+    # that unsupported operands no-match with an explanatory note.
+    # ``missing`` against a captured-empty field (note set but
+    # ``unevaluable=False``) is still allowed to match — that's the
+    # legitimate "the request didn't carry this header" case, where
+    # ``present=False`` even though we know which field to look at.
+    if unevaluable:
+        matched = False
     else:
-        raw = _apply_operator(cond.operator, actual, cond.values, cond.case_insensitive)
-    matched = raw if not cond.negate else not raw
+        if cond.operator in ("exists", "missing"):
+            raw = present if cond.operator == "exists" else not present
+        else:
+            raw = _apply_operator(cond.operator, actual, cond.values, cond.case_insensitive)
+        matched = raw if not cond.negate else not raw
     return ConditionTrace(
         operand=cond.operand,
         selector=cond.selector,
@@ -230,42 +244,65 @@ def _evaluate_condition(cond: BigipPolicyCondition, state: RequestState) -> Cond
     )
 
 
-def _extract_actual(cond: BigipPolicyCondition, state: RequestState) -> tuple[str, str]:
-    """Return ``(observed_value, note)`` for *cond*.
+def _extract_actual(cond: BigipPolicyCondition, state: RequestState) -> tuple[str, bool, str, bool]:
+    """Return ``(observed_value, present, note, unevaluable)`` for *cond*.
 
-    ``note`` is non-empty when we deliberately couldn't evaluate
-    (operand unsupported in v1, or required data absent from the
-    capture).  The trace surfaces it so the operator knows why a
-    condition didn't match.
+    * ``observed_value`` — the captured value we'll match against.
+    * ``present`` — distinct from ``bool(observed_value)``: an
+      explicitly-set empty header is *present* (so ``exists`` matches)
+      while a header that wasn't sent at all is *absent* (so
+      ``missing`` matches).  Without tracking this separately,
+      ``http-header X-Foo exists`` would wrongly no-match when
+      ``X-Foo: ""`` was actually sent.
+    * ``note`` — operator-readable explanation when something is off
+      (field absent, operand unsupported, condition malformed).
+    * ``unevaluable`` — ``True`` when we couldn't even attempt the
+      condition (operand outside the v1 surface, missing required
+      ``name``, …).  Callers must force a no-match in that case so an
+      unsupported ``geoip missing`` doesn't silently fire.
     """
     op = cond.operand
     sel = cond.selector
     if op == "http-host":
-        return state.host, ("" if state.host else "no Host captured")
+        present = bool(state.host)
+        return state.host, present, ("" if present else "no Host captured"), False
     if op == "http-uri":
         if sel == "path":
-            return state.path, ("" if state.path else "no URI captured")
+            present = bool(state.path)
+            return state.path, present, ("" if present else "no URI captured"), False
         if sel == "query":
-            return state.query, ("" if state.query else "no query string captured")
+            present = bool(state.query)
+            return (
+                state.query,
+                present,
+                ("" if present else "no query string captured"),
+                False,
+            )
         if sel == "host":
-            return state.host, ("" if state.host else "no Host captured")
-        return state.uri, ("" if state.uri else "no URI captured")
+            present = bool(state.host)
+            return state.host, present, ("" if present else "no Host captured"), False
+        present = bool(state.uri)
+        return state.uri, present, ("" if present else "no URI captured"), False
     if op == "http-method":
-        return state.method, ("" if state.method else "no method captured")
+        present = bool(state.method)
+        return state.method, present, ("" if present else "no method captured"), False
     if op == "http-header":
         if not cond.name:
-            return "", "http-header condition has no `name` — cannot evaluate"
-        v = state.headers.get(cond.name.lower(), "")
-        return v, ("" if v else f"header {cond.name!r} not seen in capture")
+            return "", False, "http-header condition has no `name` — cannot evaluate", True
+        key = cond.name.lower()
+        present = key in state.headers
+        v = state.headers.get(key, "")
+        return v, present, ("" if present else f"header {cond.name!r} not seen in capture"), False
     if op == "ssl-extension":
         if cond.name and cond.name.lower() != "server-name":
-            return "", f"ssl-extension {cond.name!r} not supported in v1"
-        return state.sni, ("" if state.sni else "no SNI captured")
+            return "", False, f"ssl-extension {cond.name!r} not supported in v1", True
+        present = bool(state.sni)
+        return state.sni, present, ("" if present else "no SNI captured"), False
     if op == "tcp":
         if sel == "address":
-            return state.client_addr, ""
-        return "", f"tcp selector {sel!r} not supported in v1"
-    return "", f"operand {op!r} not supported in v1"
+            return state.client_addr, bool(state.client_addr), "", False
+        return "", False, f"tcp selector {sel!r} not supported in v1", True
+    return "", False, f"operand {op!r} not supported in v1", True
 
 
 def _apply_operator(
@@ -333,6 +370,8 @@ def _action_summary_value(action: BigipPolicyAction) -> str:
             return f"path={action.path}"
         if action.query:
             return f"query={action.query}"
+        if action.host:
+            return f"host={action.host}"
     if action.target == "http-header":
         if action.verb == "insert":
             return f"{action.name}={action.value}"
@@ -342,7 +381,15 @@ def _action_summary_value(action: BigipPolicyAction) -> str:
         return "RST"
     # Fall back to the most relevant non-empty field so callers always
     # see something actionable in the trace.
-    for v in (action.pool, action.location, action.name, action.value, action.path, action.query):
+    for v in (
+        action.pool,
+        action.location,
+        action.name,
+        action.value,
+        action.path,
+        action.query,
+        action.host,
+    ):
         if v:
             return v
     return ""

--- a/core/bigip/policy_eval.py
+++ b/core/bigip/policy_eval.py
@@ -1,0 +1,360 @@
+"""Evaluate parsed BIG-IP LTM policies against captured request state.
+
+Operates on the model produced by :mod:`core.bigip.parser` — purely
+declarative, no c-tcl or runtime needed.  The evaluator is the same
+under static analysis and ``simulate=true``: LTM policies don't run
+arbitrary code, so the captured request fully determines the outcome.
+
+Supported operand vocabulary (the ``medium`` scope agreed for v1):
+
+* ``http-host`` — host header, exact / starts-with / ends-with /
+  contains / matches.
+* ``http-uri`` with selectors ``host``, ``path``, ``query`` (and the
+  default of the full URI when no selector is given).
+* ``http-method`` — request method.
+* ``http-header`` with ``name <header>`` — value of a named header.
+* ``ssl-extension`` with ``name server-name`` — TLS SNI.
+* ``tcp`` with selector ``address`` — client source address.
+
+Action surface:
+
+* ``forward select pool <path>``
+* ``http-reply redirect location <url>``
+* ``http-uri replace path|query|host <value>``
+* ``http-header insert name <h> value <v>``
+* ``http-header remove name <h>``
+* ``tcp reset``
+
+Out of scope for v1: cookie operands/actions, geoip/cert operands,
+rate-limit / log / shutdown actions, condition events other than
+``request``/``ssl-client-hello`` (we still surface them in the trace,
+but don't try to interpret response-phase state).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from urllib.parse import urlsplit
+
+from .model import BigipPolicy, BigipPolicyAction, BigipPolicyCondition
+
+
+@dataclass(frozen=True, slots=True)
+class RequestState:
+    """The captured request state a policy condition can read.
+
+    Build one with :func:`request_state_from_session`.  Header lookups
+    are case-insensitive: store header *names* lowercased.
+    """
+
+    method: str = ""
+    host: str = ""
+    uri: str = ""
+    path: str = ""
+    query: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+    sni: str = ""
+    tls_version: str = ""
+    client_addr: str = ""
+    server_addr: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ConditionTrace:
+    """Per-condition trace: what the condition saw and whether it matched."""
+
+    operand: str
+    selector: str
+    operator: str
+    expected: tuple[str, ...]
+    actual: str
+    matched: bool
+    name: str = ""  # http-header / ssl-extension target name
+    negate: bool = False
+    event: str = ""
+    note: str = ""  # populated when we couldn't evaluate (operand unsupported, no data)
+
+
+@dataclass(frozen=True, slots=True)
+class ActionTrace:
+    """An action that fired (only present on matched rules)."""
+
+    target: str
+    verb: str
+    value: str = ""  # most-relevant single value: pool / location / "name=value"
+
+
+@dataclass(frozen=True, slots=True)
+class RuleDecision:
+    """Per-rule decision: which conditions matched and (if fired) which actions ran."""
+
+    rule: str
+    ordinal: int
+    matched: bool
+    fired: bool
+    conditions: tuple[ConditionTrace, ...]
+    actions: tuple[ActionTrace, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """Per-policy decision: the rule walk plus the strategy that picked the winner."""
+
+    policy: str
+    strategy: str
+    rules: tuple[RuleDecision, ...]
+
+
+# Public API
+
+
+def evaluate_policy(policy: BigipPolicy, state: RequestState) -> PolicyDecision:
+    """Evaluate ``policy`` against ``state`` and return per-rule decisions.
+
+    Strategies:
+
+    * ``first-match`` — runs only the first rule whose conditions all match.
+    * ``all-match`` — runs actions of every matched rule.
+    * ``best-match`` (and unknown) — picks the matched rule with the
+      largest condition count.  F5's true best-match weights operand
+      specificity; this is a deliberate approximation we surface in
+      :attr:`PolicyDecision.strategy` so consumers can warn.
+    """
+    matched_indexes: list[int] = []
+    rules_built: list[RuleDecision] = []
+    for rule in policy.rules:
+        cond_traces = tuple(_evaluate_condition(c, state) for c in rule.conditions)
+        # A rule with no conditions is unconditional (matches always);
+        # this matches TMSH semantics for ``default`` rules.
+        all_ok = all(t.matched for t in cond_traces)
+        rules_built.append(
+            RuleDecision(
+                rule=rule.name,
+                ordinal=rule.ordinal,
+                matched=all_ok,
+                fired=False,
+                conditions=cond_traces,
+                actions=(),
+            )
+        )
+
+    strategy = (policy.strategy or "first-match").lower()
+    if strategy == "first-match":
+        for i, decision in enumerate(rules_built):
+            if decision.matched:
+                matched_indexes.append(i)
+                break
+    elif strategy == "all-match":
+        matched_indexes = [i for i, d in enumerate(rules_built) if d.matched]
+    else:  # best-match approximation
+        best_i = -1
+        best_score = -1
+        for i, decision in enumerate(rules_built):
+            if not decision.matched:
+                continue
+            score = len(decision.conditions)
+            if score > best_score:
+                best_score = score
+                best_i = i
+        if best_i >= 0:
+            matched_indexes.append(best_i)
+
+    fired = set(matched_indexes)
+    final: list[RuleDecision] = []
+    for i, decision in enumerate(rules_built):
+        if i in fired:
+            actions = tuple(_action_trace(a) for a in policy.rules[i].actions)
+            final.append(
+                RuleDecision(
+                    rule=decision.rule,
+                    ordinal=decision.ordinal,
+                    matched=True,
+                    fired=True,
+                    conditions=decision.conditions,
+                    actions=actions,
+                )
+            )
+        else:
+            final.append(decision)
+
+    return PolicyDecision(policy=policy.full_path, strategy=strategy, rules=tuple(final))
+
+
+def request_state_from_session(session) -> RequestState:  # noqa: ANN001 — Session lives in explain_flow
+    """Derive a :class:`RequestState` from an explain-flow Session.
+
+    Only the front-side client flow is consulted — that's the request
+    state the policy evaluates against.  Header keys are lowercased.
+    """
+    fc = session.front.client
+    headers = {k.lower(): v for k, v in (fc.http_request_headers or {}).items()}
+    # Host header trumps the captured Host field if present.
+    host = (headers.get("host") or fc.http_host or "").strip()
+    return RequestState(
+        method=fc.http_method or "",
+        host=host,
+        uri=fc.http_uri or "",
+        path=fc.http_path or _split_path(fc.http_uri or ""),
+        query=fc.http_query or _split_query(fc.http_uri or ""),
+        headers=headers,
+        sni=fc.tls_sni or "",
+        tls_version=fc.tls_chosen_version or fc.tls_version or "",
+        client_addr=fc.src_ip or "",
+        server_addr=fc.dst_ip or "",
+    )
+
+
+# Internals
+
+
+def _evaluate_condition(cond: BigipPolicyCondition, state: RequestState) -> ConditionTrace:
+    actual, note = _extract_actual(cond, state)
+    if cond.operator in ("exists", "missing"):
+        present = bool(actual)
+        raw = present if cond.operator == "exists" else not present
+    else:
+        raw = _apply_operator(cond.operator, actual, cond.values, cond.case_insensitive)
+    matched = raw if not cond.negate else not raw
+    return ConditionTrace(
+        operand=cond.operand,
+        selector=cond.selector,
+        operator=cond.operator,
+        expected=cond.values,
+        actual=actual,
+        matched=matched,
+        name=cond.name,
+        negate=cond.negate,
+        event=cond.event,
+        note=note,
+    )
+
+
+def _extract_actual(cond: BigipPolicyCondition, state: RequestState) -> tuple[str, str]:
+    """Return ``(observed_value, note)`` for *cond*.
+
+    ``note`` is non-empty when we deliberately couldn't evaluate
+    (operand unsupported in v1, or required data absent from the
+    capture).  The trace surfaces it so the operator knows why a
+    condition didn't match.
+    """
+    op = cond.operand
+    sel = cond.selector
+    if op == "http-host":
+        return state.host, ("" if state.host else "no Host captured")
+    if op == "http-uri":
+        if sel == "path":
+            return state.path, ("" if state.path else "no URI captured")
+        if sel == "query":
+            return state.query, ("" if state.query else "no query string captured")
+        if sel == "host":
+            return state.host, ("" if state.host else "no Host captured")
+        return state.uri, ("" if state.uri else "no URI captured")
+    if op == "http-method":
+        return state.method, ("" if state.method else "no method captured")
+    if op == "http-header":
+        if not cond.name:
+            return "", "http-header condition has no `name` — cannot evaluate"
+        v = state.headers.get(cond.name.lower(), "")
+        return v, ("" if v else f"header {cond.name!r} not seen in capture")
+    if op == "ssl-extension":
+        if cond.name and cond.name.lower() != "server-name":
+            return "", f"ssl-extension {cond.name!r} not supported in v1"
+        return state.sni, ("" if state.sni else "no SNI captured")
+    if op == "tcp":
+        if sel == "address":
+            return state.client_addr, ""
+        return "", f"tcp selector {sel!r} not supported in v1"
+    return "", f"operand {op!r} not supported in v1"
+
+
+def _apply_operator(
+    operator: str, actual: str, values: tuple[str, ...], case_insensitive: bool
+) -> bool:
+    if not values:
+        # equals/contains/etc with no values can never match.
+        return False
+    a = actual
+    vs = values
+    if case_insensitive:
+        a = a.lower()
+        vs = tuple(v.lower() for v in values)
+    if operator == "equals":
+        return a in vs
+    if operator == "starts-with":
+        return any(a.startswith(v) for v in vs)
+    if operator == "ends-with":
+        return any(a.endswith(v) for v in vs)
+    if operator == "contains":
+        return any(v in a for v in vs)
+    if operator == "matches":
+        flags = re.IGNORECASE if case_insensitive else 0
+        return any(re.search(v, actual, flags) is not None for v in values)
+    if operator == "less":
+        return _numeric_compare(actual, values, lambda x, y: x < y)
+    if operator == "greater":
+        return _numeric_compare(actual, values, lambda x, y: x > y)
+    if operator == "less-or-equal":
+        return _numeric_compare(actual, values, lambda x, y: x <= y)
+    if operator == "greater-or-equal":
+        return _numeric_compare(actual, values, lambda x, y: x >= y)
+    return False
+
+
+def _numeric_compare(actual: str, values: tuple[str, ...], op) -> bool:  # noqa: ANN001
+    try:
+        a = float(actual)
+    except (TypeError, ValueError):
+        return False
+    for v in values:
+        try:
+            if op(a, float(v)):
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _action_trace(action: BigipPolicyAction) -> ActionTrace:
+    return ActionTrace(
+        target=action.target,
+        verb=action.verb,
+        value=_action_summary_value(action),
+    )
+
+
+def _action_summary_value(action: BigipPolicyAction) -> str:
+    if action.target == "forward" and action.pool:
+        return action.pool
+    if action.target == "http-reply" and action.location:
+        return action.location
+    if action.target == "http-uri" and action.verb == "replace":
+        if action.path:
+            return f"path={action.path}"
+        if action.query:
+            return f"query={action.query}"
+    if action.target == "http-header":
+        if action.verb == "insert":
+            return f"{action.name}={action.value}"
+        if action.verb == "remove":
+            return action.name
+    if action.target == "tcp" and action.verb == "reset":
+        return "RST"
+    # Fall back to the most relevant non-empty field so callers always
+    # see something actionable in the trace.
+    for v in (action.pool, action.location, action.name, action.value, action.path, action.query):
+        if v:
+            return v
+    return ""
+
+
+def _split_path(uri: str) -> str:
+    if not uri:
+        return ""
+    return urlsplit(uri).path or uri.split("?", 1)[0]
+
+
+def _split_query(uri: str) -> str:
+    if not uri:
+        return ""
+    return urlsplit(uri).query or (uri.split("?", 1)[1] if "?" in uri else "")

--- a/tests/test_bigip_parser_policy.py
+++ b/tests/test_bigip_parser_policy.py
@@ -423,6 +423,110 @@ ltm policy /Common/p14 {
     assert cfg.policies["/Common/p14"].strategy == "first-match"
 
 
+def test_policy_values_preserve_quoted_string_with_spaces():
+    """Quoted UA strings / regex literals must survive policy values { } parsing."""
+    source = """\
+ltm policy /Common/p_quoted {
+    rules {
+        ua_match {
+            ordinal 1
+            conditions {
+                0 {
+                    http-header
+                    name User-Agent
+                    contains
+                    values { "Mozilla/5.0 (iPhone; CPU)" "curl/7.81.0" }
+                    request
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p_quoted"].rules[0].conditions[0]
+    assert cond.values == ("Mozilla/5.0 (iPhone; CPU)", "curl/7.81.0")
+
+
+def test_policy_values_quoted_with_escapes():
+    source = """\
+ltm policy /Common/p_esc {
+    rules {
+        r {
+            ordinal 1
+            conditions {
+                0 {
+                    http-header
+                    name X-Foo
+                    equals
+                    values { "a \\"b\\" c" }
+                    request
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p_esc"].rules[0].conditions[0]
+    assert cond.values == ('a "b" c',)
+
+
+def test_policy_http_uri_replace_host_action():
+    """`http-uri replace host <value>` must populate BigipPolicyAction.host."""
+    source = """\
+ltm policy /Common/p_replace_host {
+    rules {
+        rewrite_host {
+            ordinal 1
+            actions {
+                0 {
+                    http-uri
+                    replace
+                    host www.example.com
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    act = cfg.policies["/Common/p_replace_host"].rules[0].actions[0]
+    assert act.target == "http-uri"
+    assert act.verb == "replace"
+    assert act.host == "www.example.com"
+
+
+def test_policy_client_accepted_event_not_misclassified_as_operand():
+    """`client-accepted` is an event tag, not an operand — must populate event."""
+    source = """\
+ltm policy /Common/p_event {
+    rules {
+        ca {
+            ordinal 1
+            conditions {
+                0 {
+                    tcp
+                    address
+                    equals
+                    values { 10.0.0.1 }
+                    client-accepted
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p_event"].rules[0].conditions[0]
+    assert cond.operand == "tcp"
+    assert cond.event == "client-accepted"
+
+
 def test_policy_does_not_collide_with_policy_strategy_stanza():
     """`ltm policy-strategy` is a different stanza type and must not match."""
     source = """\

--- a/tests/test_bigip_parser_policy.py
+++ b/tests/test_bigip_parser_policy.py
@@ -1,0 +1,441 @@
+"""Tests for the ``ltm policy`` parser additions."""
+
+from __future__ import annotations
+
+from core.bigip.parser import parse_bigip_conf
+
+
+def test_policy_minimal():
+    source = """\
+ltm policy /Common/p_min {
+    rules {
+        only {
+            ordinal 1
+            actions {
+                0 {
+                    forward
+                    select
+                    pool /Common/p_default
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    assert "/Common/p_min" in cfg.policies
+    p = cfg.policies["/Common/p_min"]
+    assert p.name == "p_min"
+    assert p.strategy == "first-match"
+    assert len(p.rules) == 1
+    rule = p.rules[0]
+    assert rule.name == "only"
+    assert rule.ordinal == 1
+    assert rule.conditions == ()
+    assert len(rule.actions) == 1
+    act = rule.actions[0]
+    assert act.target == "forward"
+    assert act.verb == "select"
+    assert act.pool == "/Common/p_default"
+
+
+def test_policy_strips_strategy_path():
+    source = """\
+ltm policy /Common/p_strat {
+    rules { only { ordinal 1 } }
+    strategy /Common/best-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    assert cfg.policies["/Common/p_strat"].strategy == "best-match"
+
+
+def test_policy_http_host_condition():
+    source = """\
+ltm policy /Common/p1 {
+    rules {
+        host_eq {
+            ordinal 1
+            conditions {
+                0 {
+                    http-host
+                    host
+                    equals
+                    values { api.example.com www.example.com }
+                    request
+                }
+            }
+            actions {
+                0 {
+                    forward
+                    select
+                    pool /Common/p_api
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    rule = cfg.policies["/Common/p1"].rules[0]
+    cond = rule.conditions[0]
+    assert cond.operand == "http-host"
+    assert cond.selector == "host"
+    assert cond.operator == "equals"
+    assert cond.values == ("api.example.com", "www.example.com")
+    assert cond.event == "request"
+    assert not cond.negate
+
+
+def test_policy_http_uri_path_starts_with():
+    source = """\
+ltm policy /Common/p2 {
+    rules {
+        api_path {
+            ordinal 1
+            conditions {
+                0 {
+                    http-uri
+                    path
+                    starts-with
+                    case-insensitive
+                    values { /api/ /v1/ }
+                    request
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p2"].rules[0].conditions[0]
+    assert cond.operand == "http-uri"
+    assert cond.selector == "path"
+    assert cond.operator == "starts-with"
+    assert cond.case_insensitive is True
+    assert cond.values == ("/api/", "/v1/")
+
+
+def test_policy_negated_condition():
+    source = """\
+ltm policy /Common/p3 {
+    rules {
+        not_internal {
+            ordinal 1
+            conditions {
+                0 {
+                    http-uri
+                    path
+                    starts-with
+                    not
+                    values { /internal/ }
+                    request
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p3"].rules[0].conditions[0]
+    assert cond.negate is True
+    assert cond.operator == "starts-with"
+
+
+def test_policy_http_method_condition():
+    source = """\
+ltm policy /Common/p4 {
+    rules {
+        only_get {
+            ordinal 1
+            conditions {
+                0 {
+                    http-method
+                    values { GET HEAD }
+                    request
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p4"].rules[0].conditions[0]
+    assert cond.operand == "http-method"
+    assert cond.values == ("GET", "HEAD")
+
+
+def test_policy_http_header_condition_with_name():
+    source = """\
+ltm policy /Common/p5 {
+    rules {
+        hdr_match {
+            ordinal 1
+            conditions {
+                0 {
+                    http-header
+                    name X-Forwarded-Proto
+                    values { https }
+                    request
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p5"].rules[0].conditions[0]
+    assert cond.operand == "http-header"
+    assert cond.name == "X-Forwarded-Proto"
+    assert cond.values == ("https",)
+
+
+def test_policy_ssl_extension_sni_condition():
+    source = """\
+ltm policy /Common/p6 {
+    rules {
+        sni_match {
+            ordinal 1
+            conditions {
+                0 {
+                    ssl-extension
+                    name server-name
+                    values { api.example.com }
+                    ssl-client-hello
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    cond = cfg.policies["/Common/p6"].rules[0].conditions[0]
+    assert cond.operand == "ssl-extension"
+    assert cond.name == "server-name"
+    assert cond.event == "ssl-client-hello"
+
+
+def test_policy_http_reply_redirect_action():
+    source = """\
+ltm policy /Common/p7 {
+    rules {
+        redir {
+            ordinal 1
+            actions {
+                0 {
+                    http-reply
+                    redirect
+                    location "https://www.example.com/welcome"
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    act = cfg.policies["/Common/p7"].rules[0].actions[0]
+    assert act.target == "http-reply"
+    assert act.verb == "redirect"
+    assert act.location == "https://www.example.com/welcome"
+
+
+def test_policy_http_uri_replace_path_action():
+    source = """\
+ltm policy /Common/p8 {
+    rules {
+        rewrite {
+            ordinal 1
+            actions {
+                0 {
+                    http-uri
+                    replace
+                    path "/v2/health"
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    act = cfg.policies["/Common/p8"].rules[0].actions[0]
+    assert act.target == "http-uri"
+    assert act.verb == "replace"
+    assert act.path == "/v2/health"
+
+
+def test_policy_http_header_insert_action():
+    source = """\
+ltm policy /Common/p9 {
+    rules {
+        ins {
+            ordinal 1
+            actions {
+                0 {
+                    http-header
+                    insert
+                    tm-name X-Forwarded-For
+                    value "client-ip"
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    act = cfg.policies["/Common/p9"].rules[0].actions[0]
+    assert act.target == "http-header"
+    assert act.verb == "insert"
+    assert act.name == "X-Forwarded-For"
+    assert act.value == "client-ip"
+
+
+def test_policy_http_header_remove_action():
+    source = """\
+ltm policy /Common/p10 {
+    rules {
+        rm {
+            ordinal 1
+            actions {
+                0 {
+                    http-header
+                    remove
+                    name Server
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    act = cfg.policies["/Common/p10"].rules[0].actions[0]
+    assert act.target == "http-header"
+    assert act.verb == "remove"
+    assert act.name == "Server"
+
+
+def test_policy_tcp_reset_action():
+    source = """\
+ltm policy /Common/p11 {
+    rules {
+        rst {
+            ordinal 1
+            actions {
+                0 {
+                    tcp
+                    reset
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    act = cfg.policies["/Common/p11"].rules[0].actions[0]
+    assert act.target == "tcp"
+    assert act.verb == "reset"
+
+
+def test_policy_rules_sorted_by_ordinal():
+    source = """\
+ltm policy /Common/p12 {
+    rules {
+        third  { ordinal 30 }
+        first  { ordinal 10 }
+        second { ordinal 20 }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    names = [r.name for r in cfg.policies["/Common/p12"].rules]
+    assert names == ["first", "second", "third"]
+
+
+def test_policy_multiple_conditions_and_actions_preserve_index_order():
+    source = """\
+ltm policy /Common/p13 {
+    rules {
+        multi {
+            ordinal 1
+            conditions {
+                1 {
+                    http-uri
+                    path
+                    starts-with
+                    values { /v1/ }
+                    request
+                }
+                0 {
+                    http-host
+                    host
+                    equals
+                    values { api.example.com }
+                    request
+                }
+            }
+            actions {
+                1 {
+                    http-header
+                    insert
+                    name X-Trace
+                    value "yes"
+                }
+                0 {
+                    forward
+                    select
+                    pool /Common/pool_api
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    rule = cfg.policies["/Common/p13"].rules[0]
+    assert [c.index for c in rule.conditions] == [0, 1]
+    assert rule.conditions[0].operand == "http-host"
+    assert rule.conditions[1].operand == "http-uri"
+    assert [a.index for a in rule.actions] == [0, 1]
+    assert rule.actions[0].target == "forward"
+    assert rule.actions[1].target == "http-header"
+
+
+def test_policy_strategy_default_when_missing():
+    source = """\
+ltm policy /Common/p14 {
+    rules { r { ordinal 1 } }
+}
+"""
+    cfg = parse_bigip_conf(source)
+    assert cfg.policies["/Common/p14"].strategy == "first-match"
+
+
+def test_policy_does_not_collide_with_policy_strategy_stanza():
+    """`ltm policy-strategy` is a different stanza type and must not match."""
+    source = """\
+ltm policy-strategy /Common/best-match {
+    operands {
+        0 { http-host }
+    }
+}
+ltm policy /Common/p15 {
+    rules { r { ordinal 1 } }
+    strategy first-match
+}
+"""
+    cfg = parse_bigip_conf(source)
+    assert "/Common/p15" in cfg.policies
+    assert "/Common/best-match" not in cfg.policies

--- a/tests/test_bigip_policy_eval.py
+++ b/tests/test_bigip_policy_eval.py
@@ -12,17 +12,13 @@ from core.bigip.policy_eval import RequestState, evaluate_policy
 
 
 def _policy(strategy: str, *rules: BigipPolicyRule) -> BigipPolicy:
-    return BigipPolicy(
-        name="p", full_path="/Common/p", strategy=strategy, rules=tuple(rules)
-    )
+    return BigipPolicy(name="p", full_path="/Common/p", strategy=strategy, rules=tuple(rules))
 
 
 def _rule(name: str, ordinal: int, *conds_and_acts) -> BigipPolicyRule:
     conds = tuple(c for c in conds_and_acts if isinstance(c, BigipPolicyCondition))
     acts = tuple(a for a in conds_and_acts if isinstance(a, BigipPolicyAction))
-    return BigipPolicyRule(
-        name=name, ordinal=ordinal, conditions=conds, actions=acts
-    )
+    return BigipPolicyRule(name=name, ordinal=ordinal, conditions=conds, actions=acts)
 
 
 def _cond(operand, **kw) -> BigipPolicyCondition:
@@ -91,11 +87,11 @@ def test_http_uri_default_selector_matches_full_uri():
 
 
 def test_http_method_equals():
-    r = _rule(
-        "r", 1, _cond("http-method", operator="equals", values=("POST",))
-    )
+    r = _rule("r", 1, _cond("http-method", operator="equals", values=("POST",)))
     assert evaluate_policy(_policy("first-match", r), RequestState(method="POST")).rules[0].matched
-    assert not evaluate_policy(_policy("first-match", r), RequestState(method="GET")).rules[0].matched
+    assert (
+        not evaluate_policy(_policy("first-match", r), RequestState(method="GET")).rules[0].matched
+    )
 
 
 def test_http_header_with_named_target():
@@ -169,9 +165,7 @@ def test_tcp_address_equals():
     r = _rule(
         "r",
         1,
-        _cond(
-            "tcp", selector="address", operator="equals", values=("203.0.113.7",)
-        ),
+        _cond("tcp", selector="address", operator="equals", values=("203.0.113.7",)),
     )
     state = RequestState(client_addr="203.0.113.7")
     assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
@@ -232,12 +226,12 @@ def test_exists_operator_matches_when_field_present():
         1,
         _cond("http-header", name="X-Trace", operator="exists"),
     )
-    assert evaluate_policy(
-        _policy("first-match", r), RequestState(headers={"x-trace": "y"})
-    ).rules[0].matched
-    assert not evaluate_policy(
-        _policy("first-match", r), RequestState(headers={})
-    ).rules[0].matched
+    assert (
+        evaluate_policy(_policy("first-match", r), RequestState(headers={"x-trace": "y"}))
+        .rules[0]
+        .matched
+    )
+    assert not evaluate_policy(_policy("first-match", r), RequestState(headers={})).rules[0].matched
 
 
 # Strategy
@@ -302,9 +296,7 @@ def test_first_match_falls_through_to_unconditional_rule():
         99,
         _act("http-reply", verb="redirect", location="https://www.example.com/"),
     )
-    d = evaluate_policy(
-        _policy("first-match", r1, r_default), RequestState(host="other.com")
-    )
+    d = evaluate_policy(_policy("first-match", r1, r_default), RequestState(host="other.com"))
     assert not d.rules[0].fired
     assert d.rules[1].fired
     assert d.rules[1].actions[0].value == "https://www.example.com/"
@@ -354,6 +346,74 @@ def test_action_trace_summarises_tcp_reset():
 
 
 # request_state_from_session
+
+
+def test_unsupported_operand_no_match_even_with_missing_operator():
+    """`geoip missing` (or any unsupported-operand `missing`) must NOT fire.
+
+    Without this guard, `_extract_actual` returns `actual=""` for an
+    unsupported operand and `not bool("")` would be True, letting the
+    rule fire.  The contract is "unsupported operands no-match with a
+    note" — covered by the `unevaluable` flag from `_extract_actual`.
+    """
+    r = _rule("r", 1, _cond("geoip", selector="continent", operator="missing", values=()))
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert not d.rules[0].matched
+    assert not d.rules[0].fired
+    assert "not supported in v1" in d.rules[0].conditions[0].note
+
+
+def test_unsupported_ssl_extension_no_match_with_exists():
+    r = _rule("r", 1, _cond("ssl-extension", name="alpn", operator="exists"))
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert not d.rules[0].matched
+    assert "not supported in v1" in d.rules[0].conditions[0].note
+
+
+def test_http_header_exists_distinguishes_present_empty_from_absent():
+    """A header with explicit empty value is *present*; an absent header is missing."""
+    r_exists = _rule("r", 1, _cond("http-header", name="X-Foo", operator="exists"))
+    r_missing = _rule("r", 1, _cond("http-header", name="X-Foo", operator="missing"))
+
+    # Header present but value is empty: exists matches, missing does not.
+    state_present_empty = RequestState(headers={"x-foo": ""})
+    assert evaluate_policy(_policy("first-match", r_exists), state_present_empty).rules[0].matched
+    assert (
+        not evaluate_policy(_policy("first-match", r_missing), state_present_empty).rules[0].matched
+    )
+
+    # Header absent: missing matches, exists does not.
+    state_absent = RequestState(headers={})
+    assert not evaluate_policy(_policy("first-match", r_exists), state_absent).rules[0].matched
+    assert evaluate_policy(_policy("first-match", r_missing), state_absent).rules[0].matched
+
+
+def test_best_match_strategy_reports_as_approx():
+    """`best-match` should be surfaced as `best-match-approx` so consumers warn."""
+    r1 = _rule(
+        "more_specific",
+        1,
+        _cond("http-host", operator="equals", values=("a.com",)),
+        _cond("http-uri", selector="path", operator="starts-with", values=("/v1/",)),
+    )
+    r2 = _rule(
+        "less_specific",
+        2,
+        _cond("http-host", operator="equals", values=("a.com",)),
+    )
+    d = evaluate_policy(
+        _policy("best-match", r1, r2),
+        RequestState(host="a.com", path="/v1/health"),
+    )
+    assert d.strategy == "best-match-approx"
+    # The 2-condition rule should win (more conditions => better score).
+    assert [r.fired for r in d.rules] == [True, False]
+
+
+def test_unknown_strategy_falls_through_to_best_match_approx():
+    r = _rule("r", 1, _cond("http-host", operator="equals", values=("a.com",)))
+    d = evaluate_policy(_policy("custom-strategy-name", r), RequestState(host="a.com"))
+    assert d.strategy == "best-match-approx"
 
 
 def test_request_state_from_session_lowercases_headers():

--- a/tests/test_bigip_policy_eval.py
+++ b/tests/test_bigip_policy_eval.py
@@ -1,0 +1,389 @@
+"""Tests for the LTM policy evaluator."""
+
+from __future__ import annotations
+
+from core.bigip.model import (
+    BigipPolicy,
+    BigipPolicyAction,
+    BigipPolicyCondition,
+    BigipPolicyRule,
+)
+from core.bigip.policy_eval import RequestState, evaluate_policy
+
+
+def _policy(strategy: str, *rules: BigipPolicyRule) -> BigipPolicy:
+    return BigipPolicy(
+        name="p", full_path="/Common/p", strategy=strategy, rules=tuple(rules)
+    )
+
+
+def _rule(name: str, ordinal: int, *conds_and_acts) -> BigipPolicyRule:
+    conds = tuple(c for c in conds_and_acts if isinstance(c, BigipPolicyCondition))
+    acts = tuple(a for a in conds_and_acts if isinstance(a, BigipPolicyAction))
+    return BigipPolicyRule(
+        name=name, ordinal=ordinal, conditions=conds, actions=acts
+    )
+
+
+def _cond(operand, **kw) -> BigipPolicyCondition:
+    kw.setdefault("index", 0)
+    return BigipPolicyCondition(operand=operand, **kw)
+
+
+def _act(target, **kw) -> BigipPolicyAction:
+    kw.setdefault("index", 0)
+    return BigipPolicyAction(target=target, **kw)
+
+
+# Operands
+
+
+def test_http_host_equals_match():
+    r = _rule(
+        "r",
+        1,
+        _cond("http-host", selector="host", operator="equals", values=("api.example.com",)),
+        _act("forward", verb="select", pool="/Common/pool_api"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState(host="api.example.com"))
+    assert d.rules[0].matched
+    assert d.rules[0].fired
+    assert d.rules[0].actions[0].value == "/Common/pool_api"
+
+
+def test_http_host_equals_miss():
+    r = _rule(
+        "r",
+        1,
+        _cond("http-host", selector="host", operator="equals", values=("api.example.com",)),
+        _act("forward", verb="select", pool="/Common/pool_api"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState(host="other.com"))
+    assert not d.rules[0].matched
+    assert not d.rules[0].fired
+
+
+def test_http_uri_path_starts_with():
+    r = _rule(
+        "r",
+        1,
+        _cond("http-uri", selector="path", operator="starts-with", values=("/v1/",)),
+        _act("forward", verb="select", pool="/Common/pool_v1"),
+    )
+    state = RequestState(uri="/v1/health", path="/v1/health")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].fired
+
+
+def test_http_uri_query_contains():
+    r = _rule(
+        "r",
+        1,
+        _cond("http-uri", selector="query", operator="contains", values=("debug=1",)),
+    )
+    state = RequestState(uri="/x?debug=1&u=2", query="debug=1&u=2")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_http_uri_default_selector_matches_full_uri():
+    r = _rule("r", 1, _cond("http-uri", operator="ends-with", values=(".jpg",)))
+    state = RequestState(uri="/img/foo.jpg")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_http_method_equals():
+    r = _rule(
+        "r", 1, _cond("http-method", operator="equals", values=("POST",))
+    )
+    assert evaluate_policy(_policy("first-match", r), RequestState(method="POST")).rules[0].matched
+    assert not evaluate_policy(_policy("first-match", r), RequestState(method="GET")).rules[0].matched
+
+
+def test_http_header_with_named_target():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "http-header",
+            name="X-Forwarded-Proto",
+            operator="equals",
+            values=("https",),
+        ),
+    )
+    state = RequestState(headers={"x-forwarded-proto": "https"})
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_http_header_missing_when_not_in_capture():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "http-header",
+            name="X-Custom",
+            operator="equals",
+            values=("y",),
+        ),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState(headers={}))
+    assert not d.rules[0].matched
+    assert "not seen in capture" in d.rules[0].conditions[0].note
+
+
+def test_http_header_no_name_is_unevaluable():
+    r = _rule(
+        "r",
+        1,
+        _cond("http-header", operator="equals", values=("x",)),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState(headers={"x": "y"}))
+    assert not d.rules[0].matched
+    assert "no `name`" in d.rules[0].conditions[0].note
+
+
+def test_ssl_extension_sni_equals():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "ssl-extension",
+            name="server-name",
+            operator="equals",
+            values=("api.example.com",),
+        ),
+    )
+    state = RequestState(sni="api.example.com")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_ssl_extension_other_name_unsupported_in_v1():
+    r = _rule(
+        "r",
+        1,
+        _cond("ssl-extension", name="alpn", operator="equals", values=("h2",)),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert "not supported in v1" in d.rules[0].conditions[0].note
+
+
+def test_tcp_address_equals():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "tcp", selector="address", operator="equals", values=("203.0.113.7",)
+        ),
+    )
+    state = RequestState(client_addr="203.0.113.7")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+# Operators
+
+
+def test_negate_inverts_match():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "http-uri",
+            selector="path",
+            operator="starts-with",
+            values=("/internal/",),
+            negate=True,
+        ),
+    )
+    state = RequestState(uri="/api/x", path="/api/x")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_case_insensitive_equals():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "http-host",
+            operator="equals",
+            values=("API.EXAMPLE.COM",),
+            case_insensitive=True,
+        ),
+    )
+    state = RequestState(host="api.example.com")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_matches_uses_regex():
+    r = _rule(
+        "r",
+        1,
+        _cond(
+            "http-uri",
+            selector="path",
+            operator="matches",
+            values=(r"^/v\d+/health$",),
+        ),
+    )
+    state = RequestState(path="/v3/health")
+    assert evaluate_policy(_policy("first-match", r), state).rules[0].matched
+
+
+def test_exists_operator_matches_when_field_present():
+    r = _rule(
+        "r",
+        1,
+        _cond("http-header", name="X-Trace", operator="exists"),
+    )
+    assert evaluate_policy(
+        _policy("first-match", r), RequestState(headers={"x-trace": "y"})
+    ).rules[0].matched
+    assert not evaluate_policy(
+        _policy("first-match", r), RequestState(headers={})
+    ).rules[0].matched
+
+
+# Strategy
+
+
+def test_first_match_fires_only_first_matched_rule():
+    r1 = _rule(
+        "first",
+        1,
+        _cond("http-host", operator="equals", values=("a.com",)),
+        _act("forward", verb="select", pool="/Common/p1"),
+    )
+    r2 = _rule(
+        "second",
+        2,
+        _cond("http-host", operator="equals", values=("a.com",)),
+        _act("forward", verb="select", pool="/Common/p2"),
+    )
+    d = evaluate_policy(_policy("first-match", r1, r2), RequestState(host="a.com"))
+    assert [r.fired for r in d.rules] == [True, False]
+    assert d.rules[0].actions[0].value == "/Common/p1"
+
+
+def test_all_match_fires_every_matched_rule():
+    r1 = _rule(
+        "first",
+        1,
+        _cond("http-host", operator="equals", values=("a.com",)),
+        _act("http-header", verb="insert", name="X-A", value="1"),
+    )
+    r2 = _rule(
+        "second",
+        2,
+        _cond("http-host", operator="equals", values=("a.com",)),
+        _act("http-header", verb="insert", name="X-B", value="2"),
+    )
+    d = evaluate_policy(_policy("all-match", r1, r2), RequestState(host="a.com"))
+    assert [r.fired for r in d.rules] == [True, True]
+
+
+def test_unconditional_rule_matches_with_no_conditions():
+    """A rule with zero conditions is always matched (TMSH default-rule semantics)."""
+    r = _rule(
+        "default",
+        99,
+        _act("http-reply", verb="redirect", location="https://x/"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert d.rules[0].matched
+    assert d.rules[0].fired
+
+
+def test_first_match_falls_through_to_unconditional_rule():
+    r1 = _rule(
+        "specific",
+        1,
+        _cond("http-host", operator="equals", values=("api.example.com",)),
+        _act("forward", verb="select", pool="/Common/pool_api"),
+    )
+    r_default = _rule(
+        "default",
+        99,
+        _act("http-reply", verb="redirect", location="https://www.example.com/"),
+    )
+    d = evaluate_policy(
+        _policy("first-match", r1, r_default), RequestState(host="other.com")
+    )
+    assert not d.rules[0].fired
+    assert d.rules[1].fired
+    assert d.rules[1].actions[0].value == "https://www.example.com/"
+
+
+# Action summary values
+
+
+def test_action_trace_summarises_http_uri_replace():
+    r = _rule(
+        "r",
+        1,
+        _act("http-uri", verb="replace", path="/v2/health"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert d.rules[0].actions[0].value == "path=/v2/health"
+
+
+def test_action_trace_summarises_header_insert():
+    r = _rule(
+        "r",
+        1,
+        _act("http-header", verb="insert", name="X-A", value="1"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert d.rules[0].actions[0].value == "X-A=1"
+
+
+def test_action_trace_summarises_header_remove():
+    r = _rule(
+        "r",
+        1,
+        _act("http-header", verb="remove", name="Server"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert d.rules[0].actions[0].value == "Server"
+
+
+def test_action_trace_summarises_tcp_reset():
+    r = _rule(
+        "r",
+        1,
+        _act("tcp", verb="reset"),
+    )
+    d = evaluate_policy(_policy("first-match", r), RequestState())
+    assert d.rules[0].actions[0].value == "RST"
+
+
+# request_state_from_session
+
+
+def test_request_state_from_session_lowercases_headers():
+    from core.bigip.policy_eval import request_state_from_session
+
+    class _FakeFlow:
+        http_method = "GET"
+        http_host = "api.example.com"
+        http_uri = "/v1/health?debug=1"
+        http_path = "/v1/health"
+        http_query = "debug=1"
+        http_request_headers = {"X-Forwarded-Proto": "https", "Host": "api.example.com"}
+        tls_sni = "api.example.com"
+        tls_chosen_version = "TLS1.3"
+        tls_version = ""
+        src_ip = "203.0.113.7"
+        dst_ip = "10.0.0.1"
+
+    class _FakeFront:
+        client = _FakeFlow()
+
+    class _FakeSession:
+        front = _FakeFront()
+
+    s = request_state_from_session(_FakeSession())
+    assert s.method == "GET"
+    assert s.host == "api.example.com"
+    assert s.path == "/v1/health"
+    assert s.query == "debug=1"
+    assert s.sni == "api.example.com"
+    assert s.tls_version == "TLS1.3"
+    assert s.headers["x-forwarded-proto"] == "https"
+    assert s.client_addr == "203.0.113.7"

--- a/tests/test_f5_explain_flow.py
+++ b/tests/test_f5_explain_flow.py
@@ -347,9 +347,7 @@ def _http_get_packet(
     host: str,
     path: str,
 ) -> bytes:
-    payload = (
-        f"GET {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: tester\r\n\r\n".encode()
-    )
+    payload = f"GET {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: tester\r\n\r\n".encode()
     return _build_packet(src, dst, sp, dp, syn=False, payload=payload)
 
 
@@ -444,6 +442,56 @@ def test_explain_flow_policy_decisions_in_mcp_dict(tmp_path):
     assert fired["rule"] == "api_route"
     assert fired["actions"][0]["value"] == "/Common/pool_api"
     assert any(c["field"] == "http-host.host" for c in fired["matched_on"])
+
+
+def test_compact_policy_decision_omits_unmatched_conditions():
+    """`matched_on` in the compact MCP shape must list only conditions that matched."""
+    from core.bigip.explain_flow import _compact_policy_decision
+    from core.bigip.policy_eval import (
+        ConditionTrace,
+        PolicyDecision,
+        RuleDecision,
+    )
+
+    pd = PolicyDecision(
+        policy="/Common/p",
+        strategy="first-match",
+        rules=(
+            RuleDecision(
+                rule="r",
+                ordinal=1,
+                matched=True,
+                fired=True,
+                conditions=(
+                    # Unmatched condition must be hidden from `matched_on`.
+                    ConditionTrace(
+                        operand="http-host",
+                        selector="host",
+                        operator="equals",
+                        expected=("api.example.com",),
+                        actual="other.com",
+                        matched=False,
+                        note="",
+                    ),
+                    ConditionTrace(
+                        operand="http-method",
+                        selector="",
+                        operator="equals",
+                        expected=("GET",),
+                        actual="GET",
+                        matched=True,
+                        note="",
+                    ),
+                ),
+                actions=(),
+            ),
+        ),
+    )
+    out = _compact_policy_decision(pd)
+    assert len(out["fired"]) == 1
+    matched_on = out["fired"][0]["matched_on"]
+    assert len(matched_on) == 1
+    assert matched_on[0]["field"] == "http-method"
 
 
 def test_explain_flow_policy_decisions_text_report_mentions_decision(tmp_path):

--- a/tests/test_f5_explain_flow.py
+++ b/tests/test_f5_explain_flow.py
@@ -268,6 +268,210 @@ def test_explain_flow_cli_json(tmp_path, capsys):
     assert data["sessions"][0]["matched_vs"] == "/Common/vs_app"
 
 
+_CONF_WITH_POLICY = """\
+ltm virtual /Common/vs_policy {
+    destination /Common/5.6.7.8:80
+    pool /Common/pool_default
+    profiles {
+        /Common/tcp { }
+        /Common/http { }
+    }
+    policies {
+        /Common/policy_api_routing
+    }
+}
+ltm pool /Common/pool_default {
+    members {
+        /Common/10.0.0.1:80 { }
+    }
+}
+ltm pool /Common/pool_api {
+    members {
+        /Common/10.0.0.20:8080 { }
+    }
+}
+ltm profile tcp /Common/tcp { }
+ltm profile http /Common/http { }
+ltm policy /Common/policy_api_routing {
+    requires { http }
+    controls { forwarding }
+    rules {
+        api_route {
+            ordinal 1
+            conditions {
+                0 {
+                    http-host
+                    host
+                    equals
+                    values { api.example.com }
+                    request
+                }
+                1 {
+                    http-uri
+                    path
+                    starts-with
+                    values { /v1/ }
+                    request
+                }
+            }
+            actions {
+                0 {
+                    forward
+                    select
+                    pool /Common/pool_api
+                }
+            }
+        }
+        default_redirect {
+            ordinal 99
+            actions {
+                0 {
+                    http-reply
+                    redirect
+                    location "https://www.example.com/"
+                }
+            }
+        }
+    }
+    strategy first-match
+}
+"""
+
+
+def _http_get_packet(
+    src: bytes,
+    dst: bytes,
+    sp: int,
+    dp: int,
+    *,
+    host: str,
+    path: str,
+) -> bytes:
+    payload = (
+        f"GET {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: tester\r\n\r\n".encode()
+    )
+    return _build_packet(src, dst, sp, dp, syn=False, payload=payload)
+
+
+def test_explain_flow_evaluates_policy_when_request_matches(tmp_path):
+    """Policy whose conditions match the captured request should fire its action."""
+    cfg = parse_bigip_conf(_CONF_WITH_POLICY)
+    pcap = _build_pcap(
+        [
+            _build_packet(b"\xcb\x00\x71\x07", b"\x05\x06\x07\x08", 51422, 80, syn=True),
+            _http_get_packet(
+                b"\xcb\x00\x71\x07",
+                b"\x05\x06\x07\x08",
+                51422,
+                80,
+                host="api.example.com",
+                path="/v1/health",
+            ),
+        ]
+    )
+    p = tmp_path / "in.pcap"
+    p.write_bytes(pcap)
+
+    report = compute_explain_flow(p, {"u://x": cfg})
+    assert report.matched_count == 1
+    se = report.sessions[0]
+    assert se.matched_vs == "/Common/vs_policy"
+    assert se.ltm_policies == ("/Common/policy_api_routing",)
+    assert len(se.policy_decisions) == 1
+    pd = se.policy_decisions[0]
+    assert pd.policy == "/Common/policy_api_routing"
+    fired = [r for r in pd.rules if r.fired]
+    assert [r.rule for r in fired] == ["api_route"]
+    assert fired[0].actions[0].target == "forward"
+    assert fired[0].actions[0].value == "/Common/pool_api"
+
+
+def test_explain_flow_falls_through_to_default_when_request_misses(tmp_path):
+    """Policy whose specific rule misses should fall through to the unconditional default."""
+    cfg = parse_bigip_conf(_CONF_WITH_POLICY)
+    pcap = _build_pcap(
+        [
+            _build_packet(b"\xcb\x00\x71\x07", b"\x05\x06\x07\x08", 51423, 80, syn=True),
+            _http_get_packet(
+                b"\xcb\x00\x71\x07",
+                b"\x05\x06\x07\x08",
+                51423,
+                80,
+                host="other.example.com",
+                path="/v1/health",
+            ),
+        ]
+    )
+    p = tmp_path / "in.pcap"
+    p.write_bytes(pcap)
+
+    report = compute_explain_flow(p, {"u://x": cfg})
+    se = report.sessions[0]
+    pd = se.policy_decisions[0]
+    fired = [r for r in pd.rules if r.fired]
+    assert [r.rule for r in fired] == ["default_redirect"]
+    assert fired[0].actions[0].target == "http-reply"
+    assert fired[0].actions[0].value == "https://www.example.com/"
+
+
+def test_explain_flow_policy_decisions_in_mcp_dict(tmp_path):
+    cfg = parse_bigip_conf(_CONF_WITH_POLICY)
+    pcap = _build_pcap(
+        [
+            _build_packet(b"\xcb\x00\x71\x07", b"\x05\x06\x07\x08", 51424, 80, syn=True),
+            _http_get_packet(
+                b"\xcb\x00\x71\x07",
+                b"\x05\x06\x07\x08",
+                51424,
+                80,
+                host="api.example.com",
+                path="/v1/health",
+            ),
+        ]
+    )
+    p = tmp_path / "in.pcap"
+    p.write_bytes(pcap)
+
+    report = compute_explain_flow(p, {"u://x": cfg})
+    mcp = report_to_mcp_dict(report)
+    session = mcp["sessions"][0]
+    assert "policy_decisions" in session
+    pd = session["policy_decisions"][0]
+    assert pd["policy"] == "/Common/policy_api_routing"
+    assert pd["strategy"] == "first-match"
+    assert len(pd["fired"]) == 1
+    fired = pd["fired"][0]
+    assert fired["rule"] == "api_route"
+    assert fired["actions"][0]["value"] == "/Common/pool_api"
+    assert any(c["field"] == "http-host.host" for c in fired["matched_on"])
+
+
+def test_explain_flow_policy_decisions_text_report_mentions_decision(tmp_path):
+    cfg = parse_bigip_conf(_CONF_WITH_POLICY)
+    pcap = _build_pcap(
+        [
+            _build_packet(b"\xcb\x00\x71\x07", b"\x05\x06\x07\x08", 51425, 80, syn=True),
+            _http_get_packet(
+                b"\xcb\x00\x71\x07",
+                b"\x05\x06\x07\x08",
+                51425,
+                80,
+                host="api.example.com",
+                path="/v1/health",
+            ),
+        ]
+    )
+    p = tmp_path / "in.pcap"
+    p.write_bytes(pcap)
+
+    report = compute_explain_flow(p, {"u://x": cfg})
+    text = report.text_report
+    assert "ltm policy decisions" in text
+    assert "/Common/policy_api_routing" in text
+    assert "api_route" in text and "FIRED" in text
+    assert "/Common/pool_api" in text
+
+
 def test_extract_peer_tuple_from_trailer_legacy():
     """Legacy HIGH v0 trailer yields a peer 5-tuple."""
     trailer = _legacy_high_trailer(b"\x09\x09\x09\x09", b"\x0a\x0a\x0a\x0a", 12345, 8080)


### PR DESCRIPTION
## Summary

- Added parsing support for F5 BIG-IP `ltm policy` configuration blocks, including rules, conditions, and actions
- Implemented a policy evaluator (`policy_eval.py`) that determines which rules match and fire based on captured request state
- Integrated policy evaluation into explain-flow to show which policy rules matched and what actions they would execute
- Added comprehensive test coverage for policy parsing and evaluation across various condition/action types

## Changes

### Parser (`core/bigip/parser.py`)
- Added `_parse_policy()` to parse `ltm policy` blocks with strategy, requires, controls, and rules
- Added `_parse_policy_rule()` to parse individual rules with ordinal, conditions, and actions
- Added `_parse_policy_condition()` to parse condition blocks with operand/selector/operator classification
- Added `_parse_policy_action()` to parse action blocks with target/verb classification
- Defined vocabularies for operands, selectors, operators, events, action targets, and verbs
- Integrated policy parsing into the main config parser

### Model (`core/bigip/model.py`)
- Added `BigipPolicyCondition` dataclass for condition representation
- Added `BigipPolicyAction` dataclass for action representation
- Added `BigipPolicyRule` dataclass for rule representation
- Added `BigipPolicy` dataclass for policy representation with strategy and rules

### Evaluator (`core/bigip/policy_eval.py`)
- Implemented `evaluate_policy()` to evaluate policies against captured request state
- Supports operands: `http-host`, `http-uri` (with selectors), `http-method`, `http-header`, `ssl-extension`, `tcp`
- Supports operators: `equals`, `starts-with`, `ends-with`, `contains`, `matches`, `exists`, `missing`
- Supports modifiers: `negate`, `case-insensitive`
- Supports strategies: `first-match`, `all-match`, `best-match` (approximation)
- Supports actions: `forward select pool`, `http-reply redirect`, `http-uri replace`, `http-header insert/remove`, `tcp reset`
- Added `RequestState` to capture request data from sessions
- Added trace classes (`ConditionTrace`, `ActionTrace`, `RuleDecision`, `PolicyDecision`) for detailed decision reporting

### Integration (`core/bigip/explain_flow.py`)
- Added `_evaluate_attached_policies()` to evaluate policies attached to matched virtual servers
- Integrated policy decisions into `SessionExplain` output
- Added policy decision formatting to text report output
- Added policy decisions to MCP dict serialization

### Tests
- Added `tests/test_bigip_parser_policy.py` with 14 tests covering:
  - Minimal policy parsing
  - Strategy handling (including path stripping)
  - Various condition types (http-host, http-uri, http-method, http-header, ssl-extension)
  - Various action types (forward, http-reply, http-uri, http-header, tcp)
  - Rule ordering by ordinal
  - Condition/action index preservation
  - Default strategy handling
  - Collision avoidance with `policy-strategy` stanza

- Added `tests/test_bigip_policy_eval.py` with 30 tests covering:
  - Operand evaluation (http-host, http-uri, http-method, http-header, ssl-extension, tcp)
  - Operator evaluation (equals, starts-with, contains, matches, exists)
  - Modifier evaluation (negate, case-insensitive)
  - Strategy evaluation (first-match, all-match, best-match)
  - Unconditional rules
  - Action trace summarization
  - Error handling for unsupported/missing data

- Added integration tests in `tests/test_f5_explain_flow.py`:
  - Policy evaluation when request matches conditions
  - Fall-through to default rule when specific rule misses
  - Policy decisions in MCP dict output

## Validation

- [x] Added 44 new unit tests covering parser, evaluator, and integration
- [x] All tests pass locally
- [x] Existing explain-flow tests

https://claude.ai/code/session_01Ff8JeXgQLmZyL2wTBKEgrw