### PR TITLE
Harden lsp_e2e suite: config injection, invariants, both backends

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=7277445-dirty
-head=72774454766a76f9f1e4c140088765c4d1367135
-date=2026-06-11T07:12:59Z
-fingerprint=6cb2708747fef40ef057ed7cf9abb35a707090a9a76f0529a9753d92d2738743
+describe=ea18ffe6-dirty
+head=ea18ffe62aae7a6d1fe10f106957b5bd04b390e5
+date=2026-06-11T10:05:06Z
+fingerprint=f92fe0ebf3f7cd214f9baa2202a2ae8c56b990cd586d8b01566c5440ee2b158d

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=bf3d2da-dirty
-head=bf3d2da2b0925707d93537e67c7e06b169a1a601
-date=2026-06-10T21:03:26Z
-fingerprint=0ddffa029c0c9378c8b885e1bf6a26505fbe9bd004b23920fd0cb0456a1e7fb3
+describe=f383aa18-dirty
+head=f383aa18702c0d41e28a158c14dabfd087f69ba0
+date=2026-06-11T08:44:18Z
+fingerprint=673fa51f0f46bfff2c1e1dfbb1e1fe72c1bc7b59969205c40f755062d0b99825

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,9 @@ ZIPAPP_EXPLORER_GUI     := $(BUILD_DIR)/tcl-lsp-explorer-gui-$(VERSION).pyz
 ZIPAPP_EXPLORER_GUI_CDN := $(BUILD_DIR)/tcl-lsp-explorer-gui-cdn-$(VERSION).pyz
 ZIPAPP_LSP     := $(BUILD_DIR)/tcl-lsp-server-$(VERSION).pyz
 ZIPAPP_AI      := $(BUILD_DIR)/tcl-lsp-ai-$(VERSION).pyz
+
+# Cargo build profile for the native Rust LSP server (rust-server target).
+PROFILE ?= release
 ZIPAPP_MCP     := $(BUILD_DIR)/tcl-lsp-mcp-server-$(VERSION).pyz
 ZIPAPP_WASM    := $(BUILD_DIR)/tcl-wasm-compiler-$(VERSION).pyz
 CLAUDE_SKILLS  := $(BUILD_DIR)/tcl-lsp-claude-skills-$(VERSION).zip
@@ -158,7 +161,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Top-level gates
 .PHONY: ci-fast check-all test-slow verify-test-slow-stamp prep-pr install-hooks
 # Tests
-.PHONY: test test-py test-wasm test-ext test-emacs test-zig test-rust test-vm test-opt test-fuzz test-fuzz-full test-fuzz-recovery fuzz fuzz-cov
+.PHONY: test test-py test-wasm test-ext test-emacs test-zig test-rust rust-server test-lsp-e2e test-lsp-e2e-rust test-vm test-opt test-fuzz test-fuzz-full test-fuzz-recovery fuzz fuzz-cov
 .PHONY: test-tclpkg test-tclpkg-tcl
 .PHONY: test-tcl9 test-tcl9-samples test-tcl9-full test-tcl9-vm-core test-tcl9-wasm-core check-tcl9-tcltest-io tcl9-triage
 .PHONY: refresh-tcl9-vm-core-baseline refresh-tcl9-wasm-core-baseline
@@ -277,6 +280,35 @@ format: format-py format-ts ## Format Python and TypeScript code
 test-py: $(UV_STAMP) ensure-python-test-deps $(RUNTIME_WASM) ## Run the Python test suite (excludes VM tcltest and fuzz campaign tests)
 	@echo "==> Running Python tests"
 	cd $(ROOT) && $(UV) run --extra dev pytest tests/ -q -n 4 --ignore-glob='*/test_vm_*_test.py' --ignore=tests/test_optimiser_coverage.py --ignore=tests/test_optimiser_vm_equivalence.py
+
+rust-server: ## Build the native Rust LSP server (PROFILE=release|debug) if a Rust workspace is present
+	@set -eu; \
+	if [ ! -f "$(ROOT)Cargo.toml" ]; then \
+		echo "==> No top-level Cargo.toml (native server lives on the rust branch) — nothing to build"; \
+		exit 0; \
+	fi; \
+	if ! command -v cargo >/dev/null 2>&1; then \
+		echo "ERROR: 'cargo' not found on PATH (need Rust 1.95+)."; exit 1; \
+	fi; \
+	echo "==> Building native tcl-lsp-server ($(PROFILE))"; \
+	cd $(ROOT) && cargo build -p tcl-lsp-server $(if $(filter release,$(PROFILE)),--release,); \
+	echo "==> Built $(ROOT)target/$(PROFILE)/tcl-lsp-server"
+
+test-lsp-e2e: $(UV_STAMP) ensure-python-test-deps $(ZIPAPP_LSP) ## Run the backend-neutral lsp_e2e suite against the Python server
+	@echo "==> Running lsp_e2e against the Python server"
+	cd $(ROOT) && TCL_LSP_SERVER_PYZ="$(ZIPAPP_LSP)" $(UV) run --extra dev pytest tests/lsp_e2e/ -q -p no:cacheprovider
+
+test-lsp-e2e-rust: $(UV_STAMP) ensure-python-test-deps ## Run the lsp_e2e suite against the native Rust server (TCL_LSP_SERVER_BIN or target/{release,debug})
+	@set -eu; \
+	BIN="$${TCL_LSP_SERVER_BIN:-$(ROOT)target/release/tcl-lsp-server}"; \
+	if [ ! -x "$$BIN" ]; then BIN="$(ROOT)target/debug/tcl-lsp-server"; fi; \
+	if [ ! -x "$$BIN" ]; then \
+		echo "ERROR: no native tcl-lsp-server binary — set TCL_LSP_SERVER_BIN or run 'make rust-server'."; \
+		exit 1; \
+	fi; \
+	echo "==> Running lsp_e2e against the Rust server ($$BIN)"; \
+	cd $(ROOT) && TCL_LSP_SERVER_KIND=rust TCL_LSP_SERVER_BIN="$$BIN" \
+		$(UV) run --extra dev pytest tests/lsp_e2e/ -q -p no:cacheprovider
 
 test-wasm: $(UV_STAMP) ensure-python-test-deps $(RUNTIME_WASM) ## Run the WASM codegen/runtime test suite (rebuilds the Zig runtime if its sources changed)
 	@echo "==> Running WASM tests against the Zig runtime"

--- a/docs/testing/lsp-e2e-hardening.md
+++ b/docs/testing/lsp-e2e-hardening.md
@@ -77,6 +77,15 @@ divergence to close in the native server, not test noise.
 - A clean dict/flow proc emits a native optimiser hint (`O129`) where Python is
   silent.
 
+### Server identity — `test_server_version.py`
+- `serverInfo.name` is `tcl-lsp-server` natively vs `tcl-lsp` on the Python
+  server (`test_server_info_name` fails in rust mode). Left strict — a genuine
+  identity divergence to harmonise in the native server, not a test artifact.
+- The packaged-version assertion is pyz-build plumbing (it checks the exact
+  Python zipapp build string), so it is relaxed for the native backend, which
+  reports its own Cargo version — only the dev-fallback regression is still
+  guarded there.
+
 `test_invariants_e2e.py` (range well-formedness + robustness) and the
 token-alignment edit-storm tests otherwise **pass** in rust mode — the native
 server's ranges are well-formed and it survives the adversarial corpus.

--- a/docs/testing/lsp-e2e-hardening.md
+++ b/docs/testing/lsp-e2e-hardening.md
@@ -1,0 +1,125 @@
+# Hardening the `lsp_e2e` integration suite
+
+`tests/lsp_e2e/` is the backend-neutral JSON-RPC integration suite: it drives a
+real language-server subprocess over the wire and asserts the *observable* LSP
+contract, so the same battery can certify either backend.
+
+## Running both backends
+
+```sh
+# Python reference server (default)
+make test-lsp-e2e
+#   == uv run --extra dev pytest tests/lsp_e2e/ -q -p no:cacheprovider
+
+# Native Rust server
+make rust-server                      # builds target/{release,debug}/tcl-lsp-server
+make test-lsp-e2e-rust                # or set TCL_LSP_SERVER_BIN explicitly
+#   == TCL_LSP_SERVER_KIND=rust TCL_LSP_SERVER_BIN=<bin> \
+#        uv run --extra dev pytest tests/lsp_e2e/ -q -p no:cacheprovider
+```
+
+Backend selection lives in `harness.py` (`server_kind()`, `native_server_bin()`,
+`server_launch_argv()`); `conftest._lsp_build` builds/locates the right artifact
+and fails fast in `rust` mode when no binary is present. The native server lives
+on the `rust` branch — on a `main`-based checkout `make rust-server` no-ops, and
+rust-mode runs are done by pointing `TCL_LSP_SERVER_BIN` at a binary built from a
+worktree of that branch.
+
+**Rule:** every test must pass against the Python reference server. Rust-mode
+failures are *recorded parity gaps* (below), never a reason to weaken an
+assertion.
+
+## What this hardening added
+
+| Area | File | What it pins |
+|------|------|--------------|
+| Feature toggles / effective config | `test_config_e2e.py` | `getEffectiveConfig` exposes a resolved `features` map; each toggleable provider returns empty when disabled and recovers; optimiser switch round-trips; formatting honours request indent; no sticky state |
+| Config injection | `harness.py` | `apply_configuration()` / `config_session()` drive `workspace/configuration` and settle on `getEffectiveConfig` with no sleeps; restore the full prior feature map |
+| Semantic-token invariants | `_lsp_helpers.semantic_token_violations`, `test_semantic_tokens_e2e.py::TestTokenInvariants` | ordered, **non-overlapping**, in-bounds, UTF-16-correct, legend-valid — over a representative + adversarial corpus |
+| Token alignment under edits | `test_edit_tracking_stress_e2e.py::TestTokenAlignmentUnderEdits` | multi-cursor rename / block-indent (one `didChange`, many edits), random storms checked at every settled checkpoint, multibyte UTF-16 tracking |
+| Diagnostic canaries | `test_diagnostics_e2e.py::TestDiagnosticCanaries` | matched fire/silent pairs for W210, W307, W220 + clean negative control |
+| Universal range/edit invariants | `_lsp_helpers.{iter_ranges,range_violations,workspace_edit_violations}`, `test_invariants_e2e.py` | every provider's `Range` is well-formed; rename/code-action edits are disjoint |
+| Robustness / adversarial | `test_invariants_e2e.py::TestRobustnessAdversarial` | unterminated delimiters, deep nesting, multibyte/emoji, CRLF, BOM, empty, large files never hang/crash or yield a bad span |
+
+### Bug found and fixed in the Python encoder
+
+The new token-overlap invariant caught a real off-by-one: a string ending
+immediately after an interpolation (`"$name"`) emitted the closing quote as a
+**2-wide** token over a 1-char quote, over-running the line (the
+"Overlapping semantic tokens detected" class). Fixed in
+`server/features/_semantic_tokens/_collect.py` (an empty completing `ESC`
+segment now renders as a single closing quote).
+
+## Recorded Rust-mode parity gaps
+
+Captured against a debug build of the `rust` branch
+(`8f550a5e`). These are the value of the both-backend gate — each is a real
+divergence to close in the native server, not test noise.
+
+### `getEffectiveConfig` / feature toggles — `test_config_e2e.py`
+- Native `getEffectiveConfig` returns `{}` (no `features`/`dialect`/scalars), so
+  **14/15** config tests fail: it honours no feature toggle and no optimiser
+  switch. This is the single biggest parity gap.
+
+### Semantic-token alignment — `test_semantic_tokens_e2e.py::TestTokenInvariants`
+- `unicode_after_var`: `token 4 overlaps previous token on line 1` — the native
+  encoder emits overlapping tokens around an interpolation followed by unicode.
+- dense single line (`...$b";# tail`): `token 6 overlaps previous` — the same
+  closing-quote-after-interpolation +1 the Python side was fixed for, still
+  present natively.
+
+### Diagnostics — `test_diagnostics_e2e.py::TestDiagnosticCanaries`
+- W210 read-before-set on a path merge and use-after-unset: **not emitted** by
+  the native dataflow.
+- W220 dead store: not emitted (fire case) / behaviour differs.
+- W307: **fires on the opaque dispatch target** `$self` where Python suppresses
+  it (a native false positive).
+- A clean dict/flow proc emits a native optimiser hint (`O129`) where Python is
+  silent.
+
+`test_invariants_e2e.py` (range well-formedness + robustness) and the
+token-alignment edit-storm tests otherwise **pass** in rust mode — the native
+server's ranges are well-formed and it survives the adversarial corpus.
+
+## VS Code ↔ `lsp_e2e` alignment
+
+The two suites are now intentionally complementary:
+
+- **`lsp_e2e`** owns the backend-neutral protocol contract (every provider, the
+  invariants above, both backends). It is the spec the Rust port must meet.
+- **VS Code** (`editors/vscode/src/test/`) owns the *client-integration* layer
+  that `lsp_e2e` cannot reach: middleware config resolution (editor-global
+  inheritance for tri-state toggles), command-palette wiring, snippet/grammar
+  registration, code-lens/inlay rendering through the VS Code API, and
+  multi-folder workspaces.
+
+Cases that previously lived **only** in the VS Code suite and are now mirrored
+in `lsp_e2e` so they bind both backends:
+
+- "Configuration Settings → disabling features.X" → `test_config_e2e.py`
+  (`getEffectiveConfig` shape + per-provider disable + optimiser round-trip).
+
+### Migration status of the in-process pytest suite
+
+`lsp_e2e` is the e2e home for protocol behaviour; the large in-process suites
+remain the authoritative *precision* oracles and are surfaced on the wire via
+thin canaries rather than wholesale duplication:
+
+- `tests/test_fp_*.py` + `tests/test_ground_truth_tn_fn.py` (locked to tclsh
+  9.0.3) stay in-process; `TestDiagnosticCanaries` certifies one case per family
+  reaches `publishDiagnostics`.
+- `tests/test_semantic_tokens.py` stays the exhaustive encoder oracle;
+  `TestTokenInvariants` certifies the wire output satisfies the universal
+  invariants on both backends.
+
+### Follow-ups
+
+- Route the full FP / ground-truth battery through the server under an env flag
+  so it certifies either backend end-to-end (not just the canaries).
+- A cross-backend parity meta-test that diffs Python vs Rust responses over the
+  corpus in one run (needs two server processes; today parity is enforced by
+  running the suite in both modes).
+- Statement / selection-range / symbol `end` columns include the line
+  terminator (end col = line length, +1 for CRLF `\r`); clients clamp it, so the
+  universal range check leaves strict end-column off by default. Worth tightening
+  in the range computation as a follow-up.

