### PR TITLE
Update PyO3 to 0.28 and modernize Python binding APIs

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -24,7 +24,12 @@ REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 ZIG_VERSION="0.16.0"
 WASMTIME_VERSION="43.0.1"
 BINARYEN_VERSION="123"
-RUST_VERSION="1.95.0"
+# Rust tracks the floating `stable` channel to match `rust-toolchain.toml`
+# (see docs/rust-rewrite.md). Installing the channel — rather than a pinned
+# version — keeps it auto-updating to the latest stable and, critically,
+# means the wasm32-wasip2 target lands on the toolchain the project actually
+# uses. No manual bump needed when a new stable lands.
+RUST_TOOLCHAIN="stable"
 TCLLIB_TAG="tcllib-2-0"
 TCLLIB_VERSION="2.0"
 
@@ -372,7 +377,7 @@ install_tcl_regex() {
 }
 
 # ---------------------------------------------------------------------------
-# 6. Rust toolchain — rustup + stable (pinned).
+# 6. Rust toolchain — rustup + floating `stable` (matches rust-toolchain.toml).
 #    Uses the official rust-lang.org installer so we get signed binaries.
 # ---------------------------------------------------------------------------
 install_rust() {
@@ -428,12 +433,12 @@ install_rust() {
         fi
         chmod +x "${tmpdir}/rustup-init"
 
-        echo "session-start: installing rustup + rust ${RUST_VERSION}"
+        echo "session-start: installing rustup + rust ${RUST_TOOLCHAIN}"
         "${tmpdir}/rustup-init" \
             -y \
             --no-modify-path \
             --profile minimal \
-            --default-toolchain "${RUST_VERSION}" \
+            --default-toolchain "${RUST_TOOLCHAIN}" \
             --component rustfmt,clippy
 
         rustup_bin="${CARGO_HOME}/bin/rustup"
@@ -448,7 +453,7 @@ install_rust() {
     # static.rust-lang.org can 503 briefly, so retry with exponential backoff.
     local attempt
     for attempt in 1 2 3 4; do
-        if "$rustup_bin" toolchain install "${RUST_VERSION}" \
+        if "$rustup_bin" toolchain install "${RUST_TOOLCHAIN}" \
                 --profile minimal --component rustfmt --component clippy \
                 --no-self-update; then
             break
@@ -458,11 +463,11 @@ install_rust() {
             echo "session-start: rustup retry $attempt (waiting ${wait}s) ..."
             sleep "$wait"
         else
-            echo "session-start: failed to install rust ${RUST_VERSION} after 4 attempts" >&2
+            echo "session-start: failed to install rust ${RUST_TOOLCHAIN} after 4 attempts" >&2
             return 1
         fi
     done
-    "$rustup_bin" default "${RUST_VERSION}"
+    "$rustup_bin" default "${RUST_TOOLCHAIN}"
 
     # The Zed extension's clippy check (`make check-rust`, used by
     # `make test-slow`) cross-compiles to wasm32-wasip2, so the target
@@ -470,7 +475,7 @@ install_rust() {
     # already-installed targets.
     for attempt in 1 2 3 4; do
         if "$rustup_bin" target add wasm32-wasip2 \
-                --toolchain "${RUST_VERSION}"; then
+                --toolchain "${RUST_TOOLCHAIN}"; then
             break
         fi
         if [ "$attempt" -lt 4 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ to the project environment with no per-shell `source .venv/bin/activate`.
 | Zig              | 0.16.0        | `/opt/zig-0.16.0/`              | `/usr/local/bin/zig`      |
 | Wasmtime         | v43.0.1       | `/opt/wasmtime-43.0.1/`         | `/usr/local/bin/wasmtime` |
 | Binaryen         | v123          | `/opt/binaryen-123/`            | `/usr/local/bin/wasm-merge`, `/usr/local/bin/wasm-opt` |
-| rustup + Rust    | stable 1.95.0 | `/root/.rustup`, `/root/.cargo` | `/usr/local/bin/{cargo,rustc,rustup,rustfmt,clippy-driver}` |
+| rustup + Rust    | floating `stable` (currently 1.96.0) | `/root/.rustup`, `/root/.cargo` | `/usr/local/bin/{cargo,rustc,rustup,rustfmt,clippy-driver}` |
 | Tcl 8.4 source   | 8.4.20        | `tmp/tcl8.4.20/`                | —                         |
 | Tcl 8.5 source   | 8.5.19        | `tmp/tcl8.5.19/`                | —                         |
 | Tcl 8.6 source   | 8.6.16        | `tmp/tcl8.6.16/`                | —                         |
@@ -126,8 +126,9 @@ Notes on the fetched sources:
 
 To bump any of these versions, edit the pinned variables at the top of
 [`.claude/hooks/session-start.sh`](.claude/hooks/session-start.sh)
-(`ZIG_VERSION`, `WASMTIME_VERSION`, `BINARYEN_VERSION`, `RUST_VERSION`, `TCLLIB_TAG` /
-`TCLLIB_VERSION`) and, for Tcl, the version/tag maps in
+(`ZIG_VERSION`, `WASMTIME_VERSION`, `BINARYEN_VERSION`, `TCLLIB_TAG` /
+`TCLLIB_VERSION`; Rust tracks the floating `stable` channel via
+`RUST_TOOLCHAIN` and needs no version bump) and, for Tcl, the version/tag maps in
 [`.claude/skills/fetch-tcl-source/fetch_tcl_source.sh`](.claude/skills/fetch-tcl-source/fetch_tcl_source.sh).
 For Zig, refresh `expected_sha` in the hook to match the new x86_64-linux
 tarball's SHA-256 from `https://ziglang.org/download/index.json`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,9 +32,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bytes"
@@ -69,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -285,15 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,9 +286,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "litemap"
@@ -335,18 +320,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "once_cell"
@@ -375,18 +351,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -425,37 +401,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -463,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -475,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -501,14 +472,8 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -548,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -612,15 +577,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tcl-compiler"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "tcl-lexer",
  "tcl-registry",
  "tcl-syntax",
@@ -680,7 +645,7 @@ dependencies = [
 name = "tcl-registry"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "tcl-syntax",
 ]
 
@@ -688,24 +653,24 @@ dependencies = [
 name = "tcl-syntax"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "tcl-lexer",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -724,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -861,12 +826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,9 +858,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -922,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/runtime/rust/Cargo.lock
+++ b/runtime/rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "proc-macro2"
@@ -62,18 +62,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/tcl-compiler/Cargo.toml
+++ b/rust/tcl-compiler/Cargo.toml
@@ -13,7 +13,7 @@ tcl-lexer = { path = "../tcl-lexer" }
 tcl-syntax = { path = "../tcl-syntax" }
 tcl-registry = { path = "../tcl-registry" }
 bitflags = "2"
-thiserror = "1.0"
+thiserror = "2.0"
 unicode-general-category = "1.1.0"
 
 [lints]

--- a/rust/tcl-compiler/tests/recovery_positions.rs
+++ b/rust/tcl-compiler/tests/recovery_positions.rs
@@ -14,7 +14,10 @@ use std::collections::HashMap;
 use tcl_compiler::analyser::{Analyser, ProcDef};
 
 fn find_proc<'a>(procs: &'a HashMap<String, ProcDef>, name: &str) -> &'a ProcDef {
-    procs.values().find(|p| p.name == name).expect("proc not found")
+    procs
+        .values()
+        .find(|p| p.name == name)
+        .expect("proc not found")
 }
 
 #[test]
@@ -79,7 +82,9 @@ fn invocation_spans_after_recovery_use_original_offsets() {
     let mut a = Analyser::new();
     let r = a.analyse(src, "tcl8.6");
 
-    let invoc = r.command_invocations.iter()
+    let invoc = r
+        .command_invocations
+        .iter()
         .find(|inv| inv.name == "puts")
         .expect("puts must be found after recovery");
 
@@ -125,10 +130,19 @@ fn diagnostic_spans_always_point_into_original_source() {
         assert!(
             s <= e && e <= src.len(),
             "diagnostic {} span ({s},{e}) out of range for source len {}",
-            d.code, src.len(),
+            d.code,
+            src.len(),
         );
         // Span must land on UTF-8 char boundaries.
-        assert!(src.is_char_boundary(s), "diag {code} start {s} not char boundary", code = d.code);
-        assert!(src.is_char_boundary(e), "diag {code} end {e} not char boundary", code = d.code);
+        assert!(
+            src.is_char_boundary(s),
+            "diag {code} start {s} not char boundary",
+            code = d.code
+        );
+        assert!(
+            src.is_char_boundary(e),
+            "diag {code} end {e} not char boundary",
+            code = d.code
+        );
     }
 }

--- a/rust/tcl-lexer/Cargo.toml
+++ b/rust/tcl-lexer/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-thiserror = "1.0"
+thiserror = "2.0"
 
 [lints]
 workspace = true

--- a/rust/tcl-lexer/tests/edge_structural.rs
+++ b/rust/tcl-lexer/tests/edge_structural.rs
@@ -1,7 +1,7 @@
 /// Edge-case tests for the structural index — verifies behavior at boundaries.
 use tcl_lexer::{
-    BraceIndex, BracketIndex, ExprParenIndex, ParenBalance,
-    command_boundaries, reparse_window, script_is_complete,
+    command_boundaries, reparse_window, script_is_complete, BraceIndex, BracketIndex,
+    ExprParenIndex, ParenBalance,
 };
 
 // ── BracketIndex ──────────────────────────────────────────────────
@@ -252,14 +252,20 @@ fn boundaries_semicolon() {
 fn boundaries_skip_braces() {
     let src = "set x {\n}\nputs hi";
     let b = command_boundaries(src);
-    assert_eq!(*b.last().unwrap(), u32::try_from(src.len()).expect("offset fits u32"));
+    assert_eq!(
+        *b.last().unwrap(),
+        u32::try_from(src.len()).expect("offset fits u32")
+    );
 }
 
 #[test]
 fn boundaries_skip_cmd_sub() {
     let src = "if {[info exists x]} { puts hi }\nset y 1";
     let b = command_boundaries(src);
-    assert_eq!(*b.last().unwrap(), u32::try_from(src.len()).expect("offset fits u32"));
+    assert_eq!(
+        *b.last().unwrap(),
+        u32::try_from(src.len()).expect("offset fits u32")
+    );
 }
 
 #[test]

--- a/rust/tcl-lsp-py/Cargo.toml
+++ b/rust/tcl-lsp-py/Cargo.toml
@@ -19,7 +19,7 @@ tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-lsp-core = { path = "../tcl-lsp-core" }
-pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
 
 [lints]
 workspace = true

--- a/rust/tcl-lsp-py/src/analyser.rs
+++ b/rust/tcl-lsp-py/src/analyser.rs
@@ -68,67 +68,67 @@ pub fn analyser_analyse<'py>(
 }
 
 fn result_to_dict<'py>(py: Python<'py>, r: &AnalysisResult) -> PyResult<Bound<'py, PyDict>> {
-    let out = PyDict::new_bound(py);
+    let out = PyDict::new(py);
 
     out.set_item("global_scope", scope_to_dict(py, &r.global_scope)?)?;
 
-    let procs = PyDict::new_bound(py);
+    let procs = PyDict::new(py);
     for (qname, p) in &r.all_procs {
         procs.set_item(qname, proc_to_dict(py, p)?)?;
     }
     out.set_item("all_procs", procs)?;
 
-    let classes = PyDict::new_bound(py);
+    let classes = PyDict::new(py);
     for (qname, c) in &r.all_classes {
         classes.set_item(qname, class_to_dict(py, c)?)?;
     }
     out.set_item("all_classes", classes)?;
 
-    let variables = PyDict::new_bound(py);
+    let variables = PyDict::new(py);
     for (qname, v) in &r.all_variables {
         variables.set_item(qname, var_to_dict(py, v)?)?;
     }
     out.set_item("all_variables", variables)?;
 
-    let diagnostics = PyList::empty_bound(py);
+    let diagnostics = PyList::empty(py);
     for d in &r.diagnostics {
         diagnostics.append(diagnostic_to_dict(py, d)?)?;
     }
     out.set_item("diagnostics", diagnostics)?;
 
-    let invocations = PyList::empty_bound(py);
+    let invocations = PyList::empty(py);
     for inv in &r.command_invocations {
         invocations.append(invocation_to_dict(py, inv)?)?;
     }
     out.set_item("command_invocations", invocations)?;
 
-    let packages = PyList::empty_bound(py);
+    let packages = PyList::empty(py);
     for pr in &r.package_requires {
         packages.append(package_require_to_dict(py, pr)?)?;
     }
     out.set_item("package_requires", packages)?;
 
-    let sources = PyList::empty_bound(py);
+    let sources = PyList::empty(py);
     for s in &r.source_targets {
         sources.append(source_target_to_dict(py, s)?)?;
     }
     out.set_item("source_targets", sources)?;
 
-    let aliases = PyDict::new_bound(py);
+    let aliases = PyDict::new(py);
     for (qname, a) in &r.command_aliases {
         aliases.set_item(qname, alias_to_dict(py, a)?)?;
     }
     out.set_item("command_aliases", aliases)?;
 
-    let imports = PyList::empty_bound(py);
+    let imports = PyList::empty(py);
     for imp in &r.namespace_imports {
         imports.append(namespace_import_to_dict(py, imp)?)?;
     }
     out.set_item("namespace_imports", imports)?;
 
-    let provides = PyList::empty_bound(py);
+    let provides = PyList::empty(py);
     for pp in &r.package_provides {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         d.set_item("name", &pp.name)?;
         d.set_item("version", pp.version.clone())?;
         d.set_item("range", span_tuple(pp.range))?;
@@ -137,9 +137,9 @@ fn result_to_dict<'py>(py: Python<'py>, r: &AnalysisResult) -> PyResult<Bound<'p
     out.set_item("package_provides", provides)?;
     out.set_item("has_dynamic_providers", r.has_dynamic_providers)?;
 
-    let auto_paths = PyList::empty_bound(py);
+    let auto_paths = PyList::empty(py);
     for ap in &r.auto_path_entries {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         d.set_item("raw_path", &ap.raw_path)?;
         d.set_item("range", span_tuple(ap.range))?;
         auto_paths.append(d)?;
@@ -149,9 +149,9 @@ fn result_to_dict<'py>(py: Python<'py>, r: &AnalysisResult) -> PyResult<Bound<'p
     out.set_item("stub_commands", stub_commands_to_list(py, r)?)?;
     out.set_item("stub_expr_defs", stub_expr_defs_to_list(py, r)?)?;
 
-    let regex = PyList::empty_bound(py);
+    let regex = PyList::empty(py);
     for rp in &r.regex_patterns {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         d.set_item("range", span_tuple(rp.range))?;
         d.set_item("pattern", &rp.pattern)?;
         d.set_item("command", &rp.command)?;
@@ -159,9 +159,9 @@ fn result_to_dict<'py>(py: Python<'py>, r: &AnalysisResult) -> PyResult<Bound<'p
     }
     out.set_item("regex_patterns", regex)?;
 
-    let suppressed = PyDict::new_bound(py);
+    let suppressed = PyDict::new(py);
     for (line, codes) in &r.suppressed_lines {
-        let code_list = PyList::empty_bound(py);
+        let code_list = PyList::empty(py);
         for c in codes {
             code_list.append(c.as_str())?;
         }
@@ -187,13 +187,13 @@ fn result_to_dict<'py>(py: Python<'py>, r: &AnalysisResult) -> PyResult<Bound<'p
 /// ``StubFlags`` bitfield; this decomposes it back to the
 /// per-flag boolean dict shape Python consumes.
 fn stub_commands_to_list<'py>(py: Python<'py>, r: &AnalysisResult) -> PyResult<Bound<'py, PyList>> {
-    let stub_cmds = PyList::empty_bound(py);
+    let stub_cmds = PyList::empty(py);
     for sc in &r.stub_commands {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         d.set_item("name", &sc.name)?;
-        let args = PyList::empty_bound(py);
+        let args = PyList::empty(py);
         for a in &sc.args {
-            let ad = PyDict::new_bound(py);
+            let ad = PyDict::new(py);
             ad.set_item("name", &a.name)?;
             ad.set_item("role", &a.role)?;
             ad.set_item("optional", a.optional)?;
@@ -219,9 +219,9 @@ fn stub_expr_defs_to_list<'py>(
     py: Python<'py>,
     r: &AnalysisResult,
 ) -> PyResult<Bound<'py, PyList>> {
-    let stub_exprs = PyList::empty_bound(py);
+    let stub_exprs = PyList::empty(py);
     for se in &r.stub_expr_defs {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         d.set_item("name", &se.name)?;
         d.set_item("kind", &se.kind)?;
         d.set_item("arity", se.arity)?;
@@ -232,30 +232,30 @@ fn stub_expr_defs_to_list<'py>(
 }
 
 fn scope_to_dict<'py>(py: Python<'py>, s: &Scope) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("kind", s.kind.as_str())?;
     d.set_item("name", &s.name)?;
     d.set_item("body_range", s.body_span.map(span_tuple))?;
 
-    let variables = PyDict::new_bound(py);
+    let variables = PyDict::new(py);
     for (name, v) in &s.variables {
         variables.set_item(name, var_to_dict(py, v)?)?;
     }
     d.set_item("variables", variables)?;
 
-    let procs = PyDict::new_bound(py);
+    let procs = PyDict::new(py);
     for (name, p) in &s.procs {
         procs.set_item(name, proc_to_dict(py, p)?)?;
     }
     d.set_item("procs", procs)?;
 
-    let classes = PyDict::new_bound(py);
+    let classes = PyDict::new(py);
     for (name, c) in &s.classes {
         classes.set_item(name, class_to_dict(py, c)?)?;
     }
     d.set_item("classes", classes)?;
 
-    let children = PyList::empty_bound(py);
+    let children = PyList::empty(py);
     for child in &s.children {
         children.append(scope_to_dict(py, child)?)?;
     }
@@ -264,12 +264,12 @@ fn scope_to_dict<'py>(py: Python<'py>, s: &Scope) -> PyResult<Bound<'py, PyDict>
 }
 
 fn proc_to_dict<'py>(py: Python<'py>, p: &ProcDef) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &p.name)?;
     d.set_item("qualified_name", &p.qualified_name)?;
