### PR TITLE
Wait for LSP server to be ready before compiling

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=fb52da5-dirty
-head=fb52da5309af578c981ea0139b98f1103bd7cff5
-date=2026-05-21T21:23:52Z
-fingerprint=0cfb8e9ad758dde0544ad8aab1ddab1e0d5a647f40e27f50b283778f6ae0a561
+describe=cf9ec45-dirty
+head=cf9ec451f4cf710ab7141feaf4750f887f1f1e2b
+date=2026-05-21T21:41:16Z
+fingerprint=0813d7125aecfb44d05858b6c7eba98244cc7c0156c9dbc7e81c1218d34dea6f

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.7-16-ge2ec683a-dirty
-head=e2ec683ab8667a5f4b250dda142653a9a6ad7841
-date=2026-05-21T15:15:56Z
-fingerprint=9d547b79fe2ead33c4a98c2d3500d4d5f6ada7ad511446a8cac03160f98ee854
+describe=fb52da5-dirty
+head=fb52da5309af578c981ea0139b98f1103bd7cff5
+date=2026-05-21T21:23:52Z
+fingerprint=0cfb8e9ad758dde0544ad8aab1ddab1e0d5a647f40e27f50b283778f6ae0a561

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -14,7 +14,9 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerManager
+import com.intellij.platform.lsp.api.LspServerState
 import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
@@ -212,15 +214,44 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
         }
     }
 
+    /**
+     * Resolve a running Tcl LSP server, kicking it and waiting briefly if one
+     * isn't ready yet. Returns null only after a real timeout.
+     *
+     * The LSP server starts lazily on the first Tcl editor (see
+     * [TclLspServerSupportProvider]). When the explorer tool window is restored
+     * on IDE startup it pushes its first compile before that server has
+     * finished initialising, which previously surfaced a spurious "LSP server
+     * not running" error in the output pane. Poll for a Running server instead;
+     * this runs on the [runCompile] background thread, so the sleep is safe.
+     */
+    @Suppress("UnstableApiUsage")
+    private fun awaitRunningServer(timeoutMs: Long = 10_000): LspServer? {
+        val manager = LspServerManager.getInstance(project)
+        fun running(): LspServer? =
+            manager.getServersForProvider(TclLspServerSupportProvider::class.java)
+                .firstOrNull { it.state == LspServerState.Running }
+
+        running()?.let { return it }
+
+        ApplicationManager.getApplication().invokeLater {
+            manager.startServersIfNeeded(TclLspServerSupportProvider::class.java)
+        }
+
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            Thread.sleep(150)
+            running()?.let { return it }
+        }
+        return null
+    }
+
     private fun runCompile(source: String, dialect: String) {
         CompletableFuture.runAsync {
             try {
                 sendStatusToWebview("compiling")
 
-                @Suppress("UnstableApiUsage")
-                val servers = LspServerManager.getInstance(project)
-                    .getServersForProvider(TclLspServerSupportProvider::class.java)
-                val server = servers.firstOrNull()
+                val server = awaitRunningServer()
                 if (server == null) {
                     sendErrorToWebview("LSP server not running")
                     return@runAsync


### PR DESCRIPTION
## Summary

- Extract LSP server resolution logic into a new `awaitRunningServer()` method that polls for a running Tcl LSP server with a timeout
- Use this method in `runCompile()` to ensure the server is ready before attempting compilation, fixing spurious "LSP server not running" errors when the tool window is restored on IDE startup

## Details

The Tcl LSP server starts lazily when the first Tcl editor is opened. When the Compiler Explorer tool window is restored during IDE startup, it may attempt to compile before the server has finished initializing, resulting in a spurious error message.

The new `awaitRunningServer()` method:
- Checks if a running server is already available
- If not, triggers server startup via `LspServerManager.startServersIfNeeded()`
- Polls for up to 10 seconds (configurable) for the server to reach `Running` state
- Returns the server once ready, or null if the timeout expires

This runs on the background compilation thread, so the polling sleep is safe and doesn't block the UI.

## Validation

- No new tests needed; this is a defensive improvement to existing compile flow
- Existing tool window and compilation tests continue to pass

https://claude.ai/code/session_01W1Zd1vzRPwoqMe9UrTgdev