### PR TITLE
jetbrains: auto-restart LSP on settings change; log resolved Python path

### DIFF
--- a/core/analysis/checks/_style.py
+++ b/core/analysis/checks/_style.py
@@ -90,7 +90,16 @@ def check_unbraced_expr(
             start = range_for_diag.start.offset
             end = range_for_diag.end.offset
             if 0 <= start <= end < len(source):
-                text = source[start : end + 1]
+                # The token range stops at the last *content* character;
+                # widen by one when the next char is the matching closing
+                # delimiter of an opening quote/brace so the fix span
+                # covers the entire argument, not just its prefix.
+                raw_end = end + 1
+                if 0 <= start < len(source) and source[start] in ('"', "{"):
+                    close = '"' if source[start] == '"' else "}"
+                    if raw_end < len(source) and source[raw_end] == close:
+                        raw_end += 1
+                text = source[start:raw_end]
             else:
                 text = " ".join(args)
         else:
@@ -100,7 +109,12 @@ def check_unbraced_expr(
             start = range_for_diag.start.offset
             end = range_for_diag.end.offset
             if 0 <= start <= end < len(source):
-                text = source[start : end + 1]
+                raw_end = end + 1
+                if 0 <= start < len(source) and source[start] in ('"', "{"):
+                    close = '"' if source[start] == '"' else "}"
+                    if raw_end < len(source) and source[raw_end] == close:
+                        raw_end += 1
+                text = source[start:raw_end]
 
         # A braced argument is safe
         if _first_token_is_braced(tok):
@@ -272,9 +286,21 @@ def check_unbraced_body(
 
         dangerous = _has_substitution(text, tok)
 
+        # ``args[idx]`` is the *post-substitution* value of the word
+        # (e.g. ``"script"`` for the source ``$script``).  Wrapping that
+        # in braces would silently drop the leading ``$`` and turn a
+        # variable reference into a literal — exactly the bug we're
+        # warning the user about.  Slice the raw source instead so the
+        # replacement preserves the original substitution syntax.
+        raw_end = tok.end.offset + 1
+        if raw_end < len(source) and source[tok.start.offset] in ('"', "{"):
+            close = '"' if source[tok.start.offset] == '"' else "}"
+            if raw_end < len(source) and source[raw_end] == close:
+                raw_end += 1
+        raw_text = source[tok.start.offset:raw_end]
         fix = CodeFix(
             range=range_from_token(tok),
-            new_text="{" + text + "}",
+            new_text="{" + raw_text + "}",
             description="Wrap code block in braces",
         )
 

--- a/core/analysis/checks/_style.py
+++ b/core/analysis/checks/_style.py
@@ -297,7 +297,7 @@ def check_unbraced_body(
             close = '"' if source[tok.start.offset] == '"' else "}"
             if raw_end < len(source) and source[raw_end] == close:
                 raw_end += 1
-        raw_text = source[tok.start.offset:raw_end]
+        raw_text = source[tok.start.offset : raw_end]
         fix = CodeFix(
             range=range_from_token(tok),
             new_text="{" + raw_text + "}",

--- a/core/analysis/checks/_style.py
+++ b/core/analysis/checks/_style.py
@@ -128,13 +128,15 @@ def check_unbraced_expr(
         elif _is_safe_literal(stripped):
             continue
 
-        # Build the fix: wrap in braces. For quoted expr arguments,
-        # drop the outer quotes when bracing (expr "$a == $b" -> {$a == $b}).
+        # Build the fix: wrap in braces. For quoted arguments, drop the
+        # outer quotes when bracing -- otherwise the braces would wrap
+        # the literal ``"..."`` string, turning a multi-word command
+        # body into a single-word command name (or breaking expr's
+        # parse).  Codex caught the W100 if/while case in PR #438.
         fix_text = text
-        if cmd_name == "expr":
-            stripped = text.strip()
-            if len(stripped) >= 2 and stripped[0] == '"' and stripped[-1] == '"':
-                fix_text = stripped[1:-1]
+        stripped = text.strip()
+        if len(stripped) >= 2 and stripped[0] == '"' and stripped[-1] == '"':
+            fix_text = stripped[1:-1]
 
         fix = CodeFix(
             range=range_for_diag,
@@ -298,6 +300,14 @@ def check_unbraced_body(
             if raw_end < len(source) and source[raw_end] == close:
                 raw_end += 1
         raw_text = source[tok.start.offset : raw_end]
+        # Strip outer ``"..."`` quotes before bracing — otherwise the
+        # fix wraps a quoted string and changes a multi-word body into
+        # a single-word command name (e.g. ``eval "puts $x"`` would
+        # become ``eval {"puts $x"}``, which evaluates a single-word
+        # command literally named ``puts <value>``).  Codex caught
+        # this on PR #438.
+        if len(raw_text) >= 2 and raw_text[0] == '"' and raw_text[-1] == '"':
+            raw_text = raw_text[1:-1]
         fix = CodeFix(
             range=range_from_token(tok),
             new_text="{" + raw_text + "}",

--- a/core/analysis/checks/_style.py
+++ b/core/analysis/checks/_style.py
@@ -44,6 +44,37 @@ from ._helpers import (
     _upvar_local_name_args,
 )
 
+
+def _widen_for_close_delim(
+    source: str,
+    start_offset: int,
+    inclusive_end: SourcePosition,
+) -> tuple[int, SourcePosition]:
+    """Widen ``inclusive_end`` by one character when the next char is the
+    matching closing ``"``/``}`` of an opening delimiter at
+    ``source[start_offset]``.
+
+    Returns ``(exclusive_end_offset, new_inclusive_end)``.  When no
+    widening is needed, the inputs are returned unchanged (with the
+    exclusive offset being ``inclusive_end.offset + 1``).  Used by
+    quick-fix builders that previously left a stray closing delimiter
+    in the document because the replacement text spanned the full
+    argument but the fix range stopped one character short (Copilot
+    review, PR #438).
+    """
+    raw_end = inclusive_end.offset + 1
+    if 0 <= start_offset < len(source) and source[start_offset] in ('"', "{"):
+        close = '"' if source[start_offset] == '"' else "}"
+        if raw_end < len(source) and source[raw_end] == close:
+            new_inclusive = SourcePosition(
+                line=inclusive_end.line,
+                character=inclusive_end.character + 1,
+                offset=raw_end,
+            )
+            return raw_end + 1, new_inclusive
+    return raw_end, inclusive_end
+
+
 # W100: Unbraced expr
 
 
@@ -93,12 +124,13 @@ def check_unbraced_expr(
                 # The token range stops at the last *content* character;
                 # widen by one when the next char is the matching closing
                 # delimiter of an opening quote/brace so the fix span
-                # covers the entire argument, not just its prefix.
-                raw_end = end + 1
-                if 0 <= start < len(source) and source[start] in ('"', "{"):
-                    close = '"' if source[start] == '"' else "}"
-                    if raw_end < len(source) and source[raw_end] == close:
-                        raw_end += 1
+                # covers the entire argument, not just its prefix.  Widen
+                # ``range_for_diag.end`` in lockstep — otherwise the
+                # replacement text covers the delimiter but the fix range
+                # doesn't, leaving a stray ``"``/``}`` in the document.
+                raw_end, new_end_pos = _widen_for_close_delim(source, start, range_for_diag.end)
+                if new_end_pos is not range_for_diag.end:
+                    range_for_diag = Range(start=range_for_diag.start, end=new_end_pos)
                 text = source[start:raw_end]
             else:
                 text = " ".join(args)
@@ -109,11 +141,9 @@ def check_unbraced_expr(
             start = range_for_diag.start.offset
             end = range_for_diag.end.offset
             if 0 <= start <= end < len(source):
-                raw_end = end + 1
-                if 0 <= start < len(source) and source[start] in ('"', "{"):
-                    close = '"' if source[start] == '"' else "}"
-                    if raw_end < len(source) and source[raw_end] == close:
-                        raw_end += 1
+                raw_end, new_end_pos = _widen_for_close_delim(source, start, range_for_diag.end)
+                if new_end_pos is not range_for_diag.end:
+                    range_for_diag = Range(start=range_for_diag.start, end=new_end_pos)
                 text = source[start:raw_end]
 
         # A braced argument is safe
@@ -294,11 +324,10 @@ def check_unbraced_body(
         # variable reference into a literal — exactly the bug we're
         # warning the user about.  Slice the raw source instead so the
         # replacement preserves the original substitution syntax.
-        raw_end = tok.end.offset + 1
-        if raw_end < len(source) and source[tok.start.offset] in ('"', "{"):
-            close = '"' if source[tok.start.offset] == '"' else "}"
-            if raw_end < len(source) and source[raw_end] == close:
-                raw_end += 1
+        # ``_widen_for_close_delim`` also widens the corresponding
+        # range end so the fix replaces the closing ``"``/``}`` instead
+        # of leaving it behind in the document.
+        raw_end, fix_end_pos = _widen_for_close_delim(source, tok.start.offset, tok.end)
         raw_text = source[tok.start.offset : raw_end]
         # Strip outer ``"..."`` quotes before bracing — otherwise the
         # fix wraps a quoted string and changes a multi-word body into
@@ -309,7 +338,7 @@ def check_unbraced_body(
         if len(raw_text) >= 2 and raw_text[0] == '"' and raw_text[-1] == '"':
             raw_text = raw_text[1:-1]
         fix = CodeFix(
-            range=range_from_token(tok),
+            range=Range(start=tok.start, end=fix_end_pos),
             new_text="{" + raw_text + "}",
             description="Wrap code block in braces",
         )

--- a/core/analysis/irules_checks.py
+++ b/core/analysis/irules_checks.py
@@ -206,9 +206,28 @@ def check_matchclass(
     if len(args) >= 2 and len(all_tokens) >= 3 and len(arg_tokens) >= 2:
         first_tok = all_tokens[0]
         last_tok = all_tokens[-1]
+        # Token end offsets point at the last *content* character, so a
+        # quoted/braced final argument leaves the closing ``"``/``}``
+        # outside the fix range.  Widen the end by one when the next
+        # source char is the matching delimiter — otherwise applying
+        # the fix leaves a stray delimiter trailing the rewrite
+        # (Copilot review, PR #438).
+        fix_end = last_tok.end
+        next_off = last_tok.end.offset + 1
+        if 0 <= last_tok.start.offset < len(source) and source[last_tok.start.offset] in (
+            '"',
+            "{",
+        ):
+            close = '"' if source[last_tok.start.offset] == '"' else "}"
+            if next_off < len(source) and source[next_off] == close:
+                fix_end = type(last_tok.end)(
+                    line=last_tok.end.line,
+                    character=last_tok.end.character + 1,
+                    offset=next_off,
+                )
         fix_range = Range(
             start=first_tok.start,
-            end=last_tok.end,
+            end=fix_end,
         )
         # ``args[idx]`` holds the *substituted* value of each word.  For
         # ``matchclass $url ::lib`` that gives ``"url"`` instead of

--- a/core/analysis/irules_checks.py
+++ b/core/analysis/irules_checks.py
@@ -49,6 +49,25 @@ def _valid_events_for_command(cmd_name: str, dialect: str) -> list[str]:
     return legality.events_for_command(cmd_name)
 
 
+def _raw_arg_text(source: str, tok: Token) -> str:
+    """Return the raw source slice for an argument token.
+
+    Widens the end offset by one when the next character is the
+    matching closing delimiter of an opening ``"``/``{`` so quoted /
+    braced args round-trip intact.  Used by quick-fix builders that
+    must preserve variable and command substitutions in the original
+    syntax (rather than re-emitting the post-substitution value via
+    ``args[idx]``).
+    """
+    start = tok.start.offset
+    end = tok.end.offset + 1
+    if 0 <= start < len(source) and source[start] in ('"', "{"):
+        close = '"' if source[start] == '"' else "}"
+        if end < len(source) and source[end] == close:
+            end += 1
+    return source[start:end]
+
+
 # IRULE1001: Command invalid/ineffective in this event
 
 
@@ -184,15 +203,21 @@ def check_matchclass(
 
     fixes: tuple[CodeFix, ...] = ()
     # Auto-fix: matchclass <item> <class> → class match <item> equals <class>
-    if len(args) >= 2 and len(all_tokens) >= 3:
+    if len(args) >= 2 and len(all_tokens) >= 3 and len(arg_tokens) >= 2:
         first_tok = all_tokens[0]
         last_tok = all_tokens[-1]
         fix_range = Range(
             start=first_tok.start,
             end=last_tok.end,
         )
-        item = args[0]
-        cls = args[1]
+        # ``args[idx]`` holds the *substituted* value of each word.  For
+        # ``matchclass $url ::lib`` that gives ``"url"`` instead of
+        # ``"$url"`` and the replacement would silently drop the
+        # variable reference (IRULE2001 quick-fix audit, 2026-05).
+        # Pull the raw source slice via the arg token offsets so the
+        # rewrite preserves variable/command substitutions verbatim.
+        item = _raw_arg_text(source, arg_tokens[0])
+        cls = _raw_arg_text(source, arg_tokens[1])
         fixes = (
             CodeFix(
                 range=fix_range,

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/PythonDiscovery.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/PythonDiscovery.kt
@@ -28,7 +28,9 @@ fun discoverPython(configured: String = "auto"): PythonInfo? {
     if (configured.isNotBlank() && configured != "auto") {
         val info = probePython(configured, source = "configured")
         if (info != null) {
-            LOG.info("Python: using configured interpreter: ${info.path} (${info.version})")
+            LOG.info(
+                "Python: using configured interpreter: ${describePath(info.path)} (${info.version})"
+            )
             return info
         }
         LOG.warn("Python: configured interpreter '$configured' not found or below 3.10")
@@ -131,8 +133,52 @@ fun discoverPython(configured: String = "auto"): PythonInfo? {
     }
 
     val best = results.first()
-    LOG.info("Python: discovered ${results.size} interpreters, using ${best.path} (${best.version}, ${best.source})")
+    LOG.info(
+        "Python: discovered ${results.size} interpreters, using " +
+        "${describePath(best.path)} (${best.version}, ${best.source})"
+    )
     return best
+}
+
+/**
+ * Format an interpreter path for log messages. For bare PATH names
+ * (e.g. ``python3.14``) the actual executable is resolved by
+ * ProcessBuilder at spawn time, but for diagnostics it's useful to
+ * show which file on disk the name would resolve to. Returns
+ * ``"<command> (-> <resolved>)"`` when resolution succeeds, otherwise
+ * just the command itself.
+ */
+internal fun describeInterpreter(command: String): String = describePath(command)
+
+private fun describePath(command: String): String {
+    if (command.contains(File.separator)) return command
+    val resolved = resolveOnPath(command) ?: return command
+    return "$command (-> $resolved)"
+}
+
+private fun resolveOnPath(command: String): String? {
+    val pathEnv = System.getenv("PATH") ?: return null
+    val pathSep = System.getProperty("path.separator") ?: ":"
+    val isWindows = System.getProperty("os.name").lowercase().contains("win")
+    val pathExts = if (isWindows) {
+        (System.getenv("PATHEXT") ?: ".EXE;.BAT;.CMD;.COM").split(";")
+    } else {
+        listOf("")
+    }
+    for (dir in pathEnv.split(pathSep)) {
+        if (dir.isBlank()) continue
+        for (ext in pathExts) {
+            val candidate = File(dir, command + ext)
+            if (candidate.isFile && candidate.canExecute()) {
+                return try {
+                    candidate.canonicalPath
+                } catch (_: Exception) {
+                    candidate.absolutePath
+                }
+            }
+        }
+    }
+    return null
 }
 
 private val VERSION_REGEX = Regex("""Python\s+(\d+)\.(\d+)\.(\d+)""")

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/PythonDiscovery.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/PythonDiscovery.kt
@@ -151,7 +151,14 @@ fun discoverPython(configured: String = "auto"): PythonInfo? {
 internal fun describeInterpreter(command: String): String = describePath(command)
 
 private fun describePath(command: String): String {
-    if (command.contains(File.separator)) return command
+    // Anything that looks like a filesystem path (absolute, or contains
+    // either platform's separator) is already self-describing.  We treat
+    // ``\\`` and ``/`` interchangeably so Windows paths spelled
+    // ``C:/Python/python.exe`` aren't misclassified as bare PATH names
+    // and re-resolved against PATH for logging (Copilot review, PR #438).
+    if (command.contains('/') || command.contains('\\') || File(command).isAbsolute) {
+        return command
+    }
     val resolved = resolveOnPath(command) ?: return command
     return "$command (-> $resolved)"
 }
@@ -159,7 +166,11 @@ private fun describePath(command: String): String {
 private fun resolveOnPath(command: String): String? {
     val pathEnv = System.getenv("PATH") ?: return null
     val pathSep = System.getProperty("path.separator") ?: ":"
-    val isWindows = System.getProperty("os.name").lowercase().contains("win")
+    // ``os.name.contains("win")`` matches ``"Darwin"`` (macOS), which
+    // would prevent PATH resolution on macOS and apply Windows-only
+    // ``PATHEXT`` logic to other Unixes.  Match the official prefix
+    // instead (Copilot review, PR #438).
+    val isWindows = System.getProperty("os.name").lowercase().startsWith("windows")
     val pathExts = if (isWindows) {
         (System.getenv("PATHEXT") ?: ".EXE;.BAT;.CMD;.COM").split(";")
     } else {

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
@@ -63,7 +63,7 @@ class TclLspServerDescriptor(project: Project) :
             throw IllegalStateException(msg)
         }
 
-        LOG.info("Production mode: ${python.path} $pyzPath")
+        LOG.info("Production mode: ${describeInterpreter(python.path)} $pyzPath")
         return GeneralCommandLine(python.path, pyzPath)
             .withWorkDirectory(pyzPath.substringBeforeLast(File.separator))
             .withCharset(Charsets.UTF_8)

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -1,12 +1,18 @@
 package com.tcllsp.jetbrains.settings
 
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.ui.TitledSeparator
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.JBUI
+import com.tcllsp.jetbrains.TclLspServerSupportProvider
 import javax.swing.*
+
+private val LOG = Logger.getInstance("com.tcllsp.jetbrains.settings.TclLspSettingsPanel")
 
 class TclLspSettingsPanel {
 
@@ -663,6 +669,12 @@ class TclLspSettingsPanel {
 
     fun apply() {
         val s = TclLspSettings.getInstance()
+        // Capture the pre-apply launch settings so we can detect whether
+        // the LSP server needs to be restarted to pick up a new command
+        // line. Other settings flow through workspace/configuration on
+        // the next request and don't require a restart.
+        val oldPythonPath = s.pythonPath
+        val oldServerPath = s.serverPath
         s.pythonPath = pythonPathField.text
         s.serverPath = serverPathField.text
         s.dialect = TclLspSettings.DIALECT_OPTIONS.getOrNull(dialectCombo.selectedIndex)?.first ?: "tcl8.6"
@@ -868,6 +880,31 @@ class TclLspSettingsPanel {
         s.aiEnabled = aiEnabled.isSelected
         s.aiExtraPrompts = aiExtraPrompts.text
         s.diagnosticsGenericVariablePatterns = genericPatternsField.text
+
+        if (s.pythonPath != oldPythonPath || s.serverPath != oldServerPath) {
+            restartLspServers()
+        }
+    }
+
+    /**
+     * Restart the Tcl LSP server in every open project. Called after
+     * launch-affecting settings change (Python path, server path) so
+     * the user picks up the new command line without restarting the
+     * IDE. Non-launch settings (features, formatting, diagnostics, …)
+     * are sent to the running server via workspace/configuration and
+     * don't need a restart.
+     */
+    @Suppress("UnstableApiUsage")
+    private fun restartLspServers() {
+        for (project in ProjectManager.getInstance().openProjects) {
+            if (project.isDisposed) continue
+            try {
+                LspServerManager.getInstance(project)
+                    .stopAndRestartIfNeeded(TclLspServerSupportProvider::class.java)
+            } catch (e: Exception) {
+                LOG.warn("Failed to restart Tcl LSP server for project ${project.name}", e)
+            }
+        }
     }
 
     fun reset() {


### PR DESCRIPTION
Two fixes targeting the IDE-startup user experience surfaced in the
2026-05-18 web sessions:

1. **Restart LSP server when launch settings change.** Changing
   ``Settings -> Tools -> Tcl Language Server -> Python path`` (or
   server path) previously required restarting the IDE before the new
   command line was used.  ``TclLspSettingsPanel.apply()`` now captures
   the pre-apply ``pythonPath`` / ``serverPath`` and, if either changed,
   calls ``LspServerManager.stopAndRestartIfNeeded`` on every open
   project so the next request spawns the new interpreter.  Other
   settings flow to the running server via ``workspace/configuration``
   on the next exchange and don't need a restart.

2. **Log the resolved interpreter path.**  After d612e68 the discovery
   log just prints the bare PATH name (``python3.14``) because
   ``ProcessBuilder`` resolves it at spawn time.  That's correct for
   spawn but unhelpful for diagnostics — the user can't tell which
   ``python3.14`` on PATH is being picked up.  ``describeInterpreter``
   resolves the bare name against ``PATH`` (honouring ``PATHEXT`` on
   Windows) purely for logging, producing
   ``python3.14 (-> /usr/bin/python3.14)``.  The spawn path is
   unchanged.