### PR TITLE
Fix concat trailing whitespace trimming and empty proc names

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=7f7736b-dirty
-head=7f7736b46454b6b88b16e6bb637051889e08ec09
-date=2026-06-03T08:52:01Z
-fingerprint=dc917a723bf015c5c429a3242b0a2f6446e91ad15911f01c1e42259841c36030
+describe=ca7bba2-dirty
+head=ca7bba2167db88df98170f850aaa37ecbf138cb4
+date=2026-06-03T10:21:01Z
+fingerprint=1c391a9839a645e74921bc5236e0077c2ce32c13541e9b9b22d189a8a5892c0b

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=ca7bba2-dirty
-head=ca7bba2167db88df98170f850aaa37ecbf138cb4
-date=2026-06-03T10:21:01Z
-fingerprint=1c391a9839a645e74921bc5236e0077c2ce32c13541e9b9b22d189a8a5892c0b
+describe=4d0b421-dirty
+head=4d0b421152bc5dc4696d51c8b5af56b84396c34b
+date=2026-06-03T11:41:12Z
+fingerprint=bea046e950eb3e60f9a322bf34262e771d70bc6cf608478335512e68e7084505

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1525,7 +1525,22 @@ fn build_invocation_string(words: []const i32) i32 {
 fn eval_command_dispatch(words: []const i32) i32 {
     cmd_count +%= 1;
     const cmd_s = obj_ensure_string(words[0]);
-    if (cmd_s.len == 0) return 0;
+    if (cmd_s.len == 0) {
+        // A single command word that evaluates to the empty string is a
+        // genuine invocation of a command literally named "" — NOT a
+        // no-op.  (Zero-word commands never reach dispatch: eval_script
+        // skips them via ``n_words == 0``.)  Dispatch to a user-defined
+        // "" proc when one exists (proc-3.7: ``proc {} {x} {}``);
+        // otherwise fall through to the unknown path so it raises the
+        // canonical ``invalid command name ""`` (proc-old-9.1).  The
+        // builtin / ``::``-prefix / namespace-path probes below are all
+        // gated on a non-empty name, so there is nothing else to try.
+        if (procs.proc_buf_nonzero()) {
+            const bucket = procs.proc_lookup(words[0]);
+            if (bucket != 0) return eval_proc_call_bucket(words, bucket);
+        }
+        return eval_proc_call(words);
+    }
 
     // Fast path: probe the proc registry first.  Tcl semantics say a
     // user-defined proc shadows a built-in, and for dispatch-heavy
@@ -4259,6 +4274,7 @@ fn build_invocation_list(words: []const i32) i32 {
 /// so the message echoes the spelling at the call site.
 fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params: u32) void {
     const catch_mod = @import("tcl_catch.zig");
+    const quote = @import("../valtypes/tcl_list_quote.zig");
     const inv = obj_ensure_string(invoked_name);
     const ps = obj_ensure_string(params_obj);
     const prefix = "wrong # args: should be \"";
@@ -4268,7 +4284,13 @@ fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params: u32) void
         const pe = list_element_at(ps.ptr, ps.len, @intCast(i));
         pcap += pe.len + 12;
     }
-    const total: u32 = @as(u32, @intCast(prefix.len)) + inv.len + pcap + 1;
+    // The invoked name is list-element-quoted (Tcl_WrongNumArgs runs
+    // each word through TclScanElement / TclConvertElement), so an
+    // empty proc name renders as ``{}`` rather than a bare space
+    // (proc-3.7: ``proc {} {x} {}`` → ``should be "{} x"``).  Worst-
+    // case list-quoting is ``2*len + 2`` bytes; over-reserve for it.
+    const inv_cap: u32 = inv.len * 2 + 2;
+    const total: u32 = @as(u32, @intCast(prefix.len)) + inv_cap + pcap + 1;
     const buf = alloc(total);
     if (buf == 0) {
         catch_mod.tcl_cmd_error(0);
@@ -4279,10 +4301,7 @@ fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params: u32) void
         @as([*]u8, @ptrFromInt(buf + off))[0] = c;
         off += 1;
     }
