### PR TITLE
Native Rust analyser: Phase-2 precision core — battery 284→337 passing (93→40 failing)

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -1,9 +1,0 @@
-# tcl-lsp test-slow stamp — DO NOT EDIT BY HAND.
-# Written by 'make test-slow' on success; verified in CI via
-# 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
-# describe/head/date are informational (they change when this stamp is
-# committed, so they cannot be compared).
-describe=ea18ffe6-dirty
-head=ea18ffe62aae7a6d1fe10f106957b5bd04b390e5
-date=2026-06-11T10:05:06Z
-fingerprint=f92fe0ebf3f7cd214f9baa2202a2ae8c56b990cd586d8b01566c5440ee2b158d

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -4882,6 +4882,76 @@ is still **path-sensitive dataflow precision** (phi-from-undef W210, `unset`
 kill, W220 dead-store flow, `while 1`+`break` reachability) — each a CFG/SSA
 fix, not a switch.
 
+#### SYNC-JUN11-phi-undef — phi-from-undef W210 on return reads (battery 290→302)
+
+The Stage-A core, ported faithfully from `core_analyses.py::_read_before_set`
+(referencing the Python throughout; the `test_fp_*` / `test_ground_truth_*` /
+`FP.md` triples are the correctness oracle).
+
+**Root cause found via the explorer.** The def-use builder records statement +
+branch-condition uses but **not** `Terminator::Return` value reads
+(`def_use.rs:248-270` only walks `Terminator::Branch`).  So a partial-def merge
+read in a `return $v` — the dominant W210 path-merge true-positive shape — was
+never a recorded use, and the existing `DefKind::Parameter` emitter (version-0
+reads only) could not see it.  Confirmed against the SSA: `if {$x>0} {set v 1};
+return $v` builds `phi v#1 <- if_next:v#0, if_then:v#2` and the return reads the
+phi `v#1`, whose `if_next` incoming is undef.
+
+**Two landed pieces:**
+
+1. **Registry — dynamic arg-role resolver (D4-F2, `c54764be`).** `scan` /
+   `lassign` / `binary scan` hard-coded `VarWrite` for a finite slot count
+   (≤19); calls with more varName args left the tail vars unmodelled as
+   writes, so a read of var 19+ looked read-before-set.  Replaced the fixed
+   slot lists with the `arg_role_resolver` hook (already wired through
+   `registry.rs::arg_indices_for_role` and the lowering's VarWrite def walk),
+   classifying every trailing positional as `VarWrite` — `scan` args[2..],
+   `lassign` args[1..], `binary scan` args[2..].  Mirrors
+   `dialects/tcl/{scan,lassign,binary}.py`.  Root-cause fix for the many-var
+   FP-STY-11 / `test_TN_*_many_vars` false positives.
+
+2. **Analyser — `emit_return_phi_undef_w210` (`03f43e6e`).** A new pass over
+   each executable block's `Terminator::Return` value (word substitutions +
+   nested `[...]` via `VarReferenceScanner`, plus a parsed expr), firing W210
+   when the read's exit-version `phi_can_undef`:
+   - **`phi_can_undef`** — transitive trace over the phi DAG restricted to
+     SCCP-executable predecessors; version-0 / `unset`-killed origins are
+     undef, concrete defs are not, cycles (loop-header phis) resolve to
+     not-undef, per-predecessor existence guards prune.  Mirrors `_phi_can_undef`.
+   - **`unset` kill** — a *literal* `unset v` kills `v`'s reaching version; a
+     dynamic `unset $name` does **not** (it targets the named-by-value var,
+     though the IR still records a def for the bare name — the conservative
+     literal-only gate avoids that FP).
+   - **Full suppression suite** (`build_return_undef_suppression`): params,
+     `_IMPLICIT_VARS`, `::`-qualified names, scope aliases, qualified
+     `variable ns::tail` / `variable ${name}::tail` alias tails
+     (`_qualified_variable_alias_tails`), and **key-aware** `dict with` /
+     `dict update` unpacking — an empty/known-keys dict only suppresses the
+     names it unpacks (so `set d {}; dict with d {}; return $missing` still
+     fires) while an unknown-shape dict falls back to a blanket suppression.
+
+**Closed (12, no regression):** the 6 W210 merge TPs (`if`-arm-only-def,
+`switch`-no-default, dead-`if {0}`-body, loop-body-only-init, use-after-unset,
+empty-`dict with`), `test_TP_W210_array_element_read_before_any_set`, FP-DS-08
+empty-dict-fires, the FP-RBS-01/04/08 bare-read TP controls, and FP-STY-11
+scan-fewer-specifiers.  **Battery 290→302 passing / 87→75 failing**; `make
+test-lsp-e2e-rust` 24→22 failing (the W210/clean-dataflow canaries).  +14
+analyser unit tests; workspace `cargo test`/`clippy`/`fmt` clean.
+
+**Method/insight for the next increment.** The faithful approach is: read the
+Python (`_read_before_set` is the spec), verify the IR/SSA shape with the
+`compiler-explorer` skill, and treat every `test_fp_*`/`FP.md` pair as a TP+FP
+tension to satisfy — TP and FP move together, so each suppression
+(`dict`-key, alias-tail, `safe_on_uninit`, scan-resolver) is a separate
+verified piece.  The remaining W210 work is the **statement-use** phi-from-undef
+path (non-return reads — e.g. `puts $v` after a merge), which needs the same
+trace wired through the statement-use loop with the regexp/scan `provably_unset`
+suppression (`_read_before_set:3251+`) to stay sound.
+
+Updated remaining 75, by family: ground_truth 24, fp_rbs 11, fp_bnd 9, fp_ds 9,
+fp_rch 5, fp_sty 5, fp_nab 4, fp_sh 4, fp_opt 3, fp_inj 1 (the W210 merge family
+is the bulk of the ground_truth/fp_rbs drop).
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -4816,6 +4816,72 @@ Remaining 24, by cluster (worst-first, all pre-existing):
 - **irules taint** (1, IRULE3102) and **inlay-hint optional-positional labels**
   (1).
 
+#### SYNC-JUN11-precision — analyser FP-suppression increments (battery 284→290)
+
+Six targeted false-positive / true-positive precision fixes ported from the
+Python reference into the native Rust analyser, each verified against the
+fp/ground-truth battery in **rust mode** with no regression and gated on the
+full workspace (`cargo test --workspace --all-features`, `clippy
+--all-targets`, `fmt`).  All are name-/CFG-local registry-driven suppressions,
+**not** the path-sensitive dataflow core (that remains the dominant open
+cluster — see below).
+
+- **W124 OID-chain skip** (FP-STY-06) — an IPv4-shaped dotted quad that is a
+  slice of a longer dotted-digit chain (LDAP/SNMP OIDs like
+  `1.3.6.1.4.1.4203.1.11.3`) no longer fires; detect a preceding or following
+  `.<digit>`.  `DottedQuad` now carries its end offset.
+- **W302 catch fire-and-forget** (FP-STY-05) — suppress "catch without result
+  variable" on a single-statement catch body whose head is a destructive
+  builtin (`close`/`unset`/`rename`) or a documented destructive ensemble
+  subcommand (`after cancel`, `chan close`, `array`/`dict unset`,
+  `interp`/`namespace`/`file delete`).  Constructive subcommands still fire.
+- **W214 empty-body stub + quoted-keyword marker** (FP-STY-08) — an empty-body
+  proc (`proc stub {a b} {}`) is a signature placeholder (early-return on a
+  zero-statement body); a param whose name is itself a quoted literal
+  (snit `{"as" ""}`) is a positional keyword marker, not a variable read.
+- **W304 two-arg braced switch** (FP-NAB-05 / `_style.py` G12) — the
+  unambiguous `switch $x { pat body … }` form (exactly two args, trailing
+  brace-enclosed `Str`) is exempt; the split (3+ arg) form still fires.  The
+  existing `analyse_w304_constant_propagation_emits_info_with_origin` unit
+  test (which used the now-exempt braced switch as its vehicle) was re-pointed
+  at `exec $var` so it still exercises the INFO-downgrade + origin path.
+
+**Battery (rust mode):** `tests/test_fp_*.py + test_ground_truth_tn_fn.py` =
+**290 passed / 87 failed** (from 284/93), byte-identical families otherwise —
+fp_sty 11→6, fp_nab 5→4, no other family moved, no regression.  `make
+test-lsp-e2e-rust` held at **463 passed / 24 failed / 1 skipped** (unchanged
+baseline).  +14 analyser unit tests.
+
+**Attempted and reverted — phi-from-undef W210 (Stage A1/A2).** A def-use-chain
+extension that fired W210 when a use's SSA version traces (transitively, over
+the phi DAG restricted to SCCP-executable predecessors) to an undefined /
+`unset`-killed origin.  The mechanism worked but is **not** safely landable as
+a chain-based increment: the dominant target reads (`return $v` after a
+partial-def merge) are **`Terminator::Return` reads**, not statement/def-use
+uses, so they were missed; and firing on the phi/killed versions surfaced FPs
+(`incr` on an unset var = `safe_on_uninit`; `dict with` known-key unpacking;
+`unset`-then-return option propagation) that require the **full**
+`_read_before_set` suppression suite. Reverted to hold the no-regression gate.
+The faithful port (walk SSA statement uses **and** `Terminator::Return`/branch
+conditions via `exit_versions`, with the complete dict-with-key / safe-uninit /
+existence-narrowing suppression set — ~core_analyses.py:2788-3450) is the
+correct next Stage-A increment and should land worst-first as its own verified
+series.
+
+#### SYNC-JUN11-precision scoreboard
+
+| increment | family delta | battery total |
+|---|---|---|
+| W124 OID + W302 fire-and-forget | fp_sty 11→8 | 284→287 |
+| W214 empty-body + quoted-keyword | fp_sty 8→6 | 287→289 |
+| W304 braced switch | fp_nab 5→4 | 289→290 |
+
+Remaining 87, by family: ground_truth 31, fp_rbs 14, fp_ds 10, fp_bnd 9,
+fp_sty 6, fp_rch 5, fp_nab 4, fp_sh 4, fp_opt 3, fp_inj 1.  The dominant theme
+is still **path-sensitive dataflow precision** (phi-from-undef W210, `unset`
+kill, W220 dead-store flow, `while 1`+`break` reachability) — each a CFG/SSA
+fix, not a switch.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -4994,11 +4994,17 @@ test-lsp-e2e-rust` held at 22 failing throughout).  Eleven landed increments:
   unreachable block instead of dropping them, so SCCP marks them unreachable
   and **O107** fires; a `main_terminated` flag preserves the no-fall-through
   contract for nested branch bodies.
+- **CFG break/continue edges** (`bdde0f62`) — a loop-target stack lowers
+  `break`/`continue` to a `Goto` of the loop exit / continue block, so a
+  constant-condition loop's exit (`while 1 { … break }`) stays reachable and
+  O107 no longer false-fires on the post-loop code (fp_rch RCH-01).
 
-**Battery 290→316 passing / 87→61 failing** across the JUN11 sweep (session
-total from the 284 baseline: **284→316**, +32, zero regressions).  +~30
-analyser/lexer unit tests.  Remaining 61, by family: ground_truth 17, fp_rbs
-11, fp_ds 9, fp_rch 5, fp_nab 4, fp_sh 4, fp_bnd 3, fp_opt 3, fp_sty 4, fp_inj 1.
+**Battery 290→319 passing / 87→58 failing** across the JUN11 sweep (session
+total from the 284 baseline: **284→319**, +35, zero regressions — every
+remaining failure is a strict subset of the original backlog).  +~30
+analyser/lexer unit tests.  Remaining 58, by family: ground_truth 17, fp_rbs
+11, fp_ds 9, fp_nab 4, fp_sh 4, fp_bnd 3, fp_opt 3, fp_sty 4, fp_rch 2,
+fp_inj 1.
 
 **Open clusters (each a feature, not a switch), with the porting path:**
 - **regexp/scan `provably_unset`** (~8: fp_rbs RBS-02/12, fp_sty STY-10,

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -4952,6 +4952,74 @@ Updated remaining 75, by family: ground_truth 24, fp_rbs 11, fp_bnd 9, fp_ds 9,
 fp_rch 5, fp_sty 5, fp_nab 4, fp_sh 4, fp_opt 3, fp_inj 1 (the W210 merge family
 is the bulk of the ground_truth/fp_rbs drop).
 
+#### SYNC-JUN11-precision-2 — continued precision increments (battery 290→316)
+
+A further worst-first sweep, each a faithful Python port verified against the
+fp/ground-truth battery with **no regression** and the full workspace gate
+(`cargo test --workspace`, `clippy --all-targets`, `fmt`; `make
+test-lsp-e2e-rust` held at 22 failing throughout).  Eleven landed increments:
+
+- **W124 OID-chain / W302 fire-and-forget / W214 empty-body+quoted-keyword /
+  W304 braced-switch** (`294d1986`, `0392e5b0`, `2d48079a`) — registry-/CFG-
+  local FP suppressions (fp_sty 11→6, fp_nab 5→4).
+- **phi-from-undef W210 on return reads + D4-F2 scan/lassign/binary-scan
+  resolver** (`c54764be`, `755d0f9c`) — see SYNC-JUN11-phi-undef.
+- **shared dict-with/alias RBS suppression** (`2487d04d`) — thread the
+  `UndefSuppression` (dict-with keys, qualified-`variable` alias tails) through
+  the version-0 statement emitter too; a `dict with` value is resolved via SCCP
+  (interproc-empty literal) then a same-block `set`.  The statement path uses a
+  strict **known-keys-only** variant (an unknown-shape dict still fires so a
+  genuine missing-key read isn't hidden); the return path keeps the blanket
+  variant for the unknown-dict return TN.
+- **W301 single pure-var uplevel body** (`01ed4871`) — `uplevel 1 $body` (one
+  Var token) is the safe single-substitution idiom.
+- **W233 divide/modulo by a provably-zero divisor** (`8a644493`) — new pass
+  over every `[expr …]` AST (AssignExpr / branch condition / `return [expr …]`)
+  on SCCP-executable blocks; literal-`0` or SCCP-const-`0` divisor fires.
+  Reachability-aware: short-circuit `&&`/`||` and ternary arms are only walked
+  when the guard provably selects them (`0 && 1/0` silent, `1.0 && 1/0` fires).
+- **case-insensitive expr boolean lexer** (`d0036739`) — `True`/`YES`/`Off`
+  are booleans per `Tcl_GetBoolean` (was lowercase-only, so `True` lexed as a
+  function name).
+- **dispatch-protocol W214 suppression** (`88fc229b`) — port
+  `_dispatch_protocol_signatures`: ≥3 namespace peers sharing a leading-param
+  signature + an arity-compatible `$cmd` dispatcher (added `argc` to
+  `VarCommandSite`) make those params an external contract, not unused.
+- **`incr` on an uninit var** (`390124d0`) — the version-0 read `incr z`
+  records is a safe self-initialisation (8.5+), not RBS; the `safe_on_uninit`
+  skip now also covers `Statement::Incr`.
+- **CFG post-terminator dead code** (`717ff8ac`) — `lower_script` routes
+  statements after a `return` (and the `error`/`throw`/`exit`
+  `TERMINATES_BLOCK` set, promoted to a `Return` terminator) into an orphan
+  unreachable block instead of dropping them, so SCCP marks them unreachable
+  and **O107** fires; a `main_terminated` flag preserves the no-fall-through
+  contract for nested branch bodies.
+
+**Battery 290→316 passing / 87→61 failing** across the JUN11 sweep (session
+total from the 284 baseline: **284→316**, +32, zero regressions).  +~30
+analyser/lexer unit tests.  Remaining 61, by family: ground_truth 17, fp_rbs
+11, fp_ds 9, fp_rch 5, fp_nab 4, fp_sh 4, fp_bnd 3, fp_opt 3, fp_sty 4, fp_inj 1.
+
+**Open clusters (each a feature, not a switch), with the porting path:**
+- **regexp/scan `provably_unset`** (~8: fp_rbs RBS-02/12, fp_sty STY-10,
+  scan_genuine) — needs the `_read_before_set:3251+` post-pass that runs a real
+  regex match / `scan_provably_no_match` on literal pattern+input and marks the
+  output vars undef.  The `regexp` VarWrite resolver is coupled to this: alone
+  it fixes the nocase/with-options TNs but regresses the no-match TPs (output
+  becomes an unconditional def), so the two must land together.
+- **interproc dict const propagation** (~5: fp_ds DS-09, ground_truth interproc)
+  — needs `_collect_call_site_constants` + the SCCP barrier v0-preserve so a
+  callee `dict with $param` sees the caller's literal.
+- **W307 var-as-command** (4) — nested-`[…]`-command diagnostic dispatch +
+  array-element/return-literal command resolution.
+- **bounds W231/W232** — SCCP list-value resolution + nested-command dispatch
+  (`return [string index …]`).
+- **fp_rch break-edge reachability** (5) — model `break`/`continue` as CFG
+  edges so a `while 1 { … break }` post-loop block stays reachable.
+- **fp_ds W220 array-element place-model** (~3), **fp_sh shimmer S10x** (4),
+  **fp_opt O106/O109/O116** (3), and the residual misc (namespace-ensemble
+  resolution, `eval [list set …]` def recognition, S101 intrep-thrash).
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -843,6 +843,7 @@ impl Analyser {
                     method_name,
                     cmd_span: cmd_tok.span,
                     in_method,
+                    argc: args.len(),
                 });
             }
             TokenType::Cmd => {

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -4230,11 +4230,28 @@ file; this call falls through to the 'unknown' handler."
         fu: &crate::compilation_unit::FunctionUnit,
         ir_proc: &crate::ir::Procedure,
     ) {
+        // Empty-body procs (``proc foo {a b} {}``) are signature
+        // placeholders — stubs declaring an API whose implementation
+        // lives elsewhere.  Every parameter is necessarily "unused"
+        // since there is no body to use it, so flagging is pure noise.
+        // Mirrors the `not body.statements` early return in
+        // `_diag_var_lifecycle.py::_emit_unused_param_diagnostics`.
+        if ir_proc.body.statements.is_empty() {
+            return;
+        }
         for param in &ir_proc.params {
             // Tcl's variadic ``args`` parameter is conventionally
             // declared even when unused (as a "consume the rest"
             // marker).  Skip it from W214.
             if param == "args" {
+                continue;
+            }
+            // Positional keyword markers: a param whose name is itself a
+            // quoted literal (snit-style ``{"as" ""}``) is a syntactic
+            // placeholder consumed by being PRESENT in the call form, not
+            // read as a variable.  Flagging it is noise.  Conservative:
+            // only suppress params whose name starts AND ends with ``"``.
+            if param.len() >= 2 && param.starts_with('"') && param.ends_with('"') {
                 continue;
             }
             let any_live = fu
@@ -8222,6 +8239,45 @@ foo
         assert!(
             !r.diagnostics.iter().any(|d| d.code == "W302"),
             "W302 must be suppressed on `catch {{chan close ...}}`; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w214_empty_body_stub_silent() {
+        // FP-STY-08: `proc stub {a b} {}` is a signature placeholder — no
+        // W214 on its necessarily-unused params.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc stub {a b} {}", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W214"),
+            "W214 must be suppressed on an empty-body stub; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w214_quoted_keyword_marker_silent() {
+        // FP-STY-08: a param named `"as"` is a snit-style keyword marker.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc xyz {\"as\" v} { return $v }", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W214"),
+            "W214 must not fire on a quoted-keyword param; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w214_genuine_unused_param_still_fires() {
+        // TP control: a normal unused param in a non-empty body still fires.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc f {a b} { return $a }", "tcl");
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == "W214" && d.message.contains("'b'")),
+            "W214 must still fire on a genuine unused param; got {:?}",
             r.diagnostics,
         );
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -798,16 +798,10 @@ const TCL_REGEX_METACHARS: &str = r"\^$.|?*+()[]{}";
 fn is_regexp_literal_safe_switch(opt: &str) -> bool {
     matches!(
         opt,
-        "-indices"
-            | "-inline"
-            | "-all"
-            | "-line"
-            | "-lineanchor"
-            | "-linestop"
-            | "-expanded"
-            | "-start"
-            | "--"
+        "-indices" | "-inline" | "-all" | "-line" | "-lineanchor" | "-linestop" | "-start" | "--"
     )
+    // `-expanded` is handled separately (whitespace/comment-gated) by the
+    // caller, so it is intentionally not listed here.
 }
 
 /// True iff `regexp PATTERN INPUT` provably returns 0.  Sound only when
@@ -819,6 +813,7 @@ fn regexp_literal_no_match(pat: &str, inp: &str, options: &[String]) -> bool {
         return false;
     }
     let mut nocase = false;
+    let mut expanded = false;
     for opt in options {
         if !opt.starts_with('-') {
             continue; // an option value (e.g. after `-start`)
@@ -827,10 +822,22 @@ fn regexp_literal_no_match(pat: &str, inp: &str, options: &[String]) -> bool {
             nocase = true;
             continue;
         }
+        if opt == "-expanded" {
+            expanded = true;
+            continue;
+        }
         if is_regexp_literal_safe_switch(opt) {
             continue;
         }
         return false; // unknown / unsafe switch
+    }
+    // `-expanded` makes Tcl ignore unescaped whitespace and `#`-comments in
+    // the pattern, so a pattern containing either is NOT a plain substring
+    // (`regexp -expanded {a b} {ab}` matches).  Bail in that case so the
+    // no-match proof stays sound — a whitespace/comment-free literal is
+    // still safe.
+    if expanded && pat.chars().any(|c| c.is_whitespace() || c == '#') {
+        return false;
     }
     if nocase {
         !inp.to_lowercase().contains(&pat.to_lowercase())
@@ -9566,6 +9573,19 @@ foo
         // Embedded in a negated condition fires on the no-match arm.
         assert!(
             w210_codes("proc f {} { if {![regexp {x} y -> v]} { puts $v } }")
+                .iter()
+                .any(|m| m.contains("'v'"))
+        );
+    }
+
+    #[test]
+    fn w210_regexp_expanded_whitespace_pattern_silent() {
+        // `-expanded` ignores whitespace, so `{a b}` matches `ab` and writes
+        // v — the no-match proof must bail (no false W210).
+        assert!(w210_codes("proc f {} { regexp -expanded {a b} ab v\n puts $v }").is_empty());
+        // A whitespace-free literal under -expanded is still safe → fires.
+        assert!(
+            w210_codes("proc f {} { regexp -expanded {x} X v\n puts $v }")
                 .iter()
                 .any(|m| m.contains("'v'"))
         );

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -704,6 +704,358 @@ fn block_dominated_by(ssa: &crate::ssa::SsaFunction, block: &str, dom: &str) -> 
     }
 }
 
