### PR TITLE
Fix lexer line tracking for lone CR continuations

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=ff04adf-dirty
-head=ff04adf6732a4e03ab9a4009cf150bd85986f084
-date=2026-06-04T07:35:05Z
-fingerprint=4a8b1e864753585acfe417f9a29624653aa1c52e09eaf243656af11a2c8ca59f
+describe=65174a7-dirty
+head=65174a7e8570883fe9b80e9423ee43666a4b61da
+date=2026-06-04T12:57:08Z
+fingerprint=cddf8811eb1cead264cfdd8e0ea1aaca3cb6e10499457e2032ad2bb44b825b7e

--- a/compiler/parsing/incremental.py
+++ b/compiler/parsing/incremental.py
@@ -358,6 +358,18 @@ def incremental_top_level_chunks(
     if not old_chunks:
         return None
 
+    # If the old segmentation involved error recovery, no fast path can
+    # guarantee byte-identity: the window is re-segmented with recovery
+    # *disabled* (a body_token slice), so it cannot reproduce a recovered /
+    # partial command, and a from-scratch pass *would* re-run recovery.  A
+    # partial command can sit anywhere — including the window region between the
+    # prefix and the validation chunk, which the per-region checks below do not
+    # cover — so bail up front whenever any old command is partial.  Recovery
+    # only fires on malformed input (a transiently unbalanced file mid-edit), so
+    # the full-resegment fallback here is both rare and correct.
+    if any(cmd.is_partial for chunk in old_chunks for cmd in chunk.commands):
+        return None
+
     # Fast path: a brace-safe interior edit of one large braced-body command
     # (the single-giant-command file) — reuse it with a body splice instead of
     # re-lexing the whole body.
@@ -384,8 +396,6 @@ def incremental_top_level_chunks(
         else:
             break
     prefix = list(old_chunks[:prefix_count])
-    if any(cmd.is_partial for chunk in prefix for cmd in chunk.commands):
-        return None
 
     # Suffix: chunks beginning after the first newline at/after old_end sit on
     # lines strictly below the edit, so offset+line shifting (columns
@@ -403,8 +413,6 @@ def incremental_top_level_chunks(
     if val_idx is None or val_idx >= n - 1:
         return None  # need a validation chunk and at least one tail chunk to reuse.
     reuse_old = old_chunks[val_idx + 1 :]
-    if any(cmd.is_partial for chunk in old_chunks[val_idx:] for cmd in chunk.commands):
-        return None
 
     # Window: covers the middle plus the validation chunk.  The first command
     # in the window is the one at ``p`` (the first non-prefix command); the

--- a/compiler/parsing/lexer.py
+++ b/compiler/parsing/lexer.py
@@ -605,11 +605,19 @@ class TclLexer:
                             col = 0
                             pos += 1
                         elif esc == "\r":
-                            line += 1
-                            col = 0
                             pos += 1
                             if pos < _len and text[pos] == "\n":
+                                # CRLF: the LF is the line break recorded in the
+                                # _line_starts index, so count it there.
                                 pos += 1
+                                line += 1
+                                col = 0
+                            else:
+                                # A lone CR is not a line break for the line index
+                                # (_pos_at / _advance only count \n), so advance the
+                                # column to stay consistent — a token straddling it
+                                # must not report start and end on different lines.
+                                col += 1
                         else:
                             col += 1
                             pos += 1
@@ -793,12 +801,21 @@ class TclLexer:
                         # Advance past escaped char.
                         esc = text[pos]
                         if esc == "\n" or esc == "\r":
-                            line += 1
-                            col = 0
                             pos += 1
-                            # Consume the LF half of a CRLF pair.
+                            # Consume the LF half of a CRLF pair.  A lone CR is not
+                            # a line break for the _line_starts index (_pos_at /
+                            # _advance only count \n), so advance the column there
+                            # instead — otherwise a token straddling it reports
+                            # start and end on different lines.
                             if esc == "\r" and pos < _len and text[pos] == "\n":
                                 pos += 1
+                                line += 1
+                                col = 0
+                            elif esc == "\n":
+                                line += 1
+                                col = 0
+                            else:
+                                col += 1
                             # Backslash-newline at the very start of a
                             # token is pure line-continuation whitespace.
                             # Emit it as a SEP so the *next* token can
@@ -978,13 +995,20 @@ class TclLexer:
                         if next_ch == "\n" or next_ch == "\r":
                             # Backslash-newline continuation.
                             col += 1
-                            pos += 1
-                            line += 1
-                            col = 0
-                            pos += 1
-                            # Consume LF half of CRLF.
+                            pos += 1  # past backslash
+                            pos += 1  # past CR or LF
+                            # Consume LF half of CRLF.  A lone CR is not a line
+                            # break for the _line_starts index, so advance the
+                            # column instead of resetting the line.
                             if next_ch == "\r" and pos < _len and text[pos] == "\n":
                                 pos += 1
+                                line += 1
+                                col = 0
+                            elif next_ch == "\n":
+                                line += 1
+                                col = 0
+                            else:
+                                col += 1
                             continue
                         else:
                             # Backslash followed by another char.
@@ -996,11 +1020,15 @@ class TclLexer:
                                 col = 0
                                 pos += 1
                             elif esc2 == "\r":
-                                line += 1
-                                col = 0
                                 pos += 1
                                 if pos < _len and text[pos] == "\n":
+                                    # CRLF: count the LF (it is in _line_starts).
                                     pos += 1
+                                    line += 1
+                                    col = 0
+                                else:
+                                    # Lone CR is not a line break for the index.
+                                    col += 1
                             else:
                                 col += 1
                                 pos += 1

--- a/compiler/parsing/lexer.py
+++ b/compiler/parsing/lexer.py
@@ -343,11 +343,20 @@ class TclLexer:
                             col = 0
                             pos += 1
                         elif esc == "\r":
-                            line += 1
-                            col = 0
                             pos += 1
                             if pos < _len and text[pos] == "\n":
+                                # CRLF: the LF is the line break recorded in the
+                                # _line_starts index, so count it there.
                                 pos += 1
+                                line += 1
+                                col = 0
+                            else:
+                                # A lone CR is not a line break for the line index
+                                # (_pos_at / _advance only count \n), so advance the
+                                # column — a token straddling it, and tokens after
+                                # the command substitution, must not report a line
+                                # the index disagrees with.
+                                col += 1
                         else:
                             col += 1
                             pos += 1

--- a/compiler/parsing/syntax/build.py
+++ b/compiler/parsing/syntax/build.py
@@ -174,15 +174,13 @@ def build_document(
                 pending.append(eol_triv)
             prev_type = TokenType.EOL
             continue
-        # Backslash-newline continuation between words is whitespace, never a
-        # fragment (matches the segmenter, which skips it but still advances the
-        # word boundary when it follows a real word).
-        if ttype is TokenType.ESC and tok.text == "\\\n":
-            if prev_type not in _SEP_OR_EOL:
-                word_boundary = region
-            pending.append(trivia(TriviaKind.WHITESPACE, raw))
-            prev_type = TokenType.SEP
-            continue
+        # A backslash-newline that is a *separator* (between/after words, after a
+        # ``{*}`` marker, mid-word) is lexed as ``SEP`` and folded above.  The
+        # lexer emits ``\<newline>`` as an ``ESC`` token *only* as quoted-word
+        # content (``"\<newline>"`` — terminated or not), where it is a real
+        # fragment of that word, so it must fall through to the fragment path:
+        # folding it would drop a token the lexer reports and lose the (possibly
+        # only) fragment of the quoted word.
 
         leaf = GreenToken(
             token_type=ttype,

--- a/docs/design/compiler/lexing-segmentation.md
+++ b/docs/design/compiler/lexing-segmentation.md
@@ -56,6 +56,18 @@ consumers that check for stray punctuation must test
 characters from structural delimiters (which are part of `STR` or `CMD`
 tokens).
 
+**Line-tracking convention** — the lexer resolves line/column two ways that
+must agree: a `\n`-only line-start index (`_line_starts`, consumed by
+`_pos_at` and the red [concrete syntax tree](syntax-tree.md) overlay), and an
+incremental `line`/`col` counter advanced per character. **Only `\n` is a line
+break for positions.** A lone carriage return — including a backslash-CR
+*continuation* (`\<CR>`, the old-Mac line ending) — splits the word like any
+continuation but does **not** advance the line, because the index never records
+it; a CRLF advances the line on its `\n`. Treating a lone `\<CR>` as a line
+break in the incremental counter (but not the index) made the token *after* it
+report `start` one line below its own `end` — a backwards range. Any new
+position-tracking path must keep the two mechanisms in lock-step.
+
 ### Stage 2 — Segmentation
 
 The segmenter groups tokens into commands at `EOL`/`EOF` boundaries:

--- a/docs/design/compiler/syntax-tree.md
+++ b/docs/design/compiler/syntax-tree.md
@@ -178,7 +178,14 @@ locked by the suite afterwards:
   table in `tests/test_syntax_tree.py`.
 - **Position-equivalence** — red fragment tokens equal the lexer's non-trivia
   token stream (offsets, lines, UTF-16 columns, `in_quote`) over the same
-  corpus + fuzz, including multi-line and unicode bodies.
+  corpus + fuzz, including multi-line and unicode bodies. The randomised
+  generator in `tests/test_syntax_tree.py` now also covers carriage returns
+  (lone `\<CR>` continuations), astral / combining unicode, and a quoted word
+  whose entire content is a backslash-newline — the seams a `\n`-only, ASCII
+  generator never reached. The last is a real fragment, not trivia: the lexer
+  emits a separator backslash-newline as `SEP`, but a quoted-word content
+  backslash-newline as an `ESC` token the tree must keep (a fold there dropped
+  the only fragment of the word).
 - **Segment byte-identity** — `segments_from_*` matched the former
   `_segment_raw` field-for-field (`range`, `argv`, `texts`, `single_token_word`,
   `all_tokens`, `preceding_comment`, `expand_word`) over the corpus, 120k

--- a/docs/design/contracts/formatter-engine.md
+++ b/docs/design/contracts/formatter-engine.md
@@ -10,7 +10,17 @@ Formatting is implemented as an engine/config/runtime pipeline and surfaced thro
 
 ## Decision rules / contracts
 
-1. Formatter output should be idempotent for stable inputs and config.
+1. `format_tcl` is **idempotent for every input** — `format_tcl(format_tcl(x))
+   == format_tcl(x)`. Valid Tcl reaches its formatted form in one pass (the
+   confirming pass returns it unchanged). Structurally malformed input (an
+   unbalanced `{` / `[` / `"`) can reconstruct non-idempotently — the lexer
+   swallows the unterminated region to EOF and the reconstruction fabricates a
+   closer a re-parse re-mangles, formerly growing the output by a delimiter on
+   every pass — so `format_tcl` iterates to a fixed point and, if none exists
+   within the pass cap, returns the input unchanged rather than mangle or
+   unboundedly grow un-formattable code. The same `_minify_body_stable` wrapper
+   guards the minifier. (Cost: valid input formats twice — once plus the
+   confirming pass.)
 2. Formatting decisions must preserve parseability and command semantics.
 3. New formatting options require config wiring + regression coverage.
 4. Formatter consumers should import `tooling/formatter/*` directly; do not add alternate import paths.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1500,3 +1500,48 @@ class TestLSPFormatting:
         )
         edits = get_range_formatting(source, range_, options)
         assert len(edits) >= 0  # May or may not have edits depending on content
+
+
+class TestFormatterIdempotency:
+    """``format_tcl`` must be idempotent — ``format_tcl(format_tcl(x)) == format_tcl(x)``
+    — for every input, including structurally malformed code.  Before the
+    stabilising wrapper, an unbalanced ``{`` / ``[`` / ``"`` made the
+    reconstruction fabricate a closer that a re-parse re-mangled, growing the
+    output by a delimiter on *every* pass (catastrophic under format-on-save).
+    """
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "[\n{*}{",  # unterminated [ around an unterminated {
+            'set s "a b c"$};',  # bare $ + stray } after a quoted word
+            'puts "line1\nline2"[\n\tset x $y\n\n\n{',  # unterminated quote-led word
+            "proc p {a b} { return [expr {$a+$b}] ;",  # unbalanced proc body
+            "{",
+            "[",
+            "$",
+            "a$",
+            "\\",
+            "if {$x} { puts a } else { puts b }}",  # one extra }
+        ],
+    )
+    def test_malformed_input_is_idempotent(self, src):
+        once = format_tcl(src)
+        assert format_tcl(once) == once, f"not idempotent: {src!r} -> {once!r}"
+
+    def test_valid_code_unchanged_and_idempotent(self):
+        import random
+
+        snippets = [
+            "set x 1",
+            "proc add {a b} {\n    return [expr {$a + $b}]\n}",
+            "if {$x} {\n    puts a\n} else {\n    puts b\n}",
+            "foreach x $xs {\n    puts $x\n}",
+            'set s "hello world"',
+            "namespace eval ns {\n    variable v 0\n}",
+        ]
+        rng = random.Random(1234)
+        for _ in range(2000):
+            src = "\n".join(rng.choice(snippets) for _ in range(rng.randint(1, 5)))
+            once = format_tcl(src)
+            assert format_tcl(once) == once, f"valid not idempotent: {src!r}"

--- a/tests/test_incremental_reparse.py
+++ b/tests/test_incremental_reparse.py
@@ -362,3 +362,62 @@ class TestIncrementalProperty:
         # fire rate, is the contract.)
         assert checked > 1000
         assert matched > checked // 3
+
+
+class TestIncrementalRecovery:
+    """When the old segmentation involved error recovery (a partial command),
+    the fast path must bail — the window is re-segmented with recovery disabled
+    and cannot reproduce a recovered command, so reusing it would diverge from a
+    from-scratch pass (which re-runs recovery).  Regression for the #533 fuzz
+    finding: a partial command sitting in the *window* region (between the prefix
+    and the validation chunk) used to slip past the per-region partial checks.
+    """
+
+    def test_old_partial_command_bails(self):
+        # An unclosed leading ``{`` makes command 0 partial via recovery; the
+        # recovered ``puts`` command follows.  Any edit must take the full
+        # fallback (return None) rather than a wrong incremental result.
+        old = '{[x\n{*}"{}\n  [{*}puts hi\n]\nputs hi  {\n{*}\n }  '
+        new = '{[x\n{*}"{}\n  [{*}puts hi\n]\nputs hi  {\n{*}[\n }  '
+        old_chunks = segment_top_level_chunks(old)
+        assert any(c.is_partial for ch in old_chunks for c in ch.commands)
+        edit = infer_edit_range(old, new)
+        assert edit is not None
+        assert incremental_top_level_chunks(old, old_chunks, new, edit) is None
+
+    def test_recovery_inputs_never_diverge(self):
+        # Property check over heavily-unbalanced (recovery-triggering) sources:
+        # whenever the fast path returns non-None it must equal a full pass.
+        atoms = [
+            "{",
+            "}",
+            "[",
+            "]",
+            '"',
+            "$v",
+            "puts hi",
+            "{*}",
+            "set a 1",
+            "a b",
+            ";",
+            "\n",
+            " ",
+            "x",
+        ]
+        rng = random.Random(0x5EED)
+        partial_seen = 0
+        for _ in range(6000):
+            old = "".join(rng.choice(atoms) for _ in range(rng.randint(0, 24)))
+            i = rng.randint(0, len(old))
+            ins = rng.choice(["{", "}", "[", "x", " ", "\n", '"', ";"])
+            new = old[:i] + ins + old[i:]
+            old_chunks = segment_top_level_chunks(old)
+            if any(c.is_partial for ch in old_chunks for c in ch.commands):
+                partial_seen += 1
+            edit = infer_edit_range(old, new)
+            if edit is None:
+                continue
+            inc = incremental_top_level_chunks(old, old_chunks, new, edit)
+            if inc is not None:
+                assert_chunks_equal(inc, segment_top_level_chunks(new))
+        assert partial_seen > 50  # the corpus really does exercise recovery

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -477,9 +477,24 @@ class TestBackslashCRPositionConsistency:
             "# c \\\rd\nputs hi",
             "set x \\\r\n  y",
             "a\\\rb\\\rc\\\rd",
+            # Command substitutions: a lone-CR continuation inside [...] must not
+            # bump the line for the bytes after the substitution (issue surfaced
+            # in PR #537 review — the _parse_command scanner).
+            "[x\\\ry]\nset z 1",
+            "puts [x\\\ry] w",
+            "[a\\\rb]",
+            "[x\\\r\ny]\nset z 1",
         ):
             self._assert_no_backwards_range(source)
             self._assert_positions_match_index(source)
+
+    def test_cmdsub_lone_cr_following_token_line(self):
+        # The command after `[…\<CR>…]\n` lands on line 1, not line 2 — the lone
+        # CR inside the substitution is not a line break for the index.
+        toks = _tokens("[x\\\ry]\nset z 1", include_sep=True)
+        set_tok = next(t for t in toks if t.text == "set")
+        assert set_tok.start.line == 1
+        assert set_tok.start.character == 0
 
 
 class TestBackslashSubstCRLF:

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -407,6 +407,81 @@ class TestBackslashCRLFContinuation:
         assert "world" in comment_tok.text
 
 
+class TestBackslashCRPositionConsistency:
+    """A backslash-CR continuation must track line/column consistently.
+
+    The lexer's ``_line_starts`` index (used by ``_pos_at`` and the red CST
+    overlay) only counts ``\\n`` as a line break, while a lone ``\\<CR>``
+    continuation used to bump the incremental ``_line`` counter — so the token
+    *after* a ``\\<CR>`` reported its ``start`` one line below its own ``end``
+    (a backwards range).  A lone CR is therefore *not* a line break for the
+    index; CRLF still breaks the line (the LF is what the index records).
+    """
+
+    @staticmethod
+    def _all_tokens(source: str) -> list[Token]:
+        lexer = TclLexer(source)
+        out = []
+        while (tok := lexer.get_token()) is not None:
+            out.append(tok)
+        return out
+
+    def _assert_no_backwards_range(self, source: str) -> None:
+        for t in self._all_tokens(source):
+            assert (t.start.line, t.start.character) <= (t.end.line, t.end.character), (
+                f"backwards range on {t.type.name} {t.text!r}: "
+                f"start L{t.start.line}C{t.start.character} > end L{t.end.line}C{t.end.character}"
+            )
+
+    def _assert_positions_match_index(self, source: str) -> None:
+        # Every token's start/end must equal what the (\\n-only) line index says.
+        lexer = TclLexer(source)
+        for t in self._all_tokens(source):
+            for pos in (t.start, t.end):
+                want = lexer._pos_at(pos.offset)
+                assert (pos.line, pos.character) == (want.line, want.character), (
+                    f"{t.type.name} {t.text!r} offset {pos.offset}: "
+                    f"lexer says L{pos.line}C{pos.character}, "
+                    f"index says L{want.line}C{want.character}"
+                )
+
+    def test_lone_cr_continuation_no_backwards_range(self):
+        # The minimal #533-fuzz reproducer: backslash, CR, close-brace.
+        self._assert_no_backwards_range("\\\r}")
+        self._assert_positions_match_index("\\\r}")
+
+    def test_lone_cr_keeps_token_on_same_line(self):
+        toks = _tokens("\\\r}", include_sep=True)
+        brace = next(t for t in toks if t.text == "}")
+        # The lone CR is not a line break for the index, so the } stays on line 0.
+        assert brace.start.line == 0
+        assert brace.start.character == 2
+        assert brace.start.line == brace.end.line
+
+    def test_crlf_continuation_still_breaks_line(self):
+        # The LF half of a CRLF *is* a line break (it is in the line index).
+        toks = _tokens("a\\\r\nb", include_sep=True)
+        b = next(t for t in toks if t.text == "b")
+        assert b.start.line == 1
+        assert b.start.character == 0
+        self._assert_positions_match_index("a\\\r\nb")
+
+    def test_position_consistency_across_cr_contexts(self):
+        for source in (
+            "\\\r}",
+            "foo\\\r{bar}",
+            "x\\\ry",
+            "testCmd a \\\r{b}",
+            '"q\\\rr"',
+            "{a\\\rb}",
+            "# c \\\rd\nputs hi",
+            "set x \\\r\n  y",
+            "a\\\rb\\\rc\\\rd",
+        ):
+            self._assert_no_backwards_range(source)
+            self._assert_positions_match_index(source)
+
+
 class TestBackslashSubstCRLF:
     """backslash_subst must handle CR and CRLF line continuations."""
 

--- a/tests/test_minifier.py
+++ b/tests/test_minifier.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import random
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -1442,3 +1445,61 @@ class TestIRulesBraceSeparatorMinifier:
         result = minify_tcl(source, dialect="f5-irules")
         # set and x are bare words, so space must remain
         assert result == "set x {hello}"
+
+
+class TestMinifierBraceCompressionIdempotent:
+    """``${a}d`` must keep its braces through minification — stripping them to
+    ``$ad`` both changes semantics (variable ``a`` + literal ``d`` becomes
+    variable ``ad``) and breaks idempotency.  A ``$var`` immediately followed by
+    a word-char fragment needs ``${var}`` whether or not the word is quoted."""
+
+    def test_braced_var_followed_by_word_char_survives_reminify(self):
+        # Quoted form strips quotes but keeps the protecting braces...
+        assert minify_tcl('puts "${a}d"\n') == "puts ${a}d"
+        # ...and re-minifying the already-unquoted form must not drop them.
+        assert minify_tcl("puts ${a}d") == "puts ${a}d"
+
+    def test_unquoted_compound_var_keeps_braces(self):
+        for src in ("puts ${a}b", "set x ${v}1", "puts ${a}${b}c"):
+            once = minify_tcl(src)
+            assert minify_tcl(once) == once, f"not idempotent: {src!r} -> {once!r}"
+
+
+class TestMinifierIdempotency:
+    """``minify_tcl(minify_tcl(x)) == minify_tcl(x)`` for every input, including
+    structurally malformed code (unbalanced delimiters used to grow the output
+    unboundedly on every pass via fabricated closers)."""
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "[\n{*}{",
+            'set s "a b c"$};',
+            "proc p {a b} { return [expr {$a+$b}] ;",
+            "{",
+            "[",
+            "$",
+            'puts "unterminated',
+            "if {$x} {puts a}}",
+        ],
+    )
+    def test_malformed_input_is_idempotent(self, src):
+        once = minify_tcl(src)
+        assert minify_tcl(once) == once, f"not idempotent: {src!r} -> {once!r}"
+
+    def test_valid_code_idempotent(self):
+
+        snippets = [
+            "set x 1",
+            "proc add {a b} { return [expr {$a + $b}] }",
+            "if {$x} { puts a } else { puts b }",
+            "foreach x $xs { puts $x }",
+            'set s "hello world"',
+            "puts ${a}b",
+            "set v $a$b",
+        ]
+        rng = random.Random(99)
+        for _ in range(2000):
+            src = "\n".join(rng.choice(snippets) for _ in range(rng.randint(1, 5)))
+            once = minify_tcl(src)
+            assert minify_tcl(once) == once, f"valid not idempotent: {src!r}"

