### PR TITLE
Rust runtime: ledit / lmap / lseq + var-read-miss & empty-script fixes (Tcl 9 sweep +2006)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,8 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: release release-tag release-codeql-gate release-sums
 # Zig runtime + leak check
 .PHONY: build-runtime build-wasm-runtime build-runtime-leakcheck leakcheck leakcheck-diff snapshot-leak-baseline
+# Rust runtime port
+.PHONY: runtime-rust-test runtime-rust-lint runtime-rust-sweep
 # Sphinx docs
 .PHONY: docs docs-html docs-clean docs-linkcheck
 # Screenshots
@@ -1581,6 +1583,22 @@ leakcheck-diff: ## Diff the latest leak sweep against tests/baselines/wasm_leak_
 
 snapshot-leak-baseline: ## Promote tmp/perf-output/leak_sweep_results.json to the committed baseline
 	cp tmp/perf-output/leak_sweep_results.json tests/baselines/wasm_leak_baseline.json
+
+# Rust runtime port (runtime/rust) — standalone crate, excluded from the root
+# workspace (it is `unsafe`; root forbids `unsafe`). These are the gates the
+# rust-runtime-port doc + runtime/rust/README cite. Not wired into ci-fast /
+# prep-pr: the runtime port is a separate workstream from the LSP/compiler CI.
+RUNTIME_RUST_DIR := $(ROOT)runtime/rust
+
+runtime-rust-test: ## Run the Rust runtime port's cargo test (leak round-trip + unit/parse/eval suite)
+	cd $(RUNTIME_RUST_DIR) && cargo test
+
+runtime-rust-lint: ## Rust runtime port: cargo fmt --check + clippy -D warnings
+	cd $(RUNTIME_RUST_DIR) && cargo fmt --check && cargo clippy --all-targets -- -D warnings
+
+runtime-rust-sweep: ## Sweep the Tcl 9 tcltest suite against the Rust runtime (scoreboard); JSON=path to dump --json
+	cd $(RUNTIME_RUST_DIR) && cargo build --release --example run_script
+	TCL_LIBRARY=$(ROOT)tmp/tcl9.0.3/library python3 $(ROOT)scripts/dev/rust_tcltest_sweep.py $(if $(JSON),--json $(JSON),)
 
 # ---------------------------------------------------------------------------
 # Sphinx — dialects.f5.query Python API reference

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1702,6 +1702,25 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + TclOO expand / info prefix / hidden+safe | 122 / 168 | 45 | 8529 / 18775 |
 | + cross-interp aliases | 122 / 168 | 45 | 8546 / 18775 |
 | + auto-load fixes + re-entrant Safe Base | **124 / 168** | 43 (+1 timeout) | **8654 / 18939** |
