### PR TITLE
Fold existence checks and narrow reads in guarded regions

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=71a639e-dirty
-head=71a639ef2f4eb98123aa62e5a8045251467a8335
-date=2026-05-29T20:12:08Z
-fingerprint=0cabeff1c1fa2d68dacaac6de21486a8892fc80cacc2931fc9459ec3484861f7
+describe=v1.10.9-5-g9218e841
+head=9218e84181605d4e32b625bf1bb969e07c53cef9
+date=2026-05-29T21:41:30Z
+fingerprint=350c6812d50098d0709a6a0526be634115102e3f9ad85ce0fbe9b6bd201de923

--- a/README.md
+++ b/README.md
@@ -1794,7 +1794,7 @@ For the complete reference, see
 | Code | Description | Quick-fix |
 |------|-------------|-----------|
 | H300 | Possible paste error -- repeated assignment to same variable with same value | |
-| W210 | Variable read before set (with case-mismatch suggestion when applicable) | |
+| W210 | Variable read before set (with case-mismatch suggestion when applicable; `info exists`/`array exists` are existence tests, not reads, so they are excluded and instead fold to a constant branch where provable) | |
 | W211 | Variable set but never used (with case-mismatch suggestion when applicable) | |
 | W212 | Variable substitution where name expected (`set $x`, `incr $x`, `info exists $x`, etc.) | |
 | W213 | `unset` on variable that may not exist -- use `unset -nocomplain` | |

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -48,13 +48,16 @@ from shared.tokens import TokenType
 from .cfg import CFGBranch, CFGFunction, CFGGoto, CFGReturn, build_cfg
 from .eval_helpers import DECIMAL_INT_RE as _DECIMAL_INT_RE
 from .expr_ast import (
+    BinOp,
     ExprBinary,
     ExprCall,
     ExprCommand,
+    ExprLiteral,
     ExprNode,
     ExprRaw,
     ExprTernary,
     ExprUnary,
+    UnaryOp,
     expr_text,
     vars_in_expr_node,
 )
@@ -65,8 +68,10 @@ from .ir import (
     IRAssignValue,
     IRBarrier,
     IRCall,
+    IRExprEval,
     IRIncr,
     IRModule,
+    IRReturn,
     IRStatement,
 )
 from .lowering import lower_to_ir
@@ -117,6 +122,51 @@ def _parse_cmd_subst(value: str) -> tuple[str, str] | None:
     cmd = commands[0]
     args_text = inner[cmd.argv[1].start.offset :].rstrip() if len(cmd.argv) >= 2 else ""
     return cmd.texts[0], args_text
+
+
+# A plain, unqualified local scalar name — the only shape whose existence is
+# locally decidable.  Namespace-qualified (``::ns::x``, ``ns::x``), array
+# element (``a(k)``), and dynamic (``$name``) targets are excluded.
+_EXISTENCE_LOCAL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _parse_existence_check(cmd_text: str) -> tuple[str, str] | None:
+    """Parse ``[info exists X]`` / ``[array exists X]`` into ``(kind, raw_target)``.
+
+    *kind* is ``"info"`` or ``"array"`` and *raw_target* is the **unnormalised**
+    argument text (e.g. ``"X"``, ``"A(k)"``, ``"::ns::X"``).  Returns ``None``
+    when the text is not an existence check.  Callers that fold or narrow must
+    pass *raw_target* through :func:`_existence_scalar_name` so that array
+    elements and qualified names are excluded — only a plain local scalar's
+    existence is locally decidable.
+    """
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return None
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    if base not in ("info", "array"):
+        return None
+    try:
+        parts = _split_tcl_list(args_text) if args_text.strip() else []
+    except Exception:
+        return None
+    if len(parts) != 2 or parts[0] != "exists":
+        return None
+    return base, parts[1].strip()
+
+
+def _existence_scalar_name(raw_target: str) -> str | None:
+    """Return the normalised name when *raw_target* is a plain local scalar.
+
+    Array elements (``A(k)``), namespace-qualified names (``::ns::X``,
+    ``ns::X``), and dynamic targets (``$name``) are not locally decidable and
+    yield ``None``.
+    """
+    if not _EXISTENCE_LOCAL_RE.match(raw_target):
+        return None
+    name = _normalise_var_name(raw_target)
+    return name or None
 
 
 def _expr_has_command(node: ExprNode) -> bool:
@@ -827,13 +877,184 @@ def _barrier_aware_env_for_block(
     return env
 
 
+def _is_bounded_scope_decl(stmt: IRStatement) -> bool:
+    """True when *stmt* only declares its named ``global``/``variable``/``upvar``
+    target(s) — a bounded effect captured by :func:`_escaping_var_names`, not an
+    arbitrary local creation."""
+    if not isinstance(stmt, (IRCall, IRBarrier)):
+        return False
+    from compiler.var_scoping import (
+        global_declaration_indices,
+        upvar_local_declaration_indices,
+        variable_declaration_indices,
+    )
+
+    args = stmt.args
+    if upvar_local_declaration_indices(stmt.command, args):
+        return True
+    if stmt.canonical_command == "::global" and global_declaration_indices(args):
+        return True
+    if stmt.canonical_command == "::variable" and variable_declaration_indices(args):
+        return True
+    return False
+
+
+def _is_existence_transparent(stmt: IRStatement) -> bool:
+    """True when *stmt* cannot create or destroy a local variable in a way the
+    analysis cannot see — the precondition for folding existence checks."""
+    if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr, IRReturn, IRExprEval)):
+        return True
+    if isinstance(stmt, IRCall):
+        if _is_bounded_scope_decl(stmt):
+            return True
+        from compiler.registry.runtime import ArgRole, arg_indices_for_role
+        from compiler.side_effects import SideEffectTarget, classify_side_effects
+
+        se = classify_side_effects(stmt.command, stmt.args)
+        if se.dynamic_barrier or SideEffectTarget.UNKNOWN in se.write_targets:
+            return False
+        # A command that runs an inline body in this scope (``namespace eval``,
+        # ``clientside``, …) could set locals the analysis never sees.
+        if arg_indices_for_role(stmt.command, list(stmt.args), ArgRole.BODY):
+            return False
+        return True
+    # IRBarrier, IRBlock, IRUpFrame, IRSwitch, IRCatch, IRTry, IRForeach, … —
+    # opaque to local-variable creation.
+    return False
+
+
+def _existence_def_kind(stmt: IRStatement) -> str:
+    """Classify the definition a statement produces for existence reasoning:
+    ``"real"`` (a genuine assignment → exists), ``"unset"`` (→ absent), or
+    ``"unknown"`` (alias/proc-call/array-unset → undecidable)."""
+    if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
+        return "real"
+    if isinstance(stmt, (IRCall, IRBarrier)) and stmt.canonical_command == "::unset":
+        return "unset"
+    return "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class _ExistenceFolder:
+    """Folds ``[info exists X]`` / ``[array exists X]`` to a constant when the
+    variable is provably absent or present in a single function.
+
+    ``foldable`` is the per-function gate: ``False`` whenever any statement
+    could create/destroy a local invisibly (dynamic ``eval``/``uplevel``,
+    body-executing commands, unknown procs, …), in which case nothing folds.
+    """
+
+    foldable: bool
+    params: frozenset[str]
+    escaping: frozenset[str]
+    version_kind: dict[SSAValueKey, str]
+
+    @staticmethod
+    def build(cfg: CFGFunction, ssa: SSAFunction, params: frozenset[str]) -> "_ExistenceFolder":
+        foldable = all(
+            _is_existence_transparent(stmt)
+            for block in cfg.blocks.values()
+            for stmt in block.statements
+        )
+        version_kind: dict[SSAValueKey, str] = {}
+        if foldable:
+            for bn, block in cfg.blocks.items():
+                ssa_block = ssa.blocks.get(bn)
+                if ssa_block is None:
+                    continue
+                for idx, ir_stmt in enumerate(block.statements):
+                    if idx >= len(ssa_block.statements):
+                        continue
+                    kind = _existence_def_kind(ir_stmt)
+                    for name, ver in ssa_block.statements[idx].defs.items():
+                        if ver > 0:
+                            version_kind[(name, ver)] = kind
+        return _ExistenceFolder(foldable, params, _escaping_var_names(cfg), version_kind)
+
+    def _classify(self, name: str, version: int) -> bool | None:
+        """Return ``True`` (exists), ``False`` (absent), or ``None`` (unknown)."""
+        if not self.foldable:
+            return None
+        if version == 0:
+            if name in self.params:
+                return True
+            if name in self.escaping:
+                return None
+            return False
+        kind = self.version_kind.get((name, version))
+        if kind == "real":
+            return True
+        if kind == "unset":
+            return False
+        return None
+
+    def fold_command(self, cmd_text: str, uses: dict[str, int]) -> str | None:
+        parsed = _parse_existence_check(cmd_text)
+        if parsed is None:
+            return None
+        kind, raw_target = parsed
+        name = _existence_scalar_name(raw_target)
+        if name is None:
+            return None
+        verdict = self._classify(name, uses.get(name, 0))
+        if verdict is None:
+            return None
+        # A scalar assignment proves ``info exists`` but not ``array exists``.
+        if kind == "array" and verdict:
+            return None
+        return "1" if verdict else "0"
+
+    def fold_condition(self, condition: ExprNode, uses: dict[str, int]) -> ExprNode:
+        if not self.foldable:
+            return condition
+        return _fold_existence_in_expr(condition, uses, self)
+
+
+def _fold_existence_in_expr(
+    expr: ExprNode, uses: dict[str, int], folder: "_ExistenceFolder"
+) -> ExprNode:
+    """Replace foldable existence-check substitutions in *expr* with ``0``/``1``
+    literals.  ``info exists`` has no side effects, so the replacement is exact."""
+    if isinstance(expr, ExprCommand):
+        verdict = folder.fold_command(expr.text, uses)
+        if verdict is not None:
+            return ExprLiteral(text=verdict, start=expr.start, end=expr.end)
+        return expr
+    if isinstance(expr, ExprBinary):
+        return ExprBinary(
+            expr.op,
+            _fold_existence_in_expr(expr.left, uses, folder),
+            _fold_existence_in_expr(expr.right, uses, folder),
+        )
+    if isinstance(expr, ExprUnary):
+        return ExprUnary(expr.op, _fold_existence_in_expr(expr.operand, uses, folder))
+    if isinstance(expr, ExprTernary):
+        return ExprTernary(
+            _fold_existence_in_expr(expr.condition, uses, folder),
+            _fold_existence_in_expr(expr.true_branch, uses, folder),
+            _fold_existence_in_expr(expr.false_branch, uses, folder),
+        )
+    if isinstance(expr, ExprCall):
+        return ExprCall(
+            expr.function,
+            tuple(_fold_existence_in_expr(a, uses, folder) for a in expr.args),
+            expr.start,
+            expr.end,
+        )
+    return expr
+
+
 def _evaluate_branch_decision(
     cfg: CFGFunction,
     ssa: SSAFunction,
     block_name: str,
     condition: ExprNode,
     values: dict[SSAValueKey, LatticeValue],
+    folder: "_ExistenceFolder | None" = None,
 ) -> bool | None:
+    if folder is not None:
+        uses0 = _condition_use_versions(condition, ssa.blocks[block_name].exit_versions)
+        condition = folder.fold_condition(condition, uses0)
     env = _barrier_aware_env_for_block(cfg, ssa, block_name, values)
     if env is not None:
         result = evaluate_expr_with_constants(expr_text(condition), env)
@@ -852,10 +1073,15 @@ def _sccp(
     ssa: SSAFunction,
     *,
     param_constants: dict[SSAValueKey, LatticeValue] | None = None,
+    params: frozenset[str] = frozenset(),
 ) -> tuple[
     dict[SSAValueKey, LatticeValue], set[str], set[tuple[str, str]], tuple[ConstantBranch, ...]
 ]:
     preds = _compute_predecessors(cfg)
+    # Fold ``[info exists X]`` / ``[array exists X]`` to a constant when the
+    # variable is provably absent or present, so branches guarded by an
+    # existence check resolve to a single edge (feeding I230 + DCE).
+    existence_folder = _ExistenceFolder.build(cfg, ssa, params)
 
     executable_blocks: set[str] = {cfg.entry} if cfg.entry in cfg.blocks else set()
     executable_edges: set[tuple[str, str]] = set()
@@ -926,7 +1152,9 @@ def _sccp(
         # (live-in roots seeded above; undefined phi inputs joined as ⊥
         # below), so a still-UNKNOWN operand genuinely means "not yet
         # computed", never "unknowable".
-        decision = _evaluate_branch_decision(cfg, ssa, block_name, condition, values)
+        decision = _evaluate_branch_decision(
+            cfg, ssa, block_name, condition, values, existence_folder
+        )
         if decision is True:
             return (tt,)
         if decision is False:
@@ -1032,6 +1260,7 @@ def _sccp(
             bn,
             term.condition,
             values,
+            existence_folder,
         )
         if decision is None:
             continue
@@ -1333,6 +1562,151 @@ _IMPLICIT_VARS = frozenset(
 )
 
 
+def _iter_expr_commands(expr: ExprNode, out: list[ExprCommand]) -> None:
+    """Collect every ``ExprCommand`` node reachable in *expr* (no short-circuit
+    pruning — we want all existence checks, taken or not)."""
+    if isinstance(expr, ExprCommand):
+        out.append(expr)
+    elif isinstance(expr, ExprBinary):
+        _iter_expr_commands(expr.left, out)
+        _iter_expr_commands(expr.right, out)
+    elif isinstance(expr, ExprUnary):
+        _iter_expr_commands(expr.operand, out)
+    elif isinstance(expr, ExprTernary):
+        _iter_expr_commands(expr.condition, out)
+        _iter_expr_commands(expr.true_branch, out)
+        _iter_expr_commands(expr.false_branch, out)
+    elif isinstance(expr, ExprCall):
+        for arg in expr.args:
+            _iter_expr_commands(arg, out)
+
+
+def _collect_existence_in_word(text: str, out: set[str]) -> None:
+    """Find ``[info exists X]`` / ``[array exists X]`` substitutions inside a
+    word and add their targets to *out* (recursing into nested substitutions)."""
+    if "[" not in text:
+        return
+    try:
+        tokens = TclLexer(text).tokenise_all()
+    except Exception:
+        return
+    for tok in tokens:
+        if tok.type is TokenType.CMD:
+            parsed = _parse_existence_check(f"[{tok.text}]")
+            if parsed is not None:
+                nm = _normalise_var_name(parsed[1])
+                if nm:
+                    out.add(nm)
+            else:
+                _collect_existence_in_word(tok.text, out)
+
+
+def _existence_checks_in_expr(expr: ExprNode) -> set[str]:
+    """Names existence-checked (``info``/``array exists``) anywhere in *expr*."""
+    names: set[str] = set()
+    cmds: list[ExprCommand] = []
+    _iter_expr_commands(expr, cmds)
+    for c in cmds:
+        parsed = _parse_existence_check(c.text)
+        if parsed is not None:
+            nm = _normalise_var_name(parsed[1])
+            if nm:
+                names.add(nm)
+    return names
+
+
+def _existence_checks_in_stmt(stmt: IRStatement) -> set[str]:
+    """Names existence-checked by *stmt* itself — the check reference does not
+    read the variable's value, so it is never a read-before-set."""
+    names: set[str] = set()
+    if isinstance(stmt, (IRCall, IRBarrier)):
+        args = stmt.args
+        if (
+            stmt.canonical_command in ("::info", "::array")
+            and len(args) >= 2
+            and args[0] == "exists"
+        ):
+            nm = _normalise_var_name(args[1])
+            if nm:
+                names.add(nm)
+        for arg in args:
+            _collect_existence_in_word(arg, names)
+    value = getattr(stmt, "value", None)
+    if isinstance(value, str):
+        _collect_existence_in_word(value, names)
+    expr = getattr(stmt, "expr", None)
+    if expr is not None and not isinstance(expr, str):
+        names |= _existence_checks_in_expr(expr)
+    return names
+
+
+def _existence_implications(expr: ExprNode) -> tuple[set[str], set[str]]:
+    """Return ``(exists_if_true, exists_if_false)`` — names a condition proves
+    to exist when it evaluates true vs false.
+
+    A bare ``[info exists X]`` proves ``X`` when true; ``!`` swaps the arms;
+    ``&&`` proves its operands' positive facts only when the whole thing is
+    true; ``||`` proves their negative facts only when the whole thing is
+    false.  Everything else proves nothing.
+    """
+    if isinstance(expr, ExprCommand):
+        parsed = _parse_existence_check(expr.text)
+        name = _existence_scalar_name(parsed[1]) if parsed is not None else None
+        if name is not None:
+            return {name}, set()
+        return set(), set()
+    if isinstance(expr, ExprUnary) and expr.op in (UnaryOp.NOT, UnaryOp.WORD_NOT):
+        true_set, false_set = _existence_implications(expr.operand)
+        return false_set, true_set
+    if isinstance(expr, ExprBinary):
+        left_true, left_false = _existence_implications(expr.left)
+        right_true, right_false = _existence_implications(expr.right)
+        if expr.op in (BinOp.AND, BinOp.WORD_AND):
+            return left_true | right_true, set()
+        if expr.op in (BinOp.OR, BinOp.WORD_OR):
+            return set(), left_false | right_false
+    return set(), set()
+
+
+def _block_dominates(ssa: SSAFunction, dominator: str, node: str) -> bool:
+    """True when *dominator* dominates *node* in the SSA dominator tree."""
+    current: str | None = node
+    while current is not None:
+        if current == dominator:
+            return True
+        current = ssa.idom.get(current)
+    return False
+
+
+def _existence_narrowed_blocks(
+    cfg: CFGFunction, ssa: SSAFunction, considered: set[str]
+) -> dict[str, set[str]]:
+    """Map each block to the names a dominating existence guard proves to exist.
+
+    For ``if {[info exists X]} { … }`` the true successor's dominated region
+    knows ``X`` exists; a read there is not a read-before-set.  The false region
+    of a *negated* guard is handled symmetrically.  Only edges whose successor
+    is entered solely from the guard are used, so the proof is sound.
+    """
+    preds = _compute_predecessors(cfg)
+    known: dict[str, set[str]] = {}
+    for bn in considered:
+        block = cfg.blocks.get(bn)
+        if block is None or not isinstance(block.terminator, CFGBranch):
+            continue
+        exists_true, exists_false = _existence_implications(block.terminator.condition)
+        for target, names in (
+            (block.terminator.true_target, exists_true),
+            (block.terminator.false_target, exists_false),
+        ):
+            if not names or preds.get(target) != {bn}:
+                continue
+            for d in considered:
+                if _block_dominates(ssa, target, d):
+                    known.setdefault(d, set()).update(names)
+    return known
+
+
 def _read_before_set(
     cfg: CFGFunction,
     ssa: SSAFunction,
@@ -1347,6 +1721,9 @@ def _read_before_set(
     """
     considered = executable_blocks if executable_blocks is not None else set(cfg.blocks)
     skip = _IMPLICIT_VARS | params
+    # A dominating ``info exists`` / ``array exists`` guard proves a variable
+    # exists in its true region, so a read there is not a read-before-set.
+    narrowed = _existence_narrowed_blocks(cfg, ssa, considered)
 
     # dict with/update creates local variables from dict keys at runtime.
     # We cannot know which variables statically, so suppress
@@ -1401,7 +1778,10 @@ def _read_before_set(
         if ssa_block is None:
             continue
 
+        block_known = narrowed.get(bn, frozenset())
+
         for idx, stmt in enumerate(ssa_block.statements):
+            occ_checks: set[str] | None = None
             for name, ver in stmt.uses.items():
                 if ver != 0:
                     continue
@@ -1413,6 +1793,15 @@ def _read_before_set(
                     continue
                 if name.startswith("::") or name.startswith("static::"):
                     continue
+                # Proven to exist here by a dominating existence guard.
+                if name in block_known:
+                    continue
+                # The statement is itself an existence check of this name
+                # (``info exists X``) — that does not read the value.
+                if occ_checks is None:
+                    occ_checks = _existence_checks_in_stmt(cfg.blocks[bn].statements[idx])
+                if name in occ_checks:
+                    continue
                 reported.add(name)
                 result.append(ReadBeforeSet(block=bn, statement_index=idx, variable=name))
 
@@ -1420,6 +1809,7 @@ def _read_before_set(
         # The condition's variable versions come from exit_versions.
         term = cfg.blocks[bn].terminator
         if isinstance(term, CFGBranch):
+            cond_checks = _existence_checks_in_expr(term.condition)
             for name in vars_in_expr_node(term.condition):
                 ver = ssa_block.exit_versions.get(name, 0)
                 if ver != 0:
@@ -1427,6 +1817,8 @@ def _read_before_set(
                 if name in skip or name in reported:
                     continue
                 if name.startswith("::") or name.startswith("static::"):
+                    continue
+                if name in block_known or name in cond_checks:
                     continue
                 reported.add(name)
                 # Use statement_index=-1 and block to signal condition-level use.
@@ -1744,7 +2136,7 @@ def analyse_function(
     known_classes: frozenset[str] = frozenset(),
 ) -> FunctionAnalysis:
     values, executable_blocks, executable_edges, constant_branches = _sccp(
-        cfg, ssa, param_constants=param_constants
+        cfg, ssa, param_constants=param_constants, params=params
     )
     inferred_types = _type_propagation(
         cfg, ssa, values, executable_blocks, executable_edges, known_classes

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -895,10 +895,99 @@ def _is_bounded_scope_decl(stmt: IRStatement) -> bool:
     return False
 
 
+def _command_mutates_locals(cmd_text: str) -> bool:
+    """True when the ``[cmd ...]`` substitution could create, modify, or remove
+    a local variable.
+
+    Such effects are invisible to SSA when the command is nested inside a
+    value/expression (``set y [set X 1]``) rather than a top-level statement, so
+    the existence folder must treat statements containing them as opaque.
+    """
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return True  # multi-command / unparseable — assume it can
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    try:
+        args = tuple(_split_command_args(args_text))
+    except Exception:
+        return True
+    # ``unset`` / ``array unset`` change a variable's existence without a write
+    # target that side-effect analysis records.
+    if base == "unset" or (base == "array" and args and args[0] == "unset"):
+        return True
+    from compiler.registry.runtime import ArgRole, arg_indices_for_role
+    from compiler.side_effects import SideEffectTarget, classify_side_effects
+
+    # A command that runs an inline body could create locals (``[if {…} {set X …}]``).
+    if arg_indices_for_role(cmd_name, list(args), ArgRole.BODY):
+        return True
+    se = classify_side_effects(cmd_name, args)
+    if se.dynamic_barrier:
+        return True
+    return (
+        SideEffectTarget.VARIABLE in se.write_targets
+        or SideEffectTarget.UNKNOWN in se.write_targets
+    )
+
+
+def _word_mutation_free(text: str) -> bool:
+    """True when evaluating word/script *text* cannot create/modify/remove a
+    local — i.e. no command substitution within it does so."""
+    if "[" not in text:
+        return True
+    try:
+        tokens = TclLexer(text).tokenise_all()
+    except Exception:
+        return False
+    for tok in tokens:
+        if tok.type is TokenType.CMD:
+            if _command_mutates_locals(f"[{tok.text}]"):
+                return False
+            if not _word_mutation_free(tok.text):  # nested substitutions
+                return False
+    return True
+
+
+def _expr_mutation_free(node: ExprNode) -> bool:
+    """True when evaluating expression *node* cannot create/modify/remove a local."""
+    match node:
+        case ExprCommand(text=text) | ExprRaw(text=text):
+            return _word_mutation_free(text)
+        case ExprBinary(left=left, right=right):
+            return _expr_mutation_free(left) and _expr_mutation_free(right)
+        case ExprUnary(operand=operand):
+            return _expr_mutation_free(operand)
+        case ExprTernary(condition=cond, true_branch=tb, false_branch=fb):
+            return _expr_mutation_free(cond) and _expr_mutation_free(tb) and _expr_mutation_free(fb)
+        case ExprCall(args=args):
+            return all(_expr_mutation_free(a) for a in args)
+        case _:
+            return True
+
+
 def _is_existence_transparent(stmt: IRStatement) -> bool:
     """True when *stmt* cannot create or destroy a local variable in a way the
-    analysis cannot see — the precondition for folding existence checks."""
-    if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr, IRReturn, IRExprEval)):
+    analysis cannot see — the precondition for folding existence checks.
+
+    A value/expression statement whose value contains a command substitution
+    that could create a local (``set y [set X 1]``) is *not* transparent: the
+    nested write produces no SSA definition, so the folder would otherwise
+    mistake the created variable for an absent one.
+    """
+    if isinstance(stmt, IRAssignConst):
+        return True
+    if isinstance(stmt, IRAssignValue):
+        return _word_mutation_free(stmt.value)
+    if isinstance(stmt, (IRAssignExpr, IRExprEval)):
+        return _expr_mutation_free(stmt.expr)
+    if isinstance(stmt, IRIncr):
+        return stmt.amount is None or _word_mutation_free(stmt.amount)
+    if isinstance(stmt, IRReturn):
+        if stmt.value is not None and not _word_mutation_free(stmt.value):
+            return False
+        if stmt.expr is not None and not _expr_mutation_free(stmt.expr):
+            return False
         return True
     if isinstance(stmt, IRCall):
         if _is_bounded_scope_decl(stmt):
@@ -913,7 +1002,9 @@ def _is_existence_transparent(stmt: IRStatement) -> bool:
         # ``clientside``, …) could set locals the analysis never sees.
         if arg_indices_for_role(stmt.command, list(stmt.args), ArgRole.BODY):
             return False
-        return True
+        # A nested command substitution in an argument can create a local too
+        # (``puts [set X 1]``).
+        return all(_word_mutation_free(arg) for arg in stmt.args)
     # IRBarrier, IRBlock, IRUpFrame, IRSwitch, IRCatch, IRTry, IRForeach, … —
     # opaque to local-variable creation.
     return False
@@ -1590,7 +1681,10 @@ def _collect_existence_in_word(text: str, out: set[str]) -> None:
         if tok.type is TokenType.CMD:
             parsed = _parse_existence_check(f"[{tok.text}]")
             if parsed is not None:
-                nm = _normalise_var_name(parsed[1])
+                # Only a literal plain-scalar target is existence-tested without
+                # a value read; a dynamic target like ``info exists $name``
+                # reads ``name`` to form the name, so it must stay reportable.
+                nm = _existence_scalar_name(parsed[1])
                 if nm:
                     out.add(nm)
             else:
@@ -1605,7 +1699,7 @@ def _existence_checks_in_expr(expr: ExprNode) -> set[str]:
     for c in cmds:
         parsed = _parse_existence_check(c.text)
         if parsed is not None:
-            nm = _normalise_var_name(parsed[1])
+            nm = _existence_scalar_name(parsed[1])
             if nm:
                 names.add(nm)
     return names
@@ -1622,7 +1716,7 @@ def _existence_checks_in_stmt(stmt: IRStatement) -> set[str]:
             and len(args) >= 2
             and args[0] == "exists"
         ):
-            nm = _normalise_var_name(args[1])
+            nm = _existence_scalar_name(args[1])
             if nm:
                 names.add(nm)
         for arg in args:
@@ -1885,10 +1979,16 @@ def _existence_implications(expr: ExprNode) -> tuple[set[str], set[str]]:
             return comparison
         left_true, left_false = _existence_implications(expr.left)
         right_true, right_false = _existence_implications(expr.right)
+        # The right operand is evaluated after the left; if it can mutate a
+        # local (e.g. ``[info exists X] && [unset X; expr 1]``) the left's facts
+        # may no longer hold when control reaches the branch, so drop them.
+        right_safe = _expr_mutation_free(expr.right)
         if expr.op in (BinOp.AND, BinOp.WORD_AND):
-            return left_true | right_true, set()
+            carry = left_true if right_safe else set()
+            return carry | right_true, set()
         if expr.op in (BinOp.OR, BinOp.WORD_OR):
-            return set(), left_false | right_false
+            carry = left_false if right_safe else set()
+            return set(), carry | right_false
     return set(), set()
 
 

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -55,6 +55,7 @@ from .expr_ast import (
     ExprLiteral,
     ExprNode,
     ExprRaw,
+    ExprString,
     ExprTernary,
     ExprUnary,
     UnaryOp,
@@ -1640,6 +1641,194 @@ def _existence_checks_in_stmt(stmt: IRStatement) -> set[str]:
     return names
 
 
+# ``info vars`` / ``info locals`` are existence probes too — they return the
+# matching visible variable names rather than reading a value.  Only an exact
+# (non-glob) name is statically decidable; a glob pattern would need a
+# variable-lifetime matrix we do not have, so those are skipped.
+
+
+def _info_vars_exact_target(cmd_text: str) -> str | None:
+    """``[info vars X]`` / ``[info locals X]`` → exact local name ``X``."""
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return None
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    if base != "info":
+        return None
+    try:
+        parts = _split_tcl_list(args_text) if args_text.strip() else []
+    except Exception:
+        return None
+    if len(parts) != 2 or parts[0] not in ("vars", "locals"):
+        return None
+    return _existence_scalar_name(parts[1])
+
+
+def _is_info_vars_full_list(cmd_text: str) -> bool:
+    """True when *cmd_text* is exactly ``[info vars]`` / ``[info locals]``."""
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return False
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    if base != "info":
+        return False
+    try:
+        parts = _split_tcl_list(args_text) if args_text.strip() else []
+    except Exception:
+        return False
+    return parts in (["vars"], ["locals"])
+
+
+def _split_command_args(args_text: str) -> list[str]:
+    """Split a command's argument text into words, keeping ``[cmd]``, ``{str}``
+    and ``$var`` substitutions as single words (unlike ``_split_tcl_list``,
+    which treats ``[`` / ``]`` as ordinary characters)."""
+    words: list[str] = []
+    prev_sep = True
+    try:
+        tokens = TclLexer(args_text).tokenise_all()
+    except Exception:
+        return []
+    for tok in tokens:
+        if tok.type in (TokenType.SEP, TokenType.EOL, TokenType.EOF):
+            prev_sep = True
+            continue
+        piece = tok.text
+        if tok.type is TokenType.CMD:
+            piece = f"[{tok.text}]"
+        elif tok.type is TokenType.STR:
+            piece = f"{{{tok.text}}}"
+        elif tok.type is TokenType.VAR:
+            piece = f"${tok.text}"
+        if prev_sep or not words:
+            words.append(piece)
+        else:
+            words[-1] += piece
+        prev_sep = False
+    return words
+
+
+_LSEARCH_SAFE_OPTS = frozenset({"-exact", "-glob", "-sorted"})
+
+
+def _lsearch_info_vars_needle(cmd_text: str) -> str | None:
+    """``[lsearch ?-exact? [info vars] X]`` → exact needle name ``X``.
+
+    Only option flags that do not change which exact name matches are allowed
+    (``-regexp`` / ``-nocase`` / ``-all`` etc. would be unsound).
+    """
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return None
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    if base != "lsearch":
+        return None
+    parts = _split_command_args(args_text)
+    options = [p for p in parts if p.startswith("-")]
+    if any(opt not in _LSEARCH_SAFE_OPTS for opt in options):
+        return None
+    positional = [p for p in parts if not p.startswith("-")]
+    if len(positional) != 2 or not _is_info_vars_full_list(positional[0]):
+        return None
+    return _existence_scalar_name(positional[1])
+
+
+def _llength_info_vars_target(cmd_text: str) -> str | None:
+    """``[llength [info vars X]]`` → exact name ``X`` (truthy ⇒ X exists)."""
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return None
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    if base != "llength":
+        return None
+    return _info_vars_exact_target(args_text.strip())
+
+
+def _is_empty_string_literal(node: ExprNode) -> bool:
+    if not isinstance(node, ExprString):
+        return False
+    text = node.text
+    return text in ("", '""', "{}") or (len(text) >= 2 and text[0] in '"{' and text[1:-1] == "")
+
+
+def _int_const(node: ExprNode) -> int | None:
+    if isinstance(node, ExprLiteral):
+        try:
+            return int(node.text)
+        except ValueError:
+            return None
+    if (
+        isinstance(node, ExprUnary)
+        and node.op is UnaryOp.NEG
+        and isinstance(node.operand, ExprLiteral)
+    ):
+        try:
+            return -int(node.operand.text)
+        except ValueError:
+            return None
+    return None
+
+
+_SWAP_COMPARISON = {
+    BinOp.GT: BinOp.LT,
+    BinOp.LT: BinOp.GT,
+    BinOp.GE: BinOp.LE,
+    BinOp.LE: BinOp.GE,
+    BinOp.EQ: BinOp.EQ,
+    BinOp.NE: BinOp.NE,
+}
+
+
+def _lsearch_found_when_true(op: BinOp, value: int, cmd_on_left: bool) -> bool | None:
+    """For ``[lsearch …] <op> <value>``, does *true* mean the needle was found
+    (index ≥ 0)?  Returns ``True`` (found), ``False`` (not found), or ``None``."""
+    if not cmd_on_left:
+        op = _SWAP_COMPARISON.get(op, op)
+    if (
+        (op is BinOp.GT and value == -1)
+        or (op is BinOp.GE and value == 0)
+        or (op is BinOp.NE and value == -1)
+    ):
+        return True
+    if (
+        (op is BinOp.EQ and value == -1)
+        or (op is BinOp.LT and value == 0)
+        or (op is BinOp.LE and value == -1)
+    ):
+        return False
+    return None
+
+
+def _comparison_existence(expr: ExprBinary) -> tuple[set[str], set[str]] | None:
+    """Existence facts proved by a comparison: ``[info vars X] ne ""`` and
+    ``[lsearch [info vars] X] > -1`` (and their negative/`eq`/`==` variants)."""
+    # ``[info vars X] ne|eq ""``
+    for cmd_side, other in ((expr.left, expr.right), (expr.right, expr.left)):
+        if isinstance(cmd_side, ExprCommand) and _is_empty_string_literal(other):
+            name = _info_vars_exact_target(cmd_side.text)
+            if name is not None:
+                if expr.op in (BinOp.STR_NE, BinOp.NE):
+                    return {name}, set()
+                if expr.op in (BinOp.STR_EQ, BinOp.EQ):
+                    return set(), {name}
+    # ``[lsearch [info vars] X] > -1`` (membership search)
+    for cmd_side, other in ((expr.left, expr.right), (expr.right, expr.left)):
+        if isinstance(cmd_side, ExprCommand):
+            needle = _lsearch_info_vars_needle(cmd_side.text)
+            value = _int_const(other)
+            if needle is not None and value is not None:
+                found = _lsearch_found_when_true(expr.op, value, cmd_side is expr.left)
+                if found is True:
+                    return {needle}, set()
+                if found is False:
+                    return set(), {needle}
+    return None
+
+
 def _existence_implications(expr: ExprNode) -> tuple[set[str], set[str]]:
     """Return ``(exists_if_true, exists_if_false)`` — names a condition proves
     to exist when it evaluates true vs false.
@@ -1647,11 +1836,15 @@ def _existence_implications(expr: ExprNode) -> tuple[set[str], set[str]]:
     A bare ``[info exists X]`` proves ``X`` when true; ``!`` swaps the arms;
     ``&&`` proves its operands' positive facts only when the whole thing is
     true; ``||`` proves their negative facts only when the whole thing is
-    false.  Everything else proves nothing.
+    false.  ``info vars`` / ``info locals`` membership idioms
+    (``ne ""``, ``[llength …]``, ``[lsearch [info vars] …] > -1``) are also
+    recognised.  Everything else proves nothing.
     """
     if isinstance(expr, ExprCommand):
         parsed = _parse_existence_check(expr.text)
         name = _existence_scalar_name(parsed[1]) if parsed is not None else None
+        if name is None:
+            name = _llength_info_vars_target(expr.text)
         if name is not None:
             return {name}, set()
         return set(), set()
@@ -1659,6 +1852,9 @@ def _existence_implications(expr: ExprNode) -> tuple[set[str], set[str]]:
         true_set, false_set = _existence_implications(expr.operand)
         return false_set, true_set
     if isinstance(expr, ExprBinary):
+        comparison = _comparison_existence(expr)
+        if comparison is not None:
+            return comparison
         left_true, left_false = _existence_implications(expr.left)
         right_true, right_false = _existence_implications(expr.right)
         if expr.op in (BinOp.AND, BinOp.WORD_AND):

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -42,6 +42,7 @@ from compiler.parsing.command_segmenter import segment_commands
 from compiler.parsing.lexer import TclLexer
 from compiler.registry.runtime import FOLD_HINTS, FOLD_SUBCOMMAND_HINTS, TYPE_HINTS
 from compiler.registry.type_hints import CommandTypeHint, SubcommandTypeHint
+from shared.naming import is_unqualified_var_name as _is_unqualified_var_name
 from shared.naming import normalise_var_name as _normalise_var_name
 from shared.tokens import TokenType
 
@@ -125,12 +126,6 @@ def _parse_cmd_subst(value: str) -> tuple[str, str] | None:
     return cmd.texts[0], args_text
 
 
-# A plain, unqualified local scalar name — the only shape whose existence is
-# locally decidable.  Namespace-qualified (``::ns::x``, ``ns::x``), array
-# element (``a(k)``), and dynamic (``$name``) targets are excluded.
-_EXISTENCE_LOCAL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
 def _parse_existence_check(cmd_text: str) -> tuple[str, str] | None:
     """Parse ``[info exists X]`` / ``[array exists X]`` into ``(kind, raw_target)``.
 
@@ -164,7 +159,7 @@ def _existence_scalar_name(raw_target: str) -> str | None:
     ``ns::X``), and dynamic targets (``$name``) are not locally decidable and
     yield ``None``.
     """
-    if not _EXISTENCE_LOCAL_RE.match(raw_target):
+    if not _is_unqualified_var_name(raw_target):
         return None
     name = _normalise_var_name(raw_target)
     return name or None
@@ -1773,6 +1768,35 @@ def _int_const(node: ExprNode) -> int | None:
     return None
 
 
+def _catch_pure_read_target(cmd_text: str) -> str | None:
+    """``[catch {set _ $X}]`` → ``X``, when the body is exactly a pure read of a
+    single plain scalar.
+
+    A zero result (no error) proves the read succeeded, so ``X`` exists and is
+    scalar-readable.  A non-zero result is ambiguous (the variable could be
+    missing *or* be an array read as a scalar), so callers only use the
+    succeeded (false) branch.
+    """
+    parsed = _parse_cmd_subst(cmd_text)
+    if parsed is None:
+        return None
+    cmd_name, args_text = parsed
+    base = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
+    if base != "catch":
+        return None
+    words = _split_command_args(args_text)
+    # body, plus optional result / options variable names (Tcl 8.5+).
+    if not (1 <= len(words) <= 3):
+        return None
+    body = words[0]
+    if not (len(body) >= 2 and body[0] == "{" and body[-1] == "}"):
+        return None
+    inner = _split_command_args(body[1:-1].strip())
+    if len(inner) != 3 or inner[0] != "set" or not inner[2].startswith("$"):
+        return None
+    return _existence_scalar_name(inner[2][1:])
+
+
 _SWAP_COMPARISON = {
     BinOp.GT: BinOp.LT,
     BinOp.LT: BinOp.GT,
@@ -1847,6 +1871,10 @@ def _existence_implications(expr: ExprNode) -> tuple[set[str], set[str]]:
             name = _llength_info_vars_target(expr.text)
         if name is not None:
             return {name}, set()
+        # ``catch {set _ $X}`` — a zero (false) result proves X exists.
+        catch_var = _catch_pure_read_target(expr.text)
+        if catch_var is not None:
+            return set(), {catch_var}
         return set(), set()
     if isinstance(expr, ExprUnary) and expr.op in (UnaryOp.NOT, UnaryOp.WORD_NOT):
         true_set, false_set = _existence_implications(expr.operand)

--- a/docs/design/compiler/sccp-core-analyses.md
+++ b/docs/design/compiler/sccp-core-analyses.md
@@ -125,6 +125,15 @@ guard proves to exist (the true region of `if {[info exists X]}`, or the false
 region of a negated guard), and reads of those names there are suppressed. The
 opposite branch keeps version 0, so a read there is still flagged.
 
+`_existence_implications` recognises the membership idioms too, all restricted
+to a single exact (non-glob) name: `[info vars X]` / `[info locals X]`
+compared with `""` (`ne`/`eq`), `[llength [info vars X]]`, and
+`[lsearch [info vars] X] > -1` / `>= 0` / `!= -1`. `info globals` is *not*
+narrowed (it proves the global exists, not the bare-`$X` local), and unsound
+`lsearch` options (`-regexp`, `-nocase`, …) are rejected. Narrowing is a
+runtime fact (the guard passed), so unlike the fold it needs no foldability
+gate.
+
 ### Unused variables
 
 Variables that are defined but never read (across all versions) appear in

--- a/docs/design/compiler/sccp-core-analyses.md
+++ b/docs/design/compiler/sccp-core-analyses.md
@@ -51,6 +51,27 @@ ConstantBranch(
 - The not-taken target is marked unreachable.
 - O112 (constant condition elimination) is triggered.
 
+### Existence-check folding (`info exists` / `array exists`)
+
+`_ExistenceFolder` rewrites `[info exists X]` / `[array exists X]`
+sub-expressions in a branch condition to a `0`/`1` literal before the branch
+decision is taken, so an existence guard becomes an ordinary constant branch
+(feeding `I230` + DCE):
+
+- **absent** — a use at SSA version 0 of a plain local scalar that is not a
+  parameter and not frame-escaping (`global`/`variable`/`upvar`) → fold to
+  `0`. (`array exists` also folds `0`.)
+- **present** — a use whose reaching version is a real assignment, or a
+  parameter → `info exists` folds to `1` (a scalar `set` does not prove
+  `array exists`, so that stays unfolded).
+- **`unset`** version → fold to `0`.
+
+The fold is gated per function: it is disabled whenever any statement could
+create or destroy a local invisibly (any barrier/`IRBlock`/`IRUpFrame`, an
+`IRCall` with an UNKNOWN-target write, a dynamic barrier, or an inline `BODY`
+argument). Array elements (`A(k)`) and qualified names (`::ns::X`) are never
+folded. This keeps the rewrite sound for DCE/codegen.
+
 ### Unreachable blocks
 
 Blocks that are never reached (due to constant branches, code after
@@ -95,6 +116,14 @@ store.  SCCP marks it in `FunctionAnalysis.dead_stores`.
 
 If a variable is read at version 0 (never defined before use), it appears
 in `FunctionAnalysis.read_before_set` → diagnostic W103.
+
+Existence checks are excluded: `info exists X` / `array exists X` test a
+variable rather than reading its value, so the check reference itself is never
+a read-before-set. A check also narrows the region it dominates —
+`_existence_narrowed_blocks` records, for each block, the names a dominating
+guard proves to exist (the true region of `if {[info exists X]}`, or the false
+region of a negated guard), and reads of those names there are suppressed. The
+opposite branch keeps version 0, so a read there is still flagged.
 
 ### Unused variables
 

--- a/docs/design/compiler/sccp-core-analyses.md
+++ b/docs/design/compiler/sccp-core-analyses.md
@@ -130,9 +130,14 @@ to a single exact (non-glob) name: `[info vars X]` / `[info locals X]`
 compared with `""` (`ne`/`eq`), `[llength [info vars X]]`, and
 `[lsearch [info vars] X] > -1` / `>= 0` / `!= -1`. `info globals` is *not*
 narrowed (it proves the global exists, not the bare-`$X` local), and unsound
-`lsearch` options (`-regexp`, `-nocase`, …) are rejected. Narrowing is a
-runtime fact (the guard passed), so unlike the fold it needs no foldability
-gate.
+`lsearch` options (`-regexp`, `-nocase`, …) are rejected. `catch {set _ $X}`
+is recognised too: a zero (no-error) result proves the read succeeded, so the
+*false* branch knows `X` exists — the true (error) branch is ambiguous (missing
+*or* an array read as a scalar) and proves nothing. Narrowing is a runtime fact
+(the guard passed), so unlike the fold it needs no foldability gate.
+
+The exact-name shape test goes through `shared.naming.is_unqualified_var_name`
+(built on the lexer's `is_bare_var_name`), not a local regex.
 
 ### Unused variables
 

--- a/docs/kcs/codes/README.md
+++ b/docs/kcs/codes/README.md
@@ -108,6 +108,10 @@ for historical reference.
 - [W216 — broken brace-form array element reference](kcs-diagnostic-w216-broken-brace-array-element-reference.md)
 - [W220 — dead store](kcs-diagnostic-w220-dead-store.md)
 
+## Information (I-codes)
+
+- [I230 — constant existence check / unreachable branch](kcs-diagnostic-i230-constant-existence-check.md)
+
 ## Shimmer (S-codes)
 
 - [S100 — shimmer outside loop](kcs-diagnostic-s100-shimmer-outside-loop.md)

--- a/docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md
+++ b/docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md
@@ -1,0 +1,76 @@
+# KCS: I230 — Why does the analyser say my `[info exists]` branch never runs?
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, diagnostic, sccp
+
+## Profiles
+
+default
+
+## Question
+
+Why does the analyser report that `[info exists X]` (or `[array exists X]`) is
+"always false" — or "always true" — and that one branch of my `if` is
+unreachable?
+
+## Why
+
+When a variable is provably set (or provably never set) at the point of the
+check, `[info exists X]` has a known answer, so one arm of the `if` can never
+run. The most common surprise is a **local** variable used for "remember this
+between calls":
+
+```tcl
+proc authorize {} {
+    if {[info exists handle]} {
+        # re-use the existing handle
+    } else {
+        set handle [ILX::init Access-Plugin Access-Extension]
+    }
+}
+```
+
+Each call to `authorize` gets a **fresh** local scope — Tcl locals do not
+survive from one invocation to the next. So `handle` is never set when the
+check runs, `[info exists handle]` is always false, and the re-use branch is
+dead. Re-entrancy does not change this: a new call (from APM, an ILX callback,
+or anywhere) is a new frame with empty locals.
+
+The analyser folds the check to its constant value and reports **`I230`** on the
+condition. The optimiser can then drop the dead branch
+([`O107`](kcs-optimisation-o107-unreachable-dead-code.md)).
+
+## Fix
+
+To remember a value across calls, give it real cross-call storage instead of a
+local:
+
+```tcl
+proc authorize {} {
+    global handle              ;# or:  variable handle
+    if {[info exists handle]} {
+        # re-use the existing handle
+    } else {
+        set handle [ILX::init Access-Plugin Access-Extension]
+    }
+}
+```
+
+With `global` (or a namespace `variable`, or iRules `table` / `session` /
+`static::`), the variable can persist, the existence check is no longer
+constant, and `I230` disappears. If a branch really is dead, delete it.
+
+## How to suppress
+
+Add `# noqa: I230` at the end of the condition's line.
+
+## Related
+
+- [KCS codes index](README.md)
+- [W210 — variable read before set](kcs-diagnostic-w210-variable-read-before-set.md)
+- [O107 — unreachable dead code](kcs-optimisation-o107-unreachable-dead-code.md)
+- [W240 — loop condition constant false](kcs-diagnostic-w240-loop-constant-false.md)

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -52,9 +52,10 @@ the check is folded to a constant and reported as
 
 The same branch narrowing applies to the `info vars` / `info locals` membership
 idioms for a single exact name: `[info vars X] ne ""`,
-`[llength [info vars X]]`, and `[lsearch [info vars] X] > -1`. (`info globals`
-is not used — it proves the *global* exists, not the bare-`$X` local — and glob
-patterns are not statically decidable.)
+`[llength [info vars X]]`, and `[lsearch [info vars] X] > -1`; and to
+`catch {set _ $X}`, whose no-error (false) branch proves `$X` was readable.
+(`info globals` is not used — it proves the *global* exists, not the bare-`$X`
+local — and glob patterns are not statically decidable.)
 
 ## How to suppress
 

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -40,6 +40,16 @@ puts $x
 
 Assign the variable before using it.
 
+## Existence checks are not reads
+
+`[info exists X]` and `[array exists X]` *test* whether a variable is set — they
+do not read its value — so they never raise `W210`. A check also informs the
+branches it guards: inside `if {[info exists X]} { … }` the variable is known to
+exist, so reading `$X` there is safe; on the `else` side it is still unset, so a
+read there is still flagged. When the variable is provably absent (or present),
+the check is folded to a constant and reported as
+[`I230`](kcs-diagnostic-i230-constant-existence-check.md) instead.
+
 ## How to suppress
 
 Add `# noqa: W210` at the end of the offending line.

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -50,6 +50,12 @@ read there is still flagged. When the variable is provably absent (or present),
 the check is folded to a constant and reported as
 [`I230`](kcs-diagnostic-i230-constant-existence-check.md) instead.
 
+The same branch narrowing applies to the `info vars` / `info locals` membership
+idioms for a single exact name: `[info vars X] ne ""`,
+`[llength [info vars X]]`, and `[lsearch [info vars] X] > -1`. (`info globals`
+is not used — it proves the *global* exists, not the bare-`$X` local — and glob
+patterns are not statically decidable.)
+
 ## How to suppress
 
 Add `# noqa: W210` at the end of the offending line.

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -42,13 +42,16 @@ Assign the variable before using it.
 
 ## Existence checks are not reads
 
-`[info exists X]` and `[array exists X]` *test* whether a variable is set — they
-do not read its value — so they never raise `W210`. A check also informs the
-branches it guards: inside `if {[info exists X]} { … }` the variable is known to
-exist, so reading `$X` there is safe; on the `else` side it is still unset, so a
-read there is still flagged. When the variable is provably absent (or present),
-the check is folded to a constant and reported as
-[`I230`](kcs-diagnostic-i230-constant-existence-check.md) instead.
+`[info exists X]` tests whether `X` exists, and `[array exists X]` tests whether
+`X` exists *as an array variable* (a scalar `set X 1` makes `info exists` true
+but leaves `array exists` false). Both *test* rather than read the value, so
+neither raises `W210`. A check also informs the branches it guards: inside
+`if {[info exists X]} { … }` the variable is known to exist, so reading `$X`
+there is safe; on the `else` side it is still unset, so a read there is still
+flagged. When existence is statically provable, the check is folded to a
+constant and reported as
+[`I230`](kcs-diagnostic-i230-constant-existence-check.md) instead — though a
+scalar assignment only proves `info exists`, never `array exists`.
 
 The same branch narrowing applies to the `info vars` / `info locals` membership
 idioms for a single exact name: `[info vars X] ne ""`,

--- a/shared/naming.py
+++ b/shared/naming.py
@@ -59,6 +59,17 @@ def is_bare_var_name(name: str) -> bool:
     return True
 
 
+def is_unqualified_var_name(name: str) -> bool:
+    """Return True when *name* is an unqualified single variable name.
+
+    That is, a plain local scalar: a bare identifier with no ``::`` namespace
+    qualifier and no array ``(idx)`` or glob characters.  Derived from
+    :func:`is_bare_var_name` (the lexer's bare-name rule) so callers do not
+    hand-roll a regex that can drift from it.
+    """
+    return "::" not in name and is_bare_var_name(name)
+
+
 def is_brace_substitutable(name: str) -> bool:
     """Return True when ``${name}`` would successfully look up ``name``.
 

--- a/tests/test_existence_checks.py
+++ b/tests/test_existence_checks.py
@@ -214,6 +214,30 @@ class TestInfoVarsNarrowing:
         assert "X" in self._flagged('if {[info vars X*] ne ""} { puts $X }')
 
 
+class TestCatchNarrowing:
+    """``catch {set _ $X}`` signals existence on its succeeded (false) branch."""
+
+    def _flagged(self, body: str) -> set[str]:
+        src = f"proc p {{}} {{ eval $cmd; {body} }}"
+        return {d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"}
+
+    def test_false_branch_knows_it_exists(self):
+        assert "X" not in self._flagged("if {[catch {set _ $X}]} { puts a } else { puts $X }")
+
+    def test_negated_true_branch_use_is_safe(self):
+        assert "X" not in self._flagged("if {![catch {set _ $X}]} { puts $X }")
+
+    def test_result_var_form(self):
+        assert "X" not in self._flagged("if {[catch {set _ $X} e]} { puts a } else { puts $X }")
+
+    def test_failed_branch_is_ambiguous_and_still_flagged(self):
+        # catch != 0 could mean missing *or* an array read as a scalar.
+        assert "X" in self._flagged("if {[catch {set _ $X}]} { puts $X }")
+
+    def test_non_pure_body_is_not_narrowed(self):
+        assert "X" in self._flagged("if {[catch {someproc $X}]} { puts a } else { puts $X }")
+
+
 class TestAnalysisLevel:
     """Direct assertions on the core analysis result."""
 

--- a/tests/test_existence_checks.py
+++ b/tests/test_existence_checks.py
@@ -1,0 +1,181 @@
+"""Existence-check handling for ``info exists`` / ``array exists``.
+
+These commands test whether a variable is set rather than reading its value, so:
+
+* they never trigger ``W210`` ("read before set");
+* when the target is provably absent or present, SCCP folds the check to a
+  constant, the existing ``I230`` constant-branch diagnostic fires, and DCE can
+  drop the dead arm;
+* in the true region of a guard the variable is known to exist (reads are
+  safe), while the false region still flags a read-before-set.
+
+Regression coverage for issue #500.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from compiler.core_analyses import analyse_source
+from server.features.diagnostics import get_diagnostics
+
+
+def _codes(src: str, *keep: str) -> list[str]:
+    wanted = set(keep) if keep else None
+    return [str(d.code) for d in get_diagnostics(src) if wanted is None or str(d.code) in wanted]
+
+
+def _messages(src: str, code: str) -> list[str]:
+    return [d.message for d in get_diagnostics(src) if str(d.code) == code]
+
+
+class TestNoReadBeforeSet:
+    def test_info_exists_is_not_read_before_set(self):
+        # The original issue: the check itself must not be W210.
+        assert "W210" not in _codes("proc p {} { if {[info exists FOO]} { set y 1 } }")
+
+    def test_array_exists_is_not_read_before_set(self):
+        assert "W210" not in _codes("proc p {} { if {[array exists FOO]} { set y 1 } }")
+
+    def test_check_in_value_is_not_read_before_set(self):
+        assert "W210" not in _codes("proc p {} { set r [info exists FOO]; puts $r }")
+
+    def test_check_as_argument_is_not_read_before_set(self):
+        assert "W210" not in _codes("proc p {} { puts [info exists FOO] }")
+
+    def test_plain_read_still_flagged(self):
+        # A genuine value read of an unset variable is still W210.
+        assert "W210" in _codes("proc p {} { puts $BAR }", "W210")
+
+    def test_array_get_is_a_value_read_still_flagged(self):
+        # ``array get`` reads the array contents — not an existence check.
+        assert "W210" in _codes("proc p {} { puts [array get FOO] }", "W210")
+
+
+class TestProvablyAbsentFoldsFalse:
+    def test_issue_example_body_never_executes(self):
+        src = (
+            "proc myProc {} {\n"
+            "    if {[info exists ACCESS_RPC_HANDLE]} {\n"
+            "        set y 1\n"
+            "    }\n"
+            "}"
+        )
+        msgs = _messages(src, "I230")
+        assert any("always false" in m for m in msgs), msgs
+        assert "W210" not in _codes(src)
+
+    def test_lazy_init_reuse_branch_is_dead_for_local(self):
+        # Mirrors the issue's real-world ILX pattern: a *local* never persists
+        # across calls, so the re-use branch is unreachable.
+        src = (
+            "proc authorize {} {\n"
+            "    if {[info exists H]} {\n"
+            "        set reuse 1\n"
+            "    } else {\n"
+            "        set H 1\n"
+            "    }\n"
+            "}"
+        )
+        assert any("always false" in m for m in _messages(src, "I230"))
+
+    def test_array_exists_absent_folds_false(self):
+        assert any(
+            "always false" in m
+            for m in _messages("proc p {} { if {[array exists FOO]} { puts dead } }", "I230")
+        )
+
+    def test_negated_check_folds(self):
+        src = "proc p {} { if {![info exists FOO]} { puts runs } else { puts dead } }"
+        assert any("always true" in m for m in _messages(src, "I230"))
+
+
+class TestProvablyPresentFoldsTrue:
+    def test_set_before_check_folds_true(self):
+        src = "proc p {} { set X 1; if {[info exists X]} { puts ok } else { puts dead } }"
+        assert any("always true" in m for m in _messages(src, "I230"))
+
+    def test_parameter_always_exists(self):
+        src = "proc p {x} { if {[info exists x]} { puts ok } else { puts dead } }"
+        assert any("always true" in m for m in _messages(src, "I230"))
+
+    def test_unset_then_check_is_not_true(self):
+        # After ``unset`` the variable is gone again — must not fold to true.
+        src = "proc p {} { set X 1; unset X; if {[info exists X]} { puts a } else { puts b } }"
+        assert not any("always true" in m for m in _messages(src, "I230"))
+
+
+class TestSoundnessGates:
+    """The fold must bail whenever a local could be created/destroyed invisibly."""
+
+    def test_global_is_not_folded(self):
+        # A global may exist independently of this frame.
+        src = "proc p {} { global H; if {[info exists H]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+    def test_namespace_variable_is_not_folded(self):
+        src = "proc p {} { variable H; if {[info exists H]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+    def test_eval_barrier_disables_fold(self):
+        src = "proc p {} { eval $cmd; if {[info exists X]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+    def test_namespace_qualified_name_is_not_folded(self):
+        src = "proc p {} { if {[info exists ::ns::X]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+    def test_array_element_is_not_folded(self):
+        src = "proc p {} { if {[info exists A(k)]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+
+class TestFlowSensitiveNarrowing:
+    """In the true region a guarded variable exists; the false region does not."""
+
+    def _src(self, body: str) -> str:
+        # An ``eval`` barrier keeps both arms live (no fold) so the narrowing,
+        # not DCE, is what governs the result.
+        return f"proc p {{}} {{ eval $cmd; {body} }}"
+
+    def test_true_branch_read_is_safe(self):
+        src = self._src("if {[info exists X]} { puts $X }")
+        # ``cmd`` is the genuine read-before-set; ``X`` is guarded.
+        assert "X" not in [
+            d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"
+        ]
+
+    def test_false_branch_read_is_flagged(self):
+        src = self._src("if {[info exists X]} { puts $X } else { puts $X }")
+        flagged = [d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"]
+        assert "X" in flagged
+
+    def test_negated_guard_narrows_else_branch(self):
+        src = self._src("if {![info exists X]} { puts no } else { puts $X }")
+        flagged = [d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"]
+        assert "X" not in flagged
+
+    def test_nested_true_branch_read_is_safe(self):
+        src = self._src("if {[info exists X]} { if {[string length a]} { puts $X } }")
+        flagged = [d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"]
+        assert "X" not in flagged
+
+
+class TestAnalysisLevel:
+    """Direct assertions on the core analysis result."""
+
+    def test_constant_branch_recorded_for_absent_local(self):
+        module = analyse_source("proc p {} { if {[info exists FOO]} { puts dead } }")
+        fn = module.procedures["::p"]
+        assert any(not b.value for b in fn.constant_branches)
+        assert fn.unreachable_blocks
+
+    def test_no_constant_branch_for_global(self):
+        module = analyse_source(
+            "proc p {} { global FOO; if {[info exists FOO]} { puts x } else { puts y } }"
+        )
+        fn = module.procedures["::p"]
+        assert not fn.constant_branches

--- a/tests/test_existence_checks.py
+++ b/tests/test_existence_checks.py
@@ -164,6 +164,56 @@ class TestFlowSensitiveNarrowing:
         assert "X" not in flagged
 
 
+class TestInfoVarsNarrowing:
+    """``info vars`` / ``info locals`` membership idioms narrow reads too.
+
+    The leading ``eval`` barrier keeps both arms live (no fold), so narrowing —
+    not DCE — governs whether the guarded read is flagged.
+    """
+
+    def _flagged(self, body: str) -> set[str]:
+        src = f"proc p {{}} {{ eval $cmd; {body} }}"
+        return {d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"}
+
+    def test_info_vars_ne_empty_true_branch(self):
+        assert "X" not in self._flagged('if {[info vars X] ne ""} { puts $X }')
+
+    def test_info_vars_ne_empty_false_branch_flagged(self):
+        assert "X" in self._flagged('if {[info vars X] ne ""} { puts a } else { puts $X }')
+
+    def test_info_vars_eq_empty_else_branch(self):
+        assert "X" not in self._flagged('if {[info vars X] eq ""} { puts a } else { puts $X }')
+
+    def test_info_locals_ne_empty(self):
+        assert "X" not in self._flagged('if {[info locals X] ne ""} { puts $X }')
+
+    def test_llength_info_vars(self):
+        assert "X" not in self._flagged("if {[llength [info vars X]]} { puts $X }")
+
+    def test_lsearch_gt_minus_one(self):
+        assert "X" not in self._flagged("if {[lsearch [info vars] X] > -1} { puts $X }")
+
+    def test_lsearch_exact_ge_zero(self):
+        assert "X" not in self._flagged("if {[lsearch -exact [info vars] X] >= 0} { puts $X }")
+
+    def test_lsearch_eq_minus_one_else_branch(self):
+        assert "X" not in self._flagged(
+            "if {[lsearch [info vars] X] == -1} { puts a } else { puts $X }"
+        )
+
+    def test_info_globals_is_not_narrowed(self):
+        # ``info globals`` proves the *global* exists, not the local ``$X``.
+        assert "X" in self._flagged('if {[info globals X] ne ""} { puts $X }')
+
+    def test_lsearch_regexp_is_not_narrowed(self):
+        # ``-regexp`` matches a regex, not an exact name — unsound to narrow.
+        assert "X" in self._flagged("if {[lsearch -regexp [info vars] X] > -1} { puts $X }")
+
+    def test_glob_pattern_is_not_narrowed(self):
+        # A glob pattern is not a single exact name.
+        assert "X" in self._flagged('if {[info vars X*] ne ""} { puts $X }')
+
+
 class TestAnalysisLevel:
     """Direct assertions on the core analysis result."""
 

--- a/tests/test_existence_checks.py
+++ b/tests/test_existence_checks.py
@@ -54,6 +54,13 @@ class TestNoReadBeforeSet:
         # ``array get`` reads the array contents — not an existence check.
         assert "W210" in _codes("proc p {} { puts [array get FOO] }", "W210")
 
+    def test_dynamic_target_is_a_real_read(self):
+        # ``info exists $name`` reads ``name`` to form the variable name being
+        # tested, so an unset ``name`` is still a genuine read-before-set and
+        # must not be suppressed (PR #502 review).
+        assert "W210" in _codes("proc p {} { if {[info exists $name]} { puts hi } }", "W210")
+        assert "W210" in _codes("proc p {} { set r [info exists $name]; puts $r }", "W210")
+
 
 class TestProvablyAbsentFoldsFalse:
     def test_issue_example_body_never_executes(self):
@@ -132,6 +139,21 @@ class TestSoundnessGates:
         src = "proc p {} { if {[info exists A(k)]} { puts a } else { puts b } }"
         assert "I230" not in _codes(src)
 
+    def test_nested_command_sub_assignment_is_not_folded(self):
+        # `set y [set X 1]` creates X with no SSA definition, so the folder must
+        # not treat X as absent (PR #502 review).
+        src = "proc p {} { set y [set X 1]; if {[info exists X]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+    def test_command_sub_in_call_arg_is_not_folded(self):
+        src = "proc p {} { puts [set X 1]; if {[info exists X]} { puts a } else { puts b } }"
+        assert "I230" not in _codes(src)
+
+    def test_mutation_free_value_command_still_folds(self):
+        # A value whose command sub cannot create a local must not block folding.
+        src = "proc p {} { set n [string length abc]; if {[info exists X]} { puts a } else { puts b } }"
+        assert any("always false" in m for m in _messages(src, "I230"))
+
 
 class TestFlowSensitiveNarrowing:
     """In the true region a guarded variable exists; the false region does not."""
@@ -162,6 +184,19 @@ class TestFlowSensitiveNarrowing:
         src = self._src("if {[info exists X]} { if {[string length a]} { puts $X } }")
         flagged = [d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"]
         assert "X" not in flagged
+
+    def test_and_pure_right_keeps_both_facts(self):
+        # `[info exists X] && [info exists Y]` — both pure → both narrowed.
+        src = self._src("if {[info exists X] && [info exists Y]} { puts $X$Y }")
+        flagged = [d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"]
+        assert "X" not in flagged and "Y" not in flagged
+
+    def test_and_impure_right_drops_left_fact(self):
+        # An impure right operand can mutate X before the branch, so the left
+        # `info exists X` fact must not narrow the body (PR #502 review).
+        src = self._src("if {[info exists X] && [otherproc]} { puts $X }")
+        flagged = [d.message.split("'")[1] for d in get_diagnostics(src) if str(d.code) == "W210"]
+        assert "X" in flagged
 
 
 class TestInfoVarsNarrowing:


### PR DESCRIPTION
## Summary

Implement constant folding and flow-sensitive narrowing for `[info exists X]` / `[array exists X]` existence checks:

- **Constant folding**: When a plain local scalar is provably absent (version 0, not a parameter, not frame-escaping) or present (assigned or a parameter), fold the existence check to `0`/`1` in SCCP. This feeds the existing `I230` constant-branch diagnostic and enables DCE to drop dead arms.

- **Flow-sensitive narrowing**: In the true region of `if {[info exists X]} { … }`, the variable is known to exist, so reads there are not flagged as read-before-set. The false region of a negated guard is handled symmetrically. Narrowing also applies to `info vars` / `info locals` membership idioms (`ne ""`, `[llength …]`, `[lsearch [info vars] …] > -1`) and `catch {set _ $X}` patterns.

- **Soundness gates**: Folding is disabled per-function whenever any statement could create/destroy a local invisibly (barriers, `eval`, inline bodies, unknown procs). Array elements (`A(k)`) and qualified names (`::ns::X`) are never folded.

- **Existence checks are not reads**: The check reference itself never triggers W210, since `info exists` tests rather than reads a value.

This resolves the common surprise where a local variable used for "remember this between calls" is flagged as always absent (since locals do not survive across invocations).

## Changes

- **`compiler/core_analyses.py`**: 
  - Add `_parse_existence_check()` to parse `[info exists X]` / `[array exists X]`
  - Add `_existence_scalar_name()` to extract plain local scalar targets
  - Add `_ExistenceFolder` dataclass to track per-function foldability and version definitions
  - Add `_fold_existence_in_expr()` to rewrite foldable checks to literals
  - Add `_existence_checks_in_stmt()` / `_existence_checks_in_expr()` to identify check references (not reads)
  - Add `_existence_implications()` to extract narrowing facts from conditions
  - Add `_existence_narrowed_blocks()` to map blocks to names proved to exist by dominating guards
  - Integrate folding into `_evaluate_branch_decision()` and `_sccp()`
  - Integrate narrowing into `_read_before_set()` to suppress flagged reads in guarded regions
  - Support `info vars` / `info locals` membership patterns and `catch {set _ $X}` narrowing

- **`shared/naming.py`**: Add `is_unqualified_var_name()` to identify plain local scalars (no namespace qualifier, no array syntax)

- **`tests/test_existence_checks.py`**: Comprehensive test suite covering:
  - Existence checks are not read-before-set
  - Constant folding for absent/present locals
  - Soundness gates (globals, namespace variables, eval barriers, qualified names, array elements)
  - Flow-sensitive narrowing in true/false branches
  - `info vars` / `info locals` membership idioms
  - `catch` narrowing patterns
  - Analysis-level assertions

- **`docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md`**: New KCS note explaining why existence checks fold to constants and how to fix the common "lazy init" pattern

- **`docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md`**: Updated to document that existence checks are not reads and explain narrowing

- **`docs/design/compiler/sccp-core-analyses.md`**: Added section documenting existence-check folding and narrowing in SCCP

## Validation

- Added 255-line test suite (`tests/test_existence_checks.py`) covering all major scenarios: no-read-before-set, constant folding, soundness gates, flow-sensitive narrowing, and idiom recognition
- All tests pass locally
- Existing SCCP and read-before-set

https://claude.ai/code/session_01KY2hWeMwKMoq3PeCWHdVzf