### PR TITLE
Make builtin arity suppression namespace-aware

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=1bfeaf0-dirty
-head=1bfeaf066f718554dae077913c8fcdf21e2d8749
-date=2026-05-21T20:35:39Z
-fingerprint=0e4f2ee739dda081d818f5a545c15c509a1da5d7b33454de6303c13c4c237724
+describe=5e2fed3-dirty
+head=5e2fed30a61875b017e10e0599ff9a3160efe999
+date=2026-05-21T20:57:34Z
+fingerprint=a8a2909aa4a6ca797858c28b9a585c2b1c932370c70f072ecc130b84412355f6

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.7-16-ge2ec683a-dirty
-head=e2ec683ab8667a5f4b250dda142653a9a6ad7841
-date=2026-05-21T15:15:56Z
-fingerprint=9d547b79fe2ead33c4a98c2d3500d4d5f6ada7ad511446a8cac03160f98ee854
+describe=1bfeaf0-dirty
+head=1bfeaf066f718554dae077913c8fcdf21e2d8749
+date=2026-05-21T20:35:39Z
+fingerprint=0e4f2ee739dda081d818f5a545c15c509a1da5d7b33454de6303c13c4c237724

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -478,6 +478,43 @@ def _resolve_signature(cmd_name: str) -> CommandSig | SubcommandSig | None:
     return None
 
 
+def _defining_namespace(qualified_name: str) -> str:
+    """Return the namespace a command defined as *qualified_name* lives in.
+
+    Command resolution inside a proc body uses the proc's defining
+    namespace — the qualified name minus its final ``::``-separated
+    component (``::`` for a globally defined proc).
+    """
+    idx = qualified_name.rfind("::")
+    if idx <= 0:
+        return "::"
+    return qualified_name[:idx]
+
+
+def _resolves_to_user_command(cmd_name: str, call_ns: str, user_commands: frozenset[str]) -> bool:
+    """True when *cmd_name*, resolved from *call_ns*, names a user command.
+
+    Mirrors the analyser's ``_resolve_proc_call`` resolution order: an
+    absolute name resolves to itself; a namespace-qualified relative name
+    resolves against the global namespace; a bare name resolves against
+    the call-site namespace first, then the global namespace.  Suppression
+    of the builtin arity check is gated on this so a shadowing proc in one
+    namespace cannot silence a call that actually reaches the builtin.
+    """
+    if not cmd_name:
+        return False
+    candidates: list[str] = []
+    if cmd_name.startswith("::"):
+        candidates.append(normalise_qualified_name(cmd_name))
+    elif "::" in cmd_name:
+        candidates.append(normalise_qualified_name(f"::{cmd_name}"))
+    else:
+        if call_ns and call_ns != "::":
+            candidates.append(normalise_qualified_name(f"{call_ns}::{cmd_name}"))
+        candidates.append(normalise_qualified_name(f"::{cmd_name}"))
+    return any(c in user_commands for c in candidates)
+
+
 def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
     """IR-native checks: arity (E001–E003), unknown subcommands (W001), W302.
 
@@ -487,10 +524,20 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
     Only checks built-in commands against registry signatures.  User-defined
     proc-call arity is checked by the analyser which has access to full
     parameter default information via ``ProcDef``.
+
+    Builtin arity is suppressed for any call that resolves Tcl-style to a
+    user-defined command (a shadowing proc): the suppression is
+    namespace-aware so a ``proc ::ns::close`` only silences ``close`` calls
+    that actually resolve to it, not a global ``close`` that reaches the
+    builtin.
     """
     diagnostics: list[Diagnostic] = []
+    # Qualified names of every user-defined command, used to suppress the
+    # builtin arity check when a call resolves to a shadowing proc.  Mirrors
+    # the set the analyser's ``_resolve_proc_call`` consults.
+    user_commands = frozenset(ir_module.procedures.keys())
 
-    def _check_statement(stmt: IRStatement) -> None:
+    def _check_statement(stmt: IRStatement, call_ns: str) -> None:
         # W302: catch without result variable (IR-native).  Highlight just
         # the ``catch`` command word — narrowest span that identifies the
         # issue — rather than the whole ``catch {…}`` statement.
@@ -564,9 +611,11 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
                     return
                 arg_expand = list(ct.expand_word[1:])
 
-        # Built-in command arity checking
+        # Built-in command arity checking.  Skip when the call resolves to a
+        # user-defined command shadowing the builtin — that call's arity is
+        # validated against the proc's real parameter list by the analyser.
         sig = _resolve_signature(cmd_name)
