### PR TITLE
Native Rust analyser: close lsp_e2e gaps + raise fp/ground-truth battery 337→358

### DIFF
--- a/compiler/parsing/lexer.py
+++ b/compiler/parsing/lexer.py
@@ -18,6 +18,17 @@ except ImportError:
 
 _bisect_right = bisect.bisect_right
 
+# Map TokenType variant *names* to the canonical ``shared.tokens.TokenType``
+# members.  The Rust fast path (:func:`_rust_lexer_tokenise_cfg`) returns
+# PyO3 ``tcl_lsp_py.Token`` objects whose ``.type`` is a distinct
+# ``PyTokenType`` enum — equal by value but NOT identity-equal to the
+# ``shared.tokens.TokenType`` members the parser compares against with
+# ``is``.  We rebuild native :class:`Token` objects keyed on ``.type.name``
+# so ``tok.type is TokenType.VAR`` works regardless of whether the wheel is
+# installed.  Built once at import; ``TokenType[name]`` would also work but a
+# dict avoids the per-token ``__getitem__`` enum lookup in the hot path.
+_TOKEN_TYPE_BY_NAME: dict[str, TokenType] = {member.name: member for member in TokenType}
+
 # Pre-computed character class sets for O(1) membership testing in the
 # lexer hot path.  Using frozenset instead of sequential == checks
 # eliminates 5-7 chained comparisons per token (measured ~2x speedup).
@@ -92,6 +103,33 @@ def expand_syntax_disabled_scope():
 def _irules_brace_separator_active() -> bool:
     """Whether the iRules ``}{`` brace-word boundary is enabled."""
     return _dialect_var.get() == "f5-irules"
+
+
+def _convert_rust_token(tok: object) -> Token:
+    """Lift a PyO3 ``tcl_lsp_py.Token`` into a native :class:`Token`.
+
+    The Rust fast path returns tokens whose ``.type`` is a ``PyTokenType``
+    enum and whose ``.start`` / ``.end`` are ``PySourcePosition`` objects.
+    These are structurally identical to the ``shared.tokens`` dataclasses
+    but distinct types, so the parser's ``tok.type is TokenType.VAR``
+    identity checks fail against them.  We rebuild the canonical dataclass,
+    mapping the token type by ``.type.name`` and copying the line/character/
+    offset triples plus the ``in_quote`` flag.
+
+    ``tok`` is intentionally typed ``object``: when the wheel is absent the
+    annotation must not reference any ``tcl_lsp_rust`` symbol.  The duck-typed
+    attribute access (``.type.name``, ``.text``, ``.start.line`` …) mirrors
+    the PyO3 ``Token`` surface exactly.
+    """
+    start = tok.start  # type: ignore[attr-defined]
+    end = tok.end  # type: ignore[attr-defined]
+    return Token(
+        type=_TOKEN_TYPE_BY_NAME[tok.type.name],  # type: ignore[attr-defined]
+        text=tok.text,  # type: ignore[attr-defined]
+        start=SourcePosition(line=start.line, character=start.character, offset=start.offset),
+        end=SourcePosition(line=end.line, character=end.character, offset=end.offset),
+        in_quote=tok.in_quote,  # type: ignore[attr-defined]
+    )
 
 
 class TclParseError(Exception):
@@ -1220,7 +1258,13 @@ class TclLexer:
             # ``None`` rather than re-reading from offset 0.
             self.pos = self._len
             self._type = TokenType.EOF
-            return tokens
+            # Convert the PyO3 ``tcl_lsp_py.Token`` objects into native
+            # ``shared.tokens.Token`` instances.  Their ``.type`` is a
+            # ``PyTokenType`` enum that is NOT identity-equal to
+            # ``shared.tokens.TokenType``, so leaving them as-is would make
+            # every ``tok.type is TokenType.X`` check in the parser silently
+            # fail wherever the wheel is installed (see _TOKEN_TYPE_BY_NAME).
+            return [_convert_rust_token(tok) for tok in tokens]
         tokens: list[Token] = []
         while True:
             tok = self.get_token()

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5091,6 +5091,19 @@ fp_inj 1.
    after its preceding positional. lsp_e2e 469→470 passing; precision battery
    unchanged.
 
+6. **IRULE3102 unnormalised getter nested in a sink argument** (closes
+   `test_irules_e2e::TestIrulesTaintDiagnostics::test_taint_source_in_http_sink_fires_irule3102`).
+   `find_unnormalised_getter_warnings` only inspected top-level `Call`
+   (command *is* the getter) and `AssignValue` RHS (`set u [HTTP::uri]`)
+   statements. In `HTTP::respond 200 content [HTTP::uri]` the `[HTTP::uri]`
+   getter stays a literal `Cmd` *argument* of the outer sink call rather than
+   a separate statement, so it was never flagged. The `Call` arm now also
+   walks each argument: a command-substitution arg (`[…]`) is parsed via
+   `parse_command_substitution` and checked with `is_unnormalised_getter`,
+   anchoring the diagnostic on the argument token's own span. Stays silent on
+   a constant (`"static body"`) and on the `-normalized` form. lsp_e2e
+   470→471 passing; precision battery unchanged.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5044,6 +5044,22 @@ fp_inj 1.
    `flush_arity_diagnostics` keyed on the base command name). lsp_e2e
    463→465 passing; precision battery held at 284/93.
 
+3. **semantic_tokens non-overlap after `$var`** (closes
+   `test_semantic_tokens_e2e::TestTokenInvariants::test_tokens_strictly_non_overlapping_dense_line`
+   + `…test_tokens_satisfy_invariants[unicode_after_var]`). The tcl-lexer
+   `parse_quoted` *empty-content clamp* extends a quoted `Esc` fragment's span
+   by one byte over the `$` / `[` that introduces the next substitution token
+   (so `token_text` stays empty while `span.end` lands on the terminator). The
+   semantic-token emitter (`semantic_tokens.rs::push_token`) used that raw span
+   verbatim, so the opening fragment of `"$x …"` spanned `"$` and overlapped the
+   `$x` Variable token — a client "Overlapping semantic tokens detected"
+   violation. `push_token` now recognises a clamped-empty `Esc`
+   (`span_len == content_offset + 1` with a `$` / `[` last byte) and trims it to
+   just its leading delimiter (the opening `"`, or nothing for an empty ESC
+   between adjacent `$a$b`). Also collapsed the pre-existing `E::Function`
+   `if` into a match guard so the file is clippy-pedantic clean. lsp_e2e
+   465→467 passing; precision battery unchanged.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5060,6 +5060,23 @@ fp_inj 1.
    `if` into a match guard so the file is clippy-pedantic clean. lsp_e2e
    465→467 passing; precision battery unchanged.
 
+4. **invariants[clean] shared-server document leak** (closes
+   `test_invariants_e2e::TestRangeInvariants::test_all_provider_ranges_well_formed[clean]`
+   + `…TestRobustnessAdversarial::test_server_survives_and_responds[clean]`).
+   Order-dependent: passed in isolation, failed in the full suite. The
+   `lsp_server` fixtures are session-scoped and tests never closed the
+   documents they opened, so the native server's **cross-document references**
+   feature (a Rust enhancement Python lacks) surfaced a leftover
+   `proc greet` from `test_hover_e2e::test_proc_multiline_doc` (where `greet`
+   sits at line 2 col 5) in the unrelated `clean` document's references —
+   out of bounds for the clean source's one-char line 2, tripping the range
+   invariant. Fix is the leak, not the assertion: `LspServerClient` now tracks
+   open URIs, and a function-scoped autouse fixture closes every test's
+   documents on all live servers during teardown, so the shared servers start
+   each test with no foreign documents open. Test-harness only (no analyser /
+   server change); full Python-backend e2e suite still green (488 passed),
+   native lsp_e2e 467→469 passing.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5954,6 +5954,27 @@ is still flagged — only `Cmd` words are exempt).  Battery
 `TN_safe_eval_with_list_form` (`eval [list set y $x]`) now passes; 1 unit
 test.
 
+**LANDED (interval abstract domain + dynamic index bounds — battery
+2026-06-12).**  Ported `compiler/intervals.py` → `intervals.rs` (the integer
+interval lattice: `join`/`widen`/`add`/`sub`/`mul`/`intersect`, abstract
+`eval_expr`, constant-bound guard narrowing `refine_interval` +
+`build_guard_index`, and the widening forward fixpoint `compute_intervals`
+seeded from SCCP constants) and the bounds-finding portion of
+`compiler/interval_bounds.py::find_interval_bounds` → `interval_bounds.rs`.
+`emit_interval_bounds_diagnostics` runs it per function over SCCP-reachable
+blocks and fires **W230 / W231 / W232** on a `$var` index whose
+guard-narrowed interval *proves* the access is wholly out of range against a
+statically-recovered container length — the dynamic cases the syntactic
+bounds checks deliberately skip (so the two never double-fire).  One
+divergence handled for parity: Rust's SSA inserts a loop-header phi for a
+list `lset` mutates (Rust's `lset` *reads* the list), which Python's pruned
+SSA does not; `resolve_list_length` follows that phi to the length its known
+incomings agree on, ignoring the unknown length-preserving back-edge, so
+`for {set j 4} {$j < 9} {incr j} { lset l $j $v }` recovers length 3 and
+fires W231 exactly as Python does.  Battery `FP_BND_01` (loop counter past
+append) and `FP_BND_03` (×2, `string index $s $i` with a const-var index)
+now pass; 6 unit tests; zero battery / e2e regressions.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5911,6 +5911,19 @@ already-checked commands never double-fire.  Battery
 `FP_NAB_06_open_variable_pipe_fires_w103` (`set fh [open "|$cmd" r]`) now
 passes; zero battery / e2e regressions; +1 unit test.
 
+**LANDED (W304 stops at a shadowing proc param — battery 2026-06-12).**
+`last_literal_set_value_for_var` (the W304 "currently resolves to …"
+value-recovery) segmented the prefix at top level and walked backward, so
+`set path -force` at top level was wrongly attributed to the inner `$path`
+use in `proc useit {path} { file delete $path }`.  Ported the
+`_last_literal_set_value_for_var` cross-scope guard: when the backward
+scan reaches the truncated-unclosed `proc` containing the use
+(`span.end()+1 >= before_offset`) and that proc's parameter list contains
+`var_name`, stop — the parameter shadows the outer scope.  A *complete*
+proc before a top-level use ends earlier and does not shadow (control
+preserved).  Battery `FP_NAB_05_w304_lexical_does_not_cross_proc_boundary`
+now passes; 1 unit test.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5924,6 +5924,24 @@ proc before a top-level use ends earlier and does not shadow (control
 preserved).  Battery `FP_NAB_05_w304_lexical_does_not_cross_proc_boundary`
 now passes; 1 unit test.
 
+**LANDED (W306 literal-expected `regexp`/`regsub` pattern — battery
+2026-06-12).**  Ported the `regexp` / `regsub` arm of
+`_domain.py::check_literal_expected` (the whole check was previously
+absent in Rust).  `emit_w306_literal_expected` finds the pattern arg
+(`regexp_pattern_index` — skip options, `-start` consumes a value, `--`
+terminates), and fires when it carries a *live* substitution Tcl expands
+before the regex engine sees it: a quoted `"$var"` / `"[cmd]"` or an
+unbraced `[cmd]`.  Exemptions match Python: a braced `{…}` pattern
+(substitution suppressed), a bare single `$var` word (the canonical
+parameterised-pattern idiom, no braced equivalent), and `\[` / `\$` in a
+quoted pattern (literal regex chars — checked against the raw source slice
+via `raw_has_live_substitution`, since the resolved text can't distinguish
+an escaped bracket from a live command sub).  The `class match`/`search`
+arm (f5-irules) is not ported (no battery driver).  Battery
+`FP_STY_02_live_cmdsub_in_quoted_pattern_still_fires` and
+`FP_STY_02_live_dollar_in_quoted_pattern_still_fires` now pass; 1 unit
+test; no battery / e2e regressions.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5104,6 +5104,35 @@ fp_inj 1.
    a constant (`"static body"`) and on the `-normalized` form. lsp_e2e
    470→471 passing; precision battery unchanged.
 
+7. **Bracket-recovery brace-word bail** (#560; closes 2/3 of
+   `test_recovery_e2e::TestInertBracketVeto` —
+   `test_brace_word_break_still_flags_and_recovers` and
+   `test_brace_word_break_no_duplicate_diagnostics`). For
+   `set x [foo {bar\nproc …}` the command-break heuristic's after-`bar`
+   boundary is inert (inside the `{bar …}` brace word), so it was vetoed and
+   the analyser fell through to the `e201_at_brace` fallback, which inserted a
+   ghost `]` *before* the `{` — folding the swallowed `proc` / `puts` into a
+   brace-word argument (hidden from analysis, spurious E003/W123 on a 3-arg
+   `set`). `e201_at_command` now reports when a *known* command was swallowed
+   into an inert span; `detect_e201` then suppresses the brace-break fallback
+   and bails to the fix-less fallback, so no ghost is inserted, the
+   scan-to-next recovery's partial command stands (generic E200), and the tail
+   `proc` / trailing `set` are analysed as real code (symbol recovered; E002
+   on the bare `set`). Matches the Python analyser + C Tcl 9.0.3
+   (`info complete {set x [foo {bar]}` == 0). lsp_e2e 471→473; precision
+   battery held at 284/93; workspace tests + clippy green.
+
+   **Remaining (3rd test, `test_midword_delimiter_still_recovers`):** the
+   mid-word-`"` case `set x [foo abc"\nproc …` needs the *bracket interior*
+   re-lex to treat a mid-word `"` as a literal (C Tcl completes
+   `set x [foo abc"]`). The lexer's command-substitution scanner
+   (`scan_cmd_sub` / `Lexer::scan_command_substitution`) toggles quote on any
+   `"` at `blevel == 0` regardless of word-start, so a ghost `]` inserted
+   after `abc"` lands "inside the quote" and never closes the bracket. Closing
+   this needs the command-sub quote handling aligned to the word-start rule
+   `scan_top` already uses — a core-lexer change deferred to its own strip to
+   keep this batch's regression surface small.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5942,6 +5942,18 @@ arm (f5-irules) is not ported (no battery driver).  Battery
 `FP_STY_02_live_dollar_in_quoted_pattern_still_fires` now pass; 1 unit
 test; no battery / e2e regressions.
 
+**LANDED (W105 exempts a command-substitution body — battery
+2026-06-12).**  `emit_w105_unbraced_body` treated a whole-word `[…]` body
+as a substitution-bearing unbraced body and fired W105 at ERROR, diverging
+from `check_unbraced_body` which skips a `TokenType.CMD` body *before* the
+substitution test.  A `[list …]` / `[buildScript]` body is the recommended
+*safe* form — produced dynamically, parsed once, no double-substitution
+risk, and it cannot be braced (`eval {[list …]}` changes the meaning).
+Added the `Cmd`-token exemption (a `Var` body like `while {$cond} $body`
+is still flagged — only `Cmd` words are exempt).  Battery
+`TN_safe_eval_with_list_form` (`eval [list set y $x]`) now passes; 1 unit
+test.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5026,6 +5026,24 @@ fp_inj 1.
   **fp_opt O106/O109/O116** (3), and the residual misc (namespace-ensemble
   resolution, `eval [list set …]` def recognition, S101 intrep-thrash).
 
+2. **E003 subcommand arity** (closes `test_diagnostic_matrix_e2e[E003]` +
+   `test_diagnostics_e2e::test_file_link_too_many_positionals_is_e003`).
+   `analyser/diagnostics.rs::emit_arity_diagnostics` previously returned early
+   for `WithSubcommands`; it now ports the Python `_check_arity` →
+   `_check_simple_arity` path (`analyser/compiler_checks.py:783-797`) by
+   extracting a shared `check_simple_arity` helper and running it on `args[1:]`
+   against the resolved subcommand's `CommandSig`. The per-subcommand option set
+   (`SubCommand.options`, e.g. `-symbolic`/`-hard` on `file link`,
+   `-nocase` on `string match`) is now threaded into the subcommand
+   `CommandSig.leading_options` via a new `SubCommand::switch_names`
+   (mirroring `_subcommand_switch_names`), so option-aware skipping matches.
+   Stays silent on `file link -symbolic $a $b`, `file link -hard $a $b`,
+   `string match -nocase $a $b`; fires on `string length a b c` and
+   `file link $a $b $c`. Shadowing-proc suppression and `{*}`-expansion handling
+   carry over unchanged (the candidate still flows through
+   `flush_arity_diagnostics` keyed on the base command name). lsp_e2e
+   463→465 passing; precision battery held at 284/93.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5878,6 +5878,24 @@ when the between-text stays at brace depth zero and crosses no
 body while still rejecting cross-scope leaks; 2 unit tests, battery W231
 proc-body TPs (`lset l 99 X`, `lset l end X` on `{}`) now pass.
 
+**LANDED (bounds checks recurse into `[…]` substitutions — battery
+2026-06-12).**  The main analyser walk descends proc / control-flow
+*bodies* (so their commands run the per-command syntactic checks) but
+treats a `[cmd …]` substitution as an opaque value and never descends it
+— so `set x [string index abc 99]` / `return [lindex {a b c} 9]` escaped
+the index-bounds family entirely.  Added `run_nested_bounds_diagnostics`
+(+ free `collect_substitution_bounds` / `run_segment_bounds`), the bounds
+companion of the existing `collect_substitution_heads` W123/W307 walk:
+for each `[…]` word it descends the substitution and runs W230 / W231 /
+W232 + W240-W242 on every inner command, recursing into nested `[…]` and
+the inner commands' own bodies.  Mirrors main's `_recurse_nested_commands`
+re-running `run_all_checks`.  Only `[…]` regions are entered, so a command
+the main walk already checked never double-fires (verified by a
+count-of-one unit test).  Battery `TP_W232_string_index_past_end_is_smell`
+and `FP_NAB_02_lindex_oor_smell_fires` now pass; 1 unit test.  The
+remaining `$var`-indexed bounds TPs (`FP_BND_01`/`FP_BND_03`) still need
+the interval domain (§E2), not this syntactic path.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5896,6 +5896,21 @@ and `FP_NAB_02_lindex_oor_smell_fires` now pass; 1 unit test.  The
 remaining `$var`-indexed bounds TPs (`FP_BND_01`/`FP_BND_03`) still need
 the interval domain (§E2), not this syntactic path.
 
+**LANDED (full per-command dispatch on `[…]` substitutions — battery
+2026-06-12).**  Generalised the substitution recursion above from the
+bounds family to the whole per-command dispatch
+(`emit_dispatch_site_diagnostics`: security W101-W312, bounds W230-W242,
+W001 / W004 / W304, arity E002-E003, …), matching Python's
+`_recurse_nested_commands` re-running the full `run_all_checks`.
+`run_nested_command_diagnostics` collects the descended substitution
+commands as owned `SegmentedCommand`s (so the immutable source borrow ends
+before the `&mut self` dispatch) and runs the dispatch on each, with the
+enclosing command's `scope_path` (a substitution shares its embedding
+command's frame).  Only `[…]` regions are entered, so the main walk's
+already-checked commands never double-fire.  Battery
+`FP_NAB_06_open_variable_pipe_fires_w103` (`set fh [open "|$cmd" r]`) now
+passes; zero battery / e2e regressions; +1 unit test.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5986,6 +5986,15 @@ spelling (a dynamic `$`-target names no static local and is skipped).
 Battery `FP_DS_04_traced_var_no_w220` and `FP_DS_04_84_form_also_excluded`
 now pass; 1 unit test; no regressions.
 
+**LANDED (hex / binary literals typed INT — battery 2026-06-12).**
+`type_infer::literal_type` typed only decimal integers as INT (`parse::<i64>`),
+so `set n 0x80` was STRING and `incr n` looked like a per-iteration
+string→int shimmer (false S101/S102).  Matched `core_analyses._literal_type`:
+a `0x`/`0X` hex or `0b`/`0B` binary form (optionally signed) is INT — one
+clean parse, the canonical tcllib idiom — while `0o` octal stays STRING.
+Battery `FP_SH_04_hex_literal_increment_no_shimmer` now passes; 1 unit test;
+no regressions.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5077,6 +5077,20 @@ fp_inj 1.
    server change); full Python-backend e2e suite still green (488 passed),
    native lsp_e2e 467→469 passing.
 
+5. **inlay-hint optional-positional labels for `?option ...?` synopses**
+   (closes `test_editor_features_e2e::TestInlayHintOptionalPositionals::test_no_documentation_placeholder_labels`).
+   `lsearch`'s registry hover synopsis is `lsearch ?option ...? list pattern`.
+   `param_names_from_synopsis` checked the bare-varargs stop (`if
+   group.contains("...") { break; }`) *before* the optional-group handling, so
+   the `?option ...?` flag-group placeholder was mistaken for a hard varargs
+   terminator and the parse aborted — dropping the real `list` / `pattern`
+   positionals (zero hints emitted). The optional `?...?` branch now runs
+   first, so an optional flag/repeat placeholder carrying `...` is skipped
+   (multi-word inner → not a plain name) while the trailing positionals are
+   still labelled; a *non-optional* `...` repeat marker still stops the parse
+   after its preceding positional. lsp_e2e 469→470 passing; precision battery
+   unchanged.
+
 ## Testing strategy — porting the 14k-test pytest suite to Rust
 
 Audit (2026-06-10) of the **448 pytest files / ~14,112 test functions** to

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5975,6 +5975,17 @@ fires W231 exactly as Python does.  Battery `FP_BND_01` (loop counter past
 append) and `FP_BND_03` (×2, `string index $s $i` with a const-var index)
 now pass; 6 unit tests; zero battery / e2e regressions.
 
+**LANDED (traced variables excluded from W211/W220 — battery
+2026-06-12).**  `scan_scope_aliases` (the dead-store / unused-variable
+observability gate) recognised `global` / `variable` / `upvar` / `namespace
+upvar` aliases but not `trace`.  A write trace fires its callback on every
+`set`, so the traced variable is observable and must never be a dead store
+(W220) or set-but-never-used (W211).  Added a `trace` arm recognising both
+`trace add variable NAME …` (8.5+) and the 8.4 `trace variable NAME …`
+spelling (a dynamic `$`-target names no static local and is skipped).
+Battery `FP_DS_04_traced_var_no_w220` and `FP_DS_04_84_form_also_excluded`
+now pass; 1 unit test; no regressions.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5995,6 +5995,22 @@ clean parse, the canonical tcllib idiom — while `0o` octal stays STRING.
 Battery `FP_SH_04_hex_literal_increment_no_shimmer` now passes; 1 unit test;
 no regressions.
 
+**LANDED (S102 requires genuine per-iteration oscillation — battery
+2026-06-12).**  The thunking pass fired S102 on *any* SHIMMERED loop-header
+phi, so a one-time promotion (`set r {}`; `foreach … {lappend r …}` — STRING
+once then LIST forever) and sibling loops with different per-loop type
+effects on the same name produced false positives.  Ported `_find_thunking`'s
+refined condition: classify the phi's incomings into entry vs body
+(back-edge) types, exclude the empty-literal reset, and fire only when the
+body re-introduces an entry type (`entry ∩ body`) or itself produces ≥2
+distinct types.  Body types are scoped to each header's *natural loop* (a
+back-edge-driven block walk, the Rust analogue of `build_loop_forest`) so a
+sibling loop never pollutes the check; destructure-foreach (`foreach … break`)
+blocks are excluded.  Battery `FP_SH_05_destructure_foreach_no_s102` and
+`FP_SH_06_sibling_loops_no_s102` now pass; the existing one-time-promotion TP
+test (a Rust over-fire Python suppresses) was corrected to a genuine
+two-type-body case; 3 unit tests; no regressions.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -5863,6 +5863,21 @@ for the shippable token/regex form (W230-W232 + W240-W242); the
 interval-domain W233 remains the eventual main-parity target (§E2), not a
 present gap.
 
