### PR TITLE
Fix JetBrains Compiler Explorer source from editor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,21 @@
 
 ## Bug Fixes
 
+- **JetBrains plugin: Compiler Explorer tool window now receives source
+  from the editor.** Since v1.10.0 the tool window stayed stuck on
+  "Waiting for source from editor..." with the status line reading
+  "webview API unavailable". The JCEF adapter in
+  `CompilerExplorerHtml.kt` was rewriting a `const vscode =
+  acquireVsCodeApi();` string that the VS Code webview HTML no longer
+  contained — recent revisions capture the API via
+  `var __vscodeApi = typeof acquireVsCodeApi === 'function' ?
+  acquireVsCodeApi() : undefined` instead, so the replacement was a
+  silent no-op and `acquireVsCodeApi` stayed undefined. The adapter now
+  injects a `<head>` shim that defines `acquireVsCodeApi` to return a
+  bridge object whose `postMessage` queues requests until the Kotlin
+  host installs `window.__tcllspBridge` on load-end, at which point the
+  queue is drained. Compile, hover-highlight, and clear-highlight
+  messages reach the LSP server again.
 - **JetBrains plugin: bundle LSP server outside the plugin jar.**
   v1.10.6 shipped the source-level W105 quick-fix that preserves `$`
   in variable references (`$script` → `{$script}` instead of

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
@@ -40,32 +40,62 @@ fun getCompilerExplorerHtml(): String {
 
 /**
  * Replace VS Code webview API calls with JCEF bridge equivalents.
+ *
+ * The VS Code HTML calls `acquireVsCodeApi()` early during body-script
+ * evaluation to capture the host bridge, then keeps that reference for the
+ * lifetime of the page (`var __vscodeApi = ...` near the top of the first
+ * script block, plus a second `vscodeApi` capture later on). In JCEF there
+ * is no native `acquireVsCodeApi` — the host's own bridge
+ * (`window.__tcllspBridge`) is injected from Kotlin in `onLoadEnd`, which
+ * fires *after* those captures have already run.
+ *
+ * To plug that gap we inject a shim into `<head>` so it runs before any
+ * body script. The shim defines `acquireVsCodeApi` to hand back an object
+ * whose `postMessage` either forwards to `__tcllspBridge` (if already set)
+ * or queues the message; `window.__tcllspFlushQueue()` drains the queue
+ * once the host calls it on load-end. This keeps the captured `vscodeApi`
+ * reference live, makes the status line read "explorer UI ready" instead
+ * of "webview API unavailable", and ensures the `compile` request reaches
+ * Kotlin so the IR pane stops showing "Waiting for source from editor...".
  */
 private fun adaptHtmlForJcef(html: String): String {
     var result = html
 
-    // Replace acquireVsCodeApi with our bridge object
-    result = result.replace(
-        "const vscode = acquireVsCodeApi();",
-        """
-        // JCEF bridge — __tcllspBridge is injected by the Kotlin host
-        const vscode = {
-            postMessage: function(msg) {
-                if (typeof window.__tcllspBridge === 'function') {
-                    if (msg.type === 'compile' && msg.source) {
+    val shim = """
+        <script>
+        (function() {
+            var queue = [];
+            function dispatch(msg) {
+                if (typeof window.__tcllspBridge !== 'function') {
+                    queue.push(msg);
+                    return;
+                }
+                try {
+                    if (!msg || typeof msg.type !== 'string') return;
+                    if (msg.type === 'compile' && typeof msg.source === 'string') {
                         window.__tcllspBridge('compile:' + msg.source + '\u0000' + (msg.dialect || ''));
                     } else if (msg.type === 'highlightSource') {
                         window.__tcllspBridge('highlightSource:' + msg.start + ',' + msg.end);
                     } else if (msg.type === 'clearHighlight') {
                         window.__tcllspBridge('clearHighlight');
-                    } else if (msg.type === 'dialectChange') {
-                        // Dialect changes are handled locally
                     }
+                    // Other types (ready, dialectChange, scriptError, ...)
+                    // have no host action in JCEF and are intentionally dropped.
+                } catch (e) {
+                    // Bridge errors must not break the webview UI.
                 }
             }
-        };
-        """.trimIndent()
-    )
+            window.__tcllspFlushQueue = function() {
+                while (queue.length) dispatch(queue.shift());
+            };
+            window.acquireVsCodeApi = function() {
+                return { postMessage: dispatch };
+            };
+        })();
+        </script>
+    """.trimIndent()
+
+    result = result.replace("<head>", "<head>\n$shim")
 
     // Remove Content-Security-Policy that blocks inline scripts in JCEF
     result = result.replace(

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
@@ -1,5 +1,9 @@
 package com.tcllsp.jetbrains
 
+import com.intellij.openapi.diagnostic.Logger
+
+private val LOG = Logger.getInstance("com.tcllsp.jetbrains.CompilerExplorerHtml")
+
 /**
  * Generates HTML for the Compiler Explorer, adapted for JCEF from the VS Code webview.
  *
@@ -95,13 +99,41 @@ private fun adaptHtmlForJcef(html: String): String {
         </script>
     """.trimIndent()
 
-    result = result.replace("<head>", "<head>\n$shim")
+    // Inject the shim right after the opening `<head>` tag. Match
+    // case-insensitively and tolerate attributes/whitespace inside the
+    // tag — and require the match to succeed before returning, because
+    // a silent no-op replacement is exactly the failure mode this fix
+    // exists to prevent.
+    val headRegex = Regex("(?i)<head(?:\\s[^>]*)?>")
+    val headMatch = headRegex.find(result)
+    if (headMatch == null) {
+        LOG.error(
+            "JCEF adapter could not find a <head> tag in the compiler explorer " +
+                "HTML — the JS-bridge shim was not injected. Compiler Explorer " +
+                "will be unusable until the upstream template is restored."
+        )
+        return result
+    }
+    val insertAt = headMatch.range.last + 1
+    result = result.substring(0, insertAt) + "\n" + shim + result.substring(insertAt)
 
-    // Remove Content-Security-Policy that blocks inline scripts in JCEF
-    result = result.replace(
-        Regex("""<meta\s+http-equiv="Content-Security-Policy"[^>]*>"""),
-        "<!-- CSP removed for JCEF -->"
-    )
+    // Remove the Content-Security-Policy meta that blocks inline scripts
+    // (including the shim above) in JCEF. Tolerate attribute reordering
+    // and case variants for the same reason; warn if the CSP was present
+    // but didn't get stripped so a regression is loud rather than silent.
+    val cspRegex =
+        Regex(
+            """(?i)<meta\s+[^>]*http-equiv\s*=\s*["']Content-Security-Policy["'][^>]*>"""
+        )
+    if (cspRegex.containsMatchIn(result)) {
+        result = cspRegex.replaceFirst(result, "<!-- CSP removed for JCEF -->")
+        if (cspRegex.containsMatchIn(result)) {
+            LOG.warn(
+                "JCEF adapter found but could not strip the Content-Security-Policy " +
+                    "meta tag — the inline shim may be blocked."
+            )
+        }
+    }
 
     return result
 }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -50,11 +50,16 @@ private class CompilerExplorerPanel(private val project: Project) {
         browser.jbCefClient.addLoadHandler(object : CefLoadHandlerAdapter() {
             override fun onLoadEnd(cefBrowser: CefBrowser?, frame: org.cef.browser.CefFrame?, httpStatusCode: Int) {
                 if (frame?.isMain == true) {
-                    // Inject the bridge function
+                    // Install the JS→Kotlin bridge, then drain any messages
+                    // (compile/highlight/etc.) that the page enqueued while it
+                    // was loading via the shim in `adaptHtmlForJcef`.
                     val bridgeJs = """
                         window.__tcllspBridge = function(msg) {
                             ${jsQuery.inject("msg")}
                         };
+                        if (typeof window.__tcllspFlushQueue === 'function') {
+                            window.__tcllspFlushQueue();
+                        }
                     """.trimIndent()
                     cefBrowser?.executeJavaScript(bridgeJs, "", 0)
 


### PR DESCRIPTION
The JCEF adapter was rewriting a `const vscode = acquireVsCodeApi();`
string that the VS Code webview HTML no longer contained — recent
revisions capture the API via `var __vscodeApi = typeof
acquireVsCodeApi === 'function' ? acquireVsCodeApi() : undefined`
near the top of the body script. The replacement was a silent no-op,
`acquireVsCodeApi` stayed undefined under JCEF, so the status line
read "webview API unavailable" and the IR pane stayed stuck on
"Waiting for source from editor..." — the compile request never
reached Kotlin.

Inject a `<head>` shim instead. It runs before the body scripts,
defines `acquireVsCodeApi` to return a bridge object whose
`postMessage` queues requests until the Kotlin host installs
`window.__tcllspBridge` on load-end, at which point
`__tcllspFlushQueue()` drains the queue. Compile, hover-highlight,
and clear-highlight messages reach the LSP server again.