### PR TITLE
Fix variable trace and info exists bugs on unset

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=096d514-dirty
-head=096d51451d6d4633a9a215e05be44c664120f749
-date=2026-06-05T21:45:52Z
-fingerprint=96b06f516cb6076d10635778c8edac54d4bcd453d8766180630ca3927a26deee
+describe=d47c3e1-dirty
+head=d47c3e10b136f437ae42e42f1a3b048f6994cf47
+date=2026-06-06T07:46:11Z
+fingerprint=e00f700244749d0740c4b828973b0f378c8346d3aca508230d123ab4620d083a

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=63434bb-dirty
-head=63434bb65bb6961c3ab14cb6905935a76a88b4cf
-date=2026-06-05T20:56:37Z
-fingerprint=bfe6bd748c86a9b50cbeb0a183e032304f55cae708c0963ea8626088f9c6abcd
+describe=096d514-dirty
+head=096d51451d6d4633a9a215e05be44c664120f749
+date=2026-06-05T21:45:52Z
+fingerprint=96b06f516cb6076d10635778c8edac54d4bcd453d8766180630ca3927a26deee

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.10-37-g72f019b7-dirty
-head=72f019b79c44a7b5513642507e94ff27685b87cd
-date=2026-06-08T13:49:57Z
-fingerprint=9b19d59f6e3ef8ec77815a958569143c50698c889f052f161a450a61f69fe916
+describe=63434bb-dirty
+head=63434bb65bb6961c3ab14cb6905935a76a88b4cf
+date=2026-06-05T20:56:37Z
+fingerprint=bfe6bd748c86a9b50cbeb0a183e032304f55cae708c0963ea8626088f9c6abcd

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=d47c3e1-dirty
-head=d47c3e10b136f437ae42e42f1a3b048f6994cf47
-date=2026-06-06T07:46:11Z
-fingerprint=e00f700244749d0740c4b828973b0f378c8346d3aca508230d123ab4620d083a
+describe=v1.10.10-40-ge47d71e8
+head=e47d71e8b3a2682ee6f19af645085501d20f6b5a
+date=2026-06-08T14:48:49Z
+fingerprint=4b6b2c1eb47b3d8c22cc23531aa4d225ca9990c6b4cab49a45c26bcbac9563e9

--- a/compiler/codegen/wasm/_emitter/cmds/info_.py
+++ b/compiler/codegen/wasm/_emitter/cmds/info_.py
@@ -152,6 +152,28 @@ def _emit_info_value(emitter, args: tuple[str, ...]) -> None:
             emitter._emit_obj_literal(resolved)
             emitter._emit_call(gexist_idx)
             return
+        # Existence answered against the authoritative global/frame
+        # table, NOT the compiled WASM-local mirror, for the two scopes
+        # whose mirror goes stale on ``unset``:
+        #   * top-level (script-scope) names — an eval-fallback ``unset``
+        #     nulls the runtime var without clearing the mirror;
+        #   * ``global``-declared names inside a proc — the alias targets
+        #     the global table, which a sibling proc (or ``unset``) can
+        #     mutate behind the mirror's back.
+        # Both mirror the strict read paths in ``_emit_var_read_obj``
+        # (``not self._is_proc`` → ``tcl_global_get_or_error``; ``name in
+        # self._globals`` → ditto).  ``set x 1; unset x; info exists x``
+        # returned 1 because the plain-local path below read the mirror,
+        # which ``set x 1`` left non-null and ``unset`` never
+        # invalidated.  ``tcl_info_exists`` (``var_exists``) follows the
+        # ALIAS_GLOBAL frame bucket / falls through to ``global_exists``,
+        # so both scalar and pure-array globals resolve correctly.
+        if not emitter._is_proc or resolved in emitter._globals:
+            info_exists_idx = emitter._shared_imports.get("tcl_info_exists")
+            if info_exists_idx is not None:
+                emitter._emit_obj_literal(resolved)
+                emitter._emit_call(info_exists_idx)
+                return
         # FRAME-only vars (routed through tcl_local_set by the
         # escape-aware writer) don't land in a WASM local, so the
         # pointer-nullness check below would always say "no".

