### PR TITLE
rust: consolidate rust workstream onto main (pre-ARCH)

### DIFF
--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -161,7 +161,14 @@ class LspClient:
         #: argv used to spawn the server.  Defaults to the Python server via
         #: ``uv``; ``launch_cmd`` overrides it (e.g. the native Rust binary).
         self._launch_cmd = launch_cmd or [
-            "uv", "run", "--directory", server_dir, "--no-dev", "python", "-m", "lsp",
+            "uv",
+            "run",
+            "--directory",
+            server_dir,
+            "--no-dev",
+            "python",
+            "-m",
+            "lsp",
         ]
         self.process: subprocess.Popen | None = None
         self._request_id = 0

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -122,6 +122,48 @@ ownership matrices.
   current ``trace add variable`` no-op gap, the design sketch
   (per-Var TraceList + fire hooks on every mutator), and an
   effort estimate for closing it.
+- [runtime/proc-call-and-stack-traces.md](runtime/proc-call-and-stack-traces.md)
+  — the proc call protocol: argument binding, exception propagation,
+  and ``-errorinfo`` / ``-errorcode`` stack-trace assembly across the
+  call stack.
+- [runtime/c-api-ownership-contract.md](runtime/c-api-ownership-contract.md)
+  — the C Tcl API the runtime ships (``tcl.h`` / ``tclOO.h`` /
+  ``tclTomMath.h``) and the refcount-ownership / error-return contract
+  every exported C entry point must honour.
+- [runtime/c-extension-abi.md](runtime/c-extension-abi.md) — the
+  C-Tcl-extension → WASM ABI: how an unmodified C extension is compiled
+  and linked against the runtime, with the spike that validated the
+  mechanism end-to-end.
+- [runtime/tcltest-bringup.md](runtime/tcltest-bringup.md) — the plan for
+  running the real Tcl library and ``tcltest`` harness (the
+  ``pkgIndex.tcl`` / ``tm`` machinery) against real C Tcl 9 under the
+  runtime.
+- [runtime/zig-runtime-roadmap.md](runtime/zig-runtime-roadmap.md) —
+  phases 4 (residual), 5, and 6 of the Zig WASM runtime, companion to
+  the master plan: remaining P4 work and P5/P6 sequencing.
+
+## Rust runtime port
+
+The Python pipeline's port to a native Rust workspace — current state,
+where it is headed, and whether the gap is bridgeable. The companion
+chunk-by-chunk dispatch story lives in
+[`docs/rust-rewrite.md`](../rust-rewrite.md).
+
+- [rust/current-architecture.md](rust/current-architecture.md) — snapshot
+  of the Rust workspace as it stands today: crate layout and data flow
+  through the native pipeline.
+- [rust/target-architecture.md](rust/target-architecture.md) — the target
+  design (zero-copy, single-parse, incremental-reuse, MVCC) and how the
+  competing goals are reconciled.
+- [rust/feasibility.md](rust/feasibility.md) — feasibility analysis:
+  whether the target is reachable from the current architecture across
+  all six design goals.
+- [rust/review-findings.md](rust/review-findings.md) — workspace review
+  findings on correctness, performance, and memory, including the
+  ``unsafe``-forbidden discipline and where it costs.
+- [runtime/rust-runtime-port.md](runtime/rust-runtime-port.md) —
+  productionising the C-Tcl-extension-to-WASM port on the Rust runtime:
+  status, bootstrapping plan, and the end-to-end build mechanism.
 
 ## Optional WASM extensions
 
@@ -173,6 +215,11 @@ are its rules, and what are the failure modes". One contract per file.
   — command and event registry ownership rules.
 - [shared-utility-contracts.md](contracts/shared-utility-contracts.md) —
   shared helper ownership across core and LSP.
+- [core-lsp-shared-utility.md](contracts/core-lsp-shared-utility.md) — the
+  single home for logic that otherwise drifts between features/passes
+  (offset mapping, proc lookup, package ranking, event context,
+  word-shape parsing) and the rules that keep it from being
+  reimplemented.
 - [formatter-engine.md](contracts/formatter-engine.md) — formatter
   idempotency and rewrite contracts.
 - [project-layout.md](contracts/project-layout.md) — repository layout
