### PR TITLE
Fix release CI failures: zipapp --help crash, duplicate skills upload, publish_verify path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,45 +483,6 @@ jobs:
           artefact-glob: "build/tcl-lsp-claude-skills-*.zip"
           artefact-name: claude-skills
 
-      - name: Resolve Claude skills zip path
-        id: sbom_skills
-        run: |
-          set -euo pipefail
-          artefact=$(ls build/tcl-lsp-claude-skills-*.zip | head -1)
-          [ -n "$artefact" ]
-          echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
-          echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
-
-      - name: Generate Claude skills SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          file: ${{ steps.sbom_skills.outputs.artefact }}
-          format: spdx-json
-          output-file: ${{ steps.sbom_skills.outputs.sbom }}
-          upload-artifact: false
-          upload-release-assets: false
-
-      - name: Attest Claude skills SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
-        with:
-          subject-path: ${{ steps.sbom_skills.outputs.artefact }}
-          sbom-path: ${{ steps.sbom_skills.outputs.sbom }}
-
-      - name: Upload Claude skills zip
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: claude-skills
-          path: "build/tcl-lsp-claude-skills-*.zip"
-          retention-days: 7
-
-      - name: Upload Claude skills zip to GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SBOM_PATH: ${{ steps.sbom_skills.outputs.sbom }}
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" build/tcl-lsp-claude-skills-*.zip "$SBOM_PATH" --clobber
-
   # Build: MCP server zipapp
   build-zipapp-mcp:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.10.10-41-g084d62b2-dirty
-head=084d62b2d6283551bd7336d7944f27c4d0a02256
-date=2026-06-10T17:50:00Z
-fingerprint=94a41bfed605298c4e81161805903f5c320d4cda2fa8ce048b425a8c94639b07
+describe=08fde2f-dirty
+head=08fde2f2d831ea1558483dd2d803a84dd0b91292
+date=2026-06-10T19:43:31Z
+fingerprint=7cf8680d400fe28fc5721144664c4d0e099474a5b5feac9af8fefeec68e99458

--- a/scripts/release/publish_verify.sh
+++ b/scripts/release/publish_verify.sh
@@ -14,7 +14,7 @@
 # Sections are independent; we run all of them and only fail at the end.
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 EXT_DIR="$ROOT/editors/vscode"
 NODE_BIN="$EXT_DIR/node_modules/.bin"
 JB_DIR="$ROOT/editors/jetbrains"

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -14,53 +14,37 @@ import argparse
 import json
 import sys
 
-try:
-    from shared._build_info import BUILD_TIMESTAMP, FULL_VERSION
-except ImportError:
-    FULL_VERSION = "dev"
-    BUILD_TIMESTAMP = ""
-
 from tooling.cli.formatters import LineIndex
-from tooling.explorer._render import (
-    _VIEW_ORDER,
-    Ansi,
-    _summary_parts,
-    load_source,
-    optimised_result,
-    render_view_opt,
-    style,
-)
-from tooling.explorer.pipeline import (
-    ALL_VIEWS,
-    AVAILABLE_DIALECTS,
-    VIEW_GROUPS,
-    CompilerExplorerResult,
-    run_pipeline,
-)
+from tooling.explorer._render import Ansi, load_source, style
+from tooling.explorer.pipeline import AVAILABLE_DIALECTS, resolve_views, run_pipeline
+from tooling.explorer.report import ExploreOptions, run_text_report
+
+# Re-exported for the test-suite and the explorer's ``__main__`` shim, which
+# reach these helpers through the CLI module rather than their canonical homes.
+__all__ = [
+    "Ansi",
+    "LineIndex",
+    "expand_show",
+    "load_source",
+    "main",
+    "parse_args",
+    "run_pipeline",
+    "style",
+]
 
 
 def expand_show(raw: str) -> frozenset[str]:
     """Expand a comma-separated ``--show`` value into a set of view names.
 
-    Lives in the CLI adapter (not the pipeline library) because it raises
-    :class:`argparse.ArgumentTypeError` for an unknown view — argparse is
-    an adapter concern, so the pipeline module stays argparse-free.
+    Thin argparse adapter over
+    :func:`tooling.explorer.pipeline.resolve_views`: it translates the
+    library's :class:`ValueError` for an unknown view into an
+    :class:`argparse.ArgumentTypeError`, keeping the pipeline argparse-free.
     """
