### PR TITLE
test(vscode): de-flake variable-context completion probes and deep-diagnostics waits

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=623bc97-dirty
-head=623bc97ab807306c7b6c0cbc1f529b17da733f3e
-date=2026-06-02T12:47:27Z
-fingerprint=6035d885267a900e8b843bb1575691eb08641acf2301e95b7ce2cb1adeafefa6
+describe=v1.10.10-15-gbdc3b6ce8-dirty
+head=bdc3b6ce84d1bd884ce00b7102e457aee399be26
+date=2026-06-02T15:52:58Z
+fingerprint=50fdd27095be88dc81b3638708e565b2c4cf968489d0764a0f358479bcdd3506

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -140,6 +140,13 @@ export async function waitForServerLog(
  * Pass ``opts.since = getServerLogSize()`` captured **before** the
  * triggering action (didOpen, edit, restart) so the wait only matches
  * the run you care about, not a deep pass from an earlier test.
+ *
+ * Defaults to a 20s deadline (matching ``waitForDiagnostics``) rather
+ * than ``waitForServerLog``'s 5s: the deep pass runs *after* the basic
+ * pass and is at least as slow, so under parallel ``test-slow`` load it
+ * routinely needs more than 5s to land — a tighter default made callers
+ * like the ``optimiser.enabled`` toggle test flake.  Callers may still
+ * pass an explicit ``timeout`` to override.
  */
 export async function waitForDeepDiagnostics(
   docUri: vscode.Uri,
@@ -148,7 +155,7 @@ export async function waitForDeepDiagnostics(
   const uri = docUri.toString();
   const hit = await waitForServerLog(
     (line) => line.includes("[timing] deep diagnostics") && line.includes(`uri=${uri}`),
-    opts,
+    { since: opts?.since, timeout: opts?.timeout ?? 20_000 },
   );
   if (hit === null) {
     throw new Error(

--- a/editors/vscode/src/test/variableContexts.test.ts
+++ b/editors/vscode/src/test/variableContexts.test.ts
@@ -1,17 +1,70 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, waitForDiagnostics } from "./helper";
+import { getDocUri, activate, waitForDiagnostics, pollUntil } from "./helper";
+
+function labelOf(item: vscode.CompletionItem): string {
+  return typeof item.label === "string" ? item.label : item.label.label;
+}
+
+/**
+ * Request completion at *position* and poll until every label in *expect*
+ * is present, or a deadline passes.
+ *
+ * ``applyEdit`` returns as soon as VS Code has buffered the change for the
+ * language server; it does **not** wait for the server to re-analyse the
+ * mutated document.  A completion request fired immediately afterwards can
+ * therefore race the re-index and return stale results that omit a
+ * newly-in-scope variable — the source of the intermittent failures these
+ * probes used to exhibit under parallel ``make test-slow`` load.
+ *
+ * Rather than sleep for a fixed interval, we re-request completion on a
+ * bounded poll (via the shared ``pollUntil`` helper) until the server has
+ * caught up and surfaces the expected items.  ``pollUntil`` throws on
+ * timeout with the last-seen item list, so a genuine regression still
+ * fails loudly — the wait only absorbs the re-index latency, it does not
+ * mask a missing variable.
+ */
+async function completionItemsAt(
+  uri: vscode.Uri,
+  position: vscode.Position,
+  expect: string[],
+): Promise<vscode.CompletionItem[]> {
+  return pollUntil(
+    async () => {
+      const result = (await vscode.commands.executeCommand(
+        "vscode.executeCompletionItemProvider",
+        uri,
+        position,
+      )) as vscode.CompletionList;
+      return result.items;
+    },
+    (items) => {
+      const labels = new Set(items.map(labelOf));
+      return expect.every((label) => labels.has(label));
+    },
+    {
+      timeout: 10_000,
+      label: `completion items [${expect.join(", ")}] at ${position.line}:${position.character}`,
+    },
+  );
+}
 
 /**
  * Marker-based completion probing: find ``# PROBE_X`` in the fixture,
  * insert the supplied probe text on the line after the marker, position
- * the cursor at the end of the inserted text, request completion, then
- * revert the in-memory edit so the next test sees the canonical fixture.
+ * the cursor at the end of the inserted text, request completion (waiting
+ * for the server to re-index — see ``completionItemsAt``), then revert the
+ * in-memory edit so the next test sees the canonical fixture.
+ *
+ * ``expect`` lists the labels the caller is about to assert on; the probe
+ * does not return until they are all present or the deadline passes, which
+ * is what makes it deterministic under load.
  */
 async function probeAt(
   uri: vscode.Uri,
   marker: string,
   insertion: string,
+  expect: string[],
 ): Promise<vscode.CompletionItem[]> {
   const doc = await activate(uri);
   const text = doc.getText();
@@ -27,19 +80,10 @@ async function probeAt(
   await vscode.workspace.applyEdit(edit);
   const completionPos = doc.positionAt(eolOffset + insertion.length);
   try {
-    const result = (await vscode.commands.executeCommand(
-      "vscode.executeCompletionItemProvider",
-      uri,
-      completionPos,
-    )) as vscode.CompletionList;
-    return result.items;
+    return await completionItemsAt(uri, completionPos, expect);
   } finally {
     await vscode.commands.executeCommand("workbench.action.files.revert", doc);
   }
-}
-
-function labelOf(item: vscode.CompletionItem): string {
-  return typeof item.label === "string" ? item.label : item.label.label;
 }
 
 function insertedText(item: vscode.CompletionItem): string | undefined {
@@ -65,7 +109,7 @@ suite("Variable Completion: command contexts", () => {
   // the surrounding proc body.
 
   test("variable: namespace var alias is in scope inside the proc", async () => {
-    const items = await probeAt(docUri, "# PROBE_VARIABLE", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_VARIABLE", "\n        puts $", ["$namespace_var"]);
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$namespace_var"),
@@ -74,7 +118,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("namespace upvar: local alias is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_NS_UPVAR", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_NS_UPVAR", "\n        puts $", ["$local_ns_var"]);
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$local_ns_var"),
@@ -83,7 +127,11 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("lassign: each destructured var is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_LASSIGN", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_LASSIGN", "\n        puts $", [
+      "$la",
+      "$lb",
+      "$lc",
+    ]);
     const labels = items.map(labelOf);
     for (const v of ["$la", "$lb", "$lc"]) {
       assert.ok(
@@ -94,7 +142,11 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("regexp: capture-group vars are in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_REGEXP", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_REGEXP", "\n        puts $", [
+      "$rx_full",
+      "$rx_key",
+      "$rx_value",
+    ]);
     const labels = items.map(labelOf);
     for (const v of ["$rx_full", "$rx_key", "$rx_value"]) {
       assert.ok(
@@ -105,13 +157,13 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("regsub: output var is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_REGSUB", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_REGSUB", "\n        puts $", ["$rs_out"]);
     const labels = items.map(labelOf);
     assert.ok(labels.includes("$rs_out"), `Expected $rs_out: ${labels.slice(0, 30).join(", ")}`);
   });
 
   test("scan: each output var is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_SCAN", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_SCAN", "\n        puts $", ["$sx", "$sy", "$sz"]);
     const labels = items.map(labelOf);
     for (const v of ["$sx", "$sy", "$sz"]) {
       assert.ok(labels.includes(v), `Expected ${v} after scan: ${labels.slice(0, 30).join(", ")}`);
@@ -119,7 +171,10 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("catch: resultVar and optionsVar are in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_CATCH", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_CATCH", "\n        puts $", [
+      "$catch_result",
+      "$catch_opts",
+    ]);
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$catch_result"),
@@ -132,7 +187,10 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("try on error: handler binding-list vars are in scope inside body", async () => {
-    const items = await probeAt(docUri, "# PROBE_TRY", "\n            puts $");
+    const items = await probeAt(docUri, "# PROBE_TRY", "\n            puts $", [
+      "$try_msg",
+      "$try_opts",
+    ]);
     const labels = items.map(labelOf);
     for (const v of ["$try_msg", "$try_opts"]) {
       assert.ok(
@@ -143,7 +201,10 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("dict update: alias vars are in scope inside body", async () => {
-    const items = await probeAt(docUri, "# PROBE_DICT_UPDATE", "\n            puts $");
+    const items = await probeAt(docUri, "# PROBE_DICT_UPDATE", "\n            puts $", [
+      "$alias_a",
+      "$alias_b",
+    ]);
     const labels = items.map(labelOf);
     for (const v of ["$alias_a", "$alias_b"]) {
       assert.ok(
@@ -158,7 +219,9 @@ suite("Variable Completion: command contexts", () => {
     // we can't resolve statically.  We keep best-effort behaviour: the
     // calling proc's locals stay visible.  Just check that completion
     // works (returns at least one item) and includes the proc-local.
-    const items = await probeAt(docUri, "# PROBE_UPLEVEL_ONE", "\n            puts $");
+    const items = await probeAt(docUri, "# PROBE_UPLEVEL_ONE", "\n            puts $", [
+      "$up1_local",
+    ]);
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$up1_local"),
@@ -175,7 +238,7 @@ suite("Variable Completion: TextEdit shape", () => {
     // is in scope.  Type a single ``$`` and check that selecting the
     // ``$greeting`` completion produces a TextEdit whose range starts
     // at the typed ``$``, and whose new text starts with ``$``.
-    const items = await probeAt(docUri, "# PROBE_PARTIAL", "\n        puts $");
+    const items = await probeAt(docUri, "# PROBE_PARTIAL", "\n        puts $", ["$greeting"]);
     const item = items.find((i) => labelOf(i) === "$greeting");
     assert.ok(item, "Expected $greeting in completion list");
     const te = textEditOf(item);
@@ -195,7 +258,7 @@ suite("Variable Completion: TextEdit shape", () => {
   });
 
   test("$gre partial -- TextEdit replaces the partial with $greeting", async () => {
-    const items = await probeAt(docUri, "# PROBE_PARTIAL", "\n        puts $gre");
+    const items = await probeAt(docUri, "# PROBE_PARTIAL", "\n        puts $gre", ["$greeting"]);
     const item = items.find((i) => labelOf(i) === "$greeting");
     assert.ok(item, "Expected $greeting in completion list");
     const te = textEditOf(item);
@@ -210,7 +273,7 @@ suite("Variable Completion: TextEdit shape", () => {
   });
 
   test("${gre partial -- TextEdit emits ${greeting} with closing brace", async () => {
-    const items = await probeAt(docUri, "# PROBE_PARTIAL", "\n        puts ${gre");
+    const items = await probeAt(docUri, "# PROBE_PARTIAL", "\n        puts ${gre", ["$greeting"]);
     const item = items.find((i) => labelOf(i) === "$greeting");
     assert.ok(item, "Expected $greeting in completion list");
     const te = textEditOf(item);
@@ -234,12 +297,8 @@ suite("Variable Completion: TextEdit shape", () => {
     // Cursor between ``e`` and ``}`` -- one char before the end of insertion.
     const completionPos = doc.positionAt(eolOffset + insertion.length - 1);
     try {
-      const result = (await vscode.commands.executeCommand(
-        "vscode.executeCompletionItemProvider",
-        docUri,
-        completionPos,
-      )) as vscode.CompletionList;
-      const item = result.items.find((i) => labelOf(i) === "$greeting");
+      const items = await completionItemsAt(docUri, completionPos, ["$greeting"]);
+      const item = items.find((i) => labelOf(i) === "$greeting");
       assert.ok(item, "Expected $greeting");
       const te = textEditOf(item);
       assert.ok(te, "Expected TextEdit");
@@ -274,12 +333,8 @@ suite("Variable Completion: TextEdit shape", () => {
     const cursorOffset = eolOffset + 1 + 8 + 6 + 4; // \n + spaces + "puts $" + "gre"
     const completionPos = doc.positionAt(cursorOffset);
     try {
-      const result = (await vscode.commands.executeCommand(
-        "vscode.executeCompletionItemProvider",
-        docUri,
-        completionPos,
-      )) as vscode.CompletionList;
-      const item = result.items.find((i) => labelOf(i) === "$greeting");
+      const items = await completionItemsAt(docUri, completionPos, ["$greeting"]);
+      const item = items.find((i) => labelOf(i) === "$greeting");
       assert.ok(item, "Expected $greeting in completion list");
       const te = textEditOf(item);
       assert.ok(te, "Expected TextEdit");
@@ -312,12 +367,8 @@ suite("Variable Completion: TextEdit shape", () => {
     await vscode.workspace.applyEdit(edit);
     const completionPos = doc.positionAt(eolOffset + insertion.length);
     try {
-      const result = (await vscode.commands.executeCommand(
-        "vscode.executeCompletionItemProvider",
-        otherUri,
-        completionPos,
-      )) as vscode.CompletionList;
-      const item = result.items.find((i) => labelOf(i) === "$foo-bar");
+      const items = await completionItemsAt(otherUri, completionPos, ["$foo-bar"]);
+      const item = items.find((i) => labelOf(i) === "$foo-bar");
       assert.ok(item, "Expected $foo-bar in completion list");
       assert.strictEqual(
         insertedText(item),


### PR DESCRIPTION
## Summary

Two test-only fixes for pre-existing flakes in the VS Code extension suite that surface under parallel `make test-slow` load (both pass standalone). No server/behaviour changes.

- **`variableContexts.test.ts`** — `probeAt()` inserted text via `applyEdit` then immediately requested completion, with no wait for the server to re-analyse the mutated document. Under CPU contention the completion request raced the re-index and returned stale results omitting the newly in-scope variable, intermittently failing three tests (namespace var alias, namespace upvar, lassign destructuring). The probes now poll the completion provider via the existing `pollUntil` helper until the expected labels appear (10s deadline). The same hardening is applied to the other `PROBE_*` probes and the three inline `applyEdit`+completion tests via a shared `completionItemsAt()` helper. No fixed sleeps; assertions unchanged.

- **`helper.ts`** — `waitForDeepDiagnostics` inherited `waitForServerLog`'s 5s default, while its sibling `waitForDiagnostics` allows 20s. The deep pass runs after, and is at least as slow as, the basic pass, so under load it routinely needs more than 5s — flaking `configSettings.test.ts`'s "disabling optimiser.enabled suppresses O1xx diagnostics". Defaulted the deadline to 20s (callers can still override). No assertion weakened.

In both cases `pollUntil` / the wait still throws on a genuine timeout — the change only absorbs re-index/analysis latency, it does not mask a real regression.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

- `cd editors/vscode && npx tsc -p . --noEmit` — clean
- `cd editors/vscode && npm run lint` — clean (eslint + prettier)
- `make test-ext` — 440 passing
- Loop under 2× CPU overcommit (40 `yes` workers on 20 cores, harsher than `test-slow`):
  - 10× full suite for the completion-probe fix — three target tests 3/3 every iteration, `fail=0`
  - 6× full suite for the deep-diagnostics fix — optimiser test 1/1 and the three probe tests 3/3 every iteration, `fail=0`

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No (test-only changes)
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.
- [ ] If I added a new compiler KCS note, I linked it from both:
  - `docs/kcs/compiler/README.md`
  - `docs/kcs/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)