### PR TITLE
Implement execution traces, array defaults, and Tcl 9 features

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -1,9 +1,0 @@
-# tcl-lsp test-slow stamp — DO NOT EDIT BY HAND.
-# Written by 'make test-slow' on success; verified in CI via
-# 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
-# describe/head/date are informational (they change when this stamp is
-# committed, so they cannot be compared).
-describe=78debc65-dirty
-head=78debc656d5acad4d38e8642391074deefa6a61b
-date=2026-05-21T22:13:37Z
-fingerprint=7a9c45a12fb70d7b209484e5002220d7673a0e4254dbe7da56475d29d2db7aa9

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=07ed374-dirty
-head=07ed374f44e35548c53fbae1c4f41471ef3d644a
-date=2026-05-22T17:43:03Z
-fingerprint=39a488a1c89e8407d0fe8ad35ab869a18f82c07a2e4f1b67dc4f031bd4b7e1fb
+describe=875c78f-dirty
+head=875c78fce0647883ed756a98234a5401c1250cb4
+date=2026-05-22T19:22:08Z
+fingerprint=51c3597c7f258b2885568bf82d28c7da0722d7e46910cee5223e7f16da840cb9

--- a/core/compiler/codegen/wasm/_emitter/_commands.py
+++ b/core/compiler/codegen/wasm/_emitter/_commands.py
@@ -41,6 +41,15 @@ _VARIADIC_OVERFLOW_TO_EVAL = frozenset(
         "::lsort",
         "lsearch",
         "::lsearch",
+        # ``source`` has a fixed argc=1 runtime import (the bare
+        # ``source fileName`` fast path).  The option forms
+        # ``source -encoding enc fileName`` and ``source -nopkg
+        # fileName`` carry extra leading args, so route them through
+        # the interpreter's ``eval_source`` dispatcher (which strips
+        # the option and sources the trailing fileName) instead of
+        # feeding the first arg to the 1-arg import as the path.
+        "source",
+        "::source",
     }
 )
 

--- a/core/compiler/codegen/wasm/_emitter/_commands.py
+++ b/core/compiler/codegen/wasm/_emitter/_commands.py
@@ -50,6 +50,15 @@ _VARIADIC_OVERFLOW_TO_EVAL = frozenset(
         # feeding the first arg to the 1-arg import as the path.
         "source",
         "::source",
+        # ``package`` has a fixed argc=2 import covering the 2-arg
+        # subcommands (``package require X``, ``package provide X``).
+        # The longer forms — notably ``package ifneeded NAME VERSION
+        # SCRIPT`` (store) and ``package ifneeded NAME VERSION``
+        # (query), which ``tcltest::loadIntoChildInterpreter`` relies
+        # on — carry more args than the import accepts, so route them
+        # through the interpreter's ``eval_package`` dispatcher.
+        "package",
+        "::package",
     }
 )
 

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -1213,7 +1213,12 @@ class _WasmEmitterStmtMixin(_Base):
             # into a child interp.  The other ``package`` subcommands are
             # genuine no-ops under WASM, but ifneeded must route through
             # the interpreter's ``eval_package`` store/lookup.
-            if canonical_command == "::package" and args and args[0] == "ifneeded" and len(args) >= 3:
+            if (
+                canonical_command == "::package"
+                and args
+                and args[0] == "ifneeded"
+                and len(args) >= 3
+            ):
                 self._emit_eval_fallback(command, args)
                 self._emit(WasmOp.DROP)
                 return
@@ -1842,7 +1847,12 @@ class _WasmEmitterStmtMixin(_Base):
             # loadable-package registry lookup tcltest does to fetch a
             # child interp's load script.  Route through eval_package so
             # the stored script is returned rather than a null TclObj.
-            if canonical_command == "::package" and args and args[0] == "ifneeded" and len(args) >= 3:
+            if (
+                canonical_command == "::package"
+                and args
+                and args[0] == "ifneeded"
+                and len(args) >= 3
+            ):
                 self._emit_eval_fallback(command, args)
                 return
             self._emit_i32_const(0)

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -1207,6 +1207,16 @@ class _WasmEmitterStmtMixin(_Base):
                 self._emit_eval_fallback(command, args)
                 self._emit(WasmOp.DROP)
                 return
+            # ``package ifneeded NAME VERSION ?SCRIPT?`` carries real
+            # state — the loadable-package registry that
+            # ``tcltest::loadIntoChildInterpreter`` reads to load tcltest
+            # into a child interp.  The other ``package`` subcommands are
+            # genuine no-ops under WASM, but ifneeded must route through
+            # the interpreter's ``eval_package`` store/lookup.
+            if canonical_command == "::package" and args and args[0] == "ifneeded" and len(args) >= 3:
+                self._emit_eval_fallback(command, args)
+                self._emit(WasmOp.DROP)
+                return
             # ``namespace eval ns arg1 arg2 ...`` in statement context
             # with dynamic script args: build the script at WASM level
             # (so compiled-frame aliases like $arr($key) are resolved
@@ -1827,6 +1837,13 @@ class _WasmEmitterStmtMixin(_Base):
                     return
                 # Runtime imports missing — push null TclObj as fallback.
                 self._emit_i32_const(0)
+                return
+            # ``[package ifneeded NAME VERSION]`` in value context — the
+            # loadable-package registry lookup tcltest does to fetch a
+            # child interp's load script.  Route through eval_package so
+            # the stored script is returned rather than a null TclObj.
+            if canonical_command == "::package" and args and args[0] == "ifneeded" and len(args) >= 3:
+                self._emit_eval_fallback(command, args)
                 return
             self._emit_i32_const(0)
             return

--- a/core/compiler/codegen/wasm/_emitter/_statements.py
+++ b/core/compiler/codegen/wasm/_emitter/_statements.py
@@ -1882,6 +1882,29 @@ class _WasmEmitterStmtMixin(_Base):
             # ``info level 0`` argv0 — see
             # :meth:`_emit_prepare_pending_argv0`.
             argv0_local = self._emit_prepare_pending_argv0(command)
+
+            def _was_braced(call_arg_idx: int) -> bool:
+                """True if the call-site word at *call_arg_idx* was braced.
+
+                Mirrors ``_emit_cmd_proc_call``'s probe.  Without it, a
+                braced literal arg (``q {puts "$x $y"}``) reaches
+                ``_emit_value`` as a plain string and its embedded ``$x``
+                / ``[...]`` get substituted — wrong, since braces suppress
+                all substitution.  This path is the catch-body /
+                implicit-return tail; the statement path already passes
+                ``was_braced``."""
+                if tokens is None or tokens.argv is None:
+                    return False
+                tok_idx = call_arg_idx + 1
+                if tok_idx >= len(tokens.argv):
+                    return False
+                if tokens.single_token_word is not None:
+                    if tok_idx >= len(tokens.single_token_word):
+                        return False
+                    if not tokens.single_token_word[tok_idx]:
+                        return False
+                return tokens.argv[tok_idx].type == TokenType.STR
+
             if has_args_tail and n_params > 0:
                 # Variadic proc — pack call-site args past the fixed
                 # positionals into a single list TclObj for the
@@ -1893,14 +1916,17 @@ class _WasmEmitterStmtMixin(_Base):
                 # ``_emit_command_subst_value`` (value context).
                 fixed = n_params - 1
                 for i in range(min(fixed, len(args))):
-                    self._emit_value(args[i])
+                    self._emit_value(args[i], was_braced=_was_braced(i))
                 for _slot in range(len(args), fixed):
                     self._emit_i32_const(0)
-                self._emit_args_list(tuple(args[fixed:]))
+                self._emit_args_list(
+                    tuple(args[fixed:]),
+                    was_braced_fn=lambda i, base=fixed: _was_braced(base + i),
+                )
             else:
                 # Push exactly n_params args (truncate surplus, pad missing)
                 for i in range(min(n_params, len(args))):
-                    self._emit_value(args[i])
+                    self._emit_value(args[i], was_braced=_was_braced(i))
                 for _ in range(n_params - len(args)):
                     self._emit_i32_const(0)
             self._emit_push_pending_argv0(argv0_local)

--- a/core/compiler/codegen/wasm/_emitter/_variables.py
+++ b/core/compiler/codegen/wasm/_emitter/_variables.py
@@ -567,6 +567,20 @@ class _WasmEmitterVarMixin(_Base):
                     self._emit_obj_literal(name)
                     self._emit_call(lget_lenient)
                     return
+        # ``global``-declared name: consult the global table directly,
+        # never the WASM-local mirror — the mirror goes stale when a
+        # callee mutates the same global through its own ``global``
+        # declaration (e.g. a ``lappend g …`` whose value arg fires a
+        # trace whose callback ``global g; lappend g …``).  Mirrors the
+        # strict-read branch in ``_emit_var_read_obj``; the lenient
+        # variant uses ``tcl_global_get`` so an as-yet-unset global
+        # reads as a null TclObj instead of raising.
+        if name in self._globals:
+            gget_lenient = self._shared_imports.get("tcl_global_get")
+            if gget_lenient is not None:
+                self._emit_obj_literal(name)
+                self._emit_call(gget_lenient)
+                return
         if name.startswith("::"):
             gget_lenient = self._shared_imports.get("tcl_global_get")
             if gget_lenient is not None:

--- a/core/compiler/codegen/wasm/_emitter/cmds/append_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/append_.py
@@ -9,6 +9,7 @@ keeps the updated value on the stack for implicit return.
 from __future__ import annotations
 
 from ......commands.registry import REGISTRY, EmitContext
+from ..._ownership import Ownership
 from ..._parsing import _parse_array_ref
 from .._variables import _is_dynamic_var_name
 
@@ -60,13 +61,26 @@ def _emit_append(
 
     if use_var_path:
         for i, value_arg in enumerate(args[1:], start=1):
-            emitter._emit_var_read_obj(var_name)
+            # ``append`` auto-creates an unset variable (``append missing
+            # x`` ⇒ ``x``; ``append arr(new) x`` creates the element), so
+            # the read must be lenient — a missing scalar / array element
+            # / alias must read as the null TclObj (empty), not raise
+            # ``can't read "<var>": no such variable``.  ``tcl_cmd_append``
+            # treats null as the empty starting value.  Matches lappend
+            # and the var-24.x ``array default`` append cases.
+            emitter._emit_var_read_obj_lenient(var_name)
             emitter._emit_value(value_arg)
             emitter._emit_call(func_idx)
+            # ``tcl_cmd_append`` returns an OWNED handle (a fresh
+            # canonical-rebuild result on the slow path, or the input
+            # mutated in place on the fast path).  Declaring the write
+            # source OWNED balances the store's retain against the
+            # caller's +1 — without it the fresh element on an empty
+            # array is dropped before the store lands (var-24.7 append).
             if keep_last and i == last_index:
-                emitter._emit_var_write_obj_keep(var_name)
+                emitter._emit_var_write_obj_keep(var_name, source=Ownership.OWNED)
             else:
-                emitter._emit_var_write_obj(var_name)
+                emitter._emit_var_write_obj(var_name, source=Ownership.OWNED)
     else:
         var_idx = emitter._intern_local(var_name)
         for i, value_arg in enumerate(args[1:], start=1):

--- a/core/compiler/codegen/wasm/_emitter/cmds/lappend_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/lappend_.py
@@ -9,6 +9,7 @@ keeps the updated value on the stack for implicit return.
 from __future__ import annotations
 
 from ......commands.registry import REGISTRY, EmitContext
+from ..._ir import ValType
 from ..._ownership import Ownership
 from ..._parsing import _parse_array_ref
 from .._variables import _is_dynamic_var_name
@@ -57,8 +58,22 @@ def _emit_lappend(
     keep_last = context is EmitContext.VALUE
     last_index = len(args) - 1
 
+    # Tcl evaluates *all* of lappend's value arguments before reading
+    # the target variable for the read-modify-write.  A value arg can
+    # mutate that very variable as a side effect — e.g. a ``read`` trace
+    # whose callback unsets/rewrites the var (trace-16.*), or an inline
+    # ``[set var ...]`` / ``[incr var]``.  Evaluating each value first
+    # into a temp local, then reading the variable, makes the read
+    # observe those mutations instead of a pre-evaluation snapshot.
+    val_tmps: list[int] = []
+    for value_arg in args[1:]:
+        emitter._emit_value(value_arg)
+        tmp = emitter._add_extra_local(prefix="_lappend_v", val_type=ValType.I32)
+        emitter._emit_local_set(tmp)
+        val_tmps.append(tmp)
+
     if use_var_path:
-        for i, value_arg in enumerate(args[1:], start=1):
+        for i, tmp in enumerate(val_tmps, start=1):
             # ``lappend`` auto-creates an unset variable with the
             # appended values (``lappend missing a b`` ⇒ ``a b``), so
             # the read must be lenient: a missing alias / namespace
@@ -70,7 +85,7 @@ def _emit_lappend(
             # registers the alias but does not initialise the slot,
             # so the first ``lappend`` must initialise it itself.
             emitter._emit_var_read_obj_lenient(var_name)
-            emitter._emit_value(value_arg)
+            emitter._emit_local_get(tmp)
             emitter._emit_call(func_idx)
             # ``tcl_cmd_lappend`` returns either a freshly allocated
             # canonical-rebuild result (slow path, rc=1) or the input
@@ -88,9 +103,9 @@ def _emit_lappend(
                 emitter._emit_var_write_obj(var_name, source=Ownership.OWNED)
     else:
         var_idx = emitter._intern_local(var_name)
-        for i, value_arg in enumerate(args[1:], start=1):
+        for i, tmp in enumerate(val_tmps, start=1):
             emitter._emit_local_get(var_idx)
-            emitter._emit_value(value_arg)
+            emitter._emit_local_get(tmp)
             emitter._emit_call(func_idx)
             if keep_last and i == last_index:
                 emitter._emit_local_tee(var_idx)

--- a/core/compiler/codegen/wasm/_emitter/cmds/scope_.py
+++ b/core/compiler/codegen/wasm/_emitter/cmds/scope_.py
@@ -16,6 +16,20 @@ def _emit_global(
     """
     for var_name in args:
         emitter._globals.add(var_name)
+        # Register the same-name global alias in the runtime frame too
+        # (mirrors what ``upvar`` / ``variable`` already do via
+        # ``frame_alias_*``).  The compiled read/write fast paths use the
+        # WASM-local mirror, so this is mainly for the interpreter-side
+        # dispatch that consults the frame: e.g. ``trace add variable x``
+        # must see ``x`` as a global so the trace lands in the global
+        # directory and survives the proc's return (trace-17.2 / 17.3).
+        # No-op at top level (``frame_alias_global`` bails when no frame
+        # is active), so only worth emitting inside a proc body.
+        if emitter._is_proc:
+            alias_idx = emitter._shared_imports.get("tcl_frame_alias_global")
+            if alias_idx is not None:
+                emitter._emit_obj_literal(var_name)
+                emitter._emit_call(alias_idx)
         gget_idx = emitter._shared_imports.get("tcl_global_get")
         if gget_idx is not None:
             local_idx = emitter._intern_local(var_name)

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1085,6 +1085,21 @@ def _scan_needed_imports(
                     needed.add("tcl_lappend")
                 elif command == "::dict" and args and args[0] == "merge":
                     needed.add("tcl_dict_merge_pair")
+                elif command == "::set" and args and _parse_array_ref(args[0]) is not None:
+                    # ``set arr(key)`` (read) / ``set arr(key) value``
+                    # (write) route through ``_emit_array_element_read`` /
+                    # ``_emit_array_element_write`` (tcl_array_get /
+                    # tcl_array_set).  Those emitters fall back to a null
+                    # push when the import is absent, so a bare element
+                    # read whose array is never written elsewhere would
+                    # otherwise silently skip the read — and its variable
+                    # read traces never fire (trace-1.x).  The substitution
+                    # form ``$arr(k)`` is already covered by the value
+                    # scan; this handles the command-form spelling.
+                    if len(args) == 1:
+                        needed.add("tcl_array_get")
+                    else:
+                        needed.add("tcl_array_set")
                 elif command == "::global":
                     needed.add("tcl_global_get")
                     needed.add("tcl_global_set")

--- a/core/compiler/codegen/wasm/_scan.py
+++ b/core/compiler/codegen/wasm/_scan.py
@@ -1103,6 +1103,11 @@ def _scan_needed_imports(
                 elif command == "::global":
                     needed.add("tcl_global_get")
                     needed.add("tcl_global_set")
+                    # Inside a proc, ``global`` also registers a runtime
+                    # frame alias so interpreter-side dispatch (e.g. a
+                    # ``trace add variable`` on the name) resolves it to
+                    # the global — see _emit_global.
+                    needed.add("tcl_frame_alias_global")
                 elif command == "::upvar":
                     # upvar #0 resolves to a global alias — reads/writes go
                     # through the global table. The target name is computed

--- a/core/compiler/stdlib_prelude.py
+++ b/core/compiler/stdlib_prelude.py
@@ -212,6 +212,101 @@ def _recurse_bodies(stmt: IRStatement, out: set[str]) -> None:
         _collect_commands(stmt.body, out)
 
 
+def _walk_calls(script: IRScript):
+    """Yield every :class:`IRCall` anywhere in *script*, descending into
+    control-flow bodies (the same shape :func:`_recurse_bodies` walks)."""
+    for stmt in script.statements:
+        if isinstance(stmt, IRCall):
+            yield stmt
+        if isinstance(stmt, IRIf):
+            for clause in stmt.clauses:
+                yield from _walk_calls(clause.body)
+            if stmt.else_body:
+                yield from _walk_calls(stmt.else_body)
+        elif isinstance(stmt, IRFor):
+            yield from _walk_calls(stmt.init)
+            yield from _walk_calls(stmt.body)
+            yield from _walk_calls(stmt.next)
+        elif isinstance(stmt, (IRWhile, IRForeach, IRCatch, IRBlock, IRUpFrame)):
+            yield from _walk_calls(stmt.body)
+        elif isinstance(stmt, IRTry):
+            yield from _walk_calls(stmt.body)
+            for handler in stmt.handlers:
+                yield from _walk_calls(handler.body)
+            if stmt.finally_body:
+                yield from _walk_calls(stmt.finally_body)
+        elif isinstance(stmt, IRSwitch):
+            for arm in stmt.arms:
+                if arm.body:
+                    yield from _walk_calls(arm.body)
+            if stmt.default_body:
+                yield from _walk_calls(stmt.default_body)
+
+
+def _collect_package_requires(module: IRModule) -> set[str]:
+    """Names of packages the module statically ``package require``s.
+
+    Only literal names are collected — ``package require $name`` is a
+    run-time computation the compiler can't bundle, so it's skipped
+    (the runtime ``package`` machinery handles it instead)."""
+    names: set[str] = set()
+
+    def scan(script: IRScript) -> None:
+        for call in _walk_calls(script):
+            if call.command != "package" or len(call.args) < 2:
+                continue
+            if call.args[0] != "require":
+                continue
+            # ``package require ?-exact? NAME ?version?`` — skip the
+            # optional ``-exact`` flag to reach the package name.
+            idx = 1
+            if call.args[idx] == "-exact":
+                idx += 1
+            if idx >= len(call.args):
+                continue
+            name = call.args[idx]
+            if name and not _name_is_dynamic(name):
+                names.add(name)
+
+    scan(module.top_level)
+    for proc in module.procedures.values():
+        scan(proc.body)
+    return names
+
+
+# ``package ifneeded NAME VERSION [list source ?-encoding ENC? [file join
+# $dir FILE ...]]`` — the source-style entry a pkgIndex.tcl emits for a
+# pure-Tcl package (opt, msgcat, …).  ``tclPkgSetup`` / binary-loaded
+# packages use a different shape and are left to the runtime loader.
+_PKG_IFNEEDED_RE = re.compile(
+    r"package\s+ifneeded\s+(\S+)\s+\S+\s+\[list\s+source\s+"
+    r"(?:-encoding\s+\S+\s+)?\[file\s+join\s+\$dir\s+([^\]]+)\]\s*\]"
+)
+
+
+def _discover_packages(library_dir: Path) -> dict[str, str]:
+    """Map ``package name -> relative source file`` by parsing the
+    ``source``-style ``ifneeded`` entries in each ``*/pkgIndex.tcl``
+    under *library_dir*.  Packages whose index uses a non-source loader
+    (``tclPkgSetup``, binary ``load``) are omitted — those still resolve
+    through the runtime ``TCL_LIBRARY`` machinery."""
+    result: dict[str, str] = {}
+    for index_path in sorted(library_dir.glob("*/pkgIndex.tcl")):
+        try:
+            text = index_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        subdir = index_path.parent.name
+        for m in _PKG_IFNEEDED_RE.finditer(text):
+            name = m.group(1)
+            segments = m.group(2).split()
+            if name not in result and segments:
+                # ``$dir`` is the package's own directory, so the file is
+                # ``<subdir>/<segments...>`` relative to the library root.
+                result[name] = os.path.join(subdir, *segments)
+    return result
+
+
 # Commands that run a script or invoke a command by a name the static
 # call graph can't see — their script/command argument is an ordinary
 # word (not a ``[...]`` substitution the scanner walks), so any proc
@@ -392,25 +487,16 @@ def apply_stdlib_prelude(
     """
     lib = Path(library_dir)
     mapping = _parse_tcl_index(lib)
-    if not mapping:
+    # Package-require bundling keys off ``*/pkgIndex.tcl`` discovery and
+    # is independent of ``tclIndex`` — a library may have one without the
+    # other — so don't early-out on a missing ``tclIndex`` here.
+    pkg_files = _discover_packages(lib) if lib.is_dir() else {}
+    if not mapping and not pkg_files:
         return module
 
     bundled_files: set[str] = set()
     bundled_qnames: set[str] = set()
     seen_commands: set[str] = set()
-
-    # Seed the worklist with commands referenced by the user's module,
-    # gated by the allowlist (transitive deps added later are not gated).
-    # The worklist is processed FIFO with new commands added in sorted
-    # order so bundling — and the merged setup ordering below — is
-    # deterministic / reproducible regardless of set iteration order.
-    seed: set[str] = set()
-    _collect_commands(module.top_level, seed)
-    for proc in list(module.procedures.values()):
-        _collect_commands(proc.body, seed)
-    if allowlist is not None:
-        seed = {n for n in seed if n in allowlist or n.lstrip(":") in allowlist}
-    queue: deque[str] = deque(sorted(seed))
 
     # Load-time setup from each bundled file, accumulated in bundling
     # order and prepended once after the traversal (deterministic).
@@ -418,27 +504,23 @@ def apply_stdlib_prelude(
 
     from .lowering import lower_to_ir
 
-    while queue and len(bundled_files) < max_files:
-        name = queue.popleft()
-        if name in seen_commands:
-            continue
-        seen_commands.add(name)
+    # FIFO command worklist; package source files prime it by being
+    # bundled directly (below), which queues their transitive commands.
+    queue: deque[str] = deque()
 
-        rel_file = _file_for_command(name, mapping)
-        if rel_file is None or rel_file in bundled_files:
-            continue
-        # A command the user already defines as a proc shadows the
-        # library version — don't bundle it.
-        if name in module.procedures or f"::{name}" in module.procedures:
-            continue
-
+    def bundle_file(rel_file: str) -> None:
+        """Read, lower and merge one library file's procedures + setup,
+        queuing the commands it transitively references.  Idempotent per
+        *rel_file*."""
+        if rel_file in bundled_files:
+            return
         path = lib / rel_file
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
             sub = lower_to_ir(text)
         except Exception:  # noqa: BLE001 — a non-readable / non-lowerable
             # library file just falls back to the runtime auto-loader.
-            continue
+            return
 
         bundled_files.add(rel_file)
 
@@ -467,6 +549,45 @@ def apply_stdlib_prelude(
             _collect_commands(proc.body, new_cmds)
         _collect_commands(sub.top_level, new_cmds)
         queue.extend(sorted(new_cmds - seen_commands))
+
+    # Bundle the source file behind each ``package require NAME`` the
+    # module names statically.  Unlike command bundling this is not gated
+    # by the allowlist: an explicit ``package require`` is a deliberate
+    # dependency, so honour it whenever the package resolves to a
+    # source-style pkgIndex entry.
+    for pkg in sorted(_collect_package_requires(module)):
+        rel_file = pkg_files.get(pkg)
+        if rel_file is not None:
+            bundle_file(rel_file)
+
+    # Seed the command worklist with commands referenced by the user's
+    # module, gated by the allowlist (transitive deps added later are not
+    # gated).  Processed FIFO with new commands added in sorted order so
+    # bundling — and the merged setup ordering below — is deterministic /
+    # reproducible regardless of set iteration order.
+    seed: set[str] = set()
+    _collect_commands(module.top_level, seed)
+    for proc in list(module.procedures.values()):
+        _collect_commands(proc.body, seed)
+    if allowlist is not None:
+        seed = {n for n in seed if n in allowlist or n.lstrip(":") in allowlist}
+    queue.extend(sorted(seed))
+
+    while queue and len(bundled_files) < max_files:
+        name = queue.popleft()
+        if name in seen_commands:
+            continue
+        seen_commands.add(name)
+
+        rel_file = _file_for_command(name, mapping)
+        if rel_file is None or rel_file in bundled_files:
+            continue
+        # A command the user already defines as a proc shadows the
+        # library version — don't bundle it.
+        if name in module.procedures or f"::{name}" in module.procedures:
+            continue
+
+        bundle_file(rel_file)
 
     # Prepend all bundled setup ahead of the user's code so it runs
     # first, once, in deterministic bundling order.

--- a/runtime/zig/cmds/array.zig
+++ b/runtime/zig/cmds/array.zig
@@ -113,6 +113,60 @@ fn sub_rule_for(sp: [*]const u8, slen: u32) ?*const SubRule {
     return match;
 }
 
+/// ``array default set|get|unset|exists arrayName ?value?`` — per-array
+/// fallback value for missing-element reads (var-24.x).
+fn eval_default(words: []const i32) result_mod.InterpResult {
+    const array_mod = @import("../valtypes/tcl_array.zig");
+    const frames_mod = @import("../interp/tcl_frames.zig");
+    const obj_mod = @import("../valtypes/tcl_obj.zig");
+    // words: [array, default, SUB, arrayName, ?value?]
+    const sub = obj_ensure_string(words[2]);
+    const sp: [*]const u8 = @ptrFromInt(sub.ptr);
+    const resolved: i32 = frames_mod.frame_resolve_array_name(words[3]);
+    defer if (resolved != words[3]) obj_mod.tcl_obj_release(resolved);
+
+    if (str_eq(sp, sub.len, "set")) {
+        if (words.len != 5) {
+            raise_array_error("wrong # args: should be \"array default set arrayName value\"");
+            return result_mod.from_globals(0);
+        }
+        // A scalar of the same name is an error ("variable isn't array").
+        array_mod.array_default_set_value(resolved, words[4]);
+        return result_mod.from_globals(obj_new_string(0, 0));
+    }
+    if (str_eq(sp, sub.len, "get")) {
+        if (words.len != 4) {
+            raise_array_error("wrong # args: should be \"array default get arrayName\"");
+            return result_mod.from_globals(0);
+        }
+        const v = array_mod.array_default_get_value(resolved);
+        if (v == 0) {
+            raise_array_error("array has no default value");
+            return result_mod.from_globals(0);
+        }
+        obj_mod.tcl_obj_retain(v);
+        return result_mod.from_globals(v);
+    }
+    if (str_eq(sp, sub.len, "exists")) {
+        if (words.len != 4) {
+            raise_array_error("wrong # args: should be \"array default exists arrayName\"");
+            return result_mod.from_globals(0);
+        }
+        const v = array_mod.array_default_get_value(resolved);
+        return result_mod.from_globals(rt.obj_new_int(if (v != 0) 1 else 0));
+    }
+    if (str_eq(sp, sub.len, "unset")) {
+        if (words.len != 4) {
+            raise_array_error("wrong # args: should be \"array default unset arrayName\"");
+            return result_mod.from_globals(0);
+        }
+        _ = array_mod.array_default_clear(resolved);
+        return result_mod.from_globals(obj_new_string(0, 0));
+    }
+    raise_array_error("bad option: must be exists, get, set, or unset");
+    return result_mod.from_globals(0);
+}
+
 pub fn eval(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) {
         raise_array_error("wrong # args: should be \"array subcommand ?arg ...?\"");
@@ -130,6 +184,12 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
     if (words.len < rule.min_words or (rule.max_words != null and words.len > rule.max_words.?)) {
         raise_array_error(rule.usage);
         return result_mod.from_globals(0);
+    }
+    // ``array default SUB arrayName ?value?`` — distinct arg layout
+    // (the array name is words[3], not words[2]), so handle it before
+    // the shared ``resolved_name`` resolution below.
+    if (str_eq(rule.name.ptr, @intCast(rule.name.len), "default")) {
+        return eval_default(words);
     }
     // Use the canonical resolved name for dispatch comparisons —
     // user-typed prefixes like ``array next ...`` should land in

--- a/runtime/zig/cmds/fs.zig
+++ b/runtime/zig/cmds/fs.zig
@@ -38,11 +38,29 @@ fn eval_source(words: []const i32) result_mod.InterpResult {
         return result_mod.from_globals(0);
     }
     if (words.len == 2) return result_mod.from_globals(fs_mod.tcl_cmd_source(words[1]));
+    if (words.len == 3 and is_dash_nopkg(words[1])) {
+        // Undocumented -nopkg option (used by ::tcl::Pkg::source).  It only
+        // suppresses "package files" tracking, which the WASM runtime does
+        // not maintain, so it behaves exactly like a plain source.
+        return result_mod.from_globals(fs_mod.tcl_cmd_source(words[2]));
+    }
     if (words.len == 4 and is_dash_encoding(words[1])) {
         return result_mod.from_globals(fs_mod.tcl_cmd_source(words[3]));
     }
     stubs.raise("source: expected ?-encoding name? fileName");
     return result_mod.from_globals(0);
+}
+
+fn is_dash_nopkg(o: i32) bool {
+    if (o == 0) return false;
+    const s = obj.obj_ensure_string(o);
+    if (s.len != 6) return false;
+    const p: [*]const u8 = @ptrFromInt(s.ptr);
+    const lit = "-nopkg";
+    inline for (0..6) |i| {
+        if (p[i] != lit[i]) return false;
+    }
+    return true;
 }
 
 fn is_dash_encoding(o: i32) bool {

--- a/runtime/zig/cmds/fs.zig
+++ b/runtime/zig/cmds/fs.zig
@@ -83,13 +83,19 @@ fn is_dash_encoding(o: i32) bool {
 /// raises (per the man page); with the switch we silently return
 /// the empty list.
 ///
-/// Switches not yet wired (``-directory`` / ``-tails`` / ``-types``
-/// / ``-path`` / ``-join``) raise ``unsupported`` so scripts get
-/// a clear diagnostic — adding them is purely a parsing job; the
-/// underlying readdir machinery already supports the work.
+/// ``-directory DIR`` / ``-join`` / ``-tails`` are wired through
+/// :func:`fs_mod.tcl_cmd_glob_dir` (the recursive readdir walk that
+/// ``tclPkgUnknown`` uses to discover stdlib ``pkgIndex.tcl`` files
+/// under ``TCL_LIBRARY``).  ``-types`` is parsed (consuming its value)
+/// but its filter is not yet applied — the directory walk already
+/// returns regular files, which covers the stdlib-discovery callers.
+/// ``-path`` still raises ``unsupported``.
 fn eval_glob(words: []const i32) result_mod.InterpResult {
     var idx: usize = 1;
     var nocomplain = false;
+    var join = false;
+    var tails = false;
+    var dir_obj: i32 = 0;
     while (idx < words.len) : (idx += 1) {
         const w = words[idx];
         const s = obj.obj_ensure_string(w);
@@ -104,12 +110,35 @@ fn eval_glob(words: []const i32) result_mod.InterpResult {
             nocomplain = true;
             continue;
         }
-        if (eq_lit(sp, s.len, "-directory") or
-            eq_lit(sp, s.len, "-tails") or
-            eq_lit(sp, s.len, "-types") or
-            eq_lit(sp, s.len, "-path") or
-            eq_lit(sp, s.len, "-join"))
-        {
+        if (eq_lit(sp, s.len, "-join")) {
+            join = true;
+            continue;
+        }
+        if (eq_lit(sp, s.len, "-tails")) {
+            tails = true;
+            continue;
+        }
+        if (eq_lit(sp, s.len, "-directory")) {
+            if (idx + 1 >= words.len) {
+                stubs.raise("missing argument to \"-directory\"");
+                return result_mod.from_globals(0);
+            }
+            idx += 1;
+            dir_obj = words[idx];
+            continue;
+        }
+        if (eq_lit(sp, s.len, "-types")) {
+            // Consume the type-list argument; the filter is not applied
+            // (the readdir walk already yields the regular files the
+            // stdlib-discovery callers expect).
+            if (idx + 1 >= words.len) {
+                stubs.raise("missing argument to \"-types\"");
+                return result_mod.from_globals(0);
+            }
+            idx += 1;
+            continue;
+        }
+        if (eq_lit(sp, s.len, "-path")) {
             stubs.unsupported_sub("glob", sp[0..s.len]);
             return result_mod.from_globals(0);
         }
@@ -163,10 +192,57 @@ fn eval_glob(words: []const i32) result_mod.InterpResult {
     // and never released the per-pattern ``result`` after concat —
     // every multi-pattern glob leaked one TclObj per non-first
     // pattern plus the empty seed.
+    // ``-join`` collapses the remaining pattern words into a single
+    // path pattern, joining them with ``/`` (e.g. ``-join * pkgIndex.tcl``
+    // → ``*/pkgIndex.tcl``).  We build one owned TclObj and walk a
+    // one-element pattern range over it.
+    var joined: i32 = 0;
+    if (join and idx < words.len) {
+        var total: u32 = 0;
+        var n = idx;
+        while (n < words.len) : (n += 1) {
+            total += @intCast(obj.obj_ensure_string(words[n]).len);
+            if (n + 1 < words.len) total += 1; // separator
+        }
+        const jbuf = obj.alloc(total);
+        if (jbuf == 0) {
+            stubs.raise("glob: out of memory joining patterns");
+            return result_mod.from_globals(0);
+        }
+        const jp: [*]u8 = @ptrFromInt(jbuf);
+        var off: u32 = 0;
+        n = idx;
+        while (n < words.len) : (n += 1) {
+            const ps = obj.obj_ensure_string(words[n]);
+            const psp: [*]const u8 = @ptrFromInt(ps.ptr);
+            var c: u32 = 0;
+            while (c < ps.len) : (c += 1) {
+                jp[off] = psp[c];
+                off += 1;
+            }
+            if (n + 1 < words.len) {
+                jp[off] = '/';
+                off += 1;
+            }
+        }
+        joined = obj.obj_new_string_take(jbuf, total, total);
+    }
+
     var acc: i32 = 0;
     var any_matched = false;
     while (idx < words.len) : (idx += 1) {
-        const result = fs_mod.tcl_cmd_glob(words[idx]);
+        const pattern_obj = if (joined != 0) joined else words[idx];
+        const result = if (dir_obj != 0)
+            fs_mod.tcl_cmd_glob_dir(dir_obj, pattern_obj, tails)
+        else
+            fs_mod.tcl_cmd_glob(pattern_obj);
+        // The joined pattern was a single synthetic word consumed by
+        // this one call; release it and end the walk.
+        if (joined != 0) {
+            obj.tcl_obj_release(joined);
+            joined = 0;
+            idx = words.len;
+        }
         if (result == 0) {
             if (acc != 0) obj.tcl_obj_release(acc);
             return result_mod.from_globals(0); // capability-denied or fatal — error already raised

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -140,6 +140,42 @@ fn raise_unknown_trace_command(name: i32) void {
     raise_parts(&.{ "unknown command \"", obj_bytes(name), "\"" });
 }
 
+fn is_execution_keyword(p: [*]const u8, len: u32) bool {
+    if (len < 3 or len > 9) return false;
+    const lit = "execution";
+    var k: u32 = 0;
+    while (k < len) : (k += 1) {
+        if (p[k] != lit[k]) return false;
+    }
+    return true;
+}
+
+/// Parse an execution-trace op list (``{enter leave enterstep
+/// leavestep}``) into the OP_* bitmask.
+fn parse_exec_ops(ops_obj: i32) u32 {
+    const exec_trace = @import("../interp/tcl_exec_trace.zig");
+    const s = obj_ensure_string(ops_obj);
+    if (s.ptr == 0 or s.len == 0) return 0;
+    var mask: u32 = 0;
+    const n = obj.list_count_elements(s.ptr, s.len);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        const e = obj.list_element_at(s.ptr, s.len, i);
+        const ep: [*]const u8 = @ptrFromInt(s.ptr + e.start);
+        if (str_eq(ep, e.len, "enter")) mask |= exec_trace.OP_ENTER;
+        if (str_eq(ep, e.len, "leave")) mask |= exec_trace.OP_LEAVE;
+        if (str_eq(ep, e.len, "enterstep")) mask |= exec_trace.OP_ENTERSTEP;
+        if (str_eq(ep, e.len, "leavestep")) mask |= exec_trace.OP_LEAVESTEP;
+    }
+    return mask;
+}
+
+/// The command bucket (identity) an execution trace keys against, or 0.
+fn exec_trace_bucket(name: i32) u32 {
+    const procs = @import("../interp/tcl_procs.zig");
+    return @bitCast(procs.proc_lookup(name));
+}
+
 fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) {
         raise_parts(&.{"wrong # args: should be \"trace option ?arg ...?\""});
@@ -212,7 +248,12 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
             install_var_trace(name, ops, words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
-        // execution / command tracing — pass-through NOP.
+        if (is_execution_keyword(kind_p, kind_s.len)) {
+            const exec_trace = @import("../interp/tcl_exec_trace.zig");
+            exec_trace.add(exec_trace_bucket(words[3]), parse_exec_ops(words[4]), words[5]);
+            return result_mod.from_globals(obj_new_string(0, 0));
+        }
+        // command tracing — pass-through NOP.
         return result_mod.from_globals(obj_new_string(0, 0));
     }
     // ``trace remove variable NAME OPS CMD``.
@@ -225,6 +266,11 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
             _ = uninstall_var_trace(name, ops, words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
+        if (is_execution_keyword(kind_p, kind_s.len)) {
+            const exec_trace = @import("../interp/tcl_exec_trace.zig");
+            exec_trace.remove(exec_trace_bucket(words[3]), parse_exec_ops(words[4]), words[5]);
+            return result_mod.from_globals(obj_new_string(0, 0));
+        }
         return result_mod.from_globals(obj_new_string(0, 0));
     }
     // ``trace info variable NAME``.
@@ -233,6 +279,10 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
         const kind_p: [*]const u8 = @ptrFromInt(kind_s.ptr);
         if (is_variable_keyword(kind_p, kind_s.len)) {
             return result_mod.from_globals(query_var_trace(words[3]));
+        }
+        if (is_execution_keyword(kind_p, kind_s.len)) {
+            const exec_trace = @import("../interp/tcl_exec_trace.zig");
+            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3])));
         }
         return result_mod.from_globals(obj_new_string(0, 0));
     }

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -73,12 +73,102 @@ fn eval_info(words: []const i32) result_mod.InterpResult {
     return result_mod.from_globals(obj_new_string(0, 0));
 }
 
+/// Match a ``trace`` operand type — ``variable`` / ``command`` /
+/// ``execution`` — accepting any ≥3-char unique prefix (Tcl allows
+/// abbreviation).  Returns the canonical keyword, or null for an
+/// unrecognised type.
+fn trace_type_keyword(p: [*]const u8, len: u32) ?[]const u8 {
+    if (len < 3) return null;
+    const cands = [_][]const u8{ "variable", "command", "execution" };
+    for (cands) |c| {
+        if (len > c.len) continue;
+        var k: u32 = 0;
+        var match = true;
+        while (k < len) : (k += 1) {
+            if (p[k] != c[k]) {
+                match = false;
+                break;
+            }
+        }
+        if (match) return c;
+    }
+    return null;
+}
+
+/// Raise a Tcl error whose message is the concatenation of *parts*.
+fn raise_parts(parts: []const []const u8) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    var total: u32 = 0;
+    for (parts) |p| total += @intCast(p.len);
+    const buf = obj.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(obj_new_string(0, 0));
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (parts) |p| {
+        for (p) |c| {
+            dst[off] = c;
+            off += 1;
+        }
+    }
+    catch_mod.tcl_cmd_error(obj_new_string_take(buf, total, total));
+}
+
+fn obj_bytes(o: i32) []const u8 {
+    const s = obj_ensure_string(o);
+    if (s.ptr == 0 or s.len == 0) return "";
+    return (@as([*]const u8, @ptrFromInt(s.ptr)))[0..s.len];
+}
+
 fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) {
-        return result_mod.from_globals(obj_new_string(0, 0));
+        raise_parts(&.{"wrong # args: should be \"trace option ?arg ...?\""});
+        return result_mod.from_globals(0);
     }
     const sub_s = obj_ensure_string(words[1]);
     const sub_p: [*]const u8 = @ptrFromInt(sub_s.ptr);
+    // Arity / type validation for the modern add / remove / info forms
+    // (trace-14.0.x / 14.1-14.4).  Done up front so the working paths
+    // below can assume well-formed argument counts.
+    const sub_is_add = str_eq(sub_p, sub_s.len, "add");
+    const sub_is_remove = str_eq(sub_p, sub_s.len, "remove");
+    const sub_is_info = str_eq(sub_p, sub_s.len, "info");
+    if (sub_is_add or sub_is_remove) {
+        if (words.len < 3) {
+            raise_parts(&.{ "wrong # args: should be \"trace ", obj_bytes(words[1]), " type ?arg ...?\"" });
+            return result_mod.from_globals(0);
+        }
+        const ty_s = obj_ensure_string(words[2]);
+        if (trace_type_keyword(@ptrFromInt(ty_s.ptr), ty_s.len) != null) {
+            if (words.len != 6) {
+                raise_parts(&.{ "wrong # args: should be \"trace ", obj_bytes(words[1]), " ", obj_bytes(words[2]), " name opList command\"" });
+                return result_mod.from_globals(0);
+            }
+        }
+    } else if (sub_is_info) {
+        if (words.len < 3) {
+            raise_parts(&.{"wrong # args: should be \"trace info type name\""});
+            return result_mod.from_globals(0);
+        }
+        const ty_s = obj_ensure_string(words[2]);
+        if (trace_type_keyword(@ptrFromInt(ty_s.ptr), ty_s.len) != null) {
+            if (words.len != 4) {
+                raise_parts(&.{ "wrong # args: should be \"trace info ", obj_bytes(words[2]), " name\"" });
+                return result_mod.from_globals(0);
+            }
+        }
+    } else if (!str_eq(sub_p, sub_s.len, "variable") and
+        !str_eq(sub_p, sub_s.len, "vdelete") and
+        !str_eq(sub_p, sub_s.len, "vinfo"))
+    {
+        // Unknown subcommand — the legacy ``variable`` / ``vdelete`` /
+        // ``vinfo`` forms are still handled below; everything else is a
+        // bad option (trace-14.5).
+        raise_parts(&.{ "bad option \"", obj_bytes(words[1]), "\": must be add, info, or remove" });
+        return result_mod.from_globals(0);
+    }
     // ``trace add variable NAME OPS CMD`` — phase 6 implementation.
     if (str_eq(sub_p, sub_s.len, "add") and words.len >= 6) {
         const kind_s = obj_ensure_string(words[2]);

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -203,10 +203,28 @@ fn parse_exec_ops(ops_obj: i32) u32 {
     return mask;
 }
 
-/// The command bucket (identity) an execution trace keys against, or 0.
-fn exec_trace_bucket(name: i32) u32 {
+/// The command bucket (identity) an execution/command trace keys
+/// against, or 0.  When *provision* is set (the ``trace add`` path) and
+/// the target is a hardcoded BUILTIN with no proc-table Command yet,
+/// materialise a forwarding Command bucket for it: reference Tcl gives
+/// every command an identity that traces attach to, and dispatch then
+/// routes the builtin through the proc path so its enter/leave/step (and
+/// rename/delete) traces actually fire while still invoking the original
+/// handler.  ``trace remove`` / ``trace info`` pass provision=false so an
+/// untraced builtin isn't turned into a forward by a no-op query.
+fn exec_trace_bucket(name: i32, provision: bool) u32 {
     const procs = @import("../interp/tcl_procs.zig");
-    return @bitCast(procs.proc_lookup(name));
+    const existing: u32 = @bitCast(procs.proc_lookup(name));
+    if (existing != 0) return existing;
+    if (!provision) return 0;
+    const cmd_table = @import("../dispatch/tcl_cmd_table.zig");
+    const s = obj_ensure_string(name);
+    if (s.ptr == 0 or s.len == 0) return 0;
+    if (cmd_table.lookup(s.ptr, s.len)) |handler| {
+        procs.register_builtin_forward(s.ptr, s.len, @intCast(@intFromPtr(handler)));
+        return @bitCast(procs.proc_lookup(name));
+    }
+    return 0;
 }
 
 /// Validate a trace op-list against the allowed ops for *kw* (the
@@ -337,12 +355,12 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
         }
         if (is_execution_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
-            exec_trace.add(exec_trace_bucket(words[3]), parse_exec_ops(words[4]), words[5]);
+            exec_trace.add(exec_trace_bucket(words[3], true), parse_exec_ops(words[4]), words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
         if (is_command_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
-            exec_trace.add(exec_trace_bucket(words[3]), parse_command_ops(words[4]), words[5]);
+            exec_trace.add(exec_trace_bucket(words[3], true), parse_command_ops(words[4]), words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
         return result_mod.from_globals(obj_new_string(0, 0));
@@ -359,12 +377,12 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
         }
         if (is_execution_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
-            exec_trace.remove(exec_trace_bucket(words[3]), parse_exec_ops(words[4]), words[5]);
+            exec_trace.remove(exec_trace_bucket(words[3], false), parse_exec_ops(words[4]), words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
         if (is_command_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
-            exec_trace.remove(exec_trace_bucket(words[3]), parse_command_ops(words[4]), words[5]);
+            exec_trace.remove(exec_trace_bucket(words[3], false), parse_command_ops(words[4]), words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
         return result_mod.from_globals(obj_new_string(0, 0));
@@ -379,12 +397,12 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
         if (is_execution_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
             const m = exec_trace.OP_ENTER | exec_trace.OP_LEAVE | exec_trace.OP_ENTERSTEP | exec_trace.OP_LEAVESTEP;
-            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3]), m));
+            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3], false), m));
         }
         if (is_command_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
             const m = exec_trace.OP_CMD_DELETE | exec_trace.OP_CMD_RENAME;
-            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3]), m));
+            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3], false), m));
         }
         return result_mod.from_globals(obj_new_string(0, 0));
     }

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -44,6 +44,12 @@ fn is_local_trace_target(name: i32) bool {
         if (sp[k] == ':' and k + 1 < sn.len and sp[k + 1] == ':') return false;
         if (sp[k] == '(') return false;
     }
