### PR TITLE
explorer: draw IR/callout trees with Unicode box-drawing

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=b853774-dirty
-head=b853774a32bf71aea846cd6618414ddb8083f2ab
-date=2026-06-01T10:58:05Z
-fingerprint=2f7f14a47a5be1b52088677e3afae8266426a86fd61ad6e25425aa3bbe808b9a
+describe=cbdce65-dirty
+head=cbdce65e7fabd32e7b7e830357b82f32e115251e
+date=2026-06-01T14:01:35Z
+fingerprint=4d137dab9e5c8c84c1658b3eee13da3b7631ae0a90b080b01f601e835636868d

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -728,6 +728,67 @@ body {
   font-style: italic;
 }
 .disasm-diff-unchanged-note { padding: 4px 8px; color: var(--text-dim); font-size: 11px; font-style: italic; }
+/* Generic expand-on-click / Space items (shared explorer-core renderers).
+   Must mirror tooling/explorer/static/index.html so the shared xpand() /
+   optimiser-lens markup renders the same in the VS Code webview. */
+.xpand { cursor: pointer; outline: none; border-radius: 4px; }
+.xpand:focus-visible { box-shadow: inset 2px 0 0 var(--accent); background: var(--highlight); }
+.xpand > .xpand-detail, .xpand > .xpand-children { display: none; }
+.xpand.expanded > .xpand-detail, .xpand.expanded > .xpand-children { display: block; }
+.xpand-detail {
+  margin: 2px 0 6px 22px;
+  padding: 6px 10px;
+  background: var(--bg-surface);
+  border-left: 2px solid var(--border);
+  border-radius: 4px;
+  font-size: 11px;
+}
+.xpand-detail-row { display: flex; gap: 8px; padding: 1px 0; }
+.xpand-detail-k { color: var(--text-dim); min-width: 110px; flex: 0 0 auto; }
+.xpand-detail-v { color: var(--text); word-break: break-word; }
+.gt-text-full {
+  margin: 4px 0 0; padding: 6px 8px; white-space: pre-wrap; word-break: break-word;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text-bright); font-family: var(--font-mono); font-size: 11px; max-height: 220px; overflow: auto;
+}
+/* Green tree */
+.gt-tree { padding: 4px 8px; font-family: var(--font-mono); font-size: 12px; }
+.gt-node { padding: 0; }
+.gt-head { display: flex; align-items: baseline; gap: 6px; padding: 2px 6px; border-radius: 4px; }
+.gt-head:hover { background: var(--bg-hover); }
+.gt-toggle { display: inline-block; width: 12px; color: var(--text-dim); transition: transform 0.12s; flex: 0 0 auto; }
+.gt-node.expanded > .gt-head .gt-toggle { transform: rotate(90deg); }
+.gt-type { color: var(--accent); font-weight: 600; flex: 0 0 auto; }
+.gt-text { color: var(--text); white-space: pre; overflow: hidden; text-overflow: ellipsis; }
+.gt-range { color: var(--text-dim); font-size: 10px; margin-left: auto; flex: 0 0 auto; }
+.gt-node.gt-opaque > .gt-head .gt-type { color: var(--cyan); }
+.gt-node.gt-error > .gt-head .gt-type { color: var(--red); }
+.xpand-children { margin-left: 14px; border-left: 1px solid var(--border); padding-left: 4px; }
+.gt-region { color: var(--text-dim); font-size: 10px; padding: 2px 6px; font-style: italic; }
+.gt-empty { color: var(--text-dim); padding: 2px 6px; font-style: italic; }
+.loop-item > .xpand-head, .bounds-item > .xpand-head { padding: 3px 6px; border-radius: 4px; }
+.loop-item > .xpand-head:hover, .bounds-item > .xpand-head:hover { background: var(--bg-hover); }
+.type-entry.xpand > .xpand-head { display: flex; justify-content: space-between; gap: 8px; padding: 2px 4px; border-radius: 4px; }
+.type-entry.xpand > .xpand-head:hover { background: var(--bg-hover); }
+/* Optimisation lens (off / on / diff) toolbar + diff for IR & CFG tabs */
+.optlens-toolbar { display: flex; align-items: center; gap: 6px; }
+.optlens-label { color: var(--text-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+.optlens-btn {
+  font: inherit; font-size: 11px; cursor: pointer; padding: 2px 10px;
+  background: var(--bg-surface); color: var(--text); border: 1px solid var(--border); border-radius: 4px;
+}
+.optlens-btn:hover:not(:disabled) { border-color: var(--accent); }
+.optlens-btn.active { background: var(--accent); color: var(--bg); border-color: var(--accent); font-weight: 600; }
+.optlens-btn:disabled { opacity: 0.4; cursor: default; }
+.optlens-legend { font-size: 11px; color: var(--text-dim); padding: 6px 8px; }
+.optlens-del-k { color: var(--red); }
+.optlens-add-k { color: var(--green); }
+.optlens-diff { margin: 0 8px; font-family: var(--font-mono); font-size: 12px; white-space: pre-wrap; }
+.optlens-line { display: flex; gap: 6px; padding: 0 4px; border-radius: 2px; }
+.optlens-sig { width: 10px; flex: 0 0 auto; color: var(--text-dim); }
+.optlens-add { background: rgba(166, 227, 161, 0.12); color: var(--green); }
+.optlens-del { background: rgba(243, 139, 168, 0.12); color: var(--red); }
+.optlens-elide { color: var(--text-dim); font-style: italic; padding: 2px 4px 2px 20px; }
 </style>
 </head>
 <body>

--- a/tests/test_compiler_explorer.py
+++ b/tests/test_compiler_explorer.py
@@ -124,6 +124,40 @@ class TestBoundsView:
         assert "range [8, 8]" in out
 
 
+class TestOptLens:
+    # ``set a 1; set b [expr {$a+2}]; puts $b`` folds to ``puts 3`` with a dead
+    # store removed, so the optimised path differs from the original.
+    SRC = "set a 1\nset b [expr {$a + 2}]\nputs $b"
+
+    def test_opt_off_renders_original_ir(self, capsys):
+        code, out = _run_source(self.SRC, capsys, extra=["--show", "ir", "--opt", "off"])
+        assert code == 0
+        assert "assign-const a = 1" in out  # original statements present
+
+    def test_opt_on_renders_optimised_ir(self, capsys):
+        code, out = _run_source(self.SRC, capsys, extra=["--show", "ir", "--opt", "on"])
+        assert code == 0
+        assert "puts 3" in out  # constant-folded call
+        assert "assign-const a = 1" not in out  # dead store gone
+
+    def test_opt_diff_shows_unified_diff(self, capsys):
+        code, out = _run_source(self.SRC, capsys, extra=["--show", "ir", "--opt", "diff"])
+        assert code == 0
+        assert "ir (original)" in out and "ir (optimised)" in out
+        assert "-  ├── assign-const a = 1" in out or "-  └── call puts ${b}" in out
+        assert "+  └── call puts 3" in out
+
+    def test_opt_diff_on_unchanged_source_says_so(self, capsys):
+        # No optimiser rewrites here, so the diff has nothing to show.
+        code, out = _run_source("puts hi", capsys, extra=["--show", "ir", "--opt", "diff"])
+        assert code == 0
+        assert "unchanged" in out or "no change" in out
+
+    def test_non_opt_view_ignores_lens(self, capsys):
+        code, out = _run_source(self.SRC, capsys, extra=["--show", "types", "--opt", "on"])
+        assert code == 0  # types view renders normally regardless of lens
+
+
 # LineIndex unit tests
 
 

--- a/tests/test_compiler_explorer.py
+++ b/tests/test_compiler_explorer.py
@@ -256,7 +256,7 @@ class TestCompilerExplorer:
 
         assert code == 0
         assert "source-callouts" in out
-        assert "+--> O102" in out
+        assert "╰─▶ O102" in out
 
     def test_all_focus_includes_both_sections(self, capsys):
         source = "proc foo {x} { return $x }\nset y [foo 1]"

--- a/tests/test_compiler_explorer_web.py
+++ b/tests/test_compiler_explorer_web.py
@@ -97,6 +97,56 @@ class TestCompileBasic:
         assert resp.content_type == "application/json"
 
 
+# Green tree / loops / intervals / bounds — views brought over from the CLI.
+
+
+class TestExtraViews:
+    def test_keys_present(self, client):
+        data = _compile(client, "set x 1")
+        for key in ("greentree", "loops", "intervals", "bounds"):
+            assert key in data
+
+    def test_greentree_tokens_carry_detail(self, client):
+        data = _compile(client, "set x 1")
+        gt = data["greentree"]
+        assert gt["kind"] == "ROOT"
+        assert gt["tokens"]
+        tok = gt["tokens"][0]
+        for key in ("type", "text", "startOffset", "endOffset", "startLine", "startCol"):
+            assert key in tok
+
+    def test_greentree_opaque_token_has_child_region(self, client):
+        data = _compile(client, "proc f {} { set y 2 }")
+        # Find any token that descended into a child region (the braced body).
+        def has_child(node):
+            for t in node["tokens"]:
+                if "child" in t:
+                    return True
+                # children only hang off opaque tokens, no deeper walk needed
+            return False
+
+        assert has_child(data["greentree"]) or any(
+            "child" in t for t in data["greentree"]["tokens"]
+        )
+
+    def test_loops_reports_natural_loop(self, client):
+        data = _compile(client, "for {set i 0} {$i < 5} {incr i} { puts $i }")
+        loops = [lp for f in data["loops"] for lp in f["loops"]]
+        assert loops
+        assert "header" in loops[0]
+        assert "blockCount" in loops[0]
+
+    def test_intervals_bounded_range(self, client):
+        data = _compile(client, "proc f {} { set m 8 ; return [lindex {a} $m] }")
+        entries = [e for f in data["intervals"] for e in f["entries"]]
+        assert any(e["lo"] is not None or e["hi"] is not None for e in entries)
+
+    def test_bounds_divide_by_zero(self, client):
+        data = _compile(client, "proc f {} { return [expr {1 / 0}] }")
+        divzero = [d for f in data["bounds"] for d in f["divzero"]]
+        assert any(d["code"] == "W233" for d in divzero)
+
+
 # IR serialisation
 
 

--- a/tests/test_compiler_explorer_web.py
+++ b/tests/test_compiler_explorer_web.py
@@ -147,6 +147,24 @@ class TestExtraViews:
         assert any(d["code"] == "W233" for d in divzero)
 
 
+class TestOptLensData:
+    SRC = "set a 1\nset b [expr {$a + 2}]\nputs $b"
+
+    def test_optimised_keys_present_when_rewritten(self, client):
+        data = _compile(client, self.SRC)
+        assert data["irOptimised"] is not None
+        assert data["cfgPreSsaOptimised"] is not None
+        assert data["cfgPostSsaOptimised"] is not None
+        summaries = [n["summary"] for n in data["irOptimised"]["topLevel"]]
+        assert any("puts 3" in s for s in summaries)
+
+    def test_optimised_keys_null_when_unchanged(self, client):
+        data = _compile(client, "puts hi")
+        assert data["irOptimised"] is None
+        assert data["cfgPreSsaOptimised"] is None
+        assert data["cfgPostSsaOptimised"] is None
+
+
 # IR serialisation
 
 

--- a/tests/test_compiler_explorer_web.py
+++ b/tests/test_compiler_explorer_web.py
@@ -117,6 +117,7 @@ class TestExtraViews:
 
     def test_greentree_opaque_token_has_child_region(self, client):
         data = _compile(client, "proc f {} { set y 2 }")
+
         # Find any token that descended into a child region (the braced body).
         def has_child(node):
             for t in node["tokens"]:

--- a/tests/test_explorer_tui.py
+++ b/tests/test_explorer_tui.py
@@ -103,7 +103,7 @@ class TestTui:
     def test_greentree_builds_interactive_tree(self):
         from textual.widgets import Tree
 
-        from tooling.explorer.tui import _gt_detail
+        from tooling.explorer.tui import _format_detail
 
         args = parse_args(["/dev/null", "--show", "greentree,ir"])
         app = ExplorerApp(_SRC, args)
@@ -113,25 +113,71 @@ class TestTui:
                 await pilot.pause()
                 app._show("greentree")
                 await pilot.pause()
-                tree = app.query_one("#gt-tree", Tree)
-                # Tokens hang off the root; opaque {...}/[...] tokens nest their
-                # re-lexed child region's tokens.
-                token_nodes = len(tree.root.children)
-                nested = any(c.children for c in tree.root.children)
-                gt_visible = bool(app.query_one("#gt-pane").display)
-                opaque = next(c for c in tree.root.children if c.children)
-                detail = str(_gt_detail(opaque.data))
-                # Switching away hides the interactive pane again.
+                tree = app.query_one("#view-tree", Tree)
+                # The single root group is the region; its children are tokens,
+                # opaque {...}/[...] tokens nesting their re-lexed region.
+                region = tree.root.children[0]
+                tokens = region.children
+                nested = any(t.children for t in tokens)
+                tree_visible = bool(app.query_one("#tree-pane").display)
+                opaque = next(t for t in tokens if t.children)
+                detail = str(_format_detail(opaque.data))
+                return len(tokens), nested, tree_visible, detail
+
+        ntokens, nested, tree_visible, detail = asyncio.run(drive())
+        assert ntokens > 0
+        assert nested  # the proc body / command substitution descended
+        assert tree_visible
+        assert "token type" in detail and "byte range" in detail and "region" in detail
+
+    def test_analysis_views_build_trees_with_detail(self):
+        from textual.widgets import Tree
+
+        from tooling.explorer.tui import _format_detail
+
+        args = parse_args(["/dev/null", "--show", "ir,cfg,types,interproc"])
+        app = ExplorerApp(_SRC, args)
+
+        async def drive():
+            seen = {}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                for view in ("ir", "cfg", "types", "interproc"):
+                    app._show(view)
+                    await pilot.pause()
+                    assert not app._is_text_view(view)
+                    tree = app.query_one("#view-tree", Tree)
+
+                    def deepest(n):
+                        return deepest(n.children[0]) if n.children else n
+
+                    leaf = deepest(tree.root)
+                    seen[view] = (len(tree.root.children), str(_format_detail(leaf.data)))
+            return seen
+
+        seen = asyncio.run(drive())
+        for view, (nchildren, detail) in seen.items():
+            assert nchildren > 0, f"{view} produced an empty tree"
+            assert detail.strip(), f"{view} leaf had no detail"
+
+    def test_asm_stays_text_surface(self):
+        args = parse_args(["/dev/null", "--show", "ir,asm"])
+        app = ExplorerApp(_SRC, args)
+
+        async def drive():
+            async with app.run_test() as pilot:
+                await pilot.pause()
                 app._show("ir")
                 await pilot.pause()
-                gt_hidden = not app.query_one("#gt-pane").display
-                return token_nodes, nested, gt_visible, detail, gt_hidden
+                ir_tree = not app._is_text_view("ir") and bool(app.query_one("#tree-pane").display)
+                app._show("asm")
+                await pilot.pause()
+                asm_text = app._is_text_view("asm") and bool(app.query_one("#content-scroll").display)
+                return ir_tree, asm_text
 
-        token_nodes, nested, gt_visible, detail, gt_hidden = asyncio.run(drive())
-        assert token_nodes > 0
-        assert nested  # the proc body / command substitution descended
-        assert gt_visible and gt_hidden
-        assert "token type" in detail and "byte range" in detail and "region" in detail
+        ir_tree, asm_text = asyncio.run(drive())
+        assert ir_tree
+        assert asm_text
 
     def test_cycle_opt_changes_mode(self):
         args = parse_args(["/dev/null", "--show", "ir"])

--- a/tests/test_explorer_tui.py
+++ b/tests/test_explorer_tui.py
@@ -99,3 +99,52 @@ class TestTui:
         seq = asyncio.run(drive())
         assert seq == ["ir", "cfg", "ssa", "opt"]
         assert app._result is not None  # pipeline ran inside the app
+
+    def test_greentree_builds_interactive_tree(self):
+        from textual.widgets import Tree
+
+        from tooling.explorer.tui import _gt_detail
+
+        args = parse_args(["/dev/null", "--show", "greentree,ir"])
+        app = ExplorerApp(_SRC, args)
+
+        async def drive():
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                app._show("greentree")
+                await pilot.pause()
+                tree = app.query_one("#gt-tree", Tree)
+                # Tokens hang off the root; opaque {...}/[...] tokens nest their
+                # re-lexed child region's tokens.
+                token_nodes = len(tree.root.children)
+                nested = any(c.children for c in tree.root.children)
+                gt_visible = bool(app.query_one("#gt-pane").display)
+                opaque = next(c for c in tree.root.children if c.children)
+                detail = str(_gt_detail(opaque.data))
+                # Switching away hides the interactive pane again.
+                app._show("ir")
+                await pilot.pause()
+                gt_hidden = not app.query_one("#gt-pane").display
+                return token_nodes, nested, gt_visible, detail, gt_hidden
+
+        token_nodes, nested, gt_visible, detail, gt_hidden = asyncio.run(drive())
+        assert token_nodes > 0
+        assert nested  # the proc body / command substitution descended
+        assert gt_visible and gt_hidden
+        assert "token type" in detail and "byte range" in detail and "region" in detail
+
+    def test_cycle_opt_changes_mode(self):
+        args = parse_args(["/dev/null", "--show", "ir"])
+        app = ExplorerApp(_SRC, args)
+
+        async def drive():
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                seq = [app._opt_mode]
+                for _ in range(3):
+                    app.action_cycle_opt()
+                    await pilot.pause()
+                    seq.append(app._opt_mode)
+                return seq
+
+        assert asyncio.run(drive()) == ["off", "on", "diff", "off"]

--- a/tests/test_explorer_tui.py
+++ b/tests/test_explorer_tui.py
@@ -172,7 +172,9 @@ class TestTui:
                 ir_tree = not app._is_text_view("ir") and bool(app.query_one("#tree-pane").display)
                 app._show("asm")
                 await pilot.pause()
-                asm_text = app._is_text_view("asm") and bool(app.query_one("#content-scroll").display)
+                asm_text = app._is_text_view("asm") and bool(
+                    app.query_one("#content-scroll").display
+                )
                 return ir_tree, asm_text
 
         ir_tree, asm_text = asyncio.run(drive())

--- a/tests/test_highlight_ranges.py
+++ b/tests/test_highlight_ranges.py
@@ -68,7 +68,21 @@ CORPUS = {
 
 # Top-level serialisation keys whose ranges index into the *optimised*
 # source rather than the source the user typed.
-_OPTIMISED_KEYS = {"asmOptimised", "wasmOptimised"}
+_OPTIMISED_KEYS = {
+    "asmOptimised",
+    "wasmOptimised",
+    "irOptimised",
+    "cfgPreSsaOptimised",
+    "cfgPostSsaOptimised",
+}
+
+# The green tree is a lossless *lexer* view: its token offsets are raw token
+# spans (a single SEP/EOL, or a braced word's opening delimiter + inner text
+# without the closer), not the balanced whole-word highlight ranges the IR /
+# CFG / optimiser artefacts emit.  Highlighting a green-tree token to its exact
+# raw span is correct, so those ranges are exempt from the well-formed-word
+# assertion below.
+_RAW_TOKEN_KEYS = {"greentree"}
 
 
 def _explorer_dict(source: str) -> dict:
@@ -153,6 +167,8 @@ class TestEveryExplorerRangeIsWellFormed:
         problems = []
         for path, rd in _walk_ranges(data):
             top_key = path.split(".", 1)[0].split("[", 1)[0]
+            if top_key in _RAW_TOKEN_KEYS:
+                continue
             src = optimised if top_key in _OPTIMISED_KEYS else source
             covered = _covered(src, rd)
             if not _well_formed(covered):

--- a/tooling/cli/serialise.py
+++ b/tooling/cli/serialise.py
@@ -571,15 +571,19 @@ def _serialise_greentree(source: str) -> dict | None:
     def node_dict(node, depth: int) -> dict:
         tokens = []
         for tok in node.tokens:
+            # Token end positions are inclusive (the last char); the explorer
+            # front-end slices ``src[startOffset:endOffset]`` with an exclusive
+            # end, so +1 makes a single-char token highlight that char (not
+            # nothing) and a word highlight its whole span — matching range_dict.
             entry = {
                 "type": tok.type.name,
                 "text": tok.text,
                 "startOffset": tok.start.offset,
-                "endOffset": tok.end.offset,
+                "endOffset": tok.end.offset + 1,
                 "startLine": tok.start.line,
                 "startCol": tok.start.character,
                 "endLine": tok.end.line,
-                "endCol": tok.end.character,
+                "endCol": tok.end.character + 1,
             }
             if depth < 24 and tok.type in opaque and tok.text:
                 entry["child"] = node_dict(node.descend(tok), depth + 1)

--- a/tooling/cli/serialise.py
+++ b/tooling/cli/serialise.py
@@ -922,6 +922,9 @@ def _serialise_result(result: CompilerExplorerResult, build_cfg, compute_stats) 
 
     asm_optimised = None
     wasm_optimised = None
+    ir_optimised = None
+    cfg_pre_optimised = None
+    cfg_post_optimised = None
     if result.optimised_source and result.optimised_source != result.source:
         try:
             from compiler.lowering import lower_to_ir
@@ -932,7 +935,7 @@ def _serialise_result(result: CompilerExplorerResult, build_cfg, compute_stats) 
             opt_ir = None
             opt_cfg = None
         if opt_ir is not None:
-            # Optimised asm/wasm ranges index into the optimised source.
+            # Optimised asm/wasm/ir/cfg ranges index into the optimised source.
             opt_token = set_highlight_source(result.optimised_source)
             try:
                 try:
@@ -943,6 +946,21 @@ def _serialise_result(result: CompilerExplorerResult, build_cfg, compute_stats) 
                     wasm_optimised = _serialise_wasm(opt_ir, optimise=True, cfg_module=opt_cfg)
                 except Exception as exc:
                     print(f"warning: optimised wasm serialisation failed: {exc}", file=sys.stderr)
+                try:
+                    ir_optimised = _serialise_ir(opt_ir)
+                except Exception as exc:
+                    print(f"warning: optimised ir serialisation failed: {exc}", file=sys.stderr)
+                # CFG needs SSA + analysis, so re-run the pipeline on the
+                # optimised source to get its snapshots (the opt lens for the
+                # IR/CFG tabs renders / diffs against these).
+                try:
+                    from tooling.explorer.pipeline import run_pipeline
+
+                    opt_snaps = run_pipeline(result.optimised_source).snapshots
+                    cfg_pre_optimised = _serialise_cfg_pre_ssa(opt_snaps)
+                    cfg_post_optimised = _serialise_cfg_post_ssa(opt_snaps)
+                except Exception as exc:
+                    print(f"warning: optimised cfg serialisation failed: {exc}", file=sys.stderr)
             finally:
                 reset_highlight_source(opt_token)
 
@@ -968,8 +986,11 @@ def _serialise_result(result: CompilerExplorerResult, build_cfg, compute_stats) 
         "meta": _serialise_meta(),
         "greentree": _serialise_greentree(result.source),
         "ir": _serialise_ir(result.ir_module),
+        "irOptimised": ir_optimised,
         "cfgPreSsa": _serialise_cfg_pre_ssa(result.snapshots),
         "cfgPostSsa": _serialise_cfg_post_ssa(result.snapshots),
+        "cfgPreSsaOptimised": cfg_pre_optimised,
+        "cfgPostSsaOptimised": cfg_post_optimised,
         "loops": _serialise_loops(result.snapshots),
         "intervals": _serialise_intervals(result.snapshots),
         "bounds": _serialise_bounds(result.snapshots),

--- a/tooling/cli/serialise.py
+++ b/tooling/cli/serialise.py
@@ -554,6 +554,143 @@ def _serialise_rendered_properties(snapshots: list[FunctionSnapshot]) -> list[di
     return out
 
 
+def _serialise_greentree(source: str) -> dict | None:
+    """Serialise the lossless green token tree for the explorer.
+
+    Mirrors the CLI ``greentree`` view but keeps *every* token (not only the
+    opaque ones that descend), each tagged with its type, absolute character
+    range and verbatim text, so the GUI/TUI can expand any entry to the fullest
+    detail.  Opaque ``{...}`` / ``[...]`` tokens carry a ``child`` region.
+    Wrapped in a ``green_tree_scope`` because ``descend`` memoises per scope.
+    """
+    from compiler.parsing.green_tree import green_tree_scope, node_for
+    from shared.tokens import TokenType
+
+    opaque = (TokenType.STR, TokenType.CMD)
+
+    def node_dict(node, depth: int) -> dict:
+        tokens = []
+        for tok in node.tokens:
+            entry = {
+                "type": tok.type.name,
+                "text": tok.text,
+                "startOffset": tok.start.offset,
+                "endOffset": tok.end.offset,
+                "startLine": tok.start.line,
+                "startCol": tok.start.character,
+                "endLine": tok.end.line,
+                "endCol": tok.end.character,
+            }
+            if depth < 24 and tok.type in opaque and tok.text:
+                entry["child"] = node_dict(node.descend(tok), depth + 1)
+            tokens.append(entry)
+        return {
+            "kind": node.kind.name,
+            "mode": node.mode.name,
+            "offset": node.base_offset,
+            "endOffset": node.base_offset + node.width,
+            "width": node.width,
+            "isError": node.kind.name == "ERROR",
+            "tokens": tokens,
+        }
+
+    try:
+        with green_tree_scope():
+            return node_dict(node_for(source), 0)
+    except Exception as exc:  # a malformed tree must not kill the whole result
+        print(f"warning: greentree serialisation failed: {exc}", file=sys.stderr)
+        return None
+
+
+def _serialise_loops(snapshots: list[FunctionSnapshot]) -> list[dict]:
+    """Serialise the natural-loop forest per function (mirrors CLI ``loops``)."""
+    from compiler.loops import build_loop_forest, dominates
+
+    out = []
+    for snap in snapshots:
+        if snap.cfg is None or snap.ssa is None or snap.analysis is None:
+            continue
+        try:
+            executable = set(snap.cfg.blocks) - snap.analysis.unreachable_blocks
+            forest = build_loop_forest(snap.cfg, snap.ssa, executable)
+        except Exception:
+            continue
+        headers = list(forest.by_header)
+        loops = []
+        for loop in forest.loops:
+            depth = 1 + sum(
+                1 for h in headers if h != loop.header and dominates(snap.ssa, h, loop.header)
+            )
+            loops.append(
+                {
+                    "header": loop.header,
+                    "depth": depth,
+                    "blockCount": len(loop.blocks),
+                    "blocks": sorted(loop.blocks),
+                    "latches": sorted(loop.latches),
+                }
+            )
+        out.append({"name": snap.name, "loops": loops})
+    return out
+
+
+def _serialise_intervals(snapshots: list[FunctionSnapshot]) -> list[dict]:
+    """Serialise the integer-interval domain per SSA value (mirrors ``intervals``).
+
+    Only non-trivial (bounded) ranges are emitted; ``lo``/``hi`` are ``null``
+    for an unbounded (-inf / +inf) end.
+    """
+    from compiler.intervals import compute_intervals
+
+    out = []
+    for snap in snapshots:
+        if snap.cfg is None or snap.ssa is None or snap.analysis is None:
+            continue
+        try:
+            intervals = compute_intervals(snap.cfg, snap.ssa, snap.analysis.values)
+        except Exception:
+            continue
+        entries = []
+        for (name, ver), iv in sorted(intervals.items()):
+            if iv.is_top or (iv.lo is None and iv.hi is None):
+                continue
+            entries.append({"variable": name, "version": ver, "lo": iv.lo, "hi": iv.hi})
+        out.append({"name": snap.name, "entries": entries})
+    return out
+
+
+def _serialise_bounds(snapshots: list[FunctionSnapshot]) -> list[dict]:
+    """Serialise interval-driven bounds / divide-by-zero findings (``bounds``)."""
+    from compiler.interval_bounds import find_interval_findings
+
+    out = []
+    for snap in snapshots:
+        if snap.cfg is None or snap.ssa is None or snap.analysis is None:
+            continue
+        try:
+            executable = set(snap.cfg.blocks) - snap.analysis.unreachable_blocks
+            findings, divzero = find_interval_findings(
+                snap.cfg, snap.ssa, snap.execution_intent, snap.analysis.values, executable
+            )
+        except Exception:
+            continue
+        f_out = [
+            {
+                "code": f.code,
+                "command": f.command,
+                "indexVar": f.index_var,
+                "lo": f.index_interval.lo,
+                "hi": f.index_interval.hi,
+                "length": f.length,
+                "reason": f.reason,
+            }
+            for f in findings
+        ]
+        d_out = [{"code": "W233", "op": dz.op} for dz in divzero]
+        out.append({"name": snap.name, "findings": f_out, "divzero": d_out})
+    return out
+
+
 # Annotations (source callouts)
 
 
@@ -829,9 +966,13 @@ def _serialise_result(result: CompilerExplorerResult, build_cfg, compute_stats) 
 
     return {
         "meta": _serialise_meta(),
+        "greentree": _serialise_greentree(result.source),
         "ir": _serialise_ir(result.ir_module),
         "cfgPreSsa": _serialise_cfg_pre_ssa(result.snapshots),
         "cfgPostSsa": _serialise_cfg_post_ssa(result.snapshots),
+        "loops": _serialise_loops(result.snapshots),
+        "intervals": _serialise_intervals(result.snapshots),
+        "bounds": _serialise_bounds(result.snapshots),
         "interprocedural": _serialise_interproc(result.interproc),
         "optimisations": _serialise_optimisations(result.optimisations),
         "shimmer": _serialise_shimmer(result.shimmer_warnings),

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -703,24 +703,46 @@ def print_cfg_post_ssa(
     _render_cfg(snapshots, line_index=line_index, use_colour=use_colour, post_ssa=True)
 
 
-def _render_green_node(node, *, depth: int, use_colour: bool, max_depth: int = 16) -> None:
+def _render_green_tokens(
+    node, *, prefix: str, use_colour: bool, depth: int, max_depth: int
+) -> None:
+    """Draw a node's tokens as a box-drawing tree, nesting opaque regions.
+
+    Each token is a tree entry tagged with its type and absolute byte range;
+    an opaque ``{...}`` / ``[...]`` token descends into its re-lexed child
+    region (a dim ``kind [mode]`` descriptor, then that region's own tokens).
+    """
     from shared.tokens import TokenType
 
-    indent = "  " * depth
-    print(
-        style(
-            f"{indent}{node.kind.name.lower()} [{node.mode.name.lower()}] "
-            f"@{node.base_offset} w={node.width} tokens={len(node.tokens)}",
-            Ansi.CYAN if node.kind.name != "ERROR" else Ansi.RED,
-            use_colour,
+    tokens = node.tokens
+    for idx, tok in enumerate(tokens):
+        is_last = idx == len(tokens) - 1
+        connector = _TREE_LAST if is_last else _TREE_BRANCH
+        opaque = tok.type in (TokenType.STR, TokenType.CMD) and bool(tok.text)
+        preview_text = repr(preview(tok.text.replace("\n", "⏎"), 40))
+        print(
+            f"{prefix}{connector}"
+            f"{style(tok.type.name, Ansi.CYAN if opaque else Ansi.GRAY, use_colour)} "
+            f"{preview_text} "
+            f"{style(f'[{tok.start.offset}:{tok.end.offset}]', Ansi.DIM, use_colour)}"
         )
-    )
-    if depth >= max_depth:
-        return
-    for tok in node.tokens:
-        if tok.type in (TokenType.STR, TokenType.CMD) and tok.text:
-            _render_green_node(
-                node.descend(tok), depth=depth + 1, use_colour=use_colour, max_depth=max_depth
+        if opaque and depth < max_depth:
+            child = node.descend(tok)
+            child_prefix = prefix + (_TREE_GAP if is_last else _TREE_VBAR)
+            print(
+                style(
+                    f"{child_prefix}{child.kind.name.lower()} [{child.mode.name.lower()}] "
+                    f"w={child.width}",
+                    Ansi.CYAN if child.kind.name != "ERROR" else Ansi.RED,
+                    use_colour,
+                )
+            )
+            _render_green_tokens(
+                child,
+                prefix=child_prefix,
+                use_colour=use_colour,
+                depth=depth + 1,
+                max_depth=max_depth,
             )
 
 
@@ -737,7 +759,16 @@ def print_greentree(source: str, *, use_colour: bool) -> None:
     print()
     print(style("green-tree", Ansi.BOLD, use_colour))
     with green_tree_scope():
-        _render_green_node(node_for(source), depth=0, use_colour=use_colour)
+        root = node_for(source)
+        print(
+            style(
+                f"{root.kind.name.lower()} [{root.mode.name.lower()}] "
+                f"@{root.base_offset} w={root.width}",
+                Ansi.CYAN if root.kind.name != "ERROR" else Ansi.RED,
+                use_colour,
+            )
+        )
+        _render_green_tokens(root, prefix="", use_colour=use_colour, depth=0, max_depth=16)
 
 
 def print_loops(snapshots: list[FunctionSnapshot], *, use_colour: bool) -> None:

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -170,6 +170,19 @@ def _terminator_summary(term: CFGGoto | CFGBranch | CFGReturn | None) -> str:
 # Print functions (ANSI terminal output)
 
 
+# Unicode box-drawing connectors for the IR / callout trees.  The terminal
+# surfaces (flat ``--text`` and the Textual TUI) and the rest of the repo's
+# tree renderers (``tooling/tcl/verbs/pkg.py``, ``scripts/dev/tcl_test_client``)
+# all draw with these glyphs, and the CFG gutter (``_GUTTER_GLYPH``) uses the
+# same line set — so we draw the trees with them too instead of the old 7-bit
+# ASCII ``|-- `` / ``` `-- ``` connectors.  Textual renders a capable terminal,
+# so there is no reason to fall back to ASCII here.
+_TREE_BRANCH = "├── "  # a child that has siblings after it
+_TREE_LAST = "└── "  # the last child
+_TREE_VBAR = "│   "  # continuation column under a branch
+_TREE_GAP = "    "  # continuation column under the last child
+
+
 def print_source_callouts(
     source: str,
     annotations: list[Annotation],
@@ -190,7 +203,7 @@ def print_source_callouts(
     for line_number in range(line_index.line_count()):
         text = line_index.line_text(line_number)
         gutter = str(line_number + 1).rjust(line_no_width)
-        print(f"{style(gutter, Ansi.DIM, use_colour)} | {text}")
+        print(f"{style(gutter, Ansi.DIM, use_colour)} │ {text}")
 
         line_start = line_index.line_start(line_number)
         line_end_exclusive = line_index.line_end_exclusive(line_number)
@@ -209,9 +222,9 @@ def print_source_callouts(
             start_col = max(0, seg_start - line_start)
             end_col = max(start_col, seg_end - line_start)
 
-            marker = (" " * start_col) + "^" + ("-" * max(0, end_col - start_col))
-            marker_line = f"{' ' * line_no_width} | {marker}"
-            arrow_line = f"{' ' * line_no_width} | {' ' * start_col}+--> {ann.label}"
+            marker = (" " * start_col) + "^" + ("─" * max(0, end_col - start_col))
+            marker_line = f"{' ' * line_no_width} │ {marker}"
+            arrow_line = f"{' ' * line_no_width} │ {' ' * start_col}╰─▶ {ann.label}"
 
             colour = _annotation_colour(ann)
             print(style(marker_line, colour, use_colour))
@@ -234,7 +247,7 @@ def _print_ir_script(
 ) -> None:
     for idx, stmt in enumerate(script.statements):
         is_last = idx == (len(script.statements) - 1)
-        connector = "`-- " if is_last else "|-- "
+        connector = _TREE_LAST if is_last else _TREE_BRANCH
         label = stmt_summary(stmt)
         span = line_index.format_range(stmt.range)
 
@@ -244,7 +257,7 @@ def _print_ir_script(
             f"{style(f'[{span}]', Ansi.DIM, use_colour)}"
         )
 
-        child_prefix = prefix + ("    " if is_last else "|   ")
+        child_prefix = prefix + (_TREE_GAP if is_last else _TREE_VBAR)
 
         if isinstance(stmt, IRIf):
             _print_ir_if(stmt, prefix=child_prefix, line_index=line_index, use_colour=use_colour)
@@ -277,7 +290,7 @@ def _print_ir_if(
 
     for idx, (label, payload) in enumerate(children):
         is_last = idx == (len(children) - 1)
-        connector = "`-- " if is_last else "|-- "
+        connector = _TREE_LAST if is_last else _TREE_BRANCH
 
         if isinstance(payload, IRScript):
             span = (
@@ -289,7 +302,7 @@ def _print_ir_if(
                 f"{prefix}{connector}{style(label, Ansi.BLUE, use_colour)} "
                 f"{style(f'[{span}]', Ansi.DIM, use_colour)}"
             )
-            child_prefix = prefix + ("    " if is_last else "|   ")
+            child_prefix = prefix + (_TREE_GAP if is_last else _TREE_VBAR)
             _print_ir_script(
                 payload, prefix=child_prefix, line_index=line_index, use_colour=use_colour
             )
@@ -301,7 +314,7 @@ def _print_ir_if(
             f"{prefix}{connector}{style(label, Ansi.BLUE, use_colour)} "
             f"{style(f'[{clause_span}]', Ansi.DIM, use_colour)}"
         )
-        child_prefix = prefix + ("    " if is_last else "|   ")
+        child_prefix = prefix + (_TREE_GAP if is_last else _TREE_VBAR)
         _print_ir_script(
             clause.body, prefix=child_prefix, line_index=line_index, use_colour=use_colour
         )
@@ -317,13 +330,13 @@ def _print_ir_switch(
     header = f"subject: {preview(stmt.subject, 60)}"
     subject_span = line_index.format_range(stmt.subject_range)
     print(
-        f"{prefix}|-- {style(header, Ansi.BLUE, use_colour)} {style(f'[{subject_span}]', Ansi.DIM, use_colour)}"
+        f"{prefix}{_TREE_BRANCH}{style(header, Ansi.BLUE, use_colour)} {style(f'[{subject_span}]', Ansi.DIM, use_colour)}"
     )
 
     arm_count = len(stmt.arms)
     for i, arm in enumerate(stmt.arms):
         is_last = i == (arm_count - 1) and stmt.default_body is None
-        connector = "`-- " if is_last else "|-- "
+        connector = _TREE_LAST if is_last else _TREE_BRANCH
         kind = "arm"
         if arm.fallthrough:
             kind = "fallthrough"
@@ -334,7 +347,7 @@ def _print_ir_switch(
         )
 
         if arm.body is not None:
-            child_prefix = prefix + ("    " if is_last else "|   ")
+            child_prefix = prefix + (_TREE_GAP if is_last else _TREE_VBAR)
             _print_ir_script(
                 arm.body, prefix=child_prefix, line_index=line_index, use_colour=use_colour
             )
@@ -346,11 +359,11 @@ def _print_ir_switch(
             else "?:?-?:?"
         )
         print(
-            f"{prefix}`-- {style('default', Ansi.BLUE, use_colour)} {style(f'[{default_span}]', Ansi.DIM, use_colour)}"
+            f"{prefix}{_TREE_LAST}{style('default', Ansi.BLUE, use_colour)} {style(f'[{default_span}]', Ansi.DIM, use_colour)}"
         )
         _print_ir_script(
             stmt.default_body,
-            prefix=prefix + "    ",
+            prefix=prefix + _TREE_GAP,
             line_index=line_index,
             use_colour=use_colour,
         )
@@ -371,28 +384,28 @@ def _print_ir_for(
     body_span = line_index.format_range(stmt.body_range)
 
     print(
-        f"{prefix}|-- {style('init', Ansi.BLUE, use_colour)} {style(f'[{init_span}]', Ansi.DIM, use_colour)}"
+        f"{prefix}{_TREE_BRANCH}{style('init', Ansi.BLUE, use_colour)} {style(f'[{init_span}]', Ansi.DIM, use_colour)}"
     )
     _print_ir_script(
-        stmt.init, prefix=prefix + "|   ", line_index=line_index, use_colour=use_colour
+        stmt.init, prefix=prefix + _TREE_VBAR, line_index=line_index, use_colour=use_colour
     )
 
     print(
-        f"{prefix}|-- {style(f'condition: {preview(_expr_text(stmt.condition), 60)}', Ansi.BLUE, use_colour)} {style(f'[{cond_span}]', Ansi.DIM, use_colour)}"
+        f"{prefix}{_TREE_BRANCH}{style(f'condition: {preview(_expr_text(stmt.condition), 60)}', Ansi.BLUE, use_colour)} {style(f'[{cond_span}]', Ansi.DIM, use_colour)}"
     )
 
     print(
-        f"{prefix}|-- {style('next', Ansi.BLUE, use_colour)} {style(f'[{next_span}]', Ansi.DIM, use_colour)}"
+        f"{prefix}{_TREE_BRANCH}{style('next', Ansi.BLUE, use_colour)} {style(f'[{next_span}]', Ansi.DIM, use_colour)}"
     )
     _print_ir_script(
-        stmt.next, prefix=prefix + "|   ", line_index=line_index, use_colour=use_colour
+        stmt.next, prefix=prefix + _TREE_VBAR, line_index=line_index, use_colour=use_colour
     )
 
     print(
-        f"{prefix}`-- {style('body', Ansi.BLUE, use_colour)} {style(f'[{body_span}]', Ansi.DIM, use_colour)}"
+        f"{prefix}{_TREE_LAST}{style('body', Ansi.BLUE, use_colour)} {style(f'[{body_span}]', Ansi.DIM, use_colour)}"
     )
     _print_ir_script(
-        stmt.body, prefix=prefix + "    ", line_index=line_index, use_colour=use_colour
+        stmt.body, prefix=prefix + _TREE_GAP, line_index=line_index, use_colour=use_colour
     )
 
 

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -1392,6 +1392,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Print line-numbered optimised source when rewrites are found.",
     )
     parser.add_argument(
+        "--opt",
+        choices=("off", "on", "diff"),
+        default="off",
+        help="Optimisation lens for the IR/CFG/SSA/ASM/WASM views: render the "
+        "original path (off), the optimised path (on), or a diff of the two "
+        "(diff).  Other views ignore it.",
+    )
+    parser.add_argument(
         "--no-source-callouts",
         action="store_true",
         help="Disable source callouts with caret/arrow annotations.",
@@ -1573,6 +1581,150 @@ def render_view(
         raise ValueError(f"render_view: no renderer for view {view!r}")
 
 
+# Views whose output reflects the lowered program, so they can be rendered
+# against the optimised path (``--opt on``) or diffed against the original
+# (``--opt diff``).  Other views (greentree, analysis facts, callouts, ...)
+# have no meaningful optimised variant and ignore the opt mode.
+OPT_VIEWS = frozenset({"ir", "cfg", "ssa", "asm", "wasm"})
+
+
+def optimised_result(
+    result: CompilerExplorerResult, dialect: str
+) -> tuple[CompilerExplorerResult, str] | None:
+    """Run the pipeline on the optimised source so opt-aware views can show it.
+
+    Returns ``(opt_result, optimised_source)`` or ``None`` when the optimiser
+    left the source unchanged (nothing to render / diff).
+    """
+    opt_source = result.optimised_source
+    if not opt_source or opt_source == result.source:
+        return None
+    try:
+        return run_pipeline(opt_source, dialect=dialect), opt_source
+    except Exception as exc:  # pragma: no cover - optimised source should re-lower
+        print(f"warning: optimised pipeline failed: {exc}", file=sys.stderr)
+        return None
+
+
+def _capture_view(
+    view: str,
+    result: CompilerExplorerResult,
+    source: str,
+    *,
+    line_index: LineIndex,
+    views: frozenset[str],
+    max_annotations: int,
+) -> list[str]:
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        render_view(
+            view,
+            result,
+            source,
+            use_colour=False,
+            line_index=line_index,
+            views=views,
+            max_annotations=max_annotations,
+        )
+    return buf.getvalue().splitlines()
+
+
+def render_view_opt(
+    view: str,
+    result: CompilerExplorerResult,
+    source: str,
+    *,
+    use_colour: bool,
+    line_index: LineIndex,
+    opt_mode: str = "off",
+    opt: tuple[CompilerExplorerResult, str] | None = None,
+    views: frozenset[str] = frozenset(),
+    show_optimised_source: bool = False,
+    max_annotations: int = 80,
+) -> None:
+    """Render *view* honouring the optimisation lens (off / on / diff).
+
+    *opt* is the ``(opt_result, opt_source)`` pair from :func:`optimised_result`
+    (or ``None``).  Only :data:`OPT_VIEWS` react to the mode; every other view
+    renders exactly as :func:`render_view` would.  This is the shared entry
+    point for the text path and the Textual TUI so the lens behaves identically.
+    """
+    if opt_mode == "off" or view not in OPT_VIEWS:
+        render_view(
+            view,
+            result,
+            source,
+            use_colour=use_colour,
+            line_index=line_index,
+            views=views,
+            show_optimised_source=show_optimised_source,
+            max_annotations=max_annotations,
+        )
+        return
+
+    if opt is None:
+        # Nothing changed — fall back to the original and say so once.
+        render_view(
+            view,
+            result,
+            source,
+            use_colour=use_colour,
+            line_index=line_index,
+            views=views,
+            max_annotations=max_annotations,
+        )
+        print(style("  (optimiser left the source unchanged)", Ansi.DIM, use_colour))
+        return
+
+    opt_result, opt_source = opt
+    if opt_mode == "on":
+        render_view(
+            view,
+            opt_result,
+            opt_source,
+            use_colour=use_colour,
+            line_index=LineIndex(opt_source),
+            views=views,
+            max_annotations=max_annotations,
+        )
+        return
+
+    # diff: a rendered-text unified diff, surface-agnostic across all OPT_VIEWS.
+    import difflib
+
+    before = _capture_view(
+        view, result, source, line_index=line_index, views=views, max_annotations=max_annotations
+    )
+    after = _capture_view(
+        view,
+        opt_result,
+        opt_source,
+        line_index=LineIndex(opt_source),
+        views=views,
+        max_annotations=max_annotations,
+    )
+    diff = list(
+        difflib.unified_diff(
+            before, after, fromfile=f"{view} (original)", tofile=f"{view} (optimised)", lineterm=""
+        )
+    )
+    if not diff:
+        print(style(f"{view}: no change under the optimiser", Ansi.DIM, use_colour))
+        return
+    for line in diff:
+        if line.startswith("+"):
+            print(style(line, Ansi.GREEN, use_colour))
+        elif line.startswith("-"):
+            print(style(line, Ansi.RED, use_colour))
+        elif line.startswith("@@"):
+            print(style(line, Ansi.CYAN, use_colour))
+        else:
+            print(line)
+
+
 def _summary_parts(result: CompilerExplorerResult, dialect: str) -> list[str]:
     total_dead_stores = sum(len(s.analysis.dead_stores) for s in result.snapshots)
     total_unreachable = sum(len(s.analysis.unreachable_blocks) for s in result.snapshots)
@@ -1602,19 +1754,23 @@ def _render_text(
     _version = FULL_VERSION + (f" ({BUILD_TIMESTAMP})" if BUILD_TIMESTAMP else "")
     print(style(f"compiler-optimiser-explorer {_version}", Ansi.BOLD, use_colour))
     print(style(" ".join(_summary_parts(result, args.dialect)), Ansi.DIM, use_colour))
-    print(style(f"views: {','.join(sorted(args.views))}", Ansi.DIM, use_colour))
+    opt_label = "" if args.opt == "off" else f"  opt={args.opt}"
+    print(style(f"views: {','.join(sorted(args.views))}{opt_label}", Ansi.DIM, use_colour))
     print()
+    opt = optimised_result(result, args.dialect) if args.opt != "off" else None
     for view in _VIEW_ORDER:
         if view not in args.views:
             continue
         if view == "callouts" and args.no_source_callouts:
             continue
-        render_view(
+        render_view_opt(
             view,
             result,
             source,
             use_colour=use_colour,
             line_index=line_index,
+            opt_mode=args.opt,
+            opt=opt,
             views=args.views,
             show_optimised_source=args.show_optimised_source,
             max_annotations=args.max_annotations,

--- a/tooling/explorer/static/explorer-core.js
+++ b/tooling/explorer/static/explorer-core.js
@@ -399,9 +399,11 @@ function renderGvn() {
   if(!data.gvn.length){pane.innerHTML='<div class="empty-state">No redundant computations detected</div>';return;}
   var html='';
   for(var w of data.gvn){
-    html+='<div class="gvn-item"'+sourceRangeAttrs(w.range)+'><span class="gvn-code">'+esc(w.code)+'</span> '+esc(w.message||'redundant computation')+' <span class="gvn-expr">'+esc(w.expression)+'</span> <span class="gvn-first">[first: '+spanLabel(w.firstRange)+']</span> <span style="color:var(--text-dim); font-size:10px">['+spanLabel(w.range)+']</span></div>';
+    var head='<div class="gvn-item"'+sourceRangeAttrs(w.range)+'><span class="gvn-code">'+esc(w.code)+'</span> '+esc(w.message||'redundant computation')+' <span class="gvn-expr">'+esc(w.expression)+'</span> <span class="gvn-first">[first: '+spanLabel(w.firstRange)+']</span> <span style="color:var(--text-dim); font-size:10px">['+spanLabel(w.range)+']</span></div>';
+    var detail=detailRow('code',w.code)+detailRow('message',w.message||'redundant computation')+detailRow('expression',w.expression)+detailRow('first seen',spanLabel(w.firstRange))+rangeDetail(w.range);
+    html+=xpand(head,detail);
   }
-  pane.innerHTML=html;setupHoverHighlighting(pane);
+  pane.innerHTML=html;setupHoverHighlighting(pane);setupExpandable(pane);
 }
 
 // Taint
@@ -418,10 +420,13 @@ function renderTaint() {
       // the renderer just maps it to a CSS class.  Falls back to "warning"
       // when the backend didn't classify (older payloads / unit tests).
       var severity = w.severity || 'warning';
-      html+='<div class="taint-item taint-'+severity+'"'+sourceRangeAttrs(w.range)+'><span class="taint-code">'+esc(w.code)+'</span> '+esc(w.message)+' ';
-      if(w.variable)html+='<span style="color:var(--orange)">'+esc(w.variable)+'</span> ';
-      if(w.sinkCommand)html+='<span style="color:var(--red)">\u2192 '+esc(w.sinkCommand)+'</span> ';
-      html+='<span style="color:var(--text-dim); font-size:10px">['+spanLabel(w.range)+']</span></div>';
+      var head='<div class="taint-item taint-'+severity+'"'+sourceRangeAttrs(w.range)+'><span class="taint-code">'+esc(w.code)+'</span> '+esc(w.message)+' ';
+      if(w.variable)head+='<span style="color:var(--orange)">'+esc(w.variable)+'</span> ';
+      if(w.sinkCommand)head+='<span style="color:var(--red)">\u2192 '+esc(w.sinkCommand)+'</span> ';
+      head+='<span style="color:var(--text-dim); font-size:10px">['+spanLabel(w.range)+']</span></div>';
+      var detail=detailRow('code',w.code)+detailRow('severity',severity)+detailRow('message',w.message)+
+        (w.variable?detailRow('variable',w.variable):'')+(w.sinkCommand?detailRow('sink command',w.sinkCommand):'')+rangeDetail(w.range);
+      html+=xpand(head,detail);
     }
   }
   if(hasTracking){
@@ -429,11 +434,14 @@ function renderTaint() {
     for(var func of data.taintTracking){
       html+='<div class="proc-card">';
       html+='<div class="proc-name">'+esc(func.name)+'</div>';
-      for(var e of func.entries){html+='<div class="taint-tracking-var">'+esc(e.variable)+'#'+e.version+': <span class="taint-val">'+esc(e.taint)+'</span></div>';}
+      for(var e of func.entries){
+        var thead='<div class="taint-tracking-var">'+esc(e.variable)+'#'+e.version+': <span class="taint-val">'+esc(e.taint)+'</span></div>';
+        html+=xpand(thead,detailRow('variable',e.variable)+detailRow('version',e.version)+detailRow('taint',e.taint));
+      }
       html+='</div>';
     }
   }
-  pane.innerHTML=html;setupHoverHighlighting(pane);
+  pane.innerHTML=html;setupHoverHighlighting(pane);setupExpandable(pane);
 }
 
 // Types
@@ -446,11 +454,14 @@ function renderTypes() {
     html+='<div class="proc-name">'+esc(func.name)+'</div>';
     for(var e of func.entries){
       var label=e.variable.startsWith('(')?e.variable:e.variable+'#'+e.version;
-      html+='<div class="type-entry"><span class="type-var">'+esc(label)+'</span><span class="type-val type-'+e.kind+'">'+esc(e.type)+'</span></div>';
+      var head='<div class="type-entry"><span class="type-var">'+esc(label)+'</span><span class="type-val type-'+e.kind+'">'+esc(e.type)+'</span></div>';
+      var detail=detailRow('variable',e.variable)+detailRow('version',e.version)+detailRow('kind',e.kind)+detailRow('type',e.type);
+      html+=xpand(head,detail);
     }
     html+='</div>';
   }
   pane.innerHTML=html;
+  setupExpandable(pane);
 }
 
 // Rendered Properties
@@ -466,11 +477,14 @@ function renderRendered() {
       var may=e.may.length?'may: '+e.may.join(', '):'';
       var must=e.must.length?'must: '+e.must.join(', '):'';
       var parts=[may,must].filter(function(x){return x;}).join(' | ');
-      html+='<div class="type-entry"><span class="type-var">'+esc(e.variable)+'#'+e.version+'</span><span class="type-val" style="color:var(--cyan)">'+esc(parts)+'</span></div>';
+      var head='<div class="type-entry"><span class="type-var">'+esc(e.variable)+'#'+e.version+'</span><span class="type-val" style="color:var(--cyan)">'+esc(parts)+'</span></div>';
+      var detail=detailRow('variable',e.variable)+detailRow('version',e.version)+detailRow('may',e.may.join(', ')||'—')+detailRow('must',e.must.join(', ')||'—');
+      html+=xpand(head,detail);
     }
     html+='</div>';
   }
   pane.innerHTML=html;
+  setupExpandable(pane);
 }
 
 // Generic expand-on-click / Space|Enter for explorer items.
@@ -502,6 +516,20 @@ function setupExpandable(container) {
 function detailRow(k, v) {
   return '<div class="xpand-detail-row"><span class="xpand-detail-k">' + esc(k) +
          '</span><span class="xpand-detail-v">' + esc(String(v)) + '</span></div>';
+}
+
+// Non-destructively wrap an existing item's markup so it expands to a detail
+// block on click / Space.  ``headHtml`` is the item exactly as it rendered
+// before (keeping its class, data-start hover and other hooks intact); the
+// detail is a sibling that only shows when the wrapper is expanded.  Lets us
+// retrofit expand-to-detail onto a tab without restructuring its items.
+function xpand(headHtml, detailHtml) {
+  return '<div class="xpand xpand-wrap" tabindex="0">' + headHtml +
+         '<div class="xpand-detail">' + detailHtml + '</div></div>';
+}
+function rangeDetail(range) {
+  if (!range) return '';
+  return detailRow('range', spanLabel(range) + '  (' + range.startOffset + '…' + range.endOffset + ')');
 }
 
 // Optimisation lens (off / on / diff) for the structured IR & CFG tabs.
@@ -765,14 +793,18 @@ function renderDataFlow() {
     html+='<div class="analysis-entry" style="color:var(--cyan)">def-use chains:</div>';
     for(var n of func.nodes){
       var cls=n.isDead?'color:var(--yellow)':'color:var(--green)';
-      html+='<div class="analysis-entry" style="margin-left:12px; '+cls+'">';
-      html+=esc(n.name)+'#'+n.version;
-      html+=' <span style="color:var(--text-dim)">['+esc(n.defKind)+' in '+esc(n.block)+']</span>';
-      if(n.lattice)html+=' = <span class="val">'+esc(n.lattice)+'</span>';
-      if(n.typeInfo&&n.typeInfo!=='UNKNOWN')html+=' : <span class="val">'+esc(n.typeInfo)+'</span>';
-      html+=' &rarr; '+n.useCount+' use'+(n.useCount!==1?'s':'');
-      if(n.isDead)html+=' <span style="color:var(--red)">(DEAD)</span>';
-      html+='</div>';
+      var head='<div class="analysis-entry" style="margin-left:12px; '+cls+'">';
+      head+=esc(n.name)+'#'+n.version;
+      head+=' <span style="color:var(--text-dim)">['+esc(n.defKind)+' in '+esc(n.block)+']</span>';
+      if(n.lattice)head+=' = <span class="val">'+esc(n.lattice)+'</span>';
+      if(n.typeInfo&&n.typeInfo!=='UNKNOWN')head+=' : <span class="val">'+esc(n.typeInfo)+'</span>';
+      head+=' &rarr; '+n.useCount+' use'+(n.useCount!==1?'s':'');
+      if(n.isDead)head+=' <span style="color:var(--red)">(DEAD)</span>';
+      head+='</div>';
+      var detail=detailRow('ssa value',n.name+'#'+n.version)+detailRow('def kind',n.defKind)+detailRow('block',n.block)+
+        (n.lattice?detailRow('lattice',n.lattice):'')+(n.typeInfo?detailRow('type',n.typeInfo):'')+
+        detailRow('uses',n.useCount)+detailRow('dead',n.isDead?'yes':'no');
+      html+=xpand(head,detail);
     }
     // Edges summary
     if(func.edges.length){
@@ -783,6 +815,7 @@ function renderDataFlow() {
     html+='</div>';
   }
   pane.innerHTML=html;
+  setupExpandable(pane);
 }
 
 // Source callouts

--- a/tooling/explorer/static/explorer-core.js
+++ b/tooling/explorer/static/explorer-core.js
@@ -443,6 +443,185 @@ function renderRendered() {
   pane.innerHTML=html;
 }
 
+// Generic expand-on-click / Space|Enter for explorer items.
+//
+// Any element with class ``xpand`` toggles ``expanded`` when clicked or
+// (when focused) on Space/Enter, revealing its direct ``.xpand-detail`` and
+// ``.xpand-children``.  Markup gives expandable rows ``tabindex="0"`` so
+// keyboard users can focus and expand them.  Clicks inside an already-open
+// ``.xpand-detail`` are ignored so text stays selectable, and ``closest``
+// resolves to the innermost row so nested trees toggle independently.
+function setupExpandable(container) {
+  if (container._xpandWired) return;
+  container._xpandWired = true;
+  container.addEventListener('click', function(e) {
+    if (e.target.closest('a, button, input, textarea, .xpand-detail')) return;
+    var row = e.target.closest('.xpand');
+    if (row && container.contains(row)) row.classList.toggle('expanded');
+  });
+  container.addEventListener('keydown', function(e) {
+    if (e.key !== ' ' && e.key !== 'Enter') return;
+    var row = e.target.closest && e.target.closest('.xpand');
+    if (row && row === document.activeElement) {
+      e.preventDefault();
+      row.classList.toggle('expanded');
+    }
+  });
+}
+
+function detailRow(k, v) {
+  return '<div class="xpand-detail-row"><span class="xpand-detail-k">' + esc(k) +
+         '</span><span class="xpand-detail-v">' + esc(String(v)) + '</span></div>';
+}
+
+// Green token tree — proper tree with click/Space to expand every token to
+// its type, absolute character range, line:col span and verbatim text.
+// Opaque {...} / [...] tokens expand into their re-lexed child region.
+function renderGreentree() {
+  var pane = $('#pane-greentree');
+  var root = data.greentree;
+  if (!root) { pane.innerHTML = '<div class="empty-state">No green tree</div>'; return; }
+  var html = '<div class="section-header">green tree <span style="color:var(--text-dim);font-weight:normal">' +
+             esc(root.kind.toLowerCase()) + ' / ' + esc(root.mode.toLowerCase()) + ' &middot; ' + root.width + ' bytes</span></div>';
+  html += '<div class="gt-tree">' + gtTokens(root.tokens) + '</div>';
+  pane.innerHTML = html;
+  setupHoverHighlighting(pane);
+  setupExpandable(pane);
+}
+function gtTokens(tokens) {
+  if (!tokens || !tokens.length) return '<div class="gt-empty">(no tokens)</div>';
+  var html = '';
+  for (var t of tokens) {
+    var hasChild = !!t.child;
+    var opaque = t.type === 'STR' || t.type === 'CMD';
+    var errChild = hasChild && t.child.isError;
+    var cls = errChild ? 'gt-error' : (opaque ? 'gt-opaque' : '');
+    var oneLine = t.text.replace(/\n/g, '⏎');
+    var preview = oneLine.length > 48 ? oneLine.slice(0, 48) + '…' : oneLine;
+    html += '<div class="gt-node xpand ' + cls + '" tabindex="0" data-start="' + t.startOffset + '" data-end="' + t.endOffset + '">';
+    html += '<div class="xpand-head gt-head">';
+    html += '<span class="gt-toggle">' + (hasChild ? '▸' : '·') + '</span>';
+    html += '<span class="gt-type">' + esc(t.type) + '</span>';
+    html += '<span class="gt-text">' + esc(preview) + '</span>';
+    html += '<span class="gt-range">[' + t.startOffset + ':' + t.endOffset + ']</span>';
+    html += '</div>';
+    html += '<div class="xpand-detail">';
+    html += detailRow('token type', t.type);
+    html += detailRow('byte range', t.startOffset + '…' + t.endOffset + ' (' + Math.max(0, t.endOffset - t.startOffset) + ' bytes)');
+    html += detailRow('line:col', (t.startLine + 1) + ':' + (t.startCol + 1) + ' → ' + (t.endLine + 1) + ':' + (t.endCol + 1));
+    if (hasChild) html += detailRow('region', t.child.kind.toLowerCase() + ' / ' + t.child.mode.toLowerCase() + (t.child.isError ? ' (ERROR — unterminated)' : ''));
+    html += '<div class="xpand-detail-row"><span class="xpand-detail-k">text</span></div>';
+    html += '<pre class="gt-text-full">' + esc(t.text) + '</pre>';
+    html += '</div>';
+    if (hasChild) {
+      var c = t.child;
+      html += '<div class="xpand-children">';
+      html += '<div class="gt-region">' + esc(c.kind.toLowerCase()) + ' &middot; mode ' + esc(c.mode.toLowerCase()) + ' &middot; ' + c.width + ' bytes' + (c.isError ? ' &middot; <span style="color:var(--red)">ERROR</span>' : '') + '</div>';
+      html += gtTokens(c.tokens);
+      html += '</div>';
+    }
+    html += '</div>';
+  }
+  return html;
+}
+
+function fmtBound(v, pos) { return v === null || v === undefined ? (pos ? '+∞' : '−∞') : String(v); }
+
+// Natural-loop forest
+function renderLoops() {
+  var pane = $('#pane-loops');
+  var fns = data.loops || [];
+  if (!fns.reduce(function(n, f) { return n + f.loops.length; }, 0)) {
+    pane.innerHTML = '<div class="empty-state">No natural loops</div>'; return;
+  }
+  var html = '';
+  for (var f of fns) {
+    if (!f.loops.length) continue;
+    html += '<div class="proc-card"><div class="proc-name">' + esc(f.name) + '</div>';
+    for (var lp of f.loops) {
+      html += '<div class="xpand loop-item" tabindex="0"><div class="xpand-head"><span class="gt-toggle">▸</span> header <span class="val">' + esc(lp.header) + '</span> &middot; depth <span class="val">' + lp.depth + '</span> &middot; <span class="val">' + lp.blockCount + '</span> block(s)</div>';
+      html += '<div class="xpand-detail">';
+      html += detailRow('header block', lp.header);
+      html += detailRow('nesting depth', lp.depth);
+      html += detailRow('blocks (' + lp.blockCount + ')', lp.blocks.join(', '));
+      html += detailRow('latches', lp.latches.join(', ') || '—');
+      html += '</div></div>';
+    }
+    html += '</div>';
+  }
+  pane.innerHTML = html;
+  setupExpandable(pane);
+}
+
+// Integer-interval abstract domain
+function renderIntervals() {
+  var pane = $('#pane-intervals');
+  var fns = data.intervals || [];
+  if (!fns.reduce(function(n, f) { return n + f.entries.length; }, 0)) {
+    pane.innerHTML = '<div class="empty-state">No bounded ranges</div>'; return;
+  }
+  var html = '';
+  for (var f of fns) {
+    if (!f.entries.length) continue;
+    html += '<div class="proc-card"><div class="proc-name">' + esc(f.name) + '</div>';
+    for (var e of f.entries) {
+      var lo = fmtBound(e.lo, false), hi = fmtBound(e.hi, true);
+      html += '<div class="xpand type-entry" tabindex="0"><div class="xpand-head"><span class="type-var">' + esc(e.variable) + '#' + e.version + '</span><span class="type-val">[' + lo + ', ' + hi + ']</span></div>';
+      html += '<div class="xpand-detail">' + detailRow('lower bound', lo) + detailRow('upper bound', hi) + detailRow('ssa value', e.variable + '#' + e.version) + '</div></div>';
+    }
+    html += '</div>';
+  }
+  pane.innerHTML = html;
+  setupExpandable(pane);
+}
+
+// Interval-driven bounds / divide-by-zero findings
+function renderBounds() {
+  var pane = $('#pane-bounds');
+  var fns = data.bounds || [];
+  if (!fns.reduce(function(n, f) { return n + f.findings.length + f.divzero.length; }, 0)) {
+    pane.innerHTML = '<div class="empty-state">No provable out-of-range / divide-by-zero</div>'; return;
+  }
+  var html = '';
+  for (var f of fns) {
+    if (!f.findings.length && !f.divzero.length) continue;
+    html += '<div class="proc-card"><div class="proc-name">' + esc(f.name) + '</div>';
+    for (var b of f.findings) {
+      var lo = fmtBound(b.lo, false), hi = fmtBound(b.hi, true);
+      html += '<div class="xpand bounds-item" tabindex="0"><div class="xpand-head"><span class="shimmer-code">' + esc(b.code) + '</span> ' + esc(b.command) + ' $' + esc(b.indexVar) + ' in [' + lo + ', ' + hi + '] vs length ' + b.length + '</div>';
+      html += '<div class="xpand-detail">' + detailRow('code', b.code) + detailRow('command', b.command) + detailRow('index var', '$' + b.indexVar) + detailRow('index range', '[' + lo + ', ' + hi + ']') + detailRow('container length', b.length) + detailRow('reason', b.reason) + '</div></div>';
+    }
+    for (var dz of f.divzero) {
+      html += '<div class="xpand bounds-item" tabindex="0"><div class="xpand-head"><span class="shimmer-code">' + esc(dz.code) + '</span> \'' + esc(dz.op) + '\' divisor is provably 0 (divide by zero)</div>';
+      html += '<div class="xpand-detail">' + detailRow('code', dz.code) + detailRow('operator', dz.op) + detailRow('reason', 'divisor interval is exactly [0, 0]') + '</div></div>';
+    }
+    html += '</div>';
+  }
+  pane.innerHTML = html;
+  setupExpandable(pane);
+}
+
+// iRules event firing order
+function renderEventOrder() {
+  var pane = $('#pane-event-order');
+  var events = (data.eventOrder || []).slice();
+  if (!events.length) { pane.innerHTML = '<div class="empty-state">No event-order data</div>'; return; }
+  events.sort(function(a, b) {
+    return (b.base_priority + b.priority_offset) - (a.base_priority + a.priority_offset) || (a.event < b.event ? -1 : 1);
+  });
+  var html = '<div class="proc-card"><div class="proc-name">Event firing order (high → low priority)</div>';
+  for (var e of events) {
+    var eff = e.base_priority + e.priority_offset;
+    var mult = e.multiplicity && e.multiplicity !== 'once' ? ' [' + esc(e.multiplicity) + ']' : '';
+    html += '<div class="xpand type-entry" tabindex="0"' + sourceRangeAttrs(e.range) + '><div class="xpand-head"><span class="type-var">' + esc(e.event) + '</span><span class="type-val">eff ' + eff + mult + '</span></div>';
+    html += '<div class="xpand-detail">' + detailRow('event', e.event) + detailRow('effective priority', eff) + detailRow('base priority', e.base_priority) + detailRow('priority offset', e.priority_offset) + detailRow('multiplicity', e.multiplicity || 'once') + '</div></div>';
+  }
+  html += '</div>';
+  pane.innerHTML = html;
+  setupHoverHighlighting(pane);
+  setupExpandable(pane);
+}
+
 // Data Flow
 function renderDataFlow() {
   var pane=$('#pane-dataflow');

--- a/tooling/explorer/static/explorer-core.js
+++ b/tooling/explorer/static/explorer-core.js
@@ -71,10 +71,19 @@ function renderStats() {
 // IR rendering
 function renderIR() {
   var pane = $('#pane-ir');
-  var html = '<div class="section-header">top-level</div><div class="ir-tree">';
-  html += renderIRNodes(data.ir.topLevel);
+  var optAvail = !!data.irOptimised;
+  var mode = optAvail ? (structOptState['pane-ir'] || 'off') : 'off';
+  var toolbar = renderOptToolbar('pane-ir', optAvail);
+  if (mode === 'diff') {
+    pane.innerHTML = toolbar + renderTextDiff(irToLines(data.ir), irToLines(data.irOptimised));
+    setupOptToolbar(pane, 'pane-ir', renderIR);
+    return;
+  }
+  var ir = mode === 'on' ? data.irOptimised : data.ir;
+  var html = toolbar + '<div class="section-header">top-level</div><div class="ir-tree">';
+  html += renderIRNodes(ir.topLevel);
   html += '</div>';
-  var procs = data.ir.procedures;
+  var procs = ir.procedures;
   if (Object.keys(procs).length) {
     html += '<div class="section-header">procedures</div>';
     for (var _e of Object.entries(procs)) {
@@ -87,6 +96,7 @@ function renderIR() {
   pane.innerHTML = html;
   setupHoverHighlighting(pane);
   setupIRToggle(pane);
+  setupOptToolbar(pane, 'pane-ir', renderIR);
 }
 function renderIRNodes(nodes) {
   if (!nodes || !nodes.length) return '<div style="color:var(--text-dim); margin-left:16px; font-size:11px">(empty)</div>';
@@ -126,8 +136,17 @@ function setupIRToggle(container) {
 // CFG (pre-SSA)
 function renderCfgPre() {
   var pane = $('#pane-cfg-pre');
-  var html = '';
-  for (var func of data.cfgPreSsa) {
+  var optAvail = !!data.cfgPreSsaOptimised;
+  var mode = optAvail ? (structOptState['pane-cfg-pre'] || 'off') : 'off';
+  var toolbar = renderOptToolbar('pane-cfg-pre', optAvail);
+  if (mode === 'diff') {
+    pane.innerHTML = toolbar + renderTextDiff(cfgToLines(data.cfgPreSsa), cfgToLines(data.cfgPreSsaOptimised));
+    setupOptToolbar(pane, 'pane-cfg-pre', renderCfgPre);
+    return;
+  }
+  var funcs = mode === 'on' ? data.cfgPreSsaOptimised : data.cfgPreSsa;
+  var html = toolbar;
+  for (var func of funcs) {
     html += '<div class="cfg-function cfg-edges-container" data-func="' + esc(func.name) + '">';
     html += '<div class="cfg-func-header">' + esc(func.name) + ' <span style="color:var(--text-dim); font-size:11px">entry=' + esc(func.entry) + ' blocks=' + func.blockCount + '</span></div>';
     for (var block of func.blocks) {
@@ -147,7 +166,8 @@ function renderCfgPre() {
   }
   pane.innerHTML = html || '<div class="empty-state">No functions</div>';
   setupHoverHighlighting(pane);
-  requestAnimationFrame(function() { drawAllCfgEdges(pane, data.cfgPreSsa); });
+  setupOptToolbar(pane, 'pane-cfg-pre', renderCfgPre);
+  requestAnimationFrame(function() { drawAllCfgEdges(pane, funcs); });
 }
 function renderTerminator(t) {
   if (t.type === 'goto') return 'goto ' + esc(t.target);
@@ -159,8 +179,17 @@ function renderTerminator(t) {
 // CFG (post-SSA)
 function renderCfgPost() {
   var pane = $('#pane-cfg-post');
-  var html = '';
-  for (var func of data.cfgPostSsa) {
+  var optAvail = !!data.cfgPostSsaOptimised;
+  var mode = optAvail ? (structOptState['pane-cfg-post'] || 'off') : 'off';
+  var toolbar = renderOptToolbar('pane-cfg-post', optAvail);
+  if (mode === 'diff') {
+    pane.innerHTML = toolbar + renderTextDiff(cfgToLines(data.cfgPostSsa), cfgToLines(data.cfgPostSsaOptimised));
+    setupOptToolbar(pane, 'pane-cfg-post', renderCfgPost);
+    return;
+  }
+  var funcs = mode === 'on' ? data.cfgPostSsaOptimised : data.cfgPostSsa;
+  var html = toolbar;
+  for (var func of funcs) {
     html += '<div class="cfg-function cfg-edges-container" data-func="' + esc(func.name) + '">';
     html += '<div class="cfg-func-header">' + esc(func.name) + ' <span style="color:var(--text-dim); font-size:11px">entry=' + esc(func.entry) + ' blocks=' + func.blockCount + '</span></div>';
     for (var block of func.blocks) {
@@ -212,7 +241,8 @@ function renderCfgPost() {
   pane.innerHTML = html || '<div class="empty-state">No functions</div>';
   setupHoverHighlighting(pane);
   setupVarTooltips(pane);
-  requestAnimationFrame(function() { drawAllCfgEdges(pane, data.cfgPostSsa); });
+  setupOptToolbar(pane, 'pane-cfg-post', renderCfgPost);
+  requestAnimationFrame(function() { drawAllCfgEdges(pane, funcs); });
 }
 
 // Interprocedural
@@ -472,6 +502,94 @@ function setupExpandable(container) {
 function detailRow(k, v) {
   return '<div class="xpand-detail-row"><span class="xpand-detail-k">' + esc(k) +
          '</span><span class="xpand-detail-v">' + esc(String(v)) + '</span></div>';
+}
+
+// Optimisation lens (off / on / diff) for the structured IR & CFG tabs.
+// ``off`` renders the original program, ``on`` the optimised program, and
+// ``diff`` a rendered-line diff of the two.  ASM/WASM have their own toggle
+// (renderDisassembly); this mirrors it for the structured views.
+var structOptState = { 'pane-ir': 'off', 'pane-cfg-pre': 'off', 'pane-cfg-post': 'off' };
+
+function renderOptToolbar(paneId, available) {
+  var mode = available ? (structOptState[paneId] || 'off') : 'off';
+  function btn(val, label) {
+    var dis = (val !== 'off' && !available) ? ' disabled' : '';
+    var on = mode === val ? ' active' : '';
+    return '<button class="optlens-btn' + on + '" data-opt-lens="' + val + '"' + dis + '>' + label + '</button>';
+  }
+  var hint = available ? '' : '<span class="disasm-toolbar-hint">(source unchanged by optimiser)</span>';
+  return '<div class="disasm-toolbar optlens-toolbar">'
+       + '<span class="optlens-label">Optimiser</span>'
+       + btn('off', 'off') + btn('on', 'on') + btn('diff', 'diff') + hint
+       + '</div>';
+}
+function setupOptToolbar(pane, paneId, rerender) {
+  pane.querySelectorAll('[data-opt-lens]').forEach(function(b) {
+    b.addEventListener('click', function() {
+      if (b.disabled) return;
+      structOptState[paneId] = b.dataset.optLens;
+      rerender();
+    });
+  });
+}
+
+// Flatten the structured IR / CFG into plain text lines for a line diff.
+function irToLines(ir) {
+  var lines = [];
+  function walk(nodes, depth) {
+    for (var n of (nodes || [])) {
+      lines.push('  '.repeat(depth) + n.summary);
+      if (n.children) for (var c of n.children) {
+        lines.push('  '.repeat(depth + 1) + c.label + ':');
+        walk(c.body, depth + 2);
+      }
+    }
+  }
+  lines.push('top-level');
+  walk(ir.topLevel, 1);
+  if (ir.procedures) for (var name of Object.keys(ir.procedures)) {
+    lines.push('proc ' + name);
+    walk(ir.procedures[name].body, 1);
+  }
+  return lines;
+}
+function cfgToLines(funcs) {
+  var lines = [];
+  for (var f of (funcs || [])) {
+    lines.push('function ' + f.name + ' entry=' + f.entry + ' blocks=' + f.blockCount);
+    for (var b of f.blocks) {
+      lines.push('block ' + b.name + (b.isEntry ? ' [entry]' : '') + (b.isUnreachable ? ' [unreachable]' : ''));
+      if (b.phis) for (var p of b.phis) lines.push('  phi ' + p.name + '#' + p.version);
+      for (var s of b.statements) lines.push('  ' + s.summary);
+      if (b.terminator) {
+        var t = b.terminator;
+        lines.push('  term ' + t.type + (t.target ? ' ' + t.target : '') +
+                   (t.trueTarget ? ' ' + t.trueTarget + '/' + t.falseTarget : '') +
+                   (t.value ? ' ' + t.value : ''));
+      }
+    }
+  }
+  return lines;
+}
+function renderTextDiff(origLines, optLines) {
+  var segs = computeDiffSegments(origLines, optLines);
+  if (!segs.some(function(s) { return s.type !== 'same'; })) {
+    return '<div class="empty-state">No changes under the optimiser</div>';
+  }
+  var html = '<div class="optlens-legend"><span class="optlens-del-k">− original</span> <span class="optlens-add-k">+ optimised</span></div>';
+  html += '<pre class="optlens-diff">';
+  for (var seg of segs) {
+    if (seg.type === 'same') {
+      var n = seg.optEnd - seg.optStart, show = Math.min(n, 1);
+      for (var i = 0; i < show; i++) html += '<div class="optlens-line"><span class="optlens-sig"> </span>' + esc(optLines[seg.optStart + i]) + '</div>';
+      if (n > show) html += '<div class="optlens-elide">… ' + (n - show) + ' unchanged line' + ((n - show) === 1 ? '' : 's') + '</div>';
+    } else {
+      for (var i = seg.origStart; i < seg.origEnd; i++) html += '<div class="optlens-line optlens-del"><span class="optlens-sig">−</span>' + esc(origLines[i]) + '</div>';
+      for (var j = seg.optStart; j < seg.optEnd; j++) html += '<div class="optlens-line optlens-add"><span class="optlens-sig">+</span>' + esc(optLines[j]) + '</div>';
+    }
+  }
+  html += '</pre>';
+  return html;
 }
 
 // Green token tree — proper tree with click/Space to expand every token to

--- a/tooling/explorer/static/explorer-core.js
+++ b/tooling/explorer/static/explorer-core.js
@@ -511,8 +511,8 @@ function renderCallouts() {
     for (var idx of indices) {
       var ann = data.annotations[idx];
       var lineStart=lineStarts[i];var startCol=Math.max(0,ann.range.startOffset-lineStart);var endCol=Math.max(startCol,ann.range.endOffset-lineStart);
-      var marker=' '.repeat(startCol)+'^'+'-'.repeat(Math.max(0,endCol-startCol));
-      var arrow=' '.repeat(startCol)+'+--> '+ann.label;
+      var marker=' '.repeat(startCol)+'^'+'─'.repeat(Math.max(0,endCol-startCol));
+      var arrow=' '.repeat(startCol)+'╰─▶ '+ann.label;
       // Both ``kind`` (source) and ``severity`` (classification) drive
       // CSS — kind colours the per-source visual identity, severity
       // gives danger/warn/info a consistent treatment across panes.

--- a/tooling/explorer/static/index.html
+++ b/tooling/explorer/static/index.html
@@ -1452,12 +1452,15 @@ function renderShimmer() {
   let html='<div class="section-header">Warnings</div>';
   for(const w of data.shimmer){
     const sev = w.severity || 'warning';
-    html+=`<div class="shimmer-item shimmer-${sev}"${sourceRangeAttrs(w.range)}><span class="shimmer-code">${esc(w.code)}</span> ${esc(w.message)} <span style="color:var(--text-dim); font-size:10px">[${spanLabel(w.range)}]</span></div>`;
+    const head=`<div class="shimmer-item shimmer-${sev}"${sourceRangeAttrs(w.range)}><span class="shimmer-code">${esc(w.code)}</span> ${esc(w.message)} <span style="color:var(--text-dim); font-size:10px">[${spanLabel(w.range)}]</span></div>`;
+    const detail=detailRow('code',w.code)+detailRow('severity',sev)+detailRow('message',w.message)+rangeDetail(w.range);
+    html+=xpand(head,detail);
   }
   html+='<div class="section-header">Involved Lines</div>'+buildShimmerLinesView();
   pane.innerHTML=html;
   setupHoverHighlighting(pane);
   setupShimmerItemLineScroll(pane);
+  setupExpandable(pane);
 }
 
 function buildShimmerLinesView() {

--- a/tooling/explorer/static/index.html
+++ b/tooling/explorer/static/index.html
@@ -674,6 +674,46 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
 }
 .tab.irules-only { display: none; }
 .tab.irules-only.irules-visible { display: flex; }
+/* Generic expand-on-click / Space items (green tree, loops, intervals, ...) */
+.xpand { cursor: pointer; outline: none; border-radius: 4px; }
+.xpand:focus-visible { box-shadow: inset 2px 0 0 var(--accent); background: var(--highlight); }
+.xpand > .xpand-detail, .xpand > .xpand-children { display: none; }
+.xpand.expanded > .xpand-detail, .xpand.expanded > .xpand-children { display: block; }
+.xpand-detail {
+  margin: 2px 0 6px 22px;
+  padding: 6px 10px;
+  background: var(--bg-surface);
+  border-left: 2px solid var(--border);
+  border-radius: 4px;
+  font-size: 11px;
+}
+.xpand-detail-row { display: flex; gap: 8px; padding: 1px 0; }
+.xpand-detail-k { color: var(--text-dim); min-width: 110px; flex: 0 0 auto; }
+.xpand-detail-v { color: var(--text); word-break: break-word; }
+.gt-text-full {
+  margin: 4px 0 0; padding: 6px 8px; white-space: pre-wrap; word-break: break-word;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text-bright); font-family: var(--font-mono); font-size: 11px; max-height: 220px; overflow: auto;
+}
+/* Green tree */
+.gt-tree { padding: 4px 8px; font-family: var(--font-mono); font-size: 12px; }
+.gt-node { padding: 0; }
+.gt-head { display: flex; align-items: baseline; gap: 6px; padding: 2px 6px; border-radius: 4px; }
+.gt-head:hover { background: var(--bg-hover); }
+.gt-toggle { display: inline-block; width: 12px; color: var(--text-dim); transition: transform 0.12s; flex: 0 0 auto; }
+.gt-node.expanded > .gt-head .gt-toggle { transform: rotate(90deg); }
+.gt-type { color: var(--accent); font-weight: 600; flex: 0 0 auto; }
+.gt-text { color: var(--text); white-space: pre; overflow: hidden; text-overflow: ellipsis; }
+.gt-range { color: var(--text-dim); font-size: 10px; margin-left: auto; flex: 0 0 auto; }
+.gt-node.gt-opaque > .gt-head .gt-type { color: var(--cyan); }
+.gt-node.gt-error > .gt-head .gt-type { color: var(--red); }
+.xpand-children { margin-left: 14px; border-left: 1px solid var(--border); padding-left: 4px; }
+.gt-region { color: var(--text-dim); font-size: 10px; padding: 2px 6px; font-style: italic; }
+.gt-empty { color: var(--text-dim); padding: 2px 6px; font-style: italic; }
+.loop-item > .xpand-head, .bounds-item > .xpand-head { padding: 3px 6px; border-radius: 4px; }
+.loop-item > .xpand-head:hover, .bounds-item > .xpand-head:hover { background: var(--bg-hover); }
+.type-entry.xpand > .xpand-head { display: flex; justify-content: space-between; gap: 8px; padding: 2px 4px; border-radius: 4px; }
+.type-entry.xpand > .xpand-head:hover { background: var(--bg-hover); }
 /* WASM disassembly view */
 .wasm-module { margin-bottom: 16px; }
 .wasm-module-details { margin-left: 16px; font-size: 11px; color: var(--text-dim); }
@@ -895,10 +935,14 @@ puts $x"></textarea>
     <div class="output-panel" id="outputPanel" style="position:relative">
       <div class="tab-bar" id="tabBar">
         <div class="tab active" data-tab="ir">IR</div>
+        <div class="tab" data-tab="greentree">Green Tree</div>
         <div class="tab" data-tab="cfg-pre">CFG</div>
         <div class="tab" data-tab="cfg-post">SSA+Analysis</div>
+        <div class="tab" data-tab="loops">Loops</div>
         <div class="tab" data-tab="interproc">Interproc</div>
         <div class="tab" data-tab="types">Types</div>
+        <div class="tab" data-tab="intervals">Intervals</div>
+        <div class="tab" data-tab="bounds">Bounds</div>
         <div class="tab" data-tab="rendered">Rendered</div>
         <div class="tab" data-tab="dataflow">Data Flow</div>
         <div class="tab" data-tab="opt">Optimiser</div>
@@ -906,6 +950,7 @@ puts $x"></textarea>
         <div class="tab" data-tab="shimmer">Shimmer</div>
         <div class="tab" data-tab="taint">Taint</div>
         <div class="tab irules-only" data-tab="irules-flow">iRules Flow</div>
+        <div class="tab irules-only" data-tab="event-order">Event Order</div>
         <div class="tab" data-tab="callouts">Callouts</div>
         <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
@@ -914,10 +959,14 @@ puts $x"></textarea>
         <div class="tab-pane active" id="pane-ir">
           <div class="empty-state" id="emptyState">Loading compiler...</div>
         </div>
+        <div class="tab-pane" id="pane-greentree"></div>
         <div class="tab-pane" id="pane-cfg-pre"></div>
         <div class="tab-pane" id="pane-cfg-post"></div>
+        <div class="tab-pane" id="pane-loops"></div>
         <div class="tab-pane" id="pane-interproc"></div>
         <div class="tab-pane" id="pane-types"></div>
+        <div class="tab-pane" id="pane-intervals"></div>
+        <div class="tab-pane" id="pane-bounds"></div>
         <div class="tab-pane" id="pane-rendered"></div>
         <div class="tab-pane" id="pane-dataflow"></div>
         <div class="tab-pane" id="pane-opt"></div>
@@ -925,6 +974,7 @@ puts $x"></textarea>
         <div class="tab-pane" id="pane-shimmer"></div>
         <div class="tab-pane" id="pane-taint"></div>
         <div class="tab-pane" id="pane-irules-flow"></div>
+        <div class="tab-pane" id="pane-event-order"></div>
         <div class="tab-pane" id="pane-callouts"></div>
         <div class="tab-pane" id="pane-asm"></div>
         <div class="tab-pane" id="pane-wasm"></div>
@@ -1152,10 +1202,14 @@ function renderAll() {
   updateIrulesTabVisibility();
   renderStats();
   renderIR();
+  renderGreentree();
   renderCfgPre();
   renderCfgPost();
+  renderLoops();
   renderInterproc();
   renderTypes();
+  renderIntervals();
+  renderBounds();
   renderRendered();
   renderDataFlow();
   renderOpt();
@@ -1163,6 +1217,7 @@ function renderAll() {
   renderShimmer();
   renderTaint();
   renderIrulesFlow();
+  renderEventOrder();
   renderCallouts();
   renderAsm();
   renderWasm();
@@ -1181,7 +1236,11 @@ function updateBadges() {
     'gvn': data.gvn.length,
     'shimmer': data.shimmer.length,
     'taint': data.taintWarnings.length + data.taintTracking.reduce((n, f) => n + f.entries.length, 0),
+    'loops': (data.loops || []).reduce((n, f) => n + f.loops.length, 0),
+    'intervals': (data.intervals || []).reduce((n, f) => n + f.entries.length, 0),
+    'bounds': (data.bounds || []).reduce((n, f) => n + f.findings.length + f.divzero.length, 0),
     'irules-flow': (data.eventOrder || []).length + data.irulesFlow.length,
+    'event-order': (data.eventOrder || []).length,
     'callouts': data.annotations.length,
     'asm': instrCount(data.asm),
     'wasm': instrCount(data.wasm),

--- a/tooling/explorer/static/index.html
+++ b/tooling/explorer/static/index.html
@@ -714,6 +714,25 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
 .loop-item > .xpand-head:hover, .bounds-item > .xpand-head:hover { background: var(--bg-hover); }
 .type-entry.xpand > .xpand-head { display: flex; justify-content: space-between; gap: 8px; padding: 2px 4px; border-radius: 4px; }
 .type-entry.xpand > .xpand-head:hover { background: var(--bg-hover); }
+/* Optimisation lens (off / on / diff) toolbar + diff for IR & CFG tabs */
+.optlens-toolbar { display: flex; align-items: center; gap: 6px; }
+.optlens-label { color: var(--text-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+.optlens-btn {
+  font: inherit; font-size: 11px; cursor: pointer; padding: 2px 10px;
+  background: var(--bg-surface); color: var(--text); border: 1px solid var(--border); border-radius: 4px;
+}
+.optlens-btn:hover:not(:disabled) { border-color: var(--accent); }
+.optlens-btn.active { background: var(--accent); color: var(--bg); border-color: var(--accent); font-weight: 600; }
+.optlens-btn:disabled { opacity: 0.4; cursor: default; }
+.optlens-legend { font-size: 11px; color: var(--text-dim); padding: 6px 8px; }
+.optlens-del-k { color: var(--red); }
+.optlens-add-k { color: var(--green); }
+.optlens-diff { margin: 0 8px; font-family: var(--font-mono); font-size: 12px; white-space: pre-wrap; }
+.optlens-line { display: flex; gap: 6px; padding: 0 4px; border-radius: 2px; }
+.optlens-sig { width: 10px; flex: 0 0 auto; color: var(--text-dim); }
+.optlens-add { background: rgba(166, 227, 161, 0.12); color: var(--green); }
+.optlens-del { background: rgba(243, 139, 168, 0.12); color: var(--red); }
+.optlens-elide { color: var(--text-dim); font-style: italic; padding: 2px 4px 2px 20px; }
 /* WASM disassembly view */
 .wasm-module { margin-bottom: 16px; }
 .wasm-module-details { margin-left: 16px; font-size: 11px; color: var(--text-dim); }

--- a/tooling/explorer/tui.py
+++ b/tooling/explorer/tui.py
@@ -1,15 +1,21 @@
 """Textual live UI for the compiler explorer.
 
 The default ``tcl-explorer`` surface on an interactive terminal.  It is a thin
-presentation layer: it runs the *same* ``run_pipeline`` and renders each view
-with the *same* ``cli.render_view`` text renderers (captured and shown as ANSI
-via Rich), so the TUI, the flat ``--text`` output, and the web GUI all stay in
-lockstep with one pipeline + one set of renderers.
+presentation layer over one pipeline + one serialisation: every analysis view
+is an interactive **tree** built from the same ``serialise_result`` payload the
+web GUI consumes (see ``tooling.explorer.tui_views``), so each item expands to
+its full detail exactly like the GUI's click/Space expansion — and the TUI,
+the web GUI, and the flat ``--text`` output stay in lockstep.
+
+A couple of views keep the captured-ANSI text renderer instead: ``asm`` /
+``wasm`` (specialised disassembly, navigated rather than expanded) and any
+``OPT_VIEWS`` shown in ``--opt diff`` mode (a rendered unified diff).
 
 This is a debugging / code-understanding aid, not a stable interface — views
 may be added, removed, or reshaped freely.
 
-Keys: ↑/↓ or click to switch view · ``r`` re-run (re-reads the file) · ``q`` quit.
+Keys: ↑/↓ or click to switch view · click / Enter / Space to expand a tree
+item · ``o`` cycle the optimisation lens · ``r`` re-run · ``q`` quit.
 """
 
 from __future__ import annotations
@@ -23,8 +29,10 @@ from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Footer, Header, Label, ListItem, ListView, Static, Tree
 
+from tooling.cli.serialise import serialise_result
 from tooling.explorer.cli import (
     _VIEW_ORDER,
+    OPT_VIEWS,
     LineIndex,
     _summary_parts,
     load_source,
@@ -32,57 +40,31 @@ from tooling.explorer.cli import (
     render_view_opt,
 )
 from tooling.explorer.pipeline import CompilerExplorerResult, run_pipeline
+from tooling.explorer.tui_views import TREE_VIEWS, ViewNode, build_view
 
 _OPT_CYCLE = ("off", "on", "diff")
-_GT_OPAQUE = ("STR", "CMD")
 
 
-def _gt_label(tok: dict) -> Text:
-    """A one-line tree label for a green-tree token: ``TYPE 'preview' [a:b]``."""
-    opaque = tok["type"] in _GT_OPAQUE
-    one_line = tok["text"].replace("\n", "⏎")
-    preview = one_line if len(one_line) <= 40 else one_line[:40] + "…"
-    label = Text()
-    label.append(tok["type"], style="cyan" if opaque else "bright_black")
-    label.append(" ")
-    label.append(repr(preview), style="")
-    label.append(f" [{tok['startOffset']}:{tok['endOffset']}]", style="dim")
-    return label
-
-
-def _gt_detail(data: dict) -> Text:
-    """Full detail for a highlighted green-tree node (token or root region)."""
+def _format_detail(node: ViewNode | None) -> Text:
+    """Render a highlighted node's detail table (and child hint) for the panel."""
+    if node is None:
+        return Text("↑/↓ to browse  ·  Enter / Space / click to expand", style="dim")
     t = Text()
-    if "type" in data:  # a token
-        t.append("token type  ", style="bold")
-        t.append(f"{data['type']}\n")
-        t.append("byte range  ", style="bold")
+    for key, value in node.detail:
+        t.append(f"{key:<16}", style="bold")
+        sval = str(value)
+        if "\n" in sval:
+            t.append("\n")
+            t.append(sval, style="bright_white")
+        else:
+            t.append(sval)
+        t.append("\n")
+    if node.children:
+        if node.detail:
+            t.append("\n")
         t.append(
-            f"{data['startOffset']}…{data['endOffset']} "
-            f"({max(0, data['endOffset'] - data['startOffset'])} bytes)\n"
+            f"{len(node.children)} child item(s) — Enter / Space to expand", style="dim"
         )
-        t.append("line:col    ", style="bold")
-        t.append(
-            f"{data['startLine'] + 1}:{data['startCol'] + 1} → "
-            f"{data['endLine'] + 1}:{data['endCol'] + 1}\n"
-        )
-        child = data.get("child")
-        if child is not None:
-            t.append("region      ", style="bold")
-            style = "red" if child["isError"] else "cyan"
-            t.append(
-                f"{child['kind'].lower()} / {child['mode'].lower()}"
-                + (" (ERROR — unterminated)" if child["isError"] else "")
-                + "\n",
-                style=style,
-            )
-        t.append("text\n", style="bold")
-        t.append(data["text"] or "(empty)", style="bright_white")
-    else:  # the root region
-        t.append("region      ", style="bold")
-        t.append(f"{data['kind'].lower()} / {data['mode'].lower()}\n")
-        t.append("width       ", style="bold")
-        t.append(f"{data['width']} bytes\n")
     return t
 
 
@@ -118,17 +100,17 @@ def _render_view_ansi(
 
 
 class ExplorerApp(App):
-    """Live compiler-explorer TUI: a view sidebar + a scrolling render pane."""
+    """Live compiler-explorer TUI: a view sidebar + an interactive render pane."""
 
     CSS = """
     #sidebar { width: 24; border-right: solid $accent; }
     #sidebar > ListView { height: 1fr; }
     #content { padding: 0 1; }
     #summary { color: $text-muted; padding: 0 1; height: auto; }
-    #gt-pane { display: none; }
-    #gt-tree { width: 1fr; }
-    #gt-detail-scroll { width: 45%; border-left: solid $accent; }
-    #gt-detail { padding: 0 1; }
+    #tree-pane { display: none; }
+    #view-tree { width: 1fr; }
+    #view-detail-scroll { width: 45%; border-left: solid $accent; }
+    #view-detail { padding: 0 1; }
     """
 
     BINDINGS = [
@@ -142,6 +124,7 @@ class ExplorerApp(App):
         self._source = source
         self._args = args
         self._result: CompilerExplorerResult | None = None
+        self._data: dict = {}
         self._opt: tuple[CompilerExplorerResult, str] | None = None
         self._opt_mode = getattr(args, "opt", "off") or "off"
         self._views = [v for v in _VIEW_ORDER if v in args.views]
@@ -154,16 +137,15 @@ class ExplorerApp(App):
             with VerticalScroll(id="sidebar"):
                 yield ListView(*(ListItem(Label(v), id=f"view-{v}") for v in self._views))
             with Vertical(id="main"):
-                # Default surface: captured-ANSI render of the active view.
+                # Text surface: captured-ANSI render (asm/wasm and opt diff).
                 with VerticalScroll(id="content-scroll"):
                     yield Static("", id="content", markup=False)
-                # Interactive surface used only for the green tree: a real tree
-                # whose entries expand (↑/↓ + Enter/Space/click) and pop their
-                # full token detail into the side panel as you move.
-                with Horizontal(id="gt-pane"):
-                    yield Tree("green-tree", id="gt-tree")
-                    with VerticalScroll(id="gt-detail-scroll"):
-                        yield Static("", id="gt-detail", markup=False)
+                # Interactive surface: a tree whose entries expand (↑/↓ + click /
+                # Enter / Space) and pop their full detail into the side panel.
+                with Horizontal(id="tree-pane"):
+                    yield Tree("view", id="view-tree")
+                    with VerticalScroll(id="view-detail-scroll"):
+                        yield Static("", id="view-detail", markup=False)
         yield Footer()
 
     def on_mount(self) -> None:
@@ -178,16 +160,19 @@ class ExplorerApp(App):
     def _recompute(self) -> None:
         try:
             self._result = run_pipeline(self._source, dialect=self._args.dialect)
+            # One serialisation drives every tree view (same payload as the GUI).
+            self._data = serialise_result(self._result)
         except Exception as exc:
             self.query_one("#content", Static).update(
                 Text(f"compiler exploration failed: {exc}", style="red")
             )
             self._result = None
+            self._data = {}
             return
-        # Recompute the optimised pipeline lazily — only when a lens needs it.
+        # The optimised pipeline is only needed for the text diff path.
         self._opt = (
             optimised_result(self._result, self._args.dialect)
-            if self._opt_mode != "off"
+            if self._opt_mode == "diff"
             else None
         )
         self._update_subtitle()
@@ -199,67 +184,81 @@ class ExplorerApp(App):
         opt = "" if self._opt_mode == "off" else f"  ·  opt: {self._opt_mode}"
         self.sub_title = f"{self._args.dialect}{opt}"
 
+    def _is_text_view(self, view: str) -> bool:
+        """Views the TUI renders as captured ANSI text instead of a tree."""
+        if view not in TREE_VIEWS:
+            return True  # asm / wasm / asm-opt / wasm-opt
+        return self._opt_mode == "diff" and view in OPT_VIEWS
+
+    def _view_data(self, view: str) -> dict:
+        """Serialised data for *view*, swapping in optimised keys under ``opt on``."""
+        data = self._data
+        if self._opt_mode == "on" and view in OPT_VIEWS:
+            data = dict(data)
+            if data.get("irOptimised"):
+                data["ir"] = data["irOptimised"]
+            if data.get("cfgPreSsaOptimised"):
+                data["cfgPreSsa"] = data["cfgPreSsaOptimised"]
+            if data.get("cfgPostSsaOptimised"):
+                data["cfgPostSsa"] = data["cfgPostSsaOptimised"]
+        return data
+
     def _show(self, view: str) -> None:
         self._current = view
         if self._result is None:
             return
-        # The green tree gets the interactive Tree surface; everything else the
-        # captured-ANSI Static.  Toggle which one is visible.
-        gt_pane = self.query_one("#gt-pane")
+        tree_pane = self.query_one("#tree-pane")
         content_scroll = self.query_one("#content-scroll")
-        if view == "greentree":
-            content_scroll.display = False
-            gt_pane.display = True
-            self._populate_greentree()
-            # Leave focus on the sidebar so ↑/↓ keep switching views; click or
-            # Tab into the tree to navigate/expand its entries.
-            return
-        gt_pane.display = False
-        content_scroll.display = True
-        self.query_one("#content", Static).update(
-            _render_view_ansi(
-                view,
-                self._result,
-                self._source,
-                self._args,
-                opt_mode=self._opt_mode,
-                opt=self._opt,
+        if self._is_text_view(view):
+            tree_pane.display = False
+            content_scroll.display = True
+            self.query_one("#content", Static).update(
+                _render_view_ansi(
+                    view,
+                    self._result,
+                    self._source,
+                    self._args,
+                    opt_mode=self._opt_mode,
+                    opt=self._opt,
+                )
             )
-        )
-
-    def _populate_greentree(self) -> None:
-        """(Re)build the interactive green tree from the shared serialiser."""
-        from tooling.cli.serialise import _serialise_greentree
-
-        tree = self.query_one("#gt-tree", Tree)
-        tree.clear()
-        root = _serialise_greentree(self._source)
-        if root is None:
-            tree.root.set_label(Text("(green tree unavailable)", style="red"))
             return
-        tree.root.set_label(f"{root['kind'].lower()} [{root['mode'].lower()}] w={root['width']}")
-        tree.root.data = root
-        self._add_gt_tokens(tree.root, root["tokens"])
-        tree.root.expand()
-        self.query_one("#gt-detail", Static).update(_gt_detail(root))
+        content_scroll.display = False
+        tree_pane.display = True
+        self._populate_view_tree(view)
+        # Leave focus on the sidebar so ↑/↓ keep switching views; click or Tab
+        # into the tree to navigate / expand its entries.
 
-    def _add_gt_tokens(self, node, tokens: list[dict]) -> None:
-        for tok in tokens:
-            child = tok.get("child")
-            if child is not None:
-                branch = node.add(_gt_label(tok), data=tok)
-                self._add_gt_tokens(branch, child["tokens"])
+    def _populate_view_tree(self, view: str) -> None:
+        tree = self.query_one("#view-tree", Tree)
+        tree.clear()
+        tree.root.set_label(view)
+        tree.root.data = None
+        nodes = build_view(view, self._view_data(view))
+        self._add_view_nodes(tree.root, nodes)
+        tree.root.expand()
+        # Reveal the first level immediately when there's a single root group
+        # (e.g. the green tree's region, or a one-function analysis view).
+        if len(tree.root.children) == 1:
+            tree.root.children[0].expand()
+        self.query_one("#view-detail", Static).update(_format_detail(None))
+
+    def _add_view_nodes(self, parent, nodes: list[ViewNode]) -> None:
+        for n in nodes:
+            label = Text(n.label, style=n.style) if n.style else n.label
+            if n.children:
+                branch = parent.add(label, data=n)
+                self._add_view_nodes(branch, n.children)
             else:
-                node.add_leaf(_gt_label(tok), data=tok)
+                parent.add_leaf(label, data=n)
 
     def on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
-        if event.node.data is not None:
-            self.query_one("#gt-detail", Static).update(_gt_detail(event.node.data))
+        self.query_one("#view-detail", Static).update(_format_detail(event.node.data))
 
     def action_cycle_opt(self) -> None:
         """Cycle the optimisation lens off → on → diff and re-render."""
         self._opt_mode = _OPT_CYCLE[(_OPT_CYCLE.index(self._opt_mode) + 1) % len(_OPT_CYCLE)]
-        if self._opt_mode != "off" and self._opt is None and self._result is not None:
+        if self._opt_mode == "diff" and self._opt is None and self._result is not None:
             self._opt = optimised_result(self._result, self._args.dialect)
         self._update_subtitle()
         self._show(self._current)

--- a/tooling/explorer/tui.py
+++ b/tooling/explorer/tui.py
@@ -20,8 +20,8 @@ import io
 
 from rich.text import Text
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, VerticalScroll
-from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Footer, Header, Label, ListItem, ListView, Static, Tree
 
 from tooling.explorer.cli import (
     _VIEW_ORDER,
@@ -35,6 +35,56 @@ from tooling.explorer.cli import (
 from tooling.explorer.pipeline import CompilerExplorerResult, run_pipeline
 
 _OPT_CYCLE = ("off", "on", "diff")
+_GT_OPAQUE = ("STR", "CMD")
+
+
+def _gt_label(tok: dict) -> Text:
+    """A one-line tree label for a green-tree token: ``TYPE 'preview' [a:b]``."""
+    opaque = tok["type"] in _GT_OPAQUE
+    one_line = tok["text"].replace("\n", "⏎")
+    preview = one_line if len(one_line) <= 40 else one_line[:40] + "…"
+    label = Text()
+    label.append(tok["type"], style="cyan" if opaque else "bright_black")
+    label.append(" ")
+    label.append(repr(preview), style="")
+    label.append(f" [{tok['startOffset']}:{tok['endOffset']}]", style="dim")
+    return label
+
+
+def _gt_detail(data: dict) -> Text:
+    """Full detail for a highlighted green-tree node (token or root region)."""
+    t = Text()
+    if "type" in data:  # a token
+        t.append("token type  ", style="bold")
+        t.append(f"{data['type']}\n")
+        t.append("byte range  ", style="bold")
+        t.append(
+            f"{data['startOffset']}…{data['endOffset']} "
+            f"({max(0, data['endOffset'] - data['startOffset'])} bytes)\n"
+        )
+        t.append("line:col    ", style="bold")
+        t.append(
+            f"{data['startLine'] + 1}:{data['startCol'] + 1} → "
+            f"{data['endLine'] + 1}:{data['endCol'] + 1}\n"
+        )
+        child = data.get("child")
+        if child is not None:
+            t.append("region      ", style="bold")
+            style = "red" if child["isError"] else "cyan"
+            t.append(
+                f"{child['kind'].lower()} / {child['mode'].lower()}"
+                + (" (ERROR — unterminated)" if child["isError"] else "")
+                + "\n",
+                style=style,
+            )
+        t.append("text\n", style="bold")
+        t.append(data["text"] or "(empty)", style="bright_white")
+    else:  # the root region
+        t.append("region      ", style="bold")
+        t.append(f"{data['kind'].lower()} / {data['mode'].lower()}\n")
+        t.append("width       ", style="bold")
+        t.append(f"{data['width']} bytes\n")
+    return t
 
 
 def _render_view_ansi(
@@ -76,6 +126,10 @@ class ExplorerApp(App):
     #sidebar > ListView { height: 1fr; }
     #content { padding: 0 1; }
     #summary { color: $text-muted; padding: 0 1; height: auto; }
+    #gt-pane { display: none; }
+    #gt-tree { width: 1fr; }
+    #gt-detail-scroll { width: 45%; border-left: solid $accent; }
+    #gt-detail { padding: 0 1; }
     """
 
     BINDINGS = [
@@ -100,8 +154,17 @@ class ExplorerApp(App):
         with Horizontal():
             with VerticalScroll(id="sidebar"):
                 yield ListView(*(ListItem(Label(v), id=f"view-{v}") for v in self._views))
-            with VerticalScroll():
-                yield Static("", id="content", markup=False)
+            with Vertical(id="main"):
+                # Default surface: captured-ANSI render of the active view.
+                with VerticalScroll(id="content-scroll"):
+                    yield Static("", id="content", markup=False)
+                # Interactive surface used only for the green tree: a real tree
+                # whose entries expand (↑/↓ + Enter/Space/click) and pop their
+                # full token detail into the side panel as you move.
+                with Horizontal(id="gt-pane"):
+                    yield Tree("green-tree", id="gt-tree")
+                    with VerticalScroll(id="gt-detail-scroll"):
+                        yield Static("", id="gt-detail", markup=False)
         yield Footer()
 
     def on_mount(self) -> None:
@@ -141,8 +204,20 @@ class ExplorerApp(App):
         self._current = view
         if self._result is None:
             return
-        content = self.query_one("#content", Static)
-        content.update(
+        # The green tree gets the interactive Tree surface; everything else the
+        # captured-ANSI Static.  Toggle which one is visible.
+        gt_pane = self.query_one("#gt-pane")
+        content_scroll = self.query_one("#content-scroll")
+        if view == "greentree":
+            content_scroll.display = False
+            gt_pane.display = True
+            self._populate_greentree()
+            # Leave focus on the sidebar so ↑/↓ keep switching views; click or
+            # Tab into the tree to navigate/expand its entries.
+            return
+        gt_pane.display = False
+        content_scroll.display = True
+        self.query_one("#content", Static).update(
             _render_view_ansi(
                 view,
                 self._result,
@@ -152,6 +227,35 @@ class ExplorerApp(App):
                 opt=self._opt,
             )
         )
+
+    def _populate_greentree(self) -> None:
+        """(Re)build the interactive green tree from the shared serialiser."""
+        from tooling.cli.serialise import _serialise_greentree
+
+        tree = self.query_one("#gt-tree", Tree)
+        tree.clear()
+        root = _serialise_greentree(self._source)
+        if root is None:
+            tree.root.set_label(Text("(green tree unavailable)", style="red"))
+            return
+        tree.root.set_label(f"{root['kind'].lower()} [{root['mode'].lower()}] w={root['width']}")
+        tree.root.data = root
+        self._add_gt_tokens(tree.root, root["tokens"])
+        tree.root.expand()
+        self.query_one("#gt-detail", Static).update(_gt_detail(root))
+
+    def _add_gt_tokens(self, node, tokens: list[dict]) -> None:
+        for tok in tokens:
+            child = tok.get("child")
+            if child is not None:
+                branch = node.add(_gt_label(tok), data=tok)
+                self._add_gt_tokens(branch, child["tokens"])
+            else:
+                node.add_leaf(_gt_label(tok), data=tok)
+
+    def on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
+        if event.node.data is not None:
+            self.query_one("#gt-detail", Static).update(_gt_detail(event.node.data))
 
     def action_cycle_opt(self) -> None:
         """Cycle the optimisation lens off → on → diff and re-render."""

--- a/tooling/explorer/tui.py
+++ b/tooling/explorer/tui.py
@@ -62,9 +62,7 @@ def _format_detail(node: ViewNode | None) -> Text:
     if node.children:
         if node.detail:
             t.append("\n")
-        t.append(
-            f"{len(node.children)} child item(s) — Enter / Space to expand", style="dim"
-        )
+        t.append(f"{len(node.children)} child item(s) — Enter / Space to expand", style="dim")
     return t
 
 
@@ -169,11 +167,11 @@ class ExplorerApp(App):
             self._result = None
             self._data = {}
             return
-        # The optimised pipeline is only needed for the text diff path.
+        # The optimised pipeline feeds the text renderer's opt lens (asm/wasm
+        # 'on', and any view's 'diff') — needed for every non-"off" mode, not
+        # just diff.  Tree views get optimised data from the serialised payload.
         self._opt = (
-            optimised_result(self._result, self._args.dialect)
-            if self._opt_mode == "diff"
-            else None
+            optimised_result(self._result, self._args.dialect) if self._opt_mode != "off" else None
         )
         self._update_subtitle()
         self.query_one("#summary", Label).update(
@@ -258,7 +256,11 @@ class ExplorerApp(App):
     def action_cycle_opt(self) -> None:
         """Cycle the optimisation lens off → on → diff and re-render."""
         self._opt_mode = _OPT_CYCLE[(_OPT_CYCLE.index(self._opt_mode) + 1) % len(_OPT_CYCLE)]
-        if self._opt_mode == "diff" and self._opt is None and self._result is not None:
+        # Compute the optimised pipeline for any non-"off" mode so the text
+        # renderer (asm/wasm 'on', diff) has it; clear it when back to "off".
+        if self._opt_mode == "off":
+            self._opt = None
+        elif self._opt is None and self._result is not None:
             self._opt = optimised_result(self._result, self._args.dialect)
         self._update_subtitle()
         self._show(self._current)

--- a/tooling/explorer/tui.py
+++ b/tooling/explorer/tui.py
@@ -25,7 +25,6 @@ from textual.widgets import Footer, Header, Label, ListItem, ListView, Static, T
 
 from tooling.explorer.cli import (
     _VIEW_ORDER,
-    OPT_VIEWS,
     LineIndex,
     _summary_parts,
     load_source,

--- a/tooling/explorer/tui.py
+++ b/tooling/explorer/tui.py
@@ -25,27 +25,39 @@ from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
 
 from tooling.explorer.cli import (
     _VIEW_ORDER,
+    OPT_VIEWS,
     LineIndex,
     _summary_parts,
     load_source,
-    render_view,
+    optimised_result,
+    render_view_opt,
 )
 from tooling.explorer.pipeline import CompilerExplorerResult, run_pipeline
 
+_OPT_CYCLE = ("off", "on", "diff")
+
 
 def _render_view_ansi(
-    view: str, result: CompilerExplorerResult, source: str, args: argparse.Namespace
+    view: str,
+    result: CompilerExplorerResult,
+    source: str,
+    args: argparse.Namespace,
+    *,
+    opt_mode: str = "off",
+    opt: tuple[CompilerExplorerResult, str] | None = None,
 ) -> Text:
-    """Capture ``render_view``'s ANSI output for *view* and parse it for Rich."""
+    """Capture ``render_view_opt``'s ANSI output for *view* and parse it for Rich."""
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         try:
-            render_view(
+            render_view_opt(
                 view,
                 result,
                 source,
                 use_colour=True,
                 line_index=LineIndex(source),
+                opt_mode=opt_mode,
+                opt=opt,
                 views=args.views,
                 show_optimised_source=args.show_optimised_source,
                 max_annotations=args.max_annotations,
@@ -69,6 +81,7 @@ class ExplorerApp(App):
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("r", "refresh", "Re-run"),
+        ("o", "cycle_opt", "Opt off/on/diff"),
     ]
 
     def __init__(self, source: str, args: argparse.Namespace) -> None:
@@ -76,6 +89,8 @@ class ExplorerApp(App):
         self._source = source
         self._args = args
         self._result: CompilerExplorerResult | None = None
+        self._opt: tuple[CompilerExplorerResult, str] | None = None
+        self._opt_mode = getattr(args, "opt", "off") or "off"
         self._views = [v for v in _VIEW_ORDER if v in args.views]
         self._current = self._views[0] if self._views else "ir"
 
@@ -107,17 +122,44 @@ class ExplorerApp(App):
             )
             self._result = None
             return
-        self.sub_title = self._args.dialect
+        # Recompute the optimised pipeline lazily — only when a lens needs it.
+        self._opt = (
+            optimised_result(self._result, self._args.dialect)
+            if self._opt_mode != "off"
+            else None
+        )
+        self._update_subtitle()
         self.query_one("#summary", Label).update(
             "  ".join(_summary_parts(self._result, self._args.dialect))
         )
+
+    def _update_subtitle(self) -> None:
+        opt = "" if self._opt_mode == "off" else f"  ·  opt: {self._opt_mode}"
+        self.sub_title = f"{self._args.dialect}{opt}"
 
     def _show(self, view: str) -> None:
         self._current = view
         if self._result is None:
             return
         content = self.query_one("#content", Static)
-        content.update(_render_view_ansi(view, self._result, self._source, self._args))
+        content.update(
+            _render_view_ansi(
+                view,
+                self._result,
+                self._source,
+                self._args,
+                opt_mode=self._opt_mode,
+                opt=self._opt,
+            )
+        )
+
+    def action_cycle_opt(self) -> None:
+        """Cycle the optimisation lens off → on → diff and re-render."""
+        self._opt_mode = _OPT_CYCLE[(_OPT_CYCLE.index(self._opt_mode) + 1) % len(_OPT_CYCLE)]
+        if self._opt_mode != "off" and self._opt is None and self._result is not None:
+            self._opt = optimised_result(self._result, self._args.dialect)
+        self._update_subtitle()
+        self._show(self._current)
 
     def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
         if event.item is not None and event.item.id and event.item.id.startswith("view-"):

--- a/tooling/explorer/tui_views.py
+++ b/tooling/explorer/tui_views.py
@@ -102,8 +102,7 @@ def _build_greentree(d: dict) -> list[ViewNode]:
             ),
             (
                 "line:col",
-                f"{t['startLine'] + 1}:{t['startCol'] + 1} → "
-                f"{t['endLine'] + 1}:{t['endCol'] + 1}",
+                f"{t['startLine'] + 1}:{t['startCol'] + 1} → {t['endLine'] + 1}:{t['endCol'] + 1}",
             ),
         ]
         children: list[ViewNode] = []
@@ -150,7 +149,9 @@ def _build_ir(d: dict) -> list[ViewNode]:
         params = " ".join(proc.get("params", []))
         header = f"{name} {{{params}}}" if params else f"{name} {{}}"
         nodes.append(
-            ViewNode(header, [("range", _rng(proc.get("range")))], _ir_nodes(proc["body"]), style="cyan")
+            ViewNode(
+                header, [("range", _rng(proc.get("range")))], _ir_nodes(proc["body"]), style="cyan"
+            )
         )
     return nodes
 
@@ -164,7 +165,9 @@ def _term_label(t: dict | None) -> str:
     if t["type"] == "goto":
         return f"term goto {t.get('target')}"
     if t["type"] == "branch":
-        return f"term branch {t.get('condition', '')} → {t.get('trueTarget')}/{t.get('falseTarget')}"
+        return (
+            f"term branch {t.get('condition', '')} → {t.get('trueTarget')}/{t.get('falseTarget')}"
+        )
     if t["type"] == "return":
         return "term return" + (f" {t['value']}" if t.get("value") else "")
     return "term"
@@ -194,7 +197,9 @@ def _build_cfg(funcs: list[dict] | None, *, post: bool) -> list[ViewNode]:
                 items.append(ViewNode(s["summary"], detail))
             term = b.get("terminator")
             items.append(
-                ViewNode(_term_label(term), [("range", _rng((term or {}).get("range")))], style="blue")
+                ViewNode(
+                    _term_label(term), [("range", _rng((term or {}).get("range")))], style="blue"
+                )
             )
             tags = (" [entry]" if b.get("isEntry") else "") + (
                 " [unreachable]" if b.get("isUnreachable") else ""
@@ -207,7 +212,10 @@ def _build_cfg(funcs: list[dict] | None, *, post: bool) -> list[ViewNode]:
                 asub.append(
                     ViewNode(
                         f"const branch {br['block']}: always {br['value']}",
-                        [("condition", br.get("condition", "")), ("take", br.get("takenTarget", ""))],
+                        [
+                            ("condition", br.get("condition", "")),
+                            ("take", br.get("takenTarget", "")),
+                        ],
                         style="blue",
                     )
                 )
@@ -228,7 +236,9 @@ def _build_cfg(funcs: list[dict] | None, *, post: bool) -> list[ViewNode]:
                     )
                 )
             for name, ty in (a.get("inferredTypes") or {}).items():
-                asub.append(ViewNode(f"{name}: {ty}", [("value", name), ("type", ty)], style="green"))
+                asub.append(
+                    ViewNode(f"{name}: {ty}", [("value", name), ("type", ty)], style="green")
+                )
             if asub:
                 blocks.append(ViewNode("analysis", [], asub, style="bold"))
         out.append(
@@ -274,7 +284,11 @@ def _build_types(d: dict) -> list[ViewNode]:
             continue
         ents = []
         for e in f["entries"]:
-            label = e["variable"] if e["variable"].startswith("(") else f"{e['variable']}#{e['version']}"
+            label = (
+                e["variable"]
+                if e["variable"].startswith("(")
+                else f"{e['variable']}#{e['version']}"
+            )
             ents.append(
                 ViewNode(
                     f"{label}: {e['type']}",

--- a/tooling/explorer/tui_views.py
+++ b/tooling/explorer/tui_views.py
@@ -1,0 +1,637 @@
+"""Data-driven view models for the Textual explorer.
+
+The TUI renders every analysis view as an interactive tree of
+:class:`ViewNode` items built from the *same* serialised result the web GUI
+consumes (``tooling.cli.serialise.serialise_result``).  Each node carries a
+one-line ``label``, a ``detail`` table revealed when it is highlighted, and
+optional ``children`` — so every item in every view expands to its full
+information, the same contract the GUI's click/Space expansion offers.
+
+Keeping these builders next to one serialisation (rather than re-deriving from
+the IR/CFG objects) means the GUI and TUI show the same fields, and adding a
+field is a one-place edit.  ``asm`` / ``wasm`` stay on the text renderer (they
+are specialised disassembly, navigated rather than expanded), exactly as the
+GUI keeps them out of the generic expander.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ViewNode:
+    """One expandable row: a summary ``label``, a ``detail`` table, children."""
+
+    label: str
+    detail: list[tuple[str, str]] = field(default_factory=list)
+    children: list[ViewNode] = field(default_factory=list)
+    style: str | None = None  # optional Rich style for the label
+
+
+# Small formatting helpers shared by the builders.
+
+
+def _yn(v: object) -> str:
+    return "yes" if v else "no"
+
+
+def _fmt_bound(v: object, positive: bool) -> str:
+    """An interval endpoint: ``None`` is ±infinity."""
+    if v is None:
+        return "+inf" if positive else "-inf"
+    return str(v)
+
+
+def _rng(r: dict | None) -> str:
+    if not r:
+        return "?"
+    return f"{r['startLine'] + 1}:{r['startCol'] + 1}  ({r['startOffset']}…{r['endOffset']})"
+
+
+def _flags(p: dict) -> str:
+    flags = []
+    if p.get("hasBarrier"):
+        flags.append("barrier")
+    if p.get("hasUnknownCalls"):
+        flags.append("unknown_calls")
+    if p.get("writesGlobal"):
+        flags.append("writes_global")
+    return ", ".join(flags) or "—"
+
+
+def _fmt_usedef(m: dict | None) -> str:
+    if not m:
+        return "{}"
+    parts = []
+    for name, info in sorted(m.items()):
+        if isinstance(info, dict):
+            s = f"{name}#{info.get('version', '?')}"
+            if info.get("lattice"):
+                s += f"={info['lattice']}"
+            if info.get("type"):
+                s += f":{info['type']}"
+        else:
+            s = f"{name}#{info}"
+        parts.append(s)
+    return "{" + ", ".join(parts) + "}"
+
+
+# Green tree — every token, opaque {...}/[...] tokens nesting their region.
+
+_GT_OPAQUE = ("STR", "CMD")
+
+
+def _build_greentree(d: dict) -> list[ViewNode]:
+    root = d.get("greentree")
+    if not root:
+        return [ViewNode("(green tree unavailable)", style="red")]
+
+    def token_node(t: dict) -> ViewNode:
+        opaque = t["type"] in _GT_OPAQUE
+        one_line = t["text"].replace("\n", "⏎")
+        preview = one_line if len(one_line) <= 40 else one_line[:40] + "…"
+        label = f"{t['type']} {preview!r} [{t['startOffset']}:{t['endOffset']}]"
+        detail = [
+            ("token type", t["type"]),
+            (
+                "byte range",
+                f"{t['startOffset']}…{t['endOffset']} "
+                f"({max(0, t['endOffset'] - t['startOffset'])} bytes)",
+            ),
+            (
+                "line:col",
+                f"{t['startLine'] + 1}:{t['startCol'] + 1} → "
+                f"{t['endLine'] + 1}:{t['endCol'] + 1}",
+            ),
+        ]
+        children: list[ViewNode] = []
+        child = t.get("child")
+        if child is not None:
+            kind = f"{child['kind'].lower()} / {child['mode'].lower()}"
+            if child["isError"]:
+                kind += " (ERROR — unterminated)"
+            detail.append(("region", kind))
+            children = [token_node(ct) for ct in child["tokens"]]
+        detail.append(("text", t["text"] or "(empty)"))
+        return ViewNode(label, detail, children, style="cyan" if opaque else None)
+
+    region = [
+        ("region", f"{root['kind'].lower()} / {root['mode'].lower()}"),
+        ("width", f"{root['width']} bytes"),
+    ]
+    label = f"{root['kind'].lower()} [{root['mode'].lower()}] w={root['width']}"
+    return [ViewNode(label, region, [token_node(t) for t in root["tokens"]])]
+
+
+# IR
+
+
+def _ir_nodes(nodes: list[dict] | None) -> list[ViewNode]:
+    out = []
+    for n in nodes or []:
+        detail = [
+            ("kind", n.get("kind", "")),
+            ("summary", n["summary"]),
+            ("range", _rng(n.get("range"))),
+        ]
+        children = []
+        for c in n.get("children", []) or []:
+            children.append(ViewNode(c["label"] + ":", [], _ir_nodes(c["body"]), style="blue"))
+        out.append(ViewNode(n["summary"], detail, children))
+    return out
+
+
+def _build_ir(d: dict) -> list[ViewNode]:
+    ir = d["ir"]
+    nodes = [ViewNode("top-level", [], _ir_nodes(ir["topLevel"]), style="cyan")]
+    for name, proc in (ir.get("procedures") or {}).items():
+        params = " ".join(proc.get("params", []))
+        header = f"{name} {{{params}}}" if params else f"{name} {{}}"
+        nodes.append(
+            ViewNode(header, [("range", _rng(proc.get("range")))], _ir_nodes(proc["body"]), style="cyan")
+        )
+    return nodes
+
+
+# CFG (pre-/post-SSA)
+
+
+def _term_label(t: dict | None) -> str:
+    if not t:
+        return "term <none>"
+    if t["type"] == "goto":
+        return f"term goto {t.get('target')}"
+    if t["type"] == "branch":
+        return f"term branch {t.get('condition', '')} → {t.get('trueTarget')}/{t.get('falseTarget')}"
+    if t["type"] == "return":
+        return "term return" + (f" {t['value']}" if t.get("value") else "")
+    return "term"
+
+
+def _build_cfg(funcs: list[dict] | None, *, post: bool) -> list[ViewNode]:
+    out = []
+    for f in funcs or []:
+        blocks = []
+        for b in f["blocks"]:
+            items: list[ViewNode] = []
+            if post:
+                for p in b.get("phis", []):
+                    inc = ", ".join(f"{k}:{v}" for k, v in (p.get("incoming") or {}).items())
+                    items.append(
+                        ViewNode(
+                            f"phi {p['name']}#{p['version']} ← {inc}",
+                            [("type", p.get("type") or "?"), ("incoming", inc)],
+                            style="magenta",
+                        )
+                    )
+            for s in b["statements"]:
+                detail = [("summary", s["summary"]), ("range", _rng(s.get("range")))]
+                if post:
+                    detail.append(("uses", _fmt_usedef(s.get("uses"))))
+                    detail.append(("defs", _fmt_usedef(s.get("defs"))))
+                items.append(ViewNode(s["summary"], detail))
+            term = b.get("terminator")
+            items.append(
+                ViewNode(_term_label(term), [("range", _rng((term or {}).get("range")))], style="blue")
+            )
+            tags = (" [entry]" if b.get("isEntry") else "") + (
+                " [unreachable]" if b.get("isUnreachable") else ""
+            )
+            blocks.append(ViewNode(f"block {b['name']}{tags}", [], items, style="bold"))
+        if post and f.get("analysis"):
+            a = f["analysis"]
+            asub = []
+            for br in a.get("constantBranches", []):
+                asub.append(
+                    ViewNode(
+                        f"const branch {br['block']}: always {br['value']}",
+                        [("condition", br.get("condition", "")), ("take", br.get("takenTarget", ""))],
+                        style="blue",
+                    )
+                )
+            for ds in a.get("deadStores", []):
+                asub.append(
+                    ViewNode(
+                        f"dead store {ds['block']} {ds['variable']}#{ds['version']}",
+                        [("block", ds["block"]), ("stmt index", ds.get("stmtIndex", "?"))],
+                        style="yellow",
+                    )
+                )
+            if a.get("unreachableBlocks"):
+                asub.append(
+                    ViewNode(
+                        "unreachable: " + ", ".join(a["unreachableBlocks"]),
+                        [("blocks", ", ".join(a["unreachableBlocks"]))],
+                        style="magenta",
+                    )
+                )
+            for name, ty in (a.get("inferredTypes") or {}).items():
+                asub.append(ViewNode(f"{name}: {ty}", [("value", name), ("type", ty)], style="green"))
+            if asub:
+                blocks.append(ViewNode("analysis", [], asub, style="bold"))
+        out.append(
+            ViewNode(
+                f"function {f['name']} (entry={f['entry']}, {f['blockCount']} blocks)",
+                [],
+                blocks,
+                style="cyan",
+            )
+        )
+    return out or [ViewNode("(no functions)", style="dim")]
+
+
+# Loops / types / intervals / bounds / rendered (per-function tables)
+
+
+def _build_loops(d: dict) -> list[ViewNode]:
+    out = []
+    for f in d.get("loops", []):
+        if not f["loops"]:
+            continue
+        loops = [
+            ViewNode(
+                f"header {lp['header']} (depth {lp['depth']}, {lp['blockCount']} blocks)",
+                [
+                    ("header block", lp["header"]),
+                    ("nesting depth", lp["depth"]),
+                    ("blocks", ", ".join(lp["blocks"])),
+                    ("latches", ", ".join(lp["latches"]) or "—"),
+                ],
+                style="blue",
+            )
+            for lp in f["loops"]
+        ]
+        out.append(ViewNode(f"function {f['name']}", [], loops, style="cyan"))
+    return out or [ViewNode("(no natural loops)", style="dim")]
+
+
+def _build_types(d: dict) -> list[ViewNode]:
+    out = []
+    for f in d.get("types", []):
+        if not f["entries"]:
+            continue
+        ents = []
+        for e in f["entries"]:
+            label = e["variable"] if e["variable"].startswith("(") else f"{e['variable']}#{e['version']}"
+            ents.append(
+                ViewNode(
+                    f"{label}: {e['type']}",
+                    [
+                        ("variable", e["variable"]),
+                        ("version", e["version"]),
+                        ("kind", e["kind"]),
+                        ("type", e["type"]),
+                    ],
+                )
+            )
+        out.append(ViewNode(f"function {f['name']}", [], ents, style="cyan"))
+    return out or [ViewNode("(no inferred types)", style="dim")]
+
+
+def _build_intervals(d: dict) -> list[ViewNode]:
+    out = []
+    for f in d.get("intervals", []):
+        if not f["entries"]:
+            continue
+        ents = []
+        for e in f["entries"]:
+            lo, hi = _fmt_bound(e["lo"], False), _fmt_bound(e["hi"], True)
+            ents.append(
+                ViewNode(
+                    f"{e['variable']}#{e['version']}: [{lo}, {hi}]",
+                    [
+                        ("variable", e["variable"]),
+                        ("version", e["version"]),
+                        ("lower bound", lo),
+                        ("upper bound", hi),
+                    ],
+                )
+            )
+        out.append(ViewNode(f"function {f['name']}", [], ents, style="cyan"))
+    return out or [ViewNode("(no bounded ranges)", style="dim")]
+
+
+def _build_bounds(d: dict) -> list[ViewNode]:
+    out = []
+    for f in d.get("bounds", []):
+        if not f["findings"] and not f["divzero"]:
+            continue
+        items = []
+        for b in f["findings"]:
+            lo, hi = _fmt_bound(b["lo"], False), _fmt_bound(b["hi"], True)
+            items.append(
+                ViewNode(
+                    f"{b['code']} {b['command']} ${b['indexVar']} in [{lo}, {hi}] vs length {b['length']}",
+                    [
+                        ("code", b["code"]),
+                        ("command", b["command"]),
+                        ("index var", "$" + b["indexVar"]),
+                        ("index range", f"[{lo}, {hi}]"),
+                        ("container length", b["length"]),
+                        ("reason", b["reason"]),
+                    ],
+                    style="yellow",
+                )
+            )
+        for dz in f["divzero"]:
+            items.append(
+                ViewNode(
+                    f"{dz['code']} '{dz['op']}' divisor provably 0",
+                    [
+                        ("code", dz["code"]),
+                        ("operator", dz["op"]),
+                        ("reason", "divisor interval is exactly [0, 0]"),
+                    ],
+                    style="yellow",
+                )
+            )
+        out.append(ViewNode(f"function {f['name']}", [], items, style="cyan"))
+    return out or [ViewNode("(no provable out-of-range / divide-by-zero)", style="dim")]
+
+
+def _build_rendered(d: dict) -> list[ViewNode]:
+    out = []
+    for f in d.get("renderedProperties", []) or []:
+        if not f["entries"]:
+            continue
+        ents = [
+            ViewNode(
+                f"{e['variable']}#{e['version']}",
+                [
+                    ("variable", e["variable"]),
+                    ("version", e["version"]),
+                    ("may", ", ".join(e["may"]) or "—"),
+                    ("must", ", ".join(e["must"]) or "—"),
+                ],
+            )
+            for e in f["entries"]
+        ]
+        out.append(ViewNode(f"function {f['name']}", [], ents, style="cyan"))
+    return out or [ViewNode("(no rendered-property flags)", style="dim")]
+
+
+# Data flow / interprocedural
+
+
+def _build_dataflow(d: dict) -> list[ViewNode]:
+    df = d.get("dataflow")
+    if not df or not df.get("functions"):
+        return [ViewNode("(no data-flow information)", style="dim")]
+    out = []
+    for f in df["functions"]:
+        nodes = []
+        for a in f.get("aliases", []):
+            nodes.append(
+                ViewNode(
+                    f"alias {a['localName']} ↔ {a['targetName']}",
+                    [
+                        ("local", a.get("localName", "")),
+                        ("target", a.get("targetName", "")),
+                        ("reason", a.get("reason", "")),
+                    ],
+                    style="orange",
+                )
+            )
+        for n in f["nodes"]:
+            dead = " (DEAD)" if n.get("isDead") else ""
+            label = f"{n['name']}#{n['version']} [{n['defKind']} in {n['block']}]{dead}"
+            detail = [
+                ("ssa value", f"{n['name']}#{n['version']}"),
+                ("def kind", n["defKind"]),
+                ("block", n["block"]),
+                ("dead", _yn(n.get("isDead"))),
+            ]
+            if n.get("useCount") is not None:
+                detail.append(("uses", n["useCount"]))
+            if n.get("lattice"):
+                detail.append(("lattice", n["lattice"]))
+            if n.get("typeInfo"):
+                detail.append(("type", n["typeInfo"]))
+            nodes.append(ViewNode(label, detail, style="yellow" if n.get("isDead") else "green"))
+        sm = f.get("summary", {})
+        out.append(
+            ViewNode(
+                f"function {f['name']} ({sm.get('totalDefs', 0)} defs, {sm.get('totalUses', 0)} uses)",
+                [],
+                nodes,
+                style="cyan",
+            )
+        )
+    return out
+
+
+def _build_interproc(d: dict) -> list[ViewNode]:
+    out = []
+    for p in d.get("interprocedural", []):
+        if p.get("kind") == "method":
+            detail = [
+                ("method kind", p.get("methodKind", "method")),
+                ("pure", _yn(p.get("pure"))),
+                ("calls", ", ".join(p.get("calls") or []) or "—"),
+            ]
+            if p.get("writesInstanceVars"):
+                detail.append(("writes instance vars", ", ".join(p["writesInstanceVars"])))
+            detail.append(("flags", _flags(p)))
+            out.append(ViewNode(f"{p['name']} (method)", detail, style="cyan"))
+        else:
+            detail = [
+                ("arity", p.get("arity")),
+                ("pure", _yn(p.get("pure"))),
+                ("foldable", _yn(p.get("foldable"))),
+                ("return shape", p.get("returnShape", "")),
+                ("calls", ", ".join(p.get("calls") or []) or "—"),
+                ("flags", _flags(p)),
+            ]
+            out.append(ViewNode(f"{p['name']} arity={p.get('arity')}", detail, style="cyan"))
+    return out or [ViewNode("(no procedures)", style="dim")]
+
+
+# Optimiser / GVN / shimmer / taint / iRules / event order / callouts
+
+
+def _build_opt(d: dict) -> list[ViewNode]:
+    out = [
+        ViewNode(
+            f"{o['code']} {o['message']} → {o['replacement']}",
+            [
+                ("code", o["code"]),
+                ("message", o["message"]),
+                ("replacement", o["replacement"]),
+                ("range", _rng(o.get("range"))),
+            ],
+            style="green",
+        )
+        for o in d.get("optimisations", [])
+    ]
+    return out or [ViewNode("(no optimiser rewrites)", style="dim")]
+
+
+def _build_gvn(d: dict) -> list[ViewNode]:
+    out = [
+        ViewNode(
+            f"{w['code']} {w.get('expression', '')}",
+            [
+                ("code", w["code"]),
+                ("message", w.get("message", "")),
+                ("expression", w.get("expression", "")),
+                ("first seen", _rng(w.get("firstRange"))),
+                ("range", _rng(w.get("range"))),
+            ],
+            style="green",
+        )
+        for w in d.get("gvn", [])
+    ]
+    return out or [ViewNode("(no redundant computations)", style="dim")]
+
+
+def _build_shimmer(d: dict) -> list[ViewNode]:
+    out = [
+        ViewNode(
+            f"{w['code']} {w['message']}",
+            [
+                ("code", w["code"]),
+                ("severity", w.get("severity", "warning")),
+                ("message", w["message"]),
+                ("range", _rng(w.get("range"))),
+            ],
+            style="yellow",
+        )
+        for w in d.get("shimmer", [])
+    ]
+    return out or [ViewNode("(no shimmer warnings)", style="dim")]
+
+
+def _build_taint(d: dict) -> list[ViewNode]:
+    out = []
+    for w in d.get("taintWarnings", []):
+        detail = [
+            ("code", w["code"]),
+            ("severity", w.get("severity", "warning")),
+            ("message", w["message"]),
+        ]
+        if w.get("variable"):
+            detail.append(("variable", w["variable"]))
+        if w.get("sinkCommand"):
+            detail.append(("sink command", w["sinkCommand"]))
+        detail.append(("range", _rng(w.get("range"))))
+        out.append(ViewNode(f"{w['code']} {w['message']}", detail, style="red"))
+    for f in d.get("taintTracking", []):
+        ents = [
+            ViewNode(
+                f"{e['variable']}#{e['version']}: {e['taint']}",
+                [("variable", e["variable"]), ("version", e["version"]), ("taint", e["taint"])],
+            )
+            for e in f["entries"]
+        ]
+        out.append(ViewNode(f"tracking {f['name']}", [], ents, style="cyan"))
+    return out or [ViewNode("(no tainted data flows)", style="dim")]
+
+
+def _build_irules(d: dict) -> list[ViewNode]:
+    out = []
+    for e in d.get("eventOrder", []):
+        eff = e["base_priority"] + e["priority_offset"]
+        out.append(
+            ViewNode(
+                f"{e['event']} eff={eff}",
+                [
+                    ("event", e["event"]),
+                    ("effective priority", eff),
+                    ("base", e["base_priority"]),
+                    ("offset", e["priority_offset"]),
+                    ("multiplicity", e.get("multiplicity", "once")),
+                    ("range", _rng(e.get("range"))),
+                ],
+                style="blue",
+            )
+        )
+    for w in d.get("irulesFlow", []):
+        out.append(
+            ViewNode(
+                f"{w['code']} {w['message']}",
+                [("code", w["code"]), ("message", w["message"]), ("range", _rng(w.get("range")))],
+                style="yellow",
+            )
+        )
+    return out or [ViewNode("(no iRules events)", style="dim")]
+
+
+def _build_event_order(d: dict) -> list[ViewNode]:
+    events = sorted(
+        d.get("eventOrder", []),
+        key=lambda e: (-(e["base_priority"] + e["priority_offset"]), e["event"]),
+    )
+    out = []
+    for e in events:
+        eff = e["base_priority"] + e["priority_offset"]
+        mult = (
+            f" [{e['multiplicity']}]"
+            if e.get("multiplicity") and e["multiplicity"] != "once"
+            else ""
+        )
+        out.append(
+            ViewNode(
+                f"{e['event']} eff={eff}{mult}",
+                [
+                    ("event", e["event"]),
+                    ("effective priority", eff),
+                    ("base priority", e["base_priority"]),
+                    ("priority offset", e["priority_offset"]),
+                    ("multiplicity", e.get("multiplicity", "once")),
+                    ("range", _rng(e.get("range"))),
+                ],
+                style="blue",
+            )
+        )
+    return out or [ViewNode("(no event-order data)", style="dim")]
+
+
+def _build_callouts(d: dict) -> list[ViewNode]:
+    out = [
+        ViewNode(
+            f"{a.get('kind', '')}: {a.get('label', '')}",
+            [
+                ("kind", a.get("kind", "")),
+                ("severity", a.get("severity", "")),
+                ("label", a.get("label", "")),
+                ("range", _rng(a.get("range"))),
+            ],
+        )
+        for a in d.get("annotations", [])
+    ]
+    return out or [ViewNode("(no salient annotations)", style="dim")]
+
+
+# Registry: view id → builder.  ``cfg``/``ssa`` share one builder via a flag.
+VIEW_BUILDERS: dict[str, Callable[[dict], list[ViewNode]]] = {
+    "greentree": _build_greentree,
+    "ir": _build_ir,
+    "cfg": lambda d: _build_cfg(d.get("cfgPreSsa"), post=False),
+    "ssa": lambda d: _build_cfg(d.get("cfgPostSsa"), post=True),
+    "loops": _build_loops,
+    "types": _build_types,
+    "intervals": _build_intervals,
+    "bounds": _build_bounds,
+    "dataflow": _build_dataflow,
+    "interproc": _build_interproc,
+    "rendered": _build_rendered,
+    "opt": _build_opt,
+    "gvn": _build_gvn,
+    "shimmer": _build_shimmer,
+    "taint": _build_taint,
+    "irules": _build_irules,
+    "event-order": _build_event_order,
+    "callouts": _build_callouts,
+}
+
+# Views that the TUI renders as an interactive tree (everything with a
+# builder).  ``asm`` / ``wasm`` deliberately stay on the text renderer.
+TREE_VIEWS = frozenset(VIEW_BUILDERS)
+
+
+def build_view(view: str, data: dict) -> list[ViewNode]:
+    """Build the :class:`ViewNode` forest for *view* from serialised *data*."""
+    builder = VIEW_BUILDERS.get(view)
+    return builder(data) if builder else []


### PR DESCRIPTION
The IR/if/for/switch tree and the source-callout markers hand-coded 7-bit
ASCII connectors (|--, `--, |, +-->) even though the terminal surfaces
(flat --text and the Textual TUI) render full Unicode and every other tree
renderer in the repo (pkg.py, tcl_test_client.py) plus the CFG gutter already
use box-drawing glyphs. Switch them to the shared line set (├── └── │, ╰─▶)
so the trees match the rest of the UI.