+| + `ledit` + three-way var-read-miss error | **124 / 168** | 43 (+1 timeout) | **10448 / 18939** |
+
+The 2026-06-13 increment (**+1794 tests, 45.7% → 55.2%**, zero regressions):
+
+- **`ledit listVar first last ?element ...?`** (`cmd_list.rs`) — the Tcl 8.7/9.0
+  in-place `lreplace` on a list *variable*. Shares `lreplace`'s index/clamp/
+  replace logic (mirroring the Zig oracle's shared `do_lreplace`, `cmds/list.zig`,
+  and C's `Tcl_LeditObjCmd`, `tclCmdIL.c`): read the var (error on a miss, which
+  C does via `TCL_LEAVE_ERR_MSG`), splice the `[first,last]` range, store the new
+  list back, return it; addresses `a(k)` array elements like `set`/`lappend`.
+  `lreplace.test` **1790 → 3578 / 3579** (the lone residual is a pre-existing
+  backslash-trailing-space list-quoting edge in `Tcl_ConvertElement`, shared by
+  all list rendering — not a `ledit` bug).
+- **three-way variable-read-miss error** (`interp.rs::read_miss_msg`, routed from
+  `set`/`ledit`/`expr $var`) — `tclVar.c`'s distinction: a scalar read of an
+  array is `variable is array`, a missing element of an *existing* array is `no
+  such element in array` (previously wrongly `no such variable`), and a wholly
+  missing variable is `no such variable`. Lifted `set.test`/`set-old.test`/
+  `trace.test` (+6 beyond `ledit`).
 
 Cumulative: **+36 files** now run to a tcltest summary, errored-before-summary
 **81 → 45**, **+2974 tests pass**, and **zero panics** (the passed *count*
@@ -1931,6 +1950,26 @@ conflicts**.
   (2434) all pass — the expr/number/glob convergence behaves identically against
   the newer lexer.
 
+### SYNC inbound — 2026-06-13 (`ledit` + var-read-miss; audit re-baseline)
+
+Chunk: `ledit` + the three-way variable-read-miss error (scoreboard above).
+
+- **Derived from C, cross-checked vs the Zig oracle.** `ledit` was written
+  against C's `Tcl_LeditObjCmd` (`tmp/tcl9.0.3/generic/tclCmdIL.c`) and the
+  `no such element in array` distinction against `tclVar.c`; both were confirmed
+  consistent with the Zig oracle (`runtime/zig/cmds/list.zig`'s shared
+  `do_lreplace`, and `runtime/zig/cmds/var.zig`). No Zig behavioural fix was
+  back-ported — the port matches the same C control flow the Zig oracle does.
+- **Audit note (mirror anchor still `8150eca`).** `git log 8150eca..origin/rust
+  -- runtime/zig/` is **no longer empty** (it was, as of #555): the post-#555
+  main-rebases (#573 onto `0becf577`, then #583/#595/#596) carried main's Zig
+  evolution onto the branch — a large diff (≈119 files) that is the **general
+  Zig-on-main churn**, *not* a behavioural fix to a Rust-ported module triggered
+  by this chunk. Reconciling that diff against the per-module mirror baselines is
+  its own (pre-existing) audit task, independent of `ledit`/read-miss; recorded
+  here so it is not lost. The top-of-doc mirror hash is intentionally left at
+  `8150eca` until a deliberate re-baseline.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_
@@ -2074,8 +2113,11 @@ compiler/LSP or the Zig runtime.
     `CmdFrame` source/line stack; PC-3 `uplevel` + `eval` + generalised `upvar`;
     PC-4 exceptions (`error`/`catch`/`return -options` + `errorInfo`); PC-5
     `info level`/`info frame`/`source`; PC-6 AOT interop.
-11. **Run the real Tcl library + `tcltest`** (new north-star bring-up — see
-    [`tcltest-bringup.md`](tcltest-bringup.md)). Run the **unmodified** pure-Tcl
+11. ◐ **Run the real Tcl library + `tcltest`** (new north-star bring-up — see
+    [`tcltest-bringup.md`](tcltest-bringup.md); **in progress** — sweep at
+    **10448/18939**, the 2026-06-13 `ledit` + var-read-miss increment landed the
+    list-command surface that `lreplace.test`/`set*.test` exercise). Run the
+    **unmodified** pure-Tcl
     `init.tcl`/`tcltest.tcl` + real C-Tcl-9 `*.test` files by **porting the C
     command surface** (not re-porting the library): L1 eval/exception/
     introspection core (`eval`/`uplevel`/`apply`/`subst`/`catch`/`error`/`return

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1704,8 +1704,9 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + auto-load fixes + re-entrant Safe Base | **124 / 168** | 43 (+1 timeout) | **8654 / 18939** |
 | + `ledit` + three-way var-read-miss error | **124 / 168** | 43 (+1 timeout) | **10448 / 18939** |
 | + `lmap` + empty-script result reset | **125 / 168** | 43 (0 timeout) | **10566 / 19027** |
+| + `lseq` (arithmetic-series generator) | **125 / 168** | 43 (0 timeout) | **10660 / 19027** |
 
-The 2026-06-13 increments (**+1912 tests, 45.7% → 55.5%**, zero regressions):
+The 2026-06-13 increments (**+2006 tests, 45.7% → 56.0%**, zero regressions):
 
 - **`ledit listVar first last ?element ...?`** (`cmd_list.rs`) — the Tcl 8.7/9.0
   in-place `lreplace` on a list *variable*. Shares `lreplace`'s index/clamp/
@@ -1732,6 +1733,20 @@ The 2026-06-13 increments (**+1912 tests, 45.7% → 55.5%**, zero regressions):
   by an `lmap` body of `{}`, also affects empty proc bodies / `eval {}`). Rippled
   +6 `uplevel.test`, recovered `for.test` from a timeout (+51), +1 each to
   `if`/`compile`/`execute`/`namespace-old`.
+- **`lseq start ?(..|to)? end ??by? step?`** / `lseq start count count …` /
+  `lseq count …` (`cmd_lseq.rs`, new module, `have_tommath`-gated) — the
+  arithmetic-series generator, ported from C's `Tcl_LseqObjCmd` +
+  `TclNewArithSeriesObj`: the argument-decode key, the `..`/`to`/`count`/`by`
+  keywords, expression-valued arguments (via `eval_expr_obj`), int-vs-double
+  selection, the `ArithSeriesLenInt`/`ArithSeriesLenDbl` length formula, and the
+  `maxObjPrecision`/`ArithRound` double-precision matching (`lseq 0 0.5 by 0.1` →
+  `0.0 0.1 0.2 0.3 0.4 0.5`). We materialise a concrete list (C's lazy abstract
+  series is representation-only, incompatible-by-design) and cap at 100M elements
+  with C's "max length of a Tcl list exceeded" rather than OOM-aborting on the
+  multi-billion-element lazy-series tests. `lseq.test` **0 → 94 / 134** (the
+  remainder are `tcl::unsupported::representation` / lazy-series / extreme-
+  magnitude `1e50`-formatting cases — the last a pre-existing `tcl-syntax`
+  `format_double` limitation, not `lseq`).
 
 Cumulative: **+36 files** now run to a tcltest summary, errored-before-summary
 **81 → 45**, **+2974 tests pass**, and **zero panics** (the passed *count*
@@ -1961,12 +1976,14 @@ conflicts**.
   (2434) all pass — the expr/number/glob convergence behaves identically against
   the newer lexer.
 
-### SYNC inbound — 2026-06-13 (`ledit`/`lmap` + var-read-miss + eval-reset; audit re-baseline)
+### SYNC inbound — 2026-06-13 (`ledit`/`lmap`/`lseq` + var-read-miss + eval-reset; audit re-baseline)
 
-Chunks: `ledit`, `lmap`, the three-way variable-read-miss error, and the
-empty-script result reset (scoreboard above). `lmap` was written against C's
+Chunks: `ledit`, `lmap`, `lseq`, the three-way variable-read-miss error, and
+the empty-script result reset (scoreboard above). `lmap` was written against C's
 shared `EachloopCmd` (`tclCmdAH.c`, `TCL_EACH_COLLECT`) — `foreach` refactored to
-the same engine; the empty-script reset matches `Tcl_EvalEx` (`tclBasic.c`).
+the same engine; `lseq` against `Tcl_LseqObjCmd`/`TclNewArithSeriesObj`
+(`tclCmdIL.c`/`tclArithSeries.c`); the empty-script reset matches `Tcl_EvalEx`
+(`tclBasic.c`).
 
 - **Derived from C, cross-checked vs the Zig oracle.** `ledit` was written
   against C's `Tcl_LeditObjCmd` (`tmp/tcl9.0.3/generic/tclCmdIL.c`) and the
@@ -2129,9 +2146,9 @@ compiler/LSP or the Zig runtime.
     `info level`/`info frame`/`source`; PC-6 AOT interop.
 11. ◐ **Run the real Tcl library + `tcltest`** (new north-star bring-up — see
     [`tcltest-bringup.md`](tcltest-bringup.md); **in progress** — sweep at
-    **10566/19027**, the 2026-06-13 `ledit`/`lmap` + var-read-miss + empty-script
-    reset increments landed the list/loop-command surface that `lreplace.test`/
-    `lmap.test`/`set*.test` exercise). Run the **unmodified** pure-Tcl
+    **10660/19027**, the 2026-06-13 `ledit`/`lmap`/`lseq` + var-read-miss +
+    empty-script reset increments landed the list/loop-command surface that
+    `lreplace.test`/`lmap.test`/`lseq.test`/`set*.test` exercise). Run the **unmodified** pure-Tcl
     `init.tcl`/`tcltest.tcl` + real C-Tcl-9 `*.test` files by **porting the C
     command surface** (not re-porting the library): L1 eval/exception/
     introspection core (`eval`/`uplevel`/`apply`/`subst`/`catch`/`error`/`return

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -1703,8 +1703,9 @@ The Rust interpreter runs the real Tcl 9 suite end-to-end (real `tcltest`
 | + cross-interp aliases | 122 / 168 | 45 | 8546 / 18775 |
 | + auto-load fixes + re-entrant Safe Base | **124 / 168** | 43 (+1 timeout) | **8654 / 18939** |
 | + `ledit` + three-way var-read-miss error | **124 / 168** | 43 (+1 timeout) | **10448 / 18939** |
+| + `lmap` + empty-script result reset | **125 / 168** | 43 (0 timeout) | **10566 / 19027** |
 
-The 2026-06-13 increment (**+1794 tests, 45.7% → 55.2%**, zero regressions):
+The 2026-06-13 increments (**+1912 tests, 45.7% → 55.5%**, zero regressions):
 
 - **`ledit listVar first last ?element ...?`** (`cmd_list.rs`) — the Tcl 8.7/9.0
   in-place `lreplace` on a list *variable*. Shares `lreplace`'s index/clamp/
@@ -1721,6 +1722,16 @@ The 2026-06-13 increment (**+1794 tests, 45.7% → 55.2%**, zero regressions):
   such element in array` (previously wrongly `no such variable`), and a wholly
   missing variable is `no such variable`. Lifted `set.test`/`set-old.test`/
   `trace.test` (+6 beyond `ledit`).
+- **`lmap varList list ?varList list ...? body`** (`cmd_control.rs`) — `foreach`
+  that collects each non-`continue` body result into a list (refactored `foreach`
+  into a shared `each_loop(collect)` engine, mirroring C's one `EachloopCmd`,
+  `tclCmdAH.c`). `lmap.test` **0 → 57 / 66**.
+- **empty-script result reset** (`interp.rs::eval_script`) — a script with no
+  commands (empty / whitespace / comments only) now resets the result to `""`, as
+  C's `Tcl_EvalEx` does; previously a stale prior result leaked through (surfaced
+  by an `lmap` body of `{}`, also affects empty proc bodies / `eval {}`). Rippled
+  +6 `uplevel.test`, recovered `for.test` from a timeout (+51), +1 each to
+  `if`/`compile`/`execute`/`namespace-old`.
 
 Cumulative: **+36 files** now run to a tcltest summary, errored-before-summary
 **81 → 45**, **+2974 tests pass**, and **zero panics** (the passed *count*
@@ -1950,9 +1961,12 @@ conflicts**.
   (2434) all pass — the expr/number/glob convergence behaves identically against
   the newer lexer.
 
-### SYNC inbound — 2026-06-13 (`ledit` + var-read-miss; audit re-baseline)
+### SYNC inbound — 2026-06-13 (`ledit`/`lmap` + var-read-miss + eval-reset; audit re-baseline)
 
-Chunk: `ledit` + the three-way variable-read-miss error (scoreboard above).
+Chunks: `ledit`, `lmap`, the three-way variable-read-miss error, and the
+empty-script result reset (scoreboard above). `lmap` was written against C's
+shared `EachloopCmd` (`tclCmdAH.c`, `TCL_EACH_COLLECT`) — `foreach` refactored to
+the same engine; the empty-script reset matches `Tcl_EvalEx` (`tclBasic.c`).
 
 - **Derived from C, cross-checked vs the Zig oracle.** `ledit` was written
   against C's `Tcl_LeditObjCmd` (`tmp/tcl9.0.3/generic/tclCmdIL.c`) and the
@@ -2115,9 +2129,9 @@ compiler/LSP or the Zig runtime.
     `info level`/`info frame`/`source`; PC-6 AOT interop.
 11. ◐ **Run the real Tcl library + `tcltest`** (new north-star bring-up — see
     [`tcltest-bringup.md`](tcltest-bringup.md); **in progress** — sweep at
-    **10448/18939**, the 2026-06-13 `ledit` + var-read-miss increment landed the
-    list-command surface that `lreplace.test`/`set*.test` exercise). Run the
-    **unmodified** pure-Tcl
+    **10566/19027**, the 2026-06-13 `ledit`/`lmap` + var-read-miss + empty-script
+    reset increments landed the list/loop-command surface that `lreplace.test`/
+    `lmap.test`/`set*.test` exercise). Run the **unmodified** pure-Tcl
     `init.tcl`/`tcltest.tcl` + real C-Tcl-9 `*.test` files by **porting the C
     command surface** (not re-porting the library): L1 eval/exception/
     introspection core (`eval`/`uplevel`/`apply`/`subst`/`catch`/`error`/`return

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -34,6 +34,8 @@ pub fn install(interp: &mut Interp) {
     #[cfg(have_tommath)]
     crate::cmd_mathop::install(interp);
     crate::cmd_list::install(interp);
+    #[cfg(have_tommath)]
+    crate::cmd_lseq::install(interp);
     crate::cmd_dict::install(interp);
     crate::cmd_string::install(interp);
     crate::cmd_alias::install(interp);
@@ -592,6 +594,29 @@ fn expr_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         // trace at the inner command — preserve it (no `expr` frame).
         Err(_) if propagated => Code::Error,
         Err(e) => interp.set_error(&e.0),
+    }
+}
+
+/// Evaluate `src` as a Tcl expression, returning the result object (owned — the
+/// caller holds a `+1` and must release it) or the error `Code` (interp result =
+/// message). Used where an argument "may be a valid expression" — e.g. `lseq`'s
+/// numeric arguments (`SequenceIdentifyArgument`).
+#[cfg(have_tommath)]
+pub(crate) fn eval_expr_obj(interp: &mut Interp, src: &[u8]) -> Result<*mut TclObj, Code> {
+    let Ok(s) = core::str::from_utf8(src) else {
+        return Err(interp.set_error(b"expr operand is not valid UTF-8"));
+    };
+    let node = tcl_syntax::expr::parse_expr(s, None);
+    let mut ctx = InterpExprCtx {
+        interp: &mut *interp,
+        propagated: false,
+    };
+    let result = crate::expr::eval_expr(&node, &mut ctx);
+    let propagated = ctx.propagated;
+    match result {
+        Ok(r) => Ok(r.into_raw()), // transfer the +1 to the caller
+        Err(_) if propagated => Err(Code::Error),
+        Err(e) => Err(interp.set_error(&e.0)),
     }
 }
 

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -96,16 +96,11 @@ fn set(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     Code::Ok
                 }
                 None => {
-                    // A scalar read of an array name is "variable is array", not
-                    // "no such variable" (the array-vs-scalar distinction Tcl
-                    // reports — matches `var_error(IsArray)`).
-                    let mut msg = b"can't read \"".to_vec();
-                    msg.extend_from_slice(&name);
-                    if elem.is_none() && interp.var_is_array(&base) {
-                        msg.extend_from_slice(b"\": variable is array");
-                    } else {
-                        msg.extend_from_slice(b"\": no such variable");
-                    }
+                    // The C three-way distinction (`tclVar.c`): scalar read of an
+                    // array ("variable is array"), missing element of an existing
+                    // array ("no such element in array"), or wholly missing
+                    // variable ("no such variable").
+                    let msg = interp.read_miss_msg(&base, elem.as_deref());
                     interp.set_error(&msg)
                 }
             }
@@ -525,9 +520,7 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
         match obj {
             Some(o) => Ok(crate::expr::Owned::retain(o)),
             None => {
-                let mut m = b"can't read \"".to_vec();
-                m.extend_from_slice(name.as_bytes());
-                m.extend_from_slice(b"\": no such variable");
+                let m = self.interp.read_miss_msg(&base, elem.as_deref());
                 Err(crate::expr::ExprError(m))
             }
         }

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -1,5 +1,5 @@
 //! Control flow (toward executing scripts) — `if` / `while` / `for` / `foreach`
-//! plus `break` / `continue`.
+//! / `lmap` plus `break` / `continue`.
 //!
 //! Bodies evaluate through the eval loop ([`Interp::eval_str`]); a body that
 //! completes with `break`/`continue` is caught by the enclosing loop, while
@@ -21,6 +21,7 @@ pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"break", break_cmd);
     interp.register_builtin(b"continue", continue_cmd);
     interp.register_builtin(b"foreach", foreach);
+    interp.register_builtin(b"lmap", lmap);
     // `if`/`while`/`for` test Tcl expressions → need the numeric tower.
     #[cfg(have_tommath)]
     {
@@ -172,14 +173,37 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-// -- foreach ---------------------------------------------------------------
+// -- foreach / lmap --------------------------------------------------------
 
 /// `foreach varList list ?varList list ...? body` — iterate one or more
 /// (var-list, value-list) groups in parallel, padding exhausted lists with `""`.
 fn foreach(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    // [foreach] + N×(varlist, list) pairs + body ⇒ an even arg count ≥ 4.
+    each_loop(interp, argv, false)
+}
+
+/// `lmap varList list ?varList list ...? body` — `foreach` that collects each
+/// (non-`continue`) body result into a list and returns it. `break` ends the
+/// loop and returns the list accumulated so far. Mirrors C's `EachloopCmd`
+/// (`tclCmdAH.c`) with `TCL_EACH_COLLECT`.
+fn lmap(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    each_loop(interp, argv, true)
+}
+
+/// Shared `foreach`/`lmap` engine. With `collect`, each successful body result
+/// is appended to a result list (the `lmap` return value); without, the result
+/// is the empty string (`foreach`). The two differ only in result collection
+/// and the body-frame command name — exactly as C factors them through one
+/// `EachloopCmd`.
+fn each_loop(interp: &mut Interp, argv: &[*mut TclObj], collect: bool) -> Code {
+    let name: &[u8] = if collect { b"lmap" } else { b"foreach" };
+    // [cmd] + N×(varlist, list) pairs + body ⇒ an even arg count ≥ 4.
     if argv.len() < 4 || argv.len() % 2 != 0 {
-        return wrong_args(interp, b"foreach varList list ?varList list ...? command");
+        let usage: &[u8] = if collect {
+            b"lmap varList list ?varList list ...? command"
+        } else {
+            b"foreach varList list ?varList list ...? command"
+        };
+        return wrong_args(interp, usage);
     }
     let body = obj_bytes(argv[argv.len() - 1]);
 
@@ -195,7 +219,9 @@ fn foreach(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Err(e) => return interp.set_error(e.message()),
         };
         if vars.is_empty() {
-            return interp.set_error(b"foreach varlist is empty");
+            let mut m = name.to_vec();
+            m.extend_from_slice(b" varlist is empty");
+            return interp.set_error(&m);
         }
         let vals = match crate::parse::split_list(&obj_bytes(pair[1])) {
             Ok(v) => v,
@@ -205,6 +231,9 @@ fn foreach(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         groups.push((vars, vals));
     }
 
+    // Collected body results (bytes; rematerialised into the result list at the
+    // end). Only populated for `lmap`.
+    let mut collected: Vec<Vec<u8>> = Vec::new();
     for it in 0..iterations {
         for (vars, vals) in &groups {
             for (k, var) in vars.iter().enumerate() {
@@ -217,25 +246,36 @@ fn foreach(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
         match interp.eval_str(&body) {
-            Code::Ok | Code::Continue => {}
+            Code::Ok => {
+                if collect {
+                    collected.push(obj_bytes(interp.get_obj_result()));
+                }
+            }
+            Code::Continue => {} // skip collection, keep looping
             Code::Break => break,
             Code::Error => {
-                // `("foreach" body line N)` — only at top level. Tcl inlines
-                // `foreach` when it compiles the enclosing script (a proc body),
-                // so no body-frame appears there; an uncompiled top-level
-                // `foreach` runs its command form, which does add the frame.
-                // (`if`/`while`/`for` are always inlined → never a frame.) A
+                // `("<cmd>" body line N)` — only at top level. Tcl inlines
+                // `foreach`/`lmap` when it compiles the enclosing script (a proc
+                // body), so no body-frame appears there; an uncompiled top-level
+                // form runs its command form, which does add the frame. A
                 // tree-walker has no bytecode, so `!in_proc()` approximates the
                 // compilation boundary — matches tclsh 9.0 for both cases.
                 if !interp.in_proc() {
-                    interp.append_body_frame(b"foreach");
+                    interp.append_body_frame(name);
                 }
                 return Code::Error;
             }
             other => return other,
         }
     }
-    interp.set_result_bytes(b"");
+    if collect {
+        // Rematerialise into a list; `new_list_obj` takes a +1 on each fresh
+        // (rc-0) element, so the list owns them — no `drop_fresh` here.
+        let objs: Vec<*mut TclObj> = collected.iter().map(|b| new_string(b)).collect();
+        interp.set_result(crate::list::new_list_obj(&objs));
+    } else {
+        interp.set_result_bytes(b"");
+    }
     Code::Ok
 }
 
@@ -344,6 +384,32 @@ mod tests {
                 ),
                 b"1x 2y z "
             );
+        });
+    }
+
+    #[test]
+    fn lmap_collects_results() {
+        leak_free(|i| {
+            // Single-var collect.
+            assert_eq!(run(i, b"lmap x {a b c} {string toupper $x}"), b"A B C");
+            // Multi-var per iteration → one element per iteration.
+            assert_eq!(run(i, b"lmap {a b} {1 2 3 4} {list $a $b}"), b"{1 2} {3 4}");
+            // Parallel lists pad with "".
+            assert_eq!(
+                run(i, b"lmap a {1 2} b {x y z} {list $a $b}"),
+                b"{1 x} {2 y} {{} z}"
+            );
+            // `continue` skips collection; `break` ends with the list so far.
+            assert_eq!(
+                run(i, b"lmap x {1 2 3 4} {if {$x % 2 == 0} continue; set x}"),
+                b"1 3"
+            );
+            assert_eq!(
+                run(i, b"lmap x {1 2 3 4} {if {$x == 3} break; set x}"),
+                b"1 2"
+            );
+            // Empty body → one empty element per iteration.
+            assert_eq!(run(i, b"lmap x {1 2 3} {}"), b"{} {} {}");
         });
     }
 }

--- a/runtime/rust/src/cmd_list.rs
+++ b/runtime/rust/src/cmd_list.rs
@@ -1,7 +1,7 @@
 //! List commands (T1.6) — `list` / `llength` / `lindex` / `lappend` / `lrange`
 //! / `lreverse` / `concat` / `join` / `split` / `lassign`, over the [`crate::list`]
-//! value type. (`lsort`/`lsearch`/`lset`/`linsert`/`lreplace`/`lrepeat` follow,
-//! once string match/comparison lands.)
+//! value type. (`lsort`/`lsearch`/`lset`/`linsert`/`lreplace`/`ledit`/`lrepeat`
+//! follow, once string match/comparison lands.)
 //!
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -25,6 +25,7 @@ pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"lrepeat", lrepeat);
     interp.register_builtin(b"linsert", linsert);
     interp.register_builtin(b"lreplace", lreplace);
+    interp.register_builtin(b"ledit", ledit);
     interp.register_builtin(b"lsearch", lsearch);
     interp.register_builtin(b"lsort", lsort);
 }
