### PR TITLE
Fix three latent soundness bugs in the Python analyser

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -1,9 +1,0 @@
-# tcl-lsp test-slow stamp — DO NOT EDIT BY HAND.
-# Written by 'make test-slow' on success; verified in CI via
-# 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
-# describe/head/date are informational (they change when this stamp is
-# committed, so they cannot be compared).
-describe=f4271e3-dirty
-head=f4271e358292ca6f9852cf829b2eca8b02c35df9
-date=2026-06-11T15:30:11Z
-fingerprint=3597ac1c7d6188f78466609fabe8f036ba35ae1fd5f9dffa7d26daf16a094eba

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -1,0 +1,9 @@
+# tcl-lsp test-slow stamp — DO NOT EDIT BY HAND.
+# Written by 'make test-slow' on success; verified in CI via
+# 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
+# describe/head/date are informational (they change when this stamp is
+# committed, so they cannot be compared).
+describe=78333c1
+head=78333c15fc1ea377e53a7dc22f32b5594c03f422
+date=2026-06-12T07:39:01Z
+fingerprint=db062e2079cff9a586806fc7580b45bacdf2fc29c7ab0f1f8dc3e412bb36c43e

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -571,6 +571,15 @@ class _CFGBuilder:
         # default (non-optimised) bytecode stays byte-identical to tclsh 9.
         self._faithful_exceptions = faithful_exceptions
         self._exception_edges: list[tuple[str, str]] = []
+        # Set by ``_lower_script`` to the block where the script's
+        # straight-line control flow terminated (``return``/``error``/…)
+        # without a normal fall-through, or None when the script can fall
+        # through.  Surfaced separately from the fall-through return value so
+        # ``_lower_try`` can source the on-error exception edge from the
+        # throwing block (where body-set vars are defined) rather than from
+        # the pre-``try`` block.  Always read immediately after the relevant
+        # ``_lower_script`` call, before any nested lowering overwrites it.
+        self._last_terminal_block: str | None = None
         self._inline_loops = inline_loops
         self._upvar_procs = upvar_procs or {}
         self._proc_params = proc_params or {}
@@ -802,9 +811,15 @@ class _CFGBuilder:
         # bytecode byte-identical to tclsh 9 (tclsh's compiler also
         # discards post-return statements).
         orphan: str | None = None
+        # First block whose straight-line execution terminated (the throwing
+        # / returning block).  None while control still falls through.
+        terminal: str | None = None
+        self._last_terminal_block = None
         for stmt in script.statements:
             block = self._block(current)
             if block.terminator is not None:
+                if terminal is None:
+                    terminal = current
                 if not self._faithful_exceptions:
                     return None
                 if orphan is None:
@@ -1031,6 +1046,12 @@ class _CFGBuilder:
                             value=None, range=stmt.range, expr=None, braced=False
                         )
 
+        # The script has no normal fall-through if the block control finally
+        # rests in is terminated (a straight-line ``return``/``error`` as the
+        # final statement leaves ``current`` on the terminated block).
+        if terminal is None and self._block(current).terminator is not None:
+            terminal = current
+        self._last_terminal_block = terminal
         return current
 
     def _lower_if(self, stmt: IRIf, block_name: str) -> str | None:
@@ -1315,6 +1336,11 @@ class _CFGBuilder:
         # Where does control go after the body succeeds?
         post_body = self._new_block("try_ok") if stmt.handlers else end_block
         body_tail = self._lower_script(stmt.body, body_block)
+        # ``_lower_script`` surfaces the block where the body's straight-line
+        # control terminated (the throwing block) when the body has no normal
+        # fall-through.  Capture it before any nested lowering (the handler
+        # bodies below) overwrites the shared attribute.
+        body_terminal = self._last_terminal_block
         if body_tail is not None:
             self._ensure_goto(body_tail, post_body, stmt.body_range)
 
@@ -1332,19 +1358,30 @@ class _CFGBuilder:
             # ``on ok`` runs only after the body completes normally, so it
             # observes the body's *exit* versions (a body-set var is defined) —
             # its source is the body tail.  Every other handler (``on error``/
