### PR TITLE
Add double-free sub-bucket counters and pending sample capture

### DIFF
--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -439,12 +439,39 @@ var g_alloc_count: i32 = 0;
 var g_double_free_count: i32 = 0;
 var g_retain_after_defer_count: i32 = 0;
 
+// Sub-bucket splits for ``double_free`` — the three "skip and bump"
+// paths in ``tcl_obj_release`` (POISON tag, rc==0 pending, bad rc
+// value).  Triage tip from the #439 investigation: split tells you
+// whether the dominant pattern is a true UAF-release (POISON), an
+// over-release of a queued obj (pending), or a stale handle on a
+// recycled slab (bad_rc).  POISON + bad_rc together usually means
+// the deferred-free queue overflowed and the cascading immediate-free
+// reissued slabs, exposing the stale handles in the dispatch chain.
+//
+// The sub-bucket counters always add up to ``g_double_free_count``;
+// the aggregate stays so existing harness code keeps working.
+var g_double_free_poison_count: i32 = 0;
+var g_double_free_pending_count: i32 = 0;
+var g_double_free_bad_rc_count: i32 = 0;
+
 pub export fn tcl_test_alloc_count() i32 {
     return g_alloc_count;
 }
 
 pub export fn tcl_test_double_free_count() i32 {
     return g_double_free_count;
+}
+
+pub export fn tcl_test_double_free_poison_count() i32 {
+    return g_double_free_poison_count;
+}
+
+pub export fn tcl_test_double_free_pending_count() i32 {
+    return g_double_free_pending_count;
+}
+
+pub export fn tcl_test_double_free_bad_rc_count() i32 {
+    return g_double_free_bad_rc_count;
 }
 
 pub export fn tcl_test_retain_after_defer_count() i32 {
@@ -454,7 +481,82 @@ pub export fn tcl_test_retain_after_defer_count() i32 {
 pub export fn tcl_test_reset_counters() void {
     g_alloc_count = 0;
     g_double_free_count = 0;
+    g_double_free_poison_count = 0;
+    g_double_free_pending_count = 0;
+    g_double_free_bad_rc_count = 0;
     g_retain_after_defer_count = 0;
+    pending_sample_count = 0;
+}
+
+// Pending-bucket capture buffer — when a release hits the rc==0
+// path, sample the obj's address and the first 32 bytes of its
+// string buffer to a ring so a host-side triage script can read
+// them out and classify what's being over-released.
+const PENDING_SAMPLE_CAP: u32 = 32;
+const PENDING_SAMPLE_BYTES: u32 = 48;
+var pending_sample_addr: [PENDING_SAMPLE_CAP]u32 = .{0} ** PENDING_SAMPLE_CAP;
+var pending_sample_type: [PENDING_SAMPLE_CAP]i32 = .{0} ** PENDING_SAMPLE_CAP;
+var pending_sample_str: [PENDING_SAMPLE_CAP][PENDING_SAMPLE_BYTES]u8 = .{.{0} ** PENDING_SAMPLE_BYTES} ** PENDING_SAMPLE_CAP;
+var pending_sample_len: [PENDING_SAMPLE_CAP]u32 = .{0} ** PENDING_SAMPLE_CAP;
+var pending_sample_count: u32 = 0;
+
+inline fn capture_pending_sample(addr: u32) void {
+    if (pending_sample_count >= PENDING_SAMPLE_CAP) return;
+    pending_sample_addr[pending_sample_count] = addr;
+    pending_sample_type[pending_sample_count] = read_i32(addr + OBJ_TYPE_TAG);
+    const sp: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
+    const sl: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
+    var copy_len: u32 = sl;
+    if (copy_len > PENDING_SAMPLE_BYTES) copy_len = PENDING_SAMPLE_BYTES;
+    if (sp != 0 and copy_len > 0) {
+        const src: [*]const u8 = @ptrFromInt(sp);
+        var i: u32 = 0;
+        while (i < copy_len) : (i += 1) {
+            pending_sample_str[pending_sample_count][i] = src[i];
+        }
+    }
+    pending_sample_len[pending_sample_count] = sl;
+    pending_sample_count += 1;
+}
+
+pub export fn tcl_test_pending_sample_count() i32 {
+    return @intCast(pending_sample_count);
+}
+
+pub export fn tcl_test_pending_sample_addr(idx: i32) i32 {
+    const i: u32 = @bitCast(idx);
+    if (i >= pending_sample_count) return 0;
+    return @bitCast(pending_sample_addr[i]);
+}
+
+pub export fn tcl_test_pending_sample_type(idx: i32) i32 {
+    const i: u32 = @bitCast(idx);
+    if (i >= pending_sample_count) return 0;
+    return pending_sample_type[i];
+}
+
+pub export fn tcl_test_pending_sample_str_ptr(idx: i32) i32 {
+    const i: u32 = @bitCast(idx);
+    if (i >= pending_sample_count) return 0;
+    return @bitCast(@intFromPtr(&pending_sample_str[i]));
+}
+
+pub export fn tcl_test_pending_sample_str_len(idx: i32) i32 {
+    const i: u32 = @bitCast(idx);
+    if (i >= pending_sample_count) return 0;
+    const l = pending_sample_len[i];
+    if (l > PENDING_SAMPLE_BYTES) return PENDING_SAMPLE_BYTES;
+    return @intCast(l);
+}
+
+pub export fn tcl_test_pending_sample_full_len(idx: i32) i32 {
+    const i: u32 = @bitCast(idx);
+    if (i >= pending_sample_count) return 0;
+    return @intCast(pending_sample_len[i]);
+}
+
+pub export fn tcl_test_pending_sample_reset() void {
+    pending_sample_count = 0;
 }
 
 /// Run at the end of a test workload.  Drains the deferred-free
@@ -1064,7 +1166,10 @@ pub export fn tcl_obj_release(obj: i32) void {
     // intact.
     const tag = read_i32(addr + OBJ_TYPE_TAG);
     if (tag == TYPE_FREED_POISON) {
-        if (build_options.leak_check) g_double_free_count += 1;
+        if (build_options.leak_check) {
+            g_double_free_count += 1;
+            g_double_free_poison_count += 1;
+        }
         return;
     }
     const rc = read_i32(addr + OBJ_REFCOUNT);
@@ -1073,7 +1178,11 @@ pub export fn tcl_obj_release(obj: i32) void {
         // freed.  Any further release is the over-release pattern
         // S2's failed attempt hit; record it so leakcheck builds
         // surface it.  Production builds compile this branch out.
-        if (build_options.leak_check) g_double_free_count += 1;
+        if (build_options.leak_check) {
+            g_double_free_count += 1;
+            g_double_free_pending_count += 1;
+            capture_pending_sample(addr);
+        }
         return;
     }
     // Use-after-free guard #2: refcount sanity check.  A live obj's
@@ -1088,7 +1197,10 @@ pub export fn tcl_obj_release(obj: i32) void {
     // already-libc-freed slab whose first word happens to hold any
     // garbage.
     if (rc < 0 or rc > (1 << 20)) {
-        if (build_options.leak_check) g_double_free_count += 1;
+        if (build_options.leak_check) {
+            g_double_free_count += 1;
+            g_double_free_bad_rc_count += 1;
+        }
         return;
     }
     if (rc <= 1) {

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -489,9 +489,9 @@ pub export fn tcl_test_reset_counters() void {
 }
 
 // Pending-bucket capture buffer — when a release hits the rc==0
-// path, sample the obj's address and the first 32 bytes of its
-// string buffer to a ring so a host-side triage script can read
-// them out and classify what's being over-released.
+// path, sample the obj's address and the first ``PENDING_SAMPLE_BYTES``
+// of its string buffer to a ring so a host-side triage script can
+// read them out and classify what's being over-released.
 const PENDING_SAMPLE_CAP: u32 = 32;
 const PENDING_SAMPLE_BYTES: u32 = 48;
 var pending_sample_addr: [PENDING_SAMPLE_CAP]u32 = .{0} ** PENDING_SAMPLE_CAP;
@@ -500,10 +500,45 @@ var pending_sample_str: [PENDING_SAMPLE_CAP][PENDING_SAMPLE_BYTES]u8 = .{.{0} **
 var pending_sample_len: [PENDING_SAMPLE_CAP]u32 = .{0} ** PENDING_SAMPLE_CAP;
 var pending_sample_count: u32 = 0;
 
+/// Search the deferred-free queue for ``addr``.  Used by
+/// :func:`capture_pending_sample` to gate the
+/// ``OBJ_STR_PTR``/``OBJ_STR_LEN`` dereference on the slab actually
+/// being a live queued obj.  Linear scan over ``pending_free`` —
+/// O(``pending_free_count``) per call — but the capture buffer caps
+/// at 32 samples per workload and the queue drains often, so the
+/// total cost is bounded.
+inline fn is_addr_in_pending(addr: u32) bool {
+    var i: u32 = 0;
+    while (i < pending_free_count) : (i += 1) {
+        if (pending_free[i] == addr) return true;
+    }
+    return false;
+}
+
 inline fn capture_pending_sample(addr: u32) void {
     if (pending_sample_count >= PENDING_SAMPLE_CAP) return;
     pending_sample_addr[pending_sample_count] = addr;
     pending_sample_type[pending_sample_count] = read_i32(addr + OBJ_TYPE_TAG);
+    pending_sample_len[pending_sample_count] = 0;
+    // The ``rc == 0`` release path also covers stale handles to
+    // libc-freed slabs whose first word happens to be zero — the
+    // existing comment in ``tcl_obj_release`` says "or freed" and
+    // the ``bad_rc`` guard below is the catch-all.  In that case
+    // ``OBJ_STR_PTR`` is garbage and the ``src[i]`` copy would
+    // dereference an arbitrary linear-memory address, OOB-trapping
+    // leak_sweep and losing the diagnostic counters (Codex /
+    // Copilot review on PR #444).
+    //
+    // Gate the buffer copy on the address actually being on the
+    // deferred-free queue: any rc==0 obj NOT on the queue must be
+    // either freed or recycled, so its header fields can't be
+    // trusted.  When skipped, we still record the addr + type tag
+    // so host-side triage knows a non-queue-resident over-release
+    // fired (sample_len stays 0 to mark "no content captured").
+    if (!is_addr_in_pending(addr)) {
+        pending_sample_count += 1;
+        return;
+    }
     const sp: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
     const sl: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
     var copy_len: u32 = sl;

--- a/scripts/dev/leak_sweep.py
+++ b/scripts/dev/leak_sweep.py
@@ -168,6 +168,15 @@ def _run_one_with_counters(
         reset = rt_inst.exports(store)["tcl_test_reset_counters"]
         alloc_count = rt_inst.exports(store)["tcl_test_alloc_count"]
         double_free = rt_inst.exports(store)["tcl_test_double_free_count"]
+        # Sub-bucket splits — see ``tcl_obj.zig`` comment at the
+        # ``g_double_free_poison_count`` declaration.  Triage tool
+        # for narrowing the source of double-free bumps.  Optional
+        # (older leak-check binaries may not have these exports);
+        # missing exports leave the sub-bucket out of the row.
+        exports = rt_inst.exports(store)
+        df_poison = exports.get("tcl_test_double_free_poison_count")
+        df_pending = exports.get("tcl_test_double_free_pending_count")
+        df_bad_rc = exports.get("tcl_test_double_free_bad_rc_count")
         retain_after_defer = rt_inst.exports(store)["tcl_test_retain_after_defer_count"]
         finalize = rt_inst.exports(store)["tcl_test_finalize"]
         _ = alloc_count  # readable mid-run if needed
@@ -225,6 +234,12 @@ def _run_one_with_counters(
             out["alloc_residual"] = int(finalize(store))
             out["double_free"] = int(double_free(store))
             out["retain_after_defer"] = int(retain_after_defer(store))
+            if df_poison is not None:
+                out["double_free_poison"] = int(df_poison(store))
+            if df_pending is not None:
+                out["double_free_pending"] = int(df_pending(store))
+            if df_bad_rc is not None:
+                out["double_free_bad_rc"] = int(df_bad_rc(store))
         except BaseException as exc:
             out["counter_read_error"] = str(exc)[-200:]
         if watchdog_fired[0] and not out["trapped"]:


### PR DESCRIPTION
## Summary

Add diagnostic instrumentation to improve triage of double-free errors in the TCL object allocator:

- Split `g_double_free_count` into three sub-buckets: `g_double_free_poison_count` (UAF-release with POISON tag), `g_double_free_pending_count` (over-release of queued objects), and `g_double_free_bad_rc_count` (stale handles on recycled slabs)
- Add a pending-bucket capture buffer that samples object addresses and string buffer contents when rc==0 over-releases are detected, enabling host-side triage scripts to classify what's being over-released
- Export new test functions to query sub-bucket counts and pending samples
- Update `leak_sweep.py` to read and report the new sub-bucket counters (with graceful fallback for older binaries)

The sub-bucket splits help narrow down whether double-free patterns stem from true use-after-free, cascading immediate-frees from deferred-free queue overflow, or other root causes.

## Validation

- No new tests added; this is diagnostic instrumentation for existing leak-check builds
- Changes are guarded by `build_options.leak_check` and only affect debug/test builds
- Backward compatible: `leak_sweep.py` gracefully handles missing exports from older binaries

https://claude.ai/code/session_01VGfZ3mMNRjfHKodWwZUKSz