@@ -509,6 +510,66 @@ fn lreplace(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
+/// `ledit listVar first last ?element ...?` — the in-place `lreplace` on a list
+/// *variable* (Tcl 8.7/9.0). Reads `listVar`, replaces the `[first,last]` range
+/// with the new elements, stores the result back into the variable, and returns
+/// the new list value. Mirrors `Tcl_LeditObjCmd` (`tclCmdIL.c`): the variable
+/// must already exist (a read miss is `can't read ...: no such variable`), the
+/// index clamping is identical to `lreplace`, and `listVar` may name an array
+/// element (`a(k)`), addressed like `set`/`lappend`.
+fn ledit(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(interp, b"ledit listVar first last ?element ...?");
+    }
+    let name = obj_bytes(argv[1]);
+    let (base, elem) = crate::frame::split_array_ref(&name);
+    let cur = match &elem {
+        Some(k) => interp.var_get_elem(&base, k),
+        None => interp.var_get(&base),
+    };
+    let Some(listobj) = cur else {
+        // C reads via `Tcl_ObjGetVar2(..., TCL_LEAVE_ERR_MSG)`: a missing
+        // variable is a read error, with the C three-way distinction
+        // (variable-is-array / no-such-element / no-such-variable).
+        let msg = interp.read_miss_msg(&base, elem.as_deref());
+        return interp.set_error(&msg);
+    };
+    let elems = match list::list_elements(listobj) {
+        Ok(v) => v,
+        Err(e) => return bad_list(interp, e),
+    };
+    let len = elems.len();
+    let Some(first) = index_spec(&obj_bytes(argv[2]), len) else {
+        return bad_index(interp, &obj_bytes(argv[2]));
+    };
+    let Some(last) = index_spec(&obj_bytes(argv[3]), len) else {
+        return bad_index(interp, &obj_bytes(argv[3]));
+    };
+    let lo = first.max(0).min(len as isize) as usize;
+    let hi = ((last + 1).max(0) as usize).clamp(lo, len);
+    let mut out: Vec<*mut TclObj> = Vec::with_capacity(len + argv.len());
+    out.extend_from_slice(&elems[..lo]);
+    out.extend_from_slice(&argv[4..]);
+    out.extend_from_slice(&elems[hi..]);
+    // Build the new list first (retains every element), *then* store it: the
+    // store releases the old value, but the elements survive because the new
+    // list now holds its own refs. `new_list_obj` is rc 0; `var_set*` retains it.
+    let newlist = list::new_list_obj(&out);
+    let stored = match &elem {
+        Some(k) => interp.var_set_elem(&base, k, newlist),
+        None => interp.var_set(&base, newlist),
+    };
+    if stored.is_err() {
+        drop_fresh(newlist);
+        let mut m = b"can't set \"".to_vec();
+        m.extend_from_slice(&name);
+        m.extend_from_slice(b"\": variable is array");
+        return interp.set_error(&m);
+    }
+    interp.set_result(newlist);
+    Code::Ok
+}
+
 /// `lsearch ?-exact|-glob? ?-nocase? ?-all? ?-not? ?-inline? list pattern`.
 fn lsearch(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let (mut glob, mut nocase, mut all, mut not, mut inline) = (true, false, false, false, false);
@@ -738,6 +799,74 @@ mod tests {
         assert_eq!(ok(b"lreplace {a b c d} 1 2"), b"a d");
         assert_eq!(ok(b"lreplace {a b c} end end Z"), b"a b Z");
         assert_eq!(ok(b"lreplace {a b c} 1 0 X"), b"a X b c"); // first>last → insert
+    }
+
+    #[test]
+    fn ledit_replaces_in_place() {
+        // Returns the new value *and* updates the variable in place.
+        assert_eq!(ok(b"set l {1 2 3 4 5}; ledit l 1 1 a"), b"1 a 3 4 5");
+        assert_eq!(ok(b"set l {1 2 3 4 5}; ledit l 1 1 a; set l"), b"1 a 3 4 5");
+        assert_eq!(ok(b"set l {1 2 3 4 5}; ledit l 1 3; set l"), b"1 5");
+        assert_eq!(ok(b"set l {1 2 3}; ledit l 1 0 x y; set l"), b"1 x y 2 3"); // first>last
+        assert_eq!(ok(b"set l {a b c d}; ledit l end-1 end Z"), b"a b Z");
+        assert_eq!(ok(b"set l {a b}; ledit l end+1 end+1 c"), b"a b c"); // append
+                                                                         // Array-element addressing, like `lappend a(k)`.
+        assert_eq!(
+            ok(b"set a(k) {1 2 3}; ledit a(k) 0 0 X; set a(k)"),
+            b"X 2 3"
+        );
+        // COW: a shared value isn't mutated through the alias.
+        assert_eq!(
+            ok(b"set l {a b c}; set m $l; ledit l 0 0 X; list $l $m"),
+            b"{X b c} {a b c}"
+        );
+    }
+
+    #[test]
+    fn ledit_errors() {
+        let (c, b) = run(b"ledit l 0");
+        assert_eq!(c, Code::Error);
+        assert_eq!(
+            b,
+            b"wrong # args: should be \"ledit listVar first last ?element ...?\""
+        );
+        // A wholly missing variable is a read error (C's TCL_LEAVE_ERR_MSG).
+        let (c, b) = run(b"ledit nope 0 0 x");
+        assert_eq!(c, Code::Error);
+        assert_eq!(b, b"can't read \"nope\": no such variable");
+        // Missing element of an existing array → "no such element in array".
+        let (c, b) = run(b"set arr(y) y; ledit arr(x) 0 0 z");
+        assert_eq!(c, Code::Error);
+        assert_eq!(b, b"can't read \"arr(x)\": no such element in array");
+    }
+
+    #[test]
+    fn var_read_miss_three_way() {
+        // The C `tclVar.c` distinction, shared by `set`/`ledit`/`expr $var`.
+        let (c, b) = run(b"set nope");
+        assert_eq!(
+            (c, b),
+            (
+                Code::Error,
+                b"can't read \"nope\": no such variable".to_vec()
+            )
+        );
+        let (c, b) = run(b"set arr(y) y; set arr");
+        assert_eq!(
+            (c, b),
+            (
+                Code::Error,
+                b"can't read \"arr\": variable is array".to_vec()
+            )
+        );
+        let (c, b) = run(b"set arr(y) y; set arr(x)");
+        assert_eq!(
+            (c, b),
+            (
+                Code::Error,
+                b"can't read \"arr(x)\": no such element in array".to_vec()
+            )
+        );
     }
 
     #[test]

--- a/runtime/rust/src/cmd_lseq.rs
+++ b/runtime/rust/src/cmd_lseq.rs
@@ -1,0 +1,572 @@
+//! `lseq` (Tcl 8.7/9.0) — arithmetic-sequence list generator.
+//!
+//! ```text
+//! lseq start ?(..|to)? end ??by? step?
+//! lseq start count count ??by? step?
+//! lseq count ?by step?
+//! ```
+//!
+//! Ported from C's `Tcl_LseqObjCmd` (`tclCmdIL.c`) + `TclNewArithSeriesObj`
+//! (`tclArithSeries.c`): the same argument-decode key, the same `..`/`to`/
+//! `count`/`by` keywords, the same int-vs-double selection and length formula
+//! (`ArithSeriesLenInt`/`ArithSeriesLenDbl`), and the same double-precision
+//! matching (`maxObjPrecision`/`ArithRound`) so e.g. `lseq 0 0.5 by 0.1` →
+//! `0.0 0.1 0.2 0.3 0.4 0.5`. We materialise a concrete list (the C lazy
+//! abstract-list object is representation-only and incompatible-by-design).
+//!
+//! Needs the numeric tower (`expr` for expression-valued arguments, doubles), so
+//! the whole module is gated on `have_tommath` like `if`/`while`/`for`.
+//!
+//! Semantics verified against tclsh 9.0.
+//!
+//! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![cfg(have_tommath)]
+
+use crate::interp::{obj_bytes, Code, Interp};
+use crate::obj::{self, TclObj};
+use tcl_syntax::number::{self, Number};
+
+/// Register `lseq`.
+pub fn install(interp: &mut Interp) {
+    interp.register_builtin(b"lseq", lseq);
+}
+
+/// We materialise a concrete list (the C lazy *abstract* series is
+/// representation-only, incompatible-by-design — `lseq 10 2147483647` builds a
+/// 2-billion-element series lazily in C). Beyond this cap we raise C's
+/// `TclNewArithSeriesObj` "max length" error rather than OOM-aborting; no
+/// legitimate behavioural test asks for a list anywhere near this size.
+const MAX_MATERIALIZE: i64 = 100_000_000;
+
+/// A range/operation keyword.
+#[derive(Clone, Copy, PartialEq)]
+enum Op {
+    Dots,  // ".."
+    To,    // "to"
+    Count, // "count"
+    By,    // "by"
+}
+
+/// A decoded numeric argument: its int and double views, whether it is a double,
+/// and the fractional-digit precision of its source text (for double sequences).
+#[derive(Clone, Copy)]
+struct Num {
+    is_double: bool,
+    i: i64,
+    d: f64,
+    prec: u32,
+}
+
+/// One decoded argument.
+enum Arg {
+    Num(Num),
+    Kw(Op),
+}
+
+/// Fractional-digit count of a number's source text (`ObjPrecision`): the digits
+/// after `.`, or 0 for an integer or `e`-notation.
+fn frac_digits(s: &[u8]) -> u32 {
+    if s.iter().any(|&c| c == b'e' || c == b'E') {
+        return 0;
+    }
+    match s.iter().position(|&c| c == b'.') {
+        Some(dot) => (s.len() - dot - 1) as u32,
+        None => 0,
+    }
+}
+
+/// Classify `bytes` as a plain numeric literal (the `Tcl_GetNumberFromObj` step),
+/// or `None` if it is not a number (a keyword or an expression).
+fn as_number(bytes: &[u8]) -> Option<Num> {
+    let s = core::str::from_utf8(bytes).ok()?;
+    match number::parse_whole(s)? {
+        Number::Int(v) => Some(Num {
+            is_double: false,
+            i: v,
+            d: v as f64,
+            prec: 0,
+        }),
+        Number::Double(f) => Some(Num {
+            is_double: true,
+            i: f as i64,
+            d: f,
+            prec: frac_digits(bytes),
+        }),
+        Number::Nan { .. } => Some(Num {
+            is_double: true,
+            i: 0,
+            d: f64::NAN,
+            prec: 0,
+        }),
+        // A bignum literal: C's `assignNumber` rejects `TCL_NUMBER_BIG`.
+        Number::Big { .. } => None,
+    }
+}
+
+/// Match a range keyword.
+fn as_keyword(bytes: &[u8]) -> Option<Op> {
+    match bytes {
+        b".." => Some(Op::Dots),
+        b"to" => Some(Op::To),
+        b"count" => Some(Op::Count),
+        b"by" => Some(Op::By),
+        _ => None,
+    }
+}
+
+fn syntax_err(interp: &mut Interp) -> Code {
+    interp.set_error(b"wrong # args: should be \"lseq n ??op? n ??by? n??\"")
+}
+
+fn lseq(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    let nargs = argv.len() - 1;
+    if nargs == 0 || nargs > 5 {
+        return syntax_err(interp);
+    }
+
+    // -- decode each argument (the `SequenceIdentifyArgument` state machine) ---
+    // `allowed_num`/`allowed_kw` gate what each position may be; after a keyword
+    // only a number is allowed; a number after the first restricts when the next
+    // may be a keyword (mirrors C's `remNums`/`allowedArgs`).
+    let mut decoded: Vec<Arg> = Vec::with_capacity(nargs);
+    let mut use_doubles = 0u32;
+    let mut allowed_num = true;
+    let mut allowed_kw = false;
+    let mut rem_nums = 3i32;
+    for (idx, &a) in argv[1..].iter().enumerate() {
+        let bytes = obj_bytes(a);
+        let is_last = idx == nargs - 1;
+        // 1) a plain number (when numbers are allowed here);
+        let num = if allowed_num { as_number(&bytes) } else { None };
+        if let Some(n) = num {
+            if n.is_double {
+                use_doubles += 1;
+            }
+            decoded.push(Arg::Num(n));
+            rem_nums -= 1;
+            // After a number: a keyword is allowed next; a further number too,
+            // unless this is the last number with exactly two args remaining.
+            allowed_kw = true;
+            allowed_num = !(rem_nums == 1 && (nargs - 1 - idx) == 2);
+            continue;
+        }
+        // 2) a range keyword (when allowed);
+        if allowed_kw {
+            if let Some(op) = as_keyword(&bytes) {
+                if is_last {
+                    let mut m = b"missing \"".to_vec();
+                    m.extend_from_slice(&bytes);
+                    m.extend_from_slice(b"\" value.");
+                    return interp.set_error(&m);
+                }
+                decoded.push(Arg::Kw(op));
+                allowed_num = true;
+                allowed_kw = false;
+                continue;
+            }
+        }
+        // 3) otherwise, if a number is allowed, evaluate as an expression.
+        if allowed_num {
+            let obj = match crate::builtins::eval_expr_obj(interp, &bytes) {
+                Ok(o) => o,
+                Err(c) => return c,
+            };
+            let text = obj_bytes(obj);
+            let parsed = as_number(&text);
+            // SAFETY: `obj` is the owned (+1) expr result; we are done with it.
+            unsafe { obj::decr_ref_count(obj) };
+            match parsed {
+                Some(n) => {
+                    if n.is_double {
+                        use_doubles += 1;
+                    }
+                    decoded.push(Arg::Num(n));
+                    rem_nums -= 1;
+                    allowed_kw = true;
+                    allowed_num = !(rem_nums == 1 && (nargs - 1 - idx) == 2);
+                }
+                None => return syntax_err(interp),
+            }
+            continue;
+        }
+        return syntax_err(interp);
+    }
+
+    // -- dispatch on the decode key (number→1, keyword→2 per position) ---------
+    let key: u32 = decoded.iter().fold(0, |k, a| {
+        k * 10
+            + match a {
+                Arg::Num(_) => 1,
+                Arg::Kw(_) => 2,
+            }
+    });
+    let n = |i: usize| match &decoded[i] {
+        Arg::Num(x) => *x,
+        Arg::Kw(_) => unreachable!(),
+    };
+    let op = |i: usize| match &decoded[i] {
+        Arg::Kw(o) => *o,
+        Arg::Num(_) => unreachable!(),
+    };
+
+    let zero = Num {
+        is_double: false,
+        i: 0,
+        d: 0.0,
+        prec: 0,
+    };
+    let one = Num {
+        is_double: false,
+        i: 1,
+        d: 1.0,
+        prec: 0,
+    };
+    let (mut start, mut end, mut step, mut count): (Num, Option<Num>, Option<Num>, Option<Num>) =
+        (zero, None, None, None);
+
+    match key {
+        // lseq n
+        1 => {
+            count = Some(n(0));
+            step = Some(one);
+            use_doubles = 0; // count-only is integer-valued
+        }
+        // lseq n n
+        11 => {
+            start = n(0);
+            end = Some(n(1));
+        }
+        // lseq n n n
+        111 => {
+            start = n(0);
+            end = Some(n(1));
+            step = Some(n(2));
+        }
+        // lseq n (to|..|count|by) n
+        121 => match op(1) {
+            Op::Dots | Op::To => {
+                start = n(0);
+                end = Some(n(2));
+            }
+            Op::By => {
+                count = Some(n(0));
+                step = Some(n(2));
+            }
+            Op::Count => {
+                start = n(0);
+                count = Some(n(2));
+                step = Some(one);
+            }
+        },
+        // lseq n (to|count) n n
+        1211 => match op(1) {
+            Op::Dots | Op::To => {
+                start = n(0);
+                end = Some(n(2));
+                step = Some(n(3));
+            }
+            Op::Count => {
+                start = n(0);
+                count = Some(n(2));
+                step = Some(n(3));
+            }
+            _ => return syntax_err(interp),
+        },
+        // lseq n n by n
+        1121 => {
+            start = n(0);
+            end = Some(n(1));
+            match op(2) {
+                Op::By => step = Some(n(3)),
+                _ => return syntax_err(interp),
+            }
+        }
+        // lseq n (to|count) n by n
+        12121 => {
+            match op(3) {
+                Op::By => step = Some(n(4)),
+                _ => return syntax_err(interp),
+            }
+            match op(1) {
+                Op::Dots | Op::To => {
+                    start = n(0);
+                    end = Some(n(2));
+                }
+                Op::Count => {
+                    start = n(0);
+                    count = Some(n(2));
+                }
+                _ => return syntax_err(interp),
+            }
+        }
+        _ => return syntax_err(interp),
+    }
+
+    // A double-valued count is converted to an integer and does not, by itself,
+    // make the sequence use doubles (C: "Don't consider Count type ...").
+    if let Some(c) = count {
+        if c.is_double {
+            use_doubles = use_doubles.saturating_sub(1);
+            if !c.d.is_finite() || c.d.floor() != c.d {
+                return interp.set_error(b"expected integer but got non-integer count");
+            }
+        }
+    }
+
+    let elems = if use_doubles > 0 {
+        build_double(&mut start, &end, &step, &count)
+    } else {
+        build_int(&start, &end, &step, &count)
+    };
+    let elems = match elems {
+        Ok(v) => v,
+        Err(msg) => return interp.set_error(msg),
+    };
+    interp.set_result(crate::list::new_list_obj(&elems));
+    Code::Ok
+}
+
+/// `power10` for the precision scaling.
+fn power10(n: u32) -> f64 {
+    10f64.powi(n as i32)
+}
+
+/// `ArithRound` — round `d` to `n` fractional digits (identity for `n == 0`).
+fn arith_round(d: f64, n: u32) -> f64 {
+    if n == 0 {
+        return d;
+    }
+    let s = power10(n);
+    (d * s).round() / s
+}
+
+/// Integer arithmetic series → element objects (`Tcl_WideInt` path).
+fn build_int(
+    start: &Num,
+    end: &Option<Num>,
+    step: &Option<Num>,
+    count: &Option<Num>,
+) -> Result<Vec<*mut TclObj>, &'static [u8]> {
+    let s = start.i;
+    // Length is computed in i128 so an extreme `end - start` (e.g.
+    // `lseq 10 9223372036854775000`) cannot overflow i64 before the cap check.
+    let (len, st): (i128, i64) = if let Some(c) = count {
+        // count given: len = count, step defaults to 1.
+        let st = step.map_or(1, |x| x.i);
+        (i128::from(c.i).max(0), st)
+    } else {
+        let e = end.expect("int series without end or count has a count").i;
+        // step defaults to ±1 by direction when omitted.
+        let st = match step {
+            Some(x) => x.i,
+            None => {
+                if s <= e {
+                    1
+                } else {
+                    -1
+                }
+            }
+        };
+        if st == 0 {
+            return Ok(Vec::new());
+        }
+        let len = (i128::from(e) - i128::from(s)) / i128::from(st) + 1;
+        (len.max(0), st)
+    };
+    if st == 0 {
+        return Ok(Vec::new());
+    }
+    if len > i128::from(MAX_MATERIALIZE) {
+        return Err(b"max length of a Tcl list exceeded");
+    }
+    let len = len as i64;
+    let mut out = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        // s + i*st, computed in i128 (each value is in range, so the cast is
+        // lossless) — avoids accumulation overflow at the i64 boundary.
+        let v = (i128::from(s) + i128::from(i) * i128::from(st)) as i64;
+        out.push(obj::new_wide_int_obj(v));
+    }
+    Ok(out)
+}
+
+/// Double arithmetic series → element objects, with C's precision matching.
+fn build_double(
+    start: &mut Num,
+    end: &Option<Num>,
+    step: &Option<Num>,
+    count: &Option<Num>,
+) -> Result<Vec<*mut TclObj>, &'static [u8]> {
+    let ds = start.d;
+    let prec = {
+        // maxObjPrecision(start, end, step) — count is excluded.
+        let mut p = step.map_or(0, |x| x.prec);
+        p = p.max(start.prec);
+        if let Some(e) = end {
+            p = p.max(e.prec);
+        }
+        p
+    };
+    let (len, dstep) = if let Some(c) = count {
+        let dstep = step.map_or(1.0, |x| x.d);
+        (c.i.max(0), dstep)
+    } else {
+        let de = end.expect("double series without end or count").d;
+        let dstep = match step {
+            Some(x) => x.d,
+            None => {
+                if ds <= de {
+                    1.0
+                } else {
+                    -1.0
+                }
+            }
+        };
+        if dstep == 0.0 {
+            return Ok(Vec::new());
+        }
+        if !ds.is_finite() || !de.is_finite() {
+            if ds.is_nan() || de.is_nan() {
+                return Err(b"cannot use non-numeric floating-point value to estimate length of arith-series");
+            }
+            return Err(b"max length of a Tcl list exceeded");
+        }
+        (arith_series_len_dbl(ds, de, dstep, prec), dstep)
+    };
+    if dstep == 0.0 {
+        return Ok(Vec::new());
+    }
+    if len > MAX_MATERIALIZE {
+        return Err(b"max length of a Tcl list exceeded");
+    }
+    let mut out = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let d = arith_round(ds + (i as f64) * dstep, prec);
+        out.push(obj::new_double_obj(d));
+    }
+    Ok(out)
+}
+
+/// `ArithSeriesLenDbl` — element count of a double series, computed in scaled
+/// wide arithmetic for stability (mirrors the C function).
+fn arith_series_len_dbl(start: f64, end: f64, step: f64, precision: u32) -> i64 {
+    if step == 0.0 {
+        return 0;
+    }
+    let (mut s, mut e, mut st) = (start, end, step);
+    if precision > 0 {
+        let sf = power10(precision);
+        s *= sf;
+        e *= sf;
+        st *= sf;
+    }
+    let dist = e - s;
+    let wide_min = i64::MIN as f64;
+    let wide_max = i64::MAX as f64;
+    if (wide_min..=wide_max).contains(&dist) && (wide_min..=wide_max).contains(&st) {
+        let iend = if dist < 0.0 { dist - 0.5 } else { dist + 0.5 } as i64;
+        let istep = if st < 0.0 { st - 0.5 } else { st + 0.5 } as i64;
+        if istep != 0 {
+            return (iend / istep + 1).max(0);
+        }
+    }
+    let len = dist / st + 1.0;
+    if len < 0.0 {
+        0
+    } else {
+        len as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::counters;
+    use crate::interp::{Code, Interp};
+
+    /// Evaluate `src` leak-checked, asserting success, and return the result.
+    fn ok(src: &[u8]) -> Vec<u8> {
+        counters::reset();
+        let (code, bytes);
+        {
+            let mut i = Interp::new();
+            code = i.eval_str(src);
+            bytes = i.result_bytes();
+        }
+        assert_eq!(counters::finalize(), 0, "leak");
+        assert_eq!(counters::double_free_count(), 0);
+        assert_eq!(
+            code,
+            Code::Ok,
+            "result={:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+        bytes
+    }
+
+    fn err(src: &[u8]) -> Vec<u8> {
+        counters::reset();
+        let (code, bytes);
+        {
+            let mut i = Interp::new();
+            code = i.eval_str(src);
+            bytes = i.result_bytes();
+        }
+        assert_eq!(counters::finalize(), 0, "leak");
+        assert_eq!(code, Code::Error);
+        bytes
+    }
+
+    #[test]
+    fn lseq_integer_forms() {
+        assert_eq!(ok(b"lseq 5"), b"0 1 2 3 4");
+        assert_eq!(ok(b"lseq 0"), b"");
+        assert_eq!(ok(b"lseq -5"), b""); // negative count → empty
+        assert_eq!(ok(b"lseq 1 .. 10"), b"1 2 3 4 5 6 7 8 9 10");
+        assert_eq!(ok(b"lseq 10 .. 1"), b"10 9 8 7 6 5 4 3 2 1");
+        assert_eq!(ok(b"lseq 1 to 10 by 2"), b"1 3 5 7 9");
+        assert_eq!(ok(b"lseq 1 to 10 by -2"), b""); // wrong-sign step → empty
+        assert_eq!(ok(b"lseq 1 to 5 by 0"), b""); // zero step → empty
+        assert_eq!(ok(b"lseq 5 count 5"), b"5 6 7 8 9");
+        assert_eq!(ok(b"lseq 5 count 5 by -2"), b"5 3 1 -1 -3");
+        assert_eq!(ok(b"lseq 3 by 2"), b"0 2 4");
+        assert_eq!(ok(b"lseq 1 5"), b"1 2 3 4 5");
+        assert_eq!(ok(b"lseq 5 1"), b"5 4 3 2 1");
+    }
+
+    #[test]
+    fn lseq_double_precision() {
+        // Precision matches the inputs' fractional digits (`maxObjPrecision`).
+        assert_eq!(ok(b"lseq 0 0.5 by 0.1"), b"0.0 0.1 0.2 0.3 0.4 0.5");
+        assert_eq!(ok(b"lseq 25. to 5. by -5"), b"25.0 20.0 15.0 10.0 5.0");
+        assert_eq!(
+            ok(b"lseq 3.5 18.5 1.5"),
+            b"3.5 5.0 6.5 8.0 9.5 11.0 12.5 14.0 15.5 17.0 18.5"
+        );
+        // A double-valued count is used as an integer and stays an int sequence.
+        assert_eq!(ok(b"lseq 5 count 5.0"), b"5 6 7 8 9");
+    }
+
+    #[test]
+    fn lseq_expression_args() {
+        assert_eq!(ok(b"lseq 1+2 to 10"), b"3 4 5 6 7 8 9 10");
+        assert_eq!(ok(b"set n 3; lseq $n*2"), b"0 1 2 3 4 5");
+    }
+
+    #[test]
+    fn lseq_errors() {
+        assert_eq!(
+            err(b"lseq"),
+            b"wrong # args: should be \"lseq n ??op? n ??by? n??\""
+        );
+        assert_eq!(
+            err(b"lseq 12 to 24 by 2 count"),
+            b"wrong # args: should be \"lseq n ??op? n ??by? n??\""
+        );
+        // Huge series are capped rather than OOM-aborting.
+        assert_eq!(
+            err(b"lseq 10 2147483647"),
+            b"max length of a Tcl list exceeded"
+        );
+    }
+}

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1444,6 +1444,14 @@ impl Interp {
         }
         let mut last = Code::Ok;
         let commands = parse::parse_script(src);
+        if commands.is_empty() {
+            // A script with no commands (empty / whitespace / comments only)
+            // evaluates to the empty result — `Tcl_EvalEx` resets the result at
+            // entry, and with nothing to set it the result is empty. Without this
+            // a stale prior result leaks through (e.g. an empty proc body, `eval
+            // {}`, or an `lmap`/`foreach` body that produces nothing).
+            self.set_result_bytes(b"");
+        }
         for cmd in &commands {
             last = self.eval_command(src, cmd, owns_frame);
             if last != Code::Ok {

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2454,15 +2454,34 @@ impl Interp {
     }
 
     fn no_such_variable(&mut self, name: &[u8], index: Option<&[u8]>) -> Code {
+        let msg = self.read_miss_msg(name, index);
+        self.error(&msg)
+    }
+
+    /// Build the C-faithful `can't read "NAME": …` message for a failed variable
+    /// read, distinguishing the three cases `tclVar.c` reports: a scalar read of
+    /// an array (`variable is array`), a missing element of an *existing* array
+    /// (`no such element in array`), and a wholly missing variable (`no such
+    /// variable`). `base`/`index` are the split reference (`base(index)`).
+    pub(crate) fn read_miss_msg(&self, base: &[u8], index: Option<&[u8]>) -> Vec<u8> {
         let mut msg = b"can't read \"".to_vec();
-        msg.extend_from_slice(name);
+        msg.extend_from_slice(base);
         if let Some(i) = index {
             msg.push(b'(');
             msg.extend_from_slice(i);
             msg.push(b')');
         }
-        msg.extend_from_slice(b"\": no such variable");
-        self.error(&msg)
+        msg.extend_from_slice(b"\": ");
+        if self.var_is_array(base) {
+            if index.is_some() {
+                msg.extend_from_slice(b"no such element in array");
+            } else {
+                msg.extend_from_slice(b"variable is array");
+            }
+        } else {
+            msg.extend_from_slice(b"no such variable");
+        }
+        msg
     }
 
     /// Set an error result and return [`Code::Error`] — for builtins.

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -50,6 +50,9 @@ pub mod cmd_format;
 pub mod cmd_fs;
 pub mod cmd_info;
 pub mod cmd_list;
+// `lseq` arithmetic-series generator; needs the numeric tower (doubles / expr).
+#[cfg(have_tommath)]
+pub mod cmd_lseq;
 // `::tcl::mathfunc::*` / `::tcl::mathop::*` commands; need the numeric tower.
 #[cfg(have_tommath)]
 pub mod cmd_mathfunc;


### PR DESCRIPTION
Continues Track 1 of the Rust WASM-runtime port (`docs/design/runtime/rust-runtime-port.md`) by driving the **Tcl 9 tcltest sweep** up via the highest-yield missing list/loop commands. Each command was ported from **original C Tcl** and cross-checked against the **Zig oracle**, optimising **correctness → O() → memory**.

## Headline

| Metric | Before | After | Δ |
|---|---|---|---|
| **Tests passing** | 8654 / 18939 | **10660 / 19027** | **+2006** |
| **Pass rate** | 45.7% | **56.0%** | +10.3 pts |
| Files run-to-summary | 124 / 168 | 125 / 168 | +1 |
| **Regressions** | — | **0** | — |
| Runtime unit tests (leak-checked) | 237 | 245 | +8 |

## Commits

| Commit | Change | Sweep Δ |
|---|---|---|
| `ledit` + three-way var-read-miss | in-place `lreplace` on a list var; `tclVar.c` read-miss distinction (`variable is array` / `no such element in array` / `no such variable`) | **+1794** |
| `lmap` + empty-script reset | `foreach`+collect (shared `each_loop`); `Tcl_EvalEx` empty-script result reset | **+118** |
| `lseq` | arithmetic-series generator (`..`/`to`/`count`/`by`, expr args, int/double, precision matching) | **+94** |

## Biggest file gains
`lreplace.test` 1790→3578 · `lseq.test` 0→94 · `lmap.test` 0→57 · `for.test` 0→51 (timeout recovered) · `uplevel.test` 35→41 · `set`/`set-old`/`trace`/`if`/`compile`/`execute`/`namespace-old`.

## Notes
- **`ledit`** mirrors C's `Tcl_LeditObjCmd` (reuses `lreplace`'s index/clamp logic, like the Zig oracle's shared `do_lreplace`).
- The **three-way read-miss** and **empty-script reset** were fixed at their shared sources (`read_miss_msg`, `eval_script`), so they also lift `set`/`expr $var`/empty proc bodies / `eval {}`.
- **`lseq`** materialises a concrete list (C's lazy abstract series is representation-only, incompatible-by-design) and **caps at 100M elements with C's "max length" error rather than OOM-aborting** on the multi-billion-element lazy-series tests; length/element math is in i128 to avoid i64 overflow at extreme bounds. All 23 representative forms verified byte-identical to tclsh 9.0 (incl. `lseq 0 0.5 by 0.1` → `0.0 0.1 0.2 0.3 0.4 0.5`).
- Added the `runtime-rust-test` / `runtime-rust-lint` / `runtime-rust-sweep` Make targets the doc/README cited but that didn't exist.
- Tracking doc updated: scoreboard rows, priority-queue #11, SYNC-2026-06-13 entry.

Known limitation (out of scope): extreme-magnitude doubles like `1e50` print long-decimal rather than `1e+50` — a pre-existing `tcl-syntax::format_double` issue, not `lseq`.

Gates: `cargo test` 245/245 (leak-checked), `cargo fmt --check` + `clippy -D warnings` clean, sweep zero regressions.

https://claude.ai/code/session_01GTYbUXqiD192xrNh9oKZaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTYbUXqiD192xrNh9oKZaX)_