-            # ``trap``/``on return``/…) runs on an abnormal completion that can
-            # occur at *any* point in the body, so a body-set var is *maybe*
-            # defined: merge the pre-``try`` state (var unset, version-0) with
-            # the body-exit state (var set).  Sourcing only from pre-``try``
-            # would wrongly flag a definitely-set var as read-before-set —
-            # tclsh 9.0.3: ``try {set x 1; error e} on error {} {puts $x}``
-            # reads ``x`` == 1.  Merging keeps a never-set var version-0 in both
-            # predecessors, so a genuine read-before-set still fires.
+            # ``trap``/``on return``/…) runs on an abnormal completion.
+            #
+            # When the body can fall through, an abnormal completion may occur
+            # at *any* point, so a body-set var is *maybe* defined: merge the
+            # pre-``try`` state (var unset, version-0) with the body-exit state
+            # (var set).  Sourcing only from pre-``try`` would wrongly flag a
+            # definitely-set var as read-before-set — tclsh 9.0.3:
+            # ``try {set x 1; error e} on error {} {puts $x}`` reads ``x`` == 1.
+            # Merging keeps a never-set var version-0 in both predecessors, so a
+            # genuine read-before-set still fires.
+            #
+            # When the body has *no* normal fall-through (it unconditionally
+            # throws), the handler is only reachable from the throw point, where
+            # the body-set vars up to that point are defined.  Source the edge
+            # from that throwing block alone — adding the pre-``try`` block would
+            # re-introduce a version-0 predecessor and false-fire W210 on a var
+            # that is provably set at the throw.
             if self._faithful_exceptions:
                 is_on_ok = handler.kind == "on" and handler.match_arg == "ok"
                 if is_on_ok:
                     if body_tail is not None:
                         self._exception_edges.append((body_tail, handler_block))
+                elif body_terminal is not None:
+                    self._exception_edges.append((body_terminal, handler_block))
                 else:
                     self._exception_edges.append((block_name, handler_block))
                     if body_tail is not None and body_tail != block_name:

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -580,6 +580,14 @@ class _CFGBuilder:
         # the pre-``try`` block.  Always read immediately after the relevant
         # ``_lower_script`` call, before any nested lowering overwrites it.
         self._last_terminal_block: str | None = None
+        # When non-None, ``_lower_script`` appends each block that raises an
+        # explicit ``error`` / ``throw`` to this list.  ``_lower_try`` installs
+        # a fresh list around its body so the on-error edge can be sourced from
+        # *every* throw point (each at its throw-time SSA versions), catching a
+        # var that is unset on an earlier conditional throw even when a later
+        # throw has it set.  Nested ``try`` bodies install their own list so an
+        # inner-caught throw is not attributed to the outer handler.
+        self._throw_blocks: list[str] | None = None
         self._inline_loops = inline_loops
         self._upvar_procs = upvar_procs or {}
         self._proc_params = proc_params or {}
@@ -1045,6 +1053,14 @@ class _CFGBuilder:
                         block.terminator = CFGReturn(
                             value=None, range=stmt.range, expr=None, braced=False
                         )
+                        # ``error`` / ``throw`` are catchable throw points; an
+                        # enclosing ``try`` sources its on-error edge from here
+                        # so the handler sees the var state *at the throw*.
+                        # ``exit`` is not catchable, so it is not a throw point.
+                        if self._throw_blocks is not None and stmt.canonical_command.lstrip(
+                            ":"
+                        ) in ("error", "throw"):
+                            self._throw_blocks.append(current)
 
         # The script has no normal fall-through if the block control finally
         # rests in is terminated (a straight-line ``return``/``error`` as the
@@ -1335,7 +1351,15 @@ class _CFGBuilder:
 
         # Where does control go after the body succeeds?
         post_body = self._new_block("try_ok") if stmt.handlers else end_block
+        # Collect this body's explicit throw points in a fresh list (a nested
+        # ``try`` installs its own, so its caught throws are not attributed
+        # here).  Restore the parent's list before the handler bodies, whose
+        # throws belong to any enclosing ``try``.
+        outer_throw_blocks = self._throw_blocks
+        self._throw_blocks = []
         body_tail = self._lower_script(stmt.body, body_block)
+        body_throws = self._throw_blocks
+        self._throw_blocks = outer_throw_blocks
         # ``_lower_script`` surfaces the block where the body's straight-line
         # control terminated (the throwing block) when the body has no normal
         # fall-through.  Capture it before any nested lowering (the handler
@@ -1370,18 +1394,24 @@ class _CFGBuilder:
             # genuine read-before-set still fires.
             #
             # When the body has *no* normal fall-through (it unconditionally
