### PR TITLE
SYNC-MAY31-2/3: Recover switch arm bodies and fold existence queries

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -20,11 +20,32 @@ Use this to verify server behavior after making changes.
 Run from the project root (the git worktree directory):
 
 ```bash
-python3 .claude/skills/lsp-client/lsp_client.py <subcommand> <args...>
+python3 .claude/skills/lsp-client/lsp_client.py [--server python|rust] <subcommand> <args...>
 ```
 
-The script auto-detects the `tcl-lsp/` server directory.  Override with
-`--server-dir /path/to/tcl-lsp` if needed.
+The script auto-detects the server location.  Override with
+`--server-dir <path>` if needed.
+
+## Choosing a backend (`--server`)
+
+`--server` selects which language server to drive:
+
+| Value | Server | Notes |
+|---|---|---|
+| `python` (default) | `python -m lsp` (the `lsp/` package, run via `uv`) | The legacy Python server. |
+| `rust` | the native `tcl-lsp-server` binary | Built on demand with `cargo build -p tcl-lsp-server`; the binary is reused on later runs. |
+
+Use this to verify the **Rust** analyser/diagnostics (e.g. after changing
+`rust/tcl-compiler/src/analyser/`), and to A/B the two backends on the same
+file.  `--server-dir` means different things per backend: for `python` it's
+the `tcl-lsp` dir containing `lsp/`; for `rust` it's the Cargo workspace root
+(the dir with `Cargo.toml` + `rust/`).
+
+```bash
+# Same file, both servers — compare diagnostics
+python3 .claude/skills/lsp-client/lsp_client.py --server rust   diagnostics foo.tcl
+python3 .claude/skills/lsp-client/lsp_client.py --server python diagnostics foo.tcl
+```
 
 ## Subcommands
 