+    // A ``global x`` declaration aliases the local name to the root
+    // global ``::x``; a trace on it belongs in the global directory so
+    // it outlives the proc that installed it (trace-17.2 / 17.3).  An
+    // unqualified bare name that is NOT a global alias is a genuine
+    // proc-local and stays on the per-frame chain.
+    if (frames.current_frame_is_global_alias(name)) return false;
     return true;
 }
 

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -500,6 +500,7 @@ fn install_var_trace(name: i32, ops: u32, cmd_prefix: i32) void {
         var_trace.add_to_list(&frames.frame_trace_heads[frames.frame_depth - 1], name, ops, cmd_prefix);
         return;
     }
+    maybe_create_array_for_trace_install(name);
     const canon = canonical_var_name(name);
     var_trace.add(canon, ops, cmd_prefix);
     if (canon != name and canon != 0) tcl_obj_release(canon);
@@ -583,6 +584,34 @@ fn maybe_invalidate_searches_on_trace_install(name: i32) void {
     if (obj_helpers.obj_get_int(tcl_array_mod.array_element_exists(arr_name, key_obj)) == 0) {
         tcl_array_mod.array_invalidate_searches_for_obj(arr_name);
     }
+}
+
+/// When ``name`` parses as ``arr(key)`` and ``arr`` is not yet an
+/// array, create it as an empty array so element reads / unsets report
+/// ``no such element in array`` (and fire the just-installed trace)
+/// rather than ``no such variable`` — matching reference Tcl, which
+/// materialises the array when a trace is registered on one of its
+/// elements (trace-1.4 / trace-10.1).  Directory (global / top-level)
+/// case only; proc-local element traces take the per-frame path above.
+fn maybe_create_array_for_trace_install(name: i32) void {
+    const sn = obj_ensure_string(name);
+    if (sn.ptr == 0 or sn.len < 3) return;
+    const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+    if (sp[sn.len - 1] != ')') return;
+    var paren: i32 = -1;
+    var i: u32 = 0;
+    while (i < sn.len) : (i += 1) {
+        if (sp[i] == '(') {
+            paren = @intCast(i);
+            break;
+        }
+    }
+    if (paren <= 0) return;
+    const paren_at: u32 = @intCast(paren);
+    const arr_name = obj_new_string(@bitCast(sn.ptr), @bitCast(paren_at));
+    defer tcl_obj_release(arr_name);
+    const tcl_array_mod = @import("../valtypes/tcl_array.zig");
+    tcl_array_mod.ensure_array_exists(arr_name);
 }
 
 /// Fire any ``array``-op variable trace on *name*.  Reference Tcl

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -122,6 +122,24 @@ fn obj_bytes(o: i32) []const u8 {
     return (@as([*]const u8, @ptrFromInt(s.ptr)))[0..s.len];
 }
 
+/// True if *name* resolves to a live command (user proc / alias /
+/// builtin).  ``trace add|remove|info command|execution`` requires the
+/// target command to exist (trace-27.x / 28.8 / 28.9).
+fn trace_command_exists(name: i32) bool {
+    const procs = @import("../interp/tcl_procs.zig");
+    if (procs.proc_lookup(name) != 0) return true;
+    const cmd_table = @import("../dispatch/tcl_cmd_table.zig");
+    const s = obj_ensure_string(name);
+    if (s.ptr != 0 and s.len != 0 and cmd_table.lookup(s.ptr, s.len) != null) return true;
+    return false;
+}
+
+/// Raise ``unknown command "NAME"`` for a command/execution trace whose
+/// target doesn't resolve.
+fn raise_unknown_trace_command(name: i32) void {
+    raise_parts(&.{ "unknown command \"", obj_bytes(name), "\"" });
+}
+
 fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) {
         raise_parts(&.{"wrong # args: should be \"trace option ?arg ...?\""});
@@ -141,9 +159,17 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
             return result_mod.from_globals(0);
         }
         const ty_s = obj_ensure_string(words[2]);
-        if (trace_type_keyword(@ptrFromInt(ty_s.ptr), ty_s.len) != null) {
+        if (trace_type_keyword(@ptrFromInt(ty_s.ptr), ty_s.len)) |kw| {
             if (words.len != 6) {
                 raise_parts(&.{ "wrong # args: should be \"trace ", obj_bytes(words[1]), " ", obj_bytes(words[2]), " name opList command\"" });
+                return result_mod.from_globals(0);
+            }
+            // command / execution traces require the target to exist.
+            if ((str_eq(kw.ptr, @intCast(kw.len), "command") or
+                str_eq(kw.ptr, @intCast(kw.len), "execution")) and
+                !trace_command_exists(words[3]))
+            {
+                raise_unknown_trace_command(words[3]);
                 return result_mod.from_globals(0);
             }
         }
@@ -153,9 +179,16 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
             return result_mod.from_globals(0);
         }
         const ty_s = obj_ensure_string(words[2]);
-        if (trace_type_keyword(@ptrFromInt(ty_s.ptr), ty_s.len) != null) {
+        if (trace_type_keyword(@ptrFromInt(ty_s.ptr), ty_s.len)) |kw| {
             if (words.len != 4) {
                 raise_parts(&.{ "wrong # args: should be \"trace info ", obj_bytes(words[2]), " name\"" });
+                return result_mod.from_globals(0);
+            }
+            if ((str_eq(kw.ptr, @intCast(kw.len), "command") or
+                str_eq(kw.ptr, @intCast(kw.len), "execution")) and
+                !trace_command_exists(words[3]))
+            {
+                raise_unknown_trace_command(words[3]);
                 return result_mod.from_globals(0);
             }
         }

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -176,6 +176,56 @@ fn exec_trace_bucket(name: i32) u32 {
     return @bitCast(procs.proc_lookup(name));
 }
 
+/// Validate a trace op-list against the allowed ops for *kw* (the
+/// canonical type keyword).  Each op must be a full (non-abbreviated)
+/// keyword; the list must be non-empty.  Raises the canonical Tcl
+/// diagnostic and returns false on any violation (trace-14.6.x).
+fn validate_trace_oplist(ops_obj: i32, kw: []const u8) bool {
+    var allowed: []const []const u8 = undefined;
+    var allowed_str: []const u8 = undefined;
+    if (str_eq(kw.ptr, @intCast(kw.len), "variable")) {
+        allowed = &.{ "array", "read", "unset", "write" };
+        allowed_str = "array, read, unset, or write";
+    } else if (str_eq(kw.ptr, @intCast(kw.len), "command")) {
+        allowed = &.{ "delete", "rename" };
+        allowed_str = "delete or rename";
+    } else {
+        allowed = &.{ "enter", "leave", "enterstep", "leavestep" };
+        allowed_str = "enter, leave, enterstep, or leavestep";
+    }
+    const s = obj_ensure_string(ops_obj);
+    const n = obj.list_count_elements(s.ptr, s.len);
+    if (n <= 0) {
+        raise_parts(&.{ "bad operation list \"\": must be one or more of ", allowed_str });
+        return false;
+    }
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        const e = obj.list_element_at(s.ptr, s.len, i);
+        const ep: [*]const u8 = @ptrFromInt(s.ptr + e.start);
+        var ok = false;
+        for (allowed) |a| {
+            if (a.len != e.len) continue;
+            var match = true;
+            for (a, 0..) |c, k| {
+                if (ep[k] != c) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                ok = true;
+                break;
+            }
+        }
+        if (!ok) {
+            raise_parts(&.{ "bad operation \"", ep[0..e.len], "\": must be ", allowed_str });
+            return false;
+        }
+    }
+    return true;
+}
+
 fn eval_trace(words: []const i32) result_mod.InterpResult {
     if (words.len < 2) {
         raise_parts(&.{"wrong # args: should be \"trace option ?arg ...?\""});
@@ -206,6 +256,10 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
                 !trace_command_exists(words[3]))
             {
                 raise_unknown_trace_command(words[3]);
+                return result_mod.from_globals(0);
+            }
+            // Validate the op list (words[4]) against the type's ops.
+            if (!validate_trace_oplist(words[4], kw)) {
                 return result_mod.from_globals(0);
             }
         }

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -7,6 +7,7 @@ const trace_mod = @import("../interp/tcl_trace.zig");
 const var_trace = @import("../interp/tcl_var_trace.zig");
 const frames = @import("../interp/tcl_frames.zig");
 const reg = @import("../dispatch/tcl_cmd_registry.zig");
+const obj = @import("../valtypes/tcl_obj.zig");
 
 /// Phase 6 follow-up: classify ``NAME`` for ``trace add/remove/info
 /// variable``.  Proc-local traces go on the per-frame chain (so two
@@ -232,6 +233,54 @@ fn install_var_trace(name: i32, ops: u32, cmd_prefix: i32) void {
     }
     const canon = canonical_var_name(name);
     var_trace.add(canon, ops, cmd_prefix);
+    if (canon != name and canon != 0) tcl_obj_release(canon);
+}
+
+/// Drop every variable trace registered on ``name`` — the removal
+/// counterpart to :func:`install_var_trace`, routed the same way
+/// (per-frame chain for proc-locals, canonical-name directory
+/// otherwise).  Called by ``unset`` after the variable's unset
+/// callbacks have fired, so a later variable reusing the name doesn't
+/// inherit the stale trace (Tcl's documented ``unset`` semantics; see
+/// :func:`tcl_var_trace.remove_all`).  Probes both the as-written and
+/// FQ ``::name`` spellings for the directory case, mirroring the
+/// dual-form lookup the scalar fire path uses.
+pub fn remove_all_var_traces(name: i32) void {
+    if (is_local_trace_target(name)) {
+        const sn = obj_ensure_string(name);
+        if (frames.frame_depth > 0) {
+            var_trace.remove_all_in_list(
+                &frames.frame_trace_heads[frames.frame_depth - 1],
+                sn.ptr,
+                sn.len,
+            );
+        }
+        return;
+    }
+    const canon = canonical_var_name(name);
+    const sn = obj_ensure_string(canon);
+    if (sn.ptr != 0 and sn.len != 0) {
+        var_trace.remove_all(sn.ptr, sn.len);
+        // Also probe the alternate FQ / non-FQ spelling so a trace
+        // installed under ``::x`` is dropped when ``unset x`` runs
+        // (and vice versa) — matches fire_scalar_trace_op's dual probe.
+        const sp: [*]const u8 = @ptrFromInt(sn.ptr);
+        const has_fq = sn.len >= 2 and sp[0] == ':' and sp[1] == ':';
+        if (has_fq) {
+            var_trace.remove_all(sn.ptr + 2, sn.len - 2);
+        } else {
+            const total: u32 = sn.len + 2;
+            const buf = obj.alloc(total);
+            if (buf != 0) {
+                const dst: [*]u8 = @ptrFromInt(buf);
+                dst[0] = ':';
+                dst[1] = ':';
+                for (0..sn.len) |k| dst[2 + k] = sp[k];
+                var_trace.remove_all(buf, total);
+                obj.free_sized(buf, total);
+            }
+        }
+    }
     if (canon != name and canon != 0) tcl_obj_release(canon);
 }
 

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -150,6 +150,33 @@ fn is_execution_keyword(p: [*]const u8, len: u32) bool {
     return true;
 }
 
+fn is_command_keyword(p: [*]const u8, len: u32) bool {
+    if (len < 3 or len > 7) return false;
+    const lit = "command";
+    var k: u32 = 0;
+    while (k < len) : (k += 1) {
+        if (p[k] != lit[k]) return false;
+    }
+    return true;
+}
+
+/// Parse a command-trace op list (``{delete rename}``) → OP_CMD_* mask.
+fn parse_command_ops(ops_obj: i32) u32 {
+    const exec_trace = @import("../interp/tcl_exec_trace.zig");
+    const s = obj_ensure_string(ops_obj);
+    if (s.ptr == 0 or s.len == 0) return 0;
+    var mask: u32 = 0;
+    const n = obj.list_count_elements(s.ptr, s.len);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        const e = obj.list_element_at(s.ptr, s.len, i);
+        const ep: [*]const u8 = @ptrFromInt(s.ptr + e.start);
+        if (str_eq(ep, e.len, "delete")) mask |= exec_trace.OP_CMD_DELETE;
+        if (str_eq(ep, e.len, "rename")) mask |= exec_trace.OP_CMD_RENAME;
+    }
+    return mask;
+}
+
 /// Parse an execution-trace op list (``{enter leave enterstep
 /// leavestep}``) into the OP_* bitmask.
 fn parse_exec_ops(ops_obj: i32) u32 {
@@ -307,7 +334,11 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
             exec_trace.add(exec_trace_bucket(words[3]), parse_exec_ops(words[4]), words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
-        // command tracing — pass-through NOP.
+        if (is_command_keyword(kind_p, kind_s.len)) {
+            const exec_trace = @import("../interp/tcl_exec_trace.zig");
+            exec_trace.add(exec_trace_bucket(words[3]), parse_command_ops(words[4]), words[5]);
+            return result_mod.from_globals(obj_new_string(0, 0));
+        }
         return result_mod.from_globals(obj_new_string(0, 0));
     }
     // ``trace remove variable NAME OPS CMD``.
@@ -325,6 +356,11 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
             exec_trace.remove(exec_trace_bucket(words[3]), parse_exec_ops(words[4]), words[5]);
             return result_mod.from_globals(obj_new_string(0, 0));
         }
+        if (is_command_keyword(kind_p, kind_s.len)) {
+            const exec_trace = @import("../interp/tcl_exec_trace.zig");
+            exec_trace.remove(exec_trace_bucket(words[3]), parse_command_ops(words[4]), words[5]);
+            return result_mod.from_globals(obj_new_string(0, 0));
+        }
         return result_mod.from_globals(obj_new_string(0, 0));
     }
     // ``trace info variable NAME``.