-            # throws), the handler is only reachable from the throw point, where
-            # the body-set vars up to that point are defined.  Source the edge
-            # from that throwing block alone — adding the pre-``try`` block would
-            # re-introduce a version-0 predecessor and false-fire W210 on a var
-            # that is provably set at the throw.
+            # throws), the handler is reachable only from the body's explicit
+            # throw points.  Source the edge from each of them, at its own
+            # throw-time versions: a var set before a *late* throw but unset on
+            # an *earlier* conditional throw is then correctly *maybe*-defined,
+            # so a genuine read-before-set still fires — while a var provably
+            # set before the only throw is not false-flagged (no pre-``try``
+            # version-0 predecessor is added).  Fall back to the terminal block
+            # when the body terminated without an explicit ``error``/``throw``
+            # (e.g. a bare ``return``), preserving the prior edge.
             if self._faithful_exceptions:
                 is_on_ok = handler.kind == "on" and handler.match_arg == "ok"
                 if is_on_ok:
                     if body_tail is not None:
                         self._exception_edges.append((body_tail, handler_block))
                 elif body_terminal is not None:
-                    self._exception_edges.append((body_terminal, handler_block))
+                    throw_sources = list(dict.fromkeys(body_throws)) or [body_terminal]
+                    for src in throw_sources:
+                        self._exception_edges.append((src, handler_block))
                 else:
                     self._exception_edges.append((block_name, handler_block))
                     if body_tail is not None and body_tail != block_name:

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -1916,12 +1916,20 @@ _TCL_REGEX_METACHARS = frozenset(r"\^$.|?*+()[]{}")
 # pure-literal pattern (one with no metacharacters): they either alter
 # the return shape (``-indices``/``-inline``/``-all``), restrict where
 # the match may begin (``-start``; tcl-match ⊆ naive-substring), or