--- a/docs/testing/lsp-e2e-hardening.md
+++ b/docs/testing/lsp-e2e-hardening.md
@@ -134,8 +134,8 @@ suite. This is tracked here as a living matrix; the homes are:
 | Warnings `W1xx/W2xx/W3xx` | W100, W110, W128, W210, W211, W220, W302, W307 | the rest: add `_MATRIX` rows |
 | Info `I2xx` | I230 | |
 | Optimiser `O1xx` | const-fold (llength/expr) fire + no-fold negative | surfaced via `optimiseDocument`, not default diagnostics |
-| Shimmer `S1xx` | — TODO | needs specific shimmer patterns; ground-truth then add rows |
-| Taint `T1xx` | — TODO | needs iRules dialect + source/sink pairs; author against `lsp_server_irules` |
+| Shimmer `S1xx` | — TODO | S100–S102 exist but are gated off by default (`shimmer_enabled`); enable via `config_session` then ground-truth fire/silent |
+| Taint `IRULE3xxx` | IRULE3102 fire + silent (`test_irules_e2e.py::TestIrulesTaintDiagnostics`) | the deep-pass codes IRULE3001/3002 need a deep-diagnostics barrier; quick-fix geometry already covered by `TestIrulesTaintQuickFixes` |
 | Feature on/off | hover, completion, documentSymbols, definition, references, signatureHelp, folding, selectionRange, documentLinks | semanticTokens/codeActions/codeLens/inlayHints/rename/highlight: add to `_TOGGLEABLE_FEATURES` / probes |
 
 **To finish the matrix:** enumerate every code (the registry's

--- a/docs/testing/lsp-e2e-hardening.md
+++ b/docs/testing/lsp-e2e-hardening.md
@@ -112,6 +112,40 @@ thin canaries rather than wholesale duplication:
   `TestTokenInvariants` certifies the wire output satisfies the universal
   invariants on both backends.
 
+## Coverage requirement: positive + negative for every feature and every code
+
+The standing requirement is solid true/false (must-fire / must-stay-silent)
+coverage for **every** LSP server feature and **every** diagnostic / warning /
+info / optimisation / shimmer / taint code, in **both** `lsp_e2e` and the VS Code
+suite. This is tracked here as a living matrix; the homes are:
+
+- **Per code** — `test_diagnostic_matrix_e2e.py` holds the data-driven matrix
+  (`_MATRIX`): each `_Case(code, fire, silent)` row yields a positive and a
+  negative test automatically. Add a row per code.
+- **Per feature** — `test_config_e2e.py` pins each provider's positive
+  (enabled → result) and negative (disabled → empty) behaviour; the per-feature
+  *content* positives live in the feature-specific `test_*_e2e.py` files.
+
+### Status
+
+| Family | Positive+negative (lsp_e2e) | Notes |
+|--------|------------------------------|-------|
+| Errors `E0xx` | E002, E003 | extend `_MATRIX` per code |
+| Warnings `W1xx/W2xx/W3xx` | W100, W110, W128, W210, W211, W220, W302, W307 | the rest: add `_MATRIX` rows |
+| Info `I2xx` | I230 | |
+| Optimiser `O1xx` | const-fold (llength/expr) fire + no-fold negative | surfaced via `optimiseDocument`, not default diagnostics |
+| Shimmer `S1xx` | — TODO | needs specific shimmer patterns; ground-truth then add rows |
+| Taint `T1xx` | — TODO | needs iRules dialect + source/sink pairs; author against `lsp_server_irules` |
+| Feature on/off | hover, completion, documentSymbols, definition, references, signatureHelp, folding, selectionRange, documentLinks | semanticTokens/codeActions/codeLens/inlayHints/rename/highlight: add to `_TOGGLEABLE_FEATURES` / probes |
+
+**To finish the matrix:** enumerate every code (the registry's
+`diagnostic_codes()` is currently partial — many codes register lazily, so the
+authoritative list is the KCS catalogue under `docs/kcs/`), ground-truth a
+minimal fire/silent pair per code against the Python server, and add a `_MATRIX`
+row. Mirror the same fire/silent pairs in the VS Code suite for the
+client-integration path. Taint/shimmer rows need dialect setup and belong on the
+iRules fixture.
+
 ### Follow-ups
 
 - Route the full FP / ground-truth battery through the server under an env flag

--- a/editors/vscode/src/test/foldingRanges.test.ts
+++ b/editors/vscode/src/test/foldingRanges.test.ts
@@ -47,6 +47,29 @@ suite("Folding Ranges", () => {
     assert.ok(nsRange, "Should have a folding range covering the namespace block");
   });
 
+  test("backslash-continued command folds as one logical line (issue #541)", async () => {
+    await activate(docUri);
+
+    const ranges = (await vscode.commands.executeCommand(
+      "vscode.executeFoldingRangeProvider",
+      docUri,
+    )) as vscode.FoldingRange[];
+
+    assert.ok(ranges && ranges.length > 0, "Should have folding ranges");
+
+    // The continuation run `MyLongCommand $argument1 \ ... $argument3` spans the
+    // last three lines of the fixture (0-indexed 17..19).  Line-continuation
+    // folding was dropped by the folding rewrite and restored in #541, so a
+    // fold must cover that run.
+    const contRange = ranges.find((r) => r.start === 17 && r.end >= 19);
+    assert.ok(
+      contRange,
+      `Should fold the backslash-continued command (lines 17..19); got ${JSON.stringify(
+        ranges.map((r) => [r.start, r.end]),
+      )}`,
+    );
+  });
+
   test("all folding ranges have valid line numbers", async () => {
     await activate(docUri);
 

--- a/editors/vscode/src/test/inlayHints.test.ts
+++ b/editors/vscode/src/test/inlayHints.test.ts
@@ -68,4 +68,76 @@ suite("Inlay Hints", () => {
       await config.update("inlayHints", original, vscode.ConfigurationTarget.Global);
     }
   });
+
+  test("single positional binds the required slot, not the optional one (issue #510)", async () => {
+    const config = vscode.workspace.getConfiguration("tclLsp.features");
+    const original = config.get<boolean>("inlayHints", false);
+
+    try {
+      await config.update("inlayHints", true, vscode.ConfigurationTarget.Global);
+
+      // `puts ?-nonewline? ?channelId? string` — one positional argument binds
+      // to the required trailing `string`, never the leading optional
+      // `channelId` (the pre-#510 regression).  `?options?`/`?switches?`
+      // documentation placeholders are likewise never emitted.
+      const doc = await vscode.workspace.openTextDocument({
+        language: "tcl",
+        content: "puts hello\nlsearch $mylist needle\n",
+      });
+      await vscode.window.showTextDocument(doc);
+
+      const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
+      let hints: vscode.InlayHint[] | undefined;
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        hints = (await vscode.commands.executeCommand(
+          "vscode.executeInlayHintProvider",
+          doc.uri,
+          fullRange,
+        )) as vscode.InlayHint[] | undefined;
+        if (hints && hints.length > 0) {
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+
+      assert.ok(hints && hints.length > 0, "expected inlay hints with the feature enabled");
+
+      const labelText = (hint: vscode.InlayHint): string =>
+        typeof hint.label === "string" ? hint.label : hint.label.map((p) => p.value).join("");
+
+      // Parameter-kind hints on line 0 (`puts hello`).
+      const line0 = hints
+        .filter((h) => h.kind === vscode.InlayHintKind.Parameter && h.position.line === 0)
+        .map(labelText);
+      assert.ok(
+        line0.includes("string:"),
+        `expected 'string:' on line 0, got ${JSON.stringify(line0)}`,
+      );
+      assert.ok(
+        !line0.includes("channelId:"),
+        `'channelId:' must not be emitted for a single positional, got ${JSON.stringify(line0)}`,
+      );
+
+      // Parameter-kind hints on line 1 (`lsearch $mylist needle`): both real
+      // positionals are labelled and no `?options?`/`?switches?` placeholder.
+      const line1 = hints
+        .filter((h) => h.kind === vscode.InlayHintKind.Parameter && h.position.line === 1)
+        .map(labelText);
+      assert.ok(
+        line1.includes("list:"),
+        `expected 'list:' on line 1, got ${JSON.stringify(line1)}`,
+      );
+      assert.ok(
+        line1.includes("pattern:"),
+        `expected 'pattern:' on line 1, got ${JSON.stringify(line1)}`,
+      );
+      assert.ok(
+        !line1.some((l) => l === "options:" || l === "switches:"),
+        `documentation placeholders must not be labelled, got ${JSON.stringify(line1)}`,
+      );
+    } finally {
+      await config.update("inlayHints", original, vscode.ConfigurationTarget.Global);
+    }
+  });
 });

--- a/editors/vscode/testFixture/folding.tcl
+++ b/editors/vscode/testFixture/folding.tcl
@@ -13,3 +13,8 @@ namespace eval ::myns {
         return 42
     }
 }
+
+# A backslash-continued command (issue #541) folds as one logical line.
+MyLongCommand $argument1 \
+              $argument2 \
+              $argument3

