### PR TITLE
fix: suppress general Tcl diagnostics for BIG-IP config files (f5-bigip dialect)

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.10-40-ge47d71e8
-head=e47d71e8b3a2682ee6f19af645085501d20f6b5a
-date=2026-06-08T14:48:49Z
-fingerprint=4b6b2c1eb47b3d8c22cc23531aa4d225ca9990c6b4cab49a45c26bcbac9563e9
+describe=9e9ddc7-dirty
+head=9e9ddc729872fe38d20e8f010bb1c18e5adf6e02
+date=2026-06-10T07:09:20Z
+fingerprint=9308ad25ab2d50ca0bd7daa6d00f834eab3bb427a096a6bcfa079104ccfaed39

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=9e9ddc7-dirty
-head=9e9ddc729872fe38d20e8f010bb1c18e5adf6e02
-date=2026-06-10T07:09:20Z
-fingerprint=9308ad25ab2d50ca0bd7daa6d00f834eab3bb427a096a6bcfa079104ccfaed39
+describe=7a46d7d-dirty
+head=7a46d7dc4317cc6e456ede9270964d2adc6d8522
+date=2026-06-10T08:42:09Z
+fingerprint=c24954ef1fbcd1bfb437e556affbbaa41efd109ec33914a5f9e638079260dc6a

--- a/compiler/registry/dialect.py
+++ b/compiler/registry/dialect.py
@@ -109,6 +109,27 @@ DIALECT_DIRECTIVE_SCAN_LINES = 5
 _PKG_REQUIRE_SCAN_LINES = 30
 
 
+def detect_dialect_directive(source: str) -> str | None:
+    """Return the dialect named by a ``# tcl-dialect: <dialect>`` directive.
+
+    Scans the first :data:`DIALECT_DIRECTIVE_SCAN_LINES` lines for an
+    explicit ``# tcl-dialect:`` comment and returns the named dialect when
+    it is a recognised value, else ``None``.  Split out from
+    :func:`detect_dialect_from_source` so callers can give the explicit
+    user directive priority over filename heuristics (e.g. BIG-IP config
+    basenames) while leaving the rest of the autodetection lower-priority.
+    """
+    from compiler.registry.dialects import KNOWN_DIALECTS
+
+    for line in source.split("\n", DIALECT_DIRECTIVE_SCAN_LINES)[:DIALECT_DIRECTIVE_SCAN_LINES]:
+        m = _DIALECT_DIRECTIVE_RE.match(line)
+        if m:
+            candidate = m.group(1).strip().lower()
+            if candidate in KNOWN_DIALECTS:
+                return candidate
+    return None
+
+
 def detect_dialect_from_source(source: str) -> str | None:
     """Detect a dialect from source content.
 
@@ -116,20 +137,16 @@ def detect_dialect_from_source(source: str) -> str | None:
     1. ``# tcl-dialect: <dialect>`` comment directive (first 5 lines)
     2. Shebang (first line)
     3. ``package require Tcl <version>`` (first 30 lines)
+    4. Conf-wrapped iRules (``ltm rule`` / ``gtm rule`` stanzas)
 
     Returns ``None`` if no dialect hint is found.
     """
-    from compiler.registry.dialects import KNOWN_DIALECTS
-
     lines = source.split("\n", _PKG_REQUIRE_SCAN_LINES)
 
     # Comment directive (``# tcl-dialect: <dialect>``)
-    for line in lines[:DIALECT_DIRECTIVE_SCAN_LINES]:
-        m = _DIALECT_DIRECTIVE_RE.match(line)
-        if m:
-            candidate = m.group(1).strip().lower()
-            if candidate in KNOWN_DIALECTS:
-                return candidate
+    directive = detect_dialect_directive(source)
+    if directive is not None:
+        return directive
 
     # Shebang detection (first line only)
     if lines:

--- a/compiler/registry/dialect.py
+++ b/compiler/registry/dialect.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from enum import Enum
 
