### PR TITLE
Port Phase 8 place model and reroute W220/O109 to overlap

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -47,6 +47,35 @@ python3 .claude/skills/lsp-client/lsp_client.py --server rust   diagnostics foo.
 python3 .claude/skills/lsp-client/lsp_client.py --server python diagnostics foo.tcl
 ```
 
+## Selecting a dialect (`--language-id`)
+
+The server picks its analysis **dialect** from the LSP `languageId` the
+client sends on `didOpen` (this takes precedence over any `tclLsp.dialect`
+setting).  The client derives the `languageId` from the **file extension**,
+mirroring the editor's language associations:
+
+| Extension | languageId | Dialect |
+|---|---|---|
+| `.tcl`, `.tk`, `.itcl`, `.tm`, `.test` (and anything unrecognised) | `tcl` | `tcl8.6` |
+| `.irul`, `.irule` | `tcl-irule` | `f5-irules` |
+| `.iapp`, `.iappimpl`, `.impl` | `tcl-iapp` | `f5-iapps` |
+| `.exp` | `tcl-expect` | `expect` |
+
+So `.irul` files are analysed as iRules automatically — no extra flags.
+
+Use `--language-id <id>` to override this when the extension doesn't imply
+the dialect you want — e.g. an iRule saved as `.tcl`, or exercising a
+specific Tcl version.  It accepts editor ids (`tcl`, `tcl-irule`,
+`tcl-iapp`, `tcl-expect`) **or** canonical dialect names (`f5-irules`,
+`f5-iapps`, `tcl8.4`, `tcl9.0`, …):
+
+```bash
+# An iRule that happens to live in a .tcl file
+python3 .claude/skills/lsp-client/lsp_client.py --server rust --language-id tcl-irule diagnostics rule.tcl
+# Check tcl9.0-specific behaviour on a plain .tcl file
+python3 .claude/skills/lsp-client/lsp_client.py --server rust --language-id tcl9.0 diagnostics foo.tcl
+```
+
 ## Subcommands
 
 | Subcommand | Arguments | What it does |

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -511,8 +511,42 @@ def initialize(client: LspClient) -> dict:
     return result
 
 
-def open_document(client: LspClient, file_path: str) -> tuple[str, str]:
-    """Read a file, send textDocument/didOpen, return (uri, content)."""
+# File-extension → LSP languageId, mirroring the editor's language
+# associations (editors/vscode/package.json).  The server derives the
+# analysis dialect from the languageId sent on didOpen
+# (Backend::dialect_from_language_id) — and that takes precedence over
+# any `tclLsp.dialect` setting — so sending the right languageId is what
+# makes a `.irul` file analyse as f5-irules instead of plain Tcl.
+_LANGUAGE_ID_BY_EXT = {
+    ".irul": "tcl-irule",
+    ".irule": "tcl-irule",
+    ".iapp": "tcl-iapp",
+    ".iappimpl": "tcl-iapp",
+    ".impl": "tcl-iapp",
+    ".exp": "tcl-expect",
+}
+
+
+def language_id_for(path_or_uri: str) -> str:
+    """LSP languageId for a file, by extension (default ``tcl``).
+
+    Accepts a filesystem path or a ``file://`` URI.  Unknown extensions
+    fall back to ``"tcl"`` (the server maps that to its default tcl8.6).
+    """
+    ext = os.path.splitext(path_or_uri)[1].lower()
+    return _LANGUAGE_ID_BY_EXT.get(ext, "tcl")
+
+
+def open_document(
+    client: LspClient, file_path: str, language_id: str | None = None
+) -> tuple[str, str]:
+    """Read a file, send textDocument/didOpen, return (uri, content).
+
+    ``language_id`` overrides the extension-derived LSP languageId (see
+    :func:`language_id_for`).  The server maps the languageId to the
+    analysis dialect, so this is what selects f5-irules / f5-iapps /
+    tcl9.0 / etc.
+    """
     abs_path = os.path.abspath(file_path)
     if not os.path.isfile(abs_path):
         raise FileNotFoundError(f"File not found: {abs_path}")
@@ -524,7 +558,7 @@ def open_document(client: LspClient, file_path: str) -> tuple[str, str]:
         {
             "textDocument": {
                 "uri": uri,
-                "languageId": "tcl",
+                "languageId": language_id or language_id_for(abs_path),
                 "version": 1,
                 "text": content,
             },
@@ -1137,7 +1171,7 @@ def cmd_command_info(client: LspClient, command_name: str) -> None:
     print_command_info(result)
 
 
-def cmd_context(client: LspClient, uri: str, content: str) -> None:
+def cmd_context(client: LspClient, uri: str, content: str, language_id: str | None = None) -> None:
     """Build a context pack: diagnostics + symbols + event metadata.
 
     Mirrors the context enrichment from the VS Code extension's contextPack.ts.
@@ -1146,9 +1180,16 @@ def cmd_context(client: LspClient, uri: str, content: str) -> None:
     basename = os.path.basename(file_path)
     line_count = len(content.split("\n"))
 
-    # Detect dialect from extension
-    ext = os.path.splitext(file_path)[1].lower()
-    dialect = "f5-irules" if ext in (".irul", ".irule") else "tcl8.6"
+    # Report the dialect the server actually analysed under — the same
+    # languageId open_document sent, mapped to its canonical dialect
+    # name (editor ids map; canonical names like `tcl9.0` pass through).
+    lid = language_id or language_id_for(file_path)
+    dialect = {
+        "tcl": "tcl8.6",
+        "tcl-irule": "f5-irules",
+        "tcl-iapp": "f5-iapps",
+        "tcl-expect": "expect",
+    }.get(lid, lid)
 
     print("=== Context Pack ===")
     print(f"  Dialect: {dialect}")
@@ -1260,7 +1301,14 @@ def cmd_all(client: LspClient, uri: str, content: str) -> None:
 _TIMING_RE = re.compile(r"\[timing\]\s+(\S+)\s+([\d.]+)ms")
 
 
-def cmd_bench(client: LspClient, uri: str, content: str, *, iterations: int = 1) -> None:
+def cmd_bench(
+    client: LspClient,
+    uri: str,
+    content: str,
+    *,
+    iterations: int = 1,
+    language_id: str | None = None,
+) -> None:
     """Benchmark time-to-semantic-tokens replicating VS Code's request pattern.
 
     VS Code sends requests sequentially after didOpen:
@@ -1299,7 +1347,7 @@ def cmd_bench(client: LspClient, uri: str, content: str, *, iterations: int = 1)
                 {
                     "textDocument": {
                         "uri": uri,
-                        "languageId": "tcl",
+                        "languageId": language_id or language_id_for(uri),
                         "version": i + 1,
                         "text": content,
                     }
@@ -1307,16 +1355,6 @@ def cmd_bench(client: LspClient, uri: str, content: str, *, iterations: int = 1)
             )
 
         t_open = time.perf_counter()
-
-        # VS Code sends didChangeConfiguration shortly after didOpen —
-        # detect iRules content or extension to match real editor behavior.
-        ext = uri.rsplit(".", 1)[-1].lower() if "." in uri else ""
-        is_irules = ext in ("irul", "irule") or "when " in content[:2000]
-        if is_irules:
-            client.send_notification(
-                "workspace/didChangeConfiguration",
-                {"settings": {"tclLsp": {"dialect": "f5-irules"}}},
-            )
 
         # Sequential request chain — each waits for its response.
         step_times: list[tuple[str, float]] = []
@@ -1478,6 +1516,16 @@ examples:
         help="Path to the server. For --server python: the tcl-lsp dir holding "
         "`lsp/`. For --server rust: the Cargo workspace root. Auto-detected by default.",
     )
+    parser.add_argument(
+        "--language-id",
+        help="Override the LSP languageId sent on didOpen (default: derived from "
+        "the file extension — e.g. .irul -> tcl-irule). The server maps this to "
+        "the analysis dialect, so it is what selects f5-irules etc. Accepts editor "
+        "ids (tcl, tcl-irule, tcl-iapp, tcl-expect) or canonical dialect names "
+        "(f5-irules, f5-iapps, tcl8.4, tcl9.0, ...). Use it to force a dialect for "
+        "files whose extension does not imply one (e.g. an iRule saved as .tcl, or "
+        "testing tcl9.0 behaviour).",
+    )
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -1601,21 +1649,12 @@ examples:
             time.sleep(0.2)
             cmd_command_info(client, args.name)
         else:
-            # Commands that require a file
-            ext = os.path.splitext(args.file)[1].lower()
-            if ext in (".irul", ".irule"):
-                dialect = "f5-irules"
-            elif ext in (".iapp", ".iappimpl", ".impl"):
-                dialect = "f5-iapps"
-            else:
-                dialect = None
-            if dialect:
-                client.send_notification(
-                    "workspace/didChangeConfiguration",
-                    {"settings": {"tclLsp": {"dialect": dialect}}},
-                )
-
-            uri, content = open_document(client, args.file)
+            # Commands that require a file.  The LSP languageId carries
+            # the dialect to the server (it takes precedence over any
+            # `tclLsp.dialect` setting), derived from the file extension
+            # unless `--language-id` overrides it.
+            language_id = args.language_id or language_id_for(args.file)
+            uri, content = open_document(client, args.file, language_id)
 
             # Give server a moment to process didOpen and push diagnostics
             time.sleep(0.3)
@@ -1644,11 +1683,17 @@ examples:
                 case "diagram":
                     cmd_diagram(client, content)
                 case "context":
-                    cmd_context(client, uri, content)
+                    cmd_context(client, uri, content, language_id=language_id)
                 case "all":
                     cmd_all(client, uri, content)
                 case "bench":
-                    cmd_bench(client, uri, content, iterations=args.iterations)
+                    cmd_bench(
+                        client,
+                        uri,
+                        content,
+                        iterations=args.iterations,
+                        language_id=language_id,
+                    )
                 case "logs":
                     cmd_logs(client, uri, timing_only=args.timing_only)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1607,6 +1607,32 @@ Structural new surfaces (no Rust mirror today):
   emitters reroute through `places_read_to_form` instead of plain
   variable-name comparison.  Classify in-scope, structural — fold
   into the C41 analyser-core port or land as its own follow-up.
+
+  **Landed (rust) — `SYNC-MAY31-1b`, in progress.**  Per the
+  `docs/design/compiler/phase8-place-migration.md` ledger, the headline
+  ARRAY_ELEM precision win on `main` was achieved with the *suppress-only*
+  `overlap` relation + the 8E refinement, **without** the full 8F versioned
+  substrate — so the Rust port mirrors that: port `place` / `var_resolve`
+  / `place_bridge`, then reroute the W220 / W211 / O109 consumers through
+  `overlap`.  Staged, output-equivalent until the consumer reroute:
+  - **Stage 1 (done): `tcl-compiler::place`.**  Faithful port of
+    `place.py` — `Place` / `Index` / `PlaceKind` / `IndexKind`,
+    constructors, `base` / `is_global`, the over-approximating `overlap`
+    (with the 8E dynamic-*index*-vs-dynamic-*alias* split), and
+    `places_read_to_form`.  Self-contained (stdlib only); 13
+    discriminating unit tests including the `a(k)` ≠ `a(j)` disjointness
+    and the gregorian-style dynamic-alias precision case.  No consumer
+    wired yet → corpus byte-identical.
+  - Stage 2 (next): `tcl-compiler::var_resolve` (`resolve_place` +
+    `ResolveContext`, needs a `split_array_name` port + the inner
+    var-read scanner).
+  - Stage 3: `tcl-compiler::place_bridge` (`def_places` / `read_places`
+    / `terminator_read_places` + `build_resolve_context`).
+  - Stage 4 (output-changing): reroute the W220 dead-store / W211 unused
+    / O109 DCE consumers through `overlap`; gated on the full suite +
+    the array-element FP regression test (`set a(k) 1; set a(j) 2; puts
+    $a(k)` no longer emits W220 on `a(k)`, while the scalar dead store
+    still does).
 - **Phase 0 / 1 / 6 / 7 — shared infrastructure.**  Phase 0:
   registry-aware green-tree descent (`descend_command`) single-sources
   body role-resolution.  Phase 1: shared loop-nesting forest

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1631,9 +1631,21 @@ Structural new surfaces (no Rust mirror today):
     tests (local/global/ns binding, literal vs dynamic element, upvar
     alias owner, trace→observed, the `a(k)`≠`a(j)` resolve→overlap
     integration).  No consumer wired yet → output-equivalent.
-  - Stage 3 (next): `tcl-compiler::place_bridge` (`def_places` / `read_places`
-    / `terminator_read_places` + `build_resolve_context`).
-  - Stage 4 (output-changing): reroute the W220 dead-store / W211 unused
+  - **Stage 3 (done): `tcl-compiler::place_bridge`.**  Faithful port of
+    `place_bridge.py` — `build_resolve_context` (scans the CFG for
+    `global` / `variable` / `upvar` / `trace` decls), `def_places`,
+    `read_places` (element-granular `$`-refs via a new
+    `var_refs::scan_var_ref_forms` *forms* scanner; VAR_READ-role name
+    args incl. whole-array `array get`; `places_read_to_form` for
+    dynamic index/name reads; structural proc/method bodies skipped by
+    reusing `ssa::structural_body_indices`), and `terminator_read_places`
+    (branch conditions + non-braced returns).  New helpers:
+    `var_refs::{scan_var_ref_forms, command_subst_texts}` and
+    `ExprNode::command_texts`.  5 bridge tests + helper tests, including
+    the end-to-end check that `set a(k) 1; set a(j) 2; puts $a(k)`
+    produces an `a(k)` def observed by a read while `a(j)` is observed by
+    none.  No consumer wired yet → output-equivalent.
+  - Stage 4 (next, output-changing): reroute the W220 dead-store / W211 unused
     / O109 DCE consumers through `overlap`; gated on the full suite +
     the array-element FP regression test (`set a(k) 1; set a(j) 2; puts
     $a(k)` no longer emits W220 on `a(k)`, while the scalar dead store

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1646,29 +1646,41 @@ Structural new surfaces (no Rust mirror today):
     produces an `a(k)` def observed by a read while `a(j)` is observed by
     none.  No consumer wired yet → output-equivalent.
   - **Stage 4 (done): reroute the W220 dead-store consumer through
-    `overlap`.**  `emit_dead_store_diagnostics` now consults a new
-    `place_suppressed_dead_stores` helper: for each function it builds the
-    `ResolveContext`, collects every read place (statements +
-    terminators), and suppresses a dead-store candidate whose
-    **array-element / dict-path** def place overlaps a read.  Scalars keep
-    their precise name-level verdict (the suppression is element-granular
-    only), and a cheap "has array-element assign" pre-check keeps non-array
-    functions cost-free.  So `set a(k) 1; set a(j) 2; puts $a(k)` no longer
-    false-fires W220 on `a(k)`, while `set x 1; set x 2; puts $x` still
-    does.  Two discriminating analyser tests (array suppressed, scalar
-    still fires), the array one verified to fail without the reroute.
-    Note: only the **analyser** W220 is rerouted — the Rust optimiser DCE
-    (O109) is a *separate* computation (unlike Python's shared
-    `analysis.dead_stores`), so there is no shared-list desync and no
-    VM-equivalence concern here.  The rare same-element reassignment dead
-    store is intentionally not recovered (needs the versioned 8F
-    substrate), matching `main`'s suppress-only stage.
+    `overlap`.**  Both the analyser (W220) and the optimiser (O109 —
+    `Eliminate dead store`) now consult one shared helper,
+    `place_bridge::element_writes_observed_by_reads`: for each function it
+    builds the `ResolveContext`, collects every read place (statements +
+    terminators), and reports each **array-element / dict-path** write
+    whose def place `overlap`s a read.  The consumer then suppresses those
+    candidates.  Scalars keep their precise name-level verdict (the
+    suppression is element-granular only), and a cheap "has array-element
+    assign" pre-check keeps non-array functions cost-free.  So
+    `set a(k) 1; set a(j) 2; puts $a(k)` no longer false-fires W220/O109 on
+    `a(k)`, while `set x 1; set x 2; puts $x` (scalar) and
+    `set a(k) 1; set a(j) 2; puts $a(j)` (a(k) genuinely dead) still do.
+    The optimiser path threads the registry to the elimination pass via a
+    new `PassContext::registry` (set by the `optimise*` entry points;
+    `None` on the bare `run_pass` test path — so existing optimiser tests
+    are unaffected).  Four discriminating tests (analyser + optimiser ×
+    {array suppressed, genuine still fires}); the suppressed ones verified
+    to fail without the reroute.  Note: O109 emits an *optimisation
+    suggestion*, not bytecode — and it is a **separate** computation from
+    W220 (unlike Python's shared `analysis.dead_stores`), so there is no
+    shared-list desync and no VM-equivalence concern.  The rare
+    same-element reassignment dead store is intentionally not recovered
+    (needs the versioned 8F substrate), matching `main`'s suppress-only
+    stage.
 
-  Remaining follow-ups (optional, separate chunks): the **W211** unused
-  and **O109** optimiser-DCE consumers could likewise route through
-  `overlap` for full parity; both are lower-value than the W220 −88 win
-  (W211 array cases are mostly false *negatives* from name folding; O109
-  is an optimiser/VM-gated change).
+  **W211 / O126 (unused variable) — already at parity, no reroute needed.**
+  Investigated and confirmed a no-op in Rust: the def-use builder tracks
+  reads at the name level (so `array get a`, `puts $a(k)`, dynamic-index,
+  `eval`, expr command-subs are all already seen as uses of base `a`), and
+  W211/O126 are name-level-granular (fire only when the *whole* variable
+  has no live version).  The cross-scope upvar cases Python's place model
+  removed there (−2) are already handled in Rust by the `scope_aliases`
+  filter.  Wiring the place model in (verified against the suite) changed
+  no output, so it was reverted rather than ship effect-less code with no
+  discriminating test.
 - **Phase 0 / 1 / 6 / 7 — shared infrastructure.**  Phase 0:
   registry-aware green-tree descent (`descend_command`) single-sources
   body role-resolution.  Phase 1: shared loop-nesting forest

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2607,6 +2607,119 @@ piece) + reposition adapter (this row's second piece) +
 Classify: in-scope, **structural**, closes with `S*`.  No standalone
 Rust port today.
 
+## SYNC-JUN02 family — main audit (2026-06-02)
+
+Re-audited `origin/main`@`8aeaf1cd` against the prior anchor
+`origin/main`@`59c770f6` (the SYNC-MAY31 refresh point).  `main` landed
+**5** commits since then.  Histories still diverge fully (no merge-base),
+so this remains a per-file audit, not a git rebase.
+
+Out of scope (no Rust mirror — record and skip):
+
+- **Explorer / optimiser-lens tooling** — `a31d018d` (#517, offset-free
+  diff for the optimiser lens — `tooling/explorer/cli.py`), `7d5479d5`
+  (#513, Unicode box-drawing IR / callout trees — `tooling/explorer/` +
+  `editors/vscode/`).  Pure explorer / editor UI; close with `EXP*` /
+  editor-specific chunks.
+- **WASM emitter + Zig runtime (bulk of #516)** — `8aeaf1cd` is mostly a
+  WASM-codegen concat-aliasing fix (a shared `_emit_concat_chain` seeds
+  each multi-operand chain with a *null* accumulator so a borrowed `$var`
+  read — refcount 1 — is never mutated in place mid-expression; fixes
+  `set t $t$t$t$t` doubling) plus Tcl 9 command semantics in the Zig
+  interp (`lseq` doubles, `scan` charset / float, `binary` unsigned
+  formats, `apply` defaults).  The Rust port emits no WASM and runs no Zig
+  VM, so the codegen / runtime bulk has no Rust analyser hook — mirror is
+  the Zig workstream + the future Rust WASM emitter.  But #516 *also*
+  carries two in-scope lowering / registry slivers — see `SYNC-JUN02-3`.
+
+In-scope rows (mirror these into the Rust workstream):
+
+### SYNC-JUN02-1 — Lower TclOO method bodies to FunctionUnits + O126 method purity (#506)
+
+`main` populates `ir_module.methods` during lowering: `oo::class create` /
+`oo::define` bodies are descended and each method / constructor / destructor
+body is lifted to an `IRMethodDef` (**analysis-only** — codegen still sees
+the same `IRBarrier`, so bytecode is byte-identical).  `compile_source`
+lowers those to per-method `FunctionUnit`s in a separate
+`CompilationUnit.methods` dict; `analyse_interprocedural_ir` summarises them
+into `InterproceduralAnalysis.methods` (conservative purity: pure iff no
+local side effect and every proc callee pure; `my` / `next` self-dispatch
+surfaces as an unknown call → impure).  The optimiser then iterates method
+bodies with the owning class as `enclosing_class`, so the previously-inert
+SF-2 wiring in `_elimination.py` fires — `set unused [my <pure-method>]`
+folds to an O126 deletion while an impure-method RHS is preserved (flips
+FP-OPT-12 PARTIAL → FIXED).  A second commit hardens the **W307**
+VAR-as-command suppression to per-SSA-version precision
+(`set c notacommand; set c parse; $c x` must keep W307 alive for the
+dispatch, since the command-valued version reaches it).
+
+**Rust state — partial scaffolding, the real wiring is the gap.**
+`tcl-compiler::ir` already declares `Module.methods: HashMap<String,
+MethodDef>` and the `MethodDef` struct, and `interprocedural` declares a
+`MethodSummary` + `InterproceduralAnalysis.methods` map — but all three are
+**inert placeholders**: lowering never populates `Module.methods` (a unit
+test asserts it stays empty), `CompilationUnit` has no `methods` field and
+builds no per-method `FunctionUnit`s, the interproc `methods` map is
+initialised empty, and `optimiser::elimination` has no `enclosing_class` /
+method-body iteration (so O126-method / SF-2 never fires).  Note the
+analyser already has a *separate* OO model in `analyser/oo.rs` (its own
+`MethodDef`, for the OO W-codes) — this row is the *compiler / optimiser*
+method-FunctionUnit path, not that one.  **Rust mirror:** (1) lowering
+descends `oo::class create` / `oo::define` bodies → populate
+`Module.methods`; (2) `CompilationUnit` gains a `methods` map of per-method
+`FunctionUnit`s; (3) `build_interprocedural_analysis` summarises method
+purity into `InterproceduralAnalysis.methods`; (4) `elimination::run`
+iterates method bodies with `enclosing_class` so O126 fires on a
+pure-method RHS; (5) the W307 per-SSA-version suppression fix in
+`analyser/diagnostics.rs`.  Classify in-scope, **structural** — a
+multi-strip port.
+
+### SYNC-JUN02-2 — Profile-guided branch reordering (PGO) (#515)
+
+A new, opt-in, **off-by-default** `compiler/pgo/` subsystem: an `occurrence`
+execution-occurrence model (unifies C Tcl `trace add execution` /
+`TCL_COMPILE_STATS` opcode counts with the F5 BIG-IP rule-profiler log), a
+`profile_data` rollup, two importers (`trace_parser` — F5 profiler log;
+`tclsh_capture` — per-line `enterstep` + `info frame` capture under a local
+tclsh), and a `reorder` analysis whose `find_pgo_suggestions` emits
+**hint-only P100** `Optimisation` suggestions (with a materialised
+replacement for opt-in `--apply`) reordering mutually-exclusive,
+side-effect-free equality if/elseif (and switch) dispatch chains so the
+hottest branch is tested first.
+
+**Rust mirror:** a new `tcl-compiler::pgo` (occurrence + profile_data +
+reorder) plus a `P100` emitter.  **Lower priority / largely deferred:** it
+is opt-in and hint-only (no behavioural change when off), and the importers
+lean on profile sources that are tooling-side (F5 profiler logs, a captured
+tclsh) rather than the analyser core — so the portable slice is the
+`reorder` equality-chain analysis + the occurrence / profile data model; the
+importers classify with `F*` / tooling.  Classify in-scope, structural,
+deferred.
+
+### SYNC-JUN02-3 — in-scope slivers of #516 (switch `patterns_braced` + Tcl 9 registry facts)
+
+The WASM / Zig bulk of #516 is out of scope (above), but two pieces are not:
+
+- **`IRSwitch.patterns_braced` (lowering / IR — correctness).**  `main` adds
+  a `patterns_braced` flag to `IRSwitch`: `True` when the arms came from a
+  single braced `{pat body …}` block (patterns are literal list elements —
+  no substitution), `False` when supplied as separate words
+  (`switch $s $pat {body}`), where each pattern undergoes normal `$var` /
+  `[cmd]` runtime substitution before matching.  **Rust gap:** the Rust
+  `Statement::Switch` (and `SwitchArm`) has **no** `patterns_braced` field —
+  the term appears nowhere in `rust/`.  Without it, the analyser cannot tell
+  a literal-pattern switch from one whose patterns substitute, which matters
+  for any pattern-as-variable read tracking and for matching the C-Tcl
+  substitution semantics.  Add the flag to `tcl-compiler::ir::Statement::Switch`,
+  set it in `lowering` (braced-body form → `true`; separate-words form →
+  `false`), and thread it where switch patterns are interpreted.  Classify
+  in-scope, low-touch, **correctness**.
+- **Tcl 9 command-spec facts (registry — low-touch).**  The new / extended
+  Tcl 9 surfaces (`lseq`, `scan` charset/float, `binary` unsigned formats,
+  `apply` defaults) want matching `tcl-registry` command-spec facts (arity /
+  arg-roles / dialect).  Fold into the `SYNC-MAY19-tcl9-commands` +
+  Command-spec tracking rows when those commands are next touched.
+
 ## Next-up priority queue
 
 When a contributor sits down to pick up the next chunk, work
@@ -2628,6 +2741,8 @@ to the chunk-log entry that has the full spec.
 | — | `SYNC-MAY19-foreachLine-lowering` | Landed 2026-05-19 — single-iterator `Statement::Foreach` lowering in `rust/tcl-compiler/src/lowering/structured.rs::lower_foreach_line`. |
 | — | `SYNC-MAY19-stub-overlay` | **Landed in full** via sub-strips (b) (2026-05-19), (c) (`c945baa`), and (a) (`6487a4f`).  (a) added `rust/tcl-registry/src/stub_overlay.rs` carrying `StubOverlay` + `StubSig` + `StubArg` + `StubSigFlags` (with `arg_indices_for_role` mirroring the registry's shape and a deterministic `fingerprint()` for cache-key plumbing); `StubCommandDef::to_stub_sig` and `build_stub_overlay` glue the analyser-side records to the registry-side overlay; `Analyser::stub_overlay` populates via `build_stub_overlay(&stub_cmds)` after the stub-pre-scan, and `infer_param_traits` / `infer_param_traits_deep` thread the overlay through their internal helpers so role-driven trait inference unions the registry's and the overlay's tables at every call site. |
 | — | `SYNC-MAY19-tail-call-dialect` | Landed 2026-05-19 — `TAILCALL_DIALECTS` / `LASSIGN_DIALECTS` constants in `rust/tcl-compiler/src/optimiser/tail_call.rs`. |
+| 5 | `SYNC-JUN02-1` (TclOO method FunctionUnits) | **New, actionable, self-contained compiler/optimiser work** (#506).  Lower `oo::class create` / `oo::define` method bodies to per-method `FunctionUnit`s so methods get the same dataflow as procs, then summarise method purity into the interproc table and fire O126 on `set unused [my <pure-method>]`.  The Rust `ir::Module.methods` + `MethodDef` + interproc `MethodSummary` types already exist but are **inert placeholders** (lowering never populates them, `CompilationUnit` has no `methods`, the optimiser has no `enclosing_class` iteration) — so the work is real wiring, not new types.  Also carries the W307 per-SSA-version VAR-as-command suppression fix.  Multi-strip; see the `SYNC-JUN02` family section. |
+| — | `SYNC-JUN02-2` (PGO branch reordering) | **Deferred** (#515).  Opt-in, off-by-default `compiler/pgo/` subsystem emitting hint-only P100 suggestions to reorder side-effect-free equality dispatch chains by profile frequency.  No behavioural change when off, and the profile importers (F5 profiler log / tclsh capture) are tooling-side; the portable slice is the `reorder` analysis + occurrence/profile model.  Listed for tracking. |
 | 6 | `SYNC-MAY19-dialect-contextvar` | LSP server (`S*`) plumbing: thread the per-folder dialect into `LexerConfig` at document-open / change time so multi-folder workspaces with mixed dialects parse correctly.  Pure server-side, no analyser-crate changes.  Closes with `S*`. |
 | — | `SYNC-MAY19-empty-name-proc` | Landed 2026-05-19 — trailing-`::` proc-name → `Statement::Barrier` short-circuit in `rust/tcl-compiler/src/lowering/mod.rs::lower_proc`. |
 | — | `SYNC-MAY19-proc-body-const-map` | Landed 2026-05-19 — Var-token const-map materialisation + `arg_single_token` multi-token-word check in `lower_proc`. |
@@ -2747,9 +2862,15 @@ priority queue:
   with `S*`).  **Landed (rust):** `SYNC-MAY31-7` (#473 `ExprRaw`
   var scan), `-8` (#494 backslash-continuation folding), `-10`
   (#510 inlay-hint optional positionals + `infer_function_return_type`),
-  `-2` (#474 glob/regexp `switch` keeps structured dispatch), and `-3`
+  `-2` (#474 glob/regexp `switch` keeps structured dispatch), `-3`
   (#502 `info exists` / `array exists` guard narrowing + W210
-  suppression + I230 fold) — see those family sections.  Of the remainder, none are
+  suppression + I230 fold), `-9` (#475 in-order builtin-arity
+  suppression refinement), `-4` (#501 iRules BODY-role + peer side
+  flip — the W127 emitter half is still pending, now unblocked by
+  `-1b`), and `-1b` (#498 Phase 8 place model — `place` /
+  `var_resolve` / `place_bridge` ported and the W220 / O109 consumers
+  rerouted through `overlap`; W211 / O126 already at parity) — see
+  those family sections.  Of the remainder, none are
   *correctness* blockers for the analyser flip.  **Correction to a
   stale note:** earlier rows said "the Rust analyser has no live
   caller post-#241" — that referred to the deleted differential
@@ -2759,6 +2880,18 @@ priority queue:
   `-1e` lattice-driven row and the `-5a` / `-5b` / `-5c` algorithmic
   items remain output-preserving and can land any time without
   coordination with the analyser-flip plan.
+* **`SYNC-JUN02` family** — opened 2026-06-02; advances the anchor from
+  `origin/main`@`59c770f6` to `origin/main`@`8aeaf1cd` (+5 commits).
+  Three in-scope rows: `SYNC-JUN02-1` (#506 — lower TclOO method bodies to
+  per-method `FunctionUnit`s + O126 method purity / SF-2 + the W307
+  per-SSA-version VAR-as-command fix; structural, the Rust `Module.methods`
+  / interproc `MethodSummary` scaffolding exists but is inert),
+  `SYNC-JUN02-2` (#515 — opt-in PGO branch-reordering subsystem emitting
+  hint-only P100; structural, deferred), and `SYNC-JUN02-3` (#516's
+  in-scope slivers — the switch `patterns_braced` IR flag, a correctness
+  gap since `rust/` lacks it, + Tcl 9 registry facts).  Out of scope:
+  #517 / #513 (explorer + optimiser-lens UI) and the WASM-emitter /
+  Zig-runtime bulk of #516.  See the `SYNC-JUN02` family section.
 
 After the queue drains, per-feature LSP server ports (`S*`) build
 on the `tcl-lsp-server` bootstrap.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1608,13 +1608,14 @@ Structural new surfaces (no Rust mirror today):
   variable-name comparison.  Classify in-scope, structural — fold
   into the C41 analyser-core port or land as its own follow-up.
 
-  **Landed (rust) — `SYNC-MAY31-1b`, in progress.**  Per the
+  **Landed (rust) — `SYNC-MAY31-1b`, complete.**  Per the
   `docs/design/compiler/phase8-place-migration.md` ledger, the headline
   ARRAY_ELEM precision win on `main` was achieved with the *suppress-only*
   `overlap` relation + the 8E refinement, **without** the full 8F versioned
   substrate — so the Rust port mirrors that: port `place` / `var_resolve`
-  / `place_bridge`, then reroute the W220 / W211 / O109 consumers through
-  `overlap`.  Staged, output-equivalent until the consumer reroute:
+  / `place_bridge`, then reroute the W220 / O109 consumers through
+  `overlap` (W211 / O126 turned out to already be at parity — see below).
+  Staged, output-equivalent until the consumer reroute:
   - **Stage 1 (done): `tcl-compiler::place`.**  Faithful port of
     `place.py` — `Place` / `Index` / `PlaceKind` / `IndexKind`,
     constructors, `base` / `is_global`, the over-approximating `overlap`
@@ -1846,8 +1847,15 @@ on the Python side.
   reads, dynamic_nonwild)` so element-overlap queries answer from the
   same-base bucket plus wildcard / dynamic checks (A4); share the
   predicate between dead-store (W220) and unused-variable (W211)
