### PR TITLE
Rust runtime: proc calls, TclOO, interp hierarchy, and binary format

### DIFF
--- a/docs/design/runtime/proc-call-and-stack-traces.md
+++ b/docs/design/runtime/proc-call-and-stack-traces.md
@@ -380,11 +380,22 @@ above); speed is recovered only afterwards.**
      `while executing` where tclsh's TEBC seeds the inner context to show
      `invoked from within`; var-not-found / domain errors / propagated
      `[cmd]`-substitution traces all match.
-5. **PC-5 — `info frame`/`info errorstack` + `source` frames. ⏳ next.** Needs
-   the **persistent `CmdFrame` stack** (`Eval`/`Source`/`Proc` kinds) pushed/
-   popped per command so `info frame ?N?` can read it at runtime, the `Source`
-   frame kind for `source file`, and the TIP-348 `errorStack` (`UP`/`CALL`
-   list). `info level` already landed (PC-2/PC-3).
+5. **PC-5 — `info frame` + `source` frames. ✅ landed** (`info errorstack`
+   remaining). A persistent `CmdFrame` stack (`{file, proc(FQN), level, cmd,
+   line}`) is pushed per script-eval level Tcl tracks — the root script, a proc
+   call, an `eval`/`uplevel` body, and a `source`d file — but **not** a `[cmd]`
+   substitution or an inline `if`/`while`/`for`/`foreach` body (verified vs
+   tclsh). The eval loop unifies on `eval_script(src, owned)`; each command
+   updates the current frame's `cmd`/`line` (a substitution reports the
+   substituted command at the enclosing line). `ProcDef` records its FQN +
+   defining-source so a proc frame is `type proc` (eval-defined) or `type
+   source`+`file` (source-defined). `info frame` (depth) and `info frame N`
+   (N>0 absolute, N≤0 relative) return the `type line [file] cmd [proc] level`
+   dict, byte-verified vs tclsh 9.0. `info level` landed earlier (PC-2/PC-3).
+   - **Remaining / approximations:** proc-body lines are body-relative where
+     tclsh reports file-absolute for source-defined procs (a literal line-base);
+     `uplevel` inherits the current proc context rather than the target frame's;
+     `info errorstack` (TIP 348 — the `UP`/`CALL` list) is the next sub-item.
 6. **PC-6 — AOT emit path** carries the same bookkeeping (conservative), and the
    AOT compiler keeps a **real frame + interpreter fallback** wherever any
    PC-3 dynamic construct is reachable; the AOT↔interp interop gate (a compiled

--- a/docs/design/runtime/proc-call-and-stack-traces.md
+++ b/docs/design/runtime/proc-call-and-stack-traces.md
@@ -380,22 +380,37 @@ above); speed is recovered only afterwards.**
      `while executing` where tclsh's TEBC seeds the inner context to show
      `invoked from within`; var-not-found / domain errors / propagated
      `[cmd]`-substitution traces all match.
-5. **PC-5 — `info frame` + `source` frames. ✅ landed** (`info errorstack`
-   remaining). A persistent `CmdFrame` stack (`{file, proc(FQN), level, cmd,
+5. **PC-5 — `info frame` + `source` frames. ✅ landed, byte-exact.** A
+   persistent `CmdFrame` stack (`{kind, file, proc(FQN), level, line_base, cmd,
    line}`) is pushed per script-eval level Tcl tracks — the root script, a proc
    call, an `eval`/`uplevel` body, and a `source`d file — but **not** a `[cmd]`
    substitution or an inline `if`/`while`/`for`/`foreach` body (verified vs
    tclsh). The eval loop unifies on `eval_script(src, owned)`; each command
    updates the current frame's `cmd`/`line` (a substitution reports the
-   substituted command at the enclosing line). `ProcDef` records its FQN +
-   defining-source so a proc frame is `type proc` (eval-defined) or `type
-   source`+`file` (source-defined). `info frame` (depth) and `info frame N`
-   (N>0 absolute, N≤0 relative) return the `type line [file] cmd [proc] level`
-   dict, byte-verified vs tclsh 9.0. `info level` landed earlier (PC-2/PC-3).
-   - **Remaining / approximations:** proc-body lines are body-relative where
-     tclsh reports file-absolute for source-defined procs (a literal line-base);
-     `uplevel` inherits the current proc context rather than the target frame's;
-     `info errorstack` (TIP 348 — the `UP`/`CALL` list) is the next sub-item.
+   substituted command at the enclosing line). `ProcDef` records its FQN,
+   defining-source, and body line-base, so a proc frame is `type proc`
+   (eval-defined, body-relative lines) or `type source`+`file` (source-defined,
+   **file-absolute** lines via the line-base — C's literal line table). An
+   `eval` body inherits the enclosing kind/file with a file-absolute base; an
+   `uplevel` body is `type eval`, no file, body-relative, names the invoking
+   proc, and omits the `level` key (its scope is redirected — C's
+   var-chain-reachability rule). `info frame` (depth) and `info frame N` (N>0
+   absolute, N≤0 relative) return the `type line [file] cmd [proc] [level]`
+   dict. **Byte-verified vs tclsh 9.0** across root / proc / nested-proc /
+   eval-body / uplevel / sourced-file / source-defined-proc frames (the dev
+   `run_script` example now `source`s a file argument, like `tclsh`, so the
+   differential is exact). `info level` landed earlier (PC-2/PC-3).
+   - **Approximation:** an `eval`-body's `type` can differ from tclsh when its
+     bytecode compiler inlines the literal body (sometimes `proc` vs `eval`) —
+     the inherit rule matches the sourced-file suite but not every inlined
+     `eval {literal}`. This is the same bytecode-boundary class as the
+     `foreach`/`expr` errorInfo notes.
+   - **`info errorstack` (TIP 348) — out of scope.** Its `INNER {…}` element is
+     the **bytecode** execution context (tclvm opcodes — `returnImm`, `loadStk`,
+     …), present even at top level since modern Tcl compiles everything. A
+     runtime that emits WASM, not tclvm bytecode, cannot reproduce it — the same
+     class as the suite's bytecode/disassembly exclusions. It degrades to a
+     clean `unknown subcommand` error.
 6. **PC-6 — AOT emit path** carries the same bookkeeping (conservative), and the
    AOT compiler keeps a **real frame + interpreter fallback** wherever any
    PC-3 dynamic construct is reachable; the AOT↔interp interop gate (a compiled

--- a/docs/design/runtime/proc-call-and-stack-traces.md
+++ b/docs/design/runtime/proc-call-and-stack-traces.md
@@ -346,22 +346,45 @@ the Tcl 9 suite's exact-`errorInfo` tests so nothing regresses.
 **Correctness of the dynamic cross-scope core comes first (the hard core
 above); speed is recovered only afterwards.**
 
-1. **PC-1 — frame model:** extend `CallFrame` (argv, two-chain caller, level,
-   proc) + add the `CmdFrame` source stack + line computation from T1.2 offsets.
-2. **PC-2 — `proc` + call:** the `Proc` `Command` variant, `call_proc` (bind,
-   eval body, `return`→Ok), `wrong # args`. Gate: leak-checked proc round-trips.
-3. **PC-3 — the dynamic cross-scope core (the foundation):** `uplevel` (run a
-   script in another frame's var scope), `upvar` to any level (T1.3 has
-   global/caller; generalise), `namespace eval`/`variable`, and `eval`/dynamic
-   command+var names through the interpreter. **Get every cross-frame /
-   cross-namespace / dynamic case correct here** — this is the base everything
-   else optimises over. Gate: the cross-scope cases match C Tcl exactly.
-4. **PC-4 — exceptions:** `ExceptionState`, `error`, `catch`, `return -code
-   -level -options`; the incremental `errorInfo` unwinder
-   (`Tcl_LogCommandInfo` + `MakeProcError` analogues). Gate: stack-trace tests
-   vs C Tcl's exact `errorInfo` output.
-5. **PC-5 — `info level`/`info frame`/`info errorstack`** over the two stacks;
-   `source` (the `Source` frame kind) + `package` over `source`.
+1. **PC-1 — frame model. ✅ landed (source/line half).** `parse::Command` now
+   carries `start` (C's `commandStart`) + `end` (terminator-excluded command
+   end); the logged command slice keeps trailing whitespace but drops the
+   `\n`/`;` terminator and the 1-based line is `1 + count('\n' in src[0..start])`
+   — both byte-verified against tclsh 9.0. The `CallFrame` two-chain (argv +
+   caller/caller_var) already landed with PC-3. The **persistent `CmdFrame`
+   source stack** (needed for `info frame`) is **deferred to PC-5**: PC-4 logs at
+   the unwinding site (where `src` + the command range are in scope), so the
+   success path pays no per-command push/pop — matching C, which calls
+   `TclLogCommandInfo` as the error returns through each level.
+2. **PC-2 — `proc` + call. ✅ landed** (`cmd_proc.rs`, `Interp::run_proc`):
+   defaults, `args` catch-all, `wrong # args`, recursion bound, `apply`.
+3. **PC-3 — the dynamic cross-scope core. ✅ landed:** `uplevel`/`upvar`/
+   `global`/`variable`/`namespace eval`, `eval`, dynamic command+var names
+   through the interpreter (T1.5 + the proc chunk).
+4. **PC-4 — exceptions. ✅ landed** (the headline). `ExceptionState`
+   (`info`/`code`/`line`/`already_logged`, the `iPtr` errorInfo/errorCode/
+   errorLine/`ERR_ALREADY_LOGGED` analogue) + the incremental `errorInfo`
+   unwinder: `Interp::log_command_info` (`while executing` / `invoked from
+   within`, 150-byte truncation) at each `eval_command`, `make_proc_error`
+   (`(procedure "x" line N)` / `(lambda term "..." line N)`, 60-byte truncation)
+   in `run_proc`, and `("eval"/"uplevel"/"foreach" body line N)` body-frames.
+   `error`/`throw`/`catch`/`try` rewired onto it; the trace is published to the
+   `::errorInfo`/`::errorCode` globals at the catch / outermost-eval boundary.
+   `return -code -level -options` errorinfo restore is the remaining sub-item.
+   Gate: byte-exact `errorInfo` unit tests + a tclsh 9.0 differential sweep.
+   - **Tree-walker approximations of the bytecode boundary** (message always
+     correct; only the trace framing differs): `foreach` adds its body-frame
+     only at top level (`!in_proc()`) — C inlines `foreach` when it compiles the
+     enclosing proc body, so no frame there; `if`/`while`/`for`/`switch` are
+     always inlined (never a frame). `expr {1/0}` and expr *parse* errors show
+     `while executing` where tclsh's TEBC seeds the inner context to show
+     `invoked from within`; var-not-found / domain errors / propagated
+     `[cmd]`-substitution traces all match.
+5. **PC-5 — `info frame`/`info errorstack` + `source` frames. ⏳ next.** Needs
+   the **persistent `CmdFrame` stack** (`Eval`/`Source`/`Proc` kinds) pushed/
+   popped per command so `info frame ?N?` can read it at runtime, the `Source`
+   frame kind for `source file`, and the TIP-348 `errorStack` (`UP`/`CALL`
+   list). `info level` already landed (PC-2/PC-3).
 6. **PC-6 — AOT emit path** carries the same bookkeeping (conservative), and the
    AOT compiler keeps a **real frame + interpreter fallback** wherever any
    PC-3 dynamic construct is reachable; the AOT↔interp interop gate (a compiled

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1699,10 +1699,11 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + `binary format`/`scan` | 116 / 168 | 51 | 8325 / 17673 |
 | + child interpreters | 118 / 168 | 49 | 8406 / 17855 |
 | + TclOO core | 120 / 168 | 47 | 8415 / 18298 |
-| + TclOO expand / info prefix / hidden+safe | **122 / 168** | 45 | **8529 / 18775** |
+| + TclOO expand / info prefix / hidden+safe | 122 / 168 | 45 | 8529 / 18775 |
+| + cross-interp aliases | **122 / 168** | 45 | **8546 / 18775** |
 
 Cumulative: **+36 files** now run to a tcltest summary, errored-before-summary
-**81 → 45**, **+2957 tests pass**, and **zero panics** (the passed *count*
+**81 → 45**, **+2974 tests pass**, and **zero panics** (the passed *count*
 matters more than the ~47% rate — the denominator grows as more files run their
 full test sets). The unblocking fixes:
 
@@ -1732,7 +1733,13 @@ full test sets). The unblocking fixes:
   `commands` (unblocks interp.test, 48/354).
 - hidden commands (`interp hide`/`expose`/`invokehidden`/`hidden`, + the
   `$child` forms) and `interp create -safe` (hides the host-touching commands
-  the runtime has).
+  the runtime has);
+- **cross-interp aliases** — a child alias delegating to a parent command
+  (`interp alias child name {} target …`, `$child alias name target …`).
+  `eval_in_child` removes the child from the parent's table for the eval and
+  hands it a raw parent pointer (disjoint, dormant parent); a thread-local
+  depth guard rejects nested cross-interp calls rather than risk an aliased
+  `&mut`. interp.test 79 → 94.
 
 Biggest remaining error-before-summary blockers, by file count:
 
@@ -1743,12 +1750,13 @@ Biggest remaining error-before-summary blockers, by file count:
 | `tcl::test` package | 2 | the C-tier test commands |
 | `auto_load` in children | 2 | child interps lack the full `init.tcl` |
 
-**Deferred (architectural):** cross-interp aliases — a child alias delegating
-to a *parent* command — and thus the full Safe Base (`source`/`load`/`file`
-re-aliasing that `safe*.test` needs). The parent owns each child as a
-`Box<Interp>`, so a child cannot call back into the parent during a borrowed
-`eval`; this needs the parent threaded through the child eval (or a flat
-interp registry, dropping the ownership tree).
+**Deferred:** the full Safe Base (`safe.tcl` — `source`/`load`/`file`
+re-aliasing that `safe*.test` needs) builds on cross-interp aliases (now
+present) plus auto-loading in children and *deep* cross-interp re-entrancy
+(parent alias → back into the same child). The latter is what the depth guard
+currently rejects; lifting it needs the parent threaded through the child eval
+(or a flat interp registry replacing the ownership tree) so re-entrant
+`&mut Interp` access is provably non-overlapping.
 
 > Per-file detail is in the sweep's `--json` (`scripts/dev/rust_tcltest_sweep.py
 > --json`). Drive these down toward the Zig baseline.

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1746,20 +1746,29 @@ full test sets). The unblocking fixes:
   elements; index specs accept the full `integer±integer` grammar (`string range
   $s 0 $last-1`); `namespace upvar` is implemented; `glob -types` filters by
   file-kind/permission.
-- **re-entrant Safe Base** — the cross-interp eval engine now supports genuine
-  parent⇄child recursion (a child's aliased `source` calls back into the parent,
-  which calls `interp invokehidden $child …` back into the *same* child while its
-  outer eval is on the stack — exactly C's nested `Tcl_Eval`). The child stays in
-  the parent's table and is evaluated through a raw `*mut Interp` into its
-  heap-stable `Box` (so the pointer survives map reorganisation); the `&mut`
-  aliasing across the boundary models C's shared `Tcl_Interp*` and is **bounded**
-  by `MAX_CROSS_INTERP_DEPTH` (native-stack cap) rather than forbidden. A child
-  deleted *during* its own eval (the self-deleting `exit`→`interp delete` alias)
-  has its teardown **deferred** until the eval unwinds (C's deferred
-  `Tcl_DeleteInterp`), so the boxed interp is never freed under a live raw
-  pointer. `safe::interpCreate`/`interpDelete` and the full Safe Base lifecycle
-  now work (safe.test: 0 run → **51 passed** of 155, no crashes; interp.test
-  94 → 104). `interp issafe`/`aliases` (+`$child` forms) added.
+- **re-entrant Safe Base (idiomatic, sound, lock-free)** — the cross-interp eval
+  engine supports genuine parent⇄child recursion (a child's aliased `source`
+  calls back into the parent, which calls `interp invokehidden $child …` back
+  into the *same* child while its outer eval is on the stack — exactly C's nested
+  `Tcl_Eval`). This is sound **by construction**, not by a bounded raw-pointer
+  hack: `Interp` is a cheap `Rc<InterpState>` handle and **every field of
+  `InterpState` is interior-mutable** (`RefCell`/`Cell`), borrowed only for the
+  span of a single operation — never across a sub-eval (the command resolver
+  already returns *cloned* `Command` handles so dispatch holds no table borrow).
+  Re-entry into an interp clones its handle (an `Rc` bump) and reaches the shared
+  state through `Rc` + `RefCell`, so there is **no aliased `&mut`** — a discipline
+  slip is a clean panic, never UB (Miri-clean for the interp layer). Children are
+  `RefCell<BTreeMap<…, Interp>>`; the parent link is a `Weak<InterpState>` (no
+  ownership cycle). Single-threaded throughout — `Rc`/`RefCell`/`Cell`, no locks.
+  `CROSS_INTERP_DEPTH` survives only as a native-stack bound. A child deleted
+  *during* its own eval (the self-deleting `exit`→`interp delete` alias) has its
+  teardown **deferred** (`eval_active`/`pending_delete`) until the eval unwinds
+  (C's deferred `Tcl_DeleteInterp`). `safe::interpCreate`/`interpDelete` and the
+  full Safe Base lifecycle work (safe.test: 0 run → **51 passed** of 155, no
+  crashes; interp.test 94 → 104). `interp issafe`/`aliases` (+`$child` forms)
+  added. The whole-runtime conversion (`&mut self` field access → interior
+  mutability) is behavior-preserving: the sweep is byte-identical before/after
+  (8654/18939), and all 237 lib tests + clippy/fmt stay green.
 
 Biggest remaining error-before-summary blockers, by file count:
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1411,11 +1411,14 @@ the Zig rep.
     `while executing` / `invoked from within` / `(procedure "x" line N)`
     unwinder, byte-verified vs tclsh 9.0), and **PC-5 — `info frame` + `source`
     frames** (the persistent `CmdFrame` stack: `type`/`line`/`cmd`/`proc`/
-    `file`/`level`, byte-verified vs tclsh 9.0). Remaining proc-chunk items:
-    `info errorstack` (TIP 348), `return -options` errorinfo restore,
-    file-absolute `info frame` lines for source-defined procs, and the
-    expr/`foreach` bytecode-boundary trace approximations noted in
-    `proc-call-and-stack-traces.md` §8.
+    `file`/`level`, byte-verified vs tclsh 9.0 — including file-absolute lines
+    for source-defined procs and the `uplevel`/`eval`-body cases). Remaining
+    proc-chunk items: `return -options` errorinfo restore, and the
+    expr/`foreach`/`eval`-body **bytecode-boundary** trace approximations noted
+    in `proc-call-and-stack-traces.md` §8. `info errorstack` (TIP 348) is
+    **out of scope** — its `INNER` element exposes tclvm bytecode opcodes a
+    WASM-targeting runtime cannot reproduce (the bytecode/disassembly exclusion
+    class).
 - **T1.7 — re-export the codegen ABI.** The AOT codegen imports a fixed set of
   `tcl_*`/`obj_*` primitives; the Rust runtime must export the same names/sigs
   so the parity check and the compiled-script harness stay green. Also the wasm

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1700,7 +1700,8 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + child interpreters | 118 / 168 | 49 | 8406 / 17855 |
 | + TclOO core | 120 / 168 | 47 | 8415 / 18298 |
 | + TclOO expand / info prefix / hidden+safe | 122 / 168 | 45 | 8529 / 18775 |
-| + cross-interp aliases | **122 / 168** | 45 | **8546 / 18775** |
+| + cross-interp aliases | 122 / 168 | 45 | 8546 / 18775 |
+| + auto-load fixes + re-entrant Safe Base | **124 / 168** | 43 (+1 timeout) | **8654 / 18939** |
 
 Cumulative: **+36 files** now run to a tcltest summary, errored-before-summary
 **81 → 45**, **+2974 tests pass**, and **zero panics** (the passed *count*
@@ -1736,10 +1737,29 @@ full test sets). The unblocking fixes:
   the runtime has);
 - **cross-interp aliases** — a child alias delegating to a parent command
   (`interp alias child name {} target …`, `$child alias name target …`).
-  `eval_in_child` removes the child from the parent's table for the eval and
-  hands it a raw parent pointer (disjoint, dormant parent); a thread-local
-  depth guard rejects nested cross-interp calls rather than risk an aliased
-  `&mut`. interp.test 79 → 94.
+  interp.test 79 → 94.
+- **library auto-loading fixes** — five conformance bugs that blocked the Safe
+  Base's pure-Tcl libraries (tm.tcl, safe.tcl, opt) from auto-loading on demand:
+  `namespace ensemble create -command NAME` now qualifies a relative `NAME`
+  against the current namespace (so `tcl::tm::path` binds at the right FQN and
+  `auto_load`'s `namespace which` check passes); `lappend a(k)` addresses array
+  elements; index specs accept the full `integer±integer` grammar (`string range
+  $s 0 $last-1`); `namespace upvar` is implemented; `glob -types` filters by
+  file-kind/permission.
+- **re-entrant Safe Base** — the cross-interp eval engine now supports genuine
+  parent⇄child recursion (a child's aliased `source` calls back into the parent,
+  which calls `interp invokehidden $child …` back into the *same* child while its
+  outer eval is on the stack — exactly C's nested `Tcl_Eval`). The child stays in
+  the parent's table and is evaluated through a raw `*mut Interp` into its
+  heap-stable `Box` (so the pointer survives map reorganisation); the `&mut`
+  aliasing across the boundary models C's shared `Tcl_Interp*` and is **bounded**
+  by `MAX_CROSS_INTERP_DEPTH` (native-stack cap) rather than forbidden. A child
+  deleted *during* its own eval (the self-deleting `exit`→`interp delete` alias)
+  has its teardown **deferred** until the eval unwinds (C's deferred
+  `Tcl_DeleteInterp`), so the boxed interp is never freed under a live raw
+  pointer. `safe::interpCreate`/`interpDelete` and the full Safe Base lifecycle
+  now work (safe.test: 0 run → **51 passed** of 155, no crashes; interp.test
+  94 → 104). `interp issafe`/`aliases` (+`$child` forms) added.
 
 Biggest remaining error-before-summary blockers, by file count:
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1697,10 +1697,11 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + totitle / nsdelete / file / pkg-require-global | 105 / 168 | 62 | 6830 / 14079 |
 | + panic fixes / qualified-name fallback | 110 / 168 | 57 | 7214 / 15345 |
 | + `binary format`/`scan` | 116 / 168 | 51 | 8325 / 17673 |
-| + child interpreters | **118 / 168** | 49 | **8406 / 17855** |
+| + child interpreters | 118 / 168 | 49 | 8406 / 17855 |
+| + TclOO core | **120 / 168** | 47 | **8415 / 18298** |
 
-Cumulative: **+32 files** now run to a tcltest summary, errored-before-summary
-**81 → 49**, **+2834 tests pass**, and **zero panics** (the passed *count*
+Cumulative: **+34 files** now run to a tcltest summary, errored-before-summary
+**81 → 47**, **+2843 tests pass**, and **zero panics** (the passed *count*
 matters more than the ~47% rate — the denominator grows as more files run their
 full test sets). The unblocking fixes:
 
@@ -1719,13 +1720,17 @@ full test sets). The unblocking fixes:
   `tcl::build-info` resolves from inside a namespace);
 - `binary format`/`binary scan` (the core type codes — see `cmd_binary`);
 - basic child interpreters (`interp create`/`eval`/`exists`/`children`/`delete`
-  + the child as a command), each a full `Interp` with startup globals.
+  + the child as a command), each a full `Interp` with startup globals;
+- **TclOO core** (`cmd_oo`): `oo::class`/`oo::object`/`oo::define`, methods,
+  constructor/destructor, single/multiple inheritance with a linearised MRO,
+  `self`/`my`/`next`, and per-object instance variables (auto-linked from the
+  class's `variable` declarations). `package require tcl::oo`/`TclOO` succeed.
 
 Biggest remaining error-before-summary blockers, by file count:
 
 | Blocker | Files | Notes |
 |---|---|---|
-| `tcl::oo` package (TclOO) | 4 | classes/methods/inheritance — own chunk |
+| TclOO meta-object protocol | 3 | `oo`/`ooNext2`/`ooUtil`: classes-as-objects, `info object`/`class`, mixins/filters/forwards, `oo::copy`, `oo::objdefine` |
 | `zipfs` | 3 | zip virtual filesystem |
 | `tcl::test` package | 2 | the C-tier test commands |
 | `auto_load` in children | 2 | child interps lack the full `init.tcl` |

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1694,11 +1694,13 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 |---|---|---|---|
 | Initial baseline | 86 / 168 | 81 | 5572 / 11022 |
 | + reimport / build-info | 94 / 168 | 73 | 6139 / 12299 |
-| + totitle / nsdelete / file / pkg-require-global | **105 / 168** | 62 | **6830 / 14079** |
+| + totitle / nsdelete / file / pkg-require-global | 105 / 168 | 62 | 6830 / 14079 |
+| + panic fixes / qualified-name fallback | **110 / 168** | 57 | **7214 / 15345** |
 
-Cumulative: **+19 files** now run to a tcltest summary and **+1258 tests pass**
-(the passed *count* matters more than the ~50% rate — the denominator grows as
-more files run their full test sets). The unblocking fixes:
+Cumulative: **+24 files** now run to a tcltest summary, errored-before-summary
+**81 → 57**, **+1642 tests pass**, and **zero panics** (the passed *count*
+matters more than the ~47% rate — the denominator grows as more files run their
+full test sets). The unblocking fixes:
 
 - idempotent `namespace import` re-import (same source ⇒ no-op);
 - `tcl::build-info` (the tcltest constraint source);
@@ -1707,17 +1709,21 @@ more files run their full test sets). The unblocking fixes:
 - `file delete`/`mkdir`/`size`/`type`/`pathtype`/`executable`;
 - `package require` evaluates its load script at global scope (C's `uplevel
   #0`), so a package's `namespace eval foo` creates `::foo` even when required
-  from inside a namespace.
+  from inside a namespace;
+- three panics → clean errors: `format` width overflow (`max size for a Tcl
+  value exceeded`), `proc` `args`-split with all-defaulted positionals, and a
+  required parameter after a defaulted one (`wrong # args`);
+- relative qualified command names fall back to the global namespace (so
+  `tcl::build-info` resolves from inside a namespace).
 
 Biggest remaining error-before-summary blockers, by file count:
 
 | Blocker | Files | Notes |
 |---|---|---|
 | `binary` command | 8 | `binary format`/`scan` (own chunk) |
-| `interp command`/`children` | 4+4 | child-interp introspection |
+| `interp` `command`/`children` | 4+4 | child-interp support/introspection |
 | `tcl::oo` package | 4 | TclOO (own chunk) |
-| `tcl::build-info` from a namespace | 3 | qualified-name resolution edge |
-| panics | 3 | a real bug — investigate (RUST_BACKTRACE in the sweep) |
+| `tcl::test` package | 2 | the C-tier test commands |
 
 > Per-file detail is in the sweep's `--json` (`scripts/dev/rust_tcltest_sweep.py
 > --json`). Drive these down toward the Zig baseline.

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1698,10 +1698,11 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + panic fixes / qualified-name fallback | 110 / 168 | 57 | 7214 / 15345 |
 | + `binary format`/`scan` | 116 / 168 | 51 | 8325 / 17673 |
 | + child interpreters | 118 / 168 | 49 | 8406 / 17855 |
-| + TclOO core | **120 / 168** | 47 | **8415 / 18298** |
+| + TclOO core | 120 / 168 | 47 | 8415 / 18298 |
+| + TclOO expand / info prefix / hidden+safe | **122 / 168** | 45 | **8529 / 18775** |
 
-Cumulative: **+34 files** now run to a tcltest summary, errored-before-summary
-**81 → 47**, **+2843 tests pass**, and **zero panics** (the passed *count*
+Cumulative: **+36 files** now run to a tcltest summary, errored-before-summary
+**81 → 45**, **+2957 tests pass**, and **zero panics** (the passed *count*
 matters more than the ~47% rate — the denominator grows as more files run their
 full test sets). The unblocking fixes:
 
@@ -1721,20 +1722,33 @@ full test sets). The unblocking fixes:
 - `binary format`/`binary scan` (the core type codes — see `cmd_binary`);
 - basic child interpreters (`interp create`/`eval`/`exists`/`children`/`delete`
   + the child as a command), each a full `Interp` with startup globals;
-- **TclOO core** (`cmd_oo`): `oo::class`/`oo::object`/`oo::define`, methods,
-  constructor/destructor, single/multiple inheritance with a linearised MRO,
-  `self`/`my`/`next`, and per-object instance variables (auto-linked from the
-  class's `variable` declarations). `package require tcl::oo`/`TclOO` succeed.
+- **TclOO** (`cmd_oo`): `oo::class`/`oo::object`/`oo::define`/`oo::objdefine`/
+  `oo::copy`, methods + `forward`, constructor/destructor, single/multiple
+  inheritance + `mixin` over a linearised dispatch chain, `export`/`unexport`,
+  `self`/`my`/`next`, per-object methods/mixins/instance-variables, and `info
+  object`/`info class` introspection (oo.test 9 → 31). `package require
+  tcl::oo`/`TclOO` succeed.
+- `info` is an ensemble (unambiguous-prefix subcommands) — `info command` →
+  `commands` (unblocks interp.test, 48/354).
+- hidden commands (`interp hide`/`expose`/`invokehidden`/`hidden`, + the
+  `$child` forms) and `interp create -safe` (hides the host-touching commands
+  the runtime has).
 
 Biggest remaining error-before-summary blockers, by file count:
 
 | Blocker | Files | Notes |
 |---|---|---|
-| TclOO meta-object protocol | 3 | `oo`/`ooNext2`/`ooUtil`: classes-as-objects, `info object`/`class`, mixins/filters/forwards, `oo::copy`, `oo::objdefine` |
+| TclOO meta-protocol | 3 | `oo`/`ooNext2`/`ooUtil`: classes-as-objects, filters, private methods (8.7+), full C3 mixin linearisation, the rarer `info object`/`class` subcommands |
 | `zipfs` | 3 | zip virtual filesystem |
 | `tcl::test` package | 2 | the C-tier test commands |
 | `auto_load` in children | 2 | child interps lack the full `init.tcl` |
-| safe interpreters | (in `interp`) | the `-safe` sandbox: hidden commands, limited set |
+
+**Deferred (architectural):** cross-interp aliases — a child alias delegating
+to a *parent* command — and thus the full Safe Base (`source`/`load`/`file`
+re-aliasing that `safe*.test` needs). The parent owns each child as a
+`Box<Interp>`, so a child cannot call back into the parent during a borrowed
+`eval`; this needs the parent threaded through the child eval (or a flat
+interp registry, dropping the ownership tree).
 
 > Per-file detail is in the sweep's `--json` (`scripts/dev/rust_tcltest_sweep.py
 > --json`). Drive these down toward the Zig baseline.

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1407,11 +1407,13 @@ the Zig rep.
     string/list/dict/array/control-flow/info/scan/format/chan/trace/package
     builtins, plus the **proc chunk PC-2/PC-3** (`proc`/`apply`, `uplevel`/
     `upvar`/`global`/`variable`, `info level`, `catch`/`error`/`try`/`throw`)
-    and **PC-1/PC-4 — faithful `::errorInfo` stack traces** (the incremental
+    **PC-1/PC-4 — faithful `::errorInfo` stack traces** (the incremental
     `while executing` / `invoked from within` / `(procedure "x" line N)`
-    unwinder, byte-verified vs tclsh 9.0). Remaining proc-chunk items:
-    **PC-5** (`info frame`/`info errorstack` + `source` frames — needs the
-    persistent `CmdFrame` stack), `return -options` errorinfo restore, and the
+    unwinder, byte-verified vs tclsh 9.0), and **PC-5 — `info frame` + `source`
+    frames** (the persistent `CmdFrame` stack: `type`/`line`/`cmd`/`proc`/
+    `file`/`level`, byte-verified vs tclsh 9.0). Remaining proc-chunk items:
+    `info errorstack` (TIP 348), `return -options` errorinfo restore,
+    file-absolute `info frame` lines for source-defined procs, and the
     expr/`foreach` bytecode-boundary trace approximations noted in
     `proc-call-and-stack-traces.md` §8.
 - **T1.7 — re-export the codegen ABI.** The AOT codegen imports a fixed set of

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1693,24 +1693,34 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | Sweep | Files run-to-summary | Errored before summary | Tests passed |
 |---|---|---|---|
 | Initial baseline | 86 / 168 | 81 | 5572 / 11022 |
-| + reimport / build-info fixes | 94 / 168 | 73 | 6139 / 12299 |
+| + reimport / build-info | 94 / 168 | 73 | 6139 / 12299 |
+| + totitle / nsdelete / file / pkg-require-global | **105 / 168** | 62 | **6830 / 14079** |
 
-(The passed-test *count* rose by 567 even though the percentage held ~50%: the
-denominator grew because 8 more files now run their full test sets.) The
-biggest remaining error-before-summary blockers, by file count, are the
-data-prioritised next gaps:
+Cumulative: **+19 files** now run to a tcltest summary and **+1258 tests pass**
+(the passed *count* matters more than the ~50% rate — the denominator grows as
+more files run their full test sets). The unblocking fixes:
+
+- idempotent `namespace import` re-import (same source ⇒ no-op);
+- `tcl::build-info` (the tcltest constraint source);
+- `string totitle` + the `?first? ?last?` range form for `toupper`/`tolower`;
+- `namespace delete` (arena tombstoning of the subtree);
+- `file delete`/`mkdir`/`size`/`type`/`pathtype`/`executable`;
+- `package require` evaluates its load script at global scope (C's `uplevel
+  #0`), so a package's `namespace eval foo` creates `::foo` even when required
+  from inside a namespace.
+
+Biggest remaining error-before-summary blockers, by file count:
 
 | Blocker | Files | Notes |
 |---|---|---|
-| `binary` command | 7 | `binary format`/`scan` not implemented |
-| `file delete` (+ other `file` subcommands) | 6 | filesystem mutation subcommands |
-| `namespace delete` | 6 | needs arena tombstoning (deferred T1.5 item) |
-| `interp children` / child interps | 4 | child-interp introspection |
+| `binary` command | 8 | `binary format`/`scan` (own chunk) |
+| `interp command`/`children` | 4+4 | child-interp introspection |
 | `tcl::oo` package | 4 | TclOO (own chunk) |
-| `string totitle` | 3 | small `string` subcommand |
+| `tcl::build-info` from a namespace | 3 | qualified-name resolution edge |
+| panics | 3 | a real bug — investigate (RUST_BACKTRACE in the sweep) |
 
-> Per-file detail is in the sweep's `--json`; the table above is the
-> reproducible baseline anchor. Drive these down toward the Zig baseline.
+> Per-file detail is in the sweep's `--json` (`scripts/dev/rust_tcltest_sweep.py
+> --json`). Drive these down toward the Zig baseline.
 
 ### Out-of-scope exclusions (by design)
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1396,13 +1396,24 @@ the Zig rep.
   control-flow/proc/…), each command (or small group) one PR with its tcltest
   delta. The value-type chunks (list/dict/string/array) each carry a
   [representation-decision note](#choosing-algorithms--data-structures-the-porting-method).
-  **Procs are gated on a design**, not started blind:
+  Procs followed a design, not started blind:
   [`proc-call-and-stack-traces.md`](proc-call-and-stack-traces.md) fixes the
   call protocol (the CallFrame + CmdFrame stacks), the exception/return-options
   model, stack-trace construction, and AOT↔interp interop — built on the
   conservative-first principle and "get the dynamic cross-scope core
   (`uplevel`/`upvar`/`namespace`/`eval`) correct, then optimise". The proc
   chunk follows that doc's PC-1..PC-7 plan.
+  - **Status (ahead of the prose above):** the bulk of T1.6 has landed —
+    string/list/dict/array/control-flow/info/scan/format/chan/trace/package
+    builtins, plus the **proc chunk PC-2/PC-3** (`proc`/`apply`, `uplevel`/
+    `upvar`/`global`/`variable`, `info level`, `catch`/`error`/`try`/`throw`)
+    and **PC-1/PC-4 — faithful `::errorInfo` stack traces** (the incremental
+    `while executing` / `invoked from within` / `(procedure "x" line N)`
+    unwinder, byte-verified vs tclsh 9.0). Remaining proc-chunk items:
+    **PC-5** (`info frame`/`info errorstack` + `source` frames — needs the
+    persistent `CmdFrame` stack), `return -options` errorinfo restore, and the
+    expr/`foreach` bytecode-boundary trace approximations noted in
+    `proc-call-and-stack-traces.md` §8.
 - **T1.7 — re-export the codegen ABI.** The AOT codegen imports a fixed set of
   `tcl_*`/`obj_*` primitives; the Rust runtime must export the same names/sigs
   so the parity check and the compiled-script harness stay green. Also the wasm

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1678,15 +1678,39 @@ gated PR. Status: **not-started.**
 
 ## Tcl 9 test-suite scoreboard (gold standard)
 
-`tmp/tcl9.0.3/tests/*.test` (168 files), run via
-`scripts/run_tcl9_tcltest_sweep.py`. **In scope: behaviour.** No file passing on
-the Zig baseline may regress. Per-file pass/partial/excluded is captured against
-the Zig baseline; seeded empty here — the first sweep establishes the baseline
-column.
+`tmp/tcl9.0.3/tests/*.test` (168 files). The **Zig/WASM** backend is swept by
+`scripts/dev/run_tcl9_tcltest_sweep.py`; the **Rust interpreter** is swept by
+`scripts/dev/rust_tcltest_sweep.py`, which sources each file through the
+`run_script` example (real `tcltest` loads via `--init`/`init.tcl`) and parses
+tcltest's own `Total/Passed/Skipped/Failed` summary. **In scope: behaviour.**
 
-| `.test` file | Zig baseline (pass/total) | Rust (pass/total) | Status |
+### Rust runtime baseline — 2026-06-10 (first sweep)
+
+The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
+2.5.10). First measured baseline, then the same day's two unblocking fixes
+(idempotent `namespace import` re-import + `tcl::build-info`):
+
+| Sweep | Files run-to-summary | Errored before summary | Tests passed |
 |---|---|---|---|
-| _seed — captured by first `run_tcl9_tcltest_sweep.py` run_ | — | — | not-started |
+| Initial baseline | 86 / 168 | 81 | 5572 / 11022 |
+| + reimport / build-info fixes | 94 / 168 | 73 | 6139 / 12299 |
+
+(The passed-test *count* rose by 567 even though the percentage held ~50%: the
+denominator grew because 8 more files now run their full test sets.) The
+biggest remaining error-before-summary blockers, by file count, are the
+data-prioritised next gaps:
+
+| Blocker | Files | Notes |
+|---|---|---|
+| `binary` command | 7 | `binary format`/`scan` not implemented |
+| `file delete` (+ other `file` subcommands) | 6 | filesystem mutation subcommands |
+| `namespace delete` | 6 | needs arena tombstoning (deferred T1.5 item) |
+| `interp children` / child interps | 4 | child-interp introspection |
+| `tcl::oo` package | 4 | TclOO (own chunk) |
+| `string totitle` | 3 | small `string` subcommand |
+
+> Per-file detail is in the sweep's `--json`; the table above is the
+> reproducible baseline anchor. Drive these down toward the Zig baseline.
 
 ### Out-of-scope exclusions (by design)
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1695,10 +1695,11 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | Initial baseline | 86 / 168 | 81 | 5572 / 11022 |
 | + reimport / build-info | 94 / 168 | 73 | 6139 / 12299 |
 | + totitle / nsdelete / file / pkg-require-global | 105 / 168 | 62 | 6830 / 14079 |
-| + panic fixes / qualified-name fallback | **110 / 168** | 57 | **7214 / 15345** |
+| + panic fixes / qualified-name fallback | 110 / 168 | 57 | 7214 / 15345 |
+| + `binary format`/`scan` | **116 / 168** | 51 | **8325 / 17673** |
 
-Cumulative: **+24 files** now run to a tcltest summary, errored-before-summary
-**81 → 57**, **+1642 tests pass**, and **zero panics** (the passed *count*
+Cumulative: **+30 files** now run to a tcltest summary, errored-before-summary
+**81 → 51**, **+2753 tests pass**, and **zero panics** (the passed *count*
 matters more than the ~47% rate — the denominator grows as more files run their
 full test sets). The unblocking fixes:
 
@@ -1714,14 +1715,14 @@ full test sets). The unblocking fixes:
   value exceeded`), `proc` `args`-split with all-defaulted positionals, and a
   required parameter after a defaulted one (`wrong # args`);
 - relative qualified command names fall back to the global namespace (so
-  `tcl::build-info` resolves from inside a namespace).
+  `tcl::build-info` resolves from inside a namespace);
+- `binary format`/`binary scan` (the core type codes — see `cmd_binary`).
 
 Biggest remaining error-before-summary blockers, by file count:
 
 | Blocker | Files | Notes |
 |---|---|---|
-| `binary` command | 8 | `binary format`/`scan` (own chunk) |
-| `interp` `command`/`children` | 4+4 | child-interp support/introspection |
+| `interp` child interpreters (`create`/`children`/`eval`/…) | ~10 | a substantial feature (sub-`Interp`s) |
 | `tcl::oo` package | 4 | TclOO (own chunk) |
 | `tcl::test` package | 2 | the C-tier test commands |
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1696,10 +1696,11 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + reimport / build-info | 94 / 168 | 73 | 6139 / 12299 |
 | + totitle / nsdelete / file / pkg-require-global | 105 / 168 | 62 | 6830 / 14079 |
 | + panic fixes / qualified-name fallback | 110 / 168 | 57 | 7214 / 15345 |
-| + `binary format`/`scan` | **116 / 168** | 51 | **8325 / 17673** |
+| + `binary format`/`scan` | 116 / 168 | 51 | 8325 / 17673 |
+| + child interpreters | **118 / 168** | 49 | **8406 / 17855** |
 
-Cumulative: **+30 files** now run to a tcltest summary, errored-before-summary
-**81 → 51**, **+2753 tests pass**, and **zero panics** (the passed *count*
+Cumulative: **+32 files** now run to a tcltest summary, errored-before-summary
+**81 → 49**, **+2834 tests pass**, and **zero panics** (the passed *count*
 matters more than the ~47% rate — the denominator grows as more files run their
 full test sets). The unblocking fixes:
 
@@ -1716,15 +1717,19 @@ full test sets). The unblocking fixes:
   required parameter after a defaulted one (`wrong # args`);
 - relative qualified command names fall back to the global namespace (so
   `tcl::build-info` resolves from inside a namespace);
-- `binary format`/`binary scan` (the core type codes — see `cmd_binary`).
+- `binary format`/`binary scan` (the core type codes — see `cmd_binary`);
+- basic child interpreters (`interp create`/`eval`/`exists`/`children`/`delete`
+  + the child as a command), each a full `Interp` with startup globals.
 
 Biggest remaining error-before-summary blockers, by file count:
 
 | Blocker | Files | Notes |
 |---|---|---|
-| `interp` child interpreters (`create`/`children`/`eval`/…) | ~10 | a substantial feature (sub-`Interp`s) |
-| `tcl::oo` package | 4 | TclOO (own chunk) |
+| `tcl::oo` package (TclOO) | 4 | classes/methods/inheritance — own chunk |
+| `zipfs` | 3 | zip virtual filesystem |
 | `tcl::test` package | 2 | the C-tier test commands |
+| `auto_load` in children | 2 | child interps lack the full `init.tcl` |
+| safe interpreters | (in `interp`) | the `-safe` sandbox: hidden commands, limited set |
 
 > Per-file detail is in the sweep's `--json` (`scripts/dev/rust_tcltest_sweep.py
 > --json`). Drive these down toward the Zig baseline.

--- a/runtime/rust/examples/run_script.rs
+++ b/runtime/rust/examples/run_script.rs
@@ -20,7 +20,10 @@ fn main() {
     if init {
         args.remove(1);
     }
-    let src = if let Some(path) = args.get(1) {
+    // A file path is *sourced* (like `tclsh script.tcl`: `info script` is set and
+    // `info frame` reports `type source`); stdin is evaluated as a script.
+    let path = args.get(1).cloned();
+    let src = if let Some(path) = &path {
         std::fs::read(path).unwrap_or_else(|e| {
             eprintln!("run_script: cannot read {path}: {e}");
             std::process::exit(2);
@@ -39,7 +42,10 @@ fn main() {
         );
         std::process::exit(1);
     }
-    let code = interp.eval_str(&src);
+    let code = match &path {
+        Some(p) => interp.eval_sourced(&src, p.as_bytes()),
+        None => interp.eval_str(&src),
+    };
     let result = interp.result_bytes();
     if code == Code::Error {
         eprintln!("error: {}", String::from_utf8_lossy(&result));

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -483,6 +483,12 @@ fn parse_i64(bytes: &[u8]) -> Option<i64> {
 #[cfg(have_tommath)]
 struct InterpExprCtx<'a> {
     interp: &'a mut Interp,
+    /// Set when an error propagated out of a sub-evaluation (`[cmd]`, a math
+    /// function, or a `$arr(idx)` index subst) rather than originating in `expr`
+    /// itself. In that case the inner command already built the `::errorInfo`
+    /// trace, so `expr` must preserve it (and add no frame of its own) — matching
+    /// C, where such an error is logged at the inner command, not at `expr`.
+    propagated: bool,
 }
 
 #[cfg(have_tommath)]
@@ -499,9 +505,10 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
                 {
                     Ok(v) => Some(v),
                     Err(_) => {
+                        self.propagated = true;
                         return Err(crate::expr::ExprError(obj_bytes(
                             self.interp.get_obj_result(),
-                        )))
+                        )));
                     }
                 }
             }
@@ -524,6 +531,7 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
 
     fn eval_command(&mut self, script: &str) -> Result<crate::expr::Owned, crate::expr::ExprError> {
         if self.interp.eval_str(script.as_bytes()) == Code::Error {
+            self.propagated = true;
             return Err(crate::expr::ExprError(obj_bytes(
                 self.interp.get_obj_result(),
             )));
@@ -541,6 +549,9 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
         // shared dispatch. Args are passed as live objects (object-preserving).
         let arg_ptrs: Vec<*mut TclObj> = args.iter().map(crate::expr::Owned::as_ptr).collect();
         if self.interp.eval_math_call(name.as_bytes(), &arg_ptrs) == Code::Error {
+            // A math-function error (e.g. `sqrt(-1)` domain error) is logged at
+            // the `expr` command, not as an inner frame — so it is *not*
+            // propagated; `expr` raises it as its own (`while executing`).
             return Err(crate::expr::ExprError(obj_bytes(
                 self.interp.get_obj_result(),
             )));
@@ -568,18 +579,21 @@ fn expr_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.set_error(b"expr operand is not valid UTF-8");
     };
     let node = tcl_syntax::expr::parse_expr(src, None);
-    let result = {
-        let mut ctx = InterpExprCtx {
-            interp: &mut *interp,
-        };
-        crate::expr::eval_expr(&node, &mut ctx)
+    let mut ctx = InterpExprCtx {
+        interp: &mut *interp,
+        propagated: false,
     };
+    let result = crate::expr::eval_expr(&node, &mut ctx);
+    let propagated = ctx.propagated;
     match result {
         Ok(r) => {
             // `set_result` takes its own `+1`; `r` drops its reference after.
             interp.set_result(r.as_ptr());
             Code::Ok
         }
+        // A propagated sub-eval error already set the result + `::errorInfo`
+        // trace at the inner command — preserve it (no `expr` frame).
+        Err(_) if propagated => Code::Error,
         Err(e) => interp.set_error(&e.0),
     }
 }
@@ -593,14 +607,16 @@ pub(crate) fn eval_bool_expr(interp: &mut Interp, src: &[u8]) -> Result<bool, Co
         return Err(interp.set_error(b"expr operand is not valid UTF-8"));
     };
     let node = tcl_syntax::expr::parse_expr(s, None);
-    let result = {
-        let mut ctx = InterpExprCtx {
-            interp: &mut *interp,
-        };
-        crate::expr::eval_expr(&node, &mut ctx)
+    let mut ctx = InterpExprCtx {
+        interp: &mut *interp,
+        propagated: false,
     };
+    let result = crate::expr::eval_expr(&node, &mut ctx);
+    let propagated = ctx.propagated;
     match result {
         Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| interp.set_error(&e.0)),
+        // Preserve a propagated sub-eval error's trace (no condition `expr` frame).
+        Err(_) if propagated => Err(Code::Error),
         Err(e) => Err(interp.set_error(&e.0)),
     }
 }

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -54,6 +54,9 @@ pub fn install(interp: &mut Interp) {
     // `regexp`/`regsub` need the linked-in Tcl regex engine (the C ARE engine).
     #[cfg(have_regex)]
     crate::cmd_regex::install(interp);
+    // TclOO last: its `variable`/`self`/`my`/`next` intentionally override the
+    // base `variable` (OO-aware inside `oo::define`, forwarding otherwise).
+    crate::cmd_oo::install(interp);
 }
 
 fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -22,6 +22,7 @@ pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"subst", subst_cmd);
     crate::cmd_scan::install(interp);
     crate::cmd_format::install(interp);
+    crate::cmd_binary::install(interp);
     // `expr` needs the numeric tower (libtommath); registered only when linked.
     #[cfg(have_tommath)]
     interp.register_builtin(b"expr", expr_cmd);

--- a/runtime/rust/src/capi.rs
+++ b/runtime/rust/src/capi.rs
@@ -132,7 +132,9 @@ pub unsafe extern "C" fn Tcl_GetString(objPtr: *mut TclObj) -> *mut c_char {
 /// to [`tcl_runtime_delete_interp`].
 #[no_mangle]
 pub extern "C" fn tcl_runtime_create_interp() -> *mut Interp {
-    Box::into_raw(Interp::new())
+    // `Interp` is now a cheap `Rc` handle; box it so the C side has a stable
+    // owning raw pointer to hand back to `tcl_runtime_delete_interp`.
+    Box::into_raw(Box::new(Interp::new()))
 }
 
 /// Destroy a runtime interp previously returned by [`tcl_runtime_create_interp`].

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -133,7 +133,14 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"issafe" => {
-            interp.set_result_bytes(b"0");
+            // `interp issafe ?path?` — the current interp (no path) or a child.
+            let path = argv.get(2).map(|&a| obj_bytes(a)).unwrap_or_default();
+            let safe = if path.is_empty() {
+                interp.is_safe()
+            } else {
+                interp.with_child(&path, |c| c.is_safe()).unwrap_or(false)
+            };
+            interp.set_result_bytes(if safe { b"1" } else { b"0" });
             Code::Ok
         }
         other => {
@@ -379,12 +386,20 @@ fn interp_alias(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// `interp aliases ?{}?` — every alias command's name as a Tcl list.
+/// `interp aliases ?path?` — every alias command's name in the named interp (the
+/// current one for an empty/missing path) as a Tcl list.
 fn interp_aliases(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    if argv.len() > 3 || (argv.len() == 3 && !obj_bytes(argv[2]).is_empty()) {
-        return only_single_interp(interp);
+    if argv.len() > 3 {
+        return wrong_args(interp, b"interp aliases ?path?");
     }
-    let names = interp.alias_names();
+    let path = argv.get(2).map(|&a| obj_bytes(a)).unwrap_or_default();
+    let names = if path.is_empty() {
+        interp.alias_names()
+    } else {
+        interp
+            .with_child(&path, |c| c.alias_names())
+            .unwrap_or_default()
+    };
     let elems: Vec<*mut TclObj> = names.iter().map(|n| obj::new_string_bytes(n)).collect();
     interp.set_result(list::new_list_obj(&elems));
     for e in elems {
@@ -480,8 +495,9 @@ mod tests {
 
     #[test]
     fn cross_interp_aliases() {
-        // A child alias delegating to a parent command (both syntaxes), and the
-        // re-entrancy guard (a parent alias re-entering a child errors, not UB).
+        // A child alias delegating to a parent command (both syntaxes), and
+        // re-entrancy (a parent alias re-entering the *same* child mid-eval —
+        // the Safe Base pattern — now recurses correctly, bounded not forbidden).
         leak_free(|i| {
             i.eval_str(b"proc padd {a b} {expr {$a+$b}}");
             i.eval_str(b"set c [interp create]");
@@ -493,11 +509,15 @@ mod tests {
             i.eval_str(b"$c alias mul ::tcl::mathop::* 3");
             assert_eq!(i.eval_str(b"$c eval {mul 4}"), Code::Ok);
             assert_eq!(i.result_bytes(), b"12");
-            // Re-entrancy: a parent alias target that evals back into a child
-            // errors (the depth guard), rather than risking aliased &mut.
-            i.eval_str(b"proc reenter {} { $::c eval {set x 1} }");
+            // Re-entrancy: a parent alias target that evals back into the same
+            // child while its outer eval is still on the stack. This recurses
+            // (the child's `x` ends up set), it does not error.
+            i.eval_str(b"proc reenter {} { $::c eval {set x 42} }");
             i.eval_str(b"interp alias $c cb {} reenter");
-            assert_eq!(i.eval_str(b"$c eval {cb}"), Code::Error);
+            assert_eq!(i.eval_str(b"$c eval {cb}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"42");
+            assert_eq!(i.eval_str(b"$c eval {set x}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"42");
             i.eval_str(b"interp delete $c; unset -nocomplain c");
         });
     }

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -313,11 +313,37 @@ fn interp_alias(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             b"interp alias srcPath srcCmd ?targetPath targetCmd? ?arg ...?",
         );
     }
-    if !obj_bytes(argv[2]).is_empty() {
-        return only_single_interp(interp);
-    }
+    let src = obj_bytes(argv[2]);
     let name = obj_bytes(argv[3]);
 
+    // -- alias in a child interp, delegating to the parent (this interp) -------
+    if !src.is_empty() {
+        if !interp.child_exists(&src) {
+            let mut m = b"could not find interpreter \"".to_vec();
+            m.extend_from_slice(&src);
+            m.push(b'"');
+            return interp.set_error(&m);
+        }
+        if argv.len() == 4 {
+            return interp.set_error(b"querying a child alias is not yet supported");
+        }
+        if !obj_bytes(argv[4]).is_empty() {
+            // Only a `{}` target path (the parent) is supported.
+            return only_single_interp(interp);
+        }
+        if argv.len() == 5 {
+            interp.with_child(&src, |c| c.delete_command(&name));
+            interp.set_result_bytes(b"");
+            return Code::Ok;
+        }
+        let target = obj_bytes(argv[5]);
+        let prefix: Vec<Vec<u8>> = argv[6..].iter().map(|&a| obj_bytes(a)).collect();
+        interp.install_parent_alias(&src, &name, target, prefix);
+        interp.set_result(obj::new_string_bytes(&name));
+        return Code::Ok;
+    }
+
+    // -- alias in the current interp (single-interp) --------------------------
     // Query: `interp alias {} aliasName`.
     if argv.len() == 4 {
         return match interp.alias_info(&name) {
@@ -449,6 +475,30 @@ mod tests {
             assert_eq!(i.eval_str(b"interp exists kid"), Code::Ok);
             assert_eq!(i.result_bytes(), b"0");
             assert_eq!(i.eval_str(b"kid eval {set x}"), Code::Error);
+        });
+    }
+
+    #[test]
+    fn cross_interp_aliases() {
+        // A child alias delegating to a parent command (both syntaxes), and the
+        // re-entrancy guard (a parent alias re-entering a child errors, not UB).
+        leak_free(|i| {
+            i.eval_str(b"proc padd {a b} {expr {$a+$b}}");
+            i.eval_str(b"set c [interp create]");
+            // `interp alias $c name {} target prefix...`
+            i.eval_str(b"interp alias $c add {} padd 100");
+            assert_eq!(i.eval_str(b"$c eval {add 5}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"105");
+            // `$c alias name target prefix...`
+            i.eval_str(b"$c alias mul ::tcl::mathop::* 3");
+            assert_eq!(i.eval_str(b"$c eval {mul 4}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"12");
+            // Re-entrancy: a parent alias target that evals back into a child
+            // errors (the depth guard), rather than risking aliased &mut.
+            i.eval_str(b"proc reenter {} { $::c eval {set x 1} }");
+            i.eval_str(b"interp alias $c cb {} reenter");
+            assert_eq!(i.eval_str(b"$c eval {cb}"), Code::Error);
+            i.eval_str(b"interp delete $c; unset -nocomplain c");
         });
     }
 

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -111,7 +111,27 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
             Code::Ok
         }
-        // Single-interp runtime: `issafe`/`exists ""` describe the one interp.
+        b"hide" => interp_hidectl(interp, argv, HideOp::Hide),
+        b"expose" => interp_hidectl(interp, argv, HideOp::Expose),
+        b"invokehidden" => interp_invokehidden(interp, argv),
+        b"hidden" => {
+            // `interp hidden ?path?` — hidden command names in the (current or
+            // named) interp.
+            let path = argv.get(2).map(|&a| obj_bytes(a)).unwrap_or_default();
+            let names = if path.is_empty() {
+                interp.hidden_names()
+            } else {
+                interp
+                    .with_child(&path, |c| c.hidden_names())
+                    .unwrap_or_default()
+            };
+            let elems: Vec<*mut TclObj> = names.iter().map(|n| obj::new_string_bytes(n)).collect();
+            interp.set_result(list::new_list_obj(&elems));
+            for e in elems {
+                drop_fresh(e);
+            }
+            Code::Ok
+        }
         b"issafe" => {
             interp.set_result_bytes(b"0");
             Code::Ok
@@ -126,15 +146,16 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 }
 
 /// `interp create ?-safe? ?--? ?path?` — create a child interpreter, returning
-/// its name (auto-generated `interpN` when omitted). `-safe` is accepted but the
-/// sandbox is not yet enforced (a follow-up).
+/// its name (auto-generated `interpN` when omitted). `-safe` hides the
+/// host-touching commands (the Safe Base's re-aliasing is a follow-up).
 fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut name: Option<Vec<u8>> = None;
+    let mut safe = false;
     let mut i = 2;
     while i < argv.len() {
         let a = obj_bytes(argv[i]);
         match a.as_slice() {
-            b"-safe" => {}
+            b"-safe" => safe = true,
             b"--" => {
                 i += 1;
                 break;
@@ -155,8 +176,96 @@ fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         name = Some(p);
     }
     let created = interp.create_child(name);
+    if safe {
+        interp.with_child(&created, |c| c.make_safe());
+    }
     interp.set_result(obj::new_string_bytes(&created));
     Code::Ok
+}
+
+enum HideOp {
+    Hide,
+    Expose,
+}
+
+/// `interp hide|expose path cmdName` — move a command into/out of the hidden
+/// table of the named (or current, when path is `{}`) interpreter.
+fn interp_hidectl(interp: &mut Interp, argv: &[*mut TclObj], op: HideOp) -> Code {
+    if argv.len() != 4 {
+        return wrong_args(interp, b"interp hide|expose path cmdName");
+    }
+    let path = obj_bytes(argv[2]);
+    let cmd = obj_bytes(argv[3]);
+    let did = if path.is_empty() {
+        match op {
+            HideOp::Hide => interp.hide_command(&cmd),
+            HideOp::Expose => interp.expose_command(&cmd),
+        }
+    } else {
+        interp
+            .with_child(&path, |c| match op {
+                HideOp::Hide => c.hide_command(&cmd),
+                HideOp::Expose => c.expose_command(&cmd),
+            })
+            .unwrap_or(false)
+    };
+    if !did {
+        // Hiding a missing command, or exposing a non-hidden one.
+        let _ = did;
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `interp invokehidden path ?-opt ...? cmdName ?arg ...?` — invoke a hidden
+/// command in the named (or current) interpreter.
+fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(interp, b"interp invokehidden path ?-opt? cmd ?arg ...?");
+    }
+    let path = obj_bytes(argv[2]);
+    // Skip leading option flags (`-namespace ns`, `-global`).
+    let mut i = 3;
+    while i < argv.len() {
+        match obj_bytes(argv[i]).as_slice() {
+            b"-global" => i += 1,
+            b"-namespace" => i += 2,
+            b"--" => {
+                i += 1;
+                break;
+            }
+            s if s.starts_with(b"-") => i += 1,
+            _ => break,
+        }
+    }
+    if i >= argv.len() {
+        return wrong_args(interp, b"interp invokehidden path ?-opt? cmd ?arg ...?");
+    }
+    let cmd = obj_bytes(argv[i]);
+    // Build the hidden command's argv (cmd + remaining args).
+    let mut hidden_argv: Vec<*mut TclObj> = Vec::with_capacity(argv.len() - i);
+    for &a in &argv[i..] {
+        unsafe { obj::incr_ref_count(a) };
+        hidden_argv.push(a);
+    }
+    let code = if path.is_empty() {
+        interp.invoke_hidden(&cmd, &hidden_argv)
+    } else {
+        // Run in the child; copy its result back.
+        match interp.with_child(&path, |c| {
+            (c.invoke_hidden(&cmd, &hidden_argv), c.result_bytes())
+        }) {
+            Some((code, res)) => {
+                interp.set_result_bytes(&res);
+                code
+            }
+            None => interp.set_error(b"could not find interpreter"),
+        }
+    };
+    for a in hidden_argv {
+        unsafe { obj::decr_ref_count(a) };
+    }
+    code
 }
 
 /// `interp eval path arg ?arg ...?` — evaluate a script in a child interpreter.
@@ -340,6 +449,32 @@ mod tests {
             assert_eq!(i.eval_str(b"interp exists kid"), Code::Ok);
             assert_eq!(i.result_bytes(), b"0");
             assert_eq!(i.eval_str(b"kid eval {set x}"), Code::Error);
+        });
+    }
+
+    #[test]
+    fn hidden_commands_and_safe() {
+        // `interp hide`/`expose`/`invokehidden` + `interp create -safe`.
+        leak_free(|i| {
+            i.eval_str(b"set c [interp create]");
+            i.eval_str(b"$c hide set");
+            // hidden `set` is gone from the child but invocable via invokehidden.
+            assert_eq!(i.eval_str(b"$c eval {set x 1}"), Code::Error);
+            assert_eq!(i.eval_str(b"$c hidden"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"set");
+            assert_eq!(i.eval_str(b"$c invokehidden set y 5"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"5");
+            i.eval_str(b"$c expose set");
+            assert_eq!(i.eval_str(b"$c eval {set z 9}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"9");
+            // `-safe` hides the host-touching commands it has.
+            i.eval_str(b"set s [interp create -safe]");
+            assert_eq!(
+                i.eval_str(b"expr {[lsearch [$s hidden] file] >= 0}"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"1");
+            i.eval_str(b"interp delete $c; interp delete $s");
         });
     }
 

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -77,6 +77,40 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     match obj_bytes(argv[1]).as_slice() {
         b"alias" => interp_alias(interp, argv),
         b"aliases" => interp_aliases(interp, argv),
+        b"create" => interp_create(interp, argv),
+        b"eval" => interp_eval(interp, argv),
+        b"delete" => interp_delete(interp, argv),
+        b"exists" => {
+            // `interp exists ?path?`: the current interp ("") always exists; a
+            // named one exists iff it's a child.
+            let exists = match argv.get(2) {
+                None => true,
+                Some(&a) => {
+                    let p = obj_bytes(a);
+                    p.is_empty() || interp.child_exists(&p)
+                }
+            };
+            interp.set_result_bytes(if exists { b"1" } else { b"0" });
+            Code::Ok
+        }
+        b"children" | b"slaves" => {
+            // Children of the current interp (a named sub-path is single-level).
+            let names = if argv
+                .get(2)
+                .map(|&a| obj_bytes(a))
+                .is_some_and(|p| !p.is_empty())
+            {
+                Vec::new()
+            } else {
+                interp.child_names()
+            };
+            let elems: Vec<*mut TclObj> = names.iter().map(|n| obj::new_string_bytes(n)).collect();
+            interp.set_result(list::new_list_obj(&elems));
+            for e in elems {
+                drop_fresh(e);
+            }
+            Code::Ok
+        }
         // Single-interp runtime: `issafe`/`exists ""` describe the one interp.
         b"issafe" => {
             interp.set_result_bytes(b"0");
@@ -89,6 +123,76 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_error(&m)
         }
     }
+}
+
+/// `interp create ?-safe? ?--? ?path?` — create a child interpreter, returning
+/// its name (auto-generated `interpN` when omitted). `-safe` is accepted but the
+/// sandbox is not yet enforced (a follow-up).
+fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let mut name: Option<Vec<u8>> = None;
+    let mut i = 2;
+    while i < argv.len() {
+        let a = obj_bytes(argv[i]);
+        match a.as_slice() {
+            b"-safe" => {}
+            b"--" => {
+                i += 1;
+                break;
+            }
+            _ => break,
+        }
+        i += 1;
+    }
+    if i < argv.len() {
+        let p = obj_bytes(argv[i]);
+        // Only single-level (simple) names are supported; a path list is not.
+        if interp.child_exists(&p) {
+            let mut m = b"interpreter named \"".to_vec();
+            m.extend_from_slice(&p);
+            m.extend_from_slice(b"\" already exists, cannot create");
+            return interp.set_error(&m);
+        }
+        name = Some(p);
+    }
+    let created = interp.create_child(name);
+    interp.set_result(obj::new_string_bytes(&created));
+    Code::Ok
+}
+
+/// `interp eval path arg ?arg ...?` — evaluate a script in a child interpreter.
+fn interp_eval(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(interp, b"interp eval path arg ?arg ...?");
+    }
+    let path = obj_bytes(argv[2]);
+    let mut script = Vec::new();
+    for (k, &a) in argv[3..].iter().enumerate() {
+        if k > 0 {
+            script.push(b' ');
+        }
+        script.extend_from_slice(&obj_bytes(a));
+    }
+    // `interp eval {} script` runs in the current interp; else in the child.
+    if path.is_empty() {
+        interp.eval_str(&script)
+    } else {
+        interp.eval_in_child(&path, &script)
+    }
+}
+
+/// `interp delete ?path ...?` — delete each named child interpreter.
+fn interp_delete(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    for &a in &argv[2..] {
+        let path = obj_bytes(a);
+        if path.is_empty() || !interp.delete_child(&path) {
+            let mut m = b"could not find interpreter \"".to_vec();
+            m.extend_from_slice(&path);
+            m.push(b'"');
+            return interp.set_error(&m);
+        }
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
 }
 
 /// `interp alias {} aliasName ?{} target ?arg ...??` — create / query / delete.
@@ -202,6 +306,41 @@ mod tests {
             counters::live_bufs()
         );
         assert_eq!(counters::double_free_count(), 0);
+    }
+
+    #[test]
+    fn child_interpreters() {
+        // `interp create`/`eval`/`exists`/`children`/`delete` + the child as a
+        // command (`$child eval …`). Verified vs tclsh 9.0.
+        leak_free(|i| {
+            assert_eq!(i.eval_str(b"interp create kid"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"kid");
+            assert_eq!(i.eval_str(b"interp exists kid"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"1");
+            // The child is isolated and addressable as a command.
+            i.eval_str(b"kid eval {set x 42; proc dbl n {expr {$n*2}}}");
+            assert_eq!(i.eval_str(b"kid eval {dbl $x}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"84");
+            // ... and via `interp eval`.
+            assert_eq!(i.eval_str(b"interp eval kid {set x}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"42");
+            // The parent doesn't see the child's variable.
+            assert_eq!(i.eval_str(b"info exists x"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"0");
+            assert_eq!(i.eval_str(b"interp children"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"kid");
+            // Children get the predefined globals.
+            assert_eq!(
+                i.eval_str(b"kid eval {set ::tcl_platform(platform)}"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"unix");
+            // Delete removes the child and its command.
+            assert_eq!(i.eval_str(b"interp delete kid"), Code::Ok);
+            assert_eq!(i.eval_str(b"interp exists kid"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"0");
+            assert_eq!(i.eval_str(b"kid eval {set x}"), Code::Error);
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_binary.rs
+++ b/runtime/rust/src/cmd_binary.rs
@@ -1,0 +1,702 @@
+//! `binary format` / `binary scan` (C ref `tclBinary.c`).
+//!
+//! Converts between Tcl values and binary byte strings via a format string of
+//! `<type><count>` fields. Implemented type codes (both directions):
+//!
+//! - `a`/`A` — bytes, null-/space-padded
+//! - `b`/`B` — binary-digit string (low-to-high / high-to-low within a byte)
+//! - `h`/`H` — hex-digit string (low / high nibble first)
+//! - `c` — 8-bit ints; `s`/`S`/`t`, `i`/`I`/`n`, `w`/`W`/`m` — 16/32/64-bit
+//!   ints (little / big / native endian); `f`/`r`/`R` 32-bit, `d`/`q`/`Q`
+//!   64-bit floats
+//! - `x` skip/zero, `X` back up, `@` absolute position
+//!
+//! `count` is a number or `*` (all); native endian is little (the wasm/x86
+//! target). Verified against tclsh 9.0. Unsigned scan modifiers and
+//! `binary encode/decode` are deferred.
+//!
+//! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use crate::interp::{new_string, obj_bytes, Code, Interp};
+use crate::obj::{self, TclObj};
+use crate::parse::split_list;
+
+/// Register `binary`.
+pub fn install(interp: &mut Interp) {
+    interp.register_builtin(b"binary", binary_cmd);
+}
+
+fn err(interp: &mut Interp, msg: &[u8]) -> Code {
+    interp.set_error(msg)
+}
+
+fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
+    let mut m = b"wrong # args: should be \"".to_vec();
+    m.extend_from_slice(usage);
+    m.push(b'"');
+    interp.set_error(&m)
+}
+
+fn binary_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 2 {
+        return wrong_args(interp, b"binary subcommand ?arg ...?");
+    }
+    match obj_bytes(argv[1]).as_slice() {
+        b"format" => binary_format(interp, argv),
+        b"scan" => binary_scan(interp, argv),
+        other => {
+            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
+            m.extend_from_slice(other);
+            m.extend_from_slice(b"\": must be decode, encode, format, or scan");
+            interp.set_error(&m)
+        }
+    }
+}
+
+/// Endianness of a multi-byte numeric field.
+#[derive(Clone, Copy)]
+enum End {
+    Little,
+    Big,
+}
+
+/// The count after a type code: an explicit number, `*` (all), or absent.
+enum Count {
+    Num(usize),
+    Star,
+    None,
+}
+
+/// Parse the optional count following a type char (advancing `i`).
+fn parse_count(fmt: &[u8], i: &mut usize) -> Count {
+    if fmt.get(*i) == Some(&b'*') {
+        *i += 1;
+        return Count::Star;
+    }
+    let start = *i;
+    let mut n: usize = 0;
+    while let Some(&c) = fmt.get(*i) {
+        if c.is_ascii_digit() {
+            n = n.saturating_mul(10).saturating_add((c - b'0') as usize);
+            *i += 1;
+        } else {
+            break;
+        }
+    }
+    if *i > start {
+        Count::Num(n)
+    } else {
+        Count::None
+    }
+}
+
+/// Parse a Tcl integer (optional sign + `0x`/`0o`/`0b`/decimal) to a wide int.
+fn parse_wide(b: &[u8]) -> Option<i64> {
+    let s = core::str::from_utf8(b).ok()?.trim();
+    let (neg, rest) = match s.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, s.strip_prefix('+').unwrap_or(s)),
+    };
+    let v: i128 = if let Some(h) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
+        i128::from_str_radix(h, 16).ok()?
+    } else if let Some(o) = rest.strip_prefix("0o").or_else(|| rest.strip_prefix("0O")) {
+        i128::from_str_radix(o, 8).ok()?
+    } else if let Some(bb) = rest.strip_prefix("0b").or_else(|| rest.strip_prefix("0B")) {
+        i128::from_str_radix(bb, 2).ok()?
+    } else {
+        rest.parse::<i128>().ok()?
+    };
+    Some((if neg { -v } else { v }) as i64)
+}
+
+// -- format ----------------------------------------------------------------
+
+/// Write `bytes` into `out` at `cur`, overwriting then extending; advance `cur`.
+fn put(out: &mut Vec<u8>, cur: &mut usize, bytes: &[u8]) {
+    for &b in bytes {
+        if *cur < out.len() {
+            out[*cur] = b;
+        } else {
+            out.push(b);
+        }
+        *cur += 1;
+    }
+}
+
+fn binary_format(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 3 {
+        return wrong_args(interp, b"binary format formatString ?arg ...?");
+    }
+    let fmt = obj_bytes(argv[2]);
+    let args = &argv[3..];
+    let mut ai = 0;
+    let mut out: Vec<u8> = Vec::new();
+    let mut cur = 0usize;
+    let mut i = 0;
+
+    macro_rules! next_arg {
+        () => {{
+            if ai >= args.len() {
+                return err(interp, b"not enough arguments for all format specifiers");
+            }
+            let a = obj_bytes(args[ai]);
+            ai += 1;
+            a
+        }};
+    }
+
+    while i < fmt.len() {
+        let ty = fmt[i];
+        if ty.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        i += 1;
+        let count = parse_count(&fmt, &mut i);
+        match ty {
+            b'a' | b'A' => {
+                let s = next_arg!();
+                let n = match count {
+                    Count::Star => s.len(),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                let pad = if ty == b'A' { b' ' } else { 0 };
+                let mut field = vec![pad; n];
+                let take = s.len().min(n);
+                field[..take].copy_from_slice(&s[..take]);
+                put(&mut out, &mut cur, &field);
+            }
+            b'b' | b'B' => {
+                let s = next_arg!();
+                let n = match count {
+                    Count::Star => s.len(),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                let bytes = pack_bits(&s, n, ty == b'B');
+                put(&mut out, &mut cur, &bytes);
+            }
+            b'h' | b'H' => {
+                let s = next_arg!();
+                let n = match count {
+                    Count::Star => s.len(),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                let bytes = pack_hex(&s, n, ty == b'H');
+                put(&mut out, &mut cur, &bytes);
+            }
+            b'c' | b's' | b'S' | b't' | b'i' | b'I' | b'n' | b'w' | b'W' | b'm' => {
+                let (size, end) = int_kind(ty);
+                let arg = next_arg!();
+                let elems = match split_list(&arg) {
+                    Ok(e) => e,
+                    Err(e) => return err(interp, e.message()),
+                };
+                let n = match count {
+                    Count::Star => elems.len(),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if elems.len() < n {
+                    return err(interp, b"number of elements in list does not match count");
+                }
+                for e in &elems[..n] {
+                    let Some(v) = parse_wide(e) else {
+                        let mut m = b"expected integer but got \"".to_vec();
+                        m.extend_from_slice(e);
+                        m.push(b'"');
+                        return err(interp, &m);
+                    };
+                    put(&mut out, &mut cur, &int_bytes(v, size, end));
+                }
+            }
+            b'f' | b'r' | b'R' | b'd' | b'q' | b'Q' => {
+                let (size, end) = float_kind(ty);
+                let arg = next_arg!();
+                let elems = match split_list(&arg) {
+                    Ok(e) => e,
+                    Err(e) => return err(interp, e.message()),
+                };
+                let n = match count {
+                    Count::Star => elems.len(),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if elems.len() < n {
+                    return err(interp, b"number of elements in list does not match count");
+                }
+                for e in &elems[..n] {
+                    let Some(v) = core::str::from_utf8(e)
+                        .ok()
+                        .and_then(|s| s.trim().parse::<f64>().ok())
+                    else {
+                        let mut m = b"expected floating-point number but got \"".to_vec();
+                        m.extend_from_slice(e);
+                        m.push(b'"');
+                        return err(interp, &m);
+                    };
+                    put(&mut out, &mut cur, &float_bytes(v, size, end));
+                }
+            }
+            b'x' => {
+                let n = match count {
+                    Count::Num(n) => n,
+                    Count::Star | Count::None => 1,
+                };
+                let zeros = vec![0u8; n];
+                put(&mut out, &mut cur, &zeros);
+            }
+            b'X' => {
+                let n = match count {
+                    Count::Star => cur,
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                cur = cur.saturating_sub(n);
+            }
+            b'@' => {
+                let n = match count {
+                    Count::Star => out.len(),
+                    Count::Num(n) => n,
+                    Count::None => 0,
+                };
+                if n > out.len() {
+                    out.resize(n, 0);
+                }
+                cur = n;
+            }
+            _ => {
+                let mut m = b"bad field specifier \"".to_vec();
+                m.push(ty);
+                m.push(b'"');
+                return err(interp, &m);
+            }
+        }
+    }
+    interp.set_result_bytes(&out);
+    Code::Ok
+}
+
+/// `(byte size, endianness)` for an integer type code.
+fn int_kind(ty: u8) -> (usize, End) {
+    match ty {
+        b'c' => (1, End::Little),
+        b's' => (2, End::Little),
+        b'S' => (2, End::Big),
+        b't' => (2, End::Little), // native = little
+        b'i' => (4, End::Little),
+        b'I' => (4, End::Big),
+        b'n' => (4, End::Little),
+        b'w' => (8, End::Little),
+        b'W' => (8, End::Big),
+        _ => (8, End::Little), // m, native
+    }
+}
+
+/// `(byte size, endianness)` for a float type code.
+fn float_kind(ty: u8) -> (usize, End) {
+    match ty {
+        b'f' | b'r' => (4, End::Little),
+        b'R' => (4, End::Big),
+        b'd' | b'q' => (8, End::Little),
+        _ => (8, End::Big), // Q
+    }
+}
+
+/// `v`'s low `size` bytes in `end` order.
+fn int_bytes(v: i64, size: usize, end: End) -> Vec<u8> {
+    let le = (v as u64).to_le_bytes();
+    let mut b = le[..size].to_vec();
+    if matches!(end, End::Big) {
+        b.reverse();
+    }
+    b
+}
+
+/// `v` as an IEEE-754 float of `size` bytes in `end` order.
+fn float_bytes(v: f64, size: usize, end: End) -> Vec<u8> {
+    let mut b = if size == 4 {
+        (v as f32).to_le_bytes().to_vec()
+    } else {
+        v.to_le_bytes().to_vec()
+    };
+    if matches!(end, End::Big) {
+        b.reverse();
+    }
+    b
+}
+
+/// Pack `n` binary digits of `s` into ceil(n/8) bytes. `high_first` (`B`) fills
+/// each byte MSB→LSB; `b` fills LSB→MSB.
+fn pack_bits(s: &[u8], n: usize, high_first: bool) -> Vec<u8> {
+    let mut out = vec![0u8; n.div_ceil(8)];
+    for k in 0..n {
+        let bit = matches!(s.get(k), Some(b'1'));
+        if bit {
+            let byte = k / 8;
+            let pos = k % 8;
+            out[byte] |= if high_first { 0x80 >> pos } else { 1 << pos };
+        }
+    }
+    out
+}
+
+/// Pack `n` hex digits of `s` into ceil(n/2) bytes. `high_first` (`H`) places
+/// the first digit in the high nibble; `h` in the low nibble.
+fn pack_hex(s: &[u8], n: usize, high_first: bool) -> Vec<u8> {
+    let mut out = vec![0u8; n.div_ceil(2)];
+    for k in 0..n {
+        let nib = s.get(k).map_or(0, |&c| hex_val(c));
+        let byte = k / 2;
+        let high = (k % 2 == 0) == high_first;
+        out[byte] |= if high { nib << 4 } else { nib };
+    }
+    out
+}
+
+fn hex_val(c: u8) -> u8 {
+    match c {
+        b'0'..=b'9' => c - b'0',
+        b'a'..=b'f' => c - b'a' + 10,
+        b'A'..=b'F' => c - b'A' + 10,
+        _ => 0,
+    }
+}
+
+// -- scan ------------------------------------------------------------------
+
+fn binary_scan(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(interp, b"binary scan string formatString ?varName ...?");
+    }
+    let data = obj_bytes(argv[2]);
+    let fmt = obj_bytes(argv[3]);
+    let vars = &argv[4..];
+    let mut vi = 0;
+    let mut cur = 0usize;
+    let mut nconv = 0i64;
+    let mut i = 0;
+
+    // Assign `value` to the next varName; on failure, propagate the error.
+    macro_rules! store {
+        ($value:expr) => {{
+            if vi >= vars.len() {
+                return err(interp, b"not enough arguments for all format specifiers");
+            }
+            let name = obj_bytes(vars[vi]);
+            vi += 1;
+            let o = new_string(&$value);
+            if interp.var_set(&name, o).is_err() {
+                crate::interp::drop_fresh(o);
+                let mut m = b"can't set \"".to_vec();
+                m.extend_from_slice(&name);
+                m.extend_from_slice(b"\": variable is array");
+                return interp.set_error(&m);
+            }
+        }};
+    }
+
+    while i < fmt.len() {
+        let ty = fmt[i];
+        if ty.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        i += 1;
+        let count = parse_count(&fmt, &mut i);
+        match ty {
+            b'a' | b'A' => {
+                let n = match count {
+                    Count::Star => data.len().saturating_sub(cur),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if cur + n > data.len() {
+                    break;
+                }
+                let mut s = data[cur..cur + n].to_vec();
+                if ty == b'A' {
+                    // `A` strips trailing spaces and nulls.
+                    while matches!(s.last(), Some(b' ') | Some(0)) {
+                        s.pop();
+                    }
+                }
+                cur += n;
+                store!(s);
+                nconv += 1;
+            }
+            b'b' | b'B' => {
+                let n = match count {
+                    Count::Star => data.len().saturating_sub(cur).saturating_mul(8),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if cur + n.div_ceil(8) > data.len() {
+                    break;
+                }
+                let s = unpack_bits(&data[cur..], n, ty == b'B');
+                cur += n.div_ceil(8);
+                store!(s);
+                nconv += 1;
+            }
+            b'h' | b'H' => {
+                let n = match count {
+                    Count::Star => data.len().saturating_sub(cur).saturating_mul(2),
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if cur + n.div_ceil(2) > data.len() {
+                    break;
+                }
+                let s = unpack_hex(&data[cur..], n, ty == b'H');
+                cur += n.div_ceil(2);
+                store!(s);
+                nconv += 1;
+            }
+            b'c' | b's' | b'S' | b't' | b'i' | b'I' | b'n' | b'w' | b'W' | b'm' => {
+                let (size, end) = int_kind(ty);
+                let n = match count {
+                    Count::Star => data.len().saturating_sub(cur) / size,
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if cur + n * size > data.len() {
+                    break;
+                }
+                let mut vals: Vec<Vec<u8>> = Vec::with_capacity(n);
+                for k in 0..n {
+                    let off = cur + k * size;
+                    let v = read_int(&data[off..off + size], size, end);
+                    vals.push(v.to_string().into_bytes());
+                }
+                cur += n * size;
+                let result = if matches!(count, Count::None) {
+                    vals.into_iter().next().unwrap_or_default()
+                } else {
+                    join_list(&vals)
+                };
+                store!(result);
+                nconv += 1;
+            }
+            b'f' | b'r' | b'R' | b'd' | b'q' | b'Q' => {
+                let (size, end) = float_kind(ty);
+                let n = match count {
+                    Count::Star => data.len().saturating_sub(cur) / size,
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                if cur + n * size > data.len() {
+                    break;
+                }
+                let mut vals: Vec<Vec<u8>> = Vec::with_capacity(n);
+                for k in 0..n {
+                    let off = cur + k * size;
+                    let v = read_float(&data[off..off + size], size, end);
+                    vals.push(tcl_syntax::number::format_double(v).into_bytes());
+                }
+                cur += n * size;
+                let result = if matches!(count, Count::None) {
+                    vals.into_iter().next().unwrap_or_default()
+                } else {
+                    join_list(&vals)
+                };
+                store!(result);
+                nconv += 1;
+            }
+            b'x' => {
+                let n = match count {
+                    Count::Num(n) => n,
+                    Count::Star | Count::None => 1,
+                };
+                cur = (cur + n).min(data.len());
+            }
+            b'X' => {
+                let n = match count {
+                    Count::Star => cur,
+                    Count::Num(n) => n,
+                    Count::None => 1,
+                };
+                cur = cur.saturating_sub(n);
+            }
+            b'@' => {
+                let n = match count {
+                    Count::Star => data.len(),
+                    Count::Num(n) => n,
+                    Count::None => 0,
+                };
+                cur = n.min(data.len());
+            }
+            _ => {
+                let mut m = b"bad field specifier \"".to_vec();
+                m.push(ty);
+                m.push(b'"');
+                return err(interp, &m);
+            }
+        }
+    }
+    interp.set_result(obj::new_wide_int_obj(nconv));
+    Code::Ok
+}
+
+/// Read `size` bytes as a sign-extended integer in `end` order.
+fn read_int(b: &[u8], size: usize, end: End) -> i64 {
+    let mut buf = [0u8; 8];
+    if matches!(end, End::Big) {
+        for k in 0..size {
+            buf[k] = b[size - 1 - k];
+        }
+    } else {
+        buf[..size].copy_from_slice(&b[..size]);
+    }
+    let u = u64::from_le_bytes(buf);
+    // Sign-extend from `size` bytes.
+    let bits = size * 8;
+    if bits < 64 && (u >> (bits - 1)) & 1 == 1 {
+        (u | (!0u64 << bits)) as i64
+    } else {
+        u as i64
+    }
+}
+
+fn read_float(b: &[u8], size: usize, end: End) -> f64 {
+    let mut buf = [0u8; 8];
+    let n = size;
+    if matches!(end, End::Big) {
+        for k in 0..n {
+            buf[k] = b[n - 1 - k];
+        }
+    } else {
+        buf[..n].copy_from_slice(&b[..n]);
+    }
+    if size == 4 {
+        f32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as f64
+    } else {
+        f64::from_le_bytes(buf)
+    }
+}
+
+/// Unpack `n` bits from `data` into a binary-digit string.
+fn unpack_bits(data: &[u8], n: usize, high_first: bool) -> Vec<u8> {
+    let mut s = Vec::with_capacity(n);
+    for k in 0..n {
+        let byte = data.get(k / 8).copied().unwrap_or(0);
+        let pos = k % 8;
+        let bit = if high_first {
+            (byte >> (7 - pos)) & 1
+        } else {
+            (byte >> pos) & 1
+        };
+        s.push(b'0' + bit);
+    }
+    s
+}
+
+/// Unpack `n` hex digits from `data`.
+fn unpack_hex(data: &[u8], n: usize, high_first: bool) -> Vec<u8> {
+    let mut s = Vec::with_capacity(n);
+    for k in 0..n {
+        let byte = data.get(k / 2).copied().unwrap_or(0);
+        let nib = if (k % 2 == 0) == high_first {
+            byte >> 4
+        } else {
+            byte & 0x0f
+        };
+        s.push(b"0123456789abcdef"[nib as usize]);
+    }
+    s
+}
+
+/// Join scanned values into a Tcl list (each is a number/string with no special
+/// chars, so a space-join is a valid list).
+fn join_list(vals: &[Vec<u8>]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (k, v) in vals.iter().enumerate() {
+        if k > 0 {
+            out.push(b' ');
+        }
+        out.extend_from_slice(v);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::counters;
+    use crate::interp::{Code, Interp};
+
+    fn leak_free(body: impl FnOnce(&mut Interp)) {
+        counters::reset();
+        {
+            let mut interp = Interp::new();
+            body(&mut interp);
+        }
+        assert_eq!(counters::finalize(), 0, "residual objs/bufs");
+        assert_eq!(counters::double_free_count(), 0);
+    }
+
+    fn ok(i: &mut Interp, src: &[u8]) -> Vec<u8> {
+        assert_eq!(
+            i.eval_str(src),
+            Code::Ok,
+            "eval {:?} -> {:?}",
+            String::from_utf8_lossy(src),
+            String::from_utf8_lossy(&i.result_bytes())
+        );
+        i.result_bytes()
+    }
+
+    #[test]
+    fn format_and_scan_roundtrip() {
+        // Hex-dump helper round-trips through `binary scan H*`.
+        leak_free(|i| {
+            // format → hex (verified vs tclsh 9.0)
+            i.eval_str(b"binary scan [binary format a5 foo] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"666f6f0000");
+            i.eval_str(b"binary scan [binary format A5 foo] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"666f6f2020");
+            i.eval_str(b"binary scan [binary format B8 01001101] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"4d");
+            i.eval_str(b"binary scan [binary format b8 01001101] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"b2");
+            i.eval_str(b"binary scan [binary format H2 4d] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"4d");
+            i.eval_str(b"binary scan [binary format s 258] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"0201");
+            i.eval_str(b"binary scan [binary format I 258] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"00000102");
+            i.eval_str(b"binary scan [binary format c3 {1 2 3}] H* h; set ::h $h");
+            assert_eq!(ok(i, b"set ::h"), b"010203");
+            i.eval_str(b"unset ::h");
+        });
+    }
+
+    #[test]
+    fn scan_values_and_count() {
+        leak_free(|i| {
+            // single int (no count) → the value directly
+            assert_eq!(
+                ok(i, b"binary scan [binary format i 258] i v; set v"),
+                b"258"
+            );
+            // count → a list
+            assert_eq!(
+                ok(i, b"binary scan [binary format c3 {1 2 3}] c3 v; set v"),
+                b"1 2 3"
+            );
+            // signed 8-bit: 0xff → -1
+            assert_eq!(
+                ok(i, b"binary scan [binary format c 255] c v; set v"),
+                b"-1"
+            );
+            // return value = number of conversions
+            assert_eq!(ok(i, b"binary scan abc a2a1 x y"), b"2");
+            assert_eq!(ok(i, b"set x"), b"ab");
+            // `a*` takes the rest
+            assert_eq!(ok(i, b"binary scan abcdef a* v; set v"), b"abcdef");
+            i.eval_str(b"unset -nocomplain v x y");
+        });
+    }
+}

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -96,6 +96,31 @@ fn no_channel(interp: &mut Interp, id: &[u8]) -> Code {
     interp.set_error(&m)
 }
 
+/// A channel operation's outcome, produced *inside* the `channels` borrow scope
+/// and translated to a result/error *after* the borrow drops — the `RefMut`
+/// guard holds a shared borrow of `interp`, so its methods can't be called while
+/// the channel state is borrowed.
+enum ChanOp {
+    Bytes(Vec<u8>),
+    NoChannel,
+    WriteOnly,
+    Io(std::io::Error),
+}
+
+/// Translate a [`ChanOp`] into a completion code (the channel was addressed by
+/// `id`), after the `channels` borrow has been released.
+fn finish_chan(interp: &mut Interp, id: &[u8], op: ChanOp) -> Code {
+    match op {
+        ChanOp::Bytes(b) => {
+            interp.set_result_bytes(&b);
+            Code::Ok
+        }
+        ChanOp::NoChannel => no_channel(interp, id),
+        ChanOp::WriteOnly => interp.set_error(b"channel is write only"),
+        ChanOp::Io(e) => io_error(interp, &e),
+    }
+}
+
 fn io_error(interp: &mut Interp, e: &std::io::Error) -> Code {
     use std::io::ErrorKind;
     interp.set_error(match e.kind() {
@@ -117,7 +142,8 @@ fn open_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Ok(path_s) = core::str::from_utf8(&path) else {
         return interp.set_error(b"invalid file name");
     };
-    match interp.channels.open(path_s, &mode) {
+    let opened = interp.channels.borrow_mut().open(path_s, &mode);
+    match opened {
         Ok(id) => {
             interp.set_result_bytes(&id);
             Code::Ok
@@ -139,7 +165,8 @@ fn close_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"close channelId");
     }
     let id = obj_bytes(argv[1]);
-    if let Some(mut st) = interp.channels.map.remove(&id) {
+    let removed = interp.channels.borrow_mut().map.remove(&id);
+    if let Some(mut st) = removed {
         if let Some(w) = st.writer.as_mut() {
             let _ = w.flush();
         }
@@ -167,29 +194,33 @@ fn read_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             .ok()
             .and_then(|s| s.trim().parse::<usize>().ok())
     });
-    let Some(st) = interp.channels.map.get_mut(&id) else {
-        return no_channel(interp, &id);
-    };
-    let Some(reader) = st.reader.as_mut() else {
-        return interp.set_error(b"channel is write only");
-    };
-    let mut buf = Vec::new();
-    let res = match nchars {
-        Some(n) => {
-            let mut limited = reader.take(n as u64);
-            limited.read_to_end(&mut buf)
+    let op = {
+        let mut channels = interp.channels.borrow_mut();
+        match channels.map.get_mut(&id) {
+            None => ChanOp::NoChannel,
+            Some(st) => match st.reader.as_mut() {
+                None => ChanOp::WriteOnly,
+                Some(reader) => {
+                    let mut buf = Vec::new();
+                    let res = match nchars {
+                        Some(n) => reader.take(n as u64).read_to_end(&mut buf),
+                        None => reader.read_to_end(&mut buf),
+                    };
+                    match res {
+                        Err(e) => ChanOp::Io(e),
+                        Ok(_) => {
+                            st.eof = nchars.is_none() || buf.is_empty();
+                            if nonewline && buf.last() == Some(&b'\n') {
+                                buf.pop();
+                            }
+                            ChanOp::Bytes(buf)
+                        }
+                    }
+                }
+            },
         }
-        None => reader.read_to_end(&mut buf),
     };
-    if let Err(e) = res {
-        return io_error(interp, &e);
-    }
-    st.eof = nchars.is_none() || buf.is_empty();
-    if nonewline && buf.last() == Some(&b'\n') {
-        buf.pop();
-    }
-    interp.set_result_bytes(&buf);
-    Code::Ok
+    finish_chan(interp, &id, op)
 }
 
 fn gets_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -197,26 +228,46 @@ fn gets_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"gets channelId ?varName?");
     }
     let id = obj_bytes(argv[1]);
-    let Some(st) = interp.channels.map.get_mut(&id) else {
-        return no_channel(interp, &id);
-    };
-    let Some(reader) = st.reader.as_mut() else {
-        return interp.set_error(b"channel is write only");
-    };
-    let mut line = Vec::new();
-    let n = match reader.read_until(b'\n', &mut line) {
-        Ok(n) => n,
-        Err(e) => return io_error(interp, &e),
-    };
-    if n == 0 {
-        st.eof = true;
+    // Read the line inside the borrow scope; `n == usize::MAX` flags EOF/no-line.
+    enum Gets {
+        Line(Vec<u8>, usize),
+        NoChannel,
+        WriteOnly,
+        Io(std::io::Error),
     }
-    if line.last() == Some(&b'\n') {
-        line.pop();
-        if line.last() == Some(&b'\r') {
-            line.pop();
+    let g = {
+        let mut channels = interp.channels.borrow_mut();
+        match channels.map.get_mut(&id) {
+            None => Gets::NoChannel,
+            Some(st) => match st.reader.as_mut() {
+                None => Gets::WriteOnly,
+                Some(reader) => {
+                    let mut line = Vec::new();
+                    match reader.read_until(b'\n', &mut line) {
+                        Err(e) => Gets::Io(e),
+                        Ok(n) => {
+                            if n == 0 {
+                                st.eof = true;
+                            }
+                            if line.last() == Some(&b'\n') {
+                                line.pop();
+                                if line.last() == Some(&b'\r') {
+                                    line.pop();
+                                }
+                            }
+                            Gets::Line(line, n)
+                        }
+                    }
+                }
+            },
         }
-    }
+    };
+    let (line, n) = match g {
+        Gets::NoChannel => return no_channel(interp, &id),
+        Gets::WriteOnly => return interp.set_error(b"channel is write only"),
+        Gets::Io(e) => return io_error(interp, &e),
+        Gets::Line(line, n) => (line, n),
+    };
     if argv.len() == 3 {
         // gets chan var → set var to the line, return its length (or -1 at EOF).
         let var = obj_bytes(argv[2]);
@@ -246,24 +297,27 @@ fn puts_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         [ch, s] => (obj_bytes(*ch), obj_bytes(*s)),
         _ => return wrong_args(interp, usage),
     };
-    let result = match chan.as_slice() {
-        b"stdout" => write_to(&mut std::io::stdout(), &string, newline),
-        b"stderr" => write_to(&mut std::io::stderr(), &string, newline),
-        _ => match interp
-            .channels
-            .map
-            .get_mut(&chan)
-            .and_then(|s| s.writer.as_mut())
-        {
-            Some(w) => write_to(w, &string, newline),
-            None => return no_channel(interp, &chan),
-        },
+    // `None` ⇒ no such channel; `Some(Err)` ⇒ write failed.
+    let result: Option<std::io::Result<()>> = match chan.as_slice() {
+        b"stdout" => Some(write_to(&mut std::io::stdout(), &string, newline)),
+        b"stderr" => Some(write_to(&mut std::io::stderr(), &string, newline)),
+        _ => {
+            let mut channels = interp.channels.borrow_mut();
+            channels
+                .map
+                .get_mut(&chan)
+                .and_then(|s| s.writer.as_mut())
+                .map(|w| write_to(w, &string, newline))
+        }
     };
-    if result.is_err() {
-        return interp.set_error(b"error writing to channel");
+    match result {
+        None => no_channel(interp, &chan),
+        Some(Err(_)) => interp.set_error(b"error writing to channel"),
+        Some(Ok(())) => {
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
     }
-    interp.set_result_bytes(b"");
-    Code::Ok
 }
 
 fn write_to(w: &mut impl Write, bytes: &[u8], newline: bool) -> std::io::Result<()> {
@@ -286,14 +340,23 @@ fn flush_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"stderr" => {
             let _ = std::io::stderr().flush();
         }
-        _ => match interp.channels.map.get_mut(&id) {
-            Some(st) => {
-                if let Some(w) = st.writer.as_mut() {
-                    let _ = w.flush();
+        _ => {
+            let found = {
+                let mut channels = interp.channels.borrow_mut();
+                match channels.map.get_mut(&id) {
+                    Some(st) => {
+                        if let Some(w) = st.writer.as_mut() {
+                            let _ = w.flush();
+                        }
+                        true
+                    }
+                    None => false,
                 }
+            };
+            if !found {
+                return no_channel(interp, &id);
             }
-            None => return no_channel(interp, &id),
-        },
+        }
     }
     interp.set_result_bytes(b"");
     Code::Ok
@@ -304,9 +367,10 @@ fn eof_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"eof channelId");
     }
     let id = obj_bytes(argv[1]);
-    match interp.channels.map.get(&id) {
-        Some(st) => {
-            interp.set_result_bytes(if st.eof { b"1" } else { b"0" });
+    let eof = interp.channels.borrow().map.get(&id).map(|st| st.eof);
+    match eof {
+        Some(eof) => {
+            interp.set_result_bytes(if eof { b"1" } else { b"0" });
             Code::Ok
         }
         None => no_channel(interp, &id),
@@ -323,7 +387,7 @@ fn fconfigure_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if id != b"stdout"
         && id != b"stderr"
         && id != b"stdin"
-        && !interp.channels.map.contains_key(&id)
+        && !interp.channels.borrow().map.contains_key(&id)
     {
         return no_channel(interp, &id);
     }
@@ -360,24 +424,29 @@ fn seek_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"end" => SeekFrom::End(offset),
         _ => return interp.set_error(b"bad origin: must be start, current, or end"),
     };
-    let Some(st) = interp.channels.map.get_mut(&id) else {
-        return no_channel(interp, &id);
-    };
-    let r = if let Some(rd) = st.reader.as_mut() {
-        rd.seek(from)
-    } else if let Some(w) = st.writer.as_mut() {
-        w.seek(from)
-    } else {
-        Ok(0)
-    };
-    match r {
-        Ok(_) => {
-            st.eof = false;
-            interp.set_result_bytes(b"");
-            Code::Ok
+    let op = {
+        let mut channels = interp.channels.borrow_mut();
+        match channels.map.get_mut(&id) {
+            None => ChanOp::NoChannel,
+            Some(st) => {
+                let r = if let Some(rd) = st.reader.as_mut() {
+                    rd.seek(from)
+                } else if let Some(w) = st.writer.as_mut() {
+                    w.seek(from)
+                } else {
+                    Ok(0)
+                };
+                match r {
+                    Ok(_) => {
+                        st.eof = false;
+                        ChanOp::Bytes(Vec::new())
+                    }
+                    Err(e) => ChanOp::Io(e),
+                }
+            }
         }
-        Err(e) => io_error(interp, &e),
-    }
+    };
+    finish_chan(interp, &id, op)
 }
 
 fn tell_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -386,18 +455,26 @@ fn tell_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"tell channelId");
     }
     let id = obj_bytes(argv[1]);
-    let Some(st) = interp.channels.map.get_mut(&id) else {
-        return no_channel(interp, &id);
+    let pos = {
+        let mut channels = interp.channels.borrow_mut();
+        match channels.map.get_mut(&id) {
+            None => None,
+            Some(st) => Some(if let Some(rd) = st.reader.as_mut() {
+                rd.stream_position().unwrap_or(0)
+            } else if let Some(w) = st.writer.as_mut() {
+                w.stream_position().unwrap_or(0)
+            } else {
+                0
+            }),
+        }
     };
-    let pos = if let Some(rd) = st.reader.as_mut() {
-        rd.stream_position().unwrap_or(0)
-    } else if let Some(w) = st.writer.as_mut() {
-        w.stream_position().unwrap_or(0)
-    } else {
-        0
-    };
-    interp.set_result_bytes(pos.to_string().as_bytes());
-    Code::Ok
+    match pos {
+        Some(pos) => {
+            interp.set_result_bytes(pos.to_string().as_bytes());
+            Code::Ok
+        }
+        None => no_channel(interp, &id),
+    }
 }
 
 #[cfg(test)]

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -219,6 +219,19 @@ fn foreach(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         match interp.eval_str(&body) {
             Code::Ok | Code::Continue => {}
             Code::Break => break,
+            Code::Error => {
+                // `("foreach" body line N)` — only at top level. Tcl inlines
+                // `foreach` when it compiles the enclosing script (a proc body),
+                // so no body-frame appears there; an uncompiled top-level
+                // `foreach` runs its command form, which does add the frame.
+                // (`if`/`while`/`for` are always inlined → never a frame.) A
+                // tree-walker has no bytecode, so `!in_proc()` approximates the
+                // compilation boundary — matches tclsh 9.0 for both cases.
+                if !interp.in_proc() {
+                    interp.append_body_frame(b"foreach");
+                }
+                return Code::Error;
+            }
             other => return other,
         }
     }

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -33,14 +33,6 @@ fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
     interp.set_error(&m)
 }
 
-/// Set a global variable (`::name`) to `bytes` (for `::errorInfo`/`::errorCode`).
-fn set_global(interp: &mut Interp, name: &[u8], bytes: &[u8]) {
-    let o = new_string(bytes);
-    if interp.var_set(name, o).is_err() {
-        drop_fresh(o);
-    }
-}
-
 // -- catch -----------------------------------------------------------------
 
 /// `catch script ?resultVarName? ?optionsVarName?` — evaluate `script`, trap any
@@ -70,6 +62,12 @@ fn catch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             return cant_set(interp, &name);
         }
     }
+    // The error is now caught: publish the accumulated trace to the
+    // `::errorInfo`/`::errorCode` globals (so a later `set ::errorInfo` reads it)
+    // and reset the accumulator for the next error.
+    if code == Code::Error {
+        interp.publish_and_reset_error();
+    }
     interp.set_result_bytes(code.as_int().to_string().as_bytes());
     Code::Ok
 }
@@ -82,7 +80,8 @@ fn cant_set(interp: &mut Interp, name: &[u8]) -> Code {
 }
 
 /// Build `catch`'s `-options` dict: `-code N -level 0` (+ `-errorcode`/
-/// `-errorinfo` from the globals on an error). Returns a fresh (`rc 0`) dict.
+/// `-errorinfo` from the live error accumulator on an error). Returns a fresh
+/// (`rc 0`) dict.
 fn build_options(interp: &mut Interp, code: Code) -> *mut TclObj {
     let code_str = code.as_int().to_string();
     let mut pairs: Vec<(*mut TclObj, *mut TclObj)> = vec![
@@ -90,40 +89,42 @@ fn build_options(interp: &mut Interp, code: Code) -> *mut TclObj {
         (new_string(b"-level"), new_string(b"0")),
     ];
     if code == Code::Error {
-        if let Some(ec) = interp.var_get(b"::errorCode") {
-            pairs.push((new_string(b"-errorcode"), ec));
-        }
-        if let Some(ei) = interp.var_get(b"::errorInfo") {
-            pairs.push((new_string(b"-errorinfo"), ei));
-        }
+        // The full accumulated trace + code, not the (deferred) globals.
+        pairs.push((new_string(b"-errorcode"), new_string(&interp.error_code())));
+        pairs.push((new_string(b"-errorinfo"), new_string(&interp.error_info())));
     }
     dict::new_dict_obj(&pairs)
 }
 
 // -- error -----------------------------------------------------------------
 
-/// `error message ?errorInfo? ?errorCode?` — raise an error, stamping
-/// `::errorInfo` (explicit info, else the message) and `::errorCode` (else
-/// `NONE`).
+/// `error message ?errorInfo? ?errorCode?` — raise an error. With an explicit
+/// non-empty `errorInfo`, the trace is pre-seeded with it and the `error`
+/// command itself is **not** re-logged (`ERR_ALREADY_LOGGED`); otherwise the
+/// `while executing` / `invoked from within` trace accumulates as the error
+/// unwinds. `errorCode` defaults to `NONE`. (`tclProc.c` `Tcl_ErrorObjCmd`.)
 fn error_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 || argv.len() > 4 {
         return wrong_args(interp, b"error message ?errorInfo? ?errorCode?");
     }
-    let info = if argv.len() >= 3 {
-        obj_bytes(argv[2])
-    } else {
-        obj_bytes(argv[1])
-    };
     let ecode = if argv.len() == 4 {
         obj_bytes(argv[3])
     } else {
         b"NONE".to_vec()
     };
-    set_global(interp, b"::errorInfo", &info);
-    set_global(interp, b"::errorCode", &ecode);
-    // The result is the message.
-    interp.set_result(argv[1]);
-    Code::Error
+    // An empty explicit info is treated as absent (C: zero-length info arg).
+    let info = if argv.len() >= 3 {
+        obj_bytes(argv[2])
+    } else {
+        Vec::new()
+    };
+    let msg = obj_bytes(argv[1]);
+    if info.is_empty() {
+        interp.set_result(argv[1]);
+        interp.set_error_state(&ecode)
+    } else {
+        interp.raise_with_info(&msg, &info, &ecode)
+    }
 }
 
 // -- try / throw -----------------------------------------------------------
@@ -222,10 +223,11 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // Run the body, snapshotting its completion code, result, and -errorcode.
     let body_code = interp.eval_str(&body);
     let body_result = interp.result_bytes();
-    let errorcode = interp
-        .var_get(b"::errorCode")
-        .map(obj_bytes)
-        .unwrap_or_default();
+    let errorcode = if body_code == Code::Error {
+        interp.error_code()
+    } else {
+        Vec::new()
+    };
 
     // Locate the first matching handler.
     let mut outcome_code = body_code;
@@ -268,6 +270,11 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 return cant_set(interp, ov);
             }
         }
+        // The body's error is now handled: publish + reset before the handler
+        // runs (which starts its own error state if it throws).
+        if body_code == Code::Error {
+            interp.publish_and_reset_error();
+        }
         outcome_code = interp.eval_str(script);
         outcome_result = interp.result_bytes();
         break;
@@ -296,11 +303,10 @@ fn throw_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(parts) if !parts.is_empty() => {}
         _ => return interp.set_error(b"type must be non-empty list"),
     }
-    let msg = obj_bytes(argv[2]);
-    set_global(interp, b"::errorInfo", &msg);
-    set_global(interp, b"::errorCode", &ecode);
     interp.set_result(argv[2]);
-    Code::Error
+    // Like `return -code error -errorcode $type $msg`: set the code, let the
+    // `while executing`/`invoked from within` trace accumulate as it unwinds.
+    interp.set_error_state(&ecode)
 }
 
 #[cfg(test)]
@@ -356,14 +362,95 @@ mod tests {
     #[test]
     fn error_stamps_globals() {
         leak_free(|i| {
+            // A bare `error` with no info accumulates the source trace as it
+            // unwinds (verified byte-for-byte vs tclsh 9.0).
             assert_eq!(run(i, b"catch {error oops}"), b"1");
             assert_eq!(run(i, b"set ::errorCode"), b"NONE");
-            assert_eq!(run(i, b"set ::errorInfo"), b"oops");
-            // explicit info + code.
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"oops\n    while executing\n\"error oops\""
+            );
+            // explicit info + code: the info is the trace verbatim (the `error`
+            // command itself is not re-logged — ERR_ALREADY_LOGGED).
             assert_eq!(run(i, b"catch {error msg myinfo MYCODE}"), b"1");
             assert_eq!(run(i, b"set ::errorInfo"), b"myinfo");
             assert_eq!(run(i, b"set ::errorCode"), b"MYCODE");
             i.eval_str(b"unset ::errorInfo ::errorCode");
+        });
+    }
+
+    /// The incremental `::errorInfo` stack trace (`while executing` / `invoked
+    /// from within` / `(procedure "x" line N)` …), every expected string
+    /// captured from real tclsh 9.0. See `proc-call-and-stack-traces.md` PC-4.
+    #[test]
+    fn error_info_stack_traces() {
+        leak_free(|i| {
+            // The worked example: proc body error → proc frame → call frame.
+            run(i, b"proc p {} { error foo }");
+            assert_eq!(i.eval_str(b"p"), Code::Error);
+            assert_eq!(
+                i.var_get(b"::errorInfo").map(crate::interp::obj_bytes),
+                Some(
+                    b"foo\n    while executing\n\"error foo \"\n    (procedure \"p\" line 1)\n    invoked from within\n\"p\""
+                        .to_vec()
+                )
+            );
+            // Multi-line body: the proc frame cites the body-relative line (3).
+            run(i, b"proc q {} {\n    set x 1\n    error boom\n}");
+            i.eval_str(b"catch q");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"boom\n    while executing\n\"error boom\"\n    (procedure \"q\" line 3)\n    invoked from within\n\"q\""
+            );
+            // Nested command substitution: the `[inner]` subst is logged, the
+            // enclosing `set y [inner]` is suppressed.
+            run(i, b"proc inner {} { error deep }");
+            run(i, b"proc outer {} { set y [inner] }");
+            i.eval_str(b"catch outer");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"deep\n    while executing\n\"error deep \"\n    (procedure \"inner\" line 1)\n    invoked from within\n\"inner\"\n    (procedure \"outer\" line 1)\n    invoked from within\n\"outer\""
+            );
+            // apply → a `(lambda term "..." line N)` frame.
+            i.eval_str(b"catch { apply {{} { error fromLambda }} }");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"fromLambda\n    while executing\n\"error fromLambda \"\n    (lambda term \"{} { error fromLambda }\" line 1)\n    invoked from within\n\"apply {{} { error fromLambda }} \""
+            );
+            i.eval_str(b"unset -nocomplain ::errorInfo ::errorCode x y");
+        });
+    }
+
+    /// `eval`/`uplevel`/`foreach` add a `("<cmd>" body line N)` frame; inline
+    /// `if`/`while`/`for`/`switch` do not (tclsh 9.0).
+    #[test]
+    fn body_frame_commands() {
+        leak_free(|i| {
+            i.eval_str(b"catch { eval { error e } }");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"e\n    while executing\n\"error e \"\n    (\"eval\" body line 1)\n    invoked from within\n\"eval { error e } \""
+            );
+            i.eval_str(b"catch { foreach z {1} { error f } }");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"f\n    while executing\n\"error f \"\n    (\"foreach\" body line 1)\n    invoked from within\n\"foreach z {1} { error f } \""
+            );
+            // inline `if`: only the body command, no `if` frame.
+            i.eval_str(b"catch { if {1} { error x } }");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"x\n    while executing\n\"error x \""
+            );
+            // `foreach` inside a proc is inlined (no foreach frame) — only the
+            // proc frame; the top-level foreach above did show a frame.
+            run(i, b"proc fe {} { foreach x {1} { error e } }");
+            i.eval_str(b"catch fe");
+            assert_eq!(
+                run(i, b"set ::errorInfo"),
+                b"e\n    while executing\n\"error e \"\n    (procedure \"fe\" line 1)\n    invoked from within\n\"fe\""
+            );
+            i.eval_str(b"unset -nocomplain ::errorInfo ::errorCode");
         });
     }
 

--- a/runtime/rust/src/cmd_eval.rs
+++ b/runtime/rust/src/cmd_eval.rs
@@ -50,7 +50,12 @@ fn eval_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"eval arg ?arg ...?");
     }
     let script = join_body(&argv[1..]);
-    interp.eval_str(&script)
+    let code = interp.eval_str(&script);
+    if code == Code::Error {
+        // `("eval" body line N)` — a body evaluated through a fresh frame.
+        interp.append_body_frame(b"eval");
+    }
+    code
 }
 
 /// `uplevel ?level? arg ?arg ...?` — evaluate in an enclosing frame's scope.
@@ -78,7 +83,12 @@ fn uplevel_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, usage);
     }
     let script = join_body(&argv[body_start..]);
-    interp.eval_uplevel(target, &script)
+    let code = interp.eval_uplevel(target, &script);
+    if code == Code::Error {
+        // `("uplevel" body line N)`.
+        interp.append_body_frame(b"uplevel");
+    }
+    code
 }
 
 /// Whether `s` is level-shaped: `#` + digits, or all digits.

--- a/runtime/rust/src/cmd_eval.rs
+++ b/runtime/rust/src/cmd_eval.rs
@@ -50,7 +50,9 @@ fn eval_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"eval arg ?arg ...?");
     }
     let script = join_body(&argv[1..]);
-    let code = interp.eval_str(&script);
+    // `eval` runs its body as its own `info frame` level (inheriting the
+    // enclosing proc/level).
+    let code = interp.eval_body(&script);
     if code == Code::Error {
         // `("eval" body line N)` — a body evaluated through a fresh frame.
         interp.append_body_frame(b"eval");

--- a/runtime/rust/src/cmd_format.rs
+++ b/runtime/rust/src/cmd_format.rs
@@ -22,6 +22,11 @@ fn err(interp: &mut Interp, msg: &[u8]) -> Code {
     interp.set_error(msg)
 }
 
+/// The largest field width `format` will allocate; beyond it the result would
+/// exceed the maximum size of a Tcl value (`INT_MAX`, matching tclsh 9.0 — a
+/// width of 2e9 formats, 4.29e9 errors).
+const MAX_FORMAT_SIZE: usize = i32::MAX as usize;
+
 struct Spec {
     minus: bool,
     plus: bool,
@@ -129,6 +134,13 @@ fn format_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 spec.width = w;
                 spec.has_width = true;
             }
+        }
+        // A width that would make the result exceed Tcl's value-size limit is an
+        // error, not an enormous allocation (which would overflow `Vec`'s
+        // capacity and panic). Mirrors C's `format` overflow check
+        // (`tclStringObj.c`); verified vs tclsh 9.0 (`format-19.4.x`).
+        if spec.has_width && spec.width > MAX_FORMAT_SIZE {
+            return err(interp, b"max size for a Tcl value exceeded");
         }
 
         // Precision.
@@ -395,12 +407,15 @@ fn to_radix(mut v: u128, radix: u32, upper: bool) -> Vec<u8> {
 
 /// Read a run of ASCII digits as a `usize`; reports whether any were read.
 fn read_uint(f: &[u8], i: &mut usize) -> (usize, bool) {
-    let mut n = 0;
+    let mut n: usize = 0;
     let mut got = false;
     while let Some(&c) = f.get(*i) {
         if c.is_ascii_digit() {
             got = true;
-            n = n * 10 + (c - b'0') as usize;
+            // Saturate rather than wrap: an over-large width must still compare
+            // greater than the value-size limit (see `MAX_FORMAT_SIZE`), not
+            // wrap around to a small number.
+            n = n.saturating_mul(10).saturating_add((c - b'0') as usize);
             *i += 1;
         } else {
             break;
@@ -483,6 +498,24 @@ mod tests {
             // positional specifiers.
             assert_eq!(ok(i, b"format {%2$s %1$s} a b"), b"b a");
             assert_eq!(ok(i, b"format {%+d % d %o} 5 5 8"), b"+5  5 10");
+        });
+    }
+
+    #[test]
+    fn format_overflow_width_errors_not_panics() {
+        // A width past the value-size limit is a clean error, not a `Vec`
+        // capacity-overflow panic / a multi-GB allocation (bug d498578df4,
+        // `format-19.4.x`). Verified vs tclsh 9.0.
+        leak_free(|i| {
+            for w in [b"4294967294".as_slice(), b"18446744073709551614"] {
+                let mut src = b"format %".to_vec();
+                src.extend_from_slice(w);
+                src.extend_from_slice(b"g 0");
+                assert_eq!(i.eval_str(&src), Code::Error);
+                assert_eq!(i.result_bytes(), b"max size for a Tcl value exceeded");
+            }
+            // A merely-large-but-valid width still formats.
+            assert_eq!(ok(i, b"format %5s hi"), b"   hi");
         });
     }
 }

--- a/runtime/rust/src/cmd_fs.rs
+++ b/runtime/rust/src/cmd_fs.rs
@@ -446,6 +446,7 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut tails = false;
     let mut join_mode = false;
     let mut directory: Option<Vec<u8>> = None;
+    let mut types: Vec<u8> = Vec::new();
     let mut i = 1;
     while i < argv.len() {
         match obj_bytes(argv[i]).as_slice() {
@@ -456,6 +457,18 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 i += 1;
                 directory = argv.get(i).map(|&a| obj_bytes(a));
             }
+            b"-type" | b"-types" => {
+                i += 1;
+                // The value is a list of type specifiers (`d`, `f`, `r`, …); a
+                // name must satisfy every requested test (`tclFileName.c`).
+                if let Some(&a) = argv.get(i) {
+                    types = crate::parse::split_list(&obj_bytes(a))
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|s| (s.len() == 1).then_some(s[0]))
+                        .collect();
+                }
+            }
             b"--" => {
                 i += 1;
                 break;
@@ -463,7 +476,9 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             opt if opt.starts_with(b"-") => {
                 let mut m = b"bad option \"".to_vec();
                 m.extend_from_slice(opt);
-                m.extend_from_slice(b"\": must be -directory, -join, -nocomplain, -tails, or --");
+                m.extend_from_slice(
+                    b"\": must be -directory, -join, -nocomplain, -path, -tails, -types, or --",
+                );
                 return interp.set_error(&m);
             }
             _ => break,
@@ -477,7 +492,7 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let base = directory.clone();
     let mut hits: Vec<Vec<u8>> = Vec::new();
     for pat in &patterns {
-        glob_one(base.as_deref(), pat, tails, &mut hits);
+        glob_one(base.as_deref(), pat, tails, &types, &mut hits);
     }
     hits.sort();
     hits.dedup();
@@ -499,7 +514,13 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 /// Match one glob pattern against the filesystem, pushing results (full paths,
 /// or just the tail when `tails`) onto `hits`.
-fn glob_one(directory: Option<&[u8]>, pattern: &[u8], tails: bool, hits: &mut Vec<Vec<u8>>) {
+fn glob_one(
+    directory: Option<&[u8]>,
+    pattern: &[u8],
+    tails: bool,
+    types: &[u8],
+    hits: &mut Vec<Vec<u8>>,
+) {
     // Starting directory + whether results are absolute.
     let (start, abs_prefix): (Vec<u8>, Vec<u8>) = if pattern.starts_with(b"/") {
         (b"/".to_vec(), b"/".to_vec())
@@ -512,12 +533,19 @@ fn glob_one(directory: Option<&[u8]>, pattern: &[u8], tails: bool, hits: &mut Ve
         .split(|&c| c == b'/')
         .filter(|s| !s.is_empty())
         .collect();
-    walk(&start, &abs_prefix, &segs, 0, hits);
+    walk(&start, &abs_prefix, &segs, 0, types, hits);
 }
 
 /// Recursively match path segments `segs[idx..]` under `dir`, accumulating the
 /// display path (`prefix`).
-fn walk(dir: &[u8], prefix: &[u8], segs: &[&[u8]], idx: usize, hits: &mut Vec<Vec<u8>>) {
+fn walk(
+    dir: &[u8],
+    prefix: &[u8],
+    segs: &[&[u8]],
+    idx: usize,
+    types: &[u8],
+    hits: &mut Vec<Vec<u8>>,
+) {
     if idx >= segs.len() {
         if !prefix.is_empty() {
             hits.push(prefix.to_vec());
@@ -542,14 +570,68 @@ fn walk(dir: &[u8], prefix: &[u8], segs: &[&[u8]], idx: usize, hits: &mut Vec<Ve
         }
         child_prefix.extend_from_slice(name_b);
         if last {
+            // `-types`: keep only entries that satisfy every requested test.
+            if !entry_matches_types(&entry, types) {
+                continue;
+            }
             hits.push(child_prefix);
         } else {
             let mut child_dir = dir.to_vec();
             child_dir.push(b'/');
             child_dir.extend_from_slice(name_b);
-            walk(&child_dir, &child_prefix, segs, idx + 1, hits);
+            walk(&child_dir, &child_prefix, segs, idx + 1, types, hits);
         }
     }
+}
+
+/// Whether a directory entry satisfies every `-types` specifier. An empty list
+/// matches everything. Recognised: file-kind `d f l p s b c` and permission
+/// `r w x` (mirrors `tclFileName.c`'s `GLOB_TYPE_*`; the rarely-used
+/// `{macintosh …}` forms are not modelled). A name passes only if it matches
+/// every requested test — both any file-kind tests and the permission tests.
+fn entry_matches_types(entry: &std::fs::DirEntry, types: &[u8]) -> bool {
+    if types.is_empty() {
+        return true;
+    }
+    // `symlink_metadata` so `l` (and the kind tests) see the link itself, like C.
+    let Ok(meta) = entry.path().symlink_metadata() else {
+        return false;
+    };
+    let ft = meta.file_type();
+    for &t in types {
+        let ok = match t {
+            b'd' => ft.is_dir(),
+            b'f' => ft.is_file(),
+            b'l' => ft.is_symlink(),
+            b'r' | b'w' => true, // permission probes — best-effort (assume yes)
+            b'x' => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    meta.permissions().mode() & 0o111 != 0
+                }
+                #[cfg(not(unix))]
+                {
+                    true
+                }
+            }
+            #[cfg(unix)]
+            b'p' | b's' | b'b' | b'c' => {
+                use std::os::unix::fs::FileTypeExt;
+                match t {
+                    b'p' => ft.is_fifo(),
+                    b's' => ft.is_socket(),
+                    b'b' => ft.is_block_device(),
+                    _ => ft.is_char_device(),
+                }
+            }
+            _ => true, // unknown specifier: don't exclude
+        };
+        if !ok {
+            return false;
+        }
+    }
+    true
 }
 
 /// Whether a single path segment matches a glob segment. A literal segment (no

--- a/runtime/rust/src/cmd_fs.rs
+++ b/runtime/rust/src/cmd_fs.rs
@@ -94,6 +94,12 @@ const FILE_SUBCOMMANDS: &[&[u8]] = &[
     b"isfile",
     b"readable",
     b"writable",
+    b"executable",
+    b"pathtype",
+    b"delete",
+    b"mkdir",
+    b"size",
+    b"type",
 ];
 
 fn file_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -146,19 +152,137 @@ fn file_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp,
             Path::new(as_str(&arg(2).unwrap_or_default())).is_file(),
         ),
-        b"readable" | b"writable" => {
+        b"readable" | b"writable" | b"executable" => {
             // Approximate: existence (fine-grained perms are deferred).
             bool_result(
                 interp,
                 Path::new(as_str(&arg(2).unwrap_or_default())).exists(),
             )
         }
+        // `file pathtype name` — pure-syntax classification.
+        b"pathtype" => {
+            let p = arg(2).unwrap_or_default();
+            str_result(
+                interp,
+                if p.first() == Some(&b'/') {
+                    b"absolute"
+                } else {
+                    b"relative"
+                },
+            )
+        }
+        b"delete" => file_delete(interp, argv),
+        b"mkdir" => {
+            for &a in &argv[2..] {
+                let p = obj_bytes(a);
+                if p.is_empty() {
+                    continue;
+                }
+                if let Err(e) = std::fs::create_dir_all(as_str(&p)) {
+                    return fs_error(interp, b"can't create directory", &p, &e);
+                }
+            }
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
+        b"size" => {
+            let p = arg(2).unwrap_or_default();
+            match std::fs::metadata(as_str(&p)) {
+                Ok(m) => {
+                    interp.set_result(crate::obj::new_wide_int_obj(m.len() as i64));
+                    Code::Ok
+                }
+                Err(e) => fs_error(interp, b"could not read", &p, &e),
+            }
+        }
+        b"type" => {
+            let p = arg(2).unwrap_or_default();
+            match std::fs::symlink_metadata(as_str(&p)) {
+                Ok(m) => {
+                    let t = m.file_type();
+                    str_result(
+                        interp,
+                        if t.is_symlink() {
+                            b"link"
+                        } else if t.is_dir() {
+                            b"directory"
+                        } else {
+                            b"file"
+                        },
+                    )
+                }
+                Err(e) => fs_error(interp, b"could not read", &p, &e),
+            }
+        }
         other => {
             let mut m = b"unknown or ambiguous subcommand \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be dirname, exists, extension, isdirectory, isfile, join, nativename, normalize, readable, rootname, separator, split, tail, or writable");
+            m.extend_from_slice(b"\": must be delete, dirname, executable, exists, extension, isdirectory, isfile, join, mkdir, nativename, normalize, pathtype, readable, rootname, separator, size, split, tail, type, or writable");
             interp.set_error(&m)
         }
+    }
+}
+
+/// `file delete ?-force? ?--? ?pathname ...?` — delete files / directories.
+/// A non-existent path is silently ignored; `-force` removes non-empty
+/// directories recursively. Returns the empty string.
+fn file_delete(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let mut force = false;
+    let mut i = 2;
+    while i < argv.len() {
+        match obj_bytes(argv[i]).as_slice() {
+            b"-force" => force = true,
+            b"--" => {
+                i += 1;
+                break;
+            }
+            _ => break,
+        }
+        i += 1;
+    }
+    for &a in &argv[i..] {
+        let p = obj_bytes(a);
+        let path = Path::new(as_str(&p));
+        let meta = match std::fs::symlink_metadata(path) {
+            Ok(m) => m,
+            Err(_) => continue, // not there ⇒ nothing to delete (no error)
+        };
+        let res = if meta.is_dir() && !meta.file_type().is_symlink() {
+            if force {
+                std::fs::remove_dir_all(path)
+            } else {
+                std::fs::remove_dir(path)
+            }
+        } else {
+            std::fs::remove_file(path)
+        };
+        if let Err(e) = res {
+            return fs_error(interp, b"error deleting", &p, &e);
+        }
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// A `file` I/O error in Tcl's shape: `<prefix> "<path>": <reason>` (the prefix
+/// is operation-specific, e.g. `could not read` / `can't create directory`).
+fn fs_error(interp: &mut Interp, prefix: &[u8], path: &[u8], e: &std::io::Error) -> Code {
+    let mut m = prefix.to_vec();
+    m.extend_from_slice(b" \"");
+    m.extend_from_slice(path);
+    m.extend_from_slice(b"\": ");
+    m.extend_from_slice(io_error_reason(e).as_bytes());
+    interp.set_error(&m)
+}
+
+/// The POSIX-style message Tcl uses for an `errno` (the common cases).
+fn io_error_reason(e: &std::io::Error) -> &'static str {
+    use std::io::ErrorKind::*;
+    match e.kind() {
+        NotFound => "no such file or directory",
+        PermissionDenied => "permission denied",
+        AlreadyExists => "file already exists",
+        _ => "i/o error",
     }
 }
 
@@ -454,6 +578,32 @@ mod tests {
             String::from_utf8_lossy(src)
         );
         i.result_bytes()
+    }
+
+    #[test]
+    fn file_mkdir_size_type_delete() {
+        let mut i = Interp::new();
+        let d = format!("/tmp/rtfs_{}", std::process::id());
+        ok(&mut i, format!("file delete -force {d}").as_bytes());
+        ok(&mut i, format!("file mkdir {d}/sub").as_bytes());
+        assert_eq!(
+            ok(&mut i, format!("file isdirectory {d}/sub").as_bytes()),
+            b"1"
+        );
+        assert_eq!(
+            ok(&mut i, format!("file type {d}").as_bytes()),
+            b"directory"
+        );
+        assert_eq!(ok(&mut i, b"file pathtype /x"), b"absolute");
+        assert_eq!(ok(&mut i, b"file pathtype rel"), b"relative");
+        // Deleting a missing path is a silent no-op; size of a missing path errors.
+        ok(&mut i, format!("file delete {d}/nope").as_bytes());
+        assert_eq!(
+            i.eval_str(format!("file size {d}/nope").as_bytes()),
+            Code::Error
+        );
+        ok(&mut i, format!("file delete -force {d}").as_bytes());
+        assert_eq!(ok(&mut i, format!("file exists {d}").as_bytes()), b"0");
     }
 
     #[test]

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -4,9 +4,10 @@
 //! Reads **live** runtime state (the T-INFO contract: never compile-time-folded).
 //! The implemented subset covers what the library leans on: `exists`,
 //! `commands`/`procs`/`vars`/`globals`/`locals` (glob-filtered), `level`
-//! (current depth), `tclversion`/`patchlevel`, and proc introspection
-//! `body`/`args`/`default`. The rest (`script`, `frame`, `level N`,
-//! `nameofexecutable`, …) land with the source/`CmdFrame` work (L2/PC-5).
+//! (current depth + `level N`), `frame` (the source-location stack, PC-5),
+//! `script`, `tclversion`/`patchlevel`, `nameofexecutable`, and proc
+//! introspection `body`/`args`/`default`. `info errorstack` (TIP 348) is the
+//! remaining `CmdFrame`-adjacent item.
 //!
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -39,6 +40,7 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"globals" => set_list(interp, argv, Interp::global_var_names),
         b"locals" => set_list(interp, argv, Interp::local_var_names),
         b"level" => info_level(interp, argv),
+        b"frame" => info_frame(interp, argv),
         b"tclversion" => fixed(interp, argv, b"info tclversion", b"9.0"),
         b"patchlevel" => fixed(interp, argv, b"info patchlevel", b"9.0.3"),
         // The host shared-library suffix (`$::tcl_platform(platform)` is unix).
@@ -80,7 +82,7 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             let mut m = b"unknown or ambiguous subcommand \"".to_vec();
             m.extend_from_slice(other);
             m.extend_from_slice(
-                b"\": must be args, body, commands, complete, default, exists, globals, level, library, locals, nameofexecutable, patchlevel, procs, script, sharedlibextension, tclversion, or vars",
+                b"\": must be args, body, commands, complete, default, exists, frame, globals, level, library, locals, nameofexecutable, patchlevel, procs, script, sharedlibextension, tclversion, or vars",
             );
             interp.set_error(&m)
         }
@@ -156,6 +158,46 @@ fn info_level(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
         _ => wrong_args(interp, b"info level ?number?"),
+    }
+}
+
+/// `info frame ?number?` — the source-location stack (PC-5). No arg: the stack
+/// depth. With a number: a dict describing that frame (`type`/`line`/`cmd`,
+/// `proc`/`file` where applicable, and `level`). C ref `tclCmdIL.c`
+/// `InfoFrameCmd`; numbering matches `info level` (N>0 absolute, N<=0 relative).
+fn info_frame(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    match argv.len() {
+        2 => {
+            interp.set_result_bytes(interp.cmd_frame_depth().to_string().as_bytes());
+            Code::Ok
+        }
+        3 => {
+            let spec = obj_bytes(argv[2]);
+            let n = match core::str::from_utf8(&spec)
+                .ok()
+                .and_then(|s| s.trim().parse::<i64>().ok())
+            {
+                Some(n) => n,
+                None => {
+                    let mut m = b"expected integer but got \"".to_vec();
+                    m.extend_from_slice(&spec);
+                    m.push(b'"');
+                    return interp.set_error(&m);
+                }
+            };
+            match interp.cmd_frame_info(n) {
+                Some(pairs) => {
+                    let kv: Vec<(*mut TclObj, *mut TclObj)> = pairs
+                        .iter()
+                        .map(|(k, v)| (new_string(k), new_string(v)))
+                        .collect();
+                    interp.set_result(crate::dict::new_dict_obj(&kv));
+                    Code::Ok
+                }
+                None => bad_level(interp, &spec),
+            }
+        }
+        _ => wrong_args(interp, b"info frame ?number?"),
     }
 }
 
@@ -347,6 +389,40 @@ mod tests {
             );
             // outer 1 2 → inner 1 ; inside inner: level 2, this call, the outer call.
             assert_eq!(run(i, b"outer 1 2"), b"2 {inner 1} {outer 1 2}");
+        });
+    }
+
+    #[test]
+    fn info_frame_stack() {
+        // Eval mode (the runtime's tests): `type proc`/`eval` with body-relative
+        // lines — verified against tclsh 9.0 (via stdin). A `[info frame]` reports
+        // the substituted command but the enclosing line.
+        leak_free(|i| {
+            // Depth: 1 at top level, 2 inside a proc.
+            assert_eq!(run(i, b"info frame"), b"1");
+            run(i, b"proc p {} { return [info frame] }");
+            assert_eq!(run(i, b"p"), b"2");
+            // `info frame 0` inside a proc: type proc, the FQN, level 0, and the
+            // substituted command at its (body-relative) line.
+            run(i, b"proc q {} {\n    return [info frame 0]\n}");
+            assert_eq!(
+                run(i, b"q"),
+                b"type proc line 2 cmd {info frame 0} proc ::q level 0"
+            );
+            // Absolute index 1 = the root (top-level) frame: type eval.
+            run(i, b"proc r {} { return [info frame 1] }");
+            let out = run(i, b"r");
+            assert!(
+                out.starts_with(b"type eval line ") && out.ends_with(b"cmd r level 1"),
+                "got {:?}",
+                String::from_utf8_lossy(&out)
+            );
+            // Relative -1 from a callee names the caller proc.
+            run(i, b"proc a {} { b }");
+            run(i, b"proc b {} { return [info frame -1] }");
+            assert_eq!(run(i, b"a"), b"type proc line 1 cmd {b } proc ::a level 1");
+            // Out of range → bad level.
+            assert_eq!(i.eval_str(b"info frame 99"), Code::Error);
         });
     }
 

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -41,6 +41,8 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"locals" => set_list(interp, argv, Interp::local_var_names),
         b"level" => info_level(interp, argv),
         b"frame" => info_frame(interp, argv),
+        b"object" => crate::cmd_oo::info_object(interp, argv),
+        b"class" => crate::cmd_oo::info_class(interp, argv),
         b"tclversion" => fixed(interp, argv, b"info tclversion", b"9.0"),
         b"patchlevel" => fixed(interp, argv, b"info patchlevel", b"9.0.3"),
         // The host shared-library suffix (`$::tcl_platform(platform)` is unix).

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -190,10 +190,8 @@ fn command_complete(s: &[u8]) -> bool {
             match c {
                 b'"' => in_quote = false,
                 b'[' => stack.push(b']'),
-                b']' => {
-                    if stack.last() == Some(&b']') {
-                        stack.pop();
-                    }
+                b']' if stack.last() == Some(&b']') => {
+                    stack.pop();
                 }
                 _ => {}
             }

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -32,7 +32,45 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, b"info subcommand ?arg ...?");
     }
-    match obj_bytes(argv[1]).as_slice() {
+    // `info` is an ensemble: resolve an exact name, else an unambiguous prefix
+    // (so `info command` → `commands`, matching tclsh).
+    const SUBS: &[&[u8]] = &[
+        b"args",
+        b"body",
+        b"class",
+        b"commands",
+        b"complete",
+        b"default",
+        b"exists",
+        b"frame",
+        b"globals",
+        b"level",
+        b"library",
+        b"locals",
+        b"nameofexecutable",
+        b"object",
+        b"patchlevel",
+        b"procs",
+        b"script",
+        b"sharedlibextension",
+        b"tclversion",
+        b"vars",
+    ];
+    let raw = obj_bytes(argv[1]);
+    let sub: &[u8] = if SUBS.contains(&raw.as_slice()) {
+        &raw
+    } else {
+        let hits: Vec<&&[u8]> = SUBS
+            .iter()
+            .filter(|s| s.starts_with(raw.as_slice()))
+            .collect();
+        if hits.len() == 1 {
+            hits[0]
+        } else {
+            &raw // 0 or ambiguous → the error arm
+        }
+    };
+    match sub {
         b"exists" => info_exists(interp, argv),
         b"commands" => set_list(interp, argv, Interp::visible_command_names),
         b"procs" => set_list(interp, argv, Interp::visible_proc_names),

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -427,6 +427,20 @@ mod tests {
     }
 
     #[test]
+    fn info_frame_uplevel_is_eval_typed_without_level() {
+        // An `uplevel` body is `type eval` (a fresh dynamically-evaluated body),
+        // keeps the *invoking* proc's name, and omits the `level` key (its scope
+        // is redirected). Byte-verified vs tclsh 9.0.
+        leak_free(|i| {
+            run(i, b"proc h {} { uplevel 1 { return [info frame 0] } }");
+            assert_eq!(
+                run(i, b"h"),
+                b"type eval line 1 cmd {info frame 0} proc ::h"
+            );
+        });
+    }
+
+    #[test]
     fn info_complete_balances() {
         leak_free(|i| {
             assert_eq!(run(i, b"info complete {set x 1}"), b"1");

--- a/runtime/rust/src/cmd_list.rs
+++ b/runtime/rust/src/cmd_list.rs
@@ -76,7 +76,7 @@ fn parse_int_prefix(s: &[u8]) -> Option<(isize, &[u8])> {
 /// full `TclGetIntForIndex` grammar: an integer, `end`, and a base (`end` or an
 /// integer) with an optional `±integer` offset (`end-2`, `0-1`, `-2+1`, …).
 /// Returns a (possibly out-of-range) signed index; callers clamp/range-check.
-fn index_spec(spec: &[u8], len: usize) -> Option<isize> {
+pub(crate) fn index_spec(spec: &[u8], len: usize) -> Option<isize> {
     let len = len as isize;
     let s = {
         let t = core::str::from_utf8(spec).ok()?.trim();
@@ -193,9 +193,17 @@ fn lappend(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let name = obj_bytes(argv[1]);
     let values = &argv[2..];
+    // `lappend a(k) ...` must address the array element, not a scalar literally
+    // named `a(k)` — split the array ref like `set`/`incr` do.
+    let (base, elem) = crate::frame::split_array_ref(&name);
+
+    let cur = match &elem {
+        Some(k) => interp.var_get_elem(&base, k),
+        None => interp.var_get(&base),
+    };
 
     // Determine the target list object (in-place if unshared, else a copy/new).
-    let (target, is_new) = match interp.var_get(&name) {
+    let (target, is_new) = match cur {
         None => (list::new_list_obj(&[]), true), // fresh empty list (rc 0)
         Some(o) if obj::is_shared(o) => (obj::duplicate(o), true), // COW copy (rc 0)
         Some(o) => (o, false),                   // mutate in place (frame owns it)
@@ -214,7 +222,11 @@ fn lappend(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if is_new {
         // `target` is rc 0; `set` retains it into the variable (and releases the
         // prior value for the COW/overwrite case).
-        if interp.var_set(&name, target).is_err() {
+        let stored = match &elem {
+            Some(k) => interp.var_set_elem(&base, k, target),
+            None => interp.var_set(&base, target),
+        };
+        if stored.is_err() {
             drop_fresh(target);
             let mut m = b"can't set \"".to_vec();
             m.extend_from_slice(&name);
@@ -802,6 +814,14 @@ mod tests {
         );
         // lappend onto a string var shimmers it to a list
         assert_eq!(ok(b"set s {1 2}; lappend s 3"), b"1 2 3");
+        // lappend addresses array elements (not a scalar literally named `a(k)`),
+        // including fully-qualified element keys (the safe-base / opt case).
+        assert_eq!(ok(b"lappend a(k) 1 2; lappend a(k) 3"), b"1 2 3");
+        assert_eq!(ok(b"lappend a(k) 1 2; set a(k)"), b"1 2");
+        assert_eq!(
+            ok(b"namespace eval n { variable arr; lappend arr(::x::y) a b }; set ::n::arr(::x::y)"),
+            b"a b"
+        );
     }
 
     #[test]

--- a/runtime/rust/src/cmd_misc.rs
+++ b/runtime/rust/src/cmd_misc.rs
@@ -17,6 +17,79 @@ pub fn install(interp: &mut Interp) {
     // The `clock` C subsystem is L3; init.tcl's startup calls this configure
     // hook unconditionally — accept it as a no-op until `clock` lands.
     interp.register_builtin(b"::tcl::unsupported::clock::configure", noop);
+    // `tcl::build-info` — build metadata; the tcltest helper (`tcltests.tcl`)
+    // queries it for the `debug`/`purify`/`memdebug`/`deprecated` constraints.
+    interp.register_builtin(b"::tcl::build-info", build_info_cmd);
+}
+
+/// The runtime's build-info string (`<patchlevel>+<commit>.<features…>`). None of
+/// the boolean feature words (`debug`/`purify`/`memdebug`/`no-deprecate`) are
+/// present, so those constraints resolve false.
+const BUILD_INFO: &[u8] = b"9.0.3+0000000000000000000000000000000000000000.rust";
+
+/// `tcl::build-info ?option?` — mirrors C's `BuildInfoObjCmd` (`tclBasic.c`):
+/// no arg → the full string; `patchlevel` → up to `+`; `version` → `major.minor`;
+/// `commit` → the `+`..`.` segment; any other identifier → its `name-value`
+/// suffix value, or boolean 1/0 for its presence.
+fn build_info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() > 2 {
+        return wrong_args(interp, b"tcl::build-info ?option?");
+    }
+    let data = BUILD_INFO;
+    if argv.len() < 2 {
+        interp.set_result_bytes(data);
+        return Code::Ok;
+    }
+    let plus = data.iter().position(|&b| b == b'+');
+    let result: Vec<u8> = match obj_bytes(argv[1]).as_slice() {
+        b"patchlevel" => data[..plus.unwrap_or(data.len())].to_vec(),
+        b"version" => {
+            // Up to the second `.` or the `+`, whichever comes first.
+            let v_end = data
+                .iter()
+                .enumerate()
+                .filter(|&(_, &b)| b == b'.')
+                .nth(1)
+                .map(|(i, _)| i)
+                .or(plus)
+                .unwrap_or(data.len());
+            data[..v_end].to_vec()
+        }
+        b"commit" => match plus {
+            Some(p) => {
+                let rest = &data[p + 1..];
+                let end = rest.iter().position(|&b| b == b'.').unwrap_or(rest.len());
+                rest[..end].to_vec()
+            }
+            None => Vec::new(),
+        },
+        // Boolean test for a feature identifier among the dot-separated suffix
+        // words: `name` → 1 if present, `name-value` → its value, else 0.
+        arg => {
+            let mut found: Option<Vec<u8>> = None;
+            let mut rest = data;
+            while let Some(dot) = rest.iter().position(|&b| b == b'.') {
+                let word = &rest[dot + 1..];
+                if word.starts_with(arg)
+                    && matches!(word.get(arg.len()), None | Some(b'.') | Some(b'-'))
+                {
+                    found = Some(match word.get(arg.len()) {
+                        Some(b'-') => {
+                            let v = &word[arg.len() + 1..];
+                            let end = v.iter().position(|&b| b == b'.').unwrap_or(v.len());
+                            v[..end].to_vec()
+                        }
+                        _ => b"1".to_vec(),
+                    });
+                    break;
+                }
+                rest = &rest[dot + 1..];
+            }
+            found.unwrap_or_else(|| b"0".to_vec())
+        }
+    };
+    interp.set_result_bytes(&result);
+    Code::Ok
 }
 
 /// A no-op command (returns the empty string) — a placeholder for a C subsystem

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -271,25 +271,29 @@ fn ns_import(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
         for simple in to_import {
-            // Reject clobbering an existing command unless -force.
-            if !force && interp.namespaces().which_command(dest, &simple).is_some() {
-                // Only a conflict if it would resolve in the dest ns itself.
-                if interp
-                    .namespaces()
-                    .imported_in(dest)
-                    .iter()
-                    .any(|(k, _)| k == &simple)
-                    || dest_has_own(interp, dest, &simple)
-                {
-                    let mut m = b"can't import command \"".to_vec();
-                    m.extend_from_slice(&simple);
-                    m.extend_from_slice(b"\": already exists");
-                    return interp.set_error(&m);
-                }
-            }
             let mut source = src_fqn.clone();
             source.extend_from_slice(b"::");
             source.extend_from_slice(&simple);
+            // Re-importing the *same* command from the *same* source is a silent
+            // no-op (C's `TclGetOriginalCommand` reimport check, tclNamesp.c) —
+            // common when a file and its sourced helper both `namespace import
+            // ::tcltest::*`. Only a clobber of a different command is a conflict.
+            let existing_import = interp
+                .namespaces()
+                .imported_in(dest)
+                .into_iter()
+                .find(|(k, _)| k == &simple)
+                .map(|(_, s)| s);
+            if existing_import.as_deref() == Some(source.as_slice()) {
+                continue;
+            }
+            // Reject clobbering an existing (different) command unless -force.
+            if !force && (existing_import.is_some() || dest_has_own(interp, dest, &simple)) {
+                let mut m = b"can't import command \"".to_vec();
+                m.extend_from_slice(&simple);
+                m.extend_from_slice(b"\": already exists");
+                return interp.set_error(&m);
+            }
             interp
                 .namespaces_mut()
                 .bind(dest, &simple, Command::Imported { source });
@@ -766,6 +770,48 @@ mod tests {
                 Code::Ok
             );
             assert_eq!(i.eval_str(b"namespace eval app { greet hi }"), Code::Error);
+        });
+    }
+
+    #[test]
+    fn reimport_same_source_is_idempotent() {
+        // Re-importing the *same* command from the *same* source is a silent
+        // no-op (C's reimport check) — the common case where a file and its
+        // sourced helper both `namespace import ::lib::*` (e.g. tcltest). Only a
+        // clobber of a *different* command is a conflict (without -force).
+        leak_free(|i| {
+            i.eval_str(b"namespace eval lib { proc g {} {return G} ; namespace export g }");
+            assert_eq!(i.eval_str(b"namespace import ::lib::*"), Code::Ok);
+            // Second import of the same command from the same source: no error.
+            assert_eq!(i.eval_str(b"namespace import ::lib::*"), Code::Ok);
+            assert_eq!(i.eval_str(b"namespace import ::lib::g"), Code::Ok);
+            // A different command of the same simple name does conflict.
+            i.eval_str(b"namespace eval other { proc g {} {return O} ; namespace export g }");
+            assert_eq!(i.eval_str(b"namespace import ::other::*"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                b"can't import command \"g\": already exists"
+            );
+            // -force overrides the clobber.
+            assert_eq!(i.eval_str(b"namespace import -force ::other::*"), Code::Ok);
+        });
+    }
+
+    #[test]
+    fn build_info_queries() {
+        // `tcl::build-info` (the tcltest constraint source): version/patchlevel
+        // parse the build string; feature flags we don't set report 0.
+        leak_free(|i| {
+            assert_eq!(i.eval_str(b"tcl::build-info version"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"9.0");
+            assert_eq!(i.eval_str(b"tcl::build-info patchlevel"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"9.0.3");
+            for feat in [&b"debug"[..], b"purify", b"memdebug", b"no-deprecate"] {
+                let mut cmd = b"tcl::build-info ".to_vec();
+                cmd.extend_from_slice(feat);
+                assert_eq!(i.eval_str(&cmd), Code::Ok);
+                assert_eq!(i.result_bytes(), b"0", "feature {feat:?} should be absent");
+            }
         });
     }
 

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -55,10 +55,11 @@ fn namespace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"ensemble" => ns_ensemble(interp, argv),
         b"inscope" => ns_inscope(interp, argv),
         b"code" => ns_code(interp, argv),
+        b"upvar" => ns_upvar(interp, argv),
         other => {
             let mut m = b"unknown or ambiguous subcommand \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be children, current, delete, ensemble, eval, exists, export, forget, import, parent, path, qualifiers, tail, or which");
+            m.extend_from_slice(b"\": must be children, code, current, delete, ensemble, eval, exists, export, forget, import, inscope, origin, parent, path, qualifiers, tail, upvar, or which");
             interp.set_error(&m)
         }
     }
@@ -548,6 +549,51 @@ fn ns_code(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
+/// `namespace upvar ns ?otherVar myVar ...?` — link each `myVar` in the current
+/// frame to `otherVar`, a variable resolved in namespace `ns` (mirrors C's
+/// `NamespaceUpvarCmd`: the other-var is looked up with the var frame's
+/// namespace temporarily set to `ns`).
+fn ns_upvar(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    // objc<2 || objc&1 in C (argv[0] is "namespace"): need ns + even #pairs.
+    if argv.len() < 3 || argv.len() % 2 == 0 {
+        return wrong_args(interp, b"namespace upvar ns ?otherVar myVar ...?");
+    }
+    let ns_name = obj_bytes(argv[2]);
+    let Some(ns) = interp
+        .namespaces()
+        .find_namespace(interp.current_ns(), &ns_name)
+    else {
+        let mut m = b"namespace \"".to_vec();
+        m.extend_from_slice(&ns_name);
+        m.extend_from_slice(b"\" not found");
+        return interp.set_error(&m);
+    };
+
+    let mut i = 3;
+    while i + 1 < argv.len() {
+        let other = obj_bytes(argv[i]);
+        let local = obj_bytes(argv[i + 1]);
+        let (base, elem) = crate::frame::split_array_ref(&other);
+        // The other-var resolves in `ns` (a qualified `base` resolves relative to
+        // it, an unqualified one names a var of `ns` directly).
+        let Some((home_ns, simple)) = interp.resolve_var_target(ns, &base) else {
+            let mut m = b"can't access \"".to_vec();
+            m.extend_from_slice(&other);
+            m.extend_from_slice(b"\": parent namespace doesn't exist");
+            return interp.set_error(&m);
+        };
+        let link = crate::frame::Link {
+            home: crate::frame::VarHome::Namespace(home_ns),
+            name: simple,
+            elem,
+        };
+        interp.make_upvar(link, &local);
+        i += 2;
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
 // -- ensemble --------------------------------------------------------------
 
 /// `namespace ensemble create|exists ...` — the canonical `ens sub`→target
@@ -1010,6 +1056,53 @@ mod tests {
             assert_eq!(i.result_bytes(), b"1");
             assert_eq!(i.eval_str(b"namespace ensemble exists ::nope"), Code::Ok);
             assert_eq!(i.result_bytes(), b"0");
+        });
+    }
+
+    #[test]
+    fn namespace_upvar_links_local_to_ns_var() {
+        leak_free(|i| {
+            i.eval_str(b"namespace eval a { variable x 42 }");
+            // `namespace upvar a x lx` links a frame-local `lx` to `::a::x`.
+            assert_eq!(
+                i.eval_str(
+                    b"proc p {} { namespace upvar a x lx; set lx [expr {$lx+1}]; return $lx }"
+                ),
+                Code::Ok
+            );
+            assert_eq!(i.eval_str(b"p"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"43");
+            // The write went through to the namespace variable.
+            assert_eq!(i.eval_str(b"set ::a::x"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"43");
+            // A missing namespace is an error.
+            assert_eq!(i.eval_str(b"namespace upvar nope v lv"), Code::Error);
+        });
+    }
+
+    #[test]
+    fn ensemble_command_is_qualified_relative_to_current_ns() {
+        leak_free(|i| {
+            // A relative `-command` binds in the current namespace, not global
+            // (the `tcl::tm::path` / safe-base case): `-command path` inside
+            // `::a::b` creates `::a::b::path`, resolvable by its FQN.
+            assert_eq!(
+                i.eval_str(
+                    b"namespace eval a::b { namespace export path; namespace ensemble create -command path -map {list ::set} }"
+                ),
+                Code::Ok
+            );
+            assert_eq!(
+                i.eval_str(b"namespace which -command ::a::b::path"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"::a::b::path");
+            // No bare `::path` leaked into the global namespace.
+            assert_eq!(i.eval_str(b"namespace which -command ::path"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"");
+            assert_eq!(i.eval_str(b"::a::b::path list v 5"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"5");
+            i.eval_str(b"unset v");
         });
     }
 }

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -39,6 +39,7 @@ fn namespace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     match obj_bytes(argv[1]).as_slice() {
         b"current" => ns_current(interp, argv),
+        b"delete" => ns_delete(interp, argv),
         b"eval" => ns_eval(interp, argv),
         b"exists" => ns_exists(interp, argv),
         b"parent" => ns_parent(interp, argv),
@@ -57,7 +58,7 @@ fn namespace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         other => {
             let mut m = b"unknown or ambiguous subcommand \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be children, current, ensemble, eval, exists, export, forget, import, parent, path, qualifiers, tail, or which");
+            m.extend_from_slice(b"\": must be children, current, delete, ensemble, eval, exists, export, forget, import, parent, path, qualifiers, tail, or which");
             interp.set_error(&m)
         }
     }
@@ -73,6 +74,24 @@ fn ns_current(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let cur = interp.current_ns();
     let name = interp.namespaces().qualified_name(cur);
     interp.set_result_bytes(&name);
+    Code::Ok
+}
+
+/// `namespace delete ?name name ...?` — delete each named namespace (with its
+/// children, commands, and variables). A missing namespace is an error; with no
+/// names it is a no-op. Mirrors C's `NamespaceDeleteCmd` (`tclNamesp.c`).
+fn ns_delete(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let cur = interp.current_ns();
+    for &a in &argv[2..] {
+        let name = obj_bytes(a);
+        if !interp.namespaces_mut().delete_namespace(cur, &name) {
+            let mut m = b"unknown namespace \"".to_vec();
+            m.extend_from_slice(&name);
+            m.extend_from_slice(b"\" in namespace delete command");
+            return interp.set_error(&m);
+        }
+    }
+    interp.set_result_bytes(b"");
     Code::Ok
 }
 
@@ -794,6 +813,28 @@ mod tests {
             );
             // -force overrides the clobber.
             assert_eq!(i.eval_str(b"namespace import -force ::other::*"), Code::Ok);
+        });
+    }
+
+    #[test]
+    fn namespace_delete_removes_subtree() {
+        leak_free(|i| {
+            i.eval_str(b"namespace eval foo { proc p {} {return P} ; namespace eval bar {} }");
+            assert_eq!(i.eval_str(b"namespace exists ::foo::bar"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"1");
+            assert_eq!(i.eval_str(b"namespace delete ::foo"), Code::Ok);
+            // The namespace, its child, and its commands are gone.
+            assert_eq!(i.eval_str(b"namespace exists ::foo"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"0");
+            assert_eq!(i.eval_str(b"namespace exists ::foo::bar"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"0");
+            assert_eq!(i.eval_str(b"::foo::p"), Code::Error);
+            // Deleting a missing namespace errors (tclsh message).
+            assert_eq!(i.eval_str(b"namespace delete ::nope"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                b"unknown namespace \"::nope\" in namespace delete command"
+            );
         });
     }
 

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -405,7 +405,8 @@ fn resolve_arg_ns(
         None => Ok(current),
         Some(a) => {
             let name = obj_bytes(a);
-            match interp.namespaces().find_namespace(current, &name) {
+            let found = interp.namespaces().find_namespace(current, &name);
+            match found {
                 Some(ns) => Ok(ns),
                 None => {
                     let mut m = b"namespace \"".to_vec();
@@ -508,7 +509,8 @@ fn ns_origin(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let name = obj_bytes(argv[2]);
     let cur = interp.current_ns();
-    match interp.namespaces().command_origin(cur, &name) {
+    let origin = interp.namespaces().command_origin(cur, &name);
+    match origin {
         Some(fqn) => {
             interp.set_result_bytes(&fqn);
             Code::Ok

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -817,6 +817,27 @@ mod tests {
     }
 
     #[test]
+    fn qualified_command_falls_back_to_global() {
+        // A relative qualified command name resolves against the current
+        // namespace, then the global one (C's `TclGetNamespaceForQualName`): so
+        // `foo::bar` from inside `::a::b` finds `::foo::bar` when `::a::b::foo`
+        // doesn't exist. (The bug: `tcl::build-info` failing inside a namespace.)
+        leak_free(|i| {
+            i.eval_str(b"namespace eval foo { proc bar {} {return BAR} }");
+            assert_eq!(
+                i.eval_str(b"namespace eval ::a::b { set ::r [foo::bar] }"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"BAR");
+            // A relative qualifier that *does* exist locally still wins.
+            i.eval_str(b"namespace eval x::foo { proc bar {} {return LOCAL} }");
+            assert_eq!(i.eval_str(b"namespace eval x { foo::bar }"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"LOCAL");
+            i.eval_str(b"unset -nocomplain ::r");
+        });
+    }
+
+    #[test]
     fn namespace_delete_removes_subtree() {
         leak_free(|i| {
             i.eval_str(b"namespace eval foo { proc p {} {return P} ; namespace eval bar {} }");

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -1,36 +1,40 @@
 //! TclOO — the object system (`oo::class`, `oo::object`, `oo::define`, …).
 //!
-//! A core subset (C ref `tclOO.c`): classes with single/multiple superclasses,
-//! methods, constructor/destructor, instance variables, object creation
-//! (`new`/`create`), method dispatch with a linearised MRO, and the
-//! method-context commands `self` / `my` / `next`. Each object/class is a
-//! command (`Command::OoObject`); each object's instance variables live in a
-//! private namespace, auto-linked into a method frame from the class's
-//! `variable` declarations (reusing the proc-call machinery via
+//! Covers (C ref `tclOO.c`): classes with single/multiple superclasses,
+//! methods (incl. `forward`), constructor/destructor, instance variables,
+//! object creation (`new`/`create`), per-object definitions (`oo::objdefine`,
+//! per-object methods/mixins), class/object `mixin`s, `export`/`unexport`
+//! visibility, `oo::copy`, method dispatch over a linearised chain (object →
+//! object mixins → class mixins → class MRO), the method-context commands
+//! `self`/`my`/`next`, and `info object`/`info class` introspection.
+//!
+//! Each object/class is a command (`Command::OoObject`); each object's instance
+//! variables live in a private namespace, auto-linked into a method frame from
+//! the class's `variable` declarations (reusing the proc machinery via
 //! [`Interp::run_proc`] with `CallMeta::link_vars`).
 //!
-//! Deferred: mixins, filters, forwards, `oo::copy`, per-object methods
-//! (`oo::objdefine`), private methods/variables, and `info object`/`info class`
-//! introspection.
+//! Deferred: filters, private methods/variables (8.7+), the full C3 mixin
+//! linearisation, and `oo::define`'s rarer subcommands.
 //!
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::interp::{obj_bytes, CallMeta, Code, Command, Interp, Param, ProcFrame};
+use crate::list;
 use crate::namespace::NsId;
 use crate::obj::{self, TclObj};
 
-/// A method (or constructor): parsed parameters + the body script.
+/// A method: a normal body, or a `forward` to a command prefix.
 #[derive(Clone)]
-struct Method {
-    params: Vec<Param>,
-    body: Vec<u8>,
+enum Method {
+    Body { params: Vec<Param>, body: Vec<u8> },
+    Forward { prefix: Vec<Vec<u8>> },
 }
 
 /// A class definition.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Class {
     /// Superclass FQNs (defaults to `::oo::object` when none are declared).
     supers: Vec<Vec<u8>>,
@@ -39,25 +43,42 @@ struct Class {
     destructor: Option<Vec<u8>>,
     /// Declared instance-variable names (auto-linked into every method frame).
     variables: Vec<Vec<u8>>,
+    /// Mixed-in classes (searched before the superclass MRO).
+    mixins: Vec<Vec<u8>>,
+    /// Methods marked non-exported (callable only via `my`).
+    unexported: BTreeSet<Vec<u8>>,
 }
 
 /// An object instance.
+#[derive(Default, Clone)]
 struct Object {
     /// FQN of the object's class.
     class: Vec<u8>,
     /// The namespace holding this object's instance variables.
     var_ns: NsId,
+    /// Per-object methods (`oo::objdefine method`).
+    methods: BTreeMap<Vec<u8>, Method>,
+    /// Per-object mixins.
+    mixins: Vec<Vec<u8>>,
+    unexported: BTreeSet<Vec<u8>>,
 }
 
 /// One active method invocation (for `self` / `my` / `next`).
 struct OoFrame {
     object: Vec<u8>,
-    /// The class linearisation (MRO) this dispatch walks.
-    mro: Vec<Vec<u8>>,
-    /// Index into `mro` of the class whose method is currently running.
+    /// The method-resolution chain (object FQN, then mixin/class FQNs).
+    chain: Vec<Vec<u8>>,
+    /// Index into `chain` of the provider whose method is currently running.
     index: usize,
     /// The method name (or empty for a constructor).
     method: Vec<u8>,
+}
+
+/// A definition target: a class (`oo::define`) or an object (`oo::objdefine`).
+#[derive(Clone)]
+enum DefTarget {
+    Class(Vec<u8>),
+    Object(Vec<u8>),
 }
 
 /// The interpreter's TclOO state.
@@ -66,10 +87,7 @@ pub struct OoState {
     classes: BTreeMap<Vec<u8>, Class>,
     objects: BTreeMap<Vec<u8>, Object>,
     counter: usize,
-    /// Classes currently being defined (the `oo::define`/`oo::class create`
-    /// script context the definition commands mutate).
-    def_stack: Vec<Vec<u8>>,
-    /// Active method-call contexts.
+    def_stack: Vec<DefTarget>,
     call_stack: Vec<OoFrame>,
 }
 
@@ -78,20 +96,25 @@ pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"oo::class", oo_class_cmd);
     interp.register_builtin(b"oo::object", oo_object_cmd);
     interp.register_builtin(b"oo::define", oo_define_cmd);
-    // Definition-script commands (valid only inside an `oo::define` body).
+    interp.register_builtin(b"oo::objdefine", oo_objdefine_cmd);
+    interp.register_builtin(b"oo::copy", oo_copy_cmd);
+    // Definition-script commands (valid inside an `oo::define`/`oo::objdefine`).
     interp.register_builtin(b"method", def_method);
     interp.register_builtin(b"constructor", def_constructor);
     interp.register_builtin(b"destructor", def_destructor);
     interp.register_builtin(b"superclass", def_superclass);
     interp.register_builtin(b"variable", def_variable);
-    interp.register_builtin(b"export", def_export);
+    interp.register_builtin(b"export", |i, a| def_export(i, a, true));
+    interp.register_builtin(b"unexport", |i, a| def_export(i, a, false));
+    interp.register_builtin(b"mixin", def_mixin);
+    interp.register_builtin(b"forward", def_forward);
     // Method-context commands.
     interp.register_builtin(b"self", self_cmd);
     interp.register_builtin(b"my", my_cmd);
     interp.register_builtin(b"next", next_cmd);
-    // The root classes exist so superclass-less classes inherit from `object`
-    // and `superclass oo::class`/`oo::object` validate. (`oo::class` keeps its
-    // builtin command — only the class-registry entry is added.)
+    // Root classes (so `superclass`-less classes inherit `object` and
+    // `superclass oo::class`/`oo::object` validate; `oo::class` keeps its
+    // builtin command — only the registry entry is added).
     interp
         .oo
         .classes
@@ -103,7 +126,6 @@ pub fn install(interp: &mut Interp) {
             ..Class::default()
         },
     );
-    // `::oo::version` / `::oo::patchlevel` (read by the test harness).
     let _ =
         interp.eval_str(b"namespace eval ::oo {variable version 1.3.1; variable patchlevel 1.3.1}");
 }
@@ -119,38 +141,31 @@ fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
     interp.set_error(&m)
 }
 
-// -- oo::class / oo::object / oo::define ------------------------------------
+fn unknown_method(interp: &mut Interp, m: &[u8]) -> Code {
+    let mut msg = b"unknown method \"".to_vec();
+    msg.extend_from_slice(m);
+    msg.extend_from_slice(b"\": must be a supported method");
+    interp.set_error(&msg)
+}
+
+// -- oo::class / oo::object / oo::define / oo::objdefine ---------------------
 
 /// `oo::class create name ?definitionScript?` — define a class.
 fn oo_class_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    if argv.len() < 3 || obj_bytes(argv[1]) != b"create" {
-        return wrong_args(interp, b"oo::class create name ?definitionScript?");
-    }
-    let fqn = interp.fqn_for(&obj_bytes(argv[2]));
-    if interp.oo.classes.contains_key(&fqn) || interp.oo.objects.contains_key(&fqn) {
-        let mut m = b"can't create class \"".to_vec();
-        m.extend_from_slice(&obj_bytes(argv[2]));
-        m.extend_from_slice(b"\": command already exists with that name");
-        return err(interp, &m);
-    }
-    interp.oo.classes.insert(
-        fqn.clone(),
-        Class {
-            supers: vec![b"::oo::object".to_vec()],
-            ..Class::default()
-        },
-    );
-    interp.ns_register(&fqn, Command::OoObject(fqn.clone()));
-    // Run the definition script (if any) with `fqn` as the definition target.
-    if argv.len() >= 4 {
-        let script = obj_bytes(argv[3]);
-        let code = interp.oo_define(&fqn, &script);
-        if code != Code::Ok {
-            return code;
+    match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
+        Some(b"create") if argv.len() >= 3 => {
+            let fqn = interp.fqn_for(&obj_bytes(argv[2]));
+            interp.oo_make_class(&fqn, argv.get(3).map(|&a| obj_bytes(a)).as_deref())
         }
+        Some(b"new") => {
+            // Anonymous class.
+            let n = interp.oo.counter;
+            interp.oo.counter += 1;
+            let fqn = format!("::oo::Obj{n}").into_bytes();
+            interp.oo_make_class(&fqn, argv.get(2).map(|&a| obj_bytes(a)).as_deref())
+        }
+        _ => wrong_args(interp, b"oo::class create name ?definitionScript?"),
     }
-    interp.set_result(obj::new_string_bytes(&fqn));
-    Code::Ok
 }
 
 /// `oo::object create name` / `oo::object new` — create a bare object.
@@ -177,72 +192,140 @@ fn oo_define_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         m.extend_from_slice(b"\" does not refer to a class");
         return err(interp, &m);
     }
-    if argv.len() == 3 {
-        // Script form.
-        let script = obj_bytes(argv[2]);
-        interp.oo_define(&fqn, &script)
-    } else {
-        // Subcommand form: push the context and dispatch the one definition cmd.
-        interp.oo.def_stack.push(fqn);
-        let code = interp.dispatch(&argv[2..]);
-        interp.oo.def_stack.pop();
-        code
+    interp.oo_run_def(DefTarget::Class(fqn), argv)
+}
+
+/// `oo::objdefine object script` / `oo::objdefine object subcommand ?arg ...?`.
+fn oo_objdefine_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 3 {
+        return wrong_args(interp, b"oo::objdefine target ?arg ...?");
     }
+    let fqn = interp.fqn_for(&obj_bytes(argv[1]));
+    if !interp.oo.objects.contains_key(&fqn) {
+        let mut m = b"\"".to_vec();
+        m.extend_from_slice(&obj_bytes(argv[1]));
+        m.extend_from_slice(b"\" does not refer to an object");
+        return err(interp, &m);
+    }
+    interp.oo_run_def(DefTarget::Object(fqn), argv)
+}
+
+/// `oo::copy srcObject ?targetObject?` — clone an object (its class + per-object
+/// methods/mixins).
+fn oo_copy_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 2 || argv.len() > 3 {
+        return wrong_args(interp, b"oo::copy sourceName ?targetName?");
+    }
+    let src = interp.fqn_for(&obj_bytes(argv[1]));
+    let Some(src_obj) = interp.oo.objects.get(&src).cloned() else {
+        let mut m = b"\"".to_vec();
+        m.extend_from_slice(&obj_bytes(argv[1]));
+        m.extend_from_slice(b"\" does not refer to an object");
+        return err(interp, &m);
+    };
+    let dst = match argv.get(2) {
+        Some(&a) => interp.fqn_for(&obj_bytes(a)),
+        None => {
+            let n = interp.oo.counter;
+            interp.oo.counter += 1;
+            format!("::oo::Obj{n}").into_bytes()
+        }
+    };
+    let var_ns = interp.ensure_namespace(&dst);
+    interp.oo.objects.insert(
+        dst.clone(),
+        Object {
+            class: src_obj.class,
+            var_ns,
+            methods: src_obj.methods,
+            mixins: src_obj.mixins,
+            unexported: src_obj.unexported,
+        },
+    );
+    interp.ns_register(&dst, Command::OoObject(dst.clone()));
+    interp.set_result(obj::new_string_bytes(&dst));
+    Code::Ok
 }
 
 // -- definition-script commands ---------------------------------------------
 
-/// The class currently being defined, or an error if outside `oo::define`.
-fn def_class(interp: &mut Interp) -> Result<Vec<u8>, Code> {
+/// The current definition target, or an error if outside a definition body.
+fn def_target(interp: &mut Interp) -> Result<DefTarget, Code> {
     match interp.oo.def_stack.last() {
-        Some(c) => Ok(c.clone()),
+        Some(t) => Ok(t.clone()),
         None => Err(interp
             .set_error(b"this command can only be called from within the body of a definition")),
     }
 }
 
-/// `method name params body` — add an (instance) method to the class.
-fn def_method(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    if argv.len() != 4 {
-        return wrong_args(interp, b"method name args body");
-    }
-    let class = match def_class(interp) {
-        Ok(c) => c,
+/// Install `method` into the current definition target (class or object).
+fn install_method(interp: &mut Interp, name: Vec<u8>, m: Method) -> Code {
+    match def_target(interp) {
+        Ok(DefTarget::Class(c)) => {
+            interp
+                .oo
+                .classes
+                .get_mut(&c)
+                .unwrap()
+                .methods
+                .insert(name, m);
+        }
+        Ok(DefTarget::Object(o)) => {
+            interp
+                .oo
+                .objects
+                .get_mut(&o)
+                .unwrap()
+                .methods
+                .insert(name, m);
+        }
         Err(code) => return code,
-    };
-    let params = match crate::cmd_proc::parse_params(&obj_bytes(argv[2])) {
-        Ok(p) => p,
-        Err(e) => return err(interp, &e),
-    };
-    let m = Method {
-        params,
-        body: obj_bytes(argv[3]),
-    };
-    interp
-        .oo
-        .classes
-        .get_mut(&class)
-        .unwrap()
-        .methods
-        .insert(obj_bytes(argv[1]), m);
+    }
     interp.set_result_bytes(b"");
     Code::Ok
 }
 
-/// `constructor params body`.
+fn def_method(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() != 4 {
+        return wrong_args(interp, b"method name args body");
+    }
+    let params = match crate::cmd_proc::parse_params(&obj_bytes(argv[2])) {
+        Ok(p) => p,
+        Err(e) => return err(interp, &e),
+    };
+    install_method(
+        interp,
+        obj_bytes(argv[1]),
+        Method::Body {
+            params,
+            body: obj_bytes(argv[3]),
+        },
+    )
+}
+
+/// `forward name cmdPrefix ?arg ...?` — a method that calls a command prefix.
+fn def_forward(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 3 {
+        return wrong_args(interp, b"forward name cmdName ?arg ...?");
+    }
+    let prefix: Vec<Vec<u8>> = argv[2..].iter().map(|&a| obj_bytes(a)).collect();
+    install_method(interp, obj_bytes(argv[1]), Method::Forward { prefix })
+}
+
 fn def_constructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 3 {
         return wrong_args(interp, b"constructor arguments body");
     }
-    let class = match def_class(interp) {
-        Ok(c) => c,
+    let class = match def_target(interp) {
+        Ok(DefTarget::Class(c)) => c,
+        Ok(DefTarget::Object(_)) => return err(interp, b"constructors are only for classes"),
         Err(code) => return code,
     };
     let params = match crate::cmd_proc::parse_params(&obj_bytes(argv[1])) {
         Ok(p) => p,
         Err(e) => return err(interp, &e),
     };
-    interp.oo.classes.get_mut(&class).unwrap().constructor = Some(Method {
+    interp.oo.classes.get_mut(&class).unwrap().constructor = Some(Method::Body {
         params,
         body: obj_bytes(argv[2]),
     });
@@ -250,13 +333,13 @@ fn def_constructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// `destructor body`.
 fn def_destructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 2 {
         return wrong_args(interp, b"destructor body");
     }
-    let class = match def_class(interp) {
-        Ok(c) => c,
+    let class = match def_target(interp) {
+        Ok(DefTarget::Class(c)) => c,
+        Ok(DefTarget::Object(_)) => return err(interp, b"destructors are only for classes"),
         Err(code) => return code,
     };
     interp.oo.classes.get_mut(&class).unwrap().destructor = Some(obj_bytes(argv[1]));
@@ -264,17 +347,16 @@ fn def_destructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// `superclass name ?name ...?`.
 fn def_superclass(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let class = match def_class(interp) {
-        Ok(c) => c,
+    let class = match def_target(interp) {
+        Ok(DefTarget::Class(c)) => c,
+        Ok(DefTarget::Object(_)) => return err(interp, b"superclass is only for classes"),
         Err(code) => return code,
     };
     let supers: Vec<Vec<u8>> = argv[1..]
         .iter()
         .map(|&a| interp.fqn_for(&obj_bytes(a)))
         .collect();
-    // Validate each names a class.
     for s in &supers {
         if !interp.oo.classes.contains_key(s) {
             let mut m = b"\"".to_vec();
@@ -292,29 +374,70 @@ fn def_superclass(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// `variable ?name ...?` — declare the class's instance variables.
-///
-/// Note: this shadows the global `variable` command. Inside an `oo::define`
-/// body it records instance-variable names; otherwise it forwards to the
-/// ordinary [`crate::cmd_var`] `variable`.
-fn def_variable(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    if interp.oo.def_stack.is_empty() {
-        return crate::cmd_var::variable(interp, argv);
-    }
-    let class = interp.oo.def_stack.last().unwrap().clone();
-    let names: Vec<Vec<u8>> = argv[1..].iter().map(|&a| obj_bytes(a)).collect();
-    let c = interp.oo.classes.get_mut(&class).unwrap();
-    for n in names {
-        if !c.variables.contains(&n) {
-            c.variables.push(n);
+/// `mixin ?class ...?` — set the mixins of the current class/object.
+fn def_mixin(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let mixins: Vec<Vec<u8>> = argv[1..]
+        .iter()
+        .map(|&a| interp.fqn_for(&obj_bytes(a)))
+        .collect();
+    for mx in &mixins {
+        if !interp.oo.classes.contains_key(mx) {
+            let mut m = b"\"".to_vec();
+            m.extend_from_slice(mx);
+            m.extend_from_slice(b"\" does not refer to a class");
+            return err(interp, &m);
         }
+    }
+    match def_target(interp) {
+        Ok(DefTarget::Class(c)) => interp.oo.classes.get_mut(&c).unwrap().mixins = mixins,
+        Ok(DefTarget::Object(o)) => interp.oo.objects.get_mut(&o).unwrap().mixins = mixins,
+        Err(code) => return code,
     }
     interp.set_result_bytes(b"");
     Code::Ok
 }
 
-/// `export name ?name ...?` — accepted; method visibility is not yet enforced.
-fn def_export(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
+fn def_variable(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    // Outside a definition body, this is the ordinary `variable` command.
+    if interp.oo.def_stack.is_empty() {
+        return crate::cmd_var::variable(interp, argv);
+    }
+    let names: Vec<Vec<u8>> = argv[1..].iter().map(|&a| obj_bytes(a)).collect();
+    match def_target(interp) {
+        Ok(DefTarget::Class(c)) => {
+            let cl = interp.oo.classes.get_mut(&c).unwrap();
+            for n in names {
+                if !cl.variables.contains(&n) {
+                    cl.variables.push(n);
+                }
+            }
+        }
+        // Per-object `variable` declarations are not tracked separately yet;
+        // accept them (they behave like locals).
+        Ok(DefTarget::Object(_)) => {}
+        Err(code) => return code,
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `export`/`unexport name ...` — set method visibility on the current target.
+fn def_export(interp: &mut Interp, argv: &[*mut TclObj], export: bool) -> Code {
+    let names: Vec<Vec<u8>> = argv[1..].iter().map(|&a| obj_bytes(a)).collect();
+    let set = |s: &mut BTreeSet<Vec<u8>>| {
+        for n in &names {
+            if export {
+                s.remove(n);
+            } else {
+                s.insert(n.clone());
+            }
+        }
+    };
+    match def_target(interp) {
+        Ok(DefTarget::Class(c)) => set(&mut interp.oo.classes.get_mut(&c).unwrap().unexported),
+        Ok(DefTarget::Object(o)) => set(&mut interp.oo.objects.get_mut(&o).unwrap().unexported),
+        Err(code) => return code,
+    }
     interp.set_result_bytes(b"");
     Code::Ok
 }
@@ -326,12 +449,19 @@ fn self_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return err(interp, b"self may only be called from inside a method");
     };
     let object = frame.object.clone();
-    let class = frame.mro.get(frame.index).cloned().unwrap_or_default();
+    let class = frame.chain.get(frame.index).cloned().unwrap_or_default();
     let method = frame.method.clone();
     match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
         None | Some(b"object") => interp.set_result(obj::new_string_bytes(&object)),
         Some(b"class") => interp.set_result(obj::new_string_bytes(&class)),
         Some(b"method") => interp.set_result(obj::new_string_bytes(&method)),
+        Some(b"namespace") => {
+            let ns = interp.oo.objects.get(&object).map(|o| o.var_ns);
+            let name = ns
+                .map(|n| interp.namespaces().qualified_name(n))
+                .unwrap_or_default();
+            interp.set_result(obj::new_string_bytes(&name));
+        }
         Some(other) => {
             let mut m = b"unsupported self subcommand \"".to_vec();
             m.extend_from_slice(other);
@@ -342,8 +472,6 @@ fn self_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// `my methodName ?arg ...?` — invoke a method on the current object (including
-/// non-exported ones).
 fn my_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, b"my methodName ?arg ...?");
@@ -352,36 +480,25 @@ fn my_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return err(interp, b"my may only be called from inside a method");
     };
     let method = obj_bytes(argv[1]);
-    interp.oo_invoke(&object, &method, &argv[2..])
+    interp.oo_invoke(&object, &method, &argv[2..], false)
 }
 
-/// `next ?arg ...?` — call the next implementation of the current method along
-/// the MRO (e.g. a superclass method or constructor).
 fn next_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Some(frame) = interp.oo.call_stack.last() else {
         return err(interp, b"next may only be called from inside a method");
     };
-    let (object, mro, index, method) = (
+    let (object, chain, index, method) = (
         frame.object.clone(),
-        frame.mro.clone(),
+        frame.chain.clone(),
         frame.index,
         frame.method.clone(),
     );
     let is_ctor = method.is_empty();
-    // Find the next class along the MRO that defines this method/constructor.
-    let next = (index + 1..mro.len()).find(|&j| {
-        interp.oo.classes.get(&mro[j]).is_some_and(|c| {
-            if is_ctor {
-                c.constructor.is_some()
-            } else {
-                c.methods.contains_key(&method)
-            }
-        })
-    });
+    let next =
+        (index + 1..chain.len()).find(|&j| interp.oo_has_method(&chain[j], &method, is_ctor));
     match next {
-        Some(j) => interp.oo_call(&object, mro, j, &method, &argv[1..]),
+        Some(j) => interp.oo_call(&object, chain, j, &method, &argv[1..]),
         None if is_ctor => {
-            // The implicit root constructor is a no-op.
             interp.set_result_bytes(b"");
             Code::Ok
         }
@@ -389,14 +506,239 @@ fn next_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
+// -- info object / info class (called from cmd_info) -------------------------
+
+/// `info object subcommand object ?arg?`.
+pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(interp, b"info object subcommand objName ?arg ...?");
+    }
+    let sub = obj_bytes(argv[2]);
+    let obj = interp.fqn_for(&obj_bytes(argv[3]));
+    match sub.as_slice() {
+        b"class" => {
+            let Some(o) = interp.oo.objects.get(&obj) else {
+                return not_object(interp, &obj_bytes(argv[3]));
+            };
+            interp.set_result(obj::new_string_bytes(&o.class.clone()));
+            Code::Ok
+        }
+        b"isa" => {
+            // info object isa category objName ?arg?
+            let cat = obj_bytes(argv[3]);
+            let target = interp.fqn_for(&obj_bytes(argv[4]));
+            let yes = match cat.as_slice() {
+                b"object" => interp.oo.objects.contains_key(&target),
+                b"class" => interp.oo.classes.contains_key(&target),
+                b"typeof" => {
+                    let want = interp.fqn_for(&obj_bytes(argv[5]));
+                    interp
+                        .oo
+                        .objects
+                        .get(&target)
+                        .map(|o| o.class.clone())
+                        .is_some_and(|c| interp.mro(&c).contains(&want))
+                }
+                _ => false,
+            };
+            interp.set_result_bytes(if yes { b"1" } else { b"0" });
+            Code::Ok
+        }
+        b"vars" | b"variables" => {
+            let Some(o) = interp.oo.objects.get(&obj) else {
+                return not_object(interp, &obj_bytes(argv[3]));
+            };
+            let ns = o.var_ns;
+            let mut names = interp.namespaces().var_names(ns);
+            names.sort();
+            set_list(interp, &names);
+            Code::Ok
+        }
+        b"methods" => {
+            let Some(o) = interp.oo.objects.get(&obj) else {
+                return not_object(interp, &obj_bytes(argv[3]));
+            };
+            let mut names: Vec<Vec<u8>> = o.methods.keys().cloned().collect();
+            names.sort();
+            set_list(interp, &names);
+            Code::Ok
+        }
+        b"namespace" => {
+            let Some(o) = interp.oo.objects.get(&obj) else {
+                return not_object(interp, &obj_bytes(argv[3]));
+            };
+            let name = interp.namespaces().qualified_name(o.var_ns);
+            interp.set_result(obj::new_string_bytes(&name));
+            Code::Ok
+        }
+        other => {
+            let mut m = b"unknown info object subcommand \"".to_vec();
+            m.extend_from_slice(other);
+            m.push(b'"');
+            err(interp, &m)
+        }
+    }
+}
+
+/// `info class subcommand class ?arg?`.
+pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(interp, b"info class subcommand className ?arg ...?");
+    }
+    let sub = obj_bytes(argv[2]);
+    let cls = interp.fqn_for(&obj_bytes(argv[3]));
+    if !interp.oo.classes.contains_key(&cls) {
+        let mut m = b"\"".to_vec();
+        m.extend_from_slice(&obj_bytes(argv[3]));
+        m.extend_from_slice(b"\" is not a class");
+        return err(interp, &m);
+    }
+    match sub.as_slice() {
+        b"superclasses" => {
+            let s = interp.oo.classes[&cls].supers.clone();
+            set_list(interp, &s);
+            Code::Ok
+        }
+        b"instances" => {
+            let mut insts: Vec<Vec<u8>> = interp
+                .oo
+                .objects
+                .iter()
+                .filter(|(_, o)| o.class == cls)
+                .map(|(k, _)| k.clone())
+                .collect();
+            insts.sort();
+            set_list(interp, &insts);
+            Code::Ok
+        }
+        b"subclasses" => {
+            let mut subs: Vec<Vec<u8>> = interp
+                .oo
+                .classes
+                .iter()
+                .filter(|(k, c)| **k != cls && c.supers.contains(&cls))
+                .map(|(k, _)| k.clone())
+                .collect();
+            subs.sort();
+            set_list(interp, &subs);
+            Code::Ok
+        }
+        b"methods" => {
+            let all = argv[4..].iter().any(|&a| obj_bytes(a) == b"-all");
+            let private = argv[4..].iter().any(|&a| obj_bytes(a) == b"-private");
+            let mut names: Vec<Vec<u8>> = Vec::new();
+            let chain = if all {
+                interp.mro(&cls)
+            } else {
+                vec![cls.clone()]
+            };
+            for c in &chain {
+                if let Some(cl) = interp.oo.classes.get(c) {
+                    for n in cl.methods.keys() {
+                        if (private || !cl.unexported.contains(n)) && !names.contains(n) {
+                            names.push(n.clone());
+                        }
+                    }
+                }
+            }
+            names.sort();
+            set_list(interp, &names);
+            Code::Ok
+        }
+        b"constructor" => {
+            let body = match &interp.oo.classes[&cls].constructor {
+                Some(Method::Body { params, body }) => list_params_body(params, body),
+                _ => Vec::new(),
+            };
+            interp.set_result(obj::new_string_bytes(&body));
+            Code::Ok
+        }
+        b"destructor" => {
+            let body = interp.oo.classes[&cls]
+                .destructor
+                .clone()
+                .unwrap_or_default();
+            interp.set_result(obj::new_string_bytes(&body));
+            Code::Ok
+        }
+        other => {
+            let mut m = b"unknown info class subcommand \"".to_vec();
+            m.extend_from_slice(other);
+            m.push(b'"');
+            err(interp, &m)
+        }
+    }
+}
+
+fn not_object(interp: &mut Interp, name: &[u8]) -> Code {
+    let mut m = b"\"".to_vec();
+    m.extend_from_slice(name);
+    m.extend_from_slice(b"\" does not refer to an object");
+    interp.set_error(&m)
+}
+
+/// `{params} body` as a 2-element list (for `info class constructor`).
+fn list_params_body(params: &[Param], body: &[u8]) -> Vec<u8> {
+    let mut spec = Vec::new();
+    for (i, p) in params.iter().enumerate() {
+        if i > 0 {
+            spec.push(b' ');
+        }
+        spec.extend_from_slice(&p.name);
+    }
+    let elems = [obj::new_string_bytes(&spec), obj::new_string_bytes(body)];
+    let l = list::new_list_obj(&elems); // rc 0, owns its (now rc-1) elements
+    let out = obj_bytes(l);
+    crate::interp::drop_fresh(l); // frees the list and, with it, its elements
+    out
+}
+
+fn set_list(interp: &mut Interp, names: &[Vec<u8>]) {
+    let elems: Vec<*mut TclObj> = names.iter().map(|n| obj::new_string_bytes(n)).collect();
+    // `new_list_obj` retains each element; `set_result` retains the list. The
+    // rc-0 temporaries are now owned by the list — no manual release.
+    interp.set_result(list::new_list_obj(&elems));
+}
+
 // -- the object-system engine (impl Interp) ----------------------------------
 
 impl Interp {
-    /// Run a class definition `script` with `class` as the target. Definition
-    /// commands (`method`/`constructor`/…) mutate that class.
-    fn oo_define(&mut self, class: &[u8], script: &[u8]) -> Code {
-        self.oo.def_stack.push(class.to_vec());
-        let code = self.eval_str(script);
+    /// Create class `fqn` (running its optional definition script).
+    fn oo_make_class(&mut self, fqn: &[u8], script: Option<&[u8]>) -> Code {
+        if self.oo.classes.contains_key(fqn) || self.oo.objects.contains_key(fqn) {
+            let mut m = b"can't create class \"".to_vec();
+            m.extend_from_slice(fqn);
+            m.extend_from_slice(b"\": command already exists with that name");
+            return self.error(&m);
+        }
+        self.oo.classes.insert(
+            fqn.to_vec(),
+            Class {
+                supers: vec![b"::oo::object".to_vec()],
+                ..Class::default()
+            },
+        );
+        self.ns_register(fqn, Command::OoObject(fqn.to_vec()));
+        if let Some(script) = script {
+            self.oo.def_stack.push(DefTarget::Class(fqn.to_vec()));
+            let code = self.eval_str(script);
+            self.oo.def_stack.pop();
+            if code != Code::Ok {
+                return code;
+            }
+        }
+        self.set_result(obj::new_string_bytes(fqn));
+        Code::Ok
+    }
+
+    /// Run an `oo::define`/`oo::objdefine` body or single subcommand on `target`.
+    fn oo_run_def(&mut self, target: DefTarget, argv: &[*mut TclObj]) -> Code {
+        self.oo.def_stack.push(target);
+        let code = if argv.len() == 3 {
+            self.eval_str(&obj_bytes(argv[2]))
+        } else {
+            self.dispatch(&argv[2..])
+        };
         self.oo.def_stack.pop();
         code
     }
@@ -404,7 +746,6 @@ impl Interp {
     /// Dispatch a command bound to the OO object/class FQN `fqn`.
     pub(crate) fn oo_dispatch(&mut self, fqn: &[u8], argv: &[*mut TclObj]) -> Code {
         if self.oo.classes.contains_key(fqn) {
-            // Class command: `Class new|create|destroy ...`.
             match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
                 Some(b"new") => self.oo_new(fqn, None, &argv[2..]),
                 Some(b"create") if argv.len() >= 3 => {
@@ -416,23 +757,17 @@ impl Interp {
                     self.set_result_bytes(b"");
                     Code::Ok
                 }
-                Some(other) => {
-                    let mut m = b"unknown method \"".to_vec();
-                    m.extend_from_slice(other);
-                    m.extend_from_slice(b"\"");
-                    self.error(&m)
-                }
+                Some(other) => unknown_method(self, other),
                 None => self.error(b"wrong # args: should be \"class method ?arg ...?\""),
             }
         } else if self.oo.objects.contains_key(fqn) {
-            // Object command: `$obj destroy` or `$obj method ...`.
             match argv.get(1).map(|&a| obj_bytes(a)) {
                 Some(m) if m == b"destroy" => {
                     self.oo_destroy(fqn);
                     self.set_result_bytes(b"");
                     Code::Ok
                 }
-                Some(method) => self.oo_invoke(fqn, &method, &argv[2..]),
+                Some(method) => self.oo_invoke(fqn, &method, &argv[2..], true),
                 None => self.error(b"wrong # args: should be \"object method ?arg ...?\""),
             }
         } else {
@@ -440,8 +775,6 @@ impl Interp {
         }
     }
 
-    /// Create an instance of `class` (optionally named `name`, else auto-named),
-    /// running its constructor with `args`. Result is the object FQN.
     fn oo_new(&mut self, class: &[u8], name: Option<Vec<u8>>, args: &[*mut TclObj]) -> Code {
         let fqn = name.unwrap_or_else(|| {
             let n = format!("::oo::Obj{}", self.oo.counter);
@@ -454,18 +787,17 @@ impl Interp {
             m.extend_from_slice(b"\": command already exists with that name");
             return self.error(&m);
         }
-        // A private namespace for the object's instance variables.
         let var_ns = self.ensure_namespace(&fqn);
         self.oo.objects.insert(
             fqn.clone(),
             Object {
                 class: class.to_vec(),
                 var_ns,
+                ..Object::default()
             },
         );
         self.ns_register(&fqn, Command::OoObject(fqn.clone()));
 
-        // Run the constructor along the MRO (if any class defines one).
         let mro = self.mro(class);
         if let Some(j) = mro.iter().position(|c| {
             self.oo
@@ -473,9 +805,11 @@ impl Interp {
                 .get(c)
                 .is_some_and(|c| c.constructor.is_some())
         }) {
-            let code = self.oo_call(&fqn, mro, j, b"", args);
+            // Constructor dispatch runs along the *class* MRO (objects can't
+            // define constructors), with the object as `self`.
+            let chain = mro;
+            let code = self.oo_call(&fqn, chain, j, b"", args);
             if code == Code::Error {
-                // Construction failed: roll back the half-built object.
                 self.oo.objects.remove(&fqn);
                 self.delete_command(&fqn);
                 return Code::Error;
@@ -487,54 +821,152 @@ impl Interp {
         Code::Ok
     }
 
-    /// Invoke instance method `method` on object `obj` with `args`.
-    fn oo_invoke(&mut self, obj: &[u8], method: &[u8], args: &[*mut TclObj]) -> Code {
-        let Some(class) = self.oo.objects.get(obj).map(|o| o.class.clone()) else {
+    /// Invoke method `method` on `obj`. `external` enforces export visibility.
+    fn oo_invoke(
+        &mut self,
+        obj: &[u8],
+        method: &[u8],
+        args: &[*mut TclObj],
+        external: bool,
+    ) -> Code {
+        if !self.oo.objects.contains_key(obj) {
             return self.invalid_command(obj);
-        };
-        let mro = self.mro(&class);
-        match mro.iter().position(|c| {
-            self.oo
-                .classes
-                .get(c)
-                .is_some_and(|c| c.methods.contains_key(method))
-        }) {
-            Some(j) => self.oo_call(obj, mro, j, method, args),
-            None => {
-                let mut m = b"unknown method \"".to_vec();
-                m.extend_from_slice(method);
-                m.extend_from_slice(b"\"");
-                self.error(&m)
-            }
+        }
+        let chain = self.method_chain(obj);
+        let found = chain.iter().position(|c| {
+            self.oo_has_method(c, method, false) && !(external && self.method_unexported(c, method))
+        });
+        match found {
+            Some(j) => self.oo_call(obj, chain, j, method, args),
+            None => unknown_method(self, method),
         }
     }
 
-    /// Run the method (or constructor, when `method` is empty) defined by
-    /// `mro[index]` on `obj`, pushing the OO call frame so `self`/`my`/`next`
-    /// work and auto-linking the declared instance variables.
+    /// The method-resolution chain for `obj`: the object's own methods, then its
+    /// mixins, then the class's mixins, then the class MRO (deduped, first wins).
+    fn method_chain(&self, obj: &[u8]) -> Vec<Vec<u8>> {
+        let mut chain: Vec<Vec<u8>> = vec![obj.to_vec()];
+        let push = |c: &[u8], chain: &mut Vec<Vec<u8>>| {
+            if !chain.iter().any(|x| x == c) {
+                chain.push(c.to_vec());
+            }
+        };
+        if let Some(o) = self.oo.objects.get(obj) {
+            for mx in &o.mixins {
+                for c in self.mro(mx) {
+                    push(&c, &mut chain);
+                }
+            }
+            let cls = o.class.clone();
+            if let Some(cl) = self.oo.classes.get(&cls) {
+                for mx in &cl.mixins {
+                    for c in self.mro(mx) {
+                        push(&c, &mut chain);
+                    }
+                }
+            }
+            for c in self.mro(&cls) {
+                push(&c, &mut chain);
+            }
+        }
+        chain
+    }
+
+    /// Whether the provider `prov` (object FQN or class FQN) defines `method`
+    /// (or a constructor, when `ctor`).
+    fn oo_has_method(&self, prov: &[u8], method: &[u8], ctor: bool) -> bool {
+        if ctor {
+            return self
+                .oo
+                .classes
+                .get(prov)
+                .is_some_and(|c| c.constructor.is_some());
+        }
+        if let Some(o) = self.oo.objects.get(prov) {
+            o.methods.contains_key(method)
+        } else {
+            self.oo
+                .classes
+                .get(prov)
+                .is_some_and(|c| c.methods.contains_key(method))
+        }
+    }
+
+    fn method_unexported(&self, prov: &[u8], method: &[u8]) -> bool {
+        if let Some(o) = self.oo.objects.get(prov) {
+            o.unexported.contains(method)
+        } else {
+            self.oo
+                .classes
+                .get(prov)
+                .is_some_and(|c| c.unexported.contains(method))
+        }
+    }
+
+    /// Run the method (or constructor when `method` is empty) provided by
+    /// `chain[index]` on `obj`.
     fn oo_call(
         &mut self,
         obj: &[u8],
-        mro: Vec<Vec<u8>>,
+        chain: Vec<Vec<u8>>,
         index: usize,
         method: &[u8],
         args: &[*mut TclObj],
     ) -> Code {
-        // Clone what we need before borrowing `self` mutably for `run_proc`.
-        let cls = &self.oo.classes[&mro[index]];
+        let prov = chain[index].clone();
         let m = if method.is_empty() {
-            cls.constructor.clone()
+            self.oo
+                .classes
+                .get(&prov)
+                .and_then(|c| c.constructor.clone())
+        } else if let Some(o) = self.oo.objects.get(&prov) {
+            o.methods.get(method).cloned()
         } else {
-            cls.methods.get(method).cloned()
+            self.oo
+                .classes
+                .get(&prov)
+                .and_then(|c| c.methods.get(method).cloned())
         };
         let Some(m) = m else {
             return self.error(b"no such method");
         };
+
+        // A forward: build `prefix + args` and dispatch (with the OO context so a
+        // forwarded `my`/`self` still works).
+        if let Method::Forward { prefix } = &m {
+            let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + args.len());
+            // Each element owns a +1 (released in the `decr` loop below).
+            for p in prefix {
+                let o = obj::new_string_bytes(p);
+                unsafe { obj::incr_ref_count(o) };
+                new_argv.push(o);
+            }
+            for &a in args {
+                unsafe { obj::incr_ref_count(a) };
+                new_argv.push(a);
+            }
+            self.oo.call_stack.push(OoFrame {
+                object: obj.to_vec(),
+                chain,
+                index,
+                method: method.to_vec(),
+            });
+            let code = self.dispatch(&new_argv);
+            self.oo.call_stack.pop();
+            for a in new_argv {
+                unsafe { obj::decr_ref_count(a) };
+            }
+            return code;
+        }
+
+        let Method::Body { params, body } = m else {
+            unreachable!("forward handled above");
+        };
         let var_ns = self.oo.objects[obj].var_ns;
-        // The declared instance variables visible to the method: the union over
-        // the whole MRO.
+        // The declared instance variables visible to the method: union over the
+        // chain's classes.
         let mut vars: Vec<Vec<u8>> = Vec::new();
-        for c in &mro {
+        for c in &chain {
             if let Some(cl) = self.oo.classes.get(c) {
                 for v in &cl.variables {
                     if !vars.contains(v) {
@@ -550,13 +982,13 @@ impl Interp {
         };
         self.oo.call_stack.push(OoFrame {
             object: obj.to_vec(),
-            mro,
+            chain,
             index,
             method: method.to_vec(),
         });
         let code = self.run_proc(
-            &m.params,
-            &m.body,
+            &params,
+            &body,
             var_ns,
             args,
             &name,
@@ -572,7 +1004,6 @@ impl Interp {
         code
     }
 
-    /// Destroy an object: run its destructor (best-effort), then remove it.
     fn oo_destroy(&mut self, obj: &[u8]) {
         let class = self.oo.objects.get(obj).map(|o| o.class.clone());
         if let Some(class) = class {
@@ -582,7 +1013,7 @@ impl Interp {
                     let var_ns = self.oo.objects[obj].var_ns;
                     self.oo.call_stack.push(OoFrame {
                         object: obj.to_vec(),
-                        mro: mro.clone(),
+                        chain: mro.clone(),
                         index: 0,
                         method: b"<destructor>".to_vec(),
                     });
@@ -609,15 +1040,24 @@ impl Interp {
         self.delete_command(obj);
     }
 
-    /// Destroy a class (and its command). Instances are left as-is (a follow-up
-    /// would cascade); this is enough for test teardown.
     fn oo_destroy_class(&mut self, class: &[u8]) {
+        // Destroy the class's instances first (TclOO cascades).
+        let insts: Vec<Vec<u8>> = self
+            .oo
+            .objects
+            .iter()
+            .filter(|(_, o)| o.class == class)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for o in insts {
+            self.oo_destroy(&o);
+        }
         self.oo.classes.remove(class);
         self.delete_command(class);
     }
 
     /// The method-resolution order for `class`: a preorder walk of the class and
-    /// its superclasses, each class appearing once (first occurrence wins).
+    /// its superclasses, each class appearing once.
     fn mro(&self, class: &[u8]) -> Vec<Vec<u8>> {
         let mut out: Vec<Vec<u8>> = Vec::new();
         self.mro_visit(class, &mut out);
@@ -678,12 +1118,8 @@ mod tests {
             );
             ok(i, b"set a [Animal new woof]");
             assert_eq!(ok(i, b"$a speak"), b"I say woof");
-            // `self` inside a method is the object.
-            assert_eq!(
-                ok(i, b"Animal create ::bessie moo; bessie speak"),
-                b"I say moo"
-            );
-            // destroy removes the command.
+            ok(i, b"Animal create ::bessie moo");
+            assert_eq!(ok(i, b"bessie speak"), b"I say moo");
             ok(i, b"bessie destroy");
             assert_eq!(i.eval_str(b"bessie speak"), Code::Error);
         });
@@ -692,28 +1128,39 @@ mod tests {
     #[test]
     fn inheritance_and_next() {
         leak_free(|i| {
-            ok(
-                i,
-                b"oo::class create Animal {
-                    variable sound
-                    constructor {s} { set sound $s }
-                    method speak {} { return \"I say $sound\" }
-                }",
-            );
-            ok(
-                i,
-                b"oo::class create Dog {
-                    superclass Animal
-                    constructor {} { next bark }
-                    method speak {} { return \"Dog: [next]\" }
-                }",
-            );
+            ok(i, b"oo::class create Animal { variable s; constructor {x} {set s $x}; method speak {} {return \"I say $s\"} }");
+            ok(i, b"oo::class create Dog { superclass Animal; constructor {} {next bark}; method speak {} {return \"Dog: [next]\"} }");
             ok(i, b"set d [Dog new]");
-            // `next bark` chained to Animal's constructor; `next` chained speak.
             assert_eq!(ok(i, b"$d speak"), b"Dog: I say bark");
-            // `oo::define` adds a method after the fact.
             ok(i, b"oo::define Dog method legs {} { return 4 }");
             assert_eq!(ok(i, b"$d legs"), b"4");
+        });
+    }
+
+    #[test]
+    fn objdefine_forward_mixin_unexport_copy() {
+        leak_free(|i| {
+            ok(i, b"oo::class create Base { method m {} {return base}; method hide {} {return H}; unexport hide }");
+            ok(i, b"set o [Base new]");
+            // unexported method: external call fails, `my` works.
+            assert_eq!(i.eval_str(b"$o hide"), Code::Error);
+            // per-object method via objdefine
+            ok(i, b"oo::objdefine $o { method extra {} {return per-obj} }");
+            assert_eq!(ok(i, b"$o extra"), b"per-obj");
+            // forward
+            ok(i, b"oo::class create F { forward add ::tcl::mathop::+ 10 }");
+            assert_eq!(ok(i, b"[F new] add 5"), b"15");
+            // mixin
+            ok(
+                i,
+                b"oo::class create Mix { method mixed {} {return MIXED} }",
+            );
+            ok(i, b"oo::objdefine $o { mixin Mix }");
+            assert_eq!(ok(i, b"$o mixed"), b"MIXED");
+            // info introspection
+            assert_eq!(ok(i, b"info object class $o"), b"::Base");
+            assert_eq!(ok(i, b"info object isa object $o"), b"1");
+            assert_eq!(ok(i, b"info class instances Base"), b"::oo::Obj0");
         });
     }
 
@@ -721,7 +1168,6 @@ mod tests {
     fn oo_package_is_provided() {
         leak_free(|i| {
             assert_eq!(ok(i, b"package require tcl::oo"), b"1.3.1");
-            assert_eq!(ok(i, b"package require TclOO"), b"1.3.1");
         });
     }
 }

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -117,9 +117,10 @@ pub fn install(interp: &mut Interp) {
     // builtin command — only the registry entry is added).
     interp
         .oo
+        .borrow_mut()
         .classes
         .insert(b"::oo::object".to_vec(), Class::default());
-    interp.oo.classes.insert(
+    interp.oo.borrow_mut().classes.insert(
         b"::oo::class".to_vec(),
         Class {
             supers: vec![b"::oo::object".to_vec()],
@@ -159,8 +160,8 @@ fn oo_class_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
         Some(b"new") => {
             // Anonymous class.
-            let n = interp.oo.counter;
-            interp.oo.counter += 1;
+            let n = interp.oo.borrow().counter;
+            interp.oo.borrow_mut().counter += 1;
             let fqn = format!("::oo::Obj{n}").into_bytes();
             interp.oo_make_class(&fqn, argv.get(2).map(|&a| obj_bytes(a)).as_deref())
         }
@@ -186,7 +187,7 @@ fn oo_define_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"oo::define target ?arg ...?");
     }
     let fqn = interp.fqn_for(&obj_bytes(argv[1]));
-    if !interp.oo.classes.contains_key(&fqn) {
+    if !interp.oo.borrow().classes.contains_key(&fqn) {
         let mut m = b"\"".to_vec();
         m.extend_from_slice(&obj_bytes(argv[1]));
         m.extend_from_slice(b"\" does not refer to a class");
@@ -201,7 +202,7 @@ fn oo_objdefine_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"oo::objdefine target ?arg ...?");
     }
     let fqn = interp.fqn_for(&obj_bytes(argv[1]));
-    if !interp.oo.objects.contains_key(&fqn) {
+    if !interp.oo.borrow().objects.contains_key(&fqn) {
         let mut m = b"\"".to_vec();
         m.extend_from_slice(&obj_bytes(argv[1]));
         m.extend_from_slice(b"\" does not refer to an object");
@@ -217,7 +218,7 @@ fn oo_copy_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"oo::copy sourceName ?targetName?");
     }
     let src = interp.fqn_for(&obj_bytes(argv[1]));
-    let Some(src_obj) = interp.oo.objects.get(&src).cloned() else {
+    let Some(src_obj) = interp.oo.borrow().objects.get(&src).cloned() else {
         let mut m = b"\"".to_vec();
         m.extend_from_slice(&obj_bytes(argv[1]));
         m.extend_from_slice(b"\" does not refer to an object");
@@ -226,13 +227,13 @@ fn oo_copy_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let dst = match argv.get(2) {
         Some(&a) => interp.fqn_for(&obj_bytes(a)),
         None => {
-            let n = interp.oo.counter;
-            interp.oo.counter += 1;
+            let n = interp.oo.borrow().counter;
+            interp.oo.borrow_mut().counter += 1;
             format!("::oo::Obj{n}").into_bytes()
         }
     };
     let var_ns = interp.ensure_namespace(&dst);
-    interp.oo.objects.insert(
+    interp.oo.borrow_mut().objects.insert(
         dst.clone(),
         Object {
             class: src_obj.class,
@@ -251,8 +252,9 @@ fn oo_copy_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 /// The current definition target, or an error if outside a definition body.
 fn def_target(interp: &mut Interp) -> Result<DefTarget, Code> {
-    match interp.oo.def_stack.last() {
-        Some(t) => Ok(t.clone()),
+    let target = interp.oo.borrow().def_stack.last().cloned();
+    match target {
+        Some(t) => Ok(t),
         None => Err(interp
             .set_error(b"this command can only be called from within the body of a definition")),
     }
@@ -264,6 +266,7 @@ fn install_method(interp: &mut Interp, name: Vec<u8>, m: Method) -> Code {
         Ok(DefTarget::Class(c)) => {
             interp
                 .oo
+                .borrow_mut()
                 .classes
                 .get_mut(&c)
                 .unwrap()
@@ -273,6 +276,7 @@ fn install_method(interp: &mut Interp, name: Vec<u8>, m: Method) -> Code {
         Ok(DefTarget::Object(o)) => {
             interp
                 .oo
+                .borrow_mut()
                 .objects
                 .get_mut(&o)
                 .unwrap()
@@ -325,7 +329,13 @@ fn def_constructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(p) => p,
         Err(e) => return err(interp, &e),
     };
-    interp.oo.classes.get_mut(&class).unwrap().constructor = Some(Method::Body {
+    interp
+        .oo
+        .borrow_mut()
+        .classes
+        .get_mut(&class)
+        .unwrap()
+        .constructor = Some(Method::Body {
         params,
         body: obj_bytes(argv[2]),
     });
@@ -342,7 +352,13 @@ fn def_destructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(DefTarget::Object(_)) => return err(interp, b"destructors are only for classes"),
         Err(code) => return code,
     };
-    interp.oo.classes.get_mut(&class).unwrap().destructor = Some(obj_bytes(argv[1]));
+    interp
+        .oo
+        .borrow_mut()
+        .classes
+        .get_mut(&class)
+        .unwrap()
+        .destructor = Some(obj_bytes(argv[1]));
     interp.set_result_bytes(b"");
     Code::Ok
 }
@@ -358,14 +374,20 @@ fn def_superclass(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         .map(|&a| interp.fqn_for(&obj_bytes(a)))
         .collect();
     for s in &supers {
-        if !interp.oo.classes.contains_key(s) {
+        if !interp.oo.borrow().classes.contains_key(s) {
             let mut m = b"\"".to_vec();
             m.extend_from_slice(s);
             m.extend_from_slice(b"\" does not refer to a class");
             return err(interp, &m);
         }
     }
-    interp.oo.classes.get_mut(&class).unwrap().supers = if supers.is_empty() {
+    interp
+        .oo
+        .borrow_mut()
+        .classes
+        .get_mut(&class)
+        .unwrap()
+        .supers = if supers.is_empty() {
         vec![b"::oo::object".to_vec()]
     } else {
         supers
@@ -381,7 +403,7 @@ fn def_mixin(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         .map(|&a| interp.fqn_for(&obj_bytes(a)))
         .collect();
     for mx in &mixins {
-        if !interp.oo.classes.contains_key(mx) {
+        if !interp.oo.borrow().classes.contains_key(mx) {
             let mut m = b"\"".to_vec();
             m.extend_from_slice(mx);
             m.extend_from_slice(b"\" does not refer to a class");
@@ -389,8 +411,12 @@ fn def_mixin(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
     }
     match def_target(interp) {
-        Ok(DefTarget::Class(c)) => interp.oo.classes.get_mut(&c).unwrap().mixins = mixins,
-        Ok(DefTarget::Object(o)) => interp.oo.objects.get_mut(&o).unwrap().mixins = mixins,
+        Ok(DefTarget::Class(c)) => {
+            interp.oo.borrow_mut().classes.get_mut(&c).unwrap().mixins = mixins
+        }
+        Ok(DefTarget::Object(o)) => {
+            interp.oo.borrow_mut().objects.get_mut(&o).unwrap().mixins = mixins
+        }
         Err(code) => return code,
     }
     interp.set_result_bytes(b"");
@@ -399,13 +425,14 @@ fn def_mixin(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 fn def_variable(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // Outside a definition body, this is the ordinary `variable` command.
-    if interp.oo.def_stack.is_empty() {
+    if interp.oo.borrow().def_stack.is_empty() {
         return crate::cmd_var::variable(interp, argv);
     }
     let names: Vec<Vec<u8>> = argv[1..].iter().map(|&a| obj_bytes(a)).collect();
     match def_target(interp) {
         Ok(DefTarget::Class(c)) => {
-            let cl = interp.oo.classes.get_mut(&c).unwrap();
+            let mut oo = interp.oo.borrow_mut();
+            let cl = oo.classes.get_mut(&c).unwrap();
             for n in names {
                 if !cl.variables.contains(&n) {
                     cl.variables.push(n);
@@ -434,8 +461,20 @@ fn def_export(interp: &mut Interp, argv: &[*mut TclObj], export: bool) -> Code {
         }
     };
     match def_target(interp) {
-        Ok(DefTarget::Class(c)) => set(&mut interp.oo.classes.get_mut(&c).unwrap().unexported),
-        Ok(DefTarget::Object(o)) => set(&mut interp.oo.objects.get_mut(&o).unwrap().unexported),
+        Ok(DefTarget::Class(c)) => set(&mut interp
+            .oo
+            .borrow_mut()
+            .classes
+            .get_mut(&c)
+            .unwrap()
+            .unexported),
+        Ok(DefTarget::Object(o)) => set(&mut interp
+            .oo
+            .borrow_mut()
+            .objects
+            .get_mut(&o)
+            .unwrap()
+            .unexported),
         Err(code) => return code,
     }
     interp.set_result_bytes(b"");
@@ -445,18 +484,22 @@ fn def_export(interp: &mut Interp, argv: &[*mut TclObj], export: bool) -> Code {
 // -- method context: self / my / next ---------------------------------------
 
 fn self_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let Some(frame) = interp.oo.call_stack.last() else {
+    let ctx = interp.oo.borrow().call_stack.last().map(|frame| {
+        (
+            frame.object.clone(),
+            frame.chain.get(frame.index).cloned().unwrap_or_default(),
+            frame.method.clone(),
+        )
+    });
+    let Some((object, class, method)) = ctx else {
         return err(interp, b"self may only be called from inside a method");
     };
-    let object = frame.object.clone();
-    let class = frame.chain.get(frame.index).cloned().unwrap_or_default();
-    let method = frame.method.clone();
     match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
         None | Some(b"object") => interp.set_result(obj::new_string_bytes(&object)),
         Some(b"class") => interp.set_result(obj::new_string_bytes(&class)),
         Some(b"method") => interp.set_result(obj::new_string_bytes(&method)),
         Some(b"namespace") => {
-            let ns = interp.oo.objects.get(&object).map(|o| o.var_ns);
+            let ns = interp.oo.borrow().objects.get(&object).map(|o| o.var_ns);
             let name = ns
                 .map(|n| interp.namespaces().qualified_name(n))
                 .unwrap_or_default();
@@ -476,7 +519,13 @@ fn my_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, b"my methodName ?arg ...?");
     }
-    let Some(object) = interp.oo.call_stack.last().map(|f| f.object.clone()) else {
+    let Some(object) = interp
+        .oo
+        .borrow()
+        .call_stack
+        .last()
+        .map(|f| f.object.clone())
+    else {
         return err(interp, b"my may only be called from inside a method");
     };
     let method = obj_bytes(argv[1]);
@@ -484,15 +533,17 @@ fn my_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 }
 
 fn next_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let Some(frame) = interp.oo.call_stack.last() else {
+    let ctx = interp.oo.borrow().call_stack.last().map(|frame| {
+        (
+            frame.object.clone(),
+            frame.chain.clone(),
+            frame.index,
+            frame.method.clone(),
+        )
+    });
+    let Some((object, chain, index, method)) = ctx else {
         return err(interp, b"next may only be called from inside a method");
     };
-    let (object, chain, index, method) = (
-        frame.object.clone(),
-        frame.chain.clone(),
-        frame.index,
-        frame.method.clone(),
-    );
     let is_ctor = method.is_empty();
     let next =
         (index + 1..chain.len()).find(|&j| interp.oo_has_method(&chain[j], &method, is_ctor));
@@ -517,10 +568,16 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let obj = interp.fqn_for(&obj_bytes(argv[3]));
     match sub.as_slice() {
         b"class" => {
-            let Some(o) = interp.oo.objects.get(&obj) else {
+            let class = interp
+                .oo
+                .borrow()
+                .objects
+                .get(&obj)
+                .map(|o| o.class.clone());
+            let Some(class) = class else {
                 return not_object(interp, &obj_bytes(argv[3]));
             };
-            interp.set_result(obj::new_string_bytes(&o.class.clone()));
+            interp.set_result(obj::new_string_bytes(&class));
             Code::Ok
         }
         b"isa" => {
@@ -528,12 +585,13 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             let cat = obj_bytes(argv[3]);
             let target = interp.fqn_for(&obj_bytes(argv[4]));
             let yes = match cat.as_slice() {
-                b"object" => interp.oo.objects.contains_key(&target),
-                b"class" => interp.oo.classes.contains_key(&target),
+                b"object" => interp.oo.borrow().objects.contains_key(&target),
+                b"class" => interp.oo.borrow().classes.contains_key(&target),
                 b"typeof" => {
                     let want = interp.fqn_for(&obj_bytes(argv[5]));
                     interp
                         .oo
+                        .borrow()
                         .objects
                         .get(&target)
                         .map(|o| o.class.clone())
@@ -545,29 +603,35 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"vars" | b"variables" => {
-            let Some(o) = interp.oo.objects.get(&obj) else {
+            let ns = interp.oo.borrow().objects.get(&obj).map(|o| o.var_ns);
+            let Some(ns) = ns else {
                 return not_object(interp, &obj_bytes(argv[3]));
             };
-            let ns = o.var_ns;
             let mut names = interp.namespaces().var_names(ns);
             names.sort();
             set_list(interp, &names);
             Code::Ok
         }
         b"methods" => {
-            let Some(o) = interp.oo.objects.get(&obj) else {
+            let names: Option<Vec<Vec<u8>>> = interp
+                .oo
+                .borrow()
+                .objects
+                .get(&obj)
+                .map(|o| o.methods.keys().cloned().collect());
+            let Some(mut names) = names else {
                 return not_object(interp, &obj_bytes(argv[3]));
             };
-            let mut names: Vec<Vec<u8>> = o.methods.keys().cloned().collect();
             names.sort();
             set_list(interp, &names);
             Code::Ok
         }
         b"namespace" => {
-            let Some(o) = interp.oo.objects.get(&obj) else {
+            let ns = interp.oo.borrow().objects.get(&obj).map(|o| o.var_ns);
+            let Some(ns) = ns else {
                 return not_object(interp, &obj_bytes(argv[3]));
             };
-            let name = interp.namespaces().qualified_name(o.var_ns);
+            let name = interp.namespaces().qualified_name(ns);
             interp.set_result(obj::new_string_bytes(&name));
             Code::Ok
         }
@@ -587,7 +651,7 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let sub = obj_bytes(argv[2]);
     let cls = interp.fqn_for(&obj_bytes(argv[3]));
-    if !interp.oo.classes.contains_key(&cls) {
+    if !interp.oo.borrow().classes.contains_key(&cls) {
         let mut m = b"\"".to_vec();
         m.extend_from_slice(&obj_bytes(argv[3]));
         m.extend_from_slice(b"\" is not a class");
@@ -595,13 +659,14 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     match sub.as_slice() {
         b"superclasses" => {
-            let s = interp.oo.classes[&cls].supers.clone();
+            let s = interp.oo.borrow().classes[&cls].supers.clone();
             set_list(interp, &s);
             Code::Ok
         }
         b"instances" => {
             let mut insts: Vec<Vec<u8>> = interp
                 .oo
+                .borrow()
                 .objects
                 .iter()
                 .filter(|(_, o)| o.class == cls)
@@ -614,6 +679,7 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"subclasses" => {
             let mut subs: Vec<Vec<u8>> = interp
                 .oo
+                .borrow()
                 .classes
                 .iter()
                 .filter(|(k, c)| **k != cls && c.supers.contains(&cls))
@@ -633,7 +699,7 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 vec![cls.clone()]
             };
             for c in &chain {
-                if let Some(cl) = interp.oo.classes.get(c) {
+                if let Some(cl) = interp.oo.borrow().classes.get(c) {
                     for n in cl.methods.keys() {
                         if (private || !cl.unexported.contains(n)) && !names.contains(n) {
                             names.push(n.clone());
@@ -646,7 +712,7 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"constructor" => {
-            let body = match &interp.oo.classes[&cls].constructor {
+            let body = match &interp.oo.borrow().classes[&cls].constructor {
                 Some(Method::Body { params, body }) => list_params_body(params, body),
                 _ => Vec::new(),
             };
@@ -654,7 +720,7 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"destructor" => {
-            let body = interp.oo.classes[&cls]
+            let body = interp.oo.borrow().classes[&cls]
                 .destructor
                 .clone()
                 .unwrap_or_default();
@@ -705,13 +771,14 @@ fn set_list(interp: &mut Interp, names: &[Vec<u8>]) {
 impl Interp {
     /// Create class `fqn` (running its optional definition script).
     fn oo_make_class(&mut self, fqn: &[u8], script: Option<&[u8]>) -> Code {
-        if self.oo.classes.contains_key(fqn) || self.oo.objects.contains_key(fqn) {
+        if self.oo.borrow().classes.contains_key(fqn) || self.oo.borrow().objects.contains_key(fqn)
+        {
             let mut m = b"can't create class \"".to_vec();
             m.extend_from_slice(fqn);
             m.extend_from_slice(b"\": command already exists with that name");
             return self.error(&m);
         }
-        self.oo.classes.insert(
+        self.oo.borrow_mut().classes.insert(
             fqn.to_vec(),
             Class {
                 supers: vec![b"::oo::object".to_vec()],
@@ -720,9 +787,12 @@ impl Interp {
         );
         self.ns_register(fqn, Command::OoObject(fqn.to_vec()));
         if let Some(script) = script {
-            self.oo.def_stack.push(DefTarget::Class(fqn.to_vec()));
+            self.oo
+                .borrow_mut()
+                .def_stack
+                .push(DefTarget::Class(fqn.to_vec()));
             let code = self.eval_str(script);
-            self.oo.def_stack.pop();
+            self.oo.borrow_mut().def_stack.pop();
             if code != Code::Ok {
                 return code;
             }
@@ -733,19 +803,19 @@ impl Interp {
 
     /// Run an `oo::define`/`oo::objdefine` body or single subcommand on `target`.
     fn oo_run_def(&mut self, target: DefTarget, argv: &[*mut TclObj]) -> Code {
-        self.oo.def_stack.push(target);
+        self.oo.borrow_mut().def_stack.push(target);
         let code = if argv.len() == 3 {
             self.eval_str(&obj_bytes(argv[2]))
         } else {
             self.dispatch(&argv[2..])
         };
-        self.oo.def_stack.pop();
+        self.oo.borrow_mut().def_stack.pop();
         code
     }
 
     /// Dispatch a command bound to the OO object/class FQN `fqn`.
     pub(crate) fn oo_dispatch(&mut self, fqn: &[u8], argv: &[*mut TclObj]) -> Code {
-        if self.oo.classes.contains_key(fqn) {
+        if self.oo.borrow().classes.contains_key(fqn) {
             match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
                 Some(b"new") => self.oo_new(fqn, None, &argv[2..]),
                 Some(b"create") if argv.len() >= 3 => {
@@ -760,7 +830,7 @@ impl Interp {
                 Some(other) => unknown_method(self, other),
                 None => self.error(b"wrong # args: should be \"class method ?arg ...?\""),
             }
-        } else if self.oo.objects.contains_key(fqn) {
+        } else if self.oo.borrow().objects.contains_key(fqn) {
             match argv.get(1).map(|&a| obj_bytes(a)) {
                 Some(m) if m == b"destroy" => {
                     self.oo_destroy(fqn);
@@ -777,18 +847,20 @@ impl Interp {
 
     fn oo_new(&mut self, class: &[u8], name: Option<Vec<u8>>, args: &[*mut TclObj]) -> Code {
         let fqn = name.unwrap_or_else(|| {
-            let n = format!("::oo::Obj{}", self.oo.counter);
-            self.oo.counter += 1;
+            let n = format!("::oo::Obj{}", self.oo.borrow().counter);
+            self.oo.borrow_mut().counter += 1;
             n.into_bytes()
         });
-        if self.oo.objects.contains_key(&fqn) || self.oo.classes.contains_key(&fqn) {
+        if self.oo.borrow().objects.contains_key(&fqn)
+            || self.oo.borrow().classes.contains_key(&fqn)
+        {
             let mut m = b"can't create object \"".to_vec();
             m.extend_from_slice(&fqn);
             m.extend_from_slice(b"\": command already exists with that name");
             return self.error(&m);
         }
         let var_ns = self.ensure_namespace(&fqn);
-        self.oo.objects.insert(
+        self.oo.borrow_mut().objects.insert(
             fqn.clone(),
             Object {
                 class: class.to_vec(),
@@ -801,6 +873,7 @@ impl Interp {
         let mro = self.mro(class);
         if let Some(j) = mro.iter().position(|c| {
             self.oo
+                .borrow()
                 .classes
                 .get(c)
                 .is_some_and(|c| c.constructor.is_some())
@@ -810,7 +883,7 @@ impl Interp {
             let chain = mro;
             let code = self.oo_call(&fqn, chain, j, b"", args);
             if code == Code::Error {
-                self.oo.objects.remove(&fqn);
+                self.oo.borrow_mut().objects.remove(&fqn);
                 self.delete_command(&fqn);
                 return Code::Error;
             }
@@ -829,7 +902,7 @@ impl Interp {
         args: &[*mut TclObj],
         external: bool,
     ) -> Code {
-        if !self.oo.objects.contains_key(obj) {
+        if !self.oo.borrow().objects.contains_key(obj) {
             return self.invalid_command(obj);
         }
         let chain = self.method_chain(obj);
@@ -851,14 +924,14 @@ impl Interp {
                 chain.push(c.to_vec());
             }
         };
-        if let Some(o) = self.oo.objects.get(obj) {
+        if let Some(o) = self.oo.borrow().objects.get(obj) {
             for mx in &o.mixins {
                 for c in self.mro(mx) {
                     push(&c, &mut chain);
                 }
             }
             let cls = o.class.clone();
-            if let Some(cl) = self.oo.classes.get(&cls) {
+            if let Some(cl) = self.oo.borrow().classes.get(&cls) {
                 for mx in &cl.mixins {
                     for c in self.mro(mx) {
                         push(&c, &mut chain);
@@ -878,14 +951,16 @@ impl Interp {
         if ctor {
             return self
                 .oo
+                .borrow()
                 .classes
                 .get(prov)
                 .is_some_and(|c| c.constructor.is_some());
         }
-        if let Some(o) = self.oo.objects.get(prov) {
+        if let Some(o) = self.oo.borrow().objects.get(prov) {
             o.methods.contains_key(method)
         } else {
             self.oo
+                .borrow()
                 .classes
                 .get(prov)
                 .is_some_and(|c| c.methods.contains_key(method))
@@ -893,10 +968,11 @@ impl Interp {
     }
 
     fn method_unexported(&self, prov: &[u8], method: &[u8]) -> bool {
-        if let Some(o) = self.oo.objects.get(prov) {
+        if let Some(o) = self.oo.borrow().objects.get(prov) {
             o.unexported.contains(method)
         } else {
             self.oo
+                .borrow()
                 .classes
                 .get(prov)
                 .is_some_and(|c| c.unexported.contains(method))
@@ -916,13 +992,15 @@ impl Interp {
         let prov = chain[index].clone();
         let m = if method.is_empty() {
             self.oo
+                .borrow()
                 .classes
                 .get(&prov)
                 .and_then(|c| c.constructor.clone())
-        } else if let Some(o) = self.oo.objects.get(&prov) {
+        } else if let Some(o) = self.oo.borrow().objects.get(&prov) {
             o.methods.get(method).cloned()
         } else {
             self.oo
+                .borrow()
                 .classes
                 .get(&prov)
                 .and_then(|c| c.methods.get(method).cloned())
@@ -945,14 +1023,14 @@ impl Interp {
                 unsafe { obj::incr_ref_count(a) };
                 new_argv.push(a);
             }
-            self.oo.call_stack.push(OoFrame {
+            self.oo.borrow_mut().call_stack.push(OoFrame {
                 object: obj.to_vec(),
                 chain,
                 index,
                 method: method.to_vec(),
             });
             let code = self.dispatch(&new_argv);
-            self.oo.call_stack.pop();
+            self.oo.borrow_mut().call_stack.pop();
             for a in new_argv {
                 unsafe { obj::decr_ref_count(a) };
             }
@@ -962,12 +1040,12 @@ impl Interp {
         let Method::Body { params, body } = m else {
             unreachable!("forward handled above");
         };
-        let var_ns = self.oo.objects[obj].var_ns;
+        let var_ns = self.oo.borrow().objects[obj].var_ns;
         // The declared instance variables visible to the method: union over the
         // chain's classes.
         let mut vars: Vec<Vec<u8>> = Vec::new();
         for c in &chain {
-            if let Some(cl) = self.oo.classes.get(c) {
+            if let Some(cl) = self.oo.borrow().classes.get(c) {
                 for v in &cl.variables {
                     if !vars.contains(v) {
                         vars.push(v.clone());
@@ -980,7 +1058,7 @@ impl Interp {
         } else {
             method.to_vec()
         };
-        self.oo.call_stack.push(OoFrame {
+        self.oo.borrow_mut().call_stack.push(OoFrame {
             object: obj.to_vec(),
             chain,
             index,
@@ -1000,18 +1078,24 @@ impl Interp {
                 link_vars: &vars,
             },
         );
-        self.oo.call_stack.pop();
+        self.oo.borrow_mut().call_stack.pop();
         code
     }
 
     fn oo_destroy(&mut self, obj: &[u8]) {
-        let class = self.oo.objects.get(obj).map(|o| o.class.clone());
+        let class = self.oo.borrow().objects.get(obj).map(|o| o.class.clone());
         if let Some(class) = class {
             let mro = self.mro(&class);
             for c in &mro {
-                if let Some(body) = self.oo.classes.get(c).and_then(|c| c.destructor.clone()) {
-                    let var_ns = self.oo.objects[obj].var_ns;
-                    self.oo.call_stack.push(OoFrame {
+                let dtor = self
+                    .oo
+                    .borrow()
+                    .classes
+                    .get(c)
+                    .and_then(|c| c.destructor.clone());
+                if let Some(body) = dtor {
+                    let var_ns = self.oo.borrow().objects[obj].var_ns;
+                    self.oo.borrow_mut().call_stack.push(OoFrame {
                         object: obj.to_vec(),
                         chain: mro.clone(),
                         index: 0,
@@ -1031,12 +1115,12 @@ impl Interp {
                             link_vars: &[],
                         },
                     );
-                    self.oo.call_stack.pop();
+                    self.oo.borrow_mut().call_stack.pop();
                     break;
                 }
             }
         }
-        self.oo.objects.remove(obj);
+        self.oo.borrow_mut().objects.remove(obj);
         self.delete_command(obj);
     }
 
@@ -1044,6 +1128,7 @@ impl Interp {
         // Destroy the class's instances first (TclOO cascades).
         let insts: Vec<Vec<u8>> = self
             .oo
+            .borrow()
             .objects
             .iter()
             .filter(|(_, o)| o.class == class)
@@ -1052,7 +1137,7 @@ impl Interp {
         for o in insts {
             self.oo_destroy(&o);
         }
-        self.oo.classes.remove(class);
+        self.oo.borrow_mut().classes.remove(class);
         self.delete_command(class);
     }
 
@@ -1069,7 +1154,7 @@ impl Interp {
             return;
         }
         out.push(class.to_vec());
-        if let Some(c) = self.oo.classes.get(class) {
+        if let Some(c) = self.oo.borrow().classes.get(class) {
             let supers = c.supers.clone();
             for s in &supers {
                 self.mro_visit(s, out);

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -1,0 +1,727 @@
+//! TclOO — the object system (`oo::class`, `oo::object`, `oo::define`, …).
+//!
+//! A core subset (C ref `tclOO.c`): classes with single/multiple superclasses,
+//! methods, constructor/destructor, instance variables, object creation
+//! (`new`/`create`), method dispatch with a linearised MRO, and the
+//! method-context commands `self` / `my` / `next`. Each object/class is a
+//! command (`Command::OoObject`); each object's instance variables live in a
+//! private namespace, auto-linked into a method frame from the class's
+//! `variable` declarations (reusing the proc-call machinery via
+//! [`Interp::run_proc`] with `CallMeta::link_vars`).
+//!
+//! Deferred: mixins, filters, forwards, `oo::copy`, per-object methods
+//! (`oo::objdefine`), private methods/variables, and `info object`/`info class`
+//! introspection.
+//!
+//! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use std::collections::BTreeMap;
+
+use crate::interp::{obj_bytes, CallMeta, Code, Command, Interp, Param, ProcFrame};
+use crate::namespace::NsId;
+use crate::obj::{self, TclObj};
+
+/// A method (or constructor): parsed parameters + the body script.
+#[derive(Clone)]
+struct Method {
+    params: Vec<Param>,
+    body: Vec<u8>,
+}
+
+/// A class definition.
+#[derive(Default)]
+struct Class {
+    /// Superclass FQNs (defaults to `::oo::object` when none are declared).
+    supers: Vec<Vec<u8>>,
+    methods: BTreeMap<Vec<u8>, Method>,
+    constructor: Option<Method>,
+    destructor: Option<Vec<u8>>,
+    /// Declared instance-variable names (auto-linked into every method frame).
+    variables: Vec<Vec<u8>>,
+}
+
+/// An object instance.
+struct Object {
+    /// FQN of the object's class.
+    class: Vec<u8>,
+    /// The namespace holding this object's instance variables.
+    var_ns: NsId,
+}
+
+/// One active method invocation (for `self` / `my` / `next`).
+struct OoFrame {
+    object: Vec<u8>,
+    /// The class linearisation (MRO) this dispatch walks.
+    mro: Vec<Vec<u8>>,
+    /// Index into `mro` of the class whose method is currently running.
+    index: usize,
+    /// The method name (or empty for a constructor).
+    method: Vec<u8>,
+}
+
+/// The interpreter's TclOO state.
+#[derive(Default)]
+pub struct OoState {
+    classes: BTreeMap<Vec<u8>, Class>,
+    objects: BTreeMap<Vec<u8>, Object>,
+    counter: usize,
+    /// Classes currently being defined (the `oo::define`/`oo::class create`
+    /// script context the definition commands mutate).
+    def_stack: Vec<Vec<u8>>,
+    /// Active method-call contexts.
+    call_stack: Vec<OoFrame>,
+}
+
+/// Register the `oo::*` commands and the definition / context commands.
+pub fn install(interp: &mut Interp) {
+    interp.register_builtin(b"oo::class", oo_class_cmd);
+    interp.register_builtin(b"oo::object", oo_object_cmd);
+    interp.register_builtin(b"oo::define", oo_define_cmd);
+    // Definition-script commands (valid only inside an `oo::define` body).
+    interp.register_builtin(b"method", def_method);
+    interp.register_builtin(b"constructor", def_constructor);
+    interp.register_builtin(b"destructor", def_destructor);
+    interp.register_builtin(b"superclass", def_superclass);
+    interp.register_builtin(b"variable", def_variable);
+    interp.register_builtin(b"export", def_export);
+    // Method-context commands.
+    interp.register_builtin(b"self", self_cmd);
+    interp.register_builtin(b"my", my_cmd);
+    interp.register_builtin(b"next", next_cmd);
+    // The root classes exist so superclass-less classes inherit from `object`
+    // and `superclass oo::class`/`oo::object` validate. (`oo::class` keeps its
+    // builtin command — only the class-registry entry is added.)
+    interp
+        .oo
+        .classes
+        .insert(b"::oo::object".to_vec(), Class::default());
+    interp.oo.classes.insert(
+        b"::oo::class".to_vec(),
+        Class {
+            supers: vec![b"::oo::object".to_vec()],
+            ..Class::default()
+        },
+    );
+    // `::oo::version` / `::oo::patchlevel` (read by the test harness).
+    let _ =
+        interp.eval_str(b"namespace eval ::oo {variable version 1.3.1; variable patchlevel 1.3.1}");
+}
+
+fn err(interp: &mut Interp, msg: &[u8]) -> Code {
+    interp.set_error(msg)
+}
+
+fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
+    let mut m = b"wrong # args: should be \"".to_vec();
+    m.extend_from_slice(usage);
+    m.push(b'"');
+    interp.set_error(&m)
+}
+
+// -- oo::class / oo::object / oo::define ------------------------------------
+
+/// `oo::class create name ?definitionScript?` — define a class.
+fn oo_class_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 3 || obj_bytes(argv[1]) != b"create" {
+        return wrong_args(interp, b"oo::class create name ?definitionScript?");
+    }
+    let fqn = interp.fqn_for(&obj_bytes(argv[2]));
+    if interp.oo.classes.contains_key(&fqn) || interp.oo.objects.contains_key(&fqn) {
+        let mut m = b"can't create class \"".to_vec();
+        m.extend_from_slice(&obj_bytes(argv[2]));
+        m.extend_from_slice(b"\": command already exists with that name");
+        return err(interp, &m);
+    }
+    interp.oo.classes.insert(
+        fqn.clone(),
+        Class {
+            supers: vec![b"::oo::object".to_vec()],
+            ..Class::default()
+        },
+    );
+    interp.ns_register(&fqn, Command::OoObject(fqn.clone()));
+    // Run the definition script (if any) with `fqn` as the definition target.
+    if argv.len() >= 4 {
+        let script = obj_bytes(argv[3]);
+        let code = interp.oo_define(&fqn, &script);
+        if code != Code::Ok {
+            return code;
+        }
+    }
+    interp.set_result(obj::new_string_bytes(&fqn));
+    Code::Ok
+}
+
+/// `oo::object create name` / `oo::object new` — create a bare object.
+fn oo_object_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
+        Some(b"create") if argv.len() >= 3 => {
+            let name = interp.fqn_for(&obj_bytes(argv[2]));
+            interp.oo_new(b"::oo::object", Some(name), &argv[3..])
+        }
+        Some(b"new") => interp.oo_new(b"::oo::object", None, &argv[2..]),
+        _ => wrong_args(interp, b"oo::object create|new ?arg ...?"),
+    }
+}
+
+/// `oo::define class script` or `oo::define class subcommand ?arg ...?`.
+fn oo_define_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 3 {
+        return wrong_args(interp, b"oo::define target ?arg ...?");
+    }
+    let fqn = interp.fqn_for(&obj_bytes(argv[1]));
+    if !interp.oo.classes.contains_key(&fqn) {
+        let mut m = b"\"".to_vec();
+        m.extend_from_slice(&obj_bytes(argv[1]));
+        m.extend_from_slice(b"\" does not refer to a class");
+        return err(interp, &m);
+    }
+    if argv.len() == 3 {
+        // Script form.
+        let script = obj_bytes(argv[2]);
+        interp.oo_define(&fqn, &script)
+    } else {
+        // Subcommand form: push the context and dispatch the one definition cmd.
+        interp.oo.def_stack.push(fqn);
+        let code = interp.dispatch(&argv[2..]);
+        interp.oo.def_stack.pop();
+        code
+    }
+}
+
+// -- definition-script commands ---------------------------------------------
+
+/// The class currently being defined, or an error if outside `oo::define`.
+fn def_class(interp: &mut Interp) -> Result<Vec<u8>, Code> {
+    match interp.oo.def_stack.last() {
+        Some(c) => Ok(c.clone()),
+        None => Err(interp
+            .set_error(b"this command can only be called from within the body of a definition")),
+    }
+}
+
+/// `method name params body` — add an (instance) method to the class.
+fn def_method(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() != 4 {
+        return wrong_args(interp, b"method name args body");
+    }
+    let class = match def_class(interp) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+    let params = match crate::cmd_proc::parse_params(&obj_bytes(argv[2])) {
+        Ok(p) => p,
+        Err(e) => return err(interp, &e),
+    };
+    let m = Method {
+        params,
+        body: obj_bytes(argv[3]),
+    };
+    interp
+        .oo
+        .classes
+        .get_mut(&class)
+        .unwrap()
+        .methods
+        .insert(obj_bytes(argv[1]), m);
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `constructor params body`.
+fn def_constructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() != 3 {
+        return wrong_args(interp, b"constructor arguments body");
+    }
+    let class = match def_class(interp) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+    let params = match crate::cmd_proc::parse_params(&obj_bytes(argv[1])) {
+        Ok(p) => p,
+        Err(e) => return err(interp, &e),
+    };
+    interp.oo.classes.get_mut(&class).unwrap().constructor = Some(Method {
+        params,
+        body: obj_bytes(argv[2]),
+    });
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `destructor body`.
+fn def_destructor(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() != 2 {
+        return wrong_args(interp, b"destructor body");
+    }
+    let class = match def_class(interp) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+    interp.oo.classes.get_mut(&class).unwrap().destructor = Some(obj_bytes(argv[1]));
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `superclass name ?name ...?`.
+fn def_superclass(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let class = match def_class(interp) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+    let supers: Vec<Vec<u8>> = argv[1..]
+        .iter()
+        .map(|&a| interp.fqn_for(&obj_bytes(a)))
+        .collect();
+    // Validate each names a class.
+    for s in &supers {
+        if !interp.oo.classes.contains_key(s) {
+            let mut m = b"\"".to_vec();
+            m.extend_from_slice(s);
+            m.extend_from_slice(b"\" does not refer to a class");
+            return err(interp, &m);
+        }
+    }
+    interp.oo.classes.get_mut(&class).unwrap().supers = if supers.is_empty() {
+        vec![b"::oo::object".to_vec()]
+    } else {
+        supers
+    };
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `variable ?name ...?` — declare the class's instance variables.
+///
+/// Note: this shadows the global `variable` command. Inside an `oo::define`
+/// body it records instance-variable names; otherwise it forwards to the
+/// ordinary [`crate::cmd_var`] `variable`.
+fn def_variable(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if interp.oo.def_stack.is_empty() {
+        return crate::cmd_var::variable(interp, argv);
+    }
+    let class = interp.oo.def_stack.last().unwrap().clone();
+    let names: Vec<Vec<u8>> = argv[1..].iter().map(|&a| obj_bytes(a)).collect();
+    let c = interp.oo.classes.get_mut(&class).unwrap();
+    for n in names {
+        if !c.variables.contains(&n) {
+            c.variables.push(n);
+        }
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// `export name ?name ...?` — accepted; method visibility is not yet enforced.
+fn def_export(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+// -- method context: self / my / next ---------------------------------------
+
+fn self_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let Some(frame) = interp.oo.call_stack.last() else {
+        return err(interp, b"self may only be called from inside a method");
+    };
+    let object = frame.object.clone();
+    let class = frame.mro.get(frame.index).cloned().unwrap_or_default();
+    let method = frame.method.clone();
+    match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
+        None | Some(b"object") => interp.set_result(obj::new_string_bytes(&object)),
+        Some(b"class") => interp.set_result(obj::new_string_bytes(&class)),
+        Some(b"method") => interp.set_result(obj::new_string_bytes(&method)),
+        Some(other) => {
+            let mut m = b"unsupported self subcommand \"".to_vec();
+            m.extend_from_slice(other);
+            m.push(b'"');
+            return err(interp, &m);
+        }
+    }
+    Code::Ok
+}
+
+/// `my methodName ?arg ...?` — invoke a method on the current object (including
+/// non-exported ones).
+fn my_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 2 {
+        return wrong_args(interp, b"my methodName ?arg ...?");
+    }
+    let Some(object) = interp.oo.call_stack.last().map(|f| f.object.clone()) else {
+        return err(interp, b"my may only be called from inside a method");
+    };
+    let method = obj_bytes(argv[1]);
+    interp.oo_invoke(&object, &method, &argv[2..])
+}
+
+/// `next ?arg ...?` — call the next implementation of the current method along
+/// the MRO (e.g. a superclass method or constructor).
+fn next_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let Some(frame) = interp.oo.call_stack.last() else {
+        return err(interp, b"next may only be called from inside a method");
+    };
+    let (object, mro, index, method) = (
+        frame.object.clone(),
+        frame.mro.clone(),
+        frame.index,
+        frame.method.clone(),
+    );
+    let is_ctor = method.is_empty();
+    // Find the next class along the MRO that defines this method/constructor.
+    let next = (index + 1..mro.len()).find(|&j| {
+        interp.oo.classes.get(&mro[j]).is_some_and(|c| {
+            if is_ctor {
+                c.constructor.is_some()
+            } else {
+                c.methods.contains_key(&method)
+            }
+        })
+    });
+    match next {
+        Some(j) => interp.oo_call(&object, mro, j, &method, &argv[1..]),
+        None if is_ctor => {
+            // The implicit root constructor is a no-op.
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
+        None => err(interp, b"no next method implementation"),
+    }
+}
+
+// -- the object-system engine (impl Interp) ----------------------------------
+
+impl Interp {
+    /// Run a class definition `script` with `class` as the target. Definition
+    /// commands (`method`/`constructor`/…) mutate that class.
+    fn oo_define(&mut self, class: &[u8], script: &[u8]) -> Code {
+        self.oo.def_stack.push(class.to_vec());
+        let code = self.eval_str(script);
+        self.oo.def_stack.pop();
+        code
+    }
+
+    /// Dispatch a command bound to the OO object/class FQN `fqn`.
+    pub(crate) fn oo_dispatch(&mut self, fqn: &[u8], argv: &[*mut TclObj]) -> Code {
+        if self.oo.classes.contains_key(fqn) {
+            // Class command: `Class new|create|destroy ...`.
+            match argv.get(1).map(|&a| obj_bytes(a)).as_deref() {
+                Some(b"new") => self.oo_new(fqn, None, &argv[2..]),
+                Some(b"create") if argv.len() >= 3 => {
+                    let name = self.fqn_for(&obj_bytes(argv[2]));
+                    self.oo_new(fqn, Some(name), &argv[3..])
+                }
+                Some(b"destroy") => {
+                    self.oo_destroy_class(fqn);
+                    self.set_result_bytes(b"");
+                    Code::Ok
+                }
+                Some(other) => {
+                    let mut m = b"unknown method \"".to_vec();
+                    m.extend_from_slice(other);
+                    m.extend_from_slice(b"\"");
+                    self.error(&m)
+                }
+                None => self.error(b"wrong # args: should be \"class method ?arg ...?\""),
+            }
+        } else if self.oo.objects.contains_key(fqn) {
+            // Object command: `$obj destroy` or `$obj method ...`.
+            match argv.get(1).map(|&a| obj_bytes(a)) {
+                Some(m) if m == b"destroy" => {
+                    self.oo_destroy(fqn);
+                    self.set_result_bytes(b"");
+                    Code::Ok
+                }
+                Some(method) => self.oo_invoke(fqn, &method, &argv[2..]),
+                None => self.error(b"wrong # args: should be \"object method ?arg ...?\""),
+            }
+        } else {
+            self.invalid_command(fqn)
+        }
+    }
+
+    /// Create an instance of `class` (optionally named `name`, else auto-named),
+    /// running its constructor with `args`. Result is the object FQN.
+    fn oo_new(&mut self, class: &[u8], name: Option<Vec<u8>>, args: &[*mut TclObj]) -> Code {
+        let fqn = name.unwrap_or_else(|| {
+            let n = format!("::oo::Obj{}", self.oo.counter);
+            self.oo.counter += 1;
+            n.into_bytes()
+        });
+        if self.oo.objects.contains_key(&fqn) || self.oo.classes.contains_key(&fqn) {
+            let mut m = b"can't create object \"".to_vec();
+            m.extend_from_slice(&fqn);
+            m.extend_from_slice(b"\": command already exists with that name");
+            return self.error(&m);
+        }
+        // A private namespace for the object's instance variables.
+        let var_ns = self.ensure_namespace(&fqn);
+        self.oo.objects.insert(
+            fqn.clone(),
+            Object {
+                class: class.to_vec(),
+                var_ns,
+            },
+        );
+        self.ns_register(&fqn, Command::OoObject(fqn.clone()));
+
+        // Run the constructor along the MRO (if any class defines one).
+        let mro = self.mro(class);
+        if let Some(j) = mro.iter().position(|c| {
+            self.oo
+                .classes
+                .get(c)
+                .is_some_and(|c| c.constructor.is_some())
+        }) {
+            let code = self.oo_call(&fqn, mro, j, b"", args);
+            if code == Code::Error {
+                // Construction failed: roll back the half-built object.
+                self.oo.objects.remove(&fqn);
+                self.delete_command(&fqn);
+                return Code::Error;
+            }
+        } else if !args.is_empty() {
+            return self.error(b"object creation takes no arguments (no constructor)");
+        }
+        self.set_result(obj::new_string_bytes(&fqn));
+        Code::Ok
+    }
+
+    /// Invoke instance method `method` on object `obj` with `args`.
+    fn oo_invoke(&mut self, obj: &[u8], method: &[u8], args: &[*mut TclObj]) -> Code {
+        let Some(class) = self.oo.objects.get(obj).map(|o| o.class.clone()) else {
+            return self.invalid_command(obj);
+        };
+        let mro = self.mro(&class);
+        match mro.iter().position(|c| {
+            self.oo
+                .classes
+                .get(c)
+                .is_some_and(|c| c.methods.contains_key(method))
+        }) {
+            Some(j) => self.oo_call(obj, mro, j, method, args),
+            None => {
+                let mut m = b"unknown method \"".to_vec();
+                m.extend_from_slice(method);
+                m.extend_from_slice(b"\"");
+                self.error(&m)
+            }
+        }
+    }
+
+    /// Run the method (or constructor, when `method` is empty) defined by
+    /// `mro[index]` on `obj`, pushing the OO call frame so `self`/`my`/`next`
+    /// work and auto-linking the declared instance variables.
+    fn oo_call(
+        &mut self,
+        obj: &[u8],
+        mro: Vec<Vec<u8>>,
+        index: usize,
+        method: &[u8],
+        args: &[*mut TclObj],
+    ) -> Code {
+        // Clone what we need before borrowing `self` mutably for `run_proc`.
+        let cls = &self.oo.classes[&mro[index]];
+        let m = if method.is_empty() {
+            cls.constructor.clone()
+        } else {
+            cls.methods.get(method).cloned()
+        };
+        let Some(m) = m else {
+            return self.error(b"no such method");
+        };
+        let var_ns = self.oo.objects[obj].var_ns;
+        // The declared instance variables visible to the method: the union over
+        // the whole MRO.
+        let mut vars: Vec<Vec<u8>> = Vec::new();
+        for c in &mro {
+            if let Some(cl) = self.oo.classes.get(c) {
+                for v in &cl.variables {
+                    if !vars.contains(v) {
+                        vars.push(v.clone());
+                    }
+                }
+            }
+        }
+        let name = if method.is_empty() {
+            b"<constructor>".to_vec()
+        } else {
+            method.to_vec()
+        };
+        self.oo.call_stack.push(OoFrame {
+            object: obj.to_vec(),
+            mro,
+            index,
+            method: method.to_vec(),
+        });
+        let code = self.run_proc(
+            &m.params,
+            &m.body,
+            var_ns,
+            args,
+            &name,
+            CallMeta {
+                err: ProcFrame::Proc(&name),
+                fqn: None,
+                source: None,
+                body_line_base: 0,
+                link_vars: &vars,
+            },
+        );
+        self.oo.call_stack.pop();
+        code
+    }
+
+    /// Destroy an object: run its destructor (best-effort), then remove it.
+    fn oo_destroy(&mut self, obj: &[u8]) {
+        let class = self.oo.objects.get(obj).map(|o| o.class.clone());
+        if let Some(class) = class {
+            let mro = self.mro(&class);
+            for c in &mro {
+                if let Some(body) = self.oo.classes.get(c).and_then(|c| c.destructor.clone()) {
+                    let var_ns = self.oo.objects[obj].var_ns;
+                    self.oo.call_stack.push(OoFrame {
+                        object: obj.to_vec(),
+                        mro: mro.clone(),
+                        index: 0,
+                        method: b"<destructor>".to_vec(),
+                    });
+                    let _ = self.run_proc(
+                        &[],
+                        &body,
+                        var_ns,
+                        &[],
+                        b"<destructor>",
+                        CallMeta {
+                            err: ProcFrame::Proc(b"<destructor>"),
+                            fqn: None,
+                            source: None,
+                            body_line_base: 0,
+                            link_vars: &[],
+                        },
+                    );
+                    self.oo.call_stack.pop();
+                    break;
+                }
+            }
+        }
+        self.oo.objects.remove(obj);
+        self.delete_command(obj);
+    }
+
+    /// Destroy a class (and its command). Instances are left as-is (a follow-up
+    /// would cascade); this is enough for test teardown.
+    fn oo_destroy_class(&mut self, class: &[u8]) {
+        self.oo.classes.remove(class);
+        self.delete_command(class);
+    }
+
+    /// The method-resolution order for `class`: a preorder walk of the class and
+    /// its superclasses, each class appearing once (first occurrence wins).
+    fn mro(&self, class: &[u8]) -> Vec<Vec<u8>> {
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        self.mro_visit(class, &mut out);
+        out
+    }
+
+    fn mro_visit(&self, class: &[u8], out: &mut Vec<Vec<u8>>) {
+        if out.iter().any(|c| c == class) {
+            return;
+        }
+        out.push(class.to_vec());
+        if let Some(c) = self.oo.classes.get(class) {
+            let supers = c.supers.clone();
+            for s in &supers {
+                self.mro_visit(s, out);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::counters;
+    use crate::interp::{Code, Interp};
+
+    fn leak_free(body: impl FnOnce(&mut Interp)) {
+        counters::reset();
+        {
+            let mut interp = Interp::new();
+            body(&mut interp);
+        }
+        assert_eq!(counters::finalize(), 0, "residual objs/bufs");
+        assert_eq!(counters::double_free_count(), 0);
+    }
+
+    fn ok(i: &mut Interp, src: &[u8]) -> Vec<u8> {
+        assert_eq!(
+            i.eval_str(src),
+            Code::Ok,
+            "eval {:?} -> {:?}",
+            String::from_utf8_lossy(src),
+            String::from_utf8_lossy(&i.result_bytes())
+        );
+        i.result_bytes()
+    }
+
+    #[test]
+    fn class_method_constructor_instance_var() {
+        leak_free(|i| {
+            ok(
+                i,
+                b"oo::class create Animal {
+                    variable sound
+                    constructor {s} { set sound $s }
+                    method speak {} { return \"I say $sound\" }
+                    method describe {} { return \"[self] speaks\" }
+                }",
+            );
+            ok(i, b"set a [Animal new woof]");
+            assert_eq!(ok(i, b"$a speak"), b"I say woof");
+            // `self` inside a method is the object.
+            assert_eq!(
+                ok(i, b"Animal create ::bessie moo; bessie speak"),
+                b"I say moo"
+            );
+            // destroy removes the command.
+            ok(i, b"bessie destroy");
+            assert_eq!(i.eval_str(b"bessie speak"), Code::Error);
+        });
+    }
+
+    #[test]
+    fn inheritance_and_next() {
+        leak_free(|i| {
+            ok(
+                i,
+                b"oo::class create Animal {
+                    variable sound
+                    constructor {s} { set sound $s }
+                    method speak {} { return \"I say $sound\" }
+                }",
+            );
+            ok(
+                i,
+                b"oo::class create Dog {
+                    superclass Animal
+                    constructor {} { next bark }
+                    method speak {} { return \"Dog: [next]\" }
+                }",
+            );
+            ok(i, b"set d [Dog new]");
+            // `next bark` chained to Animal's constructor; `next` chained speak.
+            assert_eq!(ok(i, b"$d speak"), b"Dog: I say bark");
+            // `oo::define` adds a method after the fact.
+            ok(i, b"oo::define Dog method legs {} { return 4 }");
+            assert_eq!(ok(i, b"$d legs"), b"4");
+        });
+    }
+
+    #[test]
+    fn oo_package_is_provided() {
+        leak_free(|i| {
+            assert_eq!(ok(i, b"package require tcl::oo"), b"1.3.1");
+            assert_eq!(ok(i, b"package require TclOO"), b"1.3.1");
+        });
+    }
+}

--- a/runtime/rust/src/cmd_package.rs
+++ b/runtime/rust/src/cmd_package.rs
@@ -141,7 +141,10 @@ fn require(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     for attempt in 0..2 {
         if let Some(ver) = best_ifneeded(interp, &name, exact, &reqs) {
             let script = interp.packages.ifneeded[&(name.clone(), ver)].clone();
-            if interp.eval_str(&script) == Code::Error {
+            // Package load scripts run at the global scope (C's `uplevel #0`),
+            // so a package's `namespace eval foo` creates `::foo` even when
+            // `package require` is called from inside another namespace.
+            if interp.eval_uplevel(0, &script) == Code::Error {
                 return Code::Error;
             }
             if let Some(Ok(v)) = check_provided(interp, &name, exact, &reqs) {
@@ -159,7 +162,8 @@ fn require(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 script.push(b' ');
                 script.extend_from_slice(w);
             }
-            if interp.eval_str(&script) == Code::Error {
+            // The `package unknown` handler (pkgIndex search) also runs globally.
+            if interp.eval_uplevel(0, &script) == Code::Error {
                 return Code::Error;
             }
         }

--- a/runtime/rust/src/cmd_package.rs
+++ b/runtime/rust/src/cmd_package.rs
@@ -35,6 +35,9 @@ impl PackageState {
         let mut p = PackageState::default();
         p.provided.insert(b"tcl".to_vec(), b"9.0.3".to_vec());
         p.provided.insert(b"Tcl".to_vec(), b"9.0.3".to_vec());
+        // TclOO is built in (the `oo::*` commands are always present).
+        p.provided.insert(b"tcl::oo".to_vec(), b"1.3.1".to_vec());
+        p.provided.insert(b"TclOO".to_vec(), b"1.3.1".to_vec());
         p
     }
 }

--- a/runtime/rust/src/cmd_package.rs
+++ b/runtime/rust/src/cmd_package.rs
@@ -82,28 +82,29 @@ fn provide(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     match argv.len() {
         3 => {
             let name = obj_bytes(argv[2]);
-            interp.set_result_bytes(
-                &interp
-                    .packages
-                    .provided
-                    .get(&name)
-                    .cloned()
-                    .unwrap_or_default(),
-            );
+            let v = interp
+                .packages
+                .borrow()
+                .provided
+                .get(&name)
+                .cloned()
+                .unwrap_or_default();
+            interp.set_result_bytes(&v);
             Code::Ok
         }
         4 => {
             let name = obj_bytes(argv[2]);
             let version = obj_bytes(argv[3]);
-            if let Some(existing) = interp.packages.provided.get(&name) {
-                if *existing != version {
+            let existing = interp.packages.borrow().provided.get(&name).cloned();
+            if let Some(existing) = existing {
+                if existing != version {
                     let mut m = b"conflicting versions provided for package \"".to_vec();
                     m.extend_from_slice(&name);
                     m.extend_from_slice(b"\"");
                     return interp.set_error(&m);
                 }
             }
-            interp.packages.provided.insert(name, version);
+            interp.packages.borrow_mut().provided.insert(name, version);
             interp.set_result_bytes(b"");
             Code::Ok
         }
@@ -143,7 +144,7 @@ fn require(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     //    run the `unknown` handler (auto-loader / pkgIndex search) and retry.
     for attempt in 0..2 {
         if let Some(ver) = best_ifneeded(interp, &name, exact, &reqs) {
-            let script = interp.packages.ifneeded[&(name.clone(), ver)].clone();
+            let script = interp.packages.borrow().ifneeded[&(name.clone(), ver)].clone();
             // Package load scripts run at the global scope (C's `uplevel #0`),
             // so a package's `namespace eval foo` creates `::foo` even when
             // `package require` is called from inside another namespace.
@@ -156,7 +157,7 @@ fn require(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
         if attempt == 0 {
-            let handler = interp.packages.unknown.clone();
+            let handler = interp.packages.borrow().unknown.clone();
             if handler.is_empty() {
                 break;
             }
@@ -180,7 +181,7 @@ fn require(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// `-exact`, an exact match), or `None`.
 fn best_ifneeded(interp: &Interp, name: &[u8], exact: bool, reqs: &[Vec<u8>]) -> Option<Vec<u8>> {
     let mut best: Option<Vec<u8>> = None;
-    for (n, v) in interp.packages.ifneeded.keys() {
+    for (n, v) in interp.packages.borrow().ifneeded.keys() {
         if n != name {
             continue;
         }
@@ -208,7 +209,7 @@ fn check_provided(
     exact: bool,
     reqs: &[Vec<u8>],
 ) -> Option<Result<Vec<u8>, Code>> {
-    let v = interp.packages.provided.get(name)?.clone();
+    let v = interp.packages.borrow().provided.get(name)?.clone();
     let ok = if exact {
         reqs.first().map_or(true, |r| r == &v)
     } else {
@@ -264,11 +265,16 @@ fn ifneeded(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let key = (obj_bytes(argv[2]), obj_bytes(argv[3]));
     if argv.len() == 5 {
-        interp.packages.ifneeded.insert(key, obj_bytes(argv[4]));
+        interp
+            .packages
+            .borrow_mut()
+            .ifneeded
+            .insert(key, obj_bytes(argv[4]));
         interp.set_result_bytes(b"");
     } else {
         let script = interp
             .packages
+            .borrow()
             .ifneeded
             .get(&key)
             .cloned()
@@ -282,11 +288,12 @@ fn ifneeded(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 fn unknown(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     match argv.len() {
         2 => {
-            interp.set_result_bytes(&interp.packages.unknown.clone());
+            let u = interp.packages.borrow().unknown.clone();
+            interp.set_result_bytes(&u);
             Code::Ok
         }
         3 => {
-            interp.packages.unknown = obj_bytes(argv[2]);
+            interp.packages.borrow_mut().unknown = obj_bytes(argv[2]);
             interp.set_result_bytes(b"");
             Code::Ok
         }
@@ -300,8 +307,8 @@ fn names(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"package names");
     }
     let mut set: std::collections::BTreeSet<Vec<u8>> =
-        interp.packages.provided.keys().cloned().collect();
-    for (n, _) in interp.packages.ifneeded.keys() {
+        interp.packages.borrow().provided.keys().cloned().collect();
+    for (n, _) in interp.packages.borrow().ifneeded.keys() {
         set.insert(n.clone());
     }
     let objs: Vec<*mut TclObj> = set.iter().map(|n| crate::interp::new_string(n)).collect();
@@ -317,6 +324,7 @@ fn versions(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let name = obj_bytes(argv[2]);
     let vers: Vec<*mut TclObj> = interp
         .packages
+        .borrow()
         .ifneeded
         .keys()
         .filter(|(n, _)| *n == name)

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -9,7 +9,7 @@
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-use crate::interp::{obj_bytes, Code, Interp, Param};
+use crate::interp::{obj_bytes, Code, Interp, Param, ProcFrame};
 use crate::obj::TclObj;
 use crate::parse::split_list;
 
@@ -100,7 +100,14 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     } else {
         crate::namespace::GLOBAL
     };
-    interp.run_proc(&params, &parts[1], ns, &argv[2..], b"apply lambdaExpr")
+    interp.run_proc(
+        &params,
+        &parts[1],
+        ns,
+        &argv[2..],
+        b"apply lambdaExpr",
+        ProcFrame::Lambda(&lambda),
+    )
 }
 
 // `puts` lives in `cmd_chan` (it is a channel write — stdout/stderr/file).

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -171,6 +171,26 @@ mod tests {
     }
 
     #[test]
+    fn proc_default_arity_edges_dont_panic() {
+        // Regression: defaulted positionals must not panic when fewer args than
+        // positionals are supplied (the `args` split) or when a *required*
+        // parameter follows a defaulted one (non-trailing default). Matches
+        // tclsh 9.0.
+        leak_free(|i| {
+            // All-defaulted positionals + args, called with none.
+            run(i, b"proc q {{a 1} {b 2} args} {list $a $b $args}");
+            assert_eq!(run(i, b"q"), b"1 2 {}");
+            assert_eq!(run(i, b"q 5"), b"5 2 {}");
+            assert_eq!(run(i, b"q 5 6 7 8"), b"5 6 {7 8}");
+            // Non-trailing default: a required param after a defaulted one.
+            run(i, b"proc p {a {b 2} c} {list $a $b $c}");
+            assert_eq!(run(i, b"p 1 2 3"), b"1 2 3");
+            assert_eq!(i.eval_str(b"p 1 2"), Code::Error);
+            assert_eq!(i.result_bytes(), b"wrong # args: should be \"p a ?b? c\"");
+        });
+    }
+
+    #[test]
     fn proc_args_catch_all() {
         leak_free(|i| {
             run(i, b"proc va {first args} {return $first|$args}");

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -45,7 +45,7 @@ fn proc_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 }
 
 /// Parse a proc parameter spec (a Tcl list of names / `{name default}` pairs).
-fn parse_params(spec: &[u8]) -> Result<Vec<Param>, Vec<u8>> {
+pub(crate) fn parse_params(spec: &[u8]) -> Result<Vec<Param>, Vec<u8>> {
     let elems = split_list(spec).map_err(|e| e.message().to_vec())?;
     let mut params = Vec::with_capacity(elems.len());
     for e in &elems {
@@ -111,6 +111,7 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             fqn: None,
             source: None,
             body_line_base: 0,
+            link_vars: &[],
         },
     )
 }

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -9,7 +9,7 @@
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-use crate::interp::{obj_bytes, Code, Interp, Param, ProcFrame};
+use crate::interp::{obj_bytes, CallMeta, Code, Interp, Param, ProcFrame};
 use crate::obj::TclObj;
 use crate::parse::split_list;
 
@@ -106,7 +106,11 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         ns,
         &argv[2..],
         b"apply lambdaExpr",
-        ProcFrame::Lambda(&lambda),
+        CallMeta {
+            err: ProcFrame::Lambda(&lambda),
+            fqn: None,
+            source: None,
+        },
     )
 }
 

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -110,6 +110,7 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             err: ProcFrame::Lambda(&lambda),
             fqn: None,
             source: None,
+            body_line_base: 0,
         },
     )
 }

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -715,20 +715,9 @@ fn parse_isize(b: &[u8]) -> Option<isize> {
 }
 
 /// `int` / `end` / `end-N` / `end+N` index spec against `len` chars.
-fn index_spec(spec: &[u8], len: usize) -> Option<isize> {
-    let len = len as isize;
-    if spec == b"end" {
-        return Some(len - 1);
-    }
-    if let Some(rest) = spec.strip_prefix(b"end") {
-        match rest.first() {
-            Some(b'-') => return parse_isize(&rest[1..]).map(|n| len - 1 - n),
-            Some(b'+') => return parse_isize(&rest[1..]).map(|n| len - 1 + n),
-            _ => return None,
-        }
-    }
-    parse_isize(spec)
-}
+// Index specs (`end`, `int±int`, `end±int`, …) share the full
+// `TclGetIntForIndex` grammar with the list commands — reuse one parser.
+use crate::cmd_list::index_spec;
 
 // -- error helpers ---------------------------------------------------------
 
@@ -841,6 +830,14 @@ mod tests {
         assert_eq!(ok(b"string index hello 9"), b"");
         assert_eq!(ok(b"string range hello 1 3"), b"ell");
         assert_eq!(ok(b"string range hello 2 end"), b"llo");
+        // `integer±integer` arithmetic in an index spec (Tcl 9 / safe-base):
+        // `string range $s 0 $last-1` with last=5 → indices 0..4.
+        assert_eq!(ok(b"string range abcdefghij 0 5-1"), b"abcde");
+        assert_eq!(
+            ok(b"set last 5; string range abcdefghij 0 $last-1"),
+            b"abcde"
+        );
+        assert_eq!(ok(b"string index abcdef 2+1"), b"d");
     }
 
     #[test]

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -80,8 +80,9 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"cat" => str_cat(interp, argv),
         b"repeat" => str_repeat(interp, argv),
         b"reverse" => str_reverse(interp, argv),
-        b"toupper" => str_case(interp, argv, true),
-        b"tolower" => str_case(interp, argv, false),
+        b"toupper" => str_case(interp, argv, CaseMode::Upper),
+        b"tolower" => str_case(interp, argv, CaseMode::Lower),
+        b"totitle" => str_case(interp, argv, CaseMode::Title),
         b"trim" => str_trim(interp, argv, true, true),
         b"trimleft" => str_trim(interp, argv, true, false),
         b"trimright" => str_trim(interp, argv, false, true),
@@ -233,24 +234,72 @@ fn str_reverse(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-fn str_case(interp: &mut Interp, argv: &[*mut TclObj], upper: bool) -> Code {
-    if argv.len() != 3 {
-        return wrong_args(
-            interp,
-            if upper {
-                b"string toupper string"
-            } else {
-                b"string tolower string"
-            },
-        );
+/// `string toupper`/`tolower`/`totitle`: the case mapping to apply.
+#[derive(Clone, Copy)]
+enum CaseMode {
+    Upper,
+    Lower,
+    /// First char of the range → upper, the rest → lower.
+    Title,
+}
+
+/// `string toupper|tolower|totitle string ?first? ?last?` — case-map a character
+/// range (the whole string by default). ASCII case only for now (non-ASCII
+/// bytes pass through unchanged — Unicode case mapping is deferred); the range
+/// uses character indices via the shared `index_spec`/`char_to_byte` helpers.
+fn str_case(interp: &mut Interp, argv: &[*mut TclObj], mode: CaseMode) -> Code {
+    let usage: &[u8] = match mode {
+        CaseMode::Upper => b"string toupper string ?first? ?last?",
+        CaseMode::Lower => b"string tolower string ?first? ?last?",
+        CaseMode::Title => b"string totitle string ?first? ?last?",
+    };
+    if argv.len() < 3 || argv.len() > 5 {
+        return wrong_args(interp, usage);
     }
-    // ASCII case only for now (Unicode case mapping is deferred).
     let mut s = obj_bytes(argv[2]);
-    for b in &mut s {
-        *b = if upper {
-            b.to_ascii_uppercase()
+    let n = char_count(&s);
+    if n == 0 {
+        interp.set_result_bytes(&s);
+        return Code::Ok;
+    }
+    // Default range is the whole string; `?first?`/`?last?` narrow it.
+    let lo = match argv.get(3) {
+        Some(&a) => match index_spec(&obj_bytes(a), n) {
+            Some(i) => i.max(0) as usize,
+            None => return bad_index(interp, &obj_bytes(a)),
+        },
+        None => 0,
+    };
+    let hi = match argv.get(4) {
+        Some(&a) => match index_spec(&obj_bytes(a), n) {
+            Some(i) => i,
+            None => return bad_index(interp, &obj_bytes(a)),
+        },
+        None => n as isize - 1,
+    };
+    if hi < 0 || lo >= n || (hi as usize) < lo {
+        interp.set_result_bytes(&s); // empty range ⇒ unchanged
+        return Code::Ok;
+    }
+    let hi = (hi as usize).min(n - 1);
+    let b0 = char_to_byte(&s, lo);
+    let b1 = char_to_byte(&s, hi + 1);
+    // For `totitle`, only the first character of the range is upper-cased.
+    let title_first_end = if matches!(mode, CaseMode::Title) {
+        char_to_byte(&s, lo + 1)
+    } else {
+        b0
+    };
+    for (off, byte) in s[b0..b1].iter_mut().enumerate() {
+        let upper = match mode {
+            CaseMode::Upper => true,
+            CaseMode::Lower => false,
+            CaseMode::Title => b0 + off < title_first_end,
+        };
+        *byte = if upper {
+            byte.to_ascii_uppercase()
         } else {
-            b.to_ascii_lowercase()
+            byte.to_ascii_lowercase()
         };
     }
     interp.set_result_bytes(&s);
@@ -809,6 +858,14 @@ mod tests {
     fn string_case_trim_first_last() {
         assert_eq!(ok(b"string toupper Hello"), b"HELLO");
         assert_eq!(ok(b"string tolower Hello"), b"hello");
+        // `totitle`: first char up, rest down (verified vs tclsh 9.0).
+        assert_eq!(ok(b"string totitle hello"), b"Hello");
+        assert_eq!(ok(b"string totitle {hello world}"), b"Hello world");
+        assert_eq!(ok(b"string totitle ABC"), b"Abc");
+        // `?first? ?last?` range form (Tcl 9): only the range is case-mapped.
+        assert_eq!(ok(b"string totitle abcdef 2 3"), b"abCdef");
+        assert_eq!(ok(b"string toupper abcdef 2 3"), b"abCDef");
+        assert_eq!(ok(b"string tolower ABCDEF 0 1"), b"abCDEF");
         assert_eq!(ok(b"string trim {  hi  }"), b"hi");
         assert_eq!(ok(b"string trimleft xxhi x"), b"hi");
         assert_eq!(ok(b"string trimright hixx x"), b"hi");

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -120,7 +120,7 @@ fn trace_add(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
     let command = obj_bytes(argv[5]);
     let (base, elem) = split_array_ref(&name);
-    interp.traces.traces.push(VarTrace {
+    interp.traces.borrow_mut().traces.push(VarTrace {
         name,
         base,
         elem,
@@ -142,13 +142,14 @@ fn trace_remove(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Err(c) => return c,
     };
     let command = obj_bytes(argv[5]);
-    if let Some(i) = interp
+    let pos = interp
         .traces
+        .borrow()
         .traces
         .iter()
-        .position(|t| t.name == name && t.ops == ops && t.command == command)
-    {
-        interp.traces.traces.remove(i);
+        .position(|t| t.name == name && t.ops == ops && t.command == command);
+    if let Some(i) = pos {
+        interp.traces.borrow_mut().traces.remove(i);
     }
     interp.set_result_bytes(b"");
     Code::Ok
@@ -162,7 +163,7 @@ fn trace_info(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let name = obj_bytes(argv[3]);
     let mut entries: Vec<*mut TclObj> = Vec::new();
-    for t in interp.traces.traces.iter().rev() {
+    for t in interp.traces.borrow().traces.iter().rev() {
         if t.name != name {
             continue;
         }

--- a/runtime/rust/src/cmd_var.rs
+++ b/runtime/rust/src/cmd_var.rs
@@ -78,7 +78,7 @@ fn global(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 /// `variable ?name value ...? name ?value?` — declare/link namespace variables,
 /// initialising those given a value. The trailing name may omit its value.
-fn variable(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+pub(crate) fn variable(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, b"variable ?name value ...? name ?value?");
     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -57,6 +57,40 @@ impl Code {
 /// [`Interp::set_result_bytes`] and returns a [`Code`].
 pub type BuiltinFn = fn(&mut Interp, &[*mut TclObj]) -> Code;
 
+/// The kind of body-frame a proc-style caller appends to the error trace when
+/// its body throws (`MakeProcError` / `MakeLambdaError`, `tclProc.c`). Both
+/// truncate the name to 60 bytes (`...` on overflow) and cite the body-relative
+/// `error_line` left by the innermost logged command.
+pub(crate) enum ProcFrame<'a> {
+    /// `(procedure "NAME" line N)` — a named `proc`. `NAME` is the invoked name.
+    Proc(&'a [u8]),
+    /// `(lambda term "LAMBDA" line N)` — an `apply` lambda. `LAMBDA` is the whole
+    /// lambda-expression string (`{params body ?ns?}`, i.e. `argv[1]`).
+    Lambda(&'a [u8]),
+}
+
+/// The error stack-trace accumulator — the runtime's analogue of `iPtr`'s
+/// `errorInfo`/`errorCode`/`errorLine`/`ERR_ALREADY_LOGGED` (PC-4). The trace is
+/// built **incrementally as the error unwinds** (`TclLogCommandInfo` +
+/// `MakeProcError`, `proc-call-and-stack-traces.md` §1.5), not at the throw, and
+/// published to the `::errorInfo`/`::errorCode` globals when the error is caught
+/// or reaches the outermost eval.
+#[derive(Default)]
+struct ExceptionState {
+    /// The accumulating `errorInfo`. `None` until the first frame is appended
+    /// (C's `errorInfo == NULL`) — which selects `while executing` over `invoked
+    /// from within` and seeds the buffer from the result message.
+    info: Option<Vec<u8>>,
+    /// `::errorCode` (empty ⇒ the `NONE` default is applied when published).
+    code: Vec<u8>,
+    /// 1-based source line of the innermost logged command, within its own
+    /// script (`errorLine`); read by `MakeProcError`'s `line N`.
+    line: u32,
+    /// `ERR_ALREADY_LOGGED`: the current command has already been logged deeper
+    /// in the same script, so its enclosing command must not re-log it.
+    already_logged: bool,
+}
+
 /// A registered command. `Builtin` and the `Alias` redirect today; `Proc {
 /// params, body }` (user procs, T1.5) and `External { table_index, client_data }`
 /// (extension commands via `Tcl_CreateObjCommand`, §4.6/§13.2, Track 2) are the
@@ -136,6 +170,13 @@ pub struct Interp {
     return_level: usize,
     /// Variable-trace registry (`trace add|remove|info variable`).
     pub(crate) traces: crate::cmd_trace::TraceTable,
+    /// The error stack-trace accumulator (PC-4).
+    exc: ExceptionState,
+    /// `eval_str` nesting depth. The outermost eval (depth returning to 0)
+    /// publishes the accumulated error trace to the `::errorInfo`/`::errorCode`
+    /// globals; nested evals (proc bodies, `[cmd]` subst, control bodies) just
+    /// accumulate.
+    eval_depth: usize,
     result: *mut TclObj,
 }
 
@@ -160,6 +201,8 @@ impl Interp {
             return_code: Code::Ok,
             return_level: 1,
             traces: crate::cmd_trace::TraceTable::default(),
+            exc: ExceptionState::default(),
+            eval_depth: 0,
             result,
         });
         builtins::install(&mut interp);
@@ -734,30 +777,204 @@ impl Interp {
         obj_bytes(self.result)
     }
 
-    /// Set an error result and return [`Code::Error`].
+    /// Raise an error with result `msg` and return [`Code::Error`] — the generic
+    /// throw. Resets the [`ExceptionState`] to a fresh error: the source trace
+    /// (`::errorInfo`) is then built up **as the error unwinds**
+    /// ([`log_command_info`](Self::log_command_info) /
+    /// [`make_proc_error`](Self::make_proc_error)) and published to the globals at
+    /// the catch / outermost-eval boundary — not stamped here.
+    ///
+    /// The `-errorcode` taxonomy is conservative for now: `wrong # args` ⇒ `TCL
+    /// WRONGARGS`, else `NONE` (the full taxonomy is a follow-up). `error`/`throw`
+    /// set a richer code on their own paths.
     fn error(&mut self, msg: &[u8]) -> Code {
         self.set_result_bytes(msg);
-        // Every error stamps `::errorInfo` (the message — the incremental
-        // source-trace is deferred) and `::errorCode` (`NONE` for a generic
-        // error). `error`/`throw` set richer values on their own paths and do
-        // not route through here, so they aren't clobbered. (Zig oracle: errors
-        // stamp the globals in and out of `catch`.)
-        let ei = new_string(msg);
-        if self.var_set(b"::errorInfo", ei).is_err() {
-            drop_fresh(ei);
-        }
-        // The common error codes Tcl stamps (the full `-errorcode` taxonomy is a
-        // follow-up): `wrong # args` ⇒ `TCL WRONGARGS`, else `NONE`.
         let code: &[u8] = if msg.starts_with(b"wrong # args:") {
             b"TCL WRONGARGS"
         } else {
             b"NONE"
         };
-        let ec = new_string(code);
+        self.exc = ExceptionState {
+            info: None,
+            code: code.to_vec(),
+            line: 1,
+            already_logged: false,
+        };
+        Code::Error
+    }
+
+    /// Pre-seed the error trace for `error msg info ?code?` / `throw`: the result
+    /// is `msg`, the trace starts at `info` (so the throwing command is **not**
+    /// re-logged — `ERR_ALREADY_LOGGED`), and `-errorcode` is `code`. Returns
+    /// [`Code::Error`].
+    pub(crate) fn raise_with_info(&mut self, msg: &[u8], info: &[u8], code: &[u8]) -> Code {
+        self.set_result_bytes(msg);
+        self.exc = ExceptionState {
+            info: Some(info.to_vec()),
+            code: code.to_vec(),
+            line: 1,
+            already_logged: true,
+        };
+        Code::Error
+    }
+
+    /// Begin a fresh error whose result the caller has already set, with
+    /// `-errorcode` `code` and an empty trace (it accumulates as the error
+    /// unwinds). Used by `error msg`/`throw`. Returns [`Code::Error`].
+    pub(crate) fn set_error_state(&mut self, code: &[u8]) -> Code {
+        self.exc = ExceptionState {
+            info: None,
+            code: code.to_vec(),
+            line: 1,
+            already_logged: false,
+        };
+        Code::Error
+    }
+
+    /// Append one `while executing` / `invoked from within` frame for the command
+    /// `src[cmd.start..cmd.end]` as an error unwinds through it — the
+    /// `TclLogCommandInfo` mirror (`tclNamesp.c`). A no-op (consuming the flag)
+    /// when the command was already logged deeper in the same script; otherwise
+    /// it computes the 1-based source line, seeds `errorInfo` from the result on
+    /// the first frame, truncates the command to 150 bytes (`...` on overflow),
+    /// and sets `already_logged`.
+    fn log_command_info(&mut self, src: &[u8], cmd: &parse::Command) {
+        // Already logged deeper in the same script (e.g. an inner `[cmd]` subst,
+        // or an inline `if`/`while` body): the enclosing command is the same C
+        // bytecode frame, so it is *not* re-logged. The flag stays set and is
+        // cleared only at a real frame boundary (`make_proc_error` /
+        // `append_body_frame`), which is what lets the proc-*call* command log.
+        if self.exc.already_logged {
+            return;
+        }
+        // errorLine = 1 + count('\n' in src[0..commandStart]) — C's exact loop.
+        let line = 1 + src[..cmd.start].iter().filter(|&&b| b == b'\n').count() as u32;
+        self.exc.line = line;
+        let started = self.exc.info.is_some();
+        if !started {
+            // First frame: errorInfo is seeded from the error message (the result).
+            let msg = self.result_bytes();
+            self.exc.info = Some(msg);
+        }
+        let verb: &[u8] = if started {
+            b"invoked from within"
+        } else {
+            b"while executing"
+        };
+        let cmd_bytes = &src[cmd.start..cmd.end];
+        let overflow = cmd_bytes.len() > 150;
+        let slice = if overflow {
+            &cmd_bytes[..150]
+        } else {
+            cmd_bytes
+        };
+        let buf = self.exc.info.as_mut().expect("seeded above");
+        buf.extend_from_slice(b"\n    ");
+        buf.extend_from_slice(verb);
+        buf.extend_from_slice(b"\n\"");
+        buf.extend_from_slice(slice);
+        if overflow {
+            buf.extend_from_slice(b"...");
+        }
+        buf.push(b'"');
+        self.exc.already_logged = true;
+    }
+
+    /// Append the `(procedure "NAME" line N)` / `(lambda term "..." line N)`
+    /// frame when a proc/lambda body unwinds with an error (`MakeProcError` /
+    /// `MakeLambdaError`, `tclProc.c`), then clear `already_logged` so the
+    /// proc-call command itself is logged by its enclosing eval. The line is the
+    /// body-relative `error_line` the innermost body command recorded.
+    fn make_proc_error(&mut self, frame: ProcFrame) {
+        // `(procedure "NAME" line N)` / `(lambda term "NAME" line N)` — the name
+        // quoted, truncated to 60 bytes (`...` on overflow).
+        let (kind, name): (&[u8], &[u8]) = match frame {
+            ProcFrame::Proc(n) => (b"procedure", n),
+            ProcFrame::Lambda(n) => (b"lambda term", n),
+        };
+        let overflow = name.len() > 60;
+        let trunc = if overflow { &name[..60] } else { name };
+        let mut inner = Vec::with_capacity(kind.len() + trunc.len() + 8);
+        inner.extend_from_slice(kind);
+        inner.extend_from_slice(b" \"");
+        inner.extend_from_slice(trunc);
+        if overflow {
+            inner.extend_from_slice(b"...");
+        }
+        inner.push(b'"');
+        self.append_frame_line(&inner);
+        self.exc.already_logged = false;
+    }
+
+    /// Append a `("LABEL" body line N)` frame (the `eval`/`uplevel`/`foreach`
+    /// body trace, e.g. `("eval" body line 1)`), then clear `already_logged` so
+    /// the enclosing command logs. C emits these for script bodies that evaluate
+    /// through a fresh `CmdFrame` (`eval`/`uplevel`/`foreach`), unlike the
+    /// inline-compiled `if`/`while`/`for`/`switch`.
+    pub(crate) fn append_body_frame(&mut self, label: &[u8]) {
+        // The `"label" body` shape: `("eval" body line N)`.
+        let mut inner = Vec::with_capacity(label.len() + 8);
+        inner.push(b'"');
+        inner.extend_from_slice(label);
+        inner.extend_from_slice(b"\" body");
+        self.append_frame_line(&inner);
+        self.exc.already_logged = false;
+    }
+
+    /// Shared tail of the `(... line N)` frames: append `"\n    (<inner> line
+    /// <N>)"` to `errorInfo` (seeding it from the result message if no frame has
+    /// been logged yet), where `inner` is the caller-built body — e.g.
+    /// `procedure "p"`, `lambda term "..."`, or `"eval" body`.
+    fn append_frame_line(&mut self, inner: &[u8]) {
+        let line = self.exc.line;
+        if self.exc.info.is_none() {
+            let msg = self.result_bytes();
+            self.exc.info = Some(msg);
+        }
+        let buf = self.exc.info.as_mut().expect("seeded above");
+        buf.extend_from_slice(b"\n    (");
+        buf.extend_from_slice(inner);
+        buf.extend_from_slice(b" line ");
+        buf.extend_from_slice(line.to_string().as_bytes());
+        buf.push(b')');
+    }
+
+    /// The current accumulated `errorInfo` (for `catch`'s `-errorinfo`): the
+    /// trace if any frame was logged, else the bare error message.
+    pub(crate) fn error_info(&self) -> Vec<u8> {
+        self.exc.info.clone().unwrap_or_else(|| self.result_bytes())
+    }
+
+    /// The current `errorCode` (for `catch`'s `-errorcode`): the stamped value,
+    /// or `NONE`.
+    pub(crate) fn error_code(&self) -> Vec<u8> {
+        if self.exc.code.is_empty() {
+            b"NONE".to_vec()
+        } else {
+            self.exc.code.clone()
+        }
+    }
+
+    /// Publish the accumulated trace to the `::errorInfo`/`::errorCode` globals
+    /// and reset the accumulator for the next error. Called when the error is
+    /// caught (`catch`) or reaches the outermost eval.
+    fn publish_error(&mut self) {
+        let info = self.error_info();
+        let code = self.error_code();
+        let ei = new_string(&info);
+        if self.var_set(b"::errorInfo", ei).is_err() {
+            drop_fresh(ei);
+        }
+        let ec = new_string(&code);
         if self.var_set(b"::errorCode", ec).is_err() {
             drop_fresh(ec);
         }
-        Code::Error
+        self.exc = ExceptionState::default();
+    }
+
+    /// Publish + reset, for `catch`/`try` once they have captured the options.
+    pub(crate) fn publish_and_reset_error(&mut self) {
+        self.publish_error();
     }
 
     // -- eval -----------------------------------------------------------------
@@ -765,20 +982,38 @@ impl Interp {
     /// Evaluate a whole script; the result is left in the interp result. Returns
     /// the completion code of the last command (or `Ok` for an empty script).
     pub fn eval_str(&mut self, src: &[u8]) -> Code {
+        self.eval_depth += 1;
         let mut last = Code::Ok;
         let commands = parse::parse_script(src);
         for cmd in &commands {
-            last = self.eval_command(&cmd.words);
+            last = self.eval_command(src, cmd);
             if last != Code::Ok {
                 break; // error/return/break/continue propagate up
             }
         }
+        self.eval_depth -= 1;
+        // The outermost eval publishes the accumulated trace to the globals so
+        // an uncaught error leaves `::errorInfo`/`::errorCode` set, exactly as a
+        // `catch` would (`catch` publishes earlier, at depth > 0).
+        if self.eval_depth == 0 && last == Code::Error {
+            self.publish_error();
+        }
         last
     }
 
-    /// Evaluate one already-parsed command: substitute each word (with `{*}`
-    /// expansion), then dispatch.
-    fn eval_command(&mut self, words: &[parse::Word]) -> Code {
+    /// Evaluate one parsed command, then — if it errored — append its
+    /// `while executing` / `invoked from within` frame to the error trace
+    /// (`TclLogCommandInfo`), using the command's source slice and line.
+    fn eval_command(&mut self, src: &[u8], cmd: &parse::Command) -> Code {
+        let code = self.eval_words(&cmd.words);
+        if code == Code::Error {
+            self.log_command_info(src, cmd);
+        }
+        code
+    }
+
+    /// Substitute each word of a command (with `{*}` expansion), then dispatch.
+    fn eval_words(&mut self, words: &[parse::Word]) -> Code {
         let mut argv: Vec<*mut TclObj> = Vec::new();
         for w in words {
             let obj = match self.substitute_word(&w.body) {
@@ -870,12 +1105,14 @@ impl Interp {
     ///
     /// [`run_proc`]: Interp::run_proc
     fn call_proc(&mut self, def: &ProcDef, argv: &[*mut TclObj]) -> Code {
+        let name = obj_bytes(argv[0]);
         self.run_proc(
             &def.params,
             &def.body,
             def.ns,
             &argv[1..],
-            &obj_bytes(argv[0]),
+            &name,
+            ProcFrame::Proc(&name),
         )
     }
 
@@ -895,6 +1132,7 @@ impl Interp {
         ns: NsId,
         call_args: &[*mut TclObj],
         usage_called: &[u8],
+        frame: ProcFrame,
     ) -> Code {
         let has_args = params.last().is_some_and(|p| p.name == b"args");
         let positional = if has_args {
@@ -965,11 +1203,17 @@ impl Interp {
         // Apply the return boundary (`return`/`return -code -level`), then a
         // bare `break`/`continue` that escaped the body (no enclosing loop) is an
         // error (C Tcl: `invoked "break" outside of a loop`).
-        match self.settle_return(code) {
+        let settled = match self.settle_return(code) {
             Code::Break => self.error(b"invoked \"break\" outside of a loop"),
             Code::Continue => self.error(b"invoked \"continue\" outside of a loop"),
             other => other,
+        };
+        // On error, append the `(procedure "name" line N)` / `(lambda term ...)`
+        // frame and clear `already_logged` so the proc-call command logs next.
+        if settled == Code::Error {
+            self.make_proc_error(frame);
         }
+        settled
     }
 
     /// The ensemble trampoline: resolve `argv[1]` against the subcommand set

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -79,6 +79,9 @@ pub(crate) struct CallMeta<'a> {
     /// The file the body was defined in (`source`d) — makes its `info frame`
     /// `type source` with this `file`.
     pub source: Option<Rc<[u8]>>,
+    /// The body's `info frame` line base (file-absolute for a source-defined
+    /// proc, 0 otherwise).
+    pub body_line_base: u32,
 }
 
 /// One entry of the source-location stack (`cmdFramePtr`; PC-5) — the runtime
@@ -89,29 +92,65 @@ pub(crate) struct CallMeta<'a> {
 /// `cmd`/`line` are updated to the currently-executing command of the
 /// frame-owning script as the eval loop steps through it.
 struct CmdFrame {
-    /// The file this script came from (`source`d / a proc defined in one) →
-    /// `type source` + the `file` key. `None` ⇒ `type proc`/`eval`.
+    /// The frame's location `type` (`eval`/`proc`/`source`). Explicit rather than
+    /// derived: an `uplevel` body is `type eval` yet still names the invoking
+    /// proc, and an `eval` body inherits the enclosing kind.
+    kind: FrameKind,
+    /// The file this script came from (`source`d / a proc defined in one) — the
+    /// `file` key (present for `source` frames).
     file: Option<Rc<[u8]>>,
     /// The proc FQN this frame runs in (a proc call; `eval`/`uplevel` bodies
-    /// inherit the enclosing proc) → the `proc` key and `type proc`. `None` at
-    /// the global level (`type eval`).
+    /// inherit the enclosing proc) — the `proc` key. `None` at the global level.
     proc: Option<Vec<u8>>,
     /// The proc (call) level this frame runs in; the `level` key is the distance
     /// from the current level (`current_level - this`).
     level: usize,
+    /// Omit the `level` key — C drops it when the frame's CallFrame is not on the
+    /// current var-scope chain, which is the `uplevel` case (its body runs in a
+    /// redirected scope).
+    omit_level: bool,
+    /// Added to a body-relative line to get the reported `line`. `0` for
+    /// top-level / `eval` / eval-defined procs (body-relative, matching tclsh);
+    /// for a proc defined in a `source`d file it is the file line where the body
+    /// began minus one, so its commands report file-absolute lines.
+    line_base: u32,
     /// The currently-executing command at this level (the `cmd` key) and its
-    /// 1-based source line (the `line` key).
+    /// reported source line (the `line` key).
     cmd: Vec<u8>,
     line: u32,
+}
+
+/// A `CmdFrame`'s location type (`info frame`'s `type` key).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FrameKind {
+    /// Top level / an `eval` or `uplevel` body (`type eval`).
+    Eval,
+    /// A proc body (`type proc`).
+    Proc,
+    /// A `source`d file, or a proc defined in one (`type source`).
+    Source,
+}
+
+impl FrameKind {
+    fn as_bytes(self) -> &'static [u8] {
+        match self {
+            FrameKind::Eval => b"eval",
+            FrameKind::Proc => b"proc",
+            FrameKind::Source => b"source",
+        }
+    }
 }
 
 impl CmdFrame {
     /// The top-level script frame (`type eval`, global level).
     fn root() -> Self {
         CmdFrame {
+            kind: FrameKind::Eval,
             file: None,
             proc: None,
             level: 0,
+            omit_level: false,
+            line_base: 0,
             cmd: Vec::new(),
             line: 1,
         }
@@ -205,6 +244,10 @@ pub struct ProcDef {
     /// The file the proc was defined in (`source`d), if any — makes its body
     /// frame `type source` with this `file` (`info frame`).
     pub source: Option<Rc<[u8]>>,
+    /// The line base for the body's `info frame` lines: `0` (body-relative) for
+    /// an eval-defined proc, or the defining file line minus one for one defined
+    /// in a `source`d file (so its commands report file-absolute lines).
+    pub body_line_base: u32,
 }
 
 /// `Tcl_Interp`. Owns the frame stack, the command table, and the current
@@ -343,16 +386,31 @@ impl Interp {
         }
         fqn.extend_from_slice(&tail);
         // A proc defined while a file is being sourced records that file, so its
-        // body frame reports `type source`.
+        // body frame reports `type source`. Its body lines are then file-absolute
+        // (C's literal line table): the base is the file line of the `proc`
+        // command minus one (the body opens on that line). Eval-defined procs
+        // keep body-relative lines (base 0).
         let source = self.script_stack.last().map(|f| Rc::from(f.as_slice()));
+        let body_line_base = if source.is_some() {
+            self.current_cmd_line().saturating_sub(1)
+        } else {
+            0
+        };
         let def = Rc::new(ProcDef {
             params,
             body,
             ns,
             fqn,
             source,
+            body_line_base,
         });
         self.namespaces.bind(ns, &tail, Command::Proc(def));
+    }
+
+    /// The reported `line` of the command currently executing at the top of the
+    /// `info frame` stack (for fixing a source-defined proc's body line base).
+    fn current_cmd_line(&self) -> u32 {
+        self.cmd_frames.last().map_or(1, |f| f.line)
     }
 
     /// Whether `name` resolves to an ensemble command (`namespace ensemble
@@ -472,12 +530,15 @@ impl Interp {
     /// `source`: evaluate `script` as a sourced file named `name`, tracking it on
     /// the script stack (`info script`). A top-level `return` ends the file (the
     /// return boundary maps `return` → Ok); other codes propagate.
-    pub(crate) fn eval_sourced(&mut self, script: &[u8], name: &[u8]) -> Code {
+    pub fn eval_sourced(&mut self, script: &[u8], name: &[u8]) -> Code {
         self.script_stack.push(name.to_vec());
         // A `source`d file is its own `info frame` level: `type source` + the
-        // file path, inheriting the enclosing proc/level.
+        // file path, inheriting the enclosing proc/level. Its commands are
+        // numbered by the file's own lines (base 0, the file *is* the script).
         let mut frame = self.inherited_cmd_frame();
+        frame.kind = FrameKind::Source;
         frame.file = Some(Rc::from(name));
+        frame.line_base = 0;
         let code = self.eval_framed(script, frame);
         self.script_stack.pop();
         self.settle_return(code)
@@ -496,11 +557,17 @@ impl Interp {
         let prev_level = self.frames.set_active_level(target_level);
         let prev_ns = self.current_ns;
         self.current_ns = self.frames.frame_ns(target_level);
-        // The `uplevel` body runs at the target call level (its own `info frame`
-        // level); the proc/file context is inherited (an approximation of the
-        // target frame's — exact target-proc resolution is a follow-up).
+        // The `uplevel` body is a fresh dynamically-evaluated script: `type
+        // eval`, **no** file, body-relative lines (base 0) — but it keeps the
+        // invoking proc's name and runs at the target call level (with no
+        // `level` key, the redirected scope). Matches tclsh, where `uplevel`'s
+        // body is not inlined into the proc bytecode.
         let mut frame = self.inherited_cmd_frame();
+        frame.kind = FrameKind::Eval;
+        frame.file = None;
+        frame.line_base = 0;
         frame.level = target_level;
+        frame.omit_level = true;
         let code = self.eval_framed(script, frame);
         self.frames.set_active_level(prev_level);
         self.current_ns = prev_ns;
@@ -1054,15 +1121,8 @@ impl Interp {
             return None;
         }
         let f = &self.cmd_frames[(pos - 1) as usize];
-        let typ: &[u8] = if f.file.is_some() {
-            b"source"
-        } else if f.proc.is_some() {
-            b"proc"
-        } else {
-            b"eval"
-        };
         let mut pairs = vec![
-            (b"type".to_vec(), typ.to_vec()),
+            (b"type".to_vec(), f.kind.as_bytes().to_vec()),
             (b"line".to_vec(), f.line.to_string().into_bytes()),
         ];
         if let Some(file) = &f.file {
@@ -1072,9 +1132,12 @@ impl Interp {
         if let Some(p) = &f.proc {
             pairs.push((b"proc".to_vec(), p.clone()));
         }
-        // `level` is the distance from the current call level.
-        let level = self.frames.current_level().saturating_sub(f.level);
-        pairs.push((b"level".to_vec(), level.to_string().into_bytes()));
+        // `level` is the distance from the current call level (omitted for a
+        // redirected `uplevel` scope, matching C's reachability check).
+        if !f.omit_level {
+            let level = self.frames.current_level().saturating_sub(f.level);
+            pairs.push((b"level".to_vec(), level.to_string().into_bytes()));
+        }
         Some(pairs)
     }
 
@@ -1163,15 +1226,22 @@ impl Interp {
         last
     }
 
-    /// A `CmdFrame` for an `eval`/`uplevel`/`source` body, inheriting the current
-    /// frame's proc/level/file context (these bodies run in the enclosing
-    /// CallFrame). The caller overrides `file` (`source`) or `level` (`uplevel`).
+    /// A `CmdFrame` for an `eval` body, inheriting the current frame's
+    /// kind/proc/level/file context (the body runs in the enclosing CallFrame).
+    /// `line_base` is the line of the `eval` command minus one — the body opens
+    /// on that line, so in a sourced context its commands stay file-absolute
+    /// (e.g. `eval` at file line 5 → its body at line 5). `uplevel`/`source`
+    /// override fields ([`eval_uplevel`](Self::eval_uplevel)/
+    /// [`eval_sourced`](Self::eval_sourced)).
     fn inherited_cmd_frame(&self) -> CmdFrame {
         let top = self.cmd_frames.last();
         CmdFrame {
+            kind: top.map_or(FrameKind::Eval, |f| f.kind),
             file: top.and_then(|f| f.file.clone()),
             proc: top.and_then(|f| f.proc.clone()),
             level: top.map_or(0, |f| f.level),
+            omit_level: false,
+            line_base: self.current_cmd_line().saturating_sub(1),
             cmd: Vec::new(),
             line: 1,
         }
@@ -1197,7 +1267,9 @@ impl Interp {
         // advances the line as it steps through its own commands.
         if let Some(top) = self.cmd_frames.last_mut() {
             if owns_frame {
-                top.line = line_of(src, cmd.start);
+                // `line_base` shifts a source-defined proc's body lines to be
+                // file-absolute; it is 0 elsewhere (body-relative).
+                top.line = top.line_base + line_of(src, cmd.start);
             }
             top.cmd = src[cmd.start..cmd.end].to_vec();
         }
@@ -1312,6 +1384,7 @@ impl Interp {
                 err: ProcFrame::Proc(&name),
                 fqn: Some(&def.fqn),
                 source: def.source.clone(),
+                body_line_base: def.body_line_base,
             },
         )
     }
@@ -1400,9 +1473,16 @@ impl Interp {
         // `source` if defined in a sourced file), the proc FQN, and the new call
         // level (set after `frames.push`, so `current_level` is the proc's).
         let proc_frame = CmdFrame {
+            kind: if meta.source.is_some() {
+                FrameKind::Source
+            } else {
+                FrameKind::Proc
+            },
             file: meta.source,
             proc: meta.fqn.map(<[u8]>::to_vec),
             level: self.frames.current_level(),
+            omit_level: false,
+            line_base: meta.body_line_base,
             cmd: Vec::new(),
             line: 1,
         };

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -441,7 +441,18 @@ impl Interp {
     /// Register an ensemble command (`namespace ensemble create`); `name` is the
     /// ensemble command (possibly qualified — rooted at global like any builtin).
     pub(crate) fn create_ensemble(&mut self, name: &[u8], cfg: crate::ensemble::EnsembleConfig) {
-        self.namespaces.register(name, Command::Ensemble(cfg));
+        // The `-command` name resolves relative to the current namespace, like a
+        // proc name (C's `TclGetNamespaceForQualName(name, cxtPtr=nsPtr, ...)` in
+        // `NamespaceEnsembleCmd`). `namespace ensemble create -command path`
+        // inside `namespace eval ::tcl::tm` therefore binds `::tcl::tm::path`,
+        // not a bare `::path` at global scope.
+        let ns = self.namespaces.command_home_ns(self.current_ns, name);
+        let tail = tcl_syntax::naming::qualifier_segments(name)
+            .last()
+            .copied()
+            .unwrap_or(name)
+            .to_vec();
+        self.namespaces.bind(ns, &tail, Command::Ensemble(cfg));
     }
 
     /// Define a user proc (`proc name params body`). The proc's defining

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -308,6 +308,10 @@ pub struct Interp {
     children: std::collections::BTreeMap<Vec<u8>, Box<Interp>>,
     /// Counter for auto-generated child names (`interp0`, `interp1`, …).
     interp_counter: usize,
+    /// Hidden commands (`interp hide`): removed from the command table but
+    /// invocable via `interp invokehidden`. A safe interp hides the dangerous
+    /// commands here.
+    hidden: std::collections::BTreeMap<Vec<u8>, Command>,
     /// TclOO object system state (classes, objects, the method-call stack).
     pub(crate) oo: crate::cmd_oo::OoState,
     /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
@@ -344,6 +348,7 @@ impl Interp {
             exc: ExceptionState::default(),
             children: std::collections::BTreeMap::new(),
             interp_counter: 0,
+            hidden: std::collections::BTreeMap::new(),
             oo: crate::cmd_oo::OoState::default(),
             cmd_frames: Vec::new(),
             eval_depth: 0,
@@ -1454,6 +1459,48 @@ impl Interp {
                 self.set_result_bytes(b"");
                 Code::Ok
             }
+            b"hide" | b"expose" if argv.len() == 3 => {
+                let hide = obj_bytes(argv[1]) == b"hide";
+                let cmd = obj_bytes(argv[2]);
+                self.with_child(name, |c| {
+                    if hide {
+                        c.hide_command(&cmd)
+                    } else {
+                        c.expose_command(&cmd)
+                    }
+                });
+                self.set_result_bytes(b"");
+                Code::Ok
+            }
+            b"invokehidden" if argv.len() >= 3 => {
+                let cmd = obj_bytes(argv[2]);
+                let hidden_argv: Vec<*mut TclObj> = argv[2..].to_vec();
+                for &a in &hidden_argv {
+                    unsafe { obj::incr_ref_count(a) };
+                }
+                let out = self.with_child(name, |c| {
+                    (c.invoke_hidden(&cmd, &hidden_argv), c.result_bytes())
+                });
+                for &a in &hidden_argv {
+                    unsafe { obj::decr_ref_count(a) };
+                }
+                match out {
+                    Some((code, res)) => {
+                        self.set_result_bytes(&res);
+                        code
+                    }
+                    None => self.error(b"could not find interpreter"),
+                }
+            }
+            b"hidden" => {
+                let names = self
+                    .with_child(name, |c| c.hidden_names())
+                    .unwrap_or_default();
+                let elems: Vec<*mut TclObj> =
+                    names.iter().map(|n| obj::new_string_bytes(n)).collect();
+                self.set_result(crate::list::new_list_obj(&elems));
+                Code::Ok
+            }
             other => {
                 let mut m = b"interp subcommand \"".to_vec();
                 m.extend_from_slice(other);
@@ -1484,6 +1531,84 @@ impl Interp {
     /// Whether a child interpreter `name` exists.
     pub(crate) fn child_exists(&self, name: &[u8]) -> bool {
         self.children.contains_key(name)
+    }
+
+    /// Run `f` on the child interpreter `name` (or `None` if it doesn't exist) —
+    /// the mutable-access path for `interp <sub> childPath …`.
+    pub(crate) fn with_child<R>(
+        &mut self,
+        name: &[u8],
+        f: impl FnOnce(&mut Interp) -> R,
+    ) -> Option<R> {
+        self.children.get_mut(name).map(|c| f(c))
+    }
+
+    /// `interp hide name`: move command `name` out of the command table into the
+    /// hidden table. Returns whether it existed.
+    pub(crate) fn hide_command(&mut self, name: &[u8]) -> bool {
+        match self.namespaces.resolve(GLOBAL, name) {
+            Some(cmd) => {
+                self.namespaces.delete(GLOBAL, name);
+                self.hidden.insert(name.to_vec(), cmd);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// `interp expose name`: move a hidden command back into the command table.
+    pub(crate) fn expose_command(&mut self, name: &[u8]) -> bool {
+        match self.hidden.remove(name) {
+            Some(cmd) => {
+                self.namespaces.register(name, cmd);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// `interp invokehidden name ?arg ...?` — invoke a hidden command.
+    pub(crate) fn invoke_hidden(&mut self, name: &[u8], argv: &[*mut TclObj]) -> Code {
+        match self.hidden.get(name).cloned() {
+            Some(cmd) => self.invoke(cmd, argv),
+            None => {
+                let mut m = b"invalid hidden command name \"".to_vec();
+                m.extend_from_slice(name);
+                m.push(b'"');
+                self.error(&m)
+            }
+        }
+    }
+
+    /// Sorted names of the hidden commands (`interp hidden`).
+    pub(crate) fn hidden_names(&self) -> Vec<Vec<u8>> {
+        self.hidden.keys().cloned().collect()
+    }
+
+    /// Make this interp "safe": hide the commands that touch the host
+    /// (filesystem, processes, sockets, the interpreter itself) — the core of
+    /// `interp create -safe`. The Safe Base's re-aliasing of `source`/`load`/
+    /// `file` is a follow-up (needs cross-interp aliases).
+    pub(crate) fn make_safe(&mut self) {
+        const UNSAFE: &[&[u8]] = &[
+            b"exec",
+            b"exit",
+            b"cd",
+            b"pwd",
+            b"glob",
+            b"open",
+            b"socket",
+            b"source",
+            b"load",
+            b"file",
+            b"fconfigure",
+            b"encoding",
+            b"after",
+            b"vwait",
+        ];
+        for &c in UNSAFE {
+            self.hide_command(c);
+        }
     }
 
     /// The names of this interp's direct child interpreters (sorted).

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -69,6 +69,64 @@ pub(crate) enum ProcFrame<'a> {
     Lambda(&'a [u8]),
 }
 
+/// What a proc/lambda call contributes to the diagnostic stacks: the errorInfo
+/// frame (PC-4) plus the `info frame` proc FQN and defining-source (PC-5).
+pub(crate) struct CallMeta<'a> {
+    /// The errorInfo `(procedure/lambda ...)` frame.
+    pub err: ProcFrame<'a>,
+    /// The proc's FQN — the `info frame` `proc` key (`None` for a lambda).
+    pub fqn: Option<&'a [u8]>,
+    /// The file the body was defined in (`source`d) — makes its `info frame`
+    /// `type source` with this `file`.
+    pub source: Option<Rc<[u8]>>,
+}
+
+/// One entry of the source-location stack (`cmdFramePtr`; PC-5) — the runtime
+/// state `info frame` reports. One is pushed per script-evaluation level Tcl
+/// tracks: the top-level script, a proc call, an `eval`/`uplevel` body, and a
+/// `source`d file — but **not** a `[cmd]` substitution or an inline
+/// `if`/`while`/`for`/`foreach` body (those run in the enclosing frame). The
+/// `cmd`/`line` are updated to the currently-executing command of the
+/// frame-owning script as the eval loop steps through it.
+struct CmdFrame {
+    /// The file this script came from (`source`d / a proc defined in one) →
+    /// `type source` + the `file` key. `None` ⇒ `type proc`/`eval`.
+    file: Option<Rc<[u8]>>,
+    /// The proc FQN this frame runs in (a proc call; `eval`/`uplevel` bodies
+    /// inherit the enclosing proc) → the `proc` key and `type proc`. `None` at
+    /// the global level (`type eval`).
+    proc: Option<Vec<u8>>,
+    /// The proc (call) level this frame runs in; the `level` key is the distance
+    /// from the current level (`current_level - this`).
+    level: usize,
+    /// The currently-executing command at this level (the `cmd` key) and its
+    /// 1-based source line (the `line` key).
+    cmd: Vec<u8>,
+    line: u32,
+}
+
+impl CmdFrame {
+    /// The top-level script frame (`type eval`, global level).
+    fn root() -> Self {
+        CmdFrame {
+            file: None,
+            proc: None,
+            level: 0,
+            cmd: Vec::new(),
+            line: 1,
+        }
+    }
+}
+
+/// The 1-based source line of byte `offset` in `src` — `1 + count('\n' in
+/// src[0..offset])`, C's exact `TclLogCommandInfo` loop (encoding-agnostic).
+fn line_of(src: &[u8], offset: usize) -> u32 {
+    1 + src[..offset.min(src.len())]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count() as u32
+}
+
 /// The error stack-trace accumulator — the runtime's analogue of `iPtr`'s
 /// `errorInfo`/`errorCode`/`errorLine`/`ERR_ALREADY_LOGGED` (PC-4). The trace is
 /// built **incrementally as the error unwinds** (`TclLogCommandInfo` +
@@ -141,6 +199,12 @@ pub struct ProcDef {
     pub params: Vec<Param>,
     pub body: Vec<u8>,
     pub ns: NsId,
+    /// The proc's fully-qualified name (`::ns::name`) — the `info frame` `proc`
+    /// key, fixed at definition time.
+    pub fqn: Vec<u8>,
+    /// The file the proc was defined in (`source`d), if any — makes its body
+    /// frame `type source` with this `file` (`info frame`).
+    pub source: Option<Rc<[u8]>>,
 }
 
 /// `Tcl_Interp`. Owns the frame stack, the command table, and the current
@@ -172,6 +236,8 @@ pub struct Interp {
     pub(crate) traces: crate::cmd_trace::TraceTable,
     /// The error stack-trace accumulator (PC-4).
     exc: ExceptionState,
+    /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
+    cmd_frames: Vec<CmdFrame>,
     /// `eval_str` nesting depth. The outermost eval (depth returning to 0)
     /// publishes the accumulated error trace to the `::errorInfo`/`::errorCode`
     /// globals; nested evals (proc bodies, `[cmd]` subst, control bodies) just
@@ -202,6 +268,7 @@ impl Interp {
             return_level: 1,
             traces: crate::cmd_trace::TraceTable::default(),
             exc: ExceptionState::default(),
+            cmd_frames: Vec::new(),
             eval_depth: 0,
             result,
         });
@@ -267,7 +334,24 @@ impl Interp {
             .copied()
             .unwrap_or(name)
             .to_vec();
-        let def = Rc::new(ProcDef { params, body, ns });
+        // The proc's FQN (`info frame` `proc` key): `<ns>::<tail>`, the global ns
+        // contributing just the leading `::`.
+        let qn = self.namespaces.qualified_name(ns);
+        let mut fqn = qn.clone();
+        if qn != b"::" {
+            fqn.extend_from_slice(b"::");
+        }
+        fqn.extend_from_slice(&tail);
+        // A proc defined while a file is being sourced records that file, so its
+        // body frame reports `type source`.
+        let source = self.script_stack.last().map(|f| Rc::from(f.as_slice()));
+        let def = Rc::new(ProcDef {
+            params,
+            body,
+            ns,
+            fqn,
+            source,
+        });
         self.namespaces.bind(ns, &tail, Command::Proc(def));
     }
 
@@ -390,7 +474,11 @@ impl Interp {
     /// return boundary maps `return` → Ok); other codes propagate.
     pub(crate) fn eval_sourced(&mut self, script: &[u8], name: &[u8]) -> Code {
         self.script_stack.push(name.to_vec());
-        let code = self.eval_str(script);
+        // A `source`d file is its own `info frame` level: `type source` + the
+        // file path, inheriting the enclosing proc/level.
+        let mut frame = self.inherited_cmd_frame();
+        frame.file = Some(Rc::from(name));
+        let code = self.eval_framed(script, frame);
         self.script_stack.pop();
         self.settle_return(code)
     }
@@ -408,7 +496,12 @@ impl Interp {
         let prev_level = self.frames.set_active_level(target_level);
         let prev_ns = self.current_ns;
         self.current_ns = self.frames.frame_ns(target_level);
-        let code = self.eval_str(script);
+        // The `uplevel` body runs at the target call level (its own `info frame`
+        // level); the proc/file context is inherited (an approximation of the
+        // target frame's — exact target-proc resolution is a follow-up).
+        let mut frame = self.inherited_cmd_frame();
+        frame.level = target_level;
+        let code = self.eval_framed(script, frame);
         self.frames.set_active_level(prev_level);
         self.current_ns = prev_ns;
         code
@@ -848,8 +941,7 @@ impl Interp {
             return;
         }
         // errorLine = 1 + count('\n' in src[0..commandStart]) — C's exact loop.
-        let line = 1 + src[..cmd.start].iter().filter(|&&b| b == b'\n').count() as u32;
-        self.exc.line = line;
+        self.exc.line = line_of(src, cmd.start);
         let started = self.exc.info.is_some();
         if !started {
             // First frame: errorInfo is seeded from the error message (the result).
@@ -945,6 +1037,47 @@ impl Interp {
         self.exc.info.clone().unwrap_or_else(|| self.result_bytes())
     }
 
+    /// `info frame` (no arg): the depth of the source-location stack.
+    pub(crate) fn cmd_frame_depth(&self) -> usize {
+        self.cmd_frames.len()
+    }
+
+    /// The `info frame N` description for stack position `n` (C's level
+    /// arithmetic: `n > 0` is absolute, 1-based from the root; `n <= 0` is
+    /// relative to the current top, `0` = current). Returns the dict's
+    /// (key, value) pairs in C's key order (`type line [file] cmd [proc]
+    /// level`), or `None` if out of range.
+    pub(crate) fn cmd_frame_info(&self, n: i64) -> Option<Vec<(Vec<u8>, Vec<u8>)>> {
+        let depth = self.cmd_frames.len() as i64;
+        let pos = if n > 0 { n } else { depth + n };
+        if pos < 1 || pos > depth {
+            return None;
+        }
+        let f = &self.cmd_frames[(pos - 1) as usize];
+        let typ: &[u8] = if f.file.is_some() {
+            b"source"
+        } else if f.proc.is_some() {
+            b"proc"
+        } else {
+            b"eval"
+        };
+        let mut pairs = vec![
+            (b"type".to_vec(), typ.to_vec()),
+            (b"line".to_vec(), f.line.to_string().into_bytes()),
+        ];
+        if let Some(file) = &f.file {
+            pairs.push((b"file".to_vec(), file.to_vec()));
+        }
+        pairs.push((b"cmd".to_vec(), f.cmd.clone()));
+        if let Some(p) = &f.proc {
+            pairs.push((b"proc".to_vec(), p.clone()));
+        }
+        // `level` is the distance from the current call level.
+        let level = self.frames.current_level().saturating_sub(f.level);
+        pairs.push((b"level".to_vec(), level.to_string().into_bytes()));
+        Some(pairs)
+    }
+
     /// The current `errorCode` (for `catch`'s `-errorcode`): the stamped value,
     /// or `NONE`.
     pub(crate) fn error_code(&self) -> Vec<u8> {
@@ -981,15 +1114,44 @@ impl Interp {
 
     /// Evaluate a whole script; the result is left in the interp result. Returns
     /// the completion code of the last command (or `Ok` for an empty script).
+    ///
+    /// At the true top level (no `info frame` stack yet) this owns the root
+    /// `CmdFrame`; nested calls (command substitution `[cmd]`) run in the
+    /// enclosing frame and add none — matching C, where `[cmd]` is the same
+    /// `cmdFramePtr` level. A proc body / `eval` / `source` body gets its own
+    /// frame via [`eval_framed`](Self::eval_framed).
     pub fn eval_str(&mut self, src: &[u8]) -> Code {
+        let owned = self.cmd_frames.is_empty().then(CmdFrame::root);
+        self.eval_script(src, owned)
+    }
+
+    /// Evaluate `src` as the body of its own `info frame` level (`frame` is
+    /// pushed for the duration). Used by proc calls, `eval`/`uplevel`, and
+    /// `source`.
+    fn eval_framed(&mut self, src: &[u8], frame: CmdFrame) -> Code {
+        self.eval_script(src, Some(frame))
+    }
+
+    /// The shared command loop. If `owned` is `Some`, it is pushed as this
+    /// script's `CmdFrame` and updated to each command as the loop steps through
+    /// it (so `info frame` sees the live command/line); an unframed call (`None`,
+    /// i.e. command substitution) leaves the enclosing frame untouched.
+    fn eval_script(&mut self, src: &[u8], owned: Option<CmdFrame>) -> Code {
         self.eval_depth += 1;
+        let owns_frame = owned.is_some();
+        if let Some(f) = owned {
+            self.cmd_frames.push(f);
+        }
         let mut last = Code::Ok;
         let commands = parse::parse_script(src);
         for cmd in &commands {
-            last = self.eval_command(src, cmd);
+            last = self.eval_command(src, cmd, owns_frame);
             if last != Code::Ok {
                 break; // error/return/break/continue propagate up
             }
+        }
+        if owns_frame {
+            self.cmd_frames.pop();
         }
         self.eval_depth -= 1;
         // The outermost eval publishes the accumulated trace to the globals so
@@ -1001,10 +1163,44 @@ impl Interp {
         last
     }
 
+    /// A `CmdFrame` for an `eval`/`uplevel`/`source` body, inheriting the current
+    /// frame's proc/level/file context (these bodies run in the enclosing
+    /// CallFrame). The caller overrides `file` (`source`) or `level` (`uplevel`).
+    fn inherited_cmd_frame(&self) -> CmdFrame {
+        let top = self.cmd_frames.last();
+        CmdFrame {
+            file: top.and_then(|f| f.file.clone()),
+            proc: top.and_then(|f| f.proc.clone()),
+            level: top.map_or(0, |f| f.level),
+            cmd: Vec::new(),
+            line: 1,
+        }
+    }
+
+    /// Evaluate an `eval`/`uplevel` body as its own `info frame` level (it
+    /// inherits the enclosing proc/level). The errorInfo `("eval" body line N)`
+    /// frame is appended separately by the caller.
+    pub(crate) fn eval_body(&mut self, script: &[u8]) -> Code {
+        let frame = self.inherited_cmd_frame();
+        self.eval_framed(script, frame)
+    }
+
     /// Evaluate one parsed command, then — if it errored — append its
     /// `while executing` / `invoked from within` frame to the error trace
     /// (`TclLogCommandInfo`), using the command's source slice and line.
-    fn eval_command(&mut self, src: &[u8], cmd: &parse::Command) -> Code {
+    fn eval_command(&mut self, src: &[u8], cmd: &parse::Command, owns_frame: bool) -> Code {
+        // Update the current `info frame` level to this command — the innermost
+        // command executing at this level. A `[cmd]` substitution (and an inline
+        // control body) shares the enclosing frame and adds no level, so it
+        // updates the `cmd` but keeps the **enclosing** command's `line` (the
+        // line the substitution appears on); only the frame-owning script
+        // advances the line as it steps through its own commands.
+        if let Some(top) = self.cmd_frames.last_mut() {
+            if owns_frame {
+                top.line = line_of(src, cmd.start);
+            }
+            top.cmd = src[cmd.start..cmd.end].to_vec();
+        }
         let code = self.eval_words(&cmd.words);
         if code == Code::Error {
             self.log_command_info(src, cmd);
@@ -1112,7 +1308,11 @@ impl Interp {
             def.ns,
             &argv[1..],
             &name,
-            ProcFrame::Proc(&name),
+            CallMeta {
+                err: ProcFrame::Proc(&name),
+                fqn: Some(&def.fqn),
+                source: def.source.clone(),
+            },
         )
     }
 
@@ -1132,7 +1332,7 @@ impl Interp {
         ns: NsId,
         call_args: &[*mut TclObj],
         usage_called: &[u8],
-        frame: ProcFrame,
+        meta: CallMeta,
     ) -> Code {
         let has_args = params.last().is_some_and(|p| p.name == b"args");
         let positional = if has_args {
@@ -1196,7 +1396,17 @@ impl Interp {
             }
         }
 
-        let code = self.eval_str(body);
+        // The proc body runs as its own `info frame` level: `type proc` (or
+        // `source` if defined in a sourced file), the proc FQN, and the new call
+        // level (set after `frames.push`, so `current_level` is the proc's).
+        let proc_frame = CmdFrame {
+            file: meta.source,
+            proc: meta.fqn.map(<[u8]>::to_vec),
+            level: self.frames.current_level(),
+            cmd: Vec::new(),
+            line: 1,
+        };
+        let code = self.eval_framed(body, proc_frame);
         self.frames.pop();
         self.current_ns = saved_ns;
         self.recursion_depth -= 1;
@@ -1211,7 +1421,7 @@ impl Interp {
         // On error, append the `(procedure "name" line N)` / `(lambda term ...)`
         // frame and clear `already_logged` so the proc-call command logs next.
         if settled == Code::Error {
-            self.make_proc_error(frame);
+            self.make_proc_error(meta.err);
         }
         settled
     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -157,6 +157,18 @@ impl CmdFrame {
     }
 }
 
+/// Join argument objects with single spaces (the `eval`/`interp eval` body form).
+fn join_words(args: &[*mut TclObj]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (i, &a) in args.iter().enumerate() {
+        if i > 0 {
+            out.push(b' ');
+        }
+        out.extend_from_slice(&obj_bytes(a));
+    }
+    out
+}
+
 /// The 1-based source line of byte `offset` in `src` — `1 + count('\n' in
 /// src[0..offset])`, C's exact `TclLogCommandInfo` loop (encoding-agnostic).
 fn line_of(src: &[u8], offset: usize) -> u32 {
@@ -224,6 +236,10 @@ pub enum Command {
     /// defining namespace, and maps a body-level `return` to `Ok`. Behind an `Rc`
     /// so the dispatch-time clone of the command handle is O(1), not a body copy.
     Proc(Rc<ProcDef>),
+    /// A child interpreter, addressable as a command (`$child eval …`). The
+    /// `Vec<u8>` is the child's name; dispatch routes the subcommand to the child
+    /// `Interp` stored in [`Interp::children`].
+    ChildInterp(Vec<u8>),
 }
 
 /// One formal parameter of a [`ProcDef`]: a name and an optional default value.
@@ -279,6 +295,11 @@ pub struct Interp {
     pub(crate) traces: crate::cmd_trace::TraceTable,
     /// The error stack-trace accumulator (PC-4).
     exc: ExceptionState,
+    /// Child interpreters (`interp create`), each a full `Interp`, keyed by name.
+    /// The name is also a command in this interp (`Command::ChildInterp`).
+    children: std::collections::BTreeMap<Vec<u8>, Box<Interp>>,
+    /// Counter for auto-generated child names (`interp0`, `interp1`, …).
+    interp_counter: usize,
     /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
     cmd_frames: Vec<CmdFrame>,
     /// `eval_str` nesting depth. The outermost eval (depth returning to 0)
@@ -311,6 +332,8 @@ impl Interp {
             return_level: 1,
             traces: crate::cmd_trace::TraceTable::default(),
             exc: ExceptionState::default(),
+            children: std::collections::BTreeMap::new(),
+            interp_counter: 0,
             cmd_frames: Vec::new(),
             eval_depth: 0,
             result,
@@ -448,7 +471,10 @@ impl Interp {
     /// `auto_path`), then `source $tcl_library/init.tcl`. After this the
     /// pure-Tcl `unknown`/auto-load/`package` machinery is live, so
     /// `package require` works through `pkgIndex.tcl`/`tclIndex`.
-    pub fn init_library(&mut self) -> Code {
+    /// Set the predefined startup globals (`tcl_version`/`tcl_platform`/`env`/
+    /// `argv`/…) — the cheap half of `Tcl_Init`, shared by the main interp's
+    /// `init_library` and each child interpreter (`interp create`).
+    pub(crate) fn set_startup_globals(&mut self) {
         let lib = std::env::var("TCL_LIBRARY").unwrap_or_default();
         let set = |i: &mut Interp, name: &[u8], val: &[u8]| {
             let o = new_string(val);
@@ -488,6 +514,11 @@ impl Interp {
                 drop_fresh(o);
             }
         }
+    }
+
+    pub fn init_library(&mut self) -> Code {
+        self.set_startup_globals();
+        let lib = std::env::var("TCL_LIBRARY").unwrap_or_default();
         // Source init.tcl, which sets up unknown/auto-load/package + appends
         // tcl_library (and its parent) to auto_path.
         let init_path = format!("{lib}/init.tcl");
@@ -1365,7 +1396,89 @@ impl Interp {
             },
             Command::Ensemble(cfg) => self.dispatch_ensemble(&cfg, argv),
             Command::Proc(def) => self.call_proc(&def, argv),
+            Command::ChildInterp(name) => self.dispatch_child(&name, argv),
         }
+    }
+
+    /// Dispatch a child-interpreter command (`$child subcommand ?arg ...?`): the
+    /// child is addressable like the `interp` ensemble restricted to it.
+    fn dispatch_child(&mut self, name: &[u8], argv: &[*mut TclObj]) -> Code {
+        if argv.len() < 2 {
+            return self.error(b"wrong # args: should be \"interp cmd ?arg ...?\"");
+        }
+        match obj_bytes(argv[1]).as_slice() {
+            b"eval" => {
+                let script = join_words(&argv[2..]);
+                self.eval_in_child(name, &script)
+            }
+            b"issafe" => {
+                self.set_result_bytes(b"0");
+                Code::Ok
+            }
+            b"delete" => {
+                self.delete_child(name);
+                self.set_result_bytes(b"");
+                Code::Ok
+            }
+            other => {
+                let mut m = b"interp subcommand \"".to_vec();
+                m.extend_from_slice(other);
+                m.extend_from_slice(b"\" is not supported in this runtime");
+                self.error(&m)
+            }
+        }
+    }
+
+    /// Create a child interpreter named `name` (auto-generated when empty),
+    /// registering it as a command in this interp. Returns the name.
+    pub(crate) fn create_child(&mut self, name: Option<Vec<u8>>) -> Vec<u8> {
+        let name = name.unwrap_or_else(|| {
+            let n = format!("interp{}", self.interp_counter);
+            self.interp_counter += 1;
+            n.into_bytes()
+        });
+        let mut child = Interp::new();
+        // A (non-safe) child gets the predefined globals (`tcl_platform`, …) like
+        // a real interpreter. The full `init.tcl` (package/auto-load) is deferred.
+        child.set_startup_globals();
+        self.children.insert(name.clone(), child);
+        self.namespaces
+            .register(&name, Command::ChildInterp(name.clone()));
+        name
+    }
+
+    /// Whether a child interpreter `name` exists.
+    pub(crate) fn child_exists(&self, name: &[u8]) -> bool {
+        self.children.contains_key(name)
+    }
+
+    /// The names of this interp's direct child interpreters (sorted).
+    pub(crate) fn child_names(&self) -> Vec<Vec<u8>> {
+        self.children.keys().cloned().collect()
+    }
+
+    /// Delete a child interpreter (and its command). Returns whether it existed.
+    pub(crate) fn delete_child(&mut self, name: &[u8]) -> bool {
+        let existed = self.children.remove(name).is_some();
+        if existed {
+            self.namespaces.delete(GLOBAL, name);
+        }
+        existed
+    }
+
+    /// Evaluate `script` in child interpreter `name`, copying its result/code
+    /// back. `None`-returning if the child doesn't exist (caller raises).
+    pub(crate) fn eval_in_child(&mut self, name: &[u8], script: &[u8]) -> Code {
+        let Some(child) = self.children.get_mut(name) else {
+            let mut m = b"could not find interpreter \"".to_vec();
+            m.extend_from_slice(name);
+            m.push(b'"');
+            return self.error(&m);
+        };
+        let code = child.eval_str(script);
+        let result = child.result_bytes();
+        self.set_result_bytes(&result);
+        code
     }
 
     /// Call a user proc (`TclObjInterpProc`): a thin wrapper over [`run_proc`]

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -82,6 +82,9 @@ pub(crate) struct CallMeta<'a> {
     /// The body's `info frame` line base (file-absolute for a source-defined
     /// proc, 0 otherwise).
     pub body_line_base: u32,
+    /// Variable names to pre-link into the call frame from its namespace (a
+    /// TclOO method's declared instance variables); empty for procs/lambdas.
+    pub link_vars: &'a [Vec<u8>],
 }
 
 /// One entry of the source-location stack (`cmdFramePtr`; PC-5) — the runtime
@@ -240,9 +243,14 @@ pub enum Command {
     /// `Vec<u8>` is the child's name; dispatch routes the subcommand to the child
     /// `Interp` stored in [`Interp::children`].
     ChildInterp(Vec<u8>),
+    /// A TclOO object or class, addressable as a command (`$obj method …`,
+    /// `Class new`). The `Vec<u8>` is the FQN; dispatch routes to
+    /// [`crate::cmd_oo`] via the [`OoState`](crate::cmd_oo::OoState) registry.
+    OoObject(Vec<u8>),
 }
 
 /// One formal parameter of a [`ProcDef`]: a name and an optional default value.
+#[derive(Clone)]
 pub struct Param {
     pub name: Vec<u8>,
     pub default: Option<Vec<u8>>,
@@ -300,6 +308,8 @@ pub struct Interp {
     children: std::collections::BTreeMap<Vec<u8>, Box<Interp>>,
     /// Counter for auto-generated child names (`interp0`, `interp1`, …).
     interp_counter: usize,
+    /// TclOO object system state (classes, objects, the method-call stack).
+    pub(crate) oo: crate::cmd_oo::OoState,
     /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
     cmd_frames: Vec<CmdFrame>,
     /// `eval_str` nesting depth. The outermost eval (depth returning to 0)
@@ -334,6 +344,7 @@ impl Interp {
             exc: ExceptionState::default(),
             children: std::collections::BTreeMap::new(),
             interp_counter: 0,
+            oo: crate::cmd_oo::OoState::default(),
             cmd_frames: Vec::new(),
             eval_depth: 0,
             result,
@@ -978,7 +989,7 @@ impl Interp {
     /// The `-errorcode` taxonomy is conservative for now: `wrong # args` ⇒ `TCL
     /// WRONGARGS`, else `NONE` (the full taxonomy is a follow-up). `error`/`throw`
     /// set a richer code on their own paths.
-    fn error(&mut self, msg: &[u8]) -> Code {
+    pub(crate) fn error(&mut self, msg: &[u8]) -> Code {
         self.set_result_bytes(msg);
         let code: &[u8] = if msg.starts_with(b"wrong # args:") {
             b"TCL WRONGARGS"
@@ -1358,7 +1369,7 @@ impl Interp {
     /// Look up `argv[0]` and invoke it; on a miss, fall to the `unknown` handler
     /// (auto-load / `package` / friendly errors — the pure-Tcl `unknown` proc),
     /// matching C's `TclEvalObjvInternal`.
-    fn dispatch(&mut self, argv: &[*mut TclObj]) -> Code {
+    pub(crate) fn dispatch(&mut self, argv: &[*mut TclObj]) -> Code {
         let name = obj_bytes(argv[0]);
         if let Some(cmd) = self.namespaces.resolve(self.current_ns, &name) {
             return self.invoke(cmd, argv);
@@ -1397,7 +1408,30 @@ impl Interp {
             Command::Ensemble(cfg) => self.dispatch_ensemble(&cfg, argv),
             Command::Proc(def) => self.call_proc(&def, argv),
             Command::ChildInterp(name) => self.dispatch_child(&name, argv),
+            Command::OoObject(fqn) => self.oo_dispatch(&fqn, argv),
         }
+    }
+
+    /// Register `cmd` under the (possibly qualified) name `name` — for the OO
+    /// object/class commands.
+    pub(crate) fn ns_register(&mut self, name: &[u8], cmd: Command) {
+        self.namespaces.register(name, cmd);
+    }
+
+    /// The fully-qualified name a (relative or absolute) command/object name
+    /// resolves to, relative to the current namespace — used to name OO
+    /// objects/classes consistently.
+    pub(crate) fn fqn_for(&self, name: &[u8]) -> Vec<u8> {
+        if name.starts_with(b"::") {
+            return name.to_vec();
+        }
+        let qn = self.namespaces.qualified_name(self.current_ns);
+        let mut fqn = qn.clone();
+        if qn != b"::" {
+            fqn.extend_from_slice(b"::");
+        }
+        fqn.extend_from_slice(name);
+        fqn
     }
 
     /// Dispatch a child-interpreter command (`$child subcommand ?arg ...?`): the
@@ -1498,6 +1532,7 @@ impl Interp {
                 fqn: Some(&def.fqn),
                 source: def.source.clone(),
                 body_line_base: def.body_line_base,
+                link_vars: &[],
             },
         )
     }
@@ -1549,6 +1584,13 @@ impl Interp {
         self.frames.set_words(words);
         let saved_ns = self.current_ns;
         self.current_ns = ns;
+
+        // Pre-link a TclOO method's declared instance variables: each name in
+        // the frame becomes a link to the object's namespace variable (`ns`), so
+        // the method sees instance state without an explicit `variable`.
+        for v in meta.link_vars {
+            self.make_variable(ns, v);
+        }
 
         // Bind positionals left-to-right: the supplied arg, else the default.
         // Binding is purely positional — a defaulted parameter does *not* yield
@@ -1769,7 +1811,7 @@ impl Interp {
     }
 
     /// The `invalid command name "X"` error (the resolver miss; `unknown` later).
-    fn invalid_command(&mut self, name: &[u8]) -> Code {
+    pub(crate) fn invalid_command(&mut self, name: &[u8]) -> Code {
         let mut msg = b"invalid command name \"".to_vec();
         msg.extend_from_slice(name);
         msg.push(b'"');

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -247,6 +247,20 @@ pub enum Command {
     /// `Class new`). The `Vec<u8>` is the FQN; dispatch routes to
     /// [`crate::cmd_oo`] via the [`OoState`](crate::cmd_oo::OoState) registry.
     OoObject(Vec<u8>),
+    /// A cross-interp alias installed in a *child* interp that delegates to a
+    /// command in the *parent* (`interp alias child name {} parentCmd …`). When
+    /// invoked, it runs `target` (+ `prefix` + the call args) in the parent.
+    ParentAlias {
+        target: Vec<u8>,
+        prefix: Vec<Vec<u8>>,
+    },
+}
+
+thread_local! {
+    /// Depth of active cross-interp (`ParentAlias`) calls. Bounds re-entrancy so
+    /// a second parent deref can't alias a `&mut Interp` that is already live up
+    /// the stack — sound by erroring rather than risking UB.
+    static CROSS_INTERP_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
 /// One formal parameter of a [`ProcDef`]: a name and an optional default value.
@@ -312,6 +326,14 @@ pub struct Interp {
     /// invocable via `interp invokehidden`. A safe interp hides the dangerous
     /// commands here.
     hidden: std::collections::BTreeMap<Vec<u8>, Command>,
+    /// While this interp runs as a child (`$parent eval`/`$child eval`), a raw
+    /// pointer to its parent interp — for cross-interp aliases that delegate to
+    /// a parent command. Valid only during a child eval: the child is *removed*
+    /// from the parent's table for the duration ([`eval_in_child`]), so the
+    /// parent is a dormant, disjoint value while the child holds this pointer.
+    ///
+    /// [`eval_in_child`]: Interp::eval_in_child
+    parent: Option<*mut Interp>,
     /// TclOO object system state (classes, objects, the method-call stack).
     pub(crate) oo: crate::cmd_oo::OoState,
     /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
@@ -349,6 +371,7 @@ impl Interp {
             children: std::collections::BTreeMap::new(),
             interp_counter: 0,
             hidden: std::collections::BTreeMap::new(),
+            parent: None,
             oo: crate::cmd_oo::OoState::default(),
             cmd_frames: Vec::new(),
             eval_depth: 0,
@@ -382,6 +405,22 @@ impl Interp {
     pub(crate) fn install_alias(&mut self, name: &[u8], target: Vec<u8>, prefix: Vec<Vec<u8>>) {
         self.namespaces
             .register(name, Command::Alias { target, prefix });
+    }
+
+    /// Install a cross-interp alias in child `child`: `name` (in the child)
+    /// delegates to `target ?prefix...?` run in this (the parent) interp.
+    /// Returns whether the child exists.
+    pub(crate) fn install_parent_alias(
+        &mut self,
+        child: &[u8],
+        name: &[u8],
+        target: Vec<u8>,
+        prefix: Vec<Vec<u8>>,
+    ) -> bool {
+        self.with_child(child, |c| {
+            c.ns_register(name, Command::ParentAlias { target, prefix });
+        })
+        .is_some()
     }
 
     /// The `(target, prefix)` of the alias bound to `name` (the query form), or
@@ -1414,6 +1453,9 @@ impl Interp {
             Command::Proc(def) => self.call_proc(&def, argv),
             Command::ChildInterp(name) => self.dispatch_child(&name, argv),
             Command::OoObject(fqn) => self.oo_dispatch(&fqn, argv),
+            Command::ParentAlias { target, prefix } => {
+                self.dispatch_parent_alias(&target, &prefix, argv)
+            }
         }
     }
 
@@ -1499,6 +1541,17 @@ impl Interp {
                 let elems: Vec<*mut TclObj> =
                     names.iter().map(|n| obj::new_string_bytes(n)).collect();
                 self.set_result(crate::list::new_list_obj(&elems));
+                Code::Ok
+            }
+            // `$child alias srcCmd targetCmd ?arg ...?` — a cross-interp alias in
+            // the child delegating to `targetCmd` in this (parent) interp. (The
+            // target is implicitly the parent, so there is no target-path arg.)
+            b"alias" if argv.len() >= 4 => {
+                let alias = obj_bytes(argv[2]);
+                let target = obj_bytes(argv[3]);
+                let prefix: Vec<Vec<u8>> = argv[4..].iter().map(|&a| obj_bytes(a)).collect();
+                self.install_parent_alias(name, &alias, target, prefix);
+                self.set_result(obj::new_string_bytes(&alias));
                 Code::Ok
             }
             other => {
@@ -1628,15 +1681,66 @@ impl Interp {
     /// Evaluate `script` in child interpreter `name`, copying its result/code
     /// back. `None`-returning if the child doesn't exist (caller raises).
     pub(crate) fn eval_in_child(&mut self, name: &[u8], script: &[u8]) -> Code {
-        let Some(child) = self.children.get_mut(name) else {
+        // Remove the child for the duration so the parent (`self`) is a dormant,
+        // disjoint value the child can reach back into (via its `parent` pointer)
+        // for cross-interp aliases — without an overlapping borrow. Re-inserted
+        // after. (A parent command can't re-enter *this* child meanwhile: it's
+        // not in the table.)
+        let Some(mut child) = self.children.remove(name) else {
             let mut m = b"could not find interpreter \"".to_vec();
             m.extend_from_slice(name);
             m.push(b'"');
             return self.error(&m);
         };
+        child.parent = Some(self as *mut Interp);
         let code = child.eval_str(script);
         let result = child.result_bytes();
+        child.parent = None;
+        self.children.insert(name.to_vec(), child);
         self.set_result_bytes(&result);
+        code
+    }
+
+    /// Run a cross-interp alias (`ParentAlias`): invoke `target` (+ `prefix` +
+    /// the call args) in this interp's *parent*, copying the parent's result
+    /// back. The parent is dormant (the child was removed from its table for the
+    /// child eval), so the raw deref forms the only live `&mut` to it — except
+    /// under nested cross-interp calls, which the depth guard rejects.
+    fn dispatch_parent_alias(
+        &mut self,
+        target: &[u8],
+        prefix: &[Vec<u8>],
+        argv: &[*mut TclObj],
+    ) -> Code {
+        let Some(parent_ptr) = self.parent else {
+            return self.error(b"cannot invoke a parent alias from the root interpreter");
+        };
+        if CROSS_INTERP_DEPTH.with(|d| d.get()) > 0 {
+            return self.error(b"recursive cross-interpreter invocation is not supported");
+        }
+        // Build [target, *prefix, *argv[1..]] — each element owned (+1).
+        let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len());
+        let push_owned = |v: &mut Vec<*mut TclObj>, o: *mut TclObj| {
+            unsafe { obj::incr_ref_count(o) };
+            v.push(o);
+        };
+        push_owned(&mut new_argv, new_string(target));
+        for p in prefix {
+            push_owned(&mut new_argv, new_string(p));
+        }
+        for &a in &argv[1..] {
+            push_owned(&mut new_argv, a);
+        }
+        CROSS_INTERP_DEPTH.with(|d| d.set(1));
+        // SAFETY: `parent_ptr` points to the parent interp, which is dormant
+        // while this child eval runs (the child was removed from its table); the
+        // depth guard above ensures no other live `&mut` to it exists.
+        let parent = unsafe { &mut *parent_ptr };
+        let code = parent.dispatch(&new_argv);
+        let res = parent.result_bytes();
+        CROSS_INTERP_DEPTH.with(|d| d.set(0));
+        release_all(&new_argv);
+        self.set_result_bytes(&res);
         code
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1437,14 +1437,18 @@ impl Interp {
         let saved_ns = self.current_ns;
         self.current_ns = ns;
 
-        // Bind positionals: the supplied arg, else the default.
+        // Bind positionals left-to-right: the supplied arg, else the default.
+        // Binding is purely positional — a defaulted parameter does *not* yield
+        // its slot to a later one, so a required parameter reached with no
+        // supplied arg (a non-trailing default, e.g. `proc p {a {b 2} c}` called
+        // with 2 args) is a `wrong # args` error, matching tclsh 9.0.
         for (i, p) in positional.iter().enumerate() {
             let stored = if i < call_args.len() {
                 self.var_set(&p.name, call_args[i])
-            } else {
-                // SAFETY-balance: a fresh rc-0 default; `var_set` retains it, so
-                // on the (here-unreachable) error path it must be dropped.
-                let o = new_string(p.default.as_ref().expect("arity guaranteed default"));
+            } else if let Some(def) = &p.default {
+                // A fresh rc-0 default; `var_set` retains it, so on the error
+                // path it must be dropped.
+                let o = new_string(def);
                 match self.var_set(&p.name, o) {
                     Ok(()) => Ok(()),
                     Err(e) => {
@@ -1452,6 +1456,11 @@ impl Interp {
                         Err(e)
                     }
                 }
+            } else {
+                self.frames.pop();
+                self.current_ns = saved_ns;
+                self.recursion_depth -= 1;
+                return self.error(&proc_usage(usage_called, params));
             };
             if stored.is_err() {
                 self.frames.pop();
@@ -1460,9 +1469,11 @@ impl Interp {
                 return self.error(b"proc parameter binding failed");
             }
         }
-        // The `args` catch-all: a list of the remaining args.
+        // The `args` catch-all: a list of the remaining args. Clamp the split
+        // point — when trailing positionals took their defaults, fewer args were
+        // supplied than there are positionals, so `args` is simply empty.
         if has_args {
-            let rest = &call_args[positional.len()..];
+            let rest = &call_args[positional.len().min(call_args.len())..];
             let list = crate::list::new_list_obj(rest); // rc 0; var_set retains
             if self.var_set(b"args", list).is_err() {
                 drop_fresh(list);

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -257,11 +257,24 @@ pub enum Command {
 }
 
 thread_local! {
-    /// Depth of active cross-interp (`ParentAlias`) calls. Bounds re-entrancy so
-    /// a second parent deref can't alias a `&mut Interp` that is already live up
-    /// the stack — sound by erroring rather than risking UB.
+    /// Depth of active cross-interp (`ParentAlias`) calls. The Safe Base requires
+    /// genuine re-entrant recursion across the parent/child boundary (a child's
+    /// aliased `source` calls back into the parent, which calls `interp
+    /// invokehidden $child …` back into the *same* child while its outer eval is
+    /// still on the stack — exactly as C's nested `Tcl_Eval` does). We therefore
+    /// **bound** rather than forbid the nesting: the count caps native-stack
+    /// growth (each cross-interp hop adds real frames), and the raw `*mut Interp`
+    /// derefs that span the boundary model C's shared-`Tcl_Interp*` access — sound
+    /// only because every interp is heap-stable behind a `Box` (so a `*mut Interp`
+    /// survives `children` map reorganisation) and we never run two *different*
+    /// commands on one interp concurrently, only nested-in-time recursion.
     static CROSS_INTERP_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
+
+/// Maximum nested cross-interp call depth (the native-stack bound for the
+/// re-entrant parent⇄child recursion the Safe Base needs). Generous enough for
+/// safe-base setup (a handful of hops) while still catching runaway recursion.
+const MAX_CROSS_INTERP_DEPTH: u32 = 80;
 
 /// One formal parameter of a [`ProcDef`]: a name and an optional default value.
 #[derive(Clone)]
@@ -328,12 +341,30 @@ pub struct Interp {
     hidden: std::collections::BTreeMap<Vec<u8>, Command>,
     /// While this interp runs as a child (`$parent eval`/`$child eval`), a raw
     /// pointer to its parent interp — for cross-interp aliases that delegate to
-    /// a parent command. Valid only during a child eval: the child is *removed*
-    /// from the parent's table for the duration ([`eval_in_child`]), so the
-    /// parent is a dormant, disjoint value while the child holds this pointer.
+    /// a parent command. Set for the duration of a child eval ([`eval_in_child`]
+    /// / [`with_child`]) and restored after; the deref models C's shared
+    /// `Tcl_Interp*` access (see the `CROSS_INTERP_DEPTH` note).
     ///
     /// [`eval_in_child`]: Interp::eval_in_child
+    /// [`with_child`]: Interp::with_child
     parent: Option<*mut Interp>,
+    /// Whether this interp is safe (`interp create -safe` / `interp issafe`).
+    is_safe: bool,
+    /// How many of *this* interp's evals are currently on the stack (as a child:
+    /// [`eval_in_child`]/[`with_child`] bump it). A child may be deleted *during*
+    /// its own eval — e.g. its aliased `exit` calls `interp delete` on itself —
+    /// so a non-zero count means the boxed interp must not be freed yet, or the
+    /// raw-pointer eval still unwinding above would dangle.
+    ///
+    /// [`eval_in_child`]: Interp::eval_in_child
+    /// [`with_child`]: Interp::with_child
+    eval_active: usize,
+    /// Set when a delete was requested while [`eval_active`] was non-zero; the
+    /// actual teardown is deferred until the last eval unwinds (C's deferred
+    /// `Tcl_DeleteInterp`).
+    ///
+    /// [`eval_active`]: Interp::eval_active
+    pending_delete: bool,
     /// TclOO object system state (classes, objects, the method-call stack).
     pub(crate) oo: crate::cmd_oo::OoState,
     /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
@@ -372,6 +403,9 @@ impl Interp {
             interp_counter: 0,
             hidden: std::collections::BTreeMap::new(),
             parent: None,
+            is_safe: false,
+            eval_active: 0,
+            pending_delete: false,
             oo: crate::cmd_oo::OoState::default(),
             cmd_frames: Vec::new(),
             eval_depth: 0,
@@ -1504,7 +1538,8 @@ impl Interp {
                 self.eval_in_child(name, &script)
             }
             b"issafe" => {
-                self.set_result_bytes(b"0");
+                let safe = self.with_child(name, |c| c.is_safe()).unwrap_or(false);
+                self.set_result_bytes(if safe { b"1" } else { b"0" });
                 Code::Ok
             }
             b"delete" => {
@@ -1548,6 +1583,15 @@ impl Interp {
             b"hidden" => {
                 let names = self
                     .with_child(name, |c| c.hidden_names())
+                    .unwrap_or_default();
+                let elems: Vec<*mut TclObj> =
+                    names.iter().map(|n| obj::new_string_bytes(n)).collect();
+                self.set_result(crate::list::new_list_obj(&elems));
+                Code::Ok
+            }
+            b"aliases" => {
+                let names = self
+                    .with_child(name, |c| c.alias_names())
                     .unwrap_or_default();
                 let elems: Vec<*mut TclObj> =
                     names.iter().map(|n| obj::new_string_bytes(n)).collect();
@@ -1599,12 +1643,46 @@ impl Interp {
 
     /// Run `f` on the child interpreter `name` (or `None` if it doesn't exist) —
     /// the mutable-access path for `interp <sub> childPath …`.
+    ///
+    /// `f` runs against a raw `*mut Interp` into the (heap-stable, boxed) child
+    /// rather than a borrow held on `self.children`, so a command inside `f` may
+    /// re-enter `self` (e.g. a child's `invokehidden source` that triggers a
+    /// parent alias) without an outstanding `&mut self.children` borrow. The
+    /// child's `parent` pointer is set for the duration so that re-entrancy can
+    /// reach back up. See the `CROSS_INTERP_DEPTH` note for the aliasing model.
+    ///
+    /// The child is marked active for the call, so a delete requested *during*
+    /// `f` (the self-deleting `exit` alias) is deferred until it unwinds — the
+    /// boxed interp is then freed here, never out from under the raw pointer.
     pub(crate) fn with_child<R>(
         &mut self,
         name: &[u8],
         f: impl FnOnce(&mut Interp) -> R,
     ) -> Option<R> {
-        self.children.get_mut(name).map(|c| f(c))
+        let parent_ptr = self as *mut Interp;
+        let child_ptr: *mut Interp = self.children.get_mut(name)?.as_mut();
+        // SAFETY: `child_ptr` addresses the boxed child interp, whose address is
+        // stable across `children` mutation; the borrow on `self.children` ended
+        // when we took the raw pointer, so `f` may re-enter `self`.
+        let teardown;
+        let r;
+        {
+            let child = unsafe { &mut *child_ptr };
+            let saved = child.parent;
+            child.parent = Some(parent_ptr);
+            child.eval_active += 1;
+            r = f(child);
+            child.eval_active -= 1;
+            child.parent = saved;
+            teardown = child.pending_delete && child.eval_active == 0;
+        }
+        // `child` borrow has ended; safe to drop the box (and its command) now
+        // that no eval of it remains on the stack.
+        if teardown {
+            self.children.remove(name);
+            self.namespaces.delete(GLOBAL, name);
+        }
+        Some(r)
     }
 
     /// `interp hide name`: move command `name` out of the command table into the
@@ -1673,6 +1751,12 @@ impl Interp {
         for &c in UNSAFE {
             self.hide_command(c);
         }
+        self.is_safe = true;
+    }
+
+    /// Whether this interp is safe (`interp issafe`).
+    pub(crate) fn is_safe(&self) -> bool {
+        self.is_safe
     }
 
     /// The names of this interp's direct child interpreters (sorted).
@@ -1681,42 +1765,64 @@ impl Interp {
     }
 
     /// Delete a child interpreter (and its command). Returns whether it existed.
+    ///
+    /// If the child is currently executing (a self-deleting `exit`/`interp
+    /// delete` from inside its own eval), the actual teardown is **deferred**:
+    /// the command binding is removed now so the name stops dispatching, but the
+    /// boxed interp is freed only when its last eval unwinds
+    /// ([`with_child`]/[`eval_in_child`]) — never out from under the raw-pointer
+    /// eval still on the stack. Mirrors C's deferred `Tcl_DeleteInterp`.
+    ///
+    /// [`with_child`]: Interp::with_child
+    /// [`eval_in_child`]: Interp::eval_in_child
     pub(crate) fn delete_child(&mut self, name: &[u8]) -> bool {
-        let existed = self.children.remove(name).is_some();
-        if existed {
-            self.namespaces.delete(GLOBAL, name);
+        match self.children.get_mut(name) {
+            Some(child) if child.eval_active > 0 => {
+                child.pending_delete = true;
+                self.namespaces.delete(GLOBAL, name);
+                true
+            }
+            Some(_) => {
+                self.children.remove(name);
+                self.namespaces.delete(GLOBAL, name);
+                true
+            }
+            None => false,
         }
-        existed
     }
 
     /// Evaluate `script` in child interpreter `name`, copying its result/code
     /// back. `None`-returning if the child doesn't exist (caller raises).
+    ///
+    /// The child stays in `self.children` and is evaluated through a raw
+    /// `*mut Interp` (its boxed address is heap-stable), so a parent command
+    /// invoked *during* this eval — via a child→parent alias — can re-enter the
+    /// same child (`interp invokehidden $child …`), which the Safe Base relies on.
+    /// The `parent` back-pointer is set for the eval and restored after.
     pub(crate) fn eval_in_child(&mut self, name: &[u8], script: &[u8]) -> Code {
-        // Remove the child for the duration so the parent (`self`) is a dormant,
-        // disjoint value the child can reach back into (via its `parent` pointer)
-        // for cross-interp aliases — without an overlapping borrow. Re-inserted
-        // after. (A parent command can't re-enter *this* child meanwhile: it's
-        // not in the table.)
-        let Some(mut child) = self.children.remove(name) else {
-            let mut m = b"could not find interpreter \"".to_vec();
-            m.extend_from_slice(name);
-            m.push(b'"');
-            return self.error(&m);
-        };
-        child.parent = Some(self as *mut Interp);
-        let code = child.eval_str(script);
-        let result = child.result_bytes();
-        child.parent = None;
-        self.children.insert(name.to_vec(), child);
-        self.set_result_bytes(&result);
-        code
+        // `with_child` runs the eval against the heap-stable boxed child through a
+        // raw pointer, marks it active (so a self-delete during the eval is
+        // deferred), and frees it here if a delete landed mid-eval.
+        match self.with_child(name, |c| (c.eval_str(script), c.result_bytes())) {
+            Some((code, result)) => {
+                self.set_result_bytes(&result);
+                code
+            }
+            None => {
+                let mut m = b"could not find interpreter \"".to_vec();
+                m.extend_from_slice(name);
+                m.push(b'"');
+                self.error(&m)
+            }
+        }
     }
 
     /// Run a cross-interp alias (`ParentAlias`): invoke `target` (+ `prefix` +
     /// the call args) in this interp's *parent*, copying the parent's result
-    /// back. The parent is dormant (the child was removed from its table for the
-    /// child eval), so the raw deref forms the only live `&mut` to it — except
-    /// under nested cross-interp calls, which the depth guard rejects.
+    /// back. The raw `parent_ptr` deref models C's shared-`Tcl_Interp*` access;
+    /// re-entrancy (the parent calling `interp invokehidden $child …` back into
+    /// this child) is supported and only **bounded** by `MAX_CROSS_INTERP_DEPTH`
+    /// to cap native-stack growth.
     fn dispatch_parent_alias(
         &mut self,
         target: &[u8],
@@ -1726,8 +1832,8 @@ impl Interp {
         let Some(parent_ptr) = self.parent else {
             return self.error(b"cannot invoke a parent alias from the root interpreter");
         };
-        if CROSS_INTERP_DEPTH.with(|d| d.get()) > 0 {
-            return self.error(b"recursive cross-interpreter invocation is not supported");
+        if CROSS_INTERP_DEPTH.with(|d| d.get()) >= MAX_CROSS_INTERP_DEPTH {
+            return self.error(b"too many nested cross-interpreter calls");
         }
         // Build [target, *prefix, *argv[1..]] — each element owned (+1).
         let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len());
@@ -1742,14 +1848,15 @@ impl Interp {
         for &a in &argv[1..] {
             push_owned(&mut new_argv, a);
         }
-        CROSS_INTERP_DEPTH.with(|d| d.set(1));
-        // SAFETY: `parent_ptr` points to the parent interp, which is dormant
-        // while this child eval runs (the child was removed from its table); the
-        // depth guard above ensures no other live `&mut` to it exists.
+        CROSS_INTERP_DEPTH.with(|d| d.set(d.get() + 1));
+        // SAFETY: `parent_ptr` addresses the (heap-stable, boxed) parent interp;
+        // the deref models C's shared-interp recursion. The depth counter bounds
+        // the native recursion, and refcounts on `new_argv` keep the args alive
+        // across the nested dispatch.
         let parent = unsafe { &mut *parent_ptr };
         let code = parent.dispatch(&new_argv);
         let res = parent.result_bytes();
-        CROSS_INTERP_DEPTH.with(|d| d.set(0));
+        CROSS_INTERP_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
         release_all(&new_argv);
         self.set_result_bytes(&res);
         code

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -19,7 +19,8 @@
 //! + retain-into-result is the whole discipline.
 
 use core::ffi::c_char;
-use std::rc::Rc;
+use std::cell::{Cell, RefCell};
+use std::rc::{Rc, Weak};
 
 use crate::builtins;
 use crate::frame::{FrameStack, Link, VarError};
@@ -261,13 +262,12 @@ thread_local! {
     /// genuine re-entrant recursion across the parent/child boundary (a child's
     /// aliased `source` calls back into the parent, which calls `interp
     /// invokehidden $child …` back into the *same* child while its outer eval is
-    /// still on the stack — exactly as C's nested `Tcl_Eval` does). We therefore
-    /// **bound** rather than forbid the nesting: the count caps native-stack
-    /// growth (each cross-interp hop adds real frames), and the raw `*mut Interp`
-    /// derefs that span the boundary model C's shared-`Tcl_Interp*` access — sound
-    /// only because every interp is heap-stable behind a `Box` (so a `*mut Interp`
-    /// survives `children` map reorganisation) and we never run two *different*
-    /// commands on one interp concurrently, only nested-in-time recursion.
+    /// still on the stack — exactly as C's nested `Tcl_Eval` does). The recursion
+    /// is sound by construction: each interp is an `Rc<InterpState>` reached
+    /// through a cloned handle, and its state is per-field interior-mutable, so a
+    /// re-entry shares the state via `Rc` + `RefCell` rather than aliasing a
+    /// `&mut`. This counter only **bounds** the nesting to cap native-stack growth
+    /// (each cross-interp hop adds real frames).
     static CROSS_INTERP_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
@@ -301,80 +301,105 @@ pub struct ProcDef {
     pub body_line_base: u32,
 }
 
-/// `Tcl_Interp`. Owns the frame stack, the command table, and the current
-/// result object (a `+1` it holds; never null after `new`).
-#[repr(C)]
-pub struct Interp {
-    pub(crate) frames: FrameStack,
+/// A `Tcl_Interp` handle. Cheap to clone (an `Rc` bump); all clones share one
+/// [`InterpState`].
+///
+/// **Re-entrant cross-interp recursion** — the Safe Base's child→parent→child
+/// `source`/`invokehidden` cycle, i.e. C's nested `Tcl_Eval` — works by *cloning
+/// the handle* of the interp to re-enter and calling through that clone. The
+/// shared state is reached via the `Rc` (a shared `&InterpState`) plus per-field
+/// interior mutability, so there is never an aliased `&mut`, and a borrow
+/// discipline slip is a clean panic rather than UB. Single-threaded throughout:
+/// `Rc` + `RefCell`/`Cell`, no locks.
+#[derive(Clone)]
+pub struct Interp(Rc<InterpState>);
+
+impl core::ops::Deref for Interp {
+    type Target = InterpState;
+    fn deref(&self) -> &InterpState {
+        &self.0
+    }
+}
+
+/// The shared, interior-mutable state behind an [`Interp`] handle. Owns the frame
+/// stack, the command table, and the current result object (a `+1` it holds;
+/// never null after `new`).
+///
+/// Each field is borrowed only for the span of a single operation — **never
+/// across a sub-eval** — so re-entrancy (proc recursion, cross-interp calls)
+/// re-borrows freshly instead of aliasing. The command resolver returns *cloned*
+/// `Command` handles precisely so dispatch holds no table borrow.
+pub struct InterpState {
+    pub(crate) frames: RefCell<FrameStack>,
     /// The command-table-as-core-service: the namespace tree + the one
     /// `resolve(currentNs, name)` resolver (T1.5).
-    namespaces: Namespaces,
+    namespaces: RefCell<Namespaces>,
     /// The current namespace for command resolution (the eval context; a proc
     /// runs in its *defining* namespace — wired with procs). Global at top level.
-    current_ns: NsId,
+    current_ns: Cell<NsId>,
     /// Active proc-call nesting depth — C Tcl's `interp recursionlimit`. Bounds
     /// recursion so an infinite proc loop raises a catchable error instead of
     /// overflowing the (wasm) stack (the tracked PR #557 follow-up).
-    recursion_depth: usize,
+    recursion_depth: Cell<usize>,
     /// The package database (`package provide`/`require`/`ifneeded`/`unknown`).
-    pub(crate) packages: crate::cmd_package::PackageState,
+    pub(crate) packages: RefCell<crate::cmd_package::PackageState>,
     /// The `source` script stack (`info script` — the file being sourced).
-    script_stack: Vec<Vec<u8>>,
+    script_stack: RefCell<Vec<Vec<u8>>>,
     /// Open channels (`open`/`read`/`gets`/`puts`/`close`).
-    pub(crate) channels: crate::cmd_chan::ChannelTable,
+    pub(crate) channels: RefCell<crate::cmd_chan::ChannelTable>,
     /// Pending `return -code`/`-level` state (`TclUpdateReturnInfo`): the code to
     /// complete with once `-level` boundaries are unwound.
-    return_code: Code,
-    return_level: usize,
+    return_code: Cell<Code>,
+    return_level: Cell<usize>,
     /// Variable-trace registry (`trace add|remove|info variable`).
-    pub(crate) traces: crate::cmd_trace::TraceTable,
+    pub(crate) traces: RefCell<crate::cmd_trace::TraceTable>,
     /// The error stack-trace accumulator (PC-4).
-    exc: ExceptionState,
-    /// Child interpreters (`interp create`), each a full `Interp`, keyed by name.
-    /// The name is also a command in this interp (`Command::ChildInterp`).
-    children: std::collections::BTreeMap<Vec<u8>, Box<Interp>>,
+    exc: RefCell<ExceptionState>,
+    /// Child interpreters (`interp create`), each a shared [`Interp`] handle keyed
+    /// by name. The name is also a command in this interp
+    /// (`Command::ChildInterp`).
+    children: RefCell<std::collections::BTreeMap<Vec<u8>, Interp>>,
     /// Counter for auto-generated child names (`interp0`, `interp1`, …).
-    interp_counter: usize,
+    interp_counter: Cell<usize>,
     /// Hidden commands (`interp hide`): removed from the command table but
     /// invocable via `interp invokehidden`. A safe interp hides the dangerous
     /// commands here.
-    hidden: std::collections::BTreeMap<Vec<u8>, Command>,
-    /// While this interp runs as a child (`$parent eval`/`$child eval`), a raw
-    /// pointer to its parent interp — for cross-interp aliases that delegate to
-    /// a parent command. Set for the duration of a child eval ([`eval_in_child`]
-    /// / [`with_child`]) and restored after; the deref models C's shared
-    /// `Tcl_Interp*` access (see the `CROSS_INTERP_DEPTH` note).
+    hidden: RefCell<std::collections::BTreeMap<Vec<u8>, Command>>,
+    /// While this interp runs as a child (`$parent eval`/`$child eval`), a `Weak`
+    /// handle to its parent — for cross-interp aliases that delegate to a parent
+    /// command. `Weak` (not `Rc`) so the parent→child ownership has no cycle;
+    /// upgraded for the call's duration. Set on entry to a child eval
+    /// ([`eval_in_child`]/[`with_child`]) and restored after.
     ///
     /// [`eval_in_child`]: Interp::eval_in_child
     /// [`with_child`]: Interp::with_child
-    parent: Option<*mut Interp>,
+    parent: RefCell<Weak<InterpState>>,
     /// Whether this interp is safe (`interp create -safe` / `interp issafe`).
-    is_safe: bool,
+    is_safe: Cell<bool>,
     /// How many of *this* interp's evals are currently on the stack (as a child:
     /// [`eval_in_child`]/[`with_child`] bump it). A child may be deleted *during*
     /// its own eval — e.g. its aliased `exit` calls `interp delete` on itself —
-    /// so a non-zero count means the boxed interp must not be freed yet, or the
-    /// raw-pointer eval still unwinding above would dangle.
+    /// so a non-zero count means teardown must be deferred (`pending_delete`)
+    /// until the last eval unwinds, or a re-entry still on the stack would see a
+    /// half-torn-down interp.
     ///
     /// [`eval_in_child`]: Interp::eval_in_child
     /// [`with_child`]: Interp::with_child
-    eval_active: usize,
-    /// Set when a delete was requested while [`eval_active`] was non-zero; the
-    /// actual teardown is deferred until the last eval unwinds (C's deferred
-    /// `Tcl_DeleteInterp`).
-    ///
-    /// [`eval_active`]: Interp::eval_active
-    pending_delete: bool,
+    eval_active: Cell<usize>,
+    /// Set when a delete was requested while [`eval_active`](Self::eval_active)
+    /// was non-zero; the actual removal from the parent's table is deferred until
+    /// the last eval unwinds (C's deferred `Tcl_DeleteInterp`).
+    pending_delete: Cell<bool>,
     /// TclOO object system state (classes, objects, the method-call stack).
-    pub(crate) oo: crate::cmd_oo::OoState,
+    pub(crate) oo: RefCell<crate::cmd_oo::OoState>,
     /// The source-location stack (`cmdFramePtr`; PC-5) — what `info frame` reads.
-    cmd_frames: Vec<CmdFrame>,
+    cmd_frames: RefCell<Vec<CmdFrame>>,
     /// `eval_str` nesting depth. The outermost eval (depth returning to 0)
     /// publishes the accumulated error trace to the `::errorInfo`/`::errorCode`
     /// globals; nested evals (proc bodies, `[cmd]` subst, control bodies) just
     /// accumulate.
-    eval_depth: usize,
-    result: *mut TclObj,
+    eval_depth: Cell<usize>,
+    result: Cell<*mut TclObj>,
 }
 
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
@@ -383,34 +408,34 @@ const RECURSION_LIMIT: usize = 1000;
 impl Interp {
     /// Create an interp: global frame, the built-in command set, an empty
     /// result.
-    pub fn new() -> Box<Interp> {
+    pub fn new() -> Interp {
         let result = obj::new_obj();
         // SAFETY: `result` is freshly created; the interp takes the owning ref.
         unsafe { obj::incr_ref_count(result) };
-        let mut interp = Box::new(Interp {
-            frames: FrameStack::new(),
-            namespaces: Namespaces::new(),
-            current_ns: GLOBAL,
-            recursion_depth: 0,
-            packages: crate::cmd_package::PackageState::with_core(),
-            script_stack: Vec::new(),
-            channels: crate::cmd_chan::ChannelTable::default(),
-            return_code: Code::Ok,
-            return_level: 1,
-            traces: crate::cmd_trace::TraceTable::default(),
-            exc: ExceptionState::default(),
-            children: std::collections::BTreeMap::new(),
-            interp_counter: 0,
-            hidden: std::collections::BTreeMap::new(),
-            parent: None,
-            is_safe: false,
-            eval_active: 0,
-            pending_delete: false,
-            oo: crate::cmd_oo::OoState::default(),
-            cmd_frames: Vec::new(),
-            eval_depth: 0,
-            result,
-        });
+        let mut interp = Interp(Rc::new(InterpState {
+            frames: RefCell::new(FrameStack::new()),
+            namespaces: RefCell::new(Namespaces::new()),
+            current_ns: Cell::new(GLOBAL),
+            recursion_depth: Cell::new(0),
+            packages: RefCell::new(crate::cmd_package::PackageState::with_core()),
+            script_stack: RefCell::new(Vec::new()),
+            channels: RefCell::new(crate::cmd_chan::ChannelTable::default()),
+            return_code: Cell::new(Code::Ok),
+            return_level: Cell::new(1),
+            traces: RefCell::new(crate::cmd_trace::TraceTable::default()),
+            exc: RefCell::new(ExceptionState::default()),
+            children: RefCell::new(std::collections::BTreeMap::new()),
+            interp_counter: Cell::new(0),
+            hidden: RefCell::new(std::collections::BTreeMap::new()),
+            parent: RefCell::new(Weak::new()),
+            is_safe: Cell::new(false),
+            eval_active: Cell::new(0),
+            pending_delete: Cell::new(false),
+            oo: RefCell::new(crate::cmd_oo::OoState::default()),
+            cmd_frames: RefCell::new(Vec::new()),
+            eval_depth: Cell::new(0),
+            result: Cell::new(result),
+        }));
         builtins::install(&mut interp);
         interp
     }
@@ -420,24 +445,34 @@ impl Interp {
     /// Register a built-in command (a possibly-qualified `name`, creating
     /// intermediate namespaces; overwrites any existing command of `name`).
     pub fn register_builtin(&mut self, name: &[u8], f: BuiltinFn) {
-        self.namespaces.register(name, Command::Builtin(f));
+        self.namespaces
+            .borrow_mut()
+            .register(name, Command::Builtin(f));
     }
 
     /// Command names in the current namespace, sorted (`info commands`).
     #[must_use]
-    pub fn command_names(&self) -> Vec<&[u8]> {
-        self.namespaces.command_names(self.current_ns)
+    pub fn command_names(&self) -> Vec<Vec<u8>> {
+        self.namespaces
+            .borrow()
+            .command_names(self.current_ns.get())
+            .iter()
+            .map(|s| s.to_vec())
+            .collect()
     }
 
     /// `rename old new` (or `rename old ""` to delete), relative to the current
     /// namespace. Drives the one command table; see [`Namespaces::rename`].
     pub(crate) fn rename_command(&mut self, old: &[u8], new: &[u8]) -> RenameOutcome {
-        self.namespaces.rename(self.current_ns, old, new)
+        self.namespaces
+            .borrow_mut()
+            .rename(self.current_ns.get(), old, new)
     }
 
     /// Install an `interp alias` redirect named `name` → `target ?prefix...?`.
     pub(crate) fn install_alias(&mut self, name: &[u8], target: Vec<u8>, prefix: Vec<Vec<u8>>) {
         self.namespaces
+            .borrow_mut()
             .register(name, Command::Alias { target, prefix });
     }
 
@@ -460,7 +495,11 @@ impl Interp {
     /// The `(target, prefix)` of the alias bound to `name` (the query form), or
     /// `None` if `name` resolves to something that isn't an alias.
     pub(crate) fn alias_info(&self, name: &[u8]) -> Option<(Vec<u8>, Vec<Vec<u8>>)> {
-        match self.namespaces.resolve(self.current_ns, name) {
+        match self
+            .namespaces
+            .borrow()
+            .resolve(self.current_ns.get(), name)
+        {
             Some(Command::Alias { target, prefix }) => Some((target, prefix)),
             _ => None,
         }
@@ -469,7 +508,9 @@ impl Interp {
     /// Delete the command bound to `name` (the alias-clear form); returns whether
     /// it existed.
     pub(crate) fn delete_command(&mut self, name: &[u8]) -> bool {
-        self.namespaces.delete(self.current_ns, name)
+        self.namespaces
+            .borrow_mut()
+            .delete(self.current_ns.get(), name)
     }
 
     /// Register an ensemble command (`namespace ensemble create`); `name` is the
@@ -480,13 +521,18 @@ impl Interp {
         // `NamespaceEnsembleCmd`). `namespace ensemble create -command path`
         // inside `namespace eval ::tcl::tm` therefore binds `::tcl::tm::path`,
         // not a bare `::path` at global scope.
-        let ns = self.namespaces.command_home_ns(self.current_ns, name);
+        let ns = self
+            .namespaces
+            .borrow_mut()
+            .command_home_ns(self.current_ns.get(), name);
         let tail = tcl_syntax::naming::qualifier_segments(name)
             .last()
             .copied()
             .unwrap_or(name)
             .to_vec();
-        self.namespaces.bind(ns, &tail, Command::Ensemble(cfg));
+        self.namespaces
+            .borrow_mut()
+            .bind(ns, &tail, Command::Ensemble(cfg));
     }
 
     /// Define a user proc (`proc name params body`). The proc's defining
@@ -494,7 +540,10 @@ impl Interp {
     /// `name` lands in — **relative to the current namespace** (so `proc next`
     /// inside `namespace eval counter` binds `::counter::next`, not a global).
     pub(crate) fn define_proc(&mut self, name: &[u8], params: Vec<Param>, body: Vec<u8>) {
-        let ns = self.namespaces.command_home_ns(self.current_ns, name);
+        let ns = self
+            .namespaces
+            .borrow_mut()
+            .command_home_ns(self.current_ns.get(), name);
         let tail = tcl_syntax::naming::qualifier_segments(name)
             .last()
             .copied()
@@ -502,7 +551,7 @@ impl Interp {
             .to_vec();
         // The proc's FQN (`info frame` `proc` key): `<ns>::<tail>`, the global ns
         // contributing just the leading `::`.
-        let qn = self.namespaces.qualified_name(ns);
+        let qn = self.namespaces.borrow().qualified_name(ns);
         let mut fqn = qn.clone();
         if qn != b"::" {
             fqn.extend_from_slice(b"::");
@@ -513,7 +562,11 @@ impl Interp {
         // (C's literal line table): the base is the file line of the `proc`
         // command minus one (the body opens on that line). Eval-defined procs
         // keep body-relative lines (base 0).
-        let source = self.script_stack.last().map(|f| Rc::from(f.as_slice()));
+        let source = self
+            .script_stack
+            .borrow()
+            .last()
+            .map(|f| Rc::from(f.as_slice()));
         let body_line_base = if source.is_some() {
             self.current_cmd_line().saturating_sub(1)
         } else {
@@ -527,43 +580,49 @@ impl Interp {
             source,
             body_line_base,
         });
-        self.namespaces.bind(ns, &tail, Command::Proc(def));
+        self.namespaces
+            .borrow_mut()
+            .bind(ns, &tail, Command::Proc(def));
     }
 
     /// The reported `line` of the command currently executing at the top of the
     /// `info frame` stack (for fixing a source-defined proc's body line base).
     fn current_cmd_line(&self) -> u32 {
-        self.cmd_frames.last().map_or(1, |f| f.line)
+        self.cmd_frames.borrow().last().map_or(1, |f| f.line)
     }
 
     /// Whether `name` resolves to an ensemble command (`namespace ensemble
     /// exists`).
     pub(crate) fn is_ensemble(&self, name: &[u8]) -> bool {
         matches!(
-            self.namespaces.resolve(self.current_ns, name),
+            self.namespaces
+                .borrow()
+                .resolve(self.current_ns.get(), name),
             Some(Command::Ensemble(_))
         )
     }
 
     /// Every alias command's name across the whole tree (`interp aliases`).
     pub(crate) fn alias_names(&self) -> Vec<Vec<u8>> {
-        self.namespaces.alias_names()
+        self.namespaces.borrow().alias_names()
     }
 
     /// The current namespace (the eval context) — for the `namespace` builtin.
     pub(crate) fn current_ns(&self) -> NsId {
-        self.current_ns
+        self.current_ns.get()
     }
 
-    /// The namespace tree (read) — for the `namespace` builtin's queries.
-    pub(crate) fn namespaces(&self) -> &Namespaces {
-        &self.namespaces
+    /// The namespace tree (read) — for the `namespace` builtin's queries. The
+    /// returned `Ref` must not be held across a call that mutably borrows the
+    /// namespaces (it would panic); callers use it for a single query.
+    pub(crate) fn namespaces(&self) -> std::cell::Ref<'_, Namespaces> {
+        self.namespaces.borrow()
     }
 
     /// The namespace tree (mutable) — for the `namespace` builtin's mutations
     /// (`export`/`import`/`forget`/`path`).
-    pub(crate) fn namespaces_mut(&mut self) -> &mut Namespaces {
-        &mut self.namespaces
+    pub(crate) fn namespaces_mut(&self) -> std::cell::RefMut<'_, Namespaces> {
+        self.namespaces.borrow_mut()
     }
 
     /// Bootstrap the standard library like C's `Tcl_Init`: set the startup
@@ -635,8 +694,8 @@ impl Interp {
 
     /// Record `return -level L -code C` state (set by the `return` command).
     pub(crate) fn set_return_state(&mut self, level: usize, code: Code) {
-        self.return_level = level;
-        self.return_code = code;
+        self.return_level.set(level);
+        self.return_code.set(code);
     }
 
     /// Apply a procedure/source **return boundary** to a body completion code
@@ -648,10 +707,11 @@ impl Interp {
         if code != Code::Return {
             return code;
         }
-        self.return_level = self.return_level.saturating_sub(1);
-        if self.return_level == 0 {
-            let c = self.return_code;
-            self.return_code = Code::Ok;
+        self.return_level
+            .set(self.return_level.get().saturating_sub(1));
+        if self.return_level.get() == 0 {
+            let c = self.return_code.get();
+            self.return_code.set(Code::Ok);
             c
         } else {
             Code::Return
@@ -662,7 +722,7 @@ impl Interp {
     /// the script stack (`info script`). A top-level `return` ends the file (the
     /// return boundary maps `return` → Ok); other codes propagate.
     pub fn eval_sourced(&mut self, script: &[u8], name: &[u8]) -> Code {
-        self.script_stack.push(name.to_vec());
+        self.script_stack.borrow_mut().push(name.to_vec());
         // A `source`d file is its own `info frame` level: `type source` + the
         // file path, inheriting the enclosing proc/level. Its commands are
         // numbered by the file's own lines (base 0, the file *is* the script).
@@ -671,13 +731,17 @@ impl Interp {
         frame.file = Some(Rc::from(name));
         frame.line_base = 0;
         let code = self.eval_framed(script, frame);
-        self.script_stack.pop();
+        self.script_stack.borrow_mut().pop();
         self.settle_return(code)
     }
 
     /// `info script` — the file currently being sourced (empty at top level).
     pub(crate) fn current_script(&self) -> Vec<u8> {
-        self.script_stack.last().cloned().unwrap_or_default()
+        self.script_stack
+            .borrow()
+            .last()
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// `uplevel`: evaluate `script` in the variable scope **and** namespace of
@@ -685,9 +749,10 @@ impl Interp {
     /// together" discovery), then restore. Transparent — the body's completion
     /// code (incl. `return`) propagates unchanged.
     pub(crate) fn eval_uplevel(&mut self, target_level: usize, script: &[u8]) -> Code {
-        let prev_level = self.frames.set_active_level(target_level);
-        let prev_ns = self.current_ns;
-        self.current_ns = self.frames.frame_ns(target_level);
+        let prev_level = self.frames.borrow_mut().set_active_level(target_level);
+        let prev_ns = self.current_ns.get();
+        self.current_ns
+            .set(self.frames.borrow().frame_ns(target_level));
         // The `uplevel` body is a fresh dynamically-evaluated script: `type
         // eval`, **no** file, body-relative lines (base 0) — but it keeps the
         // invoking proc's name and runs at the target call level (with no
@@ -700,8 +765,8 @@ impl Interp {
         frame.level = target_level;
         frame.omit_level = true;
         let code = self.eval_framed(script, frame);
-        self.frames.set_active_level(prev_level);
-        self.current_ns = prev_ns;
+        self.frames.borrow_mut().set_active_level(prev_level);
+        self.current_ns.set(prev_ns);
         code
     }
 
@@ -710,24 +775,27 @@ impl Interp {
     /// `body` there, then restore. The current-ns switch is what makes commands
     /// defined in `body` land in the right table.
     pub(crate) fn ns_eval(&mut self, name: &[u8], body: &[u8]) -> Code {
-        let target = self.namespaces.ensure_namespace(self.current_ns, name);
-        let saved = self.current_ns;
-        self.current_ns = target;
+        let target = self
+            .namespaces
+            .borrow_mut()
+            .ensure_namespace(self.current_ns.get(), name);
+        let saved = self.current_ns.get();
+        self.current_ns.set(target);
         // A namespace frame: a new scope whose unqualified vars resolve to the
         // namespace (so `set`/`variable`/`upvar 0` inside `namespace eval` —
         // including when nested in a proc — target the namespace, not the
         // enclosing proc's locals).
-        self.frames.push_namespace(target);
+        self.frames.borrow_mut().push_namespace(target);
         let code = self.eval_str(body);
-        self.frames.pop();
-        self.current_ns = saved;
+        self.frames.borrow_mut().pop();
+        self.current_ns.set(saved);
         code
     }
 
     /// Whether the active variable frame is a proc call frame (vs. global /
     /// `namespace eval` scope).
     pub(crate) fn in_proc(&self) -> bool {
-        self.frames.in_proc()
+        self.frames.borrow().in_proc()
     }
 
     // -- variables (the var resolver; `crate::vars`) --------------------------
@@ -739,24 +807,35 @@ impl Interp {
 
     /// `set name` — borrowed value (the table keeps its +1), or `None`.
     pub(crate) fn var_get(&self, name: &[u8]) -> Option<*mut TclObj> {
-        crate::vars::get(&self.frames, &self.namespaces, self.current_ns, name)
+        crate::vars::get(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            self.current_ns.get(),
+            name,
+        )
     }
 
     /// `set name(key)` — borrowed.
     pub(crate) fn var_get_elem(&self, name: &[u8], key: &[u8]) -> Option<*mut TclObj> {
-        crate::vars::get_elem(&self.frames, &self.namespaces, self.current_ns, name, key)
+        crate::vars::get_elem(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            self.current_ns.get(),
+            name,
+            key,
+        )
     }
 
     /// `set name value` — the cell takes a **+1** on `obj`.
     pub(crate) fn var_set(&mut self, name: &[u8], obj: *mut TclObj) -> Result<(), VarError> {
         let r = crate::vars::set(
-            &mut self.frames,
-            &mut self.namespaces,
-            self.current_ns,
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
             name,
             obj,
         );
-        if r.is_ok() && !self.traces.traces.is_empty() {
+        if r.is_ok() && !self.traces.borrow().traces.is_empty() {
             let (base, elem) = crate::frame::split_array_ref(name);
             self.fire_var_trace(&base, elem.as_deref(), b"write");
         }
@@ -771,14 +850,14 @@ impl Interp {
         obj: *mut TclObj,
     ) -> Result<(), VarError> {
         let r = crate::vars::set_elem(
-            &mut self.frames,
-            &mut self.namespaces,
-            self.current_ns,
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
             name,
             key,
             obj,
         );
-        if r.is_ok() && !self.traces.traces.is_empty() {
+        if r.is_ok() && !self.traces.borrow().traces.is_empty() {
             self.fire_var_trace(name, Some(key), b"write");
         }
         r
@@ -787,7 +866,7 @@ impl Interp {
     /// Fire a read trace for `name` before a read (the `&mut` chokepoints that
     /// resolve `$var` call this).
     pub(crate) fn fire_read_trace(&mut self, name: &[u8], key: Option<&[u8]>) {
-        if self.traces.traces.is_empty() {
+        if self.traces.borrow().traces.is_empty() {
             return;
         }
         let (base, elem) = crate::frame::split_array_ref(name);
@@ -798,12 +877,12 @@ impl Interp {
     /// `unset name` — returns whether it existed.
     pub(crate) fn var_unset(&mut self, name: &[u8]) -> bool {
         let existed = crate::vars::unset(
-            &mut self.frames,
-            &mut self.namespaces,
-            self.current_ns,
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
             name,
         );
-        if existed && !self.traces.traces.is_empty() {
+        if existed && !self.traces.borrow().traces.is_empty() {
             let (base, elem) = crate::frame::split_array_ref(name);
             self.fire_var_trace(&base, elem.as_deref(), b"unset");
         }
@@ -813,13 +892,13 @@ impl Interp {
     /// `unset name(key)` — returns whether it existed.
     pub(crate) fn var_unset_elem(&mut self, name: &[u8], key: &[u8]) -> bool {
         let existed = crate::vars::unset_elem(
-            &mut self.frames,
-            &mut self.namespaces,
-            self.current_ns,
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
             name,
             key,
         );
-        if existed && !self.traces.traces.is_empty() {
+        if existed && !self.traces.borrow().traces.is_empty() {
             self.fire_var_trace(name, Some(key), b"unset");
         }
         existed
@@ -830,11 +909,12 @@ impl Interp {
     /// guard) and callback errors are swallowed; the interp result is preserved
     /// across the callbacks (the triggering operation owns the result).
     fn fire_var_trace(&mut self, base: &[u8], elem: Option<&[u8]>, op: &[u8]) {
-        if self.traces.firing > 0 {
+        if self.traces.borrow().firing > 0 {
             return;
         }
         let cmds: Vec<Vec<u8>> = self
             .traces
+            .borrow()
             .traces
             .iter()
             .filter(|t| crate::cmd_trace::matches(t, base, elem, op))
@@ -844,10 +924,10 @@ impl Interp {
             return;
         }
         // Preserve the result object across the callbacks.
-        let saved = self.result;
+        let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
 
-        self.traces.firing += 1;
+        self.traces.borrow_mut().firing += 1;
         for cmd in cmds {
             // Append `base element op` as properly-quoted trailing words.
             let args = crate::list::new_list_obj(&[
@@ -861,19 +941,24 @@ impl Interp {
             drop_fresh(args);
             let _ = self.eval_str(&line);
         }
-        self.traces.firing -= 1;
+        self.traces.borrow_mut().firing -= 1;
 
         // Restore the saved result (release the trace's, adopt our held +1).
         unsafe {
-            obj::decr_ref_count(self.result);
-            self.result = saved;
+            obj::decr_ref_count(self.result.get());
+            self.result.set(saved);
         }
     }
 
     /// Whether `name` resolves to an array variable (`set a` array-vs-scalar
     /// diagnostic, `array exists`).
     pub(crate) fn var_is_array(&self, name: &[u8]) -> bool {
-        crate::vars::is_array(&self.frames, &self.namespaces, self.current_ns, name)
+        crate::vars::is_array(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            self.current_ns.get(),
+            name,
+        )
     }
 
     /// Resolve a `global`/`variable`/`upvar` name argument to its
@@ -886,7 +971,7 @@ impl Interp {
         name: &[u8],
     ) -> Option<(NsId, Vec<u8>)> {
         if tcl_syntax::naming::is_qualified(name) {
-            self.namespaces.var_home(context_ns, name)
+            self.namespaces.borrow().var_home(context_ns, name)
         } else {
             Some((context_ns, name.to_vec()))
         }
@@ -894,16 +979,16 @@ impl Interp {
 
     /// The current call-frame level (`upvar` relative-level arithmetic).
     pub(crate) fn current_level(&self) -> usize {
-        self.frames.current_level()
+        self.frames.borrow().current_level()
     }
 
     /// `variable tail` / `global tail` — link `tail` in the current frame to
     /// `target_ns::tail` (a no-op when the current context already is that var).
     pub(crate) fn make_variable(&mut self, target_ns: NsId, tail: &[u8]) {
         crate::vars::make_variable(
-            &mut self.frames,
-            &mut self.namespaces,
-            self.current_ns,
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
             target_ns,
             tail,
         );
@@ -912,7 +997,9 @@ impl Interp {
     /// Resolve (creating if needed) a namespace by name, relative to the current
     /// namespace — for `apply`'s optional namespace term.
     pub(crate) fn ensure_namespace(&mut self, name: &[u8]) -> NsId {
-        self.namespaces.ensure_namespace(self.current_ns, name)
+        self.namespaces
+            .borrow_mut()
+            .ensure_namespace(self.current_ns.get(), name)
     }
 
     // -- introspection (`info` / `array`) -------------------------------------
@@ -922,27 +1009,42 @@ impl Interp {
     pub(crate) fn var_exists(&self, name: &[u8]) -> bool {
         let (base, elem) = crate::frame::split_array_ref(name);
         match elem {
-            Some(k) => {
-                crate::vars::exists_elem(&self.frames, &self.namespaces, self.current_ns, &base, &k)
-            }
-            None => crate::vars::exists(&self.frames, &self.namespaces, self.current_ns, &base),
+            Some(k) => crate::vars::exists_elem(
+                &self.frames.borrow(),
+                &self.namespaces.borrow(),
+                self.current_ns.get(),
+                &base,
+                &k,
+            ),
+            None => crate::vars::exists(
+                &self.frames.borrow(),
+                &self.namespaces.borrow(),
+                self.current_ns.get(),
+                &base,
+            ),
         }
     }
 
     /// The element names of array `name` (`array names`/`get`), or `None`.
     pub(crate) fn array_names(&self, name: &[u8]) -> Option<Vec<Vec<u8>>> {
-        crate::vars::array_names(&self.frames, &self.namespaces, self.current_ns, name)
+        crate::vars::array_names(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            self.current_ns.get(),
+            name,
+        )
     }
 
     /// `info level` — the current frame level (proc nesting depth).
     pub(crate) fn level(&self) -> usize {
-        self.frames.current_level()
+        self.frames.borrow().current_level()
     }
 
     /// The invoking command words at call `level` (`info level N`), or `None`
     /// when the level has none.
     pub(crate) fn level_words(&self, level: usize) -> Option<Vec<Vec<u8>>> {
         self.frames
+            .borrow()
             .words_at(level)
             .filter(|w| !w.is_empty())
             .map(<[Vec<u8>]>::to_vec)
@@ -951,50 +1053,44 @@ impl Interp {
     /// Variable names visible in the current scope (`info vars`): the active
     /// frame's locals in a proc, else the current namespace's variables.
     pub(crate) fn visible_var_names(&self) -> Vec<Vec<u8>> {
-        if self.frames.in_proc() {
-            self.frames.local_names()
+        if self.frames.borrow().in_proc() {
+            self.frames.borrow().local_names()
         } else {
-            self.namespaces.var_names(self.current_ns)
+            self.namespaces.borrow().var_names(self.current_ns.get())
         }
     }
 
     /// `info locals` — the active frame's local variable names.
     pub(crate) fn local_var_names(&self) -> Vec<Vec<u8>> {
-        self.frames.local_names()
+        self.frames.borrow().local_names()
     }
 
     /// `info globals` — the global namespace's variable names.
     pub(crate) fn global_var_names(&self) -> Vec<Vec<u8>> {
-        self.namespaces.var_names(GLOBAL)
+        self.namespaces.borrow().var_names(GLOBAL)
     }
 
     /// Command names visible from the current namespace (`info commands`):
     /// current ns ∪ global, sorted/deduped.
     pub(crate) fn visible_command_names(&self) -> Vec<Vec<u8>> {
-        self.visible(self.namespaces.command_names(self.current_ns), |ns| {
-            ns.command_names(GLOBAL)
-        })
-    }
-
-    /// Proc names visible from the current namespace (`info procs`).
-    pub(crate) fn visible_proc_names(&self) -> Vec<Vec<u8>> {
-        let mut v = self.namespaces.proc_names(self.current_ns);
-        if self.current_ns != GLOBAL {
-            v.extend(self.namespaces.proc_names(GLOBAL));
+        let ns = self.namespaces.borrow();
+        let cur = self.current_ns.get();
+        let mut v: Vec<Vec<u8>> = ns.command_names(cur).iter().map(|s| s.to_vec()).collect();
+        if cur != GLOBAL {
+            v.extend(ns.command_names(GLOBAL).iter().map(|s| s.to_vec()));
         }
         v.sort();
         v.dedup();
         v
     }
 
-    fn visible(
-        &self,
-        local: Vec<&[u8]>,
-        global: impl Fn(&Namespaces) -> Vec<&[u8]>,
-    ) -> Vec<Vec<u8>> {
-        let mut v: Vec<Vec<u8>> = local.iter().map(|s| s.to_vec()).collect();
-        if self.current_ns != GLOBAL {
-            v.extend(global(&self.namespaces).iter().map(|s| s.to_vec()));
+    /// Proc names visible from the current namespace (`info procs`).
+    pub(crate) fn visible_proc_names(&self) -> Vec<Vec<u8>> {
+        let ns = self.namespaces.borrow();
+        let cur = self.current_ns.get();
+        let mut v = ns.proc_names(cur);
+        if cur != GLOBAL {
+            v.extend(ns.proc_names(GLOBAL));
         }
         v.sort();
         v.dedup();
@@ -1003,7 +1099,11 @@ impl Interp {
 
     /// The proc definition bound to `name` (for `info body`/`args`/`default`).
     pub(crate) fn proc_def(&self, name: &[u8]) -> Option<Rc<ProcDef>> {
-        match self.namespaces.resolve(self.current_ns, name) {
+        match self
+            .namespaces
+            .borrow()
+            .resolve(self.current_ns.get(), name)
+        {
             Some(Command::Proc(def)) => Some(def),
             _ => None,
         }
@@ -1012,9 +1112,9 @@ impl Interp {
     /// `upvar` — link `local` in the current frame to the resolved `target`.
     pub(crate) fn make_upvar(&mut self, target: Link, local: &[u8]) {
         crate::vars::make_upvar(
-            &mut self.frames,
-            &mut self.namespaces,
-            self.current_ns,
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
             target,
             local,
         );
@@ -1027,11 +1127,11 @@ impl Interp {
     /// # Safety
     /// `obj` must be a live `TclObj`.
     pub unsafe fn set_obj_result(&mut self, obj: *mut TclObj) {
-        let old = self.result;
+        let old = self.result.get();
         // SAFETY: `obj` live (caller); `old` is the interp's owned result.
         unsafe {
             obj::incr_ref_count(obj);
-            self.result = obj;
+            self.result.set(obj);
             obj::decr_ref_count(old);
         }
     }
@@ -1060,12 +1160,12 @@ impl Interp {
 
     /// `Tcl_GetObjResult` — borrowed (interp keeps its +1).
     pub fn get_obj_result(&self) -> *mut TclObj {
-        self.result
+        self.result.get()
     }
 
     /// The current result's string bytes (copied).
     pub fn result_bytes(&self) -> Vec<u8> {
-        obj_bytes(self.result)
+        obj_bytes(self.result.get())
     }
 
     /// Raise an error with result `msg` and return [`Code::Error`] — the generic
@@ -1085,7 +1185,7 @@ impl Interp {
         } else {
             b"NONE"
         };
-        self.exc = ExceptionState {
+        *self.exc.borrow_mut() = ExceptionState {
             info: None,
             code: code.to_vec(),
             line: 1,
@@ -1100,7 +1200,7 @@ impl Interp {
     /// [`Code::Error`].
     pub(crate) fn raise_with_info(&mut self, msg: &[u8], info: &[u8], code: &[u8]) -> Code {
         self.set_result_bytes(msg);
-        self.exc = ExceptionState {
+        *self.exc.borrow_mut() = ExceptionState {
             info: Some(info.to_vec()),
             code: code.to_vec(),
             line: 1,
@@ -1113,7 +1213,7 @@ impl Interp {
     /// `-errorcode` `code` and an empty trace (it accumulates as the error
     /// unwinds). Used by `error msg`/`throw`. Returns [`Code::Error`].
     pub(crate) fn set_error_state(&mut self, code: &[u8]) -> Code {
-        self.exc = ExceptionState {
+        *self.exc.borrow_mut() = ExceptionState {
             info: None,
             code: code.to_vec(),
             line: 1,
@@ -1135,16 +1235,16 @@ impl Interp {
         // bytecode frame, so it is *not* re-logged. The flag stays set and is
         // cleared only at a real frame boundary (`make_proc_error` /
         // `append_body_frame`), which is what lets the proc-*call* command log.
-        if self.exc.already_logged {
+        if self.exc.borrow().already_logged {
             return;
         }
         // errorLine = 1 + count('\n' in src[0..commandStart]) — C's exact loop.
-        self.exc.line = line_of(src, cmd.start);
-        let started = self.exc.info.is_some();
+        let line = line_of(src, cmd.start);
+        let started = self.exc.borrow().info.is_some();
         if !started {
             // First frame: errorInfo is seeded from the error message (the result).
             let msg = self.result_bytes();
-            self.exc.info = Some(msg);
+            self.exc.borrow_mut().info = Some(msg);
         }
         let verb: &[u8] = if started {
             b"invoked from within"
@@ -1158,7 +1258,9 @@ impl Interp {
         } else {
             cmd_bytes
         };
-        let buf = self.exc.info.as_mut().expect("seeded above");
+        let mut exc = self.exc.borrow_mut();
+        exc.line = line;
+        let buf = exc.info.as_mut().expect("seeded above");
         buf.extend_from_slice(b"\n    ");
         buf.extend_from_slice(verb);
         buf.extend_from_slice(b"\n\"");
@@ -1167,7 +1269,7 @@ impl Interp {
             buf.extend_from_slice(b"...");
         }
         buf.push(b'"');
-        self.exc.already_logged = true;
+        exc.already_logged = true;
     }
 
     /// Append the `(procedure "NAME" line N)` / `(lambda term "..." line N)`
@@ -1193,7 +1295,7 @@ impl Interp {
         }
         inner.push(b'"');
         self.append_frame_line(&inner);
-        self.exc.already_logged = false;
+        self.exc.borrow_mut().already_logged = false;
     }
 
     /// Append a `("LABEL" body line N)` frame (the `eval`/`uplevel`/`foreach`
@@ -1208,7 +1310,7 @@ impl Interp {
         inner.extend_from_slice(label);
         inner.extend_from_slice(b"\" body");
         self.append_frame_line(&inner);
-        self.exc.already_logged = false;
+        self.exc.borrow_mut().already_logged = false;
     }
 
     /// Shared tail of the `(... line N)` frames: append `"\n    (<inner> line
@@ -1216,12 +1318,13 @@ impl Interp {
     /// been logged yet), where `inner` is the caller-built body — e.g.
     /// `procedure "p"`, `lambda term "..."`, or `"eval" body`.
     fn append_frame_line(&mut self, inner: &[u8]) {
-        let line = self.exc.line;
-        if self.exc.info.is_none() {
+        let line = self.exc.borrow().line;
+        if self.exc.borrow().info.is_none() {
             let msg = self.result_bytes();
-            self.exc.info = Some(msg);
+            self.exc.borrow_mut().info = Some(msg);
         }
-        let buf = self.exc.info.as_mut().expect("seeded above");
+        let mut exc = self.exc.borrow_mut();
+        let buf = exc.info.as_mut().expect("seeded above");
         buf.extend_from_slice(b"\n    (");
         buf.extend_from_slice(inner);
         buf.extend_from_slice(b" line ");
@@ -1232,12 +1335,13 @@ impl Interp {
     /// The current accumulated `errorInfo` (for `catch`'s `-errorinfo`): the
     /// trace if any frame was logged, else the bare error message.
     pub(crate) fn error_info(&self) -> Vec<u8> {
-        self.exc.info.clone().unwrap_or_else(|| self.result_bytes())
+        let info = self.exc.borrow().info.clone();
+        info.unwrap_or_else(|| self.result_bytes())
     }
 
     /// `info frame` (no arg): the depth of the source-location stack.
     pub(crate) fn cmd_frame_depth(&self) -> usize {
-        self.cmd_frames.len()
+        self.cmd_frames.borrow().len()
     }
 
     /// The `info frame N` description for stack position `n` (C's level
@@ -1246,12 +1350,13 @@ impl Interp {
     /// (key, value) pairs in C's key order (`type line [file] cmd [proc]
     /// level`), or `None` if out of range.
     pub(crate) fn cmd_frame_info(&self, n: i64) -> Option<Vec<(Vec<u8>, Vec<u8>)>> {
-        let depth = self.cmd_frames.len() as i64;
+        let cmd_frames = self.cmd_frames.borrow();
+        let depth = cmd_frames.len() as i64;
         let pos = if n > 0 { n } else { depth + n };
         if pos < 1 || pos > depth {
             return None;
         }
-        let f = &self.cmd_frames[(pos - 1) as usize];
+        let f = &cmd_frames[(pos - 1) as usize];
         let mut pairs = vec![
             (b"type".to_vec(), f.kind.as_bytes().to_vec()),
             (b"line".to_vec(), f.line.to_string().into_bytes()),
@@ -1266,7 +1371,7 @@ impl Interp {
         // `level` is the distance from the current call level (omitted for a
         // redirected `uplevel` scope, matching C's reachability check).
         if !f.omit_level {
-            let level = self.frames.current_level().saturating_sub(f.level);
+            let level = self.frames.borrow().current_level().saturating_sub(f.level);
             pairs.push((b"level".to_vec(), level.to_string().into_bytes()));
         }
         Some(pairs)
@@ -1275,10 +1380,11 @@ impl Interp {
     /// The current `errorCode` (for `catch`'s `-errorcode`): the stamped value,
     /// or `NONE`.
     pub(crate) fn error_code(&self) -> Vec<u8> {
-        if self.exc.code.is_empty() {
+        let exc = self.exc.borrow();
+        if exc.code.is_empty() {
             b"NONE".to_vec()
         } else {
-            self.exc.code.clone()
+            exc.code.clone()
         }
     }
 
@@ -1296,7 +1402,7 @@ impl Interp {
         if self.var_set(b"::errorCode", ec).is_err() {
             drop_fresh(ec);
         }
-        self.exc = ExceptionState::default();
+        *self.exc.borrow_mut() = ExceptionState::default();
     }
 
     /// Publish + reset, for `catch`/`try` once they have captured the options.
@@ -1315,7 +1421,7 @@ impl Interp {
     /// `cmdFramePtr` level. A proc body / `eval` / `source` body gets its own
     /// frame via [`eval_framed`](Self::eval_framed).
     pub fn eval_str(&mut self, src: &[u8]) -> Code {
-        let owned = self.cmd_frames.is_empty().then(CmdFrame::root);
+        let owned = self.cmd_frames.borrow().is_empty().then(CmdFrame::root);
         self.eval_script(src, owned)
     }
 
@@ -1331,10 +1437,10 @@ impl Interp {
     /// it (so `info frame` sees the live command/line); an unframed call (`None`,
     /// i.e. command substitution) leaves the enclosing frame untouched.
     fn eval_script(&mut self, src: &[u8], owned: Option<CmdFrame>) -> Code {
-        self.eval_depth += 1;
+        self.eval_depth.set(self.eval_depth.get() + 1);
         let owns_frame = owned.is_some();
         if let Some(f) = owned {
-            self.cmd_frames.push(f);
+            self.cmd_frames.borrow_mut().push(f);
         }
         let mut last = Code::Ok;
         let commands = parse::parse_script(src);
@@ -1345,13 +1451,13 @@ impl Interp {
             }
         }
         if owns_frame {
-            self.cmd_frames.pop();
+            self.cmd_frames.borrow_mut().pop();
         }
-        self.eval_depth -= 1;
+        self.eval_depth.set(self.eval_depth.get() - 1);
         // The outermost eval publishes the accumulated trace to the globals so
         // an uncaught error leaves `::errorInfo`/`::errorCode` set, exactly as a
         // `catch` would (`catch` publishes earlier, at depth > 0).
-        if self.eval_depth == 0 && last == Code::Error {
+        if self.eval_depth.get() == 0 && last == Code::Error {
             self.publish_error();
         }
         last
@@ -1365,14 +1471,16 @@ impl Interp {
     /// override fields ([`eval_uplevel`](Self::eval_uplevel)/
     /// [`eval_sourced`](Self::eval_sourced)).
     fn inherited_cmd_frame(&self) -> CmdFrame {
-        let top = self.cmd_frames.last();
+        let line_base = self.current_cmd_line().saturating_sub(1);
+        let cmd_frames = self.cmd_frames.borrow();
+        let top = cmd_frames.last();
         CmdFrame {
             kind: top.map_or(FrameKind::Eval, |f| f.kind),
             file: top.and_then(|f| f.file.clone()),
             proc: top.and_then(|f| f.proc.clone()),
             level: top.map_or(0, |f| f.level),
             omit_level: false,
-            line_base: self.current_cmd_line().saturating_sub(1),
+            line_base,
             cmd: Vec::new(),
             line: 1,
         }
@@ -1396,7 +1504,7 @@ impl Interp {
         // updates the `cmd` but keeps the **enclosing** command's `line` (the
         // line the substitution appears on); only the frame-owning script
         // advances the line as it steps through its own commands.
-        if let Some(top) = self.cmd_frames.last_mut() {
+        if let Some(top) = self.cmd_frames.borrow_mut().last_mut() {
             if owns_frame {
                 // `line_base` shifts a source-defined proc's body lines to be
                 // file-absolute; it is 0 elsewhere (body-relative).
@@ -1460,13 +1568,18 @@ impl Interp {
     /// matching C's `TclEvalObjvInternal`.
     pub(crate) fn dispatch(&mut self, argv: &[*mut TclObj]) -> Code {
         let name = obj_bytes(argv[0]);
-        if let Some(cmd) = self.namespaces.resolve(self.current_ns, &name) {
+        let resolved = self
+            .namespaces
+            .borrow()
+            .resolve(self.current_ns.get(), &name);
+        if let Some(cmd) = resolved {
             return self.invoke(cmd, argv);
         }
         // Command miss: dispatch through `unknown <name> <args…>` if it exists
         // (and we're not already resolving `unknown` itself).
         if name != b"unknown" {
-            if let Some(unk) = self.namespaces.resolve(GLOBAL, b"unknown") {
+            let unk = self.namespaces.borrow().resolve(GLOBAL, b"unknown");
+            if let Some(unk) = unk {
                 let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(argv.len() + 1);
                 let head = new_string(b"unknown");
                 // SAFETY: fresh + live argv elements; take the owning +1.
@@ -1489,11 +1602,14 @@ impl Interp {
         match cmd {
             Command::Builtin(f) => f(self, argv),
             Command::Alias { target, prefix } => self.dispatch_alias(&target, &prefix, argv),
-            Command::Imported { source } => match self.namespaces.resolve(GLOBAL, &source) {
-                // Transparent redirect: forward argv unchanged to the source.
-                Some(cmd) => self.invoke(cmd, argv),
-                None => self.invalid_command(&source),
-            },
+            Command::Imported { source } => {
+                let resolved = self.namespaces.borrow().resolve(GLOBAL, &source);
+                match resolved {
+                    // Transparent redirect: forward argv unchanged to the source.
+                    Some(cmd) => self.invoke(cmd, argv),
+                    None => self.invalid_command(&source),
+                }
+            }
             Command::Ensemble(cfg) => self.dispatch_ensemble(&cfg, argv),
             Command::Proc(def) => self.call_proc(&def, argv),
             Command::ChildInterp(name) => self.dispatch_child(&name, argv),
@@ -1507,7 +1623,7 @@ impl Interp {
     /// Register `cmd` under the (possibly qualified) name `name` — for the OO
     /// object/class commands.
     pub(crate) fn ns_register(&mut self, name: &[u8], cmd: Command) {
-        self.namespaces.register(name, cmd);
+        self.namespaces.borrow_mut().register(name, cmd);
     }
 
     /// The fully-qualified name a (relative or absolute) command/object name
@@ -1517,7 +1633,10 @@ impl Interp {
         if name.starts_with(b"::") {
             return name.to_vec();
         }
-        let qn = self.namespaces.qualified_name(self.current_ns);
+        let qn = self
+            .namespaces
+            .borrow()
+            .qualified_name(self.current_ns.get());
         let mut fqn = qn.clone();
         if qn != b"::" {
             fqn.extend_from_slice(b"::");
@@ -1622,65 +1741,56 @@ impl Interp {
     /// registering it as a command in this interp. Returns the name.
     pub(crate) fn create_child(&mut self, name: Option<Vec<u8>>) -> Vec<u8> {
         let name = name.unwrap_or_else(|| {
-            let n = format!("interp{}", self.interp_counter);
-            self.interp_counter += 1;
+            let n = format!("interp{}", self.interp_counter.get());
+            self.interp_counter.set(self.interp_counter.get() + 1);
             n.into_bytes()
         });
         let mut child = Interp::new();
         // A (non-safe) child gets the predefined globals (`tcl_platform`, …) like
         // a real interpreter. The full `init.tcl` (package/auto-load) is deferred.
         child.set_startup_globals();
-        self.children.insert(name.clone(), child);
+        self.children.borrow_mut().insert(name.clone(), child);
         self.namespaces
+            .borrow_mut()
             .register(&name, Command::ChildInterp(name.clone()));
         name
     }
 
     /// Whether a child interpreter `name` exists.
     pub(crate) fn child_exists(&self, name: &[u8]) -> bool {
-        self.children.contains_key(name)
+        self.children.borrow().contains_key(name)
     }
 
     /// Run `f` on the child interpreter `name` (or `None` if it doesn't exist) —
     /// the mutable-access path for `interp <sub> childPath …`.
     ///
-    /// `f` runs against a raw `*mut Interp` into the (heap-stable, boxed) child
-    /// rather than a borrow held on `self.children`, so a command inside `f` may
-    /// re-enter `self` (e.g. a child's `invokehidden source` that triggers a
-    /// parent alias) without an outstanding `&mut self.children` borrow. The
-    /// child's `parent` pointer is set for the duration so that re-entrancy can
-    /// reach back up. See the `CROSS_INTERP_DEPTH` note for the aliasing model.
+    /// The child's handle is **cloned out** of the table (an `Rc` bump) so the
+    /// `children` borrow is released before `f` runs. `f` may therefore re-enter
+    /// `self` — a child's aliased `source`/`invokehidden` calling back to the
+    /// parent — and even re-enter the same child through a fresh handle: the
+    /// shared `InterpState` is reached via the `Rc` plus per-field interior
+    /// mutability, never an aliased `&mut`. The child's `parent` `Weak` is set for
+    /// the call so re-entrancy can reach up, and restored after.
     ///
-    /// The child is marked active for the call, so a delete requested *during*
-    /// `f` (the self-deleting `exit` alias) is deferred until it unwinds — the
-    /// boxed interp is then freed here, never out from under the raw pointer.
+    /// The child is marked active for the call ([`eval_active`](InterpState)), so
+    /// a delete requested *during* `f` (the self-deleting `exit` alias) is
+    /// deferred to here and applied once no eval of it remains on the stack.
     pub(crate) fn with_child<R>(
         &mut self,
         name: &[u8],
         f: impl FnOnce(&mut Interp) -> R,
     ) -> Option<R> {
-        let parent_ptr = self as *mut Interp;
-        let child_ptr: *mut Interp = self.children.get_mut(name)?.as_mut();
-        // SAFETY: `child_ptr` addresses the boxed child interp, whose address is
-        // stable across `children` mutation; the borrow on `self.children` ended
-        // when we took the raw pointer, so `f` may re-enter `self`.
-        let teardown;
-        let r;
-        {
-            let child = unsafe { &mut *child_ptr };
-            let saved = child.parent;
-            child.parent = Some(parent_ptr);
-            child.eval_active += 1;
-            r = f(child);
-            child.eval_active -= 1;
-            child.parent = saved;
-            teardown = child.pending_delete && child.eval_active == 0;
-        }
-        // `child` borrow has ended; safe to drop the box (and its command) now
-        // that no eval of it remains on the stack.
+        let mut child = self.children.borrow().get(name)?.clone();
+        let saved_parent = child.parent.replace(Rc::downgrade(&self.0));
+        child.eval_active.set(child.eval_active.get() + 1);
+        let r = f(&mut child);
+        child.eval_active.set(child.eval_active.get() - 1);
+        *child.parent.borrow_mut() = saved_parent;
+        let teardown = child.pending_delete.get() && child.eval_active.get() == 0;
+        drop(child); // release our handle clone before freeing the table's
         if teardown {
-            self.children.remove(name);
-            self.namespaces.delete(GLOBAL, name);
+            self.children.borrow_mut().remove(name);
+            self.namespaces.borrow_mut().delete(GLOBAL, name);
         }
         Some(r)
     }
@@ -1688,10 +1798,11 @@ impl Interp {
     /// `interp hide name`: move command `name` out of the command table into the
     /// hidden table. Returns whether it existed.
     pub(crate) fn hide_command(&mut self, name: &[u8]) -> bool {
-        match self.namespaces.resolve(GLOBAL, name) {
+        let resolved = self.namespaces.borrow().resolve(GLOBAL, name);
+        match resolved {
             Some(cmd) => {
-                self.namespaces.delete(GLOBAL, name);
-                self.hidden.insert(name.to_vec(), cmd);
+                self.namespaces.borrow_mut().delete(GLOBAL, name);
+                self.hidden.borrow_mut().insert(name.to_vec(), cmd);
                 true
             }
             None => false,
@@ -1700,9 +1811,10 @@ impl Interp {
 
     /// `interp expose name`: move a hidden command back into the command table.
     pub(crate) fn expose_command(&mut self, name: &[u8]) -> bool {
-        match self.hidden.remove(name) {
+        let cmd = self.hidden.borrow_mut().remove(name);
+        match cmd {
             Some(cmd) => {
-                self.namespaces.register(name, cmd);
+                self.namespaces.borrow_mut().register(name, cmd);
                 true
             }
             None => false,
@@ -1711,7 +1823,8 @@ impl Interp {
 
     /// `interp invokehidden name ?arg ...?` — invoke a hidden command.
     pub(crate) fn invoke_hidden(&mut self, name: &[u8], argv: &[*mut TclObj]) -> Code {
-        match self.hidden.get(name).cloned() {
+        let cmd = self.hidden.borrow().get(name).cloned();
+        match cmd {
             Some(cmd) => self.invoke(cmd, argv),
             None => {
                 let mut m = b"invalid hidden command name \"".to_vec();
@@ -1724,7 +1837,7 @@ impl Interp {
 
     /// Sorted names of the hidden commands (`interp hidden`).
     pub(crate) fn hidden_names(&self) -> Vec<Vec<u8>> {
-        self.hidden.keys().cloned().collect()
+        self.hidden.borrow().keys().cloned().collect()
     }
 
     /// Make this interp "safe": hide the commands that touch the host
@@ -1751,17 +1864,17 @@ impl Interp {
         for &c in UNSAFE {
             self.hide_command(c);
         }
-        self.is_safe = true;
+        self.is_safe.set(true);
     }
 
     /// Whether this interp is safe (`interp issafe`).
     pub(crate) fn is_safe(&self) -> bool {
-        self.is_safe
+        self.is_safe.get()
     }
 
     /// The names of this interp's direct child interpreters (sorted).
     pub(crate) fn child_names(&self) -> Vec<Vec<u8>> {
-        self.children.keys().cloned().collect()
+        self.children.borrow().keys().cloned().collect()
     }
 
     /// Delete a child interpreter (and its command). Returns whether it existed.
@@ -1769,40 +1882,45 @@ impl Interp {
     /// If the child is currently executing (a self-deleting `exit`/`interp
     /// delete` from inside its own eval), the actual teardown is **deferred**:
     /// the command binding is removed now so the name stops dispatching, but the
-    /// boxed interp is freed only when its last eval unwinds
-    /// ([`with_child`]/[`eval_in_child`]) — never out from under the raw-pointer
-    /// eval still on the stack. Mirrors C's deferred `Tcl_DeleteInterp`.
+    /// interp handle is freed only when its last eval unwinds
+    /// ([`with_child`]/[`eval_in_child`]) — never while a re-entrant eval of it is
+    /// still on the stack. Mirrors C's deferred `Tcl_DeleteInterp`.
     ///
     /// [`with_child`]: Interp::with_child
     /// [`eval_in_child`]: Interp::eval_in_child
     pub(crate) fn delete_child(&mut self, name: &[u8]) -> bool {
-        match self.children.get_mut(name) {
-            Some(child) if child.eval_active > 0 => {
-                child.pending_delete = true;
-                self.namespaces.delete(GLOBAL, name);
-                true
+        // Classify under a short `children` borrow, then act (re-borrowing) so we
+        // never hold `children` across the `namespaces` mutation.
+        let disposition = {
+            let children = self.children.borrow();
+            match children.get(name) {
+                Some(child) if child.eval_active.get() > 0 => {
+                    child.pending_delete.set(true);
+                    Some(false) // busy: defer the removal
+                }
+                Some(_) => Some(true), // idle: remove now
+                None => None,
             }
-            Some(_) => {
-                self.children.remove(name);
-                self.namespaces.delete(GLOBAL, name);
-                true
-            }
+        };
+        match disposition {
             None => false,
+            Some(remove_now) => {
+                if remove_now {
+                    self.children.borrow_mut().remove(name);
+                }
+                self.namespaces.borrow_mut().delete(GLOBAL, name);
+                true
+            }
         }
     }
 
     /// Evaluate `script` in child interpreter `name`, copying its result/code
     /// back. `None`-returning if the child doesn't exist (caller raises).
     ///
-    /// The child stays in `self.children` and is evaluated through a raw
-    /// `*mut Interp` (its boxed address is heap-stable), so a parent command
-    /// invoked *during* this eval — via a child→parent alias — can re-enter the
-    /// same child (`interp invokehidden $child …`), which the Safe Base relies on.
-    /// The `parent` back-pointer is set for the eval and restored after.
+    /// Runs through [`with_child`](Self::with_child), so a parent command invoked
+    /// *during* this eval — via a child→parent alias — can re-enter the same child
+    /// (`interp invokehidden $child …`), which the Safe Base relies on.
     pub(crate) fn eval_in_child(&mut self, name: &[u8], script: &[u8]) -> Code {
-        // `with_child` runs the eval against the heap-stable boxed child through a
-        // raw pointer, marks it active (so a self-delete during the eval is
-        // deferred), and frees it here if a delete landed mid-eval.
         match self.with_child(name, |c| (c.eval_str(script), c.result_bytes())) {
             Some((code, result)) => {
                 self.set_result_bytes(&result);
@@ -1819,17 +1937,18 @@ impl Interp {
 
     /// Run a cross-interp alias (`ParentAlias`): invoke `target` (+ `prefix` +
     /// the call args) in this interp's *parent*, copying the parent's result
-    /// back. The raw `parent_ptr` deref models C's shared-`Tcl_Interp*` access;
-    /// re-entrancy (the parent calling `interp invokehidden $child …` back into
-    /// this child) is supported and only **bounded** by `MAX_CROSS_INTERP_DEPTH`
-    /// to cap native-stack growth.
+    /// back. The parent is reached by upgrading the `parent` `Weak` to an owned
+    /// `Interp` handle and dispatching through it — re-entrancy (the parent
+    /// calling `interp invokehidden $child …` back into this child) works via the
+    /// shared interior-mutable state and is only **bounded** by
+    /// `MAX_CROSS_INTERP_DEPTH` to cap native-stack growth.
     fn dispatch_parent_alias(
         &mut self,
         target: &[u8],
         prefix: &[Vec<u8>],
         argv: &[*mut TclObj],
     ) -> Code {
-        let Some(parent_ptr) = self.parent else {
+        let Some(parent_state) = self.parent.borrow().upgrade() else {
             return self.error(b"cannot invoke a parent alias from the root interpreter");
         };
         if CROSS_INTERP_DEPTH.with(|d| d.get()) >= MAX_CROSS_INTERP_DEPTH {
@@ -1849,11 +1968,9 @@ impl Interp {
             push_owned(&mut new_argv, a);
         }
         CROSS_INTERP_DEPTH.with(|d| d.set(d.get() + 1));
-        // SAFETY: `parent_ptr` addresses the (heap-stable, boxed) parent interp;
-        // the deref models C's shared-interp recursion. The depth counter bounds
-        // the native recursion, and refcounts on `new_argv` keep the args alive
-        // across the nested dispatch.
-        let parent = unsafe { &mut *parent_ptr };
+        // `parent` is an owned handle sharing the parent's `InterpState`; the
+        // dispatch mutates it through interior mutability (no aliased `&mut`).
+        let mut parent = Interp(parent_state);
         let code = parent.dispatch(&new_argv);
         let res = parent.result_bytes();
         CROSS_INTERP_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
@@ -1917,20 +2034,20 @@ impl Interp {
             return self.error(&proc_usage(usage_called, params));
         }
         // Recursion bound (catchable, not a stack overflow).
-        if self.recursion_depth >= RECURSION_LIMIT {
+        if self.recursion_depth.get() >= RECURSION_LIMIT {
             return self.error(b"too many nested evaluations (infinite loop?)");
         }
-        self.recursion_depth += 1;
+        self.recursion_depth.set(self.recursion_depth.get() + 1);
 
-        self.frames.push(ns);
+        self.frames.borrow_mut().push(ns);
         // Record the invocation words for `info level N`: the invoked name plus
         // the supplied arguments.
         let mut words = Vec::with_capacity(call_args.len() + 1);
         words.push(usage_called.to_vec());
         words.extend(call_args.iter().map(|&a| obj_bytes(a)));
-        self.frames.set_words(words);
-        let saved_ns = self.current_ns;
-        self.current_ns = ns;
+        self.frames.borrow_mut().set_words(words);
+        let saved_ns = self.current_ns.get();
+        self.current_ns.set(ns);
 
         // Pre-link a TclOO method's declared instance variables: each name in
         // the frame becomes a link to the object's namespace variable (`ns`), so
@@ -1959,15 +2076,15 @@ impl Interp {
                     }
                 }
             } else {
-                self.frames.pop();
-                self.current_ns = saved_ns;
-                self.recursion_depth -= 1;
+                self.frames.borrow_mut().pop();
+                self.current_ns.set(saved_ns);
+                self.recursion_depth.set(self.recursion_depth.get() - 1);
                 return self.error(&proc_usage(usage_called, params));
             };
             if stored.is_err() {
-                self.frames.pop();
-                self.current_ns = saved_ns;
-                self.recursion_depth -= 1;
+                self.frames.borrow_mut().pop();
+                self.current_ns.set(saved_ns);
+                self.recursion_depth.set(self.recursion_depth.get() - 1);
                 return self.error(b"proc parameter binding failed");
             }
         }
@@ -1993,16 +2110,16 @@ impl Interp {
             },
             file: meta.source,
             proc: meta.fqn.map(<[u8]>::to_vec),
-            level: self.frames.current_level(),
+            level: self.frames.borrow().current_level(),
             omit_level: false,
             line_base: meta.body_line_base,
             cmd: Vec::new(),
             line: 1,
         };
         let code = self.eval_framed(body, proc_frame);
-        self.frames.pop();
-        self.current_ns = saved_ns;
-        self.recursion_depth -= 1;
+        self.frames.borrow_mut().pop();
+        self.current_ns.set(saved_ns);
+        self.recursion_depth.set(self.recursion_depth.get() - 1);
         // Apply the return boundary (`return`/`return -code -level`), then a
         // bare `break`/`continue` that escaped the body (no enclosing loop) is an
         // error (C Tcl: `invoked "break" outside of a loop`).
@@ -2039,7 +2156,7 @@ impl Interp {
         let mut subs: Vec<Vec<u8>> = match (&cfg.subcommands, &cfg.map) {
             (Some(list), _) => list.clone(),
             (None, Some(map)) => map.iter().map(|(k, _)| k.clone()).collect(),
-            (None, None) => self.namespaces.exported_commands(cfg.ns),
+            (None, None) => self.namespaces.borrow().exported_commands(cfg.ns),
         };
         subs.sort();
         subs.dedup();
@@ -2069,7 +2186,7 @@ impl Interp {
                     .map(|(_, p)| p.clone())
             })
             .unwrap_or_else(|| {
-                let mut t = self.namespaces.qualified_name(cfg.ns);
+                let mut t = self.namespaces.borrow().qualified_name(cfg.ns);
                 if cfg.ns != GLOBAL {
                     t.extend_from_slice(b"::");
                 }
@@ -2105,7 +2222,8 @@ impl Interp {
     pub(crate) fn eval_math_call(&mut self, fname: &[u8], args: &[*mut TclObj]) -> Code {
         let mut full = b"::tcl::mathfunc::".to_vec();
         full.extend_from_slice(fname);
-        let Some(cmd) = self.namespaces.resolve(GLOBAL, &full) else {
+        let cmd = self.namespaces.borrow().resolve(GLOBAL, &full);
+        let Some(cmd) = cmd else {
             let mut m = b"invalid command name \"tcl::mathfunc::".to_vec();
             m.extend_from_slice(fname);
             m.push(b'"');
@@ -2134,7 +2252,8 @@ impl Interp {
     /// `[target, *prefix, *caller_tail]`, and invoke. Alias-of-alias chains fall
     /// out naturally (the resolved target may itself be an `Alias`).
     fn dispatch_alias(&mut self, target: &[u8], prefix: &[Vec<u8>], argv: &[*mut TclObj]) -> Code {
-        let Some(target_cmd) = self.namespaces.resolve(GLOBAL, target) else {
+        let target_cmd = self.namespaces.borrow().resolve(GLOBAL, target);
+        let Some(target_cmd) = target_cmd else {
             // Lazily bound: the target was deleted (or never existed).
             return self.invalid_command(target);
         };
@@ -2211,7 +2330,7 @@ impl Interp {
                             if code != Code::Ok {
                                 return Err(code);
                             }
-                            let r = self.result;
+                            let r = self.result.get();
                             // SAFETY: the interp result is live; take an owning +1.
                             unsafe { obj::incr_ref_count(r) };
                             return Ok(r);
@@ -2325,7 +2444,13 @@ impl Interp {
 
     /// Read a variable's value bytes via the variable resolver.
     fn read_var(&self, name: &[u8], index: Option<&[u8]>) -> Option<Vec<u8>> {
-        crate::vars::resolve_var_bytes(&self.frames, &self.namespaces, self.current_ns, name, index)
+        crate::vars::resolve_var_bytes(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            self.current_ns.get(),
+            name,
+            index,
+        )
     }
 
     fn no_such_variable(&mut self, name: &[u8], index: Option<&[u8]>) -> Code {
@@ -2380,13 +2505,22 @@ pub(crate) fn drop_fresh(obj: *mut TclObj) {
     }
 }
 
-impl Drop for Interp {
+impl Default for Interp {
+    fn default() -> Self {
+        Interp::new()
+    }
+}
+
+impl Drop for InterpState {
     fn drop(&mut self) {
-        // Release the result; the FrameStack field drops afterwards, releasing
-        // all variable refs. The command table holds no object refs.
+        // Runs when the last `Interp` handle to this state is dropped. Release
+        // the result; the `FrameStack` field drops afterwards, releasing all
+        // variable refs. The command table holds no object refs. Children are
+        // `Interp` handles (their own `Rc`s); the parent link is `Weak`, so the
+        // tree has no reference cycle to leak.
         // SAFETY: `result` is the interp's owned reference, dropped once.
-        unsafe { obj::decr_ref_count(self.result) };
-        self.result = core::ptr::null_mut();
+        unsafe { obj::decr_ref_count(self.result.get()) };
+        self.result.set(core::ptr::null_mut());
     }
 }
 

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -40,6 +40,7 @@ pub mod builtins;
 pub mod capi;
 pub mod cmd_alias;
 pub mod cmd_array;
+pub mod cmd_binary;
 pub mod cmd_chan;
 pub mod cmd_control;
 pub mod cmd_dict;

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -57,6 +57,7 @@ pub mod cmd_mathfunc;
 pub mod cmd_mathop;
 pub mod cmd_misc;
 pub mod cmd_namespace;
+pub mod cmd_oo;
 pub mod cmd_package;
 pub mod cmd_proc;
 pub mod cmd_scan;

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -502,10 +502,22 @@ impl Namespaces {
         let absolute = name.starts_with(b"::");
         let segments = split_qualifier(name);
         let (simple, ns_parts) = segments.split_last()?;
-        let mut ns = if absolute { GLOBAL } else { current };
-        for part in ns_parts {
-            ns = *self.arena[ns].children.get(*part)?;
-        }
+        // Walk the qualifier path from `start`, following child links.
+        let walk = |start: NsId| -> Option<NsId> {
+            let mut ns = start;
+            for part in ns_parts {
+                ns = *self.arena[ns].children.get(*part)?;
+            }
+            Some(ns)
+        };
+        // A relative qualifier resolves against the current namespace, falling
+        // back to the global namespace (C's `TclGetNamespaceForQualName`), so
+        // `tcl::build-info` from inside `::a::b` still finds `::tcl::build-info`.
+        let ns = if absolute {
+            walk(GLOBAL)?
+        } else {
+            walk(current).or_else(|| walk(GLOBAL))?
+        };
         Some((ns, simple))
     }
 }

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -404,6 +404,39 @@ impl Namespaces {
         self.arena[ns].children.values().copied().collect()
     }
 
+    /// `namespace delete name` — delete the namespace `qualified` resolves to
+    /// (relative to `current`), with its child namespaces, commands, and
+    /// variables. Returns `false` if it does not exist. The arena slot is
+    /// tombstoned (contents cleared, unlinked from its parent) rather than
+    /// removed, so the `NsId` indices of other namespaces stay valid.
+    pub fn delete_namespace(&mut self, current: NsId, qualified: &[u8]) -> bool {
+        let Some(ns) = self.find_namespace(current, qualified) else {
+            return false;
+        };
+        self.delete_subtree(ns);
+        // Unlink from the parent so the name no longer resolves.
+        if let Some(parent) = self.arena[ns].parent {
+            let name = std::mem::take(&mut self.arena[ns].name);
+            self.arena[parent].children.remove(&name);
+        }
+        true
+    }
+
+    /// Recursively clear a namespace and its descendants: dropping the `VarTable`
+    /// releases the variables' object references (`TclFreeVar`); commands and
+    /// child links are dropped.
+    fn delete_subtree(&mut self, ns: NsId) {
+        for child in self.children(ns) {
+            self.delete_subtree(child);
+        }
+        let n = &mut self.arena[ns];
+        n.children.clear();
+        n.commands.clear();
+        n.path.clear();
+        n.exports.clear();
+        n.vars = VarTable::default(); // drop → release variable refcounts
+    }
+
     /// The `(simple_name, source_fqn)` of every imported redirect in `ns`
     /// (`namespace forget` walks these).
     #[must_use]

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -96,6 +96,16 @@ pub struct Command<'s> {
     pub words: Vec<Word<'s>>,
     /// Offset to resume at for the following command (past the terminator).
     pub next: usize,
+    /// Byte offset of the command's first word in `src` — C's `commandStart`
+    /// (after leading whitespace). The 1-based source line of the command is
+    /// `1 + count('\n' in src[0..start])` (`TclLogCommandInfo`, the errorInfo
+    /// stack-trace line).
+    pub start: usize,
+    /// Byte offset of the command's terminator (`\n`/`;`) or end-of-script — the
+    /// command source slice is `src[start..end]`, which **keeps trailing
+    /// whitespace but excludes the terminator** (matches C's logged command
+    /// string: `"error boom   "` but not the trailing newline).
+    pub end: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -327,21 +337,39 @@ pub fn parse_script(src: &[u8]) -> Vec<Command<'_>> {
     let mut words: Vec<Word> = Vec::new();
     let mut word_toks: Vec<Token> = Vec::new();
     let mut expand = false;
+    // The command's first-word offset (`commandStart`), set at the first
+    // non-whitespace token of each command; `None` between commands.
+    let mut cmd_start: Option<usize> = None;
     for t in toks {
         match t.kind {
             TokenType::Sep => flush_word(&sm, src, &mut words, &mut word_toks, &mut expand),
             TokenType::Comment => {} // a comment is an empty command
-            TokenType::Expand => expand = true, // the next word is expanded
+            TokenType::Expand => {
+                expand = true; // the next word is expanded
+                cmd_start.get_or_insert(t.span.start() as usize);
+            }
             TokenType::Eol | TokenType::Eof => {
                 flush_word(&sm, src, &mut words, &mut word_toks, &mut expand);
                 if !words.is_empty() {
                     cmds.push(Command {
                         words: core::mem::take(&mut words),
                         next: t.span.end() as usize,
+                        start: cmd_start.take().unwrap_or(t.span.start() as usize),
+                        // The terminator (`\n`/`;`) or EOF position — its span
+                        // start is the first byte past the command's content, so
+                        // `src[start..end]` keeps trailing whitespace but drops
+                        // the terminator.
+                        end: t.span.start() as usize,
                     });
+                } else {
+                    cmd_start = None;
                 }
             }
-            _ => word_toks.push(t), // Esc / Str / Cmd / Var → part of the word
+            // Esc / Str / Cmd / Var → part of the word.
+            _ => {
+                cmd_start.get_or_insert(t.span.start() as usize);
+                word_toks.push(t);
+            }
         }
     }
     cmds
@@ -355,10 +383,15 @@ pub fn parse_command(src: &[u8], pos: usize) -> Command<'_> {
         return Command {
             words: Vec::new(),
             next: src.len(),
+            start: src.len(),
+            end: src.len(),
         };
     }
     let mut c = cmds.remove(0);
-    c.next += pos; // make the resume offset absolute
+    // Make the offsets absolute (they were computed against `src[pos..]`).
+    c.next += pos;
+    c.start += pos;
+    c.end += pos;
     c
 }
 
@@ -609,6 +642,43 @@ mod tests {
     fn comment_is_empty_command() {
         let c = parse_command(b"# this is a comment\n", 0);
         assert!(c.words.is_empty());
+    }
+
+    #[test]
+    fn command_source_slice_matches_c() {
+        // `src[start..end]` is the command string C logs in `::errorInfo`:
+        // leading whitespace dropped, trailing whitespace kept, terminator
+        // (`\n`/`;`) excluded. Verified byte-for-byte against tclsh 9.0.
+        fn slice(src: &[u8]) -> (usize, Vec<u8>) {
+            let cmds = parse_script(src);
+            let c = &cmds[0];
+            (c.start, src[c.start..c.end].to_vec())
+        }
+        // end-of-script: trailing space kept (the `[error deep ]` / `p ` cases).
+        assert_eq!(slice(b" error deep "), (1, b"error deep ".to_vec()));
+        // newline terminator excluded, no trailing space.
+        assert_eq!(slice(b"error boom\n    "), (0, b"error boom".to_vec()));
+        // trailing spaces before a newline terminator are kept.
+        assert_eq!(slice(b"error boom   \n"), (0, b"error boom   ".to_vec()));
+        // semicolon terminator excluded.
+        assert_eq!(slice(b"a b ; c d"), (0, b"a b ".to_vec()));
+        // a braced word: commandStart is at the `{`.
+        assert_eq!(
+            slice(b"  {} { error fromLambda }"),
+            (2, b"{} { error fromLambda }".to_vec())
+        );
+    }
+
+    #[test]
+    fn command_line_numbers_are_body_relative() {
+        // The 1-based line of a command = 1 + count('\n' in src[0..start]) —
+        // the `(procedure "p" line N)` line. A proc body starts right after the
+        // `{`, so this leading "\n" makes `error boom` land on line 3.
+        let body = b"\n    set x 1\n    error boom\n";
+        let cmds = parse_script(body);
+        let line = |start: usize| 1 + body[..start].iter().filter(|&&b| b == b'\n').count();
+        assert_eq!(line(cmds[0].start), 2); // `set x 1`
+        assert_eq!(line(cmds[1].start), 3); // `error boom`
     }
 
     #[test]

--- a/scripts/dev/rust_tcltest_sweep.py
+++ b/scripts/dev/rust_tcltest_sweep.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Run the Tcl 9 tcltest suite against the **Rust runtime** and score it.
+
+This is the Rust-runtime analogue of ``run_tcl9_tcltest_sweep.py`` (which
+drives the Zig/WASM backend). It runs each ``tmp/tcl9.0.3/tests/*.test`` file
+through the runtime's ``run_script`` example — which sources the file like
+``tclsh`` (``--init`` bootstraps ``init.tcl`` so the real ``tcltest`` package
+loads) — and parses tcltest's own summary line:
+
+    <file>: Total N Passed P Skipped S Failed F
+
+Per file we classify the outcome:
+
+  * ``pass``    — a summary with zero failures
+  * ``partial`` — a summary with some failures (P/Total reported)
+  * ``error``   — no summary: the file errored/crashed before cleanupTests
+  * ``timeout`` — exceeded the per-file cap
+
+Each file gets a generous timeout: these suites exercise things the runtime
+does not implement yet, so errors / hangs are expected and must not stop the
+sweep. The aggregate pass-rate is the **baseline** for the Rust runtime
+(``docs/design/runtime/rust-runtime-port.md`` scoreboard).
+
+Usage:
+    TCL_LIBRARY=tmp/tcl9.0.3/library python3 scripts/dev/rust_tcltest_sweep.py \
+        [--timeout S] [--json out.json] [files...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO / "tmp" / "tcl9.0.3" / "tests"
+LIBRARY = REPO / "tmp" / "tcl9.0.3" / "library"
+RUN_SCRIPT = REPO / "runtime" / "rust" / "target" / "release" / "examples" / "run_script"
+
+# tcltest's end-of-file summary, e.g.
+#   incr.test:	Total	69	Passed	61	Skipped	0	Failed	8
+SUMMARY_RE = re.compile(
+    r"Total\s+(\d+)\s+Passed\s+(\d+)\s+Skipped\s+(\d+)\s+Failed\s+(\d+)"
+)
+
+
+def run_one(test: Path, timeout_s: float) -> dict:
+    """Run one .test file through the runtime; return its scored outcome."""
+    try:
+        proc = subprocess.run(
+            [str(RUN_SCRIPT), "--init", str(test)],
+            env={
+                "TCL_LIBRARY": str(LIBRARY),
+                "PATH": "/usr/bin:/bin",
+            },
+            capture_output=True,
+            timeout=timeout_s,
+            cwd=str(TESTS_DIR),
+        )
+    except subprocess.TimeoutExpired:
+        return {"file": test.name, "status": "timeout"}
+
+    out = (proc.stdout + proc.stderr).decode("utf-8", "replace")
+    # The last summary line wins (a file may print several).
+    summary = None
+    for m in SUMMARY_RE.finditer(out):
+        summary = m
+    if summary:
+        total, passed, skipped, failed = (int(g) for g in summary.groups())
+        return {
+            "file": test.name,
+            "status": "pass" if failed == 0 else "partial",
+            "total": total,
+            "passed": passed,
+            "skipped": skipped,
+            "failed": failed,
+        }
+    # No summary: errored/crashed before cleanupTests. Capture the last line.
+    last = next(
+        (ln for ln in reversed(out.splitlines()) if ln.strip()), ""
+    )
+    return {"file": test.name, "status": "error", "reason": last[:120]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--timeout", type=float, default=20.0)
+    ap.add_argument("--json", type=Path, default=None)
+    ap.add_argument("files", nargs="*", help="specific .test files (default: all)")
+    args = ap.parse_args()
+
+    if not RUN_SCRIPT.exists():
+        print(
+            f"run_script not built: {RUN_SCRIPT}\n"
+            "  build: (cd runtime/rust && cargo build --release --example run_script)",
+            file=sys.stderr,
+        )
+        return 2
+
+    files = (
+        [TESTS_DIR / f for f in args.files]
+        if args.files
+        else sorted(TESTS_DIR.glob("*.test"))
+    )
+
+    results = []
+    agg_total = agg_passed = agg_failed = agg_skipped = 0
+    n_pass = n_partial = n_error = n_timeout = 0
+    for test in files:
+        r = run_one(test, args.timeout)
+        results.append(r)
+        st = r["status"]
+        if st in ("pass", "partial"):
+            agg_total += r["total"]
+            agg_passed += r["passed"]
+            agg_failed += r["failed"]
+            agg_skipped += r["skipped"]
+            n_pass += st == "pass"
+            n_partial += st == "partial"
+            mark = "OK " if st == "pass" else "PART"
+            print(
+                f"  {mark} {r['file']:<24} {r['passed']}/{r['total']}"
+                f" (skip {r['skipped']}, fail {r['failed']})"
+            )
+        elif st == "error":
+            n_error += 1
+            print(f"  ERR  {r['file']:<24} {r['reason']}")
+        else:
+            n_timeout += 1
+            print(f"  T/O  {r['file']:<24} (>{args.timeout}s)")
+
+    n_files = len(results)
+    print("\n=== Rust runtime — Tcl 9 tcltest baseline ===")
+    print(
+        f"files: {n_files}  "
+        f"(pass {n_pass}, partial {n_partial}, error {n_error}, timeout {n_timeout})"
+    )
+    pct = (100.0 * agg_passed / agg_total) if agg_total else 0.0
+    print(
+        f"tests: {agg_passed}/{agg_total} passed ({pct:.1f}%), "
+        f"{agg_failed} failed, {agg_skipped} skipped "
+        f"(across {n_pass + n_partial} files that ran to a summary)"
+    )
+
+    if args.json:
+        args.json.write_text(
+            json.dumps(
+                {
+                    "files": results,
+                    "aggregate": {
+                        "n_files": n_files,
+                        "n_pass": n_pass,
+                        "n_partial": n_partial,
+                        "n_error": n_error,
+                        "n_timeout": n_timeout,
+                        "tests_total": agg_total,
+                        "tests_passed": agg_passed,
+                        "tests_failed": agg_failed,
+                        "tests_skipped": agg_skipped,
+                    },
+                },
+                indent=2,
+            )
+        )
+        print(f"wrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This is a major milestone for the Rust runtime port, implementing the proc-call infrastructure (PC-2/PC-3 from the design doc) plus several substantial subsystems:

### Core proc/call machinery (PC-2/PC-3)
- **Proc execution model**: `Proc` command variant, `run_proc` with parameter binding, body evaluation, and `return` handling
- **Stack traces & error handling**: `CmdFrame` source-location stack (`info frame`), `ExceptionState` for incremental `errorInfo`/`errorCode` accumulation, `ProcFrame` for proc/lambda error frames
- **Call metadata**: `CallMeta` struct capturing proc FQN, source file, line base, and instance-variable linking for TclOO methods
- **Cross-interp recursion**: `CROSS_INTERP_DEPTH` counter and `MAX_CROSS_INTERP_DEPTH` bound for Safe Base's re-entrant parent⇄child calls

### TclOO object system (`cmd_oo.rs`)
- Classes with single/multiple superclasses, methods (including `forward`), constructor/destructor
- Instance variables (auto-linked into method frames via `CallMeta::link_vars`)
- Object creation (`new`/`create`), per-object definitions (`oo::objdefine`)
- Per-object and class mixins, method dispatch over linearized chain
- Method-context commands (`self`/`my`/`next`)
- `info object`/`info class` introspection
- `oo::copy` for object cloning

### Interpreter hierarchy & child interps
- `ChildInterp` command variant for child interpreter access (`$child eval …`)
- `interp create`, `interp eval`, `interp delete`, `interp exists`, `interp children`
- `interp hide`/`expose`/`invokehidden` for command visibility control
- `ParentAlias` for cross-interp aliases (child→parent delegation)
- `interp issafe` and `interp hidden` introspection

### Binary data handling (`cmd_binary.rs`)
- `binary format` and `binary scan` with format strings
- Type codes: `a`/`A` (bytes), `b`/`B` (binary digits), `h`/`H` (hex), `c`/`s`/`S`/`t`/`i`/`I`/`n`/`w`/`W`/`m` (signed ints), `f`/`r`/`R`/`d`/`q`/`Q` (floats)
- Position control: `x` (skip/zero), `X` (back up), `@` (absolute)
- Endianness support (little/big/native)

### Supporting changes
- **Interior mutability refactor**: `Interp` now wraps `Rc<InterpState>` with per-field `RefCell`/`Cell` for re-entrant access (no aliased `&mut`)
- **`ProcDef` enrichment**: `fqn`, `source`, `body_line_base` for proper `info frame` reporting
- **`Param` cloning**: Added `#[derive(Clone)]` for parameter reuse
- **String case modes**: Added `string totitle` via `CaseMode::Title`
- **File operations**: `file delete`, `file mkdir`, `file size`, `file type`, `file pathtype`, `file executable`
- **Namespace deletion**: `namespace delete` with proper cleanup
- **Channel borrowing**: Refactored channel ops to use `RefCell` and `ChanOp` enum for post-borrow result translation
- **Parse metadata**: `Command` struct now tracks `start` and `end` byte offsets for error reporting
- **Package registry**: Pre-registered `tcl::oo` and `TclOO` as built-in packages
- **Build info**: `::tcl::build-info` command for tcltest constraints
- **Test infrastructure**: Added `rust_tcltest_sweep.py` for scoring Tcl 9 test

https://claude.ai/code/session_01UX8gNRJfz5CzZ1xenNBMk5