### PR TITLE
Close optimization gaps: embedded cmd-subs, nested expr vars, subst fold

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=5226f9c-dirty
-head=5226f9cef63bbff88c34e113300cbf6cafc8ac20
-date=2026-06-02T16:06:23Z
-fingerprint=a3f4313df1d3adf2db4c34a03859787b33ba082727dc85d4d6006268f273bdd2
+describe=e64aff2-dirty
+head=e64aff2938a5ed93837acc54219024e531c8fe98
+date=2026-06-02T18:18:21Z
+fingerprint=137f34c93d704593542c838c7321443e494563d0630a09ecb9eb4793dd69897a

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=45aef45-dirty
-head=45aef45a3bfdb252ffcf04a1902cccb094a2db02
-date=2026-06-02T18:31:25Z
-fingerprint=40834470f047f91626f62e3f7763fee83a1f899a9c974368213435e35092bf18
+describe=97c878a-dirty
+head=97c878a1f0c199b8e1322038b203a02613afbf73
+date=2026-06-02T19:38:58Z
+fingerprint=b99a16defa7c9c6c46999f5414395b70b2cfdd83fdeb162153a802b9ebdaf150

--- a/compiler/codegen/bytecode/_bytecoded.py
+++ b/compiler/codegen/bytecode/_bytecoded.py
@@ -21,20 +21,24 @@ class _BytecodedMixin:
     """Mixin: bytecoded command optimisations dispatched via REGISTRY hooks."""
 
     def _try_bytecoded(self: _Emitter, cmd: str, args: tuple[str, ...]) -> bool:
+        from compiler.command_trust import builtin_is_trusted
         from compiler.registry import REGISTRY
 
-        # TODO(command-binding): this bytecode backend direct-dispatches a
-        # builtin by *name* via its registry ``vm`` codegen hook, ignoring any
-        # ``rename`` / redefinition in the unit — the same unsoundness the WASM
-        # backend had before it was gated (e.g. ``rename string ::s; string
-        # length hi`` would still emit the builtin).  It needs the same fix:
-        #   1. scope the lattice-derived trust verdict around the bytecode
-        #      codegen entry (``with command_trust(module_command_trust(...))``,
-        #      as compiler/codegen/wasm/api.py does), and
-        #   2. gate this dispatch on ``builtin_is_trusted(cmd)`` so a rebound
-        #      command falls through to the interpreter path instead.
-        # And, as in WASM, full correctness for a builtin renamed *to a proc*
-        # additionally needs interp→compiled-proc dispatch in the VM runtime.
+        # A builtin renamed / redefined in this unit no longer carries its core
+        # semantics, so its ``vm`` codegen hook (a direct, name-keyed dispatch)
+        # must not fire — return False so ``_emit_call`` falls through to the
+        # generic ``invokeStk``, which resolves the name through the live,
+        # rename-aware runtime command table (matching the WASM backend's
+        # value/expr/statement gates).  The trust verdict is scoped around the
+        # bytecode codegen entry in ``codegen_module``; outside that scope the
+        # default "trust all" keeps standalone ``codegen_function`` unchanged.
+        #
+        # A builtin renamed *to a user proc* additionally needs interp→compiled-
+        # proc dispatch in the VM runtime to *execute* correctly; until then the
+        # generic invoke fails safe (the VM resolves the live command) rather
+        # than emitting the wrong builtin inline.
+        if not builtin_is_trusted(cmd):
+            return False
         spec = REGISTRY.get_any(cmd)
         if spec is None:
             return False

--- a/compiler/codegen/bytecode/_cmd_subst.py
+++ b/compiler/codegen/bytecode/_cmd_subst.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from compiler.command_trust import builtin_is_trusted
 from compiler.parsing.expr_parser import parse_expr as _parse_expr_ast
 from shared.tcl_subst import backslash_subst as _tcl_backslash_subst
 
@@ -444,6 +445,17 @@ class _CmdSubstMixin:
 
         cmd = parts[0][0]
         args = parts[1:]
+
+        # A builtin renamed / redefined in this unit no longer carries its core
+        # semantics, so none of the specialised inline-opcode dispatches below
+        # (``strlen``, ``incrStkImm``, ``str*``, …) may fire for it — emit a
+        # generic invoke so the runtime resolves the live, rename-aware command.
+        # Mirrors the ``_try_bytecoded`` gate and the WASM value/expr gates; the
+        # trust verdict is scoped around the codegen entry in ``codegen_module``
+        # (default "trust all" outside it leaves every inline dispatch enabled).
+        if not builtin_is_trusted(cmd):
+            self._emit_generic_cmd_subst(cmd, args)
+            return
 
         if cmd == "expr" and len(args) == 1:
             # Inline the expression body

--- a/compiler/codegen/bytecode/_emitter.py
+++ b/compiler/codegen/bytecode/_emitter.py
@@ -1198,31 +1198,41 @@ def codegen_module(
     optimise: bool = False,
 ) -> ModuleAsm:
     """Generate bytecode assembly for an entire module."""
-    # Proc definitions are now always emitted as runtime IRCall
-    # statements at their original source positions (the lowering
-    # always returns IRCall for ``proc``).  We no longer pre-emit
-    # them via _pending_proc_defs because that would double-emit
-    # and, more critically, emit proc defs from inside ``catch``
-    # bodies at the top level where errors cannot be intercepted.
-    top = _Emitter(
-        cfg_module.top_level,
-        optimise=optimise,
-        is_proc=False,
-    ).generate()
+    from compiler.command_trust import command_trust, module_command_trust
 
-    procs: dict[str, FunctionAsm] = {}
-    for qname, cfg_func in cfg_module.procedures.items():
-        ir_proc = ir_module.procedures.get(qname)
-        # Skip procs defined inside namespace eval — tclsh compiles
-        # them lazily at runtime, not at compile time.
-        if ir_proc and ir_proc.namespace_scoped:
-            continue
-        # Skip procs whose body is purely a runtime-dispatch barrier
-        # (e.g. ``proc set_global {} {uplevel #0 {set ::g 42}}``):
-        # tclsh keeps these uncompiled so their bytecode doesn't
-        # appear in the captured reference disasm either.
-        if _proc_is_compile_blocked(ir_proc):
-            continue
-        params = ir_proc.params if ir_proc else ()
-        procs[qname] = codegen_function(cfg_func, params=params, optimise=optimise, is_proc=True)
-    return ModuleAsm(top_level=top, procedures=procs)
+    # Scope the lattice-derived builtin-trust verdict around the whole codegen
+    # so ``_try_bytecoded`` can refuse to direct-dispatch a renamed / redefined
+    # builtin (mirrors ``compiler/codegen/wasm/api.py``).  ``module_command_trust``
+    # is the whole-unit summary of tampered builtins; an empty set (the common
+    # case) leaves every direct dispatch enabled exactly as before.
+    with command_trust(module_command_trust(ir_module)):
+        # Proc definitions are now always emitted as runtime IRCall
+        # statements at their original source positions (the lowering
+        # always returns IRCall for ``proc``).  We no longer pre-emit
+        # them via _pending_proc_defs because that would double-emit
+        # and, more critically, emit proc defs from inside ``catch``
+        # bodies at the top level where errors cannot be intercepted.
+        top = _Emitter(
+            cfg_module.top_level,
+            optimise=optimise,
+            is_proc=False,
+        ).generate()
+
+        procs: dict[str, FunctionAsm] = {}
+        for qname, cfg_func in cfg_module.procedures.items():
+            ir_proc = ir_module.procedures.get(qname)
+            # Skip procs defined inside namespace eval — tclsh compiles
+            # them lazily at runtime, not at compile time.
+            if ir_proc and ir_proc.namespace_scoped:
+                continue
+            # Skip procs whose body is purely a runtime-dispatch barrier
+            # (e.g. ``proc set_global {} {uplevel #0 {set ::g 42}}``):
+            # tclsh keeps these uncompiled so their bytecode doesn't
+            # appear in the captured reference disasm either.
+            if _proc_is_compile_blocked(ir_proc):
+                continue
+            params = ir_proc.params if ir_proc else ()
+            procs[qname] = codegen_function(
+                cfg_func, params=params, optimise=optimise, is_proc=True
+            )
+        return ModuleAsm(top_level=top, procedures=procs)

