### PR TITLE
Propagate return -code break/continue through compiled proc calls

### DIFF
--- a/core/compiler/codegen/wasm/_emitter/_commands.py
+++ b/core/compiler/codegen/wasm/_emitter/_commands.py
@@ -364,23 +364,51 @@ class _WasmEmitterCmdMixin(_Base):
                 self._emit(WasmOp.END)
             self._emit(WasmOp.END)
         # ``return -code break`` / ``return -code continue`` from a
-        # compiled callee leaves a signal flag set.  Two cases:
+        # compiled callee leaves ``break_flag`` / ``continue_flag`` set
+        # (``flow_take_return`` translated the pending ``-code`` above)
+        # plus the matching signal side-channel.  Two cases:
         #
-        # * Inside a compiled while/foreach: fall through naturally
-        #   to the loop's body-end ``flow_consume_break/continue``
-        #   probes, which catch ``break_flag`` / ``continue_flag``
-        #   (both of which were paired with the signal flag).  No
-        #   explicit branch needed — the flags stay live.  We just
-        #   clear the *signal* side-channel so the next dispatch
-        #   level doesn't try to translate it.
+        # * Inside a compiled while/foreach reachable by a direct br:
+        #   consume the flag and branch to the loop's break / continue
+        #   target *immediately*.  C Tcl ends the loop body the moment a
+        #   command returns TCL_BREAK / TCL_CONTINUE — statements after
+        #   the call (e.g. ``OptNextDesc`` after ``OptDoOne`` in
+        #   optparse's ``OptDoAll``) must NOT run.  Relying on the
+        #   loop's body-end consume probe would wrongly execute them.
         #
         # * Outside any loop in this proc: ``return`` from the WASM
-        #   function so the proc dispatcher (compiled-proc path in
-        #   ``eval_proc_call_bucket`` or the matching post-dispatch
-        #   stamp) translates the signal into the caller's
-        #   ``break_flag`` / ``continue_flag``.  Skipped inside a
-        #   catch — the surrounding ``_emit_catch`` per-statement
-        #   probe handles unwind via the catch absorption path.
+        #   function so the proc dispatcher translates the signal into
+        #   the caller's ``break_flag`` / ``continue_flag``.  Skipped
+        #   inside a catch — the surrounding ``_emit_catch`` per-
+        #   statement probe handles unwind via the catch absorption
+        #   path.
+        consume_break_idx = self._shared_imports.get("tcl_flow_consume_break")
+        consume_cont_idx = self._shared_imports.get("tcl_flow_consume_continue")
+        # ``loop_inside_catch`` is True when the innermost enclosing loop
+        # is NOT separated from this call site by a compile-time
+        # ``catch`` — i.e. a structured ``br`` to the loop targets is
+        # safe (mirrors the lexical break/continue logic in
+        # ``_statements.py``).  When a catch sits between, leave the
+        # flags set so ``catch_leave`` absorbs the loop-control code.
+        loop_reachable = bool(self._loop_ctrl_depths) and (
+            not self._loop_catch_depths or self._loop_catch_depths[-1] >= self._catch_depth
+        )
+        if self._loop_depth > 0 and loop_reachable and consume_break_idx is not None:
+            loop_ctrl = self._loop_ctrl_depths[-1]
+            # The br is emitted inside the ``IF`` block, so ``_ctrl_depth``
+            # is already incremented by it — the lexical break/continue
+            # depth formulae (``_ctrl_depth - loop_ctrl + 2`` /
+            # ``_ctrl_depth - loop_ctrl``) then yield the correct target
+            # automatically (the extra IF frame is accounted for).
+            self._emit_call(consume_break_idx)
+            self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+            self._emit_br(self._ctrl_depth - loop_ctrl + 2)
+            self._emit(WasmOp.END)
+            if consume_cont_idx is not None:
+                self._emit_call(consume_cont_idx)
+                self._emit(WasmOp.IF, bytes([_BLOCK_VOID]))
+                self._emit_br(self._ctrl_depth - loop_ctrl)
+                self._emit(WasmOp.END)
         sig_loop_idx = self._shared_imports.get("tcl_flow_check_signal_loop")
         if (
             sig_loop_idx is not None

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -383,22 +383,6 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
         catch_mod.state.return_via_error_code = 1;
         return result_mod.from_globals(0);
     }
