### PR TITLE
SYNC-MAY21: Arity checks, segmenter span fix, CFG/SSA perf

### DIFF
--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1288,25 +1288,60 @@ merge + dialect-scoped switch filtering in `tcl-registry`, and the
 E003 arity check (`compiler_checks` / analyser arity validation).
 Classify: in-scope, low-touch.
 
-**Verified Rust state (2026-05-21, branch
-`claude/tcl-lsp-rust-rewrite-lNRRS`) — reclassify as blocked.** The
-"low-touch" estimate assumed the consuming machinery existed; it
-does not. The Rust analyser has **no general arity emitter at all**
-— there is no `E003` "too many arguments" check (and no live
-`E001`/`E002` either; the only `E002` occurrences are manually
-constructed test fixtures exercising the E101 de-dup pass). The
-signature side is likewise absent: `analyser::dispatch::CommandSig`
-carries only `arity` + `arg_roles` (no `leading_options`); there is
-no `_with_roles` role-hint merge and no `switch_names` / declared-
-option set in `tcl-registry` (`signature_for_command` already
-dialect-filters *subcommands*, but never computes a leading-option
-set for arity counting). Because the check itself isn't ported, the
-false positive **cannot occur today** — there is nothing to fix.
-The whole row (option-aware arity counting + dialect-scoped switch
-filtering + the `leading_options` preservation on role-hint merge)
-should land *as part of* the C41 arity-check port, not as a
-standalone mirror; building the `leading_options` plumbing ahead of
-its only consumer would be dead infrastructure. Promote to C41.
+**Landed — `claude/tcl-lsp-rust-rewrite-lNRRS`.** The Rust analyser
+had **no general arity emitter at all** (no live `E001`/`E002`/`E003`
+— the only prior `E002` occurrences were test fixtures for the E101
+de-dup pass), so this row ported the simple-command arity check from
+scratch rather than mirroring a 3-line Python delta:
+
+- **`tcl-registry`:** `CommandSpec::switch_names(dialect)` mirrors
+  Python's `models.py::switch_names` — declared option names across
+  `options` + `command_forms[].options`, dialect-filtered via
+  `OptionSpec::supports_dialect`, deduped in declaration order.
+- **`analyser::dispatch`:** `CommandSig` gains `leading_options:
+  BTreeSet<String>`, populated from `switch_names(Some(dialect))` for
+  the simple branch (the SubcommandSig branch leaves it empty —
+  per-subcommand arity is a follow-up).
+- **`analyser::diagnostics`:** `emit_arity_diagnostics` mirrors
+  `_check_simple_arity` — skip leading declared options (dialect-
+  filtered), then compare the positional count to the arity bounds
+  (E002 too few / E003 too many). `{*}`-expanded words are excluded
+  from the positional lower bound (expansion threaded through
+  `process_command`), exactly as Python does.
+- **Post-walk flush + shadowing guard:** candidates are collected
+  during the walk and emitted in `flush_arity_diagnostics` (called
+  beside `emit_unresolved_command_diagnostics`), which drops any
+  command name shadowed by a user proc / class / alias / ensemble /
+  inline stub. This is **ahead of Python's inline check** and was
+  driven by validation (below): without it, a namespace that defines
+  `proc ::ns::close {...}` and calls `close ...` with the proc's
+  wider arity false-fired E003 against the *builtin* `close` arity.
+  The post-walk timing makes the guard order-independent (the proc
+  may be defined after its call site).
+
+**Validation.** Analysed the full Tcl 8.6 standard library and the
+entire tcllib 2.0 module tree with the live `tcl8.6` path:
+**0 E002/E003 false positives** in both (the 2 tcllib hits found in
+an intermediate build — both `::websocket::close` — were what
+motivated the shadowing guard, and are gone). Regression tests cover
+the #455 leading-switch cases (`regsub -all …`), #460 dialect
+filtering (`regsub -command` 9.0-only), genuine over/under-arity,
+and `{*}`-expansion suppression.
+
+**Documented parity gaps (intentional):** (1) like Python's name-only
+`leading_options`, the *value* of a value-taking leading option is
+not skipped (Python's value-aware `skip_options` is used only for
+arg-role resolution, not arity); (2) statically-resolvable literal
+`{*}` expansions are not refined to their element count — the
+conservative form can miss a genuine over-arity but never invents a
+false positive; (3) subcommand-dispatch arity is deferred (W001
+already covers unknown subcommands).
+
+**Out-of-scope finds (pre-existing, flagged):** the analyser stack-
+overflows on `tcl8.6.16/library/http/http.tcl` and hangs on a few
+tcllib files (`fumagic/filetypes.tcl`, `nettool/*`,
+`textutil/build/*/wcswidth.tcl`) — unrelated to arity (a flat
+emitter can't recurse); worth a separate investigation.
 
 ### SYNC-MAY21-4 — Analyser diagnostic-range coverage + product fixes (#464)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1256,6 +1256,24 @@ the `-loop` stub form, plus the `tcl-registry` signature side.
 Classify: in-scope, **structural** → promote to a numbered chunk
 when the analyser-core port (C41) reaches diagnostics.
 
+**Verified Rust state (2026-05-21, branch
+`claude/tcl-lsp-rust-rewrite-lNRRS`).** The inline `-loop` stub
+*flag* is **already present**: `tcl-registry::stub_overlay`
+declares `StubSigFlags::LOOP` (bit 1) and the analyser parses /
+carries it onto each `StubSig`. What #468 actually adds on top of
+the flag is **structural and still blocked**:
+(1) routing a `-loop` stub call through real loop *lowering* (the
+Python `_lower_stub_loop`) so the loop variable stays defined and
+the body is analysed in iteration order — the Rust lowering's
+structured-hook dispatch doesn't yet consult the stub overlay for a
+loop shape; (2) external `.tcl.stubs` *file* ingestion + the ambient
+(cross-file) stub scope + bounded workspace discovery + the
+W002/W123 interplay + cache-fingerprint merge + subprocess-pool
+forwarding — none of which has a Rust home yet (workspace stub
+discovery lives in the not-yet-ported LSP-server/workspace-state
+layer). Net: the overlay data model is ready; the loop-lowering and
+workspace-ingestion consumers ride with C41 / the `S*` server port.
+
 ### SYNC-MAY21-3 — E003 false positives: switches before positional args (#460 / #455)
 
 `_with_roles` dropped a command's declared `leading_options` when
@@ -1270,6 +1288,26 @@ merge + dialect-scoped switch filtering in `tcl-registry`, and the
 E003 arity check (`compiler_checks` / analyser arity validation).
 Classify: in-scope, low-touch.
 
+**Verified Rust state (2026-05-21, branch
+`claude/tcl-lsp-rust-rewrite-lNRRS`) — reclassify as blocked.** The
+"low-touch" estimate assumed the consuming machinery existed; it
+does not. The Rust analyser has **no general arity emitter at all**
+— there is no `E003` "too many arguments" check (and no live
+`E001`/`E002` either; the only `E002` occurrences are manually
+constructed test fixtures exercising the E101 de-dup pass). The
+signature side is likewise absent: `analyser::dispatch::CommandSig`
+carries only `arity` + `arg_roles` (no `leading_options`); there is
+no `_with_roles` role-hint merge and no `switch_names` / declared-
+option set in `tcl-registry` (`signature_for_command` already
+dialect-filters *subcommands*, but never computes a leading-option
+set for arity counting). Because the check itself isn't ported, the
+false positive **cannot occur today** — there is nothing to fix.
+The whole row (option-aware arity counting + dialect-scoped switch
+filtering + the `leading_options` preservation on role-hint merge)
+should land *as part of* the C41 arity-check port, not as a
+standalone mirror; building the `leading_options` plumbing ahead of
+its only consumer would be dead infrastructure. Promote to C41.
+
 ### SYNC-MAY21-4 — Analyser diagnostic-range coverage + product fixes (#464)
 
 Test-suite hardening for diagnostic-range coverage surfaced real
@@ -1280,6 +1318,15 @@ tests exposed). **Rust mirror:** fold into the in-progress
 analyser-core port (C41) — diagnostic spans plus the specific
 lifecycle/scope fixes. Classify: in-scope, medium; tracked under
 C41.
+
+**Verified Rust state (2026-05-21) — confirmed blocked on C41.**
+The Python fixes here are spread across var-lifecycle / OO / proc /
+scope checks (`_diag_var_lifecycle`, `_oo`, `_proc`, `_scope`)
+whose Rust equivalents are exactly the analyser-core surface still
+being ported under C41 — the var-lifecycle and scope-accuracy
+emitters are not yet live in `tcl-compiler::analyser`. No standalone
+mirror is possible; the diagnostic-range fixes attach to each check
+as it lands in C41.
 
 ### SYNC-MAY21-5 — Preserve array indices when renaming base variables (#461)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1209,15 +1209,39 @@ closer via a token-tree `range_from_word_token`.
 
 This is the same convention the Rust side hit in the `${arr(idx)}`
 rename work — the lexer's `Var` token span excludes the closing
-brace. **Rust mirror:** `tcl-lsp-core::selection_range` must widen
-token ranges to the closer (it currently builds `Range(tok.start,
-tok.end)` raw); `tcl-compiler::segmenter` whole-command range
-should include the last word's closer. The audit on `main`
+brace. **Rust mirror:** `tcl-compiler::segmenter` whole-command
+range should include the last word's closer. The audit on `main`
 confirmed hover (no range), folding (line-based), and semantic
 tokens (length-encoded) are unaffected — so scope is
 selection-range + segmenter range only. Classify: in-scope,
 low/medium. Files: `selection_range.rs`, `segmenter.rs`, the span
 → LSP-range helpers.