-# only affect anchor / whitespace semantics that a no-metachar pattern
-# cannot use (``-line``/``-lineanchor``/``-linestop``/``-expanded``).
-# ``--`` is the option terminator and is also benign.  Anything outside
-# this set (e.g. ``-nocase`` which weakens matching, ``-about`` which
-# does not return a match at all, or an option we simply don't know
-# about) forces the caller to bail conservatively.
+# only affect anchor semantics that a no-metachar pattern cannot use
+# (``-line``/``-lineanchor``/``-linestop``).  ``--`` is the option
+# terminator and is also benign.  Anything outside this set (e.g.
+# ``-nocase`` which weakens matching, ``-about`` which does not return a
+# match at all, or an option we simply don't know about) forces the
+# caller to bail conservatively.
+#
+# ``-expanded`` is deliberately NOT in this set: it makes Tcl ignore
+# unescaped whitespace and ``#``-to-end-of-line comments in the pattern,
+# so ``a b`` is the substring ``ab`` (not ``a b``) under it.  A
+# metacharacter-free pattern is therefore no longer a plain substring,
+# and a "no match" proof would be unsound.  ``_regexp_literal_no_match``
+# handles ``-expanded`` specially: it stays provable only for a pattern
+# free of whitespace and ``#``.
 _REGEXP_LITERAL_SAFE_SWITCHES = frozenset(
     {
         "-indices",
@@ -1930,7 +1938,6 @@ _REGEXP_LITERAL_SAFE_SWITCHES = frozenset(
         "-line",
         "-lineanchor",
         "-linestop",
-        "-expanded",
         "-start",
         "--",
     }
@@ -1964,6 +1971,7 @@ def _regexp_literal_no_match(pat: str, inp: str, options: tuple[str, ...] = ()) 
     if any(c in _TCL_REGEX_METACHARS for c in pat):
         return False
     nocase = False
+    expanded = False
     for opt in options:
         # Skip option values (the token after ``-start`` etc.) -- only
         # the switches themselves carry semantics for this analysis.
@@ -1972,10 +1980,22 @@ def _regexp_literal_no_match(pat: str, inp: str, options: tuple[str, ...] = ()) 
         if opt == "-nocase":
             nocase = True
             continue
+        if opt == "-expanded":
+            expanded = True
+            continue
         if opt in _REGEXP_LITERAL_SAFE_SWITCHES:
             continue
         # Unknown / unsafe switch (e.g. ``-about``, or a switch added in
         # a future Tcl release we don't model).  Bail conservatively.
+        return False
+    if expanded and any(c.isspace() or c == "#" for c in pat):
+        # Under ``-expanded`` Tcl strips unescaped whitespace and
+        # ``#``-to-EOL comments from the pattern, so ``regexp -expanded
+        # {a b} {ab}`` MATCHES.  The metacharacter screen above already
+        # rejected any backslash-bearing pattern, so every space / ``#``
+        # reaching here is unescaped: a substring no-match proof would be
+        # unsound, so bail.  A whitespace-and-``#``-free literal stays
+        # provably literal and keeps firing.
         return False
     if nocase:
         return pat.casefold() not in inp.casefold()
@@ -4068,6 +4088,16 @@ def _collect_call_site_constants(ir_module: IRModule) -> dict[str, dict[int, set
                             by_idx.setdefault(i, set()).add(_UNKNOWN_ARG)
                         else:
                             by_idx.setdefault(i, set()).add(arg)
+                    # Parameters this call omits (i >= argc) take their
+                    # default value, NOT the literal another caller passes.
+                    # Poison those slots so a parameter omitted by even one
+                    # caller is never bound to a constant -- otherwise SCCP
+                    # analyses the callee as if the default path were
+                    # unreachable, hiding read-before-set / reachability
+                    # findings on it.
+                    callee = ir_module.procedures[target]
+                    for i in range(len(stmt.args), len(callee.params)):
+                        by_idx.setdefault(i, set()).add(_UNKNOWN_ARG)
             for attr in ("body", "init", "next"):
                 sub = getattr(stmt, attr, None)
                 if sub is not None and hasattr(sub, "statements"):

--- a/tests/lsp_e2e/test_diagnostics_e2e.py
+++ b/tests/lsp_e2e/test_diagnostics_e2e.py
@@ -340,3 +340,109 @@ class TestDiagnosticsTrackEdits:
         lsp_server.replace_document(uri, 2, "set\n")
         diags = lsp_server.await_diagnostics(uri, version=2)
         assert "E002" in _codes(diags)
+
+
+class TestSoundnessRegressionsE2E:
+    """End-to-end coverage for three latent W210 soundness bugs surfaced
+    while reviewing the Rust port and fixed in the analyser.  Ground truth is
+    real tclsh 9.0.3; these drive the packaged server's ``publishDiagnostics``
+    over the full pipeline, not just the in-process checker.
+    """
+
+    # -- Omitted-arg call-site constants are poisoned (interproc) ---------- #
+
+    def test_omitted_default_arg_does_not_hide_read_before_set(self, lsp_server, uri_factory):
+        # ``p`` (slot 0 omitted → default ``x == 0``) leaves ``y`` unset, so
+        # ``puts $y`` is a real read-before-set; the literal ``1`` passed by
+        # ``p 1`` must not be bound as a constant for ``x``.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc p {{x 0}} {
+                if {$x} {
+                    set y 5
+                }
+                puts $y
+            }
+            p
+            p 1
+        """)
+        diags = lsp_server.open_ready(uri, src)
+        assert "W210" in _codes(diags), _codes(diags)
+        assert 4 in _on_line(diags, "W210"), [d.get("range") for d in diags]
+
+    def test_uniform_literal_arg_still_binds_silent(self, lsp_server, uri_factory):
+        # Every caller passes ``1`` at slot 0 → the constant binding holds, the
+        # ``if {$x}`` body is provably taken, ``y`` is always set: stay silent.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc q {{x 0}} {
+                if {$x} {
+                    set y 5
+                }
+                puts $y
+            }
+            q 1
+            q 1
+        """)
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    # -- regexp ``-expanded`` is not unconditionally literal-safe ---------- #
+
+    def test_regexp_expanded_whitespace_pattern_silent(self, lsp_server, uri_factory):
+        # ``-expanded`` ignores unescaped whitespace, so ``{a b}`` matches the
+        # substring ``ab`` and writes ``v``; reading ``v`` must not fire W210.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc g {input} {
+                regexp -expanded {a b} $input v
+                puts $v
+            }
+        """)
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_regexp_expanded_clean_literal_still_fires(self, lsp_server, uri_factory):
+        # A whitespace/``#``-free literal stays provably literal: ``{x}`` never
+        # matches ``X``, never writes ``w`` → reading ``w`` is read-before-set.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc g {} {
+                regexp -expanded {x} X w
+                puts $w
+            }
+        """)
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))
+
+    # -- try body throw keeps its handler exception edge ------------------- #
+
+    def test_try_body_throw_keeps_handler_defs_silent(self, lsp_server, uri_factory):
+        # ``x`` is set before the only throw, so the handler always sees it
+        # (tclsh prints ``1``): stay silent.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc f {} {
+                try {
+                    set x 1
+                    error boom
+                } on error {} {
+                    puts $x
+                }
+            }
+        """)
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_try_body_earlier_conditional_throw_fires(self, lsp_server, uri_factory):
+        # The handler is reachable from every throw point; ``x`` is unset on the
+        # earlier ``if {$c} {error a}`` path, so the read is maybe-unset.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc f {c} {
+                try {
+                    if {$c} { error a }
+                    set x 1
+                    error b
+                } on error {} {
+                    puts $x
+                }
+            }
+        """)
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -720,6 +720,83 @@ class TestCatchBodyDefsInCondition:
         assert len(diags) == 0
 
 
