### PR TITLE
Add reposition cache for moved procedures

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -246,6 +246,12 @@ ignore_imports =
     ; the test subject, so this dev-only harness legitimately reaches
     ; into server/ to exercise it.
     tooling.fuzzing.incremental_diff -> server.workspace.document_state
+    ; The reposition-tracking differential campaign drives a real
+    ; server.workspace.DocumentState through reposition-biased edit bursts
+    ; and compares its incremental compilation unit (CFG ranges + byte
+    ; offsets) against a full rebuild.  Same dev-only test-subject rationale
+    ; as incremental_diff above.
+    tooling.fuzzing.reposition_campaign -> server.workspace.document_state
     ; The `tcl minimize` CLI verb wraps server.features.minimize, which
     ; deliberately hosts the shared minimize_diagnostic logic for both the
     ; CLI and the LSP code action.  Lazy import behind the verb dispatcher

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.10-186-g5100b6cd
-head=5100b6cd215b96a19c642585083ae0c28d55c015
-date=2026-05-31T21:27:37Z
-fingerprint=8bc78f63b378d1ff131a076b340eb66e9690094136450d435c37761134e29657
+describe=d03a102-dirty
+head=d03a102bd25c9bfc186afb89de765ebc1b8cc642
+date=2026-06-01T08:37:51Z
+fingerprint=49cb274e8e9d2b877fb01da1d9c86ebc3f4d2968d37d5479562d54a3ca2689a9

--- a/compiler/compilation_unit.py
+++ b/compiler/compilation_unit.py
@@ -240,6 +240,49 @@ def _proc_cache_key(
     )
 
 
+def _proc_reposition_key(
+    source: str,
+    qname: str,
+    start_offset: int,
+    end_offset: int,
+    stub_fingerprint: int = 0,
+    context_fingerprint: int = 0,
+    known_classes_fp: int = 0,
+) -> tuple[str, int] | None:
+    """Build a *position-independent* procedure key for the reposition cache.
+
+    This is :func:`_proc_cache_key` with the proc's start line/char/offset
+    deliberately **excluded**.  Two compilations whose only difference is that
+    the proc moved (e.g. a blank line inserted above it) produce the same
+    reposition key even though their primary cache keys differ.
+
+    A hit means the body text and every non-positional validity input (stub
+    overlay, CFG-construction context, known-class set) are unchanged, so the
+    proc's *dataflow* is identical — only its absolute source ranges shifted.
+    The caller may therefore reuse the cached unit's position-independent
+    ``analysis`` / ``execution_intent`` (keyed by block name + statement index
+    + SSA value key, never by absolute position) and rebuild just the cheap
+    CFG + SSA to recover correct ranges.  The validity contract matches the
+    primary cache exactly minus position, so this is no less sound than the
+    existing whole-unit reuse.
+    """
+    if start_offset < 0 or end_offset < start_offset or end_offset > len(source):
+        return None
+    # Slice end-exclusive at end_offset+1 to match _proc_cache_key (end_offset
+    # is the proc's last character, inclusive).
+    return (
+        qname,
+        hash(
+            (
+                source[start_offset : end_offset + 1],
+                stub_fingerprint,
+                context_fingerprint,
+                known_classes_fp,
+            )
+        ),
+    )
+
+
 def known_classes_fingerprint(known_classes: frozenset[str]) -> int:
     """Stable per-process fingerprint of the TclOO/snit class-name set.
 
@@ -278,6 +321,7 @@ def compile_source(
     *,
     ir_module: IRModule | None = None,
     proc_cache: dict[tuple[str, int], FunctionUnit] | None = None,
+    reposition_cache: dict[tuple[str, int], FunctionUnit] | None = None,
     interproc_cache: dict[tuple[str, int], ProcLocalSummary] | None = None,
     prune_interproc_cache: bool = True,
     known_classes: frozenset[str] = frozenset(),
@@ -294,6 +338,12 @@ def compile_source(
     whose source text has not changed are reused instead of rebuilding
     SSA and dataflow analysis from scratch.  The cache key is
     ``(qualified_name, hash(procedure_source_text))``.
+
+    When *reposition_cache* is provided, a procedure whose body text is
+    unchanged but which has *moved* (a primary-cache miss because its absolute
+    positions shifted) reuses the cached unit's position-independent ``analysis``
+    / ``execution_intent`` and rebuilds only the cheap CFG + SSA, instead of
+    re-running the expensive dataflow analysis.  See :func:`_proc_reposition_key`.
 
     When *interproc_cache* is provided, local interprocedural summaries
     are also reused for unchanged procedures using the same key shape.
@@ -321,6 +371,7 @@ def compile_source(
             source,
             ir_module=ir_module,
             proc_cache=proc_cache,
+            reposition_cache=reposition_cache,
             interproc_cache=interproc_cache,
             prune_interproc_cache=prune_interproc_cache,
             known_classes=known_classes,
@@ -334,6 +385,7 @@ def _compile_source_inner(
     *,
     ir_module: IRModule | None,
     proc_cache: dict[tuple[str, int], FunctionUnit] | None,
+    reposition_cache: dict[tuple[str, int], FunctionUnit] | None = None,
     interproc_cache: dict[tuple[str, int], ProcLocalSummary] | None,
     prune_interproc_cache: bool,
     known_classes: frozenset[str],
@@ -445,6 +497,39 @@ def _compile_source_inner(
             faithful_exceptions=True,
         )
         proc_cfgs[qname] = cfg
+
+        # Reposition fast-path: the proc body text (and every non-positional
+        # validity input) is unchanged but the proc moved, so the primary cache
+        # missed only because its absolute positions shifted.  The freshly-built
+        # CFG above already carries correct ranges; the cached unit's SSA +
+        # dataflow ``analysis`` / ``execution_intent`` are position-independent
+        # (keyed by block name + statement index + SSA value key), so reuse them
+        # instead of paying for SSA + the ~85%-of-cost dataflow analysis.  We
+        # still rebuild SSA (cheap, ~11%) because the cached SSA wraps the *old*
+        # IR statements with stale ranges and is consumed for ranges downstream.
+        if reposition_cache is not None and not byte_guarded:
+            repos_key = _proc_reposition_key(
+                source,
+                qname,
+                ir_proc.range.start.offset,
+                ir_proc.range.end.offset,
+                stub_fingerprint=stub_fingerprint,
+                context_fingerprint=context_fingerprint,
+                known_classes_fp=known_classes_fp,
+            )
+            repos = reposition_cache.get(repos_key) if repos_key is not None else None
+            if repos is not None and not repos.complexity_guarded:
+                ssa = build_ssa(cfg)
+                proc_units[qname] = FunctionUnit(
+                    cfg=cfg,
+                    ssa=ssa,
+                    analysis=repos.analysis,
+                    execution_intent=repos.execution_intent,
+                    complexity_guarded=repos.complexity_guarded,
+                )
+                time.sleep(0)  # Yield GIL between procedures
+                continue
+
         ssa = build_ssa(cfg, force_guard=byte_guarded)
         proc_params = frozenset(ir_proc.params)
         param_constants = _params_constants_from_call_sites(ir_proc, call_site_constants, qname)

--- a/compiler/compilation_unit.py
+++ b/compiler/compilation_unit.py
@@ -190,6 +190,7 @@ def _proc_cache_key(
     start_line: int = 0,
     start_char: int = 0,
     known_classes_fp: int = 0,
+    call_site_constants_fp: int = 0,
 ) -> tuple[str, int] | None:
     """Build a procedure cache key from source offsets.
 