--- a/compiler/codegen/wasm/_emitter/_control_flow.py
+++ b/compiler/codegen/wasm/_emitter/_control_flow.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 else:
     _Base = object
 
+from ....command_trust import builtin_is_trusted
 from ....expr_ast import (
     ExprNode,
 )
@@ -705,14 +706,23 @@ class _WasmEmitterCtrlMixin(_Base):
                     keep_on_stack=True,
                 )
             case IRIncr(name=name, amount=amount):
-                # TODO(command-binding): not rename-gated.  When ``incr`` is
-                # renamed/redefined in this unit this value-context lowering
-                # still emits the inline integer increment instead of routing to
-                # the interpreter (cf. the statement-context IRIncr gate in
-                # _statements.py).  Left ungated for now because this position
-                # leaves a result on the stack and the eval-fallback stack
-                # discipline here is delicate; gate it once interp→compiled-proc
-                # dispatch lands so the renamed-to-proc case is also correct.
+                # ``incr`` renamed/redefined in this unit → route this value
+                # (tail-of-catch-body) lowering through the interpreter so the
+                # replacement command's semantics apply instead of the inline
+                # integer increment (cf. the statement-context gate in
+                # _statements.py).  ``_emit_eval_fallback`` leaves the result
+                # (boxed TclObj) on the stack — exactly what this position needs
+                # for ``catch_set_ok_result`` to latch — and reloads locals from
+                # the frame internally, so a later read of *name* sees the
+                # interpreter's update rather than a stale local.  (A builtin
+                # renamed *to a compiled proc* still traps in the fallback until
+                # interp→compiled-proc dispatch lands — fails safe.  See
+                # _values.py.)
+                if not builtin_is_trusted("incr"):
+                    self._intern_local(name)
+                    incr_args = (name,) if amount is None else (name, amount)
+                    self._emit_eval_fallback("incr", incr_args)
+                    return
                 # Issue #262: route through ``tcl_incr`` for the
                 # strict-integer guard (rejects float strings).
                 # Lenient read so an unset scalar initialises to 0

--- a/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/compiler/codegen/wasm/_emitter/_expressions.py
@@ -741,15 +741,20 @@ class _WasmEmitterExprMixin(_Base):
         # builtin semantics — route it through the interpreter (live runtime
         # command table) rather than any builtin fast-path below.  Common case
         # (empty untrusted set) is unaffected.