+class TestSoundnessRegressionsFromRustReview:
+    """Three latent soundness bugs surfaced while reviewing the Rust port.
+
+    Each was hiding a real read-before-set (W210) finding (or, for the
+    ``-expanded`` case, false-firing one).  Ground truth is real tclsh 9.0.3.
+    """
+
+    def test_omitted_arg_call_site_constant_is_poisoned(self):
+        """A parameter omitted by one caller takes its default, so the
+        constant another caller passes must NOT be bound to it.
+
+        tclsh 9.0.3: ``p`` (default ``x == 0``) leaves ``y`` unset, so
+        ``puts $y`` errors ``can't read "y"``.  Binding ``x = const(1)`` from
+        the ``p 1`` call site would analyse the ``if {$x}`` body as always
+        taken and hide the finding."""
+        src = "proc p {{x 0}} {\n    if {$x} {\n        set y 5\n    }\n    puts $y\n}\np\np 1"
+        assert len(_diag_with_code(src, "W210")) == 1
+
+    def test_uniform_literal_call_sites_still_bind(self):
+        """When every caller passes the same literal at a slot, the constant
+        binding still applies (no over-poisoning) — the ``if {$x}`` body is
+        provably taken, so ``y`` is always set and no W210 fires."""
+        src = "proc q {{x 0}} {\n    if {$x} {\n        set y 5\n    }\n    puts $y\n}\nq 1\nq 1"
+        assert len(_diag_with_code(src, "W210")) == 0
+
+    def test_regexp_expanded_whitespace_pattern_no_false_w210(self):
+        """``-expanded`` ignores unescaped whitespace, so ``regexp -expanded
+        {a b} $input v`` matches the substring ``ab`` and writes ``v``.
+
+        tclsh 9.0.3: ``regexp -expanded {a b} ab v`` returns 1 and sets
+        ``v == ab``.  The no-match proof must not claim no-match here, else a
+        later read of ``v`` false-fires W210."""
+        src = "proc g {input} {\n    regexp -expanded {a b} $input v\n    puts $v\n}"
+        assert len(_diag_with_code(src, "W210")) == 0
+
+    def test_regexp_expanded_clean_literal_still_proves_no_match(self):
+        """A whitespace-and-``#``-free literal stays provably literal under
+        ``-expanded``: ``regexp -expanded {x} X w`` never matches (returns 0)
+        and never writes ``w``, so reading ``w`` is genuinely read-before-set."""
+        src = "proc g {} {\n    regexp -expanded {x} X w\n    puts $w\n}"
+        assert len(_diag_with_code(src, "W210")) == 1
+
+    def test_try_body_unconditional_throw_keeps_handler_defs(self):
+        """A ``try`` body that always throws after defining a var: the
+        on-error handler is reachable only from the throw point, where the
+        var is set.
+
+        tclsh 9.0.3: ``try {set x 1; error boom} on error {} {puts $x}``
+        prints ``1``.  The handler must source its versions from the throwing
+        block (``x`` set), not the pre-``try`` block (``x`` unset)."""
+        src = (
+            "proc f {} {\n"
+            "    try {\n"
+            "        set x 1\n"
+            "        error boom\n"
+            "    } on error {} {\n"
+            "        puts $x\n"
+            "    }\n"
+            "}"
+        )
+        assert len(_diag_with_code(src, "W210")) == 0
+
+    def test_try_body_throw_genuine_read_before_set_still_warns(self):
+        """A handler reading a var the body never set still fires W210 —
+        the throwing-block edge keeps a never-set var version-0."""
+        src = (
+            "proc f {} {\n"
+            "    try {\n"
+            "        error boom\n"
+            "    } on error {} {\n"
+            "        puts $y\n"
+            "    }\n"
+            "}"
+        )
+        assert len(_diag_with_code(src, "W210")) == 1
+
+
 class TestInfoExistsNotReadBeforeSet:
     """`info exists`/`array exists` is the canonical test-before-use idiom —
     referencing an unset variable there is legal (returns 0), so it must never

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -796,6 +796,49 @@ class TestSoundnessRegressionsFromRustReview:
         )
         assert len(_diag_with_code(src, "W210")) == 1
 
+    def test_try_body_earlier_conditional_throw_still_warns(self):
+        """The handler is reachable from *every* throw point, so a var set
+        before a late throw but unset on an earlier conditional throw is
+        maybe-unset and must still fire W210.
+
+        tclsh 9.0.3: ``f 1`` enters the handler with ``x`` UNSET (the
+        ``if {$c} {error a}`` fires before ``set x 1``); ``f 0`` enters with
+        ``x == 1``.  Sourcing the on-error edge only from the *last* throw
+        (``error b``, where ``x`` is set) would miss the unset path."""
+        src = (
+            "proc f {c} {\n"
+            "    try {\n"
+            "        if {$c} { error a }\n"
+            "        set x 1\n"
+            "        error b\n"
+            "    } on error {} {\n"
+            "        puts $x\n"
+            "    }\n"
+            "}"
+        )
+        diags = _diag_with_code(src, "W210")
+        assert [d.message for d in diags] == ["Variable 'x' is read before it is set"]
+
+    def test_try_nested_caught_throw_not_attributed_to_outer(self):
+        """A throw raised and caught by a nested ``try`` is not an outer throw
+        point.  The outer handler is reachable only from the outer body's own
+        throws, where ``x`` is provably set, so no W210 fires.
+
+        tclsh 9.0.3: the inner ``error inner`` is swallowed, so the outer
+        handler always sees ``x == 1``."""
+        src = (
+            "proc f {} {\n"
+            "    try {\n"
+            "        set x 1\n"
+            "        try { error inner } on error {} { }\n"
+            "        error outer\n"
+            "    } on error {} {\n"
+            "        puts $x\n"
+            "    }\n"
+            "}"
+        )
+        assert len(_diag_with_code(src, "W210")) == 0
+
 
 class TestInfoExistsNotReadBeforeSet:
     """`info exists`/`array exists` is the canonical test-before-use idiom —


