### PR TITLE
Fix highlight ranges dropping closing delimiters

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=193d861
-head=193d861cf4e3f7426259aa3ae821f9c52e05eb4e
-date=2026-05-21T14:39:49Z
-fingerprint=17ed9bafc46e06d2a26458f98c14caed5fe30a19fb6be47a8ca4a9219fa6d2bc
+describe=27296dd-dirty
+head=27296dd04c04170cfc83c105e29f9054ec0e6e9f
+date=2026-05-21T14:58:31Z
+fingerprint=cb6dc033d3f5f99655b01044f1ecd7877c870f9874eb2da212218660a5043b72

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=0429088-dirty
-head=042908864667fa78a72062f22a35ef5fe676de44
-date=2026-05-21T13:07:26Z
-fingerprint=7c1f76d909a1e6a01b72277a1e30210ce69258edcaf23a8dc8842844527fe276
+describe=193d861
+head=193d861cf4e3f7426259aa3ae821f9c52e05eb4e
+date=2026-05-21T14:39:49Z
+fingerprint=17ed9bafc46e06d2a26458f98c14caed5fe30a19fb6be47a8ca4a9219fa6d2bc

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=7752024-dirty
-head=77520246473ec04c86795db333645f94b5ea4a7e
-date=2026-05-21T14:26:18Z
-fingerprint=3127e08f82bfe7d630d3bd0bfb1b960dc0b1e338d19955a74134d93a9c06efa1
+describe=072e5af-dirty
+head=072e5af09e2205fbe173443cf088efb9ced3130d
+date=2026-05-21T15:06:57Z
+fingerprint=9084fcc4d4e961112847993a1e554c7e7f29e6d645f2fc26b6db8b73d1ddb803

--- a/core/common/ranges.py
+++ b/core/common/ranges.py
@@ -3,13 +3,40 @@
 from __future__ import annotations
 
 from bisect import bisect_right
+from contextvars import ContextVar
 
 from ..analysis.semantic_model import Range
-from ..parsing.tokens import SourcePosition, Token
+from ..parsing.tokens import SourcePosition, Token, TokenType
 
 
 def range_from_token(tok: Token) -> Range:
     """Build a Range covering exactly one token."""
+    return Range(start=tok.start, end=tok.end)
+
+
+def range_from_word_token(tok: Token) -> Range:
+    """Range covering a full word token, *including* its closing delimiter.
+
+    A braced/bracketed word token starts on the opening ``{`` / ``[`` but its
+    ``end`` sits on the last *inner* character — the matching closer is exactly
+    one position past ``end`` and ``tok.text`` omits it.  For ``STR``
+    (``{...}``) and ``CMD`` (``[...]``) tokens, extend the range by that single
+    closer character so a whole-word span covers the closer rather than
+    stopping one short.
+
+    The closer width comes from the token's *type*, so the span is derived
+    straight from the token tree with no source slicing — which is what lets it
+    work for tokens whose offsets are absolute but whose surrounding source
+    string is only a substring (nested ``proc`` / loop bodies).  ``offset`` is
+    always correct; ``character`` assumes a same-line closer, matching
+    :func:`widen_range_for_closer`.
+    """
+    if tok.type in (TokenType.STR, TokenType.CMD):
+        end = tok.end
+        return Range(
+            start=tok.start,
+            end=SourcePosition(line=end.line, character=end.character + 1, offset=end.offset + 1),
+        )
     return Range(start=tok.start, end=tok.end)
 
 
@@ -42,6 +69,35 @@ def widen_range_for_closer(source: str, range_: Range) -> Range:
             end=SourcePosition(line=end.line, character=end.character + 1, offset=end.offset + 1),
         )
     return range_
