### PR TITLE
Upgrade dependencies and GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,13 +63,13 @@ jobs:
           fetch-tags: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.5-115-g4d8ebe18-dirty
-head=4d8ebe18f2c50cd149d8463a5e57fac0a2291fd4
-date=2026-05-23T08:11:00Z
-fingerprint=044eb34d6dd7c713c0ce8711e0637f6fd28eada4c00ce594aad0dff256aa5221
+describe=129c575-dirty
+head=129c575cc02a6d68999729dfcdaaf97cc1e60ea4
+date=2026-05-24T18:34:00Z
+fingerprint=3f596a175fa51998669cca46dd7b8161b43a88667d1d30f4a7fb8913ced5f0bb

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=129c575-dirty
-head=129c575cc02a6d68999729dfcdaaf97cc1e60ea4
-date=2026-05-24T18:34:00Z
-fingerprint=3f596a175fa51998669cca46dd7b8161b43a88667d1d30f4a7fb8913ced5f0bb
+describe=6b0191f-dirty
+head=6b0191f8a99f8faa38d562944ba5fa9f6712b961
+date=2026-05-24T18:45:07Z
+fingerprint=79bdf6b52a6e1673995601d41c95c0660cb6dde0e1b4f5a875053ded0d96d477

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -821,7 +821,7 @@ def _barrier_aware_env_for_block(
                 else:
                     env.pop(name, None)
 
-    return env
+    return env  # ty: ignore[invalid-return-type]  # env values are guarded to int/bool/str by the isinstance checks above; the loop-branch widening from summarise_static_for_ir is over-broad
 
 
 def _evaluate_branch_decision(

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -771,6 +771,7 @@ def _barrier_aware_env_for_block(
     if block is None or ssa_block is None:
         return None
 
+    env: dict[str, int | float | bool | str]
     loop_meta = cfg.loop_nodes.get(block_name)
     if loop_meta is not None:
         loop_start_block, loop_stmt = loop_meta
@@ -782,9 +783,10 @@ def _barrier_aware_env_for_block(
             lv = values.get((name, ver), UNKNOWN)
             if lv.kind is LatticeKind.CONST and isinstance(lv.value, (int, bool, str)):
                 start_env[name] = lv.value
-        env = summarise_static_for_ir(loop_stmt, initial_constants=start_env)
-        if env is None:
+        summarised = summarise_static_for_ir(loop_stmt, initial_constants=start_env)
+        if summarised is None:
             return None
+        env = summarised
     else:
         env = {}
         for name, ver in ssa_block.entry_versions.items():
@@ -821,7 +823,7 @@ def _barrier_aware_env_for_block(
                 else:
                     env.pop(name, None)
 
-    return env  # ty: ignore[invalid-return-type]  # env values are guarded to int/bool/str by the isinstance checks above; the loop-branch widening from summarise_static_for_ir is over-broad
+    return env
 
 
 def _evaluate_branch_decision(

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -200,12 +200,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -213,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -226,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -240,15 +241,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -260,15 +261,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -298,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -308,21 +309,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "leb128fmt"
@@ -332,9 +333,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -360,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "percent-encoding"
@@ -378,9 +379,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -406,18 +407,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -455,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -468,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -531,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -718,15 +719,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -735,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -758,18 +759,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -779,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -790,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -801,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ dynamic = ["version"]
 description = "A Tcl Language Server Protocol implementation"
 requires-python = ">=3.10"
 dependencies = [
-    "pygls>=2.0",
-    "lsprotocol>=2024.0.0",
+    "pygls>=2.1",
+    "lsprotocol>=2025.0.0",
     "jinja2>=3.1",
-    "argcomplete>=3.0",
+    "argcomplete>=3.6",
     "tomli>=2.0; python_version < '3.11'",
 ]
 
@@ -37,37 +37,37 @@ tcl-vm = "tooling.vm.__main__:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
-    "pytest-cov>=6.0",
+    "pytest>=9.0",
+    "pytest-cov>=7.0",
     "pytest-xdist>=3.8.0",
-    "ruff>=0.11",
-    "ty==0.0.37",
+    "ruff>=0.15",
+    "ty==0.0.39",
     # Architectural dependency contracts — see `.importlinter`.  Keeps the
     # seven-concern Python layout (shared/, compiler/, dialects/, analyser/,
     # server/, tooling/, ai/) from drifting back into a tangle.
-    "import-linter>=2.0",
+    "import-linter>=2.11",
     # Available at runtime so ``scripts/print_version.py`` can compute the
     # wheel filename the Makefile expects (hatch-vcs is also a
     # ``[build-system].requires`` entry — listing it here just makes it
     # importable from the dev env).
     "hatch-vcs>=0.5",
-    "wasmtime>=20.0",
-    "flask>=3.0",
+    "wasmtime>=44.0",
+    "flask>=3.1",
     # Used by the test-slow TLS / x509 suites that spin up an HTTPS
     # server with a generated self-signed cert and exercise
     # ``url_get`` / ``tls_handshake`` / ``cert_load`` against it.
     # Also unlocks PKCS#12 parsing in ``cert_load``.
-    "cryptography>=42.0",
+    "cryptography>=48.0",
 ]
 # Sphinx + autodoc + furo theme — for building the f5q Python API
 # reference (``docs/sphinx/``).  Read the Docs uses this extras
 # group via ``.readthedocs.yaml``; locally, build with
 # ``uv run --extra docs sphinx-build -b html docs/sphinx docs/sphinx/_build/html``.
 docs = [
-    "sphinx>=7.0",
-    "myst-parser>=2.0",
-    "sphinx-autodoc-typehints>=1.25",
-    "furo>=2024.1.29",
+    "sphinx>=8.0",
+    "myst-parser>=4.0",
+    "sphinx-autodoc-typehints>=3.0",
+    "furo>=2025.12.19",
 ]
 
 [build-system]
@@ -154,5 +154,5 @@ output = "tmp/coverage/python/coverage.xml"
 
 [dependency-groups]
 dev = [
-    "ty==0.0.37",
+    "ty==0.0.39",
 ]

--- a/tooling/formatter/config.py
+++ b/tooling/formatter/config.py
@@ -120,7 +120,7 @@ class FormatterConfig:
                 if f.name in _ENUM_FIELDS and isinstance(val, str):
                     val = _ENUM_FIELDS[f.name][val.upper()]
                 kwargs[f.name] = val
-        return cls(**kwargs)
+        return cls(**kwargs)  # ty: ignore[invalid-argument-type]  # dynamic deserialisation: enum fields are coerced from their string names just above
 
     def replace(self, **changes) -> FormatterConfig:
         """Return a copy with the given fields replaced."""

--- a/tooling/formatter/config.py
+++ b/tooling/formatter/config.py
@@ -113,14 +113,14 @@ class FormatterConfig:
     @classmethod
     def from_dict(cls, data: dict) -> FormatterConfig:
         """Deserialise from a dict (e.g., LSP workspace settings)."""
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         for f in fields(cls):
             if f.name in data:
                 val = data[f.name]
                 if f.name in _ENUM_FIELDS and isinstance(val, str):
                     val = _ENUM_FIELDS[f.name][val.upper()]
                 kwargs[f.name] = val
-        return cls(**kwargs)  # ty: ignore[invalid-argument-type]  # dynamic deserialisation: enum fields are coerced from their string names just above
+        return cls(**kwargs)
 
     def replace(self, **changes) -> FormatterConfig:
         """Return a copy with the given fields replaced."""


### PR DESCRIPTION
## Summary

- Upgrade core dependencies: `pygls` (2.0→2.1), `lsprotocol` (2024.0.0→2025.0.0), `argcomplete` (3.0→3.6)
- Upgrade dev dependencies: `pytest` (8.0→9.0), `pytest-cov` (6.0→7.0), `ruff` (0.11→0.15), `ty` (0.0.37→0.0.39), `import-linter` (2.0→2.11), `wasmtime` (20.0→44.0), `flask` (3.0→3.1), `cryptography` (42.0→48.0)
- Upgrade docs dependencies: `sphinx` (7.0→8.0), `myst-parser` (2.0→4.0), `sphinx-autodoc-typehints` (1.25→3.0), `furo` (2024.1.29→2025.12.19)
- Update GitHub Actions: CodeQL and Scorecard workflows to v4.36.0

## Validation

- [ ] I ran relevant tests/checks locally and listed the exact commands.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.
- [ ] If I added a new compiler KCS note, I linked it from both:
  - `docs/kcs/compiler/README.md`
  - `docs/kcs/README.md`

https://claude.ai/code/session_01KBxiv4XLpV65hHHxpyqEWz