--- a/tests/test_syntax_tree.py
+++ b/tests/test_syntax_tree.py
@@ -57,6 +57,20 @@ EDGE_CASES = [
     "\n\n\n",
     "if {$x > 1} {puts hi} else {puts bye}",
     "set x 1;set y 2;set z 3",
+    # A quoted word whose entire content is a backslash-newline: the lexer emits
+    # it as a real ``ESC`` *content* fragment, not a separator, so the tree must
+    # keep it (folding it to trivia dropped the only fragment of the word).
+    '"\\\n',  # unterminated quote, content == backslash-newline
+    '"\\\n"',  # terminated quote, content == backslash-newline
+    'set x "\\\n"',
+    # Lone carriage-return continuations: the token after a ``\\<CR>`` must not
+    # land on a different line than the line index reports (it is not a break).
+    "\\\r}",
+    "foo\\\r{bar}",
+    "set x \\\r\n  y",
+    # Astral / combining unicode in words must not desync columns.
+    "set 😀 [list λ 𝕏]",
+    "puts a̲b",
 ]
 
 
@@ -80,8 +94,18 @@ def _gen(rng: random.Random) -> str:
         "1",
         "\\\n",
         "{a\nb}",
+        # Quoted-word backslash-newline content + lone-CR continuations + astral
+        # unicode — the seams a \\n-only / ASCII-only generator never reaches.
+        '"\\\n"',
+        '"\\\n',
+        "\\\r}",
+        "x\\\ry",
+        '"a\\\rb"',
+        "😀",
+        "λ𝕏",
+        "a̲b",
     ]