-    let params = PyList::empty_bound(py);
+    let params = PyList::empty(py);
     for param in &p.params {
-        let pd = PyDict::new_bound(py);
+        let pd = PyDict::new(py);
         pd.set_item("name", &param.name)?;
         pd.set_item("has_default", param.has_default)?;
         pd.set_item("default_value", param.default_value.clone())?;
@@ -284,9 +284,9 @@ fn proc_to_dict<'py>(py: Python<'py>, p: &ProcDef) -> PyResult<Bound<'py, PyDict
     // (``"eval"`` / ``"body"`` / ``"var_write"`` / ``"var_read"``
     // / ``"expr"`` / ``"loop_list"``).  Empty entries are
     // omitted.
-    let traits_dict = PyDict::new_bound(py);
+    let traits_dict = PyDict::new(py);
     for (param_name, set) in &p.param_traits {
-        let trait_list = PyList::empty_bound(py);
+        let trait_list = PyList::empty(py);
         for t in set {
             trait_list.append(t.as_str())?;
         }
@@ -297,25 +297,25 @@ fn proc_to_dict<'py>(py: Python<'py>, p: &ProcDef) -> PyResult<Bound<'py, PyDict
 }
 
 fn class_to_dict<'py>(py: Python<'py>, c: &ClassDef) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &c.name)?;
     d.set_item("qualified_name", &c.qualified_name)?;
     d.set_item("name_range", span_tuple(c.name_span))?;
     d.set_item("body_range", span_tuple(c.body_span))?;
     d.set_item("metaclass", &c.metaclass)?;