-        if sig is not None:
+        if sig is not None and not _resolves_to_user_command(cmd_name, call_ns, user_commands):
             _check_arity(
                 cmd_name,
                 args,
@@ -578,13 +627,14 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
                 arg_single,
             )
 
-    def _walk_ir(script: IRScript) -> None:
+    def _walk_ir(script: IRScript, call_ns: str) -> None:
         for stmt in iter_ir_statements(script):
-            _check_statement(stmt)
+            _check_statement(stmt, call_ns)
 
-    _walk_ir(ir_module.top_level)
+    _walk_ir(ir_module.top_level, "::")
     for proc in ir_module.procedures.values():
-        _walk_ir(proc.body)
+        # A proc body resolves commands in the proc's defining namespace.
+        _walk_ir(proc.body, _defining_namespace(proc.qualified_name))
 
     return diagnostics
 

--- a/core/compiler/compiler_checks.py
+++ b/core/compiler/compiler_checks.py
@@ -491,31 +491,61 @@ def _defining_namespace(qualified_name: str) -> str:
     return qualified_name[:idx]
 
 
-def _resolves_to_user_command(cmd_name: str, call_ns: str, user_commands: frozenset[str]) -> bool:
-    """True when *cmd_name*, resolved from *call_ns*, names a user command.
+def _resolution_candidates(cmd_name: str, call_ns: str) -> list[str]:
+    """Qualified names *cmd_name* may resolve to from *call_ns*.
 
     Mirrors the analyser's ``_resolve_proc_call`` resolution order: an
     absolute name resolves to itself; a namespace-qualified relative name
     resolves against the global namespace; a bare name resolves against
-    the call-site namespace first, then the global namespace.  Suppression
-    of the builtin arity check is gated on this so a shadowing proc in one
-    namespace cannot silence a call that actually reaches the builtin.
+    the call-site namespace first, then the global namespace.
     """
     if not cmd_name:
-        return False
-    candidates: list[str] = []
+        return []
     if cmd_name.startswith("::"):
-        candidates.append(normalise_qualified_name(cmd_name))
-    elif "::" in cmd_name:
-        candidates.append(normalise_qualified_name(f"::{cmd_name}"))
-    else:
-        if call_ns and call_ns != "::":
-            candidates.append(normalise_qualified_name(f"{call_ns}::{cmd_name}"))
-        candidates.append(normalise_qualified_name(f"::{cmd_name}"))
-    return any(c in user_commands for c in candidates)
+        return [normalise_qualified_name(cmd_name)]
+    if "::" in cmd_name:
+        return [normalise_qualified_name(f"::{cmd_name}")]
+    candidates: list[str] = []
+    if call_ns and call_ns != "::":
+        candidates.append(normalise_qualified_name(f"{call_ns}::{cmd_name}"))
+    candidates.append(normalise_qualified_name(f"::{cmd_name}"))
+    return candidates
 
 
-def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
+def _resolves_to_user_command(
+    cmd_name: str,
+    call_ns: str,
+    user_proc_offsets: Mapping[str, int],
+    *,
+    call_offset: int,
+    enforce_order: bool,
+) -> bool:
+    """True when *cmd_name*, resolved from *call_ns*, names a user proc.
+
+    Suppression of the builtin arity check is gated on this so a shadowing
+    proc in one namespace cannot silence a call that actually reaches the
+    builtin.  Only *unconditional* proc definitions (the keys of
+    ``user_proc_offsets``, which excludes conditional/looping definitions)
+    can shadow a builtin — a conditionally defined proc is not statically
+    known to exist.
+
+    ``enforce_order`` is set for top-level calls, which execute in source
+    order during script load: a definition only shadows the builtin if it
+    textually precedes the call (``def_offset < call_offset``).  Proc
+    bodies run after load, by which point every unconditional definition
+    exists, so ordering is not enforced there.
+    """
+    for candidate in _resolution_candidates(cmd_name, call_ns):
+        def_offset = user_proc_offsets.get(candidate)
+        if def_offset is None:
+            continue
+        if enforce_order and def_offset >= call_offset:
+            continue
+        return True
+    return False
+
+
+def _arity_checks(ir_module: IRModule, user_proc_offsets: Mapping[str, int]) -> list[Diagnostic]:
     """IR-native checks: arity (E001–E003), unknown subcommands (W001), W302.
 
     W002/W003/W004/W307 are now in checks.py ALL_CHECKS so they fire for
