### PR TITLE
Implement offset-free diff for optimiser lens

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=ab92e84-dirty
-head=ab92e84fdcc7dceed44ddf732de6526f60b35c68
-date=2026-06-01T16:19:59Z
-fingerprint=d2c73accca3f8b37bd7f96d9d2dfc466fb2a9e524e3c6f3ba5ad5093fe864e4b
+describe=8cbd3a6-dirty
+head=8cbd3a6a1499af1d2e0c9b09857f18ae9fe9b897
+date=2026-06-01T18:24:02Z
+fingerprint=4ffcfa7bcfe00bd9448448b26187ea8d50bd590185f318140123658352a22f9b

--- a/README.md
+++ b/README.md
@@ -653,6 +653,15 @@ labelled `block` / `loop` / `if` for each Tcl construct (`foreach`,
 above every instruction group, and orthogonal control-flow arrows in the
 left gutter.
 
+The IR, CFG, SSA, bytecode, and WASM tabs each carry an **optimiser lens**
+(`off` / `on` / `diff`).  The `diff` mode compares the relevant node — IR
+statement, CFG block, or bytecode instruction — rather than raw text, so
+byte offsets, source ranges, sequence indices, and tree-connector glyphs
+that merely shift when the optimiser adds or removes a node are ignored.
+A single rewrite then shows as a single localised change instead of every
+following line being flagged.  The `tcl-explorer` CLI and TUI render the
+same offset-free diff via `--opt diff`.
+
 ```
 ┌─────────────────────────────────────────────────┐
 │  IR  │  CFG  │  SSA  │  Optimiser  │  Bytecode  │

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -6,7 +6,7 @@ Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes
 
 ## Applies to
 
-VS Code
+VS Code, JetBrains, tcl-lsp CLI
 
 ## Availability
 
@@ -35,11 +35,23 @@ The **WASM** and **WASM (Opt)** tabs show a structured per-instruction disassemb
 - A label on `block` / `loop` / `if` opens identifying the Tcl construct that produced them (`foreach`, `while`, `for`, `if`, `catch body`, `switch arm`).
 - Orthogonal control-flow arrows in the left gutter showing every branch target, with forward edges drawn solid-blue and back-edges drawn dashed-yellow.
 
+### Optimiser lens (off / on / diff)
+
+The IR, CFG, SSA, bytecode, and WASM tabs each carry an optimiser lens with three modes:
+
+- **off** — the program as written.
+- **on** — the program after the optimiser runs.
+- **diff** — a localised diff of the two.
+
+The diff compares the *node* (an IR statement, a CFG block, a bytecode instruction), not the rendered text. Byte offsets, source ranges, statement and literal-pool indices, local-variable slots, header tallies, and the box-drawing tree/gutter glyphs all shift whenever the optimiser adds or removes a node, even when the surrounding nodes are untouched. The diff normalises those position-only tokens away so a single rewrite surfaces as a single localised change rather than flagging every following line. Operand values that carry meaning — instruction arities, increment immediates, literal text, variable names — are kept, so genuinely different nodes still differ.
+
+The `tcl-explorer` CLI and TUI render the same offset-free diff via `--opt diff` (for example `tcl-explorer script.tcl --show ir --opt diff`). The web panel does this for the IR/CFG diff and the bytecode "Show optimiser diff" view.
+
 ## File-path anchors
 
 - `editors/vscode/src/compilerExplorer.ts`
 - `editors/vscode/src/compilerExplorerHtml.ts`
-- `tooling/explorer/`
+- `tooling/explorer/` (`_normalise_diff_line` / `_print_opt_diff` in `cli.py`; `normaliseForDiff` / `irToLines` in `static/explorer-core.js`)
 
 ## Failure modes
 

--- a/tests/test_compiler_explorer.py
+++ b/tests/test_compiler_explorer.py
@@ -157,6 +157,61 @@ class TestOptLens:
         code, out = _run_source(self.SRC, capsys, extra=["--show", "types", "--opt", "on"])
         assert code == 0  # types view renders normally regardless of lens
 
+    # Folding the first two statements to ``puts 3`` deletes two lines, so the
+    # trailing ``puts done`` slides from line 4 to line 2.  Its IR summary is
+    # byte-for-byte identical — only its source range moved.  A raw text diff
+    # would flag it (the ``[4:1-4:9]`` vs ``[2:1-2:9]`` range differs); the
+    # node-level diff must leave it as quiet context.
+    SHIFT_SRC = "set a 1\nset b [expr {$a + 2}]\nputs $b\nputs done"
+
+    def test_opt_diff_ignores_offset_shift(self, capsys):
+        code, out = _run_source(self.SHIFT_SRC, capsys, extra=["--show", "ir", "--opt", "diff"])
+        assert code == 0
+        # The genuinely rewritten statements are still surfaced.
+        assert "+  ├── call puts 3" in out
+        # ``puts done`` only moved line:col — it must not appear as a +/- line.
+        moved = [line for line in out.splitlines() if line[:1] in "+-" and "puts done" in line]
+        assert moved == [], f"offset-only shift leaked into the diff: {moved}"
+
+
+class TestDiffNormalisation:
+    """Unit tests for the offset-ignoring diff key (``_normalise_diff_line``)."""
+
+    def test_tree_connector_and_range_collapse(self):
+        from tooling.explorer.cli import _normalise_diff_line
+
+        # Same node, different sibling position (├── vs └──) and source range.
+        a = _normalise_diff_line("│   ├── call puts ${b} [3:1-3:7]")
+        b = _normalise_diff_line("    └── call puts ${b} [9:9-9:99]")
+        assert a == b
+
+    def test_byte_offset_and_literal_index_collapse(self):
+        from tooling.explorer.cli import _normalise_diff_line
+
+        # Same instruction, shifted byte offset and literal-pool index.
+        a = _normalise_diff_line('    (15) push1 4\t# "puts"')
+        b = _normalise_diff_line('    (2) push1 0\t# "puts"')
+        assert a == b
+
+    def test_variable_slot_collapses_but_arity_is_kept(self):
+        from tooling.explorer.cli import _normalise_diff_line
+
+        # %vN slot shifts when a variable is dropped — the comment names it.
+        assert _normalise_diff_line('    (4) loadScalar1 %v2\t# var "a"') == _normalise_diff_line(
+            '    (9) loadScalar1 %v1\t# var "a"'
+        )
+        # Arity (invokeStk1 2) is semantic — distinct arities stay distinct.
+        assert _normalise_diff_line("    (4) invokeStk1 2\t# puts") != _normalise_diff_line(
+            "    (4) invokeStk1 3\t# puts"
+        )
+
+    def test_distinct_content_stays_distinct(self):
+        from tooling.explorer.cli import _normalise_diff_line
+
+        assert _normalise_diff_line('  └── call puts "a"') != _normalise_diff_line(
+            '  └── call puts "b"'
+        )
+
 
 # LineIndex unit tests
 

--- a/tests/test_compiler_explorer.py
+++ b/tests/test_compiler_explorer.py
@@ -212,6 +212,25 @@ class TestDiffNormalisation:
             '  └── call puts "b"'
         )
 
+    def test_offset_only_difference_reports_no_change(self):
+        # When the two streams differ only in offsets, the diff has nothing to
+        # show: it must print the "no change" line, not bare --- / +++ headers.
+        # (get_grouped_opcodes is a generator, so the emptiness check must
+        # materialise it first.)
+        import contextlib
+        import io
+
+        from tooling.explorer.cli import _print_opt_diff
+
+        before = ["  ├── call puts hi [1:1-1:7]"]
+        after = ["  └── call puts hi [9:9-9:15]"]  # same node, only connector + range moved
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            _print_opt_diff("ir", before, after, use_colour=False)
+        out = buf.getvalue()
+        assert "no change under the optimiser" in out
+        assert "--- ir" not in out and "+++ ir" not in out
+
 
 # LineIndex unit tests
 

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -1697,7 +1697,9 @@ def _print_opt_diff(view: str, before: list[str], after: list[str], *, use_colou
         [_normalise_diff_line(line) for line in after],
         autojunk=False,
     )
-    groups = matcher.get_grouped_opcodes(n=3)
+    # get_grouped_opcodes is a generator (always truthy) — materialise it so the
+    # "no change" check below fires when the streams are offset-identical.
+    groups = list(matcher.get_grouped_opcodes(n=3))
     if not groups:
         print(
             style(f"{view}: no change under the optimiser (offsets ignored)", Ansi.DIM, use_colour)

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -1632,6 +1633,98 @@ def _capture_view(
     return buf.getvalue().splitlines()
 
 
+# The optimiser shifts byte offsets, source ranges, sequence indices, and the
+# box-drawing connectors that encode tree depth / control-flow edges every time
+# it adds or removes a node.  The opt-diff compares *nodes* (an IR statement, a
+# bytecode instruction, a CFG block), so these position-only tokens are
+# collapsed to a constant before diffing — otherwise a single rewrite shifts
+# every following line and the localised change drowns in offset noise.  This
+# mirrors the web GUI, which already diffs offset-free keys (``normaliseForDiff``
+# / ``irToLines`` in ``static/explorer-core.js``).
+_DIFF_RANGE_SPAN = re.compile(r"\[(?:\d+:\d+-\d+:\d+|\?:\?-\?:\?)\]")  # [1:1-1:7] source range
+_DIFF_ASM_OFFSET = re.compile(r"^(\s*)\(\d+\)")  # (0) bytecode byte offset
+_DIFF_CFG_INDEX = re.compile(r"\[\d+\]")  # [0] CFG statement sequence number
+_DIFF_PC_TARGET = re.compile(r"\bpc \d+")  # absolute jump target (pc 33)
+_DIFF_ASM_COUNTS = re.compile(r"\b\d+ (instructions|bytes|literals|variables)\b")  # header tallies
+_DIFF_PUSH_LITERAL = re.compile(
+    r"\b(push\d+) \d+"
+)  # push1 0 -> push1 (the comment names the literal)
+_DIFF_LITERAL_INDEX = re.compile(r"^(\s*)\d+: ")  # literal-pool table index
+_DIFF_LVT_SLOT = re.compile(r"%v\d+")  # local-variable-table slot (the comment names the variable)
+_DIFF_BOX_ARROWS = "▶◀▸◂▴▾"
+
+
+def _normalise_diff_line(line: str) -> str:
+    """Reduce a rendered view line to an offset-free comparison key.
+
+    Maps every position-only token (tree/gutter glyph, source range, byte
+    offset, sequence index, literal-pool index, header tally) to a constant so
+    two renderings of the *same* node compare equal even when the optimiser
+    shifted everything around it.  Operand values that carry meaning —
+    instruction arities, increment immediates, variable slots, literal text —
+    are left untouched so genuinely different nodes still differ.
+    """
+    # Box-drawing glyphs (U+2500–U+257F) and arrowheads encode position, not
+    # content; map each to a single space so ``├──`` vs ``└──`` and the CFG
+    # edge gutter never register as a change while column width (the tree
+    # depth) is preserved.
+    key = "".join(" " if "─" <= ch <= "╿" or ch in _DIFF_BOX_ARROWS else ch for ch in line)
+    key = _DIFF_RANGE_SPAN.sub("[]", key)
+    key = _DIFF_ASM_OFFSET.sub(r"\1()", key)
+    key = _DIFF_CFG_INDEX.sub("[]", key)
+    key = _DIFF_PC_TARGET.sub("pc", key)
+    key = _DIFF_ASM_COUNTS.sub(r"N \1", key)
+    key = _DIFF_PUSH_LITERAL.sub(r"\1", key)
+    key = _DIFF_LITERAL_INDEX.sub(r"\1#: ", key)
+    key = _DIFF_LVT_SLOT.sub("%v", key)
+    return key.rstrip()
+
+
+def _print_opt_diff(view: str, before: list[str], after: list[str], *, use_colour: bool) -> None:
+    """Print a unified diff of two rendered views with offsets ignored.
+
+    The hunks are computed over offset-free keys (:func:`_normalise_diff_line`)
+    so only genuine node changes drive the diff, but the *original* lines —
+    offsets and all — are what gets displayed, so the reader still sees the real
+    instruction stream.  Lines that differ only in offsets fall into ``equal``
+    runs and render as quiet context.
+    """
+    import difflib
+
+    matcher = difflib.SequenceMatcher(
+        None,
+        [_normalise_diff_line(line) for line in before],
+        [_normalise_diff_line(line) for line in after],
+        autojunk=False,
+    )
+    groups = matcher.get_grouped_opcodes(n=3)
+    if not groups:
+        print(
+            style(f"{view}: no change under the optimiser (offsets ignored)", Ansi.DIM, use_colour)
+        )
+        return
+    print(style(f"--- {view} (original)", Ansi.RED, use_colour))
+    print(style(f"+++ {view} (optimised)", Ansi.GREEN, use_colour))
+    for group in groups:
+        first, last = group[0], group[-1]
+        print(
+            style(
+                f"@@ -{first[1] + 1},{last[2] - first[1]} +{first[3] + 1},{last[4] - first[3]} @@",
+                Ansi.CYAN,
+                use_colour,
+            )
+        )
+        for tag, i1, i2, j1, j2 in group:
+            if tag == "equal":
+                for line in before[i1:i2]:
+                    print(f" {line}")
+                continue
+            for line in before[i1:i2]:
+                print(style(f"-{line}", Ansi.RED, use_colour))
+            for line in after[j1:j2]:
+                print(style(f"+{line}", Ansi.GREEN, use_colour))
+
+
 def render_view_opt(
     view: str,
     result: CompilerExplorerResult,
@@ -1692,9 +1785,9 @@ def render_view_opt(
         )
         return
 
-    # diff: a rendered-text unified diff, surface-agnostic across all OPT_VIEWS.
-    import difflib
-
+    # diff: a node-level unified diff, surface-agnostic across all OPT_VIEWS.
+    # Offsets are normalised away (see _normalise_diff_line) so the diff tracks
+    # the node, not where the optimiser pushed it.
     before = _capture_view(
         view, result, source, line_index=line_index, views=views, max_annotations=max_annotations
     )
@@ -1706,23 +1799,7 @@ def render_view_opt(
         views=views,
         max_annotations=max_annotations,
     )
-    diff = list(
-        difflib.unified_diff(
-            before, after, fromfile=f"{view} (original)", tofile=f"{view} (optimised)", lineterm=""
-        )
-    )
-    if not diff:
-        print(style(f"{view}: no change under the optimiser", Ansi.DIM, use_colour))
-        return
-    for line in diff:
-        if line.startswith("+"):
-            print(style(line, Ansi.GREEN, use_colour))
-        elif line.startswith("-"):
-            print(style(line, Ansi.RED, use_colour))
-        elif line.startswith("@@"):
-            print(style(line, Ansi.CYAN, use_colour))
-        else:
-            print(line)
+    _print_opt_diff(view, before, after, use_colour=use_colour)
 
 
 def _summary_parts(result: CompilerExplorerResult, dialect: str) -> list[str]:


### PR DESCRIPTION
## Summary

Implement a node-level diff for the optimiser lens that ignores position-only tokens (byte offsets, source ranges, sequence indices, tree glyphs, etc.) so that genuine node changes surface as localised diffs rather than drowning in offset noise when the optimiser shifts surrounding instructions.

The change adds two new functions:
- `_normalise_diff_line()`: Reduces a rendered view line to an offset-free comparison key by collapsing position-only tokens to constants while preserving semantically meaningful operand values (instruction arities, literal text, variable names, etc.)
- `_print_opt_diff()`: Computes a unified diff over normalised keys but displays original lines with offsets intact, so readers see the real instruction stream while the diff tracks only genuine node changes.

The `render_view_opt()` function now calls `_print_opt_diff()` instead of the previous raw text diff, and the CLI `--opt diff` mode now produces the same offset-free diff as the web GUI.

## Changes

- **tooling/explorer/cli.py**: Added regex patterns and normalisation logic; refactored diff rendering into `_print_opt_diff()`
- **tests/test_compiler_explorer.py**: Added integration test (`test_opt_diff_ignores_offset_shift`) and unit test suite (`TestDiffNormalisation`) covering tree connectors, byte offsets, literal indices, variable slots, and semantic content preservation
- **docs/kcs/features/kcs-feature-compiler-explorer.md**: Documented the optimiser lens modes and offset-free diff behaviour; updated file-path anchors
- **README.md**: Added overview of the optimiser lens and offset-free diff feature

## Validation

- [x] Added unit tests for `_normalise_diff_line()` covering tree connectors, byte offsets, literal indices, variable slots, and semantic content
- [x] Added integration test verifying that offset-only shifts (source range changes without node rewrites) do not appear as +/- lines in the diff
- [x] Existing tests pass

https://claude.ai/code/session_016vVKrrwNd4GpZEUNZEqNch