### PR TITLE
Rust runtime: round out the `string` subcommand long-tail

### DIFF
--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3079,6 +3079,46 @@ untouched. `set_ensemble_config` now uses a new `NamespaceArena::rebind_resolved
 path`) instead of `create_ensemble`. Found by Codex review on PR #607; verified
 vs `tclsh9.0`, namespace 238 held.
 
+### SYNC inbound — 2026-06-15 (`string` subcommand long-tail: dispatch, compare/case/trim/word, `tcl::prefix`)
+
+Chunk: the `string` ensemble's non-`string is` subcommands in
+`runtime/rust/src/cmd_string.rs`, written against `tclCmdMZ.c`
+(`Tcl_StringObjCmd` and friends), `tclStringObj.c`
+(`TclStringFirst`/`TclStringLast`), `tclObj.c` (`ParseBoolean`), `tclUtf.c`
+(`Tcl_UniCharIsWordChar`), and `tclIndexObj.c` (`PrefixMatchObjCmd`). `string is`
+itself (groups 6/25/32) was rebased onto the canonical `str_is` from PR #607;
+this work only **adds the list/dict fail-index** that #607's version left at the
+string length. `string.test` 564→684 / 705 across the full sequence; no
+regressions in the file.
+
+- **Subcommand dispatch** resolves by unambiguous prefix (`Tcl_GetIndexFromObj`),
+  so `string fir`/`string co` work and `string trim` still beats its
+  `trimleft`/`trimright` prefixes.
+- **`compare`/`equal`**: enforce the 4..=7 arg bound, prefix-match
+  `-nocase`/`-length`, and read `-length` as a wide int (negative ⇒ "no limit",
+  bignum ⇒ "integer value too large to represent").
+- **`first`/`last`**: empty needle ⇒ -1; `last`'s index caps the match's final
+  character (latest start = `lastIndex + 1 - needleLen`).
+- **`map`/`match`**: `-nocase` by ≥2-char prefix, else `bad option … must be
+  -nocase`.
+- **`toupper`/`tolower`/`totitle`**: simple (1:1) Unicode case mapping, a lone
+  index maps just that character, and the four Latin digraphs title-case to their
+  mixed-case form.
+- **`trim`/`trimleft`/`trimright`**: character-based with Tcl's full default
+  whitespace set (`tclDefaultTrimSet`) and per-command usage strings.
+- **word chars** (`wordstart`/`wordend`, `string is wordchar`) include connector
+  punctuation (Unicode `Pc`).
+- **`tcl::prefix`** validates option values ("missing value for -error/-message",
+  even-length `-error` list), surfaces the full Tcl list-parse error (with the
+  offending fragment) for bad tables, computes `longest` per character, and
+  registers `::tcl::string::reverse`.
+- **`string is list`/`dict`** now report the character index where list parsing
+  fails (an odd-but-valid dict reports -1), improving #607's `class_check`.
+
+Out of scope here (blocked elsewhere): bignum `string index` arithmetic
+(`cmd_list::index_spec`), surrogate `\u` distinctness (lexer collapses to
+U+FFFD), and `tcl::prefix -error` return options (interp return-options).
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -18,9 +18,11 @@ use crate::obj::{self, TclObj};
 pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"append", append);
     interp.register_builtin(b"string", string_cmd);
-    // `::tcl::string::insert` is the real command the `string insert` ensemble
-    // maps to; some tests invoke it directly.
+    // `::tcl::string::insert`/`::tcl::string::reverse` are the real commands the
+    // `string insert`/`string reverse` ensemble entries map to; some tests (and
+    // the byte-compiler) invoke them directly.
     interp.register_builtin(b"::tcl::string::insert", tcl_string_insert);
+    interp.register_builtin(b"::tcl::string::reverse", tcl_string_reverse);
     // `tcl::prefix` — prefix matching against a table (`tclIndexObj.c`).
     interp.register_builtin(b"::tcl::prefix", tcl_prefix);
 }
@@ -75,8 +77,20 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, b"string subcommand ?arg ...?");
     }
+    // The `string` ensemble resolves its subcommand by unambiguous prefix
+    // (`Tcl_GetIndexFromObj`): `string fir` → `first`, `string trim` wins over
+    // its `trimleft`/`trimright` prefixes via the exact-match rule.
     let sub = obj_bytes(argv[1]);
-    match sub.as_slice() {
+    let canonical: &[u8] = match index_lookup(STRING_SUBCOMMANDS, &sub) {
+        Lookup::Found(i) => STRING_SUBCOMMANDS[i],
+        Lookup::None | Lookup::Ambiguous => {
+            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
+            m.extend_from_slice(&sub);
+            m.extend_from_slice(b"\": must be cat, compare, equal, first, index, insert, is, last, length, map, match, range, repeat, replace, reverse, tolower, totitle, toupper, trim, trimleft, trimright, wordend, or wordstart");
+            return interp.set_error(&m);
+        }
+    };
+    match canonical {
         b"length" => str_length(interp, argv),
         b"index" => str_index(interp, argv),
         b"range" => str_range(interp, argv),
@@ -100,14 +114,37 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"insert" => str_insert(interp, argv),
         b"wordstart" => str_word(interp, argv, true),
         b"wordend" => str_word(interp, argv, false),
-        _ => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(&sub);
-            m.extend_from_slice(b"\": must be cat, compare, equal, first, index, insert, is, last, length, map, match, range, repeat, replace, reverse, tolower, totitle, toupper, trim, trimleft, trimright, wordend, or wordstart");
-            interp.set_error(&m)
-        }
+        _ => unreachable!("index_lookup only yields a known subcommand"),
     }
 }
