### PR TITLE
Add metadata headers to all KCS feature documentation

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=9d5acda-dirty
-head=9d5acda3b0e0dd48a0ac7836de2bb39c1de36e0f
-date=2026-06-06T11:12:36Z
-fingerprint=77acfbde34099dbf89c56eff6a1fee2d712566feb55246a7a65ad31848636ec8
+describe=c2bf12c-dirty
+head=c2bf12ca8689511833de43010fc1837066ed1d92
+date=2026-06-06T11:53:18Z
+fingerprint=2e13370ff8109d03ff8ec7f4aeee8d39238b4b0579e6e7b2933c3a5f9431fd1f

--- a/docs/kcs/features/kcs-feature-ai-chat-irule.md
+++ b/docs/kcs/features/kcs-feature-ai-chat-irule.md
@@ -1,5 +1,8 @@
 # KCS: feature — @irule Chat Participant
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 VS Code Copilot Chat participant for creating, explaining, fixing, reviewing, and transforming F5 BIG-IP iRules.

--- a/docs/kcs/features/kcs-feature-ai-chat-tcl.md
+++ b/docs/kcs/features/kcs-feature-ai-chat-tcl.md
@@ -1,5 +1,8 @@
 # KCS: feature — @tcl Chat Participant
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 VS Code Copilot Chat participant for creating, explaining, fixing, validating, and optimising general Tcl code.

--- a/docs/kcs/features/kcs-feature-ai-chat-tk.md
+++ b/docs/kcs/features/kcs-feature-ai-chat-tk.md
@@ -1,5 +1,8 @@
 # KCS: feature — @tk Chat Participant
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 VS Code Copilot Chat participant for creating, explaining, and previewing Tk GUI applications.

--- a/docs/kcs/features/kcs-feature-apl-language.md
+++ b/docs/kcs/features/kcs-feature-apl-language.md
@@ -1,5 +1,8 @@
 # KCS: feature — APL (iApp Presentation Language) support
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Semantic highlighting, cross-file diagnostics, and embedded Tcl support for

--- a/docs/kcs/features/kcs-feature-call-hierarchy.md
+++ b/docs/kcs/features/kcs-feature-call-hierarchy.md
@@ -1,5 +1,8 @@
 # KCS: feature — Call Hierarchy
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 View incoming and outgoing calls for a proc.

--- a/docs/kcs/features/kcs-feature-claude-code-skills.md
+++ b/docs/kcs/features/kcs-feature-claude-code-skills.md
@@ -1,5 +1,8 @@
 # KCS: feature — Claude Code Skills
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 26 slash-command skills for Claude Code providing iRules, Tcl, Tk, and BIG-IP development assistance.

--- a/docs/kcs/features/kcs-feature-code-actions.md
+++ b/docs/kcs/features/kcs-feature-code-actions.md
@@ -1,5 +1,8 @@
 # KCS: feature — Code Actions
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Quick fixes for diagnostics and refactoring actions: brace expressions, add

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -1,5 +1,8 @@
 # KCS: feature — Compiler Explorer
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes, plus a structured WebAssembly disassembly view with click-to-source navigation, call and branch target cross-linking, control-flow arrows, and labelled structural ops.

--- a/docs/kcs/features/kcs-feature-completions.md
+++ b/docs/kcs/features/kcs-feature-completions.md
@@ -1,5 +1,8 @@
 # KCS: feature — Completions
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Context-aware completions for commands, subcommands, variables, switches, and procs.

--- a/docs/kcs/features/kcs-feature-debugger.md
+++ b/docs/kcs/features/kcs-feature-debugger.md
@@ -1,5 +1,8 @@
 # KCS: feature — Tcl Debugger
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Interactive CLI debugger for Tcl scripts with single-stepping, breakpoints,

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -1,5 +1,8 @@
 # KCS: feature — Go to Definition
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Jump to proc or variable definitions within and across files.

--- a/docs/kcs/features/kcs-feature-diagnostics.md
+++ b/docs/kcs/features/kcs-feature-diagnostics.md
@@ -1,5 +1,8 @@
 # KCS: feature — Diagnostics
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Errors, warnings, security, taint tracking, and style checks shown as you type.

--- a/docs/kcs/features/kcs-feature-dialect-selection.md
+++ b/docs/kcs/features/kcs-feature-dialect-selection.md
@@ -1,5 +1,8 @@
 # KCS: feature — Dialect Selection
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Switch between Tcl versions and iRules/iApps/BIG-IP/EDA dialects to get dialect-specific analysis.

--- a/docs/kcs/features/kcs-feature-document-links.md
+++ b/docs/kcs/features/kcs-feature-document-links.md
@@ -1,5 +1,8 @@
 # KCS: feature — Document Links
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Clickable links for URLs and file paths in comments and strings.

--- a/docs/kcs/features/kcs-feature-document-symbols.md
+++ b/docs/kcs/features/kcs-feature-document-symbols.md
@@ -1,5 +1,8 @@
 # KCS: feature — Document Symbols
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Outline of procs, namespaces, event handlers, and variables in the current file.

