### PR TITLE
Fix empty symbol names in BigIP document outline

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=ff04adf-dirty
-head=ff04adf6732a4e03ab9a4009cf150bd85986f084
-date=2026-06-04T07:35:05Z
-fingerprint=4a8b1e864753585acfe417f9a29624653aa1c52e09eaf243656af11a2c8ca59f
+describe=156f418-dirty
+head=156f418ab3adfbfc7068cf9432715cf2168841b9
+date=2026-06-04T08:21:32Z
+fingerprint=8731351b9d82a767a56f6e76a15deab08bf249b115b6ce5b1f1b65a40632db11

--- a/compiler/taint/_sinks.py
+++ b/compiler/taint/_sinks.py
@@ -357,7 +357,7 @@ def _eval_stmt_protected_by_list_literal(stmt, var_name: str) -> bool:
 
 
 def _direct_expr_operand_names(node) -> set[str]:
-    """Return the set of variable names that appear as DIRECT operands of
+    r"""Return the set of variable names that appear as DIRECT operands of
     an expression AST — ie ``ExprVar`` nodes that are NOT nested inside
     an ``ExprCommand`` (command substitution).
 

--- a/server/features/_bigip_symbols.py
+++ b/server/features/_bigip_symbols.py
@@ -74,8 +74,13 @@ def get_bigip_document_symbols(source: str) -> list[types.DocumentSymbol]:
             obj_range = getattr(obj, "range", None)
             if obj_range is None:
                 continue
+            # Global singletons (``auth password-policy``, ``net self-allow``,
+            # ``sys diags ihealth``, ...) have no path — the dict key is "".
+            # An empty ``DocumentSymbol.name`` makes the VS Code client reject
+            # the *entire* outline ("name must not be falsy"), so fall back to
+            # the kind label, which is the object's effective identity.
             by_module_kind.setdefault(module, {}).setdefault(kind, []).append(
-                (full_path, obj_range)
+                (full_path or kind, obj_range)
             )
 
     # Build the three-level tree.  Module / kind ranges span their

--- a/tests/test_document_symbols.py
+++ b/tests/test_document_symbols.py
@@ -241,3 +241,40 @@ class TestBigipDocumentSymbols:
         # Garbage input parses to an empty BigipConfig (no outline).
         out = get_bigip_document_symbols("this is not a bigip config\n")
         assert out == []
+
+    def test_global_singletons_have_non_empty_names(self):
+        from server.features._bigip_symbols import get_bigip_document_symbols
+
+        # Global singletons (``auth password-policy``, ``net self-allow``,
+        # ``sys diags ihealth``) carry no path.  An empty ``name`` makes the
+        # VS Code client reject the *entire* outline ("name must not be
+        # falsy"), so every symbol — at every depth — must be non-empty.
+        source = (
+            "auth password-policy {\n"
+            "    lockout-duration 10\n"
+            "}\n"
+            "net self-allow {\n"
+            "    defaults {\n"
+            "        tcp:443\n"
+            "    }\n"
+            "}\n"
+            "sys diags ihealth {\n"
+            "    user admin\n"
+            "}\n"
+            "ltm pool /Common/p1 { }\n"
+        )
+        out = get_bigip_document_symbols(source)
+
+        def all_names(symbols):
+            for sym in symbols:
+                yield sym.name
+                yield from all_names(sym.children or [])
+
+        names = list(all_names(out))
+        assert names, "expected a non-empty outline"
+        assert all(names), f"empty symbol name(s) present: {names!r}"
+
+        # The nameless singletons fall back to their kind label.
+        auth = next(s for s in out if s.name == "auth")
+        pwd = next(c for c in (auth.children or []) if c.name == "password-policy")
+        assert [o.name for o in (pwd.children or [])] == ["password-policy"]


### PR DESCRIPTION
## Summary

- Fixed an issue where global singleton objects in BigIP configs (e.g., `auth password-policy`, `net self-allow`, `sys diags ihealth`) were generating document symbols with empty names, causing VS Code to reject the entire outline
- When these objects have no path (empty dict key), the symbol name now falls back to the object's kind label, ensuring all symbols have non-empty names
- Added comprehensive test coverage for this edge case
- Minor docstring fix (raw string literal for regex documentation)

## Changes

**server/features/_bigip_symbols.py:**
- Modified symbol generation to use `full_path or kind` instead of just `full_path`, ensuring global singletons get a meaningful name based on their kind when they have no path
- Added explanatory comments about why this fallback is necessary for VS Code compatibility

**tests/test_document_symbols.py:**
- Added `test_global_singletons_have_non_empty_names()` to verify that all document symbols have non-empty names, including nested children
- Test validates the specific behavior for `auth password-policy`, `net self-allow`, and `sys diags ihealth` objects

**compiler/taint/_sinks.py:**
- Minor: Changed docstring to raw string literal (`r"""`) for proper regex documentation formatting

## Validation

- [x] Added unit test `test_global_singletons_have_non_empty_names` that validates the fix
- [x] Test verifies all symbol names are non-empty at all nesting levels
- [x] Test confirms the fallback behavior uses the kind label for nameless singletons

https://claude.ai/code/session_01UHshexzUti5sWRSpWmfdGu