### PR TITLE
Pin npm CLI to v12 via Corepack in CI and local dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,20 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # The npm CLI itself is pinned via the `packageManager` field in
+      # package.json (currently npm@12.0.0-pre.0.0). Dependabot tracks that
+      # field as the "npm" dependency, so isolate it in its own group: a CLI
+      # bump (e.g. the npm 12 prerelease -> stable 12.0.0) then lands as a
+      # clearly labelled standalone PR instead of being buried in the weekly
+      # devDependency roll-up.
+      npm-cli:
+        patterns:
+          - "npm"
       npm:
         patterns:
           - "*"
+        exclude-patterns:
+          - "npm"
 
   - package-ecosystem: cargo
     directory: /editors/zed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,18 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
         run: |
-          corepack enable
-          cd editors/vscode && npm --version
+          # `corepack enable` alone only shims pnpm/yarn; npm must be named
+          # explicitly (`corepack enable npm`) or the shim isn't created and
+          # the npm bundled with setup-node wins. Assert the pin is live so a
+          # silent regression fails loudly instead of using the wrong npm.
+          corepack enable npm
+          cd editors/vscode
+          active="$(npm --version)"
+          echo "Active npm: $active (pinned via packageManager)"
+          case "$active" in
+            12.*) ;;
+            *) echo "::error::expected npm 12 from packageManager pin, got $active"; exit 1 ;;
+          esac
 
       # `package-lock.json` is committed, so installs are pinned by hash.
       # Cache the npm metadata directory keyed on the lockfile so the
@@ -298,8 +308,18 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
         run: |
-          corepack enable
-          cd editors/vscode && npm --version
+          # `corepack enable` alone only shims pnpm/yarn; npm must be named
+          # explicitly (`corepack enable npm`) or the shim isn't created and
+          # the npm bundled with setup-node wins. Assert the pin is live so a
+          # silent regression fails loudly instead of using the wrong npm.
+          corepack enable npm
+          cd editors/vscode
+          active="$(npm --version)"
+          echo "Active npm: $active (pinned via packageManager)"
+          case "$active" in
+            12.*) ;;
+            *) echo "::error::expected npm 12 from packageManager pin, got $active"; exit 1 ;;
+          esac
 
       # `package-lock.json` is committed, so installs are pinned by hash.
       # Cache the npm metadata directory keyed on the lockfile so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,16 @@ jobs:
         with:
           node-version: "24"
 
+      # Pin the npm CLI via the `packageManager` field in
+      # editors/vscode/package.json. Corepack downloads and activates the
+      # pinned npm so `npm ci` runs the same version locally and in CI.
+      - name: Enable Corepack (pin npm via packageManager)
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          corepack enable
+          cd editors/vscode && npm --version
+
       # `package-lock.json` is committed, so installs are pinned by hash.
       # Cache the npm metadata directory keyed on the lockfile so the
       # cache invalidates whenever the resolved dependency tree changes.
@@ -280,6 +290,16 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+
+      # Pin the npm CLI via the `packageManager` field in
+      # editors/vscode/package.json. Corepack downloads and activates the
+      # pinned npm so `npm ci` runs the same version locally and in CI.
+      - name: Enable Corepack (pin npm via packageManager)
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          corepack enable
+          cd editors/vscode && npm --version
 
       # `package-lock.json` is committed, so installs are pinned by hash.
       # Cache the npm metadata directory keyed on the lockfile so the

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=464e7ef-dirty
-head=464e7ef285c6522fbbb58b3f0c1dfaaeffe03512
-date=2026-06-15T09:29:17Z
-fingerprint=256a3b4093a2add636a8a39881fbe031b66e53faa75da8cba2bade02e1c36599
+describe=793bba1-dirty
+head=793bba1bf19cbff9a3985cd26f3ffb3c04f75995
+date=2026-06-15T09:41:05Z
+fingerprint=c0e4e24f94e8f8136cdfb49e6f995bb38086366d8c61650b6d13a6b0ff34ecc7

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=488b20a-dirty
-head=488b20a2459ee50793047c1f90a68b5ffb9cba46
-date=2026-06-14T21:42:39Z
-fingerprint=78c5074f7f132c7902e8d965dd0199379c80dd126ad0de83fbac24cd779bf48e
+describe=464e7ef-dirty
+head=464e7ef285c6522fbbb58b3f0c1dfaaeffe03512
+date=2026-06-15T09:29:17Z
+fingerprint=256a3b4093a2add636a8a39881fbe031b66e53faa75da8cba2bade02e1c36599

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ The six `[project.scripts]` entries are: `tcl-lsp`, `tcl`,
 - Python 3.10+ with [uv](https://docs.astral.sh/uv/)
 - Node.js 24+ with npm (the npm CLI is pinned to v12 via the
   `packageManager` field in `editors/vscode/package.json`; run
-  `corepack enable` once so `npm` resolves to the pinned version)
+  `corepack enable npm` once so `npm` resolves to the pinned version —
+  the bare `corepack enable` only shims pnpm/yarn)
 
 ### Claude Code on the web — pre-installed toolchains and sources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,9 @@ The six `[project.scripts]` entries are: `tcl-lsp`, `tcl`,
 ## Prerequisites
 
 - Python 3.10+ with [uv](https://docs.astral.sh/uv/)
-- Node.js 24+ with npm
+- Node.js 24+ with npm (the npm CLI is pinned to v12 via the
+  `packageManager` field in `editors/vscode/package.json`; run
+  `corepack enable` once so `npm` resolves to the pinned version)
 
 ### Claude Code on the web — pre-installed toolchains and sources
 

--- a/README.md
+++ b/README.md
@@ -2025,7 +2025,7 @@ explicit actions (CLI, chat, MCP) default to `full`.
 
 - Python 3.10+
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
-- Node.js 24+ with npm
+- Node.js 24+ with npm (pinned to v12 via `packageManager`; run `corepack enable`)
 - VS Code 1.93+
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -2025,7 +2025,7 @@ explicit actions (CLI, chat, MCP) default to `full`.
 
 - Python 3.10+
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
-- Node.js 24+ with npm (pinned to v12 via `packageManager`; run `corepack enable`)
+- Node.js 24+ with npm (pinned to v12 via `packageManager`; run `corepack enable npm`)
 - VS Code 1.93+
 
 ## Quick start

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0-dev",
   "publisher": "bitwisecook",
   "license": "AGPL-3.0-or-later",
+  "packageManager": "npm@12.0.0-pre.0.0",
   "icon": "docs/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Add `packageManager` field to `editors/vscode/package.json` to pin npm to v12
- Enable Corepack in CI workflows to enforce the pinned npm version
- Update documentation to reflect the npm pinning requirement and Corepack setup

## Details

This change ensures consistent npm versions across local development and CI environments by leveraging Node.js's built-in Corepack tool. The npm CLI is pinned to v12 via the `packageManager` field in `package.json`, and Corepack is enabled in both CI jobs to download and activate the pinned version automatically.

The documentation updates in `AGENTS.md` and `README.md` guide developers to run `corepack enable` once locally so that `npm` resolves to the pinned version.

## Validation

- CI workflows will validate that Corepack successfully enables the pinned npm version
- No additional testing needed; this is a configuration change that improves reproducibility

https://claude.ai/code/session_011NexL3EfFQT3tVLmQSk3XQ