+/// Implicit / interpreter-provided variables that are always defined and
+/// must never raise a read-before-set.  Mirrors `_IMPLICIT_VARS` in
+/// `compiler/core_analyses.py`.
+fn is_implicit_var(name: &str) -> bool {
+    matches!(
+        name,
+        "argc"
+            | "argv"
+            | "argv0"
+            | "auto_path"
+            | "env"
+            | "errorCode"
+            | "errorInfo"
+            | "errorResult"
+            | "tcl_interactive"
+            | "tcl_library"
+            | "tcl_patchLevel"
+            | "tcl_pkgPath"
+            | "tcl_platform"
+            | "tcl_precision"
+            | "tcl_rcFileName"
+            | "tcl_version"
+            | "tcl_wordchars"
+            | "tcl_nonwordchars"
+            | "static"
+    )
+}
+
+/// Names whose whole binding is removed by an `unset` call.  Conservative
+/// vs. `compiler/core_analyses.py`: only a **literal** bare name kills
+/// (a dynamic `unset $name` targets the variable *named by* `$name`, not
+/// `name` itself — yet the IR records `name` in the call's defs, so a
+/// `$`-stripping harvest would wrongly mark it killed).  Per-element
+/// `unset x(k)` drops one array element, not the binding, so it is
+/// skipped too.
+fn whole_unset_names(args: &[String]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut i = 0;
+    while i < args.len() && args[i].starts_with('-') {
+        let is_dashdash = args[i] == "--";
+        i += 1;
+        if is_dashdash {
+            break;
+        }
+    }
+    for raw in &args[i..] {
+        // Literal bare names only — skip dynamic (`$`/`${…}`/`[…]`) and
+        // element-subscripted (`x(k)`) targets.
+        if raw.contains('$') || raw.contains('[') || raw.contains('(') {
+            continue;
+        }
+        let base = crate::naming::normalise_var_name(raw);
+        if !base.is_empty() {
+            out.insert(base.to_string());
+        }
+    }
+    out
+}
+
+/// Phi-from-undef trace.  A use's SSA version > 0 normally proves a prior
+/// definition reached it, but a phi result whose reachable incomings
+/// include an undefined (version-0) or `unset`-killed origin only reaches
+/// on a subset of paths — the others read an unset variable.  Returns
+/// true when `(name, version)` can be undefined on some reachable path.
+///
+/// Mirrors `_phi_can_undef` in `compiler/core_analyses.py`.  Version 0 is
+/// the undef origin; an `unset`-killed version is undef; a non-phi
+/// (concrete) definition is never undef; a phi is undef if any of its
+/// reachable, non-existence-guarded incomings is undef.  Cycles
+/// (loop-header phis) conservatively resolve to *not* undef on the cycle.
+#[allow(clippy::too_many_arguments)]
+fn phi_can_undef(
+    name: &str,
+    version: crate::ssa::Version,
+    phi_def: &std::collections::HashMap<(String, crate::ssa::Version), crate::ssa::Phi>,
+    killed: &HashSet<(String, crate::ssa::Version)>,
+    considered: &HashSet<String>,
+    exists_guards: &[(String, String)],
+    ssa: &crate::ssa::SsaFunction,
+    seen: &mut HashSet<(String, crate::ssa::Version)>,
+) -> bool {
+    if version == 0 {
+        return true;
+    }
+    let key = (name.to_string(), version);
+    if killed.contains(&key) {
+        return true;
+    }
+    if seen.contains(&key) {
+        // Cycle (loop-header phi): the DFS seed already accounted for the
+        // entry path's contribution; treat the back-edge as not-undef to
+        // avoid every loop-header phi self-triggering.
+        return false;
+    }
+    let Some(phi) = phi_def.get(&key) else {
+        // Concrete (non-phi) definition reached this version — safe.
+        return false;
+    };
+    seen.insert(key.clone());
+    let mut result = false;
+    for (pred, &incoming_ver) in &phi.incoming {
+        if !considered.contains(pred) {
+            continue;
+        }
+        // A dominating existence guard proves the variable is defined at
+        // the predecessor; that incoming cannot be undef regardless of
+        // its SSA version.
+        if exists_guards
+            .iter()
+            .any(|(gv, gblk)| gv == name && block_dominated_by(ssa, pred, gblk))
+        {
+            continue;
+        }
+        if phi_can_undef(
+            name,
+            incoming_ver,
+            phi_def,
+            killed,
+            considered,
+            exists_guards,
+            ssa,
+            seen,
+        ) {
+            result = true;
+            break;
+        }
+    }
+    seen.remove(&key);
+    result
+}
+
+/// `(name, version) → Phi` index used by [`phi_can_undef`].
+type PhiDefMap = std::collections::HashMap<(String, crate::ssa::Version), crate::ssa::Phi>;
+
+/// Build the `(name, version) → Phi` index and the set of `unset`-killed
+/// versions for [`phi_can_undef`], restricted to `considered` (executable)
+/// blocks.  Mirrors the `phi_def` / `killed_versions` setup in
+/// `compiler/core_analyses.py::_read_before_set`.
+fn build_phi_undef_index(
+    ssa: &crate::ssa::SsaFunction,
+    considered: &HashSet<String>,
+) -> (PhiDefMap, HashSet<(String, crate::ssa::Version)>) {
+    use crate::ir::Statement;
+    let mut phi_def: std::collections::HashMap<(String, crate::ssa::Version), crate::ssa::Phi> =
+        std::collections::HashMap::new();
+    let mut killed: HashSet<(String, crate::ssa::Version)> = HashSet::new();
+    for bn in considered {
+        let Some(sblock) = ssa.blocks.get(bn) else {
+            continue;
+        };
+        for phi in &sblock.phis {
+            phi_def.insert((phi.name.clone(), phi.version), phi.clone());
+        }
+        for s in &sblock.statements {
+            let Statement::Call {
+                command,
+                canonical_command,
+                args,
+                ..
+            } = &s.statement
+            else {
+                continue;
+            };
+            let is_unset = canonical_command.as_deref() == Some("::unset") || command == "unset";
+            if !is_unset {
+                continue;
+            }
+            let whole = whole_unset_names(args);
+            for (def_name, def_ver) in &s.defs {
+                if whole.contains(def_name) {
+                    killed.insert((def_name.clone(), *def_ver));
+                }
+            }
+        }
+    }
+    (phi_def, killed)
+}
+
+/// Name-level suppression context for the `return`-value phi-from-undef W210
+/// pass, harvested from `dict with` / `dict update` and qualified `variable`
+/// declarations.  Mirrors the corresponding `skip` / key-set construction in
+/// `compiler/core_analyses.py::_read_before_set`.
+#[derive(Default)]
+struct ReturnUndefSuppression {
+    /// A `dict with` / `dict update` is present (enables the key-aware gate).
+    has_dict_with: bool,
+    /// At least one dict-with target's value shape is statically unknown.
+    dict_with_any_unknown: bool,
+    /// Keys provably unpacked by some known-literal dict-with target.
+    dict_with_known_keys: HashSet<String>,
+    /// The dict-with target variable names themselves.
+    dict_vars: HashSet<String>,
+    /// Names with a concrete (version > 0) statement/phi definition.
+    explicitly_defined: HashSet<String>,
+    /// Local-alias tails declared by a qualified `variable ns::tail`.
+    alias_tails: HashSet<String>,
+}
+
+impl ReturnUndefSuppression {
+    /// True when a `return`-value read of `name` is suppressed by an alias
+    /// declaration or a `dict with` / `dict update` unpack (key-aware; a
+    /// concretely-defined name is never suppressed).
+    fn suppresses(&self, name: &str) -> bool {
+        if self.alias_tails.contains(name) || self.dict_vars.contains(name) {
+            return true;
+        }
+        self.has_dict_with
+            && !self.explicitly_defined.contains(name)
+            && (self.dict_with_any_unknown || self.dict_with_known_keys.contains(name))
+    }
+}
+
+/// Build the [`ReturnUndefSuppression`] context over `considered` blocks.
+fn build_return_undef_suppression(
+    fu: &crate::compilation_unit::FunctionUnit,
+    considered: &HashSet<String>,
+) -> ReturnUndefSuppression {
+    use crate::ir::Statement;
+    let mut s = ReturnUndefSuppression::default();
+
+    // `dict with` / `dict update`: harvest the dict-var names and, when the
+    // dict value is a same-block literal, its keys (key-aware suppression).
+    for bn in considered {
+        let Some(block) = fu.cfg.blocks.get(bn) else {
+            continue;
+        };
+        for (idx, stmt) in block.statements.iter().enumerate() {
+            let (Statement::Barrier { command, args, .. } | Statement::Call { command, args, .. }) =
+                stmt
+            else {
+                continue;
+            };
+            let is_dict = command == "dict" || stmt.canonical_command_or_source() == "::dict";
+            if !is_dict {
+                continue;
+            }
+            if args.first().map(String::as_str) != Some("with")
+                && args.first().map(String::as_str) != Some("update")
+            {
+                continue;
+            }
+            s.has_dict_with = true;
+            let Some(dict_var) = args.get(1) else {
+                s.dict_with_any_unknown = true;
+                continue;
+            };
+            let dvar = crate::naming::normalise_var_name(dict_var).to_string();
+            if dvar.is_empty() {
+                s.dict_with_any_unknown = true;
+                continue;
+            }
+            s.dict_vars.insert(dvar.clone());
+            // Backward-scan the same block for the dict's literal value.
+            let mut found = false;
+            for prev in (0..idx).rev() {
+                match &block.statements[prev] {
+                    Statement::AssignConst { name, value, .. }
+                        if crate::naming::normalise_var_name(name) == dvar =>
+                    {
+                        for (i, key) in crate::tcl_expr_eval::split_tcl_list(value)
+                            .into_iter()
+                            .enumerate()
+                        {
+                            if i % 2 == 0 {
+                                s.dict_with_known_keys.insert(key);
+                            }
+                        }
+                        found = true;
+                        break;
+                    }
+                    // A barrier between us and the literal invalidates the trace.
+                    Statement::Barrier { .. } => break,
+                    _ => {}
+                }
+            }
+            if !found {
+                s.dict_with_any_unknown = true;
+            }
+        }
+    }
+
+    // Names with a concrete (version > 0) statement or phi definition — a
+    // dict-with scope never suppresses these (they are genuinely set).
+    if s.has_dict_with {
+        for bn in considered {
+            let Some(sb) = fu.ssa.blocks.get(bn) else {
+                continue;
+            };
+            for st in &sb.statements {
+                for (n, v) in &st.defs {
+                    if *v > 0 {
+                        s.explicitly_defined.insert(n.clone());
+                    }
+                }
+            }
+            for phi in &sb.phis {
+                if phi.version > 0 {
+                    s.explicitly_defined.insert(phi.name.clone());
+                }
+            }
+        }
+    }
+
+    s.alias_tails = collect_qualified_variable_alias_tails(fu, considered);
+    s
+}
+
+/// Local-alias tail names declared by a *qualified* `variable`
+/// (`variable ns::tail` / `variable ${name}::tail`): the bare tail read
+/// resolves to the namespace var, not an unset local.  Mirrors
+/// `compiler/core_analyses.py::_qualified_variable_alias_tails`.
+fn collect_qualified_variable_alias_tails(
+    fu: &crate::compilation_unit::FunctionUnit,
+    considered: &HashSet<String>,
+) -> HashSet<String> {
+    use crate::ir::Statement;
+    let mut tails = HashSet::new();
+    for bn in considered {
+        let Some(block) = fu.cfg.blocks.get(bn) else {
+            continue;
+        };
+        for stmt in &block.statements {
+            let (Statement::Barrier { command, args, .. } | Statement::Call { command, args, .. }) =
+                stmt
+            else {
+                continue;
+            };
+            if command != "variable" && stmt.canonical_command_or_source() != "::variable" {
+                continue;
+            }
+            // `variable` alternates (name, value?) pairs — names at even args.
+            let mut i = 0;
+            while i < args.len() {
+                let text = &args[i];
+                if text.contains("::") {
+                    let tail = text.rsplit("::").next().unwrap_or(text);
+                    let (base, _) = crate::naming::split_array_name(tail);
+                    if !base.is_empty()
+                        && !base.contains('$')
+                        && !base.contains('[')
+                        && !base.contains('{')
+                    {
+                        tails.insert(crate::naming::normalise_var_name(base).to_string());
+                    }
+                }
+                i += 2;
+            }
+        }
+    }
+    tails
+}
+
 /// Collect every variable name defined anywhere in `cfg`.
 ///
 /// Mirrors `_collect_defined_vars` in
@@ -3876,6 +4228,21 @@ file; this call falls through to the 'unknown' handler."
             &scope_aliases,
             extra_known_defined,
         );