-    if (inv.len > 0) {
-        memcpy(buf + off, inv.ptr, inv.len);
-        off += inv.len;
-    }
+    off = quote.list_elem_quote(buf, off, inv.ptr, inv.len);
     i = 0;
     while (i < n_params) : (i += 1) {
         @as([*]u8, @ptrFromInt(buf + off))[0] = ' ';

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -558,7 +558,14 @@ pub export fn proc_register_compiled(
     const hash = fnv1a(sn.ptr, sn.len);
 
     const ctx = resolve_for_register(sn.ptr, sn.len);
-    if (ctx.r.target_ns == 0 or ctx.r.simple_len == 0) return obj_new_int(0);
+    // Reject only an unresolvable namespace — an empty *simple* name is
+    // legal (a command literally named ""), and the interpreted
+    // ``proc_register`` above accepts it.  Rejecting ``simple_len == 0``
+    // here left ``proc {} {} {…}`` undefined in ordinary (non-``eval``)
+    // source, so a later ``{}`` call trapped ``invalid command name ""``
+    // instead of dispatching the compiled body (proc-3.7 via the static
+    // codegen path, not just the eval-fallback path).
+    if (ctx.r.target_ns == 0) return obj_new_int(0);
 
     var cmd: u32 = ctx.existing;
     if (cmd == 0) {

--- a/runtime/zig/valtypes/tcl_string.zig
+++ b/runtime/zig/valtypes/tcl_string.zig
@@ -1689,29 +1689,25 @@ pub export fn tcl_cmd_join(list: i32, separator: i32) i32 {
 // Exported: concat — concatenate two TclObj string representations with space.
 // Each argument has leading/trailing whitespace trimmed before joining.
 // If both are empty after trimming, returns an empty string object.
-/// Strip trailing whitespace bytes from ``p[start..end]`` but stop
-/// when a whitespace byte is preceded by an UNESCAPED backslash
-/// (odd-count run of ``\``).  Tcl's ``concat`` uses this so that
-/// ``\}\ `` round-trips with its trailing escaped space intact —
-/// otherwise the visible space is treated as an end-of-arg
-/// separator and the result loses one byte (ledit-1.25).
+/// Strip trailing whitespace bytes from ``p[start..end]``, then — if
+/// the trim exposed a final backslash — re-expose exactly one of the
+/// trimmed whitespace bytes.  Mirrors ``Tcl_ConcatObj`` (tclUtil.c):
+/// ``TclTrimRight`` removes *all* trailing whitespace with no
+/// backslash awareness, after which ``elemLength += trimr &&
+/// (element[elemLength - 1] == '\\')`` keeps one byte back so a
+/// trailing escaped space survives the concat.  Both an odd run
+/// (``b\ `` → ``b\ ``) and an even run (``b\\   `` → ``b\\ ``) leave
+/// the same single trailing space, since the rule keys off the bare
+/// final ``\`` rather than the backslash parity (util-4.1/4.2/4.3,
+/// ledit-1.25).
 fn trim_trailing_ws_respecting_backslash(p: [*]const u8, start: u32, end_in: u32) u32 {
     var end = end_in;
-    while (end > start and is_space(p[end - 1])) {
-        // Count consecutive backslashes immediately before the
-        // candidate space.  An ODD count means the space is
-        // escaped — leave it (and the trailing backslash) in
-        // place.  EVEN count means each ``\`` pairs with another,
-        // so the trailing whitespace is plain and gets trimmed.
-        var bs: u32 = 0;
-        var j: u32 = end - 1;
-        while (j > start and p[j - 1] == '\\') {
-            bs += 1;
-            j -= 1;
-        }
-        if ((bs & 1) == 1) break;
-        end -= 1;
-    }
+    while (end > start and is_space(p[end - 1])) end -= 1;
+    // Did the trim land on a backslash?  Re-expose one whitespace byte
+    // only when something was actually trimmed and a non-empty element
+    // remains — matching C's ``trimr && element[elemLength - 1] ==
+    // '\\'`` guard (an all-whitespace element trims to nothing here).
+    if (end < end_in and end > start and p[end - 1] == '\\') end += 1;
     return end;
 }
 

--- a/tests/baselines/tcl9-tcltest-wasm/categories/proc-old.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/proc-old.toml
@@ -1,6 +1,6 @@
 # proc-old.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '13 of 74 failed'
+# reason = '12 of 74 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 74
-observed_passed = 61
-observed_failed = 13
+observed_passed = 62
+observed_failed = 12
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["proc-old-3.3", "proc-old-3.5", "proc-old-30.3", "proc-old-5.10", "proc-old-5.13", "proc-old-5.14", "proc-old-5.15", "proc-old-5.16", "proc-old-7.11", "proc-old-7.12", "proc-old-7.13", "proc-old-7.14", "proc-old-9.1"]
+ids = ["proc-old-3.3", "proc-old-3.5", "proc-old-30.3", "proc-old-5.10", "proc-old-5.13", "proc-old-5.14", "proc-old-5.15", "proc-old-5.16", "proc-old-7.11", "proc-old-7.12", "proc-old-7.13", "proc-old-7.14"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/proc.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/proc.toml
@@ -1,6 +1,6 @@
 # proc.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '2 of 38 failed'
+# reason = '1 of 38 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 38
-observed_passed = 36
-observed_failed = 2
+observed_passed = 37
+observed_failed = 1
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["proc-3.7", "proc-4.9"]
+ids = ["proc-4.9"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/util.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/util.toml
@@ -1,6 +1,6 @@
 # util.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '2 of 462 failed'
+# reason = '1 of 462 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 462
-observed_passed = 431
-observed_failed = 2
+observed_passed = 432
+observed_failed = 1
 observed_skipped = 29
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["util-3.6", "util-4.3"]
+ids = ["util-3.6"]

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-02T23:39:59Z",
+  "generated_at": "2026-06-03T09:46:54Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -420,8 +420,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 2,
-      "passed_min": 36,
+      "failed_max": 1,
+      "passed_min": 37,
       "skipped": 0,
       "total": 38
     },
@@ -429,8 +429,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 13,
-      "passed_min": 61,
+      "failed_max": 12,
+      "passed_min": 62,
       "skipped": 0,
       "total": 74
     },
@@ -573,8 +573,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 2,
-      "passed_min": 431,
+      "failed_max": 1,
+      "passed_min": 432,
       "skipped": 29,
       "total": 462
     },

--- a/tests/test_wasm_concat_trim.py
+++ b/tests/test_wasm_concat_trim.py
@@ -1,0 +1,58 @@
+"""WASM ``concat`` trailing-whitespace trimming contract.
+
+``Tcl_ConcatObj`` (tclUtil.c) trims leading and trailing whitespace
+from every element before joining with single spaces.  The trailing
+trim removes *all* whitespace with no backslash awareness, after which::
+
+    elemLength += trimr && (element[elemLength - 1] == '\\');
+
+re-exposes exactly one of the trimmed bytes when the trim landed on a
+backslash — so a trailing escaped space survives the concat.  The rule
+keys off the bare final ``\\``, not the backslash run's parity, so both
+``b\\ `` (one backslash) and ``b\\\\   `` (two backslashes) keep the
+same single trailing space.
+
+The runtime previously stopped trimming at the first odd-backslash-
+escaped space, which is correct for odd runs but trimmed the exposed
+space away for even runs (util-4.3: ``concat a {b\\\\   } c`` produced
+``a b\\\\ c`` instead of ``a b\\\\  c``).  These cases pin the C rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(source: str) -> str:
+    wasm = _compile_tcl(source)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # One backslash, one trailing space — escaped space kept (util-4.1).
+        (r"puts [concat a {b\ } c]", r"a b\  c"),
+        # One backslash, run of trailing spaces — collapse to one (util-4.2).
+        (r"puts [concat a {b\   } c]", r"a b\  c"),
+        # Two backslashes (even run) — the exposed final ``\`` still keeps
+        # one trailing space.  This is the case the old parity check broke
+        # (util-4.3).
+        (r"puts [concat a {b\\   } c]", r"a b\\  c"),
+        # Three backslashes (odd run) — same single trailing space.
+        (r"puts [concat a {b\\\   } c]", r"a b\\\  c"),
+        # No backslash — trailing whitespace fully trimmed (util-4.4).
+        (r"puts [concat a {b } c]", "a b c"),
+        # An all-whitespace element drops out entirely (util-4.5).
+        (r"puts [concat a { } c]", "a c"),
+        # Pairwise accumulation keeps the escaped space across joins.
+        (r"puts [concat {x\ } {y}]", r"x\  y"),
+    ],
+)
+def test_concat_trailing_backslash_space(source: str, expected: str) -> None:
+    assert _run(source) == expected

--- a/tests/test_wasm_proc_validate.py
+++ b/tests/test_wasm_proc_validate.py
@@ -78,3 +78,41 @@ _WRONG_ARGS = 'wrong # args: should be "proc name args body"'
 )
 def test_proc_arg_validation(source: str, expected: str) -> None:
     assert _run(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # A command word that evaluates to the empty string is a genuine
+        # invocation of a command literally named "" — NOT a no-op — so a
+        # proc defined with an empty name is reachable (proc-3.7).
+        (r"set s {proc {} {} {return ok-empty}; puts [{}]}; eval $s", "ok-empty"),
+        (
+            r"set s {proc {} {x} {return got-$x}; puts [{} 42]}; eval $s",
+            "got-42",
+        ),
+        # Calling the empty-named proc with the wrong arity reports the
+        # name list-element-quoted as ``{}`` (Tcl_WrongNumArgs runs every
+        # word through TclScanElement / TclConvertElement), not a bare
+        # leading space (proc-3.7).
+        (
+            r"set s {proc {} {x} {}; puts [catch {{}} m]:$m}; eval $s",
+            '1:wrong # args: should be "{} x"',
+        ),
+        # An undefined empty command name falls through to the canonical
+        # ``invalid command name ""`` rather than silently succeeding
+        # (proc-old-9.1: ``set v [t1]; catch {$v}`` where t1 returns "").
+        (
+            r'set s {puts [catch {$e} m]:$m}; set e ""; eval $s',
+            '1:invalid command name ""',
+        ),
+        # The quoting generalises: a proc whose name contains whitespace
+        # is wrapped in braces in the wrong-args message too.
+        (
+            r"set s {proc {a b} {x y} {}; puts [catch {{a b} 1} m]:$m}; eval $s",
+            '1:wrong # args: should be "{a b} x y"',
+        ),
+    ],
+)
+def test_proc_empty_and_quoted_command_name(source: str, expected: str) -> None:
+    assert _run(source) == expected

--- a/tests/test_wasm_proc_validate.py
+++ b/tests/test_wasm_proc_validate.py
@@ -85,7 +85,10 @@ def test_proc_arg_validation(source: str, expected: str) -> None:
     [
         # A command word that evaluates to the empty string is a genuine
         # invocation of a command literally named "" — NOT a no-op — so a
-        # proc defined with an empty name is reachable (proc-3.7).
+        # proc defined with an empty name is reachable (proc-3.7).  These
+        # cases wrap the body in ``eval`` to drive the interpreted
+        # ``eval_command_dispatch`` path; the static codegen path is
+        # covered separately in ``test_proc_empty_name_static_codegen``.
         (r"set s {proc {} {} {return ok-empty}; puts [{}]}; eval $s", "ok-empty"),
         (
             r"set s {proc {} {x} {return got-$x}; puts [{} 42]}; eval $s",
@@ -115,4 +118,27 @@ def test_proc_arg_validation(source: str, expected: str) -> None:
     ],
 )
 def test_proc_empty_and_quoted_command_name(source: str, expected: str) -> None:
+    assert _run(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # Ordinary (non-``eval``) source compiles the ``proc {}`` body
+        # statically and registers it via ``proc_register_compiled``.
+        # That path previously rejected an empty simple name, leaving the
+        # command undefined so a later ``{}`` call trapped ``invalid
+        # command name ""``.  It now registers (matching the interpreted
+        # ``proc_register``) and the compiled body is reachable (proc-3.7
+        # through the static codegen path, not just the eval-fallback).
+        ("proc {} {} {return ok-empty}\nputs [{}]", "ok-empty"),
+        ("proc {} {x} {return got-$x}\nputs [{} 7]", "got-7"),
+        # Redefining the empty-named command swaps the body in place.
+        (
+            "proc {} {} {return v1}\nputs [{}]\nproc {} {} {return v2}\nputs [{}]",
+            "v1\nv2",
+        ),
+    ],
+)
+def test_proc_empty_name_static_codegen(source: str, expected: str) -> None:
     assert _run(source) == expected


### PR DESCRIPTION
## Summary

This PR fixes two related issues in the Tcl interpreter:

1. **concat trailing whitespace trimming**: The `concat` command now correctly implements the C Tcl behavior (`Tcl_ConcatObj` in tclUtil.c) for handling trailing whitespace with backslashes. The previous implementation used an odd-backslash-parity check that incorrectly trimmed exposed spaces in even-backslash runs. The fix trims all trailing whitespace first, then re-exposes exactly one byte if the trim landed on a backslash, matching the C implementation's logic.

2. **Empty-named proc invocation**: The interpreter now correctly handles user-defined procs with empty names (`proc {} {x} {}`). Previously, empty command names were treated as no-ops. Now they dispatch to a user-defined empty-named proc if one exists, or fall through to raise the canonical "invalid command name" error. Additionally, error messages for wrong-arity calls now properly list-element-quote the invoked name, so empty proc names render as `{}` rather than a bare space.

## Validation

- Added comprehensive test suite `tests/test_wasm_concat_trim.py` covering the concat trailing whitespace behavior with various backslash and space combinations
- Added test cases in `tests/test_wasm_proc_validate.py` for empty-named proc invocation and error message formatting
- Test baselines updated: 3 previously failing tests now pass:
  - `util-4.3` (concat with even-backslash trailing spaces)
  - `proc-3.7` (empty-named proc invocation and error messages)
  - `proc-old-9.1` (undefined empty command name error)

https://claude.ai/code/session_01Wts8M69rRBJmFP2BzMSVwL