### PR TITLE
Fix JetBrains plugin compatibility with 2024.1+ IDEs

### DIFF
--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -40,6 +40,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = "241"
+            untilBuild = provider { null }
         }
 
         vendor {
@@ -49,6 +50,15 @@ intellijPlatform {
     }
 
     buildSearchableOptions = false
+
+    pluginVerification {
+        freeArgs = listOf("-offline")
+        ides {
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2024.1")
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.1.7.1")
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.2.6.2")
+        }
+    }
 
     publishing {
         token = providers.environmentVariable("JETBRAINS_TOKEN")

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import com.tcllsp.jetbrains.settings.TclLspSettings
 import org.cef.browser.CefBrowser
@@ -34,7 +35,7 @@ class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
 private class CompilerExplorerPanel(private val project: Project) {
 
     val browser: JBCefBrowser = JBCefBrowser()
-    private val jsQuery: JBCefJSQuery = JBCefJSQuery.create(browser)
+    private val jsQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private var debounceTimer: Timer? = null
     private var lastSource: String = ""
 
@@ -141,13 +142,14 @@ private class CompilerExplorerPanel(private val project: Project) {
                     return@runAsync
                 }
 
-                val lsp4jServer = server.lsp4jServer
-                val result = lsp4jServer.workspaceService.executeCommand(
-                    org.eclipse.lsp4j.ExecuteCommandParams(
-                        "tcl-lsp.compilerExplorer",
-                        listOf(source, dialect)
+                val result = server.sendRequestSync { lsp4j ->
+                    lsp4j.workspaceService.executeCommand(
+                        org.eclipse.lsp4j.ExecuteCommandParams(
+                            "tcl-lsp.compilerExplorer",
+                            listOf(source, dialect)
+                        )
                     )
-                ).get()
+                }
 
                 if (result != null) {
                     val json = com.google.gson.Gson().toJson(result)


### PR DESCRIPTION
The IntelliJ Platform Gradle plugin's default behavior caps untilBuild at
the sinceBuild major (e.g. 241.*), which made the plugin appear
incompatible with 2024.2+ IDEs on the JetBrains Marketplace. Explicitly
clear untilBuild so the plugin remains compatible with all future builds.

Also replace two APIs deprecated since 2024.1 that were producing
compiler warnings and showing up as deprecated-API usages in the
verifier report:
- JBCefJSQuery.create(JBCefBrowser) -> create(JBCefBrowserBase)
- LspServer.lsp4jServer / .get() -> LspServer.sendRequestSync { ... }

Add a pluginVerification block so future compatibility regressions are
caught at build time. Runs offline against bundled IU artifacts.

Verified compatible against IU-241.14494.240, IU-251.29188.36, and
IU-252.28539.54.