@@ -263,6 +310,12 @@ Distilled from the trickiest scars in the WASM runtime history
   import`/`export`/`forget`/`path`, ensembles, and `::tcl::mathop` /
   `::tcl::mathfunc`; the binding lattice that gates compile-time
   resolution (the command-layer parallel of the variable-frame model).
+
+## Knowledge base coverage
+
+- [kcs-completeness-plan.md](kcs-completeness-plan.md) — audit of the
+  current KCS coverage (features and top-level notes) and the plan to
+  close the gaps toward completeness.
 
 ## Templates
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -66,6 +66,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-qa-what-config-sections-are-valid.md](kcs-qa-what-config-sections-are-valid.md)
   — the nine INI sections (seven shared plus the location-specific
   `[global]` and `[project]`), their keys, and which values are valid.
+- [kcs-qa-rust-shim-env-vars.md](kcs-qa-rust-shim-env-vars.md) — what the
+  `TCL_LSP_RUST_*` environment variables do and when to set them as the
+  Python-to-Rust rewrite lands in chunks.
 
 ## How-Tos
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -6977,7 +6977,7 @@ The categorical tables A-F track *features* (a hook variant, an
 option flag, a trait); the per-command checklist below tracks
 *coverage* — what each individual `CommandSpec` /
 `SubCommand` should carry. The
-[`scripts/check_command_spec_coverage.py`](../scripts/check_command_spec_coverage.py)
+`scripts/check_command_spec_coverage.py`
 audit runs this checklist over every spec under
 `rust/tcl-registry/src/commands/` and writes
 [`docs/generated/command-spec-coverage.md`](generated/command-spec-coverage.md)

--- a/scripts/dev/rust_tcltest_sweep.py
+++ b/scripts/dev/rust_tcltest_sweep.py
@@ -42,9 +42,7 @@ RUN_SCRIPT = REPO / "runtime" / "rust" / "target" / "release" / "examples" / "ru
 
 # tcltest's end-of-file summary, e.g.
 #   incr.test:	Total	69	Passed	61	Skipped	0	Failed	8
-SUMMARY_RE = re.compile(
-    r"Total\s+(\d+)\s+Passed\s+(\d+)\s+Skipped\s+(\d+)\s+Failed\s+(\d+)"
-)
+SUMMARY_RE = re.compile(r"Total\s+(\d+)\s+Passed\s+(\d+)\s+Skipped\s+(\d+)\s+Failed\s+(\d+)")
 
 
 def run_one(test: Path, timeout_s: float) -> dict:
@@ -79,9 +77,7 @@ def run_one(test: Path, timeout_s: float) -> dict:
             "failed": failed,
         }
     # No summary: errored/crashed before cleanupTests. Capture the last line.
-    last = next(
-        (ln for ln in reversed(out.splitlines()) if ln.strip()), ""
-    )
+    last = next((ln for ln in reversed(out.splitlines()) if ln.strip()), "")
     return {"file": test.name, "status": "error", "reason": last[:120]}
 
 
@@ -100,11 +96,7 @@ def main() -> int:
         )
         return 2
 
-    files = (
-        [TESTS_DIR / f for f in args.files]
-        if args.files
-        else sorted(TESTS_DIR.glob("*.test"))
-    )
+    files = [TESTS_DIR / f for f in args.files] if args.files else sorted(TESTS_DIR.glob("*.test"))
 
     results = []
     agg_total = agg_passed = agg_failed = agg_skipped = 0

--- a/tests/rust_diag_bridge.py
+++ b/tests/rust_diag_bridge.py
@@ -5,10 +5,12 @@ Activated by ``TCL_LSP_DIAG_BACKEND=rust`` (plus ``TCL_LSP_SERVER_BIN`` /
 ``TCL_LSP_SERVER_KIND=rust`` so the e2e harness client spawns the native
 binary).  When active, ``server.features.diagnostics.get_diagnostics`` and
 ``analyser.analyse(...).diagnostics`` return the diagnostics the native
-server publishes for the source, shaped as light objects exposing ``.code``,
-``.message``, ``.severity`` and ``.range`` (with ``.start``/``.end`` →
-``.line``/``.character``) — the attributes the ``test_fp_*`` /
-``test_ground_truth_tn_fn`` battery reads.
+server publishes for the source, rebuilt as real
+``lsprotocol.types.Diagnostic`` objects — exposing ``.code``, ``.message``,
+``.severity`` and ``.range`` (with ``.start``/``.end`` →
+``.line``/``.character``), the attributes the ``test_fp_*`` /
+``test_ground_truth_tn_fn`` battery reads — so the value matches the
+``list[types.Diagnostic]`` contract its caller declares.
 
 The server is started once (module singleton) and driven with a single,
 reused document URI (full-document ``didChange`` per call, version-bumped) so
@@ -20,8 +22,9 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
+
+from lsprotocol import types
 
 _REPO = Path(__file__).resolve().parent.parent
 _LOCK = threading.Lock()
@@ -56,24 +59,23 @@ def _client():
     return client
 
 
-def _to_obj(d: dict) -> SimpleNamespace:
+def _to_diagnostic(d: dict) -> types.Diagnostic:
     rng = d.get("range") or {}
     start = rng.get("start") or {}
     end = rng.get("end") or {}
-    return SimpleNamespace(
-        code=d.get("code"),
-        message=d.get("message"),
-        severity=d.get("severity"),
-        range=SimpleNamespace(
-            start=SimpleNamespace(
-                line=start.get("line", 0), character=start.get("character", 0)
-            ),
-            end=SimpleNamespace(line=end.get("line", 0), character=end.get("character", 0)),
+    severity = d.get("severity")
+    return types.Diagnostic(
+        range=types.Range(
+            start=types.Position(line=start.get("line", 0), character=start.get("character", 0)),
+            end=types.Position(line=end.get("line", 0), character=end.get("character", 0)),
         ),
+        message=d.get("message") or "",
+        severity=types.DiagnosticSeverity(severity) if severity is not None else None,
+        code=d.get("code"),
     )
 
 
-def rust_diagnostics(source: str, language_id: str = "tcl") -> list[SimpleNamespace]:
+def rust_diagnostics(source: str, language_id: str = "tcl") -> list[types.Diagnostic]:
     global _VERSION
     with _LOCK:
         client = _client()
@@ -85,4 +87,4 @@ def rust_diagnostics(source: str, language_id: str = "tcl") -> list[SimpleNamesp
             client.replace_document(_URI, version, source)
             diags = client.await_diagnostics(_URI, version=version, timeout=30.0)
             client.await_log("workspace_state.update", _URI, timeout=30.0)
-        return [_to_obj(d) for d in diags]
+        return [_to_diagnostic(d) for d in diags]


### PR DESCRIPTION
Brings the rust workstream's pre-ARCH state (CwuDW commit
5af5d49d) onto current main as a single consolidation commit.
This is necessary because origin/rust was force-pushed and
orphaned the in-flight rust work; reconstructing the individual
commit history is impractical because both lineages (origin/rust
and bd82fae9) became disjoint orphans relative to main and to
each other.

Content vendored in:
- rust/ workspace: tcl-lexer, tcl-registry, tcl-compiler, tcl-lsp-rust
- Cargo.toml, Cargo.lock, rust-toolchain.toml at repo root
- rust integration adapters in core/parsing/lexer.py,
  core/compiler/optimiser/_manager.py, core/compiler/gvn.py,
  core/compiler/interprocedural.py, core/compiler/rust_spans.py
- rust integration tests under tests/test_rust_*.py
- rust rewrite docs (rust-rewrite.md, rust-optimiser-parity.md,
  rust-rewrite-test-audit.md, kcs-qa-rust-shim-env-vars.md)

The tree at this commit matches the rust/ + rust-integration
state from CwuDW@5af5d49d. The ARCH0-9 cleanup (which depends
on this state) lands in a follow-up commit / branch.

Non-rust changes from the bd82fae9 lineage (zig runtime
modifications, scripts, baselines, Python improvements) are
intentionally NOT brought across — they are independent work,
not rust workstream content, and would conflict with main's
own evolution of those areas.