### PR TITLE
Tcl 9 features: lseq doubles, scan charset/float, binary unsigned, apply defaults

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=b853774-dirty
-head=b853774a32bf71aea846cd6618414ddb8083f2ab
-date=2026-06-01T10:58:05Z
-fingerprint=2f7f14a47a5be1b52088677e3afae8266426a86fd61ad6e25425aa3bbe808b9a
+describe=8bbf26a-dirty
+head=8bbf26a742b6fee804292ecafcf24faa0cd0dda8
+date=2026-06-01T18:08:33Z
+fingerprint=dedf0d93fdf837f792387ddf6338803a5f80eeaf66609dbe62bb6d126b4231c3

--- a/compiler/codegen/wasm/_emitter/_control_flow.py
+++ b/compiler/codegen/wasm/_emitter/_control_flow.py
@@ -361,13 +361,35 @@ class _WasmEmitterCtrlMixin(_Base):
         self._emit(WasmOp.END)
         self._emit(WasmOp.END)
 
-    def _emit_switch(self, subject: str, arms, default_body, *, mode: str = "exact") -> None:
+    def _emit_switch(
+        self,
+        subject: str,
+        arms,
+        default_body,
+        *,
+        mode: str = "exact",
+        patterns_braced: bool = True,
+    ) -> None:
         """Emit a switch statement as a chain of if/else.
 
         Uses ``string_equal`` for exact matching and ``string_match``
         for glob matching.  Falls back to i64 integer comparison when
         the runtime imports are unavailable.
+
+        *patterns_braced* is True when the arms came from a single braced
+        ``{pat body ...}`` block (patterns are literal list elements) and
+        False when they came as separate words (``switch $s $pat {body}``),
+        in which case each pattern is a substitutable word and must be
+        emitted via ``_emit_value`` so ``$pattern`` resolves to its value
+        rather than being matched as the literal text ``$pattern``.
         """
+
+        def _emit_pattern(p: str) -> None:
+            if patterns_braced:
+                self._emit_obj_literal(p)
+            else:
+                self._emit_value(p)
+
         # Determine comparison function
         if mode == "glob":
             cmp_import = self._shared_imports.get("tcl_string_match")
@@ -397,11 +419,11 @@ class _WasmEmitterCtrlMixin(_Base):
             for g_idx, (patterns, body) in enumerate(groups):
                 # Emit the first pattern comparison
                 if mode == "glob":
-                    self._emit_obj_literal(patterns[0])
+                    _emit_pattern(patterns[0])
                     self._emit_local_get(subject_local)
                 else:
                     self._emit_local_get(subject_local)
-                    self._emit_obj_literal(patterns[0])
+                    _emit_pattern(patterns[0])
                 self._emit_call(cmp_import)
                 # string_equal/string_match returns TclObj wrapping 0 or 1
                 self._emit_unbox_int()
@@ -409,11 +431,11 @@ class _WasmEmitterCtrlMixin(_Base):
                 # OR in any additional fallthrough patterns
                 for pattern in patterns[1:]:
                     if mode == "glob":
-                        self._emit_obj_literal(pattern)
+                        _emit_pattern(pattern)
                         self._emit_local_get(subject_local)
                     else:
                         self._emit_local_get(subject_local)
-                        self._emit_obj_literal(pattern)
+                        _emit_pattern(pattern)
                     self._emit_call(cmp_import)
                     self._emit_unbox_int()
                     self._emit(WasmOp.I32_WRAP_I64)

--- a/compiler/codegen/wasm/_emitter/_statements.py
+++ b/compiler/codegen/wasm/_emitter/_statements.py
@@ -854,6 +854,7 @@ class _WasmEmitterStmtMixin(_Base):
                 default_body=default_body,
                 mode=mode,
                 raw_args=raw_args,
+                patterns_braced=patterns_braced,
             ):
                 if mode == "regexp":
                     # No WASM regex matcher: re-invoke ``switch`` through
@@ -872,7 +873,13 @@ class _WasmEmitterStmtMixin(_Base):
                         # is now stale.
                         self._const_map.clear()
                 else:
-                    self._emit_switch(subject, arms, default_body, mode=mode)
+                    self._emit_switch(
+                        subject,
+                        arms,
+                        default_body,
+                        mode=mode,
+                        patterns_braced=patterns_braced,
+                    )
 
             case IRCatch(body=body, result_var=result_var, options_var=options_var):
                 self._emit_catch(body, result_var, options_var=options_var)

