### PR TITLE
Derive release version from git tags; release flow becomes tag-only

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: release
 description: >
-  Run the full release workflow: validate branch, test, bump version,
-  generate changelog, tag, push, and publish to all editor marketplaces.
-  Asks for patch/minor/major if not specified.
+  Run the full release workflow: validate branch, test, generate changelog,
+  tag, push, and publish to all editor marketplaces. Asks for
+  patch/minor/major if not specified. Tag-only — no source-file edits,
+  no commit on main (main is protected).
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
 # Release
 
 Orchestrates a full release of tcl-lsp. This skill is internal to the project.
+
+The release is **tag-only**: every version literal in the tree is derived
+from the latest annotated tag (via `hatch-vcs` for the Python wheel and via
+the Makefile + `git describe` for every editor build). To cut a release we
+push a `vX.Y.Z` tag — there is no source-file bump and no commit on `main`.
+RELEASE_NOTES.md is the one exception, and it lands via a PR before tagging.
 
 ## Workflow
 
@@ -53,12 +60,10 @@ Then run slow tests:
 make test-slow
 ```
 
-If any test fails, investigate and fix the issue. After fixing, re-run the
-failing target. Once all tests pass, commit fixes and push:
-
-```bash
-git push origin main
-```
+If any test fails, investigate and fix the issue. **Main is protected — push
+fixes via a PR.** Create a fix branch, push, open the PR with `gh pr create`,
+wait for CI green, and ask the user to merge it. Then `git checkout main &&
+git pull origin main` before continuing.
 
 ### 4. Determine version bump
 
@@ -110,21 +115,38 @@ with these sections (omit empty sections):
 ```
 
 Focus on user-visible changes. Group related changes. Use UK spelling. Do not
-list every file touched; summarise the meaningful changes. Commit the file:
+list every file touched; summarise the meaningful changes.
+
+### 6. Land RELEASE_NOTES.md, then tag
+
+Main is protected, so the release-notes commit lands via a PR:
 
 ```bash
+git checkout -b release/vX.Y.Z
 git add RELEASE_NOTES.md
 git commit -m "Add release notes for vX.Y.Z"
+git push -u origin release/vX.Y.Z
+gh pr create --title "Release vX.Y.Z notes" --body "..."
 ```
 
-### 6. Bump version, tag, and push
+Wait for CI on the PR to go green, then ask the user to merge it (squash).
+Once merged, switch back and pull:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+Now create + push the annotated tag. `make release-tag` handles validation
+(clean tree, correct branch, no existing tag) and pushes only the tag —
+no source-file edits, no commit on main:
 
 ```bash
 make release-tag V=X.Y.Z
 ```
 
-This runs `scripts/release.sh` which bumps all version files, commits, creates
-an annotated tag `vX.Y.Z`, and pushes with `--follow-tags`.
+The tag push triggers `.github/workflows/ci.yml` to build artefacts, run
+`publish-checksums`, and publish the GitHub release.
 
 ### 6.5. Verify published artefacts
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ editors/vscode/out/
 editors/vscode/.vscode-test/
 .vscode-test/
 lsp/_build_info.py
