### PR TITLE
Preserve array indices when renaming base variables

### DIFF
--- a/lsp/features/rename.py
+++ b/lsp/features/rename.py
@@ -133,6 +133,17 @@ def _resolve_variable_symbol(
     return None
 
 
+def _array_index_suffix(body: str) -> str:
+    """Return a trailing array-index suffix like ``(a)`` from a var reference body.
+
+    A reference to an array element such as ``$arr(a)`` carries the whole
+    ``arr(a)`` span, but renaming the base variable must rewrite only the name
+    and keep the index intact.
+    """
+    paren = body.find("(")
+    return body[paren:] if paren >= 0 else ""
+
+
 def _build_var_replacement(
     ref_line: str,
     ref: Range,
@@ -162,9 +173,13 @@ def _build_var_replacement(
                 offset=end.offset + 1,
             )
     elif has_dollar:
-        replacement = "$" + new_qualified
+        # Preserve a trailing array-index suffix, e.g. $arr(a) -> $new(a).
+        body = ref_line[ch + 1 : end.character + 1]
+        suffix = _array_index_suffix(body)
+        replacement = "$" + new_qualified + suffix
     else:
-        replacement = new_qualified
+        suffix = _array_index_suffix(ref_line[ch : end.character + 1])
+        replacement = new_qualified + suffix
 
     return Range(start=ref.start, end=end), replacement
 

--- a/lsp/features/rename.py
+++ b/lsp/features/rename.py
@@ -163,7 +163,10 @@ def _build_var_replacement(
     end = ref.end
 
     if has_brace:
-        replacement = "${" + new_qualified + "}"
+        # Preserve a trailing array-index suffix, e.g. ${arr(a)} -> ${new(a)}.
+        body = ref_line[ch + 2 : end.character + 1]
+        suffix = _array_index_suffix(body)
+        replacement = "${" + new_qualified + suffix + "}"
         # Extend range to cover closing brace
         close_ch = end.character + 1
         if close_ch < len(ref_line) and ref_line[close_ch] == "}":

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -170,6 +170,7 @@ class TestRenameVariable:
             puts $arr
             puts $arr(a)
             puts $arr($i)
+            puts ${arr(b)}
         """)
         edit = get_rename_edits(source, TEST_URI, 0, 4, "new")
         assert edit is not None
@@ -180,6 +181,7 @@ class TestRenameVariable:
         assert "$new" in texts  # scalar reference
         assert "$new(a)" in texts  # literal index preserved
         assert "$new($i)" in texts  # variable index preserved
+        assert "${new(b)}" in texts  # braced index preserved
 
     def test_rename_respects_scope(self):
         source = textwrap.dedent("""\

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -163,6 +163,24 @@ class TestRenameVariable:
         assert "myns::total" in texts  # definition
         assert "${myns::total}" in texts  # braced reference
 
+    def test_rename_preserves_array_index(self):
+        """Renaming a base variable keeps the array index of element refs."""
+        source = textwrap.dedent("""\
+            set arr 1
+            puts $arr
+            puts $arr(a)
+            puts $arr($i)
+        """)
+        edit = get_rename_edits(source, TEST_URI, 0, 4, "new")
+        assert edit is not None
+        assert edit.changes is not None
+        edits = edit.changes[TEST_URI]
+        texts = {e.new_text for e in edits}
+        assert "new" in texts  # definition
+        assert "$new" in texts  # scalar reference
+        assert "$new(a)" in texts  # literal index preserved
+        assert "$new($i)" in texts  # variable index preserved
+
     def test_rename_respects_scope(self):
         source = textwrap.dedent("""\
             set x 1


### PR DESCRIPTION
## Summary

- Fixed variable rename refactoring to preserve array index suffixes (e.g., `$arr(a)` → `$new(a)`)
- Added `_array_index_suffix()` helper to extract trailing array-index syntax from variable references
- Updated `_build_var_replacement()` to append the extracted suffix to renamed variables in both dollar-prefixed and non-prefixed forms

## Details

When renaming a base variable that is referenced as an array element (e.g., `$arr(index)`), the LSP rename feature was incorrectly dropping the index suffix. The variable reference span includes the entire `arr(index)` text, but only the base name should be replaced while the index must be preserved.

This change extracts any trailing parenthesized suffix from the reference body and appends it to the new qualified name, handling both literal indices (`$arr(a)`) and variable indices (`$arr($i)`).

## Validation

- Added `test_rename_preserves_array_index()` covering scalar references, literal indices, and variable indices
- Existing rename tests continue to pass

https://claude.ai/code/session_01BwRUJP5JbCJLbEbXXvJJhp