@@ -529,15 +559,13 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
     user-defined command (a shadowing proc): the suppression is
     namespace-aware so a ``proc ::ns::close`` only silences ``close`` calls
     that actually resolve to it, not a global ``close`` that reaches the
-    builtin.
+    builtin.  ``user_proc_offsets`` maps each unconditionally defined proc
+    to its definition offset so suppression also respects definition order
+    and reachability (see :func:`_resolves_to_user_command`).
     """
     diagnostics: list[Diagnostic] = []
-    # Qualified names of every user-defined command, used to suppress the
-    # builtin arity check when a call resolves to a shadowing proc.  Mirrors
-    # the set the analyser's ``_resolve_proc_call`` consults.
-    user_commands = frozenset(ir_module.procedures.keys())
 
-    def _check_statement(stmt: IRStatement, call_ns: str) -> None:
+    def _check_statement(stmt: IRStatement, call_ns: str, enforce_order: bool) -> None:
         # W302: catch without result variable (IR-native).  Highlight just
         # the ``catch`` command word — narrowest span that identifies the
         # issue — rather than the whole ``catch {…}`` statement.
@@ -615,7 +643,13 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
         # user-defined command shadowing the builtin — that call's arity is
         # validated against the proc's real parameter list by the analyser.
         sig = _resolve_signature(cmd_name)
-        if sig is not None and not _resolves_to_user_command(cmd_name, call_ns, user_commands):
+        if sig is not None and not _resolves_to_user_command(
+            cmd_name,
+            call_ns,
+            user_proc_offsets,
+            call_offset=stmt.range.start.offset,
+            enforce_order=enforce_order,
+        ):
             _check_arity(
                 cmd_name,
                 args,
@@ -627,14 +661,17 @@ def _arity_checks(ir_module: IRModule) -> list[Diagnostic]:
                 arg_single,
             )
 
-    def _walk_ir(script: IRScript, call_ns: str) -> None:
+    def _walk_ir(script: IRScript, call_ns: str, enforce_order: bool) -> None:
         for stmt in iter_ir_statements(script):
-            _check_statement(stmt, call_ns)
+            _check_statement(stmt, call_ns, enforce_order)
 
-    _walk_ir(ir_module.top_level, "::")
+    # Top-level statements execute in source order, so a shadowing proc must
+    # be defined before the call; proc bodies run after load and see every
+    # unconditional definition regardless of order.
+    _walk_ir(ir_module.top_level, "::", enforce_order=True)
     for proc in ir_module.procedures.values():
         # A proc body resolves commands in the proc's defining namespace.
-        _walk_ir(proc.body, _defining_namespace(proc.qualified_name))
+        _walk_ir(proc.body, _defining_namespace(proc.qualified_name), enforce_order=False)
 
     return diagnostics
 
@@ -975,5 +1012,5 @@ def run_compiler_checks(
         runner.process_statement(stmt)
 
     diagnostics = runner.diagnostics
-    diagnostics.extend(_arity_checks(ir_module))
+    diagnostics.extend(_arity_checks(ir_module, user_procs))
     return diagnostics

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1064,6 +1064,66 @@ proc a {} {
         assert any(d.code == "W100" for d in result.diagnostics)
 
 
+class TestNamespaceShadowedArity:
+    """Builtin arity suppression must be namespace-aware (issue: PR #472).
+
+    A ``proc`` whose name matches a builtin only shadows that builtin for
+    calls that actually resolve to it.  A call in another namespace (e.g. a
+    global ``close``) still reaches the builtin and must keep its arity
+    check.
+    """
+
+    @staticmethod
+    def _arity_codes(source):
+        from core.compiler.compiler_checks import run_compiler_checks
+
+        return [d for d in run_compiler_checks(source) if d.code in ("E002", "E003")]
+
+    def test_global_call_to_shadowed_builtin_still_checked(self):
+        # ``proc ::ns::close`` must not silence a global ``close`` that
+        # resolves to the builtin (max 2 args).
+        source = (
+            "proc ::ns::close {a b c d} {}\n"
+            "close x y z\n"  # global -> builtin close, 3 args -> E003
+        )
+        diags = self._arity_codes(source)
+        assert len(diags) == 1
+        assert diags[0].code == "E003"
+        assert "at most 2" in diags[0].message
+
+    def test_call_resolving_to_user_proc_is_suppressed(self):
+        # ``close`` inside a ``::ns`` proc resolves to ``::ns::close`` (the
+        # user proc, 3 args) and must NOT trip the builtin arity check.
+        source = (
+            "proc ::ns::close {a b c} {}\n"
+            "proc ::ns::caller {} { close x y z }\n"
+            "close x y z\n"  # only the global call reaches the builtin
+        )
+        diags = self._arity_codes(source)
+        assert len(diags) == 1
+        assert "at most 2" in diags[0].message  # the builtin, not ::ns::close
+
+    def test_shadowing_proc_in_other_namespace_does_not_suppress(self):
+        # A proc named ``close`` in an unrelated namespace must not silence
+        # the global builtin call.
+        source = "proc ::other::close {a b c} {}\nclose x y z\n"
+        diags = self._arity_codes(source)
+        assert len(diags) == 1
+        assert diags[0].code == "E003"
+
+    def test_websocket_close_no_false_positive(self):
+        # Real-world shape: ``::websocket::close`` takes 3 args and is called
+        # as a bare ``close`` from procs in the same namespace.
+        source = (
+            "namespace eval ::websocket {}\n"
+            "proc ::websocket::close {sock {code 1000} {reason {}}} {}\n"
+            "proc ::websocket::Receiver {} {\n"
+            '    close $sock 1009 "too big"\n'
+            "}\n"
+        )
+        assert self._arity_codes(source) == []
+
+
 # W200: Binary format signed/unsigned modifier requires Tcl 8.5+
 
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1111,6 +1111,28 @@ class TestNamespaceShadowedArity:
         assert len(diags) == 1
         assert diags[0].code == "E003"
 
+    def test_top_level_call_before_definition_still_checked(self):
+        # A global call resolves to the builtin when it textually precedes
+        # the shadowing proc — script load runs in order, so suppression
+        # must respect definition order.
+        source = "close x y z\nproc close {a b c d} {}\n"
+        diags = self._arity_codes(source)
+        assert len(diags) == 1
+        assert diags[0].code == "E003"
+
+    def test_conditionally_defined_proc_does_not_suppress(self):
+        # A proc defined only inside a conditional is not statically known
+        # to exist, so the builtin arity check must still fire.
+        source = "if {$x} { proc close {a b c d} {} }\nclose x y z\n"
+        diags = self._arity_codes(source)
+        assert len(diags) == 1
+        assert diags[0].code == "E003"
+
+    def test_top_level_call_after_definition_is_suppressed(self):
+        # Once the proc is defined, a later global call resolves to it.
+        source = "proc close {a b c} {}\nclose x y z\n"
+        assert self._arity_codes(source) == []
+
     def test_websocket_close_no_false_positive(self):
         # Real-world shape: ``::websocket::close`` takes 3 args and is called
         # as a bare ``close`` from procs in the same namespace.


### PR DESCRIPTION
## Summary

Fix builtin arity checking to be namespace-aware when suppressing checks for shadowing user-defined procs. Previously, a proc named `::ns::close` would suppress arity checks for *all* `close` calls, even those in other namespaces that actually resolve to the builtin. Now suppression only applies to calls that actually resolve to the shadowing proc via Tcl's command resolution rules.

### Changes

- Add `_defining_namespace()` to extract the namespace where a proc is defined
- Add `_resolves_to_user_command()` to determine if a command name resolves to a user-defined proc using Tcl-style resolution (absolute names, namespace-qualified names, and bare names with namespace fallback)
- Update `_arity_checks()` to track the calling namespace and pass it through the statement/script walk
- Skip builtin arity checks only when a call actually resolves to a user command in that namespace
- Top-level code resolves in `::` (global namespace); proc bodies resolve in their defining namespace

### Testing

Added `TestNamespaceShadowedArity` test class with four scenarios:
- Global call to shadowed builtin still checked
- Call resolving to user proc is suppressed
- Shadowing proc in unrelated namespace doesn't suppress
- Real-world websocket example produces no false positives

## Validation

- [x] Added comprehensive test coverage for namespace-aware resolution
- [x] Tests validate both suppression and non-suppression cases
- [x] Existing arity check tests continue to pass

## Compiler/KCS checklist

- [ ] This change does not alter compiler fact contracts (it refines existing E002/E003 behavior to be more precise)
- [ ] No new KCS notes needed (behavior is a correctness fix, not a new feature)

https://claude.ai/code/session_01G7vBH6GfdNS6cfDkjmad3E