### PR TITLE
Optimize dataflow fixpoints with worklists and shared RPO

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=98ec35c
-head=98ec35cbed5b5ac06fdb27a86737131d6df29141
-date=2026-05-21T22:04:02Z
-fingerprint=6d3ccde5421bed5d1d7dd58582dc65adec52f40fccbd9a789f6597b52c31ba5a
+describe=78debc65-dirty
+head=78debc656d5acad4d38e8642391074deefa6a61b
+date=2026-05-21T22:13:37Z
+fingerprint=7a9c45a12fb70d7b209484e5002220d7673a0e4254dbe7da56475d29d2db7aa9

--- a/core/analysis/_analyser/_core.py
+++ b/core/analysis/_analyser/_core.py
@@ -28,6 +28,7 @@ from ..semantic_model import (
     Range,
     Scope,
     Severity,
+    VarDef,
 )
 from ..stub_comments import ambient_cmd_stubs, scan_source_for_stubs
 from ._snapshot import AnalyserSnapshot
@@ -105,6 +106,12 @@ class _AnalyserBase:
         self._cmd_command_sites: list[tuple[str, str | None, Range, bool, bool]] = []
         # Cache: id(scope) -> namespace string, for _namespace_from_scope.
         self._ns_cache: dict[int, str] = {}
+        # Cache: (target_ns, var_part) -> VarDef, for _resolve_qualified_var.
+        # Only positive (resolved) results are cached: a VarDef object is
+        # stable once created and the DFS-first matching scope never moves
+        # (scopes are append-only), so a cached hit stays correct.  Misses
+        # are not cached — the variable may be defined later in the walk.
+        self._qual_var_cache: dict[tuple[str, str], VarDef] = {}
         # Namespace ensembles: namespaces where ``namespace ensemble create``
         # was detected.  Their tail names become valid commands.
         self._ensemble_namespaces: set[str] = set()
@@ -168,6 +175,7 @@ class _AnalyserBase:
         self._conditional_depth = snap.conditional_depth
         self._command_aliases = dict(snap.command_aliases)
         self._ns_cache.clear()
+        self._qual_var_cache.clear()
 
         # Remap scope ids: old_id → new scope's id
         # snap.scope_id_map maps id(original_live_scope) → copied_scope_in_snap.result.
@@ -236,6 +244,7 @@ class _AnalyserBase:
         self._file_path = file_path
         self._unresolved_commands_emitted = False
         self._ns_cache.clear()
+        self._qual_var_cache.clear()
         if not skip_stubs:
             # Pre-scan for inline stubs (same as analyse()).
             cmd_stubs, expr_stubs = scan_source_for_stubs(source)
@@ -294,6 +303,7 @@ class _AnalyserBase:
         self._source = source
         self._unresolved_commands_emitted = False
         self._ns_cache.clear()
+        self._qual_var_cache.clear()
         # Pre-scan for top-of-file ``# tcl-lsp: disable=...`` directives.
         file_codes = parse_file_suppression(source)
         if file_codes:
@@ -415,6 +425,7 @@ class _AnalyserBase:
         self._file_path = file_path
         self._unresolved_commands_emitted = False
         self._ns_cache.clear()
+        self._qual_var_cache.clear()
         # Pre-scan for inline stubs blocks (independent of Tcl parsing).
         cmd_stubs, expr_stubs = scan_source_for_stubs(source)
         self.result.stub_commands.extend(cmd_stubs)

--- a/core/analysis/_analyser/_diag_var_command.py
+++ b/core/analysis/_analyser/_diag_var_command.py
@@ -463,7 +463,11 @@ class _AnalyserDiagVarCommandMixin(_Base):
                                 )
                             )
 
-            # Remove suppressed W307 diagnostics.
+            # Remove suppressed W307 diagnostics.  Rebuild in one pass
+            # (O(N)) instead of repeated del-by-index (each del shifts the
+            # tail — O(R·N) when many sites are suppressed).
             if remove_indices:
-                for i in sorted(remove_indices, reverse=True):
-                    del self.result.diagnostics[i]
+                drop = set(remove_indices)
+                self.result.diagnostics[:] = [
+                    d for i, d in enumerate(self.result.diagnostics) if i not in drop
+                ]

--- a/core/analysis/_analyser/_scope.py
+++ b/core/analysis/_analyser/_scope.py
@@ -221,13 +221,19 @@ class _AnalyserScopeMixin(_Base):
             target_ns = _normalise_qualified_name(
                 f"::{joined}" if not joined.startswith("::") else joined
             )
+        cache_key = (target_ns, var_part)
+        cached = self._qual_var_cache.get(cache_key)
+        if cached is not None:
+            return cached
         for candidate in self._walk_scopes(self.result.global_scope):
             if (
                 candidate.kind == "namespace"
                 and var_part in candidate.variables
                 and self._namespace_from_scope(candidate) == target_ns
             ):
-                return candidate.variables[var_part]
+                resolved = candidate.variables[var_part]
+                self._qual_var_cache[cache_key] = resolved
+                return resolved
         return None
 
     def _walk_scopes(self, scope: Scope):

--- a/core/analysis/checks/_orchestrator.py
+++ b/core/analysis/checks/_orchestrator.py
@@ -180,18 +180,21 @@ _PATTERN_CHECKS: list[tuple[frozenset[str], _CheckFn]] = [
 ]
 
 _targeted_checks: dict[str, list[_CheckFn]] = {}
-_targeted_checks_spec_count: int = -1
+_targeted_checks_generation: int = -1
 
 
 def _get_targeted_checks() -> dict[str, list[_CheckFn]]:
     """Return the targeted check map, rebuilding if the registry has changed.
 
     The registry lazily loads dialect packs (e.g. iRules, EDA), so the
-    targeted check map must be rebuilt whenever the spec count changes.
+    targeted check map must be rebuilt whenever the spec set changes.  The
+    registry's ``generation`` counter advances on every such change, so
+    comparing it is O(1) — far cheaper than re-summing the spec table on
+    every command (this runs once per command analysed).
     """
-    global _targeted_checks, _targeted_checks_spec_count
-    current = sum(len(v) for v in REGISTRY.specs_by_name.values())
-    if current != _targeted_checks_spec_count:
+    global _targeted_checks, _targeted_checks_generation
+    current = REGISTRY.generation
+    if current != _targeted_checks_generation:
         checks: dict[str, list[_CheckFn]] = defaultdict(list)
         for trait, check in _TRAIT_CHECK_MAP:
             for cmd in REGISTRY.check_trait_commands(trait):
@@ -200,7 +203,7 @@ def _get_targeted_checks() -> dict[str, list[_CheckFn]]:
             for cmd in cmds:
                 checks[cmd].append(check)
         _targeted_checks = dict(checks)
-        _targeted_checks_spec_count = current
+        _targeted_checks_generation = current
     return _targeted_checks
 
 

--- a/core/commands/registry/command_registry.py
+++ b/core/commands/registry/command_registry.py
@@ -188,6 +188,11 @@ class CommandRegistry:
     # Loader keys that have already been applied to this registry.
     _loaded_loaders: set[str] = field(default_factory=set, init=False, repr=False)
 
+    # Monotonic counter bumped whenever ``specs_by_name`` gains specs (a
+    # dialect pack loads).  Lets consumers detect spec changes in O(1)
+    # instead of re-summing the whole spec table on every lookup.
+    generation: int = field(default=0, init=False, repr=False)
+
     # Serialises dialect loading so concurrent threads cannot double-merge.
     _load_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
@@ -304,6 +309,7 @@ class CommandRegistry:
                     self._command_to_required_package[spec.name] = spec.required_package
 
             # Invalidate all derived caches.
+            self.generation += 1
             self._trait_indexes = self._build_trait_indexes()
             self._command_names_cache.clear()
             self._event_command_cache.clear()

--- a/core/compiler/cfg.py
+++ b/core/compiler/cfg.py
@@ -480,6 +480,16 @@ class CFGReturn:
 CFGTerminator = CFGGoto | CFGBranch | CFGReturn
 
 
+def _block_successors(term: CFGTerminator | None) -> tuple[str, ...]:
+    match term:
+        case CFGGoto(target=target):
+            return (target,)
+        case CFGBranch(true_target=tt, false_target=ft):
+            return (tt, ft)
+        case _:
+            return ()
+
+
 @dataclass(frozen=True, slots=True)
 class CFGBlock:
     name: str
@@ -493,6 +503,53 @@ class CFGFunction:
     entry: str
     blocks: dict[str, CFGBlock]
     loop_nodes: dict[str, tuple[str, IRFor]] = field(default_factory=dict)
+
+    def reverse_postorder(self) -> list[str]:
+        """Return blocks in reverse-postorder — the one shared CFG order.
+
+        Blocks reachable from :attr:`entry` come first in true reverse
+        post-order: ``entry`` is first and every block appears after all
+        of its non-back-edge predecessors.  Blocks not reachable from the
+        entry are appended in declaration order so callers that iterate
+        every block keep the full set (matching the old per-pass
+        ``_cfg_order`` helpers, which appended unreachable blocks too).
+
+        Implemented with an explicit work stack rather than recursion so
+        it cannot overflow the thread stack on a degenerate CFG — a
+        single machine-generated proc can lower to a block chain tens of
+        thousands deep, which a recursive DFS overflows at the common
+        2 MB worker-thread stack size.  This is the only RPO used across
+        the CFG/SSA passes (dominators, SCCP, liveness, type / rendered-
+        property propagation, GVN), so keeping it iterative keeps them
+        all bounded.
+        """
+        visited: set[str] = set()
+        postorder: list[str] = []
+        # Each frame is [block name, index of next successor to visit];
+        # a frame moves to ``postorder`` once all its successors have been
+        # pushed — yielding the recursive post-order, then reversed.
+        stack: list[list] = []
+        if self.entry in self.blocks:
+            visited.add(self.entry)
+            stack.append([self.entry, 0])
+        while stack:
+            frame = stack[-1]
+            bn = frame[0]
+            succs = _block_successors(self.blocks[bn].terminator)
+            if frame[1] < len(succs):
+                nxt = succs[frame[1]]
+                frame[1] += 1
+                if nxt in self.blocks and nxt not in visited:
+                    visited.add(nxt)
+                    stack.append([nxt, 0])
+            else:
+                postorder.append(bn)
+                stack.pop()
+        postorder.reverse()
+        for bn in self.blocks:
+            if bn not in visited:
+                postorder.append(bn)
+        return postorder
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/compiler/core_analyses.py
+++ b/core/compiler/core_analyses.py
@@ -293,31 +293,6 @@ def _compute_predecessors(cfg: CFGFunction) -> dict[str, set[str]]:
     return preds
 
 
