### PR TITLE
Implement alias loop detection and cross-interp upvar support

### DIFF
--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -245,6 +245,7 @@ class _WasmEmitterStmtMixin(_Base):
                 # on the brace-word path but IRAssignConst skips
                 # the runtime parser, so the codegen has to do it.
                 from ._values import _braced_lineconts
+
                 self._emit_obj_literal(_braced_lineconts(value))
                 # ``_emit_obj_literal`` always allocates a fresh
                 # TclObj → OWNED.  S2.3 migration.
@@ -1552,6 +1553,7 @@ class _WasmEmitterStmtMixin(_Base):
                         cmd_emit = "$" + inner
                 parts = [cmd_emit]
                 from ._values import _braced_lineconts as _braced_nl
+
                 for i, a in enumerate(args):
                     if _arg_was_braced(i):
                         # Braced token — IR holds the literal content

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -238,7 +238,14 @@ class _WasmEmitterStmtMixin(_Base):
             return
         match stmt:
             case IRAssignConst(name=name, value=value):
-                self._emit_obj_literal(value)
+                # Apply Tcl 9's brace ``\<newline>`` substitution
+                # before emitting — IRAssignConst's value field
+                # holds the raw post-lex source bytes; runtime
+                # ``obj_new_braced_string`` would collapse this
+                # on the brace-word path but IRAssignConst skips
+                # the runtime parser, so the codegen has to do it.
+                from ._values import _braced_lineconts
+                self._emit_obj_literal(_braced_lineconts(value))
                 # ``_emit_obj_literal`` always allocates a fresh
                 # TclObj → OWNED.  S2.3 migration.
                 self._emit_var_write_obj(name, source=Ownership.OWNED)
@@ -1544,6 +1551,7 @@ class _WasmEmitterStmtMixin(_Base):
                     if inner.endswith(")") and "(" in inner:
                         cmd_emit = "$" + inner
                 parts = [cmd_emit]
+                from ._values import _braced_lineconts as _braced_nl
                 for i, a in enumerate(args):
                     if _arg_was_braced(i):
                         # Braced token — IR holds the literal content
@@ -1552,6 +1560,13 @@ class _WasmEmitterStmtMixin(_Base):
                         # without applying any substitution.  Fall back
                         # to list-quote when the value contains an
                         # unbalanced brace (rare — ``{a{b}`` style).
+                        # Tcl's ``Tcl_ParseBraces`` collapses ``\<NL>``
+                        # to a single space even inside braces — apply
+                        # the same substitution here so the fallback
+                        # script's expanded word matches the value the
+                        # runtime would see if it parsed the braced
+                        # source directly.
+                        a = _braced_nl(a)
                         if "{" in a or "}" in a:
                             # Use list-quote to get balanced/escaped form.
                             # Args are never at command-start so a leading

--- a/core/compiler/codegen/wasm/_emitter/_values.py
+++ b/core/compiler/codegen/wasm/_emitter/_values.py
@@ -400,18 +400,6 @@ class _WasmEmitterValuesMixin(_Base):
         def _emit_compiled_call_with_bridge(self, *a: Any, **kw: Any) -> Any: ...
 
     def _emit_value(self, value: str, *, was_braced: bool = False) -> Ownership:
-        # Pre-pass: collapse ``\<newline><whitespace>*`` to a single
-        # space.  Mirrors Tcl 9's ``Tcl_ParseBraces`` substitution.
-        # Both braced literals (which intentionally preserve the
-        # raw bytes through the lexer) and any other literal that
-        # somehow leaked the sequence through (compiler-generated
-        # joined argv strings, e.g.) get the same treatment.  Safe
-        # because a literal ``\<newline>`` would only survive parsing
-        # if the source was a brace-quoted word — bare and
-        # double-quoted words have the substitution applied at
-        # lex time.
-        if "\\\n" in value or "\\\r" in value:
-            value = _braced_lineconts(value)
         """Emit an i32 TclObj pointer for *value* and return its
         :class:`Ownership` tag.
 
@@ -441,6 +429,18 @@ class _WasmEmitterValuesMixin(_Base):
         so ``\\{`` stays as the two-char sequence ``\\{`` instead of
         collapsing to ``{``.
         """
+        # Pre-pass: collapse ``\<newline><whitespace>*`` (and the
+        # ``\<CR>`` / ``\<CR><LF>`` variants) to a single space.
+        # Mirrors Tcl 9's ``Tcl_ParseBraces`` substitution.  Both
+        # braced literals (which intentionally preserve the raw bytes
+        # through the lexer) and any other literal that somehow leaked
+        # the sequence through (compiler-generated joined argv strings,
+        # e.g.) get the same treatment.  Safe because a literal
+        # ``\<newline>`` would only survive parsing if the source was
+        # a brace-quoted word — bare and double-quoted words have the
+        # substitution applied at lex time.
+        if "\\\n" in value or "\\\r" in value:
+            value = _braced_lineconts(value)
         if not was_braced:
             var = self._resolve_var_name(value)
             if var is not None:

--- a/core/compiler/codegen/wasm/_emitter/_values.py
+++ b/core/compiler/codegen/wasm/_emitter/_values.py
@@ -321,6 +321,43 @@ def _outer_braces_balanced(value: str) -> bool:
     return depth == 0
 
 
+def _braced_lineconts(value: str) -> str:
+    """Apply Tcl 9's ``\\<newline>`` brace-substitution rule.
+
+    Inside a braced word, ``\\<NL><whitespace>*`` collapses to a
+    single space — see :c:func:`Tcl_ParseBraces` in
+    ``generic/tclParse.c``.  Every other backslash escape is
+    preserved verbatim (the brace literal otherwise suppresses
+    substitution).  Used by braced-literal emitters that would
+    otherwise pass the raw source bytes (including the line-
+    continuation pair) through to the runtime — without this
+    pass, test bundles whose expected-result strings span
+    multiple lines mismatch by one byte (the literal ``\\<NL>``
+    instead of a single space).
+    """
+    if "\\\n" not in value and "\\\r" not in value:
+        return value
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        c = value[i]
+        if c == "\\" and i + 1 < n and value[i + 1] in ("\n", "\r"):
+            # Collapse the backslash + line-terminator + trailing
+            # whitespace to a single space.  ``\r\n`` counts as a
+            # single line terminator.
+            i += 2
+            if value[i - 1] == "\r" and i < n and value[i] == "\n":
+                i += 1
+            while i < n and value[i] in (" ", "\t"):
+                i += 1
+            out.append(" ")
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
 def _looks_like_string_option(arg: str) -> bool:
     """Detect a leading ``-flag`` argument on a ``string`` sub-command.
 
@@ -443,12 +480,13 @@ class _WasmEmitterValuesMixin(_Base):
         # closes twice and is NOT a single braced word, so stripping
         # would mangle it to ``-fla} {-other``.
         if value.startswith("{") and value.endswith("}") and _outer_braces_balanced(value):
-            self._emit_obj_literal(value[1:-1])
+            self._emit_obj_literal(_braced_lineconts(value[1:-1]))
             return Ownership.OWNED
         # Braced token whose outer braces the IR already stripped — emit
-        # the raw content verbatim, no ``\\`` / ``$`` / ``[`` processing.
+        # the raw content verbatim, with ``\<newline>`` line continuation
+        # collapsing per Tcl 9's ``Tcl_ParseBraces``.
         if was_braced:
-            self._emit_obj_literal(value)
+            self._emit_obj_literal(_braced_lineconts(value))
             return Ownership.OWNED
         # Command substitution: [cmd arg1 arg2 ...].  Only treat the
         # whole word as a single cmd-sub when the leading ``[`` truly

--- a/core/compiler/codegen/wasm/_emitter/_values.py
+++ b/core/compiler/codegen/wasm/_emitter/_values.py
@@ -400,6 +400,18 @@ class _WasmEmitterValuesMixin(_Base):
         def _emit_compiled_call_with_bridge(self, *a: Any, **kw: Any) -> Any: ...
 
     def _emit_value(self, value: str, *, was_braced: bool = False) -> Ownership:
+        # Pre-pass: collapse ``\<newline><whitespace>*`` to a single
+        # space.  Mirrors Tcl 9's ``Tcl_ParseBraces`` substitution.
+        # Both braced literals (which intentionally preserve the
+        # raw bytes through the lexer) and any other literal that
+        # somehow leaked the sequence through (compiler-generated
+        # joined argv strings, e.g.) get the same treatment.  Safe
+        # because a literal ``\<newline>`` would only survive parsing
+        # if the source was a brace-quoted word — bare and
+        # double-quoted words have the substitution applied at
+        # lex time.
+        if "\\\n" in value or "\\\r" in value:
+            value = _braced_lineconts(value)
         """Emit an i32 TclObj pointer for *value* and return its
         :class:`Ownership` tag.
 

--- a/core/compiler/codegen/wasm/_emitter/_variables.py
+++ b/core/compiler/codegen/wasm/_emitter/_variables.py
@@ -1500,11 +1500,23 @@ class _WasmEmitterVarMixin(_Base):
             except ValueError:
                 pass  # fall through to dynamic path
         elif not level_spec.startswith("$") and not level_spec.startswith("["):
-            # Static relative integer.
+            # Static relative integer.  Route through the runtime
+            # walker so a cross-interp ``upvar`` (e.g. inside a
+            # hidden command body invoked via ``interp invokehidden``)
+            # skips intervening foreign-interp frames pushed by the
+            # alias / invokehidden trampolines — see interp-20.35 ..
+            # 20.44.  Walker degenerates to plain arithmetic when
+            # the stack contains only same-interp frames.
             try:
                 rel = abs(int(level_spec))
             except ValueError:
                 rel = 1
+            walker_idx = self._shared_imports.get("tcl_upvar_walk_relative")
+            if walker_idx is not None:
+                self._emit_call(depth_idx)
+                self._emit_i32_const(rel)
+                self._emit_call(walker_idx)
+                return True
             self._emit_call(depth_idx)
             self._emit_i32_const(rel)
             self._emit(WasmOp.I32_SUB)

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -555,6 +555,18 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
         [ValType.I32, ValType.I32],
         [ValType.I32],
     ),
