### PR TITLE
Add profile-guided branch reordering (PGO) for if/elseif and switch

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -1,9 +1,0 @@
-# tcl-lsp test-slow stamp — DO NOT EDIT BY HAND.
-# Written by 'make test-slow' on success; verified in CI via
-# 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
-# describe/head/date are informational (they change when this stamp is
-# committed, so they cannot be compared).
-describe=b853774-dirty
-head=b853774a32bf71aea846cd6618414ddb8083f2ab
-date=2026-06-01T10:58:05Z
-fingerprint=2f7f14a47a5be1b52088677e3afae8266426a86fd61ad6e25425aa3bbe808b9a

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -1,0 +1,9 @@
+# tcl-lsp test-slow stamp — DO NOT EDIT BY HAND.
+# Written by 'make test-slow' on success; verified in CI via
+# 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
+# describe/head/date are informational (they change when this stamp is
+# committed, so they cannot be compared).
+describe=c291590
+head=c2915900f94a999568b63343262e40c1d74c02e6
+date=2026-06-01T16:17:36Z
+fingerprint=ed4370570780a8ff0713039d579ee97da7b38ffc2065dc471f653b52da00d490

--- a/ai/claude/templates/irule_test.tcl.j2
+++ b/ai/claude/templates/irule_test.tcl.j2
@@ -22,6 +22,7 @@ source [file join $script_dir compat84.tcl]
 source [file join $script_dir state_layers.tcl]
 source [file join $script_dir tmm_shim.tcl]
 source [file join $script_dir expr_ops.tcl]
+source [file join $script_dir profiler.tcl]
 source [file join $script_dir command_mocks.tcl]
 if {[file exists [file join $script_dir _mock_stubs.tcl]]} {
     source [file join $script_dir _mock_stubs.tcl]

--- a/compiler/pgo/__init__.py
+++ b/compiler/pgo/__init__.py
@@ -1,0 +1,46 @@
+"""Profile-guided optimisation (PGO) — opt-in, off by default.
+
+This package consumes execution-profile data and produces optimisation
+*suggestions* from it.  It is deliberately decoupled from the standard
+optimiser pipeline (:mod:`compiler.optimiser`): nothing here runs unless a
+profile is explicitly supplied through these entry points, and the PGO
+suggestion codes (``P``-series) are registered as their own
+:class:`~shared.codes.CodeKind` so the optimisation profiles never enable
+them.
+
+Internal representation
+-----------------------
+:mod:`compiler.pgo.occurrence` is a normalised, lossless execution-event
+model that covers **both** C Tcl execution traces (``trace add execution``,
+``TCL_COMPILE_STATS`` opcode counts) and the F5 BIG-IP ``rule-profiler``
+occurrence log (events, rule/command VM boundaries, bytecode, var-mods,
+flow/VS context).  :class:`~compiler.pgo.profile_data.ProfileData` rolls a
+stream up into the counts the analyses query.
+
+Importers
+---------
+* :func:`compiler.pgo.trace_parser.parse_f5_log` — F5 rule-profiler logs.
+* :func:`compiler.pgo.tclsh_capture.capture_profile` — live tclsh tracing.
+
+Analyses
+--------
+* :func:`compiler.pgo.reorder.find_pgo_suggestions` — branch reordering.
+"""
+
+from __future__ import annotations
+
+from .occurrence import FlowContext, Occurrence, OccurrenceKind
+from .profile_data import ProfileData, merge
+from .reorder import REORDER_CODE, find_pgo_suggestions
+from .trace_parser import parse_f5_log
+
+__all__ = [
+    "FlowContext",
+    "Occurrence",
+    "OccurrenceKind",
+    "ProfileData",
+    "REORDER_CODE",
+    "find_pgo_suggestions",
+    "merge",
+    "parse_f5_log",
+]

--- a/compiler/pgo/occurrence.py
+++ b/compiler/pgo/occurrence.py
@@ -87,6 +87,10 @@ TCL_TRACE_OP_KINDS: dict[str, OccurrenceKind] = {
     "leavestep": OccurrenceKind.CMD_EXIT,
 }
 
+#: Inverse of :data:`RP_OCCURRENCE_KINDS` — :class:`OccurrenceKind` to the
+#: canonical ``RP_*`` string, for emitting rule-profiler-format logs.
+KIND_TO_RP: dict[OccurrenceKind, str] = {v: k for k, v in RP_OCCURRENCE_KINDS.items()}
+
 
 @dataclass(frozen=True, slots=True)
 class FlowContext:

--- a/compiler/pgo/occurrence.py
+++ b/compiler/pgo/occurrence.py
@@ -1,0 +1,131 @@
+"""Normalised execution-occurrence model — the lossless internal form.
+
+Profile-guided optimisation has to ingest two very different telemetry
+sources and represent both *without losing information*:
+
+* **C Tcl** — execution traces from ``trace add execution <cmd>
+  {enter|leave|enterstep|leavestep}`` (the portable, ship-anywhere hook,
+  backed by ``Tcl_CreateObjTrace``), plus, on a ``TCL_COMPILE_STATS``
+  build, per-opcode counts (``ByteCodeStats.instructionCount``) and the
+  ``evalstats`` dump.
+
+* **F5 iRules** — the BIG-IP ``rule-profiler`` occurrence log, whose lines
+  are ``timestamp,RP_<TYPE>,<vs>,<value>,<pid>,<flow>,<remote tuple>,
+  <local tuple>[,<depth>]`` covering event / rule / command / VM /
+  bytecode / variable-modification occurrences with flow context.
+
+Both are fundamentally **timestamped streams of typed occurrences**.  This
+module is that common denominator: :class:`OccurrenceKind` is the union of
+both vocabularies, :class:`FlowContext` carries the BIG-IP connection
+tuple (absent for plain Tcl), and :class:`Occurrence` is one sample.  The
+importers (:mod:`compiler.pgo.trace_parser`,
+:mod:`compiler.pgo.tclsh_capture`) translate into this form; the
+aggregated :class:`~compiler.pgo.profile_data.ProfileData` rolls a stream
+up into the counts the analyser queries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class OccurrenceKind(Enum):
+    """A normalised occurrence type spanning C Tcl traces and F5 rule-profiler.
+
+    The ``EVENT_*`` and ``*_VM_*`` kinds are iRule-only (no C Tcl analog);
+    ``CMD_ENTER`` / ``CMD_EXIT`` / ``VAR_MOD`` / ``BYTECODE`` map onto both
+    worlds.  Keeping the full union here means neither source is lossy.
+    """
+
+    # Event boundaries (iRules ``when`` handlers — no C Tcl analog).
+    EVENT_ENTRY = "event-entry"
+    EVENT_EXIT = "event-exit"
+    # Rule boundaries (iRules — a single ``ltm rule`` body).
+    RULE_ENTRY = "rule-entry"
+    RULE_EXIT = "rule-exit"
+    # Bytecode-VM boundaries (iRules — entering/leaving compiled bytecode).
+    RULE_VM_ENTRY = "rule-vm-entry"
+    RULE_VM_EXIT = "rule-vm-exit"
+    CMD_VM_ENTRY = "cmd-vm-entry"
+    CMD_VM_EXIT = "cmd-vm-exit"
+    # Command boundaries — F5 RP_CMD_ENTRY/EXIT, C Tcl trace enter/leave
+    # (and enterstep/leavestep, which carry the precise source line).
+    CMD_ENTER = "cmd-enter"
+    CMD_EXIT = "cmd-exit"
+    # A single executed bytecode instruction — F5 RP_CMD_BYTECODE, or a
+    # C Tcl ``instructionCount`` opcode.  ``value`` is the opcode name.
+    BYTECODE = "bytecode"
+    # A variable write — F5 RP_VAR_MOD, or a C Tcl ``trace add variable
+    # write``.  ``value`` is ``name`` or ``name=value``.
+    VAR_MOD = "var-mod"
+
+
+#: F5 rule-profiler occurrence-type string -> :class:`OccurrenceKind`.
+RP_OCCURRENCE_KINDS: dict[str, OccurrenceKind] = {
+    "RP_EVENT_ENTRY": OccurrenceKind.EVENT_ENTRY,
+    "RP_EVENT_EXIT": OccurrenceKind.EVENT_EXIT,
+    "RP_RULE_ENTRY": OccurrenceKind.RULE_ENTRY,
+    "RP_RULE_EXIT": OccurrenceKind.RULE_EXIT,
+    "RP_RULE_VM_ENTRY": OccurrenceKind.RULE_VM_ENTRY,
+    "RP_RULE_VM_EXIT": OccurrenceKind.RULE_VM_EXIT,
+    "RP_CMD_VM_ENTRY": OccurrenceKind.CMD_VM_ENTRY,
+    "RP_CMD_VM_EXIT": OccurrenceKind.CMD_VM_EXIT,
+    "RP_CMD_ENTRY": OccurrenceKind.CMD_ENTER,
+    "RP_CMD_EXIT": OccurrenceKind.CMD_EXIT,
+    "RP_CMD_BYTECODE": OccurrenceKind.BYTECODE,
+    "RP_VAR_MOD": OccurrenceKind.VAR_MOD,
+}
+
+#: C Tcl ``trace add execution`` operation -> :class:`OccurrenceKind`.
+#: ``enterstep`` / ``leavestep`` fire per command *inside* a traced body
+#: (the granularity we use to recover precise per-line counts).
+TCL_TRACE_OP_KINDS: dict[str, OccurrenceKind] = {
+    "enter": OccurrenceKind.CMD_ENTER,
+    "leave": OccurrenceKind.CMD_EXIT,
+    "enterstep": OccurrenceKind.CMD_ENTER,
+    "leavestep": OccurrenceKind.CMD_EXIT,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class FlowContext:
+    """BIG-IP connection context for an occurrence (all fields optional).
+
+    Empty/``None`` for plain-Tcl captures, fully populated from an F5
+    rule-profiler log (so per-virtual-server / per-flow slicing stays
+    possible without re-parsing the raw log).
+    """
+
+    virtual_server: str | None = None
+    process_id: int | None = None
+    flow_id: str | None = None
+    remote_addr: str | None = None
+    remote_port: int | None = None
+    remote_rd: int | None = None
+    local_addr: str | None = None
+    local_port: int | None = None
+    local_rd: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Occurrence:
+    """One normalised execution occurrence."""
+
+    kind: OccurrenceKind
+    #: Occurrence value — command/event/rule name, opcode, or ``var[=value]``.
+    value: str
+    #: TMM/wall-clock timestamp in microseconds, when known.
+    timestamp_us: int | None = None
+    #: 1-based source line, when known (tclsh ``enterstep`` capture).
+    line: int | None = None
+    #: Rule / bytecode nesting depth (F5 trailing field), when known.
+    depth: int | None = None
+    #: Connection context, when known.
+    context: FlowContext | None = None
+
+    @property
+    def var_name(self) -> str:
+        """For :attr:`OccurrenceKind.VAR_MOD`, the variable name (drops ``=value``)."""
+        head, _, _ = self.value.partition("=")
+        return head

--- a/compiler/pgo/profile_data.py
+++ b/compiler/pgo/profile_data.py
@@ -17,13 +17,26 @@ iRules telemetry:
 * ``var_mod_counts`` — variable name → write count.
 * ``bytecode_counts`` — opcode → execution count (unifies F5
   ``RP_CMD_BYTECODE`` with a C Tcl ``instructionCount`` dump).
-* ``command_time_us`` — command name → total microseconds, derived by
-  pairing ``CMD_ENTER``/``CMD_EXIT`` per flow (reserved for future
-  hot-path / hot-proc work; not used by the branch reorderer).
+* ``span_time_us`` — ``(occurrence-kind, value)`` → total microseconds,
+  derived by pairing every ``*_ENTRY`` / ``*_ENTER`` occurrence with its
+  matching exit.  This mirrors the iRule timing hierarchy from the
+  rule-profiler model (Event → Rule → Rule-VM → VM → Command): the
+  ``RULE_ENTRY``/``RULE_EXIT`` span is what correlates to BIG-IP's
+  existing per-rule CPU-cycle stats.  Convenience views
+  :attr:`command_time_us` / :attr:`rule_time_us` / :attr:`event_time_us`
+  slice it by level.
 
-Importers may either hand in an occurrence stream (use
-:meth:`ProfileData.from_occurrences`) or, for already-aggregated sources
-like a C Tcl ``evalstats`` dump, populate the count maps directly.
+Caveats baked into the importers' semantics (see the rule-profiler docs):
+
+* Core Tcl commands compiled to bytecode (``set``, ``append``, ``incr``,
+  ``expr`` …) never appear as ``CMD_ENTER`` occurrences — a variable write
+  surfaces as ``VAR_MOD`` instead.  Coarse command attribution therefore
+  only sees genuine (uncompiled / extension) commands.
+* Suspend/resume commands (``table``, ``after`` …) fire enter/exit more
+  than once for a single logical call, so their counts can over-report.
+* On multi-TMM systems one log interleaves occurrences from every TMM;
+  timing is paired per ``(process_id, flow_id)`` so spans don't cross
+  TMM/flow boundaries.
 """
 
 from __future__ import annotations
@@ -33,6 +46,17 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
 from .occurrence import Occurrence, OccurrenceKind
+
+#: ``*_ENTRY`` / ``*_ENTER`` occurrence kind -> its matching exit kind.
+#: Ordered top-down to match the iRule execution hierarchy.
+_SPAN_PAIRS: dict[OccurrenceKind, OccurrenceKind] = {
+    OccurrenceKind.EVENT_ENTRY: OccurrenceKind.EVENT_EXIT,
+    OccurrenceKind.RULE_ENTRY: OccurrenceKind.RULE_EXIT,
+    OccurrenceKind.RULE_VM_ENTRY: OccurrenceKind.RULE_VM_EXIT,
+    OccurrenceKind.CMD_VM_ENTRY: OccurrenceKind.CMD_VM_EXIT,
+    OccurrenceKind.CMD_ENTER: OccurrenceKind.CMD_EXIT,
+}
+_EXIT_TO_ENTER: dict[OccurrenceKind, OccurrenceKind] = {v: k for k, v in _SPAN_PAIRS.items()}
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,10 +75,40 @@ class ProfileData:
     var_mod_counts: Mapping[str, int] = field(default_factory=dict)
     #: bytecode opcode -> execution count.
     bytecode_counts: Mapping[str, int] = field(default_factory=dict)
-    #: command name -> total time in microseconds (enter/exit deltas).
-    command_time_us: Mapping[str, int] = field(default_factory=dict)
+    #: (occurrence-kind value, occurrence value) -> total microseconds.
+    span_time_us: Mapping[tuple[str, str], int] = field(default_factory=dict)
     #: Provenance tag — e.g. ``"f5-log"`` or ``"tclsh-trace"``.
     source: str = ""
+
+    # -- span-timing convenience views -------------------------------------
+
+    def _span_level(self, kind: OccurrenceKind) -> dict[str, int]:
+        return {
+            value: total
+            for (kind_value, value), total in self.span_time_us.items()
+            if kind_value == kind.value
+        }
+
+    @property
+    def command_time_us(self) -> dict[str, int]:
+        """command name -> total microseconds (CMD_ENTER → CMD_EXIT)."""
+        return self._span_level(OccurrenceKind.CMD_ENTER)
+
+    @property
+    def rule_time_us(self) -> dict[str, int]:
+        """rule name -> total microseconds (RULE_ENTRY → RULE_EXIT).
+
+        This is the span that correlates to BIG-IP's existing per-rule
+        min/max/avg CPU-cycle timing stats.
+        """
+        return self._span_level(OccurrenceKind.RULE_ENTRY)
+
+    @property
+    def event_time_us(self) -> dict[str, int]:
+        """event name -> total microseconds (EVENT_ENTRY → EVENT_EXIT)."""
+        return self._span_level(OccurrenceKind.EVENT_ENTRY)
+
+    # -- presence / lookups ------------------------------------------------
 
     @property
     def has_line_data(self) -> bool:
@@ -92,41 +146,56 @@ class ProfileData:
         *,
         source: str = "",
     ) -> ProfileData:
-        """Roll an occurrence stream up into aggregated counts + timing."""
+        """Roll an occurrence stream up into aggregated counts + span timing."""
         lines: Counter[int] = Counter()
         commands: Counter[str] = Counter()
         events: Counter[str] = Counter()
         var_mods: Counter[str] = Counter()
         bytecode: Counter[str] = Counter()
-        times: Counter[str] = Counter()
+        spans: Counter[tuple[str, str]] = Counter()
 
-        # Per-flow enter stacks for enter/exit timing pairing.  Keyed by
-        # flow id (None collapses to a single shared stack for plain Tcl).
-        open_calls: dict[str | None, list[tuple[str, int]]] = {}
+        # Per-(pid, flow) stacks of open spans, so enter/exit pairing never
+        # crosses a TMM or connection boundary (multi-TMM interleaving).
+        open_spans: dict[tuple[int | None, str | None], list[tuple[OccurrenceKind, str, int]]] = {}
+
+        def _flow_key(occ: Occurrence) -> tuple[int | None, str | None]:
+            ctx = occ.context
+            return (ctx.process_id, ctx.flow_id) if ctx else (None, None)
 
         for occ in occurrences:
             if occ.kind is OccurrenceKind.CMD_ENTER:
                 commands[occ.value] += 1
                 if occ.line is not None:
                     lines[occ.line] += 1
