### PR TITLE
Implement Tcl 9 ensemble commands and const variables

### DIFF
--- a/core/commands/registry/tcl/__init__.py
+++ b/core/commands/registry/tcl/__init__.py
@@ -26,6 +26,7 @@ from . import (
     clock,  # noqa: F401
     close_,  # noqa: F401
     concat,  # noqa: F401
+    const,  # noqa: F401
     continue_,  # noqa: F401
     coroutine,  # noqa: F401
     dict,  # noqa: F401

--- a/core/commands/registry/tcl/const.py
+++ b/core/commands/registry/tcl/const.py
@@ -1,0 +1,53 @@
+"""const -- Define a constant variable (Tcl 9 / TIP 590)."""
+
+from __future__ import annotations
+
+from ....compiler.side_effects import ConnectionSide, SideEffect, SideEffectTarget
+from ....compiler.types import TclType
+from .._base import CommandDef
+from ..models import CommandSpec, FormKind, FormSpec, HoverSnippet, ValidationSpec
+from ..signatures import ArgRole, Arity
+from ._base import register
+
+_SOURCE = "Tcl const(1)"
+
+
+@register
+class ConstCommand(CommandDef):
+    name = "const"
+
+    @classmethod
+    def spec(cls) -> CommandSpec:
+        return CommandSpec(
+            name="const",
+            hover=HoverSnippet(
+                summary="Define a constant variable.",
+                synopsis=("const varName value",),
+                snippet=(
+                    "Stores ``value`` in ``varName`` and marks the variable as constant: "
+                    "further attempts to ``set`` or ``unset`` it raise an error. "
+                    "Re-applying ``const`` to an existing constant of the same name is a "
+                    "silent no-op; applying it to an existing non-constant variable raises."
+                ),
+                source=_SOURCE,
+            ),
+            forms=(
+                FormSpec(
+                    kind=FormKind.DEFAULT,
+                    synopsis="const varName value",
+                ),
+            ),
+            validation=ValidationSpec(
+                arity=Arity(2, 2),
+            ),
+            assigns_variable_at=0,
+            arg_roles={0: frozenset({ArgRole.VAR_WRITE})},
+            return_type=TclType.STRING,
+            side_effect_hints=(
+                SideEffect(
+                    target=SideEffectTarget.VARIABLE,
+                    writes=True,
+                    connection_side=ConnectionSide.NONE,
+                ),
+            ),
+        )

--- a/core/compiler/codegen/wasm/_emitter/_core.py
+++ b/core/compiler/codegen/wasm/_emitter/_core.py
@@ -42,6 +42,46 @@ _I64_MIN = -(1 << 63)
 _I64_MAX = (1 << 63) - 1
 
 
+# Tcl list-quote special characters — any of these in an element force
+# brace-quoting on emission.  Used by :func:`_tcl_list_quote` to
+# reconstruct the params spec for ``info args`` parity.
+_TCL_LIST_SPECIAL = frozenset(' \t\n\r{}"\\$;[')
+
+
+def _tcl_list_quote(value: str) -> str:
+    """Brace-quote ``value`` as a Tcl list element when it contains any
+    structural character; otherwise emit as-is.  Empty values become
+    ``{}``.  Backslashes / unbalanced braces inside the value fall back
+    to backslash-quoting so the rebuilt list still parses.
+    """
+    if not value:
+        return "{}"
+    if any(c in _TCL_LIST_SPECIAL for c in value):
+        depth = 0
+        ok = True
+        for c in value:
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth < 0:
+                    ok = False
+                    break
+            elif c == "\\":
+                ok = False
+                break
+        if ok and depth == 0:
+            return "{" + value + "}"
+        out_chars: list[str] = []
+        for c in value:
+            if c in _TCL_LIST_SPECIAL:
+                out_chars.append("\\" + c)
+            else:
+                out_chars.append(c)
+        return "".join(out_chars)
+    return value
+
+
 class _WasmEmitterBase:
     if TYPE_CHECKING:
         # From sibling mixins — declared here so generate() and helpers in _core.py
@@ -843,9 +883,35 @@ class _WasmEmitterBase:
                 continue
             has_args_tail = bool(proc.params and proc.params[-1] == "args")
             n_required = self._compute_n_required(qname, proc.params)
+            params_source = self._build_params_source(qname, proc.params)
             self._compiled_proc_queue.append(
-                (qname, len(proc.params), has_args_tail, n_required, proc.body_source)
+                (
+                    qname,
+                    len(proc.params),
+                    has_args_tail,
+                    n_required,
+                    proc.body_source,
+                    params_source,
+                )
             )
+
+    def _build_params_source(self, qname: str, params: tuple[str, ...]) -> str:
+        """Reconstruct the proc's params spec as a Tcl list string.
+
+        ``info args``/``info default`` read this back as a list whose
+        elements are either bare ``name`` or two-element ``{name
+        default}`` pairs.  Defaults align with ``_proc_defaults[qname]``
+        (``None`` = required, otherwise the source-text default).
+        """
+        defaults = self._proc_defaults.get(qname, ())
+        out: list[str] = []
+        for i, name in enumerate(params):
+            default = defaults[i] if i < len(defaults) else None
+            if default is None:
+                out.append(_tcl_list_quote(name))
+            else:
+                out.append("{" + _tcl_list_quote(name) + " " + _tcl_list_quote(default) + "}")
+        return " ".join(out)
 
     def _compute_n_required(self, qname: str, params: tuple[str, ...]) -> int:
         """Count required (no-default) positional params, excluding ``args`` tail."""
@@ -895,8 +961,16 @@ class _WasmEmitterBase:
         if queue:
             reg_idx = self._shared_imports.get("tcl_proc_register_compiled")
             body_idx = self._shared_imports.get("tcl_proc_set_body_source")
+            params_idx = self._shared_imports.get("tcl_proc_set_params_source_raw")
             if reg_idx is not None:
-                for qname, n_params, has_args_tail, n_required, body_source in queue:
+                for (
+                    qname,
+                    n_params,
+                    has_args_tail,
+                    n_required,
+                    body_source,
+                    params_source,
+                ) in queue:
                     self._emit_obj_literal(qname)
                     self._emit_i32_const(n_params)
                     self._emit_i32_const(1)  # func_idx marker (any non-zero)
@@ -914,6 +988,33 @@ class _WasmEmitterBase:
                         self._emit_obj_literal(qname)
                         self._emit_obj_literal(body_source)
                         self._emit_call(body_idx)
+                        self._emit(WasmOp.DROP)
+                    # Stash the source-text params spec for ``info
+                    # args`` parity.  Only emit when we actually
+                    # reconstructed a non-empty list; nullary procs
+                    # leave the slot at zero and ``info args`` on a
+                    # nullary proc returns an empty list either way.
+                    #
+                    # We pass raw (ptr, len) of the data-segment
+                    # bytes — no TclObj allocation, no retain.  The
+                    # earlier obj-passing form triggered a cmdAH
+                    # cascade tied to extra ``tcl_obj_retain`` at
+                    # module init (root cause not pinned; see
+                    # ``proc_set_params_source_raw``'s docstring).
+                    if params_idx is not None and params_source:
+                        params_encoded = params_source.encode("utf-8", errors="surrogatepass")
+                        params_offset = self._intern_string(params_source)
+                        qname_encoded = qname.encode("utf-8", errors="surrogatepass")
+                        qname_offset = self._intern_string(qname)
+                        # Push (name_ptr, name_len, params_ptr,
+                        # params_len) and call.  All four args are
+                        # raw data-segment offsets — no TclObj
+                        # allocation per proc at module init.
+                        self._emit_i32_const(qname_offset + 4)
+                        self._emit_i32_const(len(qname_encoded))
+                        self._emit_i32_const(params_offset + 4)
+                        self._emit_i32_const(len(params_encoded))
+                        self._emit_call(params_idx)
                         self._emit(WasmOp.DROP)
 
         # Compiled-proc entry prologue: push a frame and bind each

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -1200,7 +1200,16 @@ class _WasmEmitterStmtMixin(_Base):
             if (
                 canonical_command == "::namespace"
                 and args
-                and args[0] in ("import", "export", "forget", "path", "unknown", "delete")
+                and args[0]
+                in (
+                    "import",
+                    "export",
+                    "forget",
+                    "path",
+                    "unknown",
+                    "delete",
+                    "ensemble",
+                )
             ):
                 # ``namespace path LIST`` mutates the current ns's
                 # command-resolution path; tcltest's mathop.test does

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -975,6 +975,27 @@ class _WasmEmitterStmtMixin(_Base):
                 self._emit_obj_literal(body)
                 self._emit_call(body_idx)
                 self._emit(WasmOp.DROP)
+        # Re-stash the params spec so ``info args`` returns the
+        # original list after the proc_register_compiled call above
+        # cleared it.  Uses the raw (ptr, len) shape — no TclObj
+        # allocation per call, no retain — so this hook is safe to
+        # emit per-statement at runtime without the cmdAH-cascade
+        # trap that hits the obj-passing shape.  ``params`` here is
+        # the raw Tcl list source from the surrounding ``proc``
+        # statement (already parsed into a single literal string),
+        # interned in the data segment.
+        params_idx = self._shared_imports.get("tcl_proc_set_params_source_raw")
+        if params_idx is not None and params:
+            params_encoded = params.encode("utf-8", errors="surrogatepass")
+            params_offset = self._intern_string(params)
+            qname_encoded = qname.encode("utf-8", errors="surrogatepass")
+            qname_offset = self._intern_string(qname)
+            self._emit_i32_const(qname_offset + 4)
+            self._emit_i32_const(len(qname_encoded))
+            self._emit_i32_const(params_offset + 4)
+            self._emit_i32_const(len(params_encoded))
+            self._emit_call(params_idx)
+            self._emit(WasmOp.DROP)
 
     def _resolve_proc_qname(self, command: str) -> str | None:
         """Resolve ``command`` to the qualified proc name if it matches."""

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -645,6 +645,17 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
         [ValType.I32, ValType.I32],
         [ValType.I32],
     ),
+    # Stash the raw bytes of the params spec so ``info args`` /
+    # ``info default`` can materialise a fresh TclObj on demand for
+    # AOT-compiled procs.  Takes (name, ptr, len) — pointer-only,
+    # never a TclObj — so we sidestep the cmdAH-cascade trap that
+    # any extra ``tcl_obj_retain`` per proc at module init triggers.
+    "tcl_proc_set_params_source_raw": (
+        "tcl",
+        "proc_set_params_source_raw",
+        [ValType.I32, ValType.I32, ValType.I32, ValType.I32],
+        [ValType.I32],
+    ),
     # Info dispatch helpers (info exists / info <sub>).  The ``info``
     # command itself is a registry spec, but these two helpers are
     # invoked by the emitter directly rather than via a subcommand

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1463,6 +1463,12 @@ def _scan_needed_imports(
         # the AOT path would otherwise leave behind.  The codegen
         # prologue skips the call when ``body_source is None``.
         needed.add("tcl_proc_set_body_source")
+        # Raw-bytes sibling: stash the params spec via data-segment
+        # ptr/len so ``info args`` materialises a TclObj on demand.
+        # The raw shape avoids the per-proc ``tcl_obj_retain`` that
+        # cascades into tcltest bootstrap failures (see
+        # ``proc_set_params_source_raw``'s docstring).
+        needed.add("tcl_proc_set_params_source_raw")
         needed.add("tcl_frame_push")
         needed.add("tcl_frame_pop")
         needed.add("tcl_frame_set_argv")

--- a/runtime/zig/cmds/array.zig
+++ b/runtime/zig/cmds/array.zig
@@ -159,6 +159,16 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
         // We trust ``array_set_list`` to detect the odd-length list
         // case and surface the ``list must have an even number of
         // elements`` error.
+        // Parent-namespace check: ``array set foo::bar ...`` where
+        // ``foo`` isn't a registered namespace raises the canonical
+        // ``can't set "<name>": parent namespace doesn't exist``
+        // diagnostic per set-old-8.38.5/8.38.6/8.38.7 — emit it
+        // before touching the array directory so a side-effect-free
+        // probe doesn't leave a half-initialised entry behind.
+        if (parent_ns_missing_for_array_set(words[2])) {
+            raise_parent_ns_missing(words[2]);
+            return result_mod.from_globals(0);
+        }
         return result_mod.from_globals(array_mod.array_set_list(resolved_name, words[3]));
     }
     if (str_eq(sp, sub_len, "exists")) return result_mod.from_globals(array_mod.array_exists(resolved_name));
@@ -253,6 +263,76 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
     const sub_slice: []const u8 = (@as([*]const u8, @ptrFromInt(sub.ptr)))[0..sub.len];
     stubs_mod.unsupported_sub("array", sub_slice);
     return result_mod.from_globals(0);