-    d.set_item("superclasses", PyList::new_bound(py, &c.superclasses))?;
-    d.set_item("mixins", PyList::new_bound(py, &c.mixins))?;
-    let methods = PyDict::new_bound(py);
+    d.set_item("superclasses", PyList::new(py, &c.superclasses)?)?;
+    d.set_item("mixins", PyList::new(py, &c.mixins)?)?;
+    let methods = PyDict::new(py);
     for (name, m) in &c.methods {
         methods.set_item(name, method_to_dict(py, m)?)?;
     }
     d.set_item("methods", methods)?;
-    let class_methods = PyDict::new_bound(py);
+    let class_methods = PyDict::new(py);
     for (name, m) in &c.class_methods {
         class_methods.set_item(name, method_to_dict(py, m)?)?;
     }
     d.set_item("class_methods", class_methods)?;
-    let constructors = PyList::empty_bound(py);
+    let constructors = PyList::empty(py);
     for ctor in &c.constructors {
         constructors.append(method_to_dict(py, ctor)?)?;
     }
@@ -324,28 +324,28 @@ fn class_to_dict<'py>(py: Python<'py>, c: &ClassDef) -> PyResult<Bound<'py, PyDi
         Some(dtor) => d.set_item("destructor", method_to_dict(py, dtor)?)?,
         None => d.set_item("destructor", py.None())?,
     }
