### PR TITLE
Rust runtime: TIP 280 info frame source-line tracking

### DIFF
--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2713,32 +2713,27 @@ that blocked the ensemble work: defining a fresh `proc x` fired a leftover
 `::x → namespace delete ::;#` trace. With the traces freed correctly, that chain
 no longer forms.
 
-### Scoped-but-blocked — `namespace ensemble configure` / `-parameters` / `-unknown`
+### SYNC inbound — 2026-06-14 (`namespace ensemble configure` / `-parameters`; ensemble command lifecycle)
 
-A full `namespace ensemble configure` (get-all dict / cget / set), `-parameters`
-(threaded through dispatch as `target p1 p2 args…`), and `-unknown` *storage*
-were implemented and byte-verified against `tclsh9.0` (namespace-53.1/53.3
-match exactly), but the work was **reverted** because it surfaces a **pre-existing
-command-trace / namespace-deletion lifecycle crash** that aborts the whole
-namespace.test run:
+With the command-trace teardown fixed (previous entry), the ensemble work landed
+(namespace.test 209 → 223, oo.test +1, zero regressions), all from
+`tclEnsemble.c`:
 
-- Root cause (independent of ensembles): after namespace.test-7.x, a command
-  delete-trace lingers with name `::x` and body `namespace delete ::;#` (the
-  `[namespace current]` in the trace body resolved to `::`, and the trace was
-  not removed when its command's namespace was torn down). Defining a *new*
-  global `proc x` then fires that stale delete-trace via `on_command_replaced`,
-  which runs `namespace delete ::` and wipes every global command (`puts`/`set`
-  vanish → hard abort). `delete_namespace_by_id` fires/removes **variable**
-  unset traces but not **command** delete traces, so they leak.
-- Why ensembles exposed it: enabling unambiguous-prefix resolution of the
-  `namespace ensemble` subcommand (`namespace ens cre …`, namespace-49.1) let
-  that test progress to its `proc x`, which had previously errored out at the
-  unresolved `cre`.
-- Re-landing plan: first fix command delete-trace cleanup on namespace deletion
-  (fire-and-ignore, then remove — mirroring `take_ns_unset_traces`) and the
-  trace-body namespace context, *then* restore the ensemble configure/parameters
-  patch. This is in the "trace is sensitive — guard it" area, so it needs its own
-  before/after trace.test diff.
+- **`namespace ensemble configure cmd …`** — subcommands now resolve by
+  unambiguous prefix (`configure`/`create`/`exists`); `configure` with no options
+  returns the `-map -namespace -parameters -prefixes -subcommands -unknown` dict,
+  with one bare `-option` returns its value (cget), and with `-option value`
+  pairs updates the live ensemble. `create`/`configure` share one option applier.
+- **`-parameters`** — formal names that precede the subcommand in a call
+  (`ens p1 … sub args`); the subcommand is read at `1 + nparams` and the
+  parameter values thread in after the resolved target (`target p1 … args`). The
+  wrong-args usage lists the parameter names (namespace-53.1/53.3).
+- **`-unknown` is stored** (round-trips through `configure`); its dispatch
+  (invoking the handler on a miss, namespace-47.x) is still a follow-up.
+- **Ensemble command tied to its namespace** — deleting a namespace now deletes
+  the ensemble commands configured for it (even a default `::ns` ensemble living
+  in the global table), via `remove_ensembles_for` in `delete_namespace_by_id`
+  (`info command ns` is empty after `namespace delete ns`).
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2766,6 +2766,16 @@ errorInfo-frame plumbing and are deferred; namespace-50.x (rewriting target
 `wrong # args` messages to the ensemble invocation) is the documented
 ensemble-rewrite-threading rework.
 
+### SYNC inbound — 2026-06-14 (`namespace path` lifecycle + not-found)
+
+`namespace path` fixes (namespace.test 234 → 238): deleting a namespace now
+drops it from every other namespace's `namespace path` (a dangling id otherwise
+resolved to the global `::`, namespace-51.7/51.8/51.9), and `namespace path`
+given a missing namespace reports the shared `TclGetNamespaceFromObj` not-found
+error (`namespace "X" not found in "::ns"`, namespace-51.10). The remaining
+51.13–51.15 are the trace-during-deletion / path-recompute corner; namespace-50.x
+and the 53.x wrong-#-args cases are the ensemble-rewrite-threading rework.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2595,6 +2595,33 @@ the same engine; `lseq` against `Tcl_LseqObjCmd`/`TclNewArithSeriesObj`
   here so it is not lost. The top-of-doc mirror hash is intentionally left at
   `8150eca` until a deliberate re-baseline.
 
+### SYNC inbound — 2026-06-14 (`string is` full port)
+
+`string is` rewritten from C's `StringIsCmd` (`tmp/tcl9.0.3/generic/tclCmdMZ.c`),
+taking `string.test` 564 → 618 (all 54 `string-6.*` failures cleared, zero
+regressions in the broad sweep). The old implementation only matched class names
+exactly, set the `-failindex` var even on success, and rejected surrounding
+whitespace on numeric classes; the port fixes all three plus the message order.
+
+- **Class/option lookup is `Tcl_GetIndexFromObj`** — exact name or unambiguous
+  prefix, with `bad class`/`ambiguous class` distinguished (and the `must be …`
+  list in C declaration order: `…, control, boolean, …`). Abbreviated classes
+  (`bool`, `gra`, `int`) and options (`-fail`) now resolve (string-6.5, 6.6,
+  6.22/6.23, 6.86, 6.90, …). The `-failindex`-without-var error names the
+  resolved class (`string is double …`, string-6.3).
+- **`-failindex` var is set only when the result is 0** (C's `if (result==0 &&
+  failVarObj)`), so a successful `string is … -failindex var` leaves `var` unset
+  (string-6.9).
+- **Numeric classes via the shared `tcl_syntax::number` (`TclParseNumber`)** —
+  `integer`/`wideinteger`/`entier`/`double` allow a leading/trailing whitespace
+  run, report the fail index at the byte where parsing stopped, accept bignums
+  for `integer`/`entier`, and report `-1` for a `wideinteger` value that parses
+  but overflows a wide (string-6.31–6.59, 6.100–6.131).
+- **Boolean classes via `ParseBoolean` (`tclObj.c`)** — `0`/`1` or a
+  case-insensitive unambiguous prefix of `true`/`false`/`yes`/`no`/`on`/`off`
+  (so `25`, `1.0`, `o` are not booleans), failing at index 0 (string-6.45–6.47,
+  6.72–6.74).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2689,6 +2689,17 @@ Three related name-qualification fixes (namespace.test 184 → 201, proc.test 13
   whose namespace is missing is `can't create procedure "…": unknown namespace`
   (`Tcl_ProcObjCmd`), instead of silently auto-creating it (proc-1.2).
 
+### SYNC inbound — 2026-06-14 (namespace not-found error: `TclGetNamespaceFromObj`)
+
+`namespace children`/`namespace upvar` (and friends) now report the
+`TclGetNamespaceFromObj` not-found error faithfully: a *relative* name names the
+current namespace context (`namespace "X" not found in "::ns"`), an absolute one
+does not (`namespace "X" not found`), with `-errorcode TCL LOOKUP NAMESPACE X`
+(namespace.test 201 → 207; namespace-14.2/14.4/14.6). The remaining
+namespace-14.* cases are multi-colon collapsing and the "trailing `::` is a
+significant empty var name" rules, which live in the shared name parser
+(deferred).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2958,6 +2958,24 @@ Two linked fixes:
   mechanism as command-subst/`eval`/`namespace eval`, replacing the prior
   `script_stack` + proc-command-line heuristic.
 
+### SYNC inbound — 2026-06-15 (`[subst]` command-substitution line tracking)
+
+`info.test` 172 → 195 (zero regressions; trace 199, oo 357, ooProp 55/55,
+namespace 238, subst 21, eval 12, proc 20, switch 54 all held). A `[...]` inside
+a `subst` argument now reports the line it sits on (C compiles `subst` with the
+argument's line table). `do_subst` gained a located variant that reads the
+argument word's TIP 280 location (`arg_location`), aligns the enclosing frame's
+`line_base`/`file` to it for the duration, and routes each `WordPart::Command`
+through `eval_command_subst` (the shared command-substitution line-advance path)
+instead of a bare `eval_str`. The argument's `[...]` slices borrow from the
+argument bytes, so their offsets — and thus file-absolute lines — follow from the
+same `line_of` helper. Internal callers (`dict map` key subst) pass `None` and
+track relative to the enclosing frame.
+
+Remaining `info-30`/`info-33` failures are the `{*}` literal-expansion locations,
+`info-31` (script-in-variable nuances), and a few `info-24`/`info-22` interaction
+cases (dict for/with/filter, traces).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2801,6 +2801,20 @@ exponent is read from a `%.{p-1}e` rendering (robust vs `log10` rounding); fixes
 the expr-old-32.* math-function-formatting cases (the functions were already
 correct — only the `%g` rendering was wrong).
 
+### SYNC inbound — 2026-06-14 (math-function arg-count + arith `-errorcode`)
+
+`expr` math errors now carry C's `-errorcode` and the right arg-count wording
+(expr-old.test 398 → 405):
+
+- **Math-function arity** (`cmd_mathfunc`): `not enough`/`too many arguments for
+  math function "NAME"` with `-errorcode TCL WRONGARGS` (checked before operand
+  conversion), and a domain error (e.g. `sqrt(-1)`) carries `ARITH DOMAIN
+  {domain error: argument not in valid range}` (expr-old-34.7/8, 40.3, 41.3).
+- **Arithmetic `-errorcode`** — `ExprError` gained an optional `-errorcode`;
+  divide-by-zero is `ARITH DIVZERO {divide by zero}`, and `expr`/`::tcl::mathop`
+  now re-raise math/arith errors *with* their code instead of dropping it via
+  `set_error` (expr-old-26.8/26.9). `%` shares the divide-by-zero path.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2917,6 +2917,21 @@ enclosing frame's `line_base`/`line`/`cmd`. Nested substitutions compose
 naturally: each inner buffer's offset is taken against *its* enclosing `src`,
 and the `line_base` it inherits already carries the outer shift.
 
+### SYNC inbound — 2026-06-15 (`namespace eval` is its own `info frame` level)
+
+`info.test` 158 → 161 (zero regressions; trace 199, oo 357, ooProp 55/55,
+eval 12/12, namespace 238 all held). C's `namespace eval` pushes a `CmdFrame`
+for its body (depth and `info level` both advance), with `proc` cleared and
+`level` reported relative to the new scope; the runtime previously evaluated the
+body in the *enclosing* frame, so `info frame 0` inside `namespace eval` leaked
+the caller's `proc`/`level` and reported the wrong depth. `ns_eval` now pushes a
+body `CmdFrame` like a proc body — `proc: None`, `level` = the new namespace
+scope's level, and (for a single located-literal body, via the new `ns_eval_obj`
+obj-aware path) `type source` at the body's file+line so commands defined inside
+report file-absolute lines. A multi-arg (concatenated, dynamic) body stays
+`type eval`. Remaining `info-30`/`info-33` failures are now the `switch`-body
+and `[subst]` line-tracking clusters and `{*}` literal-expansion locations.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2735,6 +2735,22 @@ With the command-trace teardown fixed (previous entry), the ensemble work landed
   in the global table), via `remove_ensembles_for` in `delete_namespace_by_id`
   (`info command ns` is empty after `namespace delete ns`).
 
+### SYNC inbound — 2026-06-14 (`namespace unknown`)
+
+`namespace unknown ?handler?` (`NamespaceUnknownCmd`) — get/set the per-namespace
+unknown-command handler (namespace.test 223 → 230, zero regressions):
+
+- **Get** returns the namespace's stored handler; the global namespace defaults
+  to `::unknown`, a sub-namespace to the empty string (namespace-52.1).
+- **Set** stores a handler (empty resets to default), validating it is a
+  well-formed list first — a bad list errors *without* changing the current
+  handler (namespace-52.12).
+- **Dispatch**: on a command miss the current namespace's handler wins (invoked
+  as `handler… name args…`); a namespace with none falls back to the global
+  namespace's handler (so a script can override `::unknown` globally,
+  namespace-52.7), else the built-in `unknown` command (namespace-52.4–52.9).
+  The `TCL_EVAL_INVOKE`/child-interp-alias corner (52.11) is still open.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2650,6 +2650,25 @@ fixes, both from C (`tclDictObj.c`/`tclUtil.c`):
   filter`, dict-17.19). `dict with`/`dict update` usage strings matched to C
   (`dictVarName`/`script`). dict.test reaches 315/373.
 
+### SYNC inbound — 2026-06-14 (`lsearch -subindices` + `-index` validation)
+
+`lsearch.test` 133 → **165/165** (zero regressions), from C's `Tcl_LsearchObjCmd`
+(`tclCmdIL.c`) + `SelectObjFromSublist`:
+
+- **`-subindices` returns the resolved path / leaf** — non-inline now emits the
+  group base plus each *decoded* remaining `-index` value (`TclIndexDecode`
+  against the top list count, matching C, incl. `end`); `-inline -subindices`
+  returns the matched *leaf* drilled through the sub-path (or the in-group key
+  element when `-stride` consumed the only index), not the top element. Fixes the
+  `-subindices` ± `-stride` ± `-inline` ± `-sorted` clusters (lsearch-19.7/19.8,
+  25.*, 26.*, 27.*, 28.7–28.9).
+- **`-index` value scale validated at parse time** (`TclIndexEncode`): a negative
+  or `end+N` spec is `index "X" out of range` (`TCL VALUE INDEX OUTOFRANGE`),
+  a syntactically-bad spec is `bad index …` (lsearch-17.12–17.16).
+- **`-subindices` without `-index`** is the `BAD_OPTION_MIX` error (lsearch-3.7),
+  and the `-regexp` compile-failure prefix is `cannot compile …` to match C
+  (lsearch-2.6).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2815,6 +2815,20 @@ correct — only the `%g` rendering was wrong).
   now re-raise math/arith errors *with* their code instead of dropping it via
   `set_error` (expr-old-26.8/26.9). `%` shares the divide-by-zero path.
 
+### SYNC inbound — 2026-06-14 (`wide()`/`int()`/`entier()` over the tower)
+
+`wide`/`int`/`entier` on an **integer** operand now work over the numeric tower
+instead of the f64-limited shared math dispatch: `wide` wraps a too-big integer
+to a signed 64-bit value (C's truncation, `wide(2**63)` ⇒ `i64::MIN`, via
+libtommath `mp_get_i64`), and `int`/`entier` keep the (possibly bignum) integer
+exactly. Previously these domain-errored on anything exceeding `i64`. This also
+un-aborts the *sourcing* of expr.test (its `wideIs64bit` constraint computes
+`wide(0x8000000000000000) < 0` at top level). Note: expr.test now reaches a
+**pre-existing hang** further in (a heavy/looping test our runtime doesn't yet
+complete) — a separate follow-up; the `wide`/`int`/`entier` fix stands on its own
+(expr-old.test stays 405, byte-checked). Large *float* `int`/`entier` (bignum
+result, e.g. `int(1e30)`) is still deferred.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3042,6 +3042,18 @@ delegates to `eval_unlocated_body`, and `eval_body_obj`'s dynamic arm sets
 `type eval` / no file / `line_base = 0` (the located-literal arm is unchanged).
 Covers the `info-23.4/5` and `info-31.6` `eval`-of-dynamic-script cases.
 
+### SYNC inbound — 2026-06-15 (`apply` lambda `info frame`: `lambda` key + body source)
+
+`info.test` 225 → 227 (zero regressions; apply 21, proc 20, oo 357, ooProp 55/55,
+trace 199, namespace 238, eval 12 held). An `apply` body's `info frame` now
+reports `lambda <expr>` (the whole lambda expression) in place of `proc` — a new
+`lambda` field on `CmdFrame`, set from `ProcFrame::Lambda` in `run_proc` and
+rendered like the `oo` (method) key. A *literal* lambda in a sourced file is also
+`type source` at its body's line: `apply_cmd` derives the body element's location
+via the new `list_element_location` (the list word's line + newlines before
+element 1, the shared `TclListLines` computation); a dynamic lambda stays
+body-relative `type proc`.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3017,6 +3017,19 @@ line. Remaining `info-33` failures are a distinct issue — `return`/non-OK code
 propagating out of a `for`/`while` **test expression**'s command substitution
 (`for {*}{… {[return …]} …}`), not line tracking.
 
+### SYNC inbound — 2026-06-15 (dynamic control bodies are body-relative `type eval`)
+
+`info.test` 214 → 221 (zero regressions; if 59, while 45, for 51, foreach 38,
+switch 54, dict 315, eval 12, trace 199, oo 357, ooProp 55/55, namespace 238,
+proc 20, apply 21, uplevel 41, error 261 all held). A *dynamic* control body (a
+script held in a variable, `if 1 $body` / `while … $body` / `foreach … $body` /
+`for … $body` / `dict for … $body`) was evaluated with a frame-sharing `eval_str`,
+so `info frame 0` leaked the enclosing command's line/type. C's `TclEvalObjEx`
+always pushes a cmdframe, so the body runs as its own `type eval` level with
+**body-relative** lines (the body's 3rd line reports `line 3`). `eval_control_body`'s
+dynamic fallback now uses `eval_unlocated_body` (push a `type eval`, no-file frame
+with `line_base = 0`) — covering the `info-31` script-in-variable family.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2641,6 +2641,14 @@ fixes, both from C (`tclDictObj.c`/`tclUtil.c`):
   `tclUtil.c`'s `FindElement` with the `dict`/`DICTIONARY` type strings (the list
   splitter stays untouched), feeding `error_with_code` (dict-4.13–4.17 + the
   `…a` error-code variants).
+- **`dict filter … script` completion-code handling + var-list parse** — the
+  body's code now drives the loop (`DictFilterCmd`): `OK` keeps iff the result is
+  true, `continue` skips, `break` stops (returning what's kept), and
+  `error`/`return`/other propagate out (dict-17.16). The two variable names are
+  parsed as a list, so a malformed list surfaces its own message (dict-17.20)
+  and a wrong count is `must have exactly two variable names` (`TCL SYNTAX dict
+  filter`, dict-17.19). `dict with`/`dict update` usage strings matched to C
+  (`dictVarName`/`script`). dict.test reaches 315/373.
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2857,6 +2857,39 @@ rework):
 - **`info library`** with `tcl_library` unset reports `no library has been
   specified for Tcl` (info-10.3).
 
+### SYNC inbound — 2026-06-15 (base-layer: Tcl_Obj identity through eval / TIP 280 literal locations)
+
+Digging into the `info frame` failures surfaced a **base-layer smell**: scripts
+were evaluated as raw *bytes*, discarding the `Tcl_Obj` identity that C uses to
+carry a literal's source location (the `lineLABCPtr` table) — so an eval'd body
+literal (tcltest's `uplevel 1 $script`) reported `type eval` instead of `type
+source`. The fix is structural, not a patch (info.test 127 → 132, var.test
+59 → 72, expr-old 405; zero regressions across namespace/trace/oo/dict/string/
+list/lsearch/proc):
+
+- **TIP 280 literal-argument locations** (`Interp::arg_locs`, C's `lineLABCPtr`):
+  each literal word of a command running in a *sourced* context records
+  `objPtr → (file, line)` (dynamic scope: pushed before dispatch, popped after).
+  A later `eval`/`uplevel` of that same object reports `type source` at the
+  literal's original file+line.
+- **`eval`/`uplevel` evaluate by object, not bytes** (`eval_body_obj`/
+  `eval_uplevel_obj`): a single body argument keeps its object identity for the
+  LABC lookup; multiple args concatenate to a dynamic (`type eval`) script.
+- **Pure lists evaluate by element identity** (`dispatch_list_obj`): a *canonical*
+  list (`TclListObjIsCanonical`) is dispatched as one command from its element
+  objects — no stringify/re-parse — so `uplevel 1 [list cmd $bodyVar]` preserves
+  the nested body's source location (the tcltest `Eval`/`RunTest` chain). A new
+  `canonical` flag on the list rep distinguishes a list built from objects
+  (`new_list_obj`/append, pure) from one shimmered from a string (re-parsed).
+- **`array set` preserves value identity** — it stores the element *objects*
+  (via `list_elements`) instead of re-creating fresh strings, so a value kept in
+  an array (tcltest's option array) keeps its rep and source location (this is
+  what lifted var.test).
+
+Still off for the `info-30`/`info-33` clusters: the *line within* a bs+nl
+continuation and inline control bodies (`if`/`while`) — the type/file/source
+frame is now correct, only the precise line lags (a line-accounting follow-up).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2976,6 +2976,26 @@ Remaining `info-30`/`info-33` failures are the `{*}` literal-expansion locations
 `info-31` (script-in-variable nuances), and a few `info-24`/`info-22` interaction
 cases (dict for/with/filter, traces).
 
+### SYNC inbound — 2026-06-15 (`{*}` literal-element locations + `catch` body frame)
+
+`info.test` 195 → 205 (zero regressions; error 261, trace 199, oo 357,
+ooProp 55/55, namespace 238, eval 12, proc 20, switch 54, subst 21 all held).
+Two fixes:
+
+- **`{*}` expansion of a literal keeps each element's source line.** `eval_words`
+  now tracks lines per **argv element** (not per word), so expansion no longer
+  desyncs the line table, and it records an LABC entry for each braced element of
+  a `{*}`-expanded literal (line = the word's line + newlines before the element,
+  the shared `scan_list_offsets`/`TclListLines` computation). So
+  `namespace {*}{eval ns {proc bar {} {info frame 0}}}` defines `bar` with
+  `type source` at the body's real line. A dynamic `{*}$v` has no per-element
+  location and stays body-relative.
+- **`catch` evaluates its script as its own `info frame` level.** C bumps
+  `cmdFramePtr` for the `catch` body (depth advances like `eval`), and a located
+  literal body reports `type source` at its own line. `catch_cmd` now uses
+  `eval_body_obj` (push frame + pick up the body object's TIP 280 location)
+  instead of a bare `eval_str`.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2776,6 +2776,20 @@ error (`namespace "X" not found in "::ns"`, namespace-51.10). The remaining
 51.13–51.15 are the trace-during-deletion / path-recompute corner; namespace-50.x
 and the 53.x wrong-#-args cases are the ensemble-rewrite-threading rework.
 
+### SYNC inbound — 2026-06-14 (`expr` operand-type errors)
+
+`expr`'s operand-type errors now match C's `IllegalExprOperandType`
+(`tclExecute.c`), taking expr-old.test 358 → 390:
+
+- `cannot use floating-point value "V" as [left/right ]operand of "OP"` and
+  `cannot use non-numeric string "V" as …` — carrying the offending operand's
+  value, the operator symbol, and (for binary ops) which operand is at fault
+  (left checked first), built in `expr.rs`'s `arith`/`unary` where the operator
+  and operands are in scope (expr-old-3.*, expr-old-5.*).
+- `%` is now integer-only like the other bit/shift ops: a float operand is a
+  `NonInteger` error instead of computing a float modulo (`divmod` only floats
+  for `/`).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3007,6 +3007,16 @@ reports `type source` at its own line — covering the `info-24.7/8/9`
 (`dict for`/`with`/`filter` interaction) and `{*}`-expanded `dict for`/`map`
 bodies.
 
+### SYNC inbound — 2026-06-15 (`for` start/next script frames)
+
+`info.test` 212 → 214 (zero regressions; for 51, while 45, foreach 38, trace 199,
+oo 357 held). `for`'s `start` and `next` scripts were evaluated with a bare
+`eval_str`; they now route through `eval_control_body` like the body, so a located
+literal (including a `{*}`-expanded element) reports `type source` at its own
+line. Remaining `info-33` failures are a distinct issue — `return`/non-OK codes
+propagating out of a `for`/`while` **test expression**'s command substitution
+(`for {*}{… {[return …]} …}`), not line tracking.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2790,6 +2790,17 @@ and the 53.x wrong-#-args cases are the ensemble-rewrite-threading rework.
   `NonInteger` error instead of computing a float modulo (`divmod` only floats
   for `/`).
 
+### SYNC inbound — 2026-06-14 (`format %g` significant-digits)
+
+`format %g`/`%G` now uses **significant**-digit precision like C's `printf`
+(expr-old.test 390 → 398): pick `%e` when the decimal exponent is `< -4` or
+`>= p`, else `%f`, each at the precision giving `p` significant figures, then
+trim trailing zeros unless `#`. Previously it used `p-1` *fractional* digits, so
+`format %.6g [expr asin(0.5)]` gave `0.5236` instead of `0.523599`. The decimal
+exponent is read from a `%.{p-1}e` rendering (robust vs `log10` rounding); fixes
+the expr-old-32.* math-function-formatting cases (the functions were already
+correct — only the `%g` rendering was wrong).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2886,9 +2886,18 @@ list/lsearch/proc):
   an array (tcltest's option array) keeps its rep and source location (this is
   what lifted var.test).
 