@@ -336,7 +372,13 @@ fn eval_trace(words: []const i32) result_mod.InterpResult {
         }
         if (is_execution_keyword(kind_p, kind_s.len)) {
             const exec_trace = @import("../interp/tcl_exec_trace.zig");
-            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3])));
+            const m = exec_trace.OP_ENTER | exec_trace.OP_LEAVE | exec_trace.OP_ENTERSTEP | exec_trace.OP_LEAVESTEP;
+            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3]), m));
+        }
+        if (is_command_keyword(kind_p, kind_s.len)) {
+            const exec_trace = @import("../interp/tcl_exec_trace.zig");
+            const m = exec_trace.OP_CMD_DELETE | exec_trace.OP_CMD_RENAME;
+            return result_mod.from_globals(exec_trace.info(exec_trace_bucket(words[3]), m));
         }
         return result_mod.from_globals(obj_new_string(0, 0));
     }

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -1518,17 +1518,18 @@ fn read_ensemble_option(rec: *EnsembleRec, key_obj: i32) i32 {
 /// Wrap a TclObj's string in ``{…}`` braces for the ``configure``
 /// emit.  Empty becomes ``{}``.  Caller releases.
 fn brace_wrap(value: i32) i32 {
+    // Render *value* as a single Tcl list element for ``namespace
+    // ensemble config`` output: empty → ``{}``, a simple word →
+    // verbatim (``-unknown bar`` not ``-unknown {bar}``), and only
+    // values with whitespace / special chars get braced (namespace-47.5).
+    const quote = @import("../valtypes/tcl_list_quote.zig");
     const s = obj_ensure_string(value);
     if (s.len == 0) return obj_new_string_copy_str("{}");
-    const total: u32 = s.len + 2;
-    const buf = alloc(total);
+    const cap: u32 = 2 * s.len + 4;
+    const buf = alloc(cap);
     if (buf == 0) return obj_new_string(0, 0);
-    const dst: [*]u8 = @ptrFromInt(buf);
-    dst[0] = '{';
-    const sp: [*]const u8 = @ptrFromInt(s.ptr);
-    for (0..s.len) |i| dst[1 + i] = sp[i];
-    dst[total - 1] = '}';
-    return obj_mod.obj_new_string_take(buf, total, total);
+    const off = quote.list_elem_quote(buf, 0, s.ptr, s.len);
+    return obj_mod.obj_new_string_take(buf, off, cap);
 }
 
 fn raise_unknown_ensemble_option(name_ptr: u32, name_len: u32) void {

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -2210,7 +2210,6 @@ fn invoke_ensemble_impl(impl_obj: i32, words: []const i32, sub_idx: u32) i32 {
 }
 
 fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i32 {
-    _ = bucket;
     // Build call: unknown_prefix + ensemble_name + words[1..]
     const us = obj_ensure_string(rec.unknown_obj);
     const interp = @import("../interp/tcl_interp.zig");
@@ -2228,9 +2227,17 @@ fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i
         obj_mod.write_i32(argv + idx * 4, w);
         idx += 1;
     }
-    // Ensemble name (use words[0] as-is)
-    obj_mod.tcl_obj_retain(words[0]);
-    obj_mod.write_i32(argv + idx * 4, words[0]);
+    // Ensemble name — pass the fully-qualified command name (Tcl hands
+    // the handler the resolved ``::ns::ensemble`` form, not the short
+    // invoked word; namespace-47.7/47.8).  Fall back to words[0] if the
+    // FQN can't be built.
+    const fqn = interp_impl.command_fqn_obj(@as(u32, @bitCast(bucket)));
+    if (fqn != 0) {
+        obj_mod.write_i32(argv + idx * 4, fqn);
+    } else {
+        obj_mod.tcl_obj_retain(words[0]);
+        obj_mod.write_i32(argv + idx * 4, words[0]);
+    }
     idx += 1;
     var wi: u32 = 1;
     while (wi < words.len) : (wi += 1) {

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -1934,24 +1934,7 @@ pub fn dispatch_ensemble(bucket: i32, words: []const i32) i32 {
     }
 
     // 1. Resolve subcommand → impl.
-    var impl_obj: i32 = 0;
-    if (rec.map_obj != 0) {
-        const ms = obj_ensure_string(rec.map_obj);
-        const n = obj_mod.list_count_elements(ms.ptr, ms.len);
-        if (n > 0 and @rem(n, 2) == 0) {
-            const matched = ensemble_lookup_map(ms.ptr, ms.len, n, sub.ptr, sub.len, rec.prefixes);
-            if (matched > 0) {
-                const e = obj_mod.list_element_at(ms.ptr, ms.len, matched);
-                impl_obj = obj_mod.obj_new_string(@bitCast(ms.ptr + e.start), @bitCast(e.len));
-            } else if (matched == 0) {
-                // No match — fall through to -unknown / no-export error
-            }
-        }
-    }
-    if (impl_obj == 0) {
-        // Try exported commands of the target ns.
-        impl_obj = ensemble_lookup_exported(rec, sub.ptr, sub.len);
-    }
+    const impl_obj = ensemble_resolve(rec, sub.ptr, sub.len);
     if (impl_obj == 0) {
         // -unknown handler?
         if (rec.unknown_obj != 0) {
@@ -1964,6 +1947,28 @@ pub fn dispatch_ensemble(bucket: i32, words: []const i32) i32 {
 
     // 2. Build the full call: impl-elements + words[2..].
     return invoke_ensemble_impl(impl_obj, words);
+}
+
+/// Resolve an ensemble subcommand to its implementation command prefix
+/// (a fresh TclObj list), or 0 if no match.  Probes the ``-map`` table
+/// first, then the target namespace's exported commands.
+fn ensemble_resolve(rec: *EnsembleRec, sub_ptr: u32, sub_len: u32) i32 {
+    var impl_obj: i32 = 0;
+    if (rec.map_obj != 0) {
+        const ms = obj_ensure_string(rec.map_obj);
+        const n = obj_mod.list_count_elements(ms.ptr, ms.len);
+        if (n > 0 and @rem(n, 2) == 0) {
+            const matched = ensemble_lookup_map(ms.ptr, ms.len, n, sub_ptr, sub_len, rec.prefixes);
+            if (matched > 0) {
+                const e = obj_mod.list_element_at(ms.ptr, ms.len, matched);
+                impl_obj = obj_mod.obj_new_string(@bitCast(ms.ptr + e.start), @bitCast(e.len));
+            }
+        }
+    }
+    if (impl_obj == 0) {
+        impl_obj = ensemble_lookup_exported(rec, sub_ptr, sub_len);
+    }
+    return impl_obj;
 }
 
 /// Match *sub* against the keys of the ``-map`` list.  Returns the
@@ -2177,7 +2182,38 @@ fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i
         const v = obj_mod.read_i32(argv + j * 4);
         if (v != 0) obj_mod.tcl_obj_release(v);
     }
-    return result;
+
+    // Tcl ensemble ``-unknown`` retry protocol.  The handler ran for its
+    // side effects (it may have created / mapped the subcommand) and
+    // returns a list:
+    //   * error           → propagate.
+    //   * empty list       → re-resolve the original subcommand and
+    //                        dispatch it (the handler just created it).
+    //                        Still unknown ⇒ "unknown subcommand" error.
+    //   * non-empty list   → that list is the rewritten command prefix
+    //                        to invoke in place of the ensemble call.
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    if (catch_mod.state.error_flag != 0) return result;
+
+    const sub = obj_ensure_string(words[1]);
+    const impl = ensemble_resolve(rec, sub.ptr, sub.len);
+    if (impl != 0) {
+        if (result != 0) obj_mod.tcl_obj_release(result);
+        defer obj_mod.tcl_obj_release(impl);
+        return invoke_ensemble_impl(impl, words);
+    }
+
+    const rs = obj_ensure_string(result);
+    if (rs.len != 0) {
+        // Non-empty rewrite: evaluate the returned command prefix
+        // followed by the ensemble's argument tail (words[2..]).
+        defer if (result != 0) obj_mod.tcl_obj_release(result);
+        return invoke_ensemble_impl(result, words);
+    }
+
+    if (result != 0) obj_mod.tcl_obj_release(result);
+    raise_ensemble_unknown_sub(words[0], sub.ptr, sub.len, rec);
+    return 0;
 }
 
 fn raise_ensemble_wrong_args(name: i32, rec: *EnsembleRec) void {

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -2036,7 +2036,7 @@ pub fn dispatch_ensemble(bucket: i32, words: []const i32) i32 {
     if (impl_obj == 0) {
         // -unknown handler?
         if (rec.unknown_obj != 0) {
-            return invoke_ensemble_unknown(bucket, rec, words);
+            return invoke_ensemble_unknown(bucket, rec, words, sub_idx);
         }
         raise_ensemble_unknown_sub(words[0], sub.ptr, sub.len, rec);
         return 0;
@@ -2255,7 +2255,7 @@ fn invoke_ensemble_impl(impl_obj: i32, words: []const i32, sub_idx: u32) i32 {
     return result;
 }
 
-fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i32 {
+fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32, sub_idx: u32) i32 {
     // Build call: unknown_prefix + ensemble_name + words[1..]
     const us = obj_ensure_string(rec.unknown_obj);
     const interp = @import("../interp/tcl_interp.zig");
@@ -2320,20 +2320,24 @@ fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i
         return 0;
     }
 
-    const sub = obj_ensure_string(words[1]);
+    // The subcommand sits *after* any ``-parameters`` words, at
+    // ``sub_idx`` — not ``words[1]``.  Re-resolving with the wrong index
+    // would treat the first parameter as the subcommand, so a handler
+    // that created/mapped the real subcommand could never be recovered.
+    const sub = obj_ensure_string(words[sub_idx]);
     const impl = ensemble_resolve(rec, sub.ptr, sub.len);
     if (impl != 0) {
         if (result != 0) obj_mod.tcl_obj_release(result);
         defer obj_mod.tcl_obj_release(impl);
-        return invoke_ensemble_impl(impl, words, 1);
+        return invoke_ensemble_impl(impl, words, sub_idx);
     }
 
     const rs = obj_ensure_string(result);
     if (rs.len != 0) {
         // Non-empty rewrite: evaluate the returned command prefix
-        // followed by the ensemble's argument tail (words[2..]).
+        // followed by the ensemble's parameters + argument tail.
         defer if (result != 0) obj_mod.tcl_obj_release(result);
-        return invoke_ensemble_impl(result, words, 1);
+        return invoke_ensemble_impl(result, words, sub_idx);
     }
 
     if (result != 0) obj_mod.tcl_obj_release(result);

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -2214,8 +2214,17 @@ fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i
     //                        Still unknown ⇒ "unknown subcommand" error.
     //   * non-empty list   → that list is the rewritten command prefix
     //                        to invoke in place of the ensemble call.
-    const catch_mod = @import("../interp/tcl_catch.zig");
-    if (catch_mod.state.error_flag != 0) return result;
+    //   * break/continue/return → "unknown subcommand handler returned
+    //                        bad code: <name>" (namespace-47.4).
+    const result_mod2 = @import("../interp/tcl_result.zig");
+    const snap = result_mod2.snapshot(result);
+    if (snap.code == .ERROR) return result;
+    if (snap.code != .OK) {
+        result_mod2.consume(snap.code);
+        raise_ensemble_bad_code(snap.code);
+        if (result != 0) obj_mod.tcl_obj_release(result);
+        return 0;
+    }
 
     const sub = obj_ensure_string(words[1]);
     const impl = ensemble_resolve(rec, sub.ptr, sub.len);
@@ -2658,6 +2667,37 @@ fn raise_ns_not_found_in_current(name_ptr: u32, name_len: u32) void {
     }
     const e = obj_mod.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(e);
+}
+
+/// Raise ``unknown subcommand handler returned bad code: <name>`` when
+/// an ensemble ``-unknown`` handler returns a non-OK / non-error code
+/// (break / continue / return).  namespace-47.4.
+fn raise_ensemble_bad_code(code: @import("../interp/tcl_result.zig").Code) void {
+    const catch_mod = @import("../interp/tcl_catch.zig");
+    const name: []const u8 = switch (code) {
+        .RETURN => "return",
+        .BREAK => "break",
+        .CONTINUE => "continue",
+        else => "?",
+    };
+    const prefix: []const u8 = "unknown subcommand handler returned bad code: ";
+    const total: u32 = @intCast(prefix.len + name.len);
+    const buf = alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(obj_mod.obj_new_string(0, 0));
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    for (name) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    catch_mod.tcl_cmd_error(obj_mod.obj_new_string_take(buf, total, total));
 }
 
 /// When a ``namespace eval`` body raises, append the

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -183,6 +183,21 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                 const line_before2 = @import("../interp/tcl_frames.zig").frame_get_line(0);
                 const ns_result = interp.eval_script(buf, total);
                 append_ns_eval_error_frame(target_ns, line_before2);
+                // ``error msg …`` in the body stores ``msg`` as a bare
+                // borrow that can point into ``buf`` (the synthesised
+                // body, e.g. ``namespace eval ns error foo bar baz``);
+                // promote it to an owned copy before freeing so the
+                // catch result variable doesn't read recycled memory
+                // (namespace-25.8's ``rIn`` corruption).
+                {
+                    const tcl_catch = @import("../interp/tcl_catch.zig");
+                    if (tcl_catch.state.error_flag != 0 and tcl_catch.state.error_msg != 0) {
+                        const ms = obj_mod.obj_ensure_string(tcl_catch.state.error_msg);
+                        if (ms.len > 0 and ms.ptr >= buf and ms.ptr < buf + total) {
+                            tcl_catch.state.error_msg = obj_mod.obj_new_string_copy(ms.ptr, ms.len);
+                        }
+                    }
+                }
                 // Free the synthesised script buffer.  ``eval_script``
                 // either copies bytes into owned TclObjs or borrows
                 // through retained var slots; either way the result's

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -1020,6 +1020,12 @@ fn do_ns_delete(h: u32) void {
     // Command pointer and ``test_ns_1::q`` would keep running its
     // body (namespace-old-7.1, namespace-35.2).  Drop the LRU
     // unconditionally on every namespace teardown.
+    // Reference Tcl ``TclTeardownNamespace`` deletes each command in
+    // the namespace, which fires its ``delete`` command trace while the
+    // command (and namespace) is still live — so the callback's
+    // ``namespace which -command`` still resolves it (trace-34.4).  Fire
+    // before the tombstoning below removes the cmd_table entries.
+    fire_ns_command_delete_traces(h);
     invalidate_ns_command_imports(h);
     procs.lru_invalidate_all();
     const parent = ns.parent;
@@ -1159,6 +1165,45 @@ fn list_imported_simple_names(ns_addr: u32) i32 {
 /// import redirect that points at one of these commands.  ``info
 /// commands`` filters such "dead" redirects via ``entry_matches``,
 /// matching Tcl 9 ``Tcl_DeleteNamespace`` semantics.
+/// Fire the ``delete`` command trace for every traced command in
+/// *ns_addr* before the namespace is torn down.  The command and its
+/// home namespace are still live at this point, so the callback's
+/// ``namespace which -command <fqn>`` resolves it (trace-34.4).  Each
+/// command's traces are dropped afterwards.
+fn fire_ns_command_delete_traces(ns_addr: u32) void {
+    if (ns_addr == 0) return;
+    const ns: *const tcl_ns.Namespace = @ptrFromInt(ns_addr);
+    if (ns.cmd_table.buf == 0) return;
+    const exec_trace = @import("../interp/tcl_exec_trace.zig");
+    const bucket_size: u32 = tcl_ns.NS_BUCKET_SIZE;
+    const mem_pages: u32 = @intCast(@wasmMemorySize(0));
+    const mem_bytes: u64 = @as(u64, mem_pages) * 65536;
+    var i: u32 = 0;
+    while (i < ns.cmd_table.cap) : (i += 1) {
+        const bucket = ns.cmd_table.buf + i * bucket_size;
+        const name_ptr: u32 = @bitCast(obj_mod.read_i32(bucket));
+        if (name_ptr == 0) continue;
+        const name_len: u32 = @bitCast(obj_mod.read_i32(bucket + 4));
+        const cmd: u32 = @bitCast(obj_mod.read_i32(bucket + tcl_ns.OFF_HANDLE));
+        if (cmd == 0) continue;
+        // Guard against out-of-heap handles (builtin forwards, etc.).
+        if (@as(u64, cmd) + procs.OFF_FLAGS + 4 > mem_bytes) continue;
+        if ((exec_trace.ops_for(cmd) & exec_trace.OP_CMD_DELETE) != 0) {
+            const fqn_info = tcl_ns.ns_build_fqn(ns_addr, name_ptr, name_len);
+            const fqn: i32 = if (fqn_info.ptr != 0)
+                obj_mod.obj_new_string_take(fqn_info.ptr, fqn_info.len, fqn_info.len)
+            else
+                0;
+            defer if (fqn != 0) obj_mod.tcl_obj_release(fqn);
+            // One-shot: the delete entry is removed before its callback
+            // runs, so a callback that re-deletes this namespace can't
+            // recurse back into here forever.
+            exec_trace.fire_command_delete_oneshot(cmd, fqn);
+        }
+        exec_trace.remove_all_for(cmd);
+    }
+}
+
 fn invalidate_ns_command_imports(ns_addr: u32) void {
     if (ns_addr == 0) return;
     const ns: *const tcl_ns.Namespace = @ptrFromInt(ns_addr);

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -151,7 +151,12 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                 defer tcl_ns.current_ns = saved_ns;
                 if (words.len == 4) {
                     const bs = obj_ensure_string(words[3]);
-                    if (bs.len > 0) return result_mod.from_globals(interp.eval_script(bs.ptr, bs.len));
+                    if (bs.len > 0) {
+                        const line_before = @import("../interp/tcl_frames.zig").frame_get_line(0);
+                        const r = interp.eval_script(bs.ptr, bs.len);
+                        append_ns_eval_error_frame(target_ns, line_before);
+                        return result_mod.from_globals(r);
+                    }
                     return result_mod.from_globals(0);
                 }
                 var total: u32 = 0;
@@ -175,7 +180,9 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
                         off += 1;
                     }
                 }
+                const line_before2 = @import("../interp/tcl_frames.zig").frame_get_line(0);
                 const ns_result = interp.eval_script(buf, total);
+                append_ns_eval_error_frame(target_ns, line_before2);
                 // Free the synthesised script buffer.  ``eval_script``
                 // either copies bytes into owned TclObjs or borrows
                 // through retained var slots; either way the result's
@@ -2636,6 +2643,72 @@ fn raise_ns_not_found_in_current(name_ptr: u32, name_len: u32) void {
     }
     const e = obj_mod.obj_new_string_take(buf, total, total);
     catch_mod.tcl_cmd_error(e);
+}
+
+/// When a ``namespace eval`` body raises, append the
+/// ``\n    (in namespace eval "<FQNS>" script line N)`` errorInfo frame
+/// — the namespace-eval analogue of ``(procedure "X" line N)``.  The
+/// surrounding ``eval_script`` then stamps the ``invoked from within
+/// "namespace eval …"`` callsite frame via ``append_errinfo_frame``'s
+/// sentinel (namespace-25.6/25.7/25.8).  No-op when the body succeeded.
+fn append_ns_eval_error_frame(target_ns: u32, line_before: u32) void {
+    const tcl_catch = @import("../interp/tcl_catch.zig");
+    if (tcl_catch.state.error_flag == 0) return;
+    const ns_full = tcl_ns.ns_full_name(target_ns);
+    if (ns_full.ptr == 0 or ns_full.len == 0) return;
+    // ``error_frame_line`` is the absolute source line of the failing
+    // command.  The body's nested ``eval_script`` doesn't reset the
+    // frame line (only the outermost eval owns it), so subtract the
+    // ``namespace eval`` command's own line to get the body-relative
+    // ``script line N`` Tcl reports (1-based).
+    const abs = tcl_catch.state.error_frame_line;
+    var line_n: u32 = if (abs >= line_before and line_before > 0) abs - line_before + 1 else 1;
+    if (line_n == 0) line_n = 1;
+    // Decimal-render the line number.
+    var digits: [16]u8 = undefined;
+    var d_off: u32 = 0;
+    {
+        var n = line_n;
+        while (n > 0) : (n /= 10) {
+            digits[d_off] = @intCast('0' + (n % 10));
+            d_off += 1;
+        }
+    }
+    const prefix: []const u8 = "\n    (in namespace eval \"";
+    const middle: []const u8 = "\" script line ";
+    const suffix: []const u8 = ")";
+    const total: u32 = @intCast(prefix.len + ns_full.len + middle.len + d_off + suffix.len);
+    const buf = alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const np: [*]const u8 = @ptrFromInt(ns_full.ptr);
+    var k: u32 = 0;
+    while (k < ns_full.len) : (k += 1) {
+        dst[off] = np[k];
+        off += 1;
+    }
+    for (middle) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    // ``digits`` holds the line in reverse; emit most-significant first.
+    while (d_off > 0) {
+        d_off -= 1;
+        dst[off] = digits[d_off];
+        off += 1;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const bp_const: [*]const u8 = @ptrFromInt(buf);
+    tcl_ns.append_errinfo_frame(bp_const[0..total]);
+    obj_mod.free_sized(buf, total);
 }
 
 /// Raise the canonical Tcl 9 ``unknown namespace "NAME" in CONTEXT``

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -1945,11 +1945,21 @@ fn eval_ns_ensemble_create(words: []const i32) i32 {
 /// extra args).
 pub fn dispatch_ensemble(bucket: i32, words: []const i32) i32 {
     const rec = ensemble_rec_of(@bitCast(bucket)) orelse return 0;
-    if (words.len < 2) {
+    // ``-parameters {p1 p2 …}`` consumes that many words *before* the
+    // subcommand; they are re-inserted ahead of the resolved impl's
+    // trailing args (namespace-53.1).
+    var n_params: u32 = 0;
+    if (rec.params_obj != 0) {
+        const ps = obj_ensure_string(rec.params_obj);
+        const c = obj_mod.list_count_elements(ps.ptr, ps.len);
+        if (c > 0) n_params = @intCast(c);
+    }
+    const sub_idx: u32 = 1 + n_params;
+    if (words.len < sub_idx + 1) {
         raise_ensemble_wrong_args(words[0], rec);
         return 0;
     }
-    const sub = obj_ensure_string(words[1]);
+    const sub = obj_ensure_string(words[sub_idx]);
     if (sub.len == 0) {
         raise_ensemble_wrong_args(words[0], rec);
         return 0;
@@ -1967,8 +1977,8 @@ pub fn dispatch_ensemble(bucket: i32, words: []const i32) i32 {
     }
     defer obj_mod.tcl_obj_release(impl_obj);
 
-    // 2. Build the full call: impl-elements + words[2..].
-    return invoke_ensemble_impl(impl_obj, words);
+    // 2. Build the full call: impl-elements + parameters + trailing args.
+    return invoke_ensemble_impl(impl_obj, words, sub_idx);
 }
 
 /// Resolve an ensemble subcommand to its implementation command prefix
@@ -2129,15 +2139,19 @@ fn ensemble_match_in_exports(ns: u32, sub_ptr: u32, sub_len: u32, prefixes: u32)
 
 /// Combine the ensemble impl prefix (a Tcl list) with the remaining
 /// call args and invoke the result.
-fn invoke_ensemble_impl(impl_obj: i32, words: []const i32) i32 {
+fn invoke_ensemble_impl(impl_obj: i32, words: []const i32, sub_idx: u32) i32 {
     const is = obj_ensure_string(impl_obj);
     if (is.len == 0) return 0;
     const interp = @import("../interp/tcl_interp.zig");
-    // The impl is a list ``cmd ?arg ...?``.  Split into element
-    // TclObjs, then append words[2..].
+    // The impl is a list ``cmd ?arg ...?``.  Split into element TclObjs,
+    // then append the ensemble ``-parameters`` words (``words[1..sub_idx]``,
+    // before the subcommand) followed by the trailing args after the
+    // subcommand (``words[sub_idx+1..]``).  With no parameters
+    // ``sub_idx == 1`` so this is just ``words[2..]``.
     const n_impl = obj_mod.list_count_elements(is.ptr, is.len);
-    const tail = if (words.len >= 2) words.len - 2 else 0;
-    const total_args: u32 = @intCast(@as(i64, n_impl) + @as(i64, @intCast(tail)));
+    const n_params: u32 = if (sub_idx > 1) sub_idx - 1 else 0;
+    const n_trail: u32 = if (words.len > sub_idx + 1) @intCast(words.len - sub_idx - 1) else 0;
+    const total_args: u32 = @intCast(@as(i64, n_impl) + @as(i64, n_params) + @as(i64, n_trail));
     if (total_args == 0) return 0;
     const argv = obj_mod.alloc(total_args * 4);
     if (argv == 0) return 0;
@@ -2150,7 +2164,14 @@ fn invoke_ensemble_impl(impl_obj: i32, words: []const i32) i32 {
         obj_mod.write_i32(argv + idx * 4, w);
         idx += 1;
     }
-    var wi: u32 = 2;
+    // ``-parameters`` words (between the ensemble name and subcommand).
+    var pi: u32 = 1;
+    while (pi < sub_idx) : (pi += 1) {
+        obj_mod.tcl_obj_retain(words[pi]);
+        obj_mod.write_i32(argv + idx * 4, words[pi]);
+        idx += 1;
+    }
+    var wi: u32 = sub_idx + 1;
     while (wi < words.len) : (wi += 1) {
         obj_mod.tcl_obj_retain(words[wi]);
         obj_mod.write_i32(argv + idx * 4, words[wi]);
@@ -2231,7 +2252,7 @@ fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i
     if (impl != 0) {
         if (result != 0) obj_mod.tcl_obj_release(result);
         defer obj_mod.tcl_obj_release(impl);
-        return invoke_ensemble_impl(impl, words);
+        return invoke_ensemble_impl(impl, words, 1);
     }
 
     const rs = obj_ensure_string(result);
@@ -2239,7 +2260,7 @@ fn invoke_ensemble_unknown(bucket: i32, rec: *EnsembleRec, words: []const i32) i
         // Non-empty rewrite: evaluate the returned command prefix
         // followed by the ensemble's argument tail (words[2..]).
         defer if (result != 0) obj_mod.tcl_obj_release(result);
-        return invoke_ensemble_impl(result, words);
+        return invoke_ensemble_impl(result, words, 1);
     }
 
     if (result != 0) obj_mod.tcl_obj_release(result);

--- a/runtime/zig/cmds/namespace.zig
+++ b/runtime/zig/cmds/namespace.zig
@@ -492,6 +492,26 @@ fn eval_namespace(words: []const i32) result_mod.InterpResult {
             const nf = tcl_ns.ns_full_name(tcl_ns.ns_current());
             return result_mod.from_globals(obj_new_string(@bitCast(nf.ptr), @bitCast(nf.len)));
         }
+        if (str_eq(@ptrFromInt(sub.ptr), sub.len, "unknown")) {
+            // ``namespace unknown ?handler?`` — per-namespace
+            // unknown-command handler (namespace-52.x).
+            const cur_ns = tcl_ns.ns_current();
+            if (words.len >= 3) {
+                tcl_ns.ns_unknown_set(cur_ns, words[2]);
+                return result_mod.from_globals(obj_new_string(0, 0));
+            }
+            const h = tcl_ns.ns_unknown_get(cur_ns);
+            if (h != 0) {
+                obj_mod.tcl_obj_retain(h);
+                return result_mod.from_globals(h);
+            }
+            // No explicit handler: the root namespace defaults to
+            // ``::unknown``; every other namespace reports ``{}``.
+            if (cur_ns == tcl_ns.root_addr) {
+                return result_mod.from_globals(obj_new_string(@bitCast(@intFromPtr("::unknown".ptr)), 9));
+            }
+            return result_mod.from_globals(obj_new_string(0, 0));
+        }
         if (str_eq(@ptrFromInt(sub.ptr), sub.len, "ensemble")) {
             return result_mod.from_globals(eval_ns_ensemble(words));
         }

--- a/runtime/zig/cmds/stubs.zig
+++ b/runtime/zig/cmds/stubs.zig
@@ -63,6 +63,7 @@ const result_mod = @import("../interp/tcl_result.zig");
 const rt = @import("../tcl_runtime.zig");
 const reg = @import("../dispatch/tcl_cmd_registry.zig");
 const clock = @import("../io/tcl_clock.zig");
+const obj_mod = @import("../valtypes/tcl_obj.zig");
 
 fn eval_auto_load(words: []const i32) result_mod.InterpResult {
     _ = words;
@@ -74,8 +75,112 @@ fn eval_auto_noop(words: []const i32) result_mod.InterpResult {
     return result_mod.from_globals(rt.obj_new_string(0, 0));
 }
 
+// ``package ifneeded`` registry — the one piece of the package
+// machinery the WASM runtime needs working: ``tcltest``'s
+// ``loadIntoChildInterpreter`` does ``interp eval $child [package
+// ifneeded tcltest $Version]`` to load the framework into a freshly
+// created child interp.  Without a real store the query returns empty
+// and the child never gets ``tcltest::*``.  A small fixed-capacity
+// table keyed by ``name\x00version`` is enough — package data is
+// effectively process-global in a single-program WASM run, and the
+// volume is tiny (a handful of ``ifneeded`` registrations per run).
+const PkgEntry = struct { key_ptr: u32, key_len: u32, script: i32 };
+var pkg_entries: [128]PkgEntry = undefined;
+var pkg_count: u32 = 0;
+
+fn pkg_make_key(name: i32, version: i32) struct { ptr: u32, len: u32 } {
+    const n = rt.obj_ensure_string(name);
+    const v = rt.obj_ensure_string(version);
+    const total: u32 = n.len + 1 + v.len;
+    const buf = rt.alloc(total);
+    if (buf == 0) return .{ .ptr = 0, .len = 0 };
+    if (n.len > 0) rt.memcpy(buf, n.ptr, n.len);
+    const sep: [*]u8 = @ptrFromInt(buf + n.len);
+    sep[0] = 0;
+    if (v.len > 0) rt.memcpy(buf + n.len + 1, v.ptr, v.len);
+    return .{ .ptr = buf, .len = total };
+}
+
+fn pkg_key_eq(a_ptr: u32, a_len: u32, b_ptr: u32, b_len: u32) bool {
+    if (a_len != b_len) return false;
+    const a: [*]const u8 = @ptrFromInt(a_ptr);
+    const b: [*]const u8 = @ptrFromInt(b_ptr);
+    var i: u32 = 0;
+    while (i < a_len) : (i += 1) {
+        if (a[i] != b[i]) return false;
+    }
+    return true;
+}
+
+fn word_eq(o: i32, lit: []const u8) bool {
+    const s = rt.obj_ensure_string(o);
+    if (s.ptr == 0 or s.len != lit.len) return false;
+    const p = @as([*]const u8, @ptrFromInt(s.ptr))[0..s.len];
+    return std.mem.eql(u8, p, lit);
+}
+
 fn eval_package(words: []const i32) result_mod.InterpResult {
-    _ = words;
+    if (words.len == 0) return result_mod.from_globals(0);
+    // The handler is shared by the parent ``package`` command and the
+    // ``package <sub>`` subcommand entries; depending on the dispatch
+    // path ``words`` is either ``[package, sub, …]`` or ``[sub, …]``.
+    // Probe both so the sub-word index is correct either way.
+    const base: u32 = if (word_eq(words[0], "package")) 1 else 0;
+    if (words.len <= base) return result_mod.from_globals(0);
+    if (word_eq(words[base], "ifneeded")) {
+        // ``package ifneeded NAME VERSION ?SCRIPT?``
+        const name_i = base + 1;
+        const ver_i = base + 2;
+        const script_i = base + 3;
+        if (words.len > script_i) {
+            const key = pkg_make_key(words[name_i], words[ver_i]);
+            if (key.ptr == 0) return result_mod.from_globals(0);
+            var i: u32 = 0;
+            while (i < pkg_count) : (i += 1) {
+                if (pkg_key_eq(pkg_entries[i].key_ptr, pkg_entries[i].key_len, key.ptr, key.len)) {
+                    obj_mod.tcl_obj_retain(words[script_i]);
+                    obj_mod.tcl_obj_release(pkg_entries[i].script);
+                    pkg_entries[i].script = words[script_i];
+                    return result_mod.from_globals(0);
+                }
+            }
+            if (pkg_count < pkg_entries.len) {
+                obj_mod.tcl_obj_retain(words[script_i]);
+                pkg_entries[pkg_count] = .{ .key_ptr = key.ptr, .key_len = key.len, .script = words[script_i] };
+                pkg_count += 1;
+            }
+            return result_mod.from_globals(0);
+        }
+        if (words.len > ver_i) {
+            const key = pkg_make_key(words[name_i], words[ver_i]);
+            if (key.ptr == 0) return result_mod.from_globals(rt.obj_new_string(0, 0));
+            var i: u32 = 0;
+            while (i < pkg_count) : (i += 1) {
+                if (pkg_key_eq(pkg_entries[i].key_ptr, pkg_entries[i].key_len, key.ptr, key.len)) {
+                    const s = rt.obj_ensure_string(pkg_entries[i].script);
+                    return result_mod.from_globals(rt.obj_new_string_copy(s.ptr, s.len));
+                }
+            }
+            return result_mod.from_globals(rt.obj_new_string(0, 0));
+        }
+    }
+    // ``package require Tcl ?reqs?`` / ``package provide Tcl`` return the
+    // interpreter's version so library code that does ``variable version
+    // [package require Tcl 8.5-]`` (tcltest) gets a usable string.  Other
+    // packages have no on-disk presence under WASM, so requiring them is a
+    // silent empty no-op.
+    if (word_eq(words[base], "require") or word_eq(words[base], "provide")) {
+        if (words.len > base + 1 and word_eq(words[base + 1], "Tcl")) {
+            const ver = "9.0.3";
+            return result_mod.from_globals(rt.obj_new_string_copy(@intFromPtr(ver.ptr), ver.len));
+        }
+        return result_mod.from_globals(rt.obj_new_string(0, 0));
+    }
+    // ``package vsatisfies VERSION REQ...`` — the runtime targets Tcl
+    // 9.0.3, so version predicates a 9.0 build satisfies report true.
+    if (word_eq(words[base], "vsatisfies")) {
+        return result_mod.from_globals(rt.obj_new_int(1));
+    }
     return result_mod.from_globals(0);
 }
 

--- a/runtime/zig/cmds/stubs.zig
+++ b/runtime/zig/cmds/stubs.zig
@@ -141,19 +141,28 @@ fn eval_package(words: []const i32) result_mod.InterpResult {
                     obj_mod.tcl_obj_retain(words[script_i]);
                     obj_mod.tcl_obj_release(pkg_entries[i].script);
                     pkg_entries[i].script = words[script_i];
+                    // Overwrite: the existing entry keeps its own key, so
+                    // the freshly-built lookup key is unused — free it.
+                    obj_mod.free_sized(key.ptr, key.len);
                     return result_mod.from_globals(0);
                 }
             }
             if (pkg_count < pkg_entries.len) {
                 obj_mod.tcl_obj_retain(words[script_i]);
+                // New entry takes ownership of the key buffer.
                 pkg_entries[pkg_count] = .{ .key_ptr = key.ptr, .key_len = key.len, .script = words[script_i] };
                 pkg_count += 1;
+            } else {
+                // Table full: the key was never stored — don't leak it.
+                obj_mod.free_sized(key.ptr, key.len);
             }
             return result_mod.from_globals(0);
         }
         if (words.len > ver_i) {
             const key = pkg_make_key(words[name_i], words[ver_i]);
             if (key.ptr == 0) return result_mod.from_globals(rt.obj_new_string(0, 0));
+            // Lookup-only key — never stored, so reclaim it on every exit.
+            defer obj_mod.free_sized(key.ptr, key.len);
             var i: u32 = 0;
             while (i < pkg_count) : (i += 1) {
                 if (pkg_key_eq(pkg_entries[i].key_ptr, pkg_entries[i].key_len, key.ptr, key.len)) {

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -300,6 +300,11 @@ pub fn eval_rename(words: []const i32) i32 {
         switch (r) {
             .ok => return 0,
             .not_found => {
+                // The command existed when we resolved ``old_cmd`` above,
+                // so a not-found here means the trace callback we just
+                // fired deleted/renamed it.  That makes the outer delete
+                // a no-op rather than an error (trace-20.9 / 20.11).
+                if (old_cmd != 0) return 0;
                 rename_error("can't rename \"", old_s.ptr, old_s.len, "\": command doesn't exist");
                 return 0;
             },
@@ -340,6 +345,10 @@ pub fn eval_rename(words: []const i32) i32 {
             return 0;
         },
         .not_found => {
+            // Existed at resolution time, so the just-fired rename trace
+            // callback must have deleted/renamed it — the outer rename
+            // becomes a no-op rather than an error (trace-20.9 / 20.10).
+            if (old_cmd != 0) return 0;
             rename_error("can't rename \"", old_s.ptr, old_s.len, "\": command doesn't exist");
             return 0;
         },

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -141,6 +141,26 @@ fn rename_builtin(
     return 0;
 }
 
+/// Build an owned ``::name``-qualified TclObj from a (possibly already
+/// qualified) command name.  Used for the new-name argument of a
+/// command rename trace.
+fn qualify_simple_name(ptr: u32, len: u32) i32 {
+    if (len >= 2) {
+        const p: [*]const u8 = @ptrFromInt(ptr);
+        if (p[0] == ':' and p[1] == ':') return obj_new_string(@bitCast(ptr), @bitCast(len));
+    }
+    const total: u32 = len + 2;
+    const buf = alloc(total);
+    if (buf == 0) return obj_new_string(@bitCast(ptr), @bitCast(len));
+    const dst: [*]u8 = @ptrFromInt(buf);
+    dst[0] = ':';
+    dst[1] = ':';
+    const src: [*]const u8 = @ptrFromInt(ptr);
+    var i: u32 = 0;
+    while (i < len) : (i += 1) dst[2 + i] = src[i];
+    return rt.obj_new_string_take(buf, total, total);
+}
+
 pub fn eval_rename(words: []const i32) i32 {
     // ``rename`` takes exactly two operands (oldName + newName).
     // Extra words are rejected with ``wrong # args`` rather than
@@ -230,6 +250,22 @@ pub fn eval_rename(words: []const i32) i32 {
                 _ = procs.unregister_command(new_s.ptr, new_s.len);
                 return 0;
             }
+        }
+    }
+
+    // Fire any ``trace add command`` callbacks (rename / delete) before
+    // the command goes away, with the resolved FQ old name and (for a
+    // rename) the new name (trace-20.x).  The callback's result is
+    // discarded.  After a delete the command's traces are dropped.
+    if (old_cmd != 0) {
+        const exec_trace = @import("../interp/tcl_exec_trace.zig");
+        const op = if (new_s.len == 0) exec_trace.OP_CMD_DELETE else exec_trace.OP_CMD_RENAME;
+        if ((exec_trace.ops_for(@bitCast(old_cmd)) & op) != 0) {
+            const old_fqn = command_fqn_obj(@bitCast(old_cmd));
+            defer if (old_fqn != 0) obj_mod.tcl_obj_release(old_fqn);
+            const new_fqn: i32 = if (new_s.len == 0) 0 else qualify_simple_name(new_s.ptr, new_s.len);
+            defer if (new_fqn != 0) obj_mod.tcl_obj_release(new_fqn);
+            exec_trace.fire_command(@bitCast(old_cmd), op, old_fqn, new_fqn);
         }
     }
 

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -1353,7 +1353,38 @@ pub fn eval_interp_create(words: []const i32) i32 {
     // the raw ``-safe`` flag — Codex review on PR #451 caught a
     // path where a safe parent's child without ``-safe`` got the
     // trusted ``tcl_platform`` seed despite being marked safe.
-    seed_child_globals(child, parent_interp, (flags & interp_reg.INTERP_SAFE) != 0);
+    seed_child_globals(child, (flags & interp_reg.INTERP_SAFE) != 0);
+
+    // Tcl_Init for trusted children: C Tcl's ``ChildCreate`` runs
+    // ``Tcl_Init`` on every non-safe child, which sources ``init.tcl``
+    // so the child gets the auto-loading machinery (``auto_load``,
+    // ``auto_qualify``, ``unknown``, …).  We mirror that, but:
+    //
+    //  * only when the *parent* has itself loaded ``init.tcl`` —
+    //    detected by a real ``auto_qualify`` command in the parent's
+    //    root ns.  Bundles on the stub ``auto_load`` path are
+    //    unaffected, keeping the change scoped to runs that opt in by
+    //    loading the real stdlib; and
+    //  * lazily, on the child's first ``enter`` rather than here.
+    //    Sourcing init.tcl from inside the ``interp create`` dispatch
+    //    (nested in the parent's ``eval_command``) leaves init.tcl's
+    //    ``proc`` definitions unregistered; deferring to the first
+    //    ``interp eval`` runs them in a clean dispatch context.
+    //
+    // ``tcl_library`` / ``auto_path`` are copied from the parent now
+    // (a plain scalar copy, unaffected by the create-context issue) so
+    // the deferred bootstrap can resolve ``[file join $tcl_library
+    // init.tcl]``.
+    if ((flags & interp_reg.INTERP_SAFE) == 0) {
+        const parent_i2: *interp_reg.Interp = @ptrFromInt(parent_interp);
+        const aq = "auto_qualify";
+        if (tcl_ns.ns_cmd_find(parent_i2.root_ns, @intFromPtr(aq.ptr), aq.len) != 0) {
+            const child_i: *interp_reg.Interp = @ptrFromInt(child);
+            copy_global_scalar(parent_i2.root_ns, child_i.root_ns, "tcl_library");
+            copy_global_scalar(parent_i2.root_ns, child_i.root_ns, "auto_path");
+            child_i.flags |= interp_reg.INTERP_NEEDS_INIT;
+        }
+    }
 
     // Return the path as supplied (or the auto-generated simple
     // name) — matches tclsh's ``Tcl_SetObjResult(interp, childPtr)``
@@ -1385,7 +1416,7 @@ fn copy_global_scalar(src_ns: u32, dst_ns: u32, name: []const u8) void {
     tcl_ns.var_set_scalar(dv, value);
 }
 
-fn seed_child_globals(child: u32, parent: u32, safe_flag: bool) void {
+fn seed_child_globals(child: u32, safe_flag: bool) void {
     // Run the seed as a Tcl script inside the child so it threads
     // through the normal ``global_set`` / ``array set`` paths and
     // lands in the child's namespace state regardless of the
@@ -1416,40 +1447,6 @@ fn seed_child_globals(child: u32, parent: u32, safe_flag: bool) void {
     const save = interp_reg.enter(child);
     defer interp_reg.leave(save);
     _ = tcl_interp.eval_script(@intFromPtr(script.ptr), @intCast(script.len));
-
-    // Tcl_Init for trusted children: C Tcl's ``ChildCreate`` runs
-    // ``Tcl_Init`` on every non-safe child, which sources ``init.tcl``
-    // so the child gets the auto-loading machinery (``auto_load``,
-    // ``auto_qualify``, ``unknown``, …).  We mirror that, but only when
-    // the *parent* has itself loaded ``init.tcl`` — detected by the
-    // presence of a real ``auto_qualify`` command in the parent's root
-    // namespace.  Bundles that run on the stub ``auto_load`` path (no
-    // ``init.tcl`` in the parent) neither pay for nor are perturbed by
-    // child ``init.tcl`` sourcing, keeping the change scoped to runs
-    // that opt in by loading the real stdlib.
-    if (safe_flag) return;
-    const parent_i: *interp_reg.Interp = @ptrFromInt(parent);
-    const aq = "auto_qualify";
-    if (tcl_ns.ns_cmd_find(parent_i.root_ns, @intFromPtr(aq.ptr), aq.len) == 0) return;
-
-    const child_i: *interp_reg.Interp = @ptrFromInt(child);
-    copy_global_scalar(parent_i.root_ns, child_i.root_ns, "tcl_library");
-    copy_global_scalar(parent_i.root_ns, child_i.root_ns, "auto_path");
-
-    // ``::tcl::unsupported::clock::configure`` is a C-provided command
-    // init.tcl's clock-ensemble block signals once setup completes.
-    // The WASM runtime ships ``clock`` as a builtin, so init.tcl's
-    // ensemble glue is redundant; provide a no-op accessor so sourcing
-    // init.tcl completes.  ``env`` mirrors the minimal set tclsh's
-    // startup populates so init.tcl's reads resolve.
-    const init_script: []const u8 =
-        \\if {![info exists ::env]} { array set ::env {HOME / PATH {} USER wasm} }
-        \\namespace eval ::tcl::unsupported::clock { proc configure args { return } }
-        \\if {[info exists ::tcl_library] && $::tcl_library ne ""} {
-        \\    catch { source [file join $::tcl_library init.tcl] }
-        \\}
-    ;
-    _ = tcl_interp.eval_script(@intFromPtr(init_script.ptr), @intCast(init_script.len));
 }
 
 /// ``interp eval path script ?script ...?``.  Concatenate scripts

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -149,6 +149,18 @@ fn qualify_simple_name(ptr: u32, len: u32) i32 {
         const p: [*]const u8 = @ptrFromInt(ptr);
         if (p[0] == ':' and p[1] == ':') return obj_new_string(@bitCast(ptr), @bitCast(len));
     }
+    // Resolve the relative new name against the current namespace so a
+    // rename inside ``namespace eval foo {rename a b}`` reports the FQ
+    // ``::foo::b`` to the trace callback, not ``::b`` — the command-trace
+    // contract requires fully-qualified old/new names.  A root-context
+    // rename still yields ``::name`` (ns_build_fqn collapses root), so
+    // top-level behaviour is unchanged.
+    const cxt = tcl_ns.ns_current();
+    const r = tcl_ns.ns_resolve_qualified(cxt, ptr, len);
+    const target = if (r.target_ns != 0) r.target_ns else cxt;
+    const fqn = tcl_ns.ns_build_fqn(target, r.simple_ptr, r.simple_len);
+    if (fqn.ptr != 0) return rt.obj_new_string_take(fqn.ptr, fqn.len, fqn.len);
+    // Allocation failure — fall back to the bare ``::name`` form.
     const total: u32 = len + 2;
     const buf = alloc(total);
     if (buf == 0) return obj_new_string(@bitCast(ptr), @bitCast(len));

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -253,6 +253,24 @@ pub fn eval_rename(words: []const i32) i32 {
         }
     }
 
+    // A move whose destination is already occupied fails *before* any
+    // command trace fires — reference Tcl validates the rename target
+    // first, so ``trace add command foo {rename delete} cb`` does not
+    // see a failed ``rename foo <existing>`` (trace-19.10).  Probe the
+    // destination here and raise the same error ``rename_command``
+    // would, skipping the fire path below.
+    if (new_s.len > 0) {
+        const new_probe = tcl_ns.ns_resolve_qualified(cxt, new_s.ptr, new_s.len);
+        const probe_ns = if (new_probe.target_ns != 0) new_probe.target_ns else new_probe.alt_ns;
+        if (probe_ns != 0) {
+            const occupant = tcl_ns.ns_cmd_find(probe_ns, new_probe.simple_ptr, new_probe.simple_len);
+            if (occupant != 0 and occupant != old_cmd) {
+                rename_error("can't rename to \"", new_s.ptr, new_s.len, "\": command already exists");
+                return 0;
+            }
+        }
+    }
+
     // Fire any ``trace add command`` callbacks (rename / delete) before
     // the command goes away, with the resolved FQ old name and (for a
     // rename) the new name (trace-20.x).  The callback's result is

--- a/runtime/zig/cmds/tcl_cmd_interp.zig
+++ b/runtime/zig/cmds/tcl_cmd_interp.zig
@@ -1353,7 +1353,7 @@ pub fn eval_interp_create(words: []const i32) i32 {
     // the raw ``-safe`` flag — Codex review on PR #451 caught a
     // path where a safe parent's child without ``-safe`` got the
     // trusted ``tcl_platform`` seed despite being marked safe.
-    seed_child_globals(child, (flags & interp_reg.INTERP_SAFE) != 0);
+    seed_child_globals(child, parent_interp, (flags & interp_reg.INTERP_SAFE) != 0);
 
     // Return the path as supplied (or the auto-generated simple
     // name) — matches tclsh's ``Tcl_SetObjResult(interp, childPtr)``
@@ -1375,7 +1375,17 @@ pub fn eval_interp_create(words: []const i32) i32 {
 /// (``os``, ``osVersion``, ``machine``, ``user``) so a safe child
 /// only sees ``byteOrder``, ``engine``, ``pathSeparator``,
 /// ``platform``, ``pointerSize``, ``threaded``, ``wordSize``.
-fn seed_child_globals(child: u32, safe_flag: bool) void {
+fn copy_global_scalar(src_ns: u32, dst_ns: u32, name: []const u8) void {
+    const sv = tcl_ns.ns_var_find(src_ns, @intFromPtr(name.ptr), @intCast(name.len));
+    if (sv == 0) return;
+    const value = tcl_ns.var_get_scalar(sv);
+    if (value == 0) return;
+    const dv = tcl_ns.ns_var_create(dst_ns, @intFromPtr(name.ptr), @intCast(name.len));
+    if (dv == 0) return;
+    tcl_ns.var_set_scalar(dv, value);
+}
+
+fn seed_child_globals(child: u32, parent: u32, safe_flag: bool) void {
     // Run the seed as a Tcl script inside the child so it threads
     // through the normal ``global_set`` / ``array set`` paths and
     // lands in the child's namespace state regardless of the
@@ -1406,6 +1416,40 @@ fn seed_child_globals(child: u32, safe_flag: bool) void {
     const save = interp_reg.enter(child);
     defer interp_reg.leave(save);
     _ = tcl_interp.eval_script(@intFromPtr(script.ptr), @intCast(script.len));
+
+    // Tcl_Init for trusted children: C Tcl's ``ChildCreate`` runs
+    // ``Tcl_Init`` on every non-safe child, which sources ``init.tcl``
+    // so the child gets the auto-loading machinery (``auto_load``,
+    // ``auto_qualify``, ``unknown``, …).  We mirror that, but only when
+    // the *parent* has itself loaded ``init.tcl`` — detected by the
+    // presence of a real ``auto_qualify`` command in the parent's root
+    // namespace.  Bundles that run on the stub ``auto_load`` path (no
+    // ``init.tcl`` in the parent) neither pay for nor are perturbed by
+    // child ``init.tcl`` sourcing, keeping the change scoped to runs
+    // that opt in by loading the real stdlib.
+    if (safe_flag) return;
+    const parent_i: *interp_reg.Interp = @ptrFromInt(parent);
+    const aq = "auto_qualify";
+    if (tcl_ns.ns_cmd_find(parent_i.root_ns, @intFromPtr(aq.ptr), aq.len) == 0) return;
+
+    const child_i: *interp_reg.Interp = @ptrFromInt(child);
+    copy_global_scalar(parent_i.root_ns, child_i.root_ns, "tcl_library");
+    copy_global_scalar(parent_i.root_ns, child_i.root_ns, "auto_path");
+
+    // ``::tcl::unsupported::clock::configure`` is a C-provided command
+    // init.tcl's clock-ensemble block signals once setup completes.
+    // The WASM runtime ships ``clock`` as a builtin, so init.tcl's
+    // ensemble glue is redundant; provide a no-op accessor so sourcing
+    // init.tcl completes.  ``env`` mirrors the minimal set tclsh's
+    // startup populates so init.tcl's reads resolve.
+    const init_script: []const u8 =
+        \\if {![info exists ::env]} { array set ::env {HOME / PATH {} USER wasm} }
+        \\namespace eval ::tcl::unsupported::clock { proc configure args { return } }
+        \\if {[info exists ::tcl_library] && $::tcl_library ne ""} {
+        \\    catch { source [file join $::tcl_library init.tcl] }
+        \\}
+    ;
+    _ = tcl_interp.eval_script(@intFromPtr(init_script.ptr), @intCast(init_script.len));
 }
 
 /// ``interp eval path script ?script ...?``.  Concatenate scripts

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -190,6 +190,13 @@ fn eval_unset(words: []const i32) result_mod.InterpResult {
         } else {
             _ = frames.var_set(words[i], 0);
         }
+        // Tcl drops a variable's traces once it's unset (the unset
+        // callbacks above have already fired).  Without this a stale
+        // trace keeps firing on a later variable that reuses the name —
+        // the trace-2.x cascade.  Done after the null so the unset
+        // callback still observed the live trace.
+        const inspect = @import("inspect.zig");
+        inspect.remove_all_var_traces(words[i]);
     }
     return result_mod.from_globals(obj_new_string(0, 0));
 }

--- a/runtime/zig/interp/tcl_exec_trace.zig
+++ b/runtime/zig/interp/tcl_exec_trace.zig
@@ -1,0 +1,286 @@
+// Execution traces — ``trace add execution CMD {enter|leave|
+// enterstep|leavestep} CALLBACK``.
+//
+// A traced command fires its ``enter`` callback before it runs and
+// ``leave`` after; ``enterstep`` / ``leavestep`` fire around *every*
+// command executed inside its body (recursively).  Callbacks are
+// invoked as a script:
+//   enter:      CALLBACK <command-string> enter
+//   leave:      CALLBACK <command-string> <code> <result> leave
+//   enterstep:  CALLBACK <step-command-string> enterstep
+//   leavestep:  CALLBACK <step-command-string> <code> <result> leavestep
+//
+// Storage is a small linear registry keyed by the traced command's
+// bucket address (its identity), which the dispatcher already has — no
+// per-command name canonicalisation.  ``any_traces`` gates the hot
+// dispatch path so untraced code pays a single i32 load.
+
+const obj = @import("../valtypes/tcl_obj.zig");
+const alloc = obj.alloc;
+const obj_ensure_string = obj.obj_ensure_string;
+const obj_new_string = obj.obj_new_string;
+const tcl_obj_retain = obj.tcl_obj_retain;
+const tcl_obj_release = obj.tcl_obj_release;
+
+pub const OP_ENTER: u32 = 1;
+pub const OP_LEAVE: u32 = 2;
+pub const OP_ENTERSTEP: u32 = 4;
+pub const OP_LEAVESTEP: u32 = 8;
+
+const Entry = struct {
+    bucket: u32,
+    ops: u32,
+    callback: i32,
+};
+
+var entries: [128]Entry = undefined;
+var count: u32 = 0;
+
+/// Fast-path gate read by the command dispatcher: when zero, no
+/// execution traces exist and the dispatcher skips all trace work.
+pub var any_traces: u32 = 0;
+
+// Step-trace context stack: each entry is a traced command's bucket
+// whose body is currently executing.  While non-empty, the dispatcher
+// fires ``enterstep`` / ``leavestep`` for every command it runs.
+var step_stack: [256]u32 = undefined;
+pub var step_depth: u32 = 0;
+
+// Re-entrancy guard: non-zero while a trace callback is being
+// evaluated, so commands run *inside* the callback don't recursively
+// fire traces.
+pub var suppress: u32 = 0;
+
+pub fn push_step(bucket: u32) void {
+    if (step_depth < step_stack.len) {
+        step_stack[step_depth] = bucket;
+        step_depth += 1;
+    }
+}
+
+pub fn pop_step() void {
+    if (step_depth > 0) step_depth -= 1;
+}
+
+/// Fire ``op`` (ENTERSTEP / LEAVESTEP) for every command whose body is
+/// currently on the step stack.
+pub fn fire_step(op: u32, cmd_str: i32, code: i32, result: i32) void {
+    if (step_depth == 0) return;
+    // Snapshot the depth: a callback must not see step frames pushed by
+    // a deeper command after it.
+    var i: u32 = 0;
+    const d = step_depth;
+    while (i < d) : (i += 1) {
+        fire(step_stack[i], op, cmd_str, code, result);
+    }
+}
+
+fn cb_eq(a: i32, b: i32) bool {
+    if (a == b) return true;
+    if (a == 0 or b == 0) return false;
+    const sa = obj_ensure_string(a);
+    const sb = obj_ensure_string(b);
+    if (sa.len != sb.len) return false;
+    const pa: [*]const u8 = @ptrFromInt(sa.ptr);
+    const pb: [*]const u8 = @ptrFromInt(sb.ptr);
+    var i: u32 = 0;
+    while (i < sa.len) : (i += 1) {
+        if (pa[i] != pb[i]) return false;
+    }
+    return true;
+}
+
+/// Add (merge) ``ops`` for ``callback`` on the command at ``bucket``.
+pub fn add(bucket: u32, ops: u32, callback: i32) void {
+    if (ops == 0 or callback == 0 or bucket == 0) return;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (entries[i].bucket == bucket and cb_eq(entries[i].callback, callback)) {
+            entries[i].ops |= ops;
+            return;
+        }
+    }
+    if (count >= entries.len) return;
+    tcl_obj_retain(callback);
+    entries[count] = .{ .bucket = bucket, .ops = ops, .callback = callback };
+    count += 1;
+    any_traces = count;
+}
+
+/// Remove ``ops`` for ``callback`` on ``bucket``; drop the entry when
+/// its op set empties.
+pub fn remove(bucket: u32, ops: u32, callback: i32) void {
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (entries[i].bucket == bucket and cb_eq(entries[i].callback, callback)) {
+            entries[i].ops &= ~ops;
+            if (entries[i].ops == 0) {
+                tcl_obj_release(entries[i].callback);
+                count -= 1;
+                if (i != count) entries[i] = entries[count];
+                any_traces = count;
+            }
+            return;
+        }
+    }
+}
+
+/// Drop every execution trace on ``bucket`` (command deleted / renamed).
+pub fn remove_all_for(bucket: u32) void {
+    if (count == 0 or bucket == 0) return;
+    var i: u32 = 0;
+    while (i < count) {
+        if (entries[i].bucket == bucket) {
+            tcl_obj_release(entries[i].callback);
+            count -= 1;
+            if (i != count) entries[i] = entries[count];
+            continue;
+        }
+        i += 1;
+    }
+    any_traces = count;
+}
+
+/// Bitwise-OR of every op registered on ``bucket``.
+pub fn ops_for(bucket: u32) u32 {
+    if (count == 0 or bucket == 0) return 0;
+    var acc: u32 = 0;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (entries[i].bucket == bucket) acc |= entries[i].ops;
+    }
+    return acc;
+}
+
+/// Fire every callback on ``bucket`` whose op set intersects ``op``.
+/// ``cmd_str`` is the command invocation string; for leave/leavestep
+/// ``code``/``result`` are appended before the op word.  Re-entrancy
+/// is bounded by the caller (the dispatcher clears the bucket's active
+/// op before firing leave so a recursive call doesn't re-loop).
+pub fn fire(bucket: u32, op: u32, cmd_str: i32, code: i32, result: i32) void {
+    if (count == 0) return;
+    const interp = @import("tcl_interp.zig");
+    const op_word: []const u8 = switch (op) {
+        OP_ENTER => "enter",
+        OP_LEAVE => "leave",
+        OP_ENTERSTEP => "enterstep",
+        OP_LEAVESTEP => "leavestep",
+        else => return,
+    };
+    const with_result = (op == OP_LEAVE or op == OP_LEAVESTEP);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (entries[i].bucket != bucket) continue;
+        if ((entries[i].ops & op) == 0) continue;
+        fire_one(entries[i].callback, cmd_str, op_word, with_result, code, result, interp);
+    }
+}
+
+fn fire_one(
+    callback: i32,
+    cmd_str: i32,
+    op_word: []const u8,
+    with_result: bool,
+    code: i32,
+    result: i32,
+    interp: anytype,
+) void {
+    const quote = @import("../valtypes/tcl_list_quote.zig");
+    const cb = obj_ensure_string(callback);
+    const cmd = obj_ensure_string(cmd_str);
+    var code_ptr: u32 = 0;
+    var code_len: u32 = 0;
+    var res_ptr: u32 = 0;
+    var res_len: u32 = 0;
+    if (with_result) {
+        const cs = obj_ensure_string(code);
+        code_ptr = cs.ptr;
+        code_len = cs.len;
+        const rs = obj_ensure_string(result);
+        res_ptr = rs.ptr;
+        res_len = rs.len;
+    }
+    // Worst-case: cb verbatim + each appended arg as a list element
+    // (≤ 2*len + 2) plus a separating space.
+    var size: u32 = cb.len + (1 + 2 * cmd.len + 2) + (1 + @as(u32, @intCast(op_word.len)) + 2);
+    if (with_result) size += (1 + 2 * code_len + 2) + (1 + 2 * res_len + 2);
+    const buf = alloc(size);
+    if (buf == 0) return;
+    var off: u32 = 0;
+    if (cb.len > 0) {
+        const cbp: [*]const u8 = @ptrFromInt(cb.ptr);
+        var k: u32 = 0;
+        while (k < cb.len) : (k += 1) {
+            @as([*]u8, @ptrFromInt(buf))[off] = cbp[k];
+            off += 1;
+        }
+    }
+    off = append_sp_elem(buf, off, cmd.ptr, cmd.len, quote);
+    if (with_result) {
+        off = append_sp_elem(buf, off, code_ptr, code_len, quote);
+        off = append_sp_elem(buf, off, res_ptr, res_len, quote);
+    }
+    off = append_sp_elem(buf, off, @intFromPtr(op_word.ptr), @intCast(op_word.len), quote);
+    const script = obj.obj_new_string_take(buf, off, size);
+    if (script == 0) {
+        obj.free_sized(buf, size);
+        return;
+    }
+    // Commands run inside the callback must not recursively fire traces.
+    suppress += 1;
+    _ = interp.tcl_eval(script);
+    if (suppress > 0) suppress -= 1;
+    tcl_obj_release(script);
+}
+
+fn append_sp_elem(buf: u32, off_in: u32, ptr: u32, len: u32, quote: anytype) u32 {
+    var off = off_in;
+    @as([*]u8, @ptrFromInt(buf))[off] = ' ';
+    off += 1;
+    return quote.list_elem_quote(buf, off, ptr, len);
+}
+
+/// Tcl list of ``{ops callback}`` pairs for ``trace info execution``.
+pub fn info(bucket: u32) i32 {
+    const list_mod = @import("../valtypes/tcl_list.zig");
+    var result = obj_new_string(0, 0);
+    if (bucket == 0) return result;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (entries[i].bucket != bucket) continue;
+        const ops_str = ops_to_string(entries[i].ops);
+        var pair = list_mod.tcl_list(0, ops_str);
+        const pair2 = list_mod.tcl_list(pair, entries[i].callback);
+        tcl_obj_release(pair);
+        pair = pair2;
+        tcl_obj_release(ops_str);
+        const nr = list_mod.tcl_list(result, pair);
+        tcl_obj_release(result);
+        tcl_obj_release(pair);
+        result = nr;
+    }
+    return result;
+}
+
+fn ops_to_string(ops: u32) i32 {
+    var buf: [48]u8 = undefined;
+    var off: u32 = 0;
+    const pieces = [_]struct { op: u32, s: []const u8 }{
+        .{ .op = OP_ENTER, .s = "enter" },
+        .{ .op = OP_LEAVE, .s = "leave" },
+        .{ .op = OP_ENTERSTEP, .s = "enterstep" },
+        .{ .op = OP_LEAVESTEP, .s = "leavestep" },
+    };
+    for (pieces) |p| {
+        if ((ops & p.op) == 0) continue;
+        if (off > 0) {
+            buf[off] = ' ';
+            off += 1;
+        }
+        for (p.s) |c| {
+            buf[off] = c;
+            off += 1;
+        }
+    }
+    return obj.obj_new_string_copy(@intFromPtr(&buf), off);
+}

--- a/runtime/zig/interp/tcl_exec_trace.zig
+++ b/runtime/zig/interp/tcl_exec_trace.zig
@@ -256,8 +256,6 @@ fn fire_one(
 /// result is discarded (the rename/delete proceeds regardless).
 pub fn fire_command(bucket: u32, op: u32, old_name: i32, new_name: i32) void {
     if (count == 0) return;
-    const interp = @import("tcl_interp.zig");
-    const quote = @import("../valtypes/tcl_list_quote.zig");
     const op_word: []const u8 = switch (op) {
         OP_CMD_DELETE => "delete",
         OP_CMD_RENAME => "rename",
@@ -276,46 +274,88 @@ pub fn fire_command(bucket: u32, op: u32, old_name: i32, new_name: i32) void {
         i -= 1;
         if (entries[i].bucket != bucket) continue;
         if ((entries[i].ops & op) == 0) continue;
-        const cb = obj_ensure_string(entries[i].callback);
-        const size: u32 = cb.len + (1 + 2 * old_s.len + 2) + (1 + 2 * new_len + 2) + (1 + @as(u32, @intCast(op_word.len)) + 2);
-        const buf = alloc(size);
-        if (buf == 0) continue;
-        var off: u32 = 0;
-        if (cb.len > 0) {
-            const cbp: [*]const u8 = @ptrFromInt(cb.ptr);
-            var k: u32 = 0;
-            while (k < cb.len) : (k += 1) {
-                @as([*]u8, @ptrFromInt(buf))[off] = cbp[k];
-                off += 1;
-            }
+        run_command_callback(entries[i].callback, old_s.ptr, old_s.len, new_ptr, new_len, op_word);
+    }
+}
+
+/// Build ``CALLBACK old new op`` and evaluate it, discarding the
+/// result (including any error) inside a catch boundary.  Shared by
+/// :func:`fire_command` and :func:`fire_command_delete_oneshot`.
+fn run_command_callback(callback: i32, old_ptr: u32, old_len: u32, new_ptr: u32, new_len: u32, op_word: []const u8) void {
+    const interp = @import("tcl_interp.zig");
+    const quote = @import("../valtypes/tcl_list_quote.zig");
+    const cb = obj_ensure_string(callback);
+    const size: u32 = cb.len + (1 + 2 * old_len + 2) + (1 + 2 * new_len + 2) + (1 + @as(u32, @intCast(op_word.len)) + 2);
+    const buf = alloc(size);
+    if (buf == 0) return;
+    var off: u32 = 0;
+    if (cb.len > 0) {
+        const cbp: [*]const u8 = @ptrFromInt(cb.ptr);
+        var k: u32 = 0;
+        while (k < cb.len) : (k += 1) {
+            @as([*]u8, @ptrFromInt(buf))[off] = cbp[k];
+            off += 1;
         }
-        off = append_sp_elem(buf, off, old_s.ptr, old_s.len, quote);
-        off = append_sp_elem(buf, off, new_ptr, new_len, quote);
-        off = append_sp_elem(buf, off, @intFromPtr(op_word.ptr), @intCast(op_word.len), quote);
-        const script = obj.obj_new_string_take(buf, off, size);
-        if (script == 0) {
-            obj.free_sized(buf, size);
+    }
+    off = append_sp_elem(buf, off, old_ptr, old_len, quote);
+    off = append_sp_elem(buf, off, new_ptr, new_len, quote);
+    off = append_sp_elem(buf, off, @intFromPtr(op_word.ptr), @intCast(op_word.len), quote);
+    const script = obj.obj_new_string_take(buf, off, size);
+    if (script == 0) {
+        obj.free_sized(buf, size);
+        return;
+    }
+    // A command-trace callback's result — including an error — is
+    // discarded (Tcl Bug 1355342 / trace-20.14 / 20.16).  Run it inside
+    // a catch boundary so an ``error`` raised in the callback is
+    // absorbed (sets the flag rather than aborting the bundle at top
+    // level) and doesn't propagate out of the rename/delete that
+    // triggered the trace.  The outer pending-error state is saved and
+    // restored around the boundary so a trace firing mid-error leaves
+    // that error intact.
+    const catch_mod = @import("tcl_catch.zig");
+    const saved_err = catch_mod.state.error_flag;
+    const saved_msg = catch_mod.state.error_msg;
+    suppress += 1;
+    catch_mod.catch_enter();
+    _ = interp.tcl_eval(script);
+    _ = catch_mod.catch_leave();
+    if (suppress > 0) suppress -= 1;
+    catch_mod.state.error_flag = saved_err;
+    catch_mod.state.error_msg = saved_msg;
+    tcl_obj_release(script);
+}
+
+/// Fire a command's ``delete`` trace as a *one-shot*: each matching
+/// entry is removed from the registry **before** its callback runs, so
+/// a callback that re-deletes the same command (e.g. a delete trace
+/// whose body does ``namespace delete`` of the command's own namespace)
+/// cannot re-fire and recurse forever (namespace teardown / trace-34.4).
+pub fn fire_command_delete_oneshot(bucket: u32, old_name: i32) void {
+    if (count == 0 or bucket == 0) return;
+    const old_s = obj_ensure_string(old_name);
+    var i: u32 = 0;
+    while (i < count) {
+        if (entries[i].bucket != bucket or (entries[i].ops & OP_CMD_DELETE) == 0) {
+            i += 1;
             continue;
         }
-        // A command-trace callback's result — including an error — is
-        // discarded (Tcl Bug 1355342 / trace-20.14 / 20.16).  Run it
-        // inside a catch boundary so an ``error`` raised in the callback
-        // is absorbed (sets the flag rather than aborting the bundle at
-        // top level) and doesn't propagate out of the rename/delete that
-        // triggered the trace.  The outer pending-error state is saved
-        // and restored around the boundary so a trace firing mid-error
-        // leaves that error intact.
-        const catch_mod = @import("tcl_catch.zig");
-        const saved_err = catch_mod.state.error_flag;
-        const saved_msg = catch_mod.state.error_msg;
-        suppress += 1;
-        catch_mod.catch_enter();
-        _ = interp.tcl_eval(script);
-        _ = catch_mod.catch_leave();
-        if (suppress > 0) suppress -= 1;
-        catch_mod.state.error_flag = saved_err;
-        catch_mod.state.error_msg = saved_msg;
-        tcl_obj_release(script);
+        // Detach this entry's DELETE op before firing.  Retain the
+        // callback across the removal so the eval still has it.
+        const cb = entries[i].callback;
+        tcl_obj_retain(cb);
+        entries[i].ops &= ~OP_CMD_DELETE;
+        const drop = entries[i].ops == 0;
+        if (drop) {
+            tcl_obj_release(entries[i].callback);
+            count -= 1;
+            if (i != count) entries[i] = entries[count];
+            any_traces = count;
+        }
+        run_command_callback(cb, old_s.ptr, old_s.len, 0, 0, "delete");
+        tcl_obj_release(cb);
+        // Re-scan from the same index: a drop swapped a new entry in,
+        // and the callback may have mutated the table.
     }
 }
 

--- a/runtime/zig/interp/tcl_exec_trace.zig
+++ b/runtime/zig/interp/tcl_exec_trace.zig
@@ -172,11 +172,25 @@ pub fn fire(bucket: u32, op: u32, cmd_str: i32, code: i32, result: i32) void {
         else => return,
     };
     const with_result = (op == OP_LEAVE or op == OP_LEAVESTEP);
-    var i: u32 = 0;
-    while (i < count) : (i += 1) {
-        if (entries[i].bucket != bucket) continue;
-        if ((entries[i].ops & op) == 0) continue;
-        fire_one(entries[i].callback, cmd_str, op_word, with_result, code, result, interp);
+    // Reference Tcl fires *enter* / *enterstep* traces in reverse
+    // registration order (most-recently-added first) and *leave* /
+    // *leavestep* in forward order, so the two nest symmetrically
+    // (trace-25.4 / 25.5 enter, trace-25.6 / 25.7 leave).
+    if (with_result) {
+        var i: u32 = 0;
+        while (i < count) : (i += 1) {
+            if (entries[i].bucket != bucket) continue;
+            if ((entries[i].ops & op) == 0) continue;
+            fire_one(entries[i].callback, cmd_str, op_word, with_result, code, result, interp);
+        }
+    } else {
+        var i: u32 = count;
+        while (i > 0) {
+            i -= 1;
+            if (entries[i].bucket != bucket) continue;
+            if ((entries[i].ops & op) == 0) continue;
+            fire_one(entries[i].callback, cmd_str, op_word, with_result, code, result, interp);
+        }
     }
 }
 
@@ -257,8 +271,9 @@ pub fn fire_command(bucket: u32, op: u32, old_name: i32, new_name: i32) void {
         new_ptr = ns.ptr;
         new_len = ns.len;
     }
-    var i: u32 = 0;
-    while (i < count) : (i += 1) {
+    var i: u32 = count;
+    while (i > 0) {
+        i -= 1;
         if (entries[i].bucket != bucket) continue;
         if ((entries[i].ops & op) == 0) continue;
         const cb = obj_ensure_string(entries[i].callback);

--- a/runtime/zig/interp/tcl_exec_trace.zig
+++ b/runtime/zig/interp/tcl_exec_trace.zig
@@ -26,6 +26,10 @@ pub const OP_ENTER: u32 = 1;
 pub const OP_LEAVE: u32 = 2;
 pub const OP_ENTERSTEP: u32 = 4;
 pub const OP_LEAVESTEP: u32 = 8;
+// Command traces (``trace add command``) share the bucket-keyed
+// registry but use a disjoint op space.
+pub const OP_CMD_DELETE: u32 = 16;
+pub const OP_CMD_RENAME: u32 = 32;
 
 const Entry = struct {
     bucket: u32,
@@ -233,6 +237,58 @@ fn fire_one(
     tcl_obj_release(script);
 }
 
+/// Fire command-trace callbacks (``rename`` / ``delete``) on
+/// ``bucket`` as ``CALLBACK oldName newName op``.  The callback's
+/// result is discarded (the rename/delete proceeds regardless).
+pub fn fire_command(bucket: u32, op: u32, old_name: i32, new_name: i32) void {
+    if (count == 0) return;
+    const interp = @import("tcl_interp.zig");
+    const quote = @import("../valtypes/tcl_list_quote.zig");
+    const op_word: []const u8 = switch (op) {
+        OP_CMD_DELETE => "delete",
+        OP_CMD_RENAME => "rename",
+        else => return,
+    };
+    const old_s = obj_ensure_string(old_name);
+    var new_ptr: u32 = 0;
+    var new_len: u32 = 0;
+    if (new_name != 0) {
+        const ns = obj_ensure_string(new_name);
+        new_ptr = ns.ptr;
+        new_len = ns.len;
+    }
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (entries[i].bucket != bucket) continue;
+        if ((entries[i].ops & op) == 0) continue;
+        const cb = obj_ensure_string(entries[i].callback);
+        const size: u32 = cb.len + (1 + 2 * old_s.len + 2) + (1 + 2 * new_len + 2) + (1 + @as(u32, @intCast(op_word.len)) + 2);
+        const buf = alloc(size);
+        if (buf == 0) continue;
+        var off: u32 = 0;
+        if (cb.len > 0) {
+            const cbp: [*]const u8 = @ptrFromInt(cb.ptr);
+            var k: u32 = 0;
+            while (k < cb.len) : (k += 1) {
+                @as([*]u8, @ptrFromInt(buf))[off] = cbp[k];
+                off += 1;
+            }
+        }
+        off = append_sp_elem(buf, off, old_s.ptr, old_s.len, quote);
+        off = append_sp_elem(buf, off, new_ptr, new_len, quote);
+        off = append_sp_elem(buf, off, @intFromPtr(op_word.ptr), @intCast(op_word.len), quote);
+        const script = obj.obj_new_string_take(buf, off, size);
+        if (script == 0) {
+            obj.free_sized(buf, size);
+            continue;
+        }
+        suppress += 1;
+        _ = interp.tcl_eval(script);
+        if (suppress > 0) suppress -= 1;
+        tcl_obj_release(script);
+    }
+}
+
 fn append_sp_elem(buf: u32, off_in: u32, ptr: u32, len: u32, quote: anytype) u32 {
     var off = off_in;
     @as([*]u8, @ptrFromInt(buf))[off] = ' ';
@@ -240,15 +296,19 @@ fn append_sp_elem(buf: u32, off_in: u32, ptr: u32, len: u32, quote: anytype) u32
     return quote.list_elem_quote(buf, off, ptr, len);
 }
 
-/// Tcl list of ``{ops callback}`` pairs for ``trace info execution``.
-pub fn info(bucket: u32) i32 {
+/// Tcl list of ``{ops callback}`` pairs for ``trace info
+/// execution|command``.  ``op_mask`` restricts the result to entries
+/// (and rendered ops) in the requested op space.
+pub fn info(bucket: u32, op_mask: u32) i32 {
     const list_mod = @import("../valtypes/tcl_list.zig");
     var result = obj_new_string(0, 0);
     if (bucket == 0) return result;
     var i: u32 = 0;
     while (i < count) : (i += 1) {
         if (entries[i].bucket != bucket) continue;
-        const ops_str = ops_to_string(entries[i].ops);
+        const shown = entries[i].ops & op_mask;
+        if (shown == 0) continue;
+        const ops_str = ops_to_string(shown);
         var pair = list_mod.tcl_list(0, ops_str);
         const pair2 = list_mod.tcl_list(pair, entries[i].callback);
         tcl_obj_release(pair);
@@ -270,6 +330,8 @@ fn ops_to_string(ops: u32) i32 {
         .{ .op = OP_LEAVE, .s = "leave" },
         .{ .op = OP_ENTERSTEP, .s = "enterstep" },
         .{ .op = OP_LEAVESTEP, .s = "leavestep" },
+        .{ .op = OP_CMD_DELETE, .s = "delete" },
+        .{ .op = OP_CMD_RENAME, .s = "rename" },
     };
     for (pieces) |p| {
         if ((ops & p.op) == 0) continue;

--- a/runtime/zig/interp/tcl_exec_trace.zig
+++ b/runtime/zig/interp/tcl_exec_trace.zig
@@ -297,9 +297,24 @@ pub fn fire_command(bucket: u32, op: u32, old_name: i32, new_name: i32) void {
             obj.free_sized(buf, size);
             continue;
         }
+        // A command-trace callback's result — including an error — is
+        // discarded (Tcl Bug 1355342 / trace-20.14 / 20.16).  Run it
+        // inside a catch boundary so an ``error`` raised in the callback
+        // is absorbed (sets the flag rather than aborting the bundle at
+        // top level) and doesn't propagate out of the rename/delete that
+        // triggered the trace.  The outer pending-error state is saved
+        // and restored around the boundary so a trace firing mid-error
+        // leaves that error intact.
+        const catch_mod = @import("tcl_catch.zig");
+        const saved_err = catch_mod.state.error_flag;
+        const saved_msg = catch_mod.state.error_msg;
         suppress += 1;
+        catch_mod.catch_enter();
         _ = interp.tcl_eval(script);
+        _ = catch_mod.catch_leave();
         if (suppress > 0) suppress -= 1;
+        catch_mod.state.error_flag = saved_err;
+        catch_mod.state.error_msg = saved_msg;
         tcl_obj_release(script);
     }
 }

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -2497,6 +2497,23 @@ pub export fn local_get(name: i32) i32 {
     return 0;
 }
 
+/// True when *name* resolves through a same-name ``global`` alias
+/// (``ALIAS_GLOBAL``) in the current frame.  The variable-trace
+/// installer uses this to route a trace added inside a proc on a
+/// ``global``-declared name to the global directory rather than the
+/// per-frame chain — a frame-local record would be dropped when the
+/// proc returns, losing the trace (trace-17.2 / 17.3).
+pub fn current_frame_is_global_alias(name: i32) bool {
+    const sn = obj_ensure_string(name);
+    if (current_frame()) |base| {
+        const hash = fnv1a(sn.ptr, sn.len);
+        if (frame_find(base, sn.ptr, sn.len, hash)) |bucket| {
+            return read_i32(bucket + OFF_VALUE) == ALIAS_GLOBAL;
+        }
+    }
+    return false;
+}
+
 /// Frame-readback read — counterpart of :func:`local_set_silent`.
 /// Reads the local slot without firing READ traces; used by the
 /// codegen ``_emit_frame_readback`` path that pulls interpreter-side

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -368,6 +368,20 @@ fn find_top_string_op(ptr: u32, len: u32) ?StringOp {
         const ch2 = src[i + 2];
         const ch3 = src[i + 3];
         if (ch3 != ' ' and ch3 != '\t') continue;
+        // A string operator (``eq`` / ``ne`` / ``in`` / ``ni``) is only
+        // the top-level operator when no lower-precedence boolean /
+        // ternary operator follows it.  Without this, ``$ec ne "*" && 1
+        // ni $rc`` would be mis-read as ``$ec ne ("*" && 1 ni $rc)`` and
+        // ``eval_string_expr`` would string-compare the whole RHS — the
+        // ``==`` / ``!=`` branch above already guards this way.  When the
+        // RHS carries a ``&&`` / ``||`` / ``?:`` (or arithmetic), defer:
+        // ``continue`` so the scan reaches that operator and returns null,
+        // letting ``expr_or`` split there and recurse per operand.
+        if ((ch1 == 'e' and ch2 == 'q') or (ch1 == 'n' and ch2 == 'e') or
+            (ch1 == 'i' and ch2 == 'n') or (ch1 == 'n' and ch2 == 'i'))
+        {
+            if (!eq_op_is_top_level(src, len, i + 4)) continue;
+        }
         if (ch1 == 'e' and ch2 == 'q') {
             return .{ .kind = .eq, .start = i + 1, .op_len = 2 };
         }

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -4902,8 +4902,17 @@ fn eval_interp_eval(words: []const i32) i32 {
     const target_interp = interp_impl.resolve_interp_path(words[2]);
     if (target_interp == 0) return 0;
 
-    // Concatenate words[3..] with single-space separator.
+    // On the child's first eval, prepend its deferred Tcl_Init bootstrap
+    // (init.tcl source) so it runs at the same eval depth as the user
+    // script — the only depth at which init.tcl's proc definitions
+    // register and persist.  ``null`` for already-initialised interps
+    // and for children that never opted in (parent without init.tcl).
+    const init_prefix: ?[]const u8 = interp_reg.take_deferred_init(target_interp);
+
+    // Concatenate words[3..] with single-space separator, after the
+    // optional init prefix.
     var total: u32 = 0;
+    if (init_prefix) |pfx| total += @as(u32, @intCast(pfx.len));
     var k: u32 = 3;
     while (k < words.len) : (k += 1) {
         total += @as(u32, @intCast(obj_ensure_string(words[k]).len));
@@ -4919,6 +4928,12 @@ fn eval_interp_eval(words: []const i32) i32 {
     // eval child …`` call doesn't leak ``total`` bytes of slab.
     defer if (total > 0) obj_mod.free_sized(script_ptr, total);
     var off: u32 = 0;
+    if (init_prefix) |pfx| {
+        if (pfx.len > 0) {
+            memcpy(script_ptr + off, @intFromPtr(pfx.ptr), @intCast(pfx.len));
+            off += @intCast(pfx.len);
+        }
+    }
     k = 3;
     while (k < words.len) : (k += 1) {
         const s = obj_ensure_string(words[k]);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -4083,6 +4083,81 @@ fn build_invocation_list(words: []const i32) i32 {
     return obj_new_string_take(buf, off, total);
 }
 
+/// Raise ``wrong # args: should be "<name> <params>"`` for an
+/// interpreted proc called with fewer args than its required (no-
+/// default) parameters.  Mirrors C Tcl's ``ProcWrongNumArgs``: a
+/// defaulted parameter renders as ``?name?``, a trailing ``args``
+/// parameter as ``?arg ...?``, and a required parameter as its bare
+/// name.  ``invoked_name`` is the word the caller used (``words[0]``)
+/// so the message echoes the spelling at the call site.
+fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params: u32) void {
+    const catch_mod = @import("tcl_catch.zig");
+    const inv = obj_ensure_string(invoked_name);
+    const ps = obj_ensure_string(params_obj);
+    const prefix = "wrong # args: should be \"";
+    var pcap: u32 = 0;
+    var i: u32 = 0;
+    while (i < n_params) : (i += 1) {
+        const pe = list_element_at(ps.ptr, ps.len, @intCast(i));
+        pcap += pe.len + 12;
+    }
+    const total: u32 = @as(u32, @intCast(prefix.len)) + inv.len + pcap + 1;
+    const buf = alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(0);
+        return;
+    }
+    var off: u32 = 0;
+    for (prefix) |c| {
+        @as([*]u8, @ptrFromInt(buf + off))[0] = c;
+        off += 1;
+    }
+    if (inv.len > 0) {
+        memcpy(buf + off, inv.ptr, inv.len);
+        off += inv.len;
+    }
+    i = 0;
+    while (i < n_params) : (i += 1) {
+        @as([*]u8, @ptrFromInt(buf + off))[0] = ' ';
+        off += 1;
+        const pe = list_element_at(ps.ptr, ps.len, @intCast(i));
+        const pptr = ps.ptr + pe.start;
+        const plen = pe.len;
+        const sub_n = list_count_elements(pptr, plen);
+        var nptr = pptr;
+        var nlen = plen;
+        if (sub_n == 2) {
+            const ne = list_element_at(pptr, plen, 0);
+            nptr = pptr + ne.start;
+            nlen = ne.len;
+        }
+        const np: [*]const u8 = @ptrFromInt(nptr);
+        const is_args = (i == n_params - 1) and nlen == 4 and
+            np[0] == 'a' and np[1] == 'r' and np[2] == 'g' and np[3] == 's';
+        if (sub_n == 2) {
+            @as([*]u8, @ptrFromInt(buf + off))[0] = '?';
+            off += 1;
+            memcpy(buf + off, nptr, nlen);
+            off += nlen;
+            @as([*]u8, @ptrFromInt(buf + off))[0] = '?';
+            off += 1;
+        } else if (is_args) {
+            const lit = "?arg ...?";
+            for (lit) |c| {
+                @as([*]u8, @ptrFromInt(buf + off))[0] = c;
+                off += 1;
+            }
+        } else {
+            memcpy(buf + off, nptr, nlen);
+            off += nlen;
+        }
+    }
+    @as([*]u8, @ptrFromInt(buf + off))[0] = '"';
+    off += 1;
+    const msg = obj_mod.obj_new_string_take(buf, off, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
 /// Internal: dispatch once the proc bucket is already resolved.
 /// Shared between ``eval_proc_call`` (legacy path) and the proc-first
 /// fast path in ``eval_command``.
@@ -4465,14 +4540,15 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
                     // omitted this positional arg.
                     _ = frames.local_set(param_name, param_default);
                 } else {
-                    // No default and no caller-supplied value —
-                    // reference Tcl raises ``wrong # args`` here, but
-                    // legacy tests (and our own existing baselines)
-                    // rely on the lenient empty-default behaviour, so
-                    // keep that for the no-default case.
-                    const empty = obj_new_string(0, 0);
-                    _ = frames.local_set(param_name, empty);
-                    obj_mod.tcl_obj_release(empty);
+                    // No default and no caller-supplied value: reference
+                    // Tcl raises ``wrong # args: should be "name a ?b?"``
+                    // (``TclObjInterpProc`` → ``ProcWrongNumArgs``).
+                    // init-2.x and many tcltest cases assert this exact
+                    // message; bind-empty would silently run the body
+                    // with an empty required argument instead.
+                    raise_proc_wrong_args(words[0], params_obj, n_params);
+                    frames.frame_pop();
+                    return 0;
                 }
             }
         }
@@ -5008,11 +5084,6 @@ fn eval_interp_eval(words: []const i32) i32 {
     // paths use.  Procs cached by ``proc_lookup`` are keyed on
     // (ns, ...) so the LRU doesn't cross-pollute between interps.
     const swapped = target_interp != interp_reg.interp_current();
-    const save = if (swapped) interp_reg.enter(target_interp) else interp_reg.EnterSave{
-        .prev_interp = interp_reg.current_interp,
-        .prev_root_addr = tcl_ns.root_addr,
-        .prev_current_ns = tcl_ns.current_ns,
-    };
     // A child interp has its own call stack: ``interp eval child {…}``
     // runs at the child's *global* frame regardless of the caller's
     // depth.  Park the caller's frames (frame_depth → 0) so unqualified
@@ -5020,10 +5091,25 @@ fn eval_interp_eval(words: []const i32) i32 {
     // globals, not as locals of whatever parent proc invoked the eval.
     // Mirrors C Tcl's per-interp call stack (``ChildEval`` runs the
     // script in the child, not a continuation of the parent's frame).
+    //
+    // Order matters: stash *before* :func:`enter`.  ``frame_depth_stash``
+    // re-points ``current_ns`` at the parked top frame's caller-ns (its
+    // uplevel contract); doing it after ``enter`` would clobber the
+    // child-root context ``enter`` installs, leaving the child script
+    // running in the *parent's* namespace (observed as tcltest's
+    // ``ConstraintInitializer`` failing when the child is loaded from a
+    // ``::tcltest``-namespace proc).  ``enter`` after the stash restores
+    // ``current_ns = 0`` / ``root_addr = child``; ``leave`` then
+    // ``frame_depth_restore`` unwind in the reverse order.
     const frame_saved: i32 = if (swapped) frames.frame_depth_stash(@intCast(frames.frame_depth)) else 0;
+    const save = if (swapped) interp_reg.enter(target_interp) else interp_reg.EnterSave{
+        .prev_interp = interp_reg.current_interp,
+        .prev_root_addr = tcl_ns.root_addr,
+        .prev_current_ns = tcl_ns.current_ns,
+    };
     const result = if (off > 0) eval_script(script_ptr, off) else 0;
-    if (swapped) frames.frame_depth_restore(frame_saved);
     interp_reg.leave(save);
+    if (swapped) frames.frame_depth_restore(frame_saved);
 
     // ``ChildEval`` (tclInterp.c) wraps the child eval in
     // ``Tcl_EvalObjEx`` which calls ``TclUpdateReturnInfo`` when the

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1463,7 +1463,14 @@ pub fn eval_command(words: []const i32) i32 {
 fn eval_command_traced(words: []const i32) i32 {
     const et = @import("tcl_exec_trace.zig");
     const bucket: u32 = @bitCast(procs.proc_lookup(words[0]));
-    const ops = if (bucket != 0) et.ops_for(bucket) else 0;
+    // Only the *execution*-trace ops (enter/leave/enterstep/leavestep)
+    // fire through this dispatch path; command-trace ops (delete/rename)
+    // fire from the rename / redefine / namespace-teardown sites via
+    // ``fire_command``.  Mask them out so a command carrying *only* a
+    // delete/rename trace doesn't drag every invocation through the full
+    // wrapper (build_invocation_string + step bookkeeping) for nothing.
+    const EXEC_OP_MASK = et.OP_ENTER | et.OP_LEAVE | et.OP_ENTERSTEP | et.OP_LEAVESTEP;
+    const ops = (if (bucket != 0) et.ops_for(bucket) else 0) & EXEC_OP_MASK;
     const step_active = et.step_depth != 0;
     if (ops == 0 and !step_active) return eval_command_dispatch(words);
 

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -5159,6 +5159,23 @@ fn eval_interp_eval(words: []const i32) i32 {
         .prev_current_ns = tcl_ns.current_ns,
     };
     const result = if (off > 0) eval_script(script_ptr, off) else 0;
+    // A child error's message (``error "msg"``) is stored in
+    // ``state.error_msg`` as a *borrowed* handle into the eval script
+    // buffer (``script_ptr``), which the ``defer free_sized`` below
+    // reclaims as soon as we return.  The parent's surrounding ``catch``
+    // reads ``error_msg`` only after that free, seeing zeroed bytes.
+    // Promote it to an owned copy now, while the buffer is still live,
+    // so the message survives the interp-eval boundary intact.
+    {
+        const tcl_catch = @import("tcl_catch.zig");
+        if (tcl_catch.state.error_flag != 0 and tcl_catch.state.error_msg != 0) {
+            const em = obj_ensure_string(tcl_catch.state.error_msg);
+            if (em.len > 0) {
+                const owned = obj_mod.obj_new_string_copy(em.ptr, em.len);
+                if (owned != 0) tcl_catch.state.error_msg = owned;
+            }
+        }
+    }
     interp_reg.leave(save);
     if (swapped) frames.frame_depth_restore(frame_saved);
 

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -3898,6 +3898,46 @@ fn eval_proc_call(words: []const i32) i32 {
         if (cmd_s.len > 0 and stub_dispatch.try_stub(@as([*]const u8, @ptrFromInt(cmd_s.ptr)), cmd_s.len)) {
             return 0;
         }
+        // Per-namespace ``namespace unknown`` handler (namespace-52.x):
+        // the current namespace's explicit handler — or the root
+        // namespace's, if the current one has none — intercepts the
+        // unknown command, invoked as ``{*}$handler word0 word1 …``.
+        // When neither has an explicit handler the dispatch falls
+        // through to the global ``unknown`` proc below (the default
+        // ``::unknown`` auto-loader).
+        {
+            const ns_mod = @import("tcl_ns.zig");
+            var ns_handler = ns_mod.ns_unknown_get(ns_mod.current_ns);
+            if (ns_handler == 0 and ns_mod.current_ns != ns_mod.root_addr) {
+                ns_handler = ns_mod.ns_unknown_get(ns_mod.root_addr);
+            }
+            if (ns_handler != 0) {
+                const hs = obj_ensure_string(ns_handler);
+                const n_h: u32 = @intCast(obj_mod.list_count_elements(hs.ptr, hs.len));
+                if (n_h > 0 and n_h + words.len <= parse.MAX_WORDS) {
+                    var hw: [parse.MAX_WORDS]i32 = undefined;
+                    var hi: u32 = 0;
+                    var ei: i64 = 0;
+                    while (ei < n_h) : (ei += 1) {
+                        const e = obj_mod.list_element_at(hs.ptr, hs.len, ei);
+                        hw[hi] = obj_mod.obj_new_string(@bitCast(hs.ptr + e.start), @bitCast(e.len));
+                        hi += 1;
+                    }
+                    var wk: u32 = 0;
+                    while (wk < words.len) : (wk += 1) {
+                        obj_mod.tcl_obj_retain(words[wk]);
+                        hw[hi] = words[wk];
+                        hi += 1;
+                    }
+                    const r = eval_command(hw[0..hi]);
+                    var rk: u32 = 0;
+                    while (rk < hi) : (rk += 1) {
+                        if (hw[rk] != 0) obj_mod.tcl_obj_release(hw[rk]);
+                    }
+                    return r;
+                }
+            }
+        }
         // Before declaring the command unknown, look for a
         // user-defined ``unknown`` proc that should intercept the
         // call (Tcl's classic auto-dispatch hook).  Reference Tcl's

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -153,7 +153,7 @@ pub fn eval_expr_str(ptr: u32, len: u32) i64 {
 /// position lets the caller split the expression text into LHS / RHS
 /// substrings.
 const StringOp = struct {
-    kind: enum { eq, ne, in_, ni, eq_eq, ne_eq },
+    kind: enum { eq, ne, in_, ni, eq_eq, ne_eq, lt, gt, le, ge },
     /// First byte of the operator keyword in the expression text.
     start: u32,
     /// Byte length of the keyword (2 for all four operators).
@@ -357,6 +357,24 @@ fn find_top_string_op(ptr: u32, len: u32) ?StringOp {
                 .op_len = 2,
             };
         }
+        // ``< > <= >=`` relational operators: Tcl 9 compares numerically
+        // when both operands parse as numbers, else lexicographically.
+        // The legacy i64 ``expr_add`` path raises on non-numeric operands
+        // (``$c < "\x7F"`` in tcltest's ``Asciify``), so dispatch through
+        // ``eval_string_expr`` here.  Exclude the ``<<`` / ``>>`` shift
+        // operators (those stay numeric in ``expr_add``).  Same
+        // lower-precedence guard as the equality branch.
+        if ((c == '<' or c == '>') and !(i + 1 < len and src[i + 1] == c)) {
+            const two = i + 1 < len and src[i + 1] == '=';
+            const op_len: u32 = if (two) 2 else 1;
+            if (!eq_op_is_top_level(src, len, i + op_len)) {
+                continue;
+            }
+            if (c == '<') {
+                return .{ .kind = if (two) .le else .lt, .start = i, .op_len = op_len };
+            }
+            return .{ .kind = if (two) .ge else .gt, .start = i, .op_len = op_len };
+        }
         if (c == '+' or c == '-' or c == '*' or c == '/' or c == '%') return null;
         // String operator must be surrounded by whitespace on both
         // sides — otherwise a variable name like ``$equal`` would
@@ -474,6 +492,25 @@ fn eval_string_expr(ptr: u32, len: u32, op: StringOp) i64 {
             const eq_flag = obj_mod.obj_get_int(eq_obj);
             obj_mod.tcl_obj_release(eq_obj);
             result = if (op.kind == .eq_eq) eq_flag else (1 - eq_flag);
+        },
+        .lt, .gt, .le, .ge => {
+            // Tcl 9 ``< > <= >=``: numeric compare when both operands
+            // parse as numbers, else lexicographic string compare.
+            // ``tcl_expr_order_cmp`` returns -1 / 0 / 1 with exactly
+            // those semantics — the legacy ``expr_add`` i64 path instead
+            // raised ``cannot use non-numeric string as operand`` (e.g.
+            // tcltest's ``Asciify`` does ``$c < "\x7F"`` on a character).
+            const tcl_string = @import("../valtypes/tcl_string.zig");
+            const cmp_obj = tcl_string.tcl_expr_order_cmp(lhs_obj, rhs_obj);
+            const c = obj_mod.obj_get_int(cmp_obj);
+            obj_mod.tcl_obj_release(cmp_obj);
+            result = switch (op.kind) {
+                .lt => if (c < 0) @as(i64, 1) else 0,
+                .gt => if (c > 0) @as(i64, 1) else 0,
+                .le => if (c <= 0) @as(i64, 1) else 0,
+                .ge => if (c >= 0) @as(i64, 1) else 0,
+                else => unreachable,
+            };
         },
     }
     obj_mod.tcl_obj_release(lhs_obj);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -170,6 +170,37 @@ const StringOp = struct {
 /// regular ``expr_or`` pipeline (which itself recurses back into
 /// ``eval_expr_str`` for each side, picking up the string-op fix
 /// where it actually applies).
+/// Advance past a ``$variable`` reference starting at ``src[start] == '$'``,
+/// returning the index of its last byte (so a scanner's ``i += 1`` steps
+/// onto the next unconsumed byte).  Operator scanners must skip these so
+/// the ``::`` in ``$ns::v`` isn't read as a ternary ``:`` and the ``eq``
+/// in ``$equal`` isn't read as the string operator.  Handles ``$name``,
+/// ``$::ns::name``, ``${braced}``, and a trailing ``(index)`` array key.
+fn skip_dollar_ref(src: [*]const u8, len: u32, start: u32) u32 {
+    var i: u32 = start + 1;
+    if (i < len and src[i] == '{') {
+        i += 1;
+        while (i < len and src[i] != '}') i += 1;
+        return if (i < len) i else len - 1;
+    }
+    while (i < len and ((src[i] >= 'a' and src[i] <= 'z') or
+        (src[i] >= 'A' and src[i] <= 'Z') or
+        (src[i] >= '0' and src[i] <= '9') or src[i] == '_' or
+        (src[i] == ':' and i + 1 < len and src[i + 1] == ':')))
+    {
+        if (src[i] == ':') i += 2 else i += 1;
+    }
+    if (i < len and src[i] == '(') {
+        var d: u32 = 1;
+        i += 1;
+        while (i < len and d > 0) : (i += 1) {
+            if (src[i] == '(') d += 1 else if (src[i] == ')') d -= 1;
+        }
+        if (i > 0) i -= 1;
+    }
+    return if (i > start) i - 1 else start;
+}
+
 /// Walk *src*[rest_start..len] looking for a lower-precedence boolean
 /// or ternary operator that would override the candidate ``==``/``!=``.
 /// Returns true when no such operator is present (so the equality
@@ -180,6 +211,10 @@ fn eq_op_is_top_level(src: [*]const u8, len: u32, rest_start: u32) bool {
     var i: u32 = rest_start;
     while (i < len) : (i += 1) {
         const c = src[i];
+        if (c == '$') {
+            i = skip_dollar_ref(src, len, i);
+            continue;
+        }
         if (c == '"') {
             i += 1;
             while (i < len and src[i] != '"') {
@@ -238,6 +273,13 @@ fn find_top_string_op(ptr: u32, len: u32) ?StringOp {
     var i: u32 = 0;
     while (i < len) : (i += 1) {
         const c = src[i];
+        // Skip ``$var`` references so the ``::`` in ``$ns::v`` isn't read
+        // as a ternary ``:`` (which would bail before the real operator)
+        // and ``$equal`` doesn't self-match its ``eq`` substring.
+        if (c == '$') {
+            i = skip_dollar_ref(src, len, i);
+            continue;
+        }
         // Skip nested constructs so an inner ``eq`` doesn't get picked.
         if (c == '"') {
             i += 1;
@@ -1166,9 +1208,15 @@ fn expr_atom(ptr: u32, len: u32, pos: *u32, skip: bool) i64 {
         const vs = pos.*;
         while (pos.* < len and ((src[pos.*] >= 'a' and src[pos.*] <= 'z') or
             (src[pos.*] >= 'A' and src[pos.*] <= 'Z') or
-            (src[pos.*] >= '0' and src[pos.*] <= '9') or src[pos.*] == '_'))
+            (src[pos.*] >= '0' and src[pos.*] <= '9') or src[pos.*] == '_' or
+            // ``::`` namespace separators are part of the variable name —
+            // ``$::v`` / ``$ns::v`` must read the qualified global, not
+            // stop at the first colon and resolve an empty name to 0.
+            (src[pos.*] == ':' and pos.* + 1 < len and src[pos.* + 1] == ':')))
         {
-            pos.* += 1;
+            // Consume both colons of a ``::`` separator in one step so a
+            // trailing single ``:`` (not a separator) still terminates.
+            if (src[pos.*] == ':') pos.* += 2 else pos.* += 1;
         }
         const name = obj_new_string(@bitCast(ptr + vs), @bitCast(pos.* - vs));
         // Issue #303 — release the per-atom name temp.
@@ -4902,17 +4950,15 @@ fn eval_interp_eval(words: []const i32) i32 {
     const target_interp = interp_impl.resolve_interp_path(words[2]);
     if (target_interp == 0) return 0;
 
-    // On the child's first eval, prepend its deferred Tcl_Init bootstrap
-    // (init.tcl source) so it runs at the same eval depth as the user
-    // script — the only depth at which init.tcl's proc definitions
-    // register and persist.  ``null`` for already-initialised interps
-    // and for children that never opted in (parent without init.tcl).
-    const init_prefix: ?[]const u8 = interp_reg.take_deferred_init(target_interp);
+    // On the child's first eval, run its deferred Tcl_Init (init.tcl
+    // source) as a complete, separate eval cycle before the user script,
+    // giving trusted children the auto-loading machinery the way C Tcl's
+    // ChildCreate does.  No-op for already-initialised interps and for
+    // children that never opted in (parent without init.tcl).
+    interp_reg.run_deferred_init(target_interp);
 
-    // Concatenate words[3..] with single-space separator, after the
-    // optional init prefix.
+    // Concatenate words[3..] with single-space separator.
     var total: u32 = 0;
-    if (init_prefix) |pfx| total += @as(u32, @intCast(pfx.len));
     var k: u32 = 3;
     while (k < words.len) : (k += 1) {
         total += @as(u32, @intCast(obj_ensure_string(words[k]).len));
@@ -4928,12 +4974,6 @@ fn eval_interp_eval(words: []const i32) i32 {
     // eval child …`` call doesn't leak ``total`` bytes of slab.
     defer if (total > 0) obj_mod.free_sized(script_ptr, total);
     var off: u32 = 0;
-    if (init_prefix) |pfx| {
-        if (pfx.len > 0) {
-            memcpy(script_ptr + off, @intFromPtr(pfx.ptr), @intCast(pfx.len));
-            off += @intCast(pfx.len);
-        }
-    }
     k = 3;
     while (k < words.len) : (k += 1) {
         const s = obj_ensure_string(words[k]);
@@ -4973,7 +5013,16 @@ fn eval_interp_eval(words: []const i32) i32 {
         .prev_root_addr = tcl_ns.root_addr,
         .prev_current_ns = tcl_ns.current_ns,
     };
+    // A child interp has its own call stack: ``interp eval child {…}``
+    // runs at the child's *global* frame regardless of the caller's
+    // depth.  Park the caller's frames (frame_depth → 0) so unqualified
+    // variables and arrays at the child script's top level resolve as
+    // globals, not as locals of whatever parent proc invoked the eval.
+    // Mirrors C Tcl's per-interp call stack (``ChildEval`` runs the
+    // script in the child, not a continuation of the parent's frame).
+    const frame_saved: i32 = if (swapped) frames.frame_depth_stash(@intCast(frames.frame_depth)) else 0;
     const result = if (off > 0) eval_script(script_ptr, off) else 0;
+    if (swapped) frames.frame_depth_restore(frame_saved);
     interp_reg.leave(save);
 
     // ``ChildEval`` (tclInterp.c) wraps the child eval in

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1447,6 +1447,75 @@ pub fn recursion_check_leave() void {
 
 pub fn eval_command(words: []const i32) i32 {
     if (words.len == 0) return 0;
+    const et = @import("tcl_exec_trace.zig");
+    // Fast path: no execution traces and no active step context (and
+    // not currently inside a trace callback) — skip all bookkeeping.
+    if (et.suppress != 0 or (et.any_traces == 0 and et.step_depth == 0)) {
+        return eval_command_dispatch(words);
+    }
+    return eval_command_traced(words);
+}
+
+/// Execution-trace wrapper around the real dispatch.  Fires the traced
+/// command's ``enter`` / ``leave`` callbacks and the enclosing step
+/// traces' ``enterstep`` / ``leavestep``.  Only reached when at least
+/// one execution trace exists or a step context is active.
+fn eval_command_traced(words: []const i32) i32 {
+    const et = @import("tcl_exec_trace.zig");
+    const bucket: u32 = @bitCast(procs.proc_lookup(words[0]));
+    const ops = if (bucket != 0) et.ops_for(bucket) else 0;
+    const step_active = et.step_depth != 0;
+    if (ops == 0 and !step_active) return eval_command_dispatch(words);
+
+    const cmd_str = build_invocation_string(words);
+    defer if (cmd_str != 0) obj_mod.tcl_obj_release(cmd_str);
+
+    // Enclosing step traces fire ``enterstep`` for this command.
+    if (step_active) et.fire_step(et.OP_ENTERSTEP, cmd_str, 0, 0);
+    // This command's own ``enter`` trace.
+    if ((ops & et.OP_ENTER) != 0) et.fire(bucket, et.OP_ENTER, cmd_str, 0, 0);
+
+    const has_step = (ops & (et.OP_ENTERSTEP | et.OP_LEAVESTEP)) != 0;
+    if (has_step) et.push_step(bucket);
+    const result = eval_command_dispatch(words);
+    if (has_step) et.pop_step();
+
+    // Capture the completion code for leave / leavestep.
+    if ((ops & et.OP_LEAVE) != 0 or step_active) {
+        const snap = result_mod.snapshot(result);
+        const code_obj = obj_mod.obj_new_int(@intFromEnum(snap.code));
+        if ((ops & et.OP_LEAVE) != 0) et.fire(bucket, et.OP_LEAVE, cmd_str, code_obj, result);
+        if (step_active) et.fire_step(et.OP_LEAVESTEP, cmd_str, code_obj, result);
+        obj_mod.tcl_obj_release(code_obj);
+    }
+    return result;
+}
+
+/// Build the command-invocation string (the objv joined as a Tcl list)
+/// passed to execution-trace callbacks.
+fn build_invocation_string(words: []const i32) i32 {
+    const quote = @import("../valtypes/tcl_list_quote.zig");
+    var size: u32 = 0;
+    for (words) |w| {
+        const s = obj_ensure_string(w);
+        size += 2 * s.len + 3; // worst-case quoting + separator
+    }
+    if (size == 0) return obj_mod.obj_new_string(0, 0);
+    const buf = obj_mod.alloc(size);
+    if (buf == 0) return obj_mod.obj_new_string(0, 0);
+    var off: u32 = 0;
+    for (words, 0..) |w, i| {
+        if (i > 0) {
+            @as([*]u8, @ptrFromInt(buf))[off] = ' ';
+            off += 1;
+        }
+        const s = obj_ensure_string(w);
+        off = quote.list_elem_quote(buf, off, s.ptr, s.len);
+    }
+    return obj_mod.obj_new_string_take(buf, off, size);
+}
+
+fn eval_command_dispatch(words: []const i32) i32 {
     cmd_count +%= 1;
     const cmd_s = obj_ensure_string(words[0]);
     if (cmd_s.len == 0) return 0;

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -4057,7 +4057,7 @@ fn try_auto_index_load(cmd_obj: i32) i32 {
                     off += 1;
                 }
                 const fq_key = obj_mod.obj_new_string_take(buf, total, total);
-                const entry = tcl_array.array_get(arr_name, fq_key);
+                const entry = tcl_array.array_get_raw(arr_name, fq_key);
                 if (entry != 0) {
                     const es = obj_ensure_string(entry);
                     if (es.len > 0) {
@@ -4071,7 +4071,7 @@ fn try_auto_index_load(cmd_obj: i32) i32 {
         }
     }
     // 2. Bare-name probe.
-    const entry2 = tcl_array.array_get(arr_name, cmd_obj);
+    const entry2 = tcl_array.array_get_raw(arr_name, cmd_obj);
     if (entry2 != 0) {
         const es = obj_ensure_string(entry2);
         if (es.len > 0) {

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -217,6 +217,14 @@ const ALIAS_REC_SIZE: u32 = 40;
 /// as part of the cascade.
 pub const INTERP_DELETED: u32 = 0x2;
 
+/// Trusted child awaiting its deferred ``Tcl_Init`` (init.tcl source).
+/// Set by ``eval_interp_create`` when the parent has loaded init.tcl;
+/// :func:`enter` runs the bootstrap once on the child's first entry and
+/// clears the bit.  Deferring out of the ``interp create`` dispatch is
+/// required: init.tcl's ``proc`` definitions don't register when
+/// sourced from inside the create command's nested eval.
+pub const INTERP_NEEDS_INIT: u32 = 0x4;
+
 /// Bucket size shared across ``children`` and ``hidden_cmd_table``.
 /// Keeps ``Table(16)`` monomorphised once; matches the
 /// ``NS_BUCKET_SIZE`` used throughout the namespace tree so the
@@ -307,6 +315,20 @@ pub const Interp = extern struct {
     /// dangling source-side alias so a later dispatch through the
     /// child can't crash on a freed parent.
     alias_targets_head: u32,
+
+    /// Per-interp array directory.  ``tcl_array.zig`` keys every array
+    /// name (global, namespace-qualified, and proc-local) into a single
+    /// open-addressing table; C Tcl arrays are interp-local state, so
+    /// each interp owns its own directory here.  Without this, global
+    /// and namespace arrays (``auto_index``, ``tcl_platform``, …) would
+    /// be shared across ``interp create`` boundaries — a child's
+    /// ``array set ::tcl_platform`` would leak into the parent.
+    /// :fn:`enter` / :fn:`leave` swap the active directory between
+    /// ``tcl_array.zig``'s module-global cache and these fields.  Zero
+    /// = lazily initialised on first array op in this interp.
+    arr_dir_buf: u32,
+    arr_dir_cap: u32,
+    arr_dir_count: u32,
 };
 
 /// Root-interp singleton.  ``interp_root()`` allocates lazily and
@@ -786,11 +808,16 @@ pub const EnterSave = struct {
 /// ``tcl_ns.root_addr`` covers the case where the parent is itself
 /// a child and we need to unwind correctly on return.
 pub fn enter(target: u32) EnterSave {
+    // Establish the root interp so ``current_interp`` is non-zero and
+    // the live array directory in ``tcl_array.zig`` has an owner to be
+    // stashed back into before we swap in the target's directory.
+    if (current_interp == 0) _ = interp_root();
     const save: EnterSave = .{
         .prev_interp = current_interp,
         .prev_root_addr = tcl_ns.root_addr,
         .prev_current_ns = tcl_ns.current_ns,
     };
+    swap_array_dir(current_interp, target);
     const t: *Interp = @ptrFromInt(target);
     current_interp = target;
     tcl_ns.root_addr = t.root_ns;
@@ -798,11 +825,66 @@ pub fn enter(target: u32) EnterSave {
     return save;
 }
 
+/// The deferred ``Tcl_Init`` bootstrap a trusted child runs the first
+/// time it is the target of an ``interp eval`` / ``child eval``.  It is
+/// *prepended to the user's eval script* (see
+/// :func:`tcl_interp.eval_interp_eval`) rather than run as a separate
+/// nested eval: init.tcl's ``proc`` definitions only register and
+/// persist when sourced at the same eval depth as a top-level ``interp
+/// eval child {source init.tcl}``; a separately-nested eval leaves them
+/// unregistered.
+///
+/// ``::tcl::unsupported::clock::configure`` is a C-provided command
+/// init.tcl's clock-ensemble block signals once setup completes; the
+/// WASM runtime ships ``clock`` as a builtin, so a no-op accessor lets
+/// sourcing the upstream init.tcl finish.  ``env`` mirrors the minimal
+/// set tclsh's startup populates.  ``tcl_library`` / ``auto_path`` are
+/// copied from the parent at create time.
+pub const DEFERRED_INIT_SCRIPT: []const u8 =
+    \\if {![info exists ::env]} { array set ::env {HOME / PATH {} USER wasm} }
+    \\namespace eval ::tcl::unsupported::clock { proc configure args { return } }
+    \\if {[info exists ::tcl_library]} {
+    \\    catch { source [file join $::tcl_library init.tcl] }
+    \\}
+    \\
+;
+
+/// If *target* is a trusted child still awaiting its deferred
+/// ``Tcl_Init``, clear the bit and return the bootstrap script bytes to
+/// prepend to the caller's eval script; otherwise return ``null``.
+pub fn take_deferred_init(target: u32) ?[]const u8 {
+    if (target == 0) return null;
+    const t: *Interp = @ptrFromInt(target);
+    if ((t.flags & INTERP_NEEDS_INIT) == 0) return null;
+    t.flags &= ~INTERP_NEEDS_INIT;
+    return DEFERRED_INIT_SCRIPT;
+}
+
+/// Persist the live array directory into ``from``'s ``Interp`` slot
+/// and load ``to``'s directory into ``tcl_array.zig``'s active globals.
+/// ``enter`` / ``leave`` call this so each interp's arrays are isolated
+/// (C Tcl arrays are interp-local state).
+fn swap_array_dir(from: u32, to: u32) void {
+    const arr = @import("../valtypes/tcl_array.zig");
+    if (from != 0) {
+        const f: *Interp = @ptrFromInt(from);
+        const st = arr.dir_state_get();
+        f.arr_dir_buf = st.buf;
+        f.arr_dir_cap = st.cap;
+        f.arr_dir_count = st.count;
+    }
+    if (to != 0) {
+        const t: *Interp = @ptrFromInt(to);
+        arr.dir_state_set(.{ .buf = t.arr_dir_buf, .cap = t.arr_dir_cap, .count = t.arr_dir_count });
+    }
+}
+
 /// Inverse of :func:`enter` — restore the saved state.  Callers that
 /// match ``enter`` / ``leave`` as a save/restore pair get transparent
 /// nesting: ``interp eval child1 { interp eval child2 {...} }`` will
 /// walk into child2 from child1 and unwind back through both.
 pub fn leave(save: EnterSave) void {
+    swap_array_dir(current_interp, save.prev_interp);
     current_interp = save.prev_interp;
     tcl_ns.root_addr = save.prev_root_addr;
     tcl_ns.current_ns = save.prev_current_ns;

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -329,6 +329,10 @@ pub const Interp = extern struct {
     arr_dir_buf: u32,
     arr_dir_cap: u32,
     arr_dir_count: u32,
+    // ``array default`` registry, swapped alongside the directory so
+    // each interp's defaults are isolated.  Zero on a fresh interp.
+    arr_def_buf: u32,
+    arr_def_count: u32,
 };
 
 /// Root-interp singleton.  ``interp_root()`` allocates lazily and
@@ -889,10 +893,18 @@ fn swap_array_dir(from: u32, to: u32) void {
         f.arr_dir_buf = st.buf;
         f.arr_dir_cap = st.cap;
         f.arr_dir_count = st.count;
+        f.arr_def_buf = st.def_buf;
+        f.arr_def_count = st.def_count;
     }
     if (to != 0) {
         const t: *Interp = @ptrFromInt(to);
-        arr.dir_state_set(.{ .buf = t.arr_dir_buf, .cap = t.arr_dir_cap, .count = t.arr_dir_count });
+        arr.dir_state_set(.{
+            .buf = t.arr_dir_buf,
+            .cap = t.arr_dir_cap,
+            .count = t.arr_dir_count,
+            .def_buf = t.arr_def_buf,
+            .def_count = t.arr_def_count,
+        });
     }
 }
 

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -852,12 +852,26 @@ pub const DEFERRED_INIT_SCRIPT: []const u8 =
 /// If *target* is a trusted child still awaiting its deferred
 /// ``Tcl_Init``, clear the bit and return the bootstrap script bytes to
 /// prepend to the caller's eval script; otherwise return ``null``.
-pub fn take_deferred_init(target: u32) ?[]const u8 {
-    if (target == 0) return null;
+pub fn run_deferred_init(target: u32) void {
+    if (target == 0) return;
     const t: *Interp = @ptrFromInt(target);
-    if ((t.flags & INTERP_NEEDS_INIT) == 0) return null;
+    if ((t.flags & INTERP_NEEDS_INIT) == 0) return;
     t.flags &= ~INTERP_NEEDS_INIT;
-    return DEFERRED_INIT_SCRIPT;
+    // Run init.tcl as its own complete enter / eval / leave cycle —
+    // separate from (and before) the caller's eval script.  Sourcing it
+    // inline with the user script (e.g. tcltest's own ``source``) leaves
+    // init.tcl half-applied; a standalone cycle registers and persists
+    // its procs the same way a top-level ``interp eval child {source
+    // init.tcl}`` does.  The bit is cleared first so init.tcl's own
+    // nested evals don't re-enter this path.
+    const ti = @import("tcl_interp.zig");
+    const frames = @import("tcl_frames.zig");
+    const save = enter(target);
+    defer leave(save);
+    // Run init.tcl at the child's global frame (see eval_interp_eval).
+    const frame_saved = frames.frame_depth_stash(@intCast(frames.frame_depth));
+    defer frames.frame_depth_restore(frame_saved);
+    _ = ti.eval_script(@intFromPtr(DEFERRED_INIT_SCRIPT.ptr), @intCast(DEFERRED_INIT_SCRIPT.len));
 }
 
 /// Persist the live array directory into ``from``'s ``Interp`` slot

--- a/runtime/zig/interp/tcl_interp_registry.zig
+++ b/runtime/zig/interp/tcl_interp_registry.zig
@@ -866,11 +866,14 @@ pub fn run_deferred_init(target: u32) void {
     // nested evals don't re-enter this path.
     const ti = @import("tcl_interp.zig");
     const frames = @import("tcl_frames.zig");
-    const save = enter(target);
-    defer leave(save);
-    // Run init.tcl at the child's global frame (see eval_interp_eval).
+    // Stash before enter (see eval_interp_eval): the stash re-points
+    // current_ns at the caller's frame ns, so enter must run after it to
+    // install the child-root context.  Unwind in reverse: leave, then
+    // restore.
     const frame_saved = frames.frame_depth_stash(@intCast(frames.frame_depth));
     defer frames.frame_depth_restore(frame_saved);
+    const save = enter(target);
+    defer leave(save);
     _ = ti.eval_script(@intFromPtr(DEFERRED_INIT_SCRIPT.ptr), @intCast(DEFERRED_INIT_SCRIPT.len));
 }
 

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -105,6 +105,55 @@ pub const Namespace = extern struct {
 /// Zero before the first ``ns_root()`` call (lazy allocation).
 pub var root_addr: u32 = 0;
 
+// ``namespace unknown`` per-namespace handler registry.  Maps a
+// namespace address to its explicit unknown-command handler (a Tcl
+// command prefix).  Small linear table — namespaces with a custom
+// handler are rare.  An absent entry means "no explicit handler", in
+// which case command dispatch falls back to the global ``::unknown``
+// machinery (auto-loading) and ``namespace unknown`` queries report
+// ``::unknown`` for the root and ``{}`` elsewhere.
+const NsUnknownEntry = struct { ns: u32, handler: i32 };
+var ns_unknown_entries: [64]NsUnknownEntry = undefined;
+var ns_unknown_count: u32 = 0;
+
+/// Set (or, with an empty handler, clear) the explicit unknown handler
+/// for namespace ``ns``.
+pub fn ns_unknown_set(ns: u32, handler: i32) void {
+    if (ns == 0) return;
+    var is_empty = handler == 0;
+    if (!is_empty) {
+        const hs = obj.obj_ensure_string(handler);
+        if (hs.len == 0) is_empty = true;
+    }
+    var i: u32 = 0;
+    while (i < ns_unknown_count) : (i += 1) {
+        if (ns_unknown_entries[i].ns == ns) {
+            obj.tcl_obj_release(ns_unknown_entries[i].handler);
+            if (is_empty) {
+                ns_unknown_count -= 1;
+                if (i != ns_unknown_count) ns_unknown_entries[i] = ns_unknown_entries[ns_unknown_count];
+            } else {
+                obj.tcl_obj_retain(handler);
+                ns_unknown_entries[i].handler = handler;
+            }
+            return;
+        }
+    }
+    if (is_empty or ns_unknown_count >= ns_unknown_entries.len) return;
+    obj.tcl_obj_retain(handler);
+    ns_unknown_entries[ns_unknown_count] = .{ .ns = ns, .handler = handler };
+    ns_unknown_count += 1;
+}
+
+/// The explicit unknown handler for ``ns`` (a borrowed TclObj), or 0.
+pub fn ns_unknown_get(ns: u32) i32 {
+    var i: u32 = 0;
+    while (i < ns_unknown_count) : (i += 1) {
+        if (ns_unknown_entries[i].ns == ns) return ns_unknown_entries[i].handler;
+    }
+    return 0;
+}
+
 /// Currently-active namespace handle.  Zero means "no explicit
 /// context set" — readers should treat that as root.  Compiled
 /// procs flip this via ``ns_set`` / ``ns_restore`` (in

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -330,6 +330,23 @@ fn resolve_for_register(name_ptr: u32, name_len: u32) struct {
     return .{ .r = r, .existing = existing };
 }
 
+/// Fire a redefined command's ``delete`` trace (if any) and drop every
+/// command / execution trace keyed on its bucket.  Reference Tcl deletes
+/// the old command when ``proc`` re-registers an existing name, which
+/// invokes its delete trace and removes all traces before the new body
+/// is installed (trace-19.4 / 19.5 / 20.3).
+fn redefine_clear_command_traces(cmd: u32) void {
+    const exec_trace = @import("tcl_exec_trace.zig");
+    if (exec_trace.ops_for(cmd) == 0) return;
+    if ((exec_trace.ops_for(cmd) & exec_trace.OP_CMD_DELETE) != 0) {
+        const cmd_interp = @import("../cmds/tcl_cmd_interp.zig");
+        const fqn = cmd_interp.command_fqn_obj(cmd);
+        defer if (fqn != 0) obj.tcl_obj_release(fqn);
+        exec_trace.fire_command(cmd, exec_trace.OP_CMD_DELETE, fqn, 0);
+    }
+    exec_trace.remove_all_for(cmd);
+}
+
 /// Register an interpreted proc (body is Tcl source, func_idx = 0).
 /// params_obj and body_obj are TclObj handles (string representations).
 ///
@@ -385,6 +402,13 @@ pub export fn proc_register(name: i32, params_obj: i32, body_obj: i32) i32 {
         cmd = alloc_command(sn.ptr, sn.len, hash);
         _ = tcl_ns.ns_cmd_put(ctx.r.target_ns, ctx.r.simple_ptr, ctx.r.simple_len, cmd);
         proc_count += 1;
+    } else {
+        // Redefining an existing command deletes the old one before
+        // installing the new body (C Tcl ``TclCreateObjCommandInNs``).
+        // Fire its ``delete`` command trace and drop every command /
+        // execution trace keyed on the bucket so the recreated command
+        // starts clean — trace-19.4 / 19.5 / 20.3.
+        redefine_clear_command_traces(cmd);
     }
 
     // Clear any CMD_IMPORTED bit — defining a proc with the same

--- a/runtime/zig/interp/tcl_var_trace.zig
+++ b/runtime/zig/interp/tcl_var_trace.zig
@@ -269,6 +269,54 @@ pub fn remove(name: i32, ops: u32, cmd_prefix: i32) bool {
     return false;
 }
 
+/// Remove *every* trace registered on ``name_ptr``/``name_len`` from
+/// the global directory, freeing each record.  Mirrors Tcl's contract
+/// that ``unset`` of a variable drops the variable's traces (after the
+/// unset callbacks have fired): without this a stale write/read trace
+/// keeps firing on a later, unrelated variable that reuses the name —
+/// the trace-2.x cascade where ``unset x`` left 2.1's whole-variable
+/// write trace attached, so a subsequent ``set x(abc)`` re-fired it
+/// (and eventually trapped via re-entrant xlinks lookup).
+///
+/// Must be called only when no fire is walking the chain (i.e. after
+/// the unset callbacks return), since it frees records out from under
+/// any active iterator.
+pub fn remove_all(name_ptr: u32, name_len: u32) void {
+    if (name_ptr == 0 or name_len == 0) return;
+    if (dir_buf == 0) return;
+    const hash = fnv1a(name_ptr, name_len);
+    const bucket = dir_find(name_ptr, name_len, hash) orelse return;
+    const head: u32 = @bitCast(read_i32(bucket + 12));
+    if (head == 0) return;
+    // Re-entrancy: ``remove_all`` can run from inside a fire (an unset
+    // that the trace callback itself triggered).  A ``fire_at_key``
+    // loop higher on the stack still holds a ``cur`` into this chain
+    // and will advance through ``OFF_NEXT``, so freeing *any* record in
+    // the chain — not just the active one — is a use-after-free.  When
+    // any record is active, unlink the whole chain from the bucket
+    // (future fires see none) but leave the records allocated; the
+    // in-flight fire walks its captured chain to completion and the
+    // orphaned records leak (bounded, rare).
+    var any_active = false;
+    var scan: u32 = head;
+    while (scan != 0) : (scan = @bitCast(read_i32(scan + OFF_NEXT))) {
+        if (read_i32(scan + OFF_ACTIVE) != 0) {
+            any_active = true;
+            break;
+        }
+    }
+    write_i32(bucket + 12, 0);
+    if (any_active) return;
+    var cur: u32 = head;
+    while (cur != 0) {
+        const next: u32 = @bitCast(read_i32(cur + OFF_NEXT));
+        const cmd = read_i32(cur + OFF_CMD);
+        if (cmd != 0) tcl_obj_release(cmd);
+        obj.free_sized(cur, TRACE_REC_SIZE);
+        cur = next;
+    }
+}
+
 /// Return a Tcl list of ``{ops cmd}`` pairs for every trace on
 /// ``name``, or empty list if none.
 pub fn info(name: i32) i32 {

--- a/runtime/zig/interp/tcl_var_trace.zig
+++ b/runtime/zig/interp/tcl_var_trace.zig
@@ -475,14 +475,10 @@ fn invoke_cb(
     op_char: u8,
 ) void {
     const interp = @import("tcl_interp.zig");
-    const list_parse = @import("../valtypes/tcl_list_parse.zig");
+    const quote = @import("../valtypes/tcl_list_quote.zig");
     // Reference Tcl 9 invokes variable-trace callbacks with the full
     // op word (``read`` / ``write`` / ``unset`` / ``array``), not the
     // single-character internal op code we carry in ``op_char``.
-    // Without this expansion, the test ``trace add variable x read
-    // traceScalar; set x`` reports ``op = r`` to the callback and
-    // every reference-Tcl-shaped assertion fails (cf. trace.test
-    // 1.1–1.14, 2.1–2.5 in the Tcl 9 core slice).
     const op_word: []const u8 = switch (op_char) {
         'r' => "read",
         'w' => "write",
@@ -490,122 +486,64 @@ fn invoke_cb(
         'a' => "array",
         else => &[_]u8{op_char},
     };
-    // Build argv directly (one TclObj per word) and dispatch through
-    // ``eval_command``.  The previous implementation built a script
-    // string ``<cmd> <name1> <name2> <op>`` and called ``eval_script``;
-    // ``eval_script`` parses the bytes back into TclObjs whose
-    // ``str_ptr`` aliased into the script buffer (``obj_new_string``
-    // is a non-copying constructor), so freeing the buffer left any
-    // TclObj a callback captured into a long-lived variable
-    // dangling.  The earlier workaround leaked the buffer on every
-    // fire — fine for one-shot traces but a per-fire linear-memory
-    // leak in trace-heavy workloads (variables traced inside loops,
-    // tcltest's ``::errorInfo`` write trace fired by every test).
-    //
-    // ``cmd_prefix`` is a list TclObj — the verbatim ``CMD`` argument
-    // from ``trace add variable NAME OPS CMD``.  Parse it as a list
-    // and concatenate its elements with the three trace-supplied
-    // arguments to form the dispatched argv.  Each argv element is
-    // an owned ``obj_new_string_copy`` so the TclObjs survive the
-    // full callback lifetime even if the callback assigns one to a
-    // long-lived variable.
+    const op_ptr: u32 = @intFromPtr(op_word.ptr);
+    const op_len: u32 = @intCast(op_word.len);
+
+    // Reference Tcl (``tclTrace.c`` ``TclCallVarTraces`` →
+    // ``traceVarProc``) builds the callback string by appending the
+    // verbatim command prefix, then ``name1``, ``name2``, and the op
+    // word as *list elements*, and evaluates the whole thing as a
+    // **script** (``Tcl_EvalEx``).  That is what makes:
+    //   * a bare command prefix (``trace add variable v write myProc``)
+    //     dispatch as ``myProc name1 name2 op``; and
+    //   * the ``cmd … ;#`` idiom work — the trailing ``;#`` turns the
+    //     appended args into a comment so they don't reach ``cmd``
+    //     (tcltest's stdio-constraint trace at tcltest.tcl:284).
+    // The previous implementation list-parsed the prefix and dispatched
+    // a single ``eval_command``, so ``;#`` became literal words and
+    // multi-word / proc-name prefixes never fired correctly.
     const cs = obj_ensure_string(cmd_prefix);
     if (cs.len == 0 and cs.ptr == 0) return;
-    const n_prefix = list_parse.count_elements(cs.ptr, cs.len);
-    if (n_prefix < 0) return;
-    const total_args: u32 = @as(u32, @intCast(n_prefix)) + 3;
-    // Cap argv at a sensible upper bound — runaway list parsing on a
-    // corrupted prefix shouldn't drive us into a multi-megabyte alloc.
-    const MAX_TRACE_ARGV: u32 = 512;
-    if (total_args > MAX_TRACE_ARGV) return;
-    const argv_bytes: u32 = total_args * @sizeOf(i32);
-    const argv_buf = alloc(argv_bytes);
-    if (argv_buf == 0) return;
-    defer obj.free_sized(argv_buf, argv_bytes);
-    var argv_slice: [*]i32 = @ptrFromInt(argv_buf);
-    // Collect prefix words.
-    var i: u32 = 0;
-    var cursor: list_parse.Cursor = .{ .pos = 0 };
-    while (i < @as(u32, @intCast(n_prefix))) : (i += 1) {
-        const elem = list_parse.cursor_next(cs.ptr, cs.len, &cursor);
-        if (elem.braced) {
-            argv_slice[i] = obj.obj_new_string_copy(cs.ptr + elem.start, elem.len);
-        } else {
-            // Process backslash escapes for unbraced elements via the
-            // same path ``tcl_cmd_list_index`` uses.
-            const buf = obj.alloc(elem.len);
-            if (buf == 0) {
-                // OOM — release everything we've built and bail.
-                var j: u32 = 0;
-                while (j < i) : (j += 1) {
-                    if (argv_slice[j] != 0) tcl_obj_release(argv_slice[j]);
-                }
-                return;
-            }
-            const out_len = list_parse.copy_unbraced_elem(buf, cs.ptr + elem.start, elem.len);
-            argv_slice[i] = obj.obj_new_string_take(buf, out_len, elem.len);
-        }
+    // Worst-case size: prefix verbatim + for each of the three trailing
+    // args, a separator space plus the list-quoting expansion (≤ 2·len+2).
+    const size: u32 = cs.len +
+        (1 + 2 * name1_len + 2) +
+        (1 + 2 * name2_len + 2) +
+        (1 + 2 * op_len + 2);
+    const buf = alloc(size);
+    if (buf == 0) return;
+    var off: u32 = 0;
+    if (cs.len > 0) {
+        memcpy(buf, cs.ptr, cs.len);
+        off = cs.len;
     }
-    // name1 — copy bytes so we own the TclObj.  ``name1_ptr`` may
-    // alias into a hash-table key buffer that gets reused on the
-    // next array op; we can't borrow it across the callback.
-    argv_slice[i] = obj.obj_new_string_copy(name1_ptr, name1_len);
-    i += 1;
-    // name2 — same ownership story.  When ``name2_len == 0`` (whole-
-    // array fire) we still pass an empty string TclObj rather than
-    // 0, matching reference Tcl's ``Tcl_TraceVar2``.
-    argv_slice[i] = obj.obj_new_string_copy(name2_ptr, name2_len);
-    i += 1;
-    // op_word — copy from a stack-resident slice into an owned
-    // TclObj so the callback can assign ``$op`` to a variable
-    // without hitting freed memory.
-    argv_slice[i] = obj.obj_new_string_copy(@intFromPtr(op_word.ptr), @intCast(op_word.len));
-    i += 1;
-    // Dispatch.  ``eval_command`` runs the command synchronously and
-    // returns the result handle (or 0 on error / no-result).  The
-    // result handle is intentionally NOT released here.
-    //
-    // The dispatch chain's deferred-free queue (PENDING_FREE_CAP =
-    // 65536) overflows during long-running trace-heavy bundles like
-    // tcl9_trace.test.  When the queue is full a fresh release goes
-    // through ``release_now`` immediately, writing POISON to the
-    // slab's type tag and pushing it onto the recycler — a
-    // subsequent ``obj_alloc`` reissues that exact slab.  Releasing
-    // ``r`` here then either hits POISON (slab still on freelist) or
-    // ``bad_rc`` (slab reissued, freelist next-link bleeding through),
-    // depending on timing.
-    //
-    // Triage data on tcl9_trace.test (split counters from this
-    // investigation) attributed 92% of the bundle's 1,574,308
-    // ``g_double_free_count`` bumps to ``invoke_cb``'s post-call
-    // releases.  Skipping the result release alone drops that to 18
-    // bumps and also LOWERS ``alloc_residual`` (from 37.6M to 36.5M
-    // — the cascading immediate-frees on queue-overflowing slabs
-    // stop happening, so other paths' releases successfully queue
-    // instead of going immediate-free).
-    //
-    // ``r`` itself does NOT leak in practice: a stress test
-    // (10,000 trace fires whose proc returns a 1,000-char string)
-    // produces alloc_residual = 70,012 both with and without the
-    // release — empirical evidence that the result is consumed by
-    // the dispatch chain itself (most likely via ``eval_return``'s
-    // retain into ``return_val`` and the eval_script per-statement
-    // release at tcl_interp.zig:3967, the same way other callers
-    // such as ``cmds/namespace.zig``'s ``invoke_ensemble`` /
-    // ``invoke_ensemble_unknown`` and ``tcl_expr_eval.zig``'s
-    // math-func call site forward the result without releasing it).
-    // ``invoke_cb`` is a terminal consumer that doesn't propagate
-    // ``r``, so the original ``tcl_obj_release(r)`` over-released
-    // a handle that had already been consumed upstream.
-    const argv_view: []const i32 = (@as([*]const i32, @ptrCast(argv_slice)))[0..total_args];
-    _ = interp.eval_command(argv_view);
-    // Release every argv TclObj we built — ``eval_command`` retains
-    // any it stores into a long-lived slot via the normal var-set
-    // refcount discipline.
-    var k: u32 = 0;
-    while (k < total_args) : (k += 1) {
-        if (argv_slice[k] != 0) tcl_obj_release(argv_slice[k]);
+    const sp: [*]u8 = @ptrFromInt(buf + off);
+    sp[0] = ' ';
+    off += 1;
+    off = quote.list_elem_quote(buf, off, name1_ptr, name1_len);
+    const sp2: [*]u8 = @ptrFromInt(buf + off);
+    sp2[0] = ' ';
+    off += 1;
+    off = quote.list_elem_quote(buf, off, name2_ptr, name2_len);
+    const sp3: [*]u8 = @ptrFromInt(buf + off);
+    sp3[0] = ' ';
+    off += 1;
+    off = quote.list_elem_quote(buf, off, op_ptr, op_len);
+
+    // Wrap as an owning TclObj string (``obj_new_string_take`` claims
+    // the buffer via ``OBJ_STR_CAP``) and evaluate as a script.
+    // ``tcl_eval`` retains the script for the eval; the deferred-free
+    // queue keeps the bytes alive across any word TclObj that borrows
+    // from them, and ``var_set`` promotes a borrowed value to an owned
+    // copy before storing — so a callback that assigns a trace argument
+    // to a long-lived variable stays valid after we release here.
+    const script_obj = obj.obj_new_string_take(buf, off, size);
+    if (script_obj == 0) {
+        obj.free_sized(buf, size);
+        return;
     }
+    _ = interp.tcl_eval(script_obj);
+    tcl_obj_release(script_obj);
 }
 
 // --- Phase 6 follow-up: per-frame trace lists --------------------------

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -1363,6 +1363,100 @@ pub fn tcl_cmd_glob(pattern: i32) i32 {
     return acc;
 }
 
+/// Recursive multi-segment glob.  Matches ``pattern`` (a byte slice
+/// that may contain ``/`` separators) against the directory tree rooted
+/// at the NUL-terminated path ``base`` (``base_len`` excludes the NUL),
+/// appending full matching paths (``base/.../match``) to the Tcl list
+/// ``acc_in``.  Each segment is matched against ``readdir`` entries via
+/// ``fnmatch_basename``; non-final segments recurse into matching
+/// sub-directories.  Powers ``glob -directory DIR -join * pkgIndex.tcl``
+/// — the package-discovery walk ``tclPkgUnknown`` uses to load the
+/// stdlib (opt / msgcat / http / …) from ``TCL_LIBRARY``.
+fn glob_rec(acc_in: i32, base: [*:0]const u8, base_len: u32, pattern: []const u8, strip_len: u32) i32 {
+    var acc = acc_in;
+    var slash: u32 = @intCast(pattern.len);
+    {
+        var i: u32 = 0;
+        while (i < pattern.len) : (i += 1) {
+            if (pattern[i] == '/') {
+                slash = i;
+                break;
+            }
+        }
+    }
+    const seg: []const u8 = pattern[0..slash];
+    const is_last = slash >= pattern.len;
+    const rest: []const u8 = if (is_last) pattern[0..0] else pattern[slash + 1 ..];
+
+    const dir_handle = opendir(base);
+    if (dir_handle == null) return acc;
+    while (true) {
+        const ent = readdir(dir_handle.?);
+        if (ent == null) break;
+        const ent_addr: u32 = @intFromPtr(ent.?);
+        const name_ptr: [*]const u8 = @ptrFromInt(ent_addr + DIRENT_OFF_NAME);
+        var nlen: u32 = 0;
+        while (name_ptr[nlen] != 0) : (nlen += 1) {}
+        if (nlen == 0) continue;
+        // Skip ``.`` / ``..`` unless the segment explicitly begins with ``.``.
+        if (name_ptr[0] == '.' and (seg.len == 0 or seg[0] != '.')) continue;
+        if (!fnmatch_basename(seg.ptr, @intCast(seg.len), name_ptr, nlen)) continue;
+        const child_len: u32 = base_len + 1 + nlen;
+        const cbuf = obj.alloc(child_len + 1);
+        if (cbuf == 0) {
+            _ = closedir(dir_handle.?);
+            return acc;
+        }
+        const cp: [*]u8 = @ptrFromInt(cbuf);
+        var k: u32 = 0;
+        while (k < base_len) : (k += 1) cp[k] = base[k];
+        cp[base_len] = '/';
+        var j: u32 = 0;
+        while (j < nlen) : (j += 1) cp[base_len + 1 + j] = name_ptr[j];
+        cp[child_len] = 0;
+        if (is_last) {
+            // ``strip_len`` > 0 selects ``-tails`` output: append the
+            // path relative to the original ``-directory`` (i.e. with
+            // the directory prefix and its slash removed).
+            if (strip_len != 0 and child_len > strip_len) {
+                acc = list_append(acc, cbuf + strip_len, child_len - strip_len);
+            } else {
+                acc = list_append(acc, cbuf, child_len);
+            }
+        } else {
+            acc = glob_rec(acc, @ptrCast(cp), child_len, rest, strip_len);
+        }
+    }
+    _ = closedir(dir_handle.?);
+    return acc;
+}
+
+/// ``glob -directory DIR ?-join? ?-tails? PATTERN`` core.  Globs
+/// ``pattern`` (already joined when ``-join`` was given) relative to
+/// ``dir``.  Returns a Tcl list of full paths, or — when ``tails`` is
+/// set — paths relative to ``dir``.  Capability-gated like
+/// :func:`tcl_cmd_glob`.
+pub fn tcl_cmd_glob_dir(dir_obj: i32, pattern_obj: i32, tails: bool) i32 {
+    if (!caps.check(caps.CAP_FS_GLOB, "glob", "FS_GLOB")) return 0;
+    const d = obj_ensure_string(dir_obj);
+    const p = obj_ensure_string(pattern_obj);
+    if (d.len == 0) {
+        // No directory → behave like the bare ``glob pattern`` path.
+        return tcl_cmd_glob(pattern_obj);
+    }
+    // NUL-terminate the base directory.
+    const base = obj.alloc(d.len + 1);
+    if (base == 0) return obj_new_string(0, 0);
+    const bp: [*]u8 = @ptrFromInt(base);
+    var i: u32 = 0;
+    const dpb: [*]const u8 = @ptrFromInt(d.ptr);
+    while (i < d.len) : (i += 1) bp[i] = dpb[i];
+    bp[d.len] = 0;
+    const pat: []const u8 = (@as([*]const u8, @ptrFromInt(p.ptr)))[0..p.len];
+    const strip_len: u32 = if (tails) d.len + 1 else 0;
+    return glob_rec(obj_new_string(0, 0), @ptrCast(bp), d.len, pat, strip_len);
+}
+
 /// ``file link ?-type? linkName target`` — create a link.  Tcl's
 /// full command accepts ``-symbolic`` / ``-hard`` and arg order
 /// ``linkName target``.  Our 3-arg export has arg1=linkName,

--- a/runtime/zig/io/tcl_fs.zig
+++ b/runtime/zig/io/tcl_fs.zig
@@ -1426,6 +1426,11 @@ fn glob_rec(acc_in: i32, base: [*:0]const u8, base_len: u32, pattern: []const u8
         } else {
             acc = glob_rec(acc, @ptrCast(cp), child_len, rest, strip_len);
         }
+        // ``list_append`` copies the element bytes and ``glob_rec``
+        // copies what it needs into deeper child buffers, so this
+        // per-entry path buffer can be reclaimed immediately — without
+        // this a deep/wide recursive glob grows linear memory unbounded.
+        obj.free_sized(cbuf, child_len + 1);
     }
     _ = closedir(dir_handle.?);
     return acc;
@@ -1454,7 +1459,9 @@ pub fn tcl_cmd_glob_dir(dir_obj: i32, pattern_obj: i32, tails: bool) i32 {
     bp[d.len] = 0;
     const pat: []const u8 = (@as([*]const u8, @ptrFromInt(p.ptr)))[0..p.len];
     const strip_len: u32 = if (tails) d.len + 1 else 0;
-    return glob_rec(obj_new_string(0, 0), @ptrCast(bp), d.len, pat, strip_len);
+    const result = glob_rec(obj_new_string(0, 0), @ptrCast(bp), d.len, pat, strip_len);
+    obj.free_sized(base, d.len + 1);
+    return result;
 }
 
 /// ``file link ?-type? linkName target`` — create a link.  Tcl's

--- a/runtime/zig/parse/tcl_parse.zig
+++ b/runtime/zig/parse/tcl_parse.zig
@@ -60,7 +60,12 @@ pub const BracedRange = struct {
 pub fn skip_space(src: [*]const u8, pos: u32, len: u32) u32 {
     var p = pos;
     while (p < len) {
-        if (src[p] == ' ' or src[p] == '\t') {
+        // Tcl's command tokeniser (tclParse.c TYPE_SPACE) treats
+        // vertical tab (0x0B) and form feed (0x0C) as inter-word
+        // whitespace alongside space / tab.  Form-feed page separators
+        // appear between sections of upstream test files (init.test),
+        // so a ``\f``-only line must skip rather than parse as a word.
+        if (src[p] == ' ' or src[p] == '\t' or src[p] == 0x0B or src[p] == 0x0C) {
             p += 1;
         } else if (src[p] == '\\' and p + 1 < len and src[p + 1] == '\n') {
             // Tcl line continuation: ``\<newline>`` collapses to a
@@ -258,7 +263,11 @@ pub fn parse_command(
     // parser on a lonely backslash.
     while (p < len) {
         const c = src[p];
-        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == ';') {
+        // ``0x0B`` (VT) / ``0x0C`` (FF) are whitespace in Tcl's command
+        // tokeniser; skip them between commands so a form-feed-only line
+        // (page separators in init.test et al.) doesn't strand the
+        // parser on a bare ``\f`` word.
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == ';' or c == 0x0B or c == 0x0C) {
             p += 1;
         } else if (c == '\\' and p + 1 < len and src[p + 1] == '\n') {
             p += 2;

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1212,6 +1212,20 @@ pub export fn array_exists(arr: i32) i32 {
     return obj_new_int(1);
 }
 
+/// Make ``arr`` exist as an (empty) array if it isn't one already.
+/// Reference Tcl creates the array when a trace is registered on one
+/// of its elements (``trace add variable arr(key) …`` with ``arr``
+/// absent), so a subsequent element read reports ``no such element in
+/// array`` — and fires the registered read/unset trace — instead of
+/// ``no such variable``.  No-op when ``arr`` is already an array; bails
+/// (does not clobber) when a scalar of the same name exists.
+pub fn ensure_array_exists(arr: i32) void {
+    if (find_table(arr) != 0) return;
+    const tcl_ns = @import("../interp/tcl_ns.zig");
+    if (obj.obj_get_int(tcl_ns.global_exists(arr)) != 0) return;
+    _ = find_or_create(arr);
+}
+
 // ``array default`` — a per-array fallback value returned when a
 // missing element is *read* (Tcl 8.7 / 9 feature, var-24.x).  Defaults
 // are rare, so a small linear registry keyed by the array's normalised

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1076,6 +1076,25 @@ fn raise_array_set_scalar_conflict_empty(arr: i32) void {
 /// distinguish missing-vs-present should use ``array_element_exists``
 /// first or ``info exists``.
 pub export fn array_get(arr: i32, key: i32) i32 {
+    const v = array_get_raw(arr, key);
+    if (v != 0) return v;
+    // Element missing → fall back to the array's default value (if any),
+    // returning a fresh copy so the caller owns an independent TclObj
+    // (each ``$arr(missing)`` read yields its own value, and
+    // read-modify-write commands may mutate it).  var-24.x.
+    const d = array_default_get_value(arr);
+    if (d != 0) {
+        const ds = obj_ensure_string(d);
+        return obj.obj_new_string_copy(ds.ptr, ds.len);
+    }
+    return 0;
+}
+
+/// Pure single-element lookup: returns the stored value or 0 on miss,
+/// *without* the ``array default`` fallback.  Used by internal dispatch
+/// probes (``auto_index`` / ensemble maps) that must distinguish
+/// genuinely-absent entries from a default.
+pub export fn array_get_raw(arr: i32, key: i32) i32 {
     const sk = obj_ensure_string(key);
     // Phase 6: fire READ trace BEFORE the lookup.  The callback may
     // ``set`` the variable to provide a lazy value (e.g. tcltest
@@ -1193,6 +1212,106 @@ pub export fn array_exists(arr: i32) i32 {
     return obj_new_int(1);
 }
 
+// ``array default`` — a per-array fallback value returned when a
+// missing element is *read* (Tcl 8.7 / 9 feature, var-24.x).  Defaults
+// are rare, so a small linear registry keyed by the array's normalised
+// name is enough; no hot-path cost for arrays without one.  The default
+// does NOT create elements: ``info exists arr(x)`` / ``array size`` /
+// ``array names`` ignore it; only an element *read* (and the
+// read-modify-write commands append / lappend / incr / dict that read
+// before writing) observe it.
+const DefEntry = struct { name_ptr: u32, name_len: u32, value: i32 };
+var def_entries: [64]DefEntry = undefined;
+var def_count: u32 = 0;
+
+fn def_find(name_ptr: u32, name_len: u32) ?u32 {
+    var i: u32 = 0;
+    while (i < def_count) : (i += 1) {
+        const e = def_entries[i];
+        if (e.name_len != name_len) continue;
+        const ap: [*]const u8 = @ptrFromInt(e.name_ptr);
+        const bp: [*]const u8 = @ptrFromInt(name_ptr);
+        var match = true;
+        for (0..name_len) |k| {
+            if (ap[k] != bp[k]) {
+                match = false;
+                break;
+            }
+        }
+        if (match) return i;
+    }
+    return null;
+}
+
+/// Store ``value`` as ``arr``'s default, replacing any prior one.  The
+/// array directory entry is created if absent (Tcl: ``array default
+/// set`` on a non-existent variable makes it an empty array).
+pub fn array_default_set_value(arr: i32, value: i32) void {
+    const n = normalize_ns_name(arr);
+    defer if (n != arr) obj.tcl_obj_release(n);
+    const sn = obj_ensure_string(n);
+    if (sn.ptr == 0 or sn.len == 0) return;
+    // Ensure the array exists so `array exists` / element writes work.
+    _ = find_or_create(n);
+    obj.tcl_obj_retain(value);
+    if (def_find(sn.ptr, sn.len)) |idx| {
+        obj.tcl_obj_release(def_entries[idx].value);
+        def_entries[idx].value = value;
+        return;
+    }
+    if (def_count >= def_entries.len) {
+        obj.tcl_obj_release(value);
+        return;
+    }
+    const nbuf = alloc(sn.len);
+    if (nbuf == 0) {
+        obj.tcl_obj_release(value);
+        return;
+    }
+    const dp: [*]u8 = @ptrFromInt(nbuf);
+    const spp: [*]const u8 = @ptrFromInt(sn.ptr);
+    for (0..sn.len) |k| dp[k] = spp[k];
+    def_entries[def_count] = .{ .name_ptr = nbuf, .name_len = sn.len, .value = value };
+    def_count += 1;
+}
+
+/// Return ``arr``'s default value TclObj, or 0 if none is set.
+pub fn array_default_get_value(arr: i32) i32 {
+    const n = normalize_ns_name(arr);
+    defer if (n != arr) obj.tcl_obj_release(n);
+    const sn = obj_ensure_string(n);
+    if (sn.ptr == 0 or sn.len == 0) return 0;
+    if (def_find(sn.ptr, sn.len)) |idx| return def_entries[idx].value;
+    return 0;
+}
+
+/// Remove ``arr``'s default (no-op if none).  Returns true if one was
+/// removed.
+pub fn array_default_clear(arr: i32) bool {
+    const n = normalize_ns_name(arr);
+    defer if (n != arr) obj.tcl_obj_release(n);
+    const sn = obj_ensure_string(n);
+    if (sn.ptr == 0 or sn.len == 0) return false;
+    if (def_find(sn.ptr, sn.len)) |idx| {
+        obj.tcl_obj_release(def_entries[idx].value);
+        obj.free_sized(def_entries[idx].name_ptr, def_entries[idx].name_len);
+        // Compact: move the last entry into the hole.
+        def_count -= 1;
+        if (idx != def_count) def_entries[idx] = def_entries[def_count];
+        return true;
+    }
+    return false;
+}
+
+/// Look up a default by the array's *raw* normalised name bytes — used
+/// by the variable-read miss path to substitute the default for a
+/// missing element.  Returns the default TclObj (borrowed) or 0.
+pub fn array_default_for_raw(name_ptr: u32, name_len: u32) i32 {
+    if (def_count == 0 or name_len == 0) return 0;
+    if (def_find(name_ptr, name_len)) |idx| return def_entries[idx].value;
+    return 0;
+}
+
 /// Bare-int variant of :func:`array_exists` for runtime-side
 /// callers that don't want a TclObj round-trip.  Returns 1 iff the
 /// array directory has an entry for the given (raw byte, length)
@@ -1262,6 +1381,10 @@ pub export fn array_unset(arr: i32) i32 {
     const n = normalize_ns_name(arr);
     defer if (n != arr) obj.tcl_obj_release(n);
     const sn = obj_ensure_string(n);
+    // ``unset`` of the whole array drops its default value too.
+    if (sn.ptr != 0 and sn.len != 0 and def_count != 0) {
+        _ = array_default_clear(n);
+    }
     if (dir_buf == 0) return obj_new_int(0);
     const hash = fnv1a(sn.ptr, sn.len);
     if (dir_find(sn.ptr, sn.len, hash)) |bucket| {

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -212,16 +212,32 @@ var dir_count: u32 = 0;
 /// interp via :fn:`dir_state_get` / :fn:`dir_state_set` so each
 /// interp's arrays stay isolated.  See ``Interp.arr_dir_*`` in
 /// ``tcl_interp_registry.zig``.
-pub const DirState = struct { buf: u32, cap: u32, count: u32 };
+pub const DirState = struct {
+    buf: u32,
+    cap: u32,
+    count: u32,
+    // ``array default`` registry — swapped with the directory so
+    // defaults are interp-local too (Copilot review on PR #482).
+    def_buf: u32,
+    def_count: u32,
+};
 
 pub fn dir_state_get() DirState {
-    return .{ .buf = dir_buf, .cap = dir_cap, .count = dir_count };
+    return .{
+        .buf = dir_buf,
+        .cap = dir_cap,
+        .count = dir_count,
+        .def_buf = def_buf,
+        .def_count = def_count,
+    };
 }
 
 pub fn dir_state_set(s: DirState) void {
     dir_buf = s.buf;
     dir_cap = s.cap;
     dir_count = s.count;
+    def_buf = s.def_buf;
+    def_count = s.def_count;
 }
 
 fn dir_init() void {
@@ -1235,13 +1251,32 @@ pub fn ensure_array_exists(arr: i32) void {
 // read-modify-write commands append / lappend / incr / dict that read
 // before writing) observe it.
 const DefEntry = struct { name_ptr: u32, name_len: u32, value: i32 };
-var def_entries: [64]DefEntry = undefined;
+const DEF_CAP: u32 = 64;
+// Heap-backed default registry, swapped per-interp alongside the array
+// directory (see DirState / swap_array_dir).  A module-global fixed
+// array would leak ``array default`` state across interpreters — a
+// default set in one interp could be read from another that reused the
+// same normalised array name.  ``def_buf`` is 0 until the first default
+// is recorded in the active interp.
+var def_buf: u32 = 0;
 var def_count: u32 = 0;
 
+inline fn def_arr() [*]DefEntry {
+    return @ptrFromInt(def_buf);
+}
+
+fn def_ensure() bool {
+    if (def_buf != 0) return true;
+    def_buf = alloc(DEF_CAP * @sizeOf(DefEntry));
+    return def_buf != 0;
+}
+
 fn def_find(name_ptr: u32, name_len: u32) ?u32 {
+    if (def_buf == 0) return null;
+    const entries = def_arr();
     var i: u32 = 0;
     while (i < def_count) : (i += 1) {
-        const e = def_entries[i];
+        const e = entries[i];
         if (e.name_len != name_len) continue;
         const ap: [*]const u8 = @ptrFromInt(e.name_ptr);
         const bp: [*]const u8 = @ptrFromInt(name_ptr);
@@ -1266,14 +1301,18 @@ pub fn array_default_set_value(arr: i32, value: i32) void {
     const sn = obj_ensure_string(n);
     if (sn.ptr == 0 or sn.len == 0) return;
     // Ensure the array exists so `array exists` / element writes work.
-    _ = find_or_create(n);
+    // Bail without recording a default if the table couldn't be
+    // materialised (alloc failure) — otherwise a later read would
+    // surface the default for a variable that isn't actually an array.
+    if (find_or_create(n) == 0) return;
     obj.tcl_obj_retain(value);
     if (def_find(sn.ptr, sn.len)) |idx| {
-        obj.tcl_obj_release(def_entries[idx].value);
-        def_entries[idx].value = value;
+        const entries = def_arr();
+        obj.tcl_obj_release(entries[idx].value);
+        entries[idx].value = value;
         return;
     }
-    if (def_count >= def_entries.len) {
+    if (def_count >= DEF_CAP or !def_ensure()) {
         obj.tcl_obj_release(value);
         return;
     }
@@ -1285,7 +1324,7 @@ pub fn array_default_set_value(arr: i32, value: i32) void {
     const dp: [*]u8 = @ptrFromInt(nbuf);
     const spp: [*]const u8 = @ptrFromInt(sn.ptr);
     for (0..sn.len) |k| dp[k] = spp[k];
-    def_entries[def_count] = .{ .name_ptr = nbuf, .name_len = sn.len, .value = value };
+    def_arr()[def_count] = .{ .name_ptr = nbuf, .name_len = sn.len, .value = value };
     def_count += 1;
 }
 
@@ -1295,7 +1334,7 @@ pub fn array_default_get_value(arr: i32) i32 {
     defer if (n != arr) obj.tcl_obj_release(n);
     const sn = obj_ensure_string(n);
     if (sn.ptr == 0 or sn.len == 0) return 0;
-    if (def_find(sn.ptr, sn.len)) |idx| return def_entries[idx].value;
+    if (def_find(sn.ptr, sn.len)) |idx| return def_arr()[idx].value;
     return 0;
 }
 
@@ -1307,11 +1346,12 @@ pub fn array_default_clear(arr: i32) bool {
     const sn = obj_ensure_string(n);
     if (sn.ptr == 0 or sn.len == 0) return false;
     if (def_find(sn.ptr, sn.len)) |idx| {
-        obj.tcl_obj_release(def_entries[idx].value);
-        obj.free_sized(def_entries[idx].name_ptr, def_entries[idx].name_len);
+        const entries = def_arr();
+        obj.tcl_obj_release(entries[idx].value);
+        obj.free_sized(entries[idx].name_ptr, entries[idx].name_len);
         // Compact: move the last entry into the hole.
         def_count -= 1;
-        if (idx != def_count) def_entries[idx] = def_entries[def_count];
+        if (idx != def_count) entries[idx] = entries[def_count];
         return true;
     }
     return false;
@@ -1322,7 +1362,7 @@ pub fn array_default_clear(arr: i32) bool {
 /// missing element.  Returns the default TclObj (borrowed) or 0.
 pub fn array_default_for_raw(name_ptr: u32, name_len: u32) i32 {
     if (def_count == 0 or name_len == 0) return 0;
-    if (def_find(name_ptr, name_len)) |idx| return def_entries[idx].value;
+    if (def_find(name_ptr, name_len)) |idx| return def_arr()[idx].value;
     return 0;
 }
 

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1285,6 +1285,25 @@ pub export fn array_unset(arr: i32) i32 {
                 const kl: u32 = @bitCast(read_i32(b + 4));
                 const v: i32 = read_i32(b + 12);
                 if (v != 0) obj.tcl_obj_release(v);
+                // Drop any element-level trace (``arr(key)``) so it
+                // doesn't survive the whole-array ``unset`` and re-fire
+                // on a later array that reuses the name (trace-1.6/1.8
+                // leakage).  The element key is stored under the
+                // normalised array name + ``(key)`` — the same form the
+                // fire path builds.
+                const tk_total: u32 = sn.len + 2 + kl;
+                const tk_buf = obj.alloc(tk_total);
+                if (tk_buf != 0) {
+                    const td: [*]u8 = @ptrFromInt(tk_buf);
+                    const ap2: [*]const u8 = @ptrFromInt(sn.ptr);
+                    for (0..sn.len) |i| td[i] = ap2[i];
+                    td[sn.len] = '(';
+                    const kpb: [*]const u8 = @ptrFromInt(kp);
+                    for (0..kl) |i| td[sn.len + 1 + i] = kpb[i];
+                    td[tk_total - 1] = ')';
+                    var_trace.remove_all(tk_buf, tk_total);
+                    obj.free_sized(tk_buf, tk_total);
+                }
                 obj.free_sized(kp, kl);
             }
             obj.free_sized(table, AR_HEADER_SIZE + cap * AR_BUCKET_SIZE);

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -207,6 +207,23 @@ var dir_buf: u32 = 0;
 var dir_cap: u32 = 0;
 var dir_count: u32 = 0;
 
+/// The active array directory.  ``tcl_array.zig`` always operates on
+/// these three module globals; the interp registry swaps them per
+/// interp via :fn:`dir_state_get` / :fn:`dir_state_set` so each
+/// interp's arrays stay isolated.  See ``Interp.arr_dir_*`` in
+/// ``tcl_interp_registry.zig``.
+pub const DirState = struct { buf: u32, cap: u32, count: u32 };
+
+pub fn dir_state_get() DirState {
+    return .{ .buf = dir_buf, .cap = dir_cap, .count = dir_count };
+}
+
+pub fn dir_state_set(s: DirState) void {
+    dir_buf = s.buf;
+    dir_cap = s.cap;
+    dir_count = s.count;
+}
+
 fn dir_init() void {
     if (dir_cap != 0) return;
     dir_cap = DIR_INITIAL_CAP;

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-19T14:39:24Z",
+  "generated_at": "2026-05-21T19:39:14Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -24,8 +24,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 11,
-      "passed_min": 75,
+      "failed_max": 9,
+      "passed_min": 77,
       "skipped": 60,
       "total": 146
     },
@@ -105,8 +105,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 173,
-      "passed_min": 136,
+      "failed_max": 3,
+      "passed_min": 306,
       "skipped": 8,
       "total": 317
     },
@@ -123,8 +123,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 3,
-      "passed_min": 77,
+      "failed_max": 1,
+      "passed_min": 79,
       "skipped": 77,
       "total": 157
     },
@@ -132,17 +132,17 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 19,
-      "passed_min": 1099,
-      "skipped": 1050,
+      "failed_max": 26,
+      "passed_min": 2118,
+      "skipped": 24,
       "total": 2168
     },
     "expr-old": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 5,
-      "passed_min": 432,
+      "failed_max": 0,
+      "passed_min": 437,
       "skipped": 24,
       "total": 461
     },
@@ -165,11 +165,11 @@
       "total": 9
     },
     "foreach": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 1,
-      "passed_min": 42,
+      "failed_max": 0,
+      "passed_min": 43,
       "skipped": 0,
       "total": 43
     },
@@ -222,17 +222,17 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 58,
-      "passed_min": 228,
+      "failed_max": 57,
+      "passed_min": 229,
       "skipped": 1,
       "total": 287
     },
     "join": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 1,
-      "passed_min": 9,
+      "failed_max": 0,
+      "passed_min": 10,
       "skipped": 0,
       "total": 10
     },
@@ -357,8 +357,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 29,
-      "passed_min": 356,
+      "failed_max": 2,
+      "passed_min": 383,
       "skipped": 0,
       "total": 385
     },
@@ -384,8 +384,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 19,
-      "passed_min": 107,
+      "failed_max": 17,
+      "passed_min": 109,
       "skipped": 0,
       "total": 126
     },
@@ -411,8 +411,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 9,
-      "passed_min": 149,
+      "failed_max": 69,
+      "passed_min": 89,
       "skipped": 0,
       "total": 158
     },
@@ -429,8 +429,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 32,
-      "passed_min": 42,
+      "failed_max": 29,
+      "passed_min": 45,
       "skipped": 0,
       "total": 74
     },
@@ -525,11 +525,11 @@
       "total": 63
     },
     "switch": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 29,
-      "passed_min": 84,
+      "failed_max": 0,
+      "passed_min": 113,
       "skipped": 0,
       "total": 113
     },
@@ -552,7 +552,7 @@
       "total": 7
     },
     "uplevel": {
-      "bucket": "W-clean",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
       "failed_max": 0,
@@ -561,7 +561,7 @@
       "total": 57
     },
     "upvar": {
-      "bucket": "W-clean",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
       "failed_max": 0,
@@ -573,9 +573,9 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 56,
-      "passed_min": 254,
-      "skipped": 152,
+      "failed_max": 115,
+      "passed_min": 318,
+      "skipped": 29,
       "total": 462
     },
     "var": {
@@ -597,11 +597,11 @@
       "total": 46
     },
     "while-old": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 3,
-      "passed_min": 12,
+      "failed_max": 0,
+      "passed_min": 15,
       "skipped": 0,
       "total": 15
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-21T19:39:14Z",
+  "generated_at": "2026-05-21T20:28:14Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -429,8 +429,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 29,
-      "passed_min": 45,
+      "failed_max": 24,
+      "passed_min": 50,
       "skipped": 0,
       "total": 74
     },
@@ -582,8 +582,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 19,
-      "passed_min": 196,
+      "failed_max": 18,
+      "passed_min": 197,
       "skipped": 4,
       "total": 219
     },

--- a/tests/external/run_tcl9_tests.py
+++ b/tests/external/run_tcl9_tests.py
@@ -311,6 +311,13 @@ namespace eval ::tcl::unsupported::clock {
         }
         if {[llength $args] == 1} {
             set opt [lindex $args 0]
+            # ``-init-complete`` is the setup signal init.tcl's clock
+            # ensemble block sends once the ::clock map is installed.
+            # Real Tcl 9's C accessor accepts it as a no-op; mirror that
+            # so sourcing the upstream init.tcl completes.
+            if {$opt eq "-init-complete"} {
+                return
+            }
             if {[info exists state($opt)]} {
                 return $state($opt)
             }

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -133,6 +133,42 @@ class TestStdlibPrelude:
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "a(x) = 1\na(y) = 22\n"
 
+    def test_opt_package_bundled_runs_without_tcl_library(self, tmp_path):
+        """``package require opt`` resolves through the package's
+        ``pkgIndex.tcl`` (``source``-style ``ifneeded``) — the compiler
+        bundles ``optparse.tcl`` and its transitive ``::tcl::Opt*``
+        helpers, so the option-parsing proc it defines runs entirely
+        self-contained with no run-time library."""
+        src = (
+            "package require opt\n"
+            "::tcl::OptProc seethrough {\n"
+            '    {-a -int 1 "first option"}\n'
+            '    {-b -int 2 "second option"}\n'
+            "} {\n"
+            '    puts "a=$a b=$b"\n'
+            "}\n"
+            "seethrough -a 10 -b 20\n"
+            "seethrough\n"
+        )
+        wasm = self._link(src, tmp_path, with_library=True)
+        # No TCL_LIBRARY, no preopen — opt is compiled into the bundle.
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "a=10 b=20\na=1 b=2\n"
+
+    def test_package_require_not_bundled_without_library(self, tmp_path, monkeypatch):
+        """With no library the package source can't be discovered, so an
+        opt command still errors — proving the compile-time bundling, not
+        a runtime fallback, is what resolved it above."""
+        monkeypatch.delenv("TCL_LIBRARY", raising=False)
+        src = (
+            "package require opt\n"
+            "set rc [catch {::tcl::OptProc f {} {}} m]\n"
+            'puts "rc=$rc"\n'
+        )
+        wasm = self._link(src, tmp_path, with_library=False)
+        _, out = _run_wasm(wasm, capture_stdout=True)
+        assert out == "rc=1\n"
+
     def test_non_allowlisted_command_not_bundled_by_default(self, tmp_path, monkeypatch):
         """A library command outside the validated allowlist is not
         bundled by default (it would fall back to the runtime
@@ -247,3 +283,49 @@ class TestStdlibPreludePruning:
         module = lower_to_ir("puts [foo]\n")
         apply_stdlib_prelude(module, lib, allowlist=None)
         assert "::foo" in module.procedures
+
+
+class TestPackageRequireBundling:
+    """``package require NAME`` bundles the package's ``source``-style
+    ``pkgIndex.tcl`` entry at compile time.  Synthetic library so the
+    discovery + bundling logic is exercised without the real Tcl tree."""
+
+    def _make_lib(self, tmp_path):
+        lib = tmp_path / "lib"
+        (lib / "mypkg").mkdir(parents=True)
+        (lib / "mypkg" / "mypkg.tcl").write_text(
+            "proc ::mypkg::hello {} { return hi }\n"
+            "proc ::mypkg::unused {} { return nope }\n"
+        )
+        (lib / "mypkg" / "pkgIndex.tcl").write_text(
+            "package ifneeded mypkg 1.0 "
+            "[list source -encoding utf-8 [file join $dir mypkg.tcl]]\n"
+        )
+        return lib
+
+    def _bundled(self, src, lib):
+        from core.compiler.lowering import lower_to_ir
+        from core.compiler.stdlib_prelude import apply_stdlib_prelude
+
+        module = lower_to_ir(src)
+        before = set(module.procedures)
+        apply_stdlib_prelude(module, lib, allowlist=None)
+        return module, sorted(q.lstrip(":") for q in (set(module.procedures) - before))
+
+    def test_required_package_source_is_bundled(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        _, bundled = self._bundled("package require mypkg\nputs [::mypkg::hello]\n", lib)
+        assert "mypkg::hello" in bundled
+
+    def test_dynamic_package_name_not_bundled(self, tmp_path):
+        """``package require $name`` is a run-time computation — the
+        compiler can't see the name, so nothing is bundled (the runtime
+        package machinery handles it)."""
+        lib = self._make_lib(tmp_path)
+        _, bundled = self._bundled("set name mypkg\npackage require $name\n", lib)
+        assert bundled == []
+
+    def test_no_require_means_no_bundle(self, tmp_path):
+        lib = self._make_lib(tmp_path)
+        _, bundled = self._bundled("puts hello\n", lib)
+        assert bundled == []

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -69,11 +69,7 @@ class TestStdlibAutoLoad:
         tracking, which the WASM runtime does not maintain).  Sourcing the
         upstream ``parray.tcl`` this way must define ``::parray`` exactly
         as a flagless source would."""
-        out = self._run(
-            "source -nopkg /tcl-lib/parray.tcl\n"
-            "array set a {x 9}\n"
-            "parray a\n"
-        )
+        out = self._run("source -nopkg /tcl-lib/parray.tcl\narray set a {x 9}\nparray a\n")
         assert out == "a(x) = 9\n"
 
 

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -62,6 +62,20 @@ class TestStdlibAutoLoad:
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "rc=1\n"
 
+    def test_source_nopkg_behaves_like_plain_source(self):
+        """``source -nopkg fileName`` is the undocumented 3-word form the
+        real ``::tcl::Pkg::source`` (init.tcl) uses.  Tcl 9 treats it as a
+        plain source (the ``-nopkg`` flag only suppresses package-files
+        tracking, which the WASM runtime does not maintain).  Sourcing the
+        upstream ``parray.tcl`` this way must define ``::parray`` exactly
+        as a flagless source would."""
+        out = self._run(
+            "source -nopkg /tcl-lib/parray.tcl\n"
+            "array set a {x 9}\n"
+            "parray a\n"
+        )
+        assert out == "a(x) = 9\n"
+
 
 @_needs_library
 class TestStdlibPrelude:

--- a/tests/test_wasm_autoload.py
+++ b/tests/test_wasm_autoload.py
@@ -160,11 +160,7 @@ class TestStdlibPrelude:
         opt command still errors — proving the compile-time bundling, not
         a runtime fallback, is what resolved it above."""
         monkeypatch.delenv("TCL_LIBRARY", raising=False)
-        src = (
-            "package require opt\n"
-            "set rc [catch {::tcl::OptProc f {} {}} m]\n"
-            'puts "rc=$rc"\n'
-        )
+        src = 'package require opt\nset rc [catch {::tcl::OptProc f {} {}} m]\nputs "rc=$rc"\n'
         wasm = self._link(src, tmp_path, with_library=False)
         _, out = _run_wasm(wasm, capture_stdout=True)
         assert out == "rc=1\n"
@@ -294,12 +290,10 @@ class TestPackageRequireBundling:
         lib = tmp_path / "lib"
         (lib / "mypkg").mkdir(parents=True)
         (lib / "mypkg" / "mypkg.tcl").write_text(
-            "proc ::mypkg::hello {} { return hi }\n"
-            "proc ::mypkg::unused {} { return nope }\n"
+            "proc ::mypkg::hello {} { return hi }\nproc ::mypkg::unused {} { return nope }\n"
         )
         (lib / "mypkg" / "pkgIndex.tcl").write_text(
-            "package ifneeded mypkg 1.0 "
-            "[list source -encoding utf-8 [file join $dir mypkg.tcl]]\n"
+            "package ifneeded mypkg 1.0 [list source -encoding utf-8 [file join $dir mypkg.tcl]]\n"
         )
         return lib
 

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -357,3 +357,30 @@ class TestEnsembleUnknownRetry:
         )
         stdout, _ = _run(src)
         assert stdout.splitlines() == ["1", "no zzz"]
+
+
+class TestNamespaceEvalErrorInfo:
+    """An error propagating out of ``namespace eval`` gets the
+    ``(in namespace eval "::ns" script line N)`` errorInfo frame (the
+    namespace-eval analogue of ``(procedure "X" line N)``), with the
+    surrounding ``invoked from within`` callsite frame added by the
+    interpreter.  (namespace-25.6/25.7.)  Driven through a dynamic
+    ``eval`` so the body is interpreted (matching how tcltest runs test
+    bodies) rather than compile-time inlined.
+    """
+
+    def test_namespace_eval_errorinfo_frame(self) -> None:
+        src = (
+            "namespace eval test_ns_1 {}\n"
+            "set s {catch {namespace eval test_ns_1 {xxxx}} msg ; set ::errorInfo}\n"
+            "puts [eval $s]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == (
+            'invalid command name "xxxx"\n'
+            "    while executing\n"
+            '"xxxx"\n'
+            '    (in namespace eval "::test_ns_1" script line 1)\n'
+            "    invoked from within\n"
+            '"namespace eval test_ns_1 {xxxx}"'
+        )

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -518,3 +518,17 @@ class TestEnsembleUnknownFqnName:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "::foo|one two three"
+
+
+class TestEnsembleConfigQuoting:
+    """``namespace ensemble config`` renders each option value as a Tcl
+    list element — a simple word is unbraced (``-unknown bar`` not
+    ``-unknown {bar}``).  (namespace-47.5.)"""
+
+    def test_unknown_word_unbraced(self) -> None:
+        src = (
+            "namespace ensemble create -command foo -unknown bar\n"
+            "puts [dict get [namespace ensemble config foo] -unknown]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "bar"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -293,3 +293,23 @@ class TestArrayDefault:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "0"
+
+
+class TestAppendCreatesMissingVariable:
+    """``append`` on an unset variable treats it as empty and creates it
+    (Tcl semantics) rather than raising ``can't read "<var>": no such
+    variable``.  The compiled ``append`` emitter read the variable
+    strictly; it now uses the lenient read like ``lappend`` / ``incr``.
+    """
+
+    def test_append_missing_scalar(self) -> None:
+        stdout, _ = _run("append s abc\nputs $s\n")
+        assert stdout.strip() == "abc"
+
+    def test_append_missing_scalar_no_error(self) -> None:
+        stdout, _ = _run('set rc [catch {append s abc} m]\nputs "$rc $s"\n')
+        assert stdout.strip() == "0 abc"
+
+    def test_append_missing_array_element(self) -> None:
+        stdout, _ = _run("set a(y) 1\nappend a(x) bar\nputs $a(x)\n")
+        assert stdout.strip() == "bar"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -236,3 +236,60 @@ class TestUnsetRemovesVariableTrace:
         stdout, _ = _run(src)
         # cb fires once on the first read; after ``unset a`` it's gone.
         assert stdout.splitlines() == ["STALE", "v2=again"]
+
+
+class TestArrayDefault:
+    """``array default set|get|exists|unset`` (Tcl 8.7/9, var-24.x): a
+    per-array fallback returned when a missing element is read.  The
+    default does not create elements — ``info exists`` / ``array size``
+    ignore it — but element reads and read-modify-write ``incr`` observe
+    it.
+    """
+
+    def test_default_get_and_read(self) -> None:
+        src = (
+            "array set ary {a 3}\n"
+            "array default set ary 7\n"
+            "puts [list $ary(a) $ary(b) [info exist ary(a)]"
+            " [info exist ary(b)] [array default get ary]]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "3 7 1 0 7"
+
+    def test_default_exists_and_unset(self) -> None:
+        src = (
+            "array set ary {a 3}\n"
+            "puts [array default exists ary]\n"
+            "array default set ary 7\n"
+            "puts [array default exists ary]\n"
+            "array default unset ary\n"
+            "puts [array default exists ary]\n"
+            'set rc [catch {array default get ary} m]\n'
+            'puts "$rc $m"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == ["0", "1", "0", "1 array has no default value"]
+
+    def test_default_set_creates_empty_array(self) -> None:
+        # ``array default set`` on a non-existent variable makes it an
+        # empty array; the default doesn't add elements.
+        src = (
+            "array default set ary grill\n"
+            'puts "[array size ary] [info exist ary(x)] [array exists ary]"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "0 0 1"
+
+    def test_default_observed_by_incr(self) -> None:
+        src = "array default set a 7\nincr a(x)\nputs $a(x)\n"
+        stdout, _ = _run(src)
+        assert stdout.strip() == "8"
+
+    def test_default_dropped_on_unset(self) -> None:
+        src = (
+            "array default set a 7\n"
+            "unset a\n"
+            "puts [array default exists a]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "0"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -895,3 +895,57 @@ class TestCommandTraceLifecycle:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "::foo {} delete"
+
+
+class TestCommandTraceReentrancyAndErrors:
+    """Command-trace callbacks that error or that rename/delete the very
+    command being renamed must not break the triggering operation.
+
+    * A callback's error result is discarded (trace-20.14 / 20.16).
+    * When the callback deletes/renames the command during the rename
+      trace, the outer rename becomes a silent no-op rather than raising
+      ``command doesn't exist`` (trace-20.9 / 20.10 / 20.11).
+    """
+
+    def test_rename_trace_error_discarded(self) -> None:
+        src = (
+            "proc foo {} {}\n"
+            "trace add command foo rename {error}\n"
+            "puts [list [rename foo bar] [rename bar {}]]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{} {}"
+
+    def test_delete_trace_error_discarded(self) -> None:
+        src = (
+            "proc foo {} {}\n"
+            "trace add command foo delete {error}\n"
+            'puts ">[rename foo {}]<"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "><"
+
+    def test_callback_deletes_command_no_error(self) -> None:
+        src = (
+            'proc traceCmddelete {cmd old new op} { rename $old "" }\n'
+            "proc foo {} {}\n"
+            "trace add command foo rename [list traceCmddelete foo]\n"
+            "rename foo bar\n"
+            "puts [list [info commands foo] [info commands bar]]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{} {}"
+
+    def test_callback_renames_command_no_error(self) -> None:
+        src = (
+            "proc traceCmdrename {cmd old new op} { rename $old someothername }\n"
+            "proc foo {} {}\n"
+            "catch {rename someothername {}}\n"
+            "trace add command foo rename [list traceCmdrename foo]\n"
+            "rename foo bar\n"
+            "set r [list [info commands foo] [info commands bar] [info commands someothername]]\n"
+            "rename someothername {}\n"
+            "puts $r\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{} {} someothername"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -384,3 +384,25 @@ class TestNamespaceEvalErrorInfo:
             "    invoked from within\n"
             '"namespace eval test_ns_1 {xxxx}"'
         )
+
+
+class TestEnsembleUnknownBadCode:
+    """An ensemble ``-unknown`` handler that returns a non-ok / non-error
+    code (break / continue / return) must raise ``unknown subcommand
+    handler returned bad code: <name>`` rather than letting the control-
+    flow signal leak out of the ensemble dispatch (namespace-47.4).
+    """
+
+    def test_break_from_unknown_handler(self) -> None:
+        src = (
+            "namespace eval ns {\n"
+            "  proc Magic {e s args} { return -code break }\n"
+            "  namespace ensemble create -unknown ::ns::Magic\n"
+            "}\n"
+            "puts [catch {ns spong} msg]\nputs $msg\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == [
+            "1",
+            "unknown subcommand handler returned bad code: break",
+        ]

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -782,3 +782,34 @@ class TestTraceCreatesArrayElement:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "0"
+
+
+class TestBareArrayElementReadImport:
+    """A command-form array element read (``set arr(key)``) must pull in
+    the ``tcl_array_get`` runtime import even when nothing writes the
+    array elsewhere in the module.  The import scanner previously only
+    registered ``tcl_array_get`` for the substitution form (``$arr(k)``)
+    and for array writes, so a lone ``set arr(key)`` read silently fell
+    back to a null push — skipping the actual lookup (and any variable
+    read traces).  trace-1.x relies on the read firing.
+    """
+
+    def test_bare_set_read_returns_array_default(self) -> None:
+        # With no write to ``a`` anywhere, the read must still consult
+        # the array (here returning its configured default), proving the
+        # element read is emitted rather than short-circuited to null.
+        src = "array default set a NADA\nputs [set a(missing)]\n"
+        stdout, _ = _run(src)
+        assert stdout.strip() == "NADA"
+
+    def test_bare_set_read_fires_read_trace(self) -> None:
+        src = (
+            "proc tc {n1 n2 op} { global ran; set ran FIRED }\n"
+            "set ran {}\n"
+            "set a(0) 1\n"
+            "trace add variable a(0) read tc\n"
+            "set v [set a(0)]\n"
+            'puts "$v $ran"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "1 FIRED"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -603,3 +603,39 @@ class TestTraceOpListValidation:
     def test_execution_op_list(self) -> None:
         stdout, _ = _run('proc x {} {}\nset rc [catch {trace add execution x {bogus} a} m]\nputs "$rc|$m"\n')
         assert stdout.strip() == '1|bad operation "bogus": must be enter, leave, enterstep, or leavestep'
+
+
+class TestCommandTraces:
+    """``trace add command CMD {rename delete} CB`` fires when CMD is
+    renamed or deleted, as ``CB oldFQN newFQN op`` (trace-20.x)."""
+
+    def test_delete_via_rename_empty(self) -> None:
+        src = (
+            "eval {proc traceCommand {o n op} { global info; set info [list $o $n $op] }\n"
+            "proc foo {} {}\n"
+            "trace add command foo delete traceCommand\n"
+            'rename foo ""\n'
+            "puts $info}\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "::foo {} delete"
+
+    def test_rename(self) -> None:
+        src = (
+            "eval {proc traceCommand {o n op} { global info; set info [list $o $n $op] }\n"
+            "proc foo {} {}\n"
+            "trace add command foo rename traceCommand\n"
+            "rename foo bar\n"
+            "puts $info}\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "::foo ::bar rename"
+
+    def test_info_command(self) -> None:
+        src = (
+            "eval {proc foo {} {}\n"
+            "trace add command foo {rename delete} cb\n"
+            "puts [trace info command foo]}\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{{delete rename} cb}"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -406,3 +406,44 @@ class TestEnsembleUnknownBadCode:
             "1",
             "unknown subcommand handler returned bad code: break",
         ]
+
+
+class TestTraceCommandArity:
+    """``trace`` argument/option validation (trace-14.0.x / 14.1-14.5):
+    wrong argument counts and unknown options must raise the canonical
+    Tcl diagnostics instead of silently succeeding."""
+
+    def test_add_variable_wrong_args(self) -> None:
+        stdout, _ = _run('puts [catch {trace add variable foo bar} m]\nputs $m\n')
+        assert stdout.splitlines() == [
+            "1",
+            'wrong # args: should be "trace add variable name opList command"',
+        ]
+
+    def test_remove_variable_too_many_args(self) -> None:
+        stdout, _ = _run('puts [catch {trace remove variable foo bar baz boo} m]\nputs $m\n')
+        assert stdout.splitlines() == [
+            "1",
+            'wrong # args: should be "trace remove variable name opList command"',
+        ]
+
+    def test_info_variable_wrong_args(self) -> None:
+        stdout, _ = _run('puts [catch {trace info variable foo bar} m]\nputs $m\n')
+        assert stdout.splitlines() == [
+            "1",
+            'wrong # args: should be "trace info variable name"',
+        ]
+
+    def test_bad_option(self) -> None:
+        stdout, _ = _run('puts [catch {trace gorp} m]\nputs $m\n')
+        assert stdout.splitlines() == [
+            "1",
+            'bad option "gorp": must be add, info, or remove',
+        ]
+
+    def test_no_args(self) -> None:
+        stdout, _ = _run('puts [catch {trace} m]\nputs $m\n')
+        assert stdout.splitlines() == [
+            "1",
+            'wrong # args: should be "trace option ?arg ...?"',
+        ]

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -581,3 +581,25 @@ class TestExecutionTraces:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "{{enter leave} bar}"
+
+
+class TestTraceOpListValidation:
+    """Trace op-lists are validated against the type's allowed ops; an
+    invalid op, an abbreviation, or an empty list raises the canonical
+    diagnostic (trace-14.6.x)."""
+
+    def test_bad_op_variable(self) -> None:
+        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add variable x {y z w} a} m]\nputs "$rc|$m"\n')
+        assert stdout.strip() == '1|bad operation "y": must be array, read, unset, or write'
+
+    def test_null_op_list_command(self) -> None:
+        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add command x {} a} m]\nputs "$rc|$m"\n')
+        assert stdout.strip() == '1|bad operation list "": must be one or more of delete or rename'
+
+    def test_abbreviation_rejected(self) -> None:
+        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add variable x {r} a} m]\nputs "$rc|$m"\n')
+        assert stdout.strip() == '1|bad operation "r": must be array, read, unset, or write'
+
+    def test_execution_op_list(self) -> None:
+        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add execution x {bogus} a} m]\nputs "$rc|$m"\n')
+        assert stdout.strip() == '1|bad operation "bogus": must be enter, leave, enterstep, or leavestep'

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -147,3 +147,36 @@ class TestErrorRecursionLimit:
         # diagnostic, not whatever leaked through from the wasm trap.
         assert lines[0] == "1"
         assert "too many nested evaluations" in lines[1]
+
+
+class TestCatchBracedArgToProc:
+    """A braced argument to a user proc inside a ``catch`` (or any
+    implicit-return / tail position) must keep its literal bytes — braces
+    suppress all substitution.  Previously ``_emit_call_stmt_tail`` pushed
+    the arg through ``_emit_value`` without the ``was_braced`` flag the
+    statement path uses, so ``catch {q {puts "$x $y"}} m`` re-substituted
+    the brace-protected ``$x`` / ``$y`` and trapped under
+    ``can't read "y": no such variable``.  This is the contract opt's
+    ``::tcl::OptProc`` (``uplevel 1 [list ::proc ... "...$body"]`` wrapped
+    in the caller's catch) depends on.
+    """
+
+    def test_catch_braced_dollar_arg_not_substituted(self) -> None:
+        src = (
+            "proc q {a} { return $a }\n"
+            'catch {q {puts "$x $y"}} m\n'
+            'puts "m=$m"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == 'm=puts "$x $y"'
+
+    def test_catch_braced_arg_after_leading_stmt(self) -> None:
+        # The proc call is the *last* (captured) statement of a
+        # multi-statement catch body — the keep-result tail path.
+        src = (
+            "proc q {a} { return $a }\n"
+            'catch {set zz 1\nq {puts "$x $y"}} m\n'
+            'puts "m=$m"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == 'm=puts "$x $y"'

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -739,3 +739,46 @@ class TestGlobalLenientReadFreshness:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "A FROMPROC Z"
+
+
+class TestTraceCreatesArrayElement:
+    """``trace add variable arr(key)`` on an absent ``arr`` materialises
+    ``arr`` as an (empty) array — reference Tcl behaviour.  A subsequent
+    element read then reports ``no such element in array`` (and is an
+    array for ``array exists``) instead of ``no such variable``
+    (trace-1.4 / trace-10.1 wording).
+    """
+
+    def test_element_trace_makes_array_exist(self) -> None:
+        src = (
+            "unset -nocomplain x\n"
+            "trace add variable x(2) read traceCb\n"
+            "proc traceCb {a b c} {}\n"
+            "puts [array exists x]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "1"
+
+    def test_missing_element_reports_array_wording(self) -> None:
+        src = (
+            "unset -nocomplain x\n"
+            "proc traceCb {a b c} {}\n"
+            "trace add variable x(2) read traceCb\n"
+            "set rc [catch {set y $x(2)} m]\n"
+            'puts "$rc $m"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == '1 can\'t read "x(2)": no such element in array'
+
+    def test_does_not_clobber_existing_scalar(self) -> None:
+        # A scalar of the same name must not be silently turned into an
+        # array by an element-trace install.
+        src = (
+            "unset -nocomplain x\n"
+            "set x scalar\n"
+            "proc traceCb {a b c} {}\n"
+            "catch {trace add variable x(2) read traceCb}\n"
+            "puts [array exists x]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "0"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -180,3 +180,59 @@ class TestCatchBracedArgToProc:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == 'm=puts "$x $y"'
+
+
+class TestUnsetRemovesVariableTrace:
+    """Tcl drops a variable's traces when it is ``unset`` (after the
+    unset callbacks fire).  The WASM runtime previously kept the trace
+    registered, so a later variable that reused the name re-fired the
+    stale callback — the trace-2.x cascade that eventually trapped via
+    re-entrant xlinks lookup.  ``unset`` now removes scalar, array-name
+    and array-element traces.
+    """
+
+    def test_scalar_trace_gone_after_unset(self) -> None:
+        src = (
+            "proc cb {args} { puts FIRED }\n"
+            "trace add variable x write cb\n"
+            "set x 1\n"
+            "unset x\n"
+            'puts "after=[trace info variable x]"\n'
+            "set x 2\n"
+            'puts "x=$x"\n'
+        )
+        stdout, _ = _run(src)
+        # cb fires once (on ``set x 1``); after unset the trace is gone,
+        # so ``set x 2`` is silent.
+        assert stdout.splitlines() == ["FIRED", "after=", "x=2"]
+
+    def test_local_trace_gone_after_unset(self) -> None:
+        src = (
+            "proc p {} {\n"
+            "    proc cb {args} { puts FIRED }\n"
+            "    trace add variable y write cb\n"
+            "    set y 1\n"
+            "    unset y\n"
+            "    set y 2\n"
+            '    puts "y=$y"\n'
+            "}\n"
+            "p\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == ["FIRED", "y=2"]
+
+    def test_array_element_trace_gone_after_whole_array_unset(self) -> None:
+        # A stale element trace must not survive ``unset`` of the whole
+        # array and re-fire on a re-created array (trace-1.6 leakage).
+        src = (
+            "proc cb {n1 n2 op} { puts STALE }\n"
+            "set a(2) zzz\n"
+            "trace add variable a(2) read cb\n"
+            "set v $a(2)\n"
+            "unset a\n"
+            "set a(2) again\n"
+            'puts "v2=$a(2)"\n'
+        )
+        stdout, _ = _run(src)
+        # cb fires once on the first read; after ``unset a`` it's gone.
+        assert stdout.splitlines() == ["STALE", "v2=again"]

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -313,3 +313,47 @@ class TestAppendCreatesMissingVariable:
     def test_append_missing_array_element(self) -> None:
         stdout, _ = _run("set a(y) 1\nappend a(x) bar\nputs $a(x)\n")
         assert stdout.strip() == "bar"
+
+
+class TestEnsembleUnknownRetry:
+    """``namespace ensemble create -unknown HANDLER`` retry protocol: on
+    an unknown subcommand the handler runs, then the ensemble re-resolves
+    (the handler may have created the subcommand) and dispatches it.  A
+    non-empty handler result is a rewritten command prefix invoked in
+    place of the ensemble call.  (namespace-47.1/47.3.)
+    """
+
+    def test_handler_creates_then_retry(self) -> None:
+        src = (
+            "namespace eval ns {\n"
+            "  namespace export *\n"
+            "  proc mk {ens sub args} { proc $sub args { return done } }\n"
+            "  namespace ensemble create -unknown ::ns::mk\n"
+            "}\n"
+            "puts [ns hello a b]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "done"
+
+    def test_handler_nonempty_rewrite(self) -> None:
+        src = (
+            "proc real {a b} { return \"real:$a:$b\" }\n"
+            "namespace eval ns {\n"
+            "  proc mk {ens sub args} { return [list ::real X] }\n"
+            "  namespace ensemble create -unknown ::ns::mk\n"
+            "}\n"
+            "puts [ns foo Y]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "real:X:Y"
+
+    def test_handler_error_propagates(self) -> None:
+        src = (
+            "namespace eval ns {\n"
+            "  proc mk {ens sub args} { return -code error \"no $sub\" }\n"
+            "  namespace ensemble create -unknown ::ns::mk\n"
+            "}\n"
+            "puts [catch {ns zzz} m]\nputs $m\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == ["1", "no zzz"]

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -162,22 +162,14 @@ class TestCatchBracedArgToProc:
     """
 
     def test_catch_braced_dollar_arg_not_substituted(self) -> None:
-        src = (
-            "proc q {a} { return $a }\n"
-            'catch {q {puts "$x $y"}} m\n'
-            'puts "m=$m"\n'
-        )
+        src = 'proc q {a} { return $a }\ncatch {q {puts "$x $y"}} m\nputs "m=$m"\n'
         stdout, _ = _run(src)
         assert stdout.strip() == 'm=puts "$x $y"'
 
     def test_catch_braced_arg_after_leading_stmt(self) -> None:
         # The proc call is the *last* (captured) statement of a
         # multi-statement catch body — the keep-result tail path.
-        src = (
-            "proc q {a} { return $a }\n"
-            'catch {set zz 1\nq {puts "$x $y"}} m\n'
-            'puts "m=$m"\n'
-        )
+        src = 'proc q {a} { return $a }\ncatch {set zz 1\nq {puts "$x $y"}} m\nputs "m=$m"\n'
         stdout, _ = _run(src)
         assert stdout.strip() == 'm=puts "$x $y"'
 
@@ -264,7 +256,7 @@ class TestArrayDefault:
             "puts [array default exists ary]\n"
             "array default unset ary\n"
             "puts [array default exists ary]\n"
-            'set rc [catch {array default get ary} m]\n'
+            "set rc [catch {array default get ary} m]\n"
             'puts "$rc $m"\n'
         )
         stdout, _ = _run(src)
@@ -286,11 +278,7 @@ class TestArrayDefault:
         assert stdout.strip() == "8"
 
     def test_default_dropped_on_unset(self) -> None:
-        src = (
-            "array default set a 7\n"
-            "unset a\n"
-            "puts [array default exists a]\n"
-        )
+        src = "array default set a 7\nunset a\nputs [array default exists a]\n"
         stdout, _ = _run(src)
         assert stdout.strip() == "0"
 
@@ -337,7 +325,7 @@ class TestEnsembleUnknownRetry:
 
     def test_handler_nonempty_rewrite(self) -> None:
         src = (
-            "proc real {a b} { return \"real:$a:$b\" }\n"
+            'proc real {a b} { return "real:$a:$b" }\n'
             "namespace eval ns {\n"
             "  proc mk {ens sub args} { return [list ::real X] }\n"
             "  namespace ensemble create -unknown ::ns::mk\n"
@@ -350,7 +338,7 @@ class TestEnsembleUnknownRetry:
     def test_handler_error_propagates(self) -> None:
         src = (
             "namespace eval ns {\n"
-            "  proc mk {ens sub args} { return -code error \"no $sub\" }\n"
+            '  proc mk {ens sub args} { return -code error "no $sub" }\n'
             "  namespace ensemble create -unknown ::ns::mk\n"
             "}\n"
             "puts [catch {ns zzz} m]\nputs $m\n"
@@ -414,35 +402,35 @@ class TestTraceCommandArity:
     Tcl diagnostics instead of silently succeeding."""
 
     def test_add_variable_wrong_args(self) -> None:
-        stdout, _ = _run('puts [catch {trace add variable foo bar} m]\nputs $m\n')
+        stdout, _ = _run("puts [catch {trace add variable foo bar} m]\nputs $m\n")
         assert stdout.splitlines() == [
             "1",
             'wrong # args: should be "trace add variable name opList command"',
         ]
 
     def test_remove_variable_too_many_args(self) -> None:
-        stdout, _ = _run('puts [catch {trace remove variable foo bar baz boo} m]\nputs $m\n')
+        stdout, _ = _run("puts [catch {trace remove variable foo bar baz boo} m]\nputs $m\n")
         assert stdout.splitlines() == [
             "1",
             'wrong # args: should be "trace remove variable name opList command"',
         ]
 
     def test_info_variable_wrong_args(self) -> None:
-        stdout, _ = _run('puts [catch {trace info variable foo bar} m]\nputs $m\n')
+        stdout, _ = _run("puts [catch {trace info variable foo bar} m]\nputs $m\n")
         assert stdout.splitlines() == [
             "1",
             'wrong # args: should be "trace info variable name"',
         ]
 
     def test_bad_option(self) -> None:
-        stdout, _ = _run('puts [catch {trace gorp} m]\nputs $m\n')
+        stdout, _ = _run("puts [catch {trace gorp} m]\nputs $m\n")
         assert stdout.splitlines() == [
             "1",
             'bad option "gorp": must be add, info, or remove',
         ]
 
     def test_no_args(self) -> None:
-        stdout, _ = _run('puts [catch {trace} m]\nputs $m\n')
+        stdout, _ = _run("puts [catch {trace} m]\nputs $m\n")
         assert stdout.splitlines() == [
             "1",
             'wrong # args: should be "trace option ?arg ...?"',
@@ -496,7 +484,7 @@ class TestNamespaceUnknownHandler:
 
     def test_global_handler_inherited(self) -> None:
         src = (
-            "proc ::myunknown {args} { return \"MYUNKNOWN: $args\" }\n"
+            'proc ::myunknown {args} { return "MYUNKNOWN: $args" }\n'
             "namespace eval :: { namespace unknown ::myunknown }\n"
             "set result [namespace eval foo { dummy a b c }]\n"
             "namespace eval :: { namespace unknown {} }\n"
@@ -543,11 +531,15 @@ class TestTraceCommandTargetExists:
         assert stdout.strip() == '1|unknown command "thisdoesntexist"'
 
     def test_remove_execution_missing(self) -> None:
-        stdout, _ = _run('set rc [catch {trace remove execution nope {enter} bar} r]\nputs "$rc|$r"\n')
+        stdout, _ = _run(
+            'set rc [catch {trace remove execution nope {enter} bar} r]\nputs "$rc|$r"\n'
+        )
         assert stdout.strip() == '1|unknown command "nope"'
 
     def test_existing_command_ok(self) -> None:
-        stdout, _ = _run('proc foo {} {}\nset rc [catch {trace info command foo} r]\nputs "$rc|$r"\n')
+        stdout, _ = _run(
+            'proc foo {} {}\nset rc [catch {trace info command foo} r]\nputs "$rc|$r"\n'
+        )
         assert stdout.strip() == "0|"
 
 
@@ -589,20 +581,31 @@ class TestTraceOpListValidation:
     diagnostic (trace-14.6.x)."""
 
     def test_bad_op_variable(self) -> None:
-        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add variable x {y z w} a} m]\nputs "$rc|$m"\n')
+        stdout, _ = _run(
+            'proc x {} {}\nset rc [catch {trace add variable x {y z w} a} m]\nputs "$rc|$m"\n'
+        )
         assert stdout.strip() == '1|bad operation "y": must be array, read, unset, or write'
 
     def test_null_op_list_command(self) -> None:
-        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add command x {} a} m]\nputs "$rc|$m"\n')
+        stdout, _ = _run(
+            'proc x {} {}\nset rc [catch {trace add command x {} a} m]\nputs "$rc|$m"\n'
+        )
         assert stdout.strip() == '1|bad operation list "": must be one or more of delete or rename'
 
     def test_abbreviation_rejected(self) -> None:
-        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add variable x {r} a} m]\nputs "$rc|$m"\n')
+        stdout, _ = _run(
+            'proc x {} {}\nset rc [catch {trace add variable x {r} a} m]\nputs "$rc|$m"\n'
+        )
         assert stdout.strip() == '1|bad operation "r": must be array, read, unset, or write'
 
     def test_execution_op_list(self) -> None:
-        stdout, _ = _run('proc x {} {}\nset rc [catch {trace add execution x {bogus} a} m]\nputs "$rc|$m"\n')
-        assert stdout.strip() == '1|bad operation "bogus": must be enter, leave, enterstep, or leavestep'
+        stdout, _ = _run(
+            'proc x {} {}\nset rc [catch {trace add execution x {bogus} a} m]\nputs "$rc|$m"\n'
+        )
+        assert (
+            stdout.strip()
+            == '1|bad operation "bogus": must be enter, leave, enterstep, or leavestep'
+        )
 
 
 class TestCommandTraces:
@@ -716,8 +719,7 @@ class TestLappendArgEvalOrder:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == (
-            'unset 0 {} 1 {can\'t read "x": no such variable} '
-            '1 {can\'t read "y": no such variable}'
+            'unset 0 {} 1 {can\'t read "x": no such variable} 1 {can\'t read "y": no such variable}'
         )
 
 
@@ -917,11 +919,7 @@ class TestCommandTraceReentrancyAndErrors:
         assert stdout.strip() == "{} {}"
 
     def test_delete_trace_error_discarded(self) -> None:
-        src = (
-            "proc foo {} {}\n"
-            "trace add command foo delete {error}\n"
-            'puts ">[rename foo {}]<"\n'
-        )
+        src = 'proc foo {} {}\ntrace add command foo delete {error}\nputs ">[rename foo {}]<"\n'
         stdout, _ = _run(src)
         assert stdout.strip() == "><"
 

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -673,3 +673,69 @@ class TestExecutionTraceOrder:
         )
         stdout, _ = _run(src)
         assert stdout.splitlines() == ["te {foo 1} 0 {} leave", "te2 {foo 1} 0 {} leave"]
+
+
+class TestLappendArgEvalOrder:
+    """``lappend`` evaluates all of its value arguments *before* the
+    read-modify-write of the target variable (Tcl semantics).  A value
+    arg that mutates the same variable as a side effect — e.g. a ``read``
+    trace whose callback rewrites the var (trace-16.*), or an inline
+    ``[cmd]`` that touches it — must be observed by the subsequent read.
+    The compiled ``lappend`` emitter previously read the variable first,
+    discarding any such mutation when it wrote the snapshot back.
+    """
+
+    def test_inline_subst_mutates_target(self) -> None:
+        src = (
+            "set info {A}\n"
+            "proc mutate {} { global info; lappend info FROMPROC; return X }\n"
+            "lappend info [mutate] Y\n"
+            "puts $info\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "A FROMPROC X Y"
+
+    def test_read_trace_unset_during_lappend(self) -> None:
+        # Distilled from trace-16.1: a read trace whose callback unsets
+        # the variable (firing an unset trace that appends to ``info``),
+        # all observed by the enclosing ``lappend info ...``.
+        src = (
+            "proc traceUnset {unsetName args} {\n"
+            "  global info\n"
+            "  upvar 1 $unsetName x\n"
+            "  lappend info [catch {unset x} msg] $msg [catch {set x} msg] $msg\n"
+            "}\n"
+            "proc traceAppend {string n1 n2 op} { global info; lappend info $string }\n"
+            "unset -nocomplain y\n"
+            "set y 1234\n"
+            "set info {}\n"
+            "trace add variable y read {traceUnset y}\n"
+            "trace add variable y unset {traceAppend unset}\n"
+            "lappend info [catch {set y} msg] $msg\n"
+            "puts $info\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == (
+            'unset 0 {} 1 {can\'t read "x": no such variable} '
+            '1 {can\'t read "y": no such variable}'
+        )
+
+
+class TestGlobalLenientReadFreshness:
+    """A ``global``-declared variable read through the *lenient* path
+    (``lappend`` / ``incr``) must consult the global table directly, not
+    the WASM-local mirror.  The mirror goes stale when a callee mutates
+    the same global through its own ``global`` declaration.  The strict
+    read already did this; the lenient read now does too.
+    """
+
+    def test_lappend_sees_callee_global_write(self) -> None:
+        src = (
+            "set info {A}\n"
+            "proc mutate {} { global info; lappend info FROMPROC; return X }\n"
+            "proc doit {} { global info; set r [mutate]; lappend info Z; return $r }\n"
+            "doit\n"
+            "puts $info\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "A FROMPROC Z"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -549,3 +549,35 @@ class TestTraceCommandTargetExists:
     def test_existing_command_ok(self) -> None:
         stdout, _ = _run('proc foo {} {}\nset rc [catch {trace info command foo} r]\nputs "$rc|$r"\n')
         assert stdout.strip() == "0|"
+
+
+class TestExecutionTraces:
+    """``trace add execution`` enter/leave/enterstep/leavestep callbacks
+    (trace-21.x and the broader execution-trace suite).  Driven through a
+    dynamic ``eval`` so the traced proc's body is interpreted (step
+    traces fire on each body command), matching how tcltest runs."""
+
+    def test_enter_leave_enterstep_leavestep(self) -> None:
+        body = (
+            "proc traceExecute {args} { global info; lappend info $args }\n"
+            "proc foo {x} {set b $x}\n"
+            "set info {}\n"
+            "trace add execution foo {enter leave enterstep leavestep} [list traceExecute foo]\n"
+            "foo 3\n"
+            "trace remove execution foo {enter leave enterstep leavestep} [list traceExecute foo]\n"
+            "puts $info"
+        )
+        stdout, _ = _run("eval {" + body + "}\n")
+        assert stdout.strip() == (
+            "{foo {foo 3} enter} {foo {set b 3} enterstep} "
+            "{foo {set b 3} 0 3 leavestep} {foo {foo 3} 0 3 leave}"
+        )
+
+    def test_trace_info_execution(self) -> None:
+        src = (
+            "eval {proc foo {} {}\n"
+            "trace add execution foo {enter leave} bar\n"
+            "puts [trace info execution foo]}\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{{enter leave} bar}"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -532,3 +532,20 @@ class TestEnsembleConfigQuoting:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "bar"
+
+
+class TestTraceCommandTargetExists:
+    """``trace add|remove|info command|execution`` requires the target
+    command to exist, else ``unknown command "X"`` (trace-27.x/28.8/28.9)."""
+
+    def test_info_command_missing(self) -> None:
+        stdout, _ = _run('set rc [catch {trace info command thisdoesntexist} r]\nputs "$rc|$r"\n')
+        assert stdout.strip() == '1|unknown command "thisdoesntexist"'
+
+    def test_remove_execution_missing(self) -> None:
+        stdout, _ = _run('set rc [catch {trace remove execution nope {enter} bar} r]\nputs "$rc|$r"\n')
+        assert stdout.strip() == '1|unknown command "nope"'
+
+    def test_existing_command_ok(self) -> None:
+        stdout, _ = _run('proc foo {} {}\nset rc [catch {trace info command foo} r]\nputs "$rc|$r"\n')
+        assert stdout.strip() == "0|"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -813,3 +813,38 @@ class TestBareArrayElementReadImport:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "1 FIRED"
+
+
+class TestGlobalAliasedVariableTraceSurvivesProc:
+    """A variable trace added inside a proc on a ``global``-declared name
+    must be stored in the global trace directory, not the per-frame
+    chain — otherwise it is dropped when the proc returns (trace-17.2 /
+    17.3).  ``global`` now registers a runtime frame alias so the trace
+    installer resolves the name to the global and routes accordingly.
+    """
+
+    def test_trace_info_survives_proc_return(self) -> None:
+        src = (
+            "proc traceProc {n1 n2 op} { global info; "
+            "set info [concat $info [list $n1 $n2 $op]] }\n"
+            "unset -nocomplain x\n"
+            "proc p1 {} { global x; trace add variable x write traceProc }\n"
+            "p1\n"
+            "puts [trace info variable x]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{write traceProc}"
+
+    def test_trace_fires_after_proc_return(self) -> None:
+        src = (
+            "proc traceProc {n1 n2 op} { global info; "
+            "set info [concat $info [list $n1 $n2 $op]] }\n"
+            "unset -nocomplain x\n"
+            "set info {}\n"
+            "proc p1 {} { global x; trace add variable x write traceProc }\n"
+            "p1\n"
+            "set x 44\n"
+            "puts $info\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "x {} write"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -447,3 +447,21 @@ class TestTraceCommandArity:
             "1",
             'wrong # args: should be "trace option ?arg ...?"',
         ]
+
+
+class TestEnsembleParameters:
+    """``namespace ensemble create -parameters {p ...}`` consumes that
+    many words before the subcommand and re-inserts them ahead of the
+    resolved implementation's arguments (namespace-53.1)."""
+
+    def test_single_parameter(self) -> None:
+        src = (
+            "namespace eval ns {\n"
+            "  namespace export x\n"
+            "  proc x {para} {list 1 $para}\n"
+            "  namespace ensemble create -parameters {para1}\n"
+            "}\n"
+            "puts [ns bar x]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "1 bar"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -949,3 +949,35 @@ class TestCommandTraceReentrancyAndErrors:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "{} {} someothername"
+
+
+class TestNamespaceDeleteFiresCommandDeleteTrace:
+    """``namespace delete`` deletes each command in the namespace, firing
+    its ``delete`` command trace while the command (and namespace) are
+    still live — so the callback's ``namespace which -command`` resolves
+    it (trace-34.4).  A callback that re-deletes the same namespace must
+    not recurse forever (the delete entry is removed before it fires).
+    """
+
+    def test_delete_trace_fires_on_namespace_delete(self) -> None:
+        src = (
+            "proc callback {old args} { global x; "
+            'set x "$old exists: [namespace which -command $old]" }\n'
+            "set x notrace\n"
+            "namespace eval ::foo {proc bar {} {}}\n"
+            "trace add command ::foo::bar delete callback\n"
+            "namespace delete ::foo\n"
+            "puts $x\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "::foo::bar exists: ::foo::bar"
+
+    def test_self_deleting_callback_does_not_recurse(self) -> None:
+        src = (
+            "namespace eval ::ns { proc cmd {} {} }\n"
+            "trace add command ::ns::cmd delete {namespace delete ::ns}\n"
+            "namespace delete ::ns\n"
+            "puts ok\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "ok"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -848,3 +848,50 @@ class TestGlobalAliasedVariableTraceSurvivesProc:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "x {} write"
+
+
+class TestCommandTraceLifecycle:
+    """Command-trace lifecycle on rename / redefine.
+
+    * A move whose destination already exists fails *before* any command
+      trace fires (trace-19.10) — Tcl validates the target first.
+    * Redefining a command deletes the old one: its ``delete`` trace
+      fires and all command/execution traces are dropped, so the
+      recreated command starts clean (trace-19.4 / 19.5 / 20.3).
+    """
+
+    def test_failed_rename_does_not_fire_trace(self) -> None:
+        src = (
+            "proc traceCommand {args} { global info; lappend info $args }\n"
+            "set info {}\n"
+            "proc foo {} {}\n"
+            "proc bar {} {}\n"
+            "trace add command foo {rename delete} traceCommand\n"
+            "catch {rename foo bar}\n"
+            "puts [list $info]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{}"
+
+    def test_redefine_clears_command_traces(self) -> None:
+        src = (
+            "proc traceCommand {args} {}\n"
+            "proc foo {} {}\n"
+            "trace add command foo rename traceCommand\n"
+            "proc foo {} {}\n"
+            "puts [list [trace info command foo]]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{}"
+
+    def test_redefine_fires_delete_trace(self) -> None:
+        src = (
+            "proc traceCommand {o n op} { global info; set info [list $o $n $op] }\n"
+            "proc foo {} {}\n"
+            "set info {}\n"
+            "trace add command foo delete traceCommand\n"
+            "proc foo {} {}\n"
+            "puts $info\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "::foo {} delete"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -639,3 +639,37 @@ class TestCommandTraces:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "{{delete rename} cb}"
+
+
+class TestExecutionTraceOrder:
+    """Multiple execution traces on one command fire in Tcl's defined
+    order: enter/enterstep most-recently-added first, leave/leavestep
+    in registration order (trace-25.4/25.6)."""
+
+    def test_enter_traces_reverse_order(self) -> None:
+        src = (
+            "eval {proc te {args} { global info; lappend info $args }\n"
+            "proc te2 {args} { global info; lappend info $args }\n"
+            "proc foo {a} {}\n"
+            "set info {}\n"
+            "trace add execution foo enter [list te te]\n"
+            "trace add execution foo enter [list te2 te2]\n"
+            "foo 1\n"
+            "puts [join $info \\n]}\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == ["te2 {foo 1} enter", "te {foo 1} enter"]
+
+    def test_leave_traces_forward_order(self) -> None:
+        src = (
+            "eval {proc te {args} { global info; lappend info $args }\n"
+            "proc te2 {args} { global info; lappend info $args }\n"
+            "proc foo {a} {}\n"
+            "set info {}\n"
+            "trace add execution foo leave [list te te]\n"
+            "trace add execution foo leave [list te2 te2]\n"
+            "foo 1\n"
+            "puts [join $info \\n]}\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == ["te {foo 1} 0 {} leave", "te2 {foo 1} 0 {} leave"]

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -979,3 +979,53 @@ class TestNamespaceDeleteFiresCommandDeleteTrace:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "ok"
+
+
+class TestBuiltinCommandTrace:
+    """``trace add command|execution <builtin>`` must actually attach and
+    fire — reference Tcl gives builtins a Command identity.  Previously
+    the trace validated as OK but stored nothing (the bucket resolved to
+    0), so it silently never fired.  A forwarding Command bucket is now
+    provisioned so interpreted invocations fire the trace.
+    """
+
+    def test_execution_trace_on_builtin_fires(self) -> None:
+        src = (
+            "proc tracer {args} { global info; lappend info $args }\n"
+            "set info {}\n"
+            "set x 5\n"
+            "trace add execution incr enter tracer\n"
+            "trace add execution incr leave tracer\n"
+            "set script {incr x}\n"
+            "eval $script\n"
+            'puts "$x|$info"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "6|{{incr x} enter} {{incr x} 0 6 leave}"
+
+    def test_trace_info_lists_builtin_trace(self) -> None:
+        src = (
+            "proc tracer {args} {}\n"
+            "trace add execution incr enter tracer\n"
+            "puts [trace info execution incr]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "{enter tracer}"
+
+
+class TestArrayDefaultInterpIsolation:
+    """``array default`` state is interp-local: a default set in a child
+    interpreter must not be observable in the parent (or vice versa),
+    even when both use the same normalised array name.
+    """
+
+    def test_child_default_does_not_leak_to_parent(self) -> None:
+        src = (
+            "interp create kid\n"
+            "interp eval kid { array default set b CHILD }\n"
+            "set rc [catch {set b(z)} m]\n"
+            'puts "$rc|[info exists b]|[array exists b]"\n'
+            "interp delete kid\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "1|0|0"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -504,3 +504,17 @@ class TestNamespaceUnknownHandler:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "MYUNKNOWN: dummy a b c"
+
+
+class TestEnsembleUnknownFqnName:
+    """The ensemble ``-unknown`` handler receives the fully-qualified
+    ensemble command name, not the short invoked word (namespace-47.7)."""
+
+    def test_handler_gets_fqn(self) -> None:
+        src = (
+            "namespace ensemble create -command foo -unknown bar\n"
+            "proc bar {args} { list ::set ::x [join $args |] }\n"
+            "puts [foo {one two three}]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "::foo|one two three"

--- a/tests/test_wasm_tier2_fixes.py
+++ b/tests/test_wasm_tier2_fixes.py
@@ -465,3 +465,42 @@ class TestEnsembleParameters:
         )
         stdout, _ = _run(src)
         assert stdout.strip() == "1 bar"
+
+
+class TestNamespaceUnknownHandler:
+    """Per-namespace ``namespace unknown`` handler (namespace-52.x): a
+    namespace's handler (or the root's, when it has none) intercepts an
+    unknown command invoked within that namespace.  Queries report the
+    explicit handler, defaulting to ``::unknown`` for the root and ``{}``
+    elsewhere."""
+
+    def test_set_and_dispatch(self) -> None:
+        src = (
+            "namespace eval foo {\n"
+            "  namespace unknown [list dispatch]\n"
+            "  proc dispatch {args} { return $args }\n"
+            "  proc test {} { UnknownCmd a b c }\n"
+            "}\n"
+            "puts [foo::test]\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "UnknownCmd a b c"
+
+    def test_query_defaults(self) -> None:
+        src = (
+            'puts "<[namespace eval foobar { namespace unknown }]>"\n'
+            'puts "<[namespace eval :: { namespace unknown }]>"\n'
+        )
+        stdout, _ = _run(src)
+        assert stdout.splitlines() == ["<>", "<::unknown>"]
+
+    def test_global_handler_inherited(self) -> None:
+        src = (
+            "proc ::myunknown {args} { return \"MYUNKNOWN: $args\" }\n"
+            "namespace eval :: { namespace unknown ::myunknown }\n"
+            "set result [namespace eval foo { dummy a b c }]\n"
+            "namespace eval :: { namespace unknown {} }\n"
+            "puts $result\n"
+        )
+        stdout, _ = _run(src)
+        assert stdout.strip() == "MYUNKNOWN: dummy a b c"


### PR DESCRIPTION
## Summary

This PR implements several significant Tcl features and fixes for the WASM runtime:

### Execution Traces (`trace add execution`)
- Added `tcl_exec_trace.zig` module to handle execution traces with `enter`, `leave`, `enterstep`, and `leavestep` operations
- Integrated trace firing into the command dispatcher via `any_traces` fast-path gate
- Supports step-trace context stack for recursive command tracing
- Re-entrancy guard prevents traces from firing within trace callbacks

### Array Defaults (Tcl 8.7/9 `var-24.x`)
- Implemented `array default set|get|exists|unset` commands
- Missing array element reads fall back to the per-array default value without creating elements
- Defaults are dropped when arrays are unset
- Modified `array_get` to check default values; added `array_get_raw` for internal lookups that need to distinguish missing from default

### Variable Trace Cleanup
- Added `remove_all()` function to `tcl_var_trace.zig` to drop all traces when a variable is unset
- Prevents stale traces from firing on later variables that reuse the same name
- Handles re-entrancy by deferring cleanup if a trace is currently active

### Append Creates Missing Variables
- Modified `append` command to treat unset variables as empty (Tcl semantics) rather than raising an error
- Uses lenient read path like `lappend` and `incr`

### Ensemble Unknown Handler Retry
- Implemented `namespace ensemble create -unknown HANDLER` retry protocol
- Handler can create missing subcommands; ensemble re-resolves and dispatches after handler runs
- Non-empty handler result rewrites the command prefix

### Namespace Eval Error Frames
- Added `(in namespace eval "::ns" script line N)` errorInfo frames for errors in `namespace eval` bodies
- Matches Tcl's error reporting for namespace evaluation

### Expression Operators
- Added support for `<`, `>`, `<=`, `>=` relational operators in expressions
- Numeric comparison when both operands parse as numbers, lexicographic otherwise
- Properly skips `$variable` references to avoid false operator matches

### Braced Arguments in Catch
- Fixed `catch {proc_call {braced_arg}}` to preserve literal bytes in braced arguments
- Prevents re-substitution of brace-protected content

### Command Traces
- Implemented `trace add command {delete|rename}` for command lifecycle tracing
- Fires when commands are deleted or renamed
- Properly cleans up traces when commands are removed

### Package Management
- Added `package ifneeded NAME VERSION ?SCRIPT?` registry for dynamic package loading
- Supports `source -nopkg` option used by init.tcl's package machinery
- Enables tcltest loading into child interpreters

### Namespace Unknown Handlers
- Implemented `namespace unknown ?handler?` per-namespace command fallback
- Root namespace defaults to `::unknown`; other namespaces default to empty

### Global Variable Aliases
- Fixed trace installation to recognize `global` declarations as aliases to root globals
- Traces on global-aliased variables stay in global directory, not per-frame

### Interp Initialization
- Added `INTERP_NEEDS_INIT` flag for deferred `Tcl_Init` on child interpreters
- Prevents proc registration issues when init.tcl is sourced during interp creation

### Array Directory Per-Interp
- Made array directory state swappable per-interpreter via `dir_state_get/set`
- Ensures array isolation between interpreters

## Validation

- Added comprehensive test suite in `test_wasm_tier2_fixes.py` covering:
  - Braced arguments in catch blocks
  - Variable trace cleanup on unset
  - Array default values and operations
  - Append on missing variables
  - Ensemble unknown handler retry
  - Namespace eval error frames
  - Ensemble unknown handler bad codes
  - Trace command arity validation
  - Execution trace operations
  - Command traces (delete/rename)
  - Namespace unknown handlers
  - Global variable trace placement
  - Package ifneeded registry

https://claude.ai/code/session_01TdnFf8bYascXiGUTYxXq7u