+}
+
+/// Probe whether ``name``'s parent namespace exists.  Returns true iff
+/// *name* is qualified (contains ``::``) AND the prefix up to the
+/// last ``::`` doesn't resolve to an existing namespace.  Used by
+/// ``array set`` to surface the canonical ``parent namespace doesn't
+/// exist`` diagnostic (set-old-8.38.5/6/7) before mutating the array
+/// directory.
+fn parent_ns_missing_for_array_set(name_obj: i32) bool {
+    const obj_mod = @import("../valtypes/tcl_obj.zig");
+    const tcl_ns = @import("../interp/tcl_ns.zig");
+    const sn = obj_mod.obj_ensure_string(name_obj);
+    if (sn.len < 2 or sn.ptr == 0) return false;
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    // Find the last ``::`` boundary.  Walk left-to-right tracking the
+    // most-recent separator; cheap for short names.
+    var last_sep: i32 = -1;
+    var i: u32 = 0;
+    while (i + 1 < sn.len) : (i += 1) {
+        if (sp[i] == ':' and sp[i + 1] == ':') {
+            last_sep = @intCast(i);
+        }
+    }
+    if (last_sep < 0) return false; // bare name — no parent ns to validate
+    const sep_at: u32 = @intCast(last_sep);
+    if (sep_at == 0) return false; // leading ``::xxx`` — parent is root
+    // ``ns_resolve_qualified`` returns target_ns = the resolved
+    // namespace ONLY when the input ends at a ``::`` boundary; passing
+    // just the prefix bytes hits the "last component is the simple
+    // name" branch and returns target_ns = current-ns (always non-
+    // zero), which is the wrong signal.  Append a trailing ``::`` to
+    // the prefix so the resolver walks the full path and reports
+    // target_ns = 0 when an intermediate is missing.
+    const ctx: u32 = tcl_ns.ns_current();
+    const probe_len: u32 = sep_at + 2;
+    const r = tcl_ns.ns_resolve_qualified(ctx, sn.ptr, probe_len);
+    if (r.target_ns == 0) return true;
+    return false;
+}
+
+/// Emit ``can't set "<name>": parent namespace doesn't exist``.
+fn raise_parent_ns_missing(name_obj: i32) void {
+    const obj_mod = @import("../valtypes/tcl_obj.zig");
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const sn = obj_mod.obj_ensure_string(name_obj);
+    const prefix: []const u8 = "can't set \"";
+    const suffix: []const u8 = "\": parent namespace doesn't exist";
+    const total: u32 = @intCast(prefix.len + sn.len + suffix.len);
+    const buf = obj_mod.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(obj_mod.obj_new_string(0, 0));
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const np: [*]const u8 = @ptrFromInt(sn.ptr);
+    for (0..sn.len) |k| {
+        dst[off] = np[k];
+        off += 1;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const e = obj_mod.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(e);
 }
 
 fn raise_array_error(msg: []const u8) void {

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -17,6 +17,21 @@ const reg = @import("../dispatch/tcl_cmd_registry.zig");
 ///   * the name has no ``(`` array-element notation (array-element
 ///     traces flow through the array directory unchanged).
 /// Returns true when the per-frame chain owns the trace.
+/// Tcl 9 ``trace add`` accepts abbreviated keywords (``var`` for
+/// ``variable``, ``cmd`` for ``command``, ``exec`` for ``execution``).
+/// Match any prefix of ``"variable"`` that's at least 3 chars long so
+/// the trace-tracker hooks fire regardless of spelling.  set-old-9.10
+/// uses ``trace add var ...``.
+fn is_variable_keyword(p: [*]const u8, len: u32) bool {
+    if (len < 3 or len > 8) return false;
+    const lit = "variable";
+    var k: u32 = 0;
+    while (k < len) : (k += 1) {
+        if (p[k] != lit[k]) return false;
+    }
+    return true;
+}
+
 fn is_local_trace_target(name: i32) bool {
     if (frames.frame_depth == 0) return false;
     const sn = rt.obj_ensure_string(name);
@@ -67,7 +82,7 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (str_eq(sub_p, sub_s.len, "add") and words.len >= 6) {
         const kind_s = obj_ensure_string(words[2]);
         const kind_p: [*]const u8 = @ptrFromInt(kind_s.ptr);
-        if (str_eq(kind_p, kind_s.len, "variable")) {
+        if (is_variable_keyword(kind_p, kind_s.len)) {
             const name = words[3];
             const ops = parse_ops(words[4]);
             install_var_trace(name, ops, words[5]);
@@ -80,7 +95,7 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (str_eq(sub_p, sub_s.len, "remove") and words.len >= 6) {
         const kind_s = obj_ensure_string(words[2]);
         const kind_p: [*]const u8 = @ptrFromInt(kind_s.ptr);
-        if (str_eq(kind_p, kind_s.len, "variable")) {
+        if (is_variable_keyword(kind_p, kind_s.len)) {
             const name = words[3];
             const ops = parse_ops(words[4]);
             _ = uninstall_var_trace(name, ops, words[5]);
@@ -92,7 +107,7 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (str_eq(sub_p, sub_s.len, "info") and words.len >= 4) {
         const kind_s = obj_ensure_string(words[2]);
         const kind_p: [*]const u8 = @ptrFromInt(kind_s.ptr);
-        if (str_eq(kind_p, kind_s.len, "variable")) {
+        if (is_variable_keyword(kind_p, kind_s.len)) {
             return result_mod.from_globals(query_var_trace(words[3]));
         }
         return result_mod.from_globals(obj_new_string(0, 0));
@@ -203,6 +218,14 @@ fn canonical_var_name(name: i32) i32 {
 /// ``remove`` / ``info`` only read the bytes through the handle
 /// and don't retain it (Copilot review on PR #343).
 fn install_var_trace(name: i32, ops: u32, cmd_prefix: i32) void {
+    // Phase E (set-old-9.10): when ``trace add variable arr(key)``
+    // names an element that doesn't yet exist, reference Tcl creates
+    // the element as part of registering the trace — and that
+    // creation invalidates active ``array startsearch`` cursors on
+    // ``arr``.  Existing-element traces (9.11) make no shape change
+    // and must NOT invalidate.  Probe before the trace installation
+    // so we read the pre-install element state.
+    maybe_invalidate_searches_on_trace_install(name);
     if (is_local_trace_target(name)) {
         var_trace.add_to_list(&frames.frame_trace_heads[frames.frame_depth - 1], name, ops, cmd_prefix);
         return;
@@ -210,6 +233,38 @@ fn install_var_trace(name: i32, ops: u32, cmd_prefix: i32) void {
     const canon = canonical_var_name(name);
     var_trace.add(canon, ops, cmd_prefix);
     if (canon != name and canon != 0) tcl_obj_release(canon);
+}
+
+/// When ``name`` parses as ``arr(key)`` and ``arr`` has *no* element
+/// at ``key`` yet, invalidate every active search on ``arr`` —
+/// installing a trace on a fresh element grows the array, which Tcl
+/// treats as a search-affecting mutation.  No-op otherwise.
+fn maybe_invalidate_searches_on_trace_install(name: i32) void {
+    const sn = obj_ensure_string(name);
+    if (sn.ptr == 0 or sn.len < 3) return;
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    if (sp[sn.len - 1] != ')') return;
+    var paren: i32 = -1;
+    var i: u32 = 0;
+    while (i < sn.len) : (i += 1) {
+        if (sp[i] == '(') {
+            paren = @intCast(i);
+            break;
+        }
+    }
+    if (paren <= 0) return;
+    const paren_at: u32 = @intCast(paren);
+    const arr_name = obj_new_string(@bitCast(sn.ptr), @bitCast(paren_at));
+    const key_off: u32 = paren_at + 1;
+    const key_len: u32 = sn.len - paren_at - 2;
+    const key_obj = obj_new_string(@bitCast(sn.ptr + key_off), @bitCast(key_len));
+    defer tcl_obj_release(arr_name);
+    defer tcl_obj_release(key_obj);
+    const tcl_array_mod = @import("../valtypes/tcl_array.zig");
+    const obj_helpers = @import("../valtypes/tcl_obj.zig");
+    if (obj_helpers.obj_get_int(tcl_array_mod.array_element_exists(arr_name, key_obj)) == 0) {
+        tcl_array_mod.array_invalidate_searches_for_obj(arr_name);
+    }
 }
 
 /// Mirror of :func:`install_var_trace` for the remove path.

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -1147,71 +1147,978 @@ fn eval_ns_ensemble(words: []const i32) i32 {
         raise_bad_ensemble_subcmd(0, 0);
         return 0;
     }
-    const sp2: [*]const u8 = @ptrFromInt(sub2.ptr);
     if (slice_eq_ns(sub2.ptr, sub2.len, "create")) {
         return eval_ns_ensemble_create(words);
     }
-    if (slice_eq_ns(sub2.ptr, sub2.len, "exists")) {
-        // Stub: we don't track ensembles, so always 0.
-        return obj_new_int(0);
+    if (slice_eq_ns(sub2.ptr, sub2.len, "exists") and words.len >= 4) {
+        const bucket = ensemble_find_cmd(words[3]);
+        if (bucket == 0) return obj_new_int(0);
+        const flags: u32 = @bitCast(obj_mod.read_i32(bucket + procs.OFF_FLAGS));
+        return obj_new_int(if ((flags & procs.CMD_ENSEMBLE) != 0) 1 else 0);
     }
-    if (slice_eq_ns(sub2.ptr, sub2.len, "configure")) {
-        // Stub: report empty default options.  Matches the option
-        // names Tcl 9 ships even though we don't actually use them.
-        return obj_new_string_copy_str("-map {} -namespace ::%s -parameters {} -prefixes 1 -subcommands {} -unknown {}");
+    if ((slice_eq_ns(sub2.ptr, sub2.len, "configure") or
+        slice_eq_ns(sub2.ptr, sub2.len, "config")) and words.len >= 4)
+    {
+        return eval_ns_ensemble_configure(words);
     }
-    _ = sp2;
     raise_bad_ensemble_subcmd(sub2.ptr, sub2.len);
     return 0;
 }
 
+/// ``namespace ensemble configure CMD ?option? ?value option value ...?``
+/// — read or write one or more ensemble options.
+///   * 4-arg form (``namespace ensemble configure CMD``): return the
+///     full option list.
+///   * 5-arg form (``... CMD -OPT``): return that option's value.
+///   * 6+-arg form (``... CMD -OPT VAL ...``): set option(s); return
+///     empty.
+fn eval_ns_ensemble_configure(words: []const i32) i32 {
+    const bucket = ensemble_find_cmd(words[3]);
+    if (bucket == 0) {
+        raise_not_an_ensemble(words[3]);
+        return 0;
+    }
+    const flags: u32 = @bitCast(obj_mod.read_i32(bucket + procs.OFF_FLAGS));
+    if ((flags & procs.CMD_ENSEMBLE) == 0) {
+        raise_not_an_ensemble(words[3]);
+        return 0;
+    }
+    const rec_addr: u32 = @bitCast(obj_mod.read_i32(bucket + procs.OFF_PARAMS_OBJ));
+    if (rec_addr == 0) {
+        raise_not_an_ensemble(words[3]);
+        return 0;
+    }
+    const rec: *EnsembleRec = @ptrFromInt(rec_addr);
+    if (words.len == 4) {
+        return render_ensemble_config(rec);
+    }
+    if (words.len == 5) {
+        return read_ensemble_option(rec, words[4]);
+    }
+    // Setter form: pairs from words[4..].
+    var i: u32 = 4;
+    while (i + 1 < words.len) : (i += 2) {
+        const key = obj_ensure_string(words[i]);
+        const val_obj = words[i + 1];
+        const val = obj_ensure_string(val_obj);
+        if (slice_eq_ns(key.ptr, key.len, "-map")) {
+            if (val.len == 0) {
+                if (rec.map_obj != 0) {
+                    obj_mod.tcl_obj_release(rec.map_obj);
+                    rec.map_obj = 0;
+                }
+            } else {
+                const n = obj_mod.list_count_elements(val.ptr, val.len);
+                if (@rem(n, 2) != 0) {
+                    raise_ns_error("missing value to go with key");
+                    return 0;
+                }
+                ensemble_set_obj_slot(&rec.map_obj, val_obj);
+            }
+        } else if (slice_eq_ns(key.ptr, key.len, "-subcommands") or slice_eq_ns(key.ptr, key.len, "-subcommand")) {
+            if (val.len == 0) {
+                if (rec.sub_obj != 0) {
+                    obj_mod.tcl_obj_release(rec.sub_obj);
+                    rec.sub_obj = 0;
+                }
+            } else {
+                ensemble_set_obj_slot(&rec.sub_obj, val_obj);
+            }
+        } else if (slice_eq_ns(key.ptr, key.len, "-unknown")) {
+            if (val.len == 0) {
+                if (rec.unknown_obj != 0) {
+                    obj_mod.tcl_obj_release(rec.unknown_obj);
+                    rec.unknown_obj = 0;
+                }
+            } else {
+                ensemble_set_obj_slot(&rec.unknown_obj, val_obj);
+            }
+        } else if (slice_eq_ns(key.ptr, key.len, "-parameters")) {
+            if (val.len == 0) {
+                if (rec.params_obj != 0) {
+                    obj_mod.tcl_obj_release(rec.params_obj);
+                    rec.params_obj = 0;
+                }
+            } else {
+                ensemble_set_obj_slot(&rec.params_obj, val_obj);
+            }
+        } else if (slice_eq_ns(key.ptr, key.len, "-prefixes")) {
+            const b = obj_get_int(val_obj);
+            rec.prefixes = if (b != 0) 1 else 0;
+        }
+    }
+    return obj_new_string(0, 0);
+}
+
+fn render_ensemble_config(rec: *EnsembleRec) i32 {
+    // Build ``-map {…} -namespace ::ns -parameters {…} -prefixes N
+    // -subcommands {…} -unknown {…}``.
+    var bufs: [6]i32 = .{ 0, 0, 0, 0, 0, 0 };
+    const keys: [6][]const u8 = .{ "-map", "-namespace", "-parameters", "-prefixes", "-subcommands", "-unknown" };
+    bufs[0] = if (rec.map_obj != 0) brace_wrap(rec.map_obj) else obj_new_string_copy_str("{}");
+    {
+        const ns_full = tcl_ns.ns_full_name(rec.target_ns);
+        bufs[1] = obj_mod.obj_new_string(@bitCast(ns_full.ptr), @bitCast(ns_full.len));
+    }
+    bufs[2] = if (rec.params_obj != 0) brace_wrap(rec.params_obj) else obj_new_string_copy_str("{}");
+    bufs[3] = if (rec.prefixes != 0) obj_new_string_copy_str("1") else obj_new_string_copy_str("0");
+    bufs[4] = if (rec.sub_obj != 0) brace_wrap(rec.sub_obj) else obj_new_string_copy_str("{}");
+    bufs[5] = if (rec.unknown_obj != 0) brace_wrap(rec.unknown_obj) else obj_new_string_copy_str("{}");
+    // Compute total.
+    var total: u32 = 0;
+    var i: u32 = 0;
+    while (i < 6) : (i += 1) {
+        if (i > 0) total += 1;
+        total += @as(u32, @intCast(keys[i].len)) + 1; // key + space
+        const s = obj_ensure_string(bufs[i]);
+        total += s.len;
+    }
+    const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    i = 0;
+    while (i < 6) : (i += 1) {
+        if (i > 0) {
+            dst[off] = ' ';
+            off += 1;
+        }
+        for (keys[i]) |c| {
+            dst[off] = c;
+            off += 1;
+        }
+        dst[off] = ' ';
+        off += 1;
+        const s = obj_ensure_string(bufs[i]);
+        if (s.len > 0) {
+            const sp: [*]const u8 = @ptrFromInt(s.ptr);
+            for (0..s.len) |k| dst[off + k] = sp[k];
+            off += s.len;
+        }
+    }
+    // Release the temporary value-formatted objs.
+    i = 0;
+    while (i < 6) : (i += 1) if (bufs[i] != 0) obj_mod.tcl_obj_release(bufs[i]);
+    return obj_mod.obj_new_string_take(buf, off, total);
+}
+
+fn retained_or_empty(slot: i32) i32 {
+    if (slot == 0) return obj_new_string(0, 0);
+    obj_mod.tcl_obj_retain(slot);
+    return slot;
+}
+
+fn read_ensemble_option(rec: *EnsembleRec, key_obj: i32) i32 {
+    const key = obj_ensure_string(key_obj);
+    if (slice_eq_ns(key.ptr, key.len, "-map")) return retained_or_empty(rec.map_obj);
+    if (slice_eq_ns(key.ptr, key.len, "-namespace")) {
+        const ns_full = tcl_ns.ns_full_name(rec.target_ns);
+        return obj_mod.obj_new_string(@bitCast(ns_full.ptr), @bitCast(ns_full.len));
+    }
+    if (slice_eq_ns(key.ptr, key.len, "-parameters")) return retained_or_empty(rec.params_obj);
+    if (slice_eq_ns(key.ptr, key.len, "-prefixes")) {
+        return if (rec.prefixes != 0) obj_new_string_copy_str("1") else obj_new_string_copy_str("0");
+    }
+    if (slice_eq_ns(key.ptr, key.len, "-subcommands")) return retained_or_empty(rec.sub_obj);
+    if (slice_eq_ns(key.ptr, key.len, "-unknown")) return retained_or_empty(rec.unknown_obj);
+    return obj_new_string(0, 0);
+}
+
+/// Wrap a TclObj's string in ``{…}`` braces for the ``configure``
+/// emit.  Empty becomes ``{}``.  Caller releases.
+fn brace_wrap(value: i32) i32 {
+    const s = obj_ensure_string(value);
+    if (s.len == 0) return obj_new_string_copy_str("{}");
+    const total: u32 = s.len + 2;
+    const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
+    const dst: [*]u8 = @ptrFromInt(buf);
+    dst[0] = '{';
+    const sp: [*]const u8 = @ptrFromInt(s.ptr);
+    for (0..s.len) |i| dst[1 + i] = sp[i];
+    dst[total - 1] = '}';
+    return obj_mod.obj_new_string_take(buf, total, total);
+}
+
+fn raise_not_an_ensemble(name: i32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const sn = obj_ensure_string(name);
+    const prefix: []const u8 = "\"";
+    const suffix: []const u8 = "\" is not an ensemble command";
+    const total: u32 = @intCast(prefix.len + sn.len + suffix.len);
+    const buf = alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (sn.len > 0) {
+        const np: [*]const u8 = @ptrFromInt(sn.ptr);
+        for (0..sn.len) |i| dst[off + i] = np[i];
+        off += sn.len;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    catch_mod.tcl_cmd_error(obj_mod.obj_new_string_take(buf, total, total));
+}
+
+// -- Ensemble support (Tcl 9 ``namespace ensemble``) -----------------------
+//
+// Each ensemble is a Command bucket whose ``CMD_ENSEMBLE`` flag is set
+// and whose ``OFF_PARAMS_OBJ`` slot holds a pointer to an
+// :type:`EnsembleRec`.  The proc dispatch fast path in
+// ``eval_proc_call_bucket`` detects the flag and routes invocations
+// through :func:`dispatch_ensemble`.
+
+fn std_fmt_u32(buf: *[16]u8, v: u32) u32 {
+    if (v == 0) {
+        buf[0] = '0';
+        return 1;
+    }
+    var i: u32 = 0;
+    var x = v;
+    while (x > 0) : (i += 1) {
+        buf[i] = '0' + @as(u8, @intCast(x % 10));
+        x /= 10;
+    }
+    var a: u32 = 0;
+    var b: u32 = i - 1;
+    while (a < b) {
+        const t = buf[a];
+        buf[a] = buf[b];
+        buf[b] = t;
+        a += 1;
+        b -= 1;
+    }
+    return i;
+}
+
+/// Heap record describing a single ensemble command.  Owned by the
+/// Command bucket via ``OFF_PARAMS_OBJ``; lifetime ends when the
+/// owning Command is deleted (``rename ENS ""``) or its namespace
+/// torn down.  Retains the TclObj fields it holds — the create /
+/// configure paths balance retain/release around mutations.
+const EnsembleRec = extern struct {
+    target_ns: u32, // *Namespace
+    map_obj: i32, // {key impl key impl ...} or 0
+    sub_obj: i32, // {sub sub ...} or 0
+    unknown_obj: i32, // unknown handler cmd-prefix or 0
+    params_obj: i32, // formal parameter list or 0
+    prefixes: u32, // boolean: allow prefix matching (default 1)
+};
+
+const ENS_REC_SIZE: u32 = @sizeOf(EnsembleRec);
+
+fn ensemble_rec_alloc() u32 {
+    const addr = alloc(ENS_REC_SIZE);
+    const r: *EnsembleRec = @ptrFromInt(addr);
+    r.target_ns = 0;
+    r.map_obj = 0;
+    r.sub_obj = 0;
+    r.unknown_obj = 0;
+    r.params_obj = 0;
+    r.prefixes = 1;
+    return addr;
+}
+
+fn ensemble_rec_release(addr: u32) void {
+    if (addr == 0) return;
+    const r: *EnsembleRec = @ptrFromInt(addr);
+    if (r.map_obj != 0) obj_mod.tcl_obj_release(r.map_obj);
+    if (r.sub_obj != 0) obj_mod.tcl_obj_release(r.sub_obj);
+    if (r.unknown_obj != 0) obj_mod.tcl_obj_release(r.unknown_obj);
+    if (r.params_obj != 0) obj_mod.tcl_obj_release(r.params_obj);
+    obj_mod.free_sized(addr, ENS_REC_SIZE);
+}
+
+fn ensemble_set_obj_slot(slot: *i32, new_val: i32) void {
+    if (new_val != 0) obj_mod.tcl_obj_retain(new_val);
+    const old = slot.*;
+    slot.* = new_val;
+    if (old != 0) obj_mod.tcl_obj_release(old);
+}
+
+/// Look up a Command by qualified or bare name.  Returns 0 when not
+/// found.  Used by ensemble-introspection paths.
+fn ensemble_find_cmd(name_obj: i32) u32 {
+    const sn = obj_ensure_string(name_obj);
+    if (sn.len == 0 or sn.ptr == 0) return 0;
+    return tcl_ns.ns_find_command(tcl_ns.ns_current(), sn.ptr, sn.len);
+}
+
+/// Read the EnsembleRec for *bucket*, or null if not an ensemble.
+fn ensemble_rec_of(bucket: u32) ?*EnsembleRec {
+    if (bucket == 0) return null;
+    const flags: u32 = @bitCast(obj_mod.read_i32(bucket + procs.OFF_FLAGS));
+    if ((flags & procs.CMD_ENSEMBLE) == 0) return null;
+    const rec_addr: u32 = @bitCast(obj_mod.read_i32(bucket + procs.OFF_PARAMS_OBJ));
+    if (rec_addr == 0) return null;
+    return @ptrFromInt(rec_addr);
+}
+
+/// Append ``::`` then ``name`` to an existing FQN, producing a new
+/// owning TclObj.  Used to render the default ensemble command name
+/// (which inherits the namespace it was created in) and to qualify
+/// ``-map`` impls that arrived as bare names.
+fn ns_join_name(ns_full: anytype, simple_ptr: u32, simple_len: u32) i32 {
+    const total: u32 = ns_full.len + 2 + simple_len;
+    const buf = alloc(total);
+    if (buf == 0) return 0;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+    for (0..ns_full.len) |i| dst[i] = np[i];
+    dst[ns_full.len] = ':';
+    dst[ns_full.len + 1] = ':';
+    if (simple_len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(simple_ptr);
+        for (0..simple_len) |i| dst[ns_full.len + 2 + i] = sp[i];
+    }
+    return obj_mod.obj_new_string_take(buf, total, total);
+}
+
 fn eval_ns_ensemble_create(words: []const i32) i32 {
-    // ``namespace ensemble create ?-OPT VAL?...`` — we just validate
-    // the option shape to surface namespace-44.3 / 44.4 / 44.6 and
-    // return an empty result.  Real dispatch isn't wired up.
+    // ``namespace ensemble create ?-OPT VAL?...`` — parse the option
+    // list into a fresh EnsembleRec, then register a Command in the
+    // ``-command`` namespace (default: current ns inherits its own
+    // simple name) carrying the ENS_FLAG + EnsembleRec pointer.
     if (((words.len - 3) & 1) != 0) {
-        // A bare ``namespace ensemble create gorp`` (one trailing
-        // word) is wrong-args in Tcl 9 because options are
-        // ``-key value`` pairs; an odd remainder means the user
-        // gave a stray word like ``gorp`` (namespace-44.6).
         raise_ns_error("wrong # args: should be \"namespace ensemble create ?option value ...?\"");
         return 0;
     }
+    const rec_addr = ensemble_rec_alloc();
+    const rec: *EnsembleRec = @ptrFromInt(rec_addr);
+    rec.target_ns = tcl_ns.ns_current();
+    var cmd_name: i32 = 0; // optional ``-command`` override
     var i: u32 = 3;
     while (i + 1 < words.len) : (i += 2) {
         const key = obj_ensure_string(words[i]);
         const val = obj_ensure_string(words[i + 1]);
         if (key.len == 0 or @as([*]const u8, @ptrFromInt(key.ptr))[0] != '-') {
+            ensemble_rec_release(rec_addr);
             raise_ns_error("missing value to go with key");
             return 0;
         }
-        // ``-map`` value must be a list of {key impl key impl ...}
-        // with non-empty implementations (44.4).
         if (slice_eq_ns(key.ptr, key.len, "-map")) {
-            if (val.len == 0) continue;
-            const obj_h = @import("../valtypes/tcl_obj.zig");
-            const n = obj_h.list_count_elements(val.ptr, val.len);
-            if (@rem(n, 2) != 0) {
-                raise_ns_error("missing value to go with key");
-                return 0;
-            }
-            var k: i64 = 1;
-            while (k < n) : (k += 2) {
-                const impl = obj_h.list_element_at(val.ptr, val.len, k);
-                if (impl.len == 0) {
-                    raise_ns_error("ensemble subcommand implementations must be non-empty lists");
+            if (val.len > 0) {
+                const n = obj_mod.list_count_elements(val.ptr, val.len);
+                if (@rem(n, 2) != 0) {
+                    ensemble_rec_release(rec_addr);
+                    raise_ns_error("missing value to go with key");
                     return 0;
                 }
+                var k: i64 = 1;
+                while (k < n) : (k += 2) {
+                    const impl = obj_mod.list_element_at(val.ptr, val.len, k);
+                    if (impl.len == 0) {
+                        ensemble_rec_release(rec_addr);
+                        raise_ns_error("ensemble subcommand implementations must be non-empty lists");
+                        return 0;
+                    }
+                }
+                ensemble_set_obj_slot(&rec.map_obj, words[i + 1]);
+            }
+        } else if (slice_eq_ns(key.ptr, key.len, "-subcommands")) {
+            if (val.len > 0) ensemble_set_obj_slot(&rec.sub_obj, words[i + 1]);
+        } else if (slice_eq_ns(key.ptr, key.len, "-unknown")) {
+            if (val.len > 0) ensemble_set_obj_slot(&rec.unknown_obj, words[i + 1]);
+        } else if (slice_eq_ns(key.ptr, key.len, "-parameters")) {
+            if (val.len > 0) ensemble_set_obj_slot(&rec.params_obj, words[i + 1]);
+        } else if (slice_eq_ns(key.ptr, key.len, "-prefixes")) {
+            const b = obj_get_int(words[i + 1]);
+            rec.prefixes = if (b != 0) 1 else 0;
+        } else if (slice_eq_ns(key.ptr, key.len, "-command")) {
+            cmd_name = words[i + 1];
+        } else if (slice_eq_ns(key.ptr, key.len, "-namespace")) {
+            // Resolve the target namespace.  Bare name → child of
+            // root; FQN → resolved from root.
+            if (val.len > 0) {
+                const ns_handle = tcl_ns.ns_create_from_fqn(val.ptr, val.len);
+                if (ns_handle != 0) rec.target_ns = ns_handle;
             }
         }
     }
     if (i < words.len) {
-        // Trailing single token (e.g. ``-map`` with no value at the
-        // end) — Tcl 9 says "missing value to go with key".
+        ensemble_rec_release(rec_addr);
         raise_ns_error("missing value to go with key");
         return 0;
     }
-    return obj_new_string(0, 0);
+
+    // Determine the command name and target ns to register under.
+    var register_ns: u32 = rec.target_ns;
+    var simple_ptr: u32 = 0;
+    var simple_len: u32 = 0;
+    if (cmd_name != 0) {
+        const cns = obj_ensure_string(cmd_name);
+        const r = tcl_ns.ns_resolve_qualified_creating(tcl_ns.ns_current(), cns.ptr, cns.len);
+        if (r.target_ns != 0 and r.simple_len > 0) {
+            register_ns = r.target_ns;
+            simple_ptr = r.simple_ptr;
+            simple_len = r.simple_len;
+        }
+    } else {
+        // Default: command name = simple-tail of the target namespace.
+        const ns_full = tcl_ns.ns_full_name(rec.target_ns);
+        // Strip the leading ``::`` then walk to the last ``::`` for
+        // the simple name.
+        var start: u32 = 0;
+        if (ns_full.len >= 2) {
+            const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+            if (np[0] == ':' and np[1] == ':') start = 2;
+        }
+        const np2: [*]const u8 = @ptrFromInt(ns_full.ptr);
+        var last: u32 = start;
+        var k: u32 = start;
+        while (k + 1 < ns_full.len) : (k += 1) {
+            if (np2[k] == ':' and np2[k + 1] == ':') last = k + 2;
+        }
+        register_ns = rec.target_ns;
+        if (last > start) {
+            // The leaf name lives in the parent ns.  Walk back to find
+            // the parent.
+            const parent_full = obj_mod.obj_new_string(@bitCast(ns_full.ptr), @bitCast(last - 2));
+            const parent_s = obj_ensure_string(parent_full);
+            const parent_ns = tcl_ns.ns_create_from_fqn(parent_s.ptr, parent_s.len);
+            obj_mod.tcl_obj_release(parent_full);
+            if (parent_ns != 0) register_ns = parent_ns;
+            simple_ptr = ns_full.ptr + last;
+            simple_len = ns_full.len - last;
+        } else {
+            // Root-level ns ``::ns`` — register ``ns`` in root.
+            register_ns = tcl_ns.ns_root();
+            simple_ptr = ns_full.ptr + start;
+            simple_len = ns_full.len - start;
+        }
+    }
+    if (simple_len == 0 or register_ns == 0) {
+        ensemble_rec_release(rec_addr);
+        return obj_new_string(0, 0);
+    }
+
+    // Allocate / reuse the Command bucket.
+    const existing = tcl_ns.ns_cmd_find(register_ns, simple_ptr, simple_len);
+    var cmd: u32 = existing;
+    if (cmd == 0) {
+        cmd = procs.alloc_command_export(simple_ptr, simple_len);
+        _ = tcl_ns.ns_cmd_put(register_ns, simple_ptr, simple_len, cmd);
+    } else {
+        // Re-use: if the existing bucket already held an ensemble
+        // rec, release it before swapping in the new one.
+        const old_flags: u32 = @bitCast(obj_mod.read_i32(cmd + procs.OFF_FLAGS));
+        if ((old_flags & procs.CMD_ENSEMBLE) != 0) {
+            const old_rec: u32 = @bitCast(obj_mod.read_i32(cmd + procs.OFF_PARAMS_OBJ));
+            ensemble_rec_release(old_rec);
+        }
+    }
+    obj_mod.write_i32(cmd + procs.OFF_FLAGS, @bitCast(procs.CMD_ENSEMBLE));
+    obj_mod.write_i32(cmd + procs.OFF_PARAMS_OBJ, @bitCast(rec_addr));
+    obj_mod.write_i32(cmd + procs.OFF_BODY_OBJ, 0);
+    obj_mod.write_i32(cmd + procs.OFF_FUNC_IDX, 0);
+    obj_mod.write_i32(cmd + procs.OFF_N_PARAMS, 0);
+    obj_mod.write_i32(cmd + procs.OFF_ARGS_TAIL, 0);
+
+    // Return the fully-qualified command name (the user-visible
+    // identity of the new ensemble).  Build ``::<ns_full>::<simple>``.
+    const ns_full = tcl_ns.ns_full_name(register_ns);
+    var out_ptr: u32 = 0;
+    var out_len: u32 = 0;
+    if (ns_full.len > 2) {
+        const total: u32 = ns_full.len + 2 + simple_len;
+        const buf = alloc(total);
+        const dst: [*]u8 = @ptrFromInt(buf);
+        const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+        for (0..ns_full.len) |k| dst[k] = np[k];
+        dst[ns_full.len] = ':';
+        dst[ns_full.len + 1] = ':';
+        const sp: [*]const u8 = @ptrFromInt(simple_ptr);
+        for (0..simple_len) |k| dst[ns_full.len + 2 + k] = sp[k];
+        out_ptr = buf;
+        out_len = total;
+    } else {
+        // Root namespace ``::`` — ``::simple``.
+        const total: u32 = 2 + simple_len;
+        const buf = alloc(total);
+        const dst: [*]u8 = @ptrFromInt(buf);
+        dst[0] = ':';
+        dst[1] = ':';
+        const sp: [*]const u8 = @ptrFromInt(simple_ptr);
+        for (0..simple_len) |k| dst[2 + k] = sp[k];
+        out_ptr = buf;
+        out_len = total;
+    }
+    return obj_mod.obj_new_string_take(out_ptr, out_len, out_len);
+}
+
+/// Public entry: dispatch an ensemble call.  Invoked from
+/// :func:`eval_proc_call_bucket` when a Command has ``CMD_ENSEMBLE``
+/// set.  ``words`` is the full argv (``words[0]`` is the invoked
+/// ensemble name, ``words[1]`` is the subcommand, the rest are
+/// extra args).
+pub fn dispatch_ensemble(bucket: i32, words: []const i32) i32 {
+    const rec = ensemble_rec_of(@bitCast(bucket)) orelse return 0;
+    if (words.len < 2) {
+        raise_ensemble_wrong_args(words[0], rec);
+        return 0;
+    }
+    const sub = obj_ensure_string(words[1]);
+    if (sub.len == 0) {
+        raise_ensemble_wrong_args(words[0], rec);
+        return 0;
+    }
+
+    // 1. Resolve subcommand → impl.
+    var impl_obj: i32 = 0;
+    if (rec.map_obj != 0) {
+        const ms = obj_ensure_string(rec.map_obj);
+        const n = obj_mod.list_count_elements(ms.ptr, ms.len);
+        if (n > 0 and @rem(n, 2) == 0) {
+            const matched = ensemble_lookup_map(ms.ptr, ms.len, n, sub.ptr, sub.len, rec.prefixes);
+            if (matched > 0) {
+                const e = obj_mod.list_element_at(ms.ptr, ms.len, matched);
+                impl_obj = obj_mod.obj_new_string(@bitCast(ms.ptr + e.start), @bitCast(e.len));
+            } else if (matched == 0) {
+                // No match — fall through to -unknown / no-export error
+            }
+        }
+    }
+    if (impl_obj == 0) {
+        // Try exported commands of the target ns.
+        impl_obj = ensemble_lookup_exported(rec, sub.ptr, sub.len);
+    }
+    if (impl_obj == 0) {
+        // -unknown handler?
+        if (rec.unknown_obj != 0) {
+            return invoke_ensemble_unknown(bucket, rec, words);
+        }
+        raise_ensemble_unknown_sub(words[0], sub.ptr, sub.len, rec);
+        return 0;
+    }
+    defer obj_mod.tcl_obj_release(impl_obj);
+
+    // 2. Build the full call: impl-elements + words[2..].
+    return invoke_ensemble_impl(impl_obj, words);
+}
+
+/// Match *sub* against the keys of the ``-map`` list.  Returns the
+/// list index of the matched IMPL element (odd index) when found,
+/// 0 on miss, -1 on ambiguous prefix when ``prefixes`` is set.
+/// ``n`` is the pre-computed element count of *map*.
+fn ensemble_lookup_map(
+    map_ptr: u32,
+    map_len: u32,
+    n: i64,
+    sub_ptr: u32,
+    sub_len: u32,
+    prefixes: u32,
+) i64 {
+    var exact: i64 = -2;
+    var prefix_match: i64 = -2;
+    var prefix_count: u32 = 0;
+    var i: i64 = 0;
+    while (i < n) : (i += 2) {
+        const e = obj_mod.list_element_at(map_ptr, map_len, i);
+        if (e.len == sub_len and bytes_equal(map_ptr + e.start, sub_ptr, sub_len)) {
+            exact = i + 1;
+            break;
+        }
+        if (prefixes != 0 and e.len > sub_len and bytes_equal(map_ptr + e.start, sub_ptr, sub_len)) {
+            prefix_match = i + 1;
+            prefix_count += 1;
+        }
+    }
+    if (exact != -2) return exact;
+    if (prefix_count == 1) return prefix_match;
+    return 0;
+}
+
+fn bytes_equal(a: u32, b: u32, n: u32) bool {
+    if (n == 0) return true;
+    const ap: [*]const u8 = @ptrFromInt(a);
+    const bp: [*]const u8 = @ptrFromInt(b);
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        if (ap[i] != bp[i]) return false;
+    }
+    return true;
+}
+
+/// Walk the target ns's exported commands (or the ``-subcommands``
+/// override list) for a match against *sub*.  Returns a fresh TclObj
+/// with the FQ implementation name on hit, 0 on miss.
+fn ensemble_lookup_exported(rec: *EnsembleRec, sub_ptr: u32, sub_len: u32) i32 {
+    const ns = rec.target_ns;
+    if (ns == 0) return 0;
+    // Build candidate name list.
+    if (rec.sub_obj != 0) {
+        const ss = obj_ensure_string(rec.sub_obj);
+        return ensemble_match_in_list(ns, ss.ptr, ss.len, sub_ptr, sub_len, rec.prefixes);
+    }
+    // No explicit -subcommands → use the namespace's export patterns.
+    return ensemble_match_in_exports(ns, sub_ptr, sub_len, rec.prefixes);
+}
+
+fn ensemble_match_in_list(
+    ns: u32,
+    list_ptr: u32,
+    list_len: u32,
+    sub_ptr: u32,
+    sub_len: u32,
+    prefixes: u32,
+) i32 {
+    const n = obj_mod.list_count_elements(list_ptr, list_len);
+    if (n <= 0) return 0;
+    var i: i64 = 0;
+    var exact_off: i64 = -1;
+    var prefix_off: i64 = -1;
+    var prefix_count: u32 = 0;
+    while (i < n) : (i += 1) {
+        const e = obj_mod.list_element_at(list_ptr, list_len, i);
+        if (e.len == sub_len and bytes_equal(list_ptr + e.start, sub_ptr, sub_len)) {
+            exact_off = i;
+            break;
+        }
+        if (prefixes != 0 and e.len > sub_len and bytes_equal(list_ptr + e.start, sub_ptr, sub_len)) {
+            prefix_off = i;
+            prefix_count += 1;
+        }
+    }
+    const which = if (exact_off >= 0) exact_off else if (prefix_count == 1) prefix_off else -1;
+    if (which < 0) return 0;
+    const e = obj_mod.list_element_at(list_ptr, list_len, which);
+    // Qualify against target ns.
+    const ns_full = tcl_ns.ns_full_name(ns);
+    return ns_join_name(ns_full, list_ptr + e.start, e.len);
+}
+
+fn ensemble_match_in_exports(ns: u32, sub_ptr: u32, sub_len: u32, prefixes: u32) i32 {
+    _ = prefixes;
+    // Iterate ns.cmd_table for commands whose simple name matches an
+    // export pattern.  Simple implementation: walk cmd_table once
+    // looking for an exact match on simple name AND export.
+    const namespace: *tcl_ns.Namespace = @ptrFromInt(ns);
+    if (namespace.cmd_table.buf == 0) return 0;
+    var i: u32 = 0;
+    while (i < namespace.cmd_table.cap) : (i += 1) {
+        const bucket = namespace.cmd_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
+        const np: u32 = @bitCast(obj_mod.read_i32(bucket));
+        if (np == 0) continue;
+        const nl: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
+        if (nl != sub_len) continue;
+        if (!bytes_equal(np, sub_ptr, sub_len)) continue;
+        // Check export.
+        if (!tcl_ns.ns_export_matches(ns, np, nl)) continue;
+        const ns_full = tcl_ns.ns_full_name(ns);
+        return ns_join_name(ns_full, np, nl);
+    }
+    return 0;
+}
+
+/// Combine the ensemble impl prefix (a Tcl list) with the remaining
+/// call args and invoke the result.
+fn invoke_ensemble_impl(impl_obj: i32, words: []const i32) i32 {
+    const is = obj_ensure_string(impl_obj);
+    if (is.len == 0) return 0;
+    const interp = @import("../interp/tcl_interp.zig");
+    // The impl is a list ``cmd ?arg ...?``.  Split into element
+    // TclObjs, then append words[2..].
+    const n_impl = obj_mod.list_count_elements(is.ptr, is.len);
+    const tail = if (words.len >= 2) words.len - 2 else 0;
+    const total_args: u32 = @intCast(@as(i64, n_impl) + @as(i64, @intCast(tail)));
+    if (total_args == 0) return 0;
+    const argv = obj_mod.alloc(total_args * 4);
+    if (argv == 0) return 0;
+    defer obj_mod.free_sized(argv, total_args * 4);
+    var idx: u32 = 0;
+    var k: i64 = 0;
+    while (k < n_impl) : (k += 1) {
+        const e = obj_mod.list_element_at(is.ptr, is.len, k);
+        const w = obj_mod.obj_new_string(@bitCast(is.ptr + e.start), @bitCast(e.len));
+        obj_mod.write_i32(argv + idx * 4, w);
+        idx += 1;
+    }
+    var wi: u32 = 2;
+    while (wi < words.len) : (wi += 1) {
+        obj_mod.tcl_obj_retain(words[wi]);
+        obj_mod.write_i32(argv + idx * 4, words[wi]);
+        idx += 1;
+    }
+    // Build a slice for interp.eval_command — it expects a []const i32.
+    const argv_slice: []const i32 = @as([*]const i32, @ptrFromInt(argv))[0..total_args];
+    const result = interp.eval_command(argv_slice);
+    // Release each argv slot (we owned a retained ref to each).
+    var j: u32 = 0;
+    while (j < total_args) : (j += 1) {
+        const v = obj_mod.read_i32(argv + j * 4);
+        if (v != 0) obj_mod.tcl_obj_release(v);
+    }
+    return result;
+}
+
+fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i32 {
+    _ = bucket;
+    // Build call: unknown_prefix + ensemble_name + words[1..]
+    const us = obj_ensure_string(rec.unknown_obj);
+    const interp = @import("../interp/tcl_interp.zig");
+    const n_pref = obj_mod.list_count_elements(us.ptr, us.len);
+    // Build the resolved ensemble FQN (words[0] may be a short name).
+    const total_args: u32 = @intCast(@as(i64, n_pref) + 1 + @as(i64, @intCast(words.len - 1)));
+    const argv = obj_mod.alloc(total_args * 4);
+    if (argv == 0) return 0;
+    defer obj_mod.free_sized(argv, total_args * 4);
+    var idx: u32 = 0;
+    var k: i64 = 0;
+    while (k < n_pref) : (k += 1) {
+        const e = obj_mod.list_element_at(us.ptr, us.len, k);
+        const w = obj_mod.obj_new_string(@bitCast(us.ptr + e.start), @bitCast(e.len));
+        obj_mod.write_i32(argv + idx * 4, w);
+        idx += 1;
+    }
+    // Ensemble name (use words[0] as-is)
+    obj_mod.tcl_obj_retain(words[0]);
+    obj_mod.write_i32(argv + idx * 4, words[0]);
+    idx += 1;
+    var wi: u32 = 1;
+    while (wi < words.len) : (wi += 1) {
+        obj_mod.tcl_obj_retain(words[wi]);
+        obj_mod.write_i32(argv + idx * 4, words[wi]);
+        idx += 1;
+    }
+    const argv_slice: []const i32 = @as([*]const i32, @ptrFromInt(argv))[0..total_args];
+    const result = interp.eval_command(argv_slice);
+    var j: u32 = 0;
+    while (j < total_args) : (j += 1) {
+        const v = obj_mod.read_i32(argv + j * 4);
+        if (v != 0) obj_mod.tcl_obj_release(v);
+    }
+    return result;
+}
+
+fn raise_ensemble_wrong_args(name: i32, rec: *EnsembleRec) void {
+    _ = rec;
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const prefix: []const u8 = "wrong # args: should be \"";
+    const suffix: []const u8 = " subcommand ?arg ...?\"";
+    const sn = obj_ensure_string(name);
+    const total: u32 = @intCast(prefix.len + sn.len + suffix.len);
+    const buf = alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (sn.len > 0) {
+        const np: [*]const u8 = @ptrFromInt(sn.ptr);
+        for (0..sn.len) |i| dst[off + i] = np[i];
+        off += sn.len;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    catch_mod.tcl_cmd_error(obj_mod.obj_new_string_take(buf, total, total));
+}
+
+fn raise_ensemble_unknown_sub(name: i32, sub_ptr: u32, sub_len: u32, rec: *EnsembleRec) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    // Compute the candidate list for the error message.
+    const avail = compute_available_subcmds(rec);
+    defer if (avail != 0) obj_mod.tcl_obj_release(avail);
+    const avail_s = obj_ensure_string(avail);
+    const prefix: []const u8 = "unknown ";
+    var middle1: []const u8 = "subcommand \"";
+    if (rec.prefixes != 0) {
+        middle1 = "or ambiguous subcommand \"";
+    }
+    var suffix: []const u8 = undefined;
+    var suffix_buf: u32 = 0;
+    var suffix_buf_len: u32 = 0;
+    if (avail_s.len > 0) {
+        const middle2: []const u8 = "\": must be ";
+        // Build the full middle+avail tail dynamically.
+        suffix_buf_len = @intCast(middle2.len + avail_s.len);
+        suffix_buf = alloc(suffix_buf_len);
+        if (suffix_buf == 0) return;
+        const sb: [*]u8 = @ptrFromInt(suffix_buf);
+        var off: u32 = 0;
+        for (middle2) |c| {
+            sb[off] = c;
+            off += 1;
+        }
+        const ap: [*]const u8 = @ptrFromInt(avail_s.ptr);
+        for (0..avail_s.len) |k| sb[off + k] = ap[k];
+        suffix = sb[0..suffix_buf_len];
+    } else {
+        const ns_full = tcl_ns.ns_full_name(rec.target_ns);
+        const msg2: []const u8 = "\": namespace ";
+        const msg3: []const u8 = " does not export any commands";
+        suffix_buf_len = @intCast(msg2.len + ns_full.len + msg3.len);
+        suffix_buf = alloc(suffix_buf_len);
+        if (suffix_buf == 0) return;
+        const sb: [*]u8 = @ptrFromInt(suffix_buf);
+        var off: u32 = 0;
+        for (msg2) |c| {
+            sb[off] = c;
+            off += 1;
+        }
+        const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+        for (0..ns_full.len) |k| sb[off + k] = np[k];
+        off += ns_full.len;
+        for (msg3) |c| {
+            sb[off] = c;
+            off += 1;
+        }
+        suffix = sb[0..suffix_buf_len];
+        // Tighter ``unknown`` wording when nothing's exported (real
+        // Tcl drops the "or ambiguous" prefix for this case).
+        middle1 = "subcommand \"";
+    }
+    _ = name;
+    const total: u32 = @intCast(prefix.len + middle1.len + sub_len + suffix.len);
+    const buf = alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    for (middle1) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (sub_len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(sub_ptr);
+        for (0..sub_len) |k| dst[off + k] = sp[k];
+        off += sub_len;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    obj_mod.free_sized(suffix_buf, suffix_buf_len);
+    catch_mod.tcl_cmd_error(obj_mod.obj_new_string_take(buf, total, total));
+}
+
+/// Build a comma+`, or` separated list of available subcommands for
+/// the diagnostic in :func:`raise_ensemble_unknown_sub`.
+fn compute_available_subcmds(rec: *EnsembleRec) i32 {
+    // 1. -map keys
+    return std_keys_to_obj(rec);
+}
+
+fn std_keys_to_obj(rec: *EnsembleRec) i32 {
+    // Collect subcommand keys from -map first, then from -subcommands,
+    // then from the target ns's exported commands.  Returns a fresh
+    // owning TclObj containing the joined ``a, b, or c`` form used in
+    // ``unknown subcommand`` diagnostics.
+    var names: [128][2]u32 = undefined;
+    var count: u32 = 0;
+    if (rec.map_obj != 0) {
+        const ms = obj_ensure_string(rec.map_obj);
+        const n = obj_mod.list_count_elements(ms.ptr, ms.len);
+        var i: i64 = 0;
+        while (i < n) : (i += 2) {
+            if (count >= 128) break;
+            const e = obj_mod.list_element_at(ms.ptr, ms.len, i);
+            names[count] = .{ ms.ptr + e.start, e.len };
+            count += 1;
+        }
+    } else if (rec.sub_obj != 0) {
+        const ss = obj_ensure_string(rec.sub_obj);
+        const n = obj_mod.list_count_elements(ss.ptr, ss.len);
+        var i: i64 = 0;
+        while (i < n) : (i += 1) {
+            if (count >= 128) break;
+            const e = obj_mod.list_element_at(ss.ptr, ss.len, i);
+            names[count] = .{ ss.ptr + e.start, e.len };
+            count += 1;
+        }
+    } else if (rec.target_ns != 0) {
+        const namespace: *tcl_ns.Namespace = @ptrFromInt(rec.target_ns);
+        if (namespace.cmd_table.buf != 0) {
+            var i: u32 = 0;
+            while (i < namespace.cmd_table.cap) : (i += 1) {
+                if (count >= 128) break;
+                const bucket = namespace.cmd_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
+                const np: u32 = @bitCast(obj_mod.read_i32(bucket));
+                if (np == 0) continue;
+                const nl: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
+                if (!tcl_ns.ns_export_matches(rec.target_ns, np, nl)) continue;
+                names[count] = .{ np, nl };
+                count += 1;
+            }
+        }
+    }
+    if (count == 0) return obj_new_string(0, 0);
+    // Sort names for stable output (alphabetic).
+    sort_names(&names, count);
+    // Build "a, or b, or c, or d" — Tcl 9's ``InfoCommandsCmd``
+    // uses a uniform ", or " separator before each item past the
+    // first (so 2-element lists also render with ", or " — see
+    // namespace-46.2's expected ``must be x1, or x2``).
+    var total: u32 = 0;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (i + 1 == count and count > 1) {
+            total += 5; // ", or "
+        } else if (i > 0) {
+            total += 2; // ", "
+        }
+        total += names[i][1];
+    }
+    const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    i = 0;
+    while (i < count) : (i += 1) {
+        if (i + 1 == count and count > 1) {
+            dst[off] = ',';
+            dst[off + 1] = ' ';
+            dst[off + 2] = 'o';
+            dst[off + 3] = 'r';
+            dst[off + 4] = ' ';
+            off += 5;
+        } else if (i > 0) {
+            dst[off] = ',';
+            dst[off + 1] = ' ';
+            off += 2;
+        }
+        const sp: [*]const u8 = @ptrFromInt(names[i][0]);
+        for (0..names[i][1]) |k| dst[off + k] = sp[k];
+        off += names[i][1];
+    }
+    return obj_mod.obj_new_string_take(buf, off, total);
+}
+
+fn sort_names(names: *[128][2]u32, count: u32) void {
+    // Insertion sort — N <= 128, lexicographic compare.
+    var i: u32 = 1;
+    while (i < count) : (i += 1) {
+        const cur = names[i];
+        var j: i64 = @as(i64, i) - 1;
+        while (j >= 0 and name_lt(cur, names[@intCast(j)])) : (j -= 1) {
+            names[@intCast(j + 1)] = names[@intCast(j)];
+        }
+        names[@intCast(j + 1)] = cur;
+    }
+}
+
+fn name_lt(a: [2]u32, b: [2]u32) bool {
+    const ap: [*]const u8 = @ptrFromInt(a[0]);
+    const bp: [*]const u8 = @ptrFromInt(b[0]);
+    const lim = if (a[1] < b[1]) a[1] else b[1];
+    var i: u32 = 0;
+    while (i < lim) : (i += 1) {
+        if (ap[i] < bp[i]) return true;
+        if (ap[i] > bp[i]) return false;
+    }
+    return a[1] < b[1];
 }
 
 fn raise_bad_ensemble_subcmd(sub_ptr: u32, sub_len: u32) void {

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -1902,12 +1902,17 @@ fn ensemble_match_in_list(
 }
 
 fn ensemble_match_in_exports(ns: u32, sub_ptr: u32, sub_len: u32, prefixes: u32) i32 {
-    _ = prefixes;
-    // Iterate ns.cmd_table for commands whose simple name matches an
-    // export pattern.  Simple implementation: walk cmd_table once
-    // looking for an exact match on simple name AND export.
     const namespace: *tcl_ns.Namespace = @ptrFromInt(ns);
     if (namespace.cmd_table.buf == 0) return 0;
+    // Two passes — first looks for an exact match; second falls back
+    // to a unique-prefix match (when ``-prefixes`` is on).  Reference
+    // Tcl resolves exact subcommand names eagerly so that a longer
+    // exported name can't shadow a literal exact spelling.
+    var exact_np: u32 = 0;
+    var exact_nl: u32 = 0;
+    var prefix_np: u32 = 0;
+    var prefix_nl: u32 = 0;
+    var prefix_count: u32 = 0;
     var i: u32 = 0;
     while (i < namespace.cmd_table.cap) : (i += 1) {
         const bucket = namespace.cmd_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
@@ -1916,11 +1921,25 @@ fn ensemble_match_in_exports(ns: u32, sub_ptr: u32, sub_len: u32, prefixes: u32)
         const handle: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
         if (handle == 0) continue; // dead bucket (rename → empty)
         const nl: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
-        if (nl != sub_len) continue;
-        if (!bytes_equal(np, sub_ptr, sub_len)) continue;
         if (!tcl_ns.ns_export_matches(ns, np, nl)) continue;
+        if (nl == sub_len and bytes_equal(np, sub_ptr, sub_len)) {
+            exact_np = np;
+            exact_nl = nl;
+            break;
+        }
+        if (prefixes != 0 and nl > sub_len and bytes_equal(np, sub_ptr, sub_len)) {
+            prefix_np = np;
+            prefix_nl = nl;
+            prefix_count += 1;
+        }
+    }
+    if (exact_nl != 0) {
         const ns_full = tcl_ns.ns_full_name(ns);
-        return ns_join_name(ns_full, np, nl);
+        return ns_join_name(ns_full, exact_np, exact_nl);
+    }
+    if (prefix_count == 1) {
+        const ns_full = tcl_ns.ns_full_name(ns);
+        return ns_join_name(ns_full, prefix_np, prefix_nl);
     }
     return 0;
 }

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -937,6 +937,13 @@ fn do_ns_delete(h: u32) void {
 fn drop_parent_ensembles_for(parent_ns: *tcl_ns.Namespace, deleted_ns: u32) void {
     if (parent_ns.cmd_table.buf == 0) return;
     const bucket_size: u32 = tcl_ns.NS_BUCKET_SIZE;
+    // Capture the parent address up-front so we can route the
+    // tombstone through ``ns_cmd_clear`` (which bumps the namespace's
+    // ``cmd_ref_epoch`` to invalidate stale command-resolution
+    // caches).  Direct ``write_i32`` of OFF_HANDLE to zero leaves
+    // the epoch unchanged and stale ``::path`` lookups keep
+    // resolving to the dead bucket.
+    const parent_addr: u32 = @intFromPtr(parent_ns);
     var i: u32 = 0;
     while (i < parent_ns.cmd_table.cap) : (i += 1) {
         const bucket = parent_ns.cmd_table.buf + i * bucket_size;
@@ -953,9 +960,8 @@ fn drop_parent_ensembles_for(parent_ns: *tcl_ns.Namespace, deleted_ns: u32) void
         ensemble_rec_release(rec_addr);
         obj_mod.write_i32(cmd + procs.OFF_PARAMS_OBJ, 0);
         obj_mod.write_i32(cmd + procs.OFF_FLAGS, 0);
-        // Tombstone the cmd_table slot so ``info commands`` / proc
-        // lookups no longer surface this bucket.
-        obj_mod.write_i32(bucket + tcl_ns.OFF_HANDLE, 0);
+        const nl: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
+        _ = tcl_ns.ns_cmd_clear(parent_addr, np, nl);
     }
 }
 
@@ -1186,15 +1192,23 @@ fn eval_ns_ensemble(words: []const i32) i32 {
     if (slice_eq_ns(sub2.ptr, sub2.len, "create")) {
         return eval_ns_ensemble_create(words);
     }
-    if (slice_eq_ns(sub2.ptr, sub2.len, "exists") and words.len >= 4) {
+    if (slice_eq_ns(sub2.ptr, sub2.len, "exists")) {
+        if (words.len != 4) {
+            raise_ns_error("wrong # args: should be \"namespace ensemble exists cmdname\"");
+            return 0;
+        }
         const bucket = ensemble_find_cmd(words[3]);
         if (bucket == 0) return obj_new_int(0);
         const flags: u32 = @bitCast(obj_mod.read_i32(bucket + procs.OFF_FLAGS));
         return obj_new_int(if ((flags & procs.CMD_ENSEMBLE) != 0) 1 else 0);
     }
-    if ((slice_eq_ns(sub2.ptr, sub2.len, "configure") or
-        slice_eq_ns(sub2.ptr, sub2.len, "config")) and words.len >= 4)
+    if (slice_eq_ns(sub2.ptr, sub2.len, "configure") or
+        slice_eq_ns(sub2.ptr, sub2.len, "config"))
     {
+        if (words.len < 4) {
+            raise_ns_error("wrong # args: should be \"namespace ensemble configure cmdname ?-option value ...?\"");
+            return 0;
+        }
         return eval_ns_ensemble_configure(words);
     }
     raise_bad_ensemble_subcmd(sub2.ptr, sub2.len);
@@ -1231,7 +1245,13 @@ fn eval_ns_ensemble_configure(words: []const i32) i32 {
     if (words.len == 5) {
         return read_ensemble_option(rec, words[4]);
     }
-    // Setter form: pairs from words[4..].
+    // Setter form: pairs from words[4..].  Reject odd-length tails
+    // (each option needs a value) up front so the loop below can't
+    // silently drop the last option / value.
+    if (((words.len - 4) & 1) != 0) {
+        raise_ns_error("missing value to go with key");
+        return 0;
+    }
     var i: u32 = 4;
     while (i + 1 < words.len) : (i += 2) {
         const key = obj_ensure_string(words[i]);
@@ -1249,7 +1269,22 @@ fn eval_ns_ensemble_configure(words: []const i32) i32 {
                     raise_ns_error("missing value to go with key");
                     return 0;
                 }
-                ensemble_set_obj_slot(&rec.map_obj, val_obj);
+                // Validate non-empty impls and auto-qualify the
+                // first impl element against the ensemble's target
+                // namespace — mirrors the ``create`` path so a
+                // subsequent ``configure -map`` read returns the
+                // FQ form (namespace-46.1 semantics).
+                var k: i64 = 1;
+                while (k < n) : (k += 2) {
+                    const impl = obj_mod.list_element_at(val.ptr, val.len, k);
+                    if (impl.len == 0) {
+                        raise_ns_error("ensemble subcommand implementations must be non-empty lists");
+                        return 0;
+                    }
+                }
+                const qualified = qualify_map_impls(val_obj, rec.target_ns);
+                ensemble_set_obj_slot(&rec.map_obj, qualified);
+                if (qualified != val_obj) obj_mod.tcl_obj_release(qualified);
             }
         } else if (slice_eq_ns(key.ptr, key.len, "-subcommands") or slice_eq_ns(key.ptr, key.len, "-subcommand")) {
             if (val.len == 0) {
@@ -1281,6 +1316,11 @@ fn eval_ns_ensemble_configure(words: []const i32) i32 {
         } else if (slice_eq_ns(key.ptr, key.len, "-prefixes")) {
             const b = obj_get_int(val_obj);
             rec.prefixes = if (b != 0) 1 else 0;
+        } else {
+            // Unknown option — reference Tcl errors rather than
+            // silently dropping.  Match its ``bad option`` shape.
+            raise_unknown_ensemble_option(key.ptr, key.len);
+            return 0;
         }
     }
     return obj_new_string(0, 0);
@@ -1374,6 +1414,31 @@ fn brace_wrap(value: i32) i32 {
     for (0..s.len) |i| dst[1 + i] = sp[i];
     dst[total - 1] = '}';
     return obj_mod.obj_new_string_take(buf, total, total);
+}
+
+fn raise_unknown_ensemble_option(name_ptr: u32, name_len: u32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const prefix: []const u8 = "bad option \"";
+    const suffix: []const u8 = "\": must be -map, -namespace, -parameters, -prefixes, -subcommands, or -unknown";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
+    const buf = alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (name_len > 0) {
+        const np: [*]const u8 = @ptrFromInt(name_ptr);
+        for (0..name_len) |i| dst[off + i] = np[i];
+        off += name_len;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    catch_mod.tcl_cmd_error(obj_mod.obj_new_string_take(buf, total, total));
 }
 
 fn raise_not_an_ensemble(name: i32) void {
@@ -1711,6 +1776,11 @@ fn eval_ns_ensemble_create(words: []const i32) i32 {
     var cmd: u32 = existing;
     if (cmd == 0) {
         cmd = procs.alloc_command_export(simple_ptr, simple_len);
+        if (cmd == 0) {
+            ensemble_rec_release(rec_addr);
+            raise_ns_error("out of memory creating ensemble");
+            return 0;
+        }
         _ = tcl_ns.ns_cmd_put(register_ns, simple_ptr, simple_len, cmd);
     } else {
         // Re-use: if the existing bucket already held an ensemble
@@ -1736,6 +1806,7 @@ fn eval_ns_ensemble_create(words: []const i32) i32 {
     if (ns_full.len > 2) {
         const total: u32 = ns_full.len + 2 + simple_len;
         const buf = alloc(total);
+        if (buf == 0) return obj_new_string(0, 0);
         const dst: [*]u8 = @ptrFromInt(buf);
         const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
         for (0..ns_full.len) |k| dst[k] = np[k];
@@ -1749,6 +1820,7 @@ fn eval_ns_ensemble_create(words: []const i32) i32 {
         // Root namespace ``::`` — ``::simple``.
         const total: u32 = 2 + simple_len;
         const buf = alloc(total);
+        if (buf == 0) return obj_new_string(0, 0);
         const dst: [*]u8 = @ptrFromInt(buf);
         dst[0] = ':';
         dst[1] = ':';

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -910,6 +910,12 @@ fn do_ns_delete(h: u32) void {
     const parent = ns.parent;
     if (parent == 0) return; // can't delete root
     const parent_ns: *tcl_ns.Namespace = @ptrFromInt(parent);
+    // Drop ensemble commands whose target_ns matches the namespace
+    // being deleted.  ``namespace eval ns { namespace ensemble create
+    // }`` registers the dispatch command in the parent's cmd_table;
+    // when the ns goes away, the matching ensemble bucket should
+    // disappear too (namespace-42.1 / 42.2).
+    drop_parent_ensembles_for(parent_ns, h);
     if (parent_ns.child_table.buf == 0) return;
     const bucket_size: u32 = tcl_ns.NS_BUCKET_SIZE;
     var i: u32 = 0;
@@ -920,6 +926,36 @@ fn do_ns_delete(h: u32) void {
             obj_mod.write_i32(bucket + tcl_ns.OFF_HANDLE, 0);
             return;
         }
+    }
+}
+
+/// Walk *parent_ns*'s ``cmd_table`` and clear every ensemble Command
+/// whose ``EnsembleRec.target_ns`` is *deleted_ns*.  Mirrors C Tcl's
+/// ``TclDeleteNamespace`` → ``TclMakeEnsemble`` teardown: an
+/// ensemble dispatcher tied to a deleted namespace must stop being
+/// reachable by name.
+fn drop_parent_ensembles_for(parent_ns: *tcl_ns.Namespace, deleted_ns: u32) void {
+    if (parent_ns.cmd_table.buf == 0) return;
+    const bucket_size: u32 = tcl_ns.NS_BUCKET_SIZE;
+    var i: u32 = 0;
+    while (i < parent_ns.cmd_table.cap) : (i += 1) {
+        const bucket = parent_ns.cmd_table.buf + i * bucket_size;
+        const np: u32 = @bitCast(obj_mod.read_i32(bucket));
+        if (np == 0) continue;
+        const cmd: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
+        if (cmd == 0) continue;
+        const flags: u32 = @bitCast(obj_mod.read_i32(cmd + procs.OFF_FLAGS));
+        if ((flags & procs.CMD_ENSEMBLE) == 0) continue;
+        const rec_addr: u32 = @bitCast(obj_mod.read_i32(cmd + procs.OFF_PARAMS_OBJ));
+        if (rec_addr == 0) continue;
+        const rec: *const EnsembleRec = @ptrFromInt(rec_addr);
+        if (rec.target_ns != deleted_ns) continue;
+        ensemble_rec_release(rec_addr);
+        obj_mod.write_i32(cmd + procs.OFF_PARAMS_OBJ, 0);
+        obj_mod.write_i32(cmd + procs.OFF_FLAGS, 0);
+        // Tombstone the cmd_table slot so ``info commands`` / proc
+        // lookups no longer surface this bucket.
+        obj_mod.write_i32(bucket + tcl_ns.OFF_HANDLE, 0);
     }
 }
 
@@ -1435,6 +1471,72 @@ fn ensemble_rec_release(addr: u32) void {
     obj_mod.free_sized(addr, ENS_REC_SIZE);
 }
 
+/// Walk ``-map`` value pairs and rewrite each impl's first element
+/// to a fully-qualified name against *target_ns*.  Tcl 9 stores the
+/// FQ form so subsequent ``configure -map`` reads return what
+/// reference Tcl reports.  Returns a fresh owning TclObj when any
+/// element needed qualification; otherwise returns the input as-is
+/// (caller must not release in that case).
+fn qualify_map_impls(map_obj: i32, target_ns: u32) i32 {
+    if (target_ns == 0) return map_obj;
+    const ns_full = tcl_ns.ns_full_name(target_ns);
+    if (ns_full.len < 2) return map_obj;
+    const ms = obj_ensure_string(map_obj);
+    if (ms.len == 0) return map_obj;
+    const n = obj_mod.list_count_elements(ms.ptr, ms.len);
+    if (n <= 0 or @rem(n, 2) != 0) return map_obj;
+    // Build a new list element-by-element.  Use a Tcl-list helper to
+    // properly quote elements containing whitespace.
+    var i: i64 = 0;
+    var result: i32 = obj_mod.obj_new_string(0, 0);
+    while (i < n) : (i += 2) {
+        const k_el = obj_mod.list_element_at(ms.ptr, ms.len, i);
+        const v_el = obj_mod.list_element_at(ms.ptr, ms.len, i + 1);
+        const key_obj = obj_mod.obj_new_string(@bitCast(ms.ptr + k_el.start), @bitCast(k_el.len));
+        // Impl is itself a Tcl list (``cmd ?arg ...?``).  Qualify only
+        // the FIRST element.
+        const impl_ptr = ms.ptr + v_el.start;
+        const impl_len = v_el.len;
+        const impl_n = obj_mod.list_count_elements(impl_ptr, impl_len);
+        var impl_obj: i32 = 0;
+        if (impl_n > 0) {
+            const first = obj_mod.list_element_at(impl_ptr, impl_len, 0);
+            const fp: [*]const u8 = @ptrFromInt(impl_ptr + first.start);
+            const already_fq = first.len >= 2 and fp[0] == ':' and fp[1] == ':';
+            if (already_fq) {
+                impl_obj = obj_mod.obj_new_string(@bitCast(impl_ptr), @bitCast(impl_len));
+            } else {
+                // Build ``<ns_full>::<first> rest...``.
+                const list_mod = @import("../valtypes/tcl_list.zig");
+                const fq_first = ns_join_name(ns_full, impl_ptr + first.start, first.len);
+                var built: i32 = list_mod.tcl_list(obj_mod.obj_new_string(0, 0), fq_first);
+                obj_mod.tcl_obj_release(fq_first);
+                var j: i64 = 1;
+                while (j < impl_n) : (j += 1) {
+                    const rest_el = obj_mod.list_element_at(impl_ptr, impl_len, j);
+                    const rest_obj = obj_mod.obj_new_string(@bitCast(impl_ptr + rest_el.start), @bitCast(rest_el.len));
+                    const next = list_mod.tcl_list(built, rest_obj);
+                    obj_mod.tcl_obj_release(built);
+                    obj_mod.tcl_obj_release(rest_obj);
+                    built = next;
+                }
+                impl_obj = built;
+            }
+        } else {
+            impl_obj = obj_mod.obj_new_string(0, 0);
+        }
+        const list_mod = @import("../valtypes/tcl_list.zig");
+        const r1 = list_mod.tcl_list(result, key_obj);
+        obj_mod.tcl_obj_release(result);
+        obj_mod.tcl_obj_release(key_obj);
+        const r2 = list_mod.tcl_list(r1, impl_obj);
+        obj_mod.tcl_obj_release(r1);
+        obj_mod.tcl_obj_release(impl_obj);
+        result = r2;
+    }
+    return result;
+}
+
 fn ensemble_set_obj_slot(slot: *i32, new_val: i32) void {
     if (new_val != 0) obj_mod.tcl_obj_retain(new_val);
     const old = slot.*;
@@ -1519,7 +1621,13 @@ fn eval_ns_ensemble_create(words: []const i32) i32 {
                         return 0;
                     }
                 }
-                ensemble_set_obj_slot(&rec.map_obj, words[i + 1]);
+                // Tcl 9 auto-qualifies the first element of each impl
+                // against the target namespace when it's not already
+                // ``::``-anchored — so ``-map {A x}`` from inside
+                // ``::ns`` stores ``A ::ns::x``.
+                const qualified = qualify_map_impls(words[i + 1], rec.target_ns);
+                ensemble_set_obj_slot(&rec.map_obj, qualified);
+                if (qualified != words[i + 1]) obj_mod.tcl_obj_release(qualified);
             }
         } else if (slice_eq_ns(key.ptr, key.len, "-subcommands")) {
             if (val.len > 0) ensemble_set_obj_slot(&rec.sub_obj, words[i + 1]);
@@ -1805,10 +1913,11 @@ fn ensemble_match_in_exports(ns: u32, sub_ptr: u32, sub_len: u32, prefixes: u32)
         const bucket = namespace.cmd_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
         const np: u32 = @bitCast(obj_mod.read_i32(bucket));
         if (np == 0) continue;
+        const handle: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
+        if (handle == 0) continue; // dead bucket (rename → empty)
         const nl: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
         if (nl != sub_len) continue;
         if (!bytes_equal(np, sub_ptr, sub_len)) continue;
-        // Check export.
         if (!tcl_ns.ns_export_matches(ns, np, nl)) continue;
         const ns_full = tcl_ns.ns_full_name(ns);
         return ns_join_name(ns_full, np, nl);
@@ -2047,6 +2156,12 @@ fn std_keys_to_obj(rec: *EnsembleRec) i32 {
                 const bucket = namespace.cmd_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
                 const np: u32 = @bitCast(obj_mod.read_i32(bucket));
                 if (np == 0) continue;
+                // ``ns_cmd_clear`` (rename → empty target) zeroes the
+                // handle slot but leaves the name in place, so the
+                // export-match check alone would resurrect the dead
+                // bucket.  Skip handle == 0 too.
+                const handle: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
+                if (handle == 0) continue;
                 const nl: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
                 if (!tcl_ns.ns_export_matches(rec.target_ns, np, nl)) continue;
                 names[count] = .{ np, nl };

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -1983,27 +1983,86 @@ fn root_namespace_names_matching(pat_ptr: u32, pat_len: u32, has_pattern: bool) 
 /// multi-arg cases (``info default``) are routed via a separate
 /// entry; the interpreter's ``info`` handler picks whichever
 /// dispatcher matches the arity.
+// Canonical info subcommand names — used to expand abbreviations
+// (Tcl convention: any unique-prefix abbreviation works, e.g.
+// ``info a t1`` resolves to ``info args t1``).  Kept in sync with
+// ``inspect.info_subcommands``.
+const INFO_SUBCMDS = [_][]const u8{
+    "args",        "body",       "cmdcount",     "cmdtype",       "commands",
+    "complete",    "constant",   "consts",       "coroutine",     "default",
+    "errorstack",  "exists",     "frame",        "functions",     "globals",
+    "hostname",    "level",      "library",      "loaded",        "locals",
+    "nameofexecutable", "object", "patchlevel", "procs",          "script",
+    "sharedlibextension", "tclversion", "vars",
+};
+
+/// Expand an abbreviated subcommand name to its canonical form.
+/// Returns the original span when the input is already canonical OR
+/// the abbreviation matches multiple subcommands (ambiguous — the
+/// dispatcher's exact-match cascade will then surface the right
+/// error).  Tcl 9's ``info`` accepts any unique prefix.
+fn resolve_info_subcmd(sp: [*]const u8, sub_len: u32) struct { ptr: [*]const u8, len: u32 } {
+    // Exact match: walk the list and short-circuit.
+    for (INFO_SUBCMDS) |cand| {
+        if (cand.len == sub_len) {
+            var same = true;
+            var i: u32 = 0;
+            while (i < sub_len) : (i += 1) {
+                if (cand[i] != sp[i]) {
+                    same = false;
+                    break;
+                }
+            }
+            if (same) return .{ .ptr = sp, .len = sub_len };
+        }
+    }
+    // Prefix match: find a UNIQUE one.
+    var match_ptr: [*]const u8 = sp;
+    var match_len: u32 = 0;
+    var match_count: u32 = 0;
+    for (INFO_SUBCMDS) |cand| {
+        if (cand.len < sub_len) continue;
+        var ok = true;
+        var i: u32 = 0;
+        while (i < sub_len) : (i += 1) {
+            if (cand[i] != sp[i]) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) {
+            match_ptr = cand.ptr;
+            match_len = @intCast(cand.len);
+            match_count += 1;
+        }
+    }
+    if (match_count == 1) return .{ .ptr = match_ptr, .len = match_len };
+    return .{ .ptr = sp, .len = sub_len };
+}
+
 pub export fn info_dispatch(subcmd: i32, arg: i32) i32 {
     const sub = obj_ensure_string(subcmd);
     if (sub.len == 0) return obj_new_string(0, 0);
-    const sp: [*]const u8 = @ptrFromInt(sub.ptr);
+    const resolved = resolve_info_subcmd(@ptrFromInt(sub.ptr), sub.len);
+    const sp = resolved.ptr;
+    const sub_l = resolved.len;
 
-    if (str_eq(sp, sub.len, "exists")) return info_exists(arg);
-    if (str_eq(sp, sub.len, "body")) return info_body(arg);
-    if (str_eq(sp, sub.len, "args")) return info_args(arg);
-    if (str_eq(sp, sub.len, "complete")) return info_complete(arg);
-    if (str_eq(sp, sub.len, "nameofexecutable")) return info_nameofexecutable();
-    if (str_eq(sp, sub.len, "tclversion")) return info_tclversion();
-    if (str_eq(sp, sub.len, "patchlevel")) return info_patchlevel();
-    if (str_eq(sp, sub.len, "hostname")) return info_hostname();
-    if (str_eq(sp, sub.len, "commands")) return info_commands(arg);
-    if (str_eq(sp, sub.len, "procs")) return info_procs(arg);
-    if (str_eq(sp, sub.len, "level")) return info_level(arg);
-    if (str_eq(sp, sub.len, "script")) return info_script();
-    if (str_eq(sp, sub.len, "vars")) return info_vars(arg);
-    if (str_eq(sp, sub.len, "constant")) return info_constant(arg);
-    if (str_eq(sp, sub.len, "consts")) return info_consts(arg);
-    if (str_eq(sp, sub.len, "locals")) {
+    if (str_eq(sp, sub_l, "exists")) return info_exists(arg);
+    if (str_eq(sp, sub_l, "body")) return info_body(arg);
+    if (str_eq(sp, sub_l, "args")) return info_args(arg);
+    if (str_eq(sp, sub_l, "complete")) return info_complete(arg);
+    if (str_eq(sp, sub_l, "nameofexecutable")) return info_nameofexecutable();
+    if (str_eq(sp, sub_l, "tclversion")) return info_tclversion();
+    if (str_eq(sp, sub_l, "patchlevel")) return info_patchlevel();
+    if (str_eq(sp, sub_l, "hostname")) return info_hostname();
+    if (str_eq(sp, sub_l, "commands")) return info_commands(arg);
+    if (str_eq(sp, sub_l, "procs")) return info_procs(arg);
+    if (str_eq(sp, sub_l, "level")) return info_level(arg);
+    if (str_eq(sp, sub_l, "script")) return info_script();
+    if (str_eq(sp, sub_l, "vars")) return info_vars(arg);
+    if (str_eq(sp, sub_l, "constant")) return info_constant(arg);
+    if (str_eq(sp, sub_l, "consts")) return info_consts(arg);
+    if (str_eq(sp, sub_l, "locals")) {
         // ``info locals`` returns only local variables of the current
         // proc frame (no globals).  Outside a proc, an empty string.
         // Matches Tcl 9 semantics for info-12.x.
@@ -2019,8 +2078,8 @@ pub export fn info_dispatch(subcmd: i32, arg: i32) i32 {
         }
         return frame_locals_names_matching(pat_ptr, pat_len, has_pattern);
     }
-    if (str_eq(sp, sub.len, "frame")) return info_frame(arg);
-    if (str_eq(sp, sub.len, "cmdcount")) {
+    if (str_eq(sp, sub_l, "frame")) return info_frame(arg);
+    if (str_eq(sp, sub_l, "cmdcount")) {
         // Mirrors C Tcl ``Interp.cmdCount`` — incremented per
         // ``eval_command`` dispatch in ``tcl_interp.zig``.  Compiled
         // procs that take the AOT fast path don't increment;
@@ -2030,7 +2089,7 @@ pub export fn info_dispatch(subcmd: i32, arg: i32) i32 {
         const interp = @import("../interp/tcl_interp.zig");
         return obj_new_int(interp.cmd_count);
     }
-    if (str_eq(sp, sub.len, "coroutine")) {
+    if (str_eq(sp, sub_l, "coroutine")) {
         // ``info coroutine`` returns the FQN of the currently
         // executing coroutine, or the empty string outside a
         // coroutine context.  coroutine.test 11.1 feeds this

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -202,8 +202,14 @@ pub export fn info_args(name: i32) i32 {
     // bundles built without the params-source emit).
     const src = procs.proc_get_params_src(@bitCast(bucket));
     if (src.ptr != 0 and src.len > 0) {
+        // ``obj_new_string`` allocates with rc=1.  ``strip_param_defaults``
+        // reads its string and returns a fresh TclObj; release the
+        // temporary handle once the result is computed so the obj
+        // header doesn't leak on every ``info args`` call.
         const raw = obj_new_string(@bitCast(src.ptr), @bitCast(src.len));
-        return strip_param_defaults(raw);
+        const stripped = strip_param_defaults(raw);
+        obj.tcl_obj_release(raw);
+        return stripped;
     }
     return obj_new_string(0, 0);
 }
@@ -218,28 +224,15 @@ fn strip_param_defaults(params: i32) i32 {
     if (ps.len == 0 or ps.ptr == 0) return obj_new_string(0, 0);
     const n = obj.list_count_elements(ps.ptr, ps.len);
     if (n <= 0) return obj_new_string(0, 0);
-    // Two passes: size then emit.
+    // Walk each element, extract just the parameter name (first
+    // sub-element when the param has a default, else the element
+    // itself), and re-assemble through ``tcl_list`` so the result
+    // is properly list-quoted.  A bare byte-concat with spaces
+    // would round-trip incorrectly for parameter names that contain
+    // whitespace, braces, or other Tcl special characters.
+    const list_mod = @import("../valtypes/tcl_list.zig");
+    var result: i32 = obj_new_string(0, 0);
     var i: i64 = 0;
-    var total: u32 = 0;
-    var emit_count: u32 = 0;
-    while (i < n) : (i += 1) {
-        const elem = obj.list_element_at(ps.ptr, ps.len, i);
-        if (elem.len == 0) continue;
-        const sub_n = obj.list_count_elements(ps.ptr + elem.start, elem.len);
-        const name_len: u32 = if (sub_n > 0)
-            obj.list_element_at(ps.ptr + elem.start, elem.len, 0).len
-        else
-            elem.len;
-        if (emit_count > 0) total += 1;
-        total += name_len;
-        emit_count += 1;
-    }
-    if (emit_count == 0) return obj_new_string(0, 0);
-    const buf = alloc(total);
-    if (buf == 0) return obj_new_string(0, 0);
-    var off: u32 = 0;
-    var written: u32 = 0;
-    i = 0;
     while (i < n) : (i += 1) {
         const elem = obj.list_element_at(ps.ptr, ps.len, i);
         if (elem.len == 0) continue;
@@ -251,16 +244,13 @@ fn strip_param_defaults(params: i32) i32 {
             name_ptr = ps.ptr + elem.start + sub.start;
             name_len = sub.len;
         }
-        if (written > 0) {
-            const dp: [*]u8 = @ptrFromInt(buf + off);
-            dp[0] = ' ';
-            off += 1;
-        }
-        memcpy(buf + off, name_ptr, name_len);
-        off += name_len;
-        written += 1;
+        const name_obj = obj_new_string(@bitCast(name_ptr), @bitCast(name_len));
+        const next = list_mod.tcl_list(result, name_obj);
+        obj.tcl_obj_release(result);
+        obj.tcl_obj_release(name_obj);
+        result = next;
     }
-    return obj.obj_new_string_take(buf, off, total);
+    return result;
 }
 
 /// ``info complete script`` — returns 1 iff the script can be
@@ -1378,25 +1368,21 @@ pub fn info_constant(name: i32) i32 {
     // Namespace / global probe.  Reach the ``Var`` record directly
     // and inspect its flags.  Qualify bare names against current_ns
     // the way ``var_set`` would.
-    var ns_addr = tcl_ns.ns_root();
+    const ns_addr = tcl_ns.ns_root();
     var key_ptr = sn.ptr;
     var key_len = sn.len;
+    // Tracks an allocator-owned buffer we synthesised for the
+    // qualified-key probe; freed on every return path to avoid the
+    // per-call leak that previously persisted across each
+    // ``info constant`` invocation at namespace scope.
+    var owned_buf: u32 = 0;
+    var owned_len: u32 = 0;
     if (sn.len >= 2 and sp[0] == ':' and sp[1] == ':') {
-        // Already absolute — strip the leading ``::`` to match the
-        // flat-key form used by root.var_table.
         key_ptr = sn.ptr + 2;
         key_len = sn.len - 2;
     } else if (frames.frame_depth == 0 and tcl_ns.current_ns != 0 and tcl_ns.current_ns != tcl_ns.ns_root()) {
-        // Unqualified at namespace top-level: qualify against current_ns.
-        ns_addr = tcl_ns.ns_root();
-        // No allocation: the namespace var_table uses the FQN-ish
-        // ``ns::name`` form for nested vars (see :func:`var_set`'s
-        // namespace branch).  Skipping the alloc here means we
-        // synthesise the key on the stack via a temporary buffer.
         const ns_full_ptr = tcl_ns.current_ns_full_ptr();
         const ns_full_len = tcl_ns.current_ns_full_len();
-        // Strip leading ``::`` from ns_full_ptr too (current_ns_full
-        // returns the ``::A`` form).
         var nfp = ns_full_ptr;
         var nfl = ns_full_len;
         if (nfl >= 2) {
@@ -1417,8 +1403,11 @@ pub fn info_constant(name: i32) i32 {
         for (0..sn.len) |i| dst[nfl + 2 + i] = sp[i];
         key_ptr = buf;
         key_len = total;
+        owned_buf = buf;
+        owned_len = total;
     }
     const v_addr = tcl_ns.ns_var_find(ns_addr, key_ptr, key_len);
+    if (owned_buf != 0) obj.free_sized(owned_buf, owned_len);
     if (v_addr == 0) return obj_new_int(0);
     const v: *const tcl_ns.Var = @ptrFromInt(v_addr);
     if ((v.flags & tcl_ns.VAR_CONSTANT) != 0) return obj_new_int(1);
@@ -1512,6 +1501,10 @@ pub fn info_consts(pattern: i32) i32 {
     var match_pat_ptr: u32 = pat_ptr;
     var match_pat_len: u32 = pat_len;
     var emit_prefix_colons: bool = is_qualified; // ``::`` on emit for qualified queries
+    // Track whether the match pattern is allocator-owned so the
+    // qualified-pattern synthesis below cleans up before we return.
+    var owned_pat_buf: u32 = 0;
+    var owned_pat_len: u32 = 0;
     if (is_qualified and pat_len >= 2) {
         const pp_check: [*]const u8 = @ptrFromInt(pat_ptr);
         if (pp_check[0] == ':' and pp_check[1] == ':') {
@@ -1552,6 +1545,8 @@ pub fn info_consts(pattern: i32) i32 {
             match_pat_ptr = pb;
             match_pat_len = total_pat;
             has_pattern = true;
+            owned_pat_buf = pb;
+            owned_pat_len = total_pat;
             // Don't prefix output with ``::`` for the unqualified
             // form — var-30.5 expects the bare simple name ``X``.
             emit_prefix_colons = false;
@@ -1560,7 +1555,10 @@ pub fn info_consts(pattern: i32) i32 {
 
     const root = tcl_ns.ns_root();
     const ns: *const tcl_ns.Namespace = @ptrFromInt(root);
-    if (ns.var_table.buf == 0) return obj_new_string(0, 0);
+    if (ns.var_table.buf == 0) {
+        if (owned_pat_buf != 0) obj.free_sized(owned_pat_buf, owned_pat_len);
+        return obj_new_string(0, 0);
+    }
 
     const prefix_len: u32 = if (emit_prefix_colons) 2 else 0;
     var total_bytes: u32 = 0;
@@ -1593,9 +1591,15 @@ pub fn info_consts(pattern: i32) i32 {
         }
         count += 1;
     }
-    if (count == 0) return obj_new_string(0, 0);
+    if (count == 0) {
+        if (owned_pat_buf != 0) obj.free_sized(owned_pat_buf, owned_pat_len);
+        return obj_new_string(0, 0);
+    }
     const buf = alloc(total_bytes);
-    if (buf == 0) return obj_new_string(0, 0);
+    if (buf == 0) {
+        if (owned_pat_buf != 0) obj.free_sized(owned_pat_buf, owned_pat_len);
+        return obj_new_string(0, 0);
+    }
     var off: u32 = 0;
     var written: u32 = 0;
     i = 0;
@@ -1634,6 +1638,7 @@ pub fn info_consts(pattern: i32) i32 {
         }
         written += 1;
     }
+    if (owned_pat_buf != 0) obj.free_sized(owned_pat_buf, owned_pat_len);
     return obj.obj_new_string_take(buf, off, total_bytes);
 }
 

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -191,8 +191,76 @@ pub export fn info_args(name: i32) i32 {
         return 0;
     }
     const params = procs.proc_get_params(bucket);
-    if (params == 0) return obj_new_string(0, 0);
-    return params;
+    if (params != 0) return strip_param_defaults(params);
+    // AOT-compiled procs leave ``OFF_PARAMS_OBJ`` at zero (the
+    // dispatcher takes the host-bridge path so the runtime never
+    // needs a parsed params TclObj at call time).  Codegen instead
+    // stashes the raw params source bytes via
+    // ``proc_set_params_source_raw`` — materialise a fresh TclObj
+    // from those bytes on demand here.  Falls through to the empty
+    // string when no raw source was stashed (synthetic procs, or
+    // bundles built without the params-source emit).
+    const src = procs.proc_get_params_src(@bitCast(bucket));
+    if (src.ptr != 0 and src.len > 0) {
+        const raw = obj_new_string(@bitCast(src.ptr), @bitCast(src.len));
+        return strip_param_defaults(raw);
+    }
+    return obj_new_string(0, 0);
+}
+
+/// Reduce a params list of ``{name1 {name2 default} ...}`` to a list
+/// of just the names: ``{name1 name2 ...}``.  Tcl's ``info args``
+/// reports only parameter NAMES regardless of whether they carry
+/// defaults — even though the underlying ``proc`` syntax embeds the
+/// default value alongside the name in two-element sublists.
+fn strip_param_defaults(params: i32) i32 {
+    const ps = obj_ensure_string(params);
+    if (ps.len == 0 or ps.ptr == 0) return obj_new_string(0, 0);
+    const n = obj.list_count_elements(ps.ptr, ps.len);
+    if (n <= 0) return obj_new_string(0, 0);
+    // Two passes: size then emit.
+    var i: i64 = 0;
+    var total: u32 = 0;
+    var emit_count: u32 = 0;
+    while (i < n) : (i += 1) {
+        const elem = obj.list_element_at(ps.ptr, ps.len, i);
+        if (elem.len == 0) continue;
+        const sub_n = obj.list_count_elements(ps.ptr + elem.start, elem.len);
+        const name_len: u32 = if (sub_n > 0)
+            obj.list_element_at(ps.ptr + elem.start, elem.len, 0).len
+        else
+            elem.len;
+        if (emit_count > 0) total += 1;
+        total += name_len;
+        emit_count += 1;
+    }
+    if (emit_count == 0) return obj_new_string(0, 0);
+    const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
+    var off: u32 = 0;
+    var written: u32 = 0;
+    i = 0;
+    while (i < n) : (i += 1) {
+        const elem = obj.list_element_at(ps.ptr, ps.len, i);
+        if (elem.len == 0) continue;
+        var name_ptr: u32 = ps.ptr + elem.start;
+        var name_len: u32 = elem.len;
+        const sub_n = obj.list_count_elements(ps.ptr + elem.start, elem.len);
+        if (sub_n > 0) {
+            const sub = obj.list_element_at(ps.ptr + elem.start, elem.len, 0);
+            name_ptr = ps.ptr + elem.start + sub.start;
+            name_len = sub.len;
+        }
+        if (written > 0) {
+            const dp: [*]u8 = @ptrFromInt(buf + off);
+            dp[0] = ' ';
+            off += 1;
+        }
+        memcpy(buf + off, name_ptr, name_len);
+        off += name_len;
+        written += 1;
+    }
+    return obj.obj_new_string_take(buf, off, total);
 }
 
 /// ``info complete script`` — returns 1 iff the script can be

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -1271,6 +1271,323 @@ pub export fn info_default(proc_name: i32, arg_name: i32, var_name: i32) i32 {
     return obj_new_int(0);
 }
 
+// -- ``info constant`` / ``info consts`` ----------------------------------
+//
+// Tcl 9 TIP 590: variables flagged via ``const VARNAME VALUE`` are
+// read-only constants.  ``info constant NAME`` returns 1 when NAME
+// is currently constant, 0 otherwise.  ``info consts ?pattern?``
+// returns the list of constant names visible in the current scope
+// (proc-local list inside a frame; namespace-scoped Var.flags scan
+// otherwise).  Both are tolerant of bad inputs — array-element
+// notation, missing namespaces, dangling upvars, malformed names —
+// returning 0 / empty list, never raising (var-30.7..30.13).
+
+/// info constant NAME — 1 if NAME refers to a constant variable.
+pub fn info_constant(name: i32) i32 {
+    const sn = obj_ensure_string(name);
+    if (sn.len == 0) return obj_new_int(0);
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    // Array-element / array notation, malformed names — all return 0.
+    var k: u32 = 0;
+    while (k < sn.len) : (k += 1) {
+        if (sp[k] == '(') return obj_new_int(0);
+    }
+    // Local-frame check first when one is active.  Tcl 9 follows the
+    // same resolution chain as :func:`var_resolve`: a frame-local
+    // shadowing a global wins, so the constness check has to mirror.
+    if (frames.frame_depth != 0) {
+        const ht_mod = @import("../valtypes/hash_table.zig");
+        const hash = ht_mod.fnv1a(sn.ptr, sn.len);
+        if (frames.frame_const_check(sn.ptr, sn.len, hash)) return obj_new_int(1);
+        // A frame-local *non*-const slot shadows the namespace, so the
+        // namespace check below would lie for ``upvar`` / ``variable``
+        // bindings.  We only walk to the namespace when no local slot
+        // owns this name.  ``var_exists`` returns 1 for the local
+        // alias chain too, which is what we want.
+        const exists_obj = frames.var_exists(name);
+        if (obj.obj_get_int(exists_obj) != 0) return obj_new_int(0);
+    }
+    // Namespace / global probe.  Reach the ``Var`` record directly
+    // and inspect its flags.  Qualify bare names against current_ns
+    // the way ``var_set`` would.
+    var ns_addr = tcl_ns.ns_root();
+    var key_ptr = sn.ptr;
+    var key_len = sn.len;
+    if (sn.len >= 2 and sp[0] == ':' and sp[1] == ':') {
+        // Already absolute — strip the leading ``::`` to match the
+        // flat-key form used by root.var_table.
+        key_ptr = sn.ptr + 2;
+        key_len = sn.len - 2;
+    } else if (frames.frame_depth == 0 and tcl_ns.current_ns != 0 and tcl_ns.current_ns != tcl_ns.ns_root()) {
+        // Unqualified at namespace top-level: qualify against current_ns.
+        ns_addr = tcl_ns.ns_root();
+        // No allocation: the namespace var_table uses the FQN-ish
+        // ``ns::name`` form for nested vars (see :func:`var_set`'s
+        // namespace branch).  Skipping the alloc here means we
+        // synthesise the key on the stack via a temporary buffer.
+        const ns_full_ptr = tcl_ns.current_ns_full_ptr();
+        const ns_full_len = tcl_ns.current_ns_full_len();
+        // Strip leading ``::`` from ns_full_ptr too (current_ns_full
+        // returns the ``::A`` form).
+        var nfp = ns_full_ptr;
+        var nfl = ns_full_len;
+        if (nfl >= 2) {
+            const nsp: [*]const u8 = @ptrFromInt(nfp);
+            if (nsp[0] == ':' and nsp[1] == ':') {
+                nfp += 2;
+                nfl -= 2;
+            }
+        }
+        const total: u32 = nfl + 2 + sn.len;
+        const buf = alloc(total);
+        if (buf == 0) return obj_new_int(0);
+        const dst: [*]u8 = @ptrFromInt(buf);
+        const nsp: [*]const u8 = @ptrFromInt(nfp);
+        for (0..nfl) |i| dst[i] = nsp[i];
+        dst[nfl] = ':';
+        dst[nfl + 1] = ':';
+        for (0..sn.len) |i| dst[nfl + 2 + i] = sp[i];
+        key_ptr = buf;
+        key_len = total;
+    }
+    const v_addr = tcl_ns.ns_var_find(ns_addr, key_ptr, key_len);
+    if (v_addr == 0) return obj_new_int(0);
+    const v: *const tcl_ns.Var = @ptrFromInt(v_addr);
+    if ((v.flags & tcl_ns.VAR_CONSTANT) != 0) return obj_new_int(1);
+    return obj_new_int(0);
+}
+
+/// Glob-match a name against the optional pattern; returns ``true``
+/// when no pattern was supplied.
+fn const_pat_match(has_pattern: bool, pat_ptr: u32, pat_len: u32, name_ptr: u32, name_len: u32) bool {
+    if (!has_pattern) return true;
+    return tcl_string.glob_match(pat_ptr, pat_len, name_ptr, name_len);
+}
+
+/// Visitor state for the frame-const enumeration.
+const FrameConstsCtx = struct {
+    pat_ptr: u32,
+    pat_len: u32,
+    has_pattern: bool,
+    total_bytes: u32 = 0,
+    count: u32 = 0,
+    buf: u32 = 0,
+    off: u32 = 0,
+    written: u32 = 0,
+};
+
+var g_consts_ctx: FrameConstsCtx = .{ .pat_ptr = 0, .pat_len = 0, .has_pattern = false };
+
+fn consts_visit_size(_: u32, name_ptr: u32, name_len: u32) callconv(.c) void {
+    if (!const_pat_match(g_consts_ctx.has_pattern, g_consts_ctx.pat_ptr, g_consts_ctx.pat_len, name_ptr, name_len)) return;
+    if (g_consts_ctx.count > 0) g_consts_ctx.total_bytes += 1;
+    g_consts_ctx.total_bytes += name_len;
+    g_consts_ctx.count += 1;
+}
+
+fn consts_visit_emit(_: u32, name_ptr: u32, name_len: u32) callconv(.c) void {
+    if (!const_pat_match(g_consts_ctx.has_pattern, g_consts_ctx.pat_ptr, g_consts_ctx.pat_len, name_ptr, name_len)) return;
+    if (g_consts_ctx.written > 0) {
+        const dp: [*]u8 = @ptrFromInt(g_consts_ctx.buf + g_consts_ctx.off);
+        dp[0] = ' ';
+        g_consts_ctx.off += 1;
+    }
+    memcpy(g_consts_ctx.buf + g_consts_ctx.off, name_ptr, name_len);
+    g_consts_ctx.off += name_len;
+    g_consts_ctx.written += 1;
+}
+
+/// info consts ?pattern? — enumerate constant variable names.
+pub fn info_consts(pattern: i32) i32 {
+    var pat_ptr: u32 = 0;
+    var pat_len: u32 = 0;
+    var has_pattern = false;
+    var is_qualified = false;
+    if (pattern != 0) {
+        const ps = obj_ensure_string(pattern);
+        if (ps.len > 0) {
+            has_pattern = true;
+            pat_ptr = ps.ptr;
+            pat_len = ps.len;
+            const pp: [*]const u8 = @ptrFromInt(ps.ptr);
+            var k: u32 = 0;
+            while (k + 1 < ps.len) : (k += 1) {
+                if (pp[k] == ':' and pp[k + 1] == ':') {
+                    is_qualified = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Frame-local enumeration: only when a proc frame is active AND
+    // the user didn't ask for a qualified pattern (which targets the
+    // namespace store regardless of frame).
+    if (frames.frame_depth != 0 and !is_qualified) {
+        g_consts_ctx = .{ .pat_ptr = pat_ptr, .pat_len = pat_len, .has_pattern = has_pattern };
+        frames.frame_const_visit_current(0, &consts_visit_size);
+        if (g_consts_ctx.count == 0) return obj_new_string(0, 0);
+        const total = g_consts_ctx.total_bytes;
+        const buf = alloc(total);
+        if (buf == 0) return obj_new_string(0, 0);
+        g_consts_ctx.buf = buf;
+        g_consts_ctx.off = 0;
+        g_consts_ctx.written = 0;
+        frames.frame_const_visit_current(0, &consts_visit_emit);
+        return obj.obj_new_string_take(buf, total, total);
+    }
+
+    // Namespace enumeration: walk root.var_table for VAR_CONSTANT slots.
+    // Qualified patterns: strip leading ``::`` from the pattern for
+    // matching (var_table keys are flat with no ``::`` prefix), emit
+    // matches with the ``::`` prefix.
+    var match_pat_ptr: u32 = pat_ptr;
+    var match_pat_len: u32 = pat_len;
+    var emit_prefix_colons: bool = is_qualified; // ``::`` on emit for qualified queries
+    if (is_qualified and pat_len >= 2) {
+        const pp_check: [*]const u8 = @ptrFromInt(pat_ptr);
+        if (pp_check[0] == ':' and pp_check[1] == ':') {
+            match_pat_ptr = pat_ptr + 2;
+            match_pat_len = pat_len - 2;
+        }
+    } else if (!is_qualified and frames.frame_depth == 0 and tcl_ns.current_ns != 0 and tcl_ns.current_ns != tcl_ns.ns_root()) {
+        // Unqualified at namespace-eval scope (no frame, current_ns
+        // is non-root): the storage keys live under ``ns::name``;
+        // ``info consts X`` at that scope wants to match against just
+        // ``X``, so build a qualified pattern internally.
+        const ns_full_ptr = tcl_ns.current_ns_full_ptr();
+        const ns_full_len = tcl_ns.current_ns_full_len();
+        var nfp = ns_full_ptr;
+        var nfl = ns_full_len;
+        if (nfl >= 2) {
+            const nsp: [*]const u8 = @ptrFromInt(nfp);
+            if (nsp[0] == ':' and nsp[1] == ':') {
+                nfp += 2;
+                nfl -= 2;
+            }
+        }
+        if (nfl > 0) {
+            const total_pat: u32 = nfl + 2 + (if (has_pattern) pat_len else @as(u32, 1));
+            const pb = alloc(total_pat);
+            if (pb == 0) return obj_new_string(0, 0);
+            const dst: [*]u8 = @ptrFromInt(pb);
+            const nsp: [*]const u8 = @ptrFromInt(nfp);
+            for (0..nfl) |i| dst[i] = nsp[i];
+            dst[nfl] = ':';
+            dst[nfl + 1] = ':';
+            if (has_pattern) {
+                const pp: [*]const u8 = @ptrFromInt(pat_ptr);
+                for (0..pat_len) |i| dst[nfl + 2 + i] = pp[i];
+            } else {
+                dst[nfl + 2] = '*';
+            }
+            match_pat_ptr = pb;
+            match_pat_len = total_pat;
+            has_pattern = true;
+            // Don't prefix output with ``::`` for the unqualified
+            // form — var-30.5 expects the bare simple name ``X``.
+            emit_prefix_colons = false;
+        }
+    }
+
+    const root = tcl_ns.ns_root();
+    const ns: *const tcl_ns.Namespace = @ptrFromInt(root);
+    if (ns.var_table.buf == 0) return obj_new_string(0, 0);
+
+    const prefix_len: u32 = if (emit_prefix_colons) 2 else 0;
+    var total_bytes: u32 = 0;
+    var count: u32 = 0;
+    var i: u32 = 0;
+    while (i < ns.var_table.cap) : (i += 1) {
+        const bucket = ns.var_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
+        const name_ptr: u32 = @bitCast(read_i32(bucket));
+        if (name_ptr == 0) continue;
+        const name_len: u32 = @bitCast(read_i32(bucket + 4));
+        const var_addr: u32 = @bitCast(read_i32(bucket + tcl_ns.OFF_HANDLE));
+        if (var_addr == 0) continue;
+        const v: *const tcl_ns.Var = @ptrFromInt(var_addr);
+        if ((v.flags & tcl_ns.VAR_CONSTANT) == 0) continue;
+        // For unqualified, frame-less, namespace-rooted queries we
+        // already synthesised a qualified pattern; but we also need
+        // to ensure the *match* check considers the flat key.
+        if (has_pattern) {
+            if (!tcl_string.glob_match(match_pat_ptr, match_pat_len, name_ptr, name_len)) continue;
+        }
+        if (count > 0) total_bytes += 1;
+        total_bytes += prefix_len + name_len;
+        // Strip the ns prefix on emit when unqualified-namespace mode:
+        // var-30.5 wants ``X``, not ``var30::X``.
+        if (!emit_prefix_colons and !is_qualified) {
+            // Look for the last ``::`` in the name and emit only the tail.
+            const trailing = trailing_simple_name(name_ptr, name_len);
+            total_bytes -= name_len; // undo
+            total_bytes += trailing.len;
+        }
+        count += 1;
+    }
+    if (count == 0) return obj_new_string(0, 0);
+    const buf = alloc(total_bytes);
+    if (buf == 0) return obj_new_string(0, 0);
+    var off: u32 = 0;
+    var written: u32 = 0;
+    i = 0;
+    while (i < ns.var_table.cap) : (i += 1) {
+        const bucket = ns.var_table.buf + i * tcl_ns.NS_BUCKET_SIZE;
+        const name_ptr: u32 = @bitCast(read_i32(bucket));
+        if (name_ptr == 0) continue;
+        const name_len: u32 = @bitCast(read_i32(bucket + 4));
+        const var_addr: u32 = @bitCast(read_i32(bucket + tcl_ns.OFF_HANDLE));
+        if (var_addr == 0) continue;
+        const v: *const tcl_ns.Var = @ptrFromInt(var_addr);
+        if ((v.flags & tcl_ns.VAR_CONSTANT) == 0) continue;
+        if (has_pattern) {
+            if (!tcl_string.glob_match(match_pat_ptr, match_pat_len, name_ptr, name_len)) continue;
+        }
+        if (written > 0) {
+            const dp: [*]u8 = @ptrFromInt(buf + off);
+            dp[0] = ' ';
+            off += 1;
+        }
+        if (emit_prefix_colons) {
+            const dst: [*]u8 = @ptrFromInt(buf + off);
+            dst[0] = ':';
+            dst[1] = ':';
+            off += 2;
+            const np: [*]const u8 = @ptrFromInt(name_ptr);
+            for (0..name_len) |k| dst[2 + k] = np[k];
+            off += name_len;
+        } else if (!is_qualified) {
+            const trailing = trailing_simple_name(name_ptr, name_len);
+            memcpy(buf + off, trailing.ptr, trailing.len);
+            off += trailing.len;
+        } else {
+            memcpy(buf + off, name_ptr, name_len);
+            off += name_len;
+        }
+        written += 1;
+    }
+    return obj.obj_new_string_take(buf, off, total_bytes);
+}
+
+const ConstSpan = struct { ptr: u32, len: u32 };
+
+/// Return the tail of ``name`` after the last ``::``.  ``foo::bar``
+/// → ``bar``; ``bar`` → ``bar``.  Used to render an unqualified
+/// ``info consts`` result at namespace-eval scope where the storage
+/// key is ``ns::X`` but the visible name is ``X``.
+fn trailing_simple_name(name_ptr: u32, name_len: u32) ConstSpan {
+    if (name_len < 2) return .{ .ptr = name_ptr, .len = name_len };
+    const np: [*]const u8 = @ptrFromInt(name_ptr);
+    var last_sep: i32 = -1;
+    var k: u32 = 0;
+    while (k + 1 < name_len) : (k += 1) {
+        if (np[k] == ':' and np[k + 1] == ':') last_sep = @intCast(k + 2);
+    }
+    if (last_sep < 0) return .{ .ptr = name_ptr, .len = name_len };
+    const off: u32 = @intCast(last_sep);
+    return .{ .ptr = name_ptr + off, .len = name_len - off };
+}
+
 // -- ``info vars`` ---------------------------------------------------------
 
 /// ``info vars ?pattern?`` — return a list of variable names visible
@@ -1616,6 +1933,8 @@ pub export fn info_dispatch(subcmd: i32, arg: i32) i32 {
     if (str_eq(sp, sub.len, "level")) return info_level(arg);
     if (str_eq(sp, sub.len, "script")) return info_script();
     if (str_eq(sp, sub.len, "vars")) return info_vars(arg);
+    if (str_eq(sp, sub.len, "constant")) return info_constant(arg);
+    if (str_eq(sp, sub.len, "consts")) return info_consts(arg);
     if (str_eq(sp, sub.len, "locals")) {
         // ``info locals`` returns only local variables of the current
         // proc frame (no globals).  Outside a proc, an empty string.

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -204,8 +204,197 @@ fn pick_unset_suffix(s: anytype) []const u8 {
     return "\": no such variable";
 }
 
+/// Tcl 9 ``const VARNAME VALUE`` — set a variable and flag it as a
+/// read-only constant.  Per :cite:`tip.590`:
+///   * Re-running ``const`` on an already-constant name is a silent
+///     success (the existing value is preserved).
+///   * Running ``const`` on an existing *non-constant* variable
+///     raises ``can't make constant "<name>": variable already exists``.
+///   * Array names and array elements cannot be made constant.
+///   * In a proc frame, the constness lives in the per-frame
+///     ``frame_const_*`` side list (frame buckets have no flag bits).
+///     At namespace scope, the namespace ``Var`` carries the
+///     ``VAR_CONSTANT`` bit directly.
+fn eval_const(words: []const i32) result_mod.InterpResult {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const tcl_obj_mod = @import("../valtypes/tcl_obj.zig");
+    if (words.len != 3) {
+        const msg_text: []const u8 = "wrong # args: should be \"const varName value\"";
+        const buf = rt.alloc(@intCast(msg_text.len));
+        if (buf != 0) {
+            const dst: [*]u8 = @ptrFromInt(buf);
+            for (msg_text, 0..) |b, k| dst[k] = b;
+            const msg = rt.obj_new_string_take(buf, @intCast(msg_text.len), @intCast(msg_text.len));
+            catch_mod.tcl_cmd_error(msg);
+        }
+        return result_mod.from_globals(0);
+    }
+    const name = words[1];
+    const value = words[2];
+    const sn = obj_ensure_string(name);
+    if (sn.len == 0) return result_mod.from_globals(0);
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+
+    // Reject array-element form ``arr(key)`` — TIP 590 only flags
+    // whole scalars.  Matches the C-Tcl ISARRAYELEMENT diagnostic.
+    var i: u32 = 0;
+    while (i < sn.len) : (i += 1) {
+        if (sp[i] == '(') {
+            raise_const_array_error(sn.ptr, sn.len);
+            return result_mod.from_globals(0);
+        }
+    }
+
+    if (frames.frame_depth != 0) {
+        // Proc-local: check the frame's const list first so a repeat
+        // ``const X V`` on an already-constant name silently succeeds.
+        const ht_mod = @import("../valtypes/hash_table.zig");
+        const hash = ht_mod.fnv1a(sn.ptr, sn.len);
+        if (frames.frame_const_check(sn.ptr, sn.len, hash)) {
+            return result_mod.from_globals(value);
+        }
+        // If the local already exists *and* isn't a const, raise the
+        // ``variable already exists`` diagnostic.  Tcl's ``info exists``
+        // is the right discriminator: it gates on actual storage so an
+        // ``unset``-cleared slot doesn't count.
+        const exists_obj = frames.var_exists(name);
+        if (rt.obj_get_int(exists_obj) != 0) {
+            raise_const_exists_error(sn.ptr, sn.len);
+            return result_mod.from_globals(0);
+        }
+        _ = frames.var_set(name, value);
+        frames.frame_const_mark(sn.ptr, sn.len, hash);
+        return result_mod.from_globals(value);
+    }
+
+    // No frame: namespace scope.  Resolve the storage key the way
+    // ``global_set`` will and reach the ``Var`` record so the
+    // VAR_CONSTANT flag can be set / checked.
+    const qname = qualify_for_ns(name, sn);
+    const qs = obj_ensure_string(qname);
+    const stripped = strip_double_colon(qs.ptr, qs.len);
+    const v_addr = tcl_ns.ns_var_find(tcl_ns.ns_root(), stripped.ptr, stripped.len);
+    if (v_addr != 0) {
+        const v: *const tcl_ns.Var = @ptrFromInt(v_addr);
+        if ((v.flags & tcl_ns.VAR_CONSTANT) != 0) {
+            if (qname != name) tcl_obj_mod.tcl_obj_release(qname);
+            return result_mod.from_globals(value);
+        }
+        // Existing non-const var: error iff it has a value.  An
+        // undefined slot (created by ``variable X`` with no value)
+        // should be allowed to become a constant.
+        if (tcl_ns.var_get_scalar(v_addr) != 0) {
+            raise_const_exists_error(sn.ptr, sn.len);
+            if (qname != name) tcl_obj_mod.tcl_obj_release(qname);
+            return result_mod.from_globals(0);
+        }
+    }
+    _ = tcl_ns.global_set(qname, value);
+    const v2 = tcl_ns.ns_var_find(tcl_ns.ns_root(), stripped.ptr, stripped.len);
+    if (v2 != 0) {
+        const vp: *tcl_ns.Var = @ptrFromInt(v2);
+        vp.flags |= tcl_ns.VAR_CONSTANT;
+    }
+    if (qname != name) tcl_obj_mod.tcl_obj_release(qname);
+    return result_mod.from_globals(value);
+}
+
+/// Build the fully-qualified storage key for a bare ``name`` when no
+/// frame is active.  Mirrors :func:`var_set`'s namespace-write branch:
+///   * ``::``-anchored names pass through unchanged.
+///   * Inside ``namespace eval ::A { ... }`` (``current_ns != root``)
+///     an unqualified ``X`` becomes ``::A::X``.
+///   * Root-scope unqualified names also pass through.
+/// Returns either the original handle or a freshly-allocated owning
+/// TclObj — caller releases the latter (``qname != name``).
+fn qualify_for_ns(name: i32, sn: anytype) i32 {
+    if (sn.len >= 2) {
+        const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+        if (sp[0] == ':' and sp[1] == ':') return name;
+    }
+    if (tcl_ns.current_ns == 0 or tcl_ns.current_ns == tcl_ns.ns_root()) return name;
+    const ns_full_ptr = tcl_ns.current_ns_full_ptr();
+    const ns_full_len = tcl_ns.current_ns_full_len();
+    if (ns_full_len <= 2) return name;
+    const total: u32 = ns_full_len + 2 + sn.len;
+    const buf = rt.alloc(total);
+    if (buf == 0) return name;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    const ns_p: [*]const u8 = @ptrFromInt(ns_full_ptr);
+    for (0..ns_full_len) |k| dst[k] = ns_p[k];
+    dst[ns_full_len] = ':';
+    dst[ns_full_len + 1] = ':';
+    const name_p: [*]const u8 = @ptrFromInt(sn.ptr);
+    for (0..sn.len) |k| dst[ns_full_len + 2 + k] = name_p[k];
+    return rt.obj_new_string_take(buf, total, total);
+}
+
+/// Strip a leading ``::`` so the result matches the flat-key form the
+/// namespace ``var_table`` uses.  Pure span manipulation.
+const Span = struct { ptr: u32, len: u32 };
+fn strip_double_colon(ptr: u32, len: u32) Span {
+    if (len >= 2) {
+        const sp: [*]const u8 = @ptrFromInt(ptr);
+        if (sp[0] == ':' and sp[1] == ':') return .{ .ptr = ptr + 2, .len = len - 2 };
+    }
+    return .{ .ptr = ptr, .len = len };
+}
+
+fn raise_const_exists_error(name_ptr: u32, name_len: u32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const prefix: []const u8 = "can't make constant \"";
+    const suffix: []const u8 = "\": variable already exists";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
+    const buf = rt.alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const np: [*]const u8 = @ptrFromInt(name_ptr);
+    for (0..name_len) |k| {
+        dst[off] = np[k];
+        off += 1;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const msg = rt.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
+fn raise_const_array_error(name_ptr: u32, name_len: u32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const prefix: []const u8 = "can't make constant \"";
+    const suffix: []const u8 = "\": name refers to an element in an array";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
+    const buf = rt.alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const np: [*]const u8 = @ptrFromInt(name_ptr);
+    for (0..name_len) |k| {
+        dst[off] = np[k];
+        off += 1;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const msg = rt.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
 pub const registrations = [_]reg.CmdEntry{
     .{ .name = "set", .arity_min = 1, .arity_max = 2, .handler = &eval_set },
     .{ .name = "incr", .arity_min = 1, .arity_max = 2, .handler = &eval_incr },
     .{ .name = "unset", .arity_min = 1, .arity_max = null, .handler = &eval_unset },
+    .{ .name = "const", .arity_min = 2, .arity_max = 2, .handler = &eval_const },
 };

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -28,6 +28,12 @@ fn eval_set(words: []const i32) result_mod.InterpResult {
         return result_mod.from_globals(0);
     }
     if (words.len == 3) {
+        // Tcl 9 ``const`` semantics: a write to a constant variable
+        // raises ``can't set "<name>": variable is a constant``.
+        if (name_is_constant(words[1])) {
+            raise_const_set_error(words[1], "set");
+            return result_mod.from_globals(0);
+        }
         _ = frames.var_set(words[1], words[2]);
         return result_mod.from_globals(words[2]);
     }
@@ -48,6 +54,10 @@ fn eval_incr(words: []const i32) result_mod.InterpResult {
     if (words.len < 2 or words.len > 3) {
         const stubs = @import("../stubs/tcl_stubs.zig");
         stubs.raise("wrong # args: should be \"incr varName ?increment?\"");
+        return result_mod.from_globals(0);
+    }
+    if (name_is_constant(words[1])) {
+        raise_const_set_error(words[1], "incr");
         return result_mod.from_globals(0);
     }
     const amt_obj = if (words.len >= 3) words[2] else rt.obj_new_int(1);
@@ -99,6 +109,13 @@ fn eval_unset(words: []const i32) result_mod.InterpResult {
         // is an array but the element is missing.
         if (!nocomplain and !var_exists_for_unset(words[i])) {
             raise_unset_error(words[i]);
+            return result_mod.from_globals(0);
+        }
+        // Tcl 9 ``const``: ``unset`` of a constant variable raises
+        // even with ``-nocomplain``.  Match reference Tcl's wording
+        // (``can't unset "<name>": variable is a constant``).
+        if (name_is_constant(words[i])) {
+            raise_const_set_error(words[i], "unset");
             return result_mod.from_globals(0);
         }
         const wp: [*]const u8 = @ptrFromInt(w.ptr);
@@ -202,6 +219,129 @@ fn pick_unset_suffix(s: anytype) []const u8 {
         return "\": no such variable";
     }
     return "\": no such variable";
+}
+
+/// Predicate: is *name* currently flagged as a Tcl 9 constant?
+/// Checks the per-frame const set first (proc-local consts) then
+/// the VAR_CONSTANT bit on a namespace-resolved ``Var`` record.
+/// Array-element forms (``arr(key)``) are never constants — TIP 590
+/// only allows whole scalars.
+fn name_is_constant(name: i32) bool {
+    const tcl_obj_mod = @import("../valtypes/tcl_obj.zig");
+    const sn = tcl_obj_mod.obj_ensure_string(name);
+    if (sn.len == 0 or sn.ptr == 0) return false;
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    // ``arr(key)`` shapes are never const-flagged — bail.
+    var k: u32 = 0;
+    while (k < sn.len) : (k += 1) {
+        if (sp[k] == '(') return false;
+    }
+    // Proc-local lookup: check the per-frame const set when a frame
+    // is active and the name has no namespace qualifier (qualified
+    // names always resolve through the ns variable table).
+    if (frames.frame_depth != 0) {
+        var has_colons = false;
+        var i: u32 = 0;
+        while (i + 1 < sn.len) : (i += 1) {
+            if (sp[i] == ':' and sp[i + 1] == ':') {
+                has_colons = true;
+                break;
+            }
+        }
+        if (!has_colons) {
+            const ht_mod = @import("../valtypes/hash_table.zig");
+            const hash = ht_mod.fnv1a(sn.ptr, sn.len);
+            if (frames.frame_const_check(sn.ptr, sn.len, hash)) return true;
+            // A frame-local non-const slot shadows the namespace.
+            const exists_obj = frames.var_exists(name);
+            if (tcl_obj_mod.obj_get_int(exists_obj) != 0) return false;
+        }
+    }
+    // Namespace probe: reach the ``Var`` and inspect its flags.
+    // Qualify against current_ns the same way the read / write
+    // paths in ``var_resolve`` / ``var_set`` do.
+    var key_ptr = sn.ptr;
+    var key_len = sn.len;
+    if (sn.len >= 2 and sp[0] == ':' and sp[1] == ':') {
+        key_ptr = sn.ptr + 2;
+        key_len = sn.len - 2;
+    } else if (frames.frame_depth == 0 and tcl_ns.current_ns != 0 and tcl_ns.current_ns != tcl_ns.ns_root()) {
+        const ns_full_ptr = tcl_ns.current_ns_full_ptr();
+        const ns_full_len = tcl_ns.current_ns_full_len();
+        var nfp = ns_full_ptr;
+        var nfl = ns_full_len;
+        if (nfl >= 2) {
+            const nsp: [*]const u8 = @ptrFromInt(nfp);
+            if (nsp[0] == ':' and nsp[1] == ':') {
+                nfp += 2;
+                nfl -= 2;
+            }
+        }
+        if (nfl > 0) {
+            const total: u32 = nfl + 2 + sn.len;
+            const buf = tcl_obj_mod.alloc(total);
+            if (buf == 0) return false;
+            const dst: [*]u8 = @ptrFromInt(buf);
+            const nsp: [*]const u8 = @ptrFromInt(nfp);
+            for (0..nfl) |i| dst[i] = nsp[i];
+            dst[nfl] = ':';
+            dst[nfl + 1] = ':';
+            for (0..sn.len) |i| dst[nfl + 2 + i] = sp[i];
+            const v_addr = tcl_ns.ns_var_find(tcl_ns.ns_root(), buf, total);
+            tcl_obj_mod.free_sized(buf, total);
+            if (v_addr == 0) return false;
+            const v: *const tcl_ns.Var = @ptrFromInt(v_addr);
+            return (v.flags & tcl_ns.VAR_CONSTANT) != 0;
+        }
+    }
+    const v_addr = tcl_ns.ns_var_find(tcl_ns.ns_root(), key_ptr, key_len);
+    if (v_addr == 0) return false;
+    const v: *const tcl_ns.Var = @ptrFromInt(v_addr);
+    return (v.flags & tcl_ns.VAR_CONSTANT) != 0;
+}
+
+/// Emit the canonical ``can't <op> "<name>": variable is a constant``
+/// diagnostic for an attempted write to a constant variable.  *op* is
+/// the user-visible verb (``"set"``, ``"incr"``, ``"unset"``) the
+/// dispatcher was running.
+fn raise_const_set_error(name: i32, op: []const u8) void {
+    const tcl_obj_mod = @import("../valtypes/tcl_obj.zig");
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const sn = tcl_obj_mod.obj_ensure_string(name);
+    const prefix1: []const u8 = "can't ";
+    const prefix2: []const u8 = " \"";
+    const suffix: []const u8 = "\": variable is a constant";
+    const total: u32 = @as(u32, @intCast(prefix1.len + op.len + prefix2.len)) + sn.len + @as(u32, @intCast(suffix.len));
+    const buf = tcl_obj_mod.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(tcl_obj_mod.obj_new_string(0, 0));
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix1) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    for (op) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    for (prefix2) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (sn.len > 0) {
+        const np: [*]const u8 = @ptrFromInt(sn.ptr);
+        for (0..sn.len) |k| dst[off + k] = np[k];
+        off += sn.len;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const msg = tcl_obj_mod.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
 }
 
 /// Tcl 9 ``const VARNAME VALUE`` — set a variable and flag it as a

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -413,12 +413,32 @@ fn eval_const(words: []const i32) result_mod.InterpResult {
     const qname = qualify_for_ns(name, sn);
     const qs = obj_ensure_string(qname);
     const stripped = strip_double_colon(qs.ptr, qs.len);
+    // Reject ``const X V`` when ``X`` already exists as an array
+    // at the resolved storage key.  Arrays live in the parallel
+    // ``tcl_array`` directory, not the ``ns_var_find`` table, so
+    // the ``Var`` probe below would miss them.
+    if (tcl_array.array_exists_raw(stripped.ptr, stripped.len)) {
+        raise_const_array_var_error(sn.ptr, sn.len);
+        if (qname != name) tcl_obj_mod.tcl_obj_release(qname);
+        return result_mod.from_globals(0);
+    }
     const v_addr = tcl_ns.ns_var_find(tcl_ns.ns_root(), stripped.ptr, stripped.len);
     if (v_addr != 0) {
         const v: *const tcl_ns.Var = @ptrFromInt(v_addr);
         if ((v.flags & tcl_ns.VAR_CONSTANT) != 0) {
             if (qname != name) tcl_obj_mod.tcl_obj_release(qname);
             return result_mod.from_globals(value);
+        }
+        // Belt-and-braces: a ``Var`` record carrying ``VAR_ARRAY``
+        // (e.g. a future direct ns-var array shape) is also a
+        // non-scalar — reject just like the array-directory probe
+        // above.  ``var_get_scalar`` returns 0 for arrays, which
+        // would otherwise let the slot look like an undefined
+        // scalar and slip into the ``promote-to-const`` branch.
+        if ((v.flags & tcl_ns.VAR_ARRAY) != 0) {
+            raise_const_array_var_error(sn.ptr, sn.len);
+            if (qname != name) tcl_obj_mod.tcl_obj_release(qname);
+            return result_mod.from_globals(0);
         }
         // Existing non-const var: error iff it has a value.  An
         // undefined slot (created by ``variable X`` with no value)
@@ -484,6 +504,32 @@ fn raise_const_exists_error(name_ptr: u32, name_len: u32) void {
     const catch_mod = @import("../interp/tcl_catch.zig");
     const prefix: []const u8 = "can't make constant \"";
     const suffix: []const u8 = "\": variable already exists";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
+    const buf = rt.alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const np: [*]const u8 = @ptrFromInt(name_ptr);
+    for (0..name_len) |k| {
+        dst[off] = np[k];
+        off += 1;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const msg = rt.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
+fn raise_const_array_var_error(name_ptr: u32, name_len: u32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const prefix: []const u8 = "can't make constant \"";
+    const suffix: []const u8 = "\": variable is array";
     const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
     const buf = rt.alloc(total);
     if (buf == 0) return;

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -314,6 +314,104 @@ var frame_info: [MAX_DEPTH]FrameInfo = [_]FrameInfo{.{}} ** MAX_DEPTH;
 // reset the slot to 0 before the frame is reused.
 pub var frame_trace_heads: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
 
+// Per-frame ``const`` tracker (Tcl 9 ``const VARNAME VAL`` /
+// ``info constant`` / ``info consts``).  Frame buckets are 16 bytes
+// (12 header + 4 value) with no room for a per-slot ``VAR_CONSTANT``
+// flag, so const-ness for proc-local names rides in this side list.
+// Each slot is a small array of (name_ptr, name_len, hash) records
+// that get matched on every ``const`` re-declaration / ``info
+// constant NAME`` probe.  Capacity is bounded — runaway use is
+// pathological for a single proc — and ``frame_pop`` clears the
+// count so a recycled depth never inherits stale entries.
+const FRAME_CONST_CAP: u32 = 64;
+const FrameConstName = extern struct {
+    name_ptr: u32,
+    name_len: u32,
+    hash: u32,
+};
+// Slot contents are read only when guarded by ``frame_const_count`` —
+// the zeroed count covers stale data so leaving the records
+// ``undefined`` here is safe and avoids paying for a ~65 KiB static
+// init on module startup.
+var frame_const_names: [MAX_DEPTH][FRAME_CONST_CAP]FrameConstName = undefined;
+var frame_const_count: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
+
+/// Mark a name as constant in the current frame.  Idempotent — a
+/// repeat ``const X V`` after the first one is silently no-op in the
+/// caller (Tcl 9 semantics: re-const of an already-constant name
+/// succeeds without changing the value).  Linear scan over the
+/// frame's records; capacity overflow drops the marker silently so
+/// the runtime can't trap on a pathological proc.
+pub fn frame_const_mark(name_ptr: u32, name_len: u32, hash: u32) void {
+    if (frame_depth == 0) return;
+    const idx = frame_depth - 1;
+    const n = frame_const_count[idx];
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const r = frame_const_names[idx][i];
+        if (r.hash == hash and r.name_len == name_len and r.name_ptr == name_ptr) return;
+        if (r.hash == hash and r.name_len == name_len) {
+            const a: [*]const u8 = @ptrFromInt(r.name_ptr);
+            const b: [*]const u8 = @ptrFromInt(name_ptr);
+            var matches = true;
+            var k: u32 = 0;
+            while (k < name_len) : (k += 1) {
+                if (a[k] != b[k]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return;
+        }
+    }
+    if (n >= FRAME_CONST_CAP) return;
+    frame_const_names[idx][n] = .{ .name_ptr = name_ptr, .name_len = name_len, .hash = hash };
+    frame_const_count[idx] = n + 1;
+}
+
+/// Check whether ``name`` is flagged constant in the current frame.
+pub fn frame_const_check(name_ptr: u32, name_len: u32, hash: u32) bool {
+    if (frame_depth == 0) return false;
+    const idx = frame_depth - 1;
+    const n = frame_const_count[idx];
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const r = frame_const_names[idx][i];
+        if (r.hash != hash or r.name_len != name_len) continue;
+        const a: [*]const u8 = @ptrFromInt(r.name_ptr);
+        const b: [*]const u8 = @ptrFromInt(name_ptr);
+        var matches = true;
+        var k: u32 = 0;
+        while (k < name_len) : (k += 1) {
+            if (a[k] != b[k]) {
+                matches = false;
+                break;
+            }
+        }
+        if (matches) return true;
+    }
+    return false;
+}
+
+/// Per-frame visitor over the const-name list.  Used by
+/// ``info consts ?pattern?`` to enumerate constants of the current
+/// proc frame.  ``ctx`` is opaque; the callback receives each
+/// const's (name_ptr, name_len) span.
+pub fn frame_const_visit_current(
+    ctx: u32,
+    visit: *const fn (ctx: u32, name_ptr: u32, name_len: u32) callconv(.c) void,
+) void {
+    if (frame_depth == 0) return;
+    const idx = frame_depth - 1;
+    const n = frame_const_count[idx];
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const r = frame_const_names[idx][i];
+        if (r.name_ptr == 0 or r.name_len == 0) continue;
+        visit(ctx, r.name_ptr, r.name_len);
+    }
+}
+
 // Pending ``argv0`` for the next compiled-proc entry.  Set by a
 // compiled caller via ``frame_set_pending_argv0`` immediately
 // before it transfers control to a compiled callee, and consumed
@@ -514,6 +612,9 @@ pub export fn frame_pop() void {
         // reset-on-reuse via ``mark_dirty``; the indexed array
         // is a parallel store with its own ownership tracking.
         frame_locals_array_drop_current();
+        // Phase B (const): drop the frame's const-name list so the
+        // next tenant of this depth doesn't inherit ``const X`` flags.
+        frame_const_count[frame_depth - 1] = 0;
         frame_depth -= 1;
         // MM-B.5: release the argv reference we retained in
         // frame_set_argv before clearing the slot.

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -349,7 +349,6 @@ pub fn frame_const_mark(name_ptr: u32, name_len: u32, hash: u32) void {
     var i: u32 = 0;
     while (i < n) : (i += 1) {
         const r = frame_const_names[idx][i];
-        if (r.hash == hash and r.name_len == name_len and r.name_ptr == name_ptr) return;
         if (r.hash == hash and r.name_len == name_len) {
             const a: [*]const u8 = @ptrFromInt(r.name_ptr);
             const b: [*]const u8 = @ptrFromInt(name_ptr);
@@ -365,7 +364,21 @@ pub fn frame_const_mark(name_ptr: u32, name_len: u32, hash: u32) void {
         }
     }
     if (n >= FRAME_CONST_CAP) return;
-    frame_const_names[idx][n] = .{ .name_ptr = name_ptr, .name_len = name_len, .hash = hash };
+    // Copy the name bytes into an allocator-owned buffer.  The caller
+    // typically passes ``obj_ensure_string(name).ptr``, which points
+    // into a TclObj's borrowed string buffer; that obj is released by
+    // the parser at end-of-statement (MM-B.4), invalidating the
+    // pointer.  Heap-copying keeps every entry's lifetime bounded by
+    // the frame itself.
+    const nbuf = obj.alloc(name_len);
+    if (nbuf == 0) return;
+    if (name_len > 0) {
+        const dst: [*]u8 = @ptrFromInt(nbuf);
+        const src: [*]const u8 = @ptrFromInt(name_ptr);
+        var k: u32 = 0;
+        while (k < name_len) : (k += 1) dst[k] = src[k];
+    }
+    frame_const_names[idx][n] = .{ .name_ptr = nbuf, .name_len = name_len, .hash = hash };
     frame_const_count[idx] = n + 1;
 }
 
@@ -614,7 +627,22 @@ pub export fn frame_pop() void {
         frame_locals_array_drop_current();
         // Phase B (const): drop the frame's const-name list so the
         // next tenant of this depth doesn't inherit ``const X`` flags.
-        frame_const_count[frame_depth - 1] = 0;
+        // Each entry owns a heap-copied name buffer (see
+        // ``frame_const_mark`` for the rationale); free those before
+        // resetting the count so the allocator can recycle the
+        // slabs.
+        {
+            const cur_depth = frame_depth - 1;
+            const cn = frame_const_count[cur_depth];
+            var ci: u32 = 0;
+            while (ci < cn) : (ci += 1) {
+                const r = frame_const_names[cur_depth][ci];
+                if (r.name_ptr != 0 and r.name_len > 0) {
+                    obj.free_sized(r.name_ptr, r.name_len);
+                }
+            }
+            frame_const_count[cur_depth] = 0;
+        }
         frame_depth -= 1;
         // MM-B.5: release the argv reference we retained in
         // frame_set_argv before clearing the slot.

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -2677,6 +2677,16 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
         catch_mod.error_invalid_command_name(words[0]);
         return 0;
     }
+    // ``CMD_ENSEMBLE`` Commands carry an ``*EnsembleRec`` in their
+    // ``params_obj`` slot (see ``cmds/namespace.zig``).  Route the
+    // call through the ensemble subcommand dispatcher; the
+    // dispatcher resolves the subcommand against the configured
+    // ``-map`` / ``-subcommands`` / target-ns exports, builds the
+    // final argv, and re-enters ``eval_command``.
+    if ((cmd_flags & procs.CMD_ENSEMBLE) != 0) {
+        const ns_mod = @import("../cmds/namespace.zig");
+        return ns_mod.dispatch_ensemble(bucket, words);
+    }
     // Compiled proc (func_idx != 0 is a marker set by
     // ``proc_register_compiled``) — dispatch via the host bridge
     // because pure WASM can't call across modules.  The bridge

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -290,7 +290,7 @@ pub fn is_deleted(interp: u32) bool {
 /// ``tcl_procs.zig`` via the ``comptime`` assert below (using the
 /// ``tcl_ns.tcl_procs_constants`` shadow that ``tcl_procs.zig``
 /// already verifies against itself).
-const COMMAND_SIZE: u32 = 44;
+const COMMAND_SIZE: u32 = 52;
 comptime {
     if (COMMAND_SIZE != tcl_ns.tcl_procs_constants.COMMAND_SIZE)
         @compileError("tcl_interp_registry.COMMAND_SIZE out of sync with tcl_ns.tcl_procs_constants.COMMAND_SIZE");

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1104,7 +1104,7 @@ pub const ImportedCmdData = extern struct {
 /// ``comptime`` block that asserts these values stay in sync with its
 /// own canonical ``pub const``s, so any drift becomes a compile error.
 pub const tcl_procs_constants = struct {
-    pub const COMMAND_SIZE: u32 = 44;
+    pub const COMMAND_SIZE: u32 = 52;
     pub const OFF_FLAGS: u32 = 8;
     pub const OFF_PARAMS_OBJ: u32 = 12;
     pub const OFF_IMPORT_REF_HEAD: u32 = 32;

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -98,7 +98,7 @@ const parse_cache = @import("../valtypes/parse_cache.zig");
 //                                         procs.  Set by proc_register_compiled
 //                                         so dispatch() can raise "wrong # args"
 //                                         before calling the compiled WASM fn.)
-pub const COMMAND_SIZE: u32 = 44;
+pub const COMMAND_SIZE: u32 = 52;
 pub const OFF_FLAGS: u32 = 8;
 pub const OFF_PARAMS_OBJ: u32 = 12;
 const OFF_BODY_OBJ: u32 = 16;
@@ -108,6 +108,14 @@ const OFF_ARGS_TAIL: u32 = 28;
 pub const OFF_IMPORT_REF_HEAD: u32 = 32;
 pub const OFF_EXPORT_NAME_BUCKET: u32 = 36;
 const OFF_N_REQUIRED: u32 = 40;
+// Raw (ptr, len) of the source-text params spec.  Used by ``info
+// args`` to materialise a fresh TclObj on demand without retaining
+// anything at module-init time.  Stashed by
+// :func:`proc_set_params_source_raw`.  Pointing at WASM data segment
+// bytes (immutable, owned by the module instance) — no allocation,
+// no refcount.
+const OFF_PARAMS_SRC_PTR: u32 = 44;
+const OFF_PARAMS_SRC_LEN: u32 = 48;
 
 /// Set on imported (redirect) commands.  ``params_obj`` holds an
 /// ``*ImportedCmdData`` pointing at the source ``*Command`` and
@@ -479,6 +487,13 @@ pub export fn proc_register_compiled(
     write_i32(cmd + OFF_FUNC_IDX, func_idx);
     write_i32(cmd + OFF_ARGS_TAIL, args_tail);
     write_i32(cmd + OFF_N_REQUIRED, n_required);
+    // Clear the raw params source slot so a re-registration over an
+    // existing bucket doesn't inherit a stale data-segment pointer
+    // from a previous module instance.  Stamping is handled by
+    // :func:`proc_set_params_source_raw` immediately after this call
+    // when the codegen prologue emits the stash sequence.
+    write_i32(cmd + OFF_PARAMS_SRC_PTR, 0);
+    write_i32(cmd + OFF_PARAMS_SRC_LEN, 0);
 
     // Stash the registration-time WASM export name in the sidecar
     // record at ``OFF_EXPORT_NAME_BUCKET``.  ``tcl_dispatch`` reads
@@ -520,6 +535,63 @@ pub export fn proc_register_compiled(
 /// proc-body bytes) for large bundles like ``tcltest.test``).  We
 /// just retain the TclObj header so refcounting can't reclaim the
 /// slab while the proc table still references it.
+/// Counterpart to :func:`proc_set_body_source` for the params spec.
+/// ``proc_register_compiled`` zeros ``OFF_PARAMS_OBJ`` because the AOT
+/// path doesn't need a runtime params TclObj for dispatch — but
+/// ``info args`` / ``info default`` read this slot and need the
+/// original ``{p1 ?p2default? ... args}`` source list.  Codegen
+/// emits a call to this right after :func:`proc_set_body_source` in
+/// the compiled-proc registration prologue.
+/// Transfer-ownership variant: the caller hands over its rc=1
+/// reference and does **NOT** release after the call.  This sidesteps
+/// the cmdAH-cascade trap that ``tcl_obj_retain`` at module init
+/// triggers (root cause not yet pinned, but the empirical signature
+/// is that even one extra retain per proc-register at init breaks
+/// tcltest's bootstrap ``file mkdir`` — see the codegen comments
+/// for the matching "no caller release" pattern).
+/// Raw-bytes variant of params source stash.  Stores the data-
+/// segment ``(ptr, len)`` of the proc's params spec in
+/// ``OFF_PARAMS_SRC_*`` so ``info args`` / ``info default`` can
+/// materialise a fresh TclObj on demand.  Avoids the
+/// ``tcl_obj_retain`` cascade that hits tcltest's bootstrap when
+/// any extra retain runs at module-init time per proc — the bytes
+/// live in immutable WASM data segments and need neither retain
+/// nor release.
+pub export fn proc_set_params_source_raw(
+    name_ptr: i32,
+    name_len: i32,
+    params_ptr: i32,
+    params_len: i32,
+) i32 {
+    if (name_ptr == 0 or name_len <= 0) return obj_new_int(0);
+    if (params_ptr == 0 or params_len <= 0) return obj_new_int(0);
+    // Look up the proc bucket directly by raw bytes — no TclObj
+    // allocation happens here.  Avoids the cmdAH-cascade trap that
+    // per-proc TclObj allocs at module init trigger.
+    const cmd_addr = tcl_ns.ns_find_command(
+        tcl_ns.ns_current(),
+        @bitCast(name_ptr),
+        @bitCast(name_len),
+    );
+    if (cmd_addr == 0) return obj_new_int(0);
+    const flags: u32 = @bitCast(read_i32(cmd_addr + OFF_FLAGS));
+    const guard_mask: u32 = CMD_IMPORTED | CMD_ALIAS | CMD_INTERP_CHILD |
+        CMD_COROUTINE | CMD_BUILTIN_FORWARD | CMD_BUILTIN_MASKED;
+    if ((flags & guard_mask) != 0) return obj_new_int(0);
+    write_i32(cmd_addr + OFF_PARAMS_SRC_PTR, params_ptr);
+    write_i32(cmd_addr + OFF_PARAMS_SRC_LEN, params_len);
+    return obj_new_int(0);
+}
+
+/// Reader for the raw-bytes params source.  Returns 0/0 when the
+/// proc has no stashed source (interpreted proc, or codegen
+/// skipped the stash because ``params_source`` was empty).
+pub fn proc_get_params_src(bucket: u32) struct { ptr: u32, len: u32 } {
+    const ptr: u32 = @bitCast(read_i32(bucket + OFF_PARAMS_SRC_PTR));
+    const len: u32 = @bitCast(read_i32(bucket + OFF_PARAMS_SRC_LEN));
+    return .{ .ptr = ptr, .len = len };
+}
+
 pub export fn proc_set_body_source(name: i32, body_obj: i32) i32 {
     if (body_obj == 0) return obj_new_int(0);
     const bucket = proc_lookup(name);

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -101,10 +101,10 @@ const parse_cache = @import("../valtypes/parse_cache.zig");
 pub const COMMAND_SIZE: u32 = 52;
 pub const OFF_FLAGS: u32 = 8;
 pub const OFF_PARAMS_OBJ: u32 = 12;
-const OFF_BODY_OBJ: u32 = 16;
-const OFF_N_PARAMS: u32 = 20;
+pub const OFF_BODY_OBJ: u32 = 16;
+pub const OFF_N_PARAMS: u32 = 20;
 pub const OFF_FUNC_IDX: u32 = 24;
-const OFF_ARGS_TAIL: u32 = 28;
+pub const OFF_ARGS_TAIL: u32 = 28;
 pub const OFF_IMPORT_REF_HEAD: u32 = 32;
 pub const OFF_EXPORT_NAME_BUCKET: u32 = 36;
 const OFF_N_REQUIRED: u32 = 40;
@@ -168,6 +168,16 @@ pub const CMD_BUILTIN_FORWARD: u32 = 0x800;
 /// The dispatcher checks this flag BEFORE the BUILTIN lookup so the
 /// mask wins.
 pub const CMD_BUILTIN_MASKED: u32 = 0x1000;
+
+/// Set on a ``Command`` registered as a Tcl 9 ensemble dispatch
+/// command (``namespace ensemble create``).  ``params_obj`` stashes
+/// the ``*EnsembleRec`` (see ``cmds/namespace.zig``) describing the
+/// target namespace, the ``-map`` table, ``-subcommands`` list,
+/// ``-unknown`` handler prefix, ``-parameters`` prefix args, and
+/// ``-prefixes`` flag.  The proc-dispatch fast path consults this
+/// bit before treating the Command as a plain interpreted proc and
+/// hands control to the ensemble subcommand resolver.
+pub const CMD_ENSEMBLE: u32 = 0x2000;
 
 // ``tcl_ns.zig`` keeps a shadow copy of the Command layout constants
 // above because it can't ``@import`` this module without a circular
@@ -277,6 +287,14 @@ fn alloc_command(name_ptr: u32, name_len: u32, hash: u32) u32 {
     write_i32(addr + 4, @bitCast(name_len));
     // flags slot at offset 8 stays zero — set later for imports.
     return addr;
+}
+
+/// Public wrapper used by external command modules that need to
+/// synthesise a fresh Command bucket (e.g. ``namespace ensemble
+/// create``).  Mirrors the internal :func:`alloc_command` shape but
+/// is callable from other Zig modules.
+pub fn alloc_command_export(name_ptr: u32, name_len: u32) u32 {
+    return alloc_command(name_ptr, name_len, 0);
 }
 
 /// Resolve the registered FQN to ``(target_ns, simple_name)`` and

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -279,12 +279,19 @@ fn lru_insert(ns: u32, hash: u32, len: u32, first_byte: u8, cmd: u32) void {
 fn alloc_command(name_ptr: u32, name_len: u32, hash: u32) u32 {
     _ = hash;
     const addr = alloc(COMMAND_SIZE);
+    if (addr == 0) return 0;
     const slice: [*]u8 = @ptrFromInt(addr);
     @memset(slice[0..COMMAND_SIZE], 0);
-    const nbuf = alloc(name_len);
-    if (name_len > 0) memcpy(nbuf, name_ptr, name_len);
-    write_i32(addr, @bitCast(nbuf));
-    write_i32(addr + 4, @bitCast(name_len));
+    if (name_len > 0) {
+        const nbuf = alloc(name_len);
+        if (nbuf == 0) {
+            obj.free_sized(addr, COMMAND_SIZE);
+            return 0;
+        }
+        memcpy(nbuf, name_ptr, name_len);
+        write_i32(addr, @bitCast(nbuf));
+        write_i32(addr + 4, @bitCast(name_len));
+    }
     // flags slot at offset 8 stays zero — set later for imports.
     return addr;
 }

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -453,6 +453,7 @@ comptime {
     _ = &tcl_procs.proc_register;
     _ = &tcl_procs.proc_register_compiled;
     _ = &tcl_procs.proc_set_body_source;
+    _ = &tcl_procs.proc_set_params_source_raw;
     _ = &tcl_procs.proc_lookup;
     _ = &tcl_procs.proc_get_func_idx;
     _ = &tcl_procs.proc_get_n_params;

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1326,6 +1326,10 @@ fn drop_searches_for(name_ptr: u32, name_len: u32) void {
 /// array_unset, traces add).  ``arr`` is the user-visible name —
 /// we normalise it here so the search lookup keys match the form
 /// stored on the record.
+pub fn array_invalidate_searches_for_obj(arr: i32) void {
+    array_invalidate_searches_for(arr);
+}
+
 fn array_invalidate_searches_for(arr: i32) void {
     if (searches_head == 0) return;
     const n = normalize_ns_name(arr);


### PR DESCRIPTION
## Summary

This PR implements two major Tcl 9 features:

### 1. Namespace Ensembles (`namespace ensemble`)
- Adds full support for `namespace ensemble create`, `namespace ensemble exists`, and `namespace ensemble configure`
- Implements the `EnsembleRec` structure to track ensemble metadata (target namespace, `-map` table, `-subcommands`, `-unknown` handler, `-parameters`, `-prefixes`)
- Adds ensemble dispatch routing in the proc call fast path via the `CMD_ENSEMBLE` flag
- Properly handles ensemble cleanup when namespaces are deleted
- Supports `-map` implementation qualification against the target namespace
- Implements ensemble option reading/writing with proper TclObj lifecycle management

### 2. Constant Variables (`const` command, TIP 590)
- Adds `const VARNAME VALUE` command to define read-only constants
- Implements per-frame constant tracking for proc-local constants (via `frame_const_*` side lists)
- Implements namespace-scoped constants via `VAR_CONSTANT` flag on `Var` records
- Adds `info constant NAME` to check if a variable is constant
- Adds `info consts ?pattern?` to enumerate constant variables in current scope
- Properly rejects array elements and enforces read-only semantics

### 3. Supporting Changes
- Extends `Command` structure from 44 to 52 bytes to add `OFF_PARAMS_SRC_PTR` and `OFF_PARAMS_SRC_LEN` fields
- Implements `proc_set_params_source_raw()` to stash raw parameter source for AOT-compiled procs
- Updates `info args` to materialize parameter lists from raw source when needed (for AOT procs without retained TclObj)
- Adds `strip_param_defaults()` to reduce parameter specs to name-only lists
- Implements `_tcl_list_quote()` in codegen to properly quote params in source reconstruction
- Adds parent namespace validation for `array set` to surface proper diagnostics
- Updates trace keyword matching to accept abbreviated forms (`var` for `variable`, etc.)

## Validation

- Existing test suite passes with these changes
- New ensemble and const functionality integrated into command registry
- Proper error handling for edge cases (array elements, missing namespaces, etc.)
- Memory management verified (proper retain/release of TclObj fields in EnsembleRec)

https://claude.ai/code/session_0143FvunTMW4cSuhgTjogcMP