+    # Static-relative ``upvar`` helper that walks back ``rel`` frames
+    # belonging to the current interp, skipping frames pushed by
+    # cross-interp alias / invokehidden trampolines.  Replaces the
+    # inline ``frame_depth - rel`` emission so a hidden command's
+    # ``upvar 1`` reaches its same-interp caller (interp-20.35 ..
+    # 20.44).  Args: (cur_depth, rel).
+    "tcl_upvar_walk_relative": (
+        "tcl",
+        "upvar_walk_relative",
+        [ValType.I32, ValType.I32],
+        [ValType.I32],
+    ),
     # Per-frame invocation argv — set by the compiled-proc prologue so
     # ``info level 0`` / ``info level -N`` inside the body reads the real
     # invocation list rather than a placeholder.

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1542,6 +1542,8 @@ def _scan_needed_imports(
         needed.add("tcl_frame_alias_frame_var")
         needed.add("tcl_frame_get_depth")
         needed.add("tcl_upvar_resolve_depth")
+        # Static-relative upvar helper (skips cross-interp frames).
+        needed.add("tcl_upvar_walk_relative")
         # Pending-argv0 ABI: the callee prologue reads this slot
         # (cleared on read) to pick up the invoked word recorded by
         # the caller immediately before the compiled ``call``.  The

--- a/runtime/zig/cmds/eval.zig
+++ b/runtime/zig/cmds/eval.zig
@@ -16,6 +16,10 @@ fn eval_eval(words: []const i32) result_mod.InterpResult {
         stubs.raise("wrong # args: should be \"eval arg ?arg ...?\"");
         return result_mod.from_globals(0);
     }
+    // ``eval`` is a script-eval dispatch — counts as one level
+    // (matches C Tcl's ``TclNREvalObjEx`` ``numLevels++``).
+    if (!interp.recursion_check_enter()) return result_mod.from_globals(0);
+    defer interp.recursion_check_leave();
     if (words.len == 2) {
         const s = obj_ensure_string(words[1]);
         return result_mod.from_globals(interp.eval_script(s.ptr, s.len));
@@ -57,6 +61,9 @@ fn eval_eval(words: []const i32) result_mod.InterpResult {
 
 fn eval_uplevel(words: []const i32) result_mod.InterpResult {
     const interp = @import("../interp/tcl_interp.zig");
+    // ``uplevel`` is a script-eval dispatch.
+    if (!interp.recursion_check_enter()) return result_mod.from_globals(0);
+    defer interp.recursion_check_leave();
     return result_mod.from_globals(interp.eval_uplevel(words));
 }
 

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -487,6 +487,11 @@ fn eval_catch(words: []const i32) result_mod.InterpResult {
     }
     if (words.len >= 2) {
         const interp = @import("../interp/tcl_interp.zig");
+        // ``catch`` evaluates its body — counts as one level
+        // (mirrors C Tcl where catch's body dispatch goes through
+        // ``TclNREvalObjEx`` which ``numLevels++``s).
+        if (!interp.recursion_check_enter()) return result_mod.from_globals(0);
+        defer interp.recursion_check_leave();
         rt.catch_enter();
         const body_s = obj_ensure_string(words[1]);
         const body_result = interp.eval_script(body_s.ptr, body_s.len);

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -79,19 +79,26 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
                         {
                             code_kind = .cont;
                         } else {
-                            // Numeric ``-code N`` for N ≥ 5 — parse
-                            // the value and surface it via the
-                            // ``return_code`` side-channel that
-                            // ``catch_leave`` reads.  Negative or
-                            // non-numeric values fall through to the
-                            // default ``.ok`` mapping (matching
-                            // reference Tcl, which raises an error
-                            // for unknown codes — left as a follow-up
-                            // since the tcltest harness never relies
-                            // on the diagnostic).
-                            var n: i64 = 0;
-                            var ok = code.len > 0;
+                            // Numeric ``-code N`` for N outside the
+                            // 0..4 keyword range — parse the value
+                            // and surface it via the ``return_code``
+                            // side-channel that ``catch_leave`` reads.
+                            // Negative values (e.g. ``-1``) are valid
+                            // custom codes per Tcl 9 (interp-26.x);
+                            // non-numeric values fall through to
+                            // ``.ok`` (matching reference Tcl raises
+                            // an error here — left as a follow-up
+                            // since tcltest doesn't rely on it).
                             var ki: u32 = 0;
+                            var negative = false;
+                            if (code.len >= 1 and cp[0] == '-') {
+                                negative = true;
+                                ki = 1;
+                            } else if (code.len >= 1 and cp[0] == '+') {
+                                ki = 1;
+                            }
+                            var n: i64 = 0;
+                            var ok = ki < code.len;
                             while (ki < code.len) : (ki += 1) {
                                 if (cp[ki] < '0' or cp[ki] > '9') {
                                     ok = false;
@@ -99,7 +106,8 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
                                 }
                                 n = n * 10 + (cp[ki] - '0');
                             }
-                            if (ok and n >= 5) {
+                            if (ok) {
+                                if (negative) n = -n;
                                 code_kind = .custom;
                                 custom_code = n;
                             }

--- a/runtime/zig/cmds/tcl_alias.zig
+++ b/runtime/zig/cmds/tcl_alias.zig
@@ -79,10 +79,35 @@ pub const AliasRec = extern struct {
     /// stashed Interp*.  Keeping it inside ``AliasRec`` keeps the
     /// Command's import-machinery slots intact.
     parent_interp: u32,
+    /// ``Interp*`` whose namespace tree hosts the alias's source
+    /// command.  ``interp alias childPath foo parentPath bar``
+    /// creates the alias in ``childPath``; this slot stores that
+    /// child interp.  Used by :func:`interp_delete` and the target-
+    /// side cascade to walk an interp's own aliases.
+    child_interp: u32,
+    /// Original alias name (Tcl's ``Alias.token``) — the simple
+    /// name the alias was registered under.  Survives ``rename``
+    /// of the command in the namespace tree so
+    /// ``interp alias child foo {}`` (delete) and
+    /// ``interp aliases child`` (list) still resolve to the
+    /// original spelling.  Heap-copied at create time.
+    token_ptr: u32,
+    token_len: u32,
+    /// Linked-list pointers for two distinct chains:
+    ///   * ``next_in_child``: aliases registered in ``child_interp``.
+    ///     Head lives in ``Interp.aliases_head``; the list drives
+    ///     ``interp aliases <path>``.
+    ///   * ``next_target_in_parent``: aliases whose target lives in
+    ///     ``parent_interp``.  Head lives in
+    ///     ``Interp.alias_targets_head``; used by interp deletion
+    ///     to remove dangling source-side aliases when the target
+    ///     interp is torn down.
+    next_in_child: u32,
+    next_target_in_parent: u32,
 };
 
 comptime {
-    if (@sizeOf(AliasRec) != 20) @compileError("AliasRec layout drift");
+    if (@sizeOf(AliasRec) != 40) @compileError("AliasRec layout drift");
 }
 
 /// Allocate and populate a fresh alias redirect Command.  Returns
@@ -109,6 +134,42 @@ pub fn alias_alloc(
     n_prefix: u32,
     prefix_args_addr: u32,
     parent_interp: u32,
+    child_interp: u32,
+) u32 {
+    return alias_alloc_with_token(
+        dest_ns,
+        new_simple_ptr,
+        new_simple_len,
+        new_simple_ptr,
+        new_simple_len,
+        target_name_ptr,
+        target_name_len,
+        n_prefix,
+        prefix_args_addr,
+        parent_interp,
+        child_interp,
+    );
+}
+
+/// Like :func:`alias_alloc`, but the caller supplies the original
+/// alias *token* (the spelling the user passed to ``interp alias``)
+/// distinct from the resolved simple name + dest_ns the Command is
+/// inserted under.  Matches C Tcl's ``TclAliasCreate`` which keys
+/// the ``aliasTable`` by the original token regardless of the
+/// command's actual home namespace, so a later ``rename`` of the
+/// source Command doesn't lose the alias's identity.
+pub fn alias_alloc_with_token(
+    dest_ns: u32,
+    new_simple_ptr: u32,
+    new_simple_len: u32,
+    token_src_ptr: u32,
+    token_src_len: u32,
+    target_name_ptr: u32,
+    target_name_len: u32,
+    n_prefix: u32,
+    prefix_args_addr: u32,
+    parent_interp: u32,
+    child_interp: u32,
 ) u32 {
     const cmd = alloc(tcl_procs.COMMAND_SIZE);
     const slice: [*]u8 = @ptrFromInt(cmd);
@@ -127,6 +188,12 @@ pub fn alias_alloc(
     // Heap-copy the target name bytes.
     const tbuf = alloc(target_name_len);
     if (target_name_len > 0) memcpy(tbuf, target_name_ptr, target_name_len);
+
+    // Heap-copy the token (original alias name as the user passed
+    // it — may include ``::`` qualifiers like ``ns::cmd``).
+    // Mirrors C Tcl's ``Alias.token`` field (tclInterp.c).
+    const token_buf = alloc(token_src_len);
+    if (token_src_len > 0) memcpy(token_buf, token_src_ptr, token_src_len);
 
     // Heap-copy the prefix-args array.  Each element is a u32
     // TclObj handle.  MM-B.6: retain each handle so the alias's
@@ -154,7 +221,28 @@ pub fn alias_alloc(
     r.n_prefix = n_prefix;
     r.prefix_args_addr = pbuf;
     r.parent_interp = parent_interp;
+    r.child_interp = child_interp;
+    r.token_ptr = token_buf;
+    r.token_len = token_src_len;
+    r.next_in_child = 0;
+    r.next_target_in_parent = 0;
     write_i32(cmd + tcl_procs.OFF_PARAMS_OBJ, @bitCast(rec));
+
+    // Thread the new AliasRec into the child interp's aliases list
+    // (used by ``interp aliases``) and into the parent interp's
+    // alias_targets list (used by ``interp delete`` to clear
+    // dangling source-side aliases when the target interp is torn
+    // down).  Same parent / child shortcut as
+    // ``alias_loop_would_form``: ``parent_interp == 0`` is the
+    // same-interp shortcut C Tcl uses.
+    const interp_reg = @import("../interp/tcl_interp_registry.zig");
+    if (child_interp != 0) {
+        interp_reg.alias_chain_push(child_interp, rec, .child);
+    }
+    const real_parent = if (parent_interp == 0) child_interp else parent_interp;
+    if (real_parent != 0) {
+        interp_reg.alias_chain_push(real_parent, rec, .target);
+    }
 
     return cmd;
 }
@@ -165,6 +253,95 @@ pub fn alias_alloc(
 pub fn alias_rec(cmd: u32) *AliasRec {
     const rec_addr = read_i32(cmd + tcl_procs.OFF_PARAMS_OBJ);
     return @ptrFromInt(@as(u32, @bitCast(rec_addr)));
+}
+
+/// Public helper: render an alias's query-form result string from
+/// the :type:`AliasRec` directly (vs from the Command address).
+/// Used by ``interp alias <child> <token>`` lookup where the
+/// caller already has the AliasRec pointer from the per-interp
+/// alias chain.
+pub fn alias_describe_rec(rec_addr: u32) i32 {
+    if (rec_addr == 0) return obj_new_string(0, 0);
+    const r: *AliasRec = @ptrFromInt(rec_addr);
+    if (r.target_name_len == 0) return obj_new_string(0, 0);
+    return alias_describe_inner(r);
+}
+
+/// Public helper: clear an alias by :type:`AliasRec` pointer.
+/// Mirror of :func:`alias_clear` but skips the Command-derived
+/// indirection so post-rename callers (where the Command's
+/// stored name slot doesn't match the original token any more)
+/// still unhook from the per-interp chains.
+pub fn alias_clear_rec(rec_addr: u32) void {
+    if (rec_addr == 0) return;
+    const r: *AliasRec = @ptrFromInt(rec_addr);
+    const interp_reg = @import("../interp/tcl_interp_registry.zig");
+    if (r.child_interp != 0) {
+        interp_reg.alias_chain_remove(r.child_interp, rec_addr, .child);
+    }
+    const real_parent = if (r.parent_interp == 0) r.child_interp else r.parent_interp;
+    if (real_parent != 0) {
+        interp_reg.alias_chain_remove(real_parent, rec_addr, .target);
+    }
+    r.target_name_len = 0;
+    r.target_name_ptr = 0;
+    r.n_prefix = 0;
+    r.prefix_args_addr = 0;
+    r.parent_interp = 0;
+    r.child_interp = 0;
+    r.token_len = 0;
+    r.next_in_child = 0;
+    r.next_target_in_parent = 0;
+}
+
+/// Locate the namespace and bucket that hosts the given alias
+/// Command, walking from ``root_ns``.  Used by ``alias delete``
+/// to clear the live cmd_table entry even after a rename has
+/// moved the Command into a non-root namespace.  Returns ``0``
+/// when the Command can't be found (e.g. it was already
+/// unhooked by a prior delete).
+pub fn alias_host_ns(root_ns: u32, cmd: u32) u32 {
+    // Trivial case: the namespace from the FQN stored in the
+    // Command's name slot.  C Tcl tracks the host explicitly on
+    // ``Command.nsPtr``; we don't but the FQN encodes the same
+    // information.
+    const name_ptr: u32 = @bitCast(read_i32(cmd));
+    const name_len: u32 = @bitCast(read_i32(cmd + 4));
+    if (name_len == 0) return root_ns;
+    // Find the last ``::`` in the FQN — the namespace prefix
+    // sits before it; the simple name follows.
+    const np: [*]const u8 = @ptrFromInt(name_ptr);
+    var i: u32 = if (name_len >= 2 and np[0] == ':' and np[1] == ':') 2 else 0;
+    var last_sep: i64 = -1;
+    while (i + 1 < name_len) : (i += 1) {
+        if (np[i] == ':' and np[i + 1] == ':') last_sep = @intCast(i);
+    }
+    if (last_sep < 0) return root_ns;
+    const prefix_len: u32 = @intCast(last_sep);
+    return tcl_ns.ns_create_from_fqn(@bitCast(name_ptr), @bitCast(prefix_len));
+}
+
+/// Find the Command in ``root_ns`` (or its subtree) whose
+/// ``OFF_PARAMS_OBJ`` slot points at ``rec``.  Walks all reachable
+/// cmd tables under ``root_ns``.  Used by alias delete to recover
+/// the live Command after a rename.
+pub fn find_command_by_rec(root_ns: u32, rec: u32) u32 {
+    if (rec == 0 or root_ns == 0) return 0;
+    var ctx: FindByRecCtx = .{ .rec = rec, .found = 0 };
+    tcl_ns.walk_tree_cmd_tables(root_ns, &ctx, find_by_rec_visit);
+    return ctx.found;
+}
+
+const FindByRecCtx = struct {
+    rec: u32,
+    found: u32,
+};
+
+fn find_by_rec_visit(ctx: *FindByRecCtx, _: u32, _: u32, _: u32, cmd: u32) void {
+    if (ctx.found != 0) return;
+    if (!is_alias(cmd)) return;
+    const r_addr: u32 = @bitCast(read_i32(cmd + tcl_procs.OFF_PARAMS_OBJ));
+    if (r_addr == ctx.rec) ctx.found = cmd;
 }
 
 /// Predicate: is ``cmd`` an alias redirect?  ``cmd == 0`` returns
@@ -182,11 +359,28 @@ pub fn is_alias(cmd: u32) bool {
 pub fn alias_clear(cmd: u32) void {
     if (!is_alias(cmd)) return;
     const r = alias_rec(cmd);
+    // Unhook from per-interp alias chains BEFORE zeroing the
+    // child / parent slots — the unlink walks those chains by
+    // address.  Idempotent; double-clear is a no-op (the chains
+    // simply won't find the record again).
+    const interp_reg = @import("../interp/tcl_interp_registry.zig");
+    const rec_addr: u32 = @intFromPtr(r);
+    if (r.child_interp != 0) {
+        interp_reg.alias_chain_remove(r.child_interp, rec_addr, .child);
+    }
+    const real_parent = if (r.parent_interp == 0) r.child_interp else r.parent_interp;
+    if (real_parent != 0) {
+        interp_reg.alias_chain_remove(real_parent, rec_addr, .target);
+    }
     r.target_name_len = 0;
     r.target_name_ptr = 0;
     r.n_prefix = 0;
     r.prefix_args_addr = 0;
     r.parent_interp = 0;
+    r.child_interp = 0;
+    r.token_len = 0;
+    r.next_in_child = 0;
+    r.next_target_in_parent = 0;
 }
 
 /// Produce the query form for ``interp alias {} newName``: the
@@ -201,7 +395,10 @@ pub fn alias_describe(cmd: u32) i32 {
     if (!is_alias(cmd)) return obj_new_string(0, 0);
     const r = alias_rec(cmd);
     if (r.target_name_len == 0) return obj_new_string(0, 0);
+    return alias_describe_inner(r);
+}
 
+fn alias_describe_inner(r: *AliasRec) i32 {
     // Generous over-allocation: each source byte can expand to two
     // output bytes in the worst ``\\<byte>`` case, plus the bracing
     // overhead per element.  ``+ 8`` per element covers the worst-

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -2075,6 +2075,30 @@ fn root_namespace_names_matching(pat_ptr: u32, pat_len: u32, has_pattern: bool) 
     return obj.obj_new_string_take(buf, merge_total, merge_total);
 }
 
+/// ``info globals ?pattern?`` — list global variables (the root
+/// namespace's variables).  Mirrors Tcl 9's ``Tcl_InfoGlobalsCmd``
+/// in tclCmdIL.c: same shape as ``info vars`` at the top level but
+/// always anchored at the global ns regardless of the caller's
+/// current namespace, and arrays as well as scalars are included.
+///
+/// Used by the safe-interp test set (safe-6.1, safe-6.3) which
+/// expects a fresh ``interp create -safe`` to expose the standard
+/// ``tcl_*`` globals seeded by :func:`seed_child_globals`.
+pub fn info_globals(pattern: i32) i32 {
+    var pat_ptr: u32 = 0;
+    var pat_len: u32 = 0;
+    var has_pattern = false;
+    if (pattern != 0) {
+        const ps = obj_ensure_string(pattern);
+        if (ps.len > 0) {
+            pat_ptr = ps.ptr;
+            pat_len = ps.len;
+            has_pattern = true;
+        }
+    }
+    return root_namespace_names_matching(pat_ptr, pat_len, has_pattern);
+}
+
 // -- Dispatch --------------------------------------------------------------
 
 /// Dispatch for 'info' command — one-word / two-word cases.  The
@@ -2158,6 +2182,7 @@ pub export fn info_dispatch(subcmd: i32, arg: i32) i32 {
     if (str_eq(sp, sub_l, "level")) return info_level(arg);
     if (str_eq(sp, sub_l, "script")) return info_script();
     if (str_eq(sp, sub_l, "vars")) return info_vars(arg);
+    if (str_eq(sp, sub_l, "globals")) return info_globals(arg);
     if (str_eq(sp, sub_l, "constant")) return info_constant(arg);
     if (str_eq(sp, sub_l, "consts")) return info_consts(arg);
     if (str_eq(sp, sub_l, "locals")) {

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -680,18 +680,22 @@ pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u
     const cmd = alias_mod.find_command_by_rec(child.root_ns, rec);
     if (cmd != 0) {
         const r2 = alias_mod.alias_rec(cmd);
-        // Read the Command's stored simple-name from its header
-        // and clear the corresponding bucket.  ``ns_cmd_clear``
-        // tombstones the bucket without freeing — the Command and
-        // AliasRec stay around in bump memory, but ``alias_clear``
-        // below also un-links them from the per-interp chains so
+        // Read the Command's stored name from its header and strip
+        // any ``::`` prefix — alias Commands renamed into a
+        // namespace store the FQN on the header, but
+        // ``ns_cmd_clear`` keys buckets by the simple name (Codex /
+        // Copilot review on PR #451).  ``ns_cmd_clear`` tombstones
+        // the bucket without freeing — the Command and AliasRec
+        // stay around in bump memory, but ``alias_clear`` below
+        // also un-links them from the per-interp chains so
         // ``interp aliases`` no longer sees them.
-        const name_ptr: u32 = @bitCast(obj_mod.read_i32(cmd));
-        const name_len: u32 = @bitCast(obj_mod.read_i32(cmd + 4));
+        const hdr_ptr: u32 = @bitCast(obj_mod.read_i32(cmd));
+        const hdr_len: u32 = @bitCast(obj_mod.read_i32(cmd + 4));
+        const simple = simple_name_of(hdr_ptr, hdr_len);
         // Walk the namespace tree starting at the child's root for
         // a bucket holding ``cmd``.  Use the live-name spelling
         // (post-rename).
-        _ = tcl_ns.ns_cmd_clear(alias_mod.alias_host_ns(child.root_ns, cmd), name_ptr, name_len);
+        _ = tcl_ns.ns_cmd_clear(alias_mod.alias_host_ns(child.root_ns, cmd), simple.ptr, simple.len);
         _ = r2;
     }
     alias_mod.alias_clear_rec(rec);
@@ -1295,7 +1299,13 @@ pub fn eval_interp_create(words: []const i32) i32 {
     // children — safe-6.x specifies the trusted-equivalent set
     // intentionally redacted (no ``machine`` / ``os`` / ``user``
     // when the interp is safe; ``MakeSafe`` strips those).
-    seed_child_globals(child, safe_flag);
+    //
+    // Use the *effective* safety state on the child (which may
+    // have inherited ``INTERP_SAFE`` from the parent) rather than
+    // the raw ``-safe`` flag — Codex review on PR #451 caught a
+    // path where a safe parent's child without ``-safe`` got the
+    // trusted ``tcl_platform`` seed despite being marked safe.
+    seed_child_globals(child, (flags & interp_reg.INTERP_SAFE) != 0);
 
     // Return the path as supplied (or the auto-generated simple
     // name) — matches tclsh's ``Tcl_SetObjResult(interp, childPtr)``
@@ -1619,12 +1629,15 @@ pub fn eval_interp_target(words: []const i32) i32 {
     }
 
     // Resolve the target interp.  ``parent_interp == 0`` is the
-    // single-interp shortcut C Tcl uses when the alias lives in
-    // the same interp as its target — interpret as "the caller's
-    // own interp" (interp_current).
+    // single-interp shortcut: the alias's target Command lives in
+    // the same interp as the alias itself, i.e. ``src_interp``
+    // resolved from ``words[2]``.  Previously this branch fell
+    // through to ``interp_current()``, which returned the caller
+    // instead of the alias's source interp when ``interp target``
+    // was invoked from a sibling / parent (Codex / Copilot review).
     const rec = alias_mod.alias_rec(alias_cmd);
     const target_interp: u32 = if (rec.parent_interp == 0)
-        interp_reg.interp_current()
+        src_interp
     else
         rec.parent_interp;
 

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -5,6 +5,8 @@
 // so they can be imported from tcl_interp.zig without a cycle.
 // Renamed from tcl_interp_interp.zig (the old name was misleading).
 
+const std = @import("std");
+
 const rt = @import("../tcl_runtime.zig");
 const procs = @import("../interp/tcl_procs.zig");
 const obj_mod = @import("../valtypes/tcl_obj.zig");
@@ -323,6 +325,108 @@ pub fn emit_bad_option(name_ptr: u32, name_len: u32) void {
     const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
     catch_mod.tcl_cmd_error(msg);
 }
+/// Raise the canonical Tcl 9 alias-loop diagnostic.  Used by
+/// :func:`interp_alias_create` when its pre-check detects that
+/// installing the alias would form a cycle that ``dispatch_alias``
+/// would later recurse on forever.
+fn raise_alias_loop_error(new_name_ptr: u32, new_name_len: u32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const prefix: []const u8 = "cannot define or rename alias \"";
+    const suffix: []const u8 = "\": would create a loop";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + new_name_len + @as(u32, @intCast(suffix.len));
+    const buf = alloc(total);
+    const d: [*]u8 = @ptrFromInt(buf);
+    for (prefix, 0..) |b, k| d[k] = b;
+    if (new_name_len > 0) {
+        const np: [*]const u8 = @ptrFromInt(new_name_ptr);
+        for (0..new_name_len) |k| d[prefix.len + k] = np[k];
+    }
+    for (suffix, 0..) |b, k| d[prefix.len + new_name_len + k] = b;
+    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    catch_mod.tcl_cmd_error(msg);
+}
+
+/// Detect whether installing an alias ``new`` in ``child_interp``
+/// targeting ``target`` in ``target_interp`` would form a dispatch
+/// cycle that ``dispatch_alias`` would later recurse on forever.
+///
+/// Mirrors ``AliasCheckLoop`` in ``tclInterp.c``: walk the target
+/// chain through whatever interps the aliases route across,
+/// stopping when we either bottom out at a non-alias command or
+/// hit the (interp, simple_name) pair of the new alias.  Capped
+/// at ``MAX_LOOP_HOPS`` so the walk terminates on bizarre
+/// hand-built mutual chains.
+fn alias_loop_would_form(
+    child_interp: u32,
+    new_name_ptr: u32,
+    new_name_len: u32,
+    target_interp: u32,
+    target_name_ptr: u32,
+    target_name_len: u32,
+) bool {
+    if (new_name_len == 0 or target_name_len == 0) return false;
+    const new_simple = simple_name_of(new_name_ptr, new_name_len);
+    var cur_interp = target_interp;
+    var cur_name_ptr: u32 = target_name_ptr;
+    var cur_name_len: u32 = target_name_len;
+    const MAX_LOOP_HOPS: u32 = 16;
+    var hops: u32 = 0;
+    while (hops < MAX_LOOP_HOPS) : (hops += 1) {
+        if (cur_interp == 0) return false;
+        const cur_simple = simple_name_of(cur_name_ptr, cur_name_len);
+        // Hit the proposed new alias's (interp, simple_name) →
+        // loop.  Both must match — same name in a different interp
+        // is a different command.
+        if (cur_interp == child_interp and cur_simple.len == new_simple.len) {
+            const np: [*]const u8 = @ptrFromInt(new_simple.ptr);
+            const cp: [*]const u8 = @ptrFromInt(cur_simple.ptr);
+            var same = true;
+            var k: u32 = 0;
+            while (k < new_simple.len) : (k += 1) {
+                if (np[k] != cp[k]) {
+                    same = false;
+                    break;
+                }
+            }
+            if (same) return true;
+        }
+        // Walk one alias hop: look the current command up in its
+        // host interp's namespace tree.  Non-alias means the chain
+        // bottoms out at a regular command (proc / builtin) — no
+        // loop possible.
+        const ci: *interp_reg.Interp = @ptrFromInt(cur_interp);
+        const cmd = tcl_ns.ns_find_command(ci.root_ns, cur_simple.ptr, cur_simple.len);
+        if (cmd == 0 or !alias_mod.is_alias(cmd)) return false;
+        const rec = alias_mod.alias_rec(cmd);
+        if (rec.target_name_len == 0) return false;
+        // ``parent_interp == 0`` is the same-interp shortcut C Tcl
+        // uses when an alias's target lives in the same interp as
+        // the alias itself; otherwise it names the target's host.
+        cur_interp = if (rec.parent_interp == 0) cur_interp else rec.parent_interp;
+        cur_name_ptr = rec.target_name_ptr;
+        cur_name_len = rec.target_name_len;
+    }
+    return false;
+}
+
+/// Return the simple (un-qualified) name span of *name*.  Strips
+/// every ``::`` separator from the end backwards, returning the
+/// trailing component.  ``::foo::bar`` → ``bar``; bare ``foo`` →
+/// ``foo``.  Used only for the loop-check comparator so callers
+/// can compare across the qualified / unqualified spellings the
+/// alias machinery accepts at the user-facing surface.
+fn simple_name_of(name_ptr: u32, name_len: u32) struct { ptr: u32, len: u32 } {
+    if (name_len == 0) return .{ .ptr = name_ptr, .len = 0 };
+    const sp: [*]const u8 = @ptrFromInt(name_ptr);
+    var i: u32 = name_len;
+    while (i >= 2) : (i -= 1) {
+        if (sp[i - 2] == ':' and sp[i - 1] == ':') {
+            return .{ .ptr = name_ptr + i, .len = name_len - i };
+        }
+    }
+    return .{ .ptr = name_ptr, .len = name_len };
+}
+
 pub fn interp_alias_create(
     child_interp: u32,
     parent_interp: u32,
@@ -333,6 +437,23 @@ pub fn interp_alias_create(
     n_prefix: u32,
     prefix_buf: u32,
 ) i32 {
+    // Alias-loop pre-check.  Walk the proposed target chain
+    // through the (possibly cross-interp) alias graph and refuse
+    // to install the alias if it would create a cycle.  Mirrors
+    // ``AliasCreate`` in ``tclInterp.c`` which calls
+    // ``AliasCheckLoop`` before storing the alias (interp-17.1 /
+    // 17.2 / 17.3).
+    if (alias_loop_would_form(
+        child_interp,
+        new_name_ptr,
+        new_name_len,
+        parent_interp,
+        target_name_ptr,
+        target_name_len,
+    )) {
+        raise_alias_loop_error(new_name_ptr, new_name_len);
+        return 0;
+    }
     // The alias lives in ``child_interp`` (its source side).  The
     // target is resolved at dispatch time against ``parent_interp``.
     // Resolution context is the child interp's root ns when the
@@ -429,14 +550,32 @@ pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u
         r.target_ns
     else if (r.alt_ns != 0)
         r.alt_ns
-    else {
+    else 0;
+    const cmd = if (host_ns != 0) tcl_ns.ns_cmd_find(host_ns, r.simple_ptr, r.simple_len) else 0;
+    if (!alias_mod.is_alias(cmd)) {
+        // No alias by this name — raise the canonical
+        // ``alias "X" not found`` diagnostic.  Matches
+        // ``AliasDelete`` in tclInterp.c which fires before the
+        // un-register step.  Restore the interp swap first so the
+        // error surfaces in the caller's context.
         interp_reg.leave(save);
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const prefix: []const u8 = "alias \"";
+        const suffix: []const u8 = "\" not found";
+        const total: u32 = @as(u32, @intCast(prefix.len)) + new_name_len + @as(u32, @intCast(suffix.len));
+        const buf = alloc(total);
+        const d: [*]u8 = @ptrFromInt(buf);
+        for (prefix, 0..) |b, k| d[k] = b;
+        if (new_name_len > 0) {
+            const np: [*]const u8 = @ptrFromInt(new_name_ptr);
+            for (0..new_name_len) |k| d[prefix.len + k] = np[k];
+        }
+        for (suffix, 0..) |b, k| d[prefix.len + new_name_len + k] = b;
+        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+        catch_mod.tcl_cmd_error(msg);
         return 0;
-    };
-    const cmd = tcl_ns.ns_cmd_find(host_ns, r.simple_ptr, r.simple_len);
-    if (alias_mod.is_alias(cmd)) {
-        alias_mod.alias_clear(cmd);
     }
+    alias_mod.alias_clear(cmd);
     _ = tcl_ns.ns_cmd_clear(host_ns, r.simple_ptr, r.simple_len);
     interp_reg.leave(save);
     procs.lru_invalidate_all();
@@ -586,6 +725,18 @@ pub fn eval_interp_hide(words: []const i32) i32 {
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
+    // Safe-interpreter gate: a safe interp cannot ``interp hide``
+    // its own commands or those of any descendant.  Matches
+    // ``HiddenObjCmd`` in tclInterp.c which raises
+    // ``permission denied: safe interpreter cannot hide commands``
+    // before the path is resolved.
+    if (interp_reg.interp_is_safe(interp_reg.interp_current())) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "permission denied: safe interpreter cannot hide commands";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
     const target_interp = resolve_interp_path(words[2]);
     if (target_interp == 0) return 0;
     const src = obj_ensure_string(words[3]);
@@ -618,7 +769,14 @@ pub fn eval_interp_hide(words: []const i32) i32 {
         },
         .qualified_name_rejected => {
             const catch_mod = @import("../interp/tcl_catch.zig");
-            const err_text = "can't use namespace qualifiers as hidden command token (rename)";
+            const err_text = "cannot use namespace qualifiers in hidden command token (rename)";
+            const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+            catch_mod.tcl_cmd_error(msg);
+            return 0;
+        },
+        .non_global_source => {
+            const catch_mod = @import("../interp/tcl_catch.zig");
+            const err_text = "can only hide global namespace commands (use rename then hide)";
             const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
             catch_mod.tcl_cmd_error(msg);
             return 0;
@@ -635,6 +793,15 @@ pub fn eval_interp_expose(words: []const i32) i32 {
     if (words.len < 4 or words.len > 5) {
         const catch_mod = @import("../interp/tcl_catch.zig");
         const err_text = "wrong # args: should be \"interp expose path hiddenCmdName ?cmdName?\"";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    // Safe-interpreter gate: a safe interp cannot ``interp expose``
+    // hidden commands.  Matches ``ExposeObjCmd`` in tclInterp.c.
+    if (interp_reg.interp_is_safe(interp_reg.interp_current())) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "permission denied: safe interpreter cannot expose commands";
         const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
         catch_mod.tcl_cmd_error(msg);
         return 0;
@@ -923,8 +1090,26 @@ pub fn eval_interp_create(words: []const i32) i32 {
         }
     }
 
-    const flags: u32 = if (safe_flag) interp_reg.INTERP_SAFE else 0;
+    // Inherit the ``INTERP_SAFE`` bit from the parent: child interps
+    // of a safe parent are themselves safe regardless of whether the
+    // creator passed ``-safe``.  Matches C Tcl's ``ChildCreate``,
+    // which copies the parent's safety state onto the new child
+    // (``tmp/tcl9.0.3/generic/tclInterp.c`` ``ChildCreate`` —
+    // ``childIPtr->flags |= Tcl_IsSafe(parentInterp) ? SAFE_INTERP : 0``).
+    var flags: u32 = if (safe_flag) interp_reg.INTERP_SAFE else 0;
+    if (interp_reg.interp_is_safe(parent_interp)) {
+        flags |= interp_reg.INTERP_SAFE;
+    }
     const child = interp_reg.child_create(parent_interp, name_ptr, name_len, flags);
+
+    // Inherit the parent's recursion limit so ``interp create`` inside
+    // a parent that's already adjusted its limit (e.g. test 29.4.1's
+    // ``interp recursionlimit {} 50`` followed by ``interp create``)
+    // produces a child seeded with the parent's value rather than the
+    // default.  Mirrors C Tcl's ``ChildCreate`` which copies
+    // ``parent->maxNestingDepth`` onto ``child->maxNestingDepth``.
+    const parent_limit = interp_reg.interp_recursion_limit(parent_interp);
+    interp_reg.interp_set_recursion_limit(child, parent_limit);
 
     // Register a ``CMD_INTERP_CHILD`` Command in the parent interp's
     // root ns so ``<child> eval script`` resolves through the
@@ -944,6 +1129,18 @@ pub fn eval_interp_create(words: []const i32) i32 {
     procs.proc_count_bump();
     procs.lru_invalidate_all();
 
+    // Seed the standard ``tcl_*`` globals in the freshly-created
+    // child so ``[info globals]`` and ``[array names tcl_platform]``
+    // return the C-Tcl-equivalent shape on first use.  Real Tcl
+    // runs ``Tcl_Init`` (trusted) or ``MakeSafe`` (safe) which both
+    // populate these.  Without this seeding, safe-6.1 / safe-6.3
+    // see an empty globals list and fail.  Use the seeder helper
+    // so the same vars are seeded for both safe and trusted
+    // children — safe-6.x specifies the trusted-equivalent set
+    // intentionally redacted (no ``machine`` / ``os`` / ``user``
+    // when the interp is safe; ``MakeSafe`` strips those).
+    seed_child_globals(child, safe_flag);
+
     // Return the path as supplied (or the auto-generated simple
     // name) — matches tclsh's ``Tcl_SetObjResult(interp, childPtr)``
     // on OPT_CREATE.
@@ -952,6 +1149,49 @@ pub fn eval_interp_create(words: []const i32) i32 {
         obj_ensure_string(path_obj).len,
     );
     return words_obj_new_string_dup(name_ptr, name_len);
+}
+
+/// Populate the standard ``tcl_*`` globals in a fresh child interp
+/// so ``[info globals]`` / ``[array names tcl_platform]`` produce
+/// the Tcl-equivalent shape from the first command.  Mirrors
+/// ``Tcl_Init`` (trusted children) and ``MakeSafe`` (safe children)
+/// in ``tmp/tcl9.0.3/generic/tclInterp.c``.
+///
+/// ``MakeSafe`` redacts the unsafe ``tcl_platform`` elements
+/// (``os``, ``osVersion``, ``machine``, ``user``) so a safe child
+/// only sees ``byteOrder``, ``engine``, ``pathSeparator``,
+/// ``platform``, ``pointerSize``, ``threaded``, ``wordSize``.
+fn seed_child_globals(child: u32, safe_flag: bool) void {
+    // Run the seed as a Tcl script inside the child so it threads
+    // through the normal ``global_set`` / ``array set`` paths and
+    // lands in the child's namespace state regardless of the
+    // caller's outer frame context.  Mirrors C Tcl's ``Tcl_Init``
+    // / ``MakeSafe`` which evaluate :file:`init.tcl` (or its safe
+    // subset) in the new interp.  The exact text is fixed at
+    // compile time so this stays allocation-free past the script
+    // pointer.
+    const seed_trusted: []const u8 =
+        \\set ::tcl_interactive 0
+        \\set ::tcl_patchLevel 9.0.3
+        \\set ::tcl_version 9.0
+        \\array set ::tcl_platform {byteOrder littleEndian engine Tcl pathSeparator : platform unix pointerSize 4 threaded 0 wordSize 8 machine wasm32 os Linux osVersion 0.0 user wasm}
+    ;
+    const seed_safe: []const u8 =
+        \\set ::tcl_interactive 0
+        \\set ::tcl_patchLevel 9.0.3
+        \\set ::tcl_version 9.0
+        \\array set ::tcl_platform {byteOrder littleEndian engine Tcl pathSeparator : platform unix pointerSize 4 threaded 0 wordSize 8}
+    ;
+    const script: []const u8 = if (safe_flag) seed_safe else seed_trusted;
+
+    // Use a dynamic import to avoid the cycle that an
+    // ``@import("../interp/tcl_interp.zig")`` at file scope would
+    // create.  ``eval_script`` runs the seed in the swapped-in
+    // child context.
+    const tcl_interp = @import("../interp/tcl_interp.zig");
+    const save = interp_reg.enter(child);
+    defer interp_reg.leave(save);
+    _ = tcl_interp.eval_script(@intFromPtr(script.ptr), @intCast(script.len));
 }
 
 /// ``interp eval path script ?script ...?``.  Concatenate scripts
@@ -1141,14 +1381,25 @@ pub fn eval_interp_delete(words: []const i32) i32 {
     return 0;
 }
 
-/// ``interp target path alias`` — not supported this wave, but we
-/// emit the canonical tclsh arity error on the no-arg invocation
-/// instead of falling through to the unknown-subcommand stub
-/// (tclsh's ``InterpObjCmd`` validates this branch before the
-/// generic error-dispatch path).  Matches
-/// ``tmp/tcl9.0.3/generic/tclInterp.c`` ``OPT_TARGET`` arg-count
-/// check.  With the right number of args we still return the
-/// "unsupported" stub for now.
+/// ``interp target path alias`` — return the path to the interp
+/// hosting ``alias``'s target command, relative to the caller.
+/// Mirrors ``GetInterp2`` / ``OPT_TARGET`` in tclInterp.c.
+///
+/// Algorithm:
+///   1. Resolve ``path`` to a source interp (the interp the alias
+///      lives in).  Path resolution errors keep the canonical
+///      ``could not find interpreter "X"`` wording.
+///   2. Look up the alias in the source interp; missing → emit
+///      ``alias "FOO" in path "X" not found``.
+///   3. Read the alias's stashed ``parent_interp`` (the interp
+///      whose ``cmd_table`` holds the target command — zero
+///      means "same-interp alias, target lives in the caller's
+///      own interp").
+///   4. Walk from the target interp up through ``parent`` slots
+///      until we reach the caller; collect the simple names in
+///      reverse order to build the descendant path.  If we walk
+///      past the root without finding the caller, the target
+///      isn't ours → raise the ``not my descendant`` error.
 pub fn eval_interp_target(words: []const i32) i32 {
     if (words.len != 4) {
         const catch_mod = @import("../interp/tcl_catch.zig");
@@ -1157,11 +1408,171 @@ pub fn eval_interp_target(words: []const i32) i32 {
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
-    // Arity is valid but the operation isn't wired up.  Surface
-    // the unsupported stub rather than lying with a bogus result.
-    const stubs = @import("../stubs/tcl_stubs.zig");
-    stubs.unsupported_sub("interp", "target");
-    return 0;
+    const src_interp = resolve_interp_path(words[2]);
+    if (src_interp == 0) return 0;
+    const alias_name = obj_ensure_string(words[3]);
+
+    // Find the alias in the source interp.  Aliases live in the
+    // interp's namespace tree as Commands flagged CMD_ALIAS — walk
+    // from the root.
+    const src: *interp_reg.Interp = @ptrFromInt(src_interp);
+    const alias_cmd = tcl_ns.ns_find_command(src.root_ns, alias_name.ptr, alias_name.len);
+    if (!alias_mod.is_alias(alias_cmd)) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const path = obj_ensure_string(words[2]);
+        const prefix: []const u8 = "alias \"";
+        const infix: []const u8 = "\" in path \"";
+        const suffix: []const u8 = "\" not found";
+        const total: u32 = @as(u32, @intCast(prefix.len)) +
+            alias_name.len +
+            @as(u32, @intCast(infix.len)) +
+            path.len +
+            @as(u32, @intCast(suffix.len));
+        const buf = alloc(total);
+        const d: [*]u8 = @ptrFromInt(buf);
+        var off: u32 = 0;
+        for (prefix) |b| {
+            d[off] = b;
+            off += 1;
+        }
+        if (alias_name.len > 0) {
+            const ap: [*]const u8 = @ptrFromInt(alias_name.ptr);
+            for (0..alias_name.len) |k| {
+                d[off + k] = ap[k];
+            }
+            off += alias_name.len;
+        }
+        for (infix) |b| {
+            d[off] = b;
+            off += 1;
+        }
+        if (path.len > 0) {
+            const pp: [*]const u8 = @ptrFromInt(path.ptr);
+            for (0..path.len) |k| {
+                d[off + k] = pp[k];
+            }
+            off += path.len;
+        }
+        for (suffix) |b| {
+            d[off] = b;
+            off += 1;
+        }
+        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(off));
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+
+    // Resolve the target interp.  ``parent_interp == 0`` is the
+    // single-interp shortcut C Tcl uses when the alias lives in
+    // the same interp as its target — interpret as "the caller's
+    // own interp" (interp_current).
+    const rec = alias_mod.alias_rec(alias_cmd);
+    const target_interp: u32 = if (rec.parent_interp == 0)
+        interp_reg.interp_current()
+    else
+        rec.parent_interp;
+
+    // Walk from target up through parent pointers, collecting
+    // simple names, until we hit ``my_interp`` (the caller).
+    // The collected names are in reverse order; rebuild as a
+    // forward list when emitting the result.
+    const my_interp = interp_reg.interp_current();
+    if (target_interp == my_interp) {
+        return obj_new_string(0, 0);
+    }
+
+    // ``MAX_PATH_DEPTH`` is a static cap on the descendant chain
+    // we walk.  Real Tcl walks unbounded but the WASM runtime's
+    // interp tree is shallow in practice; 64 frames is more than
+    // tcltest needs and keeps the stack buffer fixed.
+    const MAX_PATH_DEPTH: u32 = 64;
+    var name_ptrs: [MAX_PATH_DEPTH]u32 = undefined;
+    var name_lens: [MAX_PATH_DEPTH]u32 = undefined;
+    var depth: u32 = 0;
+    var cur = target_interp;
+    while (cur != 0 and cur != my_interp and depth < MAX_PATH_DEPTH) : (depth += 1) {
+        const ci: *interp_reg.Interp = @ptrFromInt(cur);
+        name_ptrs[depth] = ci.name_ptr;
+        name_lens[depth] = ci.name_len;
+        cur = ci.parent;
+    }
+    if (cur != my_interp) {
+        // Walked past root without finding my_interp — target
+        // lives outside the caller's subtree.  Raise the canonical
+        // ``not my descendant`` error.
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const path = obj_ensure_string(words[2]);
+        const prefix: []const u8 = "target interpreter for alias \"";
+        const infix: []const u8 = "\" in path \"";
+        const suffix: []const u8 = "\" is not my descendant";
+        const total: u32 = @as(u32, @intCast(prefix.len)) +
+            alias_name.len +
+            @as(u32, @intCast(infix.len)) +
+            path.len +
+            @as(u32, @intCast(suffix.len));
+        const buf = alloc(total);
+        const d: [*]u8 = @ptrFromInt(buf);
+        var off: u32 = 0;
+        for (prefix) |b| {
+            d[off] = b;
+            off += 1;
+        }
+        if (alias_name.len > 0) {
+            const ap: [*]const u8 = @ptrFromInt(alias_name.ptr);
+            for (0..alias_name.len) |k| {
+                d[off + k] = ap[k];
+            }
+            off += alias_name.len;
+        }
+        for (infix) |b| {
+            d[off] = b;
+            off += 1;
+        }
+        if (path.len > 0) {
+            const pp: [*]const u8 = @ptrFromInt(path.ptr);
+            for (0..path.len) |k| {
+                d[off + k] = pp[k];
+            }
+            off += path.len;
+        }
+        for (suffix) |b| {
+            d[off] = b;
+            off += 1;
+        }
+        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(off));
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+
+    // Build the forward path: names[depth-1], names[depth-2], ...
+    // joined as a Tcl list with single-space separators.
+    if (depth == 0) return obj_new_string(0, 0);
+    var total_len: u32 = 0;
+    var i: u32 = 0;
+    while (i < depth) : (i += 1) {
+        total_len += name_lens[i] * 2 + 8; // generous quoting
+        if (i > 0) total_len += 1;
+    }
+    const buf = alloc(total_len);
+    var off: u32 = 0;
+    // Names are in reverse order in name_ptrs (closest-to-target
+    // first); emit them in forward order (closest-to-caller first).
+    i = depth;
+    while (i > 0) {
+        i -= 1;
+        const is_first = off == 0;
+        if (!is_first) {
+            const d: [*]u8 = @ptrFromInt(buf + off);
+            d[0] = ' ';
+            off += 1;
+        }
+        if (is_first) {
+            off = obj_mod.list_elem_quote(buf, off, name_ptrs[i], name_lens[i]);
+        } else {
+            off = obj_mod.list_elem_quote_nth(buf, off, name_ptrs[i], name_lens[i]);
+        }
+    }
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 /// ``interp issafe ?path?`` — read the ``INTERP_SAFE`` flag on the
@@ -1183,6 +1594,178 @@ pub fn eval_interp_issafe(words: []const i32) i32 {
     } else interp_reg.interp_current();
     const t: *interp_reg.Interp = @ptrFromInt(target);
     return obj_new_int(if ((t.flags & interp_reg.INTERP_SAFE) != 0) 1 else 0);
+}
+
+/// ``interp marktrusted path`` — clear the ``INTERP_SAFE`` flag on
+/// the resolved interp, making a previously-safe child trusted.
+/// Mirrors ``MarkTrustedCmd`` / ``OPT_MARKTRUSTED`` in tclInterp.c.
+///
+/// Permission gate: the *caller* (the interp issuing the command)
+/// must be trusted itself.  Calling ``interp marktrusted`` from a
+/// safe interpreter raises
+/// ``permission denied: safe interpreter cannot mark trusted``.
+pub fn eval_interp_marktrusted(words: []const i32) i32 {
+    if (words.len != 3) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "wrong # args: should be \"interp marktrusted path\"";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    // Permission gate before path resolution — matches C Tcl,
+    // which fires the "permission denied" error even when the path
+    // resolves to a non-existent interp.
+    if (interp_reg.interp_is_safe(interp_reg.interp_current())) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "permission denied: safe interpreter cannot mark trusted";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    const target = resolve_interp_path(words[2]);
+    if (target == 0) return 0;
+    interp_reg.interp_set_safe(target, false);
+    return obj_new_string(0, 0);
+}
+
+/// Parse a decimal-integer Tcl word into u32.  Mirrors Tcl 9's
+/// ``Tcl_GetIntFromObj`` / ``TclGetWideIntFromObj`` for the narrow
+/// range we accept here (i32 max).  Returns:
+///
+///   ``.ok``         — parsed successfully, ``value`` populated.
+///   ``.not_int``    — input wasn't an integer literal.
+///   ``.too_large``  — magnitude overflows i64 (matches Tcl's
+///                     ``integer value too large to represent`` path).
+const ParseIntResult = struct {
+    status: enum { ok, not_int, too_large },
+    value: i64,
+};
+
+fn parse_int_word(handle: i32) ParseIntResult {
+    const s = obj_ensure_string(handle);
+    if (s.len == 0) return .{ .status = .not_int, .value = 0 };
+    // First try the canonical i64 parser.
+    if (obj_mod.try_parse_int(s.ptr, s.len)) |v| {
+        return .{ .status = .ok, .value = v };
+    }
+    // Distinguish "not an integer" from "magnitude overflows".
+    // Walk the digits ourselves to detect overflow vs garbage.
+    const src: [*]const u8 = @ptrFromInt(s.ptr);
+    var i: u32 = 0;
+    // Skip leading whitespace
+    while (i < s.len) : (i += 1) {
+        const c = src[i];
+        if (c != ' ' and c != '\t' and c != '\n' and c != '\r' and c != 0x0B and c != 0x0C) break;
+    }
+    if (i >= s.len) return .{ .status = .not_int, .value = 0 };
+    if (src[i] == '+' or src[i] == '-') i += 1;
+    if (i >= s.len) return .{ .status = .not_int, .value = 0 };
+    var saw_digit = false;
+    while (i < s.len) : (i += 1) {
+        const c = src[i];
+        if (c < '0' or c > '9') break;
+        saw_digit = true;
+    }
+    // Allow trailing whitespace.
+    while (i < s.len) : (i += 1) {
+        const c = src[i];
+        if (c != ' ' and c != '\t' and c != '\n' and c != '\r' and c != 0x0B and c != 0x0C) {
+            return .{ .status = .not_int, .value = 0 };
+        }
+    }
+    if (!saw_digit) return .{ .status = .not_int, .value = 0 };
+    // Digits-only but try_parse_int returned null — must be an
+    // overflow.
+    return .{ .status = .too_large, .value = 0 };
+}
+
+fn raise_expected_integer(handle: i32) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const s = obj_ensure_string(handle);
+    const prefix: []const u8 = "expected integer but got \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + s.len + @as(u32, @intCast(suffix.len));
+    const buf = alloc(total);
+    const d: [*]u8 = @ptrFromInt(buf);
+    for (prefix, 0..) |b, k| d[k] = b;
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |k| d[prefix.len + k] = sp[k];
+    }
+    for (suffix, 0..) |b, k| d[prefix.len + s.len + k] = b;
+    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    catch_mod.tcl_cmd_error(msg);
+}
+
+/// ``interp recursionlimit path ?newlimit?`` — query or set the
+/// per-interp recursion limit.  Mirrors ``RecursionLimitCmd`` /
+/// ``OPT_RECLIMIT`` in tclInterp.c.
+///
+///   - 0 args (``interp recursionlimit``) — wrong-args error.
+///   - 1 arg (path) — return the current limit.
+///   - 2 args (path, newlimit) — parse newlimit as an integer > 0,
+///     install it, return the new value.  Setting from inside a
+///     safe interpreter raises
+///     ``permission denied: safe interpreters cannot change recursion limit``.
+///     Magnitude overflow raises ``integer value too large to represent``.
+pub fn eval_interp_recursionlimit(words: []const i32) i32 {
+    if (words.len < 3 or words.len > 4) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "wrong # args: should be \"interp recursionlimit path ?newlimit?\"";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    // Path-resolution comes before the safe-interp permission check
+    // so ``interp recursionlimit nosuchinterp`` raises the
+    // ``could not find interpreter`` diagnostic even when called
+    // from a safe parent.  Setter form moves the permission check
+    // ahead of the integer parse, matching C Tcl.
+    const target = resolve_interp_path(words[2]);
+    if (target == 0) return 0;
+    if (words.len == 3) {
+        const cur = interp_reg.interp_recursion_limit(target);
+        return obj_new_int(@intCast(cur));
+    }
+    if (interp_reg.interp_is_safe(interp_reg.interp_current())) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "permission denied: safe interpreters cannot change recursion limit";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    const parsed = parse_int_word(words[3]);
+    switch (parsed.status) {
+        .not_int => {
+            raise_expected_integer(words[3]);
+            return 0;
+        },
+        .too_large => {
+            const catch_mod = @import("../interp/tcl_catch.zig");
+            const err_text = "integer value too large to represent";
+            const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+            catch_mod.tcl_cmd_error(msg);
+            return 0;
+        },
+        .ok => {},
+    }
+    if (parsed.value < 1) {
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const err_text = "recursion limit must be > 0";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    // Clamp to u32 range — we already rejected magnitudes that
+    // overflowed i64; anything above u32 max is silently truncated
+    // to u32 max, matching the deep-recursion-impossible-anyway
+    // semantics of the WASM runtime.
+    const new_limit: u32 = if (parsed.value > @as(i64, std.math.maxInt(u32)))
+        std.math.maxInt(u32)
+    else
+        @intCast(parsed.value);
+    interp_reg.interp_set_recursion_limit(target, new_limit);
+    return obj_new_int(@intCast(new_limit));
 }
 // -- ``namespace which`` ---------------------------------------------------
 

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -253,6 +253,7 @@ pub fn eval_rename(words: []const i32) i32 {
                 return 0;
             },
             .target_exists => return 0, // unreachable on delete form
+            .alias_loop => return 0, // unreachable on delete form
         }
     }
 
@@ -272,7 +273,17 @@ pub fn eval_rename(words: []const i32) i32 {
         new_r.simple_len,
     );
     switch (r) {
-        .ok => return 0,
+        .ok => {
+            // Rewrite the AliasRec's token slot when an alias is
+            // renamed via the move form *and* the original token
+            // hasn't been preserved by the chain.  In C Tcl, the
+            // ``aliasTable`` keys by the token so a rename leaves
+            // the token intact — we mirror that by keeping the
+            // ``token_*`` slot untouched; the FQN on the Command
+            // header is the only thing that changes.  No extra
+            // work needed here.
+            return 0;
+        },
         .not_found => {
             rename_error("can't rename \"", old_s.ptr, old_s.len, "\": command doesn't exist");
             return 0;
@@ -283,6 +294,13 @@ pub fn eval_rename(words: []const i32) i32 {
         },
         .builtin_protected => {
             rename_error("can't rename \"", old_s.ptr, old_s.len, "\": built-in command");
+            return 0;
+        },
+        .alias_loop => {
+            // Alias rename would form a dispatch cycle —
+            // ``cannot define or rename alias "<NEW>": would
+            // create a loop`` (interp-17.4 / 17.5 / 17.6).
+            raise_alias_loop_error(new_r.simple_ptr, new_r.simple_len);
             return 0;
         },
     }
@@ -482,11 +500,94 @@ pub fn interp_alias_create(
         return 0;
     }
 
-    // If an alias / command already lives under this name, replace
-    // it.  This matches C Tcl where ``interp alias {} foo {} bar``
-    // overwrites any previous ``foo`` (proc, alias, or otherwise).
-    // The previous Command stays in linear memory — leaked per the
-    // bump-allocator contract.
+    // If a Command already lives under the destination simple name
+    // (in r.target_ns), the ``ns_cmd_put`` below overwrites it.
+    // Mirror C Tcl's ``Tcl_CreateObjCommand`` deleteProc which
+    // fires the old alias's ``AliasObjCmdDeleteProc`` cleanup
+    // (removes its ``aliasTable`` entry).  In our model, we
+    // explicitly clear the old AliasRec's chain hookup so
+    // ``interp aliases`` doesn't double-report.
+    //
+    // Special case: when the existing Command is a
+    // ``CMD_INTERP_CHILD`` (e.g. ``interp create a`` registered
+    // ``a`` as the child-interp dispatch command), overwriting
+    // it means the child interp gets deleted as a side effect
+    // — C Tcl's deleteProc fires ``ChildObjCmdDeleteProc`` which
+    // calls ``Tcl_DeleteInterp``.  Mirror that here so a later
+    // dispatch through the alias's stashed parent_interp picks
+    // up the ``INTERP_DELETED`` flag and surfaces the canonical
+    // ``cannot define or rename alias "X": interpreter deleted``
+    // diagnostic (interp-14.4).
+    const existing_cmd = tcl_ns.ns_cmd_find(r.target_ns, r.simple_ptr, r.simple_len);
+    if (existing_cmd != 0) {
+        const existing_flags: u32 = @bitCast(obj_mod.read_i32(existing_cmd + procs.OFF_FLAGS));
+        if ((existing_flags & 0x200) != 0) {
+            // CMD_INTERP_CHILD — extract the embedded child interp
+            // and tear it down before the alias install.  Match
+            // the full ``interp delete`` cascade: drop xlinks,
+            // mark deleted via ``child_delete``, and clear the
+            // parent's cmd_table bucket so ``[info commands]``
+            // no longer reports the dispatch command.
+            const victim = interp_reg.cmd_child_interp(existing_cmd);
+            if (victim != 0) {
+                const v: *interp_reg.Interp = @ptrFromInt(victim);
+                if (v.parent != 0 and v.name_len > 0) {
+                    const parent_i: *interp_reg.Interp = @ptrFromInt(v.parent);
+                    const xlinks = @import("../interp/tcl_xlinks.zig");
+                    xlinks.drop_for_interp(victim);
+                    _ = interp_reg.child_delete(v.parent, v.name_ptr, v.name_len);
+                    _ = tcl_ns.ns_cmd_clear(parent_i.root_ns, v.name_ptr, v.name_len);
+                }
+            }
+        }
+    }
+    if (alias_mod.is_alias(existing_cmd)) {
+        alias_mod.alias_clear(existing_cmd);
+    }
+    // If the alias target now lives in a deleted interp, refuse
+    // the create — mirror ``AliasCreate``'s ``Tcl_InterpDeleted``
+    // check after the loop probe (tclInterp.c lines 1410-1420).
+    if (parent_interp != 0 and interp_reg.is_deleted(parent_interp)) {
+        interp_reg.leave(save);
+        const catch_mod = @import("../interp/tcl_catch.zig");
+        const prefix: []const u8 = "cannot define or rename alias \"";
+        const suffix: []const u8 = "\": interpreter deleted";
+        const total: u32 = @as(u32, @intCast(prefix.len)) + new_name_len + @as(u32, @intCast(suffix.len));
+        const buf = alloc(total);
+        const d: [*]u8 = @ptrFromInt(buf);
+        for (prefix, 0..) |b, k| d[k] = b;
+        if (new_name_len > 0) {
+            const np: [*]const u8 = @ptrFromInt(new_name_ptr);
+            for (0..new_name_len) |k| d[prefix.len + k] = np[k];
+        }
+        for (suffix, 0..) |b, k| d[prefix.len + new_name_len + k] = b;
+        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+    // Token collision: if the proposed token already names an
+    // alias in the child's aliases chain (from a previously-renamed
+    // alias whose source Command moved off the original name slot
+    // but kept its token), prepend ``::`` until the token is
+    // unique.  Mirrors ``TclAliasCreate`` in tclInterp.c lines
+    // 1553-1580 ("alias name cannot be used as unique token, it
+    // is already taken — produce a unique token by prepending '::'
+    // repeatedly").  The prepended token is what
+    // ``interp aliases`` will report for the new alias.
+    var token_ptr: u32 = new_name_ptr;
+    var token_len: u32 = new_name_len;
+    while (interp_reg.alias_chain_find_token(child_interp, .child, token_ptr, token_len) != 0) {
+        const prefix_len: u32 = 2;
+        const new_len: u32 = prefix_len + token_len;
+        const new_buf = alloc(new_len);
+        const dst: [*]u8 = @ptrFromInt(new_buf);
+        dst[0] = ':';
+        dst[1] = ':';
+        if (token_len > 0) memcpy(new_buf + prefix_len, token_ptr, token_len);
+        token_ptr = new_buf;
+        token_len = new_len;
+    }
+
     //
     // The parent interp is stashed directly on the ``AliasRec``
     // (via ``alias_alloc``'s last parameter) rather than on the
@@ -496,15 +597,18 @@ pub fn interp_alias_create(
     // stashed Interp* and corrupt cross-interp dispatch.  Zero
     // here means "same-interp dispatch; no swap needed".
     const stash_parent: u32 = if (parent_interp != child_interp) parent_interp else 0;
-    const cmd = alias_mod.alias_alloc(
+    const cmd = alias_mod.alias_alloc_with_token(
         r.target_ns,
         r.simple_ptr,
         r.simple_len,
+        token_ptr,
+        token_len,
         target_name_ptr,
         target_name_len,
         n_prefix,
         prefix_buf,
         stash_parent,
+        child_interp,
     );
     _ = tcl_ns.ns_cmd_put(r.target_ns, r.simple_ptr, r.simple_len, cmd);
     interp_reg.leave(save);
@@ -515,50 +619,34 @@ pub fn interp_alias_create(
 }
 
 pub fn interp_alias_query(child_interp: u32, new_name_ptr: u32, new_name_len: u32) i32 {
-    const child: *interp_reg.Interp = @ptrFromInt(child_interp);
-    const cxt: u32 = if (child_interp == interp_reg.interp_current())
-        tcl_ns.ns_current()
-    else
-        child.root_ns;
-    const swapped_child = child_interp != interp_reg.interp_current();
-    const save = if (swapped_child) interp_reg.enter(child_interp) else interp_reg.EnterSave{
-        .prev_interp = interp_reg.current_interp,
-        .prev_root_addr = tcl_ns.root_addr,
-        .prev_current_ns = tcl_ns.current_ns,
-    };
-    const cmd = tcl_ns.ns_find_command(cxt, new_name_ptr, new_name_len);
-    interp_reg.leave(save);
-    if (!alias_mod.is_alias(cmd)) return 0;
-    return alias_mod.alias_describe(cmd);
+    // Look up the alias by its original token (the simple name the
+    // caller passed to ``interp alias``).  Survives ``rename`` of
+    // the source Command in the namespace tree because the token
+    // is heap-copied onto the :type:`AliasRec`.  Matches C Tcl's
+    // ``Tcl_FindHashEntry(&iPtr->child.aliasTable, ...)``.
+    const rec = interp_reg.alias_chain_find_token(
+        child_interp,
+        .child,
+        new_name_ptr,
+        new_name_len,
+    );
+    if (rec == 0) return 0;
+    return alias_mod.alias_describe_rec(rec);
 }
 
 pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u32) i32 {
-    const child: *interp_reg.Interp = @ptrFromInt(child_interp);
-    const cxt: u32 = if (child_interp == interp_reg.interp_current())
-        tcl_ns.ns_current()
-    else
-        child.root_ns;
-    const swapped_child = child_interp != interp_reg.interp_current();
-    const save = if (swapped_child) interp_reg.enter(child_interp) else interp_reg.EnterSave{
-        .prev_interp = interp_reg.current_interp,
-        .prev_root_addr = tcl_ns.root_addr,
-        .prev_current_ns = tcl_ns.current_ns,
-    };
-    const r = tcl_ns.ns_resolve_qualified(cxt, new_name_ptr, new_name_len);
-    const host_ns: u32 = if (r.target_ns != 0 and
-        tcl_ns.ns_cmd_find(r.target_ns, r.simple_ptr, r.simple_len) != 0)
-        r.target_ns
-    else if (r.alt_ns != 0)
-        r.alt_ns
-    else 0;
-    const cmd = if (host_ns != 0) tcl_ns.ns_cmd_find(host_ns, r.simple_ptr, r.simple_len) else 0;
-    if (!alias_mod.is_alias(cmd)) {
-        // No alias by this name — raise the canonical
-        // ``alias "X" not found`` diagnostic.  Matches
-        // ``AliasDelete`` in tclInterp.c which fires before the
-        // un-register step.  Restore the interp swap first so the
-        // error surfaces in the caller's context.
-        interp_reg.leave(save);
+    // Resolve by token first — covers the ``interp alias child
+    // foo {}`` form even after a ``rename foo zop`` has moved the
+    // source Command.  ``Tcl_DeleteAlias`` in tclInterp.c keeps the
+    // hashtable entry keyed by the original name for the same
+    // reason.
+    const rec = interp_reg.alias_chain_find_token(
+        child_interp,
+        .child,
+        new_name_ptr,
+        new_name_len,
+    );
+    if (rec == 0) {
         const catch_mod = @import("../interp/tcl_catch.zig");
         const prefix: []const u8 = "alias \"";
         const suffix: []const u8 = "\" not found";
@@ -575,8 +663,38 @@ pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
-    alias_mod.alias_clear(cmd);
-    _ = tcl_ns.ns_cmd_clear(host_ns, r.simple_ptr, r.simple_len);
+    // Now find the live Command — its name slot may have been
+    // ``rename``d off the original token.  Walk the AliasRec's
+    // ``parent_interp`` / ``child_interp`` slots through the
+    // interp's namespace tree and clear the bucket that still
+    // points at this alias.
+    const child: *interp_reg.Interp = @ptrFromInt(child_interp);
+    const swapped_child = child_interp != interp_reg.interp_current();
+    const save = if (swapped_child) interp_reg.enter(child_interp) else interp_reg.EnterSave{
+        .prev_interp = interp_reg.current_interp,
+        .prev_root_addr = tcl_ns.root_addr,
+        .prev_current_ns = tcl_ns.current_ns,
+    };
+    // The Command's current name lives on its header; walk the
+    // child interp's root ns for a matching alias-flagged entry.
+    const cmd = alias_mod.find_command_by_rec(child.root_ns, rec);
+    if (cmd != 0) {
+        const r2 = alias_mod.alias_rec(cmd);
+        // Read the Command's stored simple-name from its header
+        // and clear the corresponding bucket.  ``ns_cmd_clear``
+        // tombstones the bucket without freeing — the Command and
+        // AliasRec stay around in bump memory, but ``alias_clear``
+        // below also un-links them from the per-interp chains so
+        // ``interp aliases`` no longer sees them.
+        const name_ptr: u32 = @bitCast(obj_mod.read_i32(cmd));
+        const name_len: u32 = @bitCast(obj_mod.read_i32(cmd + 4));
+        // Walk the namespace tree starting at the child's root for
+        // a bucket holding ``cmd``.  Use the live-name spelling
+        // (post-rename).
+        _ = tcl_ns.ns_cmd_clear(alias_mod.alias_host_ns(child.root_ns, cmd), name_ptr, name_len);
+        _ = r2;
+    }
+    alias_mod.alias_clear_rec(rec);
     interp_reg.leave(save);
     procs.lru_invalidate_all();
     return 0;
@@ -603,24 +721,62 @@ pub fn interp_aliases_list() i32 {
 /// Shared implementation: list aliases reachable from ``target_interp``.
 /// Child-as-command (`<child> aliases`) and the explicit
 /// ``interp aliases <path>`` form both route here.
+///
+/// Walks the per-interp aliases linked list (``Interp.aliases_head``)
+/// which is keyed by the original token — so a ``rename foo zop``
+/// of an alias's source Command doesn't change what ``interp
+/// aliases`` reports.  Matches C Tcl's ``InterpAliasesCmd`` which
+/// iterates ``Interp.child.aliasTable``.
 pub fn interp_aliases_list_for(target_interp: u32) i32 {
     if (target_interp == 0) return obj_new_string(0, 0);
     const t: *interp_reg.Interp = @ptrFromInt(target_interp);
-    // Accumulator: sum string lengths (plus separators) to size the
-    // output buffer.  We walk the tree twice: once to size, once to
-    // fill.  Single-pass grown allocation would require a realloc
-    // path the bump allocator doesn't support.  Both passes route
-    // through the shared ``tcl_ns.walk_tree_cmd_tables`` helper so
-    // every ns-tree introspection walker shares one recursion shape.
-    var ctx: AliasListCtx = .{ .total = 0, .count = 0, .buf = 0, .off = 0 };
-    tcl_ns.walk_tree_cmd_tables(t.root_ns, &ctx, alias_size_visit);
-    if (ctx.total == 0) return obj_new_string(0, 0);
 
-    ctx.buf = alloc(ctx.total);
-    ctx.off = 0;
-    ctx.count = 0;
-    tcl_ns.walk_tree_cmd_tables(t.root_ns, &ctx, alias_fill_visit);
-    return obj_new_string(@bitCast(ctx.buf), @bitCast(ctx.off));
+    // Two-pass build: size, then fill.  ``list_elem_quote`` /
+    // ``_nth`` write at most ``2*len + 2`` bytes per element plus
+    // one separator each — same budget as the previous
+    // walk_tree_cmd_tables-based implementation.
+    var total: u32 = 0;
+    var count: u32 = 0;
+    var cur: u32 = t.aliases_head;
+    while (cur != 0) {
+        const r: *alias_mod.AliasRec = @ptrFromInt(cur);
+        if (r.token_len > 0 or count > 0) {
+            // Skip cleared records (token_len was zeroed by
+            // alias_clear).  Live records always have token_len
+            // > 0 since the original alias name was at least one
+            // byte.
+            if (r.token_len > 0) {
+                if (count > 0) total += 1;
+                total += 2 * r.token_len + 2;
+                count += 1;
+            }
+        }
+        cur = r.next_in_child;
+    }
+    if (count == 0) return obj_new_string(0, 0);
+
+    const buf = alloc(total);
+    var off: u32 = 0;
+    var written: u32 = 0;
+    cur = t.aliases_head;
+    const list_quote = @import("../valtypes/tcl_list_quote.zig");
+    while (cur != 0) {
+        const r: *alias_mod.AliasRec = @ptrFromInt(cur);
+        if (r.token_len > 0) {
+            if (written > 0) {
+                const d: [*]u8 = @ptrFromInt(buf + off);
+                d[0] = ' ';
+                off += 1;
+            }
+            off = if (written == 0)
+                list_quote.list_elem_quote(buf, off, r.token_ptr, r.token_len)
+            else
+                list_quote.list_elem_quote_nth(buf, off, r.token_ptr, r.token_len);
+            written += 1;
+        }
+        cur = r.next_in_child;
+    }
+    return obj_new_string(@bitCast(buf), @bitCast(off));
 }
 
 const AliasListCtx = struct {
@@ -1765,6 +1921,33 @@ pub fn eval_interp_recursionlimit(words: []const i32) i32 {
     else
         @intCast(parsed.value);
     interp_reg.interp_set_recursion_limit(target, new_limit);
+
+    // ``interp recursionlimit {} N`` evaluated INSIDE the target
+    // interp (interp == childInterp in C Tcl's check) and where
+    // the current ``num_levels`` already exceeds the new limit
+    // raises ``falling back due to new recursion limit`` — see
+    // ``ChildRecursionLimit`` in tclInterp.c.  This lets the
+    // running script discover at the boundary that the limit
+    // has been lowered below its current nesting (interp-29.3.4
+    // / 29.3.5 / 29.3.7c / 29.3.8b / 29.3.10b / 29.3.11b).
+    //
+    // C Tcl's ``Tcl_EvalObjv`` ``numLevels++``s ahead of running
+    // the ``interp recursionlimit`` handler, so the comparison
+    // reads ``numLevels > limit``.  Our :fn:`recursion_check_enter`
+    // doesn't fire for builtin commands like ``interp ...``, so we
+    // adjust by adding 1 here — the +1 represents the recursionlimit
+    // dispatch itself that would have ++d in C Tcl's accounting.
+    if (target == interp_reg.interp_current()) {
+        const ci: *interp_reg.Interp = @ptrFromInt(target);
+        if (ci.num_levels + 1 > new_limit) {
+            const catch_mod = @import("../interp/tcl_catch.zig");
+            const err_text = "falling back due to new recursion limit";
+            const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+            catch_mod.tcl_cmd_error(msg);
+            return 0;
+        }
+    }
+
     return obj_new_int(@intCast(new_limit));
 }
 // -- ``namespace which`` ---------------------------------------------------

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -372,8 +372,10 @@ fn raise_alias_loop_error(new_name_ptr: u32, new_name_len: u32) void {
 /// chain through whatever interps the aliases route across,
 /// stopping when we either bottom out at a non-alias command or
 /// hit the (interp, simple_name) pair of the new alias.  Capped
-/// at ``MAX_LOOP_HOPS`` so the walk terminates on bizarre
-/// hand-built mutual chains.
+/// at ``MAX_LOOP_HOPS`` so the walk terminates on hand-built
+/// mutual chains.  Exhausting the cap is treated as a loop so a
+/// pathologically deep chain can't slip past detection here and
+/// then recurse at dispatch (Copilot review on PR #451).
 fn alias_loop_would_form(
     child_interp: u32,
     new_name_ptr: u32,
@@ -387,7 +389,7 @@ fn alias_loop_would_form(
     var cur_interp = target_interp;
     var cur_name_ptr: u32 = target_name_ptr;
     var cur_name_len: u32 = target_name_len;
-    const MAX_LOOP_HOPS: u32 = 16;
+    const MAX_LOOP_HOPS: u32 = 64;
     var hops: u32 = 0;
     while (hops < MAX_LOOP_HOPS) : (hops += 1) {
         if (cur_interp == 0) return false;
@@ -424,7 +426,10 @@ fn alias_loop_would_form(
         cur_name_ptr = rec.target_name_ptr;
         cur_name_len = rec.target_name_len;
     }
-    return false;
+    // Hop cap exhausted without bottoming out at a non-alias —
+    // treat as a loop so a deep chain can't escape detection
+    // here and recurse at dispatch (Copilot review).
+    return true;
 }
 
 /// Return the simple (un-qualified) name span of *name*.  Strips
@@ -1797,12 +1802,21 @@ pub fn eval_interp_marktrusted(words: []const i32) i32 {
     return obj_new_string(0, 0);
 }
 
-/// Parse a decimal-integer Tcl word into u32.  Mirrors Tcl 9's
-/// ``Tcl_GetIntFromObj`` / ``TclGetWideIntFromObj`` for the narrow
-/// range we accept here (i32 max).  Returns:
+/// Parse an integer Tcl word into i64.  Accepts the decimal form
+/// the runtime's ``try_parse_int`` handles.  Note: this does NOT
+/// (yet) accept the full Tcl ``Tcl_GetIntFromObj`` surface — hex
+/// (``0x10``), octal (``0o12``), and binary (``0b1010``) literals
+/// fall into the ``.not_int`` branch and the caller emits the
+/// ``expected integer but got "X"`` diagnostic.  Tracked as a
+/// follow-up under the broader ``try_parse_int`` extension
+/// (Copilot review on PR #451 — extending this requires touching
+/// every other ``try_parse_int`` consumer and is out of scope for
+/// the per-interp recursionlimit work).
+///
+/// Returns:
 ///
 ///   ``.ok``         — parsed successfully, ``value`` populated.
-///   ``.not_int``    — input wasn't an integer literal.
+///   ``.not_int``    — input wasn't a decimal-integer literal.
 ///   ``.too_large``  — magnitude overflows i64 (matches Tcl's
 ///                     ``integer value too large to represent`` path).
 const ParseIntResult = struct {

--- a/runtime/zig/cmds/tcl_hide.zig
+++ b/runtime/zig/cmds/tcl_hide.zig
@@ -56,13 +56,18 @@ pub const HideResult = enum(u32) {
     ok = 0,
     /// ``cmd`` didn't resolve to any live Command.
     not_found = 1,
-    /// Caller passed a qualified source name
-    /// (``::foo::bar``) — hidden commands must be identified by their
-    /// simple name in the current namespace.
+    /// Caller passed a qualified hidden-token (destination) name
+    /// (``::foo::bar``) — hidden commands must be identified by a
+    /// simple token without ``::`` qualifiers.
     qualified_name_rejected = 2,
     /// An entry is already live in the hidden table under
     /// ``hiddenName``.
     hidden_name_taken = 3,
+    /// Source command resolved to a non-global namespace.  Tcl's
+    /// ``Tcl_HideCommand`` only permits hiding global-namespace
+    /// commands; namespaced commands must be ``rename``d into the
+    /// global ns first.
+    non_global_source = 4,
 };
 
 /// Outcome of :func:`expose_command`.
@@ -141,8 +146,17 @@ pub fn hide_command(
     hidden_name_ptr: u32,
     hidden_name_len: u32,
 ) HideResult {
-    if (has_qualifier(src_simple_ptr, src_simple_len)) return .qualified_name_rejected;
+    // Tcl 9 ``Tcl_HideCommand`` orders the checks:
+    //   1. hiddenCmdToken contains ``::`` → "cannot use namespace
+    //      qualifiers in hidden command token (rename)".
+    //   2. Source command resolves to a non-global namespace →
+    //      "can only hide global namespace commands (use rename
+    //      then hide)".
+    // We map (1) onto ``qualified_name_rejected`` and (2) onto a
+    // distinct ``non_global_source`` enum so the caller renders
+    // the upstream wording for each case.
     if (has_qualifier(hidden_name_ptr, hidden_name_len)) return .qualified_name_rejected;
+    if (has_qualifier(src_simple_ptr, src_simple_len)) return .non_global_source;
 
     const cmd = tcl_ns.ns_cmd_find(src_ns, src_simple_ptr, src_simple_len);
     if (cmd == 0) {

--- a/runtime/zig/cmds/tcl_rename.zig
+++ b/runtime/zig/cmds/tcl_rename.zig
@@ -56,6 +56,10 @@ pub const RenameResult = enum(u32) {
     target_exists = 2,
     /// ``oldName`` names a hardcoded built-in we refuse to rename.
     builtin_protected = 3,
+    /// Renaming this alias under the new name would form a
+    /// dispatch cycle (interp-17.4 / 17.5 / 17.6).  Matches C
+    /// Tcl's ``AliasCheckLoop`` returning ``TCL_ERROR``.
+    alias_loop = 4,
 };
 
 /// Refuse to rename these hardcoded built-ins.  Matches the spirit of
@@ -116,6 +120,69 @@ fn write_command_fqn(cmd: u32, target_ns: u32, simple_ptr: u32, simple_len: u32)
 /// Mirrors the finalisation step in ``ns_forget`` but driven from the
 /// source side: ``ns_forget`` walks redirects in a dest ns, this walks
 /// redirects pointing at a source that's being removed.
+/// Detect whether renaming an alias to ``new_name`` would form a
+/// dispatch cycle.  Walks the alias's target chain using the same
+/// algorithm as :fn:`alias_loop_would_form` in tcl_cmd_interp.zig
+/// but starts from the alias's *current* target and treats
+/// ``new_name`` (in the alias's child_interp) as the proposed
+/// new identity.
+fn alias_rename_would_loop(rec: *const @import("tcl_alias.zig").AliasRec, new_name_ptr: u32, new_name_len: u32) bool {
+    const alias_mod = @import("tcl_alias.zig");
+    const interp_reg = @import("../interp/tcl_interp_registry.zig");
+    if (new_name_len == 0) return false;
+    // The alias lives in ``child_interp``.  After rename its
+    // identity becomes (child_interp, new_name); the target it
+    // hops to is unchanged.  Walk the chain starting from
+    // ``rec.target`` and see if we revisit (child_interp,
+    // new_name).
+    const new_simple = simple_name_of(new_name_ptr, new_name_len);
+    const child_interp = rec.child_interp;
+    if (child_interp == 0) return false;
+    // Resolve the current target's effective interp: parent_interp
+    // == 0 means same-as-child for cross-interp encoding.
+    var cur_interp: u32 = if (rec.parent_interp == 0) child_interp else rec.parent_interp;
+    var cur_name_ptr: u32 = rec.target_name_ptr;
+    var cur_name_len: u32 = rec.target_name_len;
+    const MAX_HOPS: u32 = 16;
+    var hops: u32 = 0;
+    while (hops < MAX_HOPS) : (hops += 1) {
+        if (cur_interp == 0) return false;
+        const cur_simple = simple_name_of(cur_name_ptr, cur_name_len);
+        if (cur_interp == child_interp and cur_simple.len == new_simple.len) {
+            const np: [*]const u8 = @ptrFromInt(new_simple.ptr);
+            const cp: [*]const u8 = @ptrFromInt(cur_simple.ptr);
+            var same = true;
+            var k: u32 = 0;
+            while (k < new_simple.len) : (k += 1) {
+                if (np[k] != cp[k]) { same = false; break; }
+            }
+            if (same) return true;
+        }
+        // Walk one alias hop.
+        const ci: *interp_reg.Interp = @ptrFromInt(cur_interp);
+        const cmd2 = tcl_ns.ns_find_command(ci.root_ns, cur_simple.ptr, cur_simple.len);
+        if (cmd2 == 0 or !alias_mod.is_alias(cmd2)) return false;
+        const next_rec = alias_mod.alias_rec(cmd2);
+        if (next_rec.target_name_len == 0) return false;
+        cur_interp = if (next_rec.parent_interp == 0) cur_interp else next_rec.parent_interp;
+        cur_name_ptr = next_rec.target_name_ptr;
+        cur_name_len = next_rec.target_name_len;
+    }
+    return false;
+}
+
+fn simple_name_of(name_ptr: u32, name_len: u32) struct { ptr: u32, len: u32 } {
+    if (name_len == 0) return .{ .ptr = name_ptr, .len = 0 };
+    const sp: [*]const u8 = @ptrFromInt(name_ptr);
+    var i: u32 = name_len;
+    while (i >= 2) : (i -= 1) {
+        if (sp[i - 2] == ':' and sp[i - 1] == ':') {
+            return .{ .ptr = name_ptr + i, .len = name_len - i };
+        }
+    }
+    return .{ .ptr = name_ptr, .len = name_len };
+}
+
 fn deactivate_importers(source_cmd: u32) void {
     var cur = read_i32(source_cmd + tcl_procs.OFF_IMPORT_REF_HEAD);
     while (cur != 0) {
@@ -175,6 +242,21 @@ pub fn rename_command(
         new_simple_len,
     )) return .ok;
 
+    // Alias-rename loop check: when renaming an alias, the new
+    // name + the alias's target must not form a cycle once the
+    // rename is applied.  Mirrors ``AliasCheckLoop`` in
+    // tclInterp.c which runs on both create and rename paths
+    // (interp-17.4 / 17.5 / 17.6).
+    if (new_simple_len > 0) {
+        const alias_mod = @import("tcl_alias.zig");
+        if (alias_mod.is_alias(cmd)) {
+            const rec = alias_mod.alias_rec(cmd);
+            if (alias_rename_would_loop(rec, new_simple_ptr, new_simple_len)) {
+                return .alias_loop;
+            }
+        }
+    }
+
     // Delete form: new_simple is empty.  Clear the source bucket,
     // deactivate every redirect that imports it.  We don't splice
     // this command out of any lists it might be on itself (it's the
@@ -195,6 +277,16 @@ pub fn rename_command(
         } else {
             // Source side: deactivate every redirect pointing at us.
             deactivate_importers(cmd);
+        }
+        // If the command is an alias, unhook the AliasRec from
+        // the per-interp chains so ``interp aliases`` no longer
+        // reports the deleted entry (interp-19.7 / 19.8).  Match
+        // C Tcl's ``TclDeleteAlias`` which removes the
+        // ``aliasTable`` entry whenever the source command is
+        // destroyed for any reason.
+        const alias_mod = @import("tcl_alias.zig");
+        if (alias_mod.is_alias(cmd)) {
+            alias_mod.alias_clear(cmd);
         }
         _ = tcl_ns.ns_cmd_clear(old_ns, old_simple_ptr, old_simple_len);
         tcl_procs.lru_invalidate_all();

--- a/runtime/zig/cmds/tcl_rename.zig
+++ b/runtime/zig/cmds/tcl_rename.zig
@@ -143,7 +143,17 @@ fn alias_rename_would_loop(rec: *const @import("tcl_alias.zig").AliasRec, new_na
     var cur_interp: u32 = if (rec.parent_interp == 0) child_interp else rec.parent_interp;
     var cur_name_ptr: u32 = rec.target_name_ptr;
     var cur_name_len: u32 = rec.target_name_len;
-    const MAX_HOPS: u32 = 16;
+    // Safety cap on the alias-chain walk.  Reference Tcl's
+    // ``Tcl_RenameCommand`` doesn't bound the walk because the alias
+    // table is in-memory and ``Tcl_GetCommandFromObj`` is cycle-free
+    // by construction.  We don't have a visited-set here, so we
+    // pessimistically treat exhaustion of the hop cap as a loop —
+    // chains longer than this are extremely unlikely in real
+    // scripts, and a false positive (rejecting a deep-but-acyclic
+    // chain) is a kinder failure mode than letting an actual cycle
+    // through to recurse at dispatch time (Copilot review on PR
+    // #451).
+    const MAX_HOPS: u32 = 64;
     var hops: u32 = 0;
     while (hops < MAX_HOPS) : (hops += 1) {
         if (cur_interp == 0) return false;
@@ -171,7 +181,10 @@ fn alias_rename_would_loop(rec: *const @import("tcl_alias.zig").AliasRec, new_na
         cur_name_ptr = next_rec.target_name_ptr;
         cur_name_len = next_rec.target_name_len;
     }
-    return false;
+    // Hop cap exhausted without resolving to a non-alias target —
+    // treat as a loop so a runaway chain doesn't slip past
+    // detection here only to recurse at dispatch (Copilot review).
+    return true;
 }
 
 fn simple_name_of(name_ptr: u32, name_len: u32) struct { ptr: u32, len: u32 } {

--- a/runtime/zig/cmds/tcl_rename.zig
+++ b/runtime/zig/cmds/tcl_rename.zig
@@ -154,7 +154,10 @@ fn alias_rename_would_loop(rec: *const @import("tcl_alias.zig").AliasRec, new_na
             var same = true;
             var k: u32 = 0;
             while (k < new_simple.len) : (k += 1) {
-                if (np[k] != cp[k]) { same = false; break; }
+                if (np[k] != cp[k]) {
+                    same = false;
+                    break;
+                }
             }
             if (same) return true;
         }

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -70,6 +70,7 @@ fn eval_incr(words: []const i32) result_mod.InterpResult {
     // (interp-29.3.x ``incr ::i`` inside ``proc p`` relies on this).
     const name_s = obj_ensure_string(words[1]);
     var is_qualified = false;
+    var is_array_elem = false;
     if (name_s.len >= 2) {
         const np: [*]const u8 = @ptrFromInt(name_s.ptr);
         var qi: u32 = 0;
@@ -79,9 +80,25 @@ fn eval_incr(words: []const i32) result_mod.InterpResult {
                 break;
             }
         }
+        // Detect ``arr(key)`` array-element syntax — these need to
+        // route through ``var_resolve`` (which splits the name and
+        // consults the array directory) instead of
+        // ``local_get_silent`` (scalar-bucket lookup that would
+        // miss every element and return 0).  Copilot review on
+        // PR #451 flagged ``incr arr(key)`` inside a proc body
+        // silently overwriting an existing element with ``incr 1``.
+        if (np[name_s.len - 1] == ')') {
+            var pi: u32 = 0;
+            while (pi < name_s.len) : (pi += 1) {
+                if (np[pi] == '(') {
+                    if (pi > 0) is_array_elem = true;
+                    break;
+                }
+            }
+        }
     }
     const in_proc = frames.frame_depth > 0;
-    const cur: i32 = if (in_proc and !is_qualified)
+    const cur: i32 = if (in_proc and !is_qualified and !is_array_elem)
         frames.local_get_silent(words[1])
     else
         frames.var_resolve(words[1]);

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -61,16 +61,30 @@ fn eval_incr(words: []const i32) result_mod.InterpResult {
         return result_mod.from_globals(0);
     }
     const amt_obj = if (words.len >= 3) words[2] else rt.obj_new_int(1);
-    // Inside a proc frame, ``incr x`` must NOT see an outer ``x`` —
-    // unqualified names refer to local variables (the same scoping
-    // rule Tcl enforces for ``set``).  ``var_resolve`` would otherwise
-    // fall through to the namespace / global table, leaking outer
-    // state into the proc and tripping lmap-6.2 / 6.3 (where the
-    // earlier non-compiled lmap-3.* tests left a global ``x`` that
-    // an apply-wrapped lmap-6.* would inherit instead of auto-
-    // initialising fresh).
+    // Inside a proc frame, ``incr x`` (unqualified) must NOT see an
+    // outer ``x`` — unqualified names refer to local variables.
+    // BUT qualified names (``incr ::x`` or ``incr ns::x``) always
+    // refer to the global / namespace variable, exactly like
+    // ``set ::x``.  Skip the local-only restriction in that case;
+    // ``var_resolve`` already handles the qualifier routing
+    // (interp-29.3.x ``incr ::i`` inside ``proc p`` relies on this).
+    const name_s = obj_ensure_string(words[1]);
+    var is_qualified = false;
+    if (name_s.len >= 2) {
+        const np: [*]const u8 = @ptrFromInt(name_s.ptr);
+        var qi: u32 = 0;
+        while (qi + 1 < name_s.len) : (qi += 1) {
+            if (np[qi] == ':' and np[qi + 1] == ':') {
+                is_qualified = true;
+                break;
+            }
+        }
+    }
     const in_proc = frames.frame_depth > 0;
-    const cur: i32 = if (in_proc) frames.local_get_silent(words[1]) else frames.var_resolve(words[1]);
+    const cur: i32 = if (in_proc and !is_qualified)
+        frames.local_get_silent(words[1])
+    else
+        frames.var_resolve(words[1]);
     const result = rt.tcl_incr(cur, amt_obj);
     _ = frames.var_set(words[1], result);
     return result_mod.from_globals(result);

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -214,6 +214,17 @@ pub var frame_ns: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
 // than the intervening parent frame (interp-20.35 .. 20.44).
 pub var frame_interp: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
 
+// Sticky flag — set whenever :fn:`frame_push` records a frame
+// whose interp differs from the previously-seen interp anywhere
+// in the live stack window.  When this flag is ``false`` the
+// upvar walker can take the arithmetic fast path without scanning
+// every slot below the current frame.  Set conservatively (never
+// cleared) — once the run has seen any cross-interp dispatch, the
+// scan-on-walk overhead is paid for the duration of the program.
+// Tests that never cross interps (the bulk of the corpus) pay
+// only one extra branch per ``frame_push``.
+pub var any_cross_interp_frame: bool = false;
+
 // Per-frame "is global invocation" flag.  Set by ``interp
 // invokehidden -global`` before pushing the hidden command's
 // frame so an ``upvar`` from within that frame resolves to
@@ -539,7 +550,16 @@ pub export fn frame_push() i32 {
     // ``upvar`` walk can skip foreign frames sandwiched into the
     // global stack by alias / invokehidden trampolines.
     const interp_reg = @import("tcl_interp_registry.zig");
-    frame_interp[idx] = interp_reg.interp_current();
+    const me = interp_reg.interp_current();
+    frame_interp[idx] = me;
+    // Latch the sticky cross-interp flag the moment a slot below
+    // us belongs to a different interp.  This lets the
+    // ``upvar_walk_*`` fast path skip the per-call scan in the
+    // common (single-interp) run.
+    if (!any_cross_interp_frame and idx > 0) {
+        const prev = frame_interp[idx - 1];
+        if (prev != 0 and prev != me) any_cross_interp_frame = true;
+    }
     // Honour any pending ``interp invokehidden -global`` marker
     // set by the caller; the flag is one-shot (cleared after the
     // first push so nested calls inside the hidden body don't
@@ -553,15 +573,6 @@ pub export fn frame_push() i32 {
     }
     frame_depth += 1;
     return @intCast(idx);
-}
-
-/// Mark the current top frame as a global-anchored invocation
-/// (``interp invokehidden -global``), so an ``upvar`` from
-/// within its body resolves to ``#0`` rather than chasing the
-/// stacked caller chain.  Idempotent at frame_depth==0.
-pub export fn frame_mark_global_invocation() void {
-    if (frame_depth == 0) return;
-    frame_is_global[frame_depth - 1] = true;
 }
 
 /// Grow the frame at *base* to double its current bucket capacity
@@ -2186,12 +2197,16 @@ fn upvar_walk_same_interp(cur_depth: i32, rel: i32) i32 {
     // global-anchored invocation — any ``upvar`` from within
     // resolves to ``#0`` (global scope) regardless of ``rel``.
     if (frame_is_global[@intCast(cur_depth - 1)]) return 0;
+    // Fast path: the run has never observed a cross-interp frame
+    // dispatch, so every live frame belongs to the same interp.
+    // The relative walk collapses to ``cur_depth - rel`` with no
+    // per-slot scan.  Bulk of the test corpus stays on this path.
+    if (!any_cross_interp_frame) return cur_depth - rel;
     const interp_reg = @import("tcl_interp_registry.zig");
     const me = interp_reg.interp_current();
-    // Common case: single-interp run.  When every frame slot below
-    // is tagged with ``me`` (or 0, meaning untagged-top-level), the
-    // walk reduces to arithmetic.  Bail out into the slow path only
-    // when we actually detect a foreign frame in the relevant span.
+    // Slow path: scan the live stack window for a foreign frame.
+    // If none surfaces (the latch was set by a now-popped frame),
+    // fall back to plain arithmetic.
     var probe_idx: i32 = cur_depth - 1;
     var any_foreign = false;
     while (probe_idx >= 0) : (probe_idx -= 1) {

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -204,6 +204,25 @@ pub var frame_depth: u32 = 0;
 // outer-namespace array and silently return empty.
 pub var frame_ns: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
 
+// Per-frame owning interp.  Set by :fn:`frame_push` from
+// :fn:`interp_reg.interp_current` so a cross-interp dispatch
+// chain (``p1`` in child a → alias to parent → ``interp
+// invokehidden a h1``) leaves the global frame stack interleaved
+// with multiple interps' frames.  ``upvar`` / ``info level``
+// walks must skip frames whose ``frame_interp`` differs from the
+// current interp so ``upvar 1`` in ``h1`` reaches ``p1`` rather
+// than the intervening parent frame (interp-20.35 .. 20.44).
+pub var frame_interp: [MAX_DEPTH]u32 = [_]u32{0} ** MAX_DEPTH;
+
+// Per-frame "is global invocation" flag.  Set by ``interp
+// invokehidden -global`` before pushing the hidden command's
+// frame so an ``upvar`` from within that frame resolves to
+// ``#0`` (the global scope) rather than walking back into the
+// caller's frame chain.  Mirrors C Tcl's ``TCL_INVOKE_HIDDEN``
+// + ``TCL_EVAL_GLOBAL`` combination which installs a
+// global-anchored call frame (interp-20.38 / 20.43).
+pub var frame_is_global: [MAX_DEPTH]bool = [_]bool{false} ** MAX_DEPTH;
+
 // Per-frame "dirty" bitmap.  Each bit covers a 128-byte chunk (8
 // buckets × 16 bytes) of the frame buffer.  ``frame_push`` only
 // clears chunks whose bit is set, then resets the bitmap.  Writers
@@ -516,8 +535,33 @@ pub export fn frame_push() i32 {
     // slot so ``info level 0`` after a push without a subsequent
     // ``frame_set_argv`` reads 0, not an outdated list.
     frame_argv[idx] = 0;
+    // Tag the new frame with its owning interp so a cross-interp
+    // ``upvar`` walk can skip foreign frames sandwiched into the
+    // global stack by alias / invokehidden trampolines.
+    const interp_reg = @import("tcl_interp_registry.zig");
+    frame_interp[idx] = interp_reg.interp_current();
+    // Honour any pending ``interp invokehidden -global`` marker
+    // set by the caller; the flag is one-shot (cleared after the
+    // first push so nested calls inside the hidden body don't
+    // also get tagged).  Default cleared otherwise.
+    const interp_mod = @import("tcl_interp.zig");
+    if (interp_mod.pending_global_invocation) {
+        frame_is_global[idx] = true;
+        interp_mod.pending_global_invocation = false;
+    } else {
+        frame_is_global[idx] = false;
+    }
     frame_depth += 1;
     return @intCast(idx);
+}
+
+/// Mark the current top frame as a global-anchored invocation
+/// (``interp invokehidden -global``), so an ``upvar`` from
+/// within its body resolves to ``#0`` rather than chasing the
+/// stacked caller chain.  Idempotent at frame_depth==0.
+pub export fn frame_mark_global_invocation() void {
+    if (frame_depth == 0) return;
+    frame_is_global[frame_depth - 1] = true;
 }
 
 /// Grow the frame at *base* to double its current bucket capacity
@@ -2107,7 +2151,69 @@ pub export fn upvar_resolve_depth(level_obj: i32, cur_depth: i32) i32 {
         tcl_catch.tcl_cmd_error(msg);
         return cur_depth - 1;
     }
-    return cur_depth - rel;
+    // Walk ``rel`` levels up from the current frame, counting only
+    // frames belonging to the current interp.  Foreign frames
+    // sandwiched into the global stack by alias / invokehidden
+    // trampolines are skipped — so ``upvar 1`` from a hidden
+    // command's body reaches its caller within the same interp
+    // (interp-20.35 .. 20.44) rather than landing on the parent's
+    // alias frame.  Falls back to plain arithmetic when the
+    // sequence of same-interp frames isn't broken by foreigners
+    // so the well-formed single-interp case stays cheap.
+    return upvar_walk_same_interp(cur_depth, rel);
+}
+
+/// Static-relative ``upvar`` helper exposed to the compiler.
+/// Takes a frame-depth ``cur_depth`` (1-based) and a relative
+/// level count ``rel`` and returns the target frame depth,
+/// skipping over frames owned by other interps so a hidden
+/// command body's ``upvar`` reaches its same-interp caller.
+/// Cheap fast path when no foreign frames are present.
+pub export fn upvar_walk_relative(cur_depth: i32, rel: i32) i32 {
+    return upvar_walk_same_interp(cur_depth, rel);
+}
+
+/// Walk ``rel`` levels up from ``cur_depth`` (a 1-based depth, so
+/// the current frame is at slot ``cur_depth - 1``) and return the
+/// depth of the ``rel``-th preceding frame whose ``frame_interp``
+/// matches :fn:`interp_current`.  Returns ``0`` (global scope) if
+/// the chain runs out of same-interp frames before ``rel`` steps
+/// are consumed.
+fn upvar_walk_same_interp(cur_depth: i32, rel: i32) i32 {
+    if (rel <= 0) return cur_depth;
+    if (cur_depth <= 0) return cur_depth - rel;
+    // ``interp invokehidden -global`` flagged this frame as a
+    // global-anchored invocation — any ``upvar`` from within
+    // resolves to ``#0`` (global scope) regardless of ``rel``.
+    if (frame_is_global[@intCast(cur_depth - 1)]) return 0;
+    const interp_reg = @import("tcl_interp_registry.zig");
+    const me = interp_reg.interp_current();
+    // Common case: single-interp run.  When every frame slot below
+    // is tagged with ``me`` (or 0, meaning untagged-top-level), the
+    // walk reduces to arithmetic.  Bail out into the slow path only
+    // when we actually detect a foreign frame in the relevant span.
+    var probe_idx: i32 = cur_depth - 1;
+    var any_foreign = false;
+    while (probe_idx >= 0) : (probe_idx -= 1) {
+        const owner = frame_interp[@intCast(probe_idx)];
+        if (owner != me and owner != 0) {
+            any_foreign = true;
+            break;
+        }
+    }
+    if (!any_foreign) return cur_depth - rel;
+    // Slow path — walk back, decrementing the level counter only
+    // on a same-interp frame.
+    var remaining: i32 = rel;
+    var idx: i32 = cur_depth - 2; // 1 level up from current frame
+    while (idx >= 0) : (idx -= 1) {
+        const owner = frame_interp[@intCast(idx)];
+        if (owner == me or owner == 0) {
+            remaining -= 1;
+            if (remaining == 0) return idx + 1;
+        }
+    }
+    return 0;
 }
 
 // -- Local variable operations on current frame --

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -840,6 +840,45 @@ fn expr_atom(ptr: u32, len: u32, pos: *u32, skip: bool) i64 {
 /// the discrepancy, increment in the compiled-proc prologue too.
 pub var cmd_count: i64 = 0;
 
+/// Recursion-limit gate.  Increments :attr:`Interp.num_levels`,
+/// returns ``true`` if the new value is within
+/// :attr:`Interp.recursion_limit` (and within a hard cap that
+/// guards against wasm stack exhaustion).  Returns ``false``
+/// after raising ``too many nested evaluations (infinite loop?)``
+/// when the limit would be exceeded.
+///
+/// Mirrors C Tcl's ``Tcl_EvalObjv`` increment-then-check pattern
+/// (tclBasic.c line 4098).  Callers must pair every successful
+/// :fn:`recursion_check_enter` with :fn:`recursion_check_leave`
+/// — the proc / alias / eval / uplevel dispatchers use Zig
+/// ``defer`` to make this automatic.
+pub fn recursion_check_enter() bool {
+    const cur = interp_reg.interp_current();
+    const ci: *interp_reg.Interp = @ptrFromInt(cur);
+    const limit = interp_reg.interp_recursion_limit(cur);
+    const HARD_CAP: u32 = 512;
+    ci.num_levels += 1;
+    if (ci.num_levels > limit or ci.num_levels > HARD_CAP) {
+        ci.num_levels -= 1;
+        const tcl_catch_lim = @import("tcl_catch.zig");
+        const msg_text: []const u8 = "too many nested evaluations (infinite loop?)";
+        const m = obj_mod.obj_new_string_copy(@intFromPtr(msg_text.ptr), @intCast(msg_text.len));
+        tcl_catch_lim.tcl_cmd_error(m);
+        return false;
+    }
+    return true;
+}
+
+/// Pair of :fn:`recursion_check_enter`.  Decrements
+/// :attr:`Interp.num_levels` on the way out of a counted
+/// dispatch.  Safe to call when ``num_levels`` is already 0
+/// (returns silently rather than underflowing).
+pub fn recursion_check_leave() void {
+    const cur = interp_reg.interp_current();
+    const ci: *interp_reg.Interp = @ptrFromInt(cur);
+    if (ci.num_levels > 0) ci.num_levels -= 1;
+}
+
 pub fn eval_command(words: []const i32) i32 {
     if (words.len == 0) return 0;
     cmd_count +%= 1;
@@ -2643,27 +2682,15 @@ fn build_invocation_list(words: []const i32) i32 {
 /// Shared between ``eval_proc_call`` (legacy path) and the proc-first
 /// fast path in ``eval_command``.
 fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
-    // Recursion-depth ceiling — fires for both interpreted and
-    // compiled-proc dispatches that flow through this entry point.
-    // Reference Tcl's default ``Tcl_RecursionLimit`` is 1000 but a
-    // single compiled-proc invocation lands ~10 wasm stack frames,
-    // so wasmtime's default 512 KiB stack runs out long before that.
-    // Cap at a value (50) that leaves room for normal nesting (the
-    // tcltest ``proc Body { … }`` chain reaches ~15) but stops the
-    // ``error-1.8`` ``proc p {} { uplevel 1 catch p error }; p``
-    // self-recursion before the wasm call stack exhausts.
-    // ``parked_top`` covers the uplevel-style pattern where each
-    // iteration parks the top frame and ``frame_depth`` itself
-    // oscillates around 1 — without summing them in the bare
-    // ``frame_depth`` ceiling never trips.
-    if (frames.frame_depth + frames.parked_top >= 50) {
-        const tcl_catch = @import("tcl_catch.zig");
-        const msg_text: []const u8 =
-            "too many nested evaluations (infinite loop?)";
-        const m = obj_mod.obj_new_string_copy(@intFromPtr(msg_text.ptr), @intCast(msg_text.len));
-        tcl_catch.tcl_cmd_error(m);
-        return 0;
-    }
+    // Per-interp recursion gate — fires for procs, aliases, and
+    // hidden-cmd dispatches that push a Tcl call frame.  Builtins
+    // (list, set, incr, etc.) are bytecode-compiled in C Tcl and
+    // don't ``numLevels++``; mirror that here by NOT ++ing in
+    // ``eval_command`` and only checking here.  ``eval`` /
+    // ``uplevel`` / ``catch`` separately count via
+    // :fn:`recursion_check_enter`.
+    if (!recursion_check_enter()) return 0;
+    defer recursion_check_leave();
 
     // ``interp alias`` redirect Commands carry the CMD_ALIAS flag bit
     // and an ``AliasRec`` in their params_obj slot.  Route them

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -856,9 +856,29 @@ pub fn recursion_check_enter() bool {
     const cur = interp_reg.interp_current();
     const ci: *interp_reg.Interp = @ptrFromInt(cur);
     const limit = interp_reg.interp_recursion_limit(cur);
+    // WASM-stack fail-safe.  Each interpreter dispatch lands ~10
+    // wasm stack frames; wasmtime's default 512 KiB stack runs out
+    // long before reference Tcl's default 1000.  Check both the
+    // per-interp ``recursionlimit`` (user-visible knob) and the
+    // physical frame footprint (``frame_depth + parked_top``) so
+    // an ``uplevel``-style pattern that parks the top frame still
+    // trips the safety net before the wasm trap kicks in
+    // (test_wasm_tier2_fixes error-1.8 case).
     const HARD_CAP: u32 = 512;
+    // Physical wasm-stack ceiling.  Each frame_push / parked_top
+    // increment maps to ~10 wasm stack frames; wasmtime's default
+    // 512 KiB stack runs out around ~120 nested dispatches.  Pick
+    // a cap that leaves head-room above reference Tcl's typical
+    // ``recursionlimit 50`` test bodies (interp-29.3.x reach
+    // frame_depth ~50) but trips on a runaway ``uplevel`` chain
+    // (test_recursion_limit_bounded_iteration ``up 200`` parks
+    // ~100 frames before its first ``return``).
+    const FRAME_CAP: u32 = 60;
     ci.num_levels += 1;
-    if (ci.num_levels > limit or ci.num_levels > HARD_CAP) {
+    if (ci.num_levels > limit or
+        ci.num_levels > HARD_CAP or
+        frames.frame_depth + frames.parked_top >= FRAME_CAP)
+    {
         ci.num_levels -= 1;
         const tcl_catch_lim = @import("tcl_catch.zig");
         const msg_text: []const u8 = "too many nested evaluations (infinite loop?)";

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -2206,7 +2206,36 @@ fn dispatch_interp_child(words: []const i32, bucket: i32) i32 {
     if (str_eq(sp, sub.len, "expose")) return interp_impl.eval_interp_expose(new_words[0..new_len]);
     if (str_eq(sp, sub.len, "hidden")) return interp_impl.eval_interp_hidden(new_words[0..new_len]);
     if (str_eq(sp, sub.len, "invokehidden")) return eval_interp_invokehidden(new_words[0..new_len]);
-    if (str_eq(sp, sub.len, "issafe")) return interp_impl.eval_interp_issafe(new_words[0..new_len]);
+    if (str_eq(sp, sub.len, "issafe")) {
+        // ``<child> issafe`` takes no extra args (the child identity
+        // is supplied implicitly).  Matches ``ChildObjCmd``'s
+        // ``CHILD_ISSAFE`` branch in tclInterp.c, which raises
+        // ``wrong # args: should be "<child> issafe"`` when the
+        // caller appends arguments.
+        if (words.len != 2) {
+            emit_child_arity_error(child_name.ptr, child_name.len, " issafe");
+            return 0;
+        }
+        return interp_impl.eval_interp_issafe(new_words[0..new_len]);
+    }
+    if (str_eq(sp, sub.len, "marktrusted")) {
+        // ``<child> marktrusted`` takes no extra args.  Routes to
+        // the same handler as ``interp marktrusted path`` after
+        // injecting the child's identity in slot 2.
+        if (words.len != 2) {
+            emit_child_arity_error(child_name.ptr, child_name.len, " marktrusted");
+            return 0;
+        }
+        return interp_impl.eval_interp_marktrusted(new_words[0..new_len]);
+    }
+    if (str_eq(sp, sub.len, "recursionlimit")) {
+        // ``<child> recursionlimit ?newlimit?`` — 0 or 1 extra arg.
+        if (words.len < 2 or words.len > 3) {
+            emit_child_arity_error(child_name.ptr, child_name.len, " recursionlimit ?newlimit?");
+            return 0;
+        }
+        return interp_impl.eval_interp_recursionlimit(new_words[0..new_len]);
+    }
 
     // Unknown subcommand — match tclsh's per-child wording.
     emit_child_bad_option(sub.ptr, sub.len);
@@ -2750,6 +2779,9 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                 } else if (rv != 0 and rv != result) {
                     obj_mod.tcl_obj_release(rv);
                 }
+                // Apply ``return -code N`` at the proc boundary —
+                // see the matching site in eval_proc_call_bucket.
+                apply_pending_return_code(rv);
             }
         }
         // ``return -code break`` / ``return -code continue`` from
@@ -3030,6 +3062,13 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
         // ``return`` doesn't see a stale pointer in its release
         // path.  Caller's standard "holds 1" contract is met.
         result_mod.consume(.RETURN);
+        // Apply ``return -code N``'s pending code at the proc-
+        // dispatch boundary, mirroring C Tcl's
+        // ``TclUpdateReturnInfo`` in tclProc.c's InterpProcNR2.
+        // Without this, ``proc p {} {return -code 3 X}`` would
+        // absorb the TCL_RETURN to TCL_OK and lose the BREAK code
+        // (interp-26.2 / 26.3).
+        apply_pending_return_code(rv);
         return rv;
     }
     // Body-raised break/continue without an enclosing loop is a Tcl
@@ -3090,6 +3129,8 @@ pub fn eval_interp(words: []const i32) i32 {
     if (str_eq(sp, sub.len, "issafe") or str_eq(sp, sub.len, "safe")) {
         return interp_impl.eval_interp_issafe(words);
     }
+    if (str_eq(sp, sub.len, "marktrusted")) return interp_impl.eval_interp_marktrusted(words);
+    if (str_eq(sp, sub.len, "recursionlimit")) return interp_impl.eval_interp_recursionlimit(words);
     // ``interp share interpA channel interpB`` / ``interp transfer
     // interpA channel interpB`` — channel ownership manipulation
     // between interpreters.  Our runtime exposes ``stdin`` /
@@ -3259,6 +3300,18 @@ fn eval_interp_invokehidden(words: []const i32) i32 {
         return 0;
     }
 
+    // Safe-interpreter gate: a safe interp can't reach into the
+    // hidden table.  Matches ``InvokeHiddenObjCmd`` /
+    // ``ChildInvokeHidden`` in tclInterp.c which raise
+    // ``not allowed to invoke hidden commands from safe interpreter``
+    // before the path resolves.
+    if (interp_reg.interp_is_safe(interp_reg.interp_current())) {
+        const err_text = "not allowed to invoke hidden commands from safe interpreter";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+
     // words[0] = "interp", words[1] = "invokehidden", words[2] = path.
     // Resolve the path up front so cross-interp invokehidden lands in
     // the resolved child's hidden table / namespace tree.
@@ -3391,13 +3444,16 @@ fn eval_interp_invokehidden(words: []const i32) i32 {
     };
     if (saw_namespace) {
         tcl_ns.current_ns = tcl_ns.ns_create_from_fqn(ns_name_ptr, ns_name_len);
-    } else {
-        // Both ``-global`` (explicit) and the default (no flag) land
-        // at the target interp's root — matches the C Tcl behaviour
-        // where ``InvokeHiddenObjCmd`` pushes the global frame when
-        // neither flag is set.
+    } else if (use_global) {
+        // ``-global`` swaps to the root namespace, mirroring C Tcl's
+        // ``TclObjInvokeNamespace(... ::, TCL_INVOKE_HIDDEN)`` path.
         tcl_ns.current_ns = tcl_ns.ns_root();
     }
+    // Default (no flag) — invoke the hidden command at the caller's
+    // current frame.  ``ChildInvokeHidden`` in tclInterp.c routes
+    // this through ``TclNRInvoke`` which does NOT push a fresh
+    // namespace frame, so an inner ``upvar`` reaches the caller's
+    // locals (interp-20.35 / 20.36 / 20.40 / 20.41).
     const result = eval_proc_call_bucket(new_words[0..total], @bitCast(cmd));
     interp_reg.leave(save);
     return result;
@@ -3437,6 +3493,20 @@ fn eval_interp_eval(words: []const i32) i32 {
         }
     }
 
+    // Detect "deleted-interp eval" before swapping: a parent alias
+    // whose dispatch landed here after the target interp was torn
+    // down should report ``attempt to call eval in deleted
+    // interpreter`` rather than walking the zeroed namespace.
+    // Matches ``ChildEval``'s pre-check in tclInterp.c (Tcl 9.0.3
+    // interp.test 18.7 / 18.8 / 18.9 / 18.10).
+    if (interp_reg.is_deleted(target_interp)) {
+        const catch_mod = @import("tcl_catch.zig");
+        const err_text = "attempt to call eval in deleted interpreter";
+        const msg = rt.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+        catch_mod.tcl_cmd_error(msg);
+        return 0;
+    }
+
     // Swap into the target interp, eval, restore.  Single-interp
     // callers that hand us ``path == {}`` resolve to the current
     // interp and skip the swap — same shape the alias / invokehidden
@@ -3450,7 +3520,99 @@ fn eval_interp_eval(words: []const i32) i32 {
     };
     const result = if (off > 0) eval_script(script_ptr, off) else 0;
     interp_reg.leave(save);
+
+    // ``ChildEval`` (tclInterp.c) wraps the child eval in
+    // ``Tcl_EvalObjEx`` which calls ``TclUpdateReturnInfo`` when the
+    // child returns ``TCL_RETURN``.  That converts the child's
+    // pending ``-code N`` into the actual outer status code so
+    // ``catch {interp eval child return -code N}`` reports ``N``
+    // (interp-26.1).  Our model encodes the pending code in
+    // ``pending_return_code``; mirror the absorption here.
+    absorb_return_at_eval_boundary();
     return result;
+}
+
+/// Apply pending ``return -code N`` semantics at an eval boundary.
+/// Mirrors C Tcl's ``TclUpdateReturnInfo``: if the body left
+/// ``return_flag`` set, decrement the return-level counter; when
+/// it reaches zero, translate ``pending_return_code`` into the
+/// matching flag (error / break / continue / TCL_RETURN / custom).
+///
+/// Called from ``eval_interp_eval`` (and the per-child ``<c> eval``
+/// dispatch above) so the outer catch sees the user-requested code
+/// rather than the generic ``TCL_RETURN`` our internal ``return``
+/// flag normally carries.
+fn absorb_return_at_eval_boundary() void {
+    const tcl_catch = @import("tcl_catch.zig");
+    if (tcl_catch.state.return_flag == 0) return;
+    if (tcl_catch.state.return_level > 0) {
+        tcl_catch.state.return_level -= 1;
+        return;
+    }
+    // ``pending_return_code == 0`` AND ``return_code != 0`` means a
+    // lower-level absorber (proc dispatch) already translated a
+    // ``return -code N`` into its terminal flag/code shape — the
+    // proc returned with the custom code stamped onto ``return_code``
+    // and the catch above us should surface that verbatim, not re-
+    // process through ``apply_pending_return_code``.  Leave the
+    // state untouched in that case.
+    if (tcl_catch.state.pending_return_code == 0 and tcl_catch.state.return_code != 0) {
+        return;
+    }
+    // return_level == 0 and there is a pending ``-code`` to apply
+    // (or it's a plain ``return`` with ``-code 0`` that should
+    // convert into TCL_OK).  Clear ``return_flag`` first so the
+    // ``apply_pending_return_code`` decision is purely a function of
+    // the pending code — apply will re-set the flag for TCL_RETURN
+    // / custom codes that should keep propagating.
+    const saved_val = tcl_catch.state.return_val;
+    tcl_catch.state.return_flag = 0;
+    tcl_catch.state.return_val = 0;
+    apply_pending_return_code(saved_val);
+}
+
+/// Translate ``pending_return_code`` into the matching control-flow
+/// flag once a ``return -code N`` has reached the absorber level.
+/// Shared between :fn:`absorb_return_at_eval_boundary` (interp eval
+/// boundary) and :fn:`eval_proc_call_bucket`'s proc-dispatch
+/// boundary so both code paths apply identical semantics.  Mirrors
+/// the post-absorb leg of C Tcl's ``TclUpdateReturnInfo``.
+fn apply_pending_return_code(rv: i32) void {
+    const tcl_catch = @import("tcl_catch.zig");
+    const pc = tcl_catch.state.pending_return_code;
+    tcl_catch.state.pending_return_code = 0;
+    switch (pc) {
+        // TCL_OK — clean exit, no flags.
+        0 => {},
+        // TCL_ERROR — surface as an error with the return value
+        // as the error message.
+        1 => {
+            tcl_catch.state.error_flag = 1;
+            tcl_catch.state.error_msg = rv;
+        },
+        // TCL_RETURN — propagate one more eval level.  Re-set the
+        // flag so the outer absorb decrements again (each level
+        // strips one ``-code return`` layer).
+        2 => {
+            tcl_catch.state.return_flag = 1;
+            tcl_catch.state.return_val = rv;
+        },
+        // TCL_BREAK / TCL_CONTINUE
+        3 => {
+            tcl_catch.state.break_flag = 1;
+        },
+        4 => {
+            tcl_catch.state.continue_flag = 1;
+        },
+        // Custom numeric (N < 0 or N >= 5).  Re-set ``return_flag``
+        // and stamp ``return_code`` so the surrounding ``catch``
+        // surfaces the exact value via ``catch_leave``.
+        else => {
+            tcl_catch.state.return_flag = 1;
+            tcl_catch.state.return_val = rv;
+            tcl_catch.state.return_code = pc;
+        },
+    }
 }
 
 // -- Main eval entry point --
@@ -3754,6 +3916,24 @@ pub fn eval_script(script_ptr: u32, script_len: u32) i32 {
         // wasm32 4 GiB linear-memory ceiling.
         if (result != 0) obj_mod.tcl_obj_release(result);
         result = execute_parsed_command(cmd.src_ptr, cmd.tokens_ptr, cmd.tokens_len);
+        // A command may have torn down the interpreter we're
+        // currently evaluating in (e.g. ``suicide`` alias which
+        // dispatches ``interp delete tst`` in the parent — see
+        // interp-18.9 / 18.10).  Match C Tcl's ``ChildEval`` mid-
+        // loop check and raise the canonical diagnostic instead of
+        // continuing past the deletion into stale namespace state.
+        // Only fire when there is MORE script to execute — a
+        // self-delete on the final command (interp-16.0 / 16.1 /
+        // 16.2's ``xxx alias kill kill; xxx eval kill``) is a
+        // clean exit; the error only matters if the script would
+        // otherwise reach unreachable post-delete commands.
+        if (pos < script_len and interp_reg.is_deleted(interp_reg.interp_current())) {
+            const tcl_catch_d = @import("tcl_catch.zig");
+            const err_text = "attempt to call eval in deleted interpreter";
+            const msg = obj_mod.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+            tcl_catch_d.tcl_cmd_error(msg);
+            return result;
+        }
         const ir = result_mod.snapshot(result);
         // ``Tcl_LogCommandInfo`` (parse-9.2 / parse-9.1): when an
         // error fires inside the executed command, append THIS
@@ -3973,6 +4153,18 @@ fn eval_cached_slab(slab: u32, body_ptr: u32, body_len: u32) i32 {
         // leak pattern as the cold path (issue #303).
         if (result != 0) obj_mod.tcl_obj_release(result);
         result = execute_parsed_command(body_ptr, tokens_ptr, tok_len);
+        // Mid-script interp deletion check — mirrors the cold-path
+        // probe in :fn:`eval_script` (interp-18.7..18.10).  Only
+        // fires when there are MORE commands left to run so a clean
+        // last-command self-delete (interp-16.0/1/2) doesn't get
+        // flagged as a deleted-interp error.
+        if (i + 1 < n_cmds and interp_reg.is_deleted(interp_reg.interp_current())) {
+            const tcl_catch_d = @import("tcl_catch.zig");
+            const err_text = "attempt to call eval in deleted interpreter";
+            const msg = obj_mod.obj_new_string_copy(@intFromPtr(err_text.ptr), err_text.len);
+            tcl_catch_d.tcl_cmd_error(msg);
+            return result;
+        }
         if (has_signal()) return result;
         _ = next_pos;
     }
@@ -4012,8 +4204,12 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
                 // Phase 1.3 fix: copy braced-word bytes into an owned
                 // buffer instead of borrowing from the source script.
                 // See ``proc_register::ensure_owned`` for the matching
-                // proc-table-side promotion.
-                word_objs[wi] = obj_mod.obj_new_string_copy(wptr_abs, tok.len);
+                // proc-table-side promotion.  ``obj_new_braced_string``
+                // applies Tcl's ``\<newline>`` → space substitution
+                // that ``Tcl_ParseBraces`` performs in C (interp-20.33,
+                // parseOld-7.4) — falls back to the regular copy when
+                // the span has no line-continuation escapes.
+                word_objs[wi] = obj_mod.obj_new_braced_string(wptr_abs, tok.len);
             } else {
                 word_objs[wi] = subst_word(wptr_abs, tok.len);
             }
@@ -4081,7 +4277,7 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
         // Phase 1.3 fix: see the matching site above for the
         // borrow-vs-copy rationale.
         const word_obj: i32 = if (tok.braced)
-            obj_mod.obj_new_string_copy(wptr_abs, tok.len)
+            obj_mod.obj_new_braced_string(wptr_abs, tok.len)
         else
             subst_word(wptr_abs, tok.len);
 

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1327,10 +1327,22 @@ pub fn eval_upvar(words: []const i32) i32 {
                 }
             } else {
                 const rel = parse_uint_bytes(w1p, w1.len);
-                abs_target = @as(i32, @intCast(frames.frame_depth)) - @as(i32, @intCast(rel));
+                // Route through the same-interp walker so a hidden
+                // command's ``upvar`` reaches its same-interp caller
+                // when foreign frames are sandwiched into the global
+                // stack by alias / invokehidden trampolines.
+                abs_target = frames.upvar_walk_relative(
+                    @as(i32, @intCast(frames.frame_depth)),
+                    @as(i32, @intCast(rel)),
+                );
             }
+        } else {
+            // Default ``upvar 1`` — same walker treatment.
+            abs_target = frames.upvar_walk_relative(
+                @as(i32, @intCast(frames.frame_depth)),
+                1,
+            );
         }
-        // else: not a level spec; default level 1 applies
     }
 
     var i = pairs_start;
@@ -3481,10 +3493,30 @@ fn eval_interp_invokehidden(words: []const i32) i32 {
     // this through ``TclNRInvoke`` which does NOT push a fresh
     // namespace frame, so an inner ``upvar`` reaches the caller's
     // locals (interp-20.35 / 20.36 / 20.40 / 20.41).
+    //
+    // ``-global`` (use_global) mirrors C Tcl's
+    // ``TCL_INVOKE_HIDDEN | TCL_EVAL_GLOBAL`` — the hidden body
+    // runs anchored at the global frame so ``upvar 1`` inside
+    // resolves to ``#0`` (interp-20.38 / 20.39 / 20.43 / 20.44).
+    // Set the one-shot pending flag so the upcoming
+    // ``frame_push`` (deep inside ``eval_proc_call_bucket``)
+    // stamps :var:`frame_is_global` on the new top slot.
+    if (use_global) pending_global_invocation = true;
     const result = eval_proc_call_bucket(new_words[0..total], @bitCast(cmd));
+    // Clear the pending flag defensively in case the dispatch
+    // bailed before pushing.  ``frame_push`` clears it on first
+    // consumption so nested calls inside the hidden body don't
+    // also inherit the global anchor.
+    pending_global_invocation = false;
     interp_reg.leave(save);
     return result;
 }
+
+/// Single-shot sentinel consumed by :fn:`tcl_frames.frame_push`.
+/// When set, the next pushed frame is tagged as a ``-global``
+/// invokehidden invocation so ``upvar`` from within resolves to
+/// ``#0`` rather than the lexical caller chain.
+pub var pending_global_invocation: bool = false;
 
 fn eval_interp_eval(words: []const i32) i32 {
     if (words.len < 4) {

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -52,6 +52,52 @@ const tcl_ns = @import("tcl_ns.zig");
 /// discussion.
 pub const INTERP_SAFE: u32 = 0x1;
 
+/// Default per-interp recursion limit.  Matches Tcl 9's
+/// ``Tcl_CreateInterp`` initial value
+/// (``tclBasic.c`` ``Tcl_CreateInterp`` sets ``interp->maxNestingDepth = 1000``).
+pub const DEFAULT_RECURSION_LIMIT: u32 = 1000;
+
+/// Predicate: is the interp at ``addr`` flagged ``INTERP_SAFE``?
+/// Empty paths and root-interp queries route through here.
+pub fn interp_is_safe(addr: u32) bool {
+    if (addr == 0) return false;
+    const i: *Interp = @ptrFromInt(addr);
+    return (i.flags & INTERP_SAFE) != 0;
+}
+
+/// Read the per-interp recursion limit, seeding the default on
+/// first read so ``interp recursionlimit child`` always returns a
+/// non-zero answer without forcing every ``child_create`` site to
+/// remember to set it.
+pub fn interp_recursion_limit(addr: u32) u32 {
+    if (addr == 0) return DEFAULT_RECURSION_LIMIT;
+    const i: *Interp = @ptrFromInt(addr);
+    if (i.recursion_limit == 0) i.recursion_limit = DEFAULT_RECURSION_LIMIT;
+    return i.recursion_limit;
+}
+
+/// Update the per-interp recursion limit.  Values < 1 are rejected
+/// by the caller (matches Tcl 9, which bounces non-positive limits).
+pub fn interp_set_recursion_limit(addr: u32, new_limit: u32) void {
+    if (addr == 0) return;
+    const i: *Interp = @ptrFromInt(addr);
+    i.recursion_limit = new_limit;
+}
+
+/// Set / clear the ``INTERP_SAFE`` flag on ``addr``.  Used by
+/// ``interp marktrusted`` (clear) — there is no Tcl-level command
+/// to set the flag after creation; ``interp create -safe`` is the
+/// only path for that direction.
+pub fn interp_set_safe(addr: u32, safe: bool) void {
+    if (addr == 0) return;
+    const i: *Interp = @ptrFromInt(addr);
+    if (safe) {
+        i.flags |= INTERP_SAFE;
+    } else {
+        i.flags &= ~INTERP_SAFE;
+    }
+}
+
 /// Set on an ``Interp`` once ``interp delete path`` has torn it down.
 /// Dispatch paths that might still hold the stale ``Interp*`` (cross-
 /// interp alias redirect Commands whose ``OFF_IMPORT_REF_HEAD`` slot
@@ -119,6 +165,16 @@ pub const Interp = extern struct {
     /// collide, and so a deleted-then-recreated anonymous interp
     /// under one parent doesn't skew the issuer state in another.
     id_issuer: u32,
+
+    /// Per-interp recursion limit (``Tcl_SetRecursionLimit`` /
+    /// ``interp recursionlimit``).  Stored as ``u32`` for ABI
+    /// stability; ``0`` is treated as "uninitialised" and seeded to
+    /// the default (1000) on first read.  We accept and store the
+    /// value but don't actively enforce it — the WASM runtime has
+    /// no deep-recursion harness yet, so this is purely the
+    /// observable state behind the ``interp recursionlimit`` query
+    /// / setter.
+    recursion_limit: u32,
 };
 
 /// Root-interp singleton.  ``interp_root()`` allocates lazily and

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -393,6 +393,12 @@ pub fn child_create(parent: u32, name_ptr: u32, name_len: u32, flags: u32) u32 {
     c.parent = parent;
     c.flags = flags;
     c.root_ns = tcl_ns.ns_alloc_root();
+    // Inherit the parent's recursion limit (C Tcl's
+    // ``Tcl_CreateChild`` copies ``parent->maxNestingDepth``).
+    // interp-29.4.1/29.4.2 rely on this so a grandchild's
+    // recursion gate fires at the parent's lowered limit.
+    if (p.recursion_limit == 0) p.recursion_limit = DEFAULT_RECURSION_LIMIT;
+    c.recursion_limit = p.recursion_limit;
 
     if (name_len > 0) {
         const nbuf = alloc(name_len);

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -538,21 +538,41 @@ fn simple_of_fqn(name_ptr: u32, name_len: u32) struct { ptr: u32, len: u32 } {
 
 fn find_alias_cmd_in_subtree(ns: u32, target_rec: u32) AliasCmdAndNs {
     if (ns == 0 or target_rec == 0) return .{ .cmd = 0, .ns = 0 };
+    // Heap-range guard: a torn-down interp's ``root_ns`` can leave
+    // ``cmd_table.buf`` pointing at memory that was reclaimed or
+    // never mapped (basic-10.1's ``namespace delete ::`` then
+    // ``interp delete`` sequence).  Skip cleanly rather than
+    // ``read_i32``-trap.
+    const mem_pages: u32 = @intCast(@wasmMemorySize(0));
+    const mem_bytes: u64 = @as(u64, mem_pages) * 65536;
+    if (@as(u64, ns) + @sizeOf(tcl_ns.Namespace) > mem_bytes) return .{ .cmd = 0, .ns = 0 };
     const n: *const tcl_ns.Namespace = @ptrFromInt(ns);
     // Walk this ns's cmd_table.
-    if (n.cmd_table.buf != 0) {
-        var k: u32 = 0;
-        while (k < n.cmd_table.cap) : (k += 1) {
-            const bucket = n.cmd_table.buf + k * tcl_ns.NS_BUCKET_SIZE;
-            const cmd: u32 = @bitCast(read_i32(bucket + tcl_ns.OFF_HANDLE));
-            if (cmd == 0) continue;
-            // Use offset 12 for PARAMS_OBJ via the procs constants.
-            const params: u32 = @bitCast(read_i32(cmd + 12));
-            if (params == target_rec) return .{ .cmd = cmd, .ns = ns };
+    if (n.cmd_table.buf != 0 and n.cmd_table.cap > 0 and n.cmd_table.cap < (1 << 20)) {
+        const table_bytes: u64 = @as(u64, n.cmd_table.cap) * @as(u64, tcl_ns.NS_BUCKET_SIZE);
+        if (@as(u64, n.cmd_table.buf) + table_bytes <= mem_bytes) {
+            var k: u32 = 0;
+            while (k < n.cmd_table.cap) : (k += 1) {
+                const bucket = n.cmd_table.buf + k * tcl_ns.NS_BUCKET_SIZE;
+                const cmd: u32 = @bitCast(read_i32(bucket + tcl_ns.OFF_HANDLE));
+                if (cmd == 0) continue;
+                // Bounds-check the Command pointer before reading
+                // ``OFF_PARAMS_OBJ``.  Builtin forwards and alias
+                // redirects sometimes hold sentinel handles outside
+                // the heap range; reading through them would trap.
+                if (@as(u64, cmd) + 16 > mem_bytes) continue;
+                // Use offset 12 for PARAMS_OBJ via the procs constants.
+                const params: u32 = @bitCast(read_i32(cmd + 12));
+                if (params == target_rec) return .{ .cmd = cmd, .ns = ns };
+            }
         }
     }
     // Recurse into children namespaces.
-    if (n.child_table.buf == 0) return .{ .cmd = 0, .ns = 0 };
+    if (n.child_table.buf == 0 or n.child_table.cap == 0 or n.child_table.cap >= (1 << 20)) {
+        return .{ .cmd = 0, .ns = 0 };
+    }
+    const child_bytes: u64 = @as(u64, n.child_table.cap) * @as(u64, tcl_ns.NS_BUCKET_SIZE);
+    if (@as(u64, n.child_table.buf) + child_bytes > mem_bytes) return .{ .cmd = 0, .ns = 0 };
     var k: u32 = 0;
     while (k < n.child_table.cap) : (k += 1) {
         const cb = n.child_table.buf + k * tcl_ns.NS_BUCKET_SIZE;

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -98,6 +98,116 @@ pub fn interp_set_safe(addr: u32, safe: bool) void {
     }
 }
 
+/// Per-interp alias chain selector.  ``.child`` walks
+/// :attr:`Interp.aliases_head` (the source-side list of aliases
+/// registered in this interp); ``.target`` walks
+/// :attr:`Interp.alias_targets_head` (the destination-side list
+/// of aliases pointing at commands in this interp).
+pub const AliasChain = enum { child, target };
+
+/// Prepend an :type:`AliasRec` onto one of the interp's alias
+/// chains.  Mirrors ``Tcl_CreateAlias``'s wiring into
+/// ``Interp.child.aliasTable`` (for the source side) and
+/// ``Interp.parent.targetsPtr`` (for the target side).
+pub fn alias_chain_push(addr: u32, rec_addr: u32, chain: AliasChain) void {
+    if (addr == 0 or rec_addr == 0) return;
+    const i: *Interp = @ptrFromInt(addr);
+    const next_off: u32 = chain_next_offset(chain);
+    const head_addr: u32 = addr + chain_head_offset(chain);
+    // ``rec_addr`` points at an :type:`AliasRec`; ``next_off`` is
+    // the byte offset of the matching ``next_*`` field within that
+    // struct.  Mirrors C Tcl's ``aliasPtr->aliasEntryPtr = ...``
+    // (the child-side link) and ``targetPtr->nextPtr = ...`` (the
+    // parent-side link).
+    obj.write_i32(rec_addr + next_off, @bitCast(obj.read_i32(head_addr)));
+    obj.write_i32(head_addr, @bitCast(rec_addr));
+    _ = i;
+}
+
+/// Unlink an :type:`AliasRec` from one of the interp's alias
+/// chains.  Idempotent; missing entries are silently ignored
+/// (matches C Tcl's ``Tcl_DeleteHashEntry`` semantics — the
+/// caller may have already removed the record).
+pub fn alias_chain_remove(addr: u32, rec_addr: u32, chain: AliasChain) void {
+    if (addr == 0 or rec_addr == 0) return;
+    const next_off: u32 = chain_next_offset(chain);
+    var cursor: u32 = addr + chain_head_offset(chain);
+    while (true) {
+        const cur: u32 = @bitCast(obj.read_i32(cursor));
+        if (cur == 0) return;
+        if (cur == rec_addr) {
+            obj.write_i32(cursor, obj.read_i32(cur + next_off));
+            obj.write_i32(cur + next_off, 0);
+            return;
+        }
+        cursor = cur + next_off;
+    }
+}
+
+/// Walk one of the interp's alias chains.  Returns the first
+/// :type:`AliasRec` whose ``token`` (original simple name)
+/// matches ``name``.  Used by ``interp alias`` query/delete to
+/// resolve the alias by its original spelling even after a
+/// ``rename`` has moved the source Command around.
+pub fn alias_chain_find_token(
+    addr: u32,
+    chain: AliasChain,
+    name_ptr: u32,
+    name_len: u32,
+) u32 {
+    if (addr == 0) return 0;
+    const next_off: u32 = chain_next_offset(chain);
+    var cur: u32 = @bitCast(obj.read_i32(addr + chain_head_offset(chain)));
+    while (cur != 0) {
+        const tok_ptr: u32 = @bitCast(obj.read_i32(cur + ALIAS_REC_OFF_TOKEN_PTR));
+        const tok_len: u32 = @bitCast(obj.read_i32(cur + ALIAS_REC_OFF_TOKEN_LEN));
+        if (tok_len == name_len and bytes_eq(tok_ptr, name_ptr, name_len)) return cur;
+        cur = @bitCast(obj.read_i32(cur + next_off));
+    }
+    return 0;
+}
+
+fn chain_head_offset(chain: AliasChain) u32 {
+    return switch (chain) {
+        .child => @offsetOf(Interp, "aliases_head"),
+        .target => @offsetOf(Interp, "alias_targets_head"),
+    };
+}
+
+fn chain_next_offset(chain: AliasChain) u32 {
+    return switch (chain) {
+        .child => ALIAS_REC_OFF_NEXT_IN_CHILD,
+        .target => ALIAS_REC_OFF_NEXT_TARGET_IN_PARENT,
+    };
+}
+
+fn bytes_eq(a: u32, b: u32, len: u32) bool {
+    if (len == 0) return true;
+    const ap: [*]const u8 = @ptrFromInt(a);
+    const bp: [*]const u8 = @ptrFromInt(b);
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        if (ap[i] != bp[i]) return false;
+    }
+    return true;
+}
+
+// AliasRec field offsets that this module reaches into via direct
+// memory loads.  Kept in sync with ``cmds/tcl_alias.zig``'s
+// ``AliasRec`` ``extern struct`` layout via the comptime assert
+// below.
+const ALIAS_REC_OFF_TARGET_NAME_PTR: u32 = 0;
+const ALIAS_REC_OFF_TARGET_NAME_LEN: u32 = 4;
+const ALIAS_REC_OFF_N_PREFIX: u32 = 8;
+const ALIAS_REC_OFF_PREFIX_ARGS_ADDR: u32 = 12;
+const ALIAS_REC_OFF_PARENT_INTERP: u32 = 16;
+const ALIAS_REC_OFF_CHILD_INTERP: u32 = 20;
+const ALIAS_REC_OFF_TOKEN_PTR: u32 = 24;
+const ALIAS_REC_OFF_TOKEN_LEN: u32 = 28;
+const ALIAS_REC_OFF_NEXT_IN_CHILD: u32 = 32;
+const ALIAS_REC_OFF_NEXT_TARGET_IN_PARENT: u32 = 36;
+const ALIAS_REC_SIZE: u32 = 40;
+
 /// Set on an ``Interp`` once ``interp delete path`` has torn it down.
 /// Dispatch paths that might still hold the stale ``Interp*`` (cross-
 /// interp alias redirect Commands whose ``OFF_IMPORT_REF_HEAD`` slot
@@ -169,12 +279,34 @@ pub const Interp = extern struct {
     /// Per-interp recursion limit (``Tcl_SetRecursionLimit`` /
     /// ``interp recursionlimit``).  Stored as ``u32`` for ABI
     /// stability; ``0`` is treated as "uninitialised" and seeded to
-    /// the default (1000) on first read.  We accept and store the
-    /// value but don't actively enforce it — the WASM runtime has
-    /// no deep-recursion harness yet, so this is purely the
-    /// observable state behind the ``interp recursionlimit`` query
-    /// / setter.
+    /// the default (1000) on first read.  Enforcement lives in
+    /// :fn:`tcl_interp.eval_command` which compares
+    /// :attr:`num_levels` against this value and raises ``too many
+    /// nested evaluations (infinite loop?)`` when exceeded
+    /// (interp-29.3.x).
     recursion_limit: u32,
+
+    /// Current call-stack depth inside this interp.  Mirrors C Tcl's
+    /// ``Interp.numLevels`` — incremented at each ``eval_command``
+    /// entry and decremented on the way out.  Read by the recursion-
+    /// limit gate (above) and by the absorber for ``return -code N``
+    /// (``TclUpdateReturnInfo`` runs only at ``numLevels == 0``).
+    num_levels: u32,
+
+    /// Head of the doubly-linked list of aliases registered in this
+    /// interp (``Interp.child.aliasTable`` head in C Tcl, but a
+    /// simple chain serves the same purpose for our scale).  Drives
+    /// ``interp aliases <path>`` and survives ``rename`` of the
+    /// source command (the chain is keyed by the original token).
+    aliases_head: u32,
+
+    /// Head of the doubly-linked list of aliases whose *target*
+    /// lives in this interp.  Mirrors C Tcl's
+    /// ``Interp.parent.targetsPtr``: when this interp is torn down
+    /// :fn:`mark_deleted_subtree` walks the list and clears every
+    /// dangling source-side alias so a later dispatch through the
+    /// child can't crash on a freed parent.
+    alias_targets_head: u32,
 };
 
 /// Root-interp singleton.  ``interp_root()`` allocates lazily and
@@ -318,6 +450,56 @@ pub fn child_delete(parent: u32, name_ptr: u32, name_len: u32) bool {
 fn mark_deleted_subtree(interp: u32) void {
     const i: *Interp = @ptrFromInt(interp);
     i.flags |= INTERP_DELETED;
+
+    // Walk this interp's ``alias_targets_head`` chain — these are
+    // AliasRecs in OTHER interps whose target lives here.  Clear
+    // each one so a later dispatch through the source interp
+    // doesn't try to invoke a command in this (now-dead) target.
+    // Mirrors C Tcl's ``DeleteAlias`` cleanup that fires from
+    // ``DeleteInterpProc`` walking ``Interp.parent.targetsPtr``.
+    var cur_target: u32 = i.alias_targets_head;
+    while (cur_target != 0) {
+        const r: *@import("../cmds/tcl_alias.zig").AliasRec = @ptrFromInt(cur_target);
+        const next: u32 = r.next_target_in_parent;
+        // Find the live Command for this alias in its child interp
+        // and clear it (deactivates dispatch + drops the
+        // namespace-table bucket).  alias_clear unhooks from both
+        // chains so the source interp's ``interp aliases`` no
+        // longer reports a dangling entry.
+        if (r.child_interp != 0 and r.token_len > 0) {
+            const child: *Interp = @ptrFromInt(r.child_interp);
+            // Walk the child's ns tree for a Command whose
+            // params_obj == r.  Same shape as
+            // ``find_command_by_rec`` in tcl_alias.zig but
+            // inlined here to avoid the cross-module import
+            // cycle.
+            const found = find_alias_cmd_in_subtree(child.root_ns, cur_target);
+            if (found.cmd != 0 and found.ns != 0) {
+                // Clear the live cmd_table entry.  alias_clear is
+                // called below to unhook chain entries; bucket
+                // tombstoning happens here so the source name
+                // resolves to "unknown command" on next dispatch.
+                //
+                // The Command's stored name is the FQN
+                // (``::foo``); the cmd_table bucket is keyed by
+                // the simple name (``foo``).  Strip the prefix
+                // before clearing.
+                const name_ptr: u32 = @bitCast(read_i32(found.cmd));
+                const name_len: u32 = @bitCast(read_i32(found.cmd + 4));
+                const simple = simple_of_fqn(name_ptr, name_len);
+                _ = tcl_ns.ns_cmd_clear(found.ns, simple.ptr, simple.len);
+            }
+            // Always unhook from both chains, even when the
+            // Command lookup missed (the alias may have been
+            // ``rename``d off; the chain still holds it under
+            // its original token).
+            const alias_mod = @import("../cmds/tcl_alias.zig");
+            alias_mod.alias_clear_rec(cur_target);
+        }
+        cur_target = next;
+    }
+    i.alias_targets_head = 0;
+
     if (i.children.buf == 0 or i.children.cap == 0) return;
     var k: u32 = 0;
     while (k < i.children.cap) : (k += 1) {
@@ -329,6 +511,51 @@ fn mark_deleted_subtree(interp: u32) void {
         mark_deleted_subtree(handle);
         write_i32(bucket + tcl_ns.OFF_HANDLE, 0);
     }
+}
+
+const AliasCmdAndNs = struct { cmd: u32, ns: u32 };
+
+/// Strip the namespace prefix off a fully-qualified command name,
+/// returning the trailing simple name.  ``::foo::bar`` → ``bar``,
+/// bare ``foo`` → ``foo``.
+fn simple_of_fqn(name_ptr: u32, name_len: u32) struct { ptr: u32, len: u32 } {
+    if (name_len == 0) return .{ .ptr = name_ptr, .len = 0 };
+    const sp: [*]const u8 = @ptrFromInt(name_ptr);
+    var i: u32 = name_len;
+    while (i >= 2) : (i -= 1) {
+        if (sp[i - 2] == ':' and sp[i - 1] == ':') {
+            return .{ .ptr = name_ptr + i, .len = name_len - i };
+        }
+    }
+    return .{ .ptr = name_ptr, .len = name_len };
+}
+
+fn find_alias_cmd_in_subtree(ns: u32, target_rec: u32) AliasCmdAndNs {
+    if (ns == 0 or target_rec == 0) return .{ .cmd = 0, .ns = 0 };
+    const n: *const tcl_ns.Namespace = @ptrFromInt(ns);
+    // Walk this ns's cmd_table.
+    if (n.cmd_table.buf != 0) {
+        var k: u32 = 0;
+        while (k < n.cmd_table.cap) : (k += 1) {
+            const bucket = n.cmd_table.buf + k * tcl_ns.NS_BUCKET_SIZE;
+            const cmd: u32 = @bitCast(read_i32(bucket + tcl_ns.OFF_HANDLE));
+            if (cmd == 0) continue;
+            // Use offset 12 for PARAMS_OBJ via the procs constants.
+            const params: u32 = @bitCast(read_i32(cmd + 12));
+            if (params == target_rec) return .{ .cmd = cmd, .ns = ns };
+        }
+    }
+    // Recurse into children namespaces.
+    if (n.child_table.buf == 0) return .{ .cmd = 0, .ns = 0 };
+    var k: u32 = 0;
+    while (k < n.child_table.cap) : (k += 1) {
+        const cb = n.child_table.buf + k * tcl_ns.NS_BUCKET_SIZE;
+        const child_ns: u32 = @bitCast(read_i32(cb + tcl_ns.OFF_HANDLE));
+        if (child_ns == 0) continue;
+        const r = find_alias_cmd_in_subtree(child_ns, target_rec);
+        if (r.cmd != 0) return r;
+    }
+    return .{ .cmd = 0, .ns = 0 };
 }
 
 /// Predicate: has this Interp been torn down via ``interp delete``?

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -560,9 +560,9 @@ fn find_alias_cmd_in_subtree(ns: u32, target_rec: u32) AliasCmdAndNs {
                 // ``OFF_PARAMS_OBJ``.  Builtin forwards and alias
                 // redirects sometimes hold sentinel handles outside
                 // the heap range; reading through them would trap.
-                if (@as(u64, cmd) + 16 > mem_bytes) continue;
-                // Use offset 12 for PARAMS_OBJ via the procs constants.
-                const params: u32 = @bitCast(read_i32(cmd + 12));
+                const procs_mod = @import("tcl_procs.zig");
+                if (@as(u64, cmd) + procs_mod.OFF_PARAMS_OBJ + 4 > mem_bytes) continue;
+                const params: u32 = @bitCast(read_i32(cmd + procs_mod.OFF_PARAMS_OBJ));
                 if (params == target_rec) return .{ .cmd = cmd, .ns = ns };
             }
         }

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -652,6 +652,7 @@ pub export fn tcl_test_alias_create(
     n_prefix: i32,
     prefix_args_addr: i32,
 ) i32 {
+    const tcl_interp_reg = @import("interp/tcl_interp_registry.zig");
     const cmd = tcl_alias.alias_alloc(
         @bitCast(dest_ns),
         @bitCast(new_simple_ptr),
@@ -661,6 +662,7 @@ pub export fn tcl_test_alias_create(
         @bitCast(n_prefix),
         @bitCast(prefix_args_addr),
         0, // parent_interp — scaffolding always creates same-interp aliases
+        tcl_interp_reg.interp_current(),
     );
     _ = tcl_ns.ns_cmd_put(
         @bitCast(dest_ns),

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -1319,6 +1319,65 @@ pub fn memcpy(dst: u32, src: u32, len: u32) void {
 /// Create a new string TclObj by copying *len* bytes from *src*.
 /// The new TclObj owns its byte buffer (capacity = aligned alloc
 /// size) so subsequent appends can grow in place when refcount==1.
+/// Build a TclObj from a braced-word source span, applying Tcl's
+/// ``\<newline>`` → space substitution that ``Tcl_ParseBraces``
+/// performs in C.  Inside braces, every other escape stays literal
+/// — only the line-continuation sequence is collapsed.  When no
+/// substitution is needed (the common case) this falls through to
+/// :func:`obj_new_string_copy` so the inline-string fast path is
+/// preserved.
+///
+/// Reference Tcl behaviour (parseOld-7.4, interp-20.33/34): a braced
+/// string ``{a\<NL>b}`` has length ``a b`` (3 chars) once parsed —
+/// the backslash-newline plus any whitespace immediately following
+/// the newline collapses to a single space.  See ``Tcl_ParseBraces``
+/// in ``tmp/tcl9.0.3/generic/tclParse.c`` for the canonical C-side
+/// implementation.
+pub fn obj_new_braced_string(src: u32, len: u32) i32 {
+    if (len == 0) return obj_new_string(0, 0);
+    const sp: [*]const u8 = @ptrFromInt(src);
+    // Scan for ``\<newline>`` — the only substitution that fires
+    // inside braces.  No match → fast-path through the regular
+    // string-copy constructor (preserves the inline-string
+    // optimisation).
+    var has_bs_nl = false;
+    var i: u32 = 0;
+    while (i + 1 < len) : (i += 1) {
+        if (sp[i] == '\\' and sp[i + 1] == '\n') {
+            has_bs_nl = true;
+            break;
+        }
+    }
+    if (!has_bs_nl) return obj_new_string_copy(src, len);
+
+    // Allocate worst-case-sized output buffer (substitution can only
+    // *shrink* the byte span — each ``\<NL>...`` collapses to one
+    // space).  Walk again, emitting bytes verbatim except for the
+    // collapse sequence.
+    const out_buf = alloc(len);
+    if (out_buf == 0) return 0;
+    const dst: [*]u8 = @ptrFromInt(out_buf);
+    var off: u32 = 0;
+    i = 0;
+    while (i < len) {
+        if (i + 1 < len and sp[i] == '\\' and sp[i + 1] == '\n') {
+            // Collapse ``\<NL><whitespace>*`` → single space.
+            dst[off] = ' ';
+            off += 1;
+            i += 2;
+            while (i < len) : (i += 1) {
+                const c = sp[i];
+                if (c != ' ' and c != '\t') break;
+            }
+            continue;
+        }
+        dst[off] = sp[i];
+        off += 1;
+        i += 1;
+    }
+    return obj_new_string_take(out_buf, off, len);
+}
+
 pub fn obj_new_string_copy(src: u32, len: u32) i32 {
     if (len == 0) return obj_new_string(0, 0);
     // S6.2 — inline-string optimisation.  Strings short enough to

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -1336,14 +1336,17 @@ pub fn memcpy(dst: u32, src: u32, len: u32) void {
 pub fn obj_new_braced_string(src: u32, len: u32) i32 {
     if (len == 0) return obj_new_string(0, 0);
     const sp: [*]const u8 = @ptrFromInt(src);
-    // Scan for ``\<newline>`` — the only substitution that fires
-    // inside braces.  No match → fast-path through the regular
-    // string-copy constructor (preserves the inline-string
-    // optimisation).
+    // Scan for ``\<line-terminator>`` — the only substitution that
+    // fires inside braces.  All three Tcl-recognised forms count:
+    // ``\<LF>``, ``\<CR>``, and the two-byte ``\<CR><LF>``.  No
+    // match → fast-path through the regular string-copy
+    // constructor (preserves the inline-string optimisation).
+    // Matches the codegen-side ``_braced_lineconts`` helper in
+    // ``core/compiler/codegen/wasm/_emitter/_values.py``.
     var has_bs_nl = false;
     var i: u32 = 0;
     while (i + 1 < len) : (i += 1) {
-        if (sp[i] == '\\' and sp[i + 1] == '\n') {
+        if (sp[i] == '\\' and (sp[i + 1] == '\n' or sp[i + 1] == '\r')) {
             has_bs_nl = true;
             break;
         }
@@ -1360,11 +1363,16 @@ pub fn obj_new_braced_string(src: u32, len: u32) i32 {
     var off: u32 = 0;
     i = 0;
     while (i < len) {
-        if (i + 1 < len and sp[i] == '\\' and sp[i + 1] == '\n') {
-            // Collapse ``\<NL><whitespace>*`` → single space.
+        if (i + 1 < len and sp[i] == '\\' and (sp[i + 1] == '\n' or sp[i + 1] == '\r')) {
+            // Collapse ``\<line-terminator><whitespace>*`` → space.
+            // ``\<CR><LF>`` consumes the trailing ``<LF>`` so the
+            // pair is treated as one logical line terminator
+            // (matches reference Tcl's ``TclParseBackslash``).
             dst[off] = ' ';
             off += 1;
+            const was_cr = sp[i + 1] == '\r';
             i += 2;
+            if (was_cr and i < len and sp[i] == '\n') i += 1;
             while (i < len) : (i += 1) {
                 const c = sp[i];
                 if (c != ' ' and c != '\t') break;

--- a/tests/external/run_tcl9_tests.py
+++ b/tests/external/run_tcl9_tests.py
@@ -80,6 +80,22 @@ def _tcl9_test_file(name: str) -> Path:
     return p
 
 
+def _tcl9_library_root() -> Path | None:
+    """Return path to the Tcl 9 ``library/`` source tree, or None if missing.
+
+    The harness preopens this directory at guest ``/library`` so
+    bundles can resolve ``[info library]`` + ``file exists`` checks
+    against the real upstream library (safe-stock.test's opt /
+    cookiejar discovery, ``source [file join $tcl_library X]`` in
+    other tests).  Read-only from the bundle's point of view —
+    capability-bound through wasmtime's preopen so writes outside
+    ``preopen_tmpdir`` are denied.
+    """
+    tests_dir = ensure_tcl_source("9.0")
+    p = tests_dir.parent / "library"
+    return p if p.exists() else None
+
+
 def _tcl9_opt_library() -> Path | None:
     """Return path to Tcl 9's optparse.tcl, or None if missing.
 
@@ -119,8 +135,14 @@ set ::argv {}
 set ::argv0 ""
 set ::argc 0
 set ::tcl_interactive 0
-set ::auto_path {}
-set ::tcl_library ""
+# ``tcl_library`` points at the C Tcl 9 ``library/`` tree that
+# :func:`_tcl9_library_root` preopens at guest ``/library``.  Bundles
+# that resolve ``[info library]`` + ``file exists`` (safe-stock.test
+# discovering ``opt`` / ``cookiejar``, source-based ``[file join $tcl_library X]``
+# lookups elsewhere) hit the real upstream Tcl library files instead
+# of trapping with ``cannot find opt library`` at bundle setup.
+set ::tcl_library /library
+set ::auto_path [list /library]
 # Seed ::env with the handful of variables tcltest bundles probe at
 # load time.  chanio.test / io.test / fCmd.test all read ``::env(HOME)``
 # inside a ``testConstraint`` body that runs *before* any individual
@@ -705,12 +727,22 @@ def _run_bundle(bundle_src: str, label: str) -> tuple[str, str]:
             src_path = helpers_dir / helper
             if src_path.exists():
                 shutil.copyfile(src_path, Path(host_tmp) / helper)
+        # Preopen the C Tcl ``library/`` tree at guest ``/library`` so
+        # ``[info library]`` lookups and ``file exists`` probes hit
+        # real upstream files (see :func:`_tcl9_library_root`).  No
+        # copy — the tree is shared read-only via wasmtime's
+        # capability-bound preopen.
+        extra_preopens: list[tuple[str, str]] = []
+        lib_root = _tcl9_library_root()
+        if lib_root is not None:
+            extra_preopens.append((str(lib_root), "/library"))
         try:
             result = _run_wasm(
                 wasm,
                 capture_stdout=True,
                 capture_stderr=True,
                 preopen_tmpdir=host_tmp,
+                extra_preopens=tuple(extra_preopens),
             )
         except Exception as trap:
             pytest.fail(_resolve_trap(trap, getattr(trap, "tcl_stderr", ""), diag))
@@ -782,8 +814,17 @@ class TestTcltest9Init:
             pytest.skip(f"Tcl 9 tcltest.tcl does not yet compile: {exc}")
 
         with tempfile.TemporaryDirectory(prefix="tcl9test-init-") as host_tmp:
+            extra_preopens: list[tuple[str, str]] = []
+            lib_root = _tcl9_library_root()
+            if lib_root is not None:
+                extra_preopens.append((str(lib_root), "/library"))
             try:
-                result = _run_wasm(wasm, capture_stderr=True, preopen_tmpdir=host_tmp)
+                result = _run_wasm(
+                    wasm,
+                    capture_stderr=True,
+                    preopen_tmpdir=host_tmp,
+                    extra_preopens=tuple(extra_preopens),
+                )
             except Exception as trap:
                 stderr_text = getattr(trap, "tcl_stderr", "")
                 record_tcl9_result(
@@ -1008,6 +1049,16 @@ def _make_test_class(test_name: str, *, subsystem: str, deferred: bool = False):
                         src_path = helpers_dir / helper
                         if src_path.exists():
                             shutil.copyfile(src_path, Path(host_tmp) / helper)
+                    # See :func:`_tcl9_library_root` — capability-bound
+                    # share of the C Tcl 9 ``library/`` tree at guest
+                    # ``/library``.  Drives ``[info library]`` /
+                    # ``[file exists [file join $tcl_library …]]``
+                    # checks (safe-stock.test, source-based package
+                    # lookups elsewhere).
+                    extra_preopens: list[tuple[str, str]] = []
+                    lib_root = _tcl9_library_root()
+                    if lib_root is not None:
+                        extra_preopens.append((str(lib_root), "/library"))
                     # 45s wasmtime epoch watchdog: most healthy
                     # bundles finish in under 5s, the slowest non-pathological
                     # one (interp.test) takes ~12s.  A 45s cap surfaces
@@ -1021,6 +1072,7 @@ def _make_test_class(test_name: str, *, subsystem: str, deferred: bool = False):
                         capture_stdout=True,
                         capture_stderr=True,
                         preopen_tmpdir=host_tmp,
+                        extra_preopens=tuple(extra_preopens),
                         timeout_s=45,
                     )
                 ran = True

--- a/tests/external/run_tcl9_tests.py
+++ b/tests/external/run_tcl9_tests.py
@@ -87,9 +87,12 @@ def _tcl9_library_root() -> Path | None:
     bundles can resolve ``[info library]`` + ``file exists`` checks
     against the real upstream library (safe-stock.test's opt /
     cookiejar discovery, ``source [file join $tcl_library X]`` in
-    other tests).  Read-only from the bundle's point of view —
-    capability-bound through wasmtime's preopen so writes outside
-    ``preopen_tmpdir`` are denied.
+    other tests).  ``WasiConfig.preopen_dir`` grants the bundle
+    capability-scoped access to this directory; we rely on the
+    bundles not writing into it rather than on the host preopen
+    enforcing read-only perms — the test corpus is read-only by
+    construction, and any accidental write would land in the
+    checked-out source tree.
     """
     tests_dir = ensure_tcl_source("9.0")
     p = tests_dir.parent / "library"
@@ -730,8 +733,11 @@ def _run_bundle(bundle_src: str, label: str) -> tuple[str, str]:
         # Preopen the C Tcl ``library/`` tree at guest ``/library`` so
         # ``[info library]`` lookups and ``file exists`` probes hit
         # real upstream files (see :func:`_tcl9_library_root`).  No
-        # copy — the tree is shared read-only via wasmtime's
-        # capability-bound preopen.
+        # copy — the tree is shared via wasmtime's capability-bound
+        # preopen.  ``preopen_dir`` grants normal read/write access
+        # to the host directory; we rely on the bundles being well-
+        # behaved (they don't write to ``$tcl_library``) rather than
+        # on the host preopen enforcing read-only perms.
         extra_preopens: list[tuple[str, str]] = []
         lib_root = _tcl9_library_root()
         if lib_root is not None:

--- a/tests/runtime/test_tcl_hide.py
+++ b/tests/runtime/test_tcl_hide.py
@@ -26,6 +26,7 @@ HIDE_OK = 0
 HIDE_NOT_FOUND = 1
 HIDE_QUALIFIED_REJECTED = 2
 HIDE_NAME_TAKEN = 3
+HIDE_NON_GLOBAL_SOURCE = 4
 
 EXPOSE_OK = 0
 EXPOSE_NOT_FOUND = 1
@@ -157,11 +158,15 @@ def test_hide_not_found(runtime: RuntimeHandle):
 
 
 def test_hide_rejects_qualified_source(runtime: RuntimeHandle):
-    """Qualified source names are not accepted."""
+    """Qualified source names are not accepted.  Tcl 9's
+    ``Tcl_HideCommand`` classifies this as "can only hide global
+    namespace commands" — distinct from the destination-side
+    "cannot use qualifiers in hidden token" error — so the helper
+    returns :data:`HIDE_NON_GLOBAL_SOURCE` (4)."""
     root = runtime.root()
     runtime.register_proc("::foo")
     r = runtime.hide(root, "::foo", "foo")
-    assert r == HIDE_QUALIFIED_REJECTED
+    assert r == HIDE_NON_GLOBAL_SOURCE
 
 
 def test_hide_rejects_qualified_hidden_name(runtime: RuntimeHandle):

--- a/tests/test_wasm_execution.py
+++ b/tests/test_wasm_execution.py
@@ -829,6 +829,13 @@ class TestCommandDispatch:
             "frame_alias_frame_var",
             "frame_get_depth",
             "upvar_resolve_depth",
+            # ``upvar_walk_relative`` is pulled in alongside the rest
+            # of the upvar helpers — it resolves the relative-level
+            # form for the compiled-proc body and walks past foreign
+            # frames pushed by cross-interp alias/invokehidden so
+            # ``upvar 1`` inside a hidden command reaches its
+            # same-interp caller (interp-20.35 .. 20.44).
+            "upvar_walk_relative",
             # Signal-flag inspectors used by every compiled-proc-call
             # bridge to absorb ``return`` at the dispatch boundary
             # and propagate ``error`` past the call.  Always pulled

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -178,6 +178,7 @@ def _run_wasm(
     args: tuple[int, ...] = (),
     capture_stderr: bool = False,
     preopen_tmpdir: str | None = None,
+    extra_preopens: tuple[tuple[str, str], ...] = (),
     timeout_s: float | None = None,
     memory_size: int | None = None,
     capabilities: int = 0,
@@ -200,6 +201,13 @@ def _run_wasm(
     "doesn't exist" regardless of the host filesystem state.  The
     ``TestFile`` suite passes a fresh ``pytest tmp_path`` to
     exercise the real filesystem paths.
+
+    ``extra_preopens`` — additional ``(host_path, guest_path)`` pairs
+    granted alongside ``preopen_tmpdir``.  The Tcl 9 test harness uses
+    this to expose the C Tcl ``library/`` tree under ``/library`` so
+    bundle scripts (safe-stock, opt, etc.) resolve ``[info library]``
+    + ``file exists`` checks against the upstream library files
+    without copying 6 MB per test invocation.
     """
     engine = _get_engine_with_timeout() if timeout_s is not None else _get_engine()
     store = wasmtime.Store(engine)
@@ -245,6 +253,11 @@ def _run_wasm(
         # and the guest path as ``guest_path``; wasmtime's Python
         # binding follows that order.
         wasi_config.preopen_dir(preopen_tmpdir, "/")
+    for host_path, guest_path in extra_preopens:
+        # Additional dir grants — ``preopen_dir`` supports multiple
+        # mappings.  Each (host, guest) pair becomes an independent
+        # capability the guest can ``open`` paths under.
+        wasi_config.preopen_dir(host_path, guest_path)
 
     store.set_wasi(wasi_config)
 


### PR DESCRIPTION
## Summary

This PR implements two major features for Tcl 9 interpreter compatibility:

1. **Alias loop detection**: Prevents creation or renaming of aliases that would form dispatch cycles. Mirrors C Tcl's `AliasCheckLoop` by walking the target chain through the alias graph and refusing to install aliases that would create infinite recursion. Includes:
   - Pre-check in `interp_alias_create` before installing new aliases
   - Loop detection in `eval_rename` when renaming aliases
   - Canonical error messages matching C Tcl's diagnostics

2. **Cross-interp upvar support**: Enables `upvar` to correctly resolve variables across interpreter boundaries when aliases and hidden commands create interleaved call frames. Includes:
   - Per-frame interp tracking (`frame_interp` array) to tag which interpreter owns each frame
   - Cross-interp frame skipping in upvar resolution so `upvar 1` in a hidden command reaches the correct caller frame
   - Global-anchored frame support for `interp invokehidden -global`
   - Static-relative upvar walker (`upvar_walk_relative`) for proper frame counting across interp boundaries

3. **Alias infrastructure improvements**:
   - Extended `AliasRec` with `token_ptr`/`token_len` to preserve original alias names across `rename` operations
   - Added `child_interp` and `parent_interp` fields for proper interp chain tracking
   - Linked-list chains for per-interp alias management (source-side and target-side)
   - Token collision handling with `::` prefix prepending for uniqueness

4. **Per-interp recursion limits**: Implements configurable recursion depth limits per interpreter via `interp recursionlimit` command, with proper gating in dispatch paths.

5. **Interpreter deletion cascade**: When an alias's target interp is deleted, properly cleans up dangling aliases and prevents new alias creation targeting deleted interps.

## Validation

- Existing test suite passes with these changes
- Alias loop detection tested via interp-17.4/17.5/17.6 test cases
- Cross-interp upvar tested via interp-20.35..20.44 test cases
- Recursion limit enforcement tested via error-1.8 and related tests

https://claude.ai/code/session_01Fx6sS89Q8pURVe4VJpjtRq