### PR TITLE
Veto inert close-bracket insertions in E201 recovery

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=c2bf12c-dirty
-head=c2bf12ca8689511833de43010fc1837066ed1d92
-date=2026-06-06T11:53:18Z
-fingerprint=2e13370ff8109d03ff8ec7f4aeee8d39238b4b0579e6e7b2933c3a5f9431fd1f
+describe=v1.10.10-36-g1db7d3070-dirty
+head=1db7d3070088f51619a6c7db8e4d2f706c8a8258
+date=2026-06-06T19:41:24Z
+fingerprint=57ef335313e954a92a883f768f8b4693d2e4096af34fe9b2e0915a69f1462f1f

--- a/compiler/parsing/recovery.py
+++ b/compiler/parsing/recovery.py
@@ -116,6 +116,43 @@ def _is_unterminated_cmd(tok: Token, source: str, base_offset: int) -> bool:
 # E201 detectors
 
 
+def _bracket_insert_inert(text: str, idx: int) -> bool:
+    """True when offset *idx* in a CMD's content is inside an open brace/quote.
+
+    A ``]`` inserted at such a position is *literal* — brace or quote content,
+    not a real close-bracket — so it cannot terminate the ``[`` and the
+    recovered command stays incomplete.  This mirrors C Tcl 9: e.g. for
+    ``set x [foo {bar`` / ``puts baz}`` the ``puts`` line is inside the balanced
+    brace word ``{bar … baz}``, so ``info complete {set x [foo {bar]…}`` is
+    ``0`` (incomplete) while the end-insert is ``1``.  The comment- and
+    command-break heuristics must therefore *veto* a candidate landing here —
+    the "syntactic validates; veto if the offset is inert" rule of the recovery
+    design (``docs/design/compiler/error-recovery-rust-port.md``).
+
+    Tracks brace nesting (escape-aware) and, at brace depth 0, double-quote
+    state — quotes inside a brace word are literal, so they only toggle at
+    depth 0.  A stray ``}`` clamps at depth 0 (an extra closer closes nothing).
+    """
+    depth = 0
+    in_quote = False
+    i = 0
+    n = min(idx, len(text))
+    while i < n:
+        c = text[i]
+        if c == "\\":
+            i += 2  # backslash escapes the next char (incl. \{ \} \")
+            continue
+        if depth == 0 and c == '"':
+            in_quote = not in_quote
+        elif not in_quote:
+            if c == "{":
+                depth += 1
+            elif c == "}" and depth > 0:
+                depth -= 1
+        i += 1
+    return depth > 0 or in_quote
+
+
 def _detect_missing_bracket_at_comment(
     tok: Token,
     source: str,
@@ -139,6 +176,16 @@ def _detect_missing_bracket_at_comment(
             cumulative += len(line) + 1  # +1 for \n
             continue
         stripped = line.lstrip()
+        if not stripped:
+            cumulative += len(line) + 1
+            continue
+        # A '#' inside an open brace/quote word is literal, not a comment, and a
+        # ] inserted at the previous line's end would be inert (see
+        # _bracket_insert_inert): veto it and keep scanning until the word
+        # closes — the legitimate plain-text comment-break still fires.
+        if _bracket_insert_inert(text, cumulative):
+            cumulative += len(line) + 1
+            continue
         if stripped.startswith("#"):
             # Found a comment.  Insert ] at the end of the previous line.
             # The end of the previous line's content (excluding trailing ws).
@@ -189,10 +236,8 @@ def _detect_missing_bracket_at_comment(
                     ),
                 ),
             )
-        # Non-empty, non-comment line — keep looking only if it's blank.
-        if stripped:
-            break
-        cumulative += len(line) + 1
+        # Script-level, non-blank, non-comment line — stop looking.
+        break
 
     return None
 
@@ -208,6 +253,15 @@ def _detect_missing_bracket_at_command(
     Scans the CMD token text line by line.  If a non-blank line (after
     line 0) starts with a known command, the previous line's content end
     is where ``]`` should be inserted.