-    seps = [" ", "  ", "\t", ";", "\n", "\n\n", " ;", "\t;\t"]
+    seps = [" ", "  ", "\t", ";", "\n", "\n\n", " ;", "\t;\t", "\r", "\r\n", "\\\r\n", "\\\r "]
     comments = ["# c", "#", "# a b c"]
     out = []
     for _ in range(rng.randint(0, 12)):
@@ -153,6 +177,25 @@ class TestPositionEquivalence:
         seg = segments_from_document(doc, text=src)[0]
         assert src[seg.range.end.offset] == "}"
         assert seg.range.end.line == 2
+
+    @pytest.mark.parametrize("src", ['"\\\n', '"\\\n"', 'set x "\\\n"', '"a\\\rb"'])
+    def test_quoted_backslash_newline_is_a_fragment(self, src):
+        # A backslash-newline inside a quoted word is lexed as a content ESC
+        # token, never a separator — the tree must keep it as a fragment, so the
+        # red token stream still equals the lexer's non-trivia tokens.
+        doc, _ = build_document(src)
+        red = _red_fragment_tokens(SyntaxTree(doc, text=src))
+        lex = [t for t in tokenise(src, 0, 0, 0)[0] if t.type not in _TRIVIA]
+        assert red == lex, repr(src)
+
+    @pytest.mark.parametrize("src", ["\\\r}", "foo\\\r{bar}", "x\\\ry", '"q\\\rr"'])
+    def test_lone_cr_continuation_positions(self, src):
+        # After the lone-CR lexer fix, the fragment tokens still match the lexer
+        # (no token straddles two lines).
+        doc, _ = build_document(src)
+        red = _red_fragment_tokens(SyntaxTree(doc, text=src))
+        lex = [t for t in tokenise(src, 0, 0, 0)[0] if t.type not in _TRIVIA]
+        assert red == lex, repr(src)
 
 
 class TestStructuralModel:

--- a/tooling/formatter/formatter.py
+++ b/tooling/formatter/formatter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from .config import FormatterConfig
 
 # ``format_body`` is the core recursive snippet formatter.  It is part of
@@ -10,6 +12,8 @@ from .config import FormatterConfig
 # ``rangeFormatting`` provider — without the document-level normalisation
 # (final newline / line-ending rewrite) that :func:`format_tcl` applies.
 from .engine import format_body
+
+log = logging.getLogger(__name__)
 
 __all__ = ["format_body", "format_tcl"]
 
@@ -68,13 +72,30 @@ def format_tcl(source: str, config: FormatterConfig | None = None) -> str:
     # Fast path: already a fixed point (all valid Tcl, the overwhelming case).
     if _format_once(result, config) == result:
         return result
-    # Otherwise search for a fixed point a few passes out.
+    # Otherwise iterate, watching for a fixed point *or* a transform loop: track
+    # every output seen so an oscillation (the passes fight between two-or-more
+    # forms) is caught immediately instead of running to the cap, and is
+    # distinguishable from never-converging growth (each pass strictly larger,
+    # which the cap bounds).  Both fall back to the unchanged source.
+    seen = {source, result}
     current = result
     for _ in range(_STABILISE_PASSES):
         nxt = _format_once(current, config)
         if nxt == current:
-            return current
+            return current  # fixed point
+        if nxt in seen:
+            log.warning(
+                "format_tcl did not converge: the formatting passes form a "
+                "transform loop on this input; returning it unchanged."
+            )
+            return source
+        seen.add(nxt)
         current = nxt
-    # No fixed point — the input is not cleanly formattable; leave it as-is so
-    # repeated formatting is stable (returns the same *source* every time).
+    # No fixed point and no loop within the cap — the input is not cleanly
+    # formattable (delimiter imbalance the reconstruction keeps growing); leave
+    # it as-is so repeated formatting is stable (returns the same source).
+    log.debug(
+        "format_tcl did not converge within %d passes; returning input unchanged.",
+        _STABILISE_PASSES,
+    )
     return source

--- a/tooling/formatter/formatter.py
+++ b/tooling/formatter/formatter.py
@@ -13,22 +13,14 @@ from .engine import format_body
 
 __all__ = ["format_body", "format_tcl"]
 
+# Upper bound on stabilisation passes (see :func:`format_tcl`).  Valid Tcl is
+# already idempotent, so it never iterates; malformed input either reaches a
+# fixed point within a couple of passes or is declared un-formattable.
+_STABILISE_PASSES = 8
 
-def format_tcl(source: str, config: FormatterConfig | None = None) -> str:
-    """Format a Tcl source string.
 
-    Pure function: source in, formatted source out.
-
-    Args:
-        source: The Tcl source code to format.
-        config: Formatting options. Uses F5 iRules defaults if None.
-
-    Returns:
-        The formatted source code.
-    """
-    if config is None:
-        config = FormatterConfig()
-
+def _format_once(source: str, config: FormatterConfig) -> str:
+    """Format *source* a single time (document-level normalisation included)."""
     result = format_body(source, config, indent_level=0)
 
     # Trim trailing whitespace per line
