### PR TITLE
Fix {*} expansion truncation and list scaling O(N²) regressions

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=9735aa4-dirty
-head=9735aa4a1d26a531d433bacf26952f44c69117fe
-date=2026-06-05T15:38:47Z
-fingerprint=c4d8c5f5f703b38e5bbe0d65027fa6bb80b56db05281f70f3bc36a44b2dc5c70
+describe=2ba3e2b-dirty
+head=2ba3e2b2a14b3689d2ecbd537826c821737cff3c
+date=2026-06-05T16:11:24Z
+fingerprint=c090f1bf9d472cf5813be3afbb4d7460ddf40c3cee0c055e1ae069d3a68a88c3

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=327c10b-dirty
-head=327c10bcc25b9f1a2447a0e9545a3428420ebca8
-date=2026-06-05T10:42:03Z
-fingerprint=e31ad5f440e4a400b9deb2456ab003fe59a94dfa96ee4d8e58ff722ad8e969c6
+describe=9735aa4-dirty
+head=9735aa4a1d26a531d433bacf26952f44c69117fe
+date=2026-06-05T15:38:47Z
+fingerprint=c4d8c5f5f703b38e5bbe0d65027fa6bb80b56db05281f70f3bc36a44b2dc5c70

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -232,6 +232,23 @@ are its rules, and what are the failure modes". One contract per file.
   the reference implementations we copied each piece of behaviour
   from.
 
+### First-principles runtime contracts (v2 / "if starting over")
+
+Forward-looking semantic contracts — the models a from-scratch Tcl
+runtime + AOT compiler should commit to *before* writing commands.
+Distilled from the trickiest scars in the WASM runtime history
+(frame aliasing, the parser/interpreter seam, the numeric tower):
+
+- [runtime-variable-frame-model.md](contracts/runtime-variable-frame-model.md)
+  — the cell/frame/namespace resolution algorithm behind `upvar`,
+  `global`, `variable`, arrays, and traces; why locals are not slots.
+- [parser-and-aot-interpret-boundary.md](contracts/parser-and-aot-interpret-boundary.md)
+  — the one canonical grammar, and the AOT-compile vs. runtime-interpret
+  boundary that `eval`/`uplevel`/`source`/`apply`/`{*}` straddle.
+- [numeric-tower-and-expr-semantics.md](contracts/numeric-tower-and-expr-semantics.md)
+  — the small-int→wide→bignum→double tower and `expr` as a separate
+  language with overridable `mathfunc` dispatch.
+
 ## Templates
 
 Templates for new design docs live at