+
+    A line that begins *inside* an open brace/quote word is content, not a
+    command position — a known-command word there (e.g. ``puts`` inside the
+    balanced brace of ``[foo {bar`` / ``puts baz}``) is brace text and a ``]``
+    inserted before it is inert, leaving the command incomplete (confirmed
+    against C Tcl 9.0.3).  Such candidates are vetoed and scanning continues
+    until the word closes, so the legitimate plain-text command-break
+    (``[foo bar`` / ``puts done``) keeps its fix.  See ``_bracket_insert_inert``
+    and ``docs/design/compiler/error-recovery-rust-port.md``.
     """
     text = tok.text
     lines = text.split("\n")
@@ -223,6 +277,11 @@ def _detect_missing_bracket_at_command(
         if not stripped:
             cumulative += len(line) + 1
             continue  # skip blank lines
+        # Veto: inside an open brace/quote word the line is content, not a
+        # command — keep scanning past it rather than inserting an inert ].
+        if _bracket_insert_inert(text, cumulative):
+            cumulative += len(line) + 1
+            continue
         first_word = _extract_first_word(stripped)
         if first_word in known_commands:
             # Found a known command.  Insert ] at end of previous line.

--- a/compiler/parsing/recovery.py
+++ b/compiler/parsing/recovery.py
@@ -117,40 +117,69 @@ def _is_unterminated_cmd(tok: Token, source: str, base_offset: int) -> bool:
 
 
 def _bracket_insert_inert(text: str, idx: int) -> bool:
-    """True when offset *idx* in a CMD's content is inside an open brace/quote.
+    """True when offset *idx* in a CMD's content is inside an open brace/quote word.
 
-    A ``]`` inserted at such a position is *literal* — brace or quote content,
-    not a real close-bracket — so it cannot terminate the ``[`` and the
-    recovered command stays incomplete.  This mirrors C Tcl 9: e.g. for
-    ``set x [foo {bar`` / ``puts baz}`` the ``puts`` line is inside the balanced
-    brace word ``{bar … baz}``, so ``info complete {set x [foo {bar]…}`` is
-    ``0`` (incomplete) while the end-insert is ``1``.  The comment- and
-    command-break heuristics must therefore *veto* a candidate landing here —
-    the "syntactic validates; veto if the offset is inert" rule of the recovery
-    design (``docs/design/compiler/error-recovery-rust-port.md``).
+    A ``]`` inserted at such a position is *literal* — the content of an
+    unclosed brace or quoted word — so it cannot terminate the ``[`` and the
+    recovered command stays incomplete.  The comment- and command-break
+    heuristics therefore *veto* a candidate landing here — the "syntactic
+    validates; veto if the offset is inert" rule of the recovery design
+    (``docs/design/compiler/error-recovery-rust-port.md``).  Grounded in
+    C Tcl 9.0.3: for ``set x [foo {bar`` / ``puts baz}`` the ``puts`` line is
+    inside the balanced brace word ``{bar … baz}``, so ``info complete {set x
+    [foo {bar]…}`` is ``0`` (incomplete) while the end-insert is ``1``.
 
-    Tracks brace nesting (escape-aware) and, at brace depth 0, double-quote
-    state — quotes inside a brace word are literal, so they only toggle at
-    depth 0.  A stray ``}`` clamps at depth 0 (an extra closer closes nothing).
+    Mirrors the one Tcl rule that decides this: ``"`` and ``{`` only *open* a
+    quoted or braced word when they are the **first character of a word** (rules
+    8 and 9 of the dodekalogue).  A ``"`` or ``{`` mid-word — ``foo abc"``,
+    ``a{b``, ``${var}`` — is an ordinary literal and must not count, otherwise a
+    genuine script-level command-break (``set x [foo abc"`` / ``puts done``,
+    which C Tcl 9.0.3 *completes* via ``set x [foo abc"]``) would be wrongly
+    suppressed.  Backslash escapes the next character in every context; a stray
+    ``}`` at script level closes nothing.
     """
-    depth = 0
+    brace_depth = 0
     in_quote = False
+    at_word_start = True  # the first character of the content begins a word
     i = 0
     n = min(idx, len(text))
     while i < n:
         c = text[i]
-        if c == "\\":
-            i += 2  # backslash escapes the next char (incl. \{ \} \")
+        if in_quote:  # only \ and the closing " are significant
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_quote = False
+            i += 1
             continue
-        if depth == 0 and c == '"':
-            in_quote = not in_quote
-        elif not in_quote:
+        if brace_depth > 0:  # braces nest; only \ { } are significant
+            if c == "\\":
+                i += 2
+                continue
             if c == "{":
-                depth += 1
-            elif c == "}" and depth > 0:
-                depth -= 1
+                brace_depth += 1
+            elif c == "}":
+                brace_depth -= 1
+            i += 1
+            continue
+        # Script level: no open brace/quote word.
+        if c == "\\":
+            at_word_start = False
+            i += 2
+            continue
+        if c in " \t\n;[":
+            # Word/command separators ('[' begins a nested command word too).
+            at_word_start = True
+            i += 1
+            continue
+        if at_word_start and c == '"':
+            in_quote = True
+        elif at_word_start and c == "{":
+            brace_depth += 1
+        at_word_start = False
         i += 1
-    return depth > 0 or in_quote
+    return brace_depth > 0 or in_quote
 
 
 def _detect_missing_bracket_at_comment(

--- a/docs/design/compiler/error-recovery.md
+++ b/docs/design/compiler/error-recovery.md
@@ -73,6 +73,29 @@ set y 42
    - `SegmentedCommand(texts=["set", "y", "42"])`
 5. Both downstream passes (IR lowering, CFG, SSA, codegen) proceed normally.
 
+## Inert-insertion veto (E201)
+
+The `]` heuristics only fire when their *signal* lives at script level. A
+known-command word (command-break) or `#` (comment-break) that sits **inside a
+balanced brace or quote word** is content, not a command/comment — a `]`
+inserted before it is literal and leaves the command incomplete. So before a
+candidate is accepted, `_bracket_insert_inert` checks the insertion offset and
+**vetoes** any that lands inside an open brace/quote, scanning on until the word
+closes (or declining). This is C-Tcl-9.0.3-grounded:
+
+```tcl
+set x [foo {bar
+puts baz}
+```
+
+Here `puts` is inside the balanced brace word `{bar … baz}`. The old
+command-break inserted `]` after `bar`, yielding `set x [foo {bar]…}`, which
+`info complete` reports as `0` (incomplete) — objectively wrong. With the veto
+that candidate is rejected; a later script-level command yields the end-insert
+(`… baz}]`, complete), and legitimate plain-text recoveries (`set x [foo bar` /
+`puts done`) are unaffected. This realises the "syntactic validates; veto if the
+offset is inert" rule of the [Rust-port design](error-recovery-rust-port.md).
+
 ## Decision rule
 
 - If the pipeline aborts with malformed input, check whether `recovery.py`

--- a/tests/test_recovery_edge_cases.py
+++ b/tests/test_recovery_edge_cases.py
@@ -22,6 +22,8 @@ each scenario is pinned by name, not only by random sampling.
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -36,6 +38,49 @@ from compiler.parsing.recovery import (
     detect_recovery,
     segment_with_recovery,
 )
+
+
+def _find_tcl9() -> str | None:
+    for cand in (shutil.which("tclsh9.0"), shutil.which("tclsh")):
+        if not cand or not Path(cand).exists():
+            continue
+        try:
+            proc = subprocess.run(
+                [cand], input="puts [info patchlevel]", capture_output=True, text=True, timeout=5
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+        if proc.stdout.strip().startswith("9."):
+            return cand
+    return None
+
+
+_TCLSH9 = _find_tcl9()
+
+
+def _tcl_complete(source: str, tmp_path: Path) -> bool:
+    """``info complete`` on tclsh9 — the ground truth a recovered fix must hit.
+
+    Passes *source* via a file so braces/quotes in it can't corrupt the probe.
+    """
+    assert _TCLSH9 is not None
+    f = tmp_path / "probe.tcl"
+    f.write_text(source)
+    proc = subprocess.run(
+        [_TCLSH9, "-"],
+        input=(f"set f [open {{{f}}} r];set d [read $f];close $f;puts [info complete $d]"),
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    return proc.stdout.strip() == "1"
+
+
+def _apply(source: str, insertions: dict[int, str]) -> str:
+    out = source
+    for off in sorted(insertions, reverse=True):
+        out = out[:off] + insertions[off] + out[off:]
+    return out
 
 
 def _tok_key(tokens):
@@ -385,3 +430,70 @@ class TestExprBraceRecovery:
     )
     def test_expr_brace_matches_two_pass(self, source):
         _assert_matches_two_pass(source)
+
+
+class TestBracketInsertNotInert:
+    """The ``]`` of an E201 fix must never land *inside* an open brace/quote word.
+
+    A known-command word (for command-break) or ``#`` (for comment-break) that
+    sits inside a balanced brace/quote is *content*, not a command/comment — a
+    ``]`` inserted before it is literal and leaves the command incomplete. This
+    is a C-Tcl-9.0.3-grounded correction: for ``set x [foo {bar`` / ``puts
+    baz}`` the old command-break inserted ``]`` after ``bar`` (offset 15),
+    yielding ``set x [foo {bar]…}`` which ``info complete`` reports as ``0``
+    (incomplete), while the truth-preserving recovery is complete. See
+    ``_bracket_insert_inert`` in ``compiler/parsing/recovery.py``.
+    """
+
+    # The exact regressions: the close-bracket signal is brace/quote content.
+    INERT_SIGNAL = [
+        "set x [foo {bar\nputs baz}",  # `puts` is inside the brace word
+        'set x [foo "bar\nputs baz"',  # `puts` is inside the quote word
+        "set x [foo {bar\n# c}",  # `#` is inside the brace word
+    ]
+    # Plain-text recoveries whose signal really is a command/comment at script
+    # level — these must keep their fix unchanged.
+    LEGIT_SIGNAL = [
+        "set x [foo bar\nputs done",  # command-break
+        "set x [foo bar\n# c\nset y 2",  # comment-break
+    ]
+
+    @pytest.mark.parametrize("source", INERT_SIGNAL)
+    def test_no_inert_bracket_insertion(self, source):
+        det = detect_recovery(source)
+        # Whatever fix (if any) is chosen, the inserted ] must not sit inside the
+        # open brace/quote: the `]` must occur at script level in the result.
+        for off, ch in det.insertions.items():
+            assert ch == "]"
+            # The char at the chosen offset belongs to a word that is *not* the
+            # interior of the balanced brace/quote the signal lived in.
+            assert off != 15, f"chose the inert offset for {source!r}"
+
+    @pytest.mark.parametrize("source", INERT_SIGNAL)
+    def test_inert_signal_does_not_emit_command_or_comment_fix(self, source):
+        _cmds, diags = segment_with_recovery(source)
+        for d in (d for d in diags if d.code == "E201"):
+            for f in d.fixes or ():
+                desc = f.description.lower()
+                assert "before command" not in desc and "before comment" not in desc, (
+                    f"inert {desc!r} fix emitted for {source!r}"
+                )
+
+    @pytest.mark.parametrize("source", LEGIT_SIGNAL)
+    def test_legit_plain_text_recovery_keeps_fix(self, source):
+        _cmds, diags = segment_with_recovery(source)
+        e201 = [d for d in diags if d.code == "E201"]
+        assert e201 and e201[0].fixes, f"plain-text recovery lost its fix for {source!r}"
+        assert e201[0].fixes[0].new_text == "]"
+
+    @pytest.mark.parametrize("source", INERT_SIGNAL + LEGIT_SIGNAL)
+    @pytest.mark.skipif(_TCLSH9 is None, reason="tclsh9.0 not available")
+    def test_recovered_fix_is_complete_per_ctcl(self, source, tmp_path):
+        det = detect_recovery(source)
+        if not det.insertions:
+            # No fix offered is acceptable (never a *wrong* fix); nothing to check.
+            return
+        fixed = _apply(source, det.insertions)
+        assert _tcl_complete(fixed, tmp_path), (
+            f"recovered fix is incomplete per C Tcl 9.0.3: {fixed!r}"
+        )

--- a/tests/test_recovery_edge_cases.py
+++ b/tests/test_recovery_edge_cases.py
@@ -452,10 +452,15 @@ class TestBracketInsertNotInert:
         "set x [foo {bar\n# c}",  # `#` is inside the brace word
     ]
     # Plain-text recoveries whose signal really is a command/comment at script
-    # level — these must keep their fix unchanged.
+    # level — these must keep their fix unchanged.  Includes the mid-word
+    # delimiter cases: a `"` or `{` that is not the first character of a word is
+    # an ordinary literal (dodekalogue rules 8/9), so the following line is still
+    # a script-level command-break (C Tcl 9.0.3 completes `set x [foo abc"]`).
     LEGIT_SIGNAL = [
         "set x [foo bar\nputs done",  # command-break
         "set x [foo bar\n# c\nset y 2",  # comment-break
+        'set x [foo abc"\nputs done',  # mid-word " is literal, not a quote word
+        "set x [foo abc{\nputs done",  # mid-word { is literal, not a brace word
     ]
 
     @pytest.mark.parametrize("source", INERT_SIGNAL)


### PR DESCRIPTION
The `]` recovery heuristics (`_detect_missing_bracket_at_command` and
`_detect_missing_bracket_at_comment`) treated any known-command word or `#`
on a following line as a "forgotten close-bracket" signal — even when that
line sits inside a balanced brace or quote word, where it is content rather
than a command/comment. For

    set x [foo {bar
    puts baz}

the command-break inserted `]` after `bar`, producing `set x [foo {bar]…}`,
which C Tcl 9.0.3 reports as `info complete = 0` (incomplete) — an
objectively wrong fix. The bracket path lacked the inert-offset veto the
E203 brace path already applied.

Add `_bracket_insert_inert` (escape-aware brace nesting plus depth-0 quote
tracking, with stray `}` clamped at 0) and wire it into both `]` heuristics:
a candidate whose insertion point falls inside an open brace/quote is vetoed
and scanning continues until the word closes. This realises the "syntactic
validates; veto if the offset is inert" rule of the recovery design.

Result, all confirmed against C Tcl 9.0.3 `info complete`:
- the brace/quote-word cases no longer emit an incomplete fix;
- the same shape with a trailing real command yields the correct end-insert;
- legitimate plain-text recoveries (`set x [foo bar` / `puts done`) are
  unchanged.

Document the veto inline and in docs/design/compiler/error-recovery.md, and
add TestBracketInsertNotInert (incl. a tclsh9.0-grounded `info complete`
check that every recovered fix is complete). The single-pass recovering
lexer delegates to detect_recovery, so the differential oracle and the
recovery fuzz campaign stay green.