### PR TITLE
rust: consolidate rust workstream onto main (pre-ARCH)

### DIFF
--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2674,6 +2674,43 @@ pure-method RHS; (5) the W307 per-SSA-version suppression fix in
 `analyser/diagnostics.rs`.  Classify in-scope, **structural** — a
 multi-strip port.
 
+**Landed (rust) — strips 1, 2, 3, 4a, 4b, 5.**
+- **Strip 1** (`lower TclOO method bodies to Module.methods`): a
+  cache-independent `Lowerer::extract_oo_methods_pass` post-pass walks
+  the assembled module for `oo::class create` / `oo::define` barriers
+  and lifts each `method` / `classmethod` / `constructor` / `destructor`
+  body to `ir::MethodDef`.  `MethodDef` gained `instance_vars` and
+  `Module` gained `redefined_methods`.  A `Lowerer.suppress_proc_register`
+  guard keeps a `proc` defined inside a method body out of
+  `module.procedures` (codegen safety).  **Divergence:** the Rust
+  lowerer evaluates a `namespace eval` body inline and discards it
+  (emitting a `Barrier`, not Python's `IRBlock`), so the post-pass
+  re-segments the barrier's preserved body token to find classes
+  defined directly inside a namespace (`walk_segments_for_oo`).
+- **Strip 2** (`CompilationUnit.methods`): per-method `FunctionUnit`s
+  built via a new `build_cfg_function_with_upvars` (methods stay out of
+  `cfg_module.procedures`); gated on a non-empty method set.
+- **Strip 3** (interproc): `build_method_summaries` populates
+  `InterproceduralAnalysis.methods`; the Rust interproc scans the IR
+  directly, so no pre-built `method_units` are threaded.  `my` / `next`
+  carry no registry trait → `fallback_unknown_write` → unknown-state
+  effect write → impure (same *result* as Python's unknown-call path).
+- **Strip 4a** (RHS-purity gate): the C30d-era
+  `_assignment_safe_to_delete` / `_word_has_observable_side_effect` /
+  `_expr_has_observable_side_effect` guard had **never** been ported —
+  the Rust O109/O126 fired on any dead chain, so `set unused [puts hi]`
+  was deleted with its side effect.  Ported now (with `interproc_pure`
+  for user procs + the SF-2 pure-`my`-dispatch hook), gating both
+  O109 and O126.  This is the gate #506 relies on.
+- **Strip 4b** (method iteration): `elimination::run` iterates
+  `cu.methods` with `enclosing_class`; instance vars are fed through the
+  `cross_event_vars` escaping channel.  `set unused [my pureMethod]`
+  now folds to O126, impure preserved (FP-OPT-12 → FIXED).
+- **Strip 5** (W307 §A): `w307_precise_cmd_values` reads the SCCP value
+  at the dispatch's exact SSA use-version, fixing the merged-set FP on a
+  variable reassigned from a non-command to a command before the
+  dispatch.
+
 ### SYNC-JUN02-2 — Profile-guided branch reordering (PGO) (#515)
 
 A new, opt-in, **off-by-default** `compiler/pgo/` subsystem: an `occurrence`
@@ -2741,7 +2778,7 @@ to the chunk-log entry that has the full spec.
 | — | `SYNC-MAY19-foreachLine-lowering` | Landed 2026-05-19 — single-iterator `Statement::Foreach` lowering in `rust/tcl-compiler/src/lowering/structured.rs::lower_foreach_line`. |
 | — | `SYNC-MAY19-stub-overlay` | **Landed in full** via sub-strips (b) (2026-05-19), (c) (`c945baa`), and (a) (`6487a4f`).  (a) added `rust/tcl-registry/src/stub_overlay.rs` carrying `StubOverlay` + `StubSig` + `StubArg` + `StubSigFlags` (with `arg_indices_for_role` mirroring the registry's shape and a deterministic `fingerprint()` for cache-key plumbing); `StubCommandDef::to_stub_sig` and `build_stub_overlay` glue the analyser-side records to the registry-side overlay; `Analyser::stub_overlay` populates via `build_stub_overlay(&stub_cmds)` after the stub-pre-scan, and `infer_param_traits` / `infer_param_traits_deep` thread the overlay through their internal helpers so role-driven trait inference unions the registry's and the overlay's tables at every call site. |
 | — | `SYNC-MAY19-tail-call-dialect` | Landed 2026-05-19 — `TAILCALL_DIALECTS` / `LASSIGN_DIALECTS` constants in `rust/tcl-compiler/src/optimiser/tail_call.rs`. |
-| 5 | `SYNC-JUN02-1` (TclOO method FunctionUnits) | **New, actionable, self-contained compiler/optimiser work** (#506).  Lower `oo::class create` / `oo::define` method bodies to per-method `FunctionUnit`s so methods get the same dataflow as procs, then summarise method purity into the interproc table and fire O126 on `set unused [my <pure-method>]`.  The Rust `ir::Module.methods` + `MethodDef` + interproc `MethodSummary` types already exist but are **inert placeholders** (lowering never populates them, `CompilationUnit` has no `methods`, the optimiser has no `enclosing_class` iteration) — so the work is real wiring, not new types.  Also carries the W307 per-SSA-version VAR-as-command suppression fix.  Multi-strip; see the `SYNC-JUN02` family section. |
+| — | `SYNC-JUN02-1` (TclOO method FunctionUnits) | **Landed (#506)** — strips 1/2/3/4a/4b/5.  `Lowerer::extract_oo_methods_pass` populates `Module.methods`; `CompilationUnit.methods` builds per-method `FunctionUnit`s; `build_method_summaries` fills `InterproceduralAnalysis.methods`; `elimination::run` iterates method bodies with `enclosing_class` so `set unused [my <pure-method>]` folds to O126 (impure preserved — FP-OPT-12 → FIXED); W307 reads the precise SSA use-version.  Strip 4a additionally ported the C30d `_assignment_safe_to_delete` RHS-purity gate that the Rust O109/O126 had been missing (it had fired on `set unused [puts hi]`).  See the `SYNC-JUN02` family section. |
 | — | `SYNC-JUN02-2` (PGO branch reordering) | **Deferred** (#515).  Opt-in, off-by-default `compiler/pgo/` subsystem emitting hint-only P100 suggestions to reorder side-effect-free equality dispatch chains by profile frequency.  No behavioural change when off, and the profile importers (F5 profiler log / tclsh capture) are tooling-side; the portable slice is the `reorder` analysis + occurrence/profile model.  Listed for tracking. |
 | 6 | `SYNC-MAY19-dialect-contextvar` | LSP server (`S*`) plumbing: thread the per-folder dialect into `LexerConfig` at document-open / change time so multi-folder workspaces with mixed dialects parse correctly.  Pure server-side, no analyser-crate changes.  Closes with `S*`. |
 | — | `SYNC-MAY19-empty-name-proc` | Landed 2026-05-19 — trailing-`::` proc-name → `Statement::Barrier` short-circuit in `rust/tcl-compiler/src/lowering/mod.rs::lower_proc`. |
@@ -2882,16 +2919,22 @@ priority queue:
   coordination with the analyser-flip plan.
 * **`SYNC-JUN02` family** — opened 2026-06-02; advances the anchor from
   `origin/main`@`59c770f6` to `origin/main`@`8aeaf1cd` (+5 commits).
-  Three in-scope rows: `SYNC-JUN02-1` (#506 — lower TclOO method bodies to
-  per-method `FunctionUnit`s + O126 method purity / SF-2 + the W307
-  per-SSA-version VAR-as-command fix; structural, the Rust `Module.methods`
-  / interproc `MethodSummary` scaffolding exists but is inert),
+  Three in-scope rows.  **`SYNC-JUN02-1` (#506) — LANDED** (strips
+  1/2/3/4a/4b/5): TclOO method bodies lower to `Module.methods` +
+  per-method `FunctionUnit`s, interproc summarises method purity, the
+  optimiser fires O126 on `set unused [my <pure-method>]` (impure
+  preserved — FP-OPT-12 → FIXED), and W307 reads the precise SSA
+  use-version.  Strip 4a also closed a pre-existing Rust gap: the C30d
+  RHS-purity gate (`_assignment_safe_to_delete`) had never been ported,
+  so O109/O126 had been deleting side-effecting `set unused [cmd]`.
   `SYNC-JUN02-2` (#515 — opt-in PGO branch-reordering subsystem emitting
-  hint-only P100; structural, deferred), and `SYNC-JUN02-3` (#516's
+  hint-only P100; structural, deferred) and `SYNC-JUN02-3` (#516's
   in-scope slivers — the switch `patterns_braced` IR flag, a correctness
-  gap since `rust/` lacks it, + Tcl 9 registry facts).  Out of scope:
-  #517 / #513 (explorer + optimiser-lens UI) and the WASM-emitter /
-  Zig-runtime bulk of #516.  See the `SYNC-JUN02` family section.
+  gap since `rust/` lacks it, + Tcl 9 registry facts) remain open.
+  **Next actionable, self-contained item: `SYNC-JUN02-3`** (the switch
+  `patterns_braced` flag).  Out of scope: #517 / #513 (explorer +
+  optimiser-lens UI) and the WASM-emitter / Zig-runtime bulk of #516.
+  See the `SYNC-JUN02` family section.
 
 After the queue drains, per-feature LSP server ports (`S*`) build
 on the `tcl-lsp-server` bootstrap.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2939,10 +2939,14 @@ string-length / expr) and the value-position cmd-sub fold path
 (`propagation::visit_call_cmd_subst_folds`) handles **proc calls only**.
 So O129 / O130 / scan / the registry-routed list-lindex all need the
 fold-hints plumbing + the `-1` quoter first.  Per-fold notes:
-- **O115 value-position unwrap** — the helper
-  (`optimiser/helpers/expr_simplify::try_unwrap_expr_in_expr`) exists
-  but only runs on standalone `ExprEval` statements; wiring it into the
-  value / return / branch-cond cmd-sub path is a clean follow-up strip.
+- **O115 value-position unwrap** — **LANDED.**  A redundant double-expr
+  cmd-sub `[expr {[expr {E}]}]` now collapses to `[expr {E}]` in
+  command-argument positions (`propagation::visit_call_cmd_subst_folds`)
+  and `return` positions (`try_fold_return_terminator`), via a shared
+  `o115_redundant_nested_expr` helper that double-unwraps to confirm the
+  inner is itself an `[expr {…}]` (sound — a plain `[expr {$x+1}]` or an
+  `[expr {[other]}]` is left untouched).  `set x [expr {…}]` (lowered to
+  `AssignValue`, not walked for cmd-sub folds) remains a follow-up.
 - **O105 string-constant interpolation** — **already present** in Rust
   (`propagation::visit_string_interpolation`, emitted as O100); only a
   minor `return "…$x…"` completeness gap remains.
@@ -3167,7 +3171,9 @@ priority queue:
   codegen-only, no `TRACED`), **`-4`** (`command_binding` +
   `command_trust` + W128 — no Rust counterpart), **`-6`** (new
   const-folds — no registry `FOLD_HINTS` mechanism in the Rust optimiser
-  yet; O115-value-unwrap is the cleanest follow-up, O105 already present).
+  yet; the O115 value-position unwrap from `-6` is **LANDED** (cmd-arg +
+  `return`), O105 already present, the rest deferred behind `FOLD_HINTS`
+  + the `-1` quoter).
   **N/A** (Rust architecture differs, bug shape absent): `-2`'s call-site
   constant-kill (whole-function SCCP) + O104 guard (Rust O104 is
   hint-only), and **`-7`** (per-use-site DCE; braced-scalar `$=` marker —

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2818,7 +2818,12 @@ verified against Tcl's `list`), so a non-escaping local like `set msg
 `TclConvertElement`) as a shared leaf, then (b) the O100
 single-token-whole-word re-render in the propagation pass.  Classify
 in-scope, **low-touch feature** (the quoter is ~80 LOC; the O100 hook is
-small).  Applicability pending Rust-optimiser-state check.
+small).  **Rust state: deferred** — the O100 bail lives at
+`optimiser/propagation.rs::is_value_safe_bare_word` (the exact
+metacharacter conservatism #519 removes), but the fix needs the
+`tcl_list_quote` leaf, which has **no Rust counterpart**
+(`render_static_string_word` only handles a balanced `{value}`).  Land
+the quoter first (its own row), then the O100 re-render is a one-liner.
 
 ### SYNC-JUN02b-2 — optimiser variable-aliasing & trace soundness fixes (#519)
 
@@ -2836,8 +2841,21 @@ variable, plus a trace bug.  Three fixes:
   no longer collapses writes to an escaping / traced variable.
 Classify in-scope, **soundness** — these patch Rust code that already
 exists (interproc summaries + constant propagation + the elimination /
-pattern passes).  **Highest-value applicable items.**  Applicability +
-exact Rust sites pending the state check.
+pattern passes).  **Rust state:**
+- `writes_global` aliases — **LANDED** (`interprocedural.rs`:
+  `LocalFacts.global_aliases` + `global_alias_names`; `scan_statement`
+  tracks `global` / `variable` / `upvar #0` decls and flags later bare
+  writes to aliased / `::`-qualified names).
+- call-site constant kill — **N/A**: the Rust propagation pass uses a
+  *whole-function* SCCP constant map (a var is constant only if every
+  SSA version agrees), so a callee mutating an outer-scope var the
+  caller thinks constant cannot arise — there is no statement-stepped
+  kill-site logic to patch.  (Becomes relevant only if a stepped
+  propagation lands; tracked under `-6`.)
+- O104 escaping/traced guard — **N/A**: the Rust O104 is **hint-only**
+  (it never collapses the chain to a single `set`), so there is no
+  unsound rewrite to gate.  Re-evaluate if an applicable O104 rewrite
+  lands (then it needs the `-3` observability lattice).
 
 ### SYNC-JUN02b-3 — `var_observability` flow-sensitive escape/trace lattice (#519)
 
@@ -2849,7 +2867,11 @@ union; O104 consults it point-wise.  Classify in-scope, **structural** —
 a multi-strip new subsystem (foundation for flow-sensitive alias/trace
 in memory-SSA + SCCP/GVN).  Defer to its own chunk; the SYNC-JUN02b-2
 soundness fixes are the conservative whole-function approximation that
-this later refines.
+this later refines.  **Rust state: deferred** — Rust *does* have a
+flow-sensitive var-escape analysis (`var_escape/cfg_propagation/`), but
+it answers the *codegen slot-resolution* question (`Local` vs `Frame`),
+has **no `TRACED` flag** and **no `observability` artifact** on
+`FunctionUnit`; this optimiser-soundness lattice is genuinely new.
 
 ### SYNC-JUN02b-4 — `command_binding` lattice + `command_trust` + W128 (#519)
 
@@ -2863,7 +2885,13 @@ never folded with its original semantics.  A new flow-sensitive
 diagnostic **W128** (call to a command renamed/deleted earlier in the
 file) is backed by the same lattice.  Classify in-scope, **structural**
 — a large new subsystem + a new W-code.  Defer to its own chunk(s); the
-WASM/bytecode dispatch-gating half is out of scope.
+WASM/bytecode dispatch-gating half is out of scope.  **Rust state:
+deferred** — **no Rust counterpart** (`alias.rs` tracks `interp alias`
+and the analyser flips `has_dynamic_providers` on `load`/`rename`, but
+there is no per-program-point command-resolution lattice and the Rust
+SCCP / registry folds have **no trust gate** — they unconditionally
+assume builtins keep their semantics, which is the current Rust
+behaviour everywhere).
 
 ### SYNC-JUN02b-5 — string-comparison folding in the constant expr evaluator (#519)
 
@@ -2871,9 +2899,12 @@ WASM/bytecode dispatch-gating half is out of scope.
 operands *as strings* (a dedicated `_apply_string_compare`), matching C
 Tcl 9 (`5 eq 5.0` → 0, `"x" ne "y"` → 1).  Previously only numeric
 evaluation, so string-only constant comparisons never folded.  Classify
-in-scope, **low-touch correctness** — patches the existing Rust
-`tcl_expr_eval` if it has the same numeric-only gap.  Applicability +
-Rust site pending the state check.
+in-scope, **low-touch correctness**.  **Rust state: LANDED** — the Rust
+`tcl_expr_eval::eval_binary` had the identical numeric-only gap
+(`StrEq`/`StrNe`/… fell through to numeric `eval`, so a bare-string
+operand yielded `None`).  Now routed through `eval_as_string` +
+`apply_string_compare`; the now-unreachable `apply_binary` arms fold
+into its `None` group.
 
 ### SYNC-JUN02b-6 — new optimiser const-folds (#519)
 
@@ -2900,11 +2931,28 @@ than fixes:
 - direct-`[expr {$x …}]` constant propagation (the SSA use-collector
   hides expr-cmd-sub reads, so `puts [expr {$x + 1}]` folds via a
   reaching-version augmentation).
