### PR TITLE
docs: add Rust workspace review (correctness, performance, memory)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -69,6 +69,11 @@ ownership matrices.
   parse-once, single CST spine, positions from the tree, demand-driven
   cascade/invalidation, and MVCC concurrency. Companion to
   current-architecture.md; the staged route is in review-findings.md.
+- [rust/feasibility.md](rust/feasibility.md) — evidence-based readiness
+  sweep testing each target goal for hard blockers vs. work-items.
+  Verdict: every goal reachable, no hard blockers, the expensive
+  foundations already in place. Carries the determinism prerequisite
+  and the unlock ordering.
 
 ## Runtime internals
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -59,6 +59,11 @@ ownership matrices.
   intended `tcl-lsp-core` / `tcl-lsp-server` / `tcl-lsp-py`
   boundaries. Read this before adding a new Rust crate, hook, or
   registry fact.
+- [rust/review-findings.md](rust/review-findings.md) —
+  point-in-time review of the Rust workspace ordered by correctness,
+  then performance (time to first semantic tokens), then memory.
+  File:line-anchored findings plus a prioritised roadmap. Snapshot at
+  #542 / #543.
 
 ## Runtime internals
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -64,6 +64,11 @@ ownership matrices.
   then performance (time to first semantic tokens), then memory.
   File:line-anchored findings plus a prioritised roadmap. Snapshot at
   #542 / #543.
+- [rust/target-architecture.md](rust/target-architecture.md) —
+  forward-looking target the workspace is converging on: zero-copy,
+  parse-once, single CST spine, positions from the tree, demand-driven
+  cascade/invalidation, and MVCC concurrency. Companion to
+  current-architecture.md; the staged route is in review-findings.md.
 
 ## Runtime internals
 

