### PR TITLE
Handle switch -regexp as IRSwitch instead of IRBarrier

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=40d3f1f-dirty
-head=40d3f1f1d896da612b4423cb7e6a479b4305eee2
-date=2026-05-21T21:53:15Z
-fingerprint=347ba4bf05f9de403264d19cd61315cfb5b2ee618798f194dc1805a2164a1c90
+describe=98ec35c
+head=98ec35cbed5b5ac06fdb27a86737131d6df29141
+date=2026-05-21T22:04:02Z
+fingerprint=6d3ccde5421bed5d1d7dd58582dc65adec52f40fccbd9a789f6597b52c31ba5a

--- a/core/compiler/cfg.py
+++ b/core/compiler/cfg.py
@@ -955,28 +955,19 @@ class _CFGBuilder:
         return end_block
 
     def _lower_switch(self, stmt: IRSwitch, block_name: str) -> str | None:
-        # ``-regexp`` still needs a runtime regex engine pass we haven't
-        # plumbed through the CFG, so keep it as a barrier and route
-        # through the interpreter.
-        if stmt.mode == "regexp":
-            barrier = IRBarrier(
-                range=stmt.range,
-                reason="switch -regexp",
-                command="switch",
-                canonical_command="::switch",
-                args=stmt.raw_args,
-            )
-            self._block(block_name).statements.append(barrier)
-            return block_name
-        # ``-glob`` dispatch: the CFG's STR_EQ branch chain can't
-        # represent glob matching.  Keep the ``IRSwitch`` in the
-        # block's statement list so ``codegen/_statements.py`` can emit
-        # an ``invokeStk`` call matching tclsh 9.0's un-compiled approach.
+        # ``-regexp`` needs a runtime regex engine pass we haven't plumbed
+        # through the CFG, and ``-glob`` matching can't be expressed by the
+        # CFG's STR_EQ branch chain.  Both stay as an ``IRSwitch`` statement
+        # so ``codegen/_statements.py`` can emit an ``invokeStk`` call
+        # matching tclsh 9.0's un-compiled approach; keeping the structured
+        # form (rather than collapsing to an ``IRBarrier``) also lets SSA
+        # recover the subject/arm-body variable reads.
+        #
         # ``-exact`` with fallthrough arms also stays as an ``IRSwitch``
         # because the CFG's multi-predecessor shared-body topology can't
         # be lowered to valid WASM structured control flow in general;
         # ``_emit_switch`` handles OR-matching for fallthrough groups.
-        if stmt.mode == "glob":
+        if stmt.mode in ("glob", "regexp"):
             self._block(block_name).statements.append(stmt)
             return block_name
         if any(arm.fallthrough for arm in stmt.arms) and not self._expand_fallthrough_switch:

--- a/core/compiler/codegen/_statements.py
+++ b/core/compiler/codegen/_statements.py
@@ -388,8 +388,9 @@ class _StatementsMixin:
                 self._emit(Op.RETURN_IMM, 0, 0)
 
             case IRSwitch(raw_args=raw_args):
-                # switch -glob kept as IRSwitch by cfg.py; emit a generic
-                # invokeStk call matching tclsh 9.0's un-compiled approach.
+                # switch -glob/-regexp (and -exact with fallthrough arms)
+                # kept as IRSwitch by cfg.py; emit a generic invokeStk
+                # call matching tclsh 9.0's un-compiled approach.
                 self._emit_call("switch", raw_args)
 
             case _:

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -857,9 +857,19 @@ class _WasmEmitterStmtMixin(_Base):
                 if mode == "regexp":
                     # No WASM regex matcher: re-invoke ``switch`` through
                     # the runtime so regexp arm patterns match tclsh
-                    # rather than being compared as exact strings.
-                    self._emit_eval_fallback("switch", raw_args)
+                    # rather than being compared as exact strings.  Build
+                    # the eval script with the braced body re-quoted
+                    # verbatim (a pattern like ``{^\d+$}`` keeps its
+                    # backslash) instead of letting the generic fallback
+                    # backslash-substitute it.
+                    script = self._regexp_switch_eval_script(subject, raw_args)
+                    self._emit_eval_fallback("switch", raw_args, script_override=script)
                     self._emit(WasmOp.DROP)
+                    if self._optimise:
+                        # The eval-fallback runs arbitrary arm bodies that
+                        # can reassign variables, so any constant we tracked
+                        # is now stale.
+                        self._const_map.clear()
                 else:
                     self._emit_switch(subject, arms, default_body, mode=mode)
 
@@ -1462,6 +1472,53 @@ class _WasmEmitterStmtMixin(_Base):
             self._emit_call(fidx)
         if self._catch_depth == 0:
             self._emit(WasmOp.UNREACHABLE)