@@ -45,3 +37,44 @@ def format_tcl(source: str, config: FormatterConfig | None = None) -> str:
         result = result.replace("\n", config.line_ending)
 
     return result
+
+
+def format_tcl(source: str, config: FormatterConfig | None = None) -> str:
+    """Format a Tcl source string.
+
+    Pure, and **idempotent**: ``format_tcl(format_tcl(x)) == format_tcl(x)`` for
+    every input.  Valid Tcl reaches its formatted form in one pass, so the
+    confirming pass returns it immediately.  Structurally malformed input (an
+    unbalanced ``{`` / ``[`` / ``"`` the reconstruction cannot round-trip) can
+    format non-idempotently — the lexer swallows an unterminated region to EOF
+    and the reconstruction fabricates a closer, which a re-parse re-mangles.  So
+    iterate to a fixed point, and if none exists within :data:`_STABILISE_PASSES`
+    (the reconstruction keeps changing it — formerly an *unbounded* grow-by-one-
+    delimiter-per-save), return the input unchanged rather than mangle or grow
+    un-formattable code on every save.
+
+    Args:
+        source: The Tcl source code to format.
+        config: Formatting options. Uses F5 iRules defaults if None.
+
+    Returns:
+        The formatted source code (a fixed point of the formatter), or *source*
+        unchanged when it cannot be formatted to a stable result.
+    """
+    if config is None:
+        config = FormatterConfig()
+
+    result = _format_once(source, config)
+    # Fast path: already a fixed point (all valid Tcl, the overwhelming case).
+    if _format_once(result, config) == result:
+        return result
+    # Otherwise search for a fixed point a few passes out.
+    current = result
+    for _ in range(_STABILISE_PASSES):
+        nxt = _format_once(current, config)
+        if nxt == current:
+            return current
+        current = nxt
+    # No fixed point — the input is not cleanly formattable; leave it as-is so
+    # repeated formatting is stable (returns the same *source* every time).
+    return source