-Classify in-scope, **features** — most need the corresponding Rust
-optimiser pass to exist first; each is its own incremental strip.  The
-ones whose Rust pass already exists (e.g. O115 unwrap, list/lindex fold)
-are candidate fixes; the rest are new folds.  Applicability per-fold
-pending the state check.
+Classify in-scope, **features** — each its own incremental strip.
+**Rust state: deferred.**  The Rust optimiser has **no registry
+`const_fold` / `FOLD_HINTS` mechanism** — builtin folding lives only in
+SCCP's hand-rolled `try_fold_cmd_subst` (list / format / llength /
+string-length / expr) and the value-position cmd-sub fold path
+(`propagation::visit_call_cmd_subst_folds`) handles **proc calls only**.
+So O129 / O130 / scan / the registry-routed list-lindex all need the
+fold-hints plumbing + the `-1` quoter first.  Per-fold notes:
+- **O115 value-position unwrap** — the helper
+  (`optimiser/helpers/expr_simplify::try_unwrap_expr_in_expr`) exists
+  but only runs on standalone `ExprEval` statements; wiring it into the
+  value / return / branch-cond cmd-sub path is a clean follow-up strip.
+- **O105 string-constant interpolation** — **already present** in Rust
+  (`propagation::visit_string_interpolation`, emitted as O100); only a
+  minor `return "…$x…"` completeness gap remains.
+- **format flags** — Rust `codegen/helpers::try_format_fold` folds only
+  `%s` / `%d` / `%%` and returns `None` otherwise, so the Python *bug*
+  (dropping flags) does **not** exist (safe but incomplete); porting the
+  full printf-compatible `%` is a completeness upgrade, low urgency.
+- **list / lindex** — `fold_list_cmd` exists; there is **no
+  `fold_lindex`** and no O116 / O118 emission; routing through the
+  registry waits on the fold-hints mechanism.
 
 ### SYNC-JUN02b-7 — per-use-site DCE + braced-scalar SCCP marker (#519)
 
@@ -2916,9 +2964,16 @@ pending the state check.
 - **braced-scalar `${name}` SCCP marker** — `set x ${a(1)}` reads scalar
   `a(1)`; the reconstructed `$={name}` marker text must be treated as a
   (conservatively overdefined) variable reference, not folded as a
-  literal.  Classify in-scope, low-touch — applies only if the Rust SCCP
-  reconstructs the same marker.
-Applicability pending the state check.
+  literal.  Classify in-scope, low-touch.
+**Rust state: both N/A.**
+- per-use-site DCE — the Rust DCE (`elimination.rs`, O109 / O126) works
+  off `def_use` chains + SCCP purity, not the Python propagation→liveness
+  handshake (`propagated_expr_stmts`); the diamond-DCE bug shape this
+  fixes does not exist in the Rust architecture.
+- braced-scalar marker — Rust has **no `$=` marker** (grep-empty) and
+  does **not** mis-fold the braced scalar: a probe confirms `set x
+  ${a(1)}; return $x` produces *no* O100 / O102 / O103 fold on `x` (it is
+  treated as a var-read → overdefined), so there is nothing to patch.
 
 ## Next-up priority queue
 
@@ -3101,17 +3156,25 @@ priority queue:
   section.
 * **`SYNC-JUN02b` family** — opened 2026-06-02; advances the anchor from
   `origin/main`@`8aeaf1cd` to `origin/main`@`31d3aac8` (+1 commit, the
-  #519 optimiser mega-PR).  Seven in-scope rows: **`-2`** (alias/trace
-  soundness fixes — highest-value, patch existing Rust optimiser/interproc),
-  **`-5`** (string-comparison folding in expr-eval — low-touch),
-  **`-7`** (per-use-site DCE + braced-scalar SCCP marker), **`-1`** (O100
-  multi-word constant + canonical quoter), **`-6`** (new const-folds:
-  O129/O130/O105/O115/format/scan/list-lindex — mostly new features),
-  and the two **structural** lattices **`-3`** (`var_observability`) /
-  **`-4`** (`command_binding` + `command_trust` + W128) deferred to their
-  own chunks.  Out of scope: the WASM/bytecode dispatch-gating +
-  canonical-quoting migration and the `shared/tcl_list` Python
-  consolidation.  See the `SYNC-JUN02b` family section.
+  #519 optimiser mega-PR).  Seven in-scope rows.  **Applied now** (the
+  two clean soundness/correctness fixes to existing Rust):
+  **`-5` — LANDED** (string comparisons `eq`/`ne`/`lt`/`gt`/`le`/`ge`
+  fold as strings in `tcl_expr_eval`) and **`-2` — LANDED** (interproc
+  `writes_global` recognises `global`/`variable`/`upvar #0` aliases).
+  **Deferred** (large new subsystems / missing mechanisms): **`-1`** (O100
+  multi-word constant — needs a `tcl_list_quote` leaf), **`-3`**
+  (`var_observability` optimiser lattice — Rust's `var_escape` is
+  codegen-only, no `TRACED`), **`-4`** (`command_binding` +
+  `command_trust` + W128 — no Rust counterpart), **`-6`** (new
+  const-folds — no registry `FOLD_HINTS` mechanism in the Rust optimiser
+  yet; O115-value-unwrap is the cleanest follow-up, O105 already present).
+  **N/A** (Rust architecture differs, bug shape absent): `-2`'s call-site
+  constant-kill (whole-function SCCP) + O104 guard (Rust O104 is
+  hint-only), and **`-7`** (per-use-site DCE; braced-scalar `$=` marker —
+  Rust has none and doesn't mis-fold `${a(1)}`, probe-confirmed).  Out of
+  scope: the WASM/bytecode dispatch-gating + canonical-quoting migration
+  and the `shared/tcl_list` Python consolidation.  See the `SYNC-JUN02b`
+  family section.
 
 After the queue drains, per-feature LSP server ports (`S*`) build
 on the `tcl-lsp-server` bootstrap.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2776,6 +2776,150 @@ The WASM / Zig bulk of #516 is out of scope (above), but two pieces are not:
   arg-roles / dialect).  Fold into the `SYNC-MAY19-tcl9-commands` +
   Command-spec tracking rows when those commands are next touched.
 
+## SYNC-JUN02b family — main audit (2026-06-02, PR #519)
+
+Re-audited `origin/main`@`31d3aac8` against the prior anchor
+`origin/main`@`8aeaf1cd`.  `main` landed **1** commit — but #519 is a
+mega-PR (101 files, +4780/-1711) bundling ~17 distinct sub-changes
+across the optimiser, interproc, SCCP / expr-eval, two new
+flow-sensitive lattices, a new diagnostic, and the WASM / bytecode
+backends.  Histories still diverge fully (no merge-base) — per-file
+audit.
+
+Out of scope (no Rust mirror — record and skip):
+
+- **WASM codegen** rename-gating + canonical-quoting migration
+  (`compiler/codegen/wasm/*`) and the **bytecode backend** quoting
+  migration (`compiler/codegen/bytecode/*`) — the Rust port emits
+  neither.
+- **Zig VM** list/escape consolidation (`tooling/vm/*`), the minifier,
+  and the iRule-test bridge.
+- **`shared/tcl_list.py` + `shared/tcl_subst.py` consolidation** — a
+  Python DRY refactor collapsing ~13 duplicate list/quote/backslash
+  re-implementations into one canonical home.  The Rust side already
+  owns its quoting in `tcl-lexer` / `segmenter`, so the consolidation
+  itself is Python-internal.  *But* the canonical quoter
+  (`tcl_list_quote`, a `TclScanElement` / `TclConvertElement` port) is a
+  prerequisite for the O100 Rust port — see `SYNC-JUN02b-1`.
+- `editors/*` catalogues, `samples/*`, `tests/*`, `.test-slow.stamp`,
+  `.importlinter`.
+
+In-scope rows:
+
+### SYNC-JUN02b-1 — O100 multi-word string-constant propagation + canonical quoter (#519)
+
+`main`'s O100 (`optimise_constant_var_refs`) used to bail whenever a
+constant value contained Tcl metacharacters (whitespace / `$` / `[` /
+`\`).  #519 re-renders the constant as a single self-contained word via
+the canonical `tcl_list_quote` (bare / brace-quoted / backslash-escaped,
+verified against Tcl's `list`), so a non-escaping local like `set msg
+{Hello World}; return $msg` collapses to `return {Hello World}`.
+**Rust:** needs (a) a `tcl_list_quote` port (`TclScanElement` /
+`TclConvertElement`) as a shared leaf, then (b) the O100
+single-token-whole-word re-render in the propagation pass.  Classify
+in-scope, **low-touch feature** (the quoter is ~80 LOC; the O100 hook is
+small).  Applicability pending Rust-optimiser-state check.
+
+### SYNC-JUN02b-2 — optimiser variable-aliasing & trace soundness fixes (#519)
+
+Differential fuzzing surfaced correctness bugs where the optimiser
+propagated a stale constant past a call that mutates an outer-scope
+variable, plus a trace bug.  Three fixes:
+- `interprocedural.py` — `writes_global` now recognises writes through a
+  `global` / `variable` / `upvar #0` *alias* (not just literal
+  `::`-qualified names), via the `var_scoping` grammar.
+- `optimiser/_manager.py` — a call whose callee writes a global, or
+  whose effects are unbounded (`uplevel` / `eval` barrier / unknown
+  call), kills the caller's constant knowledge of every outer-scope
+  variable at the call site.
+- `optimiser/_pattern_recognition.py` — O104 string-build-chain folding
+  no longer collapses writes to an escaping / traced variable.
+Classify in-scope, **soundness** — these patch Rust code that already
+exists (interproc summaries + constant propagation + the elimination /
+pattern passes).  **Highest-value applicable items.**  Applicability +
+exact Rust sites pending the state check.
+
+### SYNC-JUN02b-3 — `var_observability` flow-sensitive escape/trace lattice (#519)
+
+New `compiler/var_observability.py`: a forward data-flow `EscapeFlag`
+lattice (GLOBAL / NAMESPACE / UPVAR aliasing + TRACED) per variable per
+program point.  `FunctionAnalysis.observability` carries it; the
+flow-insensitive `_escaping_var_names` is rewritten as its whole-function
+union; O104 consults it point-wise.  Classify in-scope, **structural** —
+a multi-strip new subsystem (foundation for flow-sensitive alias/trace
+in memory-SSA + SCCP/GVN).  Defer to its own chunk; the SYNC-JUN02b-2
+soundness fixes are the conservative whole-function approximation that
+this later refines.
+
+### SYNC-JUN02b-4 — `command_binding` lattice + `command_trust` + W128 (#519)
+
+New `compiler/command_binding.py`: a forward data-flow lattice tracking
+what each command name resolves to (BUILTIN / PROC / ALIAS / OPAQUE /
+UNKNOWN) at every program point, modelling `rename` / proc-redefinition
+/ `interp alias` flow-sensitively.  `command_trust.py` derives a
+scoped builtin-trust verdict; the optimiser gates every const-fold /
+proc-fold / incr-idiom on `builtin_is_trusted` so a rebound command is
+never folded with its original semantics.  A new flow-sensitive
+diagnostic **W128** (call to a command renamed/deleted earlier in the
+file) is backed by the same lattice.  Classify in-scope, **structural**
+— a large new subsystem + a new W-code.  Defer to its own chunk(s); the
+WASM/bytecode dispatch-gating half is out of scope.
+
+### SYNC-JUN02b-5 — string-comparison folding in the constant expr evaluator (#519)
+
+`tcl_expr_eval.py` — `eq` / `ne` / `lt` / `gt` / `le` / `ge` now compare
+operands *as strings* (a dedicated `_apply_string_compare`), matching C
+Tcl 9 (`5 eq 5.0` → 0, `"x" ne "y"` → 1).  Previously only numeric
+evaluation, so string-only constant comparisons never folded.  Classify
+in-scope, **low-touch correctness** — patches the existing Rust
+`tcl_expr_eval` if it has the same numeric-only gap.  Applicability +
+Rust site pending the state check.
+
+### SYNC-JUN02b-6 — new optimiser const-folds (#519)
+
+A family of missed-optimisation closures, mostly **new folds** rather
+than fixes:
+- **O129** — general fold of any pure builtin command substitution with
+  constant args via the registry `const_fold` callbacks (`string
+  length`, `join`, `format`, `llength`, `dict get`, `concat`, `split`,
+  `string map`, …).
+- **format folding fix** — `fold_format` honours flags / width /
+  precision (`%03d 7` → `007`); `fold_cmd_subst_to_string` keeps the
+  exact string (no numeric coercion that drops a leading space).
+- **O130** — `lappend` list-build chains fold to a single `set var {…}`
+  (canonical list quoting), guarded by the same escaping/observability
+  check as O104.
+- **scan** `const_fold` for the inline (no-varName) form.
+- **list / lindex** folding routed through the registry (O116 / O118 /
+  O129) — drops the hand-rolled single-element-only folders, picking up
+  multi-element + special-char cases.
+- **O105** — string-constant interpolation (`set x hello; puts "v=$x"` →
+  `puts "v=hello"`), same-block + no-intervening-call gate.
+- **O115** — unwrap redundant nested `[expr {[expr {E}]}]` in value
+  positions (return / set), not just EXPR-role args.
+- direct-`[expr {$x …}]` constant propagation (the SSA use-collector
+  hides expr-cmd-sub reads, so `puts [expr {$x + 1}]` folds via a
+  reaching-version augmentation).
+Classify in-scope, **features** — most need the corresponding Rust
+optimiser pass to exist first; each is its own incremental strip.  The
+ones whose Rust pass already exists (e.g. O115 unwrap, list/lindex fold)
+are candidate fixes; the rest are new folds.  Applicability per-fold
+pending the state check.
+
+### SYNC-JUN02b-7 — per-use-site DCE + braced-scalar SCCP marker (#519)
+
+- **per-use-site DCE** — DCE tracked consumed reads per *statement*, so
+  folding one var on a line wrongly suppressed liveness of the line's
+  other vars (diamond dead-store bug).  Now keyed per use-site
+  (block / idx / name / version).  Classify in-scope, **soundness** —
+  patches the Rust DCE if it shares the per-statement tracking.
+- **braced-scalar `${name}` SCCP marker** — `set x ${a(1)}` reads scalar
+  `a(1)`; the reconstructed `$={name}` marker text must be treated as a
+  (conservatively overdefined) variable reference, not folded as a
+  literal.  Classify in-scope, low-touch — applies only if the Rust SCCP
+  reconstructs the same marker.
+Applicability pending the state check.
+
 ## Next-up priority queue
 
 When a contributor sits down to pick up the next chunk, work
@@ -2955,6 +3099,19 @@ priority queue:
   of scope: #517 / #513 (explorer + optimiser-lens UI) and the
   WASM-emitter / Zig-runtime bulk of #516.  See the `SYNC-JUN02` family
   section.
+* **`SYNC-JUN02b` family** — opened 2026-06-02; advances the anchor from
+  `origin/main`@`8aeaf1cd` to `origin/main`@`31d3aac8` (+1 commit, the
+  #519 optimiser mega-PR).  Seven in-scope rows: **`-2`** (alias/trace
+  soundness fixes — highest-value, patch existing Rust optimiser/interproc),
+  **`-5`** (string-comparison folding in expr-eval — low-touch),
+  **`-7`** (per-use-site DCE + braced-scalar SCCP marker), **`-1`** (O100
+  multi-word constant + canonical quoter), **`-6`** (new const-folds:
+  O129/O130/O105/O115/format/scan/list-lindex — mostly new features),
+  and the two **structural** lattices **`-3`** (`var_observability`) /
+  **`-4`** (`command_binding` + `command_trust` + W128) deferred to their
+  own chunks.  Out of scope: the WASM/bytecode dispatch-gating +
+  canonical-quoting migration and the `shared/tcl_list` Python
+  consolidation.  See the `SYNC-JUN02b` family section.
 
 After the queue drains, per-feature LSP server ports (`S*`) build
 on the `tcl-lsp-server` bootstrap.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -2750,7 +2750,13 @@ The WASM / Zig bulk of #516 is out of scope (above), but two pieces are not:
   substitution semantics.  Add the flag to `tcl-compiler::ir::Statement::Switch`,
   set it in `lowering` (braced-body form → `true`; separate-words form →
   `false`), and thread it where switch patterns are interpreted.  Classify
