### PR TITLE
Harden GitHub Actions against recent supply-chain attacks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# Code owners — GitHub uses this file to auto-request reviews and (with
+# branch-protection "Require review from Code Owners" enabled) to block
+# merges to protected paths until the listed owner approves.
+#
+# We deliberately scope this narrowly to security- and supply-chain-
+# critical paths.  A blanket `*` owner would add review load without
+# adding security value.
+
+# Default fallback: the repo maintainer.
+*                                       @bitwisecook
+
+# CI / build infrastructure.  A compromised workflow can exfiltrate
+# secrets or sign tampered artefacts on our behalf; treat every change
+# the same way you'd treat a release.
+/.github/                               @bitwisecook
+/.github/workflows/                     @bitwisecook
+/.github/dependabot.yml                 @bitwisecook
+/.github/CODEOWNERS                     @bitwisecook
+
+# Supply-chain fetch + checksum pins for vendored Tcl sources.  Bumping
+# the checksum without bumping (and verifying) the upstream tag is
+# exactly the failure mode this guard exists to prevent.
+/scripts/fetch_tcl_regex.sh             @bitwisecook
+/scripts/tcl_regex_sha256sums.txt       @bitwisecook
+
+# Installer script published to releases — runs on user machines.
+/scripts/install.sh                     @bitwisecook
+
+# Python dependency manifest.  A PR that adds a new dependency runs that
+# dep's PEP-517 backend in CI (during `uv sync`), so a malicious package
+# can execute arbitrary code with the workflow's permissions.  Same
+# concern for lockfile bumps that would resolve to new transitive deps.
+/pyproject.toml                         @bitwisecook
+/uv.lock                                @bitwisecook
+
+# VS Code extension package manifest — same supply-chain concern as
+# pyproject.toml, but for npm.  `npm install` runs install scripts from
+# every dep in the tree.
+/editors/vscode/package.json            @bitwisecook
+/editors/vscode/package-lock.json       @bitwisecook

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Dependabot configuration.
+#
+# This is the inbound channel for security updates to pinned dependencies.
+# Workflows pin third-party actions to commit SHAs (see .github/workflows/*),
+# which is only safe if there's an automated update channel — that's this file.
+#
+# Grouped updates land as a single PR per ecosystem per week to keep review
+# load manageable. Security advisories still open a PR immediately regardless
+# of schedule.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /editors/vscode
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: /editors/zed
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gradle
+    directory: /editors/jetbrains
+    schedule:
+      interval: weekly
+    groups:
+      gradle:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,17 @@ jobs:
           fi
           install -m 0755 "$tmp" install.sh
           rm -f "$tmp"
+
+      - name: Attest installer script build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "install.sh"
+
+      - name: Upload installer script to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
           gh release upload "$tag" install.sh --clobber
 
   # Build: VSIX package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,17 +252,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          if ! gh release view "$tag" > /dev/null 2>&1; then
-            if [ -f RELEASE_NOTES.md ]; then
-              gh release create "$tag" \
-                --title "$tag" \
-                --notes-file RELEASE_NOTES.md
-            else
-              gh release create "$tag" \
-                --title "$tag" \
-                --generate-notes
-            fi
+          if gh release view "$tag" > /dev/null 2>&1; then
+            exit 0
           fi
+          # Require curated release notes.  The previous fallback to
+          # `gh release create --generate-notes` builds the changelog
+          # from commit messages and PR titles, both attacker-influenced
+          # — anyone whose PR merged since the last release can land
+          # text inside our official release notes.  Failing closed
+          # forces the maintainer to commit RELEASE_NOTES.md before
+          # tagging.
+          if [ ! -f RELEASE_NOTES.md ]; then
+            echo "ERROR: RELEASE_NOTES.md is missing for tag $tag." >&2
+            echo "Commit curated notes to RELEASE_NOTES.md before pushing the tag." >&2
+            exit 1
+          fi
+          gh release create "$tag" \
+            --title "$tag" \
+            --notes-file RELEASE_NOTES.md
 
       - name: Stamp + upload installer script to release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
+          # Explicit: setup-zig defaults to use-cache=true, but be loud
+          # about it so a future bump can't silently flip the default.
+          # Caches both the zig toolchain download and the zig-cache dir
+          # keyed on build.zig{,.zon} when present.
+          use-cache: true
 
       - name: Fetch Tcl regex engine sources (runtime/zig/vendor/tcl-regex)
         run: bash scripts/fetch_tcl_regex.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1128,6 +1128,11 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        with:
+          # Pin the cosign binary itself, not just the installer action.
+          # Without this, the installer downloads "latest" cosign — which
+          # is itself a moving target.  Bump in lockstep with the action.
+          cosign-release: 'v2.6.3'
 
       - name: Sign SHA256SUMS (keyless OIDC)
         working-directory: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   # hook installed via `make install-hooks`).  See AGENTS.md for the rule
   # that agents must run test-slow before opening a PR.
   pr-gate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -87,7 +87,7 @@ jobs:
   # the change has merged, so a regression is loud but doesn't block PRs.
   test-py:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -153,7 +153,7 @@ jobs:
   # PRs are gated by pr-gate; locally this is covered by `make test-slow`.
   test-ext:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -230,7 +230,7 @@ jobs:
   create-release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [pr-gate, test-py]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -286,7 +286,7 @@ jobs:
   build-vsix:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release, test-ext]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -361,7 +361,7 @@ jobs:
   build-zipapp-cli:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -413,7 +413,7 @@ jobs:
   build-zipapp-f5:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -481,7 +481,7 @@ jobs:
   build-zipapp-tcl:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -543,7 +543,7 @@ jobs:
   build-zipapp-gui:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -605,7 +605,7 @@ jobs:
   build-zipapp-lsp:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -657,7 +657,7 @@ jobs:
   build-claude-skills:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -712,7 +712,7 @@ jobs:
   build-zipapp-mcp:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -764,7 +764,7 @@ jobs:
   build-zipapp-wasm:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -816,7 +816,7 @@ jobs:
   build-jetbrains:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -877,7 +877,7 @@ jobs:
   build-sublime:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -941,7 +941,7 @@ jobs:
   build-zed:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
       id-token: write        # OIDC for sigstore-backed attestations
