### PR TITLE
Fix JetBrains Compiler Explorer source push and add "Open In" entries

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.7-0-g4310431c-dirty
-head=4310431c41ce07d0c561834768e3c492b65ec0df
-date=2026-05-21T11:00:42Z
-fingerprint=9cb845ec3040870af6b079298f0b23e0b2f2a3e9d263ce9633e7c8a60ffc9bbc
+describe=effd066-dirty
+head=effd066925935cb30f803496385cf6227ac673c1
+date=2026-05-21T12:39:35Z
+fingerprint=d532369c6f6db54054615cfe65cfbe506c51a9880cb64bbe9c174a53238b33a2

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=effd066-dirty
-head=effd066925935cb30f803496385cf6227ac673c1
-date=2026-05-21T12:39:35Z
-fingerprint=d532369c6f6db54054615cfe65cfbe506c51a9880cb64bbe9c174a53238b33a2
+describe=0429088-dirty
+head=042908864667fa78a72062f22a35ef5fe676de44
+date=2026-05-21T13:07:26Z
+fingerprint=7c1f76d909a1e6a01b72277a1e30210ce69258edcaf23a8dc8842844527fe276

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The full-featured extension, distributed as a `.vsix`, bundles the LSP server
 and provides the richest integration.
 
 **25+ commands** including: Restart Server, Select Dialect, Apply Safe Quick
-Fixes, Apply All Optimisations, Open Compiler Explorer, Open Tk Preview,
+Fixes, Apply All Optimisations, Open in Tcl Compiler Explorer, Open Tk Preview,
 Format Document, Minify Document, Insert iRule Event Skeleton, Scaffold Tcl
 Package Starter, Insert `package require`, Run Runtime Validation, Translate
 iRule to F5 XC, Extract iRule from Config, Escape/Unescape Selection, Base64

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,15 @@
   bridge object whose `postMessage` queues requests until the Kotlin
   host installs `window.__tcllspBridge`, at which point the queue is
   drained.
+- **JetBrains: Compiler Explorer source push no longer races the EDT.**
+  Even with the JCEF bridge in place, the explorer could stay on
+  "Waiting for source from editor..." when it was opened while a Tcl
+  file was already the active tab: the initial push ran from the JCEF
+  `onLoadEnd` callback thread and read `selectedTextEditor` off the
+  EDT, so it silently produced nothing and no editor event ever fired
+  to retry. The push now hops to the EDT, and the panel also listens
+  for `selectionChanged` so switching between already-open tabs
+  recompiles.
 - **JetBrains: bundle LSP server outside the plugin jar.** v1.10.6
   shipped the source-level W105 quick-fix that preserves `$` in
   variable references (`$script` → `{$script}`), but users running the
@@ -102,6 +111,12 @@
 
 ## Improvements
 
+- **"Open In Tcl Compiler Explorer" context-menu entry.** Both editor
+  plugins now expose the Compiler Explorer from a right-click. JetBrains
+  adds an "Open In Tcl Compiler Explorer" action to the editor and
+  project-view popups that reveals the tool window and pushes the file;
+  VS Code's existing entry is renamed to "Open in Tcl Compiler Explorer"
+  to match.
 - **`mathop` operators delegate to `tcl_arith` helpers.** The
   `::tcl::mathop` namespace no longer duplicates arithmetic; every
   operator now routes through the shared `tcl_arith` paths, bringing

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -12,11 +12,13 @@ VS Code
 
 | Context | How |
 |---------|-----|
-| VS Code | `Tcl: Open Compiler Explorer` (Ctrl+Alt+E) |
+| VS Code | `Tcl: Open in Tcl Compiler Explorer` (Ctrl+Alt+E), or right-click a Tcl file → `Tcl` → `Open in Tcl Compiler Explorer` |
+| JetBrains | Right-click a Tcl/iRule file → `Open In Tcl Compiler Explorer`, or open the `Tcl Compiler Explorer` tool window |
 
 ## How to use
 