-                if occ.timestamp_us is not None:
-                    flow = occ.context.flow_id if occ.context else None
-                    open_calls.setdefault(flow, []).append((occ.value, occ.timestamp_us))
-            elif occ.kind is OccurrenceKind.CMD_EXIT:
-                if occ.timestamp_us is not None:
-                    flow = occ.context.flow_id if occ.context else None
-                    stack = open_calls.get(flow)
-                    if stack:
-                        name, started = stack.pop()
-                        delta = occ.timestamp_us - started
-                        if delta >= 0:
-                            times[name] += delta
             elif occ.kind is OccurrenceKind.EVENT_ENTRY:
                 events[occ.value] += 1
             elif occ.kind is OccurrenceKind.VAR_MOD:
                 var_mods[occ.var_name] += 1
             elif occ.kind is OccurrenceKind.BYTECODE:
                 bytecode[occ.value] += 1
+
+            # Span timing — independent of the counting above.
+            if occ.timestamp_us is None:
+                continue
+            if occ.kind in _SPAN_PAIRS:
+                open_spans.setdefault(_flow_key(occ), []).append(
+                    (occ.kind, occ.value, occ.timestamp_us)
+                )
+            elif occ.kind in _EXIT_TO_ENTER:
+                want = _EXIT_TO_ENTER[occ.kind]
+                stack = open_spans.get(_flow_key(occ))
+                if not stack:
+                    continue
+                # Match the most recent open span of the wanted enter-kind
+                # (handles interleaved levels without assuming strict LIFO).
+                for i in range(len(stack) - 1, -1, -1):
+                    enter_kind, value, started = stack[i]
+                    if enter_kind is want:
+                        del stack[i]
+                        delta = occ.timestamp_us - started
+                        if delta >= 0:
+                            spans[(enter_kind.value, value)] += delta
+                        break
 
         return cls(
             occurrences=tuple(occurrences),
@@ -135,7 +204,7 @@ class ProfileData:
             event_counts=dict(events),
             var_mod_counts=dict(var_mods),
             bytecode_counts=dict(bytecode),
-            command_time_us=dict(times),
+            span_time_us=dict(spans),
             source=source,
         )
 
@@ -152,7 +221,7 @@ def merge(profiles: Sequence[ProfileData], *, source: str | None = None) -> Prof
     events: Counter[str] = Counter()
     var_mods: Counter[str] = Counter()
     bytecode: Counter[str] = Counter()
-    times: Counter[str] = Counter()
+    spans: Counter[tuple[str, str]] = Counter()
     tags: list[str] = []
     for p in profiles:
         occurrences.extend(p.occurrences)
@@ -161,7 +230,7 @@ def merge(profiles: Sequence[ProfileData], *, source: str | None = None) -> Prof
         events.update(p.event_counts)
         var_mods.update(p.var_mod_counts)
         bytecode.update(p.bytecode_counts)
-        times.update(p.command_time_us)
+        spans.update(p.span_time_us)
         if p.source and p.source not in tags:
             tags.append(p.source)
     return ProfileData(
@@ -171,6 +240,6 @@ def merge(profiles: Sequence[ProfileData], *, source: str | None = None) -> Prof
         event_counts=dict(events),
         var_mod_counts=dict(var_mods),
         bytecode_counts=dict(bytecode),
-        command_time_us=dict(times),
+        span_time_us=dict(spans),
         source=source if source is not None else "+".join(tags),
     )

--- a/compiler/pgo/profile_data.py
+++ b/compiler/pgo/profile_data.py
@@ -1,0 +1,176 @@
+"""Aggregated profile data for profile-guided optimisation.
+
+:class:`ProfileData` is the query-friendly rollup of an
+:mod:`~compiler.pgo.occurrence` stream — the form the PGO analyser reads.
+It keeps the raw ``occurrences`` (lossless, so nothing the importers
+captured is thrown away) alongside derived counts and timing.
+
+Aggregation dimensions, chosen so the model covers **both** C Tcl and
+iRules telemetry:
+
+* ``line_counts`` — 1-based line → count.  **Precise**; from a tclsh
+  ``enterstep`` capture (``info frame`` lines) — the signal the branch
+  reorderer prefers.
+* ``command_counts`` — command name → count.  **Coarse**; the fallback
+  when only F5 command-level data is present.
+* ``event_counts`` — iRule event name → entry count.
+* ``var_mod_counts`` — variable name → write count.
+* ``bytecode_counts`` — opcode → execution count (unifies F5
+  ``RP_CMD_BYTECODE`` with a C Tcl ``instructionCount`` dump).
+* ``command_time_us`` — command name → total microseconds, derived by
+  pairing ``CMD_ENTER``/``CMD_EXIT`` per flow (reserved for future
+  hot-path / hot-proc work; not used by the branch reorderer).
+
+Importers may either hand in an occurrence stream (use
+:meth:`ProfileData.from_occurrences`) or, for already-aggregated sources
+like a C Tcl ``evalstats`` dump, populate the count maps directly.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+from .occurrence import Occurrence, OccurrenceKind
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileData:
+    """Aggregated execution counts for one profiled run (or merge of runs)."""
+
+    #: Raw normalised stream (lossless; may be empty for aggregate-only sources).
+    occurrences: tuple[Occurrence, ...] = ()
+    #: 1-based source line -> execution count (precise; tclsh capture).
+    line_counts: Mapping[int, int] = field(default_factory=dict)
+    #: command name -> invocation count (coarse; F5 log / C Tcl trace).
+    command_counts: Mapping[str, int] = field(default_factory=dict)
+    #: iRule event name -> entry count.
+    event_counts: Mapping[str, int] = field(default_factory=dict)
+    #: variable name -> write count.
+    var_mod_counts: Mapping[str, int] = field(default_factory=dict)
+    #: bytecode opcode -> execution count.
+    bytecode_counts: Mapping[str, int] = field(default_factory=dict)
+    #: command name -> total time in microseconds (enter/exit deltas).
+    command_time_us: Mapping[str, int] = field(default_factory=dict)
+    #: Provenance tag — e.g. ``"f5-log"`` or ``"tclsh-trace"``.
+    source: str = ""
+
+    @property
+    def has_line_data(self) -> bool:
+        """True when precise per-line counts are available."""
+        return bool(self.line_counts)
+
+    @property
+    def has_command_data(self) -> bool:
+        """True when coarse per-command counts are available."""
+        return bool(self.command_counts)
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no usable count signal of any grade is present."""
+        return not (
+            self.line_counts
+            or self.command_counts
+            or self.event_counts
+            or self.var_mod_counts
+            or self.bytecode_counts
+        )
+
+    def line_count(self, line: int) -> int:
+        """Execution count for *line* (1-based), or ``0`` if unseen."""
+        return self.line_counts.get(line, 0)
+
+    def command_count(self, name: str) -> int:
+        """Invocation count for command *name*, or ``0`` if unseen."""
+        return self.command_counts.get(name, 0)
+
+    @classmethod
+    def from_occurrences(
+        cls,
+        occurrences: Sequence[Occurrence],
+        *,
+        source: str = "",
+    ) -> ProfileData:
+        """Roll an occurrence stream up into aggregated counts + timing."""
+        lines: Counter[int] = Counter()
+        commands: Counter[str] = Counter()
+        events: Counter[str] = Counter()
+        var_mods: Counter[str] = Counter()
+        bytecode: Counter[str] = Counter()
+        times: Counter[str] = Counter()
+
+        # Per-flow enter stacks for enter/exit timing pairing.  Keyed by
+        # flow id (None collapses to a single shared stack for plain Tcl).
+        open_calls: dict[str | None, list[tuple[str, int]]] = {}
+
+        for occ in occurrences:
+            if occ.kind is OccurrenceKind.CMD_ENTER:
+                commands[occ.value] += 1
+                if occ.line is not None:
+                    lines[occ.line] += 1
+                if occ.timestamp_us is not None:
+                    flow = occ.context.flow_id if occ.context else None
+                    open_calls.setdefault(flow, []).append((occ.value, occ.timestamp_us))
+            elif occ.kind is OccurrenceKind.CMD_EXIT:
+                if occ.timestamp_us is not None:
+                    flow = occ.context.flow_id if occ.context else None
+                    stack = open_calls.get(flow)
+                    if stack:
+                        name, started = stack.pop()
+                        delta = occ.timestamp_us - started
+                        if delta >= 0:
+                            times[name] += delta
+            elif occ.kind is OccurrenceKind.EVENT_ENTRY:
+                events[occ.value] += 1
+            elif occ.kind is OccurrenceKind.VAR_MOD:
+                var_mods[occ.var_name] += 1
+            elif occ.kind is OccurrenceKind.BYTECODE:
+                bytecode[occ.value] += 1
+
+        return cls(
+            occurrences=tuple(occurrences),
+            line_counts=dict(lines),
+            command_counts=dict(commands),
+            event_counts=dict(events),
+            var_mod_counts=dict(var_mods),
+            bytecode_counts=dict(bytecode),
+            command_time_us=dict(times),
+            source=source,
+        )
+
+
+def merge(profiles: Sequence[ProfileData], *, source: str | None = None) -> ProfileData:
+    """Sum several :class:`ProfileData` into one (counts add elementwise).
+
+    Useful for combining captures across multiple runs or traffic samples.
+    The raw ``occurrences`` are concatenated so the merge stays lossless.
+    """
+    occurrences: list[Occurrence] = []
+    lines: Counter[int] = Counter()
+    commands: Counter[str] = Counter()
+    events: Counter[str] = Counter()
+    var_mods: Counter[str] = Counter()
+    bytecode: Counter[str] = Counter()
+    times: Counter[str] = Counter()
+    tags: list[str] = []
+    for p in profiles:
+        occurrences.extend(p.occurrences)
+        lines.update(p.line_counts)
+        commands.update(p.command_counts)
+        events.update(p.event_counts)
+        var_mods.update(p.var_mod_counts)
+        bytecode.update(p.bytecode_counts)
+        times.update(p.command_time_us)
+        if p.source and p.source not in tags:
+            tags.append(p.source)
+    return ProfileData(
+        occurrences=tuple(occurrences),
+        line_counts=dict(lines),
+        command_counts=dict(commands),
+        event_counts=dict(events),
+        var_mod_counts=dict(var_mods),
+        bytecode_counts=dict(bytecode),
+        command_time_us=dict(times),
+        source=source if source is not None else "+".join(tags),
+    )

--- a/compiler/pgo/reorder.py
+++ b/compiler/pgo/reorder.py
@@ -1,31 +1,30 @@
 """Profile-guided branch-reordering suggestions.
 
-This is the first profile-guided optimisation: given a
-:class:`~compiler.pgo.profile_data.ProfileData`, find ``if`` / ``elseif``
-**equality-dispatch chains** whose branches are not tested
-hottest-first, and suggest reordering them so the most-frequently-taken
-branch is checked first (fewer comparisons on the common path).
+Given a :class:`~compiler.pgo.profile_data.ProfileData`, find branch
+constructs that are not tested hottest-first and suggest reordering them so
+the most-frequently-taken branch is checked first (fewer comparisons on the
+common path).  Two constructs are handled, each only when reordering is
+provably behaviour-preserving:
 
-Safety — a chain is only ever touched when reordering is provably
-behaviour-preserving:
+**if / elseif equality-dispatch chains.**  Every clause condition must be
+``<subject> eq|==|equals <constant>`` with the **same** subject expression
+and **distinct** constants (so the clauses are mutually exclusive — exactly
+one matches regardless of order), and the subject must be
+**side-effect-free** (a variable read, or a command the side-effect
+registry classifies as non-writing), since reordering changes how many
+times it is evaluated.
 
-* Every clause condition is ``<subject> eq|==|equals <constant>`` with the
-  **same** subject expression and **distinct** constants, so the clauses
-  are mutually exclusive — exactly one can match regardless of order.
-* The subject is **side-effect-free** (a variable read, or a command the
-  side-effect registry classifies as non-writing), so evaluating it a
-  different number of times across the reordered tests changes nothing
-  observable.
+**exact-match switch arms.**  Reordering arms is *safer* than an if/elseif
+chain: the subject is evaluated exactly once, so no purity requirement
+applies.  Only ``-exact`` switches with **distinct, non-fallthrough**
+patterns qualify (``-glob`` / ``-regexp`` arms are first-match-wins and may
+overlap); a trailing ``default`` arm stays last.
 
-Anything that does not fit (mixed operators, a side-effecting subject,
-repeated constants, ``glob`` / range tests, fewer than two ``elseif``
-clauses) is left untouched.
-
-Suggestions are emitted as ``hint_only`` :class:`Optimisation` objects
-(code ``P100``) carrying a materialised ``replacement`` so an opt-in
-``--apply`` can rewrite the chain.  This module is **never** called by the
-default optimiser pipeline — only by the explicit, off-by-default PGO
-entry points.
+Anything that does not fit is left untouched.  Suggestions are emitted as
+``hint_only`` :class:`Optimisation` objects (code ``P100``) carrying a
+materialised ``replacement`` so an opt-in ``--apply`` can rewrite the
+source.  This module is **never** called by the default optimiser pipeline
+— only by the explicit, off-by-default PGO entry points.
 """
 
 from __future__ import annotations
@@ -57,7 +56,6 @@ from ..ir import (
     IRFor,
     IRForeach,
     IRIf,
-    IRIfClause,
     IRIncr,
     IRModule,
     IRScript,
@@ -91,40 +89,41 @@ _DIALECT = "f5-irules"
 # ---------------------------------------------------------------------------
 
 
-def _iter_ifs(script: IRScript | None) -> Iterator[IRIf]:
-    """Yield every :class:`IRIf` in *script*, descending into nested bodies."""
+def _iter_control(script: IRScript | None) -> Iterator[IRIf | IRSwitch]:
+    """Yield every :class:`IRIf` / :class:`IRSwitch`, descending into bodies."""
     if script is None:
         return
     for stmt in script.statements:
         if isinstance(stmt, IRIf):
             yield stmt
             for clause in stmt.clauses:
-                yield from _iter_ifs(clause.body)
-            yield from _iter_ifs(stmt.else_body)
-        elif isinstance(stmt, (IRWhile, IRForeach, IRCatch, IRBlock, IRUpFrame)):
-            yield from _iter_ifs(stmt.body)
-        elif isinstance(stmt, IRFor):
-            yield from _iter_ifs(stmt.init)
-            yield from _iter_ifs(stmt.next)
-            yield from _iter_ifs(stmt.body)
-        elif isinstance(stmt, IRTry):
-            yield from _iter_ifs(stmt.body)
-            for handler in stmt.handlers:
-                yield from _iter_ifs(handler.body)
-            yield from _iter_ifs(stmt.finally_body)
+                yield from _iter_control(clause.body)
+            yield from _iter_control(stmt.else_body)
         elif isinstance(stmt, IRSwitch):
+            yield stmt
             for arm in stmt.arms:
-                yield from _iter_ifs(arm.body)
-            yield from _iter_ifs(stmt.default_body)
+                yield from _iter_control(arm.body)
+            yield from _iter_control(stmt.default_body)
+        elif isinstance(stmt, (IRWhile, IRForeach, IRCatch, IRBlock, IRUpFrame)):
+            yield from _iter_control(stmt.body)
+        elif isinstance(stmt, IRFor):
+            yield from _iter_control(stmt.init)
+            yield from _iter_control(stmt.next)
+            yield from _iter_control(stmt.body)
+        elif isinstance(stmt, IRTry):
+            yield from _iter_control(stmt.body)
+            for handler in stmt.handlers:
+                yield from _iter_control(handler.body)
+            yield from _iter_control(stmt.finally_body)
 
 
-def _iter_module_ifs(module: IRModule) -> Iterator[IRIf]:
-    """Yield every :class:`IRIf` across the whole module."""
-    yield from _iter_ifs(module.top_level)
+def _iter_module_control(module: IRModule) -> Iterator[IRIf | IRSwitch]:
+    """Yield every :class:`IRIf` / :class:`IRSwitch` across the whole module."""
+    yield from _iter_control(module.top_level)
     for proc in module.procedures.values():
-        yield from _iter_ifs(proc.body)
+        yield from _iter_control(proc.body)
     for method in module.methods.values():
-        yield from _iter_ifs(method.body)
+        yield from _iter_control(method.body)
 
 
 # ---------------------------------------------------------------------------
@@ -197,20 +196,20 @@ def _subject_is_safe(node: _Subject) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _first_line(clause: IRIfClause) -> int | None:
-    """1-based source line of the clause body's first statement."""
-    for stmt in clause.body.statements:
+def _body_first_line(body: IRScript, body_range: Range | None) -> int | None:
+    """1-based source line of *body*'s first statement."""
+    for stmt in body.statements:
         rng = getattr(stmt, "range", None)
         if rng is not None:
             return rng.start.line + 1  # internal lines are 0-based
-    if clause.body_range is not None:
-        return clause.body_range.start.line + 1
+    if body_range is not None:
+        return body_range.start.line + 1
     return None
 
 
-def _signal_key(clause: IRIfClause) -> tuple[str, str] | None:
+def _body_signal_key(body: IRScript) -> tuple[str, str] | None:
     """Coarse attribution key — the first observable command / variable write."""
-    for stmt in clause.body.statements:
+    for stmt in body.statements:
         if isinstance(stmt, IRCall):
             return ("cmd", stmt.command)
         if isinstance(stmt, (IRAssignConst, IRAssignValue, IRAssignExpr, IRIncr)):
@@ -218,13 +217,13 @@ def _signal_key(clause: IRIfClause) -> tuple[str, str] | None:
     return None
 
 
-def _clause_weight(clause: IRIfClause, profile: ProfileData) -> int | None:
-    """Execution weight for *clause*, preferring precise line counts."""
+def _body_weight(body: IRScript, body_range: Range | None, profile: ProfileData) -> int | None:
+    """Execution weight for *body*, preferring precise line counts."""
     if profile.has_line_data:
-        line = _first_line(clause)
+        line = _body_first_line(body, body_range)
         if line is not None:
             return profile.line_count(line)
-    key = _signal_key(clause)
+    key = _body_signal_key(body)
     if key is None:
         return None
     kind, name = key
@@ -283,6 +282,59 @@ def _replace_range(if_node: IRIf, source: str) -> Range:
     return Range(start=if_node.range.start, end=end)
 
 
+def _rebuild_switch(switch: IRSwitch, order: list[int], source: str) -> str | None:
+    """Reassemble a ``switch`` with arms in *order*, preserving formatting.
+
+    Works in slots: the inter-element separators (whitespace/newlines) keep
+    their positions and only the arm *texts* are permuted, so original
+    indentation is preserved exactly.  ``default`` keeps the final slot.
+    """
+    switch_start = switch.range.start.offset
+    switch_end = widen_range_for_closer(source, switch.range).end.offset
+
+    # Source-order element spans: arms first, then default (if present).
+    spans: list[tuple[int, int]] = []
+    for arm in switch.arms:
+        if arm.body_range is None:
+            return None
+        spans.append(
+            (
+                arm.pattern_range.start.offset,
+                widen_range_for_closer(source, arm.body_range).end.offset,
+            )
+        )
+    has_default = switch.default_body is not None and switch.default_range is not None
+    if has_default:
+        assert switch.default_range is not None
+        kw = source.rfind("default", switch_start, switch.default_range.start.offset)
+        if kw < 0:
+            return None
+        spans.append((kw, widen_range_for_closer(source, switch.default_range).end.offset))
+
+    # Spans must be within the switch and strictly increasing (no overlap).
+    cursor = switch_start
+    for start, end in spans:
+        if not (switch_start <= start <= end <= switch_end) or start < cursor:
+            return None
+        cursor = end + 1
+
+    texts = [source[start : end + 1] for start, end in spans]
+    prefix = source[switch_start : spans[0][0]]
+    suffix = source[spans[-1][1] + 1 : switch_end + 1]
+    seps = [source[spans[i][1] + 1 : spans[i + 1][0]] for i in range(len(spans) - 1)]
+
+    # Permute arm texts into the leading slots; default text stays last.
+    new_texts = [texts[i] for i in order] + (texts[len(switch.arms) :] if has_default else [])
+
+    out = [prefix]
+    for i, text in enumerate(new_texts):
+        out.append(text)
+        if i < len(seps):
+            out.append(seps[i])
+    out.append(suffix)
+    return "".join(out)
+
+
 # ---------------------------------------------------------------------------
 # Analysis
 # ---------------------------------------------------------------------------
@@ -315,7 +367,7 @@ def _analyse_if(if_node: IRIf, source: str, profile: ProfileData) -> Optimisatio
 
     weights: list[int] = []
     for clause in clauses:
-        w = _clause_weight(clause, profile)
+        w = _body_weight(clause.body, clause.body_range, profile)
         if w is None:
             return None
         weights.append(w)
@@ -347,6 +399,67 @@ def _analyse_if(if_node: IRIf, source: str, profile: ProfileData) -> Optimisatio
     )
 
 