+
+**Landed (segmenter) — `claude/tcl-lsp-rust-rewrite-lNRRS`.**
+`segmenter.rs` now derives the whole-command span via a new
+`command_span` / `widen_word_end` pair (mirroring Python's
+`_command_range` → `range_from_word_token`): the final word's
+exclusive end is extended by one byte when the last token is a
+`Str` / `Cmd` whose closer (`}` / `]`, derived from the token
+*type*) sits at `span.end()`. The single source byte at
+`span.end()` is inspected only to skip the degenerate `{}` / `[]`
+forms, whose span already covers the closer (the lexer extends
+those by one). Tests: braced / bracketed / multi-line / degenerate
+/ plain-word final words.
+
+**`selection_range` — no applicable hook (divergence noted).** The
+doc premise above ("`tcl-lsp-core::selection_range` … currently
+builds `Range(tok.start, tok.end)` raw") describes the *Python*
+structure. The Rust port diverged: its chain is word-at-cursor →
+single-line `;`-aware command-segment scan → line → enclosing
+bodies → document, and **none** of those links is built from a raw
+lexer `Str` / `Cmd` token — so none drops a closer (the line scan
+already runs to the `;` / EOL, past any closer). The closer-drop
+fix Python applies to its per-argument *token* link therefore has
+nothing to attach to until the deferred token-based command-segment
+machinery lands (tracked under `S-signature-help-rich`); when that
+strip ports the per-argument link, it must widen those token ranges
+to the closer (use a `widen_range_for_closer`-style helper).
 
 ### SYNC-MAY21-2 — `-loop` stubs + external `.tcl.stubs` files (#468)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1354,14 +1354,28 @@ analyser-core port (C41) — diagnostic spans plus the specific
 lifecycle/scope fixes. Classify: in-scope, medium; tracked under
 C41.
 
-**Verified Rust state (2026-05-21) — confirmed blocked on C41.**
-The Python fixes here are spread across var-lifecycle / OO / proc /
-scope checks (`_diag_var_lifecycle`, `_oo`, `_proc`, `_scope`)
-whose Rust equivalents are exactly the analyser-core surface still
-being ported under C41 — the var-lifecycle and scope-accuracy
-emitters are not yet live in `tcl-compiler::analyser`. No standalone
-mirror is possible; the diagnostic-range fixes attach to each check
-as it lands in C41.
+**Partially landed — `claude/tcl-lsp-rust-rewrite-lNRRS`.** One
+concrete, already-ported piece was mirrored: **W302** (catch without
+result var) now anchors at just the `catch` command token instead of
+the whole `catch {…}` statement (which also dropped the closing brace
+under the lexer's inner-end convention) —
+`emit_w302_catch_no_result_var` uses `cmd_tok.span`; test updated to
+assert the narrow span.
+
+The remaining #464 range-narrowing is **blocked / architectural**:
+- **W210 / W211** (read-before-set, set-but-never-used) are not ported
+  to `tcl-compiler::analyser` at all — part of the var-lifecycle
+  surface still under C41.
+- **W213 / W220** *are* live but emit from the CFG/SSA pass with
+  `stmt.span()` (whole statement); narrowing them to the variable
+  token needs the target-variable token span plumbed through the IR
+  statements / SSA use-sites — an IR/lowering change, not a local
+  emitter tweak. Fold into C41.
+- The refactoring-fidelity fixes (extract-variable `[expr {…}]`
+  wrapping, token-based inline-variable, inline-proc brace
+  preservation, extract-proc edit-overlap merge) live in the
+  refactoring/code-action subsystem (`tcl-lsp-core`), a separate
+  chunk from the analyser-core port.
 
 ### SYNC-MAY21-5 — Preserve array indices when renaming base variables (#461)
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -101,7 +101,13 @@ impl Analyser {
                     &mut self.result.suppressed_lines,
                 );
             }
-            self.process_command(&cmd.texts, &cmd.argv, &cmd.single_token_word, scope_path);
+            self.process_command(
+                &cmd.texts,
+                &cmd.argv,
+                &cmd.single_token_word,
+                cmd.expand_word.as_deref().unwrap_or(&[]),
+                scope_path,
+            );
             // `S-document-highlight-rich` / `S-references-rich`
             // follow-up: record every `$var` substitution in
             // arg positions so `VarDef.references` carries the
@@ -133,14 +139,18 @@ impl Analyser {
     ///
     /// Deferred concerns (each gets its own future strip — see
     /// the module docstring): var-as-command site recording,
-    /// W125 / IRULE5005 emission, arity checks, sub-command
-    /// resolution, command-invocation recording with
-    /// resolved-qname annotation.
+    /// W125 / IRULE5005 emission, sub-command resolution,
+    /// command-invocation recording with resolved-qname annotation.
+    /// Simple-command arity (E002 / E003) lands here via
+    /// [`Self::emit_arity_diagnostics`] (SYNC-MAY21-3); the
+    /// candidates are flushed post-walk by
+    /// [`Self::flush_arity_diagnostics`].
     pub fn process_command(
         &mut self,
         argv_texts: &[String],
         arg_tokens_in: &[Token],
         single_token_word: &[bool],
+        arg_expand_in: &[bool],
         scope_path: &[usize],
     ) {
         if argv_texts.is_empty() || arg_tokens_in.is_empty() {
@@ -309,6 +319,9 @@ impl Analyser {
         // dialect set excludes the active one.  Substituted-value
         // args and `--` terminate the scan.
         self.emit_w004_dialect_invalid_option(cmd_name, args, arg_tokens);
+
+        // **SYNC-MAY21-3.**  E002 / E003 arity; flushed post-walk.
+        self.emit_arity_diagnostics(cmd_name, args, arg_tokens, arg_expand_in, arg_tokens_in[0]);
 
         // Handler-by-handler dispatch. Each returning-bool
         // handler is consulted in turn; first match wins. The
@@ -961,6 +974,7 @@ mod tests {
             ],
             &[true, true, true],
             &[],
+            &[],
         );
         assert!(a.result.global_scope.variables.contains_key("x"));
     }
@@ -983,6 +997,7 @@ mod tests {
             ],
             &[true, true, true, true],
             &[],
+            &[],
         );
         assert!(a.result.all_procs.contains_key("::foo"));
     }
@@ -1004,6 +1019,7 @@ mod tests {
                 str_tok(span(19, 21)),
             ],
             &[true, true, true, true],
+            &[],
             &[],
         );
         assert_eq!(a.result.global_scope.children.len(), 1);
@@ -1028,6 +1044,7 @@ mod tests {
             ],
             &[true, true, true, true],
             &[],
+            &[],
         );
         assert!(a.result.global_scope.variables.contains_key("i"));
     }
@@ -1044,6 +1061,7 @@ mod tests {
             ],
             &[true, true, true],
             &[],
+            &[],
         );
         assert!(a.result.global_scope.variables.contains_key("x"));
         assert!(a.result.global_scope.variables.contains_key("y"));
@@ -1057,6 +1075,7 @@ mod tests {
             &[esc_tok(span(0, 18)), esc_tok(span(19, 22))],
             &[true, true],
             &[],
+            &[],
         );
         // No handler matched; no procs, vars, classes, or aliases
         // recorded. (Unknown-command diagnostic emission is C41d4.)