@@ -209,6 +210,12 @@ def _proc_cache_key(
     ``analyse_function``: ``[ClassName new]`` propagates an OBJECT type only
     when ``ClassName`` is known, so adding/renaming a class elsewhere must
     invalidate an otherwise-unchanged proc's cached object-type facts.
+
+    ``call_site_constants_fp`` covers the literal call-site args seeded into
+    ``analyse_function`` as ``param_constants``: editing a caller's literal arg
+    (``foo 1`` → ``foo 0``) changes the proc's SCCP / unreachable-branch facts
+    even though the proc's own text and position are unchanged, so it must
+    invalidate the cached unit (see :func:`call_site_constants_fingerprint`).
 
     The proc's **start line/char AND byte offset** are all part of the key. The
     cached ``FunctionUnit``'s CFG/SSA carry *absolute* source positions — both
@@ -235,6 +242,7 @@ def _proc_cache_key(
                 start_char,
                 start_offset,
                 known_classes_fp,
+                call_site_constants_fp,
             )
         ),
     )
@@ -248,6 +256,7 @@ def _proc_reposition_key(
     stub_fingerprint: int = 0,
     context_fingerprint: int = 0,
     known_classes_fp: int = 0,
+    call_site_constants_fp: int = 0,
 ) -> tuple[str, int] | None:
     """Build a *position-independent* procedure key for the reposition cache.
 
@@ -257,14 +266,16 @@ def _proc_reposition_key(
     reposition key even though their primary cache keys differ.
 
     A hit means the body text and every non-positional validity input (stub
-    overlay, CFG-construction context, known-class set) are unchanged, so the
-    proc's *dataflow* is identical — only its absolute source ranges shifted.
-    The caller may therefore reuse the cached unit's position-independent
-    ``analysis`` / ``execution_intent`` (keyed by block name + statement index
-    + SSA value key, never by absolute position) and rebuild just the cheap
-    CFG + SSA to recover correct ranges.  The validity contract matches the
-    primary cache exactly minus position, so this is no less sound than the
-    existing whole-unit reuse.
+    overlay, CFG-construction context, known-class set, call-site constants) are
+    unchanged, so the proc's *dataflow* is identical — only its absolute source
+    ranges shifted.  The caller may therefore reuse the cached unit's
+    position-independent ``analysis`` / ``execution_intent`` (keyed by block
+    name + statement index + SSA value key, never by absolute position) and
+    rebuild just the cheap CFG + SSA to recover correct ranges.  The validity
+    contract matches the primary cache exactly minus position, so this is no
+    less sound than the existing whole-unit reuse — including
+    ``call_site_constants_fp`` so a moved proc whose caller also changed a
+    literal arg is not served stale SCCP / unreachable-branch facts.
     """
     if start_offset < 0 or end_offset < start_offset or end_offset > len(source):
         return None
@@ -278,6 +289,7 @@ def _proc_reposition_key(
                 stub_fingerprint,
                 context_fingerprint,
                 known_classes_fp,
+                call_site_constants_fp,
             )
         ),
     )