-    d.set_item("variables", PyList::new_bound(py, &c.variables))?;
-    let properties = PyDict::new_bound(py);
+    d.set_item("variables", PyList::new(py, &c.variables)?)?;
+    let properties = PyDict::new(py);
     for (name, p) in &c.properties {
         properties.set_item(name, property_to_dict(py, p)?)?;
     }
     d.set_item("properties", properties)?;
-    d.set_item("filters", PyList::new_bound(py, &c.filters))?;
+    d.set_item("filters", PyList::new(py, &c.filters)?)?;
     // ``HashSet`` iteration is non-deterministic; sort for stable
     // output so downstream callers (and golden tests) see a
     // consistent ordering.
     let mut exports: Vec<&String> = c.exports.iter().collect();
     exports.sort();
-    d.set_item("exports", PyList::new_bound(py, &exports))?;
+    d.set_item("exports", PyList::new(py, &exports)?)?;
     let mut unexports: Vec<&String> = c.unexports.iter().collect();
     unexports.sort();
-    d.set_item("unexports", PyList::new_bound(py, &unexports))?;
+    d.set_item("unexports", PyList::new(py, &unexports)?)?;
     d.set_item("doc", &c.doc)?;
     Ok(d)
 }
 
 fn property_to_dict<'py>(py: Python<'py>, p: &PropertyDef) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &p.name)?;
     d.set_item("name_range", span_tuple(p.name_span))?;
     d.set_item("kind", &p.kind)?;
