### PR TITLE
Fix WASM string.test failures: Tcl 9 string semantics gaps

### DIFF
--- a/core/commands/registry/tcl/const_fold.py
+++ b/core/commands/registry/tcl/const_fold.py
@@ -485,10 +485,29 @@ def fold_string_wordstart(args: tuple[str, ...]) -> str | None:
 
 
 def fold_dict_create(args: tuple[str, ...]) -> str | None:
-    """``dict create ?key value ...?``"""
+    """``dict create ?key value ...?`` — canonicalise duplicate keys.
+
+    Tcl 9's ``Tcl_DictObjPut`` (tclDictObj.c) replaces the value on a
+    duplicate key while preserving the key's original insertion
+    position.  So ``dict create a X b Y a Z`` produces the canonical
+    rep ``a Z b Y`` — one ``a`` entry with the last-wins value.
+    Mirror that here so ``string map [dict create ...]`` walks the
+    deduplicated list and returns the expected ``ZZZ`` rather than the
+    first-occurrence ``XXX`` (string-10.20.1).
+    """
     if len(args) & 1:
         return None
-    return " ".join(args)
+    canon: list[str] = []
+    key_pos: dict[str, int] = {}
+    for i in range(0, len(args), 2):
+        k, v = args[i], args[i + 1]
+        if k in key_pos:
+            canon[key_pos[k] + 1] = v
+        else:
+            key_pos[k] = len(canon)
+            canon.append(k)
+            canon.append(v)
+    return " ".join(canon)
 
 
 def fold_dict_exists(args: tuple[str, ...]) -> str | None:

--- a/core/compiler/codegen/wasm/_emitter/_values.py
+++ b/core/compiler/codegen/wasm/_emitter/_values.py
@@ -914,7 +914,26 @@ class _WasmEmitterValuesMixin(_Base):
                     and a not in self._local_index
                     for a in kv
                 ):
-                    self._emit_obj_literal(" ".join(kv))
+                    # Canonicalise duplicate keys to match Tcl 9
+                    # ``Tcl_DictObjPut`` semantics (last-wins value,
+                    # preserved insertion position).  See
+                    # ``cmds/dict_.py::_emit_dict`` for the rationale —
+                    # string-10.20.1 expects ``string map [dict create
+                    # a X b Y a Z] aaa`` → ``ZZZ`` (via ``a Z b Y``),
+                    # not ``XXX`` (via the raw ``a X b Y a Z`` list).
+                    canon: list[str] = []
+                    key_pos: dict[str, int] = {}
+                    wi = 0
+                    while wi + 1 < len(kv):
+                        k, v = kv[wi], kv[wi + 1]
+                        if k in key_pos:
+                            canon[key_pos[k] + 1] = v
+                        else:
+                            key_pos[k] = len(canon)
+                            canon.append(k)
+                            canon.append(v)
+                        wi += 2
+                    self._emit_obj_literal(" ".join(canon))
                     return
                 lappend_idx = self._shared_imports.get("tcl_lappend")
                 if lappend_idx is None:
@@ -989,8 +1008,17 @@ class _WasmEmitterValuesMixin(_Base):
                 if sub_args and _looks_like_string_option(sub_args[0]):
                     self._emit_eval_fallback("string", cmd_args, script_override=cmd_text)
                     return
-                func_idx = self._shared_imports[sri.import_key]
+                # Over-arity: ``string totitle X first last`` / ``string
+                # toupper X first last`` / ``string tolower X first last``
+                # carry codepoint range bounds that the 1-param runtime
+                # import cannot see.  Route to eval-fallback so the
+                # ``cmds/string.zig`` dispatcher reaches the ``_range``
+                # variant (string-17.9).
                 param_count = len(sri.params)
+                if len(sub_args) > param_count:
+                    self._emit_eval_fallback("string", cmd_args, script_override=cmd_text)
+                    return
+                func_idx = self._shared_imports[sri.import_key]
                 for i in range(min(param_count, len(sub_args))):
                     self._emit_value(sub_args[i])
                 for _ in range(param_count - len(sub_args)):

--- a/core/compiler/codegen/wasm/_emitter/_values.py
+++ b/core/compiler/codegen/wasm/_emitter/_values.py
@@ -906,7 +906,12 @@ class _WasmEmitterValuesMixin(_Base):
                 if not kv:
                     self._emit_obj_literal("")
                     return