+lsp/_version.py
 explorer/static/build_info.json
 uv.lock
 editors/vscode/uv.lock

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,14 @@ GIT_HASH         := $(shell git rev-parse --short HEAD 2>/dev/null || echo unkno
 VERSION          := $(shell echo "$(GIT_DESCRIBE)" | sed 's/^v//')
 SEMVER_VERSION   := $(shell sh -c 'v="$(VERSION)"; if echo "$$v" | grep -Eq "^[0-9]+\\.[0-9]+\\.[0-9]+([-.][0-9A-Za-z.-]+)*$$"; then echo "$$v"; else echo "0.0.0-dev"; fi')
 FULL_VERSION     := $(VERSION)
-# Wheel filename tracks pyproject.toml's [project].version (what `uv build`
-# reads), not the git-describe VERSION above — so that worker.js can discover
-# the wheel at runtime via build_info.json rather than hard-coding a number.
-PYPROJECT_VERSION := $(shell grep -E '^version = ' $(ROOT)pyproject.toml | head -1 | sed 's/.*= *"//;s/".*//')
-WHEEL_FILENAME   := tcl_lsp-$(PYPROJECT_VERSION)-py3-none-any.whl
+# Hatch-vcs version — what ``uv build --wheel`` will embed in the wheel
+# filename and metadata. Identical to SEMVER_VERSION on a tagged commit
+# (e.g. ``1.10.5``) but PEP 440-formatted on dev commits (e.g.
+# ``1.10.5.dev9``), unlike SEMVER_VERSION which falls back to
+# ``0.0.0-dev`` on anything it can't parse. ``scripts/print_version.py``
+# loads hatch-vcs directly so the answer matches the build backend.
+HATCH_VCS_VERSION := $(shell $(UV) run --extra dev python $(ROOT)scripts/print_version.py 2>/dev/null || echo 0.0.0+unknown)
+WHEEL_FILENAME   := tcl_lsp-$(HATCH_VCS_VERSION)-py3-none-any.whl
 BUILD_TIMESTAMP := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Derived paths
@@ -1133,8 +1136,8 @@ jetbrains: $(JB_PLUGIN) ## Build JetBrains plugin (.zip)
 
 $(JB_PLUGIN): $(PY_SRCS) $(BUILD_INFO)
 	@echo "==> Building JetBrains plugin"
-	@# Inject version into gradle.properties
-	$(PYTHON) -c "import re,pathlib; p=pathlib.Path('$(JB_DIR)/gradle.properties'); p.write_text(re.sub(r'^pluginVersion=.*', 'pluginVersion=$(SEMVER_VERSION)', p.read_text(), flags=re.MULTILINE))"
+	@# build.gradle.kts reads RELEASE_VERSION from the environment first, so
+	@# the gradle.properties source file is never mutated by the build.
 	@# Copy shared resources into plugin resources
 	mkdir -p $(JB_DIR)/src/main/resources/syntaxes
 	cp $(EXT_DIR)/syntaxes/tcl.tmLanguage.json $(JB_DIR)/src/main/resources/syntaxes/
@@ -1147,8 +1150,8 @@ $(JB_PLUGIN): $(PY_SRCS) $(BUILD_INFO)
 		const {getWebviewHtml} = require('./out/compilerExplorerHtml'); \
 		require('fs').writeFileSync('$(JB_DIR)/src/main/resources/compilerExplorer.html', getWebviewHtml()); \
 	" 2>/dev/null || echo "(compiler explorer HTML extraction skipped — compile TS first)"
-	@# Build plugin
-	cd $(JB_DIR) && ./gradlew buildPlugin
+	@# Build plugin — pass version via env so build.gradle.kts picks it up
+	cd $(JB_DIR) && RELEASE_VERSION="$(SEMVER_VERSION)" ./gradlew buildPlugin
 	mkdir -p $(BUILD_DIR)
 	cp $(JB_DIR)/build/distributions/tcl-lsp-jetbrains-$(SEMVER_VERSION).zip $(JB_PLUGIN)
 	@echo ""
@@ -1160,7 +1163,7 @@ publish-jetbrains: jetbrains ## Publish JetBrains plugin to JetBrains Marketplac
 	@JETBRAINS_TOKEN="$$(bash $(ROOT)scripts/jetbrains_token.sh)" || exit 1; \
 	export JETBRAINS_TOKEN; \
 	echo "==> Publishing JetBrains plugin to Marketplace"; \
-	cd $(JB_DIR) && ./gradlew publishPlugin
+	cd $(JB_DIR) && RELEASE_VERSION="$(SEMVER_VERSION)" ./gradlew publishPlugin
 
 # Sublime Text package
 

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -4,7 +4,14 @@ plugins {
 }
 
 group = "com.tcllsp"
-version = providers.gradleProperty("pluginVersion").get()
+// Version resolution order:
+//   1. RELEASE_VERSION env var (set by the Makefile from ``git describe``)
+//   2. -PpluginVersion=... command-line override
+//   3. pluginVersion in gradle.properties (always ``0.0.0-dev`` in source)
+// The source file is therefore never mutated by the release flow.
+version = (System.getenv("RELEASE_VERSION")
+    ?: providers.gradleProperty("pluginVersion").orNull
+    ?: "0.0.0-dev")
 
 repositories {
     mavenCentral()

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -1,3 +1,3 @@
-pluginVersion=1.10.4
+pluginVersion=0.0.0-dev
 kotlin.stdlib.default.dependency=false
 org.gradle.jvmargs=-Xmx1g

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "tcl-lsp",
   "displayName": "Tcl/Tk, iRules, EDA-Tools, Expect LSP/MCP",
   "description": "Tcl/Tk, iRules, EDA-Tools, Expect language support with semantic highlighting, diagnostics, optimisations, completions, and more",
-  "version": "1.10.4",
+  "version": "0.0.0-dev",
   "publisher": "bitwisecook",
   "license": "AGPL-3.0-or-later",
   "icon": "docs/icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "tcl-lsp-zed"
-version = "1.10.4"
+version = "0.0.0-dev"
 dependencies = [
  "serde_json",
  "zed_extension_api",

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "tcl-lsp-zed"
-version = "1.10.4"
+# Source literal kept at 0.0.0-dev. The published Zed extension carries the
+# real version via ``extension.toml`` in the staged build (see Makefile
+# target ``zed``); cargo's package version never reaches end users.
+version = "0.0.0-dev"
 edition = "2021"
 
 [lib]

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "tcl-lsp"
 name = "Tcl"
-version = "1.10.4"
+version = "0.0.0-dev"
 schema_version = 1
 authors = ["tcl-lsp contributors"]
 description = "Tcl, iRules, iApps, and TMSH language support via tcl-lsp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tcl-lsp"
-version = "1.10.4"
+dynamic = ["version"]
 description = "A Tcl Language Server Protocol implementation"
 requires-python = ">=3.10"
 dependencies = [
@@ -18,6 +18,11 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.11",
     "ty==0.0.37",
+    # Available at runtime so ``scripts/print_version.py`` can compute the
+    # wheel filename the Makefile expects (hatch-vcs is also a
+    # ``[build-system].requires`` entry — listing it here just makes it
+    # importable from the dev env).
+    "hatch-vcs>=0.5",
     "wasmtime>=20.0",
     "flask>=3.0",
     # Used by the test-slow TLS / x509 suites that spin up an HTTPS
@@ -38,8 +43,24 @@ docs = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# Version comes from the latest annotated git tag (e.g. ``v1.10.5`` → ``1.10.5``).
+# Untagged commits get a PEP 440 dev suffix like ``1.10.5.dev3+ga1b2c3d``. The
+# release flow is therefore tag-only: ``git tag -a vX.Y.Z -m ...`` + push, with
+# no source-file edits needed to bump the version.
+[tool.hatch.version]
+source = "vcs"
+# Drop the local ``+gHASH`` suffix so PEP 440 strict consumers (PyPI,
+# VS Code Marketplace, JetBrains Marketplace) accept the version string.
+# ``guess-next-dev`` (the default scheme) produces e.g. ``1.10.5.dev8``
+# on an untagged commit eight past ``v1.10.4`` — i.e. an in-progress
+# preview of the next release rather than a post-release of the last.
+raw-options = { local_scheme = "no-local-version" }
+
+[tool.hatch.build.hooks.vcs]
+version-file = "lsp/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["lsp", "core", "explorer", "vm", "tclpkg", "f5q"]

--- a/scripts/print_version.py
+++ b/scripts/print_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Print the project version that hatch-vcs would produce for the current tree.
+
+Used by the Makefile so ``WHEEL_FILENAME`` matches the wheel that
+``uv build`` will actually emit (e.g. ``1.10.5`` on a tagged commit,
+``1.10.5.dev9`` nine commits past the last tag).
+
+Falls back to ``0.0.0+unknown`` if hatch-vcs is unavailable or the tree
+has no tags — so the Makefile parse never fails on a fresh clone.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    try:
+        from hatch_vcs.version_source import VCSVersionSource
+    except ImportError:
+        # hatch-vcs is a build-time dep; if it's missing in the host
+        # environment we cannot compute the version — emit a fallback
+        # that's still PEP 440-valid so wheel filenames stay legal.
+        print("0.0.0+unknown")
+        return 0
+
+    config = {
+        "source": "vcs",
+        "raw-options": {"local_scheme": "no-local-version"},
+    }
+    try:
+        version = VCSVersionSource(".", config).get_version_data()["version"]
+    except LookupError:
+        # No tag in history yet (or shallow clone with depth 1 and no
+        # tags); fall back to a stable dev string.
+        print("0.0.0.dev0")
+        return 0
+
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,72 +1,54 @@
 #!/usr/bin/env bash
-# release.sh — bump version across all source files, commit, tag, and push.
+# release.sh — create and push the annotated release tag.
 #
 # Usage:  scripts/release.sh X.Y.Z
 #         make release-tag V=X.Y.Z
+#
+# All version literals in the repo derive from the latest annotated tag
+# (via hatch-vcs for the Python wheel, via the Makefile + ``git describe``
+# for every editor build). A release therefore needs no source-file edits
+# and no commit on ``main``; this script just validates state, tags HEAD,
+# and pushes the tag. The push triggers ``.github/workflows/ci.yml``,
+# which builds + publishes the release artefacts.
 set -euo pipefail
 
 V="${1:?Usage: scripts/release.sh X.Y.Z}"
 
-# Validate
-[[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: '$V' is not a valid version (expected X.Y.Z)"; exit 1; }
-git diff --quiet && git diff --cached --quiet || { echo "error: worktree is dirty — commit or stash first"; exit 1; }
+# Validate the version literal.
+[[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "error: '$V' is not a valid version (expected X.Y.Z)"
+    exit 1
+}
+
+# Refuse to tag a dirty tree — hatch-vcs would otherwise embed a ``+dev``
+# suffix in the wheel built from this commit later.
+git diff --quiet && git diff --cached --quiet || {
+    echo "error: worktree is dirty — commit or stash first"
+    exit 1
+}
+
+# Refuse to tag if the version already exists.
 if git rev-parse "v$V" >/dev/null 2>&1; then
     echo "error: tag v$V already exists"
     exit 1
 fi
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-
-# Platform-portable in-place sed (macOS needs -i '', GNU sed needs -i)
-if [[ "$(uname)" == "Darwin" ]]; then
-    sedi() { sed -i '' "$@"; }
-else
-    sedi() { sed -i "$@"; }
+# Sanity-check the branch — releases are tagged off ``main``. Override by
+# setting ALLOW_NON_MAIN_RELEASE=1 if you need to tag from elsewhere
+# (RC branches, hot-fix branches, etc.).
+branch="$(git branch --show-current)"
+if [[ -n "$branch" && "$branch" != "main" && "${ALLOW_NON_MAIN_RELEASE:-0}" != "1" ]]; then
+    echo "error: refusing to tag from branch '$branch' (expected 'main')."
+    echo "       set ALLOW_NON_MAIN_RELEASE=1 to override."
+    exit 1
 fi
-
-# Bump version in source files
-echo "==> Bumping version to $V"
-
-# pyproject.toml
-sedi "s/^version = \".*\"/version = \"$V\"/" "$ROOT/pyproject.toml"
-
-# editors/vscode/package.json (package-lock.json is gitignored, updated by npm install)
-sedi "s/\"version\": \".*\"/\"version\": \"$V\"/" "$ROOT/editors/vscode/package.json"
-
-# explorer/static/worker.js (wheel filename)
-sedi "s/tcl_lsp-.*-py3-none-any\.whl/tcl_lsp-$V-py3-none-any.whl/" "$ROOT/explorer/static/worker.js"
-
-# editors/zed/Cargo.toml + Cargo.lock (tcl-lsp-zed entry only)
-sedi "s/^version = \".*\"/version = \"$V\"/" "$ROOT/editors/zed/Cargo.toml"
-sedi '/^name = "tcl-lsp-zed"/{n;s/^version = ".*"/version = "'"$V"'"/;}' "$ROOT/editors/zed/Cargo.lock"
-
-# editors/zed/extension.toml
-sedi "s/^version = \".*\"/version = \"$V\"/" "$ROOT/editors/zed/extension.toml"
-
-# editors/jetbrains/gradle.properties (pluginVersion=X.Y.Z-...)
-sedi "s/^pluginVersion=.*/pluginVersion=$V/" "$ROOT/editors/jetbrains/gradle.properties"
-
-# Note: server/server.py version comes from git describe at build time
-# via server/_build_info.py — no source file update needed.
-
-# Commit, tag, push
-echo "==> Committing version bump"
-git add \
-    "$ROOT/pyproject.toml" \
-    "$ROOT/editors/vscode/package.json" \
-    "$ROOT/explorer/static/worker.js" \
-    "$ROOT/editors/zed/Cargo.toml" \
-    "$ROOT/editors/zed/Cargo.lock" \
-    "$ROOT/editors/zed/extension.toml" \
-    "$ROOT/editors/jetbrains/gradle.properties"
-
-git commit -m "Bump version to $V"
 
 echo "==> Creating annotated tag v$V"
 git tag -a "v$V" -m "Release $V"
 
-echo "==> Pushing with tags"
-git push --follow-tags
+echo "==> Pushing tag v$V"
+git push origin "v$V"
 
-echo ""
-echo "Released v$V"
+echo
+echo "Tagged v$V — CI will now build and publish the release artefacts."
+echo "Track the run at: https://github.com/bitwisecook/tcl-lsp/actions"


### PR DESCRIPTION
## Summary

Every version literal in the tree now resolves from the latest annotated git tag (e.g. `v1.10.5` → `1.10.5`; an untagged commit eight past that tag → `1.10.5.dev8`). Cutting a release reduces to `git tag -a vX.Y.Z -m \"Release X.Y.Z\" && git push origin vX.Y.Z` — no source-file bumps, no commit on `main` (which is now protected).

### Mechanism

- **Python**: `pyproject.toml` switches to `dynamic = [\"version\"]` with `hatch-vcs` driving the build backend (`local_scheme = \"no-local-version\"` for PEP 440 strict consumers). `lsp/_version.py` is auto-generated at build and gitignored.
- **Editor source literals** (`editors/vscode/package.json`, `editors/zed/{Cargo.toml,Cargo.lock,extension.toml}`, `editors/jetbrains/gradle.properties`) hold `0.0.0-dev`. Real versions are injected at build time:
  - VSIX: existing `vsce package` stage rewrite already covered this.
  - Zed: target stage-rewrites `extension.toml` with `\$(SEMVER_VERSION)`.
  - JetBrains: `build.gradle.kts` now reads `RELEASE_VERSION` env var first (gradle.properties remains the IDE-run fallback), so `make jetbrains` no longer mutates the committed source.
- **Makefile**: `WHEEL_FILENAME` now derives from `scripts/print_version.py` (a hatch-vcs caller), so it matches whatever wheel name `uv build` emits for the same tree. The previous `PYPROJECT_VERSION` extraction is gone with the literal it scraped.
- **`scripts/release.sh`** is rewritten as tag-only: validate input, refuse to tag a dirty tree or duplicate tag, refuse to tag off non-`main` (override with `ALLOW_NON_MAIN_RELEASE=1`), create the annotated tag, push the tag. The push triggers `.github/workflows/ci.yml` which builds + publishes everything from the tagged ref.
- **`.claude/skills/release/SKILL.md`** is updated to match — fixes via PR, RELEASE_NOTES.md via PR, then a tag-only push.

### Verified locally against a simulated `v1.10.5` tag

- `uv build --wheel` → `tcl_lsp-1.10.5-py3-none-any.whl`
- `make package-vsix` → `tcl-lsp-vscode-1.10.5.vsix` with `\"version\": \"1.10.5\"` in the embedded `package.json`
- `make jetbrains` → `tcl-lsp-jetbrains-1.10.5.zip`; `gradle.properties` untouched in working tree
- `make zed` → `tcl-lsp-zed-1.10.5.zip` with `version = \"1.10.5\"` in the staged `extension.toml`
- `make zipapps sublime smoke-zipapps smoke-vsix` → all artefacts named `*-1.10.5.*`, all smoke checks pass

## Test plan

- [ ] CI `pr-gate`, `test-py`, `test-ext` green
- [ ] Once merged, the next release tag (e.g. v1.10.5) produces correctly-named artefacts on tag push
- [ ] JetBrains plugin published from CI carries the tag's version in its manifest
- [ ] Zed extension archive's bundled `extension.toml` matches the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)