@@ -198,6 +219,7 @@ to filter to just `[timing]` entries for performance analysis.
 ## Example Invocations
 
 ```bash
+python3 .claude/skills/lsp-client/lsp_client.py --server rust diagnostics tcl-lsp/editors/vscode/testFixture/diagnostics.tcl
 python3 .claude/skills/lsp-client/lsp_client.py semantic-tokens tcl-lsp/samples/for_screenshots/03-completions.tcl
 python3 .claude/skills/lsp-client/lsp_client.py diagnostics tcl-lsp/editors/vscode/testFixture/diagnostics.tcl
 python3 .claude/skills/lsp-client/lsp_client.py hover tcl-lsp/editors/vscode/testFixture/procs.tcl 1 6

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -156,8 +156,27 @@ SYMBOL_KIND = {
 class LspClient:
     """Manages a language server subprocess and JSON-RPC communication."""
 
-    def __init__(self, server_dir: str) -> None:
+    def __init__(
+        self,
+        server_dir: str,
+        launch_cmd: list[str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
         self.server_dir = server_dir
+        # The command used to spawn the server, and the working
+        # directory to spawn it in. Defaults to the Python server for
+        # backward compatibility; the Rust backend overrides both.
+        self.launch_cmd = launch_cmd or [
+            "uv",
+            "run",
+            "--directory",
+            server_dir,
+            "--no-dev",
+            "python",
+            "-m",
+            "lsp",
+        ]
+        self.cwd = cwd or server_dir
         self.process: subprocess.Popen | None = None
         self._request_id = 0
         self._pending: dict[int, dict] = {}  # id -> {"event": Event, "result": ...}
@@ -171,11 +190,11 @@ class LspClient:
     def start(self) -> None:
         """Spawn the server and start the reader thread."""
         self.process = subprocess.Popen(
-            ["uv", "run", "--directory", self.server_dir, "--no-dev", "python", "-m", "lsp"],
+            self.launch_cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=self.server_dir,
+            cwd=self.cwd,
         )
         self._running = True
         self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
@@ -398,6 +417,71 @@ def find_server_dir(override: str | None = None) -> str:
         f"Cannot find tcl-lsp server. Tried {server_dir} and cwd={cwd}. "
         "Use --server-dir to specify the path."
     )
+
+
+def find_repo_root(override: str | None = None) -> Path:
+    """Locate the Cargo workspace root (contains `Cargo.toml` + `rust/`)."""
+    if override:
+        root = Path(override).resolve()
+        if (root / "Cargo.toml").exists():
+            return root
+        raise FileNotFoundError(f"No Cargo workspace at {root}")
+    # Walk up from this script and from cwd looking for the workspace root.
+    starts = [Path(__file__).resolve(), Path.cwd().resolve()]
+    for start in starts:
+        for cand in [start, *start.parents]:
+            if (cand / "Cargo.toml").exists() and (cand / "rust").is_dir():
+                return cand
+    raise FileNotFoundError(
+        "Cannot find the Cargo workspace root for the Rust server. "
+        "Use --server-dir to point at the repo root."
+    )
+
+
+def resolve_rust_server(override: str | None) -> tuple[str, list[str], str]:
+    """Locate (building if needed) the Rust `tcl-lsp-server` binary.
+
+    Returns ``(server_dir, launch_cmd, cwd)``.
+    """
+    root = find_repo_root(override)
+    binary = root / "target" / "debug" / "tcl-lsp-server"
+    if not binary.exists():
+        print(
+            "Rust server binary not found; building "
+            "(cargo build -p tcl-lsp-server)...",
+            file=sys.stderr,
+        )
+        subprocess.run(
+            ["cargo", "build", "-q", "-p", "tcl-lsp-server", "--bin", "tcl-lsp-server"],
+            cwd=str(root),
+            check=True,
+        )
+    if not binary.exists():
+        raise FileNotFoundError(f"Rust server binary not found at {binary}")
+    return str(root), [str(binary)], str(root)
+
+
+def resolve_server(backend: str, override: str | None) -> tuple[str, list[str], str]:
+    """Resolve the server launch config for the chosen backend.
+
+    Returns ``(server_dir, launch_cmd, cwd)``. ``server_dir`` is used for
+    the ``rootUri`` sent at initialize; ``launch_cmd`` / ``cwd`` spawn the
+    process.
+    """
+    if backend == "rust":
+        return resolve_rust_server(override)
+    server_dir = find_server_dir(override)
+    launch_cmd = [
+        "uv",
+        "run",
+        "--directory",
+        server_dir,
+        "--no-dev",
+        "python",
+        "-m",
+        "lsp",
+    ]
+    return server_dir, launch_cmd, server_dir
 
 
 def initialize(client: LspClient) -> dict:
@@ -1382,7 +1466,18 @@ examples:
   %(prog)s all samples/for_screenshots/03-completions.tcl
 """,
     )
-    parser.add_argument("--server-dir", help="Path to tcl-lsp directory (auto-detected by default)")
+    parser.add_argument(
+        "--server",
+        choices=["python", "rust"],
+        default="python",
+        help="Which language server to drive: the Python server (`python -m lsp`, "
+        "default) or the native Rust server (`tcl-lsp-server`, built on demand).",
+    )
+    parser.add_argument(
+        "--server-dir",
+        help="Path to the server. For --server python: the tcl-lsp dir holding "
+        "`lsp/`. For --server rust: the Cargo workspace root. Auto-detected by default.",
+    )
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -1476,15 +1571,15 @@ examples:
 
     args = parser.parse_args()
 
-    # Find server
+    # Resolve the chosen backend (Python or Rust).
     try:
-        server_dir = find_server_dir(args.server_dir)
-    except FileNotFoundError as e:
+        server_dir, launch_cmd, cwd = resolve_server(args.server, args.server_dir)
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Create client and run
-    client = LspClient(server_dir)
+    client = LspClient(server_dir, launch_cmd=launch_cmd, cwd=cwd)
     try:
         client.start()
         initialize(client)

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1943,6 +1943,29 @@ between an inline `STR_EQ` chain for Exact and a runtime
 `Statement::Switch` arm in `lowering` already records `mode` so no
 upstream change is needed.  Classify: in-scope, low-touch.
 
+**Landed (rust).**  `cfg_lower.rs::lower_switch` dropped the
+mode-based barrier short-circuit; all three modes now build the
+structured arm-dispatch + arm-body + default blocks, so SSA recovers
+the subject *and* arm-body variable reads (the W214/W210 path).  Exact
+arms keep a foldable `STR_EQ(subject, pattern)` (the backend still
+builds a real jump table); glob/regexp arms branch on a *non-foldable*
+`ExprNode::Raw { text: subject }` — string equality is the wrong
+predicate for those modes, and a foldable condition would let SCCP
+spuriously kill arms.  A glob/regexp dispatch is recorded in the new
+`cfg::Function::switch_dispatches` map (entry block → `SwitchDispatch
+{ mode, raw_args, end_block, member_blocks }`); codegen
+(`emitter/generate.rs`) consults it to emit a generic `switch` invoke
+(as the old barrier did) and skip the analyser-only member blocks,
+matching tclsh's un-compiled approach for those modes.  (Note: the
+single-braced-body arm form is still lowered to an empty `Script` for
+*every* mode — a separate pre-existing lowering gap, untouched here;
+the multi-arg arm form lowers bodies and is what exercises the SSA
+recovery.)  Tests: `switch_glob_creates_branches` /
+`switch_regexp_creates_branches` (cfg_lower), `switch_glob_arm_body_
+read_counts_as_param_use` (compilation_unit), and
+`switch_glob_emits_generic_invoke_not_jump_table` (codegen
+integration).
+
 ### SYNC-MAY31-3 — Fold `info exists` / `array exists` in guarded regions (#502)
 
 `main` reclassifies `[info exists X]` / `[array exists X]` as
@@ -2500,8 +2523,9 @@ priority queue:
   inlay-hints fix mirrors the same FP family Python just fixed),
   #508 (server-side reposition cache for moved procedures — closes
   with `S*`).  **Landed (rust):** `SYNC-MAY31-7` (#473 `ExprRaw`
-  var scan), `-8` (#494 backslash-continuation folding), and `-10`
-  (#510 inlay-hint optional positionals + `infer_function_return_type`)
+  var scan), `-8` (#494 backslash-continuation folding), `-10`
+  (#510 inlay-hint optional positionals + `infer_function_return_type`),
+  and `-2` (#474 glob/regexp `switch` keeps structured dispatch)
   — see those family sections.  Of the remainder, none are
   *correctness* blockers for the analyser flip.  **Correction to a
   stale note:** earlier rows said "the Rust analyser has no live

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2078,16 +2078,23 @@ dominated (via the SSA `idom` chain) by the true target of
 `[info exists X]` (or the false target of `![info exists X]`) are
 excluded from W210.  This is done at emit time rather than by
 injecting a synthetic SSA def, which would create a spurious merge phi
-and perturb W214/W211.  (3) **Predicate fold → I230** —
-`emit_existence_constant_branch_diagnostics` folds the two
+and perturb W214/W211.  (3) **Predicate fold → I230 + O101/DCE** —
+`sccp::existence_constant_branches(cfg, params)` folds the two
 false-positive-free cases (a *parameter* always exists → true; a
 never-defined non-parameter simple local never exists → false),
 gated on a barrier-free function and skipping `unset` params, array
-elements, and namespaced/global names.  (SCCP itself is left untouched
-— it has neither parameter nor existence facts; the doc's
-`run_all_checks` wiring note reflects the Python layout, not Rust's,
-where these emitters live on the analyser.)  Tests: the
-`info_exists_*` cluster in `analyser/diagnostics.rs`.
+elements, and namespaced/global names.  The fold runs as a post-pass
+(SCCP proper has neither parameter nor existence facts): the analyser's
+`emit_existence_constant_branch_diagnostics` emits the I230 from it, and
+`FunctionUnit::build` appends the same `ConstantBranch`es to
+`sccp.constant_branches` so the optimiser's `branch_folding` surfaces an
+O101 constant-fold / DCE suggestion — unifying both consumers on one
+helper (mirroring the Python "I230 + DCE pipeline").  Emitting I230
+directly avoids a double-emit: `emit_constant_branch_diagnostics` gates
+on the not-taken arm being unreachable in `executable_blocks`, which the
+post-pass folds don't update, so it skips them.  Tests: the
+`info_exists_*` cluster in `analyser/diagnostics.rs` plus
+`optimiser::manager::tests::info_exists_fold_surfaces_o101`.
 
 ### SYNC-MAY31-4 — W127 closed-value command argument + BODY role on iRules nesting scripts (#501)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2022,6 +2022,21 @@ precedent and replace the discarded-result `switch_exact` lowering
 test with a real assertion.  Classify: in-scope, low-touch; affects
 all switch modes equally.
 
+**Landed (rust).**  `build_switch_arms` now lowers the single-braced
+arm body from its `body_span` when there is no arg token (the
+multi-arg form keeps the token path).  Rather than restructuring the
+element parser, it reuses the existing relocated, brace-inclusive
+`body_span`: the content offset is recovered as `body_span.start() +
+(span_len − body_text.len())/2`, which skips a leading `{` / `"`
+delimiter (and is `0` for a bare-word body) — matching the offset
+`lower_body_from_tok` derives from a token's `content_offset`.  So the
+canonical `switch $x { a {body} … }` form now flows real arm-body IR
+into SSA / def-use / SCCP / the CFG-SSA diagnostics and bytecode
+codegen (and, combined with `SYNC-MAY31-2`, the glob/regexp recovery
+now fires for the braced syntax too).  The `switch_exact` lowering
+test's discarded result is now a real assertion, plus
+`switch_single_braced_body_is_lowered`.
+
 ### SYNC-MAY31-3 — Fold `info exists` / `array exists` in guarded regions (#502)
 
 `main` reclassifies `[info exists X]` / `[array exists X]` as
@@ -2493,7 +2508,7 @@ to the chunk-log entry that has the full spec.
 | — | `SYNC-MAY19-word-piece-array` | Landed 2026-05-19 — bare `$arr($idx)` round-trip in `rust/tcl-compiler/src/segmenter.rs::word_piece` gated on `tok.content_offset`. |
 | — | `SYNC-MAY19-surrogate-pair` | Landed 2026-05-19 — `scan_unicode_escape` in `rust/tcl-lexer/src/substitution.rs` combines `\uHHHH \uLLLL` pairs into supplementary-plane codepoints. |
 | 7 | `SYNC-MAY19-switch-fallthrough-cfg` | Add `expand_fallthrough_switch` to `rust/tcl-compiler/src/cfg.rs` + `cfg_builder/`.  **Deferred** — the Rust path doesn't emit Tcl bytecode today, so this flag has no consumer.  Listed for tracking only. |
-| 3 | `SYNC-JUN-switch-braced-body` | Rust-only catch-up (Python already correct — no backport).  Single-braced `switch $x { a {body} … }` arm bodies lower to an empty `IRScript`, so CFG-SSA diagnostics + codegen miss them for the *canonical* switch form (the analyser tree-walk already handles it).  Low-touch fix in `lowering/structured.rs` — see the `SYNC-JUN-switch-braced-body` section for the root cause + fix sketch. |
+| — | `SYNC-JUN-switch-braced-body` | **Landed.** `build_switch_arms` lowers single-braced `switch $x { a {body} … }` arm bodies from their `body_span` (was an empty `IRScript`), so CFG-SSA diagnostics + codegen now cover the canonical switch form for every mode.  See the `SYNC-JUN-switch-braced-body` section. |
 | — | `SYNC-JUN-FRAME356-population` | Landed via PR #389 — `EscapeState` and `CfgState` carry `barriers: Vec<Barrier>` + `tag_reasons: HashMap<String, Vec<EscapeReason>>` populated by `record_barrier` / `escape_with_reason` calls at the informative handler sites; `analyse_script` copies both into `ProcEscapeSummary`. |
 | — | `SYNC-JUN-CFG-uplevel-literal-set` + `SYNC-JUN-CFG-upvar-info` wiring + embedded-substitution form | **Landed.** Direct-call form: `UpvarInfo::caller_side_defs(call_args, params)` resolves every upvar declaration against a call site (literal / param / args-tail); `CfgBuilder::apply_upvar_invalidation` augments `Statement::Call::defs` from the `other =>` arm in `lower_script`; `prepare_cfg_context` / `detect_upvar_procs` free helpers scan every procedure and register both qualified and short name keys.  Embedded-substitution form: `upvar_defs_from_text(text)` re-lexes via `tcl-lexer`, walks `[command_substitution]` tokens, and accumulates defs from any embedded upvar proc calls; `apply_upvar_invalidation` either merges into the host Call's defs or emits a synthetic `<upvar-invalidate>` Call before non-Call hosts.  28 new tests cover the resolver, the wiring, and both substitution forms. |
 | — | `C45-uri-split` | Landed 2026-05-08 — see chunk log. |

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1994,6 +1994,30 @@ lattice + the `executable_blocks` set); `rust/tcl-compiler/src/analyser/diagnost
 matching `compiler_checks::run_all_checks` wiring.  Classify:
 in-scope, medium.
 
+**Landed (rust).**  All three deltas, re-targeted to the Rust IR
+(where `[info exists X]` lowers to an opaque `ExprNode::Command`, *not*
+a `Statement::Call`, so the doc's `evaluate_def` pointer doesn't
+apply).  A shared `expr_ast::existence_query_var` recognises
+`[info exists X]` / `[array exists X]` (and `![…]`).  (1) **W210
+suppression for the query word** — `emit_read_before_set_diagnostics`
+skips a use whose statement is an existence query for that var (bare
+`info exists X` call *and* the `set y [info exists X]` command-sub
+form).  (2) **Guarded read narrowing** — reads of `X` in any block
+dominated (via the SSA `idom` chain) by the true target of
+`[info exists X]` (or the false target of `![info exists X]`) are
+excluded from W210.  This is done at emit time rather than by
+injecting a synthetic SSA def, which would create a spurious merge phi
+and perturb W214/W211.  (3) **Predicate fold → I230** —
+`emit_existence_constant_branch_diagnostics` folds the two
+false-positive-free cases (a *parameter* always exists → true; a
+never-defined non-parameter simple local never exists → false),
+gated on a barrier-free function and skipping `unset` params, array
+elements, and namespaced/global names.  (SCCP itself is left untouched
+— it has neither parameter nor existence facts; the doc's
+`run_all_checks` wiring note reflects the Python layout, not Rust's,
+where these emitters live on the analyser.)  Tests: the
+`info_exists_*` cluster in `analyser/diagnostics.rs`.
+
 ### SYNC-MAY31-4 — W127 closed-value command argument + BODY role on iRules nesting scripts (#501)
 
 Two deltas:
@@ -2525,8 +2549,9 @@ priority queue:
   with `S*`).  **Landed (rust):** `SYNC-MAY31-7` (#473 `ExprRaw`
   var scan), `-8` (#494 backslash-continuation folding), `-10`
   (#510 inlay-hint optional positionals + `infer_function_return_type`),
-  and `-2` (#474 glob/regexp `switch` keeps structured dispatch)
-  — see those family sections.  Of the remainder, none are
+  `-2` (#474 glob/regexp `switch` keeps structured dispatch), and `-3`
+  (#502 `info exists` / `array exists` guard narrowing + W210
+  suppression + I230 fold) — see those family sections.  Of the remainder, none are
   *correctness* blockers for the analyser flip.  **Correction to a
   stale note:** earlier rows said "the Rust analyser has no live
   caller post-#241" — that referred to the deleted differential

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1958,13 +1958,69 @@ spuriously kill arms.  A glob/regexp dispatch is recorded in the new
 (as the old barrier did) and skip the analyser-only member blocks,
 matching tclsh's un-compiled approach for those modes.  (Note: the
 single-braced-body arm form is still lowered to an empty `Script` for
-*every* mode — a separate pre-existing lowering gap, untouched here;
-the multi-arg arm form lowers bodies and is what exercises the SSA
-recovery.)  Tests: `switch_glob_creates_branches` /
+*every* mode — a separate pre-existing Rust lowering gap, tracked as
+`SYNC-JUN-switch-braced-body` below and untouched here; the multi-arg
+arm form lowers bodies and is what exercises the SSA recovery.)  Tests: `switch_glob_creates_branches` /
 `switch_regexp_creates_branches` (cfg_lower), `switch_glob_arm_body_
 read_counts_as_param_use` (compilation_unit), and
 `switch_glob_emits_generic_invoke_not_jump_table` (codegen
 integration).
+
+### SYNC-JUN-switch-braced-body — single-braced `switch` arm bodies not lowered to the CFG (Rust gap)
+
+Discovered while landing `SYNC-MAY31-2`.  **Rust-only; not a Python
+parity gap — no backport needed.**
+
+The canonical `switch` form `switch $x { a {body1} b {body2} }` (a
+single braced word holding every pattern/body pair) lowers its arm
+bodies to an **empty `IRScript`** on the Rust side, for *all* modes.
+The multi-arg form `switch $x a {body1} b {body2}` lowers bodies
+correctly.  Root cause: in
+`rust/tcl-compiler/src/lowering/structured.rs`, the single-braced path
+in `lower_switch` (the `i == args.len() - 1` branch) builds each
+`SwitchPair` with `body_arg_idx: None` because the per-body tokens live
+*inside* the braced word, not in `arg_tokens`.  `build_switch_arms`
+then calls `lower_body_from_tok(text, None, …)`, which returns
+`Script::new()` whenever the token is `None`.
+
+**Scope of impact.**  The gap is in the **CFG-lowering** path only, so
+it degrades everything downstream of the CFG for single-braced switch
+arm bodies: SSA / def-use / SCCP, the CFG-SSA diagnostics
+(W210/W211/W214/W220, dead-store, I230 — including the
+`SYNC-MAY31-2/-3` recoveries when the arm uses the braced form), and
+bytecode codegen of those bodies (emitted as empty).  The **analyser
+tree-walk** is a *separate* path and already handles the braced form
+correctly — `analyser/handlers.rs::handle_switch_command` extracts
+per-element tokens via `parse_switch_body_elements(body_text, body_tok)`
+and calls `analyse_body` on each, so W123 / semantic tokens / the
+regexp-pattern recording are unaffected.  (This split is why the
+existing `handle_switch_form2_braced_body_walks_each_arm` test passes
+while the lowering test at `structured.rs:771` discards its result with
+a "single braced body may not be fully parsed yet" comment.)
+
+**Python parity.**  `core/compiler/lowering.py::_lower_switch` handles
+the braced form: `_switch_body_elements` returns extracted *Tokens*,
+each body pair carries a non-`None` `body_tok`, and `_lower_body_arg`
+recursively `_lower_script`s it.  Python is correct, so this is a Rust
+catch-up only.
+
+**Fix sketch.**  The single-braced path already relocates each body's
+span into outer-source coordinates (`body_span`), so the simplest fix
+is to drop the token requirement for this case and lower from the
+offset directly — call `lower_body(text, content_offset, namespace)`
+(`lowering/mod.rs::lower_body`) with `content_offset = body_span.start()
++ 1` (skip the opening `{`), since the element text is already the
+brace-stripped content.  Alternatively, mirror the analyser by
+extracting real per-element sub-tokens (`parse_switch_body_elements`)
+and threading them through `SwitchPair` so `lower_body_from_tok` gets a
+non-`None` token — this also fixes any content-offset / encoding-flag
+nuances the bare-offset path would have to replicate.  Files:
+`rust/tcl-compiler/src/lowering/structured.rs`
+(`lower_switch` single-braced branch + `build_switch_arms`); reference
+`analyser/handlers.rs::handle_switch_command` as the working
+precedent and replace the discarded-result `switch_exact` lowering
+test with a real assertion.  Classify: in-scope, low-touch; affects
+all switch modes equally.
 
 ### SYNC-MAY31-3 — Fold `info exists` / `array exists` in guarded regions (#502)
 
@@ -2437,6 +2493,7 @@ to the chunk-log entry that has the full spec.
 | — | `SYNC-MAY19-word-piece-array` | Landed 2026-05-19 — bare `$arr($idx)` round-trip in `rust/tcl-compiler/src/segmenter.rs::word_piece` gated on `tok.content_offset`. |
 | — | `SYNC-MAY19-surrogate-pair` | Landed 2026-05-19 — `scan_unicode_escape` in `rust/tcl-lexer/src/substitution.rs` combines `\uHHHH \uLLLL` pairs into supplementary-plane codepoints. |
 | 7 | `SYNC-MAY19-switch-fallthrough-cfg` | Add `expand_fallthrough_switch` to `rust/tcl-compiler/src/cfg.rs` + `cfg_builder/`.  **Deferred** — the Rust path doesn't emit Tcl bytecode today, so this flag has no consumer.  Listed for tracking only. |
+| 3 | `SYNC-JUN-switch-braced-body` | Rust-only catch-up (Python already correct — no backport).  Single-braced `switch $x { a {body} … }` arm bodies lower to an empty `IRScript`, so CFG-SSA diagnostics + codegen miss them for the *canonical* switch form (the analyser tree-walk already handles it).  Low-touch fix in `lowering/structured.rs` — see the `SYNC-JUN-switch-braced-body` section for the root cause + fix sketch. |
 | — | `SYNC-JUN-FRAME356-population` | Landed via PR #389 — `EscapeState` and `CfgState` carry `barriers: Vec<Barrier>` + `tag_reasons: HashMap<String, Vec<EscapeReason>>` populated by `record_barrier` / `escape_with_reason` calls at the informative handler sites; `analyse_script` copies both into `ProcEscapeSummary`. |
 | — | `SYNC-JUN-CFG-uplevel-literal-set` + `SYNC-JUN-CFG-upvar-info` wiring + embedded-substitution form | **Landed.** Direct-call form: `UpvarInfo::caller_side_defs(call_args, params)` resolves every upvar declaration against a call site (literal / param / args-tail); `CfgBuilder::apply_upvar_invalidation` augments `Statement::Call::defs` from the `other =>` arm in `lower_script`; `prepare_cfg_context` / `detect_upvar_procs` free helpers scan every procedure and register both qualified and short name keys.  Embedded-substitution form: `upvar_defs_from_text(text)` re-lexes via `tcl-lexer`, walks `[command_substitution]` tokens, and accumulates defs from any embedded upvar proc calls; `apply_upvar_invalidation` either merges into the host Call's defs or emits a synthetic `<upvar-invalidate>` Call before non-Call hosts.  28 new tests cover the resolver, the wiring, and both substitution forms. |
 | — | `C45-uri-split` | Landed 2026-05-08 — see chunk log. |

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -2501,96 +2501,40 @@ before this value so it is treated as data, not an option."
     ///
     /// SYNC-MAY31-3.  SCCP can't fold these (the predicate lowers to an
     /// opaque `ExprNode::Command`, and SCCP has no parameter/existence
-    /// facts), so the fold lives here, where `ir_proc.params` and the
-    /// def-use chains are available.  Only the two false-positive-free
-    /// cases are folded, and only in functions free of opaque barriers
-    /// (an unknown command could `unset` or `upvar`-define the var):
-    ///
-    /// - a **parameter** always exists → the predicate is `true`;
-    /// - a variable that is **never defined anywhere** and is not a
-    ///   parameter never exists → the predicate is `false`.
-    ///
-    /// `![info exists X]` flips the folded value.  Conditionally-set
-    /// variables are left alone.
+    /// facts), so the fold is computed by
+    /// [`crate::sccp::existence_constant_branches`] using
+    /// `ir_proc.params` — the same helper whose result
+    /// `FunctionUnit::build` appends to `sccp.constant_branches` for the
+    /// optimiser's O101 fold / DCE.  Emitting the I230 here (rather than
+    /// via [`Self::emit_constant_branch_diagnostics`]) is deliberate:
+    /// that emitter gates on the not-taken arm being unreachable in
+    /// `executable_blocks`, which these post-pass folds don't update, so
+    /// it skips them and there is no double emission.
     fn emit_existence_constant_branch_diagnostics(
         &mut self,
         fu: &crate::compilation_unit::FunctionUnit,
         ir_proc: Option<&crate::ir::Procedure>,
     ) {
-        use crate::cfg::Terminator;
-        use crate::ir::Statement;
-
-        // An opaque barrier (unknown command, `uplevel`, …) could
-        // define or unset arbitrary variables; bail on the whole
-        // function rather than risk a false fold.
-        let has_barrier = fu.cfg.blocks.values().any(|b| {
-            b.statements
-                .iter()
-                .any(|s| matches!(s, Statement::Barrier { .. }))
-        });
-        if has_barrier {
-            return;
-        }
-
         let params: HashSet<&str> = match ir_proc {
             Some(p) => p.params.iter().map(String::as_str).collect(),
             None => HashSet::new(),
         };
-        let defined = collect_defined_vars(&fu.cfg);
-        // A var explicitly `unset` anywhere can't be assumed to exist
-        // even if it's a parameter.
-        let unset: HashSet<&str> = fu
-            .cfg
-            .blocks
-            .values()
-            .flat_map(|b| &b.statements)
-            .filter_map(|s| match s {
-                Statement::Call { command, args, .. } if command == "unset" => Some(args),
-                _ => None,
-            })
-            .flatten()
-            .map(String::as_str)
-            .collect();
-
-        for block in fu.cfg.blocks.values() {
-            let Some(Terminator::Branch {
-                condition,
-                span: Some(span),
-                ..
-            }) = &block.terminator
-            else {
-                continue;
-            };
-            let Some((var, negated)) = crate::expr_ast::existence_query_var(condition) else {
-                continue;
-            };
-            // Only fold simple local names. Array elements
-            // (`env(PATH)`) and namespaced / global vars (`::g`) may be
-            // populated by state outside this function's def-use view,
-            // so folding them to a constant risks a false positive.
-            if !var.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') || var.is_empty() {
-                continue;
-            }
-            let exists = if params.contains(var.as_str()) {
-                if unset.contains(var.as_str()) {
-                    continue;
-                }
-                true
-            } else if !defined.contains(&var) {
-                false
+        for cb in crate::sccp::existence_constant_branches(&fu.cfg, &params) {
+            let Some(span) = cb.span else { continue };
+            let message = if cb.value {
+                format!(
+                    "Condition '{}' is always true; the alternate branch is unreachable",
+                    cb.condition,
+                )
             } else {
-                continue;
-            };
-            let value = exists ^ negated;
-            let cond = crate::expr_ast::expr_text(condition);
-            let message = if value {
-                format!("Condition '{cond}' is always true; the alternate branch is unreachable")
-            } else {
-                format!("Condition '{cond}' is always false; the alternate branch is unreachable")
+                format!(
+                    "Condition '{}' is always false; the alternate branch is unreachable",
+                    cb.condition,
+                )
             };
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: "I230".to_string(),
-                span: *span,
+                span,
                 message,
                 severity: Severity::Hint,
                 fixes: Vec::new(),

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -102,6 +102,99 @@ fn find_case_mismatch<'a>(variable: &str, defined_vars: &'a HashSet<String>) -> 
     matches.into_iter().next()
 }
 
+/// SYNC-MAY31-3: variables this statement queries *only for
+/// existence* (`info exists X` / `array exists X`, whether a bare call
+/// or a `[...]` command substitution inside an assignment / argument).
+/// Such a reference is not a value read, so it must not raise W210.
+fn existence_query_vars(stmt: &crate::ir::Statement) -> Vec<String> {
+    use crate::expr_ast::existence_query_in_text;
+    use crate::ir::Statement;
+    let mut out = Vec::new();
+    // Bare-call form: `info exists X` / `array exists X`.
+    if let Statement::Call { command, args, .. } = stmt {
+        if matches!(command.as_str(), "info" | "array")
+            && args.first().map(String::as_str) == Some("exists")
+        {
+            if let Some(v) = args.get(1) {
+                out.push(v.clone());
+            }
+        }
+    }
+    // Command-substitution form: `set y [info exists X]`,
+    // `puts [array exists X]`, etc.
+    let texts: &[String] = match stmt {
+        Statement::AssignValue { value, .. } => std::slice::from_ref(value),
+        Statement::Call { args, .. } => args,
+        _ => &[],
+    };
+    for t in texts {
+        if let Some(v) = existence_query_in_text(t.trim()) {
+            out.push(v);
+        }
+    }
+    out
+}
+
+/// SYNC-MAY31-3: collect `(var, guard_block)` pairs for every
+/// `[info exists X]` / `[array exists X]` branch condition in `fu`.
+/// A read of `var` in any block dominated by `guard_block` is guarded
+/// (X provably exists).  A positive query guards the true target; a
+/// `![info exists X]` query guards the false target.
+fn collect_existence_guards(fu: &crate::compilation_unit::FunctionUnit) -> Vec<(String, String)> {
+    use crate::cfg::Terminator;
+    let mut guards = Vec::new();
+    for block in fu.cfg.blocks.values() {
+        if let Some(Terminator::Branch {
+            condition,
+            true_target,
+            false_target,
+            ..
+        }) = &block.terminator
+        {
+            if let Some((var, negated)) = crate::expr_ast::existence_query_var(condition) {
+                let target = if negated { false_target } else { true_target };
+                guards.push((var, target.clone()));
+            }
+        }
+    }
+    guards
+}
+
+/// SYNC-MAY31-3: true when a read of `var` at `use_block` is exempt
+/// from W210 because it is the existence-query word itself, or because
+/// it sits in a region guarded by an enclosing `[info exists var]`.
+fn existence_exempt(
+    stmt_opt: Option<&crate::ir::Statement>,
+    var: &str,
+    exists_guards: &[(String, String)],
+    ssa: &crate::ssa::SsaFunction,
+    use_block: &str,
+) -> bool {
+    if let Some(stmt) = stmt_opt {
+        if existence_query_vars(stmt).iter().any(|q| q == var) {
+            return true;
+        }
+    }
+    exists_guards
+        .iter()
+        .any(|(gv, gblk)| gv == var && block_dominated_by(ssa, use_block, gblk))
+}
+
+/// True when `block` is dominated by `dom` (walking the SSA immediate
+/// dominator chain; a block dominates itself).
+fn block_dominated_by(ssa: &crate::ssa::SsaFunction, block: &str, dom: &str) -> bool {
+    let mut cur = block;
+    loop {
+        if cur == dom {
+            return true;
+        }
+        match ssa.idom.get(cur) {
+            Some(Some(parent)) => cur = parent,
+            _ => return false,
+        }
+    }
+}
+
 /// Collect every variable name defined anywhere in `cfg`.
 ///
 /// Mirrors `_collect_defined_vars` in
@@ -1777,6 +1870,7 @@ before this value so it is treated as data, not an option."
             extra_known_defined,
         );
         self.emit_constant_branch_diagnostics(function_unit);
+        self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
         self.emit_invalid_ip_diagnostics(function_unit);
         if let Some(ir_proc) = ir_proc {
             self.emit_unused_param_diagnostics(function_unit, ir_proc);
@@ -2206,6 +2300,13 @@ before this value so it is treated as data, not an option."
         };
         let params = &params_owned;
 
+        // SYNC-MAY31-3: collect `[info exists X]` / `[array exists X]`
+        // guards: `(var, guard_block)` where reads of `var` in any
+        // block dominated by `guard_block` are guarded (X is known to
+        // exist there).  Positive guards the true arm; `![info exists
+        // X]` guards the false arm.
+        let exists_guards = collect_existence_guards(fu);
+
         for chain in fu.def_use.chains.values() {
             if chain.definition.kind != DefKind::Parameter {
                 continue;
@@ -2247,6 +2348,11 @@ before this value so it is treated as data, not an option."
                         (stmt.span(), Some(stmt))
                     };
                 if span.is_empty() {
+                    continue;
+                }
+                // SYNC-MAY31-3: skip the existence-query word itself and
+                // reads narrowed by an enclosing `[info exists X]` guard.
+                if existence_exempt(stmt_opt, var, &exists_guards, &fu.ssa, &use_site.block) {
                     continue;
                 }
                 // ``unset`` without ``-nocomplain`` → W213.
@@ -2384,6 +2490,107 @@ before this value so it is treated as data, not an option."
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: code.to_string(),
                 span,
+                message,
+                severity: Severity::Hint,
+                fixes: Vec::new(),
+            });
+        }
+    }
+
+    /// I230 — fold `[info exists X]` / `[array exists X]` conditions.
+    ///
+    /// SYNC-MAY31-3.  SCCP can't fold these (the predicate lowers to an
+    /// opaque `ExprNode::Command`, and SCCP has no parameter/existence
+    /// facts), so the fold lives here, where `ir_proc.params` and the
+    /// def-use chains are available.  Only the two false-positive-free
+    /// cases are folded, and only in functions free of opaque barriers
+    /// (an unknown command could `unset` or `upvar`-define the var):
+    ///
+    /// - a **parameter** always exists → the predicate is `true`;
+    /// - a variable that is **never defined anywhere** and is not a
+    ///   parameter never exists → the predicate is `false`.
+    ///
+    /// `![info exists X]` flips the folded value.  Conditionally-set
+    /// variables are left alone.
+    fn emit_existence_constant_branch_diagnostics(
+        &mut self,
+        fu: &crate::compilation_unit::FunctionUnit,
+        ir_proc: Option<&crate::ir::Procedure>,
+    ) {
+        use crate::cfg::Terminator;
+        use crate::ir::Statement;
+
+        // An opaque barrier (unknown command, `uplevel`, …) could
+        // define or unset arbitrary variables; bail on the whole
+        // function rather than risk a false fold.
+        let has_barrier = fu.cfg.blocks.values().any(|b| {
+            b.statements
+                .iter()
+                .any(|s| matches!(s, Statement::Barrier { .. }))
+        });
+        if has_barrier {
+            return;
+        }
+
+        let params: HashSet<&str> = match ir_proc {
+            Some(p) => p.params.iter().map(String::as_str).collect(),
+            None => HashSet::new(),
+        };
+        let defined = collect_defined_vars(&fu.cfg);
+        // A var explicitly `unset` anywhere can't be assumed to exist
+        // even if it's a parameter.
+        let unset: HashSet<&str> = fu
+            .cfg
+            .blocks
+            .values()
+            .flat_map(|b| &b.statements)
+            .filter_map(|s| match s {
+                Statement::Call { command, args, .. } if command == "unset" => Some(args),
+                _ => None,
+            })
+            .flatten()
+            .map(String::as_str)
+            .collect();
+
+        for block in fu.cfg.blocks.values() {
+            let Some(Terminator::Branch {
+                condition,
+                span: Some(span),
+                ..
+            }) = &block.terminator
+            else {
+                continue;
+            };
+            let Some((var, negated)) = crate::expr_ast::existence_query_var(condition) else {
+                continue;
+            };
+            // Only fold simple local names. Array elements
+            // (`env(PATH)`) and namespaced / global vars (`::g`) may be
+            // populated by state outside this function's def-use view,
+            // so folding them to a constant risks a false positive.
+            if !var.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') || var.is_empty() {
+                continue;
+            }
+            let exists = if params.contains(var.as_str()) {
+                if unset.contains(var.as_str()) {
+                    continue;
+                }
+                true
+            } else if !defined.contains(&var) {
+                false
+            } else {
+                continue;
+            };
+            let value = exists ^ negated;
+            let cond = crate::expr_ast::expr_text(condition);
+            let message = if value {
+                format!("Condition '{cond}' is always true; the alternate branch is unreachable")
+            } else {
+                format!("Condition '{cond}' is always false; the alternate branch is unreachable")
+            };
+            self.result.diagnostics.push(super::types::Diagnostic {
+                code: "I230".to_string(),
+                span: *span,
                 message,
                 severity: Severity::Hint,
                 fixes: Vec::new(),
@@ -4858,6 +5065,125 @@ mod tests {
             !a.result.diagnostics.iter().any(|d| d.code == "W210"),
             "W210 must be suppressed via global-alias case; got {:?}",
             a.result.diagnostics,
+        );
+    }
+
+    // ── SYNC-MAY31-3: info exists / array exists ──────────────────
+
+    fn codes_for(src: &str) -> Vec<String> {
+        let mut a = Analyser::new();
+        a.emit_cfg_ssa_diagnostics(src);
+        a.result
+            .diagnostics
+            .iter()
+            .map(|d| d.code.clone())
+            .collect()
+    }
+
+    #[test]
+    fn info_exists_control_still_flags_w210() {
+        // Baseline: a plain read of an unset local flags W210.
+        assert!(codes_for("proc f {} { puts $u }").contains(&"W210".to_string()));
+    }
+
+    #[test]
+    fn info_exists_guard_narrows_read_in_then_arm() {
+        // SYNC-MAY31-3(narrowing): reads inside `if {[info exists X]}`
+        // are guarded — X provably exists there, so no W210.
+        let codes = codes_for("proc f {} { if {[info exists u]} { puts $u } }");
+        assert!(
+            !codes.contains(&"W210".to_string()),
+            "guarded read must not flag W210; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_read_outside_guard_still_flags_w210() {
+        // The narrowing is scoped to the guarded arm: a read after the
+        // `if` (not dominated by the guard) still flags W210.
+        let codes = codes_for("proc f {} { if {[info exists u]} { puts hi }\nputs $u }");
+        assert!(
+            codes.contains(&"W210".to_string()),
+            "read outside the guarded arm must still flag W210; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_negated_guard_narrows_false_arm() {
+        // SYNC-MAY31-3(narrowing): the false arm of `![info exists X]`
+        // is guarded.
+        let codes = codes_for("proc f {} { if {![info exists u]} { puts no } else { puts $u } }");
+        assert!(
+            !codes.contains(&"W210".to_string()),
+            "false-arm read of `![info exists X]` must not flag W210; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_query_word_not_read_before_set() {
+        // SYNC-MAY31-3(W210 suppression): the existence-query word is
+        // not a read-before-set — bare call and command-sub forms.
+        assert!(!codes_for("proc f {} { info exists u }").contains(&"W210".to_string()));
+        assert!(!codes_for("proc f {} { array exists u }").contains(&"W210".to_string()));
+        let codes = codes_for("proc f {} { set y [info exists u]; puts $y }");
+        assert!(
+            !codes.contains(&"W210".to_string()),
+            "`set y [info exists u]` must not flag W210 on u; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_folds_false_for_never_defined_local() {
+        // SYNC-MAY31-3(fold): a never-defined non-parameter never
+        // exists → predicate folds false → I230.
+        let codes = codes_for("proc f {a} { if {[info exists b]} { puts hi } }");
+        assert!(
+            codes.contains(&"I230".to_string()),
+            "`info exists` of a never-defined local should fold to I230; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_folds_true_for_parameter() {
+        // A parameter always exists → predicate folds true → I230.
+        let codes = codes_for("proc f {a} { if {[info exists a]} { puts hi } }");
+        assert!(
+            codes.contains(&"I230".to_string()),
+            "`info exists` of a parameter should fold to I230; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_does_not_fold_conditionally_set_var() {
+        // A var that is set on some path is not provably set/unset —
+        // no fold, no false I230.
+        let codes = codes_for(
+            "proc f {flag} { if {$flag} { set u 1 } ; if {[info exists u]} { puts $u } }",
+        );
+        assert!(
+            !codes.contains(&"I230".to_string()),
+            "conditionally-set var must not fold; got {codes:?}",
+        );
+    }
+
+    #[test]
+    fn info_exists_does_not_fold_namespaced_or_array() {
+        // Array elements / namespaced vars may be populated outside the
+        // function's view — never fold them.
+        assert!(
+            !codes_for("proc f {} { if {[info exists ::env(PATH)]} { puts hi } }")
+                .contains(&"I230".to_string())
+        );
+    }
+
+    #[test]
+    fn info_exists_does_not_fold_unset_parameter() {
+        // A parameter that is `unset` before the check can't be assumed
+        // to exist.
+        let codes = codes_for("proc f {a} { unset a; if {[info exists a]} { puts hi } }");
+        assert!(
+            !codes.contains(&"I230".to_string()),
+            "unset parameter must not fold true; got {codes:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -146,6 +146,28 @@ pub struct LoopNode {
     pub span: Span,
 }
 
+/// Metadata for a `switch -glob` / `switch -regexp` dispatch whose
+/// structured arm-dispatch blocks exist only for the analyser (SSA
+/// recovers the subject + arm-body reads). Glob/regexp matching is not
+/// string equality, so the bytecode backend must **not** walk the
+/// structured chain — it emits a generic `switch` invoke instead
+/// (matching tclsh's un-compiled approach for those modes) and skips
+/// the member blocks. Keyed by the entry dispatch block in
+/// [`Function::switch_dispatches`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwitchDispatch {
+    /// Match mode (`Glob` or `Regexp`; `Exact` is never recorded —
+    /// exact switches lower to a real `STR_EQ` jump table).
+    pub mode: crate::ir::SwitchMode,
+    /// Raw `switch` argument texts for the generic invoke fallback.
+    pub raw_args: Vec<String>,
+    /// Join block control reaches after the switch.
+    pub end_block: String,
+    /// All dispatch / arm-body / default blocks of this switch, which
+    /// codegen skips (the runtime invoke subsumes them).
+    pub member_blocks: Vec<String>,
+}
+
 /// A complete control-flow graph for a single procedure or top-level script.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
@@ -157,6 +179,9 @@ pub struct Function {
     pub blocks: HashMap<String, Block>,
     /// Loop metadata: exit block → loop info.
     pub loop_nodes: HashMap<String, LoopNode>,
+    /// Glob/regexp `switch` dispatch metadata: entry dispatch block →
+    /// generic-invoke fallback info (see [`SwitchDispatch`]).
+    pub switch_dispatches: HashMap<String, SwitchDispatch>,
 }
 
 impl Function {
@@ -171,6 +196,7 @@ impl Function {
             entry,
             blocks,
             loop_nodes: HashMap::new(),
+            switch_dispatches: HashMap::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -275,10 +275,18 @@ impl CfgBuilder {
 
     // ── switch ────────────────────────────────────────────────────
 
-    /// Flatten `Statement::Switch` into a chain of string-equality branches.
+    /// Flatten `Statement::Switch` into a chain of arm-dispatch branches.
     ///
-    /// Glob/regexp switches are emitted as opaque barriers (matching
-    /// tclsh's generic `invokeStk` codegen for those modes).
+    /// All three modes flow through the structured path so SSA recovers
+    /// the subject + arm-body variable reads. Exact arms branch on a
+    /// foldable `STR_EQ(subject, pattern)` (so the bytecode backend can
+    /// build a real jump table); glob/regexp arms branch on a
+    /// non-foldable `Raw(subject)` condition — string equality is the
+    /// wrong predicate for those modes, and a foldable condition would
+    /// let SCCP spuriously kill arms. Glob/regexp dispatches are also
+    /// recorded in [`crate::cfg::Function::switch_dispatches`] so codegen
+    /// emits a generic `switch` invoke instead of walking the chain
+    /// (matching tclsh's un-compiled approach for those modes).
     pub(super) fn lower_switch(&mut self, stmt: &Statement, block_name: &str) -> String {
         let Statement::Switch {
             span,
@@ -293,21 +301,6 @@ impl CfgBuilder {
         else {
             unreachable!("lower_switch called with non-Switch");
         };
-
-        // Glob/regexp → barrier.
-        if *mode != SwitchMode::Exact {
-            self.block_mut(block_name)
-                .statements
-                .push(Statement::Barrier {
-                    span: *span,
-                    reason: format!("switch -{}", mode.as_str()),
-                    command: "switch".into(),
-                    canonical_command: None,
-                    args: raw_args.clone(),
-                    tokens: None,
-                });
-            return block_name.to_owned();
-        }
 
         let end_block = self.new_block("switch_end");
         let default_block = self.new_block("switch_default");
@@ -336,20 +329,31 @@ impl CfgBuilder {
             })
             .collect();
 
-        // Chain of equality tests.
+        // Chain of arm-dispatch tests.
         let mut dispatch = block_name.to_owned();
         for (i, arm) in arms.iter().enumerate() {
             let next_dispatch = self.new_block("switch_next");
-            let cond = ExprNode::Binary {
-                op: BinOp::StrEq,
-                left: Box::new(ExprNode::Raw {
+            // Exact mode uses a foldable `STR_EQ(subject, pattern)` so
+            // the backend can build a jump table. Glob/regexp use a
+            // non-foldable `Raw(subject)`: it still reads the subject
+            // (SSA recovery) but never folds, so SCCP can't kill an arm
+            // on a string-equality fiction.
+            let cond = if *mode == SwitchMode::Exact {
+                ExprNode::Binary {
+                    op: BinOp::StrEq,
+                    left: Box::new(ExprNode::Raw {
+                        text: subject.clone(),
+                    }),
+                    right: Box::new(ExprNode::Literal {
+                        text: arm.pattern.clone(),
+                        start: 0,
+                        end: 0,
+                    }),
+                }
+            } else {
+                ExprNode::Raw {
                     text: subject.clone(),
-                }),
-                right: Box::new(ExprNode::Literal {
-                    text: arm.pattern.clone(),
-                    start: 0,
-                    end: 0,
-                }),
+                }
             };
             self.block_mut(&dispatch).terminator = Some(Terminator::Branch {
                 condition: cond,
@@ -389,7 +393,59 @@ impl CfgBuilder {
             self.ensure_goto(&default_block, &end_block, Some(*span));
         }
 
+        // Glob/regexp: record the dispatch so codegen emits a generic
+        // `switch` invoke and skips the structured (analyser-only)
+        // blocks. Members = everything reachable from the entry's
+        // successors, stopping at the join block.
+        if *mode != SwitchMode::Exact {
+            let member_blocks = self.collect_switch_members(block_name, &end_block);
+            self.switch_dispatches.insert(
+                block_name.to_owned(),
+                crate::cfg::SwitchDispatch {
+                    mode: *mode,
+                    raw_args: raw_args.clone(),
+                    end_block: end_block.clone(),
+                    member_blocks,
+                },
+            );
+        }
+
         end_block
+    }
+
+    /// Collect every block belonging to a glob/regexp switch: a BFS
+    /// from the entry dispatch block's successors, stopping at (and
+    /// excluding) the join block `end_block`. The entry block itself is
+    /// excluded — codegen still emits its preceding statements and only
+    /// intercepts its terminator.
+    fn collect_switch_members(&self, entry: &str, end_block: &str) -> Vec<String> {
+        use std::collections::HashSet;
+        let mut members = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        seen.insert(end_block.to_owned());
+        seen.insert(entry.to_owned());
+        let mut queue: Vec<String> = self
+            .blocks
+            .get(entry)
+            .and_then(|b| b.terminator.as_ref())
+            .map(|t| t.successors().iter().map(|s| (*s).to_owned()).collect())
+            .unwrap_or_default();
+        while let Some(name) = queue.pop() {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            members.push(name.clone());
+            if let Some(block) = self.blocks.get(&name) {
+                if let Some(term) = &block.terminator {
+                    for succ in term.successors() {
+                        if !seen.contains(succ) {
+                            queue.push(succ.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        members
     }
 
     // ── try ───────────────────────────────────────────────────────
@@ -624,26 +680,78 @@ mod tests {
         assert!(matches!(entry.terminator, Some(Terminator::Branch { .. })));
     }
 
-    #[test]
-    fn switch_glob_emits_barrier() {
-        let script = Script::from_statements(vec![Statement::Switch {
-            span: Span::new(0, 30),
+    /// Build a one-arm switch (body reads `$y`) in the given mode.
+    fn glob_regexp_switch(mode: SwitchMode) -> Script {
+        Script::from_statements(vec![Statement::Switch {
+            span: Span::new(0, 40),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),
-            arms: vec![],
+            arms: vec![SwitchArm {
+                pattern: "a*".into(),
+                pattern_span: Span::new(11, 13),
+                body: Some(Script::from_statements(vec![Statement::Call {
+                    span: Span::new(15, 22),
+                    command: "puts".into(),
+                    canonical_command: None,
+                    args: vec!["$y".into()],
+                    defs: vec![],
+                    reads: vec!["y".into()],
+                    reads_own_defs: false,
+                    safe_on_uninit: false,
+                    tokens: None,
+                    foreach_groups: None,
+                }])),
+                body_span: Some(Span::new(14, 23)),
+                fallthrough: false,
+            }],
             default_body: None,
             default_span: None,
-            mode: SwitchMode::Glob,
+            mode,
             nocase: false,
-            raw_args: vec!["$x".into(), "a".into(), "{}".into()],
-        }]);
+            raw_args: vec!["$x".into(), "a*".into(), "{puts $y}".into()],
+        }])
+    }
 
-        let func = build_cfg_function("::test", &script, true);
+    #[test]
+    fn switch_glob_creates_branches() {
+        let func = build_cfg_function("::test", &glob_regexp_switch(SwitchMode::Glob), true);
+        // No barrier — the entry dispatches via a Branch like exact mode.
         let entry = &func.blocks[&func.entry];
-        assert!(entry.statements.iter().any(|s| matches!(
-            s,
-            Statement::Barrier { reason, .. } if reason.contains("glob")
-        )));
+        assert!(
+            !entry
+                .statements
+                .iter()
+                .any(|s| matches!(s, Statement::Barrier { .. })),
+            "glob switch should no longer lower to a barrier"
+        );
+        assert!(matches!(entry.terminator, Some(Terminator::Branch { .. })));
+        // The dispatch is recorded for the codegen invoke fallback.
+        let sd = func
+            .switch_dispatches
+            .get(&func.entry)
+            .expect("glob dispatch should be recorded");
+        assert_eq!(sd.mode, SwitchMode::Glob);
+        assert_eq!(sd.raw_args, vec!["$x", "a*", "{puts $y}"]);
+        // Member blocks (arm body / dispatch / default) are recorded so
+        // codegen can skip them, but the join block is not a member.
+        assert!(!sd.member_blocks.contains(&sd.end_block));
+        assert!(!sd.member_blocks.contains(&func.entry));
+        assert!(!sd.member_blocks.is_empty());
+    }
+
+    #[test]
+    fn switch_regexp_creates_branches() {
+        let func = build_cfg_function("::test", &glob_regexp_switch(SwitchMode::Regexp), true);
+        let entry = &func.blocks[&func.entry];
+        assert!(matches!(entry.terminator, Some(Terminator::Branch { .. })));
+        let sd = func
+            .switch_dispatches
+            .get(&func.entry)
+            .expect("regexp dispatch should be recorded");
+        assert_eq!(sd.mode, SwitchMode::Regexp);
+        // Exact switches are never recorded (they keep the real jump table).
+        let exact = build_cfg_function("::test", &glob_regexp_switch(SwitchMode::Exact), true);
+        assert!(exact.switch_dispatches.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -34,6 +34,9 @@ pub(crate) struct CfgBuilder {
     counter: u32,
     blocks: HashMap<String, MutableBlock>,
     loop_nodes: HashMap<String, LoopNode>,
+    /// Glob/regexp `switch` dispatch metadata accumulated during
+    /// lowering; frozen into [`Function::switch_dispatches`].
+    switch_dispatches: HashMap<String, crate::cfg::SwitchDispatch>,
     inline_loops: bool,
     /// Map from command name to upvar summary, used to pre-populate
     /// caller-side `defs` on calls to procs that use `upvar`.  Empty
@@ -62,6 +65,7 @@ impl CfgBuilder {
             counter: 0,
             blocks: HashMap::new(),
             loop_nodes: HashMap::new(),
+            switch_dispatches: HashMap::new(),
             inline_loops,
             upvar_procs,
             proc_params,
@@ -278,12 +282,14 @@ impl CfgBuilder {
             .collect();
 
         let loop_nodes = std::mem::take(&mut self.loop_nodes);
+        let switch_dispatches = std::mem::take(&mut self.switch_dispatches);
 
         Function {
             name: name.to_owned(),
             entry,
             blocks: frozen,
             loop_nodes,
+            switch_dispatches,
         }
     }
 

--- a/rust/tcl-compiler/src/codegen/emitter/generate.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/generate.rs
@@ -386,6 +386,34 @@ pub fn generate(ctx: &mut CodegenCtx, cfg: &CfgFunction, proc_defs: &[IrProcedur
             ctx.emit_stmt_with_start_cmd(stmt, None, None);
         }
 
+        // Glob/regexp switch dispatch: the structured arm blocks exist
+        // only for the analyser. Emit a generic `switch` invoke (as the
+        // old barrier did), jump to the join block, and skip the
+        // member blocks — the runtime invoke subsumes them.
+        if let Some(sd) = cfg.switch_dispatches.get(bname) {
+            let next_block = block_order.get(i + 1).map(String::as_str);
+            let invoke = Statement::Barrier {
+                span: tcl_lexer::Span::new(0, 0),
+                reason: format!("switch -{}", sd.mode.as_str()),
+                command: "switch".into(),
+                canonical_command: None,
+                args: sd.raw_args.clone(),
+                tokens: None,
+            };
+            ctx.emit_stmt_with_start_cmd(&invoke, None, None);
+            if next_block != Some(sd.end_block.as_str()) {
+                ctx.emit_comment(
+                    Op::JUMP4,
+                    vec![Operand::Label(sd.end_block.clone())],
+                    &format!("-> {}", sd.end_block),
+                );
+            }
+            for member in &sd.member_blocks {
+                state.skip_blocks.insert(member.clone());
+            }
+            continue;
+        }
+
         // If/switch arms: keep last statement value on TOS instead of
         // popping — the value is the arm's result.
         if let Some(Terminator::Goto { target, .. }) = &blk.terminator {

--- a/rust/tcl-compiler/src/codegen/emitter/generate.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/generate.rs
@@ -401,6 +401,21 @@ pub fn generate(ctx: &mut CodegenCtx, cfg: &CfgFunction, proc_defs: &[IrProcedur
                 tokens: None,
             };
             ctx.emit_stmt_with_start_cmd(&invoke, None, None);
+            // The invoke's result is the switch's value — it must reach
+            // `switch_end` on TOS like an exact arm's result, so the
+            // value-join at the join block can keep it (proc return /
+            // nested value) or pop it (statement context). Drop the
+            // statement-level POP that `emit_call` appended; without
+            // this the join's own pop / proc-return underflows the
+            // stack (a glob/regexp switch as a proc's last command, or
+            // followed by another statement).
+            if ctx
+                .instructions
+                .last()
+                .is_some_and(|inst| inst.op == Op::POP)
+            {
+                ctx.instructions.pop();
+            }
             if next_block != Some(sd.end_block.as_str()) {
                 ctx.emit_comment(
                     Op::JUMP4,

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -354,6 +354,31 @@ mod tests {
     }
 
     #[test]
+    fn switch_glob_arm_body_read_counts_as_param_use() {
+        // SYNC-MAY31-2: a `switch -glob`/`-regexp` arm body is now a
+        // real analysed CFG region (it used to vanish into a barrier).
+        // A parameter referenced *only* inside a glob-arm body therefore
+        // has a live def-use chain — the precise path behind W214.
+        // Multi-arg arm form (the single-braced-body form is a separate,
+        // pre-existing lowering gap affecting every mode equally).
+        for (mode, pat) in [("-glob", "a*"), ("-regexp", "a.*")] {
+            let src = format!("proc p {{val}} {{ switch {mode} -- $col {pat} {{puts $val}} }}");
+            let cu = CompilationUnit::build_for(&src, &registry(), false);
+            let fu = cu.function("::p").expect("proc ::p should exist");
+            let val_live = fu
+                .def_use
+                .chains
+                .iter()
+                .any(|(k, c)| k.0 == "val" && !c.is_dead());
+            assert!(
+                val_live,
+                "{mode} arm-body read `$val` should register a live use; chains: {:?}",
+                fu.def_use.chains.keys().collect::<Vec<_>>(),
+            );
+        }
+    }
+
+    #[test]
     fn return_type_infers_int_literal() {
         let cu = CompilationUnit::build_for("proc f {} { return 1 }", &registry(), false);
         let fu = cu.function("::f").expect("proc ::f");

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -84,10 +84,25 @@ impl FunctionUnit {
     /// Runs in order: SSA → def-use → SCCP → type-propagation →
     /// rendered-properties → taint-propagation.
     #[must_use]
-    pub fn build(name: impl Into<String>, cfg: CfgFunction, registry: &CommandRegistry) -> Self {
+    pub fn build(
+        name: impl Into<String>,
+        cfg: CfgFunction,
+        params: &[String],
+        registry: &CommandRegistry,
+    ) -> Self {
         let ssa = build_ssa(&cfg, registry);
         let def_use = build_def_use_chains(&ssa, Some(&cfg));
-        let sccp = sccp(&cfg, &ssa, None);
+        let mut sccp = sccp(&cfg, &ssa, None);
+        // SYNC-MAY31-3: surface `[info exists X]` / `[array exists X]`
+        // folds (parameter → exists, never-defined non-param → absent)
+        // as constant branches so the optimiser's O101 fold / DCE sees
+        // them. The analyser's I230 uses the same fold via
+        // `existence_constant_branches`; the SCCP pass proper has no
+        // parameter/existence facts to fold them itself.
+        let param_set: std::collections::HashSet<&str> =
+            params.iter().map(String::as_str).collect();
+        sccp.constant_branches
+            .extend(crate::sccp::existence_constant_branches(&cfg, &param_set));
         let types = propagate_types(&cfg, &ssa, &sccp, registry);
         let return_type =
             crate::type_infer::infer_function_return_type(&cfg, &sccp, &types, registry);
@@ -177,12 +192,16 @@ impl CompilationUnit {
         // that splices the body inline.
         crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
         let cfg_module = build_cfg(&ir_module, defer_top_level);
-        let top_level = FunctionUnit::build("::top", cfg_module.top_level.clone(), registry);
+        let top_level = FunctionUnit::build("::top", cfg_module.top_level.clone(), &[], registry);
         let mut procedures: HashMap<String, FunctionUnit> = HashMap::new();
         for (qname, cfg) in &cfg_module.procedures {
+            let params = ir_module
+                .procedures
+                .get(qname)
+                .map_or(&[][..], |p| p.params.as_slice());
             procedures.insert(
                 qname.clone(),
-                FunctionUnit::build(qname, cfg.clone(), registry),
+                FunctionUnit::build(qname, cfg.clone(), params, registry),
             );
         }
         // **C41d7.** Build the cross-event scope from the

--- a/rust/tcl-compiler/src/expr_ast.rs
+++ b/rust/tcl-compiler/src/expr_ast.rs
@@ -535,6 +535,41 @@ pub fn expr_text(node: &ExprNode) -> String {
     }
 }
 
+/// Recognise an `[info exists X]` / `[array exists X]` existence-query
+/// condition, returning `(variable, negated)` where `negated` is true
+/// for `![info exists X]`.  Used by SYNC-MAY31-3 to inject guarded-region
+/// read narrowing (`cfg_lower::lower_if`), suppress the existence-query
+/// word's W210 read, and fold the predicate to a constant (analyser I230).
+///
+/// Only the simple two-/three-word command-substitution form is matched
+/// (e.g. `[info exists name]`); anything embedded in a larger expression
+/// returns `None`.
+#[must_use]
+pub fn existence_query_var(node: &ExprNode) -> Option<(String, bool)> {
+    match node {
+        ExprNode::Unary {
+            op: UnaryOp::Not,
+            operand,
+        } => existence_query_var(operand).map(|(v, neg)| (v, !neg)),
+        ExprNode::Command { text, .. } => existence_query_in_text(text).map(|v| (v, false)),
+        _ => None,
+    }
+}
+
+/// Parse a bracketed command-substitution `text` (e.g. `"[info exists
+/// x]"`) and return the queried variable when it is exactly
+/// `info exists NAME` or `array exists NAME`.
+#[must_use]
+pub fn existence_query_in_text(text: &str) -> Option<String> {
+    let inner = text.strip_prefix('[')?.strip_suffix(']')?;
+    let words: Vec<&str> = inner.split_whitespace().collect();
+    if words.len() == 3 && matches!(words[0], "info" | "array") && words[1] == "exists" {
+        Some(words[2].to_owned())
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -536,7 +536,28 @@ impl Lowerer<'_> {
             }
 
             let body_tok = pair.body_arg_idx.and_then(|idx| arg_tokens.get(idx));
-            let body = self.lower_body_from_tok(&pair.body_text, body_tok, namespace);
+            let body = if let Some(tok) = body_tok {
+                self.lower_body_from_tok(&pair.body_text, Some(tok), namespace)
+            } else if let Some(bspan) = pair.body_span {
+                // SYNC-JUN-switch-braced-body: the single-braced form
+                // (`switch $x { a {body} … }`) has no arg token — the
+                // body tokens live inside the braced word. Lower from
+                // the body's source span instead of returning an empty
+                // script. `body_span` is brace-inclusive (the element
+                // parser extends it over the closing delimiter), so the
+                // content starts after any leading `{` / `"`; the
+                // even-sized delimiter difference recovers that shift
+                // and matches the offset `lower_body_from_tok` would
+                // have computed from a token's `content_offset`.
+                let span_len = (bspan.end().saturating_sub(bspan.start())) as usize;
+                let skip = span_len.saturating_sub(pair.body_text.len()) / 2;
+                let base = bspan
+                    .start()
+                    .saturating_add(u32::try_from(skip).unwrap_or(0));
+                self.lower_body(&pair.body_text, base, namespace)
+            } else {
+                crate::ir::Script::new()
+            };
 
             if pair.pattern == "default" && pair_idx == pairs.len() - 1 {
                 default_body = Some(body);
@@ -768,13 +789,40 @@ mod tests {
 
     #[test]
     fn switch_exact() {
-        let _m = lower_to_ir("switch $x { a {puts a} b {puts b} }", &reg());
-        // Single braced body may not be fully parsed yet, but multi-arg works:
-        let m2 = lower_to_ir("switch $x a {puts a} b {puts b}", &reg());
-        assert!(matches!(
-            &m2.top_level.statements[0],
-            Statement::Switch { mode, .. } if *mode == SwitchMode::Exact
-        ));
+        // Both forms lower to a structured Switch; the multi-arg form
+        // and the single-braced form must agree on shape.
+        for src in [
+            "switch $x { a {puts a} b {puts b} }",
+            "switch $x a {puts a} b {puts b}",
+        ] {
+            let m = lower_to_ir(src, &reg());
+            assert!(
+                matches!(
+                    &m.top_level.statements[0],
+                    Statement::Switch { mode, .. } if *mode == SwitchMode::Exact
+                ),
+                "expected exact Switch for {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn switch_single_braced_body_is_lowered() {
+        // SYNC-JUN-switch-braced-body: the single-braced arm form
+        // `switch $x { a {body} … }` must lower each arm body into real
+        // IR statements (it used to produce an empty Script).
+        let m = lower_to_ir("switch $x { a {puts hi} b {set y 1} }", &reg());
+        let Statement::Switch { arms, .. } = &m.top_level.statements[0] else {
+            panic!("expected Switch");
+        };
+        assert_eq!(arms.len(), 2);
+        for arm in arms {
+            let body = arm.body.as_ref().expect("arm body");
+            assert!(
+                !body.statements.is_empty(),
+                "single-braced arm body should lower to non-empty IR, got {body:?}",
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -114,6 +114,33 @@ mod tests {
     }
 
     #[test]
+    fn info_exists_fold_surfaces_o101() {
+        // SYNC-MAY31-3 DCE wiring: a provably-constant `info exists`
+        // guard (never-defined non-param folds false; a parameter folds
+        // true) surfaces as an O101 constant-branch fold.
+        let never = optimise(
+            "proc f {a} { if {[info exists b]} { puts hi } }",
+            &registry(),
+        );
+        assert!(
+            never
+                .iter()
+                .any(|o| o.code == "O101" && o.replacement == "0"),
+            "never-defined `info exists` should fold to 0, got {never:?}",
+        );
+        let param = optimise(
+            "proc f {a} { if {[info exists a]} { puts hi } }",
+            &registry(),
+        );
+        assert!(
+            param
+                .iter()
+                .any(|o| o.code == "O101" && o.replacement == "1"),
+            "parameter `info exists` should fold to 1, got {param:?}",
+        );
+    }
+
+    #[test]
     fn output_is_sorted_by_span_start() {
         let opts = optimise("set x 5\nif {1} { puts $x } else { puts 0 }", &registry());
         let mut prev = 0u32;

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -446,6 +446,110 @@ fn collect_constant_branches(
     constant_branches
 }
 
+/// SYNC-MAY31-3: fold `[info exists X]` / `[array exists X]`
+/// if-conditions into [`ConstantBranch`] entries for the two
+/// false-positive-free cases — a parameter always exists (`true`); a
+/// never-defined non-parameter never exists (`false`).  `![info exists
+/// X]` flips the value.
+///
+/// SCCP itself can't fold these (the predicate is an opaque
+/// `ExprNode::Command`, and SCCP has neither parameter nor existence
+/// facts), so this runs as a post-pass with the proc's `params`.  The
+/// result feeds both the analyser's I230 (constant condition) and the
+/// optimiser's O101 (constant-branch fold / DCE).  Only simple local
+/// names are folded, and only in functions free of opaque barriers (an
+/// unknown command could `unset` or `upvar`-define the variable).
+#[must_use]
+pub fn existence_constant_branches(
+    cfg: &CfgFunction,
+    params: &HashSet<&str>,
+) -> Vec<ConstantBranch> {
+    let mut out = Vec::new();
+    if cfg.blocks.values().any(|b| {
+        b.statements
+            .iter()
+            .any(|s| matches!(s, Statement::Barrier { .. }))
+    }) {
+        return out;
+    }
+    // Vars defined / unset anywhere in the function.
+    let mut defined: HashSet<String> = HashSet::new();
+    let mut unset: HashSet<&str> = HashSet::new();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            match stmt {
+                Statement::AssignConst { name, .. }
+                | Statement::AssignExpr { name, .. }
+                | Statement::AssignValue { name, .. }
+                | Statement::Incr { name, .. } => {
+                    let n = crate::naming::normalise_var_name(name);
+                    if !n.is_empty() {
+                        defined.insert(n.to_string());
+                    }
+                }
+                Statement::Call {
+                    command,
+                    args,
+                    defs,
+                    ..
+                } => {
+                    for d in defs {
+                        defined.insert(d.clone());
+                    }
+                    if command == "unset" {
+                        unset.extend(args.iter().map(String::as_str));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    for block in cfg.blocks.values() {
+        let Some(Terminator::Branch {
+            condition,
+            true_target,
+            false_target,
+            span: Some(span),
+        }) = &block.terminator
+        else {
+            continue;
+        };
+        let Some((var, negated)) = crate::expr_ast::existence_query_var(condition) else {
+            continue;
+        };
+        // Array elements / namespaced globals may be populated outside
+        // the function's view — only fold simple local names.
+        if var.is_empty() || !var.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+            continue;
+        }
+        let exists = if params.contains(var.as_str()) {
+            if unset.contains(var.as_str()) {
+                continue;
+            }
+            true
+        } else if !defined.contains(&var) {
+            false
+        } else {
+            continue;
+        };
+        let value = exists ^ negated;
+        let (taken, not_taken) = if value {
+            (true_target.clone(), false_target.clone())
+        } else {
+            (false_target.clone(), true_target.clone())
+        };
+        out.push(ConstantBranch {
+            block: block.name.clone(),
+            span: Some(*span),
+            condition: crate::expr_ast::expr_text(condition),
+            value,
+            taken_target: taken,
+            not_taken_target: not_taken,
+        });
+    }
+    out
+}
+
 /// Evaluate the lattice value produced by an SSA statement's
 /// defs.
 ///

--- a/rust/tcl-compiler/tests/codegen_integration.rs
+++ b/rust/tcl-compiler/tests/codegen_integration.rs
@@ -350,6 +350,67 @@ fn switch_dispatch_emits_jump_table() {
 }
 
 #[test]
+fn switch_glob_emits_generic_invoke_not_jump_table() {
+    use tcl_compiler::cfg_builder::build_cfg_function;
+    use tcl_compiler::ir::{SwitchArm, SwitchMode};
+
+    let arm = |pat: &str| SwitchArm {
+        pattern: pat.into(),
+        pattern_span: sp(),
+        body: Some(Script::from_statements(vec![Statement::AssignConst {
+            span: sp(),
+            name: "r".into(),
+            value: "1".into(),
+        }])),
+        body_span: Some(sp()),
+        fallthrough: false,
+    };
+    let make = |mode: SwitchMode| {
+        Script::from_statements(vec![Statement::Switch {
+            span: sp(),
+            subject: "$x".into(),
+            subject_span: sp(),
+            arms: vec![arm("a*"), arm("b*")],
+            default_body: None,
+            default_span: None,
+            mode,
+            nocase: false,
+            raw_args: vec!["$x".into(), "a* {set r 1} b* {set r 1}".into()],
+        }])
+    };
+    let registry = CommandRegistry::build_default();
+
+    // Glob: generic `switch` invoke, never a jump table (glob patterns
+    // are not exact string equality).
+    let glob = build_cfg_function("::top", &make(SwitchMode::Glob), true);
+    let ops: Vec<Op> = codegen_function(&glob, &[], false, &registry)
+        .instructions
+        .iter()
+        .map(|i| i.op)
+        .collect();
+    assert!(
+        !ops.contains(&Op::JUMP_TABLE),
+        "glob switch must not emit a jump table, got {ops:?}"
+    );
+    assert!(
+        ops.contains(&Op::INVOKE_STK1) || ops.contains(&Op::INVOKE_STK4),
+        "glob switch should emit a generic invoke, got {ops:?}"
+    );
+
+    // Exact still compiles to a real jump table.
+    let exact = build_cfg_function("::top", &make(SwitchMode::Exact), true);
+    let exact_ops: Vec<Op> = codegen_function(&exact, &[], false, &registry)
+        .instructions
+        .iter()
+        .map(|i| i.op)
+        .collect();
+    assert!(
+        exact_ops.contains(&Op::JUMP_TABLE),
+        "exact switch should still emit a jump table, got {exact_ops:?}"
+    );
+}
+
+#[test]
 fn foreach_emits_native_opcodes() {
     let mut cfg = CfgFunction::new("::top", "entry_0");
     cfg.blocks

--- a/rust/tcl-compiler/tests/codegen_integration.rs
+++ b/rust/tcl-compiler/tests/codegen_integration.rs
@@ -350,6 +350,33 @@ fn switch_dispatch_emits_jump_table() {
 }
 
 #[test]
+fn switch_glob_as_proc_tail_keeps_result_on_stack() {
+    // Regression (PR #514 review): a glob/regexp `switch` as a proc's
+    // last command must leave the invoke result on TOS for the proc
+    // return — emitting a statement-level POP underflows the stack.
+    use tcl_compiler::cfg_builder::build_cfg;
+    use tcl_compiler::lowering::lower_to_ir;
+
+    let registry = CommandRegistry::build_default();
+    let ir = lower_to_ir("proc f {x} { switch -glob -- $x a* {set r 1} }", &registry);
+    let cfg = build_cfg(&ir, false);
+    let asm = codegen_module(&cfg, &ir, &registry);
+    let f = asm.procedures.get("::f").expect("proc ::f");
+    let ops: Vec<Op> = f.instructions.iter().map(|i| i.op).collect();
+    // The arm bodies are subsumed by the runtime invoke, so the only
+    // command is the `switch` invoke. Its result flows straight to the
+    // proc return — there must be no POP dropping it.
+    assert!(
+        ops.contains(&Op::INVOKE_STK1) || ops.contains(&Op::INVOKE_STK4),
+        "expected a generic switch invoke, got {ops:?}",
+    );
+    assert!(
+        !ops.contains(&Op::POP),
+        "glob switch as proc tail must not POP its result, got {ops:?}",
+    );
+}
+
+#[test]
 fn switch_glob_emits_generic_invoke_not_jump_table() {
     use tcl_compiler::cfg_builder::build_cfg_function;
     use tcl_compiler::ir::{SwitchArm, SwitchMode};


### PR DESCRIPTION
## Summary

Implements two compiler recovery features from the main branch:

1. **SYNC-MAY31-2**: Restructure `switch -glob` / `switch -regexp` lowering to build analyser-visible CFG blocks for arm bodies (instead of emitting a barrier), enabling SSA/def-use recovery of subject and arm-body variable reads. Codegen still emits a generic `switch` invoke for glob/regexp modes (via new `SwitchDispatch` metadata) to match tclsh's un-compiled approach, while exact-mode switches retain their real jump table.

2. **SYNC-MAY31-3**: Add W210 suppression and guarded-region read narrowing for `[info exists X]` / `[array exists X]` queries, plus constant-folding of these predicates to I230 hints. The existence-query word itself is not counted as a read, and reads of a variable in blocks dominated by a guard condition are exempted from W210.

## Changes

### `cfg_builder/cfg_lower.rs`
- Removed mode-based barrier short-circuit in `lower_switch`; all three modes now build structured arm-dispatch + arm-body + default blocks
- Exact arms use foldable `STR_EQ(subject, pattern)` for jump-table codegen
- Glob/regexp arms use non-foldable `ExprNode::Raw { text: subject }` to prevent spurious SCCP arm elimination
- Added `collect_switch_members` to identify all blocks belonging to a glob/regexp switch for codegen to skip
- Updated tests: `switch_glob_creates_branches`, `switch_regexp_creates_branches`

### `cfg.rs`
- Added `SwitchDispatch` struct to record glob/regexp switch metadata (mode, raw args, end block, member blocks)
- Added `switch_dispatches` map to `Function` to track these dispatches by entry block

### `cfg_builder/mod.rs`
- Added `switch_dispatches` field to `CfgBuilder` to accumulate dispatch metadata during lowering

### `expr_ast.rs`
- Added `existence_query_var(node)` to recognize `[info exists X]` / `[array exists X]` conditions (including negated forms)
- Added `existence_query_in_text(text)` to parse bracketed command-substitution text for existence queries

### `analyser/diagnostics.rs`
- Added `existence_query_vars(stmt)` to identify variables queried for existence in a statement (bare call and command-sub forms)
- Added `collect_existence_guards(fu)` to map `(var, guard_block)` pairs from branch conditions
- Added `existence_exempt(stmt_opt, var, exists_guards, ssa, use_block)` to check if a read is exempt from W210
- Added `block_dominated_by(ssa, block, dom)` to walk the SSA immediate dominator chain
- Modified `emit_read_before_set_diagnostics` to skip existence-query words and guarded reads
- Added `emit_existence_constant_branch_diagnostics(fu, ir_proc)` to fold `[info exists X]` predicates to I230 when:
  - Variable is a parameter (always exists → true)
  - Variable is never defined and not a parameter (never exists → false)
  - Gated on barrier-free functions and skipping `unset` params, array elements, and namespaced/global names
- Added comprehensive test suite: `info_exists_*` cluster covering narrowing, suppression, and folding

### `codegen/emitter/generate.rs`
- Added glob/regexp switch dispatch handling: emits generic `switch` invoke and skips member blocks via `skip_blocks`

### `compilation_unit.rs`
- Added `switch_glob_arm_body_read_counts_as_param_use` test verifying that glob/regexp arm-body reads are now properly tracked in def-use chains

### `codegen_integration.rs`
- Added `switch_glob_emits_generic_invoke_not_jump_table` test verifying glob switches emit `INVOKE_STK` instead of

https://claude.ai/code/session_01Lb3PXMWHiEnpcpF5Rouoq4