@@ -292,6 +304,45 @@ def known_classes_fingerprint(known_classes: frozenset[str]) -> int:
     builders outside :func:`compile_source` produce matching keys.
     """
     return hash(tuple(sorted(known_classes)))
+
+
+def call_site_constants_fingerprint(
+    call_site_constants: "dict[str, dict[int, set[object]]]",
+) -> dict[str, int]:
+    """Per-proc fingerprint of the literal values flowing into each proc's
+    params from its call sites.
+
+    ``analyse_function`` is seeded with ``param_constants`` derived (via
+    ``_params_constants_from_call_sites``) from the literal args every call site
+    passes a proc.  Those facts drive SCCP / unreachable-branch results, so a
+    proc whose *body text and position are unchanged* can still need
+    re-analysis when a caller edits a literal arg (``foo 1`` → ``foo 0``).  The
+    proc-cache / reposition keys therefore fold this fingerprint in, or an
+    unchanged-but-restamped proc would serve stale branch facts (the
+    ``analyse_function`` ``param_constants`` seed is invisible to a body-text
+    key).
+
+    Returns ``{qname -> fingerprint}``; a proc absent from *call_site_constants*
+    (no user-proc call sites) maps to ``0`` via the callers' ``.get(qname, 0)``.
+    Arg indices are sorted and each value set is rendered to a sorted tuple of
+    ``(typename, repr)`` pairs so a ``1`` (int) and ``"1"`` (str) never collide.
+    The ``_UNKNOWN_ARG`` sentinel (a bare ``object()`` whose ``repr`` embeds its
+    address) is rendered to a fixed token so the fingerprint is reproducible.
+    """
+    from compiler.core_analyses import _UNKNOWN_ARG
+
+    def _render(v: object) -> tuple[str, str]:
+        if v is _UNKNOWN_ARG:
+            return ("", "<unknown-arg>")
+        return (type(v).__name__, repr(v))
+
+    out: dict[str, int] = {}
+    for qname, by_idx in call_site_constants.items():
+        items = tuple(
+            (idx, tuple(sorted(_render(v) for v in by_idx[idx]))) for idx in sorted(by_idx)
+        )
+        out[qname] = hash(items)
+    return out
 
 
 def compute_stub_fingerprint(source: str) -> int:
@@ -446,17 +497,17 @@ def _compile_source_inner(
     # D3-P2 / D3-P8 closure: collect call-site literal arg values per
     # user proc so the SCCP analysis can fold them.  Shared helper
     # also used by ``analyse_ir_module``; see its docstring for the
-    # full reasoning.  This is gated by the param-cache-key including
-    # ``call_site_constants_fp`` -- but for simplicity we collect once
-    # and pass through; the cache eviction is OK since proc bodies
-    # don't usually contain enough literal-call diversity to force
-    # frequent rebuilds.
+    # full reasoning.  The per-proc fingerprint is folded into the
+    # proc-cache / reposition keys below so a proc whose body text and
+    # position are unchanged is still re-analysed when a caller edits a
+    # literal arg (``foo 1`` → ``foo 0``) that seeds its ``param_constants``.
     from compiler.core_analyses import (
         _collect_call_site_constants,
         _params_constants_from_call_sites,
     )
 
     call_site_constants = _collect_call_site_constants(ir_module)
+    call_site_constants_fps = call_site_constants_fingerprint(call_site_constants)
 
     for qname, ir_proc in ir_module.procedures.items():
         cache_key = _proc_cache_key(
@@ -469,6 +520,7 @@ def _compile_source_inner(
             start_line=ir_proc.range.start.line,
             start_char=ir_proc.range.start.character,
             known_classes_fp=known_classes_fp,
+            call_site_constants_fp=call_site_constants_fps.get(qname, 0),
         )
 
         # Try the proc cache before rebuilding CFG + SSA + analysis.
@@ -516,6 +568,7 @@ def _compile_source_inner(
                 stub_fingerprint=stub_fingerprint,
                 context_fingerprint=context_fingerprint,
                 known_classes_fp=known_classes_fp,
+                call_site_constants_fp=call_site_constants_fps.get(qname, 0),
             )
             repos = reposition_cache.get(repos_key) if repos_key is not None else None
             if repos is not None and not repos.complexity_guarded:

--- a/server/workspace/document_state.py
+++ b/server/workspace/document_state.py
@@ -534,19 +534,37 @@ def _build_chunk_caches_standalone(
     return caches
 
 
-def _build_proc_cache(
+def _build_proc_caches(
     cu: CompilationUnit,
-) -> dict[tuple[str, int], FunctionUnit]:
-    """Build a proc cache from a CompilationUnit.
+) -> tuple[dict[tuple[str, int], FunctionUnit], dict[tuple[str, int], FunctionUnit]]:
+    """Build both the primary proc cache and the reposition cache in one pass.
 
-    Keys are ``(qualified_name, hash((proc_source_text, stub_fingerprint)))``
-    so a procedure's FunctionUnit can be reused across edits as long as
-    both the body text and the active stub overlay are unchanged.
+    Returns ``(proc_cache, reposition_cache)``.  Both caches key the same set of
+    ``FunctionUnit``s by validity fingerprints that must match
+    :func:`compiler.compilation_unit._proc_cache_key` /
+    ``_proc_reposition_key`` exactly; the only difference is that the reposition
+    key omits the proc's start line/char/offset (so a moved-but-otherwise-
+    unchanged proc still hits it).
+
+    The expensive shared inputs — stub fingerprint, CFG-construction context
+    (``prepare_cfg_context`` + ``cfg_context_fingerprint``), known-class
+    fingerprint, and the per-proc call-site-constants fingerprints — are
+    computed once here and fed into both keys, rather than walking the IR twice
+    (one pass per cache).
     """
     from compiler.cfg import cfg_context_fingerprint, prepare_cfg_context
-    from compiler.compilation_unit import compute_stub_fingerprint, known_classes_fingerprint
+    from compiler.compilation_unit import (
+        _proc_cache_key,
+        _proc_reposition_key,
+        call_site_constants_fingerprint,
+        compute_stub_fingerprint,
+        known_classes_fingerprint,
+    )
+    from compiler.core_analyses import _collect_call_site_constants
 
-    cache: dict[tuple[str, int], FunctionUnit] = {}
+    proc_cache: dict[tuple[str, int], FunctionUnit] = {}
+    reposition_cache: dict[tuple[str, int], FunctionUnit] = {}
+
     stub_fingerprint = compute_stub_fingerprint(cu.source)
     # The CFG-construction context (which callees write back into the caller
     # frame via upvar, and proc param maps) is part of a cached unit's validity:
@@ -557,71 +575,62 @@ def _build_proc_cache(
     upvar_procs, proc_params = prepare_cfg_context(cu.ir_module)
     context_fingerprint = cfg_context_fingerprint(upvar_procs, proc_params)
     known_classes_fp = known_classes_fingerprint(cu.known_classes)
-    for qname, fu in cu.procedures.items():
-        ir_proc = cu.ir_module.procedures.get(qname)
-        if ir_proc is not None:
-            # +1: range.end.offset is the proc's last character (inclusive).
-            # Key must match _proc_cache_key in compilation_unit.py exactly
-            # (body text + stub + context + class-set fingerprints + the proc's
-            # start line/char/offset), or a moved-but-unchanged proc is reused
-            # with stale positions/offsets or stale object-type facts.
-            start = ir_proc.range.start
-            proc_src = cu.source[start.offset : ir_proc.range.end.offset + 1]
-            key_hash = hash(
-                (
-                    proc_src,
-                    stub_fingerprint,
-                    context_fingerprint,
-                    start.line,
-                    start.character,
-                    start.offset,
-                    known_classes_fp,
-                )
-            )
-            cache[(qname, key_hash)] = fu
-    return cache
-
-
-def _build_reposition_cache(
-    cu: CompilationUnit,
-) -> dict[tuple[str, int], FunctionUnit]:
-    """Build a *position-independent* proc index for the reposition fast-path.
-
-    Keys mirror :func:`compiler.compilation_unit._proc_reposition_key`: body
-    text plus the stub / context / known-class fingerprints, but **not** the
-    proc's start line/char/offset.  A proc that merely moved (a primary-cache
-    miss) hits here, letting ``compile_source`` reuse the cached unit's
-    position-independent ``analysis`` / ``execution_intent`` and rebuild only
-    the cheap CFG + SSA.
-    """
-    from compiler.cfg import cfg_context_fingerprint, prepare_cfg_context
-    from compiler.compilation_unit import (
-        _proc_reposition_key,
-        compute_stub_fingerprint,
-        known_classes_fingerprint,
+    # Per-proc call-site-constants fingerprint: a caller editing a literal arg
+    # (``foo 1`` → ``foo 0``) changes the proc's SCCP / unreachable-branch facts
+    # even though the proc's own text and position are unchanged, so both keys
+    # fold it in or a restamped proc would serve stale branch facts.
+    call_site_constants_fps = call_site_constants_fingerprint(
+        _collect_call_site_constants(cu.ir_module)
     )
-
-    cache: dict[tuple[str, int], FunctionUnit] = {}
-    stub_fingerprint = compute_stub_fingerprint(cu.source)
-    upvar_procs, proc_params = prepare_cfg_context(cu.ir_module)
-    context_fingerprint = cfg_context_fingerprint(upvar_procs, proc_params)
-    known_classes_fp = known_classes_fingerprint(cu.known_classes)
     for qname, fu in cu.procedures.items():
         ir_proc = cu.ir_module.procedures.get(qname)
         if ir_proc is None:
             continue
-        key = _proc_reposition_key(
+        cs_fp = call_site_constants_fps.get(qname, 0)
+        start = ir_proc.range.start
+        end_offset = ir_proc.range.end.offset
+        key = _proc_cache_key(
             cu.source,
             qname,
-            ir_proc.range.start.offset,
-            ir_proc.range.end.offset,
+            start.offset,
+            end_offset,
+            stub_fingerprint=stub_fingerprint,
+            context_fingerprint=context_fingerprint,
+            start_line=start.line,
+            start_char=start.character,
+            known_classes_fp=known_classes_fp,
+            call_site_constants_fp=cs_fp,
+        )
+        if key is not None:
+            proc_cache[key] = fu
+        repos_key = _proc_reposition_key(
+            cu.source,
+            qname,
+            start.offset,
+            end_offset,
             stub_fingerprint=stub_fingerprint,
             context_fingerprint=context_fingerprint,
             known_classes_fp=known_classes_fp,
+            call_site_constants_fp=cs_fp,
         )
-        if key is not None:
-            cache[key] = fu
-    return cache
+        if repos_key is not None:
+            reposition_cache[repos_key] = fu
+    return proc_cache, reposition_cache
+
+
+def _build_proc_cache(cu: CompilationUnit) -> dict[tuple[str, int], FunctionUnit]:
+    """Primary proc cache only — thin wrapper over :func:`_build_proc_caches`.
+
+    The production update path uses ``_build_proc_caches`` directly (one IR
+    pass for both caches); this wrapper exists for callers/tests that only need
+    the primary cache.
+    """
+    return _build_proc_caches(cu)[0]
+
+
+def _build_reposition_cache(cu: CompilationUnit) -> dict[tuple[str, int], FunctionUnit]:
+    """Reposition cache only — thin wrapper over :func:`_build_proc_caches`."""
+    return _build_proc_caches(cu)[1]
 
 
 @dataclass
@@ -2019,8 +2028,9 @@ class DocumentState:
     ) -> None:
         """Update the procedure cache from the given compilation unit."""
         if compilation_unit is not None:
-            next_proc_cache = _build_proc_cache(compilation_unit)
-            next_reposition_cache = _build_reposition_cache(compilation_unit)
+            # One IR pass builds both caches, sharing the expensive fingerprint /
+            # CFG-context precomputation rather than walking the IR twice.
+            next_proc_cache, next_reposition_cache = _build_proc_caches(compilation_unit)
             if has_partial:
                 merged = dict(self._proc_cache)
                 merged.update(next_proc_cache)

--- a/server/workspace/document_state.py
+++ b/server/workspace/document_state.py
@@ -582,6 +582,48 @@ def _build_proc_cache(
     return cache
 
 
+def _build_reposition_cache(
+    cu: CompilationUnit,
+) -> dict[tuple[str, int], FunctionUnit]:
+    """Build a *position-independent* proc index for the reposition fast-path.
+
+    Keys mirror :func:`compiler.compilation_unit._proc_reposition_key`: body
+    text plus the stub / context / known-class fingerprints, but **not** the
+    proc's start line/char/offset.  A proc that merely moved (a primary-cache
+    miss) hits here, letting ``compile_source`` reuse the cached unit's
+    position-independent ``analysis`` / ``execution_intent`` and rebuild only
+    the cheap CFG + SSA.
+    """
+    from compiler.cfg import cfg_context_fingerprint, prepare_cfg_context
+    from compiler.compilation_unit import (
+        _proc_reposition_key,
+        compute_stub_fingerprint,
+        known_classes_fingerprint,
+    )
+
+    cache: dict[tuple[str, int], FunctionUnit] = {}
+    stub_fingerprint = compute_stub_fingerprint(cu.source)
+    upvar_procs, proc_params = prepare_cfg_context(cu.ir_module)
+    context_fingerprint = cfg_context_fingerprint(upvar_procs, proc_params)
+    known_classes_fp = known_classes_fingerprint(cu.known_classes)
+    for qname, fu in cu.procedures.items():
+        ir_proc = cu.ir_module.procedures.get(qname)
+        if ir_proc is None:
+            continue
+        key = _proc_reposition_key(
+            cu.source,
+            qname,
+            ir_proc.range.start.offset,
+            ir_proc.range.end.offset,
+            stub_fingerprint=stub_fingerprint,
+            context_fingerprint=context_fingerprint,
+            known_classes_fp=known_classes_fp,
+        )
+        if key is not None:
+            cache[key] = fu
+    return cache
+
+
 @dataclass
 class ChunkCache:
     """Cached artefacts for a single ``TopLevelChunk``.
@@ -652,6 +694,13 @@ class DocumentState:
     # Internal caches for the compilation pipeline — not accessed by
     # request handlers, so they live outside the snapshot.
     _proc_cache: dict[tuple[str, int], FunctionUnit] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    # Position-independent companion to ``_proc_cache``: lets a proc that merely
+    # moved (a primary-cache miss because its absolute positions shifted) reuse
+    # its cached dataflow analysis while rebuilding only the cheap CFG + SSA.
+    _reposition_cache: dict[tuple[str, int], FunctionUnit] = field(
         default_factory=dict,
         repr=False,
     )
@@ -1288,6 +1337,7 @@ class DocumentState:
             # stub/context fingerprints) do not encode the dialect, so a dialect
             # switch would otherwise reuse a unit analysed under the old dialect.
             self._proc_cache = {}
+            self._reposition_cache = {}
             self._interproc_cache = {}
             self._prev_analysed = None
         with self._signature_profile():
@@ -1455,6 +1505,7 @@ class DocumentState:
 
         # Lower IR incrementally.
         prev_proc_cache = dict(self._proc_cache)
+        prev_reposition_cache = dict(self._reposition_cache)
         prev_interproc_cache = dict(self._interproc_cache)
         ir_module = None
         compilation_unit: CompilationUnit | None = None
@@ -1465,6 +1516,7 @@ class DocumentState:
                 source,
                 ir_module=ir_module,
                 proc_cache=self._proc_cache,
+                reposition_cache=self._reposition_cache,
                 interproc_cache=self._interproc_cache,
                 prune_interproc_cache=not has_partial,
             )
@@ -1472,6 +1524,7 @@ class DocumentState:
             t_lower = time.perf_counter()
             log.debug("document_state: incremental compilation failed", exc_info=True)
             self._proc_cache = prev_proc_cache
+            self._reposition_cache = prev_reposition_cache
             self._interproc_cache = prev_interproc_cache
         t_compile = time.perf_counter()
 
@@ -1712,18 +1765,21 @@ class DocumentState:
                 return
 
         prev_proc_cache = dict(self._proc_cache)
+        prev_reposition_cache = dict(self._reposition_cache)
         prev_interproc_cache = dict(self._interproc_cache)
         compilation_unit: CompilationUnit | None = None
         try:
             compilation_unit = compile_source(
                 source,
                 proc_cache=self._proc_cache,
+                reposition_cache=self._reposition_cache,
                 interproc_cache=self._interproc_cache,
                 prune_interproc_cache=not has_partial,
             )
         except Exception:
             log.debug("document_state: compilation failed, preserving caches", exc_info=True)
             self._proc_cache = prev_proc_cache
+            self._reposition_cache = prev_reposition_cache
             self._interproc_cache = prev_interproc_cache
         t_compile = time.perf_counter()
 
@@ -1964,15 +2020,21 @@ class DocumentState:
         """Update the procedure cache from the given compilation unit."""
         if compilation_unit is not None:
             next_proc_cache = _build_proc_cache(compilation_unit)
+            next_reposition_cache = _build_reposition_cache(compilation_unit)
             if has_partial:
                 merged = dict(self._proc_cache)
                 merged.update(next_proc_cache)
                 self._proc_cache = merged
+                merged_repos = dict(self._reposition_cache)
+                merged_repos.update(next_reposition_cache)
+                self._reposition_cache = merged_repos
             else:
                 self._proc_cache = next_proc_cache
+                self._reposition_cache = next_reposition_cache
         else:
             if not has_partial:
                 self._proc_cache = {}
+                self._reposition_cache = {}
                 self._interproc_cache = {}
 
 

--- a/tests/test_compilation_cache.py
+++ b/tests/test_compilation_cache.py
@@ -9,7 +9,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from compiler import interprocedural as interproc_module
 from compiler.compilation_unit import compile_source
-from server.workspace.document_state import DocumentState, _build_proc_cache
+from server.workspace.document_state import (
+    DocumentState,
+    _build_proc_cache,
+    _build_reposition_cache,
+)
 
 
 class TestCompileSourceCache:
@@ -286,3 +290,100 @@ class TestDocumentStateProcCache:
         assert state.has_partial_commands
         assert len(state._proc_cache) >= 2
         assert len(state._interproc_cache) >= 2
+
+
+class TestRepositionCache:
+    """A proc whose body is unchanged but which *moved* misses the primary
+    (position-keyed) cache, yet should reuse its position-independent dataflow
+    analysis via the reposition cache while rebuilding only CFG + SSA."""
+
+    THREE_PROCS = (
+        "proc alpha {} { return 1 }\nproc beta {} { return 2 }\nproc gamma {} { return 3 }\n"
+    )
+
+    def test_moved_proc_reuses_analysis_not_whole_unit(self):
+        """A length-changing edit before gamma shifts gamma's offsets, so the
+        primary cache misses (its CFG/SSA carry stale offsets).  With the
+        reposition cache, gamma reuses the cached *analysis* / *execution_intent*
+        object (same identity) but gets a freshly-built CFG (new identity)."""
+        cu1 = compile_source(self.THREE_PROCS)
+        proc_cache = _build_proc_cache(cu1)
+        repos_cache = _build_reposition_cache(cu1)
+
+        # "return 2" -> "return 222": two chars longer, shifting gamma's offsets.
+        edited = (
+            "proc alpha {} { return 1 }\nproc beta {} { return 222 }\nproc gamma {} { return 3 }\n"
+        )
+        cu2 = compile_source(edited, proc_cache=proc_cache, reposition_cache=repos_cache)
+
+        g1, g2 = cu1.procedures["::gamma"], cu2.procedures["::gamma"]
+        # Whole-unit primary cache missed: new FunctionUnit, new CFG.
+        assert g2 is not g1
+        assert g2.cfg is not g1.cfg
+        # ...but the expensive position-independent artefacts were reused.
+        assert g2.analysis is g1.analysis
+        assert g2.execution_intent is g1.execution_intent
+
+    def test_moved_proc_has_correct_shifted_ranges(self):
+        """The reused analysis must pair with *correct* (freshly-built) ranges:
+        a moved-proc compile must be byte-identical to a cold rebuild."""
+        src = "set a 1\nproc gamma {x} {\n  if {$x} { set y 1 }\n  return $y\n}\n"
+        cu1 = compile_source(src)
+        proc_cache = _build_proc_cache(cu1)
+        repos_cache = _build_reposition_cache(cu1)
+
+        moved = "\n\n# pushed down\n" + src
+        cold = compile_source(moved)  # reference: no caches
+        got = compile_source(moved, proc_cache=proc_cache, reposition_cache=repos_cache)
+
+        def ranges(cu):
+            fu = cu.procedures["::gamma"]
+            return [
+                (
+                    bn,
+                    s.range.start.line,
+                    s.range.start.character,
+                    s.range.start.offset,
+                    s.range.end.offset,
+                )
+                for bn in sorted(fu.cfg.blocks)
+                for s in fu.cfg.blocks[bn].statements
+                if getattr(s, "range", None) is not None
+            ]
+
+        # Reposition path took effect (analysis reused) yet ranges match cold rebuild.
+        assert got.procedures["::gamma"].analysis is cu1.procedures["::gamma"].analysis
+        assert ranges(got) == ranges(cold)
+
+    def test_reposition_diagnostics_match_cold_rebuild(self):
+        """End-to-end: a read-before-set warning on a moved proc must land on the
+        shifted line, identical to a cold rebuild (no stale positions leak)."""
+        src = "proc gamma {} {\n  puts $undef\n  set undef 1\n}\n"
+        cu1 = compile_source(src)
+        proc_cache = _build_proc_cache(cu1)
+        repos_cache = _build_reposition_cache(cu1)
+
+        moved = "\n\n\n" + src  # push gamma down 3 lines
+        cold = compile_source(moved)
+        got = compile_source(moved, proc_cache=proc_cache, reposition_cache=repos_cache)
+
+        # Index-based analysis facts are identical, and the CFG ranges they
+        # resolve against are freshly shifted — so diagnostics co-locate.
+        assert got.procedures["::gamma"].analysis.read_before_set == (
+            cold.procedures["::gamma"].analysis.read_before_set
+        )
+
+    def test_changed_body_does_not_use_reposition(self):
+        """A genuine body edit (not a pure move) must NOT reuse stale analysis —
+        the reposition key includes body text, so it misses and rebuilds."""
+        cu1 = compile_source("proc gamma {} {\n  set x 1\n  return $x\n}\n")
+        repos_cache = _build_reposition_cache(cu1)
+
+        # Different body: introduces a read-before-set that wasn't there before.
+        changed = "proc gamma {} {\n  return $x\n}\n"
+        cu2 = compile_source(changed, proc_cache={}, reposition_cache=repos_cache)
+
+        g2 = cu2.procedures["::gamma"]
+        # Fresh analysis (not the cached one) — it now reports the new RBS.
+        assert g2.analysis is not cu1.procedures["::gamma"].analysis
+        assert any(r.variable == "x" for r in g2.analysis.read_before_set)

--- a/tests/test_compilation_cache.py
+++ b/tests/test_compilation_cache.py
@@ -387,3 +387,62 @@ class TestRepositionCache:
         # Fresh analysis (not the cached one) — it now reports the new RBS.
         assert g2.analysis is not cu1.procedures["::gamma"].analysis
         assert any(r.variable == "x" for r in g2.analysis.read_before_set)
+
+
+class TestCallSiteConstantsInvalidation:
+    """SCCP / unreachable-branch facts are seeded from call-site literal args
+    (``_params_constants_from_call_sites``).  A proc whose own text and position
+    are unchanged must still be re-analysed when a caller edits a literal arg —
+    both keys fold in a call-site-constants fingerprint (PR #508 review P2)."""
+
+    @staticmethod
+    def _branches(cu):
+        fu = cu.procedures["::foo"]
+        return tuple(sorted((c.block, c.value) for c in fu.analysis.constant_branches))
+
+    @staticmethod
+    def _doc(call, lead=""):
+        return (
+            lead
+            + "proc foo {x} {\n    if {$x} { set a 1 } else { set dead 2 }\n    return\n}\n"
+            + f"foo {call}\n"
+        )
+
+    def test_reposition_invalidates_on_call_site_constant_change(self):
+        """Proc moves AND its caller flips ``foo 1`` → ``foo 0`` in one edit: the
+        reposition path must NOT serve the stale ``x == 1`` branch facts."""
+        cu1 = compile_source(self._doc("1"))
+        proc_cache = _build_proc_cache(cu1)
+        repos_cache = _build_reposition_cache(cu1)
+
+        moved_changed = self._doc("0", lead="\n")  # moved + call-site const flipped
+        cold = compile_source(moved_changed)
+        got = compile_source(moved_changed, proc_cache=proc_cache, reposition_cache=repos_cache)
+        assert self._branches(got) == self._branches(cold)
+        # The cached (x==1 → True) analysis must not have been reused.
+        assert got.procedures["::foo"].analysis is not cu1.procedures["::foo"].analysis
+
+    def test_primary_cache_invalidates_on_call_site_constant_change(self):
+        """Same-length call edit (``foo 1`` → ``foo 0``) leaves foo's offsets
+        stable, so the *primary* cache would hit — but must still re-analyse."""
+        cu1 = compile_source(self._doc("1"))
+        proc_cache = _build_proc_cache(cu1)
+
+        changed = self._doc("0")  # foo unmoved, only the caller's literal changed
+        cold = compile_source(changed)
+        got = compile_source(changed, proc_cache=proc_cache)
+        assert self._branches(got) == self._branches(cold)
+
+    def test_unchanged_call_site_still_reuses_fast_path(self):
+        """A pure move with the call site unchanged must still hit the reposition
+        fast-path (the fingerprint only invalidates on an actual const change)."""
+        cu1 = compile_source(self._doc("1"))
+        proc_cache = _build_proc_cache(cu1)
+        repos_cache = _build_reposition_cache(cu1)
+
+        moved_same = self._doc("1", lead="\n")  # moved, call site unchanged
+        got = compile_source(moved_same, proc_cache=proc_cache, reposition_cache=repos_cache)
+        # Reposition reuse: same analysis object identity, fresh CFG.
+        g1, g2 = cu1.procedures["::foo"], got.procedures["::foo"]
+        assert g2.analysis is g1.analysis
+        assert g2.cfg is not g1.cfg

--- a/tooling/fuzzing/reposition_campaign.py
+++ b/tooling/fuzzing/reposition_campaign.py
@@ -1,0 +1,296 @@
+"""Adversarial campaign targeting the reposition fast-path's position tracking.
+
+The reposition cache reuses a proc's *position-independent* dataflow analysis
+(keyed by block name + statement index + SSA value key) while rebuilding only
+the CFG/SSA to recover fresh ranges.  Its soundness rests on two assumptions:
+
+  1. ``build_cfg_function(body)`` is a *pure function of body text* — identical
+     block names AND statement indices every time — so the reused index-based
+     analysis still points at the right statement.
+  2. The freshly-built CFG carries correct absolute ranges *including byte
+     offsets*, which flow into optimiser / code-action edit ``data``.
+
+This campaign hunts for any violation by driving an incremental ``DocumentState``
+through *reposition-biased* edit bursts (line churn above/around procs, blank
+lines, comment toggles, fast multi-edits) and, after each burst, asserting its
+**full compilation unit** — every proc's CFG block/index/line/char/**offset** —
+is byte-identical to a from-scratch rebuild on the same text.  This is a far
+stricter oracle than the diagnostics-only signature (which ignores byte
+offsets), so a misaligned reused analysis or a stale offset cannot hide.
+
+Reproducible: a finding is fully described by ``(seed, base, edit history)``.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+from server.workspace.document_state import DocumentState
+
+# --- full-CU structural signature -------------------------------------------
+
+
+def _stmt_sig(s) -> tuple | None:
+    r = getattr(s, "range", None)
+    if r is None:
+        return None
+    # Include byte offsets — the reposition path's reason to exist is correct
+    # offsets, and the diagnostics signature does NOT compare them.
+    return (
+        type(s).__name__,
+        r.start.line,
+        r.start.character,
+        r.start.offset,
+        r.end.line,
+        r.end.character,
+        r.end.offset,
+    )
+
+
+def _proc_cu_sig(fu) -> tuple:
+    """Structural + positional signature of one FunctionUnit's CFG.
+
+    Captures block names, per-block statement order, and every statement's
+    absolute range (line/char/offset).  Index-based analysis facts are also
+    folded in so a reused analysis pointing at the wrong statement is caught.
+    """
+    blocks = []
+    for bn in sorted(fu.cfg.blocks):
+        blk = fu.cfg.blocks[bn]
+        stmts = tuple(_stmt_sig(s) for s in blk.statements)
+        term = getattr(blk, "terminator", None)
+        tr = getattr(term, "range", None) if term is not None else None
+        term_sig = None if tr is None else (tr.start.offset, tr.end.offset)
+        blocks.append((bn, stmts, term_sig))
+    an = fu.analysis
+    facts = (
+        tuple(sorted((r.block, r.statement_index, r.variable) for r in an.read_before_set)),
+        tuple(sorted((d.block, d.statement_index, d.variable) for d in an.dead_stores)),
+        tuple(sorted((u.block, u.statement_index, u.variable) for u in an.unused_variables)),
+    )
+    return (tuple(blocks), facts, fu.complexity_guarded)
+
+
+def cu_signature(state: DocumentState) -> tuple | None:
+    """Full-CU signature: every proc's CFG structure + absolute positions."""
+    cu = state.compilation_unit
+    if cu is None:
+        return None
+    return tuple(sorted((q, _proc_cu_sig(fu)) for q, fu in cu.procedures.items()))
+
+
+def _full_cu_sig(text: str, uri: str) -> tuple | None:
+    s = DocumentState(uri=uri)
+    s.update(text)
+    return cu_signature(s)
+
+
+# --- reposition-biased edit generation --------------------------------------
+
+# Bases rich in procs (the reposition path only fires on procs) with varied
+# bodies so the reused analysis has real facts to misalign.
+_BASES = [
+    (
+        "proc add {a b} {\n"
+        "    set unused 1\n"
+        "    return [expr {$a + $b}]\n"
+        "}\n"
+        "proc greet {name} {\n"
+        '    puts "hi $name"\n'
+        "    return $missing\n"
+        "}\n"
+        "proc loop {n} {\n"
+        "    for {set i 0} {$i < $n} {incr i} {\n"
+        "        if {$i == 3} { set found 1 }\n"
+        "    }\n"
+        "    return $found\n"
+        "}\n"
+    ),
+    (
+        "namespace eval app {\n"
+        "    proc init {} {\n"
+        "        variable state\n"
+        "        set state ready\n"
+        "    }\n"
+        "    proc run {cmd} {\n"
+        "        switch $cmd {\n"
+        "            go { return 1 }\n"
+        "            stop { return 0 }\n"
+        "        }\n"
+        "        return $undefined\n"
+        "    }\n"
+        "}\n"
+    ),
+    (
+        "proc validate {x} {\n"
+        "    if {$x < 0} {\n"
+        '        return -code error "negative"\n'
+        "    } elseif {$x > 100} {\n"
+        "        set capped 100\n"
+        "    }\n"
+        "    return $x\n"
+        "}\n"
+        "proc process {items} {\n"
+        "    foreach item $items {\n"
+        "        lappend result [validate $item]\n"
+        "    }\n"
+        "    return $result\n"
+        "}\n"
+    ),
+]
+
+# Strings inserted/removed *between* and *above* procs — pure repositioning that
+# shifts proc offsets without touching proc body text (the fast-path's domain).
+_FILLERS = [
+    "\n",
+    "\n\n",
+    "\n\n\n",
+    "# a comment\n",
+    "# another comment line here\n",
+    "set toplevel_var 1\n",
+    'puts "top level"\n',
+    "    \n",  # whitespace-only line
+    "\t\n",
+    ";# trailing\n",
+]
+
+
+def _proc_starts(text: str) -> list[int]:
+    """Offsets of line-starts that begin a ``proc`` or ``namespace`` — the
+    natural insertion points for repositioning edits."""
+    offs = [0]
+    pos = 0
+    for line in text.splitlines(keepends=True):
+        offs.append(pos + len(line))
+        pos += len(line)
+    return offs
+
+
+def reposition_edit(rng: random.Random, text: str) -> str:
+    """Apply one reposition-biased edit: insert/remove filler at a line boundary
+    (above/between procs), or duplicate/delete a whole line.  Keeps proc *body*
+    text intact far more often than the generic fuzzer, so the fast-path fires."""
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return rng.choice(_FILLERS)
+    kind = rng.random()
+    if kind < 0.45:
+        # Insert filler at a random line boundary.
+        idx = rng.randrange(len(lines) + 1)
+        lines.insert(idx, rng.choice(_FILLERS))
+    elif kind < 0.7:
+        # Delete a random line (may delete a blank/comment, repositioning rest).
+        idx = rng.randrange(len(lines))
+        del lines[idx]
+    elif kind < 0.85:
+        # Duplicate a line.
+        idx = rng.randrange(len(lines))
+        lines.insert(idx, lines[idx])
+    else:
+        # Swap two adjacent lines (reorders, shifting offsets both ways).
+        if len(lines) >= 2:
+            idx = rng.randrange(len(lines) - 1)
+            lines[idx], lines[idx + 1] = lines[idx + 1], lines[idx]
+    return "".join(lines)
+
+
+@dataclass
+class Divergence:
+    seed: int
+    step: int
+    text: str
+    history: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+def _first_block_diff(inc_sig, full_sig) -> str:
+    """Human-readable first point of divergence between two CU signatures."""
+    inc = dict(inc_sig or ())
+    full = dict(full_sig or ())
+    for q in sorted(set(inc) | set(full)):
+        if q not in inc:
+            return f"proc {q} missing from incremental"
+        if q not in full:
+            return f"proc {q} missing from full rebuild"
+        if inc[q] != full[q]:
+            ib, fb = inc[q][0], full[q][0]
+            ibd = dict((b[0], b) for b in ib)
+            fbd = dict((b[0], b) for b in fb)
+            for bn in sorted(set(ibd) | set(fbd)):
+                if ibd.get(bn) != fbd.get(bn):
+                    return f"proc {q} block {bn}:\n   inc ={ibd.get(bn)}\n   full={fbd.get(bn)}"
+            return f"proc {q} facts/guard differ:\n   inc ={inc[q][1:]}\n   full={full[q][1:]}"
+    return "signatures differ but no per-proc diff isolated"
+
+
+def run_burst_sequence(seed: int, base: str, n_bursts: int, burst_size: int) -> Divergence | None:
+    """Drive *fast multi-edit bursts*: apply ``burst_size`` reposition edits
+    back-to-back (no settling) before each comparison, ``n_bursts`` times.
+
+    Compares the incremental state's FULL CU (offsets included) against a cold
+    rebuild after every burst."""
+    rng = random.Random(seed)
+    inc = DocumentState(uri=f"repos-inc:{seed}")
+    inc.update(base)
+    text = base
+    history = [base]
+
+    # Sanity: base must match (full == full).
+    si = cu_signature(inc)
+    sf = _full_cu_sig(base, f"repos-full:{seed}:base")
+    if si != sf:
+        return Divergence(seed, -1, text, history, _first_block_diff(si, sf))
+
+    for b in range(n_bursts):
+        # Fast burst: several edits applied in immediate succession.
+        for _ in range(burst_size):
+            text = reposition_edit(rng, text)
+            inc.update(text)  # every keystroke hits the incremental path
+        history.append(text)
+        si = cu_signature(inc)
+        sf = _full_cu_sig(text, f"repos-full:{seed}:{b}")
+        if si != sf:
+            return Divergence(seed, b, text, history, _first_block_diff(si, sf))
+    return None
+
+
+def campaign(
+    seeds: int = 200,
+    n_bursts: int = 12,
+    burst_size: int = 4,
+    max_report: int = 8,
+) -> list[Divergence]:
+    """Run a full campaign; return up to *max_report* divergences."""
+    found: list[Divergence] = []
+    for i in range(seeds):
+        base = _BASES[i % len(_BASES)]
+        d = run_burst_sequence(i, base, n_bursts, burst_size)
+        if d is not None:
+            found.append(d)
+            if len(found) >= max_report:
+                break
+    return found
+
+
+if __name__ == "__main__":
+    import argparse
+    import time
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-n", "--seeds", type=int, default=200)
+    ap.add_argument("--bursts", type=int, default=12)
+    ap.add_argument("--burst-size", type=int, default=4)
+    args = ap.parse_args()
+
+    t0 = time.perf_counter()
+    divs = campaign(args.seeds, args.bursts, args.burst_size)
+    secs = time.perf_counter() - t0
+    total_edits = args.seeds * args.bursts * args.burst_size
+    print(
+        f"RESULT seeds={args.seeds} bursts={args.bursts} burst_size={args.burst_size} "
+        f"edits~={total_edits} secs={secs:.0f} divergences={len(divs)}"
+    )
+    for d in divs:
+        print(f"\nDIVERGENCE seed={d.seed} burst={d.step}")
+        print(f"  {d.detail}")

--- a/tooling/fuzzing/reposition_campaign.py
+++ b/tooling/fuzzing/reposition_campaign.py
@@ -156,17 +156,6 @@ _FILLERS = [
 ]
 
 
-def _proc_starts(text: str) -> list[int]:
-    """Offsets of line-starts that begin a ``proc`` or ``namespace`` — the
-    natural insertion points for repositioning edits."""
-    offs = [0]
-    pos = 0
-    for line in text.splitlines(keepends=True):
-        offs.append(pos + len(line))
-        pos += len(line)
-    return offs
-
-
 def reposition_edit(rng: random.Random, text: str) -> str:
     """Apply one reposition-biased edit: insert/remove filler at a line boundary
     (above/between procs), or duplicate/delete a whole line.  Keeps proc *body*


### PR DESCRIPTION
## Summary

Implements a position-independent caching layer for procedures that move without body changes. When a procedure's text is unchanged but its absolute position shifts (e.g., due to blank lines or comments inserted above it), the primary cache misses because its CFG carries stale byte offsets. The new reposition cache allows reuse of the expensive position-independent dataflow analysis (`analysis` and `execution_intent`) while rebuilding only the cheap CFG and SSA to recover correct ranges.

**Key changes:**

- **`_proc_reposition_key()`** in `compiler/compilation_unit.py`: Creates a position-independent cache key using body text + fingerprints, excluding start line/char/offset. Two compilations differing only in proc position produce the same key.

- **Reposition fast-path** in `compile_source()`: When a proc body is unchanged but positions shifted, reuses cached `analysis` and `execution_intent` objects (same identity) while building fresh CFG/SSA (new identity) with correct ranges.

- **`_build_reposition_cache()`** in `server/workspace/document_state.py`: Builds the position-independent index from a compilation unit, mirroring the primary cache structure.

- **`DocumentState._reposition_cache`**: Maintains the reposition cache alongside the primary proc cache, updated on each compilation and preserved on incremental failures.

- **Fuzzing campaign** in `tooling/fuzzing/reposition_campaign.py`: Comprehensive test harness that drives incremental `DocumentState` through reposition-biased edit bursts (line churn, blank lines, comments) and asserts full CU byte-identity (including offsets) against cold rebuilds. Catches any misaligned reused analysis or stale offset.

## Validation

- Added comprehensive test suite in `tests/test_compilation_cache.py::TestRepositionCache`:
  - `test_moved_proc_reuses_analysis_not_whole_unit`: Verifies analysis/execution_intent reuse with fresh CFG
  - `test_moved_proc_has_correct_shifted_ranges`: Confirms byte-identical ranges vs. cold rebuild
  - `test_reposition_diagnostics_match_cold_rebuild`: End-to-end diagnostic positioning correctness
  - `test_changed_body_does_not_use_reposition`: Ensures body edits don't incorrectly reuse stale analysis

- Fuzzing campaign (`tooling/fuzzing/reposition_campaign.py`) validates the reposition path under realistic incremental editing patterns with a stricter oracle (full CU structural signature including byte offsets) than diagnostics-only checks.

## Compiler/KCS checklist

- [x] This change alters a compiler fact contract: introduces position-independent analysis reuse
- [x] Updated relevant KCS notes (if applicable)
- [x] Linked from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md` (if new notes added)

https://claude.ai/code/session_01BEzNen4MDe7J3x1T9TtAmQ