### PR TITLE
Per-item incremental analysis: salsa-native lattice graph + analyser fast-path widening

### DIFF
--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -210,6 +210,36 @@ practcl.tcl from ~1 s to low-ms).
 | Slice 4 — per-procedure lattice memoisation (`build_for_memoized` + `lattice_rebase`), offset-invariant | **shipped** (byte-identical; e2e parity) |
 | Slice 5 — diagnostics on the cancellable salsa graph (`file_analysis_incremental`), coalescing per-URI worker (CPU-stress-robust), `document_analysis_gate` retired | **shipped** (e2e parity; edit-storm stress green) |
 | Salsa-native per-procedure lattice graph (`function_lattice` query interning each proc's offset-0 body + `CfgContext`); both consumers (analyser tail + optimiser via `compiler_check_diagnostics`) on salsa; process-wide content cache retired | **shipped** (byte-identical; offset-invariant firewall + e2e parity) |
+| Per-item walk Phase B — widen the fast path: qualified `$::g` reads captured + replayed on the shell's globals at graft; the enclosing-context fallback narrowed from "any namespace/global/`variable`/qualified-read body" to **duplicate definitions** (top-level + nested self-redefinition) and **class-defining / qualified-writer bodies** | **shipped** (≈42% of corpus files now take the incremental fast path, up from the qualified-read-trigger floor; byte-identical — corpus + fuzzer gated) |
+
+> **Phase B — what the fast path now covers, and what still falls back.**
+> The per-item walk's enclosing-context fallback (`body_needs_enclosing_context`)
+> used to fire on *any* body touching namespace/global/`variable` state or a
+> qualified `$::g` read — i.e. almost every non-trivial file.  Phase B:
+>
+> - **Captures + replays qualified reads.** A body's `$::g` read is recorded
+>   (`Analyser::capture_global_reads`) when it misses the isolated body's empty
+>   global scope, then replayed on the shell's real `::g` at graft — so a body
+>   that only *reads* enclosing globals no longer needs the fallback.
+> - **Narrows the fallback** to the two patterns the isolated-body decomposition
+>   genuinely can't reproduce byte-for-byte: (1) **duplicate definitions** — the
+>   same proc/method qualified name defined twice (platform-conditional `proc`s
+>   *and* the lazy-init self-redefinition `proc p {a} { …; proc p {a} {real} }`,
+>   detected by tracking every defined proc name across the shell + body
+>   fragments); (2) **class-defining or qualified-writer bodies** (`oo::class` /
+>   `oo::define`, or `set ::ns::x`) — whose `all_variables` / class-method facts
+>   accumulate across bodies in a whole-file walk but only *merge* in the graft.
+>
+> Result: ~42% of corpus files take the incremental fast path (a body edit
+> recomputes one body + shell + tail).  The remaining ~58% — those that
+> **declare/write** enclosing variables (`variable` / `global` / `set ::x`) or
+> define classes in a body, including marquee files like `practcl.tcl` and
+> `init.tcl` — still fall back, because making them byte-identical needs the
+> isolated body to *pre-seed* its enclosing const-strings + variable defs (so
+> `warn_if_unused`, definition spans, and const-string-dependent diagnostics like
+> W304 resolve identically).  That pre-seeding — keyed so a body invalidates only
+> when its enclosing context changes — is the next step toward a fully
+> incremental analyser walk.
 
 > **Salsa-native lattice graph (shipped).** The per-procedure baseline lattices
 > (CFG → SSA → def-use → SCCP → type → rendered → intra-procedural taint) are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -210,13 +210,29 @@ practcl.tcl from ~1 s to low-ms).
 | Slice 4 — per-procedure lattice memoisation (`build_for_memoized` + `lattice_rebase`), offset-invariant, wired into `file_analysis_incremental` via an idempotent content cache | **shipped** (byte-identical; e2e parity) |
 | Slice 5 — diagnostics on the cancellable salsa graph (`file_analysis_incremental`), coalescing per-URI worker (CPU-stress-robust), `document_analysis_gate` retired | **shipped** (e2e parity; edit-storm stress green) |
 
-> **Remaining (future):** the interprocedural taint cascade still re-runs
-> `propagate_taints` for every function on each edit (the per-function
-> baseline lattices are reused; only the taint re-run is whole-file); the
-> optimiser's second `CompilationUnit` (`lift_compiler_diagnostics`) is still
-> whole-file. A salsa-native per-item lattice graph (interning post-inline IR)
-> would replace the process-wide content cache but needs `Hash`/`Eq` across the
-> IR graph (blocked today by float fields / no `serde`).
+> **Remaining (future).** The per-procedure baseline lattices are memoised for
+> *both* diagnostics consumers (the analyser CFG/SSA tail and the optimiser's
+> `lift_compiler_diagnostics` checks), byte-identically, via the process-wide
+> content cache + `CompilationUnit::build_for_memoized`. What's left:
+>
+> - **Interprocedural taint cascade.** `with_interprocedural` still re-runs
+>   `propagate_taints` for every function on each edit (a small fraction of the
+>   per-edit cost now). Memoising it byte-identically needs a per-function key
+>   over the reachable-callee `ProcSummary`s — i.e. hand-rolling salsa's
+>   dependency tracking, fragile enough that it's only worth doing as part of a
+>   salsa-native lattice graph.
+> - **Salsa-native per-item lattice graph.** Would replace the content cache
+>   (proper GC + a natural taint cascade) by interning each procedure's
+>   *offset-0* post-inline IR body as a salsa key. The `Hash`/`Eq` prerequisite
+>   is **done** — the IR body AST is float-free (literals are text; the
+>   `f64`-bearing `ConstValue` lives in the lattice, not the body), so
+>   `Script`/`Statement`/`ExprNode` derive `Hash`/`Eq` cleanly. The remaining
+>   blocker is *architectural*, not perf: `lift_compiler_diagnostics` runs
+>   **off** the salsa graph (in the server's lift path, with a registry but no
+>   db handle), so a `function_lattice` query can serve the analyser tail but
+>   not the optimiser consumer. A full conversion must therefore *also* move the
+>   optimiser checks onto a salsa query — only then can the content cache be
+>   retired. Net-zero perf, so deferred until that broader move is worthwhile.
 
 ## How to run the experiments
 

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -204,11 +204,19 @@ practcl.tcl from ~1 s to low-ms).
 | Async + debounced diagnostics (heavy-edit fix) | **shipped** |
 | Shared CompilationUnit (E7) — `optimiser::optimise_unit` | **shipped** |
 | Phase-0 experiments E1–E8 + differential fuzzer + cascade prototype | **shipped** (this doc's findings) |
-| Slice 1 — `item_tree`/`item_sig`/`file_decls` | **not started** (the build) |
-| Slice 2 — relative-offset item body analysis | not started (the bulk) |
-| Slice 3 — memoise `item_analysis` (the perf win) | not started |
-| Slice 4 — per-item lattices + `interproc` cascade | not started |
-| Slice 5 — cancellation-aware walk; retire the diagnostics detour + gate | not started |
+| Slice 1 — `item_tree`/`item_sig`/`file_decls` | **shipped** (corpus-gated) |
+| Slice 2 — per-item walk via deferred bodies (`analyse_per_item`); `incremental == fresh` fuzzer to 0 | **shipped** (byte-identical over corpus) |
+| Slice 3 — memoise per-body analysis (`item_body_analysis`); offset-invariant keys | **shipped** (firewall + offset-invariance tests) |
+| Slice 4 — per-procedure lattice memoisation (`build_for_memoized` + `lattice_rebase`), offset-invariant, wired into `file_analysis_incremental` via an idempotent content cache | **shipped** (byte-identical; e2e parity) |
+| Slice 5 — diagnostics on the cancellable salsa graph (`file_analysis_incremental`), coalescing per-URI worker (CPU-stress-robust), `document_analysis_gate` retired | **shipped** (e2e parity; edit-storm stress green) |
+
+> **Remaining (future):** the interprocedural taint cascade still re-runs
+> `propagate_taints` for every function on each edit (the per-function
+> baseline lattices are reused; only the taint re-run is whole-file); the
+> optimiser's second `CompilationUnit` (`lift_compiler_diagnostics`) is still
+> whole-file. A salsa-native per-item lattice graph (interning post-inline IR)
+> would replace the process-wide content cache but needs `Hash`/`Eq` across the
+> IR graph (blocked today by float fields / no `serde`).
 
 ## How to run the experiments
 

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -207,32 +207,37 @@ practcl.tcl from ~1 s to low-ms).
 | Slice 1 — `item_tree`/`item_sig`/`file_decls` | **shipped** (corpus-gated) |
 | Slice 2 — per-item walk via deferred bodies (`analyse_per_item`); `incremental == fresh` fuzzer to 0 | **shipped** (byte-identical over corpus) |
 | Slice 3 — memoise per-body analysis (`item_body_analysis`); offset-invariant keys | **shipped** (firewall + offset-invariance tests) |
-| Slice 4 — per-procedure lattice memoisation (`build_for_memoized` + `lattice_rebase`), offset-invariant, wired into `file_analysis_incremental` via an idempotent content cache | **shipped** (byte-identical; e2e parity) |
+| Slice 4 — per-procedure lattice memoisation (`build_for_memoized` + `lattice_rebase`), offset-invariant | **shipped** (byte-identical; e2e parity) |
 | Slice 5 — diagnostics on the cancellable salsa graph (`file_analysis_incremental`), coalescing per-URI worker (CPU-stress-robust), `document_analysis_gate` retired | **shipped** (e2e parity; edit-storm stress green) |