--- a/server/features/_semantic_tokens/_collect.py
+++ b/server/features/_semantic_tokens/_collect.py
@@ -958,6 +958,15 @@ def _collect_tokens(
                 # (i.e. the token completed the quoted word).
                 if tok.in_quote:
                     rendered = '"' + tok.text
+                elif tok.text == "":
+                    # A completing segment with no text is *just* the closing
+                    # quote — the string ended immediately after an
+                    # interpolation (``"$name"`` / ``"a $b"``).  The token's
+                    # start already sits on that closing quote, so emitting
+                    # ``'"' + '' + '"'`` would double-count it: a 2-wide token
+                    # over the 1-char quote, over-running the line and tripping
+                    # the client's "overlapping semantic tokens" guard.
+                    rendered = '"'
                 else:
                     rendered = '"' + tok.text + '"'
             else:

--- a/tests/lsp_e2e/_lsp_helpers.py
+++ b/tests/lsp_e2e/_lsp_helpers.py
@@ -136,6 +136,119 @@ def decode_semantic_tokens(result: Any) -> list[dict]:
     return out
 
 
+def _looks_like_range(obj: Any) -> bool:
+    """True for an LSP ``Range`` dict: ``{start:{line,character}, end:{...}}``."""
+    if not isinstance(obj, dict):
+        return False
+    start, end = obj.get("start"), obj.get("end")
+    return (
+        isinstance(start, dict)
+        and isinstance(end, dict)
+        and "line" in start
+        and "character" in start
+        and "line" in end
+        and "character" in end
+    )
+
+
+def iter_ranges(obj: Any):
+    """Recursively yield every LSP ``Range`` dict nested anywhere in *obj*.
+
+    Walks arbitrary response shapes (Location, LocationLink, DocumentSymbol
+    trees, WorkspaceEdit, CodeAction, CompletionItem textEdits, …) so a single
+    invariant pass can validate every span a provider returns.
+    """
+    if _looks_like_range(obj):
+        yield obj
+        # A Range's children are leaf positions; no need to recurse into them.
+        return
+    if isinstance(obj, dict):
+        for value in obj.values():
+            yield from iter_ranges(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iter_ranges(item)
+
+
+def range_violations(
+    result: Any,
+    text: str,
+    *,
+    label: str = "",
+    strict_end_column: bool = False,
+) -> list[str]:
+    """Return well-formedness violations for every ``Range`` in *result* (empty == ok).
+
+    Universal across providers: a span a client acts on must have non-negative
+    coordinates, ``start <= end``, sit on real lines, and a ``start`` column
+    within its line (measured in **UTF-16** units, so a multibyte/emoji column
+    slip surfaces).
+
+    ``strict_end_column`` additionally requires the ``end`` column to be within
+    its line.  It defaults off because Tcl statement / selection-range / symbol
+    spans legitimately extend to the line terminator (``end`` = line length, or
+    +1 for a CRLF ``\\r``), which clients clamp; semantic tokens, which must
+    never over-run, are checked strictly via :func:`semantic_token_violations`.
+    """
+    out: list[str] = []
+    line_u16 = _doc_lines_utf16(text)
+    n_lines = len(line_u16)
+    pre = f"{label}: " if label else ""
+    for rng in iter_ranges(result):
+        s, e = rng["start"], rng["end"]
+        sl, sc, el, ec = s["line"], s["character"], e["line"], e["character"]
+        if min(sl, sc, el, ec) < 0:
+            out.append(f"{pre}negative coordinate in range {rng}")
+            continue
+        if (el, ec) < (sl, sc):
+            out.append(f"{pre}end before start in range {rng}")
+        # ``end`` may sit at (n_lines, 0) for a whole-document span; ``start``
+        # must be on a real line.
+        if sl >= n_lines:
+            out.append(f"{pre}start line {sl} past end of document ({n_lines} lines)")
+            continue
+        if el > n_lines:
+            out.append(f"{pre}end line {el} past end of document ({n_lines} lines)")
+        if sc > line_u16[sl]:
+            out.append(f"{pre}start col {sc} past line {sl} length {line_u16[sl]} (UTF-16)")
+        if strict_end_column and el < n_lines and ec > line_u16[el]:
+            out.append(f"{pre}end col {ec} past line {el} length {line_u16[el]} (UTF-16)")
+    return out
+
+
+def workspace_edit_violations(result: Any, *, label: str = "") -> list[str]:
+    """Return overlap/duplicate violations in a ``WorkspaceEdit`` (empty == ok).
+
+    A client applies the per-file ``TextEdit`` array as a batch; the LSP spec
+    forbids overlapping edits (the result is undefined) and a duplicate edit at
+    the same range is a sign of double-counting.  This pins both for rename and
+    code-action results.
+    """
+    out: list[str] = []
+    pre = f"{label}: " if label else ""
+    for uri, edits in rename_edits(result).items():
+        spans: list[tuple[tuple[int, int], tuple[int, int], str]] = []
+        for ed in edits:
+            rng = ed.get("range") or {}
+            s, e = rng.get("start") or {}, rng.get("end") or {}
+            spans.append(
+                (
+                    (s.get("line", 0), s.get("character", 0)),
+                    (e.get("line", 0), e.get("character", 0)),
+                    ed.get("newText", ""),
+                )
+            )
+        spans.sort()
+        for i in range(1, len(spans)):
+            prev_s, prev_e, prev_t = spans[i - 1]
+            cur_s, cur_e, cur_t = spans[i]
+            if cur_s == prev_s and cur_e == prev_e and cur_t == prev_t:
+                out.append(f"{pre}{uri}: duplicate edit at {cur_s}->{cur_e}")
+            elif cur_s < prev_e:
+                out.append(f"{pre}{uri}: overlapping edits {prev_s}->{prev_e} and {cur_s}->{cur_e}")
+    return out
+
+
 def _utf16_len(s: str) -> int:
     """Length of *s* in UTF-16 code units — the unit LSP positions are measured in.
 

--- a/tests/lsp_e2e/_lsp_helpers.py
+++ b/tests/lsp_e2e/_lsp_helpers.py
@@ -134,3 +134,88 @@ def decode_semantic_tokens(result: Any) -> list[dict]:
             {"line": line, "char": char, "length": length, "type": ttype, "modifiers": tmods}
         )
     return out
+
+
+def _utf16_len(s: str) -> int:
+    """Length of *s* in UTF-16 code units — the unit LSP positions are measured in.
+
+    A character outside the BMP (e.g. an emoji) is two UTF-16 units, so a token
+    encoder that counts code points instead of UTF-16 units drifts here.
+    """
+    return len(s.encode("utf-16-le")) // 2
+
+
+def _doc_lines_utf16(text: str) -> list[int]:
+    """Per-line content length in UTF-16 units (trailing ``\\r`` excluded).
+
+    Lines are split on ``\\n``; a trailing ``\\r`` (CRLF documents) is not part
+    of the visible line content the encoder positions tokens within.
+    """
+    return [_utf16_len(line.rstrip("\r")) for line in text.split("\n")]
+
+
+def semantic_token_violations(
+    result: Any,
+    text: str,
+    *,
+    token_types: list[str],
+    token_modifiers: list[str],
+) -> list[str]:
+    """Return a list of semantic-token *invariant* violations (empty == valid).
+
+    These are the properties a conforming server must satisfy for *any*
+    document, independent of which tokens it chooses to emit — the things a
+    client relies on and silently mis-renders (or logs "Overlapping semantic
+    tokens detected") when they break:
+
+    * the raw ``data`` is a flat run of 5-int groups;
+    * every delta is non-negative (the encoding requires ascending order);
+    * each ``tokenType`` index is within the advertised legend, and every
+      ``tokenModifiers`` bit maps to a legend entry;
+    * absolute tokens are strictly ordered and **non-overlapping** — on a line,
+      the next token starts at or after the previous token's end;
+    * every token lies within document bounds, measured in **UTF-16** units
+      (so a multibyte/emoji column slip surfaces as an over-run).
+    """
+    out: list[str] = []
+    data = (result or {}).get("data") if isinstance(result, dict) else None
+    if data is None:
+        return ["semanticTokens result has no `data` array"]
+    if len(data) % 5 != 0:
+        return [f"token data length {len(data)} is not a multiple of 5"]
+
+    n_types = len(token_types)
+    n_mods = len(token_modifiers)
+    for i in range(0, len(data), 5):
+        d_line, d_char, length, ttype, tmods = data[i : i + 5]
+        if d_line < 0 or d_char < 0:
+            out.append(f"token {i // 5}: negative delta (dline={d_line}, dchar={d_char})")
+        if length <= 0:
+            out.append(f"token {i // 5}: non-positive length {length}")
+        if not (0 <= ttype < n_types):
+            out.append(f"token {i // 5}: type index {ttype} outside legend (0..{n_types - 1})")
+        if tmods < 0 or (n_mods < 32 and tmods >> n_mods):
+            out.append(f"token {i // 5}: modifier bits {tmods:#b} outside legend ({n_mods} mods)")
+
+    line_u16 = _doc_lines_utf16(text)
+    n_lines = len(line_u16)
+    prev: dict | None = None
+    for idx, tok in enumerate(decode_semantic_tokens(result)):
+        line, char, length = tok["line"], tok["char"], tok["length"]
+        if line >= n_lines:
+            out.append(f"token {idx}: line {line} past end of document ({n_lines} lines)")
+        elif char + length > line_u16[line]:
+            out.append(
+                f"token {idx}: ends at utf16 col {char + length} but line {line} is "
+                f"{line_u16[line]} units long (multibyte/UTF-16 column drift?)"
+            )
+        if prev is not None:
+            if (line, char) < (prev["line"], prev["char"]):
+                out.append(f"token {idx}: starts before previous token (not ascending)")
+            elif line == prev["line"] and char < prev["char"] + prev["length"]:
+                out.append(
+                    f"token {idx}: overlaps previous token on line {line} "
+                    f"(starts {char}, previous ends {prev['char'] + prev['length']})"
+                )
+        prev = tok
+    return out

--- a/tests/lsp_e2e/conftest.py
+++ b/tests/lsp_e2e/conftest.py
@@ -10,14 +10,20 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import NamedTuple
 
 import pytest
 
-from .harness import ROOT, LspServerClient, ensure_build_info
+from .harness import (
+    ROOT,
+    LspServerClient,
+    ensure_build_info,
+    native_server_bin,
+    server_kind,
+    server_launch_argv,
+)
 
 
 class _Build(NamedTuple):
@@ -27,13 +33,18 @@ class _Build(NamedTuple):
 
 @pytest.fixture(scope="session")
 def _lsp_build() -> _Build:
-    """Bring the packaged LSP server zipapp up to date once, via ``make``.
+    """Bring the selected LSP server up to date once.
 
-    ``make zipapp-lsp`` regenerates ``shared/_build_info.py`` (a ``.FORCE``
-    prerequisite) and rebuilds ``build/tcl-lsp-server-<version>.pyz`` from
-    current sources.  Both the file name and the bundled build-info carry the
-    same ``git describe`` version, so we read it back and address the artifact
-    by its exact path rather than guessing from a glob.
+    ``TCL_LSP_SERVER_KIND=rust`` drives the native ``tcl-lsp-server`` binary
+    (located via :func:`native_server_bin`); the default ``python`` mode runs
+    ``make zipapp-lsp`` and drives the packaged zipapp.
+
+    For the python backend: ``make zipapp-lsp`` regenerates
+    ``shared/_build_info.py`` (a ``.FORCE`` prerequisite) and rebuilds
+    ``build/tcl-lsp-server-<version>.pyz`` from current sources.  Both the file
+    name and the bundled build-info carry the same ``git describe`` version, so
+    we read it back and address the artifact by its exact path rather than
+    guessing from a glob.
 
     When ``TCL_LSP_SERVER_PYZ`` points at an already-built zipapp (the runner
     builds it once before launching parallel pytest workers — see
@@ -41,6 +52,18 @@ def _lsp_build() -> _Build:
     re-running ``make zipapp-lsp`` concurrently against the same output path,
     and keeps the ci-fast gate fast.
     """
+    if server_kind() == "rust":
+        native = native_server_bin()
+        if native is None or not native.exists():
+            pytest.fail(
+                "TCL_LSP_SERVER_KIND=rust but no native tcl-lsp-server binary was "
+                "found — set TCL_LSP_SERVER_BIN or run `make rust-server` "
+                "(`cargo build -p tcl-lsp-server`)."
+            )
+        # The native server reports its own serverInfo.version; reuse the repo's
+        # build-info string for the version fixture (the strict version-match
+        # assertion is python-pyz-specific — see test_server_version).
+        return _Build(native, ensure_build_info())
     prebuilt = os.environ.get("TCL_LSP_SERVER_PYZ")
     if prebuilt:
         # Resolve to absolute: the server subprocess runs with cwd set to a
@@ -90,7 +113,7 @@ def lsp_server(
 ) -> Iterator[LspServerClient]:
     """Start and initialise one server from the pyz; tear it down at the end."""
     workspace = tmp_path_factory.mktemp("lsp-workspace")
-    client = LspServerClient([sys.executable, str(lsp_pyz)], cwd=workspace)
+    client = LspServerClient(server_launch_argv(lsp_pyz), cwd=workspace)
     client.start()
     client.initialize(root_uri=workspace.as_uri())
     try:
@@ -112,7 +135,7 @@ def lsp_server_irules(
     tests run against their own server so the main ``lsp_server`` stays Tcl.
     """
     workspace = tmp_path_factory.mktemp("lsp-irules-workspace")
-    client = LspServerClient([sys.executable, str(lsp_pyz)], cwd=workspace)
+    client = LspServerClient(server_launch_argv(lsp_pyz), cwd=workspace)
     client.start()
     client.initialize(root_uri=workspace.as_uri())
     try:
@@ -136,7 +159,7 @@ def lsp_server_inlay(
     """
     workspace = tmp_path_factory.mktemp("lsp-inlay-workspace")
     client = LspServerClient(
-        [sys.executable, str(lsp_pyz)],
+        server_launch_argv(lsp_pyz),
         cwd=workspace,
         tcllsp_config={"features": {"linkedEditingRange": True, "inlayHints": True}},
     )
@@ -161,7 +184,7 @@ def lsp_server_bigip(
     their own server rather than contaminating the plain-Tcl ``lsp_server``.
     """
     workspace = tmp_path_factory.mktemp("lsp-bigip-workspace")
-    client = LspServerClient([sys.executable, str(lsp_pyz)], cwd=workspace)
+    client = LspServerClient(server_launch_argv(lsp_pyz), cwd=workspace)
     client.start()
     client.initialize(root_uri=workspace.as_uri())
     try:

--- a/tests/lsp_e2e/conftest.py
+++ b/tests/lsp_e2e/conftest.py
@@ -121,6 +121,74 @@ def lsp_server_irules(
         client.shutdown()
 
 
+@pytest.fixture(scope="session")
+def lsp_server_inlay(
+    lsp_pyz: Path, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[LspServerClient]:
+    """A server with inlay hints enabled via ``workspace/configuration``.
+
+    Inlay hints are gated off by default (``inlay_hints_enabled``), and the
+    main ``lsp_server`` deliberately pins that default-off contract.  The inlay
+    *content* regressions (optional-positional labelling, issue #510) need the
+    provider switched on, so they run against this dedicated server whose
+    ``tclLsp`` config reply opts into ``features.inlayHints`` (keeping linked
+    editing on too, matching the default fixture).
+    """
+    workspace = tmp_path_factory.mktemp("lsp-inlay-workspace")
+    client = LspServerClient(
+        [sys.executable, str(lsp_pyz)],
+        cwd=workspace,
+        tcllsp_config={"features": {"linkedEditingRange": True, "inlayHints": True}},
+    )
+    client.start()
+    client.initialize(root_uri=workspace.as_uri())
+    try:
+        yield client
+    finally:
+        client.shutdown()
+
+
+@pytest.fixture(scope="session")
+def lsp_server_bigip(
+    lsp_pyz: Path, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[LspServerClient]:
+    """A server dedicated to F5 BIG-IP ``*.conf`` documents.
+
+    Opening a ``bigip.conf`` as a server's first document auto-switches the
+    whole process into the ``f5-bigip`` signature pack (and the BIG-IP
+    diagnostics/outline paths are URI-keyed on the canonical basename), so —
+    exactly like ``lsp_server_irules`` — these dialect-sensitive tests run on
+    their own server rather than contaminating the plain-Tcl ``lsp_server``.
+    """
+    workspace = tmp_path_factory.mktemp("lsp-bigip-workspace")
+    client = LspServerClient([sys.executable, str(lsp_pyz)], cwd=workspace)
+    client.start()
+    client.initialize(root_uri=workspace.as_uri())
+    try:
+        yield client
+    finally:
+        client.shutdown()
+
+
+@pytest.fixture
+def bigip_uri_factory(request: pytest.FixtureRequest):
+    """Fresh unique ``file://`` URIs whose basename is a canonical BIG-IP name.
+
+    The server routes BIG-IP handling on the basename (``bigip.conf``,
+    ``bigip_base.conf``, …), so the basename is fixed while the *directory* is
+    made unique per call — keeping the long-lived shared server from serving
+    one test a buffer another test left open.
+    """
+    safe = "".join(ch if ch.isalnum() else "_" for ch in request.node.nodeid)
+    counter = {"n": 0}
+
+    def make(basename: str = "bigip.conf") -> str:
+        counter["n"] += 1
+        return f"file:///bigip/{safe}_{counter['n']}/{basename}"
+
+    return make
+
+
 @pytest.fixture
 def uri_factory(request: pytest.FixtureRequest):
     """Return a callable producing a fresh, unique ``file://`` URI per call.

--- a/tests/lsp_e2e/harness.py
+++ b/tests/lsp_e2e/harness.py
@@ -77,9 +77,24 @@ class LspError(AssertionError):
 class LspServerClient:
     """Manage a language-server subprocess and talk LSP JSON-RPC to it."""
 
-    def __init__(self, argv: list[str], cwd: Path) -> None:
+    def __init__(
+        self,
+        argv: list[str],
+        cwd: Path,
+        *,
+        tcllsp_config: dict | None = None,
+    ) -> None:
         self._argv = argv
         self._cwd = cwd
+        #: Reply returned for the ``tclLsp`` section of ``workspace/configuration``.
+        #: Defaults to an editor that has opted into linked editing only (see
+        #: ``_auto_reply``); pass a richer dict to enable default-off features
+        #: such as inlay hints for a dedicated server fixture.
+        self._tcllsp_config: dict = (
+            tcllsp_config
+            if tcllsp_config is not None
+            else {"features": {"linkedEditingRange": True}}
+        )
         self._proc: subprocess.Popen[bytes] | None = None
         self._next_id = 0
         self._lock = threading.Lock()
@@ -643,15 +658,15 @@ class LspServerClient:
         method = msg.get("method", "")
         if method == "workspace/configuration":
             items = (msg.get("params") or {}).get("items") or []
-            # Reply per requested section.  For the ``tclLsp`` section, model an
-            # editor that has opted into the features the schema leaves off by
-            # default (linked editing inherits ``editor.linkedEditing``, which is
-            # off in VS Code) so those providers are exercised in e2e.  Every
-            # other section falls back to ``null`` (server defaults).
+            # Reply per requested section.  For the ``tclLsp`` section, return
+            # this client's configured payload — by default an editor that has
+            # opted into the features the schema leaves off (linked editing
+            # inherits ``editor.linkedEditing``, off in VS Code) so those
+            # providers are exercised in e2e; a dedicated fixture can pass a
+            # richer dict (e.g. ``features.inlayHints``).  Every other section
+            # falls back to ``null`` (server defaults).
             result: Any = [
-                {"features": {"linkedEditingRange": True}}
-                if (item or {}).get("section") == "tclLsp"
-                else None
+                self._tcllsp_config if (item or {}).get("section") == "tclLsp" else None
                 for item in items
             ]
         else:

--- a/tests/lsp_e2e/harness.py
+++ b/tests/lsp_e2e/harness.py
@@ -23,17 +23,67 @@ To write a test, take the ``lsp_server`` fixture and call ``request`` /
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 BUILD_INFO = ROOT / "shared" / "_build_info.py"
+
+# -- server selection (Python pyz vs native Rust binary) -------------------
+#
+# The same JSON-RPC battery can drive either backend.  ``TCL_LSP_SERVER_KIND``
+# selects which:
+#   * ``python`` (default) — the packaged ``tcl-lsp-server-<v>.pyz`` run under
+#     the current interpreter (the shipped Python LSP server).
+#   * ``rust``             — the native ``tcl-lsp-server`` binary, run directly
+#     over stdio.
+#
+# In ``rust`` mode the binary is located via ``TCL_LSP_SERVER_BIN`` (explicit
+# path) or discovered at ``target/{release,debug}/tcl-lsp-server`` under the
+# repo root (build it with ``make rust-server`` / ``cargo build -p
+# tcl-lsp-server``).  Keeping the selector here — rather than in conftest —
+# lets every fixture and any out-of-band script share one resolution rule.
+
+
+def server_kind() -> str:
+    """Return the selected LSP backend: ``"python"`` (default) or ``"rust"``."""
+    kind = os.environ.get("TCL_LSP_SERVER_KIND", "python").strip().lower()
+    return "rust" if kind in {"rust", "native"} else "python"
+
+
+def native_server_bin() -> Path | None:
+    """Resolve the native Rust ``tcl-lsp-server`` binary for ``rust`` mode.
+
+    Honours ``TCL_LSP_SERVER_BIN`` first, then a release/debug build under the
+    repo's ``target/``.  Returns ``None`` when nothing is built yet.
+    """
+    explicit = os.environ.get("TCL_LSP_SERVER_BIN")
+    if explicit:
+        return Path(explicit).resolve()
+    for profile in ("release", "debug"):
+        candidate = ROOT / "target" / profile / "tcl-lsp-server"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def server_launch_argv(server: Path) -> list[str]:
+    """Build the subprocess argv for *server*.
+
+    A native binary runs directly; a ``.pyz`` runs under the current
+    interpreter.
+    """
+    return [str(server)] if server_kind() == "rust" else [sys.executable, str(server)]
+
 
 # Used only when no build-info file has been generated yet (bare checkout /
 # before ``make build-info``); a value that is unmistakably not the "dev"
@@ -509,6 +559,90 @@ class LspServerClient:
             {"command": command, "arguments": arguments},
             timeout=timeout,
         )
+
+    # -- configuration injection ------------------------------------------
+
+    def effective_config(self, uri: str = "", *, timeout: float = 30.0) -> dict:
+        """Return the server's *resolved* config for ``uri`` (``getEffectiveConfig``).
+
+        This is the view the analyser/formatter actually applies — folder
+        override → workspace fallback → process default — so a test can assert
+        the server honoured a config change rather than sleeping on the
+        ``workspace/configuration`` round-trip.
+        """
+        result = self.execute_command("tcl-lsp.getEffectiveConfig", [uri], timeout=timeout)
+        return result if isinstance(result, dict) else {}
+
+    def apply_configuration(
+        self,
+        config: dict,
+        *,
+        settle: Callable[[dict], bool] | None = None,
+        settle_uri: str = "",
+        timeout: float = 30.0,
+    ) -> dict:
+        """Make the server adopt *config* as the ``tclLsp`` section, then settle.
+
+        Updates the reply this client returns for the ``tclLsp`` section of
+        ``workspace/configuration`` and notifies ``didChangeConfiguration`` so
+        the server re-pulls and re-applies.  The pull/apply is async, so this
+        blocks until ``getEffectiveConfig`` for ``settle_uri`` satisfies
+        *settle* (a predicate over the resolved config) — turning a config
+        change into a deterministic barrier with no wall-clock sleeps.
+
+        Returns the resolved config the server settled on.  Tests must
+        restore the prior config (or use a dedicated server fixture) to avoid
+        leaking state across the shared session — see ``config_session``.
+        """
+        self._tcllsp_config = config
+        # An empty/None ``settings`` payload makes the server fall through to a
+        # full ``workspace/configuration`` re-pull (see settings.register).
+        self.notify("workspace/didChangeConfiguration", {"settings": {}})
+        if settle is None:
+            return self.effective_config(settle_uri, timeout=timeout)
+        import time as _time
+
+        deadline = _time.monotonic() + timeout
+        last: dict = {}
+        while _time.monotonic() < deadline:
+            last = self.effective_config(settle_uri, timeout=timeout)
+            if settle(last):
+                return last
+            _time.sleep(0.05)
+        raise AssertionError(
+            f"config did not settle within {timeout}s; last effective config: {last!r}"
+        )
+
+    @contextlib.contextmanager
+    def config_session(
+        self,
+        config: dict,
+        *,
+        settle: Callable[[dict], bool] | None = None,
+        settle_uri: str = "",
+        timeout: float = 30.0,
+    ):
+        """Apply *config* for the duration of the ``with`` block, then restore.
+
+        Snapshots the current ``tclLsp`` reply, applies *config* (settling as
+        :meth:`apply_configuration` does), and on exit restores the prior reply
+        and re-pulls — so a feature-toggle test on the *shared* server cannot
+        leak its override into the next test.  The restore runs even if the
+        body raises.
+        """
+        previous = self._tcllsp_config
+        self.apply_configuration(config, settle=settle, settle_uri=settle_uri, timeout=timeout)
+        try:
+            yield self
+        finally:
+            self._tcllsp_config = previous
+            self.notify("workspace/didChangeConfiguration", {"settings": {}})
+            # Best-effort settle back: give the re-pull a moment to land so the
+            # next test starts from the restored defaults.
+            try:
+                self.effective_config(settle_uri, timeout=timeout)
+            except Exception:  # pragma: no cover - best effort
+                pass
 
     # -- push diagnostics --------------------------------------------------
 

--- a/tests/lsp_e2e/harness.py
+++ b/tests/lsp_e2e/harness.py
@@ -546,10 +546,17 @@ class LspServerClient:
         }
         return self.request("textDocument/selectionRange", params, timeout=timeout)
 
-    def formatting(self, uri: str, *, timeout: float = 30.0) -> Any:
+    def formatting(
+        self,
+        uri: str,
+        *,
+        tab_size: int = 4,
+        insert_spaces: bool = True,
+        timeout: float = 30.0,
+    ) -> Any:
         params = {
             "textDocument": {"uri": uri},
-            "options": {"tabSize": 4, "insertSpaces": True},
+            "options": {"tabSize": tab_size, "insertSpaces": insert_spaces},
         }
         return self.request("textDocument/formatting", params, timeout=timeout)
 
@@ -624,25 +631,52 @@ class LspServerClient:
     ):
         """Apply *config* for the duration of the ``with`` block, then restore.
 
-        Snapshots the current ``tclLsp`` reply, applies *config* (settling as
-        :meth:`apply_configuration` does), and on exit restores the prior reply
-        and re-pulls — so a feature-toggle test on the *shared* server cannot
-        leak its override into the next test.  The restore runs even if the
-        body raises.
+        Snapshots the prior ``tclLsp`` reply *and* the resolved feature/scalar
+        state, applies *config* (settling as :meth:`apply_configuration` does),
+        and on exit restores the prior reply and re-pulls — blocking until the
+        resolved config matches the pre-block snapshot again.  The settled
+        restore is what makes this safe on the *shared* server: a feature
+        toggled off here is provably back on before the next test queries it.
+        The restore runs even if the body raises.
         """
-        previous = self._tcllsp_config
+        before = self.effective_config(settle_uri, timeout=timeout)
+        before_features = before.get("features")
+        before_optimiser = before.get("optimiser_enabled")
         self.apply_configuration(config, settle=settle, settle_uri=settle_uri, timeout=timeout)
         try:
             yield self
         finally:
-            self._tcllsp_config = previous
-            self.notify("workspace/didChangeConfiguration", {"settings": {}})
-            # Best-effort settle back: give the re-pull a moment to land so the
-            # next test starts from the restored defaults.
-            try:
-                self.effective_config(settle_uri, timeout=timeout)
-            except Exception:  # pragma: no cover - best effort
-                pass
+            # A pulled config only *sets* the keys it carries — omitted keys keep
+            # their last-applied value (the server treats absent as "unchanged").
+            # So restoring the prior *reply* would leave a disabled toggle stuck
+            # off.  Re-assert the full prior resolved feature map (and optimiser
+            # switch) explicitly, then block until the resolved state matches the
+            # pre-block snapshot — the settled restore is what keeps the shared
+            # server clean for the next test.
+            undo: dict[str, Any] = {}
+            if isinstance(before_features, dict):
+                undo["features"] = dict(before_features)
+            if "optimiser" in config and isinstance(before_optimiser, bool):
+                undo["optimiser"] = {"enabled": before_optimiser}
+
+            def _restored(c: dict) -> bool:
+                if isinstance(before_features, dict) and c.get("features") != before_features:
+                    return False
+                if "optimiser" in config and c.get("optimiser_enabled") != before_optimiser:
+                    return False
+                return True
+
+            restored = self.apply_configuration(
+                undo, settle=_restored, settle_uri=settle_uri, timeout=timeout
+            )
+            # Surface a botched restore loudly rather than leaking into the
+            # next test on the shared server.
+            assert _restored(restored), (
+                "config_session failed to restore prior config: "
+                f"features={restored.get('features')!r} (want {before_features!r}), "
+                f"optimiser_enabled={restored.get('optimiser_enabled')!r} "
+                f"(want {before_optimiser!r})"
+            )
 
     # -- push diagnostics --------------------------------------------------
 

--- a/tests/lsp_e2e/test_bigip_e2e.py
+++ b/tests/lsp_e2e/test_bigip_e2e.py
@@ -1,0 +1,100 @@
+"""F5 BIG-IP ``*.conf`` handling, end-to-end against the packaged server.
+
+Two 1.11.0 fixes are pinned here against the real server, keyed on the
+canonical BIG-IP basename (``bigip.conf``, ``bigip_base.conf``, …):
+
+  #534 — the document outline must never emit an empty symbol ``name`` (VS Code
+         rejects the *entire* outline when any name is falsy);
+  #571 — the general Tcl analyser must never run on BIG-IP config text, so its
+         encrypted-string markers (``$M$…$``) are not mis-read as Tcl variable
+         references (W210) and no general Tcl diagnostics are published.
+
+These run on the dedicated ``lsp_server_bigip`` fixture: opening a BIG-IP conf
+switches the whole server's dialect, so it must not share the plain-Tcl server.
+"""
+
+from __future__ import annotations
+
+from ._lsp_helpers import flatten_symbols
+
+
+def _codes(diags) -> set[str]:
+    return {str(d.get("code")) for d in (diags or [])}
+
+
+# A representative BIG-IP config: nameless global singletons (which previously
+# produced empty outline names) plus a pool, plus an embedded iRule whose body
+# holds an encrypted-string marker the Tcl analyser would mis-read as ``$M``.
+_BIGIP_CONF = """\
+auth password-policy {
+    lockout-duration 10
+}
+net self-allow {
+    defaults {
+        tcp:443
+    }
+}
+sys diags ihealth {
+    user admin
+}
+ltm pool /Common/p1 {
+    members {
+        1.2.3.4:80 { }
+    }
+}
+ltm rule /Common/r {
+    when HTTP_REQUEST {
+        log local0. "$M$mn$9uYx+bTjLD8YSGZA="
+    }
+}
+"""
+
+
+class TestBigipDocumentOutline:
+    """Issue #534 — every outline symbol carries a non-empty name."""
+
+    def test_outline_symbols_all_have_non_empty_names(self, lsp_server_bigip, bigip_uri_factory):
+        uri = bigip_uri_factory()
+        lsp_server_bigip.open_document(uri, _BIGIP_CONF)
+        # The BIG-IP path doesn't emit the Tcl ``workspace_state.update`` marker,
+        # so wait on the published (BIG-IP) diagnostics instead of open_ready.
+        lsp_server_bigip.await_diagnostics(uri, version=1)
+        syms = lsp_server_bigip.document_symbols(uri) or []
+        names = [s.get("name") for s in flatten_symbols(syms)]
+        assert names, "expected a non-empty BIG-IP outline"
+        assert all(names), f"empty symbol name(s) in outline: {names!r}"
+
+    def test_nameless_singleton_falls_back_to_kind_label(self, lsp_server_bigip, bigip_uri_factory):
+        uri = bigip_uri_factory()
+        lsp_server_bigip.open_document(uri, _BIGIP_CONF)
+        lsp_server_bigip.await_diagnostics(uri, version=1)
+        names = {s.get("name") for s in flatten_symbols(lsp_server_bigip.document_symbols(uri))}
+        # The nameless ``auth password-policy`` singleton surfaces by its module
+        # / kind labels rather than an empty string.
+        assert "auth" in names, names
+
+
+class TestBigipDiagnosticSuppression:
+    """Issue #571 — no general Tcl diagnostics on BIG-IP config text."""
+
+    def test_encrypted_marker_does_not_raise_tcl_diagnostics(
+        self, lsp_server_bigip, bigip_uri_factory
+    ):
+        uri = bigip_uri_factory()
+        lsp_server_bigip.open_document(uri, _BIGIP_CONF)
+        diags = lsp_server_bigip.await_diagnostics(uri, version=1)
+        codes = _codes(diags)
+        # ``$M$…$`` would be a W210 (read-before-set) if analysed as Tcl; the
+        # whole W/E/S general-Tcl family must be absent on a BIG-IP conf.
+        assert "W210" not in codes, codes
+        assert not any(c.startswith(("W", "E", "S")) for c in codes), (
+            f"general Tcl diagnostics leaked on BIG-IP conf: {codes}"
+        )
+
+    def test_bare_set_arity_not_flagged_on_bigip_conf(self, lsp_server_bigip, bigip_uri_factory):
+        # A line that, as Tcl, is a bare ``set`` (E002 arity) — but here it is
+        # BIG-IP config text, so the Tcl arity checker must not fire.
+        uri = bigip_uri_factory()
+        lsp_server_bigip.open_document(uri, "ltm pool /Common/p { }\nset\n")
+        diags = lsp_server_bigip.await_diagnostics(uri, version=1)
+        assert "E002" not in _codes(diags), _codes(diags)

--- a/tests/lsp_e2e/test_commands_e2e.py
+++ b/tests/lsp_e2e/test_commands_e2e.py
@@ -35,6 +35,22 @@ class TestDocumentTransforms:
         assert result is not None
         assert "puts 3" in result["source"]
 
+    def test_minify_preserves_switch_braced_quoted_pattern_closers(self, lsp_server, uri_factory):
+        # Issue #540: ``iter_switch_case_list`` derived a braced ``{a b}`` /
+        # quoted ``"c d"`` pattern's end one char short, so the minifier dropped
+        # the closing ``}`` / ``"`` and re-emitted a truncated, unbalanced
+        # pattern (tclsh rejected the result with "missing close-brace").  The
+        # minified document must keep both patterns intact and stay balanced.
+        uri = uri_factory()
+        src = 'switch $x {\n  {a b} { puts one }\n  "c d" { puts two }\n  default { puts def }\n}\n'
+        lsp_server.open_ready(uri, src)
+        result = lsp_server.execute_command("tcl-lsp.minifyDocument", [uri, False, False, False])
+        assert result is not None
+        out = result["source"]
+        assert "{a b}" in out, out
+        assert '"c d"' in out, out
+        assert out.count("{") == out.count("}"), out
+
 
 class TestRegistryLookups:
     def test_describe_event_known(self, lsp_server):

--- a/tests/lsp_e2e/test_commands_e2e.py
+++ b/tests/lsp_e2e/test_commands_e2e.py
@@ -86,3 +86,70 @@ class TestDiagramAndConfig:
         data = lsp_server.execute_command("tcl-lsp.getEffectiveConfig", [uri])
         assert isinstance(data, dict)
         assert "dialect" in data
+
+
+# Commands advertised in ``executeCommandProvider`` that every conforming
+# backend must expose.  Side-effecting / environment-coupled commands
+# (tclpkg.*, bigipCleanup, writeRuleBack, renamePartition, tkPreview,
+# compilerExplorer, searchHelp, listRules — which read external files) are
+# exercised elsewhere or out of scope for a pure-protocol probe.
+_CORE_COMMANDS = {
+    "tcl-lsp.optimiseDocument",
+    "tcl-lsp.minifyDocument",
+    "tcl-lsp.fixAllSafeIssues",
+    "tcl-lsp.getEffectiveConfig",
+    "tcl-lsp.listSubcommands",
+    "tcl-lsp.describeIruleEvent",
+    "tcl-lsp.describeIruleCommand",
+    "tcl-lsp.listIruleEvents",
+    "tcl-lsp.diagramData",
+}
+
+
+class TestCommandSurface:
+    """The advertised ``executeCommand`` surface is present and well-shaped."""
+
+    def test_core_commands_are_advertised(self, lsp_server):
+        provider = lsp_server.initialize_result["capabilities"].get("executeCommandProvider") or {}
+        advertised = set(provider.get("commands") or [])
+        missing = _CORE_COMMANDS - advertised
+        assert not missing, f"executeCommandProvider missing core commands: {missing}"
+
+    def test_minify_compact_round_trip(self, lsp_server, uri_factory):
+        # Compact renaming shortens identifiers and reports the reverse map, so a
+        # name in the minified source resolves back to the original.
+        uri = uri_factory()
+        lsp_server.open_ready(
+            uri, "proc addNumbers {a b} { return [expr {$a + $b}] }\naddNumbers 1 2\n"
+        )
+        result = lsp_server.execute_command("tcl-lsp.minifyDocument", [uri, True, False, False])
+        assert result is not None
+        assert result["minifiedLength"] < result["originalLength"]
+        assert "addNumbers" not in result["source"], result["source"]
+        assert "addNumbers" in result["symbolMap"], result["symbolMap"]
+
+    def test_list_subcommands_shape(self, lsp_server):
+        data = lsp_server.execute_command("tcl-lsp.listSubcommands", ["string"])
+        assert data["command"] == "string"
+        names = {s["name"] for s in data["subcommands"]}
+        assert {"length", "range", "map"} <= names, names
+
+    def test_list_subcommands_unknown_is_empty(self, lsp_server):
+        data = lsp_server.execute_command(
+            "tcl-lsp.listSubcommands", ["definitely_not_a_command_zzz"]
+        )
+        assert data["subcommands"] == []
+
+    def test_list_known_packages_shape(self, lsp_server):
+        data = lsp_server.execute_command("tcl-lsp.listKnownPackages", [])
+        assert isinstance(data.get("packages"), list)
+
+    def test_suggest_packages_for_symbol_shape(self, lsp_server):
+        data = lsp_server.execute_command("tcl-lsp.suggestPackagesForSymbol", ["json::write"])
+        assert data["symbol"] == "json::write"
+        assert isinstance(data.get("suggestions"), list)
+
+    def test_export_config_writes_a_file(self, lsp_server):
+        data = lsp_server.execute_command("tcl-lsp.exportConfig", [])
+        assert data.get("success") is True
+        assert data.get("path")

--- a/tests/lsp_e2e/test_config_e2e.py
+++ b/tests/lsp_e2e/test_config_e2e.py
@@ -1,0 +1,238 @@
+"""Effective-config + per-feature toggles, end-to-end against the packaged server.
+
+The single biggest hole in the suite was that *no* e2e test drove the
+``workspace/configuration`` path: ``getEffectiveConfig`` was only checked for
+``"dialect" in data``, so a server that silently ignores every feature toggle
+passed.  The VS Code suite ("Configuration Settings → disabling features.X")
+covers this and is what exposed that the native server's ``getEffectiveConfig``
+returns only ``{uri, dialect}`` and honours no toggles.
+
+These tests mirror that contract over raw JSON-RPC so it is enforced against
+*both* backends:
+
+  * ``getEffectiveConfig`` exposes a resolved ``features`` map (plus dialect,
+    line length, optimiser switch);
+  * with a provider's feature disabled, that provider returns empty/None;
+  * the optimiser master switch round-trips through both ``getEffectiveConfig``
+    and observable behaviour;
+  * formatting honours the request's indent width;
+  * a toggle flipped off and back on leaves no sticky state.
+
+Config is injected through the harness ``config_session`` helper, which updates
+the ``tclLsp`` ``workspace/configuration`` reply, notifies
+``didChangeConfiguration``, settles on ``getEffectiveConfig`` (no sleeps), and
+restores the prior config on exit so the shared server is never left mutated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Feature toggles whose handler must return empty/None when disabled.  Keyed by
+# the camelCase ``tclLsp.features.*`` name (the key ``getEffectiveConfig``
+# reports and ``apply_configuration`` injects).
+_TOGGLEABLE_FEATURES = [
+    "hover",
+    "completion",
+    "documentSymbols",
+    "definition",
+    "references",
+    "signatureHelp",
+    "folding",
+    "selectionRange",
+    "documentLinks",
+]
+
+
+def _is_empty(result) -> bool:
+    """LSP "no result": ``None``, an empty list, or an empty completion list."""
+    if result is None:
+        return True
+    if isinstance(result, list):
+        return len(result) == 0
+    if isinstance(result, dict):
+        # CompletionList / SelectionRange-style payloads.
+        if "items" in result:
+            return len(result["items"]) == 0
+        return len(result) == 0
+    return False
+
+
+class TestEffectiveConfigShape:
+    def test_reports_resolved_feature_map(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "set x 1\n")
+        cfg = lsp_server.effective_config(uri)
+        assert isinstance(cfg, dict)
+        # The resolved feature map must be present and cover the toggles the
+        # editor namespace advertises — a server returning only {uri, dialect}
+        # fails here.
+        features = cfg.get("features")
+        assert isinstance(features, dict), cfg
+        missing = [k for k in _TOGGLEABLE_FEATURES if k not in features]
+        assert not missing, f"effective config missing feature keys {missing}: {features}"
+        assert all(isinstance(v, bool) for v in features.values()), features
+
+    def test_reports_dialect_and_scalars(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "set x 1\n")
+        cfg = lsp_server.effective_config(uri)
+        assert isinstance(cfg.get("dialect"), str) and cfg["dialect"], cfg
+        assert isinstance(cfg.get("line_length"), int), cfg
+        assert isinstance(cfg.get("optimiser_enabled"), bool), cfg
+
+
+# --------------------------------------------------------------------------- #
+# Per-provider disable contract — one case per toggleable feature.
+# --------------------------------------------------------------------------- #
+
+
+def _probe(lsp_server, uri: str, feature: str):
+    """Open a document that yields a non-empty result for *feature* and query it.
+
+    Returns ``(result, query)`` where ``query`` re-runs the same request, so a
+    test can compare the enabled baseline against the disabled re-query without
+    reopening the document (handlers read the feature toggle at request time).
+    """
+    if feature == "hover":
+        lsp_server.open_ready(uri, "puts hello\n")
+        return lambda: lsp_server.hover(uri, 0, 2)
+    if feature == "completion":
+        lsp_server.open_ready(uri, "pu")
+        return lambda: lsp_server.completion(uri, 0, 2)
+    if feature == "documentSymbols":
+        lsp_server.open_ready(uri, "proc greet {} { return }\n")
+        return lambda: lsp_server.document_symbols(uri)
+    if feature == "definition":
+        lsp_server.open_ready(uri, 'proc greet {name} { puts "Hello $name" }\ngreet World\n')
+        return lambda: lsp_server.definition(uri, 1, 2)
+    if feature == "references":
+        lsp_server.open_ready(uri, 'proc greet {name} { puts "Hello $name" }\ngreet World\n')
+        return lambda: lsp_server.references(uri, 0, 6)
+    if feature == "signatureHelp":
+        lsp_server.open_ready(uri, "proc greet {name greeting} { return }\ngreet World\n")
+        return lambda: lsp_server.signature_help(uri, 1, 12)
+    if feature == "folding":
+        lsp_server.open_ready(uri, "proc greet {} {\n    set x 1\n    return $x\n}\n")
+        return lambda: lsp_server.folding_range(uri)
+    if feature == "selectionRange":
+        lsp_server.open_ready(uri, "proc greet {} {\n    set x 1\n    return $x\n}\n")
+        return lambda: lsp_server.selection_range(uri, [(2, 11)])
+    if feature == "documentLinks":
+        lsp_server.open_ready(uri, "source other.tcl\nputs done\n")
+        return lambda: lsp_server.document_links(uri)
+    raise AssertionError(f"no probe for feature {feature!r}")
+
+
+@pytest.mark.parametrize("feature", _TOGGLEABLE_FEATURES)
+def test_disabling_feature_suppresses_its_provider(feature, lsp_server, uri_factory):
+    uri = uri_factory()
+    query = _probe(lsp_server, uri, feature)
+
+    # Baseline: the provider produces a non-empty result with defaults on, so
+    # the disabled assertion below is meaningful (not vacuously empty).
+    baseline = query()
+    assert not _is_empty(baseline), f"{feature}: expected a non-empty baseline, got {baseline!r}"
+
+    # Disable just this feature; settle on the effective-config reflecting it.
+    with lsp_server.config_session(
+        {"features": {feature: False}},
+        settle=lambda c: c.get("features", {}).get(feature) is False,
+        settle_uri=uri,
+    ):
+        disabled = query()
+        assert _is_empty(disabled), (
+            f"{feature}: provider must return empty/None when disabled, got {disabled!r}"
+        )
+
+    # config_session restored the prior config — the provider works again.
+    assert not _is_empty(query()), f"{feature}: provider did not recover after re-enable"
+
+
+# --------------------------------------------------------------------------- #
+# Optimiser master switch — round-trips through getEffectiveConfig + behaviour.
+# --------------------------------------------------------------------------- #
+
+
+class TestOptimiserToggle:
+    def test_optimiser_disable_round_trips(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        # ``llength`` of a literal list folds to a constant — an O1xx optimiser
+        # offer when the optimiser is on.
+        lsp_server.open_ready(uri, "puts [llength [list a b c]]\n")
+
+        on = lsp_server.effective_config(uri)
+        assert on.get("optimiser_enabled") is True, on
+        offers_on = lsp_server.execute_command("tcl-lsp.optimiseDocument", [uri, "full"])
+        assert offers_on and "puts 3" in offers_on.get("source", ""), offers_on
+
+        with lsp_server.config_session(
+            {"optimiser": {"enabled": False}},
+            settle=lambda c: c.get("optimiser_enabled") is False,
+            settle_uri=uri,
+        ):
+            off = lsp_server.effective_config(uri)
+            assert off.get("optimiser_enabled") is False, off
+
+        # Restored.
+        assert lsp_server.effective_config(uri).get("optimiser_enabled") is True
+
+
+# --------------------------------------------------------------------------- #
+# Formatting honours the request's indent width.
+# --------------------------------------------------------------------------- #
+
+
+class TestFormattingIndentRoundTrip:
+    """The formatter must honour the LSP request's ``tabSize``.
+
+    ``getEffectiveConfig`` does not surface formatter settings, and an explicit
+    ``FormattingOptions.tabSize`` from the client overrides the server's
+    ``formatting.indentSize`` config by LSP contract — so the observable
+    round-trip is request-options → output indent width.
+    """
+
+    SRC = "proc f {} {\nputs hi\n}\n"
+
+    @staticmethod
+    def _body_indent(formatted: str) -> str:
+        for line in formatted.splitlines():
+            if line.lstrip().startswith("puts"):
+                return line[: len(line) - len(line.lstrip())]
+        raise AssertionError(f"no `puts` body line in {formatted!r}")
+
+    def test_two_space_indent(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, self.SRC)
+        edits = lsp_server.formatting(uri, tab_size=2, insert_spaces=True) or []
+        assert edits, "expected formatting edits"
+        assert self._body_indent(edits[0]["newText"]) == "  "
+
+    def test_four_space_indent(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, self.SRC)
+        edits = lsp_server.formatting(uri, tab_size=4, insert_spaces=True) or []
+        assert edits, "expected formatting edits"
+        assert self._body_indent(edits[0]["newText"]) == "    "
+
+
+# --------------------------------------------------------------------------- #
+# No sticky state across a disable/enable cycle on the shared server.
+# --------------------------------------------------------------------------- #
+
+
+class TestToggleNoStickyState:
+    def test_repeated_cycles_keep_provider_working(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "puts hello\n")
+
+        for _ in range(2):
+            assert lsp_server.hover(uri, 0, 2) is not None
+            with lsp_server.config_session(
+                {"features": {"hover": False}},
+                settle=lambda c: c.get("features", {}).get("hover") is False,
+                settle_uri=uri,
+            ):
+                assert _is_empty(lsp_server.hover(uri, 0, 2))
+            # Restored each iteration; never stuck off.
+            assert lsp_server.hover(uri, 0, 2) is not None

--- a/tests/lsp_e2e/test_diagnostic_matrix_e2e.py
+++ b/tests/lsp_e2e/test_diagnostic_matrix_e2e.py
@@ -1,0 +1,150 @@
+"""Data-driven diagnostic matrix: a must-fire / must-stay-silent pair per code.
+
+The goal (tracked in ``docs/testing/lsp-e2e-hardening.md``) is solid positive
+*and* negative coverage for every diagnostic / warning / info / optimisation /
+shimmer / taint code, on the wire, on both backends.  This file is the
+extensible home for that matrix: add a ``_Case`` row and you get a positive test
+(the code fires for ``fire``) and a negative test (it stays silent for
+``silent``) for free, each locked to the server's published diagnostics.
+
+Every pair here is ground-truthed against the Python reference server.  The
+``silent`` snippet is the *minimal* edit that removes the defect, so the pair
+also proves the diagnostic is specific (it doesn't fire on the corrected form).
+
+Codes that need dialect / sink context to fire — the taint (T1xx) and shimmer
+(S1xx) families (iRules dialect + specific sources/sinks) and the optimiser
+O-codes (surfaced through ``optimiseDocument``, not default diagnostics) — are
+covered separately (see ``TestOptimisationMatrix`` and the iRules suite) and
+tracked as follow-ups in the hardening doc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass(frozen=True)
+class _Case:
+    code: str
+    fire: str  # source that MUST raise ``code``
+    silent: str  # the corrected source that MUST NOT raise ``code``
+    note: str = ""
+
+
+# One row per code.  Bodies are wrapped in a proc where a bare top-level ``set``
+# would otherwise add incidental W211/W220 noise.
+_MATRIX: list[_Case] = [
+    _Case(
+        "E002",
+        "set\n",
+        "set x 1\nputs $x\n",
+        "wrong arg count (too few)",
+    ),
+    _Case(
+        "E003",
+        "string length a b c\n",
+        "string length abc\n",
+        "too many arguments to a subcommand",
+    ),
+    _Case(
+        "W100",
+        "proc p {a} {\n    if $a { puts x }\n}\n",
+        "proc p {a} {\n    if {$a} { puts x }\n}\n",
+        "unbraced expr",
+    ),
+    _Case(
+        "W110",
+        'proc p {x} {\n    if {$x == "foo"} { return 1 }\n    return 0\n}\n',
+        'proc p {x} {\n    if {$x eq "foo"} { return 1 }\n    return 0\n}\n',
+        "== string comparison (use eq)",
+    ),
+    _Case(
+        "W211",
+        "proc p {} {\n    set x 1\n    return 0\n}\n",
+        "proc p {} {\n    set x 1\n    return $x\n}\n",
+        "variable set but never read",
+    ),
+    _Case(
+        "W220",
+        "proc p {} {\n    set x 1\n    set x 2\n    return $x\n}\n",
+        "proc p {} {\n    set x 1\n    puts $x\n    set x 2\n    return $x\n}\n",
+        "dead store (overwritten before read)",
+    ),
+    _Case(
+        "W210",
+        "proc p {x} {\n    if {$x} {\n        set y 1\n    }\n    return $y\n}\n",
+        "proc p {x} {\n    if {$x} {\n        set y 1\n    } else {\n        set y 2\n    }\n    return $y\n}\n",
+        "read of a possibly-unset variable",
+    ),
+    _Case(
+        "W302",
+        "catch {error e}\n",
+        "catch {error e} result\n",
+        "catch without a result variable",
+    ),
+    _Case(
+        "I230",
+        "proc p {} {\n    if {1} { return 1 }\n    return 0\n}\n",
+        "proc p {cond} {\n    if {$cond} { return 1 }\n    return 0\n}\n",
+        "constant condition",
+    ),
+]
+
+
+def _diags_for(lsp_server, uri_factory, source):
+    return lsp_server.open_ready(uri_factory(), source)
+
+
+def _codes(diags) -> set[str]:
+    return {str(d.get("code")) for d in diags}
+
+
+@pytest.mark.parametrize("case", _MATRIX, ids=lambda c: c.code)
+def test_code_fires_on_defect(case: _Case, lsp_server, uri_factory):
+    diags = _diags_for(lsp_server, uri_factory, case.fire)
+    matching = [d for d in diags if str(d.get("code")) == case.code]
+    assert matching, f"{case.code} ({case.note}) must fire on:\n{case.fire}\ngot {_codes(diags)}"
+    # Severity is a valid LSP value, and an ``E``-prefixed code is an Error.
+    sev = matching[0].get("severity")
+    assert sev in (1, 2, 3, 4), f"{case.code}: invalid severity {sev}"
+    if case.code.startswith("E"):
+        assert sev == 1, f"{case.code} is an error code but severity={sev}"
+
+
+@pytest.mark.parametrize("case", _MATRIX, ids=lambda c: c.code)
+def test_code_silent_on_corrected_form(case: _Case, lsp_server, uri_factory):
+    diags = _diags_for(lsp_server, uri_factory, case.silent)
+    assert case.code not in _codes(diags), (
+        f"{case.code} ({case.note}) must NOT fire on the corrected form:\n"
+        f"{case.silent}\ngot {_codes(diags)}"
+    )
+
+
+class TestOptimisationMatrix:
+    """Optimiser offers (O-codes) surface through ``optimiseDocument``.
+
+    Positive: a foldable construct yields the folded source.  Negative: code
+    with nothing to fold is returned unchanged.
+    """
+
+    def test_constant_llength_folds(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "puts [llength [list a b c]]\n")
+        result = lsp_server.execute_command("tcl-lsp.optimiseDocument", [uri, "full"])
+        assert "puts 3" in result["source"], result["source"]
+
+    def test_constant_expr_folds(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "proc p {} { return [expr {1 + 2}] }\n")
+        result = lsp_server.execute_command("tcl-lsp.optimiseDocument", [uri, "full"])
+        assert "return 3" in result["source"], result["source"]
+
+    def test_nothing_to_fold_is_unchanged(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc p {a b} { return [expr {$a + $b}] }\n"
+        lsp_server.open_ready(uri, src)
+        result = lsp_server.execute_command("tcl-lsp.optimiseDocument", [uri, "full"])
+        # A dynamic expression has no safe constant fold — source is preserved.
+        assert "expr {$a + $b}" in result["source"], result["source"]

--- a/tests/lsp_e2e/test_diagnostics_e2e.py
+++ b/tests/lsp_e2e/test_diagnostics_e2e.py
@@ -8,9 +8,18 @@ The server advertises no pull provider, so these assert on the
 
 from __future__ import annotations
 
+import textwrap
+
 
 def _codes(diags) -> set[str]:
     return {str(d.get("code")) for d in diags}
+
+
+def _on_line(diags, code: str) -> set[int]:
+    """The set of start lines for diagnostics carrying ``code``."""
+    return {
+        d["range"]["start"]["line"] for d in diags if str(d.get("code")) == code and d.get("range")
+    }
 
 
 class TestPushDiagnostics:
@@ -74,6 +83,106 @@ class TestSubcommandOptionArity:
         uri = uri_factory()
         diags = lsp_server.open_ready(uri, "string match -nocase $pat $str\n")
         assert "E003" not in _codes(diags)
+
+
+class TestDiagnosticCanaries:
+    """One canary per analysis family, locked to the server's published output.
+
+    ``test_diagnostics_e2e`` previously asserted only E002/W100/W128/W302 — far
+    too thin to notice a whole dataflow family silently regressing.  The
+    authoritative precision battery (``tests/test_fp_*.py`` +
+    ``tests/test_ground_truth_tn_fn.py``, locked to real tclsh 9.0.3) still
+    certifies the in-process analyser; these canaries certify that the analysis
+    actually reaches the wire through the *server* pipeline, with a matched
+    must-fire / must-stay-silent pair per family so a blanket suppression can't
+    pass.
+    """
+
+    # -- W210: read of a possibly-unset variable --------------------------- #
+
+    def test_w210_read_before_set_on_path_merge(self, lsp_server, uri_factory):
+        # ``y`` is defined only inside the ``if`` arm; the read at the merge
+        # point may see it unset.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc p {x} {
+                if {$x} {
+                    set y 1
+                }
+                return $y
+            }
+        """)
+        diags = lsp_server.open_ready(uri, src)
+        assert "W210" in _codes(diags), _codes(diags)
+        # The diagnostic anchors on the read site (`return $y`), not the def.
+        assert 4 in _on_line(diags, "W210"), [d.get("range") for d in diags]
+
+    def test_w210_use_after_unset(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        diags = lsp_server.open_ready(uri, "set a 1\nunset a\nputs $a\n")
+        assert "W210" in _codes(diags), _codes(diags)
+        assert 2 in _on_line(diags, "W210")
+
+    def test_w210_silent_when_set_on_all_paths(self, lsp_server, uri_factory):
+        # Defined on both branches → no read-before-set (must-stay-silent).
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc p {x} {
+                if {$x} {
+                    set y 1
+                } else {
+                    set y 2
+                }
+                return $y
+            }
+        """)
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    # -- W307: a variable used in command position ------------------------- #
+
+    def test_w307_known_literal_non_command_fires(self, lsp_server, uri_factory):
+        # ``cmd`` resolves to the literal ``foo`` which is not a command.
+        uri = uri_factory()
+        diags = lsp_server.open_ready(uri, "proc p {} {\n    set cmd foo\n    $cmd bar\n}\n")
+        assert "W307" in _codes(diags), _codes(diags)
+
+    def test_w307_silent_for_opaque_dispatch_target(self, lsp_server, uri_factory):
+        # ``$self`` is an opaque parameter (a method-dispatch idiom); with no
+        # known non-command literal value, W307 must not fire.
+        uri = uri_factory()
+        diags = lsp_server.open_ready(uri, "proc p {self} {\n    $self configure -x 1\n}\n")
+        assert "W307" not in _codes(diags), _codes(diags)
+
+    # -- W220: dead store -------------------------------------------------- #
+
+    def test_w220_dead_store_fires(self, lsp_server, uri_factory):
+        # ``x`` is set, then overwritten before any read → the first store is dead.
+        uri = uri_factory()
+        diags = lsp_server.open_ready(
+            uri, "proc p {} {\n    set x 1\n    set x 2\n    return $x\n}\n"
+        )
+        assert "W220" in _codes(diags), _codes(diags)
+        assert 1 in _on_line(diags, "W220")
+
+    def test_w220_silent_when_value_is_read_between(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc p {} {\n    set x 1\n    puts $x\n    set x 2\n    return $x\n}\n"
+        assert "W220" not in _codes(lsp_server.open_ready(uri, src))
+
+    # -- Clean code stays clean (cross-family negative control) ------------ #
+
+    def test_clean_dataflow_has_no_diagnostics(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc p {x} {
+                set d [dict create a 1]
+                if {[dict exists $d a]} {
+                    return [dict get $d a]
+                }
+                return $x
+            }
+        """)
+        assert lsp_server.open_ready(uri, src) == []
 
 
 class TestDiagnosticsTrackEdits:

--- a/tests/lsp_e2e/test_edit_tracking_stress_e2e.py
+++ b/tests/lsp_e2e/test_edit_tracking_stress_e2e.py
@@ -21,8 +21,39 @@ import random
 
 import pytest
 
-from ._lsp_helpers import decode_semantic_tokens
+from ._lsp_helpers import decode_semantic_tokens, semantic_token_violations
 from ._textmirror import Edit, TextMirror, random_edit
+
+
+def _legend(lsp_server):
+    prov = lsp_server.initialize_result["capabilities"]["semanticTokensProvider"]["legend"]
+    return prov["tokenTypes"], prov["tokenModifiers"]
+
+
+def _assert_tokens_aligned(lsp_server, uri, text):
+    """The server's semantic tokens for *uri* must satisfy every invariant.
+
+    Stronger than the edited-vs-fresh oracle: it pins that the *absolute* token
+    geometry is internally consistent and within ``text``'s bounds (ordered,
+    non-overlapping, UTF-16-correct, legend-valid) — the "tokens never end up
+    out of alignment" guarantee, checked against the buffer the edits produced.
+    """
+    types_, mods = _legend(lsp_server)
+    raw = lsp_server.semantic_tokens(uri)
+    violations = semantic_token_violations(raw, text, token_types=types_, token_modifiers=mods)
+    assert not violations, "semantic-token alignment broke:\n" + "\n".join(violations)
+
+
+def _find_occurrences(text: str, needle: str) -> list[tuple[int, int]]:
+    """Every ``(line, utf16_col)`` where *needle* starts in *text*."""
+    out: list[tuple[int, int]] = []
+    for line_no, line in enumerate(text.split("\n")):
+        col = line.find(needle)
+        while col != -1:
+            # Columns in the seed docs here are ASCII, so char index == utf16 col.
+            out.append((line_no, col))
+            col = line.find(needle, col + 1)
+    return out
 
 
 def _norm_symbols(symbols) -> list:
@@ -280,4 +311,119 @@ class TestReopenLifecycle:
             # Fire a request that reads the buffer; we only require it not to error.
             lsp_server.document_symbols(uri)
             lsp_server.semantic_tokens(uri)
+        _assert_buffer_equiv(lsp_server, uri, version, uri_factory(), mirror.text)
+
+
+# --------------------------------------------------------------------------- #
+# Token alignment: semantic tokens must never go out of alignment under edits.
+# --------------------------------------------------------------------------- #
+
+_ALIGN_DOC = (
+    "proc tally {items} {\n"
+    "    set count 0\n"
+    "    foreach item $items {\n"
+    "        set count [expr {$count + 1}]\n"
+    '        puts "item $item count $count"\n'
+    "    }\n"
+    "    return $count\n"
+    "}\n"
+)
+
+
+class TestTokenAlignmentUnderEdits:
+    """Semantic tokens stay internally consistent through punishing edits.
+
+    The edited-vs-fresh oracle is blind to a defect present in *both* (e.g. a
+    systematic overlap).  These assert the absolute invariants — order,
+    non-overlap, in-bounds, UTF-16 columns, legend-valid — against the buffer
+    the edits produced, settling each checkpoint so the snapshot can't trail.
+    """
+
+    def test_multicursor_rename_keeps_tokens_aligned(self, lsp_server, uri_factory):
+        # A multi-cursor rename arrives as ONE didChange carrying an edit per
+        # site.  Editors send them bottom-up so earlier edits don't shift later
+        # offsets; the mirror applies them in the same order.  After the rename,
+        # every ``$count`` token must still land exactly on its (now longer)
+        # variable — no stale lengths, no overlaps.
+        uri = uri_factory()
+        lsp_server.open_ready(uri, _ALIGN_DOC)
+        mirror = TextMirror(_ALIGN_DOC)
+        _assert_tokens_aligned(lsp_server, uri, mirror.text)
+
+        sites = _find_occurrences(mirror.text, "count")
+        assert len(sites) >= 5, sites
+        # Replace the identifier `count` with a longer `counterValue` at every
+        # site, bottom-up (descending position) so offsets stay valid.
+        edits = [
+            Edit((line, col), (line, col + len("count")), "counterValue")
+            for line, col in sorted(sites, reverse=True)
+        ]
+        for e in edits:
+            mirror.apply(e)
+        lsp_server.change_document(uri, 2, [e.as_content_change() for e in edits])
+        lsp_server.settle_analysis(uri, 3, mirror.text)
+
+        _assert_tokens_aligned(lsp_server, uri, mirror.text)
+        _assert_buffer_equiv(lsp_server, uri, 3, uri_factory(), mirror.text)
+
+    def test_multicursor_insert_prefix_at_each_line(self, lsp_server, uri_factory):
+        # Insert a 4-space indent at the start of every body line in a single
+        # didChange (a column/multi-cursor block edit).  Token columns on each
+        # line must shift by exactly the inserted width and stay aligned.
+        uri = uri_factory()
+        lsp_server.open_ready(uri, _ALIGN_DOC)
+        mirror = TextMirror(_ALIGN_DOC)
+        n_lines = mirror.text.count("\n")
+        edits = [Edit((ln, 0), (ln, 0), "  ") for ln in range(n_lines - 1, -1, -1)]
+        for e in edits:
+            mirror.apply(e)
+        lsp_server.change_document(uri, 2, [e.as_content_change() for e in edits])
+        lsp_server.settle_analysis(uri, 3, mirror.text)
+        _assert_tokens_aligned(lsp_server, uri, mirror.text)
+        _assert_buffer_equiv(lsp_server, uri, 3, uri_factory(), mirror.text)
+
+    @pytest.mark.parametrize("seed", [11, 29, 51])
+    def test_invariants_hold_throughout_random_storm(self, lsp_server, uri_factory, seed):
+        # Drive batched multi-edit changes and, at each checkpoint, settle and
+        # assert the tokens satisfy every invariant against the mirror text — so
+        # alignment is pinned *throughout* the storm, not only at the end.
+        uri = uri_factory()
+        lsp_server.open_ready(uri, _ALIGN_DOC)
+        mirror = TextMirror(_ALIGN_DOC)
+        rng = random.Random(seed)
+        version = 1
+        for _ in range(8):
+            changes = []
+            for _ in range(rng.randint(1, 3)):
+                edit = random_edit(mirror, rng)
+                mirror.apply(edit)
+                changes.append(edit.as_content_change())
+            version += 1
+            lsp_server.change_document(uri, version, changes)
+            version = lsp_server.settle_analysis(uri, version + 1, mirror.text)
+            _assert_tokens_aligned(lsp_server, uri, mirror.text)
+        _assert_buffer_equiv(lsp_server, uri, version, uri_factory(), mirror.text)
+
+    def test_multibyte_edits_keep_utf16_columns_aligned(self, lsp_server, uri_factory):
+        # Interleave emoji/accented inserts with edits after them; the tokens'
+        # UTF-16 columns must track the astral widths exactly.
+        uri = uri_factory()
+        start = 'set label "tag"\nputs $label\n'
+        lsp_server.open_ready(uri, start)
+        mirror = TextMirror(start)
+        version = 1
+
+        def edit(start_pos, end_pos, text):
+            nonlocal version
+            e = Edit(start_pos, end_pos, text)
+            mirror.apply(e)
+            version += 1
+            lsp_server.change_document(uri, version, [e.as_content_change()])
+
+        # Insert an emoji inside the string, then edit after it on the same line.
+        edit((0, 14), (0, 14), "\U0001f600\U0001f680")
+        eol0 = mirror.position_at(mirror.text.index("\n"))
+        edit(eol0, eol0, " ;# 日本語")
+        version = lsp_server.settle_analysis(uri, version + 1, mirror.text)
+        _assert_tokens_aligned(lsp_server, uri, mirror.text)
         _assert_buffer_equiv(lsp_server, uri, version, uri_factory(), mirror.text)

--- a/tests/lsp_e2e/test_editor_features_e2e.py
+++ b/tests/lsp_e2e/test_editor_features_e2e.py
@@ -99,13 +99,14 @@ def _label_text(hint: dict) -> str:
 
 def _param_labels_on_line(hints, line: int) -> list[tuple[int, str]]:
     """``(character, label)`` of every parameter-kind hint on ``line``."""
-    out = []
+    out: list[tuple[int, str]] = []
     for h in hints or []:
         if h.get("kind") != 2:  # InlayHintKind.Parameter
             continue
         pos = h.get("position") or {}
-        if pos.get("line") == line:
-            out.append((pos.get("character"), _label_text(h)))
+        char = pos.get("character")
+        if pos.get("line") == line and char is not None:
+            out.append((char, _label_text(h)))
     return sorted(out)
 
 

--- a/tests/lsp_e2e/test_editor_features_e2e.py
+++ b/tests/lsp_e2e/test_editor_features_e2e.py
@@ -87,3 +87,85 @@ class TestInlayHints:
         lsp_server.open_ready(uri, "proc add {a b} { expr {$a + $b} }\nadd 1 2\n")
         for hint in lsp_server.inlay_hints(uri, (0, 0), (2, 0)) or []:
             assert hint.get("kind") in (1, 2)  # Type, Parameter
+
+
+def _label_text(hint: dict) -> str:
+    """An inlay hint's ``label`` is a string or a list of ``{value}`` parts."""
+    label = hint.get("label")
+    if isinstance(label, list):
+        return "".join(str(part.get("value", "")) for part in label)
+    return str(label or "")
+
+
+def _param_labels_on_line(hints, line: int) -> list[tuple[int, str]]:
+    """``(character, label)`` of every parameter-kind hint on ``line``."""
+    out = []
+    for h in hints or []:
+        if h.get("kind") != 2:  # InlayHintKind.Parameter
+            continue
+        pos = h.get("position") or {}
+        if pos.get("line") == line:
+            out.append((pos.get("character"), _label_text(h)))
+    return sorted(out)
+
+
+class TestInlayHintOptionalPositionals:
+    """Optional-positional parameter labelling — issue #510, end-to-end.
+
+    The synopsis ``puts ?-nonewline? ?channelId? string`` has an *optional*
+    positional (``channelId``) before a *required* trailing one (``string``).
+    A one-positional call binds that argument to the required ``string`` slot,
+    not the leftmost optional name, and the documentation placeholders
+    ``?options?`` / ``?switches?`` are never emitted as parameter labels.
+
+    These run against ``lsp_server_inlay`` (inlay hints on) so the provider
+    actually produces hints — the default server keeps them off.
+    """
+
+    def test_single_positional_binds_required_string_slot(self, lsp_server_inlay, uri_factory):
+        uri = uri_factory()
+        lsp_server_inlay.open_ready(uri, "puts hello\n")
+        labels = _param_labels_on_line(lsp_server_inlay.inlay_hints(uri, (0, 0), (1, 0)), 0)
+        names = [name for _char, name in labels]
+        # The single argument is the required ``string`` — never the optional
+        # ``channelId`` (the pre-fix regression).
+        assert "string:" in names, labels
+        assert "channelId:" not in names, labels
+
+    def test_two_positionals_label_channel_then_string(self, lsp_server_inlay, uri_factory):
+        uri = uri_factory()
+        lsp_server_inlay.open_ready(uri, "puts $chan hello\n")
+        labels = _param_labels_on_line(lsp_server_inlay.inlay_hints(uri, (0, 0), (1, 0)), 0)
+        names = [name for _char, name in labels]
+        # Both slots are filled now, left to right.
+        assert names == ["channelId:", "string:"], labels
+
+    def test_leading_flag_does_not_shift_required_slot(self, lsp_server_inlay, uri_factory):
+        # ``-nonewline`` is an option flag, not a positional; the one real
+        # positional still binds to ``string``.
+        uri = uri_factory()
+        lsp_server_inlay.open_ready(uri, "puts -nonewline hello\n")
+        names = [
+            name
+            for _char, name in _param_labels_on_line(
+                lsp_server_inlay.inlay_hints(uri, (0, 0), (1, 0)), 0
+            )
+        ]
+        assert "string:" in names, names
+        assert "channelId:" not in names, names
+
+    def test_no_documentation_placeholder_labels(self, lsp_server_inlay, uri_factory):
+        # ``lsearch ?options? list pattern`` — the ``?options?`` placeholder is
+        # the flag group, not a positional, so the real positionals label
+        # ``list`` / ``pattern`` and no ``options``/``switches`` hint appears.
+        uri = uri_factory()
+        lsp_server_inlay.open_ready(uri, "lsearch $mylist needle\n")
+        names = [
+            name
+            for _char, name in _param_labels_on_line(
+                lsp_server_inlay.inlay_hints(uri, (0, 0), (1, 0)), 0
+            )
+        ]
+        assert "list:" in names, names
+        assert "pattern:" in names, names
+        assert not any(n in ("options:", "switches:") for n in names), names

--- a/tests/lsp_e2e/test_invariants_e2e.py
+++ b/tests/lsp_e2e/test_invariants_e2e.py
@@ -1,0 +1,139 @@
+"""Universal invariants + adversarial robustness, end-to-end against the server.
+
+Most suites assert *what* a provider returns for a specific input.  These assert
+properties that must hold for **every** provider on **every** document — the
+contracts a client relies on and silently mis-renders (or crashes on) when
+broken:
+
+  * every ``Range`` a provider emits is well-formed — non-negative, ``start <=
+    end``, on real lines, ``start`` column within its line in UTF-16 units;
+  * ``rename`` / code-action ``WorkspaceEdit`` arrays contain no overlapping or
+    duplicate edits (the client applies them as a batch);
+  * adversarial documents — unterminated delimiters, deep nesting, multibyte /
+    emoji, CRLF, a BOM, an empty file, a large file — never make the server
+    hang, crash, or emit a malformed span.
+
+The robustness corpus is the second oracle: a server that wedges or throws on
+hostile input fails here even if its happy-path tests pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ._lsp_helpers import range_violations, workspace_edit_violations
+
+# A corpus spanning clean code, every multibyte/EOL hazard, and the recovery
+# paths.  Reused by the range-invariant and robustness batteries.
+_CORPUS = {
+    "clean": 'proc greet {name} {\n    puts "Hello $name"\n}\ngreet World\n',
+    "vars": "set x 1\nset y $x\nputs [expr {$x + $y}]\n",
+    "multibyte": 'set s "café résumé naïve"\nputs $s\nproc f {s} { return $s }\nf $s\n',
+    "emoji": 'set e "😀 🚀 🐫 done"\nputs $e\nset n 1\n',
+    "unicode_ident": "set 日本語 1\nputs ${日本語}\n",
+    "crlf": "proc p {} {\r\n    set x 1\r\n}\r\np\r\n",
+    "bom": "﻿puts hello\nset x 1\n",
+    "unterminated_bracket": "set x [foo bar\nproc recovered {} {}\nputs hi\n",
+    "unterminated_brace": "proc p {} {\n  set y [foo\n}\nset z 1\n",
+    "unterminated_quote": 'set s "open\nputs done\n',
+    "deep_nesting": "set x [a [b [c [d [e [f [g\nputs tail\n",
+    "empty": "",
+    "blank_lines": "\n\n\n",
+    "only_comment": "# just a comment\n",
+    "large": "".join(f"proc p{i} {{a b}} {{ return [expr {{$a + $b}}] }}\n" for i in range(400)),
+}
+
+
+def _exercise_all_providers(lsp_server, uri: str):
+    """Run a broad request battery against ``uri``; return ``{name: result}``.
+
+    Every request must return (not raise / not time out).  Positions are chosen
+    to land on real tokens in the smaller corpus entries and are harmless
+    elsewhere (providers return empty for an uninteresting position).
+    """
+    results: dict[str, object] = {}
+    results["documentSymbol"] = lsp_server.document_symbols(uri)
+    results["foldingRange"] = lsp_server.folding_range(uri)
+    results["semanticTokens"] = lsp_server.semantic_tokens(uri)
+    results["hover@0,1"] = lsp_server.hover(uri, 0, 1)
+    results["definition@0,1"] = lsp_server.definition(uri, 0, 1)
+    results["references@0,5"] = lsp_server.references(uri, 0, 5)
+    results["highlight@0,5"] = lsp_server.document_highlight(uri, 0, 5)
+    results["completion@0,1"] = lsp_server.completion(uri, 0, 1)
+    results["signatureHelp@1,8"] = lsp_server.signature_help(uri, 1, 8)
+    results["selectionRange@0,1"] = lsp_server.selection_range(uri, [(0, 1)])
+    results["codeAction@0,0-1,0"] = lsp_server.code_actions(uri, (0, 0), (1, 0))
+    results["documentLink"] = lsp_server.document_links(uri)
+    results["codeLens"] = lsp_server.code_lens(uri)
+    return results
+
+
+class TestRangeInvariants:
+    """Every Range from every provider is well-formed, over the whole corpus."""
+
+    @pytest.mark.parametrize("name", sorted(_CORPUS))
+    def test_all_provider_ranges_well_formed(self, name, lsp_server, uri_factory):
+        source = _CORPUS[name]
+        uri = uri_factory()
+        lsp_server.open_ready(uri, source)
+        results = _exercise_all_providers(lsp_server, uri)
+        violations: list[str] = []
+        for req, res in results.items():
+            violations += range_violations(res, source, label=f"{name}/{req}")
+        assert not violations, "malformed ranges:\n" + "\n".join(violations)
+
+
+class TestWorkspaceEditInvariants:
+    def test_rename_edits_do_not_overlap(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc greet {name} { puts $name }\ngreet a\ngreet b\ngreet c\n"
+        lsp_server.open_ready(uri, src)
+        edit = lsp_server.rename(uri, 0, 6, "welcome")
+        assert not workspace_edit_violations(edit, label="rename")
+
+    def test_multisite_variable_rename_edits_are_disjoint(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc p {} {\n    set count 0\n    incr count\n    incr count\n    return $count\n}\n"
+        lsp_server.open_ready(uri, src)
+        edit = lsp_server.rename(uri, 1, 8, "counter")
+        assert not workspace_edit_violations(edit, label="var-rename")
+
+    def test_code_action_edits_do_not_overlap(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        # W100 (unbraced expr) offers a safe wrap fix; its edits must be disjoint.
+        lsp_server.open_ready(uri, "if $a { puts yes }\nif $b { puts no }\n")
+        actions = lsp_server.code_actions(uri, (0, 0), (2, 0)) or []
+        for action in actions:
+            assert not workspace_edit_violations(action.get("edit"), label="code-action")
+
+
+class TestRobustnessAdversarial:
+    """Hostile inputs never hang/crash the server and never yield bad spans."""
+
+    @pytest.mark.parametrize("name", sorted(_CORPUS))
+    def test_server_survives_and_responds(self, name, lsp_server, uri_factory):
+        source = _CORPUS[name]
+        uri = uri_factory()
+        # ``open_ready`` itself proves the analysis pipeline didn't wedge.
+        lsp_server.open_ready(uri, source)
+        # The full battery must return for every adversarial input (the request
+        # helpers raise on a JSON-RPC error or time out, so reaching the end is
+        # the assertion) and every span must be well-formed.
+        results = _exercise_all_providers(lsp_server, uri)
+        violations: list[str] = []
+        for req, res in results.items():
+            violations += range_violations(res, source, label=f"{name}/{req}")
+        assert not violations, "malformed ranges on adversarial input:\n" + "\n".join(violations)
+
+    def test_server_still_responsive_after_adversarial_burst(self, lsp_server, uri_factory):
+        # After hammering hostile documents, a normal request on a fresh doc must
+        # still answer correctly — proves no document poisoned global state.
+        for name in ("deep_nesting", "unterminated_quote", "emoji", "large"):
+            u = uri_factory()
+            lsp_server.open_ready(u, _CORPUS[name])
+            _exercise_all_providers(lsp_server, u)
+        sane = uri_factory()
+        lsp_server.open_ready(sane, "puts hello\n")
+        from ._lsp_helpers import hover_text
+
+        assert "puts" in hover_text(lsp_server.hover(sane, 0, 2))

--- a/tests/lsp_e2e/test_irules_e2e.py
+++ b/tests/lsp_e2e/test_irules_e2e.py
@@ -574,3 +574,36 @@ class TestIrulesSemanticTokens:
         uri = _open(lsp_server_irules, uri_factory, source)
         tokens = _irules_typed(lsp_server_irules, uri)
         assert all(t["type"] == "comment" for t in tokens)
+
+
+def _irules_codes(diags) -> set[str]:
+    return {str(d.get("code")) for d in (diags or [])}
+
+
+class TestIrulesTaintDiagnostics:
+    """Taint diagnostics must actually *fire* on the wire (positive + negative).
+
+    ``TestIrulesTaintQuickFixes`` synthesises a diagnostic to test the quick-fix
+    geometry; nothing asserted that the server *publishes* a taint diagnostic at
+    all.  These pin the taint analysis end-to-end: a taint source flowing into an
+    HTTP sink raises ``IRULE3102``, and the same sink fed a constant stays
+    silent — the must-fire / must-stay-silent contract for the taint family.
+    """
+
+    def test_taint_source_in_http_sink_fires_irule3102(self, lsp_server_irules, uri_factory):
+        uri = uri_factory("irule")
+        diags = lsp_server_irules.open_ready(
+            uri,
+            "when HTTP_REQUEST {\n    HTTP::respond 200 content [HTTP::uri]\n}\n",
+            language_id="tcl-irule",
+        )
+        assert "IRULE3102" in _irules_codes(diags), _irules_codes(diags)
+
+    def test_constant_in_http_sink_is_silent(self, lsp_server_irules, uri_factory):
+        uri = uri_factory("irule")
+        diags = lsp_server_irules.open_ready(
+            uri,
+            'when HTTP_REQUEST {\n    HTTP::respond 200 content "static body"\n}\n',
+            language_id="tcl-irule",
+        )
+        assert "IRULE3102" not in _irules_codes(diags), _irules_codes(diags)

--- a/tests/lsp_e2e/test_recovery_e2e.py
+++ b/tests/lsp_e2e/test_recovery_e2e.py
@@ -218,6 +218,67 @@ class TestC4NoDuplicateDiagnostics:
 
 
 # --------------------------------------------------------------------------- #
+# Inert close-bracket veto (issue #560) — recovery must not fabricate a fix
+# that leaves the command incomplete.
+# --------------------------------------------------------------------------- #
+
+
+class TestInertBracketVeto:
+    """The ``]`` command/comment-break heuristics must veto an inert offset.
+
+    For ::
+
+        set x [foo {bar
+        puts baz}
+
+    the ``puts`` word sits *inside* the balanced brace word ``{bar … baz}``, so
+    inserting ``]`` after ``bar`` yields ``set x [foo {bar]…}`` which C Tcl
+    reports as incomplete — an objectively wrong fix.  Before #560 the bracket
+    path lacked the inert-offset veto the brace path already had.  Observably,
+    the unterminated ``[`` is still flagged, the tail is still analysed as code,
+    nothing is published twice, and the analysis doesn't hang.  The mid-word
+    look-alike (a literal ``"`` mid-word) still recovers normally.
+    """
+
+    def test_brace_word_break_still_flags_and_recovers(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        diags = lsp_server.open_ready(
+            uri, "set x [foo {bar\nproc recovered_after_brace_word {} {}\n"
+        )
+        assert _has_recovery_error(diags), f"unterminated [ should flag; got {_codes(diags)}"
+        names = _symbol_names(lsp_server.document_symbols(uri))
+        assert "recovered_after_brace_word" in names, f"tail not recovered; symbols={names}"
+
+    def test_brace_word_break_no_duplicate_diagnostics(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        diags = lsp_server.open_ready(uri, "set x [foo {bar\nputs baz}\nset\n")
+        seen: set[tuple] = set()
+        for d in diags:
+            ident = _diag_identity(d)
+            assert ident not in seen, f"duplicate diagnostic published: {ident}"
+            seen.add(ident)
+        # The trailing bare ``set`` is still parsed as a command → arity errors,
+        # proving the tail is analysed as code rather than swallowed.
+        assert "E002" in _codes(diags), f"tail `set` should arity-error; got {_codes(diags)}"
+
+    def test_midword_delimiter_still_recovers(self, lsp_server, uri_factory):
+        # ``foo abc"`` — the ``"`` is mid-word, an ordinary literal, so the
+        # following line is a genuine command-break that must still recover
+        # (the veto must not over-fire and strand an unfixable error).
+        uri = uri_factory()
+        lsp_server.open_ready(uri, 'set x [foo abc"\nproc recovered_after_midword {} {}\n')
+        names = _symbol_names(lsp_server.document_symbols(uri))
+        assert "recovered_after_midword" in names, f"tail not recovered; symbols={names}"
+
+    def test_brace_word_break_tokens_well_formed(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "set x [foo {bar\nputs baz}\nputs end\n")
+        raw = lsp_server.semantic_tokens(uri)
+        data = raw.get("data") if isinstance(raw, dict) else None
+        assert data is not None and len(data) % 5 == 0, "token data must be 5-int groups"
+
+
+# --------------------------------------------------------------------------- #
 # C5 — edits toggle recovery
 # --------------------------------------------------------------------------- #
 

--- a/tests/lsp_e2e/test_semantic_tokens_e2e.py
+++ b/tests/lsp_e2e/test_semantic_tokens_e2e.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import pytest
 
-from ._lsp_helpers import decode_semantic_tokens
+from ._lsp_helpers import decode_semantic_tokens, semantic_token_violations
 
 
 @pytest.fixture
@@ -49,6 +49,66 @@ def _open(lsp_server, uri_factory, source):
     uri = uri_factory()
     lsp_server.open_ready(uri, source)
     return uri
+
+
+# Representative + adversarial documents the encoder must keep coherent.  The
+# point is not what tokens come back but that they always satisfy the universal
+# invariants (ordered, non-overlapping, in-bounds, UTF-16-correct, legend-valid)
+# — the "Overlapping semantic tokens detected" class of client warning.
+_INVARIANT_CORPUS = {
+    "empty": "",
+    "simple": "puts hello\n",
+    "vars_and_numbers": "set x 42\nset y $x\nputs $y\n",
+    "proc_with_body": 'proc greet {name} {\n    puts "Hello $name"\n}\ngreet World\n',
+    "nested_blocks": "proc p {} {\n  if {1} {\n    foreach x {a b c} {\n      puts $x\n    }\n  }\n}\n",
+    "string_interp": 'set s "a $b [llength $c] d"\n',
+    "comments": "# leading comment\nputs hi ;# trailing comment\n",
+    "crlf": "proc p {} {\r\n    set x 1\r\n}\r\n",
+    # Multibyte / emoji: every column the encoder emits must be UTF-16 units.
+    "multibyte_string": 'set greeting "héllo wörld café"\nputs $greeting\n',
+    "emoji_string": 'set e "😀 tcl 🚀 rocks 🐫"\nputs $e\n',
+    "emoji_then_code": 'puts "🚀"\nset after 1\n',
+    "unicode_after_var": 'set x 1\nputs "$x — résumé — 日本語"\n',
+    # Recovery paths must still emit coherent tokens.
+    "unterminated_bracket": "set x [foo bar\nputs hi\n",
+    "unterminated_brace": "proc p {} {\n  set y [foo\n}\nset\n",
+    "deep_nesting": "set x [a [b [c [d [e\nputs tail\n",
+    "regexp_subtokens": "regexp {(\\d+)-(\\w+)} $s -> a b\n",
+    "switch_braced": "switch $x {\n  {a b} { puts one }\n  default { puts def }\n}\n",
+}
+
+
+class TestTokenInvariants:
+    """Universal semantic-token invariants over a representative/adversarial corpus.
+
+    ``edit_tracking_stress`` proves the *edited* buffer matches a fresh open, but
+    if both are equally wrong (e.g. overlapping tokens) that oracle is blind.
+    These pin the absolute contract a client depends on for every document.
+    """
+
+    @pytest.mark.parametrize("name", sorted(_INVARIANT_CORPUS))
+    def test_tokens_satisfy_invariants(self, name, lsp_server, uri_factory, legend, modifiers):
+        source = _INVARIANT_CORPUS[name]
+        uri = _open(lsp_server, uri_factory, source)
+        raw = lsp_server.semantic_tokens(uri)
+        violations = semantic_token_violations(
+            raw, source, token_types=legend, token_modifiers=modifiers
+        )
+        assert not violations, f"[{name}] semantic-token invariant violations:\n" + "\n".join(
+            violations
+        )
+
+    def test_tokens_strictly_non_overlapping_dense_line(
+        self, lsp_server, uri_factory, legend, modifiers
+    ):
+        # A single dense line with many adjacent tokens is the worst case for the
+        # overlap/ordering invariant.
+        source = 'set a 1;set b 2;puts "$a [expr {$a+$b}] $b";# tail\n'
+        uri = _open(lsp_server, uri_factory, source)
+        raw = lsp_server.semantic_tokens(uri)
+        assert not semantic_token_violations(
+            raw, source, token_types=legend, token_modifiers=modifiers
+        )
 
 
 class TestCoreTokens:

--- a/tests/lsp_e2e/test_server_version.py
+++ b/tests/lsp_e2e/test_server_version.py
@@ -17,12 +17,24 @@ should be added alongside this one against the same ``lsp_server``.
 
 from __future__ import annotations
 
+from .harness import server_kind
+
 
 def test_initialize_reports_packaged_build_version(lsp_server, lsp_full_version):
     """serverInfo.version from the live server is the build version, not 'dev'."""
     info = lsp_server.server_info
     assert info is not None, "initialize result had no serverInfo — cannot read the version banner"
     reported = info.get("version")
+    if server_kind() == "rust":
+        # The native binary reports its own (Cargo) version, not the Python
+        # zipapp build string, so the exact ``v{FULL_VERSION}`` match is
+        # pyz-specific.  Still guard the regression class the test exists for:
+        # a real, non-empty, non-fallback version banner.
+        assert reported, "native server reported no version banner"
+        assert reported not in ("vdev", "dev"), (
+            f"native server fell back to a dev version banner: {reported!r}"
+        )
+        return
     # The banner is f"v{FULL_VERSION}"; a broken build-info import yields "vdev".
     assert reported == f"v{lsp_full_version}", (
         f"running server reported version {reported!r}, expected "

--- a/tests/lsp_e2e/test_structure_e2e.py
+++ b/tests/lsp_e2e/test_structure_e2e.py
@@ -22,6 +22,45 @@ class TestFoldingRange:
         assert (lsp_server.folding_range(uri) or []) == []
 
 
+class TestLineContinuationFolding:
+    """Backslash line-continuation folding — issue #541, end-to-end.
+
+    A command stretched across physical lines by trailing ``\\`` joins is a
+    single logical command; the provider folds the run down to its opening
+    line.  The look-alikes that are *not* continuations (an escaped ``\\\\`` is
+    a literal backslash) must stay unfolded.  The feature was dropped by the
+    folding rewrite and restored in #541 — this pins the editor-visible result.
+    """
+
+    @staticmethod
+    def _spans(lsp_server, uri) -> set[tuple[int, int]]:
+        return {(r["startLine"], r["endLine"]) for r in (lsp_server.folding_range(uri) or [])}
+
+    def test_backslash_continued_command_folds(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "MyProcCall $var1 \\\n           $var2 \\\n           $var3\n")
+        # The three physical lines are one logical command; they fold (0..2).
+        assert (0, 2) in self._spans(lsp_server, uri), self._spans(lsp_server, uri)
+
+    def test_two_line_continuation_folds(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "set x $a \\\n    $b\n")
+        assert (0, 1) in self._spans(lsp_server, uri), self._spans(lsp_server, uri)
+
+    def test_separate_runs_fold_independently(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "foo $a \\\n   $b\nputs sep\nbar $c \\\n   $d\n")
+        spans = self._spans(lsp_server, uri)
+        assert {(0, 1), (3, 4)} <= spans, spans
+
+    def test_escaped_backslash_is_not_a_continuation(self, lsp_server, uri_factory):
+        # ``puts foo\\`` ends in a *literal* backslash (escaped), so the two
+        # lines are separate commands and must not fold.
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "puts foo\\\\\nputs bar\n")
+        assert (0, 1) not in self._spans(lsp_server, uri), self._spans(lsp_server, uri)
+
+
 class TestSelectionRange:
     def test_widens_from_inner_to_outer(self, lsp_server, uri_factory):
         uri = uri_factory()


### PR DESCRIPTION
## Summary

This PR significantly hardens the `lsp_e2e` integration test suite to enforce LSP contracts across both the Python reference server and the native Rust backend. The changes add:

1. **Configuration injection & feature toggles** (`test_config_e2e.py`): End-to-end tests that `getEffectiveConfig` exposes a resolved `features` map, each toggleable provider returns empty when disabled, the optimiser switch round-trips, formatting honours request indent, and no sticky state persists across toggles.

2. **Dual-backend support** (`harness.py`): Server selection via `TCL_LSP_SERVER_KIND` environment variable (default `python`, or `rust` for the native binary). The same JSON-RPC battery now drives either backend, with `conftest.py` locating the Rust binary via `TCL_LSP_SERVER_BIN` or auto-discovery under `target/{release,debug}/`.

3. **Universal invariants** (`test_invariants_e2e.py`): Validates that every `Range` emitted by any provider is well-formed (non-negative, `start <= end`, on real lines, UTF-16-correct), `WorkspaceEdit` arrays contain no overlapping/duplicate edits, and adversarial documents (unterminated delimiters, deep nesting, multibyte/emoji, CRLF, BOM, empty, large files) never hang/crash or yield malformed spans.

4. **Semantic-token invariants** (`_lsp_helpers.semantic_token_violations`, `test_semantic_tokens_e2e.py::TestTokenInvariants`): Enforces that tokens are ordered, non-overlapping, in-bounds, UTF-16-correct, and legend-valid across a representative + adversarial corpus.

5. **Token alignment under edits** (`test_edit_tracking_stress_e2e.py::TestTokenAlignmentUnderEdits`): Multi-cursor rename and block-indent operations (one `didChange`, many edits) with random edit storms checked at every settled checkpoint, including multibyte UTF-16 tracking.

6. **Diagnostic canaries** (`test_diagnostics_e2e.py::TestDiagnosticCanaries`): Matched must-fire / must-stay-silent pairs for W210, W307, W220 (and others) to prevent blanket suppression from passing.

7. **Additional coverage**: BIG-IP config handling (#534, #571), inlay hint optional-positional parameter labelling (#510), line-continuation folding (#541), minifier switch pattern preservation (#540), inert bracket veto (#560), and taint diagnostics end-to-end.

### Bug found and fixed

The new token-overlap invariant caught a real off-by-one in the Python encoder: a string ending immediately after an interpolation (`"$name"`) emitted the closing quote as a 2-wide token over a 1-char quote, over-running the line. Fixed in `server/features/_semantic_tokens/_collect.py`.

### Recorded Rust-mode parity gaps

Captured against the native server; these are real divergences to close, not test noise:
- `getEffectiveConfig` returns only `{uri, dialect}` instead of the full resolved config with `features` map
- Several feature toggles (hover, completion, documentSymbols, etc.) are not honoured
- Optimiser switch is not exposed in `getEffectiveConfig`
- Formatting does not honour request indent width

## Validation

- Added 238 lines of `test_config_e2e.py` (feature toggles, effective config shape)
- Added 139 lines of `test_invariants_e2e.py` (universal range/edit invariants, adversarial robustness)
- Added 150 lines of `test_diagnostic_matrix_e2e.py` (data-driven diagnostic matrix)
- Added 100 lines of `test_bigip_e2e.py` (BIG-IP config handling)
- Extended `test_edit_tracking_stress_e2e.py` with token alignment checks
- Extended `test_semantic_tokens_e

https://claude.ai/code/session_01WpSmFiECFKAqemvZNfzscs