--- a/compiler/codegen/wasm/_emitter/_values.py
+++ b/compiler/codegen/wasm/_emitter/_values.py
@@ -688,13 +688,12 @@ class _WasmEmitterValuesMixin(_Base):
         first operand (see ``tcl_cmd_append``'s ``current == 0`` path);
         every subsequent append then mutates that private accumulator,
         leaving all operand objects untouched.  Each ``emit_fns`` entry
-        is a zero-arg callable that pushes one operand TclObj.  Leaves an
-        OWNED TclObj on the stack.
+        is a zero-arg callable that pushes one operand TclObj.  Always
+        leaves an OWNED TclObj on the stack — including the single-operand
+        case, which still seeds the null accumulator so a borrowed
+        ``$var`` operand (e.g. ``string cat $x``) is copied rather than
+        returned borrowed (callers rely on the OWNED contract).
         """
-        if len(emit_fns) == 1:
-            # Single operand — no accumulator, no mutation hazard.
-            emit_fns[0]()
-            return
         self._emit_i32_const(0)
         for fn in emit_fns:
             fn()

--- a/compiler/codegen/wasm/_emitter/_values.py
+++ b/compiler/codegen/wasm/_emitter/_values.py
@@ -674,6 +674,32 @@ class _WasmEmitterValuesMixin(_Base):
         flush()
         return parts
 
+    def _emit_concat_chain(self, append_idx: int, emit_fns: "list") -> None:
+        """Emit a string-concat chain that never mutates its operands.
+
+        ``tcl_cmd_append(acc, x)`` mutates ``acc`` in place when ``acc``
+        has refcount 1.  A borrowed ``$var`` read has refcount 1 (held
+        only by the variable), so using it directly as the accumulator
+        corrupts the variable's value when a later operand re-reads it —
+        the ``$x$x$x`` / ``string cat $x $x`` doubling bug.
+
+        Seeding the chain with a null (``0``) TclObj makes the first
+        ``tcl_cmd_append(0, op0)`` produce a *fresh owned copy* of the
+        first operand (see ``tcl_cmd_append``'s ``current == 0`` path);
+        every subsequent append then mutates that private accumulator,
+        leaving all operand objects untouched.  Each ``emit_fns`` entry
+        is a zero-arg callable that pushes one operand TclObj.  Leaves an
+        OWNED TclObj on the stack.
+        """
+        if len(emit_fns) == 1:
+            # Single operand — no accumulator, no mutation hazard.
+            emit_fns[0]()
+            return
+        self._emit_i32_const(0)
+        for fn in emit_fns:
+            fn()
+            self._emit_call(append_idx)
+
     def _emit_interpolated_value(self, value: str) -> None:
         """Emit a TclObj for an interpolated string with $var/[cmd] chunks.
 
@@ -690,12 +716,7 @@ class _WasmEmitterValuesMixin(_Base):
             self._emit_obj_literal(value)
             return
 
-        # Emit the first part
-        self._emit_part(parts[0])
-        # Concat remaining parts
-        for part in parts[1:]:
-            self._emit_part(part)
-            self._emit_call(append_idx)
+        self._emit_concat_chain(append_idx, [lambda p=part: self._emit_part(p) for part in parts])
 
     def _emit_part(self, part: tuple[str, str]) -> None:
         kind, data = part
@@ -1047,10 +1068,9 @@ class _WasmEmitterValuesMixin(_Base):
                 if append_idx is None:
                     self._emit_eval_fallback("string", cmd_args)
                     return
-                self._emit_value(sub_args[0])
-                for rest in sub_args[1:]:
-                    self._emit_value(rest)
-                    self._emit_call(append_idx)
+                self._emit_concat_chain(
+                    append_idx, [lambda a=arg: self._emit_value(a) for arg in sub_args]
+                )
                 return
             sri = subcommand_runtime_import_for("string", subcmd)
             if sri is not None and sri.import_key in self._shared_imports:

--- a/compiler/codegen/wasm/_emitter/cmds/append_.py
+++ b/compiler/codegen/wasm/_emitter/cmds/append_.py
@@ -8,6 +8,8 @@ keeps the updated value on the stack for implicit return.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from compiler.registry import REGISTRY, EmitContext
 
 from ..._ownership import Ownership
@@ -58,40 +60,55 @@ def _emit_append(
         or _is_dynamic_var_name(var_name)
     )
     keep_last = context is EmitContext.VALUE
-    last_index = len(args) - 1
+    values = args[1:]
+    # ``append`` auto-creates an unset variable (``append missing x`` ⇒
+    # ``x``; ``append arr(new) x`` creates the element), so the read must
+    # be lenient — a missing scalar / array element / alias must read as
+    # the null TclObj (empty), not raise ``can't read …``.
+    # ``tcl_cmd_append`` treats null as the empty starting value.
+    #
+    # A single value keeps the in-place read-modify-write (the canonical
+    # ``append acc $piece`` loop idiom — O(1) amortised in the runtime's
+    # cap-doubling fast path).  Two or more values route through a
+    # fresh-seeded concat chain: appending the running result back into
+    # the variable between values would let the in-place fast path mutate
+    # the variable's object mid-expression, so a value arg that aliases
+    # the target (``append x $x $x``) re-reads the half-built accumulator
+    # and the result doubles.  ``_emit_concat_chain`` seeds with a null
+    # accumulator so the operands (including the variable's own object)
+    # are never mutated, then we write the fresh result back once.
 
+    ops: list[Callable[[], object]]
     if use_var_path:
-        for i, value_arg in enumerate(args[1:], start=1):
-            # ``append`` auto-creates an unset variable (``append missing
-            # x`` ⇒ ``x``; ``append arr(new) x`` creates the element), so
-            # the read must be lenient — a missing scalar / array element
-            # / alias must read as the null TclObj (empty), not raise
-            # ``can't read "<var>": no such variable``.  ``tcl_cmd_append``
-            # treats null as the empty starting value.  Matches lappend
-            # and the var-24.x ``array default`` append cases.
-            emitter._emit_var_read_obj_lenient(var_name)
-            emitter._emit_value(value_arg)
-            emitter._emit_call(func_idx)
-            # ``tcl_cmd_append`` returns an OWNED handle (a fresh
-            # canonical-rebuild result on the slow path, or the input
-            # mutated in place on the fast path).  Declaring the write
-            # source OWNED balances the store's retain against the
-            # caller's +1 — without it the fresh element on an empty
-            # array is dropped before the store lands (var-24.7 append).
-            if keep_last and i == last_index:
-                emitter._emit_var_write_obj_keep(var_name, source=Ownership.OWNED)
-            else:
-                emitter._emit_var_write_obj(var_name, source=Ownership.OWNED)
+        ops = [lambda: emitter._emit_var_read_obj_lenient(var_name)]
     else:
         var_idx = emitter._intern_local(var_name)
-        for i, value_arg in enumerate(args[1:], start=1):
-            emitter._emit_local_get(var_idx)
-            emitter._emit_value(value_arg)
-            emitter._emit_call(func_idx)
-            if keep_last and i == last_index:
-                emitter._emit_local_tee(var_idx)
-            else:
-                emitter._emit_local_set(var_idx)
+        ops = [lambda vi=var_idx: emitter._emit_local_get(vi)]
+    ops += [lambda a=v: emitter._emit_value(a) for v in values]
+    if len(values) == 1:
+        # Single value — in-place read-modify-write (no re-read hazard).
+        ops[0]()
+        ops[1]()
+        emitter._emit_call(func_idx)
+    else:
+        emitter._emit_concat_chain(func_idx, ops)
+    # ``tcl_cmd_append`` / the concat chain leave an OWNED handle on the
+    # stack (a fresh result, or the input mutated in place on the
+    # single-value fast path).  Declaring the write source OWNED balances
+    # the store's retain against the caller's +1 — without it the fresh
+    # element on an empty array is dropped before the store lands
+    # (var-24.7 append).
+    if use_var_path:
+        if keep_last:
+            emitter._emit_var_write_obj_keep(var_name, source=Ownership.OWNED)
+        else:
+            emitter._emit_var_write_obj(var_name, source=Ownership.OWNED)
+    else:
+        var_idx = emitter._intern_local(var_name)
+        if keep_last:
+            emitter._emit_local_tee(var_idx)
+        else:
+            emitter._emit_local_set(var_idx)
 
     return True
 

--- a/compiler/codegen/wasm/_emitter/cmds/string_.py
+++ b/compiler/codegen/wasm/_emitter/cmds/string_.py
@@ -165,10 +165,9 @@ def _emit_string(
                 else:
                     emitter._emit(WasmOp.DROP)
                 return True
-            emitter._emit_value(sub_args[0])
-            for rest in sub_args[1:]:
-                emitter._emit_value(rest)
-                emitter._emit_call(append_idx)
+            emitter._emit_concat_chain(
+                append_idx, [lambda a=arg: emitter._emit_value(a) for arg in sub_args]
+            )
         if defs:
             def_idx = emitter._intern_local(defs[0])
             emitter._emit_local_set(def_idx)

--- a/compiler/codegen/wasm/_scan.py
+++ b/compiler/codegen/wasm/_scan.py
@@ -1369,7 +1369,13 @@ def _scan_needed_imports(
                 _scan_script(body)
                 needed.add("tcl_flow_consume_break")
                 needed.add("tcl_flow_consume_continue")
-            case IRSwitch(subject=subject, arms=arms, default_body=default_body, mode=mode):
+            case IRSwitch(
+                subject=subject,
+                arms=arms,
+                default_body=default_body,
+                mode=mode,
+                patterns_braced=patterns_braced,
+            ):
                 if mode == "glob":
                     needed.add("tcl_string_match")
                 elif mode == "regexp":
@@ -1398,6 +1404,15 @@ def _scan_needed_imports(
                     # against its raw source text rather than its
                     # runtime value.
                     _scan_value(subject)
+                    if not patterns_braced:
+                        # Separate-word patterns (``switch -- $s $pat body``)
+                        # are emitted via ``_emit_value`` and may carry
+                        # ``$var`` / ``[cmd]`` / ``$arr(key)`` substitutions
+                        # that need their own runtime imports (``tcl_append``
+                        # / ``tcl_array_get`` / …).  Braced-block patterns are
+                        # literal list elements and need no scan.
+                        for arm in arms:
+                            _scan_value(arm.pattern)
                     for arm in arms:
                         if arm.body:
                             _scan_script(arm.body)

--- a/compiler/inline_uplevel.py
+++ b/compiler/inline_uplevel.py
@@ -597,6 +597,7 @@ def _rewrite_stmt(
                 mode=stmt.mode,
                 nocase=stmt.nocase,
                 raw_args=stmt.raw_args,
+                patterns_braced=stmt.patterns_braced,
             )
         return stmt
     if isinstance(stmt, IRBlock):

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -404,6 +404,12 @@ class IRSwitch:
     mode: str = "exact"  # "exact", "glob", or "regexp"
     nocase: bool = False
     raw_args: tuple[str, ...] = ()  # original command args for generic fallback
+    # True when the arms came from a single braced ``{pat body ...}``
+    # block (patterns are literal list elements — no substitution).
+    # False when they came as separate words (``switch $s $pat {body}``),
+    # where each pattern undergoes normal ``$var`` / ``[cmd]`` runtime
+    # substitution before matching.
+    patterns_braced: bool = True
 
 
 @dataclass(frozen=True, slots=True)

--- a/compiler/lowering.py
+++ b/compiler/lowering.py
@@ -968,6 +968,10 @@ class _Lowerer:
             )
 
         pairs: list[tuple[str, Token | None, str, Token | None]] = []
+        # Patterns from a single braced body are literal list elements;
+        # patterns supplied as separate words undergo runtime $var/[cmd]
+        # substitution (the ``switch $s $pat {body}`` wrapper form).
+        patterns_braced = True
         if i == len(args) - 1 and i < len(arg_tokens) and i < len(arg_single) and arg_single[i]:
             body_text = args[i]
             body_tok = arg_tokens[i]
@@ -994,6 +998,7 @@ class _Lowerer:
                 )
                 j += 2
         else:
+            patterns_braced = False
             remaining_count = len(args) - i
             if remaining_count & 1:
                 return IRBarrier(
@@ -1061,6 +1066,7 @@ class _Lowerer:
             mode=mode,
             nocase=nocase,
             raw_args=tuple(args),
+            patterns_braced=patterns_braced,
         )
 
     def _lower_for(self, cmd: _Command, *, namespace: str) -> IRFor | IRBarrier:

--- a/runtime/zig/cmds/binary.zig
+++ b/runtime/zig/cmds/binary.zig
@@ -252,9 +252,16 @@ fn format_fill(buf: u32, buf_len: u32, fmt: [*]const u8, fmt_len: u32, words: []
                         const bn = @import("../valtypes/tcl_bignum.zig");
                         const parsed = bn.parse_i128(arg_s.ptr + elem.start, elem.len);
                         if (parsed) |p| {
-                            if (p > @as(i128, std.math.maxInt(i64))) break :blk @as(i64, std.math.maxInt(i64));
-                            if (p < @as(i128, std.math.minInt(i64))) break :blk @as(i64, std.math.minInt(i64));
-                            break :blk @as(i64, @intCast(p));
+                            // Tcl packs the integer's low N*8 bits regardless
+                            // of sign or magnitude (``write_le`` / ``write_be``
+                            // mask to ``nbytes``).  Wrap to the low 64 bits
+                            // rather than saturating to the i64 range —
+                            // saturation corrupted values >= 2^63 such as
+                            // ``binary format w 0x8000000000000000`` (which
+                            // clipped to 0x7fff…ffff = a NaN bit pattern when
+                            // re-read as a double; util-10.*).
+                            const low64: u64 = @truncate(@as(u128, @bitCast(p)));
+                            break :blk @as(i64, @bitCast(low64));
                         }
                         break :blk 0;
                     } else 0;
@@ -435,6 +442,15 @@ fn eval_binary_scan(words: []const i32) i32 {
         const spec = fmt[fi];
         fi += 1;
 
+        // Tcl 8.5+ unsigned modifier: a ``u`` immediately after an
+        // integer type letter (``cu`` / ``su`` / ``iu`` / ``wu`` / …)
+        // scans the value as unsigned.  It precedes the optional count.
+        var force_unsigned = false;
+        if (fi < fmt_len and fmt[fi] == 'u') {
+            force_unsigned = true;
+            fi += 1;
+        }
+
         const count_or_null = parse_count(fmt, fmt_len, &fi);
 
         switch (spec) {
@@ -511,10 +527,9 @@ fn eval_binary_scan(words: []const i32) i32 {
                 const cnt: u32 = count_or_null orelse
                     if (nbytes > 0) (src_len -| off) / nbytes else 0;
                 const big_end = is_be(spec);
-                const signed = switch (spec) {
-                    'C' => false,
-                    else => true,
-                };
+                // ``C`` is unsigned 8-bit; every other type is signed
+                // unless the ``u`` modifier (8.5+) forces unsigned.
+                const signed = !force_unsigned and spec != 'C';
 
                 if (cnt == 1) {
                     // Scalar: assign single value to variable.
@@ -525,7 +540,7 @@ fn eval_binary_scan(words: []const i32) i32 {
                         (if (signed) read_le_signed(src_base, off, nbytes) else read_le_unsigned(src_base, off, nbytes));
                     off += nbytes;
                     if (words.len > 3 + vi) {
-                        _ = frames.var_set(words[3 + vi], obj_new_int(v));
+                        _ = frames.var_set(words[3 + vi], scan_int_obj(v, !signed));
                         vi += 1;
                         assigned += 1;
                     }
@@ -548,8 +563,13 @@ fn eval_binary_scan(words: []const i32) i32 {
                             list_dst[list_off] = ' ';
                             list_off += 1;
                         }
-                        // Format the integer as decimal.
-                        list_off += fmt_i64(list_dst, list_off, v);
+                        // Format the integer as decimal — unsigned for a
+                        // high-bit-set ``wu`` / ``mu`` element (exceeds i64).
+                        if (!signed and v < 0) {
+                            list_off += fmt_u64(list_dst, list_off, @bitCast(v));
+                        } else {
+                            list_off += fmt_i64(list_dst, list_off, v);
+                        }
                     }
                     if (words.len > 3 + vi) {
                         _ = frames.var_set(words[3 + vi], rt.obj_new_string_take(list_buf, list_off, list_buf_size));
@@ -688,6 +708,41 @@ fn fmt_i64(dst: [*]u8, off: u32, val: i64) u32 {
     const digits = 20 - pos;
     for (0..digits) |k| dst[off + len + k] = buf[pos + k];
     return len + digits;
+}
+
+/// Format an unsigned 64-bit integer as decimal into ``dst[off..]``.
+/// Used by the ``u`` scan modifier for 64-bit (``wu`` / ``mu``) values
+/// whose high bit is set — they exceed ``i64`` so the signed formatter
+/// would print a negative number.  Returns the number of bytes written.
+fn fmt_u64(dst: [*]u8, off: u32, val: u64) u32 {
+    if (val == 0) {
+        dst[off] = '0';
+        return 1;
+    }
+    var buf: [20]u8 = undefined;
+    var pos: u32 = 20;
+    var v: u64 = val;
+    while (v > 0) : (v /= 10) {
+        pos -= 1;
+        buf[pos] = @intCast('0' + (v % 10));
+    }
+    const digits = 20 - pos;
+    for (0..digits) |k| dst[off + k] = buf[pos + k];
+    return digits;
+}
+
+/// Build the TclObj for a scanned integer, honouring the ``u`` modifier
+/// for the 64-bit case: a high-bit-set ``wu`` / ``mu`` value exceeds
+/// ``i64`` and must be returned as its unsigned decimal string rather
+/// than a negative integer.
+fn scan_int_obj(v: i64, unsigned: bool) i32 {
+    if (unsigned and v < 0) {
+        var buf: [20]u8 = undefined;
+        const n = fmt_u64(@ptrCast(&buf), 0, @bitCast(v));
+        const addr: u32 = @intCast(@intFromPtr(&buf[0]));
+        return obj_new_string(@bitCast(addr), @bitCast(n));
+    }
+    return obj_new_int(v);
 }
 
 // ─── top-level dispatcher ────────────────────────────────────────────────────

--- a/runtime/zig/cmds/binary.zig
+++ b/runtime/zig/cmds/binary.zig
@@ -739,8 +739,11 @@ fn scan_int_obj(v: i64, unsigned: bool) i32 {
     if (unsigned and v < 0) {
         var buf: [20]u8 = undefined;
         const n = fmt_u64(@ptrCast(&buf), 0, @bitCast(v));
-        const addr: u32 = @intCast(@intFromPtr(&buf[0]));
-        return obj_new_string(@bitCast(addr), @bitCast(n));
+        // ``obj_new_string`` borrows its bytes (cap=0), so the stack
+        // buffer must be copied into the obj's own storage rather than
+        // referenced — otherwise the string points at freed stack space.
+        const obj_mod_b = @import("../valtypes/tcl_obj.zig");
+        return obj_mod_b.obj_new_string_copy(@intCast(@intFromPtr(&buf[0])), n);
     }
     return obj_new_int(v);
 }

--- a/runtime/zig/cmds/list.zig
+++ b/runtime/zig/cmds/list.zig
@@ -2138,120 +2138,93 @@ fn lseq_match_word(words: []const i32, i: u32, expected: []const u8) bool {
     return true;
 }
 
-/// Tcl 9 ``lseq``.  Forms supported (matching tcl9.0.3 builtin):
-///
-///   lseq N                    -> 0 .. N-1
-///   lseq START END            -> START .. END (step inferred)
-///   lseq START to END         -> same
-///   lseq START .. END         -> same
-///   lseq START END by STEP    -> step explicit
-///   lseq START to END by STEP -> same
-///   lseq START .. END by STEP -> same
-///   lseq START by STEP        -> N=START items, step from 0
-///
-/// Step direction is inferred from end-vs-start when no explicit
-/// step is given.  Floats are NOT supported yet — this impl is
-/// integer-only; tests that need ``arithSeriesDouble`` are SKIPPED
-/// by tcltest's constraint table because ``arithSeriesDouble``
-/// isn't set.
-fn eval_lseq(words: []const i32) result_mod.InterpResult {
-    if (words.len < 2) return result_mod.from_globals(obj_new_string(0, 0));
-    var start_val: i64 = 0;
-    var end_val: i64 = 0;
-    var step_val: i64 = 1;
-    var have_step = false;
+const LSEQ_MAX_COUNT: i64 = 16 * 1024 * 1024; // 16 M elements (integer series)
+// Double series materialise heavier ``TYPE_FLOAT`` objs and have no
+// lazy ArithSeries representation here, so cap them lower to stay well
+// clear of an OOM trap.  Real ``arithSeriesDouble`` tests are tiny; a
+// larger request returns empty rather than hanging the runtime.
+const LSEQ_DBL_MAX_COUNT: i64 = 1 << 20; // ~1 M elements
 
-    if (words.len == 2) {
-        // ``lseq N`` -> 0 .. N-1
-        const count = rt.obj_get_int(words[1]);
-        if (count <= 0) return result_mod.from_globals(obj_new_string(0, 0));
-        end_val = count - 1;
-    } else {
-        // Two-or-more forms.  After ``words[1] = START``, scan for an
-        // optional ``to``/``..`` separator (or its absence) and an
-        // optional ``by STEP`` suffix.
-        start_val = rt.obj_get_int(words[1]);
-        var idx: u32 = 2;
-        if (lseq_match_word(words, idx, "to") or lseq_match_word(words, idx, "..")) {
-            idx += 1;
-        }
-        if (idx >= words.len) return result_mod.from_globals(obj_new_string(0, 0));
-        // ``lseq START by STEP`` (no end) means N=START items; the
-        // separator-less ``words[2]`` could be ``by`` instead of an
-        // end value.
-        if (lseq_match_word(words, idx, "by")) {
-            // ``lseq START by STEP`` — start=0, count=START, step
-            const cnt = start_val;
-            start_val = 0;
-            if (cnt <= 0) return result_mod.from_globals(obj_new_string(0, 0));
-            if (idx + 1 < words.len) step_val = rt.obj_get_int(words[idx + 1]);
-            if (step_val == 0) return result_mod.from_globals(obj_new_string(0, 0));
-            // (cnt - 1) * step can overflow when cnt or step were
-            // clamped from out-of-range floats (e.g. ``1e50``).
-            // Bail to an empty list rather than panicking on
-            // i64-overflow safety checks.
-            const cnt_m1 = @subWithOverflow(cnt, 1);
-            if (cnt_m1[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
-            const prod = @mulWithOverflow(cnt_m1[0], step_val);
-            if (prod[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
-            const sum = @addWithOverflow(start_val, prod[0]);
-            if (sum[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
-            end_val = sum[0];
-            have_step = true;
-        } else {
-            end_val = rt.obj_get_int(words[idx]);
-            idx += 1;
-            if (lseq_match_word(words, idx, "by")) {
-                if (idx + 1 < words.len) step_val = rt.obj_get_int(words[idx + 1]);
-                have_step = true;
-            } else if (idx < words.len) {
-                // ``lseq START END STEP`` (or ``lseq START to END STEP``)
-                // — Tcl 9 accepts the trailing positional as the step
-                // without an explicit ``by`` keyword.  Without this
-                // branch, ``lseq 1000000 2000000 100000`` falls through
-                // with step=1 and tries to enumerate a million-element
-                // sequence with O(N²) tcl_list appends — that's the
-                // lseq.test hang at lseq-1.16.
-                step_val = rt.obj_get_int(words[idx]);
-                have_step = true;
-            }
-        }
+/// True when *word* is a Tcl double literal (a valid float that is not
+/// a plain integer) — drives ``lseq``'s int-vs-double output mode.
+fn lseq_is_double(word: i32) bool {
+    const s = obj_ensure_string(word);
+    if (s.len == 0) return false;
+    if (obj_mod.try_parse_int(s.ptr, s.len) != null) return false;
+    return obj_mod.try_parse_float(s.ptr, s.len) != null;
+}
 
-        if (!have_step) {
-            // Infer direction from start..end.
-            if (end_val < start_val) step_val = -1 else step_val = 1;
+/// Decimal places after the ``.`` (0 for e-notation / integers) —
+/// mirrors Tcl 9 ``ObjPrecision`` (tclArithSeries.c).
+fn lseq_precision(word: i32) u32 {
+    const s = obj_ensure_string(word);
+    if (s.len == 0) return 0;
+    const p: [*]const u8 = @ptrFromInt(s.ptr);
+    var dot: i64 = -1;
+    var k: u32 = 0;
+    while (k < s.len) : (k += 1) {
+        const c = p[k];
+        if (c == 'e' or c == 'E') return 0;
+        if (c == '.') dot = @intCast(k);
+    }
+    if (dot < 0) return 0;
+    return s.len - @as(u32, @intCast(dot)) - 1;
+}
+
+/// Tcl 9 ``ArithSeriesLenDbl`` (tclArithSeries.c): element count of a
+/// double arithmetic series.  Scaling by 10^precision so a fractional
+/// step rounds consistently — ``lseq 4 40 0.1`` yields 361, not 360.
+fn lseq_len_dbl(start: f64, end: f64, step: f64, precision: u32) i64 {
+    if (step == 0) return 0;
+    var s = start;
+    var e = end;
+    var st = step;
+    if (precision > 0) {
+        var scale: f64 = 1;
+        var i: u32 = 0;
+        while (i < precision) : (i += 1) scale *= 10;
+        s *= scale;
+        e *= scale;
+        st *= scale;
+    }
+    e -= s; // distance
+    const wmin: f64 = -9223372036854775808.0;
+    const wmax: f64 = 9223372036854775807.0;
+    if (e >= wmin and e <= wmax and st >= wmin and st <= wmax) {
+        const iend: i64 = @intFromFloat(if (e < 0) e - 0.5 else e + 0.5);
+        const istep: i64 = @intFromFloat(if (st < 0) st - 0.5 else st + 0.5);
+        if (istep != 0) {
+            const n = @divTrunc(iend, istep) + 1;
+            return if (n < 0) 0 else n;
         }
     }
-    if (step_val == 0) return result_mod.from_globals(obj_new_string(0, 0));
+    const len = (e / st) + 1;
+    if (len < 0) return 0;
+    // Don't clamp to the cap — return an over-cap value so the emitter
+    // bails to an empty list rather than materialising a giant series.
+    if (len > @as(f64, @floatFromInt(LSEQ_MAX_COUNT))) return LSEQ_MAX_COUNT + 1;
+    return @intFromFloat(len);
+}
 
-    // Sanity bound: ``lseq 1e50 1e50+1`` and similar large-double
-    // forms convert to out-of-range i64 via ``@intFromFloat`` and
-    // can otherwise loop for billions of iterations before tripping
-    // the wasmtime watchdog.  Cap the absolute span so a poorly
-    // formed call returns an empty list (or partial result) instead
-    // of hanging the test runner.  The cap is conservative — well
-    // above any realistic production lseq — but small enough that
-    // a runaway terminates in <100ms.
-    //
-    // Use overflow-safe subtraction: when start/end are at the i64
-    // extremes (e.g. clamped from ``1e50``) the unguarded ``end - start``
-    // would itself trip the integer-overflow safety panic.
-    const max_count: i64 = 16 * 1024 * 1024; // 16 M elements
+/// Emit the integer arithmetic series ``start .. end`` step ``step``.
+fn lseq_emit_int(start_val: i64, end_val: i64, step_val: i64) result_mod.InterpResult {
+    if (step_val == 0) return result_mod.from_globals(obj_new_string(0, 0));
+    // Span guard: cap element count so a runaway (e.g. a huge clamped
+    // float bound) returns empty instead of hanging.  Overflow-safe so
+    // i64-extreme bounds don't trip the safety panic.
     const span_res = if (step_val > 0)
         @subWithOverflow(end_val, start_val)
     else
         @subWithOverflow(start_val, end_val);
     if (span_res[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
     const span: i64 = span_res[0];
-    // ``abs(step_val)`` via overflow-safe negation: ``-i64_min``
-    // would itself panic, so detect it explicitly and bail.
     const abs_step_res = if (step_val > 0)
         .{ step_val, @as(u1, 0) }
     else
         @subWithOverflow(@as(i64, 0), step_val);
     if (abs_step_res[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
     const abs_step: i64 = abs_step_res[0];
-    if (span < 0 or @divTrunc(span, abs_step) > max_count) {
+    if (span < 0 or @divTrunc(span, abs_step) > LSEQ_MAX_COUNT) {
         return result_mod.from_globals(obj_new_string(0, 0));
     }
 
@@ -2259,19 +2232,11 @@ fn eval_lseq(words: []const i32) result_mod.InterpResult {
     var i: i64 = start_val;
     if (step_val > 0) {
         while (i <= end_val) {
-            // ``tcl_list`` allocates a fresh accumulator each call
-            // and does not consume its inputs (see
-            // ``valtypes/tcl_list.zig``).  Without explicit releases
-            // we'd leak one accumulator and one element obj per
-            // iteration — up to 16 M of each at the cap above.
             const elem = obj_new_int(i);
             const new_acc = rt.tcl_list(acc, elem);
             obj_mod.tcl_obj_release(acc);
             obj_mod.tcl_obj_release(elem);
             acc = new_acc;
-            // Stop before the increment overflows — this can happen
-            // when ``end_val`` is at i64_max (clamped from a float)
-            // and the loop emits the final element.
             const next = @addWithOverflow(i, step_val);
             if (next[1] != 0) break;
             i = next[0];
@@ -2289,6 +2254,160 @@ fn eval_lseq(words: []const i32) result_mod.InterpResult {
         }
     }
     return result_mod.from_globals(acc);
+}
+
+/// Emit ``n`` double elements ``start + i*step`` (computed by
+/// multiplication, not accumulation, for stable rounding).  Each
+/// element is rounded to *precision* decimals — Tcl 9 ``ArithRound``
+/// (tclArithSeries.c) — so ``lseq 4 40 0.1`` prints ``6.3`` rather than
+/// the f64 noise ``6.300000000000001``.
+fn lseq_emit_dbl(start: f64, step: f64, n_in: i64, precision: u32) result_mod.InterpResult {
+    // Beyond the element cap, return empty rather than enumerate — the
+    // integer path does the same, and generating tens of millions of
+    // elements would hang the runtime (e.g. ``lseq 1e50 ...`` whose f64
+    // length computation overflows the cap).
+    if (n_in <= 0 or n_in > LSEQ_DBL_MAX_COUNT) return result_mod.from_globals(obj_new_string(0, 0));
+    const n = n_in;
+    var scale: f64 = 1;
+    if (precision > 0) {
+        var k: u32 = 0;
+        while (k < precision) : (k += 1) scale *= 10;
+    }
+    var acc: i32 = obj_new_string(0, 0);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        var v: f64 = start + @as(f64, @floatFromInt(i)) * step;
+        if (precision > 0) v = @round(v * scale) / scale;
+        const elem = obj_mod.obj_new_float(v);
+        const new_acc = rt.tcl_list(acc, elem);
+        obj_mod.tcl_obj_release(acc);
+        obj_mod.tcl_obj_release(elem);
+        acc = new_acc;
+    }
+    return result_mod.from_globals(acc);
+}
+
+/// Tcl 9 ``lseq``.  Forms (matching tcl9.0.3 builtin):
+///
+///   lseq N                          -> 0 .. N-1
+///   lseq START ?to|..? END ?by? ?STEP?
+///   lseq START count N ?by? ?STEP?
+///   lseq START by STEP              -> N=START items from 0
+///
+/// Step direction is inferred from end-vs-start when no explicit step
+/// is given.  If START, END, or STEP is a double literal the whole
+/// series is generated in floating-point (Tcl ``arithSeriesDouble``);
+/// the ``count`` value's type never forces double output.
+fn eval_lseq(words: []const i32) result_mod.InterpResult {
+    if (words.len < 2) return result_mod.from_globals(obj_new_string(0, 0));
+
+    // ``lseq N`` -> integer 0 .. N-1 (``lseq 3.0`` is {0 1 2}).
+    if (words.len == 2) {
+        const count = rt.obj_get_int(words[1]);
+        if (count <= 0) return result_mod.from_globals(obj_new_string(0, 0));
+        return lseq_emit_int(0, count - 1, 1);
+    }
+
+    const start_word = words[1];
+    var idx: u32 = 2;
+    var is_count = false;
+    var legacy_by = false; // ``lseq START by STEP``
+    var end_word: i32 = 0;
+    var count_word: i32 = 0;
+
+    if (lseq_match_word(words, idx, "to") or lseq_match_word(words, idx, "..")) {
+        idx += 1;
+        if (idx >= words.len) return result_mod.from_globals(obj_new_string(0, 0));
+        end_word = words[idx];
+        idx += 1;
+    } else if (lseq_match_word(words, idx, "count")) {
+        idx += 1;
+        if (idx >= words.len) return result_mod.from_globals(obj_new_string(0, 0));
+        is_count = true;
+        count_word = words[idx];
+        idx += 1;
+    } else if (lseq_match_word(words, idx, "by")) {
+        // ``lseq START by STEP`` — count=START items starting at 0.
+        legacy_by = true;
+        idx += 1;
+    } else {
+        end_word = words[idx];
+        idx += 1;
+    }
+
+    // Optional explicit step: ``by STEP`` or a trailing positional STEP.
+    var step_word: i32 = 0;
+    var have_step = false;
+    if (lseq_match_word(words, idx, "by")) {
+        idx += 1;
+        if (idx < words.len) {
+            step_word = words[idx];
+            have_step = true;
+        }
+    } else if (idx < words.len) {
+        step_word = words[idx];
+        have_step = true;
+    }
+
+    if (legacy_by) {
+        // ``lseq START by STEP``: integer-only count form (start=0).
+        const cnt = rt.obj_get_int(start_word);
+        if (cnt <= 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const step_i: i64 = if (have_step) rt.obj_get_int(step_word) else 1;
+        if (step_i == 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const cnt_m1 = @subWithOverflow(cnt, 1);
+        if (cnt_m1[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const prod = @mulWithOverflow(cnt_m1[0], step_i);
+        if (prod[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
+        return lseq_emit_int(0, prod[0], step_i);
+    }
+
+    // Double mode when any of start / end / step is a double literal
+    // (the count value's type is irrelevant — lseq-1.23 / 1.24).
+    const float_mode = lseq_is_double(start_word) or
+        (end_word != 0 and lseq_is_double(end_word)) or
+        (have_step and lseq_is_double(step_word));
+
+    if (float_mode) {
+        const start_d = obj_mod.obj_get_float(start_word);
+        const step_d: f64 = if (have_step) obj_mod.obj_get_float(step_word) else 1.0;
+        var prec: u32 = lseq_precision(start_word);
+        if (have_step) {
+            const ps = lseq_precision(step_word);
+            if (ps > prec) prec = ps;
+        }
+        if (is_count) {
+            const n = rt.obj_get_int(count_word);
+            return lseq_emit_dbl(start_d, step_d, n, prec);
+        }
+        const end_d = obj_mod.obj_get_float(end_word);
+        const pe = lseq_precision(end_word);
+        if (pe > prec) prec = pe;
+        const st: f64 = if (have_step) step_d else (if (end_d < start_d) @as(f64, -1.0) else @as(f64, 1.0));
+        const n = lseq_len_dbl(start_d, end_d, st, prec);
+        return lseq_emit_dbl(start_d, st, n, prec);
+    }
+
+    // Integer mode.
+    const start_val = rt.obj_get_int(start_word);
+    if (is_count) {
+        const cnt = rt.obj_get_int(count_word);
+        if (cnt <= 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const step_i: i64 = if (have_step) rt.obj_get_int(step_word) else 1;
+        if (step_i == 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const cnt_m1 = @subWithOverflow(cnt, 1);
+        if (cnt_m1[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const prod = @mulWithOverflow(cnt_m1[0], step_i);
+        if (prod[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
+        const sum = @addWithOverflow(start_val, prod[0]);
+        if (sum[1] != 0) return result_mod.from_globals(obj_new_string(0, 0));
+        return lseq_emit_int(start_val, sum[0], step_i);
+    }
+    const end_val = rt.obj_get_int(end_word);
+    const step_val: i64 = if (have_step)
+        rt.obj_get_int(step_word)
+    else if (end_val < start_val) @as(i64, -1) else @as(i64, 1);
+    return lseq_emit_int(start_val, end_val, step_val);
 }
 
 pub const registrations = [_]reg.CmdEntry{

--- a/runtime/zig/cmds/scan.zig
+++ b/runtime/zig/cmds/scan.zig
@@ -15,7 +15,7 @@
 //   %o  octal integer
 //   %c  Unicode codepoint of next character
 //   %s  whitespace-delimited word
-//   %[  character-class match (not implemented; traps gracefully)
+//   %[  character-class match (``%[abc]`` / ``%[^x]`` / ``%[a-z]``)
 //   %f, %e, %g  floating-point (parsed as integer truncation — no fp runtime)
 //   %n  no-op count specifier (not consuming; assigned current position)
 //   %%  literal percent in format (skip in input)
@@ -24,6 +24,7 @@
 // For %s a width field limits the number of characters taken.
 
 const rt = @import("../tcl_runtime.zig");
+const std = @import("std");
 const result_mod = @import("../interp/tcl_result.zig");
 const frames = @import("../interp/tcl_frames.zig");
 const stubs = @import("../stubs/tcl_stubs.zig");
@@ -293,11 +294,77 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             continue;
         }
 
-        // ``%c`` is unique among the consuming specs — it reads the
-        // NEXT character without skipping leading whitespace, matching
-        // reference Tcl's ``CharConvert`` (tclScan.c).  All other
-        // specifiers skip whitespace before parsing.  Without this
-        // exemption ``scan " " %c x`` would skip the space, hit
+        // ``%[...]`` — character set.  Matches a run of input characters
+        // that are members (or, with a leading ``^``, non-members) of the
+        // set defined inline in the format string.  Like ``%c`` it does
+        // not skip leading whitespace.  Scan-charset quirks: a ``]``
+        // immediately after the ``[`` (or after ``^``) is a literal
+        // member rather than the close; ``a-z`` is an (order-normalised)
+        // range; a ``-`` adjacent to ``]`` is literal.  Matching is
+        // byte-wise, consistent with ``%s`` above.
+        if (spec == '[') {
+            var in_set = [_]bool{false} ** 256;
+            var negate = false;
+            if (fi < fs.len and fmt[fi] == '^') {
+                negate = true;
+                fi += 1;
+            }
+            // A ``]`` as the first set member is literal, not the close.
+            if (fi < fs.len and fmt[fi] == ']') {
+                in_set[']'] = true;
+                fi += 1;
+            }
+            while (fi < fs.len and fmt[fi] != ']') {
+                const lo = fmt[fi];
+                // Range ``lo-hi`` — but a ``-`` just before ``]`` is literal.
+                if (fi + 2 < fs.len and fmt[fi + 1] == '-' and fmt[fi + 2] != ']') {
+                    const hi = fmt[fi + 2];
+                    const a: u32 = if (lo < hi) lo else hi;
+                    const b: u32 = if (lo < hi) hi else lo;
+                    var ci: u32 = a;
+                    while (ci <= b) : (ci += 1) in_set[ci] = true;
+                    fi += 3;
+                } else {
+                    in_set[lo] = true;
+                    fi += 1;
+                }
+            }
+            // Consume the closing ``]`` (an unclosed set implicitly closes
+            // at end-of-format, mirroring the glob char-class handling).
+            if (fi < fs.len and fmt[fi] == ']') fi += 1;
+
+            const max_chars: u32 = if (width > 0) width else ss.len;
+            const start_si = si;
+            var taken: u32 = 0;
+            while (si < ss.len and taken < max_chars and (in_set[src[si]] != negate)) {
+                si += 1;
+                taken += 1;
+            }
+            if (si == start_si) break; // no characters matched — conversion fails
+            const val = obj_new_string(@bitCast(ss.ptr + start_si), @bitCast(si - start_si));
+            if (!suppress) {
+                if (has_vars) {
+                    if (vi >= n_vars) {
+                        obj_mod_scan.tcl_obj_release(val);
+                        break;
+                    }
+                    _ = frames.var_set(words[3 + vi], val);
+                    obj_mod_scan.tcl_obj_release(val);
+                } else {
+                    const next = rt.tcl_list(list_result, val);
+                    obj_mod_scan.tcl_obj_release(list_result);
+                    obj_mod_scan.tcl_obj_release(val);
+                    list_result = next;
+                }
+                vi += 1;
+                assigned += 1;
+            } else {
+                obj_mod_scan.tcl_obj_release(val);
+            }
+            continue;
+        }
+
+
         // end-of-input, and leave ``x`` unset (12days's
         // ``[scan [string index $c 0] %c x; set x]`` recursion fed it
         // a single-space char and tripped ``can't read "x"``).
@@ -370,35 +437,35 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
         }
 
         if (spec == 'f' or spec == 'e' or spec == 'g' or spec == 'E' or spec == 'G') {
-            // Floating-point: parse as much as looks like a float, return int
-            // truncation (we have no fp runtime).
-            const neg = if (si < ss.len and src[si] == '-') blk: {
-                si += 1;
-                break :blk true;
-            } else if (si < ss.len and src[si] == '+') blk: {
-                si += 1;
-                break :blk false;
-            } else false;
-            var int_val: i64 = 0;
-            var has_digits = false;
-            while (si < ss.len and src[si] >= '0' and src[si] <= '9') : (si += 1) {
-                int_val = int_val * 10 + @as(i64, src[si] - '0');
-                has_digits = true;
-            }
-            // Skip fractional part.
-            if (si < ss.len and src[si] == '.') {
-                si += 1;
+            // Floating-point.  Capture the float token (optional sign,
+            // then digits / ``.`` / exponent, or ``Inf`` / ``Infinity`` /
+            // ``NaN``) and box a real ``TYPE_FLOAT`` value.  Earlier this
+            // truncated to an integer because the runtime had no fp path,
+            // so ``scan 0.2 %f`` returned ``0`` (scan-4.49 / scan-11.*).
+            const start_si = si;
+            if (si < ss.len and (src[si] == '-' or src[si] == '+')) si += 1;
+            if (si < ss.len and ((src[si] | 0x20) == 'i' or (src[si] | 0x20) == 'n')) {
+                // ``inf`` / ``infinity`` / ``nan`` — consume the alpha run.
+                while (si < ss.len and (src[si] | 0x20) >= 'a' and (src[si] | 0x20) <= 'z') si += 1;
+            } else {
                 while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
-                has_digits = true;
+                if (si < ss.len and src[si] == '.') {
+                    si += 1;
+                    while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
+                }
+                if (si < ss.len and (src[si] == 'e' or src[si] == 'E')) {
+                    si += 1;
+                    if (si < ss.len and (src[si] == '+' or src[si] == '-')) si += 1;
+                    while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
+                }
             }
-            // Skip exponent.
-            if (si < ss.len and (src[si] == 'e' or src[si] == 'E')) {
-                si += 1;
-                if (si < ss.len and (src[si] == '+' or src[si] == '-')) si += 1;
-                while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
-            }
-            if (!has_digits) break;
-            const val = obj_new_int(if (neg) -int_val else int_val);
+            const tok_len = si - start_si;
+            if (tok_len == 0 or tok_len > 64) break;
+            var fbuf: [64]u8 = undefined;
+            var k: u32 = 0;
+            while (k < tok_len) : (k += 1) fbuf[k] = src[start_si + k];
+            const fv = std.fmt.parseFloat(f64, fbuf[0..tok_len]) catch break;
+            const val = obj_mod_scan.obj_new_float(fv);
             if (!suppress) {
                 if (has_vars) {
                     if (vi >= n_vars) {

--- a/runtime/zig/cmds/scan.zig
+++ b/runtime/zig/cmds/scan.zig
@@ -447,9 +447,16 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
                     while (si < f_limit and src[si] >= '0' and src[si] <= '9') si += 1;
                 }
                 if (si < f_limit and (src[si] == 'e' or src[si] == 'E')) {
-                    si += 1;
-                    if (si < f_limit and (src[si] == '+' or src[si] == '-')) si += 1;
-                    while (si < f_limit and src[si] >= '0' and src[si] <= '9') si += 1;
+                    // Only consume the exponent when at least one digit
+                    // follows (after an optional sign).  An incomplete
+                    // ``1e`` keeps ``1`` as the float and leaves ``e`` for
+                    // the next conversion (``scan 1e {%f%s}`` → 1 e).
+                    var j = si + 1;
+                    if (j < f_limit and (src[j] == '+' or src[j] == '-')) j += 1;
+                    if (j < f_limit and src[j] >= '0' and src[j] <= '9') {
+                        si = j;
+                        while (si < f_limit and src[si] >= '0' and src[si] <= '9') si += 1;
+                    }
                 }
             }
             const tok_len = si - start_si;

--- a/runtime/zig/cmds/scan.zig
+++ b/runtime/zig/cmds/scan.zig
@@ -16,12 +16,13 @@
 //   %c  Unicode codepoint of next character
 //   %s  whitespace-delimited word
 //   %[  character-class match (``%[abc]`` / ``%[^x]`` / ``%[a-z]``)
-//   %f, %e, %g  floating-point (parsed as integer truncation — no fp runtime)
+//   %f, %e, %g  floating-point (real TYPE_FLOAT result)
 //   %n  no-op count specifier (not consuming; assigned current position)
 //   %%  literal percent in format (skip in input)
 //
-// Width fields (e.g. %5d) are parsed but ignored for non-%s specifiers.
-// For %s a width field limits the number of characters taken.
+// A leading ``N$`` (``%2$d``) selects the XPG3 target variable.  Width
+// fields (e.g. %3d) limit the characters consumed for %s, %d, %f, and
+// %[ conversions.
 
 const rt = @import("../tcl_runtime.zig");
 const std = @import("std");
@@ -197,6 +198,47 @@ fn scan_bignum(
 
 // ── main handler ─────────────────────────────────────────────────────────────
 
+/// Store one converted value.  Consolidates the per-conversion
+/// assignment shared by every spec arm and adds XPG3 (``%N$``) support:
+/// when *xpg_slot* >= 0 the value goes to that 0-based variable rather
+/// than the next sequential one, and the sequential cursor is left
+/// untouched.  ``val`` is always consumed.  Returns false when a
+/// variable-form scan has run past the supplied variables (the caller
+/// stops the format loop).
+fn scan_store(
+    words: []const i32,
+    has_vars: bool,
+    n_vars: u32,
+    vi: *u32,
+    assigned: *u32,
+    list_result: *i32,
+    val: i32,
+    suppress: bool,
+    xpg_slot: i64,
+) bool {
+    if (suppress) {
+        obj_mod_scan.tcl_obj_release(val);
+        return true;
+    }
+    if (has_vars) {
+        const slot: u32 = if (xpg_slot >= 0) @intCast(xpg_slot) else vi.*;
+        if (slot >= n_vars) {
+            obj_mod_scan.tcl_obj_release(val);
+            return false;
+        }
+        _ = frames.var_set(words[3 + slot], val);
+        obj_mod_scan.tcl_obj_release(val);
+    } else {
+        const next = rt.tcl_list(list_result.*, val);
+        obj_mod_scan.tcl_obj_release(list_result.*);
+        obj_mod_scan.tcl_obj_release(val);
+        list_result.* = next;
+    }
+    if (xpg_slot < 0) vi.* += 1;
+    assigned.* += 1;
+    return true;
+}
+
 fn eval_scan(words: []const i32) result_mod.InterpResult {
     if (words.len < 3) return result_mod.from_globals(obj_new_int(0));
 
@@ -244,6 +286,23 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             continue;
         }
 
+        // XPG3 positional conversion: ``%N$spec`` assigns to the N-th
+        // variable (1-based) rather than the next sequential one.  The
+        // position precedes the suppress / width / size fields.
+        var xpg_slot: i64 = -1;
+        {
+            var j = fi;
+            var num: u32 = 0;
+            while (j < fs.len and fmt[j] >= '0' and fmt[j] <= '9') : (j += 1) {
+                num = num * 10 + @as(u32, fmt[j] - '0');
+            }
+            if (j > fi and num > 0 and j < fs.len and fmt[j] == '$') {
+                xpg_slot = @intCast(num - 1);
+                fi = j + 1;
+                if (fi >= fs.len) break;
+            }
+        }
+
         // Suppress flag: %* means match but don't assign.
         var suppress = false;
         if (fmt[fi] == '*') {
@@ -273,24 +332,8 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
 
         // %n — number of chars consumed so far (no input consumed).
         if (spec == 'n') {
-            if (!suppress) {
-                const val = obj_new_int(@intCast(si));
-                if (has_vars) {
-                    if (vi >= n_vars) {
-                        obj_mod_scan.tcl_obj_release(val);
-                        break;
-                    }
-                    _ = frames.var_set(words[3 + vi], val);
-                    obj_mod_scan.tcl_obj_release(val);
-                } else {
-                    const next = rt.tcl_list(list_result, val);
-                    obj_mod_scan.tcl_obj_release(list_result);
-                    obj_mod_scan.tcl_obj_release(val);
-                    list_result = next;
-                }
-                vi += 1;
-                assigned += 1;
-            }
+            const val = obj_new_int(@intCast(si));
+            if (!scan_store(words, has_vars, n_vars, &vi, &assigned, &list_result, val, suppress, xpg_slot)) break;
             continue;
         }
 
@@ -342,28 +385,9 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             }
             if (si == start_si) break; // no characters matched — conversion fails
             const val = obj_new_string(@bitCast(ss.ptr + start_si), @bitCast(si - start_si));
-            if (!suppress) {
-                if (has_vars) {
-                    if (vi >= n_vars) {
-                        obj_mod_scan.tcl_obj_release(val);
-                        break;
-                    }
-                    _ = frames.var_set(words[3 + vi], val);
-                    obj_mod_scan.tcl_obj_release(val);
-                } else {
-                    const next = rt.tcl_list(list_result, val);
-                    obj_mod_scan.tcl_obj_release(list_result);
-                    obj_mod_scan.tcl_obj_release(val);
-                    list_result = next;
-                }
-                vi += 1;
-                assigned += 1;
-            } else {
-                obj_mod_scan.tcl_obj_release(val);
-            }
+            if (!scan_store(words, has_vars, n_vars, &vi, &assigned, &list_result, val, suppress, xpg_slot)) break;
             continue;
         }
-
 
         // end-of-input, and leave ``x`` unset (12days's
         // ``[scan [string index $c 0] %c x; set x]`` recursion fed it
@@ -377,25 +401,7 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             var tmp_i = si;
             const cp = read_utf8_cp(src, ss.len, &tmp_i);
             const val = obj_new_int(cp);
-            if (!suppress) {
-                if (has_vars) {
-                    if (vi >= n_vars) {
-                        obj_mod_scan.tcl_obj_release(val);
-                        break;
-                    }
-                    _ = frames.var_set(words[3 + vi], val);
-                    obj_mod_scan.tcl_obj_release(val);
-                } else {
-                    const next = rt.tcl_list(list_result, val);
-                    obj_mod_scan.tcl_obj_release(list_result);
-                    obj_mod_scan.tcl_obj_release(val);
-                    list_result = next;
-                }
-                vi += 1;
-                assigned += 1;
-            } else {
-                obj_mod_scan.tcl_obj_release(val);
-            }
+            if (!scan_store(words, has_vars, n_vars, &vi, &assigned, &list_result, val, suppress, xpg_slot)) break;
             si = tmp_i;
             continue;
         }
@@ -409,30 +415,15 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             };
             const accept_0x = (spec == 'x' or spec == 'X');
             var matched = false;
-            const val = scan_int(src, ss.len, &si, base, accept_0x, &matched);
+            // A width field caps the digits consumed (``%3d``) — bound
+            // ``scan_int`` to ``si + width`` rather than the whole input.
+            const int_limit: u32 = if (width > 0) @min(ss.len, si + width) else ss.len;
+            const val = scan_int(src, int_limit, &si, base, accept_0x, &matched);
             if (!matched) {
                 obj_mod_scan.tcl_obj_release(val);
                 break;
             }
-            if (!suppress) {
-                if (has_vars) {
-                    if (vi >= n_vars) {
-                        obj_mod_scan.tcl_obj_release(val);
-                        break;
-                    }
-                    _ = frames.var_set(words[3 + vi], val);
-                    obj_mod_scan.tcl_obj_release(val);
-                } else {
-                    const next = rt.tcl_list(list_result, val);
-                    obj_mod_scan.tcl_obj_release(list_result);
-                    obj_mod_scan.tcl_obj_release(val);
-                    list_result = next;
-                }
-                vi += 1;
-                assigned += 1;
-            } else {
-                obj_mod_scan.tcl_obj_release(val);
-            }
+            if (!scan_store(words, has_vars, n_vars, &vi, &assigned, &list_result, val, suppress, xpg_slot)) break;
             continue;
         }
 
@@ -443,20 +434,22 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             // truncated to an integer because the runtime had no fp path,
             // so ``scan 0.2 %f`` returned ``0`` (scan-4.49 / scan-11.*).
             const start_si = si;
-            if (si < ss.len and (src[si] == '-' or src[si] == '+')) si += 1;
-            if (si < ss.len and ((src[si] | 0x20) == 'i' or (src[si] | 0x20) == 'n')) {
+            // A width field caps the characters consumed (``%3f``).
+            const f_limit: u32 = if (width > 0) @min(ss.len, si + width) else ss.len;
+            if (si < f_limit and (src[si] == '-' or src[si] == '+')) si += 1;
+            if (si < f_limit and ((src[si] | 0x20) == 'i' or (src[si] | 0x20) == 'n')) {
                 // ``inf`` / ``infinity`` / ``nan`` — consume the alpha run.
-                while (si < ss.len and (src[si] | 0x20) >= 'a' and (src[si] | 0x20) <= 'z') si += 1;
+                while (si < f_limit and (src[si] | 0x20) >= 'a' and (src[si] | 0x20) <= 'z') si += 1;
             } else {
-                while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
-                if (si < ss.len and src[si] == '.') {
+                while (si < f_limit and src[si] >= '0' and src[si] <= '9') si += 1;
+                if (si < f_limit and src[si] == '.') {
                     si += 1;
-                    while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
+                    while (si < f_limit and src[si] >= '0' and src[si] <= '9') si += 1;
                 }
-                if (si < ss.len and (src[si] == 'e' or src[si] == 'E')) {
+                if (si < f_limit and (src[si] == 'e' or src[si] == 'E')) {
                     si += 1;
-                    if (si < ss.len and (src[si] == '+' or src[si] == '-')) si += 1;
-                    while (si < ss.len and src[si] >= '0' and src[si] <= '9') si += 1;
+                    if (si < f_limit and (src[si] == '+' or src[si] == '-')) si += 1;
+                    while (si < f_limit and src[si] >= '0' and src[si] <= '9') si += 1;
                 }
             }
             const tok_len = si - start_si;
@@ -466,25 +459,7 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             while (k < tok_len) : (k += 1) fbuf[k] = src[start_si + k];
             const fv = std.fmt.parseFloat(f64, fbuf[0..tok_len]) catch break;
             const val = obj_mod_scan.obj_new_float(fv);
-            if (!suppress) {
-                if (has_vars) {
-                    if (vi >= n_vars) {
-                        obj_mod_scan.tcl_obj_release(val);
-                        break;
-                    }
-                    _ = frames.var_set(words[3 + vi], val);
-                    obj_mod_scan.tcl_obj_release(val);
-                } else {
-                    const next = rt.tcl_list(list_result, val);
-                    obj_mod_scan.tcl_obj_release(list_result);
-                    obj_mod_scan.tcl_obj_release(val);
-                    list_result = next;
-                }
-                vi += 1;
-                assigned += 1;
-            } else {
-                obj_mod_scan.tcl_obj_release(val);
-            }
+            if (!scan_store(words, has_vars, n_vars, &vi, &assigned, &list_result, val, suppress, xpg_slot)) break;
             continue;
         }
 
@@ -500,25 +475,7 @@ fn eval_scan(words: []const i32) result_mod.InterpResult {
             }
             if (end_si == start_si) break; // no word
             const val = obj_new_string(@bitCast(ss.ptr + start_si), @bitCast(end_si - start_si));
-            if (!suppress) {
-                if (has_vars) {
-                    if (vi >= n_vars) {
-                        obj_mod_scan.tcl_obj_release(val);
-                        break;
-                    }
-                    _ = frames.var_set(words[3 + vi], val);
-                    obj_mod_scan.tcl_obj_release(val);
-                } else {
-                    const next = rt.tcl_list(list_result, val);
-                    obj_mod_scan.tcl_obj_release(list_result);
-                    obj_mod_scan.tcl_obj_release(val);
-                    list_result = next;
-                }
-                vi += 1;
-                assigned += 1;
-            } else {
-                obj_mod_scan.tcl_obj_release(val);
-            }
+            if (!scan_store(words, has_vars, n_vars, &vi, &assigned, &list_result, val, suppress, xpg_slot)) break;
             si = end_si;
             continue;
         }

--- a/runtime/zig/cmds/string.zig
+++ b/runtime/zig/cmds/string.zig
@@ -885,27 +885,21 @@ fn is_valid_string_index(idx: i32) bool {
     if (beg >= end) return false;
     const sp: [*]const u8 = sp0 + beg;
     const len: u32 = end - beg;
-    // Allow ``end`` / ``end-N`` / ``end+N`` (plus optional arithmetic
-    // tail like ``end-1+0`` which C tcl folds at parse time).
+    // ``end`` / ``end±OFFSET`` — OFFSET is a single signed integer
+    // literal (``end+-1`` = end + (-1), ``end--1`` = end - (-1)).  The
+    // resolver folds exactly one offset, so chained tails are rejected.
     if (len >= 3 and sp[0] == 'e' and sp[1] == 'n' and sp[2] == 'd') {
         if (len == 3) return true;
-        // ``end+N`` / ``end-N`` — N is a signed integer literal (the
-        // offset itself may carry a sign, e.g. ``end+-1`` = end + (-1),
-        // ``end--1`` = end - (-1)), with an optional ``±N`` chain.
         if (sp[3] != '+' and sp[3] != '-') return false;
-        return is_int_arith_tail(sp, len, 4);
+        return is_single_signed_int(sp, len, 4);
     }
-    // Pure integer arithmetic: optional sign, integer literal,
-    // optional ``±N`` continuation.  Integer literals include
-    // decimal, hex (``0x``), octal (``0o``), and binary (``0b``);
-    // bignums also parse here so ``string replace abcd
-    // 0x10000000000000000-0xffffffffffffffff 2 e`` (stringComp-14.26)
-    // makes it to the dispatcher instead of erroring at the syntax
-    // check.
-    var i: u32 = 0;
-    if (sp[i] == '+' or sp[i] == '-') i += 1;
-    if (i >= len) return false;
-    return is_int_arith_tail(sp, len, i);
+    // Integer index: ``[±] int  [ (+|-) [±] int ]`` — one optional
+    // operator, matching the resolver's ``int±int`` fold.  Literals
+    // include decimal, hex (``0x``), octal (``0o``), binary (``0b``),
+    // and explicit-decimal (``0d``); bignums parse too so ``string
+    // replace abcd 0x10000000000000000-0xffffffffffffffff 2 e``
+    // (stringComp-14.26) reaches the dispatcher.
+    return is_signed_int_one_op(sp, len, 0);
 }
 
 fn is_digit_for_base(c: u8, base: u32) bool {
@@ -947,24 +941,38 @@ fn consume_integer_literal(sp: [*]const u8, len: u32, start: u32) u32 {
     return i;
 }
 
-fn is_int_arith_tail(sp: [*]const u8, len: u32, start: u32) bool {
+/// A single, optionally-signed integer literal spanning ``sp[start..len]``
+/// exactly.  Used for the ``end±OFFSET`` form, where the resolver folds
+/// one signed offset (``end+-1`` = end + (-1)) — but no further operators.
+fn is_single_signed_int(sp: [*]const u8, len: u32, start: u32) bool {
     var i = start;
-    // The operand may carry its own sign (``end+-1`` / ``-1--2`` —
-    // C Tcl's ``GetEndOffsetFromObj`` parses ``end + (-1)``).
     if (i < len and (sp[i] == '+' or sp[i] == '-')) i += 1;
-    var after0 = consume_integer_literal(sp, len, i);
-    if (after0 == i) return false;
-    i = after0;
-    // Optional ``±N`` continuation runs (each operand may be signed).
-    while (i < len) {
+    const after = consume_integer_literal(sp, len, i);
+    if (after == i) return false;
+    return after == len;
+}
+
+/// ``[±] int  [ (+|-) [±] int ]`` — an integer with at most one trailing
+/// operator and an optionally-signed operand.  This is exactly what
+/// ``resolve_list_index``'s ``int±int`` path evaluates (it folds a single
+/// operator).  Accepting longer chains here would let malformed indices
+/// such as ``-1--2+3`` validate yet resolve to the wrong position
+/// because the resolver only sums the first operator (PR #516 review).
+fn is_signed_int_one_op(sp: [*]const u8, len: u32, start: u32) bool {
+    var i = start;
+    if (i < len and (sp[i] == '+' or sp[i] == '-')) i += 1;
+    var after = consume_integer_literal(sp, len, i);
+    if (after == i) return false;
+    i = after;
+    if (i < len) {
         if (sp[i] != '+' and sp[i] != '-') return false;
         i += 1;
         if (i < len and (sp[i] == '+' or sp[i] == '-')) i += 1;
-        after0 = consume_integer_literal(sp, len, i);
-        if (after0 == i) return false;
-        i = after0;
+        after = consume_integer_literal(sp, len, i);
+        if (after == i) return false;
+        i = after;
     }
-    return true;
+    return i == len;
 }
 
 fn raise_bad_string_index(idx: i32) void {

--- a/runtime/zig/cmds/string.zig
+++ b/runtime/zig/cmds/string.zig
@@ -871,17 +871,29 @@ fn eval_compare_or_equal(words: []const i32, kind: CompareKind) i32 {
 /// silently treating them as 0.
 fn is_valid_string_index(idx: i32) bool {
     const obj_mod = @import("../valtypes/tcl_obj.zig");
+    const is_space = @import("../valtypes/tcl_chars.zig").is_space;
     const s = obj_mod.obj_ensure_string(idx);
     if (s.len == 0) return false;
-    const sp: [*]const u8 = @ptrFromInt(s.ptr);
+    const sp0: [*]const u8 = @ptrFromInt(s.ptr);
+    // Trim surrounding whitespace — ``Tcl_GetIntForIndex`` parses through
+    // ``TclParseNumber``, which skips leading / trailing whitespace, so
+    // ``string index abcd { 0 }`` / ``{end-1 }`` are valid (util-9.0.*).
+    var beg: u32 = 0;
+    var end: u32 = s.len;
+    while (beg < end and is_space(sp0[beg])) beg += 1;
+    while (end > beg and is_space(sp0[end - 1])) end -= 1;
+    if (beg >= end) return false;
+    const sp: [*]const u8 = sp0 + beg;
+    const len: u32 = end - beg;
     // Allow ``end`` / ``end-N`` / ``end+N`` (plus optional arithmetic
     // tail like ``end-1+0`` which C tcl folds at parse time).
-    if (s.len >= 3 and sp[0] == 'e' and sp[1] == 'n' and sp[2] == 'd') {
-        if (s.len == 3) return true;
-        // ``end+N`` / ``end-N`` — N is an integer literal (digits +
-        // optional further ``±N`` arithmetic chain).
+    if (len >= 3 and sp[0] == 'e' and sp[1] == 'n' and sp[2] == 'd') {
+        if (len == 3) return true;
+        // ``end+N`` / ``end-N`` — N is a signed integer literal (the
+        // offset itself may carry a sign, e.g. ``end+-1`` = end + (-1),
+        // ``end--1`` = end - (-1)), with an optional ``±N`` chain.
         if (sp[3] != '+' and sp[3] != '-') return false;
-        return is_int_arith_tail(sp, s.len, 4);
+        return is_int_arith_tail(sp, len, 4);
     }
     // Pure integer arithmetic: optional sign, integer literal,
     // optional ``±N`` continuation.  Integer literals include
@@ -892,8 +904,8 @@ fn is_valid_string_index(idx: i32) bool {
     // check.
     var i: u32 = 0;
     if (sp[i] == '+' or sp[i] == '-') i += 1;
-    if (i >= s.len) return false;
-    return is_int_arith_tail(sp, s.len, i);
+    if (i >= len) return false;
+    return is_int_arith_tail(sp, len, i);
 }
 
 fn is_digit_for_base(c: u8, base: u32) bool {
@@ -925,6 +937,9 @@ fn consume_integer_literal(sp: [*]const u8, len: u32, start: u32) u32 {
         } else if (c == 'b' or c == 'B') {
             base = 2;
             i += 2;
+        } else if (c == 'd' or c == 'D') {
+            base = 10;
+            i += 2;
         }
     }
     if (i >= len or !is_digit_for_base(sp[i], base)) return start;
@@ -933,15 +948,21 @@ fn consume_integer_literal(sp: [*]const u8, len: u32, start: u32) u32 {
 }
 
 fn is_int_arith_tail(sp: [*]const u8, len: u32, start: u32) bool {
-    var i = consume_integer_literal(sp, len, start);
-    if (i == start) return false;
-    // Optional ``±N`` continuation runs.
+    var i = start;
+    // The operand may carry its own sign (``end+-1`` / ``-1--2`` —
+    // C Tcl's ``GetEndOffsetFromObj`` parses ``end + (-1)``).
+    if (i < len and (sp[i] == '+' or sp[i] == '-')) i += 1;
+    var after0 = consume_integer_literal(sp, len, i);
+    if (after0 == i) return false;
+    i = after0;
+    // Optional ``±N`` continuation runs (each operand may be signed).
     while (i < len) {
         if (sp[i] != '+' and sp[i] != '-') return false;
         i += 1;
-        const after = consume_integer_literal(sp, len, i);
-        if (after == i) return false;
-        i = after;
+        if (i < len and (sp[i] == '+' or sp[i] == '-')) i += 1;
+        after0 = consume_integer_literal(sp, len, i);
+        if (after0 == i) return false;
+        i = after0;
     }
     return true;
 }

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -5491,10 +5491,53 @@ pub fn eval_apply(words: []const i32) i32 {
         var pi: u32 = 0;
         while (pi < n_params) : (pi += 1) {
             const param_elem = list_element_at(ps.ptr, ps.len, @intCast(pi));
-            const param_name_ptr = ps.ptr + param_elem.start;
-            const param_name_len = param_elem.len;
+            // A parameter is itself a list ``{name ?default?}`` — element
+            // 0 is the variable name, an optional element 1 the default
+            // value used when no argument is supplied.  ``{}`` (no name)
+            // and ``{a b c}`` (>2 fields) are malformed (apply-2.2 / 2.3).
+            const spec_ptr = ps.ptr + param_elem.start;
+            const spec_len = param_elem.len;
+            const field_count = list_count_elements(spec_ptr, spec_len);
+            if (field_count == 0) {
+                const stubs = @import("../stubs/tcl_stubs.zig");
+                frames.frame_pop();
+                stubs.raise("argument with no name");
+                return 0;
+            }
+            if (field_count > 2) {
+                var mbuf: [256]u8 = undefined;
+                const pfx = "too many fields in argument specifier \"";
+                var mo: u32 = 0;
+                for (pfx) |c| {
+                    mbuf[mo] = c;
+                    mo += 1;
+                }
+                const sp_bytes: [*]const u8 = @ptrFromInt(spec_ptr);
+                var si: u32 = 0;
+                while (si < spec_len and mo < mbuf.len - 1) : (si += 1) {
+                    mbuf[mo] = sp_bytes[si];
+                    mo += 1;
+                }
+                mbuf[mo] = '"';
+                mo += 1;
+                const stubs = @import("../stubs/tcl_stubs.zig");
+                frames.frame_pop();
+                stubs.raise(mbuf[0..mo]);
+                return 0;
+            }
+            const name_elem = list_element_at(spec_ptr, spec_len, 0);
+            const param_name_ptr = spec_ptr + name_elem.start;
+            const param_name_len = name_elem.len;
             const param_name = obj_new_string_copy(param_name_ptr, param_name_len);
             defer obj_mod.tcl_obj_release(param_name);
+            const has_default = field_count == 2;
+            var default_ptr: u32 = 0;
+            var default_len: u32 = 0;
+            if (has_default) {
+                const def_elem = list_element_at(spec_ptr, spec_len, 1);
+                default_ptr = spec_ptr + def_elem.start;
+                default_len = def_elem.len;
+            }
             const param_name_s: [*]const u8 = @ptrFromInt(param_name_ptr);
             const arg_idx = pi + 2; // skip words[0]=apply, words[1]=lambda
             const is_args_param = (pi == n_params - 1) and (param_name_len == 4) and
@@ -5544,6 +5587,10 @@ pub fn eval_apply(words: []const i32) i32 {
             } else {
                 if (arg_idx < words.len) {
                     _ = frames.local_set(param_name, words[arg_idx]);
+                } else if (has_default) {
+                    const dv = obj_new_string_copy(default_ptr, default_len);
+                    _ = frames.local_set(param_name, dv);
+                    obj_mod.tcl_obj_release(dv);
                 } else {
                     const empty = obj_new_string(0, 0);
                     _ = frames.local_set(param_name, empty);

--- a/runtime/zig/valtypes/tcl_bignum.zig
+++ b/runtime/zig/valtypes/tcl_bignum.zig
@@ -114,6 +114,9 @@ pub fn parse_i128(ptr: u32, len: u32) ?i128 {
         } else if (c == 'b' or c == 'B') {
             base = 2;
             i += 2;
+        } else if (c == 'd' or c == 'D') {
+            base = 10;
+            i += 2;
         }
     }
     if (i >= len) return null;
@@ -371,6 +374,9 @@ pub fn alloc_from_string(ptr: u32, len: u32) ?*BigInt {
             i += 2;
         } else if (c == 'b' or c == 'B') {
             base = 2;
+            i += 2;
+        } else if (c == 'd' or c == 'D') {
+            base = 10;
             i += 2;
         }
     }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -320,17 +320,28 @@ pub fn append_list_element(buf: u32, off_in: u32, sd_ptr: u32, elem: anytype, is
 pub fn is_valid_list_index(idx: i32) bool {
     const s = obj_ensure_string(idx);
     if (s.len == 0) return false;
-    const sp: [*]const u8 = @ptrFromInt(s.ptr);
+    const sp0: [*]const u8 = @ptrFromInt(s.ptr);
+    // Trim surrounding whitespace so the validator matches what
+    // :func:`resolve_list_index` (and :func:`is_valid_string_index`)
+    // accept — ``{ 0 }`` / ``{end-1 }`` / ``{ 0d10 }`` are valid.
+    const is_space = @import("tcl_chars.zig").is_space;
+    var beg: u32 = 0;
+    var end: u32 = s.len;
+    while (beg < end and is_space(sp0[beg])) beg += 1;
+    while (end > beg and is_space(sp0[end - 1])) end -= 1;
+    if (beg >= end) return false;
+    const sp: [*]const u8 = sp0 + beg;
+    const len: u32 = end - beg;
     // ``end`` / ``end[+-]N``.  After ``end[+-]`` only a single
     // signed integer literal is allowed — no further arithmetic
     // chain.  Reference Tcl 9 ``GetEndOffsetFromObj`` calls
     // ``TclParseNumber`` once on the substring, so multi-operator
     // forms like ``end-1+2`` would silently truncate to ``end-1``
     // at the resolver and disagree with the validator.
-    if (s.len >= 3 and sp[0] == 'e' and sp[1] == 'n' and sp[2] == 'd') {
-        if (s.len == 3) return true;
+    if (len >= 3 and sp[0] == 'e' and sp[1] == 'n' and sp[2] == 'd') {
+        if (len == 3) return true;
         if (sp[3] != '+' and sp[3] != '-') return false;
-        return is_signed_int_literal(sp, s.len, 4);
+        return is_signed_int_literal(sp, len, 4);
     }
     // Pure integer arithmetic — optional sign, integer literal,
     // optional single ``[+-]N`` continuation (also with optional
@@ -338,8 +349,8 @@ pub fn is_valid_list_index(idx: i32) bool {
     // match what :func:`resolve_list_index` actually evaluates.
     var i: u32 = 0;
     if (sp[0] == '+' or sp[0] == '-') i += 1;
-    if (i >= s.len) return false;
-    return is_int_arith_tail(sp, s.len, i);
+    if (i >= len) return false;
+    return is_int_arith_tail(sp, len, i);
 }
 
 /// Accept an optional sign + integer literal, with NO trailing
@@ -414,6 +425,9 @@ fn consume_integer_literal(sp: [*]const u8, len: u32, start: u32) u32 {
             i += 2;
         } else if (c == 'b' or c == 'B') {
             base = 2;
+            i += 2;
+        } else if (c == 'd' or c == 'D') {
+            base = 10;
             i += 2;
         }
     }

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -454,7 +454,22 @@ fn is_int_arith_tail(sp: [*]const u8, len: u32, start: u32) bool {
 // ``tclUtil.c`` for the ``int[+-]int`` form, with the result saturating
 // to ``i64`` bounds when the integer math overflows.
 pub fn resolve_list_index(idx: i32, n: i64) i64 {
-    const sv = obj_ensure_string(idx);
+    const is_space = @import("tcl_chars.zig").is_space;
+    var sv = obj_ensure_string(idx);
+    // Trim surrounding whitespace so ``{ 0 }`` / ``{end-1 }`` /
+    // ``{ -1+2 }`` resolve like their unpadded forms — ``Tcl_GetIntForIndex``
+    // parses through ``TclParseNumber``, which skips leading / trailing
+    // whitespace (util-9.0.*).  Every parse path below recomputes its
+    // pointer from ``sv.ptr`` / ``sv.len``, so trimming here is sufficient.
+    {
+        const tp: [*]const u8 = @ptrFromInt(sv.ptr);
+        var b: u32 = 0;
+        var e: u32 = sv.len;
+        while (b < e and is_space(tp[b])) b += 1;
+        while (e > b and is_space(tp[e - 1])) e -= 1;
+        sv.ptr += b;
+        sv.len = e - b;
+    }
     if (sv.len >= 3) {
         const sp: [*]const u8 = @ptrFromInt(sv.ptr);
         if (sp[0] == 'e' and sp[1] == 'n' and sp[2] == 'd') {
@@ -546,6 +561,14 @@ pub fn resolve_list_index(idx: i32, n: i64) i64 {
                 return if (positive_overflow) std.math.maxInt(i64) else std.math.minInt(i64);
             }
         }
+    }
+    // Plain integer literal (decimal / hex / octal / binary).  Parse the
+    // trimmed slice so a whitespace-padded ``{ 0 }`` / ``{ 0x0 }`` index
+    // resolves; fall back to the obj integer accessor otherwise.
+    if (@import("tcl_bignum.zig").parse_i128(sv.ptr, sv.len)) |v| {
+        if (v > std.math.maxInt(i64)) return std.math.maxInt(i64);
+        if (v < std.math.minInt(i64)) return std.math.minInt(i64);
+        return @intCast(v);
     }
     return obj_get_int(idx);
 }

--- a/tests/test_wasm_apply_lambda.py
+++ b/tests/test_wasm_apply_lambda.py
@@ -1,0 +1,51 @@
+"""WASM ``apply`` — lambda parameter specs with defaults and validation.
+
+``eval_apply`` treated each whole parameter element as the variable
+name, so a ``{name default}`` spec became a variable literally named
+``"name default"`` and default values were never applied.  It now parses
+each parameter as a ``{name ?default?}`` list:
+
+* element 0 is the variable name, optional element 1 the default used
+  when no argument is supplied (apply-8.*);
+* a ``{}`` spec (no name) raises ``argument with no name`` (apply-2.2);
+* a ``{a b c}`` spec (>2 fields) raises ``too many fields in argument
+  specifier "a b c"`` (apply-2.3).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(body: str) -> str:
+    _, stdout = _run_wasm(_compile_tcl(body), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def test_apply_defaults_all_omitted() -> None:
+    body = "set L [list {{x 1} {y 2}} {list $x $y}]\nputs [apply $L]\n"
+    assert _run(body) == "1 2"
+
+
+def test_apply_default_partial() -> None:
+    body = "set L [list {x {y 2}} {list $x $y}]\nputs [apply $L 5]\n"
+    assert _run(body) == "5 2"
+
+
+def test_apply_default_overridden() -> None:
+    body = "set L [list {{x 1} {y 2}} {list $x $y}]\nputs [apply $L 7 9]\n"
+    assert _run(body) == "7 9"
+
+
+def test_apply_malformed_no_name() -> None:
+    body = "set L [list {{}} boo]\nputs [catch {apply $L} msg]:$msg\n"
+    assert _run(body) == "1:argument with no name"
+
+
+def test_apply_malformed_too_many_fields() -> None:
+    body = "set L [list {{a b c}} boo]\nputs [catch {apply $L} msg]:$msg\n"
+    assert _run(body) == '1:too many fields in argument specifier "a b c"'

--- a/tests/test_wasm_binary.py
+++ b/tests/test_wasm_binary.py
@@ -1,0 +1,64 @@
+"""WASM ``binary`` command — wide-int encoding and the unsigned modifier.
+
+Two contracts in ``runtime/zig/cmds/binary.zig``:
+
+* ``binary format w`` / ``W`` packs the integer's low 64 bits regardless
+  of sign or magnitude.  It previously *saturated* values >= 2^63 to the
+  i64 maximum, so ``binary format w 0x8000000000000000`` produced the
+  bytes for ``0x7fff…ffff`` — which, re-read as an IEEE-754 double, is
+  NaN.  That broke the ``convertDouble`` helper behind every negative
+  case in util-10.*.
+* ``binary scan`` honours the Tcl 8.5+ ``u`` modifier (``cu`` / ``su`` /
+  ``iu`` / ``wu``), scanning the value as unsigned.  A high-bit-set
+  ``wu`` exceeds i64 and is returned as its unsigned decimal string.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(body: str) -> str:
+    _, stdout = _run_wasm(_compile_tcl(body), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "hexbits,expected",
+    [
+        ("0x7ef754e31cd072da", "4e+303"),
+        ("0x8000000000000000", "-0.0"),
+        ("0xd08afcef51f0fb5f", "-1e+80"),
+        ("0xfee754e31cd072da", "-2e+303"),
+        ("0xad3c0794d9d40e96", "-8.6e-91"),
+    ],
+)
+def test_binary_format_w_wide_double_roundtrip(hexbits: str, expected: str) -> None:
+    # convertDouble: reinterpret a 64-bit pattern as a double via binary.
+    body = (
+        "proc convertDouble {x} { binary scan [binary format w $x] d r; return $r }\n"
+        f"puts [convertDouble {hexbits}]\n"
+    )
+    assert _run(body) == expected
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("binary scan [binary format c 200] cu x\nputs $x", "200"),
+        ("binary scan [binary format c 200] c x\nputs $x", "-56"),
+        ("binary scan [binary format s 0xFFFF] su x\nputs $x", "65535"),
+        ("binary scan [binary format i -1] iu x\nputs $x", "4294967295"),
+        (
+            "binary scan [binary format w 0x8000000000000000] wu x\nputs $x",
+            "9223372036854775808",
+        ),
+        ("binary scan [binary format c3 {200 201 202}] cu3 x\nputs $x", "200 201 202"),
+    ],
+)
+def test_binary_scan_unsigned_modifier(body: str, expected: str) -> None:
+    assert _run(body) == expected

--- a/tests/test_wasm_concat_alias.py
+++ b/tests/test_wasm_concat_alias.py
@@ -1,0 +1,76 @@
+"""WASM string-concat / append aliasing contract.
+
+``tcl_cmd_append(acc, x)`` mutates ``acc`` in place on its refcount-1
+fast path.  A borrowed ``$var`` read has refcount 1 (held only by the
+variable), so any concat chain that uses a borrowed read as its
+accumulator and then re-reads the same variable would corrupt the
+variable mid-expression — the classic ``$x$x$x`` / ``append x $x $x``
+doubling bug (1→2→4→8 chars).
+
+The codegen seeds every multi-operand concat chain with a null
+accumulator (``_emit_concat_chain``) so the first ``tcl_cmd_append(0,
+op0)`` makes a fresh owned copy and no operand object is ever mutated.
+These tests pin that contract across the three affected surfaces:
+string interpolation, ``string cat``, and the ``append`` command.
+
+Regression guard for the ``parseOld-11.10-*`` cluster (62 failing
+tcltest IDs before the fix).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(source: str) -> str:
+    wasm = _compile_tcl(source)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # Interpolation self-concat — the value must come from an owned
+        # buffer (``string index`` yields a cap>0 rc==1 string), which is
+        # exactly the object the in-place fast path would mutate.
+        (
+            "set t [string index 0123456789 5]\nset t $t$t$t$t\nputs $t",
+            "5555",
+        ),
+        # Interpolation into a *different* variable still re-reads the
+        # source operand, so it doubles without the seed fix.
+        (
+            "set p [string index 0123456789 7]\nset q $p$p$p\nputs $q",
+            "777",
+        ),
+        # ``string cat`` of a repeated owned operand.
+        (
+            "set p [string index abcdef 2]\nset r [string cat $p $p $p]\nputs $r",
+            "ccc",
+        ),
+        # ``append`` command with multiple value args that alias the
+        # target variable — re-reads the half-built accumulator.
+        (
+            "set x [string index 0123456789 5]\nappend x $x $x\nputs $x",
+            "555",
+        ),
+        # Single-value append still works (in-place fast path retained).
+        (
+            "set s [string index 0123456789 9]\nappend s $s\nputs $s",
+            "99",
+        ),
+        # The canonical append-accumulator loop (distinct piece var) is
+        # unaffected — guards against a perf-motivated regression.
+        (
+            "set acc {}\nforeach c {a b c d} { append acc $c }\nputs $acc",
+            "abcd",
+        ),
+    ],
+)
+def test_concat_no_operand_mutation(source: str, expected: str) -> None:
+    assert _run(source) == expected

--- a/tests/test_wasm_lseq.py
+++ b/tests/test_wasm_lseq.py
@@ -1,0 +1,58 @@
+"""WASM ``lseq`` — double arithmetic series and the ``count`` keyword.
+
+``lseq`` was integer-only.  It now:
+
+* generates a double series when START, END, or STEP is a double literal
+  (Tcl ``arithSeriesDouble``), rounding each element to the inputs' max
+  decimal precision (Tcl ``ArithRound``) so ``lseq 4 40 0.1`` prints
+  ``6.3`` rather than the f64 noise ``6.300000000000001``;
+* supports the ``count`` keyword (``lseq START count N ?by? ?STEP?``);
+* the ``count`` value's type never forces double output (``lseq 0 count
+  3.0`` is integer ``{0 1 2}``; ``lseq 0.0 count 3.0`` is double);
+* returns an empty list rather than materialising a multi-million
+  element series (there is no lazy ArithSeries rep here).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(body: str) -> str:
+    _, stdout = _run_wasm(_compile_tcl(body), capture_stdout=True, timeout_s=15.0)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        # double series, inferred / explicit / negative step
+        ("lseq 5.0 to 15.", "5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0"),
+        ("lseq 5.0 to 25. by 5", "5.0 10.0 15.0 20.0 25.0"),
+        ("lseq 0.0 2.0", "0.0 1.0 2.0"),
+        # fractional step with consistent rounding (lseq-4.14 head)
+        ("lseq 4 4.5 0.1", "4.0 4.1 4.2 4.3 4.4 4.5"),
+        # count keyword — integer and double
+        ("lseq 5 count 5 2", "5 7 9 11 13"),
+        ("lseq 0 count 3", "0 1 2"),
+        ("lseq 0 count 3.0", "0 1 2"),
+        ("lseq 0.0 count 3.0", "0.0 1.0 2.0"),
+        ("lseq 0 count 3 by 1.0", "0.0 1.0 2.0"),
+        # integer forms unchanged
+        ("lseq 5", "0 1 2 3 4"),
+        ("lseq 1 5", "1 2 3 4 5"),
+        ("lseq 10 to 2 by -2", "10 8 6 4 2"),
+    ],
+)
+def test_lseq_double_and_count(expr: str, expected: str) -> None:
+    assert _run(f"puts [{expr}]") == expected
+
+
+def test_lseq_oversized_series_is_empty_not_hang() -> None:
+    # No lazy series rep — a multi-million element double request returns
+    # empty rather than OOM/hang.
+    assert _run("puts [llength [lseq 0.0 1e7]]") == "0"

--- a/tests/test_wasm_scan.py
+++ b/tests/test_wasm_scan.py
@@ -66,6 +66,10 @@ def test_scan_charset_and_float(source: str, expected: str) -> None:
         ("scan 3.14159 %4f x\nputs $x", "3.14"),
         # Sequential + suppress still work alongside the refactor.
         ('scan {1 2 3} {%d %*d %d} a b\nputs "$a $b"', "1 3"),
+        # Incomplete exponent: %f takes the valid prefix and leaves `e`
+        # for the next conversion rather than failing the whole scan.
+        ('scan 1e {%f%s} a b\nputs "$a $b"', "1.0 e"),
+        ('scan 2.5e {%f%s} a b\nputs "$a $b"', "2.5 e"),
     ],
 )
 def test_scan_xpg_and_width(source: str, expected: str) -> None:

--- a/tests/test_wasm_scan.py
+++ b/tests/test_wasm_scan.py
@@ -1,0 +1,50 @@
+"""WASM ``scan`` command — character sets and real floating-point.
+
+Pins two contracts added to ``runtime/zig/cmds/scan.zig``:
+
+* ``%[...]`` character-set conversion (``BuildCharSet`` / ``CharInSet``):
+  membership, ``^`` negation, ``a-z`` ranges (order-normalised), a
+  leading ``]`` as a literal member, and a ``-`` adjacent to ``]`` as a
+  literal.  Regression guard for the ``scan-1.*`` cluster.
+* ``%e`` / ``%f`` / ``%g`` boxing a real ``TYPE_FLOAT`` instead of the
+  old integer truncation (``scan 0.2 %f`` used to return ``0``).
+  Regression guard for ``scan-4.49`` / ``scan-11.*`` / ``scan-14.*``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(source: str) -> str:
+    wasm = _compile_tcl(source)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # %[...] character sets — mirrors scan-1.1 .. 1.8.
+        ("puts [list [scan foo {%[^o]} x] $x]", "1 f"),
+        ('set n [scan {]foo} {%[]f]} x]\nputs "$n $x"', "1 ]f"),
+        ("puts [list [scan abc-def {%[a-c]} x] $x]", "1 abc"),
+        ("puts [list [scan -abc-def {%[-ac]} x] $x]", "1 -a"),
+        ("puts [list [scan -abc-def {%[ac-]} x] $x]", "1 -a"),
+        ("puts [list [scan abc-def {%[c-a]} x] $x]", "1 abc"),
+        ("puts [list [scan def-abc {%[^c-a]} x] $x]", "1 def-"),
+        # charset following another conversion (scan-10.6).
+        ("puts [scan 5a {%i%[a]}]", "5 a"),
+        # Real float scanning — scan-4.49 / scan-11.1 / scan-14.1.
+        ('scan {.1 0.2 3.} {%e %f %g} x y z\nputs "$x $y $z"', "0.1 0.2 3.0"),
+        ("scan {123 13.6} {%s %f} a b\nputs $b", "13.6"),
+        ("scan -2.5 %f q\nputs $q", "-2.5"),
+        ("scan Inf %g d\nputs $d", "Inf"),
+    ],
+)
+def test_scan_charset_and_float(source: str, expected: str) -> None:
+    assert _run(source) == expected

--- a/tests/test_wasm_scan.py
+++ b/tests/test_wasm_scan.py
@@ -48,3 +48,25 @@ def _run(source: str) -> str:
 )
 def test_scan_charset_and_float(source: str, expected: str) -> None:
     assert _run(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # XPG3 positional conversions (%N$) — scan-4.11 / scan-13.1.
+        ('scan {   abc   def   } {%2$s %1$s} x y\nputs "$x $y"', "def abc"),
+        ("puts [scan a {%1$c}]", "97"),
+        ('scan {12 34} {%2$d %1$d} a b\nputs "$a $b"', "34 12"),
+        # Width fields cap the characters consumed — scan-4.12.
+        (
+            'scan {abc123456789012} {%3s%3d%3f%3[0-9]%s} a b c d e\nputs "$a $b $c $d $e"',
+            "abc 123 456.0 789 012",
+        ),
+        ("scan 123456 %3d x\nputs $x", "123"),
+        ("scan 3.14159 %4f x\nputs $x", "3.14"),
+        # Sequential + suppress still work alongside the refactor.
+        ('scan {1 2 3} {%d %*d %d} a b\nputs "$a $b"', "1 3"),
+    ],
+)
+def test_scan_xpg_and_width(source: str, expected: str) -> None:
+    assert _run(source) == expected

--- a/tests/test_wasm_string_index_parse.py
+++ b/tests/test_wasm_string_index_parse.py
@@ -1,0 +1,51 @@
+"""WASM ``Tcl_GetIntForIndex`` parsing — whitespace, signed offsets, ``0d``.
+
+``string index`` (and every index-taking command, via the shared
+``resolve_list_index``) must parse the Tcl 9 index grammar:
+
+* leading / trailing whitespace is skipped (``{ 0 }`` / ``{end-1 }``);
+* an offset after ``end±`` / between ``±`` may itself be signed
+  (``end+-1`` = end + (-1), ``end--1`` = end - (-1), ``-1--2`` = 1);
+* integer literals accept the ``0d`` explicit-decimal radix alongside
+  ``0x`` / ``0o`` / ``0b``;
+* out-of-range / overflowing indices yield the empty string.
+
+Regression guard for the util-9.* cluster.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(body: str) -> str:
+    _, stdout = _run_wasm(_compile_tcl(body), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("string index abcd { 0 }", "a"),
+        ("string index abcd { 3 }", "d"),
+        ("string index abcd {end-1 }", "c"),
+        ("string index abcd { 0x0 }", "a"),
+        ("string index abcd { 01 }", "b"),
+        ("string index abcd { 0d0 }", "a"),
+        ("string index abcdefghijk 0d10", "k"),
+        ("string index abcd { -1+2 }", "b"),
+        # signed offsets after the operator
+        ("string index abcd end+-1", "c"),
+        ("string index abcd -1--2", "b"),
+        # out-of-range / overflow -> empty string
+        ("string index abcd end--1", ""),
+        ("string index abcd -0x10000000000000000", ""),
+        ("string index abcd end+-0x10000000000000000", ""),
+    ],
+)
+def test_string_index_grammar(expr: str, expected: str) -> None:
+    assert _run(f"puts [{expr}]") == expected

--- a/tests/test_wasm_string_index_parse.py
+++ b/tests/test_wasm_string_index_parse.py
@@ -71,3 +71,19 @@ def test_string_index_rejects_operator_chains(idx: str, catch_expected: str) -> 
     # direct-import path.
     body = f"set sub index\nputs [catch {{string $sub abcd {idx}}} m]:$m"
     assert _run(body) == catch_expected
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        # list commands validate via is_valid_list_index before the shared
+        # resolver; it must accept the same whitespace / 0d forms (PR #516).
+        ("lindex {a b c d} { 1 }", "b"),
+        ("lindex {a b c d} 0d2", "c"),
+        ("lindex {a b c d} {end-1 }", "c"),
+        ("lrange {a b c d} { 1 } { 2 }", "b c"),
+        ("lindex {a b c d} { 0d10 }", ""),
+    ],
+)
+def test_list_index_grammar(expr: str, expected: str) -> None:
+    assert _run(f"puts [{expr}]") == expected

--- a/tests/test_wasm_string_index_parse.py
+++ b/tests/test_wasm_string_index_parse.py
@@ -49,3 +49,25 @@ def _run(body: str) -> str:
 )
 def test_string_index_grammar(expr: str, expected: str) -> None:
     assert _run(f"puts [{expr}]") == expected
+
+
+@pytest.mark.parametrize(
+    "idx,catch_expected",
+    [
+        # single-operator signed forms remain valid (resolver folds them)
+        ("-1+2", "0:b"),
+        ("end+-1", "0:c"),
+        ("-1--2", "0:b"),
+        # chained operators exceed the resolver's single-operator fold, so
+        # the validator must reject them as a bad index rather than let
+        # them silently resolve to the wrong position (PR #516 review).
+        ("end--1+2", '1:bad index "end--1+2": must be integer?[+-]integer? or end?[+-]integer?'),
+        ("-1--2+3", '1:bad index "-1--2+3": must be integer?[+-]integer? or end?[+-]integer?'),
+    ],
+)
+def test_string_index_rejects_operator_chains(idx: str, catch_expected: str) -> None:
+    # A dynamic subcommand forces the runtime ``string`` command (and its
+    # ``is_valid_string_index`` validator) rather than the compiled
+    # direct-import path.
+    body = f"set sub index\nputs [catch {{string $sub abcd {idx}}} m]:$m"
+    assert _run(body) == catch_expected

--- a/tests/test_wasm_switch_dynamic.py
+++ b/tests/test_wasm_switch_dynamic.py
@@ -1,0 +1,57 @@
+"""WASM ``switch`` with patterns supplied as separate (substitutable) words.
+
+When the arms come as separate words rather than a single braced
+``{pat body ...}`` block, each pattern is an ordinary word that undergoes
+``$var`` / ``[cmd]`` substitution before matching.  The codegen used to
+emit every switch pattern as a literal, so ``switch -glob -- $s $pat
+{...}`` matched against the literal text ``$pat`` and never fired —
+breaking the ``Wrapper_Tcl_StringMatch`` helper that backs util-5.*:
+
+    proc W {pattern string} {
+        switch -glob -- $string $pattern {return 1} default {return 0}
+    }
+
+The ``IRSwitch.patterns_braced`` flag now distinguishes the two forms so
+separate-word patterns are emitted via ``_emit_value``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+_WRAPPER = (
+    "proc W {pattern string} {\n"
+    "    switch -glob -- $string $pattern {return 1} default {return 0}\n"
+    "}\n"
+)
+
+
+def _run(body: str) -> str:
+    wasm = _compile_tcl(_WRAPPER + body)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "call,expected",
+    [
+        ("puts [W ab*c abc]", "1"),
+        ("puts [W a?c abc]", "1"),
+        ("puts [W *c abc]", "1"),
+        ("puts [W *3*6*9 0123456789]", "1"),
+        ("puts [W xyz abc]", "0"),
+        ("puts [W {[abc]bc} abc]", "1"),
+    ],
+)
+def test_switch_glob_dynamic_pattern(call: str, expected: str) -> None:
+    assert _run(call) == expected
+
+
+def test_switch_exact_dynamic_pattern() -> None:
+    # Exact mode with a variable pattern must also substitute.
+    body = "set p hello\nputs [switch -- hello $p {set r yes} default {set r no}]\n"
+    assert _run(body) == "yes"

--- a/tests/test_wasm_switch_dynamic.py
+++ b/tests/test_wasm_switch_dynamic.py
@@ -55,3 +55,17 @@ def test_switch_exact_dynamic_pattern() -> None:
     # Exact mode with a variable pattern must also substitute.
     body = "set p hello\nputs [switch -- hello $p {set r yes} default {set r no}]\n"
     assert _run(body) == "yes"
+
+
+def test_switch_pattern_only_import_is_scanned() -> None:
+    # A separate-word pattern is emitted via ``_emit_value`` and may be the
+    # *only* token needing a runtime helper (e.g. ``$arr(key)`` -> tcl_array_get).
+    # The import pre-scan must scan patterns when they aren't braced, or the
+    # module instantiates without the helper and the pattern miscompiles
+    # (PR #516 review).
+    body = (
+        "proc P {} { set a(p) {hel*}; "
+        "switch -glob -- hello $a(p) {return MATCH} default {return NO} }\n"
+        "puts [P]\n"
+    )
+    assert _run(body) == "MATCH"


### PR DESCRIPTION
## Summary

This PR implements several Tcl 9 features and fixes across the runtime and compiler:

### Runtime (Zig)

**`lseq` command enhancements:**
- Added support for double arithmetic series when START, END, or STEP is a float literal
- Implemented `count` keyword syntax (`lseq START count N ?by? ?STEP?`)
- Added `lseq_precision()` and `lseq_len_dbl()` to compute double series length with proper rounding
- Added `lseq_emit_dbl()` to emit double elements rounded to input precision (e.g., `lseq 4 40 0.1` now yields `6.3` instead of f64 noise)
- Refactored integer emission into `lseq_emit_int()` for clarity
- Added element count caps (`LSEQ_MAX_COUNT`, `LSEQ_DBL_MAX_COUNT`) to prevent runaway enumeration

**`scan` command enhancements:**
- Implemented `%[...]` character-set conversion with membership, `^` negation, `a-z` ranges (order-normalised), leading `]` as literal, and `-` adjacent to `]` as literal
- Changed `%e`, `%f`, `%g` to produce real `TYPE_FLOAT` results instead of integer truncation
- Added XPG3 positional conversion support (`%N$spec` assigns to the N-th variable)
- Added width field support for `%s`, `%d`, `%f`, `%[` conversions
- Refactored value assignment into `scan_store()` helper to consolidate suppress/variable/list logic

**`binary` command fixes:**
- Fixed `binary format w` to wrap wide integers to low 64 bits instead of saturating to i64 range (fixes NaN corruption in `convertDouble` helper)
- Added Tcl 8.5+ unsigned modifier support (`cu`, `su`, `iu`, `wu`) in `binary scan`

**`apply` command fixes:**
- Fixed parameter spec parsing to treat each parameter as a `{name ?default?}` list
- Added validation: `{}` (no name) raises "argument with no name"; `{a b c}` (>2 fields) raises "too many fields in argument specifier"
- Default values now properly applied when arguments omitted

**`string index` parsing:**
- Added whitespace trimming around indices (` 0 `, `end-1 `)
- Added support for signed offsets after operators (`end+-1`, `end--1`, `-1--2`)
- Added `0d` explicit-decimal radix support alongside `0x`, `0o`, `0b`

**Integer parsing:**
- Added `0d` radix support in `tcl_bignum.zig`

### Compiler (Python)

**`append` command codegen:**
- Refactored to use `_emit_concat_chain()` for multi-value appends
- Single-value append retains in-place fast path; multi-value routes through fresh-seeded concat to prevent aliasing corruption (e.g., `append x $x $x`)

**`switch` command codegen:**
- Added `patterns_braced` flag to distinguish literal patterns (single braced block) from substitutable patterns (separate words)
- Separate-word patterns now emitted via `_emit_value()` so `switch -glob -- $s $pat {...}` correctly substitutes `$pat`

**String concat chain helper:**
- Added `_emit_concat_chain()` to seed concat chains with null accumulator, ensuring first operand is copied and no operand is mutated (fixes `$x$x$x` doubling bug across interpolation, `string cat`, and `append`)

## Validation

- Added comprehensive test suites:
  - `test_wasm_lseq.py`: double series, count keyword, precision rounding
  - `test_wasm_scan.py`: character sets, float scanning, XPG3 positional conversions
  - `test_wasm_binary.py`: wide-int wrapping,

https://claude.ai/code/session_01GwENybTwsDywA8NN9ySt8s