--- a/tooling/minifier/minifier.py
+++ b/tooling/minifier/minifier.py
@@ -20,6 +20,7 @@ semantic equivalence while producing the smallest reasonable output by:
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Literal, overload
@@ -36,6 +37,8 @@ from shared.naming import split_array_name
 from shared.suffix_array import build_lcp_array, build_suffix_array
 from shared.text_edits import apply_edits, name_generator
 from shared.tokens import Token, TokenType
+
+log = logging.getLogger(__name__)
 
 # Commands whose presence in a proc body makes variable renaming unsafe
 # because they reference variables by name as strings at runtime.
@@ -357,12 +360,29 @@ def _minify_body_stable(source: str, *, dialect: str | None = None) -> str:
     result = _minify_body(source, dialect=dialect)
     if _minify_body(result, dialect=dialect) == result:
         return result
+    # Iterate, watching for a fixed point *or* a transform loop: tracking every
+    # output seen stops on an oscillation (the passes fight between two-or-more
+    # forms) immediately instead of waiting for the cap, and distinguishes it
+    # from never-converging growth (each pass strictly larger, which the cap
+    # bounds).  Both fall back to the unchanged source.
+    seen = {source, result}
     current = result
     for _ in range(_STABILISE_PASSES):
         nxt = _minify_body(current, dialect=dialect)
         if nxt == current:
-            return current
+            return current  # fixed point
+        if nxt in seen:
+            log.warning(
+                "minify did not converge: the minification passes form a "
+                "transform loop on this input; returning it unchanged."
+            )
+            return source
+        seen.add(nxt)
         current = nxt
+    log.debug(
+        "minify did not converge within %d passes; returning input unchanged.",
+        _STABILISE_PASSES,
+    )
     return source
 
 