-- **VS Code**: Open a Tcl file and run `Tcl: Open Compiler Explorer` from the command palette or press Ctrl+Alt+E. The panel shows bytecode disassembly side-by-side with the source, and updates live as you edit.
+- **VS Code**: Open a Tcl file and run `Tcl: Open in Tcl Compiler Explorer` from the command palette or press Ctrl+Alt+E. The panel shows bytecode disassembly side-by-side with the source, and updates live as you edit.
+- **JetBrains**: Right-click a Tcl/iRule file in the editor or project view and choose `Open In Tcl Compiler Explorer`, or open the `Tcl Compiler Explorer` tool window. The panel tracks the active editor and recompiles as you switch files or edit.
 
 ## Operational context
 

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -18,7 +18,7 @@ VS Code
 ## How to use
 
 - **VS Code**: Open a Tcl file and run `Tcl: Open in Tcl Compiler Explorer` from the command palette or press Ctrl+Alt+E. The panel shows bytecode disassembly side-by-side with the source, and updates live as you edit.
-- **JetBrains**: Right-click a Tcl/iRule file in the editor or project view and choose `Open In Tcl Compiler Explorer`, or open the `Tcl Compiler Explorer` tool window. The panel tracks the active editor and recompiles as you switch files or edit.
+- **JetBrains**: Right-click a Tcl/iRule file in the editor or project view and choose `Open In Tcl Compiler Explorer`, or open the `Tcl Compiler Explorer` tool window. The panel tracks the active editor and recompiles when you open or switch to a different Tcl file.
 
 ## Operational context
 

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -38,7 +38,8 @@ All features from the tcl-lsp server are supported:
 - **Call hierarchy** (incoming/outgoing)
 - **Code folding**, **inlay hints**, **signature help**
 - **Code actions** (quick fixes)
