### PR TITLE
Pre-release fixes: test-ext flake, CodeQL, npm vulns

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.8-3-g647fc482-dirty
-head=647fc482cef912ccb4c1dad3dd450b1e04a4fd5a
-date=2026-05-28T21:31:52Z
-fingerprint=3065e333e5236243581b3f7572f53fd24e06efb97105d2351cd5816e65e72d41
+describe=v1.10.8-4-g9bd83a4f-dirty
+head=9bd83a4fab17db44e20352b38daab2de8e69afcc
+date=2026-05-28T22:14:40Z
+fingerprint=f7ebbba49e7bda12a54e293342db9a6af738719723a38eabd1668c34d37588be

--- a/dialects/f5/bigip/flow/packets.py
+++ b/dialects/f5/bigip/flow/packets.py
@@ -270,13 +270,6 @@ def _peek_tls_clienthello(payload: bytes) -> tuple[bool, str, str]:
         return True, "", ""
 
 
-# Best-effort: scan an F5 ethernet trailer's LOW/MED TLV data for a printable
-# RST cause string.  Wireshark surfaces these as `f5ethtrailer.rstcause.cause`
-# and `.line`; we don't claim to match the dissector byte-for-byte, just to
-# flag the presence of an RST cause when one is encoded.
-_RST_HINT_RE = re.compile(rb"(?:RST(?:_| )?(?:cause|reason)?[: ]?)?([A-Z][A-Z0-9_/.\- ]{6,80})")
-
-
 def _extract_peer_tuple_from_trailer(
     trailer_bytes: bytes,
 ) -> tuple[str, int, str, int] | None:

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1757,13 +1757,6 @@
         "win32"
       ]
     },
-    "node_modules/@vscode/vsce/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vscode/vsce/node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -1816,17 +1809,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/acorn": {
@@ -2050,9 +2032,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2422,13 +2404,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4528,23 +4503,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/mocha/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/mocha/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -5319,9 +5277,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6273,9 +6231,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4918,6 +4918,7 @@
     "@vscode/vsce": {
       "@azure/msal-node": "^5.1.5"
     },
+    "brace-expansion": "^5.0.6",
     "lodash": "^4.18.1"
   }
 }

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -103,18 +103,23 @@ suite("Code Actions", () => {
     });
     assert.ok(irule1005, "IRULE1005 diagnostic should be present");
 
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      irulesDocUri,
-      irule1005.range,
-    )) as vscode.CodeAction[];
-
-    const collectFix = actions.find(
-      (a) =>
-        typeof a.title === "string" &&
-        a.title.includes("collect") &&
-        a.title.includes("CLIENT_ACCEPTED"),
-    );
+    let collectFix: vscode.CodeAction | undefined;
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      const actions = (await vscode.commands.executeCommand(
+        "vscode.executeCodeActionProvider",
+        irulesDocUri,
+        irule1005.range,
+      )) as vscode.CodeAction[];
+      collectFix = actions.find(
+        (a) =>
+          typeof a.title === "string" &&
+          a.title.includes("collect") &&
+          a.title.includes("CLIENT_ACCEPTED"),
+      );
+      if (collectFix) break;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
     assert.ok(collectFix, "Should provide a collect bootstrap quick fix");
   });
 });

--- a/tests/test_folding_lsp_frontend.py
+++ b/tests/test_folding_lsp_frontend.py
@@ -20,7 +20,6 @@ from lsprotocol import types
 import server.server as server_module
 import server.state as _state
 from server.feature_config import FeatureConfig
-from server.state import workspace_state
 
 
 def _fold(uri: str) -> list[types.FoldingRange]:
@@ -50,11 +49,11 @@ class TestFoldingHandler:
             '    puts "Bye $name"\n'  # 9
             "}\n"  # 10
         )
-        workspace_state.open(uri, source)
+        _state.workspace_state.open(uri, source)
         try:
             spans = _spans(_fold(uri))
         finally:
-            workspace_state.close(uri)
+            _state.workspace_state.close(uri)
 
         Region = types.FoldingRangeKind.Region
         Comment = types.FoldingRangeKind.Comment
@@ -69,11 +68,11 @@ class TestFoldingHandler:
         """Every returned range is whole-line and non-degenerate."""
         uri = "file:///folding-wellformed.tcl"
         source = "proc demo {} {\n    if {1} {\n        puts hi\n    }\n}\n"
-        workspace_state.open(uri, source)
+        _state.workspace_state.open(uri, source)
         try:
             ranges = _fold(uri)
         finally:
-            workspace_state.close(uri)
+            _state.workspace_state.close(uri)
         assert ranges
         for r in ranges:
             assert r.end_line > r.start_line, r
@@ -82,7 +81,7 @@ class TestFoldingHandler:
     def test_disabled_via_config_returns_empty(self, monkeypatch):
         uri = "file:///folding-disabled.tcl"
         source = "proc foo {} {\n    puts hi\n    puts bye\n}\n"
-        workspace_state.open(uri, source)
+        _state.workspace_state.open(uri, source)
         monkeypatch.setattr(
             _state,
             "config_for_uri",
@@ -91,4 +90,4 @@ class TestFoldingHandler:
         try:
             assert _fold(uri) == []
         finally:
-            workspace_state.close(uri)
+            _state.workspace_state.close(uri)


### PR DESCRIPTION
## Summary
Bundle of changes that were blocking the v1.10.9 tag. CI on the v1.10.9 tag failed on \`test-ext\` (flaky IRULE1005 timing race), and four CodeQL alerts were open against \`main\`. This PR addresses all of them so the tag can be re-pushed cleanly.

### \`test-ext\` IRULE1005 flake
\`codeActions.test.ts > provides guided collect bootstrap fix for IRULE1005\` failed in CI but passed locally (442/442). The race: the deep-diagnostic pass publishes \`IRULE1005\` and the test then calls \`vscode.executeCodeActionProvider\`, but on a cold CI runner the code-action provider hasn't recomputed for that diagnostic yet, so the call returns without the \`Add 'HTTP::collect' bootstrap in 'CLIENT_ACCEPTED'\` action. The test now polls for up to 10 s with a 200 ms cadence so it tolerates the race instead of failing on the first miss.

### CodeQL alerts
- **#1534 \`py/import-and-import-from\`**: \`tests/test_folding_lsp_frontend.py\` imported \`server.state\` twice (\`import server.state as _state\` *and* \`from server.state import workspace_state\`). Drop the \`from\`-import and route every reference through the existing \`_state\` alias.
- **#1533 \`py/unused-global-variable\`**: \`dialects/f5/bigip/flow/packets.py\` had an unused \`_RST_HINT_RE\` regex. Removed (with its preamble comment).
- **#1532 Scorecard \`VulnerabilitiesID\` (high)**: three open advisories in transitive \`editors/vscode\` deps:
  - \`brace-expansion < 5.0.6\` (GHSA-jxxr-4gwj-5jf2, moderate, DoS)
  - \`qs < 6.15.2\` (GHSA-q8mj-m7cp-5q26, moderate, DoS)
  - \`tmp < 0.2.6\` (GHSA-ph9p-34f9-6g65, **high**, path traversal)
  
  Added a \`brace-expansion: ^5.0.6\` override and refreshed \`package-lock.json\`. \`tmp\` and \`qs\` advanced naturally on lockfile refresh. \`npm audit\` now reports zero vulnerabilities.
- **#819 Scorecard \`BranchProtectionID\`** (high) is a GitHub repo-settings issue (no approvers / codeowners / last-push approval on \`main\`), not a code change — left for a separate manual configuration step.

The broken v1.10.9 tag and GitHub release were already deleted; this branch becomes the new tag candidate.

## Test plan
- [x] \`make prep-pr\` clean
- [x] \`make test-slow\` clean, including \`test-ext\` (which previously flaked)
- [x] \`npm audit\` reports zero vulnerabilities
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)