-    // ``return -code break`` / ``return -code continue`` aren't yet
-    // wired through the compiled-proc body machinery — propagating
-    // them correctly requires a per-statement break/continue check
-    // that can branch out to the enclosing loop's consume probe,
-    // which the codegen doesn't emit yet.  Falling through to the
-    // default return path keeps single-callsite tests green at the
-    // cost of a small handful of optparse state-machine cases
-    // (opt-10.8 / 10.9 / 11.x).  Tracking as a follow-up; the
-    // signal-flag scaffolding (``signal_break_flag`` /
-    // ``signal_continue_flag`` / ``flow_check_signal_loop``) stays
-    // in place for that future work.
-    if (code_kind == .brk or code_kind == .cont) {
-        // Suppress "unused .brk/.cont arm" while we leave the full
-        // wire-up for the follow-up that adds the codegen-side
-        // per-statement probes.
-    }
     // ``return -level 0 …`` is the no-unwind form: the command
     // produces the value with the requested status code but the
     // current frame keeps running.  ``return -level 0 X`` is exactly
@@ -432,6 +416,25 @@ fn eval_return(words: []const i32) result_mod.InterpResult {
             },
             .ret, .err => {},
         }
+    }
+    // ``return -code break`` / ``return -code continue`` (default
+    // ``-level 1``) unwind the proc body like a normal ``return`` — the
+    // ``set_return`` below sets ``return_flag`` with ``return_level ==
+    // 0`` and ``pending_return_code`` (3 / 4) was stamped above — but
+    // ALSO arm the ``signal_break_flag`` / ``signal_continue_flag``
+    // side-channel.  At the proc-dispatch / compiled-call absorb
+    // boundary the pending code is translated into ``break_flag`` /
+    // ``continue_flag`` for an enclosing loop to catch (interpreted:
+    // ``apply_pending_return_code``; compiled: ``flow_take_return``).
+    // When the loop-control ``return`` lands in a proc with no enclosing
+    // loop the signal flag drives ``flow_check_signal_loop`` so the
+    // compiled body returns out to its dispatcher, which re-stamps the
+    // caller's flag.  The ``-level 0`` no-unwind form is handled above
+    // and never reaches here.
+    if (code_kind == .brk) {
+        result_mod.set_signal_break();
+    } else if (code_kind == .cont) {
+        result_mod.set_signal_continue();
     }
     // MM-B.5: ``return_val`` slot holds the value until
     // ``eval_proc_call_bucket`` reads it back.  Retain so ``MM-B.4``'s

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -436,12 +436,26 @@ pub export fn flow_take_return() i32 {
         // ``signal_continue_flag`` stay set (armed by ``eval_return``);
         // the consume probe clears both.  Other pending codes (TCL_OK,
         // TCL_RETURN, custom) keep their existing absorb paths.
+        //
+        // Disarm the pending-return metadata when translating: once the
+        // loop-control code lives in ``break_flag`` / ``continue_flag``,
+        // a surrounding ``catch BODY result options`` must report the
+        // options dict via ``catch_leave``'s break / continue mapping
+        // (``-code 3 -level 1`` / ``-code 4 -level 1``), exactly as a
+        // raw ``break`` / ``continue`` would.  Leaving ``pending_return_
+        // armed`` set with a now-zero ``pending_return_code`` would make
+        // ``catch_leave`` snapshot ``-code 0`` even though the catch
+        // result code is 3 / 4.
         if (state.pending_return_code == 3) {
             state.break_flag = 1;
             state.pending_return_code = 0;
+            state.pending_return_level = 1;
+            state.pending_return_armed = 0;
         } else if (state.pending_return_code == 4) {
             state.continue_flag = 1;
             state.pending_return_code = 0;
+            state.pending_return_level = 1;
+            state.pending_return_armed = 0;
         }
         return v;
     }

--- a/runtime/zig/interp/tcl_catch.zig
+++ b/runtime/zig/interp/tcl_catch.zig
@@ -425,6 +425,24 @@ pub export fn flow_take_return() i32 {
         }
         state.return_flag = 0;
         state.return_val = 0;