--- a/tooling/minifier/minifier.py
+++ b/tooling/minifier/minifier.py
@@ -333,9 +333,37 @@ def minify_tcl(
     resolved_dialect = _resolve_dialect(dialect)
     if compact_names:
         renamed_source, symbol_map = _compact_names(source, isolated=isolated, seed_map=seed_map)
-        minified = _minify_body(renamed_source, dialect=resolved_dialect)
+        minified = _minify_body_stable(renamed_source, dialect=resolved_dialect)
         return minified, symbol_map
-    return _minify_body(source, dialect=resolved_dialect)
+    return _minify_body_stable(source, dialect=resolved_dialect)
+
+
+# Upper bound on stabilisation passes (see :func:`_minify_body_stable`).
+_STABILISE_PASSES = 8
+
+
+def _minify_body_stable(source: str, *, dialect: str | None = None) -> str:
+    """Minify *source* to a **fixed point**, so minification is idempotent.
+
+    Valid Tcl minifies idempotently in one pass, so the confirming pass returns
+    immediately.  Structurally malformed input (an unbalanced ``{`` / ``[`` /
+    ``"``) can minify non-idempotently — the lexer swallows an unterminated
+    region to EOF and reconstruction fabricates a closer that a re-parse
+    re-mangles, which used to grow the output by a delimiter on every pass.
+    Iterate to a fixed point; if none exists within :data:`_STABILISE_PASSES`,
+    the input is not cleanly minifiable, so return it unchanged rather than
+    mangle or unboundedly grow it.
+    """
+    result = _minify_body(source, dialect=dialect)
+    if _minify_body(result, dialect=dialect) == result:
+        return result
+    current = result
+    for _ in range(_STABILISE_PASSES):
+        nxt = _minify_body(current, dialect=dialect)
+        if nxt == current:
+            return current
+        current = nxt
+    return source
 
 
 def unminify_error(
@@ -1925,10 +1953,17 @@ def _reconstruct_arg(arg: _Arg, *, dialect: str | None = None) -> str:
     tokens = arg.tokens
     for idx, t in enumerate(tokens):
         next_t = tokens[idx + 1] if idx + 1 < len(tokens) else None
+        # Pass the following token whether or not the word is quoted: the
+        # fragments of a compound word abut with no separator either way, so a
+        # ``$var`` immediately followed by a word-char fragment needs ``${var}``
+        # braces to stop Tcl merging them into one longer name — ``${a}d`` must
+        # not minify to ``$ad`` (a different variable).  Restricting this to
+        # quoted words made re-minifying an unquoted ``${a}d`` drop the braces,
+        # which both changed semantics and broke idempotency.
         parts.append(
             _reconstruct_raw(
                 t,
-                next_tok=next_t if arg.is_quoted else None,
+                next_tok=next_t,
                 dialect=dialect,
             )
         )


### PR DESCRIPTION
## Summary

Fix a critical bug in the lexer's line/column position tracking for backslash-CR (`\<CR>`) continuations. A lone carriage return (old-Mac line ending) was incorrectly treated as a line break in the incremental `line`/`col` counter, while the `\n`-only line-start index (`_line_starts`) did not record it. This caused tokens after a `\<CR>` continuation to report `start` positions one line below their `end` positions — backwards ranges that violated position invariants.

The fix ensures that **only `\n` is treated as a line break for position tracking**. A lone `\<CR>` continuation now advances the column counter instead of the line counter, keeping the incremental counter in sync with the line-start index. CRLF pairs still correctly advance the line (on the `\n` half).

### Changes

**Lexer (`compiler/parsing/lexer.py`)**
- `_parse_brace()`: Fixed CR handling in backslash escapes to advance column for lone CR, line for CRLF
- `_parse_string()`: Same fix for quoted-word backslash escapes
- `_parse_comment()`: Same fix for comment backslash continuations

**Formatter (`tooling/formatter/formatter.py`)**
- Extracted `_format_once()` helper for single formatting pass
- Wrapped `format_tcl()` with stabilisation loop to guarantee idempotency — iterates to a fixed point (up to 8 passes) for malformed input that reconstructs non-idempotently, returning input unchanged if no fixed point exists

**Minifier (`tooling/minifier/minifier.py`)**
- Added `_minify_body_stable()` wrapper with same stabilisation strategy as formatter
- Fixed `_reconstruct_raw()` call to pass `next_tok` for both quoted and unquoted words — a `$var` immediately followed by a word-char fragment needs `${var}` braces regardless of quoting to prevent semantic changes and preserve idempotency

**Incremental reparser (`compiler/parsing/incremental.py`)**
- Added early bail-out when old segmentation involved error recovery (partial commands) — the window is re-segmented with recovery disabled, so it cannot reproduce recovered commands, and a from-scratch pass would re-run recovery

**Syntax tree builder (`compiler/parsing/syntax/build.py`)**
- Removed incorrect folding of backslash-newline tokens in quoted words — the lexer emits `\<newline>` as an `ESC` token (real content) only in quoted words, not as a separator, so it must be kept as a fragment

**Tests**
- Added `TestBackslashCRPositionConsistency` with comprehensive position invariant checks
- Added `TestMinifierBraceCompressionIdempotent` and `TestMinifierIdempotency` for minifier stability
- Added `TestFormatterIdempotency` for formatter stability
- Added `TestIncrementalRecovery` for recovery-aware incremental reparsing
- Extended `test_syntax_tree.py` corpus with CR continuations, astral/combining unicode, and quoted-word backslash-newline content

**Documentation**
- Updated `docs/design/compiler/lexing-segmentation.md` with line-tracking convention
- Updated `docs/design/contracts/formatter-engine.md` with idempotency contract
- Updated `docs/design/compiler/syntax-tree.md` with extended test corpus notes

## Validation

- All new tests pass (position consistency, idempotency, recovery handling, syntax tree equivalence)
- Existing test suite passes
- Fuzz-finding #533 (backslash-CR edge case) now handled correctly

https://claude.ai/code/session_01UHwp5mXCaKoz8m4RP2b5Ar