+from .dialects import KNOWN_DIALECTS
 from .runtime import (
     _canonical_dialect,
     _dialect_var,
@@ -119,8 +120,6 @@ def detect_dialect_directive(source: str) -> str | None:
     user directive priority over filename heuristics (e.g. BIG-IP config
     basenames) while leaving the rest of the autodetection lower-priority.
     """
-    from compiler.registry.dialects import KNOWN_DIALECTS
-
     for line in source.split("\n", DIALECT_DIRECTIVE_SCAN_LINES)[:DIALECT_DIRECTIVE_SCAN_LINES]:
         m = _DIALECT_DIRECTIVE_RE.match(line)
         if m:

--- a/server/commands.py
+++ b/server/commands.py
@@ -1084,6 +1084,10 @@ def _switch_dialect(dialect: str) -> dict:
         )
 
         for uri, state in _state.workspace_state.items():
+            # BIG-IP configuration files are not Tcl source — skip
+            # the general Tcl re-analysis path.
+            if state.dialect_hint == "f5-bigip":
+                continue
             if loop is not None:
                 spawn_publish_diagnostics(
                     uri,

--- a/server/diagnostics_pipeline.py
+++ b/server/diagnostics_pipeline.py
@@ -949,10 +949,9 @@ def _load_packages_if_needed(analysis: object, uri: str | None = None) -> None:
 
 
 def _is_bigip_conf(uri: str) -> bool:
-    from .workspace.scanner import _BIGIP_CONF_NAMES
+    from .workspace.scanner import is_bigip_conf_name
 
-    basename = uri.rsplit("/", 1)[-1].lower() if "/" in uri else uri.lower()
-    return basename in _BIGIP_CONF_NAMES
+    return is_bigip_conf_name(uri)
 
 
 def _is_irules_source(uri: str) -> bool:

--- a/server/diagnostics_pipeline.py
+++ b/server/diagnostics_pipeline.py
@@ -20,7 +20,7 @@ from .features.diagnostics import (
     get_deep_diagnostics,
     get_diagnostics,
 )
-from .workspace.scanner import path_to_uri, uri_to_path
+from .workspace.scanner import is_bigip_conf_name, path_to_uri, uri_to_path
 from .workspace.workspace_index import EntrySource
 
 if TYPE_CHECKING:
@@ -949,8 +949,6 @@ def _load_packages_if_needed(analysis: object, uri: str | None = None) -> None:
 
 
 def _is_bigip_conf(uri: str) -> bool:
-    from .workspace.scanner import is_bigip_conf_name
-
     return is_bigip_conf_name(uri)
 
 

--- a/server/diagnostics_pipeline.py
+++ b/server/diagnostics_pipeline.py
@@ -319,6 +319,11 @@ def _publish_diagnostics_sync(
 
     cfg = _state.config_for_uri(uri)
     dialect, extras = _state.resolve_dialect_for_uri(uri, source)
+    # BIG-IP configuration files have their own diagnostics pipeline
+    # (bigip parser → bigip validator).  The general Tcl analyser
+    # must never be run on their top-level text.
+    if dialect == "f5-bigip":
+        return
     with (
         dialect_scope(dialect=dialect, extra_commands=extras),
         non_ascii_mode_scope(cfg.non_ascii_mode),
@@ -428,6 +433,12 @@ async def _publish_diagnostics_inner(
     *,
     force_reanalyse: bool = False,
 ) -> None:
+    # BIG-IP configuration files have their own diagnostics pipeline
+    # (bigip parser → bigip validator).  The general Tcl analyser must
+    # never be run on their top-level text.
+    if _is_bigip_conf(uri):
+        return
+
     t_start = time.perf_counter()
 
     await asyncio.sleep(0)

--- a/server/features/diagnostics.py
+++ b/server/features/diagnostics.py
@@ -723,6 +723,14 @@ def get_basic_diagnostics(
     When *cached_style_diagnostics* is provided, W111/W112/W115 style
     checks are skipped and the cached diagnostics are used instead.
     """
+    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are not Tcl
+    # source — they are key-value config stanzas.  The general Tcl analyser
+    # must never be run on their top-level text; doing so misinterprets BIG-IP
+    # encrypted-string markers ($M$…$) as Tcl variable references.  Return an
+    # empty result so downstream callers see zero Tcl diagnostics.
+    if active_dialect() == "f5-bigip":
+        return [], AnalysisResult(), {}
+
     cu = ensure_compilation_unit(source, cu, logger=log, context="diagnostics")
 
     result = analysis if analysis is not None else analyse(source, cu=cu)

--- a/server/settings.py
+++ b/server/settings.py
@@ -754,6 +754,12 @@ def _apply_merged_settings_now() -> None:
         doc_force_reanalyse = signatures_changed or (
             pre_apply_doc_resolution.get(uri) != new_resolution
         )
+        # BIG-IP configuration files have their own diagnostics
+        # pipeline (bigip parser → bigip validator).  The general
+        # Tcl analyser must never be run on them, so skip the Tcl
+        # re-analysis / re-publish paths.
+        if doc_state.dialect_hint == "f5-bigip":
+            continue
         if doc_force_reanalyse and loop is not None:
             spawn_publish_diagnostics(
                 uri,

--- a/server/state.py
+++ b/server/state.py
@@ -17,7 +17,7 @@ from tooling.formatter import FormatterConfig
 from .async_diagnostics import DiagnosticScheduler
 from .feature_config import FeatureConfig
 from .workspace.document_state import WorkspaceState
-from .workspace.scanner import BackgroundScanner
+from .workspace.scanner import BackgroundScanner, is_bigip_conf_name
 from .workspace.workspace_index import WorkspaceIndex
 
 if TYPE_CHECKING:
@@ -219,13 +219,20 @@ def resolve_dialect_for_uri(
 
     Consults, in priority order:
 
-    1. ``detect_dialect_from_source(source)`` — in-source hints (shebang,
-       ``# tcl-dialect:`` directive, ``package require Tcl X.Y``, conf-wrapped
-       iRules).
+    1. An explicit ``# tcl-dialect:`` directive in the source — the user's
+       override always wins.
     2. BIG-IP configuration file detection (by basename → ``"f5-bigip"``).
-    3. The folder-scoped ``FeatureConfig`` (longest workspace-folder prefix
+       This beats the rest of source autodetection so a ``bigip.conf`` that
+       embeds ``ltm rule`` stanzas is not misclassified as ``f5-irules`` by
+       the conf-wrapped-iRules heuristic.
+    3. The remaining in-source hints (shebang, ``package require Tcl X.Y``,
+       conf-wrapped iRules) via ``detect_dialect_from_source(source)``.
+    4. The folder-scoped ``FeatureConfig`` (longest workspace-folder prefix
        match) — its ``dialect`` / ``extra_commands`` fields when set.
-    4. The workspace-fallback ``FeatureConfig`` — same fields.
+    5. The workspace-fallback ``FeatureConfig`` — same fields.
+
+    Steps 1-3 mirror ``infer_document_dialect`` so the two resolvers never
+    disagree about a document's dialect.
 
     Each component may independently be ``None`` (meaning "inherit the
     process default that ``configure_signatures`` set at server startup /
@@ -233,26 +240,32 @@ def resolve_dialect_for_uri(
     :func:`compiler.registry.dialect.dialect_scope` with the result; ``None``
     values leave the corresponding ContextVar untouched.
     """
-    from compiler.registry.dialect import detect_dialect_from_source
+    from compiler.registry.dialect import (
+        detect_dialect_directive,
+        detect_dialect_from_source,
+    )
 
     dialect: str | None = None
     extras: tuple[str, ...] | None = None
 
+    # 1. Explicit ``# tcl-dialect:`` directive — the user's override wins.
     if source is not None:
+        dialect = detect_dialect_directive(source)
+
+    # 2. BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are not
+    #    Tcl source — they are key-value config stanzas that often embed
+    #    ``ltm rule`` stanzas.  Resolve their dialect to ``"f5-bigip"`` ahead
+    #    of source autodetection so the conf-wrapped-iRules heuristic in
+    #    ``detect_dialect_from_source`` cannot misclassify them as
+    #    ``f5-irules`` (which would defeat the f5-bigip analysis skip).
+    if dialect is None and doc_uri is not None and is_bigip_conf_name(doc_uri):
+        dialect = "f5-bigip"
+
+    # 3. Remaining in-source hints (shebang, package require, conf-wrapped).
+    if dialect is None and source is not None:
         detected = detect_dialect_from_source(source)
         if detected is not None:
             dialect = detected
-
-    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are
-    # not Tcl source — they are key-value config stanzas.  Resolve
-    # their dialect to ``"f5-bigip"`` so the general Tcl analysis
-    # pipeline knows to skip them.
-    if dialect is None and doc_uri is not None:
-        from server.workspace.scanner import _BIGIP_CONF_NAMES
-
-        basename = doc_uri.rsplit("/", 1)[-1].lower() if "/" in doc_uri else doc_uri.lower()
-        if basename in _BIGIP_CONF_NAMES:
-            dialect = "f5-bigip"
 
     cfg = config_for_uri(doc_uri)
     if dialect is None and cfg.dialect is not None:

--- a/server/state.py
+++ b/server/state.py
@@ -12,6 +12,11 @@ from typing import TYPE_CHECKING
 
 import server._codes_init  # noqa: F401  # must precede feature_config import so profile categories are computed with full registry
 from analyser.packages import PackageResolver
+from compiler.registry.dialect import (
+    detect_dialect_directive,
+    detect_dialect_from_source,
+    dialect_scope,
+)
 from tooling.formatter import FormatterConfig
 
 from .async_diagnostics import DiagnosticScheduler
@@ -121,8 +126,6 @@ def dialect_scope_for_uri(doc_uri: str | None, source: str | None = None):
         with _state.dialect_scope_for_uri(uri, source):
             ...
     """
-    from compiler.registry.dialect import dialect_scope
-
     dialect, extras = resolve_dialect_for_uri(doc_uri, source)
     return dialect_scope(dialect=dialect, extra_commands=extras)
 
@@ -240,11 +243,6 @@ def resolve_dialect_for_uri(
     :func:`compiler.registry.dialect.dialect_scope` with the result; ``None``
     values leave the corresponding ContextVar untouched.
     """
-    from compiler.registry.dialect import (
-        detect_dialect_directive,
-        detect_dialect_from_source,
-    )
-
     dialect: str | None = None
     extras: tuple[str, ...] | None = None
 

--- a/server/state.py
+++ b/server/state.py
@@ -222,9 +222,10 @@ def resolve_dialect_for_uri(
     1. ``detect_dialect_from_source(source)`` — in-source hints (shebang,
        ``# tcl-dialect:`` directive, ``package require Tcl X.Y``, conf-wrapped
        iRules).
-    2. The folder-scoped ``FeatureConfig`` (longest workspace-folder prefix
+    2. BIG-IP configuration file detection (by basename → ``"f5-bigip"``).
+    3. The folder-scoped ``FeatureConfig`` (longest workspace-folder prefix
        match) — its ``dialect`` / ``extra_commands`` fields when set.
-    3. The workspace-fallback ``FeatureConfig`` — same fields.
+    4. The workspace-fallback ``FeatureConfig`` — same fields.
 
     Each component may independently be ``None`` (meaning "inherit the
     process default that ``configure_signatures`` set at server startup /
@@ -241,6 +242,17 @@ def resolve_dialect_for_uri(
         detected = detect_dialect_from_source(source)
         if detected is not None:
             dialect = detected
+
+    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are
+    # not Tcl source — they are key-value config stanzas.  Resolve
+    # their dialect to ``"f5-bigip"`` so the general Tcl analysis
+    # pipeline knows to skip them.
+    if dialect is None and doc_uri is not None:
+        from server.workspace.scanner import _BIGIP_CONF_NAMES
+
+        basename = doc_uri.rsplit("/", 1)[-1].lower() if "/" in doc_uri else doc_uri.lower()
+        if basename in _BIGIP_CONF_NAMES:
+            dialect = "f5-bigip"
 
     cfg = config_for_uri(doc_uri)
     if dialect is None and cfg.dialect is not None:

--- a/server/workspace/document_state.py
+++ b/server/workspace/document_state.py
@@ -47,6 +47,7 @@ from compiler.registry.dialect import (
 )
 from compiler.registry.namespace_registry import NAMESPACE_REGISTRY as EVENT_REGISTRY
 from compiler.registry.runtime import is_irules_dialect
+from server.workspace.scanner import is_bigip_conf_name
 from shared.codes import default_disabled_diagnostics
 from shared.document_buffer import DocumentBuffer
 from shared.rope import RopeEdit
@@ -240,8 +241,6 @@ def infer_document_dialect(uri: str, source: str, language_id: str = "") -> str 
     # source autodetection so the conf-wrapped-iRules heuristic in
     # ``detect_dialect_from_source`` cannot misclassify them as ``f5-irules``
     # (which would defeat the f5-bigip analysis skip).
-    from server.workspace.scanner import is_bigip_conf_name
-
     if is_bigip_conf_name(uri):
         return "f5-bigip"
 

--- a/server/workspace/document_state.py
+++ b/server/workspace/document_state.py
@@ -223,6 +223,15 @@ def infer_document_dialect(uri: str, source: str, language_id: str = "") -> str 
     if basename.endswith(_EXPECT_EXTENSIONS):
         return "expect"
 
+    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are
+    # not Tcl source — they are key-value config stanzas.  Resolve
+    # their dialect to ``"f5-bigip"`` so the general Tcl analysis
+    # pipeline knows to skip them.
+    from server.workspace.scanner import _BIGIP_CONF_NAMES
+
+    if basename in _BIGIP_CONF_NAMES:
+        return "f5-bigip"
+
     return detect_dialect_from_source(source)
 
 
@@ -258,6 +267,30 @@ def _analyse_document_fresh(
     ContextVar (dialect, extra_commands, W108 non-ASCII mode) must be
     forwarded explicitly and re-applied here.  See issue #407.
     """
+    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are
+    # not Tcl source — they are key-value config stanzas that may
+    # embed Tcl fragments (tmsh, iApp APL, iRules).  The general Tcl
+    # analyser must never be run on their top-level text; doing so
+    # misinterprets BIG-IP encrypted-string markers ($M$…$) as Tcl
+    # variable references.  Diagnostics and semantic features for
+    # these files are handled by the bigip-specific parser and
+    # validator in
+    # ``server.diagnostics_pipeline._publish_bigip_diagnostics``.
+    if dialect == "f5-bigip":
+        return {
+            "analysis": None,
+            "compilation_unit": None,
+            "chunks": [],
+            "has_partial": False,
+            "chunk_caches": [],
+            "file_profiles": frozenset(),
+            "buffer": DocumentBuffer.from_source(source, version),
+            "basic_diags": [],
+            "suppressed": {},
+            "conf_wrapped": False,
+            "embedded_rules": [],
+        }
+
     # Ensure diagnostic codes are registered in the subprocess.
     import server._codes_init  # noqa: F401
     from compiler.registry.runtime import configure_signatures
@@ -1489,6 +1522,30 @@ class DocumentState:
         Builds all new state into local variables and swaps a new
         ``_StateSnapshot`` atomically at the end.
         """
+        # BIG-IP configuration files are not Tcl source — skip the
+        # general Tcl analyser entirely.  Their dialect hint is
+        # resolved to ``"f5-bigip"`` by `infer_document_dialect`.
+        if self.dialect_hint == "f5-bigip":
+            t0 = time.perf_counter()
+            self._swap_snapshot(
+                _StateSnapshot(
+                    source=source,
+                    version=version,
+                    analysis=None,
+                    compilation_unit=None,
+                    chunks=new_chunks,
+                    has_partial_commands=has_partial,
+                    file_profiles=frozenset(),
+                    chunk_caches=[],
+                    buffer=self._carry_or_build_buffer(source, version),
+                )
+            )
+            log.info(
+                "[timing] _update_incremental %.0fms (bigip config — skipped Tcl analysis)",
+                (time.perf_counter() - t0) * 1000,
+            )
+            return
+
         t0 = time.perf_counter()
         file_profiles = (
             EVENT_REGISTRY.compute_file_profiles(source) if is_irules_dialect() else frozenset()
@@ -1745,6 +1802,30 @@ class DocumentState:
         Builds all state into local variables and swaps a new
         ``_StateSnapshot`` atomically at the end.
         """
+        # BIG-IP configuration files are not Tcl source — skip the
+        # general Tcl analyser entirely.  Their dialect hint is
+        # resolved to ``"f5-bigip"`` by `infer_document_dialect`.
+        if self.dialect_hint == "f5-bigip":
+            t0 = time.perf_counter()
+            self._swap_snapshot(
+                _StateSnapshot(
+                    source=source,
+                    version=version,
+                    analysis=None,
+                    compilation_unit=None,
+                    chunks=new_chunks,
+                    has_partial_commands=has_partial,
+                    file_profiles=frozenset(),
+                    chunk_caches=[],
+                    buffer=self._carry_or_build_buffer(source, version),
+                )
+            )
+            log.info(
+                "[timing] _update_full %.0fms (bigip config — skipped Tcl analysis)",
+                (time.perf_counter() - t0) * 1000,
+            )
+            return
+
         t0 = time.perf_counter()
         file_profiles = (
             EVENT_REGISTRY.compute_file_profiles(source) if is_irules_dialect() else frozenset()

--- a/server/workspace/document_state.py
+++ b/server/workspace/document_state.py
@@ -40,7 +40,11 @@ from compiler.parsing.incremental import (
     incremental_top_level_chunks,
     infer_edit_range,
 )
-from compiler.registry.dialect import detect_dialect_from_source, dialect_scope
+from compiler.registry.dialect import (
+    detect_dialect_directive,
+    detect_dialect_from_source,
+    dialect_scope,
+)
 from compiler.registry.namespace_registry import NAMESPACE_REGISTRY as EVENT_REGISTRY
 from compiler.registry.runtime import is_irules_dialect
 from shared.codes import default_disabled_diagnostics
@@ -223,13 +227,22 @@ def infer_document_dialect(uri: str, source: str, language_id: str = "") -> str 
     if basename.endswith(_EXPECT_EXTENSIONS):
         return "expect"
 
-    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are
-    # not Tcl source — they are key-value config stanzas.  Resolve
-    # their dialect to ``"f5-bigip"`` so the general Tcl analysis
-    # pipeline knows to skip them.
-    from server.workspace.scanner import _BIGIP_CONF_NAMES
+    # An explicit ``# tcl-dialect:`` directive is the user's override and
+    # wins over the BIG-IP basename heuristic below (kept consistent with
+    # ``resolve_dialect_for_uri``).
+    directive = detect_dialect_directive(source)
+    if directive is not None:
+        return directive
 
-    if basename in _BIGIP_CONF_NAMES:
+    # BIG-IP configuration files (bigip.conf, bigip_base.conf, …) are not
+    # Tcl source — they are key-value config stanzas that often embed
+    # ``ltm rule`` stanzas.  Resolve their dialect to ``"f5-bigip"`` ahead of
+    # source autodetection so the conf-wrapped-iRules heuristic in
+    # ``detect_dialect_from_source`` cannot misclassify them as ``f5-irules``
+    # (which would defeat the f5-bigip analysis skip).
+    from server.workspace.scanner import is_bigip_conf_name
+
+    if is_bigip_conf_name(uri):
         return "f5-bigip"
 
     return detect_dialect_from_source(source)
@@ -987,6 +1000,45 @@ class DocumentState:
             return DocumentBuffer(source=source, version=version, rope=buf.rope)
         return DocumentBuffer.from_source(source, version)
 
+    def _swap_bigip_snapshot(
+        self,
+        source: str,
+        version: int | None,
+        new_chunks: list[TopLevelChunk],
+        has_partial: bool,
+        *,
+        caller: str,
+    ) -> None:
+        """Swap in an analysis-free snapshot for a BIG-IP config document.
+
+        BIG-IP configuration files are not Tcl source — they are key-value
+        config stanzas that may embed Tcl fragments (tmsh, iApp APL, iRules).
+        The general Tcl analyser must never be run on their top-level text;
+        doing so misinterprets BIG-IP encrypted-string markers (``$M$…$``) as
+        Tcl variable references.  Diagnostics and semantic features for these
+        files are handled by the bigip-specific parser and validator in
+        ``server.diagnostics_pipeline._publish_bigip_diagnostics``.
+        """
+        t0 = time.perf_counter()
+        self._swap_snapshot(
+            _StateSnapshot(
+                source=source,
+                version=version,
+                analysis=None,
+                compilation_unit=None,
+                chunks=new_chunks,
+                has_partial_commands=has_partial,
+                file_profiles=frozenset(),
+                chunk_caches=[],
+                buffer=self._carry_or_build_buffer(source, version),
+            )
+        )
+        log.info(
+            "[timing] %s %.0fms (bigip config — skipped Tcl analysis)",
+            caller,
+            (time.perf_counter() - t0) * 1000,
+        )
+
     @property
     def lines(self) -> list[str]:
         """Source split into lines, cached for the lifetime of the current source."""
@@ -1522,27 +1574,12 @@ class DocumentState:
         Builds all new state into local variables and swaps a new
         ``_StateSnapshot`` atomically at the end.
         """
-        # BIG-IP configuration files are not Tcl source — skip the
-        # general Tcl analyser entirely.  Their dialect hint is
-        # resolved to ``"f5-bigip"`` by `infer_document_dialect`.
+        # BIG-IP configuration files are not Tcl source — skip the general
+        # Tcl analyser entirely.  Their dialect hint is resolved to
+        # ``"f5-bigip"`` by ``infer_document_dialect``.
         if self.dialect_hint == "f5-bigip":
-            t0 = time.perf_counter()
-            self._swap_snapshot(
-                _StateSnapshot(
-                    source=source,
-                    version=version,
-                    analysis=None,
-                    compilation_unit=None,
-                    chunks=new_chunks,
-                    has_partial_commands=has_partial,
-                    file_profiles=frozenset(),
-                    chunk_caches=[],
-                    buffer=self._carry_or_build_buffer(source, version),
-                )
-            )
-            log.info(
-                "[timing] _update_incremental %.0fms (bigip config — skipped Tcl analysis)",
-                (time.perf_counter() - t0) * 1000,
+            self._swap_bigip_snapshot(
+                source, version, new_chunks, has_partial, caller="_update_incremental"
             )
             return
 
@@ -1802,27 +1839,12 @@ class DocumentState:
         Builds all state into local variables and swaps a new
         ``_StateSnapshot`` atomically at the end.
         """
-        # BIG-IP configuration files are not Tcl source — skip the
-        # general Tcl analyser entirely.  Their dialect hint is
-        # resolved to ``"f5-bigip"`` by `infer_document_dialect`.
+        # BIG-IP configuration files are not Tcl source — skip the general
+        # Tcl analyser entirely.  Their dialect hint is resolved to
+        # ``"f5-bigip"`` by ``infer_document_dialect``.
         if self.dialect_hint == "f5-bigip":
-            t0 = time.perf_counter()
-            self._swap_snapshot(
-                _StateSnapshot(
-                    source=source,
-                    version=version,
-                    analysis=None,
-                    compilation_unit=None,
-                    chunks=new_chunks,
-                    has_partial_commands=has_partial,
-                    file_profiles=frozenset(),
-                    chunk_caches=[],
-                    buffer=self._carry_or_build_buffer(source, version),
-                )
-            )
-            log.info(
-                "[timing] _update_full %.0fms (bigip config — skipped Tcl analysis)",
-                (time.perf_counter() - t0) * 1000,
+            self._swap_bigip_snapshot(
+                source, version, new_chunks, has_partial, caller="_update_full"
             )
             return
 

--- a/server/workspace/scanner.py
+++ b/server/workspace/scanner.py
@@ -58,6 +58,19 @@ _BIGIP_CONF_NAMES = frozenset(
     }
 )
 
+
+def is_bigip_conf_name(uri: str) -> bool:
+    """Return ``True`` if *uri*'s basename is a canonical BIG-IP config name.
+
+    Single source of truth for the basename → BIG-IP test, shared by the
+    dialect resolution paths (``infer_document_dialect``,
+    ``resolve_dialect_for_uri``) and the diagnostics pipeline so they can
+    never disagree about what counts as a BIG-IP config file.
+    """
+    basename = uri.rsplit("/", 1)[-1].lower() if "/" in uri else uri.lower()
+    return basename in _BIGIP_CONF_NAMES
+
+
 # BIG-IP file extensions for discovery beyond the canonical basenames.
 # ``.scf`` is the F5 single-config-file export format (always BIG-IP);
 # ``.conf`` files are tried opportunistically — the parser is tolerant

--- a/tests/test_bigip_dialect_resolution.py
+++ b/tests/test_bigip_dialect_resolution.py
@@ -1,0 +1,87 @@
+"""BIG-IP config files resolve to the ``f5-bigip`` dialect consistently.
+
+These files are key-value config stanzas, not Tcl source, even though they
+embed ``ltm rule`` stanzas (iRules) and BIG-IP encrypted-string markers
+(``$M$…$``).  The general Tcl analyser must never run on their top-level
+text, so the two dialect resolvers — ``infer_document_dialect`` (sets the
+``DocumentState.dialect_hint``) and ``resolve_dialect_for_uri`` (drives the
+per-request ``dialect_scope``) — must both classify them as ``f5-bigip``.
+
+The subtle case guarded here: a real ``bigip.conf`` contains ``ltm rule``
+stanzas, which the conf-wrapped-iRules heuristic in
+``detect_dialect_from_source`` would otherwise report as ``f5-irules``.  The
+canonical BIG-IP basename must win over that autodetection so the analysis
+skip is not silently defeated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compiler.registry.dialect import detect_dialect_from_source
+from dialects.f5.bigip.rule_extract import is_conf_wrapped_irules
+from server.state import resolve_dialect_for_uri
+from server.workspace.document_state import infer_document_dialect
+from server.workspace.scanner import _BIGIP_CONF_NAMES, is_bigip_conf_name
+
+# A representative bigip.conf fragment: a pool, plus an embedded iRule whose
+# body contains an encrypted-string marker that the Tcl analyser would
+# mis-read as a variable reference (W210).
+_BIGIP_CONF_WITH_RULE = """ltm pool /Common/p { members { 1.2.3.4:80 { } } }
+ltm rule /Common/r {
+  when HTTP_REQUEST {
+    log local0. "$M$mn$9uYx+bTjLD8YSGZA="
+  }
+}
+"""
+
+
+@pytest.mark.parametrize("name", sorted(_BIGIP_CONF_NAMES))
+def test_is_bigip_conf_name_matches_canonical_basenames(name):
+    assert is_bigip_conf_name(f"file:///config/{name}") is True
+    # Case-insensitive and path-stripped.
+    assert is_bigip_conf_name(f"file:///CONFIG/{name.upper()}") is True
+    assert is_bigip_conf_name(name) is True
+
+
+def test_is_bigip_conf_name_rejects_other_files():
+    assert is_bigip_conf_name("file:///x/foo.tcl") is False
+    assert is_bigip_conf_name("file:///x/my_bigip.conf") is False
+    assert is_bigip_conf_name("file:///x/bigip.conf.bak") is False
+
+
+def test_embedded_rule_would_autodetect_as_irules():
+    # Precondition for the regression below: the bare source heuristic
+    # classifies the fragment as f5-irules.
+    assert is_conf_wrapped_irules(_BIGIP_CONF_WITH_RULE) is True
+    assert detect_dialect_from_source(_BIGIP_CONF_WITH_RULE) == "f5-irules"
+
+
+def test_both_resolvers_classify_bigip_conf_with_embedded_rule_as_bigip():
+    uri = "file:///config/bigip.conf"
+    assert infer_document_dialect(uri, _BIGIP_CONF_WITH_RULE) == "f5-bigip"
+    dialect, _extras = resolve_dialect_for_uri(uri, _BIGIP_CONF_WITH_RULE)
+    assert dialect == "f5-bigip"
+
+
+def test_resolvers_agree_for_empty_bigip_conf():
+    uri = "file:///config/bigip_base.conf"
+    assert infer_document_dialect(uri, "") == "f5-bigip"
+    assert resolve_dialect_for_uri(uri, "")[0] == "f5-bigip"
+
+
+def test_explicit_directive_overrides_bigip_basename():
+    # The user's `# tcl-dialect:` directive wins over the basename heuristic,
+    # consistently across both resolvers.
+    src = "# tcl-dialect: tcl8.6\n" + _BIGIP_CONF_WITH_RULE
+    uri = "file:///config/bigip.conf"
+    assert infer_document_dialect(uri, src) == "tcl8.6"
+    assert resolve_dialect_for_uri(uri, src)[0] == "tcl8.6"
+
+
+def test_normal_tcl_file_is_unaffected():
+    # A non-bigip basename containing the same `$M$…` text is still treated
+    # as ordinary Tcl (no forced f5-bigip), so normal analysis applies.
+    uri = "file:///x/foo.tcl"
+    assert infer_document_dialect(uri, 'set x "$M$abc="') is None
+    assert resolve_dialect_for_uri(uri, "set x 1")[0] in (None, "tcl8.6")


### PR DESCRIPTION
## Problem

BIG-IP configuration files (`bigip.conf`, `bigip_base.conf`, etc.) receive false Tcl diagnostics:

- **W210 "Variable read before set"**: `$M$mn$9uYx+bTjLD8YSGZA...=` (encrypted password strings) are mis-parsed as Tcl variable references
- **W111 "Line exceeds 120 characters"**: the line-length check is applied to config stanzas

## Root Cause

The general Tcl analyser runs on BIG-IP config text. These files are key-value config stanzas (not Tcl source), even though they may embed Tcl fragments (tmsh, iApp APL, iRules).

The `lifecycle.py` handlers (`did_open`/`did_change`) already route bigip configs to `_publish_bigip_diagnostics` which uses the BIG-IP-specific parser/validator. However, several other code paths (settings changes, dialect switches, direct analysis calls) could still trigger the Tcl analyser on bigip config text — or bypass the lifecycle routing entirely.

## Fix

Uses the **dialect system**: bigip config files are resolved to the `"f5-bigip"` dialect (already a recognised `Dialect` enum value), and the analysis pipeline skips general Tcl analysis when that dialect is active.

### Changes

| File | Change |
|------|--------|
| `server/state.py` | `resolve_dialect_for_uri`: detect bigip config by basename → `"f5-bigip"` |
| `server/workspace/document_state.py` | `infer_document_dialect`: detect bigip config → `"f5-bigip"` |
| `server/workspace/document_state.py` | `_analyse_document_fresh`: skip when `dialect == "f5-bigip"` |
| `server/workspace/document_state.py` | `_update_full` / `_update_incremental`: skip when `self.dialect_hint == "f5-bigip"` |
| `server/diagnostics_pipeline.py` | `_publish_diagnostics_sync`: skip when resolved dialect is `"f5-bigip"` |
| `server/features/diagnostics.py` | `get_basic_diagnostics`: skip when `active_dialect() == "f5-bigip"` |
| `server/settings.py` | Config-change reanalysis loop: skip when `doc_state.dialect_hint == "f5-bigip"` |
| `server/commands.py` | Dialect-switch reanalyse-all: skip when `state.dialect_hint == "f5-bigip"` |

### Design

- Uses the dialect system rather than ad-hoc URI checks — the dialect is resolved once and used consistently throughout the pipeline
- BIG-IP config detection uses the same canonical basename set (`bigip.conf`, `bigip_base.conf`, `bigip_gtm.conf`, `bigip_script.conf`, `bigip_user.conf`) already defined in `server/workspace/scanner.py`
- A source-level `# tcl-dialect:` directive takes priority over basename detection, so a user can override if needed
- Normal Tcl files are completely unaffected — all existing tests pass