-                if all(
+                # Odd arity → ``wrong # args``; fall through to the
+                # eval fallback so the runtime dispatcher raises the
+                # canonical message rather than the literal fast path
+                # silently dropping the trailing key (Copilot review on
+                # PR #443).
+                if len(kv) % 2 == 0 and all(
                     not a.startswith("$")
                     and not a.startswith("[")
                     and not self._has_embedded_subst(a)
@@ -923,8 +928,7 @@ class _WasmEmitterValuesMixin(_Base):
                     # not ``XXX`` (via the raw ``a X b Y a Z`` list).
                     canon: list[str] = []
                     key_pos: dict[str, int] = {}
-                    wi = 0
-                    while wi + 1 < len(kv):
+                    for wi in range(0, len(kv), 2):
                         k, v = kv[wi], kv[wi + 1]
                         if k in key_pos:
                             canon[key_pos[k] + 1] = v
@@ -932,7 +936,6 @@ class _WasmEmitterValuesMixin(_Base):
                             key_pos[k] = len(canon)
                             canon.append(k)
                             canon.append(v)
-                        wi += 2
                     self._emit_obj_literal(" ".join(canon))
                     return
                 lappend_idx = self._shared_imports.get("tcl_lappend")

--- a/core/compiler/codegen/wasm/_emitter/cmds/dict_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/dict_.py
@@ -105,7 +105,27 @@ def _emit_dict(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: E
             and a not in emitter._local_index
             for a in kv
         ):
-            emitter._emit_obj_literal(" ".join(kv))
+            # Canonicalise duplicate keys at compile time so the literal
+            # string rep matches Tcl 9's ``Tcl_DictObjPut`` semantics —
+            # later occurrences of the same key REPLACE the value, while
+            # the key's insertion position is preserved (tclDictObj.c).
+            # Without this, ``string map [dict create a X b Y a Z] aaa``
+            # walks the literal ``a X b Y a Z`` list and uses the first
+            # ``a→X`` mapping; Tcl 9 expects last-wins (``a→Z``) because
+            # the canonical dict has only one ``a`` entry.
+            canon: list[str] = []
+            key_pos: dict[str, int] = {}
+            wi = 0
+            while wi + 1 < len(kv):
+                k, v = kv[wi], kv[wi + 1]
+                if k in key_pos:
+                    canon[key_pos[k] + 1] = v
+                else:
+                    key_pos[k] = len(canon)
+                    canon.append(k)
+                    canon.append(v)
+                wi += 2
+            emitter._emit_obj_literal(" ".join(canon))
             if defs:
                 def_idx = emitter._intern_local(defs[0])
                 emitter._emit_local_set(def_idx)

--- a/core/compiler/codegen/wasm/_emitter/cmds/dict_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/dict_.py
@@ -97,7 +97,12 @@ def _emit_dict(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: E
             else:
                 emitter._emit(WasmOp.DROP)
             return True
-        if all(
+        # Odd arity is a ``wrong # args`` error in Tcl 9 — fall through
+        # to the eval-fallback path so the runtime dispatcher in
+        # ``cmds/dict.zig::eval_dict_create`` raises the canonical
+        # message rather than the compile-time fast path silently
+        # dropping the trailing key (Copilot review on PR #443).
+        if len(kv) % 2 == 0 and all(
             not a.startswith("$")
             and not a.startswith("[")
             and not emitter._has_embedded_subst(a)
@@ -115,8 +120,7 @@ def _emit_dict(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: E
             # the canonical dict has only one ``a`` entry.
             canon: list[str] = []
             key_pos: dict[str, int] = {}
-            wi = 0
-            while wi + 1 < len(kv):
+            for wi in range(0, len(kv), 2):
                 k, v = kv[wi], kv[wi + 1]
                 if k in key_pos:
                     canon[key_pos[k] + 1] = v
@@ -124,7 +128,6 @@ def _emit_dict(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: E
                     key_pos[k] = len(canon)
                     canon.append(k)
                     canon.append(v)
-                wi += 2
             emitter._emit_obj_literal(" ".join(canon))
             if defs:
                 def_idx = emitter._intern_local(defs[0])

--- a/core/compiler/codegen/wasm/_emitter/cmds/string_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/string_.py
@@ -105,8 +105,20 @@ def _emit_string(
                 if sub_args and _looks_like_option(sub_args[0]):
                     emitter._emit_eval_fallback("string", args)
                     return True
-                func_idx = emitter._shared_imports[sri.import_key]
+                # Over-arity calls — more sub-args than the fixed-param
+                # import accepts.  ``string totitle X 1 1`` / ``string
+                # toupper X 1 1`` / ``string tolower X 1 1`` carry
+                # codepoint range bounds that the 1-param ``string_to*``
+                # imports cannot see, so silently dropping them title-
+                # cases index 0 instead of the requested codepoint
+                # (string-17.9).  Route to the eval fallback so the
+                # ``cmds/string.zig`` dispatcher reaches the ``_range``
+                # variants.
                 param_count = len(sri.params)
+                if len(sub_args) > param_count:
+                    emitter._emit_eval_fallback("string", args)
+                    return True
+                func_idx = emitter._shared_imports[sri.import_key]
                 for i in range(min(param_count, len(sub_args))):
                     # ``i`` is into ``sub_args`` (= ``args[1:]``), so the
                     # original call-arg index is ``i + 1`` (the
@@ -207,8 +219,20 @@ def _emit_string(
             else:
                 emitter._emit(WasmOp.DROP)
             return True
-        func_idx = emitter._shared_imports[sri.import_key]
+        # Over-arity: route to eval-fallback so range-bearing forms
+        # (``string totitle X first last`` etc.) reach the runtime
+        # dispatcher's ``_range`` variant.  See the matching block in
+        # the value-context branch above.
         param_count = len(sri.params)
+        if len(sub_args) > param_count:
+            emitter._emit_eval_fallback("string", args)
+            if defs:
+                def_idx = emitter._intern_local(defs[0])
+                emitter._emit_local_set(def_idx)
+            else:
+                emitter._emit(WasmOp.DROP)
+            return True
+        func_idx = emitter._shared_imports[sri.import_key]
         for i in range(min(param_count, len(sub_args))):
             emitter._emit_value(sub_args[i], was_braced=_was_braced(emitter, i + 1))
         for _ in range(param_count - len(sub_args)):

--- a/core/parsing/subst_nocommands.py
+++ b/core/parsing/subst_nocommands.py
@@ -163,20 +163,26 @@ def _backslash_end(template: str, start: int) -> int:
     c = template[start + 1]
     # Single-char escapes the shared helper knows about all consume
     # two characters.  The multi-char variants (``\\x``, ``\\u``,
-    # ``\\U``, octal, continuation line) need explicit scanning.
-    if c == "x":
+    # ``\\U``, octal, continuation line) need explicit scanning that
+    # mirrors Tcl 9's ``ParseHex`` cap (value > 0x10FFF → stop).
+    if c in "xuU":
+        max_digits = 2 if c == "x" else (4 if c == "u" else 8)
         j = start + 2
-        while j < n and j < start + 4 and template[j] in "0123456789abcdefABCDEF":
-            j += 1
-        return j if j > start + 2 else start + 2
-    if c == "u":
-        j = start + 2
-        while j < n and j < start + 6 and template[j] in "0123456789abcdefABCDEF":
-            j += 1
-        return j if j > start + 2 else start + 2
-    if c == "U":
-        j = start + 2
-        while j < n and j < start + 10 and template[j] in "0123456789abcdefABCDEF":
+        end = min(start + 2 + max_digits, n)
+        value = 0
+        while j < end:
+            ch = template[j]
+            if ch in "0123456789":
+                digit = ord(ch) - ord("0")
+            elif ch in "abcdef":
+                digit = 10 + ord(ch) - ord("a")
+            elif ch in "ABCDEF":
+                digit = 10 + ord(ch) - ord("A")
+            else:
+                break
+            if value > 0x10FFF:
+                break
+            value = (value << 4) | digit
             j += 1
         return j if j > start + 2 else start + 2
     if c in "01234567":

--- a/core/parsing/substitution.py
+++ b/core/parsing/substitution.py
@@ -43,6 +43,42 @@ def _clamp_unicode(value: int) -> int:
     return value
 
 
+# Hex digit lookup — maps each hex char to its numeric value.
+_HEX_DIGITS: dict[str, int] = {
+    **{c: int(c) for c in "0123456789"},
+    **{c: 10 + ord(c) - ord("a") for c in "abcdef"},
+    **{c: 10 + ord(c) - ord("A") for c in "ABCDEF"},
+}
+
+
+def _parse_hex_capped(text: str, start: int, max_digits: int) -> tuple[int, int]:
+    """Mirror Tcl 9's ``ParseHex`` in tclParse.c:728.
+
+    Scan up to ``max_digits`` hex characters starting at *start*, but
+    stop early if the accumulated value would exceed U+10FFFF after one
+    more shift.  The check is ``result > 0x10FFF`` BEFORE shifting, so
+    after the shift the maximum representable value is exactly
+    0x10FFFF (the Unicode upper bound).  This means ``\\U100000b``
+    consumes only the 6 digits ``100000`` (= U+100000); the trailing
+    ``b`` falls through to the next iteration as a literal.
+
+    Returns ``(value, end_index)`` where *end_index* is the position
+    one past the last consumed hex digit.  When no hex digits follow,
+    returns ``(0, start)``.
+    """
+    n = len(text)
+    value = 0
+    i = start
+    end = min(start + max_digits, n)
+    while i < end:
+        digit = _HEX_DIGITS.get(text[i])
+        if digit is None or value > 0x10FFF:
+            break
+        value = (value << 4) | digit
+        i += 1
+    return value, i
+
+
 def backslash_subst(text: str) -> str:
     """Process Tcl backslash escapes in *text*.
 
@@ -68,54 +104,38 @@ def backslash_subst(text: str) -> str:
                     i += 1
                 result.append(" ")
             elif c == "x":
-                # hex escape: \xNN (1-2 hex digits)
-                j = i + 2
-                while j < n and j < i + 4 and text[j] in "0123456789abcdefABCDEF":
-                    j += 1
+                # ``\xNN`` — Tcl 9 reads up to 2 hex digits then masks
+                # to UCHAR (low 8 bits).  Since 2 digits never exceeds
+                # 0xFF, the ParseHex 0x10FFF cap never triggers here.
+                value, j = _parse_hex_capped(text, i + 2, 2)
                 if j > i + 2:
-                    result.append(chr(_clamp_unicode(int(text[i + 2 : j], 16))))
+                    result.append(chr(value & 0xFF))
                     i = j
                 else:
                     result.append("x")
                     i += 2
             elif c == "u":
-                # unicode escape: \uNNNN (1-4 hex digits).  If the
-                # parsed codepoint is a high surrogate (U+D800-U+DBFF)
-                # and the next four bytes form ``\uYYYY`` with YYYY a
-                # low surrogate (U+DC00-U+DFFF), combine the pair into
-                # a single supplementary-plane codepoint (Tcl 9
-                # ``tclParse.c`` ``TclParseBackslash`` behaviour).
-                j = i + 2
-                while j < n and j < i + 6 and text[j] in "0123456789abcdefABCDEF":
-                    j += 1
+                # ``\uNNNN`` — Tcl 9 reads up to 4 hex digits.  Tcl 9
+                # does NOT combine adjacent surrogate pairs at parse
+                # time — ``😂`` produces two isolated
+                # surrogate codepoints (encoded as 3-byte WTF-8 each).
+                # The runtime preserves them; do not combine here.
+                value, j = _parse_hex_capped(text, i + 2, 4)
                 if j > i + 2:
-                    cp = int(text[i + 2 : j], 16)
-                    if (
-                        0xD800 <= cp <= 0xDBFF
-                        and j + 5 < n
-                        and text[j] == "\\"
-                        and text[j + 1] == "u"
-                        and all(text[j + 2 + k] in "0123456789abcdefABCDEF" for k in range(4))
-                    ):
-                        low = int(text[j + 2 : j + 6], 16)
-                        if 0xDC00 <= low <= 0xDFFF:
-                            cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00)
-                            j = j + 6
-                    result.append(chr(_clamp_unicode(cp)))
+                    result.append(chr(value))
                     i = j
                 else:
                     result.append("u")
                     i += 2
             elif c == "U":
-                # wide unicode escape: \UNNNNNNNN (1-8 hex digits).  Tcl
-                # tests sometimes write values above U+10FFFF (the
-                # Unicode maximum) — Tcl 9 silently clamps; mirror that
-                # so the lexer doesn't bail out with chr() ValueError.
-                j = i + 2
-                while j < n and j < i + 10 and text[j] in "0123456789abcdefABCDEF":
-                    j += 1
+                # ``\UNNNNNNNN`` — Tcl 9 reads up to 8 hex digits but
+                # stops when the accumulator would exceed 0x10FFFF
+                # (see tclParse.c:728 ParseHex).  Example:
+                # ``\U100000b`` consumes the 6 digits ``100000``
+                # → U+100000, leaving ``b`` as a literal.
+                value, j = _parse_hex_capped(text, i + 2, 8)
                 if j > i + 2:
-                    result.append(chr(_clamp_unicode(int(text[i + 2 : j], 16))))
+                    result.append(chr(value))
                     i = j
                 else:
                     result.append("U")

--- a/core/parsing/substitution.py
+++ b/core/parsing/substitution.py
@@ -27,21 +27,6 @@ _BACKSLASH_MAP: dict[str, str] = {
     ";": ";",
 }
 
-# Maximum Unicode codepoint (U+10FFFF).  Tcl 9 silently clamps overlong
-# ``\xNN`` / ``\uNNNN`` / ``\UNNNNNNNN`` escapes that exceed this; we
-# do the same so the lexer doesn't bail out on test files that
-# intentionally exercise the boundary.
-_MAX_UNICODE = 0x10FFFF
-
-
-def _clamp_unicode(value: int) -> int:
-    """Return *value* clamped to the Unicode range so :func:`chr` succeeds."""
-    if value < 0:
-        return 0
-    if value > _MAX_UNICODE:
-        return _MAX_UNICODE
-    return value
-
 
 # Hex digit lookup — maps each hex char to its numeric value.
 _HEX_DIGITS: dict[str, int] = {

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -12,6 +12,7 @@ const result_mod = @import("../interp/tcl_result.zig");
 const tcl_str = @import("../valtypes/tcl_string.zig");
 const tcl_chars = @import("../valtypes/tcl_chars.zig");
 const list_parse = @import("../valtypes/tcl_list_parse.zig");
+const parse = @import("../parse/tcl_parse.zig");
 const std = @import("std");
 
 const alloc = rt.alloc;
@@ -1235,7 +1236,11 @@ fn eval_lmap(words: []const i32) result_mod.InterpResult {
         return result_mod.from_globals(0);
     }
     const n_pairs = pair_words / 2;
-    const MAX_PAIRS = 63; // (MAX_WORDS-2)/2, mirrors eval_foreach
+    // Mirrors ``eval_foreach`` in ``tcl_interp.zig`` — derived from
+    // ``parse.MAX_WORDS`` so the cap tracks the parser's word limit
+    // and doesn't go stale when the parser cap moves (Copilot review
+    // on PR #443).
+    const MAX_PAIRS = (parse.MAX_WORDS - 2) / 2;
     if (n_pairs > MAX_PAIRS) return result_mod.from_globals(obj_new_string(0, 0));
     const body_s = obj_ensure_string(words[words.len - 1]);
 

--- a/runtime/zig/cmds/string.zig
+++ b/runtime/zig/cmds/string.zig
@@ -880,26 +880,65 @@ fn is_valid_string_index(idx: i32) bool {
         if (sp[3] != '+' and sp[3] != '-') return false;
         return is_int_arith_tail(sp, s.len, 4);
     }
-    // Pure integer arithmetic: optional sign, digits, optional
-    // ``±N`` continuation.
+    // Pure integer arithmetic: optional sign, integer literal,
+    // optional ``±N`` continuation.  Integer literals include
+    // decimal, hex (``0x``), octal (``0o``), and binary (``0b``);
+    // bignums also parse here so ``string replace abcd
+    // 0x10000000000000000-0xffffffffffffffff 2 e`` (stringComp-14.26)
+    // makes it to the dispatcher instead of erroring at the syntax
+    // check.
     var i: u32 = 0;
     if (sp[i] == '+' or sp[i] == '-') i += 1;
     if (i >= s.len) return false;
     return is_int_arith_tail(sp, s.len, i);
 }
 
-fn is_int_arith_tail(sp: [*]const u8, len: u32, start: u32) bool {
+fn is_digit_for_base(c: u8, base: u32) bool {
+    return switch (base) {
+        2 => c == '0' or c == '1',
+        8 => c >= '0' and c <= '7',
+        10 => c >= '0' and c <= '9',
+        16 => (c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F'),
+        else => false,
+    };
+}
+
+/// Consume one integer literal (optional ``0x`` / ``0o`` / ``0b``
+/// prefix + at least one digit) starting at ``sp[start]``.  Returns
+/// the position one past the last digit consumed, or ``start`` when
+/// no valid literal was found.
+fn consume_integer_literal(sp: [*]const u8, len: u32, start: u32) u32 {
     var i = start;
-    // First digit run (required at least 1 digit).
-    if (i >= len) return false;
-    if (!(sp[i] >= '0' and sp[i] <= '9')) return false;
-    while (i < len and sp[i] >= '0' and sp[i] <= '9') i += 1;
+    if (i >= len) return start;
+    var base: u32 = 10;
+    if (sp[i] == '0' and i + 1 < len) {
+        const c = sp[i + 1];
+        if (c == 'x' or c == 'X') {
+            base = 16;
+            i += 2;
+        } else if (c == 'o' or c == 'O') {
+            base = 8;
+            i += 2;
+        } else if (c == 'b' or c == 'B') {
+            base = 2;
+            i += 2;
+        }
+    }
+    if (i >= len or !is_digit_for_base(sp[i], base)) return start;
+    while (i < len and is_digit_for_base(sp[i], base)) i += 1;
+    return i;
+}
+
+fn is_int_arith_tail(sp: [*]const u8, len: u32, start: u32) bool {
+    var i = consume_integer_literal(sp, len, start);
+    if (i == start) return false;
     // Optional ``±N`` continuation runs.
     while (i < len) {
         if (sp[i] != '+' and sp[i] != '-') return false;
         i += 1;
-        if (i >= len or !(sp[i] >= '0' and sp[i] <= '9')) return false;
-        while (i < len and sp[i] >= '0' and sp[i] <= '9') i += 1;
+        const after = consume_integer_literal(sp, len, i);
+        if (after == i) return false;
+        i = after;
     }
     return true;
 }

--- a/runtime/zig/cmds/string.zig
+++ b/runtime/zig/cmds/string.zig
@@ -858,14 +858,16 @@ fn eval_compare_or_equal(words: []const i32, kind: CompareKind) i32 {
 }
 
 /// Validate *idx* as a Tcl string-index argument.  Accepts integers
-/// (with optional ``+``/``-`` sign, possibly hex / octal), ``end``,
-/// ``end-N``, ``end+N``, and the ``int+int`` / ``int-int`` arithmetic
-/// forms the C tcl parser accepts.  Returns ``true`` on a valid
-/// index, ``false`` otherwise.  Used by ``string first`` / ``string
-/// last`` / ``string range`` / ``string replace`` / ``string index``
-/// / ``string repeat`` to reject garbage indices with the canonical
-/// ``bad index "X": must be integer?[+-]integer? or end?[+-]integer?``
-/// diagnostic rather than silently treating them as 0.
+/// in decimal, ``0x``/``0X`` hex, ``0o``/``0O`` octal, or ``0b``/``0B``
+/// binary form, with optional leading ``+`` / ``-`` sign; the literal
+/// keyword ``end``; ``end+N`` / ``end-N``; and the ``int±int`` arithmetic
+/// forms the C tcl parser accepts (including bignum operands resolved
+/// at runtime).  Returns ``true`` on a valid index, ``false`` otherwise.
+/// Used by ``string first`` / ``string last`` / ``string range`` /
+/// ``string replace`` / ``string index`` / ``string repeat`` to reject
+/// garbage indices with the canonical ``bad index "X": must be
+/// integer?[+-]integer? or end?[+-]integer?`` diagnostic rather than
+/// silently treating them as 0.
 fn is_valid_string_index(idx: i32) bool {
     const obj_mod = @import("../valtypes/tcl_obj.zig");
     const s = obj_mod.obj_ensure_string(idx);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1869,7 +1869,14 @@ pub fn eval_foreach(words: []const i32) i32 {
         return 0;
     }
     const n_pairs = pair_words / 2;
-    const MAX_PAIRS = 63; // (MAX_WORDS-2)/2
+    // Derived from ``parse.MAX_WORDS``: ``foreach varlist1 list1
+    // varlist2 list2 ... body`` carries 1 cmd-word + 2N pair-words + 1
+    // body-word, so the largest ``n_pairs`` the parser can ever hand
+    // us is ``(MAX_WORDS - 2) / 2``.  Tracking the parser cap directly
+    // keeps the two limits from drifting (Copilot review on PR #443
+    // flagged the stale literal that survived the ``MAX_WORDS = 128
+    // → 512`` bump).
+    const MAX_PAIRS = (parse.MAX_WORDS - 2) / 2;
     if (n_pairs > MAX_PAIRS) return 0;
     const body_s = obj_ensure_string(words[words.len - 1]);
 

--- a/runtime/zig/parse/tcl_parse.zig
+++ b/runtime/zig/parse/tcl_parse.zig
@@ -29,7 +29,17 @@
 // specially (not whitespace per-se, but command terminators), so
 // importing ``chars.is_space`` wouldn't be a drop-in swap.
 
-pub const MAX_WORDS: u32 = 128;
+// Maximum number of words a single command can have when parsed
+// through the stack-array fast path.  Tcl 9 has no hard limit — it
+// grows its argument buffer dynamically — but our parser uses
+// fixed-size stack arrays for the common case to avoid per-command
+// allocation traffic.  Bumped from 128 to handle ``string cat``
+// invocations with hundreds of args (string-29.4: 260 ``$x`` tokens
+// after ``string repeat``).  Per-frame stack cost at 512 is ~30 KB
+// across the various ``[MAX_WORDS]`` arrays in tcl_interp /
+// tcl_subst / tcl_expr_eval; well under the wasm32-wasi default
+// 1 MB stack with the usual 3-4 frame eval depth.
+pub const MAX_WORDS: u32 = 512;
 
 // ---------------------------------------------------------------------
 // Flat-array API — legacy.  Kept here so callers don't have to migrate

--- a/runtime/zig/valtypes/parse_cache.zig
+++ b/runtime/zig/valtypes/parse_cache.zig
@@ -282,9 +282,9 @@ const MAX_CACHED_BODY_LEN: u32 = 4096;
 
 /// Token buffer size for the pre-count pass.  Must exceed the
 /// maximum tokens any single command can produce (2 * MAX_WORDS
-/// on the interpreter side = 2 * 128 = 256).  We bump modestly
+/// on the interpreter side = 2 * 512 = 1024).  We bump modestly
 /// above that so a generous command still parses cleanly.
-const SCAN_TOK_BUF: u32 = 384;
+const SCAN_TOK_BUF: u32 = 1200;
 
 /// Parse ``body`` twice — first to count commands + tokens,
 /// second to populate a cache slab — and insert the slab into

--- a/runtime/zig/valtypes/tcl_bs.zig
+++ b/runtime/zig/valtypes/tcl_bs.zig
@@ -37,6 +37,42 @@ pub fn encode_utf8(d: [*]u8, cp: u32) u32 {
     }
 }
 
+/// Mirror Tcl 9's ``ParseHex`` (tclParse.c:728): scan up to
+/// ``max_digits`` hex chars from ``src[si..len]``, but stop early
+/// when the accumulator would exceed 0x10FFFF after another shift.
+/// The check is ``value > 0x10FFF`` BEFORE shifting, so the maximum
+/// value after the final shift is exactly 0x10FFFF.  This makes
+/// ``\U100000b`` consume only the 6 digits ``100000`` and leave
+/// ``b`` as a literal for the next iteration.
+fn parse_hex_capped(
+    src: [*]const u8,
+    si: u32,
+    len: u32,
+    max_digits: u32,
+) struct { value: u32, end: u32 } {
+    var value: u32 = 0;
+    var i = si;
+    var ndig: u32 = 0;
+    while (ndig < max_digits and i < len) {
+        const c = src[i];
+        var digit: u32 = undefined;
+        if (c >= '0' and c <= '9') {
+            digit = c - '0';
+        } else if (c >= 'a' and c <= 'f') {
+            digit = c - 'a' + 10;
+        } else if (c >= 'A' and c <= 'F') {
+            digit = c - 'A' + 10;
+        } else {
+            break;
+        }
+        if (value > 0x10FFF) break;
+        value = (value << 4) | digit;
+        i += 1;
+        ndig += 1;
+    }
+    return .{ .value = value, .end = i };
+}
+
 /// Decode one Tcl backslash escape starting at ``src[si]``.  ``si`` is
 /// the INDEX OF THE FIRST BYTE AFTER THE BACKSLASH — the caller has
 /// already consumed the ``\`` and verified the sequence is non-empty.
@@ -117,82 +153,25 @@ pub fn consume_bs_escape(
             return .{ .next_si = si, .written = encode_utf8(out, val) };
         },
         'u' => {
-            // ``\uNNNN`` — up to 4 hex digits → UTF-8.  When the
-            // result is a high surrogate (0xD800-0xDBFF) and the
-            // immediately following bytes form ``\uYYYY`` with YYYY
-            // a low surrogate (0xDC00-0xDFFF), combine the pair into
-            // a single supplementary-plane codepoint (Tcl 9
-            // ``tclParse.c`` ``TclParseBackslash`` behaviour).
+            // ``\uNNNN`` — up to 4 hex digits → UTF-8.  Tcl 9 does
+            // NOT combine adjacent ``\uD8XX\uDCXX`` surrogate pairs
+            // at parse time (see tclParse.c TclParseBackslash) — each
+            // \u escape produces an isolated codepoint, even when it
+            // lands in the surrogate range.  Lone surrogates are
+            // emitted as 3-byte WTF-8 sequences via encode_utf8.
             si += 1;
-            var cp: u32 = 0;
-            var ndig: u32 = 0;
-            while (ndig < 4 and si < len) {
-                const c = src[si];
-                if (c >= '0' and c <= '9') {
-                    cp = cp * 16 + @as(u32, c - '0');
-                    si += 1;
-                    ndig += 1;
-                } else if (c >= 'a' and c <= 'f') {
-                    cp = cp * 16 + @as(u32, c - 'a' + 10);
-                    si += 1;
-                    ndig += 1;
-                } else if (c >= 'A' and c <= 'F') {
-                    cp = cp * 16 + @as(u32, c - 'A' + 10);
-                    si += 1;
-                    ndig += 1;
-                } else break;
-            }
-            if (cp >= 0xD800 and cp <= 0xDBFF and si + 1 < len and
-                src[si] == '\\' and src[si + 1] == 'u')
-            {
-                var probe = si + 2;
-                var low: u32 = 0;
-                var ndig2: u32 = 0;
-                while (ndig2 < 4 and probe < len) {
-                    const c = src[probe];
-                    if (c >= '0' and c <= '9') {
-                        low = low * 16 + @as(u32, c - '0');
-                        probe += 1;
-                        ndig2 += 1;
-                    } else if (c >= 'a' and c <= 'f') {
-                        low = low * 16 + @as(u32, c - 'a' + 10);
-                        probe += 1;
-                        ndig2 += 1;
-                    } else if (c >= 'A' and c <= 'F') {
-                        low = low * 16 + @as(u32, c - 'A' + 10);
-                        probe += 1;
-                        ndig2 += 1;
-                    } else break;
-                }
-                if (ndig2 == 4 and low >= 0xDC00 and low <= 0xDFFF) {
-                    cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
-                    si = probe;
-                }
-            }
-            return .{ .next_si = si, .written = encode_utf8(out, cp) };
+            const ph = parse_hex_capped(src, si, len, 4);
+            return .{ .next_si = ph.end, .written = encode_utf8(out, ph.value) };
         },
         'U' => {
-            // ``\UNNNNNNNN`` — up to 8 hex digits → UTF-8.
+            // ``\UNNNNNNNN`` — Tcl 9 reads up to 8 hex digits but
+            // stops when the accumulator would exceed 0x10FFFF (see
+            // tclParse.c:728 ParseHex).  Example: ``\U100000b``
+            // consumes ``100000`` (6 digits → U+100000), leaving
+            // ``b`` as a trailing literal.
             si += 1;
-            var cp: u32 = 0;
-            var ndig: u32 = 0;
-            while (ndig < 8 and si < len) {
-                const c = src[si];
-                if (c >= '0' and c <= '9') {
-                    cp = cp * 16 + @as(u32, c - '0');
-                    si += 1;
-                    ndig += 1;
-                } else if (c >= 'a' and c <= 'f') {
-                    cp = cp * 16 + @as(u32, c - 'a' + 10);
-                    si += 1;
-                    ndig += 1;
-                } else if (c >= 'A' and c <= 'F') {
-                    cp = cp * 16 + @as(u32, c - 'A' + 10);
-                    si += 1;
-                    ndig += 1;
-                } else break;
-            }
-            return .{ .next_si = si, .written = encode_utf8(out, cp) };
+            const ph = parse_hex_capped(src, si, len, 8);
+            return .{ .next_si = ph.end, .written = encode_utf8(out, ph.value) };
         },
         '0'...'7' => {
             // ``\NNN`` — up to 3 octal digits → Unicode codepoint

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -841,9 +841,41 @@ pub export fn dict_values(dict: i32) i32 {
     return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
-// Exported: dict size — number of key-value pairs.
+// Exported: dict size — number of UNIQUE key-value pairs.  When the
+// underlying list rep contains duplicate keys (``set m {a X b Y a Z}``;
+// ``dict size $m`` → 2), we canonicalise via the hash side-cache to
+// match C Tcl 9 ``Tcl_DictObjSize`` (tclDictObj.c).  Just dividing
+// the list-element count by 2 would overcount on duplicates and break
+// string-10.20.1.
 pub export fn dict_size(dict: i32) i32 {
+    const ext = dict_ensure_cache(dict);
+    if (ext != 0) {
+        const count: u32 = @bitCast(obj.read_i32(ext + DICT_EXT_COUNT));
+        return obj_new_int(@intCast(count));
+    }
+    // Fallback (immediate handle / cache-OOM): walk the list rep
+    // and dedupe via O(N²) compare against earlier keys.  Slower than
+    // the cache path but correctness-preserving for the rare cases
+    // that can't allocate a hash table.
     const sd = obj_ensure_string(dict);
     const n = list_count_elements(sd.ptr, sd.len);
-    return obj_new_int(@divTrunc(n, 2));
+    if (n <= 1) return obj_new_int(0);
+    var unique: i64 = 0;
+    var idx: i64 = 0;
+    while (idx + 1 < n) : (idx += 2) {
+        const k = list_element_at(sd.ptr, sd.len, idx);
+        var seen = false;
+        var prev: i64 = 0;
+        while (prev < idx) : (prev += 2) {
+            const pk = list_element_at(sd.ptr, sd.len, prev);
+            if (pk.len == k.len and
+                str_cmp(sd.ptr + pk.start, pk.len, sd.ptr + k.start, k.len) == 0)
+            {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) unique += 1;
+    }
+    return obj_new_int(unique);
 }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -297,11 +297,14 @@ fn append_list_element(buf: u32, off_in: u32, sd_ptr: u32, elem: anytype, is_fir
     return off;
 }
 
-// Parse an index that may be "end", "end-N", "end+N", or a plain
-// integer.  Returns the resolved 0-based index (may be negative for
-// under-range or >= n for over-range; callers clamp as they see fit).
-// Exported as ``pub`` so string-index helpers in ``tcl_string.zig``
-// reuse the same "end" arithmetic.
+// Parse an index that may be "end", "end-N", "end+N", "M[+-]N"
+// (Tcl 9 integer arithmetic, including bignums), or a plain integer.
+// Returns the resolved 0-based index (may be negative for under-range
+// or >= n for over-range; callers clamp as they see fit).  Exported
+// as ``pub`` so string-index helpers in ``tcl_string.zig`` reuse the
+// same arithmetic.  Mirrors C Tcl 9 ``GetEndOffsetFromObj`` in
+// ``tclUtil.c`` for the ``int[+-]int`` form, with the result saturating
+// to ``i64`` bounds when the integer math overflows.
 pub fn resolve_list_index(idx: i32, n: i64) i64 {
     const sv = obj_ensure_string(idx);
     if (sv.len >= 3) {
@@ -325,6 +328,38 @@ pub fn resolve_list_index(idx: i32, n: i64) i64 {
                     offset = offset * 10 + @as(i64, sp[i] - '0');
                 }
                 return n - 1 + offset;
+            }
+        }
+    }
+    // ``int[+-]int`` arithmetic indices.  C Tcl 9 ``GetEndOffsetFromObj``
+    // tries the bignum / wide-int parser then performs the addition or
+    // subtraction; the result saturates to ``i64`` bounds.  Without
+    // this path, stringComp-14.26 ``string replace abcd
+    // 0x10000000000000000-0xffffffffffffffff 2 e`` would parse only the
+    // first hex literal and produce the wrong result (the difference
+    // ``2^64 - (2^64-1) = 1``, used as the first index).
+    if (sv.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(sv.ptr);
+        // Find the inner operator (skip a leading sign).
+        var op_pos: u32 = 0;
+        var k: u32 = if (sp[0] == '+' or sp[0] == '-') 1 else 0;
+        while (k < sv.len) : (k += 1) {
+            if (sp[k] == '+' or sp[k] == '-') {
+                op_pos = k;
+                break;
+            }
+        }
+        if (op_pos > 0) {
+            const bignum = @import("tcl_bignum.zig");
+            const lhs = bignum.parse_i128(sv.ptr, op_pos);
+            const rhs = bignum.parse_i128(sv.ptr + op_pos + 1, sv.len - op_pos - 1);
+            if (lhs != null and rhs != null) {
+                const a = lhs.?;
+                const b = rhs.?;
+                const r: i128 = if (sp[op_pos] == '-') a - b else a + b;
+                if (r > std.math.maxInt(i64)) return std.math.maxInt(i64);
+                if (r < std.math.minInt(i64)) return std.math.minInt(i64);
+                return @intCast(r);
             }
         }
     }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -356,10 +356,27 @@ pub fn resolve_list_index(idx: i32, n: i64) i64 {
             if (lhs != null and rhs != null) {
                 const a = lhs.?;
                 const b = rhs.?;
-                const r: i128 = if (sp[op_pos] == '-') a - b else a + b;
-                if (r > std.math.maxInt(i64)) return std.math.maxInt(i64);
-                if (r < std.math.minInt(i64)) return std.math.minInt(i64);
-                return @intCast(r);
+                // Use overflow-checked arithmetic — a + b / a - b on
+                // operands near i128 bounds (``string index abc
+                // <i128::MAX>+1``) traps in safety-checked builds and
+                // wraps in ReleaseFast.  On overflow, saturate by the
+                // direction we overflowed in: same-sign add or
+                // opposite-sign sub overflows away from zero, so the
+                // overflowing operand's sign tells us which i64 bound
+                // to pin to.
+                const is_sub = sp[op_pos] == '-';
+                const r_opt = if (is_sub) bignum.sub_overflow(a, b) else bignum.add_overflow(a, b);
+                if (r_opt) |r| {
+                    if (r > std.math.maxInt(i64)) return std.math.maxInt(i64);
+                    if (r < std.math.minInt(i64)) return std.math.minInt(i64);
+                    return @intCast(r);
+                }
+                // Overflowed i128.  ``a + b`` with both > 0 overflows
+                // positive; both < 0 overflows negative.  ``a - b``
+                // with ``a >= 0`` and ``b < 0`` overflows positive;
+                // ``a < 0`` and ``b >= 0`` overflows negative.
+                const positive_overflow = if (is_sub) (a >= 0 and b < 0) else (a > 0);
+                return if (positive_overflow) std.math.maxInt(i64) else std.math.minInt(i64);
             }
         }
     }

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -793,6 +793,15 @@ fn codepoint_lower(cp: u32) u32 {
     // Cyrillic: А-Я (0x410-0x42F) → а-я (0x430-0x44F)
     if (cp >= 0x410 and cp <= 0x42F) return cp + 32;
     if (cp >= 0x400 and cp <= 0x40F) return cp + 80;
+    // Supplementary planes — bicameral scripts where every capital
+    // pairs with a lowercase at a fixed offset.  Adlam, Warang Citi,
+    // Osage, etc. show up in the Tcl 9 string.test corpus
+    // (string-17.9 hits Warang Citi U+118A0 ↔ U+118C0).
+    if (cp >= 0x118A0 and cp <= 0x118BF) return cp + 32; // Warang Citi cap → small
+    if (cp >= 0x10400 and cp <= 0x10427) return cp + 40; // Deseret cap → small
+    if (cp >= 0x104B0 and cp <= 0x104D3) return cp + 40; // Osage cap → small
+    if (cp >= 0x10C80 and cp <= 0x10CB2) return cp + 64; // Old Hungarian cap → small
+    if (cp >= 0x1E900 and cp <= 0x1E921) return cp + 34; // Adlam cap → small
     return cp;
 }
 
@@ -814,6 +823,12 @@ fn codepoint_upper(cp: u32) u32 {
     if (cp >= 0x3C3 and cp <= 0x3CB) return cp - 32;
     if (cp >= 0x430 and cp <= 0x44F) return cp - 32;
     if (cp >= 0x450 and cp <= 0x45F) return cp - 80;
+    // Supplementary planes — see ``codepoint_lower`` for the mirror.
+    if (cp >= 0x118C0 and cp <= 0x118DF) return cp - 32; // Warang Citi small → cap
+    if (cp >= 0x10428 and cp <= 0x1044F) return cp - 40; // Deseret small → cap
+    if (cp >= 0x104D8 and cp <= 0x104FB) return cp - 40; // Osage small → cap
+    if (cp >= 0x10CC0 and cp <= 0x10CF2) return cp - 64; // Old Hungarian small → cap
+    if (cp >= 0x1E922 and cp <= 0x1E943) return cp - 34; // Adlam small → cap
     return cp;
 }
 

--- a/tests/baselines/tcl9-tcltest-wasm/categories/string.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/string.toml
@@ -1,6 +1,6 @@
 # string.test — auto-generated WASM baseline.
-# bucket = 'W-mixed-fail'
-# reason = '158 of 705 failed'
+# bucket = 'clean'
+# reason = '0 of 705 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 705
-observed_passed = 540
-observed_failed = 158
+observed_passed = 698
+observed_failed = 0
 observed_skipped = 7
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["string-2.5.0", "string-2.15.2.0", "string-2.20.0", "string-2.37.0", "string-2.38a.0", "string-2.38b.0", "string-2.38c.0", "string-2.38d.0", "string-2.38e.0", "string-2.38f.0", "string-3.4.0", "string-3.13.0", "string-3.23.0", "string-3.28.0", "string-3.43.0", "string-3.45a.0", "string-3.45b.0", "string-3.45c.0", "string-3.45d.0", "string-3.45e.0", "string-3.45f.0", "string-4.2.0", "string-4.9.0", "string-4.22.0", "string-5.7.0", "string-5.10.0", "string-5.11.0", "string-5.14.0", "string-5.15.0", "string-6.4.0", "string-6.36.0", "string-6.39.0", "string-6.61.0", "string-6.76.0", "string-6.83.0", "string-6.84.0", "string-6.102.0", "string-7.2.0", "string-7.7.0", "string-7.12.0", "string-7.14.0", "string-7.15.0", "string-7.16.0", "string-9.5.0", "string-9.7.0", "string-10.1.0", "string-10.2.0", "string-10.3.0", "string-10.9.0", "string-10.10.0", "string-10.19.0", "string-10.20.1.0", "string-11.9.8.0", "string-11.9.9.0", "string-11.9.11.0", "string-11.14.0", "string-11.15.0", "string-11.17.0", "string-11.18.0", "string-11.19.0", "string-11.20.0", "string-11.29.0", "string-11.33.0", "string-11.35.0", "string-11.38.0", "string-11.41.0", "string-11.42.0", "string-11.50.0", "string-11.51.0", "string-12.12.0", "string-12.13.0", "string-12.17.0", "string-12.18.0", "string-12.19.0", "string-12.23.0", "string-13.7.0", "string-13.14.0", "string-14.5.0", "string-14.7.0", "string-14.8.0", "string-14.9.0", "string-14.10.0", "string-14.13.0", "string-14.14.0", "string-14.15.0", "string-14.16.0", "string-14.17.0", "string-14.19.0", "string-14.20.0", "string-14.21.0", "string-14.22.0", "stringComp-14.25.0", "stringComp-14.26.0", "string-15.1.0", "string-15.2.0", "string-15.3.0", "string-15.7.0", "string-15.8.0", "string-15.9.0", "string-15.10.0", "string-16.1.0", "string-16.2.0", "string-16.3.0", "string-16.7.0", "string-16.8.0", "string-16.9.0", "string-16.10.0", "string-17.1.0", "string-17.2.0", "string-17.6.0", "string-17.7.0", "string-17.9.0", "string-18.1.0", "string-18.2.0", "string-18.12.0", "string-19.1.0", "string-19.3.0", "string-20.1.0", "string-20.6.0", "string-21.18.0", "string-21.19.0", "string-21.20.0", "string-21.22.0", "string-21.23.0", "string-21.24.0", "string-21.25.0", "string-24.5.0", "string-24.6.0", "string-24.8.0", "string-24.10.0", "string-24.11.0", "string-24.13.0", "string-24.16.0", "string-24.17.0", "string-24.18.0", "string-24.19.0", "string-25.8.0", "string-26.5.0", "string-26.6.0", "string-27.4.0", "string-27.5.0", "string-27.6.0", "string-27.7.0", "string-27.8.0", "string-27.9.0", "string-27.10.0", "string-28.4.0", "string-28.5.0", "string-28.6.0", "string-28.7.0", "string-28.8.0", "string-28.9.0", "string-28.10.0", "string-28.11.0", "string-28.12.0", "string-28.13.0", "string-29.4.0", "string-32.8.0"]
+ids = []

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -507,11 +507,11 @@
       "total": 18
     },
     "string": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 158,
-      "passed_min": 540,
+      "failed_max": 0,
+      "passed_min": 698,
       "skipped": 7,
       "total": 705
     },


### PR DESCRIPTION
string.test now passes 698/705 (baseline was 540/705 — 158 tests fixed,
0 remaining failures, 7 intentionally skipped).

Fixes by failing test:

* string-12.23.0 (string range surrogates) — fix ``\U`` / ``\u`` escape
  parsing to mirror Tcl 9's ``ParseHex`` (tclParse.c:728): stop
  consuming hex digits when the accumulator would exceed ``0x10FFFF``,
  so ``\U100000b`` resolves to U+100000 + ``b`` instead of a clamped
  U+10FFFF.  Applied to both ``core/parsing/substitution.py`` (compile
  time) and ``runtime/zig/valtypes/tcl_bs.zig`` (runtime).

* string-14.21.0 / 14.22.0 (string replace surrogates) — drop the
  surrogate-pair combining we previously did at parse time.  Tcl 9's
  ``TclParseBackslash`` does not combine adjacent ``😂`` into
  a single supplementary code point; each ``\u`` escape produces an
  isolated codepoint (encoded as 3-byte WTF-8 each).

* string-10.20.1.0 (dict size / string map with duplicates) —
  canonicalise duplicate keys in ``dict create`` at compile time
  (last-wins value, preserved insertion position; mirrors Tcl 9's
  ``Tcl_DictObjPut``) and dedupe via the hash side-cache in runtime
  ``dict_size``.

* stringComp-14.26.0 (bignum index in string replace) — extend
  ``resolve_list_index`` to handle ``integer[+-]integer`` arithmetic
  via i128 with saturation, and accept hex / octal / binary literal
  prefixes in ``is_valid_string_index``.  Without these, expressions
  like ``0x10000000000000000-0xffffffffffffffff`` (= 1) failed the
  syntax check and trapped.

* string-29.4.0 (string cat, many args) — bump parser ``MAX_WORDS``
  from 128 to 512 so commands like ``string cat $x $x ...`` with 260
  args parse as a single command instead of truncating at 128 and
  treating the remainder as syntax errors.

* string-17.9.0 (string totitle with Warang Citi) — route over-arity
  ``string {tolower,toupper,totitle} X first last`` calls through the
  eval fallback so the runtime dispatcher reaches the ``_range``
  variants (the 1-param wasm runtime imports were silently dropping
  the range bounds).  Also add Adlam, Warang Citi, Osage, Deseret,
  and Old Hungarian case-pair mappings to ``codepoint_upper`` /
  ``codepoint_lower`` so the supplementary-plane scripts that appear
  in the Tcl 9 corpus title-case correctly.