### PR TITLE
Unblock release: pin ty==0.0.37, bump TS6 eslint, dialect test timeout

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4887,8 +4887,8 @@
     "test:coverage": "mkdir -p ../../tmp/coverage/.v8-coverage-vscode ../../tmp/coverage/vscode && NODE_V8_COVERAGE=../../tmp/coverage/.v8-coverage-vscode node ./out/test/runTest.js && node scripts/coverage-report.cjs"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.46.0",
-    "@typescript-eslint/parser": "^8.46.0",
+    "@typescript-eslint/eslint-plugin": "^8.59.4",
+    "@typescript-eslint/parser": "^8.59.4",
     "@types/vscode": "^1.93.0",
     "@types/node": "^25.8.0",
     "@types/mocha": "^10.0.0",

--- a/editors/vscode/src/test/dialectDetection.test.ts
+++ b/editors/vscode/src/test/dialectDetection.test.ts
@@ -24,7 +24,7 @@ async function waitForCompletions(
   uri: vscode.Uri,
   position: vscode.Position,
   predicate: (labels: string[]) => boolean,
-  timeout = 15_000,
+  timeout = 30_000,
 ): Promise<string[]> {
   const start = Date.now();
   while (Date.now() - start < timeout) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dev = [
     "pytest-cov>=6.0",
     "pytest-xdist>=3.8.0",
     "ruff>=0.11",
-    "ty>=0.0.24,<0.0.38",
+    "ty==0.0.37",
     "wasmtime>=20.0",
     "flask>=3.0",
     # Used by the test-slow TLS / x509 suites that spin up an HTTPS
@@ -90,5 +90,5 @@ output = "tmp/coverage/python/coverage.xml"
 
 [dependency-groups]
 dev = [
-    "ty>=0.0.24,<0.0.38",
+    "ty==0.0.37",
 ]


### PR DESCRIPTION
## Summary
- **Pin `ty==0.0.37`** in both `dev` and `docs` extras. The previous range `>=0.0.24,<0.0.38` let `uv sync` (CI) resolve to `0.0.37` while a stale local `.venv` could remain on `0.0.24`. Those two versions disagree on whether existing `# ty: ignore[...]` directives in `tests/test_*.py` etc. are necessary, so release attempts from a stale venv hit a phantom 27-warning prep-pr failure that didn't reproduce in CI.
- **Bump `@typescript-eslint/eslint-plugin` and `parser` to `^8.59.4`** so a fresh `npm install` in `editors/vscode/` succeeds against `typescript@^6.0.3`. The previously-pinned 8.57.0 capped its `typescript` peer at `<6.0.0`.
- **Raise dialect-test `waitForCompletions` budget 15s → 30s.** CI run [26055185211](https://github.com/bitwisecook/tcl-lsp/actions/runs/26055185211) timed all three `.irul` / `.iapp` / `.tcl` polls out before the config-change notification was processed; a rerun passed cleanly, so the failure was a Linux-runner timing flake, not a regression from #433.

Without these, `/release` is blocked.

## Test plan
- [ ] CI `pr-gate`, `test-py`, `test-ext` green
- [ ] `make prep-pr` passes locally on a fresh `uv sync`
- [ ] `npm install` in `editors/vscode/` succeeds from clean cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)