### PR TITLE
Fix ROOT path in publish_{verify,sublime,zed}.sh

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.7-20-g733df928-dirty
-head=733df928729bbd8eed3b1de37b4da81ce8721171
-date=2026-05-27T21:18:00Z
-fingerprint=7d471acc90aac9076685388eed9f13074f259a7accf21eac6bf98f1512445af2
+describe=v1.10.8-0-g0e63f6c9-dirty
+head=0e63f6c92c0290c6dbadded5779d0f38cbcc0d6d
+date=2026-05-27T22:33:00Z
+fingerprint=2b577c4abd9c2ce9555895f8d6878d1e13b2de478fc3360922fafc5b66d7d090

--- a/scripts/release/publish_sublime.sh
+++ b/scripts/release/publish_sublime.sh
@@ -40,7 +40,7 @@
 # This script never creates the repo for you.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 REPO="bitwisecook/tcl-lsp"
 MIRROR_REPO="${TCL_LSP_SUBLIME_MIRROR_REPO:-bitwisecook/tcl-lsp-sublime-text}"
 STAGE_DIR="$ROOT/build/sublime-stage"

--- a/scripts/release/publish_verify.sh
+++ b/scripts/release/publish_verify.sh
@@ -14,7 +14,7 @@
 # Sections are independent; we run all of them and only fail at the end.
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 EXT_DIR="$ROOT/editors/vscode"
 NODE_BIN="$EXT_DIR/node_modules/.bin"
 JB_DIR="$ROOT/editors/jetbrains"

--- a/scripts/release/publish_zed.sh
+++ b/scripts/release/publish_zed.sh
@@ -34,7 +34,7 @@
 # adds the submodule and the `[tcl]` block in extensions.toml.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 UPSTREAM="zed-industries/extensions"
 EXT_NAME="tcl"
 EXT_PATH="extensions/${EXT_NAME}"


### PR DESCRIPTION
## Summary
All three release scripts in \`scripts/release/\` compute \`\$ROOT\` as \`\$(dirname \$0)/..\` — but they live two levels deep, so this only walks up to \`scripts/\` instead of the repo root. As a result:

- \`publish_verify.sh\` checked \`scripts/editors/vscode\` and \`scripts/editors/jetbrains\` for \`vsce\` + \`gradlew\`, then reported them missing on a clean tree.
- \`publish_sublime.sh\` looked for \`build/sublime-stage\` under \`scripts/\`, failed with \"not found — run 'make build-editor-sublime' first\" even after a successful build, blocking \`make publish-sublime\`.
- \`publish_zed.sh\` mostly survives because \`git -C \"\$ROOT\" describe\` walks up to find \`.git\` regardless of where \`ROOT\` points, but any future \`\$ROOT/<path>\` reference would silently mis-resolve.

Surfaced while publishing v1.10.8: \`publish-verify\` reported every editor \`[fail]\`, and \`publish-sublime\` aborted post-build. The Sublime publish was completed by patching the script locally and re-running.

Both scripts presumably moved here from \`scripts/\` in the seven-concern reorg (#449), and the extra \`/..\` was missed.

## Test plan
- [x] \`make publish-verify\` from a clean tree now \`PASS\`es (it had been printing \`[fail]\` for every editor)
- [x] \`make publish-sublime\` end-to-end pushed v1.10.8 to the mirror with the patched script
- [x] \`make test-slow\` to refresh the committed stamp
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)