-  passes so the read_places walk runs once per function (A5).  N/A
-  until the Place model ports (`SYNC-MAY31-1b`).
+  passes so the read_places walk runs once per function (A5).
+  **Landed (rust) via `SYNC-MAY31-1b`:** the predicate is shared between
+  the analyser's W220 and the optimiser's O109 through
+  `place_bridge::element_writes_observed_by_reads` (one read_places walk
+  per function).  The Rust port uses a full-scan `overlap` rather than the
+  bucketed `by_base` index — semantically equivalent (UNKNOWN /
+  UPVAR_ALIAS reads overlap every element either way); the bucketing is a
+  deferred perf optimisation, not a correctness gate.  W211 needs no share
+  (already at parity — see the `SYNC-MAY31-1b` section).
 - **A6 — shimmer per-name indices computed once per function.**
   `_find_phi_shimmers` and `_find_thunking` previously called
   `_empty_literal_versions(ssa, name)` + `_loop_body_def_types(...)`
@@ -2213,10 +2221,11 @@ Two deltas:
    `analyser/diagnostics.rs::emit_w127_*` emitter, fed by the SCCP
    lattice + the existing `places_read_to_form` machinery (the latter
    landed only on `main` with SYNC-MAY31-1's place model, so this row
-   depends on `-1b`).
+   depended on `-1b` — **now landed**, so the emitter is unblocked).
 
 Classify: BODY-role piece is in-scope, low-touch (registry edit +
-tests).  W127 emitter is in-scope, depends on `-1b`.
+tests).  W127 emitter is in-scope; its `-1b` place-model dependency has
+landed (emitter itself still to do).
 
 **Landed (rust) — BODY-role piece only.**  The four registry specs now
 declare the nesting script:
@@ -2240,8 +2249,9 @@ fixed, `peer` flipped to the *opposite* of the current side — so a
 a `peer { TCP::collect }` in a client event satisfies `SERVER_DATA` (not
 `CLIENT_DATA`).  Six discriminating tests (registry roles/arity, two
 collect-flow behaviours, body recursion across all four), each verified