-        # TODO(command-binding): renamed-*to-a-proc* still traps here — the
-        # interpreter fallback can't dispatch to a compiled proc body; needs
-        # interp→compiled-proc dispatch in the Zig runtime.  See _values.py.
-        # A *known compiled proc* gets a rename-aware, trace-aware guarded
-        # dispatch instead of a blind eval-fallback — see
-        # ``_emit_distrust_proc_subst``.  Without it, every recursive
-        # ``[proc …]`` under distrust pushes ~10 interpreter wasm frames
-        # per level, overflowing the recursion gate for a deep
-        # ``expr``-bodied recursion (compExpr-old-3.8's ``12days``).
+        #
+        # A builtin renamed/redefined *to a user proc* now dispatches correctly:
+        # the eval-fallback's ``tcl_eval`` resolves the name and
+        # ``eval_proc_call_bucket`` routes a compiled (``func_idx != 0``) proc
+        # through the host bridge, and a *known compiled proc* additionally takes
+        # the rename-aware, trace-aware guarded direct dispatch below (also the
+        # recursion-footprint win that lets a deep ``expr``-bodied recursion —
+        # compExpr-old-3.8's ``12days`` — survive the wasm recursion gate).
+        # Known narrow gap: a *variadic* ``{args}`` proc that shadows a *renamed*
+        # builtin (``rename string ::s; proc string {args} …``) binds ``args``
+        # short because the AOT prologue pre-registers every proc before
+        # ``::top`` runs, so the rename reorders against tclsh's lazy define —
+        # see ``tests/test_wasm_real_tcl.py`` (xfail).  Fixed-arity shadows are
+        # correct.
         if not builtin_is_trusted(cmd_name):
             proc_info = self._resolve_proc(cmd_name, self._full_proc_index)
             if (

--- a/compiler/codegen/wasm/_emitter/_optimisation.py
+++ b/compiler/codegen/wasm/_emitter/_optimisation.py
@@ -16,6 +16,7 @@ from ....cfg import (
     CFGGoto,
     CFGReturn,
 )
+from ....command_trust import builtin_is_trusted
 from ....expr_ast import (
     ExprNode,
     ExprRaw,
@@ -1032,11 +1033,25 @@ class _WasmEmitterOptMixin(_Base):
                 if self._optimise:
                     self._const_map.clear()
             elif isinstance(last, IRIncr):
-                # TODO(command-binding): not rename-gated (value/tail position).
-                # If ``incr`` is renamed/redefined in this unit this still emits
-                # the inline increment instead of routing to the interpreter; cf.
-                # the statement-context gate in _statements.py.  Gate once
-                # interp→compiled-proc dispatch lands.  See _values.py.
+                # ``incr`` renamed/redefined in this unit → route this tail
+                # (return-value) lowering through the interpreter so the
+                # replacement command's semantics apply, rather than the inline
+                # integer increment.  ``_emit_eval_fallback`` leaves the result
+                # (boxed TclObj) on the stack and reloads locals from the frame
+                # internally, so the value is exactly what this tail position
+                # needs to return; the proc returns immediately afterwards.
+                # Mirrors the statement-context gate in _statements.py.  (A
+                # builtin renamed *to a compiled proc* still traps in the
+                # fallback until interp→compiled-proc dispatch lands — fails
+                # safe rather than miscomputing.  See _values.py.)
+                if not builtin_is_trusted("incr"):
+                    self._intern_local(last.name)
+                    incr_args = (last.name,) if last.amount is None else (last.name, last.amount)
+                    self._emit_eval_fallback("incr", incr_args)
+                    if self._optimise:
+                        self._const_map.pop(last.name, None)
+                    self._emit(WasmOp.RETURN)
+                    return
                 # Emit incr keeping the new value (i32 TclObj) on stack.
                 # Alias-aware: reads/writes route through globals for
                 # upvar/variable-bound locals.

--- a/compiler/codegen/wasm/_emitter/_statements.py
+++ b/compiler/codegen/wasm/_emitter/_statements.py
@@ -336,13 +336,13 @@ class _WasmEmitterStmtMixin(_Base):
             case IRIncr(name=name, amount=amount):
                 # ``incr`` renamed/redefined in this unit → run it through the
                 # interpreter (live runtime command table) instead of the inline
-                # increment, so the replacement command's semantics apply.
-                # TODO(command-binding): if ``incr`` was renamed *to a proc*,
-                # the interpreter fallback traps rather than calling the compiled
-                # proc (needs interp→compiled-proc dispatch).  Also: the
-                # value-context IRIncr in _control_flow.py / _optimisation.py is
-                # NOT yet gated (rarer; stack-discipline-sensitive) — gate those
-                # too once interp→proc dispatch lands.  See _values.py.
+                # increment, so the replacement command's semantics apply.  When
+                # ``incr`` was renamed *to a proc*, the eval-fallback's
+                # ``tcl_eval`` dispatches to the compiled proc via
+                # ``eval_proc_call_bucket`` (``incr`` is fixed-arity, so the
+                # variadic-shadow gap doesn't apply).  The value/tail-context
+                # IRIncr in _control_flow.py / _optimisation.py is now gated the
+                # same way.  See _values.py.
                 if not builtin_is_trusted("incr"):
                     self._intern_local(name)
                     incr_args = (name,) if amount is None else (name, amount)

--- a/compiler/codegen/wasm/_emitter/_values.py
+++ b/compiler/codegen/wasm/_emitter/_values.py
@@ -805,17 +805,20 @@ class _WasmEmitterValuesMixin(_Base):
         # any builtin fast-path / subcommand import below.  Untouched commands
         # (the common case: an empty untrusted set) are unaffected.
         #
-        # TODO(command-binding): this is correct when the builtin was renamed
-        # *away* (the interpreter sees no such command and errors, matching Tcl).
-        # When a builtin is renamed/redefined *to a user proc* (e.g.
-        # ``rename string ::s; proc string {...}``), the interpreter fallback
-        # currently traps because tcl_eval can't dispatch to a *compiled* proc
-        # body — full correctness needs interp→compiled-proc dispatch in the Zig
-        # runtime.  Until then this fails safe (trap) instead of miscomputing.
-        # A *known compiled proc* gets a rename-aware, trace-aware guarded
-        # dispatch (mirrors ``_emit_command_subst``): needed for proc calls
-        # that appear as command *arguments* (``[string range $c [12days …]
-        # end]``).  See ``_emit_distrust_proc_subst``.
+        # Renamed *away*: the interpreter sees no such command and errors,
+        # matching Tcl.  Renamed/redefined *to a user proc* (``rename string
+        # ::s; proc string {...}``) now dispatches to the proc — the runtime's
+        # ``eval_proc_call_bucket`` routes a compiled (``func_idx != 0``) proc
+        # through the host bridge, so both the eval-fallback path and the
+        # guarded direct dispatch below run the replacement proc (verified vs
+        # tclsh in ``tests/test_wasm_real_tcl.py``).  A *known compiled proc*
+        # takes the rename-aware, trace-aware guarded dispatch (mirrors
+        # ``_emit_command_subst``): needed for proc calls that appear as command
+        # *arguments* (``[string range $c [12days …] end]``).  See
+        # ``_emit_distrust_proc_subst``.  Known narrow gap: a *variadic*
+        # ``{args}`` proc shadowing a *renamed* builtin binds ``args`` short
+        # (AOT prologue pre-registers procs before the rename runs); fixed-arity
+        # shadows are correct.
         if not builtin_is_trusted(cmd_name):
             proc_info = self._resolve_proc(cmd_name, self._full_proc_index)
             if (

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -556,6 +556,13 @@ def _fold_interpolation(
                 return OVERDEFINED
             if lv.kind is LatticeKind.UNKNOWN:
                 return UNKNOWN
+            # A CONSTSET var (branch-merged ``{ab, qrst}``) is *not* a single
+            # constant string — its ``value`` field is ``None``, so a naive
+            # ``str(lv.value)`` would splice the literal ``"None"`` into the
+            # word.  Only a singular CONST may be concatenated here; callers
+            # that want the multi-valued result use ``_fold_interpolation_set``.
+            if lv.kind is not LatticeKind.CONST:
+                return OVERDEFINED
             pieces.append(str(lv.value))
         elif tok.type is TokenType.CMD:
             # Try folding the nested command substitution.

--- a/compiler/optimiser/_helpers.py
+++ b/compiler/optimiser/_helpers.py
@@ -17,6 +17,7 @@ from shared.naming import (
 from shared.naming import (
     normalise_var_name as _normalise_var_name,
 )
+from shared.tcl_list import tcl_list_quote
 from shared.tokens import SourcePosition, Token, TokenType
 
 from ..command_trust import builtin_is_trusted
@@ -157,6 +158,21 @@ def _render_folded_literal(value: int | float | bool | str) -> str | None:
     if isinstance(value, str):
         if _SAFE_WORD_RE.fullmatch(value):
             return value
+        # A pure proc returning a *multi-word* string (``return "hi there"``)
+        # folds too — render it as one safe Tcl word via the project's
+        # ``TclScanElement`` port (brace-quotes spaces, balances braces) so the
+        # substituted word parses back to exactly the proc's result.
+        # ``first=False``: the folded value always replaces a command *argument*
+        # (a ``[proc …]`` substitution), never a command head.
+        #
+        # The interprocedural evaluator returns the *raw* return-value text, so
+        # any backslash escape / substitution / quote / separator means the raw
+        # text is not a plain literal — and brace-quoting would bake the raw
+        # bytes in (``return "a\$b"`` → value ``a$b`` but raw ``a\$b``).  Reject
+        # exactly the set ``fold_cmd_subst_to_string`` rejects so only literal
+        # values that survive re-parsing unchanged are inlined.
+        if not any(ch in ';\n\r[]$"\\' for ch in value):
+            return tcl_list_quote(value, first=False)
     return None
 
 

--- a/compiler/optimiser/_manager.py
+++ b/compiler/optimiser/_manager.py
@@ -35,6 +35,7 @@ from ._propagation import (
     optimise_load_forwarding,
     optimise_return_terminator,
     optimise_static_proc_calls,
+    optimise_string_interpolation_cmd_subs,
     optimise_string_interpolation_var_refs,
 )
 from ._types import Optimisation, PassContext
@@ -97,6 +98,7 @@ def _augment_expr_subst_constants(
     argv_texts: list[str],
     reach_versions: dict[str, int],
     values,
+    block_local_defs: frozenset[str],
 ) -> None:
     """Fold in constants read *inside* expr/body command substitutions.
 
@@ -108,19 +110,79 @@ def _augment_expr_subst_constants(
     expr-substitution pass propagate + fold a direct ``puts [expr {$x + 1}]``
     the same way it already does for ``set y [expr {$x + 1}]`` (whose expr
     reads *are* in ``uses``).
+
+    **Soundness gate** — ``reach_versions`` comes from the *semi-pruned* SSA,
+    which omits φ-nodes for variables whose only reads are these hidden ones.
+    So at a control-flow join ``entry_versions[x]`` can still name a *pre-join*
+    version (``set x 5; if … {set x 9}; puts [expr {$x+1}]`` leaves ``x`` at the
+    ``5`` version, no φ) — pinning that would fold the join to the wrong value.
+    Only names in *block_local_defs* (defined by a straight-line statement
+    earlier in this same basic block, so no join sits between the def and the
+    read) are trusted; a call that clobbers such a name produces an in-block
+    havoc def whose lattice value is OVERDEFINED, so the CONST check still bails.
     """
     from compiler.ssa import expr_substitution_read_names
 
     names = expr_substitution_read_names(argv_texts)
     if not names:
         return
-    extra_uses = {n: reach_versions[n] for n in names if reach_versions.get(n, 0) > 0}
+    extra_uses = {
+        n: reach_versions[n]
+        for n in names
+        if n in block_local_defs and reach_versions.get(n, 0) > 0
+    }
     if not extra_uses:
         return
     # Reuse the same CONST-check + formatting as the uses-based path; don't
     # override a value already present from real uses.
     for name, value in _constants_from_uses(extra_uses, values).items():
         constants.setdefault(name, value)
+
+
+def _augment_subst_uses(
+    ssa_uses: dict[str, int],
+    argv_texts: list[str],
+    reach_versions: dict[str, int],
+    block_local_defs: frozenset[str],
+) -> dict[str, int]:
+    """Reaching SSA versions for vars read *inside* expr/body command subs.
+
+    The SSA use-collector deliberately keeps reads hidden in ``[expr {$x}]``
+    (and BODY scripts nested in a substitution) out of ``stmt.uses`` so
+    read-before-set isn't perturbed.  But the *registry* cmd-sub folder
+    (:func:`compiler.core_analyses.fold_cmd_subst_to_string`) resolves ``$x``
+    through that very ``uses`` map, so the constant stays invisible to it: a
+    nested fold like ``puts [expr {[string length $s]}]`` (Gap-B) or a folded
+    cmd-sub embedded in an interpolation string (``puts "sq=[expr {$x*$x}]"``)
+    never fires.  Recover those names and pin each to its *reaching* SSA version
+    so the folder sees exactly the constant SCCP already proved.
+
+    Soundness is gated the same way as :func:`_augment_expr_subst_constants`:
+    only names in *block_local_defs* (defined earlier in this straight-line
+    basic block) are pinned, because the semi-pruned SSA's ``entry_versions``
+    can name a stale pre-join version for a variable read only in these hidden
+    positions (no φ was inserted).
+
+    Returned as a fresh map (or ``ssa_uses`` unchanged when nothing was hidden)
+    that is passed *only* to the folding passes — the real ``stmt.uses`` is left
+    intact, so the propagated-use / dead-store marking, which keys on the
+    shallow set, is unaffected.
+    """
+    from compiler.ssa import expr_substitution_read_names
+
+    names = expr_substitution_read_names(argv_texts)
+    if not names:
+        return ssa_uses
+    augmented: dict[str, int] | None = None
+    for n in names:
+        if n in ssa_uses or n not in block_local_defs:
+            continue
+        v = reach_versions.get(n, 0)
+        if v > 0:
+            if augmented is None:
+                augmented = dict(ssa_uses)
+            augmented[n] = v
+    return augmented if augmented is not None else ssa_uses
 
 
 class _CompilerOptimiser:
@@ -345,9 +407,16 @@ class _CompilerOptimiser:
             # read hidden inside an expr/body command substitution (absent from
             # ``stmt.uses``) can be resolved to its current value.
             running_versions: dict[str, int] = dict(getattr(ssa_block, "entry_versions", {}) or {})
+            # Names assigned by a straight-line statement earlier in *this* basic
+            # block — the only ones whose ``reach_versions`` entry is a sound
+            # value for a hidden (expr/cmd-sub) read, since no control-flow join
+            # sits between such a def and the read (see _augment_subst_uses).
+            block_local_defs: frozenset[str] = frozenset()
             for idx, ssa_stmt in enumerate(ssa_block.statements):
                 reach_versions = running_versions
+                reach_local_defs = block_local_defs
                 running_versions = {**running_versions, **ssa_stmt.defs}
+                block_local_defs = block_local_defs | frozenset(ssa_stmt.defs)
                 if idx < 0 or idx >= len(block.statements):
                     continue
                 ctx.cur_block = block_name
@@ -370,7 +439,14 @@ class _CompilerOptimiser:
                 arg_single = argv_single[1:]
                 constants = _constants_from_uses(ssa_stmt.uses, analysis.values)
                 _augment_expr_subst_constants(
-                    constants, argv_texts, reach_versions, analysis.values
+                    constants, argv_texts, reach_versions, analysis.values, reach_local_defs
+                )
+                # Gap-B: vars read inside ``[expr {…}]`` / nested cmd-subs are
+                # hidden from ``stmt.uses``; pin their reaching versions so the
+                # registry cmd-sub folder can resolve them (see
+                # :func:`_augment_subst_uses`).  Real ``uses`` stays untouched.
+                subst_uses = _augment_subst_uses(
+                    ssa_stmt.uses, argv_texts, reach_versions, reach_local_defs
                 )
                 stmt_start = stmt_range.start.offset
                 if constants:
@@ -388,7 +464,7 @@ class _CompilerOptimiser:
                     arg_single,
                     constants,
                     namespace=namespace,
-                    ssa_uses=ssa_stmt.uses,
+                    ssa_uses=subst_uses,
                     types=analysis.types,
                     values=analysis.values,
                 )
@@ -397,7 +473,7 @@ class _CompilerOptimiser:
                     arg_tokens,
                     arg_single,
                     constants,
-                    ssa_uses=ssa_stmt.uses,
+                    ssa_uses=subst_uses,
                     types=analysis.types,
                     values=analysis.values,
                 )
@@ -405,6 +481,22 @@ class _CompilerOptimiser:
                     ctx, arg_tokens, arg_single, constants, namespace=namespace
                 )
                 optimise_constant_var_refs(ctx, arg_tokens, arg_single, constants)
+                # Fold pure builtin / expr command subs embedded *inside* an
+                # interpolation string (``puts "v=[string length abc]"``).  Run
+                # ungated on ``constants`` — a literal-arg builtin sub
+                # (``[string length abc]``) needs none; ``subst_uses`` +
+                # ``values`` carry the Gap-B reaching constants for the var case.
+                ct_cmd = getattr(stmt, "tokens", None)
+                if ct_cmd is not None and ct_cmd.all_tokens:
+                    optimise_string_interpolation_cmd_subs(
+                        ctx,
+                        arg_tokens,
+                        arg_single,
+                        ct_cmd.all_tokens,
+                        constants,
+                        ssa_uses=subst_uses,
+                        values=analysis.values,
+                    )
                 # Track expression uses consumed by constant propagation/folding.
                 if len(ctx.optimisations) > n_before:
                     propagation_codes = frozenset(("O100", "O101", "O102", "O103"))

--- a/compiler/optimiser/_propagation.py
+++ b/compiler/optimiser/_propagation.py
@@ -664,6 +664,103 @@ def optimise_string_interpolation_var_refs(
         )
 
 
+def _fold_embedded_cmd_subst(
+    cmd_text: str,
+    constants: dict[str, str],
+    ssa_uses: dict[str, int] | None,
+    values: dict | None,
+) -> str | None:
+    """Fold a builtin or ``[expr {…}]`` substitution to its **raw** string value.
+
+    For a substitution embedded *inside an interpolation string* the replacement
+    is spliced straight into the surrounding ``"…"`` (or bare word), so the raw
+    command output is wanted — not the single-word ``tcl_list_quote`` rendering
+    that :func:`_fold_builtin_cmd_subst` produces for free-standing argument
+    positions.  Returns ``None`` when the sub isn't a constant-foldable builtin
+    or pure ``expr``.
+    """
+    from compiler.core_analyses import fold_cmd_subst_to_string
+
+    # Pure builtin command substitution: [string length abc], [list a b c], …
+    folded = fold_cmd_subst_to_string(f"[{cmd_text}]", ssa_uses or {}, values or {})
+    if folded is not None:
+        return folded
+
+    # [expr {E}] — propagate constants, fold any nested builtin subs, then fold.
+    expr_arg = _expr_arg_from_expr_command(cmd_text)
+    if expr_arg is None:
+        return None
+    substituted, _changed, _ = _substitute_expr_constants(expr_arg, constants)
+    substituted, _ = _substitute_expr_builtin_cmd_subs(
+        substituted, ssa_uses=ssa_uses, values=values
+    )
+    return _try_fold_expr(substituted)
+
+
+def optimise_string_interpolation_cmd_subs(
+    ctx: PassContext,
+    arg_tokens: list[Token],
+    arg_single: list[bool],
+    all_tokens: tuple[Token, ...],
+    constants: dict[str, str],
+    *,
+    ssa_uses: dict[str, int] | None = None,
+    values: dict | None = None,
+) -> None:
+    """Fold a pure ``[cmd …]`` embedded *inside an interpolation string* (O129).
+
+    The optimiser already folds a command substitution that is a whole argument
+    word (``puts [string length abc]`` → ``puts 5``) and propagates ``$var``
+    refs inside a quoted string (``puts "x is $x"``).  This closes the remaining
+    gap — a substitution embedded *within* a multi-token string word::
+
+        puts "v=[string length abc]"   ;# -> puts "v=5"
+        set x 3; puts "sq=[expr {$x*$x}]"  ;# -> puts "sq=9"
+
+    Only substitutions that aren't a whole-word single argument are handled here
+    (those go through :func:`optimise_expr_substitutions`).  Command subs inside
+    a *braced* expr/body word never reach ``all_tokens`` — braces suppress them
+    — so EXPR/BODY positions are untouched.
+
+    The folded value is spliced raw into the surrounding word, so it must be
+    safe in *any* word position: ``fold_cmd_subst_to_string`` already rejects
+    ``; \\n [ $ " \\``; we additionally reject a result containing whitespace,
+    which would split a *bare* (unquoted) interpolation word into extra
+    arguments.  (A space is harmless inside ``"…"`` but the token stream doesn't
+    distinguish the two cheaply, so the conservative rule keeps the rewrite
+    correct in both.)
+    """
+    if not all_tokens:
+        return
+
+    # Whole-word CMD args are folded by optimise_expr_substitutions — skip them
+    # here so the same substitution isn't optimised twice.
+    single_cmd_offsets: set[int] = set()
+    for idx, tok in enumerate(arg_tokens):
+        if idx < len(arg_single) and arg_single[idx] and tok.type is TokenType.CMD:
+            single_cmd_offsets.add(tok.start.offset)
+
+    for atk in all_tokens:
+        if atk.type is not TokenType.CMD or not atk.text:
+            continue
+        if atk.start.offset in single_cmd_offsets:
+            continue
+        folded = _fold_embedded_cmd_subst(atk.text, constants, ssa_uses, values)
+        if folded is None:
+            continue
+        # Whitespace in the result would re-split a bare interpolation word.
+        if any(ch.isspace() for ch in folded):
+            continue
+        ctx.optimisations.append(
+            Optimisation(
+                code="O129",
+                message="Fold constant command substitution",
+                range=_command_subst_range(atk),
+                replacement=folded,
+            )
+        )
+
+
 def optimise_return_terminator(
     ctx: PassContext, source: str, block, ssa_block, analysis, *, namespace: str = "::"
 ) -> None:

--- a/compiler/passes/licm.py
+++ b/compiler/passes/licm.py
@@ -1,5 +1,15 @@
 """S5.3 — Loop-invariant code motion for retain/release wraps.
 
+TODO(opt, stretch): constant-bound loop *unrolling* is a known, unimplemented
+missed-optimisation — ``for {set i 0} {$i < 3} {incr i} {body}`` with a literal
+trip count and a body free of ``break`` / ``continue`` / early ``return`` and of
+captures of ``$i``'s identity could be unrolled into three straight-line copies
+(then the per-iteration const-fold + LICM apply to each).  Deferred as a stretch
+goal: it needs a trip-count proof from the SCCP/interval lattice, a body-purity
+gate (no loop-carried side effects beyond the induction var, no command-table
+mutation), and a code-size guard so large bounds aren't expanded.  Until then the
+loop bodies still benefit from LICM (below) and per-statement folding.
+
 In the current emitter, a literal assignment inside a loop body
 allocates a fresh ``TclObj`` and runs the full retain/release wrap
 on every iteration::

--- a/dialects/tcl/const_fold.py
+++ b/dialects/tcl/const_fold.py
@@ -589,6 +589,38 @@ def fold_format(args: tuple[str, ...]) -> str | None:
         return None
 
 
+# TODO(const-fold): ``lseq`` (Tcl 9) is a provable false-negative — ``lseq 1 5``
+# folds to ``{1 2 3 4 5}`` and ``lseq 0 10 2`` to ``{0 2 4 6 8 10}``.  Deferred
+# rather than implemented because lseq has several arg shapes whose edge
+# semantics need differential pinning against tclsh9 before a fold is safe:
+# the ``start end ?step?`` and ``start end by step`` forms, ``count`` /
+# ``start count`` short forms, descending ranges (negative effective step),
+# float operands (``lseq 0 1 0.25`` yields doubles), and the ``..`` operator
+# form.  A wrong fold here would be a false *positive*, so it stays unfolded
+# until a ``fold_lseq`` callback is written against the full matrix.
+
+
+def fold_subst(args: tuple[str, ...]) -> str | None:
+    """``subst string`` — the plain single-argument form only.
+
+    By the time the registry fold machinery calls this, every ``$var`` in
+    *string* has already been resolved against the SCCP lattice (matching
+    ``subst``'s own single-pass variable substitution) and any ``[command]``
+    substitution has made the caller bail — command execution is a side effect,
+    never folded.  The one substitution ``subst`` still performs that we don't
+    model is *backslash*, so a literal carrying a backslash isn't folded.  The
+    ``-nobackslashes`` / ``-nocommands`` / ``-novariables`` options change which
+    substitutions apply, so only the bare ``subst string`` form (no leading
+    ``-option``) folds — the multi-arg form is rejected here.
+    """
+    if len(args) != 1:
+        return None
+    s = args[0]
+    if "\\" in s:
+        return None
+    return s
+
+
 _SCAN_WS = " \t\n\r\f\v"
 
 

--- a/dialects/tcl/subst_.py
+++ b/dialects/tcl/subst_.py
@@ -16,6 +16,7 @@ from compiler.side_effects import ConnectionSide, SideEffect, SideEffectTarget
 from compiler.types import TclType
 
 from ._base import register
+from .const_fold import fold_subst
 
 _SOURCE = "Tcl subst(1)"
 
@@ -57,6 +58,10 @@ class SubstCommand(CommandDef):
             ),
             taint_sink=True,
             is_unescape_command=True,
+            # Folds only the literal ``subst string`` form (no options): ``$var``
+            # is resolved by the lattice as subst would, ``[command]`` makes the
+            # folder bail (side effect), and a backslash escape is left unfolded.
+            const_fold=fold_subst,
             return_type=TclType.STRING,
             side_effect_hints=(
                 SideEffect(

--- a/tests/test_command_binding.py
+++ b/tests/test_command_binding.py
@@ -238,3 +238,55 @@ class TestModuleScanSoundness:
         assert not mut.dynamic
         assert mut.names == frozenset()
         assert mut.trusts("string")
+
+
+class TestBytecodeRenameGate:
+    """The bytecode backend must not direct-dispatch a renamed/redefined builtin
+    by name — it has to fall through to a generic ``invokeStk`` so the VM
+    resolves the live, rename-aware command (matching tclsh's own bytecode for
+    the same script, which also emits a generic invoke past a preceding
+    ``rename``).  See ``compiler/codegen/bytecode/_bytecoded.py`` /
+    ``_cmd_subst.py`` and the gate scoped in ``codegen_module``."""
+
+    def _asm(self, src: str) -> str:
+        from compiler.cfg import build_cfg
+        from compiler.codegen.bytecode import codegen_module, format_module_asm
+
+        configure_signatures(dialect="tcl9.0")
+        cu = ensure_compilation_unit(src, logger=None, context="t")
+        assert cu is not None
+        return format_module_asm(codegen_module(build_cfg(cu.ir_module), cu.ir_module))
+
+    def test_untouched_string_length_inlines_strlen(self):
+        # The baseline specialised opcode must still be emitted when nothing
+        # tampers with ``string`` (true negative — gating must not over-suppress).
+        assert "strlen" in self._asm("puts [string length hi]")
+
+    def test_renamed_string_falls_through_to_invoke(self):
+        asm = self._asm("rename string ::s\nputs [string length hi]")
+        assert "strlen" not in asm
+        # The whole ``string length hi`` is reassembled as a generic invoke.
+        assert "invokeStk" in asm
+
+    def test_renamed_incr_falls_through(self):
+        asm = self._asm("rename incr ::oi\nset c 0\nputs [incr c]")
+        assert "incrScalar" not in asm
+        assert "incrStk" not in asm
+
+    def test_unrelated_builtin_still_inlines_after_rename(self):
+        # Renaming ``incr`` must not stop ``string length`` from inlining strlen.
+        asm = self._asm("rename incr ::oi\nputs [string length hi]")
+        assert "strlen" in asm
+
+    def test_standalone_codegen_function_unchanged(self):
+        # Outside the module trust scope the default is "trust all" — a bare
+        # ``codegen_function`` keeps inlining (no behaviour change for callers
+        # that don't establish a trust context).
+        from compiler.cfg import build_cfg
+        from compiler.codegen.bytecode import codegen_function, format_function_asm
+
+        configure_signatures(dialect="tcl9.0")
+        cu = ensure_compilation_unit("puts [string length hi]", logger=None, context="t")
+        assert cu is not None
+        top = build_cfg(cu.ir_module).top_level
+        assert "strlen" in format_function_asm(codegen_function(top))

--- a/tests/test_const_fold_vs_tcl.py
+++ b/tests/test_const_fold_vs_tcl.py
@@ -112,6 +112,8 @@ _FOLDABLE = [
     "expr {2 + 3 * 4}",
     "expr {10 % 3}",
     "expr {2 ** 10}",
+    "subst {hello world}",
+    "subst plain",
 ]
 
 
@@ -213,6 +215,21 @@ _E2E = [
     "set n [expr {[llength {a b c}] * 2}]\nputs $n",
     'puts [expr {[string toupper hi] eq "HI"}]',
     "if {[llength {a b c}] == 3} {puts three}",
+    # literal subst folds; option / backslash / command forms must be left to
+    # run unchanged (behaviour-preserving either way)
+    "puts [subst {hello world}]",
+    "puts [subst plain]",
+    "puts [subst {a\\tb}]",
+    "puts [subst {x[set y 5]z}]",
+    "puts [subst -nocommands {literal}]",
+    # command subs embedded inside an interpolation string fold (Part B1)
+    'puts "v=[string length abc]"',
+    'puts "a[string length xy]b[string toupper hi]"',
+    'set x 3\nputs "sq=[expr {$x*$x}]"',
+    # nested var read inside [expr {[cmd $v]}] folds via reaching constant (B2)
+    "set s abcd\nputs [expr {[string length $s]}]",
+    # pure proc returning a multi-word string folds (B3)
+    'proc f {} {return "hi there"}\nputs [f]',
 ]
 
 
@@ -260,6 +277,36 @@ class TestScanBails:
         assert fold_scan(("42", "%d")) == "42"
         assert fold_scan(("ff", "%x")) == "255"
         assert fold_scan(("A", "%c")) == "65"
+
+
+class TestSubstFold:
+    """``subst`` folds only the literal single-argument form: any unmodelled
+    substitution (backslash) or option / command sub must bail so the optimiser
+    never bakes in a wrong literal."""
+
+    def test_literal_folds(self):
+        from dialects.tcl.const_fold import fold_subst
+
+        assert fold_subst(("hello",)) == "hello"
+        assert fold_subst(("a b c",)) == "a b c"
+
+    def test_backslash_bails(self):
+        from dialects.tcl.const_fold import fold_subst
+
+        # ``subst {a\tb}`` performs backslash substitution → a tab; the raw
+        # ``a\tb`` text is not the value, so don't fold.
+        assert fold_subst(("a\\tb",)) is None
+
+    def test_option_form_bails(self):
+        from dialects.tcl.const_fold import fold_subst
+
+        assert fold_subst(("-nocommands", "literal")) is None
+
+    def test_subst_in_fold_hints(self):
+        from compiler.registry.runtime import FOLD_HINTS, configure_signatures
+
+        configure_signatures(dialect="tcl9.0")
+        assert "subst" in FOLD_HINTS
 
 
 class TestConstFoldIsRegistrySourced:

--- a/tests/test_lsp_server_actions_e2e.py
+++ b/tests/test_lsp_server_actions_e2e.py
@@ -88,6 +88,28 @@ class TestOptimiseDocument:
         out = self._optimised("rename list ::l\nputs [llength [list a b c]]\n")
         assert "puts 3" not in out
 
+    def test_command_sub_in_interpolation_string_folds(self):
+        # Part B1: a pure builtin command sub embedded inside a quoted string
+        # surfaces as an O129 fold through the LSP optimise command.
+        uri = "file:///opt.tcl"
+        workspace_state.open(uri, 'puts "v=[string length abc]"\n')
+        result = commands.on_optimise_document(uri)
+        assert result is not None
+        assert 'puts "v=3"' in result["source"]
+        assert "O129" in {o["code"] for o in result["optimisations"]}
+
+    def test_nested_expr_var_fold_via_lsp(self):
+        # Part B2 (Gap-B): a constant read inside a nested [expr {[cmd $v]}].
+        assert "puts 4" in self._optimised("set s abcd\nputs [expr {[string length $s]}]\n")
+
+    def test_subst_literal_fold_via_lsp(self):
+        # Part B4: literal [subst {...}] folds.
+        assert "puts hello" in self._optimised("puts [subst {hello}]\n")
+
+    def test_pure_proc_multiword_string_fold_via_lsp(self):
+        # Part B3: a pure proc returning a multi-word string folds (list-quoted).
+        assert "puts {hi there}" in self._optimised('proc f {} {return "hi there"}\nputs [f]\n')
+
 
 # ── tools: minify document ─────────────────────────────────────────────
 

--- a/tests/test_minifier.py
+++ b/tests/test_minifier.py
@@ -1173,19 +1173,24 @@ class TestStaticSubstringFolding:
     def test_static_folds_in_symbol_map(self):
         """Static fold details appear in the symbol map.
 
-        Plain ``$x`` interpolation is now folded upstream by the optimiser
-        (O105), so this exercises the minifier's *unique* contribution — a pure
-        command substitution embedded in a quoted string (``[string length $x]``),
-        which the optimiser leaves intact for the minifier's static-substr pass.
+        Both plain ``$x`` interpolation (O105) and a *space-free* command
+        substitution embedded in a quoted string (``[string length $x]`` → O129
+        / Part B1) are now folded upstream by the optimiser.  This exercises the
+        minifier's *remaining* unique contribution: a command substitution whose
+        result contains whitespace (``[list a b c]`` → ``a b c``).  The optimiser
+        leaves that one intact — splicing a space into a *bare* interpolation
+        word would split it into extra arguments — but the minifier knows the
+        substitution sits inside a double-quoted string, where a space is safe,
+        so its static-substr pass folds it.
         """
-        source = 'set x hello\nputs "length is [string length $x]"\n'
+        source = 'puts "got [list a b c]"\n'
         result = minify_tcl(source, aggressive=True)
         # The command-sub template must be statically folded, and every recorded
-        # fold must carry the resolved length (``5``).
+        # fold must carry the resolved list (``a b c``).
         assert result.symbol_map.static_folds, result.source
         for _original, folded in result.symbol_map.static_folds.items():
-            assert "5" in folded
-        assert "string length" not in result.source
+            assert "a b c" in folded
+        assert "list a b c" not in result.source
 
     def test_no_fold_when_var_not_in_ssa(self):
         """Variables not tracked by SSA (e.g. global) are not folded."""

--- a/tests/test_optimiser_adversarial.py
+++ b/tests/test_optimiser_adversarial.py
@@ -173,6 +173,50 @@ _CORRECTNESS: dict[str, str] = {
         'proc setit {} {upvar 1 y v; set v 7; return "v=$v"}\n'
         "proc caller {} {set y 1; return [setit]}\nputs [caller]"
     ),
+    # --- Gap-B reaching-version soundness: a variable read *inside* a hidden
+    #     expr / nested command substitution is absent from ``stmt.uses``, so the
+    #     semi-pruned SSA inserts no φ for it.  ``entry_versions`` then names a
+    #     *pre-join* version after a conditional reassignment — folding the
+    #     hidden read against that stale constant would change behaviour.  Only a
+    #     def earlier in the *same* straight-line block may be pinned. ---
+    "gapb_branch_join_expr_var": (
+        "set x 5\nif {[string length q]==1} {set x 9}\nputs [expr {$x + 1}]"
+    ),
+    "gapb_branch_join_nested_cmdsub": (
+        "set s abc\nif {[string length x]==1} {set s qrst}\nputs [expr {[string length $s]}]"
+    ),
+    "gapb_loop_carried_mutation": (
+        "set s abc\nset n 0\nwhile {$n<2} {puts [expr {[string length $s]}]\nset s xyzw\nincr n}"
+    ),
+    "gapb_unset_then_reset": ("set s abc\nunset s\nset s wxyz\nputs [expr {[string length $s]}]"),
+    # --- command subs embedded in interpolation strings must stay equivalent
+    #     whether or not they fold (raw splice must not introduce substitutions
+    #     or, in a *bare* word, extra word boundaries) ---
+    "string_cmdsub_bare_space_result": "puts pre[list a b c]post",
+    "string_cmdsub_seq_reassign": ('set x 3\nputs "a=[expr {$x}]"\nset x 99\nputs "b=[expr {$x}]"'),
+    # --- subst folds only the literal form; backslash / command / option forms
+    #     must be left to run ---
+    "subst_backslash_runs": "puts [subst {a\\tb}]",
+    "subst_command_runs": "puts [subst {x[set y 5]z}]",
+    # --- pure proc returning a string with substitution chars must NOT bake in
+    #     the raw (un-evaluated) return text ---
+    "proc_string_escaped_dollar": 'proc f {} {return "a\\$b"}\nputs [f]',
+    # --- CONSTSET soundness: a branch-merged variable (provably one of a finite
+    #     set of constants, but not a *single* one) must NOT resolve to a single
+    #     value when folding a command sub that reads it.  ``[clock seconds] > 0``
+    #     is always true at run time but opaque to the optimiser, so ``s`` is the
+    #     CONSTSET ``{abcde, xy}``; folding ``[string length $s]`` would splice
+    #     the literal ``"None"`` (the CONSTSET's empty ``value`` field) and bake
+    #     in a wrong length.  Both the whole-word and the in-string forms. ---
+    "constset_cmdsub_wholeword": (
+        "set s abcde\nif {[clock seconds] > 0} {set s xy}\nputs [string length $s]"
+    ),
+    "constset_cmdsub_in_string": (
+        'set s abcde\nif {[clock seconds] > 0} {set s xy}\nputs "L=[string length $s]"'
+    ),
+    "constset_interpolation_assign": (
+        'set s abcde\nif {[clock seconds] > 0} {set s xy}\nset y "v=$s"\nputs $y'
+    ),
 }
 
 
@@ -345,6 +389,46 @@ _SHOULD_OPTIMISE: dict[str, tuple[str, str]] = {
     "unrelated_builtin_still_folds_after_rename": (
         "rename incr ::orig_incr\nputs [string length hello]\n",
         "puts 5",
+    ),
+    # Part B1: a pure builtin command sub embedded *inside an interpolation
+    # string* folds (the optimiser already folds whole-word subs + ``$var`` in
+    # strings; this closes the embedded-sub gap).
+    "string_interp_builtin_cmdsub": (
+        'puts "v=[string length abc]"',
+        'puts "v=3"',
+    ),
+    "string_interp_expr_cmdsub": (
+        'set x 3\nputs "sq=[expr {$x*$x}]"',
+        'puts "sq=9"',
+    ),
+    "string_interp_multi_cmdsub": (
+        'puts "a[string length xy]b[string toupper hi]"',
+        'puts "a2bHI"',
+    ),
+    # Part B2 (Gap-B): a constant read inside a *nested* ``[expr {[cmd $v]}]``
+    # folds via the threaded reaching-version constant (same-block def only).
+    "gapb_nested_cmdsub_folds": (
+        "set s abcd\nputs [expr {[string length $s]}]",
+        "puts 4",
+    ),
+    "gapb_nested_cmdsub_arith": (
+        "set s abc\nputs [expr {[string length $s] * 2}]",
+        "puts 6",
+    ),
+    # Part B3: a pure proc returning a *multi-word* string folds (previously only
+    # numeric / bare-word results folded).
+    "pure_proc_multiword_string": (
+        'proc f {} {return "hi there"}\nputs [f]',
+        "puts {hi there}",
+    ),
+    # Part B4: a literal ``[subst {...}]`` folds via the registry const_fold.
+    "subst_literal_fold": (
+        "puts [subst {hello world}]",
+        "puts {hello world}",
+    ),
+    "subst_in_interp_string": (
+        'puts "x=[subst {hi}]"',
+        'puts "x=hi"',
     ),
 }
 

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -2708,6 +2708,87 @@ class TestVariadicArgs:
         assert stdout.strip() == "2"
 
 
+class TestRenamedToProcDispatch:
+    """A builtin renamed/redefined *to a user proc* must dispatch to the proc
+    at run time (matching tclsh), not the original builtin and not a trap.
+
+    The optimiser/codegen gate routes a tampered builtin through the
+    interpreter (``builtin_is_trusted`` is False); the runtime's
+    ``eval_proc_call_bucket`` then sees the proc bucket's ``func_idx != 0``
+    marker and dispatches the compiled body through the host bridge.  These
+    pin that end-to-end behaviour so the gate + dispatch stay wired.
+    """
+
+    def test_redef_builtin_to_proc_statement(self):
+        # ``rename string ::s; proc string {...}; [string length hi]`` — the
+        # task's canonical case.  Must run the proc (prints its result).
+        ok, out, err = _run_tcl_for_stdout(
+            "rename string ::s\nproc string {args} {return PROC}\nputs [string length hi]"
+        )
+        assert ok, err
+        assert out.strip() == "PROC"
+
+    def test_redef_builtin_to_proc_uses_args(self):
+        # Fixed-arity shadow binds its parameters correctly.
+        ok, out, err = _run_tcl_for_stdout(
+            "rename string ::s\nproc string {sub arg} {return redef:$arg}\nputs [string length hi]"
+        )
+        assert ok, err
+        assert out.strip() == "redef:hi"
+
+    def test_redef_builtin_to_proc_in_expr(self):
+        # Reached as an operand inside ``[expr {…}]`` (value/expr gate).
+        ok, out, err = _run_tcl_for_stdout(
+            "rename string ::s\nproc string {a b} {return 9}\nputs [expr {[string length hi] + 1}]"
+        )
+        assert ok, err
+        assert out.strip() == "10"
+
+    def test_redef_incr_to_proc_value_position(self):
+        # The value/tail-position IRIncr gate routes a renamed ``incr`` to the
+        # proc; the proc's return value is used.
+        ok, out, err = _run_tcl_for_stdout(
+            "rename incr ::oi\nproc incr {v} {return 42}\n"
+            "proc f {} {set c 0\nreturn [incr c]}\nputs [f]"
+        )
+        assert ok, err
+        assert out.strip() == "42"
+
+    def test_redef_incr_to_proc_in_catch_body(self):
+        # The catch-body (value-position) IRIncr gate.
+        ok, out, err = _run_tcl_for_stdout(
+            "rename incr ::oi\nproc incr {v} {return 77}\nset c 0\ncatch {incr c} m\nputs $m"
+        )
+        assert ok, err
+        assert out.strip() == "77"
+
+    def test_renamed_away_still_errors(self):
+        # Renamed away with no replacement → the interpreter errors (caught).
+        ok, out, err = _run_tcl_for_stdout(
+            "rename string ::s\ncatch {string length hi} e\nputs caught"
+        )
+        assert ok, err
+        assert out.strip() == "caught"
+
+    @pytest.mark.xfail(
+        reason=(
+            "Known narrow gap: a *variadic* {args} proc that shadows a *renamed* "
+            "builtin binds args short. The AOT prologue pre-registers every proc "
+            "before ::top runs, so `rename string ::s` reorders against tclsh's "
+            "lazy define. Fixed-arity shadows (above) are correct; redefining "
+            "without a prior rename is correct too. Documented in _values.py."
+        ),
+        strict=True,
+    )
+    def test_variadic_shadow_of_renamed_builtin(self):
+        ok, out, err = _run_tcl_for_stdout(
+            "rename string ::s\nproc string {args} {return [llength $args]}\n"
+            "puts [string length abcde]"
+        )
+        assert ok, err
+        assert out.strip() == "2"
+
+
 class TestRegexp:
     """Tcl regex engine (Henry Spencer) linked via ``tcl_regex.zig``.
 


### PR DESCRIPTION
## Summary

This PR closes four optimization gaps in the compiler's constant-folding and command-substitution handling:

**Part A: Bytecode backend rename-gating** — The bytecode codegen was directly dispatching renamed/redefined builtins by name, ignoring the live command table. Now scopes the lattice-derived trust verdict (matching the WASM backend) so `_try_bytecoded` refuses to inline a tampered builtin and falls through to generic `invokeStk`.

**Part B1: Embedded command-subs in interpolation strings** — Adds `optimise_string_interpolation_cmd_subs` (O129) to fold pure builtins and `[expr {…}]` substitutions embedded *inside* quoted/bare interpolation words (e.g., `puts "v=[string length abc]"` → `puts "v=3"`). The folded value is spliced raw, so results containing whitespace are conservatively rejected to avoid re-splitting bare words.

**Part B2: Nested expr variable reads (Gap-B)** — Variables read inside hidden `[expr {…}]` / nested command-subs are absent from `stmt.uses`, so the semi-pruned SSA omits φ-nodes for them. This means `entry_versions` can name a stale pre-join version after a conditional reassignment. The fix threads reaching-version constants only for variables defined earlier in the *same* straight-line basic block (no control-flow join between def and hidden read), gating both `_augment_expr_subst_constants` and the new `_augment_subst_uses` on `block_local_defs`.

**Part B3: Pure procs returning multi-word strings** — Extends `_render_folded_literal` to fold pure proc calls returning multi-word strings by rendering them via `tcl_list_quote` (e.g., `proc f {} {return "hi there"}; puts [f]` → `puts {hi there}`).

**Part B4: Literal `[subst {…}]` folding** — Adds `fold_subst` to the registry so literal single-argument `subst` folds (backslash and option forms bail). Also adds `subst` to the command registry spec with the fold hint.

**WASM/bytecode dispatch fixes** — Updates comments and gates in `_emit_command_subst`, `_emit_command_subst_value`, and `IRIncr` value-context lowerings to reflect that renamed-to-proc dispatch now works (via `eval_proc_call_bucket` in the Zig runtime).

## Validation

- Added comprehensive adversarial test cases covering Gap-B soundness (branch joins, loop-carried mutations, unset/reset sequences) and command-sub embedding edge cases (whitespace results, sequential reassignments, CONSTSET variables).
- Added positive test cases for all four optimization parts (B1–B4) and nested expr variable folding.
- Added bytecode backend rename-gating tests verifying `strlen` inlining is suppressed for renamed `string` but not for unrelated builtins.
- Added `TestRenamedToProcDispatch` integration tests confirming renamed-to-proc dispatch works end-to-end in the WASM backend.
- Added `TestSubstFold` unit tests for the new `fold_subst` callback.
- Existing tests pass; new tests cover the optimization gaps and soundness gates.

https://claude.ai/code/session_018ZzoNrX1tNYjWxPLf1karP