--- a/docs/design/rust/feasibility.md
+++ b/docs/design/rust/feasibility.md
@@ -1,0 +1,151 @@
+# Feasibility — can we reach the target from here?
+
+> Companion to [`review-findings.md`](review-findings.md) (current
+> state) and [`target-architecture.md`](target-architecture.md)
+> (destination). Synthesises a five-thread deep sweep of the Rust
+> workspace at #548, each thread testing one architectural goal for
+> **hard blockers vs. work-items**, with file:line evidence.
+>
+> **Verdict: yes — every goal is reachable, and there are no hard
+> architectural blockers.** The foundations that are usually the
+> expensive part of this kind of rewrite are already in place.
+
+## Headline
+
+Across all six goals — zero-copy, single tree, incremental reuse,
+per-item cascade/invalidation, MVCC, and embedded sub-language
+injection — the sweep found **no hard architectural blocker**. The
+remaining work is additive and sequenceable. Several of the hardest
+structural prerequisites are *already done*, which is why the target is
+within reach rather than a rewrite.
+
+## Correction to the earlier review — there is one parse tree, not two
+
+The review's headline that "two parse representations coexist" is
+**wrong**, and the sweep (plus direct verification) corrects it:
+`segment_commands_local` (`segmenter.rs:408`) builds the red-green CST
+and derives `SegmentedCommand` from it; the token-loop segmenter was
+retired in #538 (CST-PORT) and survives **only** as a frozen oracle in
+`tests/differential_segment.rs`. So "`SegmentedCommand` as a view over
+the CST" is already shipped, and the differential harness is a
+regression oracle, not a live dual-parser sync.
+
+The underlying *re-derivation* concern is still real, just different:
+the tree is rebuilt from scratch on every call (no incremental reuse),
+`descend_*` re-lexes inner text rather than navigating
+(`descend.rs:108`), ~40 ad-hoc sub-word `Lexer::new(...)` scans bypass
+the tree, and ~29 `LineIndex::new` builds re-index per feature. That is
+"one tree, rebuilt and re-scanned repeatedly" — not "two parsers." The
+two existing docs are corrected accordingly.
+
+## What is already done (the expensive foundations)
+
+| Foundation | Evidence |
+|---|---|
+| Single CST spine — `SegmentedCommand` is a view; one parser | `segmenter.rs:408-424`; oracle only in `differential_segment.rs` |
+| Position-independent green tree with **relative** offsets (the hardest rowan prerequisite); absolute positions lazy in red | `green.rs:1-34`, `697-728`; `red.rs:139-155` |
+| Span-only tokens (16-byte `Copy`, no lifetime) | `tcl-lexer/.../tokens.rs:128-153` |
+| Substitution isolated behind one `Cow`-returning fn | `tcl-lexer/.../substitution.rs:38` |
+| IR already half-defers substitution (`value_needs_backsubst`) | `ir.rs:177`; consumed `codegen/statements.rs:100` |
+| Pure analysis entry points; no global mutable state on the analysis path; `unsafe` forbidden; no clock/rand | `lowering/mod.rs:1979`, `optimiser/manager.rs:37`, `analyser/state.rs:292` |
+| Server already snapshot-shaped: snapshot-then-drop, `spawn_blocking` workers, immutable-by-clone analysis, no lock held across `.await` | `tcl-lsp-server/src/lib.rs` (did_open/did_change drop guards before await) |
+| Per-item data model (procs/classes keyed by qname; `FunctionUnit` isolation; per-proc shape inference) + a real call graph | `compilation_unit.rs:160-264`; `param_traits.rs:67-119`; `interprocedural.rs:766` |
+| Differential corpus gating segmentation / codegen / fold | `tests/differential_*.rs` |
+
+## Per-goal readiness
+
+| Goal | Verdict | What's needed |
+|---|---|---|
+| **Single parse tree** | ✅ **Done** | — (retired token loop in #538) |
+| **Zero-copy** | Reachable with a value model | A `Text { Span \| Owned }` (or rope) threaded through `segmenter::texts`, `argv_texts`, `ExprNode.*.text`, `Assign*.value` — fields that today eagerly `String` but mostly hold source slices. Substitution/concat/`::`-normalise are the genuine `Owned` cases. Green CST must use `Arc<str>`/relative spans, not absolute `Span`, to keep reuse. |
+| **Positions from the tree** | Reachable (consolidation) | Route the ~29 `LineIndex::new` sites through one index beside the CST; lands the C1 UTF-16 fix once. |
+| **Incremental reuse** | Reachable with work | `Rc`/`Arc` (or interned) green children so surviving subtrees reuse by pointer (today `children: Vec<GreenElement>` owned, `green.rs:320`); a reparse driver (edit-range → bounded re-lex → splice); descent reuse instead of re-lex (`descend.rs:108`). Foundation (position-independence, relative offsets) already done. |
+| **Per-item cascade** | Reachable with substantial refactor | Per-item diagnostic buckets (today flat `Vec`, `types.rs:467`); use the existing call graph to scope invalidation; an incremental driver (none today — server evicts the whole result per keystroke, `lib.rs:1278`). Depends on the determinism fix below. |
+| **MVCC** | Reachable with refactor | Add `version` to `DocumentState` (params already carry it, ignored); `Arc`-share `AnalysisResult` (it's `Clone`/immutable, never `Arc`-wrapped — deep-cloned per request); version-gate published results; `publish_diagnostics(.., Some(version))`. Additive — the server is already shaped like MVCC minus the version field. |
+| **Sub-language injection** | Reachable with work (heaviest) | New `ArgRole::{Regexp,FormatString,Glob,…}` (enum is `Body`/`Expr`-only today, `arg_role.rs:11`); a foreign-node `SyntaxKind` (Tcl-only `Document`/`Command`/`Word` today, `green.rs:51`); a `descend` that dispatches by role (hardwired to Tcl `build_document` today, `descend.rs:108`); net-new regexp/format/glob/BIG-IP sub-grammar parsers. Substrate (red-green CST, `with_parts` anchoring, registry role-dispatch) is correct. |
+
+## The cross-cutting prerequisite: determinism
+
+The cascade and the differential tests both need deterministic,
+order-stable output. The pipeline is pure (no global mutable state on
+the analysis path, no clock/rand; `unsafe` forbidden) **except**:
+**diagnostics are emitted in `HashMap`-iteration order and never
+sorted** before the wire (`analyser/state.rs:1875` drives emission over
+`cu.procedures: HashMap`; the comment there claiming "insertion order"
+is factually wrong for a `HashMap`; the boundary `lift_analyser_diagnostics`
+preserves order without sorting). Under the default `RandomState`,
+identical inputs do not produce byte-identical diagnostic ordering
+across processes.
+
+This is a "stabilise output ordering" task, not a blocker — and the
+optimiser already does it right (`optimiser/helpers/select.rs:37`).
+**Fix:** sort `result.diagnostics` by `(span.start, span.end, code,
+severity)` before return; optionally switch the hot iteration maps
+(`Module::procedures`, `cfg.blocks`, `def_use.chains`, `sccp.values`,
+`ssa.blocks`) to `BTreeMap`. Cheap and high-leverage — it both unlocks
+memoisation and hardens the existing differential suite. (Two minor
+notes: `expr_cache` is a process-global `OnceLock<Mutex<…>>` but is off
+the analysis path and content-deterministic; `document_links` reads
+`$HOME` but has a pure variant — lift it into query inputs.)
+
+## Unlock ordering (what gates what)
+
+Dependency-ordered so the cheap, de-risking wins land first:
+
+1. **Determinism** — sort diagnostics. Gates the cascade and hardens
+   differential tests. Cheapest; do first.
+2. **Version + `Arc`-sharing** (MVCC core) — fixes C2, removes the
+   per-request deep clones. Cheap, high user-visible value.
+3. **Positions service + C1** — one index beside the tree; UTF-16 once.
+4. **`Text` value model** — zero-copy; also informs green-tree text
+   storage, so sequence it before the incremental work.
+5. **Incremental green-tree reuse** — `Rc`/`Arc` children + reparse
+   driver + descent reuse. The sustained-latency win.
+6. **Per-item cascade** — per-item buckets + call-graph-scoped
+   invalidation. The biggest refactor; rides on (1) and (5).
+7. **Injection** — `descend` dispatch + sub-grammar parsers. Heaviest
+   net-new; last. Registry data population (#548) runs alongside, as it
+   supplies the dispatch typing.
+
+## Risks / watch-items
+
+- **`AnalyserSnapshot` is dormant *and* a weak foundation** — it's
+  prefix-linear (not per-item) and deep-clones the whole `AnalysisResult`
+  per checkpoint (`snapshot.rs:97`), and it only covers the cheap
+  segment-walk, not the dominant CFG/SSA/interproc tail. Do **not**
+  build the cascade on it as-is; the per-item model is the right shape.
+- **Whole-module lowering transforms** (`inline_uplevel_passthrough`,
+  `specialise_factories`, `compilation_unit.rs:212-221`) splice across
+  items, so a single proc's CFG isn't trivially re-lowerable in
+  isolation — the per-item boundary needs care (re-lower the proc plus
+  its uplevel-inlined callees).
+- **`analyse` rebuilds the registry 2–3× per call** (`state.rs:359`,
+  `:453`, `diagnostics.rs:1809`) — make it a static input early; it's a
+  free win that also matters under memoisation.
+- **Green-tree zero-copy tension** — green must hold `Arc<str>` +
+  relative range, not a document-absolute `Span`, or it loses the
+  structural-sharing that makes reuse cheap.
+- **Tie-break residue** — even the optimiser's stable sort falls back to
+  `HashMap` order on exact `(start, priority, length)` ties
+  (`select.rs:37`); add a total tie-break when stabilising.
+
+## Bottom line
+
+There is a clear way to achieve every goal. No hard blockers; the
+costly structural groundwork (single CST, position-independent green
+tree with relative offsets, span-only tokens, isolated substitution,
+pure analysis, snapshot-shaped server, per-item data + call graph) is
+already laid. Sequence the cheap unlocks — determinism, MVCC
+version/`Arc`, the positions service — first: they de-risk the rest and
+deliver C1, C2, and immediate perf wins on their own. The large refactor
+(per-item cascade) and the heaviest net-new work (sub-language
+injection) come afterwards, on foundations that already exist.
+
+## Related
+
+- [`review-findings.md`](review-findings.md) — current-state findings
+  (now corrected on the single-tree point).
+- [`target-architecture.md`](target-architecture.md) — the destination.
+- [`rust-rewrite-registries.md`](../../../rust-rewrite-registries.md) —
+  per-entry registry parity (#548), supplying the injection dispatch
+  data.

--- a/docs/design/rust/review-findings.md
+++ b/docs/design/rust/review-findings.md
@@ -1,0 +1,357 @@
+# Rust workspace review — correctness, performance, memory
+
+> Point-in-time review of the Rust workspace at commit `1abc0d35`
+> (#542), reconciled against `origin/rust` #543. Every finding below
+> was verified against the source at review time; file:line anchors
+> are given so each can be re-checked or retired as the code moves.
+>
+> **Priority order (set by the maintainer):** correctness and
+> precision first, performance second — with **time to first
+> semantic tokens** called out as the headline latency metric — and
+> memory a distant third. The sections are ordered to match.
+
+## Verdict
+
+The workspace is disciplined: `unsafe` is forbidden workspace-wide,
+clippy pedantic is on, there are ~2,400 inline tests, the async layer
+holds no lock across `.await`, and the crate graph is a clean acyclic
+layering. The differential-parity strategy against Python and `tclsh`
+is the right way to protect a port.
+
+The issues are not rot. They are a small number of structural choices
+plus two concrete precision defects:
+
+1. **LSP positions are emitted in byte columns, not UTF-16** — a
+   confirmed spec violation that produces wrong ranges (and can
+   corrupt files via rename) on any non-ASCII line.
+2. **No document-version guard** — stale analyses and diagnostics can
+   overwrite fresh ones out of order.
+3. **The differential safety net is not enforced in CI** — the very
+   net that would catch a regression silently skips on the hosted
+   runner.
+4. **Nothing is shared or cached across the pipeline** — the full
+   analysis pipeline and the command registry are rebuilt from
+   scratch on every keystroke; this is the dominant performance cost.
+
+## Correctness and precision
+
+### C1 — Positions use byte columns, not UTF-16 (confirmed bug)
+
+The LSP specification defines `Position.character` as a UTF-16
+code-unit offset unless the server negotiates another encoding.
+
+- `build_server_capabilities()` (`rust/tcl-lsp-server/src/lib.rs:2825`)
+  never sets `position_encoding`, so the UTF-16 default applies.
+- Every span→position conversion calls `LineIndex::position_at`,
+  which returns a **byte** column
+  (`rust/tcl-lexer/src/line_index.rs:92`). There are ~50 such call
+  sites across `references`, `rename`, `folding`, `code_lens`,
+  `inlay_hints`, `semantic_tokens`, `linked_editing_range`,
+  `formatting`, and the server's cross-document range lifting.
+- `LineIndex::position_at_utf16` — the LSP-correct variant, fully
+  implemented and unit-tested (`line_index.rs:134`) — has **zero**
+  callers.
+- Semantic tokens compounds it: token length is `text.chars().count()`
+  (`rust/tcl-lsp-core/src/semantic_tokens.rs:379`), a Unicode scalar
+  count, which is neither bytes nor UTF-16 units (astral characters
+  are two UTF-16 units).
+
+**Impact.** On any line containing a multi-byte character (UTF-8
+string literals, accented or CJK comments, iRules log strings, Tcl 9
+Unicode identifiers), every column and length to its right is wrong:
+highlight drift, mis-placed hovers and diagnostics, wrong
+go-to-definition and reference targets, and rename edits applied at
+the wrong columns. Latent today only because most Tcl is ASCII.
+
+**Fix.** Route all span→`Position` conversions through a UTF-16
+column computation (the primitive already exists) and measure token
+length in UTF-16 units. Add a non-ASCII regression fixture. No
+differential test covers this today.
+
+### C2 — No document-version guard (confirmed latent race)
+
+`DocumentState` is `{ text, dialect }` only —  no version
+(`rust/tcl-lsp-server/src/lib.rs:98`). `did_change` evicts the cached
+analysis (`:1278`) then awaits a fresh full analysis (`:1279`);
+`publish_diagnostics(uri, diags, None)` passes `None` for the version
+(`:1112`). If two `did_change`s for one URI are serviced
+concurrently, the **older** analysis can finish last and re-insert its
+stale `AnalysisResult` (`:1111`) and publish stale diagnostics after
+the newer one, with no version check to reject it. The eviction at
+`:1278` prevents serving stale data to interim requests but does not
+sequence the workers.
+
+**Fix.** Stamp each document with its LSP version, capture a per-URI
+generation counter before `spawn_blocking`, re-check it before the
+insert and publish, and pass the version to `publish_diagnostics`.
+
+### C3 — Inline handlers do not contain a parser panic (robustness)
+
+Most handlers offload to `spawn_blocking`, which catches a panic and
+returns a JSON-RPC error. Eight handlers run CPU work **inline** with
+no catch: `folding_range` (`:1331`), `document_symbol` (`:1342`),
+`semantic_tokens_full` / `_delta` / `_range` (`:1851` / `:1876` /
+`:1941`), `document_link` (`:2021`), and `formatting` /
+`range_formatting` (`:2240` / `:2269`).
+
+The input-facing hot paths are otherwise genuinely hardened: the
+lexer clamps span ends so unterminated `{`, `[`, `"`, `${`, `$arr(`
+never push `end` past `source.len()`
+(`rust/tcl-lexer/src/lexer.rs:787`, `:967`), uses `saturating_sub` for
+bracket underflow, and builds no reversed spans; recovery slices are
+bounds-checked. So the real residual is narrow:
+
+- the 8 inline handlers should move to `spawn_blocking` for
+  defence-in-depth;
+- two CST-builder `pop().unwrap()`s on the non-test path are the
+  right fuzz target (`rust/tcl-compiler/src/parsing/syntax/build.rs:174`
+  and `:178`);
+- `LineIndex::new` asserts on sources over 4 GiB
+  (`line_index.rs:60`).
+
+### C4 — Comment classification is line-leading-only (precision limit)
+
+`push_comment_tokens` (`semantic_tokens.rs:310`) treats `#` as a
+comment only when it is the first non-whitespace character on a line.
+Real Tcl also has `;# …` inline comments and `#` at any command
+position; those are not highlighted. It mirrors Python's
+`_collect_comments`, so it is correct by the project's parity
+definition, but it diverges from true Tcl semantics.
+
+### C5 — One deliberate semantic divergence (accepted, tracked)
+
+A quoted word whose entire content is a line continuation
+(`"\<newline>"`) is dropped by the Rust segmenter, where Tcl and
+`build.py` keep it as an empty-ish word. Labelled `DELIBERATE
+DIVERGENCE … tracked as SYNC-JUN08-1`
+(`rust/tcl-compiler/src/parsing/syntax/build.rs:240`) and pinned by a
+test. Worth a tracking issue so it is not forgotten when the rebase
+settles.
+
+### The safety net, and its enforcement gap
+
+The differential design is excellent: three independent oracles — live
+Python `core.compiler.codegen`, real `tclsh9.0` folds, and a *frozen*
+pre-port segmenter snapshot — with tiered exact / semantic / divergent
+classification and accepted divergences pinned as tests.
+
+**But every oracle-backed harness degrades to a silent skip when its
+oracle is absent, and the hosted CI `rust` job installs none of them**
+(`.github/workflows/ci.yml:68` runs only `cargo test --workspace`; no
+project pip-install, no `tclsh`). In CI:
+
+- `differential_codegen` → `import core.compiler.codegen` fails →
+  skips (`rust/tcl-compiler/tests/differential_codegen.rs:138`);
+- `differential_fold` → no `tclsh9.0` → skips
+  (`rust/tcl-registry/tests/differential_fold.rs:245`);
+- `differential_segment` corpus → no `tmp/tcl*` trees → skips; only
+  its 38 hand-written edge cases run.
+
+So the parity guarantee rests on a developer running `make prep-pr`
+in a fully-provisioned environment — green CI proves little about
+Python/Tcl parity. And even when run, these harnesses compare
+disassembly, fold values, and segmentation; **none exercises LSP
+position encoding (C1) or server concurrency (C2)**, which is exactly
+why the two highest-impact correctness bugs sit undetected.
+
+The acknowledged gaps elsewhere are overwhelmingly false-negative
+biased (`conservative` / decline-to-act), which is the right bias for
+a correctness-first posture: the port errs toward silence, not wrong
+answers. CRLF and lone-CR handling is correct and regression-tested
+(`line_index.rs:34`), having previously produced a backwards range
+that was found and fixed (#537).
+
+### Correctness priority
+
+| # | Severity | Finding | Primary evidence |
+|---|---|---|---|
+| Net | Posture | Differential oracles not provisioned in CI → skip, not fail | `ci.yml:68`; skip paths in the three `tests/differential_*.rs` |
+| C1 | Confirmed bug | Byte columns / scalar lengths, not UTF-16 | `line_index.rs:92` vs `:134`; `lib.rs:2825`; `semantic_tokens.rs:379` |
+| C2 | Confirmed latent race | No document-version guard | `lib.rs:98`, `:1111`, `:1112` |
+| C3 | Robustness | Inline handlers do not contain panics; 2 fuzz targets | `lib.rs:1331…2269`; `build.rs:174`, `:178` |
+| C5 | Accepted divergence | Quoted `"\<newline>"` dropped | `build.rs:240` |
+| C4 | Precision limit | Line-leading-only comment scan | `semantic_tokens.rs:310` |
+
+## Performance — time to first semantic tokens first
+
+Good news up front: semantic tokens do **not** depend on the analyser
+— `core_semantic_tokens::full(text, dialect, registry)` only segments
+and classifies (`semantic_tokens.rs:162`), so the heavy
+lower→CFG→SSA→passes pipeline is off the TTFST path. The cost is
+everything around it.
+
+### Cold-open critical path
+
+1. `initialized` awaits a workspace scan that fully analyses up to
+   2,000 files (`WORKSPACE_SCAN_FILE_CAP = 2000`,
+   `rust/tcl-lsp-server/src/lib.rs:2734`; awaited at `:1214`) — a
+   cold-start CPU storm.
+2. `did_open` runs a full analysis for the opened file (`:1234`) —
+   needed for diagnostics, not for tokens.
+3. The first `semanticTokens` request runs **inline** on an executor
+   thread (`:1851`), **cold-builds the ~560-spec registry** on first
+   `registry_for_dialect`, then segments the whole document.
+
+### TTFST levers (highest value first)
+
+- **P1 — Pre-warm the token cache at `did_open`.** Tokens are computed
+  lazily on first request and nothing pre-computes them
+  (`semantic_tokens_cache` is only filled by the token handlers;
+  `did_change` / `did_close` only evict). Compute tokens on the
+  blocking pool during `did_open` (and on a debounced `did_change`)
+  and cache them, so the first request is a cache hit. Biggest direct
+  win.
+- **P2 — Make the `range` provider actually range-bounded.** `range`
+  calls `collect_entries` over the whole document and then `retain`s
+  to the viewport (`semantic_tokens.rs:179`), doing no less work than
+  `full` — defeating the editor's viewport fast-path. The segmenter
+  already accepts an offset; segment only from the range's start.
+- **P3 — Share / lazy-static the registry.** `Analyser::analyse`
+  rebuilds the entire registry inside every call
+  (`rust/tcl-compiler/src/analyser/state.rs:359`), ignoring the
+  server's per-dialect cache (`lib.rs:1065`). Build once into a
+  process-wide `OnceLock` and thread `&CommandRegistry` into
+  `analyse(...)`. Removes registry construction from every hot path.
+- **P4 — `spawn_blocking` the token handler and de-prioritise the
+  startup scan.** Running tokenisation inline blocks an executor
+  thread under the startup CPU storm; the 2,000-file scan is pure
+  contention for TTFST (tokens need no cross-file index). Make the
+  scan lazy or chunked.
+
+### Sustained performance
+
+- **Full recompute every keystroke; no incremental layer.** Each
+  `did_change` re-runs the whole pipeline via `Analyser::new()
+  .analyse(...)`; the `AnalyserSnapshot` chunked-reanalysis machinery
+  is compiler-internal and unused by the server. A query / incremental
+  engine (`salsa`, or reuse of unchanged green subtrees from the
+  existing CST) is the highest-leverage sustained change.
+- **The pipeline is rebuilt 2–3× per document.** The analyser builds
+  one `CompilationUnit`
+  (`rust/tcl-compiler/src/analyser/diagnostics.rs:1813`), the
+  optimiser another (`rust/tcl-compiler/src/optimiser/manager.rs:51`),
+  iRules a third (`rust/tcl-compiler/src/irules_checks.rs:464`); taint
+  runs 2–3× (`rust/tcl-compiler/src/compilation_unit.rs:110` then
+  `:317`). Build it once and share `&CompilationUnit`.
+- **No parallelism.** `rayon` is absent; the per-proc
+  `FunctionUnit::build` loop (`compilation_unit.rs:225`) and the
+  optimiser pass loops are serial despite being independent. `par_iter`
+  on the proc-build loop is a large win on big files.
+- **No debounce.** Fast typing queues N full analyses; add a debounce
+  with cancel-previous (ties to C2).
+- **Coarse locking.** Read-mostly maps (`analyses`, `workspace_index`,
+  `dialect_registries`) are `Mutex` (reads serialise), and
+  `workspace_index` is deep-cloned into the worker on every completion
+  (`lib.rs:1371`); `WorkspaceIndex::remove_document` does three full
+  `Vec::retain` per keystroke
+  (`rust/tcl-lsp-core/src/workspace_index.rs:153`). Use `RwLock` +
+  `Arc<WorkspaceIndex>` and key the index by URI.
+
+## Memory (distant third)
+
+Recorded for completeness; pursue only where it reduces allocation
+latency on the hot path.
+
+- The green CST stores two owned `String`s per token and shares
+  nothing (`#[derive(Clone)]`, no `Rc` / hash-consing) —
+  `rust/tcl-compiler/src/parsing/syntax/green.rs:139`. `rowan` exists
+  precisely for this.
+- No string interner; CFG / SSA key on owned `String` + SipHash
+  (`rust/tcl-compiler/src/cfg.rs:104`, `:179`;
+  `rust/tcl-compiler/src/ssa.rs:103`). Swapping to `FxHashMap` (and
+  eventually `Symbol(u32)`) is a near-zero-risk latency win, which is
+  why it earns a mention here rather than purely as footprint.
+- `Analyser::snapshot()` deep-clones the whole `AnalysisResult` per
+  top-level command (`rust/tcl-compiler/src/analyser/snapshot.rs:97`).
+
+Already good and worth preserving: the codegen `LiteralTable` /
+`LocalVarTable` interners, the `Arc<ExprNode>` parse cache, the cached
+green `full_width`, and the cheap `Copy` red-layer views.
+
+## Crate split and external-crate leverage
+
+The crate graph (lexer → registry → compiler → core → {server, py} →
+alias) is a clean acyclic layering, and the "pure crates plus one
+binding crate" rule is genuinely upheld. Two observations:
+
+- **`tcl-compiler` is a 100k-line monolith** spanning parsing, IR,
+  CFG, SSA, the dataflow engines, the analyser, the optimiser, and
+  codegen. As the port stabilises it wants splitting along its
+  existing seams (`tcl-syntax`, `tcl-ir`, `tcl-analysis`,
+  `tcl-codegen`), which also unlocks compile parallelism and
+  per-layer PyO3 wrapping.
+- **Mature ecosystem crates are absent where the workspace hand-rolls
+  their domain** (verified: zero in every manifest): `rowan`
+  (red-green tree), `salsa` (incremental recompute), `petgraph` (CFG
+  algorithms), a string interner, `rustc-hash` / `ahash` (the 555
+  `HashMap`s use SipHash), and `ropey` (document text is `String`
+  with full re-clone per change). `line-index` / `text-size` are also
+  hand-rolled, but those are small and low priority. The CST is a
+  faithful red-green split but a heavier realisation than `rowan`
+  because it omits `rowan`'s structural sharing — adopting `rowan`,
+  or adding `Rc` + hash-consing and source-range token text, is the
+  right convergence.
+
+## Separation of concerns and PyO3 layering
+
+The shape is right for per-layer PyO3 — pure crates stay pyo3-free,
+and `tcl-lsp-core` uses its own protocol-independent types so the
+algorithm has one home. The friction is the conversion strategy:
+
+- **Two parallel hand-written conversion layers** are maintained
+  against the same core types: the server's 16 `lift_*` functions
+  (core → `lsp_types`) and the bindings' cascade of `*_to_dict`
+  functions building a nested `PyDict`
+  (`rust/tcl-lsp-py/src/analyser.rs:70`). The latter is hand-rolled
+  serialisation; deriving `serde::Serialize` on the core types and
+  converting via `pythonize` would delete most of it.
+- **The PyO3 surface lags the server.** The bindings expose only
+  folding and document symbols among the feature providers
+  (`rust/tcl-lsp-py/src/features/mod.rs:15`); the native server
+  implements ~43 methods.
+- **The GIL is held across all Rust compute** — `allow_threads` has
+  zero uses, so multi-threaded Python callers cannot run Rust
+  concurrently. Wrap the pure compute in `py.allow_threads(...)`.
+
+The native server runs the Rust analyser ungated (the
+`TCL_LSP_RUST_ANALYSER` env-var framing was retired in #543), so
+CI-enforced parity matters more, not less. Bytecode codegen is more
+complete than the tracking docs implied (no `todo!` stubs); the
+genuinely unported block is the WASM emitter, which is out of scope
+for the LSP path.
+
+## Prioritised roadmap
+
+**Correctness — do first**
+
+1. Provision the differential oracles in CI and make the harnesses
+   fail-not-skip; add LSP-range and server-concurrency differential
+   cases (the meta-fix).
+2. Fix the UTF-16 position encoding (C1).
+3. Add the document-version guard (C2).
+4. Contain panics in the 8 inline handlers and fuzz the two
+   CST-builder `pop().unwrap()`s (C3).
+
+**Performance — TTFST first, then sustained**
+
+5. Pre-warm and cache tokens at `did_open` (P1); make `range`
+   range-bounded (P2); share / lazy-static the registry (P3);
+   `spawn_blocking` tokens plus a lazy workspace scan (P4).
+6. Build one `CompilationUnit` per document; debounce with
+   cancellation; `FxHashMap` in CFG / SSA.
+7. Incremental layer (`salsa` or CST subtree reuse) and `rayon`
+   per-proc — the large sustained wins.
+
+**Memory — opportunistic**
+
+8. Interner, `Arc` / copy-on-write snapshots, and rowan-style CST
+   sharing, pursued where they cut allocation latency.
+
+## Related
+
+- [`current-architecture.md`](current-architecture.md) — crate graph,
+  ownership rules, and authoritative paths.
+- [`docs/rust-rewrite.md`](../../rust-rewrite.md) — chunking strategy
+  and chunk log.
+- [`docs/kcs/kcs-qa-rust-shim-env-vars.md`](../../kcs/kcs-qa-rust-shim-env-vars.md)
+  — Rust shim env-var reference.

--- a/docs/design/rust/review-findings.md
+++ b/docs/design/rust/review-findings.md
@@ -32,6 +32,10 @@ plus two concrete precision defects:
 4. **Nothing is shared or cached across the pipeline** — the full
    analysis pipeline and the command registry are rebuilt from
    scratch on every keystroke; this is the dominant performance cost.
+5. **Two parse representations coexist** — a token-loop segmenter and
+   the red-green CST, kept in agreement by hand. The layers link by
+   re-deriving from source rather than sharing one parsed spine. See
+   [Cross-layer integration](#cross-layer-integration-and-data-duplication).
 
 ## Correctness and precision
 
@@ -329,6 +333,129 @@ complete than the tracking docs implied (no `todo!` stubs); the
 genuinely unported block is the WASM emitter, which is out of scope
 for the LSP path.
 
+## Cross-layer integration and data duplication
+
+Several findings above share one root: how the layers link. The test
+applied here is the maintainer's — a derived index beside the parse
+tree (a line-break table) is acceptable; a second copy of the
+*structure* is not.
+
+### The shared spine (what is integrated)
+
+Two links are shared across every layer, and they are the right ones:
+one tokeniser (`tcl_lexer::Lexer` — nothing re-implements lexing) and
+one position primitive (`Span { start, end }`, `Copy`, threaded
+through tokens, IR, CFG, and diagnostics so any node points back into
+the source without copying). A line index co-located with the tree is
+already the pattern in the red layer (`SyntaxTree` holds `text` +
+`line_starts`, `red.rs:57`) — that is the acceptable shape. The rest
+of this section is where the code departs from it.
+
+### The break — two parse representations
+
+The lexer feeds two different structured representations, and
+downstream code is split between them:
+
+- **Token-loop segmenter** → `Vec<SegmentedCommand>` (`segmenter.rs`).
+  The production workhorse: lowering (`lowering/mod.rs:592`, `:607`,
+  `:1455`, …), semantic tokens, and the analyser's top-level walk —
+  **135** `segment_commands*` call sites.
+- **Red-green CST** → `SyntaxTree` (`parsing/syntax/green.rs`,
+  `red.rs`), ported in #533 as "the representation the whole pipeline
+  is meant to ride on," with its first production consumers landing in
+  #542: the analyser's `descend_token` / `descend_command`
+  (`analyser/commands.rs:868`, `:929`, `:984`).
+
+The two are kept in agreement **by hand**: `build.rs:240` carries a
+`DELIBERATE DIVERGENCE` comment pinning the CST builder to "the
+token-loop segmenter … this rebase's byte-identity oracle," and
+`tests/differential_segment.rs` exists solely to assert the CST
+reproduces the segmenter. The SYNC-JUN08 line-continuation case is a
+drift that already occurred. The two are even used together in one
+path: `descend_token` re-lexes and builds a *fresh* child `SyntaxTree`
+(`descend.rs:108`), then segments it — so one command is segmenter
+output at the outer level and a CST at the inner level, sharing
+nothing. This is the separate parse tree the standard rules out.
+
+### Layers link by re-derivation, not by sharing
+
+With no single parsed structure threaded by reference, each consumer
+re-parses from the raw `&str`: **135** `segment_commands*` calls (top
+level plus recursive re-segmentation into every body / sub / arm),
+**29** independent `LineIndex::new(source)` builds, and **34**
+`build_line_starts` / `line_starts` sites. A single `did_change` →
+diagnostics → first-tokens cycle therefore lexes and segments the
+document many times. The acceptable case is one index beside the tree;
+the reality is ~29 of them rebuilt per feature, plus a second whole
+parse.
+
+### Data materialised outside intentional caching
+
+| Data | Where it is materialised | Verdict |
+|---|---|---|
+| Parse structure | `SegmentedCommand` (135 sites) **and** the red-green CST | ✗ a second parse tree |
+| Source text | server `String`; green `raw` *and* `text` per token; red `SyntaxTree.text`; owned sub-strings per `segment_commands(sub)` | ✗ multiple full copies |
+| Line index | 29 `LineIndex::new` + 34 `line_starts` builds | one beside the CST is fine; 63 re-derivations are not |
+| Names | token → green `text` + `raw` → IR `argv_texts` → CFG / SSA `String` keys → analyser scopes → workspace index → LSP items | ✗ copied at every layer; no interner |
+| Registry | rebuilt inside every `analyse()` (`state.rs:359`) **and** cached per dialect | ✗ base specs duplicated per dialect |
+| CompilationUnit / taint | built 2–3× (analyser, optimiser, irules) | ✗ redundant recompute |
+| AnalysisResult | per-URI cache intentional; per-handler clones are not | mixed |
+| `Span` positions | one `Copy` type threaded everywhere | ✓ the model to follow |
+
+### Consequences
+
+- **Correctness.** Two parse representations can disagree — semantic
+  tokens, the analyser, and lowering can classify the same span
+  differently if they drift (SYNC-JUN08 is an instance). The UTF-16
+  bug (C1) is amplified: positions resolve at 29 independent sites, so
+  the fix is 29 places rather than one index beside one tree.
+- **Performance / TTFST.** Re-segmentation is the per-keystroke cost; a
+  shared tree with subtree reuse turns "re-parse N times" into "reuse
+  unchanged subtrees." Neither representation is reused across edits.
+- **Maintenance.** Every syntactic decision lives in two parsers plus
+  the differential harness that keeps them aligned — triple the
+  surface for one behaviour.
+
+### Convergence — one parse spine, without a big-bang rewrite
+
+The `segment_commands*` API is a single chokepoint: all 135 callers go
+through it, so its implementation can be swapped from token-loop to
+CST-backed without touching the call sites. That is what makes this
+incremental.
+
+1. **CST → view adapter.** Implement
+   `segment_commands_from_cst(&SyntaxTree)` yielding the existing
+   `SegmentedCommand` shape. Re-point `differential_segment.rs` to
+   assert the view matches the live token loop — the harness becomes
+   the migration's safety net instead of a permanent agreement tax.
+2. **Route segmentation through the CST.** Change the
+   `segment_commands_with_*` bodies to build a `SyntaxTree` once and
+   return the view. The 135 callers are unchanged. Keep the token loop
+   behind a flag as the differential oracle until parity bakes on the
+   corpus (the project's default-off-until-baked discipline).
+3. **Build the CST once per document; navigate, don't re-lex.** Lower,
+   analyse, and tokenise from one `SyntaxTree`; make `descend_*`
+   navigate the existing tree rather than building fresh child trees
+   (`descend.rs:108`). This removes the recursive re-segmentation and
+   the per-descent re-lex.
+4. **One index beside the CST.** Expose the tree's `line_starts` as the
+   single position resolver and route the 29 `LineIndex::new` sites
+   through it. Land the C1 UTF-16 fix here, once, on the shared index.
+5. **Retire the second parser.** Once parity has baked, delete the
+   token-loop `segment_commands_local` and the frozen oracle; the
+   differential-segment harness retires with them.
+6. **(Separable) interned names + one `CompilationUnit`.** Intern
+   identifiers to `Symbol(u32)` sourced from the CST's tokens, and
+   build one `CompilationUnit` per document threaded by reference,
+   folding in the earlier performance items.
+
+Stages 1–2 are the load-bearing change (the CST already proves it can
+reproduce the segmenter byte-for-byte); 3–5 are cleanup once the view
+is the producer; 6 is independent. Each stage is shippable on its own
+and guarded by the existing differential corpus. The failure mode to
+avoid is stalling half-converted, where both representations live
+indefinitely — the most expensive state, because you pay for both.
+
 ## Prioritised roadmap
 
 **Correctness — do first**
@@ -351,9 +478,19 @@ for the LSP path.
 7. Incremental layer (`salsa` or CST subtree reuse) and `rayon`
    per-proc — the large sustained wins.
 
+**Architecture — the structural root (underpins the above)**
+
+8. Converge on one parse spine: make `SegmentedCommand` a view over
+   the red-green CST, build the CST once per document, and retire the
+   token-loop parser and its differential-agreement harness. This is
+   the root fix behind the re-derivation cost (performance), the
+   two-tree drift risk (correctness), and the duplication (memory).
+   Staged, non-big-bang plan in
+   [Cross-layer integration](#cross-layer-integration-and-data-duplication).
+
 **Memory — opportunistic**
 
-8. Interner, `Arc` / copy-on-write snapshots, and rowan-style CST
+9. Interner, `Arc` / copy-on-write snapshots, and rowan-style CST
    sharing, pursued where they cut allocation latency.
 
 ## Related

--- a/docs/design/rust/review-findings.md
+++ b/docs/design/rust/review-findings.md
@@ -204,8 +204,17 @@ everything around it.
 - **P2 — Make the `range` provider actually range-bounded.** `range`
   calls `collect_entries` over the whole document and then `retain`s
   to the viewport (`semantic_tokens.rs:179`), doing no less work than
-  `full` — defeating the editor's viewport fast-path. The segmenter
-  already accepts an offset; segment only from the range's start.
+  `full` — defeating the editor's viewport fast-path. Narrowing it is
+  subtler than it looks: `segment_commands_with_offset_and_config`
+  only relocates offsets for the text it is handed, so lexing from the
+  viewport's start would drop the enclosing-delimiter context and
+  misclassify tokens inside a multi-line construct — the second line
+  of `set x {line1\nline2}` would be read as code, not string content.
+  A correct narrowing must lex from a safe enclosing synchronisation
+  point (the start of the enclosing top-level command), not the raw
+  viewport offset; until that context-aware slicing exists, the
+  full-tokenise-then-filter path is the correct fallback, so P1
+  (pre-warming) is the safer TTFST win.
 - **P3 — Share / lazy-static the registry.** `Analyser::analyse`
   rebuilds the entire registry inside every call
   (`rust/tcl-compiler/src/analyser/state.rs:359`), ignoring the

--- a/docs/design/rust/review-findings.md
+++ b/docs/design/rust/review-findings.md
@@ -32,9 +32,11 @@ plus two concrete precision defects:
 4. **Nothing is shared or cached across the pipeline** — the full
    analysis pipeline and the command registry are rebuilt from
    scratch on every keystroke; this is the dominant performance cost.
-5. **Two parse representations coexist** — a token-loop segmenter and
-   the red-green CST, kept in agreement by hand. The layers link by
-   re-deriving from source rather than sharing one parsed spine. See
+5. **One parse tree, but rebuilt every time** — the CST is the single
+   parse representation (the segmenter became a view over it in #538);
+   the cost is that it is rebuilt from scratch on each call with no
+   incremental reuse, descent re-lexes, and ~40 ad-hoc sub-word scans
+   plus the line index re-scan the source per feature. See
    [Cross-layer integration](#cross-layer-integration-and-data-duplication).
 
 ## Correctness and precision
@@ -351,49 +353,48 @@ already the pattern in the red layer (`SyntaxTree` holds `text` +
 `line_starts`, `red.rs:57`) — that is the acceptable shape. The rest
 of this section is where the code departs from it.
 
-### The break — two parse representations
+### The break — one tree, rebuilt and re-scanned every time
 
-The lexer feeds two different structured representations, and
-downstream code is split between them:
+> **Correction.** An earlier draft of this section claimed two parse
+> representations (a token-loop segmenter *and* the CST). That is wrong:
+> the token loop was retired in #538 (CST-PORT). `segment_commands_local`
+> (`segmenter.rs:408`) builds the CST and derives `SegmentedCommand`
+> from it; the old loop survives only as the frozen oracle in
+> `tests/differential_segment.rs`. There is one parse tree.
 
-- **Token-loop segmenter** → `Vec<SegmentedCommand>` (`segmenter.rs`).
-  The production workhorse: lowering (`lowering/mod.rs:592`, `:607`,
-  `:1455`, …), semantic tokens, and the analyser's top-level walk —
-  **135** `segment_commands*` call sites.
-- **Red-green CST** → `SyntaxTree` (`parsing/syntax/green.rs`,
-  `red.rs`), ported in #533 as "the representation the whole pipeline
-  is meant to ride on," with its first production consumers landing in
-  #542: the analyser's `descend_token` / `descend_command`
-  (`analyser/commands.rs:868`, `:929`, `:984`).
+So the structure is right; the cost is that nothing is *reused*:
 
-The two are kept in agreement **by hand**: `build.rs:240` carries a
-`DELIBERATE DIVERGENCE` comment pinning the CST builder to "the
-token-loop segmenter … this rebase's byte-identity oracle," and
-`tests/differential_segment.rs` exists solely to assert the CST
-reproduces the segmenter. The SYNC-JUN08 line-continuation case is a
-drift that already occurred. The two are even used together in one
-path: `descend_token` re-lexes and builds a *fresh* child `SyntaxTree`
-(`descend.rs:108`), then segments it — so one command is segmenter
-output at the outer level and a CST at the inner level, sharing
-nothing. This is the separate parse tree the standard rules out.
+- **The tree is build-once-throwaway.** Every `segment_commands*` call
+  (135 sites: lowering `lowering/mod.rs:592`, `:607`, semantic tokens,
+  the analyser walk) re-lexes and rebuilds the whole region from source;
+  no subtree survives an edit (green children are owned `Vec`, no
+  `Rc`/`Arc`, no reparse driver — `green.rs:320`).
+- **Descent re-lexes instead of navigating.** `descend_token` builds a
+  *fresh* child `SyntaxTree` from a token's inner text
+  (`descend.rs:108`) rather than reading structure already in the tree,
+  so nested bodies are parsed twice.
+- **~40 ad-hoc sub-word scans bypass the tree** — hand-rolled
+  `Lexer::new(...)` loops re-segment word / command slices outside the
+  chokepoint (`var_refs.rs`, `lowering/structured.rs`, optimiser
+  helpers, …). These are the embedded-sub-language scanners (below), not
+  a second command parser.
 
 ### Layers link by re-derivation, not by sharing
 
-With no single parsed structure threaded by reference, each consumer
-re-parses from the raw `&str`: **135** `segment_commands*` calls (top
-level plus recursive re-segmentation into every body / sub / arm),
-**29** independent `LineIndex::new(source)` builds, and **34**
-`build_line_starts` / `line_starts` sites. A single `did_change` →
-diagnostics → first-tokens cycle therefore lexes and segments the
-document many times. The acceptable case is one index beside the tree;
-the reality is ~29 of them rebuilt per feature, plus a second whole
-parse.
+With the tree rebuilt rather than reused and no single shared index,
+each consumer re-derives from the raw `&str`: **135** `segment_commands*`
+calls (each rebuilding the tree, plus recursive re-segmentation into
+every body / sub / arm), **29** independent `LineIndex::new(source)`
+builds, and **34** `build_line_starts` / `line_starts` sites. A single
+`did_change` → diagnostics → first-tokens cycle therefore lexes and
+rebuilds the document many times. The acceptable case is one tree and
+one index reused; the reality is rebuild-from-scratch on every call.
 
 ### Data materialised outside intentional caching
 
 | Data | Where it is materialised | Verdict |
 |---|---|---|
-| Parse structure | `SegmentedCommand` (135 sites) **and** the red-green CST | ✗ a second parse tree |
+| Parse structure | one CST, but rebuilt per `segment_commands*` call (135) with no subtree reuse; descent re-lexes (`descend.rs:108`) | ✗ rebuilt, not reused |
 | Source text | server `String`; green `raw` *and* `text` per token; red `SyntaxTree.text`; owned sub-strings per `segment_commands(sub)` | ✗ multiple full copies |
 | Line index | 29 `LineIndex::new` + 34 `line_starts` builds | one beside the CST is fine; 63 re-derivations are not |
 | Names | token → green `text` + `raw` → IR `argv_texts` → CFG / SSA `String` keys → analyser scopes → workspace index → LSP items | ✗ copied at every layer; no interner |
@@ -404,57 +405,46 @@ parse.
 
 ### Consequences
 
-- **Correctness.** Two parse representations can disagree — semantic
-  tokens, the analyser, and lowering can classify the same span
-  differently if they drift (SYNC-JUN08 is an instance). The UTF-16
-  bug (C1) is amplified: positions resolve at 29 independent sites, so
-  the fix is 29 places rather than one index beside one tree.
-- **Performance / TTFST.** Re-segmentation is the per-keystroke cost; a
-  shared tree with subtree reuse turns "re-parse N times" into "reuse
-  unchanged subtrees." Neither representation is reused across edits.
-- **Maintenance.** Every syntactic decision lives in two parsers plus
-  the differential harness that keeps them aligned — triple the
-  surface for one behaviour.
+- **Correctness.** The UTF-16 bug (C1) is amplified by re-derivation:
+  positions resolve at ~29 independent `LineIndex` sites, so the fix is
+  29 places rather than one index beside one tree.
+- **Performance / TTFST.** Rebuilding the tree (and re-indexing) is the
+  per-keystroke cost; a shared tree with subtree reuse turns "rebuild N
+  times" into "reuse unchanged subtrees." Nothing is reused across edits
+  today.
+- **Maintenance.** The ~40 ad-hoc sub-word scanners re-implement slicing
+  the CST already does, so a syntactic rule can live in several places —
+  the consolidation surface for the sub-language work below.
 
-### Convergence — one parse spine, without a big-bang rewrite
+### Convergence — from "one tree, rebuilt" to "one tree, reused"
 
-The `segment_commands*` API is a single chokepoint: all 135 callers go
-through it, so its implementation can be swapped from token-loop to
-CST-backed without touching the call sites. That is what makes this
-incremental.
+The single-tree migration is already done (the segmenter is a CST view,
+#538). What remains is making that tree *shared and reused* rather than
+rebuilt — and the foundation is favourable: the green tree is
+position-independent with relative offsets, with absolute positions
+resolved lazily in the red layer (`green.rs:1-34`, `red.rs:139-155`).
 
-1. **CST → view adapter.** Implement
-   `segment_commands_from_cst(&SyntaxTree)` yielding the existing
-   `SegmentedCommand` shape. Re-point `differential_segment.rs` to
-   assert the view matches the live token loop — the harness becomes
-   the migration's safety net instead of a permanent agreement tax.
-2. **Route segmentation through the CST.** Change the
-   `segment_commands_with_*` bodies to build a `SyntaxTree` once and
-   return the view. The 135 callers are unchanged. Keep the token loop
-   behind a flag as the differential oracle until parity bakes on the
-   corpus (the project's default-off-until-baked discipline).
-3. **Build the CST once per document; navigate, don't re-lex.** Lower,
-   analyse, and tokenise from one `SyntaxTree`; make `descend_*`
-   navigate the existing tree rather than building fresh child trees
-   (`descend.rs:108`). This removes the recursive re-segmentation and
-   the per-descent re-lex.
-4. **One index beside the CST.** Expose the tree's `line_starts` as the
-   single position resolver and route the 29 `LineIndex::new` sites
-   through it. Land the C1 UTF-16 fix here, once, on the shared index.
-5. **Retire the second parser.** Once parity has baked, delete the
-   token-loop `segment_commands_local` and the frozen oracle; the
-   differential-segment harness retires with them.
+1. **Build the CST once per document and reuse it.** Thread one
+   `SyntaxTree` into lowering, the analyser, and semantic tokens instead
+   of each calling `segment_commands*` (which rebuilds).
+2. **`Rc`/`Arc` (or intern) green children + a reparse driver** so an
+   edit re-lexes a bounded region and splices reused subtrees rather
+   than rebuilding the document (children are owned `Vec` today,
+   `green.rs:320`).
+3. **Navigate on descent, don't re-lex** — make `descend_*` read
+   structure already in the tree instead of building fresh child trees
+   (`descend.rs:108`).
+4. **One index beside the CST.** Route the ~29 `LineIndex::new` sites
+   through the tree's `line_starts`; land the C1 UTF-16 fix here, once.
+5. **Fold the ~40 ad-hoc sub-word scanners onto the tree** — they become
+   CST views / typed sub-trees (the embedded-sub-language work below).
 6. **(Separable) interned names + one `CompilationUnit`.** Intern
-   identifiers to `Symbol(u32)` sourced from the CST's tokens, and
-   build one `CompilationUnit` per document threaded by reference,
-   folding in the earlier performance items.
+   identifiers to `Symbol(u32)` from the CST tokens; build one
+   `CompilationUnit` per document threaded by reference.
 
-Stages 1–2 are the load-bearing change (the CST already proves it can
-reproduce the segmenter byte-for-byte); 3–5 are cleanup once the view
-is the producer; 6 is independent. Each stage is shippable on its own
-and guarded by the existing differential corpus. The failure mode to
-avoid is stalling half-converted, where both representations live
-indefinitely — the most expensive state, because you pay for both.
+Each is shippable on its own and guarded by the existing differential
+corpus. See [`feasibility.md`](feasibility.md) for the full readiness
+assessment, the determinism prerequisite, and the unlock ordering.
 
 ## Prioritised roadmap
 

--- a/docs/design/rust/target-architecture.md
+++ b/docs/design/rust/target-architecture.md
@@ -1,0 +1,254 @@
+# Target architecture — zero-copy, single-parse, incremental, MVCC
+
+> Forward-looking companion to
+> [`current-architecture.md`](current-architecture.md). Records the
+> architectural destination the Rust workspace is converging on, set by
+> the maintainer:
+>
+> - aggressively **zero-copy** — borrow from one source buffer, do not
+>   re-materialise text;
+> - **parse to tokens once** where the parse is statically knowable;
+> - build **single trees** — one CST, no second parse representation;
+> - derive positional data (cursor ↔ byte ↔ line/column) from the
+>   **tokens underlying the CST**, not from per-feature indices;
+> - let edits **cascade**: changing an input automatically invalidates
+>   the portions of derived data that depend on it and rebuilds them on
+>   demand;
+> - use **MVCC** where concurrent reads and writes need a consistent
+>   view.
+>
+> The current-state critique and the staged route from here are in
+> [`review-findings.md`](review-findings.md); this doc is the
+> destination, not the diff.
+
+## The one tension, stated up front
+
+Two of the goals pull against each other, and the resolution is a
+deliberate decision, not a free lunch:
+
+- **Aggressive zero-copy** wants tree nodes to hold a `Span` into a
+  single `Arc<str>` source and slice text on demand (`&source[span]`),
+  copying nothing.
+- **Structural sharing across edits / files** (rowan's trick: identical
+  subtrees share one allocation, so an edit reuses untouched subtrees
+  verbatim) wants green leaves to **own** their text (interned
+  `SmolStr`), because a position-independent node cannot borrow from a
+  position-bearing buffer.
+
+rust-analyzer chose owned text to get sharing. The maintainer's stated
+priority is zero-copy, which points the other way. This is decision
+**D1** below; the rest of the architecture is the same either way.
+
+## Layered model
+
+### Layer 0 — Versioned, immutable source
+
+Each document version owns its bytes once: `Source { version: u64,
+text: Arc<str> }`. This is the only allocation of the source for that
+version and the unit of MVCC — versions coexist; a reader holds an
+`Arc` to the version it started against. Today the server stores a
+mutable `String` per URI with no version (`DocumentState`,
+`lib.rs:98`); this replaces it.
+
+### Layer 1 — Tokens, once
+
+One lex pass per version produces a structure-of-arrays token stream:
+`Tokens { source: Arc<str>, kinds: Vec<TokenKind>, spans: Vec<Span> }`.
+A token's text is `&source[span.as_range()]` — **zero copy**. This
+removes the per-token `text: String` + `raw: String` the green tree
+stores today (`green.rs:139`) and the 135 ad-hoc re-segmentations
+(`segment_commands*`): everything downstream consumes this one stream.
+Incrementally, only the edited region re-lexes.
+
+### Layer 2 — One CST, everything else a view
+
+The red-green CST is built from the token stream and is the **single**
+parse representation. The token-loop segmenter is retired;
+`SegmentedCommand`, the IR item-tree, and the lowering input become
+**views / projections** over the CST (iterators yielding command and
+word spans), not separate owned parses. This closes the two-parse-tree
+gap (`segmenter.rs` vs `parsing/syntax/`) and the hand-maintained
+agreement harness (`differential_segment.rs`).
+
+Green stores structure; the text-storage choice is **D1**. Red anchors
+absolute positions lazily and carries the **one** line index beside the
+tree (`SyntaxTree` already holds `line_starts`, `red.rs:57` — that
+co-located index is the maintainer's explicitly-acceptable pattern).
+
+### Layer 3 — Positions come from the tree
+
+A single position service lives with the CST and is the only place
+byte ↔ (line, column) and the UTF-16 conversion happen:
+
+- cursor `(line, UTF-16 column)` → byte offset via the one
+  `line_starts` index;
+- byte offset → token / node via binary search over token spans (or
+  red-tree descent).
+
+This replaces the 29 independent `LineIndex::new` builds and lands the
+C1 UTF-16 fix **once**, on the shared index, instead of at ~50 byte-
+column call sites.
+
+### Layer 4 — Demand-driven incremental graph (the cascade)
+
+Derived data is expressed as **memoised queries** over inputs, with
+dependencies tracked so a change invalidates exactly its dependents and
+recomputes them lazily, only when next demanded:
+
+```
+input    source(file)          = version + Arc<str>
+input    registry              = built-in command shapes (static)
+derived  tokens(file)          ← source(file)
+derived  cst(file)             ← tokens(file), command_shape(head)*  // shape-directed descent
+derived  command_shape(name)   ← registry, else proc_shape(name)
+derived  proc_shape(name)      ← analysis(def of name)               // discovered: signature_scan / param_traits
+derived  item_tree(file)       ← cst(file)        // whitespace-stable firewall
+derived  analysis(item)        ← item_tree(file), registry
+derived  diagnostics(file)     ← analysis(item)*
+derived  semantic_tokens(file) ← cst(file), registry
+derived  workspace_index       ← item_tree(file)*
+```
+
+Three properties do the heavy lifting:
+
+- **Firewall queries.** `item_tree` is keyed on structure, not bytes,
+  so a whitespace-only edit re-lexes and re-parses but leaves
+  `item_tree` unchanged — and every analysis downstream is reused. This
+  is what makes "edit one character" cheap.
+- **Per-item granularity.** `analysis(item)` is keyed per proc / class,
+  so editing one proc invalidates only that proc's analysis, not the
+  document's. Combined with CST subtree reuse, a keystroke recomputes a
+  bounded slice, not the world.
+- **Shape-directed descent.** How a command's arguments are parsed
+  depends on `command_shape(head)` — registry-known for built-ins,
+  discovered for user procs (D4). A proc's shape becoming known
+  cascades a targeted re-parse of just its call sites, nothing more.
+
+This replaces the current "rebuild everything every keystroke": the
+`CompilationUnit` built 2–3× (`analyser/diagnostics.rs:1813`,
+`optimiser/manager.rs:51`, `irules_checks.rs:464`), the registry
+rebuilt inside every `analyse()` (`state.rs:359`), and the absence of
+any reuse across edits. The registry becomes a static input, built once.
+
+### Layer 5 — MVCC where reads and writes overlap
+
+Reads run against an immutable snapshot; writes publish a new version:
+
+- The current derived state is an immutable `Arc<Snapshot>` behind an
+  `ArcSwap` (lock-free reads). A request `load()`s the current `Arc`
+  and holds it for its duration — so it sees one consistent version,
+  and cloning into a `spawn_blocking` worker is an `Arc` bump, not the
+  deep clone of `AnalysisResult` done today.
+- An edit builds the next version and swaps it in atomically. In-flight
+  reads either complete against their (older) snapshot and have their
+  result dropped by version tag, or are cancelled when they are now
+  pointless.
+
+This is the structural fix for C2 (no document-version guard,
+`lib.rs:1111`), for the coarse per-map `Mutex`es that serialise
+unrelated readers (`lib.rs:125`), and for the snapshot deep-clones. It
+is "MVCC **where necessary**": the document and its derived snapshots,
+not every small map.
+
+## Key decisions to confirm
+
+| | Decision | Options | Lean |
+|---|---|---|---|
+| **D1** | Green-leaf text storage | (A) `Span` into `Arc<str>` — true zero-copy, weaker cross-file dedup, incremental reuse by re-spanning (tree-sitter model); (B) owned interned `SmolStr` — rowan-style sharing and hash-consing, not zero-copy | **A**, per the stated zero-copy priority — but only if single-document zero-copy matters more than cross-file subtree sharing |
+| **D2** | Incremental engine | (A) `salsa` — proven demand-driven memoised query graph with exactly the cascade/invalidate/rebuild semantics described; a dependency and a paradigm; (B) hand-rolled revision tags — lighter, coarser, more code over time | **A** (`salsa`) for the semantics; adopt behind the project's default-off-until-baked discipline |
+| **D3** | MVCC flavour | finish-and-version-tag reads (complete, drop if stale) plus cancel-when-pointless (rust-analyzer's `Cancelled`) | both — tag for correctness, cancel for latency |
+| **D4** | "Parse once" boundary | see below | once per *(span, known-as-script)*, memoised |
+
+### D4 — "where knowable" is progressive: registry-known now, proc-shapes discovered
+
+Tcl is contextually parsed — a `{...}` word is a string *or* a script
+depending on the command — so "parse once" has two tiers of knowability
+that resolve at different times.
+
+- **Registry-known shapes — pass one.** For any command in the registry
+  (every built-in), `CommandSpec` already encodes which arguments are
+  bodies / scripts / expressions / variable names (`BodyKind`,
+  `arg_roles`, `arg_role_resolver`). Descent is *deterministic*, not a
+  guess: the first pass descends `if`'s condition as an expression and
+  its arms as scripts, `proc`'s body as a script, `foreach`'s var list,
+  and so on — each parsed once and memoised as a sub-tree.
+
+- **Discovered shapes — cascade on first analysis.** A call to a *user*
+  proc whose definition has not yet been analysed has an **unknown**
+  shape. `customcmd $x {maybe a body}` is parsed conservatively — the
+  braced word left as an opaque literal — because nothing yet says it
+  is a script. When that proc's definition is analysed
+  (`signature_scan` / `param_traits` infer that the parameter is used as
+  a script via `eval $body`, an expression via `expr $cond`, or a
+  variable via `upvar $name`), its shape becomes known and **the call
+  sites that parsed it conservatively must re-parse the affected
+  argument** — now descending the braced word as a script sub-tree.
+  This is the maintainer's example: shape discovery drives targeted
+  re-parsing of already-seen call sites.
+
+In the graph this is one edge: a call site's descent depends on
+`command_shape(head)` — the registry shape for built-ins, the derived
+`proc_shape(name)` for user procs. When `proc_shape` transitions
+unknown → known, the engine invalidates exactly the call-site parses
+that read it and rebuilds them. That is "more reparsing as the shape is
+discovered," automatic and bounded to the affected spans, rather than
+the unconditional `re-lex on every visit` of today's `descend.rs:108`.
+
+The apparent cycle — parsing a proc's body needs its shape, but the
+shape is inferred from analysing the body — is shallow and terminating
+in practice: a parameter's shape is fixed by how it is used with
+*built-in* commands (`eval`, `expr`, `upvar`, …), which are
+registry-known, so `proc_shape` is computable from the **pass-one,
+registry-only** descent — no fixpoint over user code is needed. Where a
+shape is genuinely undecidable (computed command names, dynamic
+dispatch), the parse stays conservative — opaque word, generic call —
+matching the codebase's existing "fall through to the generic `IRCall`
+when it cannot be proven safe" rule.
+
+This is also a *latency* win, not a cost. The conservative pass-one
+parse needs only the static registry, so it paints fast (good for
+time-to-first-semantic-tokens); the refined parse arrives later as an
+ordinary cascade once shape discovery completes. Progressive
+enhancement, not a blocking dependency — and `signature_scan`, the pass
+that discovers these shapes, is already default-on.
+
+## How the target resolves the open findings
+
+| Finding (see review-findings.md) | Resolved by |
+|---|---|
+| C1 — byte columns, not UTF-16 | Layer 3 — one position service, one conversion |
+| C2 — no version guard / stale overwrite | Layer 5 — versioned snapshots, MVCC |
+| Two parse representations | Layer 2 — CST is the only parse; segmenter is a view |
+| Re-derivation (135 / 29 / 34 rebuilds) | Layers 1, 3, 4 — parse and index once, reuse |
+| `CompilationUnit` built 2–3× | Layer 4 — one memoised graph, shared |
+| Registry rebuilt per `analyse()` | Layer 4 — static input, built once |
+| Deep clones into `spawn_blocking` | Layer 5 — clone an `Arc`, not the data |
+| Per-keystroke full recompute (TTFST) | Layer 4 — firewall + per-item granularity |
+| Memory duplication (third priority) | Layers 0–2 — one buffer, one tree, `Span` not `String` |
+
+## Migration
+
+This is the destination of the convergence plan in
+[`review-findings.md`](review-findings.md#convergence--one-parse-spine-without-a-big-bang-rewrite),
+and it stays incremental for the same reason: `segment_commands*` is a
+single chokepoint, the CST already exists and is differentially proven
+against the segmenter, and `salsa` can wrap the existing pure functions
+query-by-query. Suggested order: land the CST-as-spine (Layers 1–3)
+first — it is pure refactor under the existing differential corpus and
+delivers C1 and the zero-copy token stream — then introduce the query
+graph (Layer 4) one query at a time, and finally the snapshot/MVCC
+runtime (Layer 5), which is mostly server-side and closes C2.
+
+The failure mode to avoid is adopting the *vocabulary* (snapshots,
+queries) without the *firewall + per-item granularity* that makes the
+cascade cheap — a memoised graph with one coarse `analysis(file)` query
+re-runs the whole file on every keystroke and buys nothing.
+
+## Related
+
+- [`current-architecture.md`](current-architecture.md) — the crate
+  graph and ownership rules this builds on.
+- [`review-findings.md`](review-findings.md) — current-state findings,
+  the duplication map, and the staged convergence plan.
+- [`docs/rust-rewrite.md`](../../rust-rewrite.md) — chunking strategy
+  and chunk log.

--- a/docs/design/rust/target-architecture.md
+++ b/docs/design/rust/target-architecture.md
@@ -15,7 +15,10 @@
 >   the portions of derived data that depend on it and rebuilds them on
 >   demand;
 > - use **MVCC** where concurrent reads and writes need a consistent
->   view.
+>   view;
+> - apply all of the above to **every embedded grammar** — BIG-IP
+>   config, format and `scan` strings, regexps, globs, expr — not just
+>   the Tcl surface.
 >
 > The current-state critique and the staged route from here are in
 > [`review-findings.md`](review-findings.md); this doc is the
@@ -149,6 +152,67 @@ This is the structural fix for C2 (no document-version guard,
 unrelated readers (`lib.rs:125`), and for the snapshot deep-clones. It
 is "MVCC **where necessary**": the document and its derived snapshots,
 not every small map.
+
+## Embedded sub-languages — one model, applied everywhere
+
+Tcl is a host for a dozen embedded grammars, and nothing above is
+specific to the Tcl surface — it applies to each of them equally. A
+`format` template, a `regexp` pattern, a `string match` glob, an `expr`
+expression, a `clock` / `scan` specifier, a BIG-IP `.conf` stanza, a
+data-group body — every one is a small language sitting in a span of the
+same source.
+
+**Today each is an ad-hoc re-scanner.** Sub-languages are parsed by
+scattered functions that take a raw `&str` and return owned copies,
+re-deriving from text and duplicating it: format-spec parsing in three
+places (`tcl/format_.rs`, `codegen/helpers.rs::try_format_fold`,
+`hover.rs`); regexp / pattern handling across ~10 modules (`taint`,
+`optimiser/structure_elimination`, `codegen/helpers::regexp_to_glob`,
+`uri_split`, …); `var_refs::scan_word` / `scan_var_ref_forms` and
+`gvn::scan_bracketed_commands` each returning fresh `Vec<String>` /
+`BTreeSet<String>`; and a second expr entry point in the PyO3 crate
+(`expr_parser.rs`) beside the compiler's `expr_ast`. This is the
+two-parse-tree and re-derivation problem from
+[`review-findings.md`](review-findings.md#cross-layer-integration-and-data-duplication),
+repeated once per sub-language.
+
+**Target — typed sub-trees, injected, sharing the spine.** Each
+embedded grammar is parsed *once* into a typed sub-tree hanging off its
+host CST node, with the same guarantees as the host:
+
+- **Dispatched by the registry.** Which sub-grammar a word belongs to is
+  a command-shape fact the registry already carries (`arg_roles`, plus
+  the `pattern_type` / `format_string_type` / `options` fields the
+  GAP-AUDIT flagged as missing). This is D4's shape-directed descent
+  generalised from script / expr to regexp / format / glob / config:
+  the host parser sees `regexp $re` and descends `$re` into a regexp
+  sub-tree, `format $fmt` into a format sub-tree — once, memoised, and
+  re-parsed only when the typing or the text changes.
+- **Zero-copy.** Sub-parsers yield spans into the one `Arc<str>`, not
+  owned `String`s: `scan_var_ref_forms` yields var-ref spans;
+  `regexp_to_glob` reads the regexp sub-tree instead of re-scanning a
+  slice.
+- **Positions from the sub-tree.** Because the sub-tree carries spans
+  into the shared buffer, a diagnostic like "unknown conversion `%q` at
+  column 7 of the format string" resolves through the *same* position
+  service to a correct LSP range *inside* the embedded language — which
+  unlocks per-sub-language diagnostics, hover, and semantic-token
+  colouring (capture groups in a regexp, conversions in a format
+  string) that ad-hoc scanners cannot place.
+- **In the cascade.** A sub-tree is a query keyed on its span and
+  typing, so editing one regexp invalidates only that sub-tree, and a
+  discovered proc-shape that retypes an argument (D4) re-parses just
+  that argument into the right sub-grammar.
+
+**Injection runs both ways.** BIG-IP config is itself a host: a `.conf`
+file is config syntax with Tcl (iRules) injected inside `ltm rule { … }`,
+and within that Tcl the sub-grammars above are injected again. The
+model is therefore a single CST of typed nodes joined by
+language-injection edges (the tree-sitter injection model) — every node
+spanning the one source, every position resolved by the one service,
+every node a participant in the one cascade. One parser per language,
+no duplicates: the format-spec triplet and the twin expr parsers
+converge exactly as the segmenter and the CST do.
 
 ## Key decisions to confirm
 

--- a/docs/design/rust/target-architecture.md
+++ b/docs/design/rust/target-architecture.md
@@ -181,13 +181,19 @@ embedded grammar is parsed *once* into a typed sub-tree hanging off its
 host CST node, with the same guarantees as the host:
 
 - **Dispatched by the registry.** Which sub-grammar a word belongs to is
-  a command-shape fact the registry already carries (`arg_roles`, plus
-  the `pattern_type` / `format_string_type` / `options` fields the
-  GAP-AUDIT flagged as missing). This is D4's shape-directed descent
-  generalised from script / expr to regexp / format / glob / config:
-  the host parser sees `regexp $re` and descends `$re` into a regexp
-  sub-tree, `format $fmt` into a format sub-tree — once, memoised, and
-  re-parsed only when the typing or the text changes.
+  a command-shape fact the registry's schema already carries
+  (`arg_roles`, `body_kind`, `options`, `forms`). The registry parity
+  audit (#548, `rust-rewrite-registries.md`) shows the schema is largely
+  present but the Rust port has **systematically dropped the data** —
+  `forms` / `options` / `subcommands` / `side_effects` are empty on most
+  commands, and the BigIP object registry is entirely unported. So the
+  dispatch *mechanism* exists; what it needs is the per-command typing
+  *data* populated (any regexp- / format-specific role included),
+  tracked entry-by-entry in that audit. This is D4's shape-directed
+  descent generalised from script / expr to regexp / format / glob /
+  config: the host parser sees `regexp $re` and descends `$re` into a
+  regexp sub-tree, `format $fmt` into a format sub-tree — once,
+  memoised, and re-parsed only when the typing or the text changes.
 - **Zero-copy.** Sub-parsers yield spans into the one `Arc<str>`, not
   owned `String`s: `scan_var_ref_forms` yields var-ref spans;
   `regexp_to_glob` reads the regexp sub-tree instead of re-scanning a
@@ -212,7 +218,10 @@ language-injection edges (the tree-sitter injection model) — every node
 spanning the one source, every position resolved by the one service,
 every node a participant in the one cascade. One parser per language,
 no duplicates: the format-spec triplet and the twin expr parsers
-converge exactly as the segmenter and the CST do.
+converge exactly as the segmenter and the CST do. BigIP is the
+greenfield case — its registry is still unported (#548), so the config
+host and its injection can be built on this model from the start rather
+than retrofitted.
 
 ## Key decisions to confirm
 
@@ -314,5 +323,9 @@ re-runs the whole file on every keystroke and buys nothing.
   graph and ownership rules this builds on.
 - [`review-findings.md`](review-findings.md) — current-state findings,
   the duplication map, and the staged convergence plan.
+- [`rust-rewrite-registries.md`](../../../rust-rewrite-registries.md) —
+  per-entry registry parity audit (#548): the source of truth for which
+  command-shape data each dialect still needs ported, and the dispatch
+  typing the sub-language spine depends on.
 - [`docs/rust-rewrite.md`](../../rust-rewrite.md) — chunking strategy
   and chunk log.

--- a/docs/design/rust/target-architecture.md
+++ b/docs/design/rust/target-architecture.md
@@ -66,12 +66,14 @@ Incrementally, only the edited region re-lexes.
 ### Layer 2 — One CST, everything else a view
 
 The red-green CST is built from the token stream and is the **single**
-parse representation. The token-loop segmenter is retired;
-`SegmentedCommand`, the IR item-tree, and the lowering input become
-**views / projections** over the CST (iterators yielding command and
-word spans), not separate owned parses. This closes the two-parse-tree
-gap (`segmenter.rs` vs `parsing/syntax/`) and the hand-maintained
-agreement harness (`differential_segment.rs`).
+parse representation. This is **already true today**: the token-loop
+segmenter was retired in #538, and `segment_commands_local`
+(`segmenter.rs:408`) derives `SegmentedCommand` from the CST (the old
+loop survives only as the frozen oracle in `differential_segment.rs`).
+The remaining work is to make the IR item-tree and the lowering input
+likewise **views / projections** over one reused CST rather than each
+rebuilding it via `segment_commands*`, and to fold the ~40 ad-hoc
+sub-word `Lexer` scans onto the tree.
 
 Green stores structure; the text-storage choice is **D1**. Red anchors
 absolute positions lazily and carries the **one** line index beside the


### PR DESCRIPTION
## Summary

Adds `docs/design/rust/review-findings.md` — a point-in-time review of the Rust workspace, registered in the design-doc index. Verified against the source at review time; every finding carries a `file:line` anchor so it can be re-checked or retired as the code moves.

Ordered to the maintainer's stated priorities: **correctness and precision first, performance second** (with **time to first semantic tokens** as the headline latency metric), and **memory a distant third**.

## Headline findings

**Correctness**
- The differential safety net (Python / `tclsh` oracles) is **not enforced in hosted CI** — the harnesses skip silently when the oracle is absent (`ci.yml:68`).
- **C1** — LSP positions are emitted in **byte columns, not UTF-16** (`line_index.rs:92` used everywhere; `position_at_utf16` has zero callers); wrong ranges on any non-ASCII line.
- **C2** — **no document-version guard**; stale analyses/diagnostics can overwrite fresh ones out of order (`lib.rs:98`, `:1111`).
- **C3** — eight LSP handlers run CPU work inline and do not contain a parser panic.

**Performance (TTFST-first)**
- Pre-warm/cache semantic tokens at `did_open`; make the `range` provider actually range-bounded (it currently does full-document work); share/lazy-static the registry (rebuilt inside every `analyse()` at `state.rs:359`); `spawn_blocking` the token handler and de-prioritise the 2,000-file startup scan.
- Sustained: no incremental layer (full recompute per keystroke), `CompilationUnit` rebuilt 2–3× per document, no `rayon`, coarse locking.

**Memory (third)** — green CST stores two owned `String`s per token with no sharing; no symbol interner; SipHash `HashMap<String, _>` on hot paths. Pursue only where it cuts allocation latency.

## Relationship to GAP-AUDIT-JUN05 (#544)

Complementary, not redundant. The gap audit maps **missing / degraded / unwired parity** features; this review maps **correctness defects in wired code plus performance/TTFST**. Overlap is limited to the semantic-tokens legend (the audit quantifies it as 7/53 token types, 0/4 modifiers). The audit's **GAP-B3** (goto-type-definition / goto-implementation alias `compute_definition` and return definition results — verified) is a correctness item worth folding into this review's list.

No source files change; docs only.

https://claude.ai/code/session_017gcntfxYyJ8CjujYxS7xxb

---
_Generated by [Claude Code](https://claude.ai/code/session_017gcntfxYyJ8CjujYxS7xxb)_