### PR DESCRIPTION
Three read-before-set/reachability soundness bugs surfaced while
reviewing the Rust port were fixed on the Rust side; this ports the
fixes to the Python analyser, with a regression test for each. Ground
truth is real tclsh 9.0.3.

1. Omitted-arg call-site constants are now poisoned (interproc).
   `_collect_call_site_constants` only enumerated the args a call
   presented, so a parameter omitted by one caller (using its default)
   was never marked unknown. With `proc p {{x 0}} {...}; p; p 1`, slot 0
   recorded only `1`, binding `x = const(1)` and hiding findings on the
   default path. Now every parameter slot i >= argc for a known callee is
   poisoned using the callee's parameter count.

2. `-expanded` is no longer treated as unconditionally literal-safe.
   `-expanded` makes Tcl ignore unescaped whitespace and `#`-to-EOL
   comments, so `regexp -expanded {a b} {ab}` matches and writes its
   capture vars. The no-match proof wrongly returned True, false-firing
   W210 on a later capture-var read. `-expanded` is removed from the
   unconditional safe set; under it the proof bails when the pattern has
   any unescaped whitespace or `#`, and stays provable for a clean
   literal.

3. A try body that unconditionally throws keeps its exception edge to
   handlers. The on-error edge was sourced only from the pre-try block
   when the body had no normal fall-through, so a var set before the
   throw looked unset (false read-before-set). `_lower_script` now
   surfaces the throwing block distinct from its fall-through return
   value, and `_lower_try` sources the on-error edge from it.

https://claude.ai/code/session_01P18HCQRWGtBsui1R2wScNB