+
+
+# Source of the document currently being serialised for the compiler
+# explorer.  When set, :func:`widen_for_highlight` extends a braced/quoted
+# word's range to cover its closing delimiter — word-token ranges follow the
+# "inner-end" convention (the closer is excluded; consumers widen when they
+# need it), so the explorer widens at serialisation time, the same way the
+# diagnostics pipeline does.
+_HIGHLIGHT_SOURCE: ContextVar[str | None] = ContextVar("_HIGHLIGHT_SOURCE", default=None)
+
+
+def set_highlight_source(source: str | None):
+    """Set the source used to widen highlight ranges; returns a reset token."""
+    return _HIGHLIGHT_SOURCE.set(source)
+
+
+def reset_highlight_source(token) -> None:
+    _HIGHLIGHT_SOURCE.reset(token)
+
+
+def widen_for_highlight(range_: Range) -> Range:
+    """Widen *range_* to its closing delimiter against the active source.
+
+    No-op when no highlight source is set (see :func:`set_highlight_source`).
+    """
+    source = _HIGHLIGHT_SOURCE.get()
+    if source is None:
+        return range_
+    return widen_range_for_closer(source, range_)
 
 
 def position_from_relative(

--- a/core/common/ranges.py
+++ b/core/common/ranges.py
@@ -14,6 +14,20 @@ def range_from_token(tok: Token) -> Range:
     return Range(start=tok.start, end=tok.end)
 
 
+def _closer_position(end: SourcePosition, last_inner_char: str) -> SourcePosition:
+    """Position of the closing delimiter one character past *end*.
+
+    *last_inner_char* is the character at ``end.offset`` (the last character
+    inside the word).  When it is a newline the closer sits at column 0 of the
+    next line, so the line/column must advance accordingly — keeping them
+    consistent with ``offset`` for line/column-based consumers such as
+    :func:`core.common.lsp.to_lsp_range`.
+    """
+    if last_inner_char in ("\n", "\r"):
+        return SourcePosition(line=end.line + 1, character=0, offset=end.offset + 1)
+    return SourcePosition(line=end.line, character=end.character + 1, offset=end.offset + 1)
+
+
 def range_from_word_token(tok: Token) -> Range:
     """Range covering a full word token, *including* its closing delimiter.
 
@@ -27,16 +41,13 @@ def range_from_word_token(tok: Token) -> Range:
     The closer width comes from the token's *type*, so the span is derived
     straight from the token tree with no source slicing — which is what lets it
     work for tokens whose offsets are absolute but whose surrounding source
-    string is only a substring (nested ``proc`` / loop bodies).  ``offset`` is
-    always correct; ``character`` assumes a same-line closer, matching
-    :func:`widen_range_for_closer`.
+    string is only a substring (nested ``proc`` / loop bodies).  When the
+    closer falls on the next line (a multi-line braced body whose last inner
+    character is a newline), the line/column advance with the offset.
     """
     if tok.type in (TokenType.STR, TokenType.CMD):
-        end = tok.end
-        return Range(
-            start=tok.start,
-            end=SourcePosition(line=end.line, character=end.character + 1, offset=end.offset + 1),
-        )
+        last_inner = tok.text[-1] if tok.text else ""
+        return Range(start=tok.start, end=_closer_position(tok.end, last_inner))
     return Range(start=tok.start, end=tok.end)
 
 
@@ -55,8 +66,9 @@ def widen_range_for_closer(source: str, range_: Range) -> Range:
     braced/quoted/bracketed word, so a range built from such a token stops one
     character short.  When *range_* opens with one of those delimiters and the
     matching closer immediately follows its (inclusive) end, return a range
-    extended to cover the closer; otherwise return *range_* unchanged.  Only
-    same-line closers are widened, so a multi-line ``{ ... \\n}`` is left alone.
+    extended to cover the closer; otherwise return *range_* unchanged.  When the
+    closer falls on the next line (a multi-line ``{ ... \\n}``), the line/column
+    of the extended end advance with the offset so the two stay consistent.
     """
     start_off = range_.start.offset
     if not (0 <= start_off < len(source)):
@@ -64,10 +76,8 @@ def widen_range_for_closer(source: str, range_: Range) -> Range:
     closer = _RANGE_CLOSERS.get(source[start_off])
     end = range_.end
     if closer and end.offset + 1 < len(source) and source[end.offset + 1] == closer:
-        return Range(
-            start=range_.start,
-            end=SourcePosition(line=end.line, character=end.character + 1, offset=end.offset + 1),
-        )
+        last_inner = source[end.offset] if 0 <= end.offset < len(source) else ""
+        return Range(start=range_.start, end=_closer_position(end, last_inner))
     return range_
 
 

--- a/core/compiler/codegen/wasm/_ir.py
+++ b/core/compiler/codegen/wasm/_ir.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import TYPE_CHECKING
 
+from ....common.ranges import widen_for_highlight
 from ._encoding import (
     _encode_string,
     _encode_vector,
@@ -734,16 +735,23 @@ def _decode_leb128_signed(data: bytes) -> int:
 
 
 def _range_to_explorer_dict(rng: Range | None) -> dict | None:
-    """Serialise a Range for the explorer frontend."""
+    """Serialise a Range for the explorer frontend.
+
+    Mirrors ``explorer.formatters.range_dict``: widen a braced/quoted word's
+    range to its closing delimiter against the active highlight source, then
+    convert the *inclusive* semantic-model end to the *exclusive* end the
+    front-end slices with (add one).
+    """
     if rng is None:
         return None
+    rng = widen_for_highlight(rng)
     return {
         "startLine": rng.start.line,
         "startCol": rng.start.character,
         "startOffset": rng.start.offset,
         "endLine": rng.end.line,
-        "endCol": rng.end.character,
-        "endOffset": rng.end.offset,
+        "endCol": rng.end.character + 1,
+        "endOffset": rng.end.offset + 1,
     }
 
 

--- a/core/parsing/command_segmenter.py
+++ b/core/parsing/command_segmenter.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 from ..analysis.semantic_model import Range
 from ..common.document_buffer import DocumentBuffer
-from ..common.ranges import range_from_tokens
+from ..common.ranges import range_from_tokens, range_from_word_token
 from .known_commands import known_command_names
 
 if TYPE_CHECKING:
@@ -73,6 +73,21 @@ def _word_piece(tok: Token) -> str:
     if tok.type is TokenType.CMD:
         return f"[{tok.text}]"
     return tok.text
+
+
+def _command_range(tokens: list[Token]) -> Range:
+    """Span *tokens*, extending the last word to cover its closing delimiter.
+
+    ``range_from_tokens`` stops on the last token's inner end, so a command
+    whose final word is braced (``if {...} {body}``) would drop the closing
+    ``}``.  Widen the end via :func:`range_from_word_token`, which derives the
+    closer from the token's type — no source needed, so it stays correct for
+    nested bodies whose token offsets are absolute but whose source string is a
+    substring.
+    """
+    span = range_from_tokens(tokens)
+    last = range_from_word_token(tokens[-1])
+    return Range(start=span.start, end=last.end)
 
 
 # Minimum number of lines a suspicious STR token must span to trigger
@@ -263,7 +278,7 @@ def _segment_raw(
             if argv:
                 commands.append(
                     SegmentedCommand(
-                        range=range_from_tokens(all_tokens),
+                        range=_command_range(all_tokens),
                         argv=argv,
                         texts=texts,
                         single_token_word=single,
@@ -322,7 +337,7 @@ def _segment_raw(
     if argv:
         commands.append(
             SegmentedCommand(
-                range=range_from_tokens(all_tokens),
+                range=_command_range(all_tokens),
                 argv=argv,
                 texts=texts,
                 single_token_word=single,

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -37,6 +37,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   — stale incremental cache produces wrong diagnostics.
 - [kcs-issue-range-drift.md](kcs-issue-range-drift.md) — diagnostic or
   hover ranges point at the wrong span.
+- [kcs-issue-highlight-drops-closing-delimiter.md](kcs-issue-highlight-drops-closing-delimiter.md)
+  — a highlight over a braced word covers `{$condition` instead of
+  `{$condition}`, dropping the closing delimiter.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-wasm-arithmetic-divergence.md](kcs-issue-wasm-arithmetic-divergence.md)

--- a/docs/kcs/kcs-issue-highlight-drops-closing-delimiter.md
+++ b/docs/kcs/kcs-issue-highlight-drops-closing-delimiter.md
@@ -1,0 +1,87 @@
+# KCS: Highlight stops one character short of the closing brace
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Symptom
+
+A highlight over a braced, quoted, or bracketed word covers everything
+*except* its closing delimiter — `{$condition}` is highlighted as
+`{$condition` (or, when a second off-by-one stacks on top, `{$conditi`).
+Seen when hovering a control-flow graph node or an intermediate-representation
+clause in the compiler explorer, and when expanding the selection
+(`textDocument/selectionRange`) over a braced word.
+
+## Operational context
+
+A braced word token starts on the opening `{` but its `end` sits on the last
+*inner* character; the matching closer is one position past `end`, and the
+token's `text` omits it. Semantic-model [`Range`](../../core/analysis/semantic_model.py)
+ends are **inclusive** by convention, and word-token ranges follow an
+"inner-end" rule: the closer is **excluded**, and a consumer that wants to
+cover the whole word widens the range itself. This keeps the optimiser, SCCP,
+structure-elimination, code-sinking, and minifier — which strip or re-widen
+the delimiters themselves — working against a stable contract. Widening the
+range at the lowering layer breaks those consumers.
+
+## Decision rules / contracts
+
+1. Do **not** widen word-token ranges in lowering or the segmenter's word
+   tokens — many passes rely on the inner-end convention.
+2. A consumer that renders a highlight widens the range itself, the same way
+   the diagnostics pipeline does, via
+   [`widen_range_for_closer`](../../core/common/ranges.py).
+3. A whole-command range built from a token span is widened with
+   `range_from_word_token` (closer derived from the token *type*, no source
+   needed — required because nested bodies have absolute offsets but a
+   substring source).
+4. The compiler explorer front-end slices `src.substring(startOffset,
+   endOffset)` with an **exclusive** end, so serialised ranges must convert
+   the inclusive semantic-model end to exclusive (`+1`), matching
+   [`to_lsp_range`](../../core/common/lsp.py).
+
+## File-path anchors
+
+- `core/common/ranges.py` — `widen_range_for_closer`, `range_from_word_token`, `widen_for_highlight`, `set_highlight_source`
+- `core/parsing/command_segmenter.py` — `_command_range`
+- `explorer/formatters.py` — `range_dict`
+- `explorer/serialise.py` — `serialise_result` sets the highlight source
+- `core/compiler/codegen/wasm/_ir.py` — `_range_to_explorer_dict`
+- `lsp/features/selection_range.py` — token-range widening
+
+## Failure modes
+
+- A serialiser emits the inclusive end raw, so an exclusive-slicing front-end
+  drops the last character.
+- A consumer renders a word-token range without widening, so the closing
+  `}` / `]` / `"` is missing.
+- Widening the range at lowering instead of the consumer corrupts optimiser
+  passes that strip or re-widen the delimiters (string-compare detection,
+  branch folding, and others).
+
+## Triage checklist
+
+1. Slice the source with the emitted range and confirm whether the covered
+   text is a complete, balanced token.
+2. Check whether the consumer widens for the closer; if not, that is the bug.
+3. For the explorer, confirm the serialised `endOffset` is the exclusive end
+   (inclusive `+1`).
+4. Add a regression case asserting the covered substring round-trips to the
+   full word.
+
+## Test anchors
+
+- `tests/test_highlight_ranges.py`
+- `tests/test_selection_range.py`
+- `tests/test_diagnostic_ranges.py`
+
+## Related
+
+- [KCS index](README.md)
+- [range drift across passes](kcs-issue-range-drift.md)
+- [shared utility contracts](../design/contracts/core-lsp-shared-utility.md)
+- [Glossary](../GLOSSARY.md)

--- a/explorer/formatters.py
+++ b/explorer/formatters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from core.analysis.semantic_model import Range
 from core.commands.registry.taint_hints import TaintColour
+from core.common.ranges import widen_for_highlight
 from core.common.source_map import offset_to_line_col
 from core.compiler.core_analyses import LatticeKind, LatticeValue
 from core.compiler.expr_ast import ExprNode, render_expr
@@ -184,12 +185,27 @@ def stmt_kind(stmt: IRStatement) -> str:
 
 
 def range_dict(r: Range) -> dict:
-    """Convert Range to a JSON-serialisable dict."""
+    """Convert Range to a JSON-serialisable dict.
+
+    Two adjustments make the serialised offsets match what the front-end
+    highlights:
+
+    * A braced/quoted/bracketed word's range stops on the last *inner*
+      character (the closer is excluded by convention).  When the document
+      source is known (set via ``core.common.ranges.set_highlight_source``),
+      widen the range to cover the closing ``}`` / ``"`` / ``]`` so
+      ``{$condition}`` is not highlighted as ``{$conditi``.
+    * The semantic-model :class:`Range` end is *inclusive*; the front-end
+      slices ``src.substring(startOffset, endOffset)`` with an *exclusive*
+      end (matching :func:`core.common.lsp.to_lsp_range`), so add one to the
+      end position.
+    """
+    r = widen_for_highlight(r)
     return {
         "startLine": r.start.line,
         "startCol": r.start.character,
         "startOffset": r.start.offset,
         "endLine": r.end.line,
-        "endCol": r.end.character,
-        "endOffset": r.end.offset,
+        "endCol": r.end.character + 1,
+        "endOffset": r.end.offset + 1,
     }

--- a/explorer/serialise.py
+++ b/explorer/serialise.py
@@ -659,29 +659,16 @@ def _serialise_asm(ir_module: IRModule, *, cfg_module=None) -> list[dict]:
         first = getattr(top_stmts[0], "range", None)
         last = getattr(top_stmts[-1], "range", None)
         if first is not None and last is not None:
-            top_range = {
-                "startLine": first.start.line,
-                "startCol": first.start.character,
-                "startOffset": first.start.offset,
-                "endLine": last.end.line,
-                "endCol": last.end.character,
-                "endOffset": last.end.offset,
-            }
+            from core.analysis.semantic_model import Range
+
+            top_range = range_dict(Range(start=first.start, end=last.end))
     for entry in result:
         if entry["kind"] == "top":
             entry["sourceRange"] = top_range
         else:
             ir_proc = ir_module.procedures.get(entry["name"])
             if ir_proc is not None:
-                rng = ir_proc.range
-                entry["sourceRange"] = {
-                    "startLine": rng.start.line,
-                    "startCol": rng.start.character,
-                    "startOffset": rng.start.offset,
-                    "endLine": rng.end.line,
-                    "endCol": rng.end.character,
-                    "endOffset": rng.end.offset,
-                }
+                entry["sourceRange"] = range_dict(ir_proc.range)
             else:
                 entry["sourceRange"] = None
     return result
@@ -770,9 +757,22 @@ def serialise_result(result: CompilerExplorerResult) -> dict:
     This is the single serialisation function used by both the Flask
     endpoint and the Pyodide worker.
     """
+    from core.common.ranges import reset_highlight_source, set_highlight_source
     from core.compiler.cfg import build_cfg
 
     from .pipeline import compute_stats
+
+    # Widen braced/quoted word ranges to their closing delimiter against the
+    # document source while serialising (see ``range_dict``).
+    src_token = set_highlight_source(result.source)
+    try:
+        return _serialise_result(result, build_cfg, compute_stats)
+    finally:
+        reset_highlight_source(src_token)
+
+
+def _serialise_result(result: CompilerExplorerResult, build_cfg, compute_stats) -> dict:
+    from core.common.ranges import reset_highlight_source, set_highlight_source
 
     # Build CFG once for the original IR and share across asm + wasm.
     cfg_module = build_cfg(result.ir_module)
@@ -789,14 +789,19 @@ def serialise_result(result: CompilerExplorerResult) -> dict:
             opt_ir = None
             opt_cfg = None
         if opt_ir is not None:
+            # Optimised asm/wasm ranges index into the optimised source.
+            opt_token = set_highlight_source(result.optimised_source)
             try:
-                asm_optimised = _serialise_asm(opt_ir, cfg_module=opt_cfg)
-            except Exception as exc:
-                print(f"warning: optimised asm serialisation failed: {exc}", file=sys.stderr)
-            try:
-                wasm_optimised = _serialise_wasm(opt_ir, optimise=True, cfg_module=opt_cfg)
-            except Exception as exc:
-                print(f"warning: optimised wasm serialisation failed: {exc}", file=sys.stderr)
+                try:
+                    asm_optimised = _serialise_asm(opt_ir, cfg_module=opt_cfg)
+                except Exception as exc:
+                    print(f"warning: optimised asm serialisation failed: {exc}", file=sys.stderr)
+                try:
+                    wasm_optimised = _serialise_wasm(opt_ir, optimise=True, cfg_module=opt_cfg)
+                except Exception as exc:
+                    print(f"warning: optimised wasm serialisation failed: {exc}", file=sys.stderr)
+            finally:
+                reset_highlight_source(opt_token)
 
     try:
         asm = _serialise_asm(result.ir_module, cfg_module=cfg_module)

--- a/lsp/features/selection_range.py
+++ b/lsp/features/selection_range.py
@@ -8,6 +8,7 @@ from core.analysis import analyse
 from core.analysis.semantic_model import AnalysisResult, Range, Scope
 from core.common.lsp import to_lsp_range
 from core.common.position import find_command_at_position, find_token_in_command
+from core.common.ranges import widen_range_for_closer
 
 from .symbol_resolution import find_scope_at_line, find_word_span_at_position
 
@@ -94,7 +95,12 @@ def _selection_range_for_position(
         # Token range (individual argument)
         tok = find_token_in_command(cmd, line, character)
         if tok is not None:
-            tok_range = to_lsp_range(Range(start=tok.start, end=tok.end))
+            # A braced/quoted word token's end stops on the last inner
+            # character; widen to its closing delimiter so expand-selection
+            # covers ``{$condition}``, not ``{$condition``.
+            tok_range = to_lsp_range(
+                widen_range_for_closer(source, Range(start=tok.start, end=tok.end))
+            )
             ranges.append(tok_range)
 
         # Full command range

--- a/tests/test_highlight_ranges.py
+++ b/tests/test_highlight_ranges.py
@@ -30,6 +30,14 @@ from __future__ import annotations
 
 import pytest
 
+from core.analysis.semantic_model import Range
+from core.common.ranges import (
+    range_from_word_token,
+    reset_highlight_source,
+    set_highlight_source,
+    widen_for_highlight,
+)
+from core.parsing.tokens import SourcePosition, Token, TokenType
 from explorer.pipeline import run_pipeline
 from explorer.serialise import serialise_result
 
@@ -228,3 +236,91 @@ class TestMultiRangeHighlights:
                 f"branch span not well-formed: {_covered(source, rd)!r}"
             )
         assert _disjoint_and_ordered(spans), "branch spans overlap"
+
+
+# ── unit tests for the range helpers underpinning the fix ──────────────
+
+
+def _pos(offset: int, *, line: int = 0, character: int | None = None) -> SourcePosition:
+    return SourcePosition(
+        line=line, character=offset if character is None else character, offset=offset
+    )
+
+
+def _word_token(ttype: TokenType, text: str, start: int, end: int) -> Token:
+    return Token(type=ttype, text=text, start=_pos(start), end=_pos(end))
+
+
+class TestRangeFromWordToken:
+    def test_str_token_includes_closing_brace(self):
+        # `{$condition}` at offsets 0..11: the STR token spans 0..10 (the `{`
+        # through the last inner char), and the closer is one past the end.
+        tok = _word_token(TokenType.STR, "$condition", start=0, end=10)
+        r = range_from_word_token(tok)
+        assert (r.start.offset, r.end.offset) == (0, 11)
+
+    def test_cmd_token_includes_closing_bracket(self):
+        tok = _word_token(TokenType.CMD, "expr {$z + 1}", start=0, end=13)
+        r = range_from_word_token(tok)
+        assert r.end.offset == 14
+
+    def test_plain_word_token_unchanged(self):
+        tok = _word_token(TokenType.ESC, "set", start=0, end=2)
+        r = range_from_word_token(tok)
+        assert (r.start.offset, r.end.offset) == (0, 2)
+
+    def test_var_token_unchanged(self):
+        tok = _word_token(TokenType.VAR, "x", start=0, end=1)
+        r = range_from_word_token(tok)
+        assert r.end.offset == 1
+
+
+class TestWidenForHighlight:
+    def test_no_op_without_source(self):
+        r = Range(start=_pos(3), end=_pos(13))
+        assert widen_for_highlight(r) is r
+
+    def test_widens_braced_word_when_source_set(self):
+        source = "if {$condition} {body}\n"
+        r = Range(start=_pos(3), end=_pos(13))  # `{$condition` (closer at 14)
+        token = set_highlight_source(source)
+        try:
+            widened = widen_for_highlight(r)
+        finally:
+            reset_highlight_source(token)
+        assert widened.end.offset == 14
+        assert source[r.start.offset : widened.end.offset + 1] == "{$condition}"
+
+    def test_does_not_widen_non_delimiter_span(self):
+        source = "set x 1\n"
+        r = Range(start=_pos(0), end=_pos(2))  # `set`
+        token = set_highlight_source(source)
+        try:
+            assert widen_for_highlight(r).end.offset == 2
+        finally:
+            reset_highlight_source(token)
+
+
+class TestRangeDictConversion:
+    def test_inclusive_to_exclusive_end(self):
+        # Without a highlight source, range_dict still converts the inclusive
+        # semantic-model end to the exclusive end the front-end slices with.
+        from explorer.formatters import range_dict
+
+        rd = range_dict(Range(start=_pos(0), end=_pos(2)))
+        assert rd["startOffset"] == 0
+        assert rd["endOffset"] == 3
+        assert rd["endCol"] == 3
+
+    def test_widens_and_converts_with_source(self):
+        from explorer.formatters import range_dict
+
+        source = "if {$condition} {body}\n"
+        token = set_highlight_source(source)
+        try:
+            rd = range_dict(Range(start=_pos(3), end=_pos(13)))
+        finally:
+            reset_highlight_source(token)
+        # widened to the closer (14, inclusive) then +1 for exclusive end.
+        assert rd["endOffset"] == 15
+        assert source[rd["startOffset"] : rd["endOffset"]] == "{$condition}"

--- a/tests/test_highlight_ranges.py
+++ b/tests/test_highlight_ranges.py
@@ -1,0 +1,230 @@
+"""Highlight-range accuracy tests.
+
+When you hover a CFG node, an IR clause, an optimisation, or a shimmer
+warning in the compiler explorer, the editor draws a highlight over the
+range the server emitted for that artifact.  The highlight is produced by
+slicing the source with the range's offsets, so a wrong range highlights the
+wrong text — e.g. ``{$condition}`` shows up as ``{$conditi`` with the closing
+brace (and a couple of inner characters) missing.
+
+These tests pull every range the explorer serialises, slice the source the
+same way the front-end does, and assert the covered text is a *complete,
+well-formed* token: balanced braces and brackets, and — when the span opens
+with a delimiter — closed by the matching one.  Several constructs also have
+exact-coverage assertions so the off-by-one is pinned per feature, not just
+caught in aggregate.
+
+Two conventions matter:
+
+* The explorer front-end slices ``src.substring(startOffset, endOffset)`` —
+  an *exclusive* end (see ``explorer/static/index.html``
+  ``highlightSourceRanges``).
+* The semantic-model :class:`Range` end is *inclusive* (see
+  :func:`core.common.lsp.to_lsp_range`, which adds 1 to convert it).
+
+So a serialised ``endOffset`` is correct only when it is the exclusive end —
+the inclusive end plus one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from explorer.pipeline import run_pipeline
+from explorer.serialise import serialise_result
+
+# ── source corpus ──────────────────────────────────────────────────────
+
+CORPUS = {
+    "if": "if {$condition} {\n  set x 1\n}\n",
+    "if_else": "if {$a} {\n  set x 1\n} else {\n  set x 2\n}\n",
+    "if_elseif_else": (
+        "if {$a} {\n  set x 1\n} elseif {$b} {\n  set x 2\n} else {\n  set x 3\n}\n"
+    ),
+    "while": "while {$i < 10} {\n  incr i\n}\n",
+    "for": "for {set i 0} {$i < 10} {incr i} {\n  puts $i\n}\n",
+    "foreach": "foreach item {a b c} {\n  puts $item\n}\n",
+    "switch": "switch -- $x {\n  one {set y 1}\n  two {set y 2}\n  default {set y 0}\n}\n",
+    "proc": 'proc greet {name} {\n  puts "hi $name"\n}\n',
+    "catch": "catch {error boom} result\n",
+    "nested": "if {$a} {\n  while {$b} {\n    set z [expr {$z + 1}]\n  }\n}\n",
+}
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+# Top-level serialisation keys whose ranges index into the *optimised*
+# source rather than the source the user typed.
+_OPTIMISED_KEYS = {"asmOptimised", "wasmOptimised"}
+
+
+def _explorer_dict(source: str) -> dict:
+    return serialise_result(run_pipeline(source))
+
+
+def _explorer_data(source: str) -> tuple[dict, str, str]:
+    """Return ``(serialised_dict, source, optimised_source)``.
+
+    The optimiser may rewrite the source (e.g. ``set z [expr {$z + 1}]`` →
+    ``incr z``), so ranges under the optimised asm/wasm views index into the
+    optimised text — they must be sliced against that, not the original.
+    """
+    result = run_pipeline(source)
+    return serialise_result(result), result.source, result.optimised_source
+
+
+def _is_range_dict(obj: object) -> bool:
+    return isinstance(obj, dict) and "startOffset" in obj and "endOffset" in obj
+
+
+def _walk_ranges(obj: object, path: str = ""):
+    """Yield ``(path, range_dict)`` for every range dict in *obj*."""
+    if _is_range_dict(obj):
+        yield path or "<root>", obj
+        return
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            yield from _walk_ranges(value, f"{path}.{key}" if path else str(key))
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            yield from _walk_ranges(value, f"{path}[{i}]")
+
+
+def _covered(source: str, rd: dict) -> str:
+    """Slice the source the way the explorer front-end does (exclusive end)."""
+    return source[rd["startOffset"] : rd["endOffset"]]
+
+
+_OPEN_TO_CLOSE = {"{": "}", "[": "]"}
+_CLOSERS = set(_OPEN_TO_CLOSE.values())
+
+
+def _delims_balanced(text: str) -> bool:
+    """True when every ``{``/``[`` in *text* is matched, honouring ``\\`` escapes."""
+    stack: list[str] = []
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c in _OPEN_TO_CLOSE:
+            stack.append(c)
+        elif c in _CLOSERS:
+            if not stack or _OPEN_TO_CLOSE[stack[-1]] != c:
+                return False
+            stack.pop()
+        i += 1
+    return not stack
+
+
+def _well_formed(text: str) -> bool:
+    """A highlight covers a complete token: non-empty, balanced, and when it
+    opens with a delimiter it closes with the matching one."""
+    if not text:
+        return False
+    if not _delims_balanced(text):
+        return False
+    if text[0] in _OPEN_TO_CLOSE:
+        return text[-1] == _OPEN_TO_CLOSE[text[0]]
+    return True
+
+
+# ── generic well-formedness across every serialised range ──────────────
+
+
+class TestEveryExplorerRangeIsWellFormed:
+    @pytest.mark.parametrize("name", sorted(CORPUS))
+    def test_every_range_covers_a_complete_token(self, name):
+        data, source, optimised = _explorer_data(CORPUS[name])
+        problems = []
+        for path, rd in _walk_ranges(data):
+            top_key = path.split(".", 1)[0].split("[", 1)[0]
+            src = optimised if top_key in _OPTIMISED_KEYS else source
+            covered = _covered(src, rd)
+            if not _well_formed(covered):
+                problems.append((path, covered, rd["startOffset"], rd["endOffset"]))
+        assert not problems, (
+            f"[{name}] {len(problems)} range(s) highlight an incomplete/"
+            f"unbalanced span:\n"
+            + "\n".join(f"  {p}: covered={c!r} (off {s}..{e})" for p, c, s, e in problems)
+        )
+
+
+# ── exact-coverage assertions per construct ────────────────────────────
+
+
+def _covered_set(source: str) -> set[str]:
+    data = _explorer_dict(source)
+    return {_covered(source, rd) for _, rd in _walk_ranges(data)}
+
+
+class TestExactCoverage:
+    def test_if_condition_includes_closing_brace(self):
+        source = CORPUS["if"]
+        assert "{$condition}" in _covered_set(source)
+
+    def test_if_body_includes_closing_brace(self):
+        source = CORPUS["if"]
+        covered = _covered_set(source)
+        assert any(c.startswith("{") and c.endswith("}") and "set x 1" in c for c in covered)
+
+    def test_while_condition_includes_closing_brace(self):
+        assert "{$i < 10}" in _covered_set(CORPUS["while"])
+
+    def test_for_loop_clauses_include_braces(self):
+        covered = _covered_set(CORPUS["for"])
+        assert "{set i 0}" in covered
+        assert "{$i < 10}" in covered
+        assert "{incr i}" in covered
+
+    def test_foreach_statement_range_round_trips(self):
+        # foreach is not specialised in the serialiser, so it surfaces as a
+        # whole-statement range — which must include the closing body brace.
+        covered = _covered_set(CORPUS["foreach"])
+        assert "foreach item {a b c} {\n  puts $item\n}" in covered
+
+    def test_switch_arm_bodies_include_braces(self):
+        covered = _covered_set(CORPUS["switch"])
+        assert "{set y 1}" in covered
+        assert "{set y 2}" in covered
+
+    def test_command_sub_statement_includes_closing_bracket(self):
+        # The set statement carrying a [expr {...}] substitution must keep the
+        # closing ``]`` (and the brace inside it).
+        covered = _covered_set(CORPUS["nested"])
+        assert "set z [expr {$z + 1}]" in covered
+
+
+# ── multi-range (disjoint) highlights — if / elseif / else ─────────────
+
+
+def _disjoint_and_ordered(ranges: list[dict]) -> bool:
+    """A multi-select highlight is a set of non-overlapping spans in order."""
+    spans = sorted((r["startOffset"], r["endOffset"]) for r in ranges)
+    return all(spans[i][1] <= spans[i + 1][0] for i in range(len(spans) - 1))
+
+
+class TestMultiRangeHighlights:
+    def test_if_else_branch_spans_are_each_well_formed_and_disjoint(self):
+        # An if/else highlight conceptually covers several disjoint source
+        # spans (the condition, the then-body, the else-body) with the
+        # keywords/whitespace in the gaps between them.  Each span must be a
+        # complete token, and collectively they must not overlap.
+        source = CORPUS["if_else"]
+        data = _explorer_dict(source)
+        # Pull the if node's clause + else ranges out of the IR serialisation.
+        if_nodes = [n for n in data["ir"]["topLevel"] if n.get("kind") == "IRIf"]
+        assert if_nodes, "expected an if node in the IR"
+        node = if_nodes[0]
+        spans = []
+        for child in node.get("children", []):
+            if child.get("range"):
+                spans.append(child["range"])
+        assert len(spans) >= 2, "if/else should expose multiple disjoint ranges"
+        for rd in spans:
+            assert _well_formed(_covered(source, rd)), (
+                f"branch span not well-formed: {_covered(source, rd)!r}"
+            )
+        assert _disjoint_and_ordered(spans), "branch spans overlap"

--- a/tests/test_highlight_ranges.py
+++ b/tests/test_highlight_ranges.py
@@ -251,6 +251,15 @@ def _word_token(ttype: TokenType, text: str, start: int, end: int) -> Token:
     return Token(type=ttype, text=text, start=_pos(start), end=_pos(end))
 
 
+def _offset_of(source: str, line: int, character: int) -> int:
+    """Resolve a (line, character) position to an absolute offset in source."""
+    line_starts = [0]
+    for i, ch in enumerate(source):
+        if ch == "\n":
+            line_starts.append(i + 1)
+    return line_starts[line] + character
+
+
 class TestRangeFromWordToken:
     def test_str_token_includes_closing_brace(self):
         # `{$condition}` at offsets 0..11: the STR token spans 0..10 (the `{`
@@ -273,6 +282,22 @@ class TestRangeFromWordToken:
         tok = _word_token(TokenType.VAR, "x", start=0, end=1)
         r = range_from_word_token(tok)
         assert r.end.offset == 1
+
+    def test_multiline_body_closer_advances_line_and_column(self):
+        # `{\n  set x 1\n}` — the closing `}` is on the next line at column 0,
+        # so the widened end's line/column must stay consistent with offset.
+        source = "if {$a} {\n  set x 1\n}\n"
+        # The body STR token: `{` at offset 8, inner ends on the `\n` at 19.
+        tok = Token(
+            type=TokenType.STR,
+            text="\n  set x 1\n",
+            start=SourcePosition(line=0, character=8, offset=8),
+            end=SourcePosition(line=1, character=9, offset=19),
+        )
+        r = range_from_word_token(tok)
+        assert source[r.end.offset] == "}"
+        assert _offset_of(source, r.end.line, r.end.character) == r.end.offset
+        assert (r.end.line, r.end.character) == (2, 0)
 
 
 class TestWidenForHighlight:
@@ -299,6 +324,21 @@ class TestWidenForHighlight:
             assert widen_for_highlight(r).end.offset == 2
         finally:
             reset_highlight_source(token)
+
+    def test_multiline_closer_keeps_line_column_consistent(self):
+        # Closer on the next line: offset and line/column must agree.
+        source = "if {$a} {\n  set x 1\n}\n"
+        r = Range(
+            start=SourcePosition(line=0, character=8, offset=8),  # `{`
+            end=SourcePosition(line=1, character=9, offset=19),  # the `\n`
+        )
+        token = set_highlight_source(source)
+        try:
+            widened = widen_for_highlight(r)
+        finally:
+            reset_highlight_source(token)
+        assert source[widened.end.offset] == "}"
+        assert _offset_of(source, widened.end.line, widened.end.character) == widened.end.offset
 
 
 class TestRangeDictConversion:

--- a/tests/test_selection_range.py
+++ b/tests/test_selection_range.py
@@ -173,3 +173,32 @@ class TestSelectionRangeChainOrder:
 
 def _fmt(r: types.Range) -> str:
     return f"({r.start.line}:{r.start.character})-({r.end.line}:{r.end.character})"
+
+
+def _same_line_text(source: str, r: types.Range) -> str | None:
+    if r.start.line != r.end.line:
+        return None
+    return source.split("\n")[r.start.line][r.start.character : r.end.character]
+
+
+class TestSelectionRangeBracedWord:
+    def test_braced_condition_selection_includes_closing_brace(self):
+        # Regression: expand-selection over a braced word used to stop one
+        # char short (``{$condition`` instead of ``{$condition}``) because the
+        # word token's end excludes the closer.
+        source = "if {$condition} {\n  set x 1\n}\n"
+        pos = types.Position(line=0, character=6)  # inside the condition
+        chain = _chain_to_list(get_selection_ranges(source, [pos])[0])
+        texts = {_same_line_text(source, r) for r in chain}
+        assert "{$condition}" in texts
+        assert "{$condition" not in texts
+
+    def test_braced_word_selection_is_balanced(self):
+        source = 'set msg "hi"\nputs [string length $msg]\n'
+        pos = types.Position(line=1, character=14)  # inside the [string ...] word
+        chain = _chain_to_list(get_selection_ranges(source, [pos])[0])
+        for r in chain:
+            text = _same_line_text(source, r)
+            if text and text[:1] in "{[":
+                closer = "}" if text[0] == "{" else "]"
+                assert text.endswith(closer), f"unbalanced selection span: {text!r}"


### PR DESCRIPTION
## Summary

Fixes an off-by-one error where highlights over braced, quoted, or bracketed words in the compiler explorer dropped the closing delimiter (e.g., `{$condition}` was highlighted as `{$condition` or `{$conditi`).

The root cause: word tokens follow an "inner-end" convention where the closing delimiter is excluded from the token's end position. This is intentional — many compiler passes (optimizer, SCCP, structure elimination) rely on this contract. However, when serializing ranges for the explorer frontend (which slices with an exclusive end), we need to:

1. **Widen word-token ranges to include the closer** — done at serialization time via `widen_for_highlight()`, matching how the diagnostics pipeline handles this
2. **Convert inclusive semantic-model ends to exclusive ends** — add 1 to match the frontend's `substring(startOffset, endOffset)` slicing

## Changes

### Core range utilities (`core/common/ranges.py`)
- Added `range_from_word_token()` — derives the closing delimiter from token type (STR/CMD) without needing source
- Added `set_highlight_source()` / `reset_highlight_source()` / `widen_for_highlight()` — context-var-based source tracking for widening ranges at serialization time

### Explorer serialization (`explorer/serialise.py`, `explorer/formatters.py`)
- `range_dict()` now widens braced/quoted words and converts inclusive ends to exclusive (`+1`)
- `serialise_result()` sets the highlight source context around serialization so ranges are widened against the correct document (original or optimized)
- `_range_to_explorer_dict()` in wasm codegen mirrors the same logic

### Command segmentation (`core/parsing/command_segmenter.py`)
- `_command_range()` uses `range_from_word_token()` to ensure command ranges include closing delimiters of their final word

### LSP selection ranges (`lsp/features/selection_range.py`)
- Token ranges are widened via `widen_range_for_closer()` before conversion to LSP format

## Validation

- Added comprehensive test suite (`tests/test_highlight_ranges.py`) covering:
  - Generic well-formedness: every serialized range covers a complete, balanced token
  - Exact coverage: specific constructs (if/while/for/foreach/switch/nested) include their closing delimiters
  - Multi-range highlights: if/elseif/else spans are disjoint and ordered
  - Unit tests for the range helpers
- Added regression tests to `tests/test_selection_range.py` for selection-range widening
- Added KCS documentation (`docs/kcs/kcs-issue-highlight-drops-closing-delimiter.md`) explaining the contracts and failure modes

All tests pass; the fix is covered by the new test suite which validates that every range in the serialized output covers a well-formed token.

## Compiler/KCS checklist

- [x] This change alters a compiler fact contract (word-token range convention)
- [x] Updated KCS note: `docs/kcs/kcs-issue-highlight-drops-closing-delimiter.md`
- [x] Linked from `docs/kcs/README.md`

https://claude.ai/code/session_01GDZbrNdv9gDa37hvQrrCj8