### PR TITLE
Fix pre-existing typecheck failures and codes_all catalog gap

### DIFF
--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -447,8 +447,7 @@ def resolve_rust_server(override: str | None) -> tuple[str, list[str], str]:
     binary = root / "target" / "debug" / "tcl-lsp-server"
     if not binary.exists():
         print(
-            "Rust server binary not found; building "
-            "(cargo build -p tcl-lsp-server)...",
+            "Rust server binary not found; building (cargo build -p tcl-lsp-server)...",
             file=sys.stderr,
         )
         subprocess.run(

--- a/core/analysis/signature_scan.py
+++ b/core/analysis/signature_scan.py
@@ -51,7 +51,9 @@ log = logging.getLogger(__name__)
 # first call to keep the Python-only test environment clean (no
 # ``ImportError`` at module-import time when the wheel is absent).
 try:
-    from tcl_lsp_rust import signature_scan_extract as _rust_signature_scan_extract  # type: ignore[import-not-found]
+    from tcl_lsp_rust import (  # type: ignore[import-not-found]
+        signature_scan_extract as _rust_signature_scan_extract,
+    )
 except ImportError:  # pragma: no cover — exercised in pure-Python CI envs
     _rust_signature_scan_extract = None
 

--- a/core/common/codes_all.py
+++ b/core/common/codes_all.py
@@ -6,8 +6,26 @@ via :mod:`core.common.codes`.  Each module registers its codes via
 """
 
 # analysis
-import core.analysis  # noqa: F401
+#
+# ``core.analysis`` exposes the analyser lazily through a module-level
+# ``__getattr__`` (see ``core/analysis/__init__.py``), so a bare
+# ``import core.analysis`` never loads ``_analyser`` or fires its
+# ``@diag`` / ``diag(...)`` registrations.  Import the package directly
+# so the codes registry — and every codegen catalog built from it —
+# sees the full core-analyser set (E2xx, H300, W11x–W22x,
+# IRULE4005 / IRULE500x) and not just the codes wired through ``checks``.
+import core.analysis._analyser  # noqa: F401
 import core.analysis.checks._domain  # noqa: F401
+
+# style codes that were historically defined alongside the
+# pygls server in `lsp.features.diagnostics`. The bare
+# `@diag` registrations now live in
+# `core.analysis.checks._lsp_style` so the codes registry
+# stays populated after PYTHON-RETIRE-LSP deletes the LSP
+# feature tree; the actual emit functions stay in
+# `lsp.features.diagnostics` until that retirement
+# completes.
+import core.analysis.checks._lsp_style  # noqa: F401
 import core.analysis.checks._security  # noqa: F401
 import core.analysis.checks._style  # noqa: F401
 import core.analysis.checks._syntax  # noqa: F401
@@ -34,13 +52,3 @@ import core.compiler.taint._uri_split  # noqa: F401
 # extensions
 import core.tk.diagnostics  # noqa: F401
 import core.xc.translator  # noqa: F401
-
-# style codes that were historically defined alongside the
-# pygls server in `lsp.features.diagnostics`. The bare
-# `@diag` registrations now live in
-# `core.analysis.checks._lsp_style` so the codes registry
-# stays populated after PYTHON-RETIRE-LSP deletes the LSP
-# feature tree; the actual emit functions stay in
-# `lsp.features.diagnostics` until that retirement
-# completes.
-import core.analysis.checks._lsp_style  # noqa: F401

--- a/lsp/server.py
+++ b/lsp/server.py
@@ -64,7 +64,7 @@ log = logging.getLogger(__name__)
 
 
 try:
-    from ._build_info import FULL_VERSION as _version
+    from core._build_info import FULL_VERSION as _version
 except ImportError:
     _version = "dev"
 

--- a/lsp/workspace_init.py
+++ b/lsp/workspace_init.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 try:
-    from ._build_info import FULL_VERSION as _version
+    from core._build_info import FULL_VERSION as _version
 except ImportError:
     _version = "dev"
 

--- a/runtime/rust-spike/dynamic-link/loader.py
+++ b/runtime/rust-spike/dynamic-link/loader.py
@@ -140,8 +140,10 @@ def main():
 
     print("== Rust-runtime C-extension spike (DYNAMIC side-module loading) ==")
     print(f"side module: {side_path}")
-    print(f"  loaded at  __memory_base={memory_base} __table_base={table_base} "
-          f"(needs {msize}B data, {tsize} table slots)")
+    print(
+        f"  loaded at  __memory_base={memory_base} __table_base={table_base} "
+        f"(needs {msize}B data, {tsize} table slots)"
+    )
     print(f"Pkga_Init(interp) -> {init_rc} (TCL_OK = {init_rc == 0})")
     print()
 


### PR DESCRIPTION
Two independent pre-existing issues on `rust` surfaced by `make prep-pr` (which runs `format` before `typecheck`/`codegen`). Both are unrelated to the registry workstream; this branch deliberately stays out of `core/bigip/registry/**`, `core/commands/registry/**`, `rust/tcl-registry/**`, and `scripts/registry-audit/**`.

## 1. typecheck-py (ty, wheel-absent) — was 3 diagnostics, now 0

- **`core/analysis/signature_scan.py`** — `ruff format` line-wraps the `tcl_lsp_rust` import and moves `# type: ignore[import-not-found]` onto the inner line, leaving the `from … import (` line (where ty reports `unresolved-import`) unsuppressed → `unresolved-import` + `unused-type-ignore-comment`. Moved the suppression to the `from … import (` line; the magic trailing comma keeps it stable under `ruff format`.
- **`lsp/workspace_init.py` + `lsp/server.py`** — imported `from ._build_info` (= `lsp._build_info`), which is never generated (the BUILD_INFO target only writes `core/_build_info.py`), so ty flagged `unresolved-import` and at runtime the version silently fell back to `"dev"`. Switched to `from core._build_info`, matching the existing `core/_build_info` consumers (`explorer/cli.py`, zipapp mains) — also fixes the latent always-`"dev"` version bug.

## 2. codes_all catalog gap — `make codegen` dropped 18 still-emitted codes

Raw `make codegen` was dropping 18 still-emitted diagnostic codes (`E200`, `H300`, `IRULE4005`/`500x`, `W11x`–`W22x`) from every editor catalog and doc.

Root cause: `core/analysis/__init__.py` exposes the analyser via a lazy module `__getattr__`, so `codes_all`'s bare `import core.analysis` never loaded `_analyser` or fired its `@diag`/`diag()` registrations. The server registers them at runtime (it touches `analyse`) and `test_diagnostic_manifest` loads the full registry, so the committed catalogs were correct — only the codegen script (which imports `codes_all` alone) saw the truncated set. Now `codes_all` imports `core.analysis._analyser` explicitly, so codegen sees the full core-analyser catalog and regeneration is a no-op against the committed artifacts.

## Intentionally untouched

`docs/generated/command-spec-coverage.md` is left alone: it is derived entirely from `rust/tcl-registry/**` (this PR's base, PR #550) and its drift reflects that workstream's spec additions, not these fixes.

## Verification

- `make typecheck-py` (rust wheel uninstalled, mirrors CI) → **All checks passed**
- `make lint-py` → ruff check + format clean
- `make format && make codegen` → idempotent; catalogs/editor artifacts stable (only the registry-owned coverage report remains, excluded)
- Tests: `test_diagnostic_manifest` + catalog/optimiser/suppression suites (106) and signature-scan/version suites (173) all pass

https://claude.ai/code/session_011VvAgLTtipfs4tKabgrRWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011VvAgLTtipfs4tKabgrRWZ)_