-Still off for the `info-30`/`info-33` clusters: the *line within* a bs+nl
-continuation and inline control bodies (`if`/`while`) — the type/file/source
-frame is now correct, only the precise line lags (a line-accounting follow-up).
+Inline control-command bodies (`if`/`while`/`for`/`foreach`) now also advance
+the `info frame` line via `eval_control_body` (a located literal body runs as its
+own line-advancing source frame; info.test → 138).
+
+Still off for `info-30`/`info-33`: the precise *line digit* within a
+backslash-newline continuation and across **nested** `[…]` substitutions
+(info-30.0 reports the command's line, off by the bs+nl). That needs cumulative
+line threading (C's `TclAdvanceContinuations`) — each nested substitution carries
+its own source buffer while sharing the frame's `line_base`, so the line must be
+threaded through, not recomputed per buffer. That is a contained line-accounting
+effort (a parser/`info frame` follow-up), distinct from the base-layer obj-model
+fix above; the type/file/source-frame are now correct.
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2932,6 +2932,32 @@ report file-absolute lines. A multi-arg (concatenated, dynamic) body stays
 `type eval`. Remaining `info-30`/`info-33` failures are now the `switch`-body
 and `[subst]` line-tracking clusters and `{*}` literal-expansion locations.
 
+### SYNC inbound — 2026-06-15 (`switch` body lines + proc body location via LABC)
+
+`info.test` 161 → 172 (zero regressions; trace 199, oo 357, ooProp 55/55,
+namespace 238, switch 54, proc/apply/eval/if/while/for/foreach/error all held).
+Two linked fixes:
+
+- **`switch` branch bodies are TIP 280 located.** The inline form (`switch s pat
+  body …`) keeps each body's `Tcl_Obj` and runs it through `eval_control_body`
+  (the `if`/`while` path), so a located literal is `type source` at its line. The
+  single-list form (`switch s {pat body …}`) re-splits the literal and derives
+  each body's line from its byte offset within the list word (C's `TclListLines`):
+  `scan_elements` walks `tcl_syntax`'s element scanner for offsets + the `literal`
+  flag, and a matched literal body evaluates via `eval_located_body` at `list
+  word line + newlines-before-element`. A dynamically built list body (no word
+  location) reverts to `eval_unlocated_body` — `type eval`, no file — so a `proc`
+  defined inside is body-relative (C's `line = -1`).
+
+- **A `proc`'s body location now comes from the body word's LABC entry**, not a
+  whole-file "am I sourcing" flag. `define_proc` takes the body `Tcl_Obj` and
+  reads `arg_loc(body)`: a located literal → `type source` at the body word's
+  file+line (correct even when the body opens on a later line than the `proc`
+  command, and when `proc` runs inside a located `switch`/`eval` body); a dynamic
+  body → body-relative `type proc`. This is the same obj-identity location
+  mechanism as command-subst/`eval`/`namespace eval`, replacing the prior
+  `script_stack` + proc-command-line heuristic.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2751,6 +2751,21 @@ unknown-command handler (namespace.test 223 → 230, zero regressions):
   namespace-52.7), else the built-in `unknown` command (namespace-52.4–52.9).
   The `TCL_EVAL_INVOKE`/child-interp-alias corner (52.11) is still open.
 
+### SYNC inbound — 2026-06-14 (ensemble `-unknown` handler dispatch)
+
+The ensemble `-unknown` handler now dispatches on a subcommand miss
+(`EnsembleUnknownCallback`, namespace.test 230 → 234): the handler is invoked
+once as `handler… ensembleFQN argv[1..]…`; a non-empty `TCL_OK` result is the
+replacement command prefix (dispatched with the usual params/rest threading), an
+empty result reparses the call (the handler defined the subcommand), and an
+error/bad-code result fails with C's wording (`unknown subcommand handler
+returned bad code: …`). Fixes namespace-47.1/47.3/47.7/47.8. The remaining 47.x
+(47.2/47.4/47.6) only differ in the `$::errorInfo` trace frames (the
+`(ensemble unknown subcommand handler)` + handler-command lines), which need the
+errorInfo-frame plumbing and are deferred; namespace-50.x (rewriting target
+`wrong # args` messages to the ensemble invocation) is the documented
+ensemble-rewrite-threading rework.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2700,6 +2700,19 @@ namespace-14.* cases are multi-colon collapsing and the "trailing `::` is a
 significant empty var name" rules, which live in the shared name parser
 (deferred).
 
+### SYNC inbound — 2026-06-14 (command traces freed on namespace deletion)
+
+`delete_namespace_by_id` now collects, removes, and (for `delete`-op) fires the
+command traces on every command in the deleted namespace tree — the command
+analogue of the existing variable-unset-trace teardown (namespace.test 207 →
+209, trace.test unchanged at 199, zero regressions). Previously only variable
+unset traces were cleaned up, so a command delete-trace on `::ns::cmd` *lingered*
+after `ns` was deleted and mis-fired when a same-named command was later created
+(namespace-7.4/7.6). That stale trace was the root of the global-namespace wipe
+that blocked the ensemble work: defining a fresh `proc x` fired a leftover
+`::x → namespace delete ::;#` trace. With the traces freed correctly, that chain
+no longer forms.
+
 ### Scoped-but-blocked — `namespace ensemble configure` / `-parameters` / `-unknown`
 
 A full `namespace ensemble configure` (get-all dict / cget / set), `-parameters`

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3030,6 +3030,18 @@ always pushes a cmdframe, so the body runs as its own `type eval` level with
 dynamic fallback now uses `eval_unlocated_body` (push a `type eval`, no-file frame
 with `line_base = 0`) — covering the `info-31` script-in-variable family.
 
+### SYNC inbound — 2026-06-15 (dynamic `eval` bodies are body-relative `type eval`)
+
+`info.test` 221 → 225 (zero regressions; eval 12/12, uplevel 41, error 261,
+trace 199, oo 357, namespace 238, proc 20, apply 21 held). A dynamic `eval` body
+— multi-arg `eval info frame 0` (space-joined) or single-arg `eval $script` — was
+evaluated through `inherited_cmd_frame`, so it inherited the enclosing `type
+source` + file and reported file-absolute lines. C's `TclEvalObjEx` of a
+non-literal is `type eval` with body-relative lines. `eval_body` (multi-arg) now
+delegates to `eval_unlocated_body`, and `eval_body_obj`'s dynamic arm sets
+`type eval` / no file / `line_base = 0` (the located-literal arm is unchanged).
+Covers the `info-23.4/5` and `info-31.6` `eval`-of-dynamic-script cases.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2996,6 +2996,17 @@ Two fixes:
   `eval_body_obj` (push frame + pick up the body object's TIP 280 location)
   instead of a bare `eval_str`.
 
+### SYNC inbound — 2026-06-15 (`dict for`/`map`/`filter`/`update`/`with` body frames)
+
+`info.test` 205 → 212 (zero regressions; dict 315, error 261, trace 199, oo 357,
+ooProp 55/55, namespace 238, eval 12 all held). The script-body `dict`
+subcommands evaluated their body with a bare `eval_str` (shared frame, no level,
+no location). They now route through `eval_control_body` (the `if`/`while`/
+`foreach` path), so each body is its own `info frame` level and a located literal
+reports `type source` at its own line — covering the `info-24.7/8/9`
+(`dict for`/`with`/`filter` interaction) and `{*}`-expanded `dict for`/`map`
+bodies.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2669,6 +2669,26 @@ fixes, both from C (`tclDictObj.c`/`tclUtil.c`):
   and the `-regexp` compile-failure prefix is `cannot compile …` to match C
   (lsearch-2.6).
 
+### SYNC inbound — 2026-06-14 (namespace/command qualification: `info commands`, `namespace children`, `proc`)
+
+Three related name-qualification fixes (namespace.test 184 → 201, proc.test 13 →
+20, info.test +1; zero regressions), all from C:
+
+- **`info commands`/`info procs` re-qualify through the namespace's canonical
+  full name** — a *relative* qualified pattern (`info commands ns::pat`) now
+  returns absolute `::ns::…` names, via a new `Interp::canonical_ns_prefix`
+  (previously the literal pattern prefix was used, so relative patterns dropped
+  the leading `::`). Fixes the `info commands ns::*` assertions in proc-1.*.
+- **`namespace children ?ns? ?pattern?` qualifies the pattern** — a pattern
+  without a leading `::` is prefixed with the target namespace's full name before
+  matching the children's fully-qualified names (C's `NamespaceChildrenCmd`).
+  This was returning empty for the extremely common `namespace children ::
+  test_ns_*` idiom used in many suites' setup/cleanup — hence the broad
+  namespace.test jump.
+- **`proc ns::name` requires the namespace to exist** — a qualified proc name
+  whose namespace is missing is `can't create procedure "…": unknown namespace`
+  (`Tcl_ProcObjCmd`), instead of silently auto-creating it (proc-1.2).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2700,6 +2700,33 @@ namespace-14.* cases are multi-colon collapsing and the "trailing `::` is a
 significant empty var name" rules, which live in the shared name parser
 (deferred).
 
+### Scoped-but-blocked — `namespace ensemble configure` / `-parameters` / `-unknown`
+
+A full `namespace ensemble configure` (get-all dict / cget / set), `-parameters`
+(threaded through dispatch as `target p1 p2 args…`), and `-unknown` *storage*
+were implemented and byte-verified against `tclsh9.0` (namespace-53.1/53.3
+match exactly), but the work was **reverted** because it surfaces a **pre-existing
+command-trace / namespace-deletion lifecycle crash** that aborts the whole
+namespace.test run:
+
+- Root cause (independent of ensembles): after namespace.test-7.x, a command
+  delete-trace lingers with name `::x` and body `namespace delete ::;#` (the
+  `[namespace current]` in the trace body resolved to `::`, and the trace was
+  not removed when its command's namespace was torn down). Defining a *new*
+  global `proc x` then fires that stale delete-trace via `on_command_replaced`,
+  which runs `namespace delete ::` and wipes every global command (`puts`/`set`
+  vanish → hard abort). `delete_namespace_by_id` fires/removes **variable**
+  unset traces but not **command** delete traces, so they leak.
+- Why ensembles exposed it: enabling unambiguous-prefix resolution of the
+  `namespace ensemble` subcommand (`namespace ens cre …`, namespace-49.1) let
+  that test progress to its `proc x`, which had previously errored out at the
+  unresolved `cre`.
+- Re-landing plan: first fix command delete-trace cleanup on namespace deletion
+  (fire-and-ignore, then remove — mirroring `take_ns_unset_traces`) and the
+  trace-body namespace context, *then* restore the ensemble configure/parameters
+  patch. This is in the "trace is sensitive — guard it" area, so it needs its own
+  before/after trace.test diff.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2832,7 +2832,7 @@ separate follow-up). Large *float* `int`/`entier` (bignum result, e.g.
 
 ### SYNC inbound — 2026-06-15 (`info` non-frame surface)
 
-`info.test` 106 → 126 (zero regressions), the tractable non-`info frame` items
+`info.test` 106 → 127 (zero regressions), the tractable non-`info frame` items
 (the big `info-30`/`info-33`/`info-24` clusters remain the TIP-280 line-tracking
 rework):
 
@@ -2854,6 +2854,8 @@ rework):
   array (`can't set "a": variable is array`; info-6.2, 6.9).
 - **`info script ?filename?`** set-form sets (and returns) the current script
   name (info-16.6/16.7/16.8).
+- **`info library`** with `tcl_library` unset reports `no library has been
+  specified for Tcl` (info-10.3).
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2890,14 +2890,32 @@ Inline control-command bodies (`if`/`while`/`for`/`foreach`) now also advance
 the `info frame` line via `eval_control_body` (a located literal body runs as its
 own line-advancing source frame; info.test → 138).
 
-Still off for `info-30`/`info-33`: the precise *line digit* within a
-backslash-newline continuation and across **nested** `[…]` substitutions
-(info-30.0 reports the command's line, off by the bs+nl). That needs cumulative
-line threading (C's `TclAdvanceContinuations`) — each nested substitution carries
-its own source buffer while sharing the frame's `line_base`, so the line must be
-threaded through, not recomputed per buffer. That is a contained line-accounting
-effort (a parser/`info frame` follow-up), distinct from the base-layer obj-model
-fix above; the type/file/source-frame are now correct.
+### SYNC inbound — 2026-06-15 (command-substitution line advancement)
+
+`info.test` 138 → 158 (zero regressions; trace 199, oo 357, ooProp 55/55,
+eval 12/12 all held). This closes the `info-30`/`info-33` *line digit* gap: a
+command inside `[…]` now reports the line it actually appears on, even when the
+bracket spans lines or follows a `\`-newline continuation, and through **nested**
+substitutions.
+
+The insight that made it a few lines instead of C's `TclAdvanceContinuations`
+bookkeeping: a `[…]`'s inner script is a borrowed sub-slice of the enclosing
+parsed buffer (`WordPart::Command(&'s [u8])`), so its start offset — and thus
+its file-absolute line — comes straight from the original source via the shared
+`line_of` helper. Backslash-newline continuations are *real* newlines in that
+buffer, so plain newline counting already matches C's continuation-adjusted
+result; no separate continuation-position table is needed.
+
+Mechanically (`eval_command_subst`): a `[cmd]` is **not** a new `info frame`
+level — C compiles it into the enclosing command's bytecode, so `info frame`
+depth is unchanged — but it *does* advance the reported `line`. So rather than
+pushing a frame, the substitution shares the enclosing frame and temporarily
+shifts its `line_base` to `(enclosing line_base + line_of(src, bracket_offset))
+- 1`, evaluates the inner script in a new `eval_script_mode(.., advance_shared:
+true)` that advances `line`/`cmd` without pushing a level, then restores the
+enclosing frame's `line_base`/`line`/`cmd`. Nested substitutions compose
+naturally: each inner buffer's offset is taken against *its* enclosing `src`,
+and the `line_base` it inherits already carries the outer shift.
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2622,6 +2622,26 @@ whitespace on numeric classes; the port fixes all three plus the message order.
   (so `25`, `1.0`, `o` are not booleans), failing at index 0 (string-6.45–6.47,
   6.72–6.74).
 
+### SYNC inbound — 2026-06-14 (`dict` usage messages + dict-parse errors/codes)
+
+`dict.test` 276 → 304 (zero regressions in the broad sweep), in two themed
+fixes, both from C (`tclDictObj.c`/`tclUtil.c`):
+
+- **Usage strings matched to C verbatim** — the argument-count messages used
+  `dictValue`/`{keyVar valueVar}`; C uses `dictionary`/`{keyVarName
+  valueVarName}` (`get`/`exists`/`size`/`keys`/`values`/`for`/`map`/`filter`;
+  dict-24.1–4, dict-17 syntax, …).
+- **Faithful dict string-parse errors with `-errorcode`** — a malformed dict
+  value now reports the dict-typed `FindElement` diagnostics instead of the
+  generic `missing value to go with key`: `dict element in
+  braces/quotes followed by "X" instead of space` (`TCL VALUE DICTIONARY JUNK`,
+  with the offending fragment), `unmatched open brace/quote in dict` (`… BRACE`/
+  `… QUOTE`), and the odd-count `missing value to go with key` (`TCL VALUE
+  DICTIONARY`). A new runtime `dict_find_element`/`scan_dict_pairs` ports
+  `tclUtil.c`'s `FindElement` with the `dict`/`DICTIONARY` type strings (the list
+  splitter stays untouched), feeding `error_with_code` (dict-4.13–4.17 + the
+  `…a` error-code variants).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2821,13 +2821,14 @@ correct — only the `%g` rendering was wrong).
 instead of the f64-limited shared math dispatch: `wide` wraps a too-big integer
 to a signed 64-bit value (C's truncation, `wide(2**63)` ⇒ `i64::MIN`, via
 libtommath `mp_get_i64`), and `int`/`entier` keep the (possibly bignum) integer
-exactly. Previously these domain-errored on anything exceeding `i64`. This also
-un-aborts the *sourcing* of expr.test (its `wideIs64bit` constraint computes
-`wide(0x8000000000000000) < 0` at top level). Note: expr.test now reaches a
-**pre-existing hang** further in (a heavy/looping test our runtime doesn't yet
-complete) — a separate follow-up; the `wide`/`int`/`entier` fix stands on its own
-(expr-old.test stays 405, byte-checked). Large *float* `int`/`entier` (bignum
-result, e.g. `int(1e30)`) is still deferred.
+exactly. Previously these domain-errored on anything exceeding `i64`. This
+un-aborts expr.test, whose `wideIs64bit` constraint computes
+`wide(0x8000000000000000) < 0` at top level: **expr.test now runs to completion
+at 1836/2168** (it was an early-abort `ERR` before). The run is *slow* — the
+heavy bignum `**` loops in expr-23.5x exceed the sweep's default per-file cap, so
+the sweep reports it as a timeout even though it finishes (perf, not a hang; a
+separate follow-up). Large *float* `int`/`entier` (bignum result, e.g.
+`int(1e30)`) is still deferred.
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -2830,6 +2830,31 @@ the sweep reports it as a timeout even though it finishes (perf, not a hang; a
 separate follow-up). Large *float* `int`/`entier` (bignum result, e.g.
 `int(1e30)`) is still deferred.
 
+### SYNC inbound — 2026-06-15 (`info` non-frame surface)
+
+`info.test` 106 → 126 (zero regressions), the tractable non-`info frame` items
+(the big `info-30`/`info-33`/`info-24` clusters remain the TIP-280 line-tracking
+rework):
+
+- **Subcommand surface** — added Tcl 9's `constant`/`consts` (TIP 677, stubbed:
+  no const vars yet), `errorstack` (TIP 348, stubbed empty), and `hostname`
+  (best-effort from `/proc/sys/kernel/hostname`). The "unknown subcommand … must
+  be …" list is now generated from the (alphabetical) subcommand table, fixing
+  its wording (info-21.2–21.5).
+- **Per-subcommand usage / arg-count** — `info globals|vars|locals ?pattern?`,
+  `info library`, `info nameofexecutable` now report their own
+  `wrong # args` usage and reject extra args (info-8.3, 10.1, 13.1).
+- **`info tclversion`/`patchlevel` read the globals** (`::tcl_version`/
+  `::tcl_patchLevel`, `TCL_GLOBAL_ONLY`) instead of a hard-coded constant, so
+  unsetting them errors `can't read "…": no such variable` (info-14.3, 18.3).
+- **`info args`/`body`/`default` follow `namespace import`** to the underlying
+  proc (`proc_def` chases `Command::Imported`; info-1.7, 2.4).
+- **`info default`** stores the empty string and returns 0 for an argument with
+  no default, and surfaces the variable error verbatim when the target is an
+  array (`can't set "a": variable is array`; info-6.2, 6.9).
+- **`info script ?filename?`** set-form sets (and returns) the current script
+  name (info-16.6/16.7/16.8).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3068,6 +3068,17 @@ supply a `type eval` (`unlocated_frame`) frame; `uplevel` redirects its level.
 (Found by Codex review on PR #607; `info-37.0`'s two `type eval` frames are now
 correct, its remaining gap is the unrelated `etrace`/`while` line.)
 
+### SYNC inbound — 2026-06-15 (`namespace ensemble configure` rebinds the resolved command)
+
+`namespace ensemble configure cmd …` (set form) recreated the ensemble relative
+to the *current* namespace, so reconfiguring an ensemble reached via `namespace
+path` (e.g. `namespace eval b { namespace path ::a; namespace ensemble configure
+a -prefixes 0 }`) created/overwrote a shadow `::b::a` and left the real `::a`
+untouched. `set_ensemble_config` now uses a new `NamespaceArena::rebind_resolved`
+(rebind in place at the namespace `home_of`/`resolve` selects, incl. `namespace
+path`) instead of `create_ensemble`. Found by Codex review on PR #607; verified
+vs `tclsh9.0`, namespace 238 held.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3054,6 +3054,20 @@ via the new `list_element_location` (the list word's line + newlines before
 element 1, the shared `TclListLines` computation); a dynamic lambda stays
 body-relative `type proc`.
 
+### SYNC inbound — 2026-06-15 (canonical-list bodies push a `type eval` frame)
+
+A body that arrives as a canonical list object (`eval [list info frame 0]`,
+`if 1 $body` / `uplevel $body` where the var holds a pure list) was dispatched by
+element identity *without* pushing a `CmdFrame`, so `info frame` and error traces
+reported the caller's frame instead of a `type eval` level for the list command.
+`dispatch_list_obj` now takes the caller's `CmdFrame`, pushes it (cmd = the list
+string, body-relative `line 1`), and *then* dispatches by element identity — so
+both the eval-frame reporting and the identity-preserved nested-body locations
+hold. The pure-list arms of `eval_body_obj`/`eval_control_body`/`eval_uplevel_obj`
+supply a `type eval` (`unlocated_frame`) frame; `uplevel` redirects its level.
+(Found by Codex review on PR #607; `info-37.0`'s two `type eval` frames are now
+correct, its remaining gap is the unrelated `etrace`/`while` line.)
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/runtime/rust/src/bignum.rs
+++ b/runtime/rust/src/bignum.rs
@@ -448,6 +448,19 @@ pub fn is_numeric(obj: *mut TclObj) -> bool {
     read(obj).is_some()
 }
 
+/// The low 64 bits of an **integer** `obj` as a signed wide — C's `wide()`
+/// truncation (a bignum that overflows `i64` wraps, e.g. `wide(2**63)` ⇒
+/// `i64::MIN`). The caller guards with [`is_integer`]; a non-integer yields 0.
+#[must_use]
+pub fn truncate_to_wide(obj: *mut TclObj) -> i64 {
+    match read(obj) {
+        Some(NumVal::Wide(w)) => w,
+        // SAFETY: `mp` is a live mp_int; `mp_get_i64` returns its low 64 bits.
+        Some(NumVal::Big(mp)) => unsafe { mp_get_i64(mp.ptr()) },
+        _ => 0,
+    }
+}
+
 /// Read `obj` as a [`mathfunc::Num`](tcl_syntax::expr::mathfunc::Num) for the
 /// shared math-function dispatch — `None` if non-numeric. A bignum widens to a
 /// double (math functions compute on the double rung, as in C Tcl).

