### PR TITLE
Fix ping rtt parser fallback (flaky prep-pr under load)

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.8-1-g89942223-dirty
-head=899422231c6f5eed237e3ac46d039b6d8aa76ef2
-date=2026-05-28T20:35:43Z
-fingerprint=7c27e1581fe9af41aa1ba430cb1f2170af1afbc2f5ca251ee48213b46f87fd96
+describe=v1.10.8-2-g281cb0be-dirty
+head=281cb0be156e4f26993cbd722a75a5116b2df1fe
+date=2026-05-28T20:56:09Z
+fingerprint=69c8de94a277969a85e4a7fef826f1ee0d9c55d3869a8cfb8c4cb1be8785a606

--- a/dialects/f5/query/_probes.py
+++ b/dialects/f5/query/_probes.py
@@ -108,14 +108,22 @@ def ping(ip: str, *, timeout_s: float = 2.0) -> dict[str, Any]:
 
 
 def _parse_ping_rtt(stdout: str) -> float | None:
-    """Pull the ``time=NN ms`` value out of ``ping``'s first reply line."""
+    """Pull the RTT out of ``ping``'s output."""
     for line in stdout.splitlines():
         if "time=" in line:
             try:
                 bit = line.split("time=", 1)[1].split()[0]
                 return float(bit.rstrip("ms"))
             except (ValueError, IndexError):
-                return None
+                pass
+    for line in stdout.splitlines():
+        if "min/avg/max" in line and "=" in line:
+            try:
+                stats = line.split("=", 1)[1].strip()
+                avg = stats.split("/")[1]
+                return float(avg)
+            except (ValueError, IndexError):
+                pass
     return None
 
 


### PR DESCRIPTION
## Summary
\`_parse_ping_rtt\` only matched the per-reply \`time=NN ms\` token. On macOS, where the BSD \`ping\` \`-W\` flag is per-packet milliseconds (Linux iputils' is per-deadline seconds), a heavily-loaded run could exit successfully (returncode 0) without a parseable reply line — and \`ping(ip)\` then returned \`{ok: True, rtt_ms: None}\`, which is logically inconsistent for callers that rely on the rtt being present when ok is true.

Surfaced as a flaky test:

\`\`\`
tests/test_f5_query_extensions.py::TestProbeGate
    ::test_ping_succeeds_when_enabled
\`\`\`

failing under prep-pr's xdist load with \`assert None is not None\` on \`row["rtt_ms"]\` while \`row["ok"]\` was \`True\`. In isolation the test always passed.

Both BSD and Linux ping emit a summary line on success:

\`\`\`
round-trip min/avg/max/stddev = 0.040/0.040/0.040/0.000 ms   # BSD
rtt        min/avg/max/mdev  = 0.040/0.040/0.040/0.000 ms   # Linux
\`\`\`

When the per-reply \`time=\` token can't be parsed, fall back to the summary's \`avg\` field. Both formats share the \`min/avg/max\` token.

## Test plan
- [x] \`make prep-pr\` clean
- [x] \`make test-slow\` clean + stamp refreshed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)