### PR TITLE
Fix dict exists, try exception chaining, and related interpreter bugs

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=d3aa44b-dirty
-head=d3aa44b361fd8e86e58834b9e47368418c2ad500
-date=2026-06-03T15:14:16Z
-fingerprint=7d4b621e5091a8000c679327b36670eff390891b0b32e43491a1987a5bed6599
+describe=a26c150-dirty
+head=a26c150970257bd256cb6f0b6be4cbc7bf9c2a85
+date=2026-06-03T15:53:44Z
+fingerprint=61fc6bd539e4891f77ec319ea81b4b34383db38546fe619ee580f3ff8ff1cba9

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=4d0b421-dirty
-head=4d0b421152bc5dc4696d51c8b5af56b84396c34b
-date=2026-06-03T11:41:12Z
-fingerprint=bea046e950eb3e60f9a322bf34262e771d70bc6cf608478335512e68e7084505
+describe=43812a6-dirty
+head=43812a60b9dc9ebe9622b544893112743914eb29
+date=2026-06-03T12:57:02Z
+fingerprint=ebdb6df319727f514cbcde0cbee8aadc1bc024ad855ec045336207b87911c3ad

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=cbc8d05-dirty
-head=cbc8d05a6489d53029986417b4f572b9bd73a7d9
-date=2026-06-03T13:42:21Z
-fingerprint=b97ab4d78435d52892a56d28385e4ea15c2f937b21db2fe0b1ba1a540515419a
+describe=9c250f5-dirty
+head=9c250f50426c6f37946e0060b2c85de999c1422e
+date=2026-06-03T14:02:12Z
+fingerprint=f329cd74788c72fea799e00443edf48b509abae5f863c13845d8ed5714318cbd

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=603cec5-dirty
-head=603cec51cbbe9d197b52cced52195889f59f5e68
-date=2026-06-03T16:25:23Z
-fingerprint=f85954f6c44580a983846de5dd4fa64b58020cc749d92f98f0e199ac76c1e41b
+describe=763457d-dirty
+head=763457d5b298183d3aed18e01ad0e59071ce4d39
+date=2026-06-03T19:05:43Z
+fingerprint=3e3baa4459807d1d2515f1cee858a39720d37a1cb15d7d492462672a4d275393

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=a26c150-dirty
-head=a26c150970257bd256cb6f0b6be4cbc7bf9c2a85
-date=2026-06-03T15:53:44Z
-fingerprint=61fc6bd539e4891f77ec319ea81b4b34383db38546fe619ee580f3ff8ff1cba9
+describe=603cec5-dirty
+head=603cec51cbbe9d197b52cced52195889f59f5e68
+date=2026-06-03T16:25:23Z
+fingerprint=f85954f6c44580a983846de5dd4fa64b58020cc749d92f98f0e199ac76c1e41b

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=9c250f5-dirty
-head=9c250f50426c6f37946e0060b2c85de999c1422e
-date=2026-06-03T14:02:12Z
-fingerprint=f329cd74788c72fea799e00443edf48b509abae5f863c13845d8ed5714318cbd
+describe=d3aa44b-dirty
+head=d3aa44b361fd8e86e58834b9e47368418c2ad500
+date=2026-06-03T15:14:16Z
+fingerprint=7d4b621e5091a8000c679327b36670eff390891b0b32e43491a1987a5bed6599

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=763457d-dirty
-head=763457d5b298183d3aed18e01ad0e59071ce4d39
-date=2026-06-03T19:05:43Z
-fingerprint=3e3baa4459807d1d2515f1cee858a39720d37a1cb15d7d492462672a4d275393
+describe=0373dc3-dirty
+head=0373dc3f2a39cba4bcc1c3632eeeb0f24f6c078b
+date=2026-06-03T20:25:35Z
+fingerprint=ba52268e35abcef224e997fb048eb143842277b6c35c1ac13e5400e10d79c61b

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=43812a6-dirty
-head=43812a60b9dc9ebe9622b544893112743914eb29
-date=2026-06-03T12:57:02Z
-fingerprint=ebdb6df319727f514cbcde0cbee8aadc1bc024ad855ec045336207b87911c3ad
+describe=cbc8d05-dirty
+head=cbc8d05a6489d53029986417b4f572b9bd73a7d9
+date=2026-06-03T13:42:21Z
+fingerprint=b97ab4d78435d52892a56d28385e4ea15c2f937b21db2fe0b1ba1a540515419a

--- a/compiler/codegen/wasm/_emitter/_commands.py
+++ b/compiler/codegen/wasm/_emitter/_commands.py
@@ -73,6 +73,7 @@ class _WasmEmitterCmdMixin(_Base):
         def _emit_push_pending_argv0(self, *a: Any, **kw: Any) -> Any: ...
         # From _WasmEmitterStmtMixin
         def _emit_eval_fallback(self, *a: Any, **kw: Any) -> Any: ...
+        def _proc_arity_exceeded(self, *a: Any, **kw: Any) -> Any: ...
         def _emit_unsupported_trap(self, *a: Any, **kw: Any) -> Any: ...
         def _emit_diag_site(self, *a: Any, **kw: Any) -> Any: ...
         # From _WasmEmitterVarMixin
@@ -642,6 +643,17 @@ class _WasmEmitterCmdMixin(_Base):
         # pad with ``i32.const 0`` via :meth:`_emit_default_arg`
         # for missing args — no per-call-site default lookup
         # needed.
+        # Surplus positional args to a non-variadic proc are a
+        # ``wrong # args`` error.  The interpreted dispatch
+        # (``eval_proc_call_bucket``) enforces this; route the over-arity
+        # call through the eval fallback so the static-codegen path raises
+        # the same error instead of silently truncating (Codex review on
+        # PR #532; proc-old-30.3).  ``invoked_name`` is the source word
+        # the fallback re-evals; it is always set from ``_emit_call_stmt``.
+        if invoked_name is not None and self._proc_arity_exceeded(qname, n_params, len(args)):
+            self._emit_eval_fallback(invoked_name, args, tokens=tokens)
+            self._emit(WasmOp.DROP)
+            return
         has_args_tail = qname is not None and qname in self._proc_args_tail
         argv0_local = (
             self._emit_prepare_pending_argv0(invoked_name) if invoked_name is not None else None

--- a/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/compiler/codegen/wasm/_emitter/_expressions.py
@@ -83,6 +83,7 @@ class _WasmEmitterExprMixin(_Base):
         def _emit_distrust_proc_subst(self, *a: Any, **kw: Any) -> Any: ...
         def _resolve_proc_qname(self, *a: Any, **kw: Any) -> Any: ...
         def _resolve_proc(self, *a: Any, **kw: Any) -> Any: ...
+        def _proc_arity_exceeded(self, *a: Any, **kw: Any) -> Any: ...
         # From _WasmEmitterCtrlMixin
         def _emit_catch_from_args(self, *a: Any, **kw: Any) -> Any: ...
         # From _WasmEmitterCmdMixin
@@ -766,11 +767,15 @@ class _WasmEmitterExprMixin(_Base):
             ):
                 func_idx, n_params = proc_info
                 qname = self._resolve_proc_qname(cmd_name)
-                has_args_tail = qname is not None and qname in self._proc_args_tail
-                self._emit_distrust_proc_subst(
-                    cmd_name, cmd_args, cmd_text, func_idx, n_params, has_args_tail, unbox=True
-                )
-                return
+                # Surplus args to a non-variadic proc → fall through to the
+                # eval fallback so the interpreter raises ``wrong # args``
+                # (Codex review on PR #532).
+                if not self._proc_arity_exceeded(qname, n_params, len(cmd_args)):
+                    has_args_tail = qname is not None and qname in self._proc_args_tail
+                    self._emit_distrust_proc_subst(
+                        cmd_name, cmd_args, cmd_text, func_idx, n_params, has_args_tail, unbox=True
+                    )
+                    return
             self._emit_eval_fallback(cmd_name, cmd_args, script_override=cmd_text)
             self._emit_unbox_int()
             return
@@ -846,6 +851,16 @@ class _WasmEmitterExprMixin(_Base):
         proc_info = self._resolve_proc(cmd_name)
         if proc_info is not None:
             func_idx, n_params = proc_info
+            # Surplus args to a non-variadic proc → route through the eval
+            # fallback so the interpreter raises ``wrong # args`` rather
+            # than the direct dispatch silently truncating (Codex review
+            # on PR #532).  Unbox to i64 for the expression context.
+            if self._proc_arity_exceeded(
+                self._resolve_proc_qname(cmd_name), n_params, len(cmd_args)
+            ):
+                self._emit_eval_fallback(cmd_name, cmd_args, script_override=cmd_text)
+                self._emit_unbox_int()
+                return
             # Stash the caller's invoked word for the callee's
             # ``info level 0`` — see :meth:`_emit_prepare_pending_argv0`.
             argv0_local = self._emit_prepare_pending_argv0(cmd_name)

--- a/compiler/codegen/wasm/_emitter/_expressions.py
+++ b/compiler/codegen/wasm/_emitter/_expressions.py
@@ -877,6 +877,14 @@ class _WasmEmitterExprMixin(_Base):
                 func_idx = self._shared_imports[sri.import_key]
                 param_count = len(sri.params)
                 sub_args = cmd_args[1:]
+                # ``dict get/exists DICT KEY ?KEY...?`` in a condition
+                # (``if {[dict exists $d a b]}``) — the 2-param fast path
+                # only walks the first key.  Route the multi-key form
+                # through eval so the runtime descends the chain.
+                if subcmd in ("get", "exists") and len(sub_args) > 2:
+                    self._emit_eval_fallback(cmd_name, cmd_args, script_override=cmd_text)
+                    self._emit_unbox_int()
+                    return
                 for i in range(min(param_count, len(sub_args))):
                     self._emit_value(sub_args[i])
                 for _ in range(param_count - len(sub_args)):

--- a/compiler/codegen/wasm/_emitter/_statements.py
+++ b/compiler/codegen/wasm/_emitter/_statements.py
@@ -1173,6 +1173,23 @@ class _WasmEmitterStmtMixin(_Base):
             return idx.get(imported)
         return None
 
