### PR TITLE
Fix race condition in per-folder config application (#407)

### DIFF
--- a/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
+++ b/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
@@ -9,10 +9,13 @@ import * as vscode from "vscode";
 interface EffectiveConfig {
   uri: string;
   folder_uri: string | null;
-  dialect: string | null;
-  extra_commands: string[] | null;
+  // Resolved values: folder override → workspace fallback → process default.
+  // ``dialect`` always concrete (e.g. "tcl8.6"), never null.
+  // ``extra_commands`` / ``library_paths`` always arrays (empty when unset).
+  dialect: string;
+  extra_commands: string[];
   non_ascii_mode: string | null;
-  library_paths: string[] | null;
+  library_paths: string[];
   line_length: number;
   dialect_explicitly_set: boolean;
   known_folder_uris: string[];

--- a/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
+++ b/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
@@ -6,6 +6,55 @@ import * as assert from "assert";
 import * as path from "path";
 import * as vscode from "vscode";
 
+interface EffectiveConfig {
+  uri: string;
+  folder_uri: string | null;
+  dialect: string | null;
+  extra_commands: string[] | null;
+  non_ascii_mode: string | null;
+  library_paths: string[] | null;
+  line_length: number;
+  dialect_explicitly_set: boolean;
+  known_folder_uris: string[];
+}
+
+/**
+ * Wait until the server reports that ``workspace/configuration`` has been
+ * pulled and applied for every folder, by polling the
+ * ``tcl-lsp.getEffectiveConfig`` command until each folder's resolved
+ * dialect matches the value the fixture's ``.vscode/settings.json``
+ * configured.  Replaces a brittle ``setTimeout(3000)`` that masked the
+ * race issue #407 caught in real-world use.
+ */
+async function waitForConfigSettled(
+  expected: Record<string, string>,
+  timeoutMs: number = 15000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last: Record<string, EffectiveConfig | null> = {};
+  while (Date.now() < deadline) {
+    let allMatch = true;
+    for (const [folderName, wantDialect] of Object.entries(expected)) {
+      const folder = vscode.workspace.workspaceFolders!.find((f) => f.name === folderName)!;
+      const cfg = (await vscode.commands.executeCommand(
+        "tcl-lsp.getEffectiveConfig",
+        folder.uri.toString(),
+      )) as EffectiveConfig | undefined;
+      last[folderName] = cfg ?? null;
+      if (!cfg || cfg.dialect !== wantDialect) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) return;
+    await new Promise((r) => setTimeout(r, 75));
+  }
+  throw new Error(
+    `Timed out waiting for per-folder config to settle after ${timeoutMs}ms.  ` +
+      `Expected: ${JSON.stringify(expected)}.  Last seen: ${JSON.stringify(last)}`,
+  );
+}
+
 suite("Multi-folder workspace configuration (#230)", () => {
   suiteSetup(async () => {
     // Wait for the extension to activate so the LSP client is ready.
@@ -14,10 +63,10 @@ suite("Multi-folder workspace configuration (#230)", () => {
     if (!ext.isActive) {
       await ext.activate();
     }
-    // The server pulls per-folder config asynchronously after
-    // ``initialized``; give it a moment to settle so format requests
-    // see the resolved per-folder formatter config.
-    await new Promise((r) => setTimeout(r, 3000));
+    // Poll the server for its resolved per-folder dialect rather than
+    // sleeping on wall-clock time -- the previous setTimeout(3000) masked
+    // the race that issue #407 actually reports.
+    await waitForConfigSettled({ "proj-a": "tcl8.4", "proj-b": "f5-irules" });
   });
 
   test("workspace is opened in multi-folder mode with two folders", () => {
@@ -394,4 +443,114 @@ suite("Multi-folder workspace configuration (#230)", () => {
       `folder B (no extraCommands for folder-a-helper) should emit W123 for it.  Got: ${JSON.stringify(w123B.map((d) => d.message))}`,
     );
   });
+
+  test("tcl-lsp.getEffectiveConfig reports the resolved per-folder dialect", async () => {
+    // Sanity check the helper the suite setup uses -- if this regresses
+    // the rest of the suite will hit the 3-second-wait situation issue
+    // #407 reports, just by a different path.
+    const folderA = vscode.workspace.workspaceFolders!.find((f) => f.name === "proj-a")!;
+    const folderB = vscode.workspace.workspaceFolders!.find((f) => f.name === "proj-b")!;
+
+    const cfgA = (await vscode.commands.executeCommand(
+      "tcl-lsp.getEffectiveConfig",
+      folderA.uri.toString(),
+    )) as EffectiveConfig;
+    const cfgB = (await vscode.commands.executeCommand(
+      "tcl-lsp.getEffectiveConfig",
+      folderB.uri.toString(),
+    )) as EffectiveConfig;
+
+    assert.strictEqual(cfgA.dialect, "tcl8.4");
+    assert.strictEqual(cfgB.dialect, "f5-irules");
+    assert.strictEqual(cfgA.non_ascii_mode, "strict");
+    assert.strictEqual(cfgB.non_ascii_mode, "off");
+    assert.deepStrictEqual(cfgA.extra_commands, ["folder-a-helper", "shared-util"]);
+    assert.deepStrictEqual(cfgB.extra_commands, ["folder-b-helper"]);
+  });
 });
+
+// Race-detection harness for issue #407: when a per-folder dialect
+// arrives *after* a document's first analyse the cached AnalysisResult
+// keeps its stale dialect-baked W002 / W108 / W123 diagnostics.  Direct
+// startup-race reproduction would need a fresh VS Code process per test
+// (mocha shares one process), so this suite drives the same code path
+// by flipping the folder's ``tclLsp.dialect`` at runtime via
+// ``WorkspaceConfiguration.update()`` and asserting the in-cache
+// diagnostics catch up.
+suite("Multi-folder per-folder dialect change after open (#407)", () => {
+  test("flipping a folder's dialect re-analyses already-open files", async () => {
+    // Suite ``Multi-folder workspace configuration (#230)`` ran first
+    // and already waited for the initial config to settle, so proj-b
+    // is on f5-irules at this point.
+    const folderB = vscode.workspace.workspaceFolders!.find((f) => f.name === "proj-b")!;
+    const fileUri = vscode.Uri.file(path.join(folderB.uri.fsPath, "race.tcl"));
+    const source =
+      'if { [active_members http_pool] >= 2 } {\n    puts "ok"\n}\n';
+
+    // 1. Switch folder B off iRules and wait for the server to settle.
+    //    ``active_members`` becomes a disallowed builtin under tcl8.6,
+    //    so the analyser should bake W002 into the cached analysis.
+    const cfgB = vscode.workspace.getConfiguration("tclLsp", folderB.uri);
+    try {
+      await cfgB.update("dialect", "tcl8.6", vscode.ConfigurationTarget.WorkspaceFolder);
+      await waitForConfigSettled({ "proj-a": "tcl8.4", "proj-b": "tcl8.6" });
+
+      // Open the file under tcl8.6 -- W002 must fire.
+      const doc = await vscode.workspace.openTextDocument(fileUri);
+      const editor = await vscode.window.showTextDocument(doc);
+      await editor.edit((e) => {
+        const lastLine = doc.lineCount - 1;
+        const lastChar = doc.lineAt(lastLine).text.length;
+        e.replace(
+          new vscode.Range(new vscode.Position(0, 0), new vscode.Position(lastLine, lastChar)),
+          source,
+        );
+      });
+      const w002Initial = await waitForDiagnostic(fileUri, "W002", true);
+      assert.ok(
+        w002Initial.length > 0,
+        `precondition: W002 should fire under tcl8.6.  Got: ${JSON.stringify(
+          vscode.languages.getDiagnostics(fileUri).map((d) => [d.code, d.message]),
+        )}`,
+      );
+
+      // 2. Flip the folder back to f5-irules and wait for the pull to
+      //    settle.  The fix in ``_apply_merged_settings_now`` must
+      //    detect the per-folder dialect change and re-analyse the
+      //    already-open file, clearing the now-stale W002.
+      await cfgB.update("dialect", "f5-irules", vscode.ConfigurationTarget.WorkspaceFolder);
+      await waitForConfigSettled({ "proj-a": "tcl8.4", "proj-b": "f5-irules" });
+      const w002Cleared = await waitForDiagnostic(fileUri, "W002", false);
+      assert.strictEqual(
+        w002Cleared.length,
+        0,
+        `W002 must clear once the per-folder dialect resolves to f5-irules.  ` +
+          `Got: ${JSON.stringify(w002Cleared.map((d) => d.message))}`,
+      );
+    } finally {
+      // Restore the fixture state so subsequent tests see the original
+      // .vscode/settings.json values.
+      await cfgB.update("dialect", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await waitForConfigSettled({ "proj-a": "tcl8.4", "proj-b": "f5-irules" });
+    }
+  });
+});
+
+// Wait up to *timeoutMs* for a diagnostic with the given *code* to be
+// present (or absent if *wantPresent* is false) on *uri*.  Polls every
+// 100ms; returns the matching diagnostics for the final state.
+async function waitForDiagnostic(
+  uri: vscode.Uri,
+  code: string,
+  wantPresent: boolean,
+  timeoutMs: number = 6000,
+): Promise<vscode.Diagnostic[]> {
+  const deadline = Date.now() + timeoutMs;
+  let matches: vscode.Diagnostic[] = [];
+  while (Date.now() < deadline) {
+    matches = vscode.languages.getDiagnostics(uri).filter((d) => d.code === code);
+    if (wantPresent ? matches.length > 0 : matches.length === 0) return matches;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return matches;
+}

--- a/lsp/commands.py
+++ b/lsp/commands.py
@@ -320,6 +320,51 @@ def on_list_irule_events() -> dict:
     }
 
 
+def on_get_effective_config(uri: str | None = None) -> dict:
+    """Return the resolved per-folder config for ``uri``.
+
+    Surfaces the settings the language server *actually* applies to a
+    document — useful for diagnosing per-folder configuration races
+    (issue #407) and for tests that need to wait for
+    ``workspace/configuration`` to settle without polling on wall-clock
+    time.
+
+    When *uri* is empty/None, returns the workspace-fallback view.
+
+    Returns:
+        ``{
+            "uri": str,
+            "folder_uri": str | None,
+            "dialect": str | None,
+            "extra_commands": list[str] | None,
+            "non_ascii_mode": str | None,
+            "library_paths": list[str] | None,
+            "line_length": int,
+            "dialect_explicitly_set": bool,
+            "known_folder_uris": list[str],
+        }``
+    """
+    cfg = _state.config_for_uri(uri)
+    folder_uri: str | None = None
+    if uri:
+        for candidate in _state.workspace_folder_uris():
+            normalised = candidate.rstrip("/")
+            if uri == normalised or uri.startswith(normalised + "/"):
+                if folder_uri is None or len(normalised) > len(folder_uri.rstrip("/")):
+                    folder_uri = candidate
+    return {
+        "uri": uri or "",
+        "folder_uri": folder_uri,
+        "dialect": cfg.dialect,
+        "extra_commands": list(cfg.extra_commands) if cfg.extra_commands is not None else None,
+        "non_ascii_mode": cfg.non_ascii_mode,
+        "library_paths": list(cfg.library_paths) if cfg.library_paths is not None else None,
+        "line_length": cfg.line_length,
+        "dialect_explicitly_set": cfg.dialect_explicitly_set,
+        "known_folder_uris": list(_state.workspace_folder_uris()),
+    }
+
+
 def on_list_subcommands(command_name: str) -> dict:
     """Return subcommand metadata for a command from the registry."""
     name = (command_name or "").strip()
@@ -1048,6 +1093,7 @@ def register(server_instance: LanguageServer) -> None:
     server_instance.command("tcl-lsp.describeIruleCommand")(on_describe_irule_command)
     server_instance.command("tcl-lsp.fixAllSafeIssues")(on_fix_all_safe_issues)
     server_instance.command("tcl-lsp.listIruleEvents")(on_list_irule_events)
+    server_instance.command("tcl-lsp.getEffectiveConfig")(on_get_effective_config)
     server_instance.command("tcl-lsp.listSubcommands")(on_list_subcommands)
     server_instance.command("tcl-lsp.listKnownPackages")(on_list_known_packages)
     server_instance.command("tcl-lsp.suggestPackagesForSymbol")(on_suggest_packages_for_symbol)

--- a/lsp/commands.py
+++ b/lsp/commands.py
@@ -321,13 +321,25 @@ def on_list_irule_events() -> dict:
 
 
 def on_get_effective_config(uri: str | None = None) -> dict:
-    """Return the resolved per-folder config for ``uri``.
+    """Return the *resolved* per-folder config for ``uri``.
 
-    Surfaces the settings the language server *actually* applies to a
-    document — useful for diagnosing per-folder configuration races
-    (issue #407) and for tests that need to wait for
+    Returns the values the language server **actually applies** to a
+    document — folder override → workspace fallback → process default,
+    in that order — so callers see what the analyser/formatter would
+    see at request time.  Useful for diagnosing per-folder configuration
+    races (issue #407) and for tests that need to wait for
     ``workspace/configuration`` to settle without polling on wall-clock
     time.
+
+    The raw folder-cfg fields would surface ``None`` for any setting
+    the folder inherits from the workspace (and ``FeatureConfig`` uses
+    ``None``-as-inherit for ``dialect`` / ``extra_commands`` /
+    ``library_paths``), making the result ambiguous for a polling
+    client that's waiting for a concrete value.  Every field is
+    resolved through the same precedence the diagnostics pipeline
+    uses, so the returned ``dialect`` is always concrete (never null)
+    and the list fields are always lists (empty when nothing is
+    configured anywhere).
 
     When *uri* is empty/None, returns the workspace-fallback view.
 
@@ -335,16 +347,19 @@ def on_get_effective_config(uri: str | None = None) -> dict:
         ``{
             "uri": str,
             "folder_uri": str | None,
-            "dialect": str | None,
-            "extra_commands": list[str] | None,
-            "non_ascii_mode": str | None,
-            "library_paths": list[str] | None,
+            "dialect": str,                  # resolved; never null
+            "extra_commands": list[str],     # resolved; empty list when none configured
+            "non_ascii_mode": str | None,    # null only when process default applies
+            "library_paths": list[str],      # resolved
             "line_length": int,
             "dialect_explicitly_set": bool,
             "known_folder_uris": list[str],
         }``
     """
+    from core.common.dialect import active_dialect
+
     cfg = _state.config_for_uri(uri)
+    fallback = _state.feature_config
     folder_uri: str | None = None
     if uri:
         for candidate in _state.workspace_folder_uris():
@@ -352,13 +367,32 @@ def on_get_effective_config(uri: str | None = None) -> dict:
             if uri == normalised or uri.startswith(normalised + "/"):
                 if folder_uri is None or len(normalised) > len(folder_uri.rstrip("/")):
                     folder_uri = candidate
+
+    # Resolve dialect via the same precedence the diagnostic pipeline
+    # uses (in-source hints → folder → workspace → process default).
+    # Falls through to ``active_dialect()`` when no in-source / folder
+    # / workspace value is set, so polling clients never see ``null``
+    # for a setting the analyser would have a concrete value for.
+    resolved_dialect, resolved_extras = _state.resolve_dialect_for_uri(uri)
+    if resolved_dialect is None:
+        resolved_dialect = active_dialect()
+
+    resolved_extra_commands = list(resolved_extras) if resolved_extras is not None else []
+    if cfg.library_paths is not None:
+        resolved_library_paths = list(cfg.library_paths)
+    elif fallback.library_paths is not None:
+        resolved_library_paths = list(fallback.library_paths)
+    else:
+        resolved_library_paths = []
+    resolved_non_ascii = cfg.non_ascii_mode or fallback.non_ascii_mode
+
     return {
         "uri": uri or "",
         "folder_uri": folder_uri,
-        "dialect": cfg.dialect,
-        "extra_commands": list(cfg.extra_commands) if cfg.extra_commands is not None else None,
-        "non_ascii_mode": cfg.non_ascii_mode,
-        "library_paths": list(cfg.library_paths) if cfg.library_paths is not None else None,
+        "dialect": resolved_dialect,
+        "extra_commands": resolved_extra_commands,
+        "non_ascii_mode": resolved_non_ascii,
+        "library_paths": resolved_library_paths,
         "line_length": cfg.line_length,
         "dialect_explicitly_set": cfg.dialect_explicitly_set,
         "known_folder_uris": list(_state.workspace_folder_uris()),

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -551,6 +551,24 @@ def _apply_merged_settings_now() -> None:
     global _pending_apply_handle
     _pending_apply_handle = None
 
+    # Snapshot each open document's resolved (dialect, extras, non_ascii_mode)
+    # before any cfg mutates so we can detect per-folder dialect changes that
+    # don't show up in ``signatures_changed`` below (which only tracks the
+    # workspace-level ``configure_signatures`` call).  Without this, a folder
+    # whose ``tclLsp.dialect`` arrives late via ``workspace/configuration``
+    # (a normal race on session start, when ``did_open`` for already-open
+    # editors fires before the pull callback returns) leaves W002 / W108 /
+    # W123 baked into the cached analysis even after the per-folder dialect
+    # resolves to the right value.  See issue #407.
+    pre_apply_doc_resolution: dict[str, tuple] = {}
+    for uri, doc_state in _state.workspace_state.items():
+        dialect, extras = _state.resolve_dialect_for_uri(uri, doc_state.source)
+        pre_apply_doc_resolution[uri] = (
+            dialect,
+            extras,
+            _state.config_for_uri(uri).non_ascii_mode,
+        )
+
     fallback_settings = _merged_settings()
 
     # Process-wide settings: signatures (dialect / extraCommands), library
@@ -705,7 +723,20 @@ def _apply_merged_settings_now() -> None:
     except RuntimeError:
         loop = None
     for uri, doc_state in _state.workspace_state.items():
-        if signatures_changed and loop is not None:
+        # Did this doc's resolved dialect / extras / non-ASCII mode change?
+        # If so the cached analysis was built with stale per-folder settings
+        # — dialect-baked checks (W002, W108, W123, irules_checks etc.) need
+        # a re-analyse, not just a re-publish.  See issue #407.
+        new_dialect, new_extras = _state.resolve_dialect_for_uri(uri, doc_state.source)
+        new_resolution = (
+            new_dialect,
+            new_extras,
+            _state.config_for_uri(uri).non_ascii_mode,
+        )
+        doc_force_reanalyse = signatures_changed or (
+            pre_apply_doc_resolution.get(uri) != new_resolution
+        )
+        if doc_force_reanalyse and loop is not None:
             loop.create_task(
                 _publish_diagnostics(
                     uri,
@@ -719,7 +750,7 @@ def _apply_merged_settings_now() -> None:
                 uri,
                 doc_state.source,
                 doc_state.version,
-                force_reanalyse=signatures_changed,
+                force_reanalyse=doc_force_reanalyse,
             )
 
     if diags_were_enabled and not _state.feature_config.diagnostics_enabled:

--- a/lsp/settings.py
+++ b/lsp/settings.py
@@ -551,22 +551,29 @@ def _apply_merged_settings_now() -> None:
     global _pending_apply_handle
     _pending_apply_handle = None
 
-    # Snapshot each open document's resolved (dialect, extras, non_ascii_mode)
-    # before any cfg mutates so we can detect per-folder dialect changes that
-    # don't show up in ``signatures_changed`` below (which only tracks the
-    # workspace-level ``configure_signatures`` call).  Without this, a folder
-    # whose ``tclLsp.dialect`` arrives late via ``workspace/configuration``
-    # (a normal race on session start, when ``did_open`` for already-open
-    # editors fires before the pull callback returns) leaves W002 / W108 /
-    # W123 baked into the cached analysis even after the per-folder dialect
-    # resolves to the right value.  See issue #407.
+    # Snapshot each open document's resolved settings *before* any cfg
+    # mutates so we can detect per-folder changes that don't show up in
+    # ``signatures_changed`` below (which only tracks the workspace-level
+    # ``configure_signatures`` call).  Without this, a folder whose
+    # ``tclLsp.dialect`` (or other analyser-baked setting) arrives late
+    # via ``workspace/configuration`` -- a normal race on session start,
+    # when ``did_open`` for already-open editors fires before the pull
+    # callback returns -- leaves W002 / W108 / W123 baked into the cached
+    # analysis even after the per-folder setting resolves to the right
+    # value.  ``disabled_diagnostics`` is in the tuple too because the
+    # analyser gates W123 / W242 / W307 / W308 emission on it (see
+    # ``_effective_disabled_diagnostics``); user-toggled diagnostic
+    # enablement therefore changes what's in the cached AnalysisResult,
+    # not just the post-filter.  See issue #407.
     pre_apply_doc_resolution: dict[str, tuple] = {}
     for uri, doc_state in _state.workspace_state.items():
         dialect, extras = _state.resolve_dialect_for_uri(uri, doc_state.source)
+        cfg_for_uri = _state.config_for_uri(uri)
         pre_apply_doc_resolution[uri] = (
             dialect,
             extras,
-            _state.config_for_uri(uri).non_ascii_mode,
+            cfg_for_uri.non_ascii_mode,
+            frozenset(cfg_for_uri.disabled_diagnostics),
         )
 
     fallback_settings = _merged_settings()
@@ -723,15 +730,18 @@ def _apply_merged_settings_now() -> None:
     except RuntimeError:
         loop = None
     for uri, doc_state in _state.workspace_state.items():
-        # Did this doc's resolved dialect / extras / non-ASCII mode change?
-        # If so the cached analysis was built with stale per-folder settings
-        # — dialect-baked checks (W002, W108, W123, irules_checks etc.) need
-        # a re-analyse, not just a re-publish.  See issue #407.
+        # Did this doc's resolved dialect / extras / non-ASCII mode /
+        # disabled_diagnostics change?  If so the cached analysis was
+        # built with stale per-folder settings — dialect-baked checks
+        # (W002, W108, W123, irules_checks etc.) need a re-analyse, not
+        # just a re-publish.  See issue #407.
         new_dialect, new_extras = _state.resolve_dialect_for_uri(uri, doc_state.source)
+        new_cfg = _state.config_for_uri(uri)
         new_resolution = (
             new_dialect,
             new_extras,
-            _state.config_for_uri(uri).non_ascii_mode,
+            new_cfg.non_ascii_mode,
+            frozenset(new_cfg.disabled_diagnostics),
         )
         doc_force_reanalyse = signatures_changed or (
             pre_apply_doc_resolution.get(uri) != new_resolution

--- a/lsp/workspace/document_state.py
+++ b/lsp/workspace/document_state.py
@@ -146,6 +146,28 @@ _IAPPS_EXTENSIONS = (".iapp", ".iappimpl", ".impl", ".apl")
 _EXPECT_EXTENSIONS = (".exp",)
 
 
+def _effective_disabled_diagnostics(uri: str | None) -> frozenset[str]:
+    """Effective ``disabled_diagnostics`` for the analyser at *uri*.
+
+    The analyser gates expensive opt-in checks (W123 unresolved-command
+    suggestions, W242 loop termination, W307/W308 indirect-call checks,
+    etc.) on its ``_disabled_diagnostics`` set.  Constructing the
+    analyser with the static ``default_disabled_diagnostics()`` made it
+    impossible for users to enable opt-in codes via
+    ``tclLsp.diagnostics.<code>: true`` (the user's choice was filtered
+    only *post*-analysis by ``get_basic_diagnostics`` — but the analyser
+    had already short-circuited the emit path).  Resolving the
+    per-folder ``FeatureConfig`` here keeps the gate honest.
+
+    Done as a lazy import to break the ``lsp.state`` ↔
+    ``lsp.workspace.document_state`` import cycle.
+    """
+    from lsp.state import config_for_uri
+
+    cfg = config_for_uri(uri)
+    return frozenset(cfg.disabled_diagnostics)
+
+
 def infer_document_dialect(uri: str, source: str, language_id: str = "") -> str | None:
     """Infer the best dialect hint for a single document."""
     lang = language_id.lower()
@@ -206,6 +228,19 @@ def _analyse_document_fresh(
 
         set_non_ascii_mode(non_ascii_mode)
 
+    # The analyser gates expensive opt-in checks (W123 unresolved-command
+    # suggestions, W242 loop termination, etc.) on its
+    # ``_disabled_diagnostics`` set.  Use the *effective* set from the
+    # parent's ``feature_config`` (already filtered for user enablement)
+    # rather than ``default_disabled_diagnostics()`` so opt-in codes the
+    # user has enabled via ``tclLsp.diagnostics.<code>: true`` actually
+    # reach the emit path.  See issue #407 follow-up.
+    analyser_disabled = (
+        frozenset(disabled_diagnostics)
+        if disabled_diagnostics is not None
+        else default_disabled_diagnostics()
+    )
+
     t0 = time.perf_counter()
 
     chunks = segment_top_level_chunks(source)
@@ -228,7 +263,7 @@ def _analyse_document_fresh(
 
         analysis, embedded_rules = analyse_conf_wrapped(
             source,
-            disabled_diagnostics=default_disabled_diagnostics(),
+            disabled_diagnostics=analyser_disabled,
             file_path=uri,
         )
         all_profiles: set[str] = set()
@@ -284,7 +319,7 @@ def _analyse_document_fresh(
         log.debug("subprocess: compilation failed", exc_info=True)
 
     chunk_commands = [list(chunk.commands) for chunk in chunks]
-    analyser = Analyser(disabled_diagnostics=default_disabled_diagnostics())
+    analyser = Analyser(disabled_diagnostics=analyser_disabled)
     analysis, chunk_snapshots = analyser.analyse_chunked(
         source,
         chunk_commands,
@@ -1163,8 +1198,9 @@ class DocumentState:
 
         dirty_chunk_commands = [list(chunk.commands) for chunk in new_chunks[dirty_idx:]]
 
+        analyser_disabled = _effective_disabled_diagnostics(self.uri)
         if restore_snapshot is not None:
-            analyser = Analyser(disabled_diagnostics=default_disabled_diagnostics())
+            analyser = Analyser(disabled_diagnostics=analyser_disabled)
             analyser.restore(restore_snapshot)
             analysis, dirty_snapshots = analyser.analyse_chunked(
                 source,
@@ -1175,7 +1211,7 @@ class DocumentState:
             )
         else:
             # No snapshot to restore from — full chunked analysis.
-            analyser = Analyser(disabled_diagnostics=default_disabled_diagnostics())
+            analyser = Analyser(disabled_diagnostics=analyser_disabled)
             analysis, dirty_snapshots = analyser.analyse_chunked(
                 source,
                 dirty_chunk_commands,
@@ -1384,7 +1420,7 @@ class DocumentState:
         # chunk-by-chunk, capturing snapshots at each boundary.  This avoids
         # the old pattern of running analyse() then re-analysing per-chunk.
         chunk_commands = [list(chunk.commands) for chunk in new_chunks]
-        analyser = Analyser(disabled_diagnostics=default_disabled_diagnostics())
+        analyser = Analyser(disabled_diagnostics=_effective_disabled_diagnostics(self.uri))
         analysis, chunk_snapshots = analyser.analyse_chunked(
             source,
             chunk_commands,
@@ -1452,7 +1488,7 @@ class DocumentState:
 
         analysis, embedded_rules = analyse_conf_wrapped(
             source,
-            disabled_diagnostics=default_disabled_diagnostics(),
+            disabled_diagnostics=_effective_disabled_diagnostics(self.uri),
             file_path=self.uri,
         )
 

--- a/tests/test_per_folder_config.py
+++ b/tests/test_per_folder_config.py
@@ -25,6 +25,37 @@ from core.formatting import FormatterConfig
 from lsp.feature_config import FeatureConfig
 
 
+def _install_diag_capture(captured: dict) -> object:
+    """Stub the diagnostics-pipeline publisher so tests can inspect diagnostics.
+
+    Returns the original ``_publish_diags_to_client`` value so the caller
+    can restore it in a ``finally`` block.  Centralised here so the
+    ``# type: ignore`` for the deliberate signature-mismatch only appears
+    once instead of in every test method.
+    """
+    import lsp.diagnostics_pipeline as _dp
+
+    orig = _dp._publish_diags_to_client
+
+    def _capture(uri: str, diagnostics: list, version: int | None = None) -> None:
+        captured[uri] = list(diagnostics)
+
+    _dp._publish_diags_to_client = _capture  # type: ignore[assignment]
+
+    class _DummyServer:
+        @staticmethod
+        def text_document_publish_diagnostics(*_a: object, **_kw: object) -> None: ...
+
+    _dp.configure(_DummyServer())  # type: ignore[arg-type]
+    return orig
+
+
+def _restore_diag_capture(orig: object) -> None:
+    import lsp.diagnostics_pipeline as _dp
+
+    _dp._publish_diags_to_client = orig  # type: ignore[assignment]
+
+
 @pytest.fixture
 def reset_per_folder_state():
     """Snapshot/restore the module-level per-folder maps and fallback configs."""
@@ -379,13 +410,7 @@ class TestPerFolderDialect:
         _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
 
         captured: dict[str, list] = {}
-        orig_publish = _dp._publish_diags_to_client
-
-        def _capture(uri, diags, version=None):
-            captured[uri] = list(diags)
-
-        _dp._publish_diags_to_client = _capture
-        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
+        orig_publish = _install_diag_capture(captured)
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             initial = [d for d in captured.get(file_uri, []) if d.code == diagnostic_code]
@@ -404,7 +429,7 @@ class TestPerFolderDialect:
                 f"setting {late_settings!r} applies; got: " + ", ".join(d.message for d in after)
             )
         finally:
-            _dp._publish_diags_to_client = orig_publish
+            _restore_diag_capture(orig_publish)
 
 
 class TestAnalyserOptInDiagnostics:
@@ -434,9 +459,7 @@ class TestAnalyserOptInDiagnostics:
         _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
 
         captured: dict[str, list] = {}
-        orig = _dp._publish_diags_to_client
-        _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
-        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
+        orig = _install_diag_capture(captured)
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             w123 = [d for d in captured.get(file_uri, []) if d.code == "W123"]
@@ -444,7 +467,7 @@ class TestAnalyserOptInDiagnostics:
                 d.message for d in w123
             )
         finally:
-            _dp._publish_diags_to_client = orig
+            _restore_diag_capture(orig)
 
     def test_w123_fires_when_user_enables_it(self, reset_per_folder_state):
         """``tclLsp.diagnostics.W123: true`` makes the analyser emit W123."""
@@ -460,9 +483,7 @@ class TestAnalyserOptInDiagnostics:
         _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
 
         captured: dict[str, list] = {}
-        orig = _dp._publish_diags_to_client
-        _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
-        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
+        orig = _install_diag_capture(captured)
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             w123 = [d for d in captured.get(file_uri, []) if d.code == "W123"]
@@ -472,7 +493,7 @@ class TestAnalyserOptInDiagnostics:
             )
             assert "my_unknown_helper" in w123[0].message
         finally:
-            _dp._publish_diags_to_client = orig
+            _restore_diag_capture(orig)
 
     def test_toggling_w123_at_runtime_re_analyses(self, reset_per_folder_state):
         """Flipping ``tclLsp.diagnostics.W123`` invalidates the cached analysis.
@@ -495,9 +516,7 @@ class TestAnalyserOptInDiagnostics:
         _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
 
         captured: dict[str, list] = {}
-        orig = _dp._publish_diags_to_client
-        _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
-        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
+        orig = _install_diag_capture(captured)
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             initial = [d for d in captured.get(file_uri, []) if d.code == "W123"]
@@ -522,7 +541,7 @@ class TestAnalyserOptInDiagnostics:
                 d.message for d in cleared
             )
         finally:
-            _dp._publish_diags_to_client = orig
+            _restore_diag_capture(orig)
 
 
 class TestPerFolderNonAscii:

--- a/tests/test_per_folder_config.py
+++ b/tests/test_per_folder_config.py
@@ -414,6 +414,138 @@ class TestPerFolderDialect:
             _dp._publish_diags_to_client = orig_publish
 
 
+class TestAnalyserOptInDiagnostics:
+    """Opt-in (``default=False``) diagnostics must reach the emit path.
+
+    Codes that have ``default=False`` registered via ``@diag(default=False)``
+    -- currently W123 (unresolved command) and W242 (loop termination not
+    provable) -- are emitted from the analyser only when the code is *not*
+    in the analyser's ``_disabled_diagnostics`` set.  The LSP path used to
+    hardcode ``Analyser(disabled_diagnostics=default_disabled_diagnostics())``
+    which permanently disabled them: the user's ``tclLsp.diagnostics.W123:
+    true`` updated ``feature_config`` but the analyser ignored it.  The
+    fix routes ``cfg.disabled_diagnostics`` through to the Analyser via
+    ``_effective_disabled_diagnostics(uri)``.
+    """
+
+    def test_w123_does_not_fire_with_default_config(self, reset_per_folder_state):
+        """Sanity: W123 stays opt-in (off by default in the LSP path)."""
+        import lsp.diagnostics_pipeline as _dp
+
+        folder = "file:///workspaces/proj"
+        _lsp_state.get_or_init_folder_feature_config(folder)
+        _lsp_settings._apply_merged_settings_now()
+
+        file_uri = f"{folder}/file.tcl"
+        source = "my_unknown_helper foo bar\n"
+        _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
+
+        captured: dict[str, list] = {}
+        orig = _dp._publish_diags_to_client
+        _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
+        _dp.configure(
+            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
+        )
+        try:
+            _dp._publish_diagnostics_sync(file_uri, source, 1)
+            w123 = [d for d in captured.get(file_uri, []) if d.code == "W123"]
+            assert w123 == [], (
+                "W123 must stay off by default; got: "
+                + ", ".join(d.message for d in w123)
+            )
+        finally:
+            _dp._publish_diags_to_client = orig
+
+    def test_w123_fires_when_user_enables_it(self, reset_per_folder_state):
+        """``tclLsp.diagnostics.W123: true`` makes the analyser emit W123."""
+        import lsp.diagnostics_pipeline as _dp
+
+        folder = "file:///workspaces/proj"
+        _lsp_state.get_or_init_folder_feature_config(folder)
+        _lsp_state.editor_config_settings_per_folder[folder] = {
+            "diagnostics": {"W123": True}
+        }
+        _lsp_settings._apply_merged_settings_now()
+
+        file_uri = f"{folder}/file.tcl"
+        source = "my_unknown_helper foo bar\n"
+        _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
+
+        captured: dict[str, list] = {}
+        orig = _dp._publish_diags_to_client
+        _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
+        _dp.configure(
+            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
+        )
+        try:
+            _dp._publish_diagnostics_sync(file_uri, source, 1)
+            w123 = [d for d in captured.get(file_uri, []) if d.code == "W123"]
+            assert len(w123) == 1, (
+                f"W123 must fire when opted in via folder config; got {len(w123)} "
+                f"diagnostics: {[(d.code, d.message) for d in captured.get(file_uri, [])]}"
+            )
+            assert "my_unknown_helper" in w123[0].message
+        finally:
+            _dp._publish_diags_to_client = orig
+
+    def test_toggling_w123_at_runtime_re_analyses(self, reset_per_folder_state):
+        """Flipping ``tclLsp.diagnostics.W123`` invalidates the cached analysis.
+
+        The analyser bakes W123 into ``AnalysisResult.diagnostics`` at
+        analyse time -- a post-filter can't *add* it after the fact.  So
+        when the user enables W123 the cached analysis must be re-run.
+        ``_apply_merged_settings_now`` tracks per-doc resolved
+        ``disabled_diagnostics`` and forces ``force_reanalyse=True`` for
+        any doc whose effective set changed.
+        """
+        import lsp.diagnostics_pipeline as _dp
+
+        folder = "file:///workspaces/proj"
+        _lsp_state.get_or_init_folder_feature_config(folder)
+        _lsp_settings._apply_merged_settings_now()
+
+        file_uri = f"{folder}/file.tcl"
+        source = "my_unknown_helper foo\n"
+        _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
+
+        captured: dict[str, list] = {}
+        orig = _dp._publish_diags_to_client
+        _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
+        _dp.configure(
+            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
+        )
+        try:
+            _dp._publish_diagnostics_sync(file_uri, source, 1)
+            initial = [d for d in captured.get(file_uri, []) if d.code == "W123"]
+            assert initial == [], "precondition: W123 off by default"
+
+            # User opts in to W123 via folder settings.
+            _lsp_state.editor_config_settings_per_folder[folder] = {
+                "diagnostics": {"W123": True}
+            }
+            _lsp_settings._apply_merged_settings_now()
+
+            after = [d for d in captured.get(file_uri, []) if d.code == "W123"]
+            assert len(after) == 1, (
+                f"W123 must fire after the user opts in via folder config; "
+                f"got {len(after)} diagnostics, all codes: "
+                + ", ".join(d.code for d in captured.get(file_uri, []))
+            )
+
+            # Toggling back off must clear W123 again.
+            _lsp_state.editor_config_settings_per_folder[folder] = {
+                "diagnostics": {"W123": False}
+            }
+            _lsp_settings._apply_merged_settings_now()
+            cleared = [d for d in captured.get(file_uri, []) if d.code == "W123"]
+            assert cleared == [], (
+                f"W123 must clear after the user opts back out; got: "
+                + ", ".join(d.message for d in cleared)
+            )
+        finally:
+            _dp._publish_diags_to_client = orig
+
+
 class TestPerFolderNonAscii:
     """Per-folder ``tclLsp.style.nonAscii`` resolution (issue #407)."""
 

--- a/tests/test_per_folder_config.py
+++ b/tests/test_per_folder_config.py
@@ -322,6 +322,61 @@ class TestPerFolderDialect:
         _lsp_settings._apply_feature_settings({"dialect": None}, target=cfg)
         assert cfg.dialect_explicitly_set is False
 
+    def test_late_per_folder_dialect_invalidates_cached_analysis(self, reset_per_folder_state):
+        """Per-folder dialect arriving after ``did_open`` clears stale W002.
+
+        Reproduces issue #407 follow-up: at session start ``did_open`` for
+        the active editor races against the asynchronous
+        ``workspace/configuration`` pull.  The first analyse runs under the
+        workspace-fallback dialect (typically ``tcl8.6``) and bakes W002
+        for iRules-only commands into the cached analysis.  When the pull
+        callback later applies the folder's ``f5-irules`` dialect, the
+        workspace-level ``configure_signatures`` call is a no-op so the
+        old ``signatures_changed``-only re-analyse trigger never fires —
+        the user keeps seeing ``'X' is disabled in the active dialect
+        profile`` warnings even though the per-folder config is correct.
+        """
+        import lsp.diagnostics_pipeline as _dp
+
+        folder = "file:///workspaces/proj-b"
+        file_uri = f"{folder}/test.tcl"
+        _lsp_state.get_or_init_folder_feature_config(folder)
+        _lsp_settings._apply_merged_settings_now()
+
+        source = (
+            "if { [active_members http_pool] >= 2 } {\n"
+            '    puts "ok"\n'
+            "}\n"
+        )
+        _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
+
+        captured: dict[str, list] = {}
+        orig_publish = _dp._publish_diags_to_client
+
+        def _capture(uri, diags, version=None):
+            captured[uri] = list(diags)
+
+        _dp._publish_diags_to_client = _capture
+        _dp.configure(
+            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
+        )
+        try:
+            _dp._publish_diagnostics_sync(file_uri, source, 1)
+            initial = [d for d in captured.get(file_uri, []) if d.code == "W002"]
+            assert initial, "expected W002 with default tcl8.6 dialect (precondition for repro)"
+
+            # Now the pull arrives with the folder's real dialect.
+            _lsp_state.editor_config_settings_per_folder[folder] = {"dialect": "f5-irules"}
+            _lsp_settings._apply_merged_settings_now()
+
+            after = [d for d in captured.get(file_uri, []) if d.code == "W002"]
+            assert after == [], (
+                "W002 must clear once the per-folder dialect resolves to "
+                "f5-irules; got: " + ", ".join(d.message for d in after)
+            )
+        finally:
+            _dp._publish_diags_to_client = orig_publish
+
 
 class TestPerFolderNonAscii:
     """Per-folder ``tclLsp.style.nonAscii`` resolution (issue #407)."""

--- a/tests/test_per_folder_config.py
+++ b/tests/test_per_folder_config.py
@@ -334,7 +334,7 @@ class TestPerFolderDialect:
         [
             pytest.param(
                 "dialect-flips-to-irules",
-                "if { [active_members http_pool] >= 2 } {\n    puts \"ok\"\n}\n",
+                'if { [active_members http_pool] >= 2 } {\n    puts "ok"\n}\n',
                 {"dialect": "f5-irules"},
                 "W002",
                 id="dialect-W002-active_members",
@@ -385,14 +385,10 @@ class TestPerFolderDialect:
             captured[uri] = list(diags)
 
         _dp._publish_diags_to_client = _capture
-        _dp.configure(
-            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
-        )
+        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
-            initial = [
-                d for d in captured.get(file_uri, []) if d.code == diagnostic_code
-            ]
+            initial = [d for d in captured.get(file_uri, []) if d.code == diagnostic_code]
             assert initial, (
                 f"{scenario} precondition: expected {diagnostic_code} under "
                 "the workspace-fallback settings (precondition for repro)"
@@ -402,13 +398,10 @@ class TestPerFolderDialect:
             _lsp_state.editor_config_settings_per_folder[folder] = late_settings
             _lsp_settings._apply_merged_settings_now()
 
-            after = [
-                d for d in captured.get(file_uri, []) if d.code == diagnostic_code
-            ]
+            after = [d for d in captured.get(file_uri, []) if d.code == diagnostic_code]
             assert after == [], (
                 f"{scenario}: {diagnostic_code} must clear after the per-folder "
-                f"setting {late_settings!r} applies; got: "
-                + ", ".join(d.message for d in after)
+                f"setting {late_settings!r} applies; got: " + ", ".join(d.message for d in after)
             )
         finally:
             _dp._publish_diags_to_client = orig_publish
@@ -443,15 +436,12 @@ class TestAnalyserOptInDiagnostics:
         captured: dict[str, list] = {}
         orig = _dp._publish_diags_to_client
         _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
-        _dp.configure(
-            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
-        )
+        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             w123 = [d for d in captured.get(file_uri, []) if d.code == "W123"]
-            assert w123 == [], (
-                "W123 must stay off by default; got: "
-                + ", ".join(d.message for d in w123)
+            assert w123 == [], "W123 must stay off by default; got: " + ", ".join(
+                d.message for d in w123
             )
         finally:
             _dp._publish_diags_to_client = orig
@@ -462,9 +452,7 @@ class TestAnalyserOptInDiagnostics:
 
         folder = "file:///workspaces/proj"
         _lsp_state.get_or_init_folder_feature_config(folder)
-        _lsp_state.editor_config_settings_per_folder[folder] = {
-            "diagnostics": {"W123": True}
-        }
+        _lsp_state.editor_config_settings_per_folder[folder] = {"diagnostics": {"W123": True}}
         _lsp_settings._apply_merged_settings_now()
 
         file_uri = f"{folder}/file.tcl"
@@ -474,9 +462,7 @@ class TestAnalyserOptInDiagnostics:
         captured: dict[str, list] = {}
         orig = _dp._publish_diags_to_client
         _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
-        _dp.configure(
-            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
-        )
+        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             w123 = [d for d in captured.get(file_uri, []) if d.code == "W123"]
@@ -511,18 +497,14 @@ class TestAnalyserOptInDiagnostics:
         captured: dict[str, list] = {}
         orig = _dp._publish_diags_to_client
         _dp._publish_diags_to_client = lambda u, d, v=None: captured.update({u: list(d)})
-        _dp.configure(
-            type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})()
-        )
+        _dp.configure(type("S", (), {"text_document_publish_diagnostics": lambda *a, **k: None})())
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
             initial = [d for d in captured.get(file_uri, []) if d.code == "W123"]
             assert initial == [], "precondition: W123 off by default"
 
             # User opts in to W123 via folder settings.
-            _lsp_state.editor_config_settings_per_folder[folder] = {
-                "diagnostics": {"W123": True}
-            }
+            _lsp_state.editor_config_settings_per_folder[folder] = {"diagnostics": {"W123": True}}
             _lsp_settings._apply_merged_settings_now()
 
             after = [d for d in captured.get(file_uri, []) if d.code == "W123"]
@@ -533,14 +515,11 @@ class TestAnalyserOptInDiagnostics:
             )
 
             # Toggling back off must clear W123 again.
-            _lsp_state.editor_config_settings_per_folder[folder] = {
-                "diagnostics": {"W123": False}
-            }
+            _lsp_state.editor_config_settings_per_folder[folder] = {"diagnostics": {"W123": False}}
             _lsp_settings._apply_merged_settings_now()
             cleared = [d for d in captured.get(file_uri, []) if d.code == "W123"]
-            assert cleared == [], (
-                f"W123 must clear after the user opts back out; got: "
-                + ", ".join(d.message for d in cleared)
+            assert cleared == [], "W123 must clear after the user opts back out; got: " + ", ".join(
+                d.message for d in cleared
             )
         finally:
             _dp._publish_diags_to_client = orig

--- a/tests/test_per_folder_config.py
+++ b/tests/test_per_folder_config.py
@@ -322,19 +322,52 @@ class TestPerFolderDialect:
         _lsp_settings._apply_feature_settings({"dialect": None}, target=cfg)
         assert cfg.dialect_explicitly_set is False
 
-    def test_late_per_folder_dialect_invalidates_cached_analysis(self, reset_per_folder_state):
-        """Per-folder dialect arriving after ``did_open`` clears stale W002.
+    # Race matrix for issue #407: every per-folder setting that bakes into
+    # the cached ``AnalysisResult`` is exercised by ``did_open`` racing the
+    # ``workspace/configuration`` pull.  Each row drives the apply ordering
+    # directly (no LSP roundtrip), asserts the wrong diagnostic fires before
+    # the pull, then asserts ``_apply_merged_settings_now`` re-analyses and
+    # clears it once the per-folder setting arrives.  Adding a new
+    # dialect-sensitive check?  Add a row here.
+    @pytest.mark.parametrize(
+        ("scenario", "source", "late_settings", "diagnostic_code"),
+        [
+            pytest.param(
+                "dialect-flips-to-irules",
+                "if { [active_members http_pool] >= 2 } {\n    puts \"ok\"\n}\n",
+                {"dialect": "f5-irules"},
+                "W002",
+                id="dialect-W002-active_members",
+            ),
+            pytest.param(
+                "non-ascii-mode-flips-off",
+                'set greeting "“hello”"\n',
+                {"style": {"nonAscii": "off"}},
+                "W108",
+                id="nonAscii-W108-smart-quotes",
+            ),
+        ],
+    )
+    def test_late_per_folder_setting_invalidates_cached_analysis(
+        self,
+        reset_per_folder_state,
+        scenario,
+        source,
+        late_settings,
+        diagnostic_code,
+    ):
+        """Per-folder dialect/non_ascii arriving after ``did_open`` clears stale diagnostics.
 
         Reproduces issue #407 follow-up: at session start ``did_open`` for
         the active editor races against the asynchronous
         ``workspace/configuration`` pull.  The first analyse runs under the
-        workspace-fallback dialect (typically ``tcl8.6``) and bakes W002
-        for iRules-only commands into the cached analysis.  When the pull
-        callback later applies the folder's ``f5-irules`` dialect, the
-        workspace-level ``configure_signatures`` call is a no-op so the
-        old ``signatures_changed``-only re-analyse trigger never fires —
-        the user keeps seeing ``'X' is disabled in the active dialect
-        profile`` warnings even though the per-folder config is correct.
+        workspace-fallback settings and bakes dialect-sensitive checks
+        (W002 for iRules-only commands, W108 for non-ASCII, etc) into the
+        cached analysis.  When the pull callback later applies the folder's
+        real settings the workspace-level ``configure_signatures`` call is
+        a no-op so the old ``signatures_changed``-only re-analyse trigger
+        never fires — the user keeps seeing the stale warnings even though
+        the per-folder config has resolved to the correct value.
         """
         import lsp.diagnostics_pipeline as _dp
 
@@ -343,11 +376,6 @@ class TestPerFolderDialect:
         _lsp_state.get_or_init_folder_feature_config(folder)
         _lsp_settings._apply_merged_settings_now()
 
-        source = (
-            "if { [active_members http_pool] >= 2 } {\n"
-            '    puts "ok"\n'
-            "}\n"
-        )
         _lsp_state.workspace_state.open(file_uri, source, 1, language_id="tcl", analyse=False)
 
         captured: dict[str, list] = {}
@@ -362,17 +390,25 @@ class TestPerFolderDialect:
         )
         try:
             _dp._publish_diagnostics_sync(file_uri, source, 1)
-            initial = [d for d in captured.get(file_uri, []) if d.code == "W002"]
-            assert initial, "expected W002 with default tcl8.6 dialect (precondition for repro)"
+            initial = [
+                d for d in captured.get(file_uri, []) if d.code == diagnostic_code
+            ]
+            assert initial, (
+                f"{scenario} precondition: expected {diagnostic_code} under "
+                "the workspace-fallback settings (precondition for repro)"
+            )
 
-            # Now the pull arrives with the folder's real dialect.
-            _lsp_state.editor_config_settings_per_folder[folder] = {"dialect": "f5-irules"}
+            # Pull arrives with the folder's real settings.
+            _lsp_state.editor_config_settings_per_folder[folder] = late_settings
             _lsp_settings._apply_merged_settings_now()
 
-            after = [d for d in captured.get(file_uri, []) if d.code == "W002"]
+            after = [
+                d for d in captured.get(file_uri, []) if d.code == diagnostic_code
+            ]
             assert after == [], (
-                "W002 must clear once the per-folder dialect resolves to "
-                "f5-irules; got: " + ", ".join(d.message for d in after)
+                f"{scenario}: {diagnostic_code} must clear after the per-folder "
+                f"setting {late_settings!r} applies; got: "
+                + ", ".join(d.message for d in after)
             )
         finally:
             _dp._publish_diags_to_client = orig_publish


### PR DESCRIPTION
## Summary

Fixes issue #407: when per-folder configuration (dialect, non-ASCII mode, opt-in diagnostics) arrives asynchronously after a document's initial analysis, the cached `AnalysisResult` retains stale dialect-baked diagnostics (W002, W108, W123, etc.) even after the correct settings resolve.

The root cause is that `_apply_merged_settings_now()` only re-analyzes documents when workspace-level `configure_signatures` changes. Per-folder settings that don't affect signatures (like `tclLsp.diagnostics.W123`) or arrive after the workspace config is already applied never trigger re-analysis, leaving stale diagnostics in the cache.

### Changes

1. **Per-folder config change detection** (`lsp/settings.py`):
   - Snapshot each document's resolved dialect, extra commands, non-ASCII mode, and disabled diagnostics *before* applying new settings
   - After applying, detect if any document's resolution changed and force re-analysis for those documents
   - This catches per-folder changes that don't show up in the workspace-level `signatures_changed` flag

2. **Opt-in diagnostic support** (`lsp/workspace/document_state.py`):
   - Add `_effective_disabled_diagnostics(uri)` to resolve the per-folder `disabled_diagnostics` set from `FeatureConfig`
   - Pass this effective set to the `Analyser` instead of the static `default_disabled_diagnostics()`
   - This allows users to enable opt-in codes (W123, W242, W307, W308) via `tclLsp.diagnostics.<code>: true` and have them actually reach the emit path

3. **Diagnostic config command** (`lsp/commands.py`):
   - Add `tcl-lsp.getEffectiveConfig` command to expose the server's resolved per-folder configuration
   - Enables tests and clients to poll for config settlement without relying on wall-clock timeouts

4. **Test coverage** (`tests/test_per_folder_config.py`):
   - `test_late_per_folder_setting_invalidates_cached_analysis`: Reproduces the race with dialect and non-ASCII mode changes
   - `TestAnalyserOptInDiagnostics`: Three tests covering W123 opt-in behavior (default off, user enables, runtime toggle)

5. **VS Code integration tests** (`editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts`):
   - Replace brittle `setTimeout(3000)` with `waitForConfigSettled()` that polls `tcl-lsp.getEffectiveConfig`
   - Add test for the command itself
   - Add race-detection suite that flips folder dialect at runtime and verifies stale diagnostics clear

## Validation

- Added comprehensive unit tests in `tests/test_per_folder_config.py` covering the race condition and opt-in diagnostic behavior
- Added VS Code integration tests that reproduce the race by toggling folder dialect at runtime
- Existing multi-folder configuration tests updated to use config polling instead of timeouts

https://claude.ai/code/session_01VTcSrsiJ76DVDM35wqUBx4