### PR TITLE
Bundle stdlib procs at compile time and fix uplevel/upvar edge cases

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.6-126-g8921207c-dirty
-head=8921207ce2ff6e8cced628346b4898dd6a856dd0
-date=2026-05-21T09:57:21Z
-fingerprint=a91e6d48e28402de6c3b96194d9e13f79d8334d3d76246288ac9a4c28fe8adc8
+describe=4e3962a
+head=4e3962ac8b1bc347776b1d0a3361472e4f1ef70a
+date=2026-05-21T14:56:24Z
+fingerprint=45af96f593f1766a35b21c903819ab00b8e7a5c3cbb1d8a4ed18efaefddd2e9b

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=4e3962a
-head=4e3962ac8b1bc347776b1d0a3361472e4f1ef70a
-date=2026-05-21T14:56:24Z
-fingerprint=45af96f593f1766a35b21c903819ab00b8e7a5c3cbb1d8a4ed18efaefddd2e9b
+describe=v1.10.7-16-ge2ec683a-dirty
+head=e2ec683ab8667a5f4b250dda142653a9a6ad7841
+date=2026-05-21T15:15:56Z
+fingerprint=9d547b79fe2ead33c4a98c2d3500d4d5f6ada7ad511446a8cac03160f98ee854

--- a/core/compiler/codegen/wasm/_emitter/cmds/array_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/array_.py
@@ -18,6 +18,20 @@ def _emit_array_subcmd_value(emitter, args: tuple[str, ...]) -> None:
         emitter._emit_i32_const(0)
         return
     subcmd = args[0]
+    # Fire any ``array``-op variable trace before the inlined access,
+    # matching the interpreter's ``eval_array`` (trace-5.1: ``array``
+    # traces fire for get / set / names / size / exists / unset).  The
+    # helper takes the *raw* user-typed name so trace-registry routing
+    # agrees with ``trace add``.  Only emitted for a simple literal name
+    # (the common case) — a borrowed interned literal is refcount-safe
+    # to hand to the void helper; ``$``/``[``-substituted names skip the
+    # compiled fire and still fire on the interpreter fallback path.
+    if subcmd in ("exists", "size", "unset", "names", "get", "set") and len(args) >= 2:
+        fire_idx = emitter._shared_imports.get("tcl_array_fire_op_trace")
+        name = args[1]
+        if fire_idx is not None and not any(c in name for c in "$[("):
+            emitter._emit_obj_literal(name)
+            emitter._emit_call(fire_idx)
     if subcmd == "exists" and len(args) >= 2:
         fidx = emitter._shared_imports.get("tcl_array_exists")
         if fidx is not None:

--- a/core/compiler/codegen/wasm/_emitter/cmds/uplevel_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/uplevel_.py
@@ -252,6 +252,17 @@ def _emit_cmd_uplevel(emitter, args: tuple[str, ...]) -> None:
     emitter._emit_uplevel_body(body_parts)
     emitter._emit_local_set(body_local)
 
+    # Mirror this proc's compiled locals into its runtime frame before
+    # the interpreter evaluates the body.  ``uplevel #N`` can target the
+    # *current* proc's own frame (e.g. ``uplevel #1`` from a level-1
+    # proc → shift 0), in which case the eval'd body reads/writes this
+    # frame's variable table — which would otherwise miss WASM-local
+    # values that were never synced (uplevel-3.4).  Done before the
+    # stash so the write lands in the still-current frame; readback
+    # after restore surfaces any changes the body made back into the
+    # WASM locals.  No-op outside a compiled proc.
+    emitter._emit_interp_boundary("eval")
+
     # Choose the right stash variant.  ``#N`` is an *absolute*
     # level — only resolvable at runtime (relative shift depends on
     # the current call depth).  ``frame_depth_stash_abs`` does the
@@ -279,6 +290,10 @@ def _emit_cmd_uplevel(emitter, args: tuple[str, ...]) -> None:
 
     emitter._emit_local_get(saved_local)
     emitter._emit_call(restore_idx)
+
+    # Pull back any frame-variable writes the body made into this
+    # proc's WASM locals (counterpart to the pre-eval sync above).
+    emitter._emit_frame_readback()
 
     emitter._emit_local_get(result_local)
 

--- a/core/compiler/codegen/wasm/_imports.py
+++ b/core/compiler/codegen/wasm/_imports.py
@@ -771,6 +771,17 @@ _INFRASTRUCTURE_IMPORTS: dict[str, tuple[str, str, list[ValType], list[ValType]]
         [ValType.I32, ValType.I32],
         [ValType.I32],
     ),
+    # ``array_fire_op_trace(name)`` — fire any ``array``-op variable
+    # trace before a compiled ``array`` subcommand inlines its access,
+    # matching the interpreter's ``eval_array`` path (trace-5.1).  Takes
+    # the raw user-typed name so trace-registry routing agrees with
+    # ``trace add``.
+    "tcl_array_fire_op_trace": (
+        "tcl",
+        "array_fire_op_trace",
+        [ValType.I32],
+        [],
+    ),
     # Diagnostic — record the current source site so trap paths can
     # prefix stderr with ``site=<id>`` for sidecar-map resolution.
     "tcl_diag_set": ("tcl", "diag_set", [ValType.I32], []),

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -624,6 +624,11 @@ def _scan_text_for_cmd_subst(text: str, needed: set[str]) -> None:
                             needed.add("tcl_array_set")
                 elif cmd == "array" and len(parts) > 1:
                     sub = parts[1]
+                    # Every array-access subcommand fires any ``array``-op
+                    # variable trace before the access (trace-5.1); the
+                    # compiled fast-path needs the fire helper imported.
+                    if sub in ("exists", "size", "unset", "names", "get", "set"):
+                        needed.add("tcl_array_fire_op_trace")
                     if sub == "exists":
                         needed.add("tcl_array_exists")
                     elif sub == "size":

--- a/core/compiler/codegen/wasm_link.py
+++ b/core/compiler/codegen/wasm_link.py
@@ -319,6 +319,7 @@ def wasm_link(
     search_paths: tuple[str | Path, ...] = (),
     optimise: bool = False,
     max_depth: int = 10,
+    library_dir: str | Path | None = None,
 ) -> WasmModule:
     """Compile a Tcl source file and all its ``source`` dependencies to WASM.
 
@@ -335,7 +336,9 @@ def wasm_link(
         A ``WasmModule`` containing all procedures and top-level code
         from the main file and all transitively sourced files.
     """
-    merged = _link_to_ir(main_source, search_paths=search_paths, max_depth=max_depth)
+    merged = _link_to_ir(
+        main_source, search_paths=search_paths, max_depth=max_depth, library_dir=library_dir
+    )
     cfg = build_cfg(merged)
     return wasm_codegen_module(cfg, merged, optimise=optimise)
 
@@ -347,6 +350,7 @@ def wasm_link_bundled(
     optimise: bool = False,
     max_depth: int = 10,
     runtime_path: Path | None = None,
+    library_dir: str | Path | None = None,
 ) -> bytes:
     """Compile a Tcl source file to a single bundled ``.wasm`` binary.
 
@@ -374,7 +378,9 @@ def wasm_link_bundled(
     from .wasm._bundle import bundle_wasm  # noqa: PLC0415
     from .wasm.extensions import runtime_path_for  # noqa: PLC0415
 
-    merged_ir = _link_to_ir(main_source, search_paths=search_paths, max_depth=max_depth)
+    merged_ir = _link_to_ir(
+        main_source, search_paths=search_paths, max_depth=max_depth, library_dir=library_dir
+    )
     cfg = build_cfg(merged_ir)
     user_module = wasm_codegen_module(cfg, merged_ir, optimise=optimise)
 
@@ -387,6 +393,7 @@ def _link_to_ir(
     *,
     search_paths: tuple[str | Path, ...] = (),
     max_depth: int = 10,
+    library_dir: str | Path | None = None,
 ) -> IRModule:
     """Resolve ``source`` and ``package require``, return merged IR.
 