--- a/runtime/zig/cmds/inspect.zig
+++ b/runtime/zig/cmds/inspect.zig
@@ -555,6 +555,21 @@ pub fn remove_all_var_traces(name: i32) void {
     const sn = obj_ensure_string(canon);
     if (sn.ptr != 0 and sn.len != 0) {
         var_trace.remove_all(sn.ptr, sn.len);
+        // Unsetting a whole array drops traces on every element too
+        // (Tcl ``TclDeleteVars``).  Only sweep when the name is not
+        // itself an ``arr(key)`` element — an element unset removes just
+        // that element's trace via the exact-key ``remove_all`` above.
+        var is_elem = false;
+        {
+            const sp2: [*]const u8 = @ptrFromInt(sn.ptr);
+            for (0..sn.len) |k| {
+                if (sp2[k] == '(') {
+                    is_elem = true;
+                    break;
+                }
+            }
+        }
+        if (!is_elem) var_trace.remove_all_array_elements(sn.ptr, sn.len);
         // Also probe the alternate FQ / non-FQ spelling so a trace
         // installed under ``::x`` is dropped when ``unset x`` runs
         // (and vice versa) — matches fire_scalar_trace_op's dual probe.

--- a/runtime/zig/cmds/tcl_rename.zig
+++ b/runtime/zig/cmds/tcl_rename.zig
@@ -321,6 +321,37 @@ pub fn rename_command(
         if (alias_mod.is_alias(cmd)) {
             alias_mod.alias_clear(cmd);
         }
+        // Mark the Command struct as destroyed.  The struct itself is
+        // not freed (a captured ``bucket`` — e.g. the execution-trace
+        // dispatcher holding the traced command across its
+        // enter→body→leave window — may still point at it), so set
+        // CMD_DELETED on its flags.  Consumers that must distinguish
+        // "still live" from "gone" test this bit; in particular the
+        // leave/leavestep execution-trace gate (mirrors C's CMD_DYING in
+        // ``TEOV_RunLeaveTraces``) skips callbacks for a command deleted
+        // during its own enter trace or a nested step (trace-25.8..25.11).
+        write_i32(cmd + tcl_procs.OFF_FLAGS, @bitCast(flags | tcl_procs.CMD_DELETED));
+        // Deleting a command fires its ``delete`` command-trace and drops
+        // EVERY execution/command trace keyed on it — C does this in
+        // ``TclDeleteCommandFromToken`` (``CallCommandTraces`` +
+        // ``TclDeleteVarsFromTrace``-style teardown).  Without it the
+        // stale enter/leave/step entries leak onto the (later reused)
+        // bucket: re-running trace.test left phantom ``leave`` callbacks
+        // on a freshly redefined ``foo`` that re-ran ``rename foo {}`` on
+        // the gone command, clobbering the result with ``can't delete
+        // "foo"`` (trace-25.8/25.9/25.11).  Mirrors the namespace-teardown
+        // and proc-redefine cleanup paths.
+        const exec_trace = @import("../interp/tcl_exec_trace.zig");
+        if ((exec_trace.ops_for(cmd) & exec_trace.OP_CMD_DELETE) != 0) {
+            const fqn = tcl_ns.ns_build_fqn(old_ns, old_simple_ptr, old_simple_len);
+            const fqn_obj: i32 = if (fqn.ptr != 0)
+                obj.obj_new_string_take(fqn.ptr, fqn.len, fqn.len)
+            else
+                0;
+            defer if (fqn_obj != 0) obj.tcl_obj_release(fqn_obj);
+            exec_trace.fire_command_delete_oneshot(cmd, fqn_obj);
+        }
+        exec_trace.remove_all_for(cmd);
         _ = tcl_ns.ns_cmd_clear(old_ns, old_simple_ptr, old_simple_len);
         tcl_procs.lru_invalidate_all();
         return .ok;

--- a/runtime/zig/interp/tcl_frames.zig
+++ b/runtime/zig/interp/tcl_frames.zig
@@ -2596,6 +2596,17 @@ pub export fn local_exists(name: i32) i32 {
             const v = read_i32(bucket + OFF_VALUE);
             if (v == ALIAS_GLOBAL) return globals.global_exists(name);
             if (is_alias_ext(v)) return resolve_ext_exists(alias_desc_ptr(v), name);
+            // ``unset`` of a proc-local scalar nulls the bucket's value
+            // (``var_set(name, 0)`` in cmds/var.zig::eval_unset) but
+            // leaves the directory bucket in place.  A null OFF_VALUE
+            // therefore means "declared slot, currently unset" — the
+            // variable does NOT exist.  Return 0 directly rather than
+            // falling through to any namespace/global probe: an
+            // unqualified local that was just unset must not resolve to
+            // an unrelated same-named global.  (Live array variables use
+            // a separate element table plus an alias/non-null marker, so
+            // a genuine array never presents a bare null scalar here.)
+            if (v == 0) return obj_new_int(0);
             return obj_new_int(1);
         }
     }
@@ -3038,6 +3049,17 @@ pub export fn var_exists(name: i32) i32 {
             const v = read_i32(bucket + OFF_VALUE);
             if (v == ALIAS_GLOBAL) return globals.global_exists(name);
             if (is_alias_ext(v)) return resolve_ext_exists(alias_desc_ptr(v), name);
+            // ``unset`` of a proc-local scalar nulls the bucket's value
+            // (``var_set(name, 0)`` in cmds/var.zig::eval_unset) but
+            // leaves the directory bucket in place.  A null OFF_VALUE
+            // therefore means "declared slot, currently unset" — the
+            // variable does NOT exist.  Return 0 directly rather than
+            // falling through to any namespace/global probe: an
+            // unqualified local that was just unset must not resolve to
+            // an unrelated same-named global.  (Live array variables use
+            // a separate element table plus an alias/non-null marker, so
+            // a genuine array never presents a bare null scalar here.)
+            if (v == 0) return obj_new_int(0);
             return obj_new_int(1);
         }
     }

--- a/runtime/zig/interp/tcl_interp.zig
+++ b/runtime/zig/interp/tcl_interp.zig
@@ -1488,10 +1488,21 @@ fn eval_command_traced(words: []const i32) i32 {
     if (has_step) et.pop_step();
 
     // Capture the completion code for leave / leavestep.
-    if ((ops & et.OP_LEAVE) != 0 or step_active) {
+    //
+    // A command deleted during its own ``enter`` trace, or during a
+    // nested step trace fired while its body ran (``rename foo {}`` from
+    // a traceDelete callback), must NOT fire its ``leave`` trace — C Tcl
+    // gates ``TEOV_RunLeaveTraces`` on ``!(cmdPtr->flags & CMD_DYING)``.
+    // Without this, the leave callback re-runs ``rename foo {}`` on the
+    // now-gone command and the resulting ``can't delete "foo": command
+    // doesn't exist`` error clobbers the real result (the body's value,
+    // or the ``invalid command name "foo"`` raised when the deleted
+    // command failed to dispatch) — trace-25.8..25.11.
+    const cmd_deleted = procs.cmd_is_deleted(bucket);
+    if (((ops & et.OP_LEAVE) != 0 and !cmd_deleted) or step_active) {
         const snap = result_mod.snapshot(result);
         const code_obj = obj_mod.obj_new_int(@intFromEnum(snap.code));
-        if ((ops & et.OP_LEAVE) != 0) et.fire(bucket, et.OP_LEAVE, cmd_str, code_obj, result);
+        if ((ops & et.OP_LEAVE) != 0 and !cmd_deleted) et.fire(bucket, et.OP_LEAVE, cmd_str, code_obj, result);
         if (step_active) et.fire_step(et.OP_LEAVESTEP, cmd_str, code_obj, result);
         obj_mod.tcl_obj_release(code_obj);
     }

--- a/runtime/zig/interp/tcl_procs.zig
+++ b/runtime/zig/interp/tcl_procs.zig
@@ -179,6 +179,26 @@ pub const CMD_BUILTIN_MASKED: u32 = 0x1000;
 /// hands control to the ensemble subcommand resolver.
 pub const CMD_ENSEMBLE: u32 = 0x2000;
 
+/// Set on a Command's ``OFF_FLAGS`` when it is destroyed (``rename foo
+/// {}`` / command delete).  The Command struct is not freed immediately
+/// — a captured ``bucket`` pointer (e.g. the execution-trace dispatcher
+/// holding the traced command across its enter→body→leave window) stays
+/// valid — so consumers that must distinguish "still live" from "gone"
+/// test this bit.  Mirrors C Tcl's ``CMD_DYING``: ``TEOV_RunLeaveTraces``
+/// skips ``leave``/``leavestep`` callbacks for a command deleted during
+/// its own ``enter`` trace or a nested step (trace-25.8..25.11).  A reused
+/// slot is reset to flags=0 by ``proc_register``, so the bit never
+/// survives into a freshly (re)defined command.
+pub const CMD_DELETED: u32 = 0x4000;
+
+/// True iff *cmd* (a Command bucket address) has been destroyed.  Safe to
+/// call on 0 (returns false).
+pub fn cmd_is_deleted(cmd: u32) bool {
+    if (cmd == 0) return false;
+    const flags: u32 = @bitCast(read_i32(cmd + OFF_FLAGS));
+    return (flags & CMD_DELETED) != 0;
+}
+
 // ``tcl_ns.zig`` keeps a shadow copy of the Command layout constants
 // above because it can't ``@import`` this module without a circular
 // dependency.  Pin the shadow to the canonical values here so any

--- a/runtime/zig/interp/tcl_var_trace.zig
+++ b/runtime/zig/interp/tcl_var_trace.zig
@@ -317,6 +317,63 @@ pub fn remove_all(name_ptr: u32, name_len: u32) void {
     }
 }
 
+/// Remove every trace registered on an *element* of array ``arr`` — any
+/// directory key of the form ``arr(...)``.  Tcl's ``TclDeleteVars`` drops
+/// traces on an array AND on every element when the array is unset; our
+/// ``remove_all`` only matches the exact key, so without this an element
+/// write/read trace survived ``unset arr`` and re-fired on the next
+/// ``set arr(k)`` (trace-12.3 accumulation across tests).  Leading ``::``
+/// is normalised on both sides so an ``::arr(k)`` key matches an ``arr``
+/// unset and vice-versa.  Safe to call when no fire walks the chain.
+pub fn remove_all_array_elements(arr_ptr: u32, arr_len: u32) void {
+    if (arr_ptr == 0 or arr_len == 0 or dir_buf == 0) return;
+    // Normalise the target: strip a leading ``::``.
+    var ap: u32 = arr_ptr;
+    var al: u32 = arr_len;
+    {
+        const p: [*]const u8 = @ptrFromInt(ap);
+        if (al >= 2 and p[0] == ':' and p[1] == ':') {
+            ap += 2;
+            al -= 2;
+        }
+    }
+    if (al == 0) return;
+    const tgt: [*]const u8 = @ptrFromInt(ap);
+    var i: u32 = 0;
+    while (i < dir_cap) : (i += 1) {
+        const bucket = dir_buf + i * DIR_BUCKET_SIZE;
+        const ep: u32 = @bitCast(read_i32(bucket));
+        if (ep == 0) continue;
+        if (read_i32(bucket + 12) == 0) continue; // no live head
+        var kp: u32 = ep;
+        var kl: u32 = @bitCast(read_i32(bucket + 4));
+        // Normalise the key's leading ``::`` too.
+        {
+            const p: [*]const u8 = @ptrFromInt(kp);
+            if (kl >= 2 and p[0] == ':' and p[1] == ':') {
+                kp += 2;
+                kl -= 2;
+            }
+        }
+        // Must be ``<arr>(...)``: longer than ``arr(``, prefix == arr,
+        // char at arr_len == '(', last char == ')'.
+        if (kl < al + 2) continue;
+        const np: [*]const u8 = @ptrFromInt(kp);
+        if (np[al] != '(' or np[kl - 1] != ')') continue;
+        var match = true;
+        for (0..al) |k| {
+            if (np[k] != tgt[k]) {
+                match = false;
+                break;
+            }
+        }
+        if (!match) continue;
+        // Tear down this element's chain via the canonical path (handles
+        // the active-fire guard).  Use the bucket's own stored key.
+        remove_all(ep, @bitCast(read_i32(bucket + 4)));
+    }
+}
+
 /// Return a Tcl list of ``{ops cmd}`` pairs for every trace on
 /// ``name``, or empty list if none.
 pub fn info(name: i32) i32 {

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-05T21:32:13Z",
+  "generated_at": "2026-06-06T07:32:23Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -537,8 +537,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 54,
-      "passed_min": 222,
+      "failed_max": 51,
+      "passed_min": 225,
       "skipped": 14,
       "total": 290
     },

--- a/tests/baselines/tcl9-tcltest-wasm/summary.json
+++ b/tests/baselines/tcl9-tcltest-wasm/summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-05T18:00:31Z",
+  "generated_at": "2026-06-05T21:32:13Z",
   "schema_version": 1,
   "stems": {
     "append": {
@@ -537,8 +537,8 @@
       "bucket": "W-mixed-fail",
       "crash_type": "",
       "crashed": false,
-      "failed_max": 58,
-      "passed_min": 218,
+      "failed_max": 54,
+      "passed_min": 222,
       "skipped": 14,
       "total": 290
     },

--- a/tests/test_wasm_info_exists_after_unset.py
+++ b/tests/test_wasm_info_exists_after_unset.py
@@ -1,0 +1,83 @@
+"""Compiled ``info exists`` must stay coherent across ``unset``.
+
+``set x 1; unset x; info exists x`` returned 1 even though the variable
+was genuinely gone — a read (``$x``) errored with ``can't read "x": no
+such variable`` correctly, but introspection lied.  Two independent root
+causes, both "``unset`` never invalidates the compiler's local-liveness
+view":
+
+  - Top-level (script-scope): the compiled ``info exists`` answered from
+    the WASM-local mirror (seeded by ``set x 1``, never cleared by the
+    eval-fallback ``unset``).  Fixed by routing script-scope existence
+    through ``tcl_info_exists`` — the same authoritative state a
+    top-level ``$x`` read consults.
+
+  - Proc-local / parameter: ``unset`` nulls the frame bucket's value
+    (``var_set(name, 0)``) but leaves the directory bucket, and
+    ``var_exists`` / ``local_exists`` reported "exists" for any present
+    bucket.  Fixed in the runtime: a null OFF_VALUE means "declared but
+    unset" → does not exist.
+
+These compile the snippet directly (not via ``eval``) so the COMPILED
+``info exists`` path is exercised.  Reference: Tcl 9 ``Tcl_UnsetObjCmd`` /
+``InfoExistsCmd`` (generic/tclVar.c, tclCmdIL.c).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run(source: str) -> str:
+    _, stdout = _run_wasm(_compile_tcl(source), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def test_top_level_scalar_info_exists_after_unset() -> None:
+    assert _run("set x 1; unset x; puts [info exists x]") == "0"
+
+
+def test_proc_local_scalar_info_exists_after_unset() -> None:
+    assert _run("proc f {} { set x 1; unset x; return [info exists x] }; puts [f]") == "0"
+
+
+def test_proc_parameter_info_exists_after_unset() -> None:
+    assert _run("proc f {a} { unset a; return [info exists a] }; puts [f 7]") == "0"
+
+
+def test_top_level_whole_array_info_exists_after_unset() -> None:
+    assert _run("set a(1) 1; unset a; puts [info exists a]") == "0"
+
+
+def test_global_declared_info_exists_after_unset() -> None:
+    # ``global g`` aliases the global table; ``unset g`` clears it, so
+    # ``info exists g`` inside the proc AND at top level must read 0.
+    src = "set g 1; proc f {} {global g; unset g; return [info exists g]}; puts [f]/[info exists g]"
+    assert _run(src) == "0/0"
+
+
+def test_global_declared_info_exists_still_true_when_set() -> None:
+    # Guard the affirmative answer for global-declared aliases, incl.
+    # a pure-array global (no scalar slot).
+    assert _run("proc f {} {global g; set g 5; return [info exists g]}; puts [f]") == "1"
+    assert _run("set arr(1) 9; proc f {} {global arr; return [info exists arr]}; puts [f]") == "1"
+
+
+def test_info_exists_still_true_for_live_vars() -> None:
+    # Guard: the fix must not break the affirmative answer for set vars.
+    assert _run("set x 1; puts [info exists x]") == "1"
+    assert _run("set a(1) 1; puts [info exists a]") == "1"
+    assert _run("proc f {} { set x 5; return [info exists x] }; puts [f]") == "1"
+
+
+def test_info_exists_true_again_after_reset() -> None:
+    # unset then re-set: existence must flip back to 1 with the new value.
+    assert _run("set x 1; unset x; set x 5; puts [info exists x]/$x") == "1/5"
+    assert (
+        _run("proc f {} { set x 1; unset x; set x 9; return [info exists x]/$x }; puts [f]")
+        == "1/9"
+    )

--- a/tests/test_wasm_trace_array_unset_cleanup.py
+++ b/tests/test_wasm_trace_array_unset_cleanup.py
@@ -1,0 +1,89 @@
+"""Unsetting a whole array drops its element traces.
+
+Tcl's ``TclDeleteVars`` removes traces on an array AND on every element
+when the array is unset.  Our ``remove_all_var_traces`` only matched the
+exact directory key, so an element ``read``/``write`` trace survived
+``unset arr`` and re-fired on the next ``set arr(k)`` — trace.test 12.3
+saw the write trace fire three times (once per accumulated leftover from
+12.1/12.2), and 14.18/14.19 saw ``trace info variable x(0)`` report a
+stale trace after ``unset x``.
+
+These run INTERPRETED (``eval``) so the variable-trace dispatch is
+exercised the same way trace.test runs.  Reference: Tcl 9 ``tclVar.c``
+(``TclDeleteVars`` / ``Tcl_UnsetVar2``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+
+def _run_interp(body: str) -> str:
+    src = "set __s {" + body + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(src), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+_TP = "proc traceProc {name1 name2 op} {global info; lappend info $name1 $name2 $op}\n"
+
+
+def test_element_write_trace_dropped_on_array_unset_no_accumulation() -> None:
+    # Mirror trace-12.1 -> 12.2 -> 12.3: each test re-adds an element
+    # write trace after ``unset -nocomplain x``.  The leftover traces must
+    # not accumulate — the final write fires exactly once.
+    body = (
+        _TP + "unset -nocomplain x\nset info {}\n"
+        "trace add variable x(0) write traceProc\ncatch {set x 22}\n"
+        "unset -nocomplain x\nset info {}\n"
+        "trace add variable x(0) write traceProc\ncatch {set x(0)}\n"
+        "unset -nocomplain x\nset info {}\n"
+        "trace add variable x(0) write traceProc\nset x(0) 22\n"
+        "puts [list $info]"
+    )
+    assert _run_interp(body) == "{x 0 write}"
+
+
+def test_single_write_after_array_unset_then_retrace() -> None:
+    body = (
+        _TP + "set x(0) 1\ntrace add variable x(0) write traceProc\n"
+        "unset x\nset info {}\n"
+        "trace add variable x(0) write traceProc\nset x(0) 9\nputs [list $info]"
+    )
+    assert _run_interp(body) == "{x 0 write}"
+
+
+def test_trace_info_element_empty_after_array_unset() -> None:
+    # trace-14.18 / 14.19: ``trace info variable x(0)`` is empty once the
+    # array has been unset, even if a prior element trace existed.
+    body = (
+        _TP + "set x(0) 1\ntrace add variable x(0) read traceProc\n"
+        "unset -nocomplain x\nputs [list [trace info variable x(0)]]"
+    )
+    assert _run_interp(body) == "{}"
+
+
+def test_scalar_unset_still_drops_its_trace() -> None:
+    # Guard: the array-element sweep must not disturb plain scalar trace
+    # removal on unset.
+    body = (
+        _TP + "set x 1\ntrace add variable x write traceProc\n"
+        "unset x\nset info {}\n"
+        "trace add variable x write traceProc\nset x 9\nputs [list $info]"
+    )
+    assert _run_interp(body) == "{x {} write}"
+
+
+def test_unrelated_array_element_trace_survives() -> None:
+    # Guard: unsetting array ``x`` must NOT drop a trace on ``xx(0)`` —
+    # the prefix match requires the ``(`` to fall exactly after the array
+    # name, so ``xx`` is not an element of ``x``.
+    body = (
+        _TP + "set xx(0) 1\ntrace add variable xx(0) write traceProc\n"
+        "set x(0) 1\nunset x\nset info {}\n"
+        "set xx(0) 9\nputs [list $info]"
+    )
+    assert _run_interp(body) == "{xx 0 write}"

--- a/tests/test_wasm_trace_delete_during_exec.py
+++ b/tests/test_wasm_trace_delete_during_exec.py
@@ -1,0 +1,74 @@
+"""Execution traces whose callback deletes the traced command.
+
+When a ``trace add execution foo …`` callback runs ``rename foo {}``, Tcl
+must (a) NOT fire ``foo``'s ``leave`` / ``leavestep`` traces once the
+command is gone — C gates ``TEOV_RunLeaveTraces`` on
+``!(cmdPtr->flags & CMD_DYING)`` — and (b) tear down every trace keyed on
+the deleted command (``TclDeleteCommandFromToken`` →
+``CallCommandTraces`` + trace removal) so stale callbacks don't leak onto
+a later, reused command bucket.
+
+Two prior bugs:
+  * the leave callback re-ran ``rename foo {}`` on the now-gone command,
+    so ``can't delete "foo": command doesn't exist`` clobbered the real
+    result (the body's value, or the ``invalid command name "foo"`` from
+    the failed dispatch) — trace-25.8/25.9/25.10/25.11;
+  * ``rename foo {}`` left ``foo``'s enter/leave/step entries registered,
+    so a redefined ``foo`` inherited phantom callbacks.
+
+These run the bodies INTERPRETED (``eval``) so the execution-step trace
+dispatch is exercised, matching how trace.test runs.  Reference: Tcl 9
+``tclTrace.c`` / ``tclBasic.c``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+_PRE = (
+    "proc traceDelete {cmd args} { rename $cmd {}; global info; set info $args }\n"
+    "proc foo {a} { set b $a }\n"
+)
+
+
+def _run_interp(body: str) -> str:
+    src = "set __s {" + _PRE + body + "}\neval $__s\n"
+    _, stdout = _run_wasm(_compile_tcl(src), capture_stdout=True)
+    return stdout.rstrip("\n")
+
+
+def _add(*ops: str) -> str:
+    lines = "\n".join(f"trace add execution foo {op} [list traceDelete foo]" for op in ops)
+    return (
+        "set info {}\n" + lines + "\nputs [list [catch {foo 1} err] $err $info "
+        "[catch {trace info execution foo} r] $r]"
+    )
+
+
+def test_25_8_enter_leave_enterstep_leavestep() -> None:
+    # enter deletes foo → dispatch fails with invalid command name; the
+    # leave/step traces are torn down and never re-fire.
+    got = _run_interp(_add("enter", "leave", "enterstep", "leavestep"))
+    assert got == '1 {invalid command name "foo"} {{foo 1} enter} 1 {unknown command "foo"}'
+
+
+def test_25_9_enter_leave_leavestep() -> None:
+    got = _run_interp(_add("enter", "leave", "leavestep"))
+    assert got == '1 {invalid command name "foo"} {{foo 1} enter} 1 {unknown command "foo"}'
+
+
+def test_25_10_leave_leavestep_self_delete() -> None:
+    # No enter trace: foo runs, leavestep (on `set b 1`) deletes foo, so
+    # foo's own leave must be skipped — result is the body value "1", not
+    # a "can't delete" error.
+    got = _run_interp(_add("leave", "leavestep"))
+    assert got == '0 1 {{set b 1} 0 1 leavestep} 1 {unknown command "foo"}'
+
+
+def test_25_11_enter_enterstep() -> None:
+    got = _run_interp(_add("enter", "enterstep"))
+    assert got == '1 {invalid command name "foo"} {{foo 1} enter} 1 {unknown command "foo"}'


### PR DESCRIPTION
## Summary

This PR fixes three related bugs in variable and command trace handling:

1. **Array element traces not dropped on array unset** — When unsetting an array (e.g., `unset arr`), element traces (e.g., on `arr(0)`) were not removed. This caused traces to accumulate and re-fire on subsequent operations, breaking trace.test cases 12.3, 14.18, and 14.19.

2. **`info exists` returning stale results after `unset`** — The compiled `info exists` command was answering from a WASM-local mirror that was never invalidated by `unset`, causing `set x 1; unset x; info exists x` to incorrectly return 1. This affected both top-level variables and proc-local parameters.

3. **Execution traces not cleaned up when command is deleted** — When a trace callback deleted its own traced command (e.g., `rename foo {}` from within a trace), the leave/leavestep traces were not properly torn down, causing phantom callbacks to leak onto redefined commands and error messages to clobber the actual result (trace.test cases 25.8–25.11).

### Changes

**Runtime (Zig)**:
- Added `remove_all_array_elements()` in `tcl_var_trace.zig` to sweep and remove all traces on array elements when the array is unset
- Updated `remove_all_var_traces()` in `inspect.zig` to call the new element-sweep function for non-element unsets
- Added `CMD_DELETED` flag and `cmd_is_deleted()` check in `tcl_procs.zig` to mark deleted commands
- Updated `eval_command_traced()` in `tcl_interp.zig` to skip leave/leavestep traces for deleted commands (mirrors C Tcl's `CMD_DYING` gate)
- Added command deletion cleanup in `tcl_rename.zig` to fire delete traces and remove all execution traces when a command is renamed away
- Fixed `local_exists()` and `var_exists()` in `tcl_frames.zig` to treat null OFF_VALUE as "unset" rather than "exists"

**Compiler**:
- Updated `info_` codegen in `_emitter/cmds/info_.py` to route `info exists` for top-level and global-declared variables through `tcl_info_exists` (the authoritative runtime check) instead of the stale WASM-local mirror

**Tests**:
- Added `test_wasm_trace_array_unset_cleanup.py` with 4 tests covering array element trace cleanup
- Added `test_wasm_info_exists_after_unset.py` with 7 tests covering `info exists` correctness after unset
- Added `test_wasm_trace_delete_during_exec.py` with 4 tests covering execution trace cleanup on command deletion

## Validation

- Added 15 new test cases covering the three bug scenarios
- All new tests pass; trace.test results improved from 58 failures to 51 failures (7 tests now passing)
- Changes mirror Tcl 9 reference implementations in `tclVar.c`, `tclTrace.c`, and `tclBasic.c`

https://claude.ai/code/session_01WMMKkkWRgqz7NUtMgR4z6p