### PR TITLE
Add f5 irule format/minify/context verbs and deeper static analysis

### DIFF
--- a/ai/mcp/tcl_mcp_server.py
+++ b/ai/mcp/tcl_mcp_server.py
@@ -2164,8 +2164,6 @@ def _tool_irule_with_context(
 ) -> str:
     _configure_dialect("f5-irules")
 
-    from pathlib import Path as _Path
-
     from ai.shared.irule_context import (
         build_irule_context,
         context_bundle_to_dict,
@@ -2173,23 +2171,37 @@ def _tool_irule_with_context(
     )
     from core.bigip.lint import _merge_configs
     from core.bigip.parser import parse_bigip_conf
+    from explorer.verbs.f5._paths import load_irule_inputs
+
+    paths = list(config_paths or [])
+    if not config_text and not paths:
+        return json.dumps({"error": "no input config provided; pass config_text or config_paths"})
 
     sources: dict[str, str] = {}
-    configs = {}
+    configs: dict = {}
+
     if config_text:
+        # Inline config_text is a *full bigip.conf* (or SCF) — parse it
+        # directly so the original ``ltm rule`` stanzas survive.  The
+        # loader's --source path is for raw iRule bodies, which is the
+        # opposite shape.
         sources["inline://config"] = config_text
         configs["inline://config"] = parse_bigip_conf(config_text)
-    for path_str in config_paths or []:
-        p = _Path(path_str).expanduser().resolve()
-        text = p.read_text(encoding="utf-8", errors="replace")
-        uri = p.as_uri()
-        sources[uri] = text
-        configs[uri] = parse_bigip_conf(text)
+
+    if paths:
+        # Funnel files through the same loader the f5 CLI uses so UCS
+        # archives, SCF split-files, and standalone .irule files all
+        # resolve consistently — and the source-slice keys match the
+        # config keys for verbatim quoting.
+        try:
+            _inputs, file_configs, file_sources = load_irule_inputs(paths)
+        except (OSError, ValueError) as exc:
+            return json.dumps({"error": str(exc)})
+        configs.update(file_configs)
+        sources.update(file_sources)
 
     if not configs:
-        return json.dumps(
-            {"error": "no input config provided; pass config_text or config_paths"}
-        )
+        return json.dumps({"error": "no parseable BIG-IP config in input"})
 
     merged = _merge_configs(configs) if len(configs) > 1 else next(iter(configs.values()))
 
@@ -2217,9 +2229,7 @@ def _tool_irule_with_context(
             config_origin=origin,
         )
         if format == "text":
-            bundles_payload.append(
-                {"rule": path, "text": context_bundle_to_text(bundle)}
-            )
+            bundles_payload.append({"rule": path, "text": context_bundle_to_text(bundle)})
         else:
             bundles_payload.append(context_bundle_to_dict(bundle))
 

--- a/ai/mcp/tcl_mcp_server.py
+++ b/ai/mcp/tcl_mcp_server.py
@@ -2108,6 +2108,124 @@ def _tool_unminify_error(
     )
 
 
+@tool(
+    "irule_with_context",
+    "Bundle an iRule with the BIG-IP objects it references (pools, data groups, "
+    "persistence profiles, SNAT pools, profiles, monitors, nodes, called rules) "
+    "from a surrounding bigip.conf / SCF / UCS.  This is what an agent should "
+    "call before reasoning about an iRule end-to-end — the returned bundle "
+    "carries the rule body plus every referenced object's source so the "
+    "agent does not have to hand-walk the config.",
+    params={
+        "rule_path": {
+            **_STR,
+            "description": (
+                "Full BIG-IP path of the iRule (e.g. ``/Common/foo``).  "
+                "If empty, every iRule in the supplied config is bundled."
+            ),
+        },
+        "config_text": {
+            **_STR,
+            "description": (
+                "Inline bigip.conf / SCF source.  Provide either this or "
+                "``config_paths``.  Required for iRules that reference "
+                "objects defined elsewhere in the config."
+            ),
+        },
+        "config_paths": {
+            "type": "array",
+            "items": _STR,
+            "description": (
+                "Paths to bigip.conf / SCF / UCS files (alternative to "
+                "``config_text``).  All files are merged so cross-file "
+                "references resolve."
+            ),
+        },
+        "format": {
+            **_STR,
+            "description": "Output format: 'json' (default) or 'text' (Tcl-flavoured).",
+        },
+        "transitive": {
+            "type": "boolean",
+            "description": (
+                "When true (default) follow one hop deeper: pool members "
+                "→ nodes; pool monitor → monitor object."
+            ),
+        },
+    },
+    required=[],
+)
+def _tool_irule_with_context(
+    rule_path: str = "",
+    config_text: str = "",
+    config_paths: list | None = None,
+    format: str = "json",
+    transitive: bool = True,
+) -> str:
+    _configure_dialect("f5-irules")
+
+    from pathlib import Path as _Path
+
+    from ai.shared.irule_context import (
+        build_irule_context,
+        context_bundle_to_dict,
+        context_bundle_to_text,
+    )
+    from core.bigip.lint import _merge_configs
+    from core.bigip.parser import parse_bigip_conf
+
+    sources: dict[str, str] = {}
+    configs = {}
+    if config_text:
+        sources["inline://config"] = config_text
+        configs["inline://config"] = parse_bigip_conf(config_text)
+    for path_str in config_paths or []:
+        p = _Path(path_str).expanduser().resolve()
+        text = p.read_text(encoding="utf-8", errors="replace")
+        uri = p.as_uri()
+        sources[uri] = text
+        configs[uri] = parse_bigip_conf(text)
+
+    if not configs:
+        return json.dumps(
+            {"error": "no input config provided; pass config_text or config_paths"}
+        )
+
+    merged = _merge_configs(configs) if len(configs) > 1 else next(iter(configs.values()))
+
+    if rule_path:
+        if rule_path not in merged.rules:
+            return json.dumps({"error": f"rule not found: {rule_path}"})
+        targets = [(rule_path, merged.rules[rule_path])]
+    else:
+        targets = list(merged.rules.items())
+
+    bundles_payload = []
+    for path, rule in targets:
+        # Find the origin URI of this rule for source-slicing.
+        origin = None
+        for uri, cfg in configs.items():
+            if path in cfg.rules:
+                origin = uri
+                break
+
+        bundle = build_irule_context(
+            rule,
+            merged,
+            transitive=transitive,
+            sources=sources or None,
+            config_origin=origin,
+        )
+        if format == "text":
+            bundles_payload.append(
+                {"rule": path, "text": context_bundle_to_text(bundle)}
+            )
+        else:
+            bundles_payload.append(context_bundle_to_dict(bundle))
+
+    return json.dumps({"format": format, "bundles": bundles_payload}, indent=2)
+
+
 # Entry point
 
 if __name__ == "__main__":

--- a/ai/shared/irule_context.py
+++ b/ai/shared/irule_context.py
@@ -329,7 +329,9 @@ def _summarise_snat_pool(s: BigipSnatPool) -> dict[str, Any]:
 
 
 def _summarise_profile(p: BigipProfile) -> dict[str, Any]:
-    profile_type = p.profile_type.name.lower() if hasattr(p.profile_type, "name") else str(p.profile_type)
+    profile_type = (
+        p.profile_type.name.lower() if hasattr(p.profile_type, "name") else str(p.profile_type)
+    )
     return {"fullPath": p.full_path, "type": profile_type}
 
 
@@ -415,7 +417,9 @@ def _render_snat_pool_text(s: BigipSnatPool) -> str:
 
 
 def _render_profile_text(p: BigipProfile) -> str:
-    profile_type = p.profile_type.name.lower() if hasattr(p.profile_type, "name") else str(p.profile_type)
+    profile_type = (
+        p.profile_type.name.lower() if hasattr(p.profile_type, "name") else str(p.profile_type)
+    )
     return f"ltm profile {profile_type} {p.full_path} {{ }}\n"
 
 
@@ -464,7 +468,10 @@ def context_bundle_to_text(bundle: IruleContextBundle) -> str:
     sections: list[tuple[str, list[tuple[str, str]]]] = [
         (
             "pool",
-            [(p.full_path, _render_object_text(bundle, p, _render_pool_text(p))) for p in bundle.pools.values()],
+            [
+                (p.full_path, _render_object_text(bundle, p, _render_pool_text(p)))
+                for p in bundle.pools.values()
+            ],
         ),
         (
             "data-group",

--- a/ai/shared/irule_context.py
+++ b/ai/shared/irule_context.py
@@ -246,7 +246,13 @@ def build_irule_context(
                 unresolved.setdefault(kind, []).append(ref.name)
         elif kind == "rule":
             resolved = cfg.resolve_rule(ref.name)
-            if resolved and resolved in cfg.rules and resolved != rule.full_path:
+            if resolved == rule.full_path:
+                # Recursive / self-reference (e.g. ``call rule …``
+                # invoking the current rule).  The rule body is
+                # already part of the bundle; don't record it as
+                # unresolved.
+                continue
+            if resolved and resolved in cfg.rules:
                 obj = cfg.rules[resolved]
                 rules[resolved] = obj
                 _record_slice(obj)

--- a/ai/shared/irule_context.py
+++ b/ai/shared/irule_context.py
@@ -1,0 +1,537 @@
+"""Build a packaged "iRule + referenced-object" context bundle.
+
+When an AI agent reasons about an iRule it almost always needs the
+surrounding BIG-IP context: the pools the rule selects, the data
+groups it matches against, the persistence profiles it pins on, the
+SNAT pools it forwards through, etc.  Without that context the agent
+either has to be force-fed the entire bigip.conf or guess.
+
+This module assembles a focused bundle: the iRule body plus every
+BIG-IP object the rule references (resolved against the surrounding
+:class:`~core.bigip.model.BigipConfig`), with optional one-hop
+transitive expansion (pool → members → nodes; pool → monitor;
+persistence → profile chain).
+
+The bundle is consumable as either:
+
+- structured JSON (:func:`context_bundle_to_dict`) for MCP tools and
+  programmatic consumers, or
+- a Tcl-flavoured text block (:func:`context_bundle_to_text`) ready
+  to drop into an LLM prompt.
+
+Both renderings preserve the original config text when ``sources`` is
+provided, so what the LLM sees matches the operator's actual
+``bigip.conf``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.bigip.irules_refs import extract_irules_object_references
+from core.bigip.model import (
+    BigipConfig,
+    BigipDataGroup,
+    BigipMonitor,
+    BigipNode,
+    BigipPersistence,
+    BigipPool,
+    BigipProfile,
+    BigipRule,
+    BigipSnatPool,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class IruleContextBundle:
+    """A resolved iRule plus every BIG-IP object it references.
+
+    *unresolved* is keyed by reference kind (``"pool"``,
+    ``"data-group"``, …) and contains the names that did not resolve
+    against the surrounding config — surface these to the consumer.
+    *source_slices* maps each referenced object's full path to the
+    original config text that defined it, when the source map was
+    supplied to :func:`build_irule_context`.
+    """
+
+    rule: BigipRule
+    pools: dict[str, BigipPool] = field(default_factory=dict)
+    data_groups: dict[str, BigipDataGroup] = field(default_factory=dict)
+    persistence: dict[str, BigipPersistence] = field(default_factory=dict)
+    snat_pools: dict[str, BigipSnatPool] = field(default_factory=dict)
+    profiles: dict[str, BigipProfile] = field(default_factory=dict)
+    monitors: dict[str, BigipMonitor] = field(default_factory=dict)
+    nodes: dict[str, BigipNode] = field(default_factory=dict)
+    rules: dict[str, BigipRule] = field(default_factory=dict)
+    unresolved: dict[str, list[str]] = field(default_factory=dict)
+    source_slices: dict[str, str] = field(default_factory=dict)
+
+
+def _classify_kind(ref_kinds: tuple[str, ...]) -> str | None:
+    if any(k == "ltm_pool" for k in ref_kinds):
+        return "pool"
+    if any(k.startswith("ltm_data_group") or k == "sys_file_data_group" for k in ref_kinds):
+        return "data-group"
+    if any(k.startswith("ltm_persistence") for k in ref_kinds):
+        return "persistence"
+    if any(k == "ltm_snatpool" for k in ref_kinds):
+        return "snat-pool"
+    if any(k.startswith("ltm_monitor") for k in ref_kinds):
+        return "monitor"
+    if any(k.startswith("ltm_profile") for k in ref_kinds):
+        return "profile"
+    if any(k == "ltm_node" for k in ref_kinds):
+        return "node"
+    if any(k == "ltm_rule" for k in ref_kinds):
+        return "rule"
+    return None
+
+
+def _slice_for(
+    obj: Any,
+    *,
+    source: str | None,
+) -> str | None:
+    """Slice the original config text for an object using its ``range``."""
+    if source is None:
+        return None
+    rng = getattr(obj, "range", None)
+    if rng is None:
+        return None
+    lines = source.splitlines(keepends=True)
+    start_line = rng.start.line
+    end_line = rng.end.line
+    if start_line < 0 or end_line >= len(lines):
+        return None
+    chunk = "".join(lines[start_line : end_line + 1])
+    return chunk.rstrip() + "\n"
+
+
+def _origin_for_object(
+    obj: Any,
+    sources: dict[str, str] | None,
+    config_origin: str | None,
+) -> str | None:
+    """Return the source text that contains *obj*, if available.
+
+    Today every object carries a single :class:`Range` — we don't
+    record which source URI it came from, so we fall back to
+    *config_origin* (the URI of the merged/single config the bundle
+    was built from).
+    """
+    if sources is None:
+        return None
+    if config_origin and config_origin in sources:
+        return sources[config_origin]
+    if len(sources) == 1:
+        return next(iter(sources.values()))
+    return None
+
+
+def build_irule_context(
+    rule: BigipRule,
+    cfg: BigipConfig,
+    *,
+    transitive: bool = True,
+    sources: dict[str, str] | None = None,
+    config_origin: str | None = None,
+    dialect: str = "f5-irules",
+) -> IruleContextBundle:
+    """Walk *rule* and return every BIG-IP object it references.
+
+    *transitive* expands one level deeper: pool members are resolved
+    to nodes, pool monitors to monitor objects.
+
+    When *sources* is supplied, the bundle records the original
+    config-text slice for every referenced object (under
+    :attr:`IruleContextBundle.source_slices`) so renderers can echo
+    the operator's exact text rather than synthesising a stanza.
+    """
+    from core.commands.registry.runtime import configure_signatures
+
+    configure_signatures(dialect=dialect)
+
+    pools: dict[str, BigipPool] = {}
+    data_groups: dict[str, BigipDataGroup] = {}
+    persistence: dict[str, BigipPersistence] = {}
+    snat_pools: dict[str, BigipSnatPool] = {}
+    profiles: dict[str, BigipProfile] = {}
+    monitors: dict[str, BigipMonitor] = {}
+    nodes: dict[str, BigipNode] = {}
+    rules: dict[str, BigipRule] = {}
+    unresolved: dict[str, list[str]] = {}
+    source_slices: dict[str, str] = {}
+
+    seen: set[tuple[str, str]] = set()
+    src_text = _origin_for_object(rule, sources, config_origin)
+    if src_text is not None:
+        slice_text = _slice_for(rule, source=src_text)
+        if slice_text:
+            source_slices[rule.full_path] = slice_text
+
+    def _record_slice(obj: Any) -> None:
+        if src_text is None:
+            return
+        path = getattr(obj, "full_path", None)
+        if not path:
+            return
+        chunk = _slice_for(obj, source=src_text)
+        if chunk:
+            source_slices[path] = chunk
+
+    for ref in extract_irules_object_references(rule.source):
+        kind = _classify_kind(ref.kinds)
+        if kind is None:
+            continue
+        if (kind, ref.name) in seen:
+            continue
+        seen.add((kind, ref.name))
+
+        if kind == "pool":
+            resolved = cfg.resolve_pool(ref.name)
+            if resolved and resolved in cfg.pools:
+                obj = cfg.pools[resolved]
+                pools[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "data-group":
+            resolved = cfg.resolve_data_group(ref.name)
+            if resolved and resolved in cfg.data_groups:
+                obj = cfg.data_groups[resolved]
+                data_groups[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "persistence":
+            resolved = cfg.resolve_persistence(ref.name)
+            if resolved and resolved in cfg.persistence:
+                obj = cfg.persistence[resolved]
+                persistence[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "snat-pool":
+            resolved = cfg.resolve_snat_pool(ref.name)
+            if resolved and resolved in cfg.snat_pools:
+                obj = cfg.snat_pools[resolved]
+                snat_pools[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "profile":
+            resolved = cfg.resolve_profile(ref.name)
+            if resolved and resolved in cfg.profiles:
+                obj = cfg.profiles[resolved]
+                profiles[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "monitor":
+            resolved = cfg.resolve_name(ref.name, cfg.monitors)
+            if resolved and resolved in cfg.monitors:
+                obj = cfg.monitors[resolved]
+                monitors[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "node":
+            resolved = cfg.resolve_name(ref.name, cfg.nodes)
+            if resolved and resolved in cfg.nodes:
+                obj = cfg.nodes[resolved]
+                nodes[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+        elif kind == "rule":
+            resolved = cfg.resolve_rule(ref.name)
+            if resolved and resolved in cfg.rules and resolved != rule.full_path:
+                obj = cfg.rules[resolved]
+                rules[resolved] = obj
+                _record_slice(obj)
+            else:
+                unresolved.setdefault(kind, []).append(ref.name)
+
+    if transitive:
+        # Pool members → nodes; pool monitor → monitor object.  Pool
+        # member names take the form "/Common/<node>:<port>" — strip
+        # the trailing ":port" before resolving against ``cfg.nodes``.
+        for pool in list(pools.values()):
+            for member in pool.members:
+                node_name = member.name.rsplit(":", 1)[0] if ":" in member.name else member.name
+                resolved_node = cfg.resolve_name(node_name, cfg.nodes)
+                if resolved_node and resolved_node in cfg.nodes:
+                    node = cfg.nodes[resolved_node]
+                    nodes.setdefault(resolved_node, node)
+                    _record_slice(node)
+            if pool.monitor:
+                first = pool.monitor.split(" ", 1)[0]
+                resolved_mon = cfg.resolve_name(first, cfg.monitors)
+                if resolved_mon and resolved_mon in cfg.monitors:
+                    mon = cfg.monitors[resolved_mon]
+                    monitors.setdefault(resolved_mon, mon)
+                    _record_slice(mon)
+
+    return IruleContextBundle(
+        rule=rule,
+        pools=pools,
+        data_groups=data_groups,
+        persistence=persistence,
+        snat_pools=snat_pools,
+        profiles=profiles,
+        monitors=monitors,
+        nodes=nodes,
+        rules=rules,
+        unresolved=unresolved,
+        source_slices=source_slices,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _summarise_pool(pool: BigipPool) -> dict[str, Any]:
+    return {
+        "fullPath": pool.full_path,
+        "monitor": pool.monitor or None,
+        "loadBalancingMode": pool.load_balancing_mode or None,
+        "members": [
+            {
+                "name": m.name,
+                "address": m.address or None,
+                "port": m.port or None,
+                "monitor": m.monitor or None,
+            }
+            for m in pool.members
+        ],
+    }
+
+
+def _summarise_data_group(dg: BigipDataGroup) -> dict[str, Any]:
+    return {
+        "fullPath": dg.full_path,
+        "kind": dg.kind.name.lower() if hasattr(dg.kind, "name") else str(dg.kind),
+        "valueType": dg.value_type or None,
+        "recordCount": len(dg.records),
+        "records": list(dg.records),
+    }
+
+
+def _summarise_persistence(p: BigipPersistence) -> dict[str, Any]:
+    return {"fullPath": p.full_path, "type": p.persistence_type or None}
+
+
+def _summarise_snat_pool(s: BigipSnatPool) -> dict[str, Any]:
+    return {"fullPath": s.full_path, "members": list(s.members)}
+
+
+def _summarise_profile(p: BigipProfile) -> dict[str, Any]:
+    profile_type = p.profile_type.name.lower() if hasattr(p.profile_type, "name") else str(p.profile_type)
+    return {"fullPath": p.full_path, "type": profile_type}
+
+
+def _summarise_monitor(m: BigipMonitor) -> dict[str, Any]:
+    return {"fullPath": m.full_path, "type": m.monitor_type or None}
+
+
+def _summarise_node(n: BigipNode) -> dict[str, Any]:
+    return {"fullPath": n.full_path, "address": n.address or None}
+
+
+def context_bundle_to_dict(bundle: IruleContextBundle) -> dict[str, Any]:
+    """Serialise *bundle* to a JSON-friendly dict."""
+    return {
+        "rule": {
+            "fullPath": bundle.rule.full_path,
+            "name": bundle.rule.name,
+            "source": bundle.rule.source,
+        },
+        "pools": [_summarise_pool(p) for p in bundle.pools.values()],
+        "dataGroups": [_summarise_data_group(d) for d in bundle.data_groups.values()],
+        "persistence": [_summarise_persistence(p) for p in bundle.persistence.values()],
+        "snatPools": [_summarise_snat_pool(s) for s in bundle.snat_pools.values()],
+        "profiles": [_summarise_profile(p) for p in bundle.profiles.values()],
+        "monitors": [_summarise_monitor(m) for m in bundle.monitors.values()],
+        "nodes": [_summarise_node(n) for n in bundle.nodes.values()],
+        "rules": [
+            {"fullPath": r.full_path, "name": r.name, "source": r.source}
+            for r in bundle.rules.values()
+        ],
+        "unresolved": {kind: sorted(set(names)) for kind, names in bundle.unresolved.items()},
+        "sourceSlices": dict(bundle.source_slices),
+    }
+
+
+def _render_pool_text(pool: BigipPool) -> str:
+    lines = [f"ltm pool {pool.full_path} {{"]
+    if pool.load_balancing_mode:
+        lines.append(f"    load-balancing-mode {pool.load_balancing_mode}")
+    if pool.members:
+        lines.append("    members {")
+        for m in pool.members:
+            lines.append(f"        {m.name} {{")
+            if m.address:
+                lines.append(f"            address {m.address}")
+            if m.monitor:
+                lines.append(f"            monitor {m.monitor}")
+            lines.append("        }")
+        lines.append("    }")
+    if pool.monitor:
+        lines.append(f"    monitor {pool.monitor}")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_data_group_text(dg: BigipDataGroup) -> str:
+    kind = dg.kind.name.lower() if hasattr(dg.kind, "name") else str(dg.kind)
+    lines = [f"ltm data-group {kind} {dg.full_path} {{"]
+    if dg.value_type:
+        lines.append(f"    type {dg.value_type}")
+    if dg.records:
+        lines.append("    records {")
+        for record in dg.records:
+            lines.append(f"        {record} {{ }}")
+        lines.append("    }")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_persistence_text(p: BigipPersistence) -> str:
+    return f"ltm persistence {p.persistence_type or '<unknown>'} {p.full_path} {{ }}\n"
+
+
+def _render_snat_pool_text(s: BigipSnatPool) -> str:
+    lines = [f"ltm snatpool {s.full_path} {{"]
+    if s.members:
+        lines.append("    members {")
+        for member in s.members:
+            lines.append(f"        {member}")
+        lines.append("    }")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_profile_text(p: BigipProfile) -> str:
+    profile_type = p.profile_type.name.lower() if hasattr(p.profile_type, "name") else str(p.profile_type)
+    return f"ltm profile {profile_type} {p.full_path} {{ }}\n"
+
+
+def _render_monitor_text(m: BigipMonitor) -> str:
+    return f"ltm monitor {m.monitor_type or '<unknown>'} {m.full_path} {{ }}\n"
+
+
+def _render_node_text(n: BigipNode) -> str:
+    addr = n.address or ""
+    return f"ltm node {n.full_path} {{ address {addr} }}\n"
+
+
+def _render_object_text(bundle: IruleContextBundle, obj: Any, fallback: str) -> str:
+    """Prefer a real source slice; fall back to the synthetic stanza."""
+    full_path = getattr(obj, "full_path", None)
+    if full_path and full_path in bundle.source_slices:
+        return bundle.source_slices[full_path]
+    return fallback
+
+
+def context_bundle_to_text(bundle: IruleContextBundle) -> str:
+    """Render *bundle* as a single Tcl-flavoured text block.
+
+    Layout::
+
+        # ===== iRule /Common/foo =====
+        ltm rule /Common/foo { … }
+
+        # ===== referenced pool /Common/web_pool =====
+        ltm pool /Common/web_pool { … }
+
+        # ===== unresolved =====
+        # data-group: my_dg
+    """
+    parts: list[str] = []
+
+    parts.append(f"# ===== iRule {bundle.rule.full_path} =====")
+    rule_text = bundle.source_slices.get(bundle.rule.full_path)
+    if rule_text:
+        parts.append(rule_text.rstrip())
+    else:
+        parts.append(f"ltm rule {bundle.rule.full_path} {{")
+        parts.append(bundle.rule.source.rstrip())
+        parts.append("}")
+
+    sections: list[tuple[str, list[tuple[str, str]]]] = [
+        (
+            "pool",
+            [(p.full_path, _render_object_text(bundle, p, _render_pool_text(p))) for p in bundle.pools.values()],
+        ),
+        (
+            "data-group",
+            [
+                (d.full_path, _render_object_text(bundle, d, _render_data_group_text(d)))
+                for d in bundle.data_groups.values()
+            ],
+        ),
+        (
+            "persistence",
+            [
+                (p.full_path, _render_object_text(bundle, p, _render_persistence_text(p)))
+                for p in bundle.persistence.values()
+            ],
+        ),
+        (
+            "snat-pool",
+            [
+                (s.full_path, _render_object_text(bundle, s, _render_snat_pool_text(s)))
+                for s in bundle.snat_pools.values()
+            ],
+        ),
+        (
+            "profile",
+            [
+                (p.full_path, _render_object_text(bundle, p, _render_profile_text(p)))
+                for p in bundle.profiles.values()
+            ],
+        ),
+        (
+            "monitor",
+            [
+                (m.full_path, _render_object_text(bundle, m, _render_monitor_text(m)))
+                for m in bundle.monitors.values()
+            ],
+        ),
+        (
+            "node",
+            [
+                (n.full_path, _render_object_text(bundle, n, _render_node_text(n)))
+                for n in bundle.nodes.values()
+            ],
+        ),
+        (
+            "rule",
+            [
+                (
+                    r.full_path,
+                    _render_object_text(
+                        bundle,
+                        r,
+                        f"ltm rule {r.full_path} {{\n{r.source.rstrip()}\n}}\n",
+                    ),
+                )
+                for r in bundle.rules.values()
+            ],
+        ),
+    ]
+    for kind, entries in sections:
+        for full_path, text in entries:
+            parts.append(f"\n# ===== referenced {kind} {full_path} =====")
+            parts.append(text.rstrip())
+
+    if bundle.unresolved:
+        parts.append("\n# ===== unresolved =====")
+        for kind in sorted(bundle.unresolved):
+            for name in sorted(set(bundle.unresolved[kind])):
+                parts.append(f"# {kind}: {name}")
+
+    return "\n".join(parts) + "\n"

--- a/core/bigip/grep.py
+++ b/core/bigip/grep.py
@@ -212,7 +212,7 @@ def _format_text_report(
         f"# Pattern: {report_meta['pattern']}" + mode_suffix,
         f"# Direction: {report_meta['direction']}",
         f"# Sources: {', '.join(report_meta['source_uris']) or '(none)'}",
-        f"# Seeds: {len(seeds)} matched object(s)",
+        f"# Searches: {len(seeds)} matched object(s)",
         related_line,
     ]
     if summary:
@@ -236,7 +236,7 @@ def _format_text_report(
             lines.append("    }")
             lines.append("")
 
-    lines.append("# Seeds (matched by pattern):")
+    lines.append("# Searches (matched by pattern):")
     for obj in seeds:
         _emit(obj)
     lines.append("")
@@ -458,7 +458,7 @@ def report_to_dict(report: GrepReport, *, include_body: bool = False) -> dict:
             "kind": obj.kind,
             "header": obj.header,
             "depth": obj.depth,
-            "isSeed": obj.is_seed,
+            "isSearch": obj.is_seed,
             "range": {
                 "start": {
                     "line": obj.range.start.line,
@@ -480,7 +480,7 @@ def report_to_dict(report: GrepReport, *, include_body: bool = False) -> dict:
         "useCidr": report.use_cidr,
         "recurse": report.recurse,
         "direction": report.direction,
-        "seeds": [_obj_to_dict(o) for o in report.seeds],
+        "searches": [_obj_to_dict(o) for o in report.seeds],
         "related": [_obj_to_dict(o) for o in report.related],
         "edges": [
             {

--- a/core/bigip/lint/__init__.py
+++ b/core/bigip/lint/__init__.py
@@ -338,6 +338,137 @@ class _IruleUnknownEvent:
                     )
 
 
+# ── iRule cross-reference checks ─────────────────────────────────────
+#
+# These rules walk each iRule body for object references (pool /…/foo,
+# class match … <dg>, persist <profile>, …) and flag any reference that
+# fails to resolve against the surrounding bigip.conf.  When the merged
+# config has *no* objects of a given kind at all, the corresponding
+# checks are skipped — typically that means the user passed a single
+# .irule file with no surrounding context, and we don't want to spam
+# false positives.
+
+
+def _has_config_context(cfg: BigipConfig) -> bool:
+    """Return True if *cfg* carries surrounding-context objects.
+
+    A "surrounding-context" config is one that contains objects other
+    than the iRules themselves — pools, data groups, monitors, etc.
+    Standalone ``.irule`` input goes through a synthetic single-rule
+    config with all other collections empty; the bigip parser also
+    emits the rule itself into ``generic_objects`` keyed by
+    ``ltm::rule::*``, so when checking for "real" context we exclude
+    those entries from the count.
+    """
+    if (
+        cfg.pools
+        or cfg.data_groups
+        or cfg.persistence
+        or cfg.snat_pools
+        or cfg.monitors
+        or cfg.profiles
+        or cfg.nodes
+        or cfg.virtual_servers
+        or cfg.policies
+    ):
+        return True
+    for key in cfg.generic_objects:
+        if not key.startswith("ltm::rule::"):
+            return True
+    return False
+
+
+def _classify_reference_kind(ref_kinds: tuple[str, ...]) -> str | None:
+    """Map an :class:`IrulesObjectReference`'s kinds to a coarse bucket."""
+    if any(k == "ltm_pool" for k in ref_kinds):
+        return "pool"
+    if any(k.startswith("ltm_data_group") or k == "sys_file_data_group" for k in ref_kinds):
+        return "data-group"
+    if any(k.startswith("ltm_persistence") for k in ref_kinds):
+        return "persistence"
+    if any(k == "ltm_snatpool" for k in ref_kinds):
+        return "snat-pool"
+    if any(k.startswith("ltm_monitor") for k in ref_kinds):
+        return "monitor"
+    if any(k.startswith("ltm_profile") for k in ref_kinds):
+        return "profile"
+    if any(k == "ltm_node" for k in ref_kinds):
+        return "node"
+    if any(k == "ltm_rule" for k in ref_kinds):
+        return "rule"
+    return None
+
+
+def _resolve_reference(cfg: BigipConfig, kind: str, name: str) -> str | None:
+    if kind == "pool":
+        return cfg.resolve_pool(name)
+    if kind == "data-group":
+        return cfg.resolve_data_group(name)
+    if kind == "persistence":
+        return cfg.resolve_persistence(name)
+    if kind == "snat-pool":
+        return cfg.resolve_snat_pool(name)
+    if kind == "monitor":
+        return cfg.resolve_name(name, cfg.monitors)
+    if kind == "profile":
+        return cfg.resolve_profile(name)
+    if kind == "node":
+        return cfg.resolve_name(name, cfg.nodes)
+    if kind == "rule":
+        return cfg.resolve_rule(name)
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class _IruleMissingObject:
+    ID: str = "irule-missing-object"
+    SEVERITY: str = "warning"
+    CATEGORY: str = "irule"
+
+    def check(
+        self,
+        cfg: BigipConfig,
+        *,
+        sources: dict[str, str],
+        configs: dict[str, BigipConfig],
+    ) -> Iterable[Finding]:
+        try:
+            from ..irules_refs import extract_irules_object_references
+        except ImportError:
+            return
+
+        # Degraded analysis: standalone-.irule input has a synthetic
+        # single-rule config and no surrounding objects.  Without that
+        # context we cannot meaningfully resolve references, so skip
+        # the entire rule rather than emit false positives.
+        if not _has_config_context(cfg):
+            return
+
+        for path, rule in cfg.rules.items():
+            seen: set[tuple[str, str]] = set()
+            for ref in extract_irules_object_references(rule.source):
+                kind = _classify_reference_kind(ref.kinds)
+                if kind is None:
+                    continue
+                resolved = _resolve_reference(cfg, kind, ref.name)
+                if resolved is not None:
+                    continue
+                key = (kind, ref.name)
+                if key in seen:
+                    continue
+                seen.add(key)
+                yield Finding(
+                    rule_id=f"irule-missing-{kind}",
+                    severity=self.SEVERITY,
+                    category=self.CATEGORY,
+                    full_path=path,
+                    message=(
+                        f"iRule references {kind} {ref.name!r} "
+                        f"(via `{ref.command}`) but no such object exists"
+                    ),
+                )
+
+
 # Register the built-in rules in a deterministic order.
 register(_OrphanMonitor())
 register(_EmptyPool())
@@ -346,3 +477,4 @@ register(_PoolWithoutMonitor())
 register(_IruleDeprecatedCommand())
 register(_IruleEmptyWhenBlock())
 register(_IruleUnknownEvent())
+register(_IruleMissingObject())

--- a/core/minifier/minifier.py
+++ b/core/minifier/minifier.py
@@ -578,9 +578,9 @@ def _compact_names(
     Returns (renamed_source, symbol_map).
     """
     from core.analysis import analyse
+    from core.analysis.semantic_graph import find_proc_call_sites
     from core.analysis.semantic_model import Scope
     from core.commands.registry import REGISTRY
-    from lsp.features.references import find_proc_call_sites
 
     analysis = analyse(source)
     symbol_map = SymbolMap()

--- a/explorer/verbs/f5/_paths.py
+++ b/explorer/verbs/f5/_paths.py
@@ -7,10 +7,15 @@ keeps every new verb consistent.
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
-from core.bigip.model import BigipConfig
+from core.bigip.model import BigipConfig, BigipRule
 from core.bigip.parser import parse_bigip_conf
+
+_IRULE_SUFFIXES = frozenset({".tcl", ".irul", ".irule"})
+_BIGIP_SUFFIXES = frozenset({".conf", ".scf"})
+_UCS_SUFFIXES = frozenset({".ucs"})
 
 
 def read_path(path_str: str) -> tuple[str, str]:
@@ -31,3 +36,175 @@ def load_paths(paths: list[str]) -> tuple[dict[str, str], dict[str, BigipConfig]
         sources[uri] = src
         configs[uri] = parse_bigip_conf(src)
     return sources, configs
+
+
+# ---------------------------------------------------------------------------
+# Unified iRule input loading
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class IruleInput:
+    """A single iRule body resolved from a CLI input.
+
+    *origin* is the path / URI of the file the body came from.  When the
+    iRule was extracted from a bigip.conf / SCF / UCS, *rule_full_path*
+    carries the BIG-IP path of the rule (e.g. ``/Common/foo``); for
+    standalone .irule files it is ``None``.  *label* is a display name
+    suitable for diagnostics and for synthesising output filenames.
+    """
+
+    label: str
+    source: str
+    origin: str
+    rule_full_path: str | None = None
+
+
+def _read_path_bytes(path_str: str) -> tuple[str, bytes]:
+    """Return ``(origin, raw_bytes)`` for *path_str*; ``-`` reads stdin."""
+    if path_str == "-":
+        return ("stdin://input", sys.stdin.buffer.read())
+    path = Path(path_str).resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"not a file: {path_str}")
+    return (str(path), path.read_bytes())
+
+
+def _is_gzip(data: bytes) -> bool:
+    return len(data) >= 2 and data[0] == 0x1F and data[1] == 0x8B
+
+
+def _config_to_irule_inputs(
+    *,
+    origin: str,
+    label_prefix: str,
+    config: BigipConfig,
+) -> list[IruleInput]:
+    return [
+        IruleInput(
+            label=f"{label_prefix}::{rule_path}" if label_prefix else rule_path,
+            source=rule.source,
+            origin=origin,
+            rule_full_path=rule_path,
+        )
+        for rule_path, rule in config.rules.items()
+    ]
+
+
+def _classify_text_input(
+    text: str,
+    *,
+    origin: str,
+    label: str,
+) -> tuple[list[IruleInput], BigipConfig | None]:
+    """Decide whether *text* is a bigip.conf with rules or a raw iRule.
+
+    If the parser finds at least one ``ltm rule`` stanza, the resulting
+    rules are emitted; otherwise the whole text is treated as a single
+    iRule body and a synthetic single-rule config is returned.
+    """
+    config = parse_bigip_conf(text)
+    if config.rules:
+        return _config_to_irule_inputs(origin=origin, label_prefix=label, config=config), config
+
+    synth_path = f"/{Path(label).stem or 'irule'}" if label else "/irule"
+    rule = BigipRule(name=Path(label).stem or "irule", full_path=synth_path, source=text)
+    synth = BigipConfig(rules={synth_path: rule})
+    return [
+        IruleInput(label=label, source=text, origin=origin, rule_full_path=None)
+    ], synth
+
+
+def _load_one(path_str: str) -> tuple[list[IruleInput], dict[str, BigipConfig]]:
+    """Resolve a single CLI path to iRule inputs + (origin → config) pairs."""
+    origin, raw = _read_path_bytes(path_str)
+    suffix = Path(path_str).suffix.lower() if path_str != "-" else ""
+
+    # UCS — gzipped tar of /config — extract and treat as a SCF.
+    if suffix in _UCS_SUFFIXES or _is_gzip(raw):
+        from explorer.f5_remote.ucs import is_ucs_bytes, ucs_to_scf
+
+        if not is_ucs_bytes(raw):
+            raise ValueError(f"{path_str}: not a UCS archive (gzip magic missing)")
+        text = ucs_to_scf(raw)
+        cfg = parse_bigip_conf(text)
+        label = path_str if path_str != "-" else "<stdin>"
+        return (
+            _config_to_irule_inputs(origin=origin, label_prefix=label, config=cfg),
+            {origin: cfg},
+        )
+
+    text = raw.decode("utf-8", errors="replace")
+    label = path_str if path_str != "-" else "<stdin>"
+
+    # Standalone iRule file: never try to parse as bigip.conf.
+    if suffix in _IRULE_SUFFIXES:
+        synth_path = f"/{Path(label).stem or 'irule'}"
+        rule = BigipRule(name=Path(label).stem or "irule", full_path=synth_path, source=text)
+        synth = BigipConfig(rules={synth_path: rule})
+        return (
+            [IruleInput(label=label, source=text, origin=origin, rule_full_path=None)],
+            {origin: synth},
+        )
+
+    # bigip.conf / SCF / unknown extension / stdin text — sniff.
+    inputs, cfg = _classify_text_input(text, origin=origin, label=label)
+    configs = {origin: cfg} if cfg is not None else {}
+    return inputs, configs
+
+
+def load_irule_inputs(
+    paths: list[str],
+    *,
+    inline_sources: list[str] | None = None,
+) -> tuple[list[IruleInput], dict[str, BigipConfig]]:
+    """Resolve a mix of paths and inline sources into iRule bodies.
+
+    Each path may be:
+
+    - ``-`` (stdin): bytes are sniffed; gzip → UCS, otherwise text is
+      parsed as a bigip.conf/SCF; if no rules are found the whole text
+      is treated as a single iRule.
+    - ``.tcl`` / ``.irul`` / ``.irule``: standalone iRule body.
+    - ``.ucs``: gzipped tar; canonical SCF members are concatenated and
+      every ``ltm rule`` is emitted.
+    - ``.conf`` / ``.scf`` (or any other extension): parsed as a bigip
+      config; every ``ltm rule`` is emitted.  If no rules are found the
+      whole file is treated as a single iRule.
+
+    *inline_sources* is a list of literal iRule snippets supplied via
+    ``--source``; each becomes its own :class:`IruleInput`.
+
+    Returns ``(inputs, configs)``.  *configs* maps each input's origin
+    to the parsed (or synthetic single-rule) :class:`BigipConfig`,
+    which is what the lint / trace verbs consume.
+
+    Raises :class:`FileNotFoundError` for missing files,
+    :class:`ValueError` for malformed UCS archives.
+    """
+    inputs: list[IruleInput] = []
+    configs: dict[str, BigipConfig] = {}
+
+    for index, source_text in enumerate(inline_sources or [], start=1):
+        label = f"<inline:{index}>"
+        synth_name = f"inline_{index}"
+        synth_path = f"/{synth_name}"
+        rule = BigipRule(name=synth_name, full_path=synth_path, source=source_text)
+        synth_cfg = BigipConfig(rules={synth_path: rule})
+        origin = f"inline://{index}"
+        inputs.append(
+            IruleInput(
+                label=label,
+                source=source_text,
+                origin=origin,
+                rule_full_path=None,
+            )
+        )
+        configs[origin] = synth_cfg
+
+    for path_str in paths:
+        loaded, loaded_configs = _load_one(path_str)
+        inputs.extend(loaded)
+        configs.update(loaded_configs)
+
+    return inputs, configs

--- a/explorer/verbs/f5/_paths.py
+++ b/explorer/verbs/f5/_paths.py
@@ -110,13 +110,21 @@ def _classify_text_input(
     synth_path = f"/{Path(label).stem or 'irule'}" if label else "/irule"
     rule = BigipRule(name=Path(label).stem or "irule", full_path=synth_path, source=text)
     synth = BigipConfig(rules={synth_path: rule})
-    return [
-        IruleInput(label=label, source=text, origin=origin, rule_full_path=None)
-    ], synth
+    return [IruleInput(label=label, source=text, origin=origin, rule_full_path=None)], synth
 
 
-def _load_one(path_str: str) -> tuple[list[IruleInput], dict[str, BigipConfig]]:
-    """Resolve a single CLI path to iRule inputs + (origin → config) pairs."""
+def _load_one(
+    path_str: str,
+) -> tuple[list[IruleInput], dict[str, BigipConfig], dict[str, str]]:
+    """Resolve a single CLI path to iRule inputs, configs, and source text.
+
+    The third element maps each input's *origin* URI to the post-decode
+    source text that was fed into :func:`parse_bigip_conf` — this is
+    the text that downstream consumers should use for source-slicing
+    (verbatim quoting in error messages, AI context bundles, etc.).
+    For UCS inputs it is the *extracted* SCF text, not the gzipped
+    archive bytes.
+    """
     origin, raw = _read_path_bytes(path_str)
     suffix = Path(path_str).suffix.lower() if path_str != "-" else ""
 
@@ -132,6 +140,7 @@ def _load_one(path_str: str) -> tuple[list[IruleInput], dict[str, BigipConfig]]:
         return (
             _config_to_irule_inputs(origin=origin, label_prefix=label, config=cfg),
             {origin: cfg},
+            {origin: text},
         )
 
     text = raw.decode("utf-8", errors="replace")
@@ -145,19 +154,20 @@ def _load_one(path_str: str) -> tuple[list[IruleInput], dict[str, BigipConfig]]:
         return (
             [IruleInput(label=label, source=text, origin=origin, rule_full_path=None)],
             {origin: synth},
+            {origin: text},
         )
 
     # bigip.conf / SCF / unknown extension / stdin text — sniff.
     inputs, cfg = _classify_text_input(text, origin=origin, label=label)
     configs = {origin: cfg} if cfg is not None else {}
-    return inputs, configs
+    return inputs, configs, {origin: text}
 
 
 def load_irule_inputs(
     paths: list[str],
     *,
     inline_sources: list[str] | None = None,
-) -> tuple[list[IruleInput], dict[str, BigipConfig]]:
+) -> tuple[list[IruleInput], dict[str, BigipConfig], dict[str, str]]:
     """Resolve a mix of paths and inline sources into iRule bodies.
 
     Each path may be:
@@ -175,15 +185,21 @@ def load_irule_inputs(
     *inline_sources* is a list of literal iRule snippets supplied via
     ``--source``; each becomes its own :class:`IruleInput`.
 
-    Returns ``(inputs, configs)``.  *configs* maps each input's origin
-    to the parsed (or synthetic single-rule) :class:`BigipConfig`,
-    which is what the lint / trace verbs consume.
+    Returns ``(inputs, configs, sources)``.  *configs* maps each
+    input's origin to the parsed (or synthetic single-rule)
+    :class:`BigipConfig`, which is what the lint / trace verbs
+    consume.  *sources* maps the same origin keys to the post-decode
+    source text (the *extracted* SCF for UCS, not the gzip bytes), so
+    callers that need to slice the original config text — context
+    bundles, error formatters, etc. — get a single canonical view
+    keyed identically to *configs*.
 
     Raises :class:`FileNotFoundError` for missing files,
     :class:`ValueError` for malformed UCS archives.
     """
     inputs: list[IruleInput] = []
     configs: dict[str, BigipConfig] = {}
+    sources: dict[str, str] = {}
 
     for index, source_text in enumerate(inline_sources or [], start=1):
         label = f"<inline:{index}>"
@@ -201,10 +217,12 @@ def load_irule_inputs(
             )
         )
         configs[origin] = synth_cfg
+        sources[origin] = source_text
 
     for path_str in paths:
-        loaded, loaded_configs = _load_one(path_str)
+        loaded, loaded_configs, loaded_sources = _load_one(path_str)
         inputs.extend(loaded)
         configs.update(loaded_configs)
+        sources.update(loaded_sources)
 
-    return inputs, configs
+    return inputs, configs, sources

--- a/explorer/verbs/f5/_paths.py
+++ b/explorer/verbs/f5/_paths.py
@@ -61,13 +61,19 @@ class IruleInput:
 
 
 def _read_path_bytes(path_str: str) -> tuple[str, bytes]:
-    """Return ``(origin, raw_bytes)`` for *path_str*; ``-`` reads stdin."""
+    """Return ``(origin, raw_bytes)`` for *path_str*; ``-`` reads stdin.
+
+    File origins are returned as ``file://`` URIs to match the
+    convention used by :func:`read_path` / :func:`load_paths`, so
+    callers that mix the two helpers see a single canonical key
+    format.
+    """
     if path_str == "-":
         return ("stdin://input", sys.stdin.buffer.read())
     path = Path(path_str).resolve()
     if not path.is_file():
         raise FileNotFoundError(f"not a file: {path_str}")
-    return (str(path), path.read_bytes())
+    return (path.as_uri(), path.read_bytes())
 
 
 def _is_gzip(data: bytes) -> bool:
@@ -133,7 +139,7 @@ def _load_one(
         from explorer.f5_remote.ucs import is_ucs_bytes, ucs_to_scf
 
         if not is_ucs_bytes(raw):
-            raise ValueError(f"{path_str}: not a UCS archive (gzip magic missing)")
+            raise ValueError(f"{path_str}: not a valid UCS archive")
         text = ucs_to_scf(raw)
         cfg = parse_bigip_conf(text)
         label = path_str if path_str != "-" else "<stdin>"

--- a/explorer/verbs/f5/grep.py
+++ b/explorer/verbs/f5/grep.py
@@ -21,14 +21,14 @@ from ._registry import verb
 def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: str) -> None:  # noqa: ARG001
     p.description = (
         "Find every BIG-IP object reachable through reference edges from "
-        "the seed objects whose full path matches PATTERN.  PATTERN is "
-        "a substring match by default; pass --regex to treat it as a "
-        "Python regular expression, or --cidr to match IP addresses and "
-        "CIDR ranges anywhere in an object — including deep inside iRule "
-        "script bodies.  The reference graph is the same one "
-        "`f5 cleanup` walks — both configuration-property references "
-        "and iRule body references (`pool`, `persist`, `class match ... "
-        "<data-group>`) are tracked."
+        "the search-match objects whose full path matches PATTERN.  "
+        "PATTERN is a substring match by default; pass --regex to treat "
+        "it as a Python regular expression, or --cidr to match IP "
+        "addresses and CIDR ranges anywhere in an object — including "
+        "deep inside iRule script bodies.  The reference graph is the "
+        "same one `f5 cleanup` walks — both configuration-property "
+        "references and iRule body references (`pool`, `persist`, "
+        "`class match ... <data-group>`) are tracked."
     )
     p.add_argument(
         "pattern",
@@ -68,10 +68,10 @@ def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: s
         choices=sorted(DIRECTIONS),
         default="both",
         help=(
-            "Which edges to traverse from each seed.  `forward` follows "
-            "outgoing references (what the seed depends on), `reverse` "
-            "follows incoming references (what depends on the seed), "
-            "`both` walks both (default)."
+            "Which edges to traverse from each search match.  `forward` "
+            "follows outgoing references (what the match depends on), "
+            "`reverse` follows incoming references (what depends on the "
+            "match), `both` walks both (default)."
         ),
     )
     p.add_argument(
@@ -79,7 +79,7 @@ def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: s
         type=int,
         default=None,
         metavar="N",
-        help="Stop the BFS after N hops from each seed (default: unlimited).",
+        help="Stop the BFS after N hops from each search match (default: unlimited).",
     )
     p.add_argument(
         "-r",
@@ -88,10 +88,10 @@ def _configure(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: s
         default=True,
         action=argparse.BooleanOptionalAction,
         help=(
-            "Walk the related-object BFS from each seed (default).  "
-            "Pass --no-recurse to skip the BFS and report only the "
-            "objects that directly match PATTERN; --direction and "
-            "--max-depth are then ignored."
+            "Walk the related-object BFS from each search match "
+            "(default).  Pass --no-recurse to skip the BFS and report "
+            "only the objects that directly match PATTERN; --direction "
+            "and --max-depth are then ignored."
         ),
     )
     p.add_argument(
@@ -171,6 +171,6 @@ def _run_grep(args: argparse.Namespace) -> int:
     else:
         sys.stdout.write(output)
 
-    # Exit code: 0 when at least one seed matched, 1 when no seeds matched
+    # Exit code: 0 when at least one match was found, 1 otherwise
     # (mirrors `grep` convention: empty match is a non-zero exit).
     return 0 if report.seeds else 1

--- a/explorer/verbs/f5/irule.py
+++ b/explorer/verbs/f5/irule.py
@@ -30,6 +30,7 @@ import re
 import sys
 from pathlib import Path
 
+from core.bigip.model import BigipConfig
 from core.commands.registry.info import lookup_event_info
 from core.commands.registry.namespace_data import event_multiplicity, order_events_for_file
 from core.commands.registry.runtime import configure_signatures
@@ -44,7 +45,7 @@ from .._utils import (
     _write_highlighted_output,
     _write_text_output,
 )
-from ._paths import IruleInput, load_irule_inputs, read_path
+from ._paths import IruleInput, load_irule_inputs
 
 
 def _add_irule_input_arguments(
@@ -61,10 +62,7 @@ def _add_irule_input_arguments(
     parser.add_argument(
         "paths",
         nargs="*",
-        help=(
-            "Input files: .tcl/.irul/.irule, bigip.conf/SCF, or .ucs."
-            "  Pass `-` to read stdin."
-        ),
+        help=("Input files: .tcl/.irul/.irule, bigip.conf/SCF, or .ucs.  Pass `-` to read stdin."),
     )
     parser.add_argument(
         "--source",
@@ -327,11 +325,11 @@ def add_irule_subparser(
 
 def _resolve_irule_inputs(
     args: argparse.Namespace,
-) -> tuple[list[IruleInput], dict[str, object]] | int:
+) -> tuple[list[IruleInput], dict[str, BigipConfig], dict[str, str]] | int:
     """Run :func:`load_irule_inputs` with CLI error handling.
 
-    Returns the loader's ``(inputs, configs)`` tuple on success or an
-    exit code (already-printed error) on failure.
+    Returns the loader's ``(inputs, configs, sources)`` tuple on
+    success or an exit code (already-printed error) on failure.
     """
     paths = list(args.paths or [])
     inline = list(getattr(args, "source", None) or [])
@@ -388,7 +386,7 @@ def _run_irule_lint(args: argparse.Namespace) -> int:
     loaded = _resolve_irule_inputs(args)
     if isinstance(loaded, int):
         return loaded
-    _inputs, configs = loaded
+    _inputs, configs, _sources = loaded
 
     # The iRule lint category only inspects rule bodies, so the
     # ``sources`` argument can be the rule bodies joined back together
@@ -428,7 +426,7 @@ def _run_irule_trace(args: argparse.Namespace) -> int:
     loaded = _resolve_irule_inputs(args)
     if isinstance(loaded, int):
         return loaded
-    inputs, configs = loaded
+    inputs, configs, _sources = loaded
     merged = _merge_configs_for_trace(configs)
 
     block_re = re.compile(
@@ -495,13 +493,11 @@ def _run_irule_trace(args: argparse.Namespace) -> int:
     return 0 if traces else 1
 
 
-def _merge_configs_for_trace(configs: dict) -> object:
+def _merge_configs_for_trace(configs: dict[str, BigipConfig]) -> BigipConfig:
     """Lazy import so we don't pull lint code at module load."""
     from core.bigip.lint import _merge_configs
 
     if not configs:
-        from core.bigip.model import BigipConfig
-
         return BigipConfig()
     if len(configs) == 1:
         return next(iter(configs.values()))
@@ -555,7 +551,7 @@ def _run_irule_extract(args: argparse.Namespace) -> int:
         print("error: no input provided; pass bigip.conf / SCF / UCS files", file=sys.stderr)
         return 2
     try:
-        _inputs, configs = load_irule_inputs(paths)
+        _inputs, configs, _sources = load_irule_inputs(paths)
     except (OSError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -578,7 +574,7 @@ def _run_event_order(args: argparse.Namespace) -> int:
     loaded = _resolve_irule_inputs(args)
     if isinstance(loaded, int):
         return loaded
-    inputs, _configs = loaded
+    inputs, _configs, _sources = loaded
 
     configure_signatures(dialect=args.dialect)
     combined = "\n\n".join(entry.source.rstrip("\n") for entry in inputs)
@@ -699,7 +695,7 @@ def _run_irule_format(args: argparse.Namespace) -> int:
     loaded = _resolve_irule_inputs(args)
     if isinstance(loaded, int):
         return loaded
-    inputs, _configs = loaded
+    inputs, _configs, _sources = loaded
 
     configure_signatures(dialect=args.dialect)
     fmt_cfg = _resolve_formatter_config(args)
@@ -718,7 +714,7 @@ def _run_irule_minify(args: argparse.Namespace) -> int:
     loaded = _resolve_irule_inputs(args)
     if isinstance(loaded, int):
         return loaded
-    inputs, _configs = loaded
+    inputs, _configs, _sources = loaded
 
     configure_signatures(dialect=args.dialect)
     isolated = bool(getattr(args, "isolated", False))
@@ -783,23 +779,9 @@ def _run_irule_context(args: argparse.Namespace) -> int:
     loaded = _resolve_irule_inputs(args)
     if isinstance(loaded, int):
         return loaded
-    inputs, configs = loaded
+    _inputs, configs, sources_by_origin = loaded
 
     configure_signatures(dialect=args.dialect)
-
-    # Reuse load_paths-style sources for slicing.  load_irule_inputs
-    # already keeps each origin's BigipConfig but not its raw text;
-    # for slicing we need the original content, so re-read from disk
-    # for non-stdin paths.
-    sources_by_origin: dict[str, str] = {}
-    for path in args.paths or []:
-        if path == "-":
-            continue
-        try:
-            uri, src = read_path(path)
-        except OSError:
-            continue
-        sources_by_origin[uri] = src
 
     # Merge configs once so cross-file references (e.g. SCF split into
     # multiple files) all resolve.

--- a/explorer/verbs/f5/irule.py
+++ b/explorer/verbs/f5/irule.py
@@ -81,7 +81,11 @@ def _add_irule_input_arguments(
             "-o",
             "--output",
             default="-",
-            help="Output path ('-' for stdout, or a directory for multi-iRule input).",
+            help=(
+                "Output path: '-' for stdout, an existing directory (or a "
+                "trailing-slash path) for one file per iRule, or any other "
+                "path for a single concatenated file."
+            ),
         )
 
 
@@ -358,17 +362,17 @@ def _flatten_rule_path(rule_full_path: str | None, fallback_label: str) -> str:
 _KNOWN_SUFFIXES = (".tcl", ".irul", ".irule", ".conf", ".scf", ".ucs")
 
 
-def _is_directory_target(output: str, *, multi: bool) -> bool:
+def _is_directory_target(output: str) -> bool:
     """Decide whether *output* should be treated as a directory.
 
-    For multi-iRule input we always treat it as a directory.  For
-    single-iRule input we only treat it as a directory when the path
-    already exists as one (or ends with a separator).
+    Stdout (``-``) is never a directory.  Otherwise we treat *output*
+    as a directory when it already exists as one or ends with a path
+    separator — both single- and multi-rule input honour this so the
+    operator picks the shape with the path syntax (``-o out/`` for a
+    directory, ``-o out.irule`` for one concatenated file).
     """
     if output == "-":
         return False
-    if multi:
-        return True
     p = Path(output)
     return p.is_dir() or output.endswith(("/", "\\"))
 
@@ -664,37 +668,46 @@ def _write_iRule_outputs(
 ) -> int:
     """Common output dispatcher for irule format/minify.
 
-    Single iRule + ``-o FILE``-or-``-`` → write/print *transformed[0]*.
-    Multiple iRules → require a directory output; one file per rule.
+    Output shape is selected by the path passed to ``-o`` regardless of
+    how many iRules came out of the loader:
+
+    - ``-`` (default) → write the concatenated text to stdout.
+    - existing directory or trailing slash (``out/``) → write one file
+      per rule, named ``<flatten(rule_full_path)><file_extension>``.
+    - any other path → write the concatenated text to that single file.
+
+    For the concatenated forms, multi-rule output is separated by a
+    ``# ===== <rule_full_path or label> =====`` header per rule so the
+    boundary is obvious in the combined stream.
     """
-    multi = len(transformed) > 1
-    target_is_dir = _is_directory_target(args.output, multi=multi)
-
-    if multi and not target_is_dir:
-        print(
-            "error: input contains multiple iRules; -o must be a directory",
-            file=sys.stderr,
-        )
-        return 2
-
+    target_is_dir = _is_directory_target(args.output)
     use_colour = _resolve_use_colour(args)
     tab_width = _resolve_tab_width(args)
 
-    if not target_is_dir:
-        text = transformed[0] if transformed else ""
-        _write_highlighted_output(args.output, text, use_colour=use_colour, tab_width=tab_width)
+    if target_is_dir:
+        out_dir = Path(args.output)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for entry, text in zip(inputs, transformed, strict=True):
+            stem = _flatten_rule_path(entry.rule_full_path, entry.label)
+            target = out_dir / f"{stem}{file_extension}"
+            target.write_text(
+                text if text.endswith("\n") else text + "\n",
+                encoding="utf-8",
+            )
+        print(f"wrote {len(transformed)} iRule(s) to {out_dir}", file=sys.stderr)
         return 0
 
-    out_dir = Path(args.output)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    for entry, text in zip(inputs, transformed, strict=True):
-        stem = _flatten_rule_path(entry.rule_full_path, entry.label)
-        target = out_dir / f"{stem}{file_extension}"
-        target.write_text(
-            text if text.endswith("\n") else text + "\n",
-            encoding="utf-8",
-        )
-    print(f"wrote {len(transformed)} iRule(s) to {out_dir}", file=sys.stderr)
+    # Single-file / stdout: emit the concatenation.  For one rule this
+    # is just the text; for many it gets per-rule banners.
+    if len(transformed) <= 1:
+        text = transformed[0] if transformed else ""
+    else:
+        chunks: list[str] = []
+        for entry, body in zip(inputs, transformed, strict=True):
+            label = entry.rule_full_path or entry.label
+            chunks.append(f"# ===== {label} =====\n{body.rstrip()}\n")
+        text = "\n".join(chunks)
+    _write_highlighted_output(args.output, text, use_colour=use_colour, tab_width=tab_width)
     return 0
 
 
@@ -818,30 +831,32 @@ def _run_irule_context(args: argparse.Namespace) -> int:
         print("error: no iRules found in input", file=sys.stderr)
         return 1
 
-    multi = len(bundles) > 1
-    target_is_dir = _is_directory_target(args.output, multi=multi)
+    target_is_dir = _is_directory_target(args.output)
 
-    if multi and not target_is_dir:
-        print(
-            "error: input contains multiple iRules; -o must be a directory",
-            file=sys.stderr,
-        )
-        return 2
-
-    def render(bundle) -> str:
-        if args.json:
-            return json.dumps(context_bundle_to_dict(bundle), indent=2) + "\n"
-        return context_bundle_to_text(bundle)
-
-    if not target_is_dir:
-        _write_text_output(args.output, render(bundles[0][1]))
+    if target_is_dir:
+        out_dir = Path(args.output)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        suffix = ".json" if args.json else ".tcl"
+        for rule_path, bundle in bundles:
+            flat = rule_path.lstrip("/").replace("/", "__")
+            if args.json:
+                payload = json.dumps(context_bundle_to_dict(bundle), indent=2) + "\n"
+            else:
+                payload = context_bundle_to_text(bundle)
+            (out_dir / f"{flat}{suffix}").write_text(payload, encoding="utf-8")
+        print(f"wrote {len(bundles)} iRule context bundle(s) to {out_dir}", file=sys.stderr)
         return 0
 
-    out_dir = Path(args.output)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    suffix = ".json" if args.json else ".tcl"
-    for rule_path, bundle in bundles:
-        flat = rule_path.lstrip("/").replace("/", "__")
-        (out_dir / f"{flat}{suffix}").write_text(render(bundle), encoding="utf-8")
-    print(f"wrote {len(bundles)} iRule context bundle(s) to {out_dir}", file=sys.stderr)
+    # Single-file / stdout: concatenate.  JSON gets a single ``bundles``
+    # array; text mode keeps each block contiguous so the existing
+    # ``# ===== iRule …`` headers separate them naturally.
+    if args.json:
+        payload = json.dumps(
+            {"bundles": [context_bundle_to_dict(b) for _, b in bundles]},
+            indent=2,
+        )
+        _write_text_output(args.output, payload + "\n")
+    else:
+        chunks = [context_bundle_to_text(b).rstrip() + "\n" for _, b in bundles]
+        _write_text_output(args.output, "\n".join(chunks))
     return 0

--- a/explorer/verbs/f5/irule.py
+++ b/explorer/verbs/f5/irule.py
@@ -4,6 +4,17 @@ Sub-subcommands:
 
 - ``f5 irule event-order`` — show iRules events in canonical firing order.
 - ``f5 irule event-info``  — look up iRules event metadata and valid commands.
+- ``f5 irule lint``        — apply iRule-only lint rules.
+- ``f5 irule trace``       — static event-flow trace from a starting event.
+- ``f5 irule extract``     — split a bigip.conf / SCF / UCS into per-rule files.
+- ``f5 irule format``      — pretty-print iRule source.
+- ``f5 irule minify``      — strip whitespace/comments from iRule source.
+
+Every sub-subcommand except ``extract`` and ``event-info`` accepts the
+same flexible mix of inputs: individual ``.irul`` / ``.irule`` / ``.tcl``
+files, ``bigip.conf`` / SCF files containing ``ltm rule`` stanzas, UCS
+archives, ``--source`` snippets, or stdin.  ``extract`` only consumes
+configs that may *contain* iRules (bigip.conf / SCF / UCS).
 
 These verbs are purely iRules-focused and are not available on the
 general-purpose ``tcl`` CLI.  Generally-useful verbs (``command-info``,
@@ -15,24 +26,72 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import sys
+from pathlib import Path
 
 from core.commands.registry.info import lookup_event_info
 from core.commands.registry.namespace_data import event_multiplicity, order_events_for_file
 from core.commands.registry.runtime import configure_signatures
 
+from ...pipeline import AVAILABLE_DIALECTS
 from .._utils import (
-    _add_input_arguments,
-    _combine_sources,
-    _read_input_documents,
+    _add_colour_arguments,
+    _add_formatter_arguments,
+    _resolve_formatter_config,
+    _resolve_tab_width,
+    _resolve_use_colour,
+    _write_highlighted_output,
     _write_text_output,
 )
+from ._paths import IruleInput, load_irule_inputs, read_path
+
+
+def _add_irule_input_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    include_output: bool = True,
+) -> None:
+    """Add the standard input arguments shared by irule sub-verbs.
+
+    Inputs may mix .irul / .irule / .tcl files, bigip.conf / SCF, UCS
+    archives, and ``-`` for stdin.  ``--source`` adds inline iRule
+    snippets (repeatable).
+    """
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Input files: .tcl/.irul/.irule, bigip.conf/SCF, or .ucs."
+            "  Pass `-` to read stdin."
+        ),
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        help="Inline iRule source text (can be repeated).",
+    )
+    parser.add_argument(
+        "--dialect",
+        choices=AVAILABLE_DIALECTS,
+        default="f5-irules",
+        help="Dialect profile (default: f5-irules).",
+    )
+    if include_output:
+        parser.add_argument(
+            "-o",
+            "--output",
+            default="-",
+            help="Output path ('-' for stdout, or a directory for multi-iRule input).",
+        )
 
 
 def add_irule_subparser(
     sub: argparse._SubParsersAction,  # noqa: SLF001
     *,
     prog_name: str = "f5",
-    default_dialect: str = "f5-irules",
+    default_dialect: str = "f5-irules",  # noqa: ARG001 — kept for parity with other registrars
 ) -> None:
     """Register the ``irule`` verb group and its sub-subparsers."""
     irule_p = sub.add_parser(
@@ -45,6 +104,8 @@ def add_irule_subparser(
             "Examples:\n"
             f"  {prog_name} irule event-order rules/policy.irule\n"
             f"  {prog_name} irule event-info HTTP_REQUEST\n"
+            f"  {prog_name} irule format rule.irule\n"
+            f"  {prog_name} irule minify bigip.conf -o minified/\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -56,7 +117,7 @@ def add_irule_subparser(
         aliases=["eventorder"],
         help="Show iRules events in canonical firing order.",
     )
-    _add_input_arguments(eo_p, include_output=True, default_dialect="f5-irules")
+    _add_irule_input_arguments(eo_p)
     eo_p.add_argument(
         "--json",
         action="store_true",
@@ -90,20 +151,21 @@ def add_irule_subparser(
     # ── lint ───────────────────────────────────────────────────────────
     lint_p = irule_sub.add_parser(
         "lint",
-        help="Run iRule-only lint rules over a bigip.conf / SCF.",
+        help="Run iRule-only lint rules over iRule sources.",
         description=(
             "Apply only the irule-category lint rules from `f5 validate`: "
-            "deprecated commands, empty when blocks, unknown events, etc."
+            "deprecated commands, empty when blocks, unknown events, etc.  "
+            "Accepts .irul / .irule / .tcl files, bigip.conf / SCF, UCS, "
+            "or --source snippets."
         ),
     )
-    lint_p.add_argument("paths", nargs="+", help="bigip.conf / SCF files (`-` for stdin).")
+    _add_irule_input_arguments(lint_p)
     lint_p.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
     lint_p.add_argument(
         "--severity",
         choices=("error", "warning", "info"),
         help="Filter to one severity level.",
     )
-    lint_p.add_argument("-o", "--output", metavar="FILE", help="Write here (default: stdout).")
     lint_p.set_defaults(handler=_run_irule_lint)
 
     # ── trace ──────────────────────────────────────────────────────────
@@ -113,28 +175,204 @@ def add_irule_subparser(
         description=(
             "List every command an iRule fires when a given event is "
             "triggered, plus references to pools / data-groups / "
-            "persistence found inside the event's `when` block."
+            "persistence found inside the event's `when` block.  "
+            "Accepts .irul / .irule / .tcl files, bigip.conf / SCF, UCS, "
+            "or --source snippets."
         ),
     )
     trace_p.add_argument("event", help="Starting event name (e.g. HTTP_REQUEST).")
-    trace_p.add_argument("paths", nargs="+", help="bigip.conf / SCF files (`-` for stdin).")
+    _add_irule_input_arguments(trace_p)
     trace_p.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
-    trace_p.add_argument("-o", "--output", metavar="FILE", help="Write here (default: stdout).")
     trace_p.set_defaults(handler=_run_irule_trace)
 
     # ── extract ────────────────────────────────────────────────────────
     extract_p = irule_sub.add_parser(
         "extract",
-        help="Write each iRule body to a standalone .tcl file.",
+        help="Write each iRule body in a config to a standalone .tcl file.",
         description=(
             "For every `ltm rule` in the input config, write its source "
             "body to OUTDIR/<full-path-with-slashes-flattened>.tcl, "
-            "ready to load into an LSP-aware editor for editing."
+            "ready to load into an LSP-aware editor for editing.  "
+            "Accepts bigip.conf / SCF / UCS only — standalone .irule "
+            "files are already in the desired form."
         ),
     )
-    extract_p.add_argument("paths", nargs="+", help="bigip.conf / SCF files (`-` for stdin).")
+    extract_p.add_argument(
+        "paths",
+        nargs="+",
+        help="bigip.conf / SCF / UCS files (`-` for stdin).",
+    )
     extract_p.add_argument("output", help="Output directory (created if needed).")
     extract_p.set_defaults(handler=_run_irule_extract)
+
+    # ── format ─────────────────────────────────────────────────────────
+    fmt_p = irule_sub.add_parser(
+        "format",
+        aliases=["fmt"],
+        help="Format iRule source and emit rewritten Tcl.",
+        description=(
+            "Pretty-print iRule source with canonical indentation and "
+            "spacing.  Accepts .irul / .irule / .tcl files, bigip.conf "
+            "/ SCF / UCS, --source snippets, or stdin.  When the input "
+            "yields a single iRule, the formatted body is written to "
+            "stdout (or -o FILE).  When it yields more than one, -o "
+            "must point at a directory and one file per rule is written."
+        ),
+        epilog=(
+            "Examples:\n"
+            f"  {prog_name} irule format rule.irule\n"
+            f"  {prog_name} irule format --source 'when HTTP_REQUEST {{ return }}'\n"
+            f"  {prog_name} irule format bigip.conf -o formatted/\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_irule_input_arguments(fmt_p)
+    _add_colour_arguments(fmt_p)
+    _add_formatter_arguments(fmt_p)
+    fmt_p.set_defaults(handler=_run_irule_format)
+
+    # ── minify ─────────────────────────────────────────────────────────
+    min_p = irule_sub.add_parser(
+        "minify",
+        aliases=["min"],
+        help="Minify iRule source: strip comments, collapse whitespace.",
+        description=(
+            "Minify iRule source: strip comments, collapse whitespace, "
+            "and join commands with semicolons.  Accepts .irul / .irule "
+            "/ .tcl files, bigip.conf / SCF / UCS, --source snippets, "
+            "or stdin.  When the input yields more than one iRule, -o "
+            "must point at a directory and one file per rule is written."
+        ),
+        epilog=(
+            "Examples:\n"
+            f"  {prog_name} irule minify rule.irule\n"
+            f"  {prog_name} irule minify rule.irule -o min.irule\n"
+            f"  {prog_name} irule minify --compact rule.irule --symbol-map symbols.txt\n"
+            f"  {prog_name} irule minify --aggressive bigip.conf -o tiny/\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_irule_input_arguments(min_p)
+    min_p.add_argument(
+        "--compact",
+        action="store_true",
+        help="Compact variable and proc names to short identifiers.",
+    )
+    min_p.add_argument(
+        "--symbol-map",
+        metavar="FILE",
+        default=None,
+        help="Write symbol map (original -> compacted names) to FILE.",
+    )
+    min_p.add_argument(
+        "--aggressive",
+        action="store_true",
+        help="Maximum compression: run all optimiser passes, then compact names and minify.",
+    )
+    min_p.add_argument(
+        "--isolated",
+        action="store_true",
+        help="Treat script as self-contained — also compact global-scope variable names.",
+    )
+    _add_colour_arguments(min_p)
+    min_p.set_defaults(handler=_run_irule_minify)
+
+    # ── context ────────────────────────────────────────────────────────
+    ctx_p = irule_sub.add_parser(
+        "context",
+        help="Bundle each iRule with the BIG-IP objects it references.",
+        description=(
+            "For every input iRule, emit the rule body together with "
+            "every BIG-IP object it references (pools, data groups, "
+            "persistence profiles, SNAT pools, profiles, monitors, "
+            "nodes, called rules) plus a one-hop transitive expansion "
+            "(pool members → nodes; pool monitor → monitor).  "
+            "Designed to be dropped into an LLM prompt or consumed by "
+            "AI tooling that needs the full context for an iRule."
+        ),
+        epilog=(
+            "Examples:\n"
+            f"  {prog_name} irule context bigip.conf\n"
+            f"  {prog_name} irule context bigip.conf --json\n"
+            f"  {prog_name} irule context bigip.conf -o ctx/  # one file per rule\n"
+            f"  {prog_name} irule context bigip.conf --rule /Common/foo\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_irule_input_arguments(ctx_p)
+    ctx_p.add_argument(
+        "--rule",
+        action="append",
+        default=[],
+        metavar="FULL_PATH",
+        help="Limit output to rules with these full paths (repeatable).",
+    )
+    ctx_p.add_argument(
+        "--no-transitive",
+        action="store_true",
+        help="Skip the one-hop transitive expansion (pool→node, pool→monitor).",
+    )
+    ctx_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit each bundle as a JSON object (default: Tcl-flavoured text).",
+    )
+    ctx_p.set_defaults(handler=_run_irule_context)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_irule_inputs(
+    args: argparse.Namespace,
+) -> tuple[list[IruleInput], dict[str, object]] | int:
+    """Run :func:`load_irule_inputs` with CLI error handling.
+
+    Returns the loader's ``(inputs, configs)`` tuple on success or an
+    exit code (already-printed error) on failure.
+    """
+    paths = list(args.paths or [])
+    inline = list(getattr(args, "source", None) or [])
+    if not paths and not inline:
+        print("error: no input provided; pass files, --source, or `-` for stdin", file=sys.stderr)
+        return 2
+    try:
+        return load_irule_inputs(paths, inline_sources=inline)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+def _flatten_rule_path(rule_full_path: str | None, fallback_label: str) -> str:
+    """Convert a rule path (or label) to a safe file-stem."""
+    if rule_full_path:
+        return rule_full_path.lstrip("/").replace("/", "__")
+    stem = Path(fallback_label).name
+    if stem in ("", "<stdin>", "-"):
+        stem = "irule"
+    if stem.endswith(tuple(_KNOWN_SUFFIXES)):
+        stem = Path(stem).stem
+    return stem.replace("/", "__")
+
+
+_KNOWN_SUFFIXES = (".tcl", ".irul", ".irule", ".conf", ".scf", ".ucs")
+
+
+def _is_directory_target(output: str, *, multi: bool) -> bool:
+    """Decide whether *output* should be treated as a directory.
+
+    For multi-iRule input we always treat it as a directory.  For
+    single-iRule input we only treat it as a directory when the path
+    already exists as one (or ends with a separator).
+    """
+    if output == "-":
+        return False
+    if multi:
+        return True
+    p = Path(output)
+    return p.is_dir() or output.endswith(("/", "\\"))
 
 
 # ---------------------------------------------------------------------------
@@ -143,22 +381,25 @@ def add_irule_subparser(
 
 
 def _run_irule_lint(args: argparse.Namespace) -> int:
-    import sys
-    from pathlib import Path
-
     from core.bigip.lint import run_lint
 
-    from ._paths import load_paths
     from .validate import _to_json, _to_text
 
-    try:
-        sources, configs = load_paths(args.paths)
-    except OSError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 2
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    _inputs, configs = loaded
+
+    # The iRule lint category only inspects rule bodies, so the
+    # ``sources`` argument can be the rule bodies joined back together
+    # by origin URI.
+    sources_for_lint = {
+        origin: "\n".join(rule.source for rule in cfg.rules.values())
+        for origin, cfg in configs.items()
+    }
 
     findings = run_lint(
-        sources=sources,
+        sources=sources_for_lint,
         configs=configs,
         category="irule",
         severity=args.severity,
@@ -169,10 +410,7 @@ def _run_irule_lint(args: argparse.Namespace) -> int:
     else:
         output = _to_text(findings) + "\n"
 
-    if args.output:
-        Path(args.output).write_text(output, encoding="utf-8")
-    else:
-        sys.stdout.write(output)
+    _write_text_output(args.output, output)
 
     has_error = any(f.severity == "error" for f in findings)
     has_warning = any(f.severity == "warning" for f in findings)
@@ -184,17 +422,14 @@ def _run_irule_lint(args: argparse.Namespace) -> int:
 
 
 def _run_irule_trace(args: argparse.Namespace) -> int:
-    import re
-    import sys
-    from pathlib import Path
+    from core.bigip.irules_refs import extract_irules_object_references
+    from core.bigip.lint import _classify_reference_kind, _resolve_reference
 
-    from ._paths import load_paths
-
-    try:
-        _sources, configs = load_paths(args.paths)
-    except OSError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 2
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    inputs, configs = loaded
+    merged = _merge_configs_for_trace(configs)
 
     block_re = re.compile(
         rf"\bwhen\s+{re.escape(args.event)}\s*\{{",
@@ -202,20 +437,45 @@ def _run_irule_trace(args: argparse.Namespace) -> int:
     )
 
     traces: list[dict] = []
-    for cfg in configs.values():
-        for rule_path, rule in cfg.rules.items():
-            match = block_re.search(rule.source)
-            if not match:
+    for entry in inputs:
+        match = block_re.search(entry.source)
+        if not match:
+            continue
+        body = _slice_balanced_braces(entry.source, match.end() - 1)
+        commands = _extract_commands(body)
+        rule_label = entry.rule_full_path or entry.label
+
+        # Extract object references from the *event-handler body* so
+        # `references` only covers what this event actually touches.
+        refs_payload: list[dict] = []
+        seen: set[tuple[str, str]] = set()
+        for ref in extract_irules_object_references(body):
+            kind = _classify_reference_kind(ref.kinds)
+            if kind is None:
                 continue
-            body = _slice_balanced_braces(rule.source, match.end() - 1)
-            commands = _extract_commands(body)
-            traces.append(
+            key = (kind, ref.name)
+            if key in seen:
+                continue
+            seen.add(key)
+            resolved_path = _resolve_reference(merged, kind, ref.name)
+            refs_payload.append(
                 {
-                    "rule": rule_path,
-                    "commandCount": len(commands),
-                    "commands": commands,
+                    "kind": kind,
+                    "name": ref.name,
+                    "command": ref.command,
+                    "resolved": resolved_path is not None,
+                    "resolvedPath": resolved_path,
                 }
             )
+
+        traces.append(
+            {
+                "rule": rule_label,
+                "commandCount": len(commands),
+                "commands": commands,
+                "references": refs_payload,
+            }
+        )
 
     if args.json:
         out = json.dumps({"event": args.event, "traces": traces}, indent=2) + "\n"
@@ -225,13 +485,27 @@ def _run_irule_trace(args: argparse.Namespace) -> int:
             lines.append(f"  {trace['rule']} — {trace['commandCount']} command(s)")
             for cmd in trace["commands"]:
                 lines.append(f"    {cmd}")
+            for ref in trace["references"]:
+                marker = "✓" if ref["resolved"] else "✗"
+                target = ref["resolvedPath"] or ref["name"]
+                lines.append(f"    {marker} {ref['kind']}: {target}")
         out = "\n".join(lines) + "\n"
 
-    if args.output:
-        Path(args.output).write_text(out, encoding="utf-8")
-    else:
-        sys.stdout.write(out)
+    _write_text_output(args.output, out)
     return 0 if traces else 1
+
+
+def _merge_configs_for_trace(configs: dict) -> object:
+    """Lazy import so we don't pull lint code at module load."""
+    from core.bigip.lint import _merge_configs
+
+    if not configs:
+        from core.bigip.model import BigipConfig
+
+        return BigipConfig()
+    if len(configs) == 1:
+        return next(iter(configs.values()))
+    return _merge_configs(configs)
 
 
 def _slice_balanced_braces(source: str, open_brace: int) -> str:
@@ -264,9 +538,7 @@ def _extract_commands(body: str) -> list[str]:
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        # Cheap tokenisation: first whitespace-delimited word.
         head = line.split(None, 1)[0]
-        # Strip stray closing brace from one-liners
         head = head.rstrip("{};")
         if head:
             cmds.append(head)
@@ -274,14 +546,17 @@ def _extract_commands(body: str) -> list[str]:
 
 
 def _run_irule_extract(args: argparse.Namespace) -> int:
-    import sys
-    from pathlib import Path
-
-    from ._paths import load_paths
-
+    # Extract only consumes config-style inputs; bypass the standalone
+    # .irule shortcut by going through load_irule_inputs anyway — for
+    # raw .irule input the synthetic single-rule config still produces
+    # a single output file, which is harmless.
+    paths = list(args.paths or [])
+    if not paths:
+        print("error: no input provided; pass bigip.conf / SCF / UCS files", file=sys.stderr)
+        return 2
     try:
-        _sources, configs = load_paths(args.paths)
-    except OSError as exc:
+        _inputs, configs = load_irule_inputs(paths)
+    except (OSError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
@@ -300,16 +575,15 @@ def _run_irule_extract(args: argparse.Namespace) -> int:
 
 
 def _run_event_order(args: argparse.Namespace) -> int:
-    documents = _read_input_documents(
-        args.inputs,
-        inline_sources=args.source,
-        package_paths=args.package_path,
-        recursive=not args.no_recursive,
-    )
-    configure_signatures(dialect=args.dialect)
-    source = _combine_sources(documents)
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    inputs, _configs = loaded
 
-    ordered = order_events_for_file(source)
+    configure_signatures(dialect=args.dialect)
+    combined = "\n\n".join(entry.source.rstrip("\n") for entry in inputs)
+
+    ordered = order_events_for_file(combined)
     events = [
         {
             "index": index,
@@ -369,3 +643,214 @@ def _run_event_info(args: argparse.Namespace) -> int:
     lines.append(f"valid commands: {info.valid_command_count}")
     _write_text_output(args.output, "\n".join(lines))
     return 0 if info.known else 1
+
+
+# ---------------------------------------------------------------------------
+# format / minify
+# ---------------------------------------------------------------------------
+
+
+def _write_iRule_outputs(
+    *,
+    args: argparse.Namespace,
+    inputs: list[IruleInput],
+    transformed: list[str],
+    file_extension: str,
+) -> int:
+    """Common output dispatcher for irule format/minify.
+
+    Single iRule + ``-o FILE``-or-``-`` → write/print *transformed[0]*.
+    Multiple iRules → require a directory output; one file per rule.
+    """
+    multi = len(transformed) > 1
+    target_is_dir = _is_directory_target(args.output, multi=multi)
+
+    if multi and not target_is_dir:
+        print(
+            "error: input contains multiple iRules; -o must be a directory",
+            file=sys.stderr,
+        )
+        return 2
+
+    use_colour = _resolve_use_colour(args)
+    tab_width = _resolve_tab_width(args)
+
+    if not target_is_dir:
+        text = transformed[0] if transformed else ""
+        _write_highlighted_output(args.output, text, use_colour=use_colour, tab_width=tab_width)
+        return 0
+
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for entry, text in zip(inputs, transformed, strict=True):
+        stem = _flatten_rule_path(entry.rule_full_path, entry.label)
+        target = out_dir / f"{stem}{file_extension}"
+        target.write_text(
+            text if text.endswith("\n") else text + "\n",
+            encoding="utf-8",
+        )
+    print(f"wrote {len(transformed)} iRule(s) to {out_dir}", file=sys.stderr)
+    return 0
+
+
+def _run_irule_format(args: argparse.Namespace) -> int:
+    from core.formatting import format_tcl
+
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    inputs, _configs = loaded
+
+    configure_signatures(dialect=args.dialect)
+    fmt_cfg = _resolve_formatter_config(args)
+    formatted = [format_tcl(entry.source, config=fmt_cfg) for entry in inputs]
+    return _write_iRule_outputs(
+        args=args,
+        inputs=inputs,
+        transformed=formatted,
+        file_extension=".irule",
+    )
+
+
+def _run_irule_minify(args: argparse.Namespace) -> int:
+    from core.minifier import minify_tcl
+
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    inputs, _configs = loaded
+
+    configure_signatures(dialect=args.dialect)
+    isolated = bool(getattr(args, "isolated", False))
+
+    minified: list[str] = []
+    symbol_maps: list[str] = []
+    if args.aggressive:
+        for entry in inputs:
+            result = minify_tcl(
+                entry.source,
+                aggressive=True,
+                isolated=isolated,
+                dialect=args.dialect,
+            )
+            minified.append(result.source)
+            symbol_maps.append(result.symbol_map.format())
+    elif args.compact:
+        for entry in inputs:
+            text, symbol_map = minify_tcl(
+                entry.source,
+                compact_names=True,
+                isolated=isolated,
+                dialect=args.dialect,
+            )
+            minified.append(text)
+            symbol_maps.append(symbol_map.format())
+    else:
+        for entry in inputs:
+            minified.append(minify_tcl(entry.source, dialect=args.dialect))
+
+    rc = _write_iRule_outputs(
+        args=args,
+        inputs=inputs,
+        transformed=minified,
+        file_extension=".irule",
+    )
+    if rc != 0:
+        return rc
+
+    if args.symbol_map and symbol_maps:
+        joined = "\n\n".join(
+            f"# {entry.rule_full_path or entry.label}\n{m}".rstrip()
+            for entry, m in zip(inputs, symbol_maps, strict=True)
+            if m
+        )
+        _write_text_output(args.symbol_map, joined + ("\n" if joined else ""))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# context
+# ---------------------------------------------------------------------------
+
+
+def _run_irule_context(args: argparse.Namespace) -> int:
+    from ai.shared.irule_context import (
+        build_irule_context,
+        context_bundle_to_dict,
+        context_bundle_to_text,
+    )
+
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    inputs, configs = loaded
+
+    configure_signatures(dialect=args.dialect)
+
+    # Reuse load_paths-style sources for slicing.  load_irule_inputs
+    # already keeps each origin's BigipConfig but not its raw text;
+    # for slicing we need the original content, so re-read from disk
+    # for non-stdin paths.
+    sources_by_origin: dict[str, str] = {}
+    for path in args.paths or []:
+        if path == "-":
+            continue
+        try:
+            uri, src = read_path(path)
+        except OSError:
+            continue
+        sources_by_origin[uri] = src
+
+    # Merge configs once so cross-file references (e.g. SCF split into
+    # multiple files) all resolve.
+    merged = _merge_configs_for_trace(configs)
+
+    rule_filter = set(args.rule or [])
+    transitive = not args.no_transitive
+
+    bundles = []
+    for cfg_origin, cfg in configs.items():
+        for rule_path, rule in cfg.rules.items():
+            if rule_filter and rule_path not in rule_filter:
+                continue
+            bundle = build_irule_context(
+                rule,
+                merged,
+                transitive=transitive,
+                sources=sources_by_origin or None,
+                config_origin=cfg_origin,
+                dialect=args.dialect,
+            )
+            bundles.append((rule_path, bundle))
+
+    if not bundles:
+        print("error: no iRules found in input", file=sys.stderr)
+        return 1
+
+    multi = len(bundles) > 1
+    target_is_dir = _is_directory_target(args.output, multi=multi)
+
+    if multi and not target_is_dir:
+        print(
+            "error: input contains multiple iRules; -o must be a directory",
+            file=sys.stderr,
+        )
+        return 2
+
+    def render(bundle) -> str:
+        if args.json:
+            return json.dumps(context_bundle_to_dict(bundle), indent=2) + "\n"
+        return context_bundle_to_text(bundle)
+
+    if not target_is_dir:
+        _write_text_output(args.output, render(bundles[0][1]))
+        return 0
+
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    suffix = ".json" if args.json else ".tcl"
+    for rule_path, bundle in bundles:
+        flat = rule_path.lstrip("/").replace("/", "__")
+        (out_dir / f"{flat}{suffix}").write_text(render(bundle), encoding="utf-8")
+    print(f"wrote {len(bundles)} iRule context bundle(s) to {out_dir}", file=sys.stderr)
+    return 0

--- a/explorer/verbs/f5/irule.py
+++ b/explorer/verbs/f5/irule.py
@@ -542,13 +542,22 @@ def _extract_commands(body: str) -> list[str]:
 
 
 def _run_irule_extract(args: argparse.Namespace) -> int:
-    # Extract only consumes config-style inputs; bypass the standalone
-    # .irule shortcut by going through load_irule_inputs anyway — for
-    # raw .irule input the synthetic single-rule config still produces
-    # a single output file, which is harmless.
+    # Extract pulls iRule bodies *out* of a config — standalone .irule
+    # / .irul / .tcl files are already in the desired form, so reject
+    # them up front to match the documented contract.
     paths = list(args.paths or [])
     if not paths:
         print("error: no input provided; pass bigip.conf / SCF / UCS files", file=sys.stderr)
+        return 2
+    standalone = {".tcl", ".irul", ".irule"}
+    bad = [p for p in paths if p != "-" and Path(p).suffix.lower() in standalone]
+    if bad:
+        joined = ", ".join(bad)
+        print(
+            f"error: extract only accepts bigip.conf / SCF / UCS; refusing standalone "
+            f"iRule file(s): {joined}",
+            file=sys.stderr,
+        )
         return 2
     try:
         _inputs, configs, _sources = load_irule_inputs(paths)

--- a/tests/test_bigip_grep.py
+++ b/tests/test_bigip_grep.py
@@ -276,11 +276,11 @@ def test_report_to_dict_round_trips_through_json() -> None:
     again = json.loads(json.dumps(payload))
     assert again["pattern"] == "/Common/p1"
     assert again["direction"] == "both"
-    assert {item["fullPath"] for item in again["seeds"]} == {"/Common/p1"}
+    assert {item["fullPath"] for item in again["searches"]} == {"/Common/p1"}
     assert {item["fullPath"] for item in again["related"]} >= {"/Common/n1", "/Common/vs"}
     assert isinstance(again["edges"], list)
     # By default, body is omitted to keep the JSON payload compact.
-    assert "body" not in again["seeds"][0]
+    assert "body" not in again["searches"][0]
 
 
 def test_report_to_dict_with_include_body_emits_object_bodies() -> None:
@@ -296,8 +296,8 @@ def test_report_to_dict_with_include_body_emits_object_bodies() -> None:
     )
     report = _run(source, "/Common/p1", direction="both")
     payload = report_to_dict(report, include_body=True)
-    assert "body" in payload["seeds"][0]
-    assert payload["seeds"][0]["body"]
+    assert "body" in payload["searches"][0]
+    assert payload["searches"][0]["body"]
     for item in payload["related"]:
         assert "body" in item
 
@@ -408,7 +408,7 @@ def test_cli_grep_json_emits_valid_json(tmp_path: Path, capsys) -> None:
     data = json.loads(captured.out)
     assert data["pattern"] == "/Common/n1"
     assert data["direction"] == "both"
-    assert data["seeds"][0]["fullPath"] == "/Common/n1"
+    assert data["searches"][0]["fullPath"] == "/Common/n1"
 
 
 def test_cli_grep_writes_to_output_file(tmp_path: Path, capsys) -> None:
@@ -756,7 +756,7 @@ def test_cidr_report_to_dict_round_trips_use_cidr_flag() -> None:
     again = json.loads(json.dumps(payload))
     assert again["useCidr"] is True
     assert again["useRegex"] is False
-    assert {item["fullPath"] for item in again["seeds"]} == {"/Common/vs"}
+    assert {item["fullPath"] for item in again["searches"]} == {"/Common/vs"}
 
 
 def test_cli_grep_cidr_finds_irule_match(tmp_path: Path, capsys) -> None:
@@ -824,6 +824,6 @@ def test_cli_grep_full_json_emits_object_bodies(tmp_path: Path, capsys) -> None:
     captured = capsys.readouterr()
     assert rc == 0
     data = json.loads(captured.out)
-    assert data["seeds"][0]["fullPath"] == "/Common/n1"
-    assert "body" in data["seeds"][0]
-    assert "address 10.0.0.1" in data["seeds"][0]["body"]
+    assert data["searches"][0]["fullPath"] == "/Common/n1"
+    assert "body" in data["searches"][0]
+    assert "address 10.0.0.1" in data["searches"][0]["body"]

--- a/tests/test_f5_irule_format_minify.py
+++ b/tests/test_f5_irule_format_minify.py
@@ -1,0 +1,261 @@
+"""Tests for ``f5 irule format`` and ``f5 irule minify`` sub-verbs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from explorer.f5_cli import main
+from explorer.f5_remote.ucs import make_test_ucs
+
+
+def _run(args: list[str], capsys) -> tuple[int, str, str]:
+    code = main(args)
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+# ---------------------------------------------------------------------------
+# format
+# ---------------------------------------------------------------------------
+
+
+def test_irule_format_inline_source_to_stdout(capsys):
+    code, out, err = _run(
+        ["irule", "format", "--source", "when HTTP_REQUEST {return}"],
+        capsys,
+    )
+    assert code == 0, err
+    assert "when HTTP_REQUEST" in out
+    # Formatter should emit a final newline.
+    assert out.endswith("\n")
+
+
+def test_irule_format_irule_file_to_stdout(tmp_path, capsys):
+    rule = tmp_path / "rule.irule"
+    rule.write_text("when HTTP_REQUEST {return}\n", encoding="utf-8")
+
+    code, out, err = _run(["irule", "format", str(rule)], capsys)
+    assert code == 0, err
+    assert "when HTTP_REQUEST" in out
+
+
+def test_irule_format_bigip_conf_emits_directory(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm rule /Common/foo {when HTTP_REQUEST {return}}\n"
+        "ltm rule /Partition_a/bar {when HTTP_RESPONSE {return}}\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    code, _out, err = _run(["irule", "format", str(conf), "-o", str(out_dir)], capsys)
+    assert code == 0, err
+    files = sorted(p.name for p in out_dir.iterdir())
+    assert files == ["Common__foo.irule", "Partition_a__bar.irule"]
+
+
+def test_irule_format_multiple_rules_requires_directory(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm rule /Common/foo {when HTTP_REQUEST {return}}\n"
+        "ltm rule /Common/bar {when HTTP_RESPONSE {return}}\n",
+        encoding="utf-8",
+    )
+
+    # Default output is "-" (stdout) which is a scalar — should error.
+    code, _out, err = _run(["irule", "format", str(conf)], capsys)
+    assert code == 2
+    assert "multiple iRules" in err
+
+
+# ---------------------------------------------------------------------------
+# minify
+# ---------------------------------------------------------------------------
+
+
+def test_irule_minify_inline_source(capsys):
+    code, out, err = _run(
+        ["irule", "minify", "--source", "when HTTP_REQUEST { # hi\n  return\n}"],
+        capsys,
+    )
+    assert code == 0, err
+    # Comments should be stripped.
+    assert "# hi" not in out
+    assert "return" in out
+
+
+def test_irule_minify_compact_writes_symbol_map(tmp_path, capsys):
+    pytest = __import__("pytest")
+    pytest.importorskip("lsprotocol")
+
+    rule = tmp_path / "rule.irule"
+    rule.write_text("when HTTP_REQUEST { set my_var 1; log local0. $my_var }\n", encoding="utf-8")
+    sym_map = tmp_path / "syms.txt"
+
+    code, _out, err = _run(
+        [
+            "irule",
+            "minify",
+            "--compact",
+            str(rule),
+            "--symbol-map",
+            str(sym_map),
+        ],
+        capsys,
+    )
+    assert code == 0, err
+    text = sym_map.read_text(encoding="utf-8")
+    assert "my_var" in text
+
+
+def test_irule_minify_aggressive_runs(tmp_path, capsys):
+    pytest = __import__("pytest")
+    pytest.importorskip("lsprotocol")
+
+    rule = tmp_path / "r.irule"
+    rule.write_text(
+        "when HTTP_REQUEST {\n  set x 1\n  set y 2\n  log local0. $x\n}\n",
+        encoding="utf-8",
+    )
+    code, out, err = _run(["irule", "minify", "--aggressive", str(rule)], capsys)
+    assert code == 0, err
+    assert "log" in out
+
+
+def test_irule_minify_bigip_conf_to_directory(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm rule /Common/foo { when HTTP_REQUEST { return } }\n"
+        "ltm rule /Common/bar { when HTTP_RESPONSE { return } }\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "min"
+    out_dir.mkdir()
+    code, _out, err = _run(["irule", "minify", str(conf), "-o", str(out_dir)], capsys)
+    assert code == 0, err
+    files = sorted(p.name for p in out_dir.iterdir())
+    assert files == ["Common__bar.irule", "Common__foo.irule"]
+
+
+def test_irule_minify_ucs_input(tmp_path, capsys):
+    ucs = tmp_path / "device.ucs"
+    ucs.write_bytes(
+        make_test_ucs(
+            {
+                "config/bigip.conf": (
+                    "ltm rule /Common/foo { when HTTP_REQUEST { return } }\n"
+                    "ltm rule /Common/bar { when HTTP_RESPONSE { return } }\n"
+                ),
+            }
+        )
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    code, _out, err = _run(["irule", "minify", str(ucs), "-o", str(out_dir)], capsys)
+    assert code == 0, err
+    assert (out_dir / "Common__foo.irule").exists()
+    assert (out_dir / "Common__bar.irule").exists()
+
+
+# ---------------------------------------------------------------------------
+# context (smoke through the CLI)
+# ---------------------------------------------------------------------------
+
+
+def test_irule_context_text_smoke(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm pool /Common/web_pool { members { /Common/n1:80 { } } }\n"
+        "ltm rule /Common/foo {\n"
+        "    when HTTP_REQUEST {\n"
+        "        pool /Common/web_pool\n"
+        "        pool /Common/missing\n"
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    code, out, err = _run(["irule", "context", str(conf)], capsys)
+    assert code == 0, err
+    assert "iRule /Common/foo" in out
+    assert "referenced pool /Common/web_pool" in out
+    assert "unresolved" in out
+    assert "pool: /Common/missing" in out
+
+
+def test_irule_context_json_smoke(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm pool /Common/web_pool { members { /Common/n1:80 { } } }\n"
+        "ltm rule /Common/foo { when HTTP_REQUEST { pool /Common/web_pool } }\n",
+        encoding="utf-8",
+    )
+    code, out, err = _run(["irule", "context", str(conf), "--json"], capsys)
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["rule"]["fullPath"] == "/Common/foo"
+    assert any(p["fullPath"] == "/Common/web_pool" for p in payload["pools"])
+
+
+# ---------------------------------------------------------------------------
+# trace references enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_irule_trace_emits_references_array(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm pool /Common/web_pool { members { /Common/n1:80 { } } }\n"
+        "ltm rule /Common/foo { when HTTP_REQUEST { pool /Common/web_pool } }\n"
+        "ltm rule /Common/bar { when HTTP_REQUEST { pool /Common/missing } }\n",
+        encoding="utf-8",
+    )
+    code, out, err = _run(
+        ["irule", "trace", "HTTP_REQUEST", str(conf), "--json"],
+        capsys,
+    )
+    assert code == 0, err
+    payload = json.loads(out)
+    by_rule = {t["rule"]: t for t in payload["traces"]}
+    assert by_rule["/Common/foo"]["references"][0] == {
+        "kind": "pool",
+        "name": "/Common/web_pool",
+        "command": "pool",
+        "resolved": True,
+        "resolvedPath": "/Common/web_pool",
+    }
+    assert by_rule["/Common/bar"]["references"][0]["resolved"] is False
+
+
+# ---------------------------------------------------------------------------
+# lint missing-object findings
+# ---------------------------------------------------------------------------
+
+
+def test_irule_lint_emits_missing_pool(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    # At least one pool exists so `_has_config_context` returns True.
+    conf.write_text(
+        "ltm pool /Common/real { members { /Common/n1:80 { } } }\n"
+        "ltm rule /Common/foo { when HTTP_REQUEST { pool /Common/missing } }\n",
+        encoding="utf-8",
+    )
+    code, out, _err = _run(["irule", "lint", str(conf), "--json"], capsys)
+    # Warning → exit code 1.
+    assert code == 1
+    payload = json.loads(out)
+    rule_ids = {f["ruleId"] for f in payload["findings"]}
+    assert "irule-missing-pool" in rule_ids
+
+
+def test_irule_lint_skips_missing_object_for_standalone_irule(tmp_path, capsys):
+    rule = tmp_path / "r.irule"
+    rule.write_text("when HTTP_REQUEST { pool /Common/missing }\n", encoding="utf-8")
+    code, _out, err = _run(["irule", "lint", str(rule)], capsys)
+    # No surrounding context — missing-object check should be silent.
+    assert code == 0, err

--- a/tests/test_f5_irule_format_minify.py
+++ b/tests/test_f5_irule_format_minify.py
@@ -90,10 +90,9 @@ def test_irule_minify_inline_source(capsys):
 
 
 def test_irule_minify_compact_writes_symbol_map(tmp_path, capsys):
-    pytest = __import__("pytest")
-    pytest.importorskip("lsprotocol")
-
     rule = tmp_path / "rule.irule"
+    # --isolated is required to compact global-scope vars (iRules
+    # event handlers are self-contained, so this is the typical mode).
     rule.write_text("when HTTP_REQUEST { set my_var 1; log local0. $my_var }\n", encoding="utf-8")
     sym_map = tmp_path / "syms.txt"
 
@@ -102,6 +101,7 @@ def test_irule_minify_compact_writes_symbol_map(tmp_path, capsys):
             "irule",
             "minify",
             "--compact",
+            "--isolated",
             str(rule),
             "--symbol-map",
             str(sym_map),
@@ -114,9 +114,6 @@ def test_irule_minify_compact_writes_symbol_map(tmp_path, capsys):
 
 
 def test_irule_minify_aggressive_runs(tmp_path, capsys):
-    pytest = __import__("pytest")
-    pytest.importorskip("lsprotocol")
-
     rule = tmp_path / "r.irule"
     rule.write_text(
         "when HTTP_REQUEST {\n  set x 1\n  set y 2\n  log local0. $x\n}\n",

--- a/tests/test_f5_irule_format_minify.py
+++ b/tests/test_f5_irule_format_minify.py
@@ -59,7 +59,9 @@ def test_irule_format_bigip_conf_emits_directory(tmp_path, capsys):
     assert files == ["Common__foo.irule", "Partition_a__bar.irule"]
 
 
-def test_irule_format_multiple_rules_requires_directory(tmp_path, capsys):
+def test_irule_format_multiple_rules_concat_to_stdout(tmp_path, capsys):
+    """Multi-rule input + scalar -o (or stdout) emits a single
+    concatenated stream with per-rule banner headers."""
     conf = tmp_path / "bigip.conf"
     conf.write_text(
         "ltm rule /Common/foo {when HTTP_REQUEST {return}}\n"
@@ -67,10 +69,46 @@ def test_irule_format_multiple_rules_requires_directory(tmp_path, capsys):
         encoding="utf-8",
     )
 
-    # Default output is "-" (stdout) which is a scalar — should error.
-    code, _out, err = _run(["irule", "format", str(conf)], capsys)
-    assert code == 2
-    assert "multiple iRules" in err
+    code, out, err = _run(["irule", "format", str(conf)], capsys)
+    assert code == 0, err
+    assert "# ===== /Common/foo =====" in out
+    assert "# ===== /Common/bar =====" in out
+
+
+def test_irule_format_multiple_rules_to_single_file(tmp_path, capsys):
+    """Passing a non-directory ``-o FILE`` for multi-rule input writes
+    the concatenated stream to that file (no error)."""
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm rule /Common/foo {when HTTP_REQUEST {return}}\n"
+        "ltm rule /Common/bar {when HTTP_RESPONSE {return}}\n",
+        encoding="utf-8",
+    )
+    target = tmp_path / "all.irule"
+
+    code, _out, err = _run(["irule", "format", str(conf), "-o", str(target)], capsys)
+    assert code == 0, err
+    text = target.read_text(encoding="utf-8")
+    assert "# ===== /Common/foo =====" in text
+    assert "# ===== /Common/bar =====" in text
+
+
+def test_irule_format_directory_target_uses_trailing_slash(tmp_path, capsys):
+    """A path with a trailing separator is treated as a directory even
+    if it doesn't yet exist."""
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm rule /Common/foo {when HTTP_REQUEST {return}}\n"
+        "ltm rule /Common/bar {when HTTP_RESPONSE {return}}\n",
+        encoding="utf-8",
+    )
+    out_dir_arg = str(tmp_path / "fmt") + "/"
+
+    code, _out, err = _run(["irule", "format", str(conf), "-o", out_dir_arg], capsys)
+    assert code == 0, err
+    out_dir = tmp_path / "fmt"
+    assert (out_dir / "Common__foo.irule").exists()
+    assert (out_dir / "Common__bar.irule").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -195,8 +233,12 @@ def test_irule_context_json_smoke(tmp_path, capsys):
     code, out, err = _run(["irule", "context", str(conf), "--json"], capsys)
     assert code == 0, err
     payload = json.loads(out)
-    assert payload["rule"]["fullPath"] == "/Common/foo"
-    assert any(p["fullPath"] == "/Common/web_pool" for p in payload["pools"])
+    # Single-file JSON output wraps every rule in a ``bundles`` array
+    # for consistency between single- and multi-rule input.
+    assert len(payload["bundles"]) == 1
+    bundle = payload["bundles"][0]
+    assert bundle["rule"]["fullPath"] == "/Common/foo"
+    assert any(p["fullPath"] == "/Common/web_pool" for p in bundle["pools"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_f5_irule_format_minify.py
+++ b/tests/test_f5_irule_format_minify.py
@@ -250,6 +250,20 @@ def test_irule_lint_emits_missing_pool(tmp_path, capsys):
     assert "irule-missing-pool" in rule_ids
 
 
+def test_irule_extract_rejects_standalone_irule_files(tmp_path, capsys):
+    """``f5 irule extract`` is documented as accepting bigip.conf /
+    SCF / UCS only.  A standalone .irule path is meaningless (the body
+    is already in the desired form) and must be refused."""
+    rule = tmp_path / "x.irule"
+    rule.write_text("when HTTP_REQUEST { return }\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    code, _out, err = _run(["irule", "extract", str(rule), str(out_dir)], capsys)
+    assert code == 2
+    assert "standalone" in err
+    assert "x.irule" in err
+
+
 def test_irule_lint_skips_missing_object_for_standalone_irule(tmp_path, capsys):
     rule = tmp_path / "r.irule"
     rule.write_text("when HTTP_REQUEST { pool /Common/missing }\n", encoding="utf-8")

--- a/tests/test_irule_context.py
+++ b/tests/test_irule_context.py
@@ -1,0 +1,171 @@
+"""Tests for ``ai.shared.irule_context`` and the MCP wrapper."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ai.shared.irule_context import (
+    build_irule_context,
+    context_bundle_to_dict,
+    context_bundle_to_text,
+)
+from core.bigip.parser import parse_bigip_conf
+
+
+_SAMPLE_CONF = """\
+ltm pool /Common/web_pool {
+    members { /Common/n1:80 { address 10.0.0.1 } }
+    monitor /Common/http
+}
+ltm node /Common/n1 { address 10.0.0.1 }
+ltm monitor http /Common/http { }
+ltm data-group internal /Common/dg { type string records { foo { } } }
+ltm rule /Common/foo {
+when HTTP_REQUEST {
+    if { [class match [HTTP::host] equals /Common/dg] } {
+        pool /Common/web_pool
+    } else {
+        pool /Common/missing
+    }
+}
+}
+"""
+
+
+def _bundle():
+    cfg = parse_bigip_conf(_SAMPLE_CONF)
+    rule = cfg.rules["/Common/foo"]
+    return cfg, rule, build_irule_context(
+        rule,
+        cfg,
+        sources={"inline://0": _SAMPLE_CONF},
+        config_origin="inline://0",
+    )
+
+
+def test_build_irule_context_resolves_pool_and_data_group():
+    _cfg, _rule, bundle = _bundle()
+    assert "/Common/web_pool" in bundle.pools
+    assert "/Common/dg" in bundle.data_groups
+
+
+def test_build_irule_context_records_unresolved():
+    _cfg, _rule, bundle = _bundle()
+    assert "pool" in bundle.unresolved
+    assert "/Common/missing" in bundle.unresolved["pool"]
+
+
+def test_build_irule_context_transitive_pulls_node_and_monitor():
+    _cfg, _rule, bundle = _bundle()
+    # Pool member /Common/n1:80 → node /Common/n1
+    assert "/Common/n1" in bundle.nodes
+    # Pool monitor /Common/http → monitor /Common/http
+    assert "/Common/http" in bundle.monitors
+
+
+def test_build_irule_context_no_transitive_skips_pool_chase():
+    cfg = parse_bigip_conf(_SAMPLE_CONF)
+    rule = cfg.rules["/Common/foo"]
+    bundle = build_irule_context(rule, cfg, transitive=False)
+    assert "/Common/web_pool" in bundle.pools
+    assert bundle.nodes == {}
+
+
+def test_context_bundle_to_dict_shape():
+    _cfg, _rule, bundle = _bundle()
+    payload = context_bundle_to_dict(bundle)
+    assert payload["rule"]["fullPath"] == "/Common/foo"
+    pool_paths = {p["fullPath"] for p in payload["pools"]}
+    assert pool_paths == {"/Common/web_pool"}
+    assert payload["unresolved"]["pool"] == ["/Common/missing"]
+
+
+def test_context_bundle_to_text_uses_source_slices():
+    _cfg, _rule, bundle = _bundle()
+    text = context_bundle_to_text(bundle)
+    # Rule body and referenced objects are present.
+    assert "iRule /Common/foo" in text
+    assert "referenced pool /Common/web_pool" in text
+    assert "referenced data-group /Common/dg" in text
+    # Source slices preserve the original Tcl text verbatim.
+    assert "ltm pool /Common/web_pool" in text
+    # Unresolved pool surfaces.
+    assert "pool: /Common/missing" in text
+
+
+def test_context_bundle_to_text_synthetic_when_no_sources():
+    cfg = parse_bigip_conf(_SAMPLE_CONF)
+    rule = cfg.rules["/Common/foo"]
+    bundle = build_irule_context(rule, cfg)  # no sources
+    text = context_bundle_to_text(bundle)
+    # Rule body is still rendered (synthetic stanza wrapper).
+    assert "iRule /Common/foo" in text
+    assert "ltm rule /Common/foo {" in text
+
+
+# ---------------------------------------------------------------------------
+# MCP tool
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_irule_with_context_json():
+    from ai.mcp.tcl_mcp_server import _tool_irule_with_context
+
+    payload = json.loads(
+        _tool_irule_with_context(
+            rule_path="/Common/foo",
+            config_text=_SAMPLE_CONF,
+            format="json",
+        )
+    )
+    assert payload["format"] == "json"
+    assert len(payload["bundles"]) == 1
+    bundle = payload["bundles"][0]
+    assert bundle["rule"]["fullPath"] == "/Common/foo"
+    assert any(p["fullPath"] == "/Common/web_pool" for p in bundle["pools"])
+
+
+def test_mcp_irule_with_context_text():
+    from ai.mcp.tcl_mcp_server import _tool_irule_with_context
+
+    payload = json.loads(
+        _tool_irule_with_context(
+            rule_path="/Common/foo",
+            config_text=_SAMPLE_CONF,
+            format="text",
+        )
+    )
+    assert payload["format"] == "text"
+    text = payload["bundles"][0]["text"]
+    assert "iRule /Common/foo" in text
+    assert "referenced pool /Common/web_pool" in text
+
+
+def test_mcp_irule_with_context_all_rules_when_path_blank():
+    from ai.mcp.tcl_mcp_server import _tool_irule_with_context
+
+    payload = json.loads(_tool_irule_with_context(config_text=_SAMPLE_CONF))
+    assert len(payload["bundles"]) == 1  # only one rule in sample
+
+
+def test_mcp_irule_with_context_missing_input_returns_error():
+    from ai.mcp.tcl_mcp_server import _tool_irule_with_context
+
+    payload = json.loads(_tool_irule_with_context(rule_path="/Common/foo"))
+    assert "error" in payload
+
+
+def test_mcp_irule_with_context_unknown_rule_returns_error():
+    from ai.mcp.tcl_mcp_server import _tool_irule_with_context
+
+    payload = json.loads(
+        _tool_irule_with_context(
+            rule_path="/Common/nope",
+            config_text=_SAMPLE_CONF,
+        )
+    )
+    assert "error" in payload

--- a/tests/test_irule_context.py
+++ b/tests/test_irule_context.py
@@ -205,6 +205,18 @@ def test_mcp_irule_with_context_ucs_path(tmp_path):
     assert "/Common/web_pool" in pool_paths
 
 
+def test_self_reference_in_rule_body_is_not_unresolved():
+    """Recursive ``call rule`` of the current rule should be silently
+    skipped — recording it as unresolved would surface a misleading
+    “missing rule” entry on every recursive iRule."""
+    src = "ltm rule /Common/recurse {\n  when HTTP_REQUEST {\n    call /Common/recurse\n  }\n}\n"
+    cfg = parse_bigip_conf(src)
+    rule = cfg.rules["/Common/recurse"]
+    bundle = build_irule_context(rule, cfg)
+    assert "rule" not in bundle.unresolved
+    assert "/Common/recurse" not in bundle.rules  # not added; it *is* the rule
+
+
 def test_f5_irule_context_multi_file_keeps_source_slices(tmp_path, capsys):
     """Regression for the Codex P2 source-slice key-mismatch bug.
 

--- a/tests/test_irule_context.py
+++ b/tests/test_irule_context.py
@@ -15,7 +15,6 @@ from ai.shared.irule_context import (
 )
 from core.bigip.parser import parse_bigip_conf
 
-
 _SAMPLE_CONF = """\
 ltm pool /Common/web_pool {
     members { /Common/n1:80 { address 10.0.0.1 } }
@@ -39,11 +38,15 @@ when HTTP_REQUEST {
 def _bundle():
     cfg = parse_bigip_conf(_SAMPLE_CONF)
     rule = cfg.rules["/Common/foo"]
-    return cfg, rule, build_irule_context(
-        rule,
+    return (
         cfg,
-        sources={"inline://0": _SAMPLE_CONF},
-        config_origin="inline://0",
+        rule,
+        build_irule_context(
+            rule,
+            cfg,
+            sources={"inline://0": _SAMPLE_CONF},
+            config_origin="inline://0",
+        ),
     )
 
 
@@ -169,3 +172,63 @@ def test_mcp_irule_with_context_unknown_rule_returns_error():
         )
     )
     assert "error" in payload
+
+
+def test_mcp_irule_with_context_ucs_path(tmp_path):
+    """``config_paths`` must extract UCS archives, not feed gzip bytes
+    straight to the parser (regression for the original Codex review)."""
+    from ai.mcp.tcl_mcp_server import _tool_irule_with_context
+    from explorer.f5_remote.ucs import make_test_ucs
+
+    ucs_path = tmp_path / "device.ucs"
+    ucs_path.write_bytes(
+        make_test_ucs(
+            {
+                "config/bigip.conf": (
+                    "ltm pool /Common/web_pool { members { /Common/n1:80 { } } }\n"
+                    "ltm rule /Common/foo { when HTTP_REQUEST { pool /Common/web_pool } }\n"
+                ),
+            }
+        )
+    )
+    payload = json.loads(
+        _tool_irule_with_context(
+            rule_path="/Common/foo",
+            config_paths=[str(ucs_path)],
+            format="json",
+        )
+    )
+    assert payload["format"] == "json"
+    bundle = payload["bundles"][0]
+    assert bundle["rule"]["fullPath"] == "/Common/foo"
+    pool_paths = {p["fullPath"] for p in bundle["pools"]}
+    assert "/Common/web_pool" in pool_paths
+
+
+def test_f5_irule_context_multi_file_keeps_source_slices(tmp_path, capsys):
+    """Regression for the Codex P2 source-slice key-mismatch bug.
+
+    With more than one file input the source-slice map and the config
+    map must use the same keys so :func:`build_irule_context` can hand
+    each rule's slice back to the renderer.
+    """
+    a = tmp_path / "a.conf"
+    b = tmp_path / "b.conf"
+    a.write_text(
+        "ltm pool /Common/web_pool { members { /Common/n1:80 { } } }\n",
+        encoding="utf-8",
+    )
+    b.write_text(
+        "ltm rule /Common/foo { when HTTP_REQUEST { pool /Common/web_pool } }\n",
+        encoding="utf-8",
+    )
+
+    from explorer.f5_cli import main
+
+    rc = main(["irule", "context", str(a), str(b), "--rule", "/Common/foo"])
+    out = capsys.readouterr().out
+    # Slice from b.conf is reused verbatim — exact-text match,
+    # not the synthetic ``ltm rule … {`` wrapper that build_irule_context
+    # would emit when no source slice is available.
+    assert rc == 0
+    assert "ltm rule /Common/foo { when HTTP_REQUEST { pool /Common/web_pool } }" in out


### PR DESCRIPTION
The f5 CLI's irule verb group gains three new sub-verbs and a richer
input contract:

- f5 irule format / minify pretty-print or strip an iRule (or every
  iRule in a bigip.conf / SCF / UCS).  Single-rule input writes to
  stdout / -o FILE; multi-rule input writes one .irule per rule
  under -o DIR.
- f5 irule context bundles each iRule with the BIG-IP objects it
  references (pools, data groups, persistence profiles, snat pools,
  profiles, monitors, nodes, called rules) plus a one-hop transitive
  expansion (pool members -> nodes; pool monitor -> monitor object).
  Designed to be dropped into an LLM prompt or consumed by AI
  tooling that needs the full context for an iRule end-to-end.

Every irule sub-verb (except event-info) now accepts a flexible mix
of inputs: individual .irul / .irule / .tcl files, bigip.conf / SCF
/ UCS archives, --source snippets, or stdin.  A new
load_irule_inputs helper centralises the classification and
synthesises a single-rule BigipConfig for standalone .irule input
so lint / trace can drive the same engine.

When the input is a bigip.conf / SCF / UCS, the iRule lint and
trace verbs now leverage the surrounding BIG-IP context for deeper
static analysis: a new irule-missing-* lint rule family flags
references to undefined pools, data groups, persistence profiles,
snat pools, monitors, profiles, nodes, and rules; trace JSON
gains a `references` array that resolves every pool / data-group /
persistence reference against the merged config.  Standalone
.irule input runs in degraded mode and the missing-object checks
silently skip to avoid false positives.

The AI-tool surface gets the same context bundle:

- ai/shared/irule_context.py: IruleContextBundle dataclass plus
  build_irule_context, context_bundle_to_dict, context_bundle_to_text
  rendering helpers.  Source slices are reused verbatim when the
  caller supplies the original config text.
- ai/mcp/tcl_mcp_server.py: new irule_with_context MCP tool that
  takes config_text or config_paths and returns either a JSON
  bundle or a Tcl-flavoured text block.

The f5 grep CLI surface renames the user-facing "seed" terminology
to "search": JSON output keys (seeds -> searches, isSeed -> isSearch),
text-report headers (# Seeds: -> # Searches:), and help-text wording.
Internal data-model field names (GrepReport.seeds, GrepObject.is_seed)
are unchanged so the core grep test suite stays green.

https://claude.ai/code/session_01QNsE6nbjq54piKwbfC8KYG