### PR TITLE
Fix TclObj reference counting leaks across runtime and codegen

### DIFF
--- a/core/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/core/compiler/codegen/wasm/_emitter/_expressions.py
@@ -34,6 +34,7 @@ from .._ir import (
     ValType,
     WasmOp,
 )
+from .._ownership import Ownership
 from ._ops import _BINOP_WASM
 
 
@@ -369,16 +370,24 @@ class _WasmEmitterExprMixin(_Base):
         r_local = self._add_extra_local("_cmp_rhs", ValType.I32)
         res_local = self._add_extra_local("_cmp_res", ValType.I32)
         val_local = self._add_extra_local("_cmp_val", ValType.I64)
-        # Emit left and stash.
-        self._emit_str_value(left)
+        # Emit left and stash.  Use the ownership tag returned by
+        # ``_emit_str_value`` rather than the static
+        # ``_expr_node_is_borrowed`` check: an ``ExprRaw`` wrapping a
+        # bare ``$var`` (the shape CFG switch lowering produces for the
+        # subject) reads through ``_emit_value`` to a borrowed handle,
+        # but ``_expr_node_is_borrowed`` only recognises ``ExprVar``,
+        # so the trailing release below would silently drop the
+        # subject's slot ref — N times per call where N = arms before
+        # the match.  See the cmd-binary pending double-free fix.
+        l_ownership = self._emit_str_value(left)
         self._emit_local_tee(l_local)
-        if self._expr_node_is_borrowed(left):
+        if l_ownership.is_borrowed:
             self._emit_call(retain_idx)
             self._emit_local_get(l_local)
         # Emit right and stash.
-        self._emit_str_value(right)
+        r_ownership = self._emit_str_value(right)
         self._emit_local_tee(r_local)
-        if self._expr_node_is_borrowed(right):
+        if r_ownership.is_borrowed:
             self._emit_call(retain_idx)
             self._emit_local_get(r_local)
         # Call cmp — TclObj result on stack.
@@ -1328,12 +1337,23 @@ class _WasmEmitterExprMixin(_Base):
                 self._emit(WasmOp.I64_GE_S)
         self._emit(WasmOp.I64_EXTEND_I32_S)
 
-    def _emit_str_value(self, node: ExprNode) -> None:
+    def _emit_str_value(self, node: ExprNode) -> Ownership:
         """Emit an expression as an i32 TclObj pointer (for string ops).
 
         For ExprVar and ExprRaw, emits as a variable read.
         For ExprLiteral, creates a boxed string/int.
         For other nodes, evaluates as i64 and boxes.
+
+        Returns the :class:`Ownership` tag of the value left on the
+        stack so callers can manage the retain/release contract.  A
+        :data:`Ownership.BORROWED` value (typically a variable read)
+        shares its +1 with the source slot; callers that release the
+        value after consuming it must retain first or the source
+        slot's refcount goes negative.  This matters for any caller
+        that stashes the value in a local and releases it later
+        (e.g. :meth:`_emit_expr_obj_cmp_binary`).  Tagged immediates
+        are :data:`Ownership.BORROWED` too — release on an immediate
+        is a no-op so the retain/release pair is harmless.
         """
         from ....expr_ast import ExprCommand, ExprLiteral, ExprRaw, ExprString, ExprVar
 
@@ -1347,18 +1367,17 @@ class _WasmEmitterExprMixin(_Base):
                     if bare.startswith("{") and bare.endswith("}"):
                         bare = bare[1:-1]
                     self._emit_var_read_obj(bare)
-                    return
+                    return Ownership.BORROWED
                 var = self._resolve_var_name(text)
                 if var is not None:
                     self._emit_var_read_obj(var)
-                    return
+                    return Ownership.BORROWED
             case ExprCommand(text=text):
                 # Command substitution ``[cmd ...]`` — evaluate via
                 # _emit_value to get a TclObj string pointer directly.
                 # Going through the i64 fallback path loses the string
                 # representation (empty string → int 0 → "0").
-                self._emit_value(text)
-                return
+                return self._emit_value(text)
             case ExprRaw(text=text):
                 # ``ExprRaw`` carries the literal source text of a
                 # subject / operand that the expression parser
@@ -1399,12 +1418,11 @@ class _WasmEmitterExprMixin(_Base):
                         self._emit_i32_const(offset + 4)
                         self._emit_i32_const(len(encoded))
                         self._emit_call(eval_idx)
-                        return
-                self._emit_value(text)
-                return
+                        return Ownership.OWNED
+                return self._emit_value(text)
             case ExprLiteral(text=text):
                 self._emit_obj_literal(text)
-                return
+                return Ownership.OWNED
             case ExprString(text=text):
                 # Quoted string literal — strip outer quotes/braces and
                 # apply backslash substitution for double-quoted strings.
@@ -1417,7 +1435,7 @@ class _WasmEmitterExprMixin(_Base):
                     elif inner[0] == "{" and inner[-1] == "}":
                         inner = inner[1:-1]
                 self._emit_obj_literal(inner)
-                return
+                return Ownership.OWNED
         # Fallback: evaluate as TclObj (preserves TYPE_BIGNUM /
         # TYPE_FLOAT through nested arithmetic).  The previous path
         # routed through ``_emit_expr`` + ``_emit_box_int``, which
@@ -1427,6 +1445,7 @@ class _WasmEmitterExprMixin(_Base):
         # ``_emit_expr_obj`` keeps the TclObj intact so the receiving
         # ``tcl_expr_order_cmp`` (or string op) sees the bignum tag.
         self._emit_expr_obj(node)
+        return Ownership.OWNED
 
     def _emit_power(self, base: ExprNode, exp: ExprNode) -> None:
         """Emit integer exponentiation as a loop."""

--- a/runtime/zig/cmds/binary.zig
+++ b/runtime/zig/cmds/binary.zig
@@ -361,11 +361,12 @@ fn eval_binary_format(words: []const i32) i32 {
     const out_len = format_size(fmt, fs.len, words, 2);
     if (out_len == 0) return obj_new_string(0, 0);
     const buf = alloc(out_len);
+    if (buf == 0) return obj_new_string(0, 0);
     // Zero the buffer so unfilled bytes are NUL.
     const dst: [*]u8 = @ptrFromInt(buf);
     for (0..out_len) |k| dst[k] = 0;
     format_fill(buf, out_len, fmt, fs.len, words, 2);
-    return obj_new_string(@bitCast(buf), @bitCast(out_len));
+    return rt.obj_new_string_take(buf, out_len, out_len);
 }
 
 // ─── binary scan ─────────────────────────────────────────────────────────────
@@ -421,7 +422,9 @@ fn eval_binary_scan(words: []const i32) i32 {
                 } else {
                     // Multiple: build a Tcl list.
                     // Each element is at most 20 chars + space.
-                    const list_buf = alloc(cnt * 24);
+                    const list_buf_size: u32 = cnt * 24;
+                    const list_buf = alloc(list_buf_size);
+                    if (list_buf == 0) break;
                     var list_off: u32 = 0;
                     const list_dst: [*]u8 = @ptrFromInt(list_buf);
                     var k: u32 = 0;
@@ -439,7 +442,7 @@ fn eval_binary_scan(words: []const i32) i32 {
                         list_off += fmt_i64(list_dst, list_off, v);
                     }
                     if (words.len > 3 + vi) {
-                        _ = frames.var_set(words[3 + vi], obj_new_string(@bitCast(list_buf), @bitCast(list_off)));
+                        _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(list_buf, list_off, list_buf_size));
                         vi += 1;
                         assigned += 1;
                     }
@@ -465,7 +468,9 @@ fn eval_binary_scan(words: []const i32) i32 {
                 const cnt: u32 = count_or_null orelse ((src_len -| off) * 2);
                 const take_bytes = (cnt + 1) / 2;
                 if (off + take_bytes > src_len) break;
-                const hex_buf = alloc(cnt + 1);
+                const hex_buf_size: u32 = cnt + 1;
+                const hex_buf = alloc(hex_buf_size);
+                if (hex_buf == 0) break;
                 const hex_dst: [*]u8 = @ptrFromInt(hex_buf);
                 const src_p: [*]const u8 = @ptrFromInt(src_base + off);
                 const hex_chars = "0123456789abcdef";
@@ -479,7 +484,7 @@ fn eval_binary_scan(words: []const i32) i32 {
                     hex_dst[k] = hex_chars[nibble];
                 }
                 if (words.len > 3 + vi) {
-                    _ = frames.var_set(words[3 + vi], obj_new_string(@bitCast(hex_buf), @bitCast(cnt)));
+                    _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(hex_buf, cnt, hex_buf_size));
                     vi += 1;
                     assigned += 1;
                 }
@@ -489,7 +494,9 @@ fn eval_binary_scan(words: []const i32) i32 {
                 const cnt: u32 = count_or_null orelse ((src_len -| off) * 8);
                 const take_bytes = (cnt + 7) / 8;
                 if (off + take_bytes > src_len) break;
-                const bit_buf = alloc(cnt + 1);
+                const bit_buf_size: u32 = cnt + 1;
+                const bit_buf = alloc(bit_buf_size);
+                if (bit_buf == 0) break;
                 const bit_dst: [*]u8 = @ptrFromInt(bit_buf);
                 const src_p: [*]const u8 = @ptrFromInt(src_base + off);
                 var k: u32 = 0;
@@ -502,7 +509,7 @@ fn eval_binary_scan(words: []const i32) i32 {
                     bit_dst[k] = '0' + bit;
                 }
                 if (words.len > 3 + vi) {
-                    _ = frames.var_set(words[3 + vi], obj_new_string(@bitCast(bit_buf), @bitCast(cnt)));
+                    _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(bit_buf, cnt, bit_buf_size));
                     vi += 1;
                     assigned += 1;
                 }

--- a/runtime/zig/cmds/binary.zig
+++ b/runtime/zig/cmds/binary.zig
@@ -445,6 +445,13 @@ fn eval_binary_scan(words: []const i32) i32 {
                         _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(list_buf, list_off, list_buf_size));
                         vi += 1;
                         assigned += 1;
+                    } else {
+                        // No backing variable — caller is just probing
+                        // assigned count.  Free the staged list buffer
+                        // before continuing or the slab leaks for the
+                        // remainder of the runtime.
+                        const obj_mod_scan = @import("../valtypes/tcl_obj.zig");
+                        obj_mod_scan.free_sized(list_buf, list_buf_size);
                     }
                 }
             },
@@ -458,10 +465,18 @@ fn eval_binary_scan(words: []const i32) i32 {
                         @as(*const u8, @ptrFromInt(src_base + end - 1)).* == 0)) end -= 1;
                 }
                 if (words.len > 3 + vi) {
+                    // ``obj_new_string`` borrows the bytes; ``var_set``
+                    // promotes via ``ensure_var_obj_owned`` (cap==0 ->
+                    // fresh copy).  The slot then holds the copy and
+                    // releases the borrow obj — net 0 leak.
                     _ = frames.var_set(words[3 + vi], obj_new_string(@bitCast(src_base + off), @bitCast(end - off)));
                     vi += 1;
                     assigned += 1;
                 }
+                // When no variable is supplied we don't mint the
+                // borrow obj at all (above ``if`` skipped) so there's
+                // nothing to release — the source-buffer pointer is
+                // borrowed from the data input.
                 off += take;
             },
             'h', 'H' => {
@@ -487,6 +502,9 @@ fn eval_binary_scan(words: []const i32) i32 {
                     _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(hex_buf, cnt, hex_buf_size));
                     vi += 1;
                     assigned += 1;
+                } else {
+                    const obj_mod_scan = @import("../valtypes/tcl_obj.zig");
+                    obj_mod_scan.free_sized(hex_buf, hex_buf_size);
                 }
                 off += take_bytes;
             },
@@ -512,6 +530,9 @@ fn eval_binary_scan(words: []const i32) i32 {
                     _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(bit_buf, cnt, bit_buf_size));
                     vi += 1;
                     assigned += 1;
+                } else {
+                    const obj_mod_scan = @import("../valtypes/tcl_obj.zig");
+                    obj_mod_scan.free_sized(bit_buf, bit_buf_size);
                 }
                 off += take_bytes;
             },

--- a/runtime/zig/cmds/chan.zig
+++ b/runtime/zig/cmds/chan.zig
@@ -55,6 +55,7 @@ pub fn eval_fconfigure(words: []const i32) result_mod.InterpResult {
     }
     if (total_cap == 0) total_cap = 1;
     const buf = alloc(total_cap);
+    if (buf == 0) return result_mod.from_globals(chan.tcl_cmd_fconfigure(fd, 0));
     var off: u32 = 0;
     i = 2;
     while (i < words.len) : (i += 1) {
@@ -66,7 +67,7 @@ pub fn eval_fconfigure(words: []const i32) result_mod.InterpResult {
         const s = obj.obj_ensure_string(words[i]);
         off = list_quote.list_elem_quote_nth(buf, off, s.ptr, s.len);
     }
-    const args_obj = obj_new_string(@bitCast(buf), @bitCast(off));
+    const args_obj = rt.obj_new_string_take(buf, off, total_cap);
     return result_mod.from_globals(chan.tcl_cmd_fconfigure(fd, args_obj));
 }
 

--- a/runtime/zig/cmds/chan.zig
+++ b/runtime/zig/cmds/chan.zig
@@ -111,7 +111,19 @@ fn eval_chan_names(words: []const i32) i32 {
             const ns = obj_ensure_string(name);
             if (!tcl_string.glob_match(pattern_ptr, pattern_len, ns.ptr, ns.len)) continue;
         }
-        result = rt.tcl_cmd_lappend(result, name);
+        // ``tcl_cmd_lappend`` may take the in-place fast path
+        // (returning the same handle) or the canonical-rebuild slow
+        // path (returning a fresh +1 owned obj).  The empty-string
+        // seed always misses the fast path (``cap == 0``), so the
+        // first hit returns a fresh handle — release the prior
+        // accumulator on swap so the seed (and any subsequent
+        // intermediate rebuild) doesn't outlive the call.
+        const next = rt.tcl_cmd_lappend(result, name);
+        if (next != result) {
+            const obj_mod_chan = @import("../valtypes/tcl_obj.zig");
+            obj_mod_chan.tcl_obj_release(result);
+        }
+        result = next;
     }
     return result;
 }

--- a/runtime/zig/cmds/coroutine.zig
+++ b/runtime/zig/cmds/coroutine.zig
@@ -109,10 +109,15 @@ fn eval_coroutine(words: []const i32) result_mod.InterpResult {
             const n_parts = obj.list_count_elements(lam.ptr, lam.len);
             if (n_parts >= 2) {
                 const body_elem = obj.list_element_at(lam.ptr, lam.len, 1);
-                body = if (body_elem.braced)
-                    obj.obj_new_string_copy(lam.ptr + body_elem.start, body_elem.len)
-                else
-                    obj.obj_new_string(@bitCast(lam.ptr + body_elem.start), @bitCast(body_elem.len));
+                // Always copy the bytes — the unbraced branch used to
+                // ``obj_new_string`` (borrow) wrapping ``lam.ptr +
+                // body_elem.start``, but ``lam.ptr`` is borrowed from
+                // ``words[3]``'s buffer.  ``coro_mod.create`` retains
+                // the body TclObj header, but its ``str_ptr`` still
+                // pointed into ``words[3]``'s buffer.  After dispatch
+                // releases ``words[3]`` the buffer is freed and the
+                // coroutine's body string-rep dangles.
+                body = obj.obj_new_string_copy(lam.ptr + body_elem.start, body_elem.len);
             }
         } else if (w2s.len == 4 and w2s[0] == 'e' and w2s[1] == 'v' and
             w2s[2] == 'a' and w2s[3] == 'l')

--- a/runtime/zig/cmds/coroutine.zig
+++ b/runtime/zig/cmds/coroutine.zig
@@ -33,6 +33,7 @@ fn build_invocation_script(ws: []const i32) i32 {
         if (i > 0) total += 1; // separator space
     }
     const buf = obj.alloc(total);
+    if (buf == 0) return obj.obj_new_string(0, 0);
     var off: u32 = 0;
     i = 0;
     while (i < ws.len) : (i += 1) {
@@ -48,7 +49,7 @@ fn build_invocation_script(ws: []const i32) i32 {
             off = obj.list_elem_quote_nth(buf, off, s.ptr, s.len);
         }
     }
-    return obj.obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, total);
 }
 
 /// Build the dispatch ``Command`` struct.  ``fqn_ptr`` / ``fqn_len``

--- a/runtime/zig/cmds/dict.zig
+++ b/runtime/zig/cmds/dict.zig
@@ -210,7 +210,14 @@ fn eval_dict_create(words: []const i32) i32 {
     var d: i32 = rt.dict_create();
     var wi: u32 = 2;
     while (wi + 1 < words.len) : (wi += 2) {
-        d = rt.dict_set(d, words[wi], words[wi + 1]);
+        // ``dict_set`` returns the same handle when it took the
+        // in-place fast path, or a fresh +1 obj when it canonical-
+        // rebuilt.  The first iteration always rebuilds (empty dict
+        // can't be mutated in place), so without releasing the old
+        // ``d`` on swap we leak the initial empty dict.
+        const next = rt.dict_set(d, words[wi], words[wi + 1]);
+        if (next != d) obj.tcl_obj_release(d);
+        d = next;
     }
     return d;
 }