-- **Compiler Explorer** tool window (IR, CFG, SSA, optimiser, shimmer)
+- **Compiler Explorer** tool window (IR, CFG, SSA, optimiser, shimmer) — also
+  available by right-clicking a Tcl/iRule file → **Open In Tcl Compiler Explorer**
 - **Dialect support**: Tcl 8.4–9.0, F5 iRules, F5 iApps, EDA Tools
 
 ## Installation

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerService.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerService.kt
@@ -1,0 +1,27 @@
+package com.tcllsp.jetbrains
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Project-level handle to the live Compiler Explorer tool-window panel.
+ *
+ * The panel registers itself on creation so actions (e.g. the editor
+ * "Open In Tcl Compiler Explorer" entry) can push a specific file into the
+ * already-loaded webview without reaching into the tool-window internals.
+ */
+@Service(Service.Level.PROJECT)
+class CompilerExplorerService {
+
+    @Volatile
+    private var panel: CompilerExplorerPanel? = null
+
+    internal fun register(panel: CompilerExplorerPanel) {
+        this.panel = panel
+    }
+
+    /** Push the given file's source into the explorer, if the panel is live. */
+    fun pushFile(file: VirtualFile) {
+        panel?.pushFile(file)
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerService.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerService.kt
@@ -20,6 +20,13 @@ class CompilerExplorerService {
         this.panel = panel
     }
 
+    /** Clear the reference when the panel is disposed, but only if it's ours. */
+    internal fun unregister(panel: CompilerExplorerPanel) {
+        if (this.panel === panel) {
+            this.panel = null
+        }
+    }
+
     /** Push the given file's source into the explorer, if the panel is live. */
     fun pushFile(file: VirtualFile) {
         panel?.pushFile(file)

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -1,7 +1,11 @@
 package com.tcllsp.jetbrains
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -17,7 +21,6 @@ import com.tcllsp.jetbrains.settings.TclLspSettings
 import org.cef.browser.CefBrowser
 import org.cef.handler.CefLoadHandlerAdapter
 import java.util.concurrent.CompletableFuture
-import javax.swing.Timer
 
 private val LOG = Logger.getInstance("com.tcllsp.jetbrains.CompilerExplorer")
 
@@ -32,14 +35,15 @@ class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun shouldBeAvailable(project: Project): Boolean = true
 }
 
-private class CompilerExplorerPanel(private val project: Project) {
+internal class CompilerExplorerPanel(private val project: Project) {
 
     val browser: JBCefBrowser = JBCefBrowser()
     private val jsQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
-    private var debounceTimer: Timer? = null
     private var lastSource: String = ""
 
     init {
+        project.service<CompilerExplorerService>().register(this)
+
         // Set up JS → Kotlin bridge
         jsQuery.addHandler { message ->
             handleJsMessage(message)
@@ -63,20 +67,28 @@ private class CompilerExplorerPanel(private val project: Project) {
                     """.trimIndent()
                     cefBrowser?.executeJavaScript(bridgeJs, "", 0)
 
-                    // Push initial source
-                    pushSourceFromActiveEditor()
+                    // Push initial source. onLoadEnd runs on a JCEF thread, so
+                    // the editor read must hop to the EDT — see pushFromActiveEditor.
+                    pushFromActiveEditor()
                 }
             }
         }, browser.cefBrowser)
 
         browser.loadHTML(getCompilerExplorerHtml())
 
-        // Listen for file editor changes
+        // Listen for file editor changes. fileOpened covers newly opened files;
+        // selectionChanged covers switching between already-open tabs (including
+        // the common case where the explorer is opened while a Tcl file is
+        // already the active tab and no fileOpened event ever fires).
         project.messageBus.connect().subscribe(
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             object : FileEditorManagerListener {
                 override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
-                    pushSourceFromActiveEditor()
+                    pushFromActiveEditor()
+                }
+
+                override fun selectionChanged(event: FileEditorManagerEvent) {
+                    pushFromActiveEditor()
                 }
 
                 override fun fileClosed(source: FileEditorManager, file: VirtualFile) {}
@@ -84,14 +96,36 @@ private class CompilerExplorerPanel(private val project: Project) {
         )
     }
 
-    private fun pushSourceFromActiveEditor() {
-        val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
-        val document = editor.document
-        val file = FileEditorManager.getInstance(project).selectedFiles.firstOrNull() ?: return
-        if (!TclFileType.isSupported(file)) return
+    /**
+     * Read the active editor's Tcl source and push it to the webview.
+     *
+     * Editor access (`selectedTextEditor`, document text) is only valid on the
+     * EDT, but this is invoked both from the EDT (editor listeners) and from a
+     * JCEF callback thread (`onLoadEnd`). Hopping through `invokeLater`
+     * normalises that — without it the initial load-time push silently fails
+     * off-EDT and the IR pane stays stuck on "Waiting for source from editor...".
+     */
+    fun pushFromActiveEditor(force: Boolean = false) {
+        ApplicationManager.getApplication().invokeLater {
+            val manager = FileEditorManager.getInstance(project)
+            val editor = manager.selectedTextEditor ?: return@invokeLater
+            val file = manager.selectedFiles.firstOrNull() ?: return@invokeLater
+            if (!TclFileType.isSupported(file)) return@invokeLater
+            dispatchSource(editor.document.text, force)
+        }
+    }
 
-        val source = document.text
-        if (source == lastSource) return
+    /** Push a specific file's source, used by the "Open In" action. */
+    fun pushFile(file: VirtualFile, force: Boolean = true) {
+        ApplicationManager.getApplication().invokeLater {
+            if (!TclFileType.isSupported(file)) return@invokeLater
+            val document = FileDocumentManager.getInstance().getDocument(file) ?: return@invokeLater
+            dispatchSource(document.text, force)
+        }
+    }
+
+    private fun dispatchSource(source: String, force: Boolean) {
+        if (!force && source == lastSource) return
         lastSource = source
 
         val dialect = TclLspSettings.getInstance().dialect
@@ -188,20 +222,19 @@ private class CompilerExplorerPanel(private val project: Project) {
 
     private fun highlightSourceRange(startOffset: Int, endOffset: Int) {
         // Highlight in the main editor — run on EDT
-        com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+        ApplicationManager.getApplication().invokeLater {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@invokeLater
             val document = editor.document
             if (startOffset < 0 || endOffset > document.textLength) return@invokeLater
 
             val startPos = editor.offsetToLogicalPosition(startOffset)
-            val endPos = editor.offsetToLogicalPosition(endOffset)
             editor.selectionModel.setSelection(startOffset, endOffset)
             editor.scrollingModel.scrollTo(startPos, com.intellij.openapi.editor.ScrollType.CENTER_UP)
         }
     }
 
     private fun clearSourceHighlight() {
-        com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+        ApplicationManager.getApplication().invokeLater {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@invokeLater
             editor.selectionModel.removeSelection()
         }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -1,5 +1,6 @@
 package com.tcllsp.jetbrains
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -9,6 +10,7 @@ import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
@@ -29,19 +31,33 @@ class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val panel = CompilerExplorerPanel(project)
         val content = ContentFactory.getInstance().createContent(panel.browser.component, "", false)
+        // Disposing the content tears down the panel: it unregisters from the
+        // project service and disposes the JCEF browser, JS query, and the
+        // editor-listener connection (all registered as children of the panel).
+        content.setDisposer(panel)
         toolWindow.contentManager.addContent(content)
     }
 
     override fun shouldBeAvailable(project: Project): Boolean = true
 }
 
-internal class CompilerExplorerPanel(private val project: Project) {
+internal class CompilerExplorerPanel(private val project: Project) : Disposable {
 
     val browser: JBCefBrowser = JBCefBrowser()
     private val jsQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
+
+    // All three fields are touched only on the EDT (every mutator hops through
+    // invokeLater), so no extra synchronisation is needed.
     private var lastSource: String = ""
+    private var pageReady = false
+    private var pendingSource: String? = null
 
     init {
+        // Tie the native browser, the JS bridge query, and the editor-listener
+        // connection to this panel's lifetime so they're released when the
+        // tool-window content is disposed (see content.setDisposer).
+        Disposer.register(this, browser)
+        Disposer.register(this, jsQuery)
         project.service<CompilerExplorerService>().register(this)
 
         // Set up JS → Kotlin bridge
@@ -67,9 +83,22 @@ internal class CompilerExplorerPanel(private val project: Project) {
                     """.trimIndent()
                     cefBrowser?.executeJavaScript(bridgeJs, "", 0)
 
-                    // Push initial source. onLoadEnd runs on a JCEF thread, so
-                    // the editor read must hop to the EDT — see pushFromActiveEditor.
-                    pushFromActiveEditor()
+                    // The page's `message` listener is registered by load-end, so
+                    // it is now safe to deliver source. onLoadEnd runs on a JCEF
+                    // thread, so flip the ready flag and flush on the EDT. Any
+                    // push that arrived before now (e.g. the "Open In" action's
+                    // pushFile) was parked in pendingSource; deliver it, else
+                    // fall back to the active editor.
+                    ApplicationManager.getApplication().invokeLater {
+                        pageReady = true
+                        val pending = pendingSource
+                        pendingSource = null
+                        if (pending != null) {
+                            sendSourceUpdate(pending)
+                        } else {
+                            pushFromActiveEditor(force = true)
+                        }
+                    }
                 }
             }
         }, browser.cefBrowser)
@@ -79,8 +108,9 @@ internal class CompilerExplorerPanel(private val project: Project) {
         // Listen for file editor changes. fileOpened covers newly opened files;
         // selectionChanged covers switching between already-open tabs (including
         // the common case where the explorer is opened while a Tcl file is
-        // already the active tab and no fileOpened event ever fires).
-        project.messageBus.connect().subscribe(
+        // already the active tab and no fileOpened event ever fires). The
+        // connection is bound to this panel so it disconnects on dispose.
+        project.messageBus.connect(this).subscribe(
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             object : FileEditorManagerListener {
                 override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
@@ -94,6 +124,10 @@ internal class CompilerExplorerPanel(private val project: Project) {
                 override fun fileClosed(source: FileEditorManager, file: VirtualFile) {}
             }
         )
+    }
+
+    override fun dispose() {
+        project.service<CompilerExplorerService>().unregister(this)
     }
 
     /**
@@ -128,6 +162,17 @@ internal class CompilerExplorerPanel(private val project: Project) {
         if (!force && source == lastSource) return
         lastSource = source
 
+        // A sourceUpdate dispatched before the page registers its message
+        // listener is silently lost, and lastSource would then suppress the
+        // load-end retry. Park it until onLoadEnd marks the page ready.
+        if (!pageReady) {
+            pendingSource = source
+            return
+        }
+        sendSourceUpdate(source)
+    }
+
+    private fun sendSourceUpdate(source: String) {
         val dialect = TclLspSettings.getInstance().dialect
         val escaped = escapeForJs(source)
         val dialectEscaped = escapeForJs(dialect)

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenInCompilerExplorerAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenInCompilerExplorerAction.kt
@@ -1,0 +1,43 @@
+package com.tcllsp.jetbrains.actions
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.components.service
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.wm.ToolWindowManager
+import com.tcllsp.jetbrains.CompilerExplorerService
+import com.tcllsp.jetbrains.TclFileType
+
+/**
+ * Editor / project-view context-menu action that opens the current Tcl file in
+ * the Compiler Explorer tool window and pushes its source for compilation.
+ */
+class OpenInCompilerExplorerAction : AnAction(), DumbAware {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        e.presentation.isEnabledAndVisible =
+            e.project != null && file != null && !file.isDirectory && TclFileType.isSupported(file)
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        if (!TclFileType.isSupported(file)) return
+
+        // Make sure the file is open in an editor so highlight round-trips have
+        // a document to target, then reveal the explorer and push the source.
+        FileEditorManager.getInstance(project).openFile(file, true)
+
+        val toolWindow = ToolWindowManager.getInstance(project)
+            .getToolWindow("Tcl Compiler Explorer") ?: return
+        toolWindow.activate {
+            project.service<CompilerExplorerService>().pushFile(file)
+        }
+    }
+}

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -63,12 +63,22 @@
             factoryClass="com.tcllsp.jetbrains.CompilerExplorerToolWindowFactory"
             icon="/icons/tcl.svg"
             secondary="true"/>
+        <projectService
+            serviceImplementation="com.tcllsp.jetbrains.CompilerExplorerService"/>
 
         <!-- Notification group for error messages -->
         <notificationGroup id="Tcl LSP" displayType="BALLOON"/>
     </extensions>
 
     <actions>
+        <action id="TclLsp.OpenInCompilerExplorer"
+                class="com.tcllsp.jetbrains.actions.OpenInCompilerExplorerAction"
+                text="Open In Tcl Compiler Explorer"
+                description="Open the current Tcl/iRule file in the Tcl Compiler Explorer tool window">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+
         <group id="com.tcllsp.jetbrains.Actions" text="Tcl" popup="true">
             <add-to-group group-id="ToolsMenu" anchor="last"/>
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -375,7 +375,7 @@
       },
       {
         "command": "tclLsp.openCompilerExplorer",
-        "title": "Open Compiler Explorer",
+        "title": "Open in Tcl Compiler Explorer",
         "category": "Tcl"
       },
       {

--- a/editors/vscode/src/chat/commands/help.ts
+++ b/editors/vscode/src/chat/commands/help.ts
@@ -246,7 +246,10 @@ function editorCommandsSection(): HelpSection {
       { name: "Select Dialect", description: "Switch between Tcl versions and iRules" },
       { name: "Apply All Optimisations", description: "Apply optimiser suggestions (Ctrl+Alt+O)" },
       { name: "Apply Safe Quick Fixes", description: "Apply all safe fixes at once" },
-      { name: "Open in Tcl Compiler Explorer", description: "Interactive bytecode explorer (Ctrl+Alt+E)" },
+      {
+        name: "Open in Tcl Compiler Explorer",
+        description: "Interactive bytecode explorer (Ctrl+Alt+E)",
+      },
       { name: "Open Tk Preview", description: "Live Tk GUI preview pane" },
       { name: "Insert iRule Event Skeleton", description: "Pick events and generate skeleton" },
       { name: "Insert Tcl Template Snippet", description: "Built-in templates" },

--- a/editors/vscode/src/chat/commands/help.ts
+++ b/editors/vscode/src/chat/commands/help.ts
@@ -246,7 +246,7 @@ function editorCommandsSection(): HelpSection {
       { name: "Select Dialect", description: "Switch between Tcl versions and iRules" },
       { name: "Apply All Optimisations", description: "Apply optimiser suggestions (Ctrl+Alt+O)" },
       { name: "Apply Safe Quick Fixes", description: "Apply all safe fixes at once" },
-      { name: "Open Compiler Explorer", description: "Interactive bytecode explorer (Ctrl+Alt+E)" },
+      { name: "Open in Tcl Compiler Explorer", description: "Interactive bytecode explorer (Ctrl+Alt+E)" },
       { name: "Open Tk Preview", description: "Live Tk GUI preview pane" },
       { name: "Insert iRule Event Skeleton", description: "Pick events and generate skeleton" },
       { name: "Insert Tcl Template Snippet", description: "Built-in templates" },


### PR DESCRIPTION
The Compiler Explorer tool window could stay stuck on "Waiting for source
from editor..." when opened while a Tcl file was already the active tab.
The initial source push ran from the JCEF onLoadEnd callback thread and
read selectedTextEditor off the EDT, so it silently produced nothing and
no editor event fired to retry. The push now hops to the EDT, and the
panel listens for selectionChanged so switching between already-open tabs
recompiles.

Also add a right-click "Open In Tcl Compiler Explorer" action to the
JetBrains editor and project-view popups (backed by a project service
that pushes the chosen file into the live panel), and rename VS Code's
existing command to "Open in Tcl Compiler Explorer" to match.

https://claude.ai/code/session_01BdBtyNACKjHQbU8MWfJyNM