+        // Phi-from-undef on `return $v` reads (the def-use builder records
+        // statement + branch-condition uses but NOT `Terminator::Return`
+        // values).  Mirrors the `CFGReturn` arm of `_read_before_set`.
+        let rbs_params: HashSet<&str> = ir_proc
+            .map(|p| p.params.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+        let exists_guards = collect_existence_guards(function_unit);
+        self.emit_return_phi_undef_w210(
+            function_unit,
+            &rbs_params,
+            &exists_guards,
+            &scope_aliases,
+            extra_known_defined,
+            &defined,
+        );
         self.emit_constant_branch_diagnostics(function_unit);
         self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
         self.emit_invalid_ip_diagnostics(function_unit);
@@ -4445,6 +4812,127 @@ file; this call falls through to the 'unknown' handler."
                 }
                 let mut message = format!("Variable '{var}' is read before it is set");
                 if let Some(similar) = find_case_mismatch(var, defined_vars) {
+                    let _ = write!(message, "; did you mean '{similar}'?");
+                }
+                self.result.diagnostics.push(super::types::Diagnostic {
+                    code: "W210".to_string(),
+                    span,
+                    message,
+                    severity: Severity::Warning,
+                    fixes: Vec::new(),
+                });
+            }
+        }
+    }
+
+    /// W210 on `return $v` reads where `v`'s reaching version can be
+    /// undefined on some executable path (phi-from-undef / `unset`-killed).
+    /// Companion to [`Self::emit_read_before_set_diagnostics`]; see its
+    /// trailing call site for why the def-use-chain pass cannot catch
+    /// these (return values are terminator reads, not recorded uses).
+    fn emit_return_phi_undef_w210(
+        &mut self,
+        fu: &crate::compilation_unit::FunctionUnit,
+        params: &HashSet<&str>,
+        exists_guards: &[(String, String)],
+        scope_aliases: &HashSet<String>,
+        extra_known_defined: &HashSet<String>,
+        defined_vars: &HashSet<String>,
+    ) {
+        use crate::var_refs::{VarReferenceScanner, VarScanOptions};
+        use std::fmt::Write as _;
+
+        let Some(registry) = self.registry.as_ref() else {
+            return;
+        };
+
+        let considered: HashSet<String> = if fu.sccp.executable_blocks.is_empty() {
+            fu.ssa.blocks.keys().cloned().collect()
+        } else {
+            fu.sccp.executable_blocks.clone()
+        };
+        let (phi_def, killed) = build_phi_undef_index(&fu.ssa, &considered);
+        let supp = build_return_undef_suppression(fu, &considered);
+
+        let mut scanner = VarReferenceScanner::new(VarScanOptions {
+            include_var_read_roles: false,
+            recurse_cmd_substitutions: true,
+        });
+
+        let mut reported: HashSet<String> = HashSet::new();
+        // Deterministic block order for stable diagnostics.
+        let mut block_names: Vec<&String> = considered.iter().collect();
+        block_names.sort();
+
+        for bn in block_names {
+            let Some(cfg_block) = fu.cfg.blocks.get(bn) else {
+                continue;
+            };
+            let Some(crate::cfg::Terminator::Return { value, expr, .. }) = &cfg_block.terminator
+            else {
+                continue;
+            };
+            let Some(span) = cfg_block
+                .terminator
+                .as_ref()
+                .and_then(crate::cfg::Terminator::span)
+            else {
+                continue;
+            };
+            if span.is_empty() {
+                continue;
+            }
+            let Some(ssa_block) = fu.ssa.blocks.get(bn) else {
+                continue;
+            };
+
+            // Collect the variable names read by the return value (word
+            // substitutions + nested `[...]`) and any parsed expr.
+            let mut reads: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+            if let Some(v) = value {
+                reads.extend(scanner.scan_script(v, registry));
+            }
+            if let Some(e) = expr {
+                reads.extend(crate::var_refs::vars_in_expr(e));
+            }
+
+            for name in reads {
+                if reported.contains(&name) {
+                    continue;
+                }
+                let ver = ssa_block.exit_versions.get(&name).copied().unwrap_or(0);
+                let mut seen = HashSet::new();
+                if !phi_can_undef(
+                    &name,
+                    ver,
+                    &phi_def,
+                    &killed,
+                    &considered,
+                    exists_guards,
+                    &fu.ssa,
+                    &mut seen,
+                ) {
+                    continue;
+                }
+                if params.contains(name.as_str())
+                    || scope_aliases.contains(&name)
+                    || extra_known_defined.contains(&name)
+                    || is_implicit_var(&name)
+                    || name.contains("::")
+                    || supp.suppresses(&name)
+                {
+                    continue;
+                }
+                // A dominating existence guard proves the var exists here.
+                if exists_guards
+                    .iter()
+                    .any(|(gv, gblk)| *gv == name && block_dominated_by(&fu.ssa, bn, gblk))
+                {
+                    continue;
+                }
+                reported.insert(name.clone());
+                let mut message = format!("Variable '{name}' is read before it is set");
+                if let Some(similar) = find_case_mismatch(&name, defined_vars) {
                     let _ = write!(message, "; did you mean '{similar}'?");
                 }
                 self.result.diagnostics.push(super::types::Diagnostic {
@@ -8285,6 +8773,125 @@ foo
             r.diagnostics.iter().any(|d| d.code == "W304"),
             "W304 must still fire on the split switch form; got {:?}",
             r.diagnostics,
+        );
+    }
+
+    /// Helper: W210 codes for a snippet.
+    fn w210_codes(src: &str) -> Vec<String> {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl")
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W210")
+            .map(|d| d.message.clone())
+            .collect()
+    }
+
+    #[test]
+    fn w210_phi_undef_if_arm_only_def_return() {
+        // `v` is defined only when `$x > 0`; the unconditional `return $v`
+        // reads it on the no-set path too.
+        let got = w210_codes("proc f {x} { if {$x > 0} { set v 1 }\n return $v }");
+        assert!(
+            got.iter().any(|m| m.contains("'v'")),
+            "phi-from-undef merge read must fire W210; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn w210_phi_undef_switch_no_default_return() {
+        let got =
+            w210_codes("proc f {x} { switch $x { a { set v 1 } b { set v 2 } }\n return $v }");
+        assert!(
+            got.iter().any(|m| m.contains("'v'")),
+            "switch-no-default + return must fire W210; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn w210_phi_undef_use_after_unset_return() {
+        let got = w210_codes("proc f {} { set v 1\n unset v\n return $v }");
+        assert!(
+            got.iter().any(|m| m.contains("'v'")),
+            "use-after-unset return must fire W210; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn w210_phi_undef_loop_body_only_init_return() {
+        let got = w210_codes("proc f {items} { foreach i $items { lappend r $i }\n return $r }");
+        assert!(
+            got.iter().any(|m| m.contains("'r'")),
+            "loop-body-only init + return must fire W210; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn w210_no_fire_when_both_merge_arms_define() {
+        // Control: every merge predecessor defines `v` — not read-before-set.
+        let got = w210_codes("proc f {x} { if {$x > 0} { set v 1 } else { set v 2 }\n return $v }");
+        assert!(
+            got.is_empty(),
+            "both-arms-defined merge must be silent; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn w210_empty_dict_with_return_fires_but_known_key_silent() {
+        // FP-DS-08: empty dict unpacks nothing — `return $missing` fires.
+        let empty = w210_codes("proc f {} { set d {}\n dict with d {}\n return $missing }");
+        assert!(
+            empty.iter().any(|m| m.contains("'missing'")),
+            "empty dict-with return must fire W210; got {empty:?}"
+        );
+        // Known-key dict unpacks `missing` — silent.
+        let known =
+            w210_codes("proc f {} { set d {missing ok}\n dict with d {}\n return $missing }");
+        assert!(
+            known.is_empty(),
+            "known-key dict-with return must be silent; got {known:?}"
+        );
+        // Unknown-shape dict (param) — conservatively silent.
+        let unknown = w210_codes("proc f {d} { dict with d {}\n return $missing }");
+        assert!(
+            unknown.is_empty(),
+            "unknown dict-with return must be silent; got {unknown:?}"
+        );
+    }
+
+    #[test]
+    fn w210_qualified_variable_alias_tail_return_silent() {
+        // FP-RBS-04: `variable ${name}::graphAttr` declares the local alias
+        // `graphAttr`; the bare tail read is not read-before-set.
+        let got = w210_codes(
+            "proc ::ns::get {name key} { variable ${name}::graphAttr\n return $graphAttr }",
+        );
+        assert!(
+            got.is_empty(),
+            "qualified variable-alias tail read must be silent; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn w210_no_false_fire_on_many_var_scan_return() {
+        // D4-F2: the dynamic scan arg-role resolver marks every trailing
+        // varName as a write, so `return $a19` is not read-before-set.
+        let src = "proc f {} { scan {0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19} \
+{%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s} \
+a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19\n return $a19 }";
+        assert!(
+            w210_codes(src).is_empty(),
+            "20-var scan must not false-fire W210 on the tail var"
+        );
+    }
+
+    #[test]
+    fn w210_no_false_fire_on_many_var_lassign_return() {
+        let src = "proc f {l} { lassign $l a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 \
+a15 a16 a17 a18 a19 a20\n return $a20 }";
+        assert!(
+            w210_codes(src).is_empty(),
+            "21-var lassign must not false-fire W210 on the tail var"
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -887,7 +887,7 @@ fn build_phi_undef_index(
 /// declarations.  Mirrors the corresponding `skip` / key-set construction in
 /// `compiler/core_analyses.py::_read_before_set`.
 #[derive(Default)]
-struct ReturnUndefSuppression {
+struct UndefSuppression {
     /// A `dict with` / `dict update` is present (enables the key-aware gate).
     has_dict_with: bool,
     /// At least one dict-with target's value shape is statically unknown.
@@ -902,27 +902,42 @@ struct ReturnUndefSuppression {
     alias_tails: HashSet<String>,
 }
 
-impl ReturnUndefSuppression {
-    /// True when a `return`-value read of `name` is suppressed by an alias
-    /// declaration or a `dict with` / `dict update` unpack (key-aware; a
-    /// concretely-defined name is never suppressed).
+impl UndefSuppression {
+    /// True when a read of `name` is suppressed by an alias declaration or a
+    /// `dict with` / `dict update` unpack.  Blanket variant: an unknown-shape
+    /// dict suppresses every non-concrete name (the conservative
+    /// "might-have-the-key" stance, used where no truth source can confirm
+    /// the dict is empty — e.g. a `return` after a `dict with` on a param).
     fn suppresses(&self, name: &str) -> bool {
+        self.suppresses_strict(name)
+            || (self.has_dict_with
+                && self.dict_with_any_unknown
+                && !self.explicitly_defined.contains(name))
+    }
+
+    /// Like [`Self::suppresses`] but **without** the unknown-shape blanket —
+    /// only alias tails, dict vars, and *provably-unpacked* keys suppress.
+    /// Used on statement reads inside a `dict with` body, where an
+    /// unknown-shape dict (e.g. an interprocedurally-empty literal Rust's
+    /// SCCP cannot yet resolve) must still fire so a genuine missing-key read
+    /// is not hidden.
+    fn suppresses_strict(&self, name: &str) -> bool {
         if self.alias_tails.contains(name) || self.dict_vars.contains(name) {
             return true;
         }
         self.has_dict_with
             && !self.explicitly_defined.contains(name)
-            && (self.dict_with_any_unknown || self.dict_with_known_keys.contains(name))
+            && self.dict_with_known_keys.contains(name)
     }
 }
 
-/// Build the [`ReturnUndefSuppression`] context over `considered` blocks.
-fn build_return_undef_suppression(
+/// Build the [`UndefSuppression`] context over `considered` blocks.
+fn build_undef_suppression(
     fu: &crate::compilation_unit::FunctionUnit,
     considered: &HashSet<String>,
-) -> ReturnUndefSuppression {
+) -> UndefSuppression {
     use crate::ir::Statement;
-    let mut s = ReturnUndefSuppression::default();
+    let mut s = UndefSuppression::default();
 
     // `dict with` / `dict update`: harvest the dict-var names and, when the
     // dict value is a same-block literal, its keys (key-aware suppression).
@@ -956,31 +971,54 @@ fn build_return_undef_suppression(
                 continue;
             }
             s.dict_vars.insert(dvar.clone());
-            // Backward-scan the same block for the dict's literal value.
-            let mut found = false;
-            for prev in (0..idx).rev() {
-                match &block.statements[prev] {
-                    Statement::AssignConst { name, value, .. }
-                        if crate::naming::normalise_var_name(name) == dvar =>
+            // Resolve the dict's value to harvest its keys.  Prefer the
+            // SCCP CONST of the SPECIFIC version read by this dict-with (so
+            // interprocedurally-propagated literals — a caller passing `{}`
+            // — are honoured), falling back to a same-block literal `set`.
+            // A known value (even empty) harvests its keys; only a value
+            // that resolves to neither marks the dict shape unknown.
+            let mut literal: Option<String> = None;
+            if let Some(sb) = fu.ssa.blocks.get(bn) {
+                if let Some(ver) = sb
+                    .statements
+                    .get(idx)
+                    .and_then(|s| s.uses.get(&dvar).copied())
+                {
+                    if let Some(crate::analyses::LatticeValue::Const(
+                        crate::analyses::ConstValue::String(v),
+                    )) = fu.sccp.values.get(&(dvar.clone(), ver))
                     {
-                        for (i, key) in crate::tcl_expr_eval::split_tcl_list(value)
-                            .into_iter()
-                            .enumerate()
-                        {
-                            if i % 2 == 0 {
-                                s.dict_with_known_keys.insert(key);
-                            }
-                        }
-                        found = true;
-                        break;
+                        literal = Some(v.clone());
                     }
-                    // A barrier between us and the literal invalidates the trace.
-                    Statement::Barrier { .. } => break,
-                    _ => {}
                 }
             }
-            if !found {
-                s.dict_with_any_unknown = true;
+            if literal.is_none() {
+                for prev in (0..idx).rev() {
+                    match &block.statements[prev] {
+                        Statement::AssignConst { name, value, .. }
+                            if crate::naming::normalise_var_name(name) == dvar =>
+                        {
+                            literal = Some(value.clone());
+                            break;
+                        }
+                        // A barrier between us and the literal invalidates it.
+                        Statement::Barrier { .. } => break,
+                        _ => {}
+                    }
+                }
+            }
+            match literal {
+                Some(v) => {
+                    for (i, key) in crate::tcl_expr_eval::split_tcl_list(&v)
+                        .into_iter()
+                        .enumerate()
+                    {
+                        if i % 2 == 0 {
+                            s.dict_with_known_keys.insert(key);
+                        }
+                    }
+                }
+                None => s.dict_with_any_unknown = true,
             }
         }
     }
@@ -4221,20 +4259,31 @@ file; this call falls through to the 'unknown' handler."
             &textually_referenced,
         );
         self.emit_possible_paste_error_diagnostics(function_unit);
+        // Shared read-before-set context: the SCCP-executable block set and
+        // the name-level suppression (`dict with` keys, qualified-`variable`
+        // alias tails, dict vars), threaded through both the version-0
+        // statement/branch emitter and the `Terminator::Return` pass.
+        let considered: HashSet<String> = if function_unit.sccp.executable_blocks.is_empty() {
+            function_unit.ssa.blocks.keys().cloned().collect()
+        } else {
+            function_unit.sccp.executable_blocks.clone()
+        };
+        let supp = build_undef_suppression(function_unit, &considered);
+        let exists_guards = collect_existence_guards(function_unit);
+        let rbs_params: HashSet<&str> = ir_proc
+            .map(|p| p.params.iter().map(String::as_str).collect())
+            .unwrap_or_default();
         self.emit_read_before_set_diagnostics(
             function_unit,
             ir_proc,
             &defined,
             &scope_aliases,
             extra_known_defined,
+            &supp,
         );
         // Phi-from-undef on `return $v` reads (the def-use builder records
         // statement + branch-condition uses but NOT `Terminator::Return`
         // values).  Mirrors the `CFGReturn` arm of `_read_before_set`.
-        let rbs_params: HashSet<&str> = ir_proc
-            .map(|p| p.params.iter().map(String::as_str).collect())
-            .unwrap_or_default();
-        let exists_guards = collect_existence_guards(function_unit);
         self.emit_return_phi_undef_w210(
             function_unit,
             &rbs_params,
@@ -4242,6 +4291,8 @@ file; this call falls through to the 'unknown' handler."
             &scope_aliases,
             extra_known_defined,
             &defined,
+            &considered,
+            &supp,
         );
         self.emit_constant_branch_diagnostics(function_unit);
         self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
@@ -4709,6 +4760,7 @@ file; this call falls through to the 'unknown' handler."
         defined_vars: &HashSet<String>,
         scope_aliases: &HashSet<String>,
         extra_known_defined: &HashSet<String>,
+        supp: &UndefSuppression,
     ) {
         use crate::def_use::{DefKind, UseKind};
         use crate::ir::Statement;
@@ -4744,6 +4796,14 @@ file; this call falls through to the 'unknown' handler."
                 continue;
             }
             if extra_known_defined.contains(var) {
+                continue;
+            }
+            // `dict with`/`dict update` unpacking + qualified-`variable`
+            // alias tails suppress version-0 reads of the unpacked / aliased
+            // names (the `puts $a` inside `dict with d {…}` is not RBS).
+            // Strict (known-keys-only): an unknown-shape dict still fires so a
+            // genuine missing-key read inside the body is not hidden.
+            if supp.suppresses_strict(var) {
                 continue;
             }
             for use_site in &chain.uses {
@@ -4830,6 +4890,7 @@ file; this call falls through to the 'unknown' handler."
     /// Companion to [`Self::emit_read_before_set_diagnostics`]; see its
     /// trailing call site for why the def-use-chain pass cannot catch
     /// these (return values are terminator reads, not recorded uses).
+    #[allow(clippy::too_many_arguments)]
     fn emit_return_phi_undef_w210(
         &mut self,
         fu: &crate::compilation_unit::FunctionUnit,
@@ -4838,6 +4899,8 @@ file; this call falls through to the 'unknown' handler."
         scope_aliases: &HashSet<String>,
         extra_known_defined: &HashSet<String>,
         defined_vars: &HashSet<String>,
+        considered: &HashSet<String>,
+        supp: &UndefSuppression,
     ) {
         use crate::var_refs::{VarReferenceScanner, VarScanOptions};
         use std::fmt::Write as _;
@@ -4846,13 +4909,7 @@ file; this call falls through to the 'unknown' handler."
             return;
         };
 
-        let considered: HashSet<String> = if fu.sccp.executable_blocks.is_empty() {
-            fu.ssa.blocks.keys().cloned().collect()
-        } else {
-            fu.sccp.executable_blocks.clone()
-        };
-        let (phi_def, killed) = build_phi_undef_index(&fu.ssa, &considered);
-        let supp = build_return_undef_suppression(fu, &considered);
+        let (phi_def, killed) = build_phi_undef_index(&fu.ssa, considered);
 
         let mut scanner = VarReferenceScanner::new(VarScanOptions {
             include_var_read_roles: false,
@@ -4907,7 +4964,7 @@ file; this call falls through to the 'unknown' handler."
                     ver,
                     &phi_def,
                     &killed,
-                    &considered,
+                    considered,
                     exists_guards,
                     &fu.ssa,
                     &mut seen,

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -704,6 +704,15 @@ fn block_dominated_by(ssa: &crate::ssa::SsaFunction, block: &str, dom: &str) -> 
     }
 }
 
+/// The namespace of a fully-qualified name: everything up to the last `::`,
+/// or `::` for a top-level name.  Mirrors `qname.rsplit("::", 1)[0] or "::"`.
+fn namespace_of(qualified_name: &str) -> String {
+    match qualified_name.rsplit_once("::") {
+        Some((ns, _)) if !ns.is_empty() => ns.to_string(),
+        _ => "::".to_string(),
+    }
+}
+
 /// Implicit / interpreter-provided variables that are always defined and
 /// must never raise a read-before-set.  Mirrors `_IMPLICIT_VARS` in
 /// `compiler/core_analyses.py`.
@@ -4817,6 +4826,7 @@ file; this call falls through to the 'unknown' handler."
         if ir_proc.body.statements.is_empty() {
             return;
         }
+        let mut unused: Vec<String> = Vec::new();
         for param in &ir_proc.params {
             // Tcl's variadic ``args`` parameter is conventionally
             // declared even when unused (as a "consume the rest"
@@ -4856,6 +4866,37 @@ file; this call falls through to the 'unknown' handler."
                     continue;
                 }
             }
+            unused.push(param.clone());
+        }
+        if unused.is_empty() {
+            return;
+        }
+        // Dispatch-protocol suppression: when ≥3 peer procs in this
+        // namespace share this proc's leading-param signature AND an
+        // arity-compatible variable-command dispatcher exists, the leading
+        // params are an external contract, not genuinely unused.  Mirrors
+        // `_dispatch_protocol_signatures` + its W214 filter.  Computed only
+        // when there is something to report.
+        let ns = namespace_of(&ir_proc.qualified_name);
+        let leading: Vec<String> = ir_proc
+            .params
+            .iter()
+            .take_while(|p| *p != "args")
+            .cloned()
+            .collect();
+        let protocol_params: HashSet<String> = if !leading.is_empty()
+            && self
+                .dispatch_protocol_signatures()
+                .contains(&(ns, leading.clone()))
+        {
+            leading.into_iter().collect()
+        } else {
+            HashSet::new()
+        };
+        for param in unused {
+            if protocol_params.contains(&param) {
+                continue;
+            }
             let message = format!(
                 "Parameter '{param}' of proc '{name}' is unused",
                 name = ir_proc.qualified_name,
@@ -4868,6 +4909,60 @@ file; this call falls through to the 'unknown' handler."
                 fixes: Vec::new(),
             });
         }
+    }
+
+    /// Identify `(namespace, leading-param-list)` pairs that look like a
+    /// **dispatch protocol** — ≥3 peer procs in the same namespace sharing a
+    /// leading-param signature dictated by an arity-compatible
+    /// variable-command dispatcher.  Mirrors `_dispatch_protocol_signatures`
+    /// in `_diag_var_lifecycle.py`.
+    fn dispatch_protocol_signatures(&self) -> HashSet<(String, Vec<String>)> {
+        use std::collections::HashMap;
+        // Group user procs by (namespace, leading-param-tuple stopping at `args`).
+        let mut groups: HashMap<(String, Vec<String>), usize> = HashMap::new();
+        for (qname, pdef) in &self.result.all_procs {
+            let leading: Vec<String> = pdef
+                .params
+                .iter()
+                .take_while(|p| p.name != "args")
+                .map(|p| p.name.clone())
+                .collect();
+            if leading.is_empty() {
+                continue;
+            }
+            *groups.entry((namespace_of(qname), leading)).or_insert(0) += 1;
+        }
+        let peer_protos: HashSet<(String, Vec<String>)> = groups
+            .into_iter()
+            .filter(|(_, n)| *n >= 3)
+            .map(|(k, _)| k)
+            .collect();
+        if peer_protos.is_empty() {
+            return HashSet::new();
+        }
+        // Dispatcher evidence: map each dispatcher namespace → the argument
+        // counts observed at its variable-command sites.
+        let mut dispatcher_ns_argc: HashMap<String, HashSet<usize>> = HashMap::new();
+        for site in &self.var_command_sites {
+            let off = site.cmd_span.start();
+            let dns = self
+                .result
+                .all_procs
+                .iter()
+                .find(|(_, p)| p.body_span.start() <= off && off <= p.body_span.end())
+                .map_or_else(|| "::".to_string(), |(q, _)| namespace_of(q));
+            dispatcher_ns_argc.entry(dns).or_default().insert(site.argc);
+        }
+        peer_protos
+            .into_iter()
+            .filter(|(ns_key, params)| {
+                let min_argc = params.len();
+                dispatcher_ns_argc.iter().any(|(dns, argcs)| {
+                    (dns == ns_key || dns.starts_with(&format!("{ns_key}::")))
+                        && argcs.iter().any(|&a| a >= min_argc)
+                })
+            })
+            .collect()
     }
 
     /// W210 + W213 — read-before-set / unset on possibly-undefined.
@@ -9238,6 +9333,47 @@ a15 a16 a17 a18 a19 a20\n return $a20 }";
         assert!(
             !r.diagnostics.iter().any(|d| d.code == "W214"),
             "W214 must not fire on a quoted-keyword param; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w214_dispatch_protocol_suppresses_peer_family() {
+        // ≥3 peers sharing `{ctx token}` + an arity-compatible dispatcher
+        // (`$cmd $ctx $token`, 2 args) — `token` is a protocol contract.
+        let src = "namespace eval ::n {\n\
+                   proc a {ctx token} { puts $ctx }\n\
+                   proc b {ctx token} { puts $ctx }\n\
+                   proc c {ctx token} { puts $ctx }\n\
+                   proc dispatch {cmd ctx token} { $cmd $ctx $token }\n\
+                   }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == "W214" && d.message.contains("'token'")),
+            "dispatch-protocol family must suppress W214 on protocol params; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w214_no_dispatcher_still_fires_on_peer_family() {
+        // TP control: 3 peers sharing `{ctx token}` but NO dispatcher — the
+        // shared shape is coincidence, so `token` still fires.
+        let src = "namespace eval ::n {\n\
+                   proc a {ctx token} { puts $ctx }\n\
+                   proc b {ctx token} { puts $ctx }\n\
+                   proc c {ctx token} { puts $ctx }\n\
+                   }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == "W214" && d.message.contains("'token'")),
+            "without a dispatcher, an unused protocol-shaped param still fires; got {:?}",
             r.diagnostics,
         );
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -5312,6 +5312,14 @@ file; this call falls through to the 'unknown' handler."
                     continue;
                 }
                 let ver = ssa_block.exit_versions.get(&name).copied().unwrap_or(0);
+                // Version-0 return reads are now recorded in def_use, so the
+                // version-0 (`DefKind::Parameter`) emitter handles them with
+                // the full suppression set — this pass only covers the
+                // phi-from-undef / `unset`-killed (version > 0) cases, which
+                // def-use can't express.  Skipping ver 0 avoids double-firing.
+                if ver == 0 {
+                    continue;
+                }
                 let mut seen = HashSet::new();
                 if !phi_can_undef(
                     &name,

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -2622,6 +2622,20 @@ Consider capturing the result: catch {\u{2026}} result"
             return;
         };
 
+        // The braced pattern-list switch form ``switch $x { pat body … }``
+        // is NOT a runtime hazard: Tcl unambiguously identifies the
+        // trailing brace as the pattern list and never consumes the
+        // preceding word as an option.  Detect the two-arg braced form
+        // (the last arg is a brace-enclosed `Str` token) and exempt it
+        // entirely.  The SPLIT form (`switch $x -nocase {body} …`, 3+
+        // args) is still flagged.  Mirrors `_style.py` G12.
+        if cmd_name == "switch"
+            && arg_tokens.len() == 2
+            && arg_tokens.last().map(|t| t.kind) == Some(tcl_lexer::TokenType::Str)
+        {
+            return;
+        }
+
         let Some(positional_idx) = first_positional_without_terminator(args, &profile) else {
             return;
         };
@@ -8239,6 +8253,37 @@ foo
         assert!(
             !r.diagnostics.iter().any(|d| d.code == "W302"),
             "W302 must be suppressed on `catch {{chan close ...}}`; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w304_braced_switch_form_silent() {
+        // FP-NAB-05: the two-arg braced switch form is unambiguous — no W304.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc f {x} { switch $x { -nocase {puts a} default {puts b} } }",
+            "tcl",
+        );
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W304"),
+            "W304 must not fire on a two-arg braced switch; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w304_split_switch_form_still_fires() {
+        // TP control: the split (3+ arg) switch form with a dynamic string
+        // before an explicit option still warrants `--`.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc f {x} { switch $x -nocase {puts a} default {puts b} }",
+            "tcl",
+        );
+        assert!(
+            r.diagnostics.iter().any(|d| d.code == "W304"),
+            "W304 must still fire on the split switch form; got {:?}",
             r.diagnostics,
         );
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -789,6 +789,105 @@ fn whole_unset_names(args: &[String]) -> HashSet<String> {
     out
 }
 
+/// Tcl ARE metacharacters: a pattern free of these reduces to a literal
+/// substring search.  Mirrors `_TCL_REGEX_METACHARS`.
+const TCL_REGEX_METACHARS: &str = r"\^$.|?*+()[]{}";
+
+/// `regexp` switches that don't change match-vs-no-match for a pure-literal
+/// pattern.  Mirrors `_REGEXP_LITERAL_SAFE_SWITCHES`.
+fn is_regexp_literal_safe_switch(opt: &str) -> bool {
+    matches!(
+        opt,
+        "-indices"
+            | "-inline"
+            | "-all"
+            | "-line"
+            | "-lineanchor"
+            | "-linestop"
+            | "-expanded"
+            | "-start"
+            | "--"
+    )
+}
+
+/// True iff `regexp PATTERN INPUT` provably returns 0.  Sound only when
+/// `pat` is a pure-literal pattern (no ARE metacharacters), reducing the
+/// match to substring search.  Unknown / unsafe switches bail (return
+/// `false` = cannot prove no-match).  Mirrors `_regexp_literal_no_match`.
+fn regexp_literal_no_match(pat: &str, inp: &str, options: &[String]) -> bool {
+    if pat.chars().any(|c| TCL_REGEX_METACHARS.contains(c)) {
+        return false;
+    }
+    let mut nocase = false;
+    for opt in options {
+        if !opt.starts_with('-') {
+            continue; // an option value (e.g. after `-start`)
+        }
+        if opt == "-nocase" {
+            nocase = true;
+            continue;
+        }
+        if is_regexp_literal_safe_switch(opt) {
+            continue;
+        }
+        return false; // unknown / unsafe switch
+    }
+    if nocase {
+        !inp.to_lowercase().contains(&pat.to_lowercase())
+    } else {
+        !inp.contains(pat)
+    }
+}
+
+/// `Some(true)` when a `regexp` / `scan` call (`is_regexp` selects the arg
+/// order) with literal pattern + input provably can't match; `Some(false)`
+/// when it might match; `None` when the args can't be statically resolved
+/// (dynamic substitution, too few args).  Mirrors the per-call arm of the
+/// `provably_unset` setup in `_read_before_set`.
+fn regexp_scan_no_match(is_regexp: bool, args: &[String]) -> Option<bool> {
+    let value_opts: &[&str] = if is_regexp { &["-start"] } else { &[] };
+    let pos = skip_options(args, value_opts);
+    if pos + 1 >= args.len() {
+        return None;
+    }
+    let a = &args[pos];
+    let b = &args[pos + 1];
+    // `regexp ?opts? PATTERN STRING …`; `scan STRING FORMAT …`.
+    let (pat, inp) = if is_regexp { (a, b) } else { (b, a) };
+    // Dynamic substitution markers — runtime value unknown.
+    if pat.contains(['$', '[']) || inp.contains(['$', '[']) {
+        return None;
+    }
+    if is_regexp {
+        let opts: Vec<String> = args[..pos].to_vec();
+        Some(regexp_literal_no_match(pat, inp, &opts))
+    } else {
+        Some(crate::scan_predicate::scan_provably_no_match(pat, inp))
+    }
+}
+
+/// Index of the first non-option argument in `args`, skipping `-option`
+/// flags and the values of options in `value_opts`.  Mirrors `skip_options`.
+fn skip_options(args: &[String], value_opts: &[&str]) -> usize {
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        if a == "--" {
+            i += 1;
+            break;
+        }
+        if a.starts_with('-') {
+            i += 1;
+            if value_opts.contains(&a.as_str()) && i < args.len() {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    i
+}
+
 /// Phi-from-undef trace.  A use's SSA version > 0 normally proves a prior
 /// definition reached it, but a phi result whose reachable incomings
 /// include an undefined (version-0) or `unset`-killed origin only reaches
@@ -4465,6 +4564,8 @@ file; this call falls through to the 'unknown' handler."
             &considered,
             &supp,
         );
+        // W210 on reads of a provably-no-match regexp / scan output var.
+        self.emit_provably_unset_w210(function_unit, &considered, &defined);
         self.emit_constant_branch_diagnostics(function_unit);
         self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
         self.emit_invalid_ip_diagnostics(function_unit);
@@ -5250,6 +5351,192 @@ file; this call falls through to the 'unknown' handler."
                     severity: Severity::Warning,
                     fixes: Vec::new(),
                 });
+            }
+        }
+    }
+
+    /// **W210 (provably-unset regexp / scan output).** A `regexp` / `scan`
+    /// with literal pattern + input that can be statically proven not to
+    /// match leaves its output variables unset, so a later read of one is a
+    /// real read-before-set.  Handles both the top-level call form and the
+    /// call embedded in an `if` / `while` condition (firing only on the
+    /// no-match branch).  Mirrors the `provably_unset` post-pass in
+    /// `compiler/core_analyses.py::_read_before_set`.
+    fn emit_provably_unset_w210(
+        &mut self,
+        fu: &crate::compilation_unit::FunctionUnit,
+        considered: &HashSet<String>,
+        defined_vars: &HashSet<String>,
+    ) {
+        use crate::ir::Statement;
+        use std::fmt::Write as _;
+
+        // var name -> (def_block, def_stmt_idx); idx == -1 means "from the
+        // start of the block" (the embedded-condition no-match target).
+        let mut provably_unset: std::collections::HashMap<String, (String, i32)> =
+            std::collections::HashMap::new();
+
+        for bn in considered {
+            let Some(block) = fu.cfg.blocks.get(bn) else {
+                continue;
+            };
+            // Top-level regexp / scan calls.
+            for (idx, stmt) in block.statements.iter().enumerate() {
+                let Statement::Call {
+                    command,
+                    canonical_command,
+                    args,
+                    defs,
+                    ..
+                } = stmt
+                else {
+                    continue;
+                };
+                let canon = canonical_command.as_deref().unwrap_or(command);
+                let is_regexp = canon == "::regexp" || command == "regexp";
+                let is_scan = canon == "::scan" || command == "scan";
+                if (!is_regexp && !is_scan) || defs.is_empty() {
+                    continue;
+                }
+                if let Some(no_match) = regexp_scan_no_match(is_regexp, args) {
+                    if no_match {
+                        for d in defs {
+                            provably_unset.entry(d.clone()).or_insert_with(|| {
+                                (bn.clone(), i32::try_from(idx).unwrap_or(i32::MAX))
+                            });
+                        }
+                    }
+                }
+            }
+            // regexp / scan embedded in the branch condition.
+            if let Some(crate::cfg::Terminator::Branch {
+                condition,
+                true_target,
+                false_target,
+                ..
+            }) = &block.terminator
+            {
+                Self::collect_embedded_provably_unset(
+                    condition,
+                    true_target,
+                    false_target,
+                    &mut provably_unset,
+                );
+            }
+        }
+
+        if provably_unset.is_empty() {
+            return;
+        }
+
+        // Fire on every executable use after the def (same block) or in a
+        // block dominated by the def block.
+        let mut reported: HashSet<String> = HashSet::new();
+        let mut block_names: Vec<&String> = considered.iter().collect();
+        block_names.sort();
+        for bn in block_names {
+            let Some(ssa_block) = fu.ssa.blocks.get(bn) else {
+                continue;
+            };
+            for (idx, s) in ssa_block.statements.iter().enumerate() {
+                for name in s.uses.keys() {
+                    if reported.contains(name) {
+                        continue;
+                    }
+                    let Some((def_block, def_idx)) = provably_unset.get(name) else {
+                        continue;
+                    };
+                    let in_def_block_after =
+                        bn == def_block && i32::try_from(idx).unwrap_or(i32::MAX) > *def_idx;
+                    let dominated = bn != def_block && block_dominated_by(&fu.ssa, bn, def_block);
+                    if !(in_def_block_after || dominated) {
+                        continue;
+                    }
+                    let span = match fu.cfg.blocks.get(bn).and_then(|b| b.statements.get(idx)) {
+                        Some(st) if !st.span().is_empty() => st.span(),
+                        _ => continue,
+                    };
+                    reported.insert(name.clone());
+                    let mut message = format!("Variable '{name}' is read before it is set");
+                    if let Some(similar) = find_case_mismatch(name, defined_vars) {
+                        let _ = write!(message, "; did you mean '{similar}'?");
+                    }
+                    self.result.diagnostics.push(super::types::Diagnostic {
+                        code: "W210".to_string(),
+                        span,
+                        message,
+                        severity: Severity::Warning,
+                        fixes: Vec::new(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Walk a branch `condition` for an embedded `[regexp …]` / `[scan …]`
+    /// command substitution that provably can't match, recording its output
+    /// variables as provably-unset on the no-match branch target (only when
+    /// the condition is exactly `[cmd]` → false target, or `![cmd]` → true
+    /// target; more complex shapes are skipped).
+    fn collect_embedded_provably_unset(
+        condition: &ExprNode,
+        true_target: &str,
+        false_target: &str,
+        provably_unset: &mut std::collections::HashMap<String, (String, i32)>,
+    ) {
+        let (cmd_node, no_match_target) = match condition {
+            ExprNode::Command { .. } => (condition, false_target),
+            ExprNode::Unary {
+                op: UnaryOp::Not | UnaryOp::WordNot,
+                operand,
+            } if matches!(operand.as_ref(), ExprNode::Command { .. }) => {
+                (operand.as_ref(), true_target)
+            }
+            _ => return,
+        };
+        let ExprNode::Command { text, .. } = cmd_node else {
+            return;
+        };
+        // Strip the surrounding `[` … `]` and segment the interior.
+        let inner = text
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .unwrap_or(text);
+        let segs = crate::segmenter::segment_commands(inner);
+        let Some(seg) = segs.first() else {
+            return;
+        };
+        let Some(cmd) = seg.texts.first() else {
+            return;
+        };
+        let bare = cmd
+            .trim_start_matches(':')
+            .rsplit("::")
+            .next()
+            .unwrap_or(cmd);
+        let is_regexp = bare == "regexp";
+        let is_scan = bare == "scan";
+        if !is_regexp && !is_scan {
+            return;
+        }
+        let args: Vec<String> = seg.texts[1..].to_vec();
+        let pos = skip_options(&args, if is_regexp { &["-start"] } else { &[] });
+        if pos + 2 > args.len() {
+            return;
+        }
+        let out_vars = &args[(pos + 2).min(args.len())..];
+        if out_vars.is_empty() {
+            return;
+        }
+        if regexp_scan_no_match(is_regexp, &args) != Some(true) {
+            return;
+        }
+        for v in out_vars {
+            let name = crate::naming::normalise_var_name(v);
+            if !name.is_empty() {
+                provably_unset
+                    .entry(name.to_string())
+                    .or_insert_with(|| (no_match_target.to_string(), -1));
             }
         }
     }
@@ -9233,6 +9520,34 @@ foo
             got.iter().any(|m| m.contains("'v'")),
             "switch-no-default + return must fire W210; got {got:?}"
         );
+    }
+
+    #[test]
+    fn w210_provably_no_match_regexp_scan() {
+        // Provably-no-match output reads fire.
+        assert!(w210_codes("proc f {} { scan abc %d n\n puts $n }")
+            .iter()
+            .any(|m| m.contains("'n'")));
+        assert!(w210_codes("proc f {} { regexp {x} y -> v\n puts $v }")
+            .iter()
+            .any(|m| m.contains("'v'")));
+        // Embedded in a negated condition fires on the no-match arm.
+        assert!(
+            w210_codes("proc f {} { if {![regexp {x} y -> v]} { puts $v } }")
+                .iter()
+                .any(|m| m.contains("'v'"))
+        );
+    }
+
+    #[test]
+    fn w210_matchable_regexp_scan_silent() {
+        // A matchable / nocase-matchable regexp output is set — no W210.
+        assert!(w210_codes("proc f {} { regexp -nocase {x} X v\n puts $v }").is_empty());
+        assert!(w210_codes("proc f {} { scan 42 %d n\n puts $n }").is_empty());
+        // The success arm of a positive condition reads a set var.
+        assert!(w210_codes("proc f {} { if {[regexp {x} y -> v]} { puts $v } }").is_empty());
+        // An unknown / unsafe switch can't prove no-match → silent.
+        assert!(w210_codes("proc f {} { regexp -about {x} y v\n puts $v }").is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -83,7 +83,7 @@ use tcl_lexer::SourceMap;
 
 use super::state::Analyser;
 use super::types::Severity;
-use crate::expr_ast::{BinOp, ExprNode};
+use crate::expr_ast::{BinOp, ExprNode, UnaryOp};
 
 /// Find a case-insensitive match for `variable` in `defined_vars`.
 ///
@@ -880,6 +880,141 @@ fn build_phi_undef_index(
         }
     }
     (phi_def, killed)
+}
+
+/// True when an expression operand is provably the integer zero: a literal
+/// `0` (int or float spelling) or a variable whose SCCP value at `versions`
+/// is a constant zero.  Used by the W233 divide-by-zero check.
+fn expr_operand_is_zero(
+    node: &ExprNode,
+    versions: &std::collections::HashMap<String, crate::ssa::Version>,
+    sccp: &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
+) -> bool {
+    use crate::analyses::{ConstValue, LatticeValue};
+    let const_is_zero = |lv: Option<&LatticeValue>| match lv {
+        Some(LatticeValue::Const(ConstValue::Int(0) | ConstValue::Bool(false))) => true,
+        Some(LatticeValue::Const(ConstValue::Float(f))) => *f == 0.0,
+        Some(LatticeValue::Const(ConstValue::String(s))) => {
+            let t = s.trim();
+            t.parse::<i64>() == Ok(0) || t.parse::<f64>().is_ok_and(|f| f == 0.0)
+        }
+        _ => false,
+    };
+    match node {
+        ExprNode::Literal { text, .. } => {
+            let t = text.trim();
+            t.parse::<i64>() == Ok(0) || t.parse::<f64>().is_ok_and(|f| f == 0.0)
+        }
+        ExprNode::Var { name, .. } => versions
+            .get(name)
+            .is_some_and(|&ver| const_is_zero(sccp.get(&(name.clone(), ver)))),
+        _ => false,
+    }
+}
+
+/// Constant truthiness of `text` under Tcl boolean rules: a non-zero number
+/// is true, `0`/`0.0` false, and the literal boolean words (case-insensitive)
+/// map directly.  `None` when not a recognised constant.
+fn const_truthiness(text: &str) -> Option<bool> {
+    let t = text.trim();
+    if let Ok(n) = t.parse::<i64>() {
+        return Some(n != 0);
+    }
+    if let Ok(f) = t.parse::<f64>() {
+        return Some(f != 0.0);
+    }
+    match t.to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" => Some(true),
+        "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Provable truthiness of an expression operand (`Some(true)`/`Some(false)`),
+/// or `None` when not statically known.  Used to model short-circuit (`&&` /
+/// `||`) and ternary reachability for the W233 divisor walk.
+fn expr_truthiness(
+    node: &ExprNode,
+    versions: &std::collections::HashMap<String, crate::ssa::Version>,
+    sccp: &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
+) -> Option<bool> {
+    use crate::analyses::{ConstValue, LatticeValue};
+    match node {
+        ExprNode::Literal { text, .. } => const_truthiness(text),
+        ExprNode::Var { name, .. } => {
+            let ver = versions.get(name)?;
+            match sccp.get(&(name.clone(), *ver))? {
+                LatticeValue::Const(ConstValue::Int(n)) => Some(*n != 0),
+                LatticeValue::Const(ConstValue::Float(f)) => Some(*f != 0.0),
+                LatticeValue::Const(ConstValue::Bool(b)) => Some(*b),
+                LatticeValue::Const(ConstValue::String(s)) => const_truthiness(s),
+                _ => None,
+            }
+        }
+        // `-1` / `+1` keep the operand's zero-ness; `!x` / `not x` invert it.
+        ExprNode::Unary { op, operand } => match op {
+            UnaryOp::Neg | UnaryOp::Pos | UnaryOp::BitNot => {
+                expr_truthiness(operand, versions, sccp)
+            }
+            UnaryOp::Not | UnaryOp::WordNot => expr_truthiness(operand, versions, sccp).map(|b| !b),
+        },
+        _ => None,
+    }
+}
+
+/// Find the first `/` or `%` operator in `node` whose divisor is provably
+/// zero **and is actually reachable**, returning its [`BinOp`].  Models
+/// short-circuit `&&` / `||` and ternary reachability so a guarded division
+/// (`$d != 0 && 1/$d`, `0 ? 1/0 : 7`) does not fire.  Mirrors
+/// `find_divide_by_zero` (`compiler/interval_bounds.py`).
+fn find_divide_by_zero(
+    node: &ExprNode,
+    versions: &std::collections::HashMap<String, crate::ssa::Version>,
+    sccp: &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
+) -> Option<BinOp> {
+    let recurse = |n| find_divide_by_zero(n, versions, sccp);
+    match node {
+        ExprNode::Binary { op, left, right } => {
+            if matches!(op, BinOp::Div | BinOp::Mod) && expr_operand_is_zero(right, versions, sccp)
+            {
+                return Some(*op);
+            }
+            // The left operand is always evaluated.  The right operand of a
+            // short-circuit `&&` is reached only when the left is provably
+            // truthy; of `||` only when the left is provably falsy.
+            if let Some(hit) = recurse(left) {
+                return Some(hit);
+            }
+            let right_reachable = match op {
+                BinOp::And | BinOp::WordAnd => expr_truthiness(left, versions, sccp) == Some(true),
+                BinOp::Or | BinOp::WordOr => expr_truthiness(left, versions, sccp) == Some(false),
+                _ => true,
+            };
+            if right_reachable {
+                recurse(right)
+            } else {
+                None
+            }
+        }
+        ExprNode::Unary { operand, .. } => recurse(operand),
+        ExprNode::Ternary {
+            condition,
+            true_branch,
+            false_branch,
+        } => {
+            // The condition is always evaluated; an arm only when the
+            // condition provably selects it.
+            if let Some(hit) = recurse(condition) {
+                return Some(hit);
+            }
+            match expr_truthiness(condition, versions, sccp) {
+                Some(true) => recurse(true_branch),
+                Some(false) => recurse(false_branch),
+                None => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Name-level suppression context for the `return`-value phi-from-undef W210
@@ -4307,6 +4442,7 @@ file; this call falls through to the 'unknown' handler."
         self.emit_constant_branch_diagnostics(function_unit);
         self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
         self.emit_invalid_ip_diagnostics(function_unit);
+        self.emit_w233_divide_by_zero(function_unit);
         if let Some(ir_proc) = ir_proc {
             self.emit_unused_param_diagnostics(function_unit, ir_proc);
         }
@@ -5296,6 +5432,89 @@ file; this call falls through to the 'unknown' handler."
     /// Diagnostic anchors at the SSA def site (the assignment
     /// statement's span); seen-offsets dedup avoids duplicate
     /// emissions when multiple SSA versions share a def.
+    /// **W233.** Division / modulo by a provably-zero divisor — raises
+    /// "divide by zero" at runtime.  Walks every `[expr …]` AST reachable in
+    /// the function (`AssignExpr` statements, `if`/`while` branch conditions,
+    /// and `return [expr …]` values) over SCCP-executable blocks; a literal
+    /// `0` divisor or a variable whose SCCP value is a constant zero fires.
+    /// Mirrors the `find_divide_by_zero` arm of
+    /// `analyser/_analyser/_diag_interval_bounds.py`.
+    fn emit_w233_divide_by_zero(&mut self, fu: &crate::compilation_unit::FunctionUnit) {
+        use crate::cfg::Terminator;
+        use crate::ir::Statement;
+
+        let considered: HashSet<&str> = if fu.sccp.executable_blocks.is_empty() {
+            fu.ssa.blocks.keys().map(String::as_str).collect()
+        } else {
+            fu.sccp
+                .executable_blocks
+                .iter()
+                .map(String::as_str)
+                .collect()
+        };
+        let mut hits: Vec<(tcl_lexer::Span, BinOp)> = Vec::new();
+        for bn in &considered {
+            let Some(block) = fu.cfg.blocks.get(*bn) else {
+                continue;
+            };
+            let ssa_block = fu.ssa.blocks.get(*bn);
+            for (idx, stmt) in block.statements.iter().enumerate() {
+                if let Statement::AssignExpr { expr, span, .. } = stmt {
+                    let versions = ssa_block
+                        .and_then(|sb| sb.statements.get(idx))
+                        .map(|s| &s.uses);
+                    if let Some(versions) = versions {
+                        if let Some(op) = find_divide_by_zero(expr, versions, &fu.sccp.values) {
+                            hits.push((*span, op));
+                        }
+                    }
+                }
+            }
+            let exit = ssa_block.map(|sb| &sb.exit_versions);
+            let Some(exit) = exit else { continue };
+            match &block.terminator {
+                Some(Terminator::Return {
+                    expr: Some(e),
+                    span: Some(sp),
+                    ..
+                }) => {
+                    if let Some(op) = find_divide_by_zero(e, exit, &fu.sccp.values) {
+                        hits.push((*sp, op));
+                    }
+                }
+                Some(Terminator::Branch {
+                    condition,
+                    span: Some(sp),
+                    ..
+                }) => {
+                    if let Some(op) = find_divide_by_zero(condition, exit, &fu.sccp.values) {
+                        hits.push((*sp, op));
+                    }
+                }
+                _ => {}
+            }
+        }
+        for (span, op) in hits {
+            if span.is_empty() {
+                continue;
+            }
+            let verb = if op == BinOp::Div {
+                "Division"
+            } else {
+                "Modulo"
+            };
+            self.result.diagnostics.push(super::types::Diagnostic {
+                code: "W233".to_string(),
+                span,
+                message: format!(
+                    "{verb} by a provably-zero divisor — raises 'divide by zero' at runtime."
+                ),
+                severity: Severity::Warning,
+                fixes: Vec::new(),
+            });
+        }
+    }
+
     fn emit_invalid_ip_diagnostics(&mut self, fu: &crate::compilation_unit::FunctionUnit) {
         use crate::analyses::{ConstValue, LatticeValue};
         use std::net::Ipv6Addr;
@@ -8852,6 +9071,42 @@ foo
             .filter(|d| d.code == "W210")
             .map(|d| d.message.clone())
             .collect()
+    }
+
+    fn w233_codes(src: &str) -> usize {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl")
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W233")
+            .count()
+    }
+
+    #[test]
+    fn w233_divide_by_zero_literal_and_const_var() {
+        assert_eq!(w233_codes("proc f {} { return [expr {1 / 0}] }"), 1);
+        assert_eq!(w233_codes("proc f {} { return [expr {10 % 0}] }"), 1);
+        assert_eq!(
+            w233_codes("proc f {} { set d 0\n return [expr {10 / $d}] }"),
+            1
+        );
+    }
+
+    #[test]
+    fn w233_silent_on_nonzero_unknown_and_guarded() {
+        // Non-zero const + unknown divisor never fire.
+        assert_eq!(
+            w233_codes("proc f {} { set d 3\n return [expr {10 / $d}] }"),
+            0
+        );
+        assert_eq!(w233_codes("proc f {n} { return [expr {10 / $n}] }"), 0);
+        // Short-circuit / dead-arm guards make the division unreachable.
+        assert_eq!(w233_codes("proc f {} { return [expr {0 && 1/0}] }"), 0);
+        assert_eq!(w233_codes("proc f {} { return [expr {0 ? 1/0 : 7}] }"), 0);
+        assert_eq!(w233_codes("proc f {c} { return [expr {$c && 1/0}] }"), 0);
+        // Constant-truthy guard forces the arm — fires.
+        assert_eq!(w233_codes("proc f {} { return [expr {1.0 && 1/0}] }"), 1);
+        assert_eq!(w233_codes("proc f {} { return [expr {-1 && 1/0}] }"), 1);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -3462,6 +3462,16 @@ a script (like eval). Use a single braced body or {*}$cmdList to avoid injection
             {
                 return;
             }
+            // A single *pure* variable substitution (`uplevel 1 $body`) is the
+            // safe single-substitution idiom: tclsh evaluates `$body` once in
+            // the target frame, no concatenation / second substitution.  The
+            // script word must be exactly one `Var` token — a concatenation
+            // (`$a$b`, `pre$x`) is not a single token and stays flagged.
+            if arg_single.get(script_idx).copied() == Some(true)
+                && matches!(tok.kind, tcl_lexer::TokenType::Var)
+            {
+                return;
+            }
             if self.args_have_substitution(arg_tokens, arg_single) {
                 self.result.diagnostics.push(super::types::Diagnostic {
                     code: "W301".to_string(),
@@ -9521,6 +9531,11 @@ a15 a16 a17 a18 a19 a20\n return $a20 }";
         // Braced body and the `[list …]` idiom are safe.
         assert_eq!(sec_codes("uplevel 1 {set x 1}\n", "W301"), 0);
         assert_eq!(sec_codes("uplevel 1 [list set x $y]\n", "W301"), 0);
+        // A single *pure* variable script is the safe single-substitution
+        // idiom — no W301; a concatenation still fires.
+        assert_eq!(sec_codes("proc f {body} { uplevel 1 $body }\n", "W301"), 0);
+        assert_eq!(sec_codes("uplevel 1 $body\n", "W301"), 0);
+        assert_eq!(sec_codes("uplevel 1 pre$body\n", "W301"), 1);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -704,6 +704,23 @@ fn block_dominated_by(ssa: &crate::ssa::SsaFunction, block: &str, dom: &str) -> 
     }
 }
 
+/// True when a read of `var` at this use-site statement is in fact a safe
+/// self-initialisation, not a read-before-set: a `safe_on_uninit` call (e.g.
+/// `lappend`/`dict set`/`append`) that defines `var`, or an `incr` of its own
+/// target (which initialises an unset var to 0 in Tcl 8.5+).
+fn use_site_safe_initialises(stmt: Option<&crate::ir::Statement>, var: &str) -> bool {
+    use crate::ir::Statement;
+    match stmt {
+        Some(Statement::Call {
+            safe_on_uninit,
+            defs,
+            ..
+        }) => *safe_on_uninit && defs.iter().any(|d| d == var),
+        Some(Statement::Incr { name, .. }) => crate::naming::normalise_var_name(name) == var,
+        _ => false,
+    }
+}
+
 /// The namespace of a fully-qualified name: everything up to the last `::`,
 /// or `::` for a top-level name.  Mirrors `qname.rsplit("::", 1)[0] or "::"`.
 fn namespace_of(qualified_name: &str) -> String {
@@ -5098,18 +5115,11 @@ file; this call falls through to the 'unknown' handler."
                         continue;
                     }
                 }
-                // ``safe_on_uninit`` calls that initialise the
-                // variable themselves are not RBS — they handle
-                // the uninitialised case.
-                if let Some(Statement::Call {
-                    safe_on_uninit,
-                    defs,
-                    ..
-                }) = stmt_opt
-                {
-                    if *safe_on_uninit && defs.contains(var) {
-                        continue;
-                    }
+                // A use site that itself safely initialises the variable
+                // (`safe_on_uninit` calls like `lappend`/`dict set`, or an
+                // `incr` of its own target) is not read-before-set.
+                if use_site_safe_initialises(stmt_opt, var) {
+                    continue;
                 }
                 let mut message = format!("Variable '{var}' is read before it is set");
                 if let Some(similar) = find_case_mismatch(var, defined_vars) {
@@ -9223,6 +9233,16 @@ foo
             got.iter().any(|m| m.contains("'v'")),
             "switch-no-default + return must fire W210; got {got:?}"
         );
+    }
+
+    #[test]
+    fn w210_incr_on_uninit_is_silent() {
+        // `incr z` initialises z to 0 (Tcl 8.5+) — not read-before-set.
+        assert!(w210_codes("proc f {} { incr z\n return $z }").is_empty());
+        // A genuine bare read of an unset local still fires.
+        assert!(w210_codes("proc f {} { puts $z }")
+            .iter()
+            .any(|m| m.contains("'z'")));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -5160,9 +5160,11 @@ file; this call falls through to the 'unknown' handler."
             // `dict with`/`dict update` unpacking + qualified-`variable`
             // alias tails suppress version-0 reads of the unpacked / aliased
             // names (the `puts $a` inside `dict with d {…}` is not RBS).
-            // Strict (known-keys-only): an unknown-shape dict still fires so a
-            // genuine missing-key read inside the body is not hidden.
-            if supp.suppresses_strict(var) {
+            // Interproc constant propagation resolves an empty caller dict to
+            // CONST("") (keys = ∅, not unknown), so the blanket variant fires
+            // on a genuine missing-key read while still suppressing an
+            // unknown-shape (mixed-caller / no-caller) dict.
+            if supp.suppresses(var) {
                 continue;
             }
             for use_site in &chain.uses {
@@ -9520,6 +9522,28 @@ foo
             got.iter().any(|m| m.contains("'v'")),
             "switch-no-default + return must fire W210; got {got:?}"
         );
+    }
+
+    #[test]
+    fn w210_interproc_dict_with_caller_literal() {
+        // A caller passing a literal dict propagates to the callee's
+        // `dict with $param` key check (interproc constant propagation).
+        // Key present → silent.
+        assert!(
+            w210_codes("proc f {d} { dict with d { return $missing } }\nf {missing ok}\n")
+                .is_empty()
+        );
+        // Empty dict → no keys → the read fires.
+        assert!(
+            w210_codes("proc f {d} { dict with d { return $missing } }\nf {}\n")
+                .iter()
+                .any(|m| m.contains("'missing'"))
+        );
+        // Mixed callers → unknown shape → conservatively silent.
+        assert!(w210_codes(
+            "proc f {d} { dict with d { return $missing } }\nf {}\nf {missing X}\n"
+        )
+        .is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -218,6 +218,8 @@ fn is_word_byte(b: u8) -> bool {
 struct DottedQuad<'a> {
     octets: [&'a str; 4],
     start: usize,
+    /// Byte offset just past the final octet (the regex `m.end()`).
+    end: usize,
 }
 
 /// Find every `\b\d{1,N}.\d{1,N}.\d{1,N}.\d{1,N}\b` dotted quad in
@@ -234,7 +236,11 @@ fn find_dotted_quads(text: &str, max_digits: usize) -> Vec<DottedQuad<'_>> {
         let boundary_before = i == 0 || !is_word_byte(bytes[i - 1]);
         if boundary_before {
             if let Some((octets, end)) = match_dotted_quad(text, i, max_digits) {
-                out.push(DottedQuad { octets, start: i });
+                out.push(DottedQuad {
+                    octets,
+                    start: i,
+                    end,
+                });
                 i = end;
                 continue;
             }
@@ -366,6 +372,63 @@ fn has_redos_shape(pattern: &str) -> bool {
         i += 1;
     }
     false
+}
+
+/// Destructive builtins whose bare `catch {<cmd> ...}` form is the
+/// documented "fire-and-forget" idiom — failure when the target is
+/// already gone is expected and intentionally ignored.  Mirrors
+/// `analyser/compiler_checks.py::_FIRE_AND_FORGET_BARE`.
+fn fire_and_forget_bare(bare: &str) -> bool {
+    matches!(bare, "close" | "unset" | "rename")
+}
+
+/// Ensemble commands where only certain destructive subcommands are
+/// fire-and-forget (`chan close` is, `chan configure` is not).  Mirrors
+/// `_FIRE_AND_FORGET_SUBCOMMANDS`.
+fn fire_and_forget_subcommand(bare: &str, sub: &str) -> bool {
+    match bare {
+        "after" => sub == "cancel",
+        "chan" => sub == "close",
+        "array" | "dict" => sub == "unset",
+        "interp" | "file" => sub == "delete",
+        "namespace" => sub == "delete" || sub == "forget",
+        _ => false,
+    }
+}
+
+/// True when the body of a `catch` matches the documented
+/// "fire-and-forget" idiom: a single command whose head is a
+/// destructive builtin (`close $h`, `unset var`, `rename foo ""`) or a
+/// documented destructive ensemble subcommand (`after cancel`, `chan
+/// close`, `array unset`, …).  Conservative: only single-statement
+/// bodies match, and ensemble heads are subcommand-checked.  Mirrors
+/// `analyser/compiler_checks.py::_catch_body_is_fire_and_forget`.
+fn catch_body_is_fire_and_forget(body: &str) -> bool {
+    let segs: Vec<_> = crate::segmenter::segment_commands(body)
+        .into_iter()
+        .filter(|c| !c.texts.is_empty())
+        .collect();
+    if segs.len() != 1 {
+        return false;
+    }
+    let Some(head) = segs[0].texts.first() else {
+        return false;
+    };
+    if head.is_empty() {
+        return false;
+    }
+    let bare = head
+        .trim_start_matches(':')
+        .rsplit("::")
+        .next()
+        .unwrap_or(head);
+    if fire_and_forget_bare(bare) {
+        return true;
+    }
+    match segs[0].texts.get(1) {
+        Some(first_arg) => fire_and_forget_subcommand(bare, first_arg),
+        None => false,
+    }
 }
 
 /// True when `tok` is a brace-quoted word (`{…}`, a `Str` token).
@@ -1979,6 +2042,16 @@ numeric/string coercion."
         }
         if arg_tokens.is_empty() {
             return;
+        }
+        // Suppress the hint on the documented "fire-and-forget" idiom:
+        // ``catch {close $h}`` / ``catch {after cancel $h}`` etc.  These
+        // commands error when the target is already gone, and a bare
+        // ``catch {<cmd>}`` is the canonical Tcl idiom for "do this if
+        // possible, ignore if not".
+        if let Some(body) = args.first() {
+            if catch_body_is_fire_and_forget(body) {
+                return;
+            }
         }
         let span = cmd_tok.span;
         self.result.diagnostics.push(super::types::Diagnostic {
@@ -4653,7 +4726,21 @@ file; this call falls through to the 'unknown' handler."
 
             // ---- IPv4 candidates ----
             for quad in find_dotted_quads(text, 4) {
-                if quad.start > 0 && text.as_bytes()[quad.start - 1] == b'/' {
+                let bytes = text.as_bytes();
+                if quad.start > 0 && bytes[quad.start - 1] == b'/' {
+                    continue;
+                }
+                // Skip OID-like patterns: the matched quad is a slice of a
+                // longer dotted-digit chain (LDAP/SNMP OIDs like
+                // ``1.3.6.1.4.1.4203.1.11.3``).  Detect a ``digit.<quad>``
+                // before or a ``<quad>.digit`` after.
+                let before_dot_digit = quad.start >= 2
+                    && bytes[quad.start - 1] == b'.'
+                    && bytes[quad.start - 2].is_ascii_digit();
+                let after_dot_digit = quad.end + 1 < bytes.len()
+                    && bytes[quad.end] == b'.'
+                    && bytes[quad.end + 1].is_ascii_digit();
+                if before_dot_digit || after_dot_digit {
                     continue;
                 }
                 let octets = quad.octets;
@@ -8086,6 +8173,72 @@ foo
         );
         assert_eq!(w124s[0].severity, Severity::Warning);
         assert!(w124s[0].message.contains("leading zero"));
+    }
+
+    #[test]
+    fn analyse_no_w124_for_oid_chain() {
+        // FP-STY-06: an LDAP PEN OID (`1.3.6.1.4.1.4203.1.11.3`) is a
+        // hierarchical dotted chain, not IPv4 — the embedded `4203.1.11.3`
+        // slice must NOT fire W124.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc foo {} { set oid 1.3.6.1.4.1.4203.1.11.3 }", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W124"),
+            "W124 must not fire on an OID dotted chain; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn analyse_w124_real_ipv4_shaped_still_fires() {
+        // TP control: a genuine four-component dotted quad with an
+        // out-of-range octet (not part of a longer chain) still fires.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc foo {} { set ip 10.0.0.300 }", "tcl");
+        assert!(
+            r.diagnostics.iter().any(|d| d.code == "W124"),
+            "W124 must fire on a genuine over-255 IPv4 quad; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w302_fire_and_forget_bare_close_silent() {
+        // FP-STY-05: `catch {close $fh}` is the documented fire-and-forget
+        // idiom — no W302.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc f {} { catch {close $fh} }", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W302"),
+            "W302 must be suppressed on `catch {{close ...}}`; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w302_fire_and_forget_ensemble_chan_close_silent() {
+        let mut a = Analyser::new();
+        let r = a.analyse("proc f {} { catch {chan close $fh} }", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W302"),
+            "W302 must be suppressed on `catch {{chan close ...}}`; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
+    fn w302_constructive_subcommand_still_fires() {
+        // TP control: `chan configure` is constructive, not fire-and-forget.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc f {} { catch {chan configure $fh -blocking 0} }",
+            "tcl",
+        );
+        assert!(
+            r.diagnostics.iter().any(|d| d.code == "W302"),
+            "W302 must still fire on a constructive `chan configure`; got {:?}",
+            r.diagnostics,
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -36,6 +36,10 @@ pub struct VarCommandSite {
     pub cmd_span: Span,
     /// True when the call site is inside a class method body.
     pub in_method: bool,
+    /// Number of positional arguments passed at the dispatch site
+    /// (`$cmd a b c` → 3).  Used by the dispatch-protocol W214
+    /// suppression to require an arity-compatible dispatcher.
+    pub argc: usize,
 }
 
 /// One entry in [`Analyser::cmd_command_sites`] —

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2569,14 +2569,14 @@ mod tests {
 
     #[test]
     fn analyse_w304_constant_propagation_emits_info_with_origin() {
-        // ``set X "datagroup"; switch $X { default { ... } }`` — the
-        // variable resolves to a literal value that doesn't start
-        // with `-`, so severity drops to INFO and a second "origin"
-        // diagnostic anchors at the literal's range.
+        // ``set X "datagroup"; exec $X`` — the variable resolves to a
+        // literal value that doesn't start with `-`, so severity drops
+        // to INFO and a second "origin" diagnostic anchors at the
+        // literal's range.  (The two-arg braced ``switch $X { ... }``
+        // form is exempt from W304 entirely — FP-NAB-05 — so an
+        // option-bearing command that still flags is used here.)
         let src = "set totp_key_storage \"datagroup\"\n\
-                   switch $totp_key_storage {\n\
-                   \x20\x20\x20\x20default { puts ok }\n\
-                   }\n";
+                   exec $totp_key_storage\n";
         let diags = w304_diags(src);
         assert_eq!(diags.len(), 2, "got {diags:?}");
 

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -182,6 +182,14 @@ pub struct Function {
     /// Glob/regexp `switch` dispatch metadata: entry dispatch block →
     /// generic-invoke fallback info (see [`SwitchDispatch`]).
     pub switch_dispatches: HashMap<String, SwitchDispatch>,
+    /// `try` body→handler exception edges for control flow the single-
+    /// successor terminator can't express.  Consumed by SSA (as extra phi
+    /// predecessors so a handler sees the body's versions) and SCCP (as
+    /// extra reachability edges so handler bodies aren't false-unreachable
+    /// → O107).  `(from_block, handler_block)` pairs; empty in codegen
+    /// builds so the default bytecode is unchanged.  Mirrors Python's
+    /// `CFGFunction.exception_edges`.
+    pub exception_edges: Vec<(String, String)>,
 }
 
 impl Function {
@@ -197,7 +205,25 @@ impl Function {
             blocks,
             loop_nodes: HashMap::new(),
             switch_dispatches: HashMap::new(),
+            exception_edges: Vec::new(),
         }
+    }
+
+    /// All successor block names of `name`: the terminator's successors plus
+    /// any `try` exception-edge handler targets sourced at `name`.
+    #[must_use]
+    pub fn block_successors(&self, name: &str) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .blocks
+            .get(name)
+            .map(|b| b.successors().into_iter().map(str::to_owned).collect())
+            .unwrap_or_default();
+        for (from, to) in &self.exception_edges {
+            if from == name && !out.contains(to) {
+                out.push(to.clone());
+            }
+        }
+        out
     }
 
     /// Compute the predecessor map: block name → set of predecessor block names.
@@ -207,12 +233,9 @@ impl Function {
         for name in self.blocks.keys() {
             preds.entry(name.clone()).or_default();
         }
-        for (name, block) in &self.blocks {
-            for succ in block.successors() {
-                preds
-                    .entry(succ.to_owned())
-                    .or_default()
-                    .insert(name.clone());
+        for name in self.blocks.keys() {
+            for succ in self.block_successors(name) {
+                preds.entry(succ).or_default().insert(name.clone());
             }
         }
         preds
@@ -228,10 +251,10 @@ impl Function {
             if !visited.insert(name.clone()) {
                 continue;
             }
-            if let Some(block) = self.blocks.get(&name) {
-                for succ in block.successors() {
-                    if !visited.contains(succ) {
-                        queue.push_back(succ.to_owned());
+            if self.blocks.contains_key(&name) {
+                for succ in self.block_successors(&name) {
+                    if !visited.contains(&succ) {
+                        queue.push_back(succ);
                     }
                 }
             }
@@ -269,12 +292,7 @@ impl Function {
             succs: Vec<String>,
             idx: usize,
         }
-        let succs_of = |name: &str| -> Vec<String> {
-            self.blocks
-                .get(name)
-                .map(|b| b.successors().into_iter().map(str::to_owned).collect())
-                .unwrap_or_default()
-        };
+        let succs_of = |name: &str| -> Vec<String> { self.block_successors(name) };
 
         let mut visited: HashSet<String> = HashSet::new();
         let mut postorder: Vec<String> = Vec::new();

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -133,7 +133,12 @@ impl CfgBuilder {
             span: Some(*condition_span),
         });
 
-        if let Some(tail) = self.lower_script(body, &body_block) {
+        // `break` exits to `end_block`; `continue` runs the step at `step_block`.
+        self.loop_stack
+            .push((end_block.clone(), step_block.clone()));
+        let body_tail = self.lower_script(body, &body_block);
+        self.loop_stack.pop();
+        if let Some(tail) = body_tail {
             self.ensure_goto(&tail, &step_block, Some(*body_span));
         }
 
@@ -215,7 +220,11 @@ impl CfgBuilder {
             span: Some(*condition_span),
         });
 
-        if let Some(tail) = self.lower_script(body, &body_block) {
+        // `break` exits to `end_block`; `continue` re-tests at `header`.
+        self.loop_stack.push((end_block.clone(), header.clone()));
+        let body_tail = self.lower_script(body, &body_block);
+        self.loop_stack.pop();
+        if let Some(tail) = body_tail {
             self.ensure_goto(&tail, &header, Some(*body_span));
         }
 
@@ -287,7 +296,11 @@ impl CfgBuilder {
             span: Some(*span),
         });
 
-        if let Some(tail) = self.lower_script(body, &body_block) {
+        // `break` exits to `end_block`; `continue` advances at `header`.
+        self.loop_stack.push((end_block.clone(), header.clone()));
+        let body_tail = self.lower_script(body, &body_block);
+        self.loop_stack.pop();
+        if let Some(tail) = body_tail {
             self.ensure_goto(&tail, &header, Some(*body_span));
         }
 

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -511,14 +511,44 @@ impl CfgBuilder {
             self.new_block("try_ok")
         };
 
-        if let Some(tail) = self.lower_script(body, &body_block) {
-            self.ensure_goto(&tail, &post_body, Some(*body_span));
+        let body_tail = self.lower_script(body, &body_block);
+        if let Some(tail) = &body_tail {
+            self.ensure_goto(tail, &post_body, Some(*body_span));
         }
 
         // Each handler reachable from body failure.
         for handler in handlers {
             let handler_block = self.new_block("try_handler");
             self.ensure_goto(block_name, &handler_block, Some(*span));
+
+            // `block_name` already gotos `try_body` (single successor), so a
+            // real terminator edge can't reach the handler.  Record a throw
+            // edge instead — SSA uses it as an extra phi predecessor and SCCP
+            // as a reachability edge (analysis builds only).  `on ok` runs
+            // only after the body completes normally, so it observes the
+            // body's *exit* versions (source = body tail).  Every other
+            // handler runs on an abnormal completion that can occur at any
+            // point, so a body-set var is *maybe* defined: merge the
+            // pre-`try` state (version-0) with the body-exit state.  Mirrors
+            // Python `_lower_try`.
+            if self.faithful_exceptions {
+                let is_on_ok = handler.kind == "on" && handler.match_arg == "ok";
+                if is_on_ok {
+                    if let Some(tail) = &body_tail {
+                        self.exception_edges
+                            .push((tail.clone(), handler_block.clone()));
+                    }
+                } else {
+                    self.exception_edges
+                        .push((block_name.to_owned(), handler_block.clone()));
+                    if let Some(tail) = &body_tail {
+                        if tail != block_name {
+                            self.exception_edges
+                                .push((tail.clone(), handler_block.clone()));
+                        }
+                    }
+                }
+            }
 
             let mut var_defs = Vec::new();
             if let Some(vn) = &handler.var_name {

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -49,6 +49,11 @@ pub(crate) struct CfgBuilder {
     /// local`) against the actual call-site argument.  Mirrors Python
     /// `_CFGBuilder._proc_params`.
     proc_params: HashMap<String, Vec<String>>,
+    /// Stack of `(break_target, continue_target)` block names for the
+    /// enclosing loops, so `break` / `continue` in a body lower to a CFG
+    /// edge.  Without this a `while 1 { … break }` exit block is
+    /// unreachable and O107 false-fires on the code after the loop.
+    loop_stack: Vec<(String, String)>,
 }
 
 impl CfgBuilder {
@@ -69,6 +74,7 @@ impl CfgBuilder {
             inline_loops,
             upvar_procs,
             proc_params,
+            loop_stack: Vec::new(),
         }
     }
 
@@ -222,6 +228,28 @@ impl CfgBuilder {
         defs
     }
 
+    /// If `stmt` is a `break` / `continue` inside a loop, push it into
+    /// `current` and set a `Goto` terminator to the loop's exit / continue
+    /// target, returning `true`.  Returns `false` (no-op) otherwise.
+    fn lower_loop_jump(&mut self, current: &str, stmt: &Statement) -> bool {
+        let Statement::Call { command, span, .. } = stmt else {
+            return false;
+        };
+        if command != "break" && command != "continue" {
+            return false;
+        }
+        let Some((brk, cont)) = self.loop_stack.last().cloned() else {
+            return false;
+        };
+        let target = if command == "break" { brk } else { cont };
+        self.block_mut(current).statements.push(stmt.clone());
+        self.block_mut(current).terminator = Some(Terminator::Goto {
+            target,
+            span: Some(*span),
+        });
+        true
+    }
+
     /// Push a non-control-flow statement into `current` (after upvar
     /// invalidation), promoting `error` / `throw` / `exit` to a `Return`
     /// terminator so any following statements become dead code (mirrors the
@@ -335,6 +363,13 @@ impl CfgBuilder {
             if self.block_mut(&current).terminator.is_some() {
                 main_terminated = true;
                 current = self.new_block("unreachable");
+            }
+
+            // `break` / `continue` inside a loop body lower to a CFG edge to
+            // the loop's exit / continue target, so the loop-exit block stays
+            // reachable (a `while 1 { … break }` post-loop block is live).
+            if self.lower_loop_jump(&current, stmt) {
+                continue;
             }
 
             match stmt {

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -54,6 +54,12 @@ pub(crate) struct CfgBuilder {
     /// edge.  Without this a `while 1 { … break }` exit block is
     /// unreachable and O107 false-fires on the code after the loop.
     loop_stack: Vec<(String, String)>,
+    /// `try` body→handler exception edges (analysis builds only).
+    exception_edges: Vec<(String, String)>,
+    /// When `true`, record [`Self::exception_edges`] in `lower_try`.  Off for
+    /// codegen builds so the default bytecode is unchanged (mirrors Python's
+    /// `_faithful_exceptions`).
+    faithful_exceptions: bool,
 }
 
 impl CfgBuilder {
@@ -75,7 +81,15 @@ impl CfgBuilder {
             upvar_procs,
             proc_params,
             loop_stack: Vec::new(),
+            exception_edges: Vec::new(),
+            faithful_exceptions: false,
         }
+    }
+
+    /// Enable `try` exception-edge recording (analysis builds).
+    fn with_faithful_exceptions(mut self) -> Self {
+        self.faithful_exceptions = true;
+        self
     }
 
     /// Augment a statement's effective `defs` with caller-side
@@ -332,6 +346,7 @@ impl CfgBuilder {
 
         let loop_nodes = std::mem::take(&mut self.loop_nodes);
         let switch_dispatches = std::mem::take(&mut self.switch_dispatches);
+        let exception_edges = std::mem::take(&mut self.exception_edges);
 
         Function {
             name: name.to_owned(),
@@ -339,6 +354,7 @@ impl CfgBuilder {
             blocks: frozen,
             loop_nodes,
             switch_dispatches,
+            exception_edges,
         }
     }
 
@@ -703,13 +719,15 @@ pub fn build_cfg(module: &Module, defer_top_level: bool) -> CfgModule {
     let (upvar_procs, proc_params) = prepare_cfg_context(module);
 
     let mut top_builder =
-        CfgBuilder::new_with_upvars(!defer_top_level, upvar_procs.clone(), proc_params.clone());
+        CfgBuilder::new_with_upvars(!defer_top_level, upvar_procs.clone(), proc_params.clone())
+            .with_faithful_exceptions();
     let top_cfg = top_builder.build_function("::top", &module.top_level);
 
     let mut proc_cfgs = HashMap::new();
     for (qname, proc) in &module.procedures {
         let mut builder =
-            CfgBuilder::new_with_upvars(true, upvar_procs.clone(), proc_params.clone());
+            CfgBuilder::new_with_upvars(true, upvar_procs.clone(), proc_params.clone())
+                .with_faithful_exceptions();
         proc_cfgs.insert(qname.clone(), builder.build_function(qname, &proc.body));
     }
 
@@ -747,7 +765,8 @@ pub fn build_cfg_function_with_upvars(
     upvar_procs: HashMap<String, UpvarInfo>,
     proc_params: HashMap<String, Vec<String>>,
 ) -> Function {
-    let mut builder = CfgBuilder::new_with_upvars(inline_loops, upvar_procs, proc_params);
+    let mut builder = CfgBuilder::new_with_upvars(inline_loops, upvar_procs, proc_params)
+        .with_faithful_exceptions();
     builder.build_function(name, script)
 }
 

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -222,6 +222,27 @@ impl CfgBuilder {
         defs
     }
 
+    /// Push a non-control-flow statement into `current` (after upvar
+    /// invalidation), promoting `error` / `throw` / `exit` to a `Return`
+    /// terminator so any following statements become dead code (mirrors the
+    /// `TERMINATES_BLOCK` registry trait).
+    fn push_plain_statement(&mut self, current: &str, stmt: &Statement) {
+        for s in self.apply_upvar_invalidation(stmt.clone()) {
+            self.block_mut(current).statements.push(s);
+        }
+        if let Statement::Call { command, span, .. } = stmt {
+            if is_block_terminating_command(command) && self.block_mut(current).terminator.is_none()
+            {
+                self.block_mut(current).terminator = Some(Terminator::Return {
+                    value: None,
+                    span: Some(*span),
+                    expr: None,
+                    braced: false,
+                });
+            }
+        }
+    }
+
     /// Allocate a new empty block with a unique name.
     fn new_block(&mut self, prefix: &str) -> String {
         self.counter += 1;
@@ -301,12 +322,19 @@ impl CfgBuilder {
     /// the script ends with a `return`).
     fn lower_script(&mut self, script: &Script, block_name: &str) -> Option<String> {
         let mut current = block_name.to_owned();
+        // True once the *main* (reachable) path has hit an unconditional
+        // terminator — everything after is dead code captured in orphan
+        // blocks, and the script does not fall through to its caller.
+        let mut main_terminated = false;
 
         for stmt in &script.statements {
             // If the current block is already terminated, subsequent
-            // statements are dead code.
+            // statements are dead code.  Route them into a fresh orphan
+            // block with no incoming edge (rather than dropping them) so
+            // SCCP marks it unreachable and O107 can flag the dead code.
             if self.block_mut(&current).terminator.is_some() {
-                return None;
+                main_terminated = true;
+                current = self.new_block("unreachable");
             }
 
             match stmt {
@@ -387,7 +415,8 @@ impl CfgBuilder {
                         expr: expr.clone(),
                         braced: *braced,
                     });
-                    return None;
+                    // Don't return early: a following statement is dead code
+                    // and is routed to an orphan block by the loop-top check.
                 }
 
                 // Inline block (C34d): flatten the body's statements
@@ -409,14 +438,19 @@ impl CfgBuilder {
                 // `<upvar-invalidate>` `Statement::Call` when an
                 // `AssignValue` contains `[upvar_proc arg]`.
                 other => {
-                    for s in self.apply_upvar_invalidation(other.clone()) {
-                        self.block_mut(&current).statements.push(s);
-                    }
+                    self.push_plain_statement(&current, other);
                 }
             }
         }
 
-        Some(current)
+        // No fall-through when the main path terminated (a trailing orphan
+        // holding dead code is unreachable, not a fall-through edge) or the
+        // final block is itself terminated.
+        if main_terminated || self.block_mut(&current).terminator.is_some() {
+            None
+        } else {
+            Some(current)
+        }
     }
 
     /// Dispatch `Foreach` — dict for/map, opaque top-level, or inlined.
@@ -686,6 +720,14 @@ pub fn build_cfg_function_with_upvars(
 fn dedup_preserve_order(v: &mut Vec<String>) {
     let mut seen = std::collections::HashSet::new();
     v.retain(|item| seen.insert(item.clone()));
+}
+
+/// Builtin commands that unconditionally terminate the current block (the
+/// `Traits::TERMINATES_BLOCK` set).  The CFG builder has no registry handle,
+/// so the core set is matched by name here; `return` is handled separately
+/// as its own `Statement::Return`.
+fn is_block_terminating_command(command: &str) -> bool {
+    matches!(command.trim_start_matches(':'), "error" | "throw" | "exit")
 }
 
 /// Lex *text* into Tcl words, accumulating contiguous tokens between

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -443,6 +443,12 @@ fn collect_call_site_constants(
                 let Some(target) = resolve(command.as_str()) else {
                     continue;
                 };
+                // A call that omits a (defaulted) parameter uses its default,
+                // an unknown value at that slot — poison every param position
+                // this call doesn't provide so a single literal at another
+                // call site can't bind it.  Mirrors the intent of treating
+                // omitted args as `_UNKNOWN_ARG`.
+                let nparams = procedures.get(&target).map_or(0, |p| p.params.len());
                 let by_idx = out.entry(target).or_default();
                 for (i, arg) in args.iter().enumerate() {
                     let slot = by_idx.entry(i).or_default();
@@ -451,6 +457,9 @@ fn collect_call_site_constants(
                     } else {
                         slot.values.insert(arg.clone());
                     }
+                }
+                for i in args.len()..nparams {
+                    by_idx.entry(i).or_default().unknown = true;
                 }
             }
         }

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -90,9 +90,25 @@ impl FunctionUnit {
         params: &[String],
         registry: &CommandRegistry,
     ) -> Self {
+        Self::build_with_param_constants(name, cfg, params, registry, None)
+    }
+
+    /// Like [`Self::build`] but seeds SCCP with interprocedurally-collected
+    /// caller-side parameter constants (`param_constants`), so a callee that
+    /// reads a param every caller passes the same literal for folds it.
+    #[must_use]
+    pub fn build_with_param_constants(
+        name: impl Into<String>,
+        cfg: CfgFunction,
+        params: &[String],
+        registry: &CommandRegistry,
+        param_constants: Option<
+            &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
+        >,
+    ) -> Self {
         let ssa = build_ssa(&cfg, registry);
         let def_use = build_def_use_chains(&ssa, Some(&cfg));
-        let mut sccp = sccp(&cfg, &ssa, None);
+        let mut sccp = sccp(&cfg, &ssa, param_constants);
         // SYNC-MAY31-3: surface `[info exists X]` / `[array exists X]`
         // folds (parameter → exists, never-defined non-param → absent)
         // as constant branches so the optimiser's O101 fold / DCE sees
@@ -220,6 +236,10 @@ impl CompilationUnit {
         // that splices the body inline.
         crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
         let cfg_module = build_cfg(&ir_module, defer_top_level);
+        // D3-P2: collect call-site literal arg values per user proc so each
+        // callee's SCCP can fold a param every caller passes the same literal
+        // for (interprocedural constant propagation).
+        let call_site_constants = collect_call_site_constants(&cfg_module, &ir_module.procedures);
         let top_level = FunctionUnit::build("::top", cfg_module.top_level.clone(), &[], registry);
         let mut procedures: HashMap<String, FunctionUnit> = HashMap::new();
         for (qname, cfg) in &cfg_module.procedures {
@@ -227,9 +247,17 @@ impl CompilationUnit {
                 .procedures
                 .get(qname)
                 .map_or(&[][..], |p| p.params.as_slice());
+            let param_constants =
+                params_constants_from_call_sites(params, &call_site_constants, qname);
             procedures.insert(
                 qname.clone(),
-                FunctionUnit::build(qname, cfg.clone(), params, registry),
+                FunctionUnit::build_with_param_constants(
+                    qname,
+                    cfg.clone(),
+                    params,
+                    registry,
+                    param_constants.as_ref(),
+                ),
             );
         }
         // SF-2: lower TclOO method bodies (populated in
@@ -365,6 +393,102 @@ impl CompilationUnit {
     /// first, then procedures in insertion order).
     pub fn functions(&self) -> impl Iterator<Item = &FunctionUnit> {
         std::iter::once(&self.top_level).chain(self.procedures.values())
+    }
+}
+
+/// Per-arg-position call-site literal evidence for one callee.
+#[derive(Default)]
+struct ArgConsts {
+    /// At least one call passed a non-literal (`$`/`[`) value here.
+    unknown: bool,
+    /// Distinct literal values seen at this position.
+    values: std::collections::HashSet<String>,
+}
+
+/// Collect literal arg values per user-proc call site across the whole
+/// module's CFGs (top-level + every proc body, statements already flattened).
+/// Mirrors `_collect_call_site_constants`.  Returns
+/// `{callee_qname -> {arg_index -> ArgConsts}}`.
+fn collect_call_site_constants(
+    cfg_module: &CfgModule,
+    procedures: &HashMap<String, crate::ir::Procedure>,
+) -> HashMap<String, HashMap<usize, ArgConsts>> {
+    use crate::ir::Statement;
+    let mut out: HashMap<String, HashMap<usize, ArgConsts>> = HashMap::new();
+    // Resolve a call command word to a user-proc qualified name.
+    let resolve = |cmd: &str| -> Option<String> {
+        for cand in [
+            cmd.to_string(),
+            format!("::{cmd}"),
+            format!("::{}", cmd.trim_start_matches(':')),
+        ] {
+            let qn = if cand.starts_with("::") {
+                cand
+            } else {
+                format!("::{cand}")
+            };
+            if procedures.contains_key(&qn) {
+                return Some(qn);
+            }
+        }
+        None
+    };
+    let funcs = std::iter::once(&cfg_module.top_level).chain(cfg_module.procedures.values());
+    for func in funcs {
+        for block in func.blocks.values() {
+            for stmt in &block.statements {
+                let Statement::Call { command, args, .. } = stmt else {
+                    continue;
+                };
+                let Some(target) = resolve(command.as_str()) else {
+                    continue;
+                };
+                let by_idx = out.entry(target).or_default();
+                for (i, arg) in args.iter().enumerate() {
+                    let slot = by_idx.entry(i).or_default();
+                    if arg.contains(['$', '[']) {
+                        slot.unknown = true;
+                    } else {
+                        slot.values.insert(arg.clone());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Build the SCCP `param_constants` seed for `qname` from collected call-site
+/// literals: bind `(param, 0)` only when every caller passes the same single
+/// literal at that position.  Mirrors `_params_constants_from_call_sites`.
+fn params_constants_from_call_sites(
+    params: &[String],
+    call_site_constants: &HashMap<String, HashMap<usize, ArgConsts>>,
+    qname: &str,
+) -> Option<HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>> {
+    use crate::analyses::{ConstValue, LatticeValue};
+    let by_idx = call_site_constants.get(qname)?;
+    let mut consts: HashMap<crate::ssa::ValueKey, LatticeValue> = HashMap::new();
+    for (i, pname) in params.iter().enumerate() {
+        if pname == "args" {
+            break;
+        }
+        let Some(slot) = by_idx.get(&i) else {
+            continue;
+        };
+        if slot.unknown || slot.values.len() != 1 {
+            continue;
+        }
+        let val = slot.values.iter().next().unwrap().clone();
+        consts.insert(
+            (pname.clone(), 0),
+            LatticeValue::Const(ConstValue::String(val)),
+        );
+    }
+    if consts.is_empty() {
+        None
+    } else {
+        Some(consts)
     }
 }
 

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -245,32 +245,55 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
             }
         }
 
-        // Terminator uses (branch conditions).
+        // Terminator uses: branch conditions and `return` value reads.
         if let Some(cfg) = cfg {
             if let Some(cfg_block) = cfg.blocks.get(bn) {
-                if let Some(Terminator::Branch { condition, .. }) = &cfg_block.terminator {
-                    for var_name in condition.vars() {
-                        let version = block.exit_versions.get(&var_name).copied().unwrap_or(0);
-                        let key = (var_name, version);
-                        add_use(
-                            &mut chains,
-                            &ssa.entry,
-                            key,
-                            UseSite {
-                                block: bn.clone(),
-                                kind: UseKind::Terminator,
-                                statement_index: -1,
-                                variable: String::new(),
-                                phi_version: 0,
-                            },
-                        );
-                    }
+                for var_name in terminator_read_vars(cfg_block.terminator.as_ref()) {
+                    let version = block.exit_versions.get(&var_name).copied().unwrap_or(0);
+                    let key = (var_name, version);
+                    add_use(
+                        &mut chains,
+                        &ssa.entry,
+                        key,
+                        UseSite {
+                            block: bn.clone(),
+                            kind: UseKind::Terminator,
+                            statement_index: -1,
+                            variable: String::new(),
+                            phi_version: 0,
+                        },
+                    );
                 }
             }
         }
     }
 
     DefUseResult { chains }
+}
+
+/// Variable names a terminator reads: a `Branch` condition's vars, or a
+/// `return $x` value's reads.  Recording the latter (so an earlier
+/// overwritten store is a real dead store, not a "truly unused" var) matches
+/// Python, whose CFG models the return value's reads.
+fn terminator_read_vars(terminator: Option<&Terminator>) -> Vec<String> {
+    match terminator {
+        Some(Terminator::Branch { condition, .. }) => condition.vars().into_iter().collect(),
+        Some(Terminator::Return { value, expr, .. }) => {
+            let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+            if let Some(v) = value {
+                set.extend(
+                    crate::var_refs::scan_var_ref_forms(v)
+                        .into_iter()
+                        .map(|n| crate::naming::normalise_var_name(&n).to_string()),
+                );
+            }
+            if let Some(e) = expr {
+                set.extend(e.vars());
+            }
+            set.into_iter().collect()
+        }
+        _ => Vec::new(),
+    }
 }
 
 /// Append a use to an existing chain, synthesising a parameter/

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -112,6 +112,7 @@ pub mod path_concat;
 pub mod place;
 pub mod place_bridge;
 pub mod rendered_properties;
+pub mod scan_predicate;
 pub mod sccp;
 pub mod segmenter;
 pub mod shimmer;

--- a/rust/tcl-compiler/src/scan_predicate.rs
+++ b/rust/tcl-compiler/src/scan_predicate.rs
@@ -1,0 +1,195 @@
+//! Static `scan` no-match proof — `scan_provably_no_match`.
+//!
+//! Determines whether `scan INPUT FORMAT ?vars...?` is statically guaranteed
+//! to leave at least the **first** output variable unset (the first
+//! conversion can't consume any input).  Only returns `true` when fully
+//! confident; any uncertain case returns `false` so callers never fire a
+//! spurious W210.  Ported from `compiler/scan_format.py`.
+
+/// Tcl scan whitespace set (the C `isspace` characters).
+fn is_scan_ws(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{0c}' | '\u{0b}')
+}
+
+/// Advance over input whitespace.
+fn skip_leading_whitespace(s: &[char], mut i: usize) -> usize {
+    while i < s.len() && is_scan_ws(s[i]) {
+        i += 1;
+    }
+    i
+}
+
+/// Conversion-leader class for a `scan` conversion character, or `None` for
+/// an unmodelled conversion.  Mirrors `_CONV_LEADERS`.
+fn conv_leader(conv: char) -> Option<&'static str> {
+    Some(match conv {
+        'd' | 'i' | 'u' => "decimal-int",
+        'o' => "octal-int",
+        'x' | 'X' => "hex-int",
+        'b' => "binary-int",
+        'c' => "any",
+        's' => "non-space",
+        'e' | 'E' | 'f' | 'g' | 'G' => "float",
+        'n' => "always",
+        _ => return None,
+    })
+}
+
+/// True iff `s[i..]` starts with an optional sign followed by ≥1 digit from
+/// `digits`.
+fn starts_with_int(s: &[char], mut i: usize, digits: &str) -> bool {
+    if i >= s.len() {
+        return false;
+    }
+    if s[i] == '+' || s[i] == '-' {
+        i += 1;
+    }
+    i < s.len() && digits.contains(s[i])
+}
+
+/// Can the input at offset `i` satisfy a single conversion `conv`?
+/// `Some(true)`/`Some(false)`, or `None` when unmodelled.
+fn input_satisfies_conv(conv: char, s: &[char], i: usize) -> Option<bool> {
+    let kind = conv_leader(conv)?;
+    Some(match kind {
+        // `%n` writes the consumed count and never consumes input.
+        "always" => true,
+        "any" => i < s.len(),
+        "non-space" => i < s.len() && !is_scan_ws(s[i]),
+        "decimal-int" => starts_with_int(s, i, "0123456789"),
+        "octal-int" => starts_with_int(s, i, "01234567"),
+        "binary-int" => starts_with_int(s, i, "01"),
+        "hex-int" => starts_with_int(s, i, "0123456789abcdefABCDEF"),
+        "float" => {
+            if i >= s.len() {
+                return Some(false);
+            }
+            let mut j = i;
+            if s[j] == '+' || s[j] == '-' {
+                j += 1;
+                if j >= s.len() {
+                    return Some(false);
+                }
+            }
+            let c = s[j];
+            if c.is_ascii_digit() {
+                return Some(true);
+            }
+            if c == '.' && j + 1 < s.len() && s[j + 1].is_ascii_digit() {
+                return Some(true);
+            }
+            // `Inf` / `Infinity` / `NaN` (case-insensitive prefix).
+            let tail: String = s[j..].iter().collect::<String>().to_ascii_lowercase();
+            tail.starts_with("inf") || tail.starts_with("nan")
+        }
+        _ => return None,
+    })
+}
+
+/// Return `Some(true)`/`Some(false)` if we can prove the first conversion
+/// will / will not consume input; `None` when outside the modelled subset.
+fn can_consume_first_conversion(format_str: &[char], input_str: &[char]) -> Option<bool> {
+    let mut fi = 0;
+    let mut si = 0;
+    let n_fmt = format_str.len();
+    let n_inp = input_str.len();
+    while fi < n_fmt {
+        let fc = format_str[fi];
+        if fc == '%' {
+            fi += 1;
+            if fi >= n_fmt {
+                return None;
+            }
+            if format_str[fi] == '%' {
+                // `%%` matches a literal `%`.
+                if si >= n_inp || input_str[si] != '%' {
+                    return Some(false);
+                }
+                si += 1;
+                fi += 1;
+                continue;
+            }
+            // Assignment-suppression `*`.
+            if format_str[fi] == '*' {
+                fi += 1;
+                if fi >= n_fmt {
+                    return None;
+                }
+            }
+            // Width digits.
+            while fi < n_fmt && format_str[fi].is_ascii_digit() {
+                fi += 1;
+            }
+            if fi >= n_fmt {
+                return None;
+            }
+            // Size modifier (`h`, `l`, `ll`).
+            while fi < n_fmt && (format_str[fi] == 'h' || format_str[fi] == 'l') {
+                fi += 1;
+            }
+            if fi >= n_fmt {
+                return None;
+            }
+            let conv = format_str[fi];
+            if conv == '[' {
+                // Character-set conversion — unmodelled, stay conservative.
+                return None;
+            }
+            // Non-`[` conversions skip leading whitespace except `%c`/`%n`.
+            if conv != 'c' && conv != 'n' {
+                si = skip_leading_whitespace(input_str, si);
+            }
+            return input_satisfies_conv(conv, input_str, si);
+        }
+        // Whitespace directive in the format matches an input ws run.
+        if is_scan_ws(fc) {
+            fi += 1;
+            si = skip_leading_whitespace(input_str, si);
+            continue;
+        }
+        // Plain literal character: must match verbatim.
+        if si >= n_inp || input_str[si] != fc {
+            return Some(false);
+        }
+        si += 1;
+        fi += 1;
+    }
+    // No conversion in the format — nothing to write, no-match is meaningless.
+    None
+}
+
+/// True iff `scan INPUT FORMAT ?vars...?` is statically guaranteed to leave
+/// the first output variable unset.  `format_str` / `input_str` are RAW
+/// source slices (no backslash processing); a `\`, `$`, or `[` bails.
+#[must_use]
+pub fn scan_provably_no_match(format_str: &str, input_str: &str) -> bool {
+    if format_str.contains(['\\', '$', '[']) || input_str.contains(['\\', '$', '[']) {
+        return false;
+    }
+    let fmt: Vec<char> = format_str.chars().collect();
+    let inp: Vec<char> = input_str.chars().collect();
+    can_consume_first_conversion(&fmt, &inp) == Some(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provable_no_match_cases() {
+        assert!(scan_provably_no_match("%d", "abc")); // digits vs letters
+        assert!(scan_provably_no_match("%d", "")); // empty input
+        assert!(scan_provably_no_match("x%d", "y3")); // literal mismatch
+    }
+
+    #[test]
+    fn matchable_or_uncertain_cases() {
+        assert!(!scan_provably_no_match("%d", "42"));
+        assert!(!scan_provably_no_match("%s", "abc"));
+        assert!(!scan_provably_no_match("%n", "")); // %n always succeeds
+        assert!(!scan_provably_no_match("%f", "Inf"));
+        assert!(!scan_provably_no_match("\\r%d", " 123")); // backslash bail
+        assert!(!scan_provably_no_match("%[abc]", "x")); // char-set bail
+        assert!(!scan_provably_no_match("plain", "plain")); // no conversion
+    }
+}

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -387,6 +387,20 @@ fn sccp_process_terminator(
         }
         Terminator::Return { .. } => {}
     }
+    // `try` exception edges sourced at `bn`: when `bn` is executable the
+    // handler is reachable (a throw can occur in the body).
+    for (from, to) in &cfg.exception_edges {
+        if from != bn {
+            continue;
+        }
+        let edge = (bn.to_owned(), to.clone());
+        if executable_edges.insert(edge) {
+            changed = true;
+        }
+        if cfg.blocks.contains_key(to) && executable_blocks.insert(to.clone()) {
+            changed = true;
+        }
+    }
     changed
 }
 

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -288,9 +288,17 @@ pub fn sccp(
             // Statements.
             for stmt_ssa in &ssa_block.statements {
                 if matches!(stmt_ssa.statement, Statement::Barrier { .. }) {
-                    // Barriers widen all currently-tracked values.
+                    // Barriers widen all currently-tracked values — EXCEPT
+                    // version-0 (parameter) seeds, which hold the caller's
+                    // literal and are immutable across the barrier (a barrier
+                    // that mutates the var produces a fresh version).  Mirrors
+                    // Python's SCCP barrier v0-preserve refinement so a callee
+                    // `dict with $param` still sees the interproc literal.
                     let keys: Vec<ValueKey> = values.keys().cloned().collect();
                     for k in keys {
+                        if k.1 == 0 {
+                            continue;
+                        }
                         if set_value(&mut values, k, &LatticeValue::Overdefined) {
                             changed = true;
                         }

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -935,30 +935,28 @@ pub fn build_ssa(func: &cfg::Function, registry: &CommandRegistry) -> SsaFunctio
                     .collect();
                 *exit_versions.get_mut(&bn).unwrap() = xv;
 
-                // Fill in phi incoming edges for successors.
-                if let Some(block) = func.blocks.get(&bn) {
-                    if let Some(ref term) = block.terminator {
-                        for succ in term.successors() {
-                            if !func.blocks.contains_key(succ) {
-                                continue;
-                            }
-                            let succ_phis: Vec<String> = phi_vars
-                                .get(succ)
-                                .map(|s| {
-                                    let mut v: Vec<String> = s.iter().cloned().collect();
-                                    v.sort();
-                                    v
-                                })
-                                .unwrap_or_default();
-                            for var in &succ_phis {
-                                phi_incoming
-                                    .get_mut(succ)
-                                    .unwrap()
-                                    .entry(var.clone())
-                                    .or_default()
-                                    .insert(bn.clone(), top(&stacks, var));
-                            }
-                        }
+                // Fill in phi incoming edges for successors — the terminator's
+                // successors plus any `try` exception-edge handler targets, so
+                // a handler block's phis see this block's versions.
+                for succ in func.block_successors(&bn) {
+                    if !func.blocks.contains_key(&succ) {
+                        continue;
+                    }
+                    let succ_phis: Vec<String> = phi_vars
+                        .get(&succ)
+                        .map(|s| {
+                            let mut v: Vec<String> = s.iter().cloned().collect();
+                            v.sort();
+                            v
+                        })
+                        .unwrap_or_default();
+                    for var in &succ_phis {
+                        phi_incoming
+                            .get_mut(&succ)
+                            .unwrap()
+                            .entry(var.clone())
+                            .or_default()
+                            .insert(bn.clone(), top(&stacks, var));
                     }
                 }
 

--- a/rust/tcl-lexer/src/expr_lexer.rs
+++ b/rust/tcl-lexer/src/expr_lexer.rs
@@ -371,7 +371,12 @@ impl<'s> Inner<'s> {
             self.i += 1;
         }
         let text = &self.s[start..self.i];
-        let kind = if matches!(text, "true" | "false" | "yes" | "no" | "on" | "off") {
+        // Tcl boolean literals are case-insensitive (`True`, `YES`, `Off`,
+        // …) per `Tcl_GetBoolean`; compare without allocating.
+        let is_bool = ["true", "false", "yes", "no", "on", "off"]
+            .iter()
+            .any(|w| text.eq_ignore_ascii_case(w));
+        let kind = if is_bool {
             ExprTokenType::Bool
         } else if self.dialect == Some("f5-irules") && irops.contains(text) {
             ExprTokenType::Operator
@@ -556,6 +561,14 @@ mod tests {
     #[test]
     fn boolean_literals() {
         assert_eq!(types("true"), vec![ExprTokenType::Bool]);
+        // Tcl booleans are case-insensitive (`Tcl_GetBoolean`).
+        for word in ["True", "FALSE", "Yes", "NO", "On", "Off"] {
+            assert_eq!(
+                types(word),
+                vec![ExprTokenType::Bool],
+                "word `{word}` should tokenise as BOOL",
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-registry/src/commands/tcl/binary_.rs
+++ b/rust/tcl-registry/src/commands/tcl/binary_.rs
@@ -98,29 +98,22 @@ static SUBCOMMANDS: &[SubCommand] = &[
                 },
             ),
         ],
-        arg_roles: &[
-            (2, ArgRole::VarWrite),
-            (3, ArgRole::VarWrite),
-            (4, ArgRole::VarWrite),
-            (5, ArgRole::VarWrite),
-            (6, ArgRole::VarWrite),
-            (7, ArgRole::VarWrite),
-            (8, ArgRole::VarWrite),
-            (9, ArgRole::VarWrite),
-            (10, ArgRole::VarWrite),
-            (11, ArgRole::VarWrite),
-            (12, ArgRole::VarWrite),
-            (13, ArgRole::VarWrite),
-            (14, ArgRole::VarWrite),
-            (15, ArgRole::VarWrite),
-            (16, ArgRole::VarWrite),
-            (17, ArgRole::VarWrite),
-            (18, ArgRole::VarWrite),
-            (19, ArgRole::VarWrite),
-        ],
+        arg_role_resolver: Some(binary_scan_arg_roles),
         ..SubCommand::DEFAULT
     },
 ];
+
+/// D4-F2: `binary scan string formatString ?varName ...?` accepts
+/// variable-name args from index 2 onward (the resolver receives the args
+/// *after* the `scan` subcommand word: `string`, `format`, then the vars).
+/// Resolve `VarWrite` dynamically so calls with arbitrarily many vars don't
+/// false-fire W210 on the unmodelled tail.  Mirrors the `binary scan`
+/// resolver in `dialects/tcl/binary.py`.
+fn binary_scan_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    (2..args.len())
+        .filter_map(|i| u8::try_from(i).ok().map(|i| (i, ArgRole::VarWrite)))
+        .collect()
+}
 
 pub fn spec() -> CommandSpec {
     CommandSpec {

--- a/rust/tcl-registry/src/commands/tcl/lassign.rs
+++ b/rust/tcl-registry/src/commands/tcl/lassign.rs
@@ -13,6 +13,16 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "lassign list ?varName ...?",
 }];
 
+/// D4-F2: `lassign list ?varName ...?` accepts variable-name args from index 1
+/// onward to the end of the call.  Resolve `VarWrite` dynamically so calls with
+/// arbitrarily many vars don't false-fire W210 on the unmodelled tail.
+/// Mirrors `dialects/tcl/lassign.py::_lassign_arg_roles`.
+fn lassign_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    (1..args.len())
+        .filter_map(|i| u8::try_from(i).ok().map(|i| (i, ArgRole::VarWrite)))
+        .collect()
+}
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "lassign",
@@ -31,7 +41,7 @@ hover: Some(HoverSnippet {
         codegen_hook: Some(CodegenHookId::Lassign),
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
-        arg_roles: &[(1, ArgRole::VarWrite), (2, ArgRole::VarWrite), (3, ArgRole::VarWrite), (4, ArgRole::VarWrite), (5, ArgRole::VarWrite), (6, ArgRole::VarWrite), (7, ArgRole::VarWrite), (8, ArgRole::VarWrite), (9, ArgRole::VarWrite), (10, ArgRole::VarWrite), (11, ArgRole::VarWrite), (12, ArgRole::VarWrite), (13, ArgRole::VarWrite), (14, ArgRole::VarWrite), (15, ArgRole::VarWrite), (16, ArgRole::VarWrite), (17, ArgRole::VarWrite), (18, ArgRole::VarWrite), (19, ArgRole::VarWrite)],
+        arg_role_resolver: Some(lassign_arg_roles),
         arg_types: &[(0, ArgTypeHint { expected: Some(TclType::List), shimmers: true })],
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/tcl/regexp_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regexp_.rs
@@ -7,6 +7,35 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "regexp ?switches? exp string ?matchVar? ?subMatchVar ...?",
 }];
 
+/// `regexp ?switches? exp string ?matchVar ...?` — after skipping leading
+/// options (`-start` consumes a value; `--` terminates), arg 0 is the
+/// pattern, arg 1 the string, and args 2+ are capture variables.  Resolve
+/// `VarWrite` for every trailing capture var dynamically (the leading-option
+/// shift means a static slot list cannot place them).  Mirrors
+/// `dialects/tcl/regexp_.py::_regexp_arg_role_resolver`.
+fn regexp_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i];
+        if a == "--" {
+            i += 1;
+            break;
+        }
+        if a.starts_with('-') {
+            i += 1;
+            if a == "-start" && i < args.len() {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    let capture_start = i + 2; // skip pattern + string
+    (capture_start..args.len())
+        .filter_map(|j| u8::try_from(j).ok().map(|j| (j, ArgRole::VarWrite)))
+        .collect()
+}
+
 /// Command spec for `regexp`.
 #[allow(clippy::too_many_lines)] // data-heavy: full hover + 11 options
 pub fn spec() -> CommandSpec {
@@ -112,6 +141,7 @@ hover: Some(HoverSnippet {
         // pattern validation. Mirrors `tcl/regexp_.py`.
         pattern_type: Some(PatternType::Regex),
         forms: FORMS,
+        arg_role_resolver: Some(regexp_arg_roles),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/scan_.rs
+++ b/rust/tcl-registry/src/commands/tcl/scan_.rs
@@ -13,6 +13,17 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "scan string format ?varName varName ...?",
 }];
 
+/// D4-F2: `scan string format ?varName ...?` accepts variable-name args from
+/// index 2 onward to the end of the call.  Resolve `VarWrite` dynamically for
+/// every trailing arg rather than hard-coding a finite slot count, so calls
+/// with 20 / 50 / 100 vars don't false-fire W210 on the unmodelled tail.
+/// Mirrors `dialects/tcl/scan.py::_scan_arg_roles`.
+fn scan_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    (2..args.len())
+        .filter_map(|i| u8::try_from(i).ok().map(|i| (i, ArgRole::VarWrite)))
+        .collect()
+}
+
 /// SYNC-JUN03 follow-up: constant-fold the *inline* `scan string format` form
 /// (no `varName` — that form writes variables and must never fold).
 ///
@@ -194,26 +205,7 @@ pub fn spec() -> CommandSpec {
         }),
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
-        arg_roles: &[
-            (2, ArgRole::VarWrite),
-            (3, ArgRole::VarWrite),
-            (4, ArgRole::VarWrite),
-            (5, ArgRole::VarWrite),
-            (6, ArgRole::VarWrite),
-            (7, ArgRole::VarWrite),
-            (8, ArgRole::VarWrite),
-            (9, ArgRole::VarWrite),
-            (10, ArgRole::VarWrite),
-            (11, ArgRole::VarWrite),
-            (12, ArgRole::VarWrite),
-            (13, ArgRole::VarWrite),
-            (14, ArgRole::VarWrite),
-            (15, ArgRole::VarWrite),
-            (16, ArgRole::VarWrite),
-            (17, ArgRole::VarWrite),
-            (18, ArgRole::VarWrite),
-            (19, ArgRole::VarWrite),
-        ],
+        arg_role_resolver: Some(scan_arg_roles),
         ..CommandSpec::DEFAULT
     }
 }


### PR DESCRIPTION
Faithful ports of the Phase-2 precision passes from the Python reference into the native Rust analyser, worked worst-first against the fp/ground-truth precision battery (the gate). The battery in rust mode moves **284 → 337 passing / 93 → 40 failing**, with **zero regressions at every step** (every remaining failure is a strict subset of the original backlog, verified by set comparison). `make test-lsp-e2e-rust` improved **46 → 18 failing** over the series.

Each of the 21 commits is individually gated on `cargo test --workspace --all-features`, `cargo clippy --all-targets`, `cargo fmt`, and the precision battery, with `compiler-explorer` / `bytecode-compare` used to verify the IR/SSA shape and tclsh 9.0.3 as the TP oracle.

## Cross-cutting features (multi-subsystem)

- **try `exception_edges` (CFG/SSA/SCCP).** A try's single-successor terminator can't express the throw path, so `Function.exception_edges` records `(from_block, handler_block)` pairs (analysis builds only; codegen unchanged). `predecessors` / `reachable_blocks` / `reverse_postorder` route through them, SSA's phi-incoming fill walks them, and SCCP marks handler targets reachable. on-ok sources from the body tail (body-exit versions); on-error/trap from both the pre-try block (version-0) and the body tail (maybe-defined merge). Handler bodies are no longer falsely O107-unreachable.
- **phi-from-undef W210 (CFG/SSA).** A use whose SSA version traces over the phi DAG (SCCP-executable preds, cycle-safe, existence-guard aware) to an undefined / `unset`-killed origin is read-before-set — the if-arm-only-def, switch-no-default, dead-`if{0}`, loop-body-only, use-after-unset, and empty-`dict with` return-read true positives.
- **regexp/scan `provably_unset` W210 + resolvers.** Port `scan_provably_no_match` + `_can_consume_first_conversion` and `regexp_literal_no_match`; mark a literal no-match call's output vars unset (top-level and embedded-in-condition, firing only on the no-match branch) and fire on dominated reads. The regexp/scan `arg_role_resolver`s make a matchable output a real def so the match case stays silent.
- **interprocedural call-site constant propagation (+ SCCP barrier v0-preserve).** Collect per-proc call-site literals and seed `(param, 0) → CONST` when every caller agrees; preserve version-0 param seeds across a barrier widening so a callee `dict with $param` resolves the caller's dict (present key suppresses, empty literal fires, mixed/no callers stay conservative).
- **def-use return-value reads.** Record a `return $x` value's reads as terminator uses keyed by the exit version, so an overwritten store is a real dead store (W220) not a "truly unused" var.
- **CFG dead-code → O107 + break/continue edges.** Post-`return`/`error`/`throw`/`exit` code is routed to orphan unreachable blocks; `break`/`continue` lower to a CFG edge to the loop exit/continue target so a `while 1 { … break }` exit stays reachable.

## Registry / lexer / targeted analyser fixes

- D4-F2 dynamic arg-role resolvers (scan/lassign/binary scan); case-insensitive expr boolean lexer; dispatch-protocol W214 suppression; `incr`-on-uninit; W124 OID-chain, W302 catch fire-and-forget, W214 empty-body/quoted-keyword, W304 braced-switch, W301 pure-var uplevel; W233 divide-by-zero (reachability-aware over expr ASTs).

## Remaining 40 (documented, scoped)

Bounds W231/W232 (interval-bounds + nested-command dispatch), W307 var-as-command residue (snit/TclOO array-element / dict-unpacked / cmd-sub heads), W220 array-element place-model, shimmer S10x, optimiser O106/O109/O116, and a few misc (`eval [list set …]` def recognition, namespaced-ensemble resolution, S101 intrep-thrash). The append-only SYNC trail in `docs/rust-rewrite.md` carries the porting path for each.

https://claude.ai/code/session_018MJwYvxcNRMNsXBC5Mx3M6

---
_Generated by [Claude Code](https://claude.ai/code/session_018MJwYvxcNRMNsXBC5Mx3M6)_