### PR TITLE
Add f5 encrypt-secrets / decrypt-secrets verbs for master-key crypto

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=793bba1-dirty
-head=793bba1bf19cbff9a3985cd26f3ffb3c04f75995
-date=2026-06-15T09:41:05Z
-fingerprint=c0e4e24f94e8f8136cdfb49e6f995bb38086366d8c61650b6d13a6b0ff34ecc7
+describe=b64b13a-dirty
+head=b64b13a8e3bd5a0cd0d639ce99ea0108b4d98fce
+date=2026-06-16T10:55:47Z
+fingerprint=8bd5671e657bd40f7ddf2546db12a3d25ef44ee8c3798217a26047646597c679

--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ Highlights of the newer verbs:
   including support emails and log snippets.
 - **`f5 encrypt-secrets` + `f5 decrypt-secrets`** — encrypt or decrypt the
   credential-bearing values in a `bigip.conf` / SCF (passphrase, password,
-  secret, shared-secret, auth-password, priv-password, encrypted-password)
+  secret, shared-secret, auth-password, privacy-password)
   using the unit master key — the base64 key `f5mku -K` prints on the
   device.  `encrypt-secrets` wraps clear-text values in the
   `$M$<salt>$<base64>` envelope BIG-IP stores; `decrypt-secrets` recovers the

--- a/README.md
+++ b/README.md
@@ -840,9 +840,10 @@ Highlights of the newer verbs:
   `$M$<salt>$<base64>` envelope BIG-IP stores; `decrypt-secrets` recovers the
   clear text.  Both leave values already in the target form untouched, so
   they are idempotent.  The key is supplied via `--f5mku KEY`,
-  `--f5mku-file FILE`, or `$F5MKU`; the AES-ECB transform runs on the
-  bundled pure-Python cipher, so it works in the zipapp with no
-  `cryptography` dependency.
+  `--f5mku-file FILE`, or `$F5MKU`, otherwise it is read from a secure
+  `F5 MKU Key:` terminal prompt (suppress with `--no-key-prompt`); the
+  AES-ECB transform runs on the bundled pure-Python cipher, so it works
+  in the zipapp with no `cryptography` dependency.
 
   ```sh
   f5mku -K > key.txt                                       # on the device

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ f5 irule event-info HTTP_REQUEST --json
 | --- | --- |
 | Acquisition | `fetch`, `extract` (UCS → SCF) |
 | Analysis | `stats`, `graph`, `explain`, `diff`, `grep`, `cleanup`, `validate` |
-| Transformation | `rename`, `redact`, `unredact`, `pcap-remap`, `split`, `merge`, `convert`, `tmsh` |
+| Transformation | `rename`, `redact`, `unredact`, `encrypt-secrets`, `decrypt-secrets`, `pcap-remap`, `split`, `merge`, `convert`, `tmsh` |
 | Round-trip | `pull`, `push` |
 | iRules | `irule event-order`, `irule event-info`, `irule lint`, `irule trace`, `irule extract` |
 | Misc | `completion` |
@@ -832,6 +832,23 @@ Highlights of the newer verbs:
   reuses every prior assignment, so iterative work with F5 support
   stays consistent.  `unredact` walks the map in reverse over any text,
   including support emails and log snippets.
+- **`f5 encrypt-secrets` + `f5 decrypt-secrets`** — encrypt or decrypt the
+  credential-bearing values in a `bigip.conf` / SCF (passphrase, password,
+  secret, shared-secret, auth-password, priv-password, encrypted-password)
+  using the unit master key — the base64 key `f5mku -K` prints on the
+  device.  `encrypt-secrets` wraps clear-text values in the
+  `$M$<salt>$<base64>` envelope BIG-IP stores; `decrypt-secrets` recovers the
+  clear text.  Both leave values already in the target form untouched, so
+  they are idempotent.  The key is supplied via `--f5mku KEY`,
+  `--f5mku-file FILE`, or `$F5MKU`; the AES-ECB transform runs on the
+  bundled pure-Python cipher, so it works in the zipapp with no
+  `cryptography` dependency.
+
+  ```sh
+  f5mku -K > key.txt                                       # on the device
+  f5 decrypt-secrets bigip.conf --f5mku-file key.txt       # reveal secrets
+  F5MKU="$(cat key.txt)" f5 encrypt-secrets clear.conf -o sealed.conf
+  ```
 - **`f5 pcap-remap`** — apply the same map to a PCAP capture: rewrites
   IPv4/IPv6 src/dst, recomputes IP and TCP/UDP/ICMP checksums, and
   *parses* the F5 Ethernet trailer (legacy + DPT formats; `tcpdump -i