+**LANDED (W231 proc-scoped length recovery — battery 2026-06-12).**  The
+GAP-A4 `_infer_list_length_from_recent_set` port had quietly diverged: it
+recovered the list length by *top-level* command segmentation instead of
+Python's line-anchored `_LIST_SET_RE` + `_scope_is_flat` text scan.  That
+divergence silently dropped the common case where the `set var {…}` and the
+`lset` sit in the *same* `proc` body (neither is a top-level command), so
+`proc f {} { set l {a b c}; lset l 99 X }` never fired W231.  Re-ported to
+mirror Python exactly: a hand-rolled scan for `(?:^|\n)\s*set\s+(\w+)\s+
+(\{[^{}]*\})\s*(?=\n|$|;)` (no regex crate in the workspace), accepted only
+when the between-text stays at brace depth zero and crosses no
+`proc`/`namespace eval`/`apply`/`try` boundary (`scope_is_flat` +
+`has_scope_marker`).  Now recovers a same-scope `set` nested in a `proc`
+body while still rejecting cross-scope leaks; 2 unit tests, battery W231
+proc-body TPs (`lset l 99 X`, `lset l end X` on `{}`) now pass.
+
 **GAP-A5 — `core/compiler/inlining/` general function inliner (2650 LOC)
 — absent.**  `inline_pass.py::inline_module` (IR body splicer, consumed
 by `codegen/wasm/__init__.py:424`), `decision.py` (ALWAYS / IF_SINGLE_CALL

--- a/rust/tcl-compiler/src/analyser/bounds_checks.rs
+++ b/rust/tcl-compiler/src/analyser/bounds_checks.rs
@@ -642,17 +642,17 @@ pub(crate) fn lset_index_diagnostics(
 }
 
 /// Recover the literal length of `var_name` from the most recent
-/// top-level `set var {literal}` before `before_offset`, when that
-/// assignment shares the `lset`'s (flat) scope.  Mirrors
-/// `_infer_list_length_from_recent_set` (only brace-free braced literals
-/// are trusted, so the captured literal can't hide nested braces).
-///
-/// Two deliberate divergences from Python's `_LIST_SET_RE` (a
-/// line-anchored regex): the segmenter recognises a `set` after a `;`
-/// separator on the same line (not just at a line start), and a list
-/// whose `split_tcl_list` is malformed has no failure signal to reset
-/// the recovered length on (Python cleared `best_length`).  Both are
-/// narrow and the segmenter form is the more faithful parse.
+/// `set var {flat-literal}` before `before_offset`, when that assignment
+/// shares the `lset`'s (flat) scope.  Mirrors
+/// `_infer_list_length_from_recent_set` + `_scope_is_flat`: a cheap
+/// line-anchored scan for `set <var> {literal}` (the regex `_LIST_SET_RE`
+/// `(?:^|\n)\s*set\s+(\w+)\s+(\{[^{}]*\})\s*(?=\n|$|;)`), accepted only
+/// when the text *between* the `set` and the `lset` stays at brace depth
+/// zero and crosses no `proc` / `namespace eval` / `apply` / `try`
+/// boundary.  Unlike top-level segmentation this also recovers a `set`
+/// nested in the *same* `proc` body as the `lset` (both inside one brace
+/// scope, with nothing scope-introducing between them) — the case Python
+/// handles and the previous top-level-only port missed.
 fn infer_list_length_from_recent_set(
     source: &str,
     var_name: &str,
@@ -662,40 +662,177 @@ fn infer_list_length_from_recent_set(
     if before == 0 || before > source.len() || var_name.is_empty() {
         return None;
     }
-    // Segment the text preceding the `lset` and take the most recent
-    // *top-level* `set <var> {flat-literal}`.  Top-level segmentation
-    // inherently enforces the shared-flat-scope requirement: a `set`
-    // nested inside a `proc` / `namespace eval` / … body is not a
-    // top-level command here, so its length never leaks to a top-level
-    // `lset` (the old `scope_is_flat` brace-depth check is subsumed).
-    let prefix = &source[..before];
     let bytes = source.as_bytes();
     let mut best: Option<i64> = None;
-    for cmd in segment_commands(prefix) {
-        if cmd.name() != "set" {
+    let mut i = 0usize;
+    while i < before {
+        // `_LIST_SET_RE` anchors each candidate at a line start
+        // (`(?:^|\n)`): offset 0, or immediately after a newline.
+        if i != 0 && bytes[i - 1] != b'\n' {
+            i += 1;
             continue;
         }
-        let args = cmd.args();
-        if args.len() != 2 || args[0] != var_name {
+        if let Some(m) = match_set_literal(bytes, i, before) {
+            if &source[m.var_start..m.var_end] == var_name && scope_is_flat(&source[m.end..before])
+            {
+                let inner = &source[m.inner_start..m.inner_end];
+                best = Some(
+                    i64::try_from(crate::tcl_expr_eval::split_tcl_list(inner).len())
+                        .unwrap_or(i64::MAX),
+                );
+            }
+            i = m.end.max(i + 1);
             continue;
         }
-        // The value word must be a *braced* literal (delimiter `{`) with
-        // no nested braces, so its element count is unambiguous.
-        let Some(tok) = cmd.arg_tokens().get(1) else {
-            continue;
-        };
-        if tok.kind != TokenType::Str || bytes.get(tok.span.start() as usize) != Some(&b'{') {
-            continue;
-        }
-        let inner = &args[1];
-        if inner.bytes().any(|b| b == b'{' || b == b'}') {
-            continue;
-        }
-        let len =
-            i64::try_from(crate::tcl_expr_eval::split_tcl_list(inner).len()).unwrap_or(i64::MAX);
-        best = Some(len);
+        i += 1;
     }
     best
+}
+
+/// A successful `set <var> {flat-literal}` match: byte offsets of the var
+/// name, the brace-inner text, and the match end (just past the `}`).
+struct SetLiteralMatch {
+    var_start: usize,
+    var_end: usize,
+    inner_start: usize,
+    inner_end: usize,
+    end: usize,
+}
+
+/// Try to match `\s*set\s+(\w+)\s+\{[^{}]*\}\s*(?=\n|$|;)` starting at
+/// `start` within `bytes[..end]`.  Returns the captured spans on success.
+fn match_set_literal(bytes: &[u8], start: usize, end: usize) -> Option<SetLiteralMatch> {
+    let is_ws = |c: u8| matches!(c, b' ' | b'\t' | b'\r' | b'\n' | 0x0b | 0x0c);
+    let is_word = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+    let mut p = start;
+    while p < end && is_ws(bytes[p]) {
+        p += 1;
+    }
+    if end - p < 3 || &bytes[p..p + 3] != b"set" {
+        return None;
+    }
+    p += 3;
+    if p >= end || !is_ws(bytes[p]) {
+        return None;
+    }
+    while p < end && is_ws(bytes[p]) {
+        p += 1;
+    }
+    let var_start = p;
+    while p < end && is_word(bytes[p]) {
+        p += 1;
+    }
+    if p == var_start {
+        return None;
+    }
+    let var_end = p;
+    if p >= end || !is_ws(bytes[p]) {
+        return None;
+    }
+    while p < end && is_ws(bytes[p]) {
+        p += 1;
+    }
+    if p >= end || bytes[p] != b'{' {
+        return None;
+    }
+    let inner_start = p + 1;
+    p = inner_start;
+    while p < end && bytes[p] != b'{' && bytes[p] != b'}' {
+        p += 1;
+    }
+    if p >= end || bytes[p] != b'}' {
+        return None; // ran out, or hit a nested `{` (the `[^{}]*` class)
+    }
+    let inner_end = p;
+    let match_end = p + 1;
+    // `\s*(?=\n|$|;)` — skip non-newline horizontal whitespace; the match
+    // is valid only when it lands on a newline, a `;`, or end-of-region.
+    let mut q = match_end;
+    while q < end && matches!(bytes[q], b' ' | b'\t' | b'\r' | 0x0b | 0x0c) {
+        q += 1;
+    }
+    if !(q >= end || bytes[q] == b'\n' || bytes[q] == b';') {
+        return None;
+    }
+    Some(SetLiteralMatch {
+        var_start,
+        var_end,
+        inner_start,
+        inner_end,
+        end: match_end,
+    })
+}
+
+/// True when *between* stays at brace depth zero and introduces no
+/// `proc` / `namespace eval` / `apply` / `try` scope — i.e. a trailing
+/// `lset` shares the originating `set`'s scope.  Mirrors `_scope_is_flat`.
+fn scope_is_flat(between: &str) -> bool {
+    if has_scope_marker(between) {
+        return false;
+    }
+    let b = between.as_bytes();
+    let n = b.len();
+    let mut depth: i32 = 0;
+    let mut i = 0;
+    while i < n {
+        match b[i] {
+            b'\\' if i + 1 < n => {
+                i += 2;
+                continue;
+            }
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    depth == 0
+}
+
+/// Whether *s* contains a `proc` / `apply` / `try` / `namespace eval`
+/// keyword at a word boundary.  Mirrors `_SCOPE_MARKERS_RE`
+/// (`\b(?:proc|namespace\s+eval|apply|try)\b`).
+fn has_scope_marker(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let is_word = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+    let is_ws = |c: u8| matches!(c, b' ' | b'\t' | b'\r' | b'\n' | 0x0b | 0x0c);
+    let mut i = 0;
+    while i < len {
+        if (i == 0 || !is_word(bytes[i - 1])) && is_word(bytes[i]) {
+            let start = i;
+            while i < len && is_word(bytes[i]) {
+                i += 1;
+            }
+            match &text[start..i] {
+                "proc" | "apply" | "try" => return true,
+                "namespace" => {
+                    let mut j = i;
+                    while j < len && is_ws(bytes[j]) {
+                        j += 1;
+                    }
+                    if j > i {
+                        let estart = j;
+                        while j < len && is_word(bytes[j]) {
+                            j += 1;
+                        }
+                        if &text[estart..j] == "eval" {
+                            return true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// True when a `(first, last)` index pair resolves to a provably-empty
@@ -1302,5 +1439,46 @@ mod tests {
         let r = a.analyse("while {$x < 10} {puts hi}\n", "tcl8.6");
         let w242 = r.diagnostics.iter().find(|d| d.code == "W242").unwrap();
         assert_eq!(w242.severity, super::Severity::Hint);
+    }
+
+    fn w231(src: &str) -> usize {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl8.6")
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W231")
+            .count()
+    }
+
+    #[test]
+    fn w231_list_length_recovered_inside_proc_body() {
+        // The `set l {a b c}` shares the proc body's flat scope with the
+        // `lset`, so its length (3) is recovered and `99` proves OOR —
+        // the case top-level-only segmentation used to miss.
+        assert_eq!(
+            w231("proc f {} {\n    set l {a b c}\n    lset l 99 X\n}\n"),
+            1
+        );
+        // `end` on an empty list is out of range.
+        assert_eq!(w231("proc f {} {\n    set l {}\n    lset l end X\n}\n"), 1);
+        // Still fires at top level.
+        assert_eq!(w231("set l {a b c}\nlset l 99 X\n"), 1);
+        // The append slot (index == length) is accepted.
+        assert_eq!(
+            w231("proc f {} {\n    set l {a b c}\n    lset l 3 X\n}\n"),
+            0
+        );
+    }
+
+    #[test]
+    fn w231_length_not_recovered_across_scope_boundary() {
+        // A `set` in a *different* proc body must not leak its length to a
+        // top-level `lset` — `scope_is_flat` rejects the proc crossing.
+        assert_eq!(w231("proc other {} { set l {a b c} }\nlset l 99 X\n"), 0);
+        // An intervening unclosed brace scope likewise blocks recovery.
+        assert_eq!(
+            w231("set l {a b c}\nnamespace eval ns {\n    lset l 99 X\n}\n"),
+            0
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/bounds_checks.rs
+++ b/rust/tcl-compiler/src/analyser/bounds_checks.rs
@@ -1470,6 +1470,41 @@ mod tests {
         );
     }
 
+    fn has_code(src: &str, code: &str) -> bool {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl8.6")
+            .diagnostics
+            .iter()
+            .any(|d| d.code == code)
+    }
+
+    #[test]
+    fn bounds_checks_recurse_into_command_substitutions() {
+        // The main walk never descends a `[…]` substitution, so the
+        // bounds family runs on its inner commands via the nested-bounds
+        // recursion.
+        assert!(has_code("set x [lindex {a b c} 9]\n", "W230"));
+        assert!(has_code(
+            "proc f {} { return [string index abc 99] }\n",
+            "W232"
+        ));
+        // Nested two deep: `[foo [string index abc 99]]`.
+        assert!(has_code(
+            "proc f {} { return [join [string index abc 99]] }\n",
+            "W232"
+        ));
+        // A bare (non-substituted) command is still checked exactly once —
+        // the recursion only enters `[…]`, so no double-fire.
+        let mut a = Analyser::new();
+        let n = a
+            .analyse("set x [lindex {a b c} 9]\n", "tcl8.6")
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W230")
+            .count();
+        assert_eq!(n, 1);
+    }
+
     #[test]
     fn w231_length_not_recovered_across_scope_boundary() {
         // A `set` in a *different* proc body must not leak its length to a

--- a/rust/tcl-compiler/src/analyser/bounds_checks.rs
+++ b/rust/tcl-compiler/src/analyser/bounds_checks.rs
@@ -1506,6 +1506,17 @@ mod tests {
     }
 
     #[test]
+    fn security_checks_recurse_into_command_substitutions() {
+        // The full per-command dispatch — not just bounds — runs on a
+        // substitution command, so `open "|$cmd"` nested in `[…]` still
+        // fires the W103 pipeline-injection check.
+        assert!(has_code(
+            "proc f {cmd} { set fh [open \"|$cmd\" r] }\n",
+            "W103"
+        ));
+    }
+
+    #[test]
     fn w231_length_not_recovered_across_scope_boundary() {
         // A `set` in a *different* proc body must not leak its length to a
         // top-level `lset` — `scope_is_flat` rejects the proc crossing.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -262,6 +262,16 @@ impl Analyser {
         // (Python).
         self.record_nested_invocations_from_args(cmd_name, args, arg_tokens_in);
 
+        // Run the per-command index-bounds checks (W230/W231/W232 +
+        // loop-termination) on commands nested inside ``[…]``
+        // substitutions — the main walk never descends a substitution
+        // (it treats `[cmd …]` as a value), so `set x [string index abc
+        // 99]` / `return [lindex {a b c} 9]` would otherwise escape the
+        // syntactic bounds checks.  Mirrors main's
+        // ``_recurse_nested_commands`` re-running ``run_all_checks`` on
+        // each descended substitution command.
+        self.run_nested_bounds_diagnostics(arg_tokens_in);
+
         // **C41d3.** Record variable-as-command and
         // command-substitution-as-command call sites so the
         // post-walk W307 / W308 emitters can resolve them.
@@ -716,6 +726,45 @@ impl Analyser {
         self.push_collected_heads(heads);
     }
 
+    /// Run the syntactic index-bounds checks on every command nested in a
+    /// ``[…]`` substitution of this command's words, recursing into
+    /// further nested substitutions.  The main analyser walk descends
+    /// proc / control-flow *bodies* (so those commands are already
+    /// checked) but never a ``[…]`` substitution, which it treats as an
+    /// opaque value — so the bounds family (W230 `lindex`, W231 `lset`,
+    /// W232 `string index`/…, W240-W242 loop-termination) would miss
+    /// `set x [string index abc 99]` / `return [lindex {a b c} 9]`.
+    /// Mirrors main's ``_recurse_nested_commands`` re-running
+    /// ``run_all_checks`` on each descended substitution command.
+    ///
+    /// Only ``[…]`` regions are entered here; everything inside one is
+    /// invisible to the main walk, so the recursion may freely descend
+    /// the nested commands' own bodies and substitutions without
+    /// double-firing a diagnostic the main walk already emitted.
+    fn run_nested_bounds_diagnostics(&mut self, arg_tokens_in: &[Token]) {
+        let config = self.lexer_config();
+        let mut diags: Vec<super::types::Diagnostic> = Vec::new();
+        {
+            let sm = SourceMap::new(&self.source);
+            for arg_tok in arg_tokens_in {
+                if arg_tok.kind != TokenType::Cmd {
+                    continue;
+                }
+                for frag in self.cmd_fragments(*arg_tok, config) {
+                    collect_substitution_bounds(
+                        &sm,
+                        self.registry.as_ref(),
+                        &self.source,
+                        frag,
+                        config,
+                        &mut diags,
+                    );
+                }
+            }
+        }
+        self.result.diagnostics.extend(diags);
+    }
+
     /// The `[…]` substitution fragment tokens of a (possibly compound)
     /// `Cmd`-headed word, with absolute spans.  Re-lexing the word slice
     /// recovers the per-fragment boundaries the argv merge erased, so
@@ -1071,6 +1120,90 @@ fn collect_expr_substitutions(
         for tok in &seg.all_tokens {
             if tok.kind == TokenType::Cmd {
                 collect_substitution_heads(sm, registry, *tok, config, out);
+            }
+        }
+    }
+}
+
+/// Descend a ``[…]`` substitution token and run the syntactic
+/// index-bounds checks on every command inside it, recursing into nested
+/// ``[…]`` and the inner commands' bodies.  The companion of
+/// [`collect_substitution_heads`] for the bounds family — see
+/// [`Analyser::run_nested_bounds_diagnostics`] for why a substitution is
+/// the only region the main walk leaves unchecked.
+fn collect_substitution_bounds(
+    sm: &SourceMap<'_>,
+    registry: Option<&CommandRegistry>,
+    source: &str,
+    cmd_tok: Token,
+    config: LexerConfig,
+    out: &mut Vec<super::types::Diagnostic>,
+) {
+    if cmd_tok.kind != TokenType::Cmd || sm.token_text(cmd_tok).is_empty() {
+        return;
+    }
+    let descended = descend_token(sm, cmd_tok, config);
+    for seg in segments_from_tree(descended.tree(), sm) {
+        run_segment_bounds(sm, registry, source, &seg, config, out);
+    }
+}
+
+/// Run the bounds checks on one (already-segmented) substitution command,
+/// then recurse into its own nested ``[…]`` substitutions and registry-
+/// resolved bodies.  All of these live inside an outer ``[…]`` (the entry
+/// is [`collect_substitution_bounds`]), so none are visited by the main
+/// walk and the checks never double-fire.
+fn run_segment_bounds(
+    sm: &SourceMap<'_>,
+    registry: Option<&CommandRegistry>,
+    source: &str,
+    seg: &SegmentedCommand,
+    config: LexerConfig,
+    out: &mut Vec<super::types::Diagnostic>,
+) {
+    let Some(cmd_name) = seg.texts.first() else {
+        return;
+    };
+    let cmd_name = cmd_name.as_str();
+    let args: Vec<String> = seg.texts.iter().skip(1).cloned().collect();
+    let arg_tokens: Vec<Token> = seg.argv.iter().skip(1).copied().collect();
+
+    out.extend(super::bounds_checks::loop_termination_diagnostics(
+        cmd_name,
+        &args,
+        &arg_tokens,
+    ));
+    out.extend(super::bounds_checks::list_index_diagnostics(
+        cmd_name,
+        &args,
+        &arg_tokens,
+    ));
+    out.extend(super::bounds_checks::lset_index_diagnostics(
+        cmd_name,
+        &args,
+        &arg_tokens,
+        source,
+    ));
+    out.extend(super::bounds_checks::string_index_diagnostics(
+        cmd_name,
+        &args,
+        &arg_tokens,
+    ));
+
+    // Nested ``[…]`` substitutions in any word of this command.
+    for tok in &seg.all_tokens {
+        if tok.kind == TokenType::Cmd {
+            collect_substitution_bounds(sm, registry, source, *tok, config, out);
+        }
+    }
+
+    // Registry-resolved body arguments (`[if {$c} {string index …}]`):
+    // their commands are also invisible to the main walk here.
+    if let Some(registry) = registry {
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        for body in descend_command(registry, sm, cmd_name, &arg_strs, &arg_tokens, config) {
+            for inner in segments_from_tree(body.descended.tree(), sm) {
+                run_segment_bounds(sm, Some(registry), source, &inner, config, out);
             }
         }
     }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -262,15 +262,15 @@ impl Analyser {
         // (Python).
         self.record_nested_invocations_from_args(cmd_name, args, arg_tokens_in);
 
-        // Run the per-command index-bounds checks (W230/W231/W232 +
-        // loop-termination) on commands nested inside ``[…]``
-        // substitutions — the main walk never descends a substitution
-        // (it treats `[cmd …]` as a value), so `set x [string index abc
-        // 99]` / `return [lindex {a b c} 9]` would otherwise escape the
-        // syntactic bounds checks.  Mirrors main's
-        // ``_recurse_nested_commands`` re-running ``run_all_checks`` on
-        // each descended substitution command.
-        self.run_nested_bounds_diagnostics(arg_tokens_in);
+        // Run the per-command syntactic checks on commands nested inside
+        // ``[…]`` substitutions — the main walk never descends a
+        // substitution (it treats `[cmd …]` as a value), so a command
+        // like `set fh [open "|$cmd" r]` or `set x [string index abc 99]`
+        // would otherwise escape the security / bounds / arity / style
+        // families entirely.  Mirrors main's ``_recurse_nested_commands``
+        // re-running ``run_all_checks`` on each descended substitution
+        // command.
+        self.run_nested_command_diagnostics(arg_tokens_in, scope_path);
 
         // **C41d3.** Record variable-as-command and
         // command-substitution-as-command call sites so the
@@ -726,24 +726,33 @@ impl Analyser {
         self.push_collected_heads(heads);
     }
 
-    /// Run the syntactic index-bounds checks on every command nested in a
-    /// ``[…]`` substitution of this command's words, recursing into
-    /// further nested substitutions.  The main analyser walk descends
-    /// proc / control-flow *bodies* (so those commands are already
-    /// checked) but never a ``[…]`` substitution, which it treats as an
-    /// opaque value — so the bounds family (W230 `lindex`, W231 `lset`,
-    /// W232 `string index`/…, W240-W242 loop-termination) would miss
-    /// `set x [string index abc 99]` / `return [lindex {a b c} 9]`.
-    /// Mirrors main's ``_recurse_nested_commands`` re-running
-    /// ``run_all_checks`` on each descended substitution command.
+    /// Run the per-command syntactic dispatch
+    /// ([`Self::emit_dispatch_site_diagnostics`] — security W101-W312,
+    /// bounds W230-W242, W001 / W004 / W304, arity E002-E003, …) on every
+    /// command nested in a ``[…]`` substitution of this command's words,
+    /// recursing into further nested substitutions and the nested
+    /// commands' own bodies.  The main analyser walk descends proc /
+    /// control-flow *bodies* (so those commands are already checked) but
+    /// never a ``[…]`` substitution, which it treats as an opaque value —
+    /// so `set fh [open "|$cmd" r]` / `set x [string index abc 99]` would
+    /// otherwise escape the per-command checks.  Mirrors main's
+    /// ``_recurse_nested_commands`` re-running ``run_all_checks`` on each
+    /// descended substitution command.
     ///
-    /// Only ``[…]`` regions are entered here; everything inside one is
-    /// invisible to the main walk, so the recursion may freely descend
-    /// the nested commands' own bodies and substitutions without
-    /// double-firing a diagnostic the main walk already emitted.
-    fn run_nested_bounds_diagnostics(&mut self, arg_tokens_in: &[Token]) {
+    /// Only ``[…]`` regions are entered here; everything reached from
+    /// inside one is invisible to the main walk, so the recursion may
+    /// freely descend the nested commands' own bodies and substitutions
+    /// without double-firing a diagnostic the main walk already emitted.
+    /// `scope_path` is the enclosing command's scope — a substitution
+    /// runs in the same frame as the command it is embedded in.
+    fn run_nested_command_diagnostics(&mut self, arg_tokens_in: &[Token], scope_path: &[usize]) {
+        // Collect the descended substitution commands first (this borrows
+        // `self.source` through the `SourceMap`); run the `&mut self`
+        // dispatch afterwards, once the immutable borrow has ended.  Each
+        // `SegmentedCommand` is fully owned (absolute spans), so it
+        // outlives the borrow.
         let config = self.lexer_config();
-        let mut diags: Vec<super::types::Diagnostic> = Vec::new();
+        let mut nested: Vec<SegmentedCommand> = Vec::new();
         {
             let sm = SourceMap::new(&self.source);
             for arg_tok in arg_tokens_in {
@@ -751,18 +760,32 @@ impl Analyser {
                     continue;
                 }
                 for frag in self.cmd_fragments(*arg_tok, config) {
-                    collect_substitution_bounds(
+                    collect_substitution_segments(
                         &sm,
                         self.registry.as_ref(),
-                        &self.source,
                         frag,
                         config,
-                        &mut diags,
+                        &mut nested,
                     );
                 }
             }
         }
-        self.result.diagnostics.extend(diags);
+        for seg in nested {
+            if seg.texts.is_empty() || seg.argv.is_empty() {
+                continue;
+            }
+            let cmd_name = seg.texts[0].clone();
+            let cmd_tok = seg.argv[0];
+            let args = seg.texts.get(1..).unwrap_or(&[]);
+            let arg_tokens = seg.argv.get(1..).unwrap_or(&[]);
+            let arg_single = seg.single_token_word.get(1..).unwrap_or(&[]);
+            // `emit_arity_diagnostics` expects the expand array parallel to
+            // the *full* argv (head at index 0), matching `process_command`.
+            let arg_expand = seg.expand_word.as_deref().unwrap_or(&[]);
+            self.emit_dispatch_site_diagnostics(
+                &cmd_name, args, arg_tokens, arg_single, arg_expand, cmd_tok, scope_path,
+            );
+        }
     }
 
     /// The `[…]` substitution fragment tokens of a (possibly compound)
@@ -1125,88 +1148,58 @@ fn collect_expr_substitutions(
     }
 }
 
-/// Descend a ``[…]`` substitution token and run the syntactic
-/// index-bounds checks on every command inside it, recursing into nested
-/// ``[…]`` and the inner commands' bodies.  The companion of
-/// [`collect_substitution_heads`] for the bounds family — see
-/// [`Analyser::run_nested_bounds_diagnostics`] for why a substitution is
+/// Descend a ``[…]`` substitution token and collect every command inside
+/// it (recursing into nested ``[…]`` and the inner commands' bodies) into
+/// `out`, for the caller to run the per-command dispatch on.  The bounds /
+/// security companion of [`collect_substitution_heads`] — see
+/// [`Analyser::run_nested_command_diagnostics`] for why a substitution is
 /// the only region the main walk leaves unchecked.
-fn collect_substitution_bounds(
+fn collect_substitution_segments(
     sm: &SourceMap<'_>,
     registry: Option<&CommandRegistry>,
-    source: &str,
     cmd_tok: Token,
     config: LexerConfig,
-    out: &mut Vec<super::types::Diagnostic>,
+    out: &mut Vec<SegmentedCommand>,
 ) {
     if cmd_tok.kind != TokenType::Cmd || sm.token_text(cmd_tok).is_empty() {
         return;
     }
     let descended = descend_token(sm, cmd_tok, config);
     for seg in segments_from_tree(descended.tree(), sm) {
-        run_segment_bounds(sm, registry, source, &seg, config, out);
+        collect_segment_recursive(sm, registry, seg, config, out);
     }
 }
 
-/// Run the bounds checks on one (already-segmented) substitution command,
-/// then recurse into its own nested ``[…]`` substitutions and registry-
-/// resolved bodies.  All of these live inside an outer ``[…]`` (the entry
-/// is [`collect_substitution_bounds`]), so none are visited by the main
-/// walk and the checks never double-fire.
-fn run_segment_bounds(
+/// Recurse into one (already-segmented) substitution command's nested
+/// ``[…]`` substitutions and registry-resolved bodies, then record the
+/// command itself.  All of these live inside an outer ``[…]`` (the entry
+/// is [`collect_substitution_segments`]), so none are visited by the main
+/// walk and the dispatch never double-fires.
+fn collect_segment_recursive(
     sm: &SourceMap<'_>,
     registry: Option<&CommandRegistry>,
-    source: &str,
-    seg: &SegmentedCommand,
+    seg: SegmentedCommand,
     config: LexerConfig,
-    out: &mut Vec<super::types::Diagnostic>,
+    out: &mut Vec<SegmentedCommand>,
 ) {
-    let Some(cmd_name) = seg.texts.first() else {
-        return;
-    };
-    let cmd_name = cmd_name.as_str();
-    let args: Vec<String> = seg.texts.iter().skip(1).cloned().collect();
-    let arg_tokens: Vec<Token> = seg.argv.iter().skip(1).copied().collect();
-
-    out.extend(super::bounds_checks::loop_termination_diagnostics(
-        cmd_name,
-        &args,
-        &arg_tokens,
-    ));
-    out.extend(super::bounds_checks::list_index_diagnostics(
-        cmd_name,
-        &args,
-        &arg_tokens,
-    ));
-    out.extend(super::bounds_checks::lset_index_diagnostics(
-        cmd_name,
-        &args,
-        &arg_tokens,
-        source,
-    ));
-    out.extend(super::bounds_checks::string_index_diagnostics(
-        cmd_name,
-        &args,
-        &arg_tokens,
-    ));
-
     // Nested ``[…]`` substitutions in any word of this command.
     for tok in &seg.all_tokens {
         if tok.kind == TokenType::Cmd {
-            collect_substitution_bounds(sm, registry, source, *tok, config, out);
+            collect_substitution_segments(sm, registry, *tok, config, out);
         }
     }
-
     // Registry-resolved body arguments (`[if {$c} {string index …}]`):
     // their commands are also invisible to the main walk here.
     if let Some(registry) = registry {
-        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-        for body in descend_command(registry, sm, cmd_name, &arg_strs, &arg_tokens, config) {
+        let args: Vec<&str> = seg.texts.iter().skip(1).map(String::as_str).collect();
+        let arg_tokens: Vec<Token> = seg.argv.iter().skip(1).copied().collect();
+        for body in descend_command(registry, sm, seg.name(), &args, &arg_tokens, config) {
             for inner in segments_from_tree(body.descended.tree(), sm) {
-                run_segment_bounds(sm, Some(registry), source, &inner, config, out);
+                collect_segment_recursive(sm, Some(registry), inner, config, out);
             }
         }
     }
+    out.push(seg);
 }
 
 /// Mirror of main's `_switch_list_body_index`: for the

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -473,6 +473,7 @@ impl Analyser {
         self.emit_w301_uplevel_injection(cmd_name, args, arg_tokens, arg_single);
         self.emit_w312_interp_eval_injection(cmd_name, args, arg_tokens, arg_single);
         self.emit_w303_redos(cmd_name, args, arg_tokens);
+        self.emit_w306_literal_expected(cmd_name, args, arg_tokens);
         // W310 runs for every command (it scans args for credential
         // option flags), so it takes no cmd_name guard.
         self.emit_w310_hardcoded_credentials(cmd_name, args, arg_tokens);

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -2011,6 +2011,17 @@ impl Analyser {
         if matches!(body_tok.kind, tcl_lexer::TokenType::Str) {
             return;
         }
+        // A whole-word command-substitution body — `eval [list set y $x]`
+        // (the recommended *safe* form), `uplevel [buildScript]` — is
+        // produced dynamically and parsed once by the consumer: there is
+        // no double-substitution risk and it cannot be braced
+        // (`eval {[list …]}` changes the meaning).  Mirrors
+        // `check_unbraced_body`'s `tok.type is TokenType.CMD` skip.  (A
+        // `Var` body such as `while {$cond} $body` is *not* exempt — only
+        // a `Cmd` word is.)
+        if matches!(body_tok.kind, tcl_lexer::TokenType::Cmd) {
+            return;
+        }
         let trimmed = body_text.trim();
         // Mirror Python's ``_has_substitution``: textual ``$`` /
         // ``[`` count as substitutions, and so do ``Var`` / ``Cmd``

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -2886,14 +2886,81 @@ Consider capturing the result: catch {\u{2026}} result"
             return;
         };
         let dialect = DialectSet::parse(&self.dialect).unwrap_or(DialectSet::ALL_TCL);
-        let Some(CommandSignature::Simple(sig)) =
-            signature_for_command(registry, cmd_name, dialect)
-        else {
-            // Unknown command (no signature) or a subcommand-dispatch
-            // command — neither is arity-checked here.
-            return;
-        };
+        match signature_for_command(registry, cmd_name, dialect) {
+            Some(CommandSignature::Simple(sig)) => {
+                self.check_simple_arity(
+                    cmd_name, cmd_name, &sig, args, arg_tokens, arg_expand, cmd_tok, scope_path,
+                );
+            }
+            Some(CommandSignature::WithSubcommands(sig)) => {
+                // Per-subcommand arity, mirroring the Python
+                // `_check_arity` → `_check_simple_arity` path on
+                // `args[1:]` (compiler_checks.py:783-797).  The W001
+                // unknown-subcommand path is handled separately by
+                // [`Self::emit_w001_unknown_subcommand`].
+                let Some(sub_name) = args.first() else {
+                    // Missing subcommand — Python's E001 path; not here.
+                    return;
+                };
+                // A `{*}`-expanded subcommand word resolves to an unknown
+                // name at runtime; skip resolution and arity entirely.
+                if arg_expand.first().copied().unwrap_or(false) {
+                    return;
+                }
+                // Dynamic subcommand value — can't resolve statically.
+                if sub_name.contains('$') || sub_name.contains('[') {
+                    return;
+                }
+                let Some(sub_sig) = sig.subcommands.get(sub_name) else {
+                    // Unknown subcommand — W001's job, not arity.
+                    return;
+                };
+                let display_name = format!("{cmd_name} {sub_name}");
+                self.check_simple_arity(
+                    cmd_name,
+                    &display_name,
+                    sub_sig,
+                    &args[1..],
+                    arg_tokens.get(1..).unwrap_or(&[]),
+                    arg_expand.get(1..).unwrap_or(&[]),
+                    cmd_tok,
+                    scope_path,
+                );
+            }
+            None => {}
+        }
+    }
 
+    /// Compare a positional-argument count against a single
+    /// [`CommandSig`]'s arity bounds and queue an E002 / E003
+    /// candidate.  Shared by the simple-command and per-subcommand
+    /// arity paths in [`Self::emit_arity_diagnostics`]; mirrors
+    /// `_check_simple_arity` in `core/compiler/compiler_checks.py`.
+    ///
+    /// `resolution_name` is the base command name used by the
+    /// post-walk [`Self::flush_arity_diagnostics`] to honour a
+    /// shadowing user proc / class / alias (e.g. `file` for the
+    /// `file link` subcommand check), while `display_name` is the
+    /// human-facing name shown in the message (`file link`).
+    ///
+    /// `args` / `arg_tokens` / `arg_expand` are the slices *after*
+    /// whatever prefix the caller has already consumed (the command
+    /// name for the simple path; the command name and subcommand word
+    /// for the subcommand path), so the leading-option scan and
+    /// positional count operate on the same coordinate system as
+    /// `sig`.
+    #[allow(clippy::too_many_arguments)]
+    fn check_simple_arity(
+        &mut self,
+        resolution_name: &str,
+        display_name: &str,
+        sig: &super::dispatch::CommandSig,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+        arg_expand: &[bool],
+        cmd_tok: tcl_lexer::Token,
+        scope_path: &[usize],
+    ) {
         let expanded = |i: usize| arg_expand.get(i).copied().unwrap_or(false);
 
         // Skip leading declared option flags.  Stop at the first
@@ -2966,14 +3033,14 @@ Consider capturing the result: catch {\u{2026}} result"
         if !positional_any_expand && (args.len() - positional_start) < min {
             let got = args.len() - positional_start;
             self.pending_arity.push((
-                cmd_name.to_string(),
+                resolution_name.to_string(),
                 ns,
                 enforce_order,
                 super::types::Diagnostic {
                     code: "E002".to_string(),
                     span: full_span,
                     message: format!(
-                        "Too few arguments for '{cmd_name}': expected at least {min}, got {got}"
+                        "Too few arguments for '{display_name}': expected at least {min}, got {got}"
                     ),
                     severity: Severity::Error,
                     fixes: Vec::new(),
@@ -2981,14 +3048,14 @@ Consider capturing the result: catch {\u{2026}} result"
             ));
         } else if !sig.arity.is_unlimited() && nargs_min > max {
             self.pending_arity.push((
-                cmd_name.to_string(),
+                resolution_name.to_string(),
                 ns,
                 enforce_order,
                 super::types::Diagnostic {
                     code: "E003".to_string(),
                     span: full_span,
                     message: format!(
-                        "Too many arguments for '{cmd_name}': expected at most {max}, got {nargs_min}"
+                        "Too many arguments for '{display_name}': expected at most {max}, got {nargs_min}"
                     ),
                     severity: Severity::Error,
                     fixes: Vec::new(),
@@ -8098,6 +8165,81 @@ mod tests {
             !on_90.iter().any(|c| c == "E003"),
             "9.0 expands `{{*}}` → 4 positional words ≤ max → no E003: {on_90:?}",
         );
+    }
+
+    // -- subcommand-level E003 arity (per-subcommand signatures) -----
+
+    #[test]
+    fn e003_fires_on_subcommand_over_arity() {
+        // `string length` takes exactly one argument — three positional
+        // words must trip E003.
+        let mut a = Analyser::new();
+        let result = a.analyse("string length a b c", "tcl8.6");
+        let e003: Vec<&Diagnostic> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "E003")
+            .collect();
+        assert!(
+            !e003.is_empty(),
+            "expected E003 for `string length a b c`, got {:?}",
+            result.diagnostics
+        );
+        assert!(
+            e003[0].message.contains("string length"),
+            "message should name the subcommand: {:?}",
+            e003[0].message
+        );
+    }
+
+    #[test]
+    fn e003_fires_on_file_link_over_arity() {
+        // `file link ?-linktype? linkName ?target?` — `link` accepts at
+        // most two positional args, so three literal targets is E003.
+        let mut a = Analyser::new();
+        let result = a.analyse("file link $a $b $c", "tcl8.6");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == "E003"),
+            "expected E003 for `file link $a $b $c`, got {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn e003_silent_for_subcommand_leading_options() {
+        // Per-subcommand options (`file link -symbolic` / `-hard`,
+        // `string match -nocase`) must be skipped before counting
+        // positionals, so these well-formed calls stay silent.
+        for snippet in [
+            "file link -symbolic $a $b",
+            "file link -hard $a $b",
+            "string match -nocase $a $b",
+        ] {
+            let mut a = Analyser::new();
+            let result = a.analyse(snippet, "tcl8.6");
+            let e003: Vec<&Diagnostic> = result
+                .diagnostics
+                .iter()
+                .filter(|d| d.code == "E003")
+                .collect();
+            assert!(e003.is_empty(), "unexpected E003 for {snippet:?}: {e003:?}");
+        }
+    }
+
+    #[test]
+    fn subcommand_arity_skips_unknown_and_dynamic_subcommands() {
+        // An unknown subcommand is W001's job, not E003; a dynamic
+        // subcommand word (`$sub`) can't be resolved, so neither path
+        // should emit E003.
+        for snippet in ["string $sub a b c", "string [x] a b c"] {
+            let mut a = Analyser::new();
+            let result = a.analyse(snippet, "tcl8.6");
+            assert!(
+                !result.diagnostics.iter().any(|d| d.code == "E003"),
+                "unexpected E003 for {snippet:?}: {:?}",
+                result.diagnostics
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -1869,6 +1869,29 @@ fn last_literal_set_value_for_var(
     let segments = crate::segmenter::segment_commands_with_offset_and_config(prefix, 0, config);
 
     for cmd in segments.iter().rev() {
+        // Cross-scope guard: stop the backward scan at a `proc NAME
+        // {PARAMS} BODY` whose body *contains* the use offset and whose
+        // params include `var_name` — the parameter shadows any outer
+        // scope, so an outer `set` must not be attributed to the inner
+        // use.  The use is inside the proc body iff that proc is the one
+        // left unclosed by the truncation at `before_offset`: its span
+        // then reaches the last truncated byte (`end + 1 >= head`).  A
+        // *complete* proc before the use ends well before that and does
+        // not shadow.  Mirrors `_last_literal_set_value_for_var`.
+        let use_inside_proc = cmd.span.end() as usize + 1 >= head;
+        if use_inside_proc
+            && cmd.texts.first().map(String::as_str) == Some("proc")
+            && cmd.texts.len() >= 4
+            && cmd.texts[2].contains(var_name)
+        {
+            let shadows = crate::tcl_expr_eval::split_tcl_list(&cmd.texts[2])
+                .iter()
+                .any(|el| el.split_whitespace().next() == Some(var_name));
+            if shadows {
+                return None;
+            }
+        }
+
         if cmd.texts.first().map(String::as_str) != Some("set") {
             continue;
         }
@@ -10657,5 +10680,38 @@ a15 a16 a17 a18 a19 a20\n return $a20 }";
             .diagnostics
             .iter()
             .any(|d| d.code == "W310"));
+    }
+
+    #[test]
+    fn w304_does_not_cross_proc_param_shadow() {
+        // The outer `set path -force` must NOT be attributed to the inner
+        // `$path` use — the proc param `path` shadows it.  W304 may still
+        // fire on the substituted `file delete $path`, but never claiming
+        // the value is `-force`.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "set path -force\nproc useit {path} { file delete $path }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == "W304" && d.message.contains("-force")),
+            "{:?}",
+            r.diagnostics
+        );
+        // Control: a top-level `$path` use *after* a complete proc still
+        // resolves to the outer literal (no shadow crossing).
+        let r2 = a.analyse(
+            "set path -force\nproc p {path} {}\nfile delete $path\n",
+            "tcl8.6",
+        );
+        assert!(
+            r2.diagnostics
+                .iter()
+                .any(|d| d.code == "W304" && d.message.contains("-force")),
+            "{:?}",
+            r2.diagnostics
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -448,6 +448,61 @@ fn has_substitution(text: &str, tok: &tcl_lexer::Token) -> bool {
         )
 }
 
+/// First positional (pattern) argument index of `regexp` / `regsub`,
+/// after skipping option switches (`-start` consumes a value, `--`
+/// terminates).  Mirrors `regexp_pattern_index` (and the regexp arg-role
+/// resolver's option skip).  `args` excludes the command name.
+fn regexp_pattern_index(args: &[String]) -> Option<usize> {
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a == "--" {
+            i += 1;
+            break;
+        }
+        if a.starts_with('-') {
+            i += 1;
+            if a == "-start" && i < args.len() {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    (i < args.len()).then_some(i)
+}
+
+/// True when the **source** slice `raw` (backslashes intact) carries a
+/// *live* substitution: an unescaped `[`, or a `$` that actually
+/// introduces a variable name (`[A-Za-z0-9_]`, `{`, or `:`).  A `\[` /
+/// `\$` is a literal regex character, and a `$` before a quote / end /
+/// punctuation (the `(.*)$` end-anchor) is a literal dollar — neither
+/// counts.  Mirrors `_raw_has_live_substitution`.
+fn raw_has_live_substitution(raw: &str) -> bool {
+    let b = raw.as_bytes();
+    let n = b.len();
+    let mut i = 0;
+    while i < n {
+        match b[i] {
+            b'\\' => {
+                i += 2; // the next char is escaped (literal) — skip both
+                continue;
+            }
+            b'[' => return true,
+            b'$' => {
+                if let Some(&c) = b.get(i + 1) {
+                    if c.is_ascii_alphanumeric() || matches!(c, b'_' | b'{' | b':') {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
 /// True when `text` is a simple numeric or boolean literal that needs
 /// no bracing.  Mirrors `_is_safe_literal`.
 fn is_safe_literal(text: &str) -> bool {
@@ -4076,6 +4131,69 @@ matching time on crafted input."
                 });
             }
         }
+    }
+
+    /// **W306.** Warn when a `regexp` / `regsub` *pattern* — a
+    /// literal-expected position — contains a *live* substitution Tcl
+    /// expands before the regex engine sees it.  A bare `$var` pattern is
+    /// the canonical parameterised-pattern idiom and is exempt (there is
+    /// no braced equivalent); a quoted `"$var"` / `"[cmd]"` or an unbraced
+    /// `[cmd]` is the foot-gun.  `\[` / `\$` in a quoted pattern are
+    /// literal regex characters, not substitutions.  Mirrors the
+    /// `regexp` / `regsub` arm of `_domain.py::check_literal_expected`.
+    pub(super) fn emit_w306_literal_expected(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+    ) {
+        if !matches!(cmd_name, "regexp" | "regsub") {
+            return;
+        }
+        let Some(idx) = regexp_pattern_index(args) else {
+            return;
+        };
+        let (Some(&tok), Some(text)) = (arg_tokens.get(idx), args.get(idx)) else {
+            return;
+        };
+        if is_braced_word(&tok) || !has_substitution(text, &tok) {
+            return;
+        }
+        let start = tok.span.start() as usize;
+        let end = tok.span.end() as usize;
+        if start >= end || end > self.source.len() {
+            return;
+        }
+        let is_subst_token = matches!(
+            tok.kind,
+            tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
+        );
+        // A quoted/literal token (not a single `$var` / `[cmd]` word) only
+        // counts when the raw source carries a *live* (unescaped) `[`/`$`.
+        if !is_subst_token && !raw_has_live_substitution(&self.source[start..end]) {
+            return;
+        }
+        // Bare `$var` / `${var}` is the canonical idiom — a `Var` word has
+        // no surrounding literal text, so it is exactly that form.
+        if tok.kind == tcl_lexer::TokenType::Var {
+            return;
+        }
+        let is_quoted = self.source.as_bytes().get(start) == Some(&b'"');
+        let found = if text.contains('$') { "'$'" } else { "'['" };
+        let advice = if is_quoted {
+            ". Use braces '{...}' instead of quotes."
+        } else {
+            ". Use braces '{...}' to prevent substitution."
+        };
+        self.result.diagnostics.push(super::types::Diagnostic {
+            code: "W306".to_string(),
+            span: tok.span,
+            message: format!(
+                "Literal expected in {cmd_name} pattern \u{2014} found {found}{advice}"
+            ),
+            severity: Severity::Warning,
+            fixes: Vec::new(),
+        });
     }
 
     /// **IRULE2002.** Warn when a deprecated iRules command is used —
@@ -10680,6 +10798,29 @@ a15 a16 a17 a18 a19 a20\n return $a20 }";
             .diagnostics
             .iter()
             .any(|d| d.code == "W310"));
+    }
+
+    #[test]
+    fn w306_literal_expected_in_regexp_pattern() {
+        fn has_w306(src: &str) -> bool {
+            let mut a = Analyser::new();
+            a.analyse(src, "tcl8.6")
+                .diagnostics
+                .iter()
+                .any(|d| d.code == "W306")
+        }
+        // Quoted `"$var"` / `"[cmd]"` patterns fire (Tcl substitutes them
+        // before the regex engine sees the value).
+        assert!(has_w306("regexp \"$pat\" $s\n"));
+        assert!(has_w306("regexp \"[clock seconds]\" $s\n"));
+        // A bare `$var` is the canonical parameterised-pattern idiom — exempt.
+        assert!(!has_w306("regexp $pat $s\n"));
+        // A braced pattern suppresses substitution — exempt.
+        assert!(!has_w306("regexp {[abc]+} $s\n"));
+        // An escaped `\[` in a quoted pattern is a literal regex char — exempt.
+        assert!(!has_w306("regexp \"\\[abc\\]+\" $s\n"));
+        // A bare `[cmd]` pattern is the foot-gun (parsed as command sub) — fires.
+        assert!(has_w306("regexp [join $parts] $s\n"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -9157,6 +9157,28 @@ mod tests {
     }
 
     #[test]
+    fn emit_cfg_ssa_diagnostics_w211_w220_skipped_for_traced_var() {
+        // A write trace makes `x` observable on every `set`, so neither
+        // W211 (unused) nor W220 (dead store) may fire.  Both the 8.5+
+        // `trace add variable` and 8.4 `trace variable` spellings count.
+        for src in [
+            "proc f {} { trace add variable x write cb; set x 1 }",
+            "proc f {} { trace variable x w cb; set x 1 }",
+        ] {
+            let mut a = Analyser::new();
+            a.emit_cfg_ssa_diagnostics(src);
+            assert!(
+                !a.result
+                    .diagnostics
+                    .iter()
+                    .any(|d| matches!(d.code.as_str(), "W211" | "W220")),
+                "traced var must not fire W211/W220 for {src:?}; got {:?}",
+                a.result.diagnostics,
+            );
+        }
+    }
+
+    #[test]
     fn emit_cfg_ssa_diagnostics_w211_skipped_for_textually_referenced() {
         // ``proc foo {} { set msg hello; puts "got $msg" }`` —
         // ``msg`` is referenced inside a quoted string; the

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -4796,6 +4796,7 @@ file; this call falls through to the 'unknown' handler."
         self.emit_existence_constant_branch_diagnostics(function_unit, ir_proc);
         self.emit_invalid_ip_diagnostics(function_unit);
         self.emit_w233_divide_by_zero(function_unit);
+        self.emit_interval_bounds_diagnostics(function_unit);
         if let Some(ir_proc) = ir_proc {
             self.emit_unused_param_diagnostics(function_unit, ir_proc);
         }
@@ -6136,6 +6137,69 @@ file; this call falls through to the 'unknown' handler."
                 span,
                 message: format!(
                     "{verb} by a provably-zero divisor — raises 'divide by zero' at runtime."
+                ),
+                severity: Severity::Warning,
+                fixes: Vec::new(),
+            });
+        }
+    }
+
+    /// **W230 / W231 / W232 (dynamic).** Interval-driven out-of-range index
+    /// detection for a `$var` index whose [`crate::intervals`] range — guard-
+    /// narrowed at the use site — proves the access is wholly out of range
+    /// against a statically-established container length.  Complements the
+    /// syntactic bounds checks (literal index + literal container only); the
+    /// two never double-fire because the syntactic checks back off on any
+    /// `$var` index.  Restricted to SCCP-reachable blocks so a dynamic index
+    /// in dead code does not warn.  Mirrors
+    /// `_diag_interval_bounds.py::_emit_interval_bounds_diagnostics`.
+    fn emit_interval_bounds_diagnostics(&mut self, fu: &crate::compilation_unit::FunctionUnit) {
+        let executable: HashSet<String> = if fu.sccp.executable_blocks.is_empty() {
+            fu.ssa.blocks.keys().cloned().collect()
+        } else {
+            fu.sccp.executable_blocks.iter().cloned().collect()
+        };
+        let findings = crate::interval_bounds::find_interval_bounds(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.sccp.values,
+            &executable,
+        );
+        for f in findings {
+            if f.span.is_empty() {
+                continue;
+            }
+            let bound = if f.reason == "negative" {
+                "below 0".to_string()
+            } else {
+                format!("past the end ({})", f.length)
+            };
+            let rng = if f.reason == "negative" {
+                "negative".to_string()
+            } else if f.index_interval.lo == f.index_interval.hi {
+                format!("is {}", f.index_interval.lo.map_or(0, |l| l))
+            } else {
+                let lo = f
+                    .index_interval
+                    .lo
+                    .map_or("-inf".to_string(), |l| l.to_string());
+                let hi = f
+                    .index_interval
+                    .hi
+                    .map_or("+inf".to_string(), |h| h.to_string());
+                format!("is in [{lo}, {hi}]")
+            };
+            let outcome = if f.code == "W231" {
+                "raises 'index out of range' at runtime"
+            } else {
+                "silently returns the empty string"
+            };
+            self.result.diagnostics.push(super::types::Diagnostic {
+                code: f.code,
+                span: f.span,
+                message: format!(
+                    "{}: index ${} {rng}, {bound} \u{2014} {outcome}.",
+                    f.command, f.index_var
                 ),
                 severity: Severity::Warning,
                 fixes: Vec::new(),

--- a/rust/tcl-compiler/src/analyser/dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/dispatch.rs
@@ -107,16 +107,23 @@ pub fn signature_for_command(
                 .iter()
                 .map(|(idx, role)| (*idx, *role))
                 .collect();
+            // Per-subcommand options (e.g. `-symbolic` / `-hard` on
+            // `file link`) feed the subcommand arity check's leading-
+            // option skip, mirroring `_subcommand_switch_names` in
+            // `core/commands/registry/runtime.py`.  The option dialect
+            // inherits from the subcommand (falling back to the parent
+            // command) when it does not pin its own.
+            let leading_options = sub
+                .switch_names(Some(dialect), spec.dialects)
+                .into_iter()
+                .map(str::to_string)
+                .collect();
             subs.insert(
                 sub.name.to_string(),
                 CommandSig {
                     arity: sub.arity,
                     arg_roles,
-                    // Subcommand-level arity checking isn't wired up
-                    // yet (only simple-command E002 / E003 fires), so
-                    // the per-subcommand option set is left empty until
-                    // that follow-up lands.
-                    leading_options: BTreeSet::new(),
+                    leading_options,
                 },
             );
         }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1749,6 +1749,20 @@ mod tests {
     }
 
     #[test]
+    fn analyse_skips_w105_for_command_substitution_body() {
+        // A whole-word `[…]` command-substitution body is the safe
+        // list-building idiom — `check_unbraced_body` exempts `Cmd`
+        // tokens, so no W105.
+        let mut a = Analyser::new();
+        let r = a.analyse("eval [list set y $x]\n", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == "W105"),
+            "{:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
     fn analyse_emits_w105_for_unbraced_while_body_var() {
         // ``while {$cond} $body`` — Var-token body is still an
         // unbraced body with substitution.  Mirrors Python's

--- a/rust/tcl-compiler/src/analyser/syntax_checks.rs
+++ b/rust/tcl-compiler/src/analyser/syntax_checks.rs
@@ -112,13 +112,24 @@ fn detect_e201(
         return d;
     }
     if let Some(reg) = registry {
-        if let Some(d) =
-            e201_at_command(content, content_start, bracket_off, reg, &index).and_then(&accept)
-        {
+        let (cmd_diag, swallowed_known_command) =
+            e201_at_command(content, content_start, bracket_off, reg, &index);
+        if let Some(d) = cmd_diag.and_then(&accept) {
             return d;
         }
-    }
-    if let Some(d) = e201_at_brace(content, content_start, bracket_off).and_then(&accept) {
+        // A known command was swallowed into a brace word inside the bracket
+        // (e.g. `proc …` inside `[foo {bar\nproc …}`). The `e201_at_brace`
+        // fallback would insert `]` before the `{`, folding the swallowed
+        // command into a brace-word argument and hiding it from analysis.
+        // Bail to the fix-less fallback instead: with no ghost `]`, the
+        // scan-to-next recovery's partial command stands, the unterminated
+        // `[` is still flagged, and the tail is analysed as real code.
+        if !swallowed_known_command {
+            if let Some(d) = e201_at_brace(content, content_start, bracket_off).and_then(&accept) {
+                return d;
+            }
+        }
+    } else if let Some(d) = e201_at_brace(content, content_start, bracket_off).and_then(&accept) {
         return d;
     }
     // Fallback: highlight just the opening `[`, no fix.
@@ -185,17 +196,26 @@ fn e201_at_comment(content: &str, content_start: u32, bracket_off: u32) -> Optio
 
 /// E201 heuristic: a known-command line follows — insert `]` at the end
 /// of the previous line.  Mirrors `_detect_missing_bracket_at_command`.
+///
+/// Returns `(diagnostic, swallowed_known_command)`. The second field is
+/// `true` when a *known-command* line was found but its `]`-insertion
+/// boundary sits inside an inert span (a brace word / quoted run swallowed
+/// it) and no later non-inert command line was reached — i.e. the bracket's
+/// content captured real commands inside a brace word. `detect_e201` uses
+/// that to suppress the `e201_at_brace` fallback, which would otherwise
+/// insert `]` before the `{` and hide the swallowed command from analysis.
 fn e201_at_command(
     content: &str,
     content_start: u32,
     bracket_off: u32,
     registry: &CommandRegistry,
     index: &tcl_lexer::BracketIndex,
-) -> Option<Diagnostic> {
+) -> (Option<Diagnostic>, bool) {
     let lines: Vec<&str> = content.split('\n').collect();
     if lines.len() < 2 {
-        return None;
+        return (None, false);
     }
+    let mut swallowed_known_command = false;
     for (i, line) in lines.iter().enumerate() {
         if i == 0 {
             continue;
@@ -205,26 +225,35 @@ fn e201_at_command(
             continue;
         }
         let insert_idx = prev_line_content_end(&lines, i);
+        let first_word = extract_first_word(stripped);
+        let is_known = registry.get(first_word).is_some();
         // recovery-rust-port "syntactic validates": if this boundary
         // sits inside an inert span (a brace word / quoted run that
         // swallowed the line, e.g. `puts baz` inside `{bar\nputs baz}`),
         // the candidate `]` would be a literal — keep scanning for the
         // next real command past the inert span rather than giving up.
+        // Remember that a *known* command was swallowed so the caller can
+        // skip the brace-break fallback rather than paper over it.
         if index.is_inert(u32::try_from(insert_idx).unwrap_or(0)) {
+            if is_known {
+                swallowed_known_command = true;
+            }
             continue;
         }
-        let first_word = extract_first_word(stripped);
-        if registry.get(first_word).is_some() {
-            return Some(e201_with_insert(
-                content_start,
-                bracket_off,
-                insert_idx,
-                "Insert missing ']' before command",
-            ));
+        if is_known {
+            return (
+                Some(e201_with_insert(
+                    content_start,
+                    bracket_off,
+                    insert_idx,
+                    "Insert missing ']' before command",
+                )),
+                swallowed_known_command,
+            );
         }
         break;
     }
-    None
+    (None, swallowed_known_command)
 }
 
 /// E201 heuristic: a `{` swallowed the rest — insert `]` before it
@@ -828,23 +857,28 @@ mod tests {
     }
 
     #[test]
-    fn e201_fix_vetoed_inside_brace_word() {
-        // `[foo {bar\nputs baz}` — the `[` is unterminated, but `puts baz`
-        // is *inside* a balanced brace word, not a real command. The
-        // command heuristic would propose inserting `]` after `bar`
-        // (inside the brace); the structural-index veto rejects that
-        // (the `]` would be a literal there), so no wrong fix is offered.
-        //
-        // Intentional divergence from the Python analyser, which emits
-        // the after-`bar` fix — C Tcl 9.0.3 confirms it is wrong
-        // (`info complete {set x [foo {bar]}` == 0, incomplete), whereas
-        // the end-insert is complete. The veto does the correct
-        // full-fidelity thing.
+    fn e201_brace_swallowed_command_falls_back_to_e200() {
+        // `[foo {bar\nputs baz}` — the `[` is unterminated and `puts baz` is
+        // *inside* a balanced brace word, not a real command. The command
+        // heuristic's after-`bar` boundary is inert (the `]` would be a
+        // literal), and the brace-break fallback (insert `]` before the `{`)
+        // would fold the whole brace word — including the swallowed command —
+        // into an argument, hiding it from analysis. So the bracket recovery
+        // bails: no ghost `]` is inserted, the scan-to-next partial command
+        // stands, and the unterminated `[` is flagged with the generic E200
+        // (matching the Python analyser and C Tcl 9.0.3, for which
+        // `info complete {set x [foo {bar]}` == 0 — the after-`bar` insert is
+        // incomplete, so no fix is the honest answer).
         let src = "set x [foo {bar\nputs baz}\n";
-        // E201 still fires — there genuinely is an unterminated `[`.
-        assert_eq!(e201(src).len(), 1, "expected one E201: {:?}", e201(src));
-        // ...but no fix lands inside the brace word `{bar\nputs baz}`
-        // (bytes 11..=24).
+        // The unterminated `[` is still flagged — as E200, not a wrong-fix
+        // E201.
+        assert!(
+            codes(src).contains(&"E200".to_string()),
+            "expected E200 for the unterminated bracket: {:?}",
+            codes(src)
+        );
+        // No E201 fix is offered, and certainly none inside the brace word
+        // `{bar\nputs baz}` (bytes 11..=24).
         for o in e201_fix_offsets(src) {
             assert!(
                 !(11..25).contains(&o),

--- a/rust/tcl-compiler/src/interval_bounds.rs
+++ b/rust/tcl-compiler/src/interval_bounds.rs
@@ -1,0 +1,717 @@
+//! Interval-driven dynamic bounds checking (Phase 3).
+//!
+//! The syntactic bounds checks (`analyser::bounds_checks`) only fire when *both*
+//! the container and the index are literals.  This module covers the **dynamic**
+//! cases they skip: an index that is a plain `$var` whose [`crate::intervals`]
+//! range — guard-narrowed at the use site — *proves* the access is out of range,
+//! against a container length we can establish statically (a literal list /
+//! `[list …]` element count, propagated per SSA version).
+//!
+//! It is a *consumer* of the parallel interval analysis: it never perturbs SCCP
+//! or any existing diagnostic, and it only emits on the dynamic shapes the
+//! syntactic check leaves silent, so the two never double-fire.
+//!
+//! Soundness rule: an [`Interval`] over-approximates the runtime value, so a
+//! finding is reported **only** when the *whole* interval lies outside the valid
+//! range — never on "might be out of range".  Port of the bounds-finding portion
+//! of `compiler/interval_bounds.py::find_interval_bounds`.
+
+use std::collections::HashMap;
+
+use tcl_lexer::Span;
+use tcl_syntax::expr::ast::ExprNode;
+
+use crate::analyses::LatticeValue;
+use crate::cfg::{Function as CfgFunction, Terminator};
+use crate::intervals::{build_guard_index, compute_intervals, refine_interval, Interval};
+use crate::ir::Statement;
+use crate::segmenter::segment_commands;
+use crate::ssa::{Phi, SsaFunction, ValueKey, Version};
+
+/// `(name, version) → Phi` index over every block, for length resolution
+/// through loop-header phis.
+type PhiIndex<'a> = HashMap<ValueKey, &'a Phi>;
+
+/// Resolve the list length of `(name, version)`, following phis when the
+/// version itself was not seeded by a literal-list assignment.
+///
+/// Rust's SSA inserts a loop-header phi for a list `l` that `lset` mutates
+/// (`l_h = phi(l_entry, l_body)`); the body's `lset` then reads `l_h`, which is
+/// not in the length map.  Python's pruned SSA never inserts that phi (its
+/// `lset` does not *read* `l`, so `l` is not live across the back-edge), leaving
+/// `l` at its literal-assignment version.  To match Python's *result*, resolve a
+/// phi to the length its known incomings agree on, ignoring an unknown back-edge
+/// incoming (the `lset` result — `lset` preserves length under the
+/// assume-no-error model the diagnostic already encodes).  A genuine
+/// disagreement (two known but different lengths) yields `None` (sound).
+fn resolve_list_length(
+    name: &str,
+    version: Version,
+    phi_index: &PhiIndex<'_>,
+    lengths: &HashMap<ValueKey, i64>,
+    visited: &mut std::collections::HashSet<ValueKey>,
+) -> Option<i64> {
+    let key = (name.to_owned(), version);
+    if let Some(&l) = lengths.get(&key) {
+        return Some(l);
+    }
+    if !visited.insert(key.clone()) {
+        return None; // cycle (loop back-edge) — give up this path
+    }
+    let phi = phi_index.get(&key)?;
+    let mut found: Option<i64> = None;
+    for &inc in phi.incoming.values() {
+        if inc == 0 {
+            continue;
+        }
+        if let Some(l) = resolve_list_length(name, inc, phi_index, lengths, visited) {
+            match found {
+                None => found = Some(l),
+                Some(f) if f == l => {}
+                Some(_) => return None, // disagreement → unknown
+            }
+        }
+    }
+    found
+}
+
+const LINDEX: &str = "lindex";
+const LSET: &str = "lset";
+const STRING_INDEX: &str = "string index";
+
+/// A proven out-of-range dynamic index access.
+#[derive(Debug, Clone)]
+pub struct BoundsFinding {
+    /// Source span to anchor the diagnostic on.
+    pub span: Span,
+    /// `"W230"` (lindex) / `"W231"` (lset) / `"W232"` (string index).
+    pub code: String,
+    /// `"lindex"` / `"lset"` / `"string index"` (display).
+    pub command: String,
+    /// The `$var` index name (display only).
+    pub index_var: String,
+    /// The proven index interval.
+    pub index_interval: Interval,
+    /// The container length proven OOR against.
+    pub length: i64,
+    /// `"negative"` | `"past_end"` | `"past_append"`.
+    pub reason: String,
+}
+
+/// One index access: `(command, list_arg, index_arg, is_lset)`.
+#[derive(Debug, Clone)]
+struct Candidate {
+    command: &'static str,
+    list_arg: String,
+    index_arg: String,
+    is_lset: bool,
+}
+
+/// The scalar variable name if `arg` is exactly `$name` / `${name}`.  Returns
+/// `None` for `end`, `end-1`, `$arr(i)`, `[expr …]`, composites.  Mirrors
+/// `_plain_var_name`.
+fn plain_var_name(arg: &str) -> Option<String> {
+    let s = arg.trim();
+    let mut s = s.strip_prefix('$')?;
+    if let Some(inner) = s.strip_prefix('{').and_then(|r| r.strip_suffix('}')) {
+        s = inner;
+    }
+    if s.is_empty() {
+        return None;
+    }
+    if s.bytes()
+        .any(|b| matches!(b, b'(' | b'[' | b'$' | b' ' | b'\t' | b')' | b']'))
+    {
+        return None;
+    }
+    Some(s.to_owned())
+}
+
+/// Element count of a static Tcl list literal, or `None` if not literal.
+/// Mirrors `_literal_list_length`.
+fn literal_list_length(text: &str) -> Option<i64> {
+    if text.contains('$') || text.contains('[') {
+        return None;
+    }
+    i64::try_from(crate::tcl_expr_eval::split_tcl_list(text).len()).ok()
+}
+
+/// If a value word is exactly `[list a b c]` with no substitution / expansion,
+/// its element count, else `None`.  Replaces Python's intent-driven `[list …]`
+/// detection in `_list_length_map`.
+fn list_command_length(value: &str) -> Option<i64> {
+    let inner = value.trim().strip_prefix('[')?.strip_suffix(']')?;
+    let cmds = segment_commands(inner);
+    let cmd = cmds.first()?;
+    if cmds.len() != 1 || cmd.name() != "list" {
+        return None;
+    }
+    let args = cmd.args();
+    if args
+        .iter()
+        .any(|a| a.contains('$') || a.contains('[') || a.starts_with("{*}"))
+    {
+        return None;
+    }
+    i64::try_from(args.len()).ok()
+}
+
+/// Length of list-valued SSA versions established from literal-list assignments.
+/// Mirrors `_list_length_map`.
+fn list_length_map(ssa: &SsaFunction) -> HashMap<ValueKey, i64> {
+    let mut lengths = HashMap::new();
+    for sb in ssa.blocks.values() {
+        for s in &sb.statements {
+            let n = match &s.statement {
+                Statement::AssignConst { value, .. } => literal_list_length(value),
+                Statement::AssignValue { value, .. } => list_command_length(value),
+                _ => None,
+            };
+            if let Some(n) = n {
+                for (name, &ver) in &s.defs {
+                    lengths.insert((name.clone(), ver), n);
+                }
+            }
+        }
+    }
+    lengths
+}
+
+/// Character length of string-valued SSA versions from literal assignments.
+/// Mirrors `_string_length_map`.
+fn string_length_map(ssa: &SsaFunction) -> HashMap<ValueKey, i64> {
+    let mut lengths = HashMap::new();
+    for sb in ssa.blocks.values() {
+        for s in &sb.statements {
+            let (value, needs_backsubst) = match &s.statement {
+                Statement::AssignConst { value, .. } => (value, false),
+                Statement::AssignValue {
+                    value,
+                    value_needs_backsubst,
+                    ..
+                } => (value, *value_needs_backsubst),
+                _ => continue,
+            };
+            if value.contains('$') || value.contains('[') {
+                continue;
+            }
+            let resolved = if needs_backsubst && value.contains('\\') {
+                tcl_lexer::backslash_subst(value).into_owned()
+            } else {
+                value.clone()
+            };
+            if let Ok(len) = i64::try_from(resolved.chars().count()) {
+                for (name, &ver) in &s.defs {
+                    lengths.insert((name.clone(), ver), len);
+                }
+            }
+        }
+    }
+    lengths
+}
+
+/// Versions of each name reaching statement index `upto` within a block.  Used
+/// for `lset`, whose target list is a *def* (not a use).  Mirrors
+/// `_reaching_versions`.
+fn reaching_versions(
+    entry: &HashMap<String, Version>,
+    stmts: &[crate::ssa::SsaStatement],
+    upto: usize,
+) -> HashMap<String, Version> {
+    let mut cur = entry.clone();
+    for s in stmts.iter().take(upto) {
+        for (name, &ver) in &s.defs {
+            cur.insert(name.clone(), ver);
+        }
+    }
+    cur
+}
+
+/// Reason string if `index` is *wholly* out of range for `length`, else `None`.
+/// `lset` permits the append slot (`index == length`); `lindex` does not.
+/// Mirrors `_classify`.
+fn classify(index: Interval, length: i64, is_lset: bool) -> Option<&'static str> {
+    // Provably negative: the whole interval is below 0.
+    if let Some(hi) = index.hi {
+        if hi < 0 {
+            return Some("negative");
+        }
+    }
+    // Provably past the end.
+    if let Some(lo) = index.lo {
+        if is_lset {
+            if lo > length {
+                return Some("past_append");
+            }
+        } else if lo >= length {
+            return Some("past_end");
+        }
+    }
+    None
+}
+
+/// If `text` is exactly `[lindex …]` / `[string index …]`, its candidate; else
+/// `None`.  `lset` is excluded (its first arg is a var *name*).  Mirrors
+/// `_parse_index_sub`.
+fn parse_index_sub(text: &str) -> Option<Candidate> {
+    let s = text.trim();
+    let inner = s.strip_prefix('[')?.strip_suffix(']')?;
+    let cmds = segment_commands(inner);
+    let cmd = cmds.first()?;
+    let args = cmd.args();
+    match cmd.name() {
+        "lindex" if args.len() == 2 => Some(Candidate {
+            command: LINDEX,
+            list_arg: args[0].clone(),
+            index_arg: args[1].clone(),
+            is_lset: false,
+        }),
+        "string" if args.len() == 3 && args[0] == "index" => Some(Candidate {
+            command: STRING_INDEX,
+            list_arg: args[1].clone(),
+            index_arg: args[2].clone(),
+            is_lset: false,
+        }),
+        _ => None,
+    }
+}
+
+/// Index accesses embedded as `[…]` command substitutions inside an expression,
+/// restricted to *guaranteed-to-evaluate* positions (short-circuit operands and
+/// non-selected ternary arms are skipped).  Mirrors `_index_subs_in_expr` over
+/// `_walk_eager`.
+fn index_subs_in_expr(expr: &ExprNode) -> Vec<Candidate> {
+    let mut out = Vec::new();
+    walk_eager(expr, &mut |e| {
+        if let ExprNode::Command { text, .. } = e {
+            if let Some(c) = parse_index_sub(text) {
+                out.push(c);
+            }
+        }
+    });
+    out
+}
+
+/// Constant truthiness of a literal expression node (`Some(true/false)`), else
+/// `None`.  Mirrors `_const_bool` for the eager walk's guard resolution.
+fn const_bool(expr: &ExprNode) -> Option<bool> {
+    let ExprNode::Literal { text, .. } = expr else {
+        return None;
+    };
+    let t = text.trim();
+    if let Ok(n) = t.parse::<i64>() {
+        return Some(n != 0);
+    }
+    if let Ok(f) = t.parse::<f64>() {
+        return Some(f != 0.0);
+    }
+    match t.to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" => Some(true),
+        "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Visit `expr` and every **guaranteed-to-evaluate** sub-expression.  The
+/// short-circuit operand of `&&`/`||`/`and`/`or` and the non-selected ternary
+/// arm run only when forced by a *constant* guard.  Mirrors `_walk_eager`.
+fn walk_eager(expr: &ExprNode, visit: &mut impl FnMut(&ExprNode)) {
+    use tcl_syntax::expr::ast::BinOp;
+    visit(expr);
+    match expr {
+        ExprNode::Binary { op, left, right } => {
+            walk_eager(left, visit);
+            let lazy = matches!(op, BinOp::And | BinOp::Or | BinOp::WordAnd | BinOp::WordOr);
+            if !lazy {
+                walk_eager(right, visit);
+                return;
+            }
+            let Some(guard) = const_bool(left) else {
+                return; // maybe-dead RHS — leave it skipped
+            };
+            let is_and = matches!(op, BinOp::And | BinOp::WordAnd);
+            let forced = if is_and { guard } else { !guard };
+            if forced {
+                walk_eager(right, visit);
+            }
+        }
+        ExprNode::Unary { operand, .. } => walk_eager(operand, visit),
+        ExprNode::Ternary {
+            condition,
+            true_branch,
+            false_branch,
+        } => {
+            walk_eager(condition, visit);
+            match const_bool(condition) {
+                Some(true) => walk_eager(true_branch, visit),
+                Some(false) => walk_eager(false_branch, visit),
+                None => {}
+            }
+        }
+        ExprNode::Call { args, .. } => {
+            for a in args {
+                walk_eager(a, visit);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// All index accesses a statement performs.  Mirrors `_statement_candidates`.
+fn statement_candidates(stmt: &Statement) -> Vec<Candidate> {
+    let mut out = Vec::new();
+    match stmt {
+        Statement::Call { command, args, .. } => {
+            if command == LINDEX && args.len() == 2 {
+                out.push(Candidate {
+                    command: LINDEX,
+                    list_arg: args[0].clone(),
+                    index_arg: args[1].clone(),
+                    is_lset: false,
+                });
+            } else if command == LSET && args.len() == 3 {
+                out.push(Candidate {
+                    command: LSET,
+                    list_arg: args[0].clone(),
+                    index_arg: args[1].clone(),
+                    is_lset: true,
+                });
+            }
+            for a in args {
+                if let Some(c) = parse_index_sub(a) {
+                    out.push(c);
+                }
+            }
+        }
+        Statement::AssignValue { value, .. } => {
+            if let Some(c) = parse_index_sub(value) {
+                out.push(c);
+            }
+        }
+        Statement::Barrier { args, .. } => {
+            for a in args {
+                if let Some(c) = parse_index_sub(a) {
+                    out.push(c);
+                }
+            }
+        }
+        Statement::AssignExpr { expr, .. } | Statement::ExprEval { expr, .. } => {
+            out.extend(index_subs_in_expr(expr));
+        }
+        _ => {}
+    }
+    if let Statement::Return {
+        expr: Some(expr), ..
+    } = stmt
+    {
+        out.extend(index_subs_in_expr(expr));
+    }
+    out
+}
+
+/// Cheap pre-scan: any index access with a plain `$var` index?  Mirrors
+/// `_has_candidate`.
+fn has_candidate(cfg: &CfgFunction, ssa: &SsaFunction) -> bool {
+    for sb in ssa.blocks.values() {
+        for s in &sb.statements {
+            for c in statement_candidates(&s.statement) {
+                if plain_var_name(&c.index_arg).is_some() {
+                    return true;
+                }
+            }
+        }
+    }
+    for block in cfg.blocks.values() {
+        let mut cands: Vec<Candidate> = Vec::new();
+        match &block.terminator {
+            Some(Terminator::Return { value, expr, .. }) => {
+                if let Some(v) = value {
+                    if let Some(c) = parse_index_sub(v) {
+                        cands.push(c);
+                    }
+                }
+                if let Some(e) = expr {
+                    cands.extend(index_subs_in_expr(e));
+                }
+            }
+            Some(Terminator::Branch { condition, .. }) => {
+                cands.extend(index_subs_in_expr(condition));
+            }
+            _ => {}
+        }
+        if cands.iter().any(|c| plain_var_name(&c.index_arg).is_some()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Dynamic out-of-range findings for this function (empty if none).  Mirrors
+/// `find_interval_bounds`; `executable` restricts to SCCP-reachable blocks.
+#[must_use]
+#[allow(clippy::too_many_lines, clippy::similar_names, clippy::implicit_hasher)]
+pub fn find_interval_bounds(
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    values: &HashMap<ValueKey, LatticeValue>,
+    executable: &std::collections::HashSet<String>,
+) -> Vec<BoundsFinding> {
+    if !has_candidate(cfg, ssa) {
+        return Vec::new();
+    }
+    let intervals = compute_intervals(cfg, ssa, values);
+    let guard_index = build_guard_index(cfg, ssa);
+    let lengths = list_length_map(ssa);
+    let str_lengths = string_length_map(ssa);
+    let phi_index: PhiIndex = ssa
+        .blocks
+        .values()
+        .flat_map(|sb| sb.phis.iter())
+        .map(|p| ((p.name.clone(), p.version), p))
+        .collect();
+    let mut findings = Vec::new();
+
+    let length_for_list = |cand: &Candidate,
+                           version_map: &HashMap<String, Version>,
+                           entry_versions: &HashMap<String, Version>,
+                           block_stmts: &[crate::ssa::SsaStatement],
+                           stmt_idx: usize|
+     -> Option<i64> {
+        let mut visited = std::collections::HashSet::new();
+        if cand.is_lset {
+            // `lset`'s first arg is a variable *name*, recorded as a def —
+            // use the version reaching this statement.
+            let lname = cand.list_arg.trim();
+            if lname.contains('$') || lname.contains('[') {
+                return None;
+            }
+            let reaching = reaching_versions(entry_versions, block_stmts, stmt_idx);
+            let lver = *reaching.get(lname)?;
+            return resolve_list_length(lname, lver, &phi_index, &lengths, &mut visited);
+        }
+        // A *value* arg: literal list, or `$l`.
+        if let Some(lit) = literal_list_length(&cand.list_arg) {
+            return Some(lit);
+        }
+        let lvar = plain_var_name(&cand.list_arg)?;
+        let lver = *version_map.get(&lvar)?;
+        resolve_list_length(&lvar, lver, &phi_index, &lengths, &mut visited)
+    };
+
+    let process = |cand: &Candidate,
+                   bn: &str,
+                   span: Span,
+                   version_map: &HashMap<String, Version>,
+                   entry_versions: &HashMap<String, Version>,
+                   block_stmts: &[crate::ssa::SsaStatement],
+                   stmt_idx: usize,
+                   findings: &mut Vec<BoundsFinding>| {
+        let Some(ivar) = plain_var_name(&cand.index_arg) else {
+            return;
+        };
+        let Some(&iver) = version_map.get(&ivar) else {
+            return;
+        };
+        if iver == 0 {
+            return;
+        }
+        let length = if cand.command == STRING_INDEX {
+            let svar = plain_var_name(&cand.list_arg);
+            svar.and_then(|sv| {
+                version_map
+                    .get(&sv)
+                    .and_then(|&v| str_lengths.get(&(sv.clone(), v)).copied())
+            })
+        } else {
+            length_for_list(cand, version_map, entry_versions, block_stmts, stmt_idx)
+        };
+        let Some(length) = length else {
+            return;
+        };
+        let iv = refine_interval(&intervals, cfg, ssa, bn, &ivar, iver, &guard_index);
+        if iv.is_top() || iv.is_bottom() {
+            return;
+        }
+        let Some(reason) = classify(iv, length, cand.is_lset) else {
+            return;
+        };
+        let code = if cand.is_lset {
+            "W231"
+        } else if cand.command == STRING_INDEX {
+            "W232"
+        } else {
+            "W230"
+        };
+        findings.push(BoundsFinding {
+            span,
+            code: code.to_owned(),
+            command: cand.command.to_owned(),
+            index_var: ivar,
+            index_interval: iv,
+            length,
+            reason: reason.to_owned(),
+        });
+    };
+
+    for (bn, sb) in &ssa.blocks {
+        if !executable.contains(bn) {
+            continue;
+        }
+        for (idx, s) in sb.statements.iter().enumerate() {
+            let span = statement_span(&s.statement);
+            for cand in statement_candidates(&s.statement) {
+                if let Some(span) = span {
+                    process(
+                        &cand,
+                        bn,
+                        span,
+                        &s.uses,
+                        &sb.entry_versions,
+                        &sb.statements,
+                        idx,
+                        &mut findings,
+                    );
+                }
+            }
+        }
+        // Index accesses in a `return [...]` value / branch condition: the read
+        // versions are the block's exit versions; anchor on the terminator.
+        let Some(block) = cfg.blocks.get(bn) else {
+            continue;
+        };
+        match &block.terminator {
+            Some(Terminator::Return {
+                value, expr, span, ..
+            }) => {
+                let Some(span) = span else { continue };
+                if let Some(v) = value {
+                    if let Some(cand) = parse_index_sub(v) {
+                        process(
+                            &cand,
+                            bn,
+                            *span,
+                            &sb.exit_versions,
+                            &sb.exit_versions,
+                            &sb.statements,
+                            sb.statements.len(),
+                            &mut findings,
+                        );
+                    }
+                }
+                if let Some(e) = expr {
+                    for cand in index_subs_in_expr(e) {
+                        process(
+                            &cand,
+                            bn,
+                            *span,
+                            &sb.exit_versions,
+                            &sb.exit_versions,
+                            &sb.statements,
+                            sb.statements.len(),
+                            &mut findings,
+                        );
+                    }
+                }
+            }
+            Some(Terminator::Branch {
+                condition, span, ..
+            }) => {
+                let Some(span) = span else { continue };
+                for cand in index_subs_in_expr(condition) {
+                    process(
+                        &cand,
+                        bn,
+                        *span,
+                        &sb.exit_versions,
+                        &sb.exit_versions,
+                        &sb.statements,
+                        sb.statements.len(),
+                        &mut findings,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    findings
+}
+
+/// The source span of an IR statement, for anchoring a finding.  Only the flat
+/// statement shapes that appear in CFG-lowered SSA blocks carry an index access;
+/// structured statements (`If`/`For`/…) are gone by this point, so they need no
+/// span here.
+fn statement_span(stmt: &Statement) -> Option<Span> {
+    match stmt {
+        Statement::AssignConst { span, .. }
+        | Statement::AssignExpr { span, .. }
+        | Statement::AssignValue { span, .. }
+        | Statement::Incr { span, .. }
+        | Statement::ExprEval { span, .. }
+        | Statement::Call { span, .. }
+        | Statement::Return { span, .. }
+        | Statement::Barrier { span, .. } => Some(*span),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analyser::Analyser;
+
+    fn bounds(src: &str) -> Vec<(String, String)> {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl8.6")
+            .diagnostics
+            .iter()
+            .filter(|d| matches!(d.code.as_str(), "W230" | "W231" | "W232"))
+            .map(|d| (d.code.clone(), d.message.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn lset_loop_counter_past_append_fires_w231() {
+        // `$j ∈ [4, 8]` against a length-3 list — the interval domain proves
+        // every iteration is past the append slot.  The list length is
+        // recovered through the loop-header phi `lset` induces.
+        let v = bounds("proc f {v} {\n    set l {a b c}\n    for {set j 4} {$j < 9} {incr j} { lset l $j $v }\n}\n");
+        assert_eq!(v.len(), 1, "{v:?}");
+        assert_eq!(v[0].0, "W231");
+        assert!(v[0].1.contains("$j"), "{v:?}");
+    }
+
+    #[test]
+    fn string_index_const_var_past_end_fires_w232() {
+        // `$i` is the SCCP constant 10 against a 5-char string — past end.
+        assert_eq!(
+            bounds("proc f {} {\n    set s \"hello\"\n    set i 10\n    return [string index $s $i]\n}\n")
+                .iter()
+                .map(|(c, _)| c.clone())
+                .collect::<Vec<_>>(),
+            vec!["W232"]
+        );
+        // `$i == length` is also out of range for `string index`.
+        assert_eq!(
+            bounds("proc f {} { set s \"hello\"\n set i 5\n return [string index $s $i] }").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn dynamic_bounds_silent_when_not_provable() {
+        // In-range index — no diagnostic.
+        assert!(
+            bounds("proc f {} { set s \"hello\"\n set i 2\n return [string index $s $i] }")
+                .is_empty()
+        );
+        // Unknown string + unknown index (both params) — not provable.
+        assert!(bounds("proc f {s i} { return [string index $s $i] }").is_empty());
+        // The legal append slot (`index == length`) for `lset` is silent.
+        assert!(bounds("proc f {v} { set l {a b c}\n set j 3\n lset l $j $v }").is_empty());
+        // A second `lset` reads a non-phi mutated version — length not
+        // recovered (matches Python's pruned SSA), so no false positive.
+        assert!(
+            bounds("proc f {v w} { set l {a b c}\n lset l 0 $v\n set j 99\n lset l $j $w }")
+                .is_empty()
+        );
+    }
+}

--- a/rust/tcl-compiler/src/intervals.rs
+++ b/rust/tcl-compiler/src/intervals.rs
@@ -1,0 +1,684 @@
+//! Integer interval abstract domain over SSA values (Phase 3).
+//!
+//! A *parallel, non-perturbing* numeric analysis: it runs **after** SCCP and
+//! reads its constant lattice, but does not feed back into the SCCP lattice or
+//! any existing consumer.  Downstream checks (the dynamic index-bounds pass in
+//! [`crate::analyser`]) consult it for the *dynamic* (`$var`) cases the purely
+//! syntactic bounds checks skip.
+//!
+//! Each SSA value `(name, version)` maps to an [`Interval`] `[lo, hi]` over the
+//! integers, with `None` meaning unbounded (-inf / +inf).  Values that are not
+//! provably integral, or whose range we cannot bound, are `TOP` — always sound.
+//! Loop-header phis are **widened** so the fixpoint terminates.  Tightening back
+//! is query-driven via [`refine_interval`], which intersects a value's interval
+//! with the dominating constant-bound guards at a specific use site.  If the
+//! bounded fixpoint does not converge within the iteration cap, the whole result
+//! degrades to `TOP` rather than risk returning a still-ascending (unsound,
+//! too-narrow) interval.
+//!
+//! Port of `compiler/intervals.py`.  Soundness (never claim a tighter range than
+//! reality) matters far more than precision, because the only consumers turn a
+//! *proven* fact (index in range) into a diagnostic decision.
+
+use std::collections::{HashMap, HashSet};
+
+use tcl_syntax::expr::ast::{BinOp, ExprNode, UnaryOp};
+
+use crate::analyses::{ConstValue, LatticeValue};
+use crate::cfg::{Function as CfgFunction, Terminator};
+use crate::ssa::{SsaFunction, ValueKey, Version};
+
+/// A bound is an `i64`, or `None` for an infinity (sign given by position).
+pub type Bound = Option<i64>;
+
+/// A closed integer interval `[lo, hi]`; `None` bound = ±infinity.
+///
+/// `lo is None` → -inf, `hi is None` → +inf.  The empty/unreached value is
+/// `BOTTOM` (lo > hi sentinel, detected via [`Interval::is_bottom`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Interval {
+    /// Lower bound (`None` = -inf).
+    pub lo: Bound,
+    /// Upper bound (`None` = +inf).
+    pub hi: Bound,
+}
+
+/// The unbounded interval `[-inf, +inf]`.
+pub const TOP: Interval = Interval { lo: None, hi: None };
+/// The canonical empty interval (`lo > hi`).
+pub const BOTTOM: Interval = Interval {
+    lo: Some(1),
+    hi: Some(0),
+};
+
+/// The single-point interval `[n, n]`.
+#[must_use]
+pub fn constant(n: i64) -> Interval {
+    Interval {
+        lo: Some(n),
+        hi: Some(n),
+    }
+}
+
+impl Interval {
+    /// True when both bounds are infinite.
+    #[must_use]
+    pub fn is_top(self) -> bool {
+        self.lo.is_none() && self.hi.is_none()
+    }
+
+    /// True when the interval is the empty `lo > hi` sentinel.
+    #[must_use]
+    pub fn is_bottom(self) -> bool {
+        matches!((self.lo, self.hi), (Some(l), Some(h)) if l > h)
+    }
+}
+
+/// Least upper bound: the smallest interval containing both.
+#[must_use]
+fn join(a: Interval, b: Interval) -> Interval {
+    if a.is_bottom() {
+        return b;
+    }
+    if b.is_bottom() {
+        return a;
+    }
+    // lo = min(lo) treating None as -inf; hi = max(hi) treating None as +inf.
+    let lo = match (a.lo, b.lo) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        _ => None,
+    };
+    let hi = match (a.hi, b.hi) {
+        (Some(x), Some(y)) => Some(x.max(y)),
+        _ => None,
+    };
+    Interval { lo, hi }
+}
+
+/// Standard interval widening: any bound that moved outward jumps to ±inf.
+/// Guarantees termination of the loop fixpoint.
+#[must_use]
+fn widen(old: Interval, new: Interval) -> Interval {
+    if old.is_bottom() {
+        return new;
+    }
+    if new.is_bottom() {
+        return old;
+    }
+    let lo = match (old.lo, new.lo) {
+        (Some(o), Some(n)) if n >= o => Some(o),
+        _ => None,
+    };
+    let hi = match (old.hi, new.hi) {
+        (Some(o), Some(n)) if n <= o => Some(o),
+        _ => None,
+    };
+    Interval { lo, hi }
+}
+
+#[must_use]
+fn add(a: Interval, b: Interval) -> Interval {
+    if a.is_bottom() || b.is_bottom() {
+        return BOTTOM;
+    }
+    let lo = match (a.lo, b.lo) {
+        (Some(x), Some(y)) => x.checked_add(y),
+        _ => None,
+    };
+    let hi = match (a.hi, b.hi) {
+        (Some(x), Some(y)) => x.checked_add(y),
+        _ => None,
+    };
+    Interval { lo, hi }
+}
+
+#[must_use]
+fn sub(a: Interval, b: Interval) -> Interval {
+    if a.is_bottom() || b.is_bottom() {
+        return BOTTOM;
+    }
+    // a - b = [a.lo - b.hi, a.hi - b.lo]
+    let lo = match (a.lo, b.hi) {
+        (Some(x), Some(y)) => x.checked_sub(y),
+        _ => None,
+    };
+    let hi = match (a.hi, b.lo) {
+        (Some(x), Some(y)) => x.checked_sub(y),
+        _ => None,
+    };
+    Interval { lo, hi }
+}
+
+#[must_use]
+fn mul(a: Interval, b: Interval) -> Interval {
+    if a.is_bottom() || b.is_bottom() {
+        return BOTTOM;
+    }
+    // Only attempt when fully bounded; otherwise TOP (sound).
+    let (Some(alo), Some(ahi), Some(blo), Some(bhi)) = (a.lo, a.hi, b.lo, b.hi) else {
+        return TOP;
+    };
+    let corners = [
+        alo.checked_mul(blo),
+        alo.checked_mul(bhi),
+        ahi.checked_mul(blo),
+        ahi.checked_mul(bhi),
+    ];
+    // Any overflow → fall back to TOP (sound).
+    if corners.iter().any(Option::is_none) {
+        return TOP;
+    }
+    let vals: Vec<i64> = corners.into_iter().flatten().collect();
+    Interval {
+        lo: vals.iter().copied().min(),
+        hi: vals.iter().copied().max(),
+    }
+}
+
+#[must_use]
+fn negate(a: Interval) -> Interval {
+    if a.is_bottom() {
+        return BOTTOM;
+    }
+    Interval {
+        lo: a.hi.map(|h| -h),
+        hi: a.lo.map(|l| -l),
+    }
+}
+
+/// Greatest lower bound: the largest interval contained in both.  Here `None`
+/// is the *identity* (-inf for a lower bound, +inf for an upper), the opposite
+/// of [`join`] where it is absorbing.
+#[must_use]
+fn intersect(a: Interval, b: Interval) -> Interval {
+    if a.is_bottom() || b.is_bottom() {
+        return BOTTOM;
+    }
+    let lo = match (a.lo, b.lo) {
+        (None, x) | (x, None) => x,
+        (Some(x), Some(y)) => Some(x.max(y)),
+    };
+    let hi = match (a.hi, b.hi) {
+        (None, x) | (x, None) => x,
+        (Some(x), Some(y)) => Some(x.min(y)),
+    };
+    Interval { lo, hi }
+}
+
+/// The integer value of an `ExprNode::Literal` (incl. bool keyword), else
+/// `None`.  Mirrors `_literal_int`.
+#[must_use]
+fn literal_int(node: &ExprNode) -> Option<i64> {
+    let ExprNode::Literal { text, .. } = node else {
+        return None;
+    };
+    let t = text.trim();
+    match t {
+        "true" | "yes" | "on" => return Some(1),
+        "false" | "no" | "off" => return Some(0),
+        _ => {}
+    }
+    parse_radix_int(t)
+}
+
+/// Parse a literal int the way Python's `int(t, 0) if t[:2] in {0x,0o,0b} else
+/// int(t)` does: a `0x`/`0o`/`0b` prefix selects the radix (positive only,
+/// matching the `t[:2]` prefix test), otherwise plain decimal (signed).
+#[must_use]
+fn parse_radix_int(t: &str) -> Option<i64> {
+    let prefix = t.get(..2).map(str::to_ascii_lowercase);
+    match prefix.as_deref() {
+        Some("0x") => i64::from_str_radix(&t[2..], 16).ok(),
+        Some("0o") => i64::from_str_radix(&t[2..], 8).ok(),
+        Some("0b") => i64::from_str_radix(&t[2..], 2).ok(),
+        _ => t.parse::<i64>().ok(),
+    }
+}
+
+/// Parse a literal IR value word as an int, if it is exactly one.  Mirrors
+/// `_const_int_from_value` (plain `int(s)`, no radix prefixes).
+#[must_use]
+fn const_int_from_value(text: &str) -> Option<i64> {
+    text.trim().parse::<i64>().ok()
+}
+
+/// Abstract-evaluate `expr` over the current interval environment.  Mirrors
+/// `_eval_expr`.
+#[must_use]
+fn eval_expr(expr: &ExprNode, env: &HashMap<String, Interval>) -> Interval {
+    match expr {
+        ExprNode::Literal { .. } => literal_int(expr).map_or(TOP, constant),
+        ExprNode::Var { name, .. } => env.get(name).copied().unwrap_or(TOP),
+        ExprNode::Unary { op, operand } => {
+            let inner = eval_expr(operand, env);
+            match op {
+                UnaryOp::Neg => negate(inner),
+                UnaryOp::Pos => inner,
+                _ => TOP,
+            }
+        }
+        ExprNode::Binary { op, left, right } => {
+            let la = eval_expr(left, env);
+            let ra = eval_expr(right, env);
+            match op {
+                BinOp::Add => add(la, ra),
+                BinOp::Sub => sub(la, ra),
+                BinOp::Mul => mul(la, ra),
+                // Comparisons / logicals yield a boolean 0/1.
+                BinOp::Eq
+                | BinOp::Ne
+                | BinOp::Lt
+                | BinOp::Le
+                | BinOp::Gt
+                | BinOp::Ge
+                | BinOp::And
+                | BinOp::Or => Interval {
+                    lo: Some(0),
+                    hi: Some(1),
+                },
+                _ => TOP,
+            }
+        }
+        _ => TOP,
+    }
+}
+
+/// The interval a value satisfies given `value <op> k` is true (or false, when
+/// `negate`).  Returns the half-line constraint, or `None` if `op` is not an
+/// order/equality comparison.  Mirrors `_guard_interval`.
+#[must_use]
+fn guard_interval(op: BinOp, k: i64, negate: bool) -> Option<Interval> {
+    let op = if negate {
+        match op {
+            BinOp::Lt => BinOp::Ge,
+            BinOp::Le => BinOp::Gt,
+            BinOp::Gt => BinOp::Le,
+            BinOp::Ge => BinOp::Lt,
+            BinOp::Eq => BinOp::Ne,
+            BinOp::Ne => BinOp::Eq,
+            other => other,
+        }
+    } else {
+        op
+    };
+    match op {
+        BinOp::Lt => Some(Interval {
+            lo: None,
+            hi: Some(k - 1),
+        }),
+        BinOp::Le => Some(Interval {
+            lo: None,
+            hi: Some(k),
+        }),
+        BinOp::Gt => Some(Interval {
+            lo: Some(k + 1),
+            hi: None,
+        }),
+        BinOp::Ge => Some(Interval {
+            lo: Some(k),
+            hi: None,
+        }),
+        BinOp::Eq => Some(constant(k)),
+        // NE and non-comparisons give no single interval.
+        _ => None,
+    }
+}
+
+/// If `cond` is `$name <cmp> <int-const>` (or the const on the left), return the
+/// interval `name` satisfies when `cond` is true (`negate` for the false edge).
+/// Only a top-level comparison against a literal int is handled.  Mirrors
+/// `_guard_constraint`.
+#[must_use]
+fn guard_constraint(cond: &ExprNode, name: &str, negate: bool) -> Option<Interval> {
+    let ExprNode::Binary { op, left, right } = cond else {
+        return None;
+    };
+    // $name <op> K
+    if let ExprNode::Var { name: vn, .. } = left.as_ref() {
+        if vn == name {
+            if let Some(k) = literal_int(right) {
+                return guard_interval(*op, k, negate);
+            }
+        }
+    }
+    // K <op> $name  → rewrite as $name <flipped-op> K
+    if let ExprNode::Var { name: vn, .. } = right.as_ref() {
+        if vn == name {
+            if let Some(k) = literal_int(left) {
+                let mirror = match op {
+                    BinOp::Lt => BinOp::Gt,
+                    BinOp::Le => BinOp::Ge,
+                    BinOp::Gt => BinOp::Lt,
+                    BinOp::Ge => BinOp::Le,
+                    other => *other,
+                };
+                return guard_interval(mirror, k, negate);
+            }
+        }
+    }
+    None
+}
+
+/// `(name, version) → [branch-block names]` index for guard narrowing.  Mirrors
+/// `build_guard_index`: for each `Branch` block, the names in its condition
+/// against the block's exit version of each.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn build_guard_index(cfg: &CfgFunction, ssa: &SsaFunction) -> HashMap<ValueKey, Vec<String>> {
+    let mut index: HashMap<ValueKey, Vec<String>> = HashMap::new();
+    for (dn, dblock) in &cfg.blocks {
+        let Some(Terminator::Branch { condition, .. }) = &dblock.terminator else {
+            continue;
+        };
+        let Some(sb) = ssa.blocks.get(dn) else {
+            continue;
+        };
+        for name in condition.vars() {
+            if let Some(&version) = sb.exit_versions.get(&name) {
+                index.entry((name, version)).or_default().push(dn.clone());
+            }
+        }
+    }
+    index
+}
+
+/// True when `ancestor` dominates `node` (walks `node`'s idom chain).
+#[must_use]
+fn dominates(ssa: &SsaFunction, ancestor: &str, node: &str) -> bool {
+    if ancestor == node {
+        return true;
+    }
+    let mut curr = node.to_owned();
+    loop {
+        match ssa.idom.get(&curr) {
+            Some(Some(parent)) => {
+                if parent == ancestor {
+                    return true;
+                }
+                curr = parent.clone();
+            }
+            _ => return false,
+        }
+    }
+}
+
+/// Narrow `base[(name, version)]` by the constant-bound guards that hold on
+/// every path reaching `block`.  Mirrors `refine_interval`.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn refine_interval(
+    base: &HashMap<ValueKey, Interval>,
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    block: &str,
+    name: &str,
+    version: Version,
+    guard_index: &HashMap<ValueKey, Vec<String>>,
+) -> Interval {
+    let mut iv = base
+        .get(&(name.to_owned(), version))
+        .copied()
+        .unwrap_or(TOP);
+    let Some(candidate_blocks) = guard_index.get(&(name.to_owned(), version)) else {
+        return iv;
+    };
+    for dn in candidate_blocks {
+        if dn == block {
+            continue;
+        }
+        let Some(dblock) = cfg.blocks.get(dn) else {
+            continue;
+        };
+        let Some(Terminator::Branch {
+            condition,
+            true_target,
+            false_target,
+            ..
+        }) = &dblock.terminator
+        else {
+            continue;
+        };
+        let Some(sb) = ssa.blocks.get(dn) else {
+            continue;
+        };
+        if sb.exit_versions.get(name) != Some(&version) {
+            continue;
+        }
+        let true_dom = dominates(ssa, true_target.as_str(), block);
+        let false_dom = dominates(ssa, false_target.as_str(), block);
+        let c = if true_dom && !false_dom {
+            guard_constraint(condition, name, false)
+        } else if false_dom && !true_dom {
+            guard_constraint(condition, name, true)
+        } else {
+            continue;
+        };
+        if let Some(c) = c {
+            iv = intersect(iv, c);
+        }
+    }
+    iv
+}
+
+/// Seed a `[c, c]` interval from a constant-integer SCCP value, else `None`.
+#[must_use]
+fn seed_const(key: &ValueKey, values: &HashMap<ValueKey, LatticeValue>) -> Option<Interval> {
+    match values.get(key) {
+        Some(LatticeValue::Const(ConstValue::Int(n))) => Some(constant(*n)),
+        Some(LatticeValue::Const(ConstValue::Bool(b))) => Some(constant(i64::from(*b))),
+        _ => None,
+    }
+}
+
+/// Interval produced by `stmt` for its def `name`.  Mirrors `_transfer`.
+#[must_use]
+fn transfer(
+    stmt: &crate::ir::Statement,
+    name: &str,
+    env: &HashMap<String, Interval>,
+    old: Interval,
+) -> Interval {
+    use crate::ir::Statement;
+    match stmt {
+        Statement::AssignConst { value, .. } => const_int_from_value(value).map_or(TOP, constant),
+        Statement::AssignExpr { expr, .. } => eval_expr(expr, env),
+        Statement::Incr { amount, .. } => {
+            let mut base = env.get(name).copied().unwrap_or(old);
+            if base.is_bottom() {
+                base = TOP;
+            }
+            let amt = match amount {
+                None => constant(1),
+                Some(a) => const_int_from_value(a).map_or(TOP, constant),
+            };
+            add(base, amt)
+        }
+        _ => TOP,
+    }
+}
+
+const MAX_ITERS: usize = 50;
+
+/// The set of loop-header blocks: a block `v` that is the target of a back edge
+/// `u → v` (an edge where `v` dominates `u`).  Loop-header phis are widened.
+#[must_use]
+fn loop_headers(cfg: &CfgFunction, ssa: &SsaFunction) -> HashSet<String> {
+    let mut headers = HashSet::new();
+    for (u, block) in &cfg.blocks {
+        let Some(term) = &block.terminator else {
+            continue;
+        };
+        for v in term.successors() {
+            if dominates(ssa, v, u) {
+                headers.insert(v.to_owned());
+            }
+        }
+    }
+    headers
+}
+
+/// Forward interval analysis over the SSA form.  `values` is the SCCP lattice;
+/// a constant integer seeds `[c, c]`.  Everything else starts `BOTTOM` and is
+/// refined to fixpoint with loop-header widening.  Mirrors `compute_intervals`.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn compute_intervals(
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    values: &HashMap<ValueKey, LatticeValue>,
+) -> HashMap<ValueKey, Interval> {
+    let mut result: HashMap<ValueKey, Interval> = HashMap::new();
+    let cur = |result: &HashMap<ValueKey, Interval>, key: &ValueKey| -> Interval {
+        result.get(key).copied().unwrap_or(BOTTOM)
+    };
+
+    let headers = loop_headers(cfg, ssa);
+    let order = cfg.reverse_postorder();
+
+    let mut converged = false;
+    for _ in 0..MAX_ITERS {
+        let mut changed = false;
+        for bn in &order {
+            let Some(ssa_block) = ssa.blocks.get(bn) else {
+                continue;
+            };
+            let is_loop_header = headers.contains(bn);
+            for phi in &ssa_block.phis {
+                let key = (phi.name.clone(), phi.version);
+                let mut merged = BOTTOM;
+                for &inc in phi.incoming.values() {
+                    merged = if inc > 0 {
+                        join(merged, cur(&result, &(phi.name.clone(), inc)))
+                    } else {
+                        join(merged, TOP)
+                    };
+                }
+                if is_loop_header {
+                    merged = widen(cur(&result, &key), merged);
+                }
+                if merged != cur(&result, &key) {
+                    result.insert(key, merged);
+                    changed = true;
+                }
+            }
+            for s in &ssa_block.statements {
+                let env: HashMap<String, Interval> = s
+                    .uses
+                    .iter()
+                    .map(|(nm, &ver)| (nm.clone(), cur(&result, &(nm.clone(), ver))))
+                    .collect();
+                for (nm, &ver) in &s.defs {
+                    let key = (nm.clone(), ver);
+                    let val = seed_const(&key, values)
+                        .unwrap_or_else(|| transfer(&s.statement, nm, &env, cur(&result, &key)));
+                    if val != cur(&result, &key) {
+                        result.insert(key, val);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        if !changed {
+            converged = true;
+            break;
+        }
+    }
+
+    if !converged {
+        // The fixpoint did not stabilise within the cap, so `result` may still
+        // be ascending (intervals NARROWER than reality) — reporting a finding
+        // from such an under-approximation would be unsound.  Degrade every
+        // value to TOP so no consumer can derive a finding from unconverged data.
+        for v in result.values_mut() {
+            *v = TOP;
+        }
+        return result;
+    }
+
+    // Replace any remaining BOTTOM (unrefined) with TOP so consumers never see
+    // the empty sentinel for a reachable value.
+    for v in result.values_mut() {
+        if v.is_bottom() {
+            *v = TOP;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_widen_basic() {
+        assert_eq!(
+            join(constant(1), constant(3)),
+            Interval {
+                lo: Some(1),
+                hi: Some(3)
+            }
+        );
+        // widening a moving-up bound sends it to +inf.
+        let old = Interval {
+            lo: Some(0),
+            hi: Some(4),
+        };
+        let new = Interval {
+            lo: Some(0),
+            hi: Some(8),
+        };
+        assert_eq!(
+            widen(old, new),
+            Interval {
+                lo: Some(0),
+                hi: None
+            }
+        );
+    }
+
+    #[test]
+    fn add_sub_intervals() {
+        let a = Interval {
+            lo: Some(1),
+            hi: Some(3),
+        };
+        let b = Interval {
+            lo: Some(10),
+            hi: Some(20),
+        };
+        assert_eq!(
+            add(a, b),
+            Interval {
+                lo: Some(11),
+                hi: Some(23)
+            }
+        );
+        assert_eq!(
+            sub(b, a),
+            Interval {
+                lo: Some(7),
+                hi: Some(19)
+            }
+        );
+    }
+
+    #[test]
+    fn intersect_guard() {
+        // value < 10 (true) → [-inf, 9].
+        assert_eq!(
+            guard_interval(BinOp::Lt, 10, false),
+            Some(Interval {
+                lo: None,
+                hi: Some(9)
+            })
+        );
+        // negated `< 10` → `>= 10` → [10, +inf].
+        assert_eq!(
+            guard_interval(BinOp::Lt, 10, true),
+            Some(Interval {
+                lo: Some(10),
+                hi: None
+            })
+        );
+    }
+}

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -124,14 +124,47 @@ pub fn find_unnormalised_getter_warnings(
                         command,
                         args,
                         span,
+                        tokens,
                         ..
-                    } if is_unnormalised_getter(registry, command, args) => {
-                        out.push(IrulesCheckWarning {
-                            span: *span,
-                            code: "IRULE3102".to_owned(),
-                            message: format_message(command),
-                            replacement: None,
-                        });
+                    } => {
+                        // Direct getter call — e.g. `if {[HTTP::uri] eq …}`
+                        // lowers to a `Call` whose command *is* the getter.
+                        if is_unnormalised_getter(registry, command, args) {
+                            out.push(IrulesCheckWarning {
+                                span: *span,
+                                code: "IRULE3102".to_owned(),
+                                message: format_message(command),
+                                replacement: None,
+                            });
+                        }
+                        // Getter nested as a command-substitution argument —
+                        // e.g. the `[HTTP::uri]` fed into an HTTP sink in
+                        // `HTTP::respond 200 content [HTTP::uri]`.  The
+                        // substitution stays a literal `Cmd` arg on the outer
+                        // call rather than a separate statement, so flag it
+                        // here.  Prefer the argument token's own span so the
+                        // squiggle lands on the getter, not the whole call.
+                        for (i, arg) in args.iter().enumerate() {
+                            let trimmed = arg.trim();
+                            if !trimmed.starts_with('[') {
+                                continue;
+                            }
+                            let Some((cmd, sub_args)) = parse_command_substitution(trimmed) else {
+                                continue;
+                            };
+                            if is_unnormalised_getter(registry, &cmd, &sub_args) {
+                                let arg_span = tokens
+                                    .as_ref()
+                                    .and_then(|t| t.argv.get(i + 1).copied())
+                                    .unwrap_or(*span);
+                                out.push(IrulesCheckWarning {
+                                    span: arg_span,
+                                    code: "IRULE3102".to_owned(),
+                                    message: format_message(&cmd),
+                                    replacement: None,
+                                });
+                            }
+                        }
                     }
                     Statement::AssignValue { value, span, .. } => {
                         let Some((cmd, sub_args)) = parse_command_substitution(value.trim()) else {
@@ -824,6 +857,37 @@ mod tests {
         // `HTTP::path /x` — first arg `/x` is non-flag → setter form → no warning.
         let w = warnings_for_irules("HTTP::path /x");
         assert!(w.is_empty(), "expected no IRULE3102 on setter, got {w:?}");
+    }
+
+    #[test]
+    fn irule3102_warns_on_getter_nested_in_sink_argument() {
+        // `HTTP::respond 200 content [HTTP::uri]` — the unnormalised
+        // `[HTTP::uri]` getter is a command-substitution *argument* of the
+        // HTTP sink, not a top-level call/assignment, but must still fire.
+        let w = warnings_for_irules(
+            "when HTTP_REQUEST {\n    HTTP::respond 200 content [HTTP::uri]\n}\n",
+        );
+        assert_eq!(w.len(), 1, "expected one IRULE3102, got {w:?}");
+        assert_eq!(w[0].code, "IRULE3102");
+        assert!(w[0].message.contains("HTTP::uri -normalized"));
+    }
+
+    #[test]
+    fn irule3102_silent_for_constant_sink_argument() {
+        // A constant fed into the same sink stays silent.
+        let w = warnings_for_irules(
+            "when HTTP_REQUEST {\n    HTTP::respond 200 content \"static body\"\n}\n",
+        );
+        assert!(w.is_empty(), "expected no IRULE3102, got {w:?}");
+    }
+
+    #[test]
+    fn irule3102_silent_for_normalized_getter_in_sink_argument() {
+        // The nested getter with `-normalized` is canonicalised → silent.
+        let w = warnings_for_irules(
+            "when HTTP_REQUEST {\n    HTTP::respond 200 content [HTTP::uri -normalized]\n}\n",
+        );
+        assert!(w.is_empty(), "expected no IRULE3102, got {w:?}");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -97,6 +97,8 @@ pub use tcl_syntax::expr::parser as expr_parser;
 pub mod gvn;
 pub mod inline_uplevel;
 pub mod interprocedural;
+pub mod interval_bounds;
+pub mod intervals;
 pub mod ir;
 pub mod ir_helpers;
 pub mod irules_checks;

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -905,6 +905,27 @@ pub(crate) fn scan_scope_aliases(cfg: &CfgFunction) -> HashSet<String> {
                             i += 2;
                         }
                     }
+                    "trace" => {
+                        // A write trace fires the callback on every `set`, so
+                        // the traced variable is observable and must never be
+                        // a dead store (W220) / unused (W211).  Recognises both
+                        // `trace add variable NAME …` (8.5+) and the 8.4 `trace
+                        // variable NAME …` spelling; a dynamic `$`-target names
+                        // no static local and is skipped here.
+                        let target = if args.len() >= 3 && args[0] == "add" && args[1] == "variable"
+                        {
+                            Some(&args[2])
+                        } else if args.len() >= 2 && args[0] == "variable" {
+                            Some(&args[1])
+                        } else {
+                            None
+                        };
+                        if let Some(t) = target {
+                            if !t.starts_with('$') && !t.contains('[') {
+                                aliases.insert(t.clone());
+                            }
+                        }
+                    }
                     _ => {
                         // For other calls, trust the per-statement
                         // `defs` annotation when present (it

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -105,7 +105,9 @@ fn collect_expr_shimmers(
             collect_expr_shimmers(right, uses, types, stmt_span, out);
 
             match op {
-                // Arithmetic operators require numeric operands.
+                // Arithmetic, bitwise, logical, and *ordering* comparison
+                // operators are always a numeric context (Tcl `<`/`<=`/`>`/`>=`
+                // compare numerically when possible).  Mirrors `_NUMERIC_OPS`.
                 BinOp::Add
                 | BinOp::Sub
                 | BinOp::Mul
@@ -116,9 +118,28 @@ fn collect_expr_shimmers(
                 | BinOp::RShift
                 | BinOp::BitAnd
                 | BinOp::BitOr
-                | BinOp::BitXor => {
+                | BinOp::BitXor
+                | BinOp::And
+                | BinOp::Or
+                | BinOp::Lt
+                | BinOp::Le
+                | BinOp::Gt
+                | BinOp::Ge => {
                     check_numeric_operand(left, uses, types, stmt_span, *op, out);
                     check_numeric_operand(right, uses, types, stmt_span, *op, out);
+                }
+
+                // `==` / `!=` take the numeric-coercion path only when at least
+                // one operand is provably numeric (else Tcl falls back to a
+                // string compare and no shimmer occurs).  Mirrors
+                // `_CONDITIONAL_NUMERIC_OPS` + `_operand_looks_numeric`.
+                BinOp::Eq | BinOp::Ne => {
+                    if operand_looks_numeric(left, uses, types)
+                        || operand_looks_numeric(right, uses, types)
+                    {
+                        check_numeric_operand(left, uses, types, stmt_span, *op, out);
+                        check_numeric_operand(right, uses, types, stmt_span, *op, out);
+                    }
                 }
 
                 // String comparison operators: operands should be String.
@@ -153,6 +174,64 @@ fn collect_expr_shimmers(
 
         _ => {}
     }
+}
+
+/// True when `node` is provably numeric-looking — gates the conditional
+/// `==` / `!=` numeric-shimmer check.  Mirrors `_operand_looks_numeric`
+/// (the SCCP-CONST arm is omitted; the literal / numeric-string / typed-var
+/// arms cover the shimmer cases the syntactic types reach).
+fn operand_looks_numeric(
+    node: &ExprNode,
+    uses: &HashMap<String, u32>,
+    types: &HashMap<ValueKey, TypeLattice>,
+) -> bool {
+    match node {
+        ExprNode::Literal { .. } => true,
+        ExprNode::String { text, .. } => expr_string_is_numeric(text),
+        ExprNode::Var { name, .. } => {
+            let base = normalise_var_name(name);
+            let Some(&ver) = uses.get(base) else {
+                return false;
+            };
+            if ver == 0 {
+                return false;
+            }
+            types
+                .get(&(base.to_owned(), ver))
+                .filter(|l| l.kind == TypeKind::Known)
+                .and_then(|l| l.tcl_type)
+                .is_some_and(|t| {
+                    matches!(
+                        t,
+                        TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean
+                    )
+                })
+        }
+        _ => false,
+    }
+}
+
+/// True when `text` (an `ExprNode::String` body or raw value, possibly still
+/// wrapped in `{}` / `"`) parses as an int, float, or Tcl boolean literal.
+/// Mirrors `_expr_string_is_numeric`.
+fn expr_string_is_numeric(text: &str) -> bool {
+    let mut s = text.trim();
+    if s.len() >= 2
+        && ((s.starts_with('{') && s.ends_with('}')) || (s.starts_with('"') && s.ends_with('"')))
+    {
+        s = &s[1..s.len() - 1];
+    }
+    let s = s.trim();
+    if s.is_empty() {
+        return false;
+    }
+    if s.parse::<i64>().is_ok() || s.parse::<f64>().is_ok() {
+        return true;
+    }
+    matches!(
+        s.to_ascii_lowercase().as_str(),
+        "true" | "false" | "yes" | "no" | "on" | "off"
+    )
 }
 
 /// Emit S100 if `node` is a variable reference with a non-numeric type
@@ -288,6 +367,36 @@ mod tests {
         assert!(
             has_shimmer,
             "expected string-in-arithmetic shimmer, got: {w:?}"
+        );
+    }
+
+    /// A String variable compared with `==` against a numeric literal takes
+    /// the numeric-coercion path and shimmers; comparing against a non-numeric
+    /// string stays on the string path and does not.
+    #[test]
+    fn expr_shimmer_string_eq_numeric_literal() {
+        let cu = CompilationUnit::build_for(
+            "set s [string trim hello]\nset y [expr {$s == \"5\"}]",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(
+            w.iter().any(|sw| sw.variable == "s"),
+            "string == numeric literal must shimmer: {w:?}"
+        );
+        // `$s == "hello"` — both string, no numeric coercion, no shimmer.
+        let cu2 = CompilationUnit::build_for(
+            "set s [string trim hello]\nset y [expr {$s == \"hello\"}]",
+            &registry(),
+            false,
+        );
+        let fu2 = cu2.function("::top").unwrap();
+        let w2 = find_expr_shimmers(&fu2.cfg, &fu2.ssa, &fu2.types, &fu2.sccp.executable_blocks);
+        assert!(
+            !w2.iter().any(|sw| sw.variable == "s"),
+            "string == string must not shimmer: {w2:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -13,6 +13,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use tcl_registry::TclType;
+
 use crate::cfg::Function as CfgFunction;
 use crate::sccp::cfg_order;
 use crate::ssa::{SsaFunction, ValueKey};
@@ -20,6 +22,7 @@ use crate::types::{TypeKind, TypeLattice};
 
 use super::graph::loop_body_blocks;
 use super::span::{def_range_map, phi_span};
+use super::thunking::{destructure_foreach_blocks, empty_value_versions, per_loop_body_types};
 use super::{type_name, ShimmerWarning};
 
 /// Find phi-node shimmer warnings for a function.
@@ -28,6 +31,7 @@ use super::{type_name, ShimmerWarning};
 /// `TypeLattice` is `Shimmered`, the variable will require an intrep
 /// conversion on the first use after the merge point.
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub(crate) fn find_phi_shimmers(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
@@ -36,6 +40,12 @@ pub(crate) fn find_phi_shimmers(
 ) -> Vec<ShimmerWarning> {
     let loop_blocks = loop_body_blocks(cfg);
     let def_map = def_range_map(ssa);
+    let empty_by_name = empty_value_versions(ssa);
+    let destructure = destructure_foreach_blocks(cfg);
+    // Python's phi pass uses the *function-wide* loop-body type map (unlike the
+    // per-loop S102 thunking pass); reproduce that with the whole loop-block set.
+    let loop_body_types =
+        per_loop_body_types("", &loop_blocks, &destructure, ssa, types, &empty_by_name);
     let mut out = Vec::new();
 
     for block_name in cfg_order(cfg) {
@@ -61,6 +71,54 @@ pub(crate) fn find_phi_shimmers(
             let Some(to) = lattice.tcl_type else {
                 continue;
             };
+
+            // Refine the SHIMMERED-phi verdict (mirrors `_find_phi_shimmers`).
+            // A loop-header phi is SHIMMERED on any entry-vs-body type change,
+            // but the empty-accumulator promotion (`set r {}`; `lappend r …`)
+            // and a branch merge whose only shimmer comes from an empty literal
+            // are not real per-use intrep conversions.
+            let empty_vers = empty_by_name.get(&phi.name);
+            let mut entry_types: HashSet<TclType> = HashSet::new();
+            let mut body_types: HashSet<TclType> = HashSet::new();
+            let mut nonempty_known: HashSet<TclType> = HashSet::new();
+            let mut has_shimmered_incoming = false;
+            for (pred, &inc_ver) in &phi.incoming {
+                if inc_ver == 0 {
+                    continue;
+                }
+                let Some(inc_type) = types.get(&(phi.name.clone(), inc_ver)) else {
+                    continue;
+                };
+                if inc_type.kind == TypeKind::Unknown {
+                    continue;
+                }
+                let is_empty = empty_vers.is_some_and(|s| s.contains(&inc_ver));
+                if inc_type.kind == TypeKind::Known && !is_empty {
+                    if let Some(t) = inc_type.tcl_type {
+                        if loop_blocks.contains(pred) {
+                            body_types.insert(t);
+                        } else {
+                            entry_types.insert(t);
+                        }
+                        nonempty_known.insert(t);
+                    }
+                } else if inc_type.kind == TypeKind::Shimmered {
+                    has_shimmered_incoming = true;
+                }
+            }
+            if in_loop {
+                let mut all_body = body_types;
+                if let Some(pl) = loop_body_types.get(&phi.name) {
+                    all_body.extend(pl.iter().copied());
+                }
+                let oscillates =
+                    entry_types.intersection(&all_body).next().is_some() || all_body.len() >= 2;
+                if !oscillates {
+                    continue;
+                }
+            } else if !has_shimmered_incoming && nonempty_known.len() <= 1 {
+                continue;
+            }
 
             let span = phi_span(phi, ssa, &def_map);
             let related: Vec<_> = phi
@@ -126,6 +184,23 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The empty-accumulator promotion (`set r {}`; `foreach … {lappend r …}`)
+    /// is a one-time STRING→LIST stabilisation, not a per-use shimmer — no S101.
+    #[test]
+    fn no_phi_shimmer_for_empty_accumulator() {
+        let cu = CompilationUnit::build_for(
+            "proc f {} { set r {}\n foreach x {1 2 3} { lappend r $x }\n return [llength $r] }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(
+            !warnings.iter().any(|w| w.variable == "r"),
+            "accumulator must not phi-shimmer: {warnings:?}"
+        );
     }
 
     /// API smoke-test: function runs on empty source without panicking.

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -34,7 +34,9 @@ use super::span::{def_range_map, phi_span};
 use super::{type_name, ThunkingWarning};
 
 /// Invert a successor map into a predecessor map.
-fn build_predecessors(succs: &HashMap<String, Vec<String>>) -> HashMap<String, Vec<String>> {
+pub(super) fn build_predecessors(
+    succs: &HashMap<String, Vec<String>>,
+) -> HashMap<String, Vec<String>> {
     let mut preds: HashMap<String, Vec<String>> = HashMap::new();
     for (p, targets) in succs {
         for t in targets {
@@ -49,7 +51,7 @@ fn build_predecessors(succs: &HashMap<String, Vec<String>>) -> HashMap<String, V
 /// per-loop block set `build_loop_forest` provides Python's S102 pass, so a
 /// sibling loop's type effect on the same name never pollutes this loop's
 /// oscillation check.
-fn natural_loop_blocks(
+pub(super) fn natural_loop_blocks(
     header: &str,
     preds: &HashMap<String, Vec<String>>,
     loop_blocks: &HashSet<String>,
@@ -83,7 +85,7 @@ fn natural_loop_blocks(
 /// SSA versions of each name defined by the empty literal (`set x {}` / `""`)
 /// over the whole function — the typeless-empty reset, excluded from the
 /// oscillation type sets.  Mirrors `_empty_literal_versions`.
-fn empty_value_versions(ssa: &SsaFunction) -> HashMap<String, HashSet<Version>> {
+pub(super) fn empty_value_versions(ssa: &SsaFunction) -> HashMap<String, HashSet<Version>> {
     let mut out: HashMap<String, HashSet<Version>> = HashMap::new();
     for sb in ssa.blocks.values() {
         for s in &sb.statements {
@@ -106,7 +108,7 @@ fn empty_value_versions(ssa: &SsaFunction) -> HashMap<String, HashSet<Version>> 
 /// idiom (`foreach {a b c} $l break`), a one-time multi-assign whose bindings
 /// must not count as per-iteration loop-body types.  Mirrors
 /// `_destructure_foreach_blocks` (block-shape heuristic).
-fn destructure_foreach_blocks(cfg: &CfgFunction) -> HashSet<String> {
+pub(super) fn destructure_foreach_blocks(cfg: &CfgFunction) -> HashSet<String> {
     let mut out = HashSet::new();
     for (bn, block) in &cfg.blocks {
         if block.statements.len() == 1 {
@@ -123,7 +125,7 @@ fn destructure_foreach_blocks(cfg: &CfgFunction) -> HashSet<String> {
 /// KNOWN, non-empty intreps each name is *defined as* inside the per-loop
 /// blocks of `header` (destructure foreach blocks excluded).  Mirrors the
 /// per-loop `per_header_body_types` build in `_find_thunking`.
-fn per_loop_body_types(
+pub(super) fn per_loop_body_types(
     header: &str,
     loop_block_set: &HashSet<String>,
     destructure: &HashSet<String>,

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -21,20 +21,152 @@
 
 use std::collections::{HashMap, HashSet};
 
+use tcl_registry::TclType;
+
 use crate::cfg::Function as CfgFunction;
+use crate::ir::Statement;
 use crate::sccp::cfg_order;
-use crate::ssa::{SsaFunction, ValueKey};
+use crate::ssa::{SsaFunction, ValueKey, Version};
 use crate::types::{TypeKind, TypeLattice};
 
 use super::graph::{build_successors, loop_body_blocks};
 use super::span::{def_range_map, phi_span};
 use super::{type_name, ThunkingWarning};
 
+/// Invert a successor map into a predecessor map.
+fn build_predecessors(succs: &HashMap<String, Vec<String>>) -> HashMap<String, Vec<String>> {
+    let mut preds: HashMap<String, Vec<String>> = HashMap::new();
+    for (p, targets) in succs {
+        for t in targets {
+            preds.entry(t.clone()).or_default().push(p.clone());
+        }
+    }
+    preds
+}
+
+/// Blocks of the natural loop with `header`: `{header}` plus every block that
+/// reaches a back-edge source without passing through the header.  Mirrors the
+/// per-loop block set `build_loop_forest` provides Python's S102 pass, so a
+/// sibling loop's type effect on the same name never pollutes this loop's
+/// oscillation check.
+fn natural_loop_blocks(
+    header: &str,
+    preds: &HashMap<String, Vec<String>>,
+    loop_blocks: &HashSet<String>,
+) -> HashSet<String> {
+    let mut body: HashSet<String> = HashSet::new();
+    body.insert(header.to_owned());
+    let mut stack: Vec<String> = preds
+        .get(header)
+        .map(|ps| {
+            ps.iter()
+                .filter(|p| loop_blocks.contains(*p))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
+    for s in &stack {
+        body.insert(s.clone());
+    }
+    while let Some(n) = stack.pop() {
+        if let Some(ps) = preds.get(&n) {
+            for p in ps {
+                if body.insert(p.clone()) {
+                    stack.push(p.clone());
+                }
+            }
+        }
+    }
+    body
+}
+
+/// SSA versions of each name defined by the empty literal (`set x {}` / `""`)
+/// over the whole function — the typeless-empty reset, excluded from the
+/// oscillation type sets.  Mirrors `_empty_literal_versions`.
+fn empty_value_versions(ssa: &SsaFunction) -> HashMap<String, HashSet<Version>> {
+    let mut out: HashMap<String, HashSet<Version>> = HashMap::new();
+    for sb in ssa.blocks.values() {
+        for s in &sb.statements {
+            let is_empty = matches!(
+                &s.statement,
+                Statement::AssignConst { value, .. } | Statement::AssignValue { value, .. }
+                    if value.is_empty()
+            );
+            if is_empty {
+                for (name, &ver) in &s.defs {
+                    out.entry(name.clone()).or_default().insert(ver);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Foreach-header blocks whose body is a single `break` — the destructure
+/// idiom (`foreach {a b c} $l break`), a one-time multi-assign whose bindings
+/// must not count as per-iteration loop-body types.  Mirrors
+/// `_destructure_foreach_blocks` (block-shape heuristic).
+fn destructure_foreach_blocks(cfg: &CfgFunction) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for (bn, block) in &cfg.blocks {
+        if block.statements.len() == 1 {
+            if let Statement::Call { command, .. } = &block.statements[0] {
+                if command == "break" {
+                    out.insert(bn.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// KNOWN, non-empty intreps each name is *defined as* inside the per-loop
+/// blocks of `header` (destructure foreach blocks excluded).  Mirrors the
+/// per-loop `per_header_body_types` build in `_find_thunking`.
+fn per_loop_body_types(
+    header: &str,
+    loop_block_set: &HashSet<String>,
+    destructure: &HashSet<String>,
+    ssa: &SsaFunction,
+    types: &HashMap<ValueKey, TypeLattice>,
+    empty_by_name: &HashMap<String, HashSet<Version>>,
+) -> HashMap<String, HashSet<TclType>> {
+    let _ = header;
+    let mut out: HashMap<String, HashSet<TclType>> = HashMap::new();
+    for lbn in loop_block_set {
+        if destructure.contains(lbn) {
+            continue;
+        }
+        let Some(lssa) = ssa.blocks.get(lbn) else {
+            continue;
+        };
+        for s in &lssa.statements {
+            for (name, &ver) in &s.defs {
+                if empty_by_name
+                    .get(name)
+                    .is_some_and(|set| set.contains(&ver))
+                {
+                    continue;
+                }
+                if let Some(t) = types.get(&(name.clone(), ver)) {
+                    if t.kind == TypeKind::Known {
+                        if let Some(tt) = t.tcl_type {
+                            out.entry(name.clone()).or_default().insert(tt);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
 /// Find thunking warnings for a function.
 ///
 /// Returns one [`ThunkingWarning`] per phi node at a loop header whose
 /// type lattice is `Shimmered`.
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub(crate) fn find_thunking_warnings(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
@@ -67,6 +199,10 @@ pub(crate) fn find_thunking_warnings(
         .cloned()
         .collect();
 
+    let preds = build_predecessors(&succs);
+    let empty_by_name = empty_value_versions(ssa);
+    let destructure = destructure_foreach_blocks(cfg);
+
     for block_name in cfg_order(cfg) {
         if !executable_blocks.contains(&block_name) {
             continue;
@@ -77,6 +213,18 @@ pub(crate) fn find_thunking_warnings(
         let Some(ssa_block) = ssa.blocks.get(&block_name) else {
             continue;
         };
+
+        // Per-loop body types for *this* loop only (sibling loops must not
+        // pollute the oscillation check).
+        let this_loop = natural_loop_blocks(&block_name, &preds, &loop_blocks);
+        let per_loop = per_loop_body_types(
+            &block_name,
+            &this_loop,
+            &destructure,
+            ssa,
+            types,
+            &empty_by_name,
+        );
 
         for phi in &ssa_block.phis {
             let key = (phi.name.clone(), phi.version);
@@ -92,6 +240,52 @@ pub(crate) fn find_thunking_warnings(
             let Some(type_b) = lattice.tcl_type else {
                 continue;
             };
+
+            // A loop-header phi is SHIMMERED whenever the entry type differs
+            // from the body-exit type — but that includes the *one-time*
+            // promotion of an empty accumulator (`set r {}; foreach …
+            // {lappend r …}`): STRING once, then LIST forever.  Genuine
+            // thunking requires the body to re-introduce the entry type (so
+            // the phi re-shimmers each pass) or to produce ≥2 conflicting
+            // types itself.  Classify the phi's incomings (entry vs body) and
+            // require oscillation.  Mirrors `_find_thunking`.
+            let empty_vers = empty_by_name.get(&phi.name);
+            let mut entry_types: HashSet<TclType> = HashSet::new();
+            let mut body_types: HashSet<TclType> = HashSet::new();
+            let mut has_body_incoming = false;
+            for (pred, &inc_ver) in &phi.incoming {
+                if inc_ver == 0 {
+                    continue;
+                }
+                let Some(inc_type) = types.get(&(phi.name.clone(), inc_ver)) else {
+                    continue;
+                };
+                let is_empty = empty_vers.is_some_and(|s| s.contains(&inc_ver));
+                if loop_blocks.contains(pred) {
+                    if inc_type.kind == TypeKind::Known && !is_empty {
+                        has_body_incoming = true;
+                        if let Some(t) = inc_type.tcl_type {
+                            body_types.insert(t);
+                        }
+                    }
+                } else if inc_type.kind == TypeKind::Known && !is_empty {
+                    if let Some(t) = inc_type.tcl_type {
+                        entry_types.insert(t);
+                    }
+                }
+            }
+            if !has_body_incoming {
+                continue;
+            }
+            let mut all_body_types = body_types;
+            if let Some(pl) = per_loop.get(&phi.name) {
+                all_body_types.extend(pl.iter().copied());
+            }
+            let oscillates = entry_types.intersection(&all_body_types).next().is_some()
+                || all_body_types.len() >= 2;
+            if !oscillates {
+                continue;
+            }
 
             let span = phi_span(phi, ssa, &def_map);
             let related: Vec<_> = phi
@@ -149,6 +343,35 @@ mod tests {
         assert!(w.is_empty(), "unexpected thunking warnings: {w:?}");
     }
 
+    /// Sibling (non-nested) loops that each set the same var to a different
+    /// but per-loop-monomorphic type must not be reported as oscillating.
+    #[test]
+    fn no_s102_for_sibling_loops_with_different_types() {
+        let cu = CompilationUnit::build_for(
+            "proc f {items} { foreach a $items { set x \"value\" }\n \
+             foreach b $items { set x [list 1 2] } }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(w.is_empty(), "sibling loops must not thunk: {w:?}");
+    }
+
+    /// The empty-accumulator promotion (`set r {}; foreach … {lappend r …}`)
+    /// is a one-time STRING→LIST stabilisation, not per-iteration oscillation.
+    #[test]
+    fn no_s102_for_empty_accumulator_promotion() {
+        let cu = CompilationUnit::build_for(
+            "proc f {} { set r {}\n foreach x {1 2 3} { lappend r $x }\n return [llength $r] }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(w.is_empty(), "accumulator promotion must not thunk: {w:?}");
+    }
+
     /// Empty source: no thunking warnings and no panic.
     #[test]
     fn thunking_empty_source() {
@@ -167,24 +390,25 @@ mod tests {
         assert!(w.is_empty(), "unexpected thunking: {w:?}");
     }
 
-    /// A loop variable initialised as Int before the loop and reassigned as
-    /// String inside produces an S102 thunking warning: the loop-header phi
-    /// merges Int (from the entry edge) and String (from the back edge).
+    /// A loop body that produces ≥2 distinct intrep types in one iteration
+    /// (`set x "s"; set x [list 1]` — STRING then LIST) genuinely re-thunks
+    /// every pass and fires S102.  (A *one-time* promotion — `set x 0; while …
+    /// { set x "hello" }`, where x stabilises at STRING after the first pass —
+    /// is suppressed, matching Python; see the sibling/accumulator tests.)
     #[test]
-    fn thunking_detected_for_int_string_oscillation() {
-        // Use a non-constant while condition so SCCP does not eliminate
-        // the loop body, keeping both the entry and back edges executable.
+    fn thunking_detected_for_two_type_loop_body() {
+        // Non-constant condition so SCCP keeps both edges executable.
         let cu = CompilationUnit::build_for(
-            "set x 0\nwhile {[gets stdin] ne \"\"} {\n    set x \"hello\"\n}",
+            "proc f {n} { set x 0\n while {$n} { set x \"s\"\n set x [list 1] }\n return $x }",
             &registry(),
             false,
         );
-        let fu = cu.function("::top").unwrap();
+        let fu = cu.function("::f").unwrap();
         let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
         let has_thunking = w.iter().any(|tw| tw.variable == "x" && tw.code == "S102");
         assert!(
             has_thunking,
-            "expected S102 thunking for 'x' oscillating Int/String, got: {w:?}"
+            "expected S102 thunking for 'x' with a two-type loop body, got: {w:?}"
         );
     }
 }

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -47,9 +47,28 @@ const BOOL_LITERALS: &[&str] = &["true", "false", "yes", "no", "on", "off"];
 
 /// Classify a literal string as its Tcl intrep type.
 #[must_use]
+/// True when `s` is a Tcl integer literal: decimal, or a `0x`/`0X` hex or
+/// `0b`/`0B` binary form (each optionally signed).  Mirrors
+/// `core_analyses._literal_type`'s INT cases — hex/binary store an INT intrep
+/// (`set n 0x80; incr n` is one clean parse, not per-iteration shimmer), while
+/// `0o` octal stays STRING (Python's set-statement classifier excludes it).
+fn is_tcl_int_literal(s: &str) -> bool {
+    if s.parse::<i64>().is_ok() {
+        return true;
+    }
+    let body = s.strip_prefix(['+', '-']).unwrap_or(s);
+    if let Some(h) = body.strip_prefix("0x").or_else(|| body.strip_prefix("0X")) {
+        return !h.is_empty() && h.bytes().all(|c| c.is_ascii_hexdigit());
+    }
+    if let Some(b) = body.strip_prefix("0b").or_else(|| body.strip_prefix("0B")) {
+        return !b.is_empty() && b.bytes().all(|c| matches!(c, b'0' | b'1'));
+    }
+    false
+}
+
 fn literal_type(text: &str) -> TypeLattice {
     let s = text.trim();
-    if s.parse::<i64>().is_ok() {
+    if is_tcl_int_literal(s) {
         return TypeLattice::of(TclType::Int);
     }
     if looks_like_float(s) {
@@ -654,6 +673,22 @@ mod tests {
     fn string_literal_infers_string() {
         let t = literal_type("hello");
         assert_eq!(t, TypeLattice::of(TclType::String));
+    }
+
+    #[test]
+    fn hex_and_binary_literals_infer_int() {
+        // Hex / binary literals store an INT intrep (`set n 0x80; incr n` is
+        // one clean parse, not per-iteration shimmer).
+        for lit in ["0x80", "0X1f", "-0xFF", "0b1010", "0B1", "+0x0"] {
+            assert_eq!(
+                literal_type(lit),
+                TypeLattice::of(TclType::Int),
+                "{lit} should be INT"
+            );
+        }
+        // Octal `0o…` and non-integer hex stay STRING (set-statement classifier).
+        assert_eq!(literal_type("0o17"), TypeLattice::of(TclType::String));
+        assert_eq!(literal_type("0xZZ"), TypeLattice::of(TclType::String));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -265,11 +265,11 @@ fn param_names_from_synopsis(synopsis: &str, skip_words: usize) -> Vec<(String, 
     let groups = synopsis_groups(synopsis);
     let mut names = Vec::new();
     for group in groups.into_iter().skip(skip_words) {
-        // Varargs anywhere → stop.
-        if group.contains("...") {
-            break;
-        }
-        // Optional group `?...?`.
+        // Optional group `?...?` — handled *before* the bare-varargs stop
+        // so an optional flag/repeat placeholder that happens to carry
+        // `...` (e.g. `?option ...?` in `lsearch ?option ...? list pattern`)
+        // is skipped, not mistaken for a hard varargs terminator that would
+        // drop the real trailing positionals (`list` / `pattern`) after it.
         if let Some(inner) = group.strip_prefix('?').and_then(|g| g.strip_suffix('?')) {
             let inner = inner.trim();
             if inner.starts_with('-') {
@@ -277,8 +277,10 @@ fn param_names_from_synopsis(synopsis: &str, skip_words: usize) -> Vec<(String, 
                 continue;
             }
             if inner.is_empty() || inner.contains(char::is_whitespace) {
-                // Multi-word optional that isn't a plain name —
-                // skip conservatively.
+                // Multi-word optional that isn't a plain name — a flag-group
+                // or repeat placeholder (`option ...`, `arg ...`, `-length
+                // length`).  Skip conservatively; the real flags are handled
+                // per-call by the registry option table.
                 continue;
             }
             // Flag-group documentation placeholders — not real
@@ -289,6 +291,11 @@ fn param_names_from_synopsis(synopsis: &str, skip_words: usize) -> Vec<(String, 
             }
             names.push((inner.to_string(), true));
             continue;
+        }
+        // Non-optional varargs marker (`...` or `name ...`) → stop; a plain
+        // positional preceding it is already labelled.
+        if group.contains("...") {
+            break;
         }
         // Bare flag.
         if group.starts_with('-') {
@@ -576,6 +583,23 @@ mod tests {
         assert_eq!(names, vec![("path".to_string(), false)]);
         let names = param_names_from_synopsis("cmd ?switches? path", 1);
         assert_eq!(names, vec![("path".to_string(), false)]);
+    }
+
+    #[test]
+    fn param_names_skips_optional_varargs_flag_group_then_labels_positionals() {
+        // `lsearch ?option ...? list pattern` (the actual registry hover
+        // synopsis) — the `?option ...?` flag-group placeholder must be
+        // skipped, NOT treated as a hard varargs stop that drops the real
+        // `list` / `pattern` positionals after it (issue #510 follow-up).
+        let names = param_names_from_synopsis("lsearch ?option ...? list pattern", 1);
+        assert_eq!(
+            names,
+            vec![("list".to_string(), false), ("pattern".to_string(), false)],
+        );
+        // A *non-optional* `...` repeat marker still stops the parse, after
+        // the preceding plain positional is labelled.
+        let names = param_names_from_synopsis("cmd first ...", 1);
+        assert_eq!(names, vec![("first".to_string(), false)]);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1770,23 +1770,21 @@ fn collect_expr(
                     entries,
                 );
             }
-            E::Function => {
-                if !et.text.is_empty() && !et.text.contains('\n') {
-                    let pos = line_index
-                        .position_at_utf16(u32::try_from(abs_start).unwrap_or(0), full_source);
-                    let mods = if math.contains(et.text.as_str()) {
-                        MOD_DEFAULT_LIBRARY
-                    } else {
-                        0
-                    };
-                    entries.push((
-                        pos.line,
-                        pos.character,
-                        utf16_len(&et.text),
-                        TokenKind::Function,
-                        mods,
-                    ));
-                }
+            E::Function if !et.text.is_empty() && !et.text.contains('\n') => {
+                let pos = line_index
+                    .position_at_utf16(u32::try_from(abs_start).unwrap_or(0), full_source);
+                let mods = if math.contains(et.text.as_str()) {
+                    MOD_DEFAULT_LIBRARY
+                } else {
+                    0
+                };
+                entries.push((
+                    pos.line,
+                    pos.character,
+                    utf16_len(&et.text),
+                    TokenKind::Function,
+                    mods,
+                ));
             }
             _ => {}
         }
@@ -2056,14 +2054,30 @@ fn push_token(
     entries: &mut Vec<Entry>,
 ) {
     let span = tok.span;
-    let len_bytes = span.end() - span.start();
-    if len_bytes == 0 {
+    let start = span.start();
+    let mut end = span.end();
+    // The lexer's empty-content clamp (tcl-lexer `parse_quoted`) extends a
+    // quoted `Esc` fragment's span by one byte over the `$` / `[` that
+    // introduces the *next* substitution token, so `token_text` stays empty
+    // while `span.end` lands on the terminator.  That introducer byte
+    // belongs to the following `Var` / `Cmd` token; emitting it here would
+    // produce overlapping semantic tokens (e.g. `"$x"` → the opening
+    // fragment `"$` overlapping the `$x` variable).  A clamped-empty ESC is
+    // recognised by `span_len == content_offset + 1` with a `$` / `[` last
+    // byte; trim it back to just its leading delimiter (the opening `"`, or
+    // nothing when there is no delimiter, e.g. between adjacent `$a$b`).
+    if tok.kind == TokenType::Esc && end - start == u32::from(tok.content_offset) + 1 {
+        if let Some(&last) = source.as_bytes().get((end - 1) as usize) {
+            if last == b'$' || last == b'[' {
+                end = start + u32::from(tok.content_offset);
+            }
+        }
+    }
+    if end <= start {
         return;
     }
-    let pos = line_index.position_at_utf16(span.start(), source);
-    let text = source
-        .get(span.start() as usize..span.end() as usize)
-        .unwrap_or("");
+    let pos = line_index.position_at_utf16(start, source);
+    let text = source.get(start as usize..end as usize).unwrap_or("");
     // Skip multi-line tokens — LSP encoding wants per-line
     // entries; multi-line tokens would need splitting.
     // For the minimal rich port, drop them.
@@ -2192,6 +2206,74 @@ mod tests {
             .chunks(5)
             .map(|c| c[3])
             .collect()
+    }
+
+    /// Decode the packed stream into absolute `(line, col, len)` triples.
+    fn decode(src: &str, dialect: &str, registry: &CommandRegistry) -> Vec<(u32, u32, u32)> {
+        let st = full(src, dialect, registry);
+        let mut line = 0u32;
+        let mut col = 0u32;
+        let mut out = Vec::new();
+        for c in st.data.chunks(5) {
+            let (dl, dc, len) = (c[0], c[1], c[2]);
+            if dl > 0 {
+                line += dl;
+                col = dc;
+            } else {
+                col += dc;
+            }
+            out.push((line, col, len));
+        }
+        out
+    }
+
+    /// Assert no two tokens on the same line overlap (next starts at or
+    /// after the previous token's end) — the client "Overlapping semantic
+    /// tokens detected" invariant.
+    fn assert_non_overlapping(src: &str, registry: &CommandRegistry) {
+        let toks = decode(src, "tcl", registry);
+        for w in toks.windows(2) {
+            let (l0, c0, len0) = w[0];
+            let (l1, c1, _) = w[1];
+            if l0 == l1 {
+                assert!(
+                    c1 >= c0 + len0,
+                    "overlap on line {l0}: token at col {c1} starts before \
+                     previous token end {} (src={src:?}, toks={toks:?})",
+                    c0 + len0,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn quoted_var_at_string_start_no_overlap() {
+        // Regression: the lexer's empty-content clamp made the opening `"`
+        // fragment span `"$`, overlapping the `$x` variable token.  The
+        // opening fragment must shrink to just the `"`.
+        let r = reg();
+        assert_non_overlapping("puts \"$x y\"\n", &r);
+        assert_non_overlapping("set x 1\nputs \"$x — résumé — 日本語\"\n", &r);
+        // Adjacent substitutions: the empty ESC between `$a` and `$b`
+        // carries no delimiter, so it must vanish entirely (no zero-area
+        // overlap at the `$b`).
+        assert_non_overlapping("puts \"$a$b\"\n", &r);
+        // Command substitution introducer `[` at string start.
+        assert_non_overlapping("puts \"[expr {1+2}] z\"\n", &r);
+        // Dense line with several adjacent substitutions/strings.
+        assert_non_overlapping("set a 1;set b 2;puts \"$a [expr {$a+$b}] $b\";# tail\n", &r);
+    }
+
+    #[test]
+    fn quoted_string_opening_fragment_is_single_quote() {
+        // `puts "$x y"` — the opening string fragment is exactly the `"`
+        // (col 5, len 1), not `"$` (len 2).
+        let toks = decode("puts \"$x y\"\n", "tcl", &reg());
+        // The opening `"` lands at byte/col 5 on line 0 with length 1.
+        assert!(
+            toks.contains(&(0, 5, 1)),
+            "expected a length-1 string token at col 5, got {toks:?}",
+        );
     }
 
     #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -101,16 +101,33 @@ impl CommandRegistry {
     }
 
     /// Look up a command spec by name (dialect-agnostic).
+    ///
+    /// A leading `::` (global qualifier) falls back to the bare name, so an
+    /// explicitly-global call to a built-in (`::foreach`, `::for`, …)
+    /// resolves to the same spec as its unqualified form.  Mirrors
+    /// `core/commands/registry/command_registry.py::get`.
     #[must_use]
     pub fn get(&self, name: &str) -> Option<&CommandSpec> {
-        self.by_name.get(name).and_then(|v| v.last())
+        self.by_name
+            .get(name)
+            .or_else(|| {
+                name.strip_prefix("::")
+                    .and_then(|bare| self.by_name.get(bare))
+            })
+            .and_then(|v| v.last())
     }
 
     /// Look up a command spec filtered by dialect.
+    ///
+    /// As with [`Self::get`], a leading `::` falls back to the bare name.
     #[must_use]
     pub fn get_for_dialect(&self, name: &str, dialect: DialectSet) -> Option<&CommandSpec> {
         self.by_name
             .get(name)
+            .or_else(|| {
+                name.strip_prefix("::")
+                    .and_then(|bare| self.by_name.get(bare))
+            })
             .and_then(|specs| specs.iter().rev().find(|s| s.supports_dialect(dialect)))
     }
 
@@ -528,6 +545,17 @@ mod tests {
         assert!(reg.get("for").is_some());
         assert!(reg.get("set").is_some());
         assert!(reg.get("nonexistent_command").is_none());
+    }
+
+    #[test]
+    fn get_resolves_global_qualifier_to_builtin() {
+        let reg = CommandRegistry::build_default();
+        assert!(reg.get("::foreach").is_some());
+        assert_eq!(
+            reg.get("::for").map(|s| s.name),
+            reg.get("for").map(|s| s.name)
+        );
+        assert!(reg.get("::nonexistent_command").is_none());
     }
 
     #[test]

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -688,6 +688,34 @@ impl SubCommand {
             .map(|(_, r)| *r)
     }
 
+    /// Declared option-flag names for this subcommand, filtered by
+    /// *dialect*.
+    ///
+    /// Mirrors `_subcommand_switch_names` in
+    /// `core/commands/registry/runtime.py`: per-subcommand options
+    /// (e.g. `-symbolic` / `-hard` on `file link`) flow into the
+    /// subcommand's [`crate::analyser`]-side `leading_options` so the
+    /// arity check skips them before counting positionals.  An option's
+    /// dialect membership inherits from this subcommand's `dialects`
+    /// (falling back to *`parent_dialects`*, the parent
+    /// [`CommandSpec::dialects`]) when the option itself does not pin a
+    /// dialect.
+    #[must_use]
+    pub fn switch_names(
+        &self,
+        dialect: Option<DialectSet>,
+        parent_dialects: Option<DialectSet>,
+    ) -> Vec<&'static str> {
+        let effective_parent = self.dialects.or(parent_dialects);
+        let mut names: Vec<&'static str> = Vec::new();
+        for opt in self.options {
+            if opt.supports_dialect(dialect, effective_parent) && !names.contains(&opt.name) {
+                names.push(opt.name);
+            }
+        }
+        names
+    }
+
     /// Look up enumerable argument values for the 0-based
     /// `index` *after* the subcommand word.  Returns an empty
     /// slice when this argument has no fixed value set.

--- a/tests/lsp_e2e/conftest.py
+++ b/tests/lsp_e2e/conftest.py
@@ -19,11 +19,29 @@ import pytest
 from .harness import (
     ROOT,
     LspServerClient,
+    close_all_documents_on_live_servers,
     ensure_build_info,
     native_server_bin,
     server_kind,
     server_launch_argv,
 )
+
+
+@pytest.fixture(autouse=True)
+def _close_documents_after_test() -> Iterator[None]:
+    """Close every document opened during a test on all live servers.
+
+    The ``lsp_server`` fixtures are session-scoped, so a document a test opens
+    (via a unique ``uri_factory`` URI) stays open for the rest of the session
+    unless closed.  Workspace-wide providers — cross-document references,
+    workspace symbols — then surface one test's buffer in a later, unrelated
+    test (e.g. a leftover ``proc greet`` polluting another document's
+    references and tripping its range invariants).  Closing each test's
+    documents on teardown keeps the shared servers isolated between tests
+    without paying for a fresh server per test.
+    """
+    yield
+    close_all_documents_on_live_servers()
 
 
 class _Build(NamedTuple):

--- a/tests/lsp_e2e/harness.py
+++ b/tests/lsp_e2e/harness.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import weakref
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -124,6 +125,27 @@ class LspError(AssertionError):
     """Raised when the server returns a JSON-RPC error to a request."""
 
 
+#: Every constructed :class:`LspServerClient` registers itself here so a
+#: function-scoped teardown fixture can close the documents each test opened
+#: on whichever server(s) it actually used.  A ``WeakSet`` keeps shut-down
+#: servers from lingering.  Without this the session-scoped servers accumulate
+#: every test's documents, and workspace-wide providers (cross-document
+#: references, workspace symbols) then surface one test's buffer in another's
+#: results — an order-dependent leak.
+_LIVE_CLIENTS: "weakref.WeakSet[LspServerClient]" = weakref.WeakSet()
+
+
+def close_all_documents_on_live_servers() -> None:
+    """Close every still-open document on every live server.
+
+    Called from a function-scoped autouse fixture after each test so the
+    long-lived shared servers start every test with no foreign documents
+    open.  Best-effort: a server whose process has already exited is skipped.
+    """
+    for client in list(_LIVE_CLIENTS):
+        client.close_all_documents()
+
+
 class LspServerClient:
     """Manage a language-server subprocess and talk LSP JSON-RPC to it."""
 
@@ -160,6 +182,11 @@ class LspServerClient:
         #: ``serverInfo`` from the initialize result, populated by initialize().
         self.server_info: dict | None = None
         self.initialize_result: dict | None = None
+        #: URIs currently opened (``didOpen`` without a matching ``didClose``),
+        #: so per-test teardown can close them and keep the shared server from
+        #: accumulating one test's documents into the next test's results.
+        self._open_uris: set[str] = set()
+        _LIVE_CLIENTS.add(self)
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -271,6 +298,7 @@ class LspServerClient:
                 }
             },
         )
+        self._open_uris.add(uri)
 
     def change_document(
         self,
@@ -300,6 +328,22 @@ class LspServerClient:
 
     def close_document(self, uri: str) -> None:
         self.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+        self._open_uris.discard(uri)
+
+    def close_all_documents(self) -> None:
+        """Send ``didClose`` for every still-open document on this server.
+
+        Best-effort: if the server process has already exited (or any send
+        fails during teardown) the remaining URIs are simply dropped — the
+        process is going away regardless.
+        """
+        if self._proc is None or self._proc.poll() is not None:
+            self._open_uris.clear()
+            return
+        for uri in list(self._open_uris):
+            with contextlib.suppress(Exception):
+                self.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+        self._open_uris.clear()
 
     def open_ready(
         self,

--- a/tests/test_lexer_rust_fastpath.py
+++ b/tests/test_lexer_rust_fastpath.py
@@ -1,0 +1,131 @@
+"""Tests for the Rust lexer fast-path token-type compatibility.
+
+When the ``tcl_lsp_rust`` wheel is installed, ``TclLexer.tokenise_all``
+dispatches to the Rust tokeniser, which returns PyO3 ``tcl_lsp_py.Token``
+objects.  Those tokens carry a ``PyTokenType`` enum that is equal by value
+but NOT identity-equal to ``shared.tokens.TokenType``.  The parser compares
+token types with ``is`` (e.g. ``tok.type is TokenType.VAR``), so the fast
+path must convert the foreign tokens into native ``shared.tokens.Token``
+instances or every such check silently fails.
+
+These tests monkeypatch the fast-path entry point with a fake that mimics
+the PyO3 ``Token`` surface (``.type.name`` / ``.text`` /
+``.start.line|character|offset`` / ``.end.*`` / ``.in_quote``), so they run
+even when the wheel is not built in CI.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import compiler.parsing.lexer as lexer_mod
+from compiler.parsing.lexer import TclLexer
+from shared.tokens import SourcePosition, Token, TokenType
+
+
+@dataclass(frozen=True)
+class _FakePyTokenType:
+    """Mimics ``tcl_lsp_py.TokenType`` — only ``.name`` is consumed."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class _FakePySourcePosition:
+    """Mimics ``tcl_lsp_py.SourcePosition``."""
+
+    line: int
+    character: int
+    offset: int
+
+
+@dataclass(frozen=True)
+class _FakePyToken:
+    """Mimics ``tcl_lsp_py.Token`` — distinct from ``shared.tokens.Token``."""
+
+    type: _FakePyTokenType
+    text: str
+    start: _FakePySourcePosition
+    end: _FakePySourcePosition
+    in_quote: bool = False
+
+
+def _fake_rust_tokenise(source, *_args, **_kwargs):
+    """Stand-in for ``lexer_tokenise_with_config``.
+
+    Returns one ``$var`` VAR token plus an EOL so the conversion exercises a
+    type whose ``is``-identity actually matters to the parser, along with the
+    ``in_quote`` flag round-trip.
+    """
+    tokens = [
+        _FakePyToken(
+            type=_FakePyTokenType("VAR"),
+            text="var",
+            start=_FakePySourcePosition(0, 0, 0),
+            end=_FakePySourcePosition(0, 3, 3),
+            in_quote=True,
+        ),
+        _FakePyToken(
+            type=_FakePyTokenType("EOL"),
+            text="",
+            start=_FakePySourcePosition(0, 4, 4),
+            end=_FakePySourcePosition(0, 4, 4),
+            in_quote=False,
+        ),
+    ]
+    warnings: list[tuple[SourcePosition, str]] = []
+    return tokens, warnings
+
+
+@pytest.fixture
+def _patched_fastpath(monkeypatch):
+    monkeypatch.setattr(lexer_mod, "_rust_lexer_tokenise_cfg", _fake_rust_tokenise)
+
+
+def test_fastpath_returns_native_tokens(_patched_fastpath) -> None:
+    """The fast path must yield ``shared.tokens.Token`` instances."""
+    tokens = TclLexer("$var").tokenise_all()
+    assert all(isinstance(tok, Token) for tok in tokens)
+
+
+def test_fastpath_token_type_is_identity_equal(_patched_fastpath) -> None:
+    """Converted ``.type`` must be the canonical ``TokenType`` singleton.
+
+    This is the core regression: ``tok.type is TokenType.VAR`` is how the
+    parser dispatches, and a raw ``PyTokenType`` would fail that ``is`` check.
+    """
+    tokens = TclLexer("$var").tokenise_all()
+    assert tokens[0].type is TokenType.VAR
+    assert tokens[1].type is TokenType.EOL
+
+
+def test_fastpath_preserves_positions_and_text(_patched_fastpath) -> None:
+    """Positions, text, and the quoting flag survive the conversion."""
+    tokens = TclLexer("$var").tokenise_all()
+    var = tokens[0]
+    assert var.text == "var"
+    assert var.start == SourcePosition(line=0, character=0, offset=0)
+    assert var.end == SourcePosition(line=0, character=3, offset=3)
+    assert var.in_quote is True
+    assert tokens[1].in_quote is False
+
+
+def test_fastpath_only_when_no_virtuals(_patched_fastpath) -> None:
+    """Virtual insertions force the pure-Python path (fast path skipped).
+
+    With virtuals present the lexer must not call the Rust binding (which
+    cannot model them); the returned tokens come from ``get_token`` and are
+    therefore native already.
+    """
+    lexer = TclLexer("$var", virtual_insertions={4: "]"})
+    tokens = lexer.tokenise_all()
+    assert all(isinstance(tok, Token) for tok in tokens)
+    # The fake fast path only ever emits a single VAR+EOL pair; the real
+    # Python path emits a VAR token for ``$var``.
+    assert any(tok.type is TokenType.VAR for tok in tokens)


### PR DESCRIPTION
Targets `rust` (#591, `ebd44863`).  Two strands of native-Rust-analyser work,
each commit independently gated on `cargo test --workspace --all-features`,
`cargo clippy --workspace --all-targets` (pedantic-clean), `cargo fmt`, the
`lsp_e2e` suite against the native server, and the rust-mode fp/ground-truth
precision battery — no regressions at any step.

## Results
- **fp/ground-truth precision battery (rust mode): 337 → 358 passing** (19 of
  the remaining failures closed; the analyser now matches Python on these
  cases).
- **lsp_e2e (native Rust server): 483 passing / 4 pre-existing failures** — the
  4 are O129 constant-fold, W210 use-after-unset, and a bracket-recovery case,
  all unrelated to this PR and unchanged by it.

Every behavioural change is a faithful port of the Python reference (the rule
throughout: *fix the analyser to match Python, never weaken a test*); each
landed with a ported unit test and a `docs/rust-rewrite.md` note.

## lsp_e2e gap closures
- **lexer**: convert Rust fast-path tokens to native `TokenType` (Codex P1 #588).
- **E003**: subcommand arity with per-subcommand option skipping.
- **semantic_tokens**: trim a clamped-empty ESC span so `$var` fragments don't overlap.
- **lsp_e2e harness**: close each test's documents to stop shared-server doc leak.
- **inlay_hints**: skip the `?option ...?` flag-group before the varargs stop.
- **irules_checks**: flag IRULE3102 getters nested in sink-call arguments.
- **bracket recovery**: bail when a brace word swallows a known command.

## Analyser precision (fp/ground-truth battery)
- **registry**: resolve a leading `::` to the bare builtin in `get`/`get_for_dialect`.
- **W231**: recover an `lset` list length from a `set var {…}` in the *same proc
  body* (flat-scope scan mirroring Python's `_LIST_SET_RE` + `_scope_is_flat`).
- **command-substitution recursion**: run the full per-command dispatch
  (security W101–W312, bounds, arity, style) on commands nested in `[…]`
  substitutions — the main walk treats a substitution as an opaque value, so
  `set fh [open "|$cmd" r]` / `[string index abc 99]` previously escaped every
  check.
- **W304**: stop value recovery at a shadowing proc parameter (no more `-force`
  cross-proc misattribution).
- **W306**: port the literal-expected check for `regexp`/`regsub` patterns
  (previously absent in Rust).
- **W105**: exempt a whole-word `[…]` command-substitution body (the safe
  `eval [list …]` idiom).
- **Interval abstract domain (new)**: port `compiler/intervals.py` →
  `tcl-compiler/src/intervals.rs` (interval lattice with widening fixpoint,
  guard narrowing, SCCP-seeded constants) and the bounds finder →
  `interval_bounds.rs`, driving **dynamic W230/W231/W232** on a `$var` index
  whose guard-narrowed range proves an out-of-range access — the cases the
  syntactic bounds checks skip, so the two never double-fire.
- **W211/W220**: exclude `trace`d variables from the dead-store / unused-variable
  checks (a write trace makes the variable observable).
- **type inference**: type `0x…` hex / `0b…` binary integer literals as `INT`
  (so `set n 0x80; incr n` is one clean parse, not per-iteration shimmer).
- **shimmer S102**: require genuine per-iteration oscillation — classify a
  loop-header phi's entry vs body types over the *natural loop* (suppressing
  one-time accumulator promotions and sibling-loop cross-talk).
- **shimmer S101**: the same refinement for phi-merge shimmer (skip
  empty-accumulator merges).
- **shimmer S100/S101**: treat ordering comparisons (`<` `<=` `>` `>=`), `&&`/`||`,
  and the conditional `==`/`!=` (numeric only when an operand is numeric-looking)
  as numeric expression contexts.

https://claude.ai/code/session_014GForvjimNALovkgfNdeMQ