--- a/docs/kcs/features/kcs-feature-folding.md
+++ b/docs/kcs/features/kcs-feature-folding.md
@@ -1,5 +1,8 @@
 # KCS: feature — Folding
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Code folding for procs, namespaces, event handlers, and braced blocks.

--- a/docs/kcs/features/kcs-feature-formatting.md
+++ b/docs/kcs/features/kcs-feature-formatting.md
@@ -1,5 +1,8 @@
 # KCS: feature — Formatting
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Configurable code formatting: indent size/style, brace style, line length, whitespace.

--- a/docs/kcs/features/kcs-feature-hover.md
+++ b/docs/kcs/features/kcs-feature-hover.md
@@ -1,5 +1,8 @@
 # KCS: feature — Hover
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Command documentation, proc signatures, variable info, and taint status on hover.

--- a/docs/kcs/features/kcs-feature-inlay-hints.md
+++ b/docs/kcs/features/kcs-feature-inlay-hints.md
@@ -1,5 +1,8 @@
 # KCS: feature — Inlay Hints
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Inline type and value information displayed alongside code.

--- a/docs/kcs/features/kcs-feature-irule-extraction.md
+++ b/docs/kcs/features/kcs-feature-irule-extraction.md
@@ -1,5 +1,8 @@
 # KCS: feature — iRule Extraction
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Extract iRules from BIG-IP configuration files into individual editor tabs or files.

--- a/docs/kcs/features/kcs-feature-irule-skeleton.md
+++ b/docs/kcs/features/kcs-feature-irule-skeleton.md
@@ -1,5 +1,8 @@
 # KCS: feature — iRule Event Skeleton
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Pick iRules events from a list and generate a skeleton iRule with those event handlers.

--- a/docs/kcs/features/kcs-feature-mcp-server.md
+++ b/docs/kcs/features/kcs-feature-mcp-server.md
@@ -1,5 +1,8 @@
 # KCS: feature — MCP Server
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Model Context Protocol server exposing analysis/refactoring tools for AI agent integration.

--- a/docs/kcs/features/kcs-feature-minifier.md
+++ b/docs/kcs/features/kcs-feature-minifier.md
@@ -1,5 +1,8 @@
 # KCS: feature — Minifier
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Code minification: strips comments, collapses whitespace, joins commands with semicolons, recursively minifies body arguments.  Optional name compaction shortens variable and proc names with a symbol map for debugging.

--- a/docs/kcs/features/kcs-feature-optimiser.md
+++ b/docs/kcs/features/kcs-feature-optimiser.md
@@ -1,5 +1,8 @@
 # KCS: feature — Optimiser
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Finds optimisation opportunities in Tcl/iRules code and produces rewritten source.

--- a/docs/kcs/features/kcs-feature-package-scaffolding.md
+++ b/docs/kcs/features/kcs-feature-package-scaffolding.md
@@ -1,5 +1,8 @@
 # KCS: feature — Package Scaffolding
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Generate a Tcl package skeleton with namespace, package provide, and test stubs.

--- a/docs/kcs/features/kcs-feature-refactor-brace-expr.md
+++ b/docs/kcs/features/kcs-feature-refactor-brace-expr.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactor: Brace expr
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Convert an unbraced `expr "..."` argument to braced `expr {...}` for safety and performance.

--- a/docs/kcs/features/kcs-feature-refactor-extract-datagroup.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-datagroup.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactor: Extract to Data-Group
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Extract hardcoded if/elseif chains or switch statements with literal values into F5 BIG-IP data-group lookups, with type-aware inference for IP/CIDR (IPv4 + IPv6), integer, and string values.

--- a/docs/kcs/features/kcs-feature-refactor-extract-variable.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-variable.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactor: Extract Variable
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Extract a selected expression into a named variable, replacing the selection with `$var`.

--- a/docs/kcs/features/kcs-feature-refactor-if-to-switch.md
+++ b/docs/kcs/features/kcs-feature-refactor-if-to-switch.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactor: if/elseif to switch
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Convert an if/elseif equality chain on a single variable into a `switch -exact` statement.

--- a/docs/kcs/features/kcs-feature-refactor-inline-variable.md
+++ b/docs/kcs/features/kcs-feature-refactor-inline-variable.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactor: Inline Variable
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Inline a single-use `set var value` — replace the one reference with the value and remove the set command.

--- a/docs/kcs/features/kcs-feature-refactor-switch-to-dict.md
+++ b/docs/kcs/features/kcs-feature-refactor-switch-to-dict.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactor: switch to dict lookup
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Convert a `switch -exact` where every arm sets the same variable (or returns a value) into a `dict create` + `dict get`.

--- a/docs/kcs/features/kcs-feature-refactorings.md
+++ b/docs/kcs/features/kcs-feature-refactorings.md
@@ -1,5 +1,8 @@
 # KCS: feature — Refactoring Tools
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Mechanical code refactorings: extract/inline variables, if-to-switch, switch-to-dict, brace expr, and data-group extraction with type-aware IP/CIDR support.

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -1,5 +1,8 @@
 # KCS: feature — Find References
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Find all references to a proc or variable across the file.