@@ -1016,7 +1016,7 @@ jobs:
   publish-checksums:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release, build-vsix, build-zipapp-cli, build-zipapp-f5, build-zipapp-tcl, build-zipapp-gui, build-zipapp-lsp, build-claude-skills, build-zipapp-mcp, build-zipapp-wasm, build-jetbrains, build-sublime, build-zed]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write   # gh release upload
       id-token: write   # cosign keyless OIDC signing
@@ -1079,7 +1079,7 @@ jobs:
   cleanup-old-artifacts:
     if: always() && startsWith(github.ref, 'refs/tags/v')
     needs: [build-vsix, build-zipapp-cli, build-zipapp-f5, build-zipapp-tcl, build-zipapp-gui, build-zipapp-lsp, build-claude-skills, build-zipapp-mcp, build-zipapp-wasm, build-jetbrains, build-sublime, build-zed, publish-checksums]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     steps:
@@ -1130,7 +1130,7 @@ jobs:
   cleanup-untagged-artifacts:
     if: always() && startsWith(github.ref, 'refs/tags/v')
     needs: [build-vsix, build-zipapp-cli, build-zipapp-f5, build-zipapp-tcl, build-zipapp-gui, build-zipapp-lsp, build-claude-skills, build-zipapp-mcp, build-zipapp-wasm, build-jetbrains, build-sublime, build-zed, publish-checksums]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,19 @@ jobs:
         with:
           node-version: "lts/*"
 
