### PR TITLE
Support -loop stubs and external .tcl.stubs files

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=03a5b84-dirty
-head=03a5b84cdd283c7feafc10111f0ea2feb3f78a98
-date=2026-05-21T13:45:38Z
-fingerprint=6f87e30fa39720e969301ec3c0247adb6a699014e9df2f6914563cb49f948de0
+describe=6799cde-dirty
+head=6799cde681fe2972156f41977e81a533629f7112
+date=2026-05-21T13:54:15Z
+fingerprint=38ead9f1b1ac1331e12c5b2ca661a68df4aeb402de8fc56e8708c9e22527de16

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.7-0-g4310431c-dirty
-head=4310431c41ce07d0c561834768e3c492b65ec0df
-date=2026-05-21T11:00:42Z
-fingerprint=9cb845ec3040870af6b079298f0b23e0b2f2a3e9d263ce9633e7c8a60ffc9bbc
+describe=03a5b84-dirty
+head=03a5b84cdd283c7feafc10111f0ea2feb3f78a98
+date=2026-05-21T13:45:38Z
+fingerprint=6f87e30fa39720e969301ec3c0247adb6a699014e9df2f6914563cb49f948de0

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=6799cde-dirty
-head=6799cde681fe2972156f41977e81a533629f7112
-date=2026-05-21T13:54:15Z
-fingerprint=38ead9f1b1ac1331e12c5b2ca661a68df4aeb402de8fc56e8708c9e22527de16
+describe=7752024-dirty
+head=77520246473ec04c86795db333645f94b5ea4a7e
+date=2026-05-21T14:26:18Z
+fingerprint=3127e08f82bfe7d630d3bd0bfb1b960dc0b1e338d19955a74134d93a9c06efa1

--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -29,7 +29,7 @@ from ..semantic_model import (
     Scope,
     Severity,
 )
-from ..stub_comments import scan_source_for_stubs
+from ..stub_comments import ambient_cmd_stubs, scan_source_for_stubs
 from ._snapshot import AnalyserSnapshot
 from ._utils import parse_file_suppression, parse_noqa_line_suppressions
 
@@ -262,7 +262,7 @@ class _AnalyserBase:
         from core.commands.registry.runtime import stub_signature_scope
 
         snapshots: list[AnalyserSnapshot] = []
-        with stub_signature_scope(self.result.stub_commands):
+        with stub_signature_scope([*self.result.stub_commands, *ambient_cmd_stubs()]):
             for cmds in chunk_commands:
                 self._analyse_commands_inner(cmds, self._current_scope, source)
                 snapshots.append(self.snapshot())
@@ -311,7 +311,7 @@ class _AnalyserBase:
         # with it in ``self.result.stub_commands``.
         from core.commands.registry.runtime import stub_signature_scope
 
-        with stub_signature_scope(self.result.stub_commands):
+        with stub_signature_scope([*self.result.stub_commands, *ambient_cmd_stubs()]):
             self._analyse_commands_inner(commands, self._current_scope, source)
             if finalise:
                 self._emit_unresolved_command_diagnostics()
@@ -441,7 +441,7 @@ class _AnalyserBase:
         # the stubbed command's BODY argument see it as a script.
         from core.commands.registry.runtime import stub_signature_scope
 
-        with stub_signature_scope(cmd_stubs):
+        with stub_signature_scope([*cmd_stubs, *ambient_cmd_stubs()]):
             self._analyse_body(source, self._current_scope)
             self._emit_unresolved_command_diagnostics(cu=cu)
             self._emit_variable_usage_diagnostics()

--- a/core/analysis/_analyser/_diag_commands.py
+++ b/core/analysis/_analyser/_diag_commands.py
@@ -56,9 +56,9 @@ class _AnalyserDiagCommandsMixin(_Base):
         registry_names = frozenset(REGISTRY.command_names(dialect)) | frozenset(
             active_extra_commands()
         )
-        stub_names = frozenset(
-            s.name for s in self.result.stub_commands
-        ) | frozenset(s.name for s in ambient_cmd_stubs())
+        stub_names = frozenset(s.name for s in self.result.stub_commands) | frozenset(
+            s.name for s in ambient_cmd_stubs()
+        )
 
         proc_tail_names: set[str] = set()
         for qname in self.result.all_procs:

--- a/core/analysis/_analyser/_diag_commands.py
+++ b/core/analysis/_analyser/_diag_commands.py
@@ -26,6 +26,7 @@ from ..semantic_model import (
     Diagnostic,
     Severity,
 )
+from ..stub_comments import ambient_cmd_stubs
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +56,9 @@ class _AnalyserDiagCommandsMixin(_Base):
         registry_names = frozenset(REGISTRY.command_names(dialect)) | frozenset(
             active_extra_commands()
         )
-        stub_names = frozenset(s.name for s in self.result.stub_commands)
+        stub_names = frozenset(
+            s.name for s in self.result.stub_commands
+        ) | frozenset(s.name for s in ambient_cmd_stubs())
 
         proc_tail_names: set[str] = set()
         for qname in self.result.all_procs:

--- a/core/analysis/checks/_domain.py
+++ b/core/analysis/checks/_domain.py
@@ -9,6 +9,7 @@ from ...commands.registry.models import DialectStatus, FormKind
 from ...commands.registry.runtime import (
     ArgRole,
     arg_indices_for_role,
+    command_is_stubbed,
     normalized_flag_commands,
 )
 from ...common.codes import diag
