### PR TITLE
ci: set up Zig in build-zipapp-wasm job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,6 +1076,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Zig (needed for runtime auto-build)
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+          use-cache: true
+
+      - name: Fetch Tcl regex engine sources (runtime/zig/vendor/tcl-regex)
+        run: bash scripts/fetch_tcl_regex.sh
+
       - name: Sync Python environment
         run: uv sync --extra dev
 

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.6-16-gaad9ec52-dirty
-head=aad9ec529ce15d59e5f05963e558fbd8c90b67ba
-date=2026-05-21T10:19:24Z
-fingerprint=1f273ca31c37abc99670b1f87e4f1246ede665f4291dceea9ed1719662b10447
+describe=v1.10.7-0-g4310431c-dirty
+head=4310431c41ce07d0c561834768e3c492b65ec0df
+date=2026-05-21T11:00:42Z
+fingerprint=9cb845ec3040870af6b079298f0b23e0b2f2a3e9d263ce9633e7c8a60ffc9bbc


### PR DESCRIPTION
## Problem

The v1.10.7 tag CI run failed in `build-zipapp-wasm` with `zig: command not found`, which skipped `publish-checksums` and left the release without `SHA256SUMS`.

`make zipapp-wasm` now builds `runtime/zig/zig-out/bin/tcl_runtime.wasm` from the Zig sources (a real-file Make target keyed on the `.zig` sources, introduced in #464). The `build-zipapp-wasm` job — which runs **only** on `refs/tags/v*` — never installed Zig or fetched the Tcl regex vendor sources, so it was never exercised by a PR and broke on the first tag build.

## Fix

Add the same `mlugg/setup-zig` + `scripts/fetch_tcl_regex.sh` steps that the `pr-gate` job already uses, before `make zipapp-wasm`.

`.test-slow.stamp` refreshed for the `ci.yml` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)