+      # The repo doesn't commit `package-lock.json`, so setup-node's
+      # built-in `cache: 'npm'` (which needs a lockfile) won't work.
+      # Cache the npm metadata directory instead so `npm install` skips
+      # the network for tarballs it already has.  Key on package.json so
+      # the cache invalidates whenever declared deps change.
+      - name: Cache npm registry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('editors/vscode/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Install npm dependencies
         run: cd editors/vscode && npm install
 
@@ -297,6 +310,19 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
+
+      # The repo doesn't commit `package-lock.json`, so setup-node's
+      # built-in `cache: 'npm'` (which needs a lockfile) won't work.
+      # Cache the npm metadata directory instead so `npm install` skips
+      # the network for tarballs it already has.  Key on package.json so
+      # the cache invalidates whenever declared deps change.
+      - name: Cache npm registry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('editors/vscode/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
       - name: Sync Python environment
         run: uv sync --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -178,6 +180,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -281,6 +285,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -341,6 +347,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -391,6 +399,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -457,6 +467,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -517,6 +529,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -577,6 +591,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -627,6 +643,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -680,6 +698,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -730,6 +750,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -780,6 +802,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -839,6 +863,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -901,6 +927,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # `make build-info` (a dep of ci-fast) shells out to `git describe
-          # --tags`, which needs the full history.
-          fetch-depth: 0
+          # --tags`.  That needs tags but NOT full history — `fetch-depth: 1`
+          # + `fetch-tags: true` is meaningfully faster than `fetch-depth: 0`
+          # on a repo with many commits and gives the describe call exactly
+          # what it needs.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Log commit info
         # `github.head_ref` is the PR source branch and is attacker-controlled
@@ -299,7 +303,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -374,7 +382,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -426,7 +438,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -494,7 +510,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -556,7 +576,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -618,7 +642,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -670,7 +698,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -725,7 +757,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -777,7 +813,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -829,7 +869,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -890,7 +934,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -954,7 +1002,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # See pr-gate for why this is depth-1 + tags rather than full
+          # history: `git describe --tags` is the only consumer of the
+          # checkout and only needs tags reachable from HEAD.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for every job: read-only.  Jobs that need to
+# write to the repo (releases, artefact uploads, attestations) escalate
+# explicitly in their own `permissions:` block.  A compromised step in
+# `pr-gate` / `test-py` / `test-ext` therefore cannot push commits or
+# create releases even if the repo-level default is "Read and write".
+permissions:
+  contents: read
+
 jobs:
   # Fast PR gate (target wall-clock < 20s).  Runs on every PR and every push.
   # Covers: lint + typecheck + structural invariants + a tightly scoped pytest
@@ -21,25 +29,36 @@ jobs:
   pr-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # `make build-info` (a dep of ci-fast) shells out to `git describe
           # --tags`, which needs the full history.
           fetch-depth: 0
 
       - name: Log commit info
+        # `github.head_ref` is the PR source branch and is attacker-controlled
+        # on forked-PR runs — interpolating it directly into `run:` is the
+        # classic GitHub Actions expression-injection vector.  Pipe every
+        # workflow-context value through `env:` so the shell sees a plain
+        # variable, not template-expanded source.
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_EVENT: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           echo "::group::Commit info"
-          echo "github.sha       = ${{ github.sha }}"
-          echo "github.event_name = ${{ github.event_name }}"
-          echo "github.ref        = ${{ github.ref }}"
-          echo "github.head_ref   = ${{ github.head_ref }}"
-          echo "github.run_id     = ${{ github.run_id }}"
+          echo "github.sha        = $GH_SHA"
+          echo "github.event_name = $GH_EVENT"
+          echo "github.ref        = $GH_REF"
+          echo "github.head_ref   = $GH_HEAD_REF"
+          echo "github.run_id     = $GH_RUN_ID"
           echo "checked-out HEAD  = $(git rev-parse HEAD)"
           echo "::endgroup::"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           # v6's cache keys on uv.lock by default and works correctly
           # (the v4 lockfile-glob bug is fixed).  Trims a few seconds off
@@ -47,7 +66,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -74,31 +93,39 @@ jobs:
         python-version: ["3.10"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Log commit info
+        # See pr-gate for why these go through `env:` rather than direct
+        # `${{ github.* }}` interpolation in the run script.
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_EVENT: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           echo "::group::Commit info"
-          echo "github.sha       = ${{ github.sha }}"
-          echo "github.event_name = ${{ github.event_name }}"
-          echo "github.ref        = ${{ github.ref }}"
-          echo "github.head_ref   = ${{ github.head_ref }}"
-          echo "github.run_id     = ${{ github.run_id }}"
+          echo "github.sha        = $GH_SHA"
+          echo "github.event_name = $GH_EVENT"
+          echo "github.ref        = $GH_REF"
+          echo "github.head_ref   = $GH_HEAD_REF"
+          echo "github.run_id     = $GH_RUN_ID"
           echo "checked-out HEAD  = $(git rev-parse HEAD)"
           echo
           git log -1 --pretty=fuller HEAD || true
           echo "::endgroup::"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Zig (needed for runtime auto-build)
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -126,26 +153,34 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Log commit info
+        # See pr-gate for why these go through `env:` rather than direct
+        # `${{ github.* }}` interpolation in the run script.
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_EVENT: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           echo "::group::Commit info"
-          echo "github.sha       = ${{ github.sha }}"
-          echo "github.event_name = ${{ github.event_name }}"
-          echo "github.ref        = ${{ github.ref }}"
-          echo "github.head_ref   = ${{ github.head_ref }}"
-          echo "github.run_id     = ${{ github.run_id }}"
+          echo "github.sha        = $GH_SHA"
+          echo "github.event_name = $GH_EVENT"
+          echo "github.ref        = $GH_REF"
+          echo "github.head_ref   = $GH_HEAD_REF"
+          echo "github.run_id     = $GH_RUN_ID"
           echo "checked-out HEAD  = $(git rev-parse HEAD)"
           echo
           git log -1 --pretty=fuller HEAD || true
           echo "::endgroup::"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -153,7 +188,7 @@ jobs:
         run: uv sync --extra dev
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
 
@@ -180,9 +215,11 @@ jobs:
     needs: [pr-gate, test-py]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create GitHub Release
         env:
@@ -234,22 +271,24 @@ jobs:
     needs: [create-release, test-ext]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
 
@@ -262,8 +301,18 @@ jobs:
       - name: Build and verify VSIX
         run: make package-vsix
 
+      # SLSA build provenance: binds every artefact to the workflow run
+      # and source commit that produced it.  Verifiable post-hoc with
+      # `gh attestation verify --owner bitwisecook <file>`.  Complements
+      # the cosign-signed SHA256SUMS (which proves the *set* of files is
+      # what we published) with per-file proof of build provenance.
+      - name: Attest VSIX build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/*.vsix"
+
       - name: Upload VSIX
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vsix
           path: "build/*.vsix"
@@ -282,17 +331,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -305,8 +356,13 @@ jobs:
       - name: Smoke-test CLI zipapp
         run: python3 build/tcl-lsp-explorer-cli-*.pyz --help
 
+      - name: Attest CLI zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-explorer-cli-*.pyz"
+
       - name: Upload CLI zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-cli
           path: "build/tcl-lsp-explorer-cli-*.pyz"
@@ -325,17 +381,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -364,8 +422,13 @@ jobs:
           # zsh and fish aren't installed in CI; rely on the bash syntax
           # check plus the static unit tests for those scripts.
 
+      - name: Attest F5 zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/f5-*.pyz"
+
       - name: Upload F5 zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-f5
           path: "build/f5-*.pyz"
@@ -384,17 +447,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -417,8 +482,13 @@ jobs:
           python3 build/tcl-*.pyz diff samples/for_screenshots/ai-scene.irul samples/for_screenshots/ai-scene.irul --show ast --json
           python3 build/tcl-*.pyz help taint --dialect f5-irules
 
+      - name: Attest unified Tcl zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-*.pyz"
+
       - name: Upload unified Tcl zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-tcl
           path: "build/tcl-*.pyz"
@@ -437,17 +507,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -470,8 +542,13 @@ jobs:
           print(f'OK: {len(names)} entries (CDN variant)')
           "
 
+      - name: Attest CDN GUI zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-explorer-gui-cdn-*.pyz"
+
       - name: Upload CDN GUI zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-gui-cdn
           path: "build/tcl-lsp-explorer-gui-cdn-*.pyz"
@@ -490,17 +567,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -513,8 +592,13 @@ jobs:
       - name: Smoke-test LSP zipapp
         run: python3 build/tcl-lsp-server-*.pyz --help
 
+      - name: Attest LSP zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-server-*.pyz"
+
       - name: Upload LSP zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-lsp
           path: "build/tcl-lsp-server-*.pyz"
@@ -533,17 +617,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -559,8 +645,13 @@ jobs:
       - name: Build Claude skills zip
         run: make claude-skills
 
+      - name: Attest Claude skills zip build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-claude-skills-*.zip"
+
       - name: Upload Claude skills zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: claude-skills
           path: "build/tcl-lsp-claude-skills-*.zip"
@@ -579,17 +670,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -602,8 +695,13 @@ jobs:
       - name: Smoke-test MCP zipapp
         run: python3 build/tcl-lsp-mcp-server-*.pyz --help
 
+      - name: Attest MCP zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-mcp-server-*.pyz"
+
       - name: Upload MCP zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-mcp
           path: "build/tcl-lsp-mcp-server-*.pyz"
@@ -622,17 +720,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -645,8 +745,13 @@ jobs:
       - name: Smoke-test WASM zipapp
         run: python3 build/tcl-wasm-compiler-*.pyz --help
 
+      - name: Attest WASM zipapp build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-wasm-compiler-*.pyz"
+
       - name: Upload WASM zipapp
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zipapp-wasm
           path: "build/tcl-wasm-compiler-*.pyz"
@@ -665,22 +770,24 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 17
@@ -697,8 +804,13 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
         run: make jetbrains
 
+      - name: Attest JetBrains plugin build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-jetbrains-*.zip"
+
       - name: Upload JetBrains plugin
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jetbrains-plugin
           path: "build/tcl-lsp-jetbrains-*.zip"
@@ -717,17 +829,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -752,8 +866,13 @@ jobs:
           print(f'OK: {len(names)} entries')
           "
 
+      - name: Attest Sublime package build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-sublime-*.sublime-package"
+
       - name: Upload Sublime package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sublime-package
           path: "build/tcl-lsp-sublime-*.sublime-package"
@@ -772,17 +891,19 @@ jobs:
     needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # gh release upload
+      id-token: write        # OIDC for sigstore-backed attestations
+      attestations: write    # actions/attest-build-provenance writes here
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -793,7 +914,7 @@ jobs:
         # actions-rust-lang/setup-rust-toolchain wraps swatinem/rust-cache
         # so we get cargo registry / target caching for free — meaningful
         # speedup vs the bare dtolnay/rust-toolchain action.
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: stable
           target: wasm32-wasip2
@@ -816,8 +937,13 @@ jobs:
           print(f'OK: {len(names)} entries')
           "
 
+      - name: Attest Zed extension build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "build/tcl-lsp-zed-*.zip"
+
       - name: Upload Zed extension
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: zed-extension
           path: "build/tcl-lsp-zed-*.zip"
@@ -879,7 +1005,7 @@ jobs:
             --repo "${{ github.repository }}" --clobber
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign SHA256SUMS (keyless OIDC)
         working-directory: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,34 @@ jobs:
         with:
           subject-path: "build/*.vsix"
 
+      # SBOM: syft introspects the .vsix (which is a zip) and lists every
+      # package contained within.  Attestation binds the SBOM to the
+      # artefact's sha256 via Sigstore.  `gh attestation verify` returns
+      # both the build-provenance AND the SBOM attestation in one query.
+      - name: Resolve VSIX artefact path
+        id: sbom_vsix
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/*.vsix | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate VSIX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_vsix.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_vsix.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest VSIX SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_vsix.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_vsix.outputs.sbom }}
+
       - name: Upload VSIX
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -384,9 +412,10 @@ jobs:
       - name: Upload VSIX to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_vsix.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/*.vsix --clobber
+          gh release upload "$tag" build/*.vsix "$SBOM_PATH" --clobber
 
   # Build: CLI zipapp
   build-zipapp-cli:
@@ -430,6 +459,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-explorer-cli-*.pyz"
 
+      - name: Resolve CLI zipapp path
+        id: sbom_cli
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-explorer-cli-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CLI SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_cli.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_cli.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest CLI SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_cli.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_cli.outputs.sbom }}
+
       - name: Upload CLI zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -440,9 +493,10 @@ jobs:
       - name: Upload CLI zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_cli.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-explorer-cli-*.pyz --clobber
+          gh release upload "$tag" build/tcl-lsp-explorer-cli-*.pyz "$SBOM_PATH" --clobber
 
   # Build: F5 BIG-IP CLI zipapp
   build-zipapp-f5:
@@ -502,6 +556,30 @@ jobs:
         with:
           subject-path: "build/f5-*.pyz"
 
+      - name: Resolve F5 zipapp path
+        id: sbom_f5
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/f5-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate F5 SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_f5.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_f5.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest F5 SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_f5.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_f5.outputs.sbom }}
+
       - name: Upload F5 zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -512,9 +590,10 @@ jobs:
       - name: Upload F5 zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_f5.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/f5-*.pyz --clobber
+          gh release upload "$tag" build/f5-*.pyz "$SBOM_PATH" --clobber
 
   # Build: unified Tcl tools zipapp
   build-zipapp-tcl:
@@ -568,6 +647,30 @@ jobs:
         with:
           subject-path: "build/tcl-*.pyz"
 
+      - name: Resolve unified Tcl zipapp path
+        id: sbom_tcl
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate unified Tcl SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_tcl.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_tcl.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest unified Tcl SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_tcl.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_tcl.outputs.sbom }}
+
       - name: Upload unified Tcl zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -578,9 +681,10 @@ jobs:
       - name: Upload unified Tcl zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_tcl.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-*.pyz --clobber
+          gh release upload "$tag" build/tcl-*.pyz "$SBOM_PATH" --clobber
 
   # Build: GUI zipapp — CDN variant (tagged releases only)
   build-zipapp-gui:
@@ -634,6 +738,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-explorer-gui-cdn-*.pyz"
 
+      - name: Resolve CDN GUI zipapp path
+        id: sbom_gui
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-explorer-gui-cdn-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CDN GUI SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_gui.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_gui.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest CDN GUI SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_gui.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_gui.outputs.sbom }}
+
       - name: Upload CDN GUI zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -644,9 +772,10 @@ jobs:
       - name: Upload CDN GUI zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_gui.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-explorer-gui-cdn-*.pyz --clobber
+          gh release upload "$tag" build/tcl-lsp-explorer-gui-cdn-*.pyz "$SBOM_PATH" --clobber
 
   # Build: LSP server zipapp
   build-zipapp-lsp:
@@ -690,6 +819,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-server-*.pyz"
 
+      - name: Resolve LSP zipapp path
+        id: sbom_lsp
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-server-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate LSP SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_lsp.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_lsp.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest LSP SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_lsp.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_lsp.outputs.sbom }}
+
       - name: Upload LSP zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -700,9 +853,10 @@ jobs:
       - name: Upload LSP zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_lsp.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-server-*.pyz --clobber
+          gh release upload "$tag" build/tcl-lsp-server-*.pyz "$SBOM_PATH" --clobber
 
   # Build: AI analysis zipapp + Claude Code skills zip
   build-claude-skills:
@@ -749,6 +903,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-claude-skills-*.zip"
 
+      - name: Resolve Claude skills zip path
+        id: sbom_skills
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-claude-skills-*.zip | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Claude skills SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_skills.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_skills.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest Claude skills SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_skills.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_skills.outputs.sbom }}
+
       - name: Upload Claude skills zip
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -759,9 +937,10 @@ jobs:
       - name: Upload Claude skills zip to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_skills.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-claude-skills-*.zip --clobber
+          gh release upload "$tag" build/tcl-lsp-claude-skills-*.zip "$SBOM_PATH" --clobber
 
   # Build: MCP server zipapp
   build-zipapp-mcp:
@@ -805,6 +984,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-mcp-server-*.pyz"
 
+      - name: Resolve MCP zipapp path
+        id: sbom_mcp
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-mcp-server-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate MCP SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_mcp.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_mcp.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest MCP SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_mcp.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_mcp.outputs.sbom }}
+
       - name: Upload MCP zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -815,9 +1018,10 @@ jobs:
       - name: Upload MCP zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_mcp.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-mcp-server-*.pyz --clobber
+          gh release upload "$tag" build/tcl-lsp-mcp-server-*.pyz "$SBOM_PATH" --clobber
 
   # Build: WASM compiler zipapp
   build-zipapp-wasm:
@@ -861,6 +1065,30 @@ jobs:
         with:
           subject-path: "build/tcl-wasm-compiler-*.pyz"
 
+      - name: Resolve WASM zipapp path
+        id: sbom_wasm
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-wasm-compiler-*.pyz | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate WASM SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_wasm.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_wasm.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest WASM SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_wasm.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_wasm.outputs.sbom }}
+
       - name: Upload WASM zipapp
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -871,9 +1099,10 @@ jobs:
       - name: Upload WASM zipapp to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_wasm.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-wasm-compiler-*.pyz --clobber
+          gh release upload "$tag" build/tcl-wasm-compiler-*.pyz "$SBOM_PATH" --clobber
 
   # Build: JetBrains plugin
   build-jetbrains:
@@ -926,6 +1155,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-jetbrains-*.zip"
 
+      - name: Resolve JetBrains plugin path
+        id: sbom_jetbrains
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-jetbrains-*.zip | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate JetBrains SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_jetbrains.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_jetbrains.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest JetBrains SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_jetbrains.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_jetbrains.outputs.sbom }}
+
       - name: Upload JetBrains plugin
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -936,9 +1189,10 @@ jobs:
       - name: Upload JetBrains plugin to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_jetbrains.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-jetbrains-*.zip --clobber
+          gh release upload "$tag" build/tcl-lsp-jetbrains-*.zip "$SBOM_PATH" --clobber
 
   # Build: Sublime Text package
   build-sublime:
@@ -994,6 +1248,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-sublime-*.sublime-package"
 
+      - name: Resolve Sublime package path
+        id: sbom_sublime
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-sublime-*.sublime-package | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Sublime SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_sublime.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_sublime.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest Sublime SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_sublime.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_sublime.outputs.sbom }}
+
       - name: Upload Sublime package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -1004,9 +1282,10 @@ jobs:
       - name: Upload Sublime package to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_sublime.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-sublime-*.sublime-package --clobber
+          gh release upload "$tag" build/tcl-lsp-sublime-*.sublime-package "$SBOM_PATH" --clobber
 
   # Build: Zed extension
   build-zed:
@@ -1071,6 +1350,30 @@ jobs:
         with:
           subject-path: "build/tcl-lsp-zed-*.zip"
 
+      - name: Resolve Zed extension path
+        id: sbom_zed
+        run: |
+          set -euo pipefail
+          artefact=$(ls build/tcl-lsp-zed-*.zip | head -1)
+          [ -n "$artefact" ]
+          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
+          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Zed SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.sbom_zed.outputs.artefact }}
+          format: spdx-json
+          output-file: ${{ steps.sbom_zed.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest Zed SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.sbom_zed.outputs.artefact }}
+          sbom-path: ${{ steps.sbom_zed.outputs.sbom }}
+
       - name: Upload Zed extension
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -1081,9 +1384,10 @@ jobs:
       - name: Upload Zed extension to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          SBOM_PATH: ${{ steps.sbom_zed.outputs.sbom }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-zed-*.zip --clobber
+          gh release upload "$tag" build/tcl-lsp-zed-*.zip "$SBOM_PATH" --clobber
 
   # Publish: aggregate SHA256SUMS over every artefact attached to the
   # release, plus an optional cosign keyless signature. The installer

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,18 @@
 name: CodeQL
 
-# Static-analysis for the three languages whose source ships in this
-# repo and runs on user machines: Python (LSP server / zipapps), TypeScript
-# (VS Code extension), and Rust (Zed extension).  CodeQL's `actions`
-# query pack also lints the workflows themselves, catching expression-
-# injection and similar mistakes before they reach main.
+# Static-analysis for the languages whose source ships in this repo and
+# runs on user machines: Python (LSP server / zipapps) and TypeScript
+# (VS Code extension).  CodeQL's `actions` query pack also lints the
+# workflows themselves, catching expression-injection and similar
+# mistakes before they reach main.
+#
+# Rust (editors/zed) is intentionally excluded.  CodeQL Rust support is
+# still maturing, and the extension cross-compiles to `wasm32-wasip2`
+# (a target the CodeQL build-mode `manual`/`autobuild` paths don't
+# capture cleanly).  The extension itself is ~100 lines of glue around
+# `zed_extension_api`, with a small attack surface; the cost-benefit
+# of fighting CodeQL Rust's wasm-target handling isn't there yet.
+# Revisit when CodeQL Rust supports `build-mode: none` GA.
 on:
   push:
     branches: [main]
@@ -36,8 +44,6 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
-          - language: rust
-            build-mode: manual
           - language: actions
             build-mode: none
     steps:
@@ -52,19 +58,6 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
-
-      # Rust needs an actual `cargo build` for CodeQL to capture call
-      # graphs.  Other languages run extractor-only.
-      - name: Set up Rust (matrix.language == 'rust')
-        if: matrix.language == 'rust'
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          toolchain: stable
-          target: wasm32-wasip2
-
-      - name: Build Rust (matrix.language == 'rust')
-        if: matrix.language == 'rust'
-        run: cd editors/zed && cargo build --release --target wasm32-wasip2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f25eda876ebb741d872b63b9f2c6dfdd77f14b83 # v4.35.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: CodeQL
+
+# Static-analysis for the three languages whose source ships in this
+# repo and runs on user machines: Python (LSP server / zipapps), TypeScript
+# (VS Code extension), and Rust (Zed extension).  CodeQL's `actions`
+# query pack also lints the workflows themselves, catching expression-
+# injection and similar mistakes before they reach main.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan picks up newly-published advisories against deps that
+    # haven't otherwise changed.
+    - cron: "37 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write   # upload SARIF to the Security tab
+      packages: read           # CodeQL reads container packages metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: manual
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+          fetch-tags: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f25eda876ebb741d872b63b9f2c6dfdd77f14b83 # v4.35.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended,security-and-quality
+
+      # Rust needs an actual `cargo build` for CodeQL to capture call
+      # graphs.  Other languages run extractor-only.
+      - name: Set up Rust (matrix.language == 'rust')
+        if: matrix.language == 'rust'
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          target: wasm32-wasip2
+
+      - name: Build Rust (matrix.language == 'rust')
+        if: matrix.language == 'rust'
+        run: cd editors/zed && cargo build --release --target wasm32-wasip2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f25eda876ebb741d872b63b9f2c6dfdd77f14b83 # v4.35.5
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,10 +7,10 @@ name: Deploy Compiler Explorer to GitHub Pages
 #     tags: ["v*"]
 on: workflow_dispatch
 
+# Least-privilege default; the build job inherits read-only, the deploy job
+# escalates to what GitHub Pages needs.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -20,15 +20,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -39,17 +39,20 @@ jobs:
         run: make explorer-build-cdn
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: build/explorer-cdn
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -47,7 +47,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # Explorer build invokes `git describe --tags` via the Makefile;
+          # tags are required but full history isn't.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: OpenSSF Scorecard
+
+# Weekly OpenSSF Scorecard scan.  Produces SARIF findings against
+# supply-chain best practices (token permissions, pinned actions,
+# branch protection, signed releases, dependency-update tools, etc.) and
+# uploads them to the Security tab.  This is monitoring, not gating —
+# we'll see score drift over time but it doesn't block PRs.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "23 4 * * 2"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write    # upload SARIF to the Security tab
+      id-token: write           # publish-results: OIDC for transparency log
+      contents: read
+      actions: read             # scorecard inspects workflows
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the public Scorecard dashboard so the score is
+          # visible to downstreams without them having to re-run the
+          # scan themselves.
+          publish_results: true
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@f25eda876ebb741d872b63b9f2c6dfdd77f14b83 # v4.35.5
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   vm-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -3,17 +3,20 @@ name: VM Tests
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   vm-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,89 @@
+# Security
+
+## Reporting a vulnerability
+
+Please report security issues privately via [GitHub Security
+Advisories](https://github.com/bitwisecook/tcl-lsp/security/advisories/new)
+rather than opening a public issue.  We aim to acknowledge within
+72 hours.
+
+## Supply-chain posture
+
+This section documents the repo-side controls that the CI workflows
+assume are in place.  Workflow-level controls (SHA pinning, attestation,
+checksum verification, least-privilege `GITHUB_TOKEN`, expression-
+injection guards, Dependabot) live in `.github/`; everything below is
+configured in GitHub repo settings and must be checked manually.
+
+### Required repo settings
+
+These cannot be set from a workflow.  Verify on every audit pass.
+
+**Settings → Actions → General → Workflow permissions**
+
+- [x] `Read repository contents and packages permissions` (NOT "Read and
+      write").  Each workflow then explicitly opts in to writes via its
+      own `permissions:` block.  Defence in depth: a workflow that
+      forgets to declare `permissions:` should default to read-only.
+- [x] `Allow GitHub Actions to create and approve pull requests` —
+      **off**.  No workflow in this repo needs this; leaving it on lets
+      a compromised workflow self-approve a PR.
+
+**Settings → Actions → General → Fork pull request workflows from
+outside collaborators**
+
+- [x] At minimum, `Require approval for first-time contributors who are
+      new to GitHub`.  Prefer `Require approval for all outside
+      collaborators` if release cadence allows.  This is the gate that
+      stops a one-line malicious PR from running CI under your token.
+
+**Settings → Branches → Branch protection for `main`**
+
+- [x] `Require a pull request before merging` — on
+- [x] `Require approvals` — at least 1
+- [x] `Dismiss stale pull request approvals when new commits are pushed`
+      — on
+- [x] `Require review from Code Owners` — on (uses `.github/CODEOWNERS`)
+- [x] `Require status checks to pass before merging` — on, with
+      `pr-gate` (from `.github/workflows/ci.yml`) listed as required
+- [x] `Require branches to be up to date before merging` — on
+- [x] `Require signed commits` — on
+- [x] `Do not allow bypassing the above settings` — on
+- [x] `Allow force pushes` — off
+- [x] `Allow deletions` — off
+
+**Settings → Code security → Dependabot**
+
+- [x] `Dependabot alerts` — on
+- [x] `Dependabot security updates` — on
+- [x] `Grouped security updates` — on (matches the grouping in
+      `.github/dependabot.yml`)
+
+**Settings → Code security → Secret scanning**
+
+- [x] `Secret scanning` — on
+- [x] `Push protection` — on
+
+**Settings → Code security → Code scanning**
+
+- [x] CodeQL `default` setup OR the workflow-mode setup pointing at
+      `.github/workflows/codeql.yml`
+
+### Verifying release artefacts
+
+Each release asset is signed and attested:
+
+- `SHA256SUMS` + `SHA256SUMS.cosign.bundle` — cosign keyless OIDC
+  signature over the checksums file.  Verify with:
+
+      cosign verify-blob \
+        --bundle SHA256SUMS.cosign.bundle \
+        --certificate-identity-regexp "https://github.com/bitwisecook/tcl-lsp/" \
+        --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+        SHA256SUMS
+
+- Every release artefact (install.sh, *.vsix, *.pyz, JetBrains/Sublime/
+  Zed packages) carries a SLSA build-provenance attestation.  Verify
+  with:
+
+      gh attestation verify --owner bitwisecook <artefact>

--- a/scripts/fetch_tcl_regex.sh
+++ b/scripts/fetch_tcl_regex.sh
@@ -35,6 +35,32 @@ BASE_URL="https://raw.githubusercontent.com/tcltk/tcl/${TAG}/generic"
 TARGET_DIR="$REPO_ROOT/runtime/zig/vendor/tcl-regex"
 STAMP_FILE="$TARGET_DIR/.stamp"
 
+# Pinned per-file SHA-256 checksums. The tag pin above is not sufficient
+# on its own: a tag-retargeting attack on tcltk/tcl (the same shape as
+# the tj-actions/changed-files compromise in March 2025) would silently
+# substitute different bytes under the same ``core-9-0-3`` tag. The
+# content pin closes that gap. Bump the version line in the checksums
+# file when bumping TCL_REGEX_VERSION.
+CHECKSUMS_FILE="$SCRIPT_DIR/tcl_regex_sha256sums.txt"
+
+expected_version=$(awk '/^VERSION:/ {print $2; exit}' "$CHECKSUMS_FILE")
+if [[ "$expected_version" != "$VERSION" ]]; then
+    echo "ERROR: TCL_REGEX_VERSION=$VERSION but $CHECKSUMS_FILE pins $expected_version" >&2
+    echo "Bump both in lockstep (regenerate sha256sums for the new version)." >&2
+    exit 1
+fi
+
+verify_checksums() {
+    # Strip comments, blank lines and the VERSION: line, then feed the
+    # remainder to ``sha256sum -c``. Run from TARGET_DIR so the bare
+    # filenames in the checksums file resolve correctly.
+    (
+        cd "$TARGET_DIR" && \
+        grep -Ev '^[[:space:]]*(#|$)|^VERSION:' "$CHECKSUMS_FILE" \
+            | sha256sum --quiet -c -
+    )
+}
+
 # The regex engine is self-contained within 15 files in ``generic/``.
 # ``regcomp.c`` and ``regexec.c`` are the two real compilation units
 # — the ``regc_*.c`` and ``rege_*.c`` files are ``#include``d by
@@ -66,6 +92,9 @@ stamp_is_complete() {
     for f in "${FILES[@]}"; do
         [[ -f "$TARGET_DIR/$f" ]] || return 1
     done
+    # Validate that the files on disk still match the pinned checksums
+    # — detects tampering with a previously-fetched vendor dir.
+    verify_checksums >/dev/null 2>&1 || return 1
     return 0
 }
 
@@ -115,6 +144,17 @@ for f in "${FILES[@]}"; do
         fi
     done
 done
+
+# Fail closed if the downloaded bytes don't match the pinned checksums.
+# Do this BEFORE writing the stamp so a tampered fetch never produces a
+# "this dir is good" marker.
+if ! verify_checksums; then
+    echo "ERROR: SHA-256 mismatch after fetch — refusing to write stamp." >&2
+    echo "This means the upstream tag '$TAG' on tcltk/tcl was retargeted," >&2
+    echo "or the download was tampered with in transit." >&2
+    echo "Investigate before bumping checksums; do not just regenerate them." >&2
+    exit 1
+fi
 
 echo "$VERSION" > "$STAMP_FILE"
 echo "Fetched ${#FILES[@]} files to $TARGET_DIR"

--- a/scripts/tcl_regex_sha256sums.txt
+++ b/scripts/tcl_regex_sha256sums.txt
@@ -1,0 +1,26 @@
+# SHA-256 checksums of the Tcl regex engine sources fetched by
+# scripts/fetch_tcl_regex.sh from raw.githubusercontent.com/tcltk/tcl.
+#
+# These pin the *content* of each file, not just the upstream tag — so a
+# tag-retargeting attack on tcltk/tcl (the same shape as the March 2025
+# tj-actions/changed-files compromise) is detected before the bytes are
+# linked into the WASM runtime.  Bump TCL_REGEX_VERSION in fetch_tcl_regex.sh
+# and these checksums together.
+#
+# Format: `<sha256>  <filename>` (sha256sum -c compatible).  The leading
+# `VERSION:` line is parsed by the script and must match the version pin.
+VERSION: 9.0.3
+0474ca211a971356e1195221d9ac4351a62c0544122ade7a63bbde0d0882a850  regcomp.c
+ccb3dd4924f70acf276946cacbc5d9fa152adc717b6df6b62d28cd5fdc6025af  regexec.c
+03be1daf7518e2da15d6bc78847ad93e8e8a10b39e473ed6e4a5bb22f316e096  regfree.c
+d3656dcddddfe5bc04633342f4e056bcc6e78fec58bc3c976c7411d875bbb2f8  regerror.c
+ae361e311f931338a80e4b4ce25b291b0c05dffc439ce2556f4a67ca73c78587  regfronts.c
+976f6b91e51b48aef849eec79bb5118bd68e46f4f38cb815e27fdc5e5a896375  regc_color.c
+9a5bcc94d7059766c01c846074b9657a39309868fd2e7bfed847af1b2eb3c033  regc_cvec.c
+f532d88ee21186aabb9ecc3ed1fc01257ca2eb9b5ec968e93b913335b8d0ca69  regc_lex.c
+77d13b41413ad2226805b92173c763e0ad5bbf6ab9731e4e13ca87a461ad8787  regc_locale.c
+abf7429a123c4971f77e031861e68ea0814ec0b38c69e95cb37144024b3d429d  regc_nfa.c
+110ca807a464275529806155aeb060254cc1aa8622c195da56c348226bf6ec2d  rege_dfa.c
+9ab668ff9045ca52586613bc5a3a427e56350c1a87023420cc49dd5e8441f3b4  regerrs.h
+c8d2b752b8acc928d1e8fb11b8f58e3b7e18dbd623c50de98c573cf754198e7c  regex.h
+d338568fe56ba78d0431b60582bc0d1c4e7ee21eb4bb6164d7e274c7bcea6eda  regguts.h


### PR DESCRIPTION
Audits the workflows against the tj-actions/changed-files,
reviewdog/action-setup, Ultralytics, Shai-Hulud, Nx and GhostAction
incidents from late-2024 through 2025-Q4, and against current OpenSSF /
GitHub guidance.

Changes:
- Pin every third-party action to a 40-char commit SHA with a trailing
  version comment.  Mutable tag pins are the exact failure mode tj-actions
  exploited in March 2025: a write-capable attacker retargets `v45` (or
  even a major like `v6`) to a malicious commit and every consumer's next
  run executes it.  Dependabot below is the inbound update channel.
- Add `.github/dependabot.yml` for github-actions, pip, npm, cargo and
  gradle ecosystems.  Pinning to SHAs is only safe with an automated
  update channel; without it the pins decay and you stop getting fixes.
- Set workflow-level `permissions: contents: read` on all three
  workflows so jobs without their own block (pr-gate, test-py, test-ext,
  vm-tests, pages-build) cannot write to the repo even if the repo-level
  default is "read and write".
- Stop interpolating `${{ github.head_ref }}` and friends directly into
  `run:` scripts.  `head_ref` is the PR source branch name and is
  attacker-controlled on forked-PR runs; GitHub permits enough
  shell-metacharacters in branch names that this is the classic
  expression-injection vector.  Route through `env:` indirection.
- Add `actions/attest-build-provenance` to each of the twelve `build-*`
  jobs so every release artefact carries a verifiable in-toto attestation
  binding it to this workflow run and commit (defence against
  Ultralytics-style build-time tampering).  Complements the existing
  cosign-signed SHA256SUMS, which only proves the manifest is ours.
- Pin per-file SHA-256 checksums for the Tcl regex sources fetched by
  scripts/fetch_tcl_regex.sh.  The script verifies them post-download
  and on every subsequent stamp-check, failing closed if the upstream
  tcltk/tcl tag is retargeted or the transfer is tampered with.
- Align astral-sh/setup-uv to v6.8.0 across all three workflows (was
  drifting between v4 and v6).