+
+/// The `string` ensemble subcommands, in the order used by the
+/// "unknown or ambiguous subcommand" diagnostic.
+const STRING_SUBCOMMANDS: &[&[u8]] = &[
+    b"cat",
+    b"compare",
+    b"equal",
+    b"first",
+    b"index",
+    b"insert",
+    b"is",
+    b"last",
+    b"length",
+    b"map",
+    b"match",
+    b"range",
+    b"repeat",
+    b"replace",
+    b"reverse",
+    b"tolower",
+    b"totitle",
+    b"toupper",
+    b"trim",
+    b"trimleft",
+    b"trimright",
+    b"wordend",
+    b"wordstart",
+];
 
 fn str_length(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 3 {
@@ -232,6 +269,16 @@ fn tcl_string_insert(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     str_insert(interp, &shifted)
 }
 
+/// `::tcl::string::reverse string` — the command behind the `string reverse`
+/// ensemble entry. Re-aligns argv to the `string reverse …` shape.
+fn tcl_string_reverse(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() != 2 {
+        return wrong_args(interp, b"tcl::string::reverse string");
+    }
+    let shifted = [argv[0], argv[0], argv[1]];
+    str_reverse(interp, &shifted)
+}
+
 /// Render an option set as Tcl's `a, b, or c` / `a or b` / `a` enumeration.
 fn enum_must_be(items: &[Vec<u8>]) -> Vec<u8> {
     let mut m = Vec::new();
@@ -275,6 +322,129 @@ fn tcl_prefix(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
+/// Reconstruct Tcl's full list-parse error message (`TclFindElement`,
+/// tclUtil.c), including the offending fragment for the "followed by" cases.
+/// Returns `None` when `s` is a well-formed list. Mirrors
+/// `tcl_syntax::list::find_element` (whose `ListError` message is fragment-less).
+fn list_error_message(s: &[u8]) -> Option<Vec<u8>> {
+    use tcl_syntax::list::is_list_space;
+    let len = s.len();
+    let mut pos = 0;
+    while pos < len {
+        while pos < len && is_list_space(s[pos]) {
+            pos += 1;
+        }
+        if pos >= len {
+            break;
+        }
+        let mut open_braces = 0usize;
+        let mut in_quotes = false;
+        let mut p = pos;
+        match s[p] {
+            b'{' => {
+                open_braces = 1;
+                p += 1;
+            }
+            b'"' => {
+                in_quotes = true;
+                p += 1;
+            }
+            _ => {}
+        }
+        loop {
+            if p >= len {
+                if open_braces != 0 {
+                    return Some(b"unmatched open brace in list".to_vec());
+                }
+                if in_quotes {
+                    return Some(b"unmatched open quote in list".to_vec());
+                }
+                break;
+            }
+            match s[p] {
+                b'{' if open_braces != 0 => open_braces += 1,
+                b'}' if open_braces > 1 => open_braces -= 1,
+                b'}' if open_braces == 1 => {
+                    p += 1;
+                    if p < len && !is_list_space(s[p]) {
+                        return Some(followed_by_message(b"braces", s, p));
+                    }
+                    break;
+                }
+                b'"' if in_quotes => {
+                    p += 1;
+                    if p < len && !is_list_space(s[p]) {
+                        return Some(followed_by_message(b"quotes", s, p));
+                    }
+                    break;
+                }
+                b'\\' => {
+                    p += if p + 1 < len { 2 } else { 1 };
+                    continue;
+                }
+                c if open_braces == 0 && !in_quotes && is_list_space(c) => break,
+                _ => {}
+            }
+            p += 1;
+        }
+        while p < len && is_list_space(s[p]) {
+            p += 1;
+        }
+        pos = p;
+    }
+    None
+}
+
+/// The character index at which Tcl list parsing of `text` fails, or `None` for
+/// a well-formed list. Mirrors the `STR_IS_LIST` failat loop in tclCmdMZ.c:
+/// walk element by element and, on the first error, skip leading element
+/// whitespace and report the character count up to that point.
+fn list_failat(text: &str) -> Option<i64> {
+    let bytes = text.as_bytes();
+    let mut pos = 0usize;
+    loop {
+        match tcl_syntax::list::find_element(text, pos) {
+            Ok(None) => return None,
+            Ok(Some(el)) => pos = el.next,
+            Err(_) => {
+                let mut p = pos;
+                while p < bytes.len() && tcl_syntax::list::is_list_space(bytes[p]) {
+                    p += 1;
+                }
+                return Some(text[..p].chars().count() as i64);
+            }
+        }
+    }
+}
+
+/// `list element in <kind> followed by "<fragment>" instead of space`, where the
+/// fragment runs from `p` to the next list-space (max 20 bytes, as in C).
+fn followed_by_message(kind: &[u8], s: &[u8], p: usize) -> Vec<u8> {
+    use tcl_syntax::list::is_list_space;
+    let mut q = p;
+    while q < s.len() && !is_list_space(s[q]) && q < p + 20 {
+        q += 1;
+    }
+    let mut m = b"list element in ".to_vec();
+    m.extend_from_slice(kind);
+    m.extend_from_slice(b" followed by \"");
+    m.extend_from_slice(&s[p..q]);
+    m.extend_from_slice(b"\" instead of space");
+    m
+}
+
+/// Split `s` as a Tcl list, or set the full list-parse error and return the
+/// failing `Code` (used by the `tcl::prefix` subcommands).
+fn split_list_or_error(interp: &mut Interp, s: &[u8]) -> Result<Vec<Vec<u8>>, Code> {
+    match crate::parse::split_list(s) {
+        Ok(t) => Ok(t),
+        Err(e) => {
+            let msg = list_error_message(s).unwrap_or_else(|| e.message().to_vec());
+            Err(interp.set_error(&msg))
+        }
+    }
+}
+
 /// The table elements with `s` as a (string) prefix.
 fn prefix_matches(table: &[Vec<u8>], s: &[u8], exact: bool) -> Vec<usize> {
     table
@@ -291,42 +461,67 @@ fn prefix_matches(table: &[Vec<u8>], s: &[u8], exact: bool) -> Vec<usize> {
         .collect()
 }
 
+const PREFIX_MATCH_OPTIONS: &[&[u8]] = &[b"-error", b"-exact", b"-message"];
+
 fn tcl_prefix_match(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // tcl::prefix match ?options? table string
+    if argv.len() < 4 {
+        return wrong_args(interp, b"tcl::prefix match ?options? table string");
+    }
     let mut exact = false;
     let mut message: Vec<u8> = b"option".to_vec();
-    let mut error_opts: Option<Vec<u8>> = None; // Some("") ⇒ return "" instead of erroring
+    let mut error_opts: Option<Vec<u8>> = None; // Some(opts) ⇒ -error given
+                                                // Options precede the trailing `table string`; `-error`/`-message` need a
+                                                // value that must not intrude into those last two arguments.
+    let opt_end = argv.len() - 2;
     let mut i = 2;
-    while i + 2 < argv.len() {
-        match obj_bytes(argv[i]).as_slice() {
-            b"-exact" => {
+    while i < opt_end {
+        let opt = obj_bytes(argv[i]);
+        match index_lookup(PREFIX_MATCH_OPTIONS, &opt) {
+            Lookup::Found(1) => {
                 exact = true;
                 i += 1;
             }
-            b"-message" if i + 1 < argv.len() - 2 => {
+            Lookup::Found(2) => {
+                if i + 1 >= opt_end {
+                    return interp.set_error(b"missing value for -message");
+                }
                 message = obj_bytes(argv[i + 1]);
                 i += 2;
             }
-            b"-error" if i + 1 < argv.len() - 2 => {
-                error_opts = Some(obj_bytes(argv[i + 1]));
+            Lookup::Found(_) => {
+                if i + 1 >= opt_end {
+                    return interp.set_error(b"missing value for -error");
+                }
+                let val = obj_bytes(argv[i + 1]);
+                let elems = match split_list_or_error(interp, &val) {
+                    Ok(e) => e,
+                    Err(c) => return c,
+                };
+                if elems.len() % 2 != 0 {
+                    return interp.set_error(b"error options must have an even number of elements");
+                }
+                error_opts = Some(val);
                 i += 2;
             }
-            opt => {
-                let mut m = b"bad option \"".to_vec();
-                m.extend_from_slice(opt);
+            bad => {
+                let verb: &[u8] = if matches!(bad, Lookup::Ambiguous) {
+                    b"ambiguous option \""
+                } else {
+                    b"bad option \""
+                };
+                let mut m = verb.to_vec();
+                m.extend_from_slice(&opt);
                 m.extend_from_slice(b"\": must be -error, -exact, or -message");
                 return interp.set_error(&m);
             }
         }
     }
-    if argv.len() - i != 2 {
-        return wrong_args(interp, b"tcl::prefix match ?options? table string");
-    }
-    let table = match crate::parse::split_list(&obj_bytes(argv[i])) {
+    let table = match split_list_or_error(interp, &obj_bytes(argv[argv.len() - 2])) {
         Ok(t) => t,
-        Err(e) => return interp.set_error(e.message()),
+        Err(c) => return c,
     };
-    let s = obj_bytes(argv[i + 1]);
+    let s = obj_bytes(argv[argv.len() - 1]);
     let hits = prefix_matches(&table, &s, exact);
     // Exact match always wins even if it is also a prefix of others.
     if let Some(&h) = hits.iter().find(|&&h| table[h] == s) {
@@ -369,9 +564,9 @@ fn tcl_prefix_all(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 4 {
         return wrong_args(interp, b"tcl::prefix all table string");
     }
-    let table = match crate::parse::split_list(&obj_bytes(argv[2])) {
+    let table = match split_list_or_error(interp, &obj_bytes(argv[2])) {
         Ok(t) => t,
-        Err(e) => return interp.set_error(e.message()),
+        Err(c) => return c,
     };
     let s = obj_bytes(argv[3]);
     let objs: Vec<*mut TclObj> = table
@@ -390,29 +585,32 @@ fn tcl_prefix_longest(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 4 {
         return wrong_args(interp, b"tcl::prefix longest table string");
     }
-    let table = match crate::parse::split_list(&obj_bytes(argv[2])) {
+    let table = match split_list_or_error(interp, &obj_bytes(argv[2])) {
         Ok(t) => t,
-        Err(e) => return interp.set_error(e.message()),
+        Err(c) => return c,
     };
     let s = obj_bytes(argv[3]);
     let hits: Vec<&Vec<u8>> = table.iter().filter(|e| e.starts_with(&s)).collect();
-    // Longest common prefix of all matching elements (at least `s`).
-    let mut longest: Vec<u8> = match hits.first() {
-        Some(f) => (*f).clone(),
+    // Longest common prefix of all matching elements (at least `s`), compared by
+    // character so a shared multi-byte lead byte never yields a partial char.
+    let mut longest: Vec<char> = match hits.first() {
+        Some(f) => String::from_utf8_lossy(f).chars().collect(),
         None => {
             interp.set_result_bytes(b"");
             return Code::Ok;
         }
     };
     for e in &hits[1..] {
+        let ec: Vec<char> = String::from_utf8_lossy(e).chars().collect();
         let common = longest
             .iter()
-            .zip(e.iter())
+            .zip(ec.iter())
             .take_while(|(a, b)| a == b)
             .count();
         longest.truncate(common);
     }
-    interp.set_result_bytes(&longest);
+    let out: String = longest.iter().collect();
+    interp.set_result_bytes(out.as_bytes());
     Code::Ok
 }
 
@@ -438,7 +636,7 @@ fn str_word(interp: &mut Interp, argv: &[*mut TclObj], start: bool) -> Code {
         Some(i) => i,
         None => return bad_index(interp, &obj_bytes(argv[3])),
     };
-    let is_word = |c: char| c.is_alphanumeric() || c == '_';
+    let is_word = is_word_char;
     let result: usize = if start {
         if n == 0 {
             0
@@ -488,27 +686,41 @@ fn str_compare_equal(interp: &mut Interp, argv: &[*mut TclObj], equal: bool) -> 
     } else {
         b"string compare ?-nocase? ?-length int? string1 string2"
     };
-    if argv.len() < 4 {
+    // C's `StringCmpOpts` allows 3..=6 args ([cmd, ?-nocase?, ?-length n?,
+    // s1, s2]); here `string` adds one, so 4..=7.
+    if argv.len() < 4 || argv.len() > 7 {
         return wrong_args(interp, usage);
     }
     let mut nocase = false;
     let mut length: Option<usize> = None;
-    // Options occupy everything before the trailing two strings.
+    // Options occupy everything before the trailing two strings, matching by
+    // prefix (at least two characters, like C's `strncmp(string, …, length)`
+    // with `length > 1`).
     let mut i = 2;
     while i < argv.len() - 2 {
-        match obj_bytes(argv[i]).as_slice() {
-            b"-nocase" => {
-                nocase = true;
-                i += 1;
+        let opt = obj_bytes(argv[i]);
+        if opt.len() > 1 && b"-nocase".starts_with(opt.as_slice()) {
+            nocase = true;
+            i += 1;
+        } else if opt.len() > 1 && b"-length".starts_with(opt.as_slice()) {
+            if i + 1 >= argv.len() - 2 {
+                return wrong_args(interp, usage);
             }
-            b"-length" => {
-                match parse_isize(&obj_bytes(argv[i + 1])) {
-                    Some(n) => length = Some(n.max(0) as usize),
-                    None => return not_integer(interp, &obj_bytes(argv[i + 1])),
+            // `-length` reads a wide int (`TclGetWideIntFromObj`): a negative or
+            // out-of-`Tcl_Size` value means "no limit", a bignum overflows.
+            match get_wide(&obj_bytes(argv[i + 1])) {
+                Ok(w) => length = if w < 0 { None } else { Some(w as usize) },
+                Err(WideErr::TooLarge) => {
+                    return interp.set_error(b"integer value too large to represent");
                 }
-                i += 2;
+                Err(WideErr::NotInteger) => return not_integer(interp, &obj_bytes(argv[i + 1])),
             }
-            _ => return wrong_args(interp, usage),
+            i += 2;
+        } else {
+            let mut m = b"bad option \"".to_vec();
+            m.extend_from_slice(&opt);
+            m.extend_from_slice(b"\": must be -nocase or -length");
+            return interp.set_error(&m);
         }
     }
     if argv.len() - i != 2 {
@@ -618,9 +830,11 @@ enum CaseMode {
 }
 
 /// `string toupper|tolower|totitle string ?first? ?last?` — case-map a character
-/// range (the whole string by default). ASCII case only for now (non-ASCII
-/// bytes pass through unchanged — Unicode case mapping is deferred); the range
-/// uses character indices via the shared `index_spec`/`char_to_byte` helpers.
+/// range (the whole string when no range is given). With a single index, only
+/// that one character is mapped (C's `last = first`); `totitle` title-cases the
+/// first character of the range and lower-cases the rest. Case mapping is simple
+/// (1:1) Unicode, matching `Tcl_UniCharTo{Upper,Lower,Title}`: a character whose
+/// Unicode mapping is not a single code point (e.g. `ß`→`SS`) is left unchanged.
 fn str_case(interp: &mut Interp, argv: &[*mut TclObj], mode: CaseMode) -> Code {
     let usage: &[u8] = match mode {
         CaseMode::Upper => b"string toupper string ?first? ?last?",
@@ -630,83 +844,151 @@ fn str_case(interp: &mut Interp, argv: &[*mut TclObj], mode: CaseMode) -> Code {
     if argv.len() < 3 || argv.len() > 5 {
         return wrong_args(interp, usage);
     }
-    let mut s = obj_bytes(argv[2]);
-    let n = char_count(&s);
-    if n == 0 {
-        interp.set_result_bytes(&s);
+    let s = obj_bytes(argv[2]);
+
+    // No range: map the entire string.
+    if argv.len() == 3 {
+        let mapped: String = map_case(&String::from_utf8_lossy(&s), mode);
+        interp.set_result_bytes(mapped.as_bytes());
         return Code::Ok;
     }
-    // Default range is the whole string; `?first?`/`?last?` narrow it.
-    let lo = match argv.get(3) {
-        Some(&a) => match index_spec(&obj_bytes(a), n) {
-            Some(i) => i.max(0) as usize,
-            None => return bad_index(interp, &obj_bytes(a)),
-        },
-        None => 0,
+
+    let chars: Vec<char> = String::from_utf8_lossy(&s).chars().collect();
+    let n = chars.len();
+    // The index `end`/`end±N` resolves against `n-1` (`TclGetIntForIndexM`).
+    let first = match index_spec(&obj_bytes(argv[3]), n) {
+        Some(i) => i.max(0) as usize,
+        None => return bad_index(interp, &obj_bytes(argv[3])),
     };
-    let hi = match argv.get(4) {
+    // A lone index maps just that character (`last = first`).
+    let last = match argv.get(4) {
         Some(&a) => match index_spec(&obj_bytes(a), n) {
             Some(i) => i,
             None => return bad_index(interp, &obj_bytes(a)),
         },
-        None => n as isize - 1,
+        None => first as isize,
     };
-    if hi < 0 || lo >= n || (hi as usize) < lo {
+    let last = if last >= n as isize {
+        n as isize - 1
+    } else {
+        last
+    };
+    if last < first as isize {
         interp.set_result_bytes(&s); // empty range ⇒ unchanged
         return Code::Ok;
     }
-    let hi = (hi as usize).min(n - 1);
-    let b0 = char_to_byte(&s, lo);
-    let b1 = char_to_byte(&s, hi + 1);
-    // For `totitle`, only the first character of the range is upper-cased.
-    let title_first_end = if matches!(mode, CaseMode::Title) {
-        char_to_byte(&s, lo + 1)
-    } else {
-        b0
-    };
-    for (off, byte) in s[b0..b1].iter_mut().enumerate() {
-        let upper = match mode {
-            CaseMode::Upper => true,
-            CaseMode::Lower => false,
-            CaseMode::Title => b0 + off < title_first_end,
+    let last = last as usize;
+
+    let mut out = String::with_capacity(s.len());
+    out.extend(&chars[..first]);
+    for (k, &c) in chars[first..=last].iter().enumerate() {
+        let cm = match mode {
+            CaseMode::Upper => simple_upper(c),
+            CaseMode::Lower => simple_lower(c),
+            // `totitle`: first char of the range title-cased, the rest lowered.
+            CaseMode::Title if k == 0 => simple_title(c),
+            CaseMode::Title => simple_lower(c),
         };
-        *byte = if upper {
-            byte.to_ascii_uppercase()
-        } else {
-            byte.to_ascii_lowercase()
-        };
+        out.push(cm);
     }
-    interp.set_result_bytes(&s);
+    out.extend(&chars[last + 1..]);
+    interp.set_result_bytes(out.as_bytes());
     Code::Ok
 }
 
+/// Map an entire string with the given case mode (`totitle` title-cases the very
+/// first character and lower-cases the rest, like `Tcl_UtfToTitle`).
+fn map_case(s: &str, mode: CaseMode) -> String {
+    match mode {
+        CaseMode::Upper => s.chars().map(simple_upper).collect(),
+        CaseMode::Lower => s.chars().map(simple_lower).collect(),
+        CaseMode::Title => s
+            .chars()
+            .enumerate()
+            .map(|(i, c)| {
+                if i == 0 {
+                    simple_title(c)
+                } else {
+                    simple_lower(c)
+                }
+            })
+            .collect(),
+    }
+}
+
+/// Simple (1:1) Unicode case mapping helpers, matching `Tcl_UniCharTo*`: when the
+/// full Unicode mapping is not a single code point, the character is unchanged.
+fn simple_upper(c: char) -> char {
+    let mut it = c.to_uppercase();
+    match (it.next(), it.next()) {
+        (Some(u), None) => u,
+        _ => c,
+    }
+}
+fn simple_lower(c: char) -> char {
+    let mut it = c.to_lowercase();
+    match (it.next(), it.next()) {
+        (Some(l), None) => l,
+        _ => c,
+    }
+}
+/// Title-case equals upper-case except for the four Latin digraphs, whose
+/// title form is the mixed-case middle code point (`Tcl_UniCharToTitle`).
+/// (`char::to_titlecase` is still unstable, so these are hard-coded.)
+fn simple_title(c: char) -> char {
+    match c {
+        '\u{01C4}' | '\u{01C5}' | '\u{01C6}' => '\u{01C5}',
+        '\u{01C7}' | '\u{01C8}' | '\u{01C9}' => '\u{01C8}',
+        '\u{01CA}' | '\u{01CB}' | '\u{01CC}' => '\u{01CB}',
+        '\u{01F1}' | '\u{01F2}' | '\u{01F3}' => '\u{01F2}',
+        _ => simple_upper(c),
+    }
+}
+
+/// Tcl's default trim set (`tclDefaultTrimSet`): ASCII whitespace plus the full
+/// Unicode whitespace/zero-width set, including NUL.
+const DEFAULT_TRIM: &[char] = &[
+    '\u{09}', '\u{0A}', '\u{0B}', '\u{0C}', '\u{0D}', ' ', '\u{0000}', '\u{0085}', '\u{00A0}',
+    '\u{1680}', '\u{180E}', '\u{2000}', '\u{2001}', '\u{2002}', '\u{2003}', '\u{2004}', '\u{2005}',
+    '\u{2006}', '\u{2007}', '\u{2008}', '\u{2009}', '\u{200A}', '\u{200B}', '\u{2028}', '\u{2029}',
+    '\u{202F}', '\u{205F}', '\u{2060}', '\u{3000}', '\u{FEFF}',
+];
+
+/// `string trim|trimleft|trimright string ?chars?` — strip leading/trailing
+/// characters that appear in `chars` (Tcl's default whitespace set otherwise).
+/// Matching is character-based so multi-byte trim characters work.
 fn str_trim(interp: &mut Interp, argv: &[*mut TclObj], left: bool, right: bool) -> Code {
     if argv.len() < 3 || argv.len() > 4 {
-        return wrong_args(interp, b"string trim string ?chars?");
+        let usage: &[u8] = match (left, right) {
+            (true, true) => b"string trim string ?chars?",
+            (true, false) => b"string trimleft string ?chars?",
+            _ => b"string trimright string ?chars?",
+        };
+        return wrong_args(interp, usage);
     }
     let s = obj_bytes(argv[2]);
-    let trim_set: Option<Vec<u8>> = if argv.len() == 4 {
-        Some(obj_bytes(argv[3]))
+    let chars: Vec<char> = String::from_utf8_lossy(&s).chars().collect();
+    let set: Vec<char> = if argv.len() == 4 {
+        String::from_utf8_lossy(&obj_bytes(argv[3]))
+            .chars()
+            .collect()
     } else {
-        None
+        DEFAULT_TRIM.to_vec()
     };
-    let is_trim = |b: u8| match &trim_set {
-        Some(set) => set.contains(&b),
-        None => matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c),
-    };
-    let mut start = 0;
-    let mut end = s.len();
+    let mut lo = 0;
+    let mut hi = chars.len();
     if left {
-        while start < end && is_trim(s[start]) {
-            start += 1;
+        while lo < hi && set.contains(&chars[lo]) {
+            lo += 1;
         }
     }
     if right {
-        while end > start && is_trim(s[end - 1]) {
-            end -= 1;
+        while hi > lo && set.contains(&chars[hi - 1]) {
+            hi -= 1;
         }
     }
-    interp.set_result_bytes(&s[start..end]);
+    let out: String = chars[lo..hi].iter().collect();
+    interp.set_result_bytes(out.as_bytes());
     Code::Ok
 }
 
@@ -736,22 +1018,33 @@ fn str_first_last(interp: &mut Interp, argv: &[*mut TclObj], first: bool) -> Cod
         None
     };
 
+    // Empty needles never match ("We don't find empty substrings" — C's
+    // TclStringFirst/TclStringLast both bail out for a zero-length needle).
+    if char_count(&needle) == 0 {
+        interp.set_result(obj::new_wide_int_obj(-1));
+        return Code::Ok;
+    }
+    let nlen = char_count(&needle);
+
     // Byte search restricted by the bound, then convert to a char index.
     let byte_pos = if first {
         // `startIndex`: search at or after it (clamp negatives to 0).
-        let start_char = bound.map_or(0, |i| i.max(0) as usize);
+        let start_char = bound.map_or(0, |i| i.max(0) as usize).min(n);
         let start_byte = char_to_byte(&hay, start_char);
         find_sub(&hay[start_byte..], &needle).map(|bp| bp + start_byte)
     } else {
-        // `lastIndex`: the match must *start* at or before it.
-        match bound {
-            Some(i) if i < 0 => None, // nothing can start before a negative index
-            _ => {
-                let last_char = bound.map_or(n, |i| i as usize);
-                let start_max = char_to_byte(&hay, last_char);
-                let slice_end = (start_max + needle.len()).min(hay.len());
-                rfind_sub(&hay[..slice_end], &needle)
-            }
+        // `lastIndex` (default `end`) caps the index of the match's *final*
+        // character: the latest start is `last + 1 - nlen`, so scan the prefix
+        // ending just past `last` for the rightmost needle.
+        let mut last: isize = bound.unwrap_or(n as isize - 1);
+        if last >= n as isize {
+            last = n as isize - 1;
+        }
+        if last + 1 < nlen as isize {
+            None
+        } else {
+            let slice_end = char_to_byte(&hay, (last + 1) as usize);
+            rfind_sub(&hay[..slice_end], &needle)
         }
     };
     let result = byte_pos.map_or(-1, |bp| char_count(&hay[..bp]) as i64);
@@ -763,17 +1056,20 @@ fn str_first_last(interp: &mut Interp, argv: &[*mut TclObj], first: bool) -> Cod
 /// `tcl_syntax::glob` engine, so the dialect never drifts from the compiler /
 /// `switch -glob` / `lsearch -glob`).
 fn str_match(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let mut rest = &argv[2..];
-    let mut nocase = false;
-    if !rest.is_empty() && obj_bytes(rest[0]) == b"-nocase" {
-        nocase = true;
-        rest = &rest[1..];
-    }
-    if rest.len() != 2 {
+    if argv.len() < 4 || argv.len() > 5 {
         return wrong_args(interp, b"string match ?-nocase? pattern string");
     }
-    let pat = obj_bytes(rest[0]);
-    let s = obj_bytes(rest[1]);
+    let mut nocase = false;
+    if argv.len() == 5 {
+        let opt = obj_bytes(argv[2]);
+        if is_nocase_opt(&opt) {
+            nocase = true;
+        } else {
+            return bad_nocase_option(interp, &opt);
+        }
+    }
+    let pat = obj_bytes(argv[argv.len() - 2]);
+    let s = obj_bytes(argv[argv.len() - 1]);
     let m = tcl_syntax::glob::string_case_match(
         &String::from_utf8_lossy(&pat),
         &String::from_utf8_lossy(&s),
@@ -787,17 +1083,20 @@ fn str_match(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// scanning left to right and trying the keys in list order (first match wins,
 /// then skip past the replacement), per `tclCmdMZ.c` `StringMapCmd`.
 fn str_map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let mut rest = &argv[2..];
-    let mut nocase = false;
-    if !rest.is_empty() && obj_bytes(rest[0]) == b"-nocase" {
-        nocase = true;
-        rest = &rest[1..];
-    }
-    if rest.len() != 2 {
+    if argv.len() < 4 || argv.len() > 5 {
         return wrong_args(interp, b"string map ?-nocase? charMap string");
     }
-    let mapping = obj_bytes(rest[0]);
-    let s = obj_bytes(rest[1]);
+    let mut nocase = false;
+    if argv.len() == 5 {
+        let opt = obj_bytes(argv[2]);
+        if is_nocase_opt(&opt) {
+            nocase = true;
+        } else {
+            return bad_nocase_option(interp, &opt);
+        }
+    }
+    let mapping = obj_bytes(argv[argv.len() - 2]);
+    let s = obj_bytes(argv[argv.len() - 1]);
     let pairs = match crate::parse::split_list(&mapping) {
         Ok(p) => p,
         Err(e) => return interp.set_error(e.message()),
@@ -994,19 +1293,28 @@ fn class_check(class: &[u8], s: &[u8], strict: bool) -> (bool, i64) {
         b"integer" | b"wideinteger" | b"entier" | b"double" => is_number_class(class, s, strict),
         b"boolean" | b"true" | b"false" => is_boolean_class(class, s, strict),
         b"list" => {
-            // `list`/`dict` ignore strictness (empty is a well-formed list).
-            if crate::parse::split_list(s).is_ok() {
-                (true, -1)
-            } else {
-                (false, char_count(s) as i64)
+            // `list`/`dict` ignore strictness (empty is a well-formed list). On
+            // failure the index is where list parsing broke down, not the length.
+            let Ok(text) = std::str::from_utf8(s) else {
+                return (false, 0);
+            };
+            match list_failat(text) {
+                None => (true, -1),
+                Some(idx) => (false, idx),
             }
         }
         b"dict" => {
-            if crate::parse::split_list(s).is_ok_and(|l| l.len() % 2 == 0) {
-                (true, -1)
-            } else {
-                (false, char_count(s) as i64)
+            let Ok(text) = std::str::from_utf8(s) else {
+                return (false, 0);
+            };
+            // A list-parse failure reports its character index; a valid but
+            // odd-sized list reports -1 (C only computes a failat for parse
+            // errors, matching `string-32.9a`).
+            if let Some(idx) = list_failat(text) {
+                return (false, idx);
             }
+            let even = tcl_syntax::list::split_list(text).is_ok_and(|l| l.len() % 2 == 0);
+            (even, -1)
         }
         _ => {
             // Per-character class: first failing char index.
@@ -1153,10 +1461,35 @@ fn char_class_ok(class: &[u8], c: char) -> bool {
         b"punct" => c.is_ascii_punctuation(),
         b"space" => c.is_whitespace(),
         b"upper" => c.is_uppercase(),
-        b"wordchar" => c.is_alphanumeric() || c == '_',
+        b"wordchar" => is_word_char(c),
         b"xdigit" => c.is_ascii_hexdigit(),
         _ => false,
     }
+}
+
+/// The connector-punctuation characters (Unicode category `Pc`) — the full set,
+/// including `_`. `Tcl_UniCharIsWordChar` and `string is wordchar` treat these
+/// as word characters.
+fn is_connector_punct(c: char) -> bool {
+    matches!(
+        c,
+        '\u{005F}'
+            | '\u{203F}'
+            | '\u{2040}'
+            | '\u{2054}'
+            | '\u{FE33}'
+            | '\u{FE34}'
+            | '\u{FE4D}'
+            | '\u{FE4E}'
+            | '\u{FE4F}'
+            | '\u{FF3F}'
+    )
+}
+
+/// `Tcl_UniCharIsWordChar`: letters and decimal digits (here approximated by
+/// `char::is_alphanumeric`) plus connector punctuation.
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || is_connector_punct(c)
 }
 
 // -- char helpers (ASCII fast path) ----------------------------------------
@@ -1226,6 +1559,28 @@ fn parse_isize(b: &[u8]) -> Option<isize> {
     core::str::from_utf8(b).ok()?.trim().parse::<isize>().ok()
 }
 
+/// Why reading a wide integer (`TclGetWideIntFromObj`) failed.
+enum WideErr {
+    /// A valid integer that overflows a wide (`integer value too large …`).
+    TooLarge,
+    /// Not an integer at all (`expected integer but got …`).
+    NotInteger,
+}
+
+/// Read a Tcl wide integer from `b` via the shared `tcl_syntax::number` grammar
+/// (accepts decimal / `0x` / `0o` / `0b` and surrounding whitespace), reporting
+/// a bignum overflow distinctly from a non-integer.
+fn get_wide(b: &[u8]) -> Result<i64, WideErr> {
+    match core::str::from_utf8(b)
+        .ok()
+        .and_then(tcl_syntax::number::parse_whole)
+    {
+        Some(tcl_syntax::number::Number::Int(v)) => Ok(v),
+        Some(tcl_syntax::number::Number::Big { .. }) => Err(WideErr::TooLarge),
+        _ => Err(WideErr::NotInteger),
+    }
+}
+
 /// `int` / `end` / `end-N` / `end+N` index spec against `len` chars.
 // Index specs (`end`, `int±int`, `end±int`, …) share the full
 // `TclGetIntForIndex` grammar with the list commands — reuse one parser.
@@ -1237,6 +1592,17 @@ fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
     let mut m = b"wrong # args: should be \"".to_vec();
     m.extend_from_slice(usage);
     m.push(b'"');
+    interp.set_error(&m)
+}
+/// Whether `opt` abbreviates `-nocase` (`strncmp` with `length > 1`), the sole
+/// option of `string map`/`string match`.
+fn is_nocase_opt(opt: &[u8]) -> bool {
+    opt.len() > 1 && b"-nocase".starts_with(opt)
+}
+fn bad_nocase_option(interp: &mut Interp, opt: &[u8]) -> Code {
+    let mut m = b"bad option \"".to_vec();
+    m.extend_from_slice(opt);
+    m.extend_from_slice(b"\": must be -nocase");
     interp.set_error(&m)
 }
 fn no_such_var(interp: &mut Interp, name: &[u8]) -> Code {

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -708,8 +708,10 @@ fn str_compare_equal(interp: &mut Interp, argv: &[*mut TclObj], equal: bool) -> 
             }
             // `-length` reads a wide int (`TclGetWideIntFromObj`): a negative or
             // out-of-`Tcl_Size` value means "no limit", a bignum overflows.
+            // `try_from` keeps an over-wide length as `None` rather than wrapping
+            // (`w as usize` truncates on 32-bit targets such as wasm32).
             match get_wide(&obj_bytes(argv[i + 1])) {
-                Ok(w) => length = if w < 0 { None } else { Some(w as usize) },
+                Ok(w) => length = usize::try_from(w).ok(),
                 Err(WideErr::TooLarge) => {
                     return interp.set_error(b"integer value too large to represent");
                 }


### PR DESCRIPTION
Builds on PR #607's `string is` rewrite with the rest of the `string` ensemble (`runtime/rust/src/cmd_string.rs`), matched against the Tcl 9 C sources (`tclCmdMZ.c`, `tclStringObj.c`, `tclObj.c`, `tclUtf.c`, `tclIndexObj.c`) and byte-verified against `tclsh9.0`.

**`string.test`: 564 → 684 / 705** (89% → 97%), zero regressions in `string.test`/`stringComp` cases.

## What's fixed

- **Dispatch** the `string` subcommand by unambiguous prefix (`Tcl_GetIndexFromObj`), so `string fir`/`string co` resolve and `string trim` still beats its `trimleft`/`trimright` prefixes.
- **`compare`/`equal`**: 4..=7 arg bound, prefix-matched `-nocase`/`-length`, and a wide-int `-length` (negative ⇒ no limit, bignum ⇒ `integer value too large to represent`).
- **`first`/`last`**: empty needle ⇒ -1, and `last`'s index caps the match's *final* character (latest start = `lastIndex + 1 - needleLen`) rather than its start.
- **`map`/`match`**: `-nocase` by ≥2-char prefix, else `bad option … must be -nocase`.
- **`toupper`/`tolower`/`totitle`**: simple (1:1) Unicode case mapping, a lone index maps just that character, and the four Latin digraphs title-case to their mixed-case form.
- **`trim`/`trimleft`/`trimright`**: character-based with Tcl's full default whitespace set (`tclDefaultTrimSet`) and per-command usage strings.
- **word chars** (`wordstart`/`wordend`, `string is wordchar`) include connector punctuation (Unicode `Pc`).
- **`tcl::prefix`**: validate option values (`missing value for -error/-message`, even-length `-error` list), surface the full Tcl list-parse error (with the offending fragment) for bad tables, compute `longest` per character, and register `::tcl::string::reverse`.
- **`string is list`/`dict`**: report the character index where list parsing fails (an odd-but-valid dict reports -1), completing #607's `class_check`.

## Out of scope (blocked elsewhere)

The remaining 9 `string.test` failures need changes outside `cmd_string.rs`: bignum `string index` arithmetic (`cmd_list::index_spec`), surrogate `\u` distinctness (the lexer collapses surrogates to U+FFFD), `tcl::prefix -error` return options (interp return-options), and a `representationpoke` internal-rep test canary.

## Validation

- Byte-verified each form against `tclsh9.0`.
- `cargo test --release --lib`: 324 pass.
- `make runtime-rust-lint` (fmt + clippy `-D warnings`): clean.
- `rust_tcltest_sweep.py string.test`: 684/705, no regressions.

A SYNC entry was appended to `docs/design/runtime/rust-runtime-port.md`.

https://claude.ai/code/session_015j8mtAdSZcqJeic8HDwQ7y

---
_Generated by [Claude Code](https://claude.ai/code/session_015j8mtAdSZcqJeic8HDwQ7y)_