--- a/docs/design/contracts/numeric-tower-and-expr-semantics.md
+++ b/docs/design/contracts/numeric-tower-and-expr-semantics.md
@@ -1,0 +1,130 @@
+# Contract: the numeric tower & `expr` semantics
+
+> **Status:** First-principles design contract (v2 / "if starting over").
+> The numeric value model and the `expr` language a from-scratch runtime must
+> fix *before* any arithmetic command exists. Related as-built notes:
+> [shimmer-reference-behaviour.md](shimmer-reference-behaviour.md) and the
+> bignum/arith modules under `runtime/zig/valtypes/`.
+
+## Two coupled decisions
+
+`expr` is a **separate language** (its own grammar, precedence, operators,
+and function namespace), and Tcl integers are **transparently arbitrary
+precision**. These are coupled: the promotion rules of the numeric tower are
+exactly what `expr`'s operators must implement. Decide both once, centrally,
+and route *every* numeric consumer through them — `expr`, `tcl::mathop::*`,
+`incr`, `format`/`scan`, `string repeat`, list indices, comparisons, dict
+keys, hashing. The chronic failure mode is one consumer rolling its own
+integer parse and silently truncating beyond 64 bits, or an `i32`/`i64` cast
+panicking on a promoted value (a real bug class in this repo).
+
+## The tower
+
+```
+immediate small int   →   wide (i64)   →   bignum (arbitrary precision)   →   double (f64)
+        ▲ same logical integer, widened only as needed ▲                    (a distinct type)
+```
+
+* **Integers are one logical type** that widens through small→wide→bignum as
+  magnitude demands. Every integer op overflow-checks and **promotes**; it
+  never wraps. (`expr {2**200}`, factorials, `incr` past 2⁶³ all just work.)
+* **Canonicalise downward.** A bignum that fits in a wide is demoted back to
+  a wide (and a wide that fits the immediate tag to an immediate). This keeps
+  equality, hashing, and the string rep stable and is **observable** — C Tcl
+  does it and tests depend on it. Normalisation happens at the *end* of every
+  producing operation.
+* **`double` is a separate type**, not a wider integer. Mixed int/float ops
+  promote the int operand to double; the result is double. `wide`↔`double`
+  conversions lose precision deliberately per IEEE-754.
+* **String is the lazy fourth rep**: a numeric value carries a cached string
+  rep generated on demand (`1e100`, `0xff`, the canonical decimal). The
+  parse direction (string → number) and the format direction (number →
+  string) must round-trip exactly for the shortest-decimal contract below.
+
+This is the numeric facet of the object model — the typed internal rep plus a
+lazily generated string, *not* a string with a parse on every use.
+
+## `expr` is its own language
+
+A separate lexer/parser/evaluator with its own:
+
+* **Grammar & precedence** (high → low): `**` (right-assoc) ; unary `- + ~ !`
+  ; `* / %` ; `+ -` ; `<< >>` ; `< > <= >=` ; `== !=` and `eq ne` ; `in ni`
+  ; `&` ; `^` ; `|` ; `&&` ; `||` ; `?:` (right-assoc). Get the **`**`
+  right-associativity** and the placement of `eq/ne/in/ni` right.
+* **Operators string code lacks:** `eq`/`ne` (always string compare),
+  `in`/`ni` (list membership), `?:` ternary, short-circuit `&&`/`||`
+  (the un-taken branch is **not** evaluated — observable via side effects).
+* **Functions via a namespace:** `sin(x)`, `max(...)`, `rand()` dispatch to
+  `::tcl::mathfunc::*`. Users can **define or override** them, so function
+  dispatch is the namespace command table, not a builtin switch. `tcl::mathop`
+  exposes the operators as commands (`+ - * ...`) for `{*}`-style use.
+* **Literals:** `0x`/`0o`/`0b` radices, `_` digit separators (`1_000`),
+  decimal/scientific floats, `Inf`/`NaN` (case-insensitive, with the
+  `NaN(hex)` payload form for `binary`/round-trip), booleans `true/false/
+  yes/no/on/off`.
+
+### The braced vs. unbraced split (compile/interpret + security)
+
+* `expr {…}` — the braced body is parsed once and **compiled** to guarded
+  native arithmetic. This is the safe, fast form.
+* `expr $x …` — the operands are substituted **first**, then the *result* is
+  re-parsed as an expression. This double-substitution is both a performance
+  cliff and an **injection risk** (`expr "$user + 1"`); it must be
+  interpreted at runtime. Lint/diagnostics should steer users to braces, but
+  the runtime must implement both.
+
+## Numeric semantics that are tested verbatim
+
+* **Integer `/` truncates toward −∞? No — toward zero is *not* it either.**
+  Tcl integer division and `%` are defined so that `%` has the sign of the
+  **divisor** and `a == (a/b)*b + (a%b)`. Pin the exact rounding/sign rule.
+* **`/` on a float operand is float division;** all-integer `/` is integer.
+* **Bit operators (`& | ^ ~ << >>`) are integer-only** (incl. bignum); a
+  float operand is an error. Shift counts and huge shifts have defined
+  behaviour through bignum.
+* **Overflow promotes to bignum** (never wraps) — contract.
+* **Comparisons:** `==`/`!=` compare numerically when both sides look
+  numeric, else as strings; `eq`/`ne` always string. `in`/`ni` use list
+  membership with string equality.
+* **Float → string** uses the **shortest decimal that round-trips**
+  (C Tcl 9's `tcl_precision`-free default); `format`/`%g`/`%.17g` and the
+  default rep must match byte-for-byte, including `-0.0`, `Inf`, `NaN`.
+* **Errors** are verbatim: `divide by zero`, `domain error`,
+  `can't use non-numeric string as operand`, `too many digits` (charset
+  parse), etc.
+
+## Contract vs. incompatible-by-design
+
+| Behaviour | Class |
+|---|---|
+| Integer overflow → bignum (no wrap), canonical demote-when-fits | **Contract** |
+| `%`/`/` sign and rounding rules; bit-ops integer-only | **Contract** |
+| `**` right-assoc; full precedence table; short-circuit `&&`/`||` | **Contract** |
+| `mathfunc`/`mathop` dispatch through the namespace (overridable) | **Contract** |
+| Literal radices, `_` separators, `Inf`/`NaN`/`NaN(hex)`, booleans | **Contract** |
+| Shortest-round-trip float formatting, `-0.0`/`Inf`/`NaN` text | **Contract** |
+| `eq`/`ne`/`in`/`ni`, numeric-vs-string `==` rule | **Contract** |
+| Error wording (`divide by zero`, `domain error`, …) | **Contract** |
+| Which internal rep a value currently holds (`tcl::unsupported::representation`) | **Incompatible-by-design** — shimmering is observable but rep identity is not a from-scratch contract (W9-internal). |
+| Bignum limb layout / refcounts via test hooks | **Incompatible-by-design** |
+
+## AOT compiler implications
+
+* Compile braced `expr` to native ops with a **type guard ladder**: try the
+  immediate/wide fast path, fall to bignum on overflow, to double on float
+  operands — the same ladder the tower defines. Never emit a wide-only op
+  without the overflow→bignum escape.
+* Constant-fold only when the fold uses the *exact* tower semantics
+  (including canonicalisation), or the compiled and interpreted results
+  diverge.
+* Route `mathfunc` calls through the command table so user overrides win,
+  even in compiled `expr`.
+
+## See also
+
+- [shimmer-reference-behaviour.md](shimmer-reference-behaviour.md) — how the
+  number↔string boundary is observed.
+- [runtime-variable-frame-model.md](runtime-variable-frame-model.md) and
+  [parser-and-aot-interpret-boundary.md](parser-and-aot-interpret-boundary.md)
+  — the other two day-one contracts.

--- a/docs/design/contracts/parser-and-aot-interpret-boundary.md
+++ b/docs/design/contracts/parser-and-aot-interpret-boundary.md
@@ -1,0 +1,129 @@
+# Contract: canonical parser & the AOT/interpret boundary
+
+> **Status:** First-principles design contract (v2 / "if starting over").
+> The semantic boundary a from-scratch AOT compiler + runtime must agree on
+> *before* either is written. As-built notes:
+> [parsing.md](parsing.md), [lexing.md](lexing.md), the WASM codegen pipeline
+> under [../compiler/](../compiler/), and the red/green CST work.
+
+## The two non-negotiable ideas
+
+1. **Parse once, canonically.** Word splitting, quoting, substitution,
+   `{*}` expansion, comments, and command separation are *one* grammar. It is
+   used by the compiler's front end, the runtime evaluator, `subst`, the list
+   parser, and `expr`'s argument handling. Re-implementing it in N places
+   guarantees N drifts — every place that re-derives "where does this word
+   end" is a future off-by-one or a mismatched error. One scanner; many
+   clients.
+
+2. **Tcl is homoiconic and late-bound, so the AOT compiler is half of a
+   pair.** `eval`, `uplevel`, `subst`, `source`, `apply`, `proc f $a $body`,
+   `$dynamic_cmd …`, and `{*}$computed` all produce code that does not exist
+   at compile time. A *complete runtime parser + tree-walking evaluator* must
+   exist as a peer to the compiled path, and the two must be observably
+   identical: same result, same return code/options, same `errorInfo`
+   frames, same line numbers, same trace firings. The boundary between "I can
+   compile this" and "I must interpret this" is a designed contract, not an
+   accident of which cases got optimised.
+
+## The grammar (the parts everyone gets subtly wrong)
+
+A *script* is a sequence of *commands* separated by **newline** or `;`. A
+command is a sequence of *words* separated by unescaped whitespace. Within a
+word, four things happen — and *which* happen depends on how the word is
+introduced:
+
+| Word form | `$var` subst | `[cmd]` subst | `\` subst | Notes |
+|---|---|---|---|---|
+| **bare** `abc` | yes | yes | yes | whitespace ends it unless escaped/grouped |
+| **double-quoted** `"…"` | yes | yes | yes | whitespace is literal; ends at the matching `"` |
+| **braced** `{…}` | **no** | **no** | **only** `\<newline>`→space | fully literal; nesting counts balanced `{}` |
+
+Hard edges that must be in the spec, not discovered later:
+
+* **Comments** (`#`) are comments **only where a command is expected** —
+  i.e. at the start of a command. `set x #y` has a literal `#y`. After a
+  word, `#` is ordinary.
+* **`;` and newline** both terminate a command; inside `{}`/`"…"`/`[…]`
+  they do not. A `;` inside a bare word is *not* special only if escaped.
+* **Backslash-newline** (line continuation) collapses to a single space —
+  including inside braces (the one substitution braces allow). This changes
+  the *length* of a braced body (`{a\<NL>b}` has length 3, "a b").
+* **`{*}`** triggers argument expansion **only** when the three chars are a
+  complete leading prefix of a word *immediately* followed by a non-blank,
+  non-terminator character. A standalone `{*}` (end of command, or followed
+  by whitespace/`;`/newline) is the literal braced word `*`. (Getting this
+  wrong silently drops or duplicates arguments.)
+* **Nesting** is independent per bracket type: `[` … `]` command
+  substitution, `{` … `}` braces, `"` … `"` quotes; a `]` inside `{}` is
+  literal, a `}` inside `[…]` belongs to the inner command, etc.
+* **`$` variable forms:** `$name`, `${name}` (any chars), `$arr(idx)` (the
+  index is itself substituted), `$name` stops at the first non-name char.
+* The result of parsing is **tokens with source spans**, not strings. Spans
+  are needed for `info frame`, error carets, and the LSP — thread them from
+  byte zero.
+
+## Where the boundary falls
+
+| Construct | Default disposition |
+|---|---|
+| Static command name + static body (`proc`, `if {…} {…}`, `while`, `foreach`, `set x 1`, braced `expr`) | **Compile** to native code. |
+| `eval $x`, `uplevel`, `subst`, `apply {…}`, `proc f $a $body`, `$cmd …`, `namespace eval` of a computed body, `source` | **Interpret** at runtime via the shared parser+evaluator. |
+| `{*}$computed` | Compile the *call site*, but the expanded words are materialised at runtime (must grow unbounded — never a fixed-size argument array). |
+| `switch`/`expr`/`dict for`/`try` bodies | Sub-grammars; compile when the body is a literal brace word, else interpret. |
+
+The interpreter is therefore not a fallback "slow path" bolted on late — it
+is a co-equal back end. Budget for it from the start, and make every dynamic
+construct route through *one* `eval_script(tokens, frame)` entry so behaviour
+cannot fork.
+
+## The identity contract (compiled ≡ interpreted)
+
+For any script that *can* be run both ways, the following must be
+byte-identical:
+
+* the result string and the return code + options dict
+  (`-errorcode`, `-errorinfo`, `-errorstack`, `-level`);
+* the `errorInfo` traceback text, including the "invoked from within …"
+  vs. "while executing …" distinction (which depends on whether the failing
+  command was itself a bytecode-compiled sub-command — see the
+  `transparent_error` mechanism in the as-built runtime);
+* `info script` and `info level`/`info frame` *command* content;
+* the order and arguments of variable/command/execution trace callbacks.
+
+Line numbers and PC tables from `info frame` are **incompatible-by-design**
+against a from-scratch codegen and are classified, not chased.
+
+## `source` / `package` / auto-load are this boundary + a VFS
+
+`source FILE` is "read bytes, parse, evaluate in the caller's namespace,
+with `info script` set to FILE and relative paths resolved against it."
+`package require` → `package ifneeded`/`pkgIndex.tcl` → `source`, and
+`unknown`/`auto_load`/`tclIndex` are a lazy command-discovery layer on top.
+All of it is "interpret code discovered at runtime, from a filesystem."
+
+**Design rule:** put the filesystem and module discovery behind one VFS +
+loader interface so a constrained host (WASI: no writable fs, no real stat)
+is a *missing implementation of a defined interface*, not a missing design.
+The current runtime classifies these as `deferred-wasi` precisely because the
+interface boundary was not drawn first.
+
+## Contract vs. incompatible-by-design
+
+| Behaviour | Class |
+|---|---|
+| Word/quote/brace/`{*}`/comment/`;`-newline grammar, line-continuation length | **Contract** |
+| Substitution rules per word form, `$arr(idx)` index substitution | **Contract** |
+| Result + return code + options dict as the universal command return | **Contract** |
+| `errorInfo` text incl. "invoked from within"/"while executing" | **Contract** |
+| Parse errors (`missing close-brace`, `unbalanced open bracket`, …) verbatim | **Contract** |
+| `info frame` line/PC tables, bytecode disassembly | **Incompatible-by-design** (W9-internal) |
+| `info script` value, `info level` command lists | **Contract** |
+
+## See also
+
+- [runtime-variable-frame-model.md](runtime-variable-frame-model.md) — the
+  frame the interpreter injects for `uplevel`/`eval`.
+- [numeric-tower-and-expr-semantics.md](numeric-tower-and-expr-semantics.md)
+  — `expr` is a second grammar parsed by the same "parse once" discipline.
+- [parsing.md](parsing.md), [lexing.md](lexing.md) — as-built segmentation.

--- a/docs/design/contracts/runtime-variable-frame-model.md
+++ b/docs/design/contracts/runtime-variable-frame-model.md
@@ -1,0 +1,158 @@
+# Contract: variable & call-frame resolution model
+
+> **Status:** First-principles design contract (v2 / "if starting over").
+> Describes the semantic model a from-scratch Tcl runtime should commit to
+> *before* writing any command, not a description of the current
+> implementation. The as-built notes are
+> [runtime/memory-management.md](../runtime/memory-management.md),
+> [runtime/refcount-contract.md](../runtime/refcount-contract.md),
+> [runtime/rename-alias.md](../runtime/rename-alias.md),
+> [runtime/trace-implementation.md](../runtime/trace-implementation.md) and
+> [namespace-model.md](namespace-model.md).
+
+## Why this is the first thing to get right
+
+In Tcl a variable name resolves to a *cell* through a chain that is only
+fully known at runtime: `upvar`, `global`, `variable`, `namespace eval`,
+array elements, and traces can all redirect a plain name to a cell in a
+different frame or namespace. An AOT compiler that assumes "a proc local is
+a WASM local slot" is wrong the moment any of those appear — and they appear
+constantly. Almost every deep variable bug (alias sentinels leaking into
+handle arguments, traces re-entering during a write, `uplevel` running code
+that mutates the caller's locals) is a symptom of the cell/frame model being
+implicit instead of designed.
+
+**Design rule:** there is exactly one way to reach a variable — through a
+*frame → name → cell* indirection. Optimisations (treating a proven
+non-aliased, non-traced local as a raw slot) are layered *on top* behind a
+guard; they are never the base case.
+
+## The two stacks and the two contexts
+
+Tcl conflates them in surface syntax but they are distinct:
+
+| Concept | What it is | Who changes it |
+|---|---|---|
+| **Call frame** | A variable table for the *currently executing* body (proc locals, or the global table at script top level). | A proc call pushes one; `apply`, methods, `uplevel`, coroutines, `[interp] eval` reshape the active one. |
+| **Call stack / level** | The numbered chain of frames. `info level` reads it. | Proc calls push; `tailcall` replaces the top; coroutines suspend/resume sub-stacks. |
+| **Current namespace** | Context for resolving *command* names and *qualified* variable names. | `namespace eval`, and a proc's *defining* namespace on entry. |
+| **Namespace variable tables** | Per-namespace variable storage (`::`, `::foo`, …). NOT the same as call frames. | `variable`, `set ::ns::x`, `namespace eval`. |
+
+The classic trap: the current namespace is **not** the call frame. Inside a
+proc defined in `::foo`, an *unqualified* `set x` writes a frame **local**,
+not `::foo::x`. You only reach the namespace var by qualifying (`::foo::x`)
+or by declaring `variable x` (which installs a local alias to it). At script
+top level, by contrast, the call frame *is* the global namespace table, so
+unqualified `x` is `::x`.
+
+## The cell
+
+```
+Cell {
+  storage : Unset | Scalar(value_obj) | Array(name→Cell)
+  link    : ?*Cell        // non-null ⇒ this name is an alias (upvar/global/variable)
+  traces  : ?*TraceList   // read / write / unset / array traces
+  refcount                // a cell may be referenced by several aliasing names
+}
+Frame {
+  names   : Map<string, *Cell>   // local table
+  level   : int                  // absolute level number (#0 = global)
+  ns      : *Namespace           // current namespace for this frame
+  caller  : ?*Frame              // for uplevel/info-level
+}
+```
+
+A name is resolved to a cell once; an *alias* cell's `link` is followed to
+the real cell on every access (so `unset`, traces, and array-ness all act on
+the target). Following links must be cycle-safe (`upvar 0 a b; upvar 0 b a`
+is an error in C Tcl — detect it).
+
+## Resolution algorithm (the contract)
+
+`resolve(frame, name, create?) -> *Cell | error`:
+
+1. **Parse the name.** Split a trailing `(index)` → array element. Detect a
+   `::` prefix or embedded `::` → *qualified*; otherwise *unqualified*.
+2. **Qualified `::a::b::x`:** resolve namespace `::a::b` from the frame's
+   current namespace (absolute if leading `::`, else relative), then look up
+   `x` in that namespace's variable table. `create?` makes the namespace
+   var; intermediate namespaces are **not** auto-created for variables.
+3. **Unqualified `x`:** look in `frame.names`. If present, follow `link` to
+   the target cell. If absent and `create?`, create a local cell in
+   `frame.names`. (Unqualified never falls through to the namespace — that
+   is what `global`/`variable` are for.)
+4. **Array element `a(k)`:** resolve `a` by 1–3 to a cell; require it be
+   `Array` (auto-vivify on write, error on read of a missing element); then
+   the element cell. `k` is itself substituted before this step.
+
+`upvar L other my`, `global v`, `variable v` all reduce to: resolve `other`
+(in the target frame/namespace), then install `frame.names[my] = aliasCell`
+whose `link` points at it. The alias is created even if the target is
+currently Unset (link to a yet-to-exist cell).
+
+### Frame addressing for upvar/uplevel
+
+* `#N` — absolute, counting from the global frame (`#0`).
+* `N` — relative, N frames up from the current (default `1`).
+* The target frame must exist (`upvar 3` from level 1 is an error).
+* `uplevel L {script}` sets the *active call frame* to frame `L` for the
+  duration of `script`, then restores. The script is evaluated with frame
+  `L`'s locals visible — see the AOT note below.
+
+## Interactions that must be modelled, not patched
+
+* **`unset` through a link** unsets the *target* cell (and fires its unset
+  traces), then removes the local alias name. Unsetting a plain alias does
+  not orphan the target's other aliases.
+* **Traces are re-entrant interrupts.** A write trace runs arbitrary Tcl
+  *during* the write, can itself read/write/unset (including the same
+  variable, through another alias), can error (the error replaces the
+  operation's result), and fires through `upvar` links in the frame where
+  the access occurred. Define ordering (read traces before the read returns;
+  write traces after the value is stored; unset traces during teardown) and
+  a re-entrancy/recursion policy up front. (Cascaded read-trace re-entry on
+  `lappend` is a real crash in the as-built runtime.)
+* **`tailcall`** replaces the current frame's *pending* continuation; it must
+  not leave a dangling frame or double-pop.
+* **Coroutines** capture and resume a *slice* of the call stack; `upvar`/
+  `info level` inside a coroutine see the coroutine's stack, not the
+  resumer's.
+* **`rename`/aliases at the command layer** are the command-table parallel of
+  this and share the re-entrancy hazards ([rename-alias.md](../runtime/rename-alias.md)).
+
+## AOT compiler implications
+
+* Compile a proc's variable accesses against the frame's name table by
+  default. A local may be promoted to a raw register **only** when the
+  compiler can prove, for that proc, that the name is never `upvar`/`global`/
+  `variable`-aliased, never traced, never an array, and not reachable by an
+  `uplevel`/`eval` in the body. The proof is fragile — guard it and fall back.
+* `uplevel`/`eval`/`apply`/`namespace eval` bodies are generally **not**
+  compilable in the caller's context (they were compiled, if at all, as
+  separate units). They route to the runtime interpreter
+  ([parser-and-aot-interpret-boundary.md](parser-and-aot-interpret-boundary.md))
+  with the target frame injected. Treat that hand-off as a first-class path.
+* The handle ABI matters here: alias/global sentinels must not collide with
+  the small-integer immediate tag or with negative-as-i32 heap addresses
+  (see the numeric/handle notes). Reserve sentinel space deliberately.
+
+## Contract vs. incompatible-by-design
+
+| Behaviour | Class | Notes |
+|---|---|---|
+| Unqualified name = frame local (not namespace var) inside a proc | **Contract** | The single most common semantic surprise; tests depend on it. |
+| `upvar`/`global`/`variable` aliasing, link-following on read/write/unset | **Contract** | Including alias to a not-yet-existing var. |
+| `#N` vs `N` frame addressing, errors on out-of-range level | **Contract** | |
+| Trace fire order, fire-through-link, error-replaces-result | **Contract** | Re-entrancy must terminate and match C Tcl ordering. |
+| `info level` / `info frame` *numbers and line tables* | **Incompatible-by-design** | Line/PC tables are tied to C Tcl's bytecode; a from-scratch codegen cannot match them byte-for-byte (the W9-internal bucket). Match the *structure* (`info level` command lists), classify the line tables. |
+| Exact wording of `can't read "x": no such variable` etc. | **Contract** | Error strings are tested verbatim. |
+| Internal cell layout, refcount values exposed via test hooks | **Incompatible-by-design** | Object-rep probes never match. |
+
+## See also
+
+- [namespace-model.md](namespace-model.md) — command/variable namespace
+  resolution this builds on.
+- [parser-and-aot-interpret-boundary.md](parser-and-aot-interpret-boundary.md)
+  — where `uplevel`/`eval` hand off to the interpreter.
+- [runtime/trace-implementation.md](../runtime/trace-implementation.md) —
+  as-built trace dispatch.

--- a/runtime/zig/cmds/binary.zig
+++ b/runtime/zig/cmds/binary.zig
@@ -45,6 +45,15 @@ const memcpy = rt.memcpy;
 /// Parse an optional decimal count from ``fmt`` at position ``*fi``.
 /// Returns the count (or ``null`` for ``*`` which means "all remaining").
 /// If no digits, returns 1.
+///
+/// A count whose digits exceed ``u32`` saturates to ``maxInt(u32)`` rather
+/// than wrapping.  This mirrors C Tcl's ``GetFormatSpec``, which parses the
+/// count with ``strtoull`` and clamps an out-of-range value to
+/// ``TCL_SIZE_MAX`` (tclBinary.c).  A saturated count is always larger than
+/// any real buffer, so the per-specifier "count exceeds remaining bytes"
+/// guards turn it into the same no-op / ``goto done`` C produces — instead of
+/// the integer-overflow panic the naive ``n*10`` accumulation used to trap on
+/// (e.g. ``binary scan x a[format %ld 0x100000000] r``, binary-37.10..37.13).
 fn parse_count(fmt: [*]const u8, fmt_len: u32, fi: *u32) ?u32 {
     if (fi.* >= fmt_len) return 1;
     if (fmt[fi.*] == '*') {
@@ -53,9 +62,18 @@ fn parse_count(fmt: [*]const u8, fmt_len: u32, fi: *u32) ?u32 {
     }
     if (fmt[fi.*] < '0' or fmt[fi.*] > '9') return 1;
     var n: u32 = 0;
+    var overflowed = false;
     while (fi.* < fmt_len and fmt[fi.*] >= '0' and fmt[fi.*] <= '9') : (fi.* += 1) {
-        n = n * 10 + @as(u32, fmt[fi.*] - '0');
+        const digit: u32 = fmt[fi.*] - '0';
+        const mul = @mulWithOverflow(n, 10);
+        const add = @addWithOverflow(mul[0], digit);
+        if (mul[1] != 0 or add[1] != 0) {
+            overflowed = true; // keep consuming digits, but stop accumulating
+        } else {
+            n = add[0];
+        }
     }
+    if (overflowed) n = std.math.maxInt(u32);
     return n;
 }
 
@@ -586,8 +604,22 @@ fn eval_binary_scan(words: []const i32) i32 {
                 }
             },
             'a', 'A' => {
-                const cnt: u32 = count_or_null orelse (src_len -| off);
-                const take = @min(cnt, src_len -| off);
+                const remaining = src_len -| off;
+                // C contract (tclBinary.c BinaryScanCmd, case 'a'/'A'/'C'):
+                // ``*`` consumes everything left; an explicit count larger
+                // than the bytes remaining stops the scan via ``goto done``
+                // (the variable is *not* assigned) rather than clamping to a
+                // short read.  ``parse_count`` returns 1 for a bare specifier,
+                // which follows the same > remaining gate as any explicit
+                // count.  This is what makes the count-overflow cases
+                // (binary-37.10..37.13) return 0.
+                var take: u32 = undefined;
+                if (count_or_null) |cnt| {
+                    if (cnt > remaining) break;
+                    take = cnt;
+                } else {
+                    take = remaining; // ``*`` = all remaining
+                }
                 var end = off + take;
                 if (spec == 'A') {
                     // Strip trailing spaces/nulls from result.
@@ -667,16 +699,33 @@ fn eval_binary_scan(words: []const i32) i32 {
                 off += take_bytes;
             },
             'x' => {
-                const cnt: u32 = count_or_null orelse 1;
-                off += @min(cnt, src_len -| off);
+                // Skip forward.  ``x*`` (and an explicit count past the end)
+                // advances to the end of the data; otherwise skip ``cnt``
+                // bytes.  ``@min`` makes an oversized explicit count clamp to
+                // the end, matching C's ``offset = length`` branch.
+                if (count_or_null) |cnt| {
+                    off += @min(cnt, src_len -| off);
+                } else {
+                    off = src_len; // ``x*`` = skip everything remaining
+                }
             },
             'X' => {
-                const cnt: u32 = count_or_null orelse 1;
-                off -|= cnt;
+                // Move back.  ``X*`` (and an explicit count past the start)
+                // rewinds to the beginning; otherwise back up ``cnt`` bytes.
+                if (count_or_null) |cnt| {
+                    off -|= cnt;
+                } else {
+                    off = 0; // ``X*`` = rewind to the start
+                }
             },
             '@' => {
-                const cnt: u32 = count_or_null orelse 0;
-                off = @min(cnt, src_len);
+                // Absolute seek.  ``@*`` seeks to the end of the data; an
+                // explicit count seeks there, clamped to the data length.
+                if (count_or_null) |cnt| {
+                    off = @min(cnt, src_len);
+                } else {
+                    off = src_len; // ``@*`` = seek to end (BINARY_ALL)
+                }
             },
             else => {},
         }

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -2430,8 +2430,12 @@ fn ensure_local_obj_owned(o: i32) i32 {
     // :func:`tcl_ns.ensure_var_obj_owned` for the rationale.
     if (obj.is_immediate(o)) return o;
     const addr: u32 = @bitCast(o);
+    // TYPE_LIST keeps its canonical list string in the OBJ_STR_* slots
+    // too, so it shares the borrowed-buffer concern and must reach the
+    // cap check (it is always created owning today, but don't rely on
+    // that invariant here — see tcl_ns.ensure_var_obj_owned).
     const tag = obj.read_i32(addr + obj.OBJ_TYPE_TAG);
-    if (tag != obj.TYPE_STRING) return o;
+    if (tag != obj.TYPE_STRING and tag != obj.TYPE_LIST) return o;
     const cap: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_STR_CAP));
     if (cap > 0) return o;
     const sptr: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_STR_PTR));

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -5480,11 +5480,60 @@ fn apply_pending_return_code(rv: i32) void {
 
 // -- Main eval entry point --
 
-// Maximum number of words after {*} expansion.  The parse limit is
-// MAX_WORDS per command, but each {*}$var can expand to many elements.
-// 128 is generous enough for realistic Tcl calls while staying cheap
-// on the WASM stack.
-const MAX_EXPANDED_WORDS: u32 = 128;
+// Initial (stack) capacity for the post-{*}-expansion word array.  A
+// single ``{*}$list`` can expand to an unbounded number of words — far
+// more than the MAX_WORDS parse limit — so this is only the starting
+// size: ``WordBuf`` spills to a heap array once it overflows.  The old
+// code used a *fixed* 128-slot array and silently dropped every word
+// past 127, so e.g. ``tcl::mathop::+ {*}[lseq 1 1000]`` summed only the
+// first 127 elements (dict-24.24's wrong result, list-/concat-/proc-arg
+// truncation).
+const EXPAND_STACK_WORDS: u32 = 128;
+
+/// Growable argument vector for the ``{*}`` expansion slow path.  Starts
+/// in an inline stack buffer and grows geometrically onto the heap when
+/// the expanded word count exceeds it, so the argument list is never
+/// truncated.  ``deinit`` frees the heap spill (the stack buffer needs
+/// no cleanup); the caller still owns and releases each word TclObj.
+const WordBuf = struct {
+    stack: [EXPAND_STACK_WORDS]i32 = undefined,
+    ptr: [*]i32 = undefined,
+    cap: u32 = EXPAND_STACK_WORDS,
+    len: u32 = 0,
+    heap: u32 = 0, // heap buffer addr (0 ⇒ still using the stack array)
+
+    fn init(self: *WordBuf) void {
+        self.ptr = &self.stack;
+        self.cap = EXPAND_STACK_WORDS;
+        self.len = 0;
+        self.heap = 0;
+    }
+    /// Append a word handle; grows to the heap on overflow.  Returns
+    /// false only on allocation failure (caller bails the command).
+    fn push(self: *WordBuf, v: i32) bool {
+        if (self.len >= self.cap) {
+            const new_cap = self.cap * 2;
+            const nb = alloc(new_cap * 4);
+            if (nb == 0) return false;
+            const dst: [*]i32 = @ptrFromInt(nb);
+            var i: u32 = 0;
+            while (i < self.len) : (i += 1) dst[i] = self.ptr[i];
+            if (self.heap != 0) obj_mod.free_sized(self.heap, self.cap * 4);
+            self.heap = nb;
+            self.ptr = dst;
+            self.cap = new_cap;
+        }
+        self.ptr[self.len] = v;
+        self.len += 1;
+        return true;
+    }
+    fn slice(self: *WordBuf) []i32 {
+        return self.ptr[0..self.len];
+    }
+    fn deinit(self: *WordBuf) void {
+        if (self.heap != 0) obj_mod.free_sized(self.heap, self.cap * 4);
+    }
+};
 
 /// Public entry point into ``eval_command`` — lets cmds/flow.zig (tailcall)
 /// dispatch a command by words slice without exposing the private function.
@@ -6379,9 +6428,12 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
         return result;
     }
 