-to fail without the change.  **Still deferred:** the W127 emitter
-(depends on `-1b`'s place model, not yet landed).
+to fail without the change.  **Still deferred:** the W127 emitter — its
+`-1b` place-model dependency (`places_read_to_form`) has now **landed**,
+so it is unblocked (emitter itself still to do).
 
 ### SYNC-MAY31-5 — Dataflow fixpoint algorithmic improvements (#478)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2144,6 +2144,31 @@ Two deltas:
 Classify: BODY-role piece is in-scope, low-touch (registry edit +
 tests).  W127 emitter is in-scope, depends on `-1b`.
 
+**Landed (rust) — BODY-role piece only.**  The four registry specs now
+declare the nesting script:
+`clientside` / `serverside` set `arg_roles = &[(0, ArgRole::Body)]` with
+arity `Arity::new(0, 1)` (bare query form or one body, default
+`BodyKind::Plain`); `peer` gains `Traits::IS_SIDE_SWITCH`,
+`arg_roles = &[(0, ArgRole::Body)]`, the synopsis `peer NESTING_SCRIPT`,
+and the required-body arity `Arity::new(1, 1)`; `after` gains an
+`arg_role_resolver` (mirroring `_after_arg_roles` — the trailing timer
+script, never `-periodic`, never the `cancel`/`info` forms) plus
+`body_kind = BodyKind::Structural` (the timer body runs deferred in its
+own dispatch context).  A new `CommandRegistry::is_side_switch` mirrors
+Python's helper.  The analyser's generic `dispatch_body_arguments`
+recursion picks the role up automatically, so problems nested in these
+bodies are now flagged (verified: a nested zero-arg `set` trips E002
+inside each of the four bodies).  The collect/release/payload flow
+check (`irules_checks.rs::find_collect_flow_warnings`) now descends into
+side-switch bodies with the switched side — `clientside`/`serverside`
+fixed, `peer` flipped to the *opposite* of the current side — so a
+`clientside { TCP::collect }` satisfies a `CLIENT_DATA` requirement and
+a `peer { TCP::collect }` in a client event satisfies `SERVER_DATA` (not
+`CLIENT_DATA`).  Six discriminating tests (registry roles/arity, two
+collect-flow behaviours, body recursion across all four), each verified
+to fail without the change.  **Still deferred:** the W127 emitter
+(depends on `-1b`'s place model, not yet landed).
+
 ### SYNC-MAY31-5 — Dataflow fixpoint algorithmic improvements (#478)
 
 `main` consolidated three layers of algorithmic improvement into one

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2349,18 +2349,28 @@ suppress the check when the qualified call resolves to a user
 SYNC-MAY21-3 confirmed 0 E002/E003 false positives across tcllib 2.0
 + the Tcl 8.6 standard library with this shape.
 
-What's **not** yet ported: the second refinement — gating suppression
-on *reachable, in-order* proc definitions (so a top-level call before
-a `proc close` later in the file fires the arity check against the
-builtin).  Rust's post-walk flush in `flush_arity_diagnostics`
-intentionally drops shadowing-order constraints to handle the
-common "call before definition" case in well-formed code; matching
-Python's stricter check would need a per-call dominator/lexical-order
-test against the proc definition's IR location.
+Classify: in-scope, low-touch refinement.  Rust was ~90 % at parity
+already; the remaining in-order gate is described below.
 
-Classify: in-scope, low-touch refinement.  Rust is ~90 % at parity
-already; the in-order/reachability refinement is a follow-up to
-SYNC-MAY21-3 if the FP rate proves problematic in practice.
+**Landed (rust).**  The in-order half of the refinement now ports.
+`emit_arity_diagnostics` captures an `enforce_order` flag per candidate
+— `true` for top-level calls (module body, `namespace eval` bodies,
+conditionals), `false` for proc-body calls — derived from a new
+`scope_path_in_proc_body` helper (any `ScopeKind::Proc` on the
+call's scope path means the call resolves after load, so order is not
+enforced).  `flush_arity_diagnostics` now splits the suppression set:
+classes / aliases / ensembles / inline stubs always exist at run time
+and stay un-gated, while a shadowing **proc** silences a top-level call
+only when its definition (`ProcDef::name_span` start) lexically precedes
+the call.  So a top-level `close x y z` *before* a later `proc close`
+again fires E003 against the builtin, while the namespace-scoped guard
+(SYNC-MAY21-3) and proc-body forward-references stay suppressed.  Three
+discriminating analyser tests (call-before-def fires, call-after-def
+suppressed, proc-body call un-gated), each verified to fail without the
+gate.  Deferred (matches the old note): *excluding* conditionally
+defined procs from the shadow set needs the CFG dominator model, so a
+conditional `proc close` before the call still suppresses — no worse
+than the prior behaviour and no new false positives.
 
 ### SYNC-MAY31-10 — Inlay hints `is_optional` synopsis tagging + `infer_return_type` (#510)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1645,11 +1645,30 @@ Structural new surfaces (no Rust mirror today):
     the end-to-end check that `set a(k) 1; set a(j) 2; puts $a(k)`
     produces an `a(k)` def observed by a read while `a(j)` is observed by
     none.  No consumer wired yet → output-equivalent.
-  - Stage 4 (next, output-changing): reroute the W220 dead-store / W211 unused
-    / O109 DCE consumers through `overlap`; gated on the full suite +
-    the array-element FP regression test (`set a(k) 1; set a(j) 2; puts
-    $a(k)` no longer emits W220 on `a(k)`, while the scalar dead store
-    still does).
+  - **Stage 4 (done): reroute the W220 dead-store consumer through
+    `overlap`.**  `emit_dead_store_diagnostics` now consults a new
+    `place_suppressed_dead_stores` helper: for each function it builds the
+    `ResolveContext`, collects every read place (statements +
+    terminators), and suppresses a dead-store candidate whose
+    **array-element / dict-path** def place overlaps a read.  Scalars keep
+    their precise name-level verdict (the suppression is element-granular
+    only), and a cheap "has array-element assign" pre-check keeps non-array
+    functions cost-free.  So `set a(k) 1; set a(j) 2; puts $a(k)` no longer
+    false-fires W220 on `a(k)`, while `set x 1; set x 2; puts $x` still
+    does.  Two discriminating analyser tests (array suppressed, scalar
+    still fires), the array one verified to fail without the reroute.
+    Note: only the **analyser** W220 is rerouted — the Rust optimiser DCE
+    (O109) is a *separate* computation (unlike Python's shared
+    `analysis.dead_stores`), so there is no shared-list desync and no
+    VM-equivalence concern here.  The rare same-element reassignment dead
+    store is intentionally not recovered (needs the versioned 8F
+    substrate), matching `main`'s suppress-only stage.
+
+  Remaining follow-ups (optional, separate chunks): the **W211** unused
+  and **O109** optimiser-DCE consumers could likewise route through
+  `overlap` for full parity; both are lower-value than the W220 −88 win
+  (W211 array cases are mostly false *negatives* from name folding; O109
+  is an optimiser/VM-gated change).
 - **Phase 0 / 1 / 6 / 7 — shared infrastructure.**  Phase 0:
   registry-aware green-tree descent (`descend_command`) single-sources
   body role-resolution.  Phase 1: shared loop-nesting forest

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1623,10 +1623,15 @@ Structural new surfaces (no Rust mirror today):
     discriminating unit tests including the `a(k)` ≠ `a(j)` disjointness
     and the gregorian-style dynamic-alias precision case.  No consumer
     wired yet → corpus byte-identical.
-  - Stage 2 (next): `tcl-compiler::var_resolve` (`resolve_place` +
-    `ResolveContext`, needs a `split_array_name` port + the inner
-    var-read scanner).
-  - Stage 3: `tcl-compiler::place_bridge` (`def_places` / `read_places`
+  - **Stage 2 (done): `tcl-compiler::var_resolve`.**  Faithful port of
+    `var_resolve.py` — `ResolveContext`, `resolve_place` (scalar /
+    array-elem / whole-array / dynamic-name → UNKNOWN), and
+    `resolve_dict_path`, reusing a new `naming::split_array_name` and the
+    existing `VarReferenceScanner` for dynamic-index/name reads.  11 unit
+    tests (local/global/ns binding, literal vs dynamic element, upvar
+    alias owner, trace→observed, the `a(k)`≠`a(j)` resolve→overlap
+    integration).  No consumer wired yet → output-equivalent.
+  - Stage 3 (next): `tcl-compiler::place_bridge` (`def_places` / `read_places`
     / `terminator_read_places` + `build_resolve_context`).
   - Stage 4 (output-changing): reroute the W220 dead-store / W211 unused
     / O109 DCE consumers through `overlap`; gated on the full suite +

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -4390,6 +4390,33 @@ mod tests {
         );
     }
 
+    // -- SYNC-MAY31-4 (#501): BODY role on iRules nesting scripts ------
+
+    #[test]
+    fn analyser_recurses_into_irules_nesting_script_bodies() {
+        // clientside / serverside / peer / after now carry an
+        // `ArgRole::Body`, so the analyser descends into the nesting
+        // script and flags problems inside it.  A nested `set` with no
+        // arguments trips E002 only when the body is actually analysed —
+        // i.e. the generic body-walk picks the role up automatically.
+        for src in [
+            "when CLIENT_DATA { clientside { set } }",
+            "when CLIENT_ACCEPTED { serverside { set } }",
+            "when CLIENT_ACCEPTED { peer { set } }",
+            "when RULE_INIT { after 1000 { set } }",
+        ] {
+            let mut a = Analyser::new();
+            let r = a.analyse(src, "f5-irules");
+            assert!(
+                r.diagnostics
+                    .iter()
+                    .any(|d| d.code == "E002" && d.message.contains("'set'")),
+                "expected E002 from the nested `set` (body must be analysed) in {src:?}, got {:?}",
+                r.diagnostics
+            );
+        }
+    }
+
     #[test]
     fn w004_fires_on_lsearch_stride_in_tcl85() {
         // PR #441 review (Codex): the W004 coverage requires the

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -1027,16 +1027,26 @@ Consider capturing the result: catch {\u{2026}} result"
         // `namespace eval` nesting.
         let ns = self.command_resolution_namespace(scope_path);
 
+        // Top-level calls (module body, `namespace eval` bodies, and
+        // conditionals) execute in source order during load, so a
+        // shadowing proc only silences the builtin arity check when its
+        // definition lexically precedes the call.  Calls inside a proc
+        // body resolve after the whole script has loaded, so order is
+        // not enforced there.  Mirrors Python #475's `enforce_order`.
+        let enforce_order = !self.scope_path_in_proc_body(scope_path);
+
         // Collect as a *candidate*; the post-walk
         // [`Self::flush_arity_diagnostics`] drops it if the call
-        // resolves to a user proc / class / alias / ensemble / stub
-        // (resolved against the complete tables, so definition order
-        // doesn't matter).
+        // resolves to a user proc / class / alias / ensemble / stub.
+        // A class / alias / ensemble / stub match suppresses regardless
+        // of definition order; a *proc* match additionally honours
+        // `enforce_order` (in-order/reachability gate, #475).
         if !positional_any_expand && (args.len() - positional_start) < min {
             let got = args.len() - positional_start;
             self.pending_arity.push((
                 cmd_name.to_string(),
                 ns,
+                enforce_order,
                 super::types::Diagnostic {
                     code: "E002".to_string(),
                     span: full_span,
@@ -1051,6 +1061,7 @@ Consider capturing the result: catch {\u{2026}} result"
             self.pending_arity.push((
                 cmd_name.to_string(),
                 ns,
+                enforce_order,
                 super::types::Diagnostic {
                     code: "E003".to_string(),
                     span: full_span,
@@ -1081,20 +1092,47 @@ Consider capturing the result: catch {\u{2026}} result"
     /// `# tcl-lsp: stub`s — suppress by bare name regardless of
     /// namespace.
     ///
+    /// Suppression by a shadowing **proc** also honours definition
+    /// reachability (#475 / SYNC-MAY31-9): a top-level call (one whose
+    /// `enforce_order` flag is set — module body, `namespace eval`
+    /// body, or a conditional) is silenced only when the proc's
+    /// definition lexically precedes it, since top-level commands run
+    /// in source order during load (so a `close x y z` *before* a later
+    /// `proc close` still reaches the builtin).  Proc-body calls run
+    /// after load and are not order-gated.  Classes / aliases /
+    /// ensembles / stubs always exist at run time and are never
+    /// order-gated.  (Excluding *conditionally* defined procs would
+    /// need the CFG dominator model and is deferred.)
+    ///
     /// Idempotent: drains `pending_arity`, so a second call is a
     /// no-op.
     pub fn flush_arity_diagnostics(&mut self) {
         if self.pending_arity.is_empty() {
             return;
         }
-        // Fully-qualified user-command names the calls may resolve to
-        // (procs / classes / aliases are keyed by qualified name;
-        // ensemble namespaces *are* the command name).
-        let mut user_qnames: std::collections::HashSet<&str> = std::collections::HashSet::new();
-        user_qnames.extend(self.result.all_procs.keys().map(String::as_str));
-        user_qnames.extend(self.result.all_classes.keys().map(String::as_str));
-        user_qnames.extend(self.result.command_aliases.keys().map(String::as_str));
-        user_qnames.extend(self.ensemble_namespaces.iter().map(String::as_str));
+        // Fully-qualified non-proc user-command names the calls may
+        // resolve to (classes / aliases keyed by qualified name;
+        // ensemble namespaces *are* the command name).  These always
+        // exist by the time the script runs, so they suppress the
+        // builtin arity check regardless of definition order.
+        let mut non_proc_qnames: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        non_proc_qnames.extend(self.result.all_classes.keys().map(String::as_str));
+        non_proc_qnames.extend(self.result.command_aliases.keys().map(String::as_str));
+        non_proc_qnames.extend(self.ensemble_namespaces.iter().map(String::as_str));
+        // Qualified proc name → definition offset (the proc-name
+        // token start).  A shadowing proc only silences a *top-level*
+        // call (`enforce_order`) when its definition lexically
+        // precedes the call; proc-body calls are not order-gated.
+        // Conditional / nested definitions are still treated as
+        // shadowing here — distinguishing unconditionally-reachable
+        // definitions needs the CFG dominator model and is deferred
+        // per the SYNC-MAY31-9 doc note (#475).
+        let proc_offsets: std::collections::HashMap<&str, u32> = self
+            .result
+            .all_procs
+            .iter()
+            .map(|(qname, def)| (qname.as_str(), def.name_span.start()))
+            .collect();
         // Inline stubs are document-global and unqualified.
         let stub_names = super::utils::scan_stub_command_names(&self.source);
 
@@ -1109,7 +1147,7 @@ Consider capturing the result: catch {\u{2026}} result"
         };
 
         let pending = std::mem::take(&mut self.pending_arity);
-        for (cmd_name, ns, diag) in pending {
+        for (cmd_name, ns, enforce_order, diag) in pending {
             let bare = cmd_name.rsplit("::").next().unwrap_or(&cmd_name);
             // Candidate qualified names this call could resolve to.
             let candidates: Vec<String> = if cmd_name.contains("::") {
@@ -1125,8 +1163,18 @@ Consider capturing the result: catch {\u{2026}} result"
                 // Unqualified — current namespace, then global.
                 vec![join(&ns, &cmd_name), format!("::{cmd_name}")]
             };
-            let resolves_to_user = candidates.iter().any(|c| user_qnames.contains(c.as_str()))
-                || stub_names.contains(bare);
+            // A proc shadows only when reachable at the call: top-level
+            // calls require the definition to lexically precede them
+            // (`def_off < call_off`); proc-body calls accept any
+            // same-named definition.  Classes / aliases / ensembles /
+            // stubs are not order-gated.
+            let call_off = diag.span.start();
+            let resolves_to_user = candidates.iter().any(|c| {
+                non_proc_qnames.contains(c.as_str())
+                    || proc_offsets
+                        .get(c.as_str())
+                        .is_some_and(|&def_off| !enforce_order || def_off < call_off)
+            }) || stub_names.contains(bare);
             if resolves_to_user {
                 continue;
             }
@@ -4285,6 +4333,60 @@ mod tests {
             (span.start() as usize) < ns_eval_off,
             "flagged the namespaced call instead of the global one: {:?}",
             &src[span.start() as usize..span.end() as usize],
+        );
+    }
+
+    // -- SYNC-MAY31-9 (#475): reachable, in-order shadow gating -------
+
+    #[test]
+    fn e003_top_level_call_before_shadowing_proc_fires() {
+        // A top-level `close x y z` *before* `proc close` resolves to
+        // the builtin at load time (the proc does not exist yet), so the
+        // builtin arity check must fire even though a same-named proc is
+        // defined later in the file.  Regression target for #475's
+        // in-order gate (without it the post-walk flush silenced this).
+        let src = "close x y z\nproc close {a b c d} {}\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let e003: Vec<&Diagnostic> = r.diagnostics.iter().filter(|d| d.code == "E003").collect();
+        assert_eq!(
+            e003.len(),
+            1,
+            "expected E003 on the top-level close before its shadowing proc, got {:?}",
+            r.diagnostics
+        );
+        // The flagged call is the top-level one (offset 0), not the proc.
+        assert_eq!(e003[0].span.start(), 0, "wrong call flagged");
+    }
+
+    #[test]
+    fn e003_top_level_call_after_shadowing_proc_suppressed() {
+        // The mirror image: once `proc close` is defined, a later
+        // top-level `close x y z` resolves to the 4-param user proc, so
+        // the builtin arity check is suppressed.
+        let src = "proc close {a b c d} {}\nclose x y z\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "E003"),
+            "no E003 expected — the call follows its shadowing proc, got {:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
+    fn e003_proc_body_call_not_order_gated() {
+        // A call inside a proc body resolves when that proc is *invoked*
+        // — after the whole script has loaded — so a shadowing proc
+        // defined later in the file still suppresses the builtin check.
+        // Order is only enforced for top-level calls.
+        let src = "proc foo {} { close x y z }\nproc close {a b c d} {}\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "E003"),
+            "no E003 expected — proc-body calls are not order-gated, got {:?}",
+            r.diagnostics
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -1925,6 +1925,93 @@ before this value so it is treated as data, not an option."
         }
     }
 
+    /// Statements whose dead-store W220 should be **suppressed** because their
+    /// array-element / dict-path def place is observed by some read in the
+    /// function (Phase 8 place-model precision, SYNC-MAY31-1b stage 4).
+    ///
+    /// Name-level SSA folds `a(k)` / `a(j)` / `$a` to the base name `a`, so a
+    /// later `set a(j) 2` looks like it overwrites `set a(k) 1` before any read
+    /// — a false dead store when `a(k)` is in fact read.  Resolving each
+    /// element write to a [`Place`](crate::place::Place) and consulting the
+    /// over-approximating [`overlap`](crate::place::overlap) against the
+    /// function's read places suppresses exactly that case.  Scalars keep the
+    /// precise name-level verdict (they don't fold), so a genuine
+    /// `set x 1; set x 2; puts $x` dead store still fires.  Mirrors the
+    /// suppress-only `overlap` consumer on `main`
+    /// (`docs/design/compiler/phase8-place-migration.md`); the rare
+    /// same-element reassignment dead store is intentionally not recovered (it
+    /// needs the versioned 8F substrate).
+    ///
+    /// Returns `(block_name, statement_index)` keys.  Empty when the function
+    /// has no array-element assignment (the common case — no extra cost) or no
+    /// registry is bound.
+    fn place_suppressed_dead_stores(
+        &self,
+        fu: &crate::compilation_unit::FunctionUnit,
+    ) -> std::collections::HashSet<(String, i32)> {
+        use crate::ir::Statement;
+        use crate::place::{overlap, Place, PlaceKind};
+        use crate::place_bridge::{
+            build_resolve_context, def_places, read_places, terminator_read_places,
+        };
+
+        let mut out = std::collections::HashSet::new();
+        let Some(registry) = self.registry.as_ref() else {
+            return out;
+        };
+
+        let is_array_assign = |stmt: &Statement| -> bool {
+            matches!(
+                stmt,
+                Statement::AssignConst { name, .. }
+                    | Statement::AssignValue { name, .. }
+                    | Statement::AssignExpr { name, .. }
+                    if name.contains('(')
+            )
+        };
+
+        // Cheap pre-check: only array-element assignments can be mis-folded by
+        // the name-level SSA, so non-array functions cost nothing.
+        let has_array_assign = fu
+            .cfg
+            .blocks
+            .values()
+            .any(|b| b.statements.iter().any(&is_array_assign));
+        if !has_array_assign {
+            return out;
+        }
+
+        let ctx = build_resolve_context(&fu.cfg, &fu.name);
+        // All read places in the function, collected once.
+        let mut reads: Vec<Place> = Vec::new();
+        for block in fu.cfg.blocks.values() {
+            for stmt in &block.statements {
+                reads.extend(read_places(stmt, &ctx, registry));
+            }
+            if let Some(term) = &block.terminator {
+                reads.extend(terminator_read_places(term, &ctx, registry));
+            }
+        }
+
+        for (block_name, block) in &fu.cfg.blocks {
+            for (idx, stmt) in block.statements.iter().enumerate() {
+                if !is_array_assign(stmt) {
+                    continue;
+                }
+                let observed = def_places(stmt, &ctx, registry).iter().any(|d| {
+                    matches!(d.kind, PlaceKind::ArrayElem | PlaceKind::DictPath)
+                        && reads.iter().any(|r| overlap(d, r))
+                });
+                if observed {
+                    if let Ok(i) = i32::try_from(idx) {
+                        out.insert((block_name.clone(), i));
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// W220 — dead-store hint.
     ///
     /// Mirrors `_emit_dead_store_diagnostics` in
@@ -1974,6 +2061,9 @@ before this value so it is treated as data, not an option."
         use crate::ir::Statement;
         use crate::ir_helpers::expr_has_command;
         use std::fmt::Write as _;
+        // Phase 8 place-model precision: array-element / dict-path writes the
+        // name-level SSA mis-folds but that a read actually observes.
+        let place_suppressed = self.place_suppressed_dead_stores(fu);
         for chain in fu.def_use.chains.values() {
             if !chain.is_dead() || chain.definition.kind != DefKind::Statement {
                 continue;
@@ -2044,6 +2134,14 @@ before this value so it is treated as data, not an option."
                     }
                 }
                 _ => continue,
+            }
+            // Suppress when this element write is observed by a read the
+            // name-level SSA can't see (place-model overlap, stage 4).
+            if place_suppressed.contains(&(
+                chain.definition.block.clone(),
+                chain.definition.statement_index,
+            )) {
+                continue;
             }
             let span = stmt.span();
             if span.is_empty() {
@@ -4645,6 +4743,39 @@ mod tests {
         );
         assert!(w220s.iter().any(|d| d.message.contains("'x'")));
         assert_eq!(w220s[0].severity, Severity::Hint);
+    }
+
+    #[test]
+    fn w220_array_element_overwrite_not_dead() {
+        // SYNC-MAY31-1b (place model): `set a(k) 1` is NOT a dead store even
+        // though the later `set a(j) 2` bumps the name-level SSA version of the
+        // base `a`.  The place model sees `a(k)` is read by `puts $a(k)` and
+        // that `a(k)` ≠ `a(j)`, so the false W220 on the first write is
+        // suppressed.  Goes through `analyse` (the production path) so the
+        // registry — which the place bridge needs — is bound.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc f {} { set a(k) 1; set a(j) 2; puts $a(k) }", "tcl8.6");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W220"),
+            "no W220 expected — a(k) is read by `puts $a(k)`; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w220_scalar_overwrite_still_fires_via_analyse() {
+        // Regression guard for the element-granular scope of the suppression:
+        // a genuine *scalar* overwrite must still fire W220 with the place
+        // model active (scalars don't fold, so the name-level verdict stands).
+        let mut a = Analyser::new();
+        let r = a.analyse("proc f {} { set x 1; set x 2; puts $x }", "tcl8.6");
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == "W220" && d.message.contains("'x'")),
+            "scalar dead store must still fire; got {:?}",
+            r.diagnostics,
+        );
     }
 
     /// W220-IR-paths.  Variables prefixed with ``::`` are

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -1925,91 +1925,27 @@ before this value so it is treated as data, not an option."
         }
     }
 
-    /// Statements whose dead-store W220 should be **suppressed** because their
-    /// array-element / dict-path def place is observed by some read in the
-    /// function (Phase 8 place-model precision, SYNC-MAY31-1b stage 4).
+    /// Statements whose dead-store **W220** hint should be **suppressed**
+    /// because their array-element / dict-path def place is observed by some
+    /// read in the function (Phase 8 place-model precision, SYNC-MAY31-1b).
     ///
     /// Name-level SSA folds `a(k)` / `a(j)` / `$a` to the base name `a`, so a
     /// later `set a(j) 2` looks like it overwrites `set a(k) 1` before any read
-    /// — a false dead store when `a(k)` is in fact read.  Resolving each
-    /// element write to a [`Place`](crate::place::Place) and consulting the
-    /// over-approximating [`overlap`](crate::place::overlap) against the
-    /// function's read places suppresses exactly that case.  Scalars keep the
-    /// precise name-level verdict (they don't fold), so a genuine
-    /// `set x 1; set x 2; puts $x` dead store still fires.  Mirrors the
-    /// suppress-only `overlap` consumer on `main`
-    /// (`docs/design/compiler/phase8-place-migration.md`); the rare
-    /// same-element reassignment dead store is intentionally not recovered (it
-    /// needs the versioned 8F substrate).
-    ///
-    /// Returns `(block_name, statement_index)` keys.  Empty when the function
-    /// has no array-element assignment (the common case — no extra cost) or no
-    /// registry is bound.
+    /// — a false dead store when `a(k)` is in fact read.  Delegates to the
+    /// shared [`crate::place_bridge::element_writes_observed_by_reads`] (also
+    /// used by the optimiser's O109), which resolves each element write to a
+    /// [`Place`](crate::place::Place) and consults the over-approximating
+    /// [`overlap`](crate::place::overlap).  Scalars keep the precise name-level
+    /// verdict (they don't fold), so a genuine `set x 1; set x 2; puts $x` dead
+    /// store still fires.  Empty when no registry is bound (e.g. the bare
+    /// `emit_cfg_ssa_diagnostics` test path).
     fn place_suppressed_dead_stores(
         &self,
         fu: &crate::compilation_unit::FunctionUnit,
     ) -> std::collections::HashSet<(String, i32)> {
-        use crate::ir::Statement;
-        use crate::place::{overlap, Place, PlaceKind};
-        use crate::place_bridge::{
-            build_resolve_context, def_places, read_places, terminator_read_places,
-        };
-
-        let mut out = std::collections::HashSet::new();
-        let Some(registry) = self.registry.as_ref() else {
-            return out;
-        };
-
-        let is_array_assign = |stmt: &Statement| -> bool {
-            matches!(
-                stmt,
-                Statement::AssignConst { name, .. }
-                    | Statement::AssignValue { name, .. }
-                    | Statement::AssignExpr { name, .. }
-                    if name.contains('(')
-            )
-        };
-
-        // Cheap pre-check: only array-element assignments can be mis-folded by
-        // the name-level SSA, so non-array functions cost nothing.
-        let has_array_assign = fu
-            .cfg
-            .blocks
-            .values()
-            .any(|b| b.statements.iter().any(&is_array_assign));
-        if !has_array_assign {
-            return out;
-        }
-
-        let ctx = build_resolve_context(&fu.cfg, &fu.name);
-        // All read places in the function, collected once.
-        let mut reads: Vec<Place> = Vec::new();
-        for block in fu.cfg.blocks.values() {
-            for stmt in &block.statements {
-                reads.extend(read_places(stmt, &ctx, registry));
-            }
-            if let Some(term) = &block.terminator {
-                reads.extend(terminator_read_places(term, &ctx, registry));
-            }
-        }
-
-        for (block_name, block) in &fu.cfg.blocks {
-            for (idx, stmt) in block.statements.iter().enumerate() {
-                if !is_array_assign(stmt) {
-                    continue;
-                }
-                let observed = def_places(stmt, &ctx, registry).iter().any(|d| {
-                    matches!(d.kind, PlaceKind::ArrayElem | PlaceKind::DictPath)
-                        && reads.iter().any(|r| overlap(d, r))
-                });
-                if observed {
-                    if let Ok(i) = i32::try_from(idx) {
-                        out.insert((block_name.clone(), i));
-                    }
-                }
-            }
-        }
-        out
+        self.registry.as_ref().map_or_else(Default::default, |reg| {
+            crate::place_bridge::element_writes_observed_by_reads(&fu.cfg, &fu.name, reg)
+        })
     }
 
     /// W220 — dead-store hint.

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -4714,6 +4714,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn w220_braced_literal_arg_is_not_a_read() {
+        // A braced word performs no `$`-substitution, so `puts {$a(k)}` does
+        // NOT read `a(k)` — the place bridge must not treat the de-braced IR
+        // text as a read and wrongly suppress the genuine dead store on the
+        // first `set a(k)`.  (`puts $a(j)` keeps the base `a` live so `a(k)`
+        // is a W220 overwrite candidate rather than a W211.)
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc f {} { set a(k) 1; set a(j) 2; puts $a(j); puts {$a(k)} }",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics.iter().any(|d| d.code == "W220"),
+            "braced literal must not suppress the a(k) dead store; got {:?}",
+            r.diagnostics,
+        );
+    }
+
     /// W220-IR-paths.  Variables prefixed with ``::`` are
     /// externally consumed (other namespaces, the global frame
     /// outside this file) — Python's ``_dead_stores`` skips

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -375,6 +375,32 @@ impl Analyser {
         ns
     }
 
+    /// True when `scope_path` descends through a `proc` body scope.
+    ///
+    /// Gates the E002/E003 arity-shadow order check.  A call inside a
+    /// proc body resolves at *call* time — after the whole script has
+    /// loaded — so a shadowing proc defined later in the file still
+    /// silences the builtin arity check.  A top-level call (module
+    /// body, `namespace eval` body, or a conditional) executes in
+    /// source order during load, so only a definition that lexically
+    /// precedes it shadows.  Mirrors the `enforce_order` flag Python
+    /// derives from `ir_module.top_level` vs `proc.body` in
+    /// `compiler_checks._arity_checks` (#475).
+    #[must_use]
+    pub(super) fn scope_path_in_proc_body(&self, scope_path: &[usize]) -> bool {
+        let mut cursor = &self.result.global_scope;
+        for &idx in scope_path {
+            let Some(child) = cursor.children.get(idx) else {
+                break;
+            };
+            if child.kind == ScopeKind::Proc {
+                return true;
+            }
+            cursor = child;
+        }
+        false
+    }
+
     /// Record a variable read for go-to-definition / find-references.
     ///
     /// Mirrors `_record_var_read` in

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -75,7 +75,7 @@ pub struct AnalyserSnapshot {
     /// Pending E002 / E003 arity candidates (flushed post-walk).
     /// Snapshotted with `result` so a speculative rollback discards
     /// the candidates of any rolled-back commands.
-    pub pending_arity: Vec<(String, String, super::types::Diagnostic)>,
+    pub pending_arity: Vec<(String, String, bool, super::types::Diagnostic)>,
 }
 
 impl Analyser {

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -187,17 +187,22 @@ pub struct Analyser {
     pub line_offsets: Option<Vec<usize>>,
     /// Candidate E002 / E003 arity diagnostics collected during the
     /// command walk, as `(command name, call-site namespace,
-    /// diagnostic)`.  Emitted in a post-walk pass
+    /// enforce_order, diagnostic)`.  Emitted in a post-walk pass
     /// ([`Self::flush_arity_diagnostics`]) so a command that resolves
     /// to a user-defined proc / class / alias / ensemble / stub —
     /// which may be defined *after* its call site — suppresses the
-    /// builtin-arity check regardless of definition order.  The
-    /// namespace is captured so suppression is scoped to the command
-    /// the call actually resolves to (current namespace → global),
-    /// not to every same-tail-named definition anywhere in the file.
-    /// Mirrors Python running `_check_arity` over the fully-resolved
-    /// IR rather than inline during the walk.
-    pub pending_arity: Vec<(String, String, super::types::Diagnostic)>,
+    /// builtin-arity check.  The namespace is captured so suppression
+    /// is scoped to the command the call actually resolves to (current
+    /// namespace → global), not to every same-tail-named definition
+    /// anywhere in the file.  `enforce_order` is `true` for top-level
+    /// calls (module body, `namespace eval` bodies, conditionals) which
+    /// execute in source order during load: a shadowing proc only
+    /// silences such a call when its definition lexically precedes it.
+    /// Proc-body calls (`enforce_order == false`) resolve after load,
+    /// so any same-named definition shadows regardless of order.
+    /// Mirrors Python's `_arity_checks` over the fully-resolved IR
+    /// (#475) rather than checking inline during the walk.
+    pub pending_arity: Vec<(String, String, bool, super::types::Diagnostic)>,
 }
 
 impl Analyser {

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -285,7 +285,7 @@ pub fn run_all_checks(
     for w in find_unguarded_drop_warnings(cu, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
-    for w in find_collect_flow_warnings(cu, dialect) {
+    for w in find_collect_flow_warnings(cu, registry, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
     for w in find_http_flow_warnings(cu, dialect) {

--- a/rust/tcl-compiler/src/expr_ast.rs
+++ b/rust/tcl-compiler/src/expr_ast.rs
@@ -363,6 +363,48 @@ impl ExprNode {
         result
     }
 
+    /// Collect the raw text of every command substitution in this expr AST
+    /// (each an `[cmd …]` form, brackets included).  Used to recover the side
+    /// effects / reads of command substitutions evaluated inside an
+    /// expression — they run in the current scope.  Mirrors Python's
+    /// `command_texts_in_expr_node`.
+    #[must_use]
+    pub fn command_texts(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        self.collect_command_texts(&mut out);
+        out
+    }
+
+    fn collect_command_texts(&self, out: &mut Vec<String>) {
+        match self {
+            Self::Command { text, .. } => {
+                if !text.is_empty() {
+                    out.push(text.clone());
+                }
+            }
+            Self::Binary { left, right, .. } => {
+                left.collect_command_texts(out);
+                right.collect_command_texts(out);
+            }
+            Self::Unary { operand, .. } => operand.collect_command_texts(out),
+            Self::Ternary {
+                condition,
+                true_branch,
+                false_branch,
+            } => {
+                condition.collect_command_texts(out);
+                true_branch.collect_command_texts(out);
+                false_branch.collect_command_texts(out);
+            }
+            Self::Call { args, .. } => {
+                for arg in args {
+                    arg.collect_command_texts(out);
+                }
+            }
+            Self::Var { .. } | Self::Literal { .. } | Self::String { .. } | Self::Raw { .. } => {}
+        }
+    }
+
     /// Recursive variable collection helper.
     fn collect_vars(&self, out: &mut HashSet<String>) {
         match self {

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -404,18 +404,29 @@ fn classify_stmt_for_collect_flow(
     match stmt {
         Statement::Call {
             command,
+            canonical_command,
             span,
             args,
             ..
         }
         | Statement::Barrier {
             command,
+            canonical_command,
             span,
             args,
             ..
         } => {
-            if registry.is_side_switch(command) {
-                let inner_side = match command.as_str() {
+            // Normalise to the resolved/canonical head and strip a leading
+            // `::`: IR can legally carry `::clientside` or an alias, and the
+            // bare-name `is_side_switch` lookup + the side-flip `match` would
+            // otherwise miss it (and the `match`'s `_ => peer` arm would treat
+            // an unrecognised side-switch head as `peer`).
+            let head = canonical_command
+                .as_deref()
+                .unwrap_or(command)
+                .trim_start_matches(':');
+            if registry.is_side_switch(head) {
+                let inner_side = match head {
                     "clientside" => "client",
                     "serverside" => "server",
                     // peer — the opposite-side context.

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -21,8 +21,10 @@
 use tcl_lexer::Span;
 use tcl_registry::CommandRegistry;
 
+use crate::cfg_builder::build_cfg;
 use crate::compilation_unit::CompilationUnit;
 use crate::ir::Statement;
+use crate::lowering::lower_to_ir;
 use crate::sccp::cfg_order;
 use crate::taint::is_irules_dialect;
 use crate::value_shapes::parse_command_substitution;
@@ -368,6 +370,7 @@ fn scan_when_body_for_collect_flow(
     fu: &crate::compilation_unit::FunctionUnit,
     side: &str,
     state: &mut CollectFlowState,
+    registry: &CommandRegistry,
 ) {
     for bn in cfg_order(&fu.cfg) {
         if !fu.sccp.executable_blocks.contains(&bn) {
@@ -377,19 +380,82 @@ fn scan_when_body_for_collect_flow(
             continue;
         };
         for stmt in &block.statements {
-            match stmt {
-                Statement::Call { command, span, .. }
-                | Statement::Barrier { command, span, .. } => {
-                    classify_collect_command(command, side, *span, state);
+            classify_stmt_for_collect_flow(stmt, side, state, registry);
+        }
+    }
+}
+
+/// Classify one IR statement for collect/release/payload flow,
+/// descending into iRules side-switch bodies (`clientside` /
+/// `serverside` / `peer`) with the switched side.  `clientside` /
+/// `serverside` carry a fixed side; `peer` evaluates under the
+/// *opposite* of the current side (so `peer { TCP::collect }` in a
+/// client-side event issues a server-side collect, and vice-versa).
+/// These commands carry an `ArgRole::Body` arg so they lower to a
+/// `Statement::Barrier` (or a `Statement::Call` with the body in
+/// `args[0]`); both shapes keep the body text in `args[0]`.  Mirrors
+/// `_scan_ir_body_with_side` in `compiler/irules_flow.py` (#501).
+fn classify_stmt_for_collect_flow(
+    stmt: &Statement,
+    side: &str,
+    state: &mut CollectFlowState,
+    registry: &CommandRegistry,
+) {
+    match stmt {
+        Statement::Call {
+            command,
+            span,
+            args,
+            ..
+        }
+        | Statement::Barrier {
+            command,
+            span,
+            args,
+            ..
+        } => {
+            if registry.is_side_switch(command) {
+                let inner_side = match command.as_str() {
+                    "clientside" => "client",
+                    "serverside" => "server",
+                    // peer — the opposite-side context.
+                    _ if side == "client" => "server",
+                    _ => "client",
+                };
+                if let Some(body) = args.first() {
+                    scan_side_switch_body(body, inner_side, state, registry);
                 }
-                Statement::AssignValue { value, span, .. } => {
-                    let Some((cmd, _)) = parse_command_substitution(value.trim()) else {
-                        continue;
-                    };
-                    classify_collect_command(&cmd, side, *span, state);
-                }
-                _ => {}
+            } else {
+                classify_collect_command(command, side, *span, state);
             }
+        }
+        Statement::AssignValue { value, span, .. } => {
+            if let Some((cmd, _)) = parse_command_substitution(value.trim()) {
+                classify_collect_command(&cmd, side, *span, state);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Lower a side-switch body (the brace-script text in `args[0]`) and
+/// classify its commands under `side`, recursing through any nested
+/// side-switches.  The body is re-lowered to its own CFG so nested
+/// control flow is flattened the same way the enclosing `when` body is.
+fn scan_side_switch_body(
+    body_text: &str,
+    side: &str,
+    state: &mut CollectFlowState,
+    registry: &CommandRegistry,
+) {
+    let module = lower_to_ir(body_text, registry);
+    let cfg_module = build_cfg(&module, false);
+    for bn in cfg_order(&cfg_module.top_level) {
+        let Some(block) = cfg_module.top_level.blocks.get(&bn) else {
+            continue;
+        };
+        for stmt in &block.statements {
+            classify_stmt_for_collect_flow(stmt, side, state, registry);
         }
     }
 }
@@ -399,6 +465,7 @@ fn scan_when_body_for_collect_flow(
 #[must_use]
 pub fn find_collect_flow_warnings(
     cu: &CompilationUnit,
+    registry: &CommandRegistry,
     dialect: Option<&str>,
 ) -> Vec<IrulesCheckWarning> {
     let mut out = Vec::new();
@@ -413,7 +480,7 @@ pub fn find_collect_flow_warnings(
             let bare = event.split('#').next().unwrap_or(event).to_string();
             events_seen.push(bare.clone());
             let side = default_collect_side(event);
-            scan_when_body_for_collect_flow(fu, side, &mut state);
+            scan_when_body_for_collect_flow(fu, side, &mut state, registry);
         }
     }
 
@@ -892,8 +959,9 @@ mod tests {
     // -- IRULE1005 / 1006 / 1007 / 1008 -------------------------------
 
     fn flow_warnings(source: &str) -> Vec<IrulesCheckWarning> {
-        let cu = CompilationUnit::build_for(source, &registry(), false);
-        find_collect_flow_warnings(&cu, Some("f5-irules"))
+        let reg = registry();
+        let cu = CompilationUnit::build_for(source, &reg, false);
+        find_collect_flow_warnings(&cu, &reg, Some("f5-irules"))
     }
 
     #[test]
@@ -965,11 +1033,85 @@ mod tests {
         );
     }
 
+    // -- SYNC-MAY31-4 (#501): side-switch body descent + peer flip -----
+
+    #[test]
+    fn collect_inside_clientside_body_is_seen() {
+        // The collect lives inside a `clientside { ... }` nesting script.
+        // With the BODY role set, the flow check descends into the body
+        // and registers the (client-side) collect, so CLIENT_DATA's
+        // IRULE1005 requirement is satisfied.  Without the descent the
+        // collect was invisible and CLIENT_DATA wrongly fired IRULE1005.
+        let ws = flow_warnings(
+            "when CLIENT_ACCEPTED { clientside { TCP::collect } }
+             when CLIENT_DATA { log local0. \"data\" }",
+        );
+        assert!(
+            !ws.iter().any(|w| w.code == "IRULE1005"),
+            "no IRULE1005 expected — the clientside body supplies the collect, got {ws:?}",
+        );
+    }
+
+    #[test]
+    fn peer_flips_side_for_collect_flow() {
+        // `peer { TCP::collect }` evaluates under the *opposite* side of
+        // the surrounding event.  In the client-side CLIENT_ACCEPTED it
+        // issues a *server*-side collect, so it satisfies SERVER_DATA but
+        // NOT CLIENT_DATA — the inverse of a plain `clientside` collect.
+        let ws = flow_warnings(
+            "when CLIENT_ACCEPTED { peer { TCP::collect } }
+             when CLIENT_DATA { log local0. \"c\" }
+             when SERVER_DATA { log local0. \"s\" }",
+        );
+        let irule1005: Vec<&str> = ws
+            .iter()
+            .filter(|w| w.code == "IRULE1005")
+            .map(|w| w.message.as_str())
+            .collect();
+        assert_eq!(
+            irule1005.len(),
+            1,
+            "expected exactly one IRULE1005 (CLIENT_DATA only), got {ws:?}",
+        );
+        assert!(
+            irule1005[0].contains("CLIENT_DATA"),
+            "the surviving IRULE1005 must be CLIENT_DATA (peer flipped the collect to the server side), got {irule1005:?}",
+        );
+    }
+
+    #[test]
+    fn side_switch_specs_have_body_role_and_arity() {
+        // Registry-level guard for the #501 spec edits.
+        let r = registry();
+        for cmd in ["clientside", "serverside", "peer"] {
+            assert!(r.is_side_switch(cmd), "{cmd} must be a side-switch");
+            assert_eq!(
+                r.arg_indices_for_role(cmd, &["{ TCP::collect }"], tcl_registry::ArgRole::Body),
+                vec![0],
+                "{cmd} body script must be ArgRole::Body at index 0",
+            );
+        }
+        // clientside/serverside accept the bare query form or one body;
+        // peer requires its body; after's timer body is the trailing arg.
+        let cs = r.get("clientside").unwrap().arity;
+        assert_eq!((cs.min, cs.max), (0, 1), "clientside arity");
+        let ss = r.get("serverside").unwrap().arity;
+        assert_eq!((ss.min, ss.max), (0, 1), "serverside arity");
+        let pr = r.get("peer").unwrap().arity;
+        assert_eq!((pr.min, pr.max), (1, 1), "peer arity");
+        // `after`'s deferred timer body runs in its own dispatch context.
+        assert_eq!(
+            r.get("after").unwrap().body_kind,
+            tcl_registry::BodyKind::Structural,
+            "after timer body must be Structural",
+        );
+    }
+
     #[test]
     fn collect_flow_only_in_irules_dialect() {
-        let cu =
-            CompilationUnit::build_for("when CLIENT_ACCEPTED { TCP::collect }", &registry(), false);
-        let none = find_collect_flow_warnings(&cu, None);
+        let reg = registry();
+        let cu = CompilationUnit::build_for("when CLIENT_ACCEPTED { TCP::collect }", &reg, false);
+        let none = find_collect_flow_warnings(&cu, &reg, None);
         assert!(none.is_empty(), "got {none:?}");
     }
 

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -93,6 +93,7 @@ pub mod memory_ssa;
 pub mod naming;
 pub mod optimiser;
 pub mod path_concat;
+pub mod place;
 pub mod rendered_properties;
 pub mod sccp;
 pub mod segmenter;

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -113,6 +113,7 @@ pub mod uri_split;
 pub mod value_shapes;
 pub mod var_escape;
 pub mod var_refs;
+pub mod var_resolve;
 pub mod var_scoping;
 
 // Re-export key types for convenience.

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -94,6 +94,7 @@ pub mod naming;
 pub mod optimiser;
 pub mod path_concat;
 pub mod place;
+pub mod place_bridge;
 pub mod rendered_properties;
 pub mod sccp;
 pub mod segmenter;

--- a/rust/tcl-compiler/src/naming.rs
+++ b/rust/tcl-compiler/src/naming.rs
@@ -58,6 +58,49 @@ pub fn normalise_qualified_name(name: &str) -> String {
     format!("::{}", parts.join("::"))
 }
 
+/// Split a Tcl variable reference into `(base, element)`.
+///
+/// Strips `$` / `${…}` substitution sigils first, then separates the
+/// optional `(element)` array-index suffix from the base name.  Returns
+/// `(base, None)` for scalar references.  Mirrors Python's
+/// `shared/naming.py::split_array_name`, including the brace-form rule that
+/// `${arr}(foo)` is the scalar `arr` followed by literal `(foo)`, whereas
+/// `${arr(foo)}` *is* the array element `arr(foo)`.
+///
+/// ```
+/// use tcl_compiler::naming::split_array_name;
+/// assert_eq!(split_array_name("arr"), ("arr", None));
+/// assert_eq!(split_array_name("arr(foo)"), ("arr", Some("foo")));
+/// assert_eq!(split_array_name("$arr(foo)"), ("arr", Some("foo")));
+/// assert_eq!(split_array_name("${arr(foo)}"), ("arr", Some("foo")));
+/// assert_eq!(split_array_name("${arr}(foo)"), ("arr", None));
+/// assert_eq!(split_array_name("${arr}"), ("arr", None));
+/// ```
+#[must_use]
+pub fn split_array_name(name: &str) -> (&str, Option<&str>) {
+    // `${…}` brace form: only the chars inside the braces are the reference;
+    // an `(idx)` *inside* the braces is an element, one *after* `}` is not.
+    if let Some(after) = name.strip_prefix("${") {
+        if let Some(rel) = after.find('}') {
+            let inner = &after[..rel];
+            if inner.ends_with(')') {
+                if let Some(idx) = inner.find('(') {
+                    return (&inner[..idx], Some(&inner[idx + 1..inner.len() - 1]));
+                }
+            }
+            return (inner, None);
+        }
+        // No closing brace — fall through (Python gates on `"}" in base`).
+    }
+    let base = name.strip_prefix('$').unwrap_or(name);
+    if base.ends_with(')') {
+        if let Some(idx) = base.find('(') {
+            return (&base[..idx], Some(&base[idx + 1..base.len() - 1]));
+        }
+    }
+    (base, None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -65,6 +108,21 @@ mod tests {
     #[test]
     fn simple_dollar() {
         assert_eq!(normalise_var_name("$foo"), "foo");
+    }
+
+    #[test]
+    fn split_array_name_forms() {
+        assert_eq!(split_array_name("arr"), ("arr", None));
+        assert_eq!(split_array_name("arr(foo)"), ("arr", Some("foo")));
+        assert_eq!(split_array_name("$arr(foo)"), ("arr", Some("foo")));
+        assert_eq!(split_array_name("${arr(foo)}"), ("arr", Some("foo")));
+        // `${arr}(foo)` is scalar `arr` then literal `(foo)` — not an element.
+        assert_eq!(split_array_name("${arr}(foo)"), ("arr", None));
+        assert_eq!(split_array_name("${arr}"), ("arr", None));
+        // dynamic index text is preserved verbatim for later classification.
+        assert_eq!(split_array_name("a($i)"), ("a", Some("$i")));
+        // a `)` with no `(` is not an element.
+        assert_eq!(split_array_name("weird)"), ("weird)", None));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -111,6 +111,16 @@ fn emit_dead_stores_and_unused(
     // textually is kept live — conservative but correct.
     let textually_referenced = collect_textual_var_references(ctx.source, &fu.cfg);
 
+    // Phase 8 place model (SYNC-MAY31-1b): array-element writes the name-level
+    // SSA mis-folds (`set a(k) 1` "overwritten" by `set a(j) 2`) but that a read
+    // observes.  Shared with the analyser's W220.  Empty unless a registry is
+    // bound (set by the `optimise*` entry points) and the function writes array
+    // elements — so the bare test/`run_pass` path keeps its prior behaviour.
+    let place_suppressed = ctx
+        .registry
+        .map(|reg| crate::place_bridge::element_writes_observed_by_reads(&fu.cfg, &fu.name, reg))
+        .unwrap_or_default();
+
     // Collect one DseEntry per dead chain then sort + emit.
     let mut entries: Vec<DseEntry> = Vec::new();
 
@@ -131,6 +141,14 @@ fn emit_dead_stores_and_unused(
         let Some(stmt) = block.statements.get(idx) else {
             continue;
         };
+        // Suppress when this element write is observed by a read the name-level
+        // SSA can't see (place-model overlap — the O109 sibling of W220).
+        if place_suppressed.contains(&(
+            chain.definition.block.clone(),
+            chain.definition.statement_index,
+        )) {
+            continue;
+        }
         // Skip if the variable is a scope alias — writes through
         // global / upvar are visible in other scopes.
         let (var, _) = &chain.key;
@@ -655,6 +673,35 @@ mod tests {
         assert!(
             opts.iter().any(|o| o.code == "O109"),
             "expected O109 for overwritten store, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o109_array_element_overwrite_not_dead() {
+        // SYNC-MAY31-1b place model: `set a(k) 1` is NOT a dead store — the
+        // later `set a(j) 2` bumps the name-level SSA version of base `a`, but
+        // `puts $a(k)` reads a(k) and a(k) ≠ a(j).  Goes through `optimise`,
+        // which binds the registry the place bridge needs (`run_pass` leaves it
+        // unbound, so the bare-path scalar test above is unaffected).
+        let opts = crate::optimiser::optimise(
+            "proc f {} { set a(k) 1; set a(j) 2; puts $a(k) }",
+            &registry(),
+        );
+        assert!(
+            opts.iter().all(|o| o.code != "O109"),
+            "no O109 expected — a(k) is read by `puts $a(k)`; got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o109_array_element_genuinely_dead_still_fires() {
+        // Precision guard: here only a(j) is read, so a(k) IS overwritten
+        // before any read — O109 must still fire on it.  The place model
+        // suppresses only element writes that a read actually observes.
+        let opts = crate::optimiser::optimise("set a(k) 1\nset a(j) 2\nputs $a(j)", &registry());
+        assert!(
+            opts.iter().any(|o| o.code == "O109"),
+            "O109 expected — a(k) is overwritten and never read; got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -54,6 +54,7 @@ pub fn optimise_with_dialect(
     let _ = interproc;
     let ia = cu.interproc.clone().unwrap_or_default();
     let mut ctx = PassContext::with_dialect(&cu.source, ia, dialect);
+    ctx.registry = Some(registry);
     run_passes(&mut ctx, &cu, &PassId::all());
     select_non_overlapping(&ctx.optimisations)
 }
@@ -73,6 +74,7 @@ pub fn optimise_raw(
     let cu = CompilationUnit::build_for(source, registry, false);
     let ia = build_interprocedural_analysis(&cu.ir_module, registry, dialect);
     let mut ctx = PassContext::with_dialect(&cu.source, ia, dialect);
+    ctx.registry = Some(registry);
     run_passes(&mut ctx, &cu, &PassId::all());
     ctx.optimisations
 }

--- a/rust/tcl-compiler/src/optimiser/mod.rs
+++ b/rust/tcl-compiler/src/optimiser/mod.rs
@@ -54,6 +54,7 @@ use crate::compilation_unit::CompilationUnit;
 use crate::interprocedural::InterproceduralAnalysis;
 use crate::ir::Module as IrModule;
 use crate::ssa::ValueKey;
+use tcl_registry::CommandRegistry;
 
 // ---------------------------------------------------------------------------
 // Optimisation diagnostic
@@ -205,6 +206,11 @@ pub struct PassContext<'a> {
     /// Optional structured IR — some passes walk the pre-CFG
     /// tree to recover original source positions.
     pub ir_module: Option<&'a IrModule>,
+    /// Command registry — set by the `optimise*` entry points so the
+    /// elimination pass can resolve [`crate::place::Place`]s via the place
+    /// bridge (O109 array-element precision).  `None` in the bare
+    /// [`PassContext::new`] test path → place suppression is simply skipped.
+    pub registry: Option<&'a CommandRegistry>,
 }
 
 impl<'a> PassContext<'a> {

--- a/rust/tcl-compiler/src/place.rs
+++ b/rust/tcl-compiler/src/place.rs
@@ -1,0 +1,637 @@
+//! Unified variable **Place** model — the single identity for what a Tcl
+//! read/write touches (Phase 8 / SYNC-MAY31-1b).
+//!
+//! A *place* (an lvalue) is what a variable reference denotes: a scalar, a
+//! specific array element, a whole array, a dict path, an OO instance
+//! variable, an upvar alias edge, or — when it cannot be pinned down
+//! statically — the top value [`PlaceKind::Unknown`].  Today variable identity
+//! in the dataflow consumers is a bare `(name, version)` SSA string that folds
+//! `a(k)` / `a(j)` / `$a` together and makes dynamic names opaque; this module
+//! replaces that with a structured place plus two relations:
+//!
+//! * [`overlap`] — *does a read of `q` observe a write of `p`?*  The whole
+//!   point: `a(foo)` does not clobber `a(bar)`, but the whole array overlaps
+//!   every element, and [`PlaceKind::Unknown`] / dynamic indices overlap
+//!   everything.  The relation **over-approximates** real aliasing (any
+//!   uncertainty ⇒ `true`), so consumers built on it only ever *suppress* a
+//!   finding, never *falsely flag*.
+//! * [`places_read_to_form`] — the scalars read to *compute* a dynamic index,
+//!   dict key, or runtime variable name (`$i` in `a($i)`, `X` in `set $X`).
+//!
+//! Faithful port of `compiler/place.py` on `main` (Phase 8A + the 8E
+//! `overlap` refinement that separates a dynamic *index* on a known base from a
+//! dynamic *alias/name*).  The resolution layer ([`crate::var_resolve`]) maps a
+//! syntactic reference + scope context to a canonical place.
+
+/// Sentinel namespace marking a procedure-*local* scalar (frame-relative), as
+/// opposed to a global / namespace variable which carries its real `::`-FQ
+/// namespace.  Keeps the deliberate local-vs-global distinction the dataflow
+/// guards rely on (`name.starts_with("::")` → `place.ns != LOCAL_NS`).
+pub const LOCAL_NS: &str = "<local>";
+
+/// What kind of storage location a [`Place`] denotes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PlaceKind {
+    /// A scalar variable (`$x`); `ns` distinguishes local vs global/ns.
+    Scalar,
+    /// One element of an array (`a(k)`) — carries an [`Index`].
+    ArrayElem,
+    /// A whole array touched as a unit (`array set` / `array get` / `$a`).
+    ArrayWhole,
+    /// A dict accessed at a key path (`dict get $d a b`) — carries `keys`.
+    DictPath,
+    /// A `TclOO` instance variable (`owner` = class/object FQ name).
+    InstanceVar,
+    /// A local alias to a caller/namespace var (`upvar`); `owner` = target.
+    UpvarAlias,
+    /// Top — a place that cannot be pinned down (dynamic name, opaque).
+    Unknown,
+}
+
+/// How an array index / dict key in the place sub-lattice is known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IndexKind {
+    /// A statically-known index/key text.
+    Literal,
+    /// A computed index/key (`a($i)`) — its `read_places` are read.
+    Dynamic,
+    /// An unconstrained index — whole-collection or unresolvable.
+    Any,
+}
+
+/// An array index or dict key in the place sub-lattice.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Index {
+    /// How the index/key is known (literal text, computed, or unconstrained).
+    pub kind: IndexKind,
+    /// The literal text when [`IndexKind::Literal`]; empty otherwise.
+    pub value: String,
+    /// Vars read to form a [`IndexKind::Dynamic`] index/key.
+    pub read_places: Vec<Place>,
+}
+
+impl Index {
+    /// A statically-known index/key.
+    #[must_use]
+    pub fn literal(value: impl Into<String>) -> Self {
+        Self {
+            kind: IndexKind::Literal,
+            value: value.into(),
+            read_places: Vec::new(),
+        }
+    }
+
+    /// A computed index/key carrying the scalars read to form it.
+    #[must_use]
+    pub fn dynamic(read_places: Vec<Place>) -> Self {
+        Self {
+            kind: IndexKind::Dynamic,
+            value: String::new(),
+            read_places,
+        }
+    }
+
+    /// An unconstrained index (`ANY_INDEX`).
+    #[must_use]
+    pub fn any() -> Self {
+        Self {
+            kind: IndexKind::Any,
+            value: String::new(),
+            read_places: Vec::new(),
+        }
+    }
+}
+
+/// A storage location a read/write touches.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Place {
+    /// Which kind of storage location this place denotes.
+    pub kind: PlaceKind,
+    /// FQ namespace; [`LOCAL_NS`] for proc-local scalars.
+    pub ns: String,
+    /// Base variable name (bare local or ns-tail).
+    pub name: String,
+    /// `ARRAY_ELEM` index.
+    pub index: Option<Index>,
+    /// `DICT_PATH` key path.
+    pub keys: Vec<Index>,
+    /// `INSTANCE_VAR` class/obj FQ; `UPVAR_ALIAS` caller target.
+    pub owner: String,
+    /// Under a `trace` — externally observable.
+    pub observed: bool,
+    /// Alias/level/name could not be resolved precisely.
+    pub dynamic: bool,
+    /// Vars read to form a dynamic name (`X` in `set $X`).
+    pub name_reads: Vec<Place>,
+}
+
+impl Place {
+    fn bare(kind: PlaceKind) -> Self {
+        Self {
+            kind,
+            ns: LOCAL_NS.to_owned(),
+            name: String::new(),
+            index: None,
+            keys: Vec::new(),
+            owner: String::new(),
+            observed: false,
+            dynamic: false,
+            name_reads: Vec::new(),
+        }
+    }
+
+    /// True for a global / namespace variable (not a frame-local).
+    #[must_use]
+    pub fn is_global(&self) -> bool {
+        matches!(
+            self.kind,
+            PlaceKind::Scalar | PlaceKind::ArrayElem | PlaceKind::ArrayWhole
+        ) && self.ns != LOCAL_NS
+    }
+
+    /// The whole-variable identity, dropping element index / dict keys.
+    ///
+    /// `a(k)` → `ARRAY_WHOLE a`; `dict d a b` → `ARRAY_WHOLE`-style root; a
+    /// scalar is its own base.  This is the join point of [`overlap`].
+    #[must_use]
+    pub fn base(&self) -> Self {
+        match self.kind {
+            PlaceKind::ArrayElem | PlaceKind::DictPath => {
+                array_whole(&self.name, &self.ns, self.observed)
+            }
+            _ => self.clone(),
+        }
+    }
+}
+
+// Constructors -------------------------------------------------------------
+
+/// A scalar place.
+#[must_use]
+pub fn scalar(name: impl Into<String>, ns: impl Into<String>, observed: bool) -> Place {
+    Place {
+        name: name.into(),
+        ns: ns.into(),
+        observed,
+        ..Place::bare(PlaceKind::Scalar)
+    }
+}
+
+/// An array-element place.
+#[must_use]
+pub fn array_elem(
+    name: impl Into<String>,
+    index: Index,
+    ns: impl Into<String>,
+    observed: bool,
+) -> Place {
+    Place {
+        name: name.into(),
+        ns: ns.into(),
+        index: Some(index),
+        observed,
+        ..Place::bare(PlaceKind::ArrayElem)
+    }
+}
+
+/// A whole-array place.
+#[must_use]
+pub fn array_whole(name: impl Into<String>, ns: impl Into<String>, observed: bool) -> Place {
+    Place {
+        name: name.into(),
+        ns: ns.into(),
+        observed,
+        ..Place::bare(PlaceKind::ArrayWhole)
+    }
+}
+
+/// A dict-path place.
+#[must_use]
+pub fn dict_path(name: impl Into<String>, keys: Vec<Index>, ns: impl Into<String>) -> Place {
+    Place {
+        name: name.into(),
+        ns: ns.into(),
+        keys,
+        ..Place::bare(PlaceKind::DictPath)
+    }
+}
+
+/// A `TclOO` instance-variable place.
+#[must_use]
+pub fn instance_var(name: impl Into<String>, owner: impl Into<String>, observed: bool) -> Place {
+    Place {
+        name: name.into(),
+        owner: owner.into(),
+        observed,
+        ..Place::bare(PlaceKind::InstanceVar)
+    }
+}
+
+/// An `upvar` alias place.  `dynamic` is forced on when `owner` is empty
+/// (the caller target could not be resolved).
+#[must_use]
+pub fn upvar_alias(name: impl Into<String>, owner: impl Into<String>, dynamic: bool) -> Place {
+    let owner = owner.into();
+    let dynamic = dynamic || owner.is_empty();
+    Place {
+        name: name.into(),
+        owner,
+        dynamic,
+        ..Place::bare(PlaceKind::UpvarAlias)
+    }
+}
+
+/// The top place, carrying the scalars read to form its (dynamic) name.
+#[must_use]
+pub fn unknown(name_reads: Vec<Place>) -> Place {
+    Place {
+        dynamic: true,
+        name_reads,
+        ..Place::bare(PlaceKind::Unknown)
+    }
+}
+
+/// The canonical top place with no name reads.
+#[must_use]
+pub fn unknown_top() -> Place {
+    Place {
+        dynamic: true,
+        ..Place::bare(PlaceKind::Unknown)
+    }
+}
+
+// Relations ----------------------------------------------------------------
+
+/// Could indices/keys *a* and *b* denote the same slot?  Over-approximates:
+/// `ANY` or `DYNAMIC` overlaps anything; two literals overlap iff equal text.
+fn index_overlap(a: &Index, b: &Index) -> bool {
+    if a.kind == IndexKind::Any || b.kind == IndexKind::Any {
+        return true;
+    }
+    if a.kind == IndexKind::Dynamic || b.kind == IndexKind::Dynamic {
+        return true;
+    }
+    a.value == b.value
+}
+
+/// Dict key paths overlap iff one is a prefix of the other under
+/// [`index_overlap`] (a write to `d a b` is observed by a read of `d a`;
+/// `d x` is not).
+fn keys_overlap(a: &[Index], b: &[Index]) -> bool {
+    // zip stops at the shorter path → the shorter is a prefix of the longer.
+    a.iter().zip(b.iter()).all(|(ia, ib)| index_overlap(ia, ib))
+}
+
+/// Does a read of *q* observe a write of *p* (and vice-versa)?
+///
+/// Over-approximating and symmetric: [`PlaceKind::Unknown`],
+/// [`PlaceKind::UpvarAlias`], dynamic aliases, and `DYNAMIC`/`ANY` indices all
+/// return `true` — so a consumer can only ever decide "these may be the same"
+/// conservatively.
+#[must_use]
+pub fn overlap(p: &Place, q: &Place) -> bool {
+    // Top / unresolved alias edges may touch anything observable.
+    if p.kind == PlaceKind::Unknown || q.kind == PlaceKind::Unknown {
+        return true;
+    }
+    if p.kind == PlaceKind::UpvarAlias || q.kind == PlaceKind::UpvarAlias {
+        // Two non-dynamic upvar aliases name a *resolved* caller var via their
+        // `owner`; they are the same storage iff the owners match — regardless
+        // of the local alias name.  Otherwise conservatively yes.
+        if p.kind == q.kind && !p.dynamic && !q.dynamic {
+            return p.owner == q.owner;
+        }
+        return true;
+    }
+    if p.dynamic || q.dynamic {
+        // A `dynamic` place is one whose alias target / frame could not be
+        // resolved, but whose *local base name* is still known (so it is NOT a
+        // wildcard over all names — that is `Unknown`, handled above).
+        //
+        //  * two dynamic places of *different* names may still alias (two
+        //    upvar aliases can point at the same caller storage) ⇒ conservative;
+        //  * a dynamic place vs a *concrete* place of a *different* base name
+        //    cannot alias (the dead-store precision win);
+        //  * the *same* base name falls through to the structural comparison.
+        if p.ns != q.ns || p.name != q.name {
+            return p.dynamic && q.dynamic;
+        }
+        // same (ns, name): fall through to the structural element/kind logic.
+    }
+
+    if p.kind == PlaceKind::InstanceVar || q.kind == PlaceKind::InstanceVar {
+        return p.kind == q.kind && p.owner == q.owner && p.name == q.name;
+    }
+
+    if p.kind == PlaceKind::DictPath || q.kind == PlaceKind::DictPath {
+        if p.kind == q.kind {
+            return p.ns == q.ns && p.name == q.name && keys_overlap(&p.keys, &q.keys);
+        }
+        // A dict and its whole-array base overlap; a dict and a scalar/elem of
+        // a different name do not.
+        let (dpath, other) = if p.kind == PlaceKind::DictPath {
+            (p, q)
+        } else {
+            (q, p)
+        };
+        if other.kind == PlaceKind::ArrayWhole {
+            return other.ns == dpath.ns && other.name == dpath.name;
+        }
+        return false;
+    }
+
+    // Scalar / array family — same namespace + base name required.
+    if p.ns != q.ns || p.name != q.name {
+        return false;
+    }
+    if p.kind == PlaceKind::Scalar && q.kind == PlaceKind::Scalar {
+        return true;
+    }
+    if p.kind == PlaceKind::ArrayWhole || q.kind == PlaceKind::ArrayWhole {
+        // whole overlaps whole and any element of the same array.
+        return true;
+    }
+    if p.kind == PlaceKind::ArrayElem && q.kind == PlaceKind::ArrayElem {
+        // Both are ARRAY_ELEM here, so both carry an index.
+        return match (&p.index, &q.index) {
+            (Some(pi), Some(qi)) => index_overlap(pi, qi),
+            // Defensive: a malformed element with no index over-approximates.
+            _ => true,
+        };
+    }
+    // SCALAR vs ARRAY_ELEM of the same name: distinct kinds, disjoint (a scalar
+    // and an array are different variables in Tcl).
+    false
+}
+
+/// Scalars read to *compute* this place's identity — dynamic array/dict
+/// indices and runtime variable names.  These are genuine reads at the access
+/// site (`$i` in `a($i)`, `X` in `set $X v`).  Mirrors Python's
+/// `places_read_to_form` (a `frozenset`); returned de-duplicated, first-seen
+/// order.
+#[must_use]
+pub fn places_read_to_form(p: &Place) -> Vec<Place> {
+    let mut out: Vec<Place> = Vec::new();
+    let push = |pl: &Place, out: &mut Vec<Place>| {
+        if !out.contains(pl) {
+            out.push(pl.clone());
+        }
+    };
+    for pl in &p.name_reads {
+        push(pl, &mut out);
+    }
+    if let Some(idx) = &p.index {
+        for pl in &idx.read_places {
+            push(pl, &mut out);
+        }
+    }
+    for k in &p.keys {
+        for pl in &k.read_places {
+            push(pl, &mut out);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local_scalar(name: &str) -> Place {
+        scalar(name, LOCAL_NS, false)
+    }
+
+    // -- core scalar / array overlap ----------------------------------
+
+    #[test]
+    fn scalar_overlap_basics() {
+        assert!(overlap(&local_scalar("x"), &local_scalar("x")));
+        // different name → disjoint
+        assert!(!overlap(&local_scalar("x"), &local_scalar("y")));
+        // local vs global of the same name → different ns → disjoint
+        assert!(!overlap(&local_scalar("x"), &scalar("x", "::", false)));
+    }
+
+    #[test]
+    fn array_elements_are_disjoint_by_literal_index() {
+        // The headline precision: a(k) and a(j) do NOT overlap, so a write to
+        // one is not observed by a read of the other (suppresses the W220 FP).
+        let ak = array_elem("a", Index::literal("k"), LOCAL_NS, false);
+        let aj = array_elem("a", Index::literal("j"), LOCAL_NS, false);
+        assert!(overlap(&ak, &ak));
+        assert!(!overlap(&ak, &aj));
+        // but a different array entirely is also disjoint
+        let bk = array_elem("b", Index::literal("k"), LOCAL_NS, false);
+        assert!(!overlap(&ak, &bk));
+    }
+
+    #[test]
+    fn whole_array_overlaps_every_element() {
+        let whole = array_whole("a", LOCAL_NS, false);
+        let ak = array_elem("a", Index::literal("k"), LOCAL_NS, false);
+        assert!(overlap(&whole, &ak));
+        assert!(overlap(&ak, &whole));
+        // whole arrays of different names stay disjoint
+        assert!(!overlap(&whole, &array_whole("b", LOCAL_NS, false)));
+    }
+
+    #[test]
+    fn dynamic_index_overlaps_any_sibling_element() {
+        // a($i) may touch any element of `a` …
+        let dyn_elem = array_elem(
+            "a",
+            Index::dynamic(vec![local_scalar("i")]),
+            LOCAL_NS,
+            false,
+        );
+        let ak = array_elem("a", Index::literal("k"), LOCAL_NS, false);
+        assert!(overlap(&dyn_elem, &ak));
+        // … but not an element of a *different* array.
+        let bk = array_elem("b", Index::literal("k"), LOCAL_NS, false);
+        assert!(!overlap(&dyn_elem, &bk));
+    }
+
+    #[test]
+    fn scalar_and_array_element_of_same_name_are_disjoint() {
+        let s = local_scalar("a");
+        let ak = array_elem("a", Index::literal("k"), LOCAL_NS, false);
+        assert!(!overlap(&s, &ak));
+    }
+
+    // -- 8E refinement: dynamic *index* ≠ dynamic *alias* -------------
+
+    #[test]
+    fn dynamic_alias_does_not_observe_differently_named_local() {
+        // `upvar 1 $x date` makes `date` a dynamic-aliased array; a write to a
+        // differently-named local `date2(ERA)` is NOT observed by reads of
+        // `date(...)`.  This is the gregorian.tcl precision case from the
+        // phase8 design doc.
+        let mut date2 = array_elem("date2", Index::literal("ERA"), LOCAL_NS, false);
+        let mut date_dyn = array_elem(
+            "date",
+            Index::dynamic(vec![local_scalar("i")]),
+            LOCAL_NS,
+            false,
+        );
+        date_dyn.dynamic = true; // aliases an unknown caller var
+                                 // date2 is a concrete local; only the alias side is dynamic.
+        assert!(!overlap(&date2, &date_dyn));
+        // Two dynamic aliases of different names stay conservative (True):
+        // they could point at the same caller storage.
+        date2.dynamic = true;
+        assert!(overlap(&date2, &date_dyn));
+    }
+
+    #[test]
+    fn unknown_name_observes_everything() {
+        // `set $X v` → UNKNOWN: could be any variable, so it overlaps a
+        // concrete dynamic-aliased place of any name.
+        let mut date_dyn = array_elem("date", Index::literal("k"), LOCAL_NS, false);
+        date_dyn.dynamic = true;
+        assert!(overlap(&unknown(vec![local_scalar("X")]), &date_dyn));
+        assert!(overlap(&date_dyn, &unknown_top()));
+    }
+
+    // -- upvar aliases -------------------------------------------------
+
+    #[test]
+    fn upvar_aliases_compare_by_owner() {
+        // Same caller target ⇒ must-alias even with different local names.
+        let a = upvar_alias("a", "::caller::x", false);
+        let b = upvar_alias("b", "::caller::x", false);
+        let c = upvar_alias("c", "::caller::y", false);
+        assert!(overlap(&a, &b));
+        assert!(!overlap(&a, &c));
+        // A dynamic (unresolved) upvar alias is conservative against anything.
+        let dyn_alias = upvar_alias("d", "", false); // empty owner ⇒ dynamic
+        assert!(dyn_alias.dynamic);
+        assert!(overlap(&dyn_alias, &c));
+        assert!(overlap(&dyn_alias, &local_scalar("z")));
+    }
+
+    // -- instance vars + dict paths -----------------------------------
+
+    #[test]
+    fn instance_vars_compare_by_owner_and_name() {
+        let a1 = instance_var("v", "::C", false);
+        let a2 = instance_var("v", "::C", false);
+        let b = instance_var("v", "::D", false);
+        let c = instance_var("w", "::C", false);
+        assert!(overlap(&a1, &a2));
+        assert!(!overlap(&a1, &b));
+        assert!(!overlap(&a1, &c));
+    }
+
+    #[test]
+    fn dict_paths_overlap_on_prefix() {
+        let d_ab = dict_path(
+            "d",
+            vec![Index::literal("a"), Index::literal("b")],
+            LOCAL_NS,
+        );
+        let d_a = dict_path("d", vec![Index::literal("a")], LOCAL_NS);
+        let d_x = dict_path("d", vec![Index::literal("x")], LOCAL_NS);
+        // a read of `d a` observes a write of `d a b` (prefix) …
+        assert!(overlap(&d_ab, &d_a));
+        // … but `d x` is a different path.
+        assert!(!overlap(&d_ab, &d_x));
+        // A dict and its whole-array base overlap; a differently-named one not.
+        assert!(overlap(&d_a, &array_whole("d", LOCAL_NS, false)));
+        assert!(!overlap(&d_a, &array_whole("e", LOCAL_NS, false)));
+        // dict vs scalar of a different name → disjoint.
+        assert!(!overlap(&d_a, &local_scalar("e")));
+    }
+
+    #[test]
+    fn unknown_overlaps_anything() {
+        assert!(overlap(&unknown_top(), &local_scalar("x")));
+        assert!(overlap(&local_scalar("x"), &unknown_top()));
+        assert!(overlap(&unknown_top(), &unknown_top()));
+    }
+
+    #[test]
+    fn overlap_is_symmetric_on_a_sample_matrix() {
+        let samples = vec![
+            local_scalar("x"),
+            scalar("x", "::", false),
+            array_elem("a", Index::literal("k"), LOCAL_NS, false),
+            array_elem("a", Index::literal("j"), LOCAL_NS, false),
+            array_elem(
+                "a",
+                Index::dynamic(vec![local_scalar("i")]),
+                LOCAL_NS,
+                false,
+            ),
+            array_whole("a", LOCAL_NS, false),
+            dict_path("d", vec![Index::literal("a")], LOCAL_NS),
+            instance_var("v", "::C", false),
+            upvar_alias("u", "::caller::x", false),
+            unknown_top(),
+        ];
+        for p in &samples {
+            for q in &samples {
+                assert_eq!(
+                    overlap(p, q),
+                    overlap(q, p),
+                    "overlap must be symmetric for {p:?} / {q:?}",
+                );
+            }
+        }
+    }
+
+    // -- helpers -------------------------------------------------------
+
+    #[test]
+    fn base_drops_index_and_keys() {
+        let ak = array_elem("a", Index::literal("k"), "::ns", true);
+        let base = ak.base();
+        assert_eq!(base.kind, PlaceKind::ArrayWhole);
+        assert_eq!(base.name, "a");
+        assert_eq!(base.ns, "::ns");
+        assert!(base.observed);
+        assert!(base.index.is_none());
+        // a scalar is its own base
+        let s = local_scalar("x");
+        assert_eq!(s.base(), s);
+    }
+
+    #[test]
+    fn is_global_distinguishes_local_from_namespaced() {
+        assert!(!local_scalar("x").is_global());
+        assert!(scalar("g", "::", false).is_global());
+        assert!(scalar("v", "::ns", false).is_global());
+        // upvar alias / instance var / unknown are not "global" scalars
+        assert!(!upvar_alias("u", "::x", false).is_global());
+        assert!(!unknown_top().is_global());
+    }
+
+    #[test]
+    fn places_read_to_form_collects_index_and_name_reads() {
+        // a($i) reads `i`.
+        let elem = array_elem(
+            "a",
+            Index::dynamic(vec![local_scalar("i")]),
+            LOCAL_NS,
+            false,
+        );
+        assert_eq!(places_read_to_form(&elem), vec![local_scalar("i")]);
+        // set $X → unknown reading `X`.
+        assert_eq!(
+            places_read_to_form(&unknown(vec![local_scalar("X")])),
+            vec![local_scalar("X")]
+        );
+        // dedup: a($i)($i) style dict path reading `i` twice → one entry.
+        let dp = dict_path(
+            "d",
+            vec![
+                Index::dynamic(vec![local_scalar("i")]),
+                Index::dynamic(vec![local_scalar("i")]),
+            ],
+            LOCAL_NS,
+        );
+        assert_eq!(places_read_to_form(&dp), vec![local_scalar("i")]);
+        // a literal-index element reads nothing.
+        let lit = array_elem("a", Index::literal("k"), LOCAL_NS, false);
+        assert!(places_read_to_form(&lit).is_empty());
+    }
+}

--- a/rust/tcl-compiler/src/place_bridge.rs
+++ b/rust/tcl-compiler/src/place_bridge.rs
@@ -1,0 +1,514 @@
+//! Bridge from the IR/CFG to the unified [`Place`] model (Phase 8 /
+//! SYNC-MAY31-1b, stage 3).
+//!
+//! Resolves each IR statement's *def* and *read* targets to canonical
+//! [`Place`]s on demand, so the dataflow consumers (dead-store / unused /
+//! read-before-set) can switch from name-string equality to the sound
+//! [`overlap`](crate::place::overlap) relation — without re-stamping every
+//! construction site in lowering.  The per-function [`ResolveContext`] is built
+//! once by scanning the CFG for `global` / `variable` / `upvar` / `trace`
+//! declarations (reusing the [`crate::var_scoping`] grammar).
+//!
+//! Faithful port of `compiler/place_bridge.py` on `main`.  No consumer is wired
+//! yet (that is stage 4) — this stage is output-equivalent.
+
+use tcl_registry::{ArgRole, CommandRegistry};
+
+use crate::cfg::{Function, Terminator};
+use crate::ir::Statement;
+use crate::naming::{normalise_qualified_name, normalise_var_name};
+use crate::place::{self, places_read_to_form, Place};
+use crate::segmenter::segment_commands;
+use crate::ssa::structural_body_indices;
+use crate::var_refs::{command_subst_texts, scan_var_ref_forms, vars_in_expr};
+use crate::var_resolve::{resolve_place, ResolveContext};
+use crate::var_scoping::{
+    global_declaration_indices, upvar_local_declaration_indices, variable_declaration_indices,
+};
+
+// Commands whose VAR_READ-role argument names the *whole* array, not a scalar
+// (so a write to any element is observed).  Conservative — extra members only
+// widen overlap (sound).
+const WHOLE_ARRAY_COMMANDS: &[&str] = &["::array", "::parray"];
+const WHOLE_ARRAY_BARE: &[&str] = &["array", "parray"];
+
+/// Scan *cfg* for the in-scope variable declarations and build the
+/// [`ResolveContext`] used to resolve places within the function.
+///
+/// `fn_qname` is the function's fully-qualified name (`::ns::p`); the resolve
+/// namespace is its parent (`::ns`), so a `variable v` resolves to `::ns::v`.
+#[must_use]
+pub fn build_resolve_context(cfg: &Function, fn_qname: &str) -> ResolveContext {
+    let parent = fn_qname.rsplit_once("::").map_or("", |(head, _)| head);
+    let namespace = if parent.is_empty() {
+        "::".to_owned()
+    } else {
+        parent.to_owned()
+    };
+
+    let mut ctx = ResolveContext {
+        namespace: namespace.clone(),
+        ..ResolveContext::default()
+    };
+
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            let (command, canonical, args) = match stmt {
+                Statement::Call {
+                    command,
+                    canonical_command,
+                    args,
+                    ..
+                }
+                | Statement::Barrier {
+                    command,
+                    canonical_command,
+                    args,
+                    ..
+                } => (command.as_str(), canonical_command.as_deref(), args),
+                _ => continue,
+            };
+            // Match against the canonical (`::`-qualified) command name.
+            let canon = canonical.map_or_else(|| normalise_qualified_name(command), str::to_owned);
+            match canon.as_str() {
+                "::global" => {
+                    for i in global_declaration_indices(args) {
+                        if let Some(a) = args.get(i) {
+                            ctx.globals.insert(normalise_var_name(a).to_owned());
+                        }
+                    }
+                }
+                "::variable" => {
+                    for i in variable_declaration_indices(args) {
+                        if let Some(a) = args.get(i) {
+                            ctx.ns_vars.insert(normalise_var_name(a).to_owned());
+                        }
+                    }
+                }
+                "::trace" => {
+                    if let Some(t) = trace_target(args) {
+                        ctx.traced.insert(normalise_var_name(t).to_owned());
+                    }
+                }
+                _ => {}
+            }
+            // `upvar` / `namespace upvar` — recognised structurally by the
+            // shared grammar (the IR command for `namespace upvar` is
+            // `namespace`), so gate on the surface command, not the canonical.
+            collect_upvar_aliases(command, args, &mut ctx.upvar_aliases, &namespace);
+        }
+    }
+
+    ctx
+}
+
+fn qualify_namespace(ns_arg: &str, current: &str) -> String {
+    if ns_arg.starts_with("::") {
+        return ns_arg.to_owned();
+    }
+    if current.is_empty() || current == "::" {
+        format!("::{ns_arg}")
+    } else {
+        format!("{current}::{ns_arg}")
+    }
+}
+
+fn collect_upvar_aliases(
+    command: &str,
+    args: &[String],
+    out: &mut std::collections::HashMap<String, String>,
+    namespace: &str,
+) {
+    // The namespace argument of a `namespace upvar` form (None for plain upvar).
+    let ns_arg: Option<&str> =
+        if command == "namespace" && args.first().map(String::as_str) == Some("upvar") {
+            args.get(1).map(String::as_str)
+        } else if command == "namespace upvar" {
+            args.first().map(String::as_str)
+        } else {
+            None
+        };
+
+    for local_i in upvar_local_declaration_indices(command, args) {
+        let Some(alias_raw) = args.get(local_i) else {
+            continue;
+        };
+        let alias = normalise_var_name(alias_raw).to_owned();
+        if alias.is_empty() {
+            continue;
+        }
+        let target_arg = local_i
+            .checked_sub(1)
+            .and_then(|j| args.get(j))
+            .map_or("", String::as_str);
+        // A target with any embedded substitution names a runtime-computed
+        // caller var, so it is unresolvable: record it as dynamic ("").
+        let dynamic = target_arg.is_empty() || target_arg.contains('$') || target_arg.contains('[');
+        let target = if dynamic {
+            String::new()
+        } else if let Some(ns) = ns_arg {
+            if ns.is_empty() || ns.contains('$') || ns.contains('[') {
+                String::new()
+            } else {
+                let ns_fq = qualify_namespace(ns, namespace);
+                format!(
+                    "{}::{}",
+                    ns_fq.trim_end_matches(':'),
+                    target_arg.trim_start_matches(':')
+                )
+            }
+        } else {
+            target_arg.to_owned()
+        };
+        out.insert(alias, target);
+    }
+}
+
+fn trace_target(args: &[String]) -> Option<&str> {
+    if args.len() >= 3 && args[0] == "add" && args[1] == "variable" {
+        return Some(&args[2]);
+    }
+    if args.len() >= 2 && args[0] == "variable" {
+        return Some(&args[1]);
+    }
+    None
+}
+
+/// The places *stmt* writes (element-granular).
+#[must_use]
+pub fn def_places(
+    stmt: &Statement,
+    ctx: &ResolveContext,
+    registry: &CommandRegistry,
+) -> Vec<Place> {
+    match stmt {
+        Statement::AssignConst { name, .. }
+        | Statement::AssignValue { name, .. }
+        | Statement::AssignExpr { name, .. }
+        | Statement::Incr { name, .. } => {
+            vec![resolve_place(name, ctx, false, registry)]
+        }
+        Statement::Call { defs, .. } => defs
+            .iter()
+            .map(|d| resolve_place(d, ctx, false, registry))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Resolve the reads of every command in `script_text` — VAR_READ-role name
+/// args (`array get arr` reads whole array `arr`; `info exists x` reads `x`)
+/// plus a recursive descent of each arg word.
+fn command_reads(
+    script_text: &str,
+    ctx: &ResolveContext,
+    out: &mut Vec<Place>,
+    registry: &CommandRegistry,
+) {
+    for cmd in segment_commands(script_text) {
+        let name = cmd.name();
+        if name.is_empty() {
+            continue;
+        }
+        let args = cmd.args();
+        let whole = WHOLE_ARRAY_BARE.contains(&name)
+            || WHOLE_ARRAY_COMMANDS.contains(&normalise_qualified_name(name).as_str());
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        for i in registry.arg_indices_for_role(name, &arg_strs, ArgRole::VarRead) {
+            if let Some(a) = args.get(i) {
+                if !a.starts_with('$') && !a.starts_with('[') {
+                    out.push(resolve_place(a, ctx, whole, registry));
+                } else {
+                    // Dynamic VAR_READ name (`array get $arr_name`): the read
+                    // target is computed → UNKNOWN (overlaps everything) so a
+                    // write to any array is not falsely flagged dead.
+                    out.push(place::unknown_top());
+                }
+            }
+        }
+        word_reads(name, ctx, out, registry);
+        for arg in args {
+            word_reads(arg, ctx, out, registry);
+        }
+    }
+}
+
+/// Resolve reads in a single word: `$`-refs (precise, with array index) at the
+/// top level, and any `[...]` command substitution recursively.
+fn word_reads(text: &str, ctx: &ResolveContext, out: &mut Vec<Place>, registry: &CommandRegistry) {
+    if text.is_empty() {
+        return;
+    }
+    if text.contains('$') {
+        for r in scan_var_ref_forms(text) {
+            out.push(resolve_place(&r, ctx, false, registry));
+        }
+    }
+    for inner in command_subst_texts(text) {
+        command_reads(&inner, ctx, out, registry);
+    }
+}
+
+/// The places *stmt* reads (sound over-approximation).
+///
+/// Covers `$`-substitution reads (element-granular for arrays), VAR_READ-role
+/// name args at every nesting level (`[array get arr]` reads the whole array),
+/// and the name/index variables read to *form* a dynamic target/ref (`set $X`
+/// reads `X`; `$arr($i)` reads `i`) via [`places_read_to_form`].
+#[must_use]
+pub fn read_places(
+    stmt: &Statement,
+    ctx: &ResolveContext,
+    registry: &CommandRegistry,
+) -> Vec<Place> {
+    let mut out: Vec<Place> = Vec::new();
+
+    match stmt {
+        Statement::AssignValue { value, .. } => word_reads(value, ctx, &mut out, registry),
+        Statement::Incr { name, amount, .. } => {
+            // `incr x` reads its own target; the amount may read more.
+            out.push(resolve_place(name, ctx, false, registry));
+            if let Some(a) = amount {
+                word_reads(a, ctx, &mut out, registry);
+            }
+        }
+        Statement::AssignExpr { expr, .. } | Statement::ExprEval { expr, .. } => {
+            for nm in vars_in_expr(expr) {
+                out.push(resolve_place(&nm, ctx, false, registry));
+            }
+            for cmd_text in expr.command_texts() {
+                word_reads(&cmd_text, ctx, &mut out, registry);
+            }
+        }
+        Statement::Return { value, expr, .. } => {
+            if let Some(v) = value {
+                word_reads(v, ctx, &mut out, registry);
+            }
+            if let Some(e) = expr {
+                for nm in vars_in_expr(e) {
+                    out.push(resolve_place(&nm, ctx, false, registry));
+                }
+            }
+        }
+        Statement::Call {
+            command,
+            canonical_command,
+            args,
+            tokens,
+            ..
+        }
+        | Statement::Barrier {
+            command,
+            canonical_command,
+            args,
+            tokens,
+            ..
+        } => {
+            let whole = canonical_command
+                .as_deref()
+                .is_some_and(|c| WHOLE_ARRAY_COMMANDS.contains(&c));
+            let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let read_idx: std::collections::HashSet<usize> = registry
+                .arg_indices_for_role(command, &arg_strs, ArgRole::VarRead)
+                .into_iter()
+                .collect();
+            // A structural body (proc/method/test/snit) runs in its own scope
+            // and is analysed separately — its reads must not leak into this
+            // scope.
+            let structural = structural_body_indices(command, args, tokens.as_ref(), registry);
+            for (i, arg) in args.iter().enumerate() {
+                if structural.contains(&i) {
+                    continue;
+                }
+                if read_idx.contains(&i) && !arg.starts_with('$') && !arg.starts_with('[') {
+                    // A name-valued read arg (`info exists x`, `array get a`).
+                    out.push(resolve_place(arg, ctx, whole, registry));
+                } else {
+                    if read_idx.contains(&i) {
+                        // Dynamic VAR_READ name (`array get $arr_name`) → UNKNOWN.
+                        out.push(place::unknown_top());
+                    }
+                    word_reads(arg, ctx, &mut out, registry);
+                }
+            }
+            word_reads(command, ctx, &mut out, registry);
+        }
+        Statement::Block { body, .. } => {
+            // A `Block` body (inlined passthrough / `eval {…}` brace-literal)
+            // runs in the enclosing scope — recover its reads so a `$x` inside
+            // `eval {puts $x}` isn't seen as dead.  (`namespace eval ns {…}`
+            // lowers to a `Barrier`, not a `Block`, so it is not recursed.)
+            for inner in &body.statements {
+                out.extend(read_places(inner, ctx, registry));
+            }
+        }
+        _ => {}
+    }
+
+    // The vars read to *form* any dynamic def target (`set $X` / `set ${tok}(k)`
+    // / `set a($i)`) AND any dynamic read ref (`$arr($i)` reads `i`) — the
+    // genuine name/index reads the dead-store/unused checks need.
+    let mut formed: Vec<Place> = Vec::new();
+    for dp in def_places(stmt, ctx, registry) {
+        formed.extend(places_read_to_form(&dp));
+    }
+    for rp in &out {
+        formed.extend(places_read_to_form(rp));
+    }
+    out.extend(formed);
+
+    out
+}
+
+/// The places a block *terminator* reads — an `if` / `while` / `for` branch
+/// condition or a `return` value/expr.  Covers the direct `$`-refs plus any
+/// variables hidden in a command substitution within the condition.
+#[must_use]
+pub fn terminator_read_places(
+    term: &Terminator,
+    ctx: &ResolveContext,
+    registry: &CommandRegistry,
+) -> Vec<Place> {
+    let mut out: Vec<Place> = Vec::new();
+    match term {
+        Terminator::Branch { condition, .. } => {
+            for nm in vars_in_expr(condition) {
+                out.push(resolve_place(&nm, ctx, false, registry));
+            }
+            for cmd_text in condition.command_texts() {
+                word_reads(&cmd_text, ctx, &mut out, registry);
+            }
+        }
+        Terminator::Return {
+            value,
+            expr,
+            braced,
+            ..
+        } => {
+            // A braced `return {…}` is a literal — its `$`-refs are not reads.
+            if !braced {
+                if let Some(v) = value {
+                    word_reads(v, ctx, &mut out, registry);
+                }
+                if let Some(e) = expr {
+                    for nm in vars_in_expr(e) {
+                        out.push(resolve_place(&nm, ctx, false, registry));
+                    }
+                    for cmd_text in e.command_texts() {
+                        word_reads(&cmd_text, ctx, &mut out, registry);
+                    }
+                }
+            }
+        }
+        Terminator::Goto { .. } => {}
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compilation_unit::CompilationUnit;
+    use crate::place::{array_elem, overlap, scalar, Index, PlaceKind, LOCAL_NS};
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    /// Collect every def-place and read-place across a proc's CFG.
+    fn places_of(src: &str, qname: &str) -> (Vec<Place>, Vec<Place>) {
+        let r = registry();
+        let cu = CompilationUnit::build_for(src, &r, false);
+        let fu = cu.function(qname).expect("proc not found");
+        let ctx = build_resolve_context(&fu.cfg, &fu.name);
+        let mut defs = Vec::new();
+        let mut reads = Vec::new();
+        for block in fu.cfg.blocks.values() {
+            for stmt in &block.statements {
+                defs.extend(def_places(stmt, &ctx, &r));
+                reads.extend(read_places(stmt, &ctx, &r));
+            }
+        }
+        (defs, reads)
+    }
+
+    #[test]
+    fn array_element_def_and_read_are_element_granular() {
+        // The end-to-end stage-3 point: `set a(k) 1` defs a(k); `puts $a(k)`
+        // reads a(k); `set a(j) 2` defs a(j), which NO read observes.  Stage 4
+        // will suppress the W220 on a(k) (a read overlaps it) but keep a(j)'s.
+        let (defs, reads) = places_of("proc f {} { set a(k) 1; set a(j) 2; puts $a(k) }", "::f");
+        let ak = array_elem("a", Index::literal("k"), LOCAL_NS, false);
+        let aj = array_elem("a", Index::literal("j"), LOCAL_NS, false);
+        assert!(defs.contains(&ak), "expected a(k) def, got {defs:?}");
+        assert!(defs.contains(&aj), "expected a(j) def, got {defs:?}");
+        // a read observes a(k) …
+        assert!(
+            reads.iter().any(|r| overlap(r, &ak)),
+            "a(k) should be read by `puts $a(k)`, reads={reads:?}",
+        );
+        // … but nothing observes a(j).
+        assert!(
+            !reads.iter().any(|r| overlap(r, &aj)),
+            "a(j) must not be observed by any read, reads={reads:?}",
+        );
+    }
+
+    #[test]
+    fn scalar_def_and_read() {
+        let (defs, reads) = places_of("proc f {} { set x 1; puts $x }", "::f");
+        let x = scalar("x", LOCAL_NS, false);
+        assert!(defs.contains(&x));
+        assert!(reads.iter().any(|r| overlap(r, &x)));
+    }
+
+    #[test]
+    fn var_read_role_arg_resolves_whole_array() {
+        // `array get arr` reads the *whole* array arr → overlaps every element.
+        let (_defs, reads) = places_of("proc f {} { set out [array get arr] }", "::f");
+        let arr_k = array_elem("arr", Index::literal("k"), LOCAL_NS, false);
+        assert!(
+            reads.iter().any(|r| overlap(r, &arr_k)),
+            "array get arr should read the whole array, reads={reads:?}",
+        );
+    }
+
+    #[test]
+    fn build_context_collects_declarations() {
+        let r = registry();
+        let cu = CompilationUnit::build_for(
+            "proc f {} { global g; variable v; upvar 1 caller y; set x 1 }",
+            &r,
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let ctx = build_resolve_context(&fu.cfg, &fu.name);
+        assert!(ctx.globals.contains("g"), "globals={:?}", ctx.globals);
+        assert!(ctx.ns_vars.contains("v"), "ns_vars={:?}", ctx.ns_vars);
+        assert!(
+            ctx.upvar_aliases.contains_key("y"),
+            "upvar_aliases={:?}",
+            ctx.upvar_aliases
+        );
+        // `y` resolves to an upvar alias, not a plain local scalar.
+        let p = resolve_place("y", &ctx, false, &r);
+        assert_eq!(p.kind, PlaceKind::UpvarAlias);
+    }
+
+    #[test]
+    fn dynamic_index_read_records_the_index_var() {
+        // `set a($i) 1` defs a($i) (dynamic) and reads `i` (to form the index).
+        let (defs, reads) = places_of("proc f {} { set i 0; set a($i) 1 }", "::f");
+        assert!(
+            defs.iter()
+                .any(|d| d.kind == PlaceKind::ArrayElem && d.name == "a"),
+            "defs={defs:?}",
+        );
+        assert!(
+            reads
+                .iter()
+                .any(|r| overlap(r, &scalar("i", LOCAL_NS, false))),
+            "the dynamic index read of `i` must be recovered, reads={reads:?}",
+        );
+    }
+}

--- a/rust/tcl-compiler/src/place_bridge.rs
+++ b/rust/tcl-compiler/src/place_bridge.rs
@@ -15,7 +15,7 @@
 use tcl_registry::{ArgRole, CommandRegistry};
 
 use crate::cfg::{Function, Terminator};
-use crate::ir::Statement;
+use crate::ir::{CommandTokens, Statement};
 use crate::naming::{normalise_qualified_name, normalise_var_name};
 use crate::place::{self, overlap, places_read_to_form, Place, PlaceKind};
 use crate::segmenter::segment_commands;
@@ -25,6 +25,7 @@ use crate::var_resolve::{resolve_place, ResolveContext};
 use crate::var_scoping::{
     global_declaration_indices, upvar_local_declaration_indices, variable_declaration_indices,
 };
+use tcl_lexer::TokenType;
 
 // Commands whose VAR_READ-role argument names the *whole* array, not a scalar
 // (so a write to any element is observed).  Conservative — extra members only
@@ -119,6 +120,10 @@ fn collect_upvar_aliases(
     out: &mut std::collections::HashMap<String, String>,
     namespace: &str,
 ) {
+    // Tolerate a fully-qualified head (`::upvar`, `::namespace upvar`): the
+    // shared `upvar_local_declaration_indices` grammar matches the bare forms,
+    // so a `::`-qualified call would otherwise leave `upvar_aliases` incomplete.
+    let command = command.strip_prefix("::").unwrap_or(command);
     // The namespace argument of a `namespace upvar` form (None for plain upvar).
     let ns_arg: Option<&str> =
         if command == "namespace" && args.first().map(String::as_str) == Some("upvar") {
@@ -162,6 +167,22 @@ fn collect_upvar_aliases(
         };
         out.insert(alias, target);
     }
+}
+
+/// True when arg `arg_index` of a command is a **braced literal** word
+/// (`{…}`): Tcl performs no `$` / `[` substitution on it, so its de-braced IR
+/// text must NOT be scanned for reads — `puts {$a(k)}` does *not* read `a(k)`.
+///
+/// Detected via the `Str` token kind: a `$var` lexes to `Var`, a `[cmd]` to
+/// `Cmd`, and a `"…"` (which *does* substitute) to `Esc` — only a brace-quoted
+/// word is `Str`.  `tokens.argv` is command-name-first, so args are 1-based.
+/// Mirrors `place_bridge.py`'s brace-aware `add_refs` (it scans the arg *with*
+/// its braces; the Rust IR keeps args de-braced, so we gate on the token kind).
+fn is_braced_literal(tokens: Option<&CommandTokens>, arg_index: usize) -> bool {
+    tokens
+        .and_then(|t| t.argv_kinds.get(arg_index + 1))
+        .copied()
+        == Some(TokenType::Str)
 }
 
 fn trace_target(args: &[String]) -> Option<&str> {
@@ -316,6 +337,13 @@ pub fn read_places(
             // and is analysed separately — its reads must not leak into this
             // scope.
             let structural = structural_body_indices(command, args, tokens.as_ref(), registry);
+            // Body-role args (incl. non-structural ones like an iRules
+            // `clientside {…}` script) DO run, so their `$`-refs are real reads
+            // and must still be scanned even when braced.
+            let body_idx: std::collections::HashSet<usize> = registry
+                .arg_indices_for_role(command, &arg_strs, ArgRole::Body)
+                .into_iter()
+                .collect();
             for (i, arg) in args.iter().enumerate() {
                 if structural.contains(&i) {
                     continue;
@@ -328,7 +356,13 @@ pub fn read_places(
                         // Dynamic VAR_READ name (`array get $arr_name`) → UNKNOWN.
                         out.push(place::unknown_top());
                     }
-                    word_reads(arg, ctx, &mut out, registry);
+                    // A braced literal *data* word performs no substitution, so
+                    // its de-braced IR text is not a read site (`puts {$a(k)}`
+                    // must not look like a read of `a(k)`, or a real dead store
+                    // to `a(k)` would be wrongly suppressed).
+                    if body_idx.contains(&i) || !is_braced_literal(tokens.as_ref(), i) {
+                        word_reads(arg, ctx, &mut out, registry);
+                    }
                 }
             }
             word_reads(command, ctx, &mut out, registry);
@@ -430,11 +464,16 @@ pub fn element_writes_observed_by_reads(
     use std::collections::HashSet;
 
     let is_array_assign = |stmt: &Statement| -> bool {
+        // `incr a(k)` also defines an array element and folds to the base `a`
+        // under name-level SSA, so it participates in the same FP — and
+        // `def_places` already resolves it.  (The analyser's W220 never flags
+        // an `Incr`, but the optimiser's O109 reaches it, so include it.)
         matches!(
             stmt,
             Statement::AssignConst { name, .. }
                 | Statement::AssignValue { name, .. }
                 | Statement::AssignExpr { name, .. }
+                | Statement::Incr { name, .. }
                 if name.contains('(')
         )
     };
@@ -568,6 +607,26 @@ mod tests {
         // `y` resolves to an upvar alias, not a plain local scalar.
         let p = resolve_place("y", &ctx, false, &r);
         assert_eq!(p.kind, PlaceKind::UpvarAlias);
+    }
+
+    #[test]
+    fn build_context_tolerates_qualified_upvar_head() {
+        // A fully-qualified `::upvar` head must still register the alias —
+        // `collect_upvar_aliases` strips the leading `::` so the bare-form
+        // grammar matches (otherwise `upvar_aliases` would be incomplete).
+        let r = registry();
+        let cu = CompilationUnit::build_for("proc f {} { ::upvar 1 caller y; set x 1 }", &r, false);
+        let fu = cu.function("::f").unwrap();
+        let ctx = build_resolve_context(&fu.cfg, &fu.name);
+        assert!(
+            ctx.upvar_aliases.contains_key("y"),
+            "::upvar alias should be registered; upvar_aliases={:?}",
+            ctx.upvar_aliases
+        );
+        assert_eq!(
+            resolve_place("y", &ctx, false, &r).kind,
+            PlaceKind::UpvarAlias
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/place_bridge.rs
+++ b/rust/tcl-compiler/src/place_bridge.rs
@@ -17,7 +17,7 @@ use tcl_registry::{ArgRole, CommandRegistry};
 use crate::cfg::{Function, Terminator};
 use crate::ir::Statement;
 use crate::naming::{normalise_qualified_name, normalise_var_name};
-use crate::place::{self, places_read_to_form, Place};
+use crate::place::{self, overlap, places_read_to_form, Place, PlaceKind};
 use crate::segmenter::segment_commands;
 use crate::ssa::structural_body_indices;
 use crate::var_refs::{command_subst_texts, scan_var_ref_forms, vars_in_expr};
@@ -401,6 +401,81 @@ pub fn terminator_read_places(
             }
         }
         Terminator::Goto { .. } => {}
+    }
+    out
+}
+
+/// `(block_name, statement_index)` of every array-element / dict-path
+/// assignment in *cfg* whose def [`Place`] is **observed** by some read place
+/// in the function — the element writes a *name-level* dead-store / unused
+/// analysis mis-folds (SSA collapses `a(k)` / `a(j)` / `$a` to the base `a`)
+/// but that a read in fact keeps live.
+///
+/// Shared by the analyser (W220) and the optimiser (O109): both flag an
+/// overwritten/unused SSA def at name granularity, so both consult this to
+/// suppress the array-element false positives.  The suppression is
+/// element-granular only — scalar defs (which never fold) keep their precise
+/// name-level verdict.  A whole-array / UNKNOWN / upvar-alias read overlaps
+/// every element (so `array get a` keeps each `a(k)` write live); this
+/// full-scan `overlap` matches `main`'s bucketed `_make_element_observed`,
+/// where `UNKNOWN` / `UPVAR_ALIAS` reads are wildcards (here `overlap` returns
+/// `true` on those edges).  Empty (no cost) when *cfg* has no array-element
+/// assignment.
+#[must_use]
+pub fn element_writes_observed_by_reads(
+    cfg: &Function,
+    fn_qname: &str,
+    registry: &CommandRegistry,
+) -> std::collections::HashSet<(String, i32)> {
+    use std::collections::HashSet;
+
+    let is_array_assign = |stmt: &Statement| -> bool {
+        matches!(
+            stmt,
+            Statement::AssignConst { name, .. }
+                | Statement::AssignValue { name, .. }
+                | Statement::AssignExpr { name, .. }
+                if name.contains('(')
+        )
+    };
+
+    let mut out = HashSet::new();
+    // Cheap pre-check: only array-element assignments can be mis-folded.
+    if !cfg
+        .blocks
+        .values()
+        .any(|b| b.statements.iter().any(&is_array_assign))
+    {
+        return out;
+    }
+
+    let ctx = build_resolve_context(cfg, fn_qname);
+    // All read places in the function, collected once.
+    let mut reads: Vec<Place> = Vec::new();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            reads.extend(read_places(stmt, &ctx, registry));
+        }
+        if let Some(term) = &block.terminator {
+            reads.extend(terminator_read_places(term, &ctx, registry));
+        }
+    }
+
+    for (block_name, block) in &cfg.blocks {
+        for (idx, stmt) in block.statements.iter().enumerate() {
+            if !is_array_assign(stmt) {
+                continue;
+            }
+            let observed = def_places(stmt, &ctx, registry).iter().any(|d| {
+                matches!(d.kind, PlaceKind::ArrayElem | PlaceKind::DictPath)
+                    && reads.iter().any(|r| overlap(d, r))
+            });
+            if observed {
+                if let Ok(i) = i32::try_from(idx) {
+                    out.insert((block_name.clone(), i));
+                }
+            }
+        }
     }
     out
 }

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -542,7 +542,7 @@ fn is_braced_arg(tokens: Option<&CommandTokens>, arg_index: usize) -> bool {
 /// Body-carrying options for `tcltest::test`.
 const TCLTEST_BODY_OPTIONS: &[&str] = &["-setup", "-body", "-cleanup"];
 
-fn structural_body_indices(
+pub(crate) fn structural_body_indices(
     command: &str,
     args: &[String],
     tokens: Option<&CommandTokens>,

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -240,6 +240,85 @@ pub fn vars_in_expr(expr: &crate::expr_ast::ExprNode) -> BTreeSet<String> {
     expr.vars().into_iter().collect()
 }
 
+/// De-sigil a `VAR`-token's source text, keeping any array-index suffix.
+///
+/// `$a(k)` → `a(k)`, `${a(k)}` → `a(k)`, `${a}` → `a`, `$a` → `a`.  Unlike
+/// [`normalise_var_name`], the `(idx)` suffix is preserved so the form can be
+/// classified as a scalar vs an array element by `var_resolve::resolve_place`.
+fn deref_form(text: &str) -> &str {
+    if let Some(inner) = text.strip_prefix("${") {
+        inner.strip_suffix('}').unwrap_or(inner)
+    } else {
+        text.strip_prefix('$').unwrap_or(text)
+    }
+}
+
+fn collect_ref_forms(text: &str, out: &mut Vec<String>) {
+    if text.is_empty() {
+        return;
+    }
+    let source_map = SourceMap::new(text);
+    let Ok(tokens) = Lexer::new(text).tokenise_all() else {
+        return;
+    };
+    for tok in &tokens {
+        match tok.kind {
+            TokenType::Var => {
+                let form = deref_form(source_map.token_text(*tok));
+                if !form.is_empty() {
+                    out.push(form.to_owned());
+                }
+            }
+            TokenType::Cmd => {
+                let inner = source_map.token_text(*tok);
+                if !inner.is_empty() {
+                    collect_ref_forms(inner, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Return the *full* variable-reference forms read in *text* — keeping the
+/// array-index suffix that [`VarReferenceScanner`] normalises away.
+///
+/// `$a` → `"a"`, `$a(k)` → `"a(k)"`, `$state($whom)` → `"state($whom)"`.
+/// Recurses into `[...]` command substitutions.  Unlike the name-set scanners,
+/// this preserves enough structure for `var_resolve::resolve_place` to
+/// distinguish a scalar from an array element from a dynamic ref.  Mirrors
+/// `compiler/var_refs.py::scan_var_ref_forms`.
+#[must_use]
+pub fn scan_var_ref_forms(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_ref_forms(text, &mut out);
+    out
+}
+
+/// Return the inner text of every top-level `[...]` command substitution in
+/// *text* (without the surrounding brackets).  Used by the place bridge to
+/// recover the reads of commands nested in an argument word.
+#[must_use]
+pub fn command_subst_texts(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if !text.contains('[') {
+        return out;
+    }
+    let source_map = SourceMap::new(text);
+    let Ok(tokens) = Lexer::new(text).tokenise_all() else {
+        return out;
+    };
+    for tok in &tokens {
+        if tok.kind == TokenType::Cmd {
+            let inner = source_map.token_text(*tok);
+            if !inner.is_empty() {
+                out.push(inner.to_owned());
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,6 +333,29 @@ mod tests {
         let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
         let vars = scanner.scan_word("$x", &reg);
         assert!(vars.contains("x"), "should find $x; got {vars:?}");
+    }
+
+    #[test]
+    fn scan_var_ref_forms_keeps_array_index() {
+        // Unlike the name scanner, forms preserve the `(idx)` suffix.
+        assert_eq!(scan_var_ref_forms("$a(k)"), vec!["a(k)".to_owned()]);
+        assert_eq!(scan_var_ref_forms("${a(k)}"), vec!["a(k)".to_owned()]);
+        assert_eq!(scan_var_ref_forms("$x"), vec!["x".to_owned()]);
+        assert_eq!(
+            scan_var_ref_forms("$x + $a($i)"),
+            vec!["x".to_owned(), "a($i)".to_owned()]
+        );
+        // recurses into command substitutions
+        assert_eq!(scan_var_ref_forms("[foo $b]"), vec!["b".to_owned()]);
+    }
+
+    #[test]
+    fn command_subst_texts_extracts_inner() {
+        assert_eq!(
+            command_subst_texts("foo [bar $x] baz"),
+            vec!["bar $x".to_owned()]
+        );
+        assert!(command_subst_texts("no subst here").is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_resolve.rs
+++ b/rust/tcl-compiler/src/var_resolve.rs
@@ -1,0 +1,337 @@
+//! Variable canonicalisation / resolution — syntactic ref → canonical
+//! [`Place`] (Phase 8 / SYNC-MAY31-1b, stage 2).
+//!
+//! The variable analogue of lowering's command canonicalisation: given a
+//! variable reference as written (`x`, `a(k)`, `$x`, `${tok}(k)`,
+//! `$state($whom)`) plus the per-frame scope context (current namespace, the
+//! `global` / `variable` / `upvar` declarations in effect, active traces),
+//! produce a canonical [`Place`].
+//!
+//! Reuses the existing resolution substrate — [`split_array_name`] /
+//! [`normalise_qualified_name`] ([`crate::naming`]) and the variable-reference
+//! scanner ([`crate::var_refs`]) — rather than re-deriving it.  Anything that
+//! cannot be pinned down statically (dynamic variable name, computed array
+//! name, `upvar` to a dynamic target) resolves to `UNKNOWN` / `dynamic` so the
+//! [`overlap`](crate::place::overlap) relation stays sound (over-approximating).
+//!
+//! Faithful port of `compiler/var_resolve.py` on `main`.
+
+use std::collections::{HashMap, HashSet};
+
+use tcl_registry::CommandRegistry;
+
+use crate::naming::{normalise_qualified_name, split_array_name};
+use crate::place::{self, Index, Place, PlaceKind};
+use crate::var_refs::{VarReferenceScanner, VarScanOptions};
+
+/// Per-frame scope context for resolving a variable reference.
+///
+/// Built once per proc/method/namespace scope and reused (mirrors how the
+/// lowerer reuses its command-canonicalisation maps).
+#[derive(Debug, Clone)]
+pub struct ResolveContext {
+    /// Current FQ namespace.
+    pub namespace: String,
+    /// Names under a `global` declaration.
+    pub globals: HashSet<String>,
+    /// Names under a `variable` declaration.
+    pub ns_vars: HashSet<String>,
+    /// Local alias → caller target (`""` = dynamic/unresolvable).
+    pub upvar_aliases: HashMap<String, String>,
+    /// Names with an active `trace`.
+    pub traced: HashSet<String>,
+    /// `TclOO` instance vars in scope.
+    pub instance_vars: HashSet<String>,
+    /// Owning class/object FQ name for `instance_vars`.
+    pub instance_owner: String,
+}
+
+impl Default for ResolveContext {
+    fn default() -> Self {
+        Self {
+            namespace: "::".to_owned(),
+            globals: HashSet::new(),
+            ns_vars: HashSet::new(),
+            upvar_aliases: HashMap::new(),
+            traced: HashSet::new(),
+            instance_vars: HashSet::new(),
+            instance_owner: String::new(),
+        }
+    }
+}
+
+fn has_subst(text: &str) -> bool {
+    text.contains('$') || text.contains('[')
+}
+
+/// Resolve the variables read inside a dynamic index / name *text*.
+///
+/// Returns the bound read-places sorted by `(ns, name)` (deterministic, like
+/// Python's sorted tuple over the scanner's name set).
+fn inner_read_places(text: &str, ctx: &ResolveContext, registry: &CommandRegistry) -> Vec<Place> {
+    // Read-roles + cmd-sub recursion so `a([idx])` and `a($ns::i)` are covered.
+    let mut scanner = VarReferenceScanner::new(VarScanOptions {
+        include_var_read_roles: true,
+        recurse_cmd_substitutions: true,
+    });
+    let names = scanner.scan_word(text, registry);
+    let mut places: Vec<Place> = names.iter().map(|n| bind_scalar(n, ctx, None)).collect();
+    places.sort_by(|a, b| (&a.ns, &a.name).cmp(&(&b.ns, &b.name)));
+    places
+}
+
+/// Turn an array index / dict key text into an [`Index`].
+fn classify_index(elem: &str, ctx: &ResolveContext, registry: &CommandRegistry) -> Index {
+    if has_subst(elem) {
+        Index::dynamic(inner_read_places(elem, ctx, registry))
+    } else {
+        Index::literal(elem)
+    }
+}
+
+/// Bind a (sigil-stripped, scalar) base name to a canonical [`Place`] using the
+/// scope declarations in *ctx*.  `observed` overrides the trace-derived flag
+/// when `Some`.
+fn bind_scalar(base: &str, ctx: &ResolveContext, observed: Option<bool>) -> Place {
+    let obs = observed.unwrap_or_else(|| ctx.traced.contains(base));
+    if let Some(target) = ctx.upvar_aliases.get(base) {
+        // `upvar_alias` forces `dynamic` when the target is empty.
+        return place::upvar_alias(base, target.clone(), false);
+    }
+    if ctx.instance_vars.contains(base) {
+        return place::instance_var(base, &ctx.instance_owner, obs);
+    }
+    if ctx.globals.contains(base) {
+        return place::scalar(base, "::", obs);
+    }
+    if ctx.ns_vars.contains(base) {
+        return place::scalar(base, &ctx.namespace, obs);
+    }
+    if base.starts_with("::") {
+        let fq = normalise_qualified_name(base);
+        let (ns, tail) = match fq.rfind("::") {
+            Some(i) => (&fq[..i], &fq[i + 2..]),
+            None => ("", fq.as_str()),
+        };
+        let ns = if ns.is_empty() { "::" } else { ns };
+        return place::scalar(tail, ns, obs);
+    }
+    place::scalar(base, place::LOCAL_NS, obs)
+}
+
+/// Resolve a variable reference *reference* (as written) to a canonical
+/// [`Place`].
+///
+/// `whole_array` marks a reference the command touches as an entire array
+/// (`array get a` / `array set a` / a bare `$a` passed to such), so it becomes
+/// `ARRAY_WHOLE` rather than a scalar.
+#[must_use]
+pub fn resolve_place(
+    reference: &str,
+    ctx: &ResolveContext,
+    whole_array: bool,
+    registry: &CommandRegistry,
+) -> Place {
+    if reference.is_empty() {
+        return place::unknown_top();
+    }
+
+    // A target whose *name* is value-substituted (`set $X v`, `set ${tok}(k) v`)
+    // denotes the variable named by the substitution's value — a place that
+    // cannot be pinned down — but it *reads* the name variable(s).  Read
+    // references arrive de-sigilled from the scanner, so a leading `$` here
+    // always marks a write-target dynamic name.
+    if reference.starts_with('$') {
+        return place::unknown(inner_read_places(reference, ctx, registry));
+    }
+
+    let (base, elem) = split_array_name(reference);
+
+    if base.is_empty() || has_subst(base) {
+        return place::unknown(inner_read_places(reference, ctx, registry));
+    }
+
+    if let Some(elem) = elem {
+        let index = classify_index(elem, ctx, registry);
+        let bound = bind_scalar(base, ctx, None);
+        // Carry namespace/observed/dynamic/owner from the bound scalar.
+        return Place {
+            kind: PlaceKind::ArrayElem,
+            ns: bound.ns,
+            name: bound.name,
+            index: Some(index),
+            keys: Vec::new(),
+            owner: bound.owner,
+            observed: bound.observed,
+            dynamic: bound.dynamic,
+            name_reads: Vec::new(),
+        };
+    }
+
+    if whole_array {
+        let bound = bind_scalar(base, ctx, None);
+        return Place {
+            kind: PlaceKind::ArrayWhole,
+            ns: bound.ns,
+            name: bound.name,
+            index: None,
+            keys: Vec::new(),
+            owner: bound.owner,
+            observed: bound.observed,
+            dynamic: bound.dynamic,
+            name_reads: Vec::new(),
+        };
+    }
+
+    bind_scalar(base, ctx, None)
+}
+
+/// Resolve a `dict get/set $d k1 k2 …` access to a `DICT_PATH` [`Place`].
+#[must_use]
+pub fn resolve_dict_path(
+    root_ref: &str,
+    keys: &[String],
+    ctx: &ResolveContext,
+    registry: &CommandRegistry,
+) -> Place {
+    let (base, _) = split_array_name(root_ref);
+    if base.is_empty() || has_subst(base) {
+        return place::unknown(inner_read_places(root_ref, ctx, registry));
+    }
+    let bound = bind_scalar(base, ctx, None);
+    let key_indices: Vec<Index> = keys
+        .iter()
+        .map(|k| classify_index(k, ctx, registry))
+        .collect();
+    place::dict_path(bound.name, key_indices, bound.ns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::place::{places_read_to_form, scalar, LOCAL_NS};
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    fn ctx() -> ResolveContext {
+        ResolveContext::default()
+    }
+
+    #[test]
+    fn local_scalar_resolves_to_local_ns() {
+        let p = resolve_place("x", &ctx(), false, &registry());
+        assert_eq!(p, scalar("x", LOCAL_NS, false));
+    }
+
+    #[test]
+    fn absolute_scalar_splits_namespace_and_tail() {
+        assert_eq!(
+            resolve_place("::ns::v", &ctx(), false, &registry()),
+            scalar("v", "::ns", false)
+        );
+        assert_eq!(
+            resolve_place("::g", &ctx(), false, &registry()),
+            scalar("g", "::", false)
+        );
+    }
+
+    #[test]
+    fn global_and_variable_declarations_change_ns() {
+        let mut c = ctx();
+        c.globals.insert("g".to_owned());
+        assert_eq!(
+            resolve_place("g", &c, false, &registry()),
+            scalar("g", "::", false)
+        );
+        let mut c = ctx();
+        c.namespace = "::ns".to_owned();
+        c.ns_vars.insert("v".to_owned());
+        assert_eq!(
+            resolve_place("v", &c, false, &registry()),
+            scalar("v", "::ns", false)
+        );
+    }
+
+    #[test]
+    fn literal_array_element() {
+        let p = resolve_place("a(k)", &ctx(), false, &registry());
+        assert_eq!(p.kind, PlaceKind::ArrayElem);
+        assert_eq!(p.name, "a");
+        assert_eq!(p.ns, LOCAL_NS);
+        assert_eq!(p.index, Some(Index::literal("k")));
+        assert!(places_read_to_form(&p).is_empty());
+    }
+
+    #[test]
+    fn dynamic_array_element_records_index_reads() {
+        // a($i) — element index reads the scalar `i`.
+        let p = resolve_place("a($i)", &ctx(), false, &registry());
+        assert_eq!(p.kind, PlaceKind::ArrayElem);
+        assert_eq!(p.name, "a");
+        assert_eq!(places_read_to_form(&p), vec![scalar("i", LOCAL_NS, false)]);
+    }
+
+    #[test]
+    fn dynamic_name_target_is_unknown_but_reads_the_name_var() {
+        // set $X v → the *target* is UNKNOWN, but `X` is read.
+        let p = resolve_place("$X", &ctx(), false, &registry());
+        assert_eq!(p.kind, PlaceKind::Unknown);
+        assert_eq!(places_read_to_form(&p), vec![scalar("X", LOCAL_NS, false)]);
+    }
+
+    #[test]
+    fn resolved_array_elements_feed_the_overlap_precision() {
+        // The end-to-end point of stages 1+2: distinct literal elements of the
+        // same array resolve to non-overlapping places (the W220 FP fix),
+        // while a dynamic index conservatively overlaps any sibling.
+        let r = registry();
+        let ak = resolve_place("a(k)", &ctx(), false, &r);
+        let aj = resolve_place("a(j)", &ctx(), false, &r);
+        assert!(!crate::place::overlap(&ak, &aj));
+        let dyn_elem = resolve_place("a($i)", &ctx(), false, &r);
+        assert!(crate::place::overlap(&dyn_elem, &ak));
+    }
+
+    #[test]
+    fn upvar_alias_binds_to_caller_target() {
+        let mut c = ctx();
+        c.upvar_aliases
+            .insert("y".to_owned(), "::caller::x".to_owned());
+        let p = resolve_place("y", &c, false, &registry());
+        assert_eq!(p.kind, PlaceKind::UpvarAlias);
+        assert_eq!(p.owner, "::caller::x");
+        assert!(!p.dynamic);
+        // A dynamic (empty-target) upvar alias is marked dynamic.
+        let mut c = ctx();
+        c.upvar_aliases.insert("z".to_owned(), String::new());
+        let p = resolve_place("z", &c, false, &registry());
+        assert_eq!(p.kind, PlaceKind::UpvarAlias);
+        assert!(p.dynamic);
+    }
+
+    #[test]
+    fn whole_array_flag_yields_array_whole() {
+        let p = resolve_place("a", &ctx(), true, &registry());
+        assert_eq!(p.kind, PlaceKind::ArrayWhole);
+        assert_eq!(p.name, "a");
+    }
+
+    #[test]
+    fn traced_name_is_observed() {
+        let mut c = ctx();
+        c.traced.insert("x".to_owned());
+        let p = resolve_place("x", &c, false, &registry());
+        assert!(p.observed);
+    }
+
+    #[test]
+    fn dict_path_classifies_keys() {
+        let keys = vec!["a".to_owned(), "b".to_owned()];
+        let p = resolve_dict_path("d", &keys, &ctx(), &registry());
+        assert_eq!(p.kind, PlaceKind::DictPath);
+        assert_eq!(p.name, "d");
+        assert_eq!(p.keys, vec![Index::literal("a"), Index::literal("b")]);
+    }
+}

--- a/rust/tcl-registry/src/commands/irules/after.rs
+++ b/rust/tcl-registry/src/commands/irules/after.rs
@@ -1,11 +1,39 @@
 //! `after` iRules command.
 use crate::prelude::*;
+
+/// Dynamic arg-role resolver for `after`.
+///
+/// `after cancel ...` / `after info ...` take no script.  The
+/// timer-scheduling form `after MILLI_SECONDS (-periodic)?
+/// (NESTING_SCRIPT)?` carries the deferred body as its trailing
+/// argument (never the `-periodic` flag, and never when only the delay
+/// is given).  The script runs later from a timer wakeup in its own
+/// dispatch context, so `body_kind` is `Structural`.  Mirrors
+/// `_after_arg_roles` in `dialects/f5/irules/after.py` (#501).
+fn after_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    match args {
+        [] | ["cancel" | "info", ..] => Vec::new(),
+        _ => {
+            let last = args.len() - 1;
+            if last >= 1 && args[last] != "-periodic" {
+                u8::try_from(last).map_or_else(|_| Vec::new(), |idx| vec![(idx, ArgRole::Body)])
+            } else {
+                Vec::new()
+            }
+        }
+    }
+}
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "after",
         traits: Traits::DIAGRAM_ACTION,
         dialects: Some(DialectSet::IRULES),
         arity: Arity::at_least(1),
+        // The timer form's trailing nesting script is a deferred body
+        // (runs from a timer wakeup, not the caller's frame).
+        arg_role_resolver: Some(after_arg_roles),
+        body_kind: BodyKind::Structural,
         hover: Some(HoverSnippet::brief(
             "Execute iRules code after a set period of delay.",
             &["after MILLI_SECONDS (-periodic)? (NESTING_SCRIPT)?"],

--- a/rust/tcl-registry/src/commands/irules/clientside.rs
+++ b/rust/tcl-registry/src/commands/irules/clientside.rs
@@ -5,7 +5,15 @@ pub fn spec() -> CommandSpec {
         name: "clientside",
         traits: Traits::IS_SIDE_SWITCH,
         dialects: Some(DialectSet::IRULES),
-        arity: Arity::at_least(0),
+        // `clientside (NESTING_SCRIPT)?` — the bare query form (0 args,
+        // returns 1/0) or a single optional nesting-script body (#501).
+        arity: Arity::new(0, 1),
+        // The optional nesting script (index 0) is a body evaluated in
+        // the client-side context; it runs synchronously in the
+        // caller's frame, so the default `BodyKind::Plain` applies.  The
+        // 0-arg query form has no arg at index 0, so the role simply
+        // does not apply there.
+        arg_roles: &[(0, ArgRole::Body)],
         hover: Some(HoverSnippet::brief(
             "Causes the specified iRule commands to be evaluated under the client-side contex",
             &["clientside (NESTING_SCRIPT)?"],

--- a/rust/tcl-registry/src/commands/irules/peer.rs
+++ b/rust/tcl-registry/src/commands/irules/peer.rs
@@ -3,11 +3,19 @@ use crate::prelude::*;
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "peer",
+        traits: Traits::IS_SIDE_SWITCH,
         dialects: Some(DialectSet::IRULES),
-        arity: Arity::at_least(0),
+        // `peer NESTING_SCRIPT` — unlike clientside/serverside, peer has
+        // no bare query form, so the script body is required: exactly
+        // one argument at index 0 (#501).
+        arity: Arity::new(1, 1),
+        // The nesting script (index 0) is a body evaluated under the
+        // peer-side context; it runs synchronously in the caller's
+        // frame, so the default `BodyKind::Plain` applies.
+        arg_roles: &[(0, ArgRole::Body)],
         hover: Some(HoverSnippet::brief(
             "Causes the specified iRule commands to be evaluated under the peer-side context.",
-            &["peer ANY_CHARS"],
+            &["peer NESTING_SCRIPT"],
             "F5 iRules",
         )),
         ..CommandSpec::DEFAULT

--- a/rust/tcl-registry/src/commands/irules/serverside.rs
+++ b/rust/tcl-registry/src/commands/irules/serverside.rs
@@ -5,7 +5,15 @@ pub fn spec() -> CommandSpec {
         name: "serverside",
         traits: Traits::IS_SIDE_SWITCH,
         dialects: Some(DialectSet::IRULES),
-        arity: Arity::at_least(0),
+        // `serverside (NESTING_SCRIPT)?` — the bare query form (0 args,
+        // returns 1/0) or a single optional nesting-script body (#501).
+        arity: Arity::new(0, 1),
+        // The optional nesting script (index 0) is a body evaluated in
+        // the server-side context; it runs synchronously in the
+        // caller's frame, so the default `BodyKind::Plain` applies.  The
+        // 0-arg query form has no arg at index 0, so the role simply
+        // does not apply there.
+        arg_roles: &[(0, ArgRole::Body)],
         hover: Some(HoverSnippet::brief(
             "Causes the specified iRule command to be evaluated under the server-side context",
             &["serverside (NESTING_SCRIPT)?"],

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -162,6 +162,24 @@ impl CommandRegistry {
         })
     }
 
+    /// Whether `name` is an iRules side-switch — `clientside`,
+    /// `serverside`, or `peer` — i.e. a command that evaluates its
+    /// nesting-script body under a different connection-side context
+    /// than the surrounding event.  Mirrors Python's
+    /// `CommandRegistry.is_side_switch` ([`Traits::IS_SIDE_SWITCH`]),
+    /// consulted by the iRules collect/release/payload flow check when
+    /// it descends into a side-switch body.  Like
+    /// [`Self::is_byte_compiled`], checks every spec registered under
+    /// the name.
+    #[must_use]
+    pub fn is_side_switch(&self, name: &str) -> bool {
+        self.by_name.get(name).is_some_and(|specs| {
+            specs
+                .iter()
+                .any(|s| s.traits.contains(Traits::IS_SIDE_SWITCH))
+        })
+    }
+
     /// Resolve argument indices for a given role.
     ///
     /// For subcommand-based commands (e.g. `dict create`), pass the


### PR DESCRIPTION
## Summary

Ports the unified variable **Place** model from Python (`place.py`, `var_resolve.py`, `place_bridge.py`) to Rust, enabling element-granular dead-store and unused-variable analysis. Implements the over-approximating `overlap` relation to distinguish `a(k)` from `a(j)`, and reroutes the W220 dead-store and O109 elimination consumers through it.

**Stage 1–3 (output-equivalent):**
- `tcl-compiler::place` — `Place` / `Index` / `PlaceKind` / `IndexKind` types, constructors, `base()` / `is_global()`, the over-approximating `overlap()` relation (with 8E dynamic-*index*-vs-dynamic-*alias* split), and `places_read_to_form()`. 13 unit tests covering `a(k)` ≠ `a(j)` disjointness and dynamic-alias precision.
- `tcl-compiler::var_resolve` — `ResolveContext`, `resolve_place()` (scalar / array-elem / whole-array / dynamic-name → UNKNOWN), and `resolve_dict_path()`. Reuses `naming::split_array_name` (new) and existing `VarReferenceScanner`. 11 unit tests.
- `tcl-compiler::place_bridge` — `build_resolve_context()` (scans CFG for `global` / `variable` / `upvar` / `trace` decls), `def_places()`, `read_places()` (element-granular `$`-refs via new `var_refs::scan_var_ref_forms`; VAR_READ-role name args; `places_read_to_form` for dynamic indices/names; structural bodies skipped), and `terminator_read_places()`. New helpers: `var_refs::{scan_var_ref_forms, command_subst_texts}` and `ExprNode::command_texts()`. 5 bridge tests + helper tests.

**Stage 4 (functional change):**
- Reroutes W220 dead-store and O109 elimination consumers through `place_bridge::element_writes_observed_by_reads()`. For each function, builds the `ResolveContext`, collects every read place (statements + terminators), and suppresses array-element / dict-path writes whose def place `overlap`s a read. Scalars remain name-level precise. A cheap "has array-element assign" pre-check keeps non-array functions cost-free.
- Result: `set a(k) 1; set a(j) 2; puts $a(k)` no longer false-fires W220/O109 on `a(k)`, while `set x 1; set x 2; puts $x` (scalar) and `set a(k) 1; set a(j) 2; puts $a(j)` (a(k) genuinely dead) still do.
- Threads `CommandRegistry` to the optimiser elimination pass via new `PassContext::registry` (set by `optimise*` entry points; `None` on bare `run_pass` test path — existing tests unaffected).
- 4 discriminating tests (analyser + optimiser × {array suppressed, genuine still fires}).

**W211/O126 (unused variable):** Already at parity — no reroute needed. The def-use builder tracks reads at the name level, so `array get a`, `puts $a(k)`, dynamic-index, `eval`, expr command-subs are all seen as uses of base `a`.

**Bonus fixes:**
- E002/E003 arity-shadow order check (#475 / SYNC-MAY31-9): top-level calls (module body, `namespace eval` bodies, conditionals) now honour definition reachability — a shadowing proc only silences the builtin arity check when its definition lexically precedes the call. Proc-body calls run after load and are not order-gated. Classes / aliases / ensembles / stubs always exist at run time.
- iRules side-switch

https://claude.ai/code/session_01CUtVumXCsUf98n8Wse92L8