--- a/runtime/rust/src/bignum.rs
+++ b/runtime/rust/src/bignum.rs
@@ -360,13 +360,14 @@ pub fn mod_(a: *mut TclObj, b: *mut TclObj) -> Result<*mut TclObj, ArithError> {
 fn divmod(a: *mut TclObj, b: *mut TclObj, want_quotient: bool) -> Result<*mut TclObj, ArithError> {
     let x = num(a)?;
     let y = num(b)?;
-    // Float division when either operand is a float (`%` on a float is an error
-    // in Tcl, but that surfaces at the expr layer; here `/` floats, `%` would
-    // already be rejected upstream).
+    // `/` divides as floats when either operand is a float; `%` is integer-only,
+    // so a float operand is an error (`cannot use floating-point value …`).
     if matches!(x, NumVal::Float(_)) || matches!(y, NumVal::Float(_)) {
+        if !want_quotient {
+            return Err(ArithError::NonInteger);
+        }
         let (p, q) = (as_f64(x), as_f64(y));
-        let r = if want_quotient { p / q } else { p % q };
-        return Ok(obj::new_double_obj(r));
+        return Ok(obj::new_double_obj(p / q));
     }
     // Wide fast path.
     if let (NumVal::Wide(p), NumVal::Wide(q)) = (&x, &y) {
@@ -438,6 +439,13 @@ fn mp_floor_divmod(a: &Mp, b: &Mp) -> Result<(Mp, Mp), ArithError> {
 #[must_use]
 pub fn is_integer(obj: *mut TclObj) -> bool {
     matches!(read(obj), Some(NumVal::Wide(_) | NumVal::Big(_)))
+}
+
+/// Whether `obj` reads as any number (integer, bignum, or float) — used by
+/// `expr`'s operand-type error to tell a non-numeric operand from a float one.
+#[must_use]
+pub fn is_numeric(obj: *mut TclObj) -> bool {
+    read(obj).is_some()
 }
 
 /// Read `obj` as a [`mathfunc::Num`](tcl_syntax::expr::mathfunc::Num) for the

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -448,7 +448,10 @@ fn subst_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, USAGE);
     }
     let src = obj_bytes(argv[i]);
-    match interp.do_subst(&src, flags) {
+    // TIP 280: a `[...]` inside the substituted string reports the line it sits
+    // on, derived from the argument word's recorded source location.
+    let loc = interp.arg_location(argv[i]);
+    match interp.do_subst_located(&src, flags, loc) {
         Ok(bytes) => {
             interp.set_result_bytes(&bytes);
             Code::Ok

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -532,7 +532,7 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
                     Ok(v) => Some(v),
                     Err(_) => {
                         self.propagated = true;
-                        return Err(crate::expr::ExprError(obj_bytes(
+                        return Err(crate::expr::ExprError::from_bytes(obj_bytes(
                             self.interp.get_obj_result(),
                         )));
                     }
@@ -548,7 +548,7 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
             Some(o) => Ok(crate::expr::Owned::retain(o)),
             None => {
                 let m = self.interp.read_miss_msg(&base, elem.as_deref());
-                Err(crate::expr::ExprError(m))
+                Err(crate::expr::ExprError::from_bytes(m))
             }
         }
     }
@@ -556,7 +556,7 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
     fn eval_command(&mut self, script: &str) -> Result<crate::expr::Owned, crate::expr::ExprError> {
         if self.interp.eval_str(script.as_bytes()) == Code::Error {
             self.propagated = true;
-            return Err(crate::expr::ExprError(obj_bytes(
+            return Err(crate::expr::ExprError::from_bytes(obj_bytes(
                 self.interp.get_obj_result(),
             )));
         }
@@ -572,7 +572,7 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
             Ok(v) => Ok(crate::expr::Owned::fresh(crate::obj::new_string_bytes(&v))),
             Err(_) => {
                 self.propagated = true;
-                Err(crate::expr::ExprError(obj_bytes(
+                Err(crate::expr::ExprError::from_bytes(obj_bytes(
                     self.interp.get_obj_result(),
                 )))
             }
@@ -591,10 +591,12 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
         if self.interp.eval_math_call(name.as_bytes(), &arg_ptrs) == Code::Error {
             // A math-function error (e.g. `sqrt(-1)` domain error) is logged at
             // the `expr` command, not as an inner frame — so it is *not*
-            // propagated; `expr` raises it as its own (`while executing`).
-            return Err(crate::expr::ExprError(obj_bytes(
-                self.interp.get_obj_result(),
-            )));
+            // propagated; `expr` raises it as its own (`while executing`). Carry
+            // the math function's `-errorcode` (TCL WRONGARGS / ARITH DOMAIN) so
+            // `expr`'s re-raise preserves it.
+            let msg = obj_bytes(self.interp.get_obj_result());
+            let code = self.interp.error_code();
+            return Err(crate::expr::ExprError::from_parts(msg, code));
         }
         Ok(crate::expr::Owned::retain(self.interp.get_obj_result()))
     }
@@ -634,7 +636,10 @@ fn expr_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         // A propagated sub-eval error already set the result + `::errorInfo`
         // trace at the inner command — preserve it (no `expr` frame).
         Err(_) if propagated => Code::Error,
-        Err(e) => interp.set_error(&e.0),
+        Err(e) => match e.code {
+            Some(c) => interp.error_with_code(&e.msg, &c),
+            None => interp.set_error(&e.msg),
+        },
     }
 }
 
@@ -657,7 +662,10 @@ pub(crate) fn eval_expr_obj(interp: &mut Interp, src: &[u8]) -> Result<*mut TclO
     match result {
         Ok(r) => Ok(r.into_raw()), // transfer the +1 to the caller
         Err(_) if propagated => Err(Code::Error),
-        Err(e) => Err(interp.set_error(&e.0)),
+        Err(e) => Err(match e.code {
+            Some(c) => interp.error_with_code(&e.msg, &c),
+            None => interp.set_error(&e.msg),
+        }),
     }
 }
 
@@ -677,10 +685,13 @@ pub(crate) fn eval_bool_expr(interp: &mut Interp, src: &[u8]) -> Result<bool, Co
     let result = crate::expr::eval_expr(&node, &mut ctx);
     let propagated = ctx.propagated;
     match result {
-        Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| interp.set_error(&e.0)),
+        Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| interp.set_error(&e.msg)),
         // Preserve a propagated sub-eval error's trace (no condition `expr` frame).
         Err(_) if propagated => Err(Code::Error),
-        Err(e) => Err(interp.set_error(&e.0)),
+        Err(e) => Err(match e.code {
+            Some(c) => interp.error_with_code(&e.msg, &c),
+            None => interp.set_error(&e.msg),
+        }),
     }
 }
 

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -8,10 +8,9 @@
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-use crate::interp::{drop_fresh, new_string, obj_bytes, Code, Interp};
+use crate::interp::{new_string, obj_bytes, Code, Interp};
 use crate::list;
 use crate::obj::TclObj;
-use crate::parse::split_list;
 
 /// Register `array`.
 pub fn install(interp: &mut Interp) {
@@ -100,7 +99,11 @@ fn array_set(interp: &mut Interp, argv: &[*mut TclObj], name: &[u8]) -> Code {
     if argv.len() != 4 {
         return wrong_args(interp, b"array set arrayName list");
     }
-    let kvs = match split_list(&obj_bytes(argv[3])) {
+    // Read the *element objects* (not a re-split into fresh strings) so each
+    // value keeps its `Tcl_Obj` identity through the array — C shares objs by
+    // reference, and TIP 280 keys a literal's source location on that identity
+    // (so a `-body {…}` stored via `array set` still evaluates as `type source`).
+    let kvs = match crate::list::list_elements(argv[3]) {
         Ok(v) => v,
         Err(e) => return interp.set_error(e.message()),
     };
@@ -108,9 +111,9 @@ fn array_set(interp: &mut Interp, argv: &[*mut TclObj], name: &[u8]) -> Code {
         return interp.set_error(b"list must have an even number of elements");
     }
     for pair in kvs.chunks_exact(2) {
-        let v = new_string(&pair[1]); // rc 0; var_set_elem retains
-        if let Err(e) = interp.var_set_elem(name, &pair[0], v) {
-            drop_fresh(v);
+        // `var_set_elem` retains the live value obj (no fresh allocation).
+        let key = obj_bytes(pair[0]);
+        if let Err(e) = interp.var_set_elem(name, &key, pair[1]) {
             return crate::builtins::var_error(interp, name, e);
         }
     }

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -80,7 +80,7 @@ fn if_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         i += 1;
 
         match crate::builtins::eval_bool_expr(interp, &cond) {
-            Ok(true) => return interp.eval_str(&obj_bytes(body)),
+            Ok(true) => return interp.eval_control_body(body),
             Ok(false) => {}
             Err(code) => return code,
         }
@@ -101,10 +101,10 @@ fn if_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     return interp
                         .set_error(b"wrong # args: no script following \"else\" argument");
                 }
-                return interp.eval_str(&obj_bytes(argv[i]));
+                return interp.eval_control_body(argv[i]);
             }
             // A bare trailing body is the implicit else (`if {0} a b`).
-            _ => return interp.eval_str(&obj_bytes(argv[i])),
+            _ => return interp.eval_control_body(argv[i]),
         }
     }
 }
@@ -118,14 +118,14 @@ fn while_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"while test command");
     }
     let cond = obj_bytes(argv[1]);
-    let body = obj_bytes(argv[2]);
+    let body = argv[2];
     loop {
         match crate::builtins::eval_bool_expr(interp, &cond) {
             Ok(true) => {}
             Ok(false) => break,
             Err(code) => return code,
         }
-        match interp.eval_str(&body) {
+        match interp.eval_control_body(body) {
             Code::Ok | Code::Continue => {}
             Code::Break => break,
             other => return other, // return / error propagate
@@ -147,7 +147,7 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         obj_bytes(argv[1]),
         obj_bytes(argv[2]),
         obj_bytes(argv[3]),
-        obj_bytes(argv[4]),
+        argv[4],
     );
     match interp.eval_str(&init) {
         Code::Ok => {}
@@ -159,7 +159,7 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Ok(false) => break,
             Err(code) => return code,
         }
-        match interp.eval_str(&body) {
+        match interp.eval_control_body(body) {
             Code::Ok | Code::Continue => {} // `continue` still runs `next`
             Code::Break => break,
             other => return other,
@@ -205,7 +205,7 @@ fn each_loop(interp: &mut Interp, argv: &[*mut TclObj], collect: bool) -> Code {
         };
         return wrong_args(interp, usage);
     }
-    let body = obj_bytes(argv[argv.len() - 1]);
+    let body = argv[argv.len() - 1];
 
     // Parse each group's variable names + values; track the iteration count.
     // A group is `(variable names, values)`.
@@ -245,7 +245,7 @@ fn each_loop(interp: &mut Interp, argv: &[*mut TclObj], collect: bool) -> Code {
                 }
             }
         }
-        match interp.eval_str(&body) {
+        match interp.eval_control_body(body) {
             Code::Ok => {
                 if collect {
                     collected.push(obj_bytes(interp.get_obj_result()));

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -143,13 +143,11 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 5 {
         return wrong_args(interp, b"for start test next command");
     }
-    let (init, cond, next, body) = (
-        obj_bytes(argv[1]),
-        obj_bytes(argv[2]),
-        obj_bytes(argv[3]),
-        argv[4],
-    );
-    match interp.eval_str(&init) {
+    let (init, cond, next, body) = (argv[1], obj_bytes(argv[2]), argv[3], argv[4]);
+    // `start`/`next` are scripts too — run them through `eval_control_body` so a
+    // located literal reports `type source` at its own line (TIP 280), matching
+    // the body. (Their result is discarded; only their completion code matters.)
+    match interp.eval_control_body(init) {
         Code::Ok => {}
         other => return other,
     }
@@ -164,7 +162,7 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Break => break,
             other => return other,
         }
-        match interp.eval_str(&next) {
+        match interp.eval_control_body(next) {
             Code::Ok => {}
             other => return other,
         }

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -326,24 +326,37 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     b"dict filter dictionary script {keyVarName valueVarName} filterScript",
                 );
             }
+            // The two variable names are parsed as a *list*: a malformed list
+            // surfaces the list parse error verbatim (dict-17.20), then a count
+            // other than two is the dict-filter syntax error (dict-17.19).
             let vars = match crate::parse::split_list(&obj_bytes(argv[4])) {
-                Ok(v) if v.len() == 2 => v,
-                _ => {
-                    return interp
-                        .set_error(b"must have exactly two variable names for dict filter script")
-                }
+                Ok(v) => v,
+                Err(e) => return interp.set_error(e.message()),
             };
+            if vars.len() != 2 {
+                return interp.error_with_code(
+                    b"must have exactly two variable names",
+                    b"TCL SYNTAX dict filter",
+                );
+            }
             let body = obj_bytes(argv[5]);
             for (k, v) in pairs {
                 if interp.var_set(&vars[0], k).is_err() || interp.var_set(&vars[1], v).is_err() {
                     return interp.set_error(b"couldn't set dict filter variable");
                 }
-                let code = interp.eval_str(&body);
-                if code == Code::Error {
-                    return Code::Error;
-                }
-                if is_true(&obj_bytes(interp.get_obj_result())) {
-                    kept.push((k, v));
+                // The body's completion code drives the loop (C's `DictFilterCmd`
+                // script case): OK ⇒ keep iff its result is true; CONTINUE ⇒ skip;
+                // BREAK ⇒ stop, return what's kept; ERROR / RETURN / other ⇒
+                // propagate the code (and result) out of `dict filter`.
+                match interp.eval_str(&body) {
+                    Code::Ok => {
+                        if is_true(&obj_bytes(interp.get_obj_result())) {
+                            kept.push((k, v));
+                        }
+                    }
+                    Code::Continue => {}
+                    Code::Break => break,
+                    other => return other,
                 }
             }
         }
@@ -639,7 +652,7 @@ fn update(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 6 || argv.len() % 2 != 0 {
         return wrong_args(
             interp,
-            b"dict update varName key varName ?key varName ...? body",
+            b"dict update dictVarName key varName ?key varName ...? script",
         );
     }
     let dict_var = obj_bytes(argv[2]);
@@ -693,11 +706,11 @@ fn update(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     code
 }
 
-/// `dict with dictVar ?key ...? body` — map every key of the (sub-)dict to a
+/// `dict with dictVarName ?key ...? script` — map every key of the (sub-)dict to a
 /// local var, run body, write the vars back. Supports a leading key path.
 fn with(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
-        return wrong_args(interp, b"dict with dictVar ?key ...? body");
+        return wrong_args(interp, b"dict with dictVarName ?key ...? script");
     }
     let dict_var = obj_bytes(argv[2]);
     let body = obj_bytes(argv[argv.len() - 1]);

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -339,7 +339,6 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     b"TCL SYNTAX dict filter",
                 );
             }
-            let body = obj_bytes(argv[5]);
             for (k, v) in pairs {
                 if interp.var_set(&vars[0], k).is_err() || interp.var_set(&vars[1], v).is_err() {
                     return interp.set_error(b"couldn't set dict filter variable");
@@ -348,7 +347,7 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 // script case): OK ⇒ keep iff its result is true; CONTINUE ⇒ skip;
                 // BREAK ⇒ stop, return what's kept; ERROR / RETURN / other ⇒
                 // propagate the code (and result) out of `dict filter`.
-                match interp.eval_str(&body) {
+                match interp.eval_control_body(argv[5]) {
                     Code::Ok => {
                         if is_true(&obj_bytes(interp.get_obj_result())) {
                             kept.push((k, v));
@@ -582,7 +581,6 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(p) => p,
         Err(e) => return bad_dict(interp, e),
     };
-    let body = obj_bytes(argv[4]);
 
     for (k, v) in pairs {
         if interp.var_set(&kvar, k).is_err() {
@@ -591,7 +589,7 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         if interp.var_set(&vvar, v).is_err() {
             return cant_set(interp, &vvar);
         }
-        match interp.eval_str(&body) {
+        match interp.eval_control_body(argv[4]) {
             Code::Ok | Code::Continue => {}
             Code::Break => break,
             other => return other, // Return / Error propagate (result already set)
@@ -619,7 +617,6 @@ fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(p) => p,
         Err(e) => return bad_dict(interp, e),
     };
-    let body = obj_bytes(argv[4]);
     let acc = dict::new_dict_obj(&[]);
     unsafe { obj::incr_ref_count(acc) };
     for (k, v) in pairs {
@@ -627,7 +624,7 @@ fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             unsafe { obj::decr_ref_count(acc) };
             return cant_set(interp, &vars[0]);
         }
-        match interp.eval_str(&body) {
+        match interp.eval_control_body(argv[4]) {
             Code::Ok => {
                 let _ = dict::dict_set(acc, k, interp.get_obj_result());
             }
@@ -656,7 +653,7 @@ fn update(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         );
     }
     let dict_var = obj_bytes(argv[2]);
-    let body = obj_bytes(argv[argv.len() - 1]);
+    let body_obj = argv[argv.len() - 1];
     let pairs_args = &argv[3..argv.len() - 1];
 
     let Some(d) = interp.var_get(&dict_var) else {
@@ -679,7 +676,7 @@ fn update(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
     }
 
-    let code = interp.eval_str(&body);
+    let code = interp.eval_control_body(body_obj);
 
     // Write-back: re-read the dict (the body may have replaced it), then apply
     // each local var (set if it exists, drop the key if it was unset).
@@ -713,7 +710,7 @@ fn with(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"dict with dictVarName ?key ...? script");
     }
     let dict_var = obj_bytes(argv[2]);
-    let body = obj_bytes(argv[argv.len() - 1]);
+    let body_obj = argv[argv.len() - 1];
     let path = &argv[3..argv.len() - 1];
 
     let Some(d) = interp.var_get(&dict_var) else {
@@ -740,7 +737,7 @@ fn with(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
     }
 
-    let code = interp.eval_str(&body);
+    let code = interp.eval_control_body(body_obj);
 
     // Write-back: rebuild the sub-dict from the locals, then store it through
     // the key path (only the no-path case writes back nested updates here).

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -74,7 +74,7 @@ fn create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// `dict get dictValue ?key?` — the value for `key`, or the whole dict if no key.
 fn get(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 {
-        return wrong_args(interp, b"dict get dictValue ?key ...?");
+        return wrong_args(interp, b"dict get dictionary ?key ...?");
     }
     if argv.len() == 3 {
         interp.set_result(argv[2]); // whole dict
@@ -88,7 +88,7 @@ fn get(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         match dict::dict_get(cur, &key) {
             Ok(Some(v)) => cur = v,
             Ok(None) => return key_not_known(interp, &key),
-            Err(_) => return bad_dict(interp),
+            Err(e) => return bad_dict(interp, e),
         }
     }
     interp.set_result(cur);
@@ -98,7 +98,7 @@ fn get(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// `dict exists dictValue key`
 fn exists(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
-        return wrong_args(interp, b"dict exists dictValue key ?key ...?");
+        return wrong_args(interp, b"dict exists dictionary key ?key ...?");
     }
     // Drill the key path; a missing key or a non-dict along the way → 0 (Tcl
     // `dict exists` reports false rather than erroring).
@@ -122,17 +122,17 @@ fn exists(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// `dict size dictValue`
+/// `dict size dictionary`
 fn size(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 3 {
-        return wrong_args(interp, b"dict size dictValue");
+        return wrong_args(interp, b"dict size dictionary");
     }
     match dict::dict_size(argv[2]) {
         Ok(n) => {
             interp.set_result(obj::new_wide_int_obj(n as i64));
             Code::Ok
         }
-        Err(_) => bad_dict(interp),
+        Err(e) => bad_dict(interp, e),
     }
 }
 
@@ -160,28 +160,28 @@ fn glob_filtered_result(
     Code::Ok
 }
 
-/// `dict keys dictValue ?pattern?` — keys in insertion order, glob-filtered.
+/// `dict keys dictionary ?pattern?` — keys in insertion order, glob-filtered.
 fn keys(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 || argv.len() > 4 {
-        return wrong_args(interp, b"dict keys dictValue ?pattern?");
+        return wrong_args(interp, b"dict keys dictionary ?pattern?");
     }
     match dict::dict_keys(argv[2]) {
         Ok(ks) => glob_filtered_result(interp, argv, ks),
-        Err(_) => bad_dict(interp),
+        Err(e) => bad_dict(interp, e),
     }
 }
 
-/// `dict values dictValue ?pattern?` — values in insertion order, glob-filtered.
+/// `dict values dictionary ?pattern?` — values in insertion order, glob-filtered.
 fn values(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 || argv.len() > 4 {
-        return wrong_args(interp, b"dict values dictValue ?pattern?");
+        return wrong_args(interp, b"dict values dictionary ?pattern?");
     }
     match dict::dict_pairs(argv[2]) {
         Ok(pairs) => {
             let vs: Vec<*mut TclObj> = pairs.iter().map(|&(_, v)| v).collect();
             glob_filtered_result(interp, argv, vs)
         }
-        Err(_) => bad_dict(interp),
+        Err(e) => bad_dict(interp, e),
     }
 }
 
@@ -193,16 +193,16 @@ fn merge(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     for &d in &argv[2..] {
         let pairs = match dict::dict_pairs(d) {
             Ok(p) => p,
-            Err(_) => {
+            Err(e) => {
                 unsafe { obj::decr_ref_count(acc) };
-                return bad_dict(interp);
+                return bad_dict(interp, e);
             }
         };
         for (k, v) in pairs {
             // acc is unshared (we hold the only ref) → in-place set is sound.
-            if dict::dict_set(acc, k, v).is_err() {
+            if let Err(e) = dict::dict_set(acc, k, v) {
                 unsafe { obj::decr_ref_count(acc) };
-                return bad_dict(interp);
+                return bad_dict(interp, e);
             }
         }
     }
@@ -216,8 +216,8 @@ fn merge(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 fn copy_dict(interp: &mut Interp, src: *mut TclObj) -> Option<*mut TclObj> {
     let pairs = match dict::dict_pairs(src) {
         Ok(p) => p,
-        Err(_) => {
-            bad_dict(interp);
+        Err(e) => {
+            bad_dict(interp, e);
             return None;
         }
     };
@@ -281,7 +281,7 @@ fn getdef(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 interp.set_result(default);
                 return Code::Ok;
             }
-            Err(_) => return bad_dict(interp),
+            Err(e) => return bad_dict(interp, e),
         }
     }
     interp.set_result(cur);
@@ -297,7 +297,7 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let pairs = match dict::dict_pairs(argv[2]) {
         Ok(p) => p,
-        Err(_) => return bad_dict(interp),
+        Err(e) => return bad_dict(interp, e),
     };
     let kind = obj_bytes(argv[3]);
     let mut kept: Vec<(*mut TclObj, *mut TclObj)> = Vec::new();
@@ -323,7 +323,7 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             if argv.len() != 6 {
                 return wrong_args(
                     interp,
-                    b"dict filter dictionary script {keyVar valueVar} filterScript",
+                    b"dict filter dictionary script {keyVarName valueVarName} filterScript",
                 );
             }
             let vars = match crate::parse::split_list(&obj_bytes(argv[4])) {
@@ -403,12 +403,12 @@ fn append(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         buf.extend_from_slice(&obj_bytes(s));
     }
     let val = crate::interp::new_string(&buf); // rc 0; dict_set retains
-    if dict::dict_set(target, key, val).is_err() {
+    if let Err(e) = dict::dict_set(target, key, val) {
         drop_fresh(val);
         if is_new {
             drop_fresh(target);
         }
-        return bad_dict(interp);
+        return bad_dict(interp, e);
     }
     store_dict(interp, &name, target, is_new)
 }
@@ -427,12 +427,12 @@ fn lappend(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
     elems.extend_from_slice(&argv[4..]);
     let val = crate::list::new_list_obj(&elems); // rc 0; dict_set retains
-    if dict::dict_set(target, key, val).is_err() {
+    if let Err(e) = dict::dict_set(target, key, val) {
         drop_fresh(val);
         if is_new {
             drop_fresh(target);
         }
-        return bad_dict(interp);
+        return bad_dict(interp, e);
     }
     store_dict(interp, &name, target, is_new)
 }
@@ -472,12 +472,12 @@ fn incr(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
     let sum = cur.wrapping_add(amount);
     let val = crate::interp::new_string(sum.to_string().as_bytes());
-    if dict::dict_set(target, key, val).is_err() {
+    if let Err(e) = dict::dict_set(target, key, val) {
         drop_fresh(val);
         if is_new {
             drop_fresh(target);
         }
-        return bad_dict(interp);
+        return bad_dict(interp, e);
     }
     store_dict(interp, &name, target, is_new)
 }
@@ -507,11 +507,11 @@ fn set(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Some(o) if obj::is_shared(o) => (obj::duplicate(o), true),
         Some(o) => (o, false),
     };
-    if dict::dict_set(target, key, value).is_err() {
+    if let Err(e) = dict::dict_set(target, key, value) {
         if is_new {
             drop_fresh(target);
         }
-        return bad_dict(interp);
+        return bad_dict(interp, e);
     }
     if is_new && interp.var_set(&name, target).is_err() {
         drop_fresh(target);
@@ -534,11 +534,11 @@ fn unset(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Some(o) if obj::is_shared(o) => (obj::duplicate(o), true),
         Some(o) => (o, false),
     };
-    if dict::dict_unset(target, &key).is_err() {
+    if let Err(e) = dict::dict_unset(target, &key) {
         if is_new {
             drop_fresh(target);
         }
-        return bad_dict(interp);
+        return bad_dict(interp, e);
     }
     if is_new && interp.var_set(&name, target).is_err() {
         drop_fresh(target);
@@ -556,7 +556,7 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 5 {
         return wrong_args(
             interp,
-            b"dict for {keyVarName valueVarName} dictValue script",
+            b"dict for {keyVarName valueVarName} dictionary script",
         );
     }
     let var_spec = obj_bytes(argv[2]);
@@ -567,7 +567,7 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let (kvar, vvar) = (vars[0].clone(), vars[1].clone());
     let pairs = match dict::dict_pairs(argv[3]) {
         Ok(p) => p,
-        Err(_) => return bad_dict(interp),
+        Err(e) => return bad_dict(interp, e),
     };
     let body = obj_bytes(argv[4]);
 
@@ -595,7 +595,7 @@ fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 5 {
         return wrong_args(
             interp,
-            b"dict map {keyVarName valueVarName} dictValue script",
+            b"dict map {keyVarName valueVarName} dictionary script",
         );
     }
     let vars = match parse::split_list(&obj_bytes(argv[2])) {
@@ -604,7 +604,7 @@ fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
     let pairs = match dict::dict_pairs(argv[3]) {
         Ok(p) => p,
-        Err(_) => return bad_dict(interp),
+        Err(e) => return bad_dict(interp, e),
     };
     let body = obj_bytes(argv[4]);
     let acc = dict::new_dict_obj(&[]);
@@ -662,7 +662,7 @@ fn update(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Ok(None) => {
                 interp.var_unset(&var);
             }
-            Err(_) => return bad_dict(interp),
+            Err(e) => return bad_dict(interp, e),
         }
     }
 
@@ -712,12 +712,12 @@ fn with(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         match dict::dict_get(sub, &obj_bytes(k)) {
             Ok(Some(v)) => sub = v,
             Ok(None) => return key_not_known(interp, &obj_bytes(k)),
-            Err(_) => return bad_dict(interp),
+            Err(e) => return bad_dict(interp, e),
         }
     }
     let pairs = match dict::dict_pairs(sub) {
         Ok(p) => p,
-        Err(_) => return bad_dict(interp),
+        Err(e) => return bad_dict(interp, e),
     };
     // Map every key to a local var.
     let keys: Vec<Vec<u8>> = pairs.iter().map(|&(k, _)| obj_bytes(k)).collect();
@@ -767,8 +767,41 @@ fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
     interp.set_error(&m)
 }
 
-fn bad_dict(interp: &mut Interp) -> Code {
-    interp.set_error(b"missing value to go with key")
+/// Map a dict string-parse failure to its C-faithful message + `-errorcode`
+/// (`SetDictFromAny`/`FindElement`, type strings `dict`/`DICTIONARY`).
+fn bad_dict(interp: &mut Interp, e: crate::dict::DictError) -> Code {
+    use crate::dict::DictError as E;
+    let (msg, code): (Vec<u8>, &[u8]) = match e {
+        E::MissingValue => (
+            b"missing value to go with key".to_vec(),
+            b"TCL VALUE DICTIONARY",
+        ),
+        E::BraceJunk(frag) => {
+            let mut m = b"dict element in braces followed by \"".to_vec();
+            m.extend_from_slice(&frag);
+            m.extend_from_slice(b"\" instead of space");
+            (m, b"TCL VALUE DICTIONARY JUNK")
+        }
+        E::QuoteJunk(frag) => {
+            let mut m = b"dict element in quotes followed by \"".to_vec();
+            m.extend_from_slice(&frag);
+            m.extend_from_slice(b"\" instead of space");
+            (m, b"TCL VALUE DICTIONARY JUNK")
+        }
+        E::UnmatchedBrace => (
+            b"unmatched open brace in dict".to_vec(),
+            b"TCL VALUE DICTIONARY BRACE",
+        ),
+        E::UnmatchedQuote => (
+            b"unmatched open quote in dict".to_vec(),
+            b"TCL VALUE DICTIONARY QUOTE",
+        ),
+        E::NotUtf8 => (
+            b"missing value to go with key".to_vec(),
+            b"TCL VALUE DICTIONARY",
+        ),
+    };
+    interp.error_with_code(&msg, code)
 }
 
 fn key_not_known(interp: &mut Interp, key: &[u8]) -> Code {

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -41,8 +41,11 @@ fn catch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 || argv.len() > 4 {
         return wrong_args(interp, b"catch script ?resultVarName? ?optionsVarName?");
     }
-    let body = obj_bytes(argv[1]);
-    let code = interp.eval_str(&body);
+    // `catch` evaluates its script as its own `info frame` level (C bumps
+    // `cmdFramePtr` like `eval`), so a located literal body reports `type source`
+    // at its own line — `eval_body_obj` pushes that frame and picks up the body
+    // object's TIP 280 location.
+    let code = interp.eval_body_obj(argv[1]);
     // Snapshot the body's result BEFORE we overwrite the interp result with the
     // catch return value (the Zig "read before clear" discovery). `var_set`
     // retains it into the result var, so it survives the later `set_result`.

--- a/runtime/rust/src/cmd_eval.rs
+++ b/runtime/rust/src/cmd_eval.rs
@@ -49,10 +49,14 @@ fn eval_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, b"eval arg ?arg ...?");
     }
-    let script = join_body(&argv[1..]);
-    // `eval` runs its body as its own `info frame` level (inheriting the
-    // enclosing proc/level).
-    let code = interp.eval_body(&script);
+    // A single body argument keeps its object identity, so a literal from a
+    // sourced file evaluates as `type source` (TIP 280 LABC); multiple args are
+    // concatenated into a fresh dynamic script (`type eval`).
+    let code = if argv.len() == 2 {
+        interp.eval_body_obj(argv[1])
+    } else {
+        interp.eval_body(&join_body(&argv[1..]))
+    };
     if code == Code::Error {
         // `("eval" body line N)` — a body evaluated through a fresh frame.
         interp.append_body_frame(b"eval");
@@ -84,8 +88,11 @@ fn uplevel_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if body_start >= argv.len() {
         return wrong_args(interp, usage);
     }
-    let script = join_body(&argv[body_start..]);
-    let code = interp.eval_uplevel(target, &script);
+    let code = if body_start == argv.len() - 1 {
+        interp.eval_uplevel_obj(target, argv[body_start])
+    } else {
+        interp.eval_uplevel(target, &join_body(&argv[body_start..]))
+    };
     if code == Code::Error {
         // `("uplevel" body line N)`.
         interp.append_body_frame(b"uplevel");

--- a/runtime/rust/src/cmd_format.rs
+++ b/runtime/rust/src/cmd_format.rs
@@ -300,18 +300,7 @@ fn float_field(spec: &Spec, conv: u8, value: f64) -> Vec<u8> {
         b'f' => format!("{value:.prec$}"),
         b'e' => format!("{value:.prec$e}"),
         b'E' => format!("{value:.prec$E}"),
-        b'g' | b'G' => {
-            // Shortest of %e/%f with significant-digit precision; Rust's default
-            // float formatting is a close, round-trippable approximation.
-            let p = prec.max(1);
-            let g = format!("{value:.*}", p.saturating_sub(1));
-            // Trim trailing zeros (the %g behaviour) unless `#`.
-            if spec.alt {
-                g
-            } else {
-                trim_g(&g)
-            }
-        }
+        b'g' | b'G' => format_g(value, prec.max(1), conv == b'G', spec.alt),
         _ => format!("{value}"),
     };
     // Normalise Rust's exponent (`1e2` → `1e+02`) toward C's form.
@@ -346,6 +335,54 @@ fn trim_g(s: &str) -> String {
     } else {
         s.to_string()
     }
+}
+
+/// `%g`/`%G` with `p` **significant** digits (C's `printf`): use `%e` when the
+/// decimal exponent is `< -4` or `>= p`, else `%f`, each at the precision that
+/// yields `p` significant digits; trailing zeros are trimmed unless `alt` (`#`).
+fn format_g(value: f64, p: usize, upper: bool, alt: bool) -> String {
+    if !value.is_finite() {
+        let s = format!("{value}"); // inf / NaN
+        return if upper { s.to_uppercase() } else { s };
+    }
+    // Significant-digit scientific form gives the decimal exponent directly.
+    let sci = format!("{value:.*e}", p - 1);
+    let exp: i32 = sci
+        .find('e')
+        .and_then(|i| sci[i + 1..].parse().ok())
+        .unwrap_or(0);
+    let mut out = if exp < -4 || exp >= p as i32 {
+        // %e with p-1 fractional digits; trim the mantissa (keep the exponent).
+        let s = fix_exponent(&sci);
+        if alt {
+            s
+        } else {
+            trim_g_e(&s)
+        }
+    } else {
+        // %f with enough fractional digits for p significant figures.
+        let fprec = usize::try_from(p as i32 - 1 - exp).unwrap_or(0);
+        let s = format!("{value:.fprec$}");
+        if alt {
+            s
+        } else {
+            trim_g(&s)
+        }
+    };
+    if upper {
+        out = out.to_uppercase();
+    }
+    out
+}
+
+/// Trailing-zero trim of a `%e`-form `%g` result: trim zeros in the mantissa
+/// (before `e`), keeping the exponent intact.
+fn trim_g_e(s: &str) -> String {
+    let Some(epos) = s.find(['e', 'E']) else {
+        return trim_g(s);
+    };
+    let (mantissa, exp) = s.split_at(epos);
+    format!("{}{}", trim_g(mantissa), exp)
 }
 
 /// Rust prints `1e2`; C prints `1.000000e+02`-style with a signed 2-digit

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -42,15 +42,19 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"cmdtype",
         b"commands",
         b"complete",
+        b"constant",
+        b"consts",
         b"coroutine",
         b"default",
+        b"errorstack",
         b"exists",
         b"frame",
         b"functions",
         b"globals",
+        b"hostname",
         b"level",
-        b"loaded",
         b"library",
+        b"loaded",
         b"locals",
         b"nameofexecutable",
         b"object",
@@ -91,9 +95,24 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Interp::procs_in_namespace,
             Interp::visible_proc_names,
         ),
-        b"vars" => set_list(interp, argv, Interp::visible_var_names),
-        b"globals" => set_list(interp, argv, Interp::global_var_names),
-        b"locals" => set_list(interp, argv, Interp::local_var_names),
+        b"vars" => set_list(
+            interp,
+            argv,
+            b"info vars ?pattern?",
+            Interp::visible_var_names,
+        ),
+        b"globals" => set_list(
+            interp,
+            argv,
+            b"info globals ?pattern?",
+            Interp::global_var_names,
+        ),
+        b"locals" => set_list(
+            interp,
+            argv,
+            b"info locals ?pattern?",
+            Interp::local_var_names,
+        ),
         b"level" => info_level(interp, argv),
         b"frame" => info_frame(interp, argv),
         b"coroutine" => {
@@ -105,8 +124,10 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
         b"object" => crate::cmd_oo::info_object(interp, argv),
         b"class" => crate::cmd_oo::info_class(interp, argv),
-        b"tclversion" => fixed(interp, argv, b"info tclversion", b"9.0"),
-        b"patchlevel" => fixed(interp, argv, b"info patchlevel", b"9.0.3"),
+        // `info tclversion`/`patchlevel` *read* the globals (C reads
+        // `tcl_version`/`tcl_patchLevel`), so unsetting them makes these error.
+        b"tclversion" => info_global(interp, argv, b"info tclversion", b"tcl_version"),
+        b"patchlevel" => info_global(interp, argv, b"info patchlevel", b"tcl_patchLevel"),
         // The host shared-library suffix (`$::tcl_platform(platform)` is unix).
         b"sharedlibextension" => fixed(interp, argv, b"info sharedlibextension", b".so"),
         b"complete" => {
@@ -146,10 +167,20 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             if argv.len() > 3 {
                 return wrong_args(interp, b"info script ?filename?");
             }
-            interp.set_result_bytes(&interp.current_script());
+            if argv.len() == 3 {
+                // Set the current script name and return it (C's `info script F`).
+                let name = obj_bytes(argv[2]);
+                interp.set_current_script(&name);
+                interp.set_result_bytes(&name);
+            } else {
+                interp.set_result_bytes(&interp.current_script());
+            }
             Code::Ok
         }
         b"nameofexecutable" => {
+            if argv.len() != 2 {
+                return wrong_args(interp, b"info nameofexecutable");
+            }
             let exe = std::env::current_exe()
                 .ok()
                 .map(|p| p.to_string_lossy().into_owned())
@@ -157,22 +188,70 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(exe.as_bytes());
             Code::Ok
         }
-        b"library" => match interp.var_get(b"::tcl_library") {
-            Some(o) => {
-                interp.set_result(o);
-                Code::Ok
+        b"library" => {
+            if argv.len() != 2 {
+                return wrong_args(interp, b"info library");
             }
-            None => interp.set_error(b"variable \"::tcl_library\" undefined"),
-        },
+            match interp.var_get(b"::tcl_library") {
+                Some(o) => {
+                    interp.set_result(o);
+                    Code::Ok
+                }
+                None => interp.set_error(b"variable \"::tcl_library\" undefined"),
+            }
+        }
+        b"hostname" => {
+            if argv.len() != 2 {
+                return wrong_args(interp, b"info hostname");
+            }
+            interp.set_result_bytes(&hostname());
+            Code::Ok
+        }
+        b"errorstack" => {
+            // TIP 348: the error stack (`-errorstack` of the last error). Not yet
+            // tracked — report empty (`?interp?` accepted).
+            if argv.len() > 3 {
+                return wrong_args(interp, b"info errorstack ?interp?");
+            }
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
+        b"constant" => {
+            // TIP 677: whether a variable is a `const`. No const variables yet ⇒ 0.
+            if argv.len() != 3 {
+                return wrong_args(interp, b"info constant varName");
+            }
+            interp.set_result_bytes(b"0");
+            Code::Ok
+        }
+        b"consts" => {
+            // TIP 677: the const variables (glob-filtered). None yet ⇒ empty.
+            if argv.len() > 3 {
+                return wrong_args(interp, b"info consts ?pattern?");
+            }
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
         other => {
             let mut m = b"unknown or ambiguous subcommand \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(
-                b"\": must be args, body, class, cmdcount, cmdtype, commands, complete, default, exists, frame, functions, globals, level, library, loaded, locals, nameofexecutable, object, patchlevel, procs, script, sharedlibextension, tclversion, or vars",
-            );
+            m.extend_from_slice(b"\": must be ");
+            let subs: Vec<Vec<u8>> = SUBS.iter().map(|s| s.to_vec()).collect();
+            m.extend_from_slice(&crate::ensemble::must_be(&subs));
             interp.set_error(&m)
         }
     }
+}
+
+/// The host name (`info hostname`, `Tcl_GetHostName`) — best-effort from
+/// `/proc/sys/kernel/hostname`, else `/etc/hostname`, else empty.
+fn hostname() -> Vec<u8> {
+    for path in ["/proc/sys/kernel/hostname", "/etc/hostname"] {
+        if let Ok(s) = std::fs::read_to_string(path) {
+            return s.trim().as_bytes().to_vec();
+        }
+    }
+    Vec::new()
 }
 
 /// `info cmdtype command` — the kind of command (`native`/`proc`/`alias`/…).
@@ -208,9 +287,14 @@ fn set_filtered(interp: &mut Interp, names: Vec<Vec<u8>>, pattern: Option<&[u8]>
 }
 
 /// `info <sub> ?pattern?` over a name producer.
-fn set_list(interp: &mut Interp, argv: &[*mut TclObj], names: fn(&Interp) -> Vec<Vec<u8>>) -> Code {
+fn set_list(
+    interp: &mut Interp,
+    argv: &[*mut TclObj],
+    usage: &[u8],
+    names: fn(&Interp) -> Vec<Vec<u8>>,
+) -> Code {
     if argv.len() > 3 {
-        return wrong_args(interp, b"info <subcommand> ?pattern?");
+        return wrong_args(interp, usage);
     }
     let pattern = argv.get(2).map(|&a| obj_bytes(a));
     let list = names(interp);
@@ -421,6 +505,30 @@ fn fixed(interp: &mut Interp, argv: &[*mut TclObj], usage: &[u8], value: &[u8]) 
     Code::Ok
 }
 
+/// `info tclversion`/`patchlevel` — read the **global** `var` (C uses
+/// `TCL_GLOBAL_ONLY`), erroring `can't read "VAR": no such variable` if it has
+/// been unset (info-14.3/18.3). `var` is the unqualified name (for the message);
+/// the read is `::`-qualified so it works inside a proc/eval frame.
+fn info_global(interp: &mut Interp, argv: &[*mut TclObj], usage: &[u8], var: &[u8]) -> Code {
+    if argv.len() != 2 {
+        return wrong_args(interp, usage);
+    }
+    let mut qualified = b"::".to_vec();
+    qualified.extend_from_slice(var);
+    match interp.var_get(&qualified) {
+        Some(o) => {
+            interp.set_result(o);
+            Code::Ok
+        }
+        None => {
+            let mut m = b"can't read \"".to_vec();
+            m.extend_from_slice(var);
+            m.extend_from_slice(b"\": no such variable");
+            interp.set_error(&m)
+        }
+    }
+}
+
 fn info_body(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 3 {
         return wrong_args(interp, b"info body procname");
@@ -470,17 +578,19 @@ fn info_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         m.push(b'"');
         return interp.set_error(&m);
     };
-    match &param.default {
-        Some(d) => {
-            let o = new_string(d);
-            if interp.var_set(&var, o).is_err() {
-                crate::interp::drop_fresh(o);
-                return interp.set_error(b"couldn't store default value");
-            }
-            interp.set_result_bytes(b"1");
-        }
-        None => interp.set_result_bytes(b"0"),
+    // With a default, store it and return 1; without one, store the empty string
+    // and return 0 (C's `InfoDefaultCmd`). A store failure (e.g. the target is an
+    // array) is the variable error verbatim (`can't set "a": variable is array`).
+    let (val, has): (&[u8], &[u8]) = match &param.default {
+        Some(d) => (d, b"1"),
+        None => (b"", b"0"),
+    };
+    let o = new_string(val);
+    if let Err(e) = interp.var_set(&var, o) {
+        crate::interp::drop_fresh(o);
+        return crate::builtins::var_error(interp, &var, e);
     }
+    interp.set_result_bytes(has);
     Code::Ok
 }
 
@@ -658,6 +768,9 @@ mod tests {
     #[test]
     fn info_version_and_procs() {
         leak_free(|i| {
+            // `info tclversion`/`patchlevel` read the globals (set by a full
+            // interp's init; a bare test interp seeds them here).
+            run(i, b"set ::tcl_version 9.0; set ::tcl_patchLevel 9.0.3");
             assert_eq!(run(i, b"info tclversion"), b"9.0");
             assert_eq!(run(i, b"info patchlevel"), b"9.0.3");
             run(i, b"proc greet {name {g hi}} {return $g-$name}");

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -238,13 +238,18 @@ fn set_list_qualified(
             .map(|i| (&p[..i], &p[i + 2..]))
     });
     if let Some((prefix, tail)) = split {
+        // Re-qualify through the namespace's canonical full name so results are
+        // absolute even for a *relative* qualifier (`info commands ns::pat`).
+        let Some(canon) = interp.canonical_ns_prefix(prefix) else {
+            interp.set_result(list::new_list_obj(&[]));
+            return Code::Ok;
+        };
         let names = in_namespace(interp, prefix);
         let objs: Vec<*mut TclObj> = names
             .iter()
             .filter(|n| glob_match(tail, n))
             .map(|n| {
-                let mut full = prefix.to_vec();
-                full.extend_from_slice(b"::");
+                let mut full = canon.clone();
                 full.extend_from_slice(n);
                 new_string(&full)
             })

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -197,7 +197,7 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     interp.set_result(o);
                     Code::Ok
                 }
-                None => interp.set_error(b"variable \"::tcl_library\" undefined"),
+                None => interp.set_error(b"no library has been specified for Tcl"),
             }
         }
         b"hostname" => {

--- a/runtime/rust/src/cmd_list.rs
+++ b/runtime/rust/src/cmd_list.rs
@@ -112,6 +112,25 @@ fn is_ws(c: u8) -> bool {
     matches!(c, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
 }
 
+/// Whether an index spec is *encodable* the way `TclIndexEncode` requires for
+/// `lsearch`/`lsort -index`: `Some(true)` for a normal index (non-negative
+/// integer, or `end`/`end-N`), `Some(false)` for one that can never be in range
+/// (a negative integer, or `end+N`), and `None` for a syntactically bad spec.
+/// The check is length-independent: it classifies end-relativity by resolving
+/// the spec against two different lengths.
+fn index_encodable(spec: &[u8]) -> Option<bool> {
+    const BIG: usize = 1 << 20;
+    let r_big = index_spec(spec, BIG + 1)?; // None ⇒ syntactically bad
+    let r_small = index_spec(spec, 1)?;
+    if r_big != r_small {
+        // End-relative: encodable iff it lands at or before `end` (offset ≤ 0).
+        Some(r_big - BIG as isize <= 0)
+    } else {
+        // Absolute: encodable iff non-negative.
+        Some(r_big >= 0)
+    }
+}
+
 // -- commands --------------------------------------------------------------
 
 /// `list ?arg ...?` — a list of its arguments.
@@ -808,6 +827,21 @@ fn lsearch(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     Ok(p) => p,
                     Err(e) => return interp.set_error(e.message()),
                 };
+                // C validates each `-index` value's *scale* at parse time
+                // (`TclIndexEncode`): a syntactically-bad spec is `bad index`,
+                // an unencodable one (negative, or `end+N`) is `out of range`.
+                for spec in &index_path {
+                    match index_encodable(spec) {
+                        Some(true) => {}
+                        Some(false) => {
+                            let mut m = b"index \"".to_vec();
+                            m.extend_from_slice(spec);
+                            m.extend_from_slice(b"\" out of range");
+                            return interp.error_with_code(&m, b"TCL VALUE INDEX OUTOFRANGE");
+                        }
+                        None => return bad_index(interp, spec),
+                    }
+                }
                 i += 1;
             }
             other => {
@@ -818,6 +852,13 @@ fn lsearch(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
         i += 1;
+    }
+    // `-subindices` only makes sense alongside `-index` (C's BAD_OPTION_MIX).
+    if subindices && index_path.is_empty() {
+        return interp.error_with_code(
+            b"-subindices cannot be used without -index option",
+            b"TCL OPERATION LSEARCH BAD_OPTION_MIX",
+        );
     }
     let elems = match list::list_elements(argv[n - 2]) {
         Ok(v) => v,
@@ -885,7 +926,7 @@ fn lsearch(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         match crate::regex::Regex::compile(&pattern, flags) {
             Ok(r) => Some(r),
             Err(detail) => {
-                let mut m = b"couldn't compile regular expression pattern: ".to_vec();
+                let mut m = b"cannot compile regular expression pattern: ".to_vec();
                 m.extend_from_slice(&detail);
                 return interp.set_error(&m);
             }
@@ -1001,7 +1042,7 @@ fn lsearch(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 subindices,
                 group,
                 group_offset,
-                &index_path,
+                key_path,
                 listc,
             );
         }
@@ -1016,7 +1057,7 @@ fn lsearch(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         subindices,
         group,
         group_offset,
-        &index_path,
+        key_path,
         listc,
     )
 }
@@ -1032,17 +1073,31 @@ fn lsearch_result_one(
     subindices: bool,
     group: usize,
     group_offset: usize,
-    index_path: &[Vec<u8>],
-    _listc: usize,
+    key_path: &[Vec<u8>],
+    listc: usize,
 ) -> Code {
     if inline {
         if index < 0 {
             interp.set_result_bytes(b"");
+            return Code::Ok;
+        }
+        let base = index as usize;
+        if subindices {
+            // The matched leaf at the resolved sub-path (drilled), or — when the
+            // stride consumed the only `-index` value — the in-group key element.
+            let leaf = if key_path.is_empty() {
+                elems[base + group_offset]
+            } else {
+                match select_by_index(interp, elems[base + group_offset], key_path) {
+                    Ok(o) => o,
+                    Err(c) => return c,
+                }
+            };
+            interp.set_result(leaf);
         } else if group > 1 {
-            let base = index as usize;
             set_list(interp, &elems[base..base + group]);
         } else {
-            interp.set_result(elems[index as usize]);
+            interp.set_result(elems[base]);
         }
         return Code::Ok;
     }
@@ -1051,21 +1106,29 @@ fn lsearch_result_one(
         return Code::Ok;
     }
     if subindices {
-        let mut out = vec![obj::new_wide_int_obj(
-            (index as usize + group_offset) as i64,
-        )];
-        for spec in index_path {
-            out.push(crate::interp::new_string(spec));
-        }
-        let r = list::new_list_obj(&out);
-        for &o in &out {
-            drop_fresh(o);
-        }
+        let r = subindex_obj(index as usize + group_offset, key_path, listc);
         interp.set_result(r);
     } else {
         set_int(interp, index as i64);
     }
     Code::Ok
+}
+
+/// Build a `-subindices` result element: the group base followed by each
+/// remaining `-index` value, decoded the way C's `lsearch` does — end-relative
+/// specs resolve against the top-level list count `listc` (`TclIndexDecode(…,
+/// listc)`), integers pass through.
+fn subindex_obj(base: usize, key_path: &[Vec<u8>], listc: usize) -> *mut TclObj {
+    let mut out = vec![obj::new_wide_int_obj(base as i64)];
+    for spec in key_path {
+        let v = index_spec(spec, listc + 1).unwrap_or(0);
+        out.push(obj::new_wide_int_obj(v as i64));
+    }
+    let r = list::new_list_obj(&out);
+    for &o in &out {
+        drop_fresh(o);
+    }
+    r
 }
 
 /// Build the result of `lsearch -all` (every match).
@@ -1078,27 +1141,37 @@ fn lsearch_result_all(
     subindices: bool,
     group: usize,
     group_offset: usize,
-    index_path: &[Vec<u8>],
-    _listc: usize,
+    key_path: &[Vec<u8>],
+    listc: usize,
 ) -> Code {
     let mut out: Vec<*mut TclObj> = Vec::new();
     let mut fresh: Vec<*mut TclObj> = Vec::new();
     for &base in matches {
         if inline {
-            if group > 1 {
+            if subindices {
+                // Matched leaf (drilled), or the in-group key element when the
+                // stride consumed the only `-index` value.
+                let leaf = if key_path.is_empty() {
+                    elems[base + group_offset]
+                } else {
+                    match select_by_index(interp, elems[base + group_offset], key_path) {
+                        Ok(o) => o,
+                        Err(c) => {
+                            for o in fresh {
+                                drop_fresh(o);
+                            }
+                            return c;
+                        }
+                    }
+                };
+                out.push(leaf);
+            } else if group > 1 {
                 out.extend_from_slice(&elems[base..base + group]);
             } else {
                 out.push(elems[base]);
             }
         } else if subindices {
-            let mut sub = vec![obj::new_wide_int_obj((base + group_offset) as i64)];
-            for spec in index_path {
-                sub.push(crate::interp::new_string(spec));
-            }
-            let s = list::new_list_obj(&sub);
-            for &o in &sub {
-                drop_fresh(o);
-            }
+            let s = subindex_obj(base + group_offset, key_path, listc);
             fresh.push(s);
             out.push(s);
         } else {

--- a/runtime/rust/src/cmd_mathfunc.rs
+++ b/runtime/rust/src/cmd_mathfunc.rs
@@ -49,6 +49,18 @@ fn mathfunc(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.set_error(b"unknown math function");
     };
 
+    // Argument-count check first (C reports this before operand conversion), with
+    // `-errorcode TCL WRONGARGS`.
+    let lname = fname.to_ascii_lowercase();
+    let (amin, amax) = arity(&lname);
+    let n = argv.len() - 1;
+    if n < amin {
+        return wrong_func_args(interp, b"not enough arguments for math function \"", fname);
+    }
+    if amax.is_some_and(|m| n > m) {
+        return wrong_func_args(interp, b"too many arguments for math function \"", fname);
+    }
+
     // Operands → Num (object-preserving: a bignum/double keeps its rep).
     let nums: Option<Vec<Num>> = argv[1..]
         .iter()
@@ -59,7 +71,7 @@ fn mathfunc(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
 
     // `set_result` adopts a fresh rc-0 obj (retains it; no extra drop needed).
-    match dispatch(&fname.to_ascii_lowercase(), &nums) {
+    match dispatch(&lname, &nums) {
         Some(Num::Int(i)) => {
             interp.set_result(obj::new_wide_int_obj(i));
             Code::Ok
@@ -68,10 +80,33 @@ fn mathfunc(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result(obj::new_double_obj(f));
             Code::Ok
         }
-        // A *registered* name reaching `None` is a domain / arg-count error
-        // (unknown names never resolve to this builtin — they miss the table).
-        None => interp.set_error(b"domain error: argument not in valid range"),
+        // A registered name with the right arity reaching `None` is a domain
+        // error (e.g. `sqrt(-1)`), with `-errorcode ARITH DOMAIN`.
+        None => interp.error_with_code(
+            b"domain error: argument not in valid range",
+            b"ARITH DOMAIN {domain error: argument not in valid range}",
+        ),
     }
+}
+
+/// `(min, max)` argument count for a math function (`max` = `None` ⇒ unbounded).
+/// Every name reaching the builtin is registered, so unknowns can't occur; the
+/// default is the unary `(1, 1)`.
+fn arity(name: &str) -> (usize, Option<usize>) {
+    match name {
+        "min" | "max" => (1, None),
+        "atan2" | "hypot" | "fmod" | "pow" => (2, Some(2)),
+        _ => (1, Some(1)),
+    }
+}
+
+/// `{not enough|too many} arguments for math function "NAME"` with
+/// `-errorcode TCL WRONGARGS`.
+fn wrong_func_args(interp: &mut Interp, prefix: &[u8], fname: &str) -> Code {
+    let mut m = prefix.to_vec();
+    m.extend_from_slice(fname.as_bytes());
+    m.push(b'"');
+    interp.error_with_code(&m, b"TCL WRONGARGS")
 }
 
 #[cfg(test)]

--- a/runtime/rust/src/cmd_mathfunc.rs
+++ b/runtime/rust/src/cmd_mathfunc.rs
@@ -61,6 +61,22 @@ fn mathfunc(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_func_args(interp, b"too many arguments for math function \"", fname);
     }
 
+    // `wide`/`int`/`entier` on an *integer* operand work on the tower directly,
+    // not via the f64-limited shared dispatch: `wide` wraps a too-big integer to
+    // a 64-bit signed value (C's truncation), and `int`/`entier` keep the
+    // (possibly bignum) integer exactly. (A *float* operand falls through to the
+    // shared dispatch.)
+    if matches!(lname.as_str(), "wide" | "int" | "entier") && crate::bignum::is_integer(argv[1]) {
+        if lname == "wide" {
+            interp.set_result(obj::new_wide_int_obj(crate::bignum::truncate_to_wide(
+                argv[1],
+            )));
+        } else {
+            interp.set_result(argv[1]); // integer is its own int/entier
+        }
+        return Code::Ok;
+    }
+
     // Operands → Num (object-preserving: a bignum/double keeps its rep).
     let nums: Option<Vec<Num>> = argv[1..]
         .iter()

--- a/runtime/rust/src/cmd_mathop.rs
+++ b/runtime/rust/src/cmd_mathop.rs
@@ -37,7 +37,15 @@ pub fn install(interp: &mut Interp) {
 type BinOpFn = fn(*mut TclObj, *mut TclObj) -> Result<*mut TclObj, ArithError>;
 
 fn arith_error(interp: &mut Interp, e: ArithError) -> Code {
-    interp.set_error(&crate::expr::arith_err(e).0)
+    expr_error(interp, crate::expr::arith_err(e))
+}
+
+/// Raise an `ExprError`, honouring its optional `-errorcode`.
+fn expr_error(interp: &mut Interp, e: crate::expr::ExprError) -> Code {
+    match e.code {
+        Some(c) => interp.error_with_code(&e.msg, &c),
+        None => interp.set_error(&e.msg),
+    }
 }
 
 /// `wrong # args: should be "::tcl::mathop::<op> <usage>"`.
@@ -92,7 +100,7 @@ fn mathop(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
             match crate::expr::to_bool(args[0]) {
                 Ok(b) => bool_result(interp, !b),
-                Err(e) => interp.set_error(&e.0),
+                Err(e) => expr_error(interp, e),
             }
         }
         // Chained comparisons (vacuously true for <2 args).

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -52,6 +52,7 @@ const NAMESPACE_SUBS: &[&[u8]] = &[
     b"path",
     b"qualifiers",
     b"tail",
+    b"unknown",
     b"upvar",
     b"which",
 ];
@@ -74,7 +75,7 @@ fn namespace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             _ => {
                 let mut m = b"unknown or ambiguous subcommand \"".to_vec();
                 m.extend_from_slice(&raw);
-                m.extend_from_slice(b"\": must be children, code, current, delete, ensemble, eval, exists, export, forget, import, inscope, origin, parent, path, qualifiers, tail, upvar, or which");
+                m.extend_from_slice(b"\": must be children, code, current, delete, ensemble, eval, exists, export, forget, import, inscope, origin, parent, path, qualifiers, tail, unknown, upvar, or which");
                 return interp.set_error(&m);
             }
         }
@@ -97,12 +98,43 @@ fn namespace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"ensemble" => ns_ensemble(interp, argv),
         b"inscope" => ns_inscope(interp, argv),
         b"code" => ns_code(interp, argv),
+        b"unknown" => ns_unknown(interp, argv),
         b"upvar" => ns_upvar(interp, argv),
         _ => unreachable!("subcommand resolved to a canonical name above"),
     }
 }
 
 // -- current / eval / exists / parent / children ---------------------------
+
+/// `namespace unknown ?handler?` — get or set the current namespace's
+/// unknown-command handler. The global namespace's default is `::unknown`; a
+/// sub-namespace with no handler reports the empty string (and falls back to
+/// `::unknown` at dispatch). Mirrors `NamespaceUnknownCmd` (`tclNamesp.c`).
+fn ns_unknown(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() > 3 {
+        return wrong_args(interp, b"namespace unknown ?script?");
+    }
+    let cur = interp.current_ns();
+    if argv.len() == 3 {
+        let handler = obj_bytes(argv[2]);
+        // The handler must be a well-formed list (command prefix); a parse error
+        // is reported *without* changing the current handler (namespace-52.12).
+        if let Err(e) = crate::parse::split_list(&handler) {
+            return interp.set_error(e.message());
+        }
+        interp.namespaces_mut().set_unknown_handler(cur, &handler);
+        interp.set_result_bytes(b"");
+        return Code::Ok;
+    }
+    // Get: the stored handler, or the interpreter default for the global ns.
+    let h = interp.namespaces().unknown_handler(cur).map(<[u8]>::to_vec);
+    match h {
+        Some(h) => interp.set_result_bytes(&h),
+        None if cur == crate::namespace::GLOBAL => interp.set_result_bytes(b"::unknown"),
+        None => interp.set_result_bytes(b""),
+    }
+    Code::Ok
+}
 
 /// `namespace current` — the FQN of the current namespace.
 fn ns_current(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -178,6 +178,11 @@ fn ns_eval(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"namespace eval name arg ?arg...?");
     }
     let name = obj_bytes(argv[2]);
+    // A single body argument keeps its `Tcl_Obj` so a located literal runs as
+    // `type source` (TIP 280); multiple args concatenate into a dynamic body.
+    if argv.len() == 4 {
+        return interp.ns_eval_obj(&name, argv[3]);
+    }
     let mut body = Vec::new();
     for (i, &a) in argv[3..].iter().enumerate() {
         if i > 0 {

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -677,14 +677,26 @@ fn ns_ensemble(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 {
         return wrong_args(interp, b"namespace ensemble subcommand ?arg ...?");
     }
-    match obj_bytes(argv[2]).as_slice() {
+    // Subcommands resolve by exact name or unambiguous prefix (Tcl's index table).
+    let sub = obj_bytes(argv[2]);
+    const ENS_SUBS: [&[u8]; 3] = [b"configure", b"create", b"exists"];
+    let resolved: &[u8] = if let Some(&exact) = ENS_SUBS.iter().find(|s| **s == sub.as_slice()) {
+        exact
+    } else {
+        let mut it = ENS_SUBS.iter().filter(|s| s.starts_with(sub.as_slice()));
+        match (it.next(), it.next()) {
+            (Some(&c), None) => c,
+            _ => b"",
+        }
+    };
+    match resolved {
         b"create" => ens_create(interp, argv),
         b"exists" => ens_exists(interp, argv),
-        other => {
-            // `configure` is a follow-up; only create/exists are modelled.
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be create, or exists");
+        b"configure" => ens_configure(interp, argv),
+        _ => {
+            let mut m = b"bad subcommand \"".to_vec();
+            m.extend_from_slice(&sub);
+            m.extend_from_slice(b"\": must be configure, create, or exists");
             interp.set_error(&m)
         }
     }
@@ -696,55 +708,197 @@ fn ens_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let ns = interp.current_ns();
     // Default ensemble command is the namespace's own FQN.
     let mut command = interp.namespaces().qualified_name(ns);
-    let mut map: Option<EnsembleMap> = None;
-    let mut subcommands: Option<Vec<Vec<u8>>> = None;
-    let mut prefixes = true;
+    let mut cfg = EnsembleConfig {
+        ns,
+        map: None,
+        subcommands: None,
+        prefixes: true,
+        parameters: Vec::new(),
+        unknown: Vec::new(),
+    };
 
     let opts = &argv[3..];
     if opts.len() % 2 != 0 {
         return interp.set_error(b"missing value for option");
     }
     for pair in opts.chunks_exact(2) {
-        let (opt, val) = (obj_bytes(pair[0]), pair[1]);
-        match opt.as_slice() {
-            b"-command" => command = obj_bytes(val),
-            b"-subcommands" => match crate::parse::split_list(&obj_bytes(val)) {
-                Ok(list) => subcommands = Some(list),
-                Err(e) => return interp.set_error(e.message()),
-            },
-            b"-map" => match parse_map(&obj_bytes(val)) {
-                Ok(m) => map = Some(m),
-                Err(e) => return interp.set_error(&e),
-            },
-            b"-prefixes" => match parse_bool(&obj_bytes(val)) {
-                Some(b) => prefixes = b,
-                None => {
-                    let mut m = b"expected boolean value but got \"".to_vec();
-                    m.extend_from_slice(&obj_bytes(val));
-                    m.push(b'"');
-                    return interp.set_error(&m);
-                }
-            },
-            _ => {
-                let mut m = b"bad option \"".to_vec();
-                m.extend_from_slice(&opt);
-                m.extend_from_slice(b"\": should be -command, -map, -prefixes, or -subcommands");
-                return interp.set_error(&m);
-            }
+        let opt = obj_bytes(pair[0]);
+        // `-command` (create-only) names the ensemble command; the rest are the
+        // shared configuration options.
+        if opt.as_slice() == b"-command" {
+            command = obj_bytes(pair[1]);
+            continue;
+        }
+        if let Err(e) = apply_ensemble_option(&mut cfg, &opt, &obj_bytes(pair[1])) {
+            return interp.set_error(&e);
         }
     }
 
-    interp.create_ensemble(
-        &command,
-        EnsembleConfig {
-            ns,
-            map,
-            subcommands,
-            prefixes,
-        },
-    );
+    interp.create_ensemble(&command, cfg);
     interp.set_result_bytes(&command);
     Code::Ok
+}
+
+/// Apply one `-option value` to an [`EnsembleConfig`] (shared by `namespace
+/// ensemble create` and `configure`). Returns the C error text on a bad option
+/// or value.
+fn apply_ensemble_option(cfg: &mut EnsembleConfig, opt: &[u8], val: &[u8]) -> Result<(), Vec<u8>> {
+    match opt {
+        b"-subcommands" => {
+            cfg.subcommands =
+                Some(crate::parse::split_list(val).map_err(|e| e.message().to_vec())?);
+        }
+        b"-map" => {
+            // An empty `-map` clears it (C: a zero-length dict ⇒ no map).
+            let m = parse_map(val)?;
+            cfg.map = if m.is_empty() { None } else { Some(m) };
+        }
+        b"-parameters" => {
+            cfg.parameters = crate::parse::split_list(val).map_err(|e| e.message().to_vec())?;
+        }
+        b"-unknown" => {
+            cfg.unknown = crate::parse::split_list(val).map_err(|e| e.message().to_vec())?;
+        }
+        b"-prefixes" => {
+            cfg.prefixes = parse_bool(val).ok_or_else(|| {
+                let mut m = b"expected boolean value but got \"".to_vec();
+                m.extend_from_slice(val);
+                m.push(b'"');
+                m
+            })?;
+        }
+        _ => {
+            let mut m = b"bad option \"".to_vec();
+            m.extend_from_slice(opt);
+            m.extend_from_slice(
+                b"\": must be -command, -map, -parameters, -prefixes, -subcommands, or -unknown",
+            );
+            return Err(m);
+        }
+    }
+    Ok(())
+}
+
+/// `namespace ensemble configure cmd ?-option? ?value …?` — read or update an
+/// existing ensemble's configuration (`tclEnsemble.c`). No options: a dict of
+/// all settings; one bare `-option`: its value; `-option value …` pairs: update.
+fn ens_configure(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 4 {
+        return wrong_args(
+            interp,
+            b"namespace ensemble configure cmdname ?-option value ...? ?arg ...?",
+        );
+    }
+    let cmd = obj_bytes(argv[3]);
+    let Some(mut cfg) = interp.ensemble_config(&cmd) else {
+        // Distinguish a missing command from a non-ensemble one (C's wording).
+        if interp.command_exists(&cmd) {
+            let mut m = b"\"".to_vec();
+            m.extend_from_slice(&cmd);
+            m.extend_from_slice(b"\" is not an ensemble command");
+            return interp.set_error(&m);
+        }
+        let mut m = b"unknown command \"".to_vec();
+        m.extend_from_slice(&cmd);
+        m.push(b'"');
+        return interp.set_error(&m);
+    };
+    let rest = &argv[4..];
+    // Read all options as a dict.
+    if rest.is_empty() {
+        let d = ensemble_config_dict(interp, &cfg);
+        interp.set_result_bytes(&d);
+        return Code::Ok;
+    }
+    // Read a single option's value.
+    if rest.len() == 1 {
+        let opt = obj_bytes(rest[0]);
+        match ensemble_option_value(interp, &cfg, &opt) {
+            Some(v) => {
+                interp.set_result_bytes(&v);
+                Code::Ok
+            }
+            None => {
+                let mut m = b"bad option \"".to_vec();
+                m.extend_from_slice(&opt);
+                m.extend_from_slice(b"\": must be -map, -namespace, -parameters, -prefixes, -subcommands, or -unknown");
+                interp.set_error(&m)
+            }
+        }
+    } else {
+        // Update: `-option value` pairs.
+        if rest.len() % 2 != 0 {
+            return interp.set_error(b"missing value for option");
+        }
+        for pair in rest.chunks_exact(2) {
+            if let Err(e) =
+                apply_ensemble_option(&mut cfg, &obj_bytes(pair[0]), &obj_bytes(pair[1]))
+            {
+                return interp.set_error(&e);
+            }
+        }
+        interp.set_ensemble_config(&cmd, cfg);
+        interp.set_result_bytes(b"");
+        Code::Ok
+    }
+}
+
+/// One ensemble `configure`/cget option's value (string form).
+fn ensemble_option_value(interp: &Interp, cfg: &EnsembleConfig, opt: &[u8]) -> Option<Vec<u8>> {
+    Some(match opt {
+        b"-namespace" => interp.namespaces().qualified_name(cfg.ns),
+        b"-prefixes" => {
+            if cfg.prefixes {
+                b"1".to_vec()
+            } else {
+                b"0".to_vec()
+            }
+        }
+        b"-parameters" => join_words(&cfg.parameters),
+        b"-unknown" => join_words(&cfg.unknown),
+        b"-subcommands" => cfg
+            .subcommands
+            .as_deref()
+            .map(join_words)
+            .unwrap_or_default(),
+        b"-map" => match &cfg.map {
+            Some(m) => {
+                let mut flat: Vec<Vec<u8>> = Vec::with_capacity(m.len() * 2);
+                for (k, prefix) in m {
+                    flat.push(k.clone());
+                    flat.push(join_words(prefix));
+                }
+                join_words(&flat)
+            }
+            None => Vec::new(),
+        },
+        _ => return None,
+    })
+}
+
+/// Join words into a Tcl list string.
+fn join_words(words: &[Vec<u8>]) -> Vec<u8> {
+    let strs: Vec<std::borrow::Cow<str>> =
+        words.iter().map(|w| String::from_utf8_lossy(w)).collect();
+    tcl_syntax::list::join_list(strs.iter()).into_bytes()
+}
+
+/// The full `-option value …` dict an ensemble's `configure` (no args) returns,
+/// in C's alphabetical option order.
+fn ensemble_config_dict(interp: &Interp, cfg: &EnsembleConfig) -> Vec<u8> {
+    let mut pairs: Vec<Vec<u8>> = Vec::new();
+    for opt in [
+        &b"-map"[..],
+        b"-namespace",
+        b"-parameters",
+        b"-prefixes",
+        b"-subcommands",
+        b"-unknown",
+    ] {
+        pairs.push(opt.to_vec());
+        pairs.push(ensemble_option_value(interp, cfg, opt).unwrap_or_default());
+    }
+    join_words(&pairs)
 }
 
 /// `namespace ensemble exists command` — 1 if it resolves to an ensemble.

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -472,11 +472,9 @@ fn ns_path(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
     let mut path: Vec<NsId> = Vec::with_capacity(elems.len());
     for e in &elems {
-        let Some(ns) = interp.namespaces().find_namespace(cur, e) else {
-            let mut m = b"namespace \"".to_vec();
-            m.extend_from_slice(e);
-            m.extend_from_slice(b"\" not found");
-            return interp.set_error(&m);
+        let found = interp.namespaces().find_namespace(cur, e);
+        let Some(ns) = found else {
+            return ns_not_found(interp, e);
         };
         path.push(ns);
     }

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -197,7 +197,21 @@ fn ns_children(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(ns) => ns,
         Err(code) => return code,
     };
-    let pattern = argv.get(3).map(|&a| obj_bytes(a));
+    // The pattern matches against children's *fully-qualified* names, so a
+    // pattern without a leading `::` is qualified with the target namespace's
+    // full name first (C's `NamespaceChildrenCmd`).
+    let pattern = argv.get(3).map(|&a| obj_bytes(a)).map(|p| {
+        if p.starts_with(b"::") {
+            p
+        } else {
+            let mut full = interp.namespaces().qualified_name(ns);
+            if full != b"::" {
+                full.extend_from_slice(b"::");
+            }
+            full.extend_from_slice(&p);
+            full
+        }
+    });
     let mut names: Vec<Vec<u8>> = interp
         .namespaces()
         .children(ns)

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -469,15 +469,30 @@ fn resolve_arg_ns(
             let found = interp.namespaces().find_namespace(current, &name);
             match found {
                 Some(ns) => Ok(ns),
-                None => {
-                    let mut m = b"namespace \"".to_vec();
-                    m.extend_from_slice(&name);
-                    m.extend_from_slice(b"\" not found");
-                    Err(interp.set_error(&m))
-                }
+                None => Err(ns_not_found(interp, &name)),
             }
         }
     }
+}
+
+/// The `TclGetNamespaceFromObj` not-found error: a *relative* name names the
+/// current namespace context (`… not found in "::ns"`), an absolute one does not
+/// (`… not found`). Sets `-errorcode TCL LOOKUP NAMESPACE <name>`.
+fn ns_not_found(interp: &mut Interp, name: &[u8]) -> Code {
+    let mut m = b"namespace \"".to_vec();
+    m.extend_from_slice(name);
+    if name.starts_with(b"::") {
+        m.extend_from_slice(b"\" not found");
+    } else {
+        m.extend_from_slice(b"\" not found in \"");
+        let cur = interp.namespaces().qualified_name(interp.current_ns());
+        m.extend_from_slice(&cur);
+        m.push(b'"');
+    }
+    let code = tcl_syntax::list::join_list(
+        ["TCL", "LOOKUP", "NAMESPACE", &String::from_utf8_lossy(name)].iter(),
+    );
+    interp.error_with_code(&m, code.as_bytes())
 }
 
 /// Does the dest namespace hold a command of this name?
@@ -626,10 +641,7 @@ fn ns_upvar(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         .namespaces()
         .find_namespace(interp.current_ns(), &ns_name)
     else {
-        let mut m = b"namespace \"".to_vec();
-        m.extend_from_slice(&ns_name);
-        m.extend_from_slice(b"\" not found");
-        return interp.set_error(&m);
+        return ns_not_found(interp, &ns_name);
     };
 
     let mut i = 3;

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -49,8 +49,7 @@ fn proc_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Ok(p) => p,
         Err(e) => return interp.set_error(&e),
     };
-    let body = obj_bytes(argv[3]);
-    interp.define_proc(&name, params, body);
+    interp.define_proc(&name, params, argv[3]);
     interp.set_result_bytes(b"");
     Code::Ok
 }

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -34,6 +34,17 @@ fn proc_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return wrong_args(interp, b"proc name args body");
     }
     let name = obj_bytes(argv[1]);
+    // A namespace-qualified proc name requires that namespace to already exist
+    // (C's `Tcl_ProcObjCmd` via `TclGetNamespaceForQualName`).
+    if let Some(i) = name.windows(2).rposition(|w| w == b"::") {
+        let qualifier = &name[..i];
+        if !qualifier.is_empty() && interp.find_namespace_id(qualifier).is_none() {
+            let mut m = b"can't create procedure \"".to_vec();
+            m.extend_from_slice(&name);
+            m.extend_from_slice(b"\": unknown namespace");
+            return interp.set_error(&m);
+        }
+    }
     let params = match parse_params(&obj_bytes(argv[2])) {
         Ok(p) => p,
         Err(e) => return interp.set_error(&e),

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -110,6 +110,12 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     } else {
         crate::namespace::GLOBAL
     };
+    // A literal lambda in a sourced file reports `type source` at its body's line
+    // (element 1 of the lambda list — TIP 280); a dynamic lambda is body-relative.
+    let (source, body_line_base) = match interp.list_element_location(argv[1], 1) {
+        Some((file, line)) => (Some(file), line.saturating_sub(1)),
+        None => (None, 0),
+    };
     interp.run_proc(
         &params,
         &parts[1],
@@ -119,8 +125,8 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         CallMeta {
             err: ProcFrame::Lambda(&lambda),
             fqn: None,
-            source: None,
-            body_line_base: 0,
+            source,
+            body_line_base,
             link_vars: &[],
             keep_loop_codes: false,
             same_level: false,

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -836,14 +836,16 @@ fn str_map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// The recognised `string is` classes, for the bad-class diagnostic and to
-/// reject unknown classes before scanning.
+/// The recognised `string is` classes, in C's declaration order (`tclCmdMZ.c`
+/// `StringIsCmd`'s `isClasses[]`). The order is significant: it drives the
+/// `bad class`/`ambiguous class` "must be …" diagnostic, and the class is
+/// resolved against this table by exact name or unambiguous prefix.
 const IS_CLASSES: &[&[u8]] = &[
     b"alnum",
     b"alpha",
     b"ascii",
-    b"boolean",
     b"control",
+    b"boolean",
     b"dict",
     b"digit",
     b"double",
@@ -863,101 +865,277 @@ const IS_CLASSES: &[&[u8]] = &[
     b"xdigit",
 ];
 
+/// `string is` option table (for the `-strict`/`-failindex` prefix match).
+const IS_OPTIONS: &[&[u8]] = &[b"-strict", b"-failindex"];
+
+/// The outcome of an exact/unambiguous-prefix table lookup (`Tcl_GetIndexFromObj`).
+enum Lookup {
+    /// Resolved to `table[index]` (exact match, or a unique prefix).
+    Found(usize),
+    /// The prefix matched more than one entry.
+    Ambiguous,
+    /// No entry matched.
+    None,
+}
+
+/// Resolve `arg` against `table` like `Tcl_GetIndexFromObj` (flags 0): an exact
+/// match wins, else a *unique* prefix; ambiguous and no-match are distinguished
+/// so the caller can emit `bad`/`ambiguous` as C does.
+fn index_lookup(table: &[&[u8]], arg: &[u8]) -> Lookup {
+    if let Some(i) = table.iter().position(|s| *s == arg) {
+        return Lookup::Found(i);
+    }
+    // A leading "-" with nothing after is not treated as an option/class prefix
+    // by Tcl_GetIndexFromObj; an empty arg matches nothing.
+    if arg.is_empty() {
+        return Lookup::None;
+    }
+    let mut found = None;
+    for (i, s) in table.iter().enumerate() {
+        if s.starts_with(arg) {
+            if found.is_some() {
+                return Lookup::Ambiguous;
+            }
+            found = Some(i);
+        }
+    }
+    match found {
+        Some(i) => Lookup::Found(i),
+        None => Lookup::None,
+    }
+}
+
 /// `string is class ?-strict? ?-failindex var? string`. Returns 1/0; with
-/// `-failindex`, stores the first failing character index (or -1) in `var`.
-/// Empty input is a class member unless `-strict`.
+/// `-failindex`, stores the first failing character index in `var` — but **only
+/// when the result is 0** (`StringIsCmd`). Empty input is a class member unless
+/// `-strict` (except `list`/`dict`, which ignore `-strict`).
 fn str_is(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     const USAGE: &[u8] = b"string is class ?-strict? ?-failindex var? str";
-    // Bad arg count uses the generic "class"; an option error past a valid class
-    // names the class (C's `Tcl_WrongNumArgs(interp, 2, …)`).
     if argv.len() < 4 || argv.len() > 7 {
         return wrong_args(interp, USAGE);
     }
-    let class = obj_bytes(argv[2]);
-    if !IS_CLASSES.contains(&class.as_slice()) {
-        let mut m = b"bad class \"".to_vec();
-        m.extend_from_slice(&class);
-        m.extend_from_slice(b"\": must be alnum, alpha, ascii, boolean, control, dict, digit, double, entier, false, graph, integer, list, lower, print, punct, space, true, upper, wideinteger, wordchar, or xdigit");
-        return interp.set_error(&m);
-    }
-    let class_usage = || {
-        let mut m = b"string is ".to_vec();
-        m.extend_from_slice(&class);
-        m.extend_from_slice(b" ?-strict? ?-failindex var? str");
-        m
+    let class_arg = obj_bytes(argv[2]);
+    let class: &[u8] = match index_lookup(IS_CLASSES, &class_arg) {
+        Lookup::Found(i) => IS_CLASSES[i],
+        Lookup::Ambiguous => return interp.set_error(&class_err(b"ambiguous class", &class_arg)),
+        Lookup::None => return interp.set_error(&class_err(b"bad class", &class_arg)),
     };
 
+    // The last argument is always the string under test; the args between the
+    // class and it are options (`Tcl_GetIndexFromObj` over IS_OPTIONS).
     let last = argv.len() - 1;
     let mut strict = false;
     let mut failvar: Option<Vec<u8>> = None;
     let mut k = 3;
     while k < last {
         let opt = obj_bytes(argv[k]);
-        // Options match by unambiguous prefix (C's `Tcl_GetIndexFromObj`).
-        if !opt.is_empty() && b"-strict".starts_with(opt.as_slice()) {
-            k += 1;
-        } else if !opt.is_empty() && b"-failindex".starts_with(opt.as_slice()) {
-            if k + 1 >= last {
-                return wrong_args(interp, &class_usage());
+        match index_lookup(IS_OPTIONS, &opt) {
+            Lookup::Found(0) => {
+                strict = true;
+                k += 1;
             }
-            failvar = Some(obj_bytes(argv[k + 1]));
-            k += 2;
-        } else {
-            return wrong_args(interp, &class_usage());
-        }
-    }
-    // `-strict` may appear after `-failindex`; rescan for it (order-free).
-    for &a in &argv[3..last] {
-        let o = obj_bytes(a);
-        if !o.is_empty() && b"-strict".starts_with(o.as_slice()) {
-            strict = true;
+            Lookup::Found(_) => {
+                if k + 1 >= last {
+                    // C names the resolved class here (`string is double …`), not
+                    // the generic "class" the arg-count check uses.
+                    let mut usage = b"string is ".to_vec();
+                    usage.extend_from_slice(class);
+                    usage.extend_from_slice(b" ?-strict? ?-failindex var? str");
+                    return wrong_args(interp, &usage);
+                }
+                failvar = Some(obj_bytes(argv[k + 1]));
+                k += 2;
+            }
+            Lookup::Ambiguous => return interp.set_error(&option_err(b"ambiguous option", &opt)),
+            Lookup::None => return interp.set_error(&option_err(b"bad option", &opt)),
         }
     }
 
     let s = obj_bytes(argv[last]);
-    let chars: Vec<char> = String::from_utf8_lossy(&s).chars().collect();
+    let (ok, fail_index) = class_check(class, &s, strict);
 
-    let (ok, fail_index): (bool, i64) = if chars.is_empty() {
-        (!strict, -1)
-    } else {
-        match class.as_slice() {
-            b"integer" | b"wideinteger" | b"entier" => whole(is_tcl_integer(&chars), &chars),
-            b"double" => whole(is_tcl_double(&chars), &chars),
-            b"boolean" | b"true" | b"false" => whole(is_tcl_boolean(&chars, &class), &chars),
-            b"list" => whole(crate::parse::split_list(&s).is_ok(), &chars),
-            b"dict" => whole(
-                crate::parse::split_list(&s).is_ok_and(|l| l.len() % 2 == 0),
-                &chars,
-            ),
-            _ => {
-                // Per-character class: first failing char index.
-                match chars.iter().position(|&c| !char_class_ok(&class, c)) {
-                    Some(i) => (false, i as i64),
-                    None => (true, -1),
-                }
+    if !ok {
+        if let Some(var) = failvar {
+            let o = obj::new_wide_int_obj(fail_index);
+            if interp.var_set(&var, o).is_err() {
+                drop_fresh(o);
+                return cant_set(interp, &var);
             }
-        }
-    };
-
-    if let Some(var) = failvar {
-        let o = obj::new_wide_int_obj(if ok { -1 } else { fail_index });
-        if interp.var_set(&var, o).is_err() {
-            drop_fresh(o);
-            return cant_set(interp, &var);
         }
     }
     interp.set_result_bytes(if ok { b"1" } else { b"0" });
     Code::Ok
 }
 
-/// A whole-string class result: on failure the fail index is the length (no
-/// single offending char to point at), matching Tcl's behaviour closely enough
-/// for the classes the library exercises.
-fn whole(ok: bool, chars: &[char]) -> (bool, i64) {
-    if ok {
-        (true, -1)
+/// `bad class "X": must be …` / `ambiguous class "X": must be …`.
+fn class_err(kind: &[u8], arg: &[u8]) -> Vec<u8> {
+    let mut m = kind.to_vec();
+    m.extend_from_slice(b" \"");
+    m.extend_from_slice(arg);
+    m.extend_from_slice(b"\": must be ");
+    let classes: Vec<Vec<u8>> = IS_CLASSES.iter().map(|s| s.to_vec()).collect();
+    m.extend_from_slice(&crate::ensemble::must_be(&classes));
+    m
+}
+
+/// `bad option "X": must be -strict or -failindex` (two-item form: no comma).
+fn option_err(kind: &[u8], arg: &[u8]) -> Vec<u8> {
+    let mut m = kind.to_vec();
+    m.extend_from_slice(b" \"");
+    m.extend_from_slice(arg);
+    m.extend_from_slice(b"\": must be -strict or -failindex");
+    m
+}
+
+/// Run the class membership test. Returns `(is_member, fail_index)`; the fail
+/// index (a **character** offset, or -1) is only meaningful when not a member.
+fn class_check(class: &[u8], s: &[u8], strict: bool) -> (bool, i64) {
+    match class {
+        b"integer" | b"wideinteger" | b"entier" | b"double" => is_number_class(class, s, strict),
+        b"boolean" | b"true" | b"false" => is_boolean_class(class, s, strict),
+        b"list" => {
+            // `list`/`dict` ignore strictness (empty is a well-formed list).
+            if crate::parse::split_list(s).is_ok() {
+                (true, -1)
+            } else {
+                (false, char_count(s) as i64)
+            }
+        }
+        b"dict" => {
+            if crate::parse::split_list(s).is_ok_and(|l| l.len() % 2 == 0) {
+                (true, -1)
+            } else {
+                (false, char_count(s) as i64)
+            }
+        }
+        _ => {
+            // Per-character class: first failing char index.
+            if s.is_empty() {
+                return (!strict, 0);
+            }
+            for (failat, c) in String::from_utf8_lossy(s).chars().enumerate() {
+                if !char_class_ok(class, c) {
+                    return (false, failat as i64);
+                }
+            }
+            (true, -1)
+        }
+    }
+}
+
+/// Tcl numeric whitespace (matches `tcl_syntax::number`'s internal set): space,
+/// tab, newline, VT, FF, CR. `TclParseNumber` consumes a surrounding run of it.
+#[inline]
+fn is_num_ws(c: u8) -> bool {
+    matches!(c, b' ' | b'\t' | b'\n' | 0x0b | 0x0c | b'\r')
+}
+
+/// `string is integer|wideinteger|entier|double`. Defers to the shared
+/// `TclParseNumber` port: surrounding whitespace is allowed, the fail index is
+/// where parsing stopped, and `wideinteger` reports -1 on a value that parses
+/// but overflows a wide.
+fn is_number_class(class: &[u8], s: &[u8], strict: bool) -> (bool, i64) {
+    use tcl_syntax::number::{self, Number, ParseFlags};
+
+    if s.is_empty() {
+        return (!strict, 0);
+    }
+    let Ok(st) = std::str::from_utf8(s) else {
+        return (false, 0);
+    };
+    let is_double = class == b"double";
+    let flags = ParseFlags {
+        integer_only: !is_double,
+        ..Default::default()
+    };
+    let Some(p) = number::parse(st, flags) else {
+        return (false, 0); // no numeric prefix at all → fail at the start
+    };
+    // For the integer classes, reject the `Inf`/`NaN` alpha forms that the
+    // shared parser still classifies (C's `TCL_PARSE_INTEGER_ONLY` would not).
+    let is_int_val = matches!(p.number, Number::Int(_) | Number::Big { .. });
+    if !is_double && !is_int_val {
+        return (false, 0);
+    }
+    // `TclParseNumber`'s end-pointer consumes a trailing whitespace run.
+    let mut stop = p.end;
+    while stop < s.len() && is_num_ws(s[stop]) {
+        stop += 1;
+    }
+    if stop < s.len() {
+        // Some prefix parsed, but not the whole string. The fail index equals
+        // the byte stop (everything up to it is ASCII ws/digits, so byte == char).
+        return (false, stop as i64);
+    }
+    // The entire string is a number.
+    if class == b"wideinteger" {
+        match p.number {
+            Number::Int(_) => (true, -1),
+            _ => (false, -1), // a valid integer, but it overflows a wide
+        }
     } else {
-        (false, chars.len() as i64)
+        (true, -1)
+    }
+}
+
+/// `string is boolean|true|false`. A non-member fails at index 0 (the whole
+/// string is rejected as one unit).
+fn is_boolean_class(class: &[u8], s: &[u8], strict: bool) -> (bool, i64) {
+    match parse_boolean(s) {
+        Some(v) => {
+            let member = match class {
+                b"true" => v,
+                b"false" => !v,
+                _ => true,
+            };
+            (member, 0)
+        }
+        None => {
+            if strict {
+                (false, 0)
+            } else {
+                // Non-strict: empty is a member; anything else is not.
+                (s.is_empty(), 0)
+            }
+        }
+    }
+}
+
+/// `Tcl_GetBoolean`'s `ParseBoolean` (`tclObj.c`): `0`/`1`, or a case-insensitive
+/// unambiguous prefix of `true`/`false`/`yes`/`no`/`on`/`off`. Returns the
+/// boolean value, or `None` when the string is not a valid boolean.
+fn parse_boolean(s: &[u8]) -> Option<bool> {
+    let len = s.len();
+    if !(1..=5).contains(&len) {
+        return None; // "false" is the longest valid spelling
+    }
+    match s[0] {
+        b'0' => return (len == 1).then_some(false),
+        b'1' => return (len == 1).then_some(true),
+        _ => {}
+    }
+    // Lower-case, rejecting any byte outside the boolean-keyword letter set.
+    let mut lower = [0u8; 5];
+    for (i, &c) in s.iter().enumerate() {
+        let lc = c.to_ascii_lowercase();
+        if !matches!(
+            lc,
+            b'a' | b'e' | b'f' | b'l' | b'n' | b'o' | b'r' | b's' | b't' | b'u' | b'y'
+        ) {
+            return None;
+        }
+        lower[i] = lc;
+    }
+    let lc = &lower[..len];
+    // `strncmp(lc, keyword, len) == 0` ⇔ `keyword.starts_with(lc)`.
+    match lc[0] {
+        b'y' => b"yes".starts_with(lc).then_some(true),
+        b'n' => b"no".starts_with(lc).then_some(false),
+        b't' => b"true".starts_with(lc).then_some(true),
+        b'f' => b"false".starts_with(lc).then_some(false),
+        b'o' if len >= 2 && b"on".starts_with(lc) => Some(true),
+        b'o' if len >= 2 && b"off".starts_with(lc) => Some(false),
+        _ => None,
     }
 }
 
@@ -978,65 +1156,6 @@ fn char_class_ok(class: &[u8], c: char) -> bool {
         b"wordchar" => c.is_alphanumeric() || c == '_',
         b"xdigit" => c.is_ascii_hexdigit(),
         _ => false,
-    }
-}
-
-/// Tcl integer literal: optional sign, then decimal, or `0x`/`0o`/`0b` radix
-/// prefixes. No surrounding whitespace (`string is` is stricter than `expr`).
-fn is_tcl_integer(chars: &[char]) -> bool {
-    let mut i = 0;
-    if matches!(chars.first(), Some('+' | '-')) {
-        i = 1;
-    }
-    let rest = &chars[i..];
-    if rest.is_empty() {
-        return false;
-    }
-    if rest.len() >= 2 && rest[0] == '0' {
-        let (radix_ok, digits): (bool, &[char]) = match rest[1].to_ascii_lowercase() {
-            'x' => (true, &rest[2..]),
-            'o' => (true, &rest[2..]),
-            'b' => (true, &rest[2..]),
-            _ => (false, rest),
-        };
-        if radix_ok {
-            return !digits.is_empty()
-                && digits.iter().all(|&c| match rest[1].to_ascii_lowercase() {
-                    'x' => c.is_ascii_hexdigit(),
-                    'o' => ('0'..='7').contains(&c),
-                    _ => c == '0' || c == '1',
-                });
-        }
-    }
-    rest.iter().all(|c| c.is_ascii_digit())
-}
-
-/// Tcl double literal (accepts integers too).
-fn is_tcl_double(chars: &[char]) -> bool {
-    let s: String = chars.iter().collect();
-    let t = s.trim();
-    if t.is_empty() {
-        return false;
-    }
-    // Reject the leading/trailing whitespace `parse` would otherwise tolerate.
-    if t.len() != s.len() {
-        return false;
-    }
-    t.parse::<f64>().is_ok() || is_tcl_integer(chars)
-}
-
-/// Tcl boolean / true / false class.
-fn is_tcl_boolean(chars: &[char], class: &[u8]) -> bool {
-    let s: String = chars.iter().collect();
-    let l = s.to_ascii_lowercase();
-    let trues = ["1", "true", "yes", "on"];
-    let falses = ["0", "false", "no", "off"];
-    let is_t = trues.iter().any(|w| w.starts_with(&l) && !l.is_empty());
-    let is_f = falses.iter().any(|w| w.starts_with(&l) && !l.is_empty());
-    match class {
-        b"true" => is_t,
-        b"false" => is_f,
-        _ => is_t || is_f,
     }
 }
 
@@ -1202,6 +1321,27 @@ mod tests {
         assert_eq!(ok(b"string is alpha -failindex pos ab2c; set pos"), b"2");
         assert_eq!(ok(b"string is dict {a 1 b 2}"), b"1");
         assert_eq!(ok(b"string is dict {a 1 b}"), b"0");
+        // Abbreviated class + option names resolve (Tcl_GetIndexFromObj).
+        assert_eq!(ok(b"string is int 42"), b"1");
+        assert_eq!(ok(b"string is bool yes"), b"1");
+        // Numeric classes tolerate surrounding whitespace; fail index is where
+        // parsing stops.
+        assert_eq!(ok(b"string is double \"  +1.0e-1 \""), b"1");
+        assert_eq!(ok(b"string is integer -fail v 123abc; set v"), b"3");
+        // wideinteger overflow reports -1; integer accepts the bignum.
+        assert_eq!(
+            ok(b"string is wideinteger -fail v 9223372036854775808; set v"),
+            b"-1"
+        );
+        assert_eq!(ok(b"string is integer 9223372036854775808"), b"1");
+        // Boolean classes are strict about the keyword set (25 is not a bool).
+        assert_eq!(ok(b"string is true 25"), b"0");
+        assert_eq!(ok(b"string is bool 1.0"), b"0");
+        // -failindex var is left untouched when the result is 1.
+        assert_eq!(
+            ok(b"catch {unset v}; string is alpha -failindex v abc; info exists v"),
+            b"0"
+        );
     }
 
     #[test]

--- a/runtime/rust/src/cmd_switch.rs
+++ b/runtime/rust/src/cmd_switch.rs
@@ -58,41 +58,155 @@ fn switch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let string = obj_bytes(argv[i]);
     i += 1;
 
-    // Collect the pattern/body words: either a single list arg, or the rest
-    // inline. Keep them as owned byte vectors (the list form is split once).
-    let words: Vec<Vec<u8>> = if i + 1 == argv.len() {
-        match crate::parse::split_list(&obj_bytes(argv[i])) {
-            Ok(v) => v,
-            Err(e) => return interp.set_error(e.message()),
-        }
-    } else {
-        argv[i..].iter().map(|&a| obj_bytes(a)).collect()
-    };
-    if words.is_empty() || words.len() % 2 != 0 {
+    // Two forms: a single `{pattern body ...}` list argument, or the rest as
+    // inline pattern/body words. The inline form keeps each body's `Tcl_Obj`
+    // (whose TIP 280 location the LABC table already carries); the list form
+    // re-splits the literal, so each body's source line must be derived from its
+    // offset within the list word (C's `TclListLines`).
+    if i + 1 == argv.len() {
+        return switch_list_form(interp, mode, nocase, &string, argv[i]);
+    }
+    switch_inline_form(interp, mode, nocase, &string, &argv[i..])
+}
+
+/// The inline form: `switch ?opts? str pat body ?pat body ...?`. Each body is a
+/// live argument object, so a located literal runs as a `type source` frame via
+/// [`Interp::eval_control_body`] (the same path as `if`/`while` bodies).
+fn switch_inline_form(
+    interp: &mut Interp,
+    mode: Mode,
+    nocase: bool,
+    string: &[u8],
+    pairs: &[*mut TclObj],
+) -> Code {
+    if pairs.is_empty() || pairs.len() % 2 != 0 {
         return interp.set_error(b"extra switch pattern with no body");
     }
-
-    // Find the first matching pattern; `default` (as the last pattern) matches
-    // anything.
-    let npairs = words.len() / 2;
+    let npairs = pairs.len() / 2;
     for p in 0..npairs {
-        let pat = &words[p * 2];
+        let pat = obj_bytes(pairs[p * 2]);
         let is_default = pat.as_slice() == b"default" && p == npairs - 1;
-        if is_default || matches(mode, nocase, pat, &string) {
+        if is_default || matches(mode, nocase, &pat, string) {
             // Resolve a `-` fall-through to the next non-`-` body.
             let mut b = p;
-            while words[b * 2 + 1].as_slice() == b"-" {
+            while obj_bytes(pairs[b * 2 + 1]).as_slice() == b"-" {
                 b += 1;
                 if b >= npairs {
                     return interp.set_error(b"no body specified for pattern \"-\"");
                 }
             }
-            return interp.eval_str(&words[b * 2 + 1]);
+            return interp.eval_control_body(pairs[b * 2 + 1]);
         }
     }
-    // No match → empty result.
     interp.set_result_bytes(b"");
     Code::Ok
+}
+
+/// The list form: `switch ?opts? str {pat body ...}`. The body is a sub-element
+/// of the single list literal `list_obj`, so it has no `Tcl_Obj` of its own; its
+/// `info frame` line is the list word's line plus the newlines preceding the
+/// element (C's `TclListLines`). A `default` pattern (last) matches anything; a
+/// `-` body falls through.
+fn switch_list_form(
+    interp: &mut Interp,
+    mode: Mode,
+    nocase: bool,
+    string: &[u8],
+    list_obj: *mut TclObj,
+) -> Code {
+    let list_str = obj_bytes(list_obj);
+    // Scan the list once for each element's value range + `literal` flag (and so
+    // its byte offset), the location-tracking complement to `split_list`.
+    let elems = match scan_elements(&list_str) {
+        Ok(e) => e,
+        Err(e) => return interp.set_error(e),
+    };
+    if elems.is_empty() || elems.len() % 2 != 0 {
+        return interp.set_error(b"extra switch pattern with no body");
+    }
+    // The list word's file + first line (TIP 280); absent for a dynamic value,
+    // in which case bodies are body-relative (`type proc`, no file).
+    let loc = interp.arg_location(list_obj);
+    let npairs = elems.len() / 2;
+    for p in 0..npairs {
+        let pat = element_value(&list_str, &elems[p * 2]);
+        let is_default = pat.as_slice() == b"default" && p == npairs - 1;
+        if is_default || matches(mode, nocase, &pat, string) {
+            let mut b = p;
+            while element_value(&list_str, &elems[b * 2 + 1]).as_slice() == b"-" {
+                b += 1;
+                if b >= npairs {
+                    return interp.set_error(b"no body specified for pattern \"-\"");
+                }
+            }
+            let body_elem = &elems[b * 2 + 1];
+            let body = element_value(&list_str, body_elem);
+            // Source-track only a literal body in a located list (a body with
+            // backslash collapse, or a dynamic list, reverts to body-relative —
+            // C sets such lines to -1).
+            match (&loc, body_elem.literal) {
+                (Some((file, bline)), true) => {
+                    let line = bline + count_newlines(&list_str[..body_elem.start()]);
+                    return interp.eval_located_body(file.clone(), line, &body);
+                }
+                _ => return interp.eval_unlocated_body(&body),
+            }
+        }
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
+}
+
+/// A located list element: its interior byte range and whether it is `literal`
+/// (verbatim, no backslash collapse). `value.start` doubles as the line-tracking
+/// anchor — an element's opening brace/quote shares a line with its interior, so
+/// counting newlines to the interior start matches C's `element` anchor.
+struct Elem {
+    value: core::ops::Range<usize>,
+    literal: bool,
+}
+
+impl Elem {
+    fn start(&self) -> usize {
+        self.value.start
+    }
+}
+
+/// Scan `src` into its located list elements (the offset-aware complement to
+/// `split_list`, sharing `tcl_syntax`'s element scanner).
+fn scan_elements(src: &[u8]) -> Result<Vec<Elem>, &'static [u8]> {
+    let s = core::str::from_utf8(src).map_err(|_| b"unmatched open brace in list".as_slice())?;
+    let mut elems = Vec::new();
+    let mut pos = 0;
+    loop {
+        match tcl_syntax::list::find_element(s, pos) {
+            Ok(Some(e)) => {
+                pos = e.next;
+                elems.push(Elem {
+                    value: e.value,
+                    literal: e.literal,
+                });
+            }
+            Ok(None) => break,
+            Err(err) => return Err(err.message().as_bytes()),
+        }
+    }
+    Ok(elems)
+}
+
+/// The element's value bytes: verbatim for a literal (`{braced}`) element, else
+/// backslash-collapsed (matching `split_list`).
+fn element_value(src: &[u8], e: &Elem) -> Vec<u8> {
+    if e.literal {
+        src[e.value.clone()].to_vec()
+    } else {
+        tcl_syntax::backslash::decode_bytes(&src[e.value.clone()]).into_owned()
+    }
+}
+
+/// Count the newlines in `s` (line delta between two offsets).
+fn count_newlines(s: &[u8]) -> u32 {
+    s.iter().filter(|&&b| b == b'\n').count() as u32
 }
 
 fn matches(mode: Mode, nocase: bool, pat: &[u8], string: &[u8]) -> bool {

--- a/runtime/rust/src/dict.rs
+++ b/runtime/rust/src/dict.rs
@@ -43,7 +43,6 @@ use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hasher};
 
 use crate::obj::{self, TclObj, TclObjType};
-use crate::parse::{self, ListError};
 
 /// Deterministic FNV-1a hasher (no `RandomState` — reproducible across runs).
 #[derive(Default)]
@@ -160,14 +159,10 @@ fn ensure_dict(obj: *mut TclObj) -> Result<(), DictError> {
         return Ok(());
     }
     let bytes = obj::bytes_of(obj);
-    let elems = parse::split_list(&bytes).map_err(DictError::List)?;
-    if elems.len() % 2 != 0 {
-        return Err(DictError::OddLength);
-    }
-    let mut entries: Vec<(*mut TclObj, *mut TclObj)> = Vec::with_capacity(elems.len() / 2);
+    let pairs = scan_dict_pairs(&bytes)?;
+    let mut entries: Vec<(*mut TclObj, *mut TclObj)> = Vec::with_capacity(pairs.len());
     let mut index = Index::default();
-    let mut it = elems.into_iter();
-    while let (Some(k), Some(v)) = (it.next(), it.next()) {
+    for (k, v) in pairs {
         let ko = obj::new_string_bytes(&k);
         let vo = obj::new_string_bytes(&v);
         // SAFETY: fresh key/value objects; the dict takes the owning +1 on each.
@@ -195,13 +190,176 @@ fn ensure_dict(obj: *mut TclObj) -> Result<(), DictError> {
 
 // -- error ------------------------------------------------------------------
 
-/// Why a value could not be used as a dict.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Why a value could not be parsed as a dict (`SetDictFromAny`/`FindElement`
+/// with the "dict" type strings). Each variant carries what the C-faithful
+/// message and `-errorcode` need.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DictError {
-    /// The string rep is not a valid list.
-    List(ListError),
-    /// The list has an odd number of elements (missing a value for a key).
-    OddLength,
+    /// Odd number of elements — `missing value to go with key`
+    /// (`TCL VALUE DICTIONARY`).
+    MissingValue,
+    /// Junk after a closing brace — `dict element in braces followed by "X"
+    /// instead of space` (`TCL VALUE DICTIONARY JUNK`); carries the fragment.
+    BraceJunk(Vec<u8>),
+    /// Junk after a closing quote — `dict element in quotes followed by "X"
+    /// instead of space` (`TCL VALUE DICTIONARY JUNK`); carries the fragment.
+    QuoteJunk(Vec<u8>),
+    /// Unmatched `{` — `unmatched open brace in dict` (`TCL VALUE DICTIONARY BRACE`).
+    UnmatchedBrace,
+    /// Unmatched `"` — `unmatched open quote in dict` (`TCL VALUE DICTIONARY QUOTE`).
+    UnmatchedQuote,
+    /// Input bytes were not valid UTF-8 (violates the internal-rep invariant).
+    NotUtf8,
+}
+
+/// One located dict element (key or value): its interior byte range, whether it
+/// is `literal` (no backslash collapse needed), and the resume offset.
+struct DictElem {
+    value: core::ops::Range<usize>,
+    literal: bool,
+    next: usize,
+}
+
+/// Tcl list/dict-element whitespace (`TclIsSpaceProcM`).
+#[inline]
+fn is_dict_space(c: u8) -> bool {
+    matches!(c, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
+}
+
+/// Locate the next dict element in `bytes` at/after `start` — the dict-typed
+/// `FindElement` (`tclUtil.c`), distinct from the list splitter only in its
+/// error wording/codes (and in surfacing the offending fragment). Returns
+/// `Ok(None)` when only trailing whitespace remains.
+fn dict_find_element(bytes: &[u8], start: usize) -> Result<Option<DictElem>, DictError> {
+    let len = bytes.len();
+    let mut pos = start;
+    while pos < len && is_dict_space(bytes[pos]) {
+        pos += 1;
+    }
+    if pos >= len {
+        return Ok(None);
+    }
+
+    let mut open_braces: usize = 0;
+    let mut in_quotes = false;
+    let mut literal = true;
+    let elem_start;
+    match bytes[pos] {
+        b'{' => {
+            open_braces = 1;
+            pos += 1;
+            elem_start = pos;
+        }
+        b'"' => {
+            in_quotes = true;
+            pos += 1;
+            elem_start = pos;
+        }
+        _ => elem_start = pos,
+    }
+
+    // The fragment reported in a "followed by" error: up to 20 non-space bytes
+    // starting just after the closing delimiter (C's `p2` walk).
+    let frag = |from: usize| -> Vec<u8> {
+        let mut p2 = from;
+        while p2 < len && !is_dict_space(bytes[p2]) && p2 < from + 20 {
+            p2 += 1;
+        }
+        bytes[from..p2].to_vec()
+    };
+
+    let size;
+    loop {
+        if pos >= len {
+            if open_braces != 0 {
+                return Err(DictError::UnmatchedBrace);
+            }
+            if in_quotes {
+                return Err(DictError::UnmatchedQuote);
+            }
+            size = pos - elem_start;
+            break;
+        }
+        match bytes[pos] {
+            b'{' if open_braces != 0 => open_braces += 1,
+            b'}' => {
+                if open_braces == 1 {
+                    size = pos - elem_start;
+                    pos += 1;
+                    if pos < len && !is_dict_space(bytes[pos]) {
+                        return Err(DictError::BraceJunk(frag(pos)));
+                    }
+                    break;
+                } else if open_braces > 1 {
+                    open_braces -= 1;
+                }
+            }
+            b'"' if in_quotes => {
+                size = pos - elem_start;
+                pos += 1;
+                if pos < len && !is_dict_space(bytes[pos]) {
+                    return Err(DictError::QuoteJunk(frag(pos)));
+                }
+                break;
+            }
+            b'\\' => {
+                if open_braces == 0 {
+                    literal = false;
+                }
+                if pos + 1 < len {
+                    pos += 2;
+                    continue;
+                }
+                pos += 1;
+                continue;
+            }
+            ch if open_braces == 0 && !in_quotes && is_dict_space(ch) => {
+                size = pos - elem_start;
+                break;
+            }
+            _ => {}
+        }
+        pos += 1;
+    }
+
+    while pos < len && is_dict_space(bytes[pos]) {
+        pos += 1;
+    }
+    Ok(Some(DictElem {
+        value: elem_start..elem_start + size,
+        literal,
+        next: pos,
+    }))
+}
+
+/// Decoded (key, value) byte pairs from a dict's string rep.
+type BytePairs = Vec<(Vec<u8>, Vec<u8>)>;
+
+/// Parse `bytes` into dict (key, value) byte pairs — `SetDictFromAny`'s string
+/// path. A later duplicate key is *not* deduped here (the caller handles it);
+/// an odd element count is `missing value to go with key`.
+fn scan_dict_pairs(bytes: &[u8]) -> Result<BytePairs, DictError> {
+    if core::str::from_utf8(bytes).is_err() {
+        return Err(DictError::NotUtf8);
+    }
+    let decode = |el: &DictElem| -> Vec<u8> {
+        let raw = &bytes[el.value.clone()];
+        if el.literal {
+            raw.to_vec()
+        } else {
+            tcl_syntax::backslash::decode_bytes(raw).into_owned()
+        }
+    };
+    let mut pairs = Vec::new();
+    let mut pos = 0;
+    while let Some(key) = dict_find_element(bytes, pos)? {
+        let Some(val) = dict_find_element(bytes, key.next)? else {
+            return Err(DictError::MissingValue);
+        };
+        pairs.push((decode(&key), decode(&val)));
+        pos = val.next;
+    }
+    Ok(pairs)
 }
 
 // -- public ops -------------------------------------------------------------
@@ -437,7 +595,7 @@ mod tests {
         leak_free(|| {
             let v = new_string_bytes(b"a 1 b"); // missing value for b
             unsafe { obj::incr_ref_count(v) };
-            assert_eq!(dict_size(v), Err(DictError::OddLength));
+            assert_eq!(dict_size(v), Err(DictError::MissingValue));
             unsafe { obj::decr_ref_count(v) };
         });
     }

--- a/runtime/rust/src/ensemble.rs
+++ b/runtime/rust/src/ensemble.rs
@@ -32,6 +32,14 @@ pub struct EnsembleConfig {
     pub subcommands: Option<Vec<Vec<u8>>>,
     /// `-prefixes`: allow unambiguous-prefix subcommand matching (default true).
     pub prefixes: bool,
+    /// `-parameters`: formal parameter names that precede the subcommand in a
+    /// call (`ens p1 p2 sub args…`); their values are threaded in after the
+    /// resolved target (`target p1 p2 args…`). Empty for an ordinary ensemble.
+    pub parameters: Vec<Vec<u8>>,
+    /// `-unknown`: a handler command prefix invoked (as `handler… ensembleCmd
+    /// subcommand args…`) when a subcommand doesn't resolve, before erroring.
+    /// Empty for none.
+    pub unknown: Vec<Vec<u8>>,
 }
 
 /// Resolve `sub` against the (sorted) subcommand set: an exact match wins;

--- a/runtime/rust/src/expr.rs
+++ b/runtime/rust/src/expr.rs
@@ -39,6 +39,66 @@ pub(crate) fn arith_err(e: ArithError) -> ExprError {
     })
 }
 
+/// `cannot use {floating-point value|non-numeric string} "VALUE" as
+/// SIDEoperand of "OP"` — C's `IllegalExprOperandType` (`tclExecute.c`). `side`
+/// is `""` for a unary op, `"left "`/`"right "` for a binary one.
+fn operand_type_err(float: bool, value: &[u8], side: &[u8], op: &[u8]) -> ExprError {
+    let mut m = b"cannot use ".to_vec();
+    m.extend_from_slice(if float {
+        b"floating-point value \""
+    } else {
+        b"non-numeric string \""
+    });
+    m.extend_from_slice(value);
+    m.extend_from_slice(b"\" as ");
+    m.extend_from_slice(side);
+    m.extend_from_slice(b"operand of \"");
+    m.extend_from_slice(op);
+    m.push(b'"');
+    ExprError(m)
+}
+
+/// Map a binary operator to its source symbol (for operand-type errors).
+fn binop_sym(op: BinOp) -> &'static [u8] {
+    match op {
+        BinOp::Add => b"+",
+        BinOp::Sub => b"-",
+        BinOp::Mul => b"*",
+        BinOp::Div => b"/",
+        BinOp::Mod => b"%",
+        BinOp::Pow => b"**",
+        BinOp::BitAnd => b"&",
+        BinOp::BitOr => b"|",
+        BinOp::BitXor => b"^",
+        BinOp::LShift => b"<<",
+        BinOp::RShift => b">>",
+        _ => b"?",
+    }
+}
+
+/// Build the operand-type error for a *binary* op: the offending operand is the
+/// first one (left, then right) that is non-numeric (for `NonNumeric`) or a
+/// float (for `NonInteger`). Other `ArithError`s keep their plain message.
+fn binop_err(e: ArithError, op: BinOp, lp: *mut TclObj, rp: *mut TclObj) -> ExprError {
+    let float = match e {
+        ArithError::NonInteger => true,
+        ArithError::NonNumeric => false,
+        other => return arith_err(other),
+    };
+    // `NonInteger`: the float operand; `NonNumeric`: the non-numeric one.
+    let left_bad = if float {
+        bignum::is_numeric(lp) && !bignum::is_integer(lp)
+    } else {
+        !bignum::is_numeric(lp)
+    };
+    let (val, side): (Vec<u8>, &[u8]) = if left_bad {
+        (obj::bytes_of(lp), b"left ")
+    } else {
+        (obj::bytes_of(rp), b"right ")
+    };
+    operand_type_err(float, &val, side, binop_sym(op))
+}
+
 /// An owned object reference (`rc +1`) that releases on drop — the discipline
 /// that keeps the shared recursive walk leak-/double-free-safe across early
 /// returns.
@@ -179,23 +239,52 @@ impl ExprOps for TowerOps<'_> {
             _ => return Err(ExprError::msg(b"unsupported operator")),
         };
         // `left`/`right` stay alive until here, then release.
-        Ok(Owned::fresh(res.map_err(arith_err)?))
+        Ok(Owned::fresh(res.map_err(|e| binop_err(e, op, lp, rp))?))
     }
 
     fn unary(&mut self, op: UnaryOp, value: Owned) -> Result<Owned, ExprError> {
+        // A unary operand-type error names the value and the operator, with no
+        // left/right qualifier (`as operand of "OP"`).
+        let uerr = |e: ArithError, sym: &[u8]| -> ExprError {
+            match e {
+                ArithError::NonInteger => {
+                    operand_type_err(true, &obj::bytes_of(value.ptr()), b"", sym)
+                }
+                ArithError::NonNumeric => {
+                    operand_type_err(false, &obj::bytes_of(value.ptr()), b"", sym)
+                }
+                other => arith_err(other),
+            }
+        };
         match op {
             UnaryOp::Pos => {
                 if bignum::compare(value.ptr(), value.ptr()).is_none() {
-                    return Err(arith_err(ArithError::NonNumeric));
+                    return Err(operand_type_err(
+                        false,
+                        &obj::bytes_of(value.ptr()),
+                        b"",
+                        b"+",
+                    ));
                 }
                 Ok(value)
             }
-            UnaryOp::Neg => Ok(Owned::fresh(bignum::neg(value.ptr()).map_err(arith_err)?)),
-            UnaryOp::BitNot => Ok(Owned::fresh(bignum::bnot(value.ptr()).map_err(arith_err)?)),
-            UnaryOp::Not => {
-                let b = to_bool(value.ptr())?;
-                Ok(bool_obj(!b))
-            }
+            UnaryOp::Neg => Ok(Owned::fresh(
+                bignum::neg(value.ptr()).map_err(|e| uerr(e, b"-"))?,
+            )),
+            UnaryOp::BitNot => Ok(Owned::fresh(
+                bignum::bnot(value.ptr()).map_err(|e| uerr(e, b"~"))?,
+            )),
+            UnaryOp::Not => match to_bool(value.ptr()) {
+                Ok(b) => Ok(bool_obj(!b)),
+                // A `!` operand that is neither boolean nor numeric is an
+                // operand-type error (not the generic "expected boolean").
+                Err(_) => Err(operand_type_err(
+                    false,
+                    &obj::bytes_of(value.ptr()),
+                    b"",
+                    b"!",
+                )),
+            },
             UnaryOp::WordNot => Err(ExprError::msg(b"unsupported operator")),
         }
     }

--- a/runtime/rust/src/expr.rs
+++ b/runtime/rust/src/expr.rs
@@ -18,25 +18,58 @@ use crate::bignum::{self, ArithError};
 use crate::obj::{self, TclObj};
 use tcl_syntax::expr::{eval, BinOp, ExprNode, ExprOps, UnaryOp};
 
-/// An expr-evaluation error carrying Tcl's verbatim message bytes.
+/// An expr-evaluation error: Tcl's verbatim message bytes plus an optional
+/// `-errorcode` (a pre-formatted list, e.g. `ARITH DIVZERO {divide by zero}`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExprError(pub Vec<u8>);
+pub struct ExprError {
+    pub msg: Vec<u8>,
+    pub code: Option<Vec<u8>>,
+}
 
 impl ExprError {
     fn msg(s: &[u8]) -> ExprError {
-        ExprError(s.to_vec())
+        ExprError {
+            msg: s.to_vec(),
+            code: None,
+        }
+    }
+    /// An error from owned message bytes (no `-errorcode`).
+    pub fn from_bytes(m: Vec<u8>) -> ExprError {
+        ExprError { msg: m, code: None }
+    }
+    /// An error from message bytes plus an optional `-errorcode` (an empty code
+    /// is treated as none).
+    pub fn from_parts(m: Vec<u8>, code: Vec<u8>) -> ExprError {
+        ExprError {
+            msg: m,
+            code: (!code.is_empty()).then_some(code),
+        }
+    }
+    /// An error with an explicit `-errorcode`.
+    fn with_code(m: &[u8], code: &[u8]) -> ExprError {
+        ExprError {
+            msg: m.to_vec(),
+            code: Some(code.to_vec()),
+        }
     }
 }
 
 pub(crate) fn arith_err(e: ArithError) -> ExprError {
-    ExprError::msg(match e {
-        ArithError::NonNumeric => b"can't use non-numeric string as operand of arithmetic",
-        ArithError::NonInteger => b"can't use floating-point value as operand of bitwise op",
-        ArithError::DivideByZero => b"divide by zero",
-        ArithError::NegativeShift => b"negative shift argument",
-        ArithError::ExponentTooLarge => b"exponent too large",
-        ArithError::Alloc => b"out of memory",
-    })
+    match e {
+        ArithError::NonNumeric => {
+            ExprError::msg(b"can't use non-numeric string as operand of arithmetic")
+        }
+        ArithError::NonInteger => {
+            ExprError::msg(b"can't use floating-point value as operand of bitwise op")
+        }
+        // C stamps the arithmetic `-errorcode`s (`tclExecute.c`).
+        ArithError::DivideByZero => {
+            ExprError::with_code(b"divide by zero", b"ARITH DIVZERO {divide by zero}")
+        }
+        ArithError::NegativeShift => ExprError::msg(b"negative shift argument"),
+        ArithError::ExponentTooLarge => ExprError::msg(b"exponent too large"),
+        ArithError::Alloc => ExprError::msg(b"out of memory"),
+    }
 }
 
 /// `cannot use {floating-point value|non-numeric string} "VALUE" as
@@ -55,7 +88,7 @@ fn operand_type_err(float: bool, value: &[u8], side: &[u8], op: &[u8]) -> ExprEr
     m.extend_from_slice(b"operand of \"");
     m.extend_from_slice(op);
     m.push(b'"');
-    ExprError(m)
+    ExprError::from_bytes(m)
 }
 
 /// Map a binary operator to its source symbol (for operand-type errors).
@@ -189,7 +222,7 @@ pub fn dispatch_shared(name: &str, args: &[Owned]) -> Result<Owned, ExprError> {
             let mut m = b"unknown math function \"".to_vec();
             m.extend_from_slice(name.as_bytes());
             m.push(b'"');
-            Err(ExprError(m))
+            Err(ExprError::from_bytes(m))
         }
     }
 }
@@ -310,7 +343,7 @@ impl ExprOps for TowerOps<'_> {
         bool_obj(b)
     }
     fn unsupported(&mut self, what: &str) -> ExprError {
-        ExprError(what.as_bytes().to_vec())
+        ExprError::from_bytes(what.as_bytes().to_vec())
     }
 }
 
@@ -339,7 +372,7 @@ pub(crate) fn to_bool(o: *mut TclObj) -> Result<bool, ExprError> {
             let mut m = b"expected boolean value but got \"".to_vec();
             m.extend_from_slice(&bytes);
             m.push(b'"');
-            Err(ExprError(m))
+            Err(ExprError::from_bytes(m))
         }
     }
 }
@@ -475,7 +508,13 @@ mod tests {
 
     #[test]
     fn errors() {
-        assert_eq!(ev("1 / 0", &[]), Err(ExprError::msg(b"divide by zero")));
+        assert_eq!(
+            ev("1 / 0", &[]),
+            Err(ExprError::with_code(
+                b"divide by zero",
+                b"ARITH DIVZERO {divide by zero}"
+            ))
+        );
         assert!(ev("$missing + 1", &[]).is_err());
     }
 }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1042,6 +1042,17 @@ impl Interp {
             .unwrap_or_default()
     }
 
+    /// `info script filename` — set the current script name (C's
+    /// `iPtr->scriptFile`), replacing the innermost entry (or seeding one at the
+    /// top level).
+    pub(crate) fn set_current_script(&self, name: &[u8]) {
+        let mut s = self.script_stack.borrow_mut();
+        match s.last_mut() {
+            Some(last) => *last = name.to_vec(),
+            None => s.push(name.to_vec()),
+        }
+    }
+
     /// The file currently being sourced, as a shared handle (`None` at the top
     /// level) — for stamping a definition/method body's source provenance.
     pub(crate) fn current_source_file(&self) -> Option<Rc<[u8]>> {
@@ -1993,14 +2004,18 @@ impl Interp {
 
     /// The proc definition bound to `name` (for `info body`/`args`/`default`).
     pub(crate) fn proc_def(&self, name: &[u8]) -> Option<Rc<ProcDef>> {
-        match self
-            .namespaces
-            .borrow()
-            .resolve(self.current_ns.get(), name)
-        {
-            Some(Command::Proc(def)) => Some(def),
-            _ => None,
+        let ns = self.namespaces.borrow();
+        let mut cmd = ns.resolve(self.current_ns.get(), name)?;
+        // Follow `namespace import` redirects to the underlying proc, so
+        // `info args`/`body`/`default` work on an imported proc (info-1.7/2.4).
+        for _ in 0..64 {
+            match cmd {
+                Command::Proc(def) => return Some(def),
+                Command::Imported { source } => cmd = ns.resolve(GLOBAL, &source)?,
+                _ => return None,
+            }
         }
+        None
     }
 
     /// `upvar` — link `local` in the current frame to the resolved `target`.

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2899,9 +2899,41 @@ impl Interp {
                 return code;
             }
         }
-        // Command miss: dispatch through `unknown <name> <args…>` if it exists
-        // (and we're not already resolving `unknown` itself).
+        // Command miss: dispatch through the current namespace's `namespace
+        // unknown` handler if it has a custom one, else the global `unknown`
+        // command (and only if we're not already resolving `unknown` itself).
         if name != b"unknown" {
+            // A custom unknown handler is a command *prefix* (a list), invoked as
+            // `handler… name args…`. The current namespace's handler wins; a
+            // namespace with none falls back to the global namespace's (which a
+            // script can set to override `::unknown`), else the `unknown` command.
+            let ns_handler = {
+                let ns = self.namespaces.borrow();
+                let cur = self.current_ns.get();
+                ns.unknown_handler(cur).map(<[u8]>::to_vec).or_else(|| {
+                    (cur != GLOBAL)
+                        .then(|| ns.unknown_handler(GLOBAL).map(<[u8]>::to_vec))
+                        .flatten()
+                })
+            };
+            if let Some(handler) = ns_handler {
+                if let Ok(prefix) = crate::parse::split_list(&handler) {
+                    let mut new_argv: Vec<*mut TclObj> =
+                        Vec::with_capacity(prefix.len() + argv.len());
+                    for w in &prefix {
+                        let o = new_string(w);
+                        unsafe { obj::incr_ref_count(o) };
+                        new_argv.push(o);
+                    }
+                    for &a in argv {
+                        unsafe { obj::incr_ref_count(a) };
+                        new_argv.push(a);
+                    }
+                    let code = self.dispatch(&new_argv);
+                    release_all(&new_argv);
+                    return code;
+                }
+            }
             let unk = self.namespaces.borrow().resolve(GLOBAL, b"unknown");
             if let Some(unk) = unk {
                 let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(argv.len() + 1);

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1125,6 +1125,32 @@ impl Interp {
     /// `body` there, then restore. The current-ns switch is what makes commands
     /// defined in `body` land in the right table.
     pub(crate) fn ns_eval(&mut self, name: &[u8], body: &[u8]) -> Code {
+        self.ns_eval_framed(name, body, None)
+    }
+
+    /// `namespace eval` of a single body **object** — like
+    /// [`ns_eval`](Self::ns_eval), but a literal obj with a recorded TIP 280
+    /// source location runs as `type source` at its file+line (so a `proc`/
+    /// command defined inside `namespace eval { … }` reports file-absolute
+    /// `info frame` lines), rather than the dynamic `type eval`.
+    pub(crate) fn ns_eval_obj(&mut self, name: &[u8], obj: *mut TclObj) -> Code {
+        let loc = self.arg_loc(obj);
+        let bytes = obj_bytes(obj);
+        self.ns_eval_framed(name, &bytes, loc)
+    }
+
+    /// Shared `namespace eval` core: enter `name`, push a namespace var-scope
+    /// frame *and* a `CmdFrame` for the body (C's `namespace eval` is its own
+    /// `info frame` level — depth and `info level` both advance — with `proc`
+    /// cleared and `level` reported relative to the new scope). `loc` is the
+    /// body's TIP 280 location when it is a located literal (`type source`),
+    /// else `None` (`type eval`).
+    fn ns_eval_framed(
+        &mut self,
+        name: &[u8],
+        body: &[u8],
+        loc: Option<(Option<Rc<[u8]>>, u32)>,
+    ) -> Code {
         let target = self
             .namespaces
             .borrow_mut()
@@ -1136,7 +1162,22 @@ impl Interp {
         // including when nested in a proc — target the namespace, not the
         // enclosing proc's locals).
         self.frames.borrow_mut().push_namespace(target);
-        let code = self.eval_str(body);
+        let (kind, file, line_base) = match loc {
+            Some((file, line)) => (FrameKind::Source, file, line.saturating_sub(1)),
+            None => (FrameKind::Eval, None, 0),
+        };
+        let frame = CmdFrame {
+            kind,
+            file,
+            proc: None,
+            level: self.frames.borrow().current_level(),
+            omit_level: false,
+            line_base,
+            cmd: Vec::new(),
+            line: 1,
+            oo: None,
+        };
+        let code = self.eval_framed(body, frame);
         self.frames.borrow_mut().pop();
         self.current_ns.set(saved);
         code

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -167,6 +167,9 @@ struct CmdFrame {
     /// body, where C reports `method`/`class`|`object` instead of `proc`.
     /// `method-name` is empty for a constructor/destructor.
     oo: Option<(Vec<u8>, Vec<u8>, Vec<u8>)>,
+    /// The lambda expression for an `apply` body's `info frame` (`lambda <expr>`
+    /// in place of `proc`, C's `TclInfoFrame`). `None` for a normal proc/method.
+    lambda: Option<Vec<u8>>,
 }
 
 /// A TIP 280 literal-argument location: `(objPtr, file, line)` (C's `lineLABCPtr`
@@ -217,6 +220,7 @@ impl CmdFrame {
             cmd: Vec::new(),
             line: 1,
             oo: None,
+            lambda: None,
         }
     }
 }
@@ -1195,6 +1199,7 @@ impl Interp {
             cmd: Vec::new(),
             line: 1,
             oo: None,
+            lambda: None,
         };
         let code = self.eval_framed(body, frame);
         self.frames.borrow_mut().pop();
@@ -2538,13 +2543,16 @@ impl Interp {
             pairs.push((b"file".to_vec(), file.to_vec()));
         }
         pairs.push((b"cmd".to_vec(), f.cmd.clone()));
-        // A TclOO method frame reports `method`/`class`|`object` (the declarer)
-        // in place of `proc` (C's `TclInfoFrame`).
+        // A TclOO method frame reports `method`/`class`|`object` (the declarer),
+        // and an `apply` lambda reports `lambda <expr>`, in place of `proc`
+        // (C's `TclInfoFrame`).
         if let Some((method, kind, owner)) = &f.oo {
             if !method.is_empty() {
                 pairs.push((b"method".to_vec(), method.clone()));
             }
             pairs.push((kind.clone(), owner.clone()));
+        } else if let Some(l) = &f.lambda {
+            pairs.push((b"lambda".to_vec(), l.clone()));
         } else if let Some(p) = &f.proc {
             pairs.push((b"proc".to_vec(), p.clone()));
         }
@@ -2710,6 +2718,7 @@ impl Interp {
             cmd: Vec::new(),
             line: 1,
             oo: top.and_then(|f| f.oo.clone()),
+            lambda: top.and_then(|f| f.lambda.clone()),
         }
     }
 
@@ -2742,6 +2751,23 @@ impl Interp {
     /// enclosing file + the list word's line, to derive its sub-bodies' lines.
     pub(crate) fn arg_location(&self, obj: *mut TclObj) -> Option<(Option<Rc<[u8]>>, u32)> {
         self.arg_loc(obj)
+    }
+
+    /// The `(file, line)` of list element `index` within the literal `obj` — for
+    /// a body that is a sub-element of a located list literal (an `apply` lambda's
+    /// body, C's `TclListLines`). The element's line is the list word's line plus
+    /// the newlines preceding the element. `None` when `obj` is a dynamic value
+    /// or lacks a file (then the body is body-relative).
+    pub(crate) fn list_element_location(
+        &self,
+        obj: *mut TclObj,
+        index: usize,
+    ) -> Option<(Rc<[u8]>, u32)> {
+        let (Some(file), line) = self.arg_loc(obj)? else {
+            return None;
+        };
+        let nl = scan_list_offsets(&obj_bytes(obj))?.get(index)?.0;
+        Some((file, line + nl))
     }
 
     /// Evaluate a body whose file-absolute first `line` and `file` were computed
@@ -3881,6 +3907,11 @@ impl Interp {
             }
             _ => None,
         };
+        // An `apply` lambda reports `lambda <expr>` (not `proc`) in `info frame`.
+        let lambda = match &meta.err {
+            ProcFrame::Lambda(expr) => Some(expr.to_vec()),
+            _ => None,
+        };
         let proc_frame = CmdFrame {
             kind: if meta.source.is_some() {
                 FrameKind::Source
@@ -3895,6 +3926,7 @@ impl Interp {
             cmd: Vec::new(),
             line: 1,
             oo,
+            lambda,
         };
         let code = self.eval_framed(body, proc_frame);
         // The frame's local variables (and any traces on them) die with it.

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -841,6 +841,30 @@ impl Interp {
         )
     }
 
+    /// The configuration of the ensemble command `name` resolves to, or `None`
+    /// if `name` is not an ensemble (`namespace ensemble configure`/cget).
+    pub(crate) fn ensemble_config(&self, name: &[u8]) -> Option<crate::ensemble::EnsembleConfig> {
+        match self
+            .namespaces
+            .borrow()
+            .resolve(self.current_ns.get(), name)
+        {
+            Some(Command::Ensemble(cfg)) => Some(cfg),
+            _ => None,
+        }
+    }
+
+    /// Rebind the ensemble command `name` with an updated configuration
+    /// (`namespace ensemble configure` set form). `name` must already resolve to
+    /// an ensemble; rebinds at the same location `create_ensemble` would choose.
+    pub(crate) fn set_ensemble_config(
+        &mut self,
+        name: &[u8],
+        cfg: crate::ensemble::EnsembleConfig,
+    ) {
+        self.create_ensemble(name, cfg);
+    }
+
     /// Every alias command's name across the whole tree (`interp aliases`).
     pub(crate) fn alias_names(&self) -> Vec<Vec<u8>> {
         self.namespaces.borrow().alias_names()
@@ -1625,6 +1649,21 @@ impl Interp {
         // and mis-fire when a same-named command is later created (the stale
         // `::x → namespace delete ::` chain that wiped the global namespace).
         let cmd_victims = self.take_ns_cmd_traces(ns);
+        // Ensemble commands are tied to their namespace: delete those whose
+        // configured namespace is in the subtree (even if the command itself
+        // lives elsewhere, e.g. a default `::ns` ensemble in the global table).
+        {
+            let ids: std::collections::HashSet<NsId> = self
+                .namespaces
+                .borrow()
+                .descendant_ids(ns)
+                .into_iter()
+                .collect();
+            let removed = self.namespaces.borrow_mut().remove_ensembles_for(&ids);
+            for fqn in removed {
+                self.on_command_replaced(&fqn);
+            }
+        }
         self.namespaces.borrow_mut().delete_namespace_by_id(ns);
         self.fire_unset_callbacks(victims);
         self.fire_deleted_cmd_callbacks(cmd_victims);
@@ -3508,9 +3547,16 @@ impl Interp {
         cfg: &crate::ensemble::EnsembleConfig,
         argv: &[*mut TclObj],
     ) -> Code {
-        if argv.len() < 2 {
+        // `-parameters` formal args sit between the ensemble command and the
+        // subcommand (`ens p1 p2 sub …`), so the subcommand is at `1 + nparams`.
+        let nparams = cfg.parameters.len();
+        if argv.len() < 2 + nparams {
             let mut m = b"wrong # args: should be \"".to_vec();
             m.extend_from_slice(&obj_bytes(argv[0]));
+            for p in &cfg.parameters {
+                m.push(b' ');
+                m.extend_from_slice(p);
+            }
             m.extend_from_slice(b" subcommand ?arg ...?\"");
             return self.error(&m);
         }
@@ -3524,7 +3570,7 @@ impl Interp {
         subs.sort();
         subs.dedup();
 
-        let sub = obj_bytes(argv[1]);
+        let sub = obj_bytes(argv[1 + nparams]);
         let Some(idx) = crate::ensemble::resolve_subcommand(&subs, &sub, cfg.prefixes) else {
             // "unknown or ambiguous" with prefixes on; plain "unknown" otherwise.
             let mut m = if cfg.prefixes {
@@ -3557,15 +3603,22 @@ impl Interp {
                 vec![t]
             });
 
-        // Build [target…, argv[2..]…], each owned (+1), and re-dispatch.
-        let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len() - 2);
+        // Build [target…, params…, rest…], each owned (+1), and re-dispatch. The
+        // `-parameters` values (`argv[1..1+nparams]`) thread in right after the
+        // target prefix; the subcommand's own args follow from `2+nparams`.
+        let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len() - 1);
         for w in &prefix {
             let o = new_string(w);
             // SAFETY: fresh obj; take the owning +1 the new argv holds.
             unsafe { obj::incr_ref_count(o) };
             new_argv.push(o);
         }
-        for &a in &argv[2..] {
+        for &a in &argv[1..1 + nparams] {
+            // SAFETY: live arg; take an owning +1.
+            unsafe { obj::incr_ref_count(a) };
+            new_argv.push(a);
+        }
+        for &a in &argv[2 + nparams..] {
             // SAFETY: live arg; take an owning +1.
             unsafe { obj::incr_ref_count(a) };
             new_argv.push(a);

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -169,6 +169,16 @@ struct CmdFrame {
     oo: Option<(Vec<u8>, Vec<u8>, Vec<u8>)>,
 }
 
+/// The outcome of an ensemble `-unknown` handler (`EnsembleUnknownCallback`).
+enum EnsembleUnknown {
+    /// A non-empty result: the replacement command prefix to dispatch.
+    Prefix(Vec<Vec<u8>>),
+    /// An empty result: the handler defined the subcommand — reparse the call.
+    Reparse,
+    /// The handler errored (or returned a bad code); `Code` carries the failure.
+    Failed(Code),
+}
+
 /// A `CmdFrame`'s location type (`info frame`'s `type` key).
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum FrameKind {
@@ -3592,18 +3602,45 @@ impl Interp {
             m.extend_from_slice(b" subcommand ?arg ...?\"");
             return self.error(&m);
         }
-        // The valid subcommand set (sorted): explicit `-subcommands`, else the
-        // `-map` keys, else the namespace's exported commands.
-        let mut subs: Vec<Vec<u8>> = match (&cfg.subcommands, &cfg.map) {
-            (Some(list), _) => list.clone(),
-            (None, Some(map)) => map.iter().map(|(k, _)| k.clone()).collect(),
-            (None, None) => self.namespaces.borrow().exported_commands(cfg.ns),
-        };
-        subs.sort();
-        subs.dedup();
-
+        // Resolve the subcommand. On a miss, the `-unknown` handler gets one
+        // chance (`reparseCount < 1`) to define it (empty result ⇒ reparse) or
+        // supply a replacement command prefix (non-empty result).
         let sub = obj_bytes(argv[1 + nparams]);
-        let Some(idx) = crate::ensemble::resolve_subcommand(&subs, &sub, cfg.prefixes) else {
+        let mut reparsed = false;
+        loop {
+            let subs = self.ensemble_subcommands(cfg);
+            if let Some(idx) = crate::ensemble::resolve_subcommand(&subs, &sub, cfg.prefixes) {
+                let resolved = &subs[idx];
+                // The target command prefix: a `-map` entry, else `<ns>::<sub>`.
+                let prefix: Vec<Vec<u8>> = cfg
+                    .map
+                    .as_ref()
+                    .and_then(|m| {
+                        m.iter()
+                            .find(|(k, _)| k == resolved)
+                            .map(|(_, p)| p.clone())
+                    })
+                    .unwrap_or_else(|| {
+                        let mut t = self.namespaces.borrow().qualified_name(cfg.ns);
+                        if cfg.ns != GLOBAL {
+                            t.extend_from_slice(b"::");
+                        }
+                        t.extend_from_slice(resolved);
+                        vec![t]
+                    });
+                return self.dispatch_ensemble_target(&prefix, argv, nparams);
+            }
+            // Miss: try the `-unknown` handler once.
+            if !cfg.unknown.is_empty() && !reparsed {
+                reparsed = true;
+                match self.ensemble_unknown(cfg, argv) {
+                    EnsembleUnknown::Prefix(prefix) => {
+                        return self.dispatch_ensemble_target(&prefix, argv, nparams);
+                    }
+                    EnsembleUnknown::Reparse => continue,
+                    EnsembleUnknown::Failed(code) => return code,
+                }
+            }
             // "unknown or ambiguous" with prefixes on; plain "unknown" otherwise.
             let mut m = if cfg.prefixes {
                 b"unknown or ambiguous subcommand \"".to_vec()
@@ -3614,32 +3651,33 @@ impl Interp {
             m.extend_from_slice(b"\": must be ");
             m.extend_from_slice(&crate::ensemble::must_be(&subs));
             return self.error(&m);
+        }
+    }
+
+    /// The ensemble's valid subcommand set (sorted, deduped): explicit
+    /// `-subcommands`, else the `-map` keys, else the namespace's exports.
+    fn ensemble_subcommands(&self, cfg: &crate::ensemble::EnsembleConfig) -> Vec<Vec<u8>> {
+        let mut subs: Vec<Vec<u8>> = match (&cfg.subcommands, &cfg.map) {
+            (Some(list), _) => list.clone(),
+            (None, Some(map)) => map.iter().map(|(k, _)| k.clone()).collect(),
+            (None, None) => self.namespaces.borrow().exported_commands(cfg.ns),
         };
-        let resolved = &subs[idx];
+        subs.sort();
+        subs.dedup();
+        subs
+    }
 
-        // The target command prefix: a `-map` entry, else `<ns>::<sub>`.
-        let prefix: Vec<Vec<u8>> = cfg
-            .map
-            .as_ref()
-            .and_then(|m| {
-                m.iter()
-                    .find(|(k, _)| k == resolved)
-                    .map(|(_, p)| p.clone())
-            })
-            .unwrap_or_else(|| {
-                let mut t = self.namespaces.borrow().qualified_name(cfg.ns);
-                if cfg.ns != GLOBAL {
-                    t.extend_from_slice(b"::");
-                }
-                t.extend_from_slice(resolved);
-                vec![t]
-            });
-
-        // Build [target…, params…, rest…], each owned (+1), and re-dispatch. The
-        // `-parameters` values (`argv[1..1+nparams]`) thread in right after the
-        // target prefix; the subcommand's own args follow from `2+nparams`.
+    /// Dispatch a resolved ensemble subcommand: `[prefix…, params…, rest…]` (the
+    /// `-parameters` values thread in right after the target prefix; the
+    /// subcommand's own args follow). `nparams` = `cfg.parameters.len()`.
+    fn dispatch_ensemble_target(
+        &mut self,
+        prefix: &[Vec<u8>],
+        argv: &[*mut TclObj],
+        nparams: usize,
+    ) -> Code {
         let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len() - 1);
-        for w in &prefix {
+        for w in prefix {
             let o = new_string(w);
             // SAFETY: fresh obj; take the owning +1 the new argv holds.
             unsafe { obj::incr_ref_count(o) };
@@ -3658,6 +3696,56 @@ impl Interp {
         let code = self.dispatch(&new_argv);
         release_all(&new_argv);
         code
+    }
+
+    /// Invoke an ensemble's `-unknown` handler on a subcommand miss
+    /// (`EnsembleUnknownCallback`): `handler… ensembleFQN argv[1..]…`. An empty
+    /// `TCL_OK` result asks for a reparse (the handler defined the subcommand); a
+    /// non-empty one is the replacement command prefix; anything else fails.
+    fn ensemble_unknown(
+        &mut self,
+        cfg: &crate::ensemble::EnsembleConfig,
+        argv: &[*mut TclObj],
+    ) -> EnsembleUnknown {
+        let ens_fqn = self
+            .resolve_cmd_fqn(&obj_bytes(argv[0]))
+            .unwrap_or_else(|| obj_bytes(argv[0]));
+        let mut hv: Vec<*mut TclObj> = Vec::with_capacity(cfg.unknown.len() + argv.len());
+        for w in &cfg.unknown {
+            let o = new_string(w);
+            unsafe { obj::incr_ref_count(o) };
+            hv.push(o);
+        }
+        let fqo = new_string(&ens_fqn);
+        unsafe { obj::incr_ref_count(fqo) };
+        hv.push(fqo);
+        for &a in &argv[1..] {
+            unsafe { obj::incr_ref_count(a) };
+            hv.push(a);
+        }
+        let code = self.dispatch(&hv);
+        release_all(&hv);
+        match code {
+            Code::Ok => {
+                let res = obj_bytes(self.get_obj_result());
+                match crate::parse::split_list(&res) {
+                    Ok(prefix) if !prefix.is_empty() => EnsembleUnknown::Prefix(prefix),
+                    Ok(_) => EnsembleUnknown::Reparse,
+                    Err(e) => EnsembleUnknown::Failed(self.error(e.message())),
+                }
+            }
+            Code::Error => EnsembleUnknown::Failed(Code::Error),
+            other => {
+                let mut m = b"unknown subcommand handler returned bad code: ".to_vec();
+                m.extend_from_slice(match other {
+                    Code::Return => b"return".as_slice(),
+                    Code::Break => b"break",
+                    Code::Continue => b"continue",
+                    _ => b"?",
+                });
+                EnsembleUnknown::Failed(self.error(&m))
+            }
+        }
     }
 
     /// Invoke `::tcl::mathfunc::<fname>` (resolved **absolutely**, so it works

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1788,6 +1788,26 @@ impl Interp {
     /// Simple command names in the namespace named `qualifier` (absolute or
     /// relative to the current namespace), or empty if it does not exist — for
     /// a namespace-qualified `info commands ::ns::pattern`.
+    /// The canonical fully-qualified prefix (ending in `::`) of the namespace a
+    /// pattern qualifier addresses (`info commands ns::pat`): `::` for the global
+    /// namespace, `::a::b::` otherwise. Resolves a *relative* qualifier against
+    /// the current namespace, so `info commands` results are always absolute
+    /// (matching C, where names are re-qualified through the namespace's
+    /// `fullName`). `None` if the namespace doesn't exist.
+    pub(crate) fn canonical_ns_prefix(&self, qualifier: &[u8]) -> Option<Vec<u8>> {
+        let ns = self.namespaces.borrow();
+        let id = if qualifier.is_empty() {
+            GLOBAL
+        } else {
+            ns.find_namespace(self.current_ns.get(), qualifier)?
+        };
+        let mut p = ns.qualified_name(id);
+        if id != GLOBAL {
+            p.extend_from_slice(b"::"); // global's qualified_name is already `::`
+        }
+        Some(p)
+    }
+
     pub(crate) fn commands_in_namespace(&self, qualifier: &[u8]) -> Vec<Vec<u8>> {
         let ns = self.namespaces.borrow();
         // An empty qualifier (a leading `::pattern`) addresses the global ns.

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4222,16 +4222,56 @@ impl Interp {
         src: &[u8],
         flags: crate::subst::SubstFlags,
     ) -> Result<Vec<u8>, Code> {
+        self.do_subst_located(src, flags, None)
+    }
+
+    /// [`do_subst`](Self::do_subst) with the input string's TIP 280 location
+    /// (the `subst` command's argument word): a `[...]` inside the substituted
+    /// string then reports the line it appears on (C compiles `subst` with the
+    /// argument's line table). `loc` is `None` for internal callers that do not
+    /// track lines (`dict map` key substitution), where the `[...]` is line-
+    /// tracked relative to the enclosing frame as usual.
+    pub(crate) fn do_subst_located(
+        &mut self,
+        src: &[u8],
+        flags: crate::subst::SubstFlags,
+        loc: Option<(Option<Rc<[u8]>>, u32)>,
+    ) -> Result<Vec<u8>, Code> {
         let body = crate::subst::scan(src, flags);
         match &body {
             WordBody::Literal(b) => Ok(b.to_vec()),
-            WordBody::Parts(parts) => self.resolve_subst_parts(parts),
+            WordBody::Parts(parts) => {
+                // Align the enclosing frame to the argument word's file+line, so
+                // each `[...]`'s line (computed by `eval_command_subst` against
+                // `src`) is file-absolute. Saved/restored around the resolution.
+                let saved = loc.and_then(|(file, line)| {
+                    let mut frames = self.cmd_frames.borrow_mut();
+                    frames.last_mut().map(|top| {
+                        let prev = (top.line_base, top.file.clone());
+                        top.line_base = line.saturating_sub(1);
+                        if file.is_some() {
+                            top.file = file;
+                        }
+                        prev
+                    })
+                });
+                let result = self.resolve_subst_parts(src, parts);
+                if let Some((line_base, file)) = saved {
+                    if let Some(top) = self.cmd_frames.borrow_mut().last_mut() {
+                        top.line_base = line_base;
+                        top.file = file;
+                    }
+                }
+                result
+            }
         }
     }
 
-    /// Resolve substitution `parts` to bytes, propagating any non-OK code (the
-    /// `subst`-command path; cf. `substitute_word`, which builds an object).
-    fn resolve_subst_parts(&mut self, parts: &[WordPart]) -> Result<Vec<u8>, Code> {
+    /// Resolve substitution `parts` (scanned from `src`) to bytes, propagating
+    /// any non-OK code (the `subst`-command path; cf. `substitute_word`, which
+    /// builds an object). `src` lets a `[...]` part advance the `info frame`
+    /// line to its own position via [`eval_command_subst`](Self::eval_command_subst).
+    fn resolve_subst_parts(&mut self, src: &[u8], parts: &[WordPart]) -> Result<Vec<u8>, Code> {
         let mut out = Vec::new();
         for part in parts {
             match part {
@@ -4250,7 +4290,7 @@ impl Interp {
                     }
                 }
                 WordPart::Command(script) => {
-                    let code = self.eval_str(script);
+                    let code = self.eval_command_subst(src, script);
                     if code != Code::Ok {
                         return Err(code);
                     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -902,14 +902,25 @@ impl Interp {
     }
 
     /// Rebind the ensemble command `name` with an updated configuration
-    /// (`namespace ensemble configure` set form). `name` must already resolve to
-    /// an ensemble; rebinds at the same location `create_ensemble` would choose.
+    /// (`namespace ensemble configure` set form). `name` already resolves to an
+    /// ensemble (the caller read it via [`ensemble_config`](Self::ensemble_config)),
+    /// so the update lands at the namespace where it *resolves* — which may be
+    /// reached via `namespace path`, not the current namespace — rather than
+    /// creating a shadowing copy in the current namespace.
     pub(crate) fn set_ensemble_config(
         &mut self,
         name: &[u8],
         cfg: crate::ensemble::EnsembleConfig,
     ) {
-        self.create_ensemble(name, cfg);
+        if !self.namespaces.borrow_mut().rebind_resolved(
+            self.current_ns.get(),
+            name,
+            Command::Ensemble(cfg.clone()),
+        ) {
+            // Should not happen (the caller verified it resolves); create at the
+            // current-namespace location as a fallback.
+            self.create_ensemble(name, cfg);
+        }
     }
 
     /// Every alias command's name across the whole tree (`interp aliases`).

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -759,7 +759,8 @@ impl Interp {
     /// namespace (where its body runs, and where it is bound) is the namespace
     /// `name` lands in — **relative to the current namespace** (so `proc next`
     /// inside `namespace eval counter` binds `::counter::next`, not a global).
-    pub(crate) fn define_proc(&mut self, name: &[u8], params: Vec<Param>, body: Vec<u8>) {
+    pub(crate) fn define_proc(&mut self, name: &[u8], params: Vec<Param>, body_obj: *mut TclObj) {
+        let body = obj_bytes(body_obj);
         let ns = self
             .namespaces
             .borrow_mut()
@@ -777,20 +778,17 @@ impl Interp {
             fqn.extend_from_slice(b"::");
         }
         fqn.extend_from_slice(&tail);
-        // A proc defined while a file is being sourced records that file, so its
-        // body frame reports `type source`. Its body lines are then file-absolute
-        // (C's literal line table): the base is the file line of the `proc`
-        // command minus one (the body opens on that line). Eval-defined procs
-        // keep body-relative lines (base 0).
-        let source = self
-            .script_stack
-            .borrow()
-            .last()
-            .map(|f| Rc::from(f.as_slice()));
-        let body_line_base = if source.is_some() {
-            self.current_cmd_line().saturating_sub(1)
-        } else {
-            0
+        // The proc's body frame reports `type source` with file-absolute lines
+        // when its body argument is a located literal (TIP 280 LABC) — the body
+        // word, not the `proc` command, carries the location, so a `proc` whose
+        // body opens on a later line than the command is still file-accurate, and
+        // a *dynamic* body (`proc p {} $bodyVar`, or a body from a dynamically
+        // built list) has no location and stays body-relative (`type proc`),
+        // matching C's literal line table rather than a whole-file "am I
+        // sourcing" flag.
+        let (source, body_line_base) = match self.arg_loc(body_obj) {
+            Some((file @ Some(_), line)) => (file, line.saturating_sub(1)),
+            _ => (None, 0),
         };
         let def = Rc::new(ProcDef {
             params,
@@ -2712,6 +2710,43 @@ impl Interp {
             return self.eval_framed(&bytes, frame);
         }
         self.eval_str(&obj_bytes(body))
+    }
+
+    /// The TIP 280 source location recorded for `obj` (the literal-argument
+    /// location table), or `None` for a dynamic value. Lets a command that
+    /// re-splits a literal (e.g. `switch`'s single-list-arg form) recover the
+    /// enclosing file + the list word's line, to derive its sub-bodies' lines.
+    pub(crate) fn arg_location(&self, obj: *mut TclObj) -> Option<(Option<Rc<[u8]>>, u32)> {
+        self.arg_loc(obj)
+    }
+
+    /// Evaluate a body whose file-absolute first `line` and `file` were computed
+    /// by the caller (C's `switch`/list-element TIP 280 path, where the body is a
+    /// sub-element of a list literal, so it has no `Tcl_Obj` of its own to carry
+    /// a location). Runs as a line-advancing `type source` frame.
+    pub(crate) fn eval_located_body(
+        &mut self,
+        file: Option<Rc<[u8]>>,
+        line: u32,
+        body: &[u8],
+    ) -> Code {
+        let mut frame = self.inherited_cmd_frame();
+        frame.kind = FrameKind::Source;
+        frame.file = file;
+        frame.line_base = line.saturating_sub(1);
+        self.eval_framed(body, frame)
+    }
+
+    /// Evaluate a body whose source location is unknown (C's switch `line = -1`
+    /// case: a dynamically-built list body). It runs as `type eval` with **no
+    /// file**, so a command defined inside (e.g. `proc`) is body-relative
+    /// (`type proc`, line 1) rather than inheriting the enclosing file's lines.
+    pub(crate) fn eval_unlocated_body(&mut self, body: &[u8]) -> Code {
+        let mut frame = self.inherited_cmd_frame();
+        frame.kind = FrameKind::Eval;
+        frame.file = None;
+        frame.line_base = 0;
+        self.eval_framed(body, frame)
     }
 
     /// Evaluate an `eval`/`uplevel` body as its own `info frame` level (it

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1619,8 +1619,92 @@ impl Interp {
         // still exists, then the namespace is torn down, then the callbacks run
         // — so a callback sees the namespace already gone (C's order; oo-11.8).
         let victims = self.take_ns_unset_traces(ns);
+        // The commands in the namespace tree are deleted too: collect+remove
+        // their command traces (firing the `delete` ones afterwards). Without
+        // this, a delete-trace on `::ns::cmd` would *linger* after `ns` is gone
+        // and mis-fire when a same-named command is later created (the stale
+        // `::x → namespace delete ::` chain that wiped the global namespace).
+        let cmd_victims = self.take_ns_cmd_traces(ns);
         self.namespaces.borrow_mut().delete_namespace_by_id(ns);
         self.fire_unset_callbacks(victims);
+        self.fire_deleted_cmd_callbacks(cmd_victims);
+    }
+
+    /// Remove and return the `(fqn, command)` of every command trace on a command
+    /// in `ns` or a descendant (so the command's deletion via namespace teardown
+    /// drops its traces, as C does). Only `delete`-op traces are returned for
+    /// firing; `rename`-only traces are removed silently (a deletion isn't a
+    /// rename).
+    fn take_ns_cmd_traces(&self, ns: NsId) -> Vec<(Vec<u8>, Vec<u8>)> {
+        if self.traces.borrow().cmd_traces.is_empty() {
+            return Vec::new();
+        }
+        // The fully-qualified prefixes (`::a::b::`) of the namespace and every
+        // descendant; a command trace's name is `<homeQual>::<simple>`, so it
+        // belongs to the tree iff its qualifier prefix is one of these.
+        let quals: std::collections::HashSet<Vec<u8>> = {
+            let ns_ref = self.namespaces.borrow();
+            ns_ref
+                .descendant_ids(ns)
+                .into_iter()
+                .map(|i| {
+                    let mut q = ns_ref.qualified_name(i);
+                    if q != b"::" {
+                        q.extend_from_slice(b"::");
+                    }
+                    q
+                })
+                .collect()
+        };
+        let mut victims = Vec::new();
+        let mut traces = self.traces.borrow_mut();
+        traces.cmd_traces.retain(|t| {
+            // The command's home-namespace prefix: everything up to and
+            // including the last `::` (global commands are `::cmd` → `::`).
+            let qual: &[u8] = match t.name.windows(2).rposition(|w| w == b"::") {
+                Some(0) => b"::",
+                Some(i) => &t.name[..i + 2],
+                None => b"",
+            };
+            if quals.contains(qual) {
+                if (t.ops & crate::cmd_trace::ops::DELETE) != 0 {
+                    victims.push((t.name.clone(), t.command.clone()));
+                }
+                false // drop every trace on a command that is going away
+            } else {
+                true
+            }
+        });
+        victims
+    }
+
+    /// Fire collected command `delete`-trace callbacks as `command oldName {}
+    /// delete` after the namespace has been torn down (errors ignored — a delete
+    /// trace's result is discarded, matching C).
+    fn fire_deleted_cmd_callbacks(&mut self, victims: Vec<(Vec<u8>, Vec<u8>)>) {
+        if victims.is_empty() || self.traces.borrow().exec_firing > 0 {
+            return;
+        }
+        let saved = self.result.get();
+        unsafe { obj::incr_ref_count(saved) };
+        self.traces.borrow_mut().exec_firing += 1;
+        for (name, cmd) in victims {
+            let args = crate::list::new_list_obj(&[
+                new_string(&name),
+                new_string(b""),
+                new_string(b"delete"),
+            ]);
+            let mut line = cmd;
+            line.push(b' ');
+            line.extend_from_slice(&obj_bytes(args));
+            drop_fresh(args);
+            let _ = self.eval_str(&line);
+        }
+        self.traces.borrow_mut().exec_firing -= 1;
+        unsafe {
+            obj::decr_ref_count(self.result.get());
+            self.result.set(saved);
+        }
     }
 
     /// Remove and return the `(fullName, command)` of every *unset* variable

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -169,6 +169,10 @@ struct CmdFrame {
     oo: Option<(Vec<u8>, Vec<u8>, Vec<u8>)>,
 }
 
+/// A TIP 280 literal-argument location: `(objPtr, file, line)` (C's `lineLABCPtr`
+/// entry) — see [`Interp::arg_locs`].
+type ArgLoc = (*mut TclObj, Option<Rc<[u8]>>, u32);
+
 /// The outcome of an ensemble `-unknown` handler (`EnsembleUnknownCallback`).
 enum EnsembleUnknown {
     /// A non-empty result: the replacement command prefix to dispatch.
@@ -507,6 +511,15 @@ pub struct InterpState {
     /// reports file-relative `info frame` lines). Set per command just before
     /// dispatch; consumers must read it before re-entering the eval loop.
     arg_lines: RefCell<Vec<u32>>,
+    /// TIP 280 literal-argument locations (C's `lineLABCPtr`): a stack of
+    /// `(objPtr, file, line)` for each literal word of every command executing in
+    /// a *sourced* context. When such a literal is later evaluated as a script
+    /// (`eval`/`uplevel $bodyVar`), the eval reports `type source` at the
+    /// literal's original file+line instead of `type eval` — the test-body case
+    /// (tcltest's `uplevel 1 $script`). Entries are pushed before a command
+    /// dispatches and truncated after it returns (dynamic scope), so the obj
+    /// pointers stay valid for the lookup.
+    arg_locs: RefCell<Vec<ArgLoc>>,
     /// `eval_str` nesting depth. The outermost eval (depth returning to 0)
     /// publishes the accumulated error trace to the `::errorInfo`/`::errorCode`
     /// globals; nested evals (proc bodies, `[cmd]` subst, control bodies) just
@@ -577,6 +590,7 @@ impl Interp {
             oo: RefCell::new(crate::cmd_oo::OoState::default()),
             cmd_frames: RefCell::new(Vec::new()),
             arg_lines: RefCell::new(Vec::new()),
+            arg_locs: RefCell::new(Vec::new()),
             eval_depth: Cell::new(0),
             cmd_count: Cell::new(0),
             bgerror: RefCell::new(Vec::new()),
@@ -2629,6 +2643,84 @@ impl Interp {
         self.eval_framed(script, frame)
     }
 
+    /// `eval` of a single body **object** — like [`eval_body`](Self::eval_body),
+    /// but a literal obj with a recorded source location (TIP 280 LABC) runs as
+    /// `type source` at its original file+line (the test-body case) rather than
+    /// `type eval`.
+    pub(crate) fn eval_body_obj(&mut self, obj: *mut TclObj) -> Code {
+        // A pure list is one command, dispatched by element identity (so a
+        // contained literal keeps its source location — C's list-eval path).
+        if crate::list::is_pure_list(obj) {
+            return self.dispatch_list_obj(obj);
+        }
+        let mut frame = self.inherited_cmd_frame();
+        if let Some((file, line)) = self.arg_loc(obj) {
+            frame.kind = FrameKind::Source;
+            frame.file = file;
+            frame.line_base = line.saturating_sub(1);
+        }
+        let bytes = obj_bytes(obj);
+        self.eval_framed(&bytes, frame)
+    }
+
+    /// Dispatch a pure-list script object as a single command, using its element
+    /// objects directly (no stringify/re-parse) — this preserves each element's
+    /// `Tcl_Obj` identity, so a nested `eval`/`uplevel $bodyVar` still finds the
+    /// body's TIP 280 source location.
+    fn dispatch_list_obj(&mut self, obj: *mut TclObj) -> Code {
+        let elems = match crate::list::list_elements(obj) {
+            Ok(e) => e,
+            Err(e) => return self.error(e.message()),
+        };
+        if elems.is_empty() {
+            self.set_result_bytes(b"");
+            return Code::Ok;
+        }
+        for &e in &elems {
+            // SAFETY: live element; take an owning +1 for the call.
+            unsafe { obj::incr_ref_count(e) };
+        }
+        let code = self.dispatch(&elems);
+        release_all(&elems);
+        code
+    }
+
+    /// `uplevel` of a single body **object** — the redirected-scope variant of
+    /// [`eval_body_obj`](Self::eval_body_obj). A located literal keeps its source
+    /// provenance; a dynamic body is `type eval`, no file.
+    pub(crate) fn eval_uplevel_obj(&mut self, target_level: usize, obj: *mut TclObj) -> Code {
+        let loc = self.arg_loc(obj);
+        let prev_level = self.frames.borrow_mut().set_active_level(target_level);
+        let prev_ns = self.current_ns.get();
+        self.current_ns
+            .set(self.frames.borrow().frame_ns(target_level));
+        let code = if crate::list::is_pure_list(obj) {
+            // Pure list → one command by element identity (see `dispatch_list_obj`).
+            self.dispatch_list_obj(obj)
+        } else {
+            let mut frame = self.inherited_cmd_frame();
+            frame.level = target_level;
+            frame.omit_level = true;
+            match loc {
+                Some((file, line)) => {
+                    frame.kind = FrameKind::Source;
+                    frame.file = file;
+                    frame.line_base = line.saturating_sub(1);
+                }
+                None => {
+                    frame.kind = FrameKind::Eval;
+                    frame.file = None;
+                    frame.line_base = 0;
+                }
+            }
+            let bytes = obj_bytes(obj);
+            self.eval_framed(&bytes, frame)
+        };
+        self.frames.borrow_mut().set_active_level(prev_level);
+        self.current_ns.set(prev_ns);
+        code
+    }
+
     /// Evaluate one parsed command, then — if it errored — append its
     /// `while executing` / `invoked from within` frame to the error trace
     /// (`TclLogCommandInfo`), using the command's source slice and line.
@@ -2704,13 +2796,45 @@ impl Interp {
             .iter()
             .map(|w| cmd_line + count_newlines(&src[w0..w.start.min(src.len())]))
             .collect();
+
+        // TIP 280 LABC: in a sourced context, record each literal word's obj →
+        // (file, line) so a later `eval`/`uplevel` of that obj reports `type
+        // source`. Gated to commands without `{*}` (so word index == argv index)
+        // and popped after dispatch (dynamic scope; the objs live until then).
+        let file = self.cmd_frames.borrow().last().and_then(|f| f.file.clone());
+        let mut pushed = 0usize;
+        if file.is_some() && words.iter().all(|w| !w.expand) {
+            let mut locs = self.arg_locs.borrow_mut();
+            for (i, w) in words.iter().enumerate() {
+                if matches!(w.body, parse::WordBody::Literal(_)) {
+                    locs.push((argv[i], file.clone(), arg_lines[i]));
+                    pushed += 1;
+                }
+            }
+        }
         *self.arg_lines.borrow_mut() = arg_lines;
 
         let code = self.dispatch(&argv);
+        if pushed > 0 {
+            let mut locs = self.arg_locs.borrow_mut();
+            let keep = locs.len() - pushed;
+            locs.truncate(keep);
+        }
         // Safe to release argv now: a command that made an argv element its
         // result did so via set_obj_result, which holds an independent +1.
         release_all(&argv);
         code
+    }
+
+    /// The recorded TIP 280 source location of a script obj (C's `lineLABCPtr`
+    /// lookup), or `None` for a dynamic/computed script. Scans newest-first.
+    fn arg_loc(&self, obj: *mut TclObj) -> Option<(Option<Rc<[u8]>>, u32)> {
+        self.arg_locs
+            .borrow()
+            .iter()
+            .rev()
+            .find(|(o, _, _)| *o == obj)
+            .map(|(_, f, l)| (f.clone(), *l))
     }
 
     /// Look up `argv[0]` and invoke it; on a miss, fall to the `unknown` handler

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2627,12 +2627,34 @@ impl Interp {
             file: top.and_then(|f| f.file.clone()),
             proc: top.and_then(|f| f.proc.clone()),
             level: top.map_or(0, |f| f.level),
-            omit_level: false,
+            // Inherit the enclosing frame's level-reachability (an inline body
+            // of an `uplevel`-redirected script also omits `level`).
+            omit_level: top.is_some_and(|f| f.omit_level),
             line_base,
             cmd: Vec::new(),
             line: 1,
             oo: top.and_then(|f| f.oo.clone()),
         }
+    }
+
+    /// Evaluate an inline **control-command body** (`if`/`while`/`for`/`foreach`/
+    /// …). A body that is a located literal (TIP 280) runs as its own
+    /// line-advancing source frame at the body's file line, so `info frame`
+    /// reports the executing command's true line; a pure list dispatches by
+    /// element identity; a dynamic body keeps the cheap no-frame eval.
+    pub(crate) fn eval_control_body(&mut self, body: *mut TclObj) -> Code {
+        if crate::list::is_pure_list(body) {
+            return self.dispatch_list_obj(body);
+        }
+        if let Some((file, line)) = self.arg_loc(body) {
+            let mut frame = self.inherited_cmd_frame();
+            frame.kind = FrameKind::Source;
+            frame.file = file;
+            frame.line_base = line.saturating_sub(1);
+            let bytes = obj_bytes(body);
+            return self.eval_framed(&bytes, frame);
+        }
+        self.eval_str(&obj_bytes(body))
     }
 
     /// Evaluate an `eval`/`uplevel` body as its own `info frame` level (it

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2732,7 +2732,8 @@ impl Interp {
     /// not the enclosing command's line).
     pub(crate) fn eval_control_body(&mut self, body: *mut TclObj) -> Code {
         if crate::list::is_pure_list(body) {
-            return self.dispatch_list_obj(body);
+            let frame = self.unlocated_frame();
+            return self.dispatch_list_obj(body, frame);
         }
         if let Some((file, line)) = self.arg_loc(body) {
             let mut frame = self.inherited_cmd_frame();
@@ -2787,15 +2788,23 @@ impl Interp {
         self.eval_framed(body, frame)
     }
 
+    /// A `type eval`, no-file, body-relative `CmdFrame` (inheriting the enclosing
+    /// proc/level) — the frame for a body with no source location (a dynamic
+    /// script, or a canonical-list body).
+    fn unlocated_frame(&self) -> CmdFrame {
+        let mut frame = self.inherited_cmd_frame();
+        frame.kind = FrameKind::Eval;
+        frame.file = None;
+        frame.line_base = 0;
+        frame
+    }
+
     /// Evaluate a body whose source location is unknown (C's switch `line = -1`
     /// case: a dynamically-built list body). It runs as `type eval` with **no
     /// file**, so a command defined inside (e.g. `proc`) is body-relative
     /// (`type proc`, line 1) rather than inheriting the enclosing file's lines.
     pub(crate) fn eval_unlocated_body(&mut self, body: &[u8]) -> Code {
-        let mut frame = self.inherited_cmd_frame();
-        frame.kind = FrameKind::Eval;
-        frame.file = None;
-        frame.line_base = 0;
+        let frame = self.unlocated_frame();
         self.eval_framed(body, frame)
     }
 
@@ -2856,9 +2865,11 @@ impl Interp {
     /// `type eval`.
     pub(crate) fn eval_body_obj(&mut self, obj: *mut TclObj) -> Code {
         // A pure list is one command, dispatched by element identity (so a
-        // contained literal keeps its source location — C's list-eval path).
+        // contained literal keeps its source location — C's list-eval path),
+        // inside its own `type eval` frame.
         if crate::list::is_pure_list(obj) {
-            return self.dispatch_list_obj(obj);
+            let frame = self.unlocated_frame();
+            return self.dispatch_list_obj(obj, frame);
         }
         let mut frame = self.inherited_cmd_frame();
         match self.arg_loc(obj) {
@@ -2884,7 +2895,7 @@ impl Interp {
     /// objects directly (no stringify/re-parse) — this preserves each element's
     /// `Tcl_Obj` identity, so a nested `eval`/`uplevel $bodyVar` still finds the
     /// body's TIP 280 source location.
-    fn dispatch_list_obj(&mut self, obj: *mut TclObj) -> Code {
+    fn dispatch_list_obj(&mut self, obj: *mut TclObj, frame: CmdFrame) -> Code {
         let elems = match crate::list::list_elements(obj) {
             Ok(e) => e,
             Err(e) => return self.error(e.message()),
@@ -2893,12 +2904,21 @@ impl Interp {
             self.set_result_bytes(b"");
             return Code::Ok;
         }
+        // The pure list is exactly one command; push its `info frame` level (a
+        // canonical-list body has no source location, so the frame is the
+        // `type eval`, body-relative one the caller supplies) and report the list
+        // string as the executing command, before dispatching by element identity.
+        let mut owned = frame;
+        owned.cmd = obj_bytes(obj);
+        owned.line = owned.line_base + 1;
+        self.cmd_frames.borrow_mut().push(owned);
         for &e in &elems {
             // SAFETY: live element; take an owning +1 for the call.
             unsafe { obj::incr_ref_count(e) };
         }
         let code = self.dispatch(&elems);
         release_all(&elems);
+        self.cmd_frames.borrow_mut().pop();
         code
     }
 
@@ -2912,8 +2932,12 @@ impl Interp {
         self.current_ns
             .set(self.frames.borrow().frame_ns(target_level));
         let code = if crate::list::is_pure_list(obj) {
-            // Pure list → one command by element identity (see `dispatch_list_obj`).
-            self.dispatch_list_obj(obj)
+            // Pure list → one command by element identity (see `dispatch_list_obj`),
+            // in a `type eval` frame redirected to the target level.
+            let mut frame = self.unlocated_frame();
+            frame.level = target_level;
+            frame.omit_level = true;
+            self.dispatch_list_obj(obj, frame)
         } else {
             let mut frame = self.inherited_cmd_frame();
             frame.level = target_level;

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2773,12 +2773,13 @@ impl Interp {
         self.eval_framed(body, frame)
     }
 
-    /// Evaluate an `eval`/`uplevel` body as its own `info frame` level (it
-    /// inherits the enclosing proc/level). The errorInfo `("eval" body line N)`
+    /// Evaluate a multi-arg `eval`/`uplevel` body (the args were space-joined
+    /// into a fresh dynamic script) as its own `info frame` level. Such a body has
+    /// no source location, so it is `type eval` with body-relative lines (C's
+    /// `TclEvalObjEx` of a non-literal). The errorInfo `("eval" body line N)`
     /// frame is appended separately by the caller.
     pub(crate) fn eval_body(&mut self, script: &[u8]) -> Code {
-        let frame = self.inherited_cmd_frame();
-        self.eval_framed(script, frame)
+        self.eval_unlocated_body(script)
     }
 
     /// Evaluate a `[...]` command substitution's inner `script`. A `[cmd]` is
@@ -2834,10 +2835,20 @@ impl Interp {
             return self.dispatch_list_obj(obj);
         }
         let mut frame = self.inherited_cmd_frame();
-        if let Some((file, line)) = self.arg_loc(obj) {
-            frame.kind = FrameKind::Source;
-            frame.file = file;
-            frame.line_base = line.saturating_sub(1);
+        match self.arg_loc(obj) {
+            // A located literal body keeps its file+line (`type source`).
+            Some((file, line)) => {
+                frame.kind = FrameKind::Source;
+                frame.file = file;
+                frame.line_base = line.saturating_sub(1);
+            }
+            // A dynamic body (`eval $script`) is `type eval`, body-relative — it
+            // does not inherit the enclosing file's lines (C's `TclEvalObjEx`).
+            None => {
+                frame.kind = FrameKind::Eval;
+                frame.file = None;
+                frame.line_base = 0;
+            }
         }
         let bytes = obj_bytes(obj);
         self.eval_framed(&bytes, frame)

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2717,7 +2717,10 @@ impl Interp {
     /// …). A body that is a located literal (TIP 280) runs as its own
     /// line-advancing source frame at the body's file line, so `info frame`
     /// reports the executing command's true line; a pure list dispatches by
-    /// element identity; a dynamic body keeps the cheap no-frame eval.
+    /// element identity; a dynamic body (a script in a variable) runs as its own
+    /// `type eval` level with body-relative lines (C's `TclEvalObjEx` always
+    /// pushes a cmdframe — `info frame` reports `line 3` for the body's 3rd line,
+    /// not the enclosing command's line).
     pub(crate) fn eval_control_body(&mut self, body: *mut TclObj) -> Code {
         if crate::list::is_pure_list(body) {
             return self.dispatch_list_obj(body);
@@ -2730,7 +2733,7 @@ impl Interp {
             let bytes = obj_bytes(body);
             return self.eval_framed(&bytes, frame);
         }
-        self.eval_str(&obj_bytes(body))
+        self.eval_unlocated_body(&obj_bytes(body))
     }
 
     /// The TIP 280 source location recorded for `obj` (the literal-argument

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -247,6 +247,27 @@ fn count_newlines(s: &[u8]) -> u32 {
     s.iter().filter(|&&b| b == b'\n').count() as u32
 }
 
+/// For each element of the list literal `src`, its `(newlines-before-the-element,
+/// is-literal)` — the offset-aware complement to `split_list`, used to line-track
+/// `{*}`-expanded literal elements (C's `TclListLines`). Returns `None` for a
+/// non-UTF-8 / malformed list (the caller then falls back to body-relative).
+fn scan_list_offsets(src: &[u8]) -> Option<Vec<(u32, bool)>> {
+    let s = core::str::from_utf8(src).ok()?;
+    let mut out = Vec::new();
+    let mut pos = 0;
+    loop {
+        match tcl_syntax::list::find_element(s, pos) {
+            Ok(Some(e)) => {
+                out.push((count_newlines(&src[..e.value.start]), e.literal));
+                pos = e.next;
+            }
+            Ok(None) => break,
+            Err(_) => return None,
+        }
+    }
+    Some(out)
+}
+
 /// The error stack-trace accumulator — the runtime's analogue of `iPtr`'s
 /// `errorInfo`/`errorCode`/`errorLine`/`ERR_ALREADY_LOGGED` (PC-4). The trace is
 /// built **incrementally as the error unwinds** (`TclLogCommandInfo` +
@@ -2904,8 +2925,23 @@ impl Interp {
 
     /// Substitute each word of a command (with `{*}` expansion), then dispatch.
     fn eval_words(&mut self, src: &[u8], words: &[parse::Word]) -> Code {
+        // The command's reported line + source file (for TIP 280 argument-line
+        // tracking and the LABC literal-location table), and the first word's
+        // offset (to measure each word's line within the command).
+        let cmd_line = self.cmd_frames.borrow().last().map_or(0, |f| f.line);
+        let file = self.cmd_frames.borrow().last().and_then(|f| f.file.clone());
+        let w0 = words.first().map_or(0, |w| w.start);
+
         let mut argv: Vec<*mut TclObj> = Vec::new();
+        // Per-**argv-element** file-absolute line (aligned with `argv`, so `{*}`
+        // expansion stays correct), and the argv indices of literal arguments to
+        // record in the LABC table (`eval`/`uplevel`/proc body source locations).
+        let mut arg_lines: Vec<u32> = Vec::new();
+        let mut labc: Vec<usize> = Vec::new();
+
         for w in words {
+            let word_line = cmd_line + count_newlines(&src[w0..w.start.min(src.len())]);
+            let is_literal = matches!(w.body, parse::WordBody::Literal(_));
             let obj = match self.substitute_word(src, &w.body) {
                 Ok(o) => o, // owned (+1)
                 Err(code) => {
@@ -2917,21 +2953,40 @@ impl Interp {
                 // Split the substituted value as a list; each element is an arg.
                 let bytes = obj_bytes(obj);
                 unsafe { obj::decr_ref_count(obj) }; // done with the word obj
-                match parse::split_list(&bytes) {
-                    Ok(elems) => {
-                        for e in elems {
-                            let eo = new_string(&e);
-                            unsafe { obj::incr_ref_count(eo) };
-                            argv.push(eo);
-                        }
-                    }
+                let elems = match parse::split_list(&bytes) {
+                    Ok(e) => e,
                     Err(e) => {
                         release_all(&argv);
                         return self.error(e.message());
                     }
+                };
+                // For a `{*}` of a *literal* word, each element keeps its source
+                // line (its offset within the literal — C's `TclListLines`), so a
+                // body-defining element (`namespace {*}{eval ns {proc …}}`) is
+                // `type source`. A dynamic `{*}$v` has no per-element location.
+                let offsets = is_literal.then(|| scan_list_offsets(&bytes)).flatten();
+                for (k, e) in elems.iter().enumerate() {
+                    let eo = new_string(e);
+                    unsafe { obj::incr_ref_count(eo) };
+                    let idx = argv.len();
+                    argv.push(eo);
+                    let (nl, lit) = offsets
+                        .as_ref()
+                        .and_then(|o| o.get(k))
+                        .copied()
+                        .unwrap_or((0, false));
+                    arg_lines.push(word_line + nl);
+                    if file.is_some() && lit {
+                        labc.push(idx);
+                    }
                 }
             } else {
+                let idx = argv.len();
                 argv.push(obj); // already owned (+1)
+                arg_lines.push(word_line);
+                if file.is_some() && is_literal {
+                    labc.push(idx);
+                }
             }
         }
 
@@ -2939,33 +2994,14 @@ impl Interp {
             return Code::Ok;
         }
 
-        // TIP 280 argument lines: each word's file-absolute source line, for a
-        // body-defining command (`proc`/`method`/`oo::define`/…) to stamp its
-        // body so `info frame` reports file-relative lines even when the body
-        // begins on a later line than the command. Computed relative to the
-        // command's already-set line (cheap), and aligned with `words` (the
-        // body-definers do not use `{*}`, so word index == argv index). Set
-        // *after* substitution so a nested `[cmd]` cannot clobber it.
-        let cmd_line = self.cmd_frames.borrow().last().map_or(0, |f| f.line);
-        let w0 = words.first().map_or(0, |w| w.start);
-        let arg_lines: Vec<u32> = words
-            .iter()
-            .map(|w| cmd_line + count_newlines(&src[w0..w.start.min(src.len())]))
-            .collect();
-
-        // TIP 280 LABC: in a sourced context, record each literal word's obj →
-        // (file, line) so a later `eval`/`uplevel` of that obj reports `type
-        // source`. Gated to commands without `{*}` (so word index == argv index)
-        // and popped after dispatch (dynamic scope; the objs live until then).
-        let file = self.cmd_frames.borrow().last().and_then(|f| f.file.clone());
-        let mut pushed = 0usize;
-        if file.is_some() && words.iter().all(|w| !w.expand) {
+        // TIP 280 LABC: record each literal argument's obj → (file, line) so a
+        // later `eval`/`uplevel`/`proc`-body of that obj reports `type source`.
+        // Popped after dispatch (dynamic scope; the objs live until then).
+        let pushed = labc.len();
+        if pushed > 0 {
             let mut locs = self.arg_locs.borrow_mut();
-            for (i, w) in words.iter().enumerate() {
-                if matches!(w.body, parse::WordBody::Literal(_)) {
-                    locs.push((argv[i], file.clone(), arg_lines[i]));
-                    pushed += 1;
-                }
+            for &idx in &labc {
+                locs.push((argv[idx], file.clone(), arg_lines[idx]));
             }
         }
         *self.arg_lines.borrow_mut() = arg_lines;

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2571,8 +2571,24 @@ impl Interp {
     /// it (so `info frame` sees the live command/line); an unframed call (`None`,
     /// i.e. command substitution) leaves the enclosing frame untouched.
     fn eval_script(&mut self, src: &[u8], owned: Option<CmdFrame>) -> Code {
+        self.eval_script_mode(src, owned, false)
+    }
+
+    /// [`eval_script`](Self::eval_script) with an explicit `advance_shared` mode:
+    /// when `owned` is `None` but `advance_shared` is set, the enclosing frame is
+    /// shared (not pushed — no new level) yet its `line`/`cmd` still advance with
+    /// each command. This is the command-substitution case (see
+    /// [`eval_command_subst`](Self::eval_command_subst)); the caller sets up and
+    /// restores the shared frame's `line_base`.
+    fn eval_script_mode(
+        &mut self,
+        src: &[u8],
+        owned: Option<CmdFrame>,
+        advance_shared: bool,
+    ) -> Code {
         self.eval_depth.set(self.eval_depth.get() + 1);
-        let owns_frame = owned.is_some();
+        let pushed = owned.is_some();
+        let owns_frame = pushed || advance_shared;
         if let Some(f) = owned {
             self.cmd_frames.borrow_mut().push(f);
         }
@@ -2592,7 +2608,7 @@ impl Interp {
                 break; // error/return/break/continue propagate up
             }
         }
-        if owns_frame {
+        if pushed {
             self.cmd_frames.borrow_mut().pop();
         }
         self.eval_depth.set(self.eval_depth.get() - 1);
@@ -2663,6 +2679,48 @@ impl Interp {
     pub(crate) fn eval_body(&mut self, script: &[u8]) -> Code {
         let frame = self.inherited_cmd_frame();
         self.eval_framed(script, frame)
+    }
+
+    /// Evaluate a `[...]` command substitution's inner `script`. A `[cmd]` is
+    /// **not** a new `info frame` level (C compiles it into the enclosing
+    /// command's bytecode — `info frame` depth is unchanged), but it *does*
+    /// advance the reported `line`: a command inside the brackets reports the
+    /// line it actually appears on, even when the bracket spans lines or follows
+    /// a `\`-newline continuation. `script` is a sub-slice of `src` (it borrows
+    /// from the parsed buffer), so its start offset — and thus its file-absolute
+    /// line — comes straight from the original source: bs+nl continuations are
+    /// real newlines there, so plain newline counting matches C's TIP 280 result
+    /// without C's separate continuation-line `adjust` bookkeeping.
+    ///
+    /// The enclosing frame's location (`line_base`/`line`/`cmd`) is saved and
+    /// restored around the inner eval so the rest of the enclosing command keeps
+    /// reporting its own line once the substitution returns.
+    fn eval_command_subst(&mut self, src: &[u8], script: &[u8]) -> Code {
+        let offset = (script.as_ptr() as usize).wrapping_sub(src.as_ptr() as usize);
+        let saved = {
+            let mut frames = self.cmd_frames.borrow_mut();
+            match frames.last_mut() {
+                Some(top) if offset <= src.len() => {
+                    let saved = (top.line_base, top.line, std::mem::take(&mut top.cmd));
+                    // Shift the body-relative base so the inner script's line 1
+                    // maps to the bracket's file-absolute line.
+                    top.line_base = (top.line_base + line_of(src, offset)).saturating_sub(1);
+                    Some(saved)
+                }
+                _ => None,
+            }
+        };
+        // Share the enclosing frame but advance its line/cmd through the inner
+        // commands (the third eval mode: no new frame, but line tracking on).
+        let code = self.eval_script_mode(script, None, saved.is_some());
+        if let Some((line_base, line, cmd)) = saved {
+            if let Some(top) = self.cmd_frames.borrow_mut().last_mut() {
+                top.line_base = line_base;
+                top.line = line;
+                top.cmd = cmd;
+            }
+        }
+        code
     }
 
     /// `eval` of a single body **object** — like [`eval_body`](Self::eval_body),
@@ -2772,7 +2830,7 @@ impl Interp {
     fn eval_words(&mut self, src: &[u8], words: &[parse::Word]) -> Code {
         let mut argv: Vec<*mut TclObj> = Vec::new();
         for w in words {
-            let obj = match self.substitute_word(&w.body) {
+            let obj = match self.substitute_word(src, &w.body) {
                 Ok(o) => o, // owned (+1)
                 Err(code) => {
                     release_all(&argv);
@@ -3994,7 +4052,7 @@ impl Interp {
     /// Substitute one word's body into an **owned** (`+1`) object.
     /// A `Variable` reference to an unset variable, or a `[cmd]` that errors,
     /// returns `Err(code)` with the interp result already set.
-    fn substitute_word(&mut self, body: &WordBody) -> Result<*mut TclObj, Code> {
+    fn substitute_word(&mut self, src: &[u8], body: &WordBody) -> Result<*mut TclObj, Code> {
         match body {
             WordBody::Literal(bytes) => {
                 let obj = new_string(bytes);
@@ -4035,7 +4093,7 @@ impl Interp {
                             // Command substitution propagates *any* non-OK
                             // completion code (`return`/`break`/`continue`, not
                             // just error) out of `[...]`, matching C Tcl.
-                            let code = self.eval_str(script);
+                            let code = self.eval_command_subst(src, script);
                             if code != Code::Ok {
                                 return Err(code);
                             }
@@ -4066,7 +4124,7 @@ impl Interp {
                             }
                         }
                         WordPart::Command(script) => {
-                            let code = self.eval_str(script);
+                            let code = self.eval_command_subst(src, script);
                             if code != Code::Ok {
                                 return Err(code);
                             }

--- a/runtime/rust/src/list.rs
+++ b/runtime/rust/src/list.rs
@@ -31,6 +31,13 @@ use crate::parse::{self, ListError};
 /// `*mut TclObj` the list owns a `+1` of.
 struct TclList {
     elems: Vec<*mut TclObj>,
+    /// Whether the value's canonical form **is** its elements (C's
+    /// `TclListObjIsCanonical`): `true` for a list built from objects
+    /// (`new_list_obj`/append/replace), `false` for one shimmered from a string
+    /// (whose kept string rep may differ from the canonical list form). The eval
+    /// loop dispatches a canonical list by element identity; a non-canonical one
+    /// is re-parsed from its string ([`is_pure_list`]).
+    canonical: bool,
 }
 
 /// The `list` type descriptor — free/dup/update-string procs wired to the list
@@ -75,11 +82,13 @@ extern "C" fn list_free(obj: *mut TclObj) {
 extern "C" fn list_dup(src: *mut TclObj, dup: *mut TclObj) {
     // SAFETY: deep-copy the element vector and retain each element for the copy.
     unsafe {
-        let elems = list_ref(src).elems.clone();
+        let src_ref = list_ref(src);
+        let elems = src_ref.elems.clone();
+        let canonical = src_ref.canonical;
         for &e in &elems {
             obj::incr_ref_count(e);
         }
-        let boxed = Box::new(TclList { elems });
+        let boxed = Box::new(TclList { elems, canonical });
         obj::change_type(dup, &TCL_LIST_TYPE, Box::into_raw(boxed) as usize as u64);
     }
 }
@@ -115,7 +124,12 @@ fn ensure_list(obj: *mut TclObj) -> Result<(), ListError> {
         unsafe { obj::incr_ref_count(eo) };
         elems.push(eo);
     }
-    let boxed = Box::new(TclList { elems });
+    // Shimmered from a string: the kept string rep is the source of truth, so
+    // the value is *not* canonical (its string may not match the list form).
+    let boxed = Box::new(TclList {
+        elems,
+        canonical: false,
+    });
     obj::change_type(obj, &TCL_LIST_TYPE, Box::into_raw(boxed) as usize as u64);
     Ok(())
 }
@@ -129,7 +143,10 @@ pub fn new_list_obj(elems: &[*mut TclObj]) -> *mut TclObj {
         // SAFETY: each element is live; the list takes a +1.
         unsafe { obj::incr_ref_count(e) };
     }
-    let boxed = Box::new(TclList { elems: v });
+    let boxed = Box::new(TclList {
+        elems: v,
+        canonical: true,
+    });
     obj::alloc_typed(&TCL_LIST_TYPE, Box::into_raw(boxed) as usize as u64)
 }
 
@@ -149,6 +166,16 @@ pub fn list_index(obj: *mut TclObj, i: usize) -> Result<Option<*mut TclObj>, Lis
 
 /// Every element (borrowed pointers), e.g. for `Tcl_ListObjGetElements` /
 /// `foreach`. The returned objects are owned by the list.
+/// Whether `obj` is a **pure** list — it has the list internal rep and no
+/// string rep, so its canonical form is its elements (C's
+/// `TclListObjIsCanonical`). Such a value can be evaluated as a single command
+/// by element *identity* (preserving each element obj's TIP 280 source
+/// location), instead of being stringified and re-parsed.
+#[must_use]
+pub fn is_pure_list(obj: *mut TclObj) -> bool {
+    obj::obj_type_ptr(obj) == &TCL_LIST_TYPE && unsafe { list_ref(obj) }.canonical
+}
+
 pub fn list_elements(obj: *mut TclObj) -> Result<Vec<*mut TclObj>, ListError> {
     ensure_list(obj)?;
     // SAFETY: list rep guaranteed.

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -59,6 +59,10 @@ struct Namespace {
     /// namespace's holds the global variables; the variable resolver
     /// ([`crate::vars`]) routes qualified / global / namespace-eval names here.
     vars: VarTable,
+    /// `namespace unknown` handler (a command prefix). `None` ⇒ the namespace
+    /// uses the interpreter default (the global `::unknown`); an empty handler
+    /// also resets to the default.
+    unknown: Option<Vec<u8>>,
 }
 
 impl Namespace {
@@ -71,6 +75,7 @@ impl Namespace {
             path: Vec::new(),
             exports: Vec::new(),
             vars: VarTable::default(),
+            unknown: None,
         }
     }
 }
@@ -438,6 +443,22 @@ impl Namespaces {
     #[must_use]
     pub fn children(&self, ns: NsId) -> Vec<NsId> {
         self.arena[ns].children.values().copied().collect()
+    }
+
+    /// `ns`'s `namespace unknown` handler, if one is set (an empty/`None` handler
+    /// means "use the interpreter default `::unknown`").
+    #[must_use]
+    pub(crate) fn unknown_handler(&self, ns: NsId) -> Option<&[u8]> {
+        self.arena[ns].unknown.as_deref()
+    }
+
+    /// Set `ns`'s `namespace unknown` handler (an empty handler resets to default).
+    pub(crate) fn set_unknown_handler(&mut self, ns: NsId, handler: &[u8]) {
+        self.arena[ns].unknown = if handler.is_empty() {
+            None
+        } else {
+            Some(handler.to_vec())
+        };
     }
 
     /// Remove every ensemble command whose configured namespace is in `victims`,

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -440,6 +440,40 @@ impl Namespaces {
         self.arena[ns].children.values().copied().collect()
     }
 
+    /// Remove every ensemble command whose configured namespace is in `victims`,
+    /// returning each removed command's fully-qualified name. An ensemble command
+    /// is tied to its namespace, so deleting the namespace deletes the command —
+    /// even when the command itself lives elsewhere (e.g. `::ns` in the global
+    /// table for an ensemble created inside `ns`). Mirrors C's ensemble
+    /// namespace-deletion hook.
+    pub(crate) fn remove_ensembles_for(
+        &mut self,
+        victims: &std::collections::HashSet<NsId>,
+    ) -> Vec<Vec<u8>> {
+        // Collect first (immutable borrow), then unbind (mutable).
+        let mut hits: Vec<(NsId, Vec<u8>)> = Vec::new();
+        for (id, node) in self.arena.iter().enumerate() {
+            for (name, cmd) in &node.commands {
+                if let Command::Ensemble(cfg) = cmd {
+                    if victims.contains(&cfg.ns) {
+                        hits.push((id, name.clone()));
+                    }
+                }
+            }
+        }
+        let mut fqns = Vec::with_capacity(hits.len());
+        for (id, name) in hits {
+            self.arena[id].commands.remove(&name);
+            let mut fqn = self.qualified_name(id);
+            if fqn != b"::" {
+                fqn.extend_from_slice(b"::");
+            }
+            fqn.extend_from_slice(&name);
+            fqns.push(fqn);
+        }
+        fqns
+    }
+
     /// `namespace delete name` — delete the namespace `qualified` resolves to
     /// (relative to `current`), with its child namespaces, commands, and
     /// variables. Returns `false` if it does not exist. The arena slot is

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -512,11 +512,20 @@ impl Namespaces {
     /// Deleting the global namespace clears its contents but keeps the node
     /// (it has no parent to unlink from) — matching `namespace delete ::`.
     pub fn delete_namespace_by_id(&mut self, ns: NsId) {
+        let victims = self.descendant_ids(ns);
         self.delete_subtree(ns);
         // Unlink from the parent so the name no longer resolves.
         if let Some(parent) = self.arena[ns].parent {
             let name = std::mem::take(&mut self.arena[ns].name);
             self.arena[parent].children.remove(&name);
+        }
+        // Drop the deleted namespaces from every other namespace's `namespace
+        // path` — a dangling id would otherwise resolve to the global `::`
+        // (`TclResetNamespaceParameters` / path fixup in `tclNamesp.c`).
+        for node in &mut self.arena {
+            if !node.path.is_empty() {
+                node.path.retain(|p| !victims.contains(p));
+            }
         }
     }
 

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -124,6 +124,23 @@ impl Namespaces {
             .map(|(ns, simple)| self.arena[ns].commands[&simple].clone())
     }
 
+    /// Rebind an existing command in place at the namespace where it actually
+    /// resolves (the full resolution order, incl. `namespace path`) — the
+    /// `namespace ensemble configure` set form. Unlike [`bind`](Self::bind),
+    /// which always targets `current`, this updates the command `resolve` would
+    /// hit, so reconfiguring an ensemble reached via `namespace path` mutates the
+    /// real binding rather than shadowing it. Returns `false` if `name` does not
+    /// resolve (the caller has already verified it does).
+    pub fn rebind_resolved(&mut self, current: NsId, name: &[u8], command: Command) -> bool {
+        match self.home_of(current, name) {
+            Some((ns, simple)) => {
+                self.arena[ns].commands.insert(simple, command);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// The canonical fully-qualified name a (relative/absolute) command `name`
     /// resolves to, following the full resolution order — or `None` if no such
     /// command exists. Used to key command/execution traces so they address the


### PR DESCRIPTION
## Summary

Unifies and completes TIP 280 `info frame` source-location tracking across the eval core and every command that evaluates a script body. `info.test` goes **138 → 227** (of 287) with **zero regressions** in the sensitive suites (trace 199, oo 357, ooProp 55/55, namespace 238, eval 12/12). The shared infrastructure also lifted other files: **dict 315 → 325**, **upvar 43 → 47**, **foreach 38 → 39**.

The unifying principle: every script a command evaluates now derives its location from the **body object's recorded position** (the literal-argument / LABC table) or, for sub-elements of a list literal, from **byte offsets into the shared source** via one `scan_list_offsets` / `line_of` computation (C's `TclListLines`) — replacing the prior per-command `script_stack` heuristics.

## Changes (each commit byte-verified vs `tclsh9.0`, lib 324/324, `make runtime-rust-lint` clean)

- **Command substitution** advances the reported frame line (shares the frame, adds no level — matching C's bytecode model; bs+nl continuations and nested `[...]` handled via offset-into-source).
- **`namespace eval`** is its own `info frame` level (`proc` cleared, `level` relative to the new scope, located body → `type source`).
- **`switch` bodies + `proc` body location** — inline switch bodies are located via their object; the single-list form derives each body's line from offsets within the list word. A `proc`'s body location now comes from the body word's LABC entry, not a whole-file "am I sourcing" flag.
- **`[subst]`** command substitutions report their own line.
- **`{*}` literal expansion** keeps each element's source line (`eval_words` tracks lines per argv-element); **`catch`** body is its own located level.
- **`dict for`/`map`/`filter`/`update`/`with`** bodies route through the control-body path.
- **`for` start/next** scripts are located.
- **Dynamic control bodies** (`if 1 $body`, `while … $body`, …) are body-relative `type eval`.
- **Dynamic `eval` bodies** are body-relative `type eval` (not inherited source).
- **`apply` lambda** reports a `lambda` key, and a literal lambda body is `type source`.

## Testing

- `cargo test --release --manifest-path runtime/rust/Cargo.toml --lib` — 324/324
- `make runtime-rust-lint` (fmt + clippy `-D warnings`) — clean
- tcltest sweep before/after every change asserting zero regressions across trace/oo/ooProp/namespace/eval/proc/apply/switch/if/while/for/foreach/dict/subst/error/var

Remaining `info.test` failures are lower-ROI specialized work: `info cmdtype` for interps/objects/coroutines (needs those subsystems), the `etrace` uplevel stack, `info cmdcount` exact semantics, and `return`-from-expr-substitution propagation.

https://claude.ai/code/session_01W3w3kzLUUowKRyBMGEx4zv

---
_Generated by [Claude Code](https://claude.ai/code/session_018MLLapZi6KVuTVxohLca9g)_