### PR TITLE
docs: correct rust-rewrite codegen framing and retire stale TCL_LSP_RUST_ANALYSER

### DIFF
--- a/docs/design/rust/current-architecture.md
+++ b/docs/design/rust/current-architecture.md
@@ -97,7 +97,18 @@ retires.
 | Subsystem | Env var | Python fallback module | Notes |
 |---|---|---|---|
 | Background signature scan | `TCL_LSP_RUST_SIGNATURE_SCAN` | `core/analysis/signature_scan.py` | flipped in C40-default-on |
-| Single-pass analyser | `TCL_LSP_RUST_ANALYSER` | `core/analysis/_analyser/__init__.py` | flipped in C41-default-on |
+
+The **single-pass analyser has no env-var gate** any more. The Python
+override it was meant to flip (`_merge_rust_with_python_supplement` in
+`core/analysis/_analyser/__init__.py`) was deleted at #241 when that
+module shrank to a ~47-LOC passthrough, so there is nothing left to
+flip — `TCL_LSP_RUST_ANALYSER` does not exist in the tree. The native
+`tcl-lsp-server` calls `Analyser::analyse()` directly
+(`publish_analyser_diagnostics`), so analyser precision fixes are
+already user-facing on the Rust path. Only four `TCL_LSP_RUST_*` gates
+are live in the Python tree today: `…_SIGNATURE_SCAN` (above) plus
+`…_OPTIMISER`, `…_INTERPROC`, and `…_GVN` (default-off shims, next
+section).
 
 ## Default-off Rust shims
 

--- a/docs/kcs/kcs-qa-rust-shim-env-vars.md
+++ b/docs/kcs/kcs-qa-rust-shim-env-vars.md
@@ -25,11 +25,21 @@ the Python implementation if (a) the binding isn't installed or
 (b) the Rust path raises an exception.
 
 The current default for each shim is given in the tables below.
-Default-on shims (`TCL_LSP_RUST_SIGNATURE_SCAN`,
-`TCL_LSP_RUST_ANALYSER`) are **not** opt-in experiments — they ship
-as the canonical path, and the env var is the opt-out knob you set
-to `0` when bisecting a regression or running the Python side as
-the differential oracle.
+The one default-on shim (`TCL_LSP_RUST_SIGNATURE_SCAN`) is **not** an
+opt-in experiment — it ships as the canonical path, and the env var
+is the opt-out knob you set to `0` when bisecting a regression or
+running the Python side as the differential oracle.
+
+Note that there is **no `TCL_LSP_RUST_ANALYSER` env var**. The
+single-pass analyser had a dispatch shim once, but it (and the var)
+were removed at #241 when `core/analysis/_analyser/__init__.py` was
+simplified to a thin passthrough, so there is no Python override left
+to gate. The Rust analyser still exists in
+`rust/tcl-compiler/src/analyser/`, and the native `tcl-lsp-server`
+calls `Analyser::analyse()` directly — so on the Rust LSP path the
+analyser is already authoritative with no opt-out knob. The pure-Python
+`analyse()` mixin chain remains the path the Python zipapp server runs
+until the `S*` server flip retires it.
 
 Each env var is recognised in the same vocabulary: truthy values
 (`1`, `true`, `yes`, `on`, `y`, `t` — case-insensitive) opt the
@@ -52,7 +62,6 @@ knob until the Python implementation retires entirely.
 | Env var                          | Subsystem                 | Module wired                                   | Flipped in |
 |----------------------------------|---------------------------|------------------------------------------------|------------|
 | `TCL_LSP_RUST_SIGNATURE_SCAN`    | Background signature scan | `core/analysis/signature_scan.py`              | C40-default-on |
-| `TCL_LSP_RUST_ANALYSER`          | Single-pass Tcl analyser  | `core/analysis/_analyser/__init__.py`          | C41-default-on |
 
 ### Default-off (opt in via `=1`)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -223,7 +223,7 @@ parity gaps or Python is still primary), 🔴 not started.
 | Python subsystem | LOC | Target Rust crate | Status | Notes |
 |---|---|---|---|---|
 | `core/parsing/` (lexer, segmenter, expr sub-lexer, backslash) | 3.8K | `tcl-lexer`, `tcl-compiler::segmenter` | ✅ | Foundation; PyO3-exposed and differentially fuzzed. |
-| `core/compiler/` (IR, CFG, SSA, lowering, optimiser passes) | 58.6K | `tcl-compiler` | 🟡 | Most passes ported (lowering, SSA, GVN, SCCP, var_escape, inline_uplevel, side-effects, taint, type_infer). Remaining: bytecode **codegen** completeness, a few optimiser passes, full IR-disasm parity. |
+| `core/compiler/` (IR, CFG, SSA, lowering, optimiser passes) | 58.6K | `tcl-compiler` | 🟡 | Most passes ported (lowering, SSA, GVN, SCCP, var_escape, inline_uplevel, side-effects, taint, type_infer). Remaining: a few optimiser passes and full IR-disasm parity. **Bytecode** codegen (`tcl-compiler::codegen`, ~10.2K LOC) is now larger than the Python bytecode codegen (~7.1K LOC, the non-`wasm` half of `core/compiler/codegen`) and carries no `todo!`/`unimplemented!` stubs — verify completeness against the `bytecode-compare` gate rather than assuming it lags. The **`codegen/wasm/` emitter (~14K LOC in Python) is entirely unported** (zero Rust files) — that, not bytecode, is the open codegen block. |
 | `core/commands/` (command-spec registry data) | 110.8K | `tcl-registry` | 🟡 | Registry infra + ~2070 spec files ported; behavioural-trait stamping and dialect-shadow parity tracked under "Command-spec tracking". Long tail of per-spec fields. |
 | `core/analysis/` (analyser, scope, var-refs, signature_scan, taint hints) | 17K | `tcl-compiler::analyser`, `::signature_scan` | 🟡 | `signature_scan` ported (C40); analyser core in progress (C41). Scope/var-ref/diagnostic providers partially landed. |
 | `core/minifier/` | 3.4K | `tcl-lsp-core::minify` | ✅ | Aggressive + compact tiers, unminify, registry-driven skip lists. |
@@ -268,9 +268,16 @@ Crates still to stand up, roughly in dependency order:
 10. **`tcl-fuzz`** — differential fuzzer harness (retires Python last).
 
 Codegen note: bytecode **codegen** lives in `tcl-compiler::codegen`
-today but is incomplete relative to `core/compiler/codegen`. Finishing
-it is a prerequisite for `tcl-vm` running real scripts and for the
-`bytecode-compare` parity gate against tclsh.
+(~10.2K LOC) and is the more mature half — it already exceeds the
+Python bytecode codegen (~7.1K LOC, the non-`wasm` part of
+`core/compiler/codegen`) in size and carries no `todo!` /
+`unimplemented!` / `unsupported` markers. Treat its remaining gaps as
+parity items to confirm against the `bytecode-compare` gate against
+tclsh, not as a from-scratch build. The genuinely unported block is the
+**WASM emitter**: `core/compiler/codegen/wasm/` is ~14K LOC of Python
+with **no Rust counterpart at all**. Bytecode codegen plus `tcl-vm`
+unblock the analyser/debugger/iRule-test in-process runtime; the WASM
+emitter port is what feeds the Zig out-of-process runtime.
 
 ### PyO3 public-API surface (terminal state)
 


### PR DESCRIPTION
Audited the rust-rewrite tracking docs against the actual codebase and fixed two points where the docs had drifted from reality.

## 1. Codegen framing

The docs said the bytecode codegen in `tcl-compiler::codegen` "is incomplete relative to `core/compiler/codegen`". Verification against the tree:

- Rust bytecode codegen: **~10.2K LOC**, **zero** `todo!`/`unimplemented!`/`unsupported` markers.
- Python codegen is ~21.2K LOC total, but **~14K of that is `codegen/wasm/`** — leaving only ~7.1K of bytecode codegen.
- So the Rust bytecode codegen is already *larger* than its Python counterpart, while the **WASM emitter is entirely unported (zero Rust files)**.

Reworded the inventory-matrix row and the codegen note so the open codegen block is correctly identified as the WASM emitter, not bytecode.

## 2. `TCL_LSP_RUST_ANALYSER` no longer exists

The KCS env-var note and the architecture doc's default-on table both listed `TCL_LSP_RUST_ANALYSER` as a live default-on gate. Grepping the tree, **it is read nowhere** — the Python override was deleted at #241 and the native server calls `Analyser::analyse()` directly. Only four `TCL_LSP_RUST_*` gates are actually live:

- `TCL_LSP_RUST_SIGNATURE_SCAN` — default-on (`signature_scan.py:107`)
- `TCL_LSP_RUST_OPTIMISER` / `_INTERPROC` / `_GVN` — default-off

Removed the stale row from both tables and added a short note explaining the analyser's no-gate state.

## Scope

Docs only — no code changes. The chunk-log history rows in `rust-rewrite.md` are left untouched (they already record the #241 deletion as audit notes); only the forward-facing summary tables were stale.

Files:
- `docs/rust-rewrite.md`
- `docs/design/rust/current-architecture.md`
- `docs/kcs/kcs-qa-rust-shim-env-vars.md`

https://claude.ai/code/session_019ELWKEQNmi4rgdLqNqczNE

---
_Generated by [Claude Code](https://claude.ai/code/session_019ELWKEQNmi4rgdLqNqczNE)_