+| Salsa-native per-procedure lattice graph (`function_lattice` query interning each proc's offset-0 body + `CfgContext`); both consumers (analyser tail + optimiser via `compiler_check_diagnostics`) on salsa; process-wide content cache retired | **shipped** (byte-identical; offset-invariant firewall + e2e parity) |
 
-> **Remaining (future).** The per-procedure baseline lattices are memoised for
-> *both* diagnostics consumers (the analyser CFG/SSA tail and the optimiser's
-> `lift_compiler_diagnostics` checks), byte-identically, via the process-wide
-> content cache + `CompilationUnit::build_for_memoized`. What's left:
+> **Salsa-native lattice graph (shipped).** The per-procedure baseline lattices
+> (CFG → SSA → def-use → SCCP → type → rendered → intra-procedural taint) are now
+> memoised by the salsa-native `function_lattice` query, replacing the
+> process-wide content cache (so salsa garbage-collects unreferenced entries).
+> `build_for_memoized` normalises each procedure body to offset 0 and hands it
+> (with the module's `CfgContext`, interned once per build) to a callback that
+> interns the `FnLatticeKey` and demands `function_lattice`; the builder rebases
+> the returned offset-0 unit to the procedure's real span (`lattice_rebase`).
+> Reuses the same `build_cfg_function_with_upvars` call `build_cfg` makes per
+> procedure, so the rebuilt unit equals the whole-module build's (modulo offset),
+> under `db.registry` (byte-identical to both consumers' `build_default` +
+> `load_dialect`).  The optimiser path was the architectural blocker — it ran
+> *off* salsa with no db handle; it now runs through the `compiler_check_diagnostics`
+> tracked query (server filters the master-switch / per-code disables + lifts), so
+> both diagnostics consumers share the same memoised lattices.  Gated by the
+> per-item corpus + `incremental == fresh` differential fuzzer + the db
+> equivalence/offset-invariance tests (`function_lattice_reused_on_body_shift`,
+> `compiler_check_diagnostics_matches_uncached`) + e2e parity.
+>
+> **Remaining (future).**
 >
 > - **Interprocedural taint cascade.** `with_interprocedural` still re-runs
 >   `propagate_taints` for every function on each edit (a small fraction of the
 >   per-edit cost now). Memoising it byte-identically needs a per-function key
->   over the reachable-callee `ProcSummary`s — i.e. hand-rolling salsa's
->   dependency tracking, fragile enough that it's only worth doing as part of a
->   salsa-native lattice graph.
-> - **Salsa-native per-item lattice graph.** Would replace the content cache
->   (proper GC + a natural taint cascade) by interning each procedure's
->   *offset-0* post-inline IR body as a salsa key. The `Hash`/`Eq` prerequisite
->   is **done** — the IR body AST is float-free (literals are text; the
->   `f64`-bearing `ConstValue` lives in the lattice, not the body), so
->   `Script`/`Statement`/`ExprNode` derive `Hash`/`Eq` cleanly. The remaining
->   blocker is *architectural*, not perf: `lift_compiler_diagnostics` runs
->   **off** the salsa graph (in the server's lift path, with a registry but no
->   db handle), so a `function_lattice` query can serve the analyser tail but
->   not the optimiser consumer. A full conversion must therefore *also* move the
->   optimiser checks onto a salsa query — only then can the content cache be
->   retired. Net-zero perf, so deferred until that broader move is worthwhile.
+>   over the reachable-callee `ProcSummary`s — i.e. a `taint_cascade` query layered
+>   on `function_lattice`'s baseline taints, fed the reachable summaries as
+>   interned inputs.  Now tractable on the salsa-native graph; net-small perf.
 
 ## How to run the experiments
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -226,98 +226,106 @@ impl Analyser {
         // points at the unresolved name rather than the whole
         // command line.
         let cmd_tok = arg_tokens_in[0];
-        let resolved = self.resolve_command_qualified_name(cmd_name);
-        self.result.command_invocations.push(
-            crate::signature_scan::types::SignatureCommandInvocation {
-                name: cmd_name.to_string(),
-                range: cmd_tok.span,
-                resolved_qualified_name: Some(resolved),
-            },
-        );
+        // Structure-only mode (item-tree extraction) skips every diagnostic /
+        // cross-feature recording pass below — they don't affect the declared
+        // proc / class / alias / ensemble structure and are the bulk of the
+        // per-command cost.  The structural handlers further down still run, so
+        // `file_decls` is identical to a full `analyse` (gated by the
+        // `file_decls_corpus` corpus test).
+        if !self.structure_only {
+            let resolved = self.resolve_command_qualified_name(cmd_name);
+            self.result.command_invocations.push(
+                crate::signature_scan::types::SignatureCommandInvocation {
+                    name: cmd_name.to_string(),
+                    range: cmd_tok.span,
+                    resolved_qualified_name: Some(resolved),
+                },
+            );
 
-        // iRules ``call PROC ARG...`` — record an additional
-        // ``CommandInvocation`` for the target proc so that
-        // references, rename, and call-hierarchy see through the
-        // indirection.  Mirrors
-        // ``_AnalyserCommandsMixin._process_command`` line 231 in
-        // ``core/analysis/_analyser/_commands.py``.
-        if cmd_name == "call" && self.dialect == "f5-irules" {
-            if let (Some(target_name), Some(target_tok)) =
-                (args.first(), arg_tokens_in.get(1).copied())
-            {
-                let resolved = self.resolve_command_qualified_name(target_name);
-                self.result.command_invocations.push(
-                    crate::signature_scan::types::SignatureCommandInvocation {
-                        name: target_name.clone(),
-                        range: target_tok.span,
-                        resolved_qualified_name: Some(resolved),
-                    },
-                );
+            // iRules ``call PROC ARG...`` — record an additional
+            // ``CommandInvocation`` for the target proc so that
+            // references, rename, and call-hierarchy see through the
+            // indirection.  Mirrors
+            // ``_AnalyserCommandsMixin._process_command`` line 231 in
+            // ``core/analysis/_analyser/_commands.py``.
+            if cmd_name == "call" && self.dialect == "f5-irules" {
+                if let (Some(target_name), Some(target_tok)) =
+                    (args.first(), arg_tokens_in.get(1).copied())
+                {
+                    let resolved = self.resolve_command_qualified_name(target_name);
+                    self.result.command_invocations.push(
+                        crate::signature_scan::types::SignatureCommandInvocation {
+                            name: target_name.clone(),
+                            range: target_tok.span,
+                            resolved_qualified_name: Some(resolved),
+                        },
+                    );
+                }
             }
-        }
 
-        // Walk every argument's source slice for ``[cmd ...]``
-        // substitutions and record each nested head as its own
-        // ``CommandInvocation``.  Mirrors ``_iter_nested_invocations``
-        // in ``_AnalyserCommandsMixin._record_command_invocation``
-        // (Python).
-        self.record_nested_invocations_from_args(cmd_name, args, arg_tokens_in);
+            // Walk every argument's source slice for ``[cmd ...]``
+            // substitutions and record each nested head as its own
+            // ``CommandInvocation``.  Mirrors ``_iter_nested_invocations``
+            // in ``_AnalyserCommandsMixin._record_command_invocation``
+            // (Python).
+            self.record_nested_invocations_from_args(cmd_name, args, arg_tokens_in);
 
-        // Run the per-command syntactic checks on commands nested inside
-        // ``[…]`` substitutions — the main walk never descends a
-        // substitution (it treats `[cmd …]` as a value), so a command
-        // like `set fh [open "|$cmd" r]` or `set x [string index abc 99]`
-        // would otherwise escape the security / bounds / arity / style
-        // families entirely.  Mirrors main's ``_recurse_nested_commands``
-        // re-running ``run_all_checks`` on each descended substitution
-        // command.
-        self.run_nested_command_diagnostics(arg_tokens_in, scope_path);
+            // Run the per-command syntactic checks on commands nested inside
+            // ``[…]`` substitutions — the main walk never descends a
+            // substitution (it treats `[cmd …]` as a value), so a command
+            // like `set fh [open "|$cmd" r]` or `set x [string index abc 99]`
+            // would otherwise escape the security / bounds / arity / style
+            // families entirely.  Mirrors main's ``_recurse_nested_commands``
+            // re-running ``run_all_checks`` on each descended substitution
+            // command.
+            self.run_nested_command_diagnostics(arg_tokens_in, scope_path);
 
-        // **C41d3.** Record variable-as-command and
-        // command-substitution-as-command call sites so the
-        // post-walk W307 / W308 emitters can resolve them.
-        // Mirrors the inline recording in
-        // ``_AnalyserCommandsMixin._process_command``
-        // (``_commands.py:182-198``).
-        self.record_var_or_cmd_command_site(cmd_tok, args, scope_path);
+            // **C41d3.** Record variable-as-command and
+            // command-substitution-as-command call sites so the
+            // post-walk W307 / W308 emitters can resolve them.
+            // Mirrors the inline recording in
+            // ``_AnalyserCommandsMixin._process_command``
+            // (``_commands.py:182-198``).
+            self.record_var_or_cmd_command_site(cmd_tok, args, scope_path);
 
-        // Record TclOO instance creation (`set v [Cls new]`,
-        // `Cls create inst`) so the LSP providers can resolve
-        // ``$v method`` / ``inst method`` call sites to the
-        // object's class.
-        self.record_instance_creation(cmd_name, args);
+            // Record TclOO instance creation (`set v [Cls new]`,
+            // `Cls create inst`) so the LSP providers can resolve
+            // ``$v method`` / ``inst method`` call sites to the
+            // object's class.
+            self.record_instance_creation(cmd_name, args);
 
-        // Generic EXPR-argument walk via the command registry's
-        // ``ArgRole::Expr``.  Picks up the condition arg of
-        // ``if`` / ``elseif`` / ``while`` / the cond+next slots
-        // of ``for`` / the body of ``expr`` / etc.  Currently
-        // hosts the W110 (``==``/``!=`` vs ``eq``/``ne``)
-        // emitter; future EXPR-role checks slot in here.
-        //
-        // Run *before* the early-returning handlers
-        // (``handle_for_command`` / ``handle_foreach_command`` /
-        // ``handle_switch_command`` / ``handle_catch_command`` /
-        // ``handle_try_command``) so EXPR-role args on those
-        // commands aren't skipped — none of those handlers
-        // process EXPR args themselves (they own *body*
-        // recursion only), so this can't double-fire.
-        self.dispatch_expr_arguments(cmd_name, args, arg_tokens);
+            // Generic EXPR-argument walk via the command registry's
+            // ``ArgRole::Expr``.  Picks up the condition arg of
+            // ``if`` / ``elseif`` / ``while`` / the cond+next slots
+            // of ``for`` / the body of ``expr`` / etc.  Currently
+            // hosts the W110 (``==``/``!=`` vs ``eq``/``ne``)
+            // emitter; future EXPR-role checks slot in here.
+            //
+            // Run *before* the early-returning handlers
+            // (``handle_for_command`` / ``handle_foreach_command`` /
+            // ``handle_switch_command`` / ``handle_catch_command`` /
+            // ``handle_try_command``) so EXPR-role args on those
+            // commands aren't skipped — none of those handlers
+            // process EXPR args themselves (they own *body*
+            // recursion only), so this can't double-fire.
+            self.dispatch_expr_arguments(cmd_name, args, arg_tokens);
 
-        // Dispatch-site diagnostic emitters (W302 / W001 / E004 / W101
-        // / W304 / W004 / E002-E003).  Extracted from this function so
-        // it stays within the line budget; see the method for the
-        // per-code rationale and ordering.  Run before the
-        // early-returning handlers so option-bearing / body-owning
-        // commands still get checked.
-        self.emit_dispatch_site_diagnostics(
-            cmd_name,
-            args,
-            arg_tokens,
-            arg_single,
-            arg_expand_in,
-            cmd_tok,
-            scope_path,
-        );
+            // Dispatch-site diagnostic emitters (W302 / W001 / E004 / W101
+            // / W304 / W004 / E002-E003).  Extracted from this function so
+            // it stays within the line budget; see the method for the
+            // per-code rationale and ordering.  Run before the
+            // early-returning handlers so option-bearing / body-owning
+            // commands still get checked.
+            self.emit_dispatch_site_diagnostics(
+                cmd_name,
+                args,
+                arg_tokens,
+                arg_single,
+                arg_expand_in,
+                cmd_tok,
+                scope_path,
+            );
+        } // end `if !self.structure_only`
 
         // Handler-by-handler dispatch. Each returning-bool
         // handler is consulted in turn; first match wins. The

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -9589,21 +9589,21 @@ mod tests {
             let want = whole.analyse(src, "tcl");
 
             // Build a memoised unit (cold cache) and run through the seam.
-            let mut cache: HashMap<String, FunctionUnit> = HashMap::new();
-            let build_cu = |cache: &mut HashMap<String, FunctionUnit>| {
+            let mut cache: HashMap<String, (u32, FunctionUnit)> = HashMap::new();
+            let build_cu = |cache: &mut HashMap<String, (u32, FunctionUnit)>| {
                 CompilationUnit::build_for_memoized(
                     src,
                     &registry,
                     false,
                     tcl_lexer::LexerConfig::default(),
                     "tcl",
-                    &mut |key: &str, build: &mut dyn FnMut() -> FunctionUnit| {
-                        if let Some(fu) = cache.get(key) {
-                            return fu.clone();
+                    &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
+                        if let Some(entry) = cache.get(key) {
+                            return entry.clone();
                         }
-                        let fu = build();
-                        cache.insert(key.to_owned(), fu.clone());
-                        fu
+                        let entry = build();
+                        cache.insert(key.to_owned(), entry.clone());
+                        entry
                     },
                 )
                 .with_interprocedural(&registry, Some("tcl"))
@@ -9634,35 +9634,46 @@ mod tests {
     /// Slice 4 shift-correctness: a body that is **unedited but shifted** (lines
     /// inserted above it) must NOT take a stale cache hit — the cached unit's
     /// spans are absolute, so its diagnostics must land at the new positions.
-    /// The absolute offset in the cache key guarantees a miss + rebuild here.
+    /// The position-independent key + span rebase makes this a hit at the new
+    /// offset, byte-identical to a fresh analyse.
     #[test]
     fn memoized_compilation_unit_shift_correctness() {
         use crate::compilation_unit::{CompilationUnit, FunctionUnit};
         use std::collections::HashMap;
         use std::sync::Arc;
-        let base = "proc a {} { set x 1; set x 2 }\nproc b {} { set y 1; set y 2 }\n";
-        // Same procs, shifted down by a prepended top-level line.
-        let shifted = "set top 0\nproc a {} { set x 1; set x 2 }\nproc b {} { set y 1; set y 2 }\n";
+        // Bodies span read-before-set, dead store, and every control-flow shape
+        // (if/for/while/catch/switch) so the rebase traverses nested scripts +
+        // sub-spans, not just flat statements.  All produce positioned
+        // diagnostics whose spans must move with the shift.
+        let bodies = "proc a {} { return $undef }\n\
+             proc b {} { set y 1; set y 2; return $y }\n\
+             proc c {x} {\n  if {$x} { set z 1; set z 2 }\n  for {set i 0} {$i < 3} {incr i} { set w $q }\n  return $z\n}\n\
+             proc d {n} {\n  while {$n} { catch { set r $undef2 } }\n  switch -- $n { 1 { set s 1; set s 2 } default { return $missing } }\n}\n";
+        let base = bodies.to_owned();
+        // Same procs, shifted down by several prepended top-level lines.
+        let shifted = format!("set top 0\nset top2 1\n# a comment line\n{bodies}");
+        let base = base.as_str();
+        let shifted = shifted.as_str();
 
         let mut registry = tcl_registry::CommandRegistry::build_default();
         if let Some(d) = tcl_registry::prelude::DialectSet::parse("tcl") {
             registry.load_dialect(d);
         }
-        let mut cache: HashMap<String, FunctionUnit> = HashMap::new();
-        let build = |s: &str, cache: &mut HashMap<String, FunctionUnit>| {
+        let mut cache: HashMap<String, (u32, FunctionUnit)> = HashMap::new();
+        let build = |s: &str, cache: &mut HashMap<String, (u32, FunctionUnit)>| {
             let cu = CompilationUnit::build_for_memoized(
                 s,
                 &registry,
                 false,
                 tcl_lexer::LexerConfig::default(),
                 "tcl",
-                &mut |key: &str, build: &mut dyn FnMut() -> FunctionUnit| {
-                    if let Some(fu) = cache.get(key) {
-                        return fu.clone();
+                &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
+                    if let Some(entry) = cache.get(key) {
+                        return entry.clone();
                     }
-                    let fu = build();
-                    cache.insert(key.to_owned(), fu.clone());
-                    fu
+                    let entry = build();
+                    cache.insert(key.to_owned(), entry.clone());
+                    entry
                 },
             )
             .with_interprocedural(&registry, Some("tcl"));
@@ -9671,13 +9682,27 @@ mod tests {
             a.analyse(s, "tcl")
         };
 
-        // Prime the cache on `base`, then analyse `shifted` reusing it.
+        // Prime the cache on `base`, then analyse `shifted` reusing it.  The
+        // procedure bodies are unchanged, so they hit the position-independent
+        // cache and are rebased to their new offsets.
         let _ = build(base, &mut cache);
+        let entries_after_base = cache.len();
         let got = build(shifted, &mut cache);
         let want = Analyser::new().analyse(shifted, "tcl");
         assert_eq!(
             want.diagnostics, got.diagnostics,
-            "shifted-body diagnostics must match a fresh analyse (no stale hit)"
+            "shifted-body diagnostics must match a fresh analyse (rebased hit)"
+        );
+        // The shifted build reused the cached bodies (no new entries for the
+        // procedures), exercising the rebase path rather than rebuilding.
+        assert_eq!(
+            cache.len(),
+            entries_after_base,
+            "shifted bodies should reuse cached entries (position-independent key)"
+        );
+        assert!(
+            !want.diagnostics.is_empty(),
+            "test should exercise real positioned diagnostics"
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -5135,15 +5135,39 @@ file; this call falls through to the 'unknown' handler."
         // `if {$x}` body is provably taken under uniform `q 1` callers, so a
         // var set only there is not read-before-set). Mirrors the Python
         // analyser's interprocedurally-seeded compilation unit.
+        // Incremental seam: when the per-item path has supplied a unit whose
+        // per-function lattices were memoised, consume it instead of
+        // rebuilding the whole-file unit.  Equal by construction to the
+        // freshly-built unit (gated by the differential fuzzer + corpus).
+        if let Some(cu) = self.cu_override.take() {
+            self.emit_cfg_ssa_diagnostics_with_cu(&cu, &registry);
+            return;
+        }
         let dialect_opt = (!self.dialect.is_empty()).then_some(self.dialect.as_str());
         let cu = crate::compilation_unit::CompilationUnit::build_for(source, &registry, false)
             .with_interprocedural(&registry, dialect_opt);
+        self.emit_cfg_ssa_diagnostics_with_cu(&cu, &registry);
+    }
 
+    /// Emit the CFG/SSA-derived diagnostics from an already-built
+    /// [`crate::compilation_unit::CompilationUnit`].
+    ///
+    /// Split out of [`Self::emit_cfg_ssa_diagnostics`] so the incremental
+    /// per-item path can supply a `CompilationUnit` whose per-function
+    /// lattices were memoised, instead of rebuilding the whole-file unit on
+    /// every edit.  Behaviour is identical: the whole-file entry point builds
+    /// the unit exactly as before and delegates here, and every cross-function
+    /// pass below reads the supplied unit unchanged.
+    pub fn emit_cfg_ssa_diagnostics_with_cu(
+        &mut self,
+        cu: &crate::compilation_unit::CompilationUnit,
+        registry: &tcl_registry::CommandRegistry,
+    ) {
         // **W128 (SYNC-JUN02b-4).** Flag calls to commands renamed or
         // deleted earlier in the file via the flow-sensitive
         // command-binding lattice.  Independent of the CFG/SSA dead-store
         // machinery below, so run it up front against the same `cu`.
-        self.emit_w128_renamed_command(&cu, &registry);
+        self.emit_w128_renamed_command(cu, registry);
 
         // **C41e3 follow-up.** Compute the set of globals any
         // proc in this module writes to.  Top-level RBS (W210)
@@ -5151,7 +5175,7 @@ file; this call falls through to the 'unknown' handler."
         // populate them before the top-level read fires.
         // Mirrors `_globals_written_by_procs` in
         // `_diag_commands.py:264-296`.
-        let globals_written = globals_written_by_procs(&cu);
+        let globals_written = globals_written_by_procs(cu);
 
         // **W220 call-by-name suppression (SYNC-JUN02d-2).** Build the
         // interprocedural proc-index once so a caller-local passed *by
@@ -5162,7 +5186,7 @@ file; this call falls through to the 'unknown' handler."
         let cbn_proc_index = {
             let ia = crate::interprocedural::build_interprocedural_analysis(
                 &cu.ir_module,
-                &registry,
+                registry,
                 Some(self.dialect.as_str()),
             );
             crate::interprocedural::build_proc_index_from_summaries(&ia)
@@ -5198,7 +5222,7 @@ file; this call falls through to the 'unknown' handler."
             &globals_written,
             &top_level_cross_event_vars,
         );
-        self.emit_channel_diagnostics(&cu.top_level, &registry);
+        self.emit_channel_diagnostics(&cu.top_level, registry);
         for (qname, fu) in &cu.procedures {
             // **C41-default-on-followups-postpass W220-IR-paths.**
             // For ``::when::*`` procs, threaded
@@ -5234,7 +5258,7 @@ file; this call falls through to the 'unknown' handler."
                 &HashSet::new(),
                 &cross_event_vars,
             );
-            self.emit_channel_diagnostics(fu, &registry);
+            self.emit_channel_diagnostics(fu, registry);
             // **C41d7.** IRULE4005 — racy ``static::``
             // cross-event flow.  Only fires for non-RULE_INIT
             // ``when`` procs when ``ConnectionScope::racy_static_defs``
@@ -5255,7 +5279,7 @@ file; this call falls through to the 'unknown' handler."
         // collected during the walk.  Mirrors
         // ``_emit_var_command_diagnostics`` in
         // ``_diag_var_command.py``.
-        self.emit_var_command_diagnostics(&cu, &registry);
+        self.emit_var_command_diagnostics(cu, registry);
 
         // **C41 follow-up.** Suppress W123 for command-name
         // heads with partial interpolations like ``foo$suffix``
@@ -5263,7 +5287,7 @@ file; this call falls through to the 'unknown' handler."
         // known commands via SCCP.  Mirrors
         // ``_resolve_interpolated_commands`` in
         // ``_diag_commands.py:188-260``.
-        self.resolve_interpolated_w123_diagnostics(&cu);
+        self.resolve_interpolated_w123_diagnostics(cu);
     }
 
     /// Per-function diagnostic dispatcher.

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -9562,6 +9562,125 @@ mod tests {
         assert!(a.result.diagnostics.is_empty());
     }
 
+    /// Slice 4: a memoised `CompilationUnit` (built via `build_for_memoized`
+    /// and fed through the `cu_override` seam) must yield **byte-identical**
+    /// diagnostics to the whole-file path — both on a cold cache (all misses,
+    /// proving the refactor) and a warm cache (all hits, proving the cache key
+    /// captures every lattice input).
+    #[test]
+    fn memoized_compilation_unit_diagnostics_match_whole_file() {
+        use crate::compilation_unit::{CompilationUnit, FunctionUnit};
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let snippets = [
+            "proc a {x} {\n  if {$x} { set y 1 }\n  return $y\n}\nproc b {} { a 1 }\n",
+            "set g 0\nproc inc {} { global g; incr g }\ninc\nputs $g\n",
+            "proc f {n} {\n  set acc 0\n  for {set i 0} {$i < $n} {incr i} { set acc [expr {$acc + $i}] }\n  return $acc\n}\nproc g {} { set z 9; set z 10; return $z }\n",
+            "namespace eval n {\n  proc p {a} { set b $a; return $b }\n}\nset r [n::p 3]\n",
+            "oo::class create K {\n  method m {a} { set n $a; return $n }\n}\nproc top {} { set q 1; set q 2 }\n",
+        ];
+        for src in snippets {
+            let mut registry = tcl_registry::CommandRegistry::build_default();
+            if let Some(d) = tcl_registry::prelude::DialectSet::parse("tcl") {
+                registry.load_dialect(d);
+            }
+            // Whole-file reference.
+            let mut whole = Analyser::new();
+            let want = whole.analyse(src, "tcl");
+
+            // Build a memoised unit (cold cache) and run through the seam.
+            let mut cache: HashMap<String, FunctionUnit> = HashMap::new();
+            let build_cu = |cache: &mut HashMap<String, FunctionUnit>| {
+                CompilationUnit::build_for_memoized(
+                    src,
+                    &registry,
+                    false,
+                    tcl_lexer::LexerConfig::default(),
+                    "tcl",
+                    &mut |key: &str, build: &mut dyn FnMut() -> FunctionUnit| {
+                        if let Some(fu) = cache.get(key) {
+                            return fu.clone();
+                        }
+                        let fu = build();
+                        cache.insert(key.to_owned(), fu.clone());
+                        fu
+                    },
+                )
+                .with_interprocedural(&registry, Some("tcl"))
+            };
+
+            let cold = build_cu(&mut cache);
+            let mut a_cold = Analyser::new();
+            a_cold.set_cu_override(Arc::new(cold));
+            let got_cold = a_cold.analyse(src, "tcl");
+            assert_eq!(
+                want.diagnostics, got_cold.diagnostics,
+                "cold-cache memoised diagnostics differ for:\n{src}"
+            );
+            assert!(!cache.is_empty(), "cache should have entries for:\n{src}");
+
+            // Warm cache: every procedure body is a hit now.
+            let warm = build_cu(&mut cache);
+            let mut a_warm = Analyser::new();
+            a_warm.set_cu_override(Arc::new(warm));
+            let got_warm = a_warm.analyse(src, "tcl");
+            assert_eq!(
+                want.diagnostics, got_warm.diagnostics,
+                "warm-cache memoised diagnostics differ for:\n{src}"
+            );
+        }
+    }
+
+    /// Slice 4 shift-correctness: a body that is **unedited but shifted** (lines
+    /// inserted above it) must NOT take a stale cache hit — the cached unit's
+    /// spans are absolute, so its diagnostics must land at the new positions.
+    /// The absolute offset in the cache key guarantees a miss + rebuild here.
+    #[test]
+    fn memoized_compilation_unit_shift_correctness() {
+        use crate::compilation_unit::{CompilationUnit, FunctionUnit};
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let base = "proc a {} { set x 1; set x 2 }\nproc b {} { set y 1; set y 2 }\n";
+        // Same procs, shifted down by a prepended top-level line.
+        let shifted = "set top 0\nproc a {} { set x 1; set x 2 }\nproc b {} { set y 1; set y 2 }\n";
+
+        let mut registry = tcl_registry::CommandRegistry::build_default();
+        if let Some(d) = tcl_registry::prelude::DialectSet::parse("tcl") {
+            registry.load_dialect(d);
+        }
+        let mut cache: HashMap<String, FunctionUnit> = HashMap::new();
+        let build = |s: &str, cache: &mut HashMap<String, FunctionUnit>| {
+            let cu = CompilationUnit::build_for_memoized(
+                s,
+                &registry,
+                false,
+                tcl_lexer::LexerConfig::default(),
+                "tcl",
+                &mut |key: &str, build: &mut dyn FnMut() -> FunctionUnit| {
+                    if let Some(fu) = cache.get(key) {
+                        return fu.clone();
+                    }
+                    let fu = build();
+                    cache.insert(key.to_owned(), fu.clone());
+                    fu
+                },
+            )
+            .with_interprocedural(&registry, Some("tcl"));
+            let mut a = Analyser::new();
+            a.set_cu_override(Arc::new(cu));
+            a.analyse(s, "tcl")
+        };
+
+        // Prime the cache on `base`, then analyse `shifted` reusing it.
+        let _ = build(base, &mut cache);
+        let got = build(shifted, &mut cache);
+        let want = Analyser::new().analyse(shifted, "tcl");
+        assert_eq!(
+            want.diagnostics, got.diagnostics,
+            "shifted-body diagnostics must match a fresh analyse (no stale hit)"
+        );
+    }
+
     #[test]
     fn emit_cfg_ssa_diagnostics_no_w220_on_simple_assignment() {
         // ``set x 1`` — single assignment, no overwrite, no

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -9589,21 +9589,31 @@ mod tests {
             let want = whole.analyse(src, "tcl");
 
             // Build a memoised unit (cold cache) and run through the seam.
-            let mut cache: HashMap<String, (u32, FunctionUnit)> = HashMap::new();
-            let build_cu = |cache: &mut HashMap<String, (u32, FunctionUnit)>| {
+            // The callback mirrors the db's `function_lattice`: build the
+            // offset-0 unit, keyed on the offset-0 body + name + params.
+            let mut cache: HashMap<String, FunctionUnit> = HashMap::new();
+            let build_cu = |cache: &mut HashMap<String, FunctionUnit>| {
                 CompilationUnit::build_for_memoized(
                     src,
                     &registry,
                     false,
                     tcl_lexer::LexerConfig::default(),
                     "tcl",
-                    &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
-                        if let Some(entry) = cache.get(key) {
-                            return entry.clone();
+                    &mut |req: &crate::compilation_unit::LatticeRequest<'_>| -> FunctionUnit {
+                        let key = format!("{}\u{0}{:?}\u{0}{:?}", req.qname, req.body, req.params);
+                        if let Some(fu) = cache.get(&key) {
+                            return fu.clone();
                         }
-                        let entry = build();
-                        cache.insert(key.to_owned(), entry.clone());
-                        entry
+                        let cfg = crate::cfg_builder::build_cfg_function_with_upvars(
+                            req.qname,
+                            req.body,
+                            true,
+                            req.upvar_procs.clone(),
+                            req.proc_params.clone(),
+                        );
+                        let fu = FunctionUnit::build(req.qname, cfg, req.params, &registry);
+                        cache.insert(key, fu.clone());
+                        fu
                     },
                 )
                 .with_interprocedural(&registry, Some("tcl"))
@@ -9659,21 +9669,32 @@ mod tests {
         if let Some(d) = tcl_registry::prelude::DialectSet::parse("tcl") {
             registry.load_dialect(d);
         }
-        let mut cache: HashMap<String, (u32, FunctionUnit)> = HashMap::new();
-        let build = |s: &str, cache: &mut HashMap<String, (u32, FunctionUnit)>| {
+        let mut cache: HashMap<String, FunctionUnit> = HashMap::new();
+        let build = |s: &str, cache: &mut HashMap<String, FunctionUnit>| {
             let cu = CompilationUnit::build_for_memoized(
                 s,
                 &registry,
                 false,
                 tcl_lexer::LexerConfig::default(),
                 "tcl",
-                &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
-                    if let Some(entry) = cache.get(key) {
-                        return entry.clone();
+                // Position-independent key: the body is normalised to offset 0
+                // before the callback sees it, so a shifted-but-unedited proc
+                // hits and the builder rebases the cached offset-0 unit.
+                &mut |req: &crate::compilation_unit::LatticeRequest<'_>| -> FunctionUnit {
+                    let key = format!("{}\u{0}{:?}\u{0}{:?}", req.qname, req.body, req.params);
+                    if let Some(fu) = cache.get(&key) {
+                        return fu.clone();
                     }
-                    let entry = build();
-                    cache.insert(key.to_owned(), entry.clone());
-                    entry
+                    let cfg = crate::cfg_builder::build_cfg_function_with_upvars(
+                        req.qname,
+                        req.body,
+                        true,
+                        req.upvar_procs.clone(),
+                        req.proc_params.clone(),
+                    );
+                    let fu = FunctionUnit::build(req.qname, cfg, req.params, &registry);
+                    cache.insert(key, fu.clone());
+                    fu
                 },
             )
             .with_interprocedural(&registry, Some("tcl"));

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -8122,6 +8122,27 @@ file; this call falls through to the 'unknown' handler."
             deduped.push(d);
         }
         self.result.diagnostics = deduped;
+
+        // Canonical, deterministic order. The post-walk emitters
+        // (`emit_variable_usage_diagnostics` etc.) iterate the scope tree's
+        // `HashMap`s, whose per-instance iteration order is non-deterministic —
+        // so emission order varied run-to-run and, critically, between
+        // `analyse` and `analyse_commands` (the per-item incremental path).
+        // That non-determinism was the E5 differential gap (the multiset always
+        // matched; only the `Vec` order differed). Sorting by source position
+        // here makes the output deterministic and path-independent — required
+        // for `incremental == fresh`, and a saner source-ordered contract for
+        // the LSP. Dedupe above guarantees `(code, start, end, message,
+        // severity)` is unique, so this key is a total order (no ties).
+        self.result.diagnostics.sort_by(|a, b| {
+            a.span
+                .start()
+                .cmp(&b.span.start())
+                .then(a.span.end().cmp(&b.span.end()))
+                .then_with(|| a.code.cmp(&b.code))
+                .then_with(|| a.severity.as_str().cmp(b.severity.as_str()))
+                .then_with(|| a.message.cmp(&b.message))
+        });
     }
 
     /// Filter out diagnostics whose codes are in

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -289,6 +289,7 @@ impl Analyser {
     /// and the user-defined ``unknown`` proc detection from
     /// `_proc.py` are deferred to **C41d** / future strips —
     /// this strip is structural only.
+    #[allow(clippy::too_many_lines)]
     pub fn handle_proc_command(
         &mut self,
         cmd_name: &str,
@@ -463,7 +464,6 @@ impl Analyser {
                     namespace: ns_prefix.clone(),
                     scope_name: raw_name.clone(),
                     params: params.clone(),
-                    name_span,
                 });
             } else {
                 self.analyse_body(&body_text, body_tok, &child_path);

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -451,8 +451,18 @@ impl Analyser {
             // Body recursion via the shared helper.  Re-segments
             // the body (no recovery — top-level only) and
             // dispatches each command at the new proc scope path.
+            // Per-item shell pass: defer the body (its scope is already
+            // created with params; a second pass fills it in place).
             let body_text = args[2].clone();
-            self.analyse_body(&body_text, body_tok, &child_path);
+            if self.defer_proc_bodies {
+                self.deferred_bodies.push(super::per_item::DeferredBody {
+                    body_text,
+                    body_tok,
+                    scope_path: child_path.clone(),
+                });
+            } else {
+                self.analyse_body(&body_text, body_tok, &child_path);
+            }
 
             self.last_comment = saved_comment;
         }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -459,6 +459,11 @@ impl Analyser {
                     body_text,
                     body_tok,
                     scope_path: child_path.clone(),
+                    is_method: false,
+                    namespace: ns_prefix.clone(),
+                    scope_name: raw_name.clone(),
+                    params: params.clone(),
+                    name_span,
                 });
             } else {
                 self.analyse_body(&body_text, body_tok, &child_path);

--- a/rust/tcl-compiler/src/analyser/item_tree.rs
+++ b/rust/tcl-compiler/src/analyser/item_tree.rs
@@ -1,0 +1,435 @@
+//! Item tree — offset-stable structural view of a file's declarations.
+//!
+//! The foundation of per-item incremental analysis (slice 1 of the plan in
+//! `docs/design/rust/incremental-analysis.md`). Splits a file into *items*
+//! (procs, classes, methods, namespaces, aliases, ensembles) whose identity is
+//! a **stable name + kind**, never a source position — so inserting blank lines
+//! above a proc leaves its [`ItemId`] unchanged and a later memoised
+//! `item_analysis` (slice 3) is a cache hit.
+//!
+//! ## Firewall shape
+//!
+//! - [`ItemSig`] is an item's *signature* (name, namespace, params, name span):
+//!   the cross-item-relevant header. [`ItemTree`] carries one [`Item`] per
+//!   declaration with its signature plus its body span.
+//! - [`FileDecls`] is the aggregate the cross-item passes read: the set of
+//!   declared procs / classes / aliases / ensembles + the namespace tree. A
+//!   body-only edit leaves every signature equal, so `FileDecls` is unchanged
+//!   and salsa early-cutoff fires on the dependent cross-item queries.
+//!
+//! ## Correctness anchor (slice 1)
+//!
+//! Reproducing the analyser's namespace-aware item detection with a *separate*
+//! walker is exactly the work the design backs with the differential fuzzer +
+//! full-rebuild fallback (see the experiments doc: `signature_scan` already
+//! diverges from `analyse` on dynamic `${…}` names and body-nested procs). So
+//! slice 1 builds the item tree from the **authoritative [`AnalysisResult`]**
+//! the analyser already produces from the CST — it therefore *cannot* diverge
+//! from `analyse`. The [`FileDecls`] corpus gate (`tcl-lsp-db`'s
+//! `file_decls_corpus` test) is the permanent guard that protects the swap to a
+//! cheap, independent CST extractor in slices 2–3, where it becomes
+//! load-bearing alongside the fuzzer.
+
+use std::collections::{BTreeSet, HashSet};
+
+use tcl_lexer::Span;
+
+use crate::signature_scan::types::ParamDef;
+
+use super::types::{AnalysisResult, Scope, ScopeKind};
+
+/// What kind of declaration an [`Item`] is.
+///
+/// The discriminant participates in [`ItemId`] so a proc and a namespace that
+/// happen to share a qualified name (Tcl allows it) stay distinct items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ItemKind {
+    /// A `proc` definition.
+    Proc,
+    /// A `TclOO` / itcl class definition.
+    Class,
+    /// A method / constructor / destructor inside a class body.
+    Method,
+    /// A `namespace eval` scope.
+    Namespace,
+    /// An `interp alias` recorded for command resolution.
+    Alias,
+    /// A namespace marked by `namespace ensemble create`.
+    Ensemble,
+}
+
+/// Offset-stable identity of an [`Item`].
+///
+/// `key` is the fully-qualified name (procs / classes / namespaces / aliases /
+/// ensembles) or, for methods, a `class-qualified-name + kind + name`
+/// composite so the identity survives offset shifts and method reordering.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ItemId {
+    /// Declaration kind.
+    pub kind: ItemKind,
+    /// Stable name key (see type docs).
+    pub key: String,
+}
+
+impl ItemId {
+    fn new(kind: ItemKind, key: impl Into<String>) -> Self {
+        Self {
+            kind,
+            key: key.into(),
+        }
+    }
+}
+
+/// An item's signature — the cross-item-relevant header, with no body.
+///
+/// A body-only edit leaves every `ItemSig` byte-identical, which is what lets
+/// the cross-item aggregate queries early-cutoff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemSig {
+    /// Stable identity.
+    pub id: ItemId,
+    /// Enclosing namespace (`"::"` for the global namespace), or the owning
+    /// class qualified name for methods.
+    pub namespace: String,
+    /// Declared parameters (procs / methods; empty otherwise).
+    pub params: Vec<ParamDef>,
+    /// Source span of the name token (`Span::new(0, 0)` when the analyser
+    /// record carries no name span — e.g. aliases / ensembles).
+    pub name_span: Span,
+}
+
+/// One declaration: its signature plus the span of its body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Item {
+    /// Signature (header).
+    pub sig: ItemSig,
+    /// Body span (braces excluded), `None` for bodyless items (aliases /
+    /// ensembles).
+    pub body_span: Option<Span>,
+}
+
+/// The offset-stable item tree for a file: one [`Item`] per declaration,
+/// sorted by [`ItemId`] for deterministic equality (the source `HashMap`s the
+/// analyser populates have non-deterministic iteration order, which would
+/// otherwise defeat salsa value-equality early-cutoff).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ItemTree {
+    /// Items in stable [`ItemId`] order.
+    pub items: Vec<Item>,
+}
+
+/// The aggregate declaration sets the cross-item passes read: the firewall's
+/// "signature side". Built from [`ItemSig`]s; deterministic via `BTreeSet`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileDecls {
+    /// Qualified names of every `proc`.
+    pub procs: BTreeSet<String>,
+    /// Qualified names of every class.
+    pub classes: BTreeSet<String>,
+    /// Qualified names of every recorded command alias.
+    pub aliases: BTreeSet<String>,
+    /// Namespaces marked as ensembles.
+    pub ensembles: BTreeSet<String>,
+    /// Every namespace in the file's namespace tree.
+    pub namespaces: BTreeSet<String>,
+}
+
+/// Enclosing namespace of a fully-qualified name (`"::ns::foo"` → `"::ns"`,
+/// `"::foo"` → `"::"`).
+fn enclosing_namespace(qualified: &str) -> String {
+    match qualified.rsplit_once("::") {
+        Some((prefix, _)) if !prefix.is_empty() => prefix.to_string(),
+        _ => "::".to_string(),
+    }
+}
+
+/// Join a namespace prefix with a (possibly absolute) child name, mirroring the
+/// absolute-reset rule the analyser's `namespace_from_scope_path` uses.
+fn join_ns(prefix: &str, name: &str) -> String {
+    if name.starts_with("::") {
+        name.to_string()
+    } else if prefix == "::" {
+        format!("::{name}")
+    } else {
+        format!("{prefix}::{name}")
+    }
+}
+
+/// Walk the scope tree collecting every namespace's qualified name.
+fn collect_namespaces(scope: &Scope, prefix: &str, out: &mut BTreeSet<String>) {
+    for child in &scope.children {
+        match child.kind {
+            ScopeKind::Namespace => {
+                let q = join_ns(prefix, &child.name);
+                collect_namespaces(child, &q, out);
+                out.insert(q);
+            }
+            // Proc / method / uplevel bodies can still contain `namespace
+            // eval`; keep the enclosing prefix and keep descending.
+            _ => collect_namespaces(child, prefix, out),
+        }
+    }
+}
+
+impl ItemTree {
+    /// Build the item tree from the authoritative [`AnalysisResult`] plus the
+    /// analyser's `ensemble_namespaces` set (which lives on the `Analyser`, not
+    /// the result). See the module docs for why slice 1 anchors to `analyse`.
+    #[must_use]
+    pub fn from_analysis(result: &AnalysisResult, ensembles: &HashSet<String>) -> Self {
+        let mut items: Vec<Item> = Vec::new();
+
+        for (qualified, proc) in &result.all_procs {
+            items.push(Item {
+                sig: ItemSig {
+                    id: ItemId::new(ItemKind::Proc, qualified.clone()),
+                    namespace: enclosing_namespace(qualified),
+                    params: proc.params.clone(),
+                    name_span: proc.name_span,
+                },
+                body_span: Some(proc.body_span),
+            });
+        }
+
+        for (qualified, class) in &result.all_classes {
+            items.push(Item {
+                sig: ItemSig {
+                    id: ItemId::new(ItemKind::Class, qualified.clone()),
+                    namespace: enclosing_namespace(qualified),
+                    params: Vec::new(),
+                    name_span: class.name_span,
+                },
+                body_span: Some(class.body_span),
+            });
+            let mut push_method =
+                |key: String, name_span: Span, body_span: Span, params: Vec<ParamDef>| {
+                    items.push(Item {
+                        sig: ItemSig {
+                            id: ItemId::new(ItemKind::Method, key),
+                            namespace: qualified.clone(),
+                            params,
+                            name_span,
+                        },
+                        body_span: Some(body_span),
+                    });
+                };
+            for m in result_methods(class) {
+                push_method(m.key, m.name_span, m.body_span, m.params);
+            }
+        }
+
+        for qualified in result.command_aliases.keys() {
+            items.push(Item {
+                sig: ItemSig {
+                    id: ItemId::new(ItemKind::Alias, qualified.clone()),
+                    namespace: enclosing_namespace(qualified),
+                    params: Vec::new(),
+                    name_span: Span::new(0, 0),
+                },
+                body_span: None,
+            });
+        }
+
+        for ns in ensembles {
+            items.push(Item {
+                sig: ItemSig {
+                    id: ItemId::new(ItemKind::Ensemble, ns.clone()),
+                    namespace: ns.clone(),
+                    params: Vec::new(),
+                    name_span: Span::new(0, 0),
+                },
+                body_span: None,
+            });
+        }
+
+        let mut namespaces = BTreeSet::new();
+        collect_namespaces(&result.global_scope, "::", &mut namespaces);
+        for ns in &namespaces {
+            items.push(Item {
+                sig: ItemSig {
+                    id: ItemId::new(ItemKind::Namespace, ns.clone()),
+                    namespace: enclosing_namespace(ns),
+                    params: Vec::new(),
+                    name_span: Span::new(0, 0),
+                },
+                body_span: None,
+            });
+        }
+
+        // Deterministic order so `ItemTree` value-equality is stable across the
+        // analyser's non-deterministic `HashMap` iteration order.
+        items.sort_by(|a, b| a.sig.id.cmp(&b.sig.id));
+        Self { items }
+    }
+
+    /// The signatures of every item, in stable [`ItemId`] order. This is the
+    /// `item_sig*` projection of the design's query graph — the firewall's
+    /// cross-item-relevant input.
+    #[must_use]
+    pub fn sigs(&self) -> Vec<ItemSig> {
+        self.items.iter().map(|it| it.sig.clone()).collect()
+    }
+
+    /// Aggregate the declaration sets the cross-item passes read.
+    #[must_use]
+    pub fn file_decls(&self) -> FileDecls {
+        FileDecls::from_sigs(self.items.iter().map(|it| &it.sig))
+    }
+}
+
+impl FileDecls {
+    /// Aggregate declaration sets from item signatures — the design's
+    /// `file_decls ← item_sig*` edge. Body-independent: a body-only edit leaves
+    /// every `ItemSig` equal, so `FileDecls` is unchanged.
+    pub fn from_sigs<'a>(sigs: impl IntoIterator<Item = &'a ItemSig>) -> Self {
+        let mut decls = FileDecls::default();
+        for sig in sigs {
+            match sig.id.kind {
+                ItemKind::Proc => {
+                    decls.procs.insert(sig.id.key.clone());
+                }
+                ItemKind::Class => {
+                    decls.classes.insert(sig.id.key.clone());
+                }
+                ItemKind::Alias => {
+                    decls.aliases.insert(sig.id.key.clone());
+                }
+                ItemKind::Ensemble => {
+                    decls.ensembles.insert(sig.id.key.clone());
+                }
+                ItemKind::Namespace => {
+                    decls.namespaces.insert(sig.id.key.clone());
+                }
+                ItemKind::Method => {}
+            }
+        }
+        decls
+    }
+}
+
+/// A flattened method record (one per method / class-method / constructor /
+/// destructor) with a stable composite key.
+struct FlatMethod {
+    key: String,
+    name_span: Span,
+    body_span: Span,
+    params: Vec<ParamDef>,
+}
+
+/// Flatten a class's methods into stable-keyed [`FlatMethod`]s. Constructors
+/// are ordinal-keyed because `oo::configurable` allows several.
+fn result_methods(class: &super::types::ClassDef) -> Vec<FlatMethod> {
+    let cq = &class.qualified_name;
+    let mut out = Vec::new();
+    for (name, m) in &class.methods {
+        out.push(FlatMethod {
+            key: format!("{cq}::method::{name}"),
+            name_span: m.name_span,
+            body_span: m.body_span,
+            params: m.params.clone(),
+        });
+    }
+    for (name, m) in &class.class_methods {
+        out.push(FlatMethod {
+            key: format!("{cq}::classmethod::{name}"),
+            name_span: m.name_span,
+            body_span: m.body_span,
+            params: m.params.clone(),
+        });
+    }
+    for (i, m) in class.constructors.iter().enumerate() {
+        out.push(FlatMethod {
+            key: format!("{cq}::constructor::{i}"),
+            name_span: m.name_span,
+            body_span: m.body_span,
+            params: m.params.clone(),
+        });
+    }
+    if let Some(m) = &class.destructor {
+        out.push(FlatMethod {
+            key: format!("{cq}::destructor"),
+            name_span: m.name_span,
+            body_span: m.body_span,
+            params: m.params.clone(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyser::Analyser;
+
+    fn build(src: &str) -> (ItemTree, FileDecls) {
+        let mut a = Analyser::new();
+        let result = a.analyse(src, "tcl8.6");
+        let tree = ItemTree::from_analysis(&result, &a.ensemble_namespaces);
+        let decls = tree.file_decls();
+        (tree, decls)
+    }
+
+    #[test]
+    fn enclosing_namespace_cases() {
+        assert_eq!(enclosing_namespace("::foo"), "::");
+        assert_eq!(enclosing_namespace("::ns::foo"), "::ns");
+        assert_eq!(enclosing_namespace("::a::b::foo"), "::a::b");
+    }
+
+    #[test]
+    fn top_level_and_nested_procs_are_items() {
+        let (_, decls) = build("proc foo {a b} { set x 1 }\nnamespace eval ns { proc bar {} {} }");
+        assert!(decls.procs.contains("::foo"));
+        assert!(decls.procs.contains("::ns::bar"));
+        assert!(decls.namespaces.contains("::ns"));
+    }
+
+    #[test]
+    fn body_nested_proc_is_an_item() {
+        // The analyser records procs defined inside proc bodies; the item tree
+        // must too (E1: a body edit adding/removing a nested def is a signature
+        // change).
+        let (_, decls) = build("proc outer {} { proc ::inner {} {} }");
+        assert!(decls.procs.contains("::outer"));
+        assert!(decls.procs.contains("::inner"));
+    }
+
+    #[test]
+    fn classes_methods_and_ensembles() {
+        let src = "oo::class create Shape {\n  method area {} { return 0 }\n  constructor {} {}\n}\nnamespace eval ::e { namespace ensemble create }";
+        let (tree, decls) = build(src);
+        assert!(decls.classes.contains("::Shape"));
+        assert!(decls.ensembles.contains("::e"));
+        assert!(tree
+            .items
+            .iter()
+            .any(|it| it.sig.id.kind == ItemKind::Method && it.sig.id.key.contains("area")));
+    }
+
+    #[test]
+    fn item_tree_is_deterministic() {
+        let src = "proc a {} {}\nproc b {} {}\nproc c {} {}\nnamespace eval n { proc d {} {} }";
+        let (t1, _) = build(src);
+        let (t2, _) = build(src);
+        assert_eq!(t1, t2, "item tree must be order-stable across runs");
+    }
+
+    #[test]
+    fn file_decls_match_analysis_decl_sets() {
+        // The contract the corpus gate enforces at scale: file_decls equals the
+        // analyser's own decl maps. True by construction in slice 1; the guard
+        // bites when slices 2–3 swap in an independent extractor.
+        let src = "proc p {} {}\noo::class create K {}\nnamespace eval z { namespace ensemble create\n proc q {} {} }";
+        let mut a = Analyser::new();
+        let result = a.analyse(src, "tcl8.6");
+        let decls = ItemTree::from_analysis(&result, &a.ensemble_namespaces).file_decls();
+        let want_procs: BTreeSet<String> = result.all_procs.keys().cloned().collect();
+        let want_classes: BTreeSet<String> = result.all_classes.keys().cloned().collect();
+        let want_aliases: BTreeSet<String> = result.command_aliases.keys().cloned().collect();
+        let want_ensembles: BTreeSet<String> = a.ensemble_namespaces.iter().cloned().collect();
+        assert_eq!(decls.procs, want_procs);
+        assert_eq!(decls.classes, want_classes);
+        assert_eq!(decls.aliases, want_aliases);
+        assert_eq!(decls.ensembles, want_ensembles);
+    }
+}

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -37,6 +37,7 @@ pub mod confusables_table;
 pub mod diagnostics;
 pub mod dispatch;
 pub mod handlers;
+pub mod item_tree;
 pub mod mro;
 pub mod oo;
 pub mod param_traits;
@@ -49,6 +50,7 @@ pub mod types;
 pub mod utils;
 
 pub use class_hierarchy::{build_class_hierarchy, ClassHierarchy};
+pub use item_tree::{FileDecls, Item, ItemId, ItemKind, ItemSig, ItemTree};
 pub use mro::{build_mro_map, tcloo_linearise, MroError};
 pub use snapshot::AnalyserSnapshot;
 pub use state::{Analyser, NonAsciiMode};

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -41,6 +41,7 @@ pub mod item_tree;
 pub mod mro;
 pub mod oo;
 pub mod param_traits;
+pub mod per_item;
 pub mod recovery;
 pub mod scope;
 pub mod snapshot;

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -180,7 +180,6 @@ impl Analyser {
                 namespace: String::new(),
                 scope_name: String::new(),
                 params: Vec::new(),
-                name_span: tcl_lexer::Span::new(0, 0),
             });
         } else {
             self.analyse_body(&mb.body_text, mb.body_tok, &method_path);

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -167,7 +167,17 @@ impl Analyser {
             }
             self.define_var(base, mb.body_tok, &method_path, false, None);
         }
-        self.analyse_body(&mb.body_text, mb.body_tok, &method_path);
+        // Per-item shell pass: defer the method body (scope created above) for
+        // a second isolated pass, matching `handle_proc_command`.
+        if self.defer_proc_bodies {
+            self.deferred_bodies.push(super::per_item::DeferredBody {
+                body_text: mb.body_text.clone(),
+                body_tok: mb.body_tok,
+                scope_path: method_path,
+            });
+        } else {
+            self.analyse_body(&mb.body_text, mb.body_tok, &method_path);
+        }
     }
 
     /// Detect dispatch shape of a user-defined ``unknown`` proc.

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -170,10 +170,17 @@ impl Analyser {
         // Per-item shell pass: defer the method body (scope created above) for
         // a second isolated pass, matching `handle_proc_command`.
         if self.defer_proc_bodies {
+            // Method bodies are filled in place in pass 2 (byte-identical, not
+            // yet isolated/memoised — the proc-only fields are unused).
             self.deferred_bodies.push(super::per_item::DeferredBody {
                 body_text: mb.body_text.clone(),
                 body_tok: mb.body_tok,
                 scope_path: method_path,
+                is_method: true,
+                namespace: String::new(),
+                scope_name: String::new(),
+                params: Vec::new(),
+                name_span: tcl_lexer::Span::new(0, 0),
             });
         } else {
             self.analyse_body(&mb.body_text, mb.body_tok, &method_path);

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -154,17 +154,44 @@ impl Analyser {
 
         // --- pass 2: fill each deferred body ---
         let deferred = std::mem::take(&mut self.deferred_bodies);
-        // Phase-A fallback: a PROC body analysed in isolation can't see
-        // enclosing-scope state, so a body that reads/writes a namespace/global
-        // var or defines classes/instances would diverge.  Fall back to a full
-        // rebuild for those files (method bodies are filled in place below, so
-        // they don't need this guard).  Phase B will pre-seed enclosing defs.
-        if deferred
-            .iter()
-            .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text))
-        {
+        // Fall back to a full rebuild for the two patterns the isolated-body
+        // decomposition can't reproduce byte-for-byte:
+        //
+        // 1. **Duplicate definitions** — the same proc/method qualified name
+        //    defined more than once.  A whole-file walk processes the
+        //    redefinitions in source order (last-definition-wins for the shared
+        //    scope/`all_variables` key); the per-item graft *merges* every
+        //    body's facts instead.  Covers both top-level duplicates (e.g.
+        //    platform-conditional `proc auto_execok` in `if {…} else {…}`) and a
+        //    body that **redefines an enclosing/sibling proc** — the lazy-init
+        //    pattern `proc p {a} { …; proc p {a} {real} }`, where the inner def
+        //    wins in a whole-file walk but merges here.
+        // 2. **Class definition / extension in a proc body** (`oo::class` /
+        //    `oo::define` / `itcl::class` / object aliasing) — a class's methods
+        //    accumulate across bodies in a whole-file walk (remove → add →
+        //    re-insert), which the graft's overwrite-on-key cannot reproduce.
+        //
+        // Both are rare; everything else (namespace/global/`variable` state,
+        // qualified `$::g` reads — replayed at graft) takes the fast incremental
+        // path.  Guarded by the corpus `per_item == analyse` gate + the
+        // `incremental == fresh` fuzzer.
+        let structural_fallback = {
+            let mut seen = std::collections::HashSet::new();
+            let duplicate_top_level = deferred.iter().any(|db| {
+                !seen.insert((db.is_method, db.namespace.as_str(), db.scope_name.as_str()))
+            });
+            duplicate_top_level
+                || deferred
+                    .iter()
+                    .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text))
+        };
+        if structural_fallback {
             return self.fresh_full_analyse(source, dialect);
         }
+        // Track every defined proc qualified name (top-level + nested) so a body
+        // that redefines an already-defined proc forces a fallback.
+        let mut defined_procs: std::collections::HashSet<String> =
+            self.result.all_procs.keys().cloned().collect();
         for db in &deferred {
             if db.is_method {
                 // Method bodies: fill in place (byte-identical; not memoised).
@@ -174,6 +201,14 @@ impl Analyser {
                 // Proc bodies: analyse in isolation (a pure function of the
                 // body — the unit memoised by `body_fn`) and graft into shell.
                 let frag = body_fn(db);
+                if frag
+                    .result
+                    .all_procs
+                    .keys()
+                    .any(|name| !defined_procs.insert(name.clone()))
+                {
+                    return self.fresh_full_analyse(source, dialect);
+                }
                 self.graft_proc_body(db, frag);
             }
         }
@@ -239,6 +274,12 @@ impl Analyser {
         self.pending_arity.extend(frag.pending_arity);
         self.var_command_sites.extend(frag.var_sites);
         self.cmd_command_sites.extend(frag.cmd_sites);
+        // Replay the body's qualified global reads against the shell's real
+        // global scope (rebased to the body's position): a `$::g` read lands as
+        // a reference on the enclosing `::g` exactly as a whole-file walk would.
+        for (name, span) in frag.global_reads {
+            self.record_var_read(&name, shift(span, delta), &[]);
+        }
     }
 }
 
@@ -252,6 +293,9 @@ pub struct BodyFragment {
     pending_arity: Vec<(String, String, bool, super::types::Diagnostic)>,
     var_sites: Vec<super::state::VarCommandSite>,
     cmd_sites: Vec<super::state::CmdCommandSite>,
+    /// Qualified (`::`/`static::`) reads that missed the isolated body's empty
+    /// enclosing global scope; replayed on the shell's real globals at graft.
+    global_reads: Vec<(String, tcl_lexer::Span)>,
 }
 
 /// Analyse one `proc` body as an isolated unit at **offset 0** — a pure
@@ -289,6 +333,9 @@ pub fn analyse_proc_body_isolated(
     }
     a.registry = Some(registry);
     a.line_offsets = Some(super::state::compute_line_offsets(&a.source));
+    // Capture qualified (`::`/`static::`) reads that miss the (empty) enclosing
+    // global scope, so the graft can replay them on the shell's real globals.
+    a.capture_global_reads = Some(Vec::new());
     let proc_path =
         reconstruct_proc_scope(&mut a.result.global_scope, &db.namespace, &db.scope_name);
     let placeholder = tcl_lexer::Span::new(0, 0);
@@ -307,6 +354,7 @@ pub fn analyse_proc_body_isolated(
         pending_arity: a.pending_arity,
         var_sites: a.var_command_sites,
         cmd_sites: a.cmd_command_sites,
+        global_reads: a.capture_global_reads.unwrap_or_default(),
     }
 }
 
@@ -481,14 +529,26 @@ fn reconstruct_proc_scope(
     path
 }
 
-/// Does an isolated proc body need enclosing-scope context to match `analyse`?
-/// True if it references a `::`-qualified variable (read `$::x` / `${ns::x}` or
-/// a writer command targeting `::x`), or runs a command that defines/links
-/// enclosing-scope or object state.  Conservative — a false positive only costs
-/// a full-rebuild fallback, never correctness.  Phase B pre-seeds the enclosing
-/// defs to shrink this set.
+/// Does an isolated proc body interact with enclosing-scope / object state in a
+/// way the per-item graft can't reproduce byte-for-byte, forcing a full-rebuild
+/// fallback?  True when the body:
+///
+/// * **defines or extends a class / aliased object** (`oo::class` / `oo::define`
+///   / `itcl::class` / `oo::copy`) — class facts accumulate across bodies in a
+///   whole-file walk (remove → add → re-insert), which the graft's
+///   overwrite-on-key can't reproduce; **or**
+/// * **declares or writes an enclosing-scope variable** (`variable` / `global` /
+///   `upvar` / `namespace`, or a writer command — `set`/`incr`/`lappend`/
+///   `append`/`dict`/`array` — targeting a `::`-qualified name).  Such a body's
+///   `all_variables` / global-scope effect (definition span, `warn_if_unused`,
+///   const-string-dependent diagnostics like W304) depends on enclosing context
+///   the isolated analysis can't see.
+///
+/// Qualified variable *reads* (`$::g`) are **not** listed: they are captured and
+/// replayed on the shell's globals at graft time, so they stay on the fast path.
+/// Conservative — a false positive only costs a full rebuild, never correctness.
 fn body_needs_enclosing_context(body_text: &str) -> bool {
-    const RISKY: &[&str] = &[
+    const DECLARERS: &[&str] = &[
         "variable",
         "global",
         "upvar",
@@ -498,10 +558,6 @@ fn body_needs_enclosing_context(body_text: &str) -> bool {
         "oo::class",
         "oo::copy",
         "itcl::class",
-        "interp",
-        "rename",
-        "new",
-        "create",
     ];
     const WRITERS: &[&str] = &["set", "incr", "lappend", "append", "dict", "array"];
     let words: Vec<&str> = body_text
@@ -509,32 +565,13 @@ fn body_needs_enclosing_context(body_text: &str) -> bool {
         .filter(|w| !w.is_empty())
         .collect();
     for (i, &w) in words.iter().enumerate() {
-        if RISKY.contains(&w) {
+        if DECLARERS.contains(&w) {
             return true;
         }
+        // A writer whose next word or two is a `::`-qualified target writes an
+        // enclosing-scope variable.
         if WRITERS.contains(&w) && words[i + 1..].iter().take(2).any(|t| t.contains("::")) {
             return true;
-        }
-    }
-    // Qualified variable *read*: `$::x`, `${::x}`, `$ns::x`, `${ns::x}`.
-    let b = body_text.as_bytes();
-    let mut i = 0;
-    while i < b.len() {
-        if b[i] == b'$' {
-            let mut j = i + 1;
-            if j < b.len() && b[j] == b'{' {
-                j += 1;
-            }
-            let start = j;
-            while j < b.len() && (b[j].is_ascii_alphanumeric() || b[j] == b':' || b[j] == b'_') {
-                j += 1;
-            }
-            if body_text[start..j].contains("::") {
-                return true;
-            }
-            i = j.max(i + 1);
-        } else {
-            i += 1;
         }
     }
     false
@@ -578,5 +615,28 @@ mod tests {
     #[test]
     fn nested_proc_in_body() {
         eq("proc outer {} { proc ::inner {} { set z 1 } ; inner }\n");
+    }
+
+    #[test]
+    fn qualified_read_marks_enclosing_global_used() {
+        // A body's `$::g` read must land as a reference on the enclosing `::g`
+        // (captured + replayed at graft), so the "unused" state matches a
+        // whole-file walk even though the body is analysed in isolation.
+        eq("set ::g 1\nproc r {} { return [expr {$::g + 1}] }\n");
+        eq("set ::g 1\nproc r {} { return 0 }\n"); // unused global stays unused
+    }
+
+    #[test]
+    fn duplicate_top_level_proc_falls_back() {
+        // Platform-conditional redefinition: last-def-wins in a whole-file walk;
+        // the per-item path detects the duplicate and falls back, so equal.
+        eq("if {1} {\n  proc p {} { set file a; puts $file }\n} else {\n  proc p {} { return 2 }\n}\n");
+    }
+
+    #[test]
+    fn self_redefining_proc_falls_back() {
+        // Lazy-init: the inner `proc p` redefines the outer; nested-redefinition
+        // detection forces a fallback so the result matches a whole-file walk.
+        eq("proc p {a} { proc p {a} { return $a }\n p $a }\n");
     }
 }

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -84,6 +84,7 @@ impl Analyser {
     /// in salsa so a body edit recomputes only that body.  Method bodies are
     /// filled in place.  Byte-identical to `analyse` whenever `body_fn` returns
     /// what [`analyse_proc_body_isolated`] would.
+    #[allow(clippy::too_many_lines)]
     pub fn analyse_per_item_with(
         &mut self,
         source: &str,
@@ -194,9 +195,45 @@ impl Analyser {
             self.result.all_procs.keys().cloned().collect();
         for db in &deferred {
             if db.is_method {
-                // Method bodies: fill in place (byte-identical; not memoised).
+                // Method bodies fill their scope in place (byte-identical for the
+                // walk itself).  But a method that *defines* a proc/class does so
+                // in pass-2 order, not the source order a whole-file walk uses —
+                // so a name it defines that is also defined elsewhere would win
+                // here yet lose (or accumulate differently) there.  Detect that
+                // and fall back.  Cheap: only snapshot when the body text
+                // actually defines a proc/class.
                 self.last_comment = String::new();
+                let before_classes = body_word_defines(&db.body_text, CLASS_DEFINERS)
+                    .then(|| self.result.all_classes.clone());
+                let before_procs = body_word_defines(&db.body_text, &["proc"])
+                    .then(|| self.result.all_procs.clone());
                 self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
+                // A method that defines/extends a class diverges like a
+                // class-defining proc body (accumulation order) — fall back.
+                if let Some(before) = before_classes {
+                    if self
+                        .result
+                        .all_classes
+                        .iter()
+                        .any(|(k, v)| before.get(k) != Some(v))
+                    {
+                        return self.fresh_full_analyse(source, dialect);
+                    }
+                }
+                // A method that (re)defines a proc whose name is defined
+                // elsewhere is a duplicate at the shared `all_procs` key.
+                if let Some(before) = before_procs {
+                    let mut collision = false;
+                    for (k, v) in &self.result.all_procs {
+                        if before.get(k) != Some(v) && !defined_procs.insert(k.clone()) {
+                            collision = true;
+                            break;
+                        }
+                    }
+                    if collision {
+                        return self.fresh_full_analyse(source, dialect);
+                    }
+                }
             } else {
                 // Proc bodies: analyse in isolation (a pure function of the
                 // body — the unit memoised by `body_fn`) and graft into shell.
@@ -529,6 +566,27 @@ fn reconstruct_proc_scope(
     path
 }
 
+/// Class-defining / object-aliasing command heads whose facts accumulate across
+/// bodies in a whole-file walk (remove → add → re-insert) — which the per-item
+/// graft's overwrite-on-key can't reproduce.
+const CLASS_DEFINERS: &[&str] = &[
+    "oo::define",
+    "oo::objdefine",
+    "oo::class",
+    "oo::copy",
+    "itcl::class",
+];
+
+/// Word-level test: does `body_text` use any of `words` as a (whitespace- or
+/// punctuation-delimited) command word?  Used as a cheap pre-filter before the
+/// more expensive snapshot/diff that confirms what a method body actually
+/// defined.  False positives only cost a snapshot, never correctness.
+fn body_word_defines(body_text: &str, words: &[&str]) -> bool {
+    body_text
+        .split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_'))
+        .any(|w| words.contains(&w))
+}
+
 /// Does an isolated proc body interact with enclosing-scope / object state in a
 /// way the per-item graft can't reproduce byte-for-byte, forcing a full-rebuild
 /// fallback?  True when the body:
@@ -548,24 +606,14 @@ fn reconstruct_proc_scope(
 /// replayed on the shell's globals at graft time, so they stay on the fast path.
 /// Conservative — a false positive only costs a full rebuild, never correctness.
 fn body_needs_enclosing_context(body_text: &str) -> bool {
-    const DECLARERS: &[&str] = &[
-        "variable",
-        "global",
-        "upvar",
-        "namespace",
-        "oo::define",
-        "oo::objdefine",
-        "oo::class",
-        "oo::copy",
-        "itcl::class",
-    ];
+    const DECLARERS: &[&str] = &["variable", "global", "upvar", "namespace"];
     const WRITERS: &[&str] = &["set", "incr", "lappend", "append", "dict", "array"];
     let words: Vec<&str> = body_text
         .split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_'))
         .filter(|w| !w.is_empty())
         .collect();
     for (i, &w) in words.iter().enumerate() {
-        if DECLARERS.contains(&w) {
+        if DECLARERS.contains(&w) || CLASS_DEFINERS.contains(&w) {
             return true;
         }
         // A writer whose next word or two is a `::`-qualified target writes an
@@ -610,6 +658,19 @@ mod tests {
     #[test]
     fn oo_class_with_method() {
         eq("oo::class create K {\n  variable n\n  method m {a} { set n $a; return $n }\n}\n");
+    }
+
+    #[test]
+    fn method_body_defines_duplicate_proc() {
+        // A method that defines `::p`, plus a later top-level `proc p`: a
+        // whole-file walk ends with the top-level definition (source order),
+        // so the per-item path must fall back rather than let the pass-2
+        // method body win the shared `all_procs["::p"]` key.
+        eq("oo::class create C { method m {} { proc p {} { return 1 } } }\nproc p {} { return 2 }\n");
+        // Same, reversed order (top-level first, then the method).
+        eq("proc p {} { return 2 }\noo::class create C { method m {} { proc p {} { return 1 } } }\n");
+        // A method that defines a non-colliding proc stays byte-identical too.
+        eq("oo::class create C { method m {} { proc helper {} { return 1 } } }\n");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -40,7 +40,7 @@ use super::types::AnalysisResult;
 /// fills it — proc bodies via an **isolated** analysis (memoisable), method
 /// bodies in place (byte-identical, not yet memoised).
 #[derive(Debug, Clone)]
-pub(super) struct DeferredBody {
+pub struct DeferredBody {
     /// Body text (braces stripped), as `analyse_body` expects.
     pub body_text: String,
     /// The body's `Str` token (absolute span) — drives offset arithmetic.
@@ -64,8 +64,35 @@ pub(super) struct DeferredBody {
 
 impl Analyser {
     /// Per-item analysis entry — byte-identical to [`Analyser::analyse`] for
-    /// well-formed input, falling back to it otherwise. See module docs.
+    /// well-formed input, falling back to it otherwise. Analyses each proc body
+    /// directly. See module docs.
     pub fn analyse_per_item(&mut self, source: &str, dialect: &str) -> AnalysisResult {
+        let disabled = self.disabled_diagnostics.clone();
+        let non_ascii = self.non_ascii_mode;
+        let empty_overlay = super::types::build_stub_overlay(&[]);
+        let mut body_fn = |db: &DeferredBody| {
+            analyse_proc_body_isolated(
+                db,
+                dialect,
+                &disabled,
+                non_ascii,
+                Some(empty_overlay.clone()),
+            )
+        };
+        self.analyse_per_item_with(source, dialect, &mut body_fn)
+    }
+
+    /// As [`Self::analyse_per_item`], but each *proc* body's isolated analysis
+    /// is produced by `body_fn` — letting a caller (the LSP query DB) memoise it
+    /// in salsa so a body edit recomputes only that body.  Method bodies are
+    /// filled in place.  Byte-identical to `analyse` whenever `body_fn` returns
+    /// what [`analyse_proc_body_isolated`] would.
+    pub fn analyse_per_item_with(
+        &mut self,
+        source: &str,
+        dialect: &str,
+        body_fn: &mut dyn FnMut(&DeferredBody) -> BodyFragment,
+    ) -> AnalysisResult {
         use std::collections::HashSet;
         use tcl_registry::CommandRegistry;
 
@@ -148,14 +175,8 @@ impl Analyser {
                 self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
             } else {
                 // Proc bodies: analyse in isolation (a pure function of the
-                // body — the unit slice 3 memoises) and graft into the shell.
-                let frag = analyse_proc_body_isolated(
-                    db,
-                    &self.dialect,
-                    &self.disabled_diagnostics,
-                    self.non_ascii_mode,
-                    self.stub_overlay.clone(),
-                );
+                // body — the unit memoised by `body_fn`) and graft into shell.
+                let frag = body_fn(db);
                 self.graft_proc_body(db, frag);
             }
         }
@@ -213,8 +234,10 @@ impl Analyser {
     }
 }
 
-/// The facts produced by analysing one proc body in isolation.
-struct BodyFragment {
+/// The facts produced by analysing one proc body in isolation.  Cloneable +
+/// `PartialEq` so the LSP query DB can memoise it (salsa early-cutoff).
+#[derive(Clone, PartialEq)]
+pub struct BodyFragment {
     result: AnalysisResult,
     proc_scope: super::types::Scope,
     ensembles: std::collections::HashSet<String>,
@@ -229,7 +252,9 @@ struct BodyFragment {
 /// offset so the handlers' span re-slicing stays in range, and the proc's
 /// enclosing namespace + params are reconstructed) so the facts need no
 /// rebasing.  Offset-invariant memoisation (offset-0 + rebase) is a follow-up.
-fn analyse_proc_body_isolated(
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn analyse_proc_body_isolated(
     db: &DeferredBody,
     dialect: &str,
     disabled: &std::collections::HashSet<String>,

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -1,0 +1,229 @@
+//! Per-item incremental analysis (slice 2b/3 of
+//! `docs/design/rust/incremental-analysis.md`).
+//!
+//! [`Analyser::analyse_per_item`] reproduces [`Analyser::analyse`]
+//! **byte-for-byte** but decomposed so each top-level **proc / method body** is
+//! analysed as a separate unit — the granularity at which slice 3 memoises the
+//! expensive per-line walk (a body edit then re-analyses only that body).
+//!
+//! ## How it stays byte-identical
+//!
+//! The walk is split into two passes over the *same* analyser:
+//! 1. **Shell pass** — walk the top level with `defer_proc_bodies = true`, so
+//!    `handle_proc_command` / OO method walks create each body's scope (params
+//!    defined, `body_span` set) but record the body in `deferred_bodies` instead
+//!    of recursing. The whole top level (incl. `namespace eval` / control-flow
+//!    bodies and the procs they contain) is walked here, so top-level variable
+//!    flow is identical to `analyse`.
+//! 2. **Body pass** — for each deferred body, `analyse_body` fills its
+//!    already-created scope *in place*, with `defer_proc_bodies = false` so
+//!    nested defs walk within their enclosing unit.
+//!
+//! Splitting top-level vs body work reorders the walk-populated collections
+//! (`command_invocations`, `VarDef.references`, …) relative to `analyse`'s DFS,
+//! but those are made order-independent by `canonicalize_result_order` in the
+//! shared tail — so the merged result matches. The cross-item tail
+//! (`run_diagnostic_emitters`: W123 / arity / whole-source CFG-SSA) runs once at
+//! the end, exactly as in `analyse`.
+//!
+//! Correctness rests on the differential fuzzer + the `per_item == analyse`
+//! corpus gate, with a **full-rebuild fallback** for anything not provably
+//! equivalent (error recovery / partial commands / inline stub directives).
+
+use tcl_lexer::Token;
+
+use super::state::Analyser;
+use super::types::AnalysisResult;
+
+/// A proc / method body deferred by the shell pass for a second analysis pass.
+/// Its scope already exists at `scope_path` (params defined); the body pass
+/// calls `analyse_body` to fill it.
+#[derive(Debug, Clone)]
+pub(super) struct DeferredBody {
+    /// Body text (braces stripped), as `analyse_body` expects.
+    pub body_text: String,
+    /// The body's `Str` token (absolute span) — drives offset arithmetic.
+    pub body_tok: Token,
+    /// Path to the already-created (empty) proc / method scope to fill.
+    pub scope_path: Vec<usize>,
+}
+
+impl Analyser {
+    /// Per-item analysis entry — byte-identical to [`Analyser::analyse`] for
+    /// well-formed input, falling back to it otherwise. See module docs.
+    pub fn analyse_per_item(&mut self, source: &str, dialect: &str) -> AnalysisResult {
+        use std::collections::HashSet;
+        use tcl_registry::CommandRegistry;
+
+        // Recovery / stub overlays are only modelled on the full `analyse`
+        // path; fall back so the per-item result can never diverge.
+        if !tcl_lexer::script_is_complete(source) || source.contains("tcl-lsp: stub") {
+            return self.analyse(source, dialect);
+        }
+
+        // --- setup, mirroring `analyse` (gated by the corpus `per_item ==
+        // analyse` test) ---
+        self.source = source.to_string();
+        self.dialect = dialect.to_string();
+        let file_codes = super::utils::parse_file_suppression(source);
+        for code in &file_codes {
+            self.disabled_diagnostics.insert(code.clone());
+        }
+        if !file_codes.is_empty() {
+            self.result
+                .suppressed_lines
+                .insert(-1, file_codes.iter().cloned().collect());
+        }
+        super::state::merge_noqa_line_suppressions(
+            &mut self.result.suppressed_lines,
+            super::utils::parse_noqa_line_suppressions(source),
+        );
+        let (stub_cmds, stub_exprs) = super::utils::scan_source_for_stubs(source);
+        self.stub_overlay = Some(super::types::build_stub_overlay(&stub_cmds));
+        self.result.stub_commands = stub_cmds;
+        self.result.stub_expr_defs = stub_exprs;
+
+        let mut registry = CommandRegistry::build_default();
+        if let Some(d) = tcl_registry::prelude::DialectSet::parse(&self.dialect) {
+            registry.load_dialect(d);
+        }
+        self.registry = Some(registry);
+        self.line_offsets = Some(super::state::compute_line_offsets(source));
+        let known: HashSet<&str> = self
+            .registry
+            .as_ref()
+            .expect("registry just stashed")
+            .command_names()
+            .collect();
+        let mut commands = crate::segmenter::segment_commands_with_recovery_and_config(
+            source,
+            &known,
+            self.lexer_config(),
+        );
+        drop(known);
+
+        // Error recovery → fall back to full `analyse` (its ghost-recovery /
+        // partial-command handling is not reproduced on the per-item path).
+        let ghost = self.apply_ghost_recovery(source, &mut commands);
+        if ghost || commands.iter().any(|c| c.is_partial) {
+            return self.fresh_full_analyse(source, dialect);
+        }
+
+        // --- pass 1: shell (defer proc/method bodies) ---
+        self.defer_proc_bodies = true;
+        self.walk_commands_top_level(&commands, false);
+        self.defer_proc_bodies = false;
+
+        // --- pass 2: fill each deferred body in place ---
+        let deferred = std::mem::take(&mut self.deferred_bodies);
+        // Phase-A fallback: a deferred body that writes *enclosing*-scope state
+        // (namespace vars via `variable`/`global`/`upvar`, classes via
+        // `oo::define`/`oo::objdefine`, object instances) is order-sensitive
+        // across the shell/body split — the 2-pass order can pick a different
+        // first/last writer than `analyse`'s single DFS pass.  Until Phase B
+        // models that, fall back to a full rebuild for such files.
+        if deferred
+            .iter()
+            .any(|db| body_writes_enclosing_state(&db.body_text))
+        {
+            return self.fresh_full_analyse(source, dialect);
+        }
+        for db in deferred {
+            // `analyse` takes `last_comment` before each body walk so the body
+            // starts with no inherited doc-comment; mirror that here.
+            self.last_comment = String::new();
+            self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
+        }
+
+        // --- tail (cross-item passes; canonicalises order) ---
+        self.run_diagnostic_emitters(source);
+
+        let result = std::mem::take(&mut self.result);
+        self.clear_run_state();
+        result
+    }
+}
+
+/// Heuristic: does a body (textually) contain a command that writes state
+/// keyed *outside* its own scope subtree — making per-item analysis
+/// order-sensitive?  Conservative (word-level scan; false positives only cost a
+/// fallback, never correctness).  Phase A; Phase B will model these precisely.
+fn body_writes_enclosing_state(body_text: &str) -> bool {
+    // Standalone commands that link/define enclosing-scope or object state.
+    const RISKY: &[&str] = &[
+        "variable",
+        "global",
+        "upvar",
+        "namespace",
+        "oo::define",
+        "oo::objdefine",
+        "oo::class",
+        "oo::copy",
+        "itcl::class",
+        "interp",
+        "rename",
+        "new",
+        "create",
+    ];
+    // Var-writer commands; a `::`-qualified target writes a namespace/global
+    // var from inside the body (e.g. `set ::ns::x`, `incr ::ns::n`).
+    const WRITERS: &[&str] = &["set", "incr", "lappend", "append", "dict", "array"];
+    let words: Vec<&str> = body_text
+        .split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_'))
+        .filter(|w| !w.is_empty())
+        .collect();
+    for (i, &w) in words.iter().enumerate() {
+        if RISKY.contains(&w) {
+            return true;
+        }
+        if WRITERS.contains(&w) {
+            // a `::`-qualified target within the next two words (covers
+            // `set ::x` and `dict set ::x` / `array set ::x`)
+            if words[i + 1..].iter().take(2).any(|t| t.contains("::")) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eq(src: &str) {
+        let want = Analyser::new().analyse(src, "tcl8.6");
+        let got = Analyser::new().analyse_per_item(src, "tcl8.6");
+        assert_eq!(got, want, "per_item != analyse for:\n{src}");
+    }
+
+    #[test]
+    fn two_top_level_procs() {
+        eq("proc a {} { set x 1 }\nproc b {} { puts hi }\n");
+    }
+
+    #[test]
+    fn proc_calling_proc() {
+        eq("proc a {x} { return $x }\nproc b {} { a 1 }\n");
+    }
+
+    #[test]
+    fn namespace_and_top_level_code() {
+        eq("namespace eval ns { proc foo {} {} }\nset g 1\nputs $g\n");
+    }
+
+    #[test]
+    fn top_level_global_read_in_body() {
+        eq("set g 1\nproc r {} { puts $::g }\nputs $g\n");
+    }
+
+    #[test]
+    fn oo_class_with_method() {
+        eq("oo::class create K {\n  variable n\n  method m {a} { set n $a; return $n }\n}\n");
+    }
+
+    #[test]
+    fn nested_proc_in_body() {
+        eq("proc outer {} { proc ::inner {} { set z 1 } ; inner }\n");
+    }
+}

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -37,7 +37,8 @@ use super::types::AnalysisResult;
 
 /// A proc / method body deferred by the shell pass for a second analysis pass.
 /// Its scope already exists at `scope_path` (params defined); the body pass
-/// calls `analyse_body` to fill it.
+/// fills it — proc bodies via an **isolated** analysis (memoisable), method
+/// bodies in place (byte-identical, not yet memoised).
 #[derive(Debug, Clone)]
 pub(super) struct DeferredBody {
     /// Body text (braces stripped), as `analyse_body` expects.
@@ -46,6 +47,19 @@ pub(super) struct DeferredBody {
     pub body_tok: Token,
     /// Path to the already-created (empty) proc / method scope to fill.
     pub scope_path: Vec<usize>,
+    /// `true` for an OO method/constructor/destructor body (filled in place);
+    /// `false` for a `proc` body (analysed in isolation).
+    pub is_method: bool,
+    /// Lexical namespace of the proc (e.g. `"::ns"`), for reconstructing the
+    /// isolated analysis context. (Proc bodies only.)
+    pub namespace: String,
+    /// The proc scope's name (as written) — used for `all_variables` keys.
+    pub scope_name: String,
+    /// The proc's declared parameters (locals in the body). (Proc bodies only.)
+    pub params: Vec<crate::signature_scan::types::ParamDef>,
+    /// Span the proc anchors its parameter definitions to (the proc-name token),
+    /// so the isolated analysis records identical param `VarDef`s. (Proc only.)
+    pub name_span: tcl_lexer::Span,
 }
 
 impl Analyser {
@@ -114,25 +128,36 @@ impl Analyser {
         self.walk_commands_top_level(&commands, false);
         self.defer_proc_bodies = false;
 
-        // --- pass 2: fill each deferred body in place ---
+        // --- pass 2: fill each deferred body ---
         let deferred = std::mem::take(&mut self.deferred_bodies);
-        // Phase-A fallback: a deferred body that writes *enclosing*-scope state
-        // (namespace vars via `variable`/`global`/`upvar`, classes via
-        // `oo::define`/`oo::objdefine`, object instances) is order-sensitive
-        // across the shell/body split — the 2-pass order can pick a different
-        // first/last writer than `analyse`'s single DFS pass.  Until Phase B
-        // models that, fall back to a full rebuild for such files.
+        // Phase-A fallback: a PROC body analysed in isolation can't see
+        // enclosing-scope state, so a body that reads/writes a namespace/global
+        // var or defines classes/instances would diverge.  Fall back to a full
+        // rebuild for those files (method bodies are filled in place below, so
+        // they don't need this guard).  Phase B will pre-seed enclosing defs.
         if deferred
             .iter()
-            .any(|db| body_writes_enclosing_state(&db.body_text))
+            .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text))
         {
             return self.fresh_full_analyse(source, dialect);
         }
-        for db in deferred {
-            // `analyse` takes `last_comment` before each body walk so the body
-            // starts with no inherited doc-comment; mirror that here.
-            self.last_comment = String::new();
-            self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
+        for db in &deferred {
+            if db.is_method {
+                // Method bodies: fill in place (byte-identical; not memoised).
+                self.last_comment = String::new();
+                self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
+            } else {
+                // Proc bodies: analyse in isolation (a pure function of the
+                // body — the unit slice 3 memoises) and graft into the shell.
+                let frag = analyse_proc_body_isolated(
+                    db,
+                    &self.dialect,
+                    &self.disabled_diagnostics,
+                    self.non_ascii_mode,
+                    self.stub_overlay.clone(),
+                );
+                self.graft_proc_body(db, frag);
+            }
         }
 
         // --- tail (cross-item passes; canonicalises order) ---
@@ -142,14 +167,149 @@ impl Analyser {
         self.clear_run_state();
         result
     }
+
+    /// Graft an isolated proc body's facts (`frag`) into `self` (the shell):
+    /// replace the empty proc scope's contents and union the flat maps / vecs /
+    /// walk-state.  Order is canonicalised by the tail, so plain extend is fine.
+    fn graft_proc_body(&mut self, db: &DeferredBody, frag: BodyFragment) {
+        if let Some(ps) = super::scope::scope_at_mut(&mut self.result.global_scope, &db.scope_path)
+        {
+            ps.variables = frag.proc_scope.variables;
+            ps.procs = frag.proc_scope.procs;
+            ps.classes = frag.proc_scope.classes;
+            ps.children = frag.proc_scope.children;
+        }
+        let r = frag.result;
+        self.result.all_procs.extend(r.all_procs);
+        self.result.all_classes.extend(r.all_classes);
+        self.result.all_variables.extend(r.all_variables);
+        self.result.command_aliases.extend(r.command_aliases);
+        self.result.instance_classes.extend(r.instance_classes);
+        self.result.diagnostics.extend(r.diagnostics);
+        self.result
+            .command_invocations
+            .extend(r.command_invocations);
+        self.result.package_requires.extend(r.package_requires);
+        self.result.package_provides.extend(r.package_provides);
+        self.result.source_targets.extend(r.source_targets);
+        self.result.namespace_imports.extend(r.namespace_imports);
+        self.result.auto_path_entries.extend(r.auto_path_entries);
+        self.result.regex_patterns.extend(r.regex_patterns);
+        self.result.has_dynamic_providers |= r.has_dynamic_providers;
+        if self.result.unknown_proc_info.is_none() {
+            self.result.unknown_proc_info = r.unknown_proc_info;
+        }
+        for (line, codes) in r.suppressed_lines {
+            self.result
+                .suppressed_lines
+                .entry(line)
+                .or_default()
+                .extend(codes);
+        }
+        self.ensemble_namespaces.extend(frag.ensembles);
+        self.pending_arity.extend(frag.pending_arity);
+        self.var_command_sites.extend(frag.var_sites);
+        self.cmd_command_sites.extend(frag.cmd_sites);
+    }
 }
 
-/// Heuristic: does a body (textually) contain a command that writes state
-/// keyed *outside* its own scope subtree — making per-item analysis
-/// order-sensitive?  Conservative (word-level scan; false positives only cost a
-/// fallback, never correctness).  Phase A; Phase B will model these precisely.
-fn body_writes_enclosing_state(body_text: &str) -> bool {
-    // Standalone commands that link/define enclosing-scope or object state.
+/// The facts produced by analysing one proc body in isolation.
+struct BodyFragment {
+    result: AnalysisResult,
+    proc_scope: super::types::Scope,
+    ensembles: std::collections::HashSet<String>,
+    pending_arity: Vec<(String, String, bool, super::types::Diagnostic)>,
+    var_sites: Vec<super::state::VarCommandSite>,
+    cmd_sites: Vec<super::state::CmdCommandSite>,
+}
+
+/// Analyse one `proc` body as an isolated unit — a pure function of
+/// `(offset, body_text, namespace, params)` (slice 3 memoises this).  The body
+/// is walked at its real absolute offset (the source is space-padded up to that
+/// offset so the handlers' span re-slicing stays in range, and the proc's
+/// enclosing namespace + params are reconstructed) so the facts need no
+/// rebasing.  Offset-invariant memoisation (offset-0 + rebase) is a follow-up.
+fn analyse_proc_body_isolated(
+    db: &DeferredBody,
+    dialect: &str,
+    disabled: &std::collections::HashSet<String>,
+    non_ascii: super::state::NonAsciiMode,
+    stub_overlay: Option<tcl_registry::stub_overlay::StubOverlay>,
+) -> BodyFragment {
+    use tcl_registry::CommandRegistry;
+    let mut a =
+        Analyser::with_disabled_diagnostics(disabled.clone()).with_non_ascii_mode(non_ascii);
+    a.dialect = dialect.to_string();
+    a.stub_overlay = stub_overlay;
+    // `analyse_body` segments `body_text` at `span.start() + content_offset`
+    // (skipping the opening `{`), so place the content there in the padded
+    // source for the handlers' absolute span re-slicing to line up.
+    let abs = db.body_tok.span.start() as usize + db.body_tok.content_offset as usize;
+    let mut src = " ".repeat(abs);
+    src.push_str(&db.body_text);
+    a.source = src;
+    let mut registry = CommandRegistry::build_default();
+    if let Some(d) = tcl_registry::prelude::DialectSet::parse(dialect) {
+        registry.load_dialect(d);
+    }
+    a.registry = Some(registry);
+    a.line_offsets = Some(super::state::compute_line_offsets(&a.source));
+    let proc_path =
+        reconstruct_proc_scope(&mut a.result.global_scope, &db.namespace, &db.scope_name);
+    let dummy = Token::new(tcl_lexer::TokenType::Str, db.name_span);
+    for p in &db.params {
+        a.define_var(&p.name, dummy, &proc_path, false, Some(db.name_span));
+    }
+    a.analyse_body(&db.body_text, db.body_tok, &proc_path);
+    let proc_scope = super::scope::scope_at_mut(&mut a.result.global_scope, &proc_path)
+        .expect("reconstructed proc scope")
+        .clone();
+    BodyFragment {
+        result: a.result,
+        proc_scope,
+        ensembles: a.ensemble_namespaces,
+        pending_arity: a.pending_arity,
+        var_sites: a.var_command_sites,
+        cmd_sites: a.cmd_command_sites,
+    }
+}
+
+/// Build `global -> namespace* -> proc` scopes mirroring the proc's lexical
+/// context (so nested defs qualify identically), returning the proc scope path.
+fn reconstruct_proc_scope(
+    root: &mut super::types::Scope,
+    namespace: &str,
+    scope_name: &str,
+) -> Vec<usize> {
+    use super::types::{Scope, ScopeKind};
+    let comps: Vec<&str> = namespace
+        .trim_start_matches(':')
+        .split("::")
+        .filter(|s| !s.is_empty())
+        .collect();
+    let mut path: Vec<usize> = Vec::new();
+    for comp in comps {
+        let parent = super::scope::scope_at_mut(root, &path).expect("scope path");
+        let i = parent.children.len();
+        parent.children.push(Scope::new(ScopeKind::Namespace, comp));
+        path.push(i);
+    }
+    let parent = super::scope::scope_at_mut(root, &path).expect("scope path");
+    let pi = parent.children.len();
+    parent
+        .children
+        .push(Scope::new(ScopeKind::Proc, scope_name));
+    path.push(pi);
+    path
+}
+
+/// Does an isolated proc body need enclosing-scope context to match `analyse`?
+/// True if it references a `::`-qualified variable (read `$::x` / `${ns::x}` or
+/// a writer command targeting `::x`), or runs a command that defines/links
+/// enclosing-scope or object state.  Conservative — a false positive only costs
+/// a full-rebuild fallback, never correctness.  Phase B pre-seeds the enclosing
+/// defs to shrink this set.
+fn body_needs_enclosing_context(body_text: &str) -> bool {
     const RISKY: &[&str] = &[
         "variable",
         "global",
@@ -165,8 +325,6 @@ fn body_writes_enclosing_state(body_text: &str) -> bool {
         "new",
         "create",
     ];
-    // Var-writer commands; a `::`-qualified target writes a namespace/global
-    // var from inside the body (e.g. `set ::ns::x`, `incr ::ns::n`).
     const WRITERS: &[&str] = &["set", "incr", "lappend", "append", "dict", "array"];
     let words: Vec<&str> = body_text
         .split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_'))
@@ -176,12 +334,29 @@ fn body_writes_enclosing_state(body_text: &str) -> bool {
         if RISKY.contains(&w) {
             return true;
         }
-        if WRITERS.contains(&w) {
-            // a `::`-qualified target within the next two words (covers
-            // `set ::x` and `dict set ::x` / `array set ::x`)
-            if words[i + 1..].iter().take(2).any(|t| t.contains("::")) {
+        if WRITERS.contains(&w) && words[i + 1..].iter().take(2).any(|t| t.contains("::")) {
+            return true;
+        }
+    }
+    // Qualified variable *read*: `$::x`, `${::x}`, `$ns::x`, `${ns::x}`.
+    let b = body_text.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'$' {
+            let mut j = i + 1;
+            if j < b.len() && b[j] == b'{' {
+                j += 1;
+            }
+            let start = j;
+            while j < b.len() && (b[j].is_ascii_alphanumeric() || b[j] == b':' || b[j] == b'_') {
+                j += 1;
+            }
+            if body_text[start..j].contains("::") {
                 return true;
             }
+            i = j.max(i + 1);
+        } else {
+            i += 1;
         }
     }
     false

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -57,9 +57,6 @@ pub struct DeferredBody {
     pub scope_name: String,
     /// The proc's declared parameters (locals in the body). (Proc bodies only.)
     pub params: Vec<crate::signature_scan::types::ParamDef>,
-    /// Span the proc anchors its parameter definitions to (the proc-name token),
-    /// so the isolated analysis records identical param `VarDef`s. (Proc only.)
-    pub name_span: tcl_lexer::Span,
 }
 
 impl Analyser {
@@ -189,13 +186,24 @@ impl Analyser {
         result
     }
 
-    /// Graft an isolated proc body's facts (`frag`) into `self` (the shell):
-    /// replace the empty proc scope's contents and union the flat maps / vecs /
-    /// walk-state.  Order is canonicalised by the tail, so plain extend is fine.
-    fn graft_proc_body(&mut self, db: &DeferredBody, frag: BodyFragment) {
+    /// Graft an isolated (offset-0) proc body's facts into `self` (the shell):
+    /// **rebase** every span by the body's real position, then merge.  The shell
+    /// already holds the params (with their real name-span), so variables are
+    /// merge-or-inserted (an existing key is a param → keep its def span, add the
+    /// body's reads; a new key is a body local → insert).  Order is canonicalised
+    /// by the tail, so plain `extend` is fine for the rest.
+    fn graft_proc_body(&mut self, db: &DeferredBody, mut frag: BodyFragment) {
+        // Rebase: body facts are relative to the body content start.
+        let delta = db.body_tok.span.start() + u32::from(db.body_tok.content_offset);
+        let line_delta = self
+            .line_offsets
+            .as_deref()
+            .map_or(0, |lo| super::state::line_at_offset(lo, delta as usize));
+        rebase_fragment(&mut frag, delta, line_delta);
+
         if let Some(ps) = super::scope::scope_at_mut(&mut self.result.global_scope, &db.scope_path)
         {
-            ps.variables = frag.proc_scope.variables;
+            merge_scope_vars(&mut ps.variables, frag.proc_scope.variables);
             ps.procs = frag.proc_scope.procs;
             ps.classes = frag.proc_scope.classes;
             ps.children = frag.proc_scope.children;
@@ -203,7 +211,7 @@ impl Analyser {
         let r = frag.result;
         self.result.all_procs.extend(r.all_procs);
         self.result.all_classes.extend(r.all_classes);
-        self.result.all_variables.extend(r.all_variables);
+        merge_scope_vars(&mut self.result.all_variables, r.all_variables);
         self.result.command_aliases.extend(r.command_aliases);
         self.result.instance_classes.extend(r.instance_classes);
         self.result.diagnostics.extend(r.diagnostics);
@@ -246,12 +254,13 @@ pub struct BodyFragment {
     cmd_sites: Vec<super::state::CmdCommandSite>,
 }
 
-/// Analyse one `proc` body as an isolated unit — a pure function of
-/// `(offset, body_text, namespace, params)` (slice 3 memoises this).  The body
-/// is walked at its real absolute offset (the source is space-padded up to that
-/// offset so the handlers' span re-slicing stays in range, and the proc's
-/// enclosing namespace + params are reconstructed) so the facts need no
-/// rebasing.  Offset-invariant memoisation (offset-0 + rebase) is a follow-up.
+/// Analyse one `proc` body as an isolated unit at **offset 0** — a pure
+/// function of `(body_text, namespace, scope_name, params)`, so a
+/// shifted-but-unedited proc is a cache hit (offset-invariant).  The enclosing
+/// namespace + params are reconstructed; params get a placeholder definition
+/// span (the aggregator keeps the shell's real one).  Spans/lines are relative
+/// to the body start; [`Analyser::graft_proc_body`] rebases them by the body's
+/// real position.
 #[must_use]
 #[allow(clippy::implicit_hasher)]
 pub fn analyse_proc_body_isolated(
@@ -266,13 +275,14 @@ pub fn analyse_proc_body_isolated(
         Analyser::with_disabled_diagnostics(disabled.clone()).with_non_ascii_mode(non_ascii);
     a.dialect = dialect.to_string();
     a.stub_overlay = stub_overlay;
-    // `analyse_body` segments `body_text` at `span.start() + content_offset`
-    // (skipping the opening `{`), so place the content there in the padded
-    // source for the handlers' absolute span re-slicing to line up.
-    let abs = db.body_tok.span.start() as usize + db.body_tok.content_offset as usize;
-    let mut src = " ".repeat(abs);
-    src.push_str(&db.body_text);
-    a.source = src;
+    // Offset 0: the body content is the whole source; a synthetic `Str` body
+    // token spans it with `content_offset = 0` (no `{` to skip).
+    a.source.clone_from(&db.body_text);
+    #[allow(clippy::cast_possible_truncation)]
+    let body_tok = Token::new(
+        tcl_lexer::TokenType::Str,
+        tcl_lexer::Span::new(0, db.body_text.len() as u32),
+    );
     let mut registry = CommandRegistry::build_default();
     if let Some(d) = tcl_registry::prelude::DialectSet::parse(dialect) {
         registry.load_dialect(d);
@@ -281,11 +291,12 @@ pub fn analyse_proc_body_isolated(
     a.line_offsets = Some(super::state::compute_line_offsets(&a.source));
     let proc_path =
         reconstruct_proc_scope(&mut a.result.global_scope, &db.namespace, &db.scope_name);
-    let dummy = Token::new(tcl_lexer::TokenType::Str, db.name_span);
+    let placeholder = tcl_lexer::Span::new(0, 0);
+    let dummy = Token::new(tcl_lexer::TokenType::Str, placeholder);
     for p in &db.params {
-        a.define_var(&p.name, dummy, &proc_path, false, Some(db.name_span));
+        a.define_var(&p.name, dummy, &proc_path, false, Some(placeholder));
     }
-    a.analyse_body(&db.body_text, db.body_tok, &proc_path);
+    a.analyse_body(&db.body_text, body_tok, &proc_path);
     let proc_scope = super::scope::scope_at_mut(&mut a.result.global_scope, &proc_path)
         .expect("reconstructed proc scope")
         .clone();
@@ -296,6 +307,148 @@ pub fn analyse_proc_body_isolated(
         pending_arity: a.pending_arity,
         var_sites: a.var_command_sites,
         cmd_sites: a.cmd_command_sites,
+    }
+}
+
+/// Merge body-derived variables into a scope/`all_variables` map: an existing
+/// key is a param the shell already recorded (keep its real definition span;
+/// add the body's reads / warn flag / array indices); a new key is a body local
+/// (insert).
+fn merge_scope_vars(
+    dst: &mut std::collections::HashMap<String, super::types::VarDef>,
+    src: std::collections::HashMap<String, super::types::VarDef>,
+) {
+    for (k, v) in src {
+        if let Some(existing) = dst.get_mut(&k) {
+            existing.references.extend(v.references);
+            existing.warn_if_unused |= v.warn_if_unused;
+            existing.array_indices.extend(v.array_indices);
+        } else {
+            dst.insert(k, v);
+        }
+    }
+}
+
+fn shift(s: tcl_lexer::Span, d: u32) -> tcl_lexer::Span {
+    tcl_lexer::Span::new(s.start() + d, s.end() + d)
+}
+
+fn rebase_vardef(v: &mut super::types::VarDef, d: u32) {
+    v.definition_span = shift(v.definition_span, d);
+    for r in &mut v.references {
+        *r = shift(*r, d);
+    }
+}
+
+fn rebase_proc(p: &mut super::types::ProcDef, d: u32) {
+    p.name_span = shift(p.name_span, d);
+    p.body_span = shift(p.body_span, d);
+}
+
+fn rebase_method(m: &mut super::types::MethodDef, d: u32) {
+    m.name_span = shift(m.name_span, d);
+    m.body_span = shift(m.body_span, d);
+}
+
+fn rebase_class(c: &mut super::types::ClassDef, d: u32) {
+    c.name_span = shift(c.name_span, d);
+    c.body_span = shift(c.body_span, d);
+    for m in c.methods.values_mut().chain(c.class_methods.values_mut()) {
+        rebase_method(m, d);
+    }
+    for m in &mut c.constructors {
+        rebase_method(m, d);
+    }
+    if let Some(m) = &mut c.destructor {
+        rebase_method(m, d);
+    }
+    for (_, sp) in c.superclass_refs.iter_mut().chain(c.mixin_refs.iter_mut()) {
+        *sp = shift(*sp, d);
+    }
+    for p in c.properties.values_mut() {
+        p.name_span = shift(p.name_span, d);
+    }
+}
+
+fn rebase_diag(diag: &mut super::types::Diagnostic, d: u32) {
+    diag.span = shift(diag.span, d);
+    for f in &mut diag.fixes {
+        f.span = shift(f.span, d);
+    }
+}
+
+fn rebase_scope(s: &mut super::types::Scope, d: u32) {
+    if let Some(bs) = &mut s.body_span {
+        *bs = shift(*bs, d);
+    }
+    for v in s.variables.values_mut() {
+        rebase_vardef(v, d);
+    }
+    for p in s.procs.values_mut() {
+        rebase_proc(p, d);
+    }
+    for c in s.classes.values_mut() {
+        rebase_class(c, d);
+    }
+    for ch in &mut s.children {
+        rebase_scope(ch, d);
+    }
+}
+
+/// Shift every span in an offset-0 body fragment to the body's real position
+/// (`d` bytes; suppressed-line keys by `line_delta` lines).  E2 (offset-shift
+/// invariance) guarantees this reproduces an in-place walk exactly.
+fn rebase_fragment(frag: &mut BodyFragment, d: u32, line_delta: i32) {
+    rebase_scope(&mut frag.proc_scope, d);
+    let r = &mut frag.result;
+    for p in r.all_procs.values_mut() {
+        rebase_proc(p, d);
+    }
+    for c in r.all_classes.values_mut() {
+        rebase_class(c, d);
+    }
+    for v in r.all_variables.values_mut() {
+        rebase_vardef(v, d);
+    }
+    for diag in &mut r.diagnostics {
+        rebase_diag(diag, d);
+    }
+    for inv in &mut r.command_invocations {
+        inv.range = shift(inv.range, d);
+    }
+    for x in &mut r.package_requires {
+        x.range = shift(x.range, d);
+    }
+    for x in &mut r.package_provides {
+        x.range = shift(x.range, d);
+    }
+    for x in &mut r.source_targets {
+        x.range = shift(x.range, d);
+    }
+    for x in &mut r.namespace_imports {
+        x.range = shift(x.range, d);
+    }
+    for x in &mut r.auto_path_entries {
+        x.range = shift(x.range, d);
+    }
+    for x in &mut r.regex_patterns {
+        x.range = shift(x.range, d);
+    }
+    if !r.suppressed_lines.is_empty() {
+        let old = std::mem::take(&mut r.suppressed_lines);
+        for (line, codes) in old {
+            let nl = if line < 0 { line } else { line + line_delta };
+            r.suppressed_lines.entry(nl).or_default().extend(codes);
+        }
+    }
+    for (_, _, _, diag) in &mut frag.pending_arity {
+        rebase_diag(diag, d);
+    }
+    for s in &mut frag.var_sites {
+        s.cmd_span = shift(s.cmd_span, d);
+    }
+    for s in &mut frag.cmd_sites {
+        s.cmd_span = shift(s.cmd_span, d);
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -483,6 +483,13 @@ impl Analyser {
                 if let Some(e) = element {
                     var.array_indices.insert(e);
                 }
+            } else if let Some(captured) = self.capture_global_reads.as_mut() {
+                // Isolated per-item body: the enclosing global scope is empty
+                // here, so a qualified read that would resolve against it in a
+                // whole-file analyse is captured for the aggregator to replay on
+                // the shell's real global scope.  `name` (not `base_owned`)
+                // preserves any `arr(idx)` element for the replay.
+                captured.push((name.to_string(), read_span));
             }
         }
     }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -237,6 +237,14 @@ pub struct Analyser {
     /// `None` for the whole-file `analyse` path (byte-identical: it builds
     /// the unit itself, exactly as before).
     pub(super) cu_override: Option<std::sync::Arc<crate::compilation_unit::CompilationUnit>>,
+    /// When `Some`, an isolated proc-body analysis (the per-item path) records
+    /// every qualified (`::` / `static::`) variable read that fell through to
+    /// the (empty) enclosing global scope here, instead of dropping it.  The
+    /// aggregator replays these on the shell's global scope during the graft, so
+    /// a body's `$::g` read lands as a reference on the real enclosing `::g`
+    /// def — one of the divergences the per-item path must reproduce.  `None` on
+    /// the whole-file `analyse` path (reads resolve against the populated scope).
+    pub(super) capture_global_reads: Option<Vec<(String, tcl_lexer::Span)>>,
 }
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
@@ -322,6 +330,7 @@ impl Analyser {
             defer_proc_bodies: false,
             deferred_bodies: Vec::new(),
             cu_override: None,
+            capture_global_reads: None,
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -222,6 +222,14 @@ pub struct Analyser {
     /// `analyse` (gated by the `file_decls_corpus` corpus test).  Defaults to
     /// `false`; normal `analyse` is unaffected.
     pub structure_only: bool,
+    /// When `true` (the per-item shell walk), `handle_proc_command` / OO method
+    /// walks record their body for separate analysis (`deferred_bodies`) instead
+    /// of recursing into it immediately.  Set only for the shell pass; the
+    /// per-body passes run with it `false` so nested defs walk in place.
+    pub defer_proc_bodies: bool,
+    /// Bodies deferred by the shell walk (see [`Self::defer_proc_bodies`]),
+    /// each analysed in a second pass that fills its already-created scope.
+    pub(super) deferred_bodies: Vec<super::per_item::DeferredBody>,
 }
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
@@ -304,6 +312,8 @@ impl Analyser {
             pending_arity: Vec::new(),
             non_ascii_mode: NonAsciiMode::Default,
             structure_only: false,
+            defer_proc_bodies: false,
+            deferred_bodies: Vec::new(),
         }
     }
 
@@ -450,6 +460,47 @@ impl Analyser {
         // **C41e5** wires ``recover_missing_open_brace`` (for
         // switch with forgotten body brace), ``detect_stolen_close_brace``
         // (E103), and the generic E200 partial-command emitter.
+        self.walk_commands_top_level(&commands, ghost_recovery_applied);
+
+        // **C41d1.** Run the diagnostic-emission orchestrator
+        // and the post-pass filters.  Mirrors the tail of
+        // ``Analyser.analyse`` in
+        // ``core/analysis/_analyser/_core.py:380-384``:
+        //
+        // 1. ``emit_unresolved_command_diagnostics`` — C41d4.
+        // 2. ``emit_variable_usage_diagnostics`` — hook landed
+        //    in C41d1 (currently no-op).
+        // 3. ``emit_cfg_ssa_diagnostics(source)`` — orchestrator
+        //    landed in C41d1 (currently inert; per-emitter
+        //    dispatch lands in C41d2-d7).
+        // 4. ``apply_disabled_diagnostics`` — filter codes the
+        //    caller asked to silence (also covers the
+        //    file-suppression directives merged at the top of
+        //    ``analyse``).
+        // 5. ``dedupe_diagnostics`` — drop exact duplicates and
+        //    the line-based suppression pairs.
+        // Structure-only mode (item_tree extraction) skips the entire
+        // diagnostic-emission tail — the unresolved/arity/variable/CFG-SSA
+        // emitters are the dominant cost and produce no structural facts.
+        if !self.structure_only {
+            self.run_diagnostic_emitters(source);
+        }
+
+        let result = std::mem::take(&mut self.result);
+        self.clear_run_state();
+        result
+    }
+
+    /// Walk a top-level command stream through the dispatcher (the body of
+    /// `analyse`'s main loop, extracted so the per-item path can reuse it
+    /// verbatim).  `scope_path` is the global scope (`&[]`).  When
+    /// `defer_proc_bodies` is set, `handle_proc_command` / OO method walks
+    /// record the body for later isolated analysis instead of recursing.
+    pub(super) fn walk_commands_top_level(
+        &mut self,
+        commands: &[crate::segmenter::SegmentedCommand],
+        ghost_recovery_applied: bool,
+    ) {
         let total = commands.len();
         let mut cmd_idx: usize = 0;
         while cmd_idx < total {
@@ -489,7 +540,7 @@ impl Analyser {
             // check on every analysed body.)
             self.emit_syntax_recovery_diagnostics(cmd_ref, ghost_recovery_applied);
             self.recover_stray_close_bracket(&mut cmd);
-            let consumed = self.recover_missing_open_brace(&mut cmd, &commands, cmd_idx);
+            let consumed = self.recover_missing_open_brace(&mut cmd, commands, cmd_idx);
             let single = cmd.single_token_word.clone();
             // ``# noqa[: CODE,...]`` directives in
             // ``cmd.preceding_comment`` suppress diagnostics on
@@ -519,34 +570,6 @@ impl Analyser {
             self.record_arg_var_reads(&cmd, &[]);
             cmd_idx += 1 + consumed;
         }
-
-        // **C41d1.** Run the diagnostic-emission orchestrator
-        // and the post-pass filters.  Mirrors the tail of
-        // ``Analyser.analyse`` in
-        // ``core/analysis/_analyser/_core.py:380-384``:
-        //
-        // 1. ``emit_unresolved_command_diagnostics`` — C41d4.
-        // 2. ``emit_variable_usage_diagnostics`` — hook landed
-        //    in C41d1 (currently no-op).
-        // 3. ``emit_cfg_ssa_diagnostics(source)`` — orchestrator
-        //    landed in C41d1 (currently inert; per-emitter
-        //    dispatch lands in C41d2-d7).
-        // 4. ``apply_disabled_diagnostics`` — filter codes the
-        //    caller asked to silence (also covers the
-        //    file-suppression directives merged at the top of
-        //    ``analyse``).
-        // 5. ``dedupe_diagnostics`` — drop exact duplicates and
-        //    the line-based suppression pairs.
-        // Structure-only mode (item_tree extraction) skips the entire
-        // diagnostic-emission tail — the unresolved/arity/variable/CFG-SSA
-        // emitters are the dominant cost and produce no structural facts.
-        if !self.structure_only {
-            self.run_diagnostic_emitters(source);
-        }
-
-        let result = std::mem::take(&mut self.result);
-        self.clear_run_state();
-        result
     }
 
     /// GAP-A1 strip 3c: ghost-token recovery.  When the scan-to-next
@@ -559,7 +582,7 @@ impl Analyser {
     /// returned (the caller then skips its own E201 detector to avoid a
     /// double-report).  Clean / fallback input has no partial command,
     /// so this never runs a second parse on the common path.
-    fn apply_ghost_recovery(
+    pub(super) fn apply_ghost_recovery(
         &mut self,
         source: &str,
         commands: &mut Vec<crate::segmenter::SegmentedCommand>,
@@ -922,7 +945,7 @@ impl Analyser {
     /// `clear_run_state` resets only the registry + line index), so a second
     /// `analyse` on `self` would run on dirty state; a fresh analyser is the
     /// safe way to take the full-rebuild fallback mid-call.
-    fn fresh_full_analyse(&self, new_text: &str, dialect: &str) -> AnalysisResult {
+    pub(super) fn fresh_full_analyse(&self, new_text: &str, dialect: &str) -> AnalysisResult {
         let mut fresh = Analyser::with_disabled_diagnostics(self.disabled_diagnostics.clone())
             .with_non_ascii_mode(self.non_ascii_mode);
         fresh.analyse(new_text, dialect)
@@ -1053,7 +1076,7 @@ impl Analyser {
     /// disabled-code filter and the dedupe + canonical-order pass.  Shared by
     /// `analyse` / `analyse_chunked` / `analyse_commands` so the emitter set and
     /// ordering stay identical across every entry point.
-    fn run_diagnostic_emitters(&mut self, source: &str) {
+    pub(super) fn run_diagnostic_emitters(&mut self, source: &str) {
         use tcl_registry::CommandRegistry;
         let mut diag_registry = CommandRegistry::build_default();
         if let Some(d) = tcl_registry::prelude::DialectSet::parse(&self.dialect) {
@@ -1091,15 +1114,38 @@ impl Analyser {
         for v in self.result.all_variables.values_mut() {
             v.references.sort_by_key(|s| (s.start(), s.end()));
         }
+        // The remaining walk-populated record vecs are likewise set-like
+        // (consumed by version inference / workspace index / regex checks),
+        // so sort each by source position for walk-strategy independence.
+        self.result
+            .package_requires
+            .sort_by_key(|r| (r.range.start(), r.range.end()));
+        self.result
+            .package_provides
+            .sort_by_key(|r| (r.range.start(), r.range.end()));
+        self.result
+            .source_targets
+            .sort_by_key(|r| (r.range.start(), r.range.end()));
+        self.result
+            .namespace_imports
+            .sort_by_key(|r| (r.range.start(), r.range.end()));
+        self.result
+            .auto_path_entries
+            .sort_by_key(|r| (r.range.start(), r.range.end()));
+        self.result
+            .regex_patterns
+            .sort_by_key(|r| (r.range.start(), r.range.end()));
     }
 
     /// Reset transient run state so the next ``analyse`` call
     /// starts from a clean slate.  Called at the end of every
     /// public entry point (``analyse`` / ``analyse_chunked`` /
     /// ``analyse_commands``).
-    fn clear_run_state(&mut self) {
+    pub(super) fn clear_run_state(&mut self) {
         self.registry = None;
         self.line_offsets = None;
+        self.defer_proc_bodies = false;
+        self.deferred_bodies.clear();
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -212,6 +212,16 @@ pub struct Analyser {
     /// (strict for F5 iRules/iApps, confusables otherwise), matching
     /// Python's `_non_ascii_mode` + the iRules override.
     pub non_ascii_mode: NonAsciiMode,
+    /// When `true`, the walk builds only the **structural** facts (procs,
+    /// classes, aliases, ensembles, namespace/scope tree) and skips every
+    /// diagnostic-emission and cross-feature recording pass — the per-command
+    /// diagnostic dispatch *and* the post-walk emitter tail.  Used by the
+    /// `item_tree` query to extract the offset-stable declaration set cheaply
+    /// (the diagnostics are the bulk of the cost).  The structural handlers are
+    /// unchanged, so the resulting decl set is byte-identical to a full
+    /// `analyse` (gated by the `file_decls_corpus` corpus test).  Defaults to
+    /// `false`; normal `analyse` is unaffected.
+    pub structure_only: bool,
 }
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
@@ -293,6 +303,7 @@ impl Analyser {
             line_offsets: None,
             pending_arity: Vec::new(),
             non_ascii_mode: NonAsciiMode::Default,
+            structure_only: false,
         }
     }
 
@@ -301,6 +312,16 @@ impl Analyser {
     #[must_use]
     pub fn with_non_ascii_mode(mut self, mode: NonAsciiMode) -> Self {
         self.non_ascii_mode = mode;
+        self
+    }
+
+    /// Enable structure-only mode (see [`Self::structure_only`]): the walk
+    /// builds the declaration/scope structure but skips all diagnostic
+    /// emission.  Returns `self` for builder-style configuration.  Used by the
+    /// `item_tree` query for cheap offset-stable item extraction.
+    #[must_use]
+    pub fn structure_only(mut self) -> Self {
+        self.structure_only = true;
         self
     }
 
@@ -516,18 +537,12 @@ impl Analyser {
         //    ``analyse``).
         // 5. ``dedupe_diagnostics`` — drop exact duplicates and
         //    the line-based suppression pairs.
-        let mut diag_registry = CommandRegistry::build_default();
-        if let Some(d) = tcl_registry::prelude::DialectSet::parse(&self.dialect) {
-            diag_registry.load_dialect(d);
+        // Structure-only mode (item_tree extraction) skips the entire
+        // diagnostic-emission tail — the unresolved/arity/variable/CFG-SSA
+        // emitters are the dominant cost and produce no structural facts.
+        if !self.structure_only {
+            self.run_diagnostic_emitters(source);
         }
-        self.emit_unresolved_command_diagnostics(&diag_registry);
-        self.flush_arity_diagnostics();
-        self.emit_missing_package_require_diagnostics(&diag_registry);
-        self.emit_variable_usage_diagnostics();
-        self.emit_cfg_ssa_diagnostics(source);
-        self.emit_lexer_warning_diagnostics();
-        self.apply_disabled_diagnostics();
-        self.dedupe_diagnostics();
 
         let result = std::mem::take(&mut self.result);
         self.clear_run_state();
@@ -738,18 +753,7 @@ impl Analyser {
         }
 
         // Same diagnostic-emission tail as ``analyse``.
-        let mut diag_registry = CommandRegistry::build_default();
-        if let Some(d) = tcl_registry::prelude::DialectSet::parse(&self.dialect) {
-            diag_registry.load_dialect(d);
-        }
-        self.emit_unresolved_command_diagnostics(&diag_registry);
-        self.flush_arity_diagnostics();
-        self.emit_missing_package_require_diagnostics(&diag_registry);
-        self.emit_variable_usage_diagnostics();
-        self.emit_cfg_ssa_diagnostics(source);
-        self.emit_lexer_warning_diagnostics();
-        self.apply_disabled_diagnostics();
-        self.dedupe_diagnostics();
+        self.run_diagnostic_emitters(source);
 
         let result = std::mem::take(&mut self.result);
         self.clear_run_state();
@@ -829,22 +833,7 @@ impl Analyser {
         self.analyse_commands_inner(commands);
 
         if finalise {
-            let mut diag_registry = CommandRegistry::build_default();
-            if let Some(d) = tcl_registry::prelude::DialectSet::parse(&self.dialect) {
-                diag_registry.load_dialect(d);
-            }
-            self.emit_unresolved_command_diagnostics(&diag_registry);
-            self.flush_arity_diagnostics();
-            self.emit_missing_package_require_diagnostics(&diag_registry);
-            self.emit_variable_usage_diagnostics();
-            self.emit_cfg_ssa_diagnostics(source);
-            // Parity with `analyse`: surface the lexer's extra-chars /
-            // var-brace warnings (E204 / E205 / E206). Previously absent
-            // here, so `analyse_commands` / `analyse_chunked` (and the
-            // incremental path) under-reported them.
-            self.emit_lexer_warning_diagnostics();
-            self.apply_disabled_diagnostics();
-            self.dedupe_diagnostics();
+            self.run_diagnostic_emitters(source);
         }
 
         let result = std::mem::take(&mut self.result);
@@ -1057,6 +1046,27 @@ impl Analyser {
         self.builtin_names
             .as_ref()
             .expect("builtin_names populated above")
+    }
+
+    /// Run the post-walk diagnostic-emission tail: the W123 / arity / missing-
+    /// package / variable-usage / CFG-SSA / lexer-warning emitters, then the
+    /// disabled-code filter and the dedupe + canonical-order pass.  Shared by
+    /// `analyse` / `analyse_chunked` / `analyse_commands` so the emitter set and
+    /// ordering stay identical across every entry point.
+    fn run_diagnostic_emitters(&mut self, source: &str) {
+        use tcl_registry::CommandRegistry;
+        let mut diag_registry = CommandRegistry::build_default();
+        if let Some(d) = tcl_registry::prelude::DialectSet::parse(&self.dialect) {
+            diag_registry.load_dialect(d);
+        }
+        self.emit_unresolved_command_diagnostics(&diag_registry);
+        self.flush_arity_diagnostics();
+        self.emit_missing_package_require_diagnostics(&diag_registry);
+        self.emit_variable_usage_diagnostics();
+        self.emit_cfg_ssa_diagnostics(source);
+        self.emit_lexer_warning_diagnostics();
+        self.apply_disabled_diagnostics();
+        self.dedupe_diagnostics();
     }
 
     /// Reset transient run state so the next ``analyse`` call

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -230,6 +230,13 @@ pub struct Analyser {
     /// Bodies deferred by the shell walk (see [`Self::defer_proc_bodies`]),
     /// each analysed in a second pass that fills its already-created scope.
     pub(super) deferred_bodies: Vec<super::per_item::DeferredBody>,
+    /// Pre-built compilation unit for the CFG/SSA diagnostic tail.  When
+    /// `Some`, [`Self::emit_cfg_ssa_diagnostics`] consumes it instead of
+    /// rebuilding the whole-file unit — the seam the incremental per-item
+    /// path uses to supply a unit whose per-function lattices were memoised.
+    /// `None` for the whole-file `analyse` path (byte-identical: it builds
+    /// the unit itself, exactly as before).
+    pub(super) cu_override: Option<std::sync::Arc<crate::compilation_unit::CompilationUnit>>,
 }
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
@@ -314,6 +321,7 @@ impl Analyser {
             structure_only: false,
             defer_proc_bodies: false,
             deferred_bodies: Vec::new(),
+            cu_override: None,
         }
     }
 
@@ -1146,6 +1154,7 @@ impl Analyser {
         self.line_offsets = None;
         self.defer_proc_bodies = false;
         self.deferred_bodies.clear();
+        self.cu_override = None;
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -814,6 +814,18 @@ impl Analyser {
         self.registry = Some(registry);
         self.line_offsets = Some(compute_line_offsets(source));
 
+        // Stub-directive pre-scan + overlay, matching ``analyse`` so command
+        // resolution (W123 / W307 / param-trait inference) sees the same stub
+        // surface.  Previously deferred, which left ``stub_overlay`` = ``None``
+        // here vs ``Some`` on the full ``analyse`` path — a setup divergence
+        // that made ``analyse_commands`` non-byte-identical to ``analyse`` (the
+        // `incremental == fresh` fuzzer caught it).  ``AnalysisResult`` already
+        // carries the ``stub_commands`` / ``stub_expr_defs`` fields.
+        let (stub_cmds, stub_exprs) = super::utils::scan_source_for_stubs(source);
+        self.stub_overlay = Some(super::types::build_stub_overlay(&stub_cmds));
+        self.result.stub_commands = stub_cmds;
+        self.result.stub_expr_defs = stub_exprs;
+
         self.analyse_commands_inner(commands);
 
         if finalise {
@@ -871,7 +883,60 @@ impl Analyser {
         }
         let cmds =
             crate::segmenter::segment_commands_incremental(prev_text, prev_commands, new_text);
-        self.analyse_commands(new_text, &cmds, dialect, true)
+        // `analyse` segments with *error recovery*; the fast path uses plain
+        // incremental segmentation.  `script_is_complete` only checks overall
+        // delimiter balance, so a locally-unbalanced brace (a stray `}` matched
+        // by a missing `{` elsewhere) passes it yet makes recovery segmentation
+        // split off a partial command — emitting E200/E102/E202 that the plain
+        // walk never sees.  Replicate the recovery segmentation `analyse` uses
+        // and fall back to a full rebuild when it differs from what the fast
+        // path would walk, or leaves any partial command.  (This also subsumes
+        // the plain-segmentation-metadata check: the recovery segmenter is the
+        // authority on the command stream + its attached comments.)
+        let mut registry = tcl_registry::CommandRegistry::build_default();
+        if let Some(d) = tcl_registry::prelude::DialectSet::parse(dialect) {
+            registry.load_dialect(d);
+        }
+        let known: std::collections::HashSet<&str> = registry.command_names().collect();
+        let recovery_cmds = crate::segmenter::segment_commands_with_recovery_and_config(
+            new_text,
+            &known,
+            tcl_lexer::LexerConfig::for_dialect(dialect),
+        );
+        if recovery_cmds != cmds || recovery_cmds.iter().any(|c| c.is_partial) {
+            return self.fresh_full_analyse(new_text, dialect);
+        }
+        let result = self.analyse_commands(new_text, &cmds, dialect, true);
+        // Correctness fallback (the maintainer's mandate: incremental must
+        // always converge to a full rebuild).  The pre-segmented
+        // `analyse_commands` walk is byte-identical to a full `analyse` for
+        // well-formed input (verified over the whole corpus), but it diverges
+        // from `analyse`'s error-*recovery* handling when the document carries
+        // syntax errors: `analyse` runs ghost-token re-lexing,
+        // recovery-segmentation, and body-level partial detection that the
+        // pre-segmented entry only partially mirrors.  Every observed
+        // `incremental != fresh` divergence on a well-segmented document carries
+        // at least one syntax-error (E-code) diagnostic, so when the fast path
+        // reports any such error we re-analyse fully — guaranteeing the result
+        // equals a from-scratch `analyse`.  The fast path stays the common
+        // well-formed edit; only mid-edit broken states (transient) take the
+        // slow path.
+        if result.diagnostics.iter().any(|d| d.code.starts_with('E')) {
+            return self.fresh_full_analyse(new_text, dialect);
+        }
+        result
+    }
+
+    /// Run a full [`Self::analyse`] on a *fresh* analyser carrying this one's
+    /// config.  The incremental fast path consumes per-walk state (the scope
+    /// walk leaves `var_command_sites` / `ensemble_namespaces` / … populated and
+    /// `clear_run_state` resets only the registry + line index), so a second
+    /// `analyse` on `self` would run on dirty state; a fresh analyser is the
+    /// safe way to take the full-rebuild fallback mid-call.
+    fn fresh_full_analyse(&self, new_text: &str, dialect: &str) -> AnalysisResult {
+        let mut fresh = Analyser::with_disabled_diagnostics(self.disabled_diagnostics.clone())
+            .with_non_ascii_mode(self.non_ascii_mode);
+        fresh.analyse(new_text, dialect)
     }
 
     /// Inner dispatch loop shared by [`Self::analyse_chunked`]
@@ -910,19 +975,20 @@ impl Analyser {
                 cmd_idx += 1;
                 continue;
             }
-            // GAP-A6 follow-up: the E100 (stray `]`) / E102 (stray
-            // `}`) token checks run on the incremental / chunked
-            // path too, mirroring the top-level loop and
-            // ``analyse_body``.  Run on the original token stream
-            // before ``recover_stray_close_bracket`` repairs the
-            // clone.  (Nested bodies dispatched below are covered by
-            // ``analyse_body``'s own per-body check.)
-            let stray = super::syntax_checks::stray_closer_diagnostics(
-                cmd_ref,
-                &self.source,
-                self.registry.as_ref(),
-            );
-            self.result.diagnostics.extend(stray);
+            // Emit the same source-recovery syntax diagnostics as the
+            // top-level loop in ``analyse``: E100 / E102 stray closers
+            // *and* E201 (unterminated `[`) / E202 / E203 (unterminated
+            // `"` / `{`).  Previously this path ran only
+            // ``stray_closer_diagnostics`` (E100/E102), so
+            // ``analyse_commands`` / ``analyse_chunked`` (and the
+            // incremental path) under-reported E201/E202/E203 at the top
+            // level relative to ``analyse`` — a real divergence the
+            // `incremental == fresh` fuzzer caught.  ``analyse_commands``
+            // never runs ghost recovery, so pass ``false``.  Run on the
+            // original token stream before ``recover_stray_close_bracket``
+            // repairs the clone.  (Nested bodies dispatched below are
+            // covered by ``analyse_body``'s own per-body check.)
+            self.emit_syntax_recovery_diagnostics(cmd_ref, false);
             // **C41e4 + C41e5.** Repair stray ``]`` and missing
             // ``{`` in a clone of the segmented command before
             // dispatch — chunked analysis keeps the original
@@ -946,6 +1012,9 @@ impl Analyser {
                 cmd.expand_word.as_deref().unwrap_or(&[]),
                 &scope_path,
             );
+            // Parity with the top-level loop: W216 (brace-then-paren
+            // name/value confusion) fires on top-level commands here too.
+            self.emit_w216_brace_then_paren(&cmd);
             self.record_arg_var_reads(&cmd, &scope_path);
             cmd_idx += 1 + consumed;
         }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -343,6 +343,20 @@ impl Analyser {
         self
     }
 
+    /// Supply a pre-built [`crate::compilation_unit::CompilationUnit`] for the
+    /// CFG/SSA diagnostic tail, so [`Self::emit_cfg_ssa_diagnostics`] consumes
+    /// it (once) instead of rebuilding the whole-file unit.  The supplied unit
+    /// must be equal to what the tail would build for this document's source —
+    /// the incremental path builds it from memoised per-function lattices, so
+    /// only the unchanged-body lattice recompute is skipped.  Reset after the
+    /// next `analyse`.
+    pub fn set_cu_override(
+        &mut self,
+        cu: std::sync::Arc<crate::compilation_unit::CompilationUnit>,
+    ) {
+        self.cu_override = Some(cu);
+    }
+
     /// Analyse a Tcl source for the given dialect, returning a
     /// fully-populated [`AnalysisResult`].
     ///

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1067,6 +1067,30 @@ impl Analyser {
         self.emit_lexer_warning_diagnostics();
         self.apply_disabled_diagnostics();
         self.dedupe_diagnostics();
+        self.canonicalize_result_order();
+    }
+
+    /// Canonicalise the order of the walk-populated, order-sensitive result
+    /// collections so the output is independent of *how* the walk was driven
+    /// (whole-file vs per-item).  Generalises the diagnostic sort in
+    /// `dedupe_diagnostics`: `command_invocations` and every `VarDef.references`
+    /// list are sorted by source position.  These are set-like for their
+    /// consumers (W123 already emitted; LSP references/rename filter by
+    /// name/position and the client orders by position), so a canonical
+    /// source order is behaviour-preserving and lets per-item analysis merge
+    /// facts without reconstructing DFS order.
+    fn canonicalize_result_order(&mut self) {
+        self.result.command_invocations.sort_by(|a, b| {
+            a.range
+                .start()
+                .cmp(&b.range.start())
+                .then(a.range.end().cmp(&b.range.end()))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        sort_scope_refs(&mut self.result.global_scope);
+        for v in self.result.all_variables.values_mut() {
+            v.references.sort_by_key(|s| (s.start(), s.end()));
+        }
     }
 
     /// Reset transient run state so the next ``analyse`` call
@@ -1086,6 +1110,17 @@ impl Analyser {
 /// ``binary_search`` on this vector to convert a byte offset to
 /// a 0-based line number in ``O(log N)`` instead of a per-call
 /// linear scan.
+/// Recursively sort every `VarDef.references` list in a scope subtree by span,
+/// for [`Analyser::canonicalize_result_order`].
+fn sort_scope_refs(scope: &mut super::types::Scope) {
+    for v in scope.variables.values_mut() {
+        v.references.sort_by_key(|s| (s.start(), s.end()));
+    }
+    for child in &mut scope.children {
+        sort_scope_refs(child);
+    }
+}
+
 pub(super) fn compute_line_offsets(source: &str) -> Vec<usize> {
     source
         .as_bytes()

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -25,7 +25,7 @@ use super::types::AnalysisResult;
 /// Mirrors the Python ``self._var_command_sites`` tuple in
 /// ``_AnalyserBase.__init__``. Used by the W307
 /// (variable-as-command misuse) post-pass that lands in **C41d3**.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct VarCommandSite {
     /// Variable name used as a command head (no leading ``$``).
     pub var_name: String,
@@ -48,7 +48,7 @@ pub struct VarCommandSite {
 /// Mirrors ``self._cmd_command_sites`` — same shape as
 /// [`VarCommandSite`] except the head is a command-substitution
 /// rather than a variable.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CmdCommandSite {
     /// Text of the bracketed command substitution (no brackets).
     pub cmd_text: String,
@@ -234,7 +234,7 @@ pub struct Analyser {
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
 /// setting (`core/analysis/checks/_style.py`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum NonAsciiMode {
     /// No explicit setting: resolve per dialect at emit time — `Strict`
     /// for F5 iRules/iApps (ASCII-only environments), `Confusables`

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -55,7 +55,7 @@ use crate::ir::{Script, Statement};
 /// the *local* name (the alias target) so caller-side resolution can
 /// look up "which caller-frame name does my local `x` alias?" in a
 /// single hash hit.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct UpvarInfo {
     /// `local_name -> caller_literal_name` for declarations whose
     /// source word is a plain string (no `$` / `[`).  Mirrors

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -33,24 +33,57 @@ use crate::taint::{propagate_taints, TaintLattice};
 use crate::type_infer::propagate_types;
 use crate::types::TypeLattice;
 
-/// Content-addressed per-procedure lattice memo used by
+/// One procedure's **offset-0** baseline-lattice build request, handed to the
+/// [`ProcLatticeCache`] callback by [`CompilationUnit::build_for_memoized`].
+///
+/// The body has already been normalised to offset 0 (every span shifted by
+/// `-body_offset`), so a shifted-but-unchanged procedure produces an identical
+/// request — the salsa-native memo (`tcl-lsp-db`'s `function_lattice`) keys on
+/// it position-independently and the builder rebases the returned unit back to
+/// the procedure's real offset.  Carries exactly what
+/// [`crate::cfg_builder::build_cfg_function_with_upvars`] +
+/// [`FunctionUnit::build`] consume: the offset-0 body, the qualified name, the
+/// parameter list, the module-wide upvar / proc-param context (so the rebuilt
+/// CFG is identical to the whole-module build's), and the analysis dialect.
+pub struct LatticeRequest<'a> {
+    /// Qualified procedure name (e.g. `::foo::bar`).
+    pub qname: &'a str,
+    /// The procedure body, normalised to offset 0.
+    pub body: &'a crate::ir::Script,
+    /// The procedure's declared parameters.
+    pub params: &'a [String],
+    /// Module-wide `proc -> upvar summary` context (from
+    /// [`crate::cfg_builder::prepare_cfg_context`]).
+    pub upvar_procs: &'a HashMap<String, crate::cfg_builder::upvar_info::UpvarInfo>,
+    /// Module-wide `proc -> params` context (from
+    /// [`crate::cfg_builder::prepare_cfg_context`]).
+    pub proc_params: &'a HashMap<String, Vec<String>>,
+    /// Analysis dialect — selects the registry the lattice pipeline runs under.
+    pub dialect: &'a str,
+}
+
+/// Salsa-native per-procedure lattice memo used by
 /// [`CompilationUnit::build_for_memoized`].
 ///
-/// `cache(key, build)` returns the cached `(build_offset, FunctionUnit)` for
-/// `key`, or runs `build` (storing and returning its result) on a miss.  The
-/// value carries the absolute offset the cached unit was built at so the
-/// builder can rebase a shifted-but-unchanged body to its new position (the key
-/// is position-independent — body source only — so a shifted body still hits).
-/// The caller owns the backing store and its eviction policy.
-pub type ProcLatticeCache<'a> =
-    dyn FnMut(&str, &mut dyn FnMut() -> (u32, FunctionUnit)) -> (u32, FunctionUnit) + 'a;
+/// `cache(request)` returns the **offset-0** [`FunctionUnit`] for `request`
+/// (building it on a miss, reusing a memoised one on a hit).  The builder
+/// rebases the returned unit to the procedure's real position, so the result is
+/// byte-identical to [`CompilationUnit::build_for_with_config`]; only the
+/// redundant lattice recompute for an unchanged procedure body is skipped.  The
+/// caller owns the backing store and its eviction policy.
+pub type ProcLatticeCache<'a> = dyn FnMut(&LatticeRequest<'_>) -> FunctionUnit + 'a;
 
 // ---------------------------------------------------------------------------
 // Per-function analysis bundle
 // ---------------------------------------------------------------------------
 
 /// Analysis artefacts for one function (top-level or procedure).
-#[derive(Debug, Clone)]
+///
+/// `PartialEq` enables salsa early-cutoff: when [`crate`]'s salsa-native
+/// [`function_lattice`](../../tcl_lsp_db/fn.function_lattice.html) query rebuilds
+/// a procedure whose interned body changed but whose lattice came out identical,
+/// the equal comparison lets dependents skip re-execution.
+#[derive(Debug, Clone, PartialEq)]
 pub struct FunctionUnit {
     /// Qualified function name (e.g. `::top`, `::foo::bar`).
     pub name: String,
@@ -241,27 +274,26 @@ impl CompilationUnit {
     }
 
     /// Like [`Self::build_for_with_config`] but routes each procedure's
-    /// per-function lattice build through `cache`, a content-addressed memo.
+    /// per-function lattice build through `cache`, a salsa-native memo (see
+    /// [`ProcLatticeCache`] / [`LatticeRequest`]).
     ///
-    /// `cache(key, build)` returns the cached `FunctionUnit` for `key`, or
-    /// runs `build` (and stores it) on a miss.  The key captures **every**
-    /// input to [`FunctionUnit::build_with_param_constants`] for that
-    /// procedure — the body source (which, with the module-wide
-    /// upvar/param context digest, determines the CFG), the parameter list,
-    /// the interprocedural `param_constants`, and `dialect_key` (which
-    /// discriminates registries across dialects) — so a cache hit returns the
-    /// **identical** unit the non-memoised path would build.  The result is
-    /// therefore byte-identical to [`Self::build_for_with_config`]; only the
-    /// redundant SSA/SCCP/type/rendered recompute for an unchanged procedure
-    /// body is skipped.  Top-level and methods are always built fresh (no body
-    /// source to key on); the cross-function interproc taint re-run still runs
-    /// over the whole unit in [`Self::with_interprocedural`].
+    /// Each procedure's body is normalised to offset 0 and handed to `cache`,
+    /// which returns the (possibly memoised) offset-0 [`FunctionUnit`]; the
+    /// builder then rebases it to the procedure's real position.  A
+    /// shifted-but-unchanged body produces an identical request, so it is a
+    /// memo hit (and reused, rebased).  The result is byte-identical to
+    /// [`Self::build_for_with_config`]; only the redundant SSA/SCCP/type/
+    /// rendered recompute for an unchanged procedure body is skipped.
+    /// Procedures with interprocedural `param_constants`, the top level, and
+    /// methods are always built fresh (no stable offset-0 key); the
+    /// cross-function interproc taint re-run still runs over the whole unit in
+    /// [`Self::with_interprocedural`].
     pub fn build_for_memoized(
         source: &str,
         registry: &CommandRegistry,
         defer_top_level: bool,
         config: tcl_lexer::LexerConfig,
-        dialect_key: &str,
+        dialect: &str,
         cache: &mut ProcLatticeCache<'_>,
     ) -> Self {
         Self::build_for_inner(
@@ -269,7 +301,7 @@ impl CompilationUnit {
             registry,
             defer_top_level,
             config,
-            dialect_key,
+            dialect,
             Some(cache),
         )
     }
@@ -280,7 +312,7 @@ impl CompilationUnit {
         registry: &CommandRegistry,
         defer_top_level: bool,
         config: tcl_lexer::LexerConfig,
-        dialect_key: &str,
+        dialect: &str,
         mut cache: Option<&mut ProcLatticeCache<'_>>,
     ) -> Self {
         let mut ir_module = lower_to_ir_with_config(source, registry, config);
@@ -299,11 +331,13 @@ impl CompilationUnit {
         // for (interprocedural constant propagation).
         let call_site_constants = collect_call_site_constants(&cfg_module, &ir_module.procedures);
         let top_level = FunctionUnit::build("::top", cfg_module.top_level.clone(), &[], registry);
-        // One digest of the module-wide upvar/param context, shared by every
-        // procedure key: a procedure's CFG depends on this context, so an edit
-        // that changes it must invalidate every memoised lattice (conservative
-        // but correct).  Only computed on the memoised path.
-        let ctx_digest = cache.as_ref().map(|_| proc_context_digest(&ir_module));
+        // Module-wide upvar/param context — the CFG-determining context a
+        // procedure body is rebuilt under.  Computed once and shared by every
+        // memoised request (and the methods below), so the offset-0 CFG the
+        // memo rebuilds is identical to this whole-module build's.  Only needed
+        // on the memoised path or when methods are present.
+        let cfg_context = (cache.is_some() || !ir_module.methods.is_empty())
+            .then(|| crate::cfg_builder::prepare_cfg_context(&ir_module));
         let mut procedures: HashMap<String, FunctionUnit> = HashMap::new();
         for (qname, cfg) in &cfg_module.procedures {
             let params = ir_module
@@ -313,47 +347,43 @@ impl CompilationUnit {
             let param_constants =
                 params_constants_from_call_sites(params, &call_site_constants, qname);
             let proc = ir_module.procedures.get(qname);
-            let body_source = proc.and_then(|p| p.body_source.as_deref());
             let body_offset = proc.map_or(0, |p| p.span.start());
-            let fu = match (cache.as_mut(), body_source, ctx_digest) {
-                (Some(memo), Some(body_source), Some(ctx)) => {
-                    // Position-independent key: a shifted-but-unchanged body
-                    // hits, and the cached unit is rebased to its new offset.
-                    let key = proc_lattice_key(
-                        dialect_key,
-                        ctx,
+            // Route through the memo only when (a) a cache is present, (b) the
+            // procedure has a real body, (c) the module context is available,
+            // and (d) there are no interprocedural `param_constants` — those
+            // depend on call sites elsewhere in the module, so the body alone
+            // does not determine the unit; build those fresh.
+            let memoised = match (cache.as_mut(), proc, cfg_context.as_ref()) {
+                (Some(memo), Some(proc), Some((upvar_procs, proc_params)))
+                    if param_constants.is_none() =>
+                {
+                    // Normalise the body to offset 0 so a shifted-but-unchanged
+                    // procedure produces an identical request (memo hit); rebase
+                    // the returned unit back to the procedure's real position.
+                    let mut body = proc.body.clone();
+                    crate::lattice_rebase::rebase_script(&mut body, -i64::from(body_offset));
+                    let mut fu = memo(&LatticeRequest {
                         qname,
-                        body_source,
+                        body: &body,
                         params,
-                        param_constants.as_ref(),
-                    );
-                    let cfg = cfg.clone();
-                    let params = params.to_vec();
-                    let param_constants = param_constants.clone();
-                    let (built_offset, mut fu) = memo(&key, &mut || {
-                        (
-                            body_offset,
-                            FunctionUnit::build_with_param_constants(
-                                qname,
-                                cfg.clone(),
-                                &params,
-                                registry,
-                                param_constants.as_ref(),
-                            ),
-                        )
+                        upvar_procs,
+                        proc_params,
+                        dialect,
                     });
-                    let delta = i64::from(body_offset) - i64::from(built_offset);
-                    crate::lattice_rebase::rebase_function_unit(&mut fu, delta);
-                    fu
+                    crate::lattice_rebase::rebase_function_unit(&mut fu, i64::from(body_offset));
+                    Some(fu)
                 }
-                _ => FunctionUnit::build_with_param_constants(
+                _ => None,
+            };
+            let fu = memoised.unwrap_or_else(|| {
+                FunctionUnit::build_with_param_constants(
                     qname,
                     cfg.clone(),
                     params,
                     registry,
                     param_constants.as_ref(),
-                ),
-            };
+                )
+            });
             procedures.insert(qname.clone(), fu);
         }
         // SF-2: lower TclOO method bodies (populated in
@@ -367,7 +397,9 @@ impl CompilationUnit {
         let methods: HashMap<String, FunctionUnit> = if ir_module.methods.is_empty() {
             HashMap::new()
         } else {
-            let (upvar_procs, proc_params) = crate::cfg_builder::prepare_cfg_context(&ir_module);
+            let (upvar_procs, proc_params) = cfg_context
+                .as_ref()
+                .expect("cfg_context computed when methods are present");
             ir_module
                 .methods
                 .iter()
@@ -490,66 +522,6 @@ impl CompilationUnit {
     pub fn functions(&self) -> impl Iterator<Item = &FunctionUnit> {
         std::iter::once(&self.top_level).chain(self.procedures.values())
     }
-}
-
-/// Stable digest of the module-wide CFG context (`upvar_procs` +
-/// `proc_params`) that every procedure's CFG depends on.  Shared by every
-/// per-procedure lattice cache key (see [`CompilationUnit::build_for_memoized`])
-/// so an edit that changes the context invalidates every memoised lattice.
-fn proc_context_digest(ir_module: &IrModule) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let (upvar_procs, proc_params) = crate::cfg_builder::prepare_cfg_context(ir_module);
-    let mut upvar: Vec<_> = upvar_procs.iter().collect();
-    upvar.sort_by(|a, b| a.0.cmp(b.0));
-    let mut params: Vec<_> = proc_params.iter().collect();
-    params.sort_by(|a, b| a.0.cmp(b.0));
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for (name, info) in upvar {
-        name.hash(&mut hasher);
-        info.hash(&mut hasher);
-    }
-    for (name, plist) in params {
-        name.hash(&mut hasher);
-        plist.hash(&mut hasher);
-    }
-    hasher.finish()
-}
-
-/// Content-addressed cache key for one procedure's lattice (see
-/// [`CompilationUnit::build_for_memoized`]).  Captures every input to
-/// [`FunctionUnit::build_with_param_constants`] for the procedure: the
-/// `dialect_key` (registry discriminator), the module context digest `ctx`
-/// (which with the body determines the CFG), the qualified name, the body
-/// source verbatim, the parameter list, and the interprocedural
-/// `param_constants` — serialised deterministically so equal inputs yield an
-/// equal key.  **Position-independent**: the procedure's absolute offset is
-/// deliberately *not* part of the key, so a shifted-but-unchanged body hits;
-/// the builder rebases the cached unit's spans to the new offset.  A hit
-/// therefore yields the byte-identical unit after rebasing.
-fn proc_lattice_key(
-    dialect_key: &str,
-    ctx: u64,
-    qname: &str,
-    body_source: &str,
-    params: &[String],
-    param_constants: Option<&HashMap<ValueKey, crate::analyses::LatticeValue>>,
-) -> String {
-    use std::fmt::Write as _;
-    let mut key = String::with_capacity(body_source.len() + 64);
-    // Length-prefix the body so it can't run into the trailing fields.
-    let _ = write!(
-        key,
-        "{dialect_key}\u{0}{ctx:016x}\u{0}{qname}\u{0}{params:?}\u{0}{}\u{0}",
-        body_source.len()
-    );
-    key.push_str(body_source);
-    if let Some(pc) = param_constants {
-        let mut entries: Vec<_> = pc.iter().map(|(k, v)| format!("{k:?}={v:?}")).collect();
-        entries.sort_unstable();
-        key.push('\u{0}');
-        key.push_str(&entries.join("\u{1}"));
-    }
-    key
 }
 
 /// Per-arg-position call-site literal evidence for one callee.

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -34,11 +34,16 @@ use crate::type_infer::propagate_types;
 use crate::types::TypeLattice;
 
 /// Content-addressed per-procedure lattice memo used by
-/// [`CompilationUnit::build_for_memoized`].  `cache(key, build)` returns the
-/// cached [`FunctionUnit`] for `key`, or runs `build` (storing the result) on a
-/// miss.  The caller owns the backing store and its eviction policy.
+/// [`CompilationUnit::build_for_memoized`].
+///
+/// `cache(key, build)` returns the cached `(build_offset, FunctionUnit)` for
+/// `key`, or runs `build` (storing and returning its result) on a miss.  The
+/// value carries the absolute offset the cached unit was built at so the
+/// builder can rebase a shifted-but-unchanged body to its new position (the key
+/// is position-independent — body source only — so a shifted body still hits).
+/// The caller owns the backing store and its eviction policy.
 pub type ProcLatticeCache<'a> =
-    dyn FnMut(&str, &mut dyn FnMut() -> FunctionUnit) -> FunctionUnit + 'a;
+    dyn FnMut(&str, &mut dyn FnMut() -> (u32, FunctionUnit)) -> (u32, FunctionUnit) + 'a;
 
 // ---------------------------------------------------------------------------
 // Per-function analysis bundle
@@ -269,6 +274,7 @@ impl CompilationUnit {
         )
     }
 
+    #[allow(clippy::too_many_lines)]
     fn build_for_inner(
         source: &str,
         registry: &CommandRegistry,
@@ -311,11 +317,12 @@ impl CompilationUnit {
             let body_offset = proc.map_or(0, |p| p.span.start());
             let fu = match (cache.as_mut(), body_source, ctx_digest) {
                 (Some(memo), Some(body_source), Some(ctx)) => {
+                    // Position-independent key: a shifted-but-unchanged body
+                    // hits, and the cached unit is rebased to its new offset.
                     let key = proc_lattice_key(
                         dialect_key,
                         ctx,
                         qname,
-                        body_offset,
                         body_source,
                         params,
                         param_constants.as_ref(),
@@ -323,15 +330,21 @@ impl CompilationUnit {
                     let cfg = cfg.clone();
                     let params = params.to_vec();
                     let param_constants = param_constants.clone();
-                    memo(&key, &mut || {
-                        FunctionUnit::build_with_param_constants(
-                            qname,
-                            cfg.clone(),
-                            &params,
-                            registry,
-                            param_constants.as_ref(),
+                    let (built_offset, mut fu) = memo(&key, &mut || {
+                        (
+                            body_offset,
+                            FunctionUnit::build_with_param_constants(
+                                qname,
+                                cfg.clone(),
+                                &params,
+                                registry,
+                                param_constants.as_ref(),
+                            ),
                         )
-                    })
+                    });
+                    let delta = i64::from(body_offset) - i64::from(built_offset);
+                    crate::lattice_rebase::rebase_function_unit(&mut fu, delta);
+                    fu
                 }
                 _ => FunctionUnit::build_with_param_constants(
                     qname,
@@ -509,27 +522,24 @@ fn proc_context_digest(ir_module: &IrModule) -> u64 {
 /// (which with the body determines the CFG), the qualified name, the body
 /// source verbatim, the parameter list, and the interprocedural
 /// `param_constants` — serialised deterministically so equal inputs yield an
-/// equal key.  A hit therefore returns the byte-identical unit.
+/// equal key.  **Position-independent**: the procedure's absolute offset is
+/// deliberately *not* part of the key, so a shifted-but-unchanged body hits;
+/// the builder rebases the cached unit's spans to the new offset.  A hit
+/// therefore yields the byte-identical unit after rebasing.
 fn proc_lattice_key(
     dialect_key: &str,
     ctx: u64,
     qname: &str,
-    body_offset: u32,
     body_source: &str,
     params: &[String],
     param_constants: Option<&HashMap<ValueKey, crate::analyses::LatticeValue>>,
 ) -> String {
     use std::fmt::Write as _;
     let mut key = String::with_capacity(body_source.len() + 64);
-    // `body_offset` (the procedure's absolute definition offset) is part of the
-    // key because the cached unit's CFG/SSA spans are **absolute** — a
-    // shifted-but-unedited body must miss so its diagnostics land at the new
-    // positions, not the cached ones.  (Full offset-invariance — caching at
-    // offset 0 and rebasing — is a later refinement.)  Length-prefix the body
-    // so it can't run into the trailing fields.
+    // Length-prefix the body so it can't run into the trailing fields.
     let _ = write!(
         key,
-        "{dialect_key}\u{0}{ctx:016x}\u{0}{qname}\u{0}{body_offset}\u{0}{params:?}\u{0}{}\u{0}",
+        "{dialect_key}\u{0}{ctx:016x}\u{0}{qname}\u{0}{params:?}\u{0}{}\u{0}",
         body_source.len()
     );
     key.push_str(body_source);

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -33,6 +33,13 @@ use crate::taint::{propagate_taints, TaintLattice};
 use crate::type_infer::propagate_types;
 use crate::types::TypeLattice;
 
+/// Content-addressed per-procedure lattice memo used by
+/// [`CompilationUnit::build_for_memoized`].  `cache(key, build)` returns the
+/// cached [`FunctionUnit`] for `key`, or runs `build` (storing the result) on a
+/// miss.  The caller owns the backing store and its eviction policy.
+pub type ProcLatticeCache<'a> =
+    dyn FnMut(&str, &mut dyn FnMut() -> FunctionUnit) -> FunctionUnit + 'a;
+
 // ---------------------------------------------------------------------------
 // Per-function analysis bundle
 // ---------------------------------------------------------------------------
@@ -225,6 +232,51 @@ impl CompilationUnit {
         defer_top_level: bool,
         config: tcl_lexer::LexerConfig,
     ) -> Self {
+        Self::build_for_inner(source, registry, defer_top_level, config, "", None)
+    }
+
+    /// Like [`Self::build_for_with_config`] but routes each procedure's
+    /// per-function lattice build through `cache`, a content-addressed memo.
+    ///
+    /// `cache(key, build)` returns the cached `FunctionUnit` for `key`, or
+    /// runs `build` (and stores it) on a miss.  The key captures **every**
+    /// input to [`FunctionUnit::build_with_param_constants`] for that
+    /// procedure — the body source (which, with the module-wide
+    /// upvar/param context digest, determines the CFG), the parameter list,
+    /// the interprocedural `param_constants`, and `dialect_key` (which
+    /// discriminates registries across dialects) — so a cache hit returns the
+    /// **identical** unit the non-memoised path would build.  The result is
+    /// therefore byte-identical to [`Self::build_for_with_config`]; only the
+    /// redundant SSA/SCCP/type/rendered recompute for an unchanged procedure
+    /// body is skipped.  Top-level and methods are always built fresh (no body
+    /// source to key on); the cross-function interproc taint re-run still runs
+    /// over the whole unit in [`Self::with_interprocedural`].
+    pub fn build_for_memoized(
+        source: &str,
+        registry: &CommandRegistry,
+        defer_top_level: bool,
+        config: tcl_lexer::LexerConfig,
+        dialect_key: &str,
+        cache: &mut ProcLatticeCache<'_>,
+    ) -> Self {
+        Self::build_for_inner(
+            source,
+            registry,
+            defer_top_level,
+            config,
+            dialect_key,
+            Some(cache),
+        )
+    }
+
+    fn build_for_inner(
+        source: &str,
+        registry: &CommandRegistry,
+        defer_top_level: bool,
+        config: tcl_lexer::LexerConfig,
+        dialect_key: &str,
+        mut cache: Option<&mut ProcLatticeCache<'_>>,
+    ) -> Self {
         let mut ir_module = lower_to_ir_with_config(source, registry, config);
         // C36d/e/f: specialise Option-shape factories before any
         // other module-level passes so the synthesised child procs
@@ -241,6 +293,11 @@ impl CompilationUnit {
         // for (interprocedural constant propagation).
         let call_site_constants = collect_call_site_constants(&cfg_module, &ir_module.procedures);
         let top_level = FunctionUnit::build("::top", cfg_module.top_level.clone(), &[], registry);
+        // One digest of the module-wide upvar/param context, shared by every
+        // procedure key: a procedure's CFG depends on this context, so an edit
+        // that changes it must invalidate every memoised lattice (conservative
+        // but correct).  Only computed on the memoised path.
+        let ctx_digest = cache.as_ref().map(|_| proc_context_digest(&ir_module));
         let mut procedures: HashMap<String, FunctionUnit> = HashMap::new();
         for (qname, cfg) in &cfg_module.procedures {
             let params = ir_module
@@ -249,16 +306,42 @@ impl CompilationUnit {
                 .map_or(&[][..], |p| p.params.as_slice());
             let param_constants =
                 params_constants_from_call_sites(params, &call_site_constants, qname);
-            procedures.insert(
-                qname.clone(),
-                FunctionUnit::build_with_param_constants(
+            let proc = ir_module.procedures.get(qname);
+            let body_source = proc.and_then(|p| p.body_source.as_deref());
+            let body_offset = proc.map_or(0, |p| p.span.start());
+            let fu = match (cache.as_mut(), body_source, ctx_digest) {
+                (Some(memo), Some(body_source), Some(ctx)) => {
+                    let key = proc_lattice_key(
+                        dialect_key,
+                        ctx,
+                        qname,
+                        body_offset,
+                        body_source,
+                        params,
+                        param_constants.as_ref(),
+                    );
+                    let cfg = cfg.clone();
+                    let params = params.to_vec();
+                    let param_constants = param_constants.clone();
+                    memo(&key, &mut || {
+                        FunctionUnit::build_with_param_constants(
+                            qname,
+                            cfg.clone(),
+                            &params,
+                            registry,
+                            param_constants.as_ref(),
+                        )
+                    })
+                }
+                _ => FunctionUnit::build_with_param_constants(
                     qname,
                     cfg.clone(),
                     params,
                     registry,
                     param_constants.as_ref(),
                 ),
-            );
+            };
+            procedures.insert(qname.clone(), fu);
         }
         // SF-2: lower TclOO method bodies (populated in
         // `ir_module.methods` by lowering) to per-method
@@ -394,6 +477,69 @@ impl CompilationUnit {
     pub fn functions(&self) -> impl Iterator<Item = &FunctionUnit> {
         std::iter::once(&self.top_level).chain(self.procedures.values())
     }
+}
+
+/// Stable digest of the module-wide CFG context (`upvar_procs` +
+/// `proc_params`) that every procedure's CFG depends on.  Shared by every
+/// per-procedure lattice cache key (see [`CompilationUnit::build_for_memoized`])
+/// so an edit that changes the context invalidates every memoised lattice.
+fn proc_context_digest(ir_module: &IrModule) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let (upvar_procs, proc_params) = crate::cfg_builder::prepare_cfg_context(ir_module);
+    let mut upvar: Vec<_> = upvar_procs.iter().collect();
+    upvar.sort_by(|a, b| a.0.cmp(b.0));
+    let mut params: Vec<_> = proc_params.iter().collect();
+    params.sort_by(|a, b| a.0.cmp(b.0));
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for (name, info) in upvar {
+        name.hash(&mut hasher);
+        info.hash(&mut hasher);
+    }
+    for (name, plist) in params {
+        name.hash(&mut hasher);
+        plist.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Content-addressed cache key for one procedure's lattice (see
+/// [`CompilationUnit::build_for_memoized`]).  Captures every input to
+/// [`FunctionUnit::build_with_param_constants`] for the procedure: the
+/// `dialect_key` (registry discriminator), the module context digest `ctx`
+/// (which with the body determines the CFG), the qualified name, the body
+/// source verbatim, the parameter list, and the interprocedural
+/// `param_constants` — serialised deterministically so equal inputs yield an
+/// equal key.  A hit therefore returns the byte-identical unit.
+fn proc_lattice_key(
+    dialect_key: &str,
+    ctx: u64,
+    qname: &str,
+    body_offset: u32,
+    body_source: &str,
+    params: &[String],
+    param_constants: Option<&HashMap<ValueKey, crate::analyses::LatticeValue>>,
+) -> String {
+    use std::fmt::Write as _;
+    let mut key = String::with_capacity(body_source.len() + 64);
+    // `body_offset` (the procedure's absolute definition offset) is part of the
+    // key because the cached unit's CFG/SSA spans are **absolute** — a
+    // shifted-but-unedited body must miss so its diagnostics land at the new
+    // positions, not the cached ones.  (Full offset-invariance — caching at
+    // offset 0 and rebasing — is a later refinement.)  Length-prefix the body
+    // so it can't run into the trailing fields.
+    let _ = write!(
+        key,
+        "{dialect_key}\u{0}{ctx:016x}\u{0}{qname}\u{0}{body_offset}\u{0}{params:?}\u{0}{}\u{0}",
+        body_source.len()
+    );
+    key.push_str(body_source);
+    if let Some(pc) = param_constants {
+        let mut entries: Vec<_> = pc.iter().map(|(k, v)| format!("{k:?}={v:?}")).collect();
+        entries.sort_unstable();
+        key.push('\u{0}');
+        key.push_str(&entries.join("\u{1}"));
+    }
+    key
 }
 
 /// Per-arg-position call-site literal evidence for one callee.

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -103,7 +103,7 @@ impl DefUseChain {
 }
 
 /// Complete def-use analysis for one function.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct DefUseResult {
     /// All chains keyed by `(variable, version)`.
     pub chains: HashMap<SsaValueKey, DefUseChain>,

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -24,7 +24,7 @@ use crate::expr_ast::ExprNode;
 /// In the Rust pipeline, token references use [`Span`]s into the
 /// source buffer. The `argv_texts` and `single_token_word` fields
 /// preserve the Python-era per-word metadata needed by analysis passes.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CommandTokens {
     /// Per-word representative token spans.
     pub argv: Vec<Span>,
@@ -57,7 +57,7 @@ pub struct CommandTokens {
 ///
 /// Corresponds to Python's `IRScript`. Using `Vec` rather than a tuple
 /// because scripts are built incrementally during lowering.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Script {
     /// Statements in execution order.
     pub statements: Vec<Statement>,
@@ -80,7 +80,7 @@ impl Script {
 }
 
 /// An `if` clause: condition + body.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IfClause {
     /// The parsed condition expression.
     pub condition: ExprNode,
@@ -93,7 +93,7 @@ pub struct IfClause {
 }
 
 /// A `try` handler clause (`on`/`trap`).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TryHandler {
     /// Handler kind: `"on"` or `"trap"`.
     pub kind: String,
@@ -110,7 +110,7 @@ pub struct TryHandler {
 }
 
 /// A `switch` arm: pattern + body.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SwitchArm {
     /// Pattern text.
     pub pattern: String,
@@ -128,7 +128,7 @@ pub struct SwitchArm {
 ///
 /// Each group pairs a list of loop variable names with the list
 /// argument text they iterate over.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ForeachIterator {
     /// Variable names assigned each iteration.
     pub vars: Vec<String>,
@@ -142,7 +142,7 @@ pub struct ForeachIterator {
 /// carries a [`Span`] for position tracking (replacing the Python
 /// `Range` with inline `SourcePosition` pairs). The span is resolved
 /// to text or `(line, character)` via a `SourceMap` on demand.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Statement {
     /// Constant assignment: `set name value` where value is a literal.
     AssignConst {

--- a/rust/tcl-compiler/src/lattice_rebase.rs
+++ b/rust/tcl-compiler/src/lattice_rebase.rs
@@ -77,7 +77,14 @@ fn rebase_tokens(tokens: &mut Option<CommandTokens>, delta: i64) {
     }
 }
 
-fn rebase_script(script: &mut Script, delta: i64) {
+/// Shift every absolute span in `script`'s statements by `delta` bytes.  Used
+/// to normalise a procedure body to offset 0 before interning it as a
+/// salsa-native [`crate::compilation_unit`] lattice key (and reused for nested
+/// `Try` bodies during unit rebasing).
+pub(crate) fn rebase_script(script: &mut Script, delta: i64) {
+    if delta == 0 {
+        return;
+    }
     for stmt in &mut script.statements {
         rebase_statement(stmt, delta);
     }

--- a/rust/tcl-compiler/src/lattice_rebase.rs
+++ b/rust/tcl-compiler/src/lattice_rebase.rs
@@ -1,0 +1,233 @@
+//! Offset rebasing for a memoised [`FunctionUnit`] (slice 4 offset-invariance).
+//!
+//! The per-procedure lattice cache keys on a procedure's **body source** (not
+//! its position), so a body that is unchanged but *shifted* (lines inserted
+//! above it) is a cache hit.  The cached unit's CFG/SSA/SCCP spans are
+//! absolute, though, so on such a hit we must shift every span by the
+//! difference between the procedure's current definition offset and the offset
+//! the cached unit was built at.  The result is then byte-identical to a
+//! freshly-built unit at the new position.
+//!
+//! Only the span-carrying parts of a [`FunctionUnit`] are traversed (every
+//! other lattice field — `types`/`taints`/`rendered_props`/`def_use`/
+//! `memory_ssa`/SSA phis — is span-free): the CFG block statements +
+//! terminators + loop-node spans, the SSA blocks' cloned statements (read for
+//! positions by some emitters), and the SCCP constant-branch spans.
+//! `ExprNode` carries *relative* offsets anchored to a statement span we shift,
+//! so it needs no rebasing.
+
+use tcl_lexer::Span;
+
+use crate::cfg::Terminator;
+use crate::compilation_unit::FunctionUnit;
+use crate::ir::{CommandTokens, Script, Statement};
+
+/// Shift every absolute span in `fu` by `delta` bytes (signed).  A no-op for
+/// `delta == 0`.
+pub(crate) fn rebase_function_unit(fu: &mut FunctionUnit, delta: i64) {
+    if delta == 0 {
+        return;
+    }
+    for block in fu.cfg.blocks.values_mut() {
+        for stmt in &mut block.statements {
+            rebase_statement(stmt, delta);
+        }
+        if let Some(term) = &mut block.terminator {
+            rebase_terminator(term, delta);
+        }
+    }
+    for loop_node in fu.cfg.loop_nodes.values_mut() {
+        shift(&mut loop_node.span, delta);
+    }
+    // SSA holds its own clones of the IR statements; some emitters read spans
+    // from them (`stmt.statement.span()`), so rebase those too.
+    for block in fu.ssa.blocks.values_mut() {
+        for ssa_stmt in &mut block.statements {
+            rebase_statement(&mut ssa_stmt.statement, delta);
+        }
+    }
+    for cb in &mut fu.sccp.constant_branches {
+        shift_opt(&mut cb.span, delta);
+    }
+}
+
+fn shift(span: &mut Span, delta: i64) {
+    let start = (i64::from(span.start()) + delta).max(0);
+    let end = (i64::from(span.end()) + delta).max(0);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    {
+        *span = Span::new(start as u32, end as u32);
+    }
+}
+
+fn shift_opt(span: &mut Option<Span>, delta: i64) {
+    if let Some(span) = span {
+        shift(span, delta);
+    }
+}
+
+fn rebase_tokens(tokens: &mut Option<CommandTokens>, delta: i64) {
+    if let Some(tokens) = tokens {
+        for span in &mut tokens.argv {
+            shift(span, delta);
+        }
+        for span in &mut tokens.all_tokens {
+            shift(span, delta);
+        }
+    }
+}
+
+fn rebase_script(script: &mut Script, delta: i64) {
+    for stmt in &mut script.statements {
+        rebase_statement(stmt, delta);
+    }
+}
+
+fn rebase_terminator(term: &mut Terminator, delta: i64) {
+    match term {
+        Terminator::Goto { span, .. }
+        | Terminator::Branch { span, .. }
+        | Terminator::Return { span, .. } => shift_opt(span, delta),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn rebase_statement(stmt: &mut Statement, delta: i64) {
+    match stmt {
+        Statement::AssignConst { span, .. }
+        | Statement::AssignExpr { span, .. }
+        | Statement::Incr { span, .. }
+        | Statement::ExprEval { span, .. }
+        | Statement::Return { span, .. } => shift(span, delta),
+        Statement::AssignValue { span, tokens, .. }
+        | Statement::Call { span, tokens, .. }
+        | Statement::Barrier { span, tokens, .. } => {
+            shift(span, delta);
+            rebase_tokens(tokens, delta);
+        }
+        Statement::Block {
+            span, body, tokens, ..
+        }
+        | Statement::UpFrame {
+            span, body, tokens, ..
+        } => {
+            shift(span, delta);
+            rebase_script(body, delta);
+            rebase_tokens(tokens, delta);
+        }
+        Statement::If {
+            span,
+            clauses,
+            else_body,
+            else_span,
+        } => {
+            shift(span, delta);
+            shift_opt(else_span, delta);
+            for clause in clauses {
+                shift(&mut clause.condition_span, delta);
+                shift(&mut clause.body_span, delta);
+                rebase_script(&mut clause.body, delta);
+            }
+            if let Some(body) = else_body {
+                rebase_script(body, delta);
+            }
+        }
+        Statement::For {
+            span,
+            init,
+            init_span,
+            next,
+            next_span,
+            condition_span,
+            body,
+            body_span,
+            ..
+        } => {
+            shift(span, delta);
+            shift(init_span, delta);
+            shift(condition_span, delta);
+            shift(next_span, delta);
+            shift(body_span, delta);
+            rebase_script(init, delta);
+            rebase_script(next, delta);
+            rebase_script(body, delta);
+        }
+        Statement::While {
+            span,
+            condition_span,
+            body,
+            body_span,
+            ..
+        } => {
+            shift(span, delta);
+            shift(condition_span, delta);
+            shift(body_span, delta);
+            rebase_script(body, delta);
+        }
+        Statement::Foreach {
+            span,
+            body,
+            body_span,
+            ..
+        } => {
+            shift(span, delta);
+            shift(body_span, delta);
+            rebase_script(body, delta);
+        }
+        Statement::Catch {
+            span,
+            body,
+            body_span,
+            tokens,
+            ..
+        } => {
+            shift(span, delta);
+            shift(body_span, delta);
+            rebase_script(body, delta);
+            rebase_tokens(tokens, delta);
+        }
+        Statement::Try {
+            span,
+            body,
+            body_span,
+            handlers,
+            finally_body,
+            finally_span,
+            ..
+        } => {
+            shift(span, delta);
+            shift(body_span, delta);
+            shift_opt(finally_span, delta);
+            rebase_script(body, delta);
+            for handler in handlers {
+                shift(&mut handler.body_span, delta);
+                rebase_script(&mut handler.body, delta);
+            }
+            if let Some(finally) = finally_body {
+                rebase_script(finally, delta);
+            }
+        }
+        Statement::Switch {
+            span,
+            subject_span,
+            arms,
+            default_body,
+            default_span,
+            ..
+        } => {
+            shift(span, delta);
+            shift(subject_span, delta);
+            shift_opt(default_span, delta);
+            for arm in arms {
+                shift(&mut arm.pattern_span, delta);
+                shift_opt(&mut arm.body_span, delta);
+                if let Some(body) = &mut arm.body {
+                    rebase_script(body, delta);
+                }
+            }
+            if let Some(body) = default_body {
+                rebase_script(body, delta);
+            }
+        }
+    }
+}

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -102,6 +102,7 @@ pub mod intervals;
 pub mod ir;
 pub mod ir_helpers;
 pub mod irules_checks;
+mod lattice_rebase;
 pub mod lowering;
 pub mod lowering_hooks;
 pub mod memory_ssa;

--- a/rust/tcl-compiler/src/segmenter.rs
+++ b/rust/tcl-compiler/src/segmenter.rs
@@ -46,7 +46,7 @@ impl UnclosedDelimiter {
 }
 
 /// A single Tcl command parsed from the token stream.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentedCommand {
     /// Byte span covering the whole command.
     pub span: Span,

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -24,7 +24,7 @@ use tcl_lexer::Span;
 /// is the literal text following the parameter name inside a braced
 /// `{name default}` form — whitespace before it is stripped, whitespace
 /// inside the default text is preserved.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ParamDef {
     /// Parameter name as written in the proc declaration.
     pub name: String,

--- a/rust/tcl-compiler/tests/per_item_corpus.rs
+++ b/rust/tcl-compiler/tests/per_item_corpus.rs
@@ -1,0 +1,95 @@
+//! Slice-2b corpus gate: `analyse_per_item` must equal `analyse` byte-for-byte
+//! over the real-world `tmp/` corpus (the per-item walk decomposition must
+//! converge to exactly a full rebuild). Corpus-gated (`--ignored`), mirroring
+//! `differential_incremental`.
+
+use std::path::{Path, PathBuf};
+
+use tcl_compiler::analyser::Analyser;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn gather(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
+    if out.len() >= cap {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            gather(&p, out, cap);
+        } else if p.extension().is_some_and(|x| x == "tcl") {
+            out.push(p);
+            if out.len() >= cap {
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "corpus gate; run explicitly with --ignored (needs tmp/ trees)"]
+fn per_item_matches_analyse_over_corpus() {
+    let dialect = "tcl8.6";
+    let mut files = Vec::new();
+    for v in [
+        "tcl8.4.20/library",
+        "tcl8.5.19/library",
+        "tcl8.6.16/library",
+        "tcl9.0.3/library",
+        "tcllib-2.0/modules",
+    ] {
+        gather(&repo_root().join("tmp").join(v), &mut files, 1500);
+    }
+
+    let mut checked = 0usize;
+    let mut fellback = 0usize;
+    let mut mismatches: Vec<String> = Vec::new();
+    for path in &files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.len() > 400_000 {
+            continue;
+        }
+        let want = Analyser::new().analyse(&src, dialect);
+        let got = Analyser::new().analyse_per_item(&src, dialect);
+        checked += 1;
+        if !tcl_lexer::script_is_complete(&src) || src.contains("tcl-lsp: stub") {
+            fellback += 1;
+        }
+        if got != want {
+            let name = path.file_name().unwrap().to_string_lossy();
+            let field = if got.all_procs != want.all_procs {
+                "all_procs"
+            } else if got.all_classes != want.all_classes {
+                "all_classes"
+            } else if got.global_scope != want.global_scope {
+                "global_scope"
+            } else if got.diagnostics != want.diagnostics {
+                "diagnostics"
+            } else if got.command_invocations != want.command_invocations {
+                "command_invocations"
+            } else if got.all_variables != want.all_variables {
+                "all_variables"
+            } else {
+                "other"
+            };
+            if mismatches.len() < 25 {
+                mismatches.push(format!("{name}: field={field}"));
+            }
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "analyse_per_item != analyse in {} / {checked} files (fellback~{fellback}):\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+    eprintln!("slice-2b gate: {checked} files, analyse_per_item == analyse ({fellback} trivially-fellback)");
+}

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -16,7 +16,9 @@
 //! tracked query is sound and avoids requiring `CommandRegistry: PartialEq`.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
 
 use tcl_compiler::analyser::per_item::{analyse_proc_body_isolated, BodyFragment, DeferredBody};
 use tcl_compiler::analyser::{
@@ -210,10 +212,32 @@ pub fn item_body_analysis<'db>(
     ))
 }
 
+/// Process-wide content-addressed cache of per-procedure lattices (slice 4).
+///
+/// Keyed by the procedure's position-independent content key (body source +
+/// module-context digest + params + interprocedural `param_constants` + dialect
+/// — see `CompilationUnit::build_for_memoized`); the value carries the build
+/// offset so a shifted-but-unchanged body is rebased to its new position.  The
+/// map is **idempotent** (a key fully determines its `FunctionUnit`), so reading
+/// and populating it inside the otherwise-pure [`file_analysis_incremental`]
+/// query is sound — exactly like the durable `registries` cache — and the
+/// resulting `AnalysisResult` is byte-identical whether entries hit or miss.
+fn lattice_cache() -> &'static Mutex<HashMap<String, (u32, FunctionUnit)>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, (u32, FunctionUnit)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Bound on [`lattice_cache`] entries; cleared wholesale when exceeded (a miss
+/// just rebuilds the byte-identical unit, so eviction is always safe).
+const LATTICE_CACHE_CAP: usize = 16_384;
+
 /// Incremental whole-file analysis: the per-item path with each `proc` body's
 /// isolated analysis memoised via [`item_body_analysis`], so a body edit
-/// recomputes one body + the cheap shell + cross-item tail instead of the whole
-/// walk.  Byte-identical to [`file_analysis`] (and `analyse`) — proven by the
+/// recomputes one body + the cheap shell instead of the whole walk; the
+/// CFG/SSA diagnostic tail's per-procedure lattices are likewise memoised via
+/// [`lattice_cache`] + `CompilationUnit::build_for_memoized` (slice 4), so an
+/// unchanged procedure's lattice is reused (and rebased) instead of rebuilt.
+/// Byte-identical to [`file_analysis`] (and `analyse`) — proven by the
 /// `per_item_corpus` gate over the shared `analyse_per_item_with` orchestration.
 #[salsa::tracked]
 pub fn file_analysis_incremental(
@@ -227,6 +251,42 @@ pub fn file_analysis_incremental(
     let text = file.text(db).clone();
     let mut analyser = Analyser::with_disabled_diagnostics(disabled_vec.iter().cloned().collect())
         .with_non_ascii_mode(non_ascii);
+
+    // Build the CFG/SSA tail's compilation unit with per-procedure lattices
+    // memoised, and feed it through the analyser's `cu_override` seam.  The
+    // registry mirrors the one `emit_cfg_ssa_diagnostics` builds for itself, so
+    // the supplied unit is the one it would otherwise build.
+    let mut registry = CommandRegistry::build_default();
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    if let Some(d) = DialectSet::parse(&dialect) {
+        registry.load_dialect(d);
+    }
+    let cu = CompilationUnit::build_for_memoized(
+        &text,
+        &registry,
+        false,
+        tcl_lexer::LexerConfig::default(),
+        &dialect,
+        &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
+            if let Some(entry) = lattice_cache()
+                .lock()
+                .expect("lattice cache poisoned")
+                .get(key)
+            {
+                return entry.clone();
+            }
+            let entry = build();
+            let mut map = lattice_cache().lock().expect("lattice cache poisoned");
+            if map.len() >= LATTICE_CACHE_CAP {
+                map.clear();
+            }
+            map.insert(key.to_owned(), entry.clone());
+            entry
+        },
+    )
+    .with_interprocedural(&registry, dialect_opt);
+    analyser.set_cu_override(Arc::new(cu));
+
     let mut body_fn = |body: &DeferredBody| -> BodyFragment {
         let key = ItemBodyKey::new(
             db,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -18,7 +18,9 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use tcl_compiler::analyser::{Analyser, AnalysisResult, NonAsciiMode};
+use tcl_compiler::analyser::{
+    Analyser, AnalysisResult, FileDecls, ItemSig, ItemTree, NonAsciiMode,
+};
 use tcl_lsp_core::document_symbols::DocumentSymbol;
 use tcl_lsp_core::folding::FoldingRange;
 use tcl_lsp_core::semantic_tokens::SemanticTokens;
@@ -110,6 +112,43 @@ pub fn file_analysis(
     let mut analyser = Analyser::with_disabled_diagnostics(disabled)
         .with_non_ascii_mode(config.non_ascii_mode(db));
     Arc::new(analyser.analyse(file.text(db), file.dialect(db)))
+}
+
+/// Offset-stable item tree — the per-item firewall's foundation (slice 1 of
+/// `docs/design/rust/incremental-analysis.md`). One item per declaration, keyed
+/// by stable name + kind so a shifted-but-unedited proc keeps its identity.
+///
+/// **Slice-1 anchor.** `ensemble_namespaces` lives on the `Analyser`, not the
+/// returned `AnalysisResult`, so this query runs `analyse` directly and reads
+/// the ensemble set off the instance rather than reusing [`file_analysis`]. The
+/// item set therefore *cannot* diverge from `analyse`. Slices 2–3 re-home this
+/// onto a cheap, independent CST extractor — guarded by the `file_decls` corpus
+/// gate + the `incremental == fresh` differential fuzzer + the full-rebuild
+/// fallback (item detection is config-independent, hence no `AnalyserConfig`).
+#[salsa::tracked]
+pub fn item_tree(db: &dyn salsa::Database, file: SourceFile) -> Arc<ItemTree> {
+    let mut analyser = Analyser::new();
+    let result = analyser.analyse(file.text(db), file.dialect(db));
+    Arc::new(ItemTree::from_analysis(
+        &result,
+        &analyser.ensemble_namespaces,
+    ))
+}
+
+/// Item signatures — the cross-item-relevant headers, with bodies stripped
+/// (`item_sig*` in the design graph). A body-only edit leaves these equal, so
+/// [`file_decls`] and the future cross-item passes early-cutoff.
+#[salsa::tracked]
+pub fn item_sigs(db: &dyn salsa::Database, file: SourceFile) -> Arc<Vec<ItemSig>> {
+    Arc::new(item_tree(db, file).sigs())
+}
+
+/// Aggregate declaration sets (`file_decls ← item_sig*`): the set of declared
+/// procs / classes / aliases / ensembles + the namespace tree the cross-item
+/// passes (W123 / arity) read read-only.
+#[salsa::tracked]
+pub fn file_decls(db: &dyn salsa::Database, file: SourceFile) -> Arc<FileDecls> {
+    Arc::new(FileDecls::from_sigs(item_sigs(db, file).iter()))
 }
 
 /// Document outline — wraps `document_symbols_from_analysis`, reusing the
@@ -204,5 +243,49 @@ mod tests {
         let after = file_analysis(&db, file, config);
         assert!(after.all_procs.contains_key("::b"));
         assert!(!after.all_procs.contains_key("::a"));
+    }
+
+    #[test]
+    fn file_decls_match_file_analysis() {
+        use std::collections::BTreeSet;
+        let db = TclDatabase::default();
+        let src = "proc p {} {}\noo::class create K {}\nnamespace eval z { proc q {} {} }\n";
+        let file = SourceFile::new(&db, src.to_owned(), "tcl".to_owned());
+        let decls = file_decls(&db, file);
+        let analysis = file_analysis(&db, file, cfg(&db));
+        let want_procs: BTreeSet<String> = analysis.all_procs.keys().cloned().collect();
+        let want_classes: BTreeSet<String> = analysis.all_classes.keys().cloned().collect();
+        let want_aliases: BTreeSet<String> = analysis.command_aliases.keys().cloned().collect();
+        assert_eq!(decls.procs, want_procs);
+        assert_eq!(decls.classes, want_classes);
+        assert_eq!(decls.aliases, want_aliases);
+        assert!(decls.namespaces.contains("::z"));
+    }
+
+    #[test]
+    fn item_sigs_track_signatures() {
+        use tcl_compiler::analyser::ItemKind;
+        let db = TclDatabase::default();
+        let file = SourceFile::new(&db, "proc greet {name} {}\n".to_owned(), "tcl".to_owned());
+        let sigs = item_sigs(&db, file);
+        let greet = sigs
+            .iter()
+            .find(|s| s.id.kind == ItemKind::Proc && s.id.key == "::greet")
+            .expect("greet item");
+        assert_eq!(greet.params.len(), 1);
+        assert_eq!(greet.params[0].name, "name");
+        assert_eq!(greet.namespace, "::");
+    }
+
+    #[test]
+    fn item_tree_recomputes_on_edit() {
+        use salsa::Setter as _;
+        let mut db = TclDatabase::default();
+        let file = SourceFile::new(&db, "proc a {} {}\n".to_owned(), "tcl".to_owned());
+        assert!(file_decls(&db, file).procs.contains("::a"));
+        file.set_text(&mut db).to("proc b {} {}\n".to_owned());
+        let after = file_decls(&db, file);
+        assert!(after.procs.contains("::b"));
+        assert!(!after.procs.contains("::a"));
     }
 }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -127,7 +127,10 @@ pub fn file_analysis(
 /// fallback (item detection is config-independent, hence no `AnalyserConfig`).
 #[salsa::tracked]
 pub fn item_tree(db: &dyn salsa::Database, file: SourceFile) -> Arc<ItemTree> {
-    let mut analyser = Analyser::new();
+    // `structure_only` skips diagnostic emission (the dominant analyse cost)
+    // while building the identical declaration/scope structure — a cheap,
+    // non-divergent item extractor (gated by `file_decls_corpus`).
+    let mut analyser = Analyser::new().structure_only();
     let result = analyser.analyse(file.text(db), file.dialect(db));
     Arc::new(ItemTree::from_analysis(
         &result,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -231,6 +231,53 @@ fn lattice_cache() -> &'static Mutex<HashMap<String, (u32, FunctionUnit)>> {
 /// just rebuilds the byte-identical unit, so eviction is always safe).
 const LATTICE_CACHE_CAP: usize = 16_384;
 
+/// Build a `CompilationUnit` (with interprocedural summary applied) whose
+/// per-procedure lattices are memoised in the process-wide [`lattice_cache`].
+///
+/// Shared by the analyser's CFG/SSA diagnostic tail and the optimiser's
+/// compiler-checks pass so an unchanged procedure's lattice is built once and
+/// reused (rebased to its new offset) across edits *and* across both
+/// consumers' passes.  Byte-identical to
+/// [`CompilationUnit::build_for_with_config`] `+ with_interprocedural`.
+///
+/// **`cache_ns` must uniquely encode the `config`** (the two consumers lower
+/// with different [`tcl_lexer::LexerConfig`]s, which can change a `{*}`/`}{`
+/// body's IR): callers pass distinct namespaces so entries never cross-pollute.
+#[must_use]
+pub fn memoised_compilation_unit(
+    source: &str,
+    registry: &CommandRegistry,
+    defer_top_level: bool,
+    config: tcl_lexer::LexerConfig,
+    cache_ns: &str,
+    dialect_opt: Option<&str>,
+) -> CompilationUnit {
+    CompilationUnit::build_for_memoized(
+        source,
+        registry,
+        defer_top_level,
+        config,
+        cache_ns,
+        &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
+            if let Some(entry) = lattice_cache()
+                .lock()
+                .expect("lattice cache poisoned")
+                .get(key)
+            {
+                return entry.clone();
+            }
+            let entry = build();
+            let mut map = lattice_cache().lock().expect("lattice cache poisoned");
+            if map.len() >= LATTICE_CACHE_CAP {
+                map.clear();
+            }
+            map.insert(key.to_owned(), entry.clone());
+            entry
+        },
+    )
+    .with_interprocedural(registry, dialect_opt)
+}
+
 /// Incremental whole-file analysis: the per-item path with each `proc` body's
 /// isolated analysis memoised via [`item_body_analysis`], so a body edit
 /// recomputes one body + the cheap shell instead of the whole walk; the
@@ -254,37 +301,23 @@ pub fn file_analysis_incremental(
 
     // Build the CFG/SSA tail's compilation unit with per-procedure lattices
     // memoised, and feed it through the analyser's `cu_override` seam.  The
-    // registry mirrors the one `emit_cfg_ssa_diagnostics` builds for itself, so
-    // the supplied unit is the one it would otherwise build.
+    // registry + default lexer config mirror what `emit_cfg_ssa_diagnostics`
+    // builds for itself, so the supplied unit is the one it would otherwise
+    // build.  Cache namespace `"a:"` (analyser, default lexer config) is
+    // distinct from the optimiser's so the two never cross-pollute.
     let mut registry = CommandRegistry::build_default();
     let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
     if let Some(d) = DialectSet::parse(&dialect) {
         registry.load_dialect(d);
     }
-    let cu = CompilationUnit::build_for_memoized(
+    let cu = memoised_compilation_unit(
         &text,
         &registry,
         false,
         tcl_lexer::LexerConfig::default(),
-        &dialect,
-        &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
-            if let Some(entry) = lattice_cache()
-                .lock()
-                .expect("lattice cache poisoned")
-                .get(key)
-            {
-                return entry.clone();
-            }
-            let entry = build();
-            let mut map = lattice_cache().lock().expect("lattice cache poisoned");
-            if map.len() >= LATTICE_CACHE_CAP {
-                map.clear();
-            }
-            map.insert(key.to_owned(), entry.clone());
-            entry
-        },
-    )
-    .with_interprocedural(&registry, dialect_opt);
+        &format!("a:{dialect}"),
+        dialect_opt,
+    );
     analyser.set_cu_override(Arc::new(cu));
 
     let mut body_fn = |body: &DeferredBody| -> BodyFragment {

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -18,9 +18,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+use tcl_compiler::analyser::per_item::{analyse_proc_body_isolated, BodyFragment, DeferredBody};
 use tcl_compiler::analyser::{
     Analyser, AnalysisResult, FileDecls, ItemSig, ItemTree, NonAsciiMode,
 };
+use tcl_compiler::signature_scan::types::ParamDef;
 use tcl_lsp_core::document_symbols::DocumentSymbol;
 use tcl_lsp_core::folding::FoldingRange;
 use tcl_lsp_core::semantic_tokens::SemanticTokens;
@@ -152,6 +154,99 @@ pub fn item_sigs(db: &dyn salsa::Database, file: SourceFile) -> Arc<Vec<ItemSig>
 #[salsa::tracked]
 pub fn file_decls(db: &dyn salsa::Database, file: SourceFile) -> Arc<FileDecls> {
     Arc::new(FileDecls::from_sigs(item_sigs(db, file).iter()))
+}
+
+/// Interned identity of a single `proc` body's isolated analysis — the per-item
+/// firewall's memoisation key (slice 3).  Holds everything
+/// [`analyse_proc_body_isolated`] consumes; equal keys (an unedited body) reuse
+/// the cached [`item_body_analysis`].  `content_start` keys on the body's
+/// absolute offset (offset-invariant rebasing is a follow-up; a same-position
+/// body edit already recomputes only that body).
+#[salsa::interned]
+pub struct ItemBodyKey<'db> {
+    #[returns(ref)]
+    pub body_text: String,
+    pub content_start: u32,
+    #[returns(ref)]
+    pub namespace: String,
+    #[returns(ref)]
+    pub scope_name: String,
+    #[returns(ref)]
+    pub params: Vec<ParamDef>,
+    pub name_span: tcl_lexer::Span,
+    #[returns(ref)]
+    pub dialect: String,
+    #[returns(ref)]
+    pub disabled: Vec<String>,
+    pub non_ascii: NonAsciiMode,
+}
+
+/// Memoised isolated analysis of one `proc` body.  A body-only edit changes
+/// only that body's [`ItemBodyKey`], so salsa reuses every other body's result.
+#[salsa::tracked]
+pub fn item_body_analysis<'db>(
+    db: &'db dyn salsa::Database,
+    key: ItemBodyKey<'db>,
+) -> Arc<BodyFragment> {
+    let body_text = key.body_text(db).clone();
+    let content_start = key.content_start(db);
+    #[allow(clippy::cast_possible_truncation)]
+    let span = tcl_lexer::Span::new(content_start, content_start + body_text.len() as u32);
+    let body = DeferredBody {
+        body_text,
+        body_tok: tcl_lexer::Token::new(tcl_lexer::TokenType::Str, span),
+        scope_path: Vec::new(),
+        is_method: false,
+        namespace: key.namespace(db).clone(),
+        scope_name: key.scope_name(db).clone(),
+        params: key.params(db).clone(),
+        name_span: key.name_span(db),
+    };
+    let disabled: HashSet<String> = key.disabled(db).iter().cloned().collect();
+    let overlay = tcl_compiler::analyser::types::build_stub_overlay(&[]);
+    Arc::new(analyse_proc_body_isolated(
+        &body,
+        key.dialect(db),
+        &disabled,
+        key.non_ascii(db),
+        Some(overlay),
+    ))
+}
+
+/// Incremental whole-file analysis: the per-item path with each `proc` body's
+/// isolated analysis memoised via [`item_body_analysis`], so a body edit
+/// recomputes one body + the cheap shell + cross-item tail instead of the whole
+/// walk.  Byte-identical to [`file_analysis`] (and `analyse`) — proven by the
+/// `per_item_corpus` gate over the shared `analyse_per_item_with` orchestration.
+#[salsa::tracked]
+pub fn file_analysis_incremental(
+    db: &dyn salsa::Database,
+    file: SourceFile,
+    config: AnalyserConfig,
+) -> Arc<AnalysisResult> {
+    let disabled_vec = config.disabled_diagnostics(db).clone();
+    let non_ascii = config.non_ascii_mode(db);
+    let dialect = file.dialect(db).clone();
+    let text = file.text(db).clone();
+    let mut analyser = Analyser::with_disabled_diagnostics(disabled_vec.iter().cloned().collect())
+        .with_non_ascii_mode(non_ascii);
+    let mut body_fn = |body: &DeferredBody| -> BodyFragment {
+        let content_start = body.body_tok.span.start() + u32::from(body.body_tok.content_offset);
+        let key = ItemBodyKey::new(
+            db,
+            body.body_text.clone(),
+            content_start,
+            body.namespace.clone(),
+            body.scope_name.clone(),
+            body.params.clone(),
+            body.name_span,
+            dialect.clone(),
+            disabled_vec.clone(),
+            non_ascii,
+        );
+        (*item_body_analysis(db, key)).clone()
+    };
+    Arc::new(analyser.analyse_per_item_with(&text, &dialect, &mut body_fn))
 }
 
 /// Document outline — wraps `document_symbols_from_analysis`, reusing the
@@ -290,5 +385,71 @@ mod tests {
         let after = file_decls(&db, file);
         assert!(after.procs.contains("::b"));
         assert!(!after.procs.contains("::a"));
+    }
+
+    #[test]
+    fn file_analysis_incremental_matches_full() {
+        let db = TclDatabase::default();
+        let cfg = cfg(&db);
+        for src in [
+            SRC,
+            "proc a {x} { return $x }\nproc b {} { a 1 }\n",
+            "namespace eval n { proc f {y} { set z $y } }\nset g 1\nputs $g\n",
+            "oo::class create K {\n  method m {a} { set n $a }\n}\nproc p {} { set q 1 }\n",
+        ] {
+            let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+            let inc = file_analysis_incremental(&db, file, cfg);
+            let full = file_analysis(&db, file, cfg);
+            assert_eq!(*inc, *full, "incremental != full for:\n{src}");
+        }
+    }
+
+    /// The slice-3 firewall: a body-only edit (same length, so other bodies
+    /// keep their offset) recomputes exactly one `item_body_analysis`.
+    #[test]
+    fn body_edit_recomputes_one_item() {
+        use salsa::Setter as _;
+        let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = {
+            let l = Arc::clone(&log);
+            move |ev: salsa::Event| {
+                if let salsa::EventKind::WillExecute { database_key } = ev.kind {
+                    l.lock().unwrap().push(format!("{database_key:?}"));
+                }
+            }
+        };
+        let mut db = TclDatabase {
+            storage: salsa::Storage::new(Some(Box::new(sink))),
+            registries: Arc::default(),
+        };
+        let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default);
+        let file = SourceFile::new(
+            &db,
+            "proc a {} { set x 11111 }\nproc b {} { set y 22222 }\n".to_owned(),
+            "tcl8.6".to_owned(),
+        );
+        let _ = file_analysis_incremental(&db, file, cfg);
+        let init = std::mem::take(&mut *log.lock().unwrap());
+        assert_eq!(
+            init.iter()
+                .filter(|s| s.contains("item_body_analysis"))
+                .count(),
+            2,
+            "initial: both bodies analysed: {init:?}"
+        );
+
+        // Edit proc a's body, keeping length (so b's offset is unchanged).
+        file.set_text(&mut db)
+            .to("proc a {} { set x 99999 }\nproc b {} { set y 22222 }\n".to_owned());
+        let _ = file_analysis_incremental(&db, file, cfg);
+        let after = std::mem::take(&mut *log.lock().unwrap());
+        assert_eq!(
+            after
+                .iter()
+                .filter(|s| s.contains("item_body_analysis"))
+                .count(),
+            1,
+            "body edit -> exactly ONE item_body_analysis recomputes: {after:?}"
+        );
     }
 }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -16,9 +16,14 @@
 //! tracked query is sound and avoids requiring `CommandRegistry: PartialEq`.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
-use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
+use tcl_compiler::cfg_builder::build_cfg_function_with_upvars;
+use tcl_compiler::cfg_builder::upvar_info::UpvarInfo;
+use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit, LatticeRequest};
+use tcl_compiler::compiler_checks::Diagnostic as CompilerCheck;
+use tcl_compiler::ir::Script;
+use tcl_compiler::optimiser::Optimisation;
 
 use tcl_compiler::analyser::per_item::{analyse_proc_body_isolated, BodyFragment, DeferredBody};
 use tcl_compiler::analyser::{
@@ -185,10 +190,7 @@ pub struct ItemBodyKey<'db> {
 /// changes only that body's [`ItemBodyKey`], so salsa reuses every other body's
 /// result; an edit that merely *shifts* a body leaves its key unchanged.
 #[salsa::tracked]
-pub fn item_body_analysis<'db>(
-    db: &'db dyn salsa::Database,
-    key: ItemBodyKey<'db>,
-) -> Arc<BodyFragment> {
+pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc<BodyFragment> {
     // The isolated analysis works at offset 0 and ignores `body_tok` / scope
     // path (the aggregator supplies the real position when grafting), so a
     // placeholder token is fine.
@@ -212,67 +214,128 @@ pub fn item_body_analysis<'db>(
     ))
 }
 
-/// Process-wide content-addressed cache of per-procedure lattices (slice 4).
-///
-/// Keyed by the procedure's position-independent content key (body source +
-/// module-context digest + params + interprocedural `param_constants` + dialect
-/// — see `CompilationUnit::build_for_memoized`); the value carries the build
-/// offset so a shifted-but-unchanged body is rebased to its new position.  The
-/// map is **idempotent** (a key fully determines its `FunctionUnit`), so reading
-/// and populating it inside the otherwise-pure [`file_analysis_incremental`]
-/// query is sound — exactly like the durable `registries` cache — and the
-/// resulting `AnalysisResult` is byte-identical whether entries hit or miss.
-fn lattice_cache() -> &'static Mutex<HashMap<String, (u32, FunctionUnit)>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, (u32, FunctionUnit)>>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+/// Interned module-wide CFG context (`upvar_procs` + `proc_params` from
+/// `prepare_cfg_context`), the context a procedure body's CFG is built under.
+/// Interned once per build and shared by every [`FnLatticeKey`] so a procedure's
+/// key stays small and the per-build interning cost is `O(procs)`, not
+/// `O(procs²)`.  The entry vecs are sorted by name before interning so an equal
+/// context (regardless of hash-map iteration order) yields the same id.
+#[salsa::interned]
+pub struct CfgContext<'db> {
+    #[returns(ref)]
+    pub upvar_ctx: Vec<(String, UpvarInfo)>,
+    #[returns(ref)]
+    pub proc_params: Vec<(String, Vec<String>)>,
 }
 
-/// Bound on [`lattice_cache`] entries; cleared wholesale when exceeded (a miss
-/// just rebuilds the byte-identical unit, so eviction is always safe).
-const LATTICE_CACHE_CAP: usize = 16_384;
+/// Interned identity of one procedure's **offset-0** baseline lattice
+/// (salsa-native lattice graph).  Holds the procedure's post-inline IR body
+/// normalised to offset 0 plus the CFG-determining module [`CfgContext`] +
+/// params + dialect — *not* its position — so a shifted-but-unchanged body
+/// interns to the same key and reuses the cached [`function_lattice`] (the
+/// builder rebases the result to the body's span).  Procedures with
+/// interprocedural `param_constants` are built fresh and never interned, so the
+/// key needs no `param_constants`.
+#[salsa::interned]
+pub struct FnLatticeKey<'db> {
+    #[returns(ref)]
+    pub body: Script,
+    #[returns(ref)]
+    pub qname: String,
+    #[returns(ref)]
+    pub params: Vec<String>,
+    pub context: CfgContext<'db>,
+    #[returns(ref)]
+    pub dialect: String,
+}
+
+/// Memoised offset-0 baseline lattice (CFG → SSA → def-use → SCCP → type →
+/// rendered → intra-procedural taint) for one procedure, built from its interned
+/// offset-0 body + context.  A body-only edit changes only that procedure's
+/// `FnLatticeKey`, so salsa reuses every other procedure's lattice; a shifted
+/// body interns to the same key (cache hit).  Rebuilds the CFG via the same
+/// `build_cfg_function_with_upvars` call `build_cfg` makes per procedure, so the
+/// result equals the whole-module build's unit (modulo offset).  The
+/// interprocedural taint re-run still happens at aggregation time
+/// (`with_interprocedural`).  Uses `db.registry` — byte-identical to the
+/// registry both diagnostics consumers build (`build_default` + `load_dialect`).
+#[salsa::tracked]
+pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<FunctionUnit> {
+    let context = key.context(db);
+    let upvar: HashMap<String, UpvarInfo> = context.upvar_ctx(db).iter().cloned().collect();
+    let proc_params: HashMap<String, Vec<String>> =
+        context.proc_params(db).iter().cloned().collect();
+    let registry = db.registry(key.dialect(db));
+    let cfg = build_cfg_function_with_upvars(key.qname(db), key.body(db), true, upvar, proc_params);
+    Arc::new(FunctionUnit::build(
+        key.qname(db),
+        cfg,
+        key.params(db),
+        &registry,
+    ))
+}
 
 /// Build a `CompilationUnit` (with interprocedural summary applied) whose
-/// per-procedure lattices are memoised in the process-wide [`lattice_cache`].
+/// per-procedure baseline lattices are memoised by the salsa-native
+/// [`function_lattice`] query.
 ///
-/// Shared by the analyser's CFG/SSA diagnostic tail and the optimiser's
-/// compiler-checks pass so an unchanged procedure's lattice is built once and
-/// reused (rebased to its new offset) across edits *and* across both
-/// consumers' passes.  Byte-identical to
+/// Shared by the analyser's CFG/SSA diagnostic tail
+/// ([`file_analysis_incremental`]) and the optimiser's compiler-checks pass
+/// ([`compiler_check_diagnostics`]) so an unchanged procedure's lattice is built
+/// once and reused (rebased to its new offset) across edits *and* across both
+/// consumers' passes — and garbage-collected by salsa, not a process-wide
+/// content cache.  Byte-identical to
 /// [`CompilationUnit::build_for_with_config`] `+ with_interprocedural`.
 ///
-/// **`cache_ns` must uniquely encode the `config`** (the two consumers lower
-/// with different [`tcl_lexer::LexerConfig`]s, which can change a `{*}`/`}{`
-/// body's IR): callers pass distinct namespaces so entries never cross-pollute.
+/// The two consumers lower with different [`tcl_lexer::LexerConfig`]s (which can
+/// change a `{*}`/`}{` body's IR), so the same procedure can intern to two
+/// different bodies; because the **post-lowering body is part of the key**, the
+/// two never cross-pollute — no explicit namespace is needed.
 #[must_use]
-pub fn memoised_compilation_unit(
+pub fn memoised_compilation_unit<'db>(
+    db: &'db dyn TclDb,
     source: &str,
     registry: &CommandRegistry,
     defer_top_level: bool,
     config: tcl_lexer::LexerConfig,
-    cache_ns: &str,
     dialect_opt: Option<&str>,
 ) -> CompilationUnit {
+    let dialect = dialect_opt.unwrap_or("");
+    // The module CFG context is the same for every procedure in this build;
+    // intern it once on the first request and reuse the id (O(procs), not
+    // O(procs²)).
+    let mut context: Option<CfgContext<'db>> = None;
     CompilationUnit::build_for_memoized(
         source,
         registry,
         defer_top_level,
         config,
-        cache_ns,
-        &mut |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| {
-            if let Some(entry) = lattice_cache()
-                .lock()
-                .expect("lattice cache poisoned")
-                .get(key)
-            {
-                return entry.clone();
-            }
-            let entry = build();
-            let mut map = lattice_cache().lock().expect("lattice cache poisoned");
-            if map.len() >= LATTICE_CACHE_CAP {
-                map.clear();
-            }
-            map.insert(key.to_owned(), entry.clone());
-            entry
+        dialect,
+        &mut |req: &LatticeRequest<'_>| -> FunctionUnit {
+            let context = *context.get_or_insert_with(|| {
+                let mut upvar: Vec<(String, UpvarInfo)> = req
+                    .upvar_procs
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                upvar.sort_by(|a, b| a.0.cmp(&b.0));
+                let mut proc_params: Vec<(String, Vec<String>)> = req
+                    .proc_params
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                proc_params.sort_by(|a, b| a.0.cmp(&b.0));
+                CfgContext::new(db, upvar, proc_params)
+            });
+            let key = FnLatticeKey::new(
+                db,
+                req.body.clone(),
+                req.qname.to_owned(),
+                req.params.to_vec(),
+                context,
+                req.dialect.to_owned(),
+            );
+            (*function_lattice(db, key)).clone()
         },
     )
     .with_interprocedural(registry, dialect_opt)
@@ -282,13 +345,14 @@ pub fn memoised_compilation_unit(
 /// isolated analysis memoised via [`item_body_analysis`], so a body edit
 /// recomputes one body + the cheap shell instead of the whole walk; the
 /// CFG/SSA diagnostic tail's per-procedure lattices are likewise memoised via
-/// [`lattice_cache`] + `CompilationUnit::build_for_memoized` (slice 4), so an
-/// unchanged procedure's lattice is reused (and rebased) instead of rebuilt.
-/// Byte-identical to [`file_analysis`] (and `analyse`) — proven by the
-/// `per_item_corpus` gate over the shared `analyse_per_item_with` orchestration.
+/// the salsa-native [`function_lattice`] query (through
+/// [`memoised_compilation_unit`]), so an unchanged procedure's lattice is reused
+/// (and rebased) instead of rebuilt.  Byte-identical to [`file_analysis`] (and
+/// `analyse`) — proven by the `per_item_corpus` gate over the shared
+/// `analyse_per_item_with` orchestration.
 #[salsa::tracked]
 pub fn file_analysis_incremental(
-    db: &dyn salsa::Database,
+    db: &dyn TclDb,
     file: SourceFile,
     config: AnalyserConfig,
 ) -> Arc<AnalysisResult> {
@@ -300,22 +364,18 @@ pub fn file_analysis_incremental(
         .with_non_ascii_mode(non_ascii);
 
     // Build the CFG/SSA tail's compilation unit with per-procedure lattices
-    // memoised, and feed it through the analyser's `cu_override` seam.  The
-    // registry + default lexer config mirror what `emit_cfg_ssa_diagnostics`
-    // builds for itself, so the supplied unit is the one it would otherwise
-    // build.  Cache namespace `"a:"` (analyser, default lexer config) is
-    // distinct from the optimiser's so the two never cross-pollute.
-    let mut registry = CommandRegistry::build_default();
+    // memoised by `function_lattice`, and feed it through the analyser's
+    // `cu_override` seam.  The registry (`db.registry`) + default lexer config
+    // mirror what `emit_cfg_ssa_diagnostics` builds for itself, so the supplied
+    // unit is the one it would otherwise build.
     let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
-    if let Some(d) = DialectSet::parse(&dialect) {
-        registry.load_dialect(d);
-    }
+    let registry = db.registry(&dialect);
     let cu = memoised_compilation_unit(
+        db,
         &text,
         &registry,
         false,
         tcl_lexer::LexerConfig::default(),
-        &format!("a:{dialect}"),
         dialect_opt,
     );
     analyser.set_cu_override(Arc::new(cu));
@@ -334,6 +394,79 @@ pub fn file_analysis_incremental(
         (*item_body_analysis(db, key)).clone()
     };
     Arc::new(analyser.analyse_per_item_with(&text, &dialect, &mut body_fn))
+}
+
+/// The compiler-checks + optimiser diagnostics for one document, unfiltered.
+///
+/// Returned by [`compiler_check_diagnostics`] for the server to filter
+/// (optimiser master switch / per-code disables) and lift into LSP diagnostics.
+/// Kept independent of the runtime gate so the query caches across config
+/// toggles.  `Clone + PartialEq` for salsa early-cutoff.
+#[derive(Clone, PartialEq)]
+pub struct CompilerDiagnostics {
+    /// `run_all_checks` output (GVN / shimmer / thunking / taint / iRules-flow /
+    /// SCCP), severities preserved.
+    pub checks: Vec<CompilerCheck>,
+    /// `optimise_unit` rewrites (`O1xx`), surfaced as HINT-severity suggestions.
+    pub optimisations: Vec<Optimisation>,
+}
+
+/// Run the compiler-checks + optimiser passes over a built unit.  Shared by the
+/// memoised [`compiler_check_diagnostics`] query and the no-salsa-input
+/// fallback so both produce byte-identical diagnostics.
+fn compiler_diagnostics_from_unit(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+    dialect_opt: Option<&str>,
+) -> CompilerDiagnostics {
+    CompilerDiagnostics {
+        checks: tcl_compiler::compiler_checks::run_all_checks(cu, registry, dialect_opt),
+        optimisations: tcl_compiler::optimiser::optimise_unit(cu, registry, dialect_opt),
+    }
+}
+
+/// Compiler-checks + optimiser diagnostics for one document, with the unit's
+/// per-procedure lattices memoised by the salsa-native [`function_lattice`]
+/// query (so an unchanged procedure is built once and shared with the analyser
+/// tail).  The optimiser lowers with the dialect lexer config — distinct from
+/// the analyser tail's default config, so the two intern different bodies and
+/// never cross-pollute.  Byte-identical to the former direct
+/// `lift_compiler_diagnostics` build.
+#[salsa::tracked]
+pub fn compiler_check_diagnostics(db: &dyn TclDb, file: SourceFile) -> Arc<CompilerDiagnostics> {
+    let text = file.text(db).clone();
+    let dialect = file.dialect(db).clone();
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let registry = db.registry(&dialect);
+    let cu = memoised_compilation_unit(
+        db,
+        &text,
+        &registry,
+        false,
+        tcl_lexer::LexerConfig::for_dialect(&dialect),
+        dialect_opt,
+    );
+    Arc::new(compiler_diagnostics_from_unit(&cu, &registry, dialect_opt))
+}
+
+/// No-salsa-input fallback for [`compiler_check_diagnostics`]: build the unit
+/// directly (no per-procedure memoisation) and run the same passes.  Used when
+/// a document has no [`SourceFile`] input yet (mirrors the analyser fallback).
+#[must_use]
+pub fn compiler_check_diagnostics_uncached(
+    text: &str,
+    registry: &CommandRegistry,
+    dialect: &str,
+) -> CompilerDiagnostics {
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let cu = CompilationUnit::build_for_with_config(
+        text,
+        registry,
+        false,
+        tcl_lexer::LexerConfig::for_dialect(dialect),
+    )
+    .with_interprocedural(registry, dialect_opt);
+    compiler_diagnostics_from_unit(&cu, registry, dialect_opt)
 }
 
 /// Document outline — wraps `document_symbols_from_analysis`, reusing the
@@ -539,6 +672,87 @@ mod tests {
                 .count(),
             1,
             "length-changing body edit -> exactly ONE item recomputes (offset-invariant): {after:?}"
+        );
+    }
+
+    /// The salsa-native optimiser path must be byte-identical to a direct
+    /// (non-memoised) compiler-checks + optimiser build, over several dialects.
+    #[test]
+    fn compiler_check_diagnostics_matches_uncached() {
+        let db = TclDatabase::default();
+        for (src, dialect) in [
+            ("proc a {x} { if {1} { set y 1 }\n return $y }\n", "tcl8.6"),
+            ("set g 0\nproc inc {} { global g; incr g }\ninc\n", "tcl8.6"),
+            (
+                "proc f {n} { set acc 0\n for {set i 0} {$i < $n} {incr i} { set acc [expr {$acc + $i}] }\n return $acc }\n",
+                "tcl9.0",
+            ),
+            ("when HTTP_REQUEST { set u [HTTP::uri] }\n", "f5-irules"),
+        ] {
+            let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned());
+            let got = compiler_check_diagnostics(&db, file);
+            let registry = db.registry(dialect);
+            let want = compiler_check_diagnostics_uncached(src, &registry, dialect);
+            assert_eq!(
+                got.checks, want.checks,
+                "checks differ for ({dialect}):\n{src}"
+            );
+            assert_eq!(
+                got.optimisations, want.optimisations,
+                "optimisations differ for ({dialect}):\n{src}"
+            );
+        }
+    }
+
+    /// A length-changing body edit to one procedure shifts the others but must
+    /// recompute exactly ONE `function_lattice` (the salsa-native per-procedure
+    /// lattice is offset-invariant: an unedited-but-shifted body interns to the
+    /// same key and is a cache hit, rebased to its new offset).
+    #[test]
+    fn function_lattice_reused_on_body_shift() {
+        use salsa::Setter as _;
+        let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = {
+            let l = Arc::clone(&log);
+            move |ev: salsa::Event| {
+                if let salsa::EventKind::WillExecute { database_key } = ev.kind {
+                    l.lock().unwrap().push(format!("{database_key:?}"));
+                }
+            }
+        };
+        let mut db = TclDatabase {
+            storage: salsa::Storage::new(Some(Box::new(sink))),
+            registries: Arc::default(),
+        };
+        let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default);
+        let file = SourceFile::new(
+            &db,
+            "proc a {} { set x 11111 }\nproc b {} { set y 22222 }\n".to_owned(),
+            "tcl8.6".to_owned(),
+        );
+        let _ = file_analysis_incremental(&db, file, cfg);
+        let init = std::mem::take(&mut *log.lock().unwrap());
+        assert_eq!(
+            init.iter()
+                .filter(|s| s.contains("function_lattice"))
+                .count(),
+            2,
+            "initial: both procedures' lattices built: {init:?}"
+        );
+
+        // Edit a's body length — shifts b's offset; b's offset-0 body is
+        // unchanged, so its `function_lattice` key is unchanged (cache hit).
+        file.set_text(&mut db)
+            .to("proc a {} { set x 9999999999 }\nproc b {} { set y 22222 }\n".to_owned());
+        let _ = file_analysis_incremental(&db, file, cfg);
+        let after = std::mem::take(&mut *log.lock().unwrap());
+        assert_eq!(
+            after
+                .iter()
+                .filter(|s| s.contains("function_lattice"))
+                .count(),
+            1,
+            "length-changing body edit -> exactly ONE lattice recomputes (offset-invariant): {after:?}"
         );
     }
 }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -157,23 +157,21 @@ pub fn file_decls(db: &dyn salsa::Database, file: SourceFile) -> Arc<FileDecls> 
 }
 
 /// Interned identity of a single `proc` body's isolated analysis — the per-item
-/// firewall's memoisation key (slice 3).  Holds everything
-/// [`analyse_proc_body_isolated`] consumes; equal keys (an unedited body) reuse
-/// the cached [`item_body_analysis`].  `content_start` keys on the body's
-/// absolute offset (offset-invariant rebasing is a follow-up; a same-position
-/// body edit already recomputes only that body).
+/// firewall's memoisation key.  **Offset-invariant**: it holds only what the
+/// offset-0 analysis consumes (body text + enclosing namespace / name / params +
+/// config), *not* the body's position — so a shifted-but-unedited proc has the
+/// same key and reuses the cached [`item_body_analysis`] (the aggregator rebases
+/// the offset-0 facts by the body's real span).
 #[salsa::interned]
 pub struct ItemBodyKey<'db> {
     #[returns(ref)]
     pub body_text: String,
-    pub content_start: u32,
     #[returns(ref)]
     pub namespace: String,
     #[returns(ref)]
     pub scope_name: String,
     #[returns(ref)]
     pub params: Vec<ParamDef>,
-    pub name_span: tcl_lexer::Span,
     #[returns(ref)]
     pub dialect: String,
     #[returns(ref)]
@@ -181,26 +179,25 @@ pub struct ItemBodyKey<'db> {
     pub non_ascii: NonAsciiMode,
 }
 
-/// Memoised isolated analysis of one `proc` body.  A body-only edit changes
-/// only that body's [`ItemBodyKey`], so salsa reuses every other body's result.
+/// Memoised offset-0 isolated analysis of one `proc` body.  A body-only edit
+/// changes only that body's [`ItemBodyKey`], so salsa reuses every other body's
+/// result; an edit that merely *shifts* a body leaves its key unchanged.
 #[salsa::tracked]
 pub fn item_body_analysis<'db>(
     db: &'db dyn salsa::Database,
     key: ItemBodyKey<'db>,
 ) -> Arc<BodyFragment> {
-    let body_text = key.body_text(db).clone();
-    let content_start = key.content_start(db);
-    #[allow(clippy::cast_possible_truncation)]
-    let span = tcl_lexer::Span::new(content_start, content_start + body_text.len() as u32);
+    // The isolated analysis works at offset 0 and ignores `body_tok` / scope
+    // path (the aggregator supplies the real position when grafting), so a
+    // placeholder token is fine.
     let body = DeferredBody {
-        body_text,
-        body_tok: tcl_lexer::Token::new(tcl_lexer::TokenType::Str, span),
+        body_text: key.body_text(db).clone(),
+        body_tok: tcl_lexer::Token::new(tcl_lexer::TokenType::Str, tcl_lexer::Span::new(0, 0)),
         scope_path: Vec::new(),
         is_method: false,
         namespace: key.namespace(db).clone(),
         scope_name: key.scope_name(db).clone(),
         params: key.params(db).clone(),
-        name_span: key.name_span(db),
     };
     let disabled: HashSet<String> = key.disabled(db).iter().cloned().collect();
     let overlay = tcl_compiler::analyser::types::build_stub_overlay(&[]);
@@ -231,15 +228,12 @@ pub fn file_analysis_incremental(
     let mut analyser = Analyser::with_disabled_diagnostics(disabled_vec.iter().cloned().collect())
         .with_non_ascii_mode(non_ascii);
     let mut body_fn = |body: &DeferredBody| -> BodyFragment {
-        let content_start = body.body_tok.span.start() + u32::from(body.body_tok.content_offset);
         let key = ItemBodyKey::new(
             db,
             body.body_text.clone(),
-            content_start,
             body.namespace.clone(),
             body.scope_name.clone(),
             body.params.clone(),
-            body.name_span,
             dialect.clone(),
             disabled_vec.clone(),
             non_ascii,
@@ -438,9 +432,11 @@ mod tests {
             "initial: both bodies analysed: {init:?}"
         );
 
-        // Edit proc a's body, keeping length (so b's offset is unchanged).
+        // Edit proc a's body, *changing its length* — this shifts proc b's
+        // byte offset.  Offset-invariance means b's key (its body text) is
+        // unchanged, so it stays a cache hit and only a recomputes.
         file.set_text(&mut db)
-            .to("proc a {} { set x 99999 }\nproc b {} { set y 22222 }\n".to_owned());
+            .to("proc a {} { set x 9999999999 }\nproc b {} { set y 22222 }\n".to_owned());
         let _ = file_analysis_incremental(&db, file, cfg);
         let after = std::mem::take(&mut *log.lock().unwrap());
         assert_eq!(
@@ -449,7 +445,7 @@ mod tests {
                 .filter(|s| s.contains("item_body_analysis"))
                 .count(),
             1,
-            "body edit -> exactly ONE item_body_analysis recomputes: {after:?}"
+            "length-changing body edit -> exactly ONE item recomputes (offset-invariant): {after:?}"
         );
     }
 }

--- a/rust/tcl-lsp-db/tests/file_decls_corpus.rs
+++ b/rust/tcl-lsp-db/tests/file_decls_corpus.rs
@@ -62,15 +62,18 @@ fn file_decls_match_analyse_over_corpus() {
         if src.len() > 400_000 {
             continue;
         }
-        let mut analyser = Analyser::new();
-        let result = analyser.analyse(&src, dialect);
-        let decls = ItemTree::from_analysis(&result, &analyser.ensemble_namespaces).file_decls();
+        // GOT: the cheap structure-only extractor (what `item_tree` uses).
+        let mut so = Analyser::new().structure_only();
+        let so_result = so.analyse(&src, dialect);
+        let decls = ItemTree::from_analysis(&so_result, &so.ensemble_namespaces).file_decls();
 
+        // WANT: a full `analyse`'s declaration sets — the authority.
+        let mut full = Analyser::new();
+        let result = full.analyse(&src, dialect);
         let want_procs: BTreeSet<String> = result.all_procs.keys().cloned().collect();
         let want_classes: BTreeSet<String> = result.all_classes.keys().cloned().collect();
         let want_aliases: BTreeSet<String> = result.command_aliases.keys().cloned().collect();
-        let want_ensembles: BTreeSet<String> =
-            analyser.ensemble_namespaces.iter().cloned().collect();
+        let want_ensembles: BTreeSet<String> = full.ensemble_namespaces.iter().cloned().collect();
         checked += 1;
 
         let name = path.file_name().unwrap().to_string_lossy();

--- a/rust/tcl-lsp-db/tests/file_decls_corpus.rs
+++ b/rust/tcl-lsp-db/tests/file_decls_corpus.rs
@@ -1,0 +1,99 @@
+//! Slice-1 corpus gate: `file_decls` must equal the analyser's own declaration
+//! sets (`all_procs` / `all_classes` / `command_aliases` / `ensemble_namespaces`)
+//! over the real-world `tmp/` corpus.
+//!
+//! In slice 1 the `item_tree` query is anchored to `Analyser::analyse`, so this
+//! holds by construction — but the test is the **permanent guard** that bites
+//! when slices 2–3 swap `item_tree` onto a cheap, independent CST extractor.
+//! Any divergence between that extractor and `analyse` shows up here as a
+//! per-file proc/class/alias/ensemble set mismatch. Corpus-gated (`--ignored`),
+//! mirroring `tcl-compiler`'s `differential_incremental`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use tcl_compiler::analyser::{Analyser, ItemTree};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn gather(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
+    if out.len() >= cap {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            gather(&p, out, cap);
+        } else if p.extension().is_some_and(|x| x == "tcl") {
+            out.push(p);
+            if out.len() >= cap {
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "corpus gate; run explicitly with --ignored (needs tmp/ trees)"]
+fn file_decls_match_analyse_over_corpus() {
+    let dialect = "tcl8.6";
+    let mut files = Vec::new();
+    for v in [
+        "tcl8.4.20/library",
+        "tcl8.5.19/library",
+        "tcl8.6.16/library",
+        "tcl9.0.3/library",
+        "tcllib-2.0/modules",
+    ] {
+        gather(&repo_root().join("tmp").join(v), &mut files, 1500);
+    }
+
+    let mut checked = 0usize;
+    let mut mismatches: Vec<String> = Vec::new();
+    for path in &files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.len() > 400_000 {
+            continue;
+        }
+        let mut analyser = Analyser::new();
+        let result = analyser.analyse(&src, dialect);
+        let decls = ItemTree::from_analysis(&result, &analyser.ensemble_namespaces).file_decls();
+
+        let want_procs: BTreeSet<String> = result.all_procs.keys().cloned().collect();
+        let want_classes: BTreeSet<String> = result.all_classes.keys().cloned().collect();
+        let want_aliases: BTreeSet<String> = result.command_aliases.keys().cloned().collect();
+        let want_ensembles: BTreeSet<String> =
+            analyser.ensemble_namespaces.iter().cloned().collect();
+        checked += 1;
+
+        let name = path.file_name().unwrap().to_string_lossy();
+        let mut report = |field: &str, got: &BTreeSet<String>, want: &BTreeSet<String>| {
+            if got != want && mismatches.len() < 20 {
+                let only_got: Vec<_> = got.difference(want).take(4).cloned().collect();
+                let only_want: Vec<_> = want.difference(got).take(4).cloned().collect();
+                mismatches.push(format!(
+                    "{name} {field}: only_decls={only_got:?} only_analyse={only_want:?}"
+                ));
+            }
+        };
+        report("procs", &decls.procs, &want_procs);
+        report("classes", &decls.classes, &want_classes);
+        report("aliases", &decls.aliases, &want_aliases);
+        report("ensembles", &decls.ensembles, &want_ensembles);
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "file_decls != analyse decl sets in {} files / {checked} checked:\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+    eprintln!("slice-1 gate: {checked} files, file_decls == analyse decl sets");
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -160,6 +160,11 @@ struct DiagInputs {
     documents: Arc<Mutex<HashMap<Url, DocumentState>>>,
     workspace_index: Arc<Mutex<core_workspace_index::WorkspaceIndex>>,
     gate: Arc<Mutex<()>>,
+    lattice_cache: Arc<
+        std::sync::Mutex<
+            HashMap<Url, HashMap<String, tcl_compiler::compilation_unit::FunctionUnit>>,
+        >,
+    >,
 }
 
 /// Run the analyser + diagnostic lifts for one document and publish the result,
@@ -174,6 +179,60 @@ struct DiagInputs {
 /// Decoupling diagnostics from salsa keeps editing responsive; the interactive
 /// read handlers still use the memoised queries.  (Sharing the two behind one
 /// cancellation-aware query is the later per-item/MVCC step.)
+/// Build the diagnostics `CompilationUnit` for `text`, memoising each
+/// procedure's per-function lattice in the per-URI `lattice_cache` (slice 4).
+///
+/// The result is byte-identical to the unit
+/// [`Analyser::emit_cfg_ssa_diagnostics`] would build itself — the cache only
+/// skips the redundant SSA/SCCP/type/rendered recompute for a procedure whose
+/// body (and absolute position, and cross-function context) is unchanged.  The
+/// URI's sub-map is taken out for the duration of the (CPU-heavy) build so the
+/// lock isn't held across it, then swept to the procedures present in this
+/// build and put back.
+fn build_memoised_cu(
+    text: &str,
+    dialect: &str,
+    registry: &CommandRegistry,
+    uri: &Url,
+    cache: &std::sync::Mutex<
+        HashMap<Url, HashMap<String, tcl_compiler::compilation_unit::FunctionUnit>>,
+    >,
+) -> Option<tcl_compiler::compilation_unit::CompilationUnit> {
+    use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
+
+    let mut map = cache.lock().ok()?.remove(uri).unwrap_or_default();
+    let mut touched: HashSet<String> = HashSet::new();
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    let cu = {
+        let mut memo = |key: &str, build: &mut dyn FnMut() -> FunctionUnit| -> FunctionUnit {
+            touched.insert(key.to_owned());
+            if let Some(fu) = map.get(key) {
+                return fu.clone();
+            }
+            let fu = build();
+            map.insert(key.to_owned(), fu.clone());
+            fu
+        };
+        CompilationUnit::build_for_memoized(
+            text,
+            registry,
+            false,
+            tcl_lexer::LexerConfig::default(),
+            dialect,
+            &mut memo,
+        )
+        .with_interprocedural(registry, dialect_opt)
+    };
+    // Sweep dead entries (procedures removed/renamed since the last build) so
+    // the cache stays bounded to the document's live procedures.
+    map.retain(|key, _| touched.contains(key));
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(uri.clone(), map);
+    }
+    Some(cu)
+}
+
+#[allow(clippy::too_many_lines)]
 async fn run_diagnostics_core(
     inputs: DiagInputs,
     uri: Url,
@@ -192,6 +251,7 @@ async fn run_diagnostics_core(
         documents,
         workspace_index,
         gate,
+        lattice_cache,
     } = inputs;
 
     // F5 BIG-IP config is not Tcl source — publish an empty set and stop.
@@ -212,15 +272,24 @@ async fn run_diagnostics_core(
     let line_count = text.lines().count();
 
     // Base analysis: a direct analyse on a blocking worker (no salsa handle —
-    // see the function doc), off the LSP event loop.
+    // see the function doc), off the LSP event loop.  The CFG/SSA diagnostic
+    // tail consumes a `CompilationUnit` whose per-procedure lattices are
+    // memoised in the per-URI `lattice_cache` (slice 4): a body-only edit
+    // reuses every unchanged procedure's lattice instead of rebuilding the
+    // whole unit.  The supplied unit is byte-identical to the one the tail
+    // would build itself, so diagnostics are unchanged.
     let analysis: Arc<AnalysisResult> = {
         let (a_text, a_dialect, a_disabled) = (text.clone(), dialect.clone(), disabled.clone());
+        let a_registry = Arc::clone(&registry);
+        let a_uri = uri.clone();
+        let a_cache = Arc::clone(&lattice_cache);
         tokio::task::spawn_blocking(move || {
-            Arc::new(
-                Backend::configured_analyser(a_disabled, non_ascii_mode)
-                    .analyse(&a_text, &a_dialect)
-                    .clone(),
-            )
+            let mut analyser = Backend::configured_analyser(a_disabled, non_ascii_mode);
+            if let Some(cu) = build_memoised_cu(&a_text, &a_dialect, &a_registry, &a_uri, &a_cache)
+            {
+                analyser.set_cu_override(Arc::new(cu));
+            }
+            Arc::new(analyser.analyse(&a_text, &a_dialect).clone())
         })
         .await
         .unwrap_or_default()
@@ -391,6 +460,18 @@ pub struct Backend {
     /// The salsa `AnalyserConfig` input (disabled diagnostics + non-ASCII
     /// mode); `set_*` on `workspace/didChangeConfiguration`.
     db_config: Mutex<tcl_lsp_db::AnalyserConfig>,
+    /// Per-URI content-addressed cache of per-procedure `FunctionUnit`
+    /// lattices for the diagnostics CFG/SSA tail (slice 4).  Keyed by URI, then
+    /// by the procedure's content key; a body-only edit reuses the lattices of
+    /// every procedure above the edit point instead of rebuilding the whole
+    /// compilation unit.  A `std::sync::Mutex` (not tokio) because it is locked
+    /// inside the `spawn_blocking` analyser worker; swept per build so it stays
+    /// bounded to the document's live procedures, and dropped on `did_close`.
+    lattice_cache: Arc<
+        std::sync::Mutex<
+            HashMap<Url, HashMap<String, tcl_compiler::compilation_unit::FunctionUnit>>,
+        >,
+    >,
 }
 
 /// Resolved `tclLsp.features.*` toggle state.
@@ -498,6 +579,7 @@ impl Backend {
             db: Arc::new(Mutex::new(db)),
             db_files: Mutex::new(HashMap::new()),
             db_config: Mutex::new(db_config),
+            lattice_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -520,6 +602,9 @@ impl Backend {
     /// Drop the salsa `SourceFile` input for `uri` (on `did_close`).
     async fn db_remove_source(&self, uri: &Url) {
         self.db_files.lock().await.remove(uri);
+        if let Ok(mut cache) = self.lattice_cache.lock() {
+            cache.remove(uri);
+        }
     }
 
     /// Mirror the editor analyser config (disabled diagnostics + non-ASCII
@@ -1968,6 +2053,7 @@ impl Backend {
             documents: Arc::clone(&self.documents),
             workspace_index: Arc::clone(&self.workspace_index),
             gate: Arc::clone(&self.document_analysis_gate),
+            lattice_cache: Arc::clone(&self.lattice_cache),
         }
     }
 
@@ -5329,6 +5415,7 @@ mod tests {
             db: Arc::new(Mutex::new(db)),
             db_files: Mutex::new(HashMap::new()),
             db_config: Mutex::new(db_config),
+            lattice_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -325,15 +325,48 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Url, job: DiagJob) -> bo
         .unwrap_or_default()
     };
 
+    // Optimiser / compiler-checks diagnostics, also off the event loop via the
+    // cancellable salsa `compiler_check_diagnostics` query: the unit's
+    // per-procedure lattices are memoised by `function_lattice` and shared with
+    // the analyser tail above.  On cancellation, drop the run like the base
+    // analysis (the superseding edit reschedules a fresh one).  `file` is `None`
+    // only if the salsa input is absent; then build directly (uncached).
+    let compiler_diags: Arc<tcl_lsp_db::CompilerDiagnostics> = if let Some(file) = file {
+        let snapshot = db.lock().await.clone();
+        match tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(|| tcl_lsp_db::compiler_check_diagnostics(&snapshot, file)).ok()
+        })
+        .await
+        {
+            Ok(Some(d)) => d,
+            Ok(None) | Err(_) => return false,
+        }
+    } else {
+        let (c_text, c_dialect) = (text.clone(), dialect.clone());
+        let c_registry = Arc::clone(&registry);
+        tokio::task::spawn_blocking(move || {
+            Arc::new(tcl_lsp_db::compiler_check_diagnostics_uncached(
+                &c_text,
+                &c_registry,
+                &c_dialect,
+            ))
+        })
+        .await
+        .unwrap_or_else(|_| {
+            Arc::new(tcl_lsp_db::CompilerDiagnostics {
+                checks: Vec::new(),
+                optimisations: Vec::new(),
+            })
+        })
+    };
+
     let analysis_lifts = Arc::clone(&analysis);
     let lift_text = text.clone();
-    let lift_dialect = dialect.clone();
     let result = tokio::task::spawn_blocking(move || {
         let mut diagnostics = lift_analyser_diagnostics(&lift_text, &analysis_lifts.diagnostics);
         diagnostics.extend(lift_compiler_diagnostics(
             &lift_text,
-            &registry,
-            &lift_dialect,
+            &compiler_diags,
             optimiser_enabled,
             &opt_disabled,
         ));
@@ -4358,36 +4391,22 @@ fn lift_source_style_diagnostics(
 /// both is a follow-up once the document-store lands.
 fn lift_compiler_diagnostics(
     text: &str,
-    registry: &CommandRegistry,
-    dialect: &str,
+    diags: &tcl_lsp_db::CompilerDiagnostics,
     optimiser_enabled: bool,
     disabled_optimisations: &std::collections::HashSet<String>,
 ) -> Vec<tower_lsp::lsp_types::Diagnostic> {
-    use tcl_compiler::compiler_checks::{run_all_checks, Severity as CheckSeverity};
-    use tcl_compiler::optimiser::optimise_unit;
+    use tcl_compiler::compiler_checks::Severity as CheckSeverity;
     use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString};
 
     let line_index = tcl_lexer::LineIndex::new(text);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
     let mut out: Vec<tower_lsp::lsp_types::Diagnostic> = Vec::new();
 
-    // Compiler checks: GVN / shimmer / thunking / taint / iRules-flow
-    // / SCCP, all keyed off a single interprocedurally-summarised
-    // compilation unit (mirrors the `compiler_checks_run_all` PyO3
-    // bridge's construction).  The unit's per-procedure lattices are memoised
-    // in the shared process-wide cache so an unchanged procedure is built once
-    // and reused across edits (the optimiser unit was the dominant remaining
-    // per-edit cost once the analyser walk + tail were memoised).  Cache
-    // namespace `"o:"` (optimiser, dialect lexer config) is distinct from the
-    // analyser's `"a:"` since the two lower with different lexer configs.
-    let cu = tcl_lsp_db::memoised_compilation_unit(
-        text,
-        registry,
-        false,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
-        &format!("o:{dialect}"),
-        dialect_opt,
-    );
+    // Compiler checks: GVN / shimmer / thunking / taint / iRules-flow / SCCP,
+    // all keyed off a single interprocedurally-summarised compilation unit whose
+    // per-procedure lattices are memoised by the salsa-native `function_lattice`
+    // query (so an unchanged procedure is built once and reused across edits
+    // *and* shared with the analyser tail).  The unit is built by the
+    // `compiler_check_diagnostics` query; here we only filter + lift.
     // An optimiser O-code (`O1xx`) is gated by the `tclLsp.optimiser.enabled`
     // master switch and the profile + per-code `disabled_optimisations` set,
     // wherever it is emitted (some — e.g. the constant-branch `O100` — come
@@ -4396,7 +4415,8 @@ fn lift_compiler_diagnostics(
     let optimiser_suppressed = |code: &str| {
         code.starts_with('O') && (!optimiser_enabled || disabled_optimisations.contains(code))
     };
-    for d in run_all_checks(&cu, registry, dialect_opt) {
+    for d in &diags.checks {
+        let d = d.clone();
         if optimiser_suppressed(&d.code) {
             continue;
         }
@@ -4422,12 +4442,11 @@ fn lift_compiler_diagnostics(
     // fix from the diagnostic; the fix plumbing itself is GAP-C3). The
     // `tclLsp.optimiser.enabled=false` master switch suppresses the whole
     // block, mirroring Python's `if optimiser_enabled:` gate.
-    // Share the single CompilationUnit already built above for `run_all_checks`
-    // instead of letting `optimise_with_dialect` lower the source a second time
-    // (~129 ms saved per document on large files — E7).
-    for o in optimise_unit(&cu, registry, dialect_opt)
-        .into_iter()
+    for o in diags
+        .optimisations
+        .iter()
         .filter(|_| optimiser_enabled)
+        .cloned()
     {
         // Profile + per-code gate: the active profile disables whole O-code
         // categories (the default `readability` profile surfaces only

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4363,7 +4363,6 @@ fn lift_compiler_diagnostics(
     optimiser_enabled: bool,
     disabled_optimisations: &std::collections::HashSet<String>,
 ) -> Vec<tower_lsp::lsp_types::Diagnostic> {
-    use tcl_compiler::compilation_unit::CompilationUnit;
     use tcl_compiler::compiler_checks::{run_all_checks, Severity as CheckSeverity};
     use tcl_compiler::optimiser::optimise_unit;
     use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString};
@@ -4375,14 +4374,20 @@ fn lift_compiler_diagnostics(
     // Compiler checks: GVN / shimmer / thunking / taint / iRules-flow
     // / SCCP, all keyed off a single interprocedurally-summarised
     // compilation unit (mirrors the `compiler_checks_run_all` PyO3
-    // bridge's construction).
-    let cu = CompilationUnit::build_for_with_config(
+    // bridge's construction).  The unit's per-procedure lattices are memoised
+    // in the shared process-wide cache so an unchanged procedure is built once
+    // and reused across edits (the optimiser unit was the dominant remaining
+    // per-edit cost once the analyser walk + tail were memoised).  Cache
+    // namespace `"o:"` (optimiser, dialect lexer config) is distinct from the
+    // analyser's `"a:"` since the two lower with different lexer configs.
+    let cu = tcl_lsp_db::memoised_compilation_unit(
         text,
         registry,
         false,
         tcl_lexer::LexerConfig::for_dialect(dialect),
-    )
-    .with_interprocedural(registry, dialect_opt);
+        &format!("o:{dialect}"),
+        dialect_opt,
+    );
     // An optimiser O-code (`O1xx`) is gated by the `tclLsp.optimiser.enabled`
     // master switch and the profile + per-code `disabled_optimisations` set,
     // wherever it is emitted (some — e.g. the constant-branch `O100` — come

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -160,11 +160,7 @@ struct DiagInputs {
     documents: Arc<Mutex<HashMap<Url, DocumentState>>>,
     workspace_index: Arc<Mutex<core_workspace_index::WorkspaceIndex>>,
     gate: Arc<Mutex<()>>,
-    lattice_cache: Arc<
-        std::sync::Mutex<
-            HashMap<Url, HashMap<String, tcl_compiler::compilation_unit::FunctionUnit>>,
-        >,
-    >,
+    lattice_cache: LatticeCache,
 }
 
 /// Run the analyser + diagnostic lifts for one document and publish the result,
@@ -184,19 +180,17 @@ struct DiagInputs {
 ///
 /// The result is byte-identical to the unit
 /// [`Analyser::emit_cfg_ssa_diagnostics`] would build itself — the cache only
-/// skips the redundant SSA/SCCP/type/rendered recompute for a procedure whose
-/// body (and absolute position, and cross-function context) is unchanged.  The
-/// URI's sub-map is taken out for the duration of the (CPU-heavy) build so the
-/// lock isn't held across it, then swept to the procedures present in this
+/// skips the redundant SSA/SCCP/type/rendered recompute for an unchanged
+/// procedure body (a shifted body is rebased to its new offset on the way out).
+/// The URI's sub-map is taken out for the duration of the (CPU-heavy) build so
+/// the lock isn't held across it, then swept to the procedures present in this
 /// build and put back.
 fn build_memoised_cu(
     text: &str,
     dialect: &str,
     registry: &CommandRegistry,
     uri: &Url,
-    cache: &std::sync::Mutex<
-        HashMap<Url, HashMap<String, tcl_compiler::compilation_unit::FunctionUnit>>,
-    >,
+    cache: &LatticeCacheStore,
 ) -> Option<tcl_compiler::compilation_unit::CompilationUnit> {
     use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
 
@@ -204,15 +198,16 @@ fn build_memoised_cu(
     let mut touched: HashSet<String> = HashSet::new();
     let dialect_opt = (!dialect.is_empty()).then_some(dialect);
     let cu = {
-        let mut memo = |key: &str, build: &mut dyn FnMut() -> FunctionUnit| -> FunctionUnit {
-            touched.insert(key.to_owned());
-            if let Some(fu) = map.get(key) {
-                return fu.clone();
-            }
-            let fu = build();
-            map.insert(key.to_owned(), fu.clone());
-            fu
-        };
+        let mut memo =
+            |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| -> (u32, FunctionUnit) {
+                touched.insert(key.to_owned());
+                if let Some(entry) = map.get(key) {
+                    return entry.clone();
+                }
+                let entry = build();
+                map.insert(key.to_owned(), entry.clone());
+                entry
+            };
         CompilationUnit::build_for_memoized(
             text,
             registry,
@@ -460,19 +455,26 @@ pub struct Backend {
     /// The salsa `AnalyserConfig` input (disabled diagnostics + non-ASCII
     /// mode); `set_*` on `workspace/didChangeConfiguration`.
     db_config: Mutex<tcl_lsp_db::AnalyserConfig>,
-    /// Per-URI content-addressed cache of per-procedure `FunctionUnit`
-    /// lattices for the diagnostics CFG/SSA tail (slice 4).  Keyed by URI, then
-    /// by the procedure's content key; a body-only edit reuses the lattices of
-    /// every procedure above the edit point instead of rebuilding the whole
-    /// compilation unit.  A `std::sync::Mutex` (not tokio) because it is locked
-    /// inside the `spawn_blocking` analyser worker; swept per build so it stays
-    /// bounded to the document's live procedures, and dropped on `did_close`.
-    lattice_cache: Arc<
-        std::sync::Mutex<
-            HashMap<Url, HashMap<String, tcl_compiler::compilation_unit::FunctionUnit>>,
-        >,
-    >,
+    /// Per-URI content-addressed cache of per-procedure lattices for the
+    /// diagnostics CFG/SSA tail (slice 4).  Keyed by URI, then by the
+    /// procedure's position-independent content key; a body-only edit reuses
+    /// (and rebases) the lattices of every *unchanged* procedure instead of
+    /// rebuilding the whole compilation unit.  A `std::sync::Mutex` (not tokio)
+    /// because it is locked inside the `spawn_blocking` analyser worker; swept
+    /// per build so it stays bounded to the document's live procedures, and
+    /// dropped on `did_close`.
+    lattice_cache: LatticeCache,
 }
+
+/// Backing store of the per-URI lattice cache: URI → (procedure content key →
+/// `(build_offset, FunctionUnit)`).  The offset lets a shifted-but-unchanged
+/// body be rebased to its new position on a cache hit.
+type LatticeCacheStore = std::sync::Mutex<
+    HashMap<Url, HashMap<String, (u32, tcl_compiler::compilation_unit::FunctionUnit)>>,
+>;
+
+/// Shared handle to the [`LatticeCacheStore`] (see [`Backend::lattice_cache`]).
+type LatticeCache = Arc<LatticeCacheStore>;
 
 /// Resolved `tclLsp.features.*` toggle state.
 ///

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -189,7 +189,6 @@ struct DiagInputs {
     opt_disabled: HashSet<String>,
     documents: Arc<Mutex<HashMap<Url, DocumentState>>>,
     workspace_index: Arc<Mutex<core_workspace_index::WorkspaceIndex>>,
-    gate: Arc<Mutex<()>>,
     /// The salsa db handle.  Each run clones a *fresh, short-lived* snapshot and
     /// drops it immediately, so an idle worker never holds a clone across the
     /// debounce sleep (which would block the next edit's `set_text` — salsa's
@@ -253,7 +252,6 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Url, job: DiagJob) -> bo
         opt_disabled,
         documents,
         workspace_index,
-        gate,
         db,
         // The worker captures the job from these before calling us; unused here.
         db_files: _,
@@ -351,12 +349,14 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Url, job: DiagJob) -> bo
     match result {
         Ok(diags) => {
             {
-                let _gate = gate.lock().await;
-                let is_current = documents
-                    .lock()
-                    .await
-                    .get(uri)
-                    .is_some_and(|doc| doc.revision == revision);
+                // Hold the `documents` lock across the currency re-check and the
+                // workspace-index update so a concurrent `did_change`/`did_close`
+                // (which also take `documents`) cannot interleave between them
+                // and leave a stale index entry — the role the former global
+                // `document_analysis_gate` served, now via the natural
+                // `documents` → `workspace_index` lock order.
+                let docs = documents.lock().await;
+                let is_current = docs.get(uri).is_some_and(|doc| doc.revision == revision);
                 if !is_current {
                     // Superseded by a newer edit, which has marked the document
                     // dirty — settled for this version; the worker will process
@@ -412,12 +412,6 @@ pub struct Backend {
     client: Client,
     /// Open documents. `Arc` so the detached diagnostics task can hold it.
     documents: Arc<Mutex<HashMap<Url, DocumentState>>>,
-    /// Serialises the small critical section that couples the live document
-    /// revision to the workspace index update + diagnostics publication.
-    /// The expensive analyser work runs outside this lock, on a detached
-    /// task, so an older worker cannot finish late and overwrite state for
-    /// newer text.  `Arc` so the detached task can hold it.
-    document_analysis_gate: Arc<Mutex<()>>,
     /// Per-URI coalescing diagnostics scheduler state.  Each edit marks the
     /// document dirty and, if no worker is running, starts one; the single
     /// worker debounces, then repeatedly analyses the document's **latest**
@@ -594,7 +588,6 @@ impl Backend {
         Self {
             client,
             documents: Arc::new(Mutex::new(HashMap::new())),
-            document_analysis_gate: Arc::new(Mutex::new(())),
             diag_slots: Arc::new(Mutex::new(HashMap::new())),
             default_dialect: Mutex::new("tcl8.6".to_owned()),
             workspace_folders: Mutex::new(Vec::new()),
@@ -927,10 +920,9 @@ impl Backend {
     /// server restarts.  Falls back to removing the entry when the
     /// URI isn't a readable file (untitled buffer, deleted file).
     ///
-    /// Disk IO and analysis deliberately run outside
-    /// `document_analysis_gate`. The final index update rechecks that
-    /// the URI is still closed, so a slow disk read cannot overwrite a
-    /// newly reopened unsaved buffer.
+    /// Disk IO and analysis deliberately run before taking any lock; the final
+    /// index update holds the `documents` lock across the still-closed re-check
+    /// so a slow disk read cannot overwrite a newly reopened unsaved buffer.
     async fn reindex_index_from_disk(&self, uri: &Url) {
         let analysed: Option<AnalysisResult> = if let Ok(path) = uri.to_file_path() {
             let dialect = match self.resolve_folder_dialect(uri).await {
@@ -947,8 +939,13 @@ impl Backend {
         } else {
             None
         };
-        let _gate = self.document_analysis_gate.lock().await;
-        if self.documents.lock().await.contains_key(uri) {
+        // Hold `documents` across the still-closed re-check and the index
+        // update (the `documents` → `workspace_index` order used everywhere
+        // since the global gate was retired) so a concurrent `did_open` cannot
+        // open the buffer between them and have its index entry clobbered by
+        // this disk-backed one.
+        let docs = self.documents.lock().await;
+        if docs.contains_key(uri) {
             return;
         }
         let mut index = self.workspace_index.lock().await;
@@ -2080,7 +2077,6 @@ impl Backend {
             opt_disabled,
             documents: Arc::clone(&self.documents),
             workspace_index: Arc::clone(&self.workspace_index),
-            gate: Arc::clone(&self.document_analysis_gate),
             db: Arc::clone(&self.db),
             db_files: Arc::clone(&self.db_files),
             db_config: Arc::clone(&self.db_config),
@@ -2248,14 +2244,12 @@ impl Backend {
     /// the live document map at publication time so stale on-disk
     /// analysis cannot overwrite the open-buffer entry.
     async fn merge_workspace_scan_results(&self, analysed: &[(String, AnalysisResult)]) {
-        let _gate = self.document_analysis_gate.lock().await;
-        let open: HashSet<String> = self
-            .documents
-            .lock()
-            .await
-            .keys()
-            .map(ToString::to_string)
-            .collect();
+        // Hold `documents` across the open-set read + index merge (the
+        // `documents` → `workspace_index` order that replaced the global gate)
+        // so a file opening mid-merge can't have its open-buffer index entry
+        // overwritten by this disk-backed scan result.
+        let docs = self.documents.lock().await;
+        let open: HashSet<String> = docs.keys().map(ToString::to_string).collect();
         let mut index = self.workspace_index.lock().await;
         for (uri, analysis) in analysed {
             if open.contains(uri) {
@@ -2309,22 +2303,23 @@ impl LanguageServer for Backend {
         let version = params.text_document.version;
         let dialect_for_diags = dialect.clone();
         {
-            let _gate = self.document_analysis_gate.lock().await;
+            // Hold `documents` across the salsa input set + the index removal
+            // (the `documents` → `workspace_index` order that replaced the
+            // global gate): a reader must never see the new `doc.text` with a
+            // stale query result for the old text, and no diagnostics run may
+            // re-add a stale index entry between them.
             let mut docs = self.documents.lock().await;
             docs.insert(
                 uri.clone(),
                 DocumentState::with_version(params.text_document.text, dialect, version),
             );
-            // Set the salsa input while holding the `documents` lock — same
-            // reasoning as `did_change`: a reader must never see the new
-            // `doc.text` with a stale query result for the old text.
             self.db_set_source(&uri, text.clone(), dialect_for_diags.clone())
                 .await;
-            drop(docs);
             self.workspace_index
                 .lock()
                 .await
                 .remove_document(uri.as_str());
+            drop(docs);
         }
         self.schedule_diagnostics(uri, dialect_for_diags).await;
     }
@@ -2342,7 +2337,6 @@ impl LanguageServer for Backend {
         let default_dialect = self.default_dialect.lock().await.clone();
         let change_version = params.text_document.version;
         let dialect = {
-            let _gate = self.document_analysis_gate.lock().await;
             let mut docs = self.documents.lock().await;
             let entry = docs
                 .entry(uri.clone())
@@ -2356,22 +2350,20 @@ impl LanguageServer for Backend {
             entry.text = text.clone();
             entry.bump_revision(change_version);
             let dialect = entry.dialect.clone();
-            // Update the salsa `SourceFile` input WHILE still holding the
-            // `documents` lock, so no concurrent request can observe the new
-            // `doc.text` (from `read_document`) together with a stale
-            // `file_analysis`/`document_symbols`/`semantic_tokens` query result
-            // for the old text. (db_set_source locks db→db_files, never
-            // documents, so this nesting introduces no new lock-order cycle.)
+            // Update the salsa `SourceFile` input + the cross-document index
+            // WHILE still holding the `documents` lock (the `documents` →
+            // `workspace_index` order that replaced the global gate): no
+            // concurrent request can observe the new `doc.text` (from
+            // `read_document`) with a stale query result for the old text, and
+            // no diagnostics run can re-add a stale index entry between the
+            // commit and the removal.  (db_set_source locks db→db_files, never
+            // documents, so this nesting introduces no lock-order cycle.)
             self.db_set_source(&uri, text, dialect.clone()).await;
-            drop(docs);
-            // The per-document analysis is no longer cached on the server — it
-            // lives in the query database, invalidated by the `db_set_source`
-            // above bumping the `SourceFile` input. The cross-document index is
-            // still refreshed by the diagnostics run below.
             self.workspace_index
                 .lock()
                 .await
                 .remove_document(uri.as_str());
+            drop(docs);
             dialect
         };
         self.schedule_diagnostics(uri, dialect).await;
@@ -2415,20 +2407,26 @@ impl LanguageServer for Backend {
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = &params.text_document.uri;
         {
-            let _gate = self.document_analysis_gate.lock().await;
-            self.documents.lock().await.remove(uri);
+            // Remove the live document + its index entry while holding
+            // `documents` (the `documents` → `workspace_index` order that
+            // replaced the global gate): an in-flight diagnostics run re-checks
+            // currency under `documents` and, finding the doc gone, will not
+            // re-add a stale index entry or publish for it.
+            let mut docs = self.documents.lock().await;
+            docs.remove(uri);
             self.workspace_index
                 .lock()
                 .await
                 .remove_document(uri.as_str());
-            // Clear any previously-published diagnostics before a later
-            // didOpen for the same URI can run. Close publishes do not
-            // carry a reliable document version, so this short publish
-            // stays ordered by the gate.
-            self.client
-                .publish_diagnostics(uri.clone(), Vec::new(), None)
-                .await;
+            drop(docs);
         }
+        // Clear any previously-published diagnostics so a later didOpen for the
+        // same URI starts clean.  Published outside the lock; a diagnostics run
+        // for the now-closed doc no longer publishes (its currency re-check
+        // fails), so this empty publish is the last word for the URI.
+        self.client
+            .publish_diagnostics(uri.clone(), Vec::new(), None)
+            .await;
         self.db_remove_source(uri).await;
         // Re-index the file from disk rather than dropping it: the
         // file still exists on disk and was (or would be) part of
@@ -5459,7 +5457,6 @@ mod tests {
         Backend {
             client: service.inner().client.clone(),
             documents: Arc::new(Mutex::new(HashMap::new())),
-            document_analysis_gate: Arc::new(Mutex::new(())),
             diag_slots: Arc::new(Mutex::new(HashMap::new())),
             default_dialect: Mutex::new("tcl8.6".to_owned()),
             workspace_folders: Mutex::new(Vec::new()),
@@ -5493,7 +5490,6 @@ mod tests {
             .db_set_source(&uri, current_src.to_owned(), "tcl8.6".to_owned())
             .await;
         {
-            let _gate = backend.document_analysis_gate.lock().await;
             let mut doc =
                 DocumentState::with_version(current_src.to_owned(), "tcl8.6".to_owned(), 2);
             doc.revision = 2;

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -147,9 +147,39 @@ impl DocumentState {
 /// diagnostics still feel immediate after typing stops.
 const DIAGNOSTICS_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(50);
 
-/// Owned inputs for a detached diagnostics run — everything
-/// [`run_diagnostics_core`] needs without borrowing `Backend`, so the work can
-/// run on a `tokio::spawn`ed task off the LSP event loop.
+/// One document edit's complete, self-consistent diagnostics input — captured
+/// together so the analysed text, the published version, and the salsa input
+/// handle all describe the *same* revision (no divergence between a `documents`
+/// read and a separate salsa lookup).  `file` is `None` only if the salsa input
+/// is somehow absent, in which case the run falls back to a direct `analyse`.
+#[derive(Clone)]
+struct DiagJob {
+    text: String,
+    dialect: String,
+    revision: u64,
+    version: Option<i32>,
+    file: Option<tcl_lsp_db::SourceFile>,
+    config: tcl_lsp_db::AnalyserConfig,
+}
+
+/// Per-URI coalescing-scheduler slot (see [`Backend::diag_slots`]).
+#[derive(Default)]
+struct DiagSlot {
+    /// An edit arrived that the running worker has not yet analysed.  Just a
+    /// flag: the worker reads the document's *current* state at drain time, so
+    /// it is robust to out-of-order edit processing (a late, lower-version edit
+    /// can't clobber a captured job — there is no captured job).
+    dirty: bool,
+    /// A worker task is currently draining this document.
+    running: bool,
+}
+
+/// Owned inputs for a detached diagnostics run — the document-independent
+/// handles [`run_diagnostics_core`] (and the worker's per-drain [`DiagJob`]
+/// capture) need without borrowing `Backend`, so the work can run on a
+/// `tokio::spawn`ed task off the LSP event loop.  `Clone` so the coalescing
+/// worker can reuse it across successive runs of one document.
+#[derive(Clone)]
 struct DiagInputs {
     client: Client,
     registry: Arc<CommandRegistry>,
@@ -160,82 +190,60 @@ struct DiagInputs {
     documents: Arc<Mutex<HashMap<Url, DocumentState>>>,
     workspace_index: Arc<Mutex<core_workspace_index::WorkspaceIndex>>,
     gate: Arc<Mutex<()>>,
-    lattice_cache: LatticeCache,
+    /// The salsa db handle.  Each run clones a *fresh, short-lived* snapshot and
+    /// drops it immediately, so an idle worker never holds a clone across the
+    /// debounce sleep (which would block the next edit's `set_text` — salsa's
+    /// exclusive-access write waits for all outstanding handles to drop).
+    db: Arc<Mutex<tcl_lsp_db::TclDatabase>>,
+    db_files: Arc<Mutex<HashMap<Url, tcl_lsp_db::SourceFile>>>,
+    db_config: Arc<Mutex<tcl_lsp_db::AnalyserConfig>>,
+}
+
+impl DiagInputs {
+    /// Capture the document's current, self-consistent diagnostics input (live
+    /// buffer + salsa input handle + config).  Reading at drain time — after the
+    /// debounce, once a burst's edits have settled — makes the worker robust to
+    /// out-of-order edit processing: it always analyses the latest committed
+    /// state.  `None` when the document is not open.
+    async fn capture_job(&self, uri: &Url) -> Option<DiagJob> {
+        let (text, dialect, revision, version) = {
+            let docs = self.documents.lock().await;
+            let doc = docs.get(uri)?;
+            (
+                doc.text.clone(),
+                doc.dialect.clone(),
+                doc.revision,
+                doc.version,
+            )
+        };
+        let file = self.db_files.lock().await.get(uri).copied();
+        let config = *self.db_config.lock().await;
+        Some(DiagJob {
+            text,
+            dialect,
+            revision,
+            version,
+            file,
+            config,
+        })
+    }
 }
 
 /// Run the analyser + diagnostic lifts for one document and publish the result,
 /// off the LSP event loop.  This is the detached body the old synchronous
 /// `publish_analyser_diagnostics` became.
 ///
-/// Crucially, the diagnostics path computes its base analysis with a *direct*
-/// `Analyser::analyse` rather than the salsa `file_analysis` query.  salsa's
-/// `set_text` write takes global write-exclusivity over the database, so a
-/// diagnostic read-handle held across the (uncancellable) analyse would block
-/// the next edit's write and, under concurrent load, stall worker threads.
-/// Decoupling diagnostics from salsa keeps editing responsive; the interactive
-/// read handlers still use the memoised queries.  (Sharing the two behind one
-/// cancellation-aware query is the later per-item/MVCC step.)
-/// Build the diagnostics `CompilationUnit` for `text`, memoising each
-/// procedure's per-function lattice in the per-URI `lattice_cache` (slice 4).
-///
-/// The result is byte-identical to the unit
-/// [`Analyser::emit_cfg_ssa_diagnostics`] would build itself — the cache only
-/// skips the redundant SSA/SCCP/type/rendered recompute for an unchanged
-/// procedure body (a shifted body is rebased to its new offset on the way out).
-/// The URI's sub-map is taken out for the duration of the (CPU-heavy) build so
-/// the lock isn't held across it, then swept to the procedures present in this
-/// build and put back.
-fn build_memoised_cu(
-    text: &str,
-    dialect: &str,
-    registry: &CommandRegistry,
-    uri: &Url,
-    cache: &LatticeCacheStore,
-) -> Option<tcl_compiler::compilation_unit::CompilationUnit> {
-    use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
-
-    let mut map = cache.lock().ok()?.remove(uri).unwrap_or_default();
-    let mut touched: HashSet<String> = HashSet::new();
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    let cu = {
-        let mut memo =
-            |key: &str, build: &mut dyn FnMut() -> (u32, FunctionUnit)| -> (u32, FunctionUnit) {
-                touched.insert(key.to_owned());
-                if let Some(entry) = map.get(key) {
-                    return entry.clone();
-                }
-                let entry = build();
-                map.insert(key.to_owned(), entry.clone());
-                entry
-            };
-        CompilationUnit::build_for_memoized(
-            text,
-            registry,
-            false,
-            tcl_lexer::LexerConfig::default(),
-            dialect,
-            &mut memo,
-        )
-        .with_interprocedural(registry, dialect_opt)
-    };
-    // Sweep dead entries (procedures removed/renamed since the last build) so
-    // the cache stays bounded to the document's live procedures.
-    map.retain(|key, _| touched.contains(key));
-    if let Ok(mut guard) = cache.lock() {
-        guard.insert(uri.clone(), map);
-    }
-    Some(cu)
-}
-
+/// The base analysis runs through the cancellable salsa `file_analysis_incremental`
+/// query (slice 5): the per-item walk is memoised and a concurrent edit's
+/// `set_text` cancels an in-flight read at a per-item query boundary, so the
+/// diagnostics path no longer needs the uncancellable direct-`analyse` detour
+/// that previously decoupled it from salsa to avoid write-contention stalls.
 #[allow(clippy::too_many_lines)]
-async fn run_diagnostics_core(
-    inputs: DiagInputs,
-    uri: Url,
-    text: String,
-    dialect: String,
-    revision: u64,
-    version: Option<i32>,
-) {
+async fn run_diagnostics_core(inputs: DiagInputs, uri: &Url, job: DiagJob) -> bool {
+    // Returns whether this version is **settled** (published, intentionally
+    // skipped as superseded, or a BIG-IP no-op).  `false` means the run was
+    // cancelled mid-flight and the caller should retry the document's latest
+    // state.
     let DiagInputs {
         client,
         registry,
@@ -246,45 +254,74 @@ async fn run_diagnostics_core(
         documents,
         workspace_index,
         gate,
-        lattice_cache,
+        db,
+        // The worker captures the job from these before calling us; unused here.
+        db_files: _,
+        db_config: _,
     } = inputs;
+    let DiagJob {
+        text,
+        dialect,
+        revision,
+        version,
+        file,
+        config,
+    } = job;
 
     // F5 BIG-IP config is not Tcl source — publish an empty set and stop.
     if Backend::is_bigip_dialect(&dialect) {
         let is_current = documents
             .lock()
             .await
-            .get(&uri)
+            .get(uri)
             .is_some_and(|doc| doc.revision == revision);
         if is_current {
-            client.publish_diagnostics(uri, Vec::new(), version).await;
+            client
+                .publish_diagnostics(uri.clone(), Vec::new(), version)
+                .await;
         }
-        return;
+        return true;
     }
 
     let started = std::time::Instant::now();
     let uri_str = uri.to_string();
     let line_count = text.lines().count();
 
-    // Base analysis: a direct analyse on a blocking worker (no salsa handle —
-    // see the function doc), off the LSP event loop.  The CFG/SSA diagnostic
-    // tail consumes a `CompilationUnit` whose per-procedure lattices are
-    // memoised in the per-URI `lattice_cache` (slice 4): a body-only edit
-    // reuses every unchanged procedure's lattice instead of rebuilding the
-    // whole unit.  The supplied unit is byte-identical to the one the tail
-    // would build itself, so diagnostics are unchanged.
-    let analysis: Arc<AnalysisResult> = {
+    // Base analysis: the cancellable salsa `file_analysis_incremental` query
+    // (slice 5), off the LSP event loop.  This retires the old direct-`analyse`
+    // detour: the per-item walk is memoised (a body edit recomputes one body +
+    // the cheap shell + tail, not the whole file), and a concurrent edit's
+    // `set_text` cancels this read at a per-item query boundary instead of
+    // stalling behind an uncancellable analyse.  On cancellation we drop the
+    // run — the superseding edit schedules a fresh one.  `file` is `None` only
+    // if the salsa input is somehow absent; then fall back to a direct analyse.
+    let analysis: Arc<AnalysisResult> = if let Some(file) = file {
+        // Clone a fresh, short-lived snapshot for just this read and move it
+        // into the worker; it drops when the read finishes, so it never holds
+        // exclusive-access-blocking references across the debounce sleep.
+        let snapshot = db.lock().await.clone();
+        match tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(|| {
+                tcl_lsp_db::file_analysis_incremental(&snapshot, file, config)
+            })
+            .ok()
+        })
+        .await
+        {
+            Ok(Some(analysis)) => analysis,
+            // Cancelled mid-read (a concurrent `set_text` on the shared db) or
+            // the worker panicked — don't publish; signal a retry of the
+            // document's latest state.
+            Ok(None) | Err(_) => return false,
+        }
+    } else {
         let (a_text, a_dialect, a_disabled) = (text.clone(), dialect.clone(), disabled.clone());
-        let a_registry = Arc::clone(&registry);
-        let a_uri = uri.clone();
-        let a_cache = Arc::clone(&lattice_cache);
         tokio::task::spawn_blocking(move || {
-            let mut analyser = Backend::configured_analyser(a_disabled, non_ascii_mode);
-            if let Some(cu) = build_memoised_cu(&a_text, &a_dialect, &a_registry, &a_uri, &a_cache)
-            {
-                analyser.set_cu_override(Arc::new(cu));
-            }
-            Arc::new(analyser.analyse(&a_text, &a_dialect).clone())
+            Arc::new(
+                Backend::configured_analyser(a_disabled, non_ascii_mode)
+                    .analyse(&a_text, &a_dialect)
+                    .clone(),
+            )
         })
         .await
         .unwrap_or_default()
@@ -318,17 +355,22 @@ async fn run_diagnostics_core(
                 let is_current = documents
                     .lock()
                     .await
-                    .get(&uri)
+                    .get(uri)
                     .is_some_and(|doc| doc.revision == revision);
                 if !is_current {
-                    return;
+                    // Superseded by a newer edit, which has marked the document
+                    // dirty — settled for this version; the worker will process
+                    // the newer state.
+                    return true;
                 }
                 let mut index = workspace_index.lock().await;
                 index.remove_document(uri.as_str());
                 index.add_document(uri.as_str(), &analysis);
             }
             let diag_count = diags.len();
-            client.publish_diagnostics(uri, diags, version).await;
+            client
+                .publish_diagnostics(uri.clone(), diags, version)
+                .await;
             let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
             client
                 .log_message(
@@ -339,6 +381,7 @@ async fn run_diagnostics_core(
                     ),
                 )
                 .await;
+            true
         }
         Err(err) => {
             client
@@ -347,6 +390,7 @@ async fn run_diagnostics_core(
                     format!("diagnostics worker panicked: {err}"),
                 )
                 .await;
+            true
         }
     }
 }
@@ -374,11 +418,15 @@ pub struct Backend {
     /// task, so an older worker cannot finish late and overwrite state for
     /// newer text.  `Arc` so the detached task can hold it.
     document_analysis_gate: Arc<Mutex<()>>,
-    /// Per-URI diagnostics generation counter for debouncing: each edit bumps
-    /// it, and a scheduled diagnostics task only proceeds if its generation is
-    /// still current after the debounce interval — coalescing a burst of
-    /// keystrokes into one analysis instead of one per character.
-    diag_gen: Arc<Mutex<HashMap<Url, u64>>>,
+    /// Per-URI coalescing diagnostics scheduler state.  Each edit marks the
+    /// document dirty and, if no worker is running, starts one; the single
+    /// worker debounces, then repeatedly analyses the document's **latest**
+    /// state until it has published the current version (retrying if a run was
+    /// cancelled mid-flight).  This guarantees the final version's diagnostics
+    /// are always published even under heavy edit bursts / CPU load — replacing
+    /// the older per-edit generation-counter scheme, which could drop the last
+    /// run with no retry.
+    diag_slots: Arc<Mutex<HashMap<Url, DiagSlot>>>,
     /// Fallback dialect string used when ``did_open`` cannot derive
     /// one from the ``languageId`` and no per-session
     /// ``workspace/didChangeConfiguration`` has been received yet.
@@ -451,30 +499,11 @@ pub struct Backend {
     db: Arc<Mutex<tcl_lsp_db::TclDatabase>>,
     /// Per-URI salsa `SourceFile` input handles — the input-of-record the
     /// query graph reads.  Kept current by `did_open` / `did_change`.
-    db_files: Mutex<HashMap<Url, tcl_lsp_db::SourceFile>>,
+    db_files: Arc<Mutex<HashMap<Url, tcl_lsp_db::SourceFile>>>,
     /// The salsa `AnalyserConfig` input (disabled diagnostics + non-ASCII
     /// mode); `set_*` on `workspace/didChangeConfiguration`.
-    db_config: Mutex<tcl_lsp_db::AnalyserConfig>,
-    /// Per-URI content-addressed cache of per-procedure lattices for the
-    /// diagnostics CFG/SSA tail (slice 4).  Keyed by URI, then by the
-    /// procedure's position-independent content key; a body-only edit reuses
-    /// (and rebases) the lattices of every *unchanged* procedure instead of
-    /// rebuilding the whole compilation unit.  A `std::sync::Mutex` (not tokio)
-    /// because it is locked inside the `spawn_blocking` analyser worker; swept
-    /// per build so it stays bounded to the document's live procedures, and
-    /// dropped on `did_close`.
-    lattice_cache: LatticeCache,
+    db_config: Arc<Mutex<tcl_lsp_db::AnalyserConfig>>,
 }
-
-/// Backing store of the per-URI lattice cache: URI → (procedure content key →
-/// `(build_offset, FunctionUnit)`).  The offset lets a shifted-but-unchanged
-/// body be rebased to its new position on a cache hit.
-type LatticeCacheStore = std::sync::Mutex<
-    HashMap<Url, HashMap<String, (u32, tcl_compiler::compilation_unit::FunctionUnit)>>,
->;
-
-/// Shared handle to the [`LatticeCacheStore`] (see [`Backend::lattice_cache`]).
-type LatticeCache = Arc<LatticeCacheStore>;
 
 /// Resolved `tclLsp.features.*` toggle state.
 ///
@@ -566,7 +595,7 @@ impl Backend {
             client,
             documents: Arc::new(Mutex::new(HashMap::new())),
             document_analysis_gate: Arc::new(Mutex::new(())),
-            diag_gen: Arc::new(Mutex::new(HashMap::new())),
+            diag_slots: Arc::new(Mutex::new(HashMap::new())),
             default_dialect: Mutex::new("tcl8.6".to_owned()),
             workspace_folders: Mutex::new(Vec::new()),
             folder_dialects: Mutex::new(Vec::new()),
@@ -579,9 +608,8 @@ impl Backend {
             optimiser_code_overrides: Mutex::new(HashMap::new()),
             line_length: Mutex::new(80),
             db: Arc::new(Mutex::new(db)),
-            db_files: Mutex::new(HashMap::new()),
-            db_config: Mutex::new(db_config),
-            lattice_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            db_files: Arc::new(Mutex::new(HashMap::new())),
+            db_config: Arc::new(Mutex::new(db_config)),
         }
     }
 
@@ -604,9 +632,6 @@ impl Backend {
     /// Drop the salsa `SourceFile` input for `uri` (on `did_close`).
     async fn db_remove_source(&self, uri: &Url) {
         self.db_files.lock().await.remove(uri);
-        if let Ok(mut cache) = self.lattice_cache.lock() {
-            cache.remove(uri);
-        }
     }
 
     /// Mirror the editor analyser config (disabled diagnostics + non-ASCII
@@ -2024,7 +2049,8 @@ impl Backend {
     /// event loop stays responsive.  `S-async-diagnostics`
     /// minimal port — the cached-analysis surface and
     /// debounced streaming contract lands in a follow-up.
-    /// Gather the owned inputs a detached diagnostics run needs.
+    /// Gather the document-independent handles a detached diagnostics run needs
+    /// (per-edit state travels in a [`DiagJob`]).
     async fn diag_inputs(&self, dialect: &str) -> DiagInputs {
         let opt_disabled: HashSet<String> = {
             let mut set: HashSet<String> = tcl_compiler::optimiser::profiles::profile_to_disabled(
@@ -2055,7 +2081,9 @@ impl Backend {
             documents: Arc::clone(&self.documents),
             workspace_index: Arc::clone(&self.workspace_index),
             gate: Arc::clone(&self.document_analysis_gate),
-            lattice_cache: Arc::clone(&self.lattice_cache),
+            db: Arc::clone(&self.db),
+            db_files: Arc::clone(&self.db_files),
+            db_config: Arc::clone(&self.db_config),
         }
     }
 
@@ -2067,49 +2095,85 @@ impl Backend {
     async fn publish_analyser_diagnostics(
         &self,
         uri: Url,
-        text: String,
+        _text: String,
         dialect: String,
-        revision: u64,
-        version: Option<i32>,
+        _revision: u64,
+        _version: Option<i32>,
     ) {
         let inputs = self.diag_inputs(&dialect).await;
-        run_diagnostics_core(inputs, uri, text, dialect, revision, version).await;
+        let Some(job) = inputs.capture_job(&uri).await else {
+            return;
+        };
+        run_diagnostics_core(inputs, &uri, job).await;
     }
 
     /// Schedule a debounced, detached diagnostics run for `uri`.  Returns
     /// immediately (the analyser work runs on a `tokio::spawn`ed task), so
-    /// `did_open` / `did_change` never block the message loop on analysis —
-    /// the fix for editing latency, where every keystroke previously awaited a
-    /// full re-analysis.  A burst of edits collapses to one run via the
-    /// per-URI generation check after the debounce interval.
-    async fn schedule_diagnostics(
-        &self,
-        uri: Url,
-        text: String,
-        dialect: String,
-        revision: u64,
-        version: Option<i32>,
-    ) {
-        let my_gen = {
-            let mut gens = self.diag_gen.lock().await;
-            let slot = gens.entry(uri.clone()).or_insert(0);
-            *slot += 1;
-            *slot
-        };
-        let inputs = self.diag_inputs(&dialect).await;
-        let diag_gen = Arc::clone(&self.diag_gen);
-        tokio::spawn(async move {
-            // Debounce: a burst of edits all sleep here first, so none holds a
-            // salsa read while the next edit's `set_text` write runs — only the
-            // surviving (latest-generation) task then runs one analysis.  This
-            // is load-bearing: without it, concurrent per-edit analyses make
-            // each write block a worker thread waiting for in-flight reads,
-            // stalling the message loop after a dozen edits.
-            tokio::time::sleep(DIAGNOSTICS_DEBOUNCE).await;
-            if diag_gen.lock().await.get(&uri).copied() != Some(my_gen) {
-                return;
+    /// `did_open` / `did_change` never block the message loop on analysis.
+    ///
+    /// Coalescing per-URI worker: the edit marks the document dirty and, if no
+    /// worker is already draining `uri`, starts one.  The worker debounces, then
+    /// captures and analyses the document's **current** state (so a burst — even
+    /// one whose `didChange` notifications are processed out of order — settles
+    /// on the latest committed version), retrying if a run is cancelled
+    /// mid-flight by a concurrent `set_text`.  This guarantees the final
+    /// version's diagnostics are always published, even under a heavy edit burst
+    /// on a loaded machine, and never runs two analyses for one document
+    /// concurrently (so an edit's write is never blocked behind a stale read).
+    async fn schedule_diagnostics(&self, uri: Url, dialect: String) {
+        let start_worker = {
+            let mut slots = self.diag_slots.lock().await;
+            let slot = slots.entry(uri.clone()).or_default();
+            slot.dirty = true;
+            if slot.running {
+                false
+            } else {
+                slot.running = true;
+                true
             }
-            run_diagnostics_core(inputs, uri, text, dialect, revision, version).await;
+        };
+        if !start_worker {
+            return;
+        }
+        let inputs = self.diag_inputs(&dialect).await;
+        let slots = Arc::clone(&self.diag_slots);
+        tokio::spawn(async move {
+            loop {
+                // Debounce, then claim the dirty flag.  A burst collapses to one
+                // run; with nothing dirty we retire the worker (under the lock,
+                // so a concurrent edit either sees `running` and skips the spawn
+                // while we run, or sees `!running` and starts a fresh one).
+                tokio::time::sleep(DIAGNOSTICS_DEBOUNCE).await;
+                {
+                    let mut guard = slots.lock().await;
+                    let Some(slot) = guard.get_mut(&uri) else {
+                        return;
+                    };
+                    if slot.dirty {
+                        slot.dirty = false;
+                    } else {
+                        slot.running = false;
+                        return;
+                    }
+                }
+                // Capture + analyse the document's current state.  If it is gone
+                // (closed) there is nothing to publish — retire.
+                let Some(job) = inputs.capture_job(&uri).await else {
+                    let mut guard = slots.lock().await;
+                    if let Some(slot) = guard.get_mut(&uri) {
+                        slot.running = false;
+                    }
+                    return;
+                };
+                let settled = run_diagnostics_core(inputs.clone(), &uri, job).await;
+                if !settled {
+                    // Cancelled mid-flight — re-mark dirty so we retry the latest
+                    // state next loop.
+                    if let Some(slot) = slots.lock().await.get_mut(&uri) {
+                        slot.dirty = true;
+                    }
+                }
+            }
         });
     }
 
@@ -2244,7 +2308,7 @@ impl LanguageServer for Backend {
         let text = params.text_document.text.clone();
         let version = params.text_document.version;
         let dialect_for_diags = dialect.clone();
-        let (revision, version) = {
+        {
             let _gate = self.document_analysis_gate.lock().await;
             let mut docs = self.documents.lock().await;
             docs.insert(
@@ -2261,10 +2325,8 @@ impl LanguageServer for Backend {
                 .lock()
                 .await
                 .remove_document(uri.as_str());
-            (0, Some(version))
-        };
-        self.schedule_diagnostics(uri, text, dialect_for_diags, revision, version)
-            .await;
+        }
+        self.schedule_diagnostics(uri, dialect_for_diags).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
@@ -2279,7 +2341,7 @@ impl LanguageServer for Backend {
         }
         let default_dialect = self.default_dialect.lock().await.clone();
         let change_version = params.text_document.version;
-        let (text, dialect, revision, version) = {
+        let dialect = {
             let _gate = self.document_analysis_gate.lock().await;
             let mut docs = self.documents.lock().await;
             let entry = docs
@@ -2294,16 +2356,13 @@ impl LanguageServer for Backend {
             entry.text = text.clone();
             entry.bump_revision(change_version);
             let dialect = entry.dialect.clone();
-            let revision = entry.revision;
-            let version = entry.version;
             // Update the salsa `SourceFile` input WHILE still holding the
             // `documents` lock, so no concurrent request can observe the new
             // `doc.text` (from `read_document`) together with a stale
             // `file_analysis`/`document_symbols`/`semantic_tokens` query result
             // for the old text. (db_set_source locks db→db_files, never
             // documents, so this nesting introduces no new lock-order cycle.)
-            self.db_set_source(&uri, text.clone(), dialect.clone())
-                .await;
+            self.db_set_source(&uri, text, dialect.clone()).await;
             drop(docs);
             // The per-document analysis is no longer cached on the server — it
             // lives in the query database, invalidated by the `db_set_source`
@@ -2313,10 +2372,9 @@ impl LanguageServer for Backend {
                 .lock()
                 .await
                 .remove_document(uri.as_str());
-            (text, dialect, revision, version)
+            dialect
         };
-        self.schedule_diagnostics(uri, text, dialect, revision, version)
-            .await;
+        self.schedule_diagnostics(uri, dialect).await;
     }
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
@@ -5402,7 +5460,7 @@ mod tests {
             client: service.inner().client.clone(),
             documents: Arc::new(Mutex::new(HashMap::new())),
             document_analysis_gate: Arc::new(Mutex::new(())),
-            diag_gen: Arc::new(Mutex::new(HashMap::new())),
+            diag_slots: Arc::new(Mutex::new(HashMap::new())),
             default_dialect: Mutex::new("tcl8.6".to_owned()),
             workspace_folders: Mutex::new(Vec::new()),
             folder_dialects: Mutex::new(Vec::new()),
@@ -5415,9 +5473,8 @@ mod tests {
             optimiser_code_overrides: Mutex::new(HashMap::new()),
             line_length: Mutex::new(80),
             db: Arc::new(Mutex::new(db)),
-            db_files: Mutex::new(HashMap::new()),
-            db_config: Mutex::new(db_config),
-            lattice_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            db_files: Arc::new(Mutex::new(HashMap::new())),
+            db_config: Arc::new(Mutex::new(db_config)),
         }
     }
 

--- a/rust/tcl-syntax/src/expr/ast.rs
+++ b/rust/tcl-syntax/src/expr/ast.rs
@@ -257,7 +257,7 @@ impl fmt::Display for UnaryOp {
 /// can produce, plus [`Self::Raw`] as the "give up" fallback. Expression
 /// trees are immutable once built (no interior mutability). Recursive
 /// children are `Box<ExprNode>` to keep the enum size bounded.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ExprNode {
     /// Integer, float, or boolean literal.
     Literal {


### PR DESCRIPTION
## Summary

Builds out per-item incremental analysis for the Rust LSP, on top of the
async/debounced-diagnostics work. Every change here is **byte-identical to a
full rebuild** — guaranteed by a full-rebuild fallback plus the differential
`incremental == fresh` fuzzer and the `per_item == analyse` corpus gate.

Two headline pieces land on this branch:

### 1. Salsa-native per-procedure lattice graph (`577c4dd1`)
Replaces the process-wide content-addressed lattice cache with a salsa query
graph:
- `function_lattice` interns each procedure's **offset-0** post-inline IR body +
  an interned `CfgContext` (module-wide upvar/proc-param maps) + params + dialect,
  and memoises the baseline lattice (CFG → SSA → def-use → SCCP → type → rendered
  → intra-procedural taint). A shifted-but-unedited proc interns to the same key
  (offset-invariant); a body edit recomputes only that proc.
- Both diagnostics consumers now run on salsa: the analyser CFG/SSA tail
  (`file_analysis_incremental`) and the optimiser checks, moved onto a new
  `compiler_check_diagnostics` query (the former was the architectural blocker —
  it ran off-salsa with no db handle). The content cache is retired (salsa GC).
- `FunctionUnit` / `DefUseResult` derive `PartialEq` so `Arc<FunctionUnit>` is a
  valid tracked return (salsa's autoref `UpdateFallback`).

### 2. Phase B — widen the per-item analyser fast path (`347137bc`)
The per-item walk previously fell back to a full re-analyse whenever any proc
body touched namespace/global/`variable` state or read a `::`-qualified
variable — i.e. almost every non-trivial file. This widens the fast path while
staying byte-identical:
- **Replay qualified reads**: an isolated body's `$::g` read that misses its
  empty enclosing global scope is captured and replayed on the shell's real
  `::g` at graft time.
- **Narrow the fallback** to the patterns the isolated decomposition genuinely
  can't reproduce: bodies that declare/write enclosing variables or
  define/extend a class.
- **Detect duplicate definitions** (top-level platform-conditional `proc`s and
  the lazy-init `proc p {…; proc p {…}}` self-redefinition pattern) and fall
  back for those.

Fast-path coverage rises to ~42% of the corpus.

## Validation (all green)
- `per_item_corpus` byte-identical over the `tmp/` corpus
- `differential_incremental` fuzzer: **0 mismatches**
- `make test-lsp-e2e-rust`: **514 passed / 1 skipped / 1 failed** (the lone
  failure is the pre-existing registry-count parity gap)
- workspace build, `cargo clippy` (no new warnings), `cargo fmt`, full lib tests

## Performance
- **vs Python** (the headline): ~24× full diagnostics, ~40× semantic tokens,
  ~306× optimisation, ~3154× open+index on a 119-file project; on realistic
  **edits**, 8–19× faster per keystroke on medium/large modules and ~5–21× on
  project-level work.
- **vs pre-change Rust**: the salsa-native graph is ~net-zero on latency
  (architecture/GC/foundation, not speed); Phase B is latency-neutral too.

## Honest finding / next step
Per-edit latency on large files (~1–1.8 s) is **not** the per-proc body walk the
firewall memoises — it's the **non-incremental whole-file tail**: `emit_cfg_ssa`
(CFG→SSA→checks over the whole source) + the cross-item `W123`/arity passes +
the optimiser checks, all re-run on every edit. Making *those* incremental
(per-item CFG-SSA emission keyed on the memoised lattices; incremental
`W123`/arity; an interprocedural taint cascade) is the real remaining win — and
the salsa-native lattice graph here is the foundation for it.

https://claude.ai/code/session_01CFJPzeWkYa7LZ8chiDhkyd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFJPzeWkYa7LZ8chiDhkyd)_