@@ -1067,7 +1086,7 @@ mod tests {
     #[test]
     fn process_empty_argv_is_no_op() {
         let mut a = Analyser::new();
-        a.process_command(&[], &[], &[], &[]);
+        a.process_command(&[], &[], &[], &[], &[]);
         // No panic, no state mutation.
     }
 
@@ -1092,6 +1111,7 @@ mod tests {
                 esc_tok(span(25, 28)),
             ],
             &[true, true, true, true, true, true],
+            &[],
             &[],
         );
         assert!(a.command_aliases.contains_key("::myset"));

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -250,78 +250,21 @@ impl Analyser {
         // recursion only), so this can't double-fire.
         self.dispatch_expr_arguments(cmd_name, args, arg_tokens);
 
-        // **C41-default-on-followups-postpass.**  W302 — `catch`
-        // without result variable silently swallows errors.
-        // Mirrors the IRCatch arm of ``_check_statement`` in
-        // ``core/compiler/compiler_checks.py:491-504``.  Fires
-        // *before* the early-returning ``handle_catch_command``
-        // for the same reason as the EXPR-role dispatch above:
-        // the catch handler returns early and the diagnostic
-        // would otherwise be skipped.
-        if cmd_name == "catch" {
-            self.emit_w302_catch_no_result_var(args, cmd_tok, arg_tokens, arg_single);
-        }
-
-        // **C41-default-on-followups-postpass.**  W001 — unknown
-        // subcommand on a registry-known SubcommandSig command
-        // (``string``, ``dict``, ``info``, ``namespace`` …).
-        // Mirrors the SubcommandSig branch of ``_check_arity``
-        // in ``core/compiler/compiler_checks.py:580-643``.  Run
-        // before the early-returning handlers (notably
-        // ``handle_namespace_eval_command``) so ``namespace foo``
-        // for an unknown ``foo`` still gets flagged.
-        self.emit_w001_unknown_subcommand(cmd_name, args, cmd_tok, arg_tokens);
-
-        // **C41-default-on-followups-postpass.**  E004 — malformed
-        // ``if`` command (extra words after ``else``, or a
-        // structural shape that doesn't match
-        // ``if COND BODY ?elseif COND BODY ...? ?else BODY?``).
-        // Mirrors the ``IRBarrier`` arm of ``_check_statement`` in
-        // ``core/compiler/compiler_checks.py:506-525``, with the
-        // shape detection re-implemented analyser-side rather than
-        // by walking lowered IR — same dispatch-site pattern as
-        // W302 / W001.  ``if`` falls through to
-        // ``dispatch_body_arguments`` below (no early-returning
-        // handler), so dispatch ordering is consistency-only.
-        if cmd_name == "if" {
-            self.emit_e004_malformed_if(args, cmd_tok, arg_tokens);
-        }
-
-        // **C41-default-on-followups-postpass.**  W101 — ``eval``
-        // with substituted arguments (string-concatenation
-        // injection risk).  Mirrors ``check_eval_string_concat`` in
-        // ``core/analysis/checks/_security.py:19-73``.  Run before
-        // the early-returning handlers / body-walk dispatch so the
-        // generic ``ArgRole::Body`` recursion into the ``eval``
-        // body still runs even after W101 fires.  Cheap guard
-        // (cmd_name == "eval") inside the emitter avoids the
-        // overhead for the common case.
-        self.emit_w101_eval_string_concat(cmd_name, args, arg_tokens, arg_single);
-
-        // **C41-default-on-followups-postpass.**  W304 — missing
-        // option terminator (``--``) on option-bearing commands.
-        // Mirrors ``check_missing_option_terminator`` in
-        // ``core/analysis/checks/_style.py:506-679``.  Driven by
-        // the registry's ``resolve_option_terminator`` profile, so
-        // commands that don't declare a ``--`` option (e.g.
-        // ``subst``, ``string match``, ``lsearch``) are filtered
-        // out at the registry layer — no analyser-side allow-list
-        // needed.  Run before the early-returning handlers
-        // (``handle_switch_command`` etc.) so option-bearing
-        // commands with their own handler still get checked.
-        self.emit_w304_missing_option_terminator(cmd_name, args, cmd_tok, arg_tokens);
-
-        // **SYNC-MAY19-W003-W004.**  W004 — option not available in
-        // the active dialect.  Mirrors `check_dialect_invalid_option`
-        // in `core/analysis/checks/_domain.py` (PR #433, 0f9288d2).
-        // Driven by the registry's per-option `dialects` field; only
-        // fires when an option is declared on this command but its
-        // dialect set excludes the active one.  Substituted-value
-        // args and `--` terminate the scan.
-        self.emit_w004_dialect_invalid_option(cmd_name, args, arg_tokens);
-
-        // **SYNC-MAY21-3.**  E002 / E003 arity; flushed post-walk.
-        self.emit_arity_diagnostics(cmd_name, args, arg_tokens, arg_expand_in, arg_tokens_in[0]);
+        // Dispatch-site diagnostic emitters (W302 / W001 / E004 / W101
+        // / W304 / W004 / E002-E003).  Extracted from this function so
+        // it stays within the line budget; see the method for the
+        // per-code rationale and ordering.  Run before the
+        // early-returning handlers so option-bearing / body-owning
+        // commands still get checked.
+        self.emit_dispatch_site_diagnostics(
+            cmd_name,
+            args,
+            arg_tokens,
+            arg_single,
+            arg_expand_in,
+            cmd_tok,
+            scope_path,
+        );
 
         // Handler-by-handler dispatch. Each returning-bool
         // handler is consulted in turn; first match wins. The
@@ -410,6 +353,62 @@ impl Analyser {
         // walk so race-detection diagnostics see the event
         // name, mirroring the Python behaviour.
         self.dispatch_body_arguments(cmd_name, args, arg_tokens, scope_path);
+    }
+
+    /// Dispatch-site diagnostic emitters, run from
+    /// [`Self::process_command`] before the early-returning handlers so
+    /// option-bearing / body-owning commands still get checked.
+    ///
+    /// - **W302** (`catch` without a result variable) — `IRCatch` arm
+    ///   of `_check_statement` (`compiler_checks.py:491-504`); fires
+    ///   before the early-returning `handle_catch_command`.
+    /// - **W001** (unknown subcommand on a `SubcommandSig` command) —
+    ///   `SubcommandSig` branch of `_check_arity`
+    ///   (`compiler_checks.py:580-643`); before
+    ///   `handle_namespace_eval_command` so `namespace foo` is flagged.
+    /// - **E004** (malformed `if`) — `IRBarrier` arm of
+    ///   `_check_statement` (`compiler_checks.py:506-525`).
+    /// - **W101** (`eval` with substituted args) —
+    ///   `check_eval_string_concat` (`checks/_security.py:19-73`);
+    ///   before body-walk dispatch so the `ArgRole::Body` recursion
+    ///   into the `eval` body still runs.
+    /// - **W304** (missing `--` option terminator) —
+    ///   `check_missing_option_terminator` (`checks/_style.py:506-679`),
+    ///   driven by the registry's option-terminator profile.
+    /// - **W004** (option not available in the active dialect,
+    ///   SYNC-MAY19-W003-W004) — `check_dialect_invalid_option`
+    ///   (`checks/_domain.py`, PR #433).
+    /// - **E002 / E003** (arity, SYNC-MAY21-3) — collected here and
+    ///   flushed post-walk by [`Self::flush_arity_diagnostics`].
+    #[allow(clippy::too_many_arguments)]
+    fn emit_dispatch_site_diagnostics(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        arg_single: &[bool],
+        arg_expand_in: &[bool],
+        cmd_tok: Token,
+        scope_path: &[usize],
+    ) {
+        if cmd_name == "catch" {
+            self.emit_w302_catch_no_result_var(args, cmd_tok, arg_tokens, arg_single);
+        }
+        self.emit_w001_unknown_subcommand(cmd_name, args, cmd_tok, arg_tokens);
+        if cmd_name == "if" {
+            self.emit_e004_malformed_if(args, cmd_tok, arg_tokens);
+        }
+        self.emit_w101_eval_string_concat(cmd_name, args, arg_tokens, arg_single);
+        self.emit_w304_missing_option_terminator(cmd_name, args, cmd_tok, arg_tokens);
+        self.emit_w004_dialect_invalid_option(cmd_name, args, arg_tokens);
+        self.emit_arity_diagnostics(
+            cmd_name,
+            args,
+            arg_tokens,
+            arg_expand_in,
+            cmd_tok,
+            scope_path,
+        );
     }
 
     /// Generic EXPR-argument walk via the command registry's

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -667,10 +667,11 @@ numeric/string coercion."
     /// emits W302 for `IRCatch` (not `IRBarrier`) — the lowerer
     /// falls back to `IRBarrier` when the body argument is multi-token
     /// (e.g. ``catch $body``), so this Rust emit gates on
-    /// ``arg_single[0]`` to mirror that suppression.  The
-    /// diagnostic anchors at the full command span (catch keyword
-    /// through the last argument's end), matching Python's
-    /// ``stmt.range``.
+    /// ``arg_single[0]`` to mirror that suppression.  The diagnostic
+    /// anchors at just the ``catch`` command token — the narrowest
+    /// span that identifies the issue — matching the #464 narrowing
+    /// (`compiler_checks.py` now uses ``range_from_token(argv[0])``
+    /// rather than the whole-statement ``stmt.range``).
     pub(super) fn emit_w302_catch_no_result_var(
         &mut self,
         args: &[String],
@@ -691,10 +692,10 @@ numeric/string coercion."
         if arg_single.first().copied() != Some(true) {
             return;
         }
-        let Some(body_tok) = arg_tokens.first().copied() else {
+        if arg_tokens.is_empty() {
             return;
-        };
-        let span = tcl_lexer::Span::new(cmd_tok.span.start(), body_tok.span.end());
+        }
+        let span = cmd_tok.span;
         self.result.diagnostics.push(super::types::Diagnostic {
             code: "W302".to_string(),
             span,

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -814,6 +814,192 @@ Consider capturing the result: catch {\u{2026}} result"
         });
     }
 
+    /// **E002 / E003.** Argument-count check for simple (non-
+    /// subcommand) commands.  Mirrors `_check_simple_arity` in
+    /// `core/compiler/compiler_checks.py`: skip leading declared
+    /// option flags, then compare the positional-argument count
+    /// against the registry signature's arity bounds.
+    ///
+    /// Option skipping uses the dialect-filtered
+    /// [`CommandSig::leading_options`](super::dispatch::CommandSig::leading_options)
+    /// set, so switches introduced in a later Tcl release (e.g.
+    /// `regsub -command`, 9.0+) are only skipped under a dialect that
+    /// declares them.  This is the SYNC-MAY21-3 fix: it prevents both
+    /// the #455 false positive (declared switches counted as
+    /// positional → spurious E003) and the #460 dialect leak (9.0-only
+    /// switches skipped under 8.x).
+    ///
+    /// `arg_expand[i]` marks an argument preceded by the Tcl 8.5+
+    /// `{*}` expansion prefix.  A `{*}`-expanded word contributes an
+    /// unknown number of runtime arguments, so option skipping stops
+    /// at the first such word and the positional upper bound becomes
+    /// unbounded — only the count of *non-expanded* positional words
+    /// can still trip E003, exactly as Python does.
+    ///
+    /// **Parity gaps (documented, intentional):**
+    /// - Like Python's name-only `leading_options` skip, the *value*
+    ///   of a value-taking leading option is **not** skipped (Python's
+    ///   value-aware `skip_options` is used only for arg-role
+    ///   resolution, not arity).  See the validation note in
+    ///   `docs/rust-rewrite.md` (SYNC-MAY21-3).
+    /// - Statically-resolvable literal `{*}` expansions (`{*}{a b c}`)
+    ///   are not refined to their element count; the conservative form
+    ///   here can miss a genuine over-arity but never invents a false
+    ///   positive.
+    ///
+    /// Subcommand-dispatch commands are handled by
+    /// [`Self::emit_w001_unknown_subcommand`] and skipped here;
+    /// per-subcommand arity is a later follow-up.
+    pub(super) fn emit_arity_diagnostics(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+        arg_expand_in: &[bool],
+        cmd_tok: tcl_lexer::Token,
+    ) {
+        use super::dispatch::{signature_for_command, CommandSignature};
+        use tcl_registry::prelude::DialectSet;
+
+        // `arg_expand_in` is parallel to the full argv (command name at
+        // index 0); drop that slot so it lines up with `args`.
+        let arg_expand: &[bool] = arg_expand_in.get(1..).unwrap_or(&[]);
+
+        let Some(registry) = self.registry.as_ref() else {
+            return;
+        };
+        let dialect = DialectSet::parse(&self.dialect).unwrap_or(DialectSet::ALL_TCL);
+        let Some(CommandSignature::Simple(sig)) =
+            signature_for_command(registry, cmd_name, dialect)
+        else {
+            // Unknown command (no signature) or a subcommand-dispatch
+            // command — neither is arity-checked here.
+            return;
+        };
+
+        let expanded = |i: usize| arg_expand.get(i).copied().unwrap_or(false);
+
+        // Skip leading declared option flags.  Stop at the first
+        // non-option word, the option terminator `--` (consumed), or
+        // a `{*}`-expanded word (whose value can't be classified).
+        let mut positional_start = 0usize;
+        if !sig.leading_options.is_empty() {
+            for (i, arg) in args.iter().enumerate() {
+                if expanded(i) {
+                    break;
+                }
+                if sig.leading_options.contains(arg) {
+                    positional_start = i + 1;
+                    if arg == "--" {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let positional_any_expand = (positional_start..args.len()).any(expanded);
+        // E003 lower bound: non-expanded positional words.  E002
+        // upper bound: the full positional count (only meaningful
+        // when no expansion is present — an unresolved expansion
+        // makes the upper bound unbounded, so E002 can't fire).
+        let nargs_min = if positional_any_expand {
+            (positional_start..args.len())
+                .filter(|&i| !expanded(i))
+                .count()
+        } else {
+            args.len() - positional_start
+        };
+        let min = usize::from(sig.arity.min);
+        let max = usize::from(sig.arity.max);
+
+        let full_span = match arg_tokens.last() {
+            Some(last) => tcl_lexer::Span::new(cmd_tok.span.start(), last.span.end()),
+            None => cmd_tok.span,
+        };
+
+        // Collect as a *candidate* keyed by command name; the
+        // post-walk [`Self::flush_arity_diagnostics`] drops it if the
+        // name is shadowed by a user proc / class / alias / ensemble /
+        // stub (resolved against the complete tables, so definition
+        // order doesn't matter).
+        if !positional_any_expand && (args.len() - positional_start) < min {
+            let got = args.len() - positional_start;
+            self.pending_arity.push((
+                cmd_name.to_string(),
+                super::types::Diagnostic {
+                    code: "E002".to_string(),
+                    span: full_span,
+                    message: format!(
+                        "Too few arguments for '{cmd_name}': expected at least {min}, got {got}"
+                    ),
+                    severity: Severity::Error,
+                    fixes: Vec::new(),
+                },
+            ));
+        } else if !sig.arity.is_unlimited() && nargs_min > max {
+            self.pending_arity.push((
+                cmd_name.to_string(),
+                super::types::Diagnostic {
+                    code: "E003".to_string(),
+                    span: full_span,
+                    message: format!(
+                        "Too many arguments for '{cmd_name}': expected at most {max}, got {nargs_min}"
+                    ),
+                    severity: Severity::Error,
+                    fixes: Vec::new(),
+                },
+            ));
+        }
+    }
+
+    /// Post-walk flush of the [`Self::pending_arity`] candidates
+    /// collected by [`Self::emit_arity_diagnostics`].
+    ///
+    /// Runs after the command walk completes, when `all_procs`,
+    /// `all_classes`, `command_aliases`, `ensemble_namespaces` and
+    /// the inline stub set are fully populated.  A candidate is
+    /// dropped when its command name matches the tail of a
+    /// user-defined proc / class / alias / ensemble command, or an
+    /// inline `# tcl-lsp: stub`, because the call resolves to that
+    /// user definition rather than the builtin whose registry arity
+    /// produced the candidate — this is what prevents false E003s on
+    /// e.g. a namespace that defines `proc ::ns::close { ... }` and
+    /// then calls `close ...` with the proc's wider arity.
+    ///
+    /// Idempotent: drains `pending_arity`, so a second call is a
+    /// no-op.  Mirrors the shadowing-set construction in
+    /// [`Self::emit_unresolved_command_diagnostics`].
+    pub fn flush_arity_diagnostics(&mut self) {
+        if self.pending_arity.is_empty() {
+            return;
+        }
+        let tail = |qn: &str| -> Option<String> {
+            qn.rsplit_once("::")
+                .map(|(_, t)| t.to_string())
+                .filter(|s| !s.is_empty())
+        };
+        let mut shadowed: std::collections::HashSet<String> = std::collections::HashSet::new();
+        shadowed.extend(self.result.all_procs.keys().filter_map(|q| tail(q)));
+        shadowed.extend(self.result.all_classes.keys().filter_map(|q| tail(q)));
+        shadowed.extend(self.result.command_aliases.keys().filter_map(|q| tail(q)));
+        shadowed.extend(self.ensemble_namespaces.iter().filter_map(|q| tail(q)));
+        shadowed.extend(super::utils::scan_stub_command_names(&self.source));
+        // Bare (unqualified) proc / alias names also shadow a builtin.
+        shadowed.extend(self.result.all_procs.keys().cloned());
+        shadowed.extend(self.result.command_aliases.keys().cloned());
+
+        let pending = std::mem::take(&mut self.pending_arity);
+        for (cmd_name, diag) in pending {
+            let bare = cmd_name.trim_start_matches("::");
+            if shadowed.contains(&cmd_name) || shadowed.contains(bare) {
+                continue;
+            }
+            self.result.diagnostics.push(diag);
+        }
+    }
+
     /// **E004.** Emit "Malformed `if` command" / "Extra words after
     /// `else` clause" errors when an `if` invocation's structural
     /// shape doesn't match `if COND BODY ?elseif COND BODY ...?
@@ -3781,6 +3967,104 @@ mod tests {
         );
         assert!(w004[0].message.contains("-command"));
         assert!(w004[0].message.contains("regsub"));
+    }
+
+    // -- SYNC-MAY21-3 (#460 / #455): E002 / E003 arity ---------------
+
+    #[test]
+    fn e003_not_emitted_for_leading_switches() {
+        // Regression for #455: declared option flags must be skipped
+        // before counting positional args.  `regsub` (max arity 4)
+        // previously tripped a false E003 once any switch appeared.
+        // These switches exist in every supported dialect.
+        for snippet in [
+            "regsub -all -line {x} $args {} str",
+            "regsub -all {a} $b {} c",
+            "regsub -nocase -all -- $pat $s {} out",
+        ] {
+            let mut a = Analyser::new();
+            let result = a.analyse(snippet, "tcl8.6");
+            let e003: Vec<&Diagnostic> = result
+                .diagnostics
+                .iter()
+                .filter(|d| d.code == "E003")
+                .collect();
+            assert!(e003.is_empty(), "unexpected E003 for {snippet:?}: {e003:?}");
+        }
+    }
+
+    #[test]
+    fn e003_fires_on_genuine_over_arity() {
+        // 5 positional args for `regsub` (max 4) is a real error.
+        let mut a = Analyser::new();
+        let result = a.analyse("regsub a b c d e", "tcl8.6");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == "E003"),
+            "expected E003, got {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn e003_switch_options_are_dialect_filtered() {
+        // `regsub -command` is Tcl 9.0+ (TIP 463).
+        // Under 9.0 it is a real switch → skipped → 4 positional → OK.
+        let mut a = Analyser::new();
+        let r9 = a.analyse("regsub -command a b c d", "tcl9.0");
+        assert!(
+            !r9.diagnostics.iter().any(|d| d.code == "E003"),
+            "unexpected E003 under tcl9.0: {:?}",
+            r9.diagnostics
+        );
+        // Under 8.6 `-command` is unknown → counted positional →
+        // 5 > max 4 → E003 (the #460 dialect-leak guard).
+        let mut a2 = Analyser::new();
+        let r8 = a2.analyse("regsub -command a b c d", "tcl8.6");
+        assert!(
+            r8.diagnostics.iter().any(|d| d.code == "E003"),
+            "expected E003 under tcl8.6, got {:?}",
+            r8.diagnostics
+        );
+    }
+
+    #[test]
+    fn e003_suppressed_by_expanded_word() {
+        // `{*}$rest` expands to an unknown count, so the expanded word
+        // is excluded from the positional lower bound: `regsub a b c d
+        // {*}$rest` has 4 non-expanded positional words (≤ max 4) and
+        // must not trip E003, whereas the same five literal words do.
+        let mut a = Analyser::new();
+        let expanded = a.analyse("regsub a b c d {*}$rest", "tcl8.6");
+        assert!(
+            !expanded.diagnostics.iter().any(|d| d.code == "E003"),
+            "expansion should suppress E003: {:?}",
+            expanded.diagnostics
+        );
+        let mut b = Analyser::new();
+        let literal = b.analyse("regsub a b c d e", "tcl8.6");
+        assert!(
+            literal.diagnostics.iter().any(|d| d.code == "E003"),
+            "control: five literal words should fire E003: {:?}",
+            literal.diagnostics
+        );
+    }
+
+    #[test]
+    fn e002_fires_on_too_few_args() {
+        // `regsub` requires at least 3 args (exp string subSpec).
+        let mut a = Analyser::new();
+        let result = a.analyse("regsub a b", "tcl8.6");
+        let e002: Vec<&Diagnostic> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "E002")
+            .collect();
+        assert!(
+            !e002.is_empty(),
+            "expected E002 for `regsub a b`, got {:?}",
+            result.diagnostics
+        );
+        assert!(e002[0].message.contains("at least 3"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -858,6 +858,7 @@ Consider capturing the result: catch {\u{2026}} result"
         arg_tokens: &[tcl_lexer::Token],
         arg_expand_in: &[bool],
         cmd_tok: tcl_lexer::Token,
+        scope_path: &[usize],
     ) {
         use super::dispatch::{signature_for_command, CommandSignature};
         use tcl_registry::prelude::DialectSet;
@@ -923,15 +924,26 @@ Consider capturing the result: catch {\u{2026}} result"
             None => cmd_tok.span,
         };
 
-        // Collect as a *candidate* keyed by command name; the
-        // post-walk [`Self::flush_arity_diagnostics`] drops it if the
-        // name is shadowed by a user proc / class / alias / ensemble /
-        // stub (resolved against the complete tables, so definition
-        // order doesn't matter).
+        // Capture the call-site command-resolution namespace so the
+        // post-walk flush can resolve this command the Tcl way (current
+        // namespace → global) and only suppress the arity check when
+        // the call actually resolves to a user definition — not to any
+        // same-tail-named proc elsewhere in the file. Uses the proc's
+        // *defining* namespace (so `close` inside a body of
+        // `proc ::ns::x` resolves through `::ns`), not just lexical
+        // `namespace eval` nesting.
+        let ns = self.command_resolution_namespace(scope_path);
+
+        // Collect as a *candidate*; the post-walk
+        // [`Self::flush_arity_diagnostics`] drops it if the call
+        // resolves to a user proc / class / alias / ensemble / stub
+        // (resolved against the complete tables, so definition order
+        // doesn't matter).
         if !positional_any_expand && (args.len() - positional_start) < min {
             let got = args.len() - positional_start;
             self.pending_arity.push((
                 cmd_name.to_string(),
+                ns,
                 super::types::Diagnostic {
                     code: "E002".to_string(),
                     span: full_span,
@@ -945,6 +957,7 @@ Consider capturing the result: catch {\u{2026}} result"
         } else if !sig.arity.is_unlimited() && nargs_min > max {
             self.pending_arity.push((
                 cmd_name.to_string(),
+                ns,
                 super::types::Diagnostic {
                     code: "E003".to_string(),
                     span: full_span,
@@ -962,42 +975,66 @@ Consider capturing the result: catch {\u{2026}} result"
     /// collected by [`Self::emit_arity_diagnostics`].
     ///
     /// Runs after the command walk completes, when `all_procs`,
-    /// `all_classes`, `command_aliases`, `ensemble_namespaces` and
-    /// the inline stub set are fully populated.  A candidate is
-    /// dropped when its command name matches the tail of a
-    /// user-defined proc / class / alias / ensemble command, or an
-    /// inline `# tcl-lsp: stub`, because the call resolves to that
-    /// user definition rather than the builtin whose registry arity
-    /// produced the candidate — this is what prevents false E003s on
-    /// e.g. a namespace that defines `proc ::ns::close { ... }` and
-    /// then calls `close ...` with the proc's wider arity.
+    /// `all_classes`, `command_aliases`, `ensemble_namespaces` and the
+    /// inline stub set are fully populated.  A candidate is dropped
+    /// only when the call **resolves to** a user definition rather than
+    /// the builtin whose registry arity produced it — resolution
+    /// follows Tcl's rule for unqualified commands (the call-site
+    /// namespace, then global `::`), using the namespace captured at
+    /// emit time.  So `proc ::ns::close {...}` suppresses a `close`
+    /// call inside `::ns` (and a qualified `::ns::close ...`), but a
+    /// `close` call in another namespace still resolves to the builtin
+    /// and is checked.  Document-global declarations — inline
+    /// `# tcl-lsp: stub`s — suppress by bare name regardless of
+    /// namespace.
     ///
     /// Idempotent: drains `pending_arity`, so a second call is a
-    /// no-op.  Mirrors the shadowing-set construction in
-    /// [`Self::emit_unresolved_command_diagnostics`].
+    /// no-op.
     pub fn flush_arity_diagnostics(&mut self) {
         if self.pending_arity.is_empty() {
             return;
         }
-        let tail = |qn: &str| -> Option<String> {
-            qn.rsplit_once("::")
-                .map(|(_, t)| t.to_string())
-                .filter(|s| !s.is_empty())
+        // Fully-qualified user-command names the calls may resolve to
+        // (procs / classes / aliases are keyed by qualified name;
+        // ensemble namespaces *are* the command name).
+        let mut user_qnames: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        user_qnames.extend(self.result.all_procs.keys().map(String::as_str));
+        user_qnames.extend(self.result.all_classes.keys().map(String::as_str));
+        user_qnames.extend(self.result.command_aliases.keys().map(String::as_str));
+        user_qnames.extend(self.ensemble_namespaces.iter().map(String::as_str));
+        // Inline stubs are document-global and unqualified.
+        let stub_names = super::utils::scan_stub_command_names(&self.source);
+
+        // Qualify an unqualified command against a namespace, mirroring
+        // `resolve_command_qualified_name` (`::` root → `::cmd`).
+        let join = |ns: &str, cmd: &str| -> String {
+            if ns == "::" {
+                format!("::{cmd}")
+            } else {
+                format!("{ns}::{cmd}")
+            }
         };
-        let mut shadowed: std::collections::HashSet<String> = std::collections::HashSet::new();
-        shadowed.extend(self.result.all_procs.keys().filter_map(|q| tail(q)));
-        shadowed.extend(self.result.all_classes.keys().filter_map(|q| tail(q)));
-        shadowed.extend(self.result.command_aliases.keys().filter_map(|q| tail(q)));
-        shadowed.extend(self.ensemble_namespaces.iter().filter_map(|q| tail(q)));
-        shadowed.extend(super::utils::scan_stub_command_names(&self.source));
-        // Bare (unqualified) proc / alias names also shadow a builtin.
-        shadowed.extend(self.result.all_procs.keys().cloned());
-        shadowed.extend(self.result.command_aliases.keys().cloned());
 
         let pending = std::mem::take(&mut self.pending_arity);
-        for (cmd_name, diag) in pending {
-            let bare = cmd_name.trim_start_matches("::");
-            if shadowed.contains(&cmd_name) || shadowed.contains(bare) {
+        for (cmd_name, ns, diag) in pending {
+            let bare = cmd_name.rsplit("::").next().unwrap_or(&cmd_name);
+            // Candidate qualified names this call could resolve to.
+            let candidates: Vec<String> = if cmd_name.contains("::") {
+                // Already qualified — absolutise like
+                // `resolve_command_qualified_name` does.
+                let abs = if cmd_name.starts_with("::") {
+                    cmd_name.clone()
+                } else {
+                    format!("::{cmd_name}")
+                };
+                vec![abs]
+            } else {
+                // Unqualified — current namespace, then global.
+                vec![join(&ns, &cmd_name), format!("::{cmd_name}")]
+            };
+            let resolves_to_user = candidates.iter().any(|c| user_qnames.contains(c.as_str()))
+                || stub_names.contains(bare);
+            if resolves_to_user {
                 continue;
             }
             self.result.diagnostics.push(diag);
@@ -4069,6 +4106,35 @@ mod tests {
             result.diagnostics
         );
         assert!(e002[0].message.contains("at least 3"));
+    }
+
+    #[test]
+    fn e003_shadow_is_namespace_scoped() {
+        // PR #472 review (Codex): a namespaced proc named `close` must
+        // NOT suppress arity checks on a *global* `close` call (which
+        // resolves to the builtin, max 2), but must suppress a `close`
+        // call inside its own namespace (which resolves to the proc).
+        let src = "proc ::ns::close {a b c d} {}\n\
+                   close x y z\n\
+                   namespace eval ::ns { close x y z }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let e003: Vec<&Diagnostic> = r.diagnostics.iter().filter(|d| d.code == "E003").collect();
+        assert_eq!(
+            e003.len(),
+            1,
+            "expected exactly one E003 (the global close), got {:?}",
+            r.diagnostics
+        );
+        // The flagged call must be the top-level one, before the
+        // `namespace eval` body (both call sites share the same text).
+        let ns_eval_off = src.find("namespace eval").unwrap();
+        let span = e003[0].span;
+        assert!(
+            (span.start() as usize) < ns_eval_off,
+            "flagged the namespaced call instead of the global one: {:?}",
+            &src[span.start() as usize..span.end() as usize],
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -901,10 +901,13 @@ Consider capturing the result: catch {\u{2026}} result"
         }
 
         let positional_any_expand = (positional_start..args.len()).any(expanded);
-        // E003 lower bound: non-expanded positional words.  E002
-        // upper bound: the full positional count (only meaningful
-        // when no expansion is present — an unresolved expansion
-        // makes the upper bound unbounded, so E002 can't fire).
+        // `nargs_min` is the *lower bound* on the positional-argument
+        // count: the non-expanded words, since each `{*}` word
+        // contributes 0..N more at runtime.  E003 ("too many") fires
+        // when even this lower bound exceeds `max`.  E002 ("too few")
+        // needs an *upper bound* on the count, which becomes unbounded
+        // once any `{*}` expansion is present — so E002 only fires when
+        // there is no expansion and the count is therefore exact.
         let nargs_min = if positional_any_expand {
             (positional_start..args.len())
                 .filter(|&i| !expanded(i))

--- a/rust/tcl-compiler/src/analyser/dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/dispatch.rs
@@ -20,7 +20,7 @@
 //! populates), so the Rust port skips it. If a future Python
 //! change starts populating ``SIGNATURES``, mirror the data here.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use tcl_registry::prelude::DialectSet;
 use tcl_registry::{ArgRole, Arity, CommandRegistry};
@@ -36,6 +36,13 @@ pub struct CommandSig {
     /// Static arg-index → role map (0-based, after the command
     /// name). Args not listed default to ``ArgRole::Value``.
     pub arg_roles: HashMap<u8, ArgRole>,
+    /// Declared option / switch names valid in the active dialect.
+    /// Leading arguments matching one of these are skipped before
+    /// counting positional args for the E002 / E003 arity check.
+    /// Mirrors ``CommandSig.leading_options`` in
+    /// ``core/commands/registry/signatures.py``; populated from
+    /// [`tcl_registry::CommandSpec::switch_names`] (dialect-filtered).
+    pub leading_options: BTreeSet<String>,
 }
 
 /// Signature for a command that dispatches on a subcommand word.
@@ -105,6 +112,11 @@ pub fn signature_for_command(
                 CommandSig {
                     arity: sub.arity,
                     arg_roles,
+                    // Subcommand-level arity checking isn't wired up
+                    // yet (only simple-command E002 / E003 fires), so
+                    // the per-subcommand option set is left empty until
+                    // that follow-up lands.
+                    leading_options: BTreeSet::new(),
                 },
             );
         }
@@ -119,9 +131,15 @@ pub fn signature_for_command(
         .iter()
         .map(|(idx, role)| (*idx, *role))
         .collect();
+    let leading_options = spec
+        .switch_names(Some(dialect))
+        .into_iter()
+        .map(str::to_string)
+        .collect();
     Some(CommandSignature::Simple(CommandSig {
         arity: spec.arity,
         arg_roles,
+        leading_options,
     }))
 }
 

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -46,6 +46,20 @@ fn scope_at<'a>(root: &'a Scope, path: &[usize]) -> Option<&'a Scope> {
     Some(cursor)
 }
 
+/// Append a namespace component `part` onto the absolute namespace
+/// `ns` (`"::"`-rooted), mirroring the join in
+/// [`Analyser::namespace_from_scope_path`]: an absolute `part` rebases,
+/// a relative one is appended.
+fn join_namespace(ns: &str, part: &str) -> String {
+    if part.starts_with("::") {
+        normalise_qualified_name(part)
+    } else if ns == "::" {
+        normalise_qualified_name(&format!("::{part}"))
+    } else {
+        normalise_qualified_name(&format!("{ns}::{part}"))
+    }
+}
+
 /// Mutable counterpart to [`scope_at`].
 pub(super) fn scope_at_mut<'a>(root: &'a mut Scope, path: &[usize]) -> Option<&'a mut Scope> {
     let mut cursor = root;
@@ -316,6 +330,49 @@ impl Analyser {
         };
         self.ns_cache.insert(scope_path.to_vec(), result.clone());
         result
+    }
+
+    /// Namespace in which an *unqualified* command invoked at
+    /// `scope_path` resolves, following Tcl's command-resolution rule:
+    /// the call's enclosing namespace, where a proc body resolves
+    /// commands in the proc's **defining** namespace (the prefix of its
+    /// qualified name) rather than its lexical parent.
+    ///
+    /// This differs from [`Self::namespace_from_scope_path`] (which is
+    /// purely lexical and ignores proc scopes): `proc ::ns::p {...}`
+    /// declared at top level has defining namespace `::ns`, so an
+    /// unqualified `foo` in its body resolves to `::ns::foo` then
+    /// `::foo` — even though there is no enclosing `namespace eval`.
+    /// Used to scope the E002/E003 arity shadow guard to the command a
+    /// call actually resolves to.
+    #[must_use]
+    pub(super) fn command_resolution_namespace(&self, scope_path: &[usize]) -> String {
+        let mut ns = "::".to_string();
+        let mut cursor = &self.result.global_scope;
+        for &idx in scope_path {
+            let Some(child) = cursor.children.get(idx) else {
+                break;
+            };
+            match child.kind {
+                ScopeKind::Namespace => ns = join_namespace(&ns, &child.name),
+                ScopeKind::Proc => {
+                    // The proc's defining namespace = prefix of its
+                    // (possibly relative) qualified name.
+                    let qualified = if child.name.starts_with("::") {
+                        normalise_qualified_name(&child.name)
+                    } else {
+                        join_namespace(&ns, &child.name)
+                    };
+                    ns = match qualified.rsplit_once("::") {
+                        Some((prefix, _)) if !prefix.is_empty() => prefix.to_string(),
+                        _ => "::".to_string(),
+                    };
+                }
+                ScopeKind::Global => {}
+            }
+            cursor = child;
+        }
+        ns
     }
 
     /// Record a variable read for go-to-definition / find-references.

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -75,7 +75,7 @@ pub struct AnalyserSnapshot {
     /// Pending E002 / E003 arity candidates (flushed post-walk).
     /// Snapshotted with `result` so a speculative rollback discards
     /// the candidates of any rolled-back commands.
-    pub pending_arity: Vec<(String, super::types::Diagnostic)>,
+    pub pending_arity: Vec<(String, String, super::types::Diagnostic)>,
 }
 
 impl Analyser {

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -72,6 +72,10 @@ pub struct AnalyserSnapshot {
     pub var_command_sites: Vec<VarCommandSite>,
     /// Command-substitution-as-command call sites.
     pub cmd_command_sites: Vec<CmdCommandSite>,
+    /// Pending E002 / E003 arity candidates (flushed post-walk).
+    /// Snapshotted with `result` so a speculative rollback discards
+    /// the candidates of any rolled-back commands.
+    pub pending_arity: Vec<(String, super::types::Diagnostic)>,
 }
 
 impl Analyser {
@@ -102,6 +106,7 @@ impl Analyser {
             regex_vars: self.regex_vars.clone(),
             var_command_sites: self.var_command_sites.clone(),
             cmd_command_sites: self.cmd_command_sites.clone(),
+            pending_arity: self.pending_arity.clone(),
         }
     }
 
@@ -133,6 +138,7 @@ impl Analyser {
         self.regex_vars = snap.regex_vars;
         self.var_command_sites = snap.var_command_sites;
         self.cmd_command_sites = snap.cmd_command_sites;
+        self.pending_arity = snap.pending_arity;
         // Cache invalidation — the namespace cache keys on scope
         // path identity, which the deep-copy disrupts.
         self.ns_cache.clear();

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -186,14 +186,18 @@ pub struct Analyser {
     /// call.  ``None`` outside an active analysis run.
     pub line_offsets: Option<Vec<usize>>,
     /// Candidate E002 / E003 arity diagnostics collected during the
-    /// command walk, paired with the command name.  Emitted in a
-    /// post-walk pass ([`Self::flush_arity_diagnostics`]) so a
-    /// command shadowed by a user-defined proc / class / alias /
-    /// ensemble / stub — which may be defined *after* its call site —
-    /// suppresses the builtin-arity check regardless of definition
-    /// order.  Mirrors Python running `_check_arity` over the
-    /// fully-resolved IR rather than inline during the walk.
-    pub pending_arity: Vec<(String, super::types::Diagnostic)>,
+    /// command walk, as `(command name, call-site namespace,
+    /// diagnostic)`.  Emitted in a post-walk pass
+    /// ([`Self::flush_arity_diagnostics`]) so a command that resolves
+    /// to a user-defined proc / class / alias / ensemble / stub —
+    /// which may be defined *after* its call site — suppresses the
+    /// builtin-arity check regardless of definition order.  The
+    /// namespace is captured so suppression is scoped to the command
+    /// the call actually resolves to (current namespace → global),
+    /// not to every same-tail-named definition anywhere in the file.
+    /// Mirrors Python running `_check_arity` over the fully-resolved
+    /// IR rather than inline during the walk.
+    pub pending_arity: Vec<(String, String, super::types::Diagnostic)>,
 }
 
 impl Analyser {

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -185,6 +185,15 @@ pub struct Analyser {
     /// per command) cost ``O(log N)`` instead of ``O(N)`` per
     /// call.  ``None`` outside an active analysis run.
     pub line_offsets: Option<Vec<usize>>,
+    /// Candidate E002 / E003 arity diagnostics collected during the
+    /// command walk, paired with the command name.  Emitted in a
+    /// post-walk pass ([`Self::flush_arity_diagnostics`]) so a
+    /// command shadowed by a user-defined proc / class / alias /
+    /// ensemble / stub — which may be defined *after* its call site —
+    /// suppresses the builtin-arity check regardless of definition
+    /// order.  Mirrors Python running `_check_arity` over the
+    /// fully-resolved IR rather than inline during the walk.
+    pub pending_arity: Vec<(String, super::types::Diagnostic)>,
 }
 
 impl Analyser {
@@ -228,6 +237,7 @@ impl Analyser {
             deep_param_traits: false,
             stub_overlay: None,
             line_offsets: None,
+            pending_arity: Vec::new(),
         }
     }
 
@@ -385,7 +395,13 @@ impl Analyser {
             // ``std::mem::take`` it; everything else clears it on
             // the next command.
             self.last_comment = cmd.preceding_comment.clone().unwrap_or_default();
-            self.process_command(&cmd.texts, &cmd.argv, &single, &[]);
+            self.process_command(
+                &cmd.texts,
+                &cmd.argv,
+                &single,
+                cmd.expand_word.as_deref().unwrap_or(&[]),
+                &[],
+            );
             self.record_arg_var_reads(&cmd, &[]);
             cmd_idx += 1 + consumed;
         }
@@ -412,6 +428,7 @@ impl Analyser {
             diag_registry.load_dialect(d);
         }
         self.emit_unresolved_command_diagnostics(&diag_registry);
+        self.flush_arity_diagnostics();
         self.emit_missing_package_require_diagnostics(&diag_registry);
         self.emit_variable_usage_diagnostics();
         self.emit_cfg_ssa_diagnostics(source);
@@ -505,6 +522,7 @@ impl Analyser {
             diag_registry.load_dialect(d);
         }
         self.emit_unresolved_command_diagnostics(&diag_registry);
+        self.flush_arity_diagnostics();
         self.emit_missing_package_require_diagnostics(&diag_registry);
         self.emit_variable_usage_diagnostics();
         self.emit_cfg_ssa_diagnostics(source);
@@ -582,6 +600,7 @@ impl Analyser {
                 diag_registry.load_dialect(d);
             }
             self.emit_unresolved_command_diagnostics(&diag_registry);
+            self.flush_arity_diagnostics();
             self.emit_missing_package_require_diagnostics(&diag_registry);
             self.emit_variable_usage_diagnostics();
             self.emit_cfg_ssa_diagnostics(source);
@@ -642,7 +661,13 @@ impl Analyser {
                 );
             }
             self.last_comment = cmd.preceding_comment.clone().unwrap_or_default();
-            self.process_command(&cmd.texts, &cmd.argv, &cmd.single_token_word, &scope_path);
+            self.process_command(
+                &cmd.texts,
+                &cmd.argv,
+                &cmd.single_token_word,
+                cmd.expand_word.as_deref().unwrap_or(&[]),
+                &scope_path,
+            );
             self.record_arg_var_reads(&cmd, &scope_path);
             cmd_idx += 1 + consumed;
         }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1697,25 +1697,20 @@ mod tests {
     }
 
     #[test]
-    fn analyse_w302_anchors_at_command_range() {
-        // The W302 span runs from the catch keyword through (at
-        // least) the body argument's content, mirroring Python's
-        // ``stmt.range`` (the IRCatch's full source range).  The
-        // closing brace's inclusion depends on the lexer's
-        // ``Str``-token end convention; what matters for the LSP
-        // UX is that the span starts at ``catch`` and covers the
-        // body text rather than just the catch keyword.
+    fn analyse_w302_anchors_at_catch_keyword() {
+        // SYNC-MAY21-4 (#464): W302 highlights just the ``catch``
+        // command token — the narrowest span that identifies the
+        // issue — rather than the whole ``catch {…}`` statement
+        // (which also dropped the closing brace under the lexer's
+        // inner-end convention).
         let mut a = Analyser::new();
         let src = "catch { puts hi }\n";
         let r = a.analyse(src, "tcl");
         let w302: Vec<_> = r.diagnostics.iter().filter(|d| d.code == "W302").collect();
         assert_eq!(w302.len(), 1);
         let span = w302[0].span;
-        let start = span.start() as usize;
-        let end = span.end() as usize;
-        let text = &src[start..end];
-        assert!(text.starts_with("catch"), "span starts at {text:?}");
-        assert!(text.contains("puts hi"), "span text {text:?}");
+        let text = &src[span.start() as usize..span.end() as usize];
+        assert_eq!(text, "catch", "W302 should span only the catch keyword");
     }
 
     // -- ``postpass`` chunk: W001 unknown-subcommand emitter

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -218,31 +218,48 @@ impl Function {
     /// RPO is the standard traversal order for forward dataflow
     /// analyses: every block is visited after all its non-back-edge
     /// predecessors.
+    ///
+    /// Implemented with an explicit work stack rather than recursion so
+    /// it cannot overflow the thread stack on a degenerate CFG — a
+    /// single huge proc (e.g. a machine-generated multi-thousand-branch
+    /// dispatch table) lowers to a block chain tens of thousands deep,
+    /// which a recursive DFS overflows at the common 2 MB worker-thread
+    /// stack size. This is the one shared RPO used by every CFG/SSA
+    /// pass (dominators, SCCP, type / taint / rendered-property
+    /// propagation, GVN, `cfg_order`), so keeping it iterative keeps
+    /// all of them bounded.
     #[must_use]
     pub fn reverse_postorder(&self) -> Vec<String> {
-        let mut visited = HashSet::new();
-        let mut postorder = Vec::new();
-        self.dfs_postorder(&self.entry, &mut visited, &mut postorder);
-        postorder.reverse();
-        postorder
-    }
-
-    /// Depth-first postorder traversal helper.
-    fn dfs_postorder(
-        &self,
-        name: &str,
-        visited: &mut HashSet<String>,
-        postorder: &mut Vec<String>,
-    ) {
-        if !visited.insert(name.to_owned()) {
-            return;
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut postorder: Vec<String> = Vec::new();
+        // Each frame is (block name, index of the next successor to
+        // visit); a frame moves to `postorder` once all its successors
+        // have been pushed — yielding the same order as the recursive
+        // post-order DFS, then reversed.
+        let mut stack: Vec<(String, usize)> = Vec::new();
+        if self.blocks.contains_key(&self.entry) {
+            visited.insert(self.entry.clone());
+            stack.push((self.entry.clone(), 0));
         }
-        if let Some(block) = self.blocks.get(name) {
-            for succ in block.successors() {
-                self.dfs_postorder(succ, visited, postorder);
+        while let Some((name, succ_idx)) = stack.last().cloned() {
+            let succs: Vec<String> = self
+                .blocks
+                .get(&name)
+                .map(|b| b.successors().into_iter().map(str::to_owned).collect())
+                .unwrap_or_default();
+            if succ_idx < succs.len() {
+                stack.last_mut().unwrap().1 += 1;
+                let next = &succs[succ_idx];
+                if visited.insert(next.clone()) {
+                    stack.push((next.clone(), 0));
+                }
+            } else {
+                postorder.push(name);
+                stack.pop();
             }
         }
-        postorder.push(name.to_owned());
+        postorder.reverse();
+        postorder
     }
 }
 

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -230,32 +230,53 @@ impl Function {
     /// all of them bounded.
     #[must_use]
     pub fn reverse_postorder(&self) -> Vec<String> {
+        // Each frame caches the block's successor list — computed once
+        // when the frame is pushed — alongside the index of the next
+        // successor to visit, so advancing through them doesn't
+        // recompute/reallocate the list on every loop iteration (which
+        // matters on the large CFGs this iterative form exists to make
+        // safe). A frame moves to `postorder` once all its successors
+        // have been pushed — the recursive post-order DFS order,
+        // reversed.
+        struct Frame {
+            name: String,
+            succs: Vec<String>,
+            idx: usize,
+        }
+        let succs_of = |name: &str| -> Vec<String> {
+            self.blocks
+                .get(name)
+                .map(|b| b.successors().into_iter().map(str::to_owned).collect())
+                .unwrap_or_default()
+        };
+
         let mut visited: HashSet<String> = HashSet::new();
         let mut postorder: Vec<String> = Vec::new();
-        // Each frame is (block name, index of the next successor to
-        // visit); a frame moves to `postorder` once all its successors
-        // have been pushed — yielding the same order as the recursive
-        // post-order DFS, then reversed.
-        let mut stack: Vec<(String, usize)> = Vec::new();
+        let mut stack: Vec<Frame> = Vec::new();
         if self.blocks.contains_key(&self.entry) {
             visited.insert(self.entry.clone());
-            stack.push((self.entry.clone(), 0));
+            stack.push(Frame {
+                name: self.entry.clone(),
+                succs: succs_of(&self.entry),
+                idx: 0,
+            });
         }
-        while let Some((name, succ_idx)) = stack.last().cloned() {
-            let succs: Vec<String> = self
-                .blocks
-                .get(&name)
-                .map(|b| b.successors().into_iter().map(str::to_owned).collect())
-                .unwrap_or_default();
-            if succ_idx < succs.len() {
-                stack.last_mut().unwrap().1 += 1;
-                let next = &succs[succ_idx];
+        while let Some(frame) = stack.last_mut() {
+            if frame.idx < frame.succs.len() {
+                let next = frame.succs[frame.idx].clone();
+                frame.idx += 1;
                 if visited.insert(next.clone()) {
-                    stack.push((next.clone(), 0));
+                    let succs = succs_of(&next);
+                    stack.push(Frame {
+                        name: next,
+                        succs,
+                        idx: 0,
+                    });
                 }
             } else {
-                postorder.push(name);
+                let name = std::mem::take(&mut frame.name);
                 stack.pop();
+                postorder.push(name);
             }
         }
         postorder.reverse();

--- a/rust/tcl-compiler/src/segmenter.rs
+++ b/rust/tcl-compiler/src/segmenter.rs
@@ -130,14 +130,46 @@ pub fn word_piece(sm: &SourceMap<'_>, tok: Token) -> String {
     }
 }
 
-/// Compute the span covering all tokens.
-fn span_from_tokens(tokens: &[Token]) -> Span {
+/// Compute the whole-command span, widening the final word to cover its
+/// closing delimiter.
+///
+/// Mirrors `core/parsing/command_segmenter.py::_command_range`, which extends
+/// the end via `range_from_word_token`. The lexer follows an "inner-end"
+/// span convention: a braced (`{…}`) or bracketed (`[…]`) word token's
+/// `span.end()` is the *exclusive* offset of the closing `}` / `]`, so the
+/// closer itself sits one byte past the end. A command whose final word is
+/// braced (`if {$x} {body}`) would therefore drop the trailing `}` from its
+/// whole-command range. Widen the end by one byte when the last token is a
+/// `Str` / `Cmd` whose closer actually sits at `span.end()`.
+///
+/// The closer character is derived from the token *type* (Python's
+/// `range_from_word_token`); the single source byte at `span.end()` is only
+/// inspected to skip the degenerate `{}` / `[]` forms, whose span already
+/// covers the closer (the lexer extends those by one), so the byte at
+/// `span.end()` is whatever follows the word, not the closer.
+fn command_span(tokens: &[Token], source: &str) -> Span {
     if tokens.is_empty() {
         return Span::new(0, 0);
     }
     let start = tokens.first().unwrap().span.start();
-    let end = tokens.last().unwrap().span.end();
+    let end = widen_word_end(*tokens.last().unwrap(), source);
     Span::new(start, end)
+}
+
+/// Exclusive end offset of `tok` including its closing delimiter, for the
+/// braced / bracketed word forms. See [`command_span`].
+fn widen_word_end(tok: Token, source: &str) -> u32 {
+    let closer = match tok.kind {
+        TokenType::Str => b'}',
+        TokenType::Cmd => b']',
+        _ => return tok.span.end(),
+    };
+    let end = tok.span.end();
+    if source.as_bytes().get(end as usize) == Some(&closer) {
+        end + 1
+    } else {
+        end
+    }
 }
 
 /// Segment a token stream into per-command structures at EOL boundaries.
@@ -370,7 +402,7 @@ impl SegmenterState {
     fn flush_eol_or_eof(&mut self, tok: Token, sm: &SourceMap<'_>) {
         if !self.argv.is_empty() {
             self.commands.push(SegmentedCommand {
-                span: span_from_tokens(&self.all_tokens),
+                span: command_span(&self.all_tokens, sm.source()),
                 argv: std::mem::take(&mut self.argv),
                 texts: std::mem::take(&mut self.texts),
                 single_token_word: std::mem::take(&mut self.single),
@@ -503,7 +535,7 @@ fn segment_commands_local(source: &str) -> Vec<SegmentedCommand> {
             mut last_comment,
         } = state;
         commands.push(SegmentedCommand {
-            span: span_from_tokens(&all_tokens),
+            span: command_span(&all_tokens, source),
             argv,
             texts,
             single_token_word: single,
@@ -663,6 +695,63 @@ mod tests {
     fn blank_lines_between_commands() {
         let cmds = segment_commands("set x 1\n\nset y 2");
         assert_eq!(cmds.len(), 2);
+    }
+
+    // -- SYNC-MAY21-1 (#470): whole-command range covers the last
+    //    word's closing delimiter ----------------------------------
+
+    #[test]
+    fn command_span_includes_trailing_brace() {
+        // `if {$x} {body}` — the final word is a braced body whose
+        // STR token stops on the `}`. The whole-command span must
+        // reach past the closer so consumers don't drop it.
+        let src = "if {$x} {body}";
+        let cmds = segment_commands(src);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(&src[cmds[0].span.as_range()], "if {$x} {body}");
+    }
+
+    #[test]
+    fn command_span_includes_trailing_bracket() {
+        // Final word is a command substitution `[...]`; the CMD
+        // token stops on `]`, so the span must include it.
+        let src = "set x [expr 1+2]";
+        let cmds = segment_commands(src);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(&src[cmds[0].span.as_range()], "set x [expr 1+2]");
+    }
+
+    #[test]
+    fn command_span_includes_multiline_closing_brace() {
+        // Multi-line braced body — the closer is on its own line.
+        let src = "proc f {} {\n  set x 1\n}";
+        let cmds = segment_commands(src);
+        assert_eq!(cmds.len(), 1);
+        assert!(
+            src[cmds[0].span.as_range()].ends_with('}'),
+            "span text: {:?}",
+            &src[cmds[0].span.as_range()],
+        );
+    }
+
+    #[test]
+    fn command_span_unaffected_by_degenerate_empty_brace() {
+        // Degenerate `{}` already covers its closer in the token
+        // span (the lexer extends it by one), so widening must not
+        // over-reach past the `}`.
+        let src = "proc f {}";
+        let cmds = segment_commands(src);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(&src[cmds[0].span.as_range()], "proc f {}");
+    }
+
+    #[test]
+    fn command_span_unaffected_for_plain_last_word() {
+        // A bare-word final argument has no closer to widen.
+        let src = "set x 1";
+        let cmds = segment_commands(src);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(&src[cmds[0].span.as_range()], "set x 1");
     }
 }
 

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -259,46 +259,6 @@ pub fn compute_dominators(func: &cfg::Function) -> HashMap<String, HashSet<Strin
     dom
 }
 
-/// Iterative reverse-postorder over the blocks reachable from the
-/// entry, returning block names with the entry first.
-///
-/// Equivalent to [`cfg::Function::reverse_postorder`] but uses an
-/// explicit work stack instead of recursion, so it can't overflow the
-/// thread stack on a degenerate CFG (e.g. the single ~70k-line proc in
-/// machine-generated dispatch tables, whose CFG is tens of thousands
-/// of blocks deep).
-fn reverse_postorder_iter(func: &cfg::Function) -> Vec<String> {
-    let mut postorder: Vec<String> = Vec::new();
-    let mut visited: HashSet<String> = HashSet::new();
-    // Each stack frame: (block name, index of the next successor to
-    // visit). A frame is popped to postorder once all its successors
-    // have been pushed.
-    let mut stack: Vec<(String, usize)> = Vec::new();
-    if func.blocks.contains_key(&func.entry) {
-        visited.insert(func.entry.clone());
-        stack.push((func.entry.clone(), 0));
-    }
-    while let Some((name, succ_idx)) = stack.last().cloned() {
-        let succs: Vec<String> = func
-            .blocks
-            .get(&name)
-            .map(|b| b.successors().into_iter().map(str::to_owned).collect())
-            .unwrap_or_default();
-        if succ_idx < succs.len() {
-            stack.last_mut().unwrap().1 += 1;
-            let next = &succs[succ_idx];
-            if visited.insert(next.clone()) {
-                stack.push((next.clone(), 0));
-            }
-        } else {
-            postorder.push(name);
-            stack.pop();
-        }
-    }
-    postorder.reverse();
-    postorder
-}
-
 /// Compute immediate dominators directly via the Cooper-Harvey-Kennedy
 /// "A Simple, Fast Dominance Algorithm".
 ///
@@ -316,7 +276,8 @@ fn reverse_postorder_iter(func: &cfg::Function) -> Vec<String> {
 pub(crate) fn compute_idom_fast(func: &cfg::Function) -> HashMap<String, Option<String>> {
     const UNDEF: usize = usize::MAX;
 
-    let rpo = reverse_postorder_iter(func);
+    // Shared iterative RPO — see `cfg::Function::reverse_postorder`.
+    let rpo = func.reverse_postorder();
     let mut out: HashMap<String, Option<String>> = HashMap::new();
     for name in func.blocks.keys() {
         out.insert(name.clone(), None);

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -195,6 +195,16 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
 ///
 /// Uses the iterative dataflow algorithm. Returns a map from block
 /// name to the set of blocks that dominate it.
+///
+/// The fixpoint visits blocks in **reverse postorder** so that each
+/// block is processed after the predecessors it depends on, which is
+/// what makes the iteration converge in a small constant number of
+/// passes for a reducible CFG instead of one pass per block.  Driving
+/// the fixpoint off the reachable-block *set* (arbitrary hash order)
+/// instead made convergence O(blocks) passes — pathological on a proc
+/// body that lowers to a long chain of branches (e.g. a 700-way
+/// `if {$x == N} {...}` dispatch), where it turned an O(N²) job into
+/// O(N³) and stalled the analyser.
 #[must_use]
 pub fn compute_dominators(func: &cfg::Function) -> HashMap<String, HashSet<String>> {
     let reachable = func.reachable_blocks();
@@ -208,11 +218,15 @@ pub fn compute_dominators(func: &cfg::Function) -> HashMap<String, HashSet<Strin
         }
     }
 
+    // Reverse postorder over blocks reachable from the entry — this is
+    // exactly the reachable set, ordered so predecessors precede the
+    // blocks that depend on them.
+    let rpo = func.reverse_postorder();
     let preds = func.predecessors();
     let mut changed = true;
     while changed {
         changed = false;
-        for name in &reachable {
+        for name in &rpo {
             if *name == func.entry {
                 continue;
             }
@@ -245,10 +259,144 @@ pub fn compute_dominators(func: &cfg::Function) -> HashMap<String, HashSet<Strin
     dom
 }
 
+/// Iterative reverse-postorder over the blocks reachable from the
+/// entry, returning block names with the entry first.
+///
+/// Equivalent to [`cfg::Function::reverse_postorder`] but uses an
+/// explicit work stack instead of recursion, so it can't overflow the
+/// thread stack on a degenerate CFG (e.g. the single ~70k-line proc in
+/// machine-generated dispatch tables, whose CFG is tens of thousands
+/// of blocks deep).
+fn reverse_postorder_iter(func: &cfg::Function) -> Vec<String> {
+    let mut postorder: Vec<String> = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    // Each stack frame: (block name, index of the next successor to
+    // visit). A frame is popped to postorder once all its successors
+    // have been pushed.
+    let mut stack: Vec<(String, usize)> = Vec::new();
+    if func.blocks.contains_key(&func.entry) {
+        visited.insert(func.entry.clone());
+        stack.push((func.entry.clone(), 0));
+    }
+    while let Some((name, succ_idx)) = stack.last().cloned() {
+        let succs: Vec<String> = func
+            .blocks
+            .get(&name)
+            .map(|b| b.successors().into_iter().map(str::to_owned).collect())
+            .unwrap_or_default();
+        if succ_idx < succs.len() {
+            stack.last_mut().unwrap().1 += 1;
+            let next = &succs[succ_idx];
+            if visited.insert(next.clone()) {
+                stack.push((next.clone(), 0));
+            }
+        } else {
+            postorder.push(name);
+            stack.pop();
+        }
+    }
+    postorder.reverse();
+    postorder
+}
+
+/// Compute immediate dominators directly via the Cooper-Harvey-Kennedy
+/// "A Simple, Fast Dominance Algorithm".
+///
+/// Returns the same map shape as [`compute_idom`] (entry and
+/// unreachable blocks map to `None`, every other reachable block to
+/// `Some(parent)`), but **without** materialising the full dominator
+/// *sets*: it works on reverse-postorder block indices and a single
+/// `idom` pointer per block, so it is O(N·D) time and O(N) memory
+/// rather than the O(N²) memory / O(N³) worst-case time of the
+/// set-based [`compute_dominators`] + [`compute_idom`] pair.  This is
+/// what keeps `build_ssa` bounded on pathologically large functions
+/// (a single multi-thousand-branch generated proc would otherwise
+/// exhaust memory building the dominator sets).
+#[must_use]
+pub(crate) fn compute_idom_fast(func: &cfg::Function) -> HashMap<String, Option<String>> {
+    const UNDEF: usize = usize::MAX;
+
+    let rpo = reverse_postorder_iter(func);
+    let mut out: HashMap<String, Option<String>> = HashMap::new();
+    for name in func.blocks.keys() {
+        out.insert(name.clone(), None);
+    }
+    if rpo.is_empty() {
+        return out;
+    }
+    // Map block name → reverse-postorder index (entry == 0).
+    let mut rpo_index: HashMap<&str, usize> = HashMap::with_capacity(rpo.len());
+    for (i, n) in rpo.iter().enumerate() {
+        rpo_index.insert(n.as_str(), i);
+    }
+    let preds = func.predecessors();
+
+    let mut idom: Vec<usize> = vec![UNDEF; rpo.len()];
+    idom[0] = 0; // entry is its own dominator (sentinel for the walk).
+
+    // Walk up the idom tree from both nodes until they meet, using
+    // RPO indices (a dominator always has a strictly smaller index).
+    let intersect = |mut a: usize, mut b: usize, idom: &[usize]| -> usize {
+        while a != b {
+            while a > b {
+                a = idom[a];
+            }
+            while b > a {
+                b = idom[b];
+            }
+        }
+        a
+    };
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        // Skip the entry (index 0); process the rest in RPO order so
+        // each block sees already-processed predecessors.
+        for i in 1..rpo.len() {
+            let mut new_idom = UNDEF;
+            if let Some(ps) = preds.get(&rpo[i]) {
+                for p in ps {
+                    let Some(&pi) = rpo_index.get(p.as_str()) else {
+                        continue; // unreachable predecessor
+                    };
+                    if idom[pi] == UNDEF {
+                        continue; // not processed yet this pass
+                    }
+                    new_idom = if new_idom == UNDEF {
+                        pi
+                    } else {
+                        intersect(pi, new_idom, &idom)
+                    };
+                }
+            }
+            if new_idom != UNDEF && idom[i] != new_idom {
+                idom[i] = new_idom;
+                changed = true;
+            }
+        }
+    }
+
+    for (i, name) in rpo.iter().enumerate() {
+        if i == 0 || idom[i] == UNDEF {
+            out.insert(name.clone(), None);
+        } else {
+            out.insert(name.clone(), Some(rpo[idom[i]].clone()));
+        }
+    }
+    out
+}
+
 /// Compute immediate dominators from dominator sets.
 ///
 /// The immediate dominator of a block is the closest strict dominator
 /// (the one with the largest dominator set).
+///
+/// Retained as the reference set-based implementation that
+/// [`compute_idom_fast`] (the production path) is cross-validated
+/// against; see the `compute_idom_fast_matches_reference` test. Only
+/// the fast path is used in production, so this is compiled for tests.
+#[cfg(test)]
 #[must_use]
 pub(crate) fn compute_idom(
     func: &cfg::Function,
@@ -678,9 +826,12 @@ enum RenamePhase {
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn build_ssa(func: &cfg::Function, registry: &CommandRegistry) -> SsaFunction {
-    // 1. Compute dominance information.
-    let dom = compute_dominators(func);
-    let idom = compute_idom(func, &dom);
+    // 1. Compute dominance information.  Use the Cooper-Harvey-
+    //    Kennedy immediate-dominator algorithm directly — it is
+    //    O(N) memory, where the set-based `compute_dominators` is
+    //    O(N²) and exhausts memory on a single huge generated proc
+    //    (tens of thousands of CFG blocks).
+    let idom = compute_idom_fast(func);
     let df = compute_dominance_frontier(func, &idom);
     let tree = build_dom_tree(&idom);
     let phi_vars = compute_phi_vars(func, &df, registry);
@@ -1270,6 +1421,54 @@ mod tests {
         assert_eq!(idom["header"], Some("entry".into()));
         assert_eq!(idom["body"], Some("header".into()));
         assert_eq!(idom["end"], Some("header".into()));
+    }
+
+    #[test]
+    fn compute_idom_fast_matches_reference() {
+        // The production CHK path (`compute_idom_fast`) must produce
+        // exactly the same immediate dominators as the set-based
+        // reference (`compute_idom` over `compute_dominators`) across
+        // linear / diamond / loop shapes.
+        let mut linear = Function::new("::test", "entry");
+        linear.blocks.get_mut("entry").unwrap().terminator = Some(make_goto("b1"));
+        linear.blocks.insert("b1".into(), Block::new("b1"));
+        linear.blocks.get_mut("b1").unwrap().terminator = Some(make_goto("b2"));
+        linear.blocks.insert("b2".into(), Block::new("b2"));
+        linear.blocks.get_mut("b2").unwrap().terminator = Some(make_return());
+
+        for func in [linear, diamond_cfg(), loop_cfg()] {
+            let reference = compute_idom(&func, &compute_dominators(&func));
+            let fast = compute_idom_fast(&func);
+            assert_eq!(fast, reference, "CHK idom diverged for {:?}", func.entry);
+        }
+    }
+
+    #[test]
+    fn compute_idom_fast_handles_long_chain_without_blowup() {
+        // A long chain of `if`-style diamonds (the shape a big
+        // generated dispatch proc lowers to) must compute quickly via
+        // CHK — this is the regression for the analyser stalling /
+        // OOMing on machine-generated files.
+        let mut func = Function::new("::big", "b0");
+        let n = 4000;
+        for i in 0..n {
+            let cur = format!("b{i}");
+            let then = format!("t{i}");
+            let next = format!("b{}", i + 1);
+            func.blocks
+                .entry(cur.clone())
+                .or_insert_with(|| Block::new(&cur));
+            func.blocks.insert(then.clone(), Block::new(&then));
+            func.blocks.get_mut(&then).unwrap().terminator = Some(make_return());
+            func.blocks.insert(next.clone(), Block::new(&next));
+            func.blocks.get_mut(&cur).unwrap().terminator = Some(make_branch("c", &then, &next));
+        }
+        func.blocks.get_mut(&format!("b{n}")).unwrap().terminator = Some(make_return());
+        let idom = compute_idom_fast(&func);
+        // Each chain block's idom is the previous chain block.
+        assert_eq!(idom["b1"], Some("b0".into()));
+        assert_eq!(idom[&format!("b{n}")], Some(format!("b{}", n - 1)));
+        assert_eq!(idom["b0"], None);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -384,7 +384,17 @@ fn word_taint(
             rest = &rest[open..];
             if let Some(close) = rest.find(']') {
                 let sub = &rest[..=close];
-                t = t.join(word_taint(sub, uses, taints, ctx));
+                // Only recurse when the bracketed slice is strictly
+                // smaller than the word being analysed — i.e. it's a
+                // substitution *embedded* in surrounding text. When the
+                // whole word is itself the bracketed region it was
+                // already handled by the command-substitution branch
+                // above; recursing on it again (e.g. the empty `[]`
+                // inside `{[]}`) makes no progress and would recurse
+                // until the stack overflows.
+                if sub.len() < stripped.len() {
+                    t = t.join(word_taint(sub, uses, taints, ctx));
+                }
                 rest = &rest[close + 1..];
             } else {
                 break;

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -898,7 +898,7 @@ mod tests {
         assert!(!edits.is_empty(), "expected array rename edits");
         let texts: Vec<&str> = edits.iter().map(|e| e.new_text.as_str()).collect();
         assert!(
-            texts.iter().any(|t| *t == "$data(0)"),
+            texts.contains(&"$data(0)"),
             "reference edit must preserve the array index, got {texts:?}",
         );
     }
@@ -914,7 +914,7 @@ mod tests {
         assert!(!edits.is_empty(), "expected braced array rename edits");
         let texts: Vec<&str> = edits.iter().map(|e| e.new_text.as_str()).collect();
         assert!(
-            texts.iter().any(|t| *t == "${data(0)}"),
+            texts.contains(&"${data(0)}"),
             "braced reference edit must preserve the array index, got {texts:?}",
         );
     }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -513,6 +513,34 @@ mod tests {
     }
 
     #[test]
+    fn switch_names_is_dialect_filtered() {
+        use crate::dialects::DialectSet;
+        let reg = CommandRegistry::build_default();
+        let regsub = reg.get("regsub").expect("regsub spec");
+        // `-command` is Tcl 9.0+ (TIP 463); the always-available
+        // switches appear in every dialect.
+        let in_86 = regsub.switch_names(Some(DialectSet::TCL86));
+        assert!(in_86.contains(&"-all"), "{in_86:?}");
+        assert!(in_86.contains(&"-nocase"), "{in_86:?}");
+        assert!(
+            !in_86.contains(&"-command"),
+            "9.0-only -command leaked into 8.6: {in_86:?}",
+        );
+        let in_90 = regsub.switch_names(Some(DialectSet::TCL90));
+        assert!(
+            in_90.contains(&"-command"),
+            "-command missing under 9.0: {in_90:?}",
+        );
+        // No filter → every declared option, no duplicates.
+        let all = regsub.switch_names(None);
+        assert!(all.contains(&"-command"));
+        let mut dedup = all.clone();
+        dedup.sort_unstable();
+        dedup.dedup();
+        assert_eq!(dedup.len(), all.len(), "switch_names returned duplicates");
+    }
+
+    #[test]
     fn tcl9_commands_from_pr_433_are_registered() {
         // SYNC-MAY19-tcl9-commands: mirrors PR #433 (0f9288d2).
         let reg = CommandRegistry::build_default();

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -203,6 +203,43 @@ impl CommandSpec {
             Some(ds) => ds.intersects(dialect),
         }
     }
+
+    /// Declared option / switch names valid in `dialect`, in
+    /// declaration order with duplicates removed.
+    ///
+    /// Mirrors `CommandSpec.switch_names` in
+    /// `core/commands/registry/models.py`: walks the command's
+    /// declared options (both the flat [`Self::options`] list and
+    /// every [`CommandForm`](crate::CommandForm)'s options) and keeps
+    /// only those whose [`OptionSpec::supports_dialect`] holds for
+    /// `dialect`, inheriting the command's own [`Self::dialects`] as
+    /// the parent set. `dialect == None` means "no dialect filter"
+    /// (every declared option is returned).
+    ///
+    /// Used by the analyser's option-aware arity check: leading
+    /// arguments that match one of these names are skipped before
+    /// counting positional args, so option flags introduced in a
+    /// later Tcl release don't leak into an earlier dialect's
+    /// signature and get wrongly skipped (e.g. `regsub -command` is
+    /// 9.0-only).
+    #[must_use]
+    pub fn switch_names(&self, dialect: Option<DialectSet>) -> Vec<&'static str> {
+        let mut names: Vec<&'static str> = Vec::new();
+        let consider = |opt: &OptionSpec, names: &mut Vec<&'static str>| {
+            if opt.supports_dialect(dialect, self.dialects) && !names.contains(&opt.name) {
+                names.push(opt.name);
+            }
+        };
+        for opt in self.options {
+            consider(opt, &mut names);
+        }
+        for form in self.command_forms {
+            for opt in form.options {
+                consider(opt, &mut names);
+            }
+        }
+        names
+    }
 }
 
 /// Complete metadata for a single subcommand.


### PR DESCRIPTION
## Summary

Lands three SYNC-MAY21 fixes from the Python compiler:

1. **E002/E003 arity validation (SYNC-MAY21-3, #460/#455):** Implements simple-command argument-count checking with dialect-filtered option skipping. Candidates are collected during the walk and flushed post-walk to suppress false positives when a builtin is shadowed by a user-defined proc/class/alias/ensemble/stub. Includes regression tests for leading switches, dialect filtering, expansion suppression, and genuine over/under-arity.

2. **Segmenter whole-command span (SYNC-MAY21-1, #470):** Fixes the command span to include the closing delimiter of braced/bracketed final words. The lexer uses an "inner-end" convention where `Str`/`Cmd` token spans exclude the closer, so the span must be widened by one byte when the closer sits at `span.end()`. Mirrors Python's `_command_range` → `range_from_word_token` logic.

3. **CFG/SSA performance (dominators, reverse postorder):** Replaces recursive DFS with iterative stack-based reverse postorder to prevent stack overflow on degenerate CFGs (e.g., machine-generated multi-thousand-branch dispatch tables). Introduces `compute_idom_fast` (Cooper-Harvey-Kennedy algorithm) to compute immediate dominators in O(N) memory instead of O(N²), keeping `build_ssa` bounded on pathologically large functions. Fixes the dominator fixpoint to iterate in reverse postorder rather than arbitrary hash order, reducing convergence from O(blocks) passes to constant.

## Validation

- Added 8 regression tests for E002/E003 (leading switches, dialect filtering, expansion, over/under-arity)
- Added 5 tests for segmenter span widening (braced/bracketed/multiline/degenerate/plain words)
- Added cross-validation test (`compute_idom_fast_matches_reference`) and stress test (`compute_idom_fast_handles_long_chain_without_blowup`) for the new dominator algorithm
- Analysed full Tcl 8.6 stdlib and tcllib 2.0 with live `tcl8.6` path: **0 E002/E003 false positives**
- All existing tests pass

## Compiler/KCS checklist

- [x] This change alters compiler fact contracts (adds E002/E003 arity diagnostics, fixes command span)
- [x] Updated `docs/rust-rewrite.md` with SYNC-MAY21-1, SYNC-MAY21-2, SYNC-MAY21-3 sections documenting the Rust port status, validation results, and intentional parity gaps

https://claude.ai/code/session_017pddMAfF3PiEReK4eTf3hP