--- a/dialects/f5/bigip/rewrite.py
+++ b/dialects/f5/bigip/rewrite.py
@@ -290,19 +290,28 @@ def redact_secrets(
 
 # BIG-IP fields whose values it stores encrypted under the unit master
 # key (the ``$M$...`` envelope produced by ``f5mku``).  This is a
-# deliberately tighter set than ``_SECRET_KEYS`` above: redaction also
-# blanks SNMP community strings and monitor receive strings, but those
-# are kept in clear text on the device and are never master-key
-# encrypted, so feeding them through the cipher would corrupt the
-# config.
+# deliberately tighter set than ``_SECRET_KEYS`` above:
+#
+#   - Redaction also blanks SNMP community strings and monitor receive
+#     strings, but those are kept in clear text on the device and are
+#     never master-key encrypted, so feeding them through the cipher
+#     would corrupt the config.
+#   - ``encrypted-password`` is intentionally absent: in ``auth user``
+#     stanzas it holds the operating-system crypt(3) hash (``$6$...``),
+#     not a master-key ``$M$`` secret, so encrypting it would wreck the
+#     local-user credential.  (The APM ``*-encrypted-password`` variants
+#     are prefixed and so never match the word-boundary key pattern.)
+#
+# SNMPv3 secrets are ``auth-password`` / ``privacy-password`` — the names
+# the F5 SNMP registry (``dialects/f5/bigip/registry/specs/sys_snmp.py``)
+# uses for trap and user stanzas.
 _ENCRYPTED_SECRET_KEYS = (
     "passphrase",
     "password",
-    "encrypted-password",
     "secret",
     "shared-secret",
     "auth-password",
-    "priv-password",
+    "privacy-password",
 )
 
 # A secret value token is either a double-quoted string or a run of

--- a/dialects/f5/bigip/rewrite.py
+++ b/dialects/f5/bigip/rewrite.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from .parser import parse_bigip_conf
 
@@ -284,3 +284,97 @@ def redact_secrets(
         new_source=out,
         redaction_map=rm,
     )
+
+
+# ── encrypt / decrypt secrets ───────────────────────────────────────
+
+# BIG-IP fields whose values it stores encrypted under the unit master
+# key (the ``$M$...`` envelope produced by ``f5mku``).  This is a
+# deliberately tighter set than ``_SECRET_KEYS`` above: redaction also
+# blanks SNMP community strings and monitor receive strings, but those
+# are kept in clear text on the device and are never master-key
+# encrypted, so feeding them through the cipher would corrupt the
+# config.
+_ENCRYPTED_SECRET_KEYS = (
+    "passphrase",
+    "password",
+    "encrypted-password",
+    "secret",
+    "shared-secret",
+    "auth-password",
+    "priv-password",
+)
+
+# A secret value token is either a double-quoted string or a run of
+# non-whitespace, non-brace characters.  The F5 ``$M$<salt>$<base64>``
+# ciphertext is whitespace-free so it always lands in the bare-token arm.
+_SECRET_VALUE = r'"(?:[^"\\]|\\.)*"|[^\s{}]+'
+
+# Values BIG-IP uses as a sentinel for "no secret set" — never crypto.
+_SECRET_SENTINELS = frozenset({"none", "<REDACTED>"})
+
+
+@dataclass(frozen=True, slots=True)
+class SecretRewriteReport:
+    # Number of secret values *transform* actually rewrote.
+    transformed: int
+    # Number of secret-bearing values left untouched (transform returned
+    # None — e.g. already in the target form, or a ``none`` sentinel).
+    skipped: int
+    new_source: str
+
+
+def _unquote(token: str) -> tuple[str, bool]:
+    """Return ``(value, was_quoted)`` for a secret-value *token*."""
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        return token[1:-1].replace('\\"', '"').replace("\\\\", "\\"), True
+    return token, False
+
+
+def _requote(value: str, was_quoted: bool) -> str:
+    """Render *value* back as a SCF token, quoting when it needs it."""
+    needs_quote = was_quoted or value == "" or any(c in value for c in ' \t"{}#;')
+    if not needs_quote:
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def rewrite_secrets(
+    source: str,
+    transform: Callable[[str], str | None],
+) -> SecretRewriteReport:
+    """Apply *transform* to every encrypted-secret-bearing value in *source*.
+
+    For each ``<key> <value>`` whose key is in
+    :data:`_ENCRYPTED_SECRET_KEYS`, *transform* is called with the
+    decoded value and returns the replacement value, or ``None`` to
+    leave it untouched.  This is a text-level rewrite — comments,
+    whitespace, and ordering survive — and the caller supplies the
+    actual cipher (``f5 encrypt-secrets`` / ``f5 decrypt-secrets`` wire
+    in :mod:`tooling.f5.f5mku`), so this module stays free of any
+    crypto dependency.
+    """
+    transformed = 0
+    skipped = 0
+    out = source
+    for key in _ENCRYPTED_SECRET_KEYS:
+        pattern = re.compile(
+            rf"(?<![\w-])({re.escape(key)})([ \t]+)({_SECRET_VALUE})",
+        )
+
+        def _sub(match: re.Match[str]) -> str:
+            nonlocal transformed, skipped
+            value, was_quoted = _unquote(match.group(3))
+            if value in _SECRET_SENTINELS:
+                skipped += 1
+                return match.group(0)
+            replacement = transform(value)
+            if replacement is None:
+                skipped += 1
+                return match.group(0)
+            transformed += 1
+            return f"{match.group(1)}{match.group(2)}{_requote(replacement, was_quoted)}"
+
+        out = pattern.sub(_sub, out)
+    return SecretRewriteReport(transformed=transformed, skipped=skipped, new_source=out)

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -117,6 +117,7 @@ combine them when more than one form helps:
 - [kcs-feature-bigip-query.md](kcs-feature-bigip-query.md)
 - [kcs-feature-bigip-registry.md](kcs-feature-bigip-registry.md)
 - [kcs-feature-f5-cli.md](kcs-feature-f5-cli.md)
+- [kcs-feature-f5-secret-crypto.md](kcs-feature-f5-secret-crypto.md)
 - [kcs-feature-f5-query-renderers.md](kcs-feature-f5-query-renderers.md)
 
 ## AI features

--- a/docs/kcs/features/kcs-feature-f5-cli.md
+++ b/docs/kcs/features/kcs-feature-f5-cli.md
@@ -88,6 +88,8 @@ references don't trigger false-positive orphan findings.
 | `f5 query` (alias `q`) | DSL-driven property edits and identity renames; readdressing, bulk field rewrites, and iRule reference edits all land here.  See [`kcs-feature-bigip-query.md`](kcs-feature-bigip-query.md). |
 | `f5 redact` (alias `sanitize`) | Strip secrets and remap public IPs into a configurable CIDR pool. |
 | `f5 unredact` (alias `unmap`) | Reverse a `redact` using its sidecar map file. |
+| `f5 encrypt-secrets` (alias `encrypt`) | Encrypt clear-text secrets under the `f5mku` master key.  See [`kcs-feature-f5-secret-crypto.md`](kcs-feature-f5-secret-crypto.md). |
+| `f5 decrypt-secrets` (alias `decrypt`) | Decrypt `$M$...` secrets with the `f5mku` master key.  See [`kcs-feature-f5-secret-crypto.md`](kcs-feature-f5-secret-crypto.md). |
 | `f5 pcap-remap` (alias `pcapmap`) | Apply a redaction map to a PCAP capture. |
 | `f5 split` | Write one `.conf` per partition under a directory (suitable for git). |
 | `f5 merge` | Concatenate per-partition `.conf`s back into one SCF. |

--- a/docs/kcs/features/kcs-feature-f5-secret-crypto.md
+++ b/docs/kcs/features/kcs-feature-f5-secret-crypto.md
@@ -1,0 +1,89 @@
+# KCS: feature — `f5 encrypt-secrets` / `f5 decrypt-secrets`
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Applies to
+
+`f5` CLI (zipapp + `python -m tooling.f5.main`)
+
+## Summary
+
+`f5 encrypt-secrets` and `f5 decrypt-secrets` convert the
+credential-bearing values in a `bigip.conf` / SCF between clear text and
+the encrypted form BIG-IP stores, using the unit master key.  The master
+key is the base64 string `f5mku -K` prints on the device.  Encryption
+wraps a value in the `$M$<salt>$<base64>` envelope; decryption recovers
+the clear text.  Both verbs are idempotent — a value already in the
+target form is left untouched.
+
+## Question
+
+How do I read the real passwords out of a `bigip.conf`, or seal clear-text
+secrets back into the `$M$...` form, given the device master key?
+
+## How to use
+
+Get the master key off the device once:
+
+```sh
+f5mku -K > key.txt          # prints e.g. BHDLd0bbao1VlwpTk1sioQ==
+```
+
+Then decrypt or encrypt the secrets in a config:
+
+```sh
+# Reveal every stored secret in clear text
+f5 decrypt-secrets bigip.conf --f5mku-file key.txt -o clear.conf
+
+# Seal clear-text secrets back into the $M$ envelope
+F5MKU="$(cat key.txt)" f5 encrypt-secrets clear.conf -o sealed.conf
+
+# The key can also be passed inline
+f5 decrypt-secrets bigip.conf -k BHDLd0bbao1VlwpTk1sioQ==
+```
+
+The key is resolved from `--f5mku KEY`, then `--f5mku-file FILE`, then the
+`$F5MKU` environment variable.  Output goes to stdout unless `-o FILE` is
+given, and `--format scf|tmsh` re-renders the result the same way the
+other rewriting verbs do.
+
+### Which values are affected
+
+Only the fields BIG-IP actually master-key encrypts are touched:
+`passphrase`, `password`, `encrypted-password`, `secret`,
+`shared-secret`, `auth-password`, and `priv-password`.  SNMP community
+strings and monitor receive strings — which the device keeps in clear
+text and never wraps in `$M$` — are left alone, unlike the broader
+[`f5 redact`](kcs-feature-f5-cli.md) set.  The literals `none` and
+`<REDACTED>` are treated as sentinels and skipped.
+
+### Example
+
+```text
+# before  (clear.conf)
+auth radius-server /Common/rad {
+    secret "my radius secret"
+}
+
+# after  f5 encrypt-secrets clear.conf --f5mku-file key.txt
+auth radius-server /Common/rad {
+    secret "$M$ab$2wzXs0xM6OJcV5A4DJ6zCT4fMYLjTWwOPZNT4VBBbQ0="
+}
+```
+
+Running `f5 decrypt-secrets` on the output with the same key returns the
+original `secret "my radius secret"`.
+
+## Notes
+
+- The transform is AES in ECB mode with PKCS#7 padding and a two-character
+  salt — the scheme BIG-IP itself uses.  It runs on the bundled
+  pure-Python cipher, so it works in the zipapp with no `cryptography`
+  dependency.
+- A wrong master key is reported as an error (the padding or salt check
+  fails) rather than producing silent garbage.
+- The clear-text output holds real credentials and SSL key passphrases —
+  treat `decrypt-secrets` output as sensitive and avoid writing it to a
+  shared location.
+```

--- a/docs/kcs/features/kcs-feature-f5-secret-crypto.md
+++ b/docs/kcs/features/kcs-feature-f5-secret-crypto.md
@@ -44,9 +44,11 @@ f5 decrypt-secrets bigip.conf -k BHDLd0bbao1VlwpTk1sioQ==
 ```
 
 The key is resolved from `--f5mku KEY`, then `--f5mku-file FILE`, then the
-`$F5MKU` environment variable.  Output goes to stdout unless `-o FILE` is
-given, and `--format scf|tmsh` re-renders the result the same way the
-other rewriting verbs do.
+`$F5MKU` environment variable, and finally a secure `F5 MKU Key:`
+terminal prompt (no echo).  Pass `--no-key-prompt` to fail instead of
+prompting in non-interactive runs.  Output goes to stdout unless
+`-o FILE` is given, and `--format scf|tmsh` re-renders the result the
+same way the other rewriting verbs do.
 
 ### Which values are affected
 

--- a/docs/kcs/features/kcs-feature-f5-secret-crypto.md
+++ b/docs/kcs/features/kcs-feature-f5-secret-crypto.md
@@ -53,12 +53,15 @@ same way the other rewriting verbs do.
 ### Which values are affected
 
 Only the fields BIG-IP actually master-key encrypts are touched:
-`passphrase`, `password`, `encrypted-password`, `secret`,
-`shared-secret`, `auth-password`, and `priv-password`.  SNMP community
-strings and monitor receive strings — which the device keeps in clear
-text and never wraps in `$M$` — are left alone, unlike the broader
-[`f5 redact`](kcs-feature-f5-cli.md) set.  The literals `none` and
-`<REDACTED>` are treated as sentinels and skipped.
+`passphrase`, `password`, `secret`, `shared-secret`, `auth-password`,
+and `privacy-password`.  SNMP community strings and monitor receive
+strings — which the device keeps in clear text and never wraps in
+`$M$` — are left alone, unlike the broader
+[`f5 redact`](kcs-feature-f5-cli.md) set.  The `auth user`
+`encrypted-password` field is deliberately excluded: it holds an
+operating-system crypt hash (`$6$…`), not an `$M$` master-key secret.
+The literals `none` and `<REDACTED>`, and any value already in a
+`$scheme$…` encoded form, are skipped.
 
 ### Example
 

--- a/tests/test_f5_secret_input.py
+++ b/tests/test_f5_secret_input.py
@@ -1,0 +1,85 @@
+"""Tests for the shared secret-input resolver used by the ``f5`` CLI."""
+
+from __future__ import annotations
+
+import getpass
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tooling.f5.f5_remote import secret_input  # noqa: E402
+from tooling.f5.f5_remote.secret_input import (  # noqa: E402
+    SecretInputError,
+    resolve_secret,
+    secret_source_available,
+)
+
+
+def test_explicit_wins(monkeypatch):
+    monkeypatch.setenv("SECRET", "from-env")
+    assert resolve_secret(explicit="from-flag", env_var="SECRET") == "from-flag"
+
+
+def test_file_before_env(tmp_path, monkeypatch):
+    keyfile = tmp_path / "k"
+    keyfile.write_text("from-file\n", encoding="utf-8")
+    monkeypatch.setenv("SECRET", "from-env")
+    # strip=True trims the trailing newline a key file picks up.
+    assert resolve_secret(file=str(keyfile), env_var="SECRET", strip=True) == "from-file"
+
+
+def test_env_used_when_no_explicit_or_file(monkeypatch):
+    monkeypatch.setenv("SECRET", "from-env")
+    assert resolve_secret(env_var="SECRET") == "from-env"
+
+
+def test_strip_false_preserves_whitespace(monkeypatch):
+    monkeypatch.setenv("SECRET", "  spaced  ")
+    assert resolve_secret(env_var="SECRET", strip=False) == "  spaced  "
+
+
+def test_prompt_used_as_last_resort(monkeypatch):
+    monkeypatch.delenv("SECRET", raising=False)
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: True)
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": "typed")
+    assert resolve_secret(env_var="SECRET", prompt="X: ") == "typed"
+
+
+def test_no_prompt_returns_none_when_not_interactive(monkeypatch):
+    monkeypatch.delenv("SECRET", raising=False)
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: False)
+    assert resolve_secret(env_var="SECRET") is None
+
+
+def test_allow_prompt_false_skips_prompt(monkeypatch):
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: True)
+
+    def _boom(prompt=""):
+        raise AssertionError("must not prompt when allow_prompt=False")
+
+    monkeypatch.setattr(getpass, "getpass", _boom)
+    assert resolve_secret(allow_prompt=False) is None
+
+
+def test_cancelled_prompt_raises(monkeypatch):
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: True)
+
+    def _cancel(prompt=""):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(getpass, "getpass", _cancel)
+    with pytest.raises(SecretInputError):
+        resolve_secret()
+
+
+def test_source_available(tmp_path, monkeypatch):
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: False)
+    monkeypatch.delenv("SECRET", raising=False)
+    assert not secret_source_available(env_var="SECRET")
+    assert secret_source_available(explicit="x")
+    assert secret_source_available(file=str(tmp_path / "anything"))
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: True)
+    assert secret_source_available(env_var="SECRET")

--- a/tests/test_f5_secrets.py
+++ b/tests/test_f5_secrets.py
@@ -1,0 +1,214 @@
+"""Tests for F5 master-key (``f5mku``) secret crypto: the AES inverse
+transform, the :mod:`tooling.f5.f5mku` primitive, the secret-locating
+rewrite, and the ``encrypt-secrets`` / ``decrypt-secrets`` CLI verbs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dialects.f5.bigip.rewrite import rewrite_secrets  # noqa: E402
+from tooling.f5 import f5mku  # noqa: E402
+from tooling.f5.f5_remote._aes import AES  # noqa: E402
+from tooling.f5.main import main  # noqa: E402
+
+# A real F5 master key + its known-answer ciphertext, from the original
+# f5mkupy implementation's docstrings.
+_KEY = "BHDLd0bbao1VlwpTk1sioQ=="
+
+
+def _run(args, capsys):
+    code = main(args)
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+# --- AES inverse transform --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key,plain,cipher",
+    [
+        (
+            "000102030405060708090a0b0c0d0e0f",
+            "00112233445566778899aabbccddeeff",
+            "69c4e0d86a7b0430d8cdb78070b4c55a",
+        ),
+        (
+            "000102030405060708090a0b0c0d0e0f1011121314151617",
+            "00112233445566778899aabbccddeeff",
+            "dda97ca4864cdfe06eaf70a0ec0d7191",
+        ),
+        (
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "00112233445566778899aabbccddeeff",
+            "8ea2b7ca516745bfeafc49904b496089",
+        ),
+    ],
+)
+def test_aes_decrypt_block_fips197(key, plain, cipher):
+    assert AES(bytes.fromhex(key)).decrypt_block(bytes.fromhex(cipher)).hex() == plain
+
+
+def test_aes_decrypt_rejects_short_block():
+    with pytest.raises(ValueError):
+        AES(bytes(16)).decrypt_block(b"short")
+
+
+# --- f5mku primitive --------------------------------------------------------
+
+
+def test_f5mku_known_answers():
+    assert f5mku.decrypt("$M$iP$rr0su9oHn9J9p1t3nRzydA==", _KEY) == "KEY45678"
+    assert f5mku.encrypt("KEY45678", _KEY, salt="ab") == "$M$ab$mmIL9xEWGe7pbNtvS/QAQA=="
+    assert f5mku.extract_salt("$M$iP$rr0su9oHn9J9p1t3nRzydA==") == "iP"
+
+
+def test_f5mku_salt_from_ciphertext():
+    # A full ciphertext may be reused as the salt source.
+    assert f5mku.encrypt("KEY45678", _KEY, salt="$M$ab$mmIL9xEWGe7pbNtvS/QAQA==") == (
+        "$M$ab$mmIL9xEWGe7pbNtvS/QAQA=="
+    )
+
+
+@pytest.mark.parametrize("plaintext", ["", "x", "hunter2", "spaces and $ymbol$", "é—utf8"])
+def test_f5mku_round_trip_random_salt(plaintext):
+    ct = f5mku.encrypt(plaintext, _KEY)
+    assert f5mku.is_ciphertext(ct)
+    assert f5mku.decrypt(ct, _KEY) == plaintext
+
+
+def test_f5mku_bad_key_raises():
+    with pytest.raises(f5mku.F5MkuError):
+        f5mku.encrypt("x", "not base64!!!")
+
+
+def test_f5mku_wrong_key_raises():
+    ct = f5mku.encrypt("topsecret", _KEY)
+    with pytest.raises(f5mku.F5MkuError):
+        f5mku.decrypt(ct, "AAAAAAAAAAAAAAAAAAAAAA==")
+
+
+@pytest.mark.parametrize("bad", ["plain", "$M$$body==", "$M$ab$", "$X$ab$body=="])
+def test_f5mku_malformed_ciphertext(bad):
+    assert not f5mku.is_ciphertext(bad)
+    with pytest.raises(f5mku.F5MkuError):
+        f5mku.decrypt(bad, _KEY)
+
+
+# --- secret-locating rewrite ------------------------------------------------
+
+_CONF = """\
+ltm monitor https /Common/mon {
+    password clearpw
+    username admin
+}
+auth radius-server /Common/rad {
+    secret "my radius secret"
+}
+sys snmp {
+    communities {
+        public { community-name public }
+    }
+}
+"""
+
+
+def test_rewrite_only_touches_encrypted_secret_keys():
+    report = rewrite_secrets(_CONF, lambda v: f"<{v}>")
+    # password + secret are rewritten; the SNMP community-name and the
+    # username are not.
+    assert report.transformed == 2
+    assert "password <clearpw>" in report.new_source
+    assert "<my radius secret>" in report.new_source
+    assert "community-name public" in report.new_source
+    assert "username admin" in report.new_source
+
+
+def test_rewrite_skips_sentinels():
+    report = rewrite_secrets("password none\nsecret <REDACTED>\n", lambda v: "X")
+    assert report.transformed == 0
+    assert report.skipped == 2
+
+
+def test_rewrite_transform_none_is_left_untouched():
+    report = rewrite_secrets(_CONF, lambda v: None)
+    assert report.transformed == 0
+    assert report.new_source == _CONF
+
+
+# --- CLI verbs --------------------------------------------------------------
+
+
+def test_cli_round_trip(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+
+    sealed = tmp_path / "sealed.conf"
+    code, _, err = _run(
+        ["encrypt-secrets", str(conf), "-k", _KEY, "--salt", "ab", "-o", str(sealed)], capsys
+    )
+    assert code == 0
+    assert "encrypted: 2 secret(s)" in err
+    sealed_text = sealed.read_text(encoding="utf-8")
+    assert "clearpw" not in sealed_text
+    assert "$M$ab$" in sealed_text
+
+    code, out, err = _run(["decrypt-secrets", str(sealed), "-k", _KEY], capsys)
+    assert code == 0
+    assert "decrypted: 2 secret(s)" in err
+    assert "password clearpw" in out
+    assert "my radius secret" in out
+
+
+def test_cli_encrypt_is_idempotent(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    code, out, _ = _run(["encrypt-secrets", str(conf), "-k", _KEY], capsys)
+    assert code == 0
+    sealed = tmp_path / "sealed.conf"
+    sealed.write_text(out, encoding="utf-8")
+    code, _, err = _run(["encrypt-secrets", str(sealed), "-k", _KEY], capsys)
+    assert code == 0
+    assert "encrypted: 0 secret(s); 2 left untouched" in err
+
+
+def test_cli_key_from_env(tmp_path, capsys, monkeypatch):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    monkeypatch.setenv("F5MKU", _KEY)
+    code, out, _ = _run(["encrypt-secrets", str(conf)], capsys)
+    assert code == 0
+    assert "$M$" in out
+
+
+def test_cli_key_from_file(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    keyfile = tmp_path / "key.txt"
+    keyfile.write_text(_KEY + "\n", encoding="utf-8")
+    code, out, _ = _run(["encrypt-secrets", str(conf), "--f5mku-file", str(keyfile)], capsys)
+    assert code == 0
+    assert "$M$" in out
+
+
+def test_cli_missing_key_errors(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("F5MKU", raising=False)
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    code, _, err = _run(["encrypt-secrets", str(conf)], capsys)
+    assert code == 2
+    assert "no master key" in err
+
+
+def test_cli_bad_key_errors(tmp_path, capsys):
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    code, _, err = _run(["encrypt-secrets", str(conf), "-k", "not base64!!!"], capsys)
+    assert code == 2
+    assert "f5mku" in err

--- a/tests/test_f5_secrets.py
+++ b/tests/test_f5_secrets.py
@@ -217,13 +217,15 @@ def test_cli_bad_key_errors(tmp_path, capsys):
 def test_cli_key_from_prompt(tmp_path, capsys, monkeypatch):
     import getpass
 
-    from tooling.f5.verbs import secrets
+    from tooling.f5.f5_remote import secret_input
 
     conf = tmp_path / "bigip.conf"
     conf.write_text(_CONF, encoding="utf-8")
     monkeypatch.delenv("F5MKU", raising=False)
-    monkeypatch.setattr(secrets, "_interactive", lambda: True)
-    monkeypatch.setattr(getpass, "getpass", lambda prompt="": _KEY)
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: True)
+    monkeypatch.setattr(
+        getpass, "getpass", lambda prompt="": _KEY + "\n"
+    )  # trailing newline trimmed
     code, out, _ = _run(["decrypt-secrets", str(conf)], capsys)
     assert code == 0
     assert out  # decrypt ran with the prompted key
@@ -232,12 +234,12 @@ def test_cli_key_from_prompt(tmp_path, capsys, monkeypatch):
 def test_cli_no_key_prompt_skips_prompt(tmp_path, capsys, monkeypatch):
     import getpass
 
-    from tooling.f5.verbs import secrets
+    from tooling.f5.f5_remote import secret_input
 
     conf = tmp_path / "bigip.conf"
     conf.write_text(_CONF, encoding="utf-8")
     monkeypatch.delenv("F5MKU", raising=False)
-    monkeypatch.setattr(secrets, "_interactive", lambda: True)
+    monkeypatch.setattr(secret_input, "_has_tty", lambda: True)
 
     def _boom(prompt=""):
         raise AssertionError("should not prompt when --no-key-prompt is set")

--- a/tests/test_f5_secrets.py
+++ b/tests/test_f5_secrets.py
@@ -212,3 +212,37 @@ def test_cli_bad_key_errors(tmp_path, capsys):
     code, _, err = _run(["encrypt-secrets", str(conf), "-k", "not base64!!!"], capsys)
     assert code == 2
     assert "f5mku" in err
+
+
+def test_cli_key_from_prompt(tmp_path, capsys, monkeypatch):
+    import getpass
+
+    from tooling.f5.verbs import secrets
+
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    monkeypatch.delenv("F5MKU", raising=False)
+    monkeypatch.setattr(secrets, "_interactive", lambda: True)
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": _KEY)
+    code, out, _ = _run(["decrypt-secrets", str(conf)], capsys)
+    assert code == 0
+    assert out  # decrypt ran with the prompted key
+
+
+def test_cli_no_key_prompt_skips_prompt(tmp_path, capsys, monkeypatch):
+    import getpass
+
+    from tooling.f5.verbs import secrets
+
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(_CONF, encoding="utf-8")
+    monkeypatch.delenv("F5MKU", raising=False)
+    monkeypatch.setattr(secrets, "_interactive", lambda: True)
+
+    def _boom(prompt=""):
+        raise AssertionError("should not prompt when --no-key-prompt is set")
+
+    monkeypatch.setattr(getpass, "getpass", _boom)
+    code, _, err = _run(["encrypt-secrets", str(conf), "--no-key-prompt"], capsys)
+    assert code == 2
+    assert "no master key" in err

--- a/tests/test_f5_secrets.py
+++ b/tests/test_f5_secrets.py
@@ -142,6 +142,28 @@ def test_rewrite_transform_none_is_left_untouched():
     assert report.new_source == _CONF
 
 
+def test_rewrite_ignores_auth_user_crypt_hash():
+    # `auth user ... encrypted-password $6$...` is an OS crypt hash, not an
+    # f5mku $M$ secret — it must not be in the encrypted-secret key set.
+    conf = "auth user /Common/admin {\n    encrypted-password $6$abc123$def456\n}\n"
+    report = rewrite_secrets(conf, lambda v: f"<{v}>")
+    assert report.transformed == 0
+    assert report.new_source == conf
+
+
+def test_rewrite_handles_snmpv3_privacy_password():
+    conf = (
+        "sys snmp {\n    users {\n        u1 {\n"
+        "            auth-password authpw\n"
+        "            privacy-password privpw\n"
+        "        }\n    }\n}\n"
+    )
+    report = rewrite_secrets(conf, lambda v: f"<{v}>")
+    assert report.transformed == 2
+    assert "auth-password <authpw>" in report.new_source
+    assert "privacy-password <privpw>" in report.new_source
+
+
 # --- CLI verbs --------------------------------------------------------------
 
 
@@ -176,6 +198,31 @@ def test_cli_encrypt_is_idempotent(tmp_path, capsys):
     code, _, err = _run(["encrypt-secrets", str(sealed), "-k", _KEY], capsys)
     assert code == 0
     assert "encrypted: 0 secret(s); 2 left untouched" in err
+
+
+def test_cli_encrypt_skips_existing_crypt_hash(tmp_path, capsys):
+    # A crypt(3) hash sitting under a secret key must not be re-wrapped.
+    conf = tmp_path / "bigip.conf"
+    conf.write_text(
+        "ltm monitor http /Common/m {\n    password $6$salt$hash\n}\n", encoding="utf-8"
+    )
+    code, out, err = _run(["encrypt-secrets", str(conf), "-k", _KEY], capsys)
+    assert code == 0
+    assert "encrypted: 0 secret(s); 1 left untouched" in err
+    assert "password $6$salt$hash" in out
+
+
+def test_cli_tmsh_delta_does_not_recreate_existing_objects(tmp_path, capsys):
+    # With --format tmsh-delta the pre-rewrite source is passed as the
+    # delta baseline, so existing objects are not spuriously re-created
+    # (which would collide on a device that already has them).
+    conf = tmp_path / "bigip.conf"
+    conf.write_text("ltm monitor https /Common/mon {\n    password clearpw\n}\n", encoding="utf-8")
+    code, out, _ = _run(
+        ["encrypt-secrets", str(conf), "-k", _KEY, "--salt", "ab", "--format", "tmsh-delta"], capsys
+    )
+    assert code == 0
+    assert "tmsh create" not in out
 
 
 def test_cli_key_from_env(tmp_path, capsys, monkeypatch):

--- a/tooling/f5/f5_remote/_aes.py
+++ b/tooling/f5/f5_remote/_aes.py
@@ -1,17 +1,25 @@
-"""Pure-Python AES block cipher (encryption primitive only).
+"""Pure-Python AES block cipher (dependency-free).
 
-This is a self-contained, dependency-free implementation used as a
-*fallback* for decrypting encrypted (OpenPGP) UCS archives when no
-``gpg``/``gpg2`` binary is available — see :mod:`._openpgp`.  The
+This is a self-contained implementation used as a *fallback* for
+decrypting encrypted (OpenPGP) UCS archives when no ``gpg``/``gpg2``
+binary is available — see :mod:`._openpgp` — and for the F5 master-key
+(``f5mku``) secret crypto in :mod:`tooling.f5.f5mku`.  The UCS
 production path shells out to GnuPG (exactly what BIG-IP itself uses);
-this module exists purely so the zipapp can still decrypt a UCS on a
-host with no GnuPG installed, because the zipapp builder strips C
-extensions and therefore cannot bundle ``cryptography``/PGPy.
+this module exists so the zipapp can still do crypto on a host with no
+GnuPG installed, because the zipapp builder strips C extensions and
+therefore cannot bundle ``cryptography``/PGPy.
 
-Only the *forward* (encryption) transform is implemented: OpenPGP CFB
-mode — the only mode UCS encryption uses — runs the block cipher in the
-encryption direction for both encrypting and decrypting, so a decryptor
-never needs ``InvSubBytes``/``InvMixColumns``.
+The *forward* (encryption) transform (:meth:`AES.encrypt_block`) is the
+hot path: OpenPGP CFB mode — the only mode UCS encryption uses — runs
+the block cipher in the encryption direction for both encrypting and
+decrypting, so the UCS decryptor never touches the inverse transform.
+
+The *inverse* (decryption) transform (:meth:`AES.decrypt_block`) is
+needed for F5's ECB master-key mode, where decrypting a stored
+``$M$...`` secret requires running the cipher backwards.  It is a
+straightforward byte-oriented inverse cipher (``InvShiftRows`` /
+``InvSubBytes`` / ``InvMixColumns``) — clarity over speed, which is fine
+for the handful of short secrets a bigip.conf carries.
 
 Correctness is anchored by the FIPS-197 known-answer vectors and by
 round-trip tests against GnuPG output (see ``tests/test_f5_ucs_crypto.py``).
@@ -337,8 +345,54 @@ def _sub_word(w: int) -> int:
     )
 
 
+# Inverse S-box — the functional inverse of ``_SBOX`` (FIPS-197, Figure 14),
+# derived here rather than transcribed so the two tables can never drift.
+_INV_SBOX = bytearray(256)
+for _i, _v in enumerate(_SBOX):
+    _INV_SBOX[_v] = _i
+_INV_SBOX = bytes(_INV_SBOX)
+
+
+def _gmul(a: int, b: int) -> int:
+    """Multiply two bytes in GF(2^8) with the AES reduction polynomial."""
+    product = 0
+    for _ in range(8):
+        if b & 1:
+            product ^= a
+        carry = a & 0x80
+        a = (a << 1) & 0xFF
+        if carry:
+            a ^= 0x1B
+        b >>= 1
+    return product
+
+
+def _inv_shift_rows(state: bytearray) -> None:
+    """Cyclically shift each row right by its row index (column-major state)."""
+    for row in range(1, 4):
+        col = [state[row + 4 * c] for c in range(4)]
+        for c in range(4):
+            state[row + 4 * c] = col[(c - row) % 4]
+
+
+def _inv_sub_bytes(state: bytearray) -> None:
+    for i in range(16):
+        state[i] = _INV_SBOX[state[i]]
+
+
+def _inv_mix_columns(state: bytearray) -> None:
+    for c in range(4):
+        base = 4 * c
+        a0, a1, a2, a3 = state[base], state[base + 1], state[base + 2], state[base + 3]
+        state[base] = _gmul(a0, 14) ^ _gmul(a1, 11) ^ _gmul(a2, 13) ^ _gmul(a3, 9)
+        state[base + 1] = _gmul(a0, 9) ^ _gmul(a1, 14) ^ _gmul(a2, 11) ^ _gmul(a3, 13)
+        state[base + 2] = _gmul(a0, 13) ^ _gmul(a1, 9) ^ _gmul(a2, 14) ^ _gmul(a3, 11)
+        state[base + 3] = _gmul(a0, 11) ^ _gmul(a1, 13) ^ _gmul(a2, 9) ^ _gmul(a3, 14)
+
+
 class AES:
-    """AES-128/192/256 with only the forward (encrypt) block transform."""
+    """AES-128/192/256 with both the forward (encrypt) and inverse
+    (decrypt) block transforms."""
 
     __slots__ = ("_rk", "_rounds")
 
@@ -428,3 +482,29 @@ class AES:
         return struct.pack(
             ">4I", o0 & 0xFFFFFFFF, o1 & 0xFFFFFFFF, o2 & 0xFFFFFFFF, o3 & 0xFFFFFFFF
         )
+
+    def _add_round_key(self, state: bytearray, rnd: int) -> None:
+        """XOR the *rnd*-th round key into *state* (column-major bytes)."""
+        rk = self._rk
+        for c in range(4):
+            word = rk[4 * rnd + c]
+            state[4 * c] ^= (word >> 24) & 0xFF
+            state[4 * c + 1] ^= (word >> 16) & 0xFF
+            state[4 * c + 2] ^= (word >> 8) & 0xFF
+            state[4 * c + 3] ^= word & 0xFF
+
+    def decrypt_block(self, block: bytes) -> bytes:
+        """Decrypt a single 16-byte block (inverse cipher, FIPS-197 §5.3)."""
+        if len(block) != 16:
+            raise ValueError(f"AES block must be 16 bytes, got {len(block)}")
+        state = bytearray(block)
+        self._add_round_key(state, self._rounds)
+        for rnd in range(self._rounds - 1, 0, -1):
+            _inv_shift_rows(state)
+            _inv_sub_bytes(state)
+            self._add_round_key(state, rnd)
+            _inv_mix_columns(state)
+        _inv_shift_rows(state)
+        _inv_sub_bytes(state)
+        self._add_round_key(state, 0)
+        return bytes(state)

--- a/tooling/f5/f5_remote/auth.py
+++ b/tooling/f5/f5_remote/auth.py
@@ -11,11 +11,12 @@ Resolution order (highest priority first):
 
 from __future__ import annotations
 
-import getpass
 import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+from .secret_input import resolve_secret
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -122,11 +123,14 @@ def resolve_credentials(
 
     resolved_password = password or pick("password", "F5_PASSWORD", None)
     if not resolved_password:
-        if not interactive:
-            raise ValueError("no password configured (set --password or F5_PASSWORD)")
-        resolved_password = getpass.getpass(f"Password for {resolved_user}@{resolved_host}: ")
+        # Explicit / env / hosts.toml are exhausted; offer a secure prompt
+        # through the shared resolver (which gets the tty detection right).
+        resolved_password = resolve_secret(
+            allow_prompt=interactive,
+            prompt=f"Password for {resolved_user}@{resolved_host}: ",
+        )
         if not resolved_password:
-            raise ValueError("password is required")
+            raise ValueError("no password configured (set --password or F5_PASSWORD)")
 
     # CLI port overrides take precedence; only fall back to env / config if
     # the caller didn't pass an explicit value.

--- a/tooling/f5/f5_remote/secret_input.py
+++ b/tooling/f5/f5_remote/secret_input.py
@@ -1,0 +1,114 @@
+"""Shared secret-input resolution for the ``f5`` CLI.
+
+A single, idiomatic way to obtain a secret (passphrase, master key,
+password, …) from the four sources the CLI supports, tried in order:
+
+1. an explicit value (e.g. a ``--password`` flag),
+2. a file (e.g. ``--f5mku-file key.txt``),
+3. an environment variable, and
+4. a secure, no-echo terminal prompt via :func:`getpass.getpass`.
+
+Centralising this keeps the tty detection correct in one place — the
+prompt is offered whenever *either* stdin or stderr is a terminal, and
+``getpass`` itself reads from the controlling ``/dev/tty``, so a prompt
+still works when the config is piped in on stdin (``f5 decrypt-secrets
+-``).  :func:`resolve_secret` returns ``None`` when no source yields a
+value, leaving the caller to decide whether that is an error; a
+cancelled prompt (Ctrl-C / EOF) raises :class:`SecretInputError`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+__all__ = ["resolve_secret", "secret_source_available", "SecretInputError"]
+
+
+class SecretInputError(ValueError):
+    """Raised when interactive secret entry is cancelled."""
+
+
+def _has_tty() -> bool:
+    """Whether a controlling terminal is available to prompt on."""
+    for stream in (sys.stdin, sys.stderr):
+        try:
+            if stream is not None and stream.isatty():
+                return True
+        except (ValueError, AttributeError):  # pragma: no cover - closed stream
+            pass
+    return False
+
+
+def secret_source_available(
+    *,
+    explicit: str | None = None,
+    env_var: str | None = None,
+    file: str | os.PathLike[str] | None = None,
+    allow_prompt: bool = True,
+) -> bool:
+    """Whether :func:`resolve_secret` could yield a value without prompting,
+    or a prompt is possible.  Useful for a fast pre-flight check."""
+    if explicit:
+        return True
+    if file:
+        return True
+    if env_var and os.environ.get(env_var):
+        return True
+    return allow_prompt and _has_tty()
+
+
+def resolve_secret(
+    *,
+    explicit: str | None = None,
+    env_var: str | None = None,
+    file: str | os.PathLike[str] | None = None,
+    allow_prompt: bool = True,
+    prompt: str = "Secret: ",
+    strip: bool = False,
+) -> str | None:
+    """Resolve a secret from an explicit value, a file, an env var, or a prompt.
+
+    Sources are tried in that fixed order and the first non-empty one
+    wins.  Returns ``None`` when nothing yields a value (the caller
+    decides whether that is fatal).
+
+    *strip* controls whitespace trimming of the resolved value.  Leave it
+    ``False`` for passphrases and passwords, where surrounding whitespace
+    can be significant; set it ``True`` for tokens that are never meant to
+    carry whitespace (a base64 key read from ``f5mku -K > key.txt`` picks
+    up a trailing newline, for instance).
+
+    A cancelled prompt (Ctrl-C / EOF) raises :class:`SecretInputError`.
+    """
+
+    def _norm(value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() if strip else value
+
+    if explicit:
+        return _norm(explicit)
+
+    if file:
+        text = _norm(Path(file).read_text(encoding="utf-8"))
+        if text:
+            return text
+
+    if env_var:
+        env_val = os.environ.get(env_var)
+        if env_val:
+            return _norm(env_val)
+
+    if allow_prompt and _has_tty():
+        import getpass
+
+        try:
+            entered = _norm(getpass.getpass(prompt))
+        except (EOFError, KeyboardInterrupt) as exc:  # pragma: no cover - tty only
+            raise SecretInputError("secret entry cancelled") from exc
+        if entered:
+            return entered
+
+    return None

--- a/tooling/f5/f5_remote/ucs.py
+++ b/tooling/f5/f5_remote/ucs.py
@@ -47,6 +47,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Callable
 
+from .secret_input import SecretInputError, resolve_secret
+
 # Order matters: base must come first so partition declarations exist
 # before objects that reference them.
 _SCF_MEMBER_ORDER = (
@@ -108,44 +110,35 @@ def is_pgp_bytes(data: bytes) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _stdin_is_a_tty() -> bool:
-    try:
-        return sys.stdin is not None and sys.stdin.isatty()
-    except (ValueError, AttributeError):  # pragma: no cover - closed stdin
-        return False
-
-
 def resolve_passphrase(
     *,
     env_var: str | None = DEFAULT_PASSPHRASE_ENV,
     explicit: str | None = None,
+    file: str | os.PathLike[str] | None = None,
     allow_prompt: bool = True,
     prompt: str = "Enter UCS passphrase: ",
 ) -> str:
-    """Resolve a UCS passphrase from an explicit value, env var, or prompt.
+    """Resolve a UCS passphrase from an explicit value, file, env var, or prompt.
 
-    Resolution order: *explicit* (if non-empty) → ``$env_var`` (if set
-    and non-empty) → a secure :func:`getpass.getpass` prompt when
-    *allow_prompt* is true and stdin is an interactive terminal.  Raises
-    :class:`UcsPassphraseError` when none of those yields a passphrase
-    (e.g. non-interactive with the env var unset), so batch runs fail
-    fast with a clear message instead of blocking on a prompt.
+    A thin wrapper over :func:`tooling.f5.f5_remote.secret_input.resolve_secret`
+    that maps a missing or cancelled passphrase onto
+    :class:`UcsPassphraseError`, so batch runs fail fast with a clear
+    message instead of blocking on a prompt.  Passphrases are *not*
+    whitespace-trimmed — surrounding spaces can be significant.
     """
-    if explicit:
-        return explicit
-    if env_var:
-        from_env = os.environ.get(env_var)
-        if from_env:
-            return from_env
-    if allow_prompt and _stdin_is_a_tty():
-        import getpass
-
-        try:
-            entered = getpass.getpass(prompt)
-        except (EOFError, KeyboardInterrupt) as exc:  # pragma: no cover - tty only
-            raise UcsPassphraseError("passphrase entry cancelled") from exc
-        if entered:
-            return entered
+    try:
+        passphrase = resolve_secret(
+            explicit=explicit,
+            env_var=env_var,
+            file=file,
+            allow_prompt=allow_prompt,
+            prompt=prompt,
+            strip=False,
+        )
+    except SecretInputError as exc:
+        raise UcsPassphraseError("passphrase entry cancelled") from exc
+    if passphrase:
+        return passphrase
     raise UcsPassphraseError(
         "this UCS archive is encrypted and requires a passphrase; set the "
         f"{env_var} environment variable or run in an interactive terminal "

--- a/tooling/f5/f5mku.py
+++ b/tooling/f5/f5mku.py
@@ -1,0 +1,165 @@
+"""F5 master-key (``f5mku``) secret encryption / decryption.
+
+BIG-IP stores credential-bearing values (SSL key passphrases, monitor
+passwords, RADIUS/TACACS shared secrets, …) in its configuration
+encrypted under the unit master key.  On a device that key is what
+``f5mku -K`` prints — a base64-encoded AES key — and the stored secrets
+look like ``$M$<salt>$<base64-ciphertext>``.
+
+The transform is AES in ECB mode with PKCS#7 padding: a two-character
+salt is prepended to the plaintext, the result is padded to a 16-byte
+boundary, encrypted block-by-block with the master key, and base64
+encoded.  This module is a self-contained reimplementation of that
+scheme so the ``f5`` CLI can encrypt and decrypt secrets offline, given
+the master key.
+
+It deliberately avoids the optional ``cryptography`` dependency: the
+``f5`` CLI ships as a zipapp that strips C extensions, so the crypto
+runs on the bundled pure-Python :class:`tooling.f5.f5_remote._aes.AES`
+block cipher instead.
+
+Examples:
+    >>> decrypt("$M$iP$rr0su9oHn9J9p1t3nRzydA==", "BHDLd0bbao1VlwpTk1sioQ==")
+    'KEY45678'
+    >>> encrypt("KEY45678", "BHDLd0bbao1VlwpTk1sioQ==", salt="ab")
+    '$M$ab$mmIL9xEWGe7pbNtvS/QAQA=='
+"""
+
+from __future__ import annotations
+
+import secrets
+import string
+from base64 import b64decode, b64encode
+from dataclasses import dataclass
+
+from .f5_remote._aes import AES
+
+__all__ = ["encrypt", "decrypt", "extract_salt", "F5MkuError"]
+
+_BLOCK_SIZE = 16
+_SALT_LENGTH = 2
+_SALT_ALPHABET = string.ascii_letters + string.digits
+
+
+class F5MkuError(ValueError):
+    """Raised for malformed master keys or ciphertext."""
+
+
+@dataclass(frozen=True, slots=True)
+class _Ciphertext:
+    salt: bytes
+    ciphertext: bytes
+
+
+def encrypt(plaintext: str, f5mku: str, salt: str | None = None) -> str:
+    """Encrypt *plaintext* under the *f5mku* master key.
+
+    *f5mku* is the base64 key printed by ``f5mku -K``.  *salt*, when
+    given, is either a bare two-character string (no ``$``) or a full F5
+    ciphertext to copy the salt from; otherwise a fresh random salt is
+    generated.  Returns the ``$M$<salt>$<base64>`` form found in
+    bigip.conf.
+    """
+    cipher = _load_key(f5mku)
+    salt_bytes = _resolve_salt(salt)
+    padded = _pkcs7_pad(salt_bytes + plaintext.encode("utf-8"))
+    body = _ecb_encrypt(cipher, padded)
+    return _format_ciphertext(salt_bytes, body)
+
+
+def decrypt(ciphertext: str, f5mku: str) -> str:
+    """Decrypt an ``$M$<salt>$<base64>`` *ciphertext* under *f5mku*.
+
+    *f5mku* is the base64 key printed by ``f5mku -K``.  Returns the
+    recovered plaintext.
+    """
+    parsed = _deconstruct_ciphertext(ciphertext)
+    cipher = _load_key(f5mku)
+    decrypted = _pkcs7_unpad(_ecb_decrypt(cipher, parsed.ciphertext))
+    return _strip_salt(decrypted, parsed.salt).decode("utf-8")
+
+
+def extract_salt(ciphertext: str) -> str:
+    """Return the salt embedded in an F5 *ciphertext* string."""
+    return _deconstruct_ciphertext(ciphertext).salt.decode("utf-8")
+
+
+def is_ciphertext(value: str) -> bool:
+    """Whether *value* looks like an F5 ``$M$<salt>$<body>`` secret."""
+    parts = value.split("$")
+    return len(parts) == 4 and parts[0] == "" and parts[1] == "M" and bool(parts[2] and parts[3])
+
+
+def _load_key(f5mku: str) -> AES:
+    try:
+        return AES(b64decode(f5mku))
+    except Exception as exc:  # noqa: BLE001
+        raise F5MkuError(
+            "decoding of f5mku failed. Make sure you are using the base64 "
+            "formatted key returned by: f5mku -K"
+        ) from exc
+
+
+def _resolve_salt(salt: str | None) -> bytes:
+    if salt is None:
+        return "".join(secrets.choice(_SALT_ALPHABET) for _ in range(_SALT_LENGTH)).encode("utf-8")
+    if "$" in salt:
+        # Accept a full F5 ciphertext and reuse its salt.
+        salt = extract_salt(salt)
+    return salt.encode("utf-8")
+
+
+def _ecb_encrypt(cipher: AES, data: bytes) -> bytes:
+    return b"".join(
+        cipher.encrypt_block(data[i : i + _BLOCK_SIZE]) for i in range(0, len(data), _BLOCK_SIZE)
+    )
+
+
+def _ecb_decrypt(cipher: AES, data: bytes) -> bytes:
+    if not data or len(data) % _BLOCK_SIZE != 0:
+        raise F5MkuError("ciphertext length is not a multiple of the AES block size")
+    return b"".join(
+        cipher.decrypt_block(data[i : i + _BLOCK_SIZE]) for i in range(0, len(data), _BLOCK_SIZE)
+    )
+
+
+def _pkcs7_pad(data: bytes) -> bytes:
+    pad = _BLOCK_SIZE - (len(data) % _BLOCK_SIZE)
+    return data + bytes([pad]) * pad
+
+
+def _pkcs7_unpad(data: bytes) -> bytes:
+    if not data:
+        raise F5MkuError("empty plaintext after decryption")
+    pad = data[-1]
+    if pad < 1 or pad > _BLOCK_SIZE or data[-pad:] != bytes([pad]) * pad:
+        raise F5MkuError("invalid PKCS#7 padding (wrong master key?)")
+    return data[:-pad]
+
+
+def _strip_salt(plaintext: bytes, salt: bytes) -> bytes:
+    if not plaintext.startswith(salt):
+        raise F5MkuError("decrypted text does not start with its salt (wrong master key?)")
+    return plaintext[len(salt) :]
+
+
+def _deconstruct_ciphertext(ciphertext: str) -> _Ciphertext:
+    parts = ciphertext.split("$")
+    if len(parts) != 4 or (parts[0], parts[1]) != ("", "M"):
+        raise F5MkuError(
+            f"unrecognised ciphertext: expected '$M$<salt>$<base64>', got {ciphertext!r}"
+        )
+    _, _, salt, body = parts
+    if not salt:
+        raise F5MkuError("unrecognised ciphertext: empty salt")
+    if not body:
+        raise F5MkuError("unrecognised ciphertext: empty ciphertext")
+    try:
+        decoded = b64decode(body, validate=True)
+    except Exception as exc:  # noqa: BLE001
+        raise F5MkuError(f"unrecognised ciphertext: malformed base64 {body!r}") from exc
+    return _Ciphertext(salt=salt.encode("utf-8"), ciphertext=decoded)
+
+
+def _format_ciphertext(salt: bytes, body: bytes) -> str:
+    return "$".join(["", "M", salt.decode("utf-8"), b64encode(body).decode("ascii")])

--- a/tooling/f5/verbs/__init__.py
+++ b/tooling/f5/verbs/__init__.py
@@ -29,6 +29,7 @@ def load_verbs() -> None:
         redact,
         registry,
         rename,
+        secrets,
         split,
         stats,
         tmsh,

--- a/tooling/f5/verbs/secrets.py
+++ b/tooling/f5/verbs/secrets.py
@@ -14,6 +14,7 @@ idempotent and safe to re-run.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -27,6 +28,11 @@ from ._registry import verb
 
 _F5MKU_ENV = "F5MKU"
 _KEY_PROMPT = "F5 MKU Key: "
+
+# A value already in a ``$scheme$...`` encoded form — an F5 ``$M$``
+# master-key secret or an OS crypt(3) hash (``$1$`` / ``$5$`` / ``$6$`` /
+# ``$2y$`` …).  ``encrypt-secrets`` never re-wraps these.
+_ALREADY_ENCODED = re.compile(r"\$[A-Za-z0-9]+\$")
 
 
 def _add_key_args(p: argparse.ArgumentParser) -> None:
@@ -180,8 +186,12 @@ def _run(args: argparse.Namespace, *, mode: str) -> int:
         salt = getattr(args, "salt", None)
 
         def transform(value: str) -> str | None:
-            if f5mku.is_ciphertext(value):
-                return None  # already encrypted
+            # Skip anything already in a `$scheme$...` encoded form: an
+            # existing `$M$` ciphertext (idempotent re-run) or a stored
+            # crypt(3) hash like `$6$...` that slipped past the key set —
+            # double-encrypting either would corrupt the credential.
+            if _ALREADY_ENCODED.match(value):
+                return None
             return f5mku.encrypt(value, key, salt=salt)
     else:
 
@@ -201,6 +211,7 @@ def _run(args: argparse.Namespace, *, mode: str) -> int:
         fmt=args.output_format,
         tmsh_verb="modify",
         transaction=getattr(args, "output_transaction", False),
+        original=source,
     )
     if args.output:
         Path(args.output).write_text(rendered, encoding="utf-8")

--- a/tooling/f5/verbs/secrets.py
+++ b/tooling/f5/verbs/secrets.py
@@ -14,12 +14,12 @@ idempotent and safe to re-run.
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
 
 from dialects.f5.bigip.rewrite import rewrite_secrets
 from tooling.f5 import f5mku
+from tooling.f5.f5_remote.secret_input import SecretInputError, resolve_secret
 
 from ._emit import add_format_arg, render_config
 from ._paths import add_passphrase_args, provider_from_args, read_path
@@ -54,35 +54,26 @@ def _add_key_args(p: argparse.ArgumentParser) -> None:
     )
 
 
-def _interactive() -> bool:
-    """Whether a controlling terminal is available to prompt on."""
-    for stream in (sys.stdin, sys.stderr):
-        try:
-            if stream is not None and stream.isatty():
-                return True
-        except (ValueError, AttributeError):  # pragma: no cover - closed stream
-            pass
-    return False
-
-
 def _resolve_key(args: argparse.Namespace) -> str:
-    """Resolve the master key from --f5mku / --f5mku-file / $F5MKU / prompt."""
-    if args.f5mku:
-        return args.f5mku.strip()
-    if args.f5mku_file:
-        return Path(args.f5mku_file).read_text(encoding="utf-8").strip()
-    env = os.environ.get(_F5MKU_ENV)
-    if env:
-        return env.strip()
-    if not getattr(args, "no_key_prompt", False) and _interactive():
-        import getpass
+    """Resolve the master key from --f5mku / --f5mku-file / $F5MKU / prompt.
 
-        try:
-            entered = getpass.getpass(_KEY_PROMPT)
-        except (EOFError, KeyboardInterrupt) as exc:  # pragma: no cover - tty only
-            raise ValueError("master key entry cancelled") from exc
-        if entered.strip():
-            return entered.strip()
+    The base64 key is whitespace-trimmed (``strip=True``) so a file or
+    env value carrying a trailing newline — ``f5mku -K > key.txt`` — still
+    works.
+    """
+    try:
+        key = resolve_secret(
+            explicit=args.f5mku,
+            file=args.f5mku_file,
+            env_var=_F5MKU_ENV,
+            allow_prompt=not getattr(args, "no_key_prompt", False),
+            prompt=_KEY_PROMPT,
+            strip=True,
+        )
+    except SecretInputError as exc:
+        raise ValueError(str(exc)) from exc
+    if key:
+        return key
     raise ValueError(
         f"no master key supplied; pass --f5mku KEY, --f5mku-file FILE, set ${_F5MKU_ENV}, "
         "or run in an interactive terminal to be prompted"

--- a/tooling/f5/verbs/secrets.py
+++ b/tooling/f5/verbs/secrets.py
@@ -1,0 +1,196 @@
+"""``f5 encrypt-secrets`` / ``f5 decrypt-secrets`` — master-key crypto
+for the credential-bearing values in a bigip.conf / SCF.
+
+Both verbs walk every secret-bearing property (``passphrase``,
+``password``, ``secret``, ``shared-secret``, …) and run its value
+through the F5 unit master key supplied by the user — the base64 key
+that ``f5mku -K`` prints on the device.  ``encrypt-secrets`` wraps
+clear-text values in the ``$M$<salt>$<base64>`` envelope BIG-IP stores;
+``decrypt-secrets`` recovers the clear text from that envelope.  Values
+already in the target form are left untouched, so both verbs are
+idempotent and safe to re-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from dialects.f5.bigip.rewrite import rewrite_secrets
+from tooling.f5 import f5mku
+
+from ._emit import add_format_arg, render_config
+from ._paths import add_passphrase_args, provider_from_args, read_path
+from ._registry import verb
+
+_F5MKU_ENV = "F5MKU"
+
+
+def _add_key_args(p: argparse.ArgumentParser) -> None:
+    """Add the shared master-key source flags."""
+    group = p.add_argument_group("master key")
+    group.add_argument(
+        "-k",
+        "--f5mku",
+        metavar="KEY",
+        help=(
+            "base64 unit master key (the value `f5mku -K` prints on the "
+            f"device).  Falls back to ${_F5MKU_ENV} when omitted."
+        ),
+    )
+    group.add_argument(
+        "--f5mku-file",
+        metavar="FILE",
+        help="read the base64 master key from FILE (e.g. `f5mku -K > key.txt`).",
+    )
+
+
+def _resolve_key(args: argparse.Namespace) -> str:
+    """Resolve the master key from --f5mku / --f5mku-file / $F5MKU."""
+    if args.f5mku:
+        return args.f5mku.strip()
+    if args.f5mku_file:
+        return Path(args.f5mku_file).read_text(encoding="utf-8").strip()
+    env = os.environ.get(_F5MKU_ENV)
+    if env:
+        return env.strip()
+    raise ValueError(
+        f"no master key supplied; pass --f5mku KEY, --f5mku-file FILE, or set ${_F5MKU_ENV}"
+    )
+
+
+@verb(
+    "encrypt-secrets",
+    aliases=("encrypt",),
+    help="Encrypt clear-text secrets in a bigip.conf under the f5mku master key.",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+def _configure_encrypt(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: str) -> None:  # noqa: ARG001
+    p.description = (
+        "Wrap every clear-text secret value (passphrase, password, "
+        "secret, shared-secret, auth-password, priv-password, "
+        "encrypted-password) in the `$M$<salt>$<base64>` envelope BIG-IP "
+        "stores, using the unit master key.  Values already encrypted "
+        "are left untouched, so the verb is idempotent."
+    )
+    p.epilog = (
+        "Examples:\n"
+        "  f5 encrypt-secrets bigip.conf -k BHDLd0bbao1VlwpTk1sioQ== -o sealed.conf\n"
+        "  f5mku -K > key.txt; f5 encrypt-secrets bigip.conf --f5mku-file key.txt\n"
+        "  F5MKU=BHDLd0bbao1VlwpTk1sioQ== f5 encrypt-secrets bigip.conf\n"
+    )
+    p.add_argument("path", help="bigip.conf / SCF file (`-` for stdin).")
+    p.add_argument(
+        "-o", "--output", metavar="FILE", help="Write the result here (default: stdout)."
+    )
+    _add_key_args(p)
+    p.add_argument(
+        "--salt",
+        metavar="XX",
+        help=(
+            "Force this two-character salt instead of a random one "
+            "(deterministic output; mainly for testing)."
+        ),
+    )
+    add_passphrase_args(p)
+    add_format_arg(p, tmsh_default_verb="modify")
+    p.set_defaults(handler=_run_encrypt)
+
+
+@verb(
+    "decrypt-secrets",
+    aliases=("decrypt",),
+    help="Decrypt `$M$...` secrets in a bigip.conf with the f5mku master key.",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+def _configure_decrypt(p: argparse.ArgumentParser, *, prog_name: str, default_dialect: str) -> None:  # noqa: ARG001
+    p.description = (
+        "Recover the clear text of every `$M$<salt>$<base64>` secret "
+        "value (passphrase, password, secret, shared-secret, "
+        "auth-password, priv-password, encrypted-password) using the "
+        "unit master key.  Values that are not in the encrypted envelope "
+        "are left untouched."
+    )
+    p.epilog = (
+        "Examples:\n"
+        "  f5 decrypt-secrets bigip.conf -k BHDLd0bbao1VlwpTk1sioQ==\n"
+        "  f5mku -K > key.txt; f5 decrypt-secrets bigip.conf --f5mku-file key.txt\n"
+        "  F5MKU=BHDLd0bbao1VlwpTk1sioQ== f5 decrypt-secrets bigip.conf -o clear.conf\n"
+    )
+    p.add_argument("path", help="bigip.conf / SCF file (`-` for stdin).")
+    p.add_argument(
+        "-o", "--output", metavar="FILE", help="Write the result here (default: stdout)."
+    )
+    _add_key_args(p)
+    add_passphrase_args(p)
+    add_format_arg(p, tmsh_default_verb="modify")
+    p.set_defaults(handler=_run_decrypt)
+
+
+def _run_encrypt(args: argparse.Namespace) -> int:
+    return _run(args, mode="encrypt")
+
+
+def _run_decrypt(args: argparse.Namespace) -> int:
+    return _run(args, mode="decrypt")
+
+
+def _run(args: argparse.Namespace, *, mode: str) -> int:
+    try:
+        key = _resolve_key(args)
+    except (ValueError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    # Fail fast on a bad key before touching the file.
+    try:
+        f5mku.encrypt("probe", key, salt="00")
+    except f5mku.F5MkuError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        _, source = read_path(args.path, passphrase_provider=provider_from_args(args))
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if mode == "encrypt":
+        salt = getattr(args, "salt", None)
+
+        def transform(value: str) -> str | None:
+            if f5mku.is_ciphertext(value):
+                return None  # already encrypted
+            return f5mku.encrypt(value, key, salt=salt)
+    else:
+
+        def transform(value: str) -> str | None:
+            if not f5mku.is_ciphertext(value):
+                return None  # not encrypted
+            return f5mku.decrypt(value, key)
+
+    try:
+        report = rewrite_secrets(source, transform)
+    except f5mku.F5MkuError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    rendered = render_config(
+        report.new_source,
+        fmt=args.output_format,
+        tmsh_verb="modify",
+        transaction=getattr(args, "output_transaction", False),
+    )
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+
+    verb_name = "encrypted" if mode == "encrypt" else "decrypted"
+    print(
+        f"{verb_name}: {report.transformed} secret(s); {report.skipped} left untouched",
+        file=sys.stderr,
+    )
+    return 0

--- a/tooling/f5/verbs/secrets.py
+++ b/tooling/f5/verbs/secrets.py
@@ -26,6 +26,7 @@ from ._paths import add_passphrase_args, provider_from_args, read_path
 from ._registry import verb
 
 _F5MKU_ENV = "F5MKU"
+_KEY_PROMPT = "F5 MKU Key: "
 
 
 def _add_key_args(p: argparse.ArgumentParser) -> None:
@@ -37,7 +38,8 @@ def _add_key_args(p: argparse.ArgumentParser) -> None:
         metavar="KEY",
         help=(
             "base64 unit master key (the value `f5mku -K` prints on the "
-            f"device).  Falls back to ${_F5MKU_ENV} when omitted."
+            f"device).  Falls back to ${_F5MKU_ENV}, then a secure "
+            "terminal prompt."
         ),
     )
     group.add_argument(
@@ -45,10 +47,26 @@ def _add_key_args(p: argparse.ArgumentParser) -> None:
         metavar="FILE",
         help="read the base64 master key from FILE (e.g. `f5mku -K > key.txt`).",
     )
+    group.add_argument(
+        "--no-key-prompt",
+        action="store_true",
+        help="never prompt on the terminal for the master key; require a flag or $F5MKU instead.",
+    )
+
+
+def _interactive() -> bool:
+    """Whether a controlling terminal is available to prompt on."""
+    for stream in (sys.stdin, sys.stderr):
+        try:
+            if stream is not None and stream.isatty():
+                return True
+        except (ValueError, AttributeError):  # pragma: no cover - closed stream
+            pass
+    return False
 
 
 def _resolve_key(args: argparse.Namespace) -> str:
-    """Resolve the master key from --f5mku / --f5mku-file / $F5MKU."""
+    """Resolve the master key from --f5mku / --f5mku-file / $F5MKU / prompt."""
     if args.f5mku:
         return args.f5mku.strip()
     if args.f5mku_file:
@@ -56,8 +74,18 @@ def _resolve_key(args: argparse.Namespace) -> str:
     env = os.environ.get(_F5MKU_ENV)
     if env:
         return env.strip()
+    if not getattr(args, "no_key_prompt", False) and _interactive():
+        import getpass
+
+        try:
+            entered = getpass.getpass(_KEY_PROMPT)
+        except (EOFError, KeyboardInterrupt) as exc:  # pragma: no cover - tty only
+            raise ValueError("master key entry cancelled") from exc
+        if entered.strip():
+            return entered.strip()
     raise ValueError(
-        f"no master key supplied; pass --f5mku KEY, --f5mku-file FILE, or set ${_F5MKU_ENV}"
+        f"no master key supplied; pass --f5mku KEY, --f5mku-file FILE, set ${_F5MKU_ENV}, "
+        "or run in an interactive terminal to be prompted"
     )
 
 


### PR DESCRIPTION
## Summary

Add `f5 encrypt-secrets` and `f5 decrypt-secrets` CLI verbs to encrypt and decrypt credential-bearing values in bigip.conf / SCF files using the F5 unit master key.

### Key Changes

- **New module `tooling/f5/f5mku.py`**: Self-contained F5 master-key (f5mku) encryption/decryption implementation using AES-ECB with PKCS#7 padding. Handles the `$M$<salt>$<base64>` envelope format that BIG-IP stores secrets in. Uses the bundled pure-Python AES cipher to avoid external crypto dependencies in the zipapp.

- **Extended `tooling/f5/f5_remote/_aes.py`**: Added the inverse (decryption) transform to the existing AES cipher implementation. Implements `InvShiftRows`, `InvSubBytes`, `InvMixColumns`, and Galois field multiplication for ECB decryption mode. Maintains FIPS-197 correctness via known-answer test vectors.

- **New module `tooling/f5/f5_remote/secret_input.py`**: Centralized secret resolution from four sources (explicit flag, file, environment variable, secure terminal prompt). Handles TTY detection correctly so prompts work even when stdin is piped. Used by both the new secrets verbs and refactored UCS passphrase handling.

- **New verb `tooling/f5/verbs/secrets.py`**: Implements `encrypt-secrets` and `decrypt-secrets` verbs with shared master-key resolution logic. Both verbs are idempotent—values already in the target form are left untouched. Supports key input via `--f5mku`, `--f5mku-file`, `$F5MKU` env var, or interactive prompt.

- **Extended `dialects/f5/bigip/rewrite.py`**: Added `rewrite_secrets()` function and `SecretRewriteReport` dataclass to apply transformations to encrypted-secret-bearing fields (`passphrase`, `password`, `secret`, `shared-secret`, `auth-password`, `priv-password`, `encrypted-password`). Handles quoting/unquoting of SCF tokens and skips sentinel values (`none`, `<REDACTED>`).

- **Refactored `tooling/f5/f5_remote/ucs.py`**: Migrated passphrase resolution to use the new shared `resolve_secret()` function, eliminating duplicate TTY detection logic.

- **Updated `tooling/f5/f5_remote/auth.py`**: Simplified to use the new shared secret resolution.

- **Documentation**: Added KCS feature note (`docs/kcs/features/kcs-feature-f5-secret-crypto.md`) and updated README and feature index.

### Design Notes

- The cipher runs on the pure-Python AES implementation to work in the zipapp where C extensions are stripped, avoiding a `cryptography` dependency.
- Only fields BIG-IP actually master-key encrypts are touched, unlike the broader `f5 redact` set. SNMP community strings and monitor receive strings (kept in clear text on the device) are explicitly excluded.
- Wrong master keys are detected and reported as errors (padding or salt check fails) rather than producing silent garbage.

## Validation

- Added comprehensive test suite in `tests/test_f5_secrets.py` covering:
  - AES inverse transform with FIPS-197 known-answer vectors
  - f5mku encrypt/decrypt round-trips with various plaintexts
  - Secret-locating rewrite with quoting and sentinel handling
  - CLI round-trip encryption/decryption
  - Key resolution from all four sources (flag, file, env, prompt)
  - Error handling for missing/invalid keys
  - Idempotency of encrypt operation

- Added test suite in `tests/test_f5_secret_input.py` covering:
  - Resolution order (explicit → file → env → prompt)
  - Whitespace stripping behavior
  - TTY detection and prompt cancellation
  - Source availability checks

- All new tests pass; existing tests remain

https://claude.ai/code/session_01L2Egg4HHkUeup2yG749f8U