### PR TITLE
TIP 280 info frame fixes: inline bodies, conditions, expr codes

### DIFF
--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3167,10 +3167,24 @@ apply.test 21→31, proc.test 20→24; no regressions.
   942757: `a b  c` → `{a b  c}`, `` → `{}`), gated by `CallMeta.quote_name` so
   `apply`/TclOO multi-word usage prefixes stay raw.
 
-Out of scope here (deliberately deferred): the `info frame` `level`-omission
-reachability rule for `uplevel`-redirected frames (info-38.2–38.6 — needs
-cmd-frame↔CallFrame reachability threading), `switch -regexp` and `interp debug`
-features (info-30.13/14/16/17/19/20), `info cmdtype`/`cmdcount`
+`info` introspection follow-ups (same session), against `tclVar.c`
+(`TclInfoGlobalsCmd`/`TclInfoVarsCmd`) and `tclCmdIL.c` (`TclInfoFrame`).
+info.test 241→246, var.test 73→76; no regressions.
+
+- `info globals` strips leading global-namespace qualifiers when the pattern
+  starts with `::` (Bug 1057461) — `::x`/`:::x` match global `x`, a lone `:x`
+  does not (info-8.4).
+- `info vars` handles a namespace-qualified pattern via the shared
+  qualified-lookup path (`vars_in_namespace`), re-qualifying matches to their
+  full names (info-19.9).
+- `info frame` `level`-omission **reachability** for `uplevel`-bypassed frames:
+  each `CmdFrame` records its CallFrame stack index (`frame_index`), and the
+  `level` key is gated on caller-chain membership (`caller_chain_indices` walks
+  `saved_active` by identity, so an `uplevel` redirection's chain skips the frame
+  it bypassed even when levels coincide). info-38.3/38.5.
+
+Out of scope here (deliberately deferred): info-38.2/4/6 (blocked on `interp
+debug`), `switch -regexp` (info-30.16/17/19/20), `info cmdtype`/`cmdcount`
 (info-40/info-3), the alias-rewrite `wrong # args` prefix (apply-4.3–4.5), and
 insertion-ordered `info locals` (apply-8.2/8.3 — the var table is a sorted
 `BTreeMap`). Untouched per the parallel-work exclusion: `cmd_string.rs` and the

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3150,12 +3150,31 @@ dict 325, error 261, eval 12/12 held).
   value" — matching C, where the substitution's bytecode unwinds the
   expr-bearing command. Threaded as `propagated_code` through `InterpExprCtx`.
 
+Adjacent `apply`/`proc` parameter + diagnostic fixes (same session), in
+`cmd_proc.rs`/`interp.rs` against `tclProc.c` (`TclCreateProc`,
+`Tcl_ApplyObjCmd`, `ProcWrongNumArgs`) and `tclIndexObj.c` (`Tcl_WrongNumArgs`).
+apply.test 21→31, proc.test 20→24; no regressions.
+
+- A malformed lambda parameter list adds the `(parsing lambda expression
+  "<lambda>")` errorInfo frame after the parse error.
+- `parse_params` rejects non-scalar formal names: `a(1)` (array element) and
+  `a::b` (not a simple name) — shared by `proc` and `apply`.
+- `apply` resolves its namespace (prepending `::`) and errors `namespace "<n>"
+  not found` instead of creating it.
+- `info level N` of a lambda reports the real `apply <lambdaExpr> ?arg ...?`
+  invocation, not the `apply lambdaExpr` usage prefix.
+- A `wrong # args` message list-quotes a genuine single-word proc name (Bug
+  942757: `a b  c` → `{a b  c}`, `` → `{}`), gated by `CallMeta.quote_name` so
+  `apply`/TclOO multi-word usage prefixes stay raw.
+
 Out of scope here (deliberately deferred): the `info frame` `level`-omission
 reachability rule for `uplevel`-redirected frames (info-38.2–38.6 — needs
 cmd-frame↔CallFrame reachability threading), `switch -regexp` and `interp debug`
-features (info-30.13/14/16/17/19/20), and `info cmdtype`/`cmdcount`
-(info-40/info-3). Untouched per the parallel-work exclusion: `cmd_string.rs` and
-the `string` helpers in `rust/tcl-syntax/src/`.
+features (info-30.13/14/16/17/19/20), `info cmdtype`/`cmdcount`
+(info-40/info-3), the alias-rewrite `wrong # args` prefix (apply-4.3–4.5), and
+insertion-ordered `info locals` (apply-8.2/8.3 — the var table is a sorted
+`BTreeMap`). Untouched per the parallel-work exclusion: `cmd_string.rs` and the
+`string` helpers in `rust/tcl-syntax/src/`.
 
 ### Outstanding
 

--- a/docs/design/runtime/rust-runtime-port.md
+++ b/docs/design/runtime/rust-runtime-port.md
@@ -3119,6 +3119,44 @@ Out of scope here (blocked elsewhere): bignum `string index` arithmetic
 (`cmd_list::index_spec`), surrogate `\u` distinctness (lexer collapses to
 U+FFFD), and `tcl::prefix -error` return options (interp return-options).
 