+
+    def _regexp_switch_eval_script(self, subject: str, raw_args: tuple[str, ...]) -> str:
+        """Reconstruct a ``switch`` script for the ``-regexp`` eval-fallback.
+
+        ``raw_args`` holds the original words with the outer braces of the
+        body block already stripped by the lowering, e.g.
+        ``('-regexp', '${s}', '{^\\d+$} {body} default {body}')``.  The
+        generic eval-fallback would backslash-substitute the unbraced body
+        (turning ``\\d`` into ``d``), so re-quote each word here instead:
+
+        * leading option flags (``-regexp``, ``-nocase``, ``--`` and the
+          value of ``-matchvar`` / ``-indexvar``) pass through bare so the
+          runtime still recognises them;
+        * the subject — and any later command/variable substitution word —
+          passes through unquoted so it resolves against the current frame;
+        * every other word (the pattern/body block) is list-quoted, which
+          wraps brace-balanced text in ``{…}`` without applying backslash
+          substitution, preserving the regex verbatim.
+        """
+        # ``-nocase`` takes no value; only ``-matchvar`` / ``-indexvar`` do.
+        value_opts = {"-matchvar", "-indexvar"}
+        parts = ["switch"]
+        i = 0
+        n = len(raw_args)
+        while i < n and raw_args[i].startswith("-") and raw_args[i] != "-":
+            opt = raw_args[i]
+            parts.append(opt)
+            i += 1
+            if opt == "--":
+                break
+            if opt in value_opts and i < n:
+                parts.append(raw_args[i])
+                i += 1
+        if i < n:
+            subj = raw_args[i]
+            i += 1
+            parts.append(
+                subj
+                if (subj.startswith("$") or subj.startswith("["))
+                else _tcl_list_quote(subj, first=False)
+            )
+        for word in raw_args[i:]:
+            if word.startswith("$") or word.startswith("["):
+                parts.append(word)
+            else:
+                parts.append(_tcl_list_quote(word, first=False))
+        return " ".join(parts)
 
     def _emit_eval_fallback(
         self,

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -847,8 +847,21 @@ class _WasmEmitterStmtMixin(_Base):
             case IRForeach(iterators=iterators, body=body):
                 self._emit_foreach(iterators, body)
 
-            case IRSwitch(subject=subject, arms=arms, default_body=default_body, mode=mode):
-                self._emit_switch(subject, arms, default_body, mode=mode)
+            case IRSwitch(
+                subject=subject,
+                arms=arms,
+                default_body=default_body,
+                mode=mode,
+                raw_args=raw_args,
+            ):
+                if mode == "regexp":
+                    # No WASM regex matcher: re-invoke ``switch`` through
+                    # the runtime so regexp arm patterns match tclsh
+                    # rather than being compared as exact strings.
+                    self._emit_eval_fallback("switch", raw_args)
+                    self._emit(WasmOp.DROP)
+                else:
+                    self._emit_switch(subject, arms, default_body, mode=mode)
 
             case IRCatch(body=body, result_var=result_var, options_var=options_var):
                 self._emit_catch(body, result_var, options_var=options_var)

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1352,6 +1352,15 @@ def _scan_needed_imports(
             case IRSwitch(subject=subject, arms=arms, default_body=default_body, mode=mode):
                 if mode == "glob":
                     needed.add("tcl_string_match")
+                elif mode == "regexp":
+                    # No WASM regex matcher: the regexp switch is
+                    # re-invoked through the runtime via the eval
+                    # fallback (see _emit_statement's IRSwitch case),
+                    # so it needs the same imports as an IRBarrier.
+                    needed.add("tcl_eval")
+                    needed.add("tcl_catch_has_error")
+                    needed.add("tcl_flow_check_return")
+                    needed.add("tcl_flow_take_return")
                 else:
                     needed.add("tcl_string_equal")
                 # The subject may be a command substitution or

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1354,31 +1354,35 @@ def _scan_needed_imports(
                     needed.add("tcl_string_match")
                 elif mode == "regexp":
                     # No WASM regex matcher: the regexp switch is
-                    # re-invoked through the runtime via the eval
-                    # fallback (see _emit_statement's IRSwitch case),
-                    # so it needs the same imports as an IRBarrier.
+                    # re-invoked *wholesale* through the runtime via the
+                    # eval fallback (see _emit_statement's IRSwitch case).
+                    # Neither the subject nor the arm bodies are emitted
+                    # as WASM, so only the eval/flow imports an IRBarrier
+                    # needs are required — skip scanning the subject and
+                    # bodies to avoid pulling in unused imports.
                     needed.add("tcl_eval")
                     needed.add("tcl_catch_has_error")
                     needed.add("tcl_flow_check_return")
                     needed.add("tcl_flow_take_return")
                 else:
                     needed.add("tcl_string_equal")
-                # The subject may be a command substitution or
-                # interpolated string — scan it so the codegen's
-                # ``_emit_value`` call in ``_emit_str_value``
-                # (which now routes ``ExprRaw`` through the full
-                # value-emitter) can reach ``tcl_append`` /
-                # ``tcl_list_length`` / etc.  Without this the
-                # interpolation emitter degrades to
-                # ``_emit_obj_literal`` and the subject compares
-                # against its raw source text rather than its
-                # runtime value.
-                _scan_value(subject)
-                for arm in arms:
-                    if arm.body:
-                        _scan_script(arm.body)
-                if default_body:
-                    _scan_script(default_body)
+                if mode != "regexp":
+                    # The subject may be a command substitution or
+                    # interpolated string — scan it so the codegen's
+                    # ``_emit_value`` call in ``_emit_str_value``
+                    # (which now routes ``ExprRaw`` through the full
+                    # value-emitter) can reach ``tcl_append`` /
+                    # ``tcl_list_length`` / etc.  Without this the
+                    # interpolation emitter degrades to
+                    # ``_emit_obj_literal`` and the subject compares
+                    # against its raw source text rather than its
+                    # runtime value.
+                    _scan_value(subject)
+                    for arm in arms:
+                        if arm.body:
+                            _scan_script(arm.body)
+                    if default_body:
+                        _scan_script(default_body)
             case IRCatch(body=body):
                 needed.add("tcl_catch_enter")
                 needed.add("tcl_catch_leave")

--- a/tests/test_complex_codegen.py
+++ b/tests/test_complex_codegen.py
@@ -461,8 +461,8 @@ proc ext {filename} {
         )
         assert has_switch, "-glob should keep IRSwitch for inline codegen"
 
-    def test_switch_regexp_becomes_barrier(self):
-        """Switch -regexp compiles as a barrier."""
+    def test_switch_regexp_stays_switch(self):
+        """Switch -regexp keeps its IRSwitch form (no barrier)."""
         source = """\
 proc match {s} {
     switch -regexp $s {
@@ -476,10 +476,18 @@ proc match {s} {
         cfg = build_cfg(ir)
         proc_cfg = cfg.procedures["::match"]
         has_barrier = any(
-            any(isinstance(s, IRBarrier) and "switch -regexp" in s.reason for s in b.statements)
+            any(
+                isinstance(s, IRBarrier) and "switch -regexp" in (s.reason or "")
+                for s in b.statements
+            )
             for b in proc_cfg.blocks.values()
         )
-        assert has_barrier
+        assert not has_barrier, "-regexp should no longer lower to IRBarrier"
+        has_switch = any(
+            any(s.__class__.__name__ == "IRSwitch" for s in b.statements)
+            for b in proc_cfg.blocks.values()
+        )
+        assert has_switch, "-regexp should keep IRSwitch for inline codegen"
 
     def test_switch_many_arms(self):
         """Switch with many arms creates a dispatch mechanism."""

--- a/tests/test_complex_codegen.py
+++ b/tests/test_complex_codegen.py
@@ -484,8 +484,7 @@ proc match {s} {
         )
         assert not has_barrier, "-regexp should no longer lower to IRBarrier"
         has_switch = any(
-            any(s.__class__.__name__ == "IRSwitch" for s in b.statements)
-            for b in proc_cfg.blocks.values()
+            any(isinstance(s, IRSwitch) for s in b.statements) for b in proc_cfg.blocks.values()
         )
         assert has_switch, "-regexp should keep IRSwitch for inline codegen"
 


### PR DESCRIPTION
## Summary

Changed the compiler to keep `switch -regexp` statements as `IRSwitch` nodes during CFG lowering instead of converting them to `IRBarrier` nodes. This allows the structured form to be preserved through code generation, enabling SSA analysis to recover variable reads from the subject and arm bodies.

The `-regexp` mode is now handled similarly to `-glob` mode: both are kept as `IRSwitch` statements and emitted as runtime `invokeStk` calls in the final code generation, matching tclsh 9.0's un-compiled approach. This is necessary because neither mode can be fully expressed by the CFG's structured control flow primitives (regex matching requires a runtime engine, glob matching can't be represented by STR_EQ branch chains).

### Changes

- **cfg.py**: Removed special-case `IRBarrier` creation for `-regexp` mode; now both `-regexp` and `-glob` modes stay as `IRSwitch` statements with updated comments explaining the rationale.
- **_emitter/_statements.py**: Added explicit handling for `-regexp` mode to emit an `eval` fallback call through the runtime instead of attempting structured switch emission.
- **_scan.py**: Added import requirements for `-regexp` mode (`tcl_eval`, `tcl_catch_has_error`, `tcl_flow_check_return`, `tcl_flow_take_return`) to match the runtime invocation approach.
- **_statements.py**: Updated comment to reflect that both `-glob` and `-regexp` modes are kept as `IRSwitch`.
- **test_complex_codegen.py**: Updated test to verify `-regexp` no longer creates an `IRBarrier` and instead keeps the `IRSwitch` form.

## Validation

- Updated existing test `test_switch_regexp_becomes_barrier` to `test_switch_regexp_stays_switch` to verify the new behavior
- Test now confirms `-regexp` does not lower to `IRBarrier` and maintains `IRSwitch` form
- Existing `-glob` switch tests continue to validate that mode's behavior

https://claude.ai/code/session_015mPDVf8apZJAT3UFaPYEWw