+    def _proc_arity_exceeded(self, qname: "str | None", n_params: int, n_args: int) -> bool:
+        """True when a compiled call to *qname* supplies more positional
+        arguments than the proc accepts.
+
+        A proc whose last formal is the variadic ``args`` collector
+        (tracked in ``_proc_args_tail``) accepts any number of trailing
+        args, so it never exceeds.  Otherwise more than *n_params* call
+        args is a ``wrong # args`` error.  Direct-call emit sites consult
+        this and route the over-arity case through the eval fallback,
+        which raises the canonical message via ``eval_proc_call_bucket``
+        (the interpreted dispatch enforces the same limit) — proc-old-30.3
+        on the static-codegen path, matching the interpreted slice.
+        """
+        if qname is not None and qname in self._proc_args_tail:
+            return False
+        return n_args > n_params
+
     def _emit_call_stmt(
         self,
         command: str,
@@ -1967,6 +1984,14 @@ class _WasmEmitterStmtMixin(_Base):
         if proc_info is not None:
             func_idx, n_params = proc_info
             qname = self._resolve_proc_qname(command)
+            # Surplus args to a non-variadic proc → route through the eval
+            # fallback so the interpreter raises ``wrong # args`` instead
+            # of the direct dispatch silently truncating (Codex review on
+            # PR #532).  The fallback leaves its i32 result on the stack,
+            # matching this tail/value context.
+            if self._proc_arity_exceeded(qname, n_params, len(args)):
+                self._emit_eval_fallback(command, args, tokens=tokens)
+                return
             has_args_tail = qname is not None and qname in self._proc_args_tail
             # Stash the invoked word for the callee's
             # ``info level 0`` argv0 — see

--- a/compiler/codegen/wasm/_emitter/_values.py
+++ b/compiler/codegen/wasm/_emitter/_values.py
@@ -1063,11 +1063,13 @@ class _WasmEmitterValuesMixin(_Base):
                 func_idx = self._shared_imports[sri.import_key]
                 param_count = len(sri.params)
                 sub_args = cmd_args[1:]
-                # ``dict get DICT KEY ?KEY...?`` — multi-key chain
-                # descent into nested dicts.  The 2-param fast path
-                # only sees the first key; route extra keys through
-                # eval so the runtime walks the chain (error-18.10).
-                if subcmd == "get" and len(sub_args) > 2:
+                # ``dict get/exists DICT KEY ?KEY...?`` — multi-key
+                # chain descent into nested dicts.  The 2-param fast
+                # path only sees the first key; route extra keys through
+                # eval so the runtime walks the chain.  ``dict get``
+                # (error-18.10) and ``dict exists`` (error-18.8/.9/.10's
+                # ``dict exists $opts -during -during``) both need this.
+                if subcmd in ("get", "exists") and len(sub_args) > 2:
                     self._emit_eval_fallback(cmd_name, cmd_args, script_override=cmd_text)
                     return
                 for i in range(min(param_count, len(sub_args))):

--- a/compiler/codegen/wasm/_emitter/_values.py
+++ b/compiler/codegen/wasm/_emitter/_values.py
@@ -385,6 +385,7 @@ class _WasmEmitterValuesMixin(_Base):
         def _emit_distrust_proc_subst(self, *a: Any, **kw: Any) -> Any: ...
         def _resolve_proc_qname(self, *a: Any, **kw: Any) -> Any: ...
         def _resolve_proc(self, *a: Any, **kw: Any) -> Any: ...
+        def _proc_arity_exceeded(self, *a: Any, **kw: Any) -> Any: ...
         # From _WasmEmitterExprMixin
         def _emit_expr(self, *a: Any, **kw: Any) -> Any: ...
         def _emit_expr_obj(self, *a: Any, **kw: Any) -> Any: ...
@@ -815,10 +816,12 @@ class _WasmEmitterValuesMixin(_Base):
         # takes the rename-aware, trace-aware guarded dispatch (mirrors
         # ``_emit_command_subst``): needed for proc calls that appear as command
         # *arguments* (``[string range $c [12days …] end]``).  See
-        # ``_emit_distrust_proc_subst``.  Known narrow gap: a *variadic*
-        # ``{args}`` proc shadowing a *renamed* builtin binds ``args`` short
-        # (AOT prologue pre-registers procs before the rename runs); fixed-arity
-        # shadows are correct.
+        # ``_emit_distrust_proc_subst``.  A *variadic* ``{args}`` proc
+        # shadowing a *renamed* builtin whose ``args`` tail the compile-time
+        # ``_proc_args_tail`` didn't recognise is handled by the over-arity
+        # guard below: it routes that call through the eval fallback, where
+        # the runtime reads the proc's real stored params and packs the tail
+        # correctly (test_variadic_shadow_of_renamed_builtin).
         if not builtin_is_trusted(cmd_name):
             proc_info = self._resolve_proc(cmd_name, self._full_proc_index)
             if (
@@ -830,11 +833,16 @@ class _WasmEmitterValuesMixin(_Base):
             ):
                 func_idx, n_params = proc_info
                 qname = self._resolve_proc_qname(cmd_name)
-                has_args_tail = qname is not None and qname in self._proc_args_tail
-                self._emit_distrust_proc_subst(
-                    cmd_name, cmd_args, cmd_text, func_idx, n_params, has_args_tail, unbox=False
-                )
-                return
+                # Surplus args to a non-variadic proc → fall through to the
+                # eval fallback so the interpreter raises ``wrong # args``
+                # (Codex review on PR #532); don't truncate via the direct
+                # dispatch.
+                if not self._proc_arity_exceeded(qname, n_params, len(cmd_args)):
+                    has_args_tail = qname is not None and qname in self._proc_args_tail
+                    self._emit_distrust_proc_subst(
+                        cmd_name, cmd_args, cmd_text, func_idx, n_params, has_args_tail, unbox=False
+                    )
+                    return
             self._emit_eval_fallback(cmd_name, cmd_args, script_override=cmd_text)
             return
 
@@ -932,6 +940,14 @@ class _WasmEmitterValuesMixin(_Base):
         if proc_info is not None:
             func_idx, n_params = proc_info
             qname = self._resolve_proc_qname(cmd_name)
+            # Surplus args to a non-variadic proc → route through the eval
+            # fallback so the interpreter raises ``wrong # args`` instead
+            # of the direct dispatch silently truncating (Codex review on
+            # PR #532).  The fallback leaves its i32 result on the stack,
+            # matching this value context.
+            if self._proc_arity_exceeded(qname, n_params, len(cmd_args)):
+                self._emit_eval_fallback(cmd_name, cmd_args, script_override=cmd_text)
+                return
             has_args_tail = qname is not None and qname in self._proc_args_tail
             # Stash the exact word the caller wrote so the callee's
             # prologue can report it as argv[0] via

--- a/compiler/codegen/wasm/_emitter/cmds/dict_.py
+++ b/compiler/codegen/wasm/_emitter/cmds/dict_.py
@@ -30,14 +30,17 @@ def _emit_dict(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: E
                 func_idx = emitter._shared_imports[sri.import_key]
                 param_count = len(sri.params)
                 sub_args = args[1:]
-                if subcmd == "get" and len(sub_args) > 2:
-                    # ``dict get DICT KEY ?KEY...?`` — Tcl 9 supports
-                    # chained-key descent into nested dicts.  The
-                    # 2-param runtime import only handles a single
-                    # key; route the multi-key form through eval so
-                    # the runtime ``dict get`` handler walks the
-                    # chain (error-18.10's ``dict get $opts -during
-                    # -during -errorcode`` exercises this).
+                if subcmd in ("get", "exists") and len(sub_args) > 2:
+                    # ``dict get/exists DICT KEY ?KEY...?`` — Tcl 9
+                    # supports chained-key descent into nested dicts.
+                    # The 2-param runtime imports only handle a single
+                    # key; route the multi-key form through eval so the
+                    # runtime ``dict get`` / ``dict exists`` handlers
+                    # walk the chain.  ``dict get`` (error-18.10's
+                    # ``dict get $opts -during -during -errorcode``) and
+                    # ``dict exists`` (error-18.8/.9/.10's
+                    # ``dict exists $opts -during -during``) both
+                    # exercise this.
                     emitter._emit_eval_fallback("dict", args)
                     return True
                 if subcmd == "set" and len(sub_args) >= 3:
@@ -159,6 +162,19 @@ def _emit_dict(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: E
         for elem in kv:
             emitter._emit_value(elem)
             emitter._emit_call(lappend_idx)
+        if defs:
+            def_idx = emitter._intern_local(defs[0])
+            emitter._emit_local_set(def_idx)
+        else:
+            emitter._emit(WasmOp.DROP)
+        return True
+
+    if subcmd in ("get", "exists") and len(args) - 1 > 2:
+        # Multi-key ``dict get/exists DICT KEY ?KEY...?`` — the 2-param
+        # runtime imports only walk a single key, so route the chained
+        # form through eval (the runtime handlers do the nested descent).
+        # See the matching guard on the VALUE path above.
+        emitter._emit_eval_fallback("dict", args)
         if defs:
             def_idx = emitter._intern_local(defs[0])
             emitter._emit_local_set(def_idx)

--- a/runtime/zig/cmds/dict.zig
+++ b/runtime/zig/cmds/dict.zig
@@ -174,7 +174,37 @@ pub fn eval(words: []const i32) result_mod.InterpResult {
         return result_mod.from_globals(result);
     }
     if (str_eq(sp, sub.len, "update") and words.len >= 6) return result_mod.from_globals(eval_dict_update(words));
-    if (str_eq(sp, sub.len, "exists") and words.len >= 4) return result_mod.from_globals(rt.dict_exists(words[2], words[3]));
+    if (str_eq(sp, sub.len, "exists") and words.len >= 4) {
+        // ``dict exists DICT KEY ?KEY ...?`` — walk the nested key
+        // path (error-18.8/.9/.10 probe a two-level
+        // ``dict exists $opts -during -during`` chain).  Unlike
+        // ``dict get`` this never raises: a missing key OR a non-dict
+        // intermediate value collapses to false (0), matching
+        // tclDictObj.c::DictExistsCmd, which traces the path with
+        // interp==NULL so lookup errors fold into a false result.
+        //
+        // Ownership mirrors the ``dict get`` walk above: ``cur`` starts
+        // borrowed (``words[2]``); each ``dict_get`` drill returns +1
+        // owned, so release the prior owned ``cur`` before overwriting.
+        // ``dict_exists`` yields an immediate 0/1 box (no refcount).
+        var cur: i32 = words[2];
+        var owns_cur: bool = false;
+        var ki: u32 = 3;
+        while (ki + 1 < words.len) : (ki += 1) {
+            const here = rt.dict_exists(cur, words[ki]);
+            if (rt.obj_get_int(here) == 0) {
+                if (owns_cur) obj.tcl_obj_release(cur);
+                return result_mod.from_globals(here);
+            }
+            const next = rt.dict_get(cur, words[ki]);
+            if (owns_cur) obj.tcl_obj_release(cur);
+            cur = next;
+            owns_cur = true;
+        }
+        const res = rt.dict_exists(cur, words[words.len - 1]);
+        if (owns_cur) obj.tcl_obj_release(cur);
+        return result_mod.from_globals(res);
+    }
     if (str_eq(sp, sub.len, "keys")) return result_mod.from_globals(rt.dict_keys(words[2]));
     if (str_eq(sp, sub.len, "values")) return result_mod.from_globals(rt.dict_values(words[2]));
     if (str_eq(sp, sub.len, "size")) return result_mod.from_globals(rt.dict_size(words[2]));

--- a/runtime/zig/cmds/flow.zig
+++ b/runtime/zig/cmds/flow.zig
@@ -707,6 +707,18 @@ fn eval_try(words: []const i32) result_mod.InterpResult {
     const interp = @import("../interp/tcl_interp.zig");
 
     rt.catch_enter();
+    // Hygiene: drop any ``during_options`` leaked from a prior ``try``
+    // whose finally raised but whose options dict was never read
+    // (``eval_catch`` only consumes the slot for the 4-arg
+    // ``catch BODY result opts`` form, so a 2-/3-arg catch leaves it
+    // set).  Clearing here keeps this try's body/handler options
+    // snapshot from inheriting an unrelated chain — the body's own
+    // nested ``try ... finally`` re-arms the slot if it needs to.
+    if (catch_mod.state.during_options != 0) {
+        const obj_mod_entry = @import("../valtypes/tcl_obj.zig");
+        obj_mod_entry.tcl_obj_release(catch_mod.state.during_options);
+        catch_mod.state.during_options = 0;
+    }
     const body_s = obj_ensure_string(words[1]);
     const body_res = interp.eval_script(body_s.ptr, body_s.len);
     rt.catch_set_ok_result(body_res);
@@ -851,19 +863,91 @@ fn eval_try(words: []const i32) result_mod.InterpResult {
                     pending_chain = true;
                     continue;
                 }
+                // Snapshot the body's (or prior chain's) effective
+                // options BEFORE the handler runs — a throwing handler
+                // clobbers ::errorInfo/::errorCode, so the body's error
+                // metadata must be captured now.  C Tcl's TryPostHandler
+                // (tclCmdMZ.c) chains these under ``-during`` when the
+                // handler itself raises (error-16.8/.9, -18.10), and
+                // discards them — the handler's options replace the
+                // body's wholesale — when the handler completes without
+                // raising (error-16.10, -18.9).  ``catch_options`` also
+                // folds in (and clears) any pending ``during_options``.
+                const obj_mod_h = @import("../valtypes/tcl_obj.zig");
+                const body_opts = catch_mod.catch_options();
                 final_result = interp.eval_script(hb_s.ptr, hb_s.len);
                 error_raised = false;
                 handled = true;
                 pending_chain = false;
-                // If the handler raised an error itself (or re-raised
-                // the body's error via ``return -options $y $x``),
-                // the outer ``eval_script`` will add an ``invoked
-                // from within "try ..."`` frame.  Tcl 9 bytecode-
-                // compiles ``try``, so the try command never appears
-                // in the traceback — set ``transparent_error`` to
-                // suppress that frame (error-15.10.x.1.x check this).
                 if (catch_mod.state.error_flag != 0) {
+                    // Tcl 9 bytecode-compiles ``try``, so it never appears
+                    // in the traceback — suppress the outer ``invoked from
+                    // within "try ..."`` frame (error-15.10.x check this).
                     catch_mod.state.transparent_error = 1;
+                    if (catch_mod.state.return_via_error_code == 0) {
+                        // Handler raised a *direct* error (``throw`` /
+                        // ``error``): C Tcl's TryPostHandler sees TCL_ERROR
+                        // and calls During(), chaining the body's options
+                        // under ``-during``.  Force the option slots to an
+                        // ERROR outcome so ``catch_options`` emits
+                        // -errorcode / -errorinfo / -code 1 even when the
+                        // body was OK (error-16.8's ``on ok`` handler that
+                        // throws) — then attach the captured body options.
+                        catch_mod.state.last_catch_had_error = 1;
+                        catch_mod.state.last_return_code = 1;
+                        catch_mod.state.last_return_level = 0;
+                        if (catch_mod.state.last_return_extras != 0) {
+                            obj_mod_h.tcl_obj_release(catch_mod.state.last_return_extras);
+                            catch_mod.state.last_return_extras = 0;
+                        }
+                        // ``catch_options`` consumes this slot exactly once
+                        // — the finally's during_snap below, or the
+                        // enclosing catch when there is no finally
+                        // (error-16.8/.9, -18.10).  Release any chain the
+                        // handler body itself left pending (a nested
+                        // ``try ... finally {throw}``): C Tcl's During
+                        // overwrites the ``-during`` key with the outer
+                        // body's options, so the inner chain is dropped.
+                        if (catch_mod.state.during_options != 0) {
+                            obj_mod_h.tcl_obj_release(catch_mod.state.during_options);
+                        }
+                        catch_mod.state.during_options = body_opts;
+                    } else {
+                        // Handler re-raised via ``return -code error`` /
+                        // ``return -options $opts $msg``: C Tcl evaluates
+                        // this as TCL_RETURN (the level decrement happens
+                        // at the eval boundary), so TryPostHandler takes
+                        // the no-During branch and the handler's return
+                        // options replace the body's verbatim — error-15.10
+                        // checks ``catch {try …}`` ≡ ``catch $script``.
+                        // ``eval_return`` already armed pending_return_* with
+                        // the re-raised dict; let the enclosing catch_leave
+                        // snapshot them.  Drop the body snapshot, no chain.
+                        if (body_opts != 0) obj_mod_h.tcl_obj_release(body_opts);
+                    }
+                } else {
+                    // Handler completed without raising.  Its options
+                    // replace the body's (no ``-during``); drop the
+                    // snapshot.  For a clean OK completion reset the option
+                    // slots so ``catch_options`` reports the handler's
+                    // code 0 — not the body's sticky error (error-18.9
+                    // checks ``-during -code 0`` after an ``on error``
+                    // handler swallowed the body error).  A return / break
+                    // / continue handler keeps its flow signal and pending
+                    // option slots untouched so it still propagates.
+                    if (body_opts != 0) obj_mod_h.tcl_obj_release(body_opts);
+                    if (catch_mod.state.return_flag == 0 and
+                        catch_mod.state.break_flag == 0 and
+                        catch_mod.state.continue_flag == 0)
+                    {
+                        catch_mod.state.last_catch_had_error = 0;
+                        catch_mod.state.last_return_code = 0;
+                        catch_mod.state.last_return_level = 0;
+                        if (catch_mod.state.last_return_extras != 0) {
+                            obj_mod_h.tcl_obj_release(catch_mod.state.last_return_extras);
+                            catch_mod.state.last_return_extras = 0;
+                        }
+                    }
                 }
             }
             continue;

--- a/runtime/zig/cmds/var.zig
+++ b/runtime/zig/cmds/var.zig
@@ -170,6 +170,43 @@ fn eval_unset(words: []const i32) result_mod.InterpResult {
             return result_mod.from_globals(0);
         }
         const wp: [*]const u8 = @ptrFromInt(w.ptr);
+        // Array-element form ``arr(key)`` — remove just that element via
+        // ``array_unset_element`` (resolving the array name through any
+        // ``global`` / ``upvar`` link), NOT the whole array.  Without
+        // this the loop below fell through to ``array_unset`` (a no-op
+        // against the literal name ``arr(key)``) plus ``var_set(.., 0)``
+        // (which routes through the array path and merely *set* the
+        // element to the empty string), leaving the element present and
+        // the directory inconsistent — proc-old-3.3 / 3.5
+        // (``global a; unset a(y)``).  Mirrors ``array unset arr key``.
+        elem_unset: {
+            if (w.len < 3) break :elem_unset;
+            var paren: u32 = 0;
+            var has_paren = false;
+            var pk: u32 = 0;
+            while (pk < w.len) : (pk += 1) {
+                if (wp[pk] == '(') {
+                    paren = pk;
+                    has_paren = true;
+                    break;
+                }
+            }
+            if (!(has_paren and paren > 0 and wp[w.len - 1] == ')')) break :elem_unset;
+            const tcl_obj_elem = @import("../valtypes/tcl_obj.zig");
+            // ``obj_new_string`` borrows the byte span (no copy); both
+            // names point into ``words[i]``'s live buffer for the call.
+            const arr_name = tcl_obj_elem.obj_new_string(@bitCast(w.ptr), @bitCast(paren));
+            defer tcl_obj_elem.tcl_obj_release(arr_name);
+            const resolved_elem_arr = frames.frame_resolve_array_name(arr_name);
+            defer if (resolved_elem_arr != arr_name) tcl_obj_elem.tcl_obj_release(resolved_elem_arr);
+            const key_len: u32 = w.len - paren - 2;
+            const key = tcl_obj_elem.obj_new_string(@bitCast(w.ptr + paren + 1), @bitCast(key_len));
+            defer tcl_obj_elem.tcl_obj_release(key);
+            _ = tcl_array.array_unset_element(resolved_elem_arr, key);
+            const inspect_elem = @import("inspect.zig");
+            inspect_elem.remove_all_var_traces(words[i]);
+            continue;
+        }
         // Clear the array table before nulling the variable so
         // ``info exists arr`` returns 0 after ``unset arr``.
         const resolved_arr = frames.frame_resolve_array_name(words[i]);

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -2740,6 +2740,42 @@ pub export fn var_resolve(name: i32) i32 {
 /// Used by :func:`var_set` to detect the conflict BEFORE the bare
 /// name is qualified to ``::ns::name`` and routed through
 /// ``global_set`` (which would report the qualified form).
+/// ``can't set "<arr(key)>": variable isn't array`` — raised when an
+/// array-element write targets a name that already exists as a scalar
+/// (set-old-6.2, regexpComp-6.8/11.7).  *name_ptr*/*name_len* is the
+/// user's full spelling including the ``(key)`` suffix.
+fn raise_set_not_array(name_ptr: u32, name_len: u32) void {
+    const catch_mod = @import("tcl_catch.zig");
+    const prefix: []const u8 = "can't set \"";
+    const suffix: []const u8 = "\": variable isn't array";
+    const total: u32 = @intCast(prefix.len + name_len + suffix.len);
+    const buf = obj.alloc(total);
+    if (buf == 0) {
+        catch_mod.tcl_cmd_error(obj.obj_new_string(0, 0));
+        return;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (name_len > 0 and name_ptr != 0) {
+        const sp: [*]const u8 = @ptrFromInt(name_ptr);
+        var k: u32 = 0;
+        while (k < name_len) : (k += 1) {
+            dst[off] = sp[k];
+            off += 1;
+        }
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const msg = obj.obj_new_string_take(buf, total, total);
+    catch_mod.tcl_cmd_error(msg);
+}
+
 fn raise_set_array_conflict(name_ptr: u32, name_len: u32) void {
     const catch_mod = @import("tcl_catch.zig");
     const prefix: []const u8 = "can't set \"";
@@ -2828,6 +2864,35 @@ pub export fn var_set(name: i32, value: i32) i32 {
             const resolved_arr = frame_resolve_array_name(arr_name);
             const key_len = sn.len - paren - 2;
             const key = obj.obj_new_string(@bitCast(sn.ptr + paren + 1), @bitCast(key_len));
+            // Scalar-vs-array conflict: writing an element of a name
+            // that already exists as a SCALAR raises ``can't set
+            // "<arr(key)>": variable isn't array`` with the user's full
+            // spelling (set-old-6.2, regexpComp-6.8/11.7).  The probe
+            // MUST use the same scope this element write resolves to:
+            // inside a proc an unqualified name binds to a frame-local,
+            // so a same-named GLOBAL scalar must not block ``set x(1)``
+            // (which creates a fresh local array — set-old-12.2).  A
+            // ``::``-qualified name and the top-level case bind to the
+            // global/namespace store.  An existing array is fine
+            // (``array_exists``); an absent base falls through to the
+            // normal create-on-write.  Cases this scope branch misses
+            // (e.g. a namespace-eval scalar) are still caught by
+            // ``find_or_create`` inside ``array_set``.
+            if (obj.obj_get_int(tcl_array.array_exists(resolved_arr)) == 0) {
+                const ap: [*]const u8 = if (paren > 0) @ptrFromInt(sn.ptr) else undefined;
+                const qualified = paren >= 2 and ap[0] == ':' and ap[1] == ':';
+                const base_is_scalar = if (current_frame() != null and !qualified)
+                    obj.obj_get_int(local_exists(arr_name)) != 0
+                else
+                    obj.obj_get_int(globals.global_exists(arr_name)) != 0;
+                if (base_is_scalar) {
+                    raise_set_not_array(sn.ptr, sn.len);
+                    obj.tcl_obj_release(arr_name);
+                    if (resolved_arr != arr_name) obj.tcl_obj_release(resolved_arr);
+                    obj.tcl_obj_release(key);
+                    return 0;
+                }
+            }
             _ = tcl_array.array_set(resolved_arr, key, value);
             obj.tcl_obj_release(arr_name);
             if (resolved_arr != arr_name) obj.tcl_obj_release(resolved_arr);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -5425,6 +5425,99 @@ pub fn eval_call(words: []const i32) i32 {
     return eval_command(words);
 }
 
+/// Append the ``(parsing lambda expression "<lambda>")`` errorInfo frame
+/// that C Tcl's ``SetLambdaFromAny`` adds whenever ``TclCreateProc``
+/// rejects a lambda's formal-parameter list (apply-2.2..2.5).  The
+/// sentinel set by ``append_errinfo_frame`` makes the enclosing
+/// ``apply $lambda`` log use ``invoked from within`` rather than the
+/// first-frame ``while executing``.  No-op unless an error is pending.
+fn append_lambda_parse_frame(lambda_obj: i32) void {
+    const tcl_catch = @import("tcl_catch.zig");
+    if (tcl_catch.state.error_flag == 0) return;
+    const tcl_ns_mod = @import("tcl_ns.zig");
+    const ls = obj_ensure_string(lambda_obj);
+    const prefix: []const u8 = "\n    (parsing lambda expression \"";
+    const suffix: []const u8 = "\")";
+    const total: u32 = @intCast(prefix.len + ls.len + suffix.len);
+    const buf = alloc(total);
+    if (buf == 0) return;
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    if (ls.len > 0) {
+        const sp: [*]const u8 = @ptrFromInt(ls.ptr);
+        var k: u32 = 0;
+        while (k < ls.len) : (k += 1) {
+            dst[off] = sp[k];
+            off += 1;
+        }
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const bp: [*]const u8 = @ptrFromInt(buf);
+    tcl_ns_mod.append_errinfo_frame(bp[0..total]);
+    obj_mod.free_sized(buf, total);
+}
+
+/// Validate a proc/lambda formal-parameter NAME the way C Tcl's
+/// ``TclCreateProc`` does: reject array-element names (``a(1)`` ->
+/// "is an array element") and qualified names (``a::b`` -> "is not a
+/// simple name").  When NAME is invalid the matching error is raised
+/// and ``true`` returned; the caller then pops its frame, appends the
+/// lambda-parse frame, and propagates (apply-2.4 / 2.5).
+fn raise_if_bad_formal_param(name_ptr: u32, name_len: u32) bool {
+    if (name_len == 0) return false;
+    const sp: [*]const u8 = @ptrFromInt(name_ptr);
+    const last = name_len - 1;
+    var i: u32 = 0;
+    var kind: u8 = 0; // 1 = array element, 2 = not a simple name
+    while (i < last) : (i += 1) {
+        if (sp[i] == '(') {
+            if (sp[last] == ')') {
+                kind = 1;
+                break;
+            }
+        } else if (sp[i] == ':' and sp[i + 1] == ':') {
+            kind = 2;
+            break;
+        }
+    }
+    if (kind == 0) return false;
+    const stubs = @import("../stubs/tcl_stubs.zig");
+    const prefix: []const u8 = "formal parameter \"";
+    const suffix: []const u8 = if (kind == 1) "\" is an array element" else "\" is not a simple name";
+    const total: u32 = @intCast(prefix.len + name_len + suffix.len);
+    const buf = alloc(total);
+    if (buf == 0) {
+        stubs.raise("formal parameter is invalid");
+        return true;
+    }
+    const dst: [*]u8 = @ptrFromInt(buf);
+    var off: u32 = 0;
+    for (prefix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    var k: u32 = 0;
+    while (k < name_len) : (k += 1) {
+        dst[off] = sp[k];
+        off += 1;
+    }
+    for (suffix) |c| {
+        dst[off] = c;
+        off += 1;
+    }
+    const bp: [*]const u8 = @ptrFromInt(buf);
+    stubs.raise(bp[0..total]);
+    obj_mod.free_sized(buf, total);
+    return true;
+}
+
 /// ``apply`` — invoke an anonymous lambda: apply {paramList body ?ns?} ?arg ...?
 /// Public so tcl_env_stubs.zig can call it from the 2-arg compiled export.
 pub fn eval_apply(words: []const i32) i32 {
@@ -5505,6 +5598,16 @@ pub fn eval_apply(words: []const i32) i32 {
         frames.frame_set_proc_name(fq);
         obj_mod.tcl_obj_release(fq);
     }
+    {
+        // Record the invocation (``apply`` + lambda + args) so
+        // ``info level 0`` in the body returns the real call, e.g.
+        // ``apply {{} {info level 0}}`` (apply-6.2 / 6.3) rather than
+        // the legacy placeholder.  ``frame_set_argv`` retains for the
+        // slot; drop our creator-side ref (see eval_proc_call_bucket).
+        const argv = build_invocation_list(words);
+        frames.frame_set_argv(argv);
+        obj_mod.tcl_obj_release(argv);
+    }
 
     // Bind parameters — same pattern as eval_proc_call_bucket but user
     // args start at words[2] (words[0]=apply, words[1]=lambda).
@@ -5527,6 +5630,7 @@ pub fn eval_apply(words: []const i32) i32 {
                 const stubs = @import("../stubs/tcl_stubs.zig");
                 frames.frame_pop();
                 stubs.raise("argument with no name");
+                append_lambda_parse_frame(words[1]);
                 return 0;
             }
             if (field_count > 2) {
@@ -5548,11 +5652,20 @@ pub fn eval_apply(words: []const i32) i32 {
                 const stubs = @import("../stubs/tcl_stubs.zig");
                 frames.frame_pop();
                 stubs.raise(mbuf[0..mo]);
+                append_lambda_parse_frame(words[1]);
                 return 0;
             }
             const name_elem = list_element_at(spec_ptr, spec_len, 0);
             const param_name_ptr = spec_ptr + name_elem.start;
             const param_name_len = name_elem.len;
+            // Reject array-element (``a(1)``) and qualified (``a::b``)
+            // formal-parameter names, matching C Tcl's TclCreateProc
+            // (apply-2.4 / 2.5).
+            if (raise_if_bad_formal_param(param_name_ptr, param_name_len)) {
+                frames.frame_pop();
+                append_lambda_parse_frame(words[1]);
+                return 0;
+            }
             const param_name = obj_new_string_copy(param_name_ptr, param_name_len);
             defer obj_mod.tcl_obj_release(param_name);
             const has_default = field_count == 2;

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -4743,6 +4743,39 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
         }
     }
 
+    // Too-many-arguments check.  A proc whose last parameter is not the
+    // variadic ``args`` collector rejects extra arguments with
+    // ``wrong # args`` (proc-old-30.3) — the binding loop above only
+    // handles the too-FEW case.  Mirrors ProcWrongNumArgs in tclProc.c,
+    // which fires when objc-1 exceeds the declared parameter count.
+    if (words.len > n_params + 1) {
+        var last_is_args = false;
+        if (n_params > 0 and params_obj != 0) {
+            const ps2 = obj_ensure_string(params_obj);
+            const le = list_element_at(ps2.ptr, ps2.len, @intCast(n_params - 1));
+            const lptr = ps2.ptr + le.start;
+            const llen = le.len;
+            // Strip a ``{name default}`` wrapper to the bare name, the
+            // same way the binding loop detects the ``args`` collector.
+            var nptr = lptr;
+            var nlen = llen;
+            if (list_count_elements(lptr, llen) == 2) {
+                const ne = list_element_at(lptr, llen, 0);
+                nptr = lptr + ne.start;
+                nlen = ne.len;
+            }
+            if (nlen == 4) {
+                const np: [*]const u8 = @ptrFromInt(nptr);
+                last_is_args = np[0] == 'a' and np[1] == 'r' and np[2] == 'g' and np[3] == 's';
+            }
+        }
+        if (!last_is_args) {
+            raise_proc_wrong_args(words[0], params_obj, n_params);
+            frames.frame_pop();
+            return 0;
+        }
+    }
+
     // Evaluate body
     const body_s = obj_ensure_string(body_obj);
     const result = eval_script(body_s.ptr, body_s.len);

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -4272,11 +4272,15 @@ fn build_invocation_list(words: []const i32) i32 {
 /// parameter as ``?arg ...?``, and a required parameter as its bare
 /// name.  ``invoked_name`` is the word the caller used (``words[0]``)
 /// so the message echoes the spelling at the call site.
-fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params: u32) void {
+fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params_in: u32) void {
     const catch_mod = @import("tcl_catch.zig");
     const quote = @import("../valtypes/tcl_list_quote.zig");
     const inv = obj_ensure_string(invoked_name);
     const ps = obj_ensure_string(params_obj);
+    // Null/empty params (e.g. a compiled proc whose param-source stash
+    // is unavailable) → emit just ``wrong # args: should be "name"``
+    // rather than dereferencing a null list pointer.
+    const n_params: u32 = if (params_obj == 0 or ps.ptr == 0) 0 else n_params_in;
     const prefix = "wrong # args: should be \"";
     var pcap: u32 = 0;
     var i: u32 = 0;
@@ -4342,6 +4346,31 @@ fn raise_proc_wrong_args(invoked_name: i32, params_obj: i32, n_params: u32) void
     off += 1;
     const msg = obj_mod.obj_new_string_take(buf, off, total);
     catch_mod.tcl_cmd_error(msg);
+}
+
+/// True when the proc's last formal is the variadic ``args`` collector
+/// — a last element whose name (after stripping any ``{name default}``
+/// wrapper) is exactly ``args``.  Such a proc accepts any number of
+/// trailing arguments; every other proc rejects surplus args with
+/// ``wrong # args``.  Note ``{args 9}`` (args with a default) IS still
+/// the collector in Tcl 9 (the default is ignored) — verified against
+/// tclsh9.0 — so the wrapper is stripped before the name comparison.
+fn proc_last_param_is_args(params_obj: i32, n_params: u32) bool {
+    if (n_params == 0 or params_obj == 0) return false;
+    const ps = obj_ensure_string(params_obj);
+    const le = list_element_at(ps.ptr, ps.len, @intCast(n_params - 1));
+    const lptr = ps.ptr + le.start;
+    const llen = le.len;
+    var nptr = lptr;
+    var nlen = llen;
+    if (list_count_elements(lptr, llen) == 2) {
+        const ne = list_element_at(lptr, llen, 0);
+        nptr = lptr + ne.start;
+        nlen = ne.len;
+    }
+    if (nlen != 4) return false;
+    const np: [*]const u8 = @ptrFromInt(nptr);
+    return np[0] == 'a' and np[1] == 'r' and np[2] == 'g' and np[3] == 's';
 }
 
 /// Internal: dispatch once the proc bucket is already resolved.
@@ -4415,6 +4444,40 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
     if ((cmd_flags & procs.CMD_ENSEMBLE) != 0) {
         const ns_mod = @import("../cmds/namespace.zig");
         return ns_mod.dispatch_ensemble(bucket, words);
+    }
+    // Too-many-arguments check — BEFORE the compiled-proc dispatch
+    // below so it applies to compiled procs as well (their bridge call
+    // truncates surplus args and never reaches the interpreted binding
+    // loop's check).  A proc whose last formal is the variadic ``args``
+    // collector accepts any tail; otherwise more than ``n_params`` call
+    // args is ``wrong # args`` (proc-old-30.3; Codex review on PR #532
+    // — the static-codegen call sites route the over-arity case here
+    // via the eval fallback).  The too-FEW case is handled per-param in
+    // the interpreted binding loop / compiled prologue.
+    {
+        const aw_n: u32 = @intCast(procs.proc_get_n_params(bucket));
+        if (words.len > aw_n + 1) {
+            // Interpreted procs keep the param list in OFF_PARAMS_OBJ;
+            // compiled procs leave that 0 and stash the source bytes in
+            // OFF_PARAMS_SRC (the slot ``info args`` reads).  Materialise
+            // a TclObj from whichever is present so the variadic probe and
+            // the ``should be "..."`` message both see the real formals.
+            var aw_params = procs.proc_get_params(bucket);
+            var aw_owned = false;
+            if (aw_params == 0) {
+                const src = procs.proc_get_params_src(@bitCast(bucket));
+                if (src.ptr != 0 and src.len > 0) {
+                    aw_params = obj_new_string_copy(src.ptr, src.len);
+                    aw_owned = true;
+                }
+            }
+            if (!proc_last_param_is_args(aw_params, aw_n)) {
+                raise_proc_wrong_args(words[0], aw_params, aw_n);
+                if (aw_owned) obj_mod.tcl_obj_release(aw_params);
+                return 0;
+            }
+            if (aw_owned) obj_mod.tcl_obj_release(aw_params);
+        }
     }
     // Compiled proc (func_idx != 0 is a marker set by
     // ``proc_register_compiled``) — dispatch via the host bridge
@@ -4743,38 +4806,9 @@ fn eval_proc_call_bucket(words: []const i32, bucket: i32) i32 {
         }
     }
 
-    // Too-many-arguments check.  A proc whose last parameter is not the
-    // variadic ``args`` collector rejects extra arguments with
-    // ``wrong # args`` (proc-old-30.3) — the binding loop above only
-    // handles the too-FEW case.  Mirrors ProcWrongNumArgs in tclProc.c,
-    // which fires when objc-1 exceeds the declared parameter count.
-    if (words.len > n_params + 1) {
-        var last_is_args = false;
-        if (n_params > 0 and params_obj != 0) {
-            const ps2 = obj_ensure_string(params_obj);
-            const le = list_element_at(ps2.ptr, ps2.len, @intCast(n_params - 1));
-            const lptr = ps2.ptr + le.start;
-            const llen = le.len;
-            // Strip a ``{name default}`` wrapper to the bare name, the
-            // same way the binding loop detects the ``args`` collector.
-            var nptr = lptr;
-            var nlen = llen;
-            if (list_count_elements(lptr, llen) == 2) {
-                const ne = list_element_at(lptr, llen, 0);
-                nptr = lptr + ne.start;
-                nlen = ne.len;
-            }
-            if (nlen == 4) {
-                const np: [*]const u8 = @ptrFromInt(nptr);
-                last_is_args = np[0] == 'a' and np[1] == 'r' and np[2] == 'g' and np[3] == 's';
-            }
-        }
-        if (!last_is_args) {
-            raise_proc_wrong_args(words[0], params_obj, n_params);
-            frames.frame_pop();
-            return 0;
-        }
-    }
+    // (Too-many-arguments is rejected up front — before the
+    // compiled-proc dispatch — so it covers compiled procs too; see
+    // ``proc_last_param_is_args`` above.)
 
     // Evaluate body
     const body_s = obj_ensure_string(body_obj);

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1905,11 +1905,15 @@ pub export fn tcl_incr(o: i32, amount: i32) i32 {
     // "first error wins" semantics for a single command.
     if (@import("tcl_result.zig").snapshot(0).code == .ERROR) return obj_new_int_pub(0);
     if (!incr_is_strict_int(o)) {
-        raise_expected_integer(o);
+        // The variable's current value is the non-integer — no
+        // ``(reading increment)`` frame (incr-old-2.4).
+        raise_expected_integer(o, false);
         return obj_new_int_pub(0);
     }
     if (!incr_is_strict_int(amount)) {
-        raise_expected_integer(amount);
+        // The explicit increment argument is the non-integer — add the
+        // ``(reading increment)`` frame (incr-old-2.5, incr-2.30..2.33).
+        raise_expected_integer(amount, true);
         return obj_new_int_pub(0);
     }
     // Bignum-aware addition: promote to ``*BigInt`` whenever either
@@ -1979,7 +1983,7 @@ fn incr_is_strict_int(o: i32) bool {
     return true;
 }
 
-fn raise_expected_integer(o: i32) void {
+fn raise_expected_integer(o: i32, reading_increment: bool) void {
     // Preserve the first error in a chain — see ``tcl_incr`` for
     // the rationale.  Without this, a missing-variable read on the
     // increment expression that already set ``error_flag`` would be
@@ -2042,16 +2046,21 @@ fn raise_expected_integer(o: i32) void {
     const msg = obj.obj_new_string_take(buf_addr, @intCast(off), total);
     const tcl_catch = @import("tcl_catch.zig");
     tcl_catch.tcl_cmd_error(msg);
-    // Tcl 9 adds a ``(reading increment)`` frame between the
-    // error message and the surrounding command frame in
-    // ``::errorInfo`` (incr-2.30 / 2.31 / 2.32 / 2.33).  Reference
-    // Tcl emits this via ``Tcl_AddObjErrorInfo`` from
-    // ``TclCompileIncrCmd`` after ``Tcl_GetIntFromObj`` rejects
-    // the increment operand.  Append it to ``::errorInfo`` after
-    // the canonical stamp and prime the log-command state so the
-    // next ``log_command_info`` uses ``invoked from within``
-    // rather than ``while executing``.
-    append_errinfo_frame("\n    (reading increment)");
+    // Tcl 9 adds a ``(reading increment)`` frame between the error
+    // message and the surrounding command frame in ``::errorInfo``
+    // ONLY when the explicit increment operand fails to parse
+    // (``incr x 1a`` — incr-2.30/2.31/2.32/2.33, incr-old-2.5).
+    // Reference Tcl emits this via ``Tcl_AddObjErrorInfo`` from
+    // ``TclCompileIncrCmd`` / ``Tcl_IncrObjCmd`` after
+    // ``Tcl_GetIntFromObj`` rejects the increment argument.  When the
+    // *variable's own value* is the non-integer (``incr x`` with x set
+    // to "abc" — incr-old-2.4) there is no increment being read, so the
+    // frame must be omitted and the enclosing log stays ``while
+    // executing``.  Priming ``last_log_script`` (via
+    // ``append_errinfo_frame``) is likewise gated on this.
+    if (reading_increment) {
+        append_errinfo_frame("\n    (reading increment)");
+    }
 }
 
 /// Append a literal string to the current ``::errorInfo`` global

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -940,6 +940,13 @@ pub export fn array_set_list(arr: i32, pairs: i32) i32 {
         // 8.38.3).  Pass key_ptr = 0 / key_len = 0 so the helper
         // selects the empty-list message.
         if (!array_check_or_create(arr, 0, 0)) return obj_new_string(0, 0);
+        // ``array_check_or_create`` only validated the scalar conflict;
+        // it does NOT create the table (the non-empty path relies on the
+        // first ``array_set`` for that).  Materialise an empty table so
+        // ``array set X {}`` makes ``info exists X`` / ``array exists X``
+        // true and a later scalar read of X reports ``variable is
+        // array`` rather than ``no such variable`` (set-old-8.38/8.38.2).
+        _ = find_or_create(arr);
         return obj_new_string(0, 0);
     }
     // Up-front scalar-conflict probe: ``array set arr ...`` on a

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -1526,10 +1526,13 @@ pub export fn array_unset_element(arr: i32, key: i32) i32 {
         ar_set_count(t, ar_count(t) - 1);
         if (old != 0) obj.tcl_obj_release(old);
         if (kp != 0 and kl > 0) obj.free_sized(kp, kl);
+        // Phase 6: fire UNSET trace AFTER the unset so the callback sees
+        // the variable in its final (gone) state.  Only fire when an
+        // element was actually removed — ``unset -nocomplain arr(k)``
+        // against a missing key (or ``array unset`` of an absent
+        // element) must NOT trigger the trace (trace-4.7).
+        fire_var_trace_unset(arr, sk.ptr, sk.len);
     }
-    // Phase 6: fire UNSET trace AFTER the unset so the callback sees
-    // the variable in its final (gone) state.
-    fire_var_trace_unset(arr, sk.ptr, sk.len);
     return obj_new_int(0);
 }
 

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -760,6 +760,59 @@ fn regexp_about(pattern: i32, flags: c_int) i32 {
     return obj.obj_new_string_copy(@intFromPtr(&out_buf), off);
 }
 
+/// Canonical ``regexp`` option names, indexed by :func:`match_regexp_opt`.
+const REGEXP_OPT_NAMES = [_][]const u8{
+    "-nocase", // 0
+    "-line", // 1
+    "-linestop", // 2
+    "-lineanchor", // 3
+    "-expanded", // 4
+    "-indices", // 5
+    "-all", // 6
+    "-inline", // 7
+    "-about", // 8
+    "-start", // 9
+};
+
+/// Resolve a ``regexp`` option word to a :data:`REGEXP_OPT_NAMES` index,
+/// or ``-1`` if unrecognised.  Mirrors C Tcl exactly: ``-nocase`` is the
+/// only option matched by prefix (any abbreviation ``-n`` .. ``-nocase``,
+/// per ``TclCompileRegexpCmd``'s ``strncmp(str,"-nocase",len)`` special
+/// case — regexpComp-21.6/.7, 24.6/.7); every *other* option requires an
+/// exact match, matching the interpreted ``Tcl_RegexpObjCmd``'s
+/// ``TCL_EXACT`` lookup (so ``-al`` / ``-li`` / ``-l`` are plain "bad
+/// option", not abbreviations).
+fn match_regexp_opt(span: anytype) i32 {
+    const sp: [*]const u8 = @ptrFromInt(span.ptr);
+    // Prefix match for -nocase (length >= 2 so a bare "-" never matches).
+    const nocase = "-nocase";
+    if (span.len >= 2 and span.len <= nocase.len) {
+        var is_prefix = true;
+        var k: u32 = 0;
+        while (k < span.len) : (k += 1) {
+            if (sp[k] != nocase[k]) {
+                is_prefix = false;
+                break;
+            }
+        }
+        if (is_prefix) return 0; // -nocase (index 0)
+    }
+    // Exact match for every other option (indices 1..N-1).
+    for (REGEXP_OPT_NAMES[1..], 1..) |name, idx| {
+        if (span.len != name.len) continue;
+        var eq = true;
+        var k: u32 = 0;
+        while (k < span.len) : (k += 1) {
+            if (sp[k] != name[k]) {
+                eq = false;
+                break;
+            }
+        }
+        if (eq) return @intCast(idx);
+    }
+    return -1;
+}
+
 pub fn eval_regexp_cmd(words: []const i32) i32 {
     if (words.len < 3) {
         // ``regexp`` (no args) and ``regexp foo`` are too short for
@@ -788,88 +841,94 @@ pub fn eval_regexp_cmd(words: []const i32) i32 {
             i += 1;
             break;
         }
-        if (str_eq(w, "-nocase")) {
-            flags |= REG_ICASE;
-            continue;
-        }
-        if (str_eq(w, "-line")) {
-            flags |= REG_NLSTOP | REG_NLANCH;
-            continue;
-        }
-        if (str_eq(w, "-linestop")) {
-            flags |= REG_NLSTOP;
-            continue;
-        }
-        if (str_eq(w, "-lineanchor")) {
-            flags |= REG_NLANCH;
-            continue;
-        }
-        if (str_eq(w, "-expanded")) {
-            // Expanded syntax: ignore unescaped whitespace and ``#``
-            // comments in the pattern.  Mirrors ``eval_regsub_cmd``,
-            // which already ORs in ``REG_EXPANDED``; without it
-            // ``regexp -expanded {a b} ab`` failed to match (the space
-            // stayed literal) and ``regexp -about -expanded {a b}``
-            // reported no flags instead of ``REG_UNONPOSIX``.
-            flags |= REG_EXPANDED;
-            continue;
-        }
-        if (str_eq(w, "-indices")) {
-            indices_mode = true;
-            continue;
-        }
-        if (str_eq(w, "-all")) {
-            all_mode = true;
-            continue;
-        }
-        if (str_eq(w, "-inline")) {
-            inline_mode = true;
-            continue;
-        }
-        if (str_eq(w, "-about")) {
-            // ``-about`` takes no value and consumes only the pattern
-            // operand (no subject string); handled after option parsing.
-            about_mode = true;
-            continue;
-        }
-        if (str_eq(w, "-start")) {
-            i += 1;
-            if (i < words.len) {
-                const idx_s = obj_ensure_string(words[i]);
-                if (idx_s.len > 0) {
-                    const ip: [*]const u8 = @ptrFromInt(idx_s.ptr);
-                    var is_int = true;
-                    var k: u32 = 0;
-                    if (ip[0] == '-' or ip[0] == '+') k = 1;
-                    if (k >= idx_s.len) is_int = false;
-                    while (k < idx_s.len) : (k += 1) {
-                        if (ip[k] < '0' or ip[k] > '9') {
-                            is_int = false;
-                            break;
+        // Resolve the option by unique-prefix match (Tcl accepts
+        // ``-n`` / ``-no`` for ``-nocase`` etc. — regexpComp-21.6/.7,
+        // 24.6/.7).  An exact match wins over a longer prefix.
+        const opt = match_regexp_opt(w);
+        switch (opt) {
+            0 => { // -nocase
+                flags |= REG_ICASE;
+                continue;
+            },
+            1 => { // -line
+                flags |= REG_NLSTOP | REG_NLANCH;
+                continue;
+            },
+            2 => { // -linestop
+                flags |= REG_NLSTOP;
+                continue;
+            },
+            3 => { // -lineanchor
+                flags |= REG_NLANCH;
+                continue;
+            },
+            4 => { // -expanded
+                // Expanded syntax: ignore unescaped whitespace and ``#``
+                // comments in the pattern.  Mirrors ``eval_regsub_cmd``,
+                // which already ORs in ``REG_EXPANDED``; without it
+                // ``regexp -expanded {a b} ab`` failed to match (the space
+                // stayed literal) and ``regexp -about -expanded {a b}``
+                // reported no flags instead of ``REG_UNONPOSIX``.
+                flags |= REG_EXPANDED;
+                continue;
+            },
+            5 => { // -indices
+                indices_mode = true;
+                continue;
+            },
+            6 => { // -all
+                all_mode = true;
+                continue;
+            },
+            7 => { // -inline
+                inline_mode = true;
+                continue;
+            },
+            8 => { // -about — takes no value and consumes only the
+                // pattern operand (no subject string); handled after
+                // option parsing.
+                about_mode = true;
+                continue;
+            },
+            9 => { // -start <index>
+                i += 1;
+                if (i < words.len) {
+                    const idx_s = obj_ensure_string(words[i]);
+                    if (idx_s.len > 0) {
+                        const ip: [*]const u8 = @ptrFromInt(idx_s.ptr);
+                        var is_int = true;
+                        var k: u32 = 0;
+                        if (ip[0] == '-' or ip[0] == '+') k = 1;
+                        if (k >= idx_s.len) is_int = false;
+                        while (k < idx_s.len) : (k += 1) {
+                            if (ip[k] < '0' or ip[k] > '9') {
+                                is_int = false;
+                                break;
+                            }
+                        }
+                        if (!is_int) {
+                            if (!(idx_s.len >= 3 and ip[0] == 'e' and ip[1] == 'n' and ip[2] == 'd')) {
+                                raise_bad_index(@ptrFromInt(idx_s.ptr), idx_s.len);
+                                return obj_new_int(0);
+                            }
                         }
                     }
-                    if (!is_int) {
-                        if (!(idx_s.len >= 3 and ip[0] == 'e' and ip[1] == 'n' and ip[2] == 'd')) {
-                            raise_bad_index(@ptrFromInt(idx_s.ptr), idx_s.len);
-                            return obj_new_int(0);
-                        }
-                    }
+                    start_offset_cp = @intCast(obj.obj_get_int(words[i]));
                 }
-                start_offset_cp = @intCast(obj.obj_get_int(words[i]));
-            }
-            continue;
+                continue;
+            },
+            else => {
+                // Unknown option (index -1) — emit Tcl 9's reference
+                // message so regexp.test 6.3 catches the exact wording.
+                raise_bad_option(
+                    "regexp",
+                    @ptrFromInt(w.ptr),
+                    w.len,
+                    "-all, -about, -indices, -inline, -expanded, -line, -linestop, -lineanchor, -nocase, -start, or --",
+                );
+                return obj_new_int(0);
+            },
         }
-        // Unknown option — emit Tcl 9's reference message
-        // ``bad option "<opt>": must be -all, -about, -indices,
-        // -inline, -expanded, -line, -linestop, -lineanchor, -nocase,
-        // -start, or --`` so regexp.test 6.3 catches the exact wording.
-        raise_bad_option(
-            "regexp",
-            @ptrFromInt(w.ptr),
-            w.len,
-            "-all, -about, -indices, -inline, -expanded, -line, -linestop, -lineanchor, -nocase, -start, or --",
-        );
-        return obj_new_int(0);
     }
     if (about_mode) {
         // ``regexp -about exp`` — compile ``exp`` and report

--- a/runtime/zig/valtypes/tcl_regex.zig
+++ b/runtime/zig/valtypes/tcl_regex.zig
@@ -841,9 +841,12 @@ pub fn eval_regexp_cmd(words: []const i32) i32 {
             i += 1;
             break;
         }
-        // Resolve the option by unique-prefix match (Tcl accepts
-        // ``-n`` / ``-no`` for ``-nocase`` etc. — regexpComp-21.6/.7,
-        // 24.6/.7).  An exact match wins over a longer prefix.
+        // Resolve the option.  Only ``-nocase`` is matched by prefix
+        // (so ``-n`` / ``-no`` / ``-noc`` resolve to it — regexpComp-
+        // 21.6/.7, 24.6/.7); every other option requires an exact match,
+        // mirroring C Tcl (TclCompileRegexpCmd's ``strncmp(…,"-nocase",
+        // len)`` special case plus the interpreted ``Tcl_RegexpObjCmd``'s
+        // ``TCL_EXACT`` lookup).  See ``match_regexp_opt``.
         const opt = match_regexp_opt(w);
         switch (opt) {
             0 => { // -nocase

--- a/tests/baselines/tcl9-tcltest-wasm/categories/apply.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/apply.toml
@@ -1,6 +1,6 @@
 # apply.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '7 of 42 failed'
+# reason = '1 of 42 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 42
-observed_passed = 35
-observed_failed = 7
+observed_passed = 41
+observed_failed = 1
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["apply-2.2", "apply-2.3", "apply-2.4", "apply-2.5", "apply-5.1", "apply-6.2", "apply-6.3"]
+ids = ["apply-5.1"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/error.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/error.toml
@@ -1,6 +1,6 @@
 # error.test — auto-generated WASM baseline.
-# bucket = 'W-mixed-fail'
-# reason = '3 of 317 failed'
+# bucket = 'clean'
+# reason = 'all tests pass or skip'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,6 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 317
-observed_passed = 306
-observed_failed = 3
+observed_passed = 309
+observed_failed = 0
 observed_skipped = 8
-
-[failing]
-# Test IDs failing today — kept here for visibility, not gating.
-ids = ["error-18.8", "error-18.9", "error-18.10"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/incr-old.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/incr-old.toml
@@ -1,6 +1,6 @@
 # incr-old.test — auto-generated WASM baseline.
-# bucket = 'W-mixed-fail'
-# reason = '1 of 14 failed'
+# bucket = 'clean'
+# reason = 'all tests pass or skip'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,6 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 14
-observed_passed = 13
-observed_failed = 1
+observed_passed = 14
+observed_failed = 0
 observed_skipped = 0
-
-[failing]
-# Test IDs failing today — kept here for visibility, not gating.
-ids = ["incr-old-2.4"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/proc-old.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/proc-old.toml
@@ -1,6 +1,6 @@
 # proc-old.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '11 of 74 failed'
+# reason = '9 of 74 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 74
-observed_passed = 63
-observed_failed = 11
+observed_passed = 65
+observed_failed = 9
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["proc-old-3.3", "proc-old-3.5", "proc-old-5.10", "proc-old-5.13", "proc-old-5.14", "proc-old-5.15", "proc-old-5.16", "proc-old-7.11", "proc-old-7.12", "proc-old-7.13", "proc-old-7.14"]
+ids = ["proc-old-5.10", "proc-old-5.13", "proc-old-5.14", "proc-old-5.15", "proc-old-5.16", "proc-old-7.11", "proc-old-7.12", "proc-old-7.13", "proc-old-7.14"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/proc-old.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/proc-old.toml
@@ -1,6 +1,6 @@
 # proc-old.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '12 of 74 failed'
+# reason = '11 of 74 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 74
-observed_passed = 62
-observed_failed = 12
+observed_passed = 63
+observed_failed = 11
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["proc-old-3.3", "proc-old-3.5", "proc-old-30.3", "proc-old-5.10", "proc-old-5.13", "proc-old-5.14", "proc-old-5.15", "proc-old-5.16", "proc-old-7.11", "proc-old-7.12", "proc-old-7.13", "proc-old-7.14"]
+ids = ["proc-old-3.3", "proc-old-3.5", "proc-old-5.10", "proc-old-5.13", "proc-old-5.14", "proc-old-5.15", "proc-old-5.16", "proc-old-7.11", "proc-old-7.12", "proc-old-7.13", "proc-old-7.14"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/regexpComp.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/regexpComp.toml
@@ -1,6 +1,6 @@
 # regexpComp.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '6 of 179 failed'
+# reason = '2 of 179 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 179
-observed_passed = 173
-observed_failed = 6
+observed_passed = 177
+observed_failed = 2
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["regexpComp-6.8", "regexpComp-11.7", "regexpComp-21.6", "regexpComp-21.7", "regexpComp-24.6", "regexpComp-24.7"]
+ids = ["regexpComp-6.8", "regexpComp-11.7"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/regexpComp.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/regexpComp.toml
@@ -1,6 +1,6 @@
 # regexpComp.test — auto-generated WASM baseline.
-# bucket = 'W-mixed-fail'
-# reason = '2 of 179 failed'
+# bucket = 'clean'
+# reason = 'all tests pass or skip'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,6 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 179
-observed_passed = 177
-observed_failed = 2
+observed_passed = 179
+observed_failed = 0
 observed_skipped = 0
-
-[failing]
-# Test IDs failing today — kept here for visibility, not gating.
-ids = ["regexpComp-6.8", "regexpComp-11.7"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/set-old.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/set-old.toml
@@ -1,6 +1,6 @@
 # set-old.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '12 of 153 failed'
+# reason = '9 of 153 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 153
-observed_passed = 141
-observed_failed = 12
+observed_passed = 144
+observed_failed = 9
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["set-old-2.8", "set-old-6.2", "set-old-7.10", "set-old-7.16", "set-old-8.38", "set-old-8.38.2", "set-old-8.38.3", "set-old-8.43", "set-old-8.49", "set-old-8.52", "set-old-8.52.1", "set-old-9.8"]
+ids = ["set-old-2.8", "set-old-6.2", "set-old-7.16", "set-old-8.38", "set-old-8.38.2", "set-old-8.38.3", "set-old-8.49", "set-old-8.52", "set-old-8.52.1"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/set-old.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/set-old.toml
@@ -1,6 +1,6 @@
 # set-old.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '9 of 153 failed'
+# reason = '7 of 153 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 153
-observed_passed = 144
-observed_failed = 9
+observed_passed = 146
+observed_failed = 7
 observed_skipped = 0
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["set-old-2.8", "set-old-6.2", "set-old-7.16", "set-old-8.38", "set-old-8.38.2", "set-old-8.38.3", "set-old-8.49", "set-old-8.52", "set-old-8.52.1"]
+ids = ["set-old-2.8", "set-old-7.16", "set-old-8.38.2", "set-old-8.38.3", "set-old-8.49", "set-old-8.52", "set-old-8.52.1"]

--- a/tests/baselines/tcl9-tcltest-wasm/categories/trace.toml
+++ b/tests/baselines/tcl9-tcltest-wasm/categories/trace.toml
@@ -1,6 +1,6 @@
 # trace.test — auto-generated WASM baseline.
 # bucket = 'W-mixed-fail'
-# reason = '72 of 290 failed'
+# reason = '65 of 290 failed'
 trap_allowed = false
 good_to_have = []
 just_to_match_ctcl = []
@@ -11,10 +11,10 @@ good_to_have_failing = 0
 just_to_match_ctcl_failing = 0
 skip_failing = 0
 observed_total = 290
-observed_passed = 204
-observed_failed = 72
+observed_passed = 211
+observed_failed = 65
 observed_skipped = 14
 
 [failing]
 # Test IDs failing today — kept here for visibility, not gating.
-ids = ["trace-0.0", "trace-1.8", "trace-1.11", "trace-1.12", "trace-1.13", "trace-1.14", "trace-2.6", "trace-3.1", "trace-3.2", "trace-4.4", "trace-4.5", "trace-4.6", "trace-4.8", "trace-5.6", "trace-6.2", "trace-6.3", "trace-8.1", "trace-8.2", "trace-8.3", "trace-8.4", "trace-8.5", "trace-8.6", "trace-9.3", "trace-9.4", "trace-10.1", "trace-10.2", "trace-10.3", "trace-10.4", "trace-11.4", "trace-11.5", "trace-12.3", "trace-12.8", "trace-14.18", "trace-14.19", "trace-16.2", "trace-16.3", "trace-16.5", "trace-16.6", "trace-16.7", "trace-16.8", "trace-16.9", "trace-16.10", "trace-16.11", "trace-16.12", "trace-16.13", "trace-16.14", "trace-16.16", "trace-16.17", "trace-16.19", "trace-16.20", "trace-16.21", "trace-16.22", "trace-17.1", "trace-18.1", "trace-18.2", "trace-18.4", "trace-20.12", "trace-23.1", "trace-23.2", "trace-23.3", "trace-25.8", "trace-25.9", "trace-25.10", "trace-25.11", "trace-26.1", "trace-26.2", "trace-28.2", "trace-28.3", "trace-28.4", "trace-28.6", "trace-34.1", "trace-34.5"]
+ids = ["trace-0.0", "trace-1.8", "trace-1.11", "trace-1.12", "trace-1.13", "trace-1.14", "trace-2.6", "trace-3.1", "trace-3.2", "trace-4.4", "trace-4.6", "trace-5.6", "trace-6.3", "trace-8.1", "trace-8.2", "trace-8.3", "trace-8.4", "trace-8.5", "trace-8.6", "trace-9.3", "trace-9.4", "trace-10.3", "trace-10.4", "trace-11.4", "trace-11.5", "trace-12.3", "trace-12.8", "trace-14.18", "trace-14.19", "trace-16.2", "trace-16.3", "trace-16.5", "trace-16.6", "trace-16.7", "trace-16.8", "trace-16.9", "trace-16.10", "trace-16.11", "trace-16.12", "trace-16.13", "trace-16.14", "trace-16.16", "trace-16.17", "trace-16.21", "trace-16.22", "trace-17.1", "trace-18.1", "trace-18.2", "trace-18.4", "trace-20.12", "trace-23.1", "trace-23.2", "trace-23.3", "trace-25.8", "trace-25.9", "trace-25.10", "trace-25.11", "trace-26.1", "trace-26.2", "trace-28.2", "trace-28.3", "trace-28.4", "trace-28.6", "trace-34.1", "trace-34.5"]

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T13:29:27Z",
+  "generated_at": "2026-06-03T13:49:58Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -210,11 +210,11 @@
       "total": 69
     },
     "incr-old": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 1,
-      "passed_min": 13,
+      "failed_max": 0,
+      "passed_min": 14,
       "skipped": 0,
       "total": 14
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T16:12:49Z",
+  "generated_at": "2026-06-03T18:34:11Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -444,11 +444,11 @@
       "total": 257
     },
     "regexpComp": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 2,
-      "passed_min": 177,
+      "failed_max": 0,
+      "passed_min": 179,
       "skipped": 0,
       "total": 179
     },
@@ -492,8 +492,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 9,
-      "passed_min": 144,
+      "failed_max": 7,
+      "passed_min": 146,
       "skipped": 0,
       "total": 153
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T12:38:25Z",
+  "generated_at": "2026-06-03T13:29:27Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -15,8 +15,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 7,
-      "passed_min": 35,
+      "failed_max": 1,
+      "passed_min": 41,
       "skipped": 0,
       "total": 42
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T09:46:54Z",
+  "generated_at": "2026-06-03T12:38:25Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -102,11 +102,11 @@
       "total": 9
     },
     "error": {
-      "bucket": "W-mixed-fail",
+      "bucket": "clean",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 3,
-      "passed_min": 306,
+      "failed_max": 0,
+      "passed_min": 309,
       "skipped": 8,
       "total": 317
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T15:02:21Z",
+  "generated_at": "2026-06-03T15:41:57Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -429,8 +429,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 12,
-      "passed_min": 62,
+      "failed_max": 11,
+      "passed_min": 63,
       "skipped": 0,
       "total": 74
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T13:49:58Z",
+  "generated_at": "2026-06-03T15:02:21Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -447,8 +447,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 6,
-      "passed_min": 173,
+      "failed_max": 2,
+      "passed_min": 177,
       "skipped": 0,
       "total": 179
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-03T15:41:57Z",
+  "generated_at": "2026-06-03T16:12:49Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -429,8 +429,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 11,
-      "passed_min": 63,
+      "failed_max": 9,
+      "passed_min": 65,
       "skipped": 0,
       "total": 74
     },
@@ -492,8 +492,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 12,
-      "passed_min": 141,
+      "failed_max": 9,
+      "passed_min": 144,
       "skipped": 0,
       "total": 153
     },
@@ -537,8 +537,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 72,
-      "passed_min": 204,
+      "failed_max": 65,
+      "passed_min": 211,
       "skipped": 14,
       "total": 290
     },

--- a/tests/test_wasm_apply_lambda.py
+++ b/tests/test_wasm_apply_lambda.py
@@ -49,3 +49,78 @@ def test_apply_malformed_no_name() -> None:
 def test_apply_malformed_too_many_fields() -> None:
     body = "set L [list {{a b c}} boo]\nputs [catch {apply $L} msg]:$msg\n"
     assert _run(body) == '1:too many fields in argument specifier "a b c"'
+
+
+# ---------------------------------------------------------------------------
+# (parsing lambda expression ...) errorInfo frame + formal validation +
+# info level 0.  The slice runs test bodies INTERPRETED (eval_script), so
+# these force that path via ``set s {…}; eval $s`` to match it.  Mirrors
+# C Tcl's SetLambdaFromAny / TclCreateProc (apply-2.2..2.5, 6.2, 6.3).
+# ---------------------------------------------------------------------------
+
+
+def _run_interp(source: str) -> str:
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(wrapped), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def test_apply_2_2_errorinfo_frame() -> None:
+    src = "set lambda [list {{}} boo]\nputs [list [catch {apply $lambda} msg] $msg $::errorInfo]\n"
+    expected = (
+        "1 {argument with no name} {argument with no name\n"
+        '    (parsing lambda expression "{{}} boo")\n'
+        '    invoked from within\n"apply $lambda"}'
+    )
+    assert _run_interp(src) == expected
+
+
+def test_apply_2_3_errorinfo_frame() -> None:
+    src = (
+        "set lambda [list {{a b c}} boo]\n"
+        "puts [list [catch {apply $lambda} msg] $msg $::errorInfo]\n"
+    )
+    expected = (
+        '1 {too many fields in argument specifier "a b c"} '
+        '{too many fields in argument specifier "a b c"\n'
+        '    (parsing lambda expression "{{a b c}} boo")\n'
+        '    invoked from within\n"apply $lambda"}'
+    )
+    assert _run_interp(src) == expected
+
+
+def test_apply_2_4_array_element_formal() -> None:
+    src = "set lambda [list a(1) boo]\nputs [list [catch {apply $lambda} msg] $msg $::errorInfo]\n"
+    expected = (
+        '1 {formal parameter "a(1)" is an array element} '
+        '{formal parameter "a(1)" is an array element\n'
+        '    (parsing lambda expression "a(1) boo")\n'
+        '    invoked from within\n"apply $lambda"}'
+    )
+    assert _run_interp(src) == expected
+
+
+def test_apply_2_5_qualified_formal() -> None:
+    src = "set lambda [list a::b boo]\nputs [list [catch {apply $lambda} msg] $msg $::errorInfo]\n"
+    expected = (
+        '1 {formal parameter "a::b" is not a simple name} '
+        '{formal parameter "a::b" is not a simple name\n'
+        '    (parsing lambda expression "a::b boo")\n'
+        '    invoked from within\n"apply $lambda"}'
+    )
+    assert _run_interp(src) == expected
+
+
+def test_apply_open_paren_not_array_element() -> None:
+    # A scalar formal containing ``(`` but no trailing ``)`` is valid.
+    assert _run_interp("puts [apply {{a(b} {return ok}} hi]") == "ok"
+
+
+def test_apply_6_2_info_level_no_args() -> None:
+    src = "set lambda [list {} {info level 0}]\nputs [apply $lambda]\n"
+    assert _run_interp(src) == "apply {{} {info level 0}}"
+
+
+def test_apply_6_3_info_level_with_args() -> None:
+    src = "set lambda [list args {info level 0}]\nputs [apply $lambda x y]\n"
+    assert _run_interp(src) == "apply {args {info level 0}} x y"

--- a/tests/test_wasm_array_scalar_conflict.py
+++ b/tests/test_wasm_array_scalar_conflict.py
@@ -1,0 +1,82 @@
+"""WASM array-vs-scalar conflict detection (read + write sides).
+
+Two related fixes:
+
+* Empty ``array set X {}`` must materialise the (empty) array so
+  ``info exists X`` / ``array exists X`` are true and a later scalar
+  read of ``X`` reports ``can't read "X": variable is array`` rather
+  than ``no such variable``.  ``array_set_list`` (runtime/zig/valtypes/
+  tcl_array.zig) validated the scalar conflict but never created the
+  table on the empty-list path (set-old-8.38).
+
+* Writing an element of a name that already exists as a SCALAR raises
+  ``can't set "<arr(key)>": variable isn't array`` with the user's full
+  spelling.  ``var_set`` (runtime/zig/interp/tcl_frames.zig) routed the
+  write straight to ``array_set`` (which only produced a truncated
+  ``can't set: variable isn't array`` for the global case and silently
+  succeeded for a proc-local scalar).  The probe is scope-correct: a
+  same-named GLOBAL scalar must NOT block ``set x(1)`` inside a proc,
+  which creates a fresh local array (set-old-6.2, set-old-12.2,
+  regexpComp-6.8/11.7).
+
+The slice runs test bodies INTERPRETED (``eval_script``), so these force
+that path via ``set s {…}; eval $s``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run_interp(source: str) -> str:
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(wrapped), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+# --- read side: empty array set creates the array -------------------------
+
+
+def test_empty_array_set_creates_array() -> None:
+    src = 'array set arr {}\nputs "[info exists arr] [array exists arr] [catch {set arr} m]:$m"'
+    assert _run_interp(src) == '1 1 1:can\'t read "arr": variable is array'
+
+
+def test_array_set_on_scalar_still_errors() -> None:
+    src = 'set s 5\nputs "[catch {array set s {}} m]:$m"'
+    assert _run_interp(src) == "1:can't array set \"s\": variable isn't array"
+
+
+# --- write side: element write on a scalar --------------------------------
+
+
+def test_set_element_on_global_scalar() -> None:
+    # set-old-6.2 — full-name message, not the truncated form.
+    src = 'set a xxx\nputs "[catch {set a(14) 186} m]:$m"'
+    assert _run_interp(src) == "1:can't set \"a(14)\": variable isn't array"
+
+
+def test_set_element_on_proc_local_scalar() -> None:
+    # regexpComp-6.8/11.7 — a proc-local scalar must be detected too.
+    src = "puts [apply {{} {set f1 44; catch {set f1(f2) 1} m; return $m}}]"
+    assert _run_interp(src) == "can't set \"f1(f2)\": variable isn't array"
+
+
+def test_global_scalar_does_not_block_local_array() -> None:
+    # set-old-12.2 — `set x(1)` in a proc creates a fresh LOCAL array even
+    # when a global scalar `x` exists; it must not raise.
+    src = "set x global-scalar\nproc foo {} {set x(1) 23456}\nputs [foo]"
+    assert _run_interp(src) == "23456"
+
+
+def test_fresh_array_writes_unaffected() -> None:
+    src = (
+        "catch {unset n}\nset n(k) v\n"
+        "proc bar {} {set y(1) 99; return $y(1)}\n"
+        'puts "[array get n] [bar]"'
+    )
+    assert _run_interp(src) == "k v 99"

--- a/tests/test_wasm_incr_errorinfo.py
+++ b/tests/test_wasm_incr_errorinfo.py
@@ -1,0 +1,49 @@
+"""WASM ``incr`` — the ``(reading increment)`` errorInfo frame.
+
+C Tcl adds ``\\n    (reading increment)`` to ``::errorInfo`` ONLY when the
+explicit *increment argument* fails to parse as an integer (``incr x 1a``
+— incr-2.30..2.33, incr-old-2.5).  When the *variable's own value* is the
+non-integer (``incr x`` with ``x`` set to ``abc`` — incr-old-2.4) there is
+no increment being read, so the frame is omitted and the enclosing log
+stays ``while executing`` rather than ``invoked from within``.
+
+``runtime/zig/interp/tcl_ns.zig::raise_expected_integer`` previously
+appended the frame unconditionally.  The slice runs test bodies
+INTERPRETED (``eval_script``), so these force that path via
+``set s {…}; eval $s``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run_interp(source: str) -> str:
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(wrapped), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def test_incr_bad_variable_value_no_reading_increment_frame() -> None:
+    # incr-old-2.4: the variable value is the non-integer.
+    src = "set x abc\nputs [list [catch {incr x} msg] $msg $::errorInfo]\n"
+    expected = (
+        '1 {expected integer but got "abc"} {expected integer but got "abc"\n'
+        '    while executing\n"incr x"}'
+    )
+    assert _run_interp(src) == expected
+
+
+def test_incr_bad_increment_arg_has_reading_increment_frame() -> None:
+    # incr-old-2.5: the explicit increment argument is the non-integer.
+    src = "set x 123\nputs [list [catch {incr x 1a} msg] $msg $::errorInfo]\n"
+    expected = (
+        '1 {expected integer but got "1a"} {expected integer but got "1a"\n'
+        "    (reading increment)\n"
+        '    invoked from within\n"incr x 1a"}'
+    )
+    assert _run_interp(src) == expected

--- a/tests/test_wasm_proc_arity.py
+++ b/tests/test_wasm_proc_arity.py
@@ -1,0 +1,64 @@
+"""WASM proc call-time arity — too-many-arguments rejection.
+
+A proc whose last parameter is not the variadic ``args`` collector
+rejects extra arguments with ``wrong # args: should be "<name> ...>"``
+(proc-old-30.3).  ``eval_proc_call_bucket`` in
+``runtime/zig/interp/tcl_interp.zig`` previously only checked the
+too-FEW case (a required parameter with no supplied value), so extra
+arguments were silently dropped.  Mirrors ``ProcWrongNumArgs`` in
+tclProc.c.
+
+The slice runs test bodies INTERPRETED (``eval_script``), so the procs
+below are defined and called through that path via
+``set s {…}; eval $s``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run_interp(source: str) -> str:
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(wrapped), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # Exact arg count — fine.
+        ("proc t {x y z} {list $x $y $z}\nputs [t 1 2 3]", "1 2 3"),
+        # Too many — error with the full parameter signature (proc-old-30.3).
+        (
+            'proc t {x y z} {list $x $y $z}\nputs "[catch {t 1 2 3 4} m]:$m"',
+            '1:wrong # args: should be "t x y z"',
+        ),
+        # ``args`` collector accepts any number of trailing arguments.
+        ("proc t {a args} {list $a $args}\nputs [t 1 2 3 4]", "1 {2 3 4}"),
+        # Zero-parameter proc rejects any argument.
+        ("proc t {} {return ok}\nputs [t]", "ok"),
+        (
+            'proc t {} {return ok}\nputs "[catch {t x} m]:$m"',
+            '1:wrong # args: should be "t"',
+        ),
+        # Defaulted trailing parameter still rejects a true excess and
+        # renders as ``?y?`` in the signature.
+        ("proc t {x {y 9}} {list $x $y}\nputs [t 1 2]", "1 2"),
+        (
+            'proc t {x {y 9}} {list $x $y}\nputs "[catch {t 1 2 3} m]:$m"',
+            '1:wrong # args: should be "t x ?y?"',
+        ),
+        # Too FEW still errors (unchanged regression guard).
+        (
+            'proc t {x y z} {list $x $y $z}\nputs "[catch {t 1 2} m]:$m"',
+            '1:wrong # args: should be "t x y z"',
+        ),
+    ],
+)
+def test_proc_call_arity(source: str, expected: str) -> None:
+    assert _run_interp(source) == expected

--- a/tests/test_wasm_proc_arity.py
+++ b/tests/test_wasm_proc_arity.py
@@ -11,6 +11,13 @@ tclProc.c.
 The slice runs test bodies INTERPRETED (``eval_script``), so the procs
 below are defined and called through that path via
 ``set s {…}; eval $s``.
+
+The check is enforced before the compiled-proc dispatch in
+``eval_proc_call_bucket`` (so it covers compiled procs too), and the
+static-codegen call sites route the over-arity case through the eval
+fallback — so the ``_run_compiled`` cases below (ordinary non-``eval``
+source, which compiles the call to a direct proc call) raise the same
+error rather than silently truncating (Codex review on PR #532).
 """
 
 from __future__ import annotations
@@ -25,6 +32,13 @@ from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
 def _run_interp(source: str) -> str:
     wrapped = "set __s {" + source + "}\neval $__s\n"
     _, stdout = _run_wasm(_compile_tcl(wrapped), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def _run_compiled(source: str) -> str:
+    """Compile *source* directly — the proc call becomes a direct
+    static-codegen call (not eval-dispatched)."""
+    _, stdout = _run_wasm(_compile_tcl(source), capture_stdout=True)
     return stdout.rstrip("\n")
 
 
@@ -62,3 +76,36 @@ def _run_interp(source: str) -> str:
 )
 def test_proc_call_arity(source: str, expected: str) -> None:
     assert _run_interp(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # The Codex-flagged shape: ordinary (non-eval) source compiles
+        # ``t 1 2 3 4`` to a direct proc call.  Must raise, not truncate.
+        (
+            'proc t {x y z} {list $x $y $z}\nputs "[catch {t 1 2 3 4} m]:$m"',
+            '1:wrong # args: should be "t x y z"',
+        ),
+        # value context ([proc ...] substitution)
+        (
+            'proc t {x y z} {list $x $y $z}\nset r [catch {t 1 2 3 4} m]\nputs "$r:$m"',
+            '1:wrong # args: should be "t x y z"',
+        ),
+        # expression context (if {[proc ...]})
+        (
+            'proc t {x y z} {return 1}\nif {[catch {t 1 2 3 4} m]} {puts "e:$m"} else {puts ok}',
+            'e:wrong # args: should be "t x y z"',
+        ),
+        # Exact / variadic / defaulted compiled calls are unaffected.
+        ("proc t {x y z} {list $x $y $z}\nputs [t 1 2 3]", "1 2 3"),
+        ("proc t {a args} {list $a $args}\nputs [t 1 2 3 4]", "1 {2 3 4}"),
+        ("proc t {x {y 9}} {list $x $y}\nputs [t 1]", "1 9"),
+        (
+            'proc t {x {y 9}} {list $x $y}\nputs "[catch {t 1 2 3} m]:$m"',
+            '1:wrong # args: should be "t x ?y?"',
+        ),
+    ],
+)
+def test_proc_call_arity_compiled(source: str, expected: str) -> None:
+    assert _run_compiled(source) == expected

--- a/tests/test_wasm_real_tcl.py
+++ b/tests/test_wasm_real_tcl.py
@@ -2770,17 +2770,15 @@ class TestRenamedToProcDispatch:
         assert ok, err
         assert out.strip() == "caught"
 
-    @pytest.mark.xfail(
-        reason=(
-            "Known narrow gap: a *variadic* {args} proc that shadows a *renamed* "
-            "builtin binds args short. The AOT prologue pre-registers every proc "
-            "before ::top runs, so `rename string ::s` reorders against tclsh's "
-            "lazy define. Fixed-arity shadows (above) are correct; redefining "
-            "without a prior rename is correct too. Documented in _values.py."
-        ),
-        strict=True,
-    )
     def test_variadic_shadow_of_renamed_builtin(self):
+        # Formerly a known gap: a *variadic* {args} proc shadowing a
+        # *renamed* builtin bound args short because the compile-time
+        # ``_proc_args_tail`` didn't recognise the shadow as variadic, so
+        # the direct distrust dispatch truncated.  The proc-arity work
+        # (PR #532) routes the compile-time-over-arity case through the
+        # eval fallback, where the runtime reads the proc's real stored
+        # params, recognises the ``args`` collector, and packs the tail
+        # correctly — so ``string length abcde`` → args = {length abcde}.
         ok, out, err = _run_tcl_for_stdout(
             "rename string ::s\nproc string {args} {return [llength $args]}\n"
             "puts [string length abcde]"

--- a/tests/test_wasm_regexp_optabbrev.py
+++ b/tests/test_wasm_regexp_optabbrev.py
@@ -1,0 +1,64 @@
+"""WASM ``regexp`` — ``-nocase`` option abbreviation.
+
+C Tcl's ``TclCompileRegexpCmd`` prefix-matches a single option,
+``-nocase`` (``strncmp(str, "-nocase", len)``), so ``-n`` / ``-no`` /
+``-noc`` all mean ``-nocase`` — regexpComp-21.6/21.7/24.6/24.7.  Every
+*other* option goes through the interpreted ``Tcl_RegexpObjCmd``, which
+uses an exact (``TCL_EXACT``) lookup, so ``-al`` / ``-li`` / ``-l`` are
+plain ``bad option`` errors, not abbreviations.
+
+``runtime/zig/valtypes/tcl_regex.zig`` previously matched ``-nocase``
+exactly, rejecting its abbreviations.  The matcher now prefix-matches
+``-nocase`` only and exact-matches the rest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(source: str) -> str:
+    _, stdout = _run_wasm(_compile_tcl(source), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # -n / -no / -noc abbreviate -nocase (regexpComp-21.6/.7/24.6/.7).
+        ("puts [regexp -n foo dogfoOd]", "1"),
+        ("puts [regexp -no -- FoO dogfood]", "1"),
+        ("puts [regexp -noc FOO dogFOOd]", "1"),
+        # Exact options still resolve.
+        ("puts [regexp -nocase FOO dogfood]", "1"),
+        ("puts [regexp -- -x -x]", "1"),
+        ("puts [regexp -all foo foofoo]", "2"),
+        ('puts [regexp -line {^b} "a\\nb"]', "1"),
+    ],
+)
+def test_regexp_option_accepted(source: str, expected: str) -> None:
+    assert _run(source) == expected
+
+
+@pytest.mark.parametrize(
+    "opt",
+    [
+        # Abbreviations of options OTHER than -nocase are NOT accepted —
+        # C Tcl reports plain "bad option" (no prefix matching, no
+        # "ambiguous option").
+        "-al",
+        "-li",
+        "-l",
+        "-i",
+        "-a",
+        "-ind",
+        "-gorp",
+    ],
+)
+def test_regexp_non_nocase_abbrev_rejected(opt: str) -> None:
+    out = _run(f"puts [catch {{regexp {opt} foo foo}} m]:$m")
+    assert out.startswith(f'1:bad option "{opt}"'), out

--- a/tests/test_wasm_try_during_chaining.py
+++ b/tests/test_wasm_try_during_chaining.py
@@ -1,0 +1,221 @@
+"""WASM ``dict exists`` nested paths + ``try`` ``-during`` exception chaining.
+
+Pins the two root-cause fixes behind the error-18.8/.9/.10 cluster of the
+``tcl9-tcltest-wasm`` slice:
+
+* ``dict exists DICT KEY ?KEY ...?`` must walk the *whole* key chain, not
+  just the first key.  The runtime handler (``runtime/zig/cmds/dict.zig``)
+  and both WASM codegen dispatch paths
+  (``compiler/codegen/wasm/_emitter/cmds/dict_.py``) previously consulted
+  only ``words[3]``, so ``dict exists $opts -during -during`` (and any
+  multi-key probe) returned true whenever the first key existed.  Matches
+  ``tclDictObj.c::DictExistsCmd``: a missing key OR a non-dict intermediate
+  collapses to false without raising.  error-18.8 relied on this.
+
+* ``try ... on/trap ... finally`` exception chaining (the ``-during``
+  options key).  Mirrors C Tcl's ``TryPostHandler`` / ``TryPostFinal``
+  (``tclCmdMZ.c``):
+
+    - a handler that raises a *direct* error (``throw`` / ``error``) chains
+      the body's options under ``-during`` (error-16.8/.9, -18.10);
+    - a handler that re-raises via ``return -options`` reproduces the
+      body's options verbatim with NO ``-during`` (error-15.10);
+    - a handler that completes cleanly replaces the body's options
+      wholesale (error-16.10, -18.9);
+    - a finally that raises chains the *current* (handler-or-body) options
+      under ``-during`` (error-18.7, -18.8, -18.9, -18.10).
+
+  The slice runs test bodies INTERPRETED (``eval_script``), so the ``try``
+  cases below force that path via ``set s {…}; eval $s``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run_compiled(source: str) -> str:
+    """Compile *source* directly (static codegen path) and return stdout."""
+    wasm = _compile_tcl(source)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def _run_interp(source: str) -> str:
+    """Run *source* through the interpreter (``eval``), as the slice does."""
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    wasm = _compile_tcl(wrapped)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+# ---------------------------------------------------------------------------
+# dict exists — nested key paths
+# ---------------------------------------------------------------------------
+
+_DICT_EXISTS_CASES = [
+    # Single key (unchanged behaviour) — present / absent.
+    ("puts [dict exists {a 1 b 2} a]", "1"),
+    ("puts [dict exists {a 1 b 2} z]", "0"),
+    # Two-level descent into a nested dict.
+    ("puts [dict exists {a {b c}} a b]", "1"),
+    ("puts [dict exists {a {b c}} a x]", "0"),
+    # First key present but second absent — the bug returned 1 here.
+    ("puts [dict exists {-code 1 -during {-code 0 -level 0}} -during -during]", "0"),
+    ("puts [dict exists {-code 1 -during {-code 0 -level 0}} -during -code]", "1"),
+    ("puts [dict exists {-code 1 -during {-code 0 -level 0}} -during -bogus]", "0"),
+    # Non-dict intermediate value collapses to false, never raises.
+    ("puts [dict exists {a b} a b c]", "0"),
+    # Three-level descent.
+    ("puts [dict exists {a {b {c d}}} a b c]", "1"),
+    ("puts [dict exists {a {b {c d}}} a b x]", "0"),
+]
+
+
+@pytest.mark.parametrize("source,expected", _DICT_EXISTS_CASES)
+def test_dict_exists_nested_interpreted(source: str, expected: str) -> None:
+    assert _run_interp(source) == expected
+
+
+@pytest.mark.parametrize("source,expected", _DICT_EXISTS_CASES)
+def test_dict_exists_nested_compiled(source: str, expected: str) -> None:
+    # The static codegen path must route the multi-key form through the
+    # eval fallback (the 2-param runtime import only walks one key).
+    assert _run_compiled(source) == expected
+
+
+def test_dict_exists_nested_compiled_in_proc() -> None:
+    """Multi-key ``dict exists`` inside a compiled proc body."""
+    src = (
+        "proc f {} {\n"
+        "  set d {a {b c} d e}\n"
+        '  return "[dict exists $d a b] [dict exists $d a x] [dict exists $d d x]"\n'
+        "}\n"
+        "puts [f]\n"
+    )
+    assert _run_compiled(src) == "1 0 0"
+
+
+def test_dict_exists_nested_compiled_in_condition() -> None:
+    """Multi-key ``dict exists`` in an ``if`` condition (expr context)."""
+    src = (
+        "set d {a {b c}}\n"
+        "if {[dict exists $d a b]} { puts yes-ab } else { puts no-ab }\n"
+        "if {[dict exists $d a x]} { puts yes-ax } else { puts no-ax }\n"
+    )
+    assert _run_compiled(src) == "yes-ab\nno-ax"
+
+
+def test_dict_get_nested_compiled_in_condition() -> None:
+    """Multi-key ``dict get`` in an ``expr`` comparison."""
+    src = "set d {a {b 7}}\nif {[dict get $d a b] == 7} { puts seven } else { puts other }\n"
+    assert _run_compiled(src) == "seven"
+
+
+# ---------------------------------------------------------------------------
+# try ... finally — ``-during`` exception chaining (error-18.x)
+# ---------------------------------------------------------------------------
+
+
+def test_during_body_ok_handler_ok_finally_error() -> None:
+    """error-18.8: body OK, ``on ok`` handler OK, finally throws.
+
+    ``-during`` is the handler's clean options (``-code 0``) with no
+    nested ``-during``.
+    """
+    src = (
+        "catch { try { list a b c } on ok {} { list d e f }"
+        " finally { throw BAR baz } } em opts\n"
+        "puts [list [dict get $opts -during -code]"
+        " [dict exists $opts -during -during]]\n"
+    )
+    assert _run_interp(src) == "0 0"
+
+
+def test_during_body_error_handler_ok_finally_error() -> None:
+    """error-18.9: body error, ``on error`` handler OK, finally throws.
+
+    The clean handler replaces the body's error options, so ``-during``
+    is ``-code 0`` — not the body's ``-code 1``.
+    """
+    src = (
+        "catch { try { throw FOO bar } on error {} { list d e f }"
+        " finally { throw BAR baz } } em opts\n"
+        "puts [list [dict get $opts -during -code]"
+        " [dict exists $opts -during -during]]\n"
+    )
+    assert _run_interp(src) == "0 0"
+
+
+def test_during_body_error_handler_error_finally_error() -> None:
+    """error-18.10: body error, handler throws, finally throws.
+
+    Two-level chain: the finally's ``-during`` is the handler's BAR error,
+    whose own ``-during`` is the body's FOO error.
+    """
+    src = (
+        "catch { try { throw FOO bar } on error {} { throw BAR baz }"
+        " finally { throw BAR baz } } em opts\n"
+        "puts [list [dict get $opts -during -errorcode]"
+        " [dict get $opts -during -during -errorcode]]\n"
+    )
+    assert _run_interp(src) == "BAR FOO"
+
+
+def test_during_finally_only_body_error() -> None:
+    """error-18.7: body error, finally throws — ``-during`` is the body."""
+    src = (
+        "catch { try { throw FOO bar } finally { throw BAR baz } } em opts\n"
+        "puts [dict get $opts -during -errorcode]\n"
+    )
+    assert _run_interp(src) == "FOO"
+
+
+def test_during_handler_error_no_finally_chains_body() -> None:
+    """error-16.8/.9: handler error without finally still chains ``-during``.
+
+    Verifies the chaining is computed deterministically (it previously
+    only "passed" in the bundle via leaked cross-test ``during_options``).
+    """
+    # body OK, ``on ok`` handler throws -> -during is the body's OK options.
+    src_ok = (
+        "catch { try { list a b c } on ok {em opts} { throw BAR baz } }"
+        " tryem tryopts\n"
+        "puts [list [dict get $tryopts -during -code]"
+        " [dict exists $tryopts -during -during]]\n"
+    )
+    assert _run_interp(src_ok) == "0 0"
+    # body error, handler throws -> -during is the body's FOO error.
+    src_err = (
+        "catch { try { throw FOO bar } trap {} {em opts} { throw BAR baz } }"
+        " tryem tryopts\n"
+        "puts [dict get $tryopts -during -errorcode]\n"
+    )
+    assert _run_interp(src_err) == "FOO"
+
+
+def test_during_handler_ok_no_chain() -> None:
+    """error-16.10: a clean handler leaves no ``-during`` at all."""
+    src = (
+        "catch { try { throw FOO bar } trap {} {em opts} { list d e f } }"
+        " tryem tryopts\n"
+        "puts [dict exists $tryopts -during]\n"
+    )
+    assert _run_interp(src) == "0"
+
+
+def test_return_options_reraise_no_during() -> None:
+    """error-15.10: a ``return -options`` re-raise reproduces the body's
+    options verbatim, with no spurious ``-during``."""
+    src = (
+        "set script {return -level 1 -code 1 foo}\n"
+        "catch $script m1 o1\n"
+        "catch {try $script on 1 {x y} {return -options $y $x}} m2 o2\n"
+        "puts [list [dict exists $o2 -during]"
+        " [expr {[lsort -stride 2 $o1] eq [lsort -stride 2 $o2]}]]\n"
+    )
+    assert _run_interp(src) == "0 1"

--- a/tests/test_wasm_unset_element.py
+++ b/tests/test_wasm_unset_element.py
@@ -1,0 +1,63 @@
+"""WASM ``unset arr(elem)`` — interpreted array-element removal.
+
+The interpreted ``unset`` handler (``runtime/zig/cmds/var.zig``)
+mishandled the ``arr(key)`` form: it ran ``array_unset`` against the
+literal name ``arr(key)`` (a no-op) and then ``var_set(arr(key), 0)``,
+which routed through the array path and merely *set* the element to the
+empty string — leaving the element present and the array directory
+inconsistent.  It now splits ``arr(key)``, resolves the array name
+through any ``global`` / ``upvar`` link, and calls
+``array_unset_element``, matching ``array unset arr key``.  Regression
+guard for proc-old-3.3 / 3.5 and the set-old element-unset cases.
+
+The slice runs test bodies INTERPRETED (``eval_script``), so these force
+that path via ``set s {…}; eval $s``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run_interp(source: str) -> str:
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(wrapped), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def test_unset_element_toplevel() -> None:
+    src = (
+        "set a(x) 1\nset a(y) 2\nunset a(y)\n"
+        'puts "[lsort [array names a]] [info exists a(y)] [info exists a(x)]"'
+    )
+    assert _run_interp(src) == "x 0 1"
+
+
+def test_unset_element_through_global_link() -> None:
+    # proc-old-3.3 / 3.5: ``global a; unset a(y)`` removes the element
+    # from the global array, leaving the other element intact.
+    src = (
+        "set b(p) 1\nset b(q) 2\n"
+        "proc tp {} {global b; unset b(q)}\ntp\n"
+        'puts "[lsort [array names b]] [info exists b(q)]"'
+    )
+    assert _run_interp(src) == "p 0"
+
+
+def test_unset_missing_element_errors() -> None:
+    src = 'set a(x) 1\nputs "[catch {unset a(z)} m]:$m"'
+    assert _run_interp(src) == '1:can\'t unset "a(z)": no such element in array'
+
+
+def test_unset_nocomplain_missing_element() -> None:
+    src = 'set a(x) 1\nputs "[catch {unset -nocomplain a(z)} m]:$m [array names a]"'
+    assert _run_interp(src) == "0: x"
+
+
+def test_unset_whole_array_still_works() -> None:
+    src = 'set a(x) 1\nset a(y) 2\nunset a\nputs "[info exists a] [array exists a]"'
+    assert _run_interp(src) == "0 0"


### PR DESCRIPTION
## Summary

This PR fixes multiple interpreter bugs affecting the WASM runtime and codegen:

### Core Fixes

1. **`dict exists` nested key paths** — `dict exists DICT KEY ?KEY ...?` now correctly walks the entire key chain instead of only checking the first key. Previously, `dict exists {-code 1 -during {...}} -during -during` incorrectly returned true. The fix applies to both the runtime handler and WASM codegen dispatch paths.

2. **`try ... finally` exception chaining (`-during` options)** — Implements proper exception chaining semantics matching C Tcl's `TryPostHandler`:
   - A handler that raises a direct error chains the body's options under `-during`
   - A handler that re-raises via `return -options` reproduces the body's options verbatim with no `-during`
   - A handler that completes cleanly replaces the body's options wholesale
   - A finally that raises chains the current (handler-or-body) options under `-during`

3. **Proc arity validation** — Procs now reject extra arguments when the last parameter is not the variadic `args` collector, matching C Tcl's `ProcWrongNumArgs` behavior (proc-old-30.3).

4. **Array vs scalar conflict detection** — 
   - Empty `array set X {}` now materializes the array so `info exists X` and `array exists X` return true
   - Writing an array element on a scalar name now raises the proper error with the user's full spelling (set-old-6.2, regexpComp-6.8/11.7)

5. **`unset arr(elem)` element removal** — The interpreted `unset` handler now correctly removes array elements via `array_unset_element` instead of silently leaving them present.

6. **`regexp` option abbreviation** — The `-nocase` option now accepts prefix abbreviations (`-n`, `-no`, `-noc`) matching C Tcl's `TclCompileRegexpCmd`, while other options require exact matches (regexpComp-21.6/.7, 24.6/.7).

7. **`incr` errorInfo frame** — The `(reading increment)` frame is now only added when the explicit increment argument fails to parse, not when the variable's current value is non-integer (incr-old-2.4 vs incr-old-2.5).

8. **`apply` lambda validation** — Added proper formal parameter validation rejecting array-element names and qualified names, with correct `(parsing lambda expression ...)` errorInfo frames (apply-2.2..2.5).

## Changes

- **runtime/zig/cmds/dict.zig** — Multi-key `dict exists` now walks the full key chain
- **runtime/zig/cmds/flow.zig** — Exception chaining for `try ... finally` with proper `-during` handling
- **runtime/zig/interp/tcl_interp.zig** — Proc arity validation and lambda formal parameter checking
- **runtime/zig/interp/tcl_frames.zig** — Array vs scalar conflict detection on element writes
- **runtime/zig/interp/tcl_ns.zig** — Conditional `(reading increment)` errorInfo frame
- **runtime/zig/valtypes/tcl_array.zig** — Empty array materialization
- **runtime/zig/valtypes/tcl_regex.zig** — Prefix matching for `-nocase` option
- **runtime/zig/cmds/var.zig** — Proper `unset arr(elem)` element removal
- **compiler/codegen/wasm/_emitter/cmds/dict_.py** — Route multi-key `dict exists` through eval fallback
- **compiler/codegen/wasm/_emitter/_values.py** — Route multi-key `dict exists` in command substitution
- **compiler/codegen/wasm/_emitter/_expressions.py** — Route multi-key `dict exists` in expressions

## Validation

- Added comprehensive test suites:
  - `tests/test_wasm_try_during_chaining.py` — Exception chaining and `

https://claude.ai/code/session_01EHBApCTVf1UnPwZS8GBYAP