### PR TITLE
Add CodeQL security gate to release process

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -117,7 +117,7 @@ with these sections (omit empty sections):
 Focus on user-visible changes. Group related changes. Use UK spelling. Do not
 list every file touched; summarise the meaningful changes.
 
-### 6. Land RELEASE_NOTES.md, then tag
+### 6. Land RELEASE_NOTES.md via PR
 
 Main is protected, so the release-notes commit lands via a PR:
 
@@ -137,9 +137,38 @@ git checkout main
 git pull origin main
 ```
 
-Now create + push the annotated tag. `make release-tag` handles validation
-(clean tree, correct branch, no existing tag) and pushes only the tag —
-no source-file edits, no commit on main:
+### 7. Security gate (CodeQL on tag candidate)
+
+CodeQL is the release gate, not a pre-merge PR check. After pulling the
+merged release-notes commit, HEAD on `main` is the commit the tag will
+point at. Wait for CodeQL on that commit and verify no open high/critical
+alerts remain on `main`:
+
+```bash
+tag_sha="$(git rev-parse HEAD)"
+make release-codeql-gate SHA="$tag_sha"
+```
+
+`release-codeql-gate` runs `scripts/release_codeql_gate.sh`, which:
+
+1. Locates the push-triggered CodeQL run for `$tag_sha` (polling for up to
+   2 min; dispatches `workflow_dispatch` as a fallback if none appears).
+2. Watches the run with `gh run watch --exit-status` and fails if it does
+   not succeed.
+3. Queries the Code Scanning API for open alerts on `refs/heads/main` and
+   fails if any have `security_severity_level` of `high` or `critical`.
+
+If the gate fails, **do not tag**. Investigate the alerts, fix or dismiss
+them via PR (dismissals must include a justification), pull `main` again,
+and re-run the gate. Override the severity threshold only with strong
+justification by setting `CODEQL_GATE_MIN_SEVERITY=critical` in the
+environment.
+
+### 8. Create and push the tag
+
+`make release-tag` handles validation (clean tree, correct branch, no
+existing tag) and pushes only the tag — no source-file edits, no commit on
+main:
 
 ```bash
 make release-tag V=X.Y.Z
@@ -148,7 +177,7 @@ make release-tag V=X.Y.Z
 The tag push triggers `.github/workflows/ci.yml` to build artefacts, run
 `publish-checksums`, and publish the GitHub release.
 
-### 6.5. Verify published artefacts
+### 9. Verify published artefacts
 
 After `make release-tag` pushes the tag, CI builds and uploads every
 artefact, then the `publish-checksums` job aggregates them into a
@@ -158,7 +187,7 @@ installer (`scripts/install.sh`) verifies downloads against this file.
 **Wait for CI to finish, then verify locally** before publishing to any
 editor marketplace. A SUMS mismatch means an artefact was modified
 after upload or the build was non-reproducible — either way, **do not