-  in-scope, low-touch, **correctness**.
+  in-scope, low-touch, **correctness**.  **Landed (rust):**
+  `Statement::Switch.patterns_braced` added; `lower_switch` sets it
+  (single-braced branch → `true`, separate-words branch → `false`).  No
+  consumer threading was needed — every Rust pass matches `Switch` with
+  `..` or mutates arm bodies in place (none reconstruct), so the flag is
+  preserved automatically; the WASM-codegen consumers that read it in
+  `main` are out of scope.
 - **Tcl 9 command-spec facts (registry — low-touch).**  The new / extended
   Tcl 9 surfaces (`lseq`, `scan` charset/float, `binary` unsigned formats,
   `apply` defaults) want matching `tcl-registry` command-spec facts (arity /
@@ -2927,14 +2933,15 @@ priority queue:
   use-version.  Strip 4a also closed a pre-existing Rust gap: the C30d
   RHS-purity gate (`_assignment_safe_to_delete`) had never been ported,
   so O109/O126 had been deleting side-effecting `set unused [cmd]`.
-  `SYNC-JUN02-2` (#515 — opt-in PGO branch-reordering subsystem emitting
-  hint-only P100; structural, deferred) and `SYNC-JUN02-3` (#516's
-  in-scope slivers — the switch `patterns_braced` IR flag, a correctness
-  gap since `rust/` lacks it, + Tcl 9 registry facts) remain open.
-  **Next actionable, self-contained item: `SYNC-JUN02-3`** (the switch
-  `patterns_braced` flag).  Out of scope: #517 / #513 (explorer +
-  optimiser-lens UI) and the WASM-emitter / Zig-runtime bulk of #516.
-  See the `SYNC-JUN02` family section.
+  `SYNC-JUN02-3`'s switch `patterns_braced` IR flag is **also landed**
+  (`Statement::Switch.patterns_braced`, set in `lower_switch`); its Tcl 9
+  registry-fact half stays folded into `SYNC-MAY19-tcl9-commands` (touch
+  when those commands are next worked).  `SYNC-JUN02-2` (#515 — opt-in
+  PGO branch-reordering subsystem emitting hint-only P100; structural)
+  remains **deferred** (off-by-default, importers are tooling-side).  Out
+  of scope: #517 / #513 (explorer + optimiser-lens UI) and the
+  WASM-emitter / Zig-runtime bulk of #516.  See the `SYNC-JUN02` family
+  section.
 
 After the queue drains, per-feature LSP server ports (`S*`) build
 on the `tcl-lsp-server` bootstrap.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1966,6 +1966,14 @@ structural sub-chunks:
   `_literal_type` matches `0x...` / `0b...` patterns as INT (matches
   Tcl 9's `Tcl_GetIntFromObj` semantics).  Avoids spurious S101 on
   `variable n 0x80; for {…} {…} {incr n}` (tcllib idna idiom).
+  **Landed (rust):** matched `main`'s actual shape — `0x80` still types
+  as `String` (Rust `literal_type` uses `i64::from_str`, which rejects
+  hex, same as Python's `_literal_type`), so the fix is the
+  `value_is_int_literal_string` SCCP-value guard in
+  `shimmer::use_site`: the `incr` S100/S101 detector now threads
+  `fu.sccp.values` and skips the warning when the variable's CONST
+  value is a hex/oct/bin integer-literal string (mirrors
+  `_value_is_int_literal_string`, not a `_literal_type` change).
 
 Classify all of `-1e`: in-scope, low-touch each (5-50 LOC + tests);
 no structural / dependency blockers.  Suitable for PR-sized

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1944,7 +1944,12 @@ structural sub-chunks:
 - **O106 LICM purity recursion into command substitutions.**  Extend
   `gvn::is_pure_command` to lex its `args` for nested `[…]` tokens
   and verify each is also pure — an outer pure call wrapping
-  `[incr counter]` is not loop-invariant.
+  `[incr counter]` is not loop-invariant.  **Landed (rust):**
+  `is_pure_command` and `is_pure_with_procs_core` now recurse into
+  `scan_bracketed_commands(arg)` (shared `arg_substitutions_pure`
+  helper) and reject any invocation with an impure nested subst;
+  `is_pure_command_with_traces` inherits it via its `is_pure_command`
+  delegation.
 - **S100 / S101 shimmer loop-invariance lattice.**  Walk loop blocks
   once and collect every variable name ever defined; classify
   loop-invariant uses (name *not* in the set) as S100 (one-time),

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -3238,7 +3238,6 @@ before this value so it is treated as data, not an option."
         cu: &crate::compilation_unit::CompilationUnit,
         registry: &tcl_registry::CommandRegistry,
     ) {
-        use crate::analyses::{ConstValue, LatticeValue};
         use crate::types::TypeKind;
         use std::collections::HashMap;
 
@@ -3297,18 +3296,9 @@ before this value so it is treated as data, not an option."
                             out: &mut HashMap<String, HashSet<String>>| {
             for (key, lv) in &sccp.values {
                 let (var_name, _ver) = key;
-                let values: Option<Vec<String>> = match lv {
-                    LatticeValue::Const(ConstValue::String(s)) => Some(vec![s.clone()]),
-                    LatticeValue::ConstSet(set) => set
-                        .iter()
-                        .map(|cv| match cv {
-                            ConstValue::String(s) => Some(s.clone()),
-                            _ => None,
-                        })
-                        .collect::<Option<Vec<_>>>(),
-                    _ => None,
+                let Some(values) = lattice_command_values(lv) else {
+                    continue;
                 };
-                let Some(values) = values else { continue };
                 let entry = out.entry(var_name.clone()).or_default();
                 for v in values {
                     entry.insert(v);
@@ -3345,6 +3335,25 @@ before this value so it is treated as data, not an option."
                 || known_class_tails.contains(v)
                 || self.result.all_classes.contains_key(&format!("::{v}"))
         };
+
+        // Per-SSA-version refinement (post-stage2 §A): map each
+        // function to its source range + FunctionUnit so the W307
+        // suppression can read the value at the dispatch's *exact* SSA
+        // use-version instead of the merged set.  ``::top`` covers the
+        // whole source; a proc's narrower range wins where it contains
+        // the offset.  Mirrors Python's ``_func_ranges`` /
+        // ``_all_fus_named`` (methods are ``in_method``-suppressed, so
+        // — like Python's loop — they are left out).
+        let mut func_ranges: Vec<(String, u32, u32)> = vec![("::top".to_string(), 0, u32::MAX)];
+        let mut fu_by_qname: HashMap<String, &crate::compilation_unit::FunctionUnit> =
+            HashMap::new();
+        fu_by_qname.insert("::top".to_string(), &cu.top_level);
+        for (qname, fu) in &cu.procedures {
+            fu_by_qname.insert(qname.clone(), fu);
+            if let Some(ir_proc) = cu.ir_module.procedures.get(qname) {
+                func_ranges.push((qname.clone(), ir_proc.span.start(), ir_proc.span.end()));
+            }
+        }
 
         // Drain sites so we can borrow self.result mutably below.
         let sites = std::mem::take(&mut self.var_command_sites);
@@ -3442,7 +3451,21 @@ before this value so it is treated as data, not an option."
             if site.in_method {
                 continue;
             }
-            if let Some(values) = all_constsets.get(&site.var_name) {
+            // Prefer the value at the dispatch's exact SSA use-version;
+            // fall back to the merged constset when no precise version
+            // is found. This drops the merged-set false positive on a
+            // variable reassigned from a non-command to a known command
+            // before the dispatch (`set c x; set c puts; $c ...`).
+            let precise = w307_precise_cmd_values(
+                &func_ranges,
+                &fu_by_qname,
+                site.cmd_span.start(),
+                &site.var_name,
+            );
+            let effective = precise
+                .as_ref()
+                .or_else(|| all_constsets.get(&site.var_name));
+            if let Some(values) = effective {
                 if !values.is_empty() && values.iter().all(|v| is_known_command(v)) {
                     continue;
                 }
@@ -4150,6 +4173,89 @@ fn walk_dialect_invalid_ops(
         }
         _ => {}
     }
+}
+
+/// Expand a CONST / CONSTSET lattice value into the flat set of its
+/// string values, or `None` for any non-string-constant lattice state.
+/// Mirrors Python's `_lattice_to_set` as consumed by the W307 emitter.
+fn lattice_command_values(lv: &crate::analyses::LatticeValue) -> Option<Vec<String>> {
+    use crate::analyses::{ConstValue, LatticeValue};
+    match lv {
+        LatticeValue::Const(ConstValue::String(s)) => Some(vec![s.clone()]),
+        LatticeValue::ConstSet(set) => set
+            .iter()
+            .map(|cv| match cv {
+                ConstValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>(),
+        _ => None,
+    }
+}
+
+/// The SCCP value set of `var_name` at the SSA use-version that reaches
+/// the dispatch statement at `offset` (W307 per-SSA-version refinement).
+///
+/// The merged `all_constsets` map unions every version of a variable,
+/// so `set c notacommand; set c parse; $c x` wrongly keeps
+/// `notacommand` in the set even though only the `parse` version
+/// reaches the dispatch. Reading the value at the use site's exact
+/// version removes that false positive.
+///
+/// Purely additive: returns a set only when a CFG statement containing
+/// `offset` that *uses* `var_name` is found and its version has a
+/// concrete CONST / CONSTSET value — otherwise `None`, and the caller
+/// falls back to the merged-set logic. Never broadens a fire into a
+/// suppression unsoundly — the value is the exact one flowing into the
+/// dispatch. Mirrors Python's `_precise_cmd_values`.
+fn w307_precise_cmd_values(
+    func_ranges: &[(String, u32, u32)],
+    fu_by_qname: &std::collections::HashMap<String, &crate::compilation_unit::FunctionUnit>,
+    offset: u32,
+    var_name: &str,
+) -> Option<HashSet<String>> {
+    // Narrowest function range containing `offset` (mirrors the
+    // scoping `_constsets_for_offset` uses).
+    let mut best: Option<(u32, &str)> = None;
+    for (qname, start, end) in func_ranges {
+        if *start <= offset && offset <= *end {
+            let width = end - start;
+            if best.map_or(true, |(bw, _)| width < bw) {
+                best = Some((width, qname.as_str()));
+            }
+        }
+    }
+    let fu = fu_by_qname.get(best?.1)?;
+
+    // Narrowest CFG statement containing `offset` that uses `var_name`,
+    // reading its SSA use-version (CFG / SSA blocks are parallel-indexed).
+    let mut best_width: Option<u32> = None;
+    let mut best_version: Option<u32> = None;
+    for (block_name, block) in &fu.cfg.blocks {
+        let Some(ssa_block) = fu.ssa.blocks.get(block_name) else {
+            continue;
+        };
+        for (idx, stmt) in block.statements.iter().enumerate() {
+            let span = stmt.span();
+            if !(span.start() <= offset && offset <= span.end()) {
+                continue;
+            }
+            let Some(ssa_stmt) = ssa_block.statements.get(idx) else {
+                continue;
+            };
+            let Some(version) = ssa_stmt.uses.get(var_name) else {
+                continue;
+            };
+            let width = span.end() - span.start();
+            if best_width.map_or(true, |bw| width < bw) {
+                best_width = Some(width);
+                best_version = Some(*version);
+            }
+        }
+    }
+    let version = best_version?;
+    let lv = fu.sccp.values.get(&(var_name.to_string(), version))?;
+    Some(lattice_command_values(lv)?.into_iter().collect())
 }
 
 #[cfg(test)]
@@ -5774,6 +5880,44 @@ foo
         assert!(
             w307s.is_empty(),
             "W307 must be suppressed when var holds known command name; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn analyse_w307_suppressed_per_ssa_version_after_reassignment() {
+        // Per-SSA-version refinement (SYNC-JUN02-1 strip 5): `cmd` is
+        // reassigned from a non-command to a known command before the
+        // dispatch.  The merged const-set {notacommand, puts} would
+        // wrongly keep W307 alive; reading the value at the dispatch's
+        // exact SSA use-version ("puts") suppresses it.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc foo {} { set cmd notacommand\nset cmd puts\n$cmd hello }",
+            "tcl",
+        );
+        let w307s: Vec<_> = r.diagnostics.iter().filter(|d| d.code == "W307").collect();
+        assert!(
+            w307s.is_empty(),
+            "W307 must read the precise reaching version (\"puts\"); got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn analyse_w307_still_fires_when_precise_version_not_a_command() {
+        // The mirror case: the reaching version is a non-command, so
+        // W307 must still fire (the refinement only suppresses when the
+        // exact value is provably a known command).
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc foo {} { set cmd puts\nset cmd notacommand\n$cmd hello }",
+            "tcl",
+        );
+        let w307s: Vec<_> = r.diagnostics.iter().filter(|d| d.code == "W307").collect();
+        assert!(
+            !w307s.is_empty(),
+            "W307 should fire when the reaching version isn't a command; got {:?}",
             r.diagnostics,
         );
     }

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -672,6 +672,7 @@ mod tests {
             mode: SwitchMode::Exact,
             nocase: false,
             raw_args: vec![],
+            patterns_braced: true,
         }]);
 
         let func = build_cfg_function("::test", &script, true);
@@ -709,6 +710,7 @@ mod tests {
             mode,
             nocase: false,
             raw_args: vec!["$x".into(), "a*".into(), "{puts $y}".into()],
+            patterns_braced: true,
         }])
     }
 

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -659,6 +659,29 @@ pub fn build_cfg_function(name: &str, script: &Script, inline_loops: bool) -> Fu
     builder.build_function(name, script)
 }
 