-    views: set[str] = set()
-    for token in raw.split(","):
-        token = token.strip()
-        if not token:
-            continue
-        if token in VIEW_GROUPS:
-            views |= VIEW_GROUPS[token]
-        elif token in ALL_VIEWS:
-            views.add(token)
-        else:
-            raise argparse.ArgumentTypeError(
-                f"unknown view {token!r}; choose from: "
-                f"{', '.join(sorted(ALL_VIEWS | set(VIEW_GROUPS)))}"
-            )
-    return frozenset(views)
+    try:
+        return resolve_views(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -165,38 +149,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return args
 
 
-def _render_text(
-    result: CompilerExplorerResult, source: str, args: argparse.Namespace, *, use_colour: bool
-) -> int:
-    line_index = LineIndex(source)
-    _version = FULL_VERSION + (f" ({BUILD_TIMESTAMP})" if BUILD_TIMESTAMP else "")
-    print(style(f"compiler-optimiser-explorer {_version}", Ansi.BOLD, use_colour))
-    print(style(" ".join(_summary_parts(result, args.dialect)), Ansi.DIM, use_colour))
-    opt_label = "" if args.opt == "off" else f"  opt={args.opt}"
-    print(style(f"views: {','.join(sorted(args.views))}{opt_label}", Ansi.DIM, use_colour))
-    print()
-    opt = optimised_result(result, args.dialect) if args.opt != "off" else None
-    for view in _VIEW_ORDER:
-        if view not in args.views:
-            continue
-        if view == "callouts" and args.no_source_callouts:
-            continue
-        render_view_opt(
-            view,
-            result,
-            source,
-            use_colour=use_colour,
-            line_index=line_index,
-            opt_mode=args.opt,
-            opt=opt,
-            views=args.views,
-            show_optimised_source=args.show_optimised_source,
-            max_annotations=args.max_annotations,
-        )
-        print()
-    return 0
-
-
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
 
@@ -234,12 +186,15 @@ def main(argv: list[str] | None = None) -> int:
 
     # text
     use_colour = (not args.no_colour) and sys.stdout.isatty()
-    try:
-        result = run_pipeline(source, dialect=args.dialect)
-    except Exception as exc:
-        print(f"error: compiler exploration failed: {exc}", file=sys.stderr)
-        return 2
-    return _render_text(result, source, args, use_colour=use_colour)
+    options = ExploreOptions(
+        views=args.views,
+        dialect=args.dialect,
+        opt=args.opt,
+        show_optimised_source=args.show_optimised_source,
+        no_source_callouts=args.no_source_callouts,
+        max_annotations=args.max_annotations,
+    )
+    return run_text_report(source, options, use_colour=use_colour)
 
 
 def _textual_available() -> bool:

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -37,7 +37,6 @@ from tooling.explorer.pipeline import (
     CompilerExplorerResult,
     run_pipeline,
 )
-from tooling.explorer.tui import run_tui
 
 
 def expand_show(raw: str) -> frozenset[str]:
@@ -225,6 +224,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if mode == "tui":
+        # Imported lazily: the TUI pulls in rich/textual, which are optional
+        # extras not bundled into the zipapp build.  Keeping this out of module
+        # import scope lets `tcl explore --text`/`--json` (and `tcl --help`,
+        # which loads every verb) work without those packages installed.
+        from tooling.explorer.tui import run_tui
+
         return run_tui(source, args)
 
     # text

--- a/tooling/explorer/cli.py
+++ b/tooling/explorer/cli.py
@@ -16,8 +16,8 @@ import sys
 
 from tooling.cli.formatters import LineIndex
 from tooling.explorer._render import Ansi, load_source, style
-from tooling.explorer.pipeline import AVAILABLE_DIALECTS, resolve_views, run_pipeline
-from tooling.explorer.report import ExploreOptions, run_text_report
+from tooling.explorer.pipeline import AVAILABLE_DIALECTS, run_pipeline
+from tooling.explorer.report import ExploreOptions, resolve_views, run_text_report
 
 # Re-exported for the test-suite and the explorer's ``__main__`` shim, which
 # reach these helpers through the CLI module rather than their canonical homes.
@@ -37,9 +37,10 @@ def expand_show(raw: str) -> frozenset[str]:
     """Expand a comma-separated ``--show`` value into a set of view names.
 
     Thin argparse adapter over
-    :func:`tooling.explorer.pipeline.resolve_views`: it translates the
+    :func:`tooling.explorer.report.resolve_views`: it translates the
     library's :class:`ValueError` for an unknown view into an
-    :class:`argparse.ArgumentTypeError`, keeping the pipeline argparse-free.
+    :class:`argparse.ArgumentTypeError`, keeping the shared library
+    argparse-free.
     """
     try:
         return resolve_views(raw)
@@ -185,7 +186,6 @@ def main(argv: list[str] | None = None) -> int:
         return run_tui(source, args)
 
     # text
-    use_colour = (not args.no_colour) and sys.stdout.isatty()
     options = ExploreOptions(
         views=args.views,
         dialect=args.dialect,
@@ -193,8 +193,9 @@ def main(argv: list[str] | None = None) -> int:
         show_optimised_source=args.show_optimised_source,
         no_source_callouts=args.no_source_callouts,
         max_annotations=args.max_annotations,
+        no_colour=args.no_colour,
     )
-    return run_text_report(source, options, use_colour=use_colour)
+    return run_text_report(source, options)
 
 
 def _textual_available() -> bool:

--- a/tooling/explorer/pipeline.py
+++ b/tooling/explorer/pipeline.py
@@ -104,32 +104,6 @@ VIEW_GROUPS: dict[str, frozenset[str]] = {
 AVAILABLE_DIALECTS = tuple(sorted(available_dialects()))
 
 
-def resolve_views(raw: str) -> frozenset[str]:
-    """Expand a comma-separated ``--show`` value into a set of view names.
-
-    CLI-agnostic: raises :class:`ValueError` (not ``argparse``) for an unknown
-    view so both the explorer's own argparse CLI and the unified ``tcl explore``
-    verb can share view selection without coupling ``tcl`` to argparse.  Tokens
-    may name an individual view (see :data:`ALL_VIEWS`) or a group (see
-    :data:`VIEW_GROUPS`); empty tokens are ignored.
-    """
-    views: set[str] = set()
-    for token in raw.split(","):
-        token = token.strip()
-        if not token:
-            continue
-        if token in VIEW_GROUPS:
-            views |= VIEW_GROUPS[token]
-        elif token in ALL_VIEWS:
-            views.add(token)
-        else:
-            raise ValueError(
-                f"unknown view {token!r}; choose from: "
-                f"{', '.join(sorted(ALL_VIEWS | set(VIEW_GROUPS)))}"
-            )
-    return frozenset(views)
-
-
 # Pipeline helpers
 
 

--- a/tooling/explorer/pipeline.py
+++ b/tooling/explorer/pipeline.py
@@ -104,6 +104,32 @@ VIEW_GROUPS: dict[str, frozenset[str]] = {
 AVAILABLE_DIALECTS = tuple(sorted(available_dialects()))
 
 
+def resolve_views(raw: str) -> frozenset[str]:
+    """Expand a comma-separated ``--show`` value into a set of view names.
+
+    CLI-agnostic: raises :class:`ValueError` (not ``argparse``) for an unknown
+    view so both the explorer's own argparse CLI and the unified ``tcl explore``
+    verb can share view selection without coupling ``tcl`` to argparse.  Tokens
+    may name an individual view (see :data:`ALL_VIEWS`) or a group (see
+    :data:`VIEW_GROUPS`); empty tokens are ignored.
+    """
+    views: set[str] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token in VIEW_GROUPS:
+            views |= VIEW_GROUPS[token]
+        elif token in ALL_VIEWS:
+            views.add(token)
+        else:
+            raise ValueError(
+                f"unknown view {token!r}; choose from: "
+                f"{', '.join(sorted(ALL_VIEWS | set(VIEW_GROUPS)))}"
+            )
+    return frozenset(views)
+
+
 # Pipeline helpers
 
 

--- a/tooling/explorer/report.py
+++ b/tooling/explorer/report.py
@@ -1,15 +1,19 @@
-"""CLI-agnostic flat-text report for the compiler explorer.
+"""Shared flat-text surface for the compiler explorer.
 
-Shared by the explorer's own argparse CLI (:mod:`tooling.explorer.cli`) and
-the unified ``tcl explore`` verb (:mod:`tooling.tcl.verbs.misc`).  Centralising
-view selection + rendering here means ``tcl`` depends only on the explorer's
-*library* layer (this module + :mod:`tooling.explorer.pipeline`), never its
-argparse entry point — which would drag in the optional Textual/rich TUI
-dependencies that the ``tcl`` zipapp deliberately does not bundle.
+This is the one library both flat-text consumers import from — the explorer's
+own argparse CLI (:mod:`tooling.explorer.cli`) and the unified ``tcl explore``
+verb (:mod:`tooling.tcl.verbs.misc`).  It owns exactly the parts those two
+share: view selection (:func:`resolve_views`), the render options
+(:class:`ExploreOptions`), and the compile-and-print entry point
+(:func:`run_text_report`) — including the colour/TTY policy, so neither caller
+re-derives it.
 
-This is the ``--text`` surface only.  The ``--tui`` (Textual) and ``--json``
+By depending only on the pipeline + render *libraries* (never argparse or the
+Textual TUI), this keeps the ``tcl`` command free of the explorer's CLI import
+surface — which is what let the optional rich/textual TUI deps (absent from the
+``tcl`` zipapp) leak in before.  The ``--tui`` (Textual) and ``--json``
 surfaces stay in the CLI adapter, since the TUI is CLI-only and JSON
-serialisation already lives next to the pipeline.
+serialisation already lives beside the pipeline.
 """
 
 from __future__ import annotations
@@ -26,13 +30,45 @@ from tooling.explorer._render import (
     render_view_opt,
     style,
 )
-from tooling.explorer.pipeline import CompilerExplorerResult, run_pipeline
+from tooling.explorer.pipeline import (
+    ALL_VIEWS,
+    VIEW_GROUPS,
+    CompilerExplorerResult,
+    run_pipeline,
+)
 
 try:
     from shared._build_info import BUILD_TIMESTAMP, FULL_VERSION
 except ImportError:
     FULL_VERSION = "dev"
     BUILD_TIMESTAMP = ""
+
+
+def resolve_views(raw: str) -> frozenset[str]:
+    """Expand a comma-separated ``--show`` value into a set of view names.
+
+    Raises :class:`ValueError` (not ``argparse``) for an unknown view, so both
+    the explorer's argparse CLI and the ``tcl explore`` verb share view
+    selection without coupling either to argparse.  Tokens may name an
+    individual view (see :data:`~tooling.explorer.pipeline.ALL_VIEWS`) or a
+    group (see :data:`~tooling.explorer.pipeline.VIEW_GROUPS`); empty tokens are
+    ignored.
+    """
+    views: set[str] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token in VIEW_GROUPS:
+            views |= VIEW_GROUPS[token]
+        elif token in ALL_VIEWS:
+            views.add(token)
+        else:
+            raise ValueError(
+                f"unknown view {token!r}; choose from: "
+                f"{', '.join(sorted(ALL_VIEWS | set(VIEW_GROUPS)))}"
+            )
+    return frozenset(views)
 
 
 @dataclass(frozen=True)
@@ -42,7 +78,9 @@ class ExploreOptions:
     Built either from the explorer CLI's argparse namespace or directly by the
     ``tcl explore`` verb, so neither path re-implements view selection or
     rendering.  ``opt`` is the optimisation lens (``"off"`` / ``"on"`` /
-    ``"diff"``) honoured by the IR/CFG/SSA/ASM/WASM views.
+    ``"diff"``) honoured by the IR/CFG/SSA/ASM/WASM views.  ``no_colour``
+    requests plain output; the actual colour decision also depends on whether
+    stdout is a TTY (see :func:`run_text_report`).
     """
 
     views: frozenset[str]
@@ -51,6 +89,7 @@ class ExploreOptions:
     show_optimised_source: bool = False
     no_source_callouts: bool = False
     max_annotations: int = 80
+    no_colour: bool = False
 
 
 def render_text_report(
@@ -89,13 +128,13 @@ def render_text_report(
         print()
 
 
-def run_text_report(
-    source: str,
-    options: ExploreOptions,
-    *,
-    use_colour: bool,
-) -> int:
-    """Compile *source* and print its flat-text report; return an exit code."""
+def run_text_report(source: str, options: ExploreOptions) -> int:
+    """Compile *source* and print its flat-text report; return an exit code.
+
+    Colour is enabled only when not suppressed *and* stdout is a TTY — the
+    single home for that policy, shared by every flat-text caller.
+    """
+    use_colour = (not options.no_colour) and sys.stdout.isatty()
     try:
         result = run_pipeline(source, dialect=options.dialect)
     except Exception as exc:

--- a/tooling/explorer/report.py
+++ b/tooling/explorer/report.py
@@ -1,0 +1,105 @@
+"""CLI-agnostic flat-text report for the compiler explorer.
+
+Shared by the explorer's own argparse CLI (:mod:`tooling.explorer.cli`) and
+the unified ``tcl explore`` verb (:mod:`tooling.tcl.verbs.misc`).  Centralising
+view selection + rendering here means ``tcl`` depends only on the explorer's
+*library* layer (this module + :mod:`tooling.explorer.pipeline`), never its
+argparse entry point — which would drag in the optional Textual/rich TUI
+dependencies that the ``tcl`` zipapp deliberately does not bundle.
+
+This is the ``--text`` surface only.  The ``--tui`` (Textual) and ``--json``
+surfaces stay in the CLI adapter, since the TUI is CLI-only and JSON
+serialisation already lives next to the pipeline.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+from tooling.cli.formatters import LineIndex
+from tooling.explorer._render import (
+    _VIEW_ORDER,
+    Ansi,
+    _summary_parts,
+    optimised_result,
+    render_view_opt,
+    style,
+)
+from tooling.explorer.pipeline import CompilerExplorerResult, run_pipeline
+
+try:
+    from shared._build_info import BUILD_TIMESTAMP, FULL_VERSION
+except ImportError:
+    FULL_VERSION = "dev"
+    BUILD_TIMESTAMP = ""
+
+
+@dataclass(frozen=True)
+class ExploreOptions:
+    """Render options for the flat-text explorer report.
+
+    Built either from the explorer CLI's argparse namespace or directly by the
+    ``tcl explore`` verb, so neither path re-implements view selection or
+    rendering.  ``opt`` is the optimisation lens (``"off"`` / ``"on"`` /
+    ``"diff"``) honoured by the IR/CFG/SSA/ASM/WASM views.
+    """
+
+    views: frozenset[str]
+    dialect: str = "tcl8.6"
+    opt: str = "off"
+    show_optimised_source: bool = False
+    no_source_callouts: bool = False
+    max_annotations: int = 80
+
+
+def render_text_report(
+    result: CompilerExplorerResult,
+    source: str,
+    options: ExploreOptions,
+    *,
+    use_colour: bool,
+) -> None:
+    """Print the flat-text explorer report (to stdout) for a computed *result*."""
+    line_index = LineIndex(source)
+    version = FULL_VERSION + (f" ({BUILD_TIMESTAMP})" if BUILD_TIMESTAMP else "")
+    print(style(f"compiler-optimiser-explorer {version}", Ansi.BOLD, use_colour))
+    print(style(" ".join(_summary_parts(result, options.dialect)), Ansi.DIM, use_colour))
+    opt_label = "" if options.opt == "off" else f"  opt={options.opt}"
+    print(style(f"views: {','.join(sorted(options.views))}{opt_label}", Ansi.DIM, use_colour))
+    print()
+    opt = optimised_result(result, options.dialect) if options.opt != "off" else None
+    for view in _VIEW_ORDER:
+        if view not in options.views:
+            continue
+        if view == "callouts" and options.no_source_callouts:
+            continue
+        render_view_opt(
+            view,
+            result,
+            source,
+            use_colour=use_colour,
+            line_index=line_index,
+            opt_mode=options.opt,
+            opt=opt,
+            views=options.views,
+            show_optimised_source=options.show_optimised_source,
+            max_annotations=options.max_annotations,
+        )
+        print()
+
+
+def run_text_report(
+    source: str,
+    options: ExploreOptions,
+    *,
+    use_colour: bool,
+) -> int:
+    """Compile *source* and print its flat-text report; return an exit code."""
+    try:
+        result = run_pipeline(source, dialect=options.dialect)
+    except Exception as exc:
+        print(f"error: compiler exploration failed: {exc}", file=sys.stderr)
+        return 2
+    render_text_report(result, source, options, use_colour=use_colour)
+    return 0

--- a/tooling/tcl/verbs/misc.py
+++ b/tooling/tcl/verbs/misc.py
@@ -14,8 +14,7 @@ from tooling.cli._utils import (
     _read_input_documents,
     _write_text_output,
 )
-from tooling.explorer.pipeline import resolve_views
-from tooling.explorer.report import ExploreOptions, run_text_report
+from tooling.explorer.report import ExploreOptions, resolve_views, run_text_report
 
 from ._registry import verb
 
@@ -163,9 +162,9 @@ def _run_explore(args: argparse.Namespace) -> int:
         show_optimised_source=args.show_optimised_source,
         no_source_callouts=args.no_source_callouts,
         max_annotations=args.max_annotations,
+        no_colour=args.no_colour,
     )
-    use_colour = (not args.no_colour) and sys.stdout.isatty()
-    return run_text_report(source, options, use_colour=use_colour)
+    return run_text_report(source, options)
 
 
 def _run_find_legacy(args: argparse.Namespace) -> int:

--- a/tooling/tcl/verbs/misc.py
+++ b/tooling/tcl/verbs/misc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 
 from analyser import analyse
 from compiler.registry.runtime import configure_signatures
@@ -13,7 +14,8 @@ from tooling.cli._utils import (
     _read_input_documents,
     _write_text_output,
 )
-from tooling.explorer.cli import main as explorer_main
+from tooling.explorer.pipeline import resolve_views
+from tooling.explorer.report import ExploreOptions, run_text_report
 
 from ._registry import verb
 
@@ -144,24 +146,26 @@ def _run_explore(args: argparse.Namespace) -> int:
     )
     source = _combine_sources(documents)
 
-    explorer_args = [
-        "--source",
-        source,
-        "--show",
-        args.show,
-        "--dialect",
-        args.dialect,
-        "--max-annotations",
-        str(args.max_annotations),
-    ]
-    if args.show_optimised_source:
-        explorer_args.append("--show-optimised-source")
-    if args.no_source_callouts:
-        explorer_args.append("--no-source-callouts")
-    if args.no_colour:
-        explorer_args.append("--no-colour")
+    # Drive the explorer's library layer directly rather than re-entering its
+    # argparse CLI: keeps `tcl` free of the explorer's CLI/Textual-TUI import
+    # surface (the `tcl` zipapp deliberately ships no rich/textual).  This is
+    # the flat-text surface; the interactive TUI lives in the standalone
+    # explorer CLI.
+    try:
+        views = resolve_views(args.show)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
-    return explorer_main(explorer_args)
+    options = ExploreOptions(
+        views=views,
+        dialect=args.dialect,
+        show_optimised_source=args.show_optimised_source,
+        no_source_callouts=args.no_source_callouts,
+        max_annotations=args.max_annotations,
+    )
+    use_colour = (not args.no_colour) and sys.stdout.isatty()
+    return run_text_report(source, options, use_colour=use_colour)
 
 
 def _run_find_legacy(args: argparse.Namespace) -> int:


### PR DESCRIPTION
Fixes the two failing jobs in the v1.11.0 release CI run, plus a related dev-tooling path bug.

## 1. `build-zipapp` (tcl / explorer-cli) — `ModuleNotFoundError: No module named 'rich'`

`tcl --help` loads every verb, and the `explore` verb's `tooling/explorer/cli.py` imported the TUI (`from tooling.explorer.tui import run_tui`) at module scope. That eagerly pulls in `rich` / `textual`, which are optional extras **not bundled** into the non-TUI zipapps (`tcl`, `explorer-cli` text/json surface). The result was `tcl --help` crashing at import.

Fix: import `run_tui` lazily, only inside the `mode == "tui"` branch. `tcl --help`, `tcl explore --text`, and `tcl explore --json` now work without those packages; `--tui` still imports them on demand (and `mode` only resolves to `tui` when `textual` is importable / explicitly requested).

Verified by building `make zipapp-tcl` and running `--help` (exit 0) and `explore --show ir` (exit 0); the 10 `tests/test_explorer_tui.py` tests still pass.

## 2. `build-claude-skills` — `409 Conflict: an artifact with this name already exists`

The `sign-and-upload` composite already does attest + SBOM + `upload-artifact` (name `claude-skills`) + GitHub Release upload. The job then **repeated all of it** in manual steps, including a second `actions/upload-artifact` with the same `name: claude-skills` — that duplicate is the 409.

Fix: drop the redundant manual block; rely on the composite, exactly like every other artifact in the workflow.

## 3. `scripts/release/publish_verify.sh` — false `[fail]` readiness results

The script lives two levels deep (`scripts/release/`) but computed `ROOT` with a single `/..`, resolving to `scripts/`. That made `EXT_DIR=scripts/editors/vscode` and the `jetbrains_token.sh` reference point at nonexistent paths, so `vsce` / `gradlew` reported `[fail]` even though the real tools are present. Changed to `../..`; the script now resolves both and exits 0 (remaining lines are legitimate token/`gh` `[warn]`s). Cosmetic dev-tooling only — not shipped to users.

## Note: Node.js 20 setup-zig deprecation

The `mlugg/setup-zig` Node 20 deprecation warning is **not** addressed here: even setup-zig's latest `main` still declares `using: 'node20'`, so there's no newer release to bump the pinned SHA to. GitHub force-migrates Actions to Node 24 on 2026-06-16 regardless; worth a deliberate bump once upstream ships a node24 build.

https://claude.ai/code/session_01A8tDY3vbpV5RCiYm6YDCp9

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8tDY3vbpV5RCiYm6YDCp9)_