-proceed to step 7**.
+proceed to step 10**.
 
 ```bash
 tag="vX.Y.Z"
@@ -215,9 +244,9 @@ job. The post-install checks above catch the next failure modes after
 that: a successfully-completed installer that nevertheless landed
 stale or version-skewed binaries (e.g. cached artefact, partial
 upload, dev build leaking through). All checks must pass before
-step 7.
+step 10.
 
-### 7. Editor publishing
+### 10. Editor publishing
 
 Before asking which editors to publish, run a readiness check so any
 missing token or unclaimed namespace surfaces *before* the user picks
@@ -282,7 +311,7 @@ external repositories — any external-repo PR (JetBrains first-time
 upload, Package Control channel submission, Zed extensions registry,
 nvim-lspconfig, Helix) is raised by the user.
 
-### 8. Summary
+### 11. Summary
 
 Print a summary of what was done:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,14 +13,24 @@ name: CodeQL
 # `zed_extension_api`, with a small attack surface; the cost-benefit
 # of fighting CodeQL Rust's wasm-target handling isn't there yet.
 # Revisit when CodeQL Rust supports `build-mode: none` GA.
+#
+# Triggers:
+#   - push to main: continuous analysis of trunk after every merge.  The
+#     release skill (see `.claude/skills/release/SKILL.md`) waits for
+#     these runs to finish on the release-notes commit and on the
+#     version-bump commit, and refuses to tag if any open alert on main
+#     has security-severity high/critical.  That is the actual security
+#     gate — CodeQL is no longer a pre-merge PR check.
+#   - workflow_dispatch: lets the release skill (or a maintainer) force
+#     a re-run on the current HEAD if the push-triggered run was missed
+#     or cancelled by concurrency.
+#   - schedule: weekly scan picks up newly-published advisories against
+#     dependencies that haven't otherwise changed.
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
   schedule:
-    # Weekly scan picks up newly-published advisories against deps that
-    # haven't otherwise changed.
     - cron: "37 6 * * 1"
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,12 +15,12 @@ name: CodeQL
 # Revisit when CodeQL Rust supports `build-mode: none` GA.
 #
 # Triggers:
-#   - push to main: continuous analysis of trunk after every merge.  The
-#     release skill (see `.claude/skills/release/SKILL.md`) waits for
-#     these runs to finish on the release-notes commit and on the
-#     version-bump commit, and refuses to tag if any open alert on main
-#     has security-severity high/critical.  That is the actual security
-#     gate — CodeQL is no longer a pre-merge PR check.
+#   - push to main: continuous analysis of trunk after every merge.
+#     Releases are tag-only (see `scripts/release.sh`); the release
+#     skill (`.claude/skills/release/SKILL.md`) waits for the run on
+#     the tag-candidate commit and refuses to tag if any open alert on
+#     main has security-severity high/critical.  That is the actual
+#     security gate — CodeQL is no longer a pre-merge PR check.
 #   - workflow_dispatch: lets the release skill (or a maintainer) force
 #     a re-run on the current HEAD if the push-triggered run was missed
 #     or cancelled by concurrency.

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@
 #   make sublime       Build the Sublime Text package (.sublime-package)
 #   make zed           Build the Zed extension archive (.tar.gz)
 #   make screenshots   Capture extension screenshots and build demo GIF (macOS)
-#   make release       Build all release artifacts (parity with tagged CI release jobs)
-#   make release-tag   Bump version, tag, and push (V=x.y.z)
+#   make release             Build all release artifacts (parity with tagged CI release jobs)
+#   make release-tag         Create + push the annotated release tag (V=x.y.z)
+#   make release-codeql-gate Wait for CodeQL on a commit and block on open high/critical alerts (SHA=<sha>)
 #   make coverage      Generate all coverage reports (Python + VS Code)
 #   make coverage-py   Run Python tests with coverage (HTML + XML in tmp/coverage/python/)
 #   make coverage-ext  Run VS Code extension tests with coverage (HTML in tmp/coverage/vscode/)
@@ -135,7 +136,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 
 # Main targets
 
-.PHONY: vsix verify-vsix install publish-vsix publish-jetbrains publish-sublime publish-zed publish-all publish-verify test test-py test-slow test-opt test-ext test-emacs test-zig test-rust lint lint-py typecheck-py typecheck-py-full lint-ts format format-py format-ts typecheck-ts npm-env compile clean distclean help explorer-build explorer-build-cdn compiler-explorer-gui zipapp-tcl zipapp-cli zipapp-f5 zipapp-gui zipapp-gui-cdn zipapp-lsp zipapp-ai zipapp-mcp zipapp-wasm zipapps claude-skills package-vsix jetbrains sublime zed release release-tag build-info screenshot screenshots clean-screenshots prep-pr smoke-zipapps smoke-vsix copy-canonical coverage coverage-py coverage-ext generate check-generated ci-fast check-all check-zig check-rust install-hooks capture-bytecode-refs ensure-test-deps ensure-python-test-deps ensure-tcl-deps ensure-check-zig-deps ensure-test-zig-deps ensure-rust-deps ensure-emacs-deps ensure-vscode-test-deps .FORCE
+.PHONY: vsix verify-vsix install publish-vsix publish-jetbrains publish-sublime publish-zed publish-all publish-verify test test-py test-slow test-opt test-ext test-emacs test-zig test-rust lint lint-py typecheck-py typecheck-py-full lint-ts format format-py format-ts typecheck-ts npm-env compile clean distclean help explorer-build explorer-build-cdn compiler-explorer-gui zipapp-tcl zipapp-cli zipapp-f5 zipapp-gui zipapp-gui-cdn zipapp-lsp zipapp-ai zipapp-mcp zipapp-wasm zipapps claude-skills package-vsix jetbrains sublime zed release release-tag release-codeql-gate build-info screenshot screenshots clean-screenshots prep-pr smoke-zipapps smoke-vsix copy-canonical coverage coverage-py coverage-ext generate check-generated ci-fast check-all check-zig check-rust install-hooks capture-bytecode-refs ensure-test-deps ensure-python-test-deps ensure-tcl-deps ensure-check-zig-deps ensure-test-zig-deps ensure-rust-deps ensure-emacs-deps ensure-vscode-test-deps .FORCE
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
@@ -1267,8 +1268,11 @@ release-sums: zipapp-cli zipapp-tcl zipapp-f5 zipapp-gui-cdn zipapp-lsp zipapp-m
 	    fi
 	@echo "Wrote $(BUILD_DIR)/SHA256SUMS"
 
-release-tag: ## Bump version, annotated-tag, and push (V=x.y.z)
+release-tag: ## Create + push the annotated release tag (V=x.y.z); run release-codeql-gate first
 	@bash $(ROOT)scripts/release.sh $(V)
+
+release-codeql-gate: ## Wait for CodeQL on a commit and block on open high/critical alerts (SHA=<sha>)
+	@bash $(ROOT)scripts/release_codeql_gate.sh $(SHA)
 
 publish-all: publish-vsix publish-jetbrains publish-sublime publish-zed ## Publish to all editor marketplaces
 

--- a/scripts/release_codeql_gate.sh
+++ b/scripts/release_codeql_gate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# release_codeql_gate.sh — block a release until CodeQL has finished
+# cleanly on a given commit and no open high/critical alerts remain on
+# the target ref.
+#
+# Usage:  scripts/release_codeql_gate.sh <commit-sha> [ref]
+#
+# The release skill calls this twice: once after pushing the release-
+# notes commit, and again after pushing the version-bump commit.  The
+# CodeQL workflow runs automatically on push to main, so the script
+# normally just locates the existing run and waits for it.  If no run
+# is found within ~2 min the script falls back to `workflow_dispatch`
+# so a missed run (cancelled by concurrency, infra hiccup) doesn't
+# silently skip the gate.
+#
+# Exit codes:
+#   0  CodeQL run succeeded and no open high/critical alerts on ref
+#   1  CodeQL run failed, was cancelled, or open high/critical alerts exist
+#   2  Could not locate or dispatch a run within the timeout
+set -euo pipefail
+
+SHA="${1:?usage: $0 <commit-sha> [ref]}"
+REF="${2:-refs/heads/main}"
+REPO="${GH_REPO:-bitwisecook/tcl-lsp}"
+WORKFLOW="codeql.yml"
+
+# Severity threshold honoured by the alert check.  "high" blocks on
+# both high and critical; "critical" blocks only on critical.  Set
+# CODEQL_GATE_MIN_SEVERITY=critical to relax temporarily.
+MIN_SEVERITY="${CODEQL_GATE_MIN_SEVERITY:-high}"
+
+case "$MIN_SEVERITY" in
+    critical)         SEVERITY_FILTER='.rule.security_severity_level == "critical"' ;;
+    high|*)           SEVERITY_FILTER='.rule.security_severity_level == "high" or .rule.security_severity_level == "critical"' ;;
+esac
+
+require_gh() {
+    command -v gh >/dev/null 2>&1 || { echo "error: gh CLI required" >&2; exit 2; }
+    gh auth status >/dev/null 2>&1 || { echo "error: gh CLI not authenticated" >&2; exit 2; }
+}
+
+find_run() {
+    gh run list \
+        --repo "$REPO" \
+        --workflow "$WORKFLOW" \
+        --commit "$SHA" \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId // empty'
+}
+
+wait_for_run_to_appear() {
+    local run_id=""
+    local i
+    for i in $(seq 1 12); do
+        run_id="$(find_run)"
+        [ -n "$run_id" ] && { printf '%s' "$run_id"; return 0; }
+        sleep 10
+    done
+    return 1
+}
+
+main() {
+    require_gh
+
+    echo "==> CodeQL gate for $SHA (ref $REF, repo $REPO)"
+
+    local run_id
+    if ! run_id="$(wait_for_run_to_appear)"; then
+        echo "    no push-triggered run found after 2 min; dispatching workflow_dispatch"
+        gh workflow run "$WORKFLOW" --repo "$REPO" --ref main
+        if ! run_id="$(wait_for_run_to_appear)"; then
+            echo "ERROR: could not locate a CodeQL run for $SHA after dispatch" >&2
+            exit 2
+        fi
+    fi
+
+    echo "    watching run $run_id"
+    if ! gh run watch --repo "$REPO" "$run_id" --exit-status; then
+        echo "ERROR: CodeQL run $run_id did not succeed; release blocked" >&2
+        exit 1
+    fi
+
+    echo "==> Checking open CodeQL alerts on $REF (threshold: $MIN_SEVERITY)"
+    local alerts_json
+    alerts_json="$(gh api --paginate \
+        "/repos/$REPO/code-scanning/alerts?state=open&tool_name=CodeQL&per_page=100")"
+
+    local matching
+    matching="$(printf '%s' "$alerts_json" | \
+        jq "[.[] | select(.most_recent_instance.ref == \"$REF\") | select($SEVERITY_FILTER)]")"
+
+    local count
+    count="$(printf '%s' "$matching" | jq 'length')"
+
+    if [ "$count" -gt 0 ]; then
+        echo "ERROR: $count open CodeQL alert(s) at $MIN_SEVERITY+ on $REF; release blocked" >&2
+        printf '%s' "$matching" | jq -r '.[] |
+            "  #\(.number)  \(.rule.id)  [\(.rule.security_severity_level)]  \(.html_url)"' >&2
+        echo >&2
+        echo "Resolve the alerts (fix or dismiss with justification) and re-run the release." >&2
+        exit 1
+    fi
+
+    echo "    no open alerts at $MIN_SEVERITY+ on $REF"
+    echo "==> CodeQL gate passed for $SHA"
+}
+
+main "$@"

--- a/scripts/release_codeql_gate.sh
+++ b/scripts/release_codeql_gate.sh
@@ -1,26 +1,30 @@
 #!/usr/bin/env bash
 # release_codeql_gate.sh — block a release until CodeQL has finished
 # cleanly on a given commit and no open high/critical alerts remain on
-# the target ref.
+# main.
 #
-# Usage:  scripts/release_codeql_gate.sh <commit-sha> [ref]
+# Usage:  scripts/release_codeql_gate.sh <commit-sha>
 #
-# The release skill calls this twice: once after pushing the release-
-# notes commit, and again after pushing the version-bump commit.  The
-# CodeQL workflow runs automatically on push to main, so the script
-# normally just locates the existing run and waits for it.  If no run
-# is found within ~2 min the script falls back to `workflow_dispatch`
-# so a missed run (cancelled by concurrency, infra hiccup) doesn't
-# silently skip the gate.
+# The release skill calls this once, against HEAD of main after the
+# RELEASE_NOTES.md PR has merged — that is the commit the tag will
+# point at.  The CodeQL workflow runs automatically on push to main,
+# so the script normally just locates the existing run and waits for
+# it.  If no run is found within ~2 min the script falls back to
+# `workflow_dispatch` so a missed run (cancelled by concurrency, infra
+# hiccup) doesn't silently skip the gate.
+#
+# Releases are tag-only off main; the gate (and the dispatch fallback)
+# is hardcoded to `refs/heads/main` to match.
 #
 # Exit codes:
-#   0  CodeQL run succeeded and no open high/critical alerts on ref
+#   0  CodeQL run succeeded and no open high/critical alerts on main
 #   1  CodeQL run failed, was cancelled, or open high/critical alerts exist
-#   2  Could not locate or dispatch a run within the timeout
+#   2  gh or jq missing/unauthenticated, or could not locate/dispatch
+#      a run within the timeout
 set -euo pipefail
 
-SHA="${1:?usage: $0 <commit-sha> [ref]}"
-REF="${2:-refs/heads/main}"
+SHA="${1:?usage: $0 <commit-sha>}"
+REF="refs/heads/main"
 REPO="${GH_REPO:-bitwisecook/tcl-lsp}"
 WORKFLOW="codeql.yml"
 
@@ -34,8 +38,9 @@ case "$MIN_SEVERITY" in
     high|*)           SEVERITY_FILTER='.rule.security_severity_level == "high" or .rule.security_severity_level == "critical"' ;;
 esac
 
-require_gh() {
+require_deps() {
     command -v gh >/dev/null 2>&1 || { echo "error: gh CLI required" >&2; exit 2; }
+    command -v jq >/dev/null 2>&1 || { echo "error: jq required" >&2; exit 2; }
     gh auth status >/dev/null 2>&1 || { echo "error: gh CLI not authenticated" >&2; exit 2; }
 }
 
@@ -61,7 +66,7 @@ wait_for_run_to_appear() {
 }
 
 main() {
-    require_gh
+    require_deps
 
     echo "==> CodeQL gate for $SHA (ref $REF, repo $REPO)"
 
@@ -82,13 +87,17 @@ main() {
     fi
 
     echo "==> Checking open CodeQL alerts on $REF (threshold: $MIN_SEVERITY)"
-    local alerts_json
-    alerts_json="$(gh api --paginate \
-        "/repos/$REPO/code-scanning/alerts?state=open&tool_name=CodeQL&per_page=100")"
-
+    # `gh api --paginate` emits one JSON document per page, not a single
+    # combined array — `jq -s` slurps every page into one array, and
+    # `.[][]` flattens to the full alert stream.  Filtering inside one
+    # jq invocation guarantees the count below is a single integer; the
+    # naive `gh --paginate | jq length` form produces one count per
+    # page, which would crash `[ "$count" -gt 0 ]` and silently fall
+    # through to the success path (CVE-grade failure mode for a gate).
     local matching
-    matching="$(printf '%s' "$alerts_json" | \
-        jq "[.[] | select(.most_recent_instance.ref == \"$REF\") | select($SEVERITY_FILTER)]")"
+    matching="$(gh api --paginate \
+        "/repos/$REPO/code-scanning/alerts?state=open&tool_name=CodeQL&per_page=100" \
+        | jq -s "[.[][] | select(.most_recent_instance.ref == \"$REF\") | select($SEVERITY_FILTER)]")"
 
     local count
     count="$(printf '%s' "$matching" | jq 'length')"


### PR DESCRIPTION
## Summary

Implements a security gate for releases that blocks tagging until CodeQL analysis completes successfully on the release candidate commit and no open high/critical alerts remain on `main`.

**Changes:**

- **New script** `scripts/release_codeql_gate.sh`: Orchestrates the CodeQL gate by:
  - Locating the push-triggered CodeQL run for a given commit (with 2-min polling + fallback `workflow_dispatch`)
  - Waiting for the run to complete with `gh run watch --exit-status`
  - Querying the Code Scanning API for open alerts on `main` and failing if any have `security_severity_level` of `high` or `critical`
  - Supporting `CODEQL_GATE_MIN_SEVERITY` environment variable to override the threshold

- **Updated CodeQL workflow** (`.github/workflows/codeql.yml`):
  - Removed `pull_request` trigger (CodeQL is no longer a pre-merge check)
  - Added `workflow_dispatch` trigger (allows manual re-runs if push-triggered run is missed)
  - Kept `push` to `main` (continuous analysis after every merge) and `schedule` (weekly advisory scan)
  - Added documentation explaining the new release-gate role

- **Updated release skill documentation** (`.claude/skills/release/SKILL.md`):
  - Inserted new step 7 "Security gate (CodeQL on tag candidate)" between landing release notes and creating the tag
  - Renumbered subsequent steps (8→10, 7→11)
  - Documented the gate workflow, failure modes, and override mechanism

- **Updated Makefile**:
  - Added `release-codeql-gate` target that invokes the script with `SHA` parameter
  - Updated help text to clarify `release-tag` and document the new target

## Validation

- No automated tests needed; this is a release process enhancement
- The script uses standard `gh` CLI commands with proper error handling and exit codes
- Workflow trigger changes are configuration-only and will be validated by CI on merge

## Notes

The gate is intentionally placed *after* the release-notes PR merges but *before* tagging, ensuring the commit that will be tagged has passed CodeQL analysis. The fallback `workflow_dispatch` mechanism handles edge cases where the push-triggered run is cancelled by concurrency or infrastructure issues.

https://claude.ai/code/session_01GcMFey6WBXBCkA9WErdZRh