### PR TITLE
Release v1.10.10 notes

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.9-5-g9218e841
-head=9218e84181605d4e32b625bf1bb969e07c53cef9
-date=2026-05-29T21:41:30Z
-fingerprint=350c6812d50098d0709a6a0526be634115102e3f9ad85ce0fbe9b6bd201de923
+describe=v1.10.9-2-gdd206790-dirty
+head=dd20679067d907ac6397bc9c4e0f7ee4d32883f0
+date=2026-05-29T22:11:06Z
+fingerprint=9149518a2102f516172b0e07ac337dfab96c626136fb93cd65b31052c88dabf3

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,52 +1,69 @@
-# v1.10.9
+# v1.10.10
 
 ## New Features
 
-- **Folding for backslash line-continuation commands (#493).** Commands
-  spread across multiple physical lines via `\<newline>` continuations
-  (e.g. a long proc call with each argument on its own line) are now
-  foldable, collapsing to the opening line. Restores the legacy Tcl
-  editor plugin behaviour.
-- **`#region` / `#endregion` marker folding** (kind=`region`). Works
-  in every LSP client — Zed, Neovim, Emacs, Sublime, Helix included —
-  rather than depending on the VS Code language-configuration file.
-- **Import-group folding** (kind=`imports`). Consecutive
-  `package require` / `source` / `load` runs collapse to a single
-  fold, matching the convention used by other language servers.
+- **W127 — argument value outside a command's closed set.** Some
+  command arguments accept only a fixed, exhaustive set of literals
+  (e.g. the bareword `HTTP::version` setter takes only `0.9` / `1.0` /
+  `1.1`). A literal outside that set is now flagged with the allowed
+  values listed in the message. Dynamic values (`$var`, `[cmd]`) and
+  option flags are skipped, so `HTTP::version -string $raw` stays
+  silent. Marked via a new `FormSpec.closed_value_args` registry
+  field — other commands can opt in by listing their closed indices.
+- **HTTP/1.x version completions on `HTTP::version`.** The bareword
+  setter now offers `0.9`, `1.0`, `1.1` as completions. The
+  `-string` form remains unconstrained (HTTP/2 and HTTP/3 live in
+  the separate `HTTP2::` / `HTTP3::` namespaces).
 
 ## Improvements
 
-- **Unified block folding.** A single syntactic block collector now
-  folds every multi-line braced `{...}` token (proc / namespace /
-  control-flow bodies *and* plain data literals — lists, dicts, switch
-  arms), bracketed `[...]` command substitutions, and quoted
-  `"..."` strings. Resolves the inconsistency where a proc body folded
-  but an identical-looking multi-line list did not, and lets
-  continuations inside `[...]` fold via their enclosing token.
-- **Folding is now purely syntactic.** The semantic-analysis
-  dependency was removed, so folding works on incomplete or
-  syntactically-broken files where the analyser would have bailed out.
-- **Comment-block folds yield to region markers.** A `#region` /
-  `#endregion` inside a comment block now produces a Region fold
-  instead of being absorbed silently.
+- **Bodies of `clientside`, `serverside`, `after`, and `peer` are
+  now recursively analysed.** All four iRule commands take an
+  optional `NESTING_SCRIPT` but previously declared no `ArgRole.BODY`
+  — their script contents were treated as opaque, so nested
+  diagnostics, semantic tokens, and scope handling didn't fire
+  inside them. Each now carries the correct BodyKind and
+  `is_side_switch` flag, with arity tightened from unbounded to
+  `(0, 1)` so a stray `clientside a b c` reports E003.
+- **`peer` is a first-class side-switch.** It now flips to the
+  *opposite* of the current side rather than being treated as
+  opaque, so `peer { TCP::collect }` inside a server event correctly
+  satisfies a `CLIENT_DATA` payload requirement.
+- **W210 (read-before-set) no longer fires inside an existence
+  guard.** `info exists X`, `array exists X`, `info vars X` (and the
+  `info locals` variant), `[lsearch [info vars] X]`, and
+  `catch {set _ $X}` are now recognised as *existence probes*, not
+  value reads — and reads of `X` inside the region they prove are
+  safe.
+- **SCCP folds existence checks both directions.** When the answer
+  is statically provable (a local that never persists, or a definite
+  assignment / parameter), the I230 diagnostic fires and the dead
+  arm is dropped by DCE. `array exists` only folds to false (a
+  scalar set is not an array). A conservative per-function gate
+  keeps the fold sound: it bails on any barrier / `IRBlock` /
+  `IRUpFrame`, any call with an UNKNOWN-target write or inline-body
+  argument (e.g. `eval`, `clientside`, …), and excludes array
+  elements and qualified names. Resolves #500.
+- **Existence-name shape is now derived from the lexer.** The
+  legacy `_EXISTENCE_LOCAL_RE` regex was replaced with
+  `shared.naming.is_unqualified_var_name`, built on the lexer's
+  `is_bare_var_name` rule — single source of truth, no drift, and
+  it handles the digit-leading / Unicode names the lexer accepts.
 
 ## Bug Fixes
 
-- **Folding dropped a degenerate fold on a dangling `\` at EOF.**
-  A trailing backslash on the last line no longer produces a fold
-  over the empty space past it.
-- **`ping(ip)` in f5-query could return `ok=True` with `rtt_ms=None`.**
-  Under load (and on macOS where the BSD `ping -W` flag is per-packet
-  milliseconds rather than per-deadline seconds), the per-reply
-  `time=NN ms` token could be missing even when the subprocess exited
-  cleanly. The parser now falls back to the summary line
-  (`min/avg/max[/...] = X/Y/Z[/...] ms`) that both BSD and Linux
-  `ping` emit on success, so the rtt is always populated when `ok` is
-  true.
-- **`make publish-{verify,sublime,zed}` looked in the wrong directory.**
-  The three release scripts under `scripts/release/` computed `$ROOT`
-  as `$(dirname $0)/..` — one level too shallow after the seven-concern
-  package reorg moved them out of `scripts/`. `publish-verify`
-  consequently reported every editor `[fail]` on a clean tree, and
-  `publish-sublime` aborted post-build with `build/sublime-stage not
-  found`. Both now resolve to the repo root.
+- **Dynamic existence targets are no longer silently exempted.**
+  `if {[info exists $name]}` reads `name` to *form* the variable
+  name being probed, so the read is real — only literal plain
+  scalars are now exempted. `$name`, `A(k)`, `::ns::X` are flagged
+  as W210 if they read before set.
+- **Nested command substitutions inside an existence guard's value
+  or expression are no longer mistaken for absent variables.**
+  `set y [set X 1]` and `puts [set X 1]` create a local inside a
+  command substitution that has no SSA definition; the folder
+  previously treated the resulting `X` as never-set. The
+  transparency check now rejects statements whose value / expr /
+  args carry a command sub that can create / modify / remove a
+  local. `unset` / `array unset` and BODY-running commands are
+  treated as mutating; mutation-free subs (`string length`,
+  `ILX::call`, …) still fold.


### PR DESCRIPTION
## Summary
- Add \`RELEASE_NOTES.md\` for v1.10.10 (W127 closed-value arg check, iRule body analysis for clientside/serverside/after/peer, existence-check narrowing + SCCP folds)
- Refresh \`.test-slow.stamp\` from a passing local run

Release-notes PR for the v1.10.10 tag (patch). Merge once CI is green; the tag will be pushed against the resulting commit on \`main\`.

## Test plan
- [x] \`make prep-pr\` clean (14250 tests)
- [x] \`make test-slow\` clean (some hover/Call-Hierarchy tests flaked once locally on this macOS box but the second run was green; CI is the canonical check)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)