@@ -220,14 +227,32 @@ fn eval_dict_create(words: []const i32) i32 {
 /// absent the value is treated as the empty string.  Mirrors
 /// ``tclDictObj.c::DictAppendCmd``.
 fn eval_dict_append(words: []const i32) i32 {
-    var cur = frames.var_resolve(words[2]);
-    if (cur == 0) cur = rt.dict_create();
+    // Ownership inventory:
+    //   * ``cur`` — borrowed from the var slot, OR +1 owned (when
+    //     we created the empty dict).
+    //   * ``existing`` — +1 owned (dict_get retains its bucket value
+    //     and the fallback obj_new_string_copy returns +1 too).
+    //   * ``tcl_cmd_append`` — may mutate in place (returns same
+    //     handle) or canonical-rebuild (returns fresh +1).  Release
+    //     the prior ``existing`` on swap.
+    //   * ``dict_set`` — same in-place-or-rebuild contract.  When it
+    //     returns the same handle as ``cur``, our +1 (if any) is
+    //     the same as the returned handle's +1; transfer it to the
+    //     caller via the return value.  When it returns a fresh obj,
+    //     release the local ``cur`` we owned.
+    const cur_borrowed = frames.var_resolve(words[2]);
+    const cur: i32 = if (cur_borrowed == 0) rt.dict_create() else cur_borrowed;
+    const owns_cur: bool = (cur_borrowed == 0);
     var existing = rt.dict_get(cur, words[3]);
     var wi: u32 = 4;
     while (wi < words.len) : (wi += 1) {
-        existing = rt.tcl_cmd_append(existing, words[wi]);
+        const next = rt.tcl_cmd_append(existing, words[wi]);
+        if (next != existing) obj.tcl_obj_release(existing);
+        existing = next;
     }
     const result = rt.dict_set(cur, words[3], existing);
+    obj.tcl_obj_release(existing);
+    if (owns_cur and result != cur) obj.tcl_obj_release(cur);
     _ = frames.var_set(words[2], result);
     return result;
 }
@@ -237,14 +262,20 @@ fn eval_dict_append(words: []const i32) i32 {
 /// is absent the value starts as the empty list.  Mirrors
 /// ``tclDictObj.c::DictLappendCmd``.
 fn eval_dict_lappend(words: []const i32) i32 {
-    var cur = frames.var_resolve(words[2]);
-    if (cur == 0) cur = rt.dict_create();
+    // See ``eval_dict_append`` for the ownership inventory.
+    const cur_borrowed = frames.var_resolve(words[2]);
+    const cur: i32 = if (cur_borrowed == 0) rt.dict_create() else cur_borrowed;
+    const owns_cur: bool = (cur_borrowed == 0);
     var existing = rt.dict_get(cur, words[3]);
     var wi: u32 = 4;
     while (wi < words.len) : (wi += 1) {
-        existing = rt.tcl_cmd_lappend(existing, words[wi]);
+        const next = rt.tcl_cmd_lappend(existing, words[wi]);
+        if (next != existing) obj.tcl_obj_release(existing);
+        existing = next;
     }
     const result = rt.dict_set(cur, words[3], existing);
+    obj.tcl_obj_release(existing);
+    if (owns_cur and result != cur) obj.tcl_obj_release(cur);
     _ = frames.var_set(words[2], result);
     return result;
 }
@@ -253,13 +284,24 @@ fn eval_dict_lappend(words: []const i32) i32 {
 /// to the integer value at KEY.  When KEY is absent treats the value
 /// as 0 before incrementing.  Mirrors ``tclDictObj.c::DictIncrCmd``.
 fn eval_dict_incr(words: []const i32) i32 {
-    var cur = frames.var_resolve(words[2]);
-    if (cur == 0) cur = rt.dict_create();
+    // See ``eval_dict_append`` for the ownership inventory.  Note
+    // that ``dict_get`` here returns +1 owned but we only read its
+    // int value — release it before computing ``new_val``.
+    const cur_borrowed = frames.var_resolve(words[2]);
+    const cur: i32 = if (cur_borrowed == 0) rt.dict_create() else cur_borrowed;
+    const owns_cur: bool = (cur_borrowed == 0);
     const incr_amount: i64 = if (words.len >= 5) rt.obj_get_int(words[4]) else 1;
     const has_key = rt.obj_get_int(rt.dict_exists(cur, words[3])) != 0;
-    const old_val: i64 = if (has_key) rt.obj_get_int(rt.dict_get(cur, words[3])) else 0;
+    var old_val: i64 = 0;
+    if (has_key) {
+        const cur_val = rt.dict_get(cur, words[3]);
+        old_val = rt.obj_get_int(cur_val);
+        obj.tcl_obj_release(cur_val);
+    }
     const new_val = obj.obj_new_int(old_val + incr_amount);
     const result = rt.dict_set(cur, words[3], new_val);
+    obj.tcl_obj_release(new_val);
+    if (owns_cur and result != cur) obj.tcl_obj_release(cur);
     _ = frames.var_set(words[2], result);
     return result;
 }
@@ -269,10 +311,21 @@ fn eval_dict_incr(words: []const i32) i32 {
 fn eval_dict_merge(words: []const i32) i32 {
     if (words.len <= 2) return rt.dict_create();
     if (words.len == 3) return words[2];
+    // ``result`` starts as the borrowed ``words[2]``; after the first
+    // ``dict_merge_pair`` it may flip to a fresh +1 owned obj.  Track
+    // ownership so intermediate dicts get released — without this the
+    // earlier code leaked every intermediate ``current`` produced by
+    // the merge chain past iteration 1.
     var result: i32 = words[2];
+    var owns_result: bool = false;
     var wi: u32 = 3;
     while (wi < words.len) : (wi += 1) {
-        result = rt.dict_merge_pair(result, words[wi]);
+        const next = rt.dict_merge_pair(result, words[wi]);
+        if (next != result) {
+            if (owns_result) obj.tcl_obj_release(result);
+            owns_result = true;
+        }
+        result = next;
     }
     return result;
 }
@@ -280,10 +333,17 @@ fn eval_dict_merge(words: []const i32) i32 {
 /// ``dict remove DICT ?KEY ...?`` — return a copy of DICT with each
 /// listed KEY removed.  Mirrors ``tclDictObj.c::DictRemoveCmd``.
 fn eval_dict_remove(words: []const i32) i32 {
+    // See ``eval_dict_merge`` for the ownership-tracking rationale.
     var result: i32 = words[2];
+    var owns_result: bool = false;
     var wi: u32 = 3;
     while (wi < words.len) : (wi += 1) {
-        result = rt.dict_unset(result, words[wi]);
+        const next = rt.dict_unset(result, words[wi]);
+        if (next != result) {
+            if (owns_result) obj.tcl_obj_release(result);
+            owns_result = true;
+        }
+        result = next;
     }
     return result;
 }
@@ -299,10 +359,17 @@ fn eval_dict_replace(words: []const i32) i32 {
         stubs.raise("wrong # args: should be \"dict replace dictionary ?key value ...?\"");
         return 0;
     }
+    // See ``eval_dict_merge`` for the ownership-tracking rationale.
     var result: i32 = words[2];
+    var owns_result: bool = false;
     var wi: u32 = 3;
     while (wi + 1 < words.len) : (wi += 2) {
-        result = rt.dict_set(result, words[wi], words[wi + 1]);
+        const next = rt.dict_set(result, words[wi], words[wi + 1]);
+        if (next != result) {
+            if (owns_result) obj.tcl_obj_release(result);
+            owns_result = true;
+        }
+        result = next;
     }
     return result;
 }
@@ -362,8 +429,12 @@ fn eval_dict_iter(words: []const i32, collect: bool) i32 {
     if (n_vars != 2) return 0;
     const kelem = rt.list_element_at(varlist.ptr, varlist.len, 0);
     const velem = rt.list_element_at(varlist.ptr, varlist.len, 1);
+    // ``kvar`` / ``vvar`` are owned +1 each — release on every exit
+    // path or they leak per ``dict for/map`` invocation.
     const kvar = obj.obj_new_string_copy(varlist.ptr + kelem.start, kelem.len);
     const vvar = obj.obj_new_string_copy(varlist.ptr + velem.start, velem.len);
+    defer obj.tcl_obj_release(kvar);
+    defer obj.tcl_obj_release(vvar);
 
     const dict = words[3];
     const sd = obj_ensure_string(dict);
@@ -390,6 +461,12 @@ fn eval_dict_iter(words: []const i32, collect: bool) i32 {
     while (pairs_left > 0) : (pairs_left -= 1) {
         const k = list_parse.cursor_next(sd.ptr, sd.len, &cur);
         const v = list_parse.cursor_next(sd.ptr, sd.len, &cur);
+        // Each iteration allocates fresh +1 key/val/body_result objs.
+        // ``frames.var_set`` and ``rt.dict_set`` retain what they
+        // need; the caller-side +1s here must be explicitly released
+        // every iteration or the loop leaks 2 (or 3 with collect)
+        // TclObjs per pair.  On non-OK exits release any partially-
+        // accumulated state too.
         const key_obj = obj.obj_new_string_copy(sd.ptr + k.start, k.len);
         const val_obj = obj.obj_new_string_copy(sd.ptr + v.start, v.len);
         _ = frames.var_set(kvar, key_obj);
@@ -398,19 +475,36 @@ fn eval_dict_iter(words: []const i32, collect: bool) i32 {
         const ir = result_mod.snapshot(body_result);
         switch (ir.code) {
             .OK => {},
-            .ERROR, .RETURN => return 0,
+            .ERROR, .RETURN => {
+                obj.tcl_obj_release(key_obj);
+                obj.tcl_obj_release(val_obj);
+                if (body_result != 0) obj.tcl_obj_release(body_result);
+                if (collect and collected != 0) obj.tcl_obj_release(collected);
+                return 0;
+            },
             .BREAK => {
+                obj.tcl_obj_release(key_obj);
+                obj.tcl_obj_release(val_obj);
+                if (body_result != 0) obj.tcl_obj_release(body_result);
                 result_mod.consume(.BREAK);
                 break;
             },
             .CONTINUE => {
+                obj.tcl_obj_release(key_obj);
+                obj.tcl_obj_release(val_obj);
+                if (body_result != 0) obj.tcl_obj_release(body_result);
                 result_mod.consume(.CONTINUE);
                 continue;
             },
         }
         if (collect) {
-            collected = rt.dict_set(collected, key_obj, body_result);
+            const next_collected = rt.dict_set(collected, key_obj, body_result);
+            if (next_collected != collected) obj.tcl_obj_release(collected);
+            collected = next_collected;
         }
+        obj.tcl_obj_release(key_obj);
+        obj.tcl_obj_release(val_obj);
+        if (body_result != 0) obj.tcl_obj_release(body_result);
     }
     return if (collect) collected else 0;
 }

--- a/runtime/zig/cmds/dict.zig
+++ b/runtime/zig/cmds/dict.zig
@@ -530,13 +530,24 @@ fn eval_dict_with(words: []const i32) i32 {
     const dict_var = words[2];
     const body = obj_ensure_string(words[words.len - 1]);
 
-    // Resolve the sub-dict at the optional key path.
+    // Resolve the sub-dict at the optional key path.  ``cur`` starts
+    // borrowed from the var slot; ``dict_get`` returns +1 owned, so
+    // after the first drill step ``cur`` is owned and each subsequent
+    // step leaks the prior ``cur`` unless we release it.  Track
+    // ownership so the loop's intermediates get reclaimed.
     var cur = frames.var_resolve(dict_var);
     if (cur == 0) return 0;
+    var owns_cur: bool = false;
     var ki: u32 = 3;
     while (ki + 1 < words.len) : (ki += 1) {
-        if (rt.obj_get_int(rt.dict_exists(cur, words[ki])) == 0) return 0;
-        cur = rt.dict_get(cur, words[ki]);
+        if (rt.obj_get_int(rt.dict_exists(cur, words[ki])) == 0) {
+            if (owns_cur) obj.tcl_obj_release(cur);
+            return 0;
+        }
+        const next = rt.dict_get(cur, words[ki]);
+        if (owns_cur) obj.tcl_obj_release(cur);
+        cur = next;
+        owns_cur = true;
     }
 
     // Snapshot keys and bind each as a same-named local.  Use a
@@ -551,17 +562,28 @@ fn eval_dict_with(words: []const i32) i32 {
         while (pairs > 0) : (pairs -= 1) {
             const k = list_parse.cursor_next(sd.ptr, sd.len, &lc);
             const v = list_parse.cursor_next(sd.ptr, sd.len, &lc);
+            // Per-pair +1 owned key/val — release after ``var_set``
+            // retains them.
             const key_obj = obj.obj_new_string_copy(sd.ptr + k.start, k.len);
             const val_obj = obj.obj_new_string_copy(sd.ptr + v.start, v.len);
             _ = frames.var_set(key_obj, val_obj);
+            obj.tcl_obj_release(key_obj);
+            obj.tcl_obj_release(val_obj);
         }
     }
 
     _ = interp.eval_script(body.ptr, body.len);
-    if (result_mod.snapshot(0).code == .ERROR) return 0;
+    if (result_mod.snapshot(0).code == .ERROR) {
+        if (owns_cur) obj.tcl_obj_release(cur);
+        return 0;
+    }
 
     // Write back each key from the (potentially modified) locals.
+    // ``sub`` inherits ``cur``'s ownership: if ``cur`` is owned (drill
+    // happened), ``sub`` starts owned too; otherwise borrowed.  Each
+    // ``dict_set`` swap follows the same own-vs-borrow track.
     var sub = cur;
+    var owns_sub: bool = owns_cur;
     {
         var lc: list_parse.Cursor = .{ .pos = 0 };
         var pairs: i64 = @divTrunc(n, 2);
@@ -573,8 +595,14 @@ fn eval_dict_with(words: []const i32) i32 {
             const key_obj = obj.obj_new_string_copy(sd.ptr + k.start, k.len);
             const new_val = frames.var_resolve(key_obj);
             if (new_val != 0) {
-                sub = rt.dict_set(sub, key_obj, new_val);
+                const next = rt.dict_set(sub, key_obj, new_val);
+                if (next != sub) {
+                    if (owns_sub) obj.tcl_obj_release(sub);
+                    owns_sub = true;
+                }
+                sub = next;
             }
+            obj.tcl_obj_release(key_obj);
         }
     }
 
@@ -582,19 +610,21 @@ fn eval_dict_with(words: []const i32) i32 {
     if (words.len == 4) {
         // No key path — sub is the top-level dict.
         _ = frames.var_set(dict_var, sub);
+        if (owns_sub) obj.tcl_obj_release(sub);
     } else {
+        // Multi-key drill writeback.  This is intentionally
+        // permissive about ownership of intermediates — the existing
+        // nested ``dict_get``/``dict_set`` chain has the same
+        // borrowed-vs-owned ambiguity throughout, and a partial fix
+        // here would risk premature frees.  ``sub`` is released
+        // after the chain rebuilds the top-level dict (see end).
         var top = frames.var_resolve(dict_var);
         if (top == 0) top = rt.dict_create();
-        // Walk back up: rebuild each ancestor with the new sub-dict
-        // at the corresponding key.  Build nested writes innermost-first.
         var depth: u32 = words.len - 1; // index of the deepest key + 1
-        // depth is currently the body index; the deepest key is depth - 1.
         depth -= 1;
-        // Rewrite from deepest to shallowest.
         var inner = sub;
         while (depth > 3) : (depth -= 1) {
             const key = words[depth];
-            // Get the parent dict by walking from top to depth - 1.
             var parent = top;
             var pi: u32 = 3;
             while (pi < depth) : (pi += 1) {
@@ -604,6 +634,10 @@ fn eval_dict_with(words: []const i32) i32 {
         }
         const final = rt.dict_set(top, words[3], inner);
         _ = frames.var_set(dict_var, final);
+        // We own ``sub``'s +1 from the drill chain; ``dict_set``
+        // copied its bytes into the rebuilt ``inner`` / ``final``,
+        // so we can release.
+        if (owns_sub) obj.tcl_obj_release(sub);
     }
     return 0;
 }
@@ -635,6 +669,10 @@ fn eval_dict_filter(words: []const i32) i32 {
     while (pairs > 0) : (pairs -= 1) {
         const k = list_parse.cursor_next(sd.ptr, sd.len, &lc);
         const v = list_parse.cursor_next(sd.ptr, sd.len, &lc);
+        // ``key_obj`` and ``val_obj`` are +1 owned; release per
+        // iteration to stop the per-pair leak.  ``dict_set`` may
+        // return a fresh +1 obj (canonical rebuild); track and
+        // release the prior ``result`` on swap.
         const key_obj = obj.obj_new_string_copy(sd.ptr + k.start, k.len);
         const val_obj = obj.obj_new_string_copy(sd.ptr + v.start, v.len);
         const candidate: i32 = if (filter_keys) key_obj else val_obj;
@@ -647,8 +685,12 @@ fn eval_dict_filter(words: []const i32) i32 {
             }
         }
         if (match) {
-            result = rt.dict_set(result, key_obj, val_obj);
+            const next = rt.dict_set(result, key_obj, val_obj);
+            if (next != result) obj.tcl_obj_release(result);
+            result = next;
         }
+        obj.tcl_obj_release(key_obj);
+        obj.tcl_obj_release(val_obj);
     }
     return result;
 }
@@ -675,8 +717,11 @@ fn eval_dict_filter_script(words: []const i32) i32 {
     }
     const kelem = rt.list_element_at(varlist.ptr, varlist.len, 0);
     const velem = rt.list_element_at(varlist.ptr, varlist.len, 1);
+    // ``kvar`` / ``vvar`` allocated once; release via defer.
     const kvar = obj.obj_new_string_copy(varlist.ptr + kelem.start, kelem.len);
     const vvar = obj.obj_new_string_copy(varlist.ptr + velem.start, velem.len);
+    defer obj.tcl_obj_release(kvar);
+    defer obj.tcl_obj_release(vvar);
 
     const sd = obj_ensure_string(words[2]);
     const n = rt.list_count_elements(sd.ptr, sd.len);
@@ -688,6 +733,9 @@ fn eval_dict_filter_script(words: []const i32) i32 {
     while (idx + 1 < n) : (idx += 2) {
         const k = rt.list_element_at(sd.ptr, sd.len, idx);
         const v = rt.list_element_at(sd.ptr, sd.len, idx + 1);
+        // ``key_obj`` / ``val_obj`` released after the per-iter
+        // dispose path runs.  ``body_result`` left alone — see
+        // ``eval_dict_iter`` for the borrowed-handle rationale.
         const key_obj = obj.obj_new_string_copy(sd.ptr + k.start, k.len);
         const val_obj = obj.obj_new_string_copy(sd.ptr + v.start, v.len);
         _ = frames.var_set(kvar, key_obj);
@@ -697,19 +745,32 @@ fn eval_dict_filter_script(words: []const i32) i32 {
         switch (ir.code) {
             .OK => {
                 if (rt.obj_get_int(body_result) != 0) {
-                    result = rt.dict_set(result, key_obj, val_obj);
+                    const next = rt.dict_set(result, key_obj, val_obj);
+                    if (next != result) obj.tcl_obj_release(result);
+                    result = next;
                 }
             },
-            .ERROR, .RETURN => return 0,
+            .ERROR, .RETURN => {
+                obj.tcl_obj_release(key_obj);
+                obj.tcl_obj_release(val_obj);
+                obj.tcl_obj_release(result);
+                return 0;
+            },
             .BREAK => {
+                obj.tcl_obj_release(key_obj);
+                obj.tcl_obj_release(val_obj);
                 result_mod.consume(.BREAK);
                 break;
             },
             .CONTINUE => {
+                obj.tcl_obj_release(key_obj);
+                obj.tcl_obj_release(val_obj);
                 result_mod.consume(.CONTINUE);
                 continue;
             },
         }
+        obj.tcl_obj_release(key_obj);
+        obj.tcl_obj_release(val_obj);
     }
     return result;
 }

--- a/runtime/zig/cmds/dict.zig
+++ b/runtime/zig/cmds/dict.zig
@@ -113,15 +113,29 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
         str_eq(sp, sub.len, "getwithdefault")) and words.len >= 5)
     {
         // Walk nested keys: dict, key1, key2, ..., default.
+        // ``cur`` starts borrowed (``words[2]``) and after the first
+        // ``dict_get`` becomes +1 owned.  Each subsequent ``dict_get``
+        // overwrites ``cur`` with another +1 owned obj; release the
+        // prior one or the chain leaks one obj per drill level.
         const default_obj = words[words.len - 1];
         var cur: i32 = words[2];
+        var owns_cur: bool = false;
         var ki: u32 = 3;
         while (ki + 1 < words.len) : (ki += 1) {
-            if (rt.obj_get_int(rt.dict_exists(cur, words[ki])) == 0) {
+            const exists_obj = rt.dict_exists(cur, words[ki]);
+            const exists = rt.obj_get_int(exists_obj) != 0;
+            if (!exists) {
+                if (owns_cur) obj.tcl_obj_release(cur);
                 return result_mod.from_globals(default_obj);
             }
-            cur = rt.dict_get(cur, words[ki]);
+            const next = rt.dict_get(cur, words[ki]);
+            if (owns_cur) obj.tcl_obj_release(cur);
+            cur = next;
+            owns_cur = true;
         }
+        // ``result_mod.from_globals`` doesn't take ownership; the
+        // dispatcher's retain-then-release pair on the return value
+        // covers our +1 transfer when ``owns_cur``.
         return result_mod.from_globals(cur);
     }
     if (str_eq(sp, sub.len, "set") and words.len >= 5) {
@@ -461,12 +475,14 @@ fn eval_dict_iter(words: []const i32, collect: bool) i32 {
     while (pairs_left > 0) : (pairs_left -= 1) {
         const k = list_parse.cursor_next(sd.ptr, sd.len, &cur);
         const v = list_parse.cursor_next(sd.ptr, sd.len, &cur);
-        // Each iteration allocates fresh +1 key/val/body_result objs.
-        // ``frames.var_set`` and ``rt.dict_set`` retain what they
-        // need; the caller-side +1s here must be explicitly released
-        // every iteration or the loop leaks 2 (or 3 with collect)
-        // TclObjs per pair.  On non-OK exits release any partially-
-        // accumulated state too.
+        // ``key_obj`` and ``val_obj`` are fresh +1 owned; ``var_set``
+        // retains them, so release our +1 once the bind is done.
+        // ``body_result`` is left alone — ``eval_script`` may return
+        // a BORROWED handle into a variable's live slot (see the
+        // contract at tcl_interp.zig:775); releasing it could
+        // corrupt that var.  ``dict_set`` copies the body_result's
+        // bytes, so the bytes stay valid even after we drop our
+        // key/val refs.
         const key_obj = obj.obj_new_string_copy(sd.ptr + k.start, k.len);
         const val_obj = obj.obj_new_string_copy(sd.ptr + v.start, v.len);
         _ = frames.var_set(kvar, key_obj);
@@ -478,21 +494,18 @@ fn eval_dict_iter(words: []const i32, collect: bool) i32 {
             .ERROR, .RETURN => {
                 obj.tcl_obj_release(key_obj);
                 obj.tcl_obj_release(val_obj);
-                if (body_result != 0) obj.tcl_obj_release(body_result);
                 if (collect and collected != 0) obj.tcl_obj_release(collected);
                 return 0;
             },
             .BREAK => {
                 obj.tcl_obj_release(key_obj);
                 obj.tcl_obj_release(val_obj);
-                if (body_result != 0) obj.tcl_obj_release(body_result);
                 result_mod.consume(.BREAK);
                 break;
             },
             .CONTINUE => {
                 obj.tcl_obj_release(key_obj);
                 obj.tcl_obj_release(val_obj);
-                if (body_result != 0) obj.tcl_obj_release(body_result);
                 result_mod.consume(.CONTINUE);
                 continue;
             },
@@ -504,7 +517,6 @@ fn eval_dict_iter(words: []const i32, collect: bool) i32 {
         }
         obj.tcl_obj_release(key_obj);
         obj.tcl_obj_release(val_obj);
-        if (body_result != 0) obj.tcl_obj_release(body_result);
     }
     return if (collect) collected else 0;
 }

--- a/runtime/zig/cmds/dict.zig
+++ b/runtime/zig/cmds/dict.zig
@@ -68,7 +68,16 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
         // a two-level chain).  Walk the chain from words[2] (the
         // dict) through words[3..] (the keys).  Missing keys raise
         // ``key "K" not known in dictionary``.
+        //
+        // Ownership: ``cur`` starts borrowed (``words[2]``).  Each
+        // ``dict_get`` call returns +1 owned, so on the second and
+        // later iterations the prior +1 must be released before
+        // overwriting ``cur`` — otherwise nested ``dict get`` chains
+        // (and the missing-key error path that bails mid-walk) leak
+        // one obj per drill level past the first.  Mirrors the
+        // ``owns_cur`` pattern in the ``dict getd`` arm below.
         var cur: i32 = words[2];
+        var owns_cur: bool = false;
         var ki: u32 = 3;
         while (ki < words.len) : (ki += 1) {
             if (rt.obj_get_int(rt.dict_exists(cur, words[ki])) == 0) {
@@ -81,6 +90,7 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
                 const total: u32 = @intCast(prefix.len + ks.len + middle.len);
                 const buf = obj_mod_dict.alloc(total);
                 if (buf == 0) {
+                    if (owns_cur) obj_mod_dict.tcl_obj_release(cur);
                     stubs_mod.raise("dict get: key not found");
                     return result_mod.from_globals(0);
                 }
@@ -96,9 +106,13 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
                 const msg = obj_mod_dict.obj_new_string_take(buf, total, total);
                 const catch_mod_dict = @import("../interp/tcl_catch.zig");
                 catch_mod_dict.tcl_cmd_error(msg);
+                if (owns_cur) obj_mod_dict.tcl_obj_release(cur);
                 return result_mod.from_globals(0);
             }
-            cur = rt.dict_get(cur, words[ki]);
+            const next = rt.dict_get(cur, words[ki]);
+            if (owns_cur) obj.tcl_obj_release(cur);
+            cur = next;
+            owns_cur = true;
         }
         return result_mod.from_globals(cur);
     }
@@ -807,7 +821,13 @@ fn eval_dict_update(words: []const i32) i32 {
         const cur = frames.var_resolve(dict_var);
         if (cur == 0) continue;
         if (rt.obj_get_int(rt.dict_exists(cur, words[key_idx])) != 0) {
-            _ = frames.var_set(words[var_idx], rt.dict_get(cur, words[key_idx]));
+            // ``dict_get`` returns +1 owned; ``var_set`` retains for
+            // the slot.  Release the local +1 share after the store
+            // — without this every ``dict update`` pre-bind leaked
+            // one TclObj header per key.
+            const val = rt.dict_get(cur, words[key_idx]);
+            _ = frames.var_set(words[var_idx], val);
+            obj.tcl_obj_release(val);
         }
     }
 
@@ -827,18 +847,34 @@ fn eval_dict_update(words: []const i32) i32 {
 
     // 3. Post-script: reflect each VAR back into the dict (or
     //    remove the key if VAR was unset).
+    //
+    // Ownership: ``cur`` is borrowed from the var slot; we own
+    // ``dict_now`` only when we minted it via ``rt.dict_create``
+    // (the empty-slot path).  ``dict_set`` / ``dict_unset`` either
+    // mutate in place (returning the same handle) or rebuild
+    // (fresh +1 owned).  ``var_set`` retains for the slot — we
+    // must release our local +1 to ``updated`` after the store, AND
+    // release the minted ``dict_now`` on the rebuild path so the
+    // empty-dict seed isn't orphaned.
     pi = 0;
     while (pi < n_pairs) : (pi += 1) {
         const key_idx = 3 + pi * 2;
         const var_idx = 4 + pi * 2;
         const cur = frames.var_resolve(dict_var);
         const dict_now = if (cur == 0) rt.dict_create() else cur;
+        const owns_dict_now = (cur == 0);
         const var_val = frames.var_resolve(words[var_idx]);
         const updated = if (var_val == 0)
             rt.dict_unset(dict_now, words[key_idx])
         else
             rt.dict_set(dict_now, words[key_idx], var_val);
         _ = frames.var_set(dict_var, updated);
+        if (owns_dict_now and updated != dict_now) {
+            obj.tcl_obj_release(dict_now);
+        }
+        if (updated != cur and updated != dict_now) {
+            obj.tcl_obj_release(updated);
+        }
     }
 
     // Re-raise the captured flow-control signal so the enclosing

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -988,13 +988,14 @@ fn eval_time(words: []const i32) result_mod.InterpResult {
     const suffix = " microseconds per iteration";
     const total: u32 = @intCast(pi_s.len + suffix.len);
     const buf = rt.alloc(total);
+    if (buf == 0) return result_mod.from_globals(rt.obj_new_string(0, 0));
     rt.memcpy(buf, pi_s.ptr, pi_s.len);
     var k: u32 = 0;
     while (k < suffix.len) : (k += 1) {
         const d: [*]u8 = @ptrFromInt(buf + pi_s.len + k);
         d[0] = suffix[k];
     }
-    return result_mod.from_globals(rt.obj_new_string(@bitCast(buf), @bitCast(total)));
+    return result_mod.from_globals(rt.obj_new_string_take(buf, total, total));
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -516,7 +516,13 @@ fn eval_catch(words: []const i32) result_mod.InterpResult {
         // Mirrors the wasm-codegen path in
         // ``_emitter/_control_flow.py::_emit_catch``.
         if (words.len >= 4) {
-            _ = frames.var_set(words[3], catch_mod.catch_options());
+            // ``catch_options`` returns +1 owned; ``var_set`` retains
+            // for the slot.  Release the local +1 share after the
+            // store or every 4-arg catch leaks one dict per call.
+            const opt_obj = catch_mod.catch_options();
+            _ = frames.var_set(words[3], opt_obj);
+            const obj_mod_catch = @import("../valtypes/tcl_obj.zig");
+            obj_mod_catch.tcl_obj_release(opt_obj);
         }
         return result_mod.from_globals(code);
     }
@@ -782,13 +788,29 @@ fn eval_try(words: []const i32) result_mod.InterpResult {
                         if (v0.len > 0) {
                             const vn = rt.obj_new_string_copy(vl_s.ptr + v0.start, v0.len);
                             _ = frames.var_set(vn, catch_val);
+                            // Release the freshly-allocated var-name
+                            // TclObj — ``var_set`` reads its bytes
+                            // without taking ownership, so the +1 share
+                            // returned by ``obj_new_string_copy`` would
+                            // otherwise leak per matched handler.
+                            const obj_mod_try = @import("../valtypes/tcl_obj.zig");
+                            obj_mod_try.tcl_obj_release(vn);
                         }
                     }
                     if (vl_n >= 2) {
                         const v1 = rt.list_element_at(vl_s.ptr, vl_s.len, 1);
                         if (v1.len > 0) {
                             const vn = rt.obj_new_string_copy(vl_s.ptr + v1.start, v1.len);
-                            _ = frames.var_set(vn, catch_mod.catch_options());
+                            // ``catch_options`` returns +1 owned; ``var_set``
+                            // retains for the slot.  Release the local +1
+                            // and the freshly minted var-name obj or each
+                            // matched handler with an options-var arg leaks
+                            // one dict + one name TclObj per execution.
+                            const opt_obj = catch_mod.catch_options();
+                            _ = frames.var_set(vn, opt_obj);
+                            const obj_mod_try = @import("../valtypes/tcl_obj.zig");
+                            obj_mod_try.tcl_obj_release(opt_obj);
+                            obj_mod_try.tcl_obj_release(vn);
                         }
                     }
                 }
@@ -968,33 +990,49 @@ fn eval_time(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) return result_mod.from_globals(obj_new_string(0, 0));
     const interp = @import("../interp/tcl_interp.zig");
     const clock = @import("../io/tcl_clock.zig");
+    const obj_mod_time = @import("../valtypes/tcl_obj.zig");
 
     const count: i64 = if (words.len >= 3) rt.obj_get_int(words[2]) else 1;
     const body_s = obj_ensure_string(words[1]);
 
     const start_us = rt.obj_get_int(clock.clock_clicks());
     var i: i64 = 0;
-    var last: i32 = obj_new_string(0, 0);
+    var last: i32 = 0;
     while (i < count) : (i += 1) {
+        // Each iteration's eval_script returns +1 owned.  Release
+        // the previous iteration's result before overwriting so a
+        // ``time { ... } 1000`` body doesn't leak 999 result objs.
+        if (last != 0) obj_mod_time.tcl_obj_release(last);
         last = interp.eval_script(body_s.ptr, body_s.len);
         const ir = result_mod.snapshot(last);
         if (ir.code == .ERROR or ir.code == .RETURN) return result_mod.from_globals(last);
     }
+    // Loop completed normally — release the final body result
+    // (we don't propagate it; the summary string is built fresh).
+    if (last != 0) obj_mod_time.tcl_obj_release(last);
     const end_us = rt.obj_get_int(clock.clock_clicks());
     const per_iter = if (count > 0) @divTrunc(end_us - start_us, count) else 0;
 
-    // Build "<N> microseconds per iteration"
-    const pi_s = rt.obj_ensure_string(rt.obj_new_int(per_iter));
+    // Build "<N> microseconds per iteration".  ``obj_new_int`` mints
+    // a fresh +1 owned that we use only for its byte form; release
+    // immediately after the memcpy so the int obj doesn't outlive
+    // the function.
+    const pi_obj = rt.obj_new_int(per_iter);
+    const pi_s = rt.obj_ensure_string(pi_obj);
     const suffix = " microseconds per iteration";
     const total: u32 = @intCast(pi_s.len + suffix.len);
     const buf = rt.alloc(total);
-    if (buf == 0) return result_mod.from_globals(rt.obj_new_string(0, 0));
+    if (buf == 0) {
+        obj_mod_time.tcl_obj_release(pi_obj);
+        return result_mod.from_globals(rt.obj_new_string(0, 0));
+    }
     rt.memcpy(buf, pi_s.ptr, pi_s.len);
     var k: u32 = 0;
     while (k < suffix.len) : (k += 1) {
         const d: [*]u8 = @ptrFromInt(buf + pi_s.len + k);
         d[0] = suffix[k];
     }
+    obj_mod_time.tcl_obj_release(pi_obj);
     return result_mod.from_globals(rt.obj_new_string_take(buf, total, total));
 }
 

--- a/runtime/zig/cmds/fs.zig
+++ b/runtime/zig/cmds/fs.zig
@@ -103,6 +103,10 @@ fn eval_glob(words: []const i32) result_mod.InterpResult {
         const suffix: []const u8 = "\": must be -directory, -join, -nocomplain, -path, -tails, -types, or --";
         const total: u32 = @intCast(prefix.len + s.len + suffix.len);
         const buf_addr = obj.alloc(total);
+        if (buf_addr == 0) {
+            stubs.raise("bad option");
+            return result_mod.from_globals(0);
+        }
         const buf: [*]u8 = @ptrFromInt(buf_addr);
         var off: usize = 0;
         for (prefix) |c| {
@@ -117,8 +121,14 @@ fn eval_glob(words: []const i32) result_mod.InterpResult {
             buf[off] = c;
             off += 1;
         }
-        const msg_slice = (@as([*]const u8, @ptrFromInt(buf_addr)))[0..total];
-        stubs.raise(msg_slice);
+        // Wrap the buffer via ``obj_new_string_take`` so its bytes
+        // belong to the error message TclObj — previously the slab
+        // was orphaned and ``stubs.raise`` minted a second copy from
+        // the byte view, leaking the original ``total`` bytes per
+        // unknown-switch diagnostic.
+        const msg_obj = obj.obj_new_string_take(buf_addr, total, total);
+        const catch_mod_glob = @import("../interp/tcl_catch.zig");
+        catch_mod_glob.tcl_cmd_error(msg_obj);
         return result_mod.from_globals(0);
     }
     if (idx >= words.len) {
@@ -126,26 +136,49 @@ fn eval_glob(words: []const i32) result_mod.InterpResult {
         stubs.raise("wrong # args: should be \"glob ?switches? pattern ?pattern ...?\"");
         return result_mod.from_globals(0);
     }
-    var acc: i32 = obj.obj_new_string(0, 0);
+    // Ownership: ``acc`` is NULL until the first non-empty glob
+    // result lands.  On match #1 we move ``result`` straight into
+    // ``acc`` (transfer of +1).  On match #2+ we concat into a fresh
+    // ``list_concat`` return (also +1) and release both the prior
+    // ``acc`` and ``result``.  The earlier code seeded ``acc`` with
+    // a fresh empty-string obj that leaked on the first transfer,
+    // and never released the per-pattern ``result`` after concat —
+    // every multi-pattern glob leaked one TclObj per non-first
+    // pattern plus the empty seed.
+    var acc: i32 = 0;
     var any_matched = false;
     while (idx < words.len) : (idx += 1) {
         const result = fs_mod.tcl_cmd_glob(words[idx]);
-        if (result == 0) return result_mod.from_globals(0); // capability-denied or fatal — error already raised
+        if (result == 0) {
+            if (acc != 0) obj.tcl_obj_release(acc);
+            return result_mod.from_globals(0); // capability-denied or fatal — error already raised
+        }
         const r = obj.obj_ensure_string(result);
-        if (r.len == 0) continue;
+        if (r.len == 0) {
+            obj.tcl_obj_release(result);
+            continue;
+        }
         any_matched = true;
-        // Concatenate result lists by pasting raw bytes with a single
-        // separator — both sides are already canonical list strings.
-        if (obj.obj_ensure_string(acc).len == 0) {
+        if (acc == 0) {
             acc = result;
         } else {
-            acc = list_concat(acc, result);
+            const next = list_concat(acc, result);
+            // ``list_concat`` may return a borrow on the empty-side
+            // paths; only release the inputs when they're not the
+            // returned handle.  Both ``acc`` and ``result`` are +1
+            // owned here so the safe pattern is "release each if it
+            // didn't become the new accumulator".
+            if (next != acc) obj.tcl_obj_release(acc);
+            if (next != result) obj.tcl_obj_release(result);
+            acc = next;
         }
     }
     if (!any_matched and !nocomplain) {
+        if (acc != 0) obj.tcl_obj_release(acc);
         stubs.raise("no files matched glob pattern");
         return result_mod.from_globals(0);
     }
+    if (acc == 0) acc = obj.obj_new_string(0, 0);
     return result_mod.from_globals(acc);
 }
 

--- a/runtime/zig/cmds/fs.zig
+++ b/runtime/zig/cmds/fs.zig
@@ -167,13 +167,14 @@ fn list_concat(a: i32, b: i32) i32 {
     if (sb.len == 0) return a;
     const total: u32 = sa.len + 1 + sb.len;
     const buf = obj.alloc(total);
+    if (buf == 0) return obj.obj_new_string(0, 0);
     const out: [*]u8 = @ptrFromInt(buf);
     const ap: [*]const u8 = @ptrFromInt(sa.ptr);
     const bp: [*]const u8 = @ptrFromInt(sb.ptr);
     for (0..sa.len) |i| out[i] = ap[i];
     out[sa.len] = ' ';
     for (0..sb.len) |i| out[sa.len + 1 + i] = bp[i];
-    return obj.obj_new_string(@bitCast(buf), @bitCast(total));
+    return obj.obj_new_string_take(buf, total, total);
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -948,7 +948,9 @@ fn ls_match_exact(nocase: bool, pat_ptr: u32, pat_len: u32, ep: u32, elen: u32) 
 fn ls_match_glob_nc(pat_ptr: u32, pat_len: u32, ep: u32, elen: u32) bool {
     // Case-insensitive glob: lowercase copies then call glob_match.
     const bp = alloc(pat_len + 1);
+    if (bp == 0) return false;
     const be = alloc(elen + 1);
+    if (be == 0) return false;
     if (pat_len > 0 and bp != 0) {
         const src: [*]const u8 = @ptrFromInt(pat_ptr);
         const dst: [*]u8 = @ptrFromInt(bp);
@@ -1852,6 +1854,7 @@ fn eval_join(words: []const i32) result_mod.InterpResult {
         return result_mod.from_globals(0);
     if (words.len == 3) return result_mod.from_globals(rt.tcl_cmd_join(words[1], words[2]));
     const sp = alloc(1);
+    if (sp == 0) return result_mod.from_globals(0);
     const d: [*]u8 = @ptrFromInt(sp);
     d[0] = ' ';
     return result_mod.from_globals(rt.tcl_cmd_join(words[1], obj_new_string(@bitCast(sp), 1)));
@@ -1902,6 +1905,7 @@ fn eval_lrepeat(words: []const i32) result_mod.InterpResult {
         if (vi > 2) cycle_max += 1;
     }
     const cycle_buf = alloc(cycle_max + 4);
+    if (cycle_buf == 0) return result_mod.from_globals(0);
     var cycle_off: u32 = 0;
     vi = 2;
     while (vi < words.len) : (vi += 1) {
@@ -1920,6 +1924,7 @@ fn eval_lrepeat(words: []const i32) result_mod.InterpResult {
     if (cycle_off == 0) return result_mod.from_globals(obj_new_string(0, 0));
     const total: u32 = count * (cycle_off + 1);
     const result_buf = alloc(total);
+    if (result_buf == 0) return result_mod.from_globals(0);
     var off: u32 = 0;
     var ci: u32 = 0;
     while (ci < count) : (ci += 1) {

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -192,19 +192,32 @@ fn eval_lset(words: []const i32) result_mod.InterpResult {
     }
     const current = frames.var_resolve(words[1]);
     const newval = words[words.len - 1];
-    const indices: i32 = if (words.len == 3)
-        obj_new_string(0, 0)
-    else if (words.len == 4)
+    // ``indices`` ownership:
+    //   words.len == 3 — fresh empty-string obj (owned, must release);
+    //   words.len == 4 — borrowed ``words[2]`` (do NOT release);
+    //   words.len  > 4 — fresh +1 owned list built by ``tcl_list``.
+    // Tracking ``owns_indices`` lets the multi-index loop release
+    // the per-step intermediate ``acc`` returned by each ``tcl_list``
+    // call without breaking the borrowed single-index case.
+    var owns_indices: bool = false;
+    const indices: i32 = if (words.len == 3) blk_empty: {
+        owns_indices = true;
+        break :blk_empty obj_new_string(0, 0);
+    } else if (words.len == 4)
         words[2]
     else blk: {
         var acc: i32 = rt.tcl_list(words[2], words[3]);
         var wi: u32 = 4;
         while (wi + 1 < words.len) : (wi += 1) {
-            acc = rt.tcl_list(acc, words[wi]);
+            const next = rt.tcl_list(acc, words[wi]);
+            obj_mod.tcl_obj_release(acc);
+            acc = next;
         }
+        owns_indices = true;
         break :blk acc;
     };
     const result = rt.tcl_cmd_list_set(current, indices, newval);
+    if (owns_indices) obj_mod.tcl_obj_release(indices);
     _ = frames.var_set(words[1], result);
     return result_mod.from_globals(result);
 }

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -1934,9 +1934,11 @@ fn eval_lassign(words: []const i32) result_mod.InterpResult {
             if (elem.braced) {
                 break :blk rt.obj_new_string_copy(list_s.ptr + elem.start, elem.len);
             } else {
-                const buf = alloc(elem.len + 4);
+                const buf_size: u32 = elem.len + 4;
+                const buf = alloc(buf_size);
+                if (buf == 0) break :blk obj_new_string(0, 0);
                 const out_len = rt.copy_unbraced_elem(buf, list_s.ptr + elem.start, elem.len);
-                break :blk obj_new_string(@bitCast(buf), @bitCast(out_len));
+                break :blk obj_mod.obj_new_string_take(buf, out_len, buf_size);
             }
         } else obj_new_string(0, 0);
         _ = frames.var_set(words[pi], val);
@@ -2045,7 +2047,17 @@ fn eval_lmap(words: []const i32) result_mod.InterpResult {
         const item = interp.eval_script(body_s.ptr, body_s.len);
         const ir = result_mod.snapshot(item);
         switch (ir.code) {
-            .OK => result = rt.tcl_list(result, item),
+            .OK => {
+                // ``tcl_list`` always returns a fresh +1 owned obj.
+                // Release the prior accumulator AND the per-iter
+                // item once the new accumulator absorbs their bytes
+                // — without this the loop leaks one obj per item
+                // appended plus the empty seed.
+                const next_result = rt.tcl_list(result, item);
+                obj_mod.tcl_obj_release(result);
+                if (item != 0) obj_mod.tcl_obj_release(item);
+                result = next_result;
+            },
             .BREAK => {
                 result_mod.consume(.BREAK);
                 if (item != 0) obj_mod.tcl_obj_release(item);
@@ -2056,7 +2068,12 @@ fn eval_lmap(words: []const i32) result_mod.InterpResult {
                 if (item != 0) obj_mod.tcl_obj_release(item);
                 continue;
             },
-            .ERROR, .RETURN => return result_mod.from_globals(item),
+            .ERROR, .RETURN => {
+                // Forward ``item`` as the result and drop the
+                // accumulator we've been building.
+                obj_mod.tcl_obj_release(result);
+                return result_mod.from_globals(item);
+            },
         }
     }
     return result_mod.from_globals(result);

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -16,6 +16,7 @@ const parse = @import("../parse/tcl_parse.zig");
 const std = @import("std");
 
 const alloc = rt.alloc;
+const free_sized = obj_mod.free_sized;
 const obj_new_string = rt.obj_new_string;
 const obj_new_int = rt.obj_new_int;
 const obj_ensure_string = rt.obj_ensure_string;
@@ -947,17 +948,29 @@ fn ls_match_exact(nocase: bool, pat_ptr: u32, pat_len: u32, ep: u32, elen: u32) 
 
 fn ls_match_glob_nc(pat_ptr: u32, pat_len: u32, ep: u32, elen: u32) bool {
     // Case-insensitive glob: lowercase copies then call glob_match.
-    const bp = alloc(pat_len + 1);
+    // Both buffers must reclaim via ``free_sized`` after ``glob_match``
+    // returns — the earlier revision (Copilot review on PR #453)
+    // allocated them but never freed either, leaking ~``pat_len +
+    // elen + 2`` bytes per ``lsearch -nocase`` probe.  The
+    // ``be == 0`` failure path also previously orphaned ``bp``.
+    const bp_size = pat_len + 1;
+    const bp = alloc(bp_size);
     if (bp == 0) return false;
-    const be = alloc(elen + 1);
-    if (be == 0) return false;
-    if (pat_len > 0 and bp != 0) {
+    const be_size = elen + 1;
+    const be = alloc(be_size);
+    if (be == 0) {
+        free_sized(bp, bp_size);
+        return false;
+    }
+    defer free_sized(bp, bp_size);
+    defer free_sized(be, be_size);
+    if (pat_len > 0) {
         const src: [*]const u8 = @ptrFromInt(pat_ptr);
         const dst: [*]u8 = @ptrFromInt(bp);
         var k: u32 = 0;
         while (k < pat_len) : (k += 1) dst[k] = ls_tolower(src[k]);
     }
-    if (elen > 0 and be != 0) {
+    if (elen > 0) {
         const src: [*]const u8 = @ptrFromInt(ep);
         const dst: [*]u8 = @ptrFromInt(be);
         var k: u32 = 0;
@@ -1853,11 +1866,18 @@ fn eval_join(words: []const i32) result_mod.InterpResult {
     if (list_parse.check_list_syntax(ls.ptr, ls.len) != 0)
         return result_mod.from_globals(0);
     if (words.len == 3) return result_mod.from_globals(rt.tcl_cmd_join(words[1], words[2]));
-    const sp = alloc(1);
-    if (sp == 0) return result_mod.from_globals(0);
-    const d: [*]u8 = @ptrFromInt(sp);
-    d[0] = ' ';
-    return result_mod.from_globals(rt.tcl_cmd_join(words[1], obj_new_string(@bitCast(sp), 1)));
+    // Default separator: a single space.  ``obj_new_string_copy``
+    // mints an OWNED 1-byte buffer so the separator TclObj cleans
+    // up via release.  The earlier ``alloc(1)`` + ``obj_new_string``
+    // pattern leaked both the slab (cap=0 borrow obj couldn't
+    // reclaim it on release) and the obj header itself (no caller
+    // released the temporary, Copilot review on PR #453).
+    const sep_byte: u8 = ' ';
+    const sep_obj = rt.obj_new_string_copy(@intFromPtr(&sep_byte), 1);
+    if (sep_obj == 0) return result_mod.from_globals(0);
+    const result = rt.tcl_cmd_join(words[1], sep_obj);
+    obj_mod.tcl_obj_release(sep_obj);
+    return result_mod.from_globals(result);
 }
 
 fn eval_split(words: []const i32) result_mod.InterpResult {

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -2061,17 +2061,25 @@ fn eval_lmap(words: []const i32) result_mod.InterpResult {
         const ir = result_mod.snapshot(item);
         switch (ir.code) {
             .OK => {
-                // ``tcl_list`` always returns a fresh +1 owned obj.
-                // Release the prior accumulator AND the per-iter
-                // item once the new accumulator absorbs their bytes
-                // — without this the loop leaks one obj per item
-                // appended plus the empty seed.
+                // ``tcl_list`` returns a fresh +1 owned obj (or the
+                // existing handle when the in-place fast path takes
+                // — accumulator grow).  Release the prior accumulator
+                // on swap.  ``item`` is intentionally NOT released:
+                // ``eval_script`` can return a BORROWED handle into a
+                // variable's live storage (a body that ends in
+                // ``[set x]`` or similar borrows-the-var-slot
+                // pattern).  Releasing item here would corrupt the
+                // var; leaking it when the body produced a +1 owned
+                // obj is the safer trade-off until ``eval_script``'s
+                // contract is normalised across the runtime.
                 const next_result = rt.tcl_list(result, item);
-                obj_mod.tcl_obj_release(result);
-                if (item != 0) obj_mod.tcl_obj_release(item);
+                if (next_result != result) obj_mod.tcl_obj_release(result);
                 result = next_result;
             },
             .BREAK => {
+                // ``break`` / ``continue`` return 0 (no value) so
+                // the historical release-when-non-zero on ``item``
+                // is a no-op.  Kept for documentation.
                 result_mod.consume(.BREAK);
                 if (item != 0) obj_mod.tcl_obj_release(item);
                 break;

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -484,6 +484,12 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                     return result_mod.from_globals(0);
                 }
                 const targets_buf = alloc(@intCast(count * 4));
+                // OOM: alloc raised ``oom_flag``.  Drop the partial
+                // assignment without touching ``ns_current``'s path
+                // — the existing path remains in effect.  Returning
+                // 0 mirrors every other error/no-op branch in this
+                // ``namespace path`` block.
+                if (targets_buf == 0) return result_mod.from_globals(0);
                 var li: i64 = 0;
                 while (li < count) : (li += 1) {
                     const elt = obj_mod.list_element_at(ls.ptr, ls.len, li);
@@ -1583,6 +1589,11 @@ const ENS_REC_SIZE: u32 = @sizeOf(EnsembleRec);
 
 fn ensemble_rec_alloc() u32 {
     const addr = alloc(ENS_REC_SIZE);
+    // OOM: surface 0 to the caller without writing through a null
+    // pointer.  ``alloc`` already raised ``oom_flag``; callers test
+    // ``rec_addr == 0`` (added at each call site) and raise a Tcl
+    // error before returning.
+    if (addr == 0) return 0;
     const r: *EnsembleRec = @ptrFromInt(addr);
     r.target_ns = 0;
     r.map_obj = 0;
@@ -1724,6 +1735,12 @@ fn eval_ns_ensemble_create(words: []const i32) i32 {
         return 0;
     }
     const rec_addr = ensemble_rec_alloc();
+    // OOM: ``ensemble_rec_alloc`` returned 0 and raised ``oom_flag``;
+    // surface a Tcl error rather than ``@ptrFromInt(0)``.
+    if (rec_addr == 0) {
+        raise_ns_error("namespace ensemble create: out of memory");
+        return 0;
+    }
     const rec: *EnsembleRec = @ptrFromInt(rec_addr);
     rec.target_ns = tcl_ns.ns_current();
     var cmd_name: i32 = 0; // optional ``-command`` override

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -771,10 +771,11 @@ fn ns_parent(ptr: u32, len: u32) i32 {
     if (i == 0 and has_sep) {
         // Was ``::foo`` — parent is root ``::``.
         const buf = alloc(2);
+        if (buf == 0) return obj_new_string(0, 0);
         const d: [*]u8 = @ptrFromInt(buf);
         d[0] = ':';
         d[1] = ':';
-        return obj_new_string(@bitCast(buf), 2);
+        return rt.obj_new_string_take(buf, 2, 2);
     }
     return obj_new_string(@bitCast(ptr), @bitCast(i));
 }
@@ -888,6 +889,7 @@ fn ns_children(ns_handle: u32, pat_ptr: u32, pat_len: u32) i32 {
     }
     if (count == 0) return obj_new_string(0, 0);
     const buf = alloc(total_bytes);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var first: bool = true;
     i = 0;
@@ -908,7 +910,7 @@ fn ns_children(ns_handle: u32, pat_ptr: u32, pat_len: u32) i32 {
         memcpy(buf + off, fqn.ptr, fqn.len);
         off += fqn.len;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(total_bytes));
+    return rt.obj_new_string_take(buf, total_bytes, total_bytes);
 }
 
 /// ``namespace delete name ...`` — mark namespace dead by removing it from its

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -162,6 +162,7 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                     if (wi + 1 < words.len) total += 1;
                 }
                 const buf = alloc(total);
+                if (buf == 0) return result_mod.from_globals(0);
                 var off: u32 = 0;
                 wi = 3;
                 while (wi < words.len) : (wi += 1) {
@@ -174,7 +175,13 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                         off += 1;
                     }
                 }
-                return result_mod.from_globals(interp.eval_script(buf, total));
+                const ns_result = interp.eval_script(buf, total);
+                // Free the synthesised script buffer.  ``eval_script``
+                // either copies bytes into owned TclObjs or borrows
+                // through retained var slots; either way the result's
+                // bytes don't reference this buffer once we return.
+                obj_mod.free_sized(buf, total);
+                return result_mod.from_globals(ns_result);
             }
         }
         if (sub.len == 6 and sub.ptr != 0) {
@@ -616,21 +623,37 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
             }
             // Build a properly-quoted args list via tcl_list, then append to body.
             // This ensures args containing spaces/braces are re-tokenized correctly.
+            //
+            // Each ``tcl_list`` call returns a fresh +1 owned obj (or
+            // an in-place same-handle return on capacity).  Release
+            // the prior accumulator on swap, then release the final
+            // args_obj after the bytes are copied into ``buf`` — and
+            // free the synthesised script buffer once eval_script
+            // finishes, mirroring the ``namespace eval`` arm above.
             var args_obj: i32 = obj_new_string_copy(0, 0);
             var wi: u32 = 4;
             while (wi < words.len) : (wi += 1) {
-                args_obj = rt.tcl_list(args_obj, words[wi]);
+                const next = rt.tcl_list(args_obj, words[wi]);
+                if (next != args_obj) obj_mod.tcl_obj_release(args_obj);
+                args_obj = next;
             }
             const as = obj_ensure_string(args_obj);
             const total = bs.len + (if (as.len > 0) 1 + as.len else 0);
             const buf = alloc(total);
+            if (buf == 0) {
+                obj_mod.tcl_obj_release(args_obj);
+                return result_mod.from_globals(0);
+            }
             memcpy(buf, bs.ptr, bs.len);
             if (as.len > 0) {
                 const d: [*]u8 = @ptrFromInt(buf + bs.len);
                 d[0] = ' ';
                 memcpy(buf + bs.len + 1, as.ptr, as.len);
             }
-            return result_mod.from_globals(interp.eval_script(buf, total));
+            obj_mod.tcl_obj_release(args_obj);
+            const ns_result = interp.eval_script(buf, total);
+            obj_mod.free_sized(buf, total);
+            return result_mod.from_globals(ns_result);
         }
         // ``namespace code script`` — return a script that evaluates
         // *script* in the current namespace.  Reference Tcl

--- a/runtime/zig/cmds/scan.zig
+++ b/runtime/zig/cmds/scan.zig
@@ -28,6 +28,7 @@ const result_mod = @import("../interp/tcl_result.zig");
 const frames = @import("../interp/tcl_frames.zig");
 const stubs = @import("../stubs/tcl_stubs.zig");
 const chars = @import("../valtypes/tcl_chars.zig");
+const obj_mod_scan = @import("../valtypes/tcl_obj.zig");
 const reg = @import("../dispatch/tcl_cmd_registry.zig");
 const obj_mod = @import("../valtypes/tcl_obj.zig");
 const bignum = @import("../valtypes/tcl_bignum.zig");
@@ -274,10 +275,17 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             if (!suppress) {
                 const val = obj_new_int(@intCast(si));
                 if (has_vars) {
-                    if (vi >= n_vars) break;
+                    if (vi >= n_vars) {
+                        obj_mod_scan.tcl_obj_release(val);
+                        break;
+                    }
                     _ = frames.var_set(words[3 + vi], val);
+                    obj_mod_scan.tcl_obj_release(val);
                 } else {
-                    list_result = rt.tcl_list(list_result, val);
+                    const next = rt.tcl_list(list_result, val);
+                    obj_mod_scan.tcl_obj_release(list_result);
+                    obj_mod_scan.tcl_obj_release(val);
+                    list_result = next;
                 }
                 vi += 1;
                 assigned += 1;
@@ -304,13 +312,22 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             const val = obj_new_int(cp);
             if (!suppress) {
                 if (has_vars) {
-                    if (vi >= n_vars) break;
+                    if (vi >= n_vars) {
+                        obj_mod_scan.tcl_obj_release(val);
+                        break;
+                    }
                     _ = frames.var_set(words[3 + vi], val);
+                    obj_mod_scan.tcl_obj_release(val);
                 } else {
-                    list_result = rt.tcl_list(list_result, val);
+                    const next = rt.tcl_list(list_result, val);
+                    obj_mod_scan.tcl_obj_release(list_result);
+                    obj_mod_scan.tcl_obj_release(val);
+                    list_result = next;
                 }
                 vi += 1;
                 assigned += 1;
+            } else {
+                obj_mod_scan.tcl_obj_release(val);
             }
             si = tmp_i;
             continue;
@@ -326,16 +343,28 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             const accept_0x = (spec == 'x' or spec == 'X');
             var matched = false;
             const val = scan_int(src, ss.len, &si, base, accept_0x, &matched);
-            if (!matched) break;
+            if (!matched) {
+                obj_mod_scan.tcl_obj_release(val);
+                break;
+            }
             if (!suppress) {
                 if (has_vars) {
-                    if (vi >= n_vars) break;
+                    if (vi >= n_vars) {
+                        obj_mod_scan.tcl_obj_release(val);
+                        break;
+                    }
                     _ = frames.var_set(words[3 + vi], val);
+                    obj_mod_scan.tcl_obj_release(val);
                 } else {
-                    list_result = rt.tcl_list(list_result, val);
+                    const next = rt.tcl_list(list_result, val);
+                    obj_mod_scan.tcl_obj_release(list_result);
+                    obj_mod_scan.tcl_obj_release(val);
+                    list_result = next;
                 }
                 vi += 1;
                 assigned += 1;
+            } else {
+                obj_mod_scan.tcl_obj_release(val);
             }
             continue;
         }
@@ -372,13 +401,22 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             const val = obj_new_int(if (neg) -int_val else int_val);
             if (!suppress) {
                 if (has_vars) {
-                    if (vi >= n_vars) break;
+                    if (vi >= n_vars) {
+                        obj_mod_scan.tcl_obj_release(val);
+                        break;
+                    }
                     _ = frames.var_set(words[3 + vi], val);
+                    obj_mod_scan.tcl_obj_release(val);
                 } else {
-                    list_result = rt.tcl_list(list_result, val);
+                    const next = rt.tcl_list(list_result, val);
+                    obj_mod_scan.tcl_obj_release(list_result);
+                    obj_mod_scan.tcl_obj_release(val);
+                    list_result = next;
                 }
                 vi += 1;
                 assigned += 1;
+            } else {
+                obj_mod_scan.tcl_obj_release(val);
             }
             continue;
         }
@@ -397,13 +435,22 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             const val = obj_new_string(@bitCast(ss.ptr + start_si), @bitCast(end_si - start_si));
             if (!suppress) {
                 if (has_vars) {
-                    if (vi >= n_vars) break;
+                    if (vi >= n_vars) {
+                        obj_mod_scan.tcl_obj_release(val);
+                        break;
+                    }
                     _ = frames.var_set(words[3 + vi], val);
+                    obj_mod_scan.tcl_obj_release(val);
                 } else {
-                    list_result = rt.tcl_list(list_result, val);
+                    const next = rt.tcl_list(list_result, val);
+                    obj_mod_scan.tcl_obj_release(list_result);
+                    obj_mod_scan.tcl_obj_release(val);
+                    list_result = next;
                 }
                 vi += 1;
                 assigned += 1;
+            } else {
+                obj_mod_scan.tcl_obj_release(val);
             }
             si = end_si;
             continue;
@@ -417,6 +464,10 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
         // No-variable form: return the list of parsed values.
         return result_mod.from_globals(list_result);
     }
+    // ``has_vars`` path doesn't return ``list_result`` — release the
+    // empty seed (and any partial accumulation if vars ran short
+    // partway through) so it doesn't outlive the call.
+    obj_mod_scan.tcl_obj_release(list_result);
     return result_mod.from_globals(obj_new_int(@intCast(assigned)));
 }
 

--- a/runtime/zig/cmds/scope.zig
+++ b/runtime/zig/cmds/scope.zig
@@ -8,6 +8,7 @@ const reg = @import("../dispatch/tcl_cmd_registry.zig");
 
 const obj_new_string = rt.obj_new_string;
 const obj_ensure_string = rt.obj_ensure_string;
+const obj = @import("../valtypes/tcl_obj.zig");
 
 fn eval_global(words: []const i32) result_mod.InterpResult {
     var gi: u32 = 1;
@@ -65,6 +66,10 @@ fn eval_variable(words: []const i32) result_mod.InterpResult {
         // and avoid descriptor-side TclObj lifetime questions
         // (Copilot review on PR #343).
         frames.frame_alias_ns_var(local_name, var_ptr, r.target_ns, r.simple_ptr, r.simple_len);
+        // ``frame_alias_ns_var`` reads ``local_name``'s bytes (for
+        // hashing) but doesn't retain the obj.  Release our +1 here
+        // or each ``variable foo`` declaration leaks one TclObj.
+        obj.tcl_obj_release(local_name);
         if (i + 1 < words.len) {
             tcl_ns.var_set_scalar(var_ptr, @bitCast(words[i + 1]));
             i += 1;

--- a/runtime/zig/cmds/string.zig
+++ b/runtime/zig/cmds/string.zig
@@ -380,6 +380,7 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
             total += ws.len;
         }
         const buf = rt.alloc(total);
+        if (buf == 0) return result_mod.from_globals(obj_new_string(0, 0));
         var off: u32 = 0;
         i = 2;
         while (i < words.len) : (i += 1) {
@@ -389,7 +390,7 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
                 off += ws.len;
             }
         }
-        return result_mod.from_globals(obj_new_string(@bitCast(buf), @bitCast(total)));
+        return result_mod.from_globals(rt.obj_new_string_take(buf, total, total));
     }
     if (words.len < 3) return result_mod.from_globals(0);
     if (str_eq(sp, sub.len, "length")) return result_mod.from_globals(rt.string_length(words[2]));

--- a/runtime/zig/cmds/tcl_alias.zig
+++ b/runtime/zig/cmds/tcl_alias.zig
@@ -372,6 +372,25 @@ pub fn alias_clear(cmd: u32) void {
     if (real_parent != 0) {
         interp_reg.alias_chain_remove(real_parent, rec_addr, .target);
     }
+    // ``alias_alloc`` retains every prefix-args TclObj for the
+    // alias's lifetime; release them here or every
+    // ``interp alias {} foo {}`` (delete) leaks ``n_prefix``
+    // TclObjs.  Also free the heap-allocated arrays so they
+    // don't leak the slab.
+    const objm = @import("../valtypes/tcl_obj.zig");
+    if (r.n_prefix > 0 and r.prefix_args_addr != 0) {
+        var i: u32 = 0;
+        while (i < r.n_prefix) : (i += 1) {
+            const handle = read_i32(r.prefix_args_addr + i * 4);
+            if (handle != 0) objm.tcl_obj_release(handle);
+        }
+        objm.free_sized(r.prefix_args_addr, r.n_prefix * 4);
+    }
+    // ``target_name_ptr`` is a heap-allocated byte copy from
+    // ``alias_alloc``; free the slab so it doesn't leak.
+    if (r.target_name_len > 0 and r.target_name_ptr != 0) {
+        objm.free_sized(r.target_name_ptr, r.target_name_len);
+    }
     r.target_name_len = 0;
     r.target_name_ptr = 0;
     r.n_prefix = 0;

--- a/runtime/zig/cmds/tcl_alias.zig
+++ b/runtime/zig/cmds/tcl_alias.zig
@@ -412,6 +412,7 @@ fn alias_describe_inner(r: *AliasRec) i32 {
         total += 1 + s.len * 2 + 8; // leading space + quoted element
     }
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
 
     // Element 0: the target name.  ``list_elem_quote`` treats it as
     // the first list element so a leading ``#`` is braced — matches
@@ -430,5 +431,5 @@ fn alias_describe_inner(r: *AliasRec) i32 {
         const s = obj_ensure_string(h);
         off = obj.list_elem_quote_nth(buf, off, s.ptr, s.len);
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, total);
 }

--- a/runtime/zig/cmds/tcl_alias.zig
+++ b/runtime/zig/cmds/tcl_alias.zig
@@ -283,6 +283,27 @@ pub fn alias_clear_rec(rec_addr: u32) void {
     if (real_parent != 0) {
         interp_reg.alias_chain_remove(real_parent, rec_addr, .target);
     }
+    // Release each prefix-args TclObj retained by ``alias_alloc``
+    // and free the heap-allocated arrays.  Mirrors :func:`alias_clear`
+    // — the previous implementation just zeroed the fields, leaking
+    // ``n_prefix + 1`` TclObj retains and two slab allocations every
+    // time an alias was deleted via the cross-interp cascade or via
+    // ``interp alias child foo {}`` after a rename.
+    const objm = @import("../valtypes/tcl_obj.zig");
+    if (r.n_prefix > 0 and r.prefix_args_addr != 0) {
+        var i: u32 = 0;
+        while (i < r.n_prefix) : (i += 1) {
+            const handle = read_i32(r.prefix_args_addr + i * 4);
+            if (handle != 0) objm.tcl_obj_release(handle);
+        }
+        objm.free_sized(r.prefix_args_addr, r.n_prefix * 4);
+    }
+    if (r.target_name_len > 0 and r.target_name_ptr != 0) {
+        objm.free_sized(r.target_name_ptr, r.target_name_len);
+    }
+    if (r.token_len > 0 and r.token_ptr != 0) {
+        objm.free_sized(r.token_ptr, r.token_len);
+    }
     r.target_name_len = 0;
     r.target_name_ptr = 0;
     r.n_prefix = 0;
@@ -290,6 +311,7 @@ pub fn alias_clear_rec(rec_addr: u32) void {
     r.parent_interp = 0;
     r.child_interp = 0;
     r.token_len = 0;
+    r.token_ptr = 0;
     r.next_in_child = 0;
     r.next_target_in_parent = 0;
 }

--- a/runtime/zig/cmds/tcl_alias.zig
+++ b/runtime/zig/cmds/tcl_alias.zig
@@ -172,6 +172,7 @@ pub fn alias_alloc_with_token(
     child_interp: u32,
 ) u32 {
     const cmd = alloc(tcl_procs.COMMAND_SIZE);
+    if (cmd == 0) return 0;
     const slice: [*]u8 = @ptrFromInt(cmd);
     @memset(slice[0..tcl_procs.COMMAND_SIZE], 0);
 
@@ -187,12 +188,14 @@ pub fn alias_alloc_with_token(
 
     // Heap-copy the target name bytes.
     const tbuf = alloc(target_name_len);
+    if (tbuf == 0 and target_name_len > 0) return 0;
     if (target_name_len > 0) memcpy(tbuf, target_name_ptr, target_name_len);
 
     // Heap-copy the token (original alias name as the user passed
     // it — may include ``::`` qualifiers like ``ns::cmd``).
     // Mirrors C Tcl's ``Alias.token`` field (tclInterp.c).
     const token_buf = alloc(token_src_len);
+    if (token_buf == 0 and token_src_len > 0) return 0;
     if (token_src_len > 0) memcpy(token_buf, token_src_ptr, token_src_len);
 
     // Heap-copy the prefix-args array.  Each element is a u32
@@ -203,6 +206,7 @@ pub fn alias_alloc_with_token(
     var pbuf: u32 = 0;
     if (n_prefix > 0 and prefix_args_addr != 0) {
         pbuf = alloc(n_prefix * 4);
+        if (pbuf == 0) return 0;
         var i: u32 = 0;
         while (i < n_prefix) : (i += 1) {
             const handle = read_i32(prefix_args_addr + i * 4);
@@ -215,6 +219,7 @@ pub fn alias_alloc_with_token(
     }
 
     const rec = alloc(@sizeOf(AliasRec));
+    if (rec == 0) return 0;
     const r: *AliasRec = @ptrFromInt(rec);
     r.target_name_ptr = tbuf;
     r.target_name_len = target_name_len;

--- a/runtime/zig/cmds/tcl_cmd_info.zig
+++ b/runtime/zig/cmds/tcl_cmd_info.zig
@@ -71,6 +71,7 @@ fn raise_not_a_procedure(name_ptr: u32, name_len: u32) void {
     const suffix = "\" isn't a procedure";
     const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
     const buf = alloc(total);
+    if (buf == 0) return;
     const d: [*]u8 = @ptrFromInt(buf);
     d[0] = '"';
     if (name_len > 0) {
@@ -78,7 +79,7 @@ fn raise_not_a_procedure(name_ptr: u32, name_len: u32) void {
         for (0..name_len) |k| d[prefix.len + k] = sp[k];
     }
     for (suffix, 0..) |b, k| d[prefix.len + name_len + k] = b;
-    const msg = obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = obj.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -651,6 +652,7 @@ fn raise_bad_level(arg_s: anytype) i32 {
     const suffix = "\"";
     const total: u32 = @as(u32, @intCast(prefix.len)) + arg_s.len + @as(u32, @intCast(suffix.len));
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (arg_s.len > 0) {
@@ -658,7 +660,7 @@ fn raise_bad_level(arg_s: anytype) i32 {
         for (0..arg_s.len) |k| d[prefix.len + k] = sp[k];
     }
     for (suffix, 0..) |b, k| d[prefix.len + arg_s.len + k] = b;
-    const msg = obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = obj.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
     return obj_new_string(0, 0);
 }
@@ -1254,6 +1256,7 @@ fn run_cmd_walk(kind: WalkKind, pattern: i32) i32 {
 
     // Pass 2: fill.
     ctx.buf = alloc(ctx.total);
+    if (ctx.buf == 0) return obj_new_string(0, 0);
     ctx.off = 0;
     ctx.count = 0;
     if (qualified_target != 0) {
@@ -1261,7 +1264,7 @@ fn run_cmd_walk(kind: WalkKind, pattern: i32) i32 {
     } else {
         walk_unqualified_path(&ctx);
     }
-    return obj_new_string(@bitCast(ctx.buf), @bitCast(ctx.off));
+    return obj.obj_new_string_take(ctx.buf, ctx.off, ctx.total);
 }
 
 /// info commands ?pattern? — public entry.  ``pattern == 0`` means
@@ -1290,6 +1293,7 @@ fn raise_missing_argument(proc_ptr: u32, proc_len: u32, arg_ptr: u32, arg_len: u
         @as(u32, @intCast(middle.len)) + arg_len +
         @as(u32, @intCast(suffix.len));
     const buf = alloc(total);
+    if (buf == 0) return;
     const d: [*]u8 = @ptrFromInt(buf);
     var off: u32 = 0;
     for (prefix, 0..) |b, k| d[k] = b;
@@ -1307,7 +1311,7 @@ fn raise_missing_argument(proc_ptr: u32, proc_len: u32, arg_ptr: u32, arg_len: u
     }
     off += arg_len;
     for (suffix, 0..) |b, k| d[off + k] = b;
-    const msg = obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = obj.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -1846,6 +1850,7 @@ pub fn info_vars(pattern: i32) i32 {
         const arr_sep: u32 = if (arr_s.len > 0) @as(u32, 1) else @as(u32, 0);
         const merge_total: u32 = arr_s.len + arr_sep + scalar_total;
         const merge_buf = alloc(merge_total);
+        if (merge_buf == 0) return obj_new_string(0, 0);
         var off: u32 = 0;
         if (arr_s.len > 0) {
             memcpy(merge_buf, arr_s.ptr, arr_s.len);
@@ -1879,7 +1884,7 @@ pub fn info_vars(pattern: i32) i32 {
                 written += 1;
             }
         }
-        return obj_new_string(@bitCast(merge_buf), @bitCast(off));
+        return obj.obj_new_string_take(merge_buf, off, merge_total);
     }
 
     // Unqualified pattern or no pattern.  Inside a proc frame, scan

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -591,6 +591,14 @@ pub fn interp_alias_create(
     // ``interp aliases`` will report for the new alias.
     var token_ptr: u32 = new_name_ptr;
     var token_len: u32 = new_name_len;
+    // ``owns_token`` flips to true the first time we mint a fresh
+    // ``::``-prefixed buffer.  Subsequent loop iterations release
+    // the previous buffer before reassigning so a chain of N
+    // collisions reclaims N-1 intermediate slabs instead of leaking
+    // them — and the post-loop ``alias_alloc_with_token`` (which
+    // copies the bytes into its own buffer) cleans up the final
+    // ``token_ptr`` allocation too.
+    var owns_token: bool = false;
     while (interp_reg.alias_chain_find_token(child_interp, .child, token_ptr, token_len) != 0) {
         const prefix_len: u32 = 2;
         const new_len: u32 = prefix_len + token_len;
@@ -599,9 +607,12 @@ pub fn interp_alias_create(
         dst[0] = ':';
         dst[1] = ':';
         if (token_len > 0) memcpy(new_buf + prefix_len, token_ptr, token_len);
+        if (owns_token) obj_mod.free_sized(token_ptr, token_len);
         token_ptr = new_buf;
         token_len = new_len;
+        owns_token = true;
     }
+    defer if (owns_token) obj_mod.free_sized(token_ptr, token_len);
 
     //
     // The parent interp is stashed directly on the ``AliasRec``

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -1123,6 +1123,13 @@ pub fn render_uint(value: u32) struct { ptr: u32, len: u32 } {
     }
     const len: u32 = @intCast(tmp.len - pos);
     const buf = alloc(len);
+    // OOM: alloc raised ``oom_flag``.  Return ``ptr=0, len=0`` so the
+    // caller's downstream ``alloc(prefix.len + d.len)`` produces a
+    // short buffer carrying just the prefix — the auto-name probe
+    // will then collide (or not) on the prefix alone, which is
+    // benign: the caller eventually surfaces the OOM via the
+    // interpreter boundary check.  Avoids ``@ptrFromInt(0)``.
+    if (buf == 0) return .{ .ptr = 0, .len = 0 };
     const d: [*]u8 = @ptrFromInt(buf);
     for (0..len) |i| d[i] = tmp[pos + i];
     return .{ .ptr = buf, .len = len };
@@ -1212,6 +1219,10 @@ pub fn eval_interp_create(words: []const i32) i32 {
             const prefix: []const u8 = "interp";
             const total: u32 = @as(u32, @intCast(prefix.len)) + d.len;
             const buf = alloc(total);
+            // OOM: alloc raised ``oom_flag``.  Bail out of the
+            // auto-name probe without writing through ``@ptrFromInt(0)``;
+            // the caller surfaces the OOM at the next interp boundary.
+            if (buf == 0) return 0;
             const dst: [*]u8 = @ptrFromInt(buf);
             for (prefix, 0..) |b, k| dst[k] = b;
             const dp: [*]const u8 = @ptrFromInt(d.ptr);

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -355,6 +355,10 @@ fn raise_alias_loop_error(new_name_ptr: u32, new_name_len: u32) void {
     const suffix: []const u8 = "\": would create a loop";
     const total: u32 = @as(u32, @intCast(prefix.len)) + new_name_len + @as(u32, @intCast(suffix.len));
     const buf = alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (new_name_len > 0) {
@@ -362,7 +366,7 @@ fn raise_alias_loop_error(new_name_ptr: u32, new_name_len: u32) void {
         for (0..new_name_len) |k| d[prefix.len + k] = np[k];
     }
     for (suffix, 0..) |b, k| d[prefix.len + new_name_len + k] = b;
-    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = rt.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -561,6 +565,10 @@ pub fn interp_alias_create(
         const suffix: []const u8 = "\": interpreter deleted";
         const total: u32 = @as(u32, @intCast(prefix.len)) + new_name_len + @as(u32, @intCast(suffix.len));
         const buf = alloc(total);
+        if (buf == 0) {
+            catch_mod.tcl_cmd_error(0);
+            return 0;
+        }
         const d: [*]u8 = @ptrFromInt(buf);
         for (prefix, 0..) |b, k| d[k] = b;
         if (new_name_len > 0) {
@@ -568,7 +576,7 @@ pub fn interp_alias_create(
             for (0..new_name_len) |k| d[prefix.len + k] = np[k];
         }
         for (suffix, 0..) |b, k| d[prefix.len + new_name_len + k] = b;
-        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+        const msg = rt.obj_new_string_take(buf, total, total);
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
@@ -659,6 +667,10 @@ pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u
         const suffix: []const u8 = "\" not found";
         const total: u32 = @as(u32, @intCast(prefix.len)) + new_name_len + @as(u32, @intCast(suffix.len));
         const buf = alloc(total);
+        if (buf == 0) {
+            catch_mod.tcl_cmd_error(0);
+            return 0;
+        }
         const d: [*]u8 = @ptrFromInt(buf);
         for (prefix, 0..) |b, k| d[k] = b;
         if (new_name_len > 0) {
@@ -666,7 +678,7 @@ pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u
             for (0..new_name_len) |k| d[prefix.len + k] = np[k];
         }
         for (suffix, 0..) |b, k| d[prefix.len + new_name_len + k] = b;
-        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+        const msg = rt.obj_new_string_take(buf, total, total);
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
@@ -1611,6 +1623,10 @@ pub fn eval_interp_target(words: []const i32) i32 {
             path.len +
             @as(u32, @intCast(suffix.len));
         const buf = alloc(total);
+        if (buf == 0) {
+            catch_mod.tcl_cmd_error(0);
+            return 0;
+        }
         const d: [*]u8 = @ptrFromInt(buf);
         var off: u32 = 0;
         for (prefix) |b| {
@@ -1639,7 +1655,7 @@ pub fn eval_interp_target(words: []const i32) i32 {
             d[off] = b;
             off += 1;
         }
-        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(off));
+        const msg = rt.obj_new_string_take(buf, off, total);
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
@@ -1696,6 +1712,10 @@ pub fn eval_interp_target(words: []const i32) i32 {
             path.len +
             @as(u32, @intCast(suffix.len));
         const buf = alloc(total);
+        if (buf == 0) {
+            catch_mod.tcl_cmd_error(0);
+            return 0;
+        }
         const d: [*]u8 = @ptrFromInt(buf);
         var off: u32 = 0;
         for (prefix) |b| {
@@ -1724,7 +1744,7 @@ pub fn eval_interp_target(words: []const i32) i32 {
             d[off] = b;
             off += 1;
         }
-        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(off));
+        const msg = rt.obj_new_string_take(buf, off, total);
         catch_mod.tcl_cmd_error(msg);
         return 0;
     }
@@ -1739,6 +1759,7 @@ pub fn eval_interp_target(words: []const i32) i32 {
         if (i > 0) total_len += 1;
     }
     const buf = alloc(total_len);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     // Names are in reverse order in name_ptrs (closest-to-target
     // first); emit them in forward order (closest-to-caller first).
@@ -1757,7 +1778,7 @@ pub fn eval_interp_target(words: []const i32) i32 {
             off = obj_mod.list_elem_quote_nth(buf, off, name_ptrs[i], name_lens[i]);
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return rt.obj_new_string_take(buf, off, total_len);
 }
 
 /// ``interp issafe ?path?`` — read the ``INTERP_SAFE`` flag on the
@@ -1880,6 +1901,10 @@ fn raise_expected_integer(handle: i32) void {
     const suffix: []const u8 = "\"";
     const total: u32 = @as(u32, @intCast(prefix.len)) + s.len + @as(u32, @intCast(suffix.len));
     const buf = alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (s.len > 0) {
@@ -1887,7 +1912,7 @@ fn raise_expected_integer(handle: i32) void {
         for (0..s.len) |k| d[prefix.len + k] = sp[k];
     }
     for (suffix, 0..) |b, k| d[prefix.len + s.len + k] = b;
-    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = rt.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -44,6 +44,7 @@ const interp_reg = @import("../interp/tcl_interp_registry.zig");
 pub fn rename_error(template_prefix: []const u8, name_ptr: u32, name_len: u32, template_suffix: []const u8) void {
     const total: u32 = @intCast(template_prefix.len + name_len + template_suffix.len);
     const buf = alloc(total);
+    if (buf == 0) return;
     const dst: [*]u8 = @ptrFromInt(buf);
     var off: u32 = 0;
     for (template_prefix) |c| {
@@ -59,7 +60,7 @@ pub fn rename_error(template_prefix: []const u8, name_ptr: u32, name_len: u32, t
         dst[off] = c;
         off += 1;
     }
-    const msg = obj_new_string(@bitCast(buf), @bitCast(off));
+    const msg = rt.obj_new_string_take(buf, off, total);
     const catch_mod = @import("../interp/tcl_catch.zig");
     catch_mod.tcl_cmd_error(msg);
 }
@@ -330,6 +331,7 @@ pub fn emit_bad_option(name_ptr: u32, name_len: u32) void {
         @as(u32, @intCast(infix.len)) +
         @as(u32, @intCast(INTERP_SUBCOMMAND_LIST.len));
     const buf = alloc(total);
+    if (buf == 0) return;
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (name_len > 0) {
@@ -340,7 +342,7 @@ pub fn emit_bad_option(name_ptr: u32, name_len: u32) void {
     for (INTERP_SUBCOMMAND_LIST, 0..) |b, k| {
         d[prefix.len + name_len + infix.len + k] = b;
     }
-    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = rt.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 /// Raise the canonical Tcl 9 alias-loop diagnostic.  Used by
@@ -713,9 +715,7 @@ pub fn interp_alias_delete(child_interp: u32, new_name_ptr: u32, new_name_len: u
 /// Tiny helper to avoid pulling in ``obj_new_string_copy``'s ABI
 /// naming at every callsite.
 pub fn words_obj_new_string_dup(ptr: u32, len: u32) i32 {
-    const buf = alloc(len);
-    if (len > 0) memcpy(buf, ptr, len);
-    return obj_new_string(@bitCast(buf), @bitCast(len));
+    return obj_new_string_copy(ptr, len);
 }
 
 /// ``interp aliases ?path?`` — list every registered alias in the
@@ -765,6 +765,7 @@ pub fn interp_aliases_list_for(target_interp: u32) i32 {
     if (count == 0) return obj_new_string(0, 0);
 
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var written: u32 = 0;
     cur = t.aliases_head;
@@ -785,7 +786,10 @@ pub fn interp_aliases_list_for(target_interp: u32) i32 {
         }
         cur = r.next_in_child;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    // ``obj_new_string_take`` so the result obj owns ``buf`` —
+    // without it, the borrow form (cap=0) leaves the buffer
+    // unreclaimable on release.
+    return rt.obj_new_string_take(buf, off, total);
 }
 
 const AliasListCtx = struct {
@@ -837,6 +841,7 @@ pub fn interp_hide_error(prefix: []const u8, name_ptr: u32, name_len: u32, suffi
     const catch_mod = @import("../interp/tcl_catch.zig");
     const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
     const buf = alloc(total);
+    if (buf == 0) return;
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (name_len > 0) {
@@ -844,7 +849,7 @@ pub fn interp_hide_error(prefix: []const u8, name_ptr: u32, name_len: u32, suffi
         for (0..name_len) |k| d[prefix.len + k] = sp[k];
     }
     for (suffix, 0..) |b, k| d[prefix.len + name_len + k] = b;
-    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+    const msg = rt.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 
@@ -864,6 +869,7 @@ pub fn resolve_interp_path(path_obj: i32) u32 {
         const suffix: []const u8 = "\"";
         const total: u32 = @as(u32, @intCast(prefix.len)) + s.len + @as(u32, @intCast(suffix.len));
         const buf = alloc(total);
+        if (buf == 0) return target;
         const d: [*]u8 = @ptrFromInt(buf);
         for (prefix, 0..) |b, k| d[k] = b;
         if (s.len > 0) {
@@ -871,7 +877,7 @@ pub fn resolve_interp_path(path_obj: i32) u32 {
             for (0..s.len) |k| d[prefix.len + k] = sp[k];
         }
         for (suffix, 0..) |b, k| d[prefix.len + s.len + k] = b;
-        const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+        const msg = rt.obj_new_string_take(buf, total, total);
         catch_mod.tcl_cmd_error(msg);
     }
     return target;
@@ -1137,13 +1143,14 @@ pub fn eval_interp_create(words: []const i32) i32 {
             const suffix: []const u8 = "\": must be -safe or --";
             const total: u32 = @as(u32, @intCast(prefix.len)) + arg.len + @as(u32, @intCast(suffix.len));
             const buf = alloc(total);
+            if (buf == 0) return 0;
             const d: [*]u8 = @ptrFromInt(buf);
             for (prefix, 0..) |b, k| d[k] = b;
             if (arg.len > 0) {
                 for (0..arg.len) |k| d[prefix.len + k] = ap[k];
             }
             for (suffix, 0..) |b, k| d[prefix.len + arg.len + k] = b;
-            const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+            const msg = rt.obj_new_string_take(buf, total, total);
             catch_mod.tcl_cmd_error(msg);
             return 0;
         }
@@ -1224,12 +1231,13 @@ pub fn eval_interp_create(words: []const i32) i32 {
                     const suffix: []const u8 = "\"";
                     const total: u32 = @as(u32, @intCast(prefix.len)) + elem.len + @as(u32, @intCast(suffix.len));
                     const buf = alloc(total);
+                    if (buf == 0) return 0;
                     const d: [*]u8 = @ptrFromInt(buf);
                     for (prefix, 0..) |b, kk| d[kk] = b;
                     const pp: [*]const u8 = @ptrFromInt(s.ptr + elem.start);
                     for (0..elem.len) |kk| d[prefix.len + kk] = pp[kk];
                     for (suffix, 0..) |b, kk| d[prefix.len + elem.len + kk] = b;
-                    const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+                    const msg = rt.obj_new_string_take(buf, total, total);
                     catch_mod.tcl_cmd_error(msg);
                     return 0;
                 }
@@ -1244,12 +1252,13 @@ pub fn eval_interp_create(words: []const i32) i32 {
             const suffix: []const u8 = "\" already exists, cannot create";
             const total: u32 = @as(u32, @intCast(prefix.len)) + name_len + @as(u32, @intCast(suffix.len));
             const buf = alloc(total);
+            if (buf == 0) return 0;
             const d: [*]u8 = @ptrFromInt(buf);
             for (prefix, 0..) |b, k| d[k] = b;
             const np: [*]const u8 = @ptrFromInt(name_ptr);
             for (0..name_len) |k| d[prefix.len + k] = np[k];
             for (suffix, 0..) |b, k| d[prefix.len + name_len + k] = b;
-            const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+            const msg = rt.obj_new_string_take(buf, total, total);
             catch_mod.tcl_cmd_error(msg);
             return 0;
         }
@@ -1454,6 +1463,7 @@ pub fn emit_bucket_names_as_list(buf_addr: u32, cap: u32) i32 {
     if (total == 0) return obj_new_string(0, 0);
 
     const out = alloc(total);
+    if (out == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     count = 0;
     i = 0;
@@ -1475,7 +1485,7 @@ pub fn emit_bucket_names_as_list(buf_addr: u32, cap: u32) i32 {
             list_quote.list_elem_quote_nth(out, off, ep, nlen);
         count += 1;
     }
-    return obj_new_string(@bitCast(out), @bitCast(off));
+    return rt.obj_new_string_take(out, off, total);
 }
 
 /// ``interp delete ?path ...?``.  Each path is resolved and
@@ -1514,12 +1524,13 @@ pub fn eval_interp_delete(words: []const i32) i32 {
             const suffix: []const u8 = "\"";
             const total: u32 = @as(u32, @intCast(prefix.len)) + path.len + @as(u32, @intCast(suffix.len));
             const buf = alloc(total);
+            if (buf == 0) return 0;
             const d: [*]u8 = @ptrFromInt(buf);
             for (prefix, 0..) |b, j| d[j] = b;
             const sp: [*]const u8 = @ptrFromInt(path.ptr);
             for (0..path.len) |j| d[prefix.len + j] = sp[j];
             for (suffix, 0..) |b, j| d[prefix.len + path.len + j] = b;
-            const msg = rt.obj_new_string(@bitCast(buf), @bitCast(total));
+            const msg = rt.obj_new_string_take(buf, total, total);
             catch_mod.tcl_cmd_error(msg);
             return 0;
         }

--- a/runtime/zig/cmds/tcl_rename.zig
+++ b/runtime/zig/cmds/tcl_rename.zig
@@ -290,9 +290,26 @@ pub fn rename_command(
                 if (d.real_cmd != 0) tcl_ns.unlink_import_ref(d.real_cmd, cmd);
                 d.real_cmd = 0;
             }
+        } else if ((flags & tcl_procs.CMD_ALIAS) != 0) {
+            // Alias deletion — release the prefix retains and free
+            // the AliasRec slab so the per-alias n_prefix TclObj
+            // retains don't leak.
+            const alias_mod = @import("tcl_alias.zig");
+            alias_mod.alias_clear(cmd);
         } else {
             // Source side: deactivate every redirect pointing at us.
+            // Also release the proc's retained ``params_obj`` and
+            // ``body_obj`` so every ``rename foo {}`` over a plain
+            // interpreted proc reclaims its source-text TclObjs
+            // rather than leaking them.
             deactivate_importers(cmd);
+            const obj_mod = @import("../valtypes/tcl_obj.zig");
+            const prev_params: i32 = read_i32(cmd + tcl_procs.OFF_PARAMS_OBJ);
+            const prev_body: i32 = read_i32(cmd + tcl_procs.OFF_BODY_OBJ);
+            if (prev_params != 0) obj_mod.tcl_obj_release(prev_params);
+            if (prev_body != 0) obj_mod.tcl_obj_release(prev_body);
+            obj_mod.write_i32(cmd + tcl_procs.OFF_PARAMS_OBJ, 0);
+            obj_mod.write_i32(cmd + tcl_procs.OFF_BODY_OBJ, 0);
         }
         // If the command is an alias, unhook the AliasRec from
         // the per-interp chains so ``interp aliases`` no longer

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -47,6 +47,17 @@ fn eval_set(words: []const i32) result_mod.InterpResult {
         catch_mod.var_unset_error(words[1]);
         return result_mod.from_globals(0);
     }
+    // ``var_resolve`` hands back the var slot's stored handle WITHOUT
+    // bumping the refcount — the slot's own +1 is the only reference
+    // backing the obj.  ``eval_script`` releases each statement's
+    // result before running the next (and again at the eval_script
+    // caller boundary), so handing back this bare borrow would
+    // decrement the slot's hold to zero and queue the obj for free.
+    // Retain here so the result is a true +1 owned handle the
+    // dispatcher / eval_script chain can release without ever
+    // touching the slot's live reference.
+    const tcl_obj_mod = @import("../valtypes/tcl_obj.zig");
+    tcl_obj_mod.tcl_obj_retain(v);
     return result_mod.from_globals(v);
 }
 

--- a/runtime/zig/dispatch/tcl_dispatch.zig
+++ b/runtime/zig/dispatch/tcl_dispatch.zig
@@ -179,8 +179,18 @@ pub fn dispatch(bucket: i32, words: []const i32) i32 {
     const argc: u32 = n_params;
 
     var argv_buf: u32 = 0;
+    const argv_buf_size: u32 = argc * 4;
+    // Track the tail-args list so we can release it after the
+    // compiled proc returns.  ``build_args_list`` returns a fresh
+    // +1 owned obj; the compiled proc's prologue retains via
+    // ``frame_local_set_at`` for the ``args`` slot, then the
+    // matching ``frame_pop`` releases.  Without this caller-side
+    // release every ``args``-bearing compiled-proc dispatch leaked
+    // one TclObj header per call.
+    var tail_list: i32 = 0;
     if (argc > 0) {
-        argv_buf = obj.alloc(argc * 4);
+        argv_buf = obj.alloc(argv_buf_size);
+        if (argv_buf == 0) return 0;
         if (has_args_tail) {
             // How many leading words map to non-``args`` params
             // (equivalently: how many positional slots we copy
@@ -194,7 +204,7 @@ pub fn dispatch(bucket: i32, words: []const i32) i32 {
             // Remaining call args → join into a single list-shaped
             // TclObj.  Empty list when callee received ``given <=
             // fixed`` (Tcl semantics: ``args`` becomes ``{}``).
-            const tail_list = build_args_list(words, fixed);
+            tail_list = build_args_list(words, fixed);
             obj.write_i32(argv_buf + fixed * 4, tail_list);
         } else {
             // Pad with 0 when caller supplied fewer args than the
@@ -218,12 +228,15 @@ pub fn dispatch(bucket: i32, words: []const i32) i32 {
     // cumulative trace re-entry pushed the heap past the boundary
     // before reaching the test summary, blowing up here on what was
     // an otherwise benign proc dispatch.
-    return call_compiled_proc(
+    const result = call_compiled_proc(
         name_ptr,
         name_len,
         @bitCast(argv_buf),
         @bitCast(argc),
     );
+    if (tail_list != 0) obj.tcl_obj_release(tail_list);
+    if (argv_buf != 0) obj.free_sized(argv_buf, argv_buf_size);
+    return result;
 }
 
 /// Build a Tcl list TclObj from ``words[fixed+1 ..]`` (skipping

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -296,7 +296,11 @@ pub export fn tcl_return_set(value: i32) void {
     state.pending_return_level = 1;
     state.pending_return_armed = 1;
     const old = state.return_val;
-    if (value != 0) obj.tcl_obj_retain(value);
+    // Same-handle re-stamp must be a no-op on rc.  Earlier code
+    // retained unconditionally and only skipped the matching
+    // release when ``old == value``, so every duplicate stamp
+    // leaked +1.  Gate both sides on the inequality.
+    if (value != 0 and value != old) obj.tcl_obj_retain(value);
     state.return_val = value;
     if (old != 0 and old != value) obj.tcl_obj_release(old);
 }

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -770,6 +770,12 @@ fn stamp_error_globals(msg: i32, info: i32, code: i32) void {
         code;
     _ = globals.global_set(code_name, code_val);
     obj.tcl_obj_release(code_name);
+    // Only release on the default branch — that "NONE" obj was
+    // minted here.  Caller-supplied ``code`` keeps its +1 ownership
+    // discipline (the explicit ``error msg info code`` form passes
+    // a borrowed ``words[3]``; the typed-error path's
+    // ``detect_error_code`` ownership is handled at the call site
+    // below).
     if (default_code) obj.tcl_obj_release(code_val);
 }
 
@@ -865,7 +871,14 @@ pub export fn tcl_cmd_error(msg: i32) void {
         const frames_mod = @import("tcl_frames.zig");
         state.error_frame_line = frames_mod.frame_get_line(0);
     }
-    stamp_error_globals(msg, 0, detect_error_code(msg));
+    // ``detect_error_code`` returns a fresh +1 owned obj when the
+    // msg matches a typed pattern (``wrong # args:``, divide-by-zero,
+    // overflow, …).  ``stamp_error_globals`` retains it via
+    // ``global_set`` so it's safe to release here once the stamp
+    // completes; without this every typed error leaked one TclObj.
+    const code = detect_error_code(msg);
+    stamp_error_globals(msg, 0, code);
+    if (code != 0) obj.tcl_obj_release(code);
     if (state.catch_depth > 0) {
         state.error_flag = 1;
         state.error_msg = msg;

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -242,7 +242,18 @@ pub export fn catch_enter() void {
     state.catch_depth += 1;
     state.error_flag = 0;
     state.error_msg = 0;
-    state.catch_ok_result = 0;
+    // Release the previous catch's body-result handle before
+    // zeroing the slot.  ``catch_set_ok_result`` transfers a +1
+    // share into ``state.catch_ok_result`` without retaining;
+    // without this release, every successful catch leaked one
+    // TclObj header per invocation (test suites that exercise
+    // catch heavily — e.g. tcltest's per-test ``::tcltest::test``
+    // body — accumulated thousands of orphaned handles).
+    if (state.catch_ok_result != 0) {
+        const old_ok = state.catch_ok_result;
+        state.catch_ok_result = 0;
+        obj.tcl_obj_release(old_ok);
+    }
     // Release any captured payload from a previous catch so a
     // drain between catches doesn't see a stale +1 hold.
     if (state.last_catch_value != 0) {

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -507,6 +507,7 @@ pub export fn frame_push() i32 {
         // when an insert exhausts the probe chain.
         frame_capacity[idx] = FRAME_INITIAL_BUCKETS;
         frame_stack[idx] = alloc(FRAME_INITIAL_BUCKETS * FRAME_BUCKET_SIZE);
+        if (frame_stack[idx] == 0) return -1; // OOM — surface as stack-overflow-style failure
         first_use = true;
     }
     const base = frame_stack[idx];
@@ -1846,6 +1847,7 @@ pub export fn frame_alias_global(name: i32) void {
             // Qualified target: route through KIND_GLOBAL_NAMED so the
             // alias reads / writes the named global var directly.
             const desc = alloc(12);
+            if (desc == 0) return;
             write_i32(desc, KIND_GLOBAL_NAMED);
             write_i32(desc + 4, 0);
             write_i32(desc + 8, name);
@@ -1910,6 +1912,7 @@ pub export fn frame_alias_named(local_name: i32, target_name: i32) void {
                 obj.free_sized(old_desc, 24);
             }
             const desc = alloc(12);
+            if (desc == 0) return;
             write_i32(desc, KIND_GLOBAL_NAMED);
             write_i32(desc + 4, 0);
             write_i32(desc + 8, qualified_target);
@@ -1917,6 +1920,7 @@ pub export fn frame_alias_named(local_name: i32, target_name: i32) void {
             return;
         }
         const desc = alloc(12);
+        if (desc == 0) return;
         write_i32(desc, KIND_GLOBAL_NAMED);
         write_i32(desc + 4, 0);
         write_i32(desc + 8, qualified_target);
@@ -1995,6 +1999,7 @@ pub export fn frame_alias_frame_var(local_name: i32, abs_depth: i32, target_name
                 obj.free_sized(old_desc, 24);
             }
             const desc = alloc(12);
+            if (desc == 0) return;
             write_i32(desc, KIND_FRAME_VAR);
             write_i32(desc + 4, abs_depth);
             write_i32(desc + 8, target_name);
@@ -2002,6 +2007,7 @@ pub export fn frame_alias_frame_var(local_name: i32, abs_depth: i32, target_name
             return;
         }
         const desc = alloc(12);
+        if (desc == 0) return;
         write_i32(desc, KIND_FRAME_VAR);
         write_i32(desc + 4, abs_depth);
         write_i32(desc + 8, target_name);
@@ -2073,6 +2079,7 @@ pub fn frame_alias_ns_var(local_name: i32, var_ptr: u32, target_ns: u32, simple_
             obj.free_sized(old_desc, 12);
         }
         const desc = alloc(24);
+        if (desc == 0) return;
         write_i32(desc, KIND_NS_VAR_PTR);
         write_i32(desc + 4, 0);
         write_i32(desc + 8, @bitCast(var_ptr));
@@ -2083,6 +2090,7 @@ pub fn frame_alias_ns_var(local_name: i32, var_ptr: u32, target_ns: u32, simple_
         return;
     }
     const desc = alloc(24);
+    if (desc == 0) return;
     write_i32(desc, KIND_NS_VAR_PTR);
     write_i32(desc + 4, 0);
     write_i32(desc + 8, @bitCast(var_ptr));
@@ -2149,6 +2157,10 @@ pub export fn upvar_resolve_depth(level_obj: i32, cur_depth: i32) i32 {
         const total: u32 = @as(u32, @intCast(prefix.len)) + sn.len +
             @as(u32, @intCast(suffix.len));
         const buf = obj.alloc(total);
+        if (buf == 0) {
+            tcl_catch.tcl_cmd_error(0);
+            return cur_depth - 1;
+        }
         const d: [*]u8 = @ptrFromInt(buf);
         var off: u32 = 0;
         for (prefix) |b| {
@@ -2599,40 +2611,44 @@ pub export fn var_resolve(name: i32) i32 {
             // look it up.  Skip when ns is the root (length 2 = "::").
             const total: u32 = ns_full.len + 2 + sn.len;
             const buf = obj.alloc(total);
-            const dst: [*]u8 = @ptrFromInt(buf);
-            const ns_p: [*]const u8 = @ptrFromInt(ns_full.ptr);
-            for (0..ns_full.len) |i| dst[i] = ns_p[i];
-            dst[ns_full.len] = ':';
-            dst[ns_full.len + 1] = ':';
-            const name_p: [*]const u8 = @ptrFromInt(sn.ptr);
-            for (0..sn.len) |i| dst[ns_full.len + 2 + i] = name_p[i];
-            const qname = obj.obj_new_string(@bitCast(buf), @bitCast(total));
-            // global_exists returns a TclObj wrapping 0 or 1 — its
-            // *handle* is always non-zero (a fresh integer obj), so a
-            // raw ``!= 0`` test always passed and we always returned
-            // ``global_get(qname)`` even for non-existent names.  Check
-            // the wrapped int.
-            const exists = obj.obj_get_int(globals.global_exists(qname)) != 0;
-            if (exists) {
-                const v = globals.global_get(qname);
-                // Reclaim the qname temp + its backing buffer.  Without
-                // this every ``$var`` read inside a namespace
-                // accumulated a small leak that pushed io.test past the
-                // 2 GiB linear-memory ceiling and tripped a u32→i32
-                // ``@intCast`` panic in ``obj_new_string``.
+            if (buf != 0) {
+                const dst: [*]u8 = @ptrFromInt(buf);
+                const ns_p: [*]const u8 = @ptrFromInt(ns_full.ptr);
+                for (0..ns_full.len) |i| dst[i] = ns_p[i];
+                dst[ns_full.len] = ':';
+                dst[ns_full.len + 1] = ':';
+                const name_p: [*]const u8 = @ptrFromInt(sn.ptr);
+                for (0..sn.len) |i| dst[ns_full.len + 2 + i] = name_p[i];
+                const qname = obj.obj_new_string(@bitCast(buf), @bitCast(total));
+                // global_exists returns a TclObj wrapping 0 or 1 — its
+                // *handle* is always non-zero (a fresh integer obj), so a
+                // raw ``!= 0`` test always passed and we always returned
+                // ``global_get(qname)`` even for non-existent names.  Check
+                // the wrapped int.
+                const exists = obj.obj_get_int(globals.global_exists(qname)) != 0;
+                if (exists) {
+                    const v = globals.global_get(qname);
+                    // Reclaim the qname temp + its backing buffer.  Without
+                    // this every ``$var`` read inside a namespace
+                    // accumulated a small leak that pushed io.test past the
+                    // 2 GiB linear-memory ceiling and tripped a u32→i32
+                    // ``@intCast`` panic in ``obj_new_string``.
+                    obj.tcl_obj_release(qname);
+                    obj.free_sized(buf, total);
+                    return v;
+                }
                 obj.tcl_obj_release(qname);
                 obj.free_sized(buf, total);
-                return v;
+                // No FQN match — fall through to the root global below.
+                // (The strict ``namespace-17.7`` discipline of refusing
+                // to fall back was correct in spirit but broke the
+                // common eval-fallback path where a proc-local read
+                // probes the frame, misses, falls through here, and
+                // expects to keep hunting up the chain.  We re-evaluate
+                // namespace-17.7 separately via a different mechanism.)
             }
-            obj.tcl_obj_release(qname);
-            obj.free_sized(buf, total);
-            // No FQN match — fall through to the root global below.
-            // (The strict ``namespace-17.7`` discipline of refusing
-            // to fall back was correct in spirit but broke the
-            // common eval-fallback path where a proc-local read
-            // probes the frame, misses, falls through here, and
-            // expects to keep hunting up the chain.  We re-evaluate
-            // namespace-17.7 separately via a different mechanism.)
+            // OOM — skip the namespace probe and fall through to the
+            // root global below.
         }
     }
     // Fall through to root global (current_ns is root or not set)

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -750,8 +750,12 @@ pub export fn frame_set_argv(argv: i32) void {
     // argv list (built per-call from words[]) gets freed by the
     // parser-side release at end-of-statement (MM-B.4) before the
     // proc body's ``info level 0`` can read it.
+    //
+    // Same-handle re-stamp must be a net no-op on rc — gate both
+    // retain and release on the inequality, otherwise a duplicate
+    // ``frame_set_argv(same_list)`` leaks +1 per call.
     const old = frame_argv[frame_depth - 1];
-    if (argv != 0) obj.tcl_obj_retain(argv);
+    if (argv != 0 and argv != old) obj.tcl_obj_retain(argv);
     frame_argv[frame_depth - 1] = argv;
     if (old != 0 and old != argv) obj.tcl_obj_release(old);
 }
@@ -797,7 +801,9 @@ pub export fn frame_set_script(script_obj: i32) void {
     if (frame_depth == 0) return;
     const fi = &frame_info[frame_depth - 1];
     const old = fi.script_obj;
-    if (script_obj != 0) obj.tcl_obj_retain(script_obj);
+    // Gate retain on inequality — see ``frame_set_argv`` for the
+    // same-handle re-stamp rationale.
+    if (script_obj != 0 and script_obj != old) obj.tcl_obj_retain(script_obj);
     fi.script_obj = script_obj;
     if (old != 0 and old != script_obj) obj.tcl_obj_release(old);
 }
@@ -847,7 +853,7 @@ pub export fn frame_set_cmd_text(cmd_text: i32) void {
     if (frame_depth == 0) return;
     const fi = &frame_info[frame_depth - 1];
     const old = fi.cmd_text;
-    if (cmd_text != 0) obj.tcl_obj_retain(cmd_text);
+    if (cmd_text != 0 and cmd_text != old) obj.tcl_obj_retain(cmd_text);
     fi.cmd_text = cmd_text;
     if (old != 0 and old != cmd_text) obj.tcl_obj_release(old);
 }
@@ -858,7 +864,7 @@ pub export fn frame_set_proc_name(proc_name: i32) void {
     if (frame_depth == 0) return;
     const fi = &frame_info[frame_depth - 1];
     const old = fi.proc_name;
-    if (proc_name != 0) obj.tcl_obj_retain(proc_name);
+    if (proc_name != 0 and proc_name != old) obj.tcl_obj_retain(proc_name);
     fi.proc_name = proc_name;
     if (old != 0 and old != proc_name) obj.tcl_obj_release(old);
 }
@@ -1107,7 +1113,9 @@ pub export fn frame_local_set_at(idx: u32, value: i32) i32 {
     if (idx >= LOCALS_ARRAY_CAP) return value;
     const slot = &frame_locals_array[frame_depth - 1][idx];
     const old = slot.*;
-    if (value != 0) obj.tcl_obj_retain(value);
+    // Same-handle re-stamp must be a net no-op on rc — see
+    // ``frame_set_argv`` for the rationale.
+    if (value != 0 and value != old) obj.tcl_obj_retain(value);
     slot.* = value;
     if (old != 0 and old != value) obj.tcl_obj_release(old);
     return value;

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1217,18 +1217,20 @@ fn expr_atom(ptr: u32, len: u32, pos: *u32, skip: bool) i64 {
         // require us to avoid.
         if (skip) return 0;
         const result = eval_script(ptr + cs, pos.* - 1 - cs);
-        // Codex review on PR #319 (issue #303): do NOT release
-        // ``result`` here — ``eval_script`` can return a *borrowed*
-        // handle into a variable's live storage (``[set x]`` read
-        // mode goes through ``frames.var_resolve`` and forwards
-        // that handle directly), and a release would decrement the
-        // var slot's live refcount and free the value still stored
-        // there.  The intermediate-result discipline can only run
-        // at sites that are guaranteed to see +1-owned returns.
-        // The narrow ``$var`` ``name`` release a few lines up is
-        // safe because that name TclObj is freshly allocated by
-        // this function, not borrowed.
-        if (result != 0) return obj_get_int(result);
+        // ``eval_script`` returns +1 owned to the caller — the
+        // ``eval_set``-read-form borrow regression (issue #303,
+        // PR #319) was paid down by retaining inside the handler
+        // before forwarding the var slot's handle, so every
+        // command's result now carries its own +1 share regardless
+        // of whether the underlying value came from a var slot,
+        // a fresh allocation, or a parser-allocated word.  Release
+        // the result so the substituted ``[…]`` doesn't leak one
+        // TclObj per expression invocation.
+        if (result != 0) {
+            const v = obj_get_int(result);
+            obj_mod.tcl_obj_release(result);
+            return v;
+        }
         return 0;
     }
     var negative = false;

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1708,12 +1708,13 @@ pub fn qualify_name(name: i32) i32 {
     const ns_ptr: [*]const u8 = @ptrFromInt(ns_full.ptr);
     const total: u32 = ns_full.len + 2 + s.len;
     const buf_addr: u32 = obj_mod.alloc(total);
+    if (buf_addr == 0) return name;
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (0..ns_full.len) |i| buf[i] = ns_ptr[i];
     buf[ns_full.len] = ':';
     buf[ns_full.len + 1] = ':';
     for (0..s.len) |i| buf[ns_full.len + 2 + i] = sp[i];
-    return obj_mod.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    return obj_mod.obj_new_string_take(buf_addr, total, total);
 }
 
 // -- upvar / uplevel helpers --
@@ -3363,7 +3364,12 @@ fn dispatch_interp_child(words: []const i32, bucket: i32) i32 {
     // ``interp`` dispatcher with a synthesised ``path`` slot.  Build
     // ``["interp", subcmd, <child_path>, words[2..]]``.
     const c: *interp_reg.Interp = @ptrFromInt(child);
+    // ``child_path_obj`` is a fresh +1 owned TclObj wrapping the
+    // child interp's name bytes; release after the sub-handler
+    // returns or the slot leaks one TclObj header per
+    // ``<child> SUBCOMMAND`` dispatch.
     const child_path_obj = rt.obj_new_string(@bitCast(c.name_ptr), @bitCast(c.name_len));
+    defer obj_mod.tcl_obj_release(child_path_obj);
 
     const new_len: u32 = @as(u32, @intCast(words.len)) + 1;
     if (new_len > parse.MAX_WORDS) {
@@ -3375,7 +3381,10 @@ fn dispatch_interp_child(words: []const i32, bucket: i32) i32 {
     }
     var new_words: [parse.MAX_WORDS]i32 = undefined;
     const interp_str: []const u8 = "interp";
+    // ``new_words[0]`` (``"interp"`` copy) is +1 owned; release on
+    // every return path via defer.
     new_words[0] = rt.obj_new_string_copy(@intFromPtr(interp_str.ptr), interp_str.len);
+    defer obj_mod.tcl_obj_release(new_words[0]);
     new_words[1] = words[1]; // subcmd (re-use caller's TclObj)
     new_words[2] = child_path_obj;
     var j: u32 = 3;
@@ -4592,7 +4601,12 @@ fn eval_interp_invokehidden(words: []const i32) i32 {
             return 0;
         }
         var bwords: [parse.MAX_WORDS]i32 = undefined;
+        // ``bwords[0]`` is a fresh +1 owned TclObj wrapping the hidden
+        // name's bytes; release after the dispatch — without this each
+        // ``interp invokehidden`` (builtin path) leaked one TclObj
+        // header per call.
         bwords[0] = rt.obj_new_string(@bitCast(hidden_name.ptr), @bitCast(hidden_name.len));
+        defer obj_mod.tcl_obj_release(bwords[0]);
         var bk: u32 = 0;
         while (bk < tail_count_b) : (bk += 1) {
             bwords[1 + bk] = words[idx + 1 + bk];
@@ -4628,7 +4642,12 @@ fn eval_interp_invokehidden(words: []const i32) i32 {
         return 0;
     }
     var new_words: [parse.MAX_WORDS]i32 = undefined;
+    // ``new_words[0]`` is a fresh +1 owned TclObj wrapping the hidden
+    // name's bytes; release after the dispatch — see the builtin path
+    // above for the same rationale.  Without this each
+    // ``interp invokehidden`` (proc path) leaked one TclObj header.
     new_words[0] = rt.obj_new_string(@bitCast(hidden_name.ptr), @bitCast(hidden_name.len));
+    defer obj_mod.tcl_obj_release(new_words[0]);
     var k: u32 = 0;
     while (k < tail_count) : (k += 1) {
         new_words[1 + k] = words[idx + 1 + k];

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1742,6 +1742,7 @@ pub fn concat_words(ws: []const i32) i32 {
     }
     total += @as(u32, @intCast(ws.len)) - 1; // spaces
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     for (ws, 0..) |w, wi| {
         const s = obj_ensure_string(w);
@@ -1753,7 +1754,7 @@ pub fn concat_words(ws: []const i32) i32 {
             off += 1;
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(total));
+    return obj_mod.obj_new_string_take(buf, total, total);
 }
 
 /// ``upvar ?level? otherVar myVar ?otherVar myVar ...?``
@@ -2665,10 +2666,15 @@ fn switch_opt_prefix(opt_ptr: [*]const u8, opt_len: u32, comptime full: []const 
 /// option-set wording exactly so switch-3.x return-code tests catch
 /// the upstream string.
 fn switch_bad_option(opt_ptr: [*]const u8, opt_len: u32) void {
+    const catch_mod = @import("tcl_catch.zig");
     const prefix: []const u8 = "bad option \"";
     const suffix: []const u8 = "\": must be -exact, -glob, -indexvar, -matchvar, -nocase, -regexp, or --";
     const total: u32 = @intCast(prefix.len + opt_len + suffix.len);
     const buf = obj_mod.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
     const bp: [*]u8 = @ptrFromInt(buf);
     var off: u32 = 0;
     for (prefix) |c| {
@@ -2684,8 +2690,7 @@ fn switch_bad_option(opt_ptr: [*]const u8, opt_len: u32) void {
         bp[off] = c;
         off += 1;
     }
-    const msg = obj_mod.obj_new_string(@bitCast(buf), @bitCast(total));
-    const catch_mod = @import("tcl_catch.zig");
+    const msg = obj_mod.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(msg);
 }
 

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -3221,6 +3221,7 @@ fn emit_child_arity_error(
         @as(u32, @intCast(suffix.len)) +
         @as(u32, @intCast(tail.len));
     const buf = alloc(total);
+    if (buf == 0) return;
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (child_name_len > 0) {
@@ -3246,6 +3247,7 @@ fn emit_child_bad_option(name_ptr: u32, name_len: u32) void {
         @as(u32, @intCast(infix.len)) +
         @as(u32, @intCast(CHILD_SUBCOMMAND_LIST.len));
     const buf = alloc(total);
+    if (buf == 0) return;
     const d: [*]u8 = @ptrFromInt(buf);
     for (prefix, 0..) |b, k| d[k] = b;
     if (name_len > 0) {
@@ -4197,6 +4199,10 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                     }
                     const args_alloc_size: u32 = total + 4;
                     const buf = alloc(args_alloc_size);
+                    if (buf == 0) {
+                        frames.frame_pop();
+                        return 0;
+                    }
                     var off: u32 = 0;
                     ai = arg_idx;
                     while (ai < words.len) : (ai += 1) {
@@ -4914,9 +4920,11 @@ pub fn eval_apply(words: []const i32) i32 {
     else blk: {
         const alloc_size: u32 = params_elem.len + 4;
         const buf = alloc(alloc_size);
+        if (buf == 0) break :blk 0;
         const out_len = copy_unbraced_elem(buf, lambda_s.ptr + params_elem.start, params_elem.len);
         break :blk obj_new_string_take(buf, out_len, alloc_size);
     };
+    if (params_obj == 0) return 0;
     // Issue #317: ``params_obj`` / ``body_obj`` are local copies of
     // the lambda's two list elements; they're never stored in a
     // frame slot or registered command, so without these defers
@@ -4928,9 +4936,11 @@ pub fn eval_apply(words: []const i32) i32 {
     else blk: {
         const alloc_size: u32 = body_elem.len + 4;
         const buf = alloc(alloc_size);
+        if (buf == 0) break :blk 0;
         const out_len = copy_unbraced_elem(buf, lambda_s.ptr + body_elem.start, body_elem.len);
         break :blk obj_new_string_take(buf, out_len, alloc_size);
     };
+    if (body_obj == 0) return 0;
     defer obj_mod.tcl_obj_release(body_obj);
 
     // Optional namespace from third lambda element
@@ -4997,6 +5007,10 @@ pub fn eval_apply(words: []const i32) i32 {
                     }
                     const args_alloc_size: u32 = total + 4;
                     const buf = alloc(args_alloc_size);
+                    if (buf == 0) {
+                        frames.frame_pop();
+                        return 0;
+                    }
                     var off: u32 = 0;
                     ai = arg_idx;
                     while (ai < words.len) : (ai += 1) {
@@ -5634,6 +5648,10 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
                     expanded[ecount] = obj_new_string_copy(s.ptr + elem.start, elem.len);
                 } else {
                     const buf = alloc(elem.len);
+                    if (buf == 0) {
+                        obj_mod.tcl_obj_release(word_obj);
+                        return 0;
+                    }
                     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
                     expanded[ecount] = obj_new_string_take(buf, out_len, elem.len);
                 }

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1565,10 +1565,18 @@ fn try_ensemble_rewrite(cmd_s: anytype, words: []const i32) ?i32 {
     // [1], and the caller's args[1..] at [2..].  Use the bump
     // allocator — the slice lives only for the handler call.
     const total: u32 = @as(u32, @intCast(words.len)) + 1;
-    const buf = obj_mod.alloc(total * 4);
+    const buf_size: u32 = total * 4;
+    const buf = obj_mod.alloc(buf_size);
+    if (buf == 0) return null;
+    defer obj_mod.free_sized(buf, buf_size);
     const slot: [*]i32 = @ptrFromInt(buf);
+    // Slots 0 and 1 are fresh +1 TclObjs we own; release after the
+    // handler returns.  Without this each ``dict for`` / ``string
+    // cat`` / etc. ensemble dispatch leaked two TclObjs per call.
     slot[0] = obj_mod.obj_new_string(@bitCast(ens_ptr), @bitCast(ens_len));
     slot[1] = obj_mod.obj_new_string(@bitCast(sub_ptr), @bitCast(sub_len));
+    defer obj_mod.tcl_obj_release(slot[0]);
+    defer obj_mod.tcl_obj_release(slot[1]);
     var k: u32 = 1;
     while (k < words.len) : (k += 1) {
         slot[k + 1] = words[k];
@@ -1607,10 +1615,15 @@ fn try_ensemble_rewrite_relative(cmd_s: anytype, words: []const i32) ?i32 {
     const handler = cmd_table_visible_lookup(ens_ptr, ens_len) orelse return null;
 
     const total: u32 = @as(u32, @intCast(words.len)) + 1;
-    const buf = obj_mod.alloc(total * 4);
+    const buf_size: u32 = total * 4;
+    const buf = obj_mod.alloc(buf_size);
+    if (buf == 0) return null;
+    defer obj_mod.free_sized(buf, buf_size);
     const slot: [*]i32 = @ptrFromInt(buf);
     slot[0] = obj_mod.obj_new_string(@bitCast(ens_ptr), @bitCast(ens_len));
     slot[1] = obj_mod.obj_new_string(@bitCast(sub_ptr), @bitCast(sub_len));
+    defer obj_mod.tcl_obj_release(slot[0]);
+    defer obj_mod.tcl_obj_release(slot[1]);
     var k: u32 = 1;
     while (k < words.len) : (k += 1) {
         slot[k + 1] = words[k];
@@ -1861,7 +1874,14 @@ pub fn eval_uplevel(words: []const i32) i32 {
 
     if (body_start >= words.len) return 0;
 
-    const body_obj = concat_words(words[body_start..]);
+    // ``concat_words`` returns the borrowed input handle when there's
+    // exactly one body word, and a fresh +1 owned obj otherwise.
+    // Only release in the multi-arg case — releasing the single-word
+    // borrow would decrement the caller's word ref and over-release.
+    const body_words = words[body_start..];
+    const body_obj = concat_words(body_words);
+    const body_owned = body_words.len > 1;
+    defer if (body_owned) obj_mod.tcl_obj_release(body_obj);
     // ``frame_depth_stash`` / ``frame_depth_restore`` save and
     // restore both the frame depth and the namespace context,
     // re-entering the target frame's recorded caller-ns for the
@@ -3465,11 +3485,18 @@ fn dispatch_alias(words: []const i32, bucket: i32) i32 {
     }
 
     var new_words: [parse.MAX_WORDS]i32 = undefined;
-    // Slot 0: the target command name as a fresh TclObj.
-    new_words[0] = rt.obj_new_string(
+    // Slot 0: the target command name as a fresh TclObj (+1 owned).
+    // Track the original allocation separately so every return path
+    // can release it — without this each alias dispatch leaks the
+    // target-name obj, and the auto-index branch below (which
+    // overwrites ``new_words[0]`` with a different handle) would
+    // drop the original on the floor.
+    const target_name_obj = rt.obj_new_string(
         @bitCast(rec.target_name_ptr),
         @bitCast(rec.target_name_len),
     );
+    defer obj_mod.tcl_obj_release(target_name_obj);
+    new_words[0] = target_name_obj;
     // Slots 1..1+n_prefix: the frozen prefix args.  The AliasRec
     // stores u32 TclObj handles but the interpreter runs on i32
     // handles; @bitCast is the reinterpretation we want.
@@ -3569,13 +3596,20 @@ fn dispatch_alias(words: []const i32, bucket: i32) i32 {
     // the test expects.
     const ai_loaded = try_auto_index_load(new_words[0]);
     if (ai_loaded != 0) {
+        // ai_loaded carries a +1 from try_auto_index_load; the
+        // function-exit defer below releases it.  No extra retain
+        // needed even when we swap it into ``new_words[0]`` — the
+        // slot is a local array entry whose lifetime is bounded by
+        // this function, and the +1 from try_auto_index_load is
+        // alive until the defer fires after return.
         defer obj_mod.tcl_obj_release(ai_loaded);
         const ai_bucket = procs.proc_lookup(ai_loaded);
         if (ai_bucket != 0) {
             // Swap in the loaded FQ name as the dispatched command
             // name so ``info level 0`` etc see the canonical form.
+            // Releasing ``target_name_obj`` happens via the outer
+            // ``defer`` (it stays alive for the duration of the call).
             new_words[0] = ai_loaded;
-            obj_mod.tcl_obj_retain(ai_loaded);
             const result = eval_proc_call_bucket(new_words[0..total], ai_bucket);
             interp_reg.leave(save);
             return result;
@@ -4668,6 +4702,14 @@ fn eval_interp_eval(words: []const i32) i32 {
         if (k + 1 < words.len) total += 1;
     }
     const script_ptr: u32 = if (total == 0) 0 else alloc(total);
+    if (total > 0 and script_ptr == 0) {
+        // OOM allocating the concat buffer — bail rather than write
+        // through ``@ptrFromInt(0)`` below.
+        return 0;
+    }
+    // Reclaim the concat buffer before returning so every ``interp
+    // eval child …`` call doesn't leak ``total`` bytes of slab.
+    defer if (total > 0) obj_mod.free_sized(script_ptr, total);
     var off: u32 = 0;
     k = 3;
     while (k < words.len) : (k += 1) {

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -325,6 +325,14 @@ pub var current_interp: u32 = 0;
 fn alloc_interp() u32 {
     const size: u32 = @sizeOf(Interp);
     const addr = alloc(size);
+    // OOM: alloc raised ``oom_flag``.  Return 0 so callers can
+    // surface the failure rather than ``@memset`` through a null
+    // pointer.  ``child_create`` propagates 0 up to
+    // ``eval_interp_create`` which already bails on a missing
+    // child handle; ``interp_root`` callers will see the root
+    // interp unallocated and the next interp boundary will
+    // surface the OOM.
+    if (addr == 0) return 0;
     const slice: [*]u8 = @ptrFromInt(addr);
     @memset(slice[0..size], 0);
     return addr;
@@ -338,6 +346,14 @@ fn alloc_interp() u32 {
 pub fn interp_root() u32 {
     if (root_interp_addr != 0) return root_interp_addr;
     root_interp_addr = alloc_interp();
+    // OOM at very early init: ``alloc_interp`` already surfaced 0
+    // and raised ``oom_flag``.  Skip the field writes (otherwise
+    // ``@ptrFromInt(0)`` panics in debug) and return 0 so the next
+    // ``interp_root`` call retries the allocation.  Callers that
+    // assume this is non-null are limited to early-init hooks; if
+    // they actually deref they'll panic the same way as today, but
+    // strictly worse off than before — net win.
+    if (root_interp_addr == 0) return 0;
     const i: *Interp = @ptrFromInt(root_interp_addr);
     i.root_ns = tcl_ns.ns_root();
     // Root interp has no parent, no simple name, no children yet.
@@ -389,6 +405,12 @@ pub fn child_create(parent: u32, name_ptr: u32, name_len: u32, flags: u32) u32 {
         p.children.insert_header(name_ptr, name_len, hash);
 
     const child = alloc_interp();
+    // OOM: ``alloc_interp`` returned 0 and raised ``oom_flag``.
+    // Don't write back through the bucket; the bucket entry still
+    // has its handle slot zero (per ``insert_header``) and a
+    // retry after the OOM clears can reattempt the create against
+    // the same bucket name.
+    if (child == 0) return 0;
     const c: *Interp = @ptrFromInt(child);
     c.parent = parent;
     c.flags = flags;
@@ -402,9 +424,18 @@ pub fn child_create(parent: u32, name_ptr: u32, name_len: u32, flags: u32) u32 {
 
     if (name_len > 0) {
         const nbuf = alloc(name_len);
-        memcpy(nbuf, name_ptr, name_len);
-        c.name_ptr = nbuf;
-        c.name_len = name_len;
+        // OOM: alloc raised ``oom_flag``.  Leave the child without
+        // a name (name_ptr=0, name_len=0) and surface the partial
+        // Interp anyway — the bucket entry still points to it so
+        // callers can find / delete the half-built child.  Skipping
+        // the ``memcpy`` avoids ``@ptrFromInt(0)``; the missing
+        // name will surface as an empty path in any subsequent
+        // ``namespace which`` style lookup.
+        if (nbuf != 0) {
+            memcpy(nbuf, name_ptr, name_len);
+            c.name_ptr = nbuf;
+            c.name_len = name_len;
+        }
     }
 
     write_i32(bucket + tcl_ns.OFF_HANDLE, @bitCast(child));
@@ -623,6 +654,12 @@ pub fn alloc_child_command(
     child_interp: u32,
 ) u32 {
     const cmd = alloc(COMMAND_SIZE);
+    // OOM: alloc raised ``oom_flag``.  Surface 0 to the caller
+    // (``eval_interp_create``) which already handles a 0 return
+    // for the analogous ``child_create`` path — it bails before
+    // registering the half-built Command into the parent's
+    // cmd_table.
+    if (cmd == 0) return 0;
     const slice: [*]u8 = @ptrFromInt(cmd);
     @memset(slice[0..COMMAND_SIZE], 0);
 

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -138,6 +138,7 @@ pub fn ns_alloc_root() u32 {
 fn alloc_namespace() u32 {
     const size: u32 = @sizeOf(Namespace);
     const addr = alloc(size);
+    if (addr == 0) return 0;
     // ``alloc`` doesn't zero, so wipe the whole struct.  This is
     // important for the sub-table ``buf`` fields — a non-zero ``buf``
     // would make ``Table.init`` skip allocation and the
@@ -159,6 +160,7 @@ fn install_name(ns_addr: u32, name_ptr: u32, name_len: u32) void {
         return;
     }
     const buf = alloc(name_len);
+    if (buf == 0) return;
     memcpy(buf, name_ptr, name_len);
     ns.name_ptr = buf;
     ns.name_len = name_len;
@@ -270,6 +272,7 @@ pub fn ns_build_fqn(target_ns: u32, simple_ptr: u32, simple_len: u32) struct { p
     const parent_is_root = parent_full.len == 2;
     const total: u32 = if (parent_is_root) 2 + simple_len else parent_full.len + 2 + simple_len;
     const buf = alloc(total);
+    if (buf == 0) return .{ .ptr = 0, .len = 0 };
     const dst: [*]u8 = @ptrFromInt(buf);
     var off: u32 = 0;
     if (parent_is_root) {
@@ -302,6 +305,7 @@ pub fn ns_full_name(ns_addr: u32) struct { ptr: u32, len: u32 } {
     if (ns.parent == 0) {
         // Root namespace: full name is the literal ``::``.
         const buf = alloc(2);
+        if (buf == 0) return .{ .ptr = 0, .len = 0 };
         const dst: [*]u8 = @ptrFromInt(buf);
         dst[0] = ':';
         dst[1] = ':';
@@ -323,6 +327,7 @@ pub fn ns_full_name(ns_addr: u32) struct { ptr: u32, len: u32 } {
         break :blk parent_full.len + 2 + ns.name_len;
     };
     const buf = alloc(total);
+    if (buf == 0) return .{ .ptr = 0, .len = 0 };
     const dst: [*]u8 = @ptrFromInt(buf);
     var off: u32 = 0;
     if (parent_full.len == 2) {
@@ -822,6 +827,7 @@ pub fn ns_var_create(ns_addr: u32, name_ptr: u32, name_len: u32) u32 {
     const bucket = ns.var_table.insert_header(name_ptr, name_len, hash);
 
     const var_addr = alloc(VAR_SIZE);
+    if (var_addr == 0) return 0;
     const v: *Var = @ptrFromInt(var_addr);
     v.flags = VAR_IN_HASHTABLE | VAR_NAMESPACE_VAR;
     v.value = 0;
@@ -964,10 +970,12 @@ pub fn ns_export(ns_addr: u32, pattern_ptr: u32, pattern_len: u32) void {
     // bump allocator can't free, but namespace export lists are
     // tiny so the leakage is bounded.
     const new_buf = alloc(new_count * 8);
+    if (new_buf == 0) return;
     if (old_count > 0) {
         memcpy(new_buf, ns.export_patterns, old_count * 8);
     }
     const pat_copy = alloc(pattern_len);
+    if (pat_copy == 0) return;
     memcpy(pat_copy, pattern_ptr, pattern_len);
     write_i32(new_buf + old_count * 8, @bitCast(pat_copy));
     write_i32(new_buf + old_count * 8 + 4, @bitCast(pattern_len));
@@ -1057,6 +1065,11 @@ pub fn ns_set_path(ns_addr: u32, targets_buf: u32, targets_count: u32) void {
         return;
     }
     const buf = alloc(nonzero_count * PATH_ENTRY_SIZE);
+    if (buf == 0) {
+        ns.path_array = 0;
+        ns.path_len = 0;
+        return;
+    }
     var slot: u32 = 0;
     var j: u32 = 0;
     while (j < targets_count) : (j += 1) {
@@ -1185,15 +1198,18 @@ pub const ImportRef = extern struct {
 fn alloc_import_redirect(name_ptr: u32, name_len: u32, source_cmd: u32) u32 {
     const c = tcl_procs_constants;
     const cmd = alloc(c.COMMAND_SIZE);
+    if (cmd == 0) return 0;
     const slice: [*]u8 = @ptrFromInt(cmd);
     @memset(slice[0..c.COMMAND_SIZE], 0);
     const nbuf = alloc(name_len);
+    if (nbuf == 0) return 0;
     if (name_len > 0) memcpy(nbuf, name_ptr, name_len);
     write_i32(cmd, @bitCast(nbuf));
     write_i32(cmd + 4, @bitCast(name_len));
     write_i32(cmd + c.OFF_FLAGS, @bitCast(c.CMD_IMPORTED));
 
     const desc = alloc(@sizeOf(ImportedCmdData));
+    if (desc == 0) return 0;
     const d: *ImportedCmdData = @ptrFromInt(desc);
     d.real_cmd = source_cmd;
     d.self_cmd = cmd;
@@ -1297,6 +1313,7 @@ pub fn link_import_ref(source_cmd: u32, redirect: u32) void {
     const c = tcl_procs_constants;
     const prev_head: u32 = @bitCast(read_i32(source_cmd + c.OFF_IMPORT_REF_HEAD));
     const node = alloc(@sizeOf(ImportRef));
+    if (node == 0) return;
     const r: *ImportRef = @ptrFromInt(node);
     r.imported_cmd = redirect;
     r.next = prev_head;

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1885,6 +1885,10 @@ fn raise_expected_integer(o: i32) void {
     else
         @intCast(prefix.len + open_quote.len + s.len + close_quote.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) {
+        // OOM building the diagnostic — bail without raising further.
+        return;
+    }
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |c| {
@@ -1913,7 +1917,13 @@ fn raise_expected_integer(o: i32) void {
             off += 1;
         }
     }
-    const msg = obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    // ``obj_new_string_take`` (not the borrow-form ``obj_new_string``)
+    // transfers ownership of ``buf_addr`` to the resulting TclObj so
+    // the slab is reclaimed when the error message is released.  The
+    // old borrow form left ``OBJ_STR_CAP = 0`` and the buffer slab
+    // leaked permanently — one ``total``-byte slab per
+    // ``expected integer`` diagnostic.
+    const msg = obj.obj_new_string_take(buf_addr, @intCast(off), total);
     const tcl_catch = @import("tcl_catch.zig");
     tcl_catch.tcl_cmd_error(msg);
     // Tcl 9 adds a ``(reading increment)`` frame between the

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -390,8 +390,17 @@ pub export fn proc_register(name: i32, params_obj: i32, body_obj: i32) i32 {
     // Clear any CMD_IMPORTED bit — defining a proc with the same
     // simple name shadows an import in this ns (matches C Tcl).
     write_i32(cmd + OFF_FLAGS, 0);
+    // Re-registration over an existing slot must release the
+    // prior ``params_obj``/``body_obj`` retains before overwriting,
+    // or each ``proc foo …; proc foo …`` cycle leaks two TclObjs.
+    // First-registration paths land here with both slots at 0; the
+    // null-safe ``tcl_obj_release`` handles that without a branch.
+    const prev_params: i32 = read_i32(cmd + OFF_PARAMS_OBJ);
+    const prev_body: i32 = read_i32(cmd + OFF_BODY_OBJ);
     write_i32(cmd + OFF_PARAMS_OBJ, owned_params);
     write_i32(cmd + OFF_BODY_OBJ, owned_body);
+    if (prev_params != 0 and prev_params != owned_params) obj.tcl_obj_release(prev_params);
+    if (prev_body != 0 and prev_body != owned_body) obj.tcl_obj_release(prev_body);
     write_i32(cmd + OFF_N_PARAMS, @intCast(n_params));
     write_i32(cmd + OFF_FUNC_IDX, 0);
     write_i32(cmd + OFF_ARGS_TAIL, 0);
@@ -637,10 +646,14 @@ pub export fn proc_set_body_source(name: i32, body_obj: i32) i32 {
     // (so a self-set with the same handle stays alive), then release
     // the old slot — the order makes a same-obj rebind a net no-op
     // refcount change rather than a transient drop-to-zero.
+    //
+    // Gate both the retain AND release on the inequality so a
+    // same-handle re-stamp doesn't leak +1 (the retain would have
+    // fired unconditionally while the release was suppressed).
     const prev: i32 = read_i32(cmd + OFF_BODY_OBJ);
-    obj.tcl_obj_retain(body_obj);
+    if (body_obj != prev) obj.tcl_obj_retain(body_obj);
     write_i32(cmd + OFF_BODY_OBJ, body_obj);
-    if (prev != 0) obj.tcl_obj_release(prev);
+    if (prev != 0 and prev != body_obj) obj.tcl_obj_release(prev);
     return obj_new_int(0);
 }
 

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -475,6 +475,25 @@ pub fn register_builtin_masked(name_ptr: u32, name_len: u32) void {
 pub fn unregister_command(name_ptr: u32, name_len: u32) bool {
     const ctx = resolve_for_register(name_ptr, name_len);
     if (ctx.existing == 0) return false;
+    // Release any retained ``params_obj`` / ``body_obj`` slots
+    // before clearing the table entry — every ``rename foo {}``
+    // (and every inverse-rename through here) used to leak the
+    // proc's params + body retains.
+    const cmd = ctx.existing;
+    const flags: u32 = @bitCast(read_i32(cmd + OFF_FLAGS));
+    // Only release for plain interpreted procs — imports / aliases /
+    // hidden child Interp pointers stash other things in PARAMS_OBJ
+    // / BODY_OBJ that aren't TclObj refs.
+    const is_special = (flags & (CMD_IMPORTED | CMD_ALIAS | CMD_INTERP_CHILD |
+        CMD_COROUTINE | CMD_BUILTIN_FORWARD | CMD_BUILTIN_MASKED | CMD_ENSEMBLE)) != 0;
+    if (!is_special) {
+        const prev_params: i32 = read_i32(cmd + OFF_PARAMS_OBJ);
+        const prev_body: i32 = read_i32(cmd + OFF_BODY_OBJ);
+        if (prev_params != 0) obj.tcl_obj_release(prev_params);
+        if (prev_body != 0) obj.tcl_obj_release(prev_body);
+        write_i32(cmd + OFF_PARAMS_OBJ, 0);
+        write_i32(cmd + OFF_BODY_OBJ, 0);
+    }
     _ = tcl_ns.ns_cmd_clear(ctx.r.target_ns, ctx.r.simple_ptr, ctx.r.simple_len);
     lru_invalidate_all();
     return true;

--- a/runtime/zig/interp/tcl_xlinks.zig
+++ b/runtime/zig/interp/tcl_xlinks.zig
@@ -222,11 +222,12 @@ pub fn install(
     const hash = fnv1a(sn.ptr, sn.len);
     if (dir_find(local_interp, sn.ptr, sn.len, hash)) |bucket| {
         // Update existing entry — release old target name, retain
-        // the new one.
+        // the new one.  Gate the retain on inequality so a
+        // same-handle re-stamp doesn't leak +1.
         const th: u32 = @bitCast(read_i32(bucket + OFF_TARGET_HANDLE));
         const old_name = read_i32(th + T_OFF_NAME);
         write_i32(th + T_OFF_INTERP, @bitCast(target_interp));
-        if (target_name != 0) tcl_obj_retain(target_name);
+        if (target_name != 0 and target_name != old_name) tcl_obj_retain(target_name);
         write_i32(th + T_OFF_NAME, target_name);
         if (old_name != 0 and old_name != target_name) tcl_obj_release(old_name);
         return true;

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -724,6 +724,7 @@ pub export fn tcl_cmd_close(chan: i32) i32 {
 fn refill(c: *Channel) u32 {
     if (c.buf_addr == 0) {
         c.buf_addr = obj.alloc(READ_BUF_SIZE);
+        if (c.buf_addr == 0) return 0;
     }
     var carry: u32 = 0;
     if (c.buf_pos < c.buf_end) {
@@ -781,6 +782,7 @@ fn refill_decoded(c: *Channel) u32 {
         // recycler so the slab can be reused without realloc.
         c.dec_cap = 8;
         c.dec_addr = obj.alloc(c.dec_cap);
+        if (c.dec_addr == 0) return 0;
     }
     while (true) {
         if (c.buf_pos >= c.buf_end) {
@@ -856,9 +858,12 @@ const ByteBuf = struct {
 
 fn buf_init(initial: u32) ByteBuf {
     const cap = if (initial < 64) 64 else initial;
+    const addr = obj.alloc(cap);
+    // OOM: clamp cap to 0 so ``buf_push`` / ``buf_grow`` see a
+    // zero-capacity buffer and bail without writing to addr=0.
     return .{
-        .addr = obj.alloc(cap),
-        .cap = cap,
+        .addr = addr,
+        .cap = if (addr == 0) 0 else cap,
         .len = 0,
     };
 }
@@ -1239,6 +1244,7 @@ fn emit_byte(c: *Channel, byte: u8) bool {
     if (c.out_buf_addr == 0) {
         if (c.out_buf_size == 0) c.out_buf_size = WRITE_BUF_SIZE;
         c.out_buf_addr = obj.alloc(c.out_buf_size);
+        if (c.out_buf_addr == 0) return false;
         c.out_buf_pos = 0;
     }
     const dst: [*]u8 = @ptrFromInt(c.out_buf_addr);
@@ -1788,6 +1794,7 @@ pub export fn tcl_cmd_fconfigure(fd: i32, args: i32) i32 {
     // exits below.
     const work_cap: u32 = if (a.len == 0) 1 else a.len;
     const work_buf = obj.alloc(work_cap);
+    if (work_buf == 0) return 0;
     defer obj.free_sized(work_buf, work_cap);
 
     var elem_off: [MAX_FCONFIGURE_WORDS]u32 = undefined;

--- a/runtime/zig/io/tcl_chan.zig
+++ b/runtime/zig/io/tcl_chan.zig
@@ -868,6 +868,13 @@ fn buf_grow(b: *ByteBuf, want: u32) void {
     var new_cap = b.cap * 2;
     while (new_cap < b.len + want) new_cap *= 2;
     const new_addr = obj.alloc(new_cap);
+    if (new_addr == 0) {
+        // OOM growing the buffer — leave the existing buf intact so
+        // ``buf_push`` (and downstream callers) can detect the
+        // capacity didn't grow and bail.  Without this the
+        // ``@ptrFromInt(0)`` write below corrupts low memory.
+        return;
+    }
     const dst: [*]u8 = @ptrFromInt(new_addr);
     const src: [*]const u8 = @ptrFromInt(b.addr);
     for (0..b.len) |i| dst[i] = src[i];
@@ -878,6 +885,9 @@ fn buf_grow(b: *ByteBuf, want: u32) void {
 
 fn buf_push(b: *ByteBuf, byte: u8) void {
     buf_grow(b, 1);
+    // ``buf_grow`` returns silently on OOM; recheck capacity
+    // before writing or we'd ``@ptrFromInt(0)`` into linear memory.
+    if (b.len >= b.cap) return;
     const dst: [*]u8 = @ptrFromInt(b.addr);
     dst[b.len] = byte;
     b.len += 1;
@@ -885,14 +895,15 @@ fn buf_push(b: *ByteBuf, byte: u8) void {
 
 fn buf_finish(b: ByteBuf) i32 {
     if (b.len == 0) {
-        obj.free_sized(b.addr, b.cap);
+        if (b.addr != 0) obj.free_sized(b.addr, b.cap);
         return obj_new_string(0, 0);
     }
-    const out = obj_new_string(@bitCast(b.addr), @bitCast(b.len));
-    if (out != 0) {
-        obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
-    }
-    return out;
+    // Route through ``obj_new_string_take`` so the cap stamp is
+    // size-class-rounded the same way ``alloc``/``free_sized``
+    // expect.  The inline pattern that wrote ``b.cap`` directly
+    // could land a doubled-then-not-rounded cap into the wrong
+    // free-list bucket on release.
+    return obj.obj_new_string_take(b.addr, b.len, b.cap);
 }
 
 // Translate one input byte: with auto/cr/crlf translation, fold
@@ -1434,7 +1445,10 @@ fn set_obj_option(slot: *i32, src_p: [*]const u8, src_len: u32) void {
             // the old value).
             return;
         }
-        obj.tcl_obj_retain(new_obj);
+        // ``obj_new_string_copy`` already returned a fresh +1 — the
+        // slot inherits that ref directly.  A second ``tcl_obj_retain``
+        // bumped rc to 2 and only one release fires at channel close,
+        // permanently leaking every encoding/eofchar/profile value.
         slot.* = new_obj;
     }
     if (old != 0) obj.tcl_obj_release(old);

--- a/runtime/zig/io/tcl_clock.zig
+++ b/runtime/zig/io/tcl_clock.zig
@@ -2120,6 +2120,12 @@ fn raise_clock_error(msg: []const u8, code: []const u8) void {
     const code_obj = obj_new_string_copy(@intCast(@intFromPtr(code.ptr)), @intCast(code.len));
     const tcl_catch = @import("../interp/tcl_catch.zig");
     tcl_catch.tcl_cmd_error_full(msg_obj, 0, code_obj);
+    // ``tcl_cmd_error_full`` retains both handles into the
+    // ``::errorInfo`` / ``::errorCode`` var slots via ``global_set``;
+    // our local +1 share is unconsumed and would otherwise leak one
+    // TclObj header per error.  Release after the stamp.
+    obj.tcl_obj_release(msg_obj);
+    obj.tcl_obj_release(code_obj);
 }
 
 /// clock_scan_format — strftime-driven scan.  Returns a TclObj integer

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -211,7 +211,12 @@ fn path_cstr(path: i32) [*:0]const u8 {
 // No call site preserves the stat buffer beyond a single command
 // invocation, so a single shared buffer is safe and eliminates the
 // permanent ~160-byte leak per ``file exists`` / ``file stat``.
-var stat_buf_static: [STAT_SIZE]u8 = undefined;
+//
+// 8-byte alignment is mandatory: the stat fields include ``i64``
+// time/size values that ``stat_size`` reads via ``*i64`` deref.
+// A bare ``[STAT_SIZE]u8`` lands at byte-1 alignment and Debug
+// builds trap with ``incorrectAlignment``.
+var stat_buf_static: [STAT_SIZE]u8 align(8) = undefined;
 
 /// Run ``stat(2)`` on *path*.  Returns the static-buffer address
 /// of the filled struct, or 0 if the call failed (path doesn't

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -179,6 +179,13 @@ const S_IFIFO: u32 = 0o010000;
 // clobber the first when materialising the second.  The bump
 // allocator can't free so a per-call alloc would leak the bytes
 // permanently.
+//
+// PATH_BUF_CAP is sized to match WASI's path-length ceiling (most
+// hosts cap at 4096); inputs longer than ``PATH_BUF_CAP - 1`` are
+// rejected by emptying the buffer rather than silently truncated —
+// truncation would let ``file delete /very/long/path`` operate on a
+// different (shorter) path with destructive results (Codex P2 on
+// PR #453).
 const PATH_BUF_CAP: u32 = 4096;
 var path_buf_a: [PATH_BUF_CAP]u8 = undefined;
 var path_buf_b: [PATH_BUF_CAP]u8 = undefined;
@@ -190,12 +197,23 @@ var path_buf_toggle: u32 = 0;
 /// caller (``rename old new``) can hold two valid path C-strings
 /// at once; a third concurrent call within the same statement
 /// would alias the first slot — none exist today.
+///
+/// Paths whose byte length is ``PATH_BUF_CAP - 1`` or more land at
+/// an empty NUL buffer so the receiving syscall fails with ENOENT
+/// (or the equivalent ``open``/``stat`` error).  Failing loudly is
+/// safer than silently truncating to a shorter pathname.
 fn path_cstr(path: i32) [*:0]const u8 {
     const s = obj_ensure_string(path);
     const buf: *[PATH_BUF_CAP]u8 = if (path_buf_toggle == 0) &path_buf_a else &path_buf_b;
     path_buf_toggle ^= 1;
-    var copy_len: u32 = s.len;
-    if (copy_len >= PATH_BUF_CAP) copy_len = PATH_BUF_CAP - 1;
+    // Reject overlong paths — empty C-string lets every wasi-libc
+    // path syscall surface a clean failure instead of operating on
+    // a silently-shortened name.
+    if (s.len >= PATH_BUF_CAP) {
+        buf[0] = 0;
+        return @ptrCast(buf);
+    }
+    const copy_len: u32 = s.len;
     if (copy_len > 0) {
         const src: [*]const u8 = @ptrFromInt(s.ptr);
         for (0..copy_len) |i| buf[i] = src[i];
@@ -312,10 +330,11 @@ pub export fn tcl_cmd_source(path: i32) i32 {
         return 0;
     }
     const size_i64 = stat_size(stat_buf);
-    // Free the stat scratch buffer immediately — repeated sources of
-    // a missing file used to leak STAT_SIZE bytes per call.  After
-    // this point ``stat_buf`` must not be dereferenced.
-    obj.free_sized(stat_buf, STAT_SIZE);
+    // ``stat_buf`` is a static shared buffer (see ``stat_buf_static``
+    // in this file) — it must NOT be returned to the allocator.  An
+    // earlier revision routed it through ``obj.free_sized``, which
+    // would have corrupted the size-class free-list with a non-
+    // allocator address (Codex review on PR #453).
     if (size_i64 < 0 or size_i64 > 64 * 1024 * 1024) {
         stubs.raise("source: file size out of range");
         return 0;

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -173,27 +173,52 @@ const S_IFDIR: u32 = 0o040000;
 const S_IFCHR: u32 = 0o020000;
 const S_IFIFO: u32 = 0o010000;
 
-/// Copy *path*'s bytes onto the bump allocator with a trailing
+// Static 2-slot toggle for ``path_cstr`` — mirrors the pattern in
+// ``io/tcl_chan.zig``.  Two slots so a caller that needs both a
+// source and destination path (``rename`` / ``copy``) doesn't
+// clobber the first when materialising the second.  The bump
+// allocator can't free so a per-call alloc would leak the bytes
+// permanently.
+const PATH_BUF_CAP: u32 = 4096;
+var path_buf_a: [PATH_BUF_CAP]u8 = undefined;
+var path_buf_b: [PATH_BUF_CAP]u8 = undefined;
+var path_buf_toggle: u32 = 0;
+
+/// Copy *path*'s bytes into a static toggle slot with a trailing
 /// NUL so it can be passed to wasi-libc APIs that expect
-/// C-strings.
+/// C-strings.  Each call alternates between two slots so a single
+/// caller (``rename old new``) can hold two valid path C-strings
+/// at once; a third concurrent call within the same statement
+/// would alias the first slot — none exist today.
 fn path_cstr(path: i32) [*:0]const u8 {
     const s = obj_ensure_string(path);
-    const buf_addr = obj.alloc(s.len + 1);
-    const out: [*]u8 = @ptrFromInt(buf_addr);
-    if (s.len > 0) {
+    const buf: *[PATH_BUF_CAP]u8 = if (path_buf_toggle == 0) &path_buf_a else &path_buf_b;
+    path_buf_toggle ^= 1;
+    var copy_len: u32 = s.len;
+    if (copy_len >= PATH_BUF_CAP) copy_len = PATH_BUF_CAP - 1;
+    if (copy_len > 0) {
         const src: [*]const u8 = @ptrFromInt(s.ptr);
-        for (0..s.len) |i| out[i] = src[i];
+        for (0..copy_len) |i| buf[i] = src[i];
     }
-    out[s.len] = 0;
-    return @ptrCast(out);
+    buf[copy_len] = 0;
+    return @ptrCast(buf);
 }
 
-/// Run ``stat(2)`` on *path*.  Returns the bump-allocator address
+// Static buffer for stat results — stat_path / lstat_path return
+// the address of this buffer.  Callers read the fields then either
+// use the address-stable shape (followed by another stat call which
+// overwrites the buffer) or copy the fields into a Tcl-side result.
+// No call site preserves the stat buffer beyond a single command
+// invocation, so a single shared buffer is safe and eliminates the
+// permanent ~160-byte leak per ``file exists`` / ``file stat``.
+var stat_buf_static: [STAT_SIZE]u8 = undefined;
+
+/// Run ``stat(2)`` on *path*.  Returns the static-buffer address
 /// of the filled struct, or 0 if the call failed (path doesn't
 /// exist, not accessible, etc.).
 fn stat_path(path: i32) u32 {
-    const buf_addr = obj.alloc(STAT_SIZE);
-    const buf: *anyopaque = @ptrFromInt(buf_addr);
+    const buf_addr: u32 = @intFromPtr(&stat_buf_static);
+    const buf: *anyopaque = @ptrCast(&stat_buf_static);
     const rc = stat(path_cstr(path), buf);
     if (rc != 0) return 0;
     return buf_addr;
@@ -202,8 +227,8 @@ fn stat_path(path: i32) u32 {
 /// Same as :func:`stat_path` but uses ``lstat(2)`` — does not
 /// follow symbolic links on the final path component.
 fn lstat_path(path: i32) u32 {
-    const buf_addr = obj.alloc(STAT_SIZE);
-    const buf: *anyopaque = @ptrFromInt(buf_addr);
+    const buf_addr: u32 = @intFromPtr(&stat_buf_static);
+    const buf: *anyopaque = @ptrCast(&stat_buf_static);
     const rc = lstat(path_cstr(path), buf);
     if (rc != 0) return 0;
     return buf_addr;

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -925,6 +925,16 @@ fn file_copy(src: i32, dst: i32) i32 {
     // memory for tcltest-scale files.
     const buf_size: u32 = 8 * 1024;
     const buf_addr = obj.alloc(buf_size);
+    // OOM: alloc raised ``oom_flag``.  Close the FDs and bail before
+    // ``@ptrFromInt(0)`` panics; the partial destination file is
+    // intentionally left in place — matching the I/O-error path
+    // below which also doesn't unlink dst.
+    if (buf_addr == 0) {
+        _ = close(in_fd);
+        _ = close(out_fd);
+        stubs.raise("file copy: out of memory allocating transfer buffer");
+        return 0;
+    }
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var ok = true;
     while (true) {
@@ -1198,6 +1208,11 @@ fn pattern_has_meta(pattern: []const u8) bool {
 fn unescape_pattern(pattern: []const u8) []const u8 {
     if (pattern.len == 0) return pattern;
     const buf_addr = obj.alloc(@intCast(pattern.len));
+    // OOM: alloc raised ``oom_flag``.  Return an empty slice so the
+    // caller's subsequent ``cstr_from_bytes`` + ``access`` probe
+    // resolves to the empty path (which doesn't exist) and the glob
+    // reports no matches.  Avoids ``@ptrFromInt(0)`` on the next line.
+    if (buf_addr == 0) return pattern[0..0];
     const out: [*]u8 = @ptrFromInt(buf_addr);
     var src: usize = 0;
     var dst: usize = 0;
@@ -1225,11 +1240,23 @@ fn split_dir_basename(pattern: []const u8) struct { dir_len: u32, base_off: u32 
     return .{ .dir_len = i, .base_off = i };
 }
 
+/// Static fallback used when :func:`cstr_from_bytes` hits OOM.  The
+/// data-segment ``""`` literal has a fixed address Zig guarantees is
+/// non-null, so callers can ``@ptrFromInt`` safely; they will then
+/// see "no match" / "doesn't exist" against the empty path, which is
+/// the desired graceful-degrade behaviour under allocator failure.
+const EMPTY_CSTR: [*:0]const u8 = "";
+
 /// Build a NUL-terminated bump-allocator copy of *src*.  Mirrors
 /// :func:`path_cstr` but takes raw bytes so callers can pass a
 /// dir-prefix slice carved out of the pattern.
 fn cstr_from_bytes(src: []const u8) [*:0]const u8 {
     const buf_addr = obj.alloc(@intCast(src.len + 1));
+    // OOM: alloc raised ``oom_flag``; fall back to an empty cstring
+    // so callers don't ``@ptrFromInt(0)`` and panic.  The empty path
+    // will then fail ``access`` / ``opendir`` cleanly and the caller
+    // returns "no matches".
+    if (buf_addr == 0) return EMPTY_CSTR;
     const out: [*]u8 = @ptrFromInt(buf_addr);
     for (src, 0..) |c, i| out[i] = c;
     out[src.len] = 0;
@@ -1314,6 +1341,17 @@ pub fn tcl_cmd_glob(pattern: i32) i32 {
         // Glue the dir prefix back onto the matched basename.
         const out_len: u32 = split.dir_len + nlen;
         const out_buf = obj.alloc(out_len);
+        // OOM: bail out of the readdir loop early.  ``acc`` already
+        // contains any matches found before the allocator failed, so
+        // returning it gives the caller a (possibly truncated) view
+        // of the glob — better than synthesising a Tcl error from a
+        // generic command that's expected to be non-fatal under
+        // ``-nocomplain``.  ``oom_flag`` is set; the interp boundary
+        // will surface it.
+        if (out_buf == 0 and out_len != 0) {
+            _ = closedir(dir_handle.?);
+            return acc;
+        }
         const out: [*]u8 = @ptrFromInt(out_buf);
         if (split.dir_len > 0) {
             for (0..split.dir_len) |i| out[i] = dir_bytes[i];

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -609,11 +609,12 @@ fn file_join(a: i32, b: i32) i32 {
     while (a_end > 0 and ap[a_end - 1] == '/') : (a_end -= 1) {}
     const total: u32 = a_end + 1 + bs.len;
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) return obj.obj_new_string(0, 0);
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (0..a_end) |i| buf[i] = ap[i];
     buf[a_end] = '/';
     for (0..bs.len) |i| buf[a_end + 1 + i] = bp[i];
-    return obj.obj_new_string(@bitCast(buf_addr), @bitCast(total));
+    return obj.obj_new_string_take(buf_addr, total, total);
 }
 
 fn file_dirname(a: i32) i32 {
@@ -1009,13 +1010,14 @@ fn file_readlink(path: i32) i32 {
     // preopen-relative resolution).
     const buf_size: usize = 4096;
     const buf_addr = obj.alloc(buf_size);
+    if (buf_addr == 0) return obj.obj_new_string(0, 0);
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     const n = readlink(path_cstr(path), buf, buf_size);
     if (n < 0) {
         stubs.raise("file readlink: path is not a symlink or is inaccessible");
         return 0;
     }
-    return obj.obj_new_string(@bitCast(buf_addr), @bitCast(n));
+    return obj.obj_new_string_take(buf_addr, @intCast(n), @intCast(buf_size));
 }
 
 // --- glob ---

--- a/runtime/zig/sched/tcl_coro.zig
+++ b/runtime/zig/sched/tcl_coro.zig
@@ -254,6 +254,17 @@ pub fn create(name_ptr: u32, name_len: u32, body_obj: i32) ?*Coro {
     // Heap-copy the name so the coroutine survives the caller's
     // word release.
     const nbuf = obj.alloc(name_len);
+    // OOM: alloc raised ``oom_flag``.  Surface ``null`` to the
+    // caller so the coroutine isn't half-registered.  Release the
+    // body retain taken above (otherwise the caller has no handle
+    // to balance it) and mark the freshly-allocated slot FREE so
+    // a future ``alloc_slot`` reclaims it instead of leaking the
+    // table entry.
+    if (nbuf == 0 and name_len != 0) {
+        tcl_obj_release(body_obj);
+        c.state = .FREE;
+        return null;
+    }
     if (name_len > 0) obj.memcpy(nbuf, name_ptr, name_len);
     c.name_ptr = nbuf;
     c.name_len = name_len;
@@ -290,6 +301,16 @@ pub fn record_registration(c: *Coro, ns_addr: u32, simple_ptr: u32, simple_len: 
     c.ns_addr = ns_addr;
     if (simple_len > 0) {
         const buf = obj.alloc(simple_len);
+        // OOM: alloc raised ``oom_flag``.  Leave ``cmd_simple_ptr``
+        // unset (zero) and ``cmd_simple_len`` zero so the cleanup
+        // path's ``simple_len != 0`` gate skips the ``ns_cmd_clear``
+        // — without that gate ``ns_cmd_clear`` would dereference a
+        // null pointer when the coro terminates.
+        if (buf == 0) {
+            c.cmd_simple_ptr = 0;
+            c.cmd_simple_len = 0;
+            return;
+        }
         obj.memcpy(buf, simple_ptr, simple_len);
         c.cmd_simple_ptr = buf;
     } else {
@@ -385,6 +406,13 @@ pub export fn tcl_coro_drive(coro_addr: i32) i32 {
     const is_resume = c.state == .SUSPENDED;
     if (c.state == .PENDING) {
         c.async_buf = obj.alloc(tcl_async.DEFAULT_BUFFER_SIZE);
+        // OOM: alloc raised ``oom_flag``.  Without an async buffer
+        // the asyncify rewind / unwind machinery cannot run, so
+        // surface 0 (the body never executes a single bytecode);
+        // the OOM is on the interp's error path and the caller's
+        // catch / next-boundary check sees it.  Avoids
+        // ``init_buffer`` writing through a null pointer.
+        if (c.async_buf == 0) return 0;
         c.async_buf_size = tcl_async.DEFAULT_BUFFER_SIZE;
         tcl_async.init_buffer(c.async_buf, c.async_buf_size);
     }

--- a/runtime/zig/sched/tcl_coro.zig
+++ b/runtime/zig/sched/tcl_coro.zig
@@ -624,9 +624,14 @@ pub fn resume_one(c: *Coro) i32 {
 /// the saved call site and re-fires the unwind (issue #282).
 pub fn signal_yield(value: i32) bool {
     if (g_call_depth == 0) return false;
-    if (value != 0) tcl_obj_retain(value);
+    // Same-handle re-stamp must be a net no-op on rc, and the prior
+    // ``yield_value`` (if any) must be released so successive yields
+    // without a caller-side consume don't leak.
+    const prev = tcl_catch.state.yield_value;
+    if (value != 0 and value != prev) tcl_obj_retain(value);
     tcl_catch.state.yield_flag = 1;
     tcl_catch.state.yield_value = value;
+    if (prev != 0 and prev != value) tcl_obj_release(prev);
     if (tcl_async.ENABLED) {
         if (current_coro()) |c| {
             tcl_async.coro_yield_unwind(c.async_buf);

--- a/runtime/zig/sched/tcl_sched.zig
+++ b/runtime/zig/sched/tcl_sched.zig
@@ -231,6 +231,7 @@ pub fn info_all() i32 {
     }
     if (total == 0) return obj_new_string(0, 0);
     const buf = obj.alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var off: u32 = 0;
     i = 0;
@@ -247,7 +248,7 @@ pub fn info_all() i32 {
         off += 1;
     }
     if (off > 0) off -= 1; // strip trailing space
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, total);
 }
 
 fn write_id(dst: [*]u8, off_in: u32, id: u32) u32 {
@@ -305,6 +306,7 @@ fn build_info_pair(script_obj: i32, kind: []const u8) i32 {
     // and ``kind.len`` for the trailing word.
     const cap: u32 = s.len * 2 + 8 + 1 + @as(u32, @intCast(kind.len));
     const buf = obj.alloc(cap);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     off = obj.list_elem_quote(buf, off, s.ptr, s.len);
     const dst: [*]u8 = @ptrFromInt(buf);
@@ -314,7 +316,7 @@ fn build_info_pair(script_obj: i32, kind: []const u8) i32 {
         dst[off] = c;
         off += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, cap);
 }
 
 // -- Dispatch -----------------------------------------------------------------

--- a/runtime/zig/stubs/tcl_env_stubs.zig
+++ b/runtime/zig/stubs/tcl_env_stubs.zig
@@ -74,9 +74,10 @@ pub export fn tcl_cmd_package_cmd(sub: i32, arg: i32) i32 {
         }
         if (match) {
             const buf = obj.alloc(1);
+            if (buf == 0) return obj.obj_new_string(0, 0);
             const d: [*]u8 = @ptrFromInt(buf);
             d[0] = '1';
-            return obj.obj_new_string(@bitCast(buf), 1);
+            return obj.obj_new_string_take(buf, 1, 1);
         }
     }
     return obj.obj_new_string(0, 0);

--- a/runtime/zig/stubs/tcl_env_stubs.zig
+++ b/runtime/zig/stubs/tcl_env_stubs.zig
@@ -95,6 +95,7 @@ pub export fn tcl_cmd_interp_cmd(sub: i32, arg: i32) i32 {
 
 pub export fn tcl_cmd_apply(lambda: i32, args: i32) i32 {
     const rt = @import("../tcl_runtime.zig");
+    const obj_mod = @import("../valtypes/tcl_obj.zig");
     const interp = @import("../interp/tcl_interp.zig");
 
     // Unpack the args list into individual TclObj handles.
@@ -105,8 +106,14 @@ pub export fn tcl_cmd_apply(lambda: i32, args: i32) i32 {
         0;
 
     // Build words slice: words[0]=dummy, words[1]=lambda, words[2..]=args.
+    // Track every fresh TclObj we allocate so the function exit can
+    // release them — without this each ``apply`` call leaked one
+    // placeholder + N per-arg TclObjs plus the ``words_buf`` slab.
     const n_words: u32 = 2 + n_args;
-    const words_buf: u32 = rt.alloc(n_words * 4);
+    const words_buf_size: u32 = n_words * 4;
+    const words_buf: u32 = rt.alloc(words_buf_size);
+    if (words_buf == 0) return 0;
+    defer obj_mod.free_sized(words_buf, words_buf_size);
     const words_ptr: [*]i32 = @ptrFromInt(words_buf);
     words_ptr[0] = rt.obj_new_string(0, 0); // placeholder for "apply" name
     words_ptr[1] = lambda;
@@ -116,11 +123,23 @@ pub export fn tcl_cmd_apply(lambda: i32, args: i32) i32 {
         const elem_obj = if (elem.braced)
             rt.obj_new_string_copy(args_s.ptr + elem.start, elem.len)
         else blk: {
-            const buf = rt.alloc(elem.len + 4);
+            const buf_size: u32 = elem.len + 4;
+            const buf = rt.alloc(buf_size);
+            if (buf == 0) break :blk rt.obj_new_string(0, 0);
             const out_len = rt.copy_unbraced_elem(buf, args_s.ptr + elem.start, elem.len);
-            break :blk rt.obj_new_string(@bitCast(buf), @bitCast(out_len));
+            break :blk rt.obj_new_string_take(buf, out_len, buf_size);
         };
         words_ptr[2 + ai] = elem_obj;
     }
-    return interp.eval_apply(words_ptr[0..n_words]);
+    const result = interp.eval_apply(words_ptr[0..n_words]);
+    // Release the placeholder (slot 0) and every per-arg elem_obj
+    // we allocated (slots 2..).  ``eval_apply`` reads but does not
+    // consume the words, so the +1s are still on us.  Slot 1
+    // (``lambda``) is the caller's BORROWED handle — do not release.
+    obj_mod.tcl_obj_release(words_ptr[0]);
+    ai = 0;
+    while (ai < n_args) : (ai += 1) {
+        obj_mod.tcl_obj_release(words_ptr[2 + ai]);
+    }
+    return result;
 }

--- a/runtime/zig/stubs/tcl_stubs.zig
+++ b/runtime/zig/stubs/tcl_stubs.zig
@@ -30,6 +30,13 @@ pub fn unsupported(name: []const u8) void {
     const prefix: []const u8 = "unsupported command: ";
     const total: u32 = @intCast(prefix.len + name.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) {
+        // OOM building the diagnostic — surface a literal-only
+        // error so a hostile script that triggered the allocation
+        // failure can't pivot to writing through ``@ptrFromInt(0)``.
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (prefix, 0..) |c, i| buf[i] = c;
     for (name, 0..) |c, i| buf[prefix.len + i] = c;
@@ -53,6 +60,10 @@ pub fn unsupported(name: []const u8) void {
 pub fn raise(msg: []const u8) void {
     const alloc_size: u32 = @intCast(msg.len);
     const buf_addr: u32 = obj.alloc(alloc_size);
+    if (buf_addr == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     for (msg, 0..) |c, i| buf[i] = c;
     // Issue #317: see ``unsupported`` above.
@@ -69,6 +80,10 @@ pub fn unsupported_sub(cmd: []const u8, sub: []const u8) void {
     const sep: []const u8 = " ";
     const total: u32 = @intCast(prefix.len + cmd.len + sep.len + sub.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |c| {

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -869,7 +869,13 @@ pub export fn tcl_test_interp_eval_script(
     script_len: i32,
 ) i32 {
     const save = tcl_interp_registry.enter(@bitCast(target_interp));
-    const res = interp.tcl_eval(tcl_obj.obj_new_string(script_ptr, script_len));
+    // Capture the script TclObj so we can release it after tcl_eval
+    // returns — the prior single-expression form leaked one TclObj
+    // header per test invocation (every cross-interp ``eval`` test
+    // in the harness).
+    const script_obj = tcl_obj.obj_new_string(script_ptr, script_len);
+    const res = interp.tcl_eval(script_obj);
+    tcl_obj.tcl_obj_release(script_obj);
     tcl_interp_registry.leave(save);
     return res;
 }

--- a/runtime/zig/tcl_runtime.zig
+++ b/runtime/zig/tcl_runtime.zig
@@ -741,7 +741,12 @@ pub export fn tcl_test_hidden_exists(name_ptr: i32, name_len: i32) i32 {
 pub export fn tcl_test_info_commands(pattern_ptr: i32, pattern_len: i32) i32 {
     if (pattern_len == 0) return tcl_cmd_info.info_commands(0);
     const pat = tcl_obj.obj_new_string(pattern_ptr, pattern_len);
-    return tcl_cmd_info.info_commands(pat);
+    const result = tcl_cmd_info.info_commands(pat);
+    // ``info_commands`` reads the pattern's bytes but doesn't take
+    // ownership — release the +1 here so this test export doesn't
+    // leak one TclObj per call.
+    tcl_obj.tcl_obj_release(pat);
+    return result;
 }
 
 /// Run ``info procs pattern``.  Same shape as
@@ -749,7 +754,9 @@ pub export fn tcl_test_info_commands(pattern_ptr: i32, pattern_len: i32) i32 {
 pub export fn tcl_test_info_procs(pattern_ptr: i32, pattern_len: i32) i32 {
     if (pattern_len == 0) return tcl_cmd_info.info_procs(0);
     const pat = tcl_obj.obj_new_string(pattern_ptr, pattern_len);
-    return tcl_cmd_info.info_procs(pat);
+    const result = tcl_cmd_info.info_procs(pat);
+    tcl_obj.tcl_obj_release(pat);
+    return result;
 }
 
 /// Probe ``namespace which -command name`` without routing through

--- a/runtime/zig/tcltest/cmd_misc.zig
+++ b/runtime/zig/tcltest/cmd_misc.zig
@@ -194,7 +194,10 @@ fn eval_testdoubledigits(words: []const i32) result_mod.InterpResult {
         .exponential => std.fmt.bufPrint(&buf, "{e:.[1]}", .{ v, precision }) catch "0",
         .fixed => std.fmt.bufPrint(&buf, "{d:.[1]}", .{ v, precision }) catch "0",
     };
-    return result_mod.ok(obj.obj_new_string(@intCast(@intFromPtr(slice.ptr)), @intCast(slice.len)));
+    // Copy the bytes out of the stack buffer — ``obj_new_string`` would
+    // return a TclObj whose ``OBJ_STR_PTR`` aliased ``buf`` and gone
+    // garbage as soon as this function returned.
+    return result_mod.ok(obj.obj_new_string_copy(@intCast(@intFromPtr(slice.ptr)), @intCast(slice.len)));
 }
 
 // -- testlutil ---------------------------------------------------------
@@ -342,7 +345,9 @@ fn eval_testprint(words: []const i32) result_mod.InterpResult {
     var out_buf: [128]u8 = undefined;
     const slice = std.fmt.bufPrint(&out_buf, "{d}", .{v}) catch return err_msg("format error");
     _ = fmt; // we don't honour the format string's prefix/suffix yet
-    return result_mod.ok(obj.obj_new_string(@intCast(@intFromPtr(slice.ptr)), @intCast(slice.len)));
+    // Copy out of the stack buffer — see ``eval_testdoubledigits`` for
+    // the use-after-stack-free rationale.
+    return result_mod.ok(obj.obj_new_string_copy(@intCast(@intFromPtr(slice.ptr)), @intCast(slice.len)));
 }
 
 // -- testparseargs ------------------------------------------------------
@@ -403,7 +408,10 @@ var current_platform_len: u32 = 4;
 
 fn eval_testgetplatform(words: []const i32) result_mod.InterpResult {
     _ = words;
-    return result_mod.ok(obj.obj_new_string(@intCast(@intFromPtr(&current_platform_buf)), @intCast(current_platform_len)));
+    // Copy out of the mutable static — ``testsetplatform`` can
+    // rewrite ``current_platform_buf`` in place, which would
+    // silently mutate a TclObj the caller already holds.
+    return result_mod.ok(obj.obj_new_string_copy(@intCast(@intFromPtr(&current_platform_buf)), @intCast(current_platform_len)));
 }
 
 fn eval_testsetplatform(words: []const i32) result_mod.InterpResult {

--- a/runtime/zig/tcltest/cmd_obj.zig
+++ b/runtime/zig/tcltest/cmd_obj.zig
@@ -182,13 +182,17 @@ fn eval_testintobj(words: []const i32) result_mod.InterpResult {
     if (obj_eq_lit(words[1], "get")) {
         if (words.len != 3) return err_msg("wrong # args: testintobj get varIndex");
         if (check_unset(slot)) |e| return e;
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "get2")) {
         if (words.len != 3) return err_msg("wrong # args: testintobj get2 varIndex");
         if (check_unset(slot)) |e| return e;
+        // ``obj_new_string_copy`` (NOT the borrow form) — the prior
+        // ``obj_new_string`` left ``cap=0`` and pointed at the
+        // slot's bytes.  If the slot is later overwritten the
+        // returned TclObj's str_ptr would dangle (cmd_obj UAF).
         const s = obj.obj_ensure_string(slots.get(slot));
-        return result_mod.ok(obj.obj_new_string(@bitCast(s.ptr), @bitCast(s.len)));
+        return result_mod.ok(obj.obj_new_string_copy(s.ptr, s.len));
     }
     if (obj_eq_lit(words[1], "inttoobigtest")) {
         if (words.len != 3) return err_msg("wrong # args: testintobj inttoobigtest varIndex");
@@ -238,7 +242,7 @@ fn eval_testbooleanobj(words: []const i32) result_mod.InterpResult {
     if (obj_eq_lit(words[1], "get")) {
         if (words.len != 3) return err_msg("wrong # args: testbooleanobj get varIndex");
         if (check_unset(slot)) |e| return e;
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "not")) {
         if (words.len != 3) return err_msg("wrong # args: testbooleanobj not varIndex");
@@ -272,7 +276,7 @@ fn eval_testdoubleobj(words: []const i32) result_mod.InterpResult {
     if (obj_eq_lit(words[1], "get")) {
         if (words.len != 3) return err_msg("wrong # args: testdoubleobj get varIndex");
         if (check_unset(slot)) |e| return e;
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "mult10")) {
         if (words.len != 3) return err_msg("wrong # args: testdoubleobj mult10 varIndex");
@@ -321,7 +325,7 @@ fn eval_testbignumobj(words: []const i32) result_mod.InterpResult {
     if (obj_eq_lit(words[1], "get")) {
         if (words.len != 3) return err_msg("wrong # args: testbignumobj get varIndex");
         if (check_unset(slot)) |e| return e;
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "mult10")) {
         if (words.len != 3) return err_msg("wrong # args: testbignumobj mult10 varIndex");
@@ -448,7 +452,7 @@ fn eval_testlistobj(words: []const i32) result_mod.InterpResult {
     if (obj_eq_lit(words[1], "get")) {
         if (words.len != 3) return err_msg("wrong # args: testlistobj get varIndex");
         if (check_unset(slot)) |e| return e;
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "replace")) {
         // testlistobj replace varIndex start count ?element...?
@@ -559,7 +563,7 @@ fn eval_testobj(words: []const i32) result_mod.InterpResult {
             .err => |e| return e,
         };
         slots.set(dslot, slots.get(sslot));
-        return result_mod.ok(slots.get(dslot));
+        return result_mod.ok(slots.get_owned(dslot));
     }
     if (obj_eq_lit(words[1], "duplicate")) {
         if (words.len != 4) return err_msg("wrong # args: testobj duplicate varIndex destIndex");
@@ -576,10 +580,17 @@ fn eval_testobj(words: []const i32) result_mod.InterpResult {
         };
         // "Duplicate" semantically: build a fresh string-rep obj.  Our
         // tagged-immediate values are already shared-safe; for non-
-        // immediate types we copy the string rep.
+        // immediate types we copy the string rep.  Must use
+        // ``obj_new_string_copy`` so the duplicate owns its bytes;
+        // the prior ``obj_new_string`` borrowed the source slot's
+        // buffer, and clearing the source via ``slots.set`` later
+        // would have left the duplicate with a dangling str_ptr.
         const s = obj.obj_ensure_string(slots.get(sslot));
-        const fresh = obj.obj_new_string(@bitCast(s.ptr), @bitCast(s.len));
+        const fresh = obj.obj_new_string_copy(s.ptr, s.len);
         slots.set(dslot, fresh);
+        // ``slots.set`` retained ``fresh`` for ``dslot``; return our
+        // local +1 to the caller without extra release (this site
+        // owns the share that propagates through eval_script).
         return result_mod.ok(fresh);
     }
     if (obj_eq_lit(words[1], "convert")) {
@@ -593,7 +604,7 @@ fn eval_testobj(words: []const i32) result_mod.InterpResult {
         // Forces materialisation by reading the string rep — that's
         // the closest portable approximation of Tcl_ConvertToType.
         _ = obj.obj_ensure_string(slots.get(slot));
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "refcount") or
         obj_eq_lit(words[1], "invalidateStringRep") or
@@ -636,15 +647,20 @@ fn eval_teststringobj(words: []const i32) result_mod.InterpResult {
 
     if (obj_eq_lit(words[1], "set") or obj_eq_lit(words[1], "set2")) {
         if (words.len != 4) return err_msg("wrong # args: teststringobj set varIndex value");
+        // ``obj_new_string_copy`` materialises an owned buffer so
+        // the slot survives the parser's release of ``words[3]``.
+        // The prior ``obj_new_string`` borrowed ``words[3]``'s
+        // bytes — after the dispatcher's word-release loop ran the
+        // slot held a dangling pointer.
         const s = obj.obj_ensure_string(words[3]);
-        const out = obj.obj_new_string(@bitCast(s.ptr), @bitCast(s.len));
+        const out = obj.obj_new_string_copy(s.ptr, s.len);
         slots.set(slot, out);
         return result_mod.ok(out);
     }
     if (obj_eq_lit(words[1], "get") or obj_eq_lit(words[1], "get2")) {
         if (words.len != 3) return err_msg("wrong # args: teststringobj get varIndex");
         if (check_unset(slot)) |e| return e;
-        return result_mod.ok(slots.get(slot));
+        return result_mod.ok(slots.get_owned(slot));
     }
     if (obj_eq_lit(words[1], "length") or obj_eq_lit(words[1], "length2")) {
         if (words.len != 3) return err_msg("wrong # args: teststringobj length varIndex");

--- a/runtime/zig/tcltest/slots.zig
+++ b/runtime/zig/tcltest/slots.zig
@@ -55,6 +55,19 @@ pub fn get(idx: u32) i32 {
     return slots[idx];
 }
 
+/// Same as :func:`get` but bumps the returned handle's refcount so
+/// the caller can return it through the dispatcher chain without
+/// the eval_script-loop release dropping the slot's own +1.  Mirror
+/// of the ``eval_set`` read-form fix in ``cmds/var.zig`` — every
+/// borrow returned to the dispatcher needs an extra retain so the
+/// caller's release doesn't decrement the storage's live reference.
+pub fn get_owned(idx: u32) i32 {
+    if (idx >= NUM_SLOTS) return 0;
+    const h = slots[idx];
+    if (h != 0) obj.tcl_obj_retain(h);
+    return h;
+}
+
 /// Store *handle* in slot *idx*, retaining the new value and
 /// releasing the prior occupant.  ``handle == 0`` clears the slot.
 pub fn set(idx: u32, handle: i32) void {

--- a/runtime/zig/valtypes/hash_table.zig
+++ b/runtime/zig/valtypes/hash_table.zig
@@ -280,6 +280,10 @@ pub fn Table(comptime bucket_size: u32) type {
                         // Bulk-copy all bucket bytes (header + value)
                         // word-by-word.  ``bucket_size`` is comptime
                         // so this loop is fully unrolled in release.
+                        // The ``name_ptr`` byte buffer is transferred
+                        // verbatim — both old and new bucket share
+                        // the same heap allocation, so we MUST NOT
+                        // free it here (the new bucket still uses it).
                         var k: u32 = 0;
                         while (k < bucket_size) : (k += 4) {
                             write_i32(nb + k, read_i32(base + k));
@@ -290,6 +294,11 @@ pub fn Table(comptime bucket_size: u32) type {
                     idx = (idx + 1) & mask;
                 }
             }
+            // Free the old bucket array backbone — the per-entry
+            // name buffers were transferred to the new buffer above,
+            // so only the table itself needs reclaiming.  Without
+            // this every grow leaked ``old_cap * bucket_size`` bytes.
+            obj.free_sized(old_buf, old_cap * bucket_size);
         }
 
         /// Iterate every populated bucket base in capacity order
@@ -321,12 +330,18 @@ pub fn Table(comptime bucket_size: u32) type {
         pub fn delete_at(self: *Self, base: u32) void {
             const ep: u32 = @bitCast(read_i32(base));
             if (ep == 0 or ep == TOMBSTONE) return;
+            // Free the name buffer that ``try_insert_header`` minted
+            // — the tombstone marker overwrites the pointer, so the
+            // slab would otherwise leak.  Capture the length before
+            // we zero the field below.
+            const el: u32 = @bitCast(read_i32(base + 4));
             write_i32(base, @bitCast(TOMBSTONE));
             // Optional: zero name_len + hash so a stale read sees
             // self-consistent zero rather than partial old data.
             write_i32(base + 4, 0);
             write_i32(base + 8, 0);
             if (self.count > 0) self.count -= 1;
+            if (el > 0) obj.free_sized(ep, el);
         }
     };
 }

--- a/runtime/zig/valtypes/hash_table.zig
+++ b/runtime/zig/valtypes/hash_table.zig
@@ -90,6 +90,15 @@ pub fn Table(comptime bucket_size: u32) type {
             if (self.buf != 0) return;
             self.cap = initial_cap;
             self.buf = alloc(self.cap * bucket_size);
+            // OOM: leave ``buf == 0`` so ``find``/``insert_header`` /
+            // ``each`` continue to treat the table as unallocated and
+            // a subsequent ``init`` retry can succeed.  Clear ``cap``
+            // too to keep the (buf == 0, cap == 0) invariant the rest
+            // of this file relies on.
+            if (self.buf == 0) {
+                self.cap = 0;
+                return;
+            }
             var i: u32 = 0;
             while (i < self.cap) : (i += 1) {
                 write_i32(self.buf + i * bucket_size, 0); // empty marker
@@ -261,6 +270,17 @@ pub fn Table(comptime bucket_size: u32) type {
             const old_cap = self.cap;
             self.cap = old_cap * 2;
             self.buf = alloc(self.cap * bucket_size);
+            // OOM: leave the table in a usable state by restoring the
+            // original buffer.  ``alloc`` already raised ``oom_flag``,
+            // so the caller will see the OOM on the next interpreter
+            // boundary check.  Callers that rely on ``needs_grow`` +
+            // ``grow`` will simply skip the rehash this round and try
+            // again after the OOM clears.
+            if (self.buf == 0) {
+                self.buf = old_buf;
+                self.cap = old_cap;
+                return;
+            }
             self.count = 0;
             var i: u32 = 0;
             while (i < self.cap) : (i += 1) {

--- a/runtime/zig/valtypes/tcl_arith.zig
+++ b/runtime/zig/valtypes/tcl_arith.zig
@@ -338,6 +338,11 @@ pub export fn tcl_math_double(a: i32) i32 {
             const total: u32 = @as(u32, @intCast(prefix.len)) + sa.len +
                 @as(u32, @intCast(suffix.len));
             const buf = obj.alloc(total);
+            // OOM: alloc raised ``oom_flag``.  Surface a 0.0 float
+            // without raising the descriptive diagnostic — the OOM
+            // itself is already on the interp's error path and the
+            // pending error wins.  Avoids ``@ptrFromInt(0)``.
+            if (buf == 0) return obj.obj_new_float(0.0);
             const d: [*]u8 = @ptrFromInt(buf);
             var off: u32 = 0;
             for (prefix) |b| {
@@ -1209,6 +1214,10 @@ fn raise_float_in_bitwise(o: i32, op_sym: []const u8, position: []const u8) void
     const suffix: []const u8 = "\"";
     const total: u32 = @intCast(prefix.len + s.len + middle.len + position.len + between.len + op_sym.len + suffix.len);
     const buf_addr: u32 = obj.alloc(total);
+    // OOM: alloc raised ``oom_flag``; skip the message build (the
+    // OOM is already on the interp's error path) rather than
+    // ``@ptrFromInt(0)`` on the next line.
+    if (buf_addr == 0) return;
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |c| {
@@ -1264,6 +1273,11 @@ fn raise_float_in_unary_bitwise(o: i32, op_sym: []const u8) void {
     const suffix: []const u8 = "\"";
     const total: u32 = @intCast(prefix.len + s.len + middle.len + op_sym.len + suffix.len);
     const buf_addr: u32 = obj.alloc(total);
+    // OOM: alloc raised ``oom_flag``; skip the message build (no
+    // diagnostic gets surfaced this call) so we don't
+    // ``@ptrFromInt(0)`` on the next line.  The pending OOM is
+    // already on the interp's error path.
+    if (buf_addr == 0) return;
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |c| {

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1679,6 +1679,7 @@ pub fn array_top_level_names_matching(pat_ptr: u32, pat_len: u32) i32 {
     if (total == 0) return obj_new_string(0, 0);
 
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var written: u32 = 0;
     i = 0;
@@ -1701,7 +1702,7 @@ pub fn array_top_level_names_matching(pat_ptr: u32, pat_len: u32) i32 {
         off += name_len;
         written += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, total);
 }
 
 pub fn array_dir_names_matching(pat_ptr: u32, pat_len: u32) i32 {
@@ -1730,6 +1731,7 @@ pub fn array_dir_names_matching(pat_ptr: u32, pat_len: u32) i32 {
     if (total == 0) return obj_new_string(0, 0);
 
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var written: u32 = 0;
     i = 0;
@@ -1753,5 +1755,5 @@ pub fn array_dir_names_matching(pat_ptr: u32, pat_len: u32) i32 {
         off += name_len;
         written += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, total);
 }

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -211,6 +211,12 @@ fn dir_init() void {
     if (dir_cap != 0) return;
     dir_cap = DIR_INITIAL_CAP;
     dir_buf = alloc(dir_cap * DIR_BUCKET_SIZE);
+    if (dir_buf == 0) {
+        // OOM — leave the directory uninitialised so callers retry
+        // (dir_cap == 0 is the not-yet-initialised sentinel).
+        dir_cap = 0;
+        return;
+    }
     var i: u32 = 0;
     while (i < dir_cap) : (i += 1) {
         write_i32(dir_buf + i * DIR_BUCKET_SIZE, 0);
@@ -256,6 +262,7 @@ fn dir_find(name_ptr: u32, name_len: u32, hash: u32) ?u32 {
 
 fn dir_insert(name_ptr: u32, name_len: u32, hash: u32, table_ptr: u32) void {
     dir_init();
+    if (dir_buf == 0) return; // dir_init OOM
     if (dir_count * 4 >= dir_cap * 3) dir_grow();
     const mask = dir_cap - 1;
     var idx = hash & mask;
@@ -268,6 +275,7 @@ fn dir_insert(name_ptr: u32, name_len: u32, hash: u32, table_ptr: u32) void {
         // probed via the same chain.
         if (ep == 0 or ep == @as(u32, 0xFFFFFFFF)) {
             const nbuf = alloc(name_len);
+            if (nbuf == 0) return;
             memcpy(nbuf, name_ptr, name_len);
             write_i32(bucket, @bitCast(nbuf));
             write_i32(bucket + 4, @bitCast(name_len));
@@ -285,6 +293,13 @@ fn dir_grow() void {
     const old_cap = dir_cap;
     dir_cap *= 2;
     dir_buf = alloc(dir_cap * DIR_BUCKET_SIZE);
+    if (dir_buf == 0) {
+        // OOM — keep the old directory live so existing entries stay
+        // reachable.  The next insert will retry the grow.
+        dir_buf = old_buf;
+        dir_cap = old_cap;
+        return;
+    }
     var i: u32 = 0;
     while (i < dir_cap) : (i += 1) {
         write_i32(dir_buf + i * DIR_BUCKET_SIZE, 0);
@@ -330,6 +345,7 @@ const AR_TOMBSTONE: i32 = @bitCast(@as(u32, 0xFFFF_FFFF));
 fn ar_new() u32 {
     const cap: u32 = AR_INITIAL_CAP;
     const t = alloc(AR_HEADER_SIZE + cap * AR_BUCKET_SIZE);
+    if (t == 0) return 0;
     write_i32(t, @bitCast(cap));
     write_i32(t + 4, 0);
     var i: u32 = 0;
@@ -445,6 +461,7 @@ fn ar_insert(table: u32, key_ptr: u32, key_len: u32, hash: u32, value: i32) u32 
             // Empty terminator: insert here, or fill the earlier tombstone if any.
             const target = first_tomb orelse bucket;
             const kbuf = alloc(key_len);
+            if (kbuf == 0) return t;
             memcpy(kbuf, key_ptr, key_len);
             write_i32(target, @bitCast(kbuf));
             write_i32(target + 4, @bitCast(key_len));
@@ -484,6 +501,7 @@ fn ar_insert(table: u32, key_ptr: u32, key_len: u32, hash: u32, value: i32) u32 
     // Table was full of tombstones — fall back to the tombstone slot.
     if (first_tomb) |target| {
         const kbuf = alloc(key_len);
+        if (kbuf == 0) return t;
         memcpy(kbuf, key_ptr, key_len);
         write_i32(target, @bitCast(kbuf));
         write_i32(target + 4, @bitCast(key_len));
@@ -499,6 +517,7 @@ fn ar_grow(old_table: u32) u32 {
     const old_cap = ar_cap(old_table);
     const new_cap = old_cap * 2;
     const t = alloc(AR_HEADER_SIZE + new_cap * AR_BUCKET_SIZE);
+    if (t == 0) return old_table;
     write_i32(t, @bitCast(new_cap));
     write_i32(t + 4, 0);
     var i: u32 = 0;

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -299,7 +299,16 @@ fn dir_grow() void {
         const eh: u32 = @bitCast(read_i32(bucket + 8));
         const tp: u32 = @bitCast(read_i32(bucket + 12));
         dir_insert(ep, el, eh, tp);
+        // ``dir_insert`` duplicates the name bytes into a fresh
+        // ``alloc(name_len)`` buffer, so the old per-entry name
+        // buffer is no longer referenced — free it instead of
+        // leaking one slab per live entry per grow.
+        obj.free_sized(ep, el);
     }
+    // Free the old directory buffer itself.  Without this the
+    // grow doubled the directory but left the prior buffer on the
+    // heap forever — ``dir_cap * DIR_BUCKET_SIZE`` bytes per grow.
+    obj.free_sized(old_buf, old_cap * DIR_BUCKET_SIZE);
 }
 
 // --- Per-array table (key → value) -------------------------------------
@@ -508,6 +517,13 @@ fn ar_grow(old_table: u32) u32 {
         const eh: u32 = @bitCast(read_i32(bucket + 8));
         const v: i32 = read_i32(bucket + 12);
         _ = ar_insert(t, ep, el, eh, v);
+        // ``ar_insert`` allocates a fresh key buffer + retains the
+        // value handle.  Free the old key buffer and release the
+        // old retain so the rc accounting nets to "slot transferred,
+        // same total ref count".  Without these, every grow leaked
+        // one key slab + one obj retain per live entry.
+        obj.free_sized(ep, el);
+        if (v != 0) obj.tcl_obj_release(v);
     }
     // Rewrite the directory entries that pointed at old_table.  Since
     // we don't know which directory entry owned it cheaply, walk the
@@ -522,6 +538,11 @@ fn ar_grow(old_table: u32) u32 {
             }
         }
     }
+    // Free the old table itself.  The bucket headers and per-key
+    // slabs are reclaimed above; without this the table backbone
+    // (``AR_HEADER_SIZE + old_cap * AR_BUCKET_SIZE`` bytes) stayed
+    // resident forever after every grow.
+    obj.free_sized(old_table, AR_HEADER_SIZE + old_cap * AR_BUCKET_SIZE);
     return t;
 }
 
@@ -1208,6 +1229,30 @@ pub export fn array_unset(arr: i32) i32 {
     if (dir_buf == 0) return obj_new_int(0);
     const hash = fnv1a(sn.ptr, sn.len);
     if (dir_find(sn.ptr, sn.len, hash)) |bucket| {
+        // Release every value TclObj, free every key buffer, then
+        // free the table backbone before clearing the directory
+        // pointer.  Without this teardown ``array unset arrName``
+        // dropped its sole reference to the entire array without
+        // reclaiming any of the per-element key slabs (one alloc per
+        // ``set arr(K)``), the per-element TclObj values (each had
+        // the bucket's retain), or the table header itself
+        // (``AR_HEADER_SIZE + cap * AR_BUCKET_SIZE`` bytes).
+        const table: u32 = @bitCast(read_i32(bucket + 12));
+        if (table != 0) {
+            const cap = ar_cap(table);
+            var k: u32 = 0;
+            while (k < cap) : (k += 1) {
+                const b = table + AR_HEADER_SIZE + k * AR_BUCKET_SIZE;
+                const raw = read_i32(b);
+                if (raw == 0 or raw == AR_TOMBSTONE) continue;
+                const kp: u32 = @bitCast(raw);
+                const kl: u32 = @bitCast(read_i32(b + 4));
+                const v: i32 = read_i32(b + 12);
+                if (v != 0) obj.tcl_obj_release(v);
+                obj.free_sized(kp, kl);
+            }
+            obj.free_sized(table, AR_HEADER_SIZE + cap * AR_BUCKET_SIZE);
+        }
         // Null out the table pointer so array_exists / find_table
         // treat this array as non-existent.  The directory entry itself
         // stays so the open-addressing chain isn't broken; find_or_create
@@ -1236,13 +1281,19 @@ pub export fn array_unset_element(arr: i32, key: i32) i32 {
         // isn't there does NOT auto-stop).
         array_invalidate_searches_for(arr);
         // MM-B.5: release the value slot's reference before tombstoning.
+        // Also free the per-element key buffer allocated by
+        // ``ar_insert`` — without this every ``unset arr(k)`` leaked
+        // one ``alloc(key_len)`` slab.
         const old: i32 = read_i32(bucket + 12);
+        const kp: u32 = @bitCast(read_i32(bucket));
+        const kl: u32 = @bitCast(read_i32(bucket + 4));
         write_i32(bucket, AR_TOMBSTONE);
         write_i32(bucket + 4, 0);
         write_i32(bucket + 8, 0);
         write_i32(bucket + 12, 0);
         ar_set_count(t, ar_count(t) - 1);
         if (old != 0) obj.tcl_obj_release(old);
+        if (kp != 0 and kl > 0) obj.free_sized(kp, kl);
     }
     // Phase 6: fire UNSET trace AFTER the unset so the callback sees
     // the variable in its final (gone) state.

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -389,7 +389,10 @@ fn ar_find(table: u32, key_ptr: u32, key_len: u32, hash: u32) ?u32 {
 /// :func:`ensure_array_value_owned`.
 fn bucket_set_value(bucket: u32, value: i32) void {
     const old: i32 = read_i32(bucket + 12);
-    if (value != 0) obj.tcl_obj_retain(value);
+    // Same-handle re-stamp (``set arr(k) $val`` with $val unchanged)
+    // must be a no-op on rc.  Gate both retain AND release on the
+    // inequality or the unconditional retain leaks +1 per repeat.
+    if (value != 0 and value != old) obj.tcl_obj_retain(value);
     write_i32(bucket + 12, value);
     if (old != 0 and old != value) obj.tcl_obj_release(old);
 }

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -553,9 +553,15 @@ pub export fn dict_set(dict: i32, key: i32, value: i32) i32 {
             target_ext = dict_clone_ext(ext);
         }
         obj.write_i32(new_addr + obj.OBJ_DICT_EXT, @bitCast(target_ext));
-        const v_obj = obj_new_string_copy(sv.ptr, sv.len);
-        dict_hash_insert(target_ext, sk.ptr, sk.len, h, v_obj);
-        obj.tcl_obj_release(v_obj);
+        // ``dict_clone_ext`` returns 0 on OOM; ``dict_hash_insert``
+        // would then read/write addresses 4/8/12 of low memory.
+        // Skip the cache plumbing on the OOM path — the dict's
+        // list-rep is correct either way.
+        if (target_ext != 0) {
+            const v_obj = obj_new_string_copy(sv.ptr, sv.len);
+            dict_hash_insert(target_ext, sk.ptr, sk.len, h, v_obj);
+            obj.tcl_obj_release(v_obj);
+        }
     } else {
         dict_invalidate_cache(dict);
     }

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -782,7 +782,9 @@ pub export fn dict_keys(dict: i32) i32 {
     const sd = obj_ensure_string(dict);
     const n = list_count_elements(sd.ptr, sd.len);
     if (n == 0) return obj_new_string(0, 0);
-    const buf = alloc(sd.len);
+    const buf_size: u32 = sd.len;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var idx: i64 = 0;
     while (idx < n) : (idx += 2) {
@@ -806,7 +808,7 @@ pub export fn dict_keys(dict: i32) i32 {
             off += elem.len;
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, buf_size);
 }
 
 // Exported: dict values — return a list of all values in the dict.
@@ -814,7 +816,9 @@ pub export fn dict_values(dict: i32) i32 {
     const sd = obj_ensure_string(dict);
     const n = list_count_elements(sd.ptr, sd.len);
     if (n == 0) return obj_new_string(0, 0);
-    const buf = alloc(sd.len);
+    const buf_size: u32 = sd.len;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var idx: i64 = 1;
     while (idx < n) : (idx += 2) {
@@ -838,7 +842,7 @@ pub export fn dict_values(dict: i32) i32 {
             off += elem.len;
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, buf_size);
 }
 
 // Exported: dict size — number of UNIQUE key-value pairs.  When the

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -640,18 +640,12 @@ fn dict_rebuild_without_pair(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64) 
             off += elem.len;
         }
     }
-    // Claim ownership of ``buf`` via OBJ_STR_CAP so eventual
-    // ``tcl_obj_release`` reclaims the bytes through ``free_sized``.
-    // Without this the rebuilt-dict buffer would leak on every
-    // ``dict unset`` (or any caller that releases the returned
-    // dict TclObj).
-    const out = obj_new_string(@bitCast(buf), @bitCast(off));
-    if (out == 0) {
-        obj.free_sized(buf, cap);
-        return 0;
-    }
-    obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(cap));
-    return out;
+    // ``obj_new_string_take`` writes the cap atomically with the
+    // header and free_sizes ``buf`` on its own OOM path — the
+    // earlier two-step ``obj_new_string`` + manual cap-write form
+    // was racy under header OOM (we had to add an explicit free
+    // on the OOM branch to compensate).
+    return obj.obj_new_string_take(buf, off, cap);
 }
 
 fn dict_rebuild_with_value(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64, vp: u32, vl: u32) i32 {
@@ -696,13 +690,10 @@ fn dict_rebuild_with_value(sd_ptr: u32, sd_len: u32, n: i64, target_idx: i64, vp
             }
         }
     }
-    const out = obj_new_string(@bitCast(buf), @bitCast(off));
-    if (out == 0) {
-        obj.free_sized(buf, cap);
-        return 0;
-    }
-    obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(cap));
-    return out;
+    // ``_take`` atomically transfers ownership of ``buf`` to the
+    // returned obj and frees it on header-OOM — no need for the
+    // explicit ``free_sized`` + manual cap-write dance.
+    return obj.obj_new_string_take(buf, off, cap);
 }
 
 fn dict_append_pair(sd_ptr: u32, sd_len: u32, kp: u32, kl: u32, vp: u32, vl: u32) i32 {
@@ -730,11 +721,8 @@ fn dict_append_pair(sd_ptr: u32, sd_len: u32, kp: u32, kl: u32, vp: u32, vl: u32
     d[0] = ' ';
     off += 1;
     off = list_elem_quote_nth(buf, off, vp, vl);
-    const new_obj = obj_new_string(@bitCast(buf), @bitCast(off));
-    if (new_obj != 0) {
-        obj.write_i32(@as(u32, @bitCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
-    }
-    return new_obj;
+    // Atomic take — see the rationale in ``dict_rebuild_with_value``.
+    return obj.obj_new_string_take(buf, off, cap);
 }
 
 // Exported: dict merge — merge *source* into *target*; for duplicate

--- a/runtime/zig/valtypes/tcl_encoding.zig
+++ b/runtime/zig/valtypes/tcl_encoding.zig
@@ -250,11 +250,11 @@ pub fn buf_to_obj(b: ByteBuf) i32 {
         obj.free_sized(b.addr, b.cap);
         return obj_new_string(0, 0);
     }
-    const out = obj_new_string(@bitCast(b.addr), @bitCast(b.len));
-    if (out != 0) {
-        obj.write_i32(@as(u32, @bitCast(out)) + obj.OBJ_STR_CAP, @bitCast(b.cap));
-    }
-    return out;
+    // ``obj_new_string_take`` writes ``OBJ_STR_CAP`` and ``OBJ_STR_PTR``
+    // / ``OBJ_STR_LEN`` atomically and frees ``b.addr`` on header-alloc
+    // OOM — the prior split form leaked the byte buffer when ``obj_alloc``
+    // returned 0.
+    return obj.obj_new_string_take(b.addr, b.len, b.cap);
 }
 
 // -- UTF-8 iteration --------------------------------------------

--- a/runtime/zig/valtypes/tcl_format.zig
+++ b/runtime/zig/valtypes/tcl_format.zig
@@ -147,13 +147,28 @@ pub export fn tcl_cmd_format_list(fmt: i32, args_list: i32) i32 {
     // ``tcl_cmd_list_index`` (handles braced + quoted elements
     // and backslash decoding) so the format routine can pull
     // integer widths and string values uniformly.
-    const objs_addr = alloc(n * 4);
+    //
+    // Every ``tcl_cmd_list_index`` returns a fresh +1 owned obj
+    // and every immediate ``obj_new_int(i)`` past 2^30 is also
+    // heap-allocated.  Previously these were just dropped on the
+    // floor — N+1 leaked TclObjs per ``format`` call plus the
+    // ``objs_addr`` indexer buffer.  Release each element AFTER
+    // ``format_internal`` is done reading it, and free the buffer.
+    const objs_size: u32 = n * 4;
+    const objs_addr = alloc(objs_size);
+    if (objs_addr == 0) return format_internal(fmt, &[_]i32{});
+    defer obj.free_sized(objs_addr, objs_size);
     const objs: [*]i32 = @ptrFromInt(objs_addr);
     var i: u32 = 0;
     while (i < n) : (i += 1) {
-        objs[i] = list_mod.tcl_cmd_list_index(args_list, obj.obj_new_int(@intCast(i)));
+        const idx_obj = obj.obj_new_int(@intCast(i));
+        objs[i] = list_mod.tcl_cmd_list_index(args_list, idx_obj);
+        obj.tcl_obj_release(idx_obj);
     }
-    return format_internal(fmt, objs[0..n]);
+    const result = format_internal(fmt, objs[0..n]);
+    i = 0;
+    while (i < n) : (i += 1) obj.tcl_obj_release(objs[i]);
+    return result;
 }
 
 /// Scan a format string for the maximum literal width / precision

--- a/runtime/zig/valtypes/tcl_format.zig
+++ b/runtime/zig/valtypes/tcl_format.zig
@@ -271,6 +271,16 @@ fn format_internal(fmt: i32, args: []const i32) i32 {
         bufsize += as.len + 64;
     }
     const buf_addr: u32 = alloc(bufsize);
+    if (buf_addr == 0) return obj_new_string(0, 0);
+    // Cascade-leak fix: every early-return path through the format
+    // loop (``"not enough arguments"``, ``"format string ended"``,
+    // checked_int / checked_float failures, the positional /
+    // sequential-mix diagnostic, etc.) previously abandoned
+    // ``buf_addr`` on the heap.  Schedule a free that fires on
+    // every exit, then clear the flag on the success path so the
+    // buffer's ownership transfers to the returned TclObj instead.
+    var success: bool = false;
+    defer if (!success) obj.free_sized(buf_addr, bufsize);
     const out: [*]u8 = @ptrFromInt(buf_addr);
     var off: u32 = 0;
 
@@ -471,6 +481,7 @@ fn format_internal(fmt: i32, args: []const i32) i32 {
     // The older borrowing form leaked one buf per ``format`` call;
     // tcltest's progress / diagnostic output exercises this path
     // heavily.
+    success = true; // ownership transferred to the TclObj below
     return obj.obj_new_string_take(buf_addr, off, bufsize);
 }
 

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -881,7 +881,9 @@ pub export fn tcl_cmd_list_insert(list: i32, index: i32, value: i32) i32 {
     // existing element plus the inserted value.  Inserted-value
     // worst-case is ``2 * len + 2`` because list_elem_quote_*
     // may brace-wrap.
-    const buf = alloc(s.len + n * 3 + sv.len * 2 + 8);
+    const buf_size: u32 = s.len + n * 3 + sv.len * 2 + 8;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var i: u32 = 0;
     while (i < n) : (i += 1) {
@@ -918,7 +920,7 @@ pub export fn tcl_cmd_list_insert(list: i32, index: i32, value: i32) i32 {
         const quoter: *const fn (u32, u32, u32, u32) u32 = if (off == 0) &list_elem_quote else &list_elem_quote_nth;
         off = quoter(buf, off, sv.ptr, sv.len);
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, buf_size);
 }
 
 // Exported: list replace — ``lreplace list first last ?value1 ...?``.
@@ -952,7 +954,9 @@ pub export fn tcl_cmd_list_replace(list: i32, first: i32, last: i32, value: i32)
 
     // Over-allocate to fit worst-case brace-wrapping on every
     // preserved element plus the canonically-quoted value.
-    const buf = alloc(s.len + n * 3 + sv_len * 2 + 8);
+    const buf_size: u32 = s.len + n * 3 + sv_len * 2 + 8;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var i: u32 = 0;
     const uf: u32 = @intCast(if (f < 0) 0 else f);
@@ -998,7 +1002,7 @@ pub export fn tcl_cmd_list_replace(list: i32, first: i32, last: i32, value: i32)
         const quoter: *const fn (u32, u32, u32, u32) u32 = if (off == 0) &list_elem_quote else &list_elem_quote_nth;
         off = quoter(buf, off, sv_ptr, sv_len);
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, buf_size);
 }
 
 // Exported: multi-value lreplace driven by a Tcl LIST of inserts.
@@ -1191,7 +1195,9 @@ fn lset_recurse(
     // Build the result list by copying elements, substituting the
     // replacement at ``uidx``.  Over-allocate to fit worst-case
     // brace-wrapping on every element.
-    const buf = alloc(src_len + n_src * 3 + s_rep.len * 2 + 8);
+    const buf_size: u32 = src_len + n_src * 3 + s_rep.len * 2 + 8;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var i: u32 = 0;
     while (i < n_src) : (i += 1) {
@@ -1212,7 +1218,7 @@ fn lset_recurse(
             off = append_list_element(buf, off, src_ptr, elem, off == 0);
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    return obj.obj_new_string_take(buf, off, buf_size);
 }
 
 // Exported: list repeat — ``lrepeat count value1 ?value2 ...?``.
@@ -1235,15 +1241,30 @@ pub export fn tcl_cmd_list_repeat(count: i32, value: i32) i32 {
     // result parses back as ``count`` elements rather than splitting
     // on the literal whitespace.  Worst-case quoted length is
     // ``2 * sv.len + 2``.
-    const first_buf = alloc(sv.len * 2 + 4);
+    const scratch_size: u32 = sv.len * 2 + 4;
+    const first_buf = alloc(scratch_size);
+    if (first_buf == 0) return obj_new_string(0, 0);
     const first_len = list_elem_quote(first_buf, 0, sv.ptr, sv.len);
-    const next_buf = alloc(sv.len * 2 + 4);
+    const next_buf = alloc(scratch_size);
+    if (next_buf == 0) {
+        obj.free_sized(first_buf, scratch_size);
+        return obj_new_string(0, 0);
+    }
     const next_len = list_elem_quote_nth(next_buf, 0, sv.ptr, sv.len);
 
     const sep_count: u32 = if (ucnt == 0) 0 else ucnt - 1;
     const total: u32 = first_len + sep_count * (1 + next_len);
-    if (total == 0) return obj_new_string(0, 0);
+    if (total == 0) {
+        obj.free_sized(first_buf, scratch_size);
+        obj.free_sized(next_buf, scratch_size);
+        return obj_new_string(0, 0);
+    }
     const buf = alloc(total);
+    if (buf == 0) {
+        obj.free_sized(first_buf, scratch_size);
+        obj.free_sized(next_buf, scratch_size);
+        return obj_new_string(0, 0);
+    }
     var off: u32 = 0;
     if (first_len > 0) {
         memcpy(buf + off, first_buf, first_len);
@@ -1259,5 +1280,7 @@ pub export fn tcl_cmd_list_repeat(count: i32, value: i32) i32 {
             off += next_len;
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(off));
+    obj.free_sized(first_buf, scratch_size);
+    obj.free_sized(next_buf, scratch_size);
+    return obj.obj_new_string_take(buf, off, total);
 }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -180,6 +180,12 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
         } else {
             const tmp_size: u32 = elem.len + 1;
             const tmp = alloc(tmp_size);
+            // OOM: alloc raised ``oom_flag``.  Bail with an empty
+            // list; the partial ``buf`` written so far is discarded
+            // (it will be reclaimed by the bump allocator's GC
+            // sweep — no leak).  ``copy_unbraced_elem`` would
+            // otherwise ``@ptrFromInt(0)``.
+            if (tmp == 0) return obj_new_string(0, 0);
             const actual_len = copy_unbraced_elem(tmp, sc_ptr + elem.start, elem.len);
             off = quoter(buf, off, tmp, actual_len);
             // Issue #317: ``tmp`` is a per-element scratch buffer
@@ -202,11 +208,10 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
     } else {
         off = list_elem_quote(buf, off, sv_ptr, sv_len);
     }
-    const new_obj = obj_new_string(@bitCast(buf), @bitCast(off));
-    if (new_obj != 0) {
-        obj.write_i32(@as(u32, @bitCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(cap));
-    }
-    return new_obj;
+    // Switch to ``obj_new_string_take`` so the cap is set atomically
+    // with the new TclObj — the older ``obj_new_string`` + manual
+    // ``OBJ_STR_CAP`` write pattern leaks ``buf`` if obj_alloc OOMs.
+    return obj.obj_new_string_take(buf, off, cap);
 }
 
 // Exported: list — append one value to a list accumulator.  The
@@ -558,6 +563,11 @@ pub export fn tcl_cmd_list_index(list: i32, idx: i32) i32 {
     // bytes and ``release_now`` reclaims them — the older
     // borrowing form leaked one buf per ``lindex`` call.
     const buf = alloc(elem.len);
+    // OOM: alloc raised ``oom_flag``.  Surface an empty TclObj
+    // so ``lindex`` returns the empty string under memory
+    // pressure rather than ``@ptrFromInt(0)`` inside
+    // ``copy_unbraced_elem``.
+    if (buf == 0 and elem.len != 0) return obj_new_string(0, 0);
     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
     return obj.obj_new_string_take(buf, out_len, elem.len);
 }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -1163,8 +1163,11 @@ fn lset_recurse(
     // relative to the *indices* text.  Build a TclObj wrapping the
     // single index word so ``resolve_list_index`` (which takes a
     // TclObj) can parse ``end[-N]`` / ``end+N`` / integer forms.
+    // Release after the call — without this every recursion depth
+    // leaked one TclObj per index.
     const idx_obj = obj_new_string_copy(indices_ptr + idx_elem.start, idx_elem.len);
     const idx = resolve_list_index(idx_obj, n_src_i64);
+    obj.tcl_obj_release(idx_obj);
     if (idx < 0 or idx >= n_src_i64) {
         // Out of range — return a copy of the source unchanged.
         // The compiler-level caller is expected to treat the result
@@ -1177,7 +1180,12 @@ fn lset_recurse(
     // Determine the replacement for the element at this depth:
     //   - At the deepest level, the replacement is *value* itself.
     //   - Otherwise, recurse into the element treated as a sublist.
+    // When we recurse, ``replacement`` is a fresh +1 owned obj that
+    // we must release after the buffer is built.  When we don't
+    // (deepest level), it borrows from ``value`` and we leave it
+    // alone — the caller still owns ``value``.
     var replacement: i32 = value;
+    var owns_replacement: bool = false;
     if (depth + 1 < n_indices) {
         const elem = list_element_at(src_ptr, src_len, idx);
         replacement = lset_recurse(
@@ -1189,7 +1197,9 @@ fn lset_recurse(
             n_indices,
             value,
         );
+        owns_replacement = true;
     }
+    defer if (owns_replacement) obj.tcl_obj_release(replacement);
     const s_rep = obj_ensure_string(replacement);
 
     // Build the result list by copying elements, substituting the

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -1395,6 +1395,11 @@ pub fn obj_new_string_copy(src: u32, len: u32) i32 {
     // ``release_now`` doesn't try to free a non-existent buffer.
     if (len <= MAX_INLINE_STR) {
         const obj = obj_alloc();
+        // OOM on the inline path: the non-inline branch (below)
+        // checks ``buf == 0`` but this branch used to write straight
+        // through ``@ptrFromInt(0)`` (offsets 4 / 8 / 12 / 16 / 20
+        // of low memory).  Debug panics, release silently corrupts.
+        if (obj == 0) return 0;
         write_i32(obj + OBJ_TYPE_TAG, TYPE_INLINE_STRING);
         memcpy(obj + OBJ_INT_CACHE, src, len);
         // Point str_ptr at the inline buffer so callers reading

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -1018,11 +1018,12 @@ fn build_capture_value(
         const end_str = obj.itoa(@intCast(end_inclusive));
         const total: u32 = start_len + 1 + @as(u32, @intCast(end_str.len));
         const buf = alloc(total);
+        if (buf == 0) return obj_new_string(0, 0);
         const dst: [*]u8 = @ptrFromInt(buf);
         for (0..start_len) |k| dst[k] = start_buf[k];
         dst[start_len] = ' ';
         for (0..end_str.len) |k| dst[start_len + 1 + k] = end_str.ptr[k];
-        return obj_new_string(@bitCast(buf), @bitCast(total));
+        return obj.obj_new_string_take(buf, total, total);
     }
     // Substring mode: extract the bytes covering [start_cp, end_cp).
     const sb_start = codepoint_to_byte(sub_s.ptr, sub_s.len, start_cp);
@@ -1030,10 +1031,11 @@ fn build_capture_value(
     if (sb_end <= sb_start) return obj_new_string(0, 0);
     const len = sb_end - sb_start;
     const buf = alloc(len);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     const src: [*]const u8 = @ptrFromInt(sub_s.ptr + sb_start);
     for (0..len) |k| dst[k] = src[k];
-    return obj_new_string(@bitCast(buf), @bitCast(len));
+    return obj.obj_new_string_take(buf, len, len);
 }
 
 /// Append one capture (already decoded into start/end codepoints) to

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -115,6 +115,7 @@ fn raise_bad_index(idx_ptr: [*]const u8, idx_len: usize) void {
     const suffix: []const u8 = "\": must be integer?[+-]integer? or end?[+-]integer?";
     const total: u32 = @intCast(prefix.len + idx_len + suffix.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) return;
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |b| {
@@ -152,6 +153,7 @@ fn raise_bad_option(
     const middle: []const u8 = "\": must be ";
     const total: u32 = @intCast(prefix.len + opt_len + middle.len + must_be.len);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) return;
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |b| {
@@ -196,6 +198,7 @@ fn raise_compile_error(errcode: c_int) void {
         detail_len - 1;
     const total: u32 = @intCast(prefix.len + written);
     const buf_addr: u32 = obj.alloc(total);
+    if (buf_addr == 0) return;
     const buf: [*]u8 = @ptrFromInt(buf_addr);
     var off: usize = 0;
     for (prefix) |b| {
@@ -812,6 +815,12 @@ pub fn eval_regexp_cmd(words: []const i32) i32 {
     var inline_cap: u32 = 0;
     inline_cap = 256;
     inline_buf = alloc(inline_cap);
+    if (inline_buf == 0) {
+        arena.arena_free(re_alloc);
+        arena.arena_free(sub_u.alloc);
+        arena.arena_free(pat_u.alloc);
+        return obj_new_int(0);
+    }
 
     // nmatch shape mirrors do_regsub's working pattern.  Without
     // captures we only need slot 0 (whole match start/end) — request

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -1156,6 +1156,11 @@ pub fn capture_match_for_switch(
     var index_buf: u32 = alloc(256);
     var index_cap: u32 = 256;
     var index_off: u32 = 0;
+    if (match_buf == 0 or index_buf == 0) {
+        if (match_buf != 0) obj.free_sized(match_buf, match_cap);
+        if (index_buf != 0) obj.free_sized(index_buf, index_cap);
+        return .{ .match_list = 0, .index_list = 0 };
+    }
 
     const pm: [*]const i32 = @ptrFromInt(pmatch_buf);
     var g: usize = 0;
@@ -1194,8 +1199,11 @@ pub fn capture_match_for_switch(
     arena.arena_free(sub_u.alloc);
     arena.arena_free(pat_u.alloc);
 
-    const match_obj = obj_new_string(@bitCast(match_buf), @bitCast(match_off));
-    const index_obj = obj_new_string(@bitCast(index_buf), @bitCast(index_off));
+    // ``obj_new_string_take`` so each result obj owns its buffer and
+    // ``release_now`` reclaims the slab — the borrow form would let
+    // both match_buf and index_buf leak permanently per match call.
+    const match_obj = obj.obj_new_string_take(match_buf, match_off, match_cap);
+    const index_obj = obj.obj_new_string_take(index_buf, index_off, index_cap);
     return .{ .match_list = match_obj, .index_list = index_obj };
 }
 

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -524,6 +524,12 @@ pub fn do_regsub(pattern: i32, string: i32, subspec: i32, nocase: bool, all: boo
     const sub_len: u32 = sub_s.len;
     const max_result: u32 = str_s.len * (sub_len + 2) + 256;
     const result_buf = alloc(max_result);
+    if (result_buf == 0) {
+        arena.arena_free(re_alloc);
+        arena.arena_free(str_u.alloc);
+        arena.arena_free(pat_u.alloc);
+        return rt.obj_new_string(0, 0);
+    }
     var result_off: u32 = 0;
 
     const nmatch: usize = 10; // whole match + up to 9 capture groups
@@ -637,7 +643,7 @@ pub fn do_regsub(pattern: i32, string: i32, subspec: i32, nocase: bool, all: boo
     result_off += tail_len;
 
     if (n_subs_out) |p| p.* = n_subs;
-    return rt.obj_new_string(@bitCast(result_buf), @bitCast(result_off));
+    return rt.obj_new_string_take(result_buf, result_off, max_result);
 }
 
 /// Interpreter-side ``regexp`` command handler.  Called from
@@ -1554,6 +1560,10 @@ pub fn eval_regsub_cmd(words: []const i32) i32 {
     }
     const max_out: u32 = @intCast(max_out_usize);
     const out_addr = alloc(max_out);
+    if (out_addr == 0) {
+        regfree_safe(re_ptr);
+        return obj_new_int(0);
+    }
     const out: [*]u8 = @ptrFromInt(out_addr);
     var out_len: usize = 0;
 
@@ -1635,7 +1645,7 @@ pub fn eval_regsub_cmd(words: []const i32) i32 {
 
     regfree_safe(re_ptr);
 
-    const result = obj_new_string(@bitCast(out_addr), @bitCast(out_len));
+    const result = rt.obj_new_string_take(out_addr, @intCast(out_len), max_out);
 
     if (has_var) {
         _ = frames.var_set(varname, result);

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -915,6 +915,14 @@ pub fn eval_regexp_cmd(words: []const i32) i32 {
             while (v < var_words.len and v < nmatch) : (v += 1) {
                 const so = pm[v * 2];
                 const eo = pm[v * 2 + 1];
+                // ``build_capture_value`` returns a fresh +1 owned obj.
+                // ``var_set`` retains internally (via the array/global
+                // store), so the extra ``tcl_obj_retain`` on top
+                // double-counted the var slot's ref AND the original
+                // +1 from ``build_capture_value`` was never released.
+                // Net effect: every captured group leaked +2.  Just
+                // release after ``var_set`` to match the caller-owned
+                // contract.
                 const value = build_capture_value(
                     indices_mode,
                     sub_s,
@@ -923,12 +931,14 @@ pub fn eval_regexp_cmd(words: []const i32) i32 {
                     so,
                     eo,
                 );
-                obj.tcl_obj_retain(value);
                 _ = frames.var_set(var_words[v], value);
+                obj.tcl_obj_release(value);
             }
             // Remaining unset vars get empty (Tcl matches set "").
             while (v < var_words.len) : (v += 1) {
-                _ = frames.var_set(var_words[v], obj_new_string(0, 0));
+                const empty = obj_new_string(0, 0);
+                _ = frames.var_set(var_words[v], empty);
+                obj.tcl_obj_release(empty);
             }
         }
 

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -1051,7 +1051,16 @@ fn append_inline_capture(
     rm_so: i32,
     rm_eo: i32,
 ) u32 {
+    // ``build_capture_value`` returns a fresh +1 owned obj; release
+    // after ``list_elem_quote_nth`` copies its bytes into the
+    // accumulator buffer.  An earlier revision (the F7 fix sweep
+    // missed this site) leaked one TclObj per capture group AND
+    // leaked the old buffer on every grow.  ``defer`` in Zig fires
+    // at function exit — safe to schedule before the byte read at
+    // line below because the quoter consumes ``vs.ptr`` synchronously
+    // and the obj's str_ptr stays valid until function exit.
     const value = build_capture_value(indices_mode, sub_s, sub_u, pos_cp, rm_so, rm_eo);
+    defer obj.tcl_obj_release(value);
     const vs = obj_ensure_string(value);
     // Worst case: ' ' + braces + content
     const need: u32 = off_in + vs.len + 4;
@@ -1059,11 +1068,16 @@ fn append_inline_capture(
         var new_cap: u32 = cap_ref.* * 2;
         while (new_cap < need) new_cap *= 2;
         const new_buf = alloc(new_cap);
+        if (new_buf == 0) return off_in;
         if (off_in > 0) {
             const src: [*]const u8 = @ptrFromInt(buf_ref.*);
             const dst: [*]u8 = @ptrFromInt(new_buf);
             for (0..off_in) |k| dst[k] = src[k];
         }
+        // Free the prior buffer on grow — the earlier revision
+        // overwrote ``buf_ref.*`` without ``free_sized``ing the
+        // previous slab.
+        if (buf_ref.* != 0) obj.free_sized(buf_ref.*, cap_ref.*);
         buf_ref.* = new_buf;
         cap_ref.* = new_cap;
     }

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -1165,7 +1165,9 @@ pub export fn string_reverse(value: i32) i32 {
     // ``\uDE02\uD83Dblubф``).  Reserve worst-case 6 bytes per
     // input codepoint (BMP = 3 bytes UTF-8; supplementary = 4 input →
     // 2 × 3 output bytes for surrogates).
-    const buf = alloc(sv.len * 2 + 4);
+    const buf_size: u32 = sv.len * 2 + 4;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var src_i: u32 = 0;
     // First pass: walk forward and accumulate the reversed output by
@@ -1173,7 +1175,7 @@ pub export fn string_reverse(value: i32) i32 {
     var out_len: u32 = 0;
     // Use a two-pass strategy — gather byte runs into ``buf`` from
     // the *end* so each new unit takes the lowest-index slot.
-    var write_head: u32 = sv.len * 2 + 4;
+    var write_head: u32 = buf_size;
     while (src_i < sv.len) {
         const d = decode_utf8_at(src, sv.len, src_i);
         if (d.cp >= 0x10000 and d.cp <= 0x10FFFF) {
@@ -1210,7 +1212,7 @@ pub export fn string_reverse(value: i32) i32 {
             dst[i] = dst[write_head + i];
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out_len));
+    return obj_new_string_take(buf, out_len, buf_size);
 }
 
 // Exported: string toupper — convert to uppercase.
@@ -1240,7 +1242,9 @@ fn case_fold_whole(value: i32, kind: FoldKind) i32 {
     const sv = obj_ensure_string(value);
     if (sv.len == 0) return value;
     const src: [*]const u8 = @ptrFromInt(sv.ptr);
-    const buf = alloc(sv.len * 4 + 4);
+    const buf_size: u32 = sv.len * 4 + 4;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var src_i: u32 = 0;
     var out_i: u32 = 0;
@@ -1250,7 +1254,7 @@ fn case_fold_whole(value: i32, kind: FoldKind) i32 {
         out_i += encode_utf8(folded, dst + out_i);
         src_i += d.len;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out_i));
+    return obj_new_string_take(buf, out_i, buf_size);
 }
 
 /// Range-bounded variants for ``string tolower/toupper STRING
@@ -1275,7 +1279,9 @@ fn case_fold_range(value: i32, first: i32, last: i32, kind: FoldKind) i32 {
     if (l >= cp_count) l = cp_count - 1;
     if (f > l) return value;
     const src: [*]const u8 = @ptrFromInt(sv.ptr);
-    const buf = alloc(sv.len * 4 + 4);
+    const buf_size: u32 = sv.len * 4 + 4;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var src_i: u32 = 0;
     var out_i: u32 = 0;
@@ -1290,7 +1296,7 @@ fn case_fold_range(value: i32, first: i32, last: i32, kind: FoldKind) i32 {
         src_i += d.len;
         cp_idx += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out_i));
+    return obj_new_string_take(buf, out_i, buf_size);
 }
 
 // Exported: string totitle — title-case the first codepoint and
@@ -1301,7 +1307,9 @@ pub export fn string_totitle(value: i32) i32 {
     const sv = obj_ensure_string(value);
     if (sv.len == 0) return value;
     const src: [*]const u8 = @ptrFromInt(sv.ptr);
-    const buf = alloc(sv.len * 4 + 4);
+    const buf_size: u32 = sv.len * 4 + 4;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var src_i: u32 = 0;
     var out_i: u32 = 0;
@@ -1313,7 +1321,7 @@ pub export fn string_totitle(value: i32) i32 {
         src_i += d.len;
         first = false;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out_i));
+    return obj_new_string_take(buf, out_i, buf_size);
 }
 
 /// ``string totitle STRING ?first? ?last?`` — title-case the
@@ -1331,7 +1339,9 @@ pub export fn string_totitle_range(value: i32, first: i32, last: i32) i32 {
     if (l >= cp_count) l = cp_count - 1;
     if (f > l) return value;
     const src: [*]const u8 = @ptrFromInt(sv.ptr);
-    const buf = alloc(sv.len * 4 + 4);
+    const buf_size: u32 = sv.len * 4 + 4;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var src_i: u32 = 0;
     var out_i: u32 = 0;
@@ -1347,7 +1357,7 @@ pub export fn string_totitle_range(value: i32, first: i32, last: i32) i32 {
         src_i += d.len;
         cp_idx += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out_i));
+    return obj_new_string_take(buf, out_i, buf_size);
 }
 
 // Exported: string insert — insert ``ins`` into ``value`` at byte
@@ -1428,11 +1438,13 @@ pub export fn string_replace(value: i32, first: i32, last: i32, new_str: i32) i3
         sv.len;
     const tail_len = sv.len - tail_start_byte;
     const total = fst_byte + sn.len + tail_len;
-    const buf = alloc(total + 1);
+    const buf_size: u32 = total + 1;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     if (fst_byte > 0) memcpy(buf, sv.ptr, fst_byte);
     if (sn.len > 0) memcpy(buf + fst_byte, sn.ptr, sn.len);
     if (tail_len > 0) memcpy(buf + fst_byte + sn.len, sv.ptr + tail_start_byte, tail_len);
-    return obj_new_string(@bitCast(buf), @bitCast(total));
+    return obj_new_string_take(buf, total, buf_size);
 }
 
 // Exported: string is integer — check if a string is a valid integer.
@@ -1542,7 +1554,9 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
         // Each char becomes a properly-quoted list element.
         // Allocate generously: each char can expand to at most 4 bytes
         // (backslash + char + possible braces) plus a space separator.
-        const buf = alloc(sv.len * 5 + 4);
+        const buf_size: u32 = sv.len * 5 + 4;
+        const buf = alloc(buf_size);
+        if (buf == 0) return obj_new_string(0, 0);
         var out: u32 = 0;
         for (0..sv.len) |i| {
             if (i > 0) {
@@ -1552,7 +1566,7 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
             }
             out = list_quote_elem(buf, out, sv.ptr + @as(u32, @intCast(i)), 1);
         }
-        return obj_new_string(@bitCast(buf), @bitCast(out));
+        return obj_new_string_take(buf, out, buf_size);
     }
 
     // Single-char separator (common case)
@@ -1560,7 +1574,9 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
     if (sd.len == 1) {
         const sc = sep[0];
         // Allocate generously — backslash-escape path can double each byte.
-        const buf = alloc(sv.len * 3 + 4);
+        const buf_size: u32 = sv.len * 3 + 4;
+        const buf = alloc(buf_size);
+        if (buf == 0) return obj_new_string(0, 0);
         var out: u32 = 0;
         var start: u32 = 0;
         var i: u32 = 0;
@@ -1577,14 +1593,16 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
                 start = i + 1;
             }
         }
-        return obj_new_string(@bitCast(buf), @bitCast(out));
+        return obj_new_string_take(buf, out, buf_size);
     }
 
     // Multi-char separator: split on any codepoint in splitChars.
     // Both *src* and *sep* are walked codepoint by codepoint so a
     // multi-byte separator like ``乎`` doesn't mis-split on its
     // continuation bytes (cmdMZ-4.13).
-    const buf = alloc(sv.len * 3 + 4);
+    const buf_size: u32 = sv.len * 3 + 4;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var out: u32 = 0;
     var start: u32 = 0;
     var i: u32 = 0;
@@ -1611,7 +1629,7 @@ pub export fn tcl_cmd_split(value: i32, split_chars: i32) i32 {
         out += 1;
     }
     out = list_quote_elem(buf, out, sv.ptr + start, sv.len - start);
-    return obj_new_string(@bitCast(buf), @bitCast(out));
+    return obj_new_string_take(buf, out, buf_size);
 }
 
 /// Does *cp* appear in the codepoint set described by *set_ptr*
@@ -1644,7 +1662,9 @@ pub export fn tcl_cmd_join(list: i32, separator: i32) i32 {
         return obj_new_string_copy(sl.ptr + elem.start, elem.len);
     }
     // Estimate output: sum of element lengths + (n-1) * sep_len
-    const buf = alloc(sl.len + @as(u32, @intCast(n)) * ss_len + 1);
+    const buf_size: u32 = sl.len + @as(u32, @intCast(n)) * ss_len + 1;
+    const buf = alloc(buf_size);
+    if (buf == 0) return obj_new_string(0, 0);
     var out: u32 = 0;
     var idx: i64 = 0;
     while (idx < n) : (idx += 1) {
@@ -1658,7 +1678,7 @@ pub export fn tcl_cmd_join(list: i32, separator: i32) i32 {
             out += elem.len;
         }
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out));
+    return obj_new_string_take(buf, out, buf_size);
 }
 
 // Exported: concat — concatenate two TclObj string representations with space.
@@ -1715,9 +1735,10 @@ pub export fn tcl_cmd_concat(a: i32, b: i32) i32 {
     if (tb_len == 0) return obj_new_string_copy(sa.ptr + a_start, ta_len);
     const total = ta_len + 1 + tb_len;
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     memcpy(buf, sa.ptr + a_start, ta_len);
     const dst: [*]u8 = @ptrFromInt(buf + ta_len);
     dst[0] = ' ';
     memcpy(buf + ta_len + 1, sb.ptr + b_start, tb_len);
-    return obj_new_string(@bitCast(buf), @bitCast(total));
+    return obj_new_string_take(buf, total, total);
 }

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -98,11 +98,13 @@ pub export fn tcl_cmd_append(current: i32, addition: i32) i32 {
     if (buf == 0) return obj_new_string(0, 0);
     if (a.len > 0) memcpy(buf, a.ptr, a.len);
     if (b.len > 0) memcpy(buf + a.len, b.ptr, b.len);
-    const new_obj = obj_new_string(@bitCast(buf), @bitCast(total));
-    if (new_obj != 0) {
-        obj.write_i32(@as(u32, @bitCast(new_obj)) + obj.OBJ_STR_CAP, @bitCast(new_cap));
-    }
-    return new_obj;
+    // ``obj_new_string_take`` claims ``buf`` as the obj's owned
+    // backing storage in one shot — the older two-step pattern
+    // (``obj_new_string`` + manual ``OBJ_STR_CAP`` write) is
+    // bug-prone because an OOM on the obj header would leak ``buf``
+    // outright.  ``_take`` frees ``buf`` internally when the obj
+    // header alloc fails, so the path is leak-safe end-to-end.
+    return obj.obj_new_string_take(buf, total, new_cap);
 }
 
 // Exported: string compare — lexicographic comparison of string representations.

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -15,6 +15,7 @@ const obj_new_string = obj.obj_new_string;
 const obj_new_int = obj.obj_new_int;
 const obj_get_int = obj.obj_get_int;
 const obj_new_string_copy = obj.obj_new_string_copy;
+const obj_new_string_take = obj.obj_new_string_take;
 const try_parse_int = obj.try_parse_int;
 const is_space = obj.is_space;
 const list_count_elements = obj.list_count_elements;
@@ -382,10 +383,11 @@ pub export fn string_index(value: i32, idx: i32) i32 {
     const cl = utf8_lead_len(sp[start]);
     const actual = if (start + cl > s.len) s.len - start else cl;
     const buf = alloc(actual);
+    if (buf == 0) return obj_new_string(0, 0);
     const dst: [*]u8 = @ptrFromInt(buf);
     var k: u32 = 0;
     while (k < actual) : (k += 1) dst[k] = sp[start + k];
-    return obj_new_string(@bitCast(buf), @bitCast(actual));
+    return obj_new_string_take(buf, actual, actual);
 }
 
 // Exported: string range — extract codepoints [first..last] inclusive.
@@ -428,7 +430,9 @@ fn string_map_impl(mapping: i32, value: i32, nocase: bool) i32 {
     const n_elems = list_count_elements(sm.ptr, sm.len);
     if (n_elems < 2) return value;
     const n_pairs: u32 = @intCast(@divTrunc(n_elems, 2));
-    const buf = alloc(sv.len * 2 + 64);
+    const alloc_size = sv.len * 2 + 64;
+    const buf = alloc(alloc_size);
+    if (buf == 0) return obj_new_string(0, 0);
     const src: [*]const u8 = @ptrFromInt(sv.ptr);
     var out_len: u32 = 0;
     var pos: u32 = 0;
@@ -470,7 +474,7 @@ fn string_map_impl(mapping: i32, value: i32, nocase: bool) i32 {
         out_len += 1;
         pos += 1;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(out_len));
+    return obj_new_string_take(buf, out_len, alloc_size);
 }
 
 // Exported: string match — glob pattern matching (* and ? wildcards).
@@ -1139,13 +1143,14 @@ pub export fn string_repeat(value: i32, count: i32) i32 {
     const cn: u32 = @intCast(n);
     const total = sv.len * cn;
     const buf = alloc(total);
+    if (buf == 0) return obj_new_string(0, 0);
     var off: u32 = 0;
     var i: u32 = 0;
     while (i < cn) : (i += 1) {
         memcpy(buf + off, sv.ptr, sv.len);
         off += sv.len;
     }
-    return obj_new_string(@bitCast(buf), @bitCast(total));
+    return obj_new_string_take(buf, total, total);
 }
 
 // Exported: string reverse — reverse a string.

--- a/tests/test_eval_set_ownership.py
+++ b/tests/test_eval_set_ownership.py
@@ -1,14 +1,28 @@
-"""Stress test for eval_set read-form ownership fix.
+"""Regression test for eval_set read-form ownership fix.
 
 Exercises the interpreted eval_set read form (via dynamic var names so
-codegen can't fold into a direct frame read). After the fix, each
-[set $varname] substitution must return a +1 owned handle and not
-dangle the var slot's value.
+codegen can't fold into a direct frame read).  After the fix, every
+command handler hands the dispatcher a true +1 owned share regardless
+of whether the underlying value came from a var slot, a fresh
+allocation, or a parser-allocated word.
+
+Before the fix the read form returned the var slot's stored handle
+without bumping its refcount; the eval_script loop's release of the
+previous statement's result would decrement the slot's hold to zero
+and queue the obj for free.  In practice the deferred-free queue
+masked the bug (drains fire only at the outermost ``tcl_eval``
+boundary), but the rc accounting was lying — every borrow-return
+sequence was one resize or hash-table rebuild away from a use-after-
+free.
 """
-import wasmtime
+
+from __future__ import annotations
+
 import pytest
 
-from tests.test_wasm_execution import (
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_execution import (  # noqa: E402
     _compile_to_wasm,
     _get_engine,
     _link_and_instantiate,
@@ -18,11 +32,12 @@ from tests.test_wasm_execution import (
 def test_repeated_set_read_via_dynamic_name():
     """Stress: repeatedly read a global through a dynamic var name.
 
-    `set $name` is the read form (no value) with a dynamic name —
+    ``set $name`` is the read form (no value) with a dynamic name —
     the compiler can't fold this and routes via the eval-fallback
-    path through eval_set. Before the fix, each iteration's read
-    would queue the slot's value for free, and the next iteration
-    would see a freed handle.
+    path through ``eval_set``.  Before the fix each iteration's read
+    queued the slot's value for free, and the next iteration could
+    observe a recycled slab if the allocator reissued it before the
+    drain fired.
     """
     src = """\
 set persistent [string repeat "alphabet" 50]
@@ -38,19 +53,21 @@ for {set i 0} {$i < 100} {incr i} {
     store = wasmtime.Store(engine)
     wasi_config = wasmtime.WasiConfig()
     store.set_wasi(wasi_config)
-    tcl_instance, rt_instance = _link_and_instantiate(store, wasm_bytes)
+    tcl_instance, _ = _link_and_instantiate(store, wasm_bytes)
     top_func = tcl_instance.exports(store).get("::top")
     if top_func is not None:
         top_func(store)
-    # Survival is the test — if the slot dangled we'd trap or read garbage.
+    # Survival is the test — a dangling slot would trap or read garbage
+    # somewhere in the 100-iteration loop.
 
 
 def test_eval_set_via_eval_command():
-    """eval triggers the interpreter path, not codegen.
+    """``eval`` triggers the interpreter path, not codegen.
 
-    `eval "set x"` parses the body string and routes through
-    eval_set's read form. After the fix, the result must be +1
-    owned and not corrupt the slot.
+    ``eval "set x"`` parses the body string and routes through
+    ``eval_set``'s read form.  After the fix the result is a true +1
+    owned handle and the outer ``set y`` write doesn't trip on a
+    freed handle.
     """
     src = """\
 set x "hello world"
@@ -61,14 +78,7 @@ set y [eval "set x"]
     store = wasmtime.Store(engine)
     wasi_config = wasmtime.WasiConfig()
     store.set_wasi(wasi_config)
-    tcl_instance, rt_instance = _link_and_instantiate(store, wasm_bytes)
+    tcl_instance, _ = _link_and_instantiate(store, wasm_bytes)
     top_func = tcl_instance.exports(store).get("::top")
     if top_func is not None:
         top_func(store)
-
-
-if __name__ == "__main__":
-    test_repeated_set_read_via_dynamic_name()
-    print("repeated dynamic-name set: OK")
-    test_eval_set_via_eval_command()
-    print("eval set: OK")

--- a/tests/test_eval_set_ownership.py
+++ b/tests/test_eval_set_ownership.py
@@ -1,0 +1,74 @@
+"""Stress test for eval_set read-form ownership fix.
+
+Exercises the interpreted eval_set read form (via dynamic var names so
+codegen can't fold into a direct frame read). After the fix, each
+[set $varname] substitution must return a +1 owned handle and not
+dangle the var slot's value.
+"""
+import wasmtime
+import pytest
+
+from tests.test_wasm_execution import (
+    _compile_to_wasm,
+    _get_engine,
+    _link_and_instantiate,
+)
+
+
+def test_repeated_set_read_via_dynamic_name():
+    """Stress: repeatedly read a global through a dynamic var name.
+
+    `set $name` is the read form (no value) with a dynamic name —
+    the compiler can't fold this and routes via the eval-fallback
+    path through eval_set. Before the fix, each iteration's read
+    would queue the slot's value for free, and the next iteration
+    would see a freed handle.
+    """
+    src = """\
+set persistent [string repeat "alphabet" 50]
+proc readit {n} { set $n }
+set tmp ""
+for {set i 0} {$i < 100} {incr i} {
+    set tmp [readit persistent]
+}
+"""
+    _, wasm_bytes = _compile_to_wasm(src)
+
+    engine = _get_engine()
+    store = wasmtime.Store(engine)
+    wasi_config = wasmtime.WasiConfig()
+    store.set_wasi(wasi_config)
+    tcl_instance, rt_instance = _link_and_instantiate(store, wasm_bytes)
+    top_func = tcl_instance.exports(store).get("::top")
+    if top_func is not None:
+        top_func(store)
+    # Survival is the test — if the slot dangled we'd trap or read garbage.
+
+
+def test_eval_set_via_eval_command():
+    """eval triggers the interpreter path, not codegen.
+
+    `eval "set x"` parses the body string and routes through
+    eval_set's read form. After the fix, the result must be +1
+    owned and not corrupt the slot.
+    """
+    src = """\
+set x "hello world"
+set y [eval "set x"]
+"""
+    _, wasm_bytes = _compile_to_wasm(src)
+    engine = _get_engine()
+    store = wasmtime.Store(engine)
+    wasi_config = wasmtime.WasiConfig()
+    store.set_wasi(wasi_config)
+    tcl_instance, rt_instance = _link_and_instantiate(store, wasm_bytes)
+    top_func = tcl_instance.exports(store).get("::top")
+    if top_func is not None:
+        top_func(store)
+
+
+if __name__ == "__main__":
+    test_repeated_set_read_via_dynamic_name()
+    print("repeated dynamic-name set: OK")
+    test_eval_set_via_eval_command()
+    print("eval set: OK")

--- a/tests/test_wasm_codegen.py
+++ b/tests/test_wasm_codegen.py
@@ -418,6 +418,13 @@ def test_no_cmd_imports_for_pure_math():
         "obj_get_int",
         "tcl_arith_add",
         "tcl_cmd_error",
+        # ``tcl_cmd_error_via_return`` is always imported now that
+        # the runtime wires ``return -code error msg`` through a
+        # dedicated entry point (PR #452); the lowering/codegen
+        # doesn't fire it for pure arithmetic but the import
+        # scanner pulls it into the always-on set alongside
+        # ``tcl_cmd_error``.
+        "tcl_cmd_error_via_return",
         "tcl_eval",
         "tcl_obj_retain",
         "tcl_obj_release",

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -4285,9 +4285,11 @@ class TestExternalTcllibCounter:
             pytest.skip(f"tcllib counter.tcl not present at {self._COUNTER_TCL}")
         source = self._COUNTER_TCL.read_text()
         wasm_bytes = _compile_tcl(source)
-        # Should be a reasonable size
+        # Should be a reasonable size.  Upper bound is a rough sanity
+        # check, not a tight budget — every refcount-discipline tweak
+        # adds a handful of bytes per call site.
         assert len(wasm_bytes) > 5000
-        assert len(wasm_bytes) < 100000
+        assert len(wasm_bytes) < 110000
 
     def test_top_level_runs(self):
         """Running ::top should not trap (validates string table sharing)."""

--- a/tests/test_wasm_switch_overrelease.py
+++ b/tests/test_wasm_switch_overrelease.py
@@ -1,0 +1,259 @@
+"""Regression test for the compiled-codegen switch over-release.
+
+The CFG builder for ``-exact`` ``switch`` lowers each arm into a
+``CFGBranch`` whose condition is
+``ExprBinary(STR_EQ, ExprRaw(subject), ExprLiteral(pattern))``.  The
+codegen helper :meth:`_emit_expr_obj_cmp_binary` (in
+``_emitter/_expressions.py``) stashed each operand in a scratch local
+and blanket-released both after the cmp call.  It only retained
+*borrowed* operands first, and recognised borrowed-ness via
+:meth:`_expr_node_is_borrowed`, which returned True solely for
+``ExprVar`` — not for ``ExprRaw`` even when the raw text resolved to
+a bare ``$var`` via ``_emit_value``.
+
+The result: every non-matching arm released the subject's TclObj
+without a matching retain.  N arms before the match ⇒ N over-releases
+per call ⇒ ``double_free_pending`` grows linearly with iteration count
+and arm position.  The fix propagates the ownership tag from
+``_emit_str_value`` so the helper retains the borrowed handle before
+stashing it.
+
+Requires the leak-check runtime (``make build-runtime-leakcheck``);
+skips otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import wasmtime
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from core.runtime_wasm import DEFAULT_PATH as _RUNTIME_WASM  # noqa: E402
+
+os.environ.setdefault("TCL_LSP_RUNTIME_WASM", str(_RUNTIME_WASM))
+
+from tests.test_wasm_real_tcl import (  # noqa: E402
+    _compile_tcl,
+    _define_call_compiled_proc,
+    _get_engine_with_timeout,
+)
+
+
+def _has_leakcheck_exports() -> bool:
+    """True when the runtime binary carries the leak-check counters."""
+    if not _RUNTIME_WASM.exists():
+        return False
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(_RUNTIME_WASM))
+    names = {imp.name for imp in module.exports}
+    return "tcl_test_double_free_pending_count" in names
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_leakcheck_exports(),
+    reason="leak-check runtime exports missing — run 'make build-runtime-leakcheck'",
+)
+
+
+def _call_counter(exports, name: str, store: wasmtime.Store) -> int:
+    """Look up a counter-export by *name*, assert it's a Func, call it,
+    and coerce the result to ``int``.
+
+    The leak-check counter exports all have signature ``() -> i32``,
+    so the call result rounds-trips via ``int()`` cleanly.  This
+    tiny wrapper exists to satisfy ty's union-type narrowing — the
+    subscript on ``exports`` returns
+    ``Func | Table | Memory | SharedMemory | Global`` and only
+    ``Func`` is callable.
+    """
+    fn = exports[name]
+    assert isinstance(fn, wasmtime.Func), f"{name!r} is not a Func: {type(fn)}"
+    result = fn(store)
+    assert result is not None, f"{name!r} returned None"
+    return int(result)  # type: ignore[call-overload]
+
+
+def _call_void(exports, name: str, store: wasmtime.Store) -> None:
+    """Call a void-returning export by *name*.  See :func:`_call_counter`
+    for the narrowing rationale.
+    """
+    fn = exports[name]
+    assert isinstance(fn, wasmtime.Func), f"{name!r} is not a Func: {type(fn)}"
+    fn(store)
+
+
+def _run_under_leakcheck(tcl_source: str) -> dict[str, int]:
+    """Compile *tcl_source*, run ``::top``, return the leak-check counters."""
+    wasm_bytes = _compile_tcl(tcl_source, frame_elision=True)
+    engine = _get_engine_with_timeout()
+    store = wasmtime.Store(engine)
+    store.set_epoch_deadline(1_000_000_000)
+    wasi_config = wasmtime.WasiConfig()
+    with tempfile.TemporaryDirectory(prefix="leakrep-") as host_tmp:
+        wasi_config.preopen_dir(host_tmp, "/")
+        store.set_wasi(wasi_config)
+        rt_module = wasmtime.Module.from_file(engine, str(_RUNTIME_WASM))
+        linker = wasmtime.Linker(engine)
+        linker.define_wasi()
+        tcl_box, mem_box, rt_box = _define_call_compiled_proc(linker, store)
+        rt_inst = linker.instantiate(store, rt_module)
+        rt_box[0] = rt_inst
+        init = rt_inst.exports(store).get("_initialize")
+        if init is not None and isinstance(init, wasmtime.Func):
+            init(store)
+        for export in rt_module.exports:
+            name = export.name
+            if name.startswith("__"):
+                continue
+            val = rt_inst.exports(store)[name]
+            if isinstance(val, wasmtime.Func):
+                linker.define(store, "tcl", name, val)
+            elif name == "memory":
+                linker.define(store, "tcl", name, val)
+        exports = rt_inst.exports(store)
+        _call_void(exports, "tcl_test_reset_counters", store)
+        user_module = wasmtime.Module(engine, wasm_bytes)
+        user_inst = linker.instantiate(store, user_module)
+        tcl_box[0] = user_inst
+        mem_box[0] = exports["memory"]
+        _call_void(user_inst.exports(store), "::top", store)
+        residual = _call_counter(exports, "tcl_test_finalize", store)
+        return {
+            "residual": residual,
+            "double_free": _call_counter(exports, "tcl_test_double_free_count", store),
+            "pending": _call_counter(exports, "tcl_test_double_free_pending_count", store),
+            "poison": _call_counter(exports, "tcl_test_double_free_poison_count", store),
+            "bad_rc": _call_counter(exports, "tcl_test_double_free_bad_rc_count", store),
+        }
+
+
+def test_switch_exact_no_pending_overrelease():
+    """A ``switch -exact`` whose subject is a variable must not over-release
+    the subject's TclObj as arms are tested.
+
+    Before the fix: ``pending`` scaled as ``iters * (matching_arm_index)``.
+    After the fix: ``pending == 0`` regardless of arm position.
+    """
+    src = """
+proc test {x} {
+    switch $x { a {return 1} b {return 2} c {return 3} d {return 4} e {return 5} }
+}
+for {set i 0} {$i < 50} {incr i} { test e }
+"""
+    counters = _run_under_leakcheck(src)
+    assert counters["pending"] == 0, (
+        f"switch over-released subject TclObj: {counters}.  "
+        f"Each non-matching arm before the match released the subject "
+        f"without a matching retain — fix in _emit_expr_obj_cmp_binary."
+    )
+    assert counters["double_free"] == 0, counters
+
+
+def test_switch_exact_stress_10k():
+    """10k-iteration stress: ``pending`` and ``double_free`` stay at 0
+    across a much larger workload.  Catches regressions that the
+    smaller 50-iter test might miss (e.g. counter overflow, slab
+    recycling races).
+    """
+    src = """
+proc test {x} {
+    switch $x { a {return 1} b {return 2} c {return 3} d {return 4} e {return 5} }
+}
+for {set i 0} {$i < 10000} {incr i} { test e }
+"""
+    counters = _run_under_leakcheck(src)
+    assert counters["pending"] == 0, counters
+    assert counters["double_free"] == 0, counters
+
+
+@pytest.mark.parametrize(
+    "subject,arm_count_before_match",
+    [
+        ("a", 0),
+        ("b", 1),
+        ("c", 2),
+        ("d", 3),
+        ("e", 4),
+    ],
+)
+def test_switch_no_overrelease_at_each_position(subject, arm_count_before_match):
+    """Each match position in the arm list must hold rc discipline.
+
+    The bug's signature was ``pending == iters * arm_count_before_match``;
+    by sweeping each position we'd see a positive ``pending`` for any
+    position except ``a`` (the first arm) if the regression returned.
+    """
+    src = f"""
+proc test {{x}} {{
+    switch $x {{ a {{return 1}} b {{return 2}} c {{return 3}} d {{return 4}} e {{return 5}} }}
+}}
+for {{set i 0}} {{$i < 100}} {{incr i}} {{ test {subject} }}
+"""
+    counters = _run_under_leakcheck(src)
+    assert counters["pending"] == 0, (
+        f"match position {subject!r} (arm index {arm_count_before_match}) over-released: {counters}"
+    )
+    assert counters["double_free"] == 0, counters
+
+
+def test_switch_glob_no_pending_overrelease():
+    """``-glob`` switches use the inline ``_emit_switch`` path rather
+    than CFG lowering.  Verify they also stay clean — even though the
+    bug fix targets cmp_binary, future refactors might unify the two
+    paths.  (The glob path has unrelated alloc-residual that is not
+    asserted on here.)
+    """
+    src = """
+proc test {x} {
+    switch -glob $x { a {return 1} b {return 2} c {return 3} d {return 4} e {return 5} }
+}
+for {set i 0} {$i < 50} {incr i} { test e }
+"""
+    counters = _run_under_leakcheck(src)
+    assert counters["pending"] == 0, counters
+    assert counters["double_free"] == 0, counters
+
+
+def test_switch_fallthrough_arms_no_pending_overrelease():
+    """Fallthrough arms route through ``_emit_switch`` (not CFG) but
+    use the same ``string_equal`` import.  Verify rc discipline is
+    held.
+    """
+    src = """
+proc test {x} {
+    switch $x { a - b - c {return 1} d - e {return 2} }
+}
+for {set i 0} {$i < 50} {incr i} { test e }
+"""
+    counters = _run_under_leakcheck(src)
+    assert counters["pending"] == 0, counters
+    assert counters["double_free"] == 0, counters
+
+
+def test_if_elseif_chain_no_pending_overrelease():
+    """``if`` / ``elseif`` chains exercise ``_emit_expr_obj_cmp_binary``
+    too, but with ``ExprVar`` operands (not ``ExprRaw``).  The pre-fix
+    code path handled this correctly via the ``_expr_node_is_borrowed``
+    check — kept here to lock in the equivalence between switch and
+    if/elseif now that switch is also clean.
+    """
+    src = """
+proc test {x} {
+    if {$x eq "a"} {return 1} \\
+    elseif {$x eq "b"} {return 2} \\
+    elseif {$x eq "c"} {return 3} \\
+    elseif {$x eq "d"} {return 4} \\
+    elseif {$x eq "e"} {return 5}
+}
+for {set i 0} {$i < 50} {incr i} { test e }
+"""
+    counters = _run_under_leakcheck(src)
+    assert counters["pending"] == 0, counters
+    assert counters["double_free"] == 0, counters


### PR DESCRIPTION
## Summary

This PR fixes multiple reference counting leaks in the Tcl runtime and compiled code generation:

1. **Compiled switch statement over-release** (primary issue): The CFG builder for `-exact` switch statements lowered each arm into a comparison that stashed operands in scratch locals. The codegen helper `_emit_expr_obj_cmp_binary` blanket-released both operands after the comparison, but only retained *borrowed* operands first. It recognized borrowed-ness via `_expr_node_is_borrowed`, which only returned True for `ExprVar`, not for `ExprRaw` (even when the raw text resolved to a bare `$var`). Result: every non-matching arm released the subject's TclObj without a matching retain, causing N over-releases per call where N = arms before the match. Fixed by propagating the ownership tag from `_emit_str_value` so the helper retains borrowed handles before stashing.

2. **Runtime allocation and ownership tracking fixes**: Multiple Zig runtime functions were leaking TclObjs due to:
   - Not releasing intermediate results from in-place-or-rebuild operations (dict operations, list operations)
   - Not releasing fresh +1 owned objects returned by helper functions before returning
   - Not tracking ownership correctly when operations may return the same handle or a fresh object
   - Missing null checks after allocations that could fail
   - Incorrect retain/release pairing on same-handle re-stamps

3. **Memory allocation safety**: Added null checks after `alloc()` calls throughout the runtime to prevent writing through `@ptrFromInt(0)` on OOM conditions.

4. **String allocation refactoring**: Replaced direct `obj_new_string(@bitCast(buf), @bitCast(len))` calls with `obj_new_string_take(buf, len, capacity)` to properly track allocated buffer sizes for cleanup.

## Validation

- Added comprehensive regression test suite (`test_wasm_switch_overrelease.py`) with leak-check runtime validation:
  - `test_switch_exact_no_pending_overrelease`: Verifies switch statements don't over-release
  - `test_switch_exact_stress_10k`: Stress test with 10k iterations
  - `test_switch_no_overrelease_at_each_position`: Tests each arm position
  - `test_switch_glob_no_pending_overrelease`: Validates glob-mode switches
  - `test_switch_fallthrough_arms_no_pending_overrelease`: Tests fallthrough arms
  - `test_if_elseif_chain_no_pending_overrelease`: Tests if/elseif chains
- Tests require leak-check runtime (`make build-runtime-leakcheck`) and skip gracefully if unavailable
- Existing codegen tests updated to reflect new import requirements

## Files Modified

**Compiler (codegen)**:
- `core/compiler/codegen/wasm/_emitter/_expressions.py`: Fixed `_emit_expr_obj_cmp_binary` to use ownership tags from `_emit_str_value`

**Runtime (Zig)**:
- `runtime/zig/cmds/dict.zig`: Fixed ownership tracking in dict operations (getwithdefault, create, append, lappend, incr, merge, remove)
- `runtime/zig/cmds/list.zig`: Fixed ownership tracking in lset and lassign
- `runtime/zig/cmds/tcl_alias.zig`: Added cleanup for alias prefix args
- `runtime/zig/cmds/binary.zig`: Added OOM checks and proper string allocation
- `runtime/zig/cmds/coroutine.zig`: Added OOM checks
- `runtime/zig/cmds/tcl_cmd_interp.zig`: Added OOM checks and string allocation fixes
- `runtime/zig/cmds/tcl_cmd_info.zig`: Added OOM checks
- `runtime/zig/cmds/tcl_rename.zig`: Added alias cleanup on deletion
- `runtime/zig/cmds/chan.zig`: Added OOM checks
- `runtime/zig/cmds/flow.zig`: Added OOM

https://claude.ai/code/session_017ic62QQUZ4216K5j46m1MK