### PR TITLE
Add --run-manual flag for heavyweight test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ exclude = [
 testpaths = ["tests"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "manual: marks tests that are NOT collected by default (even under test-slow); run them explicitly with '--run-manual' or RUN_MANUAL_TESTS=1",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -121,12 +122,42 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "cannot be fetched (no network or no git)."
         ),
     )
+    parser.addoption(
+        "--run-manual",
+        action="store_true",
+        dest="run_manual",
+        default=False,
+        help=(
+            "Collect tests marked @pytest.mark.manual, which are excluded "
+            "from every default run (including test-slow) because they are "
+            "too expensive. Also enabled by RUN_MANUAL_TESTS=1."
+        ),
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:
     global TCL9_REQUIRED
     if config.getoption("tcl9_required", default=False):
         TCL9_REQUIRED = True
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Deselect ``@pytest.mark.manual`` tests unless explicitly opted in.
+
+    These are heavyweight soak/stress tests that should only run on demand
+    (e.g. ``pytest --run-manual tests/test_buffer_mvcc.py``), never as part
+    of the default suite or the ``test-slow`` gate.
+    """
+    if config.getoption("run_manual", default=False) or os.environ.get(
+        "RUN_MANUAL_TESTS"
+    ):
+        return
+    deselected = [it for it in items if it.get_closest_marker("manual") is not None]
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = [it for it in items if it not in deselected]
 
 
 _RESULTS_KEY = "_tcl9_results"

--- a/tests/test_buffer_mvcc.py
+++ b/tests/test_buffer_mvcc.py
@@ -237,6 +237,7 @@ def _giant_body_interior_offset(source: str) -> int:
 
 
 @pytest.mark.slow
+@pytest.mark.manual
 def test_mvcc_document_path_tens_of_thousands_of_edits_no_leak():
     """Punish the MVCC through the *real document edit path* at scale.
 


### PR DESCRIPTION
## Summary

- Add `--run-manual` pytest option and `RUN_MANUAL_TESTS` environment variable to explicitly opt-in to heavyweight tests marked with `@pytest.mark.manual`
- Implement `pytest_collection_modifyitems` hook to deselect manual tests by default, ensuring they never run in standard test suites or the `test-slow` gate
- Mark `test_mvcc_document_path_tens_of_thousands_of_edits_no_leak()` as a manual test since it's a heavyweight soak/stress test
- Register the new `manual` marker in pytest configuration

## Validation

- Existing pytest infrastructure tests pass
- Manual tests are deselected by default: `pytest tests/` will skip manual tests
- Manual tests run when explicitly requested: `pytest --run-manual tests/test_buffer_mvcc.py` includes them
- Manual tests run when environment variable is set: `RUN_MANUAL_TESTS=1 pytest tests/` includes them

https://claude.ai/code/session_01GxF8oHo177t5SQQJi8V1fr