+        // ``return -code break`` / ``return -code continue`` arrive here
+        // with ``return_flag`` set (the unwind reached the proc body's
+        // top) and ``pending_return_code`` == 3 / 4.  Translate the
+        // pending code into the matching loop-control flag so the
+        // caller's enclosing compiled loop (its ``flow_consume_break`` /
+        // ``flow_consume_continue`` probe) — or, when there's no loop,
+        // the compiled body's ``flow_check_signal_loop`` early-return —
+        // observes the break / continue.  ``signal_break_flag`` /
+        // ``signal_continue_flag`` stay set (armed by ``eval_return``);
+        // the consume probe clears both.  Other pending codes (TCL_OK,
+        // TCL_RETURN, custom) keep their existing absorb paths.
+        if (state.pending_return_code == 3) {
+            state.break_flag = 1;
+            state.pending_return_code = 0;
+        } else if (state.pending_return_code == 4) {
+            state.continue_flag = 1;
+            state.pending_return_code = 0;
+        }
         return v;
     }
     return 0;

--- a/tests/baselines/tcl9-tcltest/categories/opt.toml
+++ b/tests/baselines/tcl9-tcltest/categories/opt.toml
@@ -1,19 +1,14 @@
 # opt.test categorisation (Tcl 9.0.3 source tree).
-# Bundle reaches its tcltest summary line now.  Residual must_pass
-# failures are ``return -code break`` / ``return -code continue``
-# propagation through compiled-proc bodies — see issue #325 follow-up.
+# Runs the real upstream ``library/opt/optparse.tcl`` and passes
+# 31/31 — no opt-specific runtime / compiler support.  ``OptDoOne``'s
+# ``return -code break`` / ``return -code continue`` now propagate
+# through compiled-proc bodies to ``OptDoAll``'s enclosing loop.
 
-good_to_have = [
-  "10.8",   # opt-10.8: ``OptDoOne`` issues ``return -code break`` to
-            # exit the ``OptDoAll`` foreach early; our compiled-proc
-            # codegen consumes the break flag at the proc boundary
-            # instead of letting it bubble to the enclosing loop.
-  "10.9",   # opt-10.9: same shape with ``return -code continue``.
-]
+good_to_have = []
 just_to_match_ctcl = []
 skip = []
 
 [baseline]
-good_to_have_failing = 2
+good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0

--- a/tests/external/run_tcl9_tests.py
+++ b/tests/external/run_tcl9_tests.py
@@ -942,10 +942,6 @@ _BASELINE: dict[str, dict[str, int | bool]] = {
     # vs expected 1) and proc-old-10.1 (ByteCode epoch change during
     # recursive proc execution).
     "proc-old": {"min_passed": 31, "max_failed": 43},
-    # opt.test — 29/31 passing.  opt-10.8 / opt-10.9 need
-    # ``return -code break`` / ``return -code continue`` to propagate
-    # through compiled-proc bodies (codegen follow-up from #325).
-    "opt": {"min_passed": 27, "max_failed": 4},
 }
 
 


### PR DESCRIPTION
return -code break / return -code continue from a proc body must
surface as a loop-control exit in the caller: an enclosing loop should
break or continue, exactly as if the called command itself raised
TCL_BREAK / TCL_CONTINUE. The compiled-proc path silently degraded
these to a plain return, so optparse's OptDoOne/OptDoAll state machine
(and any code relying on this idiom) misbehaved.

- flow.zig: return -code break/continue now arm the
  signal_break/continue side-channel alongside the existing
  return_flag + pending_return_code unwind.
- tcl_catch.zig: flow_take_return (the compiled proc-call absorb
  boundary) translates pending code 3/4 into break_flag/continue_flag.
- _commands.py: after a compiled proc call inside a loop, consume a
  pending break/continue and branch to the loop's break/continue
  target immediately so statements after the call do not run.

opt.test now passes 31/31 against the real upstream optparse.tcl with
no opt-specific runtime or compiler support. Tightened the opt triage
baseline to gate strictly at zero failures.

https://claude.ai/code/session_016PakynqrVCikDQuCsskdVc