@@ -358,9 +358,9 @@ fn unknown_proc_info_to_dict<'py>(
     py: Python<'py>,
     info: &UnknownProcInfo,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     let targets: Vec<&String> = info.dispatch_targets.iter().collect();
-    d.set_item("dispatch_targets", PyList::new_bound(py, &targets))?;
+    d.set_item("dispatch_targets", PyList::new(py, &targets)?)?;
     d.set_item("chains_original", info.chains_original)?;
     d.set_item("empty_stub", info.empty_stub)?;
     d.set_item("case_insensitive", info.case_insensitive)?;
@@ -374,11 +374,11 @@ fn method_to_dict<'py>(
     py: Python<'py>,
     m: &tcl_compiler::analyser::MethodDef,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &m.name)?;
-    let params = PyList::empty_bound(py);
+    let params = PyList::empty(py);
     for param in &m.params {
-        let pd = PyDict::new_bound(py);
+        let pd = PyDict::new(py);
         pd.set_item("name", &param.name)?;
         pd.set_item("has_default", param.has_default)?;
         pd.set_item("default_value", param.default_value.clone())?;
@@ -394,10 +394,10 @@ fn method_to_dict<'py>(
 }
 
 fn var_to_dict<'py>(py: Python<'py>, v: &VarDef) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &v.name)?;
     d.set_item("definition_range", span_tuple(v.definition_span))?;
-    let refs = PyList::empty_bound(py);
+    let refs = PyList::empty(py);
     for r in &v.references {
         refs.append(span_tuple(*r))?;
     }
@@ -407,12 +407,12 @@ fn var_to_dict<'py>(py: Python<'py>, v: &VarDef) -> PyResult<Bound<'py, PyDict>>
 }
 
 fn diagnostic_to_dict<'py>(py: Python<'py>, d: &Diagnostic) -> PyResult<Bound<'py, PyDict>> {
-    let out = PyDict::new_bound(py);
+    let out = PyDict::new(py);
     out.set_item("code", &d.code)?;
     out.set_item("range", span_tuple(d.span))?;
     out.set_item("message", &d.message)?;
     out.set_item("severity", d.severity.as_str())?;
-    let fixes = PyList::empty_bound(py);
+    let fixes = PyList::empty(py);
     for fix in &d.fixes {
         fixes.append(code_fix_to_dict(py, fix)?)?;
     }
@@ -421,7 +421,7 @@ fn diagnostic_to_dict<'py>(py: Python<'py>, d: &Diagnostic) -> PyResult<Bound<'p
 }
 
 fn code_fix_to_dict<'py>(py: Python<'py>, fix: &CodeFix) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("range", span_tuple(fix.span))?;
     d.set_item("new_text", &fix.new_text)?;
     d.set_item("description", &fix.description)?;
@@ -432,7 +432,7 @@ fn invocation_to_dict<'py>(
     py: Python<'py>,
     inv: &SignatureCommandInvocation,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &inv.name)?;
     d.set_item("range", span_tuple(inv.range))?;
     Ok(d)
@@ -442,7 +442,7 @@ fn package_require_to_dict<'py>(
     py: Python<'py>,
     pr: &SignaturePackageRequire,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &pr.name)?;
     d.set_item("version", pr.version.clone())?;
     d.set_item("range", span_tuple(pr.range))?;
@@ -454,7 +454,7 @@ fn source_target_to_dict<'py>(
     py: Python<'py>,
     s: &SignatureSource,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("raw_path", &s.raw_path)?;
     d.set_item("range", span_tuple(s.range))?;
     d.set_item("is_literal", s.is_literal)?;
@@ -462,10 +462,10 @@ fn source_target_to_dict<'py>(
 }
 
 fn alias_to_dict<'py>(py: Python<'py>, a: &SignatureCommandAlias) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("qualified_name", &a.qualified_name)?;
     d.set_item("target", &a.target)?;
-    d.set_item("extras", PyList::new_bound(py, &a.extras))?;
+    d.set_item("extras", PyList::new(py, &a.extras)?)?;
     Ok(d)
 }
 
@@ -473,7 +473,7 @@ fn namespace_import_to_dict<'py>(
     py: Python<'py>,
     imp: &SignatureNamespaceImport,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("ns", &imp.ns)?;
     d.set_item("pattern", &imp.pattern)?;
     d.set_item("range", span_tuple(imp.range))?;

