### PR TITLE
Fix braced-literal highlighting (#579) and skip Emacs lock symlinks

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=08fde2f-dirty
-head=08fde2f2d831ea1558483dd2d803a84dd0b91292
-date=2026-06-10T19:43:31Z
-fingerprint=7cf8680d400fe28fc5721144664c4d0e099474a5b5feac9af8fefeec68e99458
+describe=d18bc6c-dirty
+head=d18bc6c5de61d9cac7288e9cbf08771dd4d2b6d2
+date=2026-06-10T20:03:01Z
+fingerprint=47e39bcf23fa1ddeece42fabec51e6e63d5b25dda72962bb8dbc9b035d35704d

--- a/server/features/_semantic_tokens/_collect.py
+++ b/server/features/_semantic_tokens/_collect.py
@@ -921,6 +921,29 @@ def _collect_tokens(
             ):
                 modifiers = 1 << _MOD_INDEX["defaultLibrary"]
 
+            # Braced literal classified as a string: colour only the inner
+            # content and leave the ``{`` / ``}`` delimiters as grouping
+            # syntax.  ``tok.text`` already holds just the inner content, but
+            # the token starts on the opening brace, so shift one character
+            # right (via ``token_content_base``) and emit from there; the
+            # closing brace is simply not covered.  Emitting ``tok.text`` from
+            # ``tok.start`` instead would start on the brace and fall one
+            # character short, dropping the last inner character (issue #579).
+            if tok.type is TokenType.STR and type_idx == _TYPE_INDEX["string"]:
+                content_offset, content_line, content_col = token_content_base(tok)
+                _append_text_token(
+                    tokens,
+                    start=SourcePosition(
+                        line=content_line,
+                        character=content_col,
+                        offset=content_offset,
+                    ),
+                    text=tok.text,
+                    type_idx=type_idx,
+                    modifiers=modifiers,
+                )
+                continue
+
             # Reconstruct the full source representation so
             # len(rendered) matches the source span.
             if tok.type is TokenType.VAR:
@@ -937,15 +960,6 @@ def _collect_tokens(
                     rendered = '"' + tok.text
                 else:
                     rendered = '"' + tok.text + '"'
-            elif tok.type is TokenType.STR:
-                # A braced word's text holds only the inner content; the
-                # ``{``/``}`` delimiters are stripped by the lexer but the
-                # token still starts on the opening brace.  Re-add both braces
-                # so the rendered span covers the whole ``{...}`` literal,
-                # matching the quoted-string convention above.  Without this
-                # the token is one character short and the closing brace plus
-                # the final inner character lose their colour (issue #579).
-                rendered = "{" + tok.text + "}"
             else:
                 rendered = tok.text
 

--- a/server/features/_semantic_tokens/_collect.py
+++ b/server/features/_semantic_tokens/_collect.py
@@ -937,6 +937,15 @@ def _collect_tokens(
                     rendered = '"' + tok.text
                 else:
                     rendered = '"' + tok.text + '"'
+            elif tok.type is TokenType.STR:
+                # A braced word's text holds only the inner content; the
+                # ``{``/``}`` delimiters are stripped by the lexer but the
+                # token still starts on the opening brace.  Re-add both braces
+                # so the rendered span covers the whole ``{...}`` literal,
+                # matching the quoted-string convention above.  Without this
+                # the token is one character short and the closing brace plus
+                # the final inner character lose their colour (issue #579).
+                rendered = "{" + tok.text + "}"
             else:
                 rendered = tok.text
 

--- a/server/workspace/scanner.py
+++ b/server/workspace/scanner.py
@@ -59,6 +59,24 @@ _BIGIP_CONF_NAMES = frozenset(
 )
 
 
+def is_editor_lock_symlink(file_path: str) -> bool:
+    """Return ``True`` for an Emacs lock file — a symlink named ``.#name``.
+
+    Emacs creates ``.#name.tcl`` next to the document being edited as a
+    **symlink** whose target (``user@host.pid:boot``) is not a real file, so
+    reading it raises ``FileNotFoundError``.  It shares the document's
+    extension, so the extension filter alone lets it through.  Detecting it
+    needs *both* the ``.#`` name and the symlink nature, so we never skip a
+    real source file that merely starts with ``.#``.  Skipping it keeps
+    ``didChangeWatchedFiles`` churn from spamming the log with read failures
+    (issue #579 log noise).
+    """
+    basename = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
+    if not basename.startswith(".#"):
+        return False
+    return os.path.islink(file_path)
+
+
 def is_bigip_conf_name(uri: str) -> bool:
     """Return ``True`` if *uri*'s basename is a canonical BIG-IP config name.
 
@@ -166,6 +184,10 @@ class BackgroundScanner:
                     fname_lower = fname.lower()
                     # Skip tclIndex itself — it is metadata, not Tcl code.
                     if fname_lower == "tclindex":
+                        continue
+                    # Skip Emacs lock files (``.#name.tcl`` dangling symlinks)
+                    # that share a real source extension.
+                    if fname.startswith(".#") and is_editor_lock_symlink(os.path.join(root, fname)):
                         continue
                     # BIG-IP config discovery — canonical basenames
                     # always; ``.scf`` always; ``.conf`` opportunistic
@@ -351,6 +373,8 @@ class BackgroundScanner:
 
     def rescan_file(self, file_path: str) -> ScanResult | None:
         """Re-scan a single file (e.g. after a filesystem change)."""
+        if is_editor_lock_symlink(file_path):
+            return None
         ext = os.path.splitext(file_path)[1].lower()
         return self._analyse_file(file_path, ext)
 
@@ -510,6 +534,12 @@ class BackgroundScanner:
                 bigip_configs[uri] = config
             log.debug("Scanner: parsed bigip config %s", full_path)
             return config
+        except OSError as exc:
+            # File vanished or is unreadable (e.g. a transient editor file
+            # deleted between the watch event and the read) — not worth a
+            # stack trace.
+            log.debug("Scanner: could not read bigip config %s: %s", full_path, exc)
+            return None
         except Exception:
             log.debug("Scanner: failed to parse bigip config %s", full_path, exc_info=True)
             return None
@@ -539,6 +569,12 @@ class BackgroundScanner:
                 dialect_hint=dialect,
                 rule_init_exports=rule_init_exports,
             )
+        except OSError as exc:
+            # File vanished or is unreadable (e.g. a transient editor file
+            # deleted between the watch event and the read) — not worth a
+            # stack trace.
+            log.debug("Scanner: could not read %s: %s", full_path, exc)
+            return None
         except Exception:
             log.debug("Scanner: failed to analyse %s", full_path, exc_info=True)
             return None

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from server.workspace.scanner import (
     BackgroundScanner,
     _dialect_from_ext,
+    is_editor_lock_symlink,
     path_to_uri,
     uri_to_path,
 )
@@ -196,3 +197,83 @@ class TestBackgroundScanner:
         scanner.configure(workspace_roots=["/nonexistent/path/xyz"])
         results = scanner.scan_all()
         assert results == {}
+
+    def test_scan_ignores_emacs_lock_symlink(self):
+        """A dangling Emacs lock symlink (``.#name.tcl``) is not analysed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(os.path.join(tmpdir, "lib.tcl")).write_text("proc foo {} {}")
+            # Emacs lock file: a symlink to a target that does not exist.
+            lock = os.path.join(tmpdir, ".#lib.tcl")
+            os.symlink("user@host.12345:1700000000", lock)
+
+            scanner = BackgroundScanner()
+            scanner.configure(workspace_roots=[tmpdir])
+            results = scanner.scan_all()
+
+            # Only the real file is indexed; the lock symlink is skipped
+            # without raising on the unreadable target.
+            assert len(results) == 1
+            assert path_to_uri(os.path.join(tmpdir, "lib.tcl")) in results
+            assert path_to_uri(lock) not in results
+
+    def test_rescan_skips_emacs_lock_symlink_without_reading(self, monkeypatch):
+        """``rescan_file`` short-circuits a lock symlink before any read.
+
+        The fix's value is avoiding the read entirely (and the log churn it
+        produced); the old code would attempt the read, raise
+        ``FileNotFoundError`` on the dangling target, and swallow it.  Guard
+        against regressing back to "read then swallow" by failing if the file
+        is read at all.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock = os.path.join(tmpdir, ".#rename-only.tcl")
+            os.symlink("user@host.12345:1700000000", lock)
+
+            def _no_read(self, *args, **kwargs):
+                raise AssertionError(f"lock symlink should not be read: {self}")
+
+            monkeypatch.setattr(Path, "read_text", _no_read)
+
+            scanner = BackgroundScanner()
+            scanner.configure(workspace_roots=[tmpdir])
+            assert scanner.rescan_file(lock) is None
+
+    def test_run_analysis_swallows_missing_file_quietly(self, caplog):
+        """A genuinely missing file logs at debug with no traceback."""
+        import logging
+
+        scanner = BackgroundScanner()
+        with caplog.at_level(logging.DEBUG, logger="server.workspace.scanner"):
+            assert scanner.rescan_file("/nonexistent/path/gone.tcl") is None
+        # No exception escaped, and nothing was logged with traceback info.
+        assert all(rec.exc_info is None for rec in caplog.records)
+
+
+class TestEditorLockSymlink:
+    def test_dangling_lock_symlink_detected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock = os.path.join(tmpdir, ".#doc.tcl")
+            os.symlink("user@host.999:1", lock)
+            assert is_editor_lock_symlink(lock) is True
+
+    def test_regular_file_starting_with_hash_not_skipped(self):
+        """A real (non-symlink) file named ``.#...`` is still analysed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real = os.path.join(tmpdir, ".#real.tcl")
+            Path(real).write_text("proc foo {} {}")
+            assert is_editor_lock_symlink(real) is False
+
+    def test_ordinary_source_not_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ordinary = os.path.join(tmpdir, "lib.tcl")
+            Path(ordinary).write_text("proc foo {} {}")
+            assert is_editor_lock_symlink(ordinary) is False
+
+    def test_symlink_without_lock_prefix_not_skipped(self):
+        """A symlink that is not a ``.#`` lock file is not treated as one."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "lib.tcl")
+            Path(target).write_text("proc foo {} {}")
+            link = os.path.join(tmpdir, "alias.tcl")
+            os.symlink(target, link)
+            assert is_editor_lock_symlink(link) is False

--- a/tests/test_semantic_tokens.py
+++ b/tests/test_semantic_tokens.py
@@ -122,35 +122,58 @@ class TestSemanticTokens:
         types = [t["type"] for t in tokens]
         assert "string" in types
 
-    def test_braced_string_spans_full_literal(self):
-        """A braced word's string token must cover the whole ``{...}`` literal.
+    def test_braced_string_covers_full_inner_content(self):
+        """A braced word's string token must cover the whole inner content.
 
         Regression for issue #579: the braced word's text holds only the inner
-        content, but the token starts on the opening brace.  Emitting it without
-        re-adding the braces left the token one character short, so the closing
-        brace and the final inner character lost their colour (the reported
-        "last digit a different colour" symptom).
+        content, but the token started on the opening brace.  Emitting the inner
+        text from the brace position left the token one character short, so the
+        final inner character lost its colour (the reported "last digit a
+        different colour" symptom).  The braces themselves are grouping syntax
+        and are left uncoloured.
         """
         source = "puts {12345}"
         tokens = _decode_tokens(semantic_tokens_full(source))
         string_tokens = [t for t in tokens if t["type"] == "string"]
         assert len(string_tokens) == 1
         tok = string_tokens[0]
-        # ``{12345}`` starts at column 5 and is 7 characters wide.
-        assert tok["char"] == source.index("{")
-        assert tok["length"] == len("{12345}")
+        # The token covers ``12345`` only — one column past the ``{``, no braces.
+        assert tok["char"] == source.index("{") + 1
+        assert tok["length"] == len("12345")
 
-    def test_braced_number_single_string_token(self):
-        """Braced numbers should produce exactly one full-width string token."""
+    def test_braced_literal_includes_last_character(self):
+        """The final inner character of a braced literal must be coloured.
+
+        Covers the user-reported cases where a trailing letter (``a``, ``g``)
+        or digit was dropped from the highlight.
+        """
+        for source, inner in (
+            ("set v {10 20 30 40 50a}", "10 20 30 40 50a"),
+            ("set v {ab cd efg}", "ab cd efg"),
+        ):
+            tokens = _decode_tokens(semantic_tokens_full(source))
+            string_tokens = [t for t in tokens if t["type"] == "string"]
+            assert len(string_tokens) == 1, source
+            tok = string_tokens[0]
+            assert tok["char"] == source.index("{") + 1, source
+            assert tok["length"] == len(inner), source
+
+    def test_braced_number_single_inner_token(self):
+        """Braced numbers produce one string token over the inner content."""
         source = "{42}"
         tokens = _decode_tokens(semantic_tokens_full(source))
         assert len(tokens) == 1
         assert tokens[0]["type"] == "string"
-        assert tokens[0]["char"] == 0
-        assert tokens[0]["length"] == len("{42}")
+        assert tokens[0]["char"] == 1  # past the opening brace
+        assert tokens[0]["length"] == len("42")
 
-    def test_braced_string_multiline_covers_both_delimiters(self):
-        """A multi-line braced literal keeps the opening and closing braces."""
+    def test_empty_braces_emit_no_string_token(self):
+        """An empty ``{}`` braced word has no inner content to colour."""
+        tokens = _decode_tokens(semantic_tokens_full("set v {}"))
+        assert not [t for t in tokens if t["type"] == "string"]
+
+    def test_braced_string_multiline_excludes_delimiters(self):
+        """A multi-line braced literal colours inner content, not the braces."""
         source = "puts {line1\nline2}"
         tokens = _decode_tokens(semantic_tokens_full(source))
         string_tokens = sorted(
@@ -158,16 +181,16 @@ class TestSemanticTokens:
             key=lambda t: (t["line"], t["char"]),
         )
         assert len(string_tokens) == 2
-        # First line: ``{line1`` (brace + content, no trailing brace yet).
+        # First line: ``line1`` (one column past the ``{``, no brace).
         first = string_tokens[0]
         assert first["line"] == 0
-        assert first["char"] == source.index("{")
-        assert first["length"] == len("{line1")
-        # Second line: ``line2}`` (content + closing brace).
+        assert first["char"] == source.index("{") + 1
+        assert first["length"] == len("line1")
+        # Second line: ``line2`` only — the closing brace is excluded.
         second = string_tokens[1]
         assert second["line"] == 1
         assert second["char"] == 0
-        assert second["length"] == len("line2}")
+        assert second["length"] == len("line2")
 
     def test_quoted_string_still_spans_full_literal(self):
         """Quoted strings keep covering both quote delimiters (guards the fix)."""

--- a/tests/test_semantic_tokens.py
+++ b/tests/test_semantic_tokens.py
@@ -122,6 +122,62 @@ class TestSemanticTokens:
         types = [t["type"] for t in tokens]
         assert "string" in types
 
+    def test_braced_string_spans_full_literal(self):
+        """A braced word's string token must cover the whole ``{...}`` literal.
+
+        Regression for issue #579: the braced word's text holds only the inner
+        content, but the token starts on the opening brace.  Emitting it without
+        re-adding the braces left the token one character short, so the closing
+        brace and the final inner character lost their colour (the reported
+        "last digit a different colour" symptom).
+        """
+        source = "puts {12345}"
+        tokens = _decode_tokens(semantic_tokens_full(source))
+        string_tokens = [t for t in tokens if t["type"] == "string"]
+        assert len(string_tokens) == 1
+        tok = string_tokens[0]
+        # ``{12345}`` starts at column 5 and is 7 characters wide.
+        assert tok["char"] == source.index("{")
+        assert tok["length"] == len("{12345}")
+
+    def test_braced_number_single_string_token(self):
+        """Braced numbers should produce exactly one full-width string token."""
+        source = "{42}"
+        tokens = _decode_tokens(semantic_tokens_full(source))
+        assert len(tokens) == 1
+        assert tokens[0]["type"] == "string"
+        assert tokens[0]["char"] == 0
+        assert tokens[0]["length"] == len("{42}")
+
+    def test_braced_string_multiline_covers_both_delimiters(self):
+        """A multi-line braced literal keeps the opening and closing braces."""
+        source = "puts {line1\nline2}"
+        tokens = _decode_tokens(semantic_tokens_full(source))
+        string_tokens = sorted(
+            (t for t in tokens if t["type"] == "string"),
+            key=lambda t: (t["line"], t["char"]),
+        )
+        assert len(string_tokens) == 2
+        # First line: ``{line1`` (brace + content, no trailing brace yet).
+        first = string_tokens[0]
+        assert first["line"] == 0
+        assert first["char"] == source.index("{")
+        assert first["length"] == len("{line1")
+        # Second line: ``line2}`` (content + closing brace).
+        second = string_tokens[1]
+        assert second["line"] == 1
+        assert second["char"] == 0
+        assert second["length"] == len("line2}")
+
+    def test_quoted_string_still_spans_full_literal(self):
+        """Quoted strings keep covering both quote delimiters (guards the fix)."""
+        source = 'puts "hello"'
+        tokens = _decode_tokens(semantic_tokens_full(source))
+        string_tokens = [t for t in tokens if t["type"] == "string"]
+        assert len(string_tokens) == 1
+        assert string_tokens[0]["char"] == source.index('"')
+        assert string_tokens[0]["length"] == len('"hello"')
+
     def test_if_elseif_else_body_recursion(self):
         source = "if {$x} { set a 1 } elseif {$y} { set b 2 } else { set c 3 }"
         tokens = _decode_tokens(semantic_tokens_full(source))


### PR DESCRIPTION
## Summary

- **Fix issue #579**: a braced literal such as `{12345}` was highlighted with its last character a different colour. The semantic-token `string` started on the opening `{` but used only the inner-content length, so it fell one character short and dropped the final inner character (and the closing brace). It now emits the `string` token over the inner content shifted one column past the `{`, leaving the `{ }` **uncoloured as grouping syntax** — matching this project's own TextMate grammar (`{ }` → `punctuation.section.braces`, content highlighted by context). Quoted `"..."` strings keep their delimiters, as is the universal convention.
- Add `is_editor_lock_symlink()` to detect and skip Emacs lock files (`.#name.tcl` **dangling symlinks**) during scanning and rescanning. The check requires *both* the `.#` name **and** the path actually being a symlink, so a real source file that merely starts with `.#` is never skipped. These shared the `.tcl` extension and raised `FileNotFoundError` on every `didChangeWatchedFiles` event, spamming the log with stack traces.
- Handle `OSError` gracefully in `_run_analysis()` and `_parse_bigip_file()` when a file vanishes or is unreadable between the watch event and the read — a quiet debug log instead of a traceback.

## Validation

- Semantic-token tests: inner-content span, last-character-included for trailing letters/digits (`{...50a}`, `{ab cd efg}`), empty `{}`, multi-line braces, and a quoted-string guard.
- Scanner tests: lock symlinks skipped in `scan_all` and short-circuited in `rescan_file` *before any read* (monkeypatched `read_text` asserts it is never called), quiet handling of a missing file, and `is_editor_lock_symlink` true/false cases (dangling lock, real `.#` file, ordinary source, non-lock symlink).
- `make test-slow` passed all phases against the rebased tree.

https://claude.ai/code/session_01JHPtDhwXyLDxhtWEkR61L8