### PR TITLE
Release hardening: fix format/scan const-fold blocker + WASM incr (#262), backfill issue/FP test coverage

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.10-52-gf41d9825-dirty
-head=f41d98257801e9cfa872e5000646e168d79714d2
-date=2026-06-10T12:11:37Z
-fingerprint=3a8d3ea68800910409be4c78e6f85cca50c48e73674de90cbfa843ac86932c17
+describe=v1.10.10-44-g58a98c90-dirty
+head=58a98c9080f25368e3615e387c176e29d987963e
+date=2026-06-10T14:30:59Z
+fingerprint=a83b65df3a021b2c8a83468ee0067840f4eda7e48d72f32244a0e7d384d4279a

--- a/compiler/codegen/wasm/_emitter/cmds/set_.py
+++ b/compiler/codegen/wasm/_emitter/cmds/set_.py
@@ -87,10 +87,93 @@ def _emit_set(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: Em
     return True
 
 
+def _emit_incr_strict(
+    emitter, args: tuple[str, ...], defs: tuple[str, ...], context: EmitContext
+) -> bool:
+    """Issue #262: route ``incr`` through the strict ``tcl_incr`` runtime
+    helper so a non-integer current value (e.g. the float string ``"52.60"``
+    or ``"abc"``) raises ``expected integer but got ...`` rather than being
+    silently truncated/zeroed by the permissive inline unbox (``obj_get_int``).
+
+    This mirrors the strict lowering the optimiser/CFG paths already use for
+    ``IRIncr`` (``_optimisation.py`` / ``_control_flow.py`` / ``_statements.py``);
+    the inline command emitter is reached for ``incr`` in value position and in
+    un-optimised statement positions such as a ``catch {}`` body, which is where
+    the permissiveness bug surfaced.
+
+    Returns ``False`` when the runtime predates the ``tcl_incr`` import so the
+    caller falls back to the legacy inline arithmetic.
+    """
+    incr_idx = emitter._shared_imports.get("tcl_incr")
+    if incr_idx is None:
+        return False
+    var = args[0]
+    array_ref = _parse_array_ref(var)
+    base = array_ref[0] if array_ref else var
+
+    # Compute the post-increment value (boxed TclObj) on the stack:
+    #   tcl_incr(lenient_read(var), amount_obj)
+    # Lenient read so ``incr x`` on an unset scalar initialises to 0
+    # (Tcl 8.5+: returns the increment, doesn't raise) — same as the
+    # optimised tail path.  ``tcl_incr`` enforces the strict-integer guard
+    # on both the current value and a non-literal increment.
+    emitter._emit_var_read_obj_lenient(var)
+    if len(args) >= 2:
+        try:
+            emitter._emit_i64_const(int(args[1]))
+            emitter._emit_box_int()
+        except ValueError:
+            emitter._emit_value(args[1])
+    else:
+        emitter._emit_i64_const(1)
+        emitter._emit_box_int()
+    emitter._emit_call(incr_idx)
+    # Stack: [new_value_obj]
+
+    in_ns_block = (
+        not emitter._is_proc
+        and emitter._block_namespace is not None
+        and emitter._block_namespace != "::"
+        and array_ref is None
+    )
+    use_var_path = (
+        not emitter._is_proc
+        or var in emitter._globals
+        or var in emitter._aliases
+        or base in emitter._aliases
+        or array_ref is not None
+        or in_ns_block
+        or _is_dynamic_var_name(var)
+    )
+
+    if context is EmitContext.VALUE:
+        # Keep the new value on the stack for the enclosing expression.
+        if use_var_path:
+            emitter._emit_var_write_obj_keep(var)
+        else:
+            idx = emitter._intern_local(var)
+            emitter._emit_local_tee(idx)
+        return True
+
+    # STATEMENT context — write back (consume), mirroring the legacy path's
+    # def-mirror capture for non-dynamic names.
+    use_def_mirror = bool(defs) and not _is_dynamic_var_name(defs[0])
+    if use_def_mirror:
+        emitter._emit_var_write_obj_keep(var)
+        def_idx = emitter._intern_local(defs[0])
+        emitter._emit_local_set(def_idx)
+    else:
+        emitter._emit_var_write_obj(var)
+    return True
+
+
 def _emit_incr(emitter, args: tuple[str, ...], defs: tuple[str, ...], context: EmitContext) -> bool:
-    """``incr varName ?increment?`` — unbox, i64 add, rebox."""
+    """``incr varName ?increment?`` — strict ``tcl_incr`` when available,
+    otherwise legacy inline unbox / i64 add / rebox."""
     if not (1 <= len(args) <= 2):
         return False
+    if _emit_incr_strict(emitter, args, defs, context):
+        return True
     var = args[0]
 
     if context is EmitContext.VALUE:

--- a/compiler/codegen/wasm/_scan.py
+++ b/compiler/codegen/wasm/_scan.py
@@ -144,6 +144,7 @@ def _scan_needed_imports_ir_only(ir_module: IRModule, needed: set[str]) -> None:
         IRFor,
         IRForeach,
         IRIf,
+        IRIncr,
         IRReturn,
         IRSwitch,
         IRTry,
@@ -225,6 +226,17 @@ def _scan_needed_imports_ir_only(ir_module: IRModule, needed: set[str]) -> None:
             case IRReturn(expr=expr):
                 if expr is not None:
                     _scan_expr_body_imports_from_node(expr, needed)
+            case IRIncr(amount=amount):
+                # ``incr`` in a brace-quoted body (e.g. the last statement of
+                # ``[catch {incr i} msg]``) lowers to IRIncr but is emitted via
+                # the strict ``tcl_incr`` path (issue #262 — a non-integer value
+                # must raise, not be silently truncated).  The full-module
+                # scanner adds these for top-level IRIncr; mirror it here so the
+                # import is present for body-scanned IRIncr too.
+                needed.add("tcl_incr")
+                needed.add("tcl_obj_new_int")
+                if isinstance(amount, str) and "[" in amount:
+                    _scan_text_for_cmd_subst(amount, needed)
             case _:
                 # Scan value strings in IRCall / IRAssignValue for cmd-substs.
                 args = getattr(stmt, "args", None)
@@ -536,6 +548,18 @@ def _scan_text_for_cmd_subst(text: str, needed: set[str]) -> None:
                     # this import the interpolation collapses to a literal
                     # in the lookup table and ``$x`` never substitutes.
                     needed.add("tcl_append")
+                elif cmd == "incr":
+                    # ``[incr i]`` in value position (and ``incr`` as the
+                    # last statement of a ``catch`` body) is emitted by the
+                    # inline ``_emit_incr`` hook, which routes through
+                    # ``tcl_incr`` for the strict-integer guard (issue #262 —
+                    # a non-integer value like ``"52.60"`` must raise rather
+                    # than be silently truncated).  ``runtime_import_for`` has
+                    # no entry for ``incr``, so request the helper here; the
+                    # IRIncr statement scanner does the same at the lowered
+                    # statement level.
+                    needed.add("tcl_incr")
+                    needed.add("tcl_obj_new_int")
                 elif cmd == "dict" and len(parts) > 1:
                     subcmd = parts[1]
                     sri = subcommand_runtime_import_for("dict", subcmd)

--- a/dialects/tcl/const_fold.py
+++ b/dialects/tcl/const_fold.py
@@ -628,7 +628,8 @@ def fold_scan(args: tuple[str, ...]) -> str | None:
     """``scan string format`` — the *inline* (no ``varName``) form only.
 
     Returns the list of converted values.  Deliberately conservative: only the
-    integer / string / char conversions (``%d %o %x %X %u %s %c``) are folded,
+    integer / string / char conversions (``%d %o %x %X %s %c``) are folded
+    (``%u`` is excluded — its unsigned-width semantics are version-specific),
     and only when **every** conversion succeeds (no whitespace-flag, width,
     ``*`` suppression, ``%[`` set, size modifier, or float conversion, and no
     partial / failed match — those have empty-element semantics we don't
@@ -691,20 +692,29 @@ def _tcl_scan(string: str, fmt: str) -> str | None:
             while si < n and string[si] not in _SCAN_WS:
                 si += 1
             results.append(string[start:si])
-        elif conv in "doxXu":
+        elif conv in "doxX":
+            # ``%u`` is deliberately excluded: scanning an unsigned word has
+            # version-specific width semantics (``scan -5 %u`` differs on
+            # Tcl 8 vs 9), so it is never folded.
             start = si
             if string[si] in "+-":
                 si += 1
-            digit_start = si
             if conv in "xX":
                 base = 16
                 allowed = "0123456789abcdefABCDEF"
+                # Tcl's ``%x`` accepts an optional ``0x``/``0X`` prefix before
+                # the hex digits (``scan 0xff %x`` -> 255).  Skip it so Python's
+                # ``int(..., 16)`` sees a valid literal; require a following hex
+                # digit so a bare ``0`` still scans as ``0``.
+                if string[si : si + 2] in ("0x", "0X") and si + 2 < n and string[si + 2] in allowed:
+                    si += 2
             elif conv == "o":
                 base = 8
                 allowed = "01234567"
-            else:  # d, u
+            else:  # d
                 base = 10
                 allowed = "0123456789"
+            digit_start = si
             while si < n and string[si] in allowed:
                 si += 1
             if si == digit_start:
@@ -901,9 +911,27 @@ def _tcl_format(fmt: str, vals: tuple[str, ...]) -> str | None:
         pyspec = "%" + flags + width + prec
         try:
             if conv in "diu":
-                out.append((pyspec + "d") % _format_int_arg(raw))
+                ival = _format_int_arg(raw)
+                # ``%u`` of a negative value renders as an unsigned word whose
+                # width is version-specific (32-bit on Tcl 9, 64-bit on 8.x),
+                # and Python's ``%d`` keeps the sign instead — never fold it.
+                if conv == "u" and ival < 0:
+                    return None
+                out.append((pyspec + "d") % ival)
             elif conv in "xXo":
-                out.append((pyspec + conv) % _format_int_arg(raw))
+                ival = _format_int_arg(raw)
+                # Negative hex/octal is two's-complement at a word width that
+                # differs across Tcl versions (``ffffffff`` on 9 vs the 64-bit
+                # form on 8.x); Python renders ``-N``.  Don't fold.
+                if ival < 0:
+                    return None
+                # The ``#`` alternate-form prefix also diverges by version:
+                # ``%#o`` is ``010`` on 8.x but ``0o10`` on 9, and ``%#X`` is
+                # ``0XFF`` on 8.x but ``0xFF`` on 9.  (``%#x`` is identical
+                # everywhere, so it stays foldable.)
+                if "#" in flags and conv in "Xo":
+                    return None
+                out.append((pyspec + conv) % ival)
             elif conv in "feEgG":
                 out.append((pyspec + conv) % float(raw))
             elif conv == "s":

--- a/tests/test_const_fold_format_scan_safety.py
+++ b/tests/test_const_fold_format_scan_safety.py
@@ -1,0 +1,100 @@
+"""Regression guards for ``format`` / ``scan`` constant folding.
+
+The optimiser surfaces ``const_fold`` results as O129 ("Fold constant command
+substitution") replacements that *rewrite user source*.  A wrong fold here
+silently corrupts code, so the folder must bail (return ``None``) whenever the
+true result is version-dependent (32-bit Tcl 9 vs 64-bit Tcl 8 word width) or
+otherwise not reproducible without running the interpreter.
+
+These were real bugs: ``[format %x -1]`` folded to ``-1`` (tclsh gives
+``ffffffff`` on 9 / ``ffffffffffffffff`` on 8), ``[scan 0xff %x]`` folded to
+``0``, ``[format %#o 8]`` folded to ``0o10`` (wrong on 8.x where it is ``010``).
+
+Unlike :mod:`tests.test_const_fold_vs_tcl`, this module has **no** ``tclsh``
+dependency — the expected values below were pinned against real ``tclsh8.6``
+and ``tclsh9.0`` and are asserted unconditionally so the guard survives in
+environments without a Tcl interpreter.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Importing ``compiler.core_analyses`` first fully initialises the command
+# registry, which otherwise races the ``dialects.tcl`` package import below and
+# raises a partially-initialised-module ImportError when this file is collected
+# in isolation.
+import compiler.core_analyses  # noqa: E402, F401
+from dialects.tcl.const_fold import fold_format, fold_scan  # noqa: E402
+
+
+class TestFormatNeverFoldsWrong:
+    """``format`` folds must be byte-identical across Tcl 8.4-9.0 or not fold."""
+
+    @pytest.mark.parametrize(
+        ("spec", "arg"),
+        [
+            # negative %x/%X/%o/%u render as two's-complement at a word width
+            # that differs by version; Python's % keeps the sign -> never fold.
+            ("%x", "-1"),
+            ("%X", "-1"),
+            ("%o", "-8"),
+            ("%u", "-1"),
+            ("%08x", "-1"),
+            # the ``#`` alternate-form prefix diverges by version:
+            # ``%#o`` 010 (8.x) vs 0o10 (9); ``%#X`` 0XFF (8.x) vs 0xFF (9).
+            ("%#o", "8"),
+            ("%#X", "255"),
+        ],
+    )
+    def test_version_dependent_specs_bail(self, spec: str, arg: str) -> None:
+        assert fold_format((spec, arg)) is None
+
+    @pytest.mark.parametrize(
+        ("spec", "arg", "expected"),
+        [
+            ("%d", "-5", "-5"),  # signed decimal is identical everywhere
+            ("%x", "255", "ff"),
+            ("%X", "255", "FF"),
+            ("%o", "8", "10"),
+            ("%u", "5", "5"),  # %u of a non-negative value == %d
+            ("%#x", "255", "0xff"),  # 0x prefix is identical across versions
+            ("%05d", "7", "00007"),
+            ("%+d", "42", "+42"),
+            ("%5.2f", "3.14159", " 3.14"),
+        ],
+    )
+    def test_safe_specs_still_fold(self, spec: str, arg: str, expected: str) -> None:
+        assert fold_format((spec, arg)) == expected
+
+
+class TestScanNeverFoldsWrong:
+    """``scan`` folds must match the interpreter or bail."""
+
+    def test_unsigned_conversion_bails(self) -> None:
+        # %u has version-specific unsigned-width semantics -> never fold.
+        assert fold_scan(("-5", "%u")) is None
+        assert fold_scan(("5", "%u")) is None
+
+    @pytest.mark.parametrize(
+        ("string", "spec", "expected"),
+        [
+            ("0xff", "%x", "255"),  # optional 0x prefix honoured
+            ("0X1f", "%x", "31"),  # uppercase 0X prefix too
+            ("0xff", "%X", "255"),
+            ("ff", "%x", "255"),  # bare hex still works
+            ("0", "%x", "0"),  # a lone 0 is not a truncated prefix
+            ("+ff", "%x", "255"),  # leading sign accepted
+            ("010", "%o", "8"),  # octal, leading 0 is a digit not a prefix
+            ("42", "%d", "42"),
+            ("-5", "%d", "-5"),
+            ("A", "%c", "65"),
+        ],
+    )
+    def test_integer_conversions(self, string: str, spec: str, expected: str) -> None:
+        assert fold_scan((string, spec)) == expected

--- a/tests/test_const_fold_vs_tcl.py
+++ b/tests/test_const_fold_vs_tcl.py
@@ -142,6 +142,13 @@ _FORMATS = [
     ("%X", "255"),
     ("%o", "8"),
     ("%08x", "255"),
+    # version/sign-dependent: must either match tclsh9 exactly or not fold
+    ("%x", "-1"),
+    ("%u", "-1"),
+    ("%o", "-8"),
+    ("%#o", "8"),
+    ("%#X", "255"),
+    ("%u", "5"),
     ("%s", "hi"),
     ("%10s", "hi"),
     ("%-10s", "hi"),
@@ -195,8 +202,18 @@ _E2E = [
     # scan of constant literals (no varName form)
     "puts [scan 42 %d]",
     "puts [scan ff %x]",
+    "puts [scan 0xff %x]",  # optional 0x prefix must be honoured (-> 255)
     "puts [scan {1 2 3} {%d %d %d}]",
     "set n [scan 99 %d]\nputs $n",
+    # Regression guards: format/scan whose value is version- or sign-dependent
+    # must stay unfolded.  Leaving them untouched keeps before==after on tclsh9;
+    # a reintroduced wrong fold (e.g. ``%x -1`` -> ``-1``) would diverge here.
+    "puts [format %x -1]",
+    "puts [format %u -1]",
+    "puts [format %o -8]",
+    "puts [format %#o 8]",
+    "puts [format %#X 255]",
+    "puts [scan -5 %u]",
     # nested builtin command subs fold inside-out (the inner sub becomes a
     # literal, then the outer folds on a later pass)
     "puts [llength [list a b c]]",

--- a/tests/test_diagnostic_manifest.py
+++ b/tests/test_diagnostic_manifest.py
@@ -288,6 +288,7 @@ _HAS_PROJECT_TSC = _TSC is not None
 @pytest.mark.skipif(not _HAS_PROJECT_TSC, reason="no tsc found (project npm install or global tsc)")
 def test_typescript_catalog_compiles():
     """Generated diagnosticCatalog.ts compiles with tsc (if available)."""
+    assert _TSC is not None  # guaranteed by the skipif above
     ts_path = ROOT / "editors" / "vscode" / "src" / "generated" / "diagnosticCatalog.ts"
     assert ts_path.exists(), f"Missing {ts_path}"
 
@@ -319,6 +320,7 @@ def test_typescript_catalog_compiles():
 )
 def test_typescript_catalog_importable_by_node():
     """Generated diagnosticCatalog.ts can be transpiled and loaded by Node."""
+    assert _TSC is not None  # guaranteed by the skipif above
     ts_path = ROOT / "editors" / "vscode" / "src" / "generated" / "diagnosticCatalog.ts"
     assert ts_path.exists(), f"Missing {ts_path}"
 

--- a/tests/test_diagnostic_manifest.py
+++ b/tests/test_diagnostic_manifest.py
@@ -264,10 +264,28 @@ def test_generator_is_idempotent():
 
 _EXT_DIR = ROOT / "editors" / "vscode"
 _PROJECT_TSC = _EXT_DIR / "node_modules" / ".bin" / "tsc"
-_HAS_PROJECT_TSC = _PROJECT_TSC.exists()
 
 
-@pytest.mark.skipif(not _HAS_PROJECT_TSC, reason="project tsc not found (run npm install)")
+def _resolve_tsc() -> str | None:
+    """Locate a usable ``tsc`` so these tests RUN whenever a TypeScript
+    toolchain is present, rather than only when the VS Code workspace has
+    been ``npm install``-ed.
+
+    Order: the project-local binary (``editors/vscode/node_modules/.bin/tsc``)
+    first — it pins the version the extension actually builds with — then any
+    ``tsc`` on ``PATH`` (a global install).  Returns ``None`` only when no
+    compiler can be found, which is the one case that legitimately skips.
+    """
+    if _PROJECT_TSC.exists():
+        return str(_PROJECT_TSC)
+    return shutil.which("tsc")
+
+
+_TSC = _resolve_tsc()
+_HAS_PROJECT_TSC = _TSC is not None
+
+
+@pytest.mark.skipif(not _HAS_PROJECT_TSC, reason="no tsc found (project npm install or global tsc)")
 def test_typescript_catalog_compiles():
     """Generated diagnosticCatalog.ts compiles with tsc (if available)."""
     ts_path = ROOT / "editors" / "vscode" / "src" / "generated" / "diagnosticCatalog.ts"
@@ -276,7 +294,7 @@ def test_typescript_catalog_compiles():
     with tempfile.TemporaryDirectory() as tmp:
         result = subprocess.run(
             [
-                str(_PROJECT_TSC),
+                _TSC,
                 "--noEmit",
                 "--strict",
                 "--target",
@@ -313,7 +331,7 @@ def test_typescript_catalog_importable_by_node():
         # (which is still supported, just not the default).
         result = subprocess.run(
             [
-                str(_PROJECT_TSC),
+                _TSC,
                 "--outDir",
                 tmp,
                 "--target",

--- a/tests/test_issue_133_format_on_save_default_regression.py
+++ b/tests/test_issue_133_format_on_save_default_regression.py
@@ -1,0 +1,93 @@
+"""Regression test for issue #133 — format-on-save must be off by default.
+
+Issue #133 ("Formatting VSCode settings are ignored when Formatting Feature
+is enabled") reported that the server reformatted whole files on save even
+when the user's editor had format-on-save disabled and a different formatter
+selected.  The fix is that the server's ``willSaveWaitUntil`` format-on-save
+fallback is **opt-in**: the ``will_save_wait_until_enabled`` toggle defaults
+to ``False`` and ``on_will_save_wait_until`` returns ``None`` (no edits) when
+it is off.  Editors with a native format-on-save mechanism (VS Code's
+``editor.formatOnSave``) route through ``textDocument/formatting`` instead.
+
+``tests/test_will_save.py`` covers the willSaveWaitUntil -> formatter
+delegation, but nothing there asserts the actual fix.  These tests pin the
+default-off behaviour so that re-enabling format-on-save by default would
+fail loudly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from lsprotocol import types
+
+import server.state as _lsp_state
+from server.feature_config import FeatureConfig
+from server.server import on_will_save_wait_until
+
+# A deliberately mis-formatted proc so a real format-on-save pass produces
+# edits (used by the positive control to keep the negative tests honest).
+_MESSY_SOURCE = "proc f {a  b} {return [expr {$a+$b}]}\n"
+_DOC_URI = "file:///tmp/issue_133_format_on_save.tcl"
+
+
+@pytest.fixture
+def reset_feature_config():
+    """Snapshot/restore the process-global feature config and document state."""
+    snap_feature = _lsp_state.feature_config
+    snap_per_folder = dict(_lsp_state._per_folder_feature_configs)
+    try:
+        _lsp_state.feature_config = FeatureConfig()
+        _lsp_state._per_folder_feature_configs.clear()
+        yield
+    finally:
+        _lsp_state.feature_config = snap_feature
+        _lsp_state._per_folder_feature_configs.clear()
+        _lsp_state._per_folder_feature_configs.update(snap_per_folder)
+        _lsp_state.workspace_state.close(_DOC_URI)
+
+
+def _will_save_params() -> types.WillSaveTextDocumentParams:
+    return types.WillSaveTextDocumentParams(
+        text_document=types.TextDocumentIdentifier(uri=_DOC_URI),
+        reason=types.TextDocumentSaveReason.Manual,
+    )
+
+
+class TestFormatOnSaveDefaultOff:
+    """Issue #133: format-on-save must never be the out-of-the-box default."""
+
+    def test_default_config_does_not_enable_will_save_formatting(self):
+        """A freshly constructed FeatureConfig has the toggle off."""
+        assert FeatureConfig().will_save_wait_until_enabled is False
+
+    def test_handler_returns_none_when_disabled(self, reset_feature_config):
+        """With the default config, the handler emits no edits on save."""
+        # Register a mis-formatted document; if the handler tried to format
+        # it would return edits.  It must not, because the toggle is off.
+        _lsp_state.workspace_state.open(_DOC_URI, _MESSY_SOURCE, analyse=False)
+        assert _lsp_state.feature_config.will_save_wait_until_enabled is False
+
+        result = on_will_save_wait_until(_will_save_params())
+
+        assert result is None
+
+    def test_handler_formats_when_explicitly_enabled(self, reset_feature_config):
+        """Positive control: when opted in, the handler DOES format on save.
+
+        Without this, the disabled-case assertions could pass vacuously (e.g.
+        if the handler always returned None or the document never formats).
+        """
+        _lsp_state.workspace_state.open(_DOC_URI, _MESSY_SOURCE, analyse=False)
+        _lsp_state.feature_config = FeatureConfig(will_save_wait_until_enabled=True)
+
+        result = on_will_save_wait_until(_will_save_params())
+
+        assert result is not None
+        assert len(result) >= 1
+        # The edit must actually change the mis-formatted source.
+        assert any(edit.new_text != _MESSY_SOURCE for edit in result)

--- a/tests/test_issue_22_o109_regression.py
+++ b/tests/test_issue_22_o109_regression.py
@@ -1,0 +1,105 @@
+"""Two-sided regression test for issue #22 ("Rule O109 Setting Ignored").
+
+Issue #22 reported a false positive from the O109 optimisation under the
+``synopsys-eda-tcl`` dialect.  The reporter's snippet builds an accumulator
+collection with ``append_to_collection`` inside a ``foreach_in_collection``
+loop and consumes it *after* the loop via ``remove_shapes $to_delete_shapes``::
+
+    set to_delete_shapes {}
+    foreach_in_collection shape $shapes {
+        ...
+        append_to_collection to_delete_shapes $shape
+        ...
+    }
+    remove_shapes $to_delete_shapes
+
+The optimiser wrongly flagged the post-loop read as an O109 redundant-copy /
+dead-store candidate and proposed rewriting ``remove_shapes $to_delete_shapes``
+to ``remove_shapes s`` -- a transform that silently breaks the program because
+``append_to_collection`` mutates ``to_delete_shapes`` in place across loop
+iterations (it is *not* a simple ``set``-then-read pair).
+
+This test pins **both** sides:
+
+* **fix holds** -- the accumulate-in-loop/consume-after-loop snippet produces
+  no O109 and no rewrite touches the post-loop read; and
+* **true positive still fires** -- a genuine dead-store/redundant-copy still
+  raises O109, so the test cannot pass vacuously.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from compiler.optimiser import find_optimisations
+from compiler.registry.runtime import configure_signatures
+
+
+def _setup_eda_dialect() -> None:
+    configure_signatures(dialect="synopsys-eda-tcl")
+
+
+# Exact pattern from issue #22: accumulate via append_to_collection inside the
+# loop, then consume the accumulator after the loop.
+ISSUE_22_SNIPPET = textwrap.dedent("""\
+    set to_delete_shapes {}
+    foreach_in_collection shape $shapes {
+        set layer [get_attr $shape layer_name]
+        if {[lsearch $except_list $layer] == -1} {
+            append_to_collection to_delete_shapes $shape
+        } else {
+            echo Keeping shape of layer $layer
+        }
+    }
+    remove_shapes $to_delete_shapes
+""")
+
+
+class TestIssue22O109FalsePositive:
+    """#22 -- O109 must not flag a collection accumulated in a loop."""
+
+    def test_fix_holds_no_o109_on_accumulator(self):
+        """The accumulate-then-consume snippet raises no O109."""
+        _setup_eda_dialect()
+        rewrites = find_optimisations(ISSUE_22_SNIPPET)
+        o109 = [r for r in rewrites if r.code == "O109"]
+        assert o109 == [], f"unexpected O109 rewrites: {[r.message for r in o109]}"
+
+    def test_fix_holds_no_rewrite_renames_the_read(self):
+        """No suggested edit may rename/remove the post-loop ``$to_delete_shapes`` read.
+
+        The original bug proposed ``remove_shapes s``; guard against *any*
+        rewrite whose replacement drops the accumulator name from the final
+        ``remove_shapes`` command.
+        """
+        _setup_eda_dialect()
+        rewrites = find_optimisations(ISSUE_22_SNIPPET)
+        # The accumulator name must survive untouched: no rewrite should
+        # propose a replacement that omits it while overlapping the read.
+        read_line = ISSUE_22_SNIPPET.count("\n") - 1  # 0-based line of remove_shapes
+        for r in rewrites:
+            touches_read = r.range.start.line <= read_line <= r.range.end.line
+            if touches_read:
+                assert "to_delete_shapes" in (r.replacement or ""), (
+                    f"rewrite {r.code} drops the accumulator name from the read: {r.replacement!r}"
+                )
+
+
+class TestIssue22O109TruePositiveStillFires:
+    """The O109 rule must still fire on a genuine dead store/redundant copy."""
+
+    def test_true_positive_redundant_copy_still_flagged(self):
+        """A plain ``set y $x`` copy that is the sole use of ``x`` is O109."""
+        _setup_eda_dialect()
+        # x is set once and only copied into y; the copy is redundant and the
+        # intermediate store is dead -- O109 should propose collapsing it.
+        source = "set x 5\nset y $x\nputs $y\n"
+        rewrites = find_optimisations(source)
+        assert any(r.code == "O109" for r in rewrites), (
+            "O109 no longer fires on a genuine redundant copy -- the "
+            "false-positive test above could now pass vacuously"
+        )

--- a/tests/test_issue_32_inlay_toggle_regression.py
+++ b/tests/test_issue_32_inlay_toggle_regression.py
@@ -1,0 +1,101 @@
+"""Regression test for GitHub issue #32 ("Superfluous type hints are inserted").
+
+The user reported confusing ``: int`` / ``: str`` type annotations being
+injected after ``set`` statements.  Inlay hints are an *opt-in* feature
+(``features.inlayHints`` → ``FeatureConfig.inlay_hints_enabled``, default
+``False``), so the fix is that the server must produce *no* inlay hints unless
+the user explicitly enables them.
+
+The existing coverage only asserts that the flag parses
+(``tests/test_user_config.py``) and that ``get_inlay_hints`` renders hints when
+called directly (``tests/test_inlay_hints.py``).  Neither exercises the actual
+gate.  The toggle is honoured at the *handler* level: ``on_inlay_hint`` in
+``server/server.py`` checks ``config_for_uri(uri).inlay_hints_enabled`` and
+short-circuits to ``[]`` before ever calling ``get_inlay_hints``.  This test
+drives that handler directly so a regression that stops honouring the toggle
+(e.g. dropping the guard, or defaulting the flag on) fails here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from lsprotocol import types
+
+import server.state as _state
+from server.server import on_inlay_hint
+
+# A snippet that mirrors the issue report: ``set`` statements whose RHS the
+# analyser can type-infer, so the ``: int`` / ``: str`` annotations the user
+# complained about are produced when the feature is enabled.
+SOURCE = "set keep [expr {1 ? 1 : 0}]\nset name [file rootname foo]\n"
+
+_URI = "file:///tmp/tcl-lsp-issue-32-inlay.tcl"
+
+_RANGE = types.Range(
+    start=types.Position(line=0, character=0),
+    end=types.Position(line=10, character=0),
+)
+
+
+def _params() -> types.InlayHintParams:
+    return types.InlayHintParams(
+        text_document=types.TextDocumentIdentifier(uri=_URI),
+        range=_RANGE,
+    )
+
+
+@pytest.fixture
+def opened_doc():
+    """Register the document with the workspace and restore global state after."""
+    _state.workspace_state.open(_URI, SOURCE)
+    original = _state.feature_config.inlay_hints_enabled
+    try:
+        yield
+    finally:
+        _state.feature_config.inlay_hints_enabled = original
+        _state.workspace_state.close(_URI)
+
+
+def test_inlay_hints_produced_when_enabled(opened_doc):
+    """Positive control: with the feature on, the type hints from #32 appear."""
+    _state.feature_config.inlay_hints_enabled = True
+    hints = on_inlay_hint(_params())
+    assert hints, "expected inlay hints when features.inlayHints is enabled"
+    # The specific ``: <type>`` annotations the issue complained about.
+    type_labels = [h.label for h in hints if h.kind == types.InlayHintKind.Type]
+    assert ": int" in type_labels
+    assert ": str" in type_labels
+
+
+def test_no_inlay_hints_when_disabled(opened_doc):
+    """Regression for #32: with the feature off, the handler returns zero hints.
+
+    This is the assertion the audit found missing.  Must fail if the toggle
+    stops being honoured at the handler gate.
+    """
+    _state.feature_config.inlay_hints_enabled = False
+    hints = on_inlay_hint(_params())
+    assert hints == [], (
+        "inlay hints must be suppressed when features.inlayHints is disabled; "
+        f"got {[h.label for h in hints]}"
+    )
+
+
+def test_disabled_is_the_default(opened_doc):
+    """The feature ships off by default, so an untouched config produces none.
+
+    Guards against a regression that flips the default flag on (which would
+    reintroduce the unwanted annotations for every user).
+    """
+    from server.feature_config import FeatureConfig
+
+    assert FeatureConfig().inlay_hints_enabled is False
+    # And the live process config the handler reads honours that default too,
+    # unless a test explicitly opted in.
+    _state.feature_config.inlay_hints_enabled = FeatureConfig().inlay_hints_enabled
+    assert on_inlay_hint(_params()) == []

--- a/tests/test_issue_526_after_regression.py
+++ b/tests/test_issue_526_after_regression.py
@@ -1,0 +1,77 @@
+"""Regression test for GitHub issue #526 -- ``after`` command argument (W105).
+
+Issue #526 (tcl-lsp v1.10.10, VSCode) reported a **false positive**: the
+recommended, safe list-built form ::
+
+    after 10 [list myCommand $arg1 $arg2]
+
+was flagged W105 ("Code block argument to 'after' is not braced and contains
+substitutions -- risk of double substitution. Use braces: { ... }").
+
+A command-substitution body (``[list ...]``) is produced dynamically and parsed
+exactly once by ``after`` -- there is no double-substitution risk and it cannot
+be braced (``after 10 {[list ...]}`` changes the meaning), so W105 must not
+fire.  The fix lives in :func:`analyser.checks._style.check_unbraced_body`.
+
+W105 reaches ``after`` because ``after``'s trailing script argument carries the
+``ArgRole.BODY`` role; the audit flagged that this BODY-role wiring is
+exercised only generically (``eval [list ...]``) and never through ``after``
+specifically.  This file asserts **both** sides so the wiring can't silently
+regress:
+
+* **fix holds** -- ``after 10 [list ...]`` (and the ``after idle`` variant)
+  raises no W105; and
+* **true positive still fires** -- a genuinely-unsafe string-concatenated
+  script (``after 10 "myCommand $arg"``) is still flagged W105 as an Error.
+
+The exact diagnostic code involved is **W105** (severity Error for the
+dangerous string-concatenated form).  Verified empirically with
+``get_diagnostics`` -- do not assume the code letter.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lsprotocol.types import DiagnosticSeverity
+
+from server.features.diagnostics import get_diagnostics
+
+
+def _w105(source: str):
+    """Return all W105 diagnostics for *source*."""
+    return [d for d in get_diagnostics(source) if d.code == "W105"]
+
+
+class TestIssue526AfterArgument:
+    """#526 -- ``after`` script argument and W105 double-substitution warning."""
+
+    def test_fix_holds_list_built_script_not_flagged(self):
+        # The exact snippet from issue #526.  Safe list-built command:
+        # parsed once by ``after``, no double substitution, cannot be braced.
+        assert _w105("after 10 [list myCommand $arg1 $arg2]") == []
+
+    def test_fix_holds_after_idle_list_built_script_not_flagged(self):
+        # Same safe form via the ``after idle`` subcommand -- also a BODY arg.
+        assert _w105("after idle [list myCommand $arg1 $arg2]") == []
+
+    def test_fix_holds_braced_script_not_flagged(self):
+        # An explicitly braced body is the canonical safe form.
+        assert _w105("after 10 {myCommand $arg1 $arg2}") == []
+
+    def test_true_positive_quoted_script_still_flagged(self):
+        # Genuinely unsafe: a double-quoted script undergoes substitution at
+        # call time and again when ``after`` evaluates it -- double
+        # substitution.  This must still be flagged W105 (Error).  If the
+        # BODY-role wiring for ``after`` regresses, this assertion fails.
+        diags = _w105('after 10 "myCommand $arg1 $arg2"')
+        assert len(diags) == 1
+        assert diags[0].severity is DiagnosticSeverity.Error
+
+    def test_true_positive_after_idle_quoted_script_still_flagged(self):
+        diags = _w105('after idle "myCommand $arg1 $arg2"')
+        assert len(diags) == 1
+        assert diags[0].severity is DiagnosticSeverity.Error

--- a/tests/test_wasm_strictness_regression.py
+++ b/tests/test_wasm_strictness_regression.py
@@ -1,0 +1,186 @@
+"""WASM-runtime strictness regression tests.
+
+End-to-end regressions for four strictness gaps the release audit found
+GAPPED or only partially covered against the differential fuzzer.  Each
+test compiles a tiny Tcl script, runs it under wasmtime, and asserts that
+the runtime ERRORS with the exact C-Tcl wording rather than silently
+computing a permissive result.
+
+The error wording is captured into stdout via ``catch {...} msg`` +
+``puts``, so we assert on the precise message the runtime produces
+(mirroring the ``catch``/``puts $msg`` idiom in ``test_wasm_mathop.py``).
+
+Issues covered:
+  * #259 — ``if {1} {a} else {b} elseif {1} {c}`` (elseif after else)
+    must raise ``wrong # args: extra words after "else" clause in "if"
+    command``.
+  * #261 — floating-point operand in a bitwise/shift op must raise
+    ``cannot use floating-point value "<v>" as [left|right] operand of
+    "<op>"``.
+  * #262 — ``incr i`` where ``i`` holds a float string (``"52.60"``)
+    must raise ``expected integer but got "52.60"``.  The AOT-compiled
+    ``incr`` codegen path is still permissive here (silently advances to
+    53), so the AOT case is an xfail tracking the live bug; the
+    interpreted path is asserted to error.
+  * #263 — reading an unset scalar inside ``expr`` (``expr {$count}``
+    with ``count`` unset) must raise ``can't read "count": no such
+    variable``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("wasmtime", reason="wasmtime not installed")
+
+from shared.runtime_wasm import runtime_wasm_path  # noqa: E402
+from tests.test_wasm_real_tcl import _compile_tcl, _run_wasm  # noqa: E402
+
+_ZIG_RUNTIME_PATH = runtime_wasm_path(build_if_missing=False)
+
+pytestmark = pytest.mark.skipif(
+    not _ZIG_RUNTIME_PATH.exists(),
+    reason=f"Zig WASM runtime not built: {_ZIG_RUNTIME_PATH}",
+)
+
+
+def _run(source: str) -> str:
+    """Compile + run ``source`` under wasmtime, returning stripped stdout."""
+    wasm = _compile_tcl(source)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.strip()
+
+
+def _catch_msg(body: str) -> str:
+    """Run ``body`` guarded by ``catch`` and return the captured ``[code msg]``.
+
+    A passing strictness test produces ``1 {<error message>}``; a
+    permissive (buggy) runtime produces ``0 {...}`` because the body ran
+    without error.
+    """
+    return _run(f"puts [list [catch {{{body}}} msg] $msg]")
+
+
+# ---------------------------------------------------------------------------
+# #259 — elseif after else clause must error.
+# ---------------------------------------------------------------------------
+
+
+def test_elseif_after_else_clause_errors() -> None:
+    """``if {1} {a} else {b} elseif {1} {c}`` must raise the extra-words
+    error rather than silently running the if/else and discarding the
+    trailing ``elseif`` clause.  Regression for issue #259."""
+    out = _catch_msg("if {1} {set x 1} else {set x 2} elseif {1} {set x 3}")
+    assert out == '1 {wrong # args: extra words after "else" clause in "if" command}'
+
+
+# ---------------------------------------------------------------------------
+# #261 — floating-point operand in bitwise / shift ops must error.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("expr {~ -38.6}", 'cannot use floating-point value "-38.6" as operand of "~"'),
+        (
+            "expr {5 & 70.34}",
+            'cannot use floating-point value "70.34" as right operand of "&"',
+        ),
+        (
+            "expr {-23.55 << 1}",
+            'cannot use floating-point value "-23.55" as left operand of "<<"',
+        ),
+    ],
+)
+def test_float_operand_in_bitwise_or_shift_errors(body: str, expected: str) -> None:
+    """A floating-point operand in a bitwise (``~`` ``&``) or shift
+    (``<<``) operator must error with the C-Tcl 9 wording rather than
+    truncating the float and computing a result.  Regression for #261."""
+    assert _catch_msg(body) == f"1 {{{expected}}}"
+
+
+# ---------------------------------------------------------------------------
+# #262 — float string where an integer is required (incr) must error.
+# ---------------------------------------------------------------------------
+
+
+def _run_interp(source: str) -> str:
+    """Run ``source`` through the runtime interpreter (eval-fallback path).
+
+    Mirrors the helper in ``test_wasm_incr_errorinfo.py`` — wrapping the
+    body in ``set s {...}; eval $s`` forces the runtime interpreter
+    (rather than the AOT-compiled statement codegen) to execute it.
+    """
+    wrapped = "set __s {" + source + "}\neval $__s\n"
+    wasm = _compile_tcl(wrapped)
+    _, stdout = _run_wasm(wasm, capture_stdout=True)
+    return stdout.strip()
+
+
+def test_incr_float_string_errors_interpreted() -> None:
+    """``incr i`` with ``i = "52.60"`` must raise ``expected integer but
+    got "52.60"`` — a float string is rejected by Tcl's strict-integer
+    parser.  Asserted on the runtime-interpreter path (the AOT path is
+    covered, as xfail, by :func:`test_incr_float_string_errors_aot`).
+    Regression for issue #262."""
+    out = _run_interp("set i 52.60\nputs [list [catch {incr i} msg] $msg]")
+    assert out == '1 {expected integer but got "52.60"}'
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Issue #262: the inline `_emit_incr` codegen fallback (used in "
+        "un-optimised positions such as a `catch {}` body) is permissive — "
+        '`catch {incr i}` with i="52.60" returns `0 53` (and i="abc" '
+        "returns `0 1`) instead of erroring. Root cause: the fallback reads "
+        "the operand via `_emit_unbox_int` -> the runtime `obj_get_int` "
+        "(runtime/zig/valtypes/tcl_obj.zig), which truncates a float/garbage "
+        "string rather than raising; the optimised top-level path routes "
+        "through the strict `tcl_incr` helper instead, which is why a bare "
+        "top-level `incr` traps correctly. Fix: make `_emit_incr` enforce the "
+        "strict-integer guard (call `tcl_incr` / a strict accessor) on the "
+        "inline path too, then remove this xfail. Needs WASM-baseline "
+        "re-validation, so it is tracked here rather than fixed inline."
+    ),
+)
+def test_incr_float_string_errors_aot() -> None:
+    """AOT-compiled counterpart of the interpreted #262 test.
+
+    Routes ``incr i`` through the inline statement/catch-body codegen
+    rather than the runtime interpreter or the optimised top-level path.
+    This is the live permissiveness bug: the float string ``"52.60"``
+    must error, but the inline path returns 53.  Marked
+    ``xfail(strict=True)`` so it flips to a hard failure (forcing the
+    marker's removal) the moment the codegen path is fixed.
+    """
+    out = _run("set i 52.60\nputs [list [catch {incr i} msg] $msg]")
+    assert out == '1 {expected integer but got "52.60"}'
+
+
+# ---------------------------------------------------------------------------
+# #263 — reading an unset scalar inside expr must error.
+# ---------------------------------------------------------------------------
+
+
+def test_unset_scalar_in_expr_errors() -> None:
+    """``expr {$count}`` with ``count`` never set must raise ``can't read
+    "count": no such variable`` rather than substituting 0/empty and
+    rolling forward.  Regression for issue #263 (the scalar-in-expr case
+    the audit found uncovered)."""
+    assert _catch_msg("expr {$count}") == '1 {can\'t read "count": no such variable}'
+
+
+def test_unset_scalar_in_expr_arithmetic_errors() -> None:
+    """The seed-shape repro: ``set y [expr {$count + 1}]`` must error on
+    the unset read before any arithmetic.  Regression for issue #263."""
+    out = _catch_msg("set y [expr {$count + 1}]")
+    assert out == '1 {can\'t read "count": no such variable}'
+
+
+def test_unset_scalar_in_expr_inside_proc_errors() -> None:
+    """The in-proc seed shape: an unset local read inside ``expr`` must
+    error rather than defaulting.  Regression for issue #263."""
+    out = _run("proc p {} { return [expr {$undefined * 2}] }\nputs [list [catch {p} msg] $msg]")
+    assert out == '1 {can\'t read "undefined": no such variable}'

--- a/tests/test_wasm_strictness_regression.py
+++ b/tests/test_wasm_strictness_regression.py
@@ -128,35 +128,50 @@ def test_incr_float_string_errors_interpreted() -> None:
     assert out == '1 {expected integer but got "52.60"}'
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Issue #262: the inline `_emit_incr` codegen fallback (used in "
-        "un-optimised positions such as a `catch {}` body) is permissive — "
-        '`catch {incr i}` with i="52.60" returns `0 53` (and i="abc" '
-        "returns `0 1`) instead of erroring. Root cause: the fallback reads "
-        "the operand via `_emit_unbox_int` -> the runtime `obj_get_int` "
-        "(runtime/zig/valtypes/tcl_obj.zig), which truncates a float/garbage "
-        "string rather than raising; the optimised top-level path routes "
-        "through the strict `tcl_incr` helper instead, which is why a bare "
-        "top-level `incr` traps correctly. Fix: make `_emit_incr` enforce the "
-        "strict-integer guard (call `tcl_incr` / a strict accessor) on the "
-        "inline path too, then remove this xfail. Needs WASM-baseline "
-        "re-validation, so it is tracked here rather than fixed inline."
-    ),
-)
 def test_incr_float_string_errors_aot() -> None:
     """AOT-compiled counterpart of the interpreted #262 test.
 
     Routes ``incr i`` through the inline statement/catch-body codegen
-    rather than the runtime interpreter or the optimised top-level path.
-    This is the live permissiveness bug: the float string ``"52.60"``
-    must error, but the inline path returns 53.  Marked
-    ``xfail(strict=True)`` so it flips to a hard failure (forcing the
-    marker's removal) the moment the codegen path is fixed.
+    (the last statement of a ``catch {}`` body) rather than the runtime
+    interpreter or the optimised top-level path.  This was the live
+    permissiveness bug: the inline ``_emit_incr`` fallback read the
+    operand via the permissive ``obj_get_int`` and silently returned 53.
+    It now routes through the strict ``tcl_incr`` helper (the scan layer
+    requests the import for inline/value/body ``incr`` too), so a
+    non-integer current value errors like every other path.
     """
     out = _run("set i 52.60\nputs [list [catch {incr i} msg] $msg]")
     assert out == '1 {expected integer but got "52.60"}'
+
+
+def test_incr_garbage_string_errors_aot() -> None:
+    """Companion to the float case: ``incr`` of a non-numeric string in a
+    ``catch`` body must error rather than treating the value as 0 and
+    returning 1.  Regression for issue #262."""
+    out = _run("set i abc\nputs [list [catch {incr i} msg] $msg]")
+    assert out == '1 {expected integer but got "abc"}'
+
+
+def test_incr_value_position_float_string_errors() -> None:
+    """``[incr i]`` in value position (command substitution) with a float
+    string must also enforce the strict-integer guard.  Regression for
+    issue #262 (the value-context inline path)."""
+    assert _catch_msg("set i 52.60; incr i") == '1 {expected integer but got "52.60"}'
+
+
+def test_incr_nonint_amount_errors() -> None:
+    """A non-integer *increment* (``incr i 2.5``) must error too — the
+    strict guard applies to both operands.  Regression for issue #262."""
+    assert _catch_msg("set i 5; incr i 2.5") == '1 {expected integer but got "2.5"}'
+
+
+def test_incr_normal_paths_still_work() -> None:
+    """Positive controls: integer ``incr`` in value/catch/statement
+    position still increments, and ``incr`` on an unset scalar still
+    initialises to 0 (Tcl 8.5+)."""
+    assert _run("set i 5\nputs [incr i]") == "6"
+    assert _catch_msg("set i 5; incr i") == "0 6"
+    assert _run("proc p {} {incr x}\nputs [p]") == "1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Release-hardening for the v1.11.0 candidate (`main` since `v1.10.10`), branched off `origin/main` (main is protected).

A deep review of `main` plus a coverage audit of **all** open + closed GitHub issues and the `FP.md` catalog. Fixes one release blocker and one live correctness bug found during the audit, backfills the genuine regression-test gaps, and makes the `tsc` toolchain tests autodetect instead of skip.

## Fixes

- **🔴 Blocker — optimiser folded `format`/`scan` to wrong literals.** The O129 const-folder rewrote correct code to incorrect literals: `[format %x -1]`→`-1` (tcl: `ffffffff`/`ffffffffffffffff`), `[format %u -1]`→`-1`, `[format %o -8]`→`-10`, `[format %#o 8]`→`0o10` (wrong on 8.x), `[scan 0xff %x]`→`0`, `[scan -5 %u]`→`-5`. The folder is version-blind, so two's-complement-width and alt-form-prefix cases can't be correct for 8.x and 9 at once. Now bails on those and honours scan's `0x` prefix. Verified against real `tclsh8.6` + `tclsh9.0`.

- **🟠 Live bug #262 — WASM `incr` permissive in catch/value position.** The inline `_emit_incr` hook read its operand via the permissive `obj_get_int`, so `catch {incr i}` with `i="52.60"` returned `0 53` (and `"abc"`→`0 1`) instead of erroring, while the optimised top-level path was already strict. Now routes through the strict `tcl_incr` helper, with the import wired up for value/body `incr` in the scanner. `[incr i]`, `catch {incr i}`, `incr i 2.5` all error correctly; integer incr and unset-init still work.

## Tests

- Always-run `format`/`scan` safety unit file + differential matrix entries pinned to real tclsh.
- Issue-audit gap backfill (two-sided, can't pass vacuously): **#22** O109 false positive, **#32** inlay-hints toggle, **#526** `after` W105 BODY role, **#133** format-on-save off by default, WASM strictness **#259/#261/#262/#263**.
- `tsc` toolchain tests now autodetect a project-local **or** PATH `tsc` instead of skipping when the VS Code workspace isn't `npm install`-ed.

## Audit results (no code needed)

- **All ~93 GitHub issues**: coverage is strong (`test_issue_regressions_two_sided.py` etc. pin most fixed issues two-sided). Only the gaps above were genuine.
- **FP.md**: all **102 entries** fully covered — 305 FP tests pass, zero xfail/xpass/fail.

## Verification

- Full Python suite (non-slow): **17480 passed, 0 skipped, 2 xfailed** (the 2 remaining xfails are the tcllib `auto_load`/`parray` WASM-runtime gap — internal, tracked, a separate effort).
- WASM suite (`test_wasm_real_tcl` + codegen + execution + runtime/): **1050 passed**.

## Notes for release

- Document the deliberate **folding-coverage reduction** (multi-line strings, `#region`, import groups — re #493/#182) in release notes.
- The tcllib `auto_load`/`parray` xfails want a dedicated WASM-runtime PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