+### SYNC inbound — 2026-06-15 (info frame: try bodies, inline-body sharing, condition `[cmd]` lines, expr code propagation)
+
+Chunk: TIP 280 `info frame` line-correctness follow-ups on top of PR #607, in
+`runtime/rust/src/{cmd_error.rs,cmd_control.rs,builtins.rs,interp.rs}`, written
+against `tclCmdMZ.c` (`Tcl_TryObjCmd`), `tclCmdAH.c`/`tclExecute.c` (inline
+`while`/`for`/`if`/`foreach` compilation), and `tclCmdIL.c` (`TclInfoFrame`).
+`info.test` 227→241 / 287; zero regressions (trace 199, oo 357, namespace 238,
+dict 325, error 261, eval 12/12 held).
+
+- **`try` body/handler/finally** kept their argument *objects* (not flattened
+  bytes) and run through `eval_control_body`, so a literal body's source location
+  is recovered for `info frame` (info-33.23–33.31, 8 tests).
+- **Inline control bodies share the frame.** In a proc, `while`/`for`/`if`/
+  `foreach`/`try` are compiled inline, so their literal bodies run in the *same*
+  `info frame` level — the runtime had pushed a new `CmdFrame` per body,
+  inflating depth by one (3 where tclsh reports 2) and freezing the proc frame's
+  reported line/cmd. Now an in-proc located-literal body shares the enclosing
+  frame (shift `line_base`, restore after) via `eval_shared_located_body`;
+  top-level and dynamic/pure-list bodies still get their own frame (C's
+  uncompiled `TclEvalObjEx`). Fixes the absolute-level `info frame $level` corner
+  (info-38.1, etrace/while line) and verified `info frame` depth vs tclsh9.0.
+- **Condition `[cmd]` source line.** `eval_bool_expr` now takes the condition
+  *object* and, for a located literal, shifts the shared frame's `line_base` to
+  the condition word while the expression evaluates, so a `[cmd]` substitution in
+  an `if`/`while`/`for` condition reports its file-absolute line (info-33.11/14/21).
+- **expr command-subst code propagation.** A `[cmd]` operand inside an expression
+  that completes with `return`/`break`/`continue` (codes 2/3/4) now propagates
+  that code out of the whole expression instead of raising "expected boolean
+  value" — matching C, where the substitution's bytecode unwinds the
+  expr-bearing command. Threaded as `propagated_code` through `InterpExprCtx`.
+
+Out of scope here (deliberately deferred): the `info frame` `level`-omission
+reachability rule for `uplevel`-redirected frames (info-38.2–38.6 — needs
+cmd-frame↔CallFrame reachability threading), `switch -regexp` and `interp debug`
+features (info-30.13/14/16/17/19/20), and `info cmdtype`/`cmdcount`
+(info-40/info-3). Untouched per the parallel-work exclusion: `cmd_string.rs` and
+the `string` helpers in `rust/tcl-syntax/src/`.
+
 ### Outstanding
 
 _(empty — populated as Zig lands behavioural fixes during the port)_

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -512,12 +512,19 @@ fn parse_i64(bytes: &[u8]) -> Option<i64> {
 #[cfg(have_tommath)]
 struct InterpExprCtx<'a> {
     interp: &'a mut Interp,
-    /// Set when an error propagated out of a sub-evaluation (`[cmd]`, a math
-    /// function, or a `$arr(idx)` index subst) rather than originating in `expr`
-    /// itself. In that case the inner command already built the `::errorInfo`
-    /// trace, so `expr` must preserve it (and add no frame of its own) — matching
-    /// C, where such an error is logged at the inner command, not at `expr`.
+    /// Set when a completion code propagated out of a sub-evaluation (`[cmd]`, a
+    /// math function, or a `$arr(idx)` index subst) rather than originating in
+    /// `expr` itself. For an *error* the inner command already built the
+    /// `::errorInfo` trace, so `expr` must preserve it (and add no frame of its
+    /// own) — matching C, where such an error is logged at the inner command, not
+    /// at `expr`. For a non-error code (`return`/`break`/`continue` from a `[cmd]`
+    /// substitution) the code propagates out of the whole `expr` (and thus out of
+    /// the enclosing `if`/`while`/`for` condition).
     propagated: bool,
+    /// The completion code carried by `propagated` (only meaningful when
+    /// `propagated` is set). Defaults to `Error`; a `[cmd]` substitution that
+    /// completes with `return`/`break`/`continue` records that code here.
+    propagated_code: Code,
 }
 
 #[cfg(have_tommath)]
@@ -557,8 +564,16 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
     }
 
     fn eval_command(&mut self, script: &str) -> Result<crate::expr::Owned, crate::expr::ExprError> {
-        if self.interp.eval_str(script.as_bytes()) == Code::Error {
+        // A `[cmd]` operand that completes with any non-OK code (`error`, or a
+        // `return`/`break`/`continue`) propagates that code out of the whole
+        // expression. C does this implicitly: the bytecode for the substitution
+        // returns the code, which unwinds the `expr`-bearing command. For an
+        // error the interp result already holds the message + `::errorInfo`; for
+        // the others it holds the substitution's result value.
+        let code = self.interp.eval_str(script.as_bytes());
+        if code != Code::Ok {
             self.propagated = true;
+            self.propagated_code = code;
             return Err(crate::expr::ExprError::from_bytes(obj_bytes(
                 self.interp.get_obj_result(),
             )));
@@ -627,18 +642,21 @@ fn expr_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut ctx = InterpExprCtx {
         interp: &mut *interp,
         propagated: false,
+        propagated_code: Code::Error,
     };
     let result = crate::expr::eval_expr(&node, &mut ctx);
     let propagated = ctx.propagated;
+    let propagated_code = ctx.propagated_code;
     match result {
         Ok(r) => {
             // `set_result` takes its own `+1`; `r` drops its reference after.
             interp.set_result(r.as_ptr());
             Code::Ok
         }
-        // A propagated sub-eval error already set the result + `::errorInfo`
-        // trace at the inner command — preserve it (no `expr` frame).
-        Err(_) if propagated => Code::Error,
+        // A propagated sub-eval code already set the interp result at the inner
+        // command — preserve it (an error keeps its `::errorInfo`; a
+        // `return`/`break`/`continue` keeps the substitution's value).
+        Err(_) if propagated => propagated_code,
         Err(e) => match e.code {
             Some(c) => interp.error_with_code(&e.msg, &c),
             None => interp.set_error(&e.msg),
@@ -659,12 +677,14 @@ pub(crate) fn eval_expr_obj(interp: &mut Interp, src: &[u8]) -> Result<*mut TclO
     let mut ctx = InterpExprCtx {
         interp: &mut *interp,
         propagated: false,
+        propagated_code: Code::Error,
     };
     let result = crate::expr::eval_expr(&node, &mut ctx);
     let propagated = ctx.propagated;
+    let propagated_code = ctx.propagated_code;
     match result {
         Ok(r) => Ok(r.into_raw()), // transfer the +1 to the caller
-        Err(_) if propagated => Err(Code::Error),
+        Err(_) if propagated => Err(propagated_code),
         Err(e) => Err(match e.code {
             Some(c) => interp.error_with_code(&e.msg, &c),
             None => interp.set_error(&e.msg),
@@ -684,13 +704,17 @@ pub(crate) fn eval_bool_expr(interp: &mut Interp, src: &[u8]) -> Result<bool, Co
     let mut ctx = InterpExprCtx {
         interp: &mut *interp,
         propagated: false,
+        propagated_code: Code::Error,
     };
     let result = crate::expr::eval_expr(&node, &mut ctx);
     let propagated = ctx.propagated;
+    let propagated_code = ctx.propagated_code;
     match result {
         Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| interp.set_error(&e.msg)),
-        // Preserve a propagated sub-eval error's trace (no condition `expr` frame).
-        Err(_) if propagated => Err(Code::Error),
+        // A propagated sub-eval code unwinds the condition: an error keeps its
+        // trace (no condition `expr` frame); a `return`/`break`/`continue` from a
+        // `[cmd]` substitution carries that code out of the loop/`if`.
+        Err(_) if propagated => Err(propagated_code),
         Err(e) => Err(match e.code {
             Some(c) => interp.error_with_code(&e.msg, &c),
             None => interp.set_error(&e.msg),

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -540,8 +540,12 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
                     .do_subst(&k, crate::subst::SubstFlags::default())
                 {
                     Ok(v) => Some(v),
-                    Err(_) => {
+                    // The index's `[cmd]` completed with a non-OK code — carry it
+                    // (error, or `return`/`break`/`continue`) out of the whole
+                    // expression, exactly like a `[cmd]` operand.
+                    Err(code) => {
                         self.propagated = true;
+                        self.propagated_code = code;
                         return Err(crate::expr::ExprError::from_bytes(obj_bytes(
                             self.interp.get_obj_result(),
                         )));
@@ -588,8 +592,11 @@ impl crate::expr::ExprCtx for InterpExprCtx<'_> {
             .do_subst(inner.as_bytes(), crate::subst::SubstFlags::default())
         {
             Ok(v) => Ok(crate::expr::Owned::fresh(crate::obj::new_string_bytes(&v))),
-            Err(_) => {
+            // A `"…"` operand whose `[cmd]` completed non-OK carries that code
+            // (error, or `return`/`break`/`continue`) out of the expression.
+            Err(code) => {
                 self.propagated = true;
+                self.propagated_code = code;
                 Err(crate::expr::ExprError::from_bytes(obj_bytes(
                     self.interp.get_obj_result(),
                 )))

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -692,13 +692,21 @@ pub(crate) fn eval_expr_obj(interp: &mut Interp, src: &[u8]) -> Result<*mut TclO
     }
 }
 
-/// Evaluate `src` as a Tcl expression and coerce the result to a boolean — the
-/// condition evaluator `if`/`while`/`for` share. `Err(code)` carries the
-/// completion code (with the interp result already set to the error message).
+/// Evaluate the condition object `cond` as a Tcl expression and coerce the result
+/// to a boolean — the condition evaluator `if`/`while`/`for` share. `Err(code)`
+/// carries the completion code (with the interp result already set to the error
+/// message). A located-literal condition shifts the shared frame's `line_base` to
+/// the condition word so a `[cmd]` substitution inside reports its file-absolute
+/// line (TIP 280); the base is restored afterward.
 #[cfg(have_tommath)]
-pub(crate) fn eval_bool_expr(interp: &mut Interp, src: &[u8]) -> Result<bool, Code> {
-    let Ok(s) = core::str::from_utf8(src) else {
+pub(crate) fn eval_bool_expr(interp: &mut Interp, cond: *mut TclObj) -> Result<bool, Code> {
+    let src = obj_bytes(cond);
+    let Ok(s) = core::str::from_utf8(&src) else {
         return Err(interp.set_error(b"expr operand is not valid UTF-8"));
+    };
+    let saved = match interp.arg_location(cond) {
+        Some((_, line)) => interp.push_cond_line_base(line),
+        None => None,
     };
     let node = tcl_syntax::expr::parse_expr(s, None);
     let mut ctx = InterpExprCtx {
@@ -709,6 +717,9 @@ pub(crate) fn eval_bool_expr(interp: &mut Interp, src: &[u8]) -> Result<bool, Co
     let result = crate::expr::eval_expr(&node, &mut ctx);
     let propagated = ctx.propagated;
     let propagated_code = ctx.propagated_code;
+    if let Some(old) = saved {
+        interp.restore_line_base(old);
+    }
     match result {
         Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| interp.set_error(&e.msg)),
         // A propagated sub-eval code unwinds the condition: an error keeps its

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -44,6 +44,10 @@ fn break_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 1 {
         return wrong_args(interp, b"break");
     }
+    // `break`/`continue` carry no value — clear any prior result so `catch
+    // {break}` (and a `break` propagated out of an expr substitution) report the
+    // empty string, matching C (where each command entry resets the result).
+    interp.set_result_bytes(b"");
     Code::Break
 }
 
@@ -51,6 +55,7 @@ fn continue_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 1 {
         return wrong_args(interp, b"continue");
     }
+    interp.set_result_bytes(b"");
     Code::Continue
 }
 

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -64,7 +64,8 @@ fn if_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         if i >= argv.len() {
             return interp.set_error(b"wrong # args: no expression after \"if\" argument");
         }
-        let cond = obj_bytes(argv[i]);
+        let cond_obj = argv[i];
+        let cond = obj_bytes(cond_obj);
         i += 1;
         // optional `then` keyword.
         if i < argv.len() && obj_bytes(argv[i]).as_slice() == b"then" {
@@ -79,7 +80,7 @@ fn if_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         let body = argv[i];
         i += 1;
 
-        match crate::builtins::eval_bool_expr(interp, &cond) {
+        match crate::builtins::eval_bool_expr(interp, cond_obj) {
             Ok(true) => return interp.eval_control_body(body),
             Ok(false) => {}
             Err(code) => return code,
@@ -117,10 +118,10 @@ fn while_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 3 {
         return wrong_args(interp, b"while test command");
     }
-    let cond = obj_bytes(argv[1]);
+    let cond = argv[1];
     let body = argv[2];
     loop {
-        match crate::builtins::eval_bool_expr(interp, &cond) {
+        match crate::builtins::eval_bool_expr(interp, cond) {
             Ok(true) => {}
             Ok(false) => break,
             Err(code) => return code,
@@ -143,7 +144,7 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 5 {
         return wrong_args(interp, b"for start test next command");
     }
-    let (init, cond, next, body) = (argv[1], obj_bytes(argv[2]), argv[3], argv[4]);
+    let (init, cond, next, body) = (argv[1], argv[2], argv[3], argv[4]);
     // `start`/`next` are scripts too — run them through `eval_control_body` so a
     // located literal reports `type source` at its own line (TIP 280), matching
     // the body. (Their result is discarded; only their completion code matters.)
@@ -152,7 +153,7 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         other => return other,
     }
     loop {
-        match crate::builtins::eval_bool_expr(interp, &cond) {
+        match crate::builtins::eval_bool_expr(interp, cond) {
             Ok(true) => {}
             Ok(false) => break,
             Err(code) => return code,

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -132,20 +132,22 @@ fn error_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 // -- try / throw -----------------------------------------------------------
 
-/// A `try` handler clause.
+/// A `try` handler clause. The handler `script` is kept as its argument object
+/// (not flattened to bytes) so it evaluates through `eval_control_body`, which
+/// recovers the literal's TIP 280 source location for `info frame`.
 enum Handler {
     /// `on code varList script` — matches the body's completion code.
     On {
         code: Vec<u8>,
         vars: Vec<u8>,
-        script: Vec<u8>,
+        script: *mut TclObj,
     },
     /// `trap pattern varList script` — matches an error whose `-errorcode`
     /// has `pattern` (a list) as a leading sublist.
     Trap {
         pattern: Vec<u8>,
         vars: Vec<u8>,
-        script: Vec<u8>,
+        script: *mut TclObj,
     },
 }
 
@@ -183,10 +185,10 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return wrong_args(interp, USAGE);
     }
-    let body = obj_bytes(argv[1]);
+    let body = argv[1];
 
     let mut handlers: Vec<Handler> = Vec::new();
-    let mut finally: Option<Vec<u8>> = None;
+    let mut finally: Option<*mut TclObj> = None;
     let mut j = 2;
     while j < argv.len() {
         match obj_bytes(argv[j]).as_slice() {
@@ -196,14 +198,14 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                         b"wrong # args to finally clause: must be \"... finally script\"",
                     );
                 }
-                finally = Some(obj_bytes(argv[j + 1]));
+                finally = Some(argv[j + 1]);
                 j += 2;
             }
             b"on" if j + 4 <= argv.len() => {
                 handlers.push(Handler::On {
                     code: obj_bytes(argv[j + 1]),
                     vars: obj_bytes(argv[j + 2]),
-                    script: obj_bytes(argv[j + 3]),
+                    script: argv[j + 3],
                 });
                 j += 4;
             }
@@ -211,7 +213,7 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 handlers.push(Handler::Trap {
                     pattern: obj_bytes(argv[j + 1]),
                     vars: obj_bytes(argv[j + 2]),
-                    script: obj_bytes(argv[j + 3]),
+                    script: argv[j + 3],
                 });
                 j += 4;
             }
@@ -224,7 +226,9 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 
     // Run the body, snapshotting its completion code, result, and -errorcode.
-    let body_code = interp.eval_str(&body);
+    // `eval_control_body` recovers the body literal's TIP 280 source location so
+    // an `info frame` inside reports the right `type source` line.
+    let body_code = interp.eval_control_body(body);
     let body_result = interp.result_bytes();
     let errorcode = if body_code == Code::Error {
         interp.error_code()
@@ -278,14 +282,14 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         if body_code == Code::Error {
             interp.publish_and_reset_error();
         }
-        outcome_code = interp.eval_str(script);
+        outcome_code = interp.eval_control_body(*script);
         outcome_result = interp.result_bytes();
         break;
     }
 
     // `finally` always runs; only its error overrides the result.
     if let Some(fin) = finally {
-        let fc = interp.eval_str(&fin);
+        let fc = interp.eval_control_body(fin);
         if fc != Code::Ok {
             return fc; // finally's result is already the interp result
         }

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -95,18 +95,31 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Interp::procs_in_namespace,
             Interp::visible_proc_names,
         ),
-        b"vars" => set_list(
+        b"vars" => set_list_qualified(
             interp,
             argv,
             b"info vars ?pattern?",
+            Interp::vars_in_namespace,
             Interp::visible_var_names,
         ),
-        b"globals" => set_list(
-            interp,
-            argv,
-            b"info globals ?pattern?",
-            Interp::global_var_names,
-        ),
+        b"globals" => {
+            if argv.len() > 3 {
+                return wrong_args(interp, b"info globals ?pattern?");
+            }
+            // Strip leading global-namespace qualifiers (Bug 1057461): only when
+            // the pattern starts with `::` — then drop *all* leading colons, so
+            // `::x`/`:::x` match global `x` but a lone `:x` does not.
+            let pattern = argv.get(2).map(|&a| obj_bytes(a)).map(|p| {
+                if p.starts_with(b"::") {
+                    let n = p.iter().position(|&c| c != b':').unwrap_or(p.len());
+                    p[n..].to_vec()
+                } else {
+                    p
+                }
+            });
+            let list = interp.global_var_names();
+            set_filtered(interp, list, pattern.as_deref())
+        }
         b"locals" => set_list(
             interp,
             argv,

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -5707,6 +5707,7 @@ impl Interp {
                 same_level: index > 0,
                 usage_prefix,
                 level_words,
+                quote_name: false,
             },
         );
         self.oo.borrow_mut().filter_handling = saved_fh;

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -179,6 +179,10 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Some((file, line)) => (Some(file), line.saturating_sub(1)),
         None => (None, 0),
     };
+    // `info level N` of a lambda reports the actual invocation words
+    // (`apply <lambdaExpr> ?arg ...?`), not the `apply lambdaExpr` usage prefix
+    // used for `wrong # args` (C records `objv` verbatim for the lambda frame).
+    let level_words: Vec<Vec<u8>> = argv.iter().map(|&a| obj_bytes(a)).collect();
     interp.run_proc(
         &params,
         &parts[1],
@@ -194,7 +198,7 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             keep_loop_codes: false,
             same_level: false,
             usage_prefix: None,
-            level_words: None,
+            level_words: Some(level_words),
         },
     )
 }

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -62,14 +62,20 @@ pub(crate) fn parse_params(spec: &[u8]) -> Result<Vec<Param>, Vec<u8>> {
         let parts = split_list(e).map_err(|er| er.message().to_vec())?;
         match parts.len() {
             0 => return Err(b"argument with no name".to_vec()),
-            1 => params.push(Param {
-                name: parts[0].clone(),
-                default: None,
-            }),
-            2 => params.push(Param {
-                name: parts[0].clone(),
-                default: Some(parts[1].clone()),
-            }),
+            1 => {
+                check_param_name(&parts[0])?;
+                params.push(Param {
+                    name: parts[0].clone(),
+                    default: None,
+                });
+            }
+            2 => {
+                check_param_name(&parts[0])?;
+                params.push(Param {
+                    name: parts[0].clone(),
+                    default: Some(parts[1].clone()),
+                });
+            }
             _ => {
                 let mut m = b"too many fields in argument specifier \"".to_vec();
                 m.extend_from_slice(e);
@@ -79,6 +85,36 @@ pub(crate) fn parse_params(spec: &[u8]) -> Result<Vec<Param>, Vec<u8>> {
         }
     }
     Ok(params)
+}
+
+/// A formal parameter name must be a scalar simple name: not an array element
+/// (`a(1)`) and not namespace-qualified (`a::b`). Mirrors the scan in C's
+/// `TclCreateProc` (`tclProc.c`): an `(` anywhere before the final char with a
+/// trailing `)` is an array element; a `::` anywhere before the final char makes
+/// the name non-simple.
+fn check_param_name(name: &[u8]) -> Result<(), Vec<u8>> {
+    if name.is_empty() {
+        return Ok(());
+    }
+    let last = name.len() - 1;
+    let mut i = 0;
+    while i < last {
+        if name[i] == b'(' {
+            if name[last] == b')' {
+                let mut m = b"formal parameter \"".to_vec();
+                m.extend_from_slice(name);
+                m.extend_from_slice(b"\" is an array element");
+                return Err(m);
+            }
+        } else if name[i] == b':' && name[i + 1] == b':' {
+            let mut m = b"formal parameter \"".to_vec();
+            m.extend_from_slice(name);
+            m.extend_from_slice(b"\" is not a simple name");
+            return Err(m);
+        }
+        i += 1;
+    }
+    Ok(())
 }
 
 // -- apply -----------------------------------------------------------------
@@ -103,7 +139,14 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     let params = match parse_params(&parts[0]) {
         Ok(p) => p,
-        Err(e) => return interp.set_error(&e),
+        Err(e) => {
+            // A malformed parameter list: report the parse error, then add the
+            // `(parsing lambda expression "<lambda>")` errorInfo frame (C's
+            // `Tcl_ApplyObjCmd` after a failed `TclCreateProc`).
+            let code = interp.set_error(&e);
+            interp.append_lambda_parse_frame(&lambda);
+            return code;
+        }
     };
     let ns = if parts.len() == 3 {
         interp.ensure_namespace(&parts[2])

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -199,6 +199,7 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             same_level: false,
             usage_prefix: None,
             level_words: Some(level_words),
+            quote_name: false,
         },
     )
 }

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -149,7 +149,27 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
     };
     let ns = if parts.len() == 3 {
-        interp.ensure_namespace(&parts[2])
+        // C prepends `::` to a non-global-qualified namespace name, then resolves
+        // it (`TclGetNamespaceFromObj`); a missing namespace is an error — apply
+        // does **not** create it.
+        let full: Vec<u8> = if parts[2].starts_with(b"::") {
+            parts[2].clone()
+        } else {
+            let mut f = b"::".to_vec();
+            f.extend_from_slice(&parts[2]);
+            f
+        };
+        match interp.find_namespace_id(&full) {
+            Some(id) => id,
+            None => {
+                let mut m = b"namespace \"".to_vec();
+                m.extend_from_slice(&full);
+                m.extend_from_slice(b"\" not found");
+                let mut ecode = b"TCL LOOKUP NAMESPACE ".to_vec();
+                ecode.extend_from_slice(&full);
+                return interp.error_with_code(&m, &ecode);
+            }
+        }
     } else {
         crate::namespace::GLOBAL
     };

--- a/runtime/rust/src/frame.rs
+++ b/runtime/rust/src/frame.rs
@@ -425,6 +425,37 @@ impl FrameStack {
         self.frames.iter().rposition(|f| f.level == level)
     }
 
+    /// The stack index of the current active (var) frame — the identity a new
+    /// `CmdFrame` records as its CallFrame (C's `framePtr->framePtr`).
+    pub(crate) fn current_frame_index(&self) -> usize {
+        self.index_of_level(self.active_level).unwrap_or(0)
+    }
+
+    /// The set of stack indices on the active frame's caller chain (C's
+    /// `callerVarPtr` walk from `varFramePtr`). Each frame's caller is the topmost
+    /// frame *below* it at the level that was active when it was pushed
+    /// (`saved_active`) — so an `uplevel`-redirected call's chain skips the frame
+    /// it bypassed, even when that frame shares a level. Used by `info frame` to
+    /// decide whether to report a frame's `level`.
+    pub(crate) fn caller_chain_indices(&self) -> std::collections::HashSet<usize> {
+        let mut set = std::collections::HashSet::new();
+        let mut idx = self.current_frame_index();
+        loop {
+            if !set.insert(idx) || idx == 0 {
+                break;
+            }
+            let caller_level = self.frames[idx].saved_active;
+            match self.frames[..idx]
+                .iter()
+                .rposition(|f| f.level == caller_level)
+            {
+                Some(c) => idx = c,
+                None => break,
+            }
+        }
+        set
+    }
+
     /// Redirect the active variable frame to `level` (for `uplevel`), returning
     /// the previous active level so the caller can restore it.
     pub fn set_active_level(&mut self, level: usize) -> usize {

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -158,6 +158,12 @@ struct CmdFrame {
     /// current var-scope chain, which is the `uplevel` case (its body runs in a
     /// redirected scope).
     omit_level: bool,
+    /// The **stack index** (identity, not logical level) of the CallFrame this
+    /// cmd-frame runs in — C's `framePtr->framePtr`. `level` alone can't identify
+    /// the frame (an `uplevel`-invoked proc shares its caller's level), so the
+    /// `info frame` `level` reachability test (TclInfoFrame) walks the caller
+    /// chain by this index. `0` is the global frame.
+    frame_index: usize,
     /// Added to a body-relative line to get the reported `line`. `0` for
     /// top-level / `eval` / eval-defined procs (body-relative, matching tclsh);
     /// for a proc defined in a `source`d file it is the file line where the body
@@ -221,6 +227,7 @@ impl CmdFrame {
             proc: None,
             level: 0,
             omit_level: false,
+            frame_index: 0,
             line_base: 0,
             cmd: Vec::new(),
             line: 1,
@@ -1205,12 +1212,17 @@ impl Interp {
             Some((file, line)) => (FrameKind::Source, file, line.saturating_sub(1)),
             None => (FrameKind::Eval, None, 0),
         };
+        let (ns_level, ns_index) = {
+            let f = self.frames.borrow();
+            (f.current_level(), f.current_frame_index())
+        };
         let frame = CmdFrame {
             kind,
             file,
             proc: None,
-            level: self.frames.borrow().current_level(),
+            level: ns_level,
             omit_level: false,
+            frame_index: ns_index,
             line_base,
             cmd: Vec::new(),
             line: 1,
@@ -2612,11 +2624,19 @@ impl Interp {
         } else if let Some(p) = &f.proc {
             pairs.push((b"proc".to_vec(), p.clone()));
         }
-        // `level` is the distance from the current call level (omitted for a
-        // redirected `uplevel` scope, matching C's reachability check).
+        // `level` is the distance from the current call level — but C only adds
+        // it when the frame's CallFrame is *reachable* from the current var frame
+        // by walking the caller chain (`TclInfoFrame`). A frame bypassed by an
+        // `uplevel` redirection (e.g. the proc that called `uplevel`, when viewed
+        // from the uplevel'd callee) is off the chain and omits `level`, even
+        // though it shares a level with a chain frame. `omit_level` short-circuits
+        // the explicit `uplevel`-body case (C's `framePtr->framePtr == NULL`).
         if !f.omit_level {
-            let level = self.frames.borrow().current_level().saturating_sub(f.level);
-            pairs.push((b"level".to_vec(), level.to_string().into_bytes()));
+            let frames = self.frames.borrow();
+            if frames.caller_chain_indices().contains(&f.frame_index) {
+                let level = frames.current_level().saturating_sub(f.level);
+                pairs.push((b"level".to_vec(), level.to_string().into_bytes()));
+            }
         }
         Some(pairs)
     }
@@ -2770,6 +2790,10 @@ impl Interp {
             // Inherit the enclosing frame's level-reachability (an inline body
             // of an `uplevel`-redirected script also omits `level`).
             omit_level: top.is_some_and(|f| f.omit_level),
+            // An `eval`/body frame runs in the enclosing call frame — inherit its
+            // identity so the `info frame` `level` reachability test sees it as
+            // the same CallFrame.
+            frame_index: top.map_or(0, |f| f.frame_index),
             line_base,
             cmd: Vec::new(),
             line: 1,
@@ -4051,6 +4075,10 @@ impl Interp {
             ProcFrame::Lambda(expr) => Some(expr.to_vec()),
             _ => None,
         };
+        let (proc_lvl, proc_idx) = {
+            let f = self.frames.borrow();
+            (f.current_level(), f.current_frame_index())
+        };
         let proc_frame = CmdFrame {
             kind: if meta.source.is_some() {
                 FrameKind::Source
@@ -4059,8 +4087,9 @@ impl Interp {
             },
             file: meta.source,
             proc: meta.fqn.map(<[u8]>::to_vec),
-            level: self.frames.borrow().current_level(),
+            level: proc_lvl,
             omit_level: false,
+            frame_index: proc_idx,
             line_base: meta.body_line_base,
             cmd: Vec::new(),
             line: 1,

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2747,6 +2747,15 @@ impl Interp {
             return self.dispatch_list_obj(body, frame);
         }
         if let Some((file, line)) = self.arg_loc(body) {
+            // Inside a proc the enclosing command (`while`/`for`/`if`/`foreach`/
+            // `try`) is compiled inline, so its literal body runs in the **same**
+            // `info frame` level — no new frame, the shared frame's line just
+            // advances to each body command (C's bytecode inlining). At the top
+            // level (uncompiled command form) the body is evaluated as its own
+            // frame (`TclEvalObjEx`), matching tclsh's `info frame` depth.
+            if self.in_proc() {
+                return self.eval_shared_located_body(body, line);
+            }
             let mut frame = self.inherited_cmd_frame();
             frame.kind = FrameKind::Source;
             frame.file = file;
@@ -2755,6 +2764,36 @@ impl Interp {
             return self.eval_framed(&bytes, frame);
         }
         self.eval_unlocated_body(&obj_bytes(body))
+    }
+
+    /// Evaluate a located-literal control body that is **inlined** into the
+    /// enclosing frame (the in-proc case of [`eval_control_body`]). The enclosing
+    /// frame is shared (no new `info frame` level); its `line_base` is shifted so
+    /// the body's commands report their own file-absolute lines, then restored.
+    /// The body literal lives in the same source as the enclosing frame, so the
+    /// frame's `kind`/`file` already match — only the line mapping changes.
+    fn eval_shared_located_body(&mut self, body: *mut TclObj, line: u32) -> Code {
+        let saved = {
+            let mut frames = self.cmd_frames.borrow_mut();
+            frames.last_mut().map(|top| {
+                let saved = (top.line_base, top.line, std::mem::take(&mut top.cmd));
+                top.line_base = line.saturating_sub(1);
+                saved
+            })
+        };
+        let Some((line_base, line, cmd)) = saved else {
+            // No enclosing frame to share (shouldn't happen under `in_proc`) —
+            // fall back to a body-relative eval rather than panic.
+            return self.eval_unlocated_body(&obj_bytes(body));
+        };
+        let bytes = obj_bytes(body);
+        let code = self.eval_script_mode(&bytes, None, true);
+        if let Some(top) = self.cmd_frames.borrow_mut().last_mut() {
+            top.line_base = line_base;
+            top.line = line;
+            top.cmd = cmd;
+        }
+        code
     }
 
     /// The TIP 280 source location recorded for `obj` (the literal-argument

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2084,6 +2084,26 @@ impl Interp {
         }
     }
 
+    /// Variable names in the namespace named `qualifier` (`info vars
+    /// ::ns::pattern`), or empty if it does not exist. An empty qualifier (a
+    /// leading `::pattern`) addresses the global namespace.
+    pub(crate) fn vars_in_namespace(&self, qualifier: &[u8]) -> Vec<Vec<u8>> {
+        let ns = self.namespaces.borrow();
+        let target = if qualifier.is_empty() {
+            Some(GLOBAL)
+        } else {
+            ns.find_namespace(self.current_ns.get(), qualifier)
+        };
+        match target {
+            Some(id) => {
+                let mut v = ns.var_names(id);
+                v.sort();
+                v
+            }
+            None => Vec::new(),
+        }
+    }
+
     /// Proc names visible from the current namespace (`info procs`).
     pub(crate) fn visible_proc_names(&self) -> Vec<Vec<u8>> {
         let ns = self.namespaces.borrow();

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2804,6 +2804,25 @@ impl Interp {
         self.arg_loc(obj)
     }
 
+    /// Point the current shared frame's `line_base` at `line` (a condition word's
+    /// source line) so command substitutions inside an `if`/`while`/`for`
+    /// expression report their file-absolute line (TIP 280). Returns the previous
+    /// `line_base` to hand back to [`restore_line_base`](Self::restore_line_base).
+    pub(crate) fn push_cond_line_base(&self, line: u32) -> Option<u32> {
+        self.cmd_frames.borrow_mut().last_mut().map(|top| {
+            let old = top.line_base;
+            top.line_base = line.saturating_sub(1);
+            old
+        })
+    }
+
+    /// Restore a `line_base` saved by [`push_cond_line_base`](Self::push_cond_line_base).
+    pub(crate) fn restore_line_base(&self, old: u32) {
+        if let Some(top) = self.cmd_frames.borrow_mut().last_mut() {
+            top.line_base = old;
+        }
+    }
+
     /// The `(file, line)` of list element `index` within the literal `obj` — for
     /// a body that is a sub-element of a located list literal (an `apply` lambda's
     /// body, C's `TclListLines`). The element's line is the list word's line plus

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -126,6 +126,11 @@ pub(crate) struct CallMeta<'a> {
     /// constructor (the `create`/`new` invocation, e.g. `oo::object create foo`)
     /// so `info level 0` reflects the instantiation, not `<constructor>`.
     pub level_words: Option<Vec<Vec<u8>>>,
+    /// List-quote the command name in a `wrong # args` message (Bug 942757) — a
+    /// genuine single-word proc name (`a b  c` → `{a b  c}`, `` → `{}`). Off for
+    /// `apply`/TclOO whose `usage_called`/`usage_prefix` is a pre-joined
+    /// multi-word string (`apply lambdaExpr`, `obj method`) that must stay raw.
+    pub quote_name: bool,
 }
 
 /// One entry of the source-location stack (`cmdFramePtr`; PC-5) — the runtime
@@ -3892,6 +3897,7 @@ impl Interp {
                 same_level: false,
                 usage_prefix: None,
                 level_words: None,
+                quote_name: true,
             },
         )
     }
@@ -3929,7 +3935,7 @@ impl Interp {
         let supplied = call_args.len();
         let required = positional.iter().filter(|p| p.default.is_none()).count();
         if supplied < required || (!has_args && supplied > positional.len()) {
-            return self.error(&self.proc_wrong_args(usage, params, supplied));
+            return self.error(&self.proc_wrong_args(usage, params, supplied, meta.quote_name));
         }
         // Recursion bound (catchable, not a stack overflow).
         if self.recursion_depth.get() >= RECURSION_LIMIT {
@@ -3985,7 +3991,7 @@ impl Interp {
                 self.frames.borrow_mut().pop();
                 self.current_ns.set(saved_ns);
                 self.recursion_depth.set(self.recursion_depth.get() - 1);
-                return self.error(&self.proc_wrong_args(usage, params, supplied));
+                return self.error(&self.proc_wrong_args(usage, params, supplied, meta.quote_name));
             };
             if stored.is_err() {
                 self.frames.borrow_mut().pop();
@@ -4587,6 +4593,7 @@ impl Interp {
         called: &[u8],
         params: &[Param],
         supplied: usize,
+        quote_name: bool,
     ) -> Vec<u8> {
         if let Some(rw) = self.ensemble_rewrite() {
             // How many trailing words of `source` were the user's own arguments,
@@ -4605,7 +4612,7 @@ impl Interp {
                 return proc_usage_words(&prefix, &params[drop..], params);
             }
         }
-        proc_usage(called, params)
+        proc_usage(called, params, quote_name)
     }
 }
 
@@ -4637,9 +4644,16 @@ fn proc_usage_words(words: &[&[u8]], shown: &[Param], all: &[Param]) -> Vec<u8> 
     m
 }
 
-fn proc_usage(called: &[u8], params: &[Param]) -> Vec<u8> {
+fn proc_usage(called: &[u8], params: &[Param], quote_name: bool) -> Vec<u8> {
     let mut m = b"wrong # args: should be \"".to_vec();
-    m.extend_from_slice(called);
+    // A single-word proc name is list-quoted if it needs it — `a b  c` → `{a b  c}`,
+    // `` → `{}` (C's `Tcl_WrongNumArgs` via `TclScanElement`, Bug 942757). `apply`
+    // and TclOO pass a pre-joined multi-word usage prefix that must stay raw.
+    if quote_name {
+        crate::list::append_list_element(&mut m, called, false);
+    } else {
+        m.extend_from_slice(called);
+    }
     let n = params.len();
     for (i, p) in params.iter().enumerate() {
         m.push(b' ');

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2506,6 +2506,26 @@ impl Interp {
         self.exc.borrow_mut().already_logged = false;
     }
 
+    /// Append `"\n    (parsing lambda expression \"<name>\")"` to errorInfo — the
+    /// `apply` lambda-parse failure frame (C's `Tcl_AppendObjToErrorInfo` in
+    /// `Tcl_ApplyObjCmd`). Unlike [`append_frame_line`](Self::append_frame_line)
+    /// it carries no `line N` suffix. Clears `already_logged` so the enclosing
+    /// `apply` command still logs its own `invoked from within` frame.
+    pub(crate) fn append_lambda_parse_frame(&mut self, name: &[u8]) {
+        if self.exc.borrow().info.is_none() {
+            let msg = self.result_bytes();
+            self.exc.borrow_mut().info = Some(msg);
+        }
+        {
+            let mut exc = self.exc.borrow_mut();
+            let buf = exc.info.as_mut().expect("seeded above");
+            buf.extend_from_slice(b"\n    (parsing lambda expression \"");
+            buf.extend_from_slice(name);
+            buf.extend_from_slice(b"\")");
+        }
+        self.exc.borrow_mut().already_logged = false;
+    }
+
     pub(crate) fn append_frame_line(&mut self, inner: &[u8]) {
         let line = self.exc.borrow().line;
         if self.exc.borrow().info.is_none() {


### PR DESCRIPTION
## Summary

Implement TIP 280 source-location correctness for `info frame` across control structures and expression evaluation:

- **Inline control-body frame sharing**: In procs, `while`/`for`/`if`/`foreach`/`try` bodies now share the enclosing frame instead of creating a new one, matching tclsh's `info frame` depth. Located-literal bodies shift the frame's `line_base` during evaluation and restore it afterward via `eval_shared_located_body`.

- **Condition `[cmd]` source lines**: `eval_bool_expr` now accepts the condition object and, for located literals, temporarily shifts the shared frame's `line_base` to the condition word so command substitutions inside `if`/`while`/`for` conditions report their file-absolute line.

- **Expression code propagation**: A `[cmd]` operand in an expression that completes with `return`/`break`/`continue` now propagates that code out of the whole expression (via `propagated_code` in `InterpExprCtx`), matching C's bytecode behavior.

- **`info frame` level reachability**: Each `CmdFrame` records its CallFrame stack index (`frame_index`), and the `level` key is only added when the frame is reachable from the current var frame by walking the caller chain. This correctly omits `level` for frames bypassed by `uplevel` redirection, even when levels coincide.

- **`try` body/handler/finally TIP 280 support**: Handler and finally scripts are kept as objects (not flattened bytes) and evaluated through `eval_control_body` to recover source locations.

Adjacent fixes in parameter validation and diagnostics:

- `parse_params` now rejects non-scalar formal parameter names (`a(1)` array elements, `a::b` namespace-qualified names).
- `apply` resolves its namespace argument (prepending `::` if needed) and errors if not found, instead of creating it.
- `apply` lambda parse errors add the `(parsing lambda expression "<lambda>")` errorInfo frame.
- `info level N` of a lambda reports the actual `apply <lambdaExpr> ?arg ...?` invocation via `level_words`, not the usage prefix.
- `wrong # args` messages list-quote genuine single-word proc names (Bug 942757: `a b  c` → `{a b  c}`), gated by `CallMeta.quote_name` so `apply`/TclOO multi-word prefixes stay raw.
- `info globals` strips leading `::` from patterns (Bug 1057461).
- `info vars` handles namespace-qualified patterns via `vars_in_namespace`.

## Validation

- `info.test` 227→241 / 287; `apply.test` 21→31; `proc.test` 20→24; `var.test` 73→76
- Zero regressions across trace (199), oo (357), namespace (238), dict (325), error (261), eval (12/12) test suites
- Verified `info frame` depth and `level` reachability against tclsh9.0

https://claude.ai/code/session_0133qZX8kD366x8tNDdGQMYU