--- a/docs/kcs/features/kcs-feature-runtime-validation.md
+++ b/docs/kcs/features/kcs-feature-runtime-validation.md
@@ -1,5 +1,8 @@
 # KCS: feature — Runtime Validation
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Validate Tcl code against a real tclsh interpreter if available on the system.

--- a/docs/kcs/features/kcs-feature-selection-range.md
+++ b/docs/kcs/features/kcs-feature-selection-range.md
@@ -1,5 +1,8 @@
 # KCS: feature — Selection Range
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Smart expand/shrink selection by syntactic structure.

--- a/docs/kcs/features/kcs-feature-semantic-tokens.md
+++ b/docs/kcs/features/kcs-feature-semantic-tokens.md
@@ -1,5 +1,8 @@
 # KCS: feature — Semantic Tokens
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Rich syntax highlighting for regex, format strings, binary specs, and clock formats with incremental delta delivery and per-chunk caching.

--- a/docs/kcs/features/kcs-feature-signature-help.md
+++ b/docs/kcs/features/kcs-feature-signature-help.md
@@ -1,5 +1,8 @@
 # KCS: feature — Signature Help
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Parameter hints for commands and procs as you type arguments.

--- a/docs/kcs/features/kcs-feature-tcl-verb-cli.md
+++ b/docs/kcs/features/kcs-feature-tcl-verb-cli.md
@@ -1,5 +1,8 @@
 # KCS: feature — Unified Tcl Verb CLI
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 `tcl.pyz` provides a single verb-based CLI for optimisation, diagnostics/linting, validation, formatting, symbol/graph extraction, iRules event metadata lookups, legacy-pattern conversion guidance, disassembly, syntax highlighting, WASM compilation, compiler exploration, and KCS help search.

--- a/docs/kcs/features/kcs-feature-template-snippets.md
+++ b/docs/kcs/features/kcs-feature-template-snippets.md
@@ -1,5 +1,8 @@
 # KCS: feature — Template Snippets
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 16 built-in Tcl and iRules code templates insertable from the command palette.

--- a/docs/kcs/features/kcs-feature-text-transforms.md
+++ b/docs/kcs/features/kcs-feature-text-transforms.md
@@ -1,5 +1,8 @@
 # KCS: feature — Text Transforms
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Escape, unescape, and base64 encode/decode selected text.

--- a/docs/kcs/features/kcs-feature-tk-preview.md
+++ b/docs/kcs/features/kcs-feature-tk-preview.md
@@ -1,5 +1,8 @@
 # KCS: feature — Tk Preview
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Live preview pane for Tk GUI applications that updates as you edit.

--- a/docs/kcs/features/kcs-feature-unknown-command-resolution.md
+++ b/docs/kcs/features/kcs-feature-unknown-command-resolution.md
@@ -1,5 +1,8 @@
 # KCS: feature — Unknown Command Resolution (W123)
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Detects unresolved commands and offers "did you mean?" suggestions. Static

--- a/docs/kcs/features/kcs-feature-unminify-error.md
+++ b/docs/kcs/features/kcs-feature-unminify-error.md
@@ -1,5 +1,8 @@
 # KCS: feature — Unminify Error
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Translate Tcl or iRule error messages produced by minified code back to the original variable, proc, and command names using a saved symbol map.  Optionally remaps line-number references from minified single-line output to approximate original source lines.

--- a/docs/kcs/features/kcs-feature-unused-variables.md
+++ b/docs/kcs/features/kcs-feature-unused-variables.md
@@ -1,5 +1,8 @@
 # KCS: feature — Unused Variable Detection
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Detects variables that are set but never read, unused procedure parameters, and dead stores where a value is overwritten before use. Offers quick-fix code actions to remove unused assignments.

--- a/docs/kcs/features/kcs-feature-workspace-symbols.md
+++ b/docs/kcs/features/kcs-feature-workspace-symbols.md
@@ -1,5 +1,8 @@
 # KCS: feature — Workspace Symbols
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Search symbols across all open files in the workspace.

--- a/docs/kcs/features/kcs-feature-xc-translation.md
+++ b/docs/kcs/features/kcs-feature-xc-translation.md
@@ -1,5 +1,8 @@
 # KCS: feature — XC Translation
 
+> **Audience:** User
+> **Type:** Functionality
+
 ## Summary
 
 Translate F5 BIG-IP iRules to F5 Distributed Cloud (XC) routes and service policies.


### PR DESCRIPTION
## Summary

Add standardized metadata headers to all 47 KCS feature documentation files. Each file now includes:
- `Audience: User` — indicating these docs are for end users
- `Type: Functionality` — categorizing the content type

This metadata enables better organization, filtering, and navigation of the KCS documentation.

## Validation

- [ ] Documentation changes reviewed for consistency across all 47 feature files

## Notes

This is a documentation-only change affecting the `docs/kcs/features/` directory. No compiler behavior, diagnostics, or analysis contracts are affected.

https://claude.ai/code/session_01PzN9ZGeZr1nCKn1DZrhVub