--- a/rust/tcl-lsp-py/src/compilation_unit.rs
+++ b/rust/tcl-lsp-py/src/compilation_unit.rs
@@ -24,7 +24,12 @@ use tcl_compiler::compilation_unit::CompilationUnit;
 /// Rust side. `Arc` lets the handle be cheap-cloneable so future
 /// follow-up bindings can take it by value without sacrificing
 /// amortised reuse.
-#[pyclass(module = "tcl_lsp_py", name = "CompilationUnit", frozen)]
+#[pyclass(
+    module = "tcl_lsp_py",
+    name = "CompilationUnit",
+    frozen,
+    from_py_object
+)]
 #[derive(Clone)]
 pub struct CompilationUnitHandle {
     pub(crate) inner: Arc<CompilationUnit>,

--- a/rust/tcl-lsp-py/src/expr_lexer.rs
+++ b/rust/tcl-lsp-py/src/expr_lexer.rs
@@ -6,7 +6,14 @@ use tcl_lexer::{
     tokenise_expr as core_tokenise, ExprToken as CoreExprToken, ExprTokenType as CoreExprTokenType,
 };
 
-#[pyclass(name = "ExprTokenType", eq, hash, frozen, module = "tcl_lsp_py")]
+#[pyclass(
+    name = "ExprTokenType",
+    eq,
+    hash,
+    frozen,
+    module = "tcl_lsp_py",
+    from_py_object
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PyExprTokenType {
     #[pyo3(name = "NUMBER")]
@@ -102,7 +109,14 @@ impl From<PyExprTokenType> for CoreExprTokenType {
     }
 }
 
-#[pyclass(name = "ExprToken", eq, hash, frozen, module = "tcl_lsp_py")]
+#[pyclass(
+    name = "ExprToken",
+    eq,
+    hash,
+    frozen,
+    module = "tcl_lsp_py",
+    from_py_object
+)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PyExprToken {
     kind: PyExprTokenType,
@@ -116,7 +130,7 @@ impl PyExprToken {
     #[getter]
     #[pyo3(name = "type")]
     fn token_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let class = py.get_type_bound::<PyExprTokenType>();
+        let class = py.get_type::<PyExprTokenType>();
         class.getattr(self.kind.name())
     }
 

--- a/rust/tcl-lsp-py/src/features/document_symbols_binding.rs
+++ b/rust/tcl-lsp-py/src/features/document_symbols_binding.rs
@@ -49,7 +49,7 @@ fn symbols_to_list<'py>(
     py: Python<'py>,
     symbols: &[DocumentSymbol],
 ) -> PyResult<Bound<'py, PyList>> {
-    let out = PyList::empty_bound(py);
+    let out = PyList::empty(py);
     for s in symbols {
         out.append(symbol_to_dict(py, s)?)?;
     }
@@ -57,7 +57,7 @@ fn symbols_to_list<'py>(
 }
 
 fn symbol_to_dict<'py>(py: Python<'py>, s: &DocumentSymbol) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &s.name)?;
     match &s.detail {
         Some(text) => d.set_item("detail", text)?,
@@ -71,7 +71,7 @@ fn symbol_to_dict<'py>(py: Python<'py>, s: &DocumentSymbol) -> PyResult<Bound<'p
 }
 
 fn range_to_dict(py: Python<'_>, r: LineRange) -> PyResult<Bound<'_, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("start_line", r.start_line)?;
     d.set_item("start_character", r.start_character)?;
     d.set_item("end_line", r.end_line)?;

--- a/rust/tcl-lsp-py/src/features/folding_binding.rs
+++ b/rust/tcl-lsp-py/src/features/folding_binding.rs
@@ -41,7 +41,7 @@ pub fn folding_ranges<'py>(
 ) -> PyResult<Bound<'py, PyList>> {
     let registry = crate::registry::default_registry_for_dialect(dialect);
     let ranges = compute_folding_ranges(source, dialect, registry);
-    let out = PyList::empty_bound(py);
+    let out = PyList::empty(py);
     for r in ranges {
         out.append(folding_range_to_dict(py, r)?)?;
     }
@@ -49,7 +49,7 @@ pub fn folding_ranges<'py>(
 }
 
 fn folding_range_to_dict(py: Python<'_>, r: FoldingRange) -> PyResult<Bound<'_, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("start_line", r.start_line)?;
     d.set_item("end_line", r.end_line)?;
     d.set_item("kind", r.kind.as_str())?;

--- a/rust/tcl-lsp-py/src/interprocedural.rs
+++ b/rust/tcl-lsp-py/src/interprocedural.rs
@@ -56,7 +56,7 @@ pub fn interprocedural_summaries<'py>(
     let registry = crate::registry::default_registry();
     let cu =
         CompilationUnit::build_for(source, registry, false).with_interprocedural(registry, dialect);
-    let out = PyDict::new_bound(py);
+    let out = PyDict::new(py);
     let Some(ia) = cu.interproc.as_ref() else {
         return Ok(out);
     };
@@ -68,12 +68,12 @@ pub fn interprocedural_summaries<'py>(
 }
 
 fn summary_to_dict<'py>(py: Python<'py>, s: &ProcSummary) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("qualified_name", &s.qualified_name)?;
-    d.set_item("params", PyList::new_bound(py, &s.params))?;
+    d.set_item("params", PyList::new(py, &s.params)?)?;
     d.set_item("arity_min", s.arity.min)?;
     d.set_item("arity_max", s.arity.max)?;