@@ -70,6 +71,14 @@ def check_disabled_command(
     # bare (``log``) and fully-qualified (``::log``) call sites
     # resolve to the same spec.
     lookup = qualified.lstrip(":")
+
+    # A command declared by an inline/file stub is intentionally made
+    # available in this file regardless of the active dialect — the
+    # whole point of the stub is to teach the analyser the command.
+    # Suppress W002 so the user's own declaration isn't flagged as
+    # "disabled".
+    if command_is_stubbed(lookup):
+        return []
 
     dialect = active_dialect()
     status = REGISTRY.command_status(lookup, dialect)

--- a/core/analysis/stub_comments.py
+++ b/core/analysis/stub_comments.py
@@ -99,8 +99,8 @@ if TYPE_CHECKING:
 # and the compile cache fingerprint, but NOT the per-file shadow check
 # (W116/W117) — their ``range`` points into a different document, so
 # attaching diagnostics to the file under analysis would be wrong.
-_ambient_cmd_stubs_var: contextvars.ContextVar[tuple[StubCommandDef, ...]] = (
-    contextvars.ContextVar("tcl_lsp_ambient_cmd_stubs", default=())
+_ambient_cmd_stubs_var: contextvars.ContextVar[tuple[StubCommandDef, ...]] = contextvars.ContextVar(
+    "tcl_lsp_ambient_cmd_stubs", default=()
 )
 
 
@@ -131,6 +131,7 @@ def set_ambient_stubs(cmd_stubs: "Iterable[StubCommandDef]") -> None:
     parent process and re-establish per-request state on every call (the
     same pattern as ``configure_signatures``)."""
     _ambient_cmd_stubs_var.set(tuple(cmd_stubs))
+
 
 _VALID_ROLES: frozenset[str] = frozenset(
     {"body", "expr", "var", "var_read", "name", "pattern", "channel", "value"}

--- a/core/analysis/stub_comments.py
+++ b/core/analysis/stub_comments.py
@@ -42,6 +42,15 @@ Flags:
     -unsafe       — Command is unsafe
     -scope_alias  — Command creates a scope alias (like upvar)
 
+A ``-loop`` stub is lowered to a real loop (so the loop variable stays
+defined and the body is analysed in iteration order) when the call has
+the single-iterator ``... varName:var collection body:body`` shape — a
+leading subcommand word or option flags are tolerated.  Other shapes,
+and non-loop ``body:body`` arguments, are treated as barriers: nested
+commands are still checked, but the body's variable writes are not
+threaded into the surrounding data flow (the command's body scope is
+unknown, so assuming it runs in the caller's scope could be wrong).
+
 Examples::
 
     # tcl-lsp: stubs-begin
@@ -73,10 +82,55 @@ In ``.tcl.stubs`` files::
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .semantic_model import Range, StubArgDef, StubCommandDef, StubExprDef
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Workspace-level stub commands discovered from external ``.tcl.stubs``
+# files.  Unlike inline stubs (scanned per-source), these apply to every
+# file analysed under the active scope.  They feed the signature overlay
+# and the compile cache fingerprint, but NOT the per-file shadow check
+# (W116/W117) — their ``range`` points into a different document, so
+# attaching diagnostics to the file under analysis would be wrong.
+_ambient_cmd_stubs_var: contextvars.ContextVar[tuple[StubCommandDef, ...]] = (
+    contextvars.ContextVar("tcl_lsp_ambient_cmd_stubs", default=())
+)
+
+
+def ambient_cmd_stubs() -> tuple[StubCommandDef, ...]:
+    """Return the workspace stub commands active in the current scope."""
+    return _ambient_cmd_stubs_var.get()
+
+
+@contextlib.contextmanager
+def ambient_stub_scope(cmd_stubs: "Iterable[StubCommandDef]"):
+    """Make *cmd_stubs* the ambient workspace stubs for the ``with`` block.
+
+    In-process callers (the LSP diagnostics pipeline and its thread
+    fallbacks) use this so :func:`ambient_cmd_stubs` resolves to the
+    workspace's external stubs.  Restored on exit — safe to nest.
+    """
+    token = _ambient_cmd_stubs_var.set(tuple(cmd_stubs))
+    try:
+        yield
+    finally:
+        _ambient_cmd_stubs_var.reset(token)
+
+
+def set_ambient_stubs(cmd_stubs: "Iterable[StubCommandDef]") -> None:
+    """Set the ambient workspace stubs without a restore token.
+
+    For subprocess-pool workers, which do not share ContextVars with the
+    parent process and re-establish per-request state on every call (the
+    same pattern as ``configure_signatures``)."""
+    _ambient_cmd_stubs_var.set(tuple(cmd_stubs))
 
 _VALID_ROLES: frozenset[str] = frozenset(
     {"body", "expr", "var", "var_read", "name", "pattern", "channel", "value"}

--- a/core/commands/registry/runtime.py
+++ b/core/commands/registry/runtime.py
@@ -844,7 +844,7 @@ def stub_to_command_sig(stub: "StubCommandDef") -> CommandSig:
             static_roles[idx] = frozenset({role})
 
     if not has_optional:
-        return CommandSig(arity=arity, arg_roles=static_roles)
+        return CommandSig(arity=arity, arg_roles=static_roles, loop=stub.loop)
 
     # Build a dynamic resolver that walks the actual argument list and
     # decides which optional slots are filled (left-to-right).
@@ -875,7 +875,9 @@ def stub_to_command_sig(stub: "StubCommandDef") -> CommandSig:
             actual_idx += 1
         return result
 
-    return CommandSig(arity=arity, arg_roles=static_roles, arg_role_resolver=_resolver)
+    return CommandSig(
+        arity=arity, arg_roles=static_roles, arg_role_resolver=_resolver, loop=stub.loop
+    )
 
 
 def signatures_from_stubs(
@@ -1508,6 +1510,43 @@ def arg_indices_for_roles(
 def body_arg_indices(command: str, args: list[str]) -> set[int]:
     """Return BODY argument indices for *command* given args after command name."""
     return arg_indices_for_role(command, args, ArgRole.BODY)
+
+
+def command_is_stubbed(command: str) -> bool:
+    """Return ``True`` when *command* is declared by an active stub overlay.
+
+    Consults the in-scope inline/file stub signatures (see
+    :func:`stub_signature_scope`).  Both the bare (``redirect``) and
+    fully-qualified (``::redirect``) spellings are checked, mirroring how
+    :func:`signatures_from_stubs` registers each name.
+    """
+    stubs = _stub_signatures_var.get()
+    if not stubs:
+        return False
+    bare = command.lstrip(":")
+    return bare in stubs or f"::{bare}" in stubs
+
+
+def is_loop_command(command: str, args: list[str]) -> bool:
+    """Return ``True`` when *command* has a loop-body signature.
+
+    Currently driven by ``-loop`` stub declarations: the overlay
+    :class:`CommandSig` carries ``loop=True`` so the lowering pass can
+    model the body as an iterated block rather than an opaque barrier.
+    """
+    sig = SIGNATURES.get(command)
+    if sig is None:
+        canonical = _canonicalise_command_name(command)
+        if canonical != command:
+            sig = SIGNATURES.get(canonical)
+    if isinstance(sig, SubcommandSig):
+        if not args:
+            return False
+        sub = sig.subcommands.get(args[0])
+        return bool(sub is not None and sub.loop)
+    if isinstance(sig, CommandSig):
+        return sig.loop
+    return False
 
 
 def expr_arg_indices(command: str, args: list[str]) -> set[int]:

--- a/core/commands/registry/signatures.py
+++ b/core/commands/registry/signatures.py
@@ -113,6 +113,14 @@ class CommandSig:
     (3 positional args, exceeds max 2).
     """
 
+    loop: bool = False
+    """``True`` when a ``BODY`` argument is the body of a loop.
+
+    Set by ``-loop`` stub declarations so the lowering pass can model the
+    body as an iterated block (loop variables stay defined, body vars are
+    tracked in order) instead of an opaque barrier.
+    """
+
 
 @dataclass(frozen=True, slots=True)
 class SubcommandSig:

--- a/core/compiler/compilation_unit.py
+++ b/core/compiler/compilation_unit.py
@@ -155,10 +155,11 @@ def compute_stub_fingerprint(source: str) -> int:
     source declares no stubs — the empty-overlay case stays compatible
     with callers that omit the fingerprint argument.
     """
-    from core.analysis.stub_comments import scan_source_for_stubs
+    from core.analysis.stub_comments import ambient_cmd_stubs, scan_source_for_stubs
     from core.commands.registry.runtime import signatures_from_stubs
 
     cmd_stubs, _ = scan_source_for_stubs(source)
+    cmd_stubs = [*cmd_stubs, *ambient_cmd_stubs()]
     if not cmd_stubs:
         return 0
     overlay = signatures_from_stubs(cmd_stubs)
@@ -192,10 +193,11 @@ def compile_source(
     When *interproc_cache* is provided, local interprocedural summaries
     are also reused for unchanged procedures using the same key shape.
     """
-    from core.analysis.stub_comments import scan_source_for_stubs
+    from core.analysis.stub_comments import ambient_cmd_stubs, scan_source_for_stubs
     from core.commands.registry.runtime import stub_signature_scope
 
     cmd_stubs, _ = scan_source_for_stubs(source)
+    cmd_stubs = [*cmd_stubs, *ambient_cmd_stubs()]
     # Fingerprint the stub overlay so cached proc / interproc summaries
     # are invalidated whenever a stub is added, removed, or changed —
     # the proc body text alone is not enough because summaries depend

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -21,7 +21,7 @@ from typing import cast
 
 from ..analysis.semantic_model import Range
 from ..commands.registry import REGISTRY
-from ..commands.registry.runtime import ArgRole, arg_indices_for_role
+from ..commands.registry.runtime import ArgRole, arg_indices_for_role, is_loop_command
 from ..common.alias import (
     detect_interp_alias,
 )
@@ -2345,10 +2345,14 @@ class _Lowerer:
             case "foreach":
                 return self._lower_foreach(cmd, namespace=namespace)
 
-            case "foreach_in_collection" if REGISTRY.get(cmd_name, _active_dialect()) is not None:
-                # Only lower as a loop when enabled in the active dialect.
-                # Enforce exact arity so incorrect arg counts produce
-                # IRBarrier and get caught by generic arity checks (E002/E003).
+            case "foreach_in_collection" if (
+                REGISTRY.get(cmd_name, _active_dialect()) is not None
+                or is_loop_command(cmd_name, args)
+            ):
+                # Lower as a loop when the command is enabled in the active
+                # dialect or declared as a ``-loop`` stub.  Enforce exact
+                # arity so incorrect arg counts produce IRBarrier and get
+                # caught by generic arity checks (E002/E003).
                 if len(args) != 3:
                     return IRBarrier(
                         range=cmd.range,
@@ -2403,6 +2407,19 @@ class _Lowerer:
                 var_indices = arg_indices_for_role(role_cmd, role_args, ArgRole.VAR_WRITE)
                 var_read_indices = arg_indices_for_role(role_cmd, role_args, ArgRole.VAR_READ)
                 if body_indices:
+                    # A ``-loop`` stub with a trailing body and a
+                    # foreach-shaped argument list (``var collection body``)
+                    # is modelled as a real loop: the loop variables stay
+                    # defined and the body is analysed in iteration order,
+                    # rather than collapsing to an opaque barrier.
+                    if (
+                        prepend_n == 0
+                        and len(args) >= 3
+                        and len(args) % 2 == 1
+                        and (len(args) - 1) in body_indices
+                        and is_loop_command(role_cmd, role_args)
+                    ):
+                        return self._lower_foreach(cmd, namespace=namespace)
                     return IRBarrier(
                         range=cmd.range,
                         reason="unsupported body command",

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -1183,6 +1183,47 @@ class _Lowerer:
             raw_args=tuple(args),
         )
 
+    def _lower_stub_loop(
+        self,
+        cmd: _Command,
+        *,
+        namespace: str,
+        var_indices: set[int],
+        body_indices: set[int],
+    ) -> IRForeach | None:
+        """Lower a ``-loop`` stub call to :class:`IRForeach`, or ``None``.
+
+        Handles the single-iterator ``... var collection body`` shape using
+        the stub's declared roles, so it works regardless of a leading
+        subcommand word or option flags.  Returns ``None`` (caller falls
+        back to :class:`IRBarrier`) when the call does not match that shape
+        or the body is not a braced literal.
+        """
+        if len(var_indices) != 1 or not body_indices:
+            return None
+        var_idx = next(iter(var_indices))
+        body_idx = max(body_indices)
+        coll_idx = var_idx + 1
+        args = cmd.args
+        if not (0 <= var_idx < coll_idx < body_idx < len(args)):
+            return None
+
+        arg_tokens = cmd.arg_tokens
+        arg_single = cmd.arg_single_token
+        body_tok = arg_tokens[body_idx] if body_idx < len(arg_tokens) else None
+        if body_tok is None or not (body_idx < len(arg_single) and arg_single[body_idx]):
+            return None
+
+        var_names = _parse_param_names(args[var_idx])
+        body_script = self._lower_body_arg(args[body_idx], body_tok, namespace=namespace)
+        return IRForeach(
+            range=cmd.range,
+            iterators=((var_names, args[coll_idx]),),
+            body=body_script,
+            body_range=range_from_token(body_tok),
+            raw_args=tuple(args),
+        )
+
     def _lower_catch(self, cmd: _Command, *, namespace: str) -> IRCatch | IRBarrier:
         args = cmd.args
         arg_tokens = cmd.arg_tokens
@@ -2407,19 +2448,21 @@ class _Lowerer:
                 var_indices = arg_indices_for_role(role_cmd, role_args, ArgRole.VAR_WRITE)
                 var_read_indices = arg_indices_for_role(role_cmd, role_args, ArgRole.VAR_READ)
                 if body_indices:
-                    # A ``-loop`` stub with a trailing body and a
-                    # foreach-shaped argument list (``var collection body``)
-                    # is modelled as a real loop: the loop variables stay
-                    # defined and the body is analysed in iteration order,
-                    # rather than collapsing to an opaque barrier.
-                    if (
-                        prepend_n == 0
-                        and len(args) >= 3
-                        and len(args) % 2 == 1
-                        and (len(args) - 1) in body_indices
-                        and is_loop_command(role_cmd, role_args)
-                    ):
-                        return self._lower_foreach(cmd, namespace=namespace)
+                    # A ``-loop`` stub is modelled as a real loop so the
+                    # loop variable stays defined and the body is analysed
+                    # in iteration order, rather than collapsing to an
+                    # opaque barrier.  Role-driven (not positional) so the
+                    # ``var collection body`` shape is found even behind a
+                    # subcommand word or leading option flags.
+                    if prepend_n == 0 and is_loop_command(role_cmd, role_args):
+                        loop_ir = self._lower_stub_loop(
+                            cmd,
+                            namespace=namespace,
+                            var_indices=var_indices,
+                            body_indices=body_indices,
+                        )
+                        if loop_ir is not None:
+                            return loop_ir
                     return IRBarrier(
                         range=cmd.range,
                         reason="unsupported body command",

--- a/core/compiler/lowering.py
+++ b/core/compiler/lowering.py
@@ -2386,10 +2386,9 @@ class _Lowerer:
             case "foreach":
                 return self._lower_foreach(cmd, namespace=namespace)
 
-            case "foreach_in_collection" if (
-                REGISTRY.get(cmd_name, _active_dialect()) is not None
-                or is_loop_command(cmd_name, args)
-            ):
+            case "foreach_in_collection" if REGISTRY.get(
+                cmd_name, _active_dialect()
+            ) is not None or is_loop_command(cmd_name, args):
                 # Lower as a loop when the command is enabled in the active
                 # dialect or declared as a ``-loop`` stub.  Enforce exact
                 # arity so incorrect arg counts produce IRBarrier and get

--- a/lsp/diagnostics_pipeline.py
+++ b/lsp/diagnostics_pipeline.py
@@ -213,6 +213,7 @@ def _publish_diagnostics_sync(
     force_reanalyse: bool = False,
 ) -> None:
     from core.analysis.checks._style import non_ascii_mode_scope
+    from core.analysis.stub_comments import ambient_stub_scope
     from core.common.dialect import dialect_scope
 
     cfg = _state.config_for_uri(uri)
@@ -220,6 +221,7 @@ def _publish_diagnostics_sync(
     with (
         dialect_scope(dialect=dialect, extra_commands=extras),
         non_ascii_mode_scope(cfg.non_ascii_mode),
+        ambient_stub_scope(_state.workspace_stub_commands),
     ):
         state = _state.workspace_state.update(
             uri,
@@ -264,6 +266,7 @@ async def _publish_diagnostics(
     force_reanalyse: bool = False,
 ) -> None:
     from core.analysis.checks._style import non_ascii_mode_scope
+    from core.analysis.stub_comments import ambient_stub_scope
     from core.common.dialect import dialect_scope
 
     dialect, extras = _state.resolve_dialect_for_uri(uri, source)
@@ -280,6 +283,7 @@ async def _publish_diagnostics(
     with (
         dialect_scope(dialect=dialect, extra_commands=extras),
         non_ascii_mode_scope(cfg.non_ascii_mode),
+        ambient_stub_scope(_state.workspace_stub_commands),
     ):
         await _publish_diagnostics_inner(uri, source, version, force_reanalyse=force_reanalyse)
 
@@ -357,6 +361,10 @@ async def _publish_diagnostics_inner(
                             # default when a folder hasn't overridden it.
                             extra_commands=_extra_commands_var.get(),
                             non_ascii_mode=_non_ascii_mode_var.get(),
+                            # External .tcl.stubs are workspace state, not a
+                            # ContextVar, so forward them explicitly for the
+                            # subprocess to re-establish (mirrors dialect).
+                            stub_commands=tuple(_state.workspace_stub_commands),
                         ),
                     ),
                     timeout=15.0,

--- a/lsp/state.py
+++ b/lsp/state.py
@@ -44,6 +44,12 @@ diagnostic_scheduler = DiagnosticScheduler()
 _per_folder_feature_configs: dict[str, FeatureConfig] = {}
 _per_folder_formatter_configs: dict[str, FormatterConfig] = {}
 
+# Workspace-level command stubs discovered from external ``.tcl.stubs``
+# files at workspace init.  Applied to every analysed document so the
+# analyser understands EDA / dialect commands the same way it does for
+# inline ``# tcl-lsp: stub`` blocks.  Empty when no stub files exist.
+workspace_stub_commands: list = []
+
 # Per-folder PackageResolver instances (issue #407).  When a workspace
 # folder defines its own ``tclLsp.libraryPaths`` the lazily-built resolver
 # in this map is configured with those paths plus the workspace_roots; the

--- a/lsp/workspace/document_state.py
+++ b/lsp/workspace/document_state.py
@@ -205,6 +205,7 @@ def _analyse_document_fresh(
     optimiser_enabled: bool = True,
     extra_commands: tuple[str, ...] = (),
     non_ascii_mode: str | None = None,
+    stub_commands: tuple = (),
 ) -> dict:
     """Run the full analysis pipeline in a subprocess.
 
@@ -227,6 +228,13 @@ def _analyse_document_fresh(
         from core.analysis.checks._style import set_non_ascii_mode
 
         set_non_ascii_mode(non_ascii_mode)
+
+    # Re-establish workspace .tcl.stubs in this worker.  Set (not scoped):
+    # the pool reuses workers and forwards stubs on every call, mirroring
+    # configure_signatures above.
+    from core.analysis.stub_comments import set_ambient_stubs
+
+    set_ambient_stubs(stub_commands)
 
     # The analyser gates expensive opt-in checks (W123 unresolved-command
     # suggestions, W242 loop termination, etc.) on its

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lsprotocol import types
@@ -36,6 +37,59 @@ except ImportError:
     _version = "dev"
 
 _server: LanguageServer | None = None
+
+# Cap the external-stub discovery walk so a pathological tree can't stall
+# initialisation.  Stub files are normally few and near the workspace root.
+_MAX_STUB_FILES = 200
+_STUB_WALK_SKIP_DIRS = frozenset(
+    {".git", ".hg", ".svn", "node_modules", "__pycache__", ".mypy_cache", ".tox"}
+)
+
+
+def _discover_workspace_stubs(roots: list[str], library_paths: list[str]) -> None:
+    """Find and parse external ``*.tcl.stubs`` files under the workspace.
+
+    Populates :data:`lsp.state.workspace_stub_commands` so every analysed
+    document sees the declared commands (same overlay as inline
+    ``# tcl-lsp: stub`` blocks).  Best-effort: unreadable files and parse
+    failures are skipped.
+    """
+    import os
+
+    from core.analysis.stub_comments import parse_stubs_file
+
+    seen: set[str] = set()
+    stub_files: list[str] = []
+    for base in [*roots, *library_paths]:
+        if not base or not os.path.isdir(base):
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in _STUB_WALK_SKIP_DIRS]
+            for name in filenames:
+                if name.endswith(".tcl.stubs"):
+                    full = os.path.realpath(os.path.join(dirpath, name))
+                    if full not in seen:
+                        seen.add(full)
+                        stub_files.append(full)
+            if len(stub_files) >= _MAX_STUB_FILES:
+                break
+
+    cmd_stubs: list = []
+    for path in stub_files:
+        try:
+            file_cmds, _ = parse_stubs_file(Path(path))
+        except Exception:
+            log.warning("Failed to parse stub file: %s", path, exc_info=True)
+            continue
+        cmd_stubs.extend(file_cmds)
+
+    _state.workspace_stub_commands = cmd_stubs
+    if cmd_stubs:
+        log.info(
+            "Loaded %d command stub(s) from %d external .tcl.stubs file(s)",
+            len(cmd_stubs),
+            len(stub_files),
+        )
 
 
 def configure(server_instance: LanguageServer) -> None:
@@ -377,6 +431,8 @@ def on_initialized(params: types.InitializedParams) -> None:
             if os.path.isdir(venv_lib):
                 library_paths.append(venv_lib)
                 log.info("Auto-detected tclpkg venv lib: %s", venv_lib)
+
+    _discover_workspace_stubs(roots, library_paths)
 
     _state.background_scanner.configure(
         workspace_roots=roots,

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -46,13 +46,18 @@ _STUB_WALK_SKIP_DIRS = frozenset(
 )
 
 
-def _discover_workspace_stubs(roots: list[str], library_paths: list[str]) -> None:
+def _discover_workspace_stubs(bases: list[str]) -> None:
     """Find and parse external ``*.tcl.stubs`` files under the workspace.
 
-    Populates :data:`lsp.state.workspace_stub_commands` so every analysed
-    document sees the declared commands (same overlay as inline
-    ``# tcl-lsp: stub`` blocks).  Best-effort: unreadable files and parse
-    failures are skipped.
+    *bases* are the directories to search — workspace roots, every
+    workspace folder (multi-root), and library paths.  Populates
+    :data:`lsp.state.workspace_stub_commands` so every analysed document
+    sees the declared commands (same overlay as inline ``# tcl-lsp: stub``
+    blocks).  Best-effort: unreadable files and parse failures are skipped.
+
+    Traversal is sorted and the discovered file list is sorted before
+    parsing, so when two files declare the same command the "last wins"
+    overlay is deterministic across platforms.
     """
     import os
 
@@ -60,20 +65,29 @@ def _discover_workspace_stubs(roots: list[str], library_paths: list[str]) -> Non
 
     seen: set[str] = set()
     stub_files: list[str] = []
-    for base in [*roots, *library_paths]:
+    capped = False
+    for base in bases:
+        if capped:
+            break
         if not base or not os.path.isdir(base):
             continue
         for dirpath, dirnames, filenames in os.walk(base):
-            dirnames[:] = [d for d in dirnames if d not in _STUB_WALK_SKIP_DIRS]
-            for name in filenames:
-                if name.endswith(".tcl.stubs"):
-                    full = os.path.realpath(os.path.join(dirpath, name))
-                    if full not in seen:
-                        seen.add(full)
-                        stub_files.append(full)
-            if len(stub_files) >= _MAX_STUB_FILES:
+            # Sort in place for deterministic traversal; prune noise dirs.
+            dirnames[:] = sorted(d for d in dirnames if d not in _STUB_WALK_SKIP_DIRS)
+            for name in sorted(filenames):
+                if not name.endswith(".tcl.stubs"):
+                    continue
+                full = os.path.realpath(os.path.join(dirpath, name))
+                if full not in seen:
+                    seen.add(full)
+                    stub_files.append(full)
+                    if len(stub_files) >= _MAX_STUB_FILES:
+                        capped = True
+                        break
+            if capped:
                 break
 
+    stub_files.sort()
     cmd_stubs: list = []
     for path in stub_files:
         try:
@@ -432,7 +446,11 @@ def on_initialized(params: types.InitializedParams) -> None:
                 library_paths.append(venv_lib)
                 log.info("Auto-detected tclpkg venv lib: %s", venv_lib)
 
-    _discover_workspace_stubs(roots, library_paths)
+    # Search workspace roots, every workspace folder (multi-root), and
+    # library paths — deduped, order-preserving — so external stubs load
+    # consistently regardless of whether ``root_path`` is set.
+    stub_bases = list(dict.fromkeys([*roots, *(p for _, p in folder_paths), *library_paths]))
+    _discover_workspace_stubs(stub_bases)
 
     _state.background_scanner.configure(
         workspace_roots=roots,

--- a/samples/dialect_stubs_inline_example.tcl
+++ b/samples/dialect_stubs_inline_example.tcl
@@ -15,6 +15,7 @@
 # Now the LSP understands these commands
 set all_cells [get_cells -hierarchical *]
 set count [sizeof_collection $all_cells]
+puts "Found $count cells"
 
 foreach_in_collection cell $all_cells {
     set name [get_attribute $cell full_name]

--- a/tests/test_stub_semantics_e2e.py
+++ b/tests/test_stub_semantics_e2e.py
@@ -1,0 +1,141 @@
+"""End-to-end semantic tests for inline dialect stubs.
+
+These tests drive the full :func:`core.analysis.analyse` pipeline and
+assert on the *meaning* the stubs give a file — not just that a stub is
+parsed.  Each behaviour is paired with a negative control (the same
+source without the stub) so the assertions prove the stub is what does
+the work, and that genuine problems are still reported when a stub
+declares the command's shape.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.analysis import analyse
+
+
+def _codes(source: str) -> set[str]:
+    return {d.code for d in analyse(textwrap.dedent(source)).diagnostics}
+
+
+def _messages(source: str, code: str) -> list[str]:
+    return [d.message for d in analyse(textwrap.dedent(source)).diagnostics if d.code == code]
+
+
+class TestLoopStubSemantics:
+    """A ``-loop`` stub turns a custom command into a real, analysed loop."""
+
+    _LOOP_BODY = """\
+        # tcl-lsp: stubs-begin
+        # tcl-lsp: stub each_cell {varName:var collection body:body} -loop
+        # tcl-lsp: stubs-end
+        set cells {a b c}
+        each_cell cell $cells {
+            set name $cell
+            puts $name
+        }
+    """
+
+    def test_loop_body_is_analysed_in_iteration_order(self):
+        # `name` is set before it is read inside the body, so once the
+        # body is understood as a script there is no read-before-set.
+        assert "W210" not in _codes(self._LOOP_BODY)
+
+    def test_loop_variable_is_defined_by_the_stub(self):
+        # `$cell` is the loop variable; the loop lowering defines it, so
+        # reading it inside the body is not a read-before-set.
+        rbs = _messages(self._LOOP_BODY, "W210")
+        assert not any("cell" in m for m in rbs)
+
+    def test_without_stub_loop_var_and_body_are_unknown(self):
+        # Negative control: drop the stub block and the same call is an
+        # unknown command whose "body" is opaque, so both the loop
+        # variable and the body-local variable look read-before-set.
+        no_stub = """\
+            set cells {a b c}
+            each_cell cell $cells {
+                set name $cell
+                puts $name
+            }
+        """
+        codes = _codes(no_stub)
+        assert "W123" in codes  # unknown command
+        rbs = _messages(no_stub, "W210")
+        assert any("cell" in m for m in rbs)
+        assert any("name" in m for m in rbs)
+
+    def test_body_is_really_analysed_not_merely_suppressed(self):
+        # A genuine read-before-set inside the loop body must still fire —
+        # the body is analysed as a script, not treated as an opaque
+        # region where diagnostics are silenced.
+        bad = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub each_cell {varName:var collection body:body} -loop
+            # tcl-lsp: stubs-end
+            set cells {a b c}
+            each_cell cell $cells {
+                puts $never_set
+            }
+        """
+        assert any("never_set" in m for m in _messages(bad, "W210"))
+
+    def test_foreach_in_collection_stub_lowers_as_loop(self):
+        # The canonical EDA example: the documented foreach_in_collection
+        # stub must behave like a loop regardless of the active dialect.
+        src = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub foreach_in_collection {varName:var collection body:body} -loop
+            # tcl-lsp: stub get_cells {pattern:pattern} -pure
+            # tcl-lsp: stub get_attribute {object attrName:name} -pure
+            # tcl-lsp: stubs-end
+            set all_cells [get_cells *]
+            foreach_in_collection cell $all_cells {
+                set name [get_attribute $cell full_name]
+                puts "Cell: $name"
+            }
+        """
+        assert _codes(src) == set()
+
+
+class TestDisabledCommandStubSemantics:
+    """A stub re-enables a command disabled in the active dialect (W002)."""
+
+    def test_stub_suppresses_w002_for_disabled_command(self):
+        src = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub redirect {?-variable? ?-file? target body:body}
+            # tcl-lsp: stubs-end
+            redirect -file timing.rpt {
+                set y 1
+            }
+        """
+        assert "W002" not in _codes(src)
+
+    def test_without_stub_disabled_command_is_flagged(self):
+        # Negative control: `redirect` is a known command that is not in
+        # the default tcl dialect, so without a stub it is reported as
+        # disabled.
+        no_stub = """\
+            redirect -file timing.rpt {
+                set y 1
+            }
+        """
+        assert "W002" in _codes(no_stub)
+
+
+class TestShippedSampleIsClean:
+    def test_inline_example_sample_has_no_diagnostics(self):
+        sample = (
+            Path(__file__).resolve().parent.parent
+            / "samples"
+            / "dialect_stubs_inline_example.tcl"
+        )
+        result = analyse(sample.read_text(encoding="utf-8"))
+        assert result.diagnostics == [], [
+            (d.code, d.message) for d in result.diagnostics
+        ]

--- a/tests/test_stub_semantics_e2e.py
+++ b/tests/test_stub_semantics_e2e.py
@@ -127,6 +127,51 @@ class TestDisabledCommandStubSemantics:
         """
         assert "W002" in _codes(no_stub)
 
+    def test_stub_suppression_does_not_leak_to_other_files(self):
+        # The overlay is scoped to the analysis pass that declared it;
+        # analysing a stubbed file must not silence W002 in a later,
+        # unrelated file that calls the same command without a stub.
+        stubbed = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub redirect {?-file? target body:body}
+            # tcl-lsp: stubs-end
+            redirect -file out.rpt {set y 1}
+        """
+        analyse(textwrap.dedent(stubbed))
+        assert "W002" in _codes("redirect -file out.rpt {set y 1}\n")
+
+
+class TestBodyStubRecursion:
+    """Body args of a stub are descended into for command-level checks."""
+
+    def test_inner_command_of_non_loop_body_is_checked(self):
+        # A plain ``body:body`` stub (no -loop) is not a control-flow loop,
+        # but its body is still walked: an unknown command inside it is
+        # reported, proving the body is analysed rather than ignored.
+        src = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub redirect {?-file? target body:body}
+            # tcl-lsp: stubs-end
+            redirect -file out.rpt {
+                totally_unknown_command foo bar
+            }
+        """
+        assert any("totally_unknown_command" in m for m in _messages(src, "W123"))
+
+    def test_barrier_stub_body_is_not_silenced(self):
+        # A ``-barrier`` body executes in a dynamic scope, so a read of a
+        # variable that is never set is still surfaced — the body is not
+        # treated as an opaque region where diagnostics are dropped.
+        src = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub my_eval {script:body} -barrier
+            # tcl-lsp: stubs-end
+            my_eval {
+                puts $never_set_anywhere
+            }
+        """
+        assert any("never_set_anywhere" in m for m in _messages(src, "W210"))
+
 
 class TestShippedSampleIsClean:
     def test_inline_example_sample_has_no_diagnostics(self):

--- a/tests/test_stub_semantics_e2e.py
+++ b/tests/test_stub_semantics_e2e.py
@@ -84,6 +84,47 @@ class TestLoopStubSemantics:
         """
         assert any("never_set" in m for m in _messages(bad, "W210"))
 
+    def test_subcommand_loop_stub_lowers_as_loop(self):
+        # A loop declared on an ensemble subcommand (``coll foreach ...``)
+        # is found via roles, past the leading subcommand word.
+        src = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub coll foreach {varName:var collection body:body} -loop
+            # tcl-lsp: stubs-end
+            set xs {1 2 3}
+            coll foreach x $xs {
+                set n $x
+                puts $n
+            }
+        """
+        assert _codes(src) == set()
+        # And the body is still analysed: a genuine unset read fires.
+        bad = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub coll foreach {varName:var collection body:body} -loop
+            # tcl-lsp: stubs-end
+            set xs {1 2 3}
+            coll foreach x $xs {
+                puts $never_set
+            }
+        """
+        assert any("never_set" in m for m in _messages(bad, "W210"))
+
+    def test_loop_stub_with_leading_option_lowers_as_loop(self):
+        # The ``var collection body`` triple is located by role even when a
+        # leading optional flag shifts the positions (even arg count).
+        src = """\
+            # tcl-lsp: stubs-begin
+            # tcl-lsp: stub each_cell {?-filter? varName:var collection body:body} -loop
+            # tcl-lsp: stubs-end
+            set cells {a b c}
+            each_cell -filter cell $cells {
+                set n $cell
+                puts $n
+            }
+        """
+        assert _codes(src) == set()
+
     def test_foreach_in_collection_stub_lowers_as_loop(self):
         # The canonical EDA example: the documented foreach_in_collection
         # stub must behave like a loop regardless of the active dialect.
@@ -171,6 +212,109 @@ class TestBodyStubRecursion:
             }
         """
         assert any("never_set_anywhere" in m for m in _messages(src, "W210"))
+
+
+class TestExternalStubFiles:
+    """Stubs loaded from external ``.tcl.stubs`` files via the ambient scope."""
+
+    _SRC = """\
+        set cells [get_cells *]
+        foreach_in_collection cell $cells {
+            set name $cell
+            puts $name
+        }
+        redirect -file out.rpt {
+            set y 1
+        }
+    """
+
+    @staticmethod
+    def _write_stub_file(tmp_path):
+        from core.analysis.stub_comments import parse_stubs_file
+
+        path = tmp_path / "eda.tcl.stubs"
+        path.write_text(
+            "stub foreach_in_collection {varName:var collection body:body} -loop\n"
+            "stub get_cells {pattern:pattern} -pure\n"
+            "stub redirect {?-file? target body:body}\n",
+            encoding="utf-8",
+        )
+        cmd_stubs, _ = parse_stubs_file(path)
+        return cmd_stubs
+
+    def test_external_stubs_make_file_clean(self, tmp_path):
+        from core.analysis.stub_comments import ambient_stub_scope
+
+        cmd_stubs = self._write_stub_file(tmp_path)
+        with ambient_stub_scope(cmd_stubs):
+            assert _codes(self._SRC) == set()
+
+    def test_without_external_stubs_diagnostics_fire(self):
+        # Negative control: same source, no ambient stubs in scope.
+        codes = _codes(self._SRC)
+        assert "W002" in codes  # redirect disabled
+        assert "W210" in codes  # loop var / body not understood
+
+    def test_external_stub_scope_does_not_leak(self, tmp_path):
+        from core.analysis.stub_comments import ambient_stub_scope
+
+        cmd_stubs = self._write_stub_file(tmp_path)
+        with ambient_stub_scope(cmd_stubs):
+            assert _codes(self._SRC) == set()
+        # Outside the scope the stubs are gone again.
+        assert "W210" in _codes(self._SRC)
+
+    def test_external_stub_does_not_emit_shadow_diagnostic(self, tmp_path):
+        # An external stub's range points into the .tcl.stubs file, not the
+        # document under analysis, so it must NOT raise W116/W117 against
+        # the analysed source even when it shadows a built-in.
+        from core.analysis.stub_comments import ambient_stub_scope, parse_stubs_file
+
+        path = tmp_path / "shadow.tcl.stubs"
+        path.write_text("stub set {varName:var value}\n", encoding="utf-8")
+        cmd_stubs, _ = parse_stubs_file(path)
+        with ambient_stub_scope(cmd_stubs):
+            codes = _codes("set x 1\nputs $x\n")
+        assert "W116" not in codes
+
+
+class TestExternalStubDiscovery:
+    """Workspace init discovers and parses ``.tcl.stubs`` files."""
+
+    def test_discovery_populates_workspace_stubs(self, tmp_path, monkeypatch):
+        import lsp.state as state
+        from lsp.workspace_init import _discover_workspace_stubs
+
+        (tmp_path / "eda.tcl.stubs").write_text(
+            "stub get_cells {pattern:pattern} -pure\n", encoding="utf-8"
+        )
+        nested = tmp_path / "lib"
+        nested.mkdir()
+        (nested / "more.tcl.stubs").write_text(
+            "stub get_ports {pattern:pattern} -pure\n", encoding="utf-8"
+        )
+
+        monkeypatch.setattr(state, "workspace_stub_commands", [], raising=False)
+        _discover_workspace_stubs([str(tmp_path)], [])
+
+        names = {s.name for s in state.workspace_stub_commands}
+        assert {"get_cells", "get_ports"} <= names
+
+    def test_discovery_skips_vcs_dirs(self, tmp_path, monkeypatch):
+        import lsp.state as state
+        from lsp.workspace_init import _discover_workspace_stubs
+
+        git = tmp_path / ".git"
+        git.mkdir()
+        (git / "ignored.tcl.stubs").write_text(
+            "stub should_not_load {x}\n", encoding="utf-8"
+        )
+
+        monkeypatch.setattr(state, "workspace_stub_commands", [], raising=False)
+        _discover_workspace_stubs([str(tmp_path)], [])
+
+        names = {s.name for s in state.workspace_stub_commands}
+        assert "should_not_load" not in names
 
 
 class TestShippedSampleIsClean:

--- a/tests/test_stub_semantics_e2e.py
+++ b/tests/test_stub_semantics_e2e.py
@@ -295,7 +295,7 @@ class TestExternalStubDiscovery:
         )
 
         monkeypatch.setattr(state, "workspace_stub_commands", [], raising=False)
-        _discover_workspace_stubs([str(tmp_path)], [])
+        _discover_workspace_stubs([str(tmp_path)])
 
         names = {s.name for s in state.workspace_stub_commands}
         assert {"get_cells", "get_ports"} <= names
@@ -309,10 +309,28 @@ class TestExternalStubDiscovery:
         (git / "ignored.tcl.stubs").write_text("stub should_not_load {x}\n", encoding="utf-8")
 
         monkeypatch.setattr(state, "workspace_stub_commands", [], raising=False)
-        _discover_workspace_stubs([str(tmp_path)], [])
+        _discover_workspace_stubs([str(tmp_path)])
 
         names = {s.name for s in state.workspace_stub_commands}
         assert "should_not_load" not in names
+
+    def test_discovery_spans_multiple_roots(self, tmp_path, monkeypatch):
+        # Multi-root workspaces: every base directory is searched.
+        import lsp.state as state
+        from lsp.workspace_init import _discover_workspace_stubs
+
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        root_a.mkdir()
+        root_b.mkdir()
+        (root_a / "a.tcl.stubs").write_text("stub cmd_a {x}\n", encoding="utf-8")
+        (root_b / "b.tcl.stubs").write_text("stub cmd_b {x}\n", encoding="utf-8")
+
+        monkeypatch.setattr(state, "workspace_stub_commands", [], raising=False)
+        _discover_workspace_stubs([str(root_a), str(root_b)])
+
+        names = {s.name for s in state.workspace_stub_commands}
+        assert {"cmd_a", "cmd_b"} <= names
 
 
 class TestShippedSampleIsClean:

--- a/tests/test_stub_semantics_e2e.py
+++ b/tests/test_stub_semantics_e2e.py
@@ -306,9 +306,7 @@ class TestExternalStubDiscovery:
 
         git = tmp_path / ".git"
         git.mkdir()
-        (git / "ignored.tcl.stubs").write_text(
-            "stub should_not_load {x}\n", encoding="utf-8"
-        )
+        (git / "ignored.tcl.stubs").write_text("stub should_not_load {x}\n", encoding="utf-8")
 
         monkeypatch.setattr(state, "workspace_stub_commands", [], raising=False)
         _discover_workspace_stubs([str(tmp_path)], [])
@@ -320,11 +318,7 @@ class TestExternalStubDiscovery:
 class TestShippedSampleIsClean:
     def test_inline_example_sample_has_no_diagnostics(self):
         sample = (
-            Path(__file__).resolve().parent.parent
-            / "samples"
-            / "dialect_stubs_inline_example.tcl"
+            Path(__file__).resolve().parent.parent / "samples" / "dialect_stubs_inline_example.tcl"
         )
         result = analyse(sample.read_text(encoding="utf-8"))
-        assert result.diagnostics == [], [
-            (d.code, d.message) for d in result.diagnostics
-        ]
+        assert result.diagnostics == [], [(d.code, d.message) for d in result.diagnostics]


### PR DESCRIPTION
## Summary

This PR adds two major features for dialect stub support:

1. **`-loop` stub declarations**: Stubs can now declare that a command's body argument is a loop body using the `-loop` flag. When a call matches the `varName:var collection body:body` shape, the lowering pass models it as a real loop (like `foreach`), so loop variables stay defined and the body is analysed in iteration order. This works regardless of leading subcommand words or option flags, using role-based argument matching.

2. **External `.tcl.stubs` files**: The workspace initializer now discovers and parses `*.tcl.stubs` files from the workspace root and library paths. These stubs are applied globally to every analysed document via an ambient scope, providing the same signature overlay as inline `# tcl-lsp: stub` blocks. Discovery skips VCS directories (`.git`, `.hg`, `.svn`, etc.) and caps the walk at 200 files to prevent pathological trees from stalling initialization.

### Key changes:

- **`core/compiler/lowering.py`**: Added `_lower_stub_loop()` method to lower `-loop` stubs to `IRForeach`. Updated `foreach_in_collection` lowering to check `is_loop_command()` so stubs are recognized alongside dialect-enabled commands.

- **`core/analysis/stub_comments.py`**: Added context variable infrastructure (`ambient_cmd_stubs()`, `ambient_stub_scope()`, `set_ambient_stubs()`) to manage workspace-level stubs. Added `parse_stubs_file()` function to parse external stub files.

- **`core/commands/registry/runtime.py`**: Added `is_loop_command()` to check if a command has a loop-body signature (from `-loop` stubs). Added `command_is_stubbed()` to detect stub-declared commands. Updated `stub_to_command_sig()` to propagate the `loop` flag from stubs.

- **`core/commands/registry/signatures.py`**: Added `loop: bool` field to `CommandSig` to track loop-body declarations.

- **`core/analysis/checks/_domain.py`**: Updated `check_disabled_command()` to suppress W002 for commands declared by stubs, since the stub intentionally makes them available.

- **`lsp/workspace_init.py`**: Added `_discover_workspace_stubs()` function to find and parse external stub files during workspace initialization.

- **`lsp/state.py`**: Added `workspace_stub_commands` to store discovered stubs.

- **`lsp/diagnostics_pipeline.py`**: Updated to apply workspace stubs via `ambient_stub_scope()` during analysis.

- **`lsp/workspace/document_state.py`**: Updated subprocess workers to re-establish workspace stubs via `set_ambient_stubs()`.

- **`core/compiler/compilation_unit.py`**: Updated stub fingerprinting to include ambient stubs.

- **`core/analysis/_analyser/_core.py`**: Updated to merge ambient stubs with inline stubs during analysis.

- **`core/analysis/_analyser/_diag_commands.py`**: Updated to include ambient stubs when checking for unresolved commands.

- **`samples/dialect_stubs_inline_example.tcl`**: Minor fix to the example (added missing output statement).

## Validation

- Added comprehensive end-to-end test suite (`tests/test_stub_semantics_e2e.py`) covering:
  - Loop stub lowering and variable scoping
  - Disabled command suppression via stubs
  - Body argument recursion and analysis
  - External stub file discovery and scoping
  - Shipped sample validation
- All new tests pass; existing tests remain unaffected.

## Compiler/KCS checklist

- [x] This change alters compiler lowering behaviour (adds `-loop` stub support)
- [x] Updated relevant documentation (stub comments module docstring explains `-loop` semantics)
- [ ] No new KCS notes required (feature is self-documenting via stub syntax and tests)

https://claude.ai/code/session_0117YphudcApjop2JKKtFz1L