### PR TITLE
Apply zig fmt to dict.zig and tcl_mathop.zig

### DIFF
--- a/runtime/zig/cmds/dict.zig
+++ b/runtime/zig/cmds/dict.zig
@@ -96,13 +96,22 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
                 }
                 const dst: [*]u8 = @ptrFromInt(buf);
                 var off: u32 = 0;
-                for (prefix) |c| { dst[off] = c; off += 1; }
+                for (prefix) |c| {
+                    dst[off] = c;
+                    off += 1;
+                }
                 if (ks.len > 0 and ks.ptr != 0) {
                     const sp_k: [*]const u8 = @ptrFromInt(ks.ptr);
                     var k: u32 = 0;
-                    while (k < ks.len) : (k += 1) { dst[off] = sp_k[k]; off += 1; }
+                    while (k < ks.len) : (k += 1) {
+                        dst[off] = sp_k[k];
+                        off += 1;
+                    }
                 }
-                for (middle) |c| { dst[off] = c; off += 1; }
+                for (middle) |c| {
+                    dst[off] = c;
+                    off += 1;
+                }
                 const msg = obj_mod_dict.obj_new_string_take(buf, total, total);
                 const catch_mod_dict = @import("../interp/tcl_catch.zig");
                 catch_mod_dict.tcl_cmd_error(msg);

--- a/runtime/zig/cmds/tcl_mathop.zig
+++ b/runtime/zig/cmds/tcl_mathop.zig
@@ -306,7 +306,6 @@ fn op_rshift(args: []const i32) i32 {
     return tcl_arith.tcl_arith_rshift(args[0], args[1]);
 }
 
-
 // -- numeric comparison (chain) ----------------------------------------------
 
 const CmpKind = enum { eq, ne, lt, le, gt, ge };


### PR DESCRIPTION
## Summary
- Run `zig fmt` on `runtime/zig/cmds/dict.zig` and `runtime/zig/cmds/tcl_mathop.zig`.
- Unblocks `make check-zig` / `make test-slow`, required for the upcoming release.

## Test plan
- [x] `make check-zig` clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)