-    d.set_item("calls", PyList::new_bound(py, &s.calls))?;
+    d.set_item("calls", PyList::new(py, &s.calls)?)?;
     d.set_item("has_barrier", s.has_barrier)?;
     d.set_item("has_unknown_calls", s.has_unknown_calls)?;
     d.set_item("writes_global", s.writes_global)?;
@@ -87,7 +87,7 @@ fn summary_to_dict<'py>(py: Python<'py>, s: &ProcSummary) -> PyResult<Bound<'py,
     )?;
     d.set_item(
         "return_depends_on_params",
-        PyList::new_bound(py, &s.return_depends_on_params),
+        PyList::new(py, &s.return_depends_on_params)?,
     )?;
     d.set_item(
         "return_passthrough_param",
@@ -109,11 +109,11 @@ fn param_traits_to_dict<'py>(
     py: Python<'py>,
     traits: &HashMap<String, std::collections::HashSet<ProcArgTrait>>,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     for (name, set) in traits {
         let mut names: Vec<&'static str> = set.iter().map(|t| t.as_str()).collect();
         names.sort_unstable();
-        d.set_item(name, PyList::new_bound(py, &names))?;
+        d.set_item(name, PyList::new(py, &names)?)?;
     }
     Ok(d)
 }

--- a/rust/tcl-lsp-py/src/signature_scan.rs
+++ b/rust/tcl-lsp-py/src/signature_scan.rs
@@ -50,51 +50,51 @@ use tcl_lexer::Span;
 #[pyo3(signature = (source, /))]
 pub fn signature_scan_extract<'py>(py: Python<'py>, source: &str) -> PyResult<Bound<'py, PyDict>> {
     let result = extract_signatures(source, crate::registry::default_registry());
-    let out = PyDict::new_bound(py);
+    let out = PyDict::new(py);
 
-    let procs = PyDict::new_bound(py);
+    let procs = PyDict::new(py);
     for (qname, p) in &result.procs {
         procs.set_item(qname, proc_to_dict(py, p)?)?;
     }
     out.set_item("procs", procs)?;
 
-    let classes = PyDict::new_bound(py);
+    let classes = PyDict::new(py);
     for (qname, c) in &result.classes {
         classes.set_item(qname, class_to_dict(py, c)?)?;
     }
     out.set_item("classes", classes)?;
 
-    let invocations = PyList::empty_bound(py);
+    let invocations = PyList::empty(py);
     for inv in &result.command_invocations {
         invocations.append(invocation_to_dict(py, inv)?)?;
     }
     out.set_item("command_invocations", invocations)?;
 
-    let packages = PyList::empty_bound(py);
+    let packages = PyList::empty(py);
     for pr in &result.package_requires {
         packages.append(package_require_to_dict(py, pr)?)?;
     }
     out.set_item("package_requires", packages)?;
 
-    let sources = PyList::empty_bound(py);
+    let sources = PyList::empty(py);
     for s in &result.source_targets {
         sources.append(source_to_dict(py, s)?)?;
     }
     out.set_item("source_targets", sources)?;
 
-    let aliases = PyDict::new_bound(py);
+    let aliases = PyDict::new(py);
     for (qname, a) in &result.command_aliases {
         aliases.set_item(qname, alias_to_dict(py, a)?)?;
     }
     out.set_item("command_aliases", aliases)?;
 
-    let imports = PyList::empty_bound(py);
+    let imports = PyList::empty(py);
     for imp in &result.namespace_imports {
         imports.append(namespace_import_to_dict(py, imp)?)?;
     }
     out.set_item("namespace_imports", imports)?;
 
-    let autopath = PyList::empty_bound(py);
+    let autopath = PyList::empty(py);
     for entry in &result.auto_path_entries {
         autopath.append(auto_path_entry_to_dict(py, entry)?)?;
     }
@@ -104,10 +104,10 @@ pub fn signature_scan_extract<'py>(py: Python<'py>, source: &str) -> PyResult<Bo
 }
 
 fn proc_to_dict<'py>(py: Python<'py>, p: &SignatureProc) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &p.name)?;
     d.set_item("qualified_name", &p.qualified_name)?;
-    let params = PyList::empty_bound(py);
+    let params = PyList::empty(py);
     for param in &p.params {
         params.append(param_to_dict(py, param)?)?;
     }
@@ -118,7 +118,7 @@ fn proc_to_dict<'py>(py: Python<'py>, p: &SignatureProc) -> PyResult<Bound<'py, 
 }
 
 fn class_to_dict<'py>(py: Python<'py>, c: &SignatureClass) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &c.name)?;
     d.set_item("qualified_name", &c.qualified_name)?;
     d.set_item("name_range", span_tuple(c.name_range))?;
@@ -130,14 +130,14 @@ fn invocation_to_dict<'py>(
     py: Python<'py>,
     inv: &SignatureCommandInvocation,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &inv.name)?;
     d.set_item("range", span_tuple(inv.range))?;
     Ok(d)
 }
 
 fn param_to_dict<'py>(py: Python<'py>, p: &ParamDef) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &p.name)?;
     d.set_item("has_default", p.has_default)?;
     d.set_item("default_value", p.default_value.clone())?;
@@ -148,7 +148,7 @@ fn package_require_to_dict<'py>(
     py: Python<'py>,
     pr: &SignaturePackageRequire,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("name", &pr.name)?;
     d.set_item("version", pr.version.clone())?;
     d.set_item("range", span_tuple(pr.range))?;
