### PR TITLE
Harden compiler-explorer LSP server wait

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=cf9ec45-dirty
-head=cf9ec451f4cf710ab7141feaf4750f887f1f1e2b
-date=2026-05-21T21:41:16Z
-fingerprint=0813d7125aecfb44d05858b6c7eba98244cc7c0156c9dbc7e81c1218d34dea6f
+describe=40d3f1f-dirty
+head=40d3f1f1d896da612b4423cb7e6a479b4305eee2
+date=2026-05-21T21:53:15Z
+fingerprint=347ba4bf05f9de403264d19cd61315cfb5b2ee618798f194dc1805a2164a1c90

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -24,9 +24,12 @@ import com.intellij.ui.jcef.JBCefJSQuery
 import com.tcllsp.jetbrains.settings.TclLspSettings
 import org.cef.browser.CefBrowser
 import org.cef.handler.CefLoadHandlerAdapter
-import java.util.concurrent.CompletableFuture
 
 private val LOG = Logger.getInstance("com.tcllsp.jetbrains.CompilerExplorer")
+
+/** How long [CompilerExplorerPanel.awaitRunningServer] waits for the lazily
+ *  started Tcl LSP server to reach Running before giving up. */
+private const val SERVER_WAIT_TIMEOUT_MS = 10_000L
 
 class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
 
@@ -226,7 +229,7 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
      * this runs on the [runCompile] background thread, so the sleep is safe.
      */
     @Suppress("UnstableApiUsage")
-    private fun awaitRunningServer(timeoutMs: Long = 10_000): LspServer? {
+    private fun awaitRunningServer(timeoutMs: Long = SERVER_WAIT_TIMEOUT_MS): LspServer? {
         val manager = LspServerManager.getInstance(project)
         fun running(): LspServer? =
             manager.getServersForProvider(TclLspServerSupportProvider::class.java)
@@ -234,27 +237,46 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
 
         running()?.let { return it }
 
-        ApplicationManager.getApplication().invokeLater {
+        // Kick the lazily-started server before the clock starts, so a busy EDT
+        // during startup can't eat the timeout budget before the start request
+        // even runs. invokeAndWait is safe here: this runs on a pooled thread,
+        // never the EDT, so it can't deadlock against the dispatch it waits on.
+        ApplicationManager.getApplication().invokeAndWait {
             manager.startServersIfNeeded(TclLspServerSupportProvider::class.java)
         }
 
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            Thread.sleep(150)
+        // Monotonic clock: a wall-clock adjustment must not distort the wait.
+        val deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000
+        while (System.nanoTime() < deadlineNanos) {
+            if (project.isDisposed) return null
+            try {
+                Thread.sleep(150)
+            } catch (e: InterruptedException) {
+                // Preserve cancellation semantics for the pooled-thread task.
+                Thread.currentThread().interrupt()
+                return null
+            }
             running()?.let { return it }
         }
         return null
     }
 
     private fun runCompile(source: String, dialect: String) {
-        CompletableFuture.runAsync {
+        // IntelliJ's pooled executor rather than the FJP common pool: the
+        // awaitRunningServer wait can block this task for several seconds, which
+        // would otherwise starve unrelated common-pool work.
+        ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 sendStatusToWebview("compiling")
 
                 val server = awaitRunningServer()
                 if (server == null) {
-                    sendErrorToWebview("LSP server not running")
-                    return@runAsync
+                    sendErrorToWebview(
+                        "Tcl LSP server did not become ready within " +
+                            "${SERVER_WAIT_TIMEOUT_MS / 1000}s — it may still be " +
+                            "starting up, or be disabled or not installed."
+                    )
+                    return@executeOnPooledThread
                 }
 
                 val result = server.sendRequestSync { lsp4j ->


### PR DESCRIPTION
## Summary

Follow-up to #476, addressing the five Copilot review comments on `awaitRunningServer` / `runCompile` in `CompilerExplorerToolWindowFactory.kt` that were left unresolved when that PR merged.

- **Monotonic clock** — the wait deadline now uses `System.nanoTime()` instead of `System.currentTimeMillis()`, so a wall-clock adjustment can't shorten/lengthen the wait. Also bails early if `project.isDisposed` becomes true mid-wait.
- **Interrupt handling** — `Thread.sleep` now catches `InterruptedException`, restores the interrupt flag (`Thread.currentThread().interrupt()`), and returns early so cancellation behaves predictably.
- **EDT timing** — the server is started via `invokeAndWait` *before* the timeout clock starts, so a busy EDT during startup can't burn the budget before the start request even runs. (Safe from a pooled thread, which is never the EDT.)
- **Thread-pool starvation** — `runCompile` runs on IntelliJ's `executeOnPooledThread` instead of `CompletableFuture.runAsync` (FJP common pool), which the multi-second wait could otherwise starve.
- **Clearer error** — the timeout message now distinguishes "still starting up / disabled / not installed" from a hard "not running".

## Test plan

- [x] `./gradlew compileKotlin` passes
- [x] `make test-slow` passes; `.test-slow.stamp` refreshed for the CI gate

https://claude.ai/code/session_01W1Zd1vzRPwoqMe9UrTgdev

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1Zd1vzRPwoqMe9UrTgdev)_