### PR TITLE
Update GitHub Actions dependencies in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,12 +24,12 @@ jobs:
       contents: read
       actions: read             # scorecard inspects workflows
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- Updated `actions/checkout` from v4.2.2 to v5.0.1
- Updated `ossf/scorecard-action` to latest commit hash while maintaining v2.4.3 tag

## Validation

- [ ] Scorecard workflow runs successfully with updated action versions

## Notes

These are routine dependency updates for the GitHub Actions workflow. The changes maintain compatibility with the existing workflow configuration while pulling in the latest versions of the checkout and scorecard analysis actions.

https://claude.ai/code/session_01R7mTT2eEAKY2nrqoZ7Tc94