@@ -432,4 +439,15 @@ def _link_to_ir(
                 _resolve_recursive(pkg_path.resolve(), depth + 1)
 
     _resolve_recursive(main_path, 0)
-    return merge_ir_modules(*modules)
+    merged = merge_ir_modules(*modules)
+
+    # Bundle referenced standard-library procedures at compile time so
+    # they compile to WASM functions and the binary is self-contained,
+    # rather than auto-loading them from ``TCL_LIBRARY`` at run time.
+    # Opt-in: skipped entirely when no ``library_dir`` is supplied.
+    if library_dir is not None:
+        from ..stdlib_prelude import apply_stdlib_prelude  # noqa: PLC0415
+
+        merged = apply_stdlib_prelude(merged, library_dir)
+
+    return merged

--- a/core/compiler/codegen/wasm_link.py
+++ b/core/compiler/codegen/wasm_link.py
@@ -444,10 +444,10 @@ def _link_to_ir(
     # Bundle referenced standard-library procedures at compile time so
     # they compile to WASM functions and the binary is self-contained,
     # rather than auto-loading them from ``TCL_LIBRARY`` at run time.
-    # Opt-in: skipped entirely when no ``library_dir`` is supplied.
-    if library_dir is not None:
-        from ..stdlib_prelude import apply_stdlib_prelude  # noqa: PLC0415
+    # Default-on: explicit ``library_dir`` wins, else the compile-time
+    # ``TCL_LIBRARY`` env var; a no-op when neither is set, with stdlib
+    # procs then resolving via the runtime auto-loader.  Only the
+    # validated allowlist is bundled by default.
+    from ..stdlib_prelude import apply_stdlib_prelude_auto  # noqa: PLC0415
 
-        merged = apply_stdlib_prelude(merged, library_dir)
-
-    return merged
+    return apply_stdlib_prelude_auto(merged, library_dir)

--- a/core/compiler/stdlib_prelude.py
+++ b/core/compiler/stdlib_prelude.py
@@ -1,0 +1,217 @@
+"""Compile-time bundling of referenced standard-library procedures.
+
+The runtime can auto-load stdlib procs from ``TCL_LIBRARY`` at run time
+(see ``runtime/zig`` ``ensure_stdlib_index_loaded``), but that costs a
+filesystem dependency and runs the loaded proc through the interpreter.
+For commands a program references whose definitions live in the standard
+library, we can do better: read the ``.tcl`` file off the host once,
+lower it to IR, and splice its procedures into the module so they
+compile to WASM functions and the bundle is self-contained.
+
+This mirrors :mod:`core.compiler.source_inliner` (which inlines explicit
+``source LITERAL`` calls) but is *reference-driven*: the trigger is a
+call to a command that the library's ``tclIndex`` maps to a file.  Only
+files for commands actually referenced (transitively) are pulled in, so
+the bundle grows by the few KB a program uses rather than the whole
+library.
+
+Anything not statically resolvable — dynamic command names (``$cmd`` /
+``eval``), or a library file that fails to lower — is left untouched and
+falls back to the runtime ``TCL_LIBRARY`` auto-loader.  The pass runs
+after :func:`core.compiler.lowering.lower_to_ir` and before
+:func:`core.compiler.cfg.build_cfg`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .ir import (
+    IRBlock,
+    IRCall,
+    IRCatch,
+    IRFor,
+    IRForeach,
+    IRIf,
+    IRModule,
+    IRScript,
+    IRStatement,
+    IRSwitch,
+    IRTry,
+    IRUpFrame,
+    IRWhile,
+)
+
+# ``set auto_index(NAME) [list <loader> [file join $dir FILE]]`` — the
+# canonical tclIndex (version 2.0) entry shape.  ``NAME`` is the command
+# (possibly namespace-qualified), ``FILE`` the relative file under the
+# library directory.
+_AUTO_INDEX_RE = re.compile(
+    r"set\s+auto_index\(([^)]+)\)\s+\[list\s+\S+\s+\[file\s+join\s+\$dir\s+([^\]]+)\]\]"
+)
+
+
+def _parse_tcl_index(library_dir: Path) -> dict[str, str]:
+    """Parse ``$library_dir/tclIndex`` into a ``command -> relative file`` map.
+
+    Returns an empty map when the index is absent or unreadable (the
+    caller then leaves the module untouched).
+    """
+    index_path = library_dir / "tclIndex"
+    if not index_path.is_file():
+        return {}
+    mapping: dict[str, str] = {}
+    try:
+        text = index_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    for line in text.splitlines():
+        m = _AUTO_INDEX_RE.search(line)
+        if m:
+            mapping[m.group(1)] = m.group(2).strip()
+    return mapping
+
+
+def _collect_commands(script: IRScript, out: set[str]) -> None:
+    """Collect every command name invoked anywhere in *script*.
+
+    Records both the surface ``command`` and the resolved
+    ``canonical_command`` so a call written as ``parray`` and one written
+    as ``::parray`` both match the index map.
+    """
+    for stmt in script.statements:
+        if isinstance(stmt, IRCall):
+            if stmt.command:
+                out.add(stmt.command)
+            if stmt.canonical_command:
+                out.add(stmt.canonical_command)
+        _recurse_bodies(stmt, out)
+
+
+def _recurse_bodies(stmt: IRStatement, out: set[str]) -> None:
+    if isinstance(stmt, IRIf):
+        for clause in stmt.clauses:
+            _collect_commands(clause.body, out)
+        if stmt.else_body:
+            _collect_commands(stmt.else_body, out)
+    elif isinstance(stmt, IRFor):
+        _collect_commands(stmt.init, out)
+        _collect_commands(stmt.body, out)
+        _collect_commands(stmt.next, out)
+    elif isinstance(stmt, IRWhile):
+        _collect_commands(stmt.body, out)
+    elif isinstance(stmt, IRForeach):
+        _collect_commands(stmt.body, out)
+    elif isinstance(stmt, IRCatch):
+        _collect_commands(stmt.body, out)
+    elif isinstance(stmt, IRTry):
+        _collect_commands(stmt.body, out)
+        for handler in stmt.handlers:
+            _collect_commands(handler.body, out)
+        if stmt.finally_body:
+            _collect_commands(stmt.finally_body, out)
+    elif isinstance(stmt, IRSwitch):
+        for arm in stmt.arms:
+            if arm.body:
+                _collect_commands(arm.body, out)
+        if stmt.default_body:
+            _collect_commands(stmt.default_body, out)
+    elif isinstance(stmt, IRBlock):
+        _collect_commands(stmt.body, out)
+    elif isinstance(stmt, IRUpFrame):
+        _collect_commands(stmt.body, out)
+
+
+def _file_for_command(name: str, mapping: dict[str, str]) -> str | None:
+    """Resolve a referenced command to its library file, tolerating the
+    leading ``::`` that canonicalisation adds to global names."""
+    if name in mapping:
+        return mapping[name]
+    if name.startswith("::") and name[2:] in mapping:
+        return mapping[name[2:]]
+    return None
+
+
+def apply_stdlib_prelude(
+    module: IRModule,
+    library_dir: str | Path,
+    *,
+    max_files: int = 64,
+) -> IRModule:
+    """Bundle the library files for stdlib commands *module* references.
+
+    Mutates and returns *module*: procedures (and load-time top-level
+    setup) from each referenced library file are merged in.  Resolution
+    is transitive — a bundled proc that calls another library command
+    pulls that file in too — to a fixpoint, capped at *max_files*.
+
+    A no-op (returns *module* unchanged) when *library_dir* has no
+    ``tclIndex`` or references nothing autoloadable, so callers can pass
+    a missing path harmlessly.
+    """
+    lib = Path(library_dir)
+    mapping = _parse_tcl_index(lib)
+    if not mapping:
+        return module
+
+    bundled_files: set[str] = set()
+    seen_commands: set[str] = set()
+
+    # Seed the worklist with commands referenced by the user's module.
+    pending: set[str] = set()
+    _collect_commands(module.top_level, pending)
+    for proc in list(module.procedures.values()):
+        _collect_commands(proc.body, pending)
+
+    from .lowering import lower_to_ir
+
+    while pending and len(bundled_files) < max_files:
+        name = pending.pop()
+        if name in seen_commands:
+            continue
+        seen_commands.add(name)
+
+        rel_file = _file_for_command(name, mapping)
+        if rel_file is None or rel_file in bundled_files:
+            continue
+        # A command the user already defines as a proc shadows the
+        # library version — don't bundle it.
+        if name in module.procedures or f"::{name}" in module.procedures:
+            continue
+
+        path = lib / rel_file
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            sub = lower_to_ir(text)
+        except Exception:  # noqa: BLE001 — a non-readable / non-lowerable
+            # library file just falls back to the runtime auto-loader.
+            continue
+
+        bundled_files.add(rel_file)
+
+        # Merge procedures (skip any the user already defined).
+        for qname, proc in sub.procedures.items():
+            if qname not in module.procedures:
+                module.procedures[qname] = proc
+        # Merge the file's load-time top-level setup (``namespace eval`` /
+        # ``variable`` declarations the procs depend on) ahead of the
+        # user's code so it runs first.  Most index files lift their
+        # whole body into ``procedures`` and leave this empty.
+        if sub.top_level.statements:
+            module.top_level = IRScript(
+                statements=tuple(sub.top_level.statements) + tuple(module.top_level.statements)
+            )
+        if sub.namespace_imports:
+            module.namespace_imports = module.namespace_imports + sub.namespace_imports
+        if sub.namespace_exports:
+            module.namespace_exports = module.namespace_exports + sub.namespace_exports
+
+        # Transitive: queue commands the freshly-bundled procs reference.
+        new_cmds: set[str] = set()
+        for proc in sub.procedures.values():
+            _collect_commands(proc.body, new_cmds)
+        _collect_commands(sub.top_level, new_cmds)
+        pending |= new_cmds - seen_commands
+
+    return module

--- a/core/compiler/stdlib_prelude.py
+++ b/core/compiler/stdlib_prelude.py
@@ -24,6 +24,7 @@ after :func:`core.compiler.lowering.lower_to_ir` and before
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -41,6 +42,27 @@ from .ir import (
     IRTry,
     IRUpFrame,
     IRWhile,
+)
+
+# Standard-library commands verified to bundle *and run* correctly when
+# compiled into the WASM module (output matches reference tclsh 8.6/9.0).
+# Only these seed compile-time bundling by default; everything else
+# falls back to the runtime ``TCL_LIBRARY`` auto-loader.  "Compiles" is
+# not enough — some library procs depend on init-time state set
+# elsewhere in the bootstrap — so this list grows only as commands are
+# differentially validated (see ``tests/test_wasm_autoload.py``).
+# Transitive helpers a listed command pulls in (e.g. word.tcl's
+# ``::tcl::UpdateWordBreakREs``) come along automatically and need not
+# be listed.
+DEFAULT_STDLIB_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "parray",
+        "tcl_endOfWord",
+        "tcl_startOfNextWord",
+        "tcl_startOfPreviousWord",
+        "tcl_wordBreakAfter",
+        "tcl_wordBreakBefore",
+    }
 )
 
 # ``set auto_index(NAME) [list <loader> [file join $dir FILE]]`` — the
@@ -73,12 +95,59 @@ def _parse_tcl_index(library_dir: Path) -> dict[str, str]:
     return mapping
 
 
+def _script_command_names(script_text: str, out: set[str]) -> None:
+    """Collect the command name of each command in *script_text* and
+    recurse into any ``[...]`` substitutions it contains.
+
+    ``script_text`` is treated as a Tcl *script*: the first word of each
+    command (after a command boundary) is a command name.  Used for the
+    bodies of command substitutions, where the leading word genuinely is
+    a command.
+    """
+    from core.parsing.lexer import TclLexer
+    from core.parsing.tokens import TokenType
+
+    at_cmd_start = True
+    for tok in TclLexer(script_text).tokenise_all():
+        ttype = tok.type
+        if ttype in (TokenType.EOL,):
+            at_cmd_start = True
+        elif ttype == TokenType.SEP:
+            # Leading whitespace before the command word doesn't end the
+            # command-start state.
+            continue
+        elif ttype == TokenType.COMMENT:
+            continue
+        else:
+            if at_cmd_start and ttype in (TokenType.ESC, TokenType.STR):
+                out.add(tok.text)
+            at_cmd_start = False
+            if ttype == TokenType.CMD:
+                _script_command_names(tok.text, out)
+
+
+def _subst_commands(word_text: str, out: set[str]) -> None:
+    """Collect command names from ``[...]`` substitutions inside a *word*.
+
+    The word's own bare text is NOT a command (e.g. ``lappend l foo``'s
+    ``foo`` is data) — only the contents of command substitutions are.
+    """
+    from core.parsing.lexer import TclLexer
+    from core.parsing.tokens import TokenType
+
+    for tok in TclLexer(word_text).tokenise_all():
+        if tok.type == TokenType.CMD:
+            _script_command_names(tok.text, out)
+
+
 def _collect_commands(script: IRScript, out: set[str]) -> None:
     """Collect every command name invoked anywhere in *script*.
 
-    Records both the surface ``command`` and the resolved
-    ``canonical_command`` so a call written as ``parray`` and one written
-    as ``::parray`` both match the index map.
+    Records statement-level commands (both the surface ``command`` and
+    the resolved ``canonical_command`` so ``parray`` and ``::parray``
+    both match), plus commands embedded in ``[...]`` substitutions inside
+    call arguments and value assignments — the dominant case for
+    library procs that return values (``set i [tcl_endOfWord ...]``).
     """
     for stmt in script.statements:
         if isinstance(stmt, IRCall):
@@ -86,6 +155,12 @@ def _collect_commands(script: IRScript, out: set[str]) -> None:
                 out.add(stmt.command)
             if stmt.canonical_command:
                 out.add(stmt.canonical_command)
+            for arg in stmt.args:
+                _subst_commands(arg, out)
+        else:
+            value = getattr(stmt, "value", None)
+            if isinstance(value, str):
+                _subst_commands(value, out)
         _recurse_bodies(stmt, out)
 
 
@@ -138,6 +213,7 @@ def apply_stdlib_prelude(
     library_dir: str | Path,
     *,
     max_files: int = 64,
+    allowlist: frozenset[str] | None = DEFAULT_STDLIB_ALLOWLIST,
 ) -> IRModule:
     """Bundle the library files for stdlib commands *module* references.
 
@@ -146,9 +222,16 @@ def apply_stdlib_prelude(
     is transitive — a bundled proc that calls another library command
     pulls that file in too — to a fixpoint, capped at *max_files*.
 
+    *allowlist* gates which *referenced* commands seed bundling: only
+    commands in it (default :data:`DEFAULT_STDLIB_ALLOWLIST`, the
+    differentially-validated set) are bundled from the user's module.
+    Pass ``None`` to bundle every referenced command (power / validation
+    use).  Transitive helpers a seeded command pulls in are never gated
+    — they're part of that command's verified closure.
+
     A no-op (returns *module* unchanged) when *library_dir* has no
-    ``tclIndex`` or references nothing autoloadable, so callers can pass
-    a missing path harmlessly.
+    ``tclIndex`` or references nothing bundleable, so callers can pass a
+    missing path harmlessly.
     """
     lib = Path(library_dir)
     mapping = _parse_tcl_index(lib)
@@ -158,11 +241,14 @@ def apply_stdlib_prelude(
     bundled_files: set[str] = set()
     seen_commands: set[str] = set()
 
-    # Seed the worklist with commands referenced by the user's module.
+    # Seed the worklist with commands referenced by the user's module,
+    # gated by the allowlist (transitive deps added later are not gated).
     pending: set[str] = set()
     _collect_commands(module.top_level, pending)
     for proc in list(module.procedures.values()):
         _collect_commands(proc.body, pending)
+    if allowlist is not None:
+        pending = {n for n in pending if n in allowlist or n.lstrip(":") in allowlist}
 
     from .lowering import lower_to_ir
 
@@ -215,3 +301,25 @@ def apply_stdlib_prelude(
         pending |= new_cmds - seen_commands
 
     return module
+
+
+def apply_stdlib_prelude_auto(
+    module: IRModule,
+    library_dir: str | Path | None = None,
+    *,
+    allowlist: frozenset[str] | None = DEFAULT_STDLIB_ALLOWLIST,
+) -> IRModule:
+    """Apply :func:`apply_stdlib_prelude`, resolving the library directory
+    from the compile-time ``TCL_LIBRARY`` env var when *library_dir* is
+    not given.
+
+    This is the default-on entry point: bundling happens whenever a
+    standard library is discoverable (explicit path or ``TCL_LIBRARY``),
+    and is a no-op otherwise.  Shared by the compile-time linker
+    (:func:`core.compiler.codegen.wasm_link`) and the WASM CLI so both
+    pick up the same behaviour.
+    """
+    effective = library_dir if library_dir is not None else os.environ.get("TCL_LIBRARY")
+    if not effective:
+        return module
+    return apply_stdlib_prelude(module, effective, allowlist=allowlist)

--- a/core/compiler/stdlib_prelude.py
+++ b/core/compiler/stdlib_prelude.py
@@ -198,6 +198,149 @@ def _recurse_bodies(stmt: IRStatement, out: set[str]) -> None:
         _collect_commands(stmt.body, out)
 
 
+# Commands that run a script or invoke a command by a name the static
+# call graph can't see — their script/command argument is an ordinary
+# word (not a ``[...]`` substitution the scanner walks), so any proc
+# they reach is invisible.  ``eval`` / ``uplevel`` / dynamic
+# ``namespace eval`` / dynamic ``catch`` already lower to
+# :class:`IRBarrier`; this set covers the rest that stay plain
+# :class:`IRCall`.  If any appears, pruning is unsafe.
+_DISPATCH_COMMANDS: frozenset[str] = frozenset(
+    {
+        "apply",
+        "source",
+        "subst",
+        "interp",
+        "after",
+        "trace",
+        "coroutine",
+        "tailcall",
+        "vwait",
+        "uplevel",
+        "eval",
+        "namespace",
+        "unknown",
+    }
+)
+
+
+def _name_is_dynamic(name: str) -> bool:
+    """A command name that isn't a compile-time literal (it's computed at
+    run time via variable / command substitution, so it could resolve to
+    any proc)."""
+    return "$" in name or "[" in name or "{" in name
+
+
+def _has_barrier(script: IRScript) -> bool:
+    """True if *script* (recursively) contains an :class:`IRBarrier` —
+    eval / uplevel / dynamic ``namespace eval`` / dynamic ``catch`` and
+    friends, which run scripts the static analysis can't see into."""
+    from .ir import IRBarrier
+
+    for stmt in script.statements:
+        if isinstance(stmt, IRBarrier):
+            return True
+        # Reuse the body-recursion shape; collect into a throwaway set
+        # is overkill, so walk bodies directly here.
+        if _stmt_bodies_have_barrier(stmt):
+            return True
+    return False
+
+
+def _stmt_bodies_have_barrier(stmt: IRStatement) -> bool:
+    if isinstance(stmt, IRIf):
+        return any(_has_barrier(c.body) for c in stmt.clauses) or (
+            stmt.else_body is not None and _has_barrier(stmt.else_body)
+        )
+    if isinstance(stmt, IRFor):
+        return _has_barrier(stmt.init) or _has_barrier(stmt.body) or _has_barrier(stmt.next)
+    if isinstance(stmt, (IRWhile, IRForeach, IRCatch, IRBlock, IRUpFrame)):
+        return _has_barrier(stmt.body)
+    if isinstance(stmt, IRTry):
+        return (
+            _has_barrier(stmt.body)
+            or any(_has_barrier(h.body) for h in stmt.handlers)
+            or (stmt.finally_body is not None and _has_barrier(stmt.finally_body))
+        )
+    if isinstance(stmt, IRSwitch):
+        return any(arm.body is not None and _has_barrier(arm.body) for arm in stmt.arms) or (
+            stmt.default_body is not None and _has_barrier(stmt.default_body)
+        )
+    return False
+
+
+def _module_has_dynamic_dispatch(module: IRModule) -> bool:
+    """True when the module contains *any* construct that could invoke a
+    command by a name the static call graph can't enumerate — an
+    :class:`IRBarrier`, a non-literal command name, or a call to a
+    :data:`_DISPATCH_COMMANDS` script-runner.  Pruning bundled procs is
+    only sound when this is False."""
+    if _has_barrier(module.top_level):
+        return True
+    for proc in module.procedures.values():
+        if _has_barrier(proc.body):
+            return True
+    refs: set[str] = set()
+    _collect_commands(module.top_level, refs)
+    for proc in module.procedures.values():
+        _collect_commands(proc.body, refs)
+    for name in refs:
+        if _name_is_dynamic(name):
+            return True
+        if name.lstrip(":") in _DISPATCH_COMMANDS:
+            return True
+    return False
+
+
+def _prune_unused_bundled(module: IRModule, bundled_qnames: set[str]) -> None:
+    """Remove bundled procs unreachable from the user's code.
+
+    Roots are the top level plus every *non-bundled* proc (any of which
+    may run).  A bundled proc survives only if statically reachable from
+    a root, transitively through other bundled procs.  Skipped entirely
+    when the module has any dynamic dispatch (:func:`_module_has_dynamic
+    _dispatch`) — then we cannot prove what a runtime-resolved name
+    invokes, so nothing is pruned.
+    """
+    if not bundled_qnames:
+        return
+    if _module_has_dynamic_dispatch(module):
+        return
+
+    def _norm(n: str) -> str:
+        return n.lstrip(":")
+
+    bundled_by_norm: dict[str, str] = {_norm(q): q for q in bundled_qnames}
+
+    # Seed reachability with commands referenced by the roots.
+    worklist: set[str] = set()
+    _collect_commands(module.top_level, worklist)
+    for qname, proc in module.procedures.items():
+        if qname not in bundled_qnames:
+            _collect_commands(proc.body, worklist)
+
+    live: set[str] = set()
+    while worklist:
+        name = worklist.pop()
+        qn = bundled_by_norm.get(_norm(name))
+        if qn is None or qn in live:
+            continue
+        live.add(qn)
+        # Pull in the commands this now-live bundled proc references.
+        _collect_commands(module.procedures[qn].body, worklist)
+
+    for qname in bundled_qnames - live:
+        module.procedures.pop(qname, None)
+
+
+def _is_proc_definition(stmt: IRStatement) -> bool:
+    """True if *stmt* is a top-level ``proc NAME ARGS BODY`` definition —
+    redundant once the proc is in ``module.procedures``."""
+    return isinstance(stmt, IRCall) and (
+        stmt.command == "proc" or stmt.canonical_command == "::proc"
+    )
+
+
 def _file_for_command(name: str, mapping: dict[str, str]) -> str | None:
     """Resolve a referenced command to its library file, tolerating the
     leading ``::`` that canonicalisation adds to global names."""
@@ -239,6 +382,7 @@ def apply_stdlib_prelude(
         return module
 
     bundled_files: set[str] = set()
+    bundled_qnames: set[str] = set()
     seen_commands: set[str] = set()
 
     # Seed the worklist with commands referenced by the user's module,
@@ -280,13 +424,19 @@ def apply_stdlib_prelude(
         for qname, proc in sub.procedures.items():
             if qname not in module.procedures:
                 module.procedures[qname] = proc
+                bundled_qnames.add(qname)
         # Merge the file's load-time top-level setup (``namespace eval`` /
         # ``variable`` declarations the procs depend on) ahead of the
-        # user's code so it runs first.  Most index files lift their
-        # whole body into ``procedures`` and leave this empty.
-        if sub.top_level.statements:
+        # user's code so it runs first.  Drop the file's ``proc``
+        # *definition* statements: the procs are already merged into
+        # ``module.procedures`` (whence codegen compiles them), so the
+        # top-level ``proc`` calls are redundant — and scanning their
+        # body arguments would otherwise pollute the prune root set with
+        # commands the bundled procs reference internally.
+        setup_stmts = tuple(s for s in sub.top_level.statements if not _is_proc_definition(s))
+        if setup_stmts:
             module.top_level = IRScript(
-                statements=tuple(sub.top_level.statements) + tuple(module.top_level.statements)
+                statements=setup_stmts + tuple(module.top_level.statements)
             )
         if sub.namespace_imports:
             module.namespace_imports = module.namespace_imports + sub.namespace_imports
@@ -299,6 +449,10 @@ def apply_stdlib_prelude(
             _collect_commands(proc.body, new_cmds)
         _collect_commands(sub.top_level, new_cmds)
         pending |= new_cmds - seen_commands
+
+    # Drop bundled procs the program can't statically reach — but only
+    # when it's provably safe (no eval/source/dynamic dispatch).
+    _prune_unused_bundled(module, bundled_qnames)
 
     return module
 

--- a/core/compiler/stdlib_prelude.py
+++ b/core/compiler/stdlib_prelude.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections import deque
 from pathlib import Path
 
 from .ir import (
@@ -91,7 +92,13 @@ def _parse_tcl_index(library_dir: Path) -> dict[str, str]:
     for line in text.splitlines():
         m = _AUTO_INDEX_RE.search(line)
         if m:
-            mapping[m.group(1)] = m.group(2).strip()
+            # The ``[file join $dir ...]`` tail may carry several path
+            # segments (subdirectories), e.g. ``[file join $dir sub
+            # foo.tcl]``.  Join them into a relative path rather than
+            # treating the whole tail as one segment.
+            segments = m.group(2).split()
+            if segments:
+                mapping[m.group(1)] = os.path.join(*segments)
     return mapping
 
 
@@ -119,8 +126,15 @@ def _script_command_names(script_text: str, out: set[str]) -> None:
         elif ttype == TokenType.COMMENT:
             continue
         else:
-            if at_cmd_start and ttype in (TokenType.ESC, TokenType.STR):
-                out.add(tok.text)
+            if at_cmd_start:
+                if ttype in (TokenType.ESC, TokenType.STR):
+                    out.add(tok.text)
+                elif ttype in (TokenType.VAR, TokenType.CMD):
+                    # The command name itself is computed at run time
+                    # (``[$cmd ...]`` / ``[[set c foo] ...]``) — record a
+                    # non-literal marker so the dynamic-dispatch gate
+                    # trips and pruning stays conservative.
+                    out.add("${dyn}")
             at_cmd_start = False
             if ttype == TokenType.CMD:
                 _script_command_names(tok.text, out)
@@ -387,17 +401,25 @@ def apply_stdlib_prelude(
 
     # Seed the worklist with commands referenced by the user's module,
     # gated by the allowlist (transitive deps added later are not gated).
-    pending: set[str] = set()
-    _collect_commands(module.top_level, pending)
+    # The worklist is processed FIFO with new commands added in sorted
+    # order so bundling — and the merged setup ordering below — is
+    # deterministic / reproducible regardless of set iteration order.
+    seed: set[str] = set()
+    _collect_commands(module.top_level, seed)
     for proc in list(module.procedures.values()):
-        _collect_commands(proc.body, pending)
+        _collect_commands(proc.body, seed)
     if allowlist is not None:
-        pending = {n for n in pending if n in allowlist or n.lstrip(":") in allowlist}
+        seed = {n for n in seed if n in allowlist or n.lstrip(":") in allowlist}
+    queue: deque[str] = deque(sorted(seed))
+
+    # Load-time setup from each bundled file, accumulated in bundling
+    # order and prepended once after the traversal (deterministic).
+    setup: list[IRStatement] = []
 
     from .lowering import lower_to_ir
 
-    while pending and len(bundled_files) < max_files:
-        name = pending.pop()
+    while queue and len(bundled_files) < max_files:
+        name = queue.popleft()
         if name in seen_commands:
             continue
         seen_commands.add(name)
@@ -425,30 +447,31 @@ def apply_stdlib_prelude(
             if qname not in module.procedures:
                 module.procedures[qname] = proc
                 bundled_qnames.add(qname)
-        # Merge the file's load-time top-level setup (``namespace eval`` /
-        # ``variable`` declarations the procs depend on) ahead of the
-        # user's code so it runs first.  Drop the file's ``proc``
-        # *definition* statements: the procs are already merged into
-        # ``module.procedures`` (whence codegen compiles them), so the
-        # top-level ``proc`` calls are redundant — and scanning their
-        # body arguments would otherwise pollute the prune root set with
-        # commands the bundled procs reference internally.
-        setup_stmts = tuple(s for s in sub.top_level.statements if not _is_proc_definition(s))
-        if setup_stmts:
-            module.top_level = IRScript(
-                statements=setup_stmts + tuple(module.top_level.statements)
-            )
+        # Collect the file's load-time top-level setup (``namespace eval``
+        # / ``variable`` declarations the procs depend on).  Drop the
+        # file's ``proc`` *definition* statements: the procs are already
+        # merged into ``module.procedures`` (whence codegen compiles
+        # them), so the top-level ``proc`` calls are redundant — and
+        # scanning their body arguments would otherwise pollute the prune
+        # root set with commands the bundled procs reference internally.
+        setup.extend(s for s in sub.top_level.statements if not _is_proc_definition(s))
         if sub.namespace_imports:
             module.namespace_imports = module.namespace_imports + sub.namespace_imports
         if sub.namespace_exports:
             module.namespace_exports = module.namespace_exports + sub.namespace_exports
 
-        # Transitive: queue commands the freshly-bundled procs reference.
+        # Transitive: queue commands the freshly-bundled procs reference,
+        # in sorted order for deterministic traversal.
         new_cmds: set[str] = set()
         for proc in sub.procedures.values():
             _collect_commands(proc.body, new_cmds)
         _collect_commands(sub.top_level, new_cmds)
-        pending |= new_cmds - seen_commands
+        queue.extend(sorted(new_cmds - seen_commands))
+
+    # Prepend all bundled setup ahead of the user's code so it runs
+    # first, once, in deterministic bundling order.
+    if setup:
+        module.top_level = IRScript(statements=tuple(setup) + tuple(module.top_level.statements))
 
     # Drop bundled procs the program can't statically reach — but only
     # when it's provably safe (no eval/source/dynamic dispatch).

--- a/explorer/wasm_cli.py
+++ b/explorer/wasm_cli.py
@@ -48,6 +48,7 @@ def compile_tcl_to_wasm(
     source: str,
     *,
     optimise: bool = False,
+    library_dir: str | None = None,
 ) -> WasmModule:
     """Compile Tcl source to a WASM module.
 
@@ -55,6 +56,10 @@ def compile_tcl_to_wasm(
         source: Tcl source code.
         optimise: Enable optimisation passes (constant folding,
             peephole optimisation, dead-code elimination).
+        library_dir: Standard-library directory to bundle referenced
+            stdlib procs from at compile time.  Defaults to the
+            ``TCL_LIBRARY`` env var; a no-op when neither is available
+            (stdlib procs then resolve via the runtime auto-loader).
 
     Returns:
         A ``WasmModule`` ready for serialisation.
@@ -63,7 +68,10 @@ def compile_tcl_to_wasm(
     :func:`link_tcl_to_wasm` to fold in the runtime and get a binary
     that instantiates standalone.
     """
+    from core.compiler.stdlib_prelude import apply_stdlib_prelude_auto
+
     ir_module = lower_to_ir(source)
+    ir_module = apply_stdlib_prelude_auto(ir_module, library_dir)
     cfg_module = build_cfg(ir_module)
     return wasm_codegen_module(cfg_module, ir_module, optimise=optimise)
 
@@ -72,6 +80,7 @@ def link_tcl_to_wasm(
     source: str,
     *,
     optimise: bool = False,
+    library_dir: str | None = None,
 ) -> bytes:
     """Compile *and link* Tcl source into a self-contained ``.wasm``.
 
@@ -89,8 +98,10 @@ def link_tcl_to_wasm(
     # extension-manifest dependency.
     from core.compiler.codegen.wasm._bundle import bundle_wasm
     from core.compiler.codegen.wasm.extensions import runtime_path_for
+    from core.compiler.stdlib_prelude import apply_stdlib_prelude_auto
 
     ir_module = lower_to_ir(source)
+    ir_module = apply_stdlib_prelude_auto(ir_module, library_dir)
     cfg_module = build_cfg(ir_module)
     module = wasm_codegen_module(cfg_module, ir_module, optimise=optimise)
     return bundle_wasm(module.to_bytes(), runtime_path=runtime_path_for(ir_module))
@@ -147,6 +158,16 @@ def main() -> int:
             "output; requires Binaryen wasm-merge/wasm-opt on PATH)"
         ),
     )
+    parser.add_argument(
+        "--tcl-library",
+        default=None,
+        help=(
+            "Standard-library directory to bundle referenced stdlib procs "
+            "(e.g. parray) from at compile time, so the binary is "
+            "self-contained. Defaults to the TCL_LIBRARY env var; if "
+            "unset, stdlib procs resolve via the runtime auto-loader."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -163,7 +184,7 @@ def main() -> int:
 
     # Linked binary: fold in the runtime and emit a runnable module.
     if args.link:
-        linked = link_tcl_to_wasm(source, optimise=args.optimise)
+        linked = link_tcl_to_wasm(source, optimise=args.optimise, library_dir=args.tcl_library)
         out_path = args.output or "out.wasm"
         Path(out_path).write_bytes(linked)
         opt_label = "optimised" if args.optimise else "non-optimised"
@@ -174,7 +195,7 @@ def main() -> int:
         return 0
 
     # Compile
-    module = compile_tcl_to_wasm(source, optimise=args.optimise)
+    module = compile_tcl_to_wasm(source, optimise=args.optimise, library_dir=args.tcl_library)
 
     opt_label = "optimised" if args.optimise else "non-optimised"
 
@@ -207,8 +228,8 @@ def main() -> int:
 
     if args.format == "both":
         # Also show comparison info
-        module_no_opt = compile_tcl_to_wasm(source, optimise=False)
-        module_opt = compile_tcl_to_wasm(source, optimise=True)
+        module_no_opt = compile_tcl_to_wasm(source, optimise=False, library_dir=args.tcl_library)
+        module_opt = compile_tcl_to_wasm(source, optimise=True, library_dir=args.tcl_library)
 
         no_opt_size = len(module_no_opt.to_bytes())
         opt_size = len(module_opt.to_bytes())

--- a/runtime/zig/cmds/array.zig
+++ b/runtime/zig/cmds/array.zig
@@ -141,6 +141,19 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
     const obj_mod = @import("../valtypes/tcl_obj.zig");
     const resolved_name: i32 = frames_mod.frame_resolve_array_name(words[2]);
     defer if (resolved_name != words[2]) obj_mod.tcl_obj_release(resolved_name);
+    // Fire any ``array``-op trace before the access so the callback can
+    // lazily populate the array (reference Tcl: ``array`` traces fire
+    // for get / names / set / size / exists / unset / statistics — but
+    // not for plain element reads / writes; trace-5.1 / 5.2).  The
+    // search-cursor subcommands and ``default`` don't fire.
+    if (str_eq(sp, sub_len, "get") or str_eq(sp, sub_len, "set") or
+        str_eq(sp, sub_len, "names") or str_eq(sp, sub_len, "size") or
+        str_eq(sp, sub_len, "exists") or str_eq(sp, sub_len, "unset") or
+        str_eq(sp, sub_len, "statistics"))
+    {
+        const inspect_mod = @import("inspect.zig");
+        inspect_mod.fire_array_op_trace(words[2]);
+    }
     if (rule.needs_array) {
         const exists_obj = array_mod.array_exists(resolved_name);
         if (obj_mod.obj_get_int(exists_obj) == 0) {

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -267,6 +267,45 @@ fn maybe_invalidate_searches_on_trace_install(name: i32) void {
     }
 }
 
+/// Fire any ``array``-op variable trace on *name*.  Reference Tcl
+/// invokes ``array`` traces when the variable is accessed through the
+/// ``array`` command (``array get`` / ``names`` / ``set`` / ``size`` /
+/// ``exists`` / ``unset`` / ``statistics``) — not on ordinary element
+/// reads / writes (trace-5.1 / 5.2).  The trace fires *before* the
+/// subcommand runs so the callback can lazily populate the array.
+///
+/// Routing mirrors :func:`install_var_trace` so the fire finds the
+/// record wherever ``trace add`` stored it: a bare proc-local name
+/// lives in the per-frame chain (keyed by the raw name); everything
+/// else lives in the canonical-name directory.
+pub fn fire_array_op_trace(name: i32) void {
+    if (is_local_trace_target(name)) {
+        if (frames.frame_depth > 0) {
+            const head = frames.frame_trace_heads[frames.frame_depth - 1];
+            if (head != 0) {
+                const sn = obj_ensure_string(name);
+                var_trace.fire_in_list(head, sn.ptr, sn.len, var_trace.OP_ARRAY, 'a');
+            }
+        }
+        return;
+    }
+    const canon = canonical_var_name(name);
+    const sn = obj_ensure_string(canon);
+    if (sn.ptr != 0 and sn.len != 0 and var_trace.has_trace(sn.ptr, sn.len, var_trace.OP_ARRAY)) {
+        var_trace.fire(sn.ptr, sn.len, 0, 0, var_trace.OP_ARRAY, 'a');
+    }
+    if (canon != name and canon != 0) tcl_obj_release(canon);
+}
+
+/// Exported wrapper so the WASM codegen can fire ``array``-op traces
+/// from the compiled ``array`` fast-path (which inlines the op instead
+/// of dispatching through the interpreter's ``eval_array``).  Takes the
+/// *raw* (user-typed) array name so the registry routing in
+/// :func:`fire_array_op_trace` matches what ``trace add`` recorded.
+pub export fn array_fire_op_trace(name: i32) void {
+    fire_array_op_trace(name);
+}
+
 /// Mirror of :func:`install_var_trace` for the remove path.
 fn uninstall_var_trace(name: i32, ops: u32, cmd_prefix: i32) bool {
     if (is_local_trace_target(name)) {

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -1721,6 +1721,24 @@ fn resolve_ext_exists(desc: u32, local_name: i32) i32 {
 /// Read variable *name* from the frame at *abs_depth* (1-indexed).
 /// Follows aliases within that frame.  *fallback_name* is the local name
 /// used to look up same-name ALIAS_GLOBAL entries.
+/// Fire a target frame's proc-local variable trace that was reached
+/// through an ``upvar`` alias.  The trace record lives in the target
+/// frame (``abs_depth``) under ``target_name``, but reference Tcl
+/// reports the *alias* name used at the access site (``report_name``)
+/// to the callback — see tcltest upvar-5.1 / 5.2 / 5.3.  The callback
+/// is dispatched from the *current* (accessing) frame, so a ``uplevel
+/// info vars`` inside it observes the accessing proc's locals.  No-op
+/// when the target frame has no traces installed (the hot path).
+fn fire_frame_alias_trace(abs_depth: u32, target_name: i32, report_name: i32, op: u32, op_char: u8) void {
+    if (abs_depth == 0 or abs_depth > frame_depth) return;
+    const head = frame_trace_heads[abs_depth - 1];
+    if (head == 0) return;
+    const tcl_var_trace = @import("tcl_var_trace.zig");
+    const tn = obj_ensure_string(target_name);
+    const rn = obj_ensure_string(report_name);
+    tcl_var_trace.fire_in_list_as(head, tn.ptr, tn.len, rn.ptr, rn.len, op, op_char);
+}
+
 fn frame_get_at_depth(abs_depth: u32, name: i32, fallback_name: i32) i32 {
     if (abs_depth == 0) return globals.global_get(name);
     if (frame_at_depth(abs_depth)) |base| {
@@ -1730,6 +1748,14 @@ fn frame_get_at_depth(abs_depth: u32, name: i32, fallback_name: i32) i32 {
             const v = read_i32(bucket + OFF_VALUE);
             if (v == ALIAS_GLOBAL) return globals.global_get(name);
             if (is_alias_ext(v)) return resolve_ext_get(alias_desc_ptr(v), fallback_name);
+            // A read through an ``upvar`` alias must fire the target
+            // variable's READ trace, reporting the alias name.  The
+            // callback may mutate the slot, so re-read afterwards.
+            const tcl_var_trace = @import("tcl_var_trace.zig");
+            if (frame_trace_heads[abs_depth - 1] != 0) {
+                fire_frame_alias_trace(abs_depth, name, fallback_name, tcl_var_trace.OP_READ, 'r');
+                return read_i32(bucket + OFF_VALUE);
+            }
             return v;
         }
     }
@@ -1756,6 +1782,24 @@ fn frame_set_at_depth(abs_depth: u32, name: i32, fallback_name: i32, value: i32)
                 return;
             }
             write_i32(bucket + OFF_VALUE, value);
+            // A write / unset through an ``upvar`` alias must fire the
+            // target variable's WRITE / UNSET trace, reporting the
+            // alias name and dispatching from the accessing frame.
+            // ``value == 0`` is the in-runtime unset signal (matches
+            // ``var_set(name, 0)`` from ``unset NAME``).
+            const tcl_var_trace = @import("tcl_var_trace.zig");
+            if (value == 0) {
+                fire_frame_alias_trace(abs_depth, name, fallback_name, tcl_var_trace.OP_UNSET, 'u');
+                // Reference Tcl removes the target variable and all its
+                // traces at unset time, so the owning frame's teardown
+                // drain must not re-fire a stale unset callback.  Drop
+                // the target name's trace records now (upvar-5.3).
+                if (abs_depth >= 1 and abs_depth <= frame_depth and frame_trace_heads[abs_depth - 1] != 0) {
+                    tcl_var_trace.remove_all_in_list(&frame_trace_heads[abs_depth - 1], sn.ptr, sn.len);
+                }
+            } else {
+                fire_frame_alias_trace(abs_depth, name, fallback_name, tcl_var_trace.OP_WRITE, 'w');
+            }
             return;
         }
         frame_insert(base, sn.ptr, sn.len, hash, value);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1831,7 +1831,14 @@ pub fn eval_upvar(words: []const i32) i32 {
     while (i + 1 < words.len) : (i += 2) {
         const other_var = words[i]; // name in the target frame
         const local_var = words[i + 1]; // alias name in the current frame
-        if (is_global or abs_target <= 0) {
+        if (frames.frame_depth == 0) {
+            // Top-level (global) ``upvar`` — no proc frame exists to
+            // hold an ALIAS_EXT descriptor, so alias within the global
+            // scope via a ``VAR_LINK`` in the root namespace's var
+            // table (upvar-7.1).  Covers both ``upvar #0`` and ``upvar
+            // 0`` at the script top level (both target globals).
+            tcl_ns.global_alias_link(local_var, other_var);
+        } else if (is_global or abs_target <= 0) {
             // #0 or level underflow → global alias
             frames.frame_alias_named(local_var, other_var);
         } else {

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -3742,7 +3742,14 @@ fn eval_proc_call(words: []const i32) i32 {
         // path ignored the loader's error and overwrote it with
         // ``invalid command name`` in ``error_unknown_command``
         // below, hiding the real failure.
-        const loaded_name = try_auto_index_load(words[0]);
+        var loaded_name = try_auto_index_load(words[0]);
+        if (loaded_name == 0 and result_mod.snapshot(0).code != .ERROR) {
+            // Not in ``::auto_index`` yet — populate it from the
+            // standard library's ``tclIndex`` (via ``$TCL_LIBRARY``)
+            // once, then retry.  No-op when ``TCL_LIBRARY`` is unset.
+            ensure_stdlib_index_loaded();
+            loaded_name = try_auto_index_load(words[0]);
+        }
         if (result_mod.snapshot(0).code == .ERROR) {
             // Loader script raised; ``error_msg`` already holds the
             // user-facing message.  Drop any retained ``loaded_name``
@@ -3832,6 +3839,78 @@ fn eval_proc_call(words: []const i32) i32 {
 /// namespace for the namespaced probe — for ``interp alias``
 /// dispatches that's the global root (TCL_EVAL_INVOKE), so only the
 /// bare entry can match (parse-8.12).
+var stdlib_index_loaded: bool = false;
+
+extern fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
+/// Lazily populate ``::auto_index`` from the standard library's
+/// ``tclIndex``, located via the ``TCL_LIBRARY`` environment variable.
+/// Runs once, the first time a command misses both the proc registry
+/// and ``::auto_index`` — mirroring Tcl's ``unknown`` → ``auto_load``
+/// path without shipping ``init.tcl``.
+///
+/// We do NOT port the standard library: the runtime is pointed at the
+/// real on-disk library (preopened under WASI) and sources its index
+/// plus the per-command files it references on demand.  The bootstrap
+/// sets ``dir`` (the variable the index entries interpolate) and
+/// injects a thin ``::tcl::Pkg::source`` shim — the loader the real
+/// Tcl 9 ``tclIndex`` entries name — over the builtin ``source``.
+///
+/// No-op when ``TCL_LIBRARY`` is unset (every non-stdlib script), so it
+/// cannot perturb existing behaviour.  Any error from sourcing the
+/// index is swallowed (a missing / broken library must not become the
+/// caller's unknown-command diagnostic) — the surrounding flow state is
+/// saved and restored across the load.
+fn ensure_stdlib_index_loaded() void {
+    if (stdlib_index_loaded) return;
+    stdlib_index_loaded = true;
+    const lib_c = getenv("TCL_LIBRARY") orelse return;
+    var lib_len: u32 = 0;
+    while (lib_c[lib_len] != 0) : (lib_len += 1) {}
+    if (lib_len == 0) return;
+    const lib_p: [*]const u8 = @ptrCast(lib_c);
+    const part1: []const u8 = "set dir {";
+    // The shim must source at the GLOBAL scope.  A bare ``source`` in
+    // its own body would resolve to this proc (namespace ``::tcl::Pkg``)
+    // and recurse; even ``::source`` run in the proc's own frame would
+    // define the loaded procs in ``::tcl::Pkg`` rather than ``::``.
+    // ``uplevel #0`` runs the real ``::source`` at the global frame so
+    // autoloaded procs land where callers expect them.
+    const part2: []const u8 = "}\nproc ::tcl::Pkg::source {file args} {uplevel #0 [list ::source $file]}\nsource {";
+    const part3: []const u8 = "/tclIndex}\n";
+    const total: u32 = @as(u32, @intCast(part1.len)) + lib_len +
+        @as(u32, @intCast(part2.len)) + lib_len + @as(u32, @intCast(part3.len));
+    const buf = obj_mod.alloc(total);
+    if (buf == 0) return;
+    defer obj_mod.free_sized(buf, total);
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (part1) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    for (0..lib_len) |i| {
+        dst[off] = lib_p[i];
+        off += 1;
+    }
+    for (part2) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    for (0..lib_len) |i| {
+        dst[off] = lib_p[i];
+        off += 1;
+    }
+    for (part3) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const saved = result_mod.signal_save_and_clear();
+    const r = eval_script(buf, total);
+    if (r != 0) obj_mod.tcl_obj_release(r);
+    result_mod.signal_restore(saved);
+}
+
 fn try_auto_index_load(cmd_obj: i32) i32 {
     if (cmd_obj == 0) return 0;
     const cmd_s = obj_ensure_string(cmd_obj);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1841,6 +1841,41 @@ pub fn eval_upvar(words: []const i32) i32 {
     return 0;
 }
 
+/// Raise ``bad level "<token>"`` from the interpreter ``uplevel`` /
+/// ``upvar`` level parser, matching reference Tcl's
+/// ``TCL LOOKUP LEVEL`` error wording (tclProc.c:TclObjGetFrame).
+fn raise_bad_level(level_obj: i32) void {
+    const catch_mod = @import("tcl_catch.zig");
+    const s = obj_ensure_string(level_obj);
+    const prefix: []const u8 = "bad level \"";
+    const suffix: []const u8 = "\"";
+    const total: u32 = @as(u32, @intCast(prefix.len)) + s.len + @as(u32, @intCast(suffix.len));
+    const buf = obj_mod.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (s.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(s.ptr);
+        for (0..s.len) |i| {
+            dst[off] = sp[i];
+            off += 1;
+        }
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const msg = obj_mod.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
 /// ``uplevel ?level? body ?body ...?``
 ///
 /// Evaluates the body in the caller's frame by temporarily adjusting
@@ -1872,6 +1907,31 @@ pub fn eval_uplevel(words: []const i32) i32 {
         } else if (w1p[0] >= '0' and w1p[0] <= '9') {
             body_start = 2;
             shift = @intCast(parse_uint_bytes(w1p, w1.len));
+        } else if (w1p[0] == '-') {
+            // Signed integer level — mirrors reference Tcl's
+            // ``Tcl_GetIntFromObj`` path (tclProc.c:TclObjGetFrame).
+            // ``-0`` is a valid relative level 0 (the current frame);
+            // any other all-decimal-digit magnitude (``-1`` …) parses
+            // to a negative integer, which reference Tcl rejects with
+            // ``bad level``.  A non-numeric or hex ``-foo`` / ``-0xff``
+            // is not a level — leave it as the body word.
+            var all_digits = w1.len >= 2;
+            var di: u32 = 1;
+            while (di < w1.len) : (di += 1) {
+                if (w1p[di] < '0' or w1p[di] > '9') {
+                    all_digits = false;
+                    break;
+                }
+            }
+            if (all_digits) {
+                if (parse_uint_bytes(w1p + 1, w1.len - 1) == 0) {
+                    body_start = 2;
+                    shift = 0;
+                } else {
+                    raise_bad_level(words[1]);
+                    return 0;
+                }
+            }
         }
         // else: not a level spec; body_start stays 1, shift stays 1
     }

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1893,13 +1893,17 @@ pub fn eval_uplevel(words: []const i32) i32 {
 
     if (w1.len > 0) {
         if (w1p[0] == '#') {
-            // ``#N`` is an ABSOLUTE target level — shift by
-            // (frame_depth - N) so the target frame becomes the
-            // active one.  Clamp to ``frame_depth`` when ``N`` is
-            // deeper than the current stack (treats as #0).
+            // ``#N`` is an ABSOLUTE target level (global is ``#0`` at
+            // runtime frame_depth 0, the first proc is ``#1`` at depth
+            // 1, …), so shift by ``frame_depth - N`` to make that frame
+            // active.  ``#N`` where ``N == frame_depth`` is the current
+            // proc's *own* frame (shift 0) — e.g. ``uplevel #1`` from a
+            // level-1 proc (uplevel-3.4).  Only a genuinely over-deep
+            // ``N > frame_depth`` clamps to the global frame (reference
+            // Tcl raises "bad level" there; we degrade leniently).
             body_start = 2;
             const level = parse_uint_bytes(w1p + 1, w1.len - 1);
-            if (level >= frames.frame_depth) {
+            if (level > frames.frame_depth) {
                 shift = @intCast(frames.frame_depth);
             } else {
                 shift = @intCast(frames.frame_depth - level);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1942,6 +1942,17 @@ pub fn eval_uplevel(words: []const i32) i32 {
                     raise_bad_level(words[1]);
                     return 0;
                 }
+            } else if (w1.len >= 4 and w1p[1] == '0' and
+                (w1p[2] == 'x' or w1p[2] == 'X' or w1p[2] == 'o' or
+                    w1p[2] == 'O' or w1p[2] == 'b' or w1p[2] == 'B'))
+            {
+                // ``-0x..`` / ``-0o..`` / ``-0b..`` — a based integer
+                // literal with a leading sign.  Reference Tcl's
+                // ``Tcl_GetInt`` parses it and rejects (negative /
+                // out-of-range) with ``bad level``, rather than treating
+                // it as a body word (uplevel-4.17).
+                raise_bad_level(words[1]);
+                return 0;
             }
         }
         // else: not a level spec; body_start stays 1, shift stays 1

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -909,6 +909,34 @@ pub fn var_set_scalar(v_addr: u32, obj_handle: u32) void {
     if (old != 0 and old != stored) obj.tcl_obj_release(@bitCast(old));
 }
 
+/// Create a global-scope ``upvar`` alias: make ``local`` a ``VAR_LINK``
+/// to the global variable ``target`` in the root namespace.  Used when
+/// ``upvar #0`` / ``upvar 0`` runs at the script top level (no proc
+/// frame), where there is no frame hash to hold an ALIAS_EXT descriptor
+/// — the link lives in the global ``Var`` table instead, and
+/// ``var_get_scalar`` / ``var_set_scalar`` chase it via
+/// ``var_resolve_link`` (tcltest upvar-7.1).  Re-aliasing an existing
+/// link simply re-points it.
+pub fn global_alias_link(local: i32, target: i32) void {
+    const ln = obj.obj_ensure_string(local);
+    const tn = obj.obj_ensure_string(target);
+    if (ln.len == 0 or ln.ptr == 0 or tn.len == 0 or tn.ptr == 0) return;
+    const lk = strip_global_prefix(ln.ptr, ln.len);
+    const tk = strip_global_prefix(tn.ptr, tn.len);
+    const target_var = ns_var_create(ns_root(), tk.ptr, tk.len);
+    if (target_var == 0) return;
+    const local_var = ns_var_create(ns_root(), lk.ptr, lk.len);
+    if (local_var == 0 or local_var == target_var) return;
+    const v: *Var = @ptrFromInt(local_var);
+    // If the slot currently holds a real scalar value (not already a
+    // link), release it before repurposing the slot as a redirect.
+    if ((v.flags & VAR_LINK) == 0 and (v.flags & VAR_ARRAY) == 0 and v.value != 0) {
+        obj.tcl_obj_release(@bitCast(v.value));
+    }
+    v.flags = (v.flags & ~VAR_ARRAY) | VAR_LINK;
+    v.value = target_var;
+}
+
 /// Promote a possibly-borrowing TclObj to an owning copy.  Mirrors
 /// :func:`tcl_procs.ensure_owned` — when the input's
 /// ``OBJ_STR_CAP == 0`` the buffer bytes belong to *someone else*

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -909,6 +909,19 @@ pub fn var_set_scalar(v_addr: u32, obj_handle: u32) void {
     if (old != 0 and old != stored) obj.tcl_obj_release(@bitCast(old));
 }
 
+/// True when *name* (``ptr``/``len``) has array-element shape
+/// ``base(index)`` — a ``(`` after position 0 and a trailing ``)``.
+fn is_array_element_name(ptr: u32, len: u32) bool {
+    if (len < 3 or ptr == 0) return false;
+    const p: [*]const u8 = @ptrFromInt(ptr);
+    if (p[len - 1] != ')') return false;
+    var i: u32 = 1;
+    while (i < len) : (i += 1) {
+        if (p[i] == '(') return true;
+    }
+    return false;
+}
+
 /// Create a global-scope ``upvar`` alias: make ``local`` a ``VAR_LINK``
 /// to the global variable ``target`` in the root namespace.  Used when
 /// ``upvar #0`` / ``upvar 0`` runs at the script top level (no proc
@@ -923,6 +936,15 @@ pub fn global_alias_link(local: i32, target: i32) void {
     if (ln.len == 0 or ln.ptr == 0 or tn.len == 0 or tn.ptr == 0) return;
     const lk = strip_global_prefix(ln.ptr, ln.len);
     const tk = strip_global_prefix(tn.ptr, tn.len);
+    // ``upvar #0 arr(k) uv`` aliases an array *element*.  A scalar
+    // ``VAR_LINK`` to a Var literally named ``arr(k)`` would diverge from
+    // the array directory that ``$arr(k)`` reads/writes go through, so
+    // don't create a misleading link.  At the script top level there is
+    // no frame to hold the element-alias descriptor the in-proc path
+    // uses, so element targets are left unaliased here (the pre-feature
+    // behaviour) rather than silently linked to the wrong storage.
+    // Scalar targets — the common ``upvar #0 x uv`` (upvar-7.1) — work.
+    if (is_array_element_name(tk.ptr, tk.len)) return;
     const target_var = ns_var_create(ns_root(), tk.ptr, tk.len);
     if (target_var == 0) return;
     const local_var = ns_var_create(ns_root(), lk.ptr, lk.len);

--- a/runtime/zig/interp/tcl_var_trace.zig
+++ b/runtime/zig/interp/tcl_var_trace.zig
@@ -727,6 +727,28 @@ pub fn remove_from_list(head_addr: *u32, name: i32, ops: u32, cmd_prefix: i32) b
     return false;
 }
 
+/// Remove (and free) every trace record matching ``(name_ptr, name_len)``
+/// from the frame-local list rooted at ``head_addr``, regardless of ops
+/// or command.  Used when a variable is unset through an ``upvar``
+/// alias: reference Tcl removes the target variable *and* all its
+/// traces at unset time, so the owning frame's teardown drain must not
+/// fire a second, stale unset callback (tcltest upvar-5.3).
+pub fn remove_all_in_list(head_addr: *u32, name_ptr: u32, name_len: u32) void {
+    if (name_ptr == 0 or name_len == 0) return;
+    var prev_addr: *u32 = head_addr;
+    var cur: u32 = head_addr.*;
+    while (cur != 0) {
+        const next: u32 = @bitCast(read_i32(cur + F_OFF_NEXT));
+        if (name_bytes_match(cur, name_ptr, name_len)) {
+            prev_addr.* = next;
+            frame_trace_free(cur);
+        } else {
+            prev_addr = @ptrFromInt(cur + F_OFF_NEXT);
+        }
+        cur = next;
+    }
+}
+
 /// Return a Tcl list of ``{ops cmd}`` pairs for every trace on
 /// ``name`` in the list rooted at ``head``.  Empty list if no match.
 pub fn info_for_list(head: u32, name: i32) i32 {
@@ -779,20 +801,39 @@ pub fn fire_in_list(
     op: u32,
     op_char: u8,
 ) void {
-    if (head == 0 or name_ptr == 0 or name_len == 0) return;
+    fire_in_list_as(head, name_ptr, name_len, name_ptr, name_len, op, op_char);
+}
+
+/// Like :func:`fire_in_list`, but matches trace records against
+/// ``(match_ptr, match_len)`` while passing ``(report_ptr, report_len)``
+/// as ``name1`` to the callback.  Used when a variable is accessed
+/// through an ``upvar`` alias: the trace record lives in the target
+/// frame under the *target* name (e.g. ``c``), but reference Tcl
+/// reports the *alias* name used at the access site (e.g. ``x1``) to
+/// the callback — see tcltest upvar-5.1 / 5.2 / 5.3.
+pub fn fire_in_list_as(
+    head: u32,
+    match_ptr: u32,
+    match_len: u32,
+    report_ptr: u32,
+    report_len: u32,
+    op: u32,
+    op_char: u8,
+) void {
+    if (head == 0 or match_ptr == 0 or match_len == 0) return;
     var cur = head;
     while (cur != 0) : (cur = @bitCast(read_i32(cur + F_OFF_NEXT))) {
         const r_ops: u32 = @bitCast(read_i32(cur + F_OFF_OPS));
         if ((r_ops & op) == 0) continue;
-        if (!name_bytes_match(cur, name_ptr, name_len)) continue;
+        if (!name_bytes_match(cur, match_ptr, match_len)) continue;
         const active: u32 = @bitCast(read_i32(cur + F_OFF_ACTIVE));
         if (active != 0) continue;
         write_i32(cur + F_OFF_ACTIVE, 1);
         const cmd = read_i32(cur + F_OFF_CMD);
-        // Frame-local traces are scalars only — name1 = the local
+        // Frame-local traces are scalars only — name1 = the reported
         // name, name2 = empty (matching Tcl's ``$VAR_NAME`` pattern
         // for scalar-trace callbacks).
-        invoke_cb(cmd, name_ptr, name_len, 0, 0, op_char);
+        invoke_cb(cmd, report_ptr, report_len, 0, 0, op_char);
         write_i32(cur + F_OFF_ACTIVE, 0);
     }
 }

--- a/tests/baselines/tcl9-tcltest-wasm/categories/uplevel.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/uplevel.toml
@@ -1,6 +1,6 @@
 # uplevel.test — auto-generated WASM baseline.
-# bucket = 'W-mixed-fail'
-# reason = '1 of 57 failed'
+# bucket = 'W-clean'
+# reason = 'all 57 passed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 57
-observed_passed = 56
-observed_failed = 1
+observed_passed = 57
+observed_failed = 0
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["uplevel-3.4"]
+ids = []

--- a/tests/baselines/tcl9-tcltest-wasm/categories/uplevel.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/uplevel.toml
@@ -1,6 +1,6 @@
 # uplevel.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '2 of 57 failed'
+# reason = '1 of 57 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 57
-observed_passed = 55
-observed_failed = 2
+observed_passed = 56
+observed_failed = 1
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["uplevel-3.4", "uplevel-4.9"]
+ids = ["uplevel-3.4"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/upvar.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/upvar.toml
@@ -1,6 +1,6 @@
 # upvar.test — auto-generated WASM baseline.
-# bucket = 'W-mixed-fail'
-# reason = '1 of 70 failed'
+# bucket = 'W-clean'
+# reason = 'all observed passed (8 skipped)'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 70
-observed_passed = 61
-observed_failed = 1
+observed_passed = 62
+observed_failed = 0
 observed_skipped = 8
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["upvar-7.1"]
+ids = []

--- a/tests/baselines/tcl9-tcltest-wasm/categories/upvar.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/upvar.toml
@@ -1,6 +1,6 @@
 # upvar.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '4 of 70 failed'
+# reason = '1 of 70 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 70
-observed_passed = 58
-observed_failed = 4
+observed_passed = 61
+observed_failed = 1
 observed_skipped = 8
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["upvar-5.1", "upvar-5.2", "upvar-5.3", "upvar-7.1"]
+ids = ["upvar-7.1"]

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -552,11 +552,11 @@
       "total": 7
     },
     "uplevel": {
-      "bucket": "W-mixed-fail",
+      "bucket": "W-clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 1,
-      "passed_min": 56,
+      "failed_max": 0,
+      "passed_min": 57,
       "skipped": 0,
       "total": 57
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -561,11 +561,11 @@
       "total": 57
     },
     "upvar": {
-      "bucket": "W-mixed-fail",
+      "bucket": "W-clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 1,
-      "passed_min": 61,
+      "failed_max": 0,
+      "passed_min": 62,
       "skipped": 8,
       "total": 70
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -555,8 +555,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 2,
-      "passed_min": 55,
+      "failed_max": 1,
+      "passed_min": 56,
       "skipped": 0,
       "total": 57
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -564,8 +564,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 4,
-      "passed_min": 58,
+      "failed_max": 1,
+      "passed_min": 61,
       "skipped": 8,
       "total": 70
     },

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -92,10 +92,25 @@ class TestStdlibPrelude:
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "a(alpha) = 1\na(beta)  = 22\na(gamma) = 333\n"
 
-    def test_prelude_is_opt_in(self, tmp_path):
-        """Without ``library_dir`` the prelude is a no-op, so an
-        unbundled ``parray`` (no ``TCL_LIBRARY`` either) still errors —
-        proving the bundling, not some fallback, is what resolved it."""
+    def test_word_commands_bundle_in_substitutions(self, tmp_path):
+        """word.tcl commands are referenced inside ``[...]`` (they return
+        values) and depend on init-time globals the file itself sets;
+        bundling captures both, so they run self-contained and match the
+        reference output."""
+        wasm = self._link(
+            'puts [tcl_endOfWord "hello world" 0]\n'
+            'puts [tcl_startOfNextWord "hello world" 0]\n',
+            tmp_path,
+            with_library=True,
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "5\n6\n"
+
+    def test_no_library_means_no_bundle(self, tmp_path, monkeypatch):
+        """With no library (no param, no compile-time ``TCL_LIBRARY``)
+        the prelude is a no-op, so an unbundled ``parray`` still errors —
+        proving the bundling, not a fallback, is what resolved it."""
+        monkeypatch.delenv("TCL_LIBRARY", raising=False)
         wasm = self._link(
             "array set a {x 1}\nset rc [catch {parray a} m]\nputs \"rc=$rc\"\n",
             tmp_path,
@@ -104,9 +119,35 @@ class TestStdlibPrelude:
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "rc=1\n"
 
-    def test_only_referenced_files_are_bundled(self, tmp_path):
-        """A program that references no autoloadable command pulls in
+    def test_default_on_via_compile_time_tcl_library_env(self, tmp_path, monkeypatch):
+        """With no explicit ``library_dir`` but ``TCL_LIBRARY`` set in the
+        *compile-time* environment, bundling is on by default — and the
+        resulting binary still runs with no run-time library."""
+        monkeypatch.setenv("TCL_LIBRARY", str(_TCL_LIBRARY))
+        wasm = self._link(
+            "array set a {x 1 y 22}\nparray a\n", tmp_path, with_library=False
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "a(x) = 1\na(y) = 22\n"
+
+    def test_non_allowlisted_command_not_bundled_by_default(self, tmp_path, monkeypatch):
+        """A library command outside the validated allowlist is not
+        bundled by default (it would fall back to the runtime
+        auto-loader), so without a run-time library it still errors."""
+        monkeypatch.delenv("TCL_LIBRARY", raising=False)
+        # ``history`` is autoloadable but not on the validated allowlist.
+        wasm = self._link(
+            "set rc [catch {history info} m]\nputs \"rc=$rc\"\n",
+            tmp_path,
+            with_library=True,
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "rc=1\n"
+
+    def test_only_referenced_files_are_bundled(self, tmp_path, monkeypatch):
+        """A program that references no bundleable command pulls in
         nothing — bundle size matches the no-library build."""
+        monkeypatch.delenv("TCL_LIBRARY", raising=False)
         src = "puts hello\n"
         with_lib = self._link(src, tmp_path, with_library=True)
         without = self._link(src, tmp_path, with_library=False)

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -1,0 +1,65 @@
+"""WASM auto-loading of the Tcl standard library via ``TCL_LIBRARY``.
+
+The runtime does not *port* the standard library; instead it is pointed
+at the real on-disk library (preopened under WASI) through the
+``TCL_LIBRARY`` environment variable.  The first time a command misses
+both the proc registry and ``::auto_index``, the runtime sources
+``$TCL_LIBRARY/tclIndex`` (setting ``dir`` and injecting the thin
+``::tcl::Pkg::source`` loader the real index names) and then resolves
+the command through the existing ``::auto_index`` machinery — sourcing
+the per-command file (e.g. ``parray.tcl``) on demand.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TCL_LIBRARY = _REPO_ROOT / "tmp" / "tcl9.0.3" / "library"
+
+_needs_library = pytest.mark.skipif(
+    not (_TCL_LIBRARY / "tclIndex").is_file() or not (_TCL_LIBRARY / "parray.tcl").is_file(),
+    reason="Tcl 9 library tree not present (run scripts to fetch tmp/tcl9.0.3)",
+)
+
+
+@_needs_library
+class TestStdlibAutoLoad:
+    def _run(self, src: str) -> str:
+        wasm = _compile_tcl(src)
+        _, out = _run_wasm(
+            wasm,
+            capture_stdout=True,
+            extra_preopens=((str(_TCL_LIBRARY), "/tcl-lib"),),
+            env={"TCL_LIBRARY": "/tcl-lib"},
+        )
+        return out
+
+    def test_parray_autoloads_from_tcl_library(self):
+        """``parray`` is not built in, but auto-loads from the real
+        ``parray.tcl`` pointed to by ``TCL_LIBRARY`` and prints the
+        array contents."""
+        out = self._run("array set a {alpha 1 beta 22 gamma 333}\nparray a\n")
+        assert out == "a(alpha) = 1\na(beta)  = 22\na(gamma) = 333\n"
+
+    def test_parray_autoloads_via_dynamic_dispatch(self):
+        """The same resolution works when the command name is only known
+        at runtime (interpreter dispatch path)."""
+        out = self._run("array set a {x 9}\nset cmd parray\n$cmd a\n")
+        assert out == "a(x) = 9\n"
+
+    def test_unknown_command_without_library_still_errors(self):
+        """With no ``TCL_LIBRARY`` the auto-loader is a no-op, so a
+        genuinely unknown command still reports an error rather than
+        silently succeeding."""
+        wasm = _compile_tcl(
+            "set rc [catch {definitely_not_a_command 1 2} m]\nputs \"rc=$rc\"\n"
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "rc=1\n"

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -63,3 +63,51 @@ class TestStdlibAutoLoad:
         )
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "rc=1\n"
+
+
+@_needs_library
+class TestStdlibPrelude:
+    """Compile-time bundling of referenced stdlib procs (the preferred
+    path): the proc compiles to a WASM function and the binary is
+    self-contained — it runs with NO ``TCL_LIBRARY`` and no preopen.
+    """
+
+    def _link(self, tcl_src: str, tmp_path, *, with_library: bool):
+        from core.compiler.codegen.wasm_link import wasm_link
+
+        prog = tmp_path / "prog.tcl"
+        prog.write_text(tcl_src)
+        module = wasm_link(
+            prog, library_dir=str(_TCL_LIBRARY) if with_library else None
+        )
+        return module.to_bytes()
+
+    def test_parray_bundled_runs_without_tcl_library(self, tmp_path):
+        wasm = self._link(
+            "array set a {alpha 1 beta 22 gamma 333}\nparray a\n",
+            tmp_path,
+            with_library=True,
+        )
+        # No TCL_LIBRARY, no preopen — the proc is compiled into the bundle.
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "a(alpha) = 1\na(beta)  = 22\na(gamma) = 333\n"
+
+    def test_prelude_is_opt_in(self, tmp_path):
+        """Without ``library_dir`` the prelude is a no-op, so an
+        unbundled ``parray`` (no ``TCL_LIBRARY`` either) still errors —
+        proving the bundling, not some fallback, is what resolved it."""
+        wasm = self._link(
+            "array set a {x 1}\nset rc [catch {parray a} m]\nputs \"rc=$rc\"\n",
+            tmp_path,
+            with_library=False,
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "rc=1\n"
+
+    def test_only_referenced_files_are_bundled(self, tmp_path):
+        """A program that references no autoloadable command pulls in
+        nothing — bundle size matches the no-library build."""
+        src = "puts hello\n"
+        with_lib = self._link(src, tmp_path, with_library=True)
+        without = self._link(src, tmp_path, with_library=False)
+        assert with_lib == without

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -58,9 +58,7 @@ class TestStdlibAutoLoad:
         """With no ``TCL_LIBRARY`` the auto-loader is a no-op, so a
         genuinely unknown command still reports an error rather than
         silently succeeding."""
-        wasm = _compile_tcl(
-            "set rc [catch {definitely_not_a_command 1 2} m]\nputs \"rc=$rc\"\n"
-        )
+        wasm = _compile_tcl('set rc [catch {definitely_not_a_command 1 2} m]\nputs "rc=$rc"\n')
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "rc=1\n"
 
@@ -77,9 +75,7 @@ class TestStdlibPrelude:
 
         prog = tmp_path / "prog.tcl"
         prog.write_text(tcl_src)
-        module = wasm_link(
-            prog, library_dir=str(_TCL_LIBRARY) if with_library else None
-        )
+        module = wasm_link(prog, library_dir=str(_TCL_LIBRARY) if with_library else None)
         return module.to_bytes()
 
     def test_parray_bundled_runs_without_tcl_library(self, tmp_path):
@@ -98,8 +94,7 @@ class TestStdlibPrelude:
         bundling captures both, so they run self-contained and match the
         reference output."""
         wasm = self._link(
-            'puts [tcl_endOfWord "hello world" 0]\n'
-            'puts [tcl_startOfNextWord "hello world" 0]\n',
+            'puts [tcl_endOfWord "hello world" 0]\nputs [tcl_startOfNextWord "hello world" 0]\n',
             tmp_path,
             with_library=True,
         )
@@ -112,7 +107,7 @@ class TestStdlibPrelude:
         proving the bundling, not a fallback, is what resolved it."""
         monkeypatch.delenv("TCL_LIBRARY", raising=False)
         wasm = self._link(
-            "array set a {x 1}\nset rc [catch {parray a} m]\nputs \"rc=$rc\"\n",
+            'array set a {x 1}\nset rc [catch {parray a} m]\nputs "rc=$rc"\n',
             tmp_path,
             with_library=False,
         )
@@ -124,9 +119,7 @@ class TestStdlibPrelude:
         *compile-time* environment, bundling is on by default — and the
         resulting binary still runs with no run-time library."""
         monkeypatch.setenv("TCL_LIBRARY", str(_TCL_LIBRARY))
-        wasm = self._link(
-            "array set a {x 1 y 22}\nparray a\n", tmp_path, with_library=False
-        )
+        wasm = self._link("array set a {x 1 y 22}\nparray a\n", tmp_path, with_library=False)
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "a(x) = 1\na(y) = 22\n"
 
@@ -137,7 +130,7 @@ class TestStdlibPrelude:
         monkeypatch.delenv("TCL_LIBRARY", raising=False)
         # ``history`` is autoloadable but not on the validated allowlist.
         wasm = self._link(
-            "set rc [catch {history info} m]\nputs \"rc=$rc\"\n",
+            'set rc [catch {history info} m]\nputs "rc=$rc"\n',
             tmp_path,
             with_library=True,
         )
@@ -216,3 +209,31 @@ class TestStdlibPreludePruning:
         lib = self._make_lib(tmp_path)
         out = self._bundled("set c alpha\n$c\nputs [gamma]\n", lib)
         assert out == ["alpha", "beta", "delta", "gamma"]
+
+    def test_dynamic_command_in_substitution_disables_pruning(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        # `[$c]` — a command substitution whose command word is computed
+        # at run time — must trip the gate (was previously missed).
+        out = self._bundled("set c beta\nputs [gamma][$c]\n", lib)
+        assert out == ["alpha", "beta", "delta", "gamma"]
+
+    def test_nested_command_substitution_disables_pruning(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        out = self._bundled("puts [gamma][[set c beta]]\n", lib)
+        assert out == ["alpha", "beta", "delta", "gamma"]
+
+    def test_multi_segment_file_join_path(self, tmp_path):
+        """tclIndex entries with subdirectory file-join segments
+        (``[file join $dir sub foo.tcl]``) resolve correctly."""
+        from core.compiler.lowering import lower_to_ir
+        from core.compiler.stdlib_prelude import apply_stdlib_prelude
+
+        lib = tmp_path / "lib"
+        (lib / "sub").mkdir(parents=True)
+        (lib / "sub" / "foo.tcl").write_text("proc foo {} { return 42 }\n")
+        (lib / "tclIndex").write_text(
+            "set auto_index(foo) [list ::tcl::Pkg::source [file join $dir sub foo.tcl]]\n"
+        )
+        module = lower_to_ir("puts [foo]\n")
+        apply_stdlib_prelude(module, lib, allowlist=None)
+        assert "::foo" in module.procedures

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -152,3 +152,67 @@ class TestStdlibPrelude:
         with_lib = self._link(src, tmp_path, with_library=True)
         without = self._link(src, tmp_path, with_library=False)
         assert with_lib == without
+
+
+class TestStdlibPreludePruning:
+    """A bundled file may define several procs; only those statically
+    reachable from the program are kept — and only when it's provably
+    safe (no eval/source/dynamic dispatch that could invoke a proc by a
+    runtime-computed name).  Uses a synthetic library so it exercises the
+    pruning logic without depending on the real Tcl tree."""
+
+    def _make_lib(self, tmp_path):
+        lib = tmp_path / "lib"
+        lib.mkdir()
+        (lib / "multi.tcl").write_text(
+            "proc alpha {} { return [beta] }\n"
+            "proc beta {} { return 2 }\n"
+            "proc gamma {} { return 3 }\n"
+            "proc delta {} { return 4 }\n"
+        )
+        (lib / "tclIndex").write_text(
+            "# Tcl autoload index file, version 2.0\n"
+            + "".join(
+                f"set auto_index({c}) [list ::tcl::Pkg::source [file join $dir multi.tcl]]\n"
+                for c in ("alpha", "beta", "gamma", "delta")
+            )
+        )
+        return lib
+
+    def _bundled(self, src, lib):
+        from core.compiler.lowering import lower_to_ir
+        from core.compiler.stdlib_prelude import apply_stdlib_prelude
+
+        module = lower_to_ir(src)
+        before = set(module.procedures)
+        # allowlist=None: bundle every referenced command (the gate under
+        # test is the *pruning* safety check, not the seed allowlist).
+        apply_stdlib_prelude(module, lib, allowlist=None)
+        return sorted(q.lstrip(":") for q in (set(module.procedures) - before))
+
+    def test_unreachable_procs_pruned(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        # alpha calls beta; gamma/delta are unreachable.
+        assert self._bundled("puts [alpha]\n", lib) == ["alpha", "beta"]
+
+    def test_single_proc_reachability(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        assert self._bundled("puts [gamma]\n", lib) == ["gamma"]
+
+    def test_eval_disables_pruning(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        # `eval $x` could invoke any proc by name → keep everything.
+        out = self._bundled("set x foo\neval $x\nputs [alpha]\n", lib)
+        assert out == ["alpha", "beta", "delta", "gamma"]
+
+    def test_dispatcher_command_disables_pruning(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        # `after`'s script arg isn't a [...] substitution the scanner
+        # walks → unprovable → keep everything.
+        out = self._bundled("after 0 {puts hi}\nputs [alpha]\n", lib)
+        assert out == ["alpha", "beta", "delta", "gamma"]
+
+    def test_dynamic_command_name_disables_pruning(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        out = self._bundled("set c alpha\n$c\nputs [gamma]\n", lib)
+        assert out == ["alpha", "beta", "delta", "gamma"]

--- a/tests/test_wasm_execution.py
+++ b/tests/test_wasm_execution.py
@@ -2347,6 +2347,29 @@ class TestEvalUplevel:
         assert out == 'rc=1:bad level "-1"\n'
 
 
+class TestUpvarTopLevel:
+    """``upvar`` at the script top level (no proc frame) aliases within
+    the global scope, so writes through the alias reach the target
+    global — tcltest upvar-7.1.  The body is evaluated through the
+    interpreter (matching how tcltest runs test bodies)."""
+
+    def test_upvar_global_links_and_relinks(self):
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        wasm = _compile_tcl(
+            "set x 44\n"
+            "set y 55\n"
+            "catch {unset uv}\n"
+            # ``eval $body`` forces interpreter dispatch (a literal body
+            # would be compiled inline, where top-level upvar isn't wired).
+            "set body {upvar #0 x uv; set uv abc; upvar 0 y uv; set uv xyzzy}\n"
+            "eval $body\n"
+            "puts [list $x $y]\n"
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "abc xyzzy\n"
+
+
 # Global variable scoping
 
 

--- a/tests/test_wasm_execution.py
+++ b/tests/test_wasm_execution.py
@@ -2296,6 +2296,33 @@ class TestEvalUplevel:
         )
         assert result == 99
 
+    def test_uplevel_minus_zero_is_relative_level_zero(self):
+        """``uplevel -0`` is a valid relative level 0 (current frame),
+        matching reference Tcl's ``Tcl_GetIntFromObj`` level path
+        (tcltest uplevel-4.9).  The body runs in the calling frame."""
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        wasm = _compile_tcl("puts [apply {{} {uplevel -0 {expr {40 + 2}}}}]\n")
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "42\n"
+
+    def test_uplevel_minus_zero_empty_body(self):
+        """``uplevel -0 {}`` returns the empty string (tcltest uplevel-4.9)."""
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        wasm = _compile_tcl('puts "rc=[catch {apply {{} {uplevel -0 {}}}} m]:$m"\n')
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "rc=0:\n"
+
+    def test_uplevel_negative_level_is_bad_level_error(self):
+        """``uplevel -1`` (any negative magnitude) is a ``bad level``
+        error, not a body word — matches reference Tcl (uplevel-4.21)."""
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        wasm = _compile_tcl('puts "rc=[catch {apply {{} {uplevel -1 {}}}} m]:$m"\n')
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == 'rc=1:bad level "-1"\n'
+
 
 # Global variable scoping
 

--- a/tests/test_wasm_execution.py
+++ b/tests/test_wasm_execution.py
@@ -2314,6 +2314,29 @@ class TestEvalUplevel:
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "rc=0:\n"
 
+    def test_uplevel_hashN_targets_own_frame(self):
+        """``uplevel #N`` where N is the current proc's own level targets
+        that proc's own frame (shift 0), reading its locals — not the
+        global frame (tcltest uplevel-3.4).  Covers both the interpreted
+        proc body (via ``apply``) and a compiled proc."""
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        # Interpreted lambda body: apply runs at level 1, so `uplevel #1`
+        # is the lambda's own frame.
+        wasm = _compile_tcl(
+            'set y zzz\nputs [apply {{} {set y 55; uplevel #1 set y}}]\n'
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "55\n"
+
+        # Compiled proc: a1 is called from the global frame (level 1), so
+        # `uplevel #1` is a1's own frame.
+        wasm2 = _compile_tcl(
+            'set y zzz\nproc a1 {} {set y 55; uplevel #1 set y}\nputs [a1]\n'
+        )
+        _, out2 = _run_wasm(wasm2, capture_stdout=True)
+        assert out2 == "55\n"
+
     def test_uplevel_negative_level_is_bad_level_error(self):
         """``uplevel -1`` (any negative magnitude) is a ``bad level``
         error, not a body word — matches reference Tcl (uplevel-4.21)."""

--- a/tests/test_wasm_execution.py
+++ b/tests/test_wasm_execution.py
@@ -2323,17 +2323,13 @@ class TestEvalUplevel:
 
         # Interpreted lambda body: apply runs at level 1, so `uplevel #1`
         # is the lambda's own frame.
-        wasm = _compile_tcl(
-            'set y zzz\nputs [apply {{} {set y 55; uplevel #1 set y}}]\n'
-        )
+        wasm = _compile_tcl("set y zzz\nputs [apply {{} {set y 55; uplevel #1 set y}}]\n")
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "55\n"
 
         # Compiled proc: a1 is called from the global frame (level 1), so
         # `uplevel #1` is a1's own frame.
-        wasm2 = _compile_tcl(
-            'set y zzz\nproc a1 {} {set y 55; uplevel #1 set y}\nputs [a1]\n'
-        )
+        wasm2 = _compile_tcl("set y zzz\nproc a1 {} {set y 55; uplevel #1 set y}\nputs [a1]\n")
         _, out2 = _run_wasm(wasm2, capture_stdout=True)
         assert out2 == "55\n"
 
@@ -2345,6 +2341,16 @@ class TestEvalUplevel:
         wasm = _compile_tcl('puts "rc=[catch {apply {{} {uplevel -1 {}}}} m]:$m"\n')
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == 'rc=1:bad level "-1"\n'
+
+    def test_uplevel_signed_based_level_is_bad_level(self):
+        """A signed based-integer level (``-0xff``) parses as an int and
+        is rejected as ``bad level`` — not treated as a body word
+        (uplevel-4.17)."""
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        wasm = _compile_tcl('puts "rc=[catch {apply {{} {uplevel -0xff {}}}} m]:$m"\n')
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == 'rc=1:bad level "-0xff"\n'
 
 
 class TestUpvarTopLevel:
@@ -2368,6 +2374,24 @@ class TestUpvarTopLevel:
         )
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "abc xyzzy\n"
+
+    def test_top_level_upvar_array_element_does_not_link_wrong_storage(self):
+        """Top-level ``upvar #0 arr(k) uv`` must NOT silently link ``uv``
+        to a scalar named ``arr(k)`` (which would diverge from the array
+        storage ``$arr(k)`` uses).  There's no frame to hold an
+        element-alias descriptor here, so the element target is left
+        unaliased rather than wrongly linked — ``arr(k)`` keeps its value."""
+        from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm
+
+        wasm = _compile_tcl(
+            "set arr(k) orig\n"
+            "set body {upvar #0 arr(k) uv; set uv changed}\n"
+            "eval $body\n"
+            "puts $arr(k)\n"
+        )
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        # The array element is untouched (uv did not alias it).
+        assert out == "orig\n"
 
 
 # Global variable scoping

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -183,6 +183,7 @@ def _run_wasm(
     memory_size: int | None = None,
     capabilities: int = 0,
     host_spawn=None,
+    env: dict[str, str] | None = None,
 ) -> tuple:
     """Link and run a compiled Tcl WASM module.
 
@@ -232,6 +233,12 @@ def _run_wasm(
         deadline_value = _epoch_count + 1
         store.set_epoch_deadline(deadline_value)
     wasi_config = wasmtime.WasiConfig()
+
+    if env:
+        # Expose host-supplied environment variables to the guest via
+        # WASI ``environ_get`` (so the runtime's ``getenv`` sees them —
+        # e.g. ``TCL_LIBRARY`` driving the stdlib auto-loader).
+        wasi_config.env = list(env.items())
 
     stdout_path = None
     if capture_stdout:

--- a/tests/test_wasm_var_trace.py
+++ b/tests/test_wasm_var_trace.py
@@ -76,23 +76,39 @@ unset x
         )
         assert result == b"unset"
 
-    @pytest.mark.skip(
-        reason="``trace add variable ARR array CMD`` whole-array fire "
-        "semantics aren't fully wired in the runtime — covered by "
-        "the upstream ``trace.test`` slice (1.7 / 1.8 / 1.9), not by "
-        "this op-word contract."
-    )
-    def test_array_trace_op_is_array(self):
+    def test_array_trace_op_fires_on_array_command(self):
+        """An ``array``-op trace fires when the variable is accessed via
+        the ``array`` command, reporting ``name1 = arr``, ``name2 = ""``,
+        ``op = array`` — matches reference Tcl (trace-5.1).  Verified
+        against tclsh 8.6 / 9.0."""
         result = _run_and_read_global(
             """\
-set ::seen ""
-proc cb {name1 name2 op} { set ::seen $op }
+set ::seen NONE
+proc cb {name1 name2 op} { set ::seen [list $name1 $name2 $op] }
+set arr(b) 2
 trace add variable arr array cb
-catch { set _ $arr(missing) }
+set _ [array get arr]
 """,
             "::seen",
         )
-        assert result == b"array"
+        assert result == b"arr {} array"
+
+    def test_array_trace_does_not_fire_on_element_access(self):
+        """An ``array``-op trace does NOT fire on ordinary element reads
+        or writes — only on ``array`` command accesses (trace-5.2).
+        Verified against tclsh 8.6 / 9.0."""
+        result = _run_and_read_global(
+            """\
+set ::seen NONE
+proc cb {name1 name2 op} { set ::seen [list $name1 $name2 $op] }
+set arr(b) 2
+trace add variable arr array cb
+set arr(a) 1
+set _ $arr(a)
+""",
+            "::seen",
+        )
+        assert result == b"NONE"
 
 
 class TestVarTraceProcLocalFires:

--- a/tests/test_wasm_var_trace.py
+++ b/tests/test_wasm_var_trace.py
@@ -144,6 +144,54 @@ p
         assert result == b"x unset"
 
 
+class TestVarTraceThroughUpvar:
+    """A variable trace installed in one frame fires when the variable
+    is accessed through an ``upvar`` alias in a callee frame, reporting
+    the *alias* name (the name used at the access site) and dispatching
+    the callback from the accessing frame — matching reference Tcl
+    (tcltest upvar-5.1 / 5.2 / 5.3).
+    """
+
+    def test_write_trace_fires_through_upvar(self):
+        result = _run_and_read_global(
+            """\
+proc tproc {args} {global x; set x [list $args [uplevel info vars]]}
+proc p1 {a b} {set c 22; set d 33; trace add var c {read write} tproc; p2}
+proc p2 {} {upvar c x1; set x1 22}
+set x ---
+p1 foo bar
+""",
+            "::x",
+        )
+        assert result == b"{x1 {} write} x1"
+
+    def test_read_trace_fires_through_upvar(self):
+        result = _run_and_read_global(
+            """\
+proc tproc {args} {global x; set x [list $args [uplevel info vars]]}
+proc p1 {a b} {set c 22; set d 33; trace add var c {read write} tproc; p2}
+proc p2 {} {upvar c x1; set x1}
+set x ---
+p1 foo bar
+""",
+            "::x",
+        )
+        assert result == b"{x1 {} read} x1"
+
+    def test_unset_trace_fires_through_upvar_no_teardown_refire(self):
+        result = _run_and_read_global(
+            """\
+proc tproc {args} {global x; set x [list $args [uplevel info vars]]}
+proc p1 {a b} {set c 22; set d 33; trace add var c {read write unset} tproc; p2}
+proc p2 {} {upvar c x1; unset x1}
+set x ---
+p1 foo bar
+""",
+            "::x",
+        )
+        assert result == b"{x1 {} unset} x1"
+
+
 class TestExtAliasResolutionRobustness:
     """An ``upvar`` / ``variable`` alias whose descriptor outlives the
     matching frame must not fault the wasm engine on subsequent


### PR DESCRIPTION
## Summary

This PR adds compile-time bundling of referenced standard-library procedures and fixes several edge cases in `uplevel` and `upvar` handling.

### Stdlib Prelude Bundling

Adds `core/compiler/stdlib_prelude.py` which implements reference-driven bundling of Tcl standard-library procedures. When a program references a stdlib command (e.g., `parray`, `tcl_endOfWord`), the compiler now:

1. Reads the library's `tclIndex` to map commands to their source files
2. Lowers the referenced `.tcl` files to IR at compile time
3. Merges procedures into the module so they compile to WASM functions
4. Bundles only files for commands actually referenced (transitively)
5. Prunes unreachable bundled procs when safe (no dynamic dispatch)

This produces self-contained binaries that don't require `TCL_LIBRARY` at runtime. An allowlist (`DEFAULT_STDLIB_ALLOWLIST`) gates which commands seed bundling by default; transitive dependencies are always included. Fallback to runtime auto-loading occurs for:
- Commands outside the allowlist
- Non-lowerable library files
- Modules with dynamic dispatch (eval/source/dynamic names)

### Uplevel/Upvar Fixes

**Uplevel:**
- `uplevel #N` where N equals the current frame depth now correctly targets that frame's own locals (not the global frame)
- `uplevel -0` is now recognized as a valid relative level 0 (current frame)
- Negative levels like `uplevel -1` now properly raise `bad level` errors instead of treating them as body words
- Signed integer parsing mirrors reference Tcl's `Tcl_GetIntFromObj` behavior

**Upvar:**
- Top-level `upvar #0` / `upvar 0` (no proc frame) now creates global-scope `VAR_LINK` aliases in the root namespace instead of failing
- Variable traces now fire correctly when accessed through `upvar` aliases, reporting the alias name to the callback
- Trace cleanup through upvar aliases no longer causes stale unset callbacks

### Array Traces

Implements `array`-op variable traces: traces now fire when variables are accessed via the `array` command (get/set/names/size/exists/unset) but not on ordinary element reads/writes, matching reference Tcl behavior.

### Runtime Changes

- `ensure_stdlib_index_loaded()` populates `::auto_index` from `$TCL_LIBRARY/tclIndex` on first unknown command, enabling fallback auto-loading
- Frame-local variable trace firing through upvar aliases
- Global alias link support in namespace variable table

## Validation

- Added `tests/test_wasm_autoload.py` covering stdlib auto-loading and prelude bundling with synthetic and real library trees
- Added `tests/test_wasm_var_trace.py` tests for array traces and upvar trace firing
- Extended `tests/test_wasm_execution.py` with uplevel edge case tests (minus-zero, own-frame targeting, negative level errors)
- Updated baseline expectations: `uplevel` and `upvar` test suites now pass completely (57/57 and 62/70 respectively, with 8 skipped)
- All existing tests continue to pass

## Compiler/KCS Checklist

- [x] This change alters compiler behavior (adds stdlib bundling pass)
- [x] Updated KCS notes (new `docs/kcs/compiler/stdlib_prelude.md`)
- [x] Linked from `docs/kcs/compiler/README.md` and `docs/kcs/README.md`

https://claude.ai/code/session_01UyaMiKB9DZDLswmLY45QDe