-def _cfg_order(cfg: CFGFunction) -> list[str]:
-    seen: set[str] = set()
-    order: list[str] = []
-    stack = [cfg.entry]
-    while stack:
-        bn = stack.pop()
-        if bn in seen or bn not in cfg.blocks:
-            continue
-        seen.add(bn)
-        order.append(bn)
-        match cfg.blocks[bn].terminator:
-            case CFGGoto(target=target):
-                succs = [target]
-            case CFGBranch(true_target=tt, false_target=ft):
-                succs = [tt, ft]
-            case _:
-                succs = []
-        for succ in reversed(succs):
-            stack.append(succ)
-    for bn in cfg.blocks:
-        if bn not in seen:
-            order.append(bn)
-    return order
-
-
 def _parse_literal_value(text: str) -> int | str:
     stripped = text.strip()
     if _DECIMAL_INT_RE.fullmatch(stripped):
@@ -884,7 +859,7 @@ def _sccp(
     if param_constants:
         for key, lv in param_constants.items():
             values[key] = lv
-    order = _cfg_order(cfg)
+    order = cfg.reverse_postorder()
 
     def set_value(key: SSAValueKey, candidate: LatticeValue) -> bool:
         old = values.get(key, UNKNOWN)
@@ -1046,7 +1021,7 @@ def _liveness(
     use, defs = _block_use_def(cfg, ssa)
     live_in: dict[str, set[SSAValueKey]] = {bn: set() for bn in cfg.blocks}
     live_out: dict[str, set[SSAValueKey]] = {bn: set() for bn in cfg.blocks}
-    order = list(reversed(_cfg_order(cfg)))
+    order = list(reversed(cfg.reverse_postorder()))
 
     changed = True
     while changed:
@@ -1327,7 +1302,7 @@ def _read_before_set(
     reported: set[str] = set()
     result: list[ReadBeforeSet] = []
 
-    order = _cfg_order(cfg)
+    order = cfg.reverse_postorder()
     for bn in order:
         if bn not in considered:
             continue
@@ -1403,7 +1378,7 @@ def _unused_variables(
     reported: set[str] = set()
     result: list[UnusedVariable] = []
 
-    order = _cfg_order(cfg)
+    order = cfg.reverse_postorder()
     for bn in order:
         if bn not in considered:
             continue
@@ -1600,7 +1575,7 @@ def _type_propagation(
     preds = _compute_predecessors(cfg)
 
     types: dict[SSAValueKey, TypeLattice] = {}
-    order = _cfg_order(cfg)
+    order = cfg.reverse_postorder()
 
     def set_type(key: SSAValueKey, candidate: TypeLattice) -> bool:
         old = types.get(key, _TYPE_UNKNOWN)

--- a/core/compiler/core_analyses.py
+++ b/core/compiler/core_analyses.py
@@ -856,9 +856,16 @@ def _sccp(
     executable_blocks: set[str] = {cfg.entry} if cfg.entry in cfg.blocks else set()
     executable_edges: set[tuple[str, str]] = set()
     values: dict[SSAValueKey, LatticeValue] = {}
+    # Keys whose current value is not yet OVERDEFINED.  A barrier widens
+    # every tracked value to OVERDEFINED; tracking the live set lets each
+    # barrier visit touch only the not-yet-widened keys instead of
+    # re-scanning the whole ``values`` map on every fixpoint pass.
+    non_overdefined: set[SSAValueKey] = set()
     if param_constants:
         for key, lv in param_constants.items():
             values[key] = lv
+            if lv.kind is not LatticeKind.OVERDEFINED:
+                non_overdefined.add(key)
     order = cfg.reverse_postorder()
 
     def set_value(key: SSAValueKey, candidate: LatticeValue) -> bool:
@@ -866,6 +873,10 @@ def _sccp(
         merged = _join(old, candidate)
         if merged != old:
             values[key] = merged
+            if merged.kind is LatticeKind.OVERDEFINED:
+                non_overdefined.discard(key)
+            else:
+                non_overdefined.add(key)
             return True
         return False
 
@@ -895,10 +906,13 @@ def _sccp(
             for s in ssa_block.statements:
                 if isinstance(s.statement, IRBarrier):
                     # Barriers can modify any variable — widen all
-                    # currently-tracked values to OVERDEFINED.
-                    for key in list(values):
-                        if set_value(key, OVERDEFINED):
-                            changed = True
+                    # currently-tracked values to OVERDEFINED.  Only the
+                    # not-yet-widened keys need touching.
+                    if non_overdefined:
+                        for key in non_overdefined:
+                            values[key] = OVERDEFINED
+                        non_overdefined.clear()
+                        changed = True
                     continue
                 for var, ver in s.defs.items():
                     val = _evaluate_def(s.statement, s, values)

--- a/core/compiler/core_analyses.py
+++ b/core/compiler/core_analyses.py
@@ -880,83 +880,142 @@ def _sccp(
             return True
         return False
 
-    # SCCP keeps the round-robin RPO sweep (no sparse worklist): it marks
-    # CFG edges executable as it goes and never un-marks them, so an
-    # undetermined branch (decision ``None``) conservatively marks BOTH
-    # targets.  The RPO sweep resolves a condition's value before the
-    # branch is visited, so the pessimistic both-edge marking is avoided;
-    # a value-driven worklist could visit the branch first (in a
-    # different order), permanently mark both edges, and lose precision
-    # (e.g. a constant condition no longer detected as always-false).
-    # The other propagations read this fixed executable set and only join
-    # values, so their worklists are order-independent.
-    changed = True
-    while changed:
-        changed = False
-        for bn in order:
-            if bn not in executable_blocks:
-                continue
-            ssa_block = ssa.blocks[bn]
+    # Seed live-in roots to OVERDEFINED.  A value that is *used* but never
+    # *defined* anywhere in this function (a proc parameter, a global or
+    # namespace variable read, an upvar target) holds a runtime-unknown
+    # value, so it is ⊥, not ⊤.  Without this seeding such a root defaults
+    # to UNKNOWN, and because UNKNOWN is the join identity it silently
+    # vanishes from any phi it feeds — e.g. ``join(const 0, $runtime)``
+    # would fold to ``0`` and make a genuinely runtime condition look
+    # constant (a false-positive "always true/false" branch).
+    defined_keys: set[SSAValueKey] = set()
+    used_keys: set[SSAValueKey] = set()
+    for sblock in ssa.blocks.values():
+        for phi in sblock.phis:
+            defined_keys.add((phi.name, phi.version))
+            for inc in phi.incoming.values():
+                if inc > 0:
+                    used_keys.add((phi.name, inc))
+        for s in sblock.statements:
+            for var, ver in s.defs.items():
+                defined_keys.add((var, ver))
+            used_keys.update(s.uses.items())
+    for term_bn, term_block in cfg.blocks.items():
+        term = term_block.terminator
+        if isinstance(term, CFGBranch):
+            sb = ssa.blocks.get(term_bn)
+            if sb is not None:
+                used_keys.update(_condition_use_versions(term.condition, sb.exit_versions).items())
+    for key in used_keys - defined_keys:
+        if key not in values:
+            values[key] = OVERDEFINED
 
-            incoming_exec_preds = [p for p in preds.get(bn, set()) if (p, bn) in executable_edges]
-            for phi in ssa_block.phis:
-                if bn == cfg.entry:
+    def branch_targets(block_name: str, condition: ExprNode, tt: str, ft: str) -> tuple[str, ...]:
+        # Optimistic (Wegman–Zadeck) branch resolution: fold to a single
+        # edge when the condition is constant; mark BOTH arms only when it
+        # is genuinely non-constant (an OVERDEFINED operand, or
+        # all-constant but unfoldable).  While any operand is still UNKNOWN
+        # the condition may yet fold, so open NO edge and let a later pass
+        # retry — this is what detects loop-carried constant conditions
+        # instead of pessimistically opening both arms forever.  Soundness
+        # relies on every runtime-unknown input already being OVERDEFINED
+        # (live-in roots seeded above; undefined phi inputs joined as ⊥
+        # below), so a still-UNKNOWN operand genuinely means "not yet
+        # computed", never "unknowable".
+        decision = _evaluate_branch_decision(cfg, ssa, block_name, condition, values)
+        if decision is True:
+            return (tt,)
+        if decision is False:
+            return (ft,)
+        sb = ssa.blocks.get(block_name)
+        exit_versions = sb.exit_versions if sb is not None else {}
+        op_vals = [
+            values.get((n, v), UNKNOWN)
+            for n, v in _condition_use_versions(condition, exit_versions).items()
+        ]
+        if (
+            op_vals
+            and any(ov.kind is LatticeKind.UNKNOWN for ov in op_vals)
+            and not any(ov.kind is LatticeKind.OVERDEFINED for ov in op_vals)
+        ):
+            return ()
+        return (tt, ft)
+
+    # Optimistic fixpoint over the RPO sweep, followed by a finalization
+    # pass that forces both arms for any executable branch still stuck on
+    # an UNKNOWN condition (defensive: a value defined only in
+    # unreachable code could otherwise leave a successor spuriously
+    # unreachable).  ``finalizing`` is monotone, so the outer loop runs at
+    # most twice.
+    finalizing = False
+    while True:
+        changed = True
+        while changed:
+            changed = False
+            for bn in order:
+                if bn not in executable_blocks:
                     continue
-                if not incoming_exec_preds:
-                    continue
-                phi_val = UNKNOWN
-                for pred in incoming_exec_preds:
-                    incoming_ver = phi.incoming.get(pred, 0)
-                    if incoming_ver <= 0:
+                ssa_block = ssa.blocks[bn]
+
+                incoming_exec_preds = [
+                    p for p in preds.get(bn, set()) if (p, bn) in executable_edges
+                ]
+                for phi in ssa_block.phis:
+                    if bn == cfg.entry:
                         continue
-                    phi_val = _join(phi_val, values.get((phi.name, incoming_ver), UNKNOWN))
-                if set_value((phi.name, phi.version), phi_val):
-                    changed = True
-
-            for s in ssa_block.statements:
-                if isinstance(s.statement, IRBarrier):
-                    # Barriers can modify any variable — widen all
-                    # currently-tracked values to OVERDEFINED.  Only the
-                    # not-yet-widened keys need touching.
-                    if non_overdefined:
-                        for key in non_overdefined:
-                            values[key] = OVERDEFINED
-                        non_overdefined.clear()
-                        changed = True
-                    continue
-                for var, ver in s.defs.items():
-                    val = _evaluate_def(s.statement, s, values)
-                    if set_value((var, ver), val):
+                    if not incoming_exec_preds:
+                        continue
+                    phi_val = UNKNOWN
+                    for pred in incoming_exec_preds:
+                        incoming_ver = phi.incoming.get(pred, 0)
+                        if incoming_ver <= 0:
+                            # The variable is undefined / live-in on this
+                            # executable edge — a runtime-unknown value, ⊥.
+                            phi_val = _join(phi_val, OVERDEFINED)
+                        else:
+                            phi_val = _join(
+                                phi_val, values.get((phi.name, incoming_ver), UNKNOWN)
+                            )
+                    if set_value((phi.name, phi.version), phi_val):
                         changed = True
 
-            match cfg.blocks[bn].terminator:
-                case CFGGoto(target=target):
-                    edge = (bn, target)
+                for s in ssa_block.statements:
+                    if isinstance(s.statement, IRBarrier):
+                        # Barriers can modify any variable — widen all
+                        # currently-tracked values to OVERDEFINED.  Only the
+                        # not-yet-widened keys need touching.
+                        if non_overdefined:
+                            for key in non_overdefined:
+                                values[key] = OVERDEFINED
+                            non_overdefined.clear()
+                            changed = True
+                        continue
+                    for var, ver in s.defs.items():
+                        val = _evaluate_def(s.statement, s, values)
+                        if set_value((var, ver), val):
+                            changed = True
+
+                match cfg.blocks[bn].terminator:
+                    case CFGGoto(target=target):
+                        targets: tuple[str, ...] = (target,)
+                    case CFGBranch(condition=condition, true_target=tt, false_target=ft):
+                        targets = branch_targets(bn, condition, tt, ft)
+                        if not targets and finalizing:
+                            targets = (tt, ft)
+                    case _:
+                        targets = ()
+                for tgt in targets:
+                    edge = (bn, tgt)
                     if edge not in executable_edges:
                         executable_edges.add(edge)
                         changed = True
-                    if target in cfg.blocks and target not in executable_blocks:
-                        executable_blocks.add(target)
+                    if tgt in cfg.blocks and tgt not in executable_blocks:
+                        executable_blocks.add(tgt)
                         changed = True
-                case CFGBranch(condition=condition, true_target=tt, false_target=ft):
-                    decision = _evaluate_branch_decision(cfg, ssa, bn, condition, values)
-                    if decision is True:
-                        targets = (tt,)
-                    elif decision is False:
-                        targets = (ft,)
-                    else:
-                        targets = (tt, ft)
-                    for tgt in targets:
-                        edge = (bn, tgt)
-                        if edge not in executable_edges:
-                            executable_edges.add(edge)
-                            changed = True
-                        if tgt in cfg.blocks and tgt not in executable_blocks:
-                            executable_blocks.add(tgt)
-                            changed = True
-                case _:
-                    pass
-        time.sleep(0)  # Yield GIL between fixed-point iterations
+            time.sleep(0)  # Yield GIL between fixed-point iterations
+        if finalizing:
+            break
+        finalizing = True
 
     constant_branches: list[ConstantBranch] = []
     for bn in order:

--- a/core/compiler/core_analyses.py
+++ b/core/compiler/core_analyses.py
@@ -973,9 +973,7 @@ def _sccp(
                             # executable edge — a runtime-unknown value, ⊥.
                             phi_val = _join(phi_val, OVERDEFINED)
                         else:
-                            phi_val = _join(
-                                phi_val, values.get((phi.name, incoming_ver), UNKNOWN)
-                            )
+                            phi_val = _join(phi_val, values.get((phi.name, incoming_ver), UNKNOWN))
                     if set_value((phi.name, phi.version), phi_val):
                         changed = True
 

--- a/core/compiler/core_analyses.py
+++ b/core/compiler/core_analyses.py
@@ -69,7 +69,7 @@ from .ir import (
     IRStatement,
 )
 from .lowering import lower_to_ir
-from .ssa import SSAFunction, SSAStatement, SSAValueKey, build_ssa
+from .ssa import SSAFunction, SSAStatement, SSAValueKey, build_ssa, value_use_blocks
 from .static_loops import (
     evaluate_expr_with_constants,
     summarise_static_for_ir,
@@ -880,6 +880,16 @@ def _sccp(
             return True
         return False
 
+    # SCCP keeps the round-robin RPO sweep (no sparse worklist): it marks
+    # CFG edges executable as it goes and never un-marks them, so an
+    # undetermined branch (decision ``None``) conservatively marks BOTH
+    # targets.  The RPO sweep resolves a condition's value before the
+    # branch is visited, so the pessimistic both-edge marking is avoided;
+    # a value-driven worklist could visit the branch first (in a
+    # different order), permanently mark both edges, and lose precision
+    # (e.g. a constant condition no longer detected as always-false).
+    # The other propagations read this fixed executable set and only join
+    # values, so their worklists are order-independent.
     changed = True
     while changed:
         changed = False
@@ -929,13 +939,7 @@ def _sccp(
                         executable_blocks.add(target)
                         changed = True
                 case CFGBranch(condition=condition, true_target=tt, false_target=ft):
-                    decision = _evaluate_branch_decision(
-                        cfg,
-                        ssa,
-                        bn,
-                        condition,
-                        values,
-                    )
+                    decision = _evaluate_branch_decision(cfg, ssa, bn, condition, values)
                     if decision is True:
                         targets = (tt,)
                     elif decision is False:
@@ -1036,37 +1040,49 @@ def _liveness(
     live_in: dict[str, set[SSAValueKey]] = {bn: set() for bn in cfg.blocks}
     live_out: dict[str, set[SSAValueKey]] = {bn: set() for bn in cfg.blocks}
     order = list(reversed(cfg.reverse_postorder()))
+    preds = _compute_predecessors(cfg)
 
-    changed = True
-    while changed:
-        changed = False
-        for bn in order:
-            match cfg.blocks[bn].terminator:
-                case CFGGoto(target=target):
-                    succs = (target,)
-                case CFGBranch(true_target=tt, false_target=ft):
-                    succs = (tt, ft)
-                case _:
-                    succs = ()
+    # Backward dataflow worklist: a block's live_out is built from its
+    # successors' live_in, so when live_in[bn] changes only bn's
+    # predecessors need recomputing — re-enqueue those instead of
+    # re-scanning every block each pass.
+    worklist: list[str] = list(order)
+    queued: set[str] = set(worklist)
+    yield_counter = 0
+    while worklist:
+        bn = worklist.pop()
+        queued.discard(bn)
+        match cfg.blocks[bn].terminator:
+            case CFGGoto(target=target):
+                succs = (target,)
+            case CFGBranch(true_target=tt, false_target=ft):
+                succs = (tt, ft)
+            case _:
+                succs = ()
 
-            out: set[SSAValueKey] = set()
-            for succ in succs:
-                if succ not in cfg.blocks:
-                    continue
-                edge_live = set(live_in[succ])
-                for phi in ssa.blocks[succ].phis:
-                    edge_live.discard((phi.name, phi.version))
-                    incoming = phi.incoming.get(bn, 0)
-                    if incoming > 0:
-                        edge_live.add((phi.name, incoming))
-                out |= edge_live
+        out: set[SSAValueKey] = set()
+        for succ in succs:
+            if succ not in cfg.blocks:
+                continue
+            edge_live = set(live_in[succ])
+            for phi in ssa.blocks[succ].phis:
+                edge_live.discard((phi.name, phi.version))
+                incoming = phi.incoming.get(bn, 0)
+                if incoming > 0:
+                    edge_live.add((phi.name, incoming))
+            out |= edge_live
 
-            new_in = use[bn] | (out - defs[bn])
-            if new_in != live_in[bn] or out != live_out[bn]:
-                live_in[bn] = new_in
-                live_out[bn] = out
-                changed = True
-        time.sleep(0)  # Yield GIL between fixed-point iterations
+        new_in = use[bn] | (out - defs[bn])
+        live_out[bn] = out
+        if new_in != live_in[bn]:
+            live_in[bn] = new_in
+            for p in preds.get(bn, set()):
+                if p not in queued:
+                    worklist.append(p)
+                    queued.add(p)
+        yield_counter += 1
+        if yield_counter % 256 == 0:
+            time.sleep(0)  # Yield GIL periodically
 
     return live_in, live_out
 
@@ -1590,58 +1606,70 @@ def _type_propagation(
 
     types: dict[SSAValueKey, TypeLattice] = {}
     order = cfg.reverse_postorder()
+    # Forward dataflow worklist: when a value's type changes, re-enqueue
+    # only the blocks that read it (precomputed def→use map) instead of
+    # re-scanning every block each pass.
+    deps = value_use_blocks(ssa)
+    changed_keys: list[SSAValueKey] = []
 
     def set_type(key: SSAValueKey, candidate: TypeLattice) -> bool:
         old = types.get(key, _TYPE_UNKNOWN)
         merged = type_join(old, candidate)
         if merged != old:
             types[key] = merged
+            changed_keys.append(key)
             return True
         return False
 
-    changed = True
-    while changed:
-        changed = False
-        for bn in order:
-            if bn not in executable_blocks:
-                continue
-            ssa_block = ssa.blocks.get(bn)
-            if ssa_block is None:
-                continue
+    worklist: list[str] = [bn for bn in order if bn in executable_blocks]
+    queued: set[str] = set(worklist)
+    yield_counter = 0
+    while worklist:
+        bn = worklist.pop()
+        queued.discard(bn)
+        ssa_block = ssa.blocks.get(bn)
+        if ssa_block is None:
+            continue
+        changed_keys.clear()
 
-            # Phi nodes
-            incoming_exec_preds = [p for p in preds.get(bn, set()) if (p, bn) in executable_edges]
-            for phi in ssa_block.phis:
-                if bn == cfg.entry:
+        # Phi nodes
+        incoming_exec_preds = [p for p in preds.get(bn, set()) if (p, bn) in executable_edges]
+        for phi in ssa_block.phis:
+            if bn == cfg.entry:
+                continue
+            if not incoming_exec_preds:
+                continue
+            phi_type = _TYPE_UNKNOWN
+            for pred in incoming_exec_preds:
+                incoming_ver = phi.incoming.get(pred, 0)
+                if incoming_ver <= 0:
                     continue
-                if not incoming_exec_preds:
-                    continue
-                phi_type = _TYPE_UNKNOWN
-                for pred in incoming_exec_preds:
-                    incoming_ver = phi.incoming.get(pred, 0)
-                    if incoming_ver <= 0:
-                        continue
-                    phi_type = type_join(
-                        phi_type,
-                        types.get((phi.name, incoming_ver), _TYPE_UNKNOWN),
-                    )
-                if set_type((phi.name, phi.version), phi_type):
-                    changed = True
+                phi_type = type_join(
+                    phi_type,
+                    types.get((phi.name, incoming_ver), _TYPE_UNKNOWN),
+                )
+            set_type((phi.name, phi.version), phi_type)
 
-            # Statements
-            for s in ssa_block.statements:
-                stmt = s.statement
-                if isinstance(stmt, IRBarrier):
-                    # Barriers widen all defs to OVERDEFINED
-                    for var, ver in s.defs.items():
-                        if set_type((var, ver), _TYPE_OVERDEFINED):
-                            changed = True
-                    continue
+        # Statements
+        for s in ssa_block.statements:
+            stmt = s.statement
+            if isinstance(stmt, IRBarrier):
+                # Barriers widen all defs to OVERDEFINED
                 for var, ver in s.defs.items():
-                    inferred = _evaluate_type_def(stmt, s, values, types, known_classes)
-                    if set_type((var, ver), inferred):
-                        changed = True
-        time.sleep(0)  # Yield GIL between fixed-point iterations
+                    set_type((var, ver), _TYPE_OVERDEFINED)
+                continue
+            for var, ver in s.defs.items():
+                inferred = _evaluate_type_def(stmt, s, values, types, known_classes)
+                set_type((var, ver), inferred)
+
+        for key in changed_keys:
+            for ub in deps.get(key, ()):
+                if ub in executable_blocks and ub not in queued:
+                    worklist.append(ub)
+                    queued.add(ub)
+        yield_counter += 1
+        if yield_counter % 256 == 0:
+            time.sleep(0)  # Yield GIL periodically
 
     return types
 

--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -698,9 +698,7 @@ def _find_partial_redundancies(
 
     may_in: dict[BlockName, int] = {bn: 0 for bn in executable}
     may_out: dict[BlockName, int] = {bn: 0 for bn in executable}
-    must_in: dict[BlockName, int] = {
-        bn: (0 if bn == ssa.entry else full_mask) for bn in executable
-    }
+    must_in: dict[BlockName, int] = {bn: (0 if bn == ssa.entry else full_mask) for bn in executable}
     must_out: dict[BlockName, int] = {bn: transfer(bn, must_in[bn]) for bn in executable}
 
     changed = True

--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -567,28 +567,6 @@ def _cfg_predecessors(
     return preds
 
 
-def _cfg_order(cfg: CFGFunction, executable: set[BlockName]) -> list[BlockName]:
-    """Return a stable forward traversal order for executable blocks."""
-    seen: set[BlockName] = set()
-    order: list[BlockName] = []
-    stack: list[BlockName] = [cfg.entry]
-
-    while stack:
-        bn = stack.pop()
-        if bn in seen or bn not in executable:
-            continue
-        seen.add(bn)
-        order.append(bn)
-        succs = [s for s in _cfg_successors(cfg, bn) if s in executable]
-        for succ in reversed(succs):
-            stack.append(succ)
-
-    for bn in cfg.blocks:
-        if bn in executable and bn not in seen:
-            order.append(bn)
-    return order
-
-
 def _collect_function_occurrence_events(
     cfg: CFGFunction,
     ssa: SSAFunction,
@@ -690,7 +668,7 @@ def _find_partial_redundancies(
 
     universe: set[ExprKey] = {occ.key for occ in all_occurrences}
     preds = _cfg_predecessors(cfg, executable)
-    order = _cfg_order(cfg, executable)
+    order = [bn for bn in cfg.reverse_postorder() if bn in executable]
 
     may_in: dict[BlockName, set[ExprKey]] = {bn: set() for bn in executable}
     may_out: dict[BlockName, set[ExprKey]] = {bn: set() for bn in executable}

--- a/core/compiler/gvn.py
+++ b/core/compiler/gvn.py
@@ -626,19 +626,6 @@ def _collect_function_occurrence_events(
     return events_by_block, all_occurrences
 
 
-def _transfer_occurrence_keys(
-    events: tuple[_ExprOccurrence | None, ...],
-    in_set: set[ExprKey],
-) -> set[ExprKey]:
-    state = set(in_set)
-    for event in events:
-        if event is None:
-            state.clear()
-            continue
-        state.add(event.key)
-    return state
-
-
 def _find_partial_redundancies(
     cfg: CFGFunction,
     ssa: SSAFunction,
@@ -666,18 +653,55 @@ def _find_partial_redundancies(
     if not all_occurrences:
         return []
 
-    universe: set[ExprKey] = {occ.key for occ in all_occurrences}
     preds = _cfg_predecessors(cfg, executable)
     order = [bn for bn in cfg.reverse_postorder() if bn in executable]
 
-    may_in: dict[BlockName, set[ExprKey]] = {bn: set() for bn in executable}
-    may_out: dict[BlockName, set[ExprKey]] = {bn: set() for bn in executable}
-    must_in: dict[BlockName, set[ExprKey]] = {
-        bn: (set() if bn == ssa.entry else set(universe)) for bn in executable
+    # Encode the expression universe as bit indices so the availability
+    # fixpoint runs on integer bitmasks (one machine word per ~64
+    # expressions) instead of per-block hash sets.  The set form spent
+    # O(|universe|·|blocks|) just initialising must-in to ⊤ for every
+    # block, then re-built that full set via intersection each pass.
+    bit_of: dict[ExprKey, int] = {}
+    for occ in all_occurrences:
+        if occ.key not in bit_of:
+            bit_of[occ.key] = len(bit_of)
+    full_mask = (1 << len(bit_of)) - 1
+
+    # Per-block transfer.  The occurrence transfer clears state on a
+    # barrier (``None`` event) then adds every later key, so a block's
+    # out-state is either independent of in (a barrier is present → only
+    # post-barrier keys survive) or ``in | gen`` (no barrier → the keys
+    # generated in the block).  Precompute both forms once.
+    block_has_barrier: dict[BlockName, bool] = {}
+    block_post_barrier: dict[BlockName, int] = {}
+    block_gen: dict[BlockName, int] = {}
+    for bn in executable:
+        has_barrier = False
+        post = 0
+        gen = 0
+        for event in events_by_block.get(bn, ()):
+            if event is None:
+                has_barrier = True
+                post = 0
+                continue
+            b = 1 << bit_of[event.key]
+            gen |= b
+            post |= b
+        block_has_barrier[bn] = has_barrier
+        block_post_barrier[bn] = post
+        block_gen[bn] = gen
+
+    def transfer(bn: BlockName, in_mask: int) -> int:
+        if block_has_barrier[bn]:
+            return block_post_barrier[bn]
+        return in_mask | block_gen[bn]
+
+    may_in: dict[BlockName, int] = {bn: 0 for bn in executable}
+    may_out: dict[BlockName, int] = {bn: 0 for bn in executable}
+    must_in: dict[BlockName, int] = {
+        bn: (0 if bn == ssa.entry else full_mask) for bn in executable
     }
-    must_out: dict[BlockName, set[ExprKey]] = {
-        bn: _transfer_occurrence_keys(events_by_block.get(bn, ()), must_in[bn]) for bn in executable
-    }
+    must_out: dict[BlockName, int] = {bn: transfer(bn, must_in[bn]) for bn in executable}
 
     changed = True
     while changed:
@@ -685,25 +709,19 @@ def _find_partial_redundancies(
         for bn in order:
             pred_list = [p for p in preds.get(bn, set()) if p in executable]
             if bn == ssa.entry or not pred_list:
-                new_must_in: set[ExprKey] = set()
-                new_may_in: set[ExprKey] = set()
+                new_must_in = 0
+                new_may_in = 0
             else:
-                new_must_in = set(must_out[pred_list[0]])
+                new_must_in = must_out[pred_list[0]]
                 for p in pred_list[1:]:
                     new_must_in &= must_out[p]
 
-                new_may_in = set()
+                new_may_in = 0
                 for p in pred_list:
                     new_may_in |= may_out[p]
 
-            new_must_out = _transfer_occurrence_keys(
-                events_by_block.get(bn, ()),
-                new_must_in,
-            )
-            new_may_out = _transfer_occurrence_keys(
-                events_by_block.get(bn, ()),
-                new_may_in,
-            )
+            new_must_out = transfer(bn, new_must_in)
+            new_may_out = transfer(bn, new_may_in)
 
             if new_must_in != must_in[bn]:
                 must_in[bn] = new_must_in
@@ -728,18 +746,19 @@ def _find_partial_redundancies(
 
     results: list[RedundantComputation] = []
     for bn in order:
-        state_may = set(may_in.get(bn, set()))
-        state_must = set(must_in.get(bn, set()))
+        state_may = may_in.get(bn, 0)
+        state_must = must_in.get(bn, 0)
 
         for event in events_by_block.get(bn, ()):
             if event is None:
-                state_may.clear()
-                state_must.clear()
+                state_may = 0
+                state_must = 0
                 continue
 
             occ = event
+            b = bit_of[occ.key]
             if len(key_offsets.get(occ.key, ())) >= 2:
-                if occ.key in state_may and occ.key not in state_must:
+                if (state_may >> b) & 1 and not ((state_must >> b) & 1):
                     first_occ = first_by_key.get(occ.key, occ)
                     if first_occ.range.start.offset != occ.range.start.offset:
                         results.append(
@@ -751,8 +770,9 @@ def _find_partial_redundancies(
                             )
                         )
 
-            state_may.add(occ.key)
-            state_must.add(occ.key)
+            bit = 1 << b
+            state_may |= bit
+            state_must |= bit
 
     return results
 

--- a/core/compiler/interprocedural.py
+++ b/core/compiler/interprocedural.py
@@ -1120,9 +1120,7 @@ def analyse_interprocedural_ir(
         qname = worklist.pop()
         queued.discard(qname)
         local = local_proc_summaries[qname]
-        new_pure = local_pure_base[qname] and all(
-            pure.get(callee, False) for callee in local.calls
-        )
+        new_pure = local_pure_base[qname] and all(pure.get(callee, False) for callee in local.calls)
         if new_pure != pure[qname]:
             pure[qname] = new_pure
             for caller in callers[qname]:

--- a/core/compiler/interprocedural.py
+++ b/core/compiler/interprocedural.py
@@ -1102,35 +1102,59 @@ def analyse_interprocedural_ir(
             and local.local_effect_writes == EffectRegion.NONE
         )
 
+    # Reverse call graph: callers[callee] = procs that call it.  Both
+    # fixpoints below propagate a monotone change at a proc only to its
+    # callers, so a worklist visits O(edges) work instead of re-scanning
+    # every proc each pass (round-robin was O(procs² · fanout) on deep
+    # call chains).
+    callers: dict[str, set[str]] = {qname: set() for qname in local_proc_summaries}
+    for qname, local in local_proc_summaries.items():
+        for callee in local.calls:
+            if callee in callers:
+                callers[callee].add(qname)
+
     pure: dict[str, bool] = dict(local_pure_base)
-    changed = True
-    while changed:
-        changed = False
-        for qname, local in local_proc_summaries.items():
-            new_pure = local_pure_base[qname] and all(
-                pure.get(callee, False) for callee in local.calls
-            )
-            if new_pure != pure[qname]:
-                pure[qname] = new_pure
-                changed = True
+    worklist: list[str] = list(local_proc_summaries)
+    queued: set[str] = set(worklist)
+    while worklist:
+        qname = worklist.pop()
+        queued.discard(qname)
+        local = local_proc_summaries[qname]
+        new_pure = local_pure_base[qname] and all(
+            pure.get(callee, False) for callee in local.calls
+        )
+        if new_pure != pure[qname]:
+            pure[qname] = new_pure
+            for caller in callers[qname]:
+                if caller not in queued:
+                    worklist.append(caller)
+                    queued.add(caller)
 
     effect_reads: dict[str, EffectRegion] = dict(local_reads)
     effect_writes: dict[str, EffectRegion] = dict(local_writes)
-    changed = True
-    while changed:
-        changed = False
-        for qname, local in local_proc_summaries.items():
-            new_reads = local_reads[qname]
-            new_writes = local_writes[qname]
-            for callee in local.calls:
-                new_reads |= effect_reads.get(callee, EffectRegion.UNKNOWN_STATE)
-                new_writes |= effect_writes.get(callee, EffectRegion.UNKNOWN_STATE)
-            if new_reads != effect_reads[qname]:
-                effect_reads[qname] = new_reads
-                changed = True
-            if new_writes != effect_writes[qname]:
-                effect_writes[qname] = new_writes
-                changed = True
+    worklist = list(local_proc_summaries)
+    queued = set(worklist)
+    while worklist:
+        qname = worklist.pop()
+        queued.discard(qname)
+        local = local_proc_summaries[qname]
+        new_reads = local_reads[qname]
+        new_writes = local_writes[qname]
+        for callee in local.calls:
+            new_reads |= effect_reads.get(callee, EffectRegion.UNKNOWN_STATE)
+            new_writes |= effect_writes.get(callee, EffectRegion.UNKNOWN_STATE)
+        dirty = False
+        if new_reads != effect_reads[qname]:
+            effect_reads[qname] = new_reads
+            dirty = True
+        if new_writes != effect_writes[qname]:
+            effect_writes[qname] = new_writes
+            dirty = True
+        if dirty:
+            for caller in callers[qname]:
+                if caller not in queued:
+                    worklist.append(caller)
+                    queued.add(caller)
 
     summaries: dict[str, ProcSummary] = {}
     for qname in sorted(ir_module.procedures):

--- a/core/compiler/interprocedural.py
+++ b/core/compiler/interprocedural.py
@@ -773,12 +773,13 @@ def _scan_local_facts(
 
 
 def _compute_param_dependencies(
+    cfg: CFGFunction,
     ssa: SSAFunction,
     params: tuple[str, ...],
 ) -> dict[SSAValueKey, frozenset[str]]:
     param_set = set(params)
     deps: dict[SSAValueKey, set[str]] = {}
-    order = list(ssa.blocks.keys())
+    order = cfg.reverse_postorder()
 
     changed = True
     while changed:
@@ -992,7 +993,7 @@ def _summarise_proc_local(
             if facts.writes_global:
                 break
 
-    param_deps = _compute_param_dependencies(ssa, proc.params)
+    param_deps = _compute_param_dependencies(cfg, ssa, proc.params)
     return_infos = _collect_return_infos(
         cfg,
         ssa,

--- a/core/compiler/rendered_properties.py
+++ b/core/compiler/rendered_properties.py
@@ -411,25 +411,8 @@ def rendered_properties_propagation(
 
     props: dict[SSAValueKey, RenderedValueProps] = {}
 
-    # DFS traversal order.
-    seen: set[str] = set()
-    order: list[str] = []
-    stack = [cfg.entry]
-    while stack:
-        _bn = stack.pop()
-        if _bn in seen or _bn not in cfg.blocks:
-            continue
-        seen.add(_bn)
-        order.append(_bn)
-        match cfg.blocks[_bn].terminator:
-            case CFGGoto(target=_t):
-                _s_list = [_t]
-            case CFGBranch(true_target=_tt, false_target=_ft):
-                _s_list = [_tt, _ft]
-            case _:
-                _s_list = []
-        for _s in reversed(_s_list):
-            stack.append(_s)
+    # Forward dataflow over the shared reverse-postorder.
+    order = cfg.reverse_postorder()
 
     def set_props(key: SSAValueKey, candidate: RenderedValueProps) -> bool:
         old = props.get(key, _BOTTOM)

--- a/core/compiler/rendered_properties.py
+++ b/core/compiler/rendered_properties.py
@@ -37,7 +37,7 @@ from .ir import (
     IRCall,
     IRIncr,
 )
-from .ssa import SSAFunction, SSAStatement, SSAValueKey
+from .ssa import SSAFunction, SSAStatement, SSAValueKey, value_use_blocks
 from .value_shapes import is_pure_var_ref, parse_command_substitution
 
 
@@ -414,54 +414,64 @@ def rendered_properties_propagation(
     # Forward dataflow over the shared reverse-postorder.
     order = cfg.reverse_postorder()
 
+    # Forward dataflow worklist: when a value's properties change,
+    # re-enqueue only the blocks that read it instead of re-scanning
+    # every block each pass.
+    deps = value_use_blocks(ssa)
+    changed_keys: list[SSAValueKey] = []
+
     def set_props(key: SSAValueKey, candidate: RenderedValueProps) -> bool:
         old = props.get(key, _BOTTOM)
         merged = rendered_join(old, candidate)
         if merged != old:
             props[key] = merged
+            changed_keys.append(key)
             return True
         return False
 
-    changed = True
-    while changed:
-        changed = False
-        for bn in order:
-            if bn not in executable_blocks:
-                continue
-            ssa_block = ssa.blocks.get(bn)
-            if ssa_block is None:
-                continue
+    worklist: list[str] = [bn for bn in order if bn in executable_blocks]
+    queued: set[str] = set(worklist)
+    while worklist:
+        bn = worklist.pop()
+        queued.discard(bn)
+        ssa_block = ssa.blocks.get(bn)
+        if ssa_block is None:
+            continue
+        changed_keys.clear()
 
-            # Phi nodes.
-            incoming_exec_preds = [p for p in preds.get(bn, set()) if (p, bn) in executable_edges]
-            for phi in ssa_block.phis:
-                if bn == cfg.entry:
+        # Phi nodes.
+        incoming_exec_preds = [p for p in preds.get(bn, set()) if (p, bn) in executable_edges]
+        for phi in ssa_block.phis:
+            if bn == cfg.entry:
+                continue
+            if not incoming_exec_preds:
+                continue
+            phi_props = _BOTTOM
+            for pred in incoming_exec_preds:
+                incoming_ver = phi.incoming.get(pred, 0)
+                if incoming_ver <= 0:
                     continue
-                if not incoming_exec_preds:
-                    continue
-                phi_props = _BOTTOM
-                for pred in incoming_exec_preds:
-                    incoming_ver = phi.incoming.get(pred, 0)
-                    if incoming_ver <= 0:
-                        continue
-                    phi_props = rendered_join(
-                        phi_props,
-                        props.get((phi.name, incoming_ver), _BOTTOM),
-                    )
-                if set_props((phi.name, phi.version), phi_props):
-                    changed = True
+                phi_props = rendered_join(
+                    phi_props,
+                    props.get((phi.name, incoming_ver), _BOTTOM),
+                )
+            set_props((phi.name, phi.version), phi_props)
 
-            # Statements.
-            for s in ssa_block.statements:
-                stmt = s.statement
-                if isinstance(stmt, IRBarrier):
-                    for var, ver in s.defs.items():
-                        if set_props((var, ver), _TOP):
-                            changed = True
-                    continue
+        # Statements.
+        for s in ssa_block.statements:
+            stmt = s.statement
+            if isinstance(stmt, IRBarrier):
                 for var, ver in s.defs.items():
-                    inferred = _evaluate_rendered_def(stmt, s, props)
-                    if set_props((var, ver), inferred):
-                        changed = True
+                    set_props((var, ver), _TOP)
+                continue
+            for var, ver in s.defs.items():
+                inferred = _evaluate_rendered_def(stmt, s, props)
+                set_props((var, ver), inferred)
+
+        for key in changed_keys:
+            for ub in deps.get(key, ()):
+                if ub in executable_blocks and ub not in queued:
+                    worklist.append(ub)
+                    queued.add(ub)
 
     return props

--- a/core/compiler/ssa.py
+++ b/core/compiler/ssa.py
@@ -349,6 +349,30 @@ class SSAFunction:
     dominator_tree: dict[BlockName, tuple[BlockName, ...]]
 
 
+def value_use_blocks(ssa: SSAFunction) -> dict[SSAValueKey, set[BlockName]]:
+    """Map each SSA value ``(name, version)`` to the blocks that read it.
+
+    A reader is any block whose phi nodes take that version on an incoming
+    edge, or whose statements use it.  Forward dataflow worklists
+    (SCCP, type / rendered-property / taint propagation) use this to
+    re-enqueue exactly the blocks affected when a value's lattice entry
+    changes, instead of re-scanning every block on every fixpoint pass.
+
+    Terminator (branch/return) uses are not included — passes that read
+    values in a terminator add those dependencies themselves.
+    """
+    deps: dict[SSAValueKey, set[BlockName]] = {}
+    for bn, block in ssa.blocks.items():
+        for phi in block.phis:
+            for inc_ver in phi.incoming.values():
+                if inc_ver > 0:
+                    deps.setdefault((phi.name, inc_ver), set()).add(bn)
+        for s in block.statements:
+            for name, ver in s.uses.items():
+                deps.setdefault((name, ver), set()).add(bn)
+    return deps
+
+
 def _reachable_blocks(cfg: CFGFunction) -> set[str]:
     seen: set[str] = set()
     stack = [cfg.entry]

--- a/core/compiler/ssa.py
+++ b/core/compiler/ssa.py
@@ -402,6 +402,68 @@ def _dominators(
     return dom
 
 
+def _compute_idom_fast(
+    cfg: CFGFunction,
+    reachable: set[str],
+    preds: dict[str, set[str]],
+) -> dict[str, str | None]:
+    """Immediate dominators via Cooper-Harvey-Kennedy.
+
+    Computes idom directly over reverse-postorder indices with the
+    walk-up ``intersect`` — O(N) memory, no per-block dominator sets.
+    The naive set-based fixpoint (:func:`_dominators` /
+    :func:`_immediate_dominators`, retained for cross-validation) is
+    O(N²) memory / ~O(N³) time and OOMs on a single huge generated proc
+    that lowers to tens of thousands of CFG blocks.
+
+    Result shape matches the set-based path exactly: entry → ``None``,
+    unreachable → ``None``, otherwise the immediate-dominator block.
+
+    Reference: ``compute_idom_fast`` in ``rust/tcl-compiler/src/ssa.rs``.
+    """
+    out: dict[str, str | None] = {bn: None for bn in cfg.blocks}
+    # Pure reachable RPO (entry == index 0): reverse_postorder lists
+    # reachable blocks first in true RPO, so filtering drops only the
+    # unreachable tail.
+    rpo = [bn for bn in cfg.reverse_postorder() if bn in reachable]
+    if not rpo:
+        return out
+    rpo_index = {bn: i for i, bn in enumerate(rpo)}
+    undef = -1
+    idom = [undef] * len(rpo)
+    idom[0] = 0  # entry dominates itself (sentinel for the walk-up)
+
+    def intersect(a: int, b: int) -> int:
+        # Walk both nodes up the idom tree until they meet; a dominator
+        # always has a strictly smaller RPO index.
+        while a != b:
+            while a > b:
+                a = idom[a]
+            while b > a:
+                b = idom[b]
+        return a
+
+    changed = True
+    while changed:
+        changed = False
+        # Process in RPO order (skipping the entry) so each block sees
+        # already-processed predecessors.
+        for i in range(1, len(rpo)):
+            new_idom = undef
+            for p in preds.get(rpo[i], set()):
+                pi = rpo_index.get(p)
+                if pi is None or idom[pi] == undef:
+                    continue  # unreachable / not yet processed this pass
+                new_idom = pi if new_idom == undef else intersect(pi, new_idom)
+            if new_idom != undef and idom[i] != new_idom:
+                idom[i] = new_idom
+                changed = True
+
+    for i, bn in enumerate(rpo):
+        out[bn] = None if i == 0 or idom[i] == undef else rpo[idom[i]]
+    return out
+
+
 def _immediate_dominators(
     cfg: CFGFunction,
     reachable: set[str],
@@ -486,8 +548,7 @@ def build_ssa(cfg: CFGFunction) -> SSAFunction:
     """Build SSA with dominator-based phi placement and renaming."""
     reachable = _reachable_blocks(cfg)
     preds = _predecessors(cfg)
-    dom = _dominators(cfg, reachable, preds)
-    idom = _immediate_dominators(cfg, reachable, dom)
+    idom = _compute_idom_fast(cfg, reachable, preds)
     df = _dominance_frontier(cfg, reachable, preds, idom)
     tree = _dom_tree(idom)
     phi_vars = _phi_vars(cfg, reachable, df)
@@ -511,57 +572,75 @@ def build_ssa(cfg: CFGFunction) -> SSAFunction:
     exit_versions: dict[str, dict[str, int]] = {bn: {} for bn in cfg.blocks}
     stmt_infos: dict[str, list[SSAStatement]] = {bn: [] for bn in cfg.blocks}
 
-    def rename(bn: str) -> None:
-        pushed_in_block: list[str] = []
+    # Rename walk over the dominator tree.  Iterative with an explicit
+    # stack rather than recursion: a long block chain ⇒ deep dominator
+    # tree, which a recursive descent overflows at the common 2 MB
+    # worker-thread stack.  Each frame is processed in two phases —
+    # ``_ENTER`` does the per-block work (phis, statements, successor phi
+    # edges), then ``_CHILDREN`` walks the dominator-tree children and,
+    # once exhausted, pops the versions this block pushed.
+    _ENTER, _CHILDREN = 0, 1
+    work: list[list] = []
+    if cfg.entry in cfg.blocks:
+        work.append([cfg.entry, 0, [], _ENTER])
 
-        for var in sorted(phi_vars.get(bn, set())):
-            ver = push_new(var)
-            pushed_in_block.append(var)
-            phi_versions[bn][var] = ver
-            phi_incoming[bn].setdefault(var, {})
+    while work:
+        frame = work[-1]
+        bn = frame[0]
+        if frame[3] == _ENTER:
+            pushed_in_block: list[str] = frame[2]
 
-        visible_vars = set(stacks.keys()) | set(phi_versions[bn].keys())
-        entry_versions[bn] = {v: top(v) for v in sorted(visible_vars) if top(v) > 0}
-
-        for stmt in cfg.blocks[bn].statements:
-            uses_map: dict[str, int] = {}
-            for var in _uses(stmt):
-                uses_map[var] = top(var)
-
-            defs_map: dict[str, int] = {}
-            for var in _defs(stmt):
+            for var in sorted(phi_vars.get(bn, set())):
                 ver = push_new(var)
                 pushed_in_block.append(var)
-                defs_map[var] = ver
+                phi_versions[bn][var] = ver
+                phi_incoming[bn].setdefault(var, {})
 
-            stmt_infos[bn].append(
-                SSAStatement(
-                    statement=stmt,
-                    uses=uses_map,
-                    defs=defs_map,
+            visible_vars = set(stacks.keys()) | set(phi_versions[bn].keys())
+            entry_versions[bn] = {v: top(v) for v in sorted(visible_vars) if top(v) > 0}
+
+            for stmt in cfg.blocks[bn].statements:
+                uses_map: dict[str, int] = {}
+                for var in _uses(stmt):
+                    uses_map[var] = top(var)
+
+                defs_map: dict[str, int] = {}
+                for var in _defs(stmt):
+                    ver = push_new(var)
+                    pushed_in_block.append(var)
+                    defs_map[var] = ver
+
+                stmt_infos[bn].append(
+                    SSAStatement(
+                        statement=stmt,
+                        uses=uses_map,
+                        defs=defs_map,
+                    )
                 )
-            )
 
-        visible_vars = set(stacks.keys()) | set(phi_versions[bn].keys())
-        exit_versions[bn] = {v: top(v) for v in sorted(visible_vars) if top(v) > 0}
+            visible_vars = set(stacks.keys()) | set(phi_versions[bn].keys())
+            exit_versions[bn] = {v: top(v) for v in sorted(visible_vars) if top(v) > 0}
 
-        for succ in _successors(cfg.blocks[bn].terminator):
-            if succ not in cfg.blocks:
-                continue
-            for var in sorted(phi_vars.get(succ, set())):
-                phi_incoming[succ].setdefault(var, {})
-                phi_incoming[succ][var][bn] = top(var)
+            for succ in _successors(cfg.blocks[bn].terminator):
+                if succ not in cfg.blocks:
+                    continue
+                for var in sorted(phi_vars.get(succ, set())):
+                    phi_incoming[succ].setdefault(var, {})
+                    phi_incoming[succ][var][bn] = top(var)
 
-        for child in tree.get(bn, []):
-            rename(child)
-
-        for var in reversed(pushed_in_block):
-            stacks[var].pop()
-            if not stacks[var]:
-                del stacks[var]
-
-    if cfg.entry in cfg.blocks:
-        rename(cfg.entry)
+            frame[3] = _CHILDREN
+        else:
+            children = tree.get(bn, [])
+            if frame[1] < len(children):
+                child = children[frame[1]]
+                frame[1] += 1
+                work.append([child, 0, [], _ENTER])
+            else:
+                for var in reversed(frame[2]):
+                    stacks[var].pop()
+                    if not stacks[var]:
+                        del stacks[var]
+                work.pop()
 
     ssa_blocks: dict[str, SSABlock] = {}
     for bn, block in cfg.blocks.items():

--- a/core/compiler/taint/_propagation.py
+++ b/core/compiler/taint/_propagation.py
@@ -23,7 +23,7 @@ from ..ir import (
     IRCall,
     IRIncr,
 )
-from ..ssa import SSAFunction, SSAValueKey
+from ..ssa import SSAFunction, SSAValueKey, value_use_blocks
 from ..value_shapes import is_pure_var_ref, parse_command_substitution
 from ._lattice import (
     _TAINTED,
@@ -531,23 +531,41 @@ def taint_propagation(
     # Forward dataflow over the shared reverse-postorder.
     order = cfg.reverse_postorder()
 
+    # Forward dataflow worklist: a value's change re-enqueues only the
+    # blocks that read it (precomputed def→use map) instead of re-scanning
+    # every block each pass.  The alias closure stays a whole-function
+    # step run between worklist drains until both reach a fixpoint.
+    deps = value_use_blocks(ssa)
+    changed_keys: list[SSAValueKey] = []
+
     def set_taint(key: SSAValueKey, candidate: TaintLattice) -> bool:
         old = taints.get(key, _UNTAINTED)
         merged = taint_join(old, candidate)
         if merged != old:
             taints[key] = merged
+            changed_keys.append(key)
             return True
         return False
 
-    changed = True
-    while changed:
-        changed = False
-        for bn in order:
-            if bn not in executable_blocks:
-                continue
+    worklist: list[str] = [bn for bn in order if bn in executable_blocks]
+    queued: set[str] = set(worklist)
+
+    def enqueue_readers() -> None:
+        for key in changed_keys:
+            for ub in deps.get(key, ()):
+                if ub in executable_blocks and ub not in queued:
+                    worklist.append(ub)
+                    queued.add(ub)
+
+    work_pending = True
+    while work_pending:
+        while worklist:
+            bn = worklist.pop()
+            queued.discard(bn)
             ssa_block = ssa.blocks.get(bn)
             if ssa_block is None:
                 continue
+            changed_keys.clear()
 
             # Phi nodes
             incoming_exec_preds = [p for p in preds.get(bn, set()) if (p, bn) in executable_edges]
@@ -565,8 +583,7 @@ def taint_propagation(
                         phi_taint,
                         taints.get((phi.name, incoming_ver), _UNTAINTED),
                     )
-                if set_taint((phi.name, phi.version), phi_taint):
-                    changed = True
+                set_taint((phi.name, phi.version), phi_taint)
 
             # Statements
             for s in ssa_block.statements:
@@ -574,8 +591,7 @@ def taint_propagation(
                 if isinstance(stmt, IRBarrier):
                     # Barriers conservatively taint all defs.
                     for var, ver in s.defs.items():
-                        if set_taint((var, ver), _TAINTED):
-                            changed = True
+                        set_taint((var, ver), _TAINTED)
                     continue
                 for var, ver in s.defs.items():
                     inferred = _evaluate_taint_def(
@@ -585,12 +601,16 @@ def taint_propagation(
                         caller_qname=cfg.name,
                         call_return_provider=call_return_provider,
                     )
-                    if set_taint((var, ver), inferred):
-                        changed = True
+                    set_taint((var, ver), inferred)
 
-        # Alias closure: share taint across names that alias the same storage.
+            enqueue_readers()
+
+        # Alias closure: share taint across names that alias the same
+        # storage.  Run once the per-block worklist drains; if it taints
+        # new values, re-enqueue their readers and drain again.
+        work_pending = False
         if alias_groups:
-            # Snapshot the per-group taint, then broadcast it to every member.
+            changed_keys.clear()
             for group in alias_groups:
                 group_taint = _UNTAINTED
                 for (name, _ver), t in taints.items():
@@ -603,7 +623,13 @@ def taint_propagation(
                 # by its own ``upvar`` declaration) observes it.
                 for name in group:
                     for ver in member_versions.get(name, (0,)):
-                        if set_taint((name, ver), group_taint):
-                            changed = True
+                        set_taint((name, ver), group_taint)
+            if changed_keys:
+                # The closure changed taint — re-enqueue any readers and
+                # loop so the worklist drains and the closure runs again
+                # (it reads every taint, so overlapping groups may still
+                # be propagating).
+                enqueue_readers()
+                work_pending = True
 
     return taints

--- a/core/compiler/taint/_propagation.py
+++ b/core/compiler/taint/_propagation.py
@@ -528,25 +528,8 @@ def taint_propagation(
                     if name in member_versions:
                         member_versions[name].add(ver)
 
-    # Compute traversal order (DFS over CFG, same algorithm as core_analyses).
-    _seen: set[str] = set()
-    order: list[str] = []
-    _stack = [cfg.entry]
-    while _stack:
-        _bn = _stack.pop()
-        if _bn in _seen or _bn not in cfg.blocks:
-            continue
-        _seen.add(_bn)
-        order.append(_bn)
-        match cfg.blocks[_bn].terminator:
-            case CFGGoto(target=_t):
-                _s_list = [_t]
-            case CFGBranch(true_target=_tt, false_target=_ft):
-                _s_list = [_tt, _ft]
-            case _:
-                _s_list = []
-        for _s in reversed(_s_list):
-            _stack.append(_s)
+    # Forward dataflow over the shared reverse-postorder.
+    order = cfg.reverse_postorder()
 
     def set_taint(key: SSAValueKey, candidate: TaintLattice) -> bool:
         old = taints.get(key, _UNTAINTED)

--- a/core/compiler/var_refs.py
+++ b/core/compiler/var_refs.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from ..commands.registry.runtime import ArgRole, arg_indices_for_role
 from ..common.naming import normalise_var_name
 from ..parsing.lexer import TclLexer
-from ..parsing.tokens import TokenType
+from ..parsing.tokens import Token, TokenType
 
 _DEFAULT_CACHE_SIZE = 512
 
@@ -80,12 +80,12 @@ class VarReferenceScanner:
     def _scan_script_uncached(self, source: str) -> frozenset[str]:
         """Scan without cache — called on cache miss."""
         vars_found: set[str] = set()
-        lexer = TclLexer(source)
+        # Tokenise once and share the token stream across the variable,
+        # var-read-role, and script-role scans below — each of those
+        # previously built its own ``TclLexer`` over the same source.
+        tokens = TclLexer(source).tokenise_all()
 
-        while True:
-            tok = lexer.get_token()
-            if tok is None:
-                break
+        for tok in tokens:
             if tok.type is TokenType.VAR:
                 name = normalise_var_name(tok.text)
                 if name:
@@ -94,15 +94,16 @@ class VarReferenceScanner:
                 vars_found |= self.scan_script(tok.text)
 
         if self._options.include_var_read_roles:
-            vars_found |= self._scan_var_read_role_names(source)
+            vars_found |= self._scan_var_read_role_names(tokens)
 
         if self._options.recurse_into_script_roles:
-            vars_found |= self._scan_script_role_args(source)
+            vars_found |= self._scan_script_role_args(tokens)
 
         return frozenset(vars_found)
 
-    def _scan_script_role_args(self, source: str) -> set[str]:
-        """Walk *source* command-by-command and recurse into BODY/EXPR args.
+    def _scan_script_role_args(self, tokens: list[Token]) -> set[str]:
+        """Walk a pre-tokenised script command-by-command, recursing into
+        BODY/EXPR args.
 
         Only argument positions registered as ``ArgRole.BODY`` (Tcl scripts)
         or ``ArgRole.EXPR`` (expressions) are descended into.  Plain braced
@@ -110,7 +111,6 @@ class VarReferenceScanner:
         for literals like ``set msg {$unused}``.
         """
         result: set[str] = set()
-        lexer = TclLexer(source)
         words: list[str] = []
         prev_type = TokenType.EOL
 
@@ -134,7 +134,7 @@ class VarReferenceScanner:
                 if inner:
                     result.update(self.scan_script(inner))
 
-        for tok in lexer.tokenise_all():
+        for tok in tokens:
             if tok.type in (TokenType.EOL, TokenType.EOF):
                 flush_command()
                 words = []
@@ -164,9 +164,8 @@ class VarReferenceScanner:
         flush_command()
         return result
 
-    def _scan_var_read_role_names(self, source: str) -> set[str]:
+    def _scan_var_read_role_names(self, tokens: list[Token]) -> set[str]:
         result: set[str] = set()
-        lexer = TclLexer(source)
         words: list[str] = []
         prev_type = TokenType.EOL
 
@@ -181,7 +180,7 @@ class VarReferenceScanner:
                     if name:
                         result.add(name)
 
-        for tok in lexer.tokenise_all():
+        for tok in tokens:
             if tok.type in (TokenType.EOL, TokenType.EOF):
                 flush_command()
                 words = []

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -12,7 +12,14 @@ from core.compiler.cfg import CFGBlock, CFGBranch, CFGFunction, CFGGoto, CFGRetu
 from core.compiler.expr_ast import ExprRaw
 from core.compiler.ir import IRAssignConst, IRAssignExpr
 from core.compiler.lowering import lower_to_ir
-from core.compiler.ssa import build_ssa
+from core.compiler.ssa import (
+    _compute_idom_fast,
+    _dominators,
+    _immediate_dominators,
+    _predecessors,
+    _reachable_blocks,
+    build_ssa,
+)
 from core.parsing.tokens import SourcePosition
 
 
@@ -145,3 +152,114 @@ class TestBarrierVarWriteRoles:
                 range=r, reason="dynamic command", command=cmd, args=("x", "y", "z")
             )
             assert _defs(barrier) == (), cmd
+
+
+class TestSharedTraversal:
+    """The centralised reverse-postorder + Cooper-Harvey-Kennedy idom."""
+
+    _SOURCES = [
+        "set a 1\nset b 2",
+        "if {$x} {set a 1} else {set a 2}\nset b [expr {$a + 0}]",
+        "set i 0\nwhile {$i < 10} {set i [expr {$i + 1}]}\nset done 1",
+        "for {set i 0} {$i < 5} {incr i} {if {$i} {set a 1} else {set a 2}}",
+        "switch $x {a {set r 1} b {set r 2} default {set r 3}}\nset y $r",
+        "if {$a} {if {$b} {set c 1} else {set c 2}} else {set c 3}\nset d $c",
+        "while {$a} {while {$b} {set x 1}\nset y 2}\nset z 3",
+    ]
+
+    def _cfgs(self):
+        for src in self._SOURCES:
+            yield build_cfg(lower_to_ir(src)).top_level
+
+    def test_reverse_postorder_entry_first_and_complete(self):
+        for cfg in self._cfgs():
+            order = cfg.reverse_postorder()
+            # Same set as cfg.blocks (reachable RPO + unreachable tail).
+            assert set(order) == set(cfg.blocks)
+            assert len(order) == len(cfg.blocks)
+            assert order[0] == cfg.entry
+
+    def test_reverse_postorder_respects_non_back_edges(self):
+        # Every reachable block appears after its non-back-edge
+        # predecessors.  We approximate "back edge" as an edge whose
+        # target precedes the source in RPO; all forward edges must be
+        # ordered pred-before-succ.
+        from core.compiler.cfg import _block_successors
+
+        for cfg in self._cfgs():
+            order = cfg.reverse_postorder()
+            pos = {bn: i for i, bn in enumerate(order)}
+            reachable = _reachable_blocks(cfg)
+            # Count forward vs back edges; a valid RPO has every edge
+            # either forward (pred < succ) or a genuine back edge into an
+            # ancestor.  At minimum the entry has no incoming forward edge.
+            for bn in reachable:
+                for succ in _block_successors(cfg.blocks[bn].terminator):
+                    if succ not in reachable:
+                        continue
+                    # forward edge ⇒ predecessor strictly earlier.
+                    if pos[succ] > pos[bn]:
+                        assert pos[bn] < pos[succ]
+
+    def test_compute_idom_fast_matches_reference(self):
+        # The production CHK path must produce exactly the same idom map
+        # as the naive set-based reference (_dominators →
+        # _immediate_dominators) on every shape.
+        for cfg in self._cfgs():
+            reachable = _reachable_blocks(cfg)
+            preds = _predecessors(cfg)
+            dom = _dominators(cfg, reachable, preds)
+            reference = _immediate_dominators(cfg, reachable, dom)
+            fast = _compute_idom_fast(cfg, reachable, preds)
+            assert fast == reference
+
+
+class TestDeepCFGStackSafety:
+    """A long block chain must not overflow the worker-thread stack.
+
+    The recursive dominator-tree rename / DFS traversal blew the stack on
+    machine-generated procs that lower to thousands of sequential blocks
+    (e.g. ~700 chained ``if {$c == N} {return X}`` arms).  Both the shared
+    reverse_postorder and the SSA rename walk are now iterative, so this
+    must complete under the common 2 MB worker-thread stack.
+    """
+
+    def _deep_chain_cfg(self, n: int) -> CFGFunction:
+        # entry -> b1 -> b2 -> ... -> bn -> exit, each block a trivial set.
+        r = _dummy_range()
+        blocks: dict[str, CFGBlock] = {}
+        names = ["entry"] + [f"b{i}" for i in range(1, n + 1)]
+        for idx, name in enumerate(names):
+            stmt = IRAssignConst(range=r, name=f"v{idx}", value="1")
+            nxt = names[idx + 1] if idx + 1 < len(names) else None
+            term = CFGGoto(target=nxt, range=r) if nxt else CFGReturn(range=r)
+            blocks[name] = CFGBlock(name=name, statements=(stmt,), terminator=term)
+        return CFGFunction(name="deep", entry="entry", blocks=blocks)
+
+    def test_deep_chain_under_small_stack(self):
+        import threading
+
+        cfg = self._deep_chain_cfg(8000)
+
+        result: dict[str, object] = {}
+
+        def run() -> None:
+            try:
+                ssa = build_ssa(cfg)
+                # idom forms a chain: each block's idom is its predecessor.
+                result["ok"] = len(ssa.blocks) == len(cfg.blocks)
+                result["rpo_len"] = len(cfg.reverse_postorder())
+            except Exception as exc:  # pragma: no cover - failure path
+                result["error"] = repr(exc)
+
+        old = threading.stack_size(2 * 1024 * 1024)
+        try:
+            t = threading.Thread(target=run)
+            t.start()
+            t.join()
+        finally:
+            threading.stack_size(old)
+
+        assert "error" not in result, result.get("error")
+        assert result.get("ok") is True
+        assert result.get("rpo_len") == len(cfg.blocks)

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -180,26 +180,29 @@ class TestSharedTraversal:
             assert order[0] == cfg.entry
 
     def test_reverse_postorder_respects_non_back_edges(self):
-        # Every reachable block appears after its non-back-edge
-        # predecessors.  We approximate "back edge" as an edge whose
-        # target precedes the source in RPO; all forward edges must be
-        # ordered pred-before-succ.
+        # A valid RPO places every block before all of its successors
+        # except across *back edges* (loop-closing edges).  In a reducible
+        # CFG a back edge is exactly one whose target dominates its source,
+        # so identify back edges via the dominance relation and require
+        # strict predecessor-before-successor ordering for every other edge.
         from core.compiler.cfg import _block_successors
 
         for cfg in self._cfgs():
             order = cfg.reverse_postorder()
             pos = {bn: i for i, bn in enumerate(order)}
             reachable = _reachable_blocks(cfg)
-            # Count forward vs back edges; a valid RPO has every edge
-            # either forward (pred < succ) or a genuine back edge into an
-            # ancestor.  At minimum the entry has no incoming forward edge.
+            preds = _predecessors(cfg)
+            dom = _dominators(cfg, reachable, preds)
             for bn in reachable:
                 for succ in _block_successors(cfg.blocks[bn].terminator):
                     if succ not in reachable:
                         continue
-                    # forward edge ⇒ predecessor strictly earlier.
-                    if pos[succ] > pos[bn]:
-                        assert pos[bn] < pos[succ]
+                    # Back edge (succ dominates bn) closes a loop, so RPO is
+                    # permitted to place succ earlier.  Every non-back edge
+                    # must order the predecessor strictly before the successor.
+                    if succ in dom[bn]:
+                        continue
+                    assert pos[bn] < pos[succ], (bn, succ, order)
 
     def test_compute_idom_fast_matches_reference(self):
         # The production CHK path must produce exactly the same idom map


### PR DESCRIPTION
## Summary

This PR significantly optimizes the compiler's dataflow analysis passes by:

1. **Centralizing CFG traversal order**: Introduces `CFGFunction.reverse_postorder()` as the single shared reverse-postorder implementation used across all passes (SCCP, liveness, type/rendered-property/taint propagation, GVN, interprocedural analysis). Replaces scattered per-pass `_cfg_order()` helpers.

2. **Optimizing dominator computation**: Replaces the O(N²) memory set-based dominator algorithm with the Cooper-Harvey-Kennedy algorithm (`_compute_idom_fast`), which runs in O(N) memory and ~O(N) time. Critical for handling machine-generated procs that lower to tens of thousands of CFG blocks.

3. **Implementing forward/backward dataflow worklists**: Replaces naive round-robin fixpoint iteration (re-scanning all blocks every pass) with targeted worklist algorithms:
   - **SCCP**: Tracks non-OVERDEFINED values and only widens barriers on those keys; uses optimistic branch resolution with a finalization pass
   - **Liveness**: Backward worklist that re-enqueues only predecessors when a block's live_in changes
   - **Type/rendered-property/taint propagation**: Forward worklists using `value_use_blocks()` to re-enqueue only blocks that read changed values
   - **Interprocedural analysis**: Reverse call-graph worklist for pure/effect propagation

4. **Making traversals stack-safe**: Converts recursive dominator-tree rename and DFS traversals to iterative implementations with explicit stacks, preventing stack overflow on deep block chains (thousands of sequential blocks).

5. **Adding `value_use_blocks()` helper**: New SSA utility that maps each value to blocks reading it, enabling efficient forward dataflow worklist construction.

## Key Changes

- `cfg.py`: Added `reverse_postorder()` method and `_block_successors()` helper
- `ssa.py`: 
  - Added `value_use_blocks()` function
  - Replaced `_dominators()` + `_immediate_dominators()` with `_compute_idom_fast()`
  - Converted recursive rename walk to iterative implementation
- `core_analyses.py`:
  - Removed `_cfg_order()` helper
  - Rewrote SCCP with optimistic branch resolution and finalization pass
  - Converted liveness to backward worklist algorithm
  - Updated all passes to use `cfg.reverse_postorder()`
- `rendered_properties.py`, `taint/_propagation.py`: Converted to forward worklist using `value_use_blocks()`
- `interprocedural.py`: Added reverse call-graph worklist for pure/effect propagation
- `gvn.py`: Optimized partial redundancy analysis with bitmask encoding
- `var_refs.py`: Tokenize once and share token stream across multiple scans

## Validation

- Added comprehensive tests in `test_ssa.py`:
  - `TestSharedTraversal`: Validates `reverse_postorder()` correctness and `_compute_idom_fast()` equivalence to reference implementation
  - `TestDeepCFGStackSafety`: Verifies stack safety on 8000-block chains under 2 MB thread stack
- Existing test suite passes; no test regressions

## Performance Impact

- Dominator computation: O(N²) → O(N) on large procs
- Dataflow fixpoints: O(blocks²) → O(blocks + edges) via worklists
- Handles machine-generated procs with thousands of blocks without stack overflow or timeout

https://claude.ai/code/session_01PuQVPSNGPoJcgBaAPKmcGf