+def _analyse_switch(switch: IRSwitch, source: str, profile: ProfileData) -> Optimisation | None:
+    """Suggest reordering exact-match ``switch`` arms by profile frequency.
+
+    Safer than an if/elseif chain: the subject is evaluated exactly once, so
+    no purity requirement applies.  Only ``-exact`` switches with distinct,
+    non-fallthrough patterns qualify (glob/regexp arms are first-match-wins
+    and may overlap).  A ``default`` arm is, by construction, already last
+    (the lowerer only treats a trailing ``default`` as the catch-all) and
+    stays there.
+    """
+    # Only exact matching is order-independent for distinct patterns.
+    if switch.mode != "exact":
+        return None
+    arms = switch.arms
+    if len(arms) < 2:
+        return None
+    # Fallthrough (``pat -``) chains share a body — reordering breaks them.
+    if any(arm.fallthrough or arm.body is None for arm in arms):
+        return None
+    # Distinct patterns (case-normalised under -nocase) ⇒ mutually exclusive.
+    patterns = [arm.pattern.lower() if switch.nocase else arm.pattern for arm in arms]
+    if len(set(patterns)) != len(patterns):
+        return None
+
+    weights: list[int] = []
+    for arm in arms:
+        assert arm.body is not None  # guaranteed by the fallthrough guard
+        w = _body_weight(arm.body, arm.body_range, profile)
+        if w is None:
+            return None
+        weights.append(w)
+
+    if sum(1 for w in weights if w > 0) < 2:
+        return None
+
+    order = sorted(range(len(arms)), key=lambda i: (-weights[i], i))
+    if order == list(range(len(arms))):
+        return None  # already hottest-first
+
+    replacement = _rebuild_switch(switch, order, source)
+    if replacement is None:
+        return None
+
+    hot_idx = order[0]
+    message = (
+        f"Reorder switch arms by profile frequency: the arm matching "
+        f"{arms[hot_idx].pattern!r} is taken most often ({weights[hot_idx]}×) but "
+        f"is in position {hot_idx + 1}; place the hottest arm first."
+    )
+    return Optimisation(
+        code=REORDER_CODE,
+        message=message,
+        range=Range(
+            start=switch.range.start,
+            end=widen_range_for_closer(source, switch.range).end,
+        ),
+        replacement=replacement,
+        hint_only=True,
+    )
+
+
 def find_pgo_suggestions(
     source: str,
     profile: ProfileData | None,
@@ -363,8 +476,11 @@ def find_pgo_suggestions(
     if cu is None:
         return []
     suggestions: list[Optimisation] = []
-    for if_node in _iter_module_ifs(cu.ir_module):
-        opt = _analyse_if(if_node, source, profile)
+    for node in _iter_module_control(cu.ir_module):
+        if isinstance(node, IRIf):
+            opt = _analyse_if(node, source, profile)
+        else:
+            opt = _analyse_switch(node, source, profile)
         if opt is not None:
             suggestions.append(opt)
     suggestions.sort(key=lambda o: o.range.start.offset)

--- a/compiler/pgo/reorder.py
+++ b/compiler/pgo/reorder.py
@@ -1,0 +1,371 @@
+"""Profile-guided branch-reordering suggestions.
+
+This is the first profile-guided optimisation: given a
+:class:`~compiler.pgo.profile_data.ProfileData`, find ``if`` / ``elseif``
+**equality-dispatch chains** whose branches are not tested
+hottest-first, and suggest reordering them so the most-frequently-taken
+branch is checked first (fewer comparisons on the common path).
+
+Safety — a chain is only ever touched when reordering is provably
+behaviour-preserving:
+
+* Every clause condition is ``<subject> eq|==|equals <constant>`` with the
+  **same** subject expression and **distinct** constants, so the clauses
+  are mutually exclusive — exactly one can match regardless of order.
+* The subject is **side-effect-free** (a variable read, or a command the
+  side-effect registry classifies as non-writing), so evaluating it a
+  different number of times across the reordered tests changes nothing
+  observable.
+
+Anything that does not fit (mixed operators, a side-effecting subject,
+repeated constants, ``glob`` / range tests, fewer than two ``elseif``
+clauses) is left untouched.
+
+Suggestions are emitted as ``hint_only`` :class:`Optimisation` objects
+(code ``P100``) carrying a materialised ``replacement`` so an opt-in
+``--apply`` can rewrite the chain.  This module is **never** called by the
+default optimiser pipeline — only by the explicit, off-by-default PGO
+entry points.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+from shared.diagnostic import Range
+from shared.naming import normalise_var_name
+from shared.ranges import widen_range_for_closer
+
+from ..compilation_unit import CompilationUnit, ensure_compilation_unit
+from ..expr_ast import (
+    BinOp,
+    ExprBinary,
+    ExprCommand,
+    ExprLiteral,
+    ExprNode,
+    ExprString,
+    ExprVar,
+)
+from ..ir import (
+    IRAssignConst,
+    IRAssignExpr,
+    IRAssignValue,
+    IRBlock,
+    IRCall,
+    IRCatch,
+    IRFor,
+    IRForeach,
+    IRIf,
+    IRIfClause,
+    IRIncr,
+    IRModule,
+    IRScript,
+    IRSwitch,
+    IRTry,
+    IRUpFrame,
+    IRWhile,
+)
+from ..optimiser._types import Optimisation
+from ..side_effects import classify_side_effects
+from .profile_data import ProfileData
+
+log = logging.getLogger(__name__)
+
+#: The PGO suggestion code (registered in ``shared/codes.py`` as a PGO-kind
+#: code so it stays out of the optimisation profiles).
+REORDER_CODE = "P100"
+
+#: Equality operators that form a mutually-exclusive dispatch on distinct
+#: constants: ``==`` (numeric), ``eq`` (string), ``equals`` (iRules).
+_EQ_OPS = frozenset({BinOp.EQ, BinOp.STR_EQ, BinOp.STR_EQUALS})
+
+#: Dialect used for subject side-effect classification.  iRule getters
+#: (``IP::remote_addr`` …) resolve here; the registry falls back to
+#: ``get_any`` for plain Tcl commands, so this is safe for both.
+_DIALECT = "f5-irules"
+
+
+# ---------------------------------------------------------------------------
+# IR traversal
+# ---------------------------------------------------------------------------
+
+
+def _iter_ifs(script: IRScript | None) -> Iterator[IRIf]:
+    """Yield every :class:`IRIf` in *script*, descending into nested bodies."""
+    if script is None:
+        return
+    for stmt in script.statements:
+        if isinstance(stmt, IRIf):
+            yield stmt
+            for clause in stmt.clauses:
+                yield from _iter_ifs(clause.body)
+            yield from _iter_ifs(stmt.else_body)
+        elif isinstance(stmt, (IRWhile, IRForeach, IRCatch, IRBlock, IRUpFrame)):
+            yield from _iter_ifs(stmt.body)
+        elif isinstance(stmt, IRFor):
+            yield from _iter_ifs(stmt.init)
+            yield from _iter_ifs(stmt.next)
+            yield from _iter_ifs(stmt.body)
+        elif isinstance(stmt, IRTry):
+            yield from _iter_ifs(stmt.body)
+            for handler in stmt.handlers:
+                yield from _iter_ifs(handler.body)
+            yield from _iter_ifs(stmt.finally_body)
+        elif isinstance(stmt, IRSwitch):
+            for arm in stmt.arms:
+                yield from _iter_ifs(arm.body)
+            yield from _iter_ifs(stmt.default_body)
+
+
+def _iter_module_ifs(module: IRModule) -> Iterator[IRIf]:
+    """Yield every :class:`IRIf` across the whole module."""
+    yield from _iter_ifs(module.top_level)
+    for proc in module.procedures.values():
+        yield from _iter_ifs(proc.body)
+    for method in module.methods.values():
+        yield from _iter_ifs(method.body)
+
+
+# ---------------------------------------------------------------------------
+# Equality-dispatch recognition
+# ---------------------------------------------------------------------------
+
+
+_Subject = ExprVar | ExprCommand
+_Const = ExprString | ExprLiteral
+
+
+def _split_eq(cond: ExprNode) -> tuple[_Subject, _Const] | None:
+    """Return ``(subject, const)`` if *cond* is ``subject <eq> const``."""
+    if not isinstance(cond, ExprBinary) or cond.op not in _EQ_OPS:
+        return None
+    left, right = cond.left, cond.right
+    if isinstance(right, (ExprString, ExprLiteral)) and isinstance(left, (ExprVar, ExprCommand)):
+        return left, right
+    if isinstance(left, (ExprString, ExprLiteral)) and isinstance(right, (ExprVar, ExprCommand)):
+        return right, left
+    return None
+
+
+def _subject_key(node: _Subject) -> str:
+    """Normalised identity of a subject, for the same-subject check."""
+    if isinstance(node, ExprVar):
+        return "var:" + normalise_var_name(node.name)
+    # ExprCommand — collapse internal whitespace so spacing differences
+    # between clauses don't defeat the equality test.
+    return "cmd:" + " ".join(node.text.split())
+
+
+def _const_value(node: _Const) -> str:
+    """The constant's value text, stripped of one layer of quotes/braces."""
+    text = node.text
+    if len(text) >= 2 and ((text[0] == '"' and text[-1] == '"') or (text[0] == "{" and text[-1] == "}")):
+        return text[1:-1]
+    return text
+
+
+def _subject_is_safe(node: _Subject) -> bool:
+    """True when evaluating *node* repeatedly has no observable effect."""
+    if isinstance(node, ExprVar):
+        return True  # reading a variable is side-effect-free
+    inner = node.text.strip()
+    if inner.startswith("[") and inner.endswith("]"):
+        inner = inner[1:-1].strip()
+    # A nested command substitution could hide a side effect the registry
+    # cannot see — stay conservative.
+    if "[" in inner:
+        return False
+    from compiler.parsing.command_segmenter import segment_commands
+
+    try:
+        cmds = segment_commands(inner)
+    except Exception:
+        return False
+    if len(cmds) != 1 or not cmds[0].texts:
+        return False
+    command = cmds[0].texts[0]
+    if "$" in command:  # dynamic command name
+        return False
+    args = tuple(cmds[0].texts[1:])
+    effects = classify_side_effects(command, args, dialect=_DIALECT)
+    return not effects.writes_any and not effects.dynamic_barrier
+
+
+# ---------------------------------------------------------------------------
+# Profile attribution
+# ---------------------------------------------------------------------------
+
+
+def _first_line(clause: IRIfClause) -> int | None:
+    """1-based source line of the clause body's first statement."""
+    for stmt in clause.body.statements:
+        rng = getattr(stmt, "range", None)
+        if rng is not None:
+            return rng.start.line + 1  # internal lines are 0-based
+    if clause.body_range is not None:
+        return clause.body_range.start.line + 1
+    return None
+
+
+def _signal_key(clause: IRIfClause) -> tuple[str, str] | None:
+    """Coarse attribution key — the first observable command / variable write."""
+    for stmt in clause.body.statements:
+        if isinstance(stmt, IRCall):
+            return ("cmd", stmt.command)
+        if isinstance(stmt, (IRAssignConst, IRAssignValue, IRAssignExpr, IRIncr)):
+            return ("var", normalise_var_name(stmt.name))
+    return None
+
+
+def _clause_weight(clause: IRIfClause, profile: ProfileData) -> int | None:
+    """Execution weight for *clause*, preferring precise line counts."""
+    if profile.has_line_data:
+        line = _first_line(clause)
+        if line is not None:
+            return profile.line_count(line)
+    key = _signal_key(clause)
+    if key is None:
+        return None
+    kind, name = key
+    if kind == "cmd":
+        return profile.command_count(name)
+    return profile.var_mod_counts.get(name, 0)
+
+
+# ---------------------------------------------------------------------------
+# Rewrite construction
+# ---------------------------------------------------------------------------
+
+
+def _slice(source: str, rng: Range | None) -> str | None:
+    """Verbatim source for *rng*, including a trailing brace/bracket closer."""
+    if rng is None:
+        return None
+    widened = widen_range_for_closer(source, rng)
+    start = widened.start.offset
+    end = widened.end.offset + 1  # Range end offsets are inclusive
+    if 0 <= start <= end <= len(source):
+        return source[start:end]
+    return None
+
+
+def _rebuild_if(if_node: IRIf, order: list[int], source: str) -> str | None:
+    """Reassemble the ``if`` chain with clauses in *order* (else stays last)."""
+    parts: list[str] = []
+    for position, idx in enumerate(order):
+        clause = if_node.clauses[idx]
+        cond_txt = _slice(source, clause.condition_range)
+        body_txt = _slice(source, clause.body_range)
+        if cond_txt is None or body_txt is None:
+            return None
+        keyword = "if " if position == 0 else " elseif "
+        parts.append(f"{keyword}{cond_txt} {body_txt}")
+    if if_node.else_body is not None:
+        else_txt = _slice(source, if_node.else_range)
+        if else_txt is None:
+            return None
+        parts.append(f" else {else_txt}")
+    return "".join(parts)
+
+
+def _replace_range(if_node: IRIf, source: str) -> Range:
+    """Range covering the whole ``if`` statement (through the final closer)."""
+    last = (
+        if_node.else_range
+        if if_node.else_body is not None and if_node.else_range is not None
+        else if_node.clauses[-1].body_range
+    )
+    if last is not None:
+        end = widen_range_for_closer(source, last).end
+    else:
+        end = if_node.range.end
+    return Range(start=if_node.range.start, end=end)
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def _analyse_if(if_node: IRIf, source: str, profile: ProfileData) -> Optimisation | None:
+    clauses = if_node.clauses
+    # Need at least two conditions to have any reordering to suggest.
+    if len(clauses) < 2:
+        return None
+
+    subjects: list[str] = []
+    consts: list[str] = []
+    for clause in clauses:
+        split = _split_eq(clause.condition)
+        if split is None:
+            return None
+        subject, const = split
+        if not _subject_is_safe(subject):
+            return None
+        subjects.append(_subject_key(subject))
+        consts.append(_const_value(const))
+
+    # Same subject across all clauses, and distinct constants → mutually
+    # exclusive → free to reorder.
+    if len(set(subjects)) != 1:
+        return None
+    if len(set(consts)) != len(consts):
+        return None
+
+    weights: list[int] = []
+    for clause in clauses:
+        w = _clause_weight(clause, profile)
+        if w is None:
+            return None
+        weights.append(w)
+
+    # Need at least two clauses with a positive signal to rank meaningfully.
+    if sum(1 for w in weights if w > 0) < 2:
+        return None
+
+    order = sorted(range(len(clauses)), key=lambda i: (-weights[i], i))
+    if order == list(range(len(clauses))):
+        return None  # already hottest-first
+
+    replacement = _rebuild_if(if_node, order, source)
+    if replacement is None:
+        return None
+
+    hot_idx = order[0]
+    message = (
+        f"Reorder branches by profile frequency: the branch matching "
+        f"{consts[hot_idx]!r} is taken most often ({weights[hot_idx]}×) but is "
+        f"tested in position {hot_idx + 1}; test the hottest branch first."
+    )
+    return Optimisation(
+        code=REORDER_CODE,
+        message=message,
+        range=_replace_range(if_node, source),
+        replacement=replacement,
+        hint_only=True,
+    )
+
+
+def find_pgo_suggestions(
+    source: str,
+    profile: ProfileData | None,
+    cu: CompilationUnit | None = None,
+) -> list[Optimisation]:
+    """Return profile-guided reordering suggestions for *source*.
+
+    Off-by-default by construction: returns ``[]`` when *profile* is empty,
+    and is never invoked by the standard optimiser pipeline.
+    """
+    if profile is None or profile.is_empty:
+        return []
+    cu = ensure_compilation_unit(source, cu, logger=log, context="pgo")
+    if cu is None:
+        return []
+    suggestions: list[Optimisation] = []
+    for if_node in _iter_module_ifs(cu.ir_module):
+        opt = _analyse_if(if_node, source, profile)
+        if opt is not None:
+            suggestions.append(opt)
+    suggestions.sort(key=lambda o: o.range.start.offset)
+    return suggestions

--- a/compiler/pgo/reorder.py
+++ b/compiler/pgo/reorder.py
@@ -159,7 +159,9 @@ def _subject_key(node: _Subject) -> str:
 def _const_value(node: _Const) -> str:
     """The constant's value text, stripped of one layer of quotes/braces."""
     text = node.text
-    if len(text) >= 2 and ((text[0] == '"' and text[-1] == '"') or (text[0] == "{" and text[-1] == "}")):
+    if len(text) >= 2 and (
+        (text[0] == '"' and text[-1] == '"') or (text[0] == "{" and text[-1] == "}")
+    ):
         return text[1:-1]
     return text
 

--- a/compiler/pgo/reorder.py
+++ b/compiler/pgo/reorder.py
@@ -7,12 +7,15 @@ common path).  Two constructs are handled, each only when reordering is
 provably behaviour-preserving:
 
 **if / elseif equality-dispatch chains.**  Every clause condition must be
-``<subject> eq|==|equals <constant>`` with the **same** subject expression
-and **distinct** constants (so the clauses are mutually exclusive — exactly
-one matches regardless of order), and the subject must be
-**side-effect-free** (a variable read, or a command the side-effect
-registry classifies as non-writing), since reordering changes how many
-times it is evaluated.
+``<subject> eq|equals <constant>`` (string equality) with the **same**
+subject expression and **distinct** constant values (so the clauses are
+mutually exclusive — exactly one matches regardless of order), and the
+subject must be **side-effect-free** (a variable read, or a command the
+side-effect registry classifies as non-writing), since reordering changes
+how many times it is evaluated.  Numeric ``==`` is intentionally excluded
+(textually distinct numbers can be numerically equal — ``1`` == ``01``),
+as are constants containing backslash escapes (whose runtime value is
+ambiguous), so distinct source text always implies distinct values.
 
 **exact-match switch arms.**  Reordering arms is *safer* than an if/elseif
 chain: the subject is evaluated exactly once, so no purity requirement
@@ -75,8 +78,13 @@ log = logging.getLogger(__name__)
 REORDER_CODE = "P100"
 
 #: Equality operators that form a mutually-exclusive dispatch on distinct
-#: constants: ``==`` (numeric), ``eq`` (string), ``equals`` (iRules).
-_EQ_OPS = frozenset({BinOp.EQ, BinOp.STR_EQ, BinOp.STR_EQUALS})
+#: String-equality operators whose distinct *constant text* guarantees the
+#: arms are mutually exclusive: ``eq`` (Tcl string ==) and ``equals``
+#: (iRules).  Numeric ``==`` (``BinOp.EQ``) is **excluded**: textually
+#: distinct numeric literals can be numerically equal (``1`` == ``01`` ==
+#: ``1.0`` == ``0x1``), so reordering such arms could change which body
+#: runs.  String comparison has no such collision (``1 eq 01`` is false).
+_EQ_OPS = frozenset({BinOp.STR_EQ, BinOp.STR_EQUALS})
 
 #: Dialect used for subject side-effect classification.  iRule getters
 #: (``IP::remote_addr`` …) resolve here; the registry falls back to
@@ -239,6 +247,26 @@ def _body_weight(body: IRScript, body_range: Range | None, profile: ProfileData)
 # ---------------------------------------------------------------------------
 
 
+def _is_word_char(ch: str) -> bool:
+    return ch.isalnum() or ch == "_"
+
+
+def _find_keyword(source: str, word: str, lo: int, hi: int) -> int:
+    """Offset of the last whole-word *word* in ``source[lo:hi]``, or -1.
+
+    "Whole word" means not flanked by identifier characters, so ``default``
+    is matched but ``mydefault`` / ``defaults`` are not.
+    """
+    idx = source.rfind(word, lo, hi)
+    while idx >= 0:
+        before = source[idx - 1] if idx > 0 else ""
+        after = source[idx + len(word)] if idx + len(word) < len(source) else ""
+        if not _is_word_char(before) and not _is_word_char(after):
+            return idx
+        idx = source.rfind(word, lo, idx)
+    return -1
+
+
 def _slice(source: str, rng: Range | None) -> str | None:
     """Verbatim source for *rng*, including a trailing brace/bracket closer."""
     if rng is None:
@@ -308,7 +336,12 @@ def _rebuild_switch(switch: IRSwitch, order: list[int], source: str) -> str | No
     has_default = switch.default_body is not None and switch.default_range is not None
     if has_default:
         assert switch.default_range is not None
-        kw = source.rfind("default", switch_start, switch.default_range.start.offset)
+        # Locate the ``default`` keyword as a whole word, searching only the
+        # gap between the previous element's body and the default body — so a
+        # stray "default" substring inside an earlier arm (or unrelated text)
+        # cannot be matched.
+        window_lo = spans[-1][1] + 1 if spans else switch_start
+        kw = _find_keyword(source, "default", window_lo, switch.default_range.start.offset)
         if kw < 0:
             return None
         spans.append((kw, widen_range_for_closer(source, switch.default_range).end.offset))
@@ -356,6 +389,11 @@ def _analyse_if(if_node: IRIf, source: str, profile: ProfileData) -> Optimisatio
             return None
         subject, const = split
         if not _subject_is_safe(subject):
+            return None
+        # A backslash escape (e.g. "\x41") makes the runtime string value
+        # ambiguous against another arm's plain text ("A"), so distinct
+        # source text no longer proves distinct values — refuse to reorder.
+        if "\\" in const.text:
             return None
         subjects.append(_subject_key(subject))
         consts.append(_const_value(const))
@@ -419,6 +457,11 @@ def _analyse_switch(switch: IRSwitch, source: str, profile: ProfileData) -> Opti
         return None
     # Fallthrough (``pat -``) chains share a body — reordering breaks them.
     if any(arm.fallthrough or arm.body is None for arm in arms):
+        return None
+    # A backslash escape in a pattern makes its runtime value ambiguous (it
+    # depends on whether the arm list was braced), so distinct text no
+    # longer proves distinct match values — refuse to reorder.
+    if any("\\" in arm.pattern for arm in arms):
         return None
     # Distinct patterns (case-normalised under -nocase) ⇒ mutually exclusive.
     patterns = [arm.pattern.lower() if switch.nocase else arm.pattern for arm in arms]

--- a/compiler/pgo/tclsh_capture.py
+++ b/compiler/pgo/tclsh_capture.py
@@ -1,0 +1,148 @@
+"""Capture a profile by running a script under tclsh with execution tracing.
+
+This is the *precise* profile source: it drives a real ``tclsh`` with
+``trace add execution source enterstep`` — the same passive-observation
+hook the BIG-IP rule-profiler is modelled on, and the one this repo's
+debugger already uses — and recovers the source **line** of every executed
+command via ``info frame``.  That yields per-line counts the branch
+reorderer can attribute exactly (unlike an F5 log, which only has command
+names).
+
+The capture is best-effort: it returns an empty :class:`ProfileData` (and
+logs at debug level) if no ``tclsh`` is found or the script cannot run.
+Line attribution is most reliable for top-level / event-handler code; the
+trace records whatever line ``info frame`` reports for each command.
+
+Note: a raw iRule (``when EVENT { … }``) is not directly runnable under a
+stock ``tclsh`` — ``when`` is not a core command.  Use this on plain Tcl /
+proc bodies, or stub the iRule commands; use the F5-log importer for live
+iRule traffic.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from .profile_data import ProfileData
+
+log = logging.getLogger(__name__)
+
+#: tclsh executables to try, in order of preference.
+_TCLSH_CANDIDATES = ("tclsh", "tclsh9.0", "tclsh8.6", "tclsh8.5")
+
+# Tcl-side harness.  Installs an ``enterstep`` trace on ``source``, tallies
+# per-line and per-command counts, then prints them as JSON.  Its own procs
+# are namespaced ``::__pgo*`` and skipped when walking the frame stack.
+_HARNESS = r"""
+array set ::__pgo_lines {}
+array set ::__pgo_cmds {}
+
+proc ::__pgo_step {args} {
+    set depth [info frame]
+    for {set i $depth} {$i >= 1} {incr i -1} {
+        if {[catch {info frame $i} fi]} continue
+        if {[dict exists $fi proc]} {
+            set pn [dict get $fi proc]
+            if {[string match "::__pgo*" $pn]} continue
+        }
+        if {[dict exists $fi type] && [dict get $fi type] eq "source"
+            && [dict exists $fi line]} {
+            incr ::__pgo_lines([dict get $fi line])
+            if {[dict exists $fi cmd]} {
+                set c [lindex [dict get $fi cmd] 0]
+                if {$c ne ""} { incr ::__pgo_cmds($c) }
+            }
+            break
+        }
+    }
+}
+
+set ::__pgo_script [lindex $argv 0]
+trace add execution source enterstep ::__pgo_step
+catch {source $::__pgo_script}
+trace remove execution source enterstep ::__pgo_step
+
+proc ::__pgo_emit {} {
+    set lparts {}
+    foreach {k v} [array get ::__pgo_lines] { lappend lparts "\"$k\":$v" }
+    set cparts {}
+    foreach {k v} [array get ::__pgo_cmds] {
+        set ek [string map [list \\ \\\\ \" \\\"] $k]
+        lappend cparts "\"$ek\":$v"
+    }
+    puts "{\"lines\":{[join $lparts ,]},\"commands\":{[join $cparts ,]}}"
+}
+::__pgo_emit
+"""
+
+
+def find_tclsh() -> str | None:
+    """Return the path to a usable ``tclsh``, or ``None`` if none is found."""
+    for name in _TCLSH_CANDIDATES:
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def capture_profile(
+    script_path: str | Path,
+    *,
+    tclsh: str | None = None,
+    timeout: float = 30.0,
+) -> ProfileData:
+    """Run *script_path* under tclsh and return a :class:`ProfileData`.
+
+    Returns an empty profile (logged at debug level) when tracing is not
+    possible — no ``tclsh``, a run error, or unparseable output.
+    """
+    exe = tclsh or find_tclsh()
+    if exe is None:
+        log.debug("pgo capture: no tclsh found on PATH")
+        return ProfileData(source="tclsh-trace")
+
+    script_path = Path(script_path)
+    with tempfile.NamedTemporaryFile("w", suffix=".tcl", delete=False, encoding="utf-8") as fh:
+        fh.write(_HARNESS)
+        harness_path = fh.name
+    try:
+        proc = subprocess.run(
+            [exe, harness_path, str(script_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.debug("pgo capture: tclsh run failed: %s", exc)
+        return ProfileData(source="tclsh-trace")
+    finally:
+        try:
+            Path(harness_path).unlink()
+        except OSError:
+            pass
+
+    # The JSON line is the harness' final stdout line.
+    payload = proc.stdout.strip().splitlines()
+    for line in reversed(payload):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        line_counts = {int(k): int(v) for k, v in data.get("lines", {}).items()}
+        command_counts = {str(k): int(v) for k, v in data.get("commands", {}).items()}
+        return ProfileData(
+            line_counts=line_counts,
+            command_counts=command_counts,
+            source="tclsh-trace",
+        )
+    log.debug("pgo capture: no parseable profile output from tclsh")
+    return ProfileData(source="tclsh-trace")

--- a/compiler/pgo/trace_parser.py
+++ b/compiler/pgo/trace_parser.py
@@ -29,8 +29,9 @@ For precise per-line attribution use :mod:`compiler.pgo.tclsh_capture`.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
-from .occurrence import RP_OCCURRENCE_KINDS, FlowContext, Occurrence
+from .occurrence import KIND_TO_RP, RP_OCCURRENCE_KINDS, FlowContext, Occurrence
 from .profile_data import ProfileData
 
 #: Anchor on the ``<timestamp>,RP_<TYPE>,<rest…>`` payload, ignoring any
@@ -96,3 +97,41 @@ def parse_f5_occurrences(text: str) -> list[Occurrence]:
 def parse_f5_log(text: str) -> ProfileData:
     """Parse rule-profiler log *text* into aggregated :class:`ProfileData`."""
     return ProfileData.from_occurrences(parse_f5_occurrences(text), source="f5-log")
+
+
+def _csv_field(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def format_f5_occurrence(occ: Occurrence) -> str:
+    """Render one :class:`Occurrence` as a rule-profiler CSV record.
+
+    The inverse of :func:`parse_f5_occurrences`: produces the bare
+    ``<ts>,RP_<TYPE>,<vs>,<value>,<pid>,<flow>,<r_ip>,<r_port>,<r_rd>,
+    <l_ip>,<l_port>,<l_rd>,<depth>`` payload (no syslog prefix).
+    """
+    rp_type = KIND_TO_RP.get(occ.kind)
+    if rp_type is None:  # pragma: no cover - every kind has an RP_ name
+        raise ValueError(f"no rule-profiler name for {occ.kind}")
+    ctx = occ.context
+    cells = [
+        _csv_field(occ.timestamp_us),
+        rp_type,
+        _csv_field(ctx.virtual_server if ctx else None),
+        occ.value,
+        _csv_field(ctx.process_id if ctx else None),
+        _csv_field(ctx.flow_id if ctx else None),
+        _csv_field(ctx.remote_addr if ctx else None),
+        _csv_field(ctx.remote_port if ctx else None),
+        _csv_field(ctx.remote_rd if ctx else None),
+        _csv_field(ctx.local_addr if ctx else None),
+        _csv_field(ctx.local_port if ctx else None),
+        _csv_field(ctx.local_rd if ctx else None),
+        _csv_field(occ.depth),
+    ]
+    return ",".join(cells)
+
+
+def format_f5_log(occurrences: Iterable[Occurrence]) -> str:
+    """Render an occurrence stream as rule-profiler log text (one line each)."""
+    return "".join(format_f5_occurrence(occ) + "\n" for occ in occurrences)

--- a/compiler/pgo/trace_parser.py
+++ b/compiler/pgo/trace_parser.py
@@ -1,18 +1,23 @@
 """Importer for F5 BIG-IP ``rule-profiler`` occurrence logs.
 
-The rule-profiler writes one CSV line per occurrence to its configured
-syslog publisher (e.g. ``/var/log/ltm``).  Each line has the shape::
+The rule-profiler writes one CSV record per occurrence to its configured
+syslog publisher.  On a typical ``/var/log/ltm`` destination each record is
+embedded in a syslog line, e.g.::
+
+    Nov 24 06:22:32 bigip1 info tmm[18291]: 1511494952932589,RP_EVENT_ENTRY,/Common/vs1,CLIENT_ACCEPTED,18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,
+
+The CSV payload (everything from the timestamp onward) has the field order::
 
     <ts>,RP_<TYPE>,<vs>,<value>,<pid>,<flow>,<r_ip>,<r_port>,<r_rd>,<l_ip>,<l_port>,<l_rd>[,<depth>]
 
-for example::
+This importer is tolerant of an arbitrary syslog prefix: it anchors on the
+``<digits>,RP_<TYPE>,`` payload start, so both raw ``/var/log/ltm`` lines
+and already-stripped CSV (as in the DevCentral articles) parse cleanly.
+The field layout matches the community ``bigip-irule-profiler`` parser
+(mhermsdorferf5/bigip-irule-profiler).
 
-    1511494952932589,RP_EVENT_ENTRY,/Common/vs1,CLIENT_ACCEPTED,18291,0x9455...,10.10.10.2,46052,0,10.10.10.160,80,
-    1511494952932633,RP_CMD_EXIT,/Common/vs1,IP::remote_addr,18291,0x9455...,10.10.10.2,46052,0,10.10.10.160,80,0
-
-This module translates such a log into the normalised
-:mod:`~compiler.pgo.occurrence` stream and rolls it up into a
-:class:`~compiler.pgo.profile_data.ProfileData`.
+It translates the log into the normalised :mod:`~compiler.pgo.occurrence`
+stream and rolls it up into a :class:`~compiler.pgo.profile_data.ProfileData`.
 
 **Limitation:** F5 logs carry command / event *names* but no source line
 numbers, so this importer yields ``command_counts`` / ``event_counts``
@@ -23,8 +28,16 @@ For precise per-line attribution use :mod:`compiler.pgo.tclsh_capture`.
 
 from __future__ import annotations
 
+import re
+
 from .occurrence import RP_OCCURRENCE_KINDS, FlowContext, Occurrence
 from .profile_data import ProfileData
+
+#: Anchor on the ``<timestamp>,RP_<TYPE>,<rest…>`` payload, ignoring any
+#: leading syslog prefix.  ``RP_`` cannot appear in a syslog prefix in this
+#: shape (a pid like ``tmm[18291]:`` is not followed by ``,RP_``), so the
+#: first match is always the real record.
+_RP_LINE = re.compile(r"(\d+),(RP_[A-Z_]+),(.*)$")
 
 
 def _maybe_int(text: str, *, base: int = 10) -> int | None:
@@ -37,10 +50,6 @@ def _maybe_int(text: str, *, base: int = 10) -> int | None:
         return None
 
 
-def _field(fields: list[str], idx: int) -> str:
-    return fields[idx].strip() if idx < len(fields) else ""
-
-
 def parse_f5_occurrences(text: str) -> list[Occurrence]:
     """Parse rule-profiler log *text* into a list of :class:`Occurrence`.
 
@@ -49,35 +58,35 @@ def parse_f5_occurrences(text: str) -> list[Occurrence]:
     """
     occurrences: list[Occurrence] = []
     for raw in text.splitlines():
-        line = raw.strip()
-        if not line:
+        match = _RP_LINE.search(raw)
+        if match is None:
             continue
-        fields = line.split(",")
-        if len(fields) < 4:
-            continue
-        kind = RP_OCCURRENCE_KINDS.get(_field(fields, 1))
+        kind = RP_OCCURRENCE_KINDS.get(match.group(2))
         if kind is None:
-            continue  # comment line, header, or unknown occurrence type
-        # Flow id is logged as hex (``0x...``); keep the raw token as the
-        # flow key and parse pid/ports/rd as best-effort integers.
+            continue  # unknown occurrence type
+        fields = [f.strip() for f in match.group(3).split(",")]
+
+        def field(idx: int, _fields: list[str] = fields) -> str:
+            return _fields[idx] if idx < len(_fields) else ""
+
         context = FlowContext(
-            virtual_server=_field(fields, 2) or None,
-            process_id=_maybe_int(_field(fields, 4)),
-            flow_id=_field(fields, 5) or None,
-            remote_addr=_field(fields, 6) or None,
-            remote_port=_maybe_int(_field(fields, 7)),
-            remote_rd=_maybe_int(_field(fields, 8)),
-            local_addr=_field(fields, 9) or None,
-            local_port=_maybe_int(_field(fields, 10)),
-            local_rd=_maybe_int(_field(fields, 11)),
+            virtual_server=field(0) or None,
+            process_id=_maybe_int(field(2)),
+            flow_id=field(3) or None,
+            remote_addr=field(4) or None,
+            remote_port=_maybe_int(field(5)),
+            remote_rd=_maybe_int(field(6)),
+            local_addr=field(7) or None,
+            local_port=_maybe_int(field(8)),
+            local_rd=_maybe_int(field(9)),
         )
         occurrences.append(
             Occurrence(
                 kind=kind,
-                value=_field(fields, 3),
-                timestamp_us=_maybe_int(_field(fields, 0)),
+                value=field(1),
+                timestamp_us=_maybe_int(match.group(1)),
                 line=None,  # F5 logs have no source line
-                depth=_maybe_int(_field(fields, 12)),
+                depth=_maybe_int(field(10)),
                 context=context,
             )
         )

--- a/compiler/pgo/trace_parser.py
+++ b/compiler/pgo/trace_parser.py
@@ -1,0 +1,89 @@
+"""Importer for F5 BIG-IP ``rule-profiler`` occurrence logs.
+
+The rule-profiler writes one CSV line per occurrence to its configured
+syslog publisher (e.g. ``/var/log/ltm``).  Each line has the shape::
+
+    <ts>,RP_<TYPE>,<vs>,<value>,<pid>,<flow>,<r_ip>,<r_port>,<r_rd>,<l_ip>,<l_port>,<l_rd>[,<depth>]
+
+for example::
+
+    1511494952932589,RP_EVENT_ENTRY,/Common/vs1,CLIENT_ACCEPTED,18291,0x9455...,10.10.10.2,46052,0,10.10.10.160,80,
+    1511494952932633,RP_CMD_EXIT,/Common/vs1,IP::remote_addr,18291,0x9455...,10.10.10.2,46052,0,10.10.10.160,80,0
+
+This module translates such a log into the normalised
+:mod:`~compiler.pgo.occurrence` stream and rolls it up into a
+:class:`~compiler.pgo.profile_data.ProfileData`.
+
+**Limitation:** F5 logs carry command / event *names* but no source line
+numbers, so this importer yields ``command_counts`` / ``event_counts``
+(coarse) — never ``line_counts``.  Branch attribution from an F5 log is
+therefore best-effort (by the first command name in each branch body).
+For precise per-line attribution use :mod:`compiler.pgo.tclsh_capture`.
+"""
+
+from __future__ import annotations
+
+from .occurrence import RP_OCCURRENCE_KINDS, FlowContext, Occurrence
+from .profile_data import ProfileData
+
+
+def _maybe_int(text: str, *, base: int = 10) -> int | None:
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        return int(text, base)
+    except ValueError:
+        return None
+
+
+def _field(fields: list[str], idx: int) -> str:
+    return fields[idx].strip() if idx < len(fields) else ""
+
+
+def parse_f5_occurrences(text: str) -> list[Occurrence]:
+    """Parse rule-profiler log *text* into a list of :class:`Occurrence`.
+
+    Lines that are blank, malformed, or carry an unrecognised occurrence
+    type are skipped, so partial / truncated captures parse cleanly.
+    """
+    occurrences: list[Occurrence] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        fields = line.split(",")
+        if len(fields) < 4:
+            continue
+        kind = RP_OCCURRENCE_KINDS.get(_field(fields, 1))
+        if kind is None:
+            continue  # comment line, header, or unknown occurrence type
+        # Flow id is logged as hex (``0x...``); keep the raw token as the
+        # flow key and parse pid/ports/rd as best-effort integers.
+        context = FlowContext(
+            virtual_server=_field(fields, 2) or None,
+            process_id=_maybe_int(_field(fields, 4)),
+            flow_id=_field(fields, 5) or None,
+            remote_addr=_field(fields, 6) or None,
+            remote_port=_maybe_int(_field(fields, 7)),
+            remote_rd=_maybe_int(_field(fields, 8)),
+            local_addr=_field(fields, 9) or None,
+            local_port=_maybe_int(_field(fields, 10)),
+            local_rd=_maybe_int(_field(fields, 11)),
+        )
+        occurrences.append(
+            Occurrence(
+                kind=kind,
+                value=_field(fields, 3),
+                timestamp_us=_maybe_int(_field(fields, 0)),
+                line=None,  # F5 logs have no source line
+                depth=_maybe_int(_field(fields, 12)),
+                context=context,
+            )
+        )
+    return occurrences
+
+
+def parse_f5_log(text: str) -> ProfileData:
+    """Parse rule-profiler log *text* into aggregated :class:`ProfileData`."""
+    return ProfileData.from_occurrences(parse_f5_occurrences(text), source="f5-log")

--- a/docs/design/contracts/irule-test-framework.md
+++ b/docs/design/contracts/irule-test-framework.md
@@ -24,6 +24,8 @@ User test script (Tcl or Python)
     -> state_layers.tcl  (10 protocol state namespaces)
     -> tmm_shim.tcl      (disabled commands, info override)
     -> expr_ops.tcl      (contains/starts_with/ends_with/etc.)
+    -> profiler.tcl      (optional, off by default: emits rule-profiler
+                          occurrence logs for profile-guided optimisation)
 ```
 
 ## Decision rules / contracts

--- a/shared/codes.py
+++ b/shared/codes.py
@@ -38,6 +38,14 @@ _F = TypeVar("_F", bound=Callable)
 class CodeKind(Enum):
     DIAGNOSTIC = "diagnostic"
     OPTIMISATION = "optimisation"
+    PGO = "pgo"
+    """Profile-guided suggestion code (e.g. ``P100``).
+
+    Deliberately a kind of its own — **not** ``OPTIMISATION`` — so PGO codes
+    are excluded from :func:`optimisation_codes` and therefore never swept
+    into the ``full`` / ``aggressive`` optimisation profiles (which enable
+    *all* registered optimisation codes).  PGO is opt-in: it only runs when
+    a profile is explicitly supplied via the dedicated entry points."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -232,6 +240,46 @@ def default_disabled_diagnostics() -> frozenset[str]:
 def optimisation_codes() -> frozenset[str]:
     """All registered optimisation codes."""
     return frozenset(c for c, info in _registry.items() if info.kind is CodeKind.OPTIMISATION)
+
+
+def pgo(code: str, description: str) -> Callable[[_F], _F]:
+    """Register a profile-guided optimisation (PGO) code.
+
+    Use as ``@pgo(...)`` decorator or bare call.  PGO codes live in their
+    own :class:`CodeKind` so they are excluded from
+    :func:`optimisation_codes` and never auto-enabled by the optimisation
+    profiles — they only surface through the explicit, opt-in PGO entry
+    points (see :mod:`compiler.pgo`).
+    """
+    if code in _registry:
+        existing = _registry[code]
+        if existing.description == description and existing.kind is CodeKind.PGO:
+
+            def _identity_dup(fn: _F) -> _F:
+                return fn
+
+            return _identity_dup
+        raise ValueError(f"Duplicate PGO code: {code}")
+    _registry[code] = CodeInfo(
+        code=code,
+        description=description,
+        kind=CodeKind.PGO,
+    )
+
+    def _identity(fn: _F) -> _F:
+        return fn
+
+    return _identity
+
+
+def pgo_codes() -> frozenset[str]:
+    """All registered profile-guided optimisation codes."""
+    return frozenset(c for c, info in _registry.items() if info.kind is CodeKind.PGO)
+
+
+# Profile-guided optimisation codes (P-series).  Off by default everywhere:
+# emitted only by the opt-in ``compiler.pgo`` entry points.
+pgo("P100", "Reorder conditional branches so the most-frequently-taken case is tested first.")
 
 
 # Source-level style and package diagnostics.

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -40,7 +40,7 @@ import pytest
 import server._codes_init  # noqa: F401 — registers every code
 from compiler.registry.dialect import dialect_scope
 from server.features.diagnostics import get_diagnostics
-from shared.codes import all_codes
+from shared.codes import all_codes, pgo_codes
 
 
 @dataclass(frozen=True)
@@ -1108,7 +1108,11 @@ NOT_YET_COVERED: frozenset[str] = frozenset(
 
 def test_every_code_is_classified_exactly_once():
     covered = set(FIXTURES) | set(RANGE_FIXME) | set(CROSSFILE) | set(NOT_YET_COVERED)
-    registered = set(all_codes())
+    # PGO (``P``-series) codes are not diagnostics surfaced through document
+    # analysis — they are produced by the opt-in profile-guided subsystem and
+    # are covered by the dedicated ``test_pgo_*`` suites, so they are outside
+    # this diagnostic/optimisation partition.
+    registered = set(all_codes()) - pgo_codes()
 
     unclassified = registered - covered
     assert not unclassified, (

--- a/tests/test_pgo_off_by_default.py
+++ b/tests/test_pgo_off_by_default.py
@@ -1,0 +1,46 @@
+"""PGO must be off by default everywhere — it only runs through the
+explicit, profile-driven entry points, never the normal optimiser."""
+
+from __future__ import annotations
+
+from compiler.optimiser._manager import find_optimisations
+from compiler.pgo.reorder import REORDER_CODE
+from shared.codes import optimisation_codes, pgo_codes
+from shared.optimisation_profiles import OptimisationProfile, profile_to_disabled
+
+# A chain that the PGO reorderer *would* flag given a profile.
+DISPATCH = """\
+when HTTP_REQUEST {
+    if {[IP::remote_addr] eq "10.0.0.1"} {
+        pool pool_a
+    } elseif {[IP::remote_addr] eq "10.0.0.2"} {
+        pool pool_b
+    } elseif {[IP::remote_addr] eq "10.0.0.3"} {
+        pool pool_c
+    }
+}
+"""
+
+
+def test_pgo_code_registered_but_not_an_optimisation_code() -> None:
+    assert REORDER_CODE in pgo_codes()
+    assert REORDER_CODE not in optimisation_codes()
+
+
+def test_standard_optimiser_never_emits_pgo_codes() -> None:
+    codes = {opt.code for opt in find_optimisations(DISPATCH)}
+    assert REORDER_CODE not in codes
+
+
+def test_no_optimisation_profile_enables_pgo() -> None:
+    # ``full`` / ``aggressive`` enable *all* optimisation codes; none of
+    # the profiles should ever leave a PGO code enabled (i.e. it must be
+    # in every profile's disabled set — or, equivalently, never in the
+    # optimisation universe at all).
+    for profile in OptimisationProfile:
+        disabled = profile_to_disabled(profile)
+        # PGO codes are not optimisation codes, so they are neither enabled
+        # nor disabled by the optimiser machinery — assert they never leak
+        # into the enabled set.
+        enabled = optimisation_codes() - disabled
+        assert REORDER_CODE not in enabled

--- a/tests/test_pgo_off_by_default.py
+++ b/tests/test_pgo_off_by_default.py
@@ -3,6 +3,12 @@ explicit, profile-driven entry points, never the normal optimiser."""
 
 from __future__ import annotations
 
+# Force registration of every optimisation code BEFORE touching the
+# profile machinery: shared.optimisation_profiles._all_codes() caches the
+# optimisation-code set on first call, so calling profile_to_disabled()
+# with only a partial set registered would freeze that partial set for the
+# whole test session (and break generated-file freshness checks elsewhere).
+import server._codes_init  # noqa: F401
 from compiler.optimiser._manager import find_optimisations
 from compiler.pgo.reorder import REORDER_CODE
 from shared.codes import optimisation_codes, pgo_codes

--- a/tests/test_pgo_profile_gen.py
+++ b/tests/test_pgo_profile_gen.py
@@ -1,0 +1,112 @@
+"""Tests for generating rule-profiler logs from the iRule test framework."""
+
+from __future__ import annotations
+
+import pytest
+
+from compiler.pgo import find_pgo_suggestions
+from compiler.pgo.occurrence import FlowContext, Occurrence, OccurrenceKind
+from compiler.pgo.trace_parser import (
+    format_f5_log,
+    parse_f5_log,
+    parse_f5_occurrences,
+)
+
+# --- serializer (pure, no backend) -----------------------------------------
+
+
+def test_format_round_trips_through_parser() -> None:
+    occ = Occurrence(
+        kind=OccurrenceKind.CMD_ENTER,
+        value="IP::client_addr",
+        timestamp_us=42,
+        depth=0,
+        context=FlowContext(
+            virtual_server="/Common/vs1",
+            process_id=1,
+            flow_id="0x9",
+            remote_addr="10.0.0.2",
+            remote_port=1234,
+            remote_rd=0,
+            local_addr="10.0.0.9",
+            local_port=80,
+            local_rd=0,
+        ),
+    )
+    text = format_f5_log([occ])
+    (back,) = parse_f5_occurrences(text)
+    assert back.kind is OccurrenceKind.CMD_ENTER
+    assert back.value == "IP::client_addr"
+    assert back.timestamp_us == 42
+    assert back.context is not None
+    assert back.context.virtual_server == "/Common/vs1"
+    assert back.context.local_port == 80
+
+
+# --- generator (needs the in-process Tcl backend) ---------------------------
+
+
+def _backend_available() -> bool:
+    try:
+        from tooling.irule_test.bridge import IruleTestSessionSync
+
+        with IruleTestSessionSync(profiles=["TCP", "HTTP"]):
+            return True
+    except Exception:
+        return False
+
+
+requires_backend = pytest.mark.skipif(
+    not _backend_available(), reason="iRule test framework backend unavailable"
+)
+
+_DISPATCH = """\
+when HTTP_REQUEST {
+    if {[IP::client_addr] eq "10.0.0.1"} {
+        log local0. low
+    } elseif {[IP::client_addr] eq "10.0.0.2"} {
+        HTTP::redirect http://busy/
+    } elseif {[IP::client_addr] eq "10.0.0.3"} {
+        HTTP::respond 200
+    }
+}
+"""
+
+
+@requires_backend
+def test_generates_rule_profiler_log() -> None:
+    from tooling.irule_test.profile_gen import Stimulus, generate_occurrence_log
+
+    log = generate_occurrence_log(
+        _DISPATCH,
+        [Stimulus(state={"connection": {"client_addr": "10.0.0.2"}}, repeat=3)],
+    )
+    assert "RP_EVENT_ENTRY,/Common/vs_test,HTTP_REQUEST" in log
+    assert "RP_CMD_ENTRY" in log
+    assert "IP::client_addr" in log
+    # The log parses back cleanly and reflects the fired event.
+    prof = parse_f5_log(log)
+    assert prof.event_counts.get("HTTP_REQUEST") == 3
+    # Core compiled commands (e.g. the implicit set/if) never appear.
+    assert "set" not in prof.command_counts
+    assert "if" not in prof.command_counts
+
+
+@requires_backend
+def test_generated_profile_drives_branch_reorder() -> None:
+    from tooling.irule_test.profile_gen import Stimulus, generate_profile
+
+    prof = generate_profile(
+        _DISPATCH,
+        [
+            Stimulus(state={"connection": {"client_addr": "10.0.0.2"}}, repeat=20),
+            Stimulus(state={"connection": {"client_addr": "10.0.0.3"}}, repeat=5),
+            Stimulus(state={"connection": {"client_addr": "10.0.0.1"}}, repeat=2),
+        ],
+    )
+    assert prof.source == "test-gen"
+    # HTTP::redirect (hot branch) is the most-invoked extension command.
+    assert prof.command_counts.get("HTTP::redirect", 0) == 20
+    sugs = find_pgo_suggestions(_DISPATCH, prof)
+    assert len(sugs) == 1
+    assert "10.0.0.2" in sugs[0].message

--- a/tests/test_pgo_profile_gen.py
+++ b/tests/test_pgo_profile_gen.py
@@ -110,3 +110,32 @@ def test_generated_profile_drives_branch_reorder() -> None:
     sugs = find_pgo_suggestions(_DISPATCH, prof)
     assert len(sugs) == 1
     assert "10.0.0.2" in sugs[0].message
+
+
+@requires_backend
+def test_cli_from_test_reports_suggestion(tmp_path, capsys) -> None:
+    import json
+
+    from tooling.f5.main import main
+
+    irule = tmp_path / "rule.irule"
+    irule.write_text(_DISPATCH, encoding="utf-8")
+    stimuli = tmp_path / "stimuli.json"
+    stimuli.write_text(
+        json.dumps(
+            [
+                {"state": {"connection": {"client_addr": "10.0.0.2"}}, "repeat": 20},
+                {"state": {"connection": {"client_addr": "10.0.0.3"}}, "repeat": 5},
+                {"state": {"connection": {"client_addr": "10.0.0.1"}}, "repeat": 2},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    code = main(["irule", "pgo", "--from-test", str(stimuli), str(irule), "--json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    payload = json.loads(out)
+    suggestions = payload["rules"][0]["suggestions"]
+    assert len(suggestions) == 1
+    assert suggestions[0]["code"] == "P100"
+    assert "10.0.0.2" in suggestions[0]["message"]

--- a/tests/test_pgo_reorder.py
+++ b/tests/test_pgo_reorder.py
@@ -198,3 +198,74 @@ def test_coarse_cannot_rank_same_command_branches() -> None:
         ]
     )
     assert find_pgo_suggestions(DISPATCH, parse_f5_log(log)) == []
+
+
+# --- switch arms -----------------------------------------------------------
+
+SWITCH = """\
+when HTTP_REQUEST {
+    switch [HTTP::path] {
+        /a {
+            pool pool_a
+        }
+        /b {
+            pool pool_b
+        }
+        /c {
+            pool pool_c
+        }
+        default {
+            pool pool_default
+        }
+    }
+}
+"""
+
+
+def test_switch_reorders_hottest_arm_first_default_last() -> None:
+    # Arm bodies: /a line 4, /b line 7, /c line 10.  /b hottest.
+    prof = ProfileData(line_counts={4: 5, 7: 500, 10: 30}, source="test")
+    sugs = find_pgo_suggestions(SWITCH, prof)
+    assert len(sugs) == 1
+    assert sugs[0].code == REORDER_CODE
+    assert "/b" in sugs[0].message
+
+    rewritten = _apply(SWITCH, sugs)
+    # Hottest arm first, default still last, indentation preserved.
+    order = [rewritten.index(f"/{c} {{") for c in ("b", "c", "a")]
+    assert order == sorted(order)
+    assert rewritten.index("default {") > rewritten.index("/a {")
+    assert "        /b {\n            pool pool_b" in rewritten
+
+
+def test_switch_glob_mode_not_reordered() -> None:
+    src = """\
+when HTTP_REQUEST {
+    switch -glob [HTTP::path] {
+        /a* { pool a }
+        /b* { pool b }
+        /c* { pool c }
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 4: 999, 5: 1}, source="t")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_switch_fallthrough_not_reordered() -> None:
+    src = """\
+when HTTP_REQUEST {
+    switch [HTTP::path] {
+        /a -
+        /b { pool ab }
+        /c { pool c }
+    }
+}
+"""
+    prof = ProfileData(line_counts={4: 1, 5: 999}, source="t")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_switch_already_hottest_first_not_reordered() -> None:
+    prof = ProfileData(line_counts={4: 500, 7: 30, 10: 5}, source="test")
+    assert find_pgo_suggestions(SWITCH, prof) == []

--- a/tests/test_pgo_reorder.py
+++ b/tests/test_pgo_reorder.py
@@ -149,6 +149,41 @@ when HTTP_REQUEST {
     assert find_pgo_suggestions(src, prof) == []
 
 
+def test_numeric_equality_rejected() -> None:
+    # Numeric ``==`` is excluded: 1 == 01 == 1.0, so distinct literal text
+    # does NOT prove the arms are mutually exclusive (Codex review P2).
+    src = """\
+when HTTP_REQUEST {
+    if {$x == 1} {
+        set r 1
+    } elseif {$x == 01} {
+        set r 2
+    } elseif {$x == 2} {
+        set r 3
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 999, 7: 1}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_backslash_escape_constant_rejected() -> None:
+    # "\x41" and "A" are textually distinct but the same runtime string.
+    src = """\
+when HTTP_REQUEST {
+    if {$x eq "A"} {
+        set r 1
+    } elseif {$x eq "\\x41"} {
+        set r 2
+    } elseif {$x eq "B"} {
+        set r 3
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 999, 7: 1}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
 def test_repeated_constant_rejected() -> None:
     # Two clauses testing the same value are not a clean dispatch.
     src = """\

--- a/tests/test_pgo_reorder.py
+++ b/tests/test_pgo_reorder.py
@@ -1,0 +1,200 @@
+"""Tests for profile-guided branch-reordering suggestions (P100)."""
+
+from __future__ import annotations
+
+from compiler.pgo import find_pgo_suggestions
+from compiler.pgo.profile_data import ProfileData
+from compiler.pgo.reorder import REORDER_CODE
+from compiler.pgo.trace_parser import parse_f5_log
+from shared.text_edits import apply_edits
+
+# An if/elseif equality-dispatch chain (the article's dc_1 idiom, extended
+# to three addresses).  Body lines: pool_a=3, pool_b=5, pool_c=7.
+DISPATCH = """\
+when HTTP_REQUEST {
+    if {[IP::remote_addr] eq "10.0.0.1"} {
+        pool pool_a
+    } elseif {[IP::remote_addr] eq "10.0.0.2"} {
+        pool pool_b
+    } elseif {[IP::remote_addr] eq "10.0.0.3"} {
+        pool pool_c
+    }
+}
+"""
+
+
+def _apply(source: str, suggestions: list) -> str:
+    edits = [
+        (s.range.start.offset, s.range.end.offset + 1 - s.range.start.offset, s.replacement)
+        for s in suggestions
+    ]
+    return apply_edits(source, edits)
+
+
+def test_precise_line_profile_reorders_hottest_first() -> None:
+    # pool_b (line 5) is hottest, then pool_c (7), then pool_a (3).
+    prof = ProfileData(line_counts={3: 10, 5: 900, 7: 50}, source="test")
+    sugs = find_pgo_suggestions(DISPATCH, prof)
+    assert len(sugs) == 1
+    sug = sugs[0]
+    assert sug.code == REORDER_CODE
+    assert sug.hint_only is True
+    assert "10.0.0.2" in sug.message
+
+    rewritten = _apply(DISPATCH, sugs)
+    # Hottest branch tested first, original first branch demoted to last.
+    first_if = rewritten.index('if {[IP::remote_addr]')
+    assert rewritten[first_if:].startswith('if {[IP::remote_addr] eq "10.0.0.2"}')
+    # Order of the three constants in the rewrite reflects the weights.
+    order = [rewritten.index(f'"10.0.0.{n}"') for n in (2, 3, 1)]
+    assert order == sorted(order)
+
+
+def test_no_suggestion_when_already_hottest_first() -> None:
+    prof = ProfileData(line_counts={3: 900, 5: 50, 7: 10}, source="test")
+    assert find_pgo_suggestions(DISPATCH, prof) == []
+
+
+def test_no_suggestion_without_a_profile() -> None:
+    assert find_pgo_suggestions(DISPATCH, ProfileData()) == []
+
+
+def test_two_branch_if_else_is_not_reordered() -> None:
+    # Only one condition to test (plus else) — nothing to reorder.
+    src = """\
+when HTTP_REQUEST {
+    if {[IP::remote_addr] eq "10.0.0.1"} {
+        pool a
+    } else {
+        pool b
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 1000}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_else_clause_preserved_last() -> None:
+    src = """\
+when HTTP_REQUEST {
+    if {$x eq "a"} {
+        set r 1
+    } elseif {$x eq "b"} {
+        set r 2
+    } elseif {$x eq "c"} {
+        set r 3
+    } else {
+        set r 0
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 1, 7: 999}, source="test")
+    sugs = find_pgo_suggestions(src, prof)
+    assert len(sugs) == 1
+    rewritten = _apply(src, sugs)
+    assert rewritten.rstrip().endswith("}")
+    # else stays after every elseif.
+    assert rewritten.index("else {") > rewritten.rindex("elseif")
+
+
+# --- safety gate -----------------------------------------------------------
+
+
+def test_side_effecting_subject_rejected() -> None:
+    # HTTP::header replace mutates state — must not be reordered around.
+    src = """\
+when HTTP_REQUEST {
+    if {[HTTP::header replace X] eq "a"} {
+        set r 1
+    } elseif {[HTTP::header replace X] eq "b"} {
+        set r 2
+    } elseif {[HTTP::header replace X] eq "c"} {
+        set r 3
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 1, 7: 999}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_mixed_operators_rejected() -> None:
+    src = """\
+when HTTP_REQUEST {
+    if {$x eq "a"} {
+        set r 1
+    } elseif {$x ne "b"} {
+        set r 2
+    } elseif {$x eq "c"} {
+        set r 3
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 999, 7: 1}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_different_subjects_rejected() -> None:
+    src = """\
+when HTTP_REQUEST {
+    if {$x eq "a"} {
+        set r 1
+    } elseif {$y eq "b"} {
+        set r 2
+    } elseif {$x eq "c"} {
+        set r 3
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 999, 7: 1}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+def test_repeated_constant_rejected() -> None:
+    # Two clauses testing the same value are not a clean dispatch.
+    src = """\
+when HTTP_REQUEST {
+    if {$x eq "a"} {
+        set r 1
+    } elseif {$x eq "a"} {
+        set r 2
+    } elseif {$x eq "c"} {
+        set r 3
+    }
+}
+"""
+    prof = ProfileData(line_counts={3: 1, 5: 999, 7: 1}, source="test")
+    assert find_pgo_suggestions(src, prof) == []
+
+
+# --- coarse F5-log attribution ---------------------------------------------
+
+
+def test_coarse_command_attribution_ranks_distinct_commands() -> None:
+    src = (
+        'when HTTP_REQUEST {\n'
+        '    if {$x eq "a"} { log local0. hit }'
+        ' elseif {$x eq "b"} { HTTP::redirect http://x }\n'
+        "}\n"
+    )
+    log = "\n".join(
+        [
+            "1,RP_CMD_ENTRY,/Common/vs1,HTTP::redirect,1,0x1,a,1,0,b,2,0",
+            "2,RP_CMD_ENTRY,/Common/vs1,HTTP::redirect,1,0x1,a,1,0,b,2,0",
+            "3,RP_CMD_ENTRY,/Common/vs1,log,1,0x1,a,1,0,b,2,0",
+        ]
+    )
+    sugs = find_pgo_suggestions(src, parse_f5_log(log))
+    assert len(sugs) == 1
+    assert "b" in sugs[0].message
+
+
+def test_coarse_cannot_rank_same_command_branches() -> None:
+    # pool/pool/pool collide under coarse command attribution — no
+    # (potentially wrong) suggestion is emitted.
+    log = "\n".join(
+        [
+            "1,RP_CMD_ENTRY,/Common/vs1,IP::remote_addr,1,0x1,a,1,0,b,2,0",
+            "2,RP_EVENT_ENTRY,/Common/vs1,HTTP_REQUEST,1,0x1,a,1,0,b,2,0",
+        ]
+    )
+    assert find_pgo_suggestions(DISPATCH, parse_f5_log(log)) == []

--- a/tests/test_pgo_reorder.py
+++ b/tests/test_pgo_reorder.py
@@ -43,7 +43,7 @@ def test_precise_line_profile_reorders_hottest_first() -> None:
 
     rewritten = _apply(DISPATCH, sugs)
     # Hottest branch tested first, original first branch demoted to last.
-    first_if = rewritten.index('if {[IP::remote_addr]')
+    first_if = rewritten.index("if {[IP::remote_addr]")
     assert rewritten[first_if:].startswith('if {[IP::remote_addr] eq "10.0.0.2"}')
     # Order of the three constants in the rewrite reflects the weights.
     order = [rewritten.index(f'"10.0.0.{n}"') for n in (2, 3, 1)]
@@ -171,7 +171,7 @@ when HTTP_REQUEST {
 
 def test_coarse_command_attribution_ranks_distinct_commands() -> None:
     src = (
-        'when HTTP_REQUEST {\n'
+        "when HTTP_REQUEST {\n"
         '    if {$x eq "a"} { log local0. hit }'
         ' elseif {$x eq "b"} { HTTP::redirect http://x }\n'
         "}\n"

--- a/tests/test_pgo_trace_parser.py
+++ b/tests/test_pgo_trace_parser.py
@@ -83,3 +83,47 @@ def test_merge_sums_counts() -> None:
 def test_empty_profile_is_empty() -> None:
     assert ProfileData().is_empty
     assert parse_f5_log("").is_empty
+
+
+def test_tolerates_syslog_prefix() -> None:
+    # Real /var/log/ltm lines wrap the CSV payload in a syslog prefix.
+    line = (
+        "Nov 24 06:22:32 bigip1 info tmm[18291]: "
+        "1511494952932622,RP_RULE_ENTRY,/Common/vs1,/Common/dc_1,"
+        "18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,0"
+    )
+    occs = parse_f5_occurrences(line)
+    assert len(occs) == 1
+    assert occs[0].kind is OccurrenceKind.RULE_ENTRY
+    assert occs[0].value == "/Common/dc_1"
+    assert occs[0].timestamp_us == 1511494952932622
+    assert occs[0].context is not None
+    assert occs[0].context.virtual_server == "/Common/vs1"
+    assert occs[0].context.process_id == 18291
+
+
+def test_rule_span_timing() -> None:
+    # RP_RULE_ENTRY → RP_RULE_EXIT span correlates to BIG-IP per-rule timing.
+    log = "\n".join(
+        [
+            "1000,RP_RULE_ENTRY,/Common/vs1,/Common/dc_1,1,0x1,a,1,0,b,2,0",
+            "1042,RP_RULE_EXIT,/Common/vs1,/Common/dc_1,1,0x1,a,1,0,b,2,0",
+        ]
+    )
+    prof = parse_f5_log(log)
+    assert prof.rule_time_us == {"/Common/dc_1": 42}
+
+
+def test_multi_tmm_timing_paired_per_flow() -> None:
+    # Two TMM (distinct pids) interleave; spans must not cross pid/flow.
+    log = "\n".join(
+        [
+            "1000,RP_CMD_ENTRY,/Common/vs1,table,1,0xA,a,1,0,b,2,0",
+            "1005,RP_CMD_ENTRY,/Common/vs1,table,2,0xB,a,1,0,b,2,0",
+            "1010,RP_CMD_EXIT,/Common/vs1,table,2,0xB,a,1,0,b,2,0",  # pid2: 5µs
+            "1100,RP_CMD_EXIT,/Common/vs1,table,1,0xA,a,1,0,b,2,0",  # pid1: 100µs
+        ]
+    )
+    prof = parse_f5_log(log)
+    assert prof.command_time_us == {"table": 105}
+

--- a/tests/test_pgo_trace_parser.py
+++ b/tests/test_pgo_trace_parser.py
@@ -126,4 +126,3 @@ def test_multi_tmm_timing_paired_per_flow() -> None:
     )
     prof = parse_f5_log(log)
     assert prof.command_time_us == {"table": 105}
-

--- a/tests/test_pgo_trace_parser.py
+++ b/tests/test_pgo_trace_parser.py
@@ -1,0 +1,85 @@
+"""Tests for the F5 rule-profiler occurrence-log importer."""
+
+from __future__ import annotations
+
+from compiler.pgo.occurrence import OccurrenceKind
+from compiler.pgo.profile_data import ProfileData, merge
+from compiler.pgo.trace_parser import parse_f5_log, parse_f5_occurrences
+
+# A small capture modelled on the community-article example (the dc_1 rule).
+SAMPLE_LOG = """\
+1511494952932589,RP_EVENT_ENTRY,/Common/vs1,CLIENT_ACCEPTED,18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,
+1511494952932622,RP_RULE_ENTRY,/Common/vs1,/Common/dc_1,18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,0
+1511494952932630,RP_CMD_ENTRY,/Common/vs1,IP::remote_addr,18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,0
+1511494952932633,RP_CMD_EXIT,/Common/vs1,IP::remote_addr,18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,0
+1511494952932638,RP_VAR_MOD,/Common/vs1,the_one=true,18291,0x9455,10.10.10.2,46052,0,10.10.10.160,80,0
+1511673715911280,RP_CMD_BYTECODE,/Common/vs1,push1,18291,0x9455,10.10.10.2,41772,0,10.10.10.160,80,2
+"""
+
+
+def test_parses_each_occurrence_kind() -> None:
+    occs = parse_f5_occurrences(SAMPLE_LOG)
+    kinds = [o.kind for o in occs]
+    assert kinds == [
+        OccurrenceKind.EVENT_ENTRY,
+        OccurrenceKind.RULE_ENTRY,
+        OccurrenceKind.CMD_ENTER,
+        OccurrenceKind.CMD_EXIT,
+        OccurrenceKind.VAR_MOD,
+        OccurrenceKind.BYTECODE,
+    ]
+
+
+def test_aggregated_counts() -> None:
+    prof = parse_f5_log(SAMPLE_LOG)
+    assert prof.source == "f5-log"
+    assert prof.event_counts == {"CLIENT_ACCEPTED": 1}
+    assert prof.command_counts == {"IP::remote_addr": 1}
+    assert prof.var_mod_counts == {"the_one": 1}
+    assert prof.bytecode_counts == {"push1": 1}
+    # F5 logs carry no source lines.
+    assert not prof.has_line_data
+    assert prof.has_command_data
+
+
+def test_command_timing_from_enter_exit() -> None:
+    prof = parse_f5_log(SAMPLE_LOG)
+    # CMD_EXIT (…633) − CMD_ENTRY (…630) == 3µs for IP::remote_addr.
+    assert prof.command_time_us["IP::remote_addr"] == 3
+
+
+def test_flow_context_captured() -> None:
+    occs = parse_f5_occurrences(SAMPLE_LOG)
+    ctx = occs[0].context
+    assert ctx is not None
+    assert ctx.virtual_server == "/Common/vs1"
+    assert ctx.remote_addr == "10.10.10.2"
+    assert ctx.local_port == 80
+    assert ctx.flow_id == "0x9455"
+
+
+def test_malformed_and_unknown_lines_skipped() -> None:
+    text = "\n".join(
+        [
+            "",
+            "# a comment",
+            "not,enough",
+            "123,RP_UNKNOWN_TYPE,/Common/vs1,foo,1,0x1,a,1,0,b,2,0",
+            "456,RP_CMD_ENTRY,/Common/vs1,log,1,0x1,a,1,0,b,2,0",
+        ]
+    )
+    prof = parse_f5_log(text)
+    assert prof.command_counts == {"log": 1}
+
+
+def test_merge_sums_counts() -> None:
+    a = parse_f5_log(SAMPLE_LOG)
+    b = parse_f5_log(SAMPLE_LOG)
+    m = merge([a, b])
+    assert m.command_counts == {"IP::remote_addr": 2}
+    assert m.event_counts == {"CLIENT_ACCEPTED": 2}
+
+
+def test_empty_profile_is_empty() -> None:
+    assert ProfileData().is_empty
+    assert parse_f5_log("").is_empty

--- a/tooling/f5/verbs/irule.py
+++ b/tooling/f5/verbs/irule.py
@@ -630,13 +630,23 @@ def _load_pgo_stimuli(path: str):
         if not isinstance(item, dict):
             print("error: each stimulus must be a JSON object", file=sys.stderr)
             return 2
-        stimuli.append(
-            Stimulus(
-                event=str(item.get("event", "HTTP_REQUEST")),
-                state=item.get("state", {}) or {},
-                repeat=int(item.get("repeat", 1)),
+        event = item.get("event", "HTTP_REQUEST")
+        if not isinstance(event, str):
+            print("error: stimulus 'event' must be a string", file=sys.stderr)
+            return 2
+        state = item.get("state", {})
+        if not isinstance(state, dict) or not all(isinstance(v, dict) for v in state.values()):
+            print(
+                "error: stimulus 'state' must be an object of {layer: {key: value}}",
+                file=sys.stderr,
             )
-        )
+            return 2
+        repeat = item.get("repeat", 1)
+        # bool is a subclass of int — reject true/false as a count.
+        if isinstance(repeat, bool) or not isinstance(repeat, int) or repeat < 1:
+            print("error: stimulus 'repeat' must be a positive integer", file=sys.stderr)
+            return 2
+        stimuli.append(Stimulus(event=event, state=state, repeat=repeat))
     return stimuli
 
 

--- a/tooling/f5/verbs/irule.py
+++ b/tooling/f5/verbs/irule.py
@@ -196,6 +196,47 @@ def add_irule_subparser(
     trace_p.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
     trace_p.set_defaults(handler=_run_irule_trace)
 
+    # ── pgo ────────────────────────────────────────────────────────────
+    pgo_p = irule_sub.add_parser(
+        "pgo",
+        help="Profile-guided suggestions: reorder branches by execution frequency.",
+        description=(
+            "Use an execution profile to suggest reordering if/elseif "
+            "equality-dispatch chains so the most-frequently-taken branch is "
+            "tested first.  Supply an F5 rule-profiler occurrence log with "
+            "--profile, or --capture to trace each input under a local tclsh.  "
+            "Suggestions are advisory; pass --apply to rewrite the chains.\n\n"
+            "Off by default: PGO never runs as part of the normal optimiser — "
+            "it only runs through this verb when a profile is supplied."
+        ),
+        epilog=(
+            "Examples:\n"
+            f"  {prog_name} irule pgo --profile rule_profiler.log rule.irule\n"
+            f"  {prog_name} irule pgo --profile rule_profiler.log rule.irule --apply -o tuned/\n"
+            f"  {prog_name} irule pgo --capture script.tcl\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_irule_input_arguments(pgo_p)
+    pgo_src = pgo_p.add_mutually_exclusive_group(required=True)
+    pgo_src.add_argument(
+        "--profile",
+        metavar="FILE",
+        help="F5 rule-profiler occurrence log ('-' for stdin).",
+    )
+    pgo_src.add_argument(
+        "--capture",
+        action="store_true",
+        help="Capture a profile by running each input under a local tclsh.",
+    )
+    pgo_p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Rewrite the reordered chains instead of only reporting suggestions.",
+    )
+    pgo_p.add_argument("--json", action="store_true", help="Emit suggestions as JSON.")
+    pgo_p.set_defaults(handler=_run_irule_pgo)
+
     # ── extract ────────────────────────────────────────────────────────
     extract_p = irule_sub.add_parser(
         "extract",
@@ -515,6 +556,122 @@ def _merge_configs_for_trace(configs: dict[str, BigipConfig]) -> BigipConfig:
     if len(configs) == 1:
         return next(iter(configs.values()))
     return _merge_configs(configs)
+
+
+def _capture_pgo_profile(source: str):
+    """Trace *source* under a local tclsh and return its profile, or ``None``."""
+    import os
+    import tempfile
+
+    from compiler.pgo.tclsh_capture import capture_profile, find_tclsh
+
+    if find_tclsh() is None:
+        return None
+    with tempfile.NamedTemporaryFile("w", suffix=".tcl", delete=False, encoding="utf-8") as fh:
+        fh.write(source)
+        tmp = fh.name
+    try:
+        return capture_profile(tmp)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _apply_pgo_suggestions(source: str, suggestions: list) -> str:
+    """Apply non-overlapping PGO rewrites (outermost wins) to *source*."""
+    from shared.text_edits import apply_edits
+
+    edits: list[tuple[int, int, str]] = []
+    last_end = -1
+    for sug in sorted(suggestions, key=lambda o: o.range.start.offset):
+        start = sug.range.start.offset
+        end = sug.range.end.offset
+        if start > last_end:  # skip nested/overlapping rewrites
+            edits.append((start, end - start + 1, sug.replacement))
+            last_end = end
+    return apply_edits(source, edits)
+
+
+def _run_irule_pgo(args: argparse.Namespace) -> int:
+    from compiler.pgo import find_pgo_suggestions, parse_f5_log
+    from compiler.pgo.profile_data import ProfileData
+
+    loaded = _resolve_irule_inputs(args)
+    if isinstance(loaded, int):
+        return loaded
+    inputs, _configs, _sources = loaded
+    configure_signatures(dialect=args.dialect)
+
+    shared_profile: ProfileData | None = None
+    if args.profile:
+        try:
+            log_text = sys.stdin.read() if args.profile == "-" else Path(args.profile).read_text(
+                encoding="utf-8"
+            )
+        except OSError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        shared_profile = parse_f5_log(log_text)
+
+    results: list[tuple[IruleInput, list, ProfileData | None]] = []
+    for entry in inputs:
+        if args.capture:
+            profile = _capture_pgo_profile(entry.source)
+            if profile is None:
+                print("error: --capture requires tclsh on PATH", file=sys.stderr)
+                return 2
+        else:
+            profile = shared_profile
+        suggestions = find_pgo_suggestions(entry.source, profile)
+        results.append((entry, suggestions, profile))
+
+    if args.apply:
+        transformed = [
+            _apply_pgo_suggestions(entry.source, suggestions)
+            for entry, suggestions, _ in results
+        ]
+        return _write_iRule_outputs(
+            args=args,
+            inputs=inputs,
+            transformed=transformed,
+            file_extension=".irule",
+        )
+
+    if args.json:
+        payload = {
+            "rules": [
+                {
+                    "rule": entry.rule_full_path or entry.label,
+                    "profileSource": profile.source if profile is not None else None,
+                    "suggestions": [
+                        {
+                            "code": sug.code,
+                            "line": sug.range.start.line + 1,
+                            "message": sug.message,
+                            "replacement": sug.replacement,
+                        }
+                        for sug in suggestions
+                    ],
+                }
+                for entry, suggestions, profile in results
+            ]
+        }
+        out = json.dumps(payload, indent=2) + "\n"
+    else:
+        lines: list[str] = []
+        for entry, suggestions, profile in results:
+            label = entry.rule_full_path or entry.label
+            tag = f" [profile: {profile.source}]" if profile is not None and profile.source else ""
+            lines.append(f"{label}: {len(suggestions)} suggestion(s){tag}")
+            for sug in suggestions:
+                lines.append(f"  line {sug.range.start.line + 1}: {sug.code} — {sug.message}")
+        out = "\n".join(lines) + "\n"
+
+    _write_text_output(args.output, out)
+    total = sum(len(suggestions) for _, suggestions, _ in results)
+    return 0 if total else 1
 
 
 def _slice_balanced_braces(source: str, open_brace: int) -> str:

--- a/tooling/f5/verbs/irule.py
+++ b/tooling/f5/verbs/irule.py
@@ -653,8 +653,10 @@ def _run_irule_pgo(args: argparse.Namespace) -> int:
     shared_profile: ProfileData | None = None
     if args.profile:
         try:
-            log_text = sys.stdin.read() if args.profile == "-" else Path(args.profile).read_text(
-                encoding="utf-8"
+            log_text = (
+                sys.stdin.read()
+                if args.profile == "-"
+                else Path(args.profile).read_text(encoding="utf-8")
             )
         except OSError as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -685,8 +687,7 @@ def _run_irule_pgo(args: argparse.Namespace) -> int:
 
     if args.apply:
         transformed = [
-            _apply_pgo_suggestions(entry.source, suggestions)
-            for entry, suggestions, _ in results
+            _apply_pgo_suggestions(entry.source, suggestions) for entry, suggestions, _ in results
         ]
         return _write_iRule_outputs(
             args=args,

--- a/tooling/f5/verbs/irule.py
+++ b/tooling/f5/verbs/irule.py
@@ -202,10 +202,12 @@ def add_irule_subparser(
         help="Profile-guided suggestions: reorder branches by execution frequency.",
         description=(
             "Use an execution profile to suggest reordering if/elseif "
-            "equality-dispatch chains so the most-frequently-taken branch is "
-            "tested first.  Supply an F5 rule-profiler occurrence log with "
-            "--profile, or --capture to trace each input under a local tclsh.  "
-            "Suggestions are advisory; pass --apply to rewrite the chains.\n\n"
+            "equality-dispatch chains and exact-match switch arms so the "
+            "most-frequently-taken branch is tested first.  Supply a profile "
+            "via --profile (an F5 rule-profiler occurrence log), --capture "
+            "(trace each input under a local tclsh), or --from-test (run each "
+            "input through the iRule test framework with a JSON stimuli file).  "
+            "Suggestions are advisory; pass --apply to rewrite.\n\n"
             "Off by default: PGO never runs as part of the normal optimiser — "
             "it only runs through this verb when a profile is supplied."
         ),
@@ -214,6 +216,7 @@ def add_irule_subparser(
             f"  {prog_name} irule pgo --profile rule_profiler.log rule.irule\n"
             f"  {prog_name} irule pgo --profile rule_profiler.log rule.irule --apply -o tuned/\n"
             f"  {prog_name} irule pgo --capture script.tcl\n"
+            f"  {prog_name} irule pgo --from-test stimuli.json rule.irule\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -228,6 +231,15 @@ def add_irule_subparser(
         "--capture",
         action="store_true",
         help="Capture a profile by running each input under a local tclsh.",
+    )
+    pgo_src.add_argument(
+        "--from-test",
+        metavar="STIMULI",
+        help=(
+            "Generate a profile by running each input through the iRule test "
+            "framework. STIMULI is a JSON list of "
+            '{"event": NAME, "state": {layer: {key: val}}, "repeat": N}.'
+        ),
     )
     pgo_p.add_argument(
         "--apply",
@@ -594,6 +606,40 @@ def _apply_pgo_suggestions(source: str, suggestions: list) -> str:
     return apply_edits(source, edits)
 
 
+def _load_pgo_stimuli(path: str):
+    """Load a ``--from-test`` stimuli JSON file into ``Stimulus`` objects.
+
+    Returns a list on success or an exit code (already-printed error) on
+    failure.  The file is a JSON list of objects with optional ``event``
+    (default ``HTTP_REQUEST``), ``state`` (``{layer: {key: val}}``) and
+    ``repeat`` (default 1) keys.
+    """
+    from tooling.irule_test.profile_gen import Stimulus
+
+    try:
+        raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError) as exc:
+        print(f"error: cannot read stimuli {path}: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(data, list):
+        print("error: stimuli JSON must be a list of stimulus objects", file=sys.stderr)
+        return 2
+    stimuli = []
+    for item in data:
+        if not isinstance(item, dict):
+            print("error: each stimulus must be a JSON object", file=sys.stderr)
+            return 2
+        stimuli.append(
+            Stimulus(
+                event=str(item.get("event", "HTTP_REQUEST")),
+                state=item.get("state", {}) or {},
+                repeat=int(item.get("repeat", 1)),
+            )
+        )
+    return stimuli
+
+
 def _run_irule_pgo(args: argparse.Namespace) -> int:
     from compiler.pgo import find_pgo_suggestions, parse_f5_log
     from compiler.pgo.profile_data import ProfileData
@@ -615,6 +661,12 @@ def _run_irule_pgo(args: argparse.Namespace) -> int:
             return 2
         shared_profile = parse_f5_log(log_text)
 
+    stimuli = None
+    if args.from_test:
+        stimuli = _load_pgo_stimuli(args.from_test)
+        if isinstance(stimuli, int):
+            return stimuli
+
     results: list[tuple[IruleInput, list, ProfileData | None]] = []
     for entry in inputs:
         if args.capture:
@@ -622,6 +674,10 @@ def _run_irule_pgo(args: argparse.Namespace) -> int:
             if profile is None:
                 print("error: --capture requires tclsh on PATH", file=sys.stderr)
                 return 2
+        elif stimuli is not None:
+            from tooling.irule_test.profile_gen import generate_profile
+
+            profile = generate_profile(entry.source, stimuli, profiles=["TCP", "HTTP"])
         else:
             profile = shared_profile
         suggestions = find_pgo_suggestions(entry.source, profile)

--- a/tooling/irule_test/bridge.py
+++ b/tooling/irule_test/bridge.py
@@ -34,6 +34,7 @@ _FRAMEWORK_FILES = [
     "state_layers.tcl",
     "tmm_shim.tcl",
     "expr_ops.tcl",
+    "profiler.tcl",
     "command_mocks.tcl",
     "_mock_stubs.tcl",
     "itest_core.tcl",
@@ -639,6 +640,15 @@ class IruleTestSession:
             flat.extend([k, str(v)])
         await self._send({"cmd": "set_state", "layer": layer, "values": flat})
 
+    async def eval_tcl(self, script: str) -> str:
+        """Evaluate a raw Tcl *script* in the framework and return its result.
+
+        Used by tooling that drives framework internals directly (e.g. the
+        profile generator toggling ``::itest::profiler``).
+        """
+        resp = await self._send({"cmd": "eval", "script": script})
+        return str(resp.get("result", ""))
+
     async def fire_event(self, event: str) -> EventResult:
         """Fire a single event and return the result."""
         resp = await self._send({"cmd": "fire_event", "event": event})
@@ -965,6 +975,14 @@ class IruleTestSessionSync:
     def close_connection(self) -> None:
         assert self._session and self._loop
         self._loop.run_until_complete(self._session.close_connection())
+
+    def set_state(self, layer: str, values: dict[str, Any]) -> None:
+        assert self._session and self._loop
+        self._loop.run_until_complete(self._session.set_state(layer, values))
+
+    def eval_tcl(self, script: str) -> str:
+        assert self._session and self._loop
+        return self._loop.run_until_complete(self._session.eval_tcl(script))
 
     def get_decisions(self, category: str = "") -> list[tuple[str, str, Any]]:
         assert self._session and self._loop

--- a/tooling/irule_test/profile_gen.py
+++ b/tooling/irule_test/profile_gen.py
@@ -56,9 +56,7 @@ def generate_occurrence_log(
     Returns an empty string if the test framework backend is unavailable.
     """
     try:
-        session_cm = IruleTestSessionSync(
-            profiles=profiles or ["TCP", "HTTP"], backend=backend
-        )
+        session_cm = IruleTestSessionSync(profiles=profiles or ["TCP", "HTTP"], backend=backend)
     except Exception:
         return ""
     try:
@@ -83,7 +81,5 @@ def generate_profile(
     backend: str = "auto",
 ) -> ProfileData:
     """Run *irule_source* against *stimuli* and return aggregated profile data."""
-    log = generate_occurrence_log(
-        irule_source, stimuli, profiles=profiles, backend=backend
-    )
+    log = generate_occurrence_log(irule_source, stimuli, profiles=profiles, backend=backend)
     return ProfileData.from_occurrences(parse_f5_occurrences(log), source="test-gen")

--- a/tooling/irule_test/profile_gen.py
+++ b/tooling/irule_test/profile_gen.py
@@ -1,0 +1,89 @@
+"""Generate synthetic rule-profiler logs by running an iRule under test.
+
+The iRule testing framework already mocks every extension command and
+fires events; with the (default-off) ``::itest::profiler`` instrumentation
+enabled, a test run emits a count- and sequence-accurate occurrence stream
+in the F5 BIG-IP rule-profiler CSV format — *without a real BIG-IP*.
+
+This module drives that: given an iRule and a list of stimuli (events to
+fire, optionally with connection/request state and a repeat count), it runs
+them through :class:`~tooling.irule_test.bridge.IruleTestSessionSync`,
+collects the profiler stream, and returns it as log text or a
+:class:`~compiler.pgo.profile_data.ProfileData`.
+
+**Accuracy caveat:** timestamps are a monotonic ordinal, not wall-clock,
+so this drives *frequency*-based profile-guided optimisation (which branch
+is hot) — not real performance numbers.  As on a real BIG-IP, bytecode-
+compiled core commands (``set``, ``if`` …) do not appear as command
+occurrences.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from compiler.pgo.profile_data import ProfileData
+from compiler.pgo.trace_parser import parse_f5_occurrences
+
+from .bridge import IruleTestSessionSync
+
+
+@dataclass(frozen=True)
+class Stimulus:
+    """One unit of traffic to drive the iRule with.
+
+    ``state`` is applied (per layer, e.g. ``{"connection": {"client_addr":
+    "10.0.0.2"}}``) before the event fires; ``event`` is then fired
+    ``repeat`` times.  Setting state once and repeating models a burst of
+    like traffic — the common case for surfacing a hot branch.
+    """
+
+    event: str = "HTTP_REQUEST"
+    state: dict[str, dict[str, Any]] = field(default_factory=dict)
+    repeat: int = 1
+
+
+def generate_occurrence_log(
+    irule_source: str,
+    stimuli: list[Stimulus],
+    *,
+    profiles: list[str] | None = None,
+    backend: str = "auto",
+) -> str:
+    """Run *irule_source* against *stimuli* and return rule-profiler log text.
+
+    Returns an empty string if the test framework backend is unavailable.
+    """
+    try:
+        session_cm = IruleTestSessionSync(
+            profiles=profiles or ["TCP", "HTTP"], backend=backend
+        )
+    except Exception:
+        return ""
+    try:
+        with session_cm as session:
+            session.load_irule(irule_source)
+            session.eval_tcl("::itest::profiler::enable")
+            for stim in stimuli:
+                for layer, values in stim.state.items():
+                    session.set_state(layer, values)
+                for _ in range(max(1, stim.repeat)):
+                    session.fire_event(stim.event)
+            return session.eval_tcl("::itest::profiler::dump")
+    except Exception:
+        return ""
+
+
+def generate_profile(
+    irule_source: str,
+    stimuli: list[Stimulus],
+    *,
+    profiles: list[str] | None = None,
+    backend: str = "auto",
+) -> ProfileData:
+    """Run *irule_source* against *stimuli* and return aggregated profile data."""
+    log = generate_occurrence_log(
+        irule_source, stimuli, profiles=profiles, backend=backend
+    )
+    return ProfileData.from_occurrences(parse_f5_occurrences(log), source="test-gen")

--- a/tooling/irule_test/tcl/command_mocks.tcl
+++ b/tooling/irule_test/tcl/command_mocks.tcl
@@ -82,7 +82,15 @@ namespace eval ::itest {
             # Try our command dispatch first
             set resolved [::itest::_resolve_command $cmd]
             if {$resolved ne ""} {
-                return [eval $resolved $args]
+                # Profiler hook (no-op unless enabled): record the command
+                # under its real iRule spelling, around its execution.
+                ::itest::profiler::emit RP_CMD_ENTRY $cmd
+                set _rc [catch {eval $resolved $args} _res]
+                ::itest::profiler::emit RP_CMD_EXIT $cmd
+                if {$_rc} {
+                    return -code $_rc $_res
+                }
+                return $_res
             }
 
             # Fall through to original unknown if it exists

--- a/tooling/irule_test/tcl/command_mocks.tcl
+++ b/tooling/irule_test/tcl/command_mocks.tcl
@@ -82,12 +82,21 @@ namespace eval ::itest {
             # Try our command dispatch first
             set resolved [::itest::_resolve_command $cmd]
             if {$resolved ne ""} {
-                # Profiler hook (no-op unless enabled): record the command
-                # under its real iRule spelling, around its execution.
+                # Fast path: when the profiler is off (the default), dispatch
+                # exactly as before so error propagation is untouched.
+                if {!$::itest::profiler::enabled} {
+                    return [eval $resolved $args]
+                }
+                # Profiler on: record the command under its real iRule
+                # spelling around execution, then re-raise preserving the
+                # full error context (-errorinfo / -errorcode) so a failing
+                # mock is no harder to debug than the direct dispatch.
                 ::itest::profiler::emit RP_CMD_ENTRY $cmd
                 set _rc [catch {eval $resolved $args} _res]
                 ::itest::profiler::emit RP_CMD_EXIT $cmd
-                if {$_rc} {
+                if {$_rc == 1} {
+                    return -code error -errorinfo $::errorInfo -errorcode $::errorCode $_res
+                } elseif {$_rc != 0} {
                     return -code $_rc $_res
                 }
                 return $_res

--- a/tooling/irule_test/tcl/example_multi_tmm_test.tcl
+++ b/tooling/irule_test/tcl/example_multi_tmm_test.tcl
@@ -27,6 +27,7 @@ source [file join $script_dir compat84.tcl]
 source [file join $script_dir state_layers.tcl]
 source [file join $script_dir tmm_shim.tcl]
 source [file join $script_dir expr_ops.tcl]
+source [file join $script_dir profiler.tcl]
 source [file join $script_dir command_mocks.tcl]
 if {[file exists [file join $script_dir _mock_stubs.tcl]]} {
     source [file join $script_dir _mock_stubs.tcl]

--- a/tooling/irule_test/tcl/example_test.tcl
+++ b/tooling/irule_test/tcl/example_test.tcl
@@ -16,6 +16,7 @@ source [file join $script_dir compat84.tcl]
 source [file join $script_dir state_layers.tcl]
 source [file join $script_dir tmm_shim.tcl]
 source [file join $script_dir expr_ops.tcl]
+source [file join $script_dir profiler.tcl]
 source [file join $script_dir command_mocks.tcl]
 if {[file exists [file join $script_dir _mock_stubs.tcl]]} {
     source [file join $script_dir _mock_stubs.tcl]

--- a/tooling/irule_test/tcl/itest_core.tcl
+++ b/tooling/irule_test/tcl/itest_core.tcl
@@ -119,13 +119,19 @@ namespace eval ::itest {
         set handlers $event_handlers($event_name)
         set sorted [lsort -index 0 -integer $handlers]
 
+        # Profiler hooks (no-op unless enabled): bracket the event and each
+        # rule handler so the occurrence stream mirrors the iRule timing
+        # hierarchy (event -> rule -> commands).
+        ::itest::profiler::emit RP_EVENT_ENTRY $event_name
         set results [list]
         foreach handler $sorted {
             set priority [lindex $handler 0]
             set proc_name [lindex $handler 1]
             set current_priority $priority
 
+            ::itest::profiler::emit RP_RULE_ENTRY [::itest::profiler::rule]
             set code [catch {$proc_name} result]
+            ::itest::profiler::emit RP_RULE_EXIT [::itest::profiler::rule]
             if {$code == 1} {
                 # Error -- single entry with error info
                 lappend results [list priority $priority code $code error $result errorInfo $::errorInfo]
@@ -133,6 +139,7 @@ namespace eval ::itest {
                 lappend results [list priority $priority code $code result $result]
             }
         }
+        ::itest::profiler::emit RP_EVENT_EXIT $event_name
 
         return [list fired 1 handlers $results]
     }

--- a/tooling/irule_test/tcl/profiler.tcl
+++ b/tooling/irule_test/tcl/profiler.tcl
@@ -1,0 +1,98 @@
+# profiler.tcl -- synthetic rule-profiler occurrence emitter
+#
+# Optional, OFF BY DEFAULT.  When enabled, the event firer
+# (itest_core.tcl) and the command dispatcher (command_mocks.tcl unknown
+# handler) call ::itest::profiler::emit to record occurrences in the F5
+# BIG-IP rule-profiler CSV format.  This lets a test run produce a
+# profile (compiler/pgo consumes it) WITHOUT a real BIG-IP.
+#
+# The occurrence stream is count- and sequence-accurate (it reflects the
+# commands and events the test actually exercised); timestamps are a
+# monotonic ordinal, NOT wall-clock microseconds, so derived "timing" is
+# only a proxy for work done -- not real performance data.
+#
+# Core Tcl commands compiled to bytecode (set, if, expr, ...) do not pass
+# through the unknown handler, so -- exactly as on a real BIG-IP -- they
+# do not appear as RP_CMD_ENTRY occurrences.
+#
+# Copyright (c) 2024 tcl-lsp contributors.  MIT licence.
+
+namespace eval ::itest::profiler {
+
+    variable enabled 0
+    variable stream [list]
+    variable seq 0
+
+    # Connection / flow context applied to every emitted record.  Mirrors
+    # the rule-profiler field layout; defaults are placeholders a test
+    # harness can override via ::itest::profiler::configure.
+    variable ctx
+    if {![info exists ctx]} {
+        array set ctx {
+            vs          /Common/vs_test
+            rule        /Common/test_irule
+            pid         1
+            flow        0x1
+            remote_addr 10.0.0.1
+            remote_port 0
+            remote_rd   0
+            local_addr  10.0.0.250
+            local_port  80
+            local_rd    0
+        }
+    }
+
+    # Begin a fresh capture.
+    proc enable {} {
+        variable enabled
+        variable stream
+        variable seq
+        set enabled 1
+        set stream [list]
+        set seq 0
+    }
+
+    proc disable {} {
+        variable enabled
+        set enabled 0
+    }
+
+    # Override one or more context fields: -vs, -flow, -remote_addr, ...
+    proc configure {args} {
+        variable ctx
+        foreach {key value} $args {
+            set name [string trimleft $key -]
+            if {[info exists ctx($name)]} {
+                set ctx($name) $value
+            }
+        }
+    }
+
+    # The rule name used for RP_RULE_ENTRY / RP_RULE_EXIT.
+    proc rule {} {
+        variable ctx
+        return $ctx(rule)
+    }
+
+    # Record one occurrence.  No-op (and cheap) unless enabled.
+    proc emit {rp_type value {depth {}}} {
+        variable enabled
+        if {!$enabled} {
+            return
+        }
+        variable stream
+        variable seq
+        variable ctx
+        incr seq
+        lappend stream [join [list \
+            $seq $rp_type $ctx(vs) $value $ctx(pid) $ctx(flow) \
+            $ctx(remote_addr) $ctx(remote_port) $ctx(remote_rd) \
+            $ctx(local_addr) $ctx(local_port) $ctx(local_rd) $depth] ,]
+    }
+
+    # Return the captured stream as rule-profiler log text.
+    proc dump {} {
+        variable stream
+        return [join $stream "\n"]
+    }
+}

--- a/tooling/irule_test/tcl/runner.tcl
+++ b/tooling/irule_test/tcl/runner.tcl
@@ -35,6 +35,7 @@ source [file join $_runner_dir compat84.tcl]
 source [file join $_runner_dir state_layers.tcl]
 source [file join $_runner_dir tmm_shim.tcl]
 source [file join $_runner_dir expr_ops.tcl]
+source [file join $_runner_dir profiler.tcl]
 source [file join $_runner_dir command_mocks.tcl]
 if {[file exists [file join $_runner_dir _mock_stubs.tcl]]} {
     source [file join $_runner_dir _mock_stubs.tcl]


### PR DESCRIPTION
## Summary

Implements profile-guided optimisation (PGO) for reordering branches by execution frequency. Given an execution profile, the system suggests reordering `if`/`elseif` equality-dispatch chains and exact-match `switch` arms so the most-frequently-taken branch is tested first, reducing comparisons on the common path.

### Key Features

- **Branch reordering analysis** (`compiler/pgo/reorder.py`): Identifies reorderable constructs and generates suggestions with materialised replacements
  - `if`/`elseif` equality-dispatch chains (subject must be side-effect-free)
  - Exact-match `switch` arms (safer: subject evaluated once)
  - Preserves `else` clauses at the end; skips overlapping/nested rewrites

- **Profile data model** (`compiler/pgo/profile_data.py`, `compiler/pgo/occurrence.py`): Normalised, lossless representation covering both C Tcl traces and F5 BIG-IP rule-profiler logs
  - Per-line counts (precise, from tclsh `enterstep` trace)
  - Per-command counts (coarse, from F5 logs)
  - Event/rule/VM/bytecode/variable-modification occurrences with flow context
  - Span-timing views (command/rule/event microseconds)

- **Profile importers**:
  - `compiler/pgo/trace_parser.py`: F5 rule-profiler CSV log parser
  - `compiler/pgo/tclsh_capture.py`: Precise profile capture via local tclsh with execution tracing

- **Test framework integration** (`tooling/irule_test/profile_gen.py`, `tooling/irule_test/tcl/profiler.tcl`): Synthetic rule-profiler occurrence emitter for generating profiles from iRule test runs without a real BIG-IP

- **CLI entry point** (`tooling/f5/verbs/irule.py`): New `irule pgo` subcommand with `--profile`, `--capture`, `--from-test` options and `--apply` to rewrite

- **Code registration** (`shared/codes.py`): New `CodeKind.PGO` to keep PGO codes (P100) out of standard optimisation profiles—PGO is opt-in only

### Safety & Design

- PGO is **off by default**: never runs in the standard optimiser pipeline; only via explicit `irule pgo` entry points
- Suggestions are `hint_only` with materialised replacements for opt-in `--apply`
- Equality-dispatch chains require same subject and distinct constants (mutually exclusive)
- Subject purity check: variable reads or side-effect-free commands only (reordering changes evaluation count)
- Switch arms are safer (subject evaluated once) and require distinct, non-fallthrough patterns

### Testing

- Comprehensive unit tests for reordering logic, profile parsing, and safety gates
- Tests for coarse (command-based) and precise (line-based) attribution
- Integration tests with iRule test framework backend
- Validation that PGO codes are excluded from standard optimisation profiles

## Validation

- [x] Added 271 lines of tests in `tests/test_pgo_reorder.py` covering reordering, safety gates, and attribution
- [x] Added 141 lines of tests in `tests/test_pgo_profile_gen.py` for profile generation and round-tripping
- [x] Added 129 lines of tests in `tests/test_pgo_trace_parser.py` for F5 log parsing and aggregation
- [x] Added 52 lines of tests in `tests/test_pgo_off_by_default.py` validating PGO is excluded from standard profiles
- [x] All new modules include comprehensive docstrings explaining design and limitations

https://claude.ai/code/session_018Y6k4xwJVzhbZzfTbKUxod