+/// Build a CFG for a single script body with an explicit upvar
+/// context (from [`prepare_cfg_context`]). Used for `TclOO` method
+/// bodies (SF-2), which are lowered to their own [`Function`]s
+/// outside [`build_cfg`] (methods are deliberately excluded from
+/// [`CfgModule::procedures`] — codegen never emits them) but still
+/// need the same call-site def invalidation as procs. Mirrors
+/// Python's `build_cfg_function(..., upvar_procs=, proc_params=)`.
+///
+/// The maps come straight from [`prepare_cfg_context`] (default
+/// hasher), so the signature isn't generalised over `BuildHasher`.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn build_cfg_function_with_upvars(
+    name: &str,
+    script: &Script,
+    inline_loops: bool,
+    upvar_procs: HashMap<String, UpvarInfo>,
+    proc_params: HashMap<String, Vec<String>>,
+) -> Function {
+    let mut builder = CfgBuilder::new_with_upvars(inline_loops, upvar_procs, proc_params);
+    builder.build_function(name, script)
+}
+
 /// Deduplicate a `Vec` while preserving first-occurrence order.
 fn dedup_preserve_order(v: &mut Vec<String>) {
     let mut seen = std::collections::HashSet::new();

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -158,6 +158,13 @@ pub struct CompilationUnit {
     pub top_level: FunctionUnit,
     /// Per-procedure analyses keyed by qualified name.
     pub procedures: HashMap<String, FunctionUnit>,
+    /// `TclOO` method bodies lowered to per-method [`FunctionUnit`]s
+    /// (SF-2). Keyed by `{class_qname}::{method_name}`; empty for
+    /// non-OO sources. Kept separate from [`Self::procedures`] so the
+    /// per-proc diagnostic passes are unaffected — only the optimiser's
+    /// O126 gate iterates these. Mirrors Python's
+    /// `CompilationUnit.methods`.
+    pub methods: HashMap<String, FunctionUnit>,
     /// Interprocedural summary (optional — populated when the
     /// interprocedural pass has been run).
     pub interproc: Option<InterproceduralAnalysis>,
@@ -204,6 +211,36 @@ impl CompilationUnit {
                 FunctionUnit::build(qname, cfg.clone(), params, registry),
             );
         }
+        // SF-2: lower TclOO method bodies (populated in
+        // `ir_module.methods` by lowering) to per-method
+        // `FunctionUnit`s, using the same CFG → SSA → analysis
+        // pipeline as procs. Kept in a separate map so the per-proc
+        // diagnostic passes (which iterate `procedures`) are
+        // unaffected — only the interproc purity summary and the O126
+        // optimiser gate consume methods. Gated on a non-empty method
+        // set so non-OO sources skip the upvar-context scan entirely.
+        let methods: HashMap<String, FunctionUnit> = if ir_module.methods.is_empty() {
+            HashMap::new()
+        } else {
+            let (upvar_procs, proc_params) = crate::cfg_builder::prepare_cfg_context(&ir_module);
+            ir_module
+                .methods
+                .iter()
+                .map(|(mqname, method)| {
+                    let cfg = crate::cfg_builder::build_cfg_function_with_upvars(
+                        mqname,
+                        &method.body,
+                        true,
+                        upvar_procs.clone(),
+                        proc_params.clone(),
+                    );
+                    (
+                        mqname.clone(),
+                        FunctionUnit::build(mqname, cfg, &method.params, registry),
+                    )
+                })
+                .collect()
+        };
         // **C41d7.** Build the cross-event scope from the
         // ``::when::*`` subset of procedures.  ``None`` when no
         // ``when`` block is present so non-iRules consumers
@@ -226,6 +263,7 @@ impl CompilationUnit {
             cfg_module,
             top_level,
             procedures,
+            methods,
             interproc: None,
             connection_scope,
         }
@@ -343,6 +381,39 @@ mod tests {
         assert!(!cu.procedures.is_empty());
         assert!(cu.function("::greet").is_some());
         assert!(cu.function("::top").is_some());
+        // No OO methods in a plain proc source.
+        assert!(cu.methods.is_empty());
+    }
+
+    #[test]
+    fn build_for_lowers_oo_methods_to_function_units() {
+        // SF-2 (SYNC-JUN02-1): TclOO method bodies get their own
+        // FunctionUnit (CFG → SSA → analysis) in `cu.methods`, kept
+        // separate from `procedures` so the optimiser's O126 gate can
+        // iterate them. `procedures` stays free of method qnames.
+        let src = "oo::class create Counter {\n\
+                   \x20   variable n\n\
+                   \x20   method bump {} { incr n }\n\
+                   \x20   method get {} { return $n }\n\
+                   }\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let mut keys: Vec<&String> = cu.methods.keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                &"::Counter::bump".to_string(),
+                &"::Counter::get".to_string()
+            ],
+            "method units: {keys:?}",
+        );
+        // Each method unit carries a real analysis pipeline (its CFG
+        // has the entry block at minimum).
+        let get = &cu.methods["::Counter::get"];
+        assert_eq!(get.name, "::Counter::get");
+        assert!(!get.cfg.blocks.is_empty());
+        // Methods are NOT mixed into the per-proc map.
+        assert!(!cu.procedures.contains_key("::Counter::get"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -216,6 +216,7 @@ pub fn run_all_checks(
             &fu.types,
             &fu.sccp.executable_blocks,
             registry,
+            &fu.sccp.values,
         ) {
             out.push(Diagnostic::from_shimmer(&w));
         }

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -526,22 +526,20 @@ fn is_pure_with_procs_core(
     args: &[String],
     dialect: Option<&str>,
 ) -> bool {
-    if pure.contains(cmd) {
-        return true;
-    }
-    // Try the common `::` prefix form too — some lowerings yield
-    // fully-qualified command words.
-    if let Some(stripped) = cmd.strip_prefix("::") {
-        if pure.contains(stripped) {
-            return true;
+    let outer_pure = pure.contains(cmd)
+        // Try the common `::` prefix form too — some lowerings yield
+        // fully-qualified command words.
+        || match cmd.strip_prefix("::") {
+            Some(stripped) => pure.contains(stripped),
+            None => pure.contains(&format!("::{cmd}")),
         }
-    } else {
-        let prefixed = format!("::{cmd}");
-        if pure.contains(&prefixed) {
-            return true;
-        }
-    }
-    classify_side_effects(registry, cmd, args, dialect, None).pure
+        || classify_side_effects(registry, cmd, args, dialect, None).pure;
+    // O106: an outer-pure command whose args read from an impure inner
+    // substitution is not loop-invariant — recurse into nested `[…]`.
+    outer_pure
+        && arg_substitutions_pure(args, |c, a| {
+            is_pure_with_procs_core(registry, pure, c, a, dialect)
+        })
 }
 
 /// Purity predicate for GVN that consults the intra-module
@@ -599,8 +597,29 @@ pub fn is_pure_command(
     args: &[String],
     dialect: Option<&str>,
 ) -> bool {
-    let effect = classify_side_effects(registry, command, args, dialect, None);
-    effect.pure
+    if !classify_side_effects(registry, command, args, dialect, None).pure {
+        return false;
+    }
+    // O106 (SYNC-MAY31-1e): an outer pure command whose args read from
+    // an impure command substitution is NOT loop-invariant — its value
+    // depends on the inner side effect's per-call return (e.g.
+    // `expr [incr counter]`). Recurse into every nested `[…]` and
+    // require each to be pure too. Mirrors `gvn.py::_is_pure_command`.
+    arg_substitutions_pure(args, |c, a| is_pure_command(registry, c, a, dialect))
+}
+
+/// Scan `args` for embedded `[cmd …]` command substitutions and return
+/// `true` iff every nested command satisfies `check`. Braced regions
+/// are skipped (no substitution inside `{…}`). Shared by the purity
+/// gates so an outer pure command wrapping an impure inner subst is
+/// rejected as loop-invariant (O106).
+fn arg_substitutions_pure(args: &[String], check: impl Fn(&str, &[String]) -> bool) -> bool {
+    args.iter().all(|arg| {
+        !arg.contains('[')
+            || scan_bracketed_commands(arg)
+                .iter()
+                .all(|(cmd, inner)| check(cmd, inner))
+    })
 }
 
 /// SYNC8: trace-aware purity gate.
@@ -1754,6 +1773,29 @@ mod tests {
             &["x".into(), "1".into()],
             None
         ));
+    }
+
+    #[test]
+    fn is_pure_command_recurses_into_impure_substitution() {
+        // O106 (SYNC-MAY31-1e): `expr` is pure, but an arg that embeds
+        // an impure `[incr c]` substitution makes the whole invocation
+        // impure — its value depends on the per-call side effect, so it
+        // must not be hoisted as loop-invariant.
+        let registry = CommandRegistry::build_default();
+        assert!(
+            !is_pure_command(&registry, "expr", &["[incr c]".into()], None),
+            "outer pure `expr` wrapping impure `[incr c]` must be impure",
+        );
+        // A pure nested substitution keeps the outer call pure.
+        assert!(
+            is_pure_command(&registry, "expr", &["[expr {1 + 1}]".into()], None),
+            "outer pure `expr` wrapping a pure subst stays pure",
+        );
+        // Deeper nesting: the impurity is two levels down.
+        assert!(
+            !is_pure_command(&registry, "expr", &["[expr [incr c]]".into()], None),
+            "nested impure subst at any depth must propagate",
+        );
     }
 
     /// SYNC8: a pure command (`expr`) gates to non-pure once its

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -13,7 +13,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::naming::normalise_qualified_name;
+use crate::naming::{normalise_qualified_name, normalise_var_name, split_array_name};
 use crate::side_effects::EffectRegion;
 
 // ---------------------------------------------------------------------------
@@ -338,10 +338,282 @@ pub fn build_interprocedural_analysis(
         &effect_writes,
     );
 
+    // SF-2: summarise TclOO method bodies into `MethodSummary` entries
+    // (consumed by the O126 `my <method>` purity gate).
+    let methods = build_method_summaries(
+        ir_module,
+        &known,
+        registry,
+        dialect,
+        &pure,
+        &effect_reads,
+        &effect_writes,
+    );
+
     InterproceduralAnalysis {
         procedures,
-        methods: HashMap::new(),
+        methods,
     }
+}
+
+/// Summarise `TclOO` method bodies into [`MethodSummary`] entries
+/// (SF-2). The purity rule is intentionally conservative — a method is
+/// pure iff its own body has no observable side effect (no barrier, no
+/// unknown call, no global write, no instance-var write, no local
+/// effect write) **and** every *proc* it calls is pure. A `my
+/// <method>` / `next` self-dispatch resolves to no registry trait, so
+/// it falls through to an unknown-state effect write and forces the
+/// method impure — we never mark a method pure on the strength of an
+/// unproven peer method (sound: false negatives only). A redefined
+/// method is forced impure (we can't prove which body a dispatch
+/// runs). Mirrors Python's method branch of `analyse_interprocedural_ir`.
+fn build_method_summaries(
+    ir_module: &crate::ir::Module,
+    known: &HashSet<String>,
+    registry: &tcl_registry::CommandRegistry,
+    dialect: Option<&str>,
+    pure: &HashMap<String, bool>,
+    effect_reads: &HashMap<String, EffectRegion>,
+    effect_writes: &HashMap<String, EffectRegion>,
+) -> HashMap<String, MethodSummary> {
+    if ir_module.methods.is_empty() {
+        return HashMap::new();
+    }
+    // A call resolving to a method qname is "known" (not unknown), so
+    // seed the resolver with both procs and method names.
+    let mut method_known = known.clone();
+    method_known.extend(ir_module.methods.keys().cloned());
+
+    let mut out: HashMap<String, MethodSummary> = HashMap::with_capacity(ir_module.methods.len());
+    for (mqname, method) in &ir_module.methods {
+        let mut facts = LocalFacts {
+            local_pure: true,
+            ..LocalFacts::default()
+        };
+        let params: HashSet<String> = method.params.iter().cloned().collect();
+        scan_script(
+            &method.body,
+            mqname,
+            &method_known,
+            registry,
+            dialect,
+            &mut facts,
+            &params,
+        );
+
+        // Instance-variable writes mutate object state and survive the
+        // call — so a method that writes any in-scope instance var is
+        // impure even though the write looks like a plain local `set`.
+        let mut written_ivars: HashSet<String> = HashSet::new();
+        if !method.instance_vars.is_empty() {
+            collect_instance_var_writes(&method.body, &method.instance_vars, &mut written_ivars);
+        }
+
+        let pure_base = !facts.has_barrier
+            && !facts.has_unknown_calls
+            && !facts.writes_global
+            && written_ivars.is_empty()
+            && facts.effect_writes == EffectRegion::NONE;
+        let mut is_pure = pure_base
+            && facts
+                .direct_calls
+                .iter()
+                .all(|c| pure.get(c).copied().unwrap_or(false));
+        // A redefined method (later oo::define / duplicate body) is
+        // conservatively impure: the stored body may not be the one a
+        // given dispatch runs.
+        if ir_module.redefined_methods.contains(mqname) {
+            is_pure = false;
+        }
+
+        // Effects: the method's own local effects unioned with the
+        // (transitive) effects of every proc callee. Non-proc callees
+        // (method qnames) default to NONE — mirrors Python.
+        let mut m_reads = facts.effect_reads;
+        let mut m_writes = facts.effect_writes;
+        for c in &facts.direct_calls {
+            m_reads |= effect_reads.get(c).copied().unwrap_or(EffectRegion::NONE);
+            m_writes |= effect_writes.get(c).copied().unwrap_or(EffectRegion::NONE);
+        }
+
+        let mut calls: Vec<String> = facts.direct_calls.iter().cloned().collect();
+        calls.sort();
+        let (returns_constant, constant_return, passthrough, depends) =
+            summarise_returns(&facts.returns);
+
+        out.insert(
+            mqname.clone(),
+            MethodSummary {
+                base: ProcSummary {
+                    qualified_name: mqname.clone(),
+                    params: method.params.clone(),
+                    arity: Arity::exact(u32::try_from(method.params.len()).unwrap_or(u32::MAX)),
+                    calls,
+                    has_barrier: facts.has_barrier,
+                    has_unknown_calls: facts.has_unknown_calls,
+                    writes_global: facts.writes_global,
+                    pure: is_pure,
+                    effect_reads: m_reads,
+                    effect_writes: m_writes,
+                    returns_constant,
+                    constant_return,
+                    return_depends_on_params: depends,
+                    return_passthrough_param: passthrough,
+                    // Methods are not folded at static call sites.
+                    can_fold_static_calls: false,
+                    param_traits: HashMap::new(),
+                },
+                class_name: method.class_name.clone(),
+                method_kind: method.kind.as_str().to_owned(),
+                // Read-set / MRO-dispatch tracking is not part of SF-2;
+                // left empty (the purity gate consumes only `pure`).
+                reads_instance_vars: HashSet::new(),
+                writes_instance_vars: written_ivars,
+                calls_my: Vec::new(),
+                calls_next: false,
+            },
+        );
+    }
+    out
+}
+
+/// Recursively collect the base names of instance-variable *writes* in
+/// a method body, comparing each written name against `ivars`. Mirrors
+/// Python's CFG walk: every `defs` of a non-`::variable` / `::upvar`
+/// Call, plus every assign / incr / loop / catch target. Array-element
+/// writes (`counter(0)`) compare on the base scalar name so they are
+/// not missed. Over-approximating writes is the sound direction (a
+/// spurious write only costs an O126 fold; a missed one would wrongly
+/// delete a state mutation).
+fn collect_instance_var_writes(
+    script: &crate::ir::Script,
+    ivars: &HashSet<String>,
+    out: &mut HashSet<String>,
+) {
+    use crate::ir::Statement;
+    for stmt in &script.statements {
+        match stmt {
+            Statement::AssignConst { name, .. }
+            | Statement::AssignExpr { name, .. }
+            | Statement::AssignValue { name, .. }
+            | Statement::Incr { name, .. } => check_ivar_write(name, ivars, out),
+            Statement::Call {
+                command,
+                canonical_command,
+                defs,
+                ..
+            } => {
+                // `variable` / `upvar` link or declare a name; they are
+                // not writes to instance state.
+                if is_variable_or_upvar(command, canonical_command.as_deref()) {
+                    continue;
+                }
+                for d in defs {
+                    check_ivar_write(d, ivars, out);
+                }
+            }
+            Statement::If {
+                clauses, else_body, ..
+            } => {
+                for clause in clauses {
+                    collect_instance_var_writes(&clause.body, ivars, out);
+                }
+                if let Some(eb) = else_body {
+                    collect_instance_var_writes(eb, ivars, out);
+                }
+            }
+            Statement::For {
+                init, next, body, ..
+            } => {
+                collect_instance_var_writes(init, ivars, out);
+                collect_instance_var_writes(next, ivars, out);
+                collect_instance_var_writes(body, ivars, out);
+            }
+            Statement::While { body, .. } => collect_instance_var_writes(body, ivars, out),
+            Statement::Foreach {
+                iterators, body, ..
+            } => {
+                for it in iterators {
+                    for v in &it.vars {
+                        check_ivar_write(v, ivars, out);
+                    }
+                }
+                collect_instance_var_writes(body, ivars, out);
+            }
+            Statement::Catch {
+                body,
+                result_var,
+                options_var,
+                ..
+            } => {
+                collect_instance_var_writes(body, ivars, out);
+                if let Some(rv) = result_var {
+                    check_ivar_write(rv, ivars, out);
+                }
+                if let Some(ov) = options_var {
+                    check_ivar_write(ov, ivars, out);
+                }
+            }
+            Statement::Try {
+                body,
+                handlers,
+                finally_body,
+                ..
+            } => {
+                collect_instance_var_writes(body, ivars, out);
+                for h in handlers {
+                    if let Some(v) = &h.var_name {
+                        check_ivar_write(v, ivars, out);
+                    }
+                    if let Some(ov) = &h.options_var {
+                        check_ivar_write(ov, ivars, out);
+                    }
+                    collect_instance_var_writes(&h.body, ivars, out);
+                }
+                if let Some(fb) = finally_body {
+                    collect_instance_var_writes(fb, ivars, out);
+                }
+            }
+            Statement::Switch {
+                arms, default_body, ..
+            } => {
+                for arm in arms {
+                    if let Some(b) = &arm.body {
+                        collect_instance_var_writes(b, ivars, out);
+                    }
+                }
+                if let Some(db) = default_body {
+                    collect_instance_var_writes(db, ivars, out);
+                }
+            }
+            Statement::Block { body, .. } | Statement::UpFrame { body, .. } => {
+                collect_instance_var_writes(body, ivars, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Record `raw` as an instance-var write when its base scalar name (an
+/// array element `arr(idx)` compares on `arr`) is a declared instance
+/// var.
+fn check_ivar_write(raw: &str, ivars: &HashSet<String>, out: &mut HashSet<String>) {
+    if raw.is_empty() {
+        return;
+    }
+    let base = split_array_name(normalise_var_name(raw)).0;
+    if ivars.contains(base) {
+        out.insert(base.to_owned());
+    }
+}
+
+/// True iff a statement's command (preferring its canonical form,
+/// `::`-stripped) is `variable` or `upvar` — a link/declaration, not a
+/// write to instance state.
+fn is_variable_or_upvar(command: &str, canonical: Option<&str>) -> bool {
+    let c = canonical.unwrap_or(command);
+    let c = c.strip_prefix("::").unwrap_or(c);
+    c == "variable" || c == "upvar"
 }
 
 fn scan_all_procs(
@@ -1373,6 +1645,107 @@ mod tests {
         let s = ia.procedures.get("::greet").expect("proc summary");
         assert_eq!(s.params, vec!["name".to_string()]);
         assert_eq!(s.arity, Arity::exact(1));
+    }
+
+    // -- SF-2 (SYNC-JUN02-1) method-purity summary tests ------------------
+
+    #[test]
+    fn pure_getter_method_is_summarised_pure() {
+        let ia = build(
+            "oo::class create C {\n\
+             \x20   variable n\n\
+             \x20   method get {} { return $n }\n\
+             }",
+        );
+        let m = ia.methods.get("::C::get").expect("method summary");
+        assert!(m.base.pure, "read-only getter should be pure");
+        assert!(m.writes_instance_vars.is_empty());
+        assert_eq!(m.class_name, "::C");
+        assert_eq!(m.method_kind, "method");
+    }
+
+    #[test]
+    fn instance_var_write_makes_method_impure() {
+        let ia = build(
+            "oo::class create C {\n\
+             \x20   variable n\n\
+             \x20   method bump {} { incr n }\n\
+             }",
+        );
+        let m = ia.methods.get("::C::bump").expect("method summary");
+        assert!(!m.base.pure, "instance-var write must be impure");
+        assert!(
+            m.writes_instance_vars.contains("n"),
+            "writes_instance_vars: {:?}",
+            m.writes_instance_vars
+        );
+    }
+
+    #[test]
+    fn array_element_instance_var_write_makes_method_impure() {
+        // `set counter(0) 1` writes the instance var `counter` (compared
+        // on the base scalar name, not the raw element name).
+        let ia = build(
+            "oo::class create C {\n\
+             \x20   variable counter\n\
+             \x20   method bump {} { set counter(0) 1 }\n\
+             }",
+        );
+        let m = ia.methods.get("::C::bump").expect("method summary");
+        assert!(!m.base.pure);
+        assert!(m.writes_instance_vars.contains("counter"));
+    }
+
+    #[test]
+    fn my_dispatch_makes_method_impure() {
+        // `my <other>` is a dynamic self-dispatch — unresolvable
+        // statically, so the method can't be proven pure.
+        let ia = build(
+            "oo::class create C {\n\
+             \x20   method a {} { my b }\n\
+             \x20   method b {} { return 1 }\n\
+             }",
+        );
+        let a = ia.methods.get("::C::a").expect("method a");
+        assert!(!a.base.pure, "my-dispatch caller must be impure");
+        // The pure leaf method still summarises pure.
+        let b = ia.methods.get("::C::b").expect("method b");
+        assert!(b.base.pure);
+    }
+
+    #[test]
+    fn redefined_method_is_forced_impure() {
+        let ia = build(
+            "oo::class create C {\n\
+             \x20   method m {} { return 1 }\n\
+             }\n\
+             oo::define C {\n\
+             \x20   method m {} { return 2 }\n\
+             }",
+        );
+        let m = ia.methods.get("::C::m").expect("method summary");
+        assert!(!m.base.pure, "redefined method must stay conservative");
+    }
+
+    #[test]
+    fn variable_decl_is_not_counted_as_instance_var_write() {
+        // A method-local `variable x` is a link/declaration, not a
+        // write — its def must not land in `writes_instance_vars`
+        // (Python soundness fix: a read-only instance-var method isn't
+        // forced impure by *that* path).  Note: the Rust registry models
+        // `variable` itself as a scope-alias barrier, so `peek` is still
+        // impure overall — but not via the instance-var-write channel.
+        let ia = build(
+            "oo::class create C {\n\
+             \x20   method peek {} { variable x; return $x }\n\
+             }",
+        );
+        let m = ia.methods.get("::C::peek").expect("method summary");
+        assert!(
+            m.writes_instance_vars.is_empty(),
+            "variable decl wrongly counted as write: {:?}",
+            m.writes_instance_vars
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -789,6 +789,13 @@ struct LocalFacts {
     /// final `ProcSummary::param_traits` is built from this
     /// after the body walk completes.
     param_trait_flags: HashMap<String, HashSet<ProcArgTrait>>,
+    /// Local variable names this proc aliased into global /
+    /// enclosing-namespace scope via `global` / `variable` / `upvar
+    /// #0`. A later bare `set g` / `incr g` / `append g` to one of
+    /// these mutates a variable the *caller* can see, so it counts as
+    /// `writes_global` even though the written name is bare. Mirrors
+    /// Python's `_LocalFacts.global_aliases` (#519).
+    global_aliases: HashSet<String>,
 }
 
 /// Classification of a single return statement's shape.
@@ -818,6 +825,7 @@ impl Default for LocalFacts {
             effect_writes: EffectRegion::NONE,
             returns: Vec::new(),
             param_trait_flags: HashMap::new(),
+            global_aliases: HashSet::new(),
         }
     }
 }
@@ -968,7 +976,10 @@ fn scan_statement(
         | Statement::AssignValue { name, .. }
         | Statement::AssignExpr { name, .. }
         | Statement::Incr { name, .. } => {
-            if is_global_or_namespace(name) {
+            // A write to a `::`-qualified name OR a name aliased into
+            // global / namespace scope earlier in the body (`global g;
+            // set g 5`) mutates caller-visible state (SYNC-JUN02b-2).
+            if is_global_or_namespace(name) || facts.global_aliases.contains(name.as_str()) {
                 facts.writes_global = true;
                 facts.local_pure = false;
                 facts.effect_writes |= EffectRegion::GLOBAL_STATE;
@@ -978,7 +989,38 @@ fn scan_statement(
             let kind = classify_return(value.as_deref(), expr.as_ref(), params);
             facts.returns.push(kind);
         }
-        Statement::Call { command, args, .. } => {
+        Statement::Call {
+            command,
+            args,
+            defs,
+            ..
+        } => {
+            // SYNC-JUN02b-2: track scope-aliasing declarations (`global`
+            // / `variable` / `upvar #0`) so a later bare write to an
+            // aliased name counts as `writes_global`. Declaring is not
+            // writing, so handle the declaration before the defs-based
+            // write check. Mirrors Python's `_scan_local_facts`.
+            match global_alias_names(command, args) {
+                Some(alias_names) => {
+                    if alias_names.contains("") {
+                        // Dynamic / unbounded alias target — conservative.
+                        facts.writes_global = true;
+                    }
+                    facts
+                        .global_aliases
+                        .extend(alias_names.into_iter().filter(|n| !n.is_empty()));
+                }
+                None => {
+                    // A non-declaration command that writes a `::`-qualified
+                    // or global-aliased variable (`append g`, `lappend g`,
+                    // `dict set ::cfg ...`) mutates caller-visible state.
+                    if defs.iter().any(|n| {
+                        !n.is_empty() && (n.starts_with("::") || facts.global_aliases.contains(n))
+                    }) {
+                        facts.writes_global = true;
+                    }
+                }
+            }
             scan_call_facts(
                 command, args, caller, known, registry, dialect, facts, params,
             );
@@ -1061,6 +1103,46 @@ fn scan_statement(
 
 fn is_global_or_namespace(name: &str) -> bool {
     name.starts_with("::") || name.contains("::")
+}
+
+/// Local names a scope-aliasing *command* binds to global / namespace
+/// scope. Returns `None` when *command* is not a global-aliasing
+/// declaration. The returned set holds the bound local names; an empty
+/// string (`""`) in the set is a sentinel for a dynamic / unbounded
+/// declaration (`global $x`), which the caller must treat as a global
+/// write. `upvar` at any level other than `#0` / `0` aliases a caller
+/// frame, not global scope, and returns `None`. Mirrors Python's
+/// `_global_alias_names` (#519).
+fn global_alias_names(command: &str, args: &[String]) -> Option<HashSet<String>> {
+    fn names(raw_names: &[String]) -> HashSet<String> {
+        raw_names
+            .iter()
+            .map(|raw| match raw.trim_start().as_bytes().first() {
+                // Dynamic alias target — can't bound the name set.
+                Some(b'$' | b'[') => String::new(),
+                _ => normalise_var_name(raw).to_owned(),
+            })
+            .collect()
+    }
+    match command {
+        "global" => Some(names(args)),
+        // `variable name ?value? name ?value? ...` — names at even indices.
+        "variable" => Some(names(&args.iter().step_by(2).cloned().collect::<Vec<_>>())),
+        "upvar" => {
+            let level = args.first()?.trim();
+            // Only `#0` / `0` alias the *global* frame; an omitted or
+            // numeric level aliases a caller frame (handled elsewhere).
+            if level != "#0" && level != "0" {
+                return None;
+            }
+            // `upvar #0 otherVar localVar ...` — local names at indices
+            // 2, 4, 6, … (every second arg after the level + otherVar).
+            Some(names(
+                &args.iter().skip(2).step_by(2).cloned().collect::<Vec<_>>(),
+            ))
+        }
+        _ => None,
+    }
 }
 
 /// Walk an expression AST and record call-graph edges (and Body
@@ -1645,6 +1727,42 @@ mod tests {
         let s = ia.procedures.get("::greet").expect("proc summary");
         assert_eq!(s.params, vec!["name".to_string()]);
         assert_eq!(s.arity, Arity::exact(1));
+    }
+
+    // -- SYNC-JUN02b-2: writes_global recognises scope aliases ------------
+
+    #[test]
+    fn global_alias_write_counts_as_writes_global() {
+        // A bare `set g` after `global g` mutates a caller-visible
+        // variable through the alias — writes_global, even though the
+        // written name is bare (previously missed: only `::`-qualified
+        // names counted).
+        for src in [
+            "proc ::f {} { global g\nset g 5 }",
+            "proc ::f {} { variable v\nset v 1 }",
+            "proc ::f {} { upvar #0 ::x g\nset g 1 }",
+            "proc ::f {} { global g\nincr g }",
+            "proc ::f {} { global g\nappend g x }",
+        ] {
+            let ia = build(src);
+            let s = ia.procedures.get("::f").expect("::f summary");
+            assert!(s.writes_global, "expected writes_global for: {src}");
+        }
+    }
+
+    #[test]
+    fn non_aliased_local_write_is_not_writes_global() {
+        // A plain local `set g` (no global/variable/upvar #0 decl) is
+        // not a global write; `upvar 1` aliases a caller frame, not
+        // global scope, so it is not flagged here either.
+        for src in [
+            "proc ::f {} { set g 5 }",
+            "proc ::f {} { upvar 1 x g\nset g 1 }",
+        ] {
+            let ia = build(src);
+            let s = ia.procedures.get("::f").expect("::f summary");
+            assert!(!s.writes_global, "unexpected writes_global for: {src}");
+        }
     }
 
     // -- SF-2 (SYNC-JUN02-1) method-purity summary tests ------------------

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -588,6 +588,13 @@ pub struct MethodDef {
     pub kind: MethodKind,
     /// Source span (may be absent for synthetic methods).
     pub span: Option<Span>,
+    /// Instance-variable names in scope for this method (class-level
+    /// `variable` declarations + the method's own `variable` decls).
+    /// A method that *writes* any of these mutates object state and is
+    /// therefore impure for O126 purposes, even though the write looks
+    /// like a plain local `set`. Used by interprocedural method-purity
+    /// (SF-2). Mirrors Python's `IRMethodDef.instance_vars`.
+    pub instance_vars: std::collections::HashSet<String>,
 }
 
 /// The kind of a class method.
@@ -642,6 +649,13 @@ pub struct Module {
     pub methods: std::collections::HashMap<String, MethodDef>,
     /// Procedure names that were defined more than once.
     pub redefined_procedures: std::collections::HashSet<String>,
+    /// `TclOO` method qnames defined more than once (a later
+    /// `oo::define` / in-body redefinition replaces the body at
+    /// runtime). Method purity is forced impure for these — we can't
+    /// prove which body a given dispatch runs, so the O126 `my
+    /// <method>` deletion gate must stay conservative. Mirrors
+    /// Python's `IRModule.redefined_methods`.
+    pub redefined_methods: std::collections::HashSet<String>,
     /// `namespace import` directives captured at lowering time —
     /// `(context_namespace, absolute_pattern)` pairs. Future codegen
     /// passes pattern-match each against the final
@@ -921,6 +935,7 @@ mod tests {
         assert!(module.procedures.is_empty());
         assert!(module.methods.is_empty());
         assert!(module.redefined_procedures.is_empty());
+        assert!(module.redefined_methods.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -456,6 +456,14 @@ pub enum Statement {
         nocase: bool,
         /// Raw argument texts for generic fallback.
         raw_args: Vec<String>,
+        /// `true` when the arms came from a single braced
+        /// `{pat body …}` block — patterns are literal list elements
+        /// with no substitution. `false` when supplied as separate
+        /// words (`switch $s $pat {body}`), where each pattern
+        /// undergoes normal `$var` / `[cmd]` runtime substitution
+        /// before matching. Mirrors Python's `IRSwitch.patterns_braced`
+        /// (defaults `true`, the canonical braced form).
+        patterns_braced: bool,
     },
 }
 
@@ -1043,6 +1051,7 @@ mod tests {
             mode: SwitchMode::Exact,
             nocase: false,
             raw_args: Vec::new(),
+            patterns_braced: true,
         };
         if let Statement::Switch { arms, mode, .. } = &stmt {
             assert_eq!(arms.len(), 2);

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! Ports `core/compiler/lowering.py`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use tcl_lexer::TokenType;
 use tcl_registry::hooks::LoweringHookId;
@@ -14,7 +14,7 @@ use tcl_registry::prelude::DialectSet;
 use tcl_registry::{ArgRole, CommandRegistry};
 
 use crate::alias::{detect_interp_alias, resolve_alias, CommandAliasMap};
-use crate::ir::{CommandTokens, Module, Procedure, Script, Statement};
+use crate::ir::{CommandTokens, MethodDef, MethodKind, Module, Procedure, Script, Statement};
 use crate::lowering_hooks::{try_lower_hook, ArgTokenKind, LoweringCommand};
 use crate::naming::{normalise_qualified_name, normalise_var_name};
 use crate::segmenter::{segment_commands, segment_commands_with_offset, SegmentedCommand};
@@ -42,6 +42,117 @@ fn join_namespace(parent: &str, child: &str) -> String {
         return normalise_qualified_name(&format!("::{child}"));
     }
     normalise_qualified_name(&format!("{parent}::{child}"))
+}
+
+/// The namespace a procedure body lowers in — everything up to the
+/// last `::` of its qualified name, or `::` for a global proc.
+/// Mirrors Python's `_normalise_qualified_name(qname).rsplit("::",
+/// 1)[0] or "::"`.
+fn proc_namespace(qname: &str) -> String {
+    let n = normalise_qualified_name(qname);
+    match n.rfind("::") {
+        Some(0) | None => "::".to_string(),
+        Some(idx) => n[..idx].to_string(),
+    }
+}
+
+/// Recognise the OO definition-command spellings. Returns
+/// `Some("oo::class")` / `Some("oo::define")` when the command is one
+/// of those (with or without a leading `::`), else `None`. Mirrors
+/// Python's `canonical_command in ("::oo::class", "::oo::define")`
+/// gate, which also normalises both spellings.
+fn oo_definition_form(command: &str, canonical: Option<&str>) -> Option<&'static str> {
+    let c = canonical.unwrap_or(command);
+    let c = c.strip_prefix("::").unwrap_or(c);
+    match c {
+        "oo::class" => Some("oo::class"),
+        "oo::define" => Some("oo::define"),
+        _ => None,
+    }
+}
+
+/// True iff the command carries the class/define shape with a static
+/// braced body block:
+///
+/// * `oo::class create Name { body }` — body at argv index 3.
+/// * `oo::define Name { body }` — body at argv index 2.
+///
+/// Only static braced bodies qualify — the single-method
+/// `oo::define Name method m {...} {...}` and dynamic-body forms are
+/// left to the default lowering. Mirrors Python's
+/// `_is_oo_definition_shape`. `texts` / `kinds` / `single` are the
+/// full per-word arrays (index 0 = command word).
+fn is_oo_definition_shape(
+    form: &str,
+    texts: &[String],
+    kinds: &[TokenType],
+    single: &[bool],
+) -> bool {
+    match form {
+        "oo::class" => {
+            texts.len() >= 4
+                && texts.get(1).is_some_and(|s| s == "create")
+                && word_is_static_braced(kinds, single, 3)
+        }
+        "oo::define" => texts.len() >= 3 && word_is_static_braced(kinds, single, 2),
+        _ => false,
+    }
+}
+
+/// Full-argv index of the body word for an OO definition form
+/// (`oo::class create Name {body}` → 3, `oo::define Name {body}` → 2).
+fn oo_body_word_idx(form: &str) -> usize {
+    if form == "oo::class" {
+        3
+    } else {
+        2
+    }
+}
+
+/// True iff `command` (`::`-stripped) is `namespace` and the args are
+/// the `eval CHILD {static-braced-body}` shape — the form whose body
+/// the Rust lowerer evaluates inline and discards (it emits a
+/// `Barrier`), so the OO post-pass must re-segment it to find any
+/// classes defined directly inside the namespace.
+fn is_namespace_eval_shape(
+    command: &str,
+    texts: &[String],
+    kinds: &[TokenType],
+    single: &[bool],
+) -> bool {
+    command.strip_prefix("::").unwrap_or(command) == "namespace"
+        && texts.len() >= 4
+        && texts.get(1).is_some_and(|s| s == "eval")
+        && word_is_static_braced(kinds, single, 3)
+}
+
+/// True iff word `idx` (full argv index) is a single braced-literal
+/// (`Str`) token. Mirrors Python's `_is_static_braced`.
+fn word_is_static_braced(kinds: &[TokenType], single: &[bool], idx: usize) -> bool {
+    idx < kinds.len() && idx < single.len() && single[idx] && kinds[idx] == TokenType::Str
+}
+
+/// `SegmentedCommand` variant of [`word_is_static_braced`]: word
+/// `idx` is a single braced-literal (`Str`) token.
+fn seg_word_is_static_braced(seg: &SegmentedCommand, idx: usize) -> bool {
+    seg.single_token_word.get(idx).copied().unwrap_or(false)
+        && seg.argv.get(idx).is_some_and(|t| t.kind == TokenType::Str)
+}
+
+/// True iff `nm` is a static instance-variable name (not a `$var` /
+/// `[cmd]` substitution and not an option flag). Dynamic names are
+/// skipped — conservative.
+fn is_instance_var_name(nm: &str) -> bool {
+    !nm.is_empty() && !nm.contains('$') && !nm.contains('[') && !nm.starts_with('-')
+}
+
+/// True iff a statement's command (preferring its canonical form,
+/// `::`-stripped) equals `bare`. Mirrors Python's
+/// `stmt.canonical_command == "::{bare}"` checks while tolerating the
+/// Rust IR's `canonical_command == None` for un-aliased commands.
+fn canonical_matches(command: &str, canonical: Option<&str>, bare: &str) -> bool {
+    let c = canonical.unwrap_or(command);
+    c.strip_prefix("::").unwrap_or(c) == bare
 }
 
 /// Qualify a procedure name relative to a namespace.
@@ -408,6 +519,15 @@ pub struct Lowerer<'r> {
     /// offset see the original structure. Mirrors Python's
     /// `_dead_code_depth`.
     pub(crate) dead_code_depth: u32,
+    /// `true` while lowering a `TclOO` method body (SF-2). A `proc`
+    /// (or `namespace eval`-lifted proc) defined inside a method
+    /// body is created at method-call time in the global namespace,
+    /// NOT at class-definition time — so it must not be lifted into
+    /// `module.procedures` (codegen would otherwise emit it
+    /// unconditionally at script load). The method body is still
+    /// lowered for analysis; only the global registration is
+    /// suppressed. Mirrors Python's `_suppress_proc_register`.
+    suppress_proc_register: bool,
 }
 
 impl<'r> Lowerer<'r> {
@@ -425,6 +545,7 @@ impl<'r> Lowerer<'r> {
             namespace_imports: Vec::new(),
             namespace_exports: Vec::new(),
             dead_code_depth: 0,
+            suppress_proc_register: false,
         }
     }
 
@@ -1009,22 +1130,32 @@ impl<'r> Lowerer<'r> {
         self.const_map_stack.pop();
         self.proc_depth -= 1;
 
-        if let std::collections::hash_map::Entry::Vacant(e) =
-            self.module.procedures.entry(qualified.clone())
-        {
-            e.insert(Procedure {
-                name: proc_name.clone(),
-                qualified_name: qualified,
-                params,
-                span: seg.span,
-                body,
-                params_raw: args[1].clone(),
-                body_source: Some(args[2].clone()),
-                namespace_scoped: self.in_namespace_eval,
-                base_priority: 500,
-            });
-        } else {
-            self.module.redefined_procedures.insert(qualified);
+        // SF-2: a `proc` defined inside a TclOO method body is created
+        // at method-call time in the global namespace, not at script
+        // load — so it must not be lifted into `module.procedures`
+        // (codegen would otherwise emit it unconditionally). The body
+        // was still lowered above for analysis; only the global
+        // registration is suppressed. Mirrors Python's
+        // `_suppress_proc_register` guard.
+        if !self.suppress_proc_register {
+            match self.module.procedures.entry(qualified.clone()) {
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(Procedure {
+                        name: proc_name.clone(),
+                        qualified_name: qualified,
+                        params,
+                        span: seg.span,
+                        body,
+                        params_raw: args[1].clone(),
+                        body_source: Some(args[2].clone()),
+                        namespace_scoped: self.in_namespace_eval,
+                        base_priority: 500,
+                    });
+                }
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    self.module.redefined_procedures.insert(qualified);
+                }
+            }
         }
 
         Statement::Call {
@@ -1543,6 +1674,275 @@ impl<'r> Lowerer<'r> {
             foreach_groups: None,
         }
     }
+
+    // ---------------------------------------------------------------
+    // TclOO method-body lowering (SF-2: method purity for O126)
+    // ---------------------------------------------------------------
+
+    /// Populate `module.methods` from the fully-assembled IR.
+    ///
+    /// Runs as a cache-independent post-pass (mirroring
+    /// [`populate_trace_facts`]): clone the top-level script and proc
+    /// bodies, then walk them — plus any `namespace eval` blocks — for
+    /// `oo::class create` / `oo::define` barriers and lift each
+    /// `method` / `constructor` / `destructor` body to an
+    /// [`MethodDef`]. Method bodies are lowered for analysis only —
+    /// codegen never reads `module.methods`, and the barrier emitted
+    /// for the class command is unchanged, so bytecode is
+    /// byte-identical. Mirrors Python's `extract_oo_methods_pass`.
+    pub fn extract_oo_methods_pass(&mut self) {
+        let top_level = self.module.top_level.clone();
+        self.walk_for_oo_methods(&top_level.statements, "::");
+        let procs: Vec<(String, Script)> = self
+            .module
+            .procedures
+            .iter()
+            .map(|(q, p)| (q.clone(), p.body.clone()))
+            .collect();
+        for (qname, body) in &procs {
+            let proc_ns = proc_namespace(qname);
+            self.walk_for_oo_methods(&body.statements, &proc_ns);
+        }
+    }
+
+    /// Recursive walk for `oo::class` / `oo::define` definition
+    /// barriers. Descends `namespace eval` blocks (tracking the active
+    /// namespace) and extracts methods from any class/define command
+    /// carrying a static braced body. Mirrors Python's
+    /// `_walk_for_oo_methods` — except the Rust lowerer evaluates a
+    /// `namespace eval` body inline and discards it (emitting a
+    /// `Barrier`), so where Python descends a preserved `IRBlock`, the
+    /// Rust walk re-segments the barrier's body token instead (see
+    /// [`Self::walk_segments_for_oo`]).
+    fn walk_for_oo_methods(&mut self, statements: &[Statement], namespace: &str) {
+        for stmt in statements {
+            match stmt {
+                // C35-folded `eval` / `uplevel` bodies survive as Blocks.
+                Statement::Block {
+                    body,
+                    namespace: block_ns,
+                    ..
+                } => {
+                    let ns = if block_ns.is_empty() {
+                        namespace
+                    } else {
+                        block_ns.as_str()
+                    };
+                    self.walk_for_oo_methods(&body.statements, ns);
+                }
+                Statement::Call {
+                    command,
+                    canonical_command,
+                    tokens: Some(ct),
+                    ..
+                }
+                | Statement::Barrier {
+                    command,
+                    canonical_command,
+                    tokens: Some(ct),
+                    ..
+                } => {
+                    if let Some(form) = oo_definition_form(command, canonical_command.as_deref()) {
+                        if is_oo_definition_shape(
+                            form,
+                            &ct.argv_texts,
+                            &ct.argv_kinds,
+                            &ct.single_token_word,
+                        ) {
+                            let idx = oo_body_word_idx(form);
+                            self.extract_oo_methods(
+                                form,
+                                &ct.argv_texts,
+                                ct.argv[idx].start() + 1,
+                                namespace,
+                            );
+                        }
+                    } else if is_namespace_eval_shape(
+                        command,
+                        &ct.argv_texts,
+                        &ct.argv_kinds,
+                        &ct.single_token_word,
+                    ) {
+                        // The body was lowered inline and discarded;
+                        // re-segment it to find classes defined directly
+                        // inside the namespace.
+                        let child_ns = join_namespace(namespace, &ct.argv_texts[2]);
+                        let body_off = ct.argv[3].start() + 1;
+                        let segments = segment_commands_with_offset(&ct.argv_texts[3], body_off);
+                        self.walk_segments_for_oo(&segments, &child_ns);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Segment-level counterpart of [`Self::walk_for_oo_methods`] used
+    /// for `namespace eval` bodies (which the lowerer discards). Walks
+    /// re-segmented commands, recursing through nested `namespace eval`
+    /// and extracting methods from `oo::class` / `oo::define` blocks.
+    fn walk_segments_for_oo(&mut self, segments: &[SegmentedCommand], namespace: &str) {
+        for seg in segments {
+            if seg.is_partial || seg.texts.is_empty() {
+                continue;
+            }
+            let kinds: Vec<TokenType> = seg.argv.iter().map(|t| t.kind).collect();
+            let cmd = seg.texts[0].as_str();
+            if let Some(form) = oo_definition_form(cmd, None) {
+                if is_oo_definition_shape(form, &seg.texts, &kinds, &seg.single_token_word) {
+                    let idx = oo_body_word_idx(form);
+                    let off = seg.argv[idx].span.start() + u32::from(seg.argv[idx].content_offset);
+                    self.extract_oo_methods(form, &seg.texts, off, namespace);
+                }
+            } else if is_namespace_eval_shape(cmd, &seg.texts, &kinds, &seg.single_token_word) {
+                let child_ns = join_namespace(namespace, &seg.texts[2]);
+                let off = seg.argv[3].span.start() + u32::from(seg.argv[3].content_offset);
+                let sub = segment_commands_with_offset(&seg.texts[3], off);
+                self.walk_segments_for_oo(&sub, &child_ns);
+            }
+        }
+    }
+
+    /// Lift `method` / `classmethod` / `constructor` / `destructor`
+    /// bodies inside an `oo::class create` / `oo::define` block to
+    /// per-method [`MethodDef`] entries keyed by
+    /// `{class_qname}::{method_name}` (constructors / destructors use
+    /// the synthetic names `<constructor>` / `<destructor>`). Mirrors
+    /// Python's `_extract_oo_methods`. `texts` is the class command's
+    /// full per-word text array; `body_content_offset` is the absolute
+    /// source offset of the first byte inside the body's braces.
+    fn extract_oo_methods(
+        &mut self,
+        form: &str,
+        texts: &[String],
+        body_content_offset: u32,
+        namespace: &str,
+    ) {
+        // `is_oo_definition_shape` guarantees the indices below exist.
+        let (class_simple, body_text) = match form {
+            "oo::class" => (texts[2].as_str(), texts[3].as_str()),
+            // oo::define
+            _ => (texts[1].as_str(), texts[2].as_str()),
+        };
+        // Dynamic class names can't be resolved statically.
+        if class_simple.contains('$') || class_simple.contains('[') {
+            return;
+        }
+        let class_qname = qualify_proc_name(namespace, class_simple);
+        let segments = segment_commands_with_offset(body_text, body_content_offset);
+
+        // Class-level instance-variable declarations (`variable a b
+        // ...`) are auto-linked into every method. The TclOO
+        // class-body `variable` slot is names-only (`variable a b c`
+        // declares three instance vars — verified vs tclsh 9.0 — NOT
+        // name/value pairs), so every literal trailing word is a name.
+        let mut class_ivars: HashSet<String> = HashSet::new();
+        for seg in &segments {
+            if !seg.is_partial && seg.texts.len() >= 2 && seg.texts[0] == "variable" {
+                for nm in &seg.texts[1..] {
+                    if is_instance_var_name(nm) {
+                        class_ivars.insert(normalise_var_name(nm).to_string());
+                    }
+                }
+            }
+        }
+
+        for seg in &segments {
+            if seg.is_partial || seg.texts.is_empty() {
+                continue;
+            }
+            let head = seg.texts[0].as_str();
+            let (name, params_str, b_idx, kind): (&str, &str, usize, &str) = match head {
+                "method" if seg.texts.len() >= 4 => {
+                    (seg.texts[1].as_str(), seg.texts[2].as_str(), 3, "method")
+                }
+                "classmethod" if seg.texts.len() >= 4 => (
+                    seg.texts[1].as_str(),
+                    seg.texts[2].as_str(),
+                    3,
+                    "classmethod",
+                ),
+                "constructor" if seg.texts.len() >= 3 => {
+                    ("<constructor>", seg.texts[1].as_str(), 2, "constructor")
+                }
+                "destructor" if seg.texts.len() >= 2 => ("<destructor>", "", 1, "destructor"),
+                _ => continue,
+            };
+            // Dynamic method names / non-static bodies are left
+            // un-lowered (the optimiser stays conservative for them).
+            if name.contains('$') || name.contains('[') {
+                continue;
+            }
+            if !seg_word_is_static_braced(seg, b_idx) {
+                continue;
+            }
+            let params = if params_str.is_empty() {
+                Vec::new()
+            } else {
+                parse_param_names(params_str)
+            };
+            // Lower the method body in its own frame (fresh const-map +
+            // proc-depth) so the enclosing scope's tracked scalars
+            // don't leak into the body's barrier-relaxation gate —
+            // exactly as the `proc` case does — and suppress
+            // nested-proc registration while doing so.
+            let body_tok = seg.argv[b_idx];
+            let body_off = body_tok.span.start() + u32::from(body_tok.content_offset);
+            self.proc_depth += 1;
+            self.const_map_stack.push(HashMap::new());
+            let prev_suppress = self.suppress_proc_register;
+            self.suppress_proc_register = true;
+            let body_script = self.lower_body(seg.texts[b_idx].as_str(), body_off, namespace);
+            self.suppress_proc_register = prev_suppress;
+            self.const_map_stack.pop();
+            self.proc_depth -= 1;
+
+            // Instance vars in scope: class-level decls plus this
+            // method's own top-level `variable` declarations. A write
+            // to any of these mutates object state (impure for O126).
+            let mut method_ivars = class_ivars.clone();
+            for st in &body_script.statements {
+                if let Statement::Call {
+                    command,
+                    canonical_command,
+                    args,
+                    ..
+                } = st
+                {
+                    if canonical_matches(command, canonical_command.as_deref(), "variable") {
+                        for nm in args {
+                            if is_instance_var_name(nm) {
+                                method_ivars.insert(normalise_var_name(nm).to_string());
+                            }
+                        }
+                    }
+                }
+            }
+
+            let method_qname = format!("{class_qname}::{name}");
+            // First definition wins for the stored body (matches proc
+            // registration), but a redefinition (a later `oo::define`
+            // or a duplicate in-body `method`) replaces the body at
+            // runtime — we can't statically know which body a given
+            // dispatch runs, so flag it impure to keep O126 sound.
+            if self.module.methods.contains_key(&method_qname) {
+                self.module.redefined_methods.insert(method_qname);
+                continue;
+            }
+            self.module.methods.insert(
+                method_qname,
+                MethodDef {
+                    class_name: class_qname.clone(),
+                    method_name: name.to_string(),
+                    params,
+                    body: body_script,
+                    kind: MethodKind::from_str_lossy(kind),
+                    span: Some(seg.span),
+                    instance_vars: method_ivars,
+                },
+            );
+        }
+    }
 }
 
 // Public API
@@ -1554,6 +1954,9 @@ impl<'r> Lowerer<'r> {
 pub fn lower_to_ir(source: &str, registry: &CommandRegistry) -> Module {
     let mut lowerer = Lowerer::new(registry);
     lowerer.lower(source);
+    // SF-2: extract TclOO method bodies from the fully-assembled
+    // module (cache-independent — see `extract_oo_methods_pass`).
+    lowerer.extract_oo_methods_pass();
     let mut module = lowerer.module;
     populate_trace_facts(&mut module);
     module
@@ -1703,6 +2106,128 @@ mod tests {
             &m.top_level.statements[0],
             Statement::Incr { name, .. } if name == "i"
         ));
+    }
+
+    // SF-2 (SYNC-JUN02-1): the `extract_oo_methods_pass` post-pass
+    // lifts TclOO method bodies into `module.methods`.
+
+    #[test]
+    fn extracts_oo_class_methods() {
+        let src = "oo::class create Counter {\n\
+                   \x20   variable n\n\
+                   \x20   constructor {} { set n 0 }\n\
+                   \x20   method bump {} { incr n }\n\
+                   \x20   method get {} { return $n }\n\
+                   }\n";
+        let m = lower_to_ir(src, &reg());
+        let mut keys: Vec<&String> = m.methods.keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                &"::Counter::<constructor>".to_string(),
+                &"::Counter::bump".to_string(),
+                &"::Counter::get".to_string(),
+            ],
+            "methods: {keys:?}",
+        );
+        let get = &m.methods["::Counter::get"];
+        assert_eq!(get.method_name, "get");
+        assert_eq!(get.kind, MethodKind::Method);
+        assert_eq!(get.class_name, "::Counter");
+        // `variable n` in the class body is an in-scope instance var
+        // for every method (auto-linked).
+        assert!(
+            get.instance_vars.contains("n"),
+            "get ivars: {:?}",
+            get.instance_vars
+        );
+        // The method body is lowered for analysis (the `incr n` /
+        // `return $n` statements are present, not an empty barrier).
+        let bump = &m.methods["::Counter::bump"];
+        assert!(
+            !bump.body.statements.is_empty(),
+            "bump body should be lowered"
+        );
+        let ctor = &m.methods["::Counter::<constructor>"];
+        assert_eq!(ctor.kind, MethodKind::Constructor);
+        assert!(m.redefined_methods.is_empty());
+    }
+
+    #[test]
+    fn extracts_oo_define_methods_and_namespaced_class() {
+        // `oo::define` adds methods to an existing class, and a class
+        // created inside `namespace eval` qualifies under that ns.
+        let src = "namespace eval ::app {\n\
+                   \x20   oo::class create Widget {\n\
+                   \x20       method draw {} { return ok }\n\
+                   \x20   }\n\
+                   }\n\
+                   oo::define ::app::Widget {\n\
+                   \x20   method hide {} { return done }\n\
+                   }\n";
+        let m = lower_to_ir(src, &reg());
+        assert!(
+            m.methods.contains_key("::app::Widget::draw"),
+            "methods: {:?}",
+            m.methods.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            m.methods.contains_key("::app::Widget::hide"),
+            "methods: {:?}",
+            m.methods.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn redefined_oo_method_is_flagged() {
+        // A method redefined by a later `oo::define` keeps the first
+        // body but is recorded in `redefined_methods` so purity stays
+        // conservative.
+        let src = "oo::class create C {\n\
+                   \x20   method m {} { return 1 }\n\
+                   }\n\
+                   oo::define C {\n\
+                   \x20   method m {} { return 2 }\n\
+                   }\n";
+        let m = lower_to_ir(src, &reg());
+        assert!(m.methods.contains_key("::C::m"));
+        assert!(
+            m.redefined_methods.contains("::C::m"),
+            "redefined: {:?}",
+            m.redefined_methods
+        );
+    }
+
+    #[test]
+    fn oo_method_nested_proc_not_registered_globally() {
+        // A `proc` defined inside a method body is created at
+        // method-call time, not script load — it must not leak into
+        // `module.procedures` (codegen safety).
+        let src = "oo::class create C {\n\
+                   \x20   method m {} { proc helper {} { return 1 }; return 2 }\n\
+                   }\n\
+                   proc toplevel {} { return 3 }\n";
+        let m = lower_to_ir(src, &reg());
+        assert!(
+            m.procedures.contains_key("::toplevel"),
+            "procs: {:?}",
+            m.procedures.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !m.procedures.contains_key("::helper"),
+            "nested method proc must not be registered: {:?}",
+            m.procedures.keys().collect::<Vec<_>>()
+        );
+        // The method body still lowered the `proc helper ...` call.
+        assert!(m.methods.contains_key("::C::m"));
+    }
+
+    #[test]
+    fn no_oo_methods_for_plain_script() {
+        let m = lower_to_ir("proc greet {} { puts hi }", &reg());
+        assert!(m.methods.is_empty());
+        assert!(m.redefined_methods.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -603,6 +603,12 @@ impl Lowerer<'_> {
         // the right content offset / encoding flags.
         let mut pairs: Vec<SwitchPair> = Vec::new();
 
+        // Patterns from a single braced body are literal list elements;
+        // patterns supplied as separate words undergo runtime
+        // `$var` / `[cmd]` substitution (the `switch $s $pat {body}`
+        // wrapper form). Mirrors Python's `patterns_braced`.
+        let mut patterns_braced = true;
+
         // Single braced body form: switch subject { pat1 body1 pat2 body2 ... }
         if i == args.len() - 1 && i < arg_single.len() && arg_single[i] {
             let body_text = &args[i];
@@ -636,7 +642,9 @@ impl Lowerer<'_> {
                 j += 2;
             }
         } else {
-            // Multi-arg form: remaining args are pattern body pairs.
+            // Multi-arg form: remaining args are pattern body pairs —
+            // each pattern word substitutes at runtime.
+            patterns_braced = false;
             let remaining = args.len() - i;
             if remaining % 2 != 0 {
                 return Self::barrier(seg, "switch odd pattern count");
@@ -671,6 +679,7 @@ impl Lowerer<'_> {
             mode,
             nocase,
             raw_args: args.to_vec(),
+            patterns_braced,
         }
     }
 
@@ -823,6 +832,41 @@ mod tests {
                 "single-braced arm body should lower to non-empty IR, got {body:?}",
             );
         }
+    }
+
+    // SYNC-JUN02-3: `patterns_braced` distinguishes a literal-pattern
+    // braced block from the substituting separate-words form.
+
+    #[test]
+    fn switch_braced_block_sets_patterns_braced_true() {
+        let m = lower_to_ir("switch $x { a {puts hi} b {set y 1} }", &reg());
+        let Statement::Switch {
+            patterns_braced, ..
+        } = &m.top_level.statements[0]
+        else {
+            panic!("expected Switch");
+        };
+        assert!(
+            *patterns_braced,
+            "single braced `{{pat body …}}` block → patterns_braced = true",
+        );
+    }
+
+    #[test]
+    fn switch_separate_words_sets_patterns_braced_false() {
+        // `switch $s a {body1} b {body2}` — patterns are separate words
+        // that substitute at runtime, so patterns_braced must be false.
+        let m = lower_to_ir("switch $x a {puts hi} b {set y 1}", &reg());
+        let Statement::Switch {
+            patterns_braced, ..
+        } = &m.top_level.statements[0]
+        else {
+            panic!("expected Switch");
+        };
+        assert!(
+            !*patterns_braced,
+            "separate-words pattern form → patterns_braced = false",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -382,6 +382,7 @@ mod tests {
                 procedures: HashMap::new(),
                 methods: HashMap::new(),
                 redefined_procedures: std::collections::HashSet::new(),
+                redefined_methods: std::collections::HashSet::new(),
                 namespace_imports: Vec::new(),
                 namespace_exports: Vec::new(),
                 traced_commands: std::collections::BTreeSet::new(),

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -394,6 +394,7 @@ mod tests {
             },
             top_level: fu,
             procedures: HashMap::new(),
+            methods: HashMap::new(),
             interproc: None,
             connection_scope: None,
         }

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -303,6 +303,34 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
             emit_dead_stores_and_unused(ctx, fu, false, &interproc_pure, &pure_methods, None);
         emit_adce(ctx, fu, &baseline);
     }
+
+    // SF-2 (#506): optimise TclOO method bodies as functions too,
+    // passing the owning class qname so the O126 `my <method>` purity
+    // gate can resolve same-class pure methods. Instance variables
+    // escape the method frame (they are object state), so they are fed
+    // through the same escaping channel iRules cross-event state uses —
+    // the dead-store / unused-assignment passes must not delete a
+    // state-mutating `set ivar ...` inside the method body. Mirrors the
+    // method-iteration loop in `optimiser/_manager.py`.
+    let saved_cross = std::mem::take(&mut ctx.cross_event_vars);
+    for (mqname, fu) in &cu.methods {
+        let ir_method = cu.ir_module.methods.get(mqname);
+        let enclosing_class = ir_method.map(|m| m.class_name.as_str());
+        ctx.cross_event_vars = ir_method
+            .map(|m| m.instance_vars.clone())
+            .unwrap_or_default();
+        emit_unreachable(ctx, fu);
+        let baseline = emit_dead_stores_and_unused(
+            ctx,
+            fu,
+            false,
+            &interproc_pure,
+            &pure_methods,
+            enclosing_class,
+        );
+        emit_adce(ctx, fu, &baseline);
+    }
+    ctx.cross_event_vars = saved_cross;
 }
 
 fn emit_unreachable(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
@@ -1106,6 +1134,56 @@ mod tests {
         assert!(
             opts.iter().any(|o| o.code == "O126"),
             "literal RHS should still fold, got {opts:?}",
+        );
+    }
+
+    // -- SF-2 method-body O126 (SYNC-JUN02-1 strip 4b) --------------------
+
+    #[test]
+    fn sf2_o126_folds_pure_my_dispatch_in_method_body() {
+        // The optimiser now runs over TclOO method bodies with the
+        // owning class as `enclosing_class`, so `set unused [my pure]`
+        // — a self-dispatch to a method proven pure — folds to O126.
+        // (FP-OPT-12 PARTIAL → FIXED.)
+        let src = "oo::class create C {\n\
+                   \x20   method pure {} { return 1 }\n\
+                   \x20   method uses {} { set unused [my pure]; return 2 }\n\
+                   }";
+        let opts = crate::optimiser::optimise(src, &registry());
+        assert!(
+            opts.iter().any(|o| o.code == "O126"),
+            "pure `my` self-dispatch RHS should fold, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn sf2_o126_preserves_impure_my_dispatch_in_method_body() {
+        // An impure method (`puts`) must keep its self-dispatch — the
+        // assignment is preserved so the side effect still runs.
+        let src = "oo::class create C {\n\
+                   \x20   method noisy {} { puts hi }\n\
+                   \x20   method uses {} { set unused [my noisy]; return 2 }\n\
+                   }";
+        let opts = crate::optimiser::optimise(src, &registry());
+        assert!(
+            opts.iter().all(|o| o.code != "O126"),
+            "impure `my` self-dispatch RHS must be preserved, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn sf2_instance_var_write_in_method_not_deleted() {
+        // An instance-var write inside a method body is object state
+        // that escapes the frame — it must not be flagged O109/O126
+        // even when the method never reads it back.
+        let src = "oo::class create C {\n\
+                   \x20   variable n\n\
+                   \x20   method bump {} { set n 5 }\n\
+                   }";
+        let opts = crate::optimiser::optimise(src, &registry());
+        assert!(
+            opts.iter().all(|o| o.code != "O109" && o.code != "O126"),
+            "instance-var write must be preserved, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -21,27 +21,286 @@
 
 use std::collections::{HashMap, HashSet};
 
+use tcl_registry::CommandRegistry;
+
 use crate::cfg::Function as CfgFunction;
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::def_use::DefKind;
+use crate::expr_ast::ExprNode;
 use crate::ir::Statement;
 use crate::sccp::{cfg_order, SccpResult};
+use crate::segmenter::segment_commands;
+use crate::side_effects::classify_side_effects;
 
 use super::helpers::spans::full_rewrite_span;
 use super::{Optimisation, PassContext};
+
+/// True when `text` (a Tcl word body) contains a command substitution
+/// that has an observable side effect — writes a variable, prints to
+/// stdout, mutates global state, runs a dynamic barrier, etc. Used to
+/// gate elimination of unused / dead assignments: `set v [puts X]`
+/// discards the result but still prints, so the assignment is NOT safe
+/// to delete.
+///
+/// `interproc_pure` is the set of qualified user-proc names proven pure
+/// by interprocedural analysis; a cmd-sub of such a proc is treated as
+/// side-effect-free even though [`classify_side_effects`] is
+/// conservative for user commands. `pure_methods` + `enclosing_class`
+/// (SF-2) recognise a pure `my <method>` self-dispatch. Conservative:
+/// anything we can't classify (unknown proc, dynamic dispatch,
+/// unparseable / no registry) is treated as having a side effect.
+/// Mirrors Python's `_word_has_observable_side_effect`.
+fn word_has_observable_side_effect(
+    text: &str,
+    registry: Option<&CommandRegistry>,
+    interproc_pure: &HashSet<String>,
+    pure_methods: &HashSet<String>,
+    enclosing_class: Option<&str>,
+) -> bool {
+    if !text.contains('[') {
+        return false;
+    }
+    // No registry to classify embedded commands → conservative.
+    let Some(registry) = registry else {
+        return true;
+    };
+    let sm = tcl_lexer::SourceMap::new(text);
+    let Ok(tokens) = tcl_lexer::Lexer::new(text).tokenise_all() else {
+        return true; // unparseable → conservative
+    };
+    for tok in &tokens {
+        if tok.kind != tcl_lexer::TokenType::Cmd {
+            continue;
+        }
+        // `token_text` yields the command substitution's inner text
+        // (brackets stripped); segment it to get name + args.
+        let cmds = segment_commands(sm.token_text(*tok));
+        if cmds.len() != 1 || cmds[0].texts.is_empty() {
+            // Multi-command substitution or empty → conservative.
+            return true;
+        }
+        let cmd_name = cmds[0].texts[0].as_str();
+        let cmd_args: &[String] = &cmds[0].texts[1..];
+        let se = classify_side_effects(registry, cmd_name, cmd_args, None, None);
+        if !se.pure {
+            // A user proc / method that the registry can't classify may
+            // have been interprocedurally proven pure — consult those.
+            let proc_pure = interproc_pure.contains(cmd_name)
+                || interproc_pure.contains(format!("::{cmd_name}").as_str())
+                || interproc_pure.contains(cmd_name.trim_start_matches(':'));
+            let self_dispatch_pure = matches!(cmd_name, "my" | "::my")
+                && !cmd_args.is_empty()
+                && enclosing_class.is_some_and(|cls| method_pure(cls, &cmd_args[0], pure_methods));
+            if !proc_pure && !self_dispatch_pure {
+                return true;
+            }
+        }
+        // Recurse into nested substitutions inside the args.
+        for arg in cmd_args {
+            if word_has_observable_side_effect(
+                arg,
+                Some(registry),
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            ) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Return `true` iff `class_qname::method_name` (or a common qualifier
+/// spelling) is in `pure_methods`. Mirrors Python's `_method_pure`.
+fn method_pure(class_qname: &str, method_name: &str, pure_methods: &HashSet<String>) -> bool {
+    if method_name.is_empty() {
+        return false;
+    }
+    let cls = class_qname.trim_start_matches(':');
+    [
+        format!("{class_qname}::{method_name}"),
+        format!("::{cls}::{method_name}"),
+        format!("{cls}::{method_name}"),
+    ]
+    .iter()
+    .any(|k| pure_methods.contains(k))
+}
+
+/// Expr-tree analogue of [`word_has_observable_side_effect`] — `true`
+/// if any embedded command substitution in the expression has an
+/// observable side effect. Mirrors Python's
+/// `_expr_has_observable_side_effect`.
+fn expr_has_observable_side_effect(
+    node: &ExprNode,
+    registry: Option<&CommandRegistry>,
+    interproc_pure: &HashSet<String>,
+    pure_methods: &HashSet<String>,
+    enclosing_class: Option<&str>,
+) -> bool {
+    match node {
+        ExprNode::Command { text, .. } | ExprNode::Raw { text } => word_has_observable_side_effect(
+            text,
+            registry,
+            interproc_pure,
+            pure_methods,
+            enclosing_class,
+        ),
+        ExprNode::Binary { left, right, .. } => {
+            expr_has_observable_side_effect(
+                left,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            ) || expr_has_observable_side_effect(
+                right,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            )
+        }
+        ExprNode::Unary { operand, .. } => expr_has_observable_side_effect(
+            operand,
+            registry,
+            interproc_pure,
+            pure_methods,
+            enclosing_class,
+        ),
+        ExprNode::Ternary {
+            condition,
+            true_branch,
+            false_branch,
+        } => {
+            expr_has_observable_side_effect(
+                condition,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            ) || expr_has_observable_side_effect(
+                true_branch,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            ) || expr_has_observable_side_effect(
+                false_branch,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            )
+        }
+        ExprNode::Call { args, .. } => args.iter().any(|a| {
+            expr_has_observable_side_effect(
+                a,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            )
+        }),
+        _ => false,
+    }
+}
+
+/// `true` when `stmt` is an assignment whose RHS can be discarded
+/// without losing observable behaviour. A literal (`AssignConst`) is
+/// always safe; value / expr forms require every embedded command
+/// substitution to be provably side-effect-free; `incr v` is safe
+/// unless its optional amount word has a side effect. Any other
+/// statement form is conservatively unsafe. Mirrors Python's
+/// `_assignment_safe_to_delete`.
+fn assignment_safe_to_delete(
+    stmt: &Statement,
+    registry: Option<&CommandRegistry>,
+    interproc_pure: &HashSet<String>,
+    pure_methods: &HashSet<String>,
+    enclosing_class: Option<&str>,
+) -> bool {
+    match stmt {
+        Statement::AssignConst { .. } => true,
+        Statement::AssignValue { value, .. } => !word_has_observable_side_effect(
+            value,
+            registry,
+            interproc_pure,
+            pure_methods,
+            enclosing_class,
+        ),
+        Statement::AssignExpr { expr, .. } => !expr_has_observable_side_effect(
+            expr,
+            registry,
+            interproc_pure,
+            pure_methods,
+            enclosing_class,
+        ),
+        // `incr v` reads + writes v — the assignment itself is the
+        // observable effect, so deleting it is OK when v is dead and
+        // the optional amount word is side-effect-free.
+        Statement::Incr { amount, .. } => match amount {
+            None => true,
+            Some(a) => !word_has_observable_side_effect(
+                a,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            ),
+        },
+        // Unknown statement form — conservative.
+        _ => false,
+    }
+}
+
+/// Collect the qualified names of procs / methods that interprocedural
+/// analysis has proven pure — threaded into the O109 / O126 RHS-purity
+/// gates so `set unused [pureProc]` / `set unused [my pureMethod]` can
+/// fold. Mirrors the `interproc_pure` / `interproc_pure_methods` sets
+/// built at the top of Python's `optimise_elimination_passes`.
+fn pure_call_targets(ctx: &PassContext<'_>) -> (HashSet<String>, HashSet<String>) {
+    let interproc_pure: HashSet<String> = ctx
+        .interproc
+        .procedures
+        .iter()
+        .filter(|(_, s)| s.pure)
+        .map(|(q, _)| q.clone())
+        .collect();
+    let pure_methods: HashSet<String> = ctx
+        .interproc
+        .methods
+        .iter()
+        .filter(|(_, s)| s.base.pure)
+        .map(|(q, _)| q.clone())
+        .collect();
+    (interproc_pure, pure_methods)
+}
 
 /// Run the elimination pass — emits O107, O108, O109, O126
 /// across every function in `cu`.
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
     let is_top_level = |fu: &FunctionUnit| fu.name == "::top";
+    // D2-O126/O109 closure: the user-proc / TclOO-method purity sets
+    // that gate RHS-side-effect-safe deletion (owned so the `&mut ctx`
+    // calls below don't alias `ctx.interproc`).
+    let (interproc_pure, pure_methods) = pure_call_targets(ctx);
 
     emit_unreachable(ctx, &cu.top_level);
-    let baseline = emit_dead_stores_and_unused(ctx, &cu.top_level, is_top_level(&cu.top_level));
+    let baseline = emit_dead_stores_and_unused(
+        ctx,
+        &cu.top_level,
+        is_top_level(&cu.top_level),
+        &interproc_pure,
+        &pure_methods,
+        None,
+    );
     emit_adce(ctx, &cu.top_level, &baseline);
 
     for fu in cu.procedures.values() {
         emit_unreachable(ctx, fu);
-        let baseline = emit_dead_stores_and_unused(ctx, fu, false);
+        let baseline =
+            emit_dead_stores_and_unused(ctx, fu, false, &interproc_pure, &pure_methods, None);
         emit_adce(ctx, fu, &baseline);
     }
 }
@@ -101,7 +360,11 @@ fn emit_dead_stores_and_unused(
     ctx: &mut PassContext<'_>,
     fu: &FunctionUnit,
     is_top_level: bool,
+    interproc_pure: &HashSet<String>,
+    pure_methods: &HashSet<String>,
+    enclosing_class: Option<&str>,
 ) -> HashSet<(String, u32)> {
+    let registry = ctx.registry;
     let unreachable = unreachable_blocks(&fu.cfg, &fu.sccp);
     let scope_aliases = scan_scope_aliases(&fu.cfg);
     // The `def_use` builder does not scan Return-value reads or
@@ -141,6 +404,20 @@ fn emit_dead_stores_and_unused(
         let Some(stmt) = block.statements.get(idx) else {
             continue;
         };
+        // D2-O109/O126 closure: gate deletion on RHS purity. The def is
+        // dead at the SSA level, but its RHS may have observable side
+        // effects (`set unused [puts X]` prints, `set unused [my
+        // impureMethod]` mutates object state). Only delete when every
+        // embedded command substitution is provably side-effect-free.
+        if !assignment_safe_to_delete(
+            stmt,
+            registry,
+            interproc_pure,
+            pure_methods,
+            enclosing_class,
+        ) {
+            continue;
+        }
         // Suppress when this element write is observed by a read the name-level
         // SSA can't see (place-model overlap — the O109 sibling of W220).
         if place_suppressed.contains(&(
@@ -787,6 +1064,48 @@ mod tests {
         assert!(
             bad.is_empty(),
             "[::set x] should count as a read for x; got {opts:?}",
+        );
+    }
+
+    // -- D2-O126/O109 RHS-purity gate (SYNC-JUN02-1 strip 4a) -------------
+
+    #[test]
+    fn o126_preserved_for_impure_command_sub_rhs() {
+        // `set unused [puts hi]` discards the result but still prints —
+        // the assignment must NOT be deleted (was a latent FP: the Rust
+        // O126 fired unconditionally on dead chains).
+        let opts = crate::optimiser::optimise(
+            "proc ::f {} { set unused [puts hi]; return 1 }",
+            &registry(),
+        );
+        assert!(
+            opts.iter().all(|o| o.code != "O126"),
+            "impure cmd-sub RHS must be preserved, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o126_fires_for_pure_user_proc_rhs() {
+        // A user proc proven pure by interproc analysis has no
+        // observable side effect, so `set unused [::pure]` folds.
+        let opts = crate::optimiser::optimise(
+            "proc ::pure {} { return 1 }\nproc ::f {} { set unused [::pure]; return 1 }",
+            &registry(),
+        );
+        assert!(
+            opts.iter().any(|o| o.code == "O126"),
+            "pure-proc RHS should fold to O126, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o126_still_fires_for_literal_rhs() {
+        // The gate must not regress the literal case — `set y 42` has
+        // no RHS side effect and stays foldable.
+        let opts = run_pass("proc ::f {} { set y 42; return 1 }");
+        assert!(
+            opts.iter().any(|o| o.code == "O126"),
+            "literal RHS should still fold, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -51,6 +51,7 @@ use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::ir::{CommandTokens, Script, Statement};
 use crate::naming::normalise_var_name;
 
+use super::helpers::expr_simplify::try_unwrap_expr_in_expr;
 use super::helpers::literals::{is_safe_word, is_static_var_word};
 use super::helpers::spans::{full_quoted_string_span, full_word_span};
 use super::{Optimisation, PassContext};
@@ -404,6 +405,20 @@ fn try_fold_return_terminator(
 ) {
     use crate::naming::normalise_var_name;
 
+    // O115: `return [expr {[expr {E}]}]` → `return [expr {E}]`. Checked
+    // before the `expr`-gate below because the return value of a cmd-sub
+    // also populates `expr`, yet the redundant-nested-expr collapse
+    // operates on the raw value text.
+    if let Some(collapsed) = value.and_then(|raw| o115_redundant_nested_expr(raw.trim())) {
+        ctx.report(Optimisation::new(
+            "O115",
+            "Remove redundant nested expr",
+            span,
+            format!("return {collapsed}"),
+        ));
+        return;
+    }
+
     // Only fold `return $v` — numeric/bare literals and complex
     // values are left to richer passes.
     if expr.is_some() {
@@ -509,6 +524,24 @@ fn try_substitute_assign_expr(
     ));
 }
 
+/// O115 (value position): collapse a redundant double-`expr` command
+/// substitution `[expr {[expr {E}]}]` to `[expr {E}]`, returning the
+/// inner cmd-sub when *word* has that shape.
+///
+/// Sound because both forms evaluate `E` as an expression. The gate is
+/// the double-unwrap: the outer `[expr {…}]`'s body must itself be an
+/// `[expr {…}]` cmd-sub, so the collapsed form stays a valid value-
+/// position word. A plain `[expr {$x + 1}]` (whose unwrap `$x + 1`
+/// would be invalid as a bare value) — or an `[expr {[other]}]` whose
+/// inner is not itself `expr` (not value-equivalent for non-numeric
+/// results) — yields `None`. Mirrors the O115 value-position path added
+/// to `optimise_expr_substitutions` (#519).
+fn o115_redundant_nested_expr(word: &str) -> Option<String> {
+    let expr_arg = try_unwrap_expr_in_expr(word)?;
+    try_unwrap_expr_in_expr(&expr_arg)?;
+    Some(expr_arg)
+}
+
 /// O103 (CMD-subst form): walk each argv word looking for a
 /// command substitution `[cmd …]` whose head resolves to a proc
 /// with `can_fold_static_calls` and a proven `constant_return`.
@@ -526,9 +559,6 @@ fn visit_call_cmd_subst_folds(
 ) {
     use crate::interprocedural::ConstantReturn;
 
-    let Some(ia) = cu.interproc.as_ref() else {
-        return;
-    };
     for (i, argv_span) in tokens.argv.iter().enumerate() {
         let single = tokens.single_token_word.get(i).copied().unwrap_or(false);
         if !single {
@@ -538,6 +568,21 @@ fn visit_call_cmd_subst_folds(
             continue;
         };
         let Some(inner) = text.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+            continue;
+        };
+        // O115: collapse a redundant double-`expr` cmd-sub in this
+        // argument value position (needs no interproc summary).
+        if let Some(collapsed) = o115_redundant_nested_expr(text) {
+            ctx.report(Optimisation::new(
+                "O115",
+                "Remove redundant nested expr",
+                full_word_span(ctx.source, *argv_span),
+                collapsed,
+            ));
+            continue;
+        }
+        // O103 (below) folds a pure-proc cmd-sub to its constant return.
+        let Some(ia) = cu.interproc.as_ref() else {
             continue;
         };
         let Some(head) = parse_cmd_subst_head(inner) else {
@@ -1128,6 +1173,47 @@ mod tests {
         // Leading `$` / `[` / `{` / `"` → would re-substitute.
         assert_eq!(parse_cmd_subst_head("$cmd"), None);
         assert_eq!(parse_cmd_subst_head("[cmd]"), None);
+    }
+
+    #[test]
+    fn o115_collapses_redundant_nested_expr_in_value_positions() {
+        // SYNC-JUN02b-6 (#519): a redundant double-`expr` cmd-sub
+        // `[expr {[expr {E}]}]` collapses to `[expr {E}]` in command-arg
+        // and return value positions (previously O115 only fired on a
+        // standalone `expr` statement).
+        let collapsed = |src: &str| -> Vec<String> {
+            crate::optimiser::optimise_raw(src, &registry(), None)
+                .into_iter()
+                .filter(|o| o.code == "O115")
+                .map(|o| o.replacement)
+                .collect()
+        };
+        assert_eq!(
+            collapsed("proc ::f {x} { puts [expr {[expr {$x * 2}]}] }"),
+            vec!["[expr {$x * 2}]".to_string()],
+            "command-arg position should collapse",
+        );
+        assert_eq!(
+            collapsed("proc ::f {x} { return [expr {[expr {$x * 2}]}] }"),
+            vec!["return [expr {$x * 2}]".to_string()],
+            "return position should collapse",
+        );
+    }
+
+    #[test]
+    fn o115_value_position_is_sound() {
+        // A single `[expr {$x + 1}]` must NOT collapse (its unwrap
+        // `$x + 1` would be invalid as a bare value), and an
+        // `[expr {[other]}]` whose inner is not itself `expr` is not
+        // value-equivalent for non-numeric results.
+        let has_o115 = |src: &str| -> bool {
+            crate::optimiser::optimise_raw(src, &registry(), None)
+                .iter()
+                .any(|o| o.code == "O115")
+        };
+        assert!(!has_o115("proc ::f {x} { puts [expr {$x + 1}] }"));
+        assert!(!has_o115("proc ::f {x} { return [expr {$x + 1}] }"));
+        assert!(!has_o115("proc ::f {x} { puts [expr {[someproc]}] }"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -112,6 +112,7 @@ pub(crate) fn find_shimmer_warnings(
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<String>,
     registry: &CommandRegistry,
+    values: &HashMap<ValueKey, crate::analyses::LatticeValue>,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
     out.extend(use_site::find_use_site_shimmers(
@@ -120,6 +121,7 @@ pub(crate) fn find_shimmer_warnings(
         types,
         executable_blocks,
         registry,
+        values,
     ));
     out.extend(phi::find_phi_shimmers(cfg, ssa, types, executable_blocks));
     out.extend(expr::find_expr_shimmers(cfg, ssa, types, executable_blocks));
@@ -164,10 +166,15 @@ mod tests {
         let ssa = crate::ssa::build_ssa(&f, &registry());
         let sccp = crate::sccp::sccp(&f, &ssa, None);
         let types: HashMap<ValueKey, TypeLattice> = HashMap::new();
-        assert!(
-            find_shimmer_warnings(&f, &ssa, &types, &sccp.executable_blocks, &registry())
-                .is_empty()
-        );
+        assert!(find_shimmer_warnings(
+            &f,
+            &ssa,
+            &types,
+            &sccp.executable_blocks,
+            &registry(),
+            &sccp.values
+        )
+        .is_empty());
         assert!(find_thunking_warnings(&f, &ssa, &types, &sccp.executable_blocks).is_empty());
     }
 }

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, HashSet};
 use tcl_lexer::Span;
 use tcl_registry::{CommandRegistry, TclType};
 
+use crate::analyses::{ConstValue, LatticeValue};
 use crate::cfg::Function as CfgFunction;
 use crate::ir::Statement;
 use crate::naming::normalise_var_name;
@@ -46,6 +47,7 @@ pub(crate) fn find_use_site_shimmers(
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<String>,
     registry: &CommandRegistry,
+    values: &HashMap<ValueKey, LatticeValue>,
 ) -> Vec<ShimmerWarning> {
     let loop_blocks = loop_body_blocks(cfg);
     let def_map = def_range_map(ssa);
@@ -67,6 +69,7 @@ pub(crate) fn find_use_site_shimmers(
                 registry,
                 in_loop,
                 &def_map,
+                values,
                 &mut out,
             );
         }
@@ -75,6 +78,32 @@ pub(crate) fn find_use_site_shimmers(
     out
 }
 
+/// True when `value` is a SCCP CONST string whose text is a hex /
+/// octal / binary integer literal (`0xff`, `0o15`, `0b1010`, optionally
+/// signed). These spellings classify as `String` by `literal_type` (the
+/// canonical stringified intrep differs from the source text) but
+/// promote cleanly to `Int` at the first arithmetic op — not a real
+/// shimmer. Mirrors Python's `_value_is_int_literal_string`.
+fn value_is_int_literal_string(value: Option<&LatticeValue>) -> bool {
+    let Some(LatticeValue::Const(ConstValue::String(text))) = value else {
+        return false;
+    };
+    let sign_stripped = text.strip_prefix(['+', '-']).unwrap_or(text);
+    let bytes = sign_stripped.as_bytes();
+    // Need at least a `0x`-style prefix plus one body digit.
+    if bytes.len() < 3 || bytes[0] != b'0' {
+        return false;
+    }
+    let body = &sign_stripped[2..];
+    match bytes[1] {
+        b'x' | b'X' => body.bytes().all(|c| c.is_ascii_hexdigit()),
+        b'o' | b'O' => body.bytes().all(|c| (b'0'..=b'7').contains(&c)),
+        b'b' | b'B' => body.bytes().all(|c| c == b'0' || c == b'1'),
+        _ => false,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn check_statement(
     stmt: &Statement,
     uses: &HashMap<String, u32>,
@@ -82,6 +111,7 @@ fn check_statement(
     registry: &CommandRegistry,
     in_loop: bool,
     def_map: &HashMap<ValueKey, Span>,
+    values: &HashMap<ValueKey, LatticeValue>,
     out: &mut Vec<ShimmerWarning>,
 ) {
     match stmt {
@@ -161,6 +191,14 @@ fn check_statement(
             if is_numeric_compatible(current, TclType::Int) {
                 return;
             }
+            // A hex / octal / binary literal string (`0x80`, `0b1010`)
+            // classifies as String but promotes cleanly to Int at the
+            // `incr` — not a real shimmer (SYNC-MAY31-1e; avoids the
+            // spurious S101 on the tcllib `variable n 0x80; … incr n`
+            // idiom).
+            if value_is_int_literal_string(values.get(&(var.clone(), ver))) {
+                return;
+            }
             let related: Vec<(Span, String)> = def_map
                 .get(&(var.clone(), ver))
                 .map(|&sp| vec![(sp, "value defined here".to_owned())])
@@ -207,6 +245,7 @@ mod tests {
             &fu.types,
             &fu.sccp.executable_blocks,
             &registry(),
+            &fu.sccp.values,
         );
         let w = warnings
             .iter()
@@ -216,6 +255,27 @@ mod tests {
             "expected incr/String shimmer, got: {warnings:?}"
         );
         assert_eq!(w.unwrap().to_type, TclType::Int);
+    }
+
+    /// SYNC-MAY31-1e: a hex literal string (`0x80`) classifies as
+    /// String but promotes cleanly to Int at `incr` — no shimmer.
+    #[test]
+    fn no_shimmer_for_hex_literal_string_used_with_incr() {
+        let cu = CompilationUnit::build_for("set n 0x80\nincr n", &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let incr_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "incr").collect();
+        assert!(
+            incr_shimmers.is_empty(),
+            "0x80 promotes cleanly to int — no incr shimmer expected: {incr_shimmers:?}",
+        );
     }
 
     /// An Int variable passed to `incr` has no shimmer.
@@ -229,6 +289,7 @@ mod tests {
             &fu.types,
             &fu.sccp.executable_blocks,
             &registry(),
+            &fu.sccp.values,
         );
         let incr_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "incr").collect();
         assert!(
@@ -249,6 +310,7 @@ mod tests {
             &fu.types,
             &fu.sccp.executable_blocks,
             &registry(),
+            &fu.sccp.values,
         );
         let w = warnings.iter().find(|w| w.command == "lindex");
         assert!(
@@ -271,6 +333,7 @@ mod tests {
             &fu.types,
             &fu.sccp.executable_blocks,
             &registry(),
+            &fu.sccp.values,
         );
         // x has Unknown type; should not produce a shimmer.
         let lindex_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "lindex").collect();

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -419,9 +419,39 @@ fn eval_binary(op: BinOp, left: &ExprNode, right: &ExprNode, env: &Env) -> Optio
         return apply_irules_string_op(op, &ls, &rs);
     }
 
+    // Tcl string-comparison ops (`eq`/`ne`/`lt`/`le`/`gt`/`ge`) always
+    // compare their operands *as strings* (unlike `==`/`!=`), so extract
+    // string operands — evaluating a bare string like `"x"` numerically
+    // yields nothing, leaving `"x" ne "y"` (and `5 eq 5.0`) unfolded.
+    // Mirrors `tcl_expr_eval.py::_STRING_COMPARE_OPS` (#519).
+    if matches!(
+        op,
+        BinOp::StrEq | BinOp::StrNe | BinOp::StrLt | BinOp::StrLe | BinOp::StrGt | BinOp::StrGe
+    ) {
+        let ls = eval_as_string(left, env)?;
+        let rs = eval_as_string(right, env)?;
+        return apply_string_compare(op, &ls, &rs);
+    }
+
     let lv = eval(left, env)?;
     let rv = eval(right, env)?;
     apply_binary(op, lv, rv)
+}
+
+/// Apply a Tcl string-comparison operator (`eq`/`ne`/`lt`/`le`/`gt`/`ge`)
+/// to two already-stringified operands. Mirrors Python's
+/// `_apply_string_compare`.
+fn apply_string_compare(op: BinOp, a: &str, b: &str) -> Option<TclValue> {
+    let result = match op {
+        BinOp::StrEq => a == b,
+        BinOp::StrNe => a != b,
+        BinOp::StrLt => a < b,
+        BinOp::StrLe => a <= b,
+        BinOp::StrGt => a > b,
+        BinOp::StrGe => a >= b,
+        _ => return None,
+    };
+    Some(TclValue::Int(i64::from(result)))
 }
 
 fn apply_binary(op: BinOp, a: TclValue, b: TclValue) -> Option<TclValue> {
@@ -480,29 +510,17 @@ fn apply_binary(op: BinOp, a: TclValue, b: TclValue) -> Option<TclValue> {
             numeric_cmp(a, b) != std::cmp::Ordering::Less,
         ))),
 
-        // String comparison — render both sides via format_tcl_value
-        // and compare lexicographically.
-        BinOp::StrEq => Some(TclValue::Int(i64::from(
-            format_tcl_value(a) == format_tcl_value(b),
-        ))),
-        BinOp::StrNe => Some(TclValue::Int(i64::from(
-            format_tcl_value(a) != format_tcl_value(b),
-        ))),
-        BinOp::StrLt => Some(TclValue::Int(i64::from(
-            format_tcl_value(a) < format_tcl_value(b),
-        ))),
-        BinOp::StrLe => Some(TclValue::Int(i64::from(
-            format_tcl_value(a) <= format_tcl_value(b),
-        ))),
-        BinOp::StrGt => Some(TclValue::Int(i64::from(
-            format_tcl_value(a) > format_tcl_value(b),
-        ))),
-        BinOp::StrGe => Some(TclValue::Int(i64::from(
-            format_tcl_value(a) >= format_tcl_value(b),
-        ))),
-
-        // Short-circuit and iRules string ops are handled in eval_binary.
-        BinOp::And
+        // String-comparison ops (eq/ne/lt/le/gt/ge) are routed through
+        // `apply_string_compare` from `eval_binary` before they reach here
+        // (they need string, not numeric, operands), as are the
+        // short-circuit and iRules string ops.
+        BinOp::StrEq
+        | BinOp::StrNe
+        | BinOp::StrLt
+        | BinOp::StrLe
+        | BinOp::StrGt
+        | BinOp::StrGe
+        | BinOp::And
         | BinOp::Or
         | BinOp::WordAnd
         | BinOp::WordOr
@@ -1007,6 +1025,22 @@ mod tests {
     fn string_comparisons() {
         assert_eq!(eval_str("1 eq 1"), Some(TclValue::Int(1)));
         assert_eq!(eval_str("1 ne 2"), Some(TclValue::Int(1)));
+    }
+
+    #[test]
+    fn string_comparisons_fold_string_operands() {
+        // SYNC-JUN02b-5 (#519): `eq`/`ne`/`lt`/`gt`/`le`/`ge` compare
+        // operands AS strings, so string-only operands now fold
+        // (previously `eval` parsed them numerically, returning None).
+        assert_eq!(eval_str("\"x\" eq \"y\""), Some(TclValue::Int(0)));
+        assert_eq!(eval_str("\"x\" ne \"y\""), Some(TclValue::Int(1)));
+        assert_eq!(eval_str("\"x\" eq \"x\""), Some(TclValue::Int(1)));
+        // Lexical ordering on string operands.
+        assert_eq!(eval_str("\"abc\" lt \"abd\""), Some(TclValue::Int(1)));
+        assert_eq!(eval_str("\"b\" gt \"a\""), Some(TclValue::Int(1)));
+        // `5 eq 5.0` compares the strings "5" vs "5.0" (→ 0), matching
+        // C Tcl 9 — a regression guard for the numeric-looking case.
+        assert_eq!(eval_str("5 eq 5.0"), Some(TclValue::Int(0)));
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/codegen_integration.rs
+++ b/rust/tcl-compiler/tests/codegen_integration.rs
@@ -403,6 +403,7 @@ fn switch_glob_emits_generic_invoke_not_jump_table() {
             mode,
             nocase: false,
             raw_args: vec!["$x".into(), "a* {set r 1} b* {set r 1}".into()],
+            patterns_braced: true,
         }])
     };
     let registry = CommandRegistry::build_default();

--- a/rust/tcl-compiler/tests/codegen_integration.rs
+++ b/rust/tcl-compiler/tests/codegen_integration.rs
@@ -724,6 +724,7 @@ fn codegen_module_with_no_procs() {
         procedures: HashMap::new(),
         methods: HashMap::new(),
         redefined_procedures: HashSet::new(),
+        redefined_methods: HashSet::new(),
         namespace_imports: Vec::new(),
         namespace_exports: Vec::new(),
         traced_commands: std::collections::BTreeSet::new(),


### PR DESCRIPTION
Brings the rust workstream's pre-ARCH state (CwuDW commit
5af5d49d) onto current main as a single consolidation commit.
This is necessary because origin/rust was force-pushed and
orphaned the in-flight rust work; reconstructing the individual
commit history is impractical because both lineages (origin/rust
and bd82fae9) became disjoint orphans relative to main and to
each other.

Content vendored in:
- rust/ workspace: tcl-lexer, tcl-registry, tcl-compiler, tcl-lsp-rust
- Cargo.toml, Cargo.lock, rust-toolchain.toml at repo root
- rust integration adapters in core/parsing/lexer.py,
  core/compiler/optimiser/_manager.py, core/compiler/gvn.py,
  core/compiler/interprocedural.py, core/compiler/rust_spans.py
- rust integration tests under tests/test_rust_*.py
- rust rewrite docs (rust-rewrite.md, rust-optimiser-parity.md,
  rust-rewrite-test-audit.md, kcs-qa-rust-shim-env-vars.md)

The tree at this commit matches the rust/ + rust-integration
state from CwuDW@5af5d49d. The ARCH0-9 cleanup (which depends
on this state) lands in a follow-up commit / branch.

Non-rust changes from the bd82fae9 lineage (zig runtime
modifications, scripts, baselines, Python improvements) are
intentionally NOT brought across — they are independent work,
not rust workstream content, and would conflict with main's
own evolution of those areas.