@@ -157,7 +157,7 @@ fn package_require_to_dict<'py>(
 }
 
 fn source_to_dict<'py>(py: Python<'py>, s: &SignatureSource) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("raw_path", &s.raw_path)?;
     d.set_item("range", span_tuple(s.range))?;
     d.set_item("is_literal", s.is_literal)?;
@@ -165,10 +165,10 @@ fn source_to_dict<'py>(py: Python<'py>, s: &SignatureSource) -> PyResult<Bound<'
 }
 
 fn alias_to_dict<'py>(py: Python<'py>, a: &SignatureCommandAlias) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("qualified_name", &a.qualified_name)?;
     d.set_item("target", &a.target)?;
-    d.set_item("extras", PyList::new_bound(py, &a.extras))?;
+    d.set_item("extras", PyList::new(py, &a.extras)?)?;
     Ok(d)
 }
 
@@ -176,7 +176,7 @@ fn namespace_import_to_dict<'py>(
     py: Python<'py>,
     imp: &SignatureNamespaceImport,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("ns", &imp.ns)?;
     d.set_item("pattern", &imp.pattern)?;
     d.set_item("range", span_tuple(imp.range))?;
@@ -188,7 +188,7 @@ fn auto_path_entry_to_dict<'py>(
     py: Python<'py>,
     entry: &SignatureAutoPathEntry,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let d = PyDict::new_bound(py);
+    let d = PyDict::new(py);
     d.set_item("raw", &entry.raw)?;
     d.set_item("range", span_tuple(entry.range))?;
     Ok(d)

--- a/rust/tcl-lsp-py/src/tokens.rs
+++ b/rust/tcl-lsp-py/src/tokens.rs
@@ -22,7 +22,14 @@ use tcl_lexer::{SourcePosition as CoreSourcePosition, TokenType as CoreTokenType
 /// original Python `auto()` declarations (1-indexed) so `TokenType.X.value`
 /// stays stable across the Rust port and any external scripts that
 /// happened to read it.
-#[pyclass(name = "TokenType", eq, hash, frozen, module = "tcl_lsp_py")]
+#[pyclass(
+    name = "TokenType",
+    eq,
+    hash,
+    frozen,
+    module = "tcl_lsp_py",
+    from_py_object
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PyTokenType {
     /// Plain string fragment.
@@ -117,7 +124,14 @@ impl From<PyTokenType> for CoreTokenType {
 /// A position in source text. Exposed to Python as
 /// `tcl_lsp_py.SourcePosition` (also reachable via the legacy
 /// `tcl_lsp_rust.SourcePosition` alias for the transition window).
-#[pyclass(name = "SourcePosition", eq, hash, frozen, module = "tcl_lsp_py")]
+#[pyclass(
+    name = "SourcePosition",
+    eq,
+    hash,
+    frozen,
+    module = "tcl_lsp_py",
+    from_py_object
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PySourcePosition {
     inner: CoreSourcePosition,
@@ -179,7 +193,14 @@ impl PySourcePosition {
 /// Owns its text as `String`. The original Python dataclass was frozen
 /// (`@dataclass(frozen=True, slots=True)`) and Rust enforces the same
 /// invariant via `#[pyclass(frozen)]`.
-#[pyclass(name = "Token", eq, hash, frozen, module = "tcl_lsp_py")]
+#[pyclass(
+    name = "Token",
+    eq,
+    hash,
+    frozen,
+    module = "tcl_lsp_py",
+    from_py_object
+)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PyToken {
     kind: PyTokenType,
@@ -245,7 +266,7 @@ impl PyToken {
     #[getter]
     #[pyo3(name = "type")]
     fn token_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let class = py.get_type_bound::<PyTokenType>();
+        let class = py.get_type::<PyTokenType>();
         class.getattr(self.kind.name())
     }
 

--- a/rust/tcl-lsp-rust/Cargo.toml
+++ b/rust/tcl-lsp-rust/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 tcl-lsp-py = { path = "../tcl-lsp-py" }
-pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- Upgrade PyO3 from 0.22 to 0.28 in tcl-lsp-rust and tcl-lsp-py
- Migrate deprecated PyO3 APIs to their modern equivalents:
  - `PyDict::new_bound()` → `PyDict::new()`
  - `PyList::empty_bound()` → `PyList::empty()`
  - `PyList::new_bound()` → `PyList::new()` with error handling
  - `py.get_type_bound::<T>()` → `py.get_type::<T>()`
- Add `from_py_object` attribute to `#[pyclass]` macros for better Python interop
- Update thiserror dependency from 1.0 to 2.0 across tcl-compiler and tcl-lexer
- Switch Rust toolchain from pinned version (1.95.0) to floating `stable` channel in session-start.sh
- Minor code formatting improvements for consistency

## Validation

- No new tests added; changes are mechanical API migrations with no behavioral impact
- Existing test suite validates the refactored code paths
- PyO3 0.28 is backward compatible with the abi3-py310 feature used by the project

## Notes

The PyO3 API changes reflect the library's evolution toward more ergonomic bound object handling. The `_bound` suffix variants are now the default, and the non-suffixed versions return `PyResult` to handle potential errors during object creation. The `from_py_object` attribute enables automatic conversion of Python objects to Rust types, improving interoperability.

The Rust toolchain change to floating `stable` ensures the wasm32-wasip2 target is automatically available on the toolchain the project actually uses, eliminating the need for manual version bumps when new stable releases land.

https://claude.ai/code/session_01DkX3YY6hAo17h6qtP4YGsT