-    // Slow path: at least one {*} expansion.
-    var expanded: [MAX_EXPANDED_WORDS]i32 = undefined;
-    var ecount: u32 = 0;
+    // Slow path: at least one {*} expansion.  ``WordBuf`` grows onto
+    // the heap so the expanded argument list is never truncated.
+    const list_parse = @import("../valtypes/tcl_list_parse.zig");
+    var wb: WordBuf = .{};
+    wb.init();
+    defer wb.deinit();
     var pending_expand = false;
     var t: u32 = 0;
     while (t < tokens_len) : (t += 1) {
@@ -6402,68 +6454,76 @@ fn execute_parsed_command(body_ptr: u32, tokens_ptr: u32, tokens_len: u32) i32 {
             pending_expand = false;
             const s = obj_ensure_string(word_obj);
             const n = list_count_elements(s.ptr, s.len);
+            // Walk with a forward cursor (O(1) per element) instead of
+            // ``list_element_at(j)`` (O(j) — a ``{*}`` of an N-element
+            // list would otherwise be O(N^2)).
+            var cur = list_parse.Cursor{ .pos = 0 };
             var j: i64 = 0;
             while (j < n) : (j += 1) {
-                if (ecount >= MAX_EXPANDED_WORDS) break;
-                const elem = list_element_at(s.ptr, s.len, j);
-                if (elem.braced) {
-                    expanded[ecount] = obj_new_string_copy(s.ptr + elem.start, elem.len);
-                } else {
+                const elem = list_parse.cursor_next(s.ptr, s.len, &cur);
+                const ew: i32 = if (elem.braced)
+                    obj_new_string_copy(s.ptr + elem.start, elem.len)
+                else blk: {
                     const buf = alloc(elem.len);
                     if (buf == 0) {
                         obj_mod.tcl_obj_release(word_obj);
-                        return 0;
+                        return release_wordbuf_and_return(&wb, 0);
                     }
                     const out_len = copy_unbraced_elem(buf, s.ptr + elem.start, elem.len);
-                    expanded[ecount] = obj_new_string_take(buf, out_len, elem.len);
+                    break :blk obj_new_string_take(buf, out_len, elem.len);
+                };
+                if (!wb.push(ew)) {
+                    obj_mod.tcl_obj_release(ew);
+                    obj_mod.tcl_obj_release(word_obj);
+                    return release_wordbuf_and_return(&wb, 0);
                 }
-                ecount += 1;
             }
             // Release the source word obj — its bytes have been copied
-            // into independently-owned ``expanded[]`` entries above.
-            // Without this release, every ``{*}$args`` expansion leaked
-            // the source list object, growing the heap monotonically
-            // across long-running tcltest sweeps and exhausting the
-            // 32-byte slab class.
+            // into independently-owned ``wb`` entries above.  Without
+            // this release, every ``{*}$args`` expansion leaked the
+            // source list object, growing the heap monotonically across
+            // long-running tcltest sweeps and exhausting the 32-byte
+            // slab class.
             obj_mod.tcl_obj_release(word_obj);
         } else {
-            if (ecount < MAX_EXPANDED_WORDS) {
-                expanded[ecount] = word_obj;
-                ecount += 1;
+            if (!wb.push(word_obj)) {
+                obj_mod.tcl_obj_release(word_obj);
+                return release_wordbuf_and_return(&wb, 0);
             }
         }
     }
-    // MM-B.4 (slow path): release expanded[] elements after
-    // dispatch, with the same alias-aware retain pattern as the
-    // fast path.  Each ``{*}$args`` expansion element is a fresh
-    // TclObj that owns its bytes — braced elements via
-    // ``obj_new_string_copy`` (cap = rounded-up alloc), unbraced
-    // via ``obj_new_string_take`` (cap matches the per-element
-    // ``alloc(elem.len)`` that backed the backslash-decoded copy).
-    // Issue #317: the older ``obj_new_string`` borrowing form left
-    // ``cap = 0`` and leaked one buf per unbraced element on
-    // release — observed under io.test as the residual heap
-    // pressure that pushed the runtime past its 4 GiB ceiling.
-    // In both cases an element's release is independent of any
-    // peer; releasing one doesn't free a buffer another element
-    // borrows.
-    const result = eval_command(expanded[0..ecount]);
+    // MM-B.4 (slow path): release the word TclObjs after dispatch, with
+    // the same alias-aware retain pattern as the fast path.  Each
+    // ``{*}$args`` expansion element is a fresh TclObj that owns its
+    // bytes — braced elements via ``obj_new_string_copy`` (cap =
+    // rounded-up alloc), unbraced via ``obj_new_string_take`` (cap
+    // matches the per-element ``alloc(elem.len)``).  Releasing one is
+    // independent of any peer.
+    const words_slice = wb.slice();
+    const result = eval_command(words_slice);
     var result_is_word = false;
-    if (result != 0) {
-        var sc: u32 = 0;
-        while (sc < ecount) : (sc += 1) {
-            if (expanded[sc] == result) {
-                result_is_word = true;
-                break;
-            }
+    for (words_slice) |w| {
+        if (w == result) {
+            result_is_word = true;
+            break;
         }
     }
     if (result_is_word) obj_mod.tcl_obj_retain(result);
-    var ri: u32 = 0;
-    while (ri < ecount) : (ri += 1) {
-        if (expanded[ri] != 0) obj_mod.tcl_obj_release(expanded[ri]);
+    for (words_slice) |w| {
+        if (w != 0) obj_mod.tcl_obj_release(w);
     }
     return result;
+}
+
+/// Release every word TclObj staged in ``wb`` and return ``ret`` —
+/// the bail-out path for the ``{*}`` expansion slow path when an
+/// allocation fails mid-assembly.  ``wb.deinit`` (via the caller's
+/// ``defer``) frees the heap spill afterwards.
+fn release_wordbuf_and_return(wb: *WordBuf, ret: i32) i32 {
+    for (wb.slice()) |w| {
+        if (w != 0) obj_mod.tcl_obj_release(w);
+    }
+    return ret;
 }
 
 // Exported: evaluate a Tcl script string.

--- a/runtime/zig/interp/tcl_ns.zig
+++ b/runtime/zig/interp/tcl_ns.zig
@@ -1074,12 +1074,16 @@ fn ensure_var_obj_owned(o: i32) i32 {
     // pointers would read unrelated memory (or trap above 2 GiB).
     if (obj.is_immediate(o)) return o;
     const addr: u32 = @bitCast(o);
-    // Only string-typed objs have a borrowed-buffer concern.  Int /
-    // float / list / dict objs use the value slot for their payload
-    // (the str_* slots may be lazily-materialised string reps the
-    // borrower owns themselves).
+    // String AND list objs keep their primary bytes in the OBJ_STR_*
+    // slots, so both carry the borrowed-buffer concern and must reach
+    // the cap check below.  A TYPE_LIST is a canonical list string; it
+    // is currently always created owning its buffer (cap > 0), but
+    // routing it through the cap check — rather than relying on that
+    // (load-bearing) invariant — keeps this helper correct even if a
+    // borrowing (cap == 0) TYPE_LIST is ever introduced.  Int / float /
+    // dict objs carry their payload in the value slot and pass through.
     const tag = obj.read_i32(addr + obj.OBJ_TYPE_TAG);
-    if (tag != obj.TYPE_STRING) return o;
+    if (tag != obj.TYPE_STRING and tag != obj.TYPE_LIST) return o;
     const cap: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_STR_CAP));
     if (cap > 0) return o;
     const sptr: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_STR_PTR));

--- a/runtime/zig/valtypes/tcl_array.zig
+++ b/runtime/zig/valtypes/tcl_array.zig
@@ -465,8 +465,12 @@ fn ensure_array_value_owned(o: i32) i32 {
     // S6.4 — tagged immediates have no header to read.
     if (obj.is_immediate(o)) return o;
     const addr: u32 = @bitCast(o);
+    // TYPE_LIST stores its canonical list string in the OBJ_STR_* slots,
+    // so it shares the borrowed-buffer concern and must reach the cap
+    // check (always owning today; don't depend on that invariant — see
+    // tcl_ns.ensure_var_obj_owned).
     const tag = read_i32(addr + obj.OBJ_TYPE_TAG);
-    if (tag != obj.TYPE_STRING) return o;
+    if (tag != obj.TYPE_STRING and tag != obj.TYPE_LIST) return o;
     const cap: u32 = @bitCast(read_i32(addr + obj.OBJ_STR_CAP));
     if (cap > 0) return o;
     const sptr: u32 = @bitCast(read_i32(addr + obj.OBJ_STR_PTR));

--- a/runtime/zig/valtypes/tcl_dict.zig
+++ b/runtime/zig/valtypes/tcl_dict.zig
@@ -96,7 +96,7 @@ pub fn dict_destroy_ext(ext_addr: u32) void {
 pub fn dict_invalidate_cache(dict_obj: i32) void {
     if (dict_obj == 0) return;
     if (obj.is_immediate(dict_obj)) return;
-    const addr: u32 = @intCast(dict_obj);
+    const addr: u32 = @bitCast(dict_obj);
     const ext: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_DICT_EXT));
     if (ext == 0) return;
     obj.write_i32(addr + obj.OBJ_DICT_EXT, 0);
@@ -343,7 +343,7 @@ fn dict_hash_insert(ext_addr: u32, kp: u32, kl: u32, h: u32, value: i32) void {
 fn dict_ensure_cache(dict_obj: i32) u32 {
     if (dict_obj == 0) return 0;
     if (obj.is_immediate(dict_obj)) return 0;
-    const addr: u32 = @intCast(dict_obj);
+    const addr: u32 = @bitCast(dict_obj);
     var ext: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_DICT_EXT));
     if (ext != 0) return ext;
     ext = dict_ext_alloc();
@@ -479,7 +479,7 @@ pub export fn dict_set(dict: i32, key: i32, value: i32) i32 {
     // already cope with immediates; the in-place path needs the same
     // guard.
     if (sd.len > 0 and dict != 0 and !obj.is_immediate(dict)) {
-        const addr: u32 = @intCast(dict);
+        const addr: u32 = @bitCast(dict);
         const rc = obj.read_i32(addr + obj.OBJ_REFCOUNT);
         const tag = obj.read_i32(addr + obj.OBJ_TYPE_TAG);
         const cap: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_STR_CAP));
@@ -540,8 +540,8 @@ pub export fn dict_set(dict: i32, key: i32, value: i32) i32 {
     // just-appended (k, v) pair, so the next mutation on the new
     // dict starts cache-warm.
     if (new != 0 and !obj.is_immediate(new) and ext != 0 and dict != 0 and !obj.is_immediate(dict)) {
-        const dict_addr: u32 = @intCast(dict);
-        const new_addr: u32 = @intCast(new);
+        const dict_addr: u32 = @bitCast(dict);
+        const new_addr: u32 = @bitCast(new);
         const dict_rc = obj.read_i32(dict_addr + obj.OBJ_REFCOUNT);
         var target_ext: u32 = 0;
         if (dict_rc <= 1) {

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -31,8 +31,8 @@ const list_parse = @import("tcl_list_parse.zig");
 // index, cursor position, count) lets a forward step advance the cursor in
 // O(1), making the loop O(N).  Random / cold access falls back to a full
 // walk (no worse than before).  The cache is validated by object handle +
-// buffer pointer + length + count, and invalidated whenever that buffer is
-// freed (see ``list_index_cache_invalidate``, called from
+// buffer pointer + length + count, and invalidated when the cached object is
+// released (see ``list_index_cache_invalidate``, called from
 // ``tcl_obj.release_now``), so a recycled slab can never produce a stale hit.
 var lic_obj: i32 = 0;
 var lic_buf: u32 = 0;
@@ -41,11 +41,15 @@ var lic_count: i64 = 0;
 var lic_idx: i64 = -1; // element index the cursor currently sits *after*
 var lic_cursor: list_parse.Cursor = .{ .pos = 0 };
 
-/// Drop the cursor cache if it refers to ``buf`` (a buffer about to be
-/// freed).  Pointer-keyed so the obj module can call it without knowing the
-/// cache layout.
-pub fn list_index_cache_invalidate(buf: u32) void {
-    if (buf != 0 and buf == lic_buf) {
+/// Drop the cursor cache if it refers to object ``o`` (a TclObj about to be
+/// freed).  Keyed on the object *handle* so it fires for every rep — crucially
+/// including inline strings, whose buffer lives inside the obj header
+/// (``cap == 0``) and so never reaches ``release_now``'s external-buffer free
+/// path.  Without this, a freed slab reissued to another same-length inline
+/// list could satisfy the (handle, ptr, len) cache check and return an element
+/// from the stale cursor position instead of reparsing the new bytes.
+pub fn list_index_cache_invalidate(o: i32) void {
+    if (o != 0 and o == lic_obj) {
         lic_obj = 0;
         lic_buf = 0;
         lic_idx = -1;

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -63,8 +63,18 @@ pub export fn tcl_cmd_lappend(current: i32, value: i32) i32 {
     // raise ``unmatched open brace in list`` (listobj-4.4).  Without
     // this guard the fast path below appended ``" abc"`` to the
     // malformed string and silently produced a still-malformed list.
+    //
+    // Phase 1 list rep: a value tagged ``TYPE_LIST`` already carries a
+    // canonical list string by construction — every byte we appended
+    // was quoted canonically, so the buffer is known-valid and the
+    // O(N) re-scan is redundant.  Skipping it for the canonical case is
+    // what turns an N-element accumulate from O(N^2) back into O(N):
+    // ``lsearch -all`` over a 100k list (dict-24.24/24.25) went from a
+    // >120 s watchdog timeout to ~0.1 s.  We only validate when the
+    // source is NOT a known-canonical list.
     const lp = @import("tcl_list_parse.zig");
-    if (sc.len > 0 and lp.check_list_syntax(sc.ptr, sc.len) != 0) {
+    const cur_is_canon_list = is_canonical_list(current);
+    if (sc.len > 0 and !cur_is_canon_list and lp.check_list_syntax(sc.ptr, sc.len) != 0) {
         return 0;
     }
     // Fast path: when ``current`` is non-empty AND we own its byte
@@ -101,7 +111,7 @@ pub export fn tcl_cmd_lappend(current: i32, value: i32) i32 {
         const rc = obj.read_i32(addr + obj.OBJ_REFCOUNT);
         const tag = obj.read_i32(addr + obj.OBJ_TYPE_TAG);
         const cap: u32 = @bitCast(obj.read_i32(addr + obj.OBJ_STR_CAP));
-        if (rc == 1 and tag == obj.TYPE_STRING and cap > 0 and cap <= FAST_PATH_LEN_LIMIT / 2) {
+        if (rc == 1 and (tag == obj.TYPE_STRING or tag == obj.TYPE_LIST) and cap > 0 and cap <= FAST_PATH_LEN_LIMIT / 2) {
             // Worst case for the new tail: a single space + sv.len*2 + 2
             // (for surrounding braces if the value needs them).
             const tail_max: u32 = 1 + sv.len * 2 + 4;
@@ -131,10 +141,36 @@ pub export fn tcl_cmd_lappend(current: i32, value: i32) i32 {
             d[0] = ' ';
             const off = list_elem_quote_nth(buf, sc.len + 1, sv.ptr, sv.len);
             obj.write_i32(addr + obj.OBJ_STR_LEN, @bitCast(off));
+            // The buffer is still a canonical list (we appended one
+            // canonically-quoted element) — mark it so the next lappend
+            // skips the O(N) re-validation above.
+            obj.write_i32(addr + obj.OBJ_TYPE_TAG, obj.TYPE_LIST);
             return current;
         }
     }
     return lappend_canonical(sc.ptr, sc.len, sv.ptr, sv.len);
+}
+
+/// True when *obj* is a heap value carrying a canonical list string rep
+/// (``TYPE_LIST``) — its bytes are valid-by-construction so list ops can
+/// trust them without re-parsing.
+inline fn is_canonical_list(o: i32) bool {
+    if (o <= 0 or obj.is_immediate(o)) return false;
+    return obj.read_i32(@as(u32, @intCast(o)) + obj.OBJ_TYPE_TAG) == obj.TYPE_LIST;
+}
+
+/// Tag a freshly-built heap list string as ``TYPE_LIST`` so subsequent
+/// list operations skip re-validation / re-parsing.  Only promotes a
+/// plain heap ``TYPE_STRING`` (which keeps its materialised string rep
+/// in the same OBJ_STR_PTR/LEN/CAP slots TYPE_LIST reads from); leaves
+/// immediates, inline strings, ints, etc. untouched.
+inline fn mark_canonical_list(o: i32) i32 {
+    if (o > 0 and !obj.is_immediate(o)) {
+        const a: u32 = @intCast(o);
+        if (obj.read_i32(a + obj.OBJ_TYPE_TAG) == obj.TYPE_STRING)
+            obj.write_i32(a + obj.OBJ_TYPE_TAG, obj.TYPE_LIST);
+    }
+    return o;
 }
 
 /// Parse the existing list, re-quote each element canonically, then
@@ -211,7 +247,9 @@ fn lappend_canonical(sc_ptr: u32, sc_len: u32, sv_ptr: u32, sv_len: u32) i32 {
     // Switch to ``obj_new_string_take`` so the cap is set atomically
     // with the new TclObj — the older ``obj_new_string`` + manual
     // ``OBJ_STR_CAP`` write pattern leaks ``buf`` if obj_alloc OOMs.
-    return obj.obj_new_string_take(buf, off, cap);
+    // Mark TYPE_LIST: this rebuild produced a canonical list, so the
+    // next lappend against the result skips re-validation.
+    return mark_canonical_list(obj.obj_new_string_take(buf, off, cap));
 }
 
 // Exported: list — append one value to a list accumulator.  The

--- a/runtime/zig/valtypes/tcl_list.zig
+++ b/runtime/zig/valtypes/tcl_list.zig
@@ -19,6 +19,38 @@ const list_count_elements = obj.list_count_elements;
 const list_element_at = obj.list_element_at;
 const read_i32 = obj.read_i32;
 const write_i32 = obj.write_i32;
+const list_parse = @import("tcl_list_parse.zig");
+
+// ─── forward cursor cache for tcl_cmd_list_index ─────────────────────────────
+// The compiled ``foreach`` / forward ``lindex`` loops call
+// ``tcl_cmd_list_index(L, i)`` with monotonically increasing ``i`` on the
+// same list object.  Re-deriving element ``i`` from the string each time is
+// O(i) (plus an O(N) ``list_count_elements`` for index resolution), so a loop
+// over an N-element list is O(N^2) — ``foreach {k v} $huge`` was ~35 s at 20k
+// elements and trapped at 40k.  Caching the last (object, buffer, element
+// index, cursor position, count) lets a forward step advance the cursor in
+// O(1), making the loop O(N).  Random / cold access falls back to a full
+// walk (no worse than before).  The cache is validated by object handle +
+// buffer pointer + length + count, and invalidated whenever that buffer is
+// freed (see ``list_index_cache_invalidate``, called from
+// ``tcl_obj.release_now``), so a recycled slab can never produce a stale hit.
+var lic_obj: i32 = 0;
+var lic_buf: u32 = 0;
+var lic_len: u32 = 0;
+var lic_count: i64 = 0;
+var lic_idx: i64 = -1; // element index the cursor currently sits *after*
+var lic_cursor: list_parse.Cursor = .{ .pos = 0 };
+
+/// Drop the cursor cache if it refers to ``buf`` (a buffer about to be
+/// freed).  Pointer-keyed so the obj module can call it without knowing the
+/// cache layout.
+pub fn list_index_cache_invalidate(buf: u32) void {
+    if (buf != 0 and buf == lic_buf) {
+        lic_obj = 0;
+        lic_buf = 0;
+        lic_idx = -1;
+    }
+}
 
 // Exported: list length — count elements by whitespace-splitting.
 //
@@ -666,10 +698,29 @@ pub fn resolve_list_index(idx: i32, n: i64) i64 {
 // Exported: list index — extract the nth element (0-based).
 pub export fn tcl_cmd_list_index(list: i32, idx: i32) i32 {
     const s = obj_ensure_string(list);
-    const n = list_count_elements(s.ptr, s.len);
+    // Forward cursor cache: when this is the same list buffer we just
+    // walked, reuse the cached element count (skip the O(N) re-count) and,
+    // for the very common forward step (i == cached_i + 1), advance the
+    // cached cursor in O(1) instead of re-scanning from the start.
+    const cache_hit = lic_buf != 0 and list == lic_obj and s.ptr == lic_buf and s.len == lic_len;
+    const n = if (cache_hit) lic_count else list_count_elements(s.ptr, s.len);
     const i_val = resolve_list_index(idx, n);
     if (i_val < 0 or i_val >= n) return obj_new_string(0, 0);
-    const elem = list_element_at(s.ptr, s.len, i_val);
+    var elem: list_parse.Element = undefined;
+    if (cache_hit and i_val == lic_idx + 1) {
+        elem = list_parse.cursor_next(s.ptr, s.len, &lic_cursor);
+        lic_idx = i_val;
+    } else {
+        var cur = list_parse.Cursor{ .pos = 0 };
+        if (i_val > 0) list_parse.cursor_skip(s.ptr, s.len, &cur, @intCast(i_val));
+        elem = list_parse.cursor_next(s.ptr, s.len, &cur);
+        lic_obj = list;
+        lic_buf = s.ptr;
+        lic_len = s.len;
+        lic_count = n;
+        lic_idx = i_val;
+        lic_cursor = cur;
+    }
     if (elem.braced) return obj_new_string_copy(s.ptr + elem.start, elem.len);
     // Unbraced element: process backslash escapes.  Issue #317:
     // ``obj_new_string_take`` so the resulting TclObj owns its

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -1167,6 +1167,10 @@ fn release_now(addr: u32) void {
             // cmdIL.test.
             const parse_cache = @import("parse_cache.zig");
             parse_cache.invalidate_for_buffer(sp);
+            // Drop the list-index forward cursor cache if it points at
+            // this buffer, so a recycled slab can't yield a stale element.
+            const tcl_list = @import("tcl_list.zig");
+            tcl_list.list_index_cache_invalidate(sp);
             free_sized(sp, cap);
         }
     }

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -741,7 +741,7 @@ pub fn obj_get_bignum(obj: i32) i128 {
         const fval: f64 = @bitCast(read_i64(addr + OBJ_INT_CACHE));
         return float_to_i128_clamped(fval);
     }
-    if (tag == TYPE_STRING or tag == TYPE_INLINE_STRING) {
+    if (tag == TYPE_STRING or tag == TYPE_INLINE_STRING or tag == TYPE_LIST) {
         const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
         const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (bignum.parse_i128(sptr, slen)) |val| return val;
@@ -798,7 +798,7 @@ pub fn obj_promote_to_bignum(obj: i32) struct { m: ?*bignum.BigInt, owned: bool 
     if (obj != 0 and !is_immediate(obj)) {
         const addr: u32 = @bitCast(obj);
         const tag = read_i32(addr + OBJ_TYPE_TAG);
-        if (tag == TYPE_STRING or tag == TYPE_INLINE_STRING) {
+        if (tag == TYPE_STRING or tag == TYPE_INLINE_STRING or tag == TYPE_LIST) {
             const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
             const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
             if (try_parse_int(sptr, slen) == null) {
@@ -827,7 +827,7 @@ pub export fn obj_get_float(obj: i32) f64 {
         const m: *bignum.BigInt = @ptrFromInt(ptr_addr);
         return bignum.to_f64(m);
     }
-    if (tag == TYPE_STRING) {
+    if (tag == TYPE_STRING or tag == TYPE_LIST) {
         const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
         const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (try_parse_float(sptr, slen)) |val| return val;
@@ -884,7 +884,7 @@ pub export fn obj_get_int(obj: i32) i64 {
         const m: *bignum.BigInt = @ptrFromInt(ptr_addr);
         return bignum.to_i64(m);
     }
-    if (tag == TYPE_STRING) {
+    if (tag == TYPE_STRING or tag == TYPE_LIST) {
         const sptr: u32 = @bitCast(read_i32(addr + OBJ_STR_PTR));
         const slen: u32 = @bitCast(read_i32(addr + OBJ_STR_LEN));
         if (try_parse_int(sptr, slen)) |val| {
@@ -1310,6 +1310,15 @@ pub fn obj_type(obj: i32) i32 {
     // callers checking ``obj_type`` for ``TYPE_STRING`` shouldn't
     // have to know about it.
     if (tag == TYPE_INLINE_STRING) return TYPE_STRING;
+    // Phase 1 list rep: ``TYPE_LIST`` is a plain string obj whose buffer
+    // is additionally known to be a canonical list (the "skip list
+    // re-validation" marker set by ``tcl_cmd_lappend``).  Its scalar
+    // identity is still string — every value-level consumer (arithmetic
+    // float/bignum heuristics, ``string is``, formatting) must treat it
+    // exactly like ``TYPE_STRING``; the list-ness is an internal hint
+    // that only the list builders read via the raw type tag.  Normalise
+    // it here so introducing the marker can't change scalar behaviour.
+    if (tag == TYPE_LIST) return TYPE_STRING;
     return tag;
 }
 

--- a/runtime/zig/valtypes/tcl_obj.zig
+++ b/runtime/zig/valtypes/tcl_obj.zig
@@ -1167,13 +1167,16 @@ fn release_now(addr: u32) void {
             // cmdIL.test.
             const parse_cache = @import("parse_cache.zig");
             parse_cache.invalidate_for_buffer(sp);
-            // Drop the list-index forward cursor cache if it points at
-            // this buffer, so a recycled slab can't yield a stale element.
-            const tcl_list = @import("tcl_list.zig");
-            tcl_list.list_index_cache_invalidate(sp);
             free_sized(sp, cap);
         }
     }
+    // Drop the list-index forward cursor cache if it points at this object.
+    // Keyed on the handle (not the buffer) so it also fires for inline
+    // strings, whose buffer is inside the header (cap == 0) and never reaches
+    // the external-buffer free path above — otherwise a recycled slab reissued
+    // to another same-length inline list could yield a stale cursor element.
+    const tcl_list = @import("tcl_list.zig");
+    tcl_list.list_index_cache_invalidate(@bitCast(addr));
     free_obj(addr);
 }
 

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-04T07:49:58Z",
+  "generated_at": "2026-06-05T13:36:28Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -24,8 +24,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 7,
-      "passed_min": 79,
+      "failed_max": 6,
+      "passed_min": 80,
       "skipped": 60,
       "total": 146
     },
@@ -34,9 +34,9 @@
       "crash_type": "",
       "crashed": false,
       "failed_max": 20,
-      "passed_min": 4966,
+      "passed_min": 14734,
       "skipped": 147,
-      "total": 5133
+      "total": 14901
     },
     "cmdIL": {
       "bucket": "W-mixed-fail",
@@ -87,8 +87,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 7,
-      "passed_min": 149,
+      "failed_max": 4,
+      "passed_min": 152,
       "skipped": 15,
       "total": 171
     },

--- a/tests/test_wasm_binary.py
+++ b/tests/test_wasm_binary.py
@@ -47,6 +47,51 @@ def test_binary_format_w_wide_double_roundtrip(hexbits: str, expected: str) -> N
 
 
 @pytest.mark.parametrize(
+    "count",
+    [
+        # 0x7fffffff: fits in u32 but ``n*10`` overflowed mid-parse.
+        "2147483647",
+        # 0x10000000: in range, exercises the same accumulator.
+        "268435456",
+        # 0x100000000: exceeds u32 entirely.
+        "4294967296",
+        # 0x10000000000000000: exceeds u64 — C's strtoull sets ERANGE.
+        "18446744073709551616",
+    ],
+)
+def test_binary_scan_count_overflow_does_not_trap(count: str) -> None:
+    # GetFormatSpec count overflow (binary-37.10..37.13): a count larger
+    # than the data must saturate and make ``binary scan`` return 0 (the
+    # variable is left unset), never panic with an integer overflow trap
+    # that truncates the whole script.  ``x`` is a single byte, so any of
+    # these counts is far past the end.
+    body = f"puts [binary scan x a{count} r]\n"
+    assert _run(body) == "0"
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        # 'a' over-count: explicit count past the data stops the scan
+        # (goto done) — result 0, the variable is not written.
+        ("set r unset\nputs [binary scan abc a5 r]\nputs $r", "0\nunset"),
+        # 'a' exact / short counts still read normally.
+        ("binary scan abcdef a3 r\nputs $r", "abc"),
+        ("binary scan abcdef a* r\nputs $r", "abcdef"),
+        # x* skips to the end: the trailing a3 finds no bytes (goto done),
+        # so the scan returns 1 and the second variable keeps its old value.
+        ("set s foo\nputs [binary scan abcdefg a3x*a3 r s]\nputs $s", "1\nfoo"),
+        # X* rewinds to the start, so a2 re-reads from the front.
+        ("binary scan abcdef a3X*a2 r s\nputs [list $r $s]", "abc ab"),
+        # @* seeks to the end of the data; the following a1 finds nothing.
+        ("set s foo\nputs [binary scan abcdef a2@*a1 r s]\nputs $s", "1\nfoo"),
+    ],
+)
+def test_binary_scan_seek_and_overcount(body: str, expected: str) -> None:
+    assert _run(body) == expected
+
+
+@pytest.mark.parametrize(
     "body,expected",
     [
         ("binary scan [binary format c 200] cu x\nputs $x", "200"),

--- a/tests/test_wasm_expand_operator.py
+++ b/tests/test_wasm_expand_operator.py
@@ -65,3 +65,20 @@ _ECHO = "proc tp {args} {return $args}\n"
 )
 def test_expand_operator(source: str, expected: str) -> None:
     assert _run(source) == expected
+
+
+@pytest.mark.parametrize("n", [127, 128, 129, 500, 2000])
+def test_expand_does_not_truncate_large_lists(n: int) -> None:
+    # The compiled ``{*}`` slow path assembled words into a fixed 128-slot
+    # stack array and silently dropped every word past 127, so any command
+    # with more than ~127 expanded args was truncated (e.g.
+    # ``tcl::mathop::+ {*}[lseq 1 1000]`` summed only 1..127).  WordBuf now
+    # grows onto the heap; the full argument list must reach the command.
+    src = _COUNT + f"puts [tp {{*}}[lseq 1 {n}]]"
+    assert _run(src) == str(n)
+
+
+def test_expand_large_sum_is_exact() -> None:
+    # End-to-end: a >128-element {*} into a variadic builtin produces the
+    # full sum (dict-24.24's wrong value came from this truncation).
+    assert _run("puts [tcl::mathop::+ {*}[lseq 1 1000]]") == str(1000 * 1001 // 2)

--- a/tests/test_wasm_list_scaling.py
+++ b/tests/test_wasm_list_scaling.py
@@ -26,9 +26,7 @@ from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
 
 
 def _run(body: str, timeout_s: float = 30.0) -> str:
-    _, stdout = _run_wasm(
-        _compile_tcl(body), capture_stdout=True, timeout_s=timeout_s
-    )
+    _, stdout = _run_wasm(_compile_tcl(body), capture_stdout=True, timeout_s=timeout_s)
     return stdout.rstrip("\n")
 
 
@@ -65,11 +63,7 @@ def test_dict_map_huge_dict_terminates() -> None:
 def test_lappend_still_validates_malformed_list() -> None:
     # The marker must not weaken correctness: appending to a value whose
     # string rep is NOT a canonical list still raises (listobj-4.4).
-    body = (
-        'set x "a \\{b"\n'
-        "puts [catch {lappend x c} m]\n"
-        "puts $m\n"
-    )
+    body = 'set x "a \\{b"\nputs [catch {lappend x c} m]\nputs $m\n'
     assert _run(body) == "1\nunmatched open brace in list"
 
 
@@ -92,11 +86,7 @@ def test_foreach_over_large_list_is_linear() -> None:
     # monotonically increasing i.  Without the forward cursor cache each
     # call re-derived element i from the string (O(i)), making the loop
     # O(N^2) — foreach {k v} over a 20k list was ~35 s.  Now O(N).
-    body = (
-        "set s 0\n"
-        "foreach {k v} [lseq 1 20000] { incr s [expr {$k * $v}] }\n"
-        "puts $s\n"
-    )
+    body = "set s 0\nforeach {k v} [lseq 1 20000] { incr s [expr {$k * $v}] }\nputs $s\n"
     assert _run(body) == "1333433330000"
 
 
@@ -118,7 +108,7 @@ def test_forward_lindex_loop_is_linear() -> None:
         # nested loops must all return the right element.
         ("puts [lindex {a b c d e} 3]", "d"),
         ("puts [lindex {a b c d e} end]", "e"),
-        ("set L {a b c d}\nputs \"[lindex $L 3][lindex $L 0][lindex $L 2]\"", "dac"),
+        ('set L {a b c d}\nputs "[lindex $L 3][lindex $L 0][lindex $L 2]"', "dac"),
         (
             "set o {}\nforeach a {1 2 3} {foreach b {x y} {append o $a$b}}\nputs $o",
             "1x1y2x2y3x3y",
@@ -127,3 +117,22 @@ def test_forward_lindex_loop_is_linear() -> None:
 )
 def test_list_index_cache_correctness(body: str, expected: str) -> None:
     assert _run(body) == expected
+
+
+def test_list_index_cache_inline_slab_reuse() -> None:
+    # Regression: the cursor cache must invalidate on object *release*, keyed
+    # on the handle — inline strings (<=8 bytes, cap==0) keep their buffer in
+    # the obj header and never hit the external-buffer free path.  Repeatedly
+    # building, indexing, and discarding a short list reuses the freed slab; a
+    # stale (handle, ptr, len) hit would return an element from a prior list.
+    body = (
+        "set ok 1\n"
+        "for {set i 0} {$i < 5000} {incr i} {\n"
+        "  set L [list a b c]\n"
+        '  if {[lindex $L 0] ne "a" || [lindex $L 2] ne "c"} { set ok 0; break }\n'
+        "  set M [list x y z]\n"
+        '  if {[lindex $M 0] ne "x" || [lindex $M 2] ne "z"} { set ok 0; break }\n'
+        "}\n"
+        "puts $ok\n"
+    )
+    assert _run(body) == "1"

--- a/tests/test_wasm_list_scaling.py
+++ b/tests/test_wasm_list_scaling.py
@@ -1,0 +1,87 @@
+"""WASM list/dict build scaling — the Phase 1 list internal rep.
+
+``tcl_cmd_lappend`` used to re-validate the *entire* accumulator with
+``check_list_syntax`` (an O(N) scan) on every append, so building an
+N-element list — ``lappend`` in a loop, ``lsearch -all``, ``dict map``
+collecting a result — was O(N^2).  At 100k elements this blew past the
+180 s watchdog (dict-24.24 / dict-24.25 timed out).
+
+Phase 1 gives a lappend-built list a ``TYPE_LIST`` marker meaning "this
+buffer is a canonical list by construction", so subsequent appends skip
+the re-validation and the build is back to amortised O(N).  These tests
+exercise sizes that finish in well under a second when linear but would
+trip the wasmtime watchdog if the quadratic regressed.
+
+The runtime ``timeout_s`` is the real assertion: a regression to O(N^2)
+makes ``_run_wasm`` raise (watchdog interrupt) and the test fails.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wasmtime = pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(body: str, timeout_s: float = 30.0) -> str:
+    _, stdout = _run_wasm(
+        _compile_tcl(body), capture_stdout=True, timeout_s=timeout_s
+    )
+    return stdout.rstrip("\n")
+
+
+def test_lappend_loop_is_linear() -> None:
+    # Build a 50k-element list one lappend at a time; O(N^2) would not
+    # finish under the watchdog.  Verify length + a sampled element.
+    body = (
+        "set x {}\n"
+        "for {set i 0} {$i < 50000} {incr i} { lappend x $i }\n"
+        "puts [llength $x]\n"
+        "puts [lindex $x 49999]\n"
+    )
+    assert _run(body) == "50000\n49999"
+
+
+def test_lsearch_all_is_linear() -> None:
+    # lsearch -all accumulates every match via tcl_cmd_lappend — the
+    # exact path that made dict-24.24's input build quadratic.
+    body = "puts [llength [lsearch -all [lrepeat 100000 x] x]]\n"
+    assert _run(body) == "100000"
+
+
+def test_dict_map_huge_dict_terminates() -> None:
+    # dict-24.24 verbatim: dict map over a 100k-element dict, summing
+    # k*v.  Hung (>120 s) before the fix; ~1.7 s after.
+    body = (
+        "puts [tcl::mathop::+ {*}"
+        "[dict map {k v} [lsearch -all [lrepeat 100000 x] x] "
+        "{ expr { $k * $v } }]]\n"
+    )
+    assert _run(body) == "166666666600000"
+
+
+def test_lappend_still_validates_malformed_list() -> None:
+    # The marker must not weaken correctness: appending to a value whose
+    # string rep is NOT a canonical list still raises (listobj-4.4).
+    body = (
+        'set x "a \\{b"\n'
+        "puts [catch {lappend x c} m]\n"
+        "puts $m\n"
+    )
+    assert _run(body) == "1\nunmatched open brace in list"
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        # A lappend-built list whose single element is numeric must still
+        # parse as a number (the TYPE_LIST marker is scalar-transparent).
+        ("set x {}\nlappend x 5\nputs [expr {$x + 1}]", "6"),
+        ("set x {}\nlappend x 5.5\nputs [expr {$x + 1}]", "6.5"),
+        ("set x {}\nlappend x a b c\nputs [lindex $x 1]", "b"),
+    ],
+)
+def test_lappend_marker_is_scalar_transparent(body: str, expected: str) -> None:
+    assert _run(body) == expected

--- a/tests/test_wasm_list_scaling.py
+++ b/tests/test_wasm_list_scaling.py
@@ -85,3 +85,45 @@ def test_lappend_still_validates_malformed_list() -> None:
 )
 def test_lappend_marker_is_scalar_transparent(body: str, expected: str) -> None:
     assert _run(body) == expected
+
+
+def test_foreach_over_large_list_is_linear() -> None:
+    # The compiled foreach calls tcl_cmd_list_index(L, i) per element with
+    # monotonically increasing i.  Without the forward cursor cache each
+    # call re-derived element i from the string (O(i)), making the loop
+    # O(N^2) — foreach {k v} over a 20k list was ~35 s.  Now O(N).
+    body = (
+        "set s 0\n"
+        "foreach {k v} [lseq 1 20000] { incr s [expr {$k * $v}] }\n"
+        "puts $s\n"
+    )
+    assert _run(body) == "1333433330000"
+
+
+def test_forward_lindex_loop_is_linear() -> None:
+    # The same cursor cache covers a forward ``lindex $L $i`` loop.
+    body = (
+        "set L [lseq 0 19999]\n"
+        "set s 0\n"
+        "for {set i 0} {$i < 20000} {incr i} { incr s [lindex $L $i] }\n"
+        "puts $s\n"
+    )
+    assert _run(body) == str(sum(range(20000)))
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        # Cursor cache correctness: random / backward / repeated access and
+        # nested loops must all return the right element.
+        ("puts [lindex {a b c d e} 3]", "d"),
+        ("puts [lindex {a b c d e} end]", "e"),
+        ("set L {a b c d}\nputs \"[lindex $L 3][lindex $L 0][lindex $L 2]\"", "dac"),
+        (
+            "set o {}\nforeach a {1 2 3} {foreach b {x y} {append o $a$b}}\nputs $o",
+            "1x1y2x2y3x3y",
+        ),
+    ],
+)
+def test_list_index_cache_correctness(body: str, expected: str) -> None:
+    assert _run(body) == expected


### PR DESCRIPTION
## Summary

This PR fixes three critical performance and correctness issues in the WASM runtime:

1. **{*} expansion truncation (dict-24.24 wrong result):** The `{*}` slow path assembled expanded words into a fixed 128-slot stack array and silently dropped every word past 127. Commands like `tcl::mathop::+ {*}[lseq 1 1000]` would sum only the first 127 elements. Replaced the fixed array with a `WordBuf` struct that grows geometrically onto the heap, ensuring the full argument list reaches the command.

2. **List operation O(N²) scaling (dict-24.24/24.25 timeout):** 
   - `lappend` re-validated the entire accumulator with `check_list_syntax` on every append, making N-element list builds O(N²). Introduced a `TYPE_LIST` marker for canonically-built lists to skip redundant validation.
   - `lindex` in forward loops (e.g., `foreach` over large lists) re-derived element positions from scratch each time, also O(N²). Added a forward cursor cache (`lic_*` variables) that advances in O(1) for monotonically increasing indices.

3. **`binary scan` count overflow (binary-37.10..37.13):** The count parser accumulated digits with `n*10` without overflow checking, causing integer overflow panics on large counts like `a[0x100000000]`. Now saturates to `maxInt(u32)` per C Tcl's `GetFormatSpec` behavior, making over-count cases return 0 (variable unset) instead of panicking.

## Changes

- **`runtime/zig/interp/tcl_interp.zig`:** Replaced `MAX_EXPANDED_WORDS` fixed array with `WordBuf` growable struct; updated `{*}` expansion slow path to use it.
- **`runtime/zig/valtypes/tcl_list.zig`:** Added `TYPE_LIST` marker and forward cursor cache for `lindex`; optimized `lappend` to skip validation for canonical lists.
- **`runtime/zig/cmds/binary.zig`:** Fixed `parse_count` to saturate on overflow; fixed `binary scan` 'a'/'A' specifiers to respect count bounds per C contract.
- **`runtime/zig/valtypes/tcl_obj.zig`:** Updated `obj_get_bignum` and `obj_promote_to_bignum` to handle `TYPE_LIST` tag.
- **`runtime/zig/valtypes/tcl_dict.zig`:** Fixed bitcast in `dict_invalidate_cache`.
- **Tests:** Added `test_wasm_list_scaling.py` with scaling tests for lappend, lsearch, dict map, and foreach; added `test_wasm_expand_operator.py` tests for large expansion; added `test_wasm_binary.py` tests for count overflow and seek/overcount behavior.
- **Design docs:** Added three first-principles runtime contracts:
  - `runtime-variable-frame-model.md` — cell/frame/namespace resolution
  - `parser-and-aot-interpret-boundary.md` — AOT/interpret boundary
  - `numeric-tower-and-expr-semantics.md` — numeric tower and expr semantics

## Validation

- Added comprehensive test suites covering the fixed regressions:
  - `test_lappend_loop_is_linear()` — 50k-element lappend in <1s (was >180s)
  - `test_dict_map_huge_dict_terminates()` — dict-24.24 verbatim, now ~1.7s (was >120s)
  - `test_foreach_over_large_list_is_linear()` — 20k-element foreach in O(N)
  - `test_expand_does_not_truncate_large_lists()` — {*} with >128 args
  - `test_binary_scan_count_overflow_does_not_trap()` —

https://claude.ai/code/session_01D5PfV8vqyAyNYQ7NqZXxhX