### PR TITLE
Incremental analysis: per-item fast path + per-proc lattice memo, byte-identical to full rebuild

### DIFF
--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -285,17 +285,61 @@ practcl.tcl from ~1 s to low-ms).
 > the per-item walk under random edits — which the older `differential_incremental`
 > does not cover, as it exercises `analyse_commands`-based `analyse_incremental`).
 >
-> **Still falling back / not yet won (the next steps).**
-> - **Duplicate definitions** (e.g. `practcl.tcl` defines `::clay::uuid::generate`
->   twice) remain a genuine correctness fallback — last-def-wins (DFS) vs the
->   graft's merge.
+> **Where the remaining per-edit time actually goes (post-Phase-C profiling).**
+> Phase-timed on the salsa graph (warm DB, single-char body edit), the picture
+> that the original "memoise the tail" sub-tasks assumed turns out **not** to
+> hold — the tail's *emission* is already cheap; the cost is the unit **build**:
+>
+> - **The analyser tail's `emit_cfg_ssa_diagnostics` emission is ~6 ms** once it
+>   consumes the memoised `cu_override`; the 130 ms it costs on the *no-override*
+>   path (`analyse_per_item`) is entirely the **`CompilationUnit` build** it does
+>   for itself.  Every other tail emitter (W123 / arity / W120 / var-usage / W002
+>   / W304) is ~0 ms.  So *making the emission incremental buys almost nothing.*
+> - The dominant per-edit cost on a fast-path file is the **`CompilationUnit`
+>   build** — `memoised_compilation_unit`, run once in *each* of the two tracked
+>   queries (`file_analysis_incremental` + `compiler_check_diagnostics`).  On
+>   `parse_lemon.tcl` (7.4 kLOC, 177 fns): `build_for_memoized` ≈ 80 ms +
+>   `with_interprocedural` ≈ 19 ms, ×2 queries.  The per-function *lattices* are
+>   memoised (cache hits across edits), so this 80 ms is the **non-memoised
+>   whole-module work**: `lower_to_ir` + module `build_cfg` +
+>   `collect_call_site_constants` + the 177 lattice clone/rebases — i.e. O(file)
+>   lowering, the genuine floor.  `run_all_checks` (≈ 23 ms) + `optimise_unit`
+>   (≈ 13 ms) are minor by comparison.
+> - **Net:** fast-path large files already sit at the *target* — `parse_lemon`
+>   ≈ 150 ms (`file_analysis_incremental`) + 141 ms (`compiler_check`); `pki.tcl`
+>   (3.3 kLOC) ≈ 115 + 119 ms.  Driving them lower means attacking the
+>   lowering/CFG floor (incremental lexing/lowering, or sharing one built unit
+>   between the two queries when their `LexerConfig`s coincide — they differ only
+>   for tcl8.4 / iRules) — a larger architecture step, *not* the diagnostic-tail
+>   memoisation the original plan named.
+>
+> **Still falling back (fallback-reason census over the corpus, production
+> settings): `duplicate` 86, `variable_ns` 44, `proc_collision` 12,
+> `syntax_error` 11.**
+> - **Duplicate definitions** (`duplicate` + `proc_collision` ≈ 98 files, incl.
+>   `practcl.tcl`'s twice-defined `::clay::uuid::generate`) are the biggest
+>   remaining fallback class — and, like the Phase-B/C enclosing fallback, are
+>   *mostly over-conservative*: bypassing the fallback leaves **0 diagnostic
+>   divergence** and only ~19 internal symbol-table struct-diffs.  But the
+>   residual is a genuine nest of **last-definition-wins** semantics that the
+>   graft's position-independent merge can't cheaply reproduce: a whole-file
+>   `define_var` *overwrites* `all_variables` on each redefinition (discarding the
+>   earlier body's references — *including params*), and duplicate **class**
+>   definitions accumulate (`all_classes` / `instance_classes` / `global_scope`,
+>   e.g. `clay.tcl`, `practcl.tcl`).  A partial "`all_variables` last-wins" graft
+>   cut the residual to ~8 files but mishandled duplicate-proc param references —
+>   so the duplicate fast-path needs a dedicated, carefully-gated pass, not a
+>   quick patch.
 > - **OO method bodies** are walked *in place* in the shell pass (not deferred /
->   memoised); OO-heavy files (practcl: 244 methods vs 132 procs) therefore see
->   little body-memo benefit even on the fast path.
-> - **The whole-file tail** (`run_diagnostic_emitters`: `emit_cfg_ssa` +
->   W123 / arity) still re-runs every edit and dominates per-edit latency on the
->   largest files; making it incremental is the remaining lever (the original
->   task's sub-tasks #1–#4).
+>   memoised — 0 deferred methods on every file profiled); OO-heavy files
+>   (`practcl`: 244 methods vs 132 procs) see little body-memo benefit even once
+>   on the fast path.  Memoising them means routing `is_method` bodies through an
+>   isolated+grafted analysis like procs (with class / `self` / instance-var
+>   context), then handling the class-accumulation fallback.
+>
+> So `practcl` specifically needs *all three* — duplicate fast-path **and** method
+> memoisation **and** a cheaper unit build — before it leaves the full-rebuild
+> floor; each is a substantial, independently-gated piece.
 
 > **Salsa-native lattice graph (shipped).** The per-procedure baseline lattices
 > (CFG → SSA → def-use → SCCP → type → rendered → intra-procedural taint) are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -349,12 +349,28 @@ practcl.tcl from ~1 s to low-ms).
 > **Still not won.**
 > - **The `variable ns::x` (`variable_ns`) + `syntax_error` fallbacks** remain
 >   (correct, narrow).
-> - **The `CompilationUnit` lowering floor** (~80 ms O(file) `lower_to_ir` +
->   module `build_cfg`) is the per-edit floor for fast-path files; lowering them
->   incrementally is the remaining architecture-level lever.
+> - **The `CompilationUnit` per-edit floor is architecture-level.** Phase-timed
+>   on `parse_lemon.tcl` (7.4 kLOC, 177 procs), the per-edit CU rebuild splits
+>   into: `lower_to_ir` ~26 ms + module `build_cfg` ~10 ms (both O(file)) + the
+>   **per-procedure loop ~52 ms** + `with_interprocedural` ~19 ms.  The
+>   per-procedure 52 ms is *not* lattice compute — the lattices are memoised
+>   (`function_lattice`) — it is the **offset-invariant plumbing run for every
+>   procedure on every edit**: clone the proc's offset-0 IR body + `rebase_script`
+>   it, then deep-clone the memoised `FunctionUnit` + `rebase_function_unit` it to
+>   the proc's real offset.  Because the rebase target (the offset) changes
+>   whenever an edit shifts a procedure, the rebased unit can't be cached across
+>   edits, so this plumbing is irreducible without either **incremental
+>   lowering/CFG** or making the diagnostic consumers **offset-aware** (consume
+>   offset-0 units + a per-proc offset, no rebase) — both large refactors.
+>   - *Tried and reverted:* folding interprocedural `param_constants` into the
+>     `function_lattice` key (so param-constant procedures memoise too, instead of
+>     the fresh-build bypass).  It is byte-identical but a net **regression**: the
+>     added clone+rebase+body-normalise plumbing for those procedures costs more
+>     than the fresh lattice build it replaced (parse_lemon BOTH-queries
+>     ~202 ms → ~245 ms), confirming the plumbing — not the compute — is the floor.
 > - **`practcl.tcl`** still falls back on a genuine twice-defined method-style
->   definer and is OO-heavy, so it needs the lowering floor before it leaves the
->   full-rebuild path.
+>   definer and is OO-heavy, so it needs that architectural step before it leaves
+>   the full-rebuild path.
 
 > **OO method-body memoisation (shipped).** Method bodies were walked *in place*
 > in pass 2 (not memoised), so a body edit re-walked every method.  They are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -211,6 +211,7 @@ practcl.tcl from ~1 s to low-ms).
 | Slice 5 — diagnostics on the cancellable salsa graph (`file_analysis_incremental`), coalescing per-URI worker (CPU-stress-robust), `document_analysis_gate` retired | **shipped** (e2e parity; edit-storm stress green) |
 | Salsa-native per-procedure lattice graph (`function_lattice` query interning each proc's offset-0 body + `CfgContext`); both consumers (analyser tail + optimiser via `compiler_check_diagnostics`) on salsa; process-wide content cache retired | **shipped** (byte-identical; offset-invariant firewall + e2e parity) |
 | Per-item walk Phase B — widen the fast path: qualified `$::g` reads captured + replayed on the shell's globals at graft; the enclosing-context fallback narrowed from "any namespace/global/`variable`/qualified-read body" to **duplicate definitions** (top-level + nested self-redefinition) and **class-defining / qualified-writer bodies** | **shipped** (≈42% of corpus files now take the incremental fast path, up from the qualified-read-trigger floor; byte-identical — corpus + fuzzer gated) |
+| Per-item walk Phase C — widen the fast path to the enclosing-variable class: the three residual divergences made byte-identical (W120 anchored at the source-earliest invocation; W002 disabled-command shadow check deferred to the tail over the merged `all_procs`; W304 `$var` resolution deferred to the tail over the full source); qualified-read replay gated on source-order visibility; `body_needs_enclosing_context` narrowed to just `variable ns::x`; post-walk `E…` syntax-error backstop added (mirrors `analyse_incremental`) | **shipped** (≈42%→**86.6%** of corpus files take the fast path; byte-identical — `per_item_corpus` *and* the new `per_item_matches_analyse_under_edits` edit fuzzer + `differential_incremental` + e2e gated) |
 
 > **Phase B — what the fast path now covers, and what still falls back.**
 > The per-item walk's enclosing-context fallback (`body_needs_enclosing_context`)
@@ -233,13 +234,68 @@ practcl.tcl from ~1 s to low-ms).
 > Result: ~42% of corpus files take the incremental fast path (a body edit
 > recomputes one body + shell + tail).  The remaining ~58% — those that
 > **declare/write** enclosing variables (`variable` / `global` / `set ::x`) or
-> define classes in a body, including marquee files like `practcl.tcl` and
-> `init.tcl` — still fall back, because making them byte-identical needs the
-> isolated body to *pre-seed* its enclosing const-strings + variable defs (so
-> `warn_if_unused`, definition spans, and const-string-dependent diagnostics like
-> W304 resolve identically).  That pre-seeding — keyed so a body invalidates only
-> when its enclosing context changes — is the next step toward a fully
-> incremental analyser walk.
+> define classes in a body — still fell back (addressed in **Phase C** below).
+
+> **Phase C — the enclosing-variable / class class joins the fast path
+> (shipped).**  A probe (`tcl-compiler/examples/per_item_divergence`,
+> analyse-vs-per-item over the `tmp/` corpus with the enclosing-context fallback
+> bypassed) showed the broad Phase-B fallback was ~98.6% unnecessary: bypassing
+> it left only **three** diagnostic-divergence classes and two book-keeping nits,
+> all narrow and reproducible.  Each was made byte-identical at the
+> isolated-body / graft / tail seam — the rust-analyzer "cross-item facts live in
+> the aggregate, not the body" split — so the fallback could be narrowed to
+> almost nothing:
+>
+> - **W120** (missing `package require`) now anchors at each command's
+>   *source-earliest* invocation instead of the first in walk order, making it
+>   independent of whole-file-DFS vs per-item shell-order (it is emitted before
+>   `canonicalize_result_order`).  Applies to both paths — no behaviour change for
+>   `analyse` beyond determinism.
+> - **W002** (disabled-in-dialect command) — its user-proc-shadowing suppression
+>   reads the file's whole `all_procs`, which an isolated body lacks.  The body now
+>   *captures* would-be-W002 sites (`pending_disabled_commands`) and the tail
+>   re-applies the shadow check against the merged `all_procs`
+>   (`flush_disabled_command_diagnostics`) — mirroring `pending_arity` /
+>   `capture_global_reads`.
+> - **W304** (missing `--`) — only its `$var` branch is source-dependent
+>   (`last_literal_set_value_for_var` scans the *whole* source for the most-recent
+>   literal `set`).  That branch is deferred (`pending_w304`) and classified in the
+>   tail where `self.source` is the full file; every other W304 branch stays
+>   inline.
+> - **Qualified-read replay** is now gated on source-order visibility: a captured
+>   `$::ns::v` is replayed only when its enclosing definition *precedes the body*
+>   (a whole-file DFS walks a proc body before a later top-level `set ::ns::v`, so
+>   it records no reference there).
+> - **`body_needs_enclosing_context`** is narrowed from "any
+>   `variable`/`global`/`set ::x`/class body" to just **`variable ns::x`** (a
+>   `variable` linking to a *sub-namespace* variable — the lone residual whose
+>   merged `warn_if_unused` / `definition_span` is walk-order-sensitive).  Plain
+>   `variable x`, `global`, `upvar`, qualified writes, and class definitions all
+>   take the fast path.
+> - A post-walk **`E…` syntax-error backstop** (mirroring `analyse_incremental`)
+>   re-analyses fully whenever the per-item result carries any error diagnostic —
+>   locally-unbalanced braces that pass `script_is_complete` engage `analyse`'s
+>   error-recovery machinery, which the per-item walk does not reproduce.
+>
+> Result: **86.6%** of corpus files take the fast path (up from ~42%), 100%
+> byte-identical; large *non-duplicate* files (e.g. `pki.tcl`, 3.3 kLOC) drop from
+> ~360 ms full-analyse to ~115 ms per warm edit.  Gated by the unedited
+> `per_item_corpus` test **and** a new edit fuzzer
+> (`per_item_matches_analyse_under_edits`, the `incremental == fresh` contract for
+> the per-item walk under random edits — which the older `differential_incremental`
+> does not cover, as it exercises `analyse_commands`-based `analyse_incremental`).
+>
+> **Still falling back / not yet won (the next steps).**
+> - **Duplicate definitions** (e.g. `practcl.tcl` defines `::clay::uuid::generate`
+>   twice) remain a genuine correctness fallback — last-def-wins (DFS) vs the
+>   graft's merge.
+> - **OO method bodies** are walked *in place* in the shell pass (not deferred /
+>   memoised); OO-heavy files (practcl: 244 methods vs 132 procs) therefore see
+>   little body-memo benefit even on the fast path.
+> - **The whole-file tail** (`run_diagnostic_emitters`: `emit_cfg_ssa` +
+>   W123 / arity) still re-runs every edit and dominates per-edit latency on the
+>   largest files; making it incremental is the remaining lever (the original
+>   task's sub-tasks #1–#4).
 
 > **Salsa-native lattice graph (shipped).** The per-procedure baseline lattices
 > (CFG → SSA → def-use → SCCP → type → rendered → intra-procedural taint) are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -375,36 +375,48 @@ practcl.tcl from ~1 s to low-ms).
 >     fresh-build** (pki 4 ms vs 38 ms; parse_lemon 6 ms vs 52 ms) and per-edit
 >     latency improves (pki BOTH-queries ~235 ms → ~150 ms; parse_lemon ~202 →
 >     ~191 ms, the smaller win eaten by the IR body-normalise needed to form the
->     offset-0 key).  It is **correct in isolation** but was reverted because it
->     *extends* the pre-existing memo byte-identity bug below to more procedures —
->     that must be fixed first.
+>     offset-0 key).  It is **correct in isolation** and was reverted only because
+>     it *extended* the memo byte-identity bug below to more procedures; with that
+>     bug now fixed (see "Memo byte-identity (fixed)"), it can land on top.
 > - **`practcl.tcl`** still falls back on a genuine twice-defined method-style
 >   definer and is OO-heavy, so it needs that architectural step before it leaves
 >   the full-rebuild path.
 
-> **⚠ Pre-existing memo byte-identity bug (found, not yet fixed — highest
-> priority).**  The salsa-native lattice graph (#604) promises that the memoised
-> `build_for_memoized` (offset-0 per-procedure `function_lattice` + rebase) is
-> byte-identical to a fresh whole-module `build_for_with_config`.  A new corpus
-> differential (`tcl-lsp-db/tests/compiler_check_corpus.rs`, comparing
-> `compiler_check_diagnostics` vs `compiler_check_diagnostics_uncached`) shows it
-> **is not**: **~30% of corpus files diverge** (init/safe/http/tcltest/clock/…).
-> It is **per-file, not a cross-file cache collision** (fresh-db-per-file diverges
-> too), and surfaces as **`S101` shimmer check spans of *different width*** — so
-> the offset-0 build's analysis genuinely differs from the whole-module build's,
-> beyond a uniform offset (repro: `cargo run -p tcl-lsp-db --example cc_diff` with
-> `FILE=tmp/tcl8.6.16/library/safe.tcl`).  Both production diagnostics paths
-> consume the memo CU (the analyser tail via `cu_override`, the compiler-checks
-> via the `compilation_unit` query), so the LSP currently emits compiler-check
-> diagnostics that differ from a from-scratch analysis for ~30% of files.  The
-> existing guard (`compiler_check_diagnostics_matches_uncached`, 5 cases) and the
-> e2e suite happened to miss it; `per_item_corpus` does not exercise the memo CU
-> (its `emit_cfg_ssa` builds a fresh unit).  Suspected locus: `rebase_script` /
-> `rebase_function_unit` completeness vs what `find_shimmer_warnings` reads, or a
-> subtle `build_cfg_function_with_upvars` vs module-`build_cfg` difference.  The
-> corpus differential is committed `#[ignore]`d as the regression guard; un-ignore
-> when fixed.  **This blocks extending the lattice memo** (the `param_constants`
-> win above lands on top of it once green).
+> **Memo byte-identity (fixed).**  The salsa-native lattice graph (#604) promises
+> that the memoised `build_for_memoized` (offset-0 per-procedure `function_lattice`
+> + rebase) is byte-identical to a fresh whole-module `build_for_with_config`.  A
+> corpus differential (`tcl-lsp-db/tests/compiler_check_corpus.rs`, comparing
+> `compiler_check_diagnostics` vs `compiler_check_diagnostics_uncached`) found
+> ~30% of files diverging.  The root cause was **nondeterminism, not an
+> offset-0-vs-whole-module analysis difference** — both builds disagreed run-to-run
+> with themselves.  Five `HashMap`-iteration-order dependencies, each fixed to a
+> stable order:
+>
+> 1. **`shimmer::span::phi_span`** picked the *first* incoming def span in
+>    `phi.incoming` (a `HashMap`) → nondeterministic `S101` span; now the earliest
+>    (min) span.
+> 2. **`compiler_checks::run_all_checks`** emitted diagnostics in producer order
+>    (per-function `HashMap` walks); now sorted on a total
+>    `(span, code, category, severity, message, replacement)` key
+>    (`sort_diagnostics`).
+> 3. **`optimiser::optimise_unit`** allocated monotonic group ids and emitted in
+>    `cu.procedures` / def-use-chain `HashMap` order; now canonicalised before
+>    overlap arbitration (stable sort) with group ids renumbered by first
+>    appearance (`renumber_groups`).
+> 4. **`taint::find_destructive_file_warnings`** (W313) named the *first offending
+>    path variable* from `ssa_stmt.uses` (a `HashMap`), so `file rename $a $b`
+>    reported `$a` or `$b` at random; now iterates path variables in argument
+>    (source) order (`arg_var_names_ordered`).
+> 5. **`type_infer`** folded the order-sensitive `type_join` over a phi's
+>    predecessors in `HashSet` order — and `type_join` records only a `(from, to)`
+>    pair for a 3+-way shimmer, so the `S101` message named different types
+>    run-to-run; the predecessor list is now sorted before the fold.
+>
+> With these, the memo and whole-module builds agree byte-for-byte across the full
+> `tmp/` corpus (893 files), stable across process-level `HashMap` seeds.  The
+> corpus differential is the (now-passing) regression guard, `#[ignore]`d only for
+> being slow (`--ignored`, ~100 s).  This **unblocks extending the lattice memo**
+> (the `param_constants` win above can now land on top).
 
 > **OO method-body memoisation (shipped).** Method bodies were walked *in place*
 > in pass 2 (not memoised), so a body edit re-walked every method.  They are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -347,19 +347,32 @@ practcl.tcl from ~1 s to low-ms).
 > **86.6% → 92.2%**, 100% byte-identical, 0 diagnostic divergence.
 >
 > **Still not won.**
-> - **OO method *bodies* are walked in place** (not memoised), so method-heavy
->   files now take the fast path (proc + lattice memo engages) but their own
->   per-edit latency stays high until `is_method` bodies are routed through an
->   isolated+grafted+memoised analysis like procs (class / `self` / instance-var
->   context).  The cleanest next step.
 > - **The `variable ns::x` (`variable_ns`) + `syntax_error` fallbacks** remain
 >   (correct, narrow).
 > - **The `CompilationUnit` lowering floor** (~80 ms O(file) `lower_to_ir` +
 >   module `build_cfg`) is the per-edit floor for fast-path files; lowering them
 >   incrementally is the remaining architecture-level lever.
 > - **`practcl.tcl`** still falls back on a genuine twice-defined method-style
->   definer and is OO-heavy, so it needs method-body memoisation + the lowering
->   floor before it leaves the full-rebuild path.
+>   definer and is OO-heavy, so it needs the lowering floor before it leaves the
+>   full-rebuild path.
+
+> **OO method-body memoisation (shipped).** Method bodies were walked *in place*
+> in pass 2 (not memoised), so a body edit re-walked every method.  They are now
+> analysed as offset-0 isolated units and grafted like procs: `DeferredBody`
+> carries the method's defining namespace + params + class instance variables,
+> `analyse_proc_body_isolated` reconstructs a `ScopeKind::Method` scope (so
+> `in_method` dispatch recording fires) with the instance variables pre-bound,
+> and the proc/method pass-2 branches are unified through `body_fn` +
+> `graft_proc_body`.  `ItemBodyKey` gains `is_method` + `class_variables`.  W308
+> object tracking is the one method-specific subtlety — a method resolves the
+> class against the whole file's classes, not analyse's DFS prefix, so a method
+> that *actually* records an instance falls back (detected precisely: captured
+> candidates are replayed at graft and the fallback fires only when
+> `instance_classes` truly changed, so benign `dict create` stays fast).  Result:
+> pt_rdengine_oo.tcl (2.2 kLOC, 113 methods) per-edit **165 ms → 44 ms**;
+> cookiejar / disjointset / metaclass 8–16 ms.  Coverage holds at 92.2%,
+> byte-identical; gated by `method_body_edit_recomputes_one_item` + the corpus +
+> edit fuzzer.
 
 > **Salsa-native lattice graph (shipped).** The per-procedure baseline lattices
 > (CFG → SSA → def-use → SCCP → type → rendered → intra-procedural taint) are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -313,33 +313,53 @@ practcl.tcl from ~1 s to low-ms).
 >   for tcl8.4 / iRules) — a larger architecture step, *not* the diagnostic-tail
 >   memoisation the original plan named.
 >
-> **Still falling back (fallback-reason census over the corpus, production
-> settings): `duplicate` 86, `variable_ns` 44, `proc_collision` 12,
-> `syntax_error` 11.**
-> - **Duplicate definitions** (`duplicate` + `proc_collision` ≈ 98 files, incl.
->   `practcl.tcl`'s twice-defined `::clay::uuid::generate`) are the biggest
->   remaining fallback class — and, like the Phase-B/C enclosing fallback, are
->   *mostly over-conservative*: bypassing the fallback leaves **0 diagnostic
->   divergence** and only ~19 internal symbol-table struct-diffs.  But the
->   residual is a genuine nest of **last-definition-wins** semantics that the
->   graft's position-independent merge can't cheaply reproduce: a whole-file
->   `define_var` *overwrites* `all_variables` on each redefinition (discarding the
->   earlier body's references — *including params*), and duplicate **class**
->   definitions accumulate (`all_classes` / `instance_classes` / `global_scope`,
->   e.g. `clay.tcl`, `practcl.tcl`).  A partial "`all_variables` last-wins" graft
->   cut the residual to ~8 files but mishandled duplicate-proc param references —
->   so the duplicate fast-path needs a dedicated, carefully-gated pass, not a
->   quick patch.
-> - **OO method bodies** are walked *in place* in the shell pass (not deferred /
->   memoised — 0 deferred methods on every file profiled); OO-heavy files
->   (`practcl`: 244 methods vs 132 procs) see little body-memo benefit even once
->   on the fast path.  Memoising them means routing `is_method` bodies through an
->   isolated+grafted analysis like procs (with class / `self` / instance-var
->   context), then handling the class-accumulation fallback.
+> **Shared `CompilationUnit` build (shipped).** The unit was built twice per
+> edit (once per diagnostics query).  A tracked `compilation_unit(file, cfg)`
+> query keyed on an interned `LexerCfgKey` lets the analyser tail
+> (`file_analysis_incremental`) and the optimiser/compiler-checks
+> (`compiler_check_diagnostics`) **share one build per edit** whenever their
+> lexer configs coincide — every dialect but `tcl8.4` / `f5-irules`.  Combined
+> per-edit latency on `parse_lemon.tcl` (7.4 kLOC) drops ~287 ms → ~202 ms (one
+> build eliminated).  `CompilationUnit` gained `PartialEq` so salsa returns
+> `Arc<CompilationUnit>`; gated by `compilation_unit_shared_across_consumers`.
+
+> **Duplicate procs + multi-method classes on the fast path (shipped).** The
+> remaining fallback census (`duplicate` 86, `variable_ns` 44, `proc_collision`
+> 12, `syntax_error` 11) was dominated by two avoidable causes:
 >
-> So `practcl` specifically needs *all three* — duplicate fast-path **and** method
-> memoisation **and** a cheaper unit build — before it leaves the full-rebuild
-> floor; each is a substantial, independently-gated piece.
+> - **Multi-method classes were a false duplicate** — method deferred-bodies had
+>   an empty `scope_name`, so the duplicate detector treated every method after
+>   the first as a duplicate of `(is_method, "", "")`; *any* class with 2+
+>   methods fell back.  Methods now carry their qualified name, so distinct
+>   methods are distinct (only a genuinely twice-defined method falls back).
+> - **Genuine proc duplicates** now graft byte-identically: a whole-file
+>   `define_var` unions each definition's locals with last-definition-wins on
+>   shared keys, reproduced by overwrite-on-collision for body-owned
+>   `all_variables` keys while param keys keep the shell's real definition span
+>   (taking only the last body's references).
+>
+> The cross-item facts an isolated/in-place body can't reproduce are handled
+> precisely (not by a blanket fallback): **object instances** (`[Cls new]` /
+> `Cls create v`) are captured in the isolated proc body and replayed against the
+> shell's full `all_classes` at graft (no memo-key change), with a per-method
+> snapshot fallback for in-place method bodies; **class extension** (`oo::define`)
+> falls back only on an `all_classes` key collision.  Result: fast-path coverage
+> **86.6% → 92.2%**, 100% byte-identical, 0 diagnostic divergence.
+>
+> **Still not won.**
+> - **OO method *bodies* are walked in place** (not memoised), so method-heavy
+>   files now take the fast path (proc + lattice memo engages) but their own
+>   per-edit latency stays high until `is_method` bodies are routed through an
+>   isolated+grafted+memoised analysis like procs (class / `self` / instance-var
+>   context).  The cleanest next step.
+> - **The `variable ns::x` (`variable_ns`) + `syntax_error` fallbacks** remain
+>   (correct, narrow).
+> - **The `CompilationUnit` lowering floor** (~80 ms O(file) `lower_to_ir` +
+>   module `build_cfg`) is the per-edit floor for fast-path files; lowering them
+>   incrementally is the remaining architecture-level lever.
+> - **`practcl.tcl`** still falls back on a genuine twice-defined method-style
+>   definer and is OO-heavy, so it needs method-body memoisation + the lowering
+>   floor before it leaves the full-rebuild path.
 
 > **Salsa-native lattice graph (shipped).** The per-procedure baseline lattices
 > (CFG → SSA → def-use → SCCP → type → rendered → intra-procedural taint) are now

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -362,15 +362,49 @@ practcl.tcl from ~1 s to low-ms).
 >   edits, so this plumbing is irreducible without either **incremental
 >   lowering/CFG** or making the diagnostic consumers **offset-aware** (consume
 >   offset-0 units + a per-proc offset, no rebase) — both large refactors.
->   - *Tried and reverted:* folding interprocedural `param_constants` into the
->     `function_lattice` key (so param-constant procedures memoise too, instead of
->     the fresh-build bypass).  It is byte-identical but a net **regression**: the
->     added clone+rebase+body-normalise plumbing for those procedures costs more
->     than the fresh lattice build it replaced (parse_lemon BOTH-queries
->     ~202 ms → ~245 ms), confirming the plumbing — not the compute — is the floor.
+>   - **`function_lattice` barely engages for real files.** Instrumenting the
+>     proc loop shows *every* procedure in init/pki/parse_lemon/textutil takes the
+>     **fresh-build** branch — `params_constants_from_call_sites` returns `Some` for
+>     nearly all of them, and the memo was keyed *without* `param_constants` so
+>     those bypass it.  So the 52 ms is fresh SSA/SCCP/type/taint builds, and the
+>     headline lattice memo only helps callee-free procs.
+>   - *Tried (param_constants in the key) then reverted — blocked by the bug
+>     below, not by perf.* Folding `param_constants` into `FnLatticeKey` makes the
+>     memo engage for all procs; with the cache verified hitting (a warm edit
+>     re-executes 0–2 lattices, not 176), clone+rebase is **~9× cheaper than
+>     fresh-build** (pki 4 ms vs 38 ms; parse_lemon 6 ms vs 52 ms) and per-edit
+>     latency improves (pki BOTH-queries ~235 ms → ~150 ms; parse_lemon ~202 →
+>     ~191 ms, the smaller win eaten by the IR body-normalise needed to form the
+>     offset-0 key).  It is **correct in isolation** but was reverted because it
+>     *extends* the pre-existing memo byte-identity bug below to more procedures —
+>     that must be fixed first.
 > - **`practcl.tcl`** still falls back on a genuine twice-defined method-style
 >   definer and is OO-heavy, so it needs that architectural step before it leaves
 >   the full-rebuild path.
+
+> **⚠ Pre-existing memo byte-identity bug (found, not yet fixed — highest
+> priority).**  The salsa-native lattice graph (#604) promises that the memoised
+> `build_for_memoized` (offset-0 per-procedure `function_lattice` + rebase) is
+> byte-identical to a fresh whole-module `build_for_with_config`.  A new corpus
+> differential (`tcl-lsp-db/tests/compiler_check_corpus.rs`, comparing
+> `compiler_check_diagnostics` vs `compiler_check_diagnostics_uncached`) shows it
+> **is not**: **~30% of corpus files diverge** (init/safe/http/tcltest/clock/…).
+> It is **per-file, not a cross-file cache collision** (fresh-db-per-file diverges
+> too), and surfaces as **`S101` shimmer check spans of *different width*** — so
+> the offset-0 build's analysis genuinely differs from the whole-module build's,
+> beyond a uniform offset (repro: `cargo run -p tcl-lsp-db --example cc_diff` with
+> `FILE=tmp/tcl8.6.16/library/safe.tcl`).  Both production diagnostics paths
+> consume the memo CU (the analyser tail via `cu_override`, the compiler-checks
+> via the `compilation_unit` query), so the LSP currently emits compiler-check
+> diagnostics that differ from a from-scratch analysis for ~30% of files.  The
+> existing guard (`compiler_check_diagnostics_matches_uncached`, 5 cases) and the
+> e2e suite happened to miss it; `per_item_corpus` does not exercise the memo CU
+> (its `emit_cfg_ssa` builds a fresh unit).  Suspected locus: `rebase_script` /
+> `rebase_function_unit` completeness vs what `find_shimmer_warnings` reads, or a
+> subtle `build_cfg_function_with_upvars` vs module-`build_cfg` difference.  The
+> corpus differential is committed `#[ignore]`d as the regression guard; un-ignore
+> when fixed.  **This blocks extending the lattice memo** (the `param_constants`
+> win above lands on top of it once green).
 
 > **OO method-body memoisation (shipped).** Method bodies were walked *in place*
 > in pass 2 (not memoised), so a body edit re-walked every method.  They are now

--- a/rust/tcl-compiler/examples/per_item_divergence.rs
+++ b/rust/tcl-compiler/examples/per_item_divergence.rs
@@ -1,0 +1,232 @@
+//! Probe: with the `body_needs_enclosing_context` fallback bypassed, how far is
+//! the per-item path from a full `analyse`?  Categorises the residual diagnostic
+//! divergences across the tmp/ corpus so the fast path can be widened to cover
+//! them.  Run: `cargo run --release -p tcl-compiler --example per_item_divergence`.
+
+#![allow(clippy::cast_precision_loss, clippy::too_many_lines)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::analyser::types::{AnalysisResult, Diagnostic};
+
+fn gather_tcl(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
+    if out.len() >= cap {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = rd.flatten().map(|e| e.path()).collect();
+    entries.sort();
+    for p in entries {
+        if p.is_dir() {
+            gather_tcl(&p, out, cap);
+        } else if p.extension().is_some_and(|x| x == "tcl") {
+            out.push(p);
+            if out.len() >= cap {
+                return;
+            }
+        }
+    }
+}
+
+fn diag_key(d: &Diagnostic) -> (u32, u32, String, String) {
+    (
+        d.span.start(),
+        d.span.end(),
+        d.code.clone(),
+        d.message.clone(),
+    )
+}
+
+/// Symmetric diff of two diagnostic sets, keyed by (span, code, message).
+fn diff_diags(want: &AnalysisResult, got: &AnalysisResult) -> (Vec<Diagnostic>, Vec<Diagnostic>) {
+    let mut w: BTreeMap<(u32, u32, String, String), Diagnostic> = BTreeMap::new();
+    for d in &want.diagnostics {
+        w.insert(diag_key(d), d.clone());
+    }
+    let mut g: BTreeMap<(u32, u32, String, String), Diagnostic> = BTreeMap::new();
+    for d in &got.diagnostics {
+        g.insert(diag_key(d), d.clone());
+    }
+    let missing: Vec<Diagnostic> = w
+        .iter()
+        .filter(|(k, _)| !g.contains_key(*k))
+        .map(|(_, v)| v.clone())
+        .collect();
+    let extra: Vec<Diagnostic> = g
+        .iter()
+        .filter(|(k, _)| !w.contains_key(*k))
+        .map(|(_, v)| v.clone())
+        .collect();
+    (missing, extra)
+}
+
+fn main() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp");
+    let dialect = "tcl8.6";
+    let cap: usize = std::env::var("CAP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2000);
+    let mut files = Vec::new();
+    gather_tcl(&root, &mut files, cap);
+    println!("corpus: {} files (dialect {dialect})", files.len());
+
+    let mut total = 0usize;
+    let mut fast_path = 0usize;
+    let mut identical = 0usize;
+    let mut fell_back = 0usize; // still fell back for OTHER reasons (recovery/dup)
+    let mut diverged = 0usize;
+    // category -> (missing_count, extra_count, files_affected)
+    let mut by_code: BTreeMap<String, (usize, usize, usize)> = BTreeMap::new();
+    let mut worst: Vec<(usize, String)> = Vec::new();
+
+    for path in &files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.is_empty() {
+            continue;
+        }
+        total += 1;
+        let want = Analyser::new().analyse(&src, dialect);
+
+        let mut a = Analyser::new();
+        // Default: exercise the *production* path (narrow fallback active).  Set
+        // SKIP_FALLBACK=1 to bypass `body_needs_enclosing_context` and measure
+        // the raw residual divergence the fast path would have.
+        a.probe_skip_enclosing_fallback = std::env::var("SKIP_FALLBACK").is_ok();
+        let got = a.analyse_per_item(&src, dialect);
+        if a.took_fast_path {
+            fast_path += 1;
+            if std::env::var("LIST_FAST").is_ok() && src.lines().count() > 1500 {
+                println!(
+                    "  FAST {:>5}L  {}",
+                    src.lines().count(),
+                    path.strip_prefix(&root).unwrap_or(path).display()
+                );
+            }
+        }
+
+        if got == want {
+            identical += 1;
+            continue;
+        }
+        let (missing, extra) = diff_diags(&want, &got);
+        if missing.is_empty() && extra.is_empty() {
+            // Diagnostics match but some other AnalysisResult field differs
+            // (scopes/vars) — report which fields diverge.
+            fell_back += 1;
+            let mut fields = Vec::new();
+            if want.global_scope != got.global_scope {
+                fields.push("global_scope");
+            }
+            if want.all_procs != got.all_procs {
+                fields.push("all_procs");
+            }
+            if want.all_classes != got.all_classes {
+                fields.push("all_classes");
+            }
+            if want.all_variables != got.all_variables {
+                fields.push("all_variables");
+            }
+            if want.command_invocations != got.command_invocations {
+                fields.push("command_invocations");
+            }
+            if want.command_aliases != got.command_aliases {
+                fields.push("command_aliases");
+            }
+            if want.instance_classes != got.instance_classes {
+                fields.push("instance_classes");
+            }
+            if want.package_requires != got.package_requires {
+                fields.push("package_requires");
+            }
+            if want.package_provides != got.package_provides {
+                fields.push("package_provides");
+            }
+            if want.namespace_imports != got.namespace_imports {
+                fields.push("namespace_imports");
+            }
+            if want.regex_patterns != got.regex_patterns {
+                fields.push("regex_patterns");
+            }
+            if want.suppressed_lines != got.suppressed_lines {
+                fields.push("suppressed_lines");
+            }
+            if want.unknown_proc_info != got.unknown_proc_info {
+                fields.push("unknown_proc_info");
+            }
+            if want.has_dynamic_providers != got.has_dynamic_providers {
+                fields.push("has_dynamic_providers");
+            }
+            println!(
+                "  STRUCT-DIFF {}  fields={fields:?}",
+                path.strip_prefix(&root).unwrap_or(path).display()
+            );
+            continue;
+        }
+        diverged += 1;
+        let mut codes = std::collections::BTreeSet::new();
+        for d in &missing {
+            let e = by_code.entry(format!("-{}", d.code)).or_default();
+            e.0 += 1;
+            codes.insert(format!("-{}", d.code));
+        }
+        for d in &extra {
+            let e = by_code.entry(format!("+{}", d.code)).or_default();
+            e.1 += 1;
+            codes.insert(format!("+{}", d.code));
+        }
+        for c in codes {
+            by_code.entry(c).or_default().2 += 1;
+        }
+        worst.push((
+            missing.len() + extra.len(),
+            format!(
+                "{}  (-{} +{})",
+                path.strip_prefix(&root).unwrap_or(path).display(),
+                missing.len(),
+                extra.len()
+            ),
+        ));
+    }
+
+    println!("\n== results ==");
+    println!("  total non-empty:        {total}");
+    println!(
+        "  took FAST PATH:         {fast_path}  ({:.1}%)",
+        100.0 * fast_path as f64 / total as f64
+    );
+    println!(
+        "  byte-identical:         {identical}  ({:.1}%)",
+        100.0 * identical as f64 / total as f64
+    );
+    println!("  diag-equal, struct-diff:{fell_back}");
+    println!(
+        "  diagnostic-diverged:    {diverged}  ({:.1}%)",
+        100.0 * diverged as f64 / total as f64
+    );
+
+    println!("\n== divergence by code (-=missing in per_item, +=extra) ==");
+    let mut codes: Vec<_> = by_code.into_iter().collect();
+    codes.sort_by_key(|(_, v)| std::cmp::Reverse(v.0 + v.1));
+    for (code, (m, e, files)) in codes.iter().take(40) {
+        let (mc, ec) = if code.starts_with('-') {
+            (*m, 0)
+        } else {
+            (0, *e)
+        };
+        let _ = (mc, ec);
+        println!("  {code:<14} count={:<6} files={files}", m + e);
+    }
+
+    println!("\n== worst files ==");
+    worst.sort_by_key(|(n, _)| std::cmp::Reverse(*n));
+    for (n, f) in worst.iter().take(20) {
+        println!("  {n:<6} {f}");
+    }
+}

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -966,6 +966,19 @@ impl Analyser {
     /// Best-effort and not flow-sensitive: the last assignment
     /// to a given name wins.
     pub(crate) fn record_instance_creation(&mut self, cmd_name: &str, args: &[String]) {
+        // Per-item isolated proc body: `all_classes` is empty here, so the class
+        // can't be resolved.  Capture the raw `(command, args)` for the two
+        // instance-creation shapes and let the graft replay them against the
+        // shell's full `all_classes` instead (see `pending_instances`).
+        if let Some(pending) = self.pending_instances.as_mut() {
+            let shape_a =
+                cmd_name == "set" && args.len() >= 2 && args[1].trim_start().starts_with('[');
+            let shape_b = args.len() >= 2 && args[0] == "create";
+            if shape_a || shape_b {
+                pending.push((cmd_name.to_owned(), args.to_vec()));
+            }
+            return;
+        }
         // Pattern A: `set VAR [CLASS new|create ...]`.
         if cmd_name == "set"
             && args.len() >= 2

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -3404,13 +3404,24 @@ Consider capturing the result: catch {\u{2026}} result"
         {
             return;
         }
-        self.result.diagnostics.push(super::types::Diagnostic {
+        let diag = super::types::Diagnostic {
             code: "W002".to_string(),
             span: cmd_tok.span,
             message: format!("'{cmd_name}' is disabled in the active dialect profile"),
             severity: Severity::Warning,
             fixes: Vec::new(),
-        });
+        };
+        // Per-item path (isolated body): the body's own `all_procs` couldn't
+        // prove a shadow, but a *sibling/enclosing* user proc still might.  That
+        // is a cross-item fact, so defer the shadow re-check to the tail (over
+        // the merged `all_procs`).  `capture_global_reads.is_some()` marks the
+        // isolated-body analysis; on the whole-file path it is `None` and W002 is
+        // emitted inline exactly as before.
+        if self.capture_global_reads.is_some() {
+            self.pending_disabled_commands.push((qualified, diag));
+        } else {
+            self.result.diagnostics.push(diag);
+        }
     }
 
     pub(super) fn emit_w001_unknown_subcommand(
@@ -3768,6 +3779,27 @@ Consider capturing the result: catch {\u{2026}} result"
     /// order-gated.  (Excluding *conditionally* defined procs would
     /// need the CFG dominator model and is deferred.)
     ///
+    /// Emit the per-item path's deferred W002 (disabled-in-dialect command)
+    /// diagnostics, re-applying the user-proc-shadowing suppression against the
+    /// merged `all_procs` (a cross-item fact unavailable to an isolated body).
+    /// No-op on the whole-file `analyse` path (W002 is emitted inline there, so
+    /// `pending_disabled_commands` is empty) — keeping the two paths
+    /// byte-identical.  The position guard (`name_span.start() < call.start()`)
+    /// matches the inline check, so a unique-named proc resolves identically
+    /// whether checked inline or here (duplicate proc names already force the
+    /// per-item path to fall back).
+    pub(super) fn flush_disabled_command_diagnostics(&mut self) {
+        let pending = std::mem::take(&mut self.pending_disabled_commands);
+        for (qualified, diag) in pending {
+            if let Some(def) = self.result.all_procs.get(&qualified)
+                && def.name_span.start() < diag.span.start()
+            {
+                continue;
+            }
+            self.result.diagnostics.push(diag);
+        }
+    }
+
     /// Idempotent: drains `pending_arity`, so a second call is a
     /// no-op.
     pub fn flush_arity_diagnostics(&mut self) {
@@ -4062,13 +4094,12 @@ Consider capturing the result: catch {\u{2026}} result"
             None => cmd_name.to_string(),
         };
 
-        let (severity, message, origin) =
-            self.classify_w304(tok, is_dynamic, looks_like_option, &command_label);
-
         // Build the code-fix span.  For ``Cmd`` (`[…]`) tokens the
         // lexer span covers ``[inner`` but excludes the closing
         // ``]``; extend by one byte when the byte after ``span.end``
         // is ``]`` so the replacement encompasses the bracket pair.
+        // (Body-local: the fix text is the argument's own source slice, so it is
+        // computable in an isolated body and rebased by the graft.)
         let (fix_span, diag_end) = self.compute_w304_fix_span(tok);
         let fix_text = format!(
             "-- {}",
@@ -4085,6 +4116,25 @@ Consider capturing the result: catch {\u{2026}} result"
         // arg's span, not the command head).
         let _ = cmd_tok;
 
+        // The `Var` dynamic-not-option branch of `classify_w304` resolves the
+        // variable against the most recent literal `set` in the *whole file*
+        // (`last_literal_set_value_for_var` scans `self.source`).  An isolated
+        // proc body's `self.source` is only the body, so an enclosing-scope set
+        // would be missed.  On the per-item path, defer that one source-dependent
+        // case to the tail (where `self.source` is the full file); every other
+        // branch is body-local and emitted inline.
+        if self.capture_global_reads.is_some()
+            && is_dynamic
+            && !looks_like_option
+            && matches!(tok.kind, tcl_lexer::TokenType::Var)
+        {
+            self.pending_w304
+                .push((tok, command_label, fixes, diag_span));
+            return;
+        }
+
+        let (severity, message, origin) =
+            self.classify_w304(tok, is_dynamic, looks_like_option, &command_label);
         self.result.diagnostics.push(super::types::Diagnostic {
             code: "W304".to_string(),
             span: diag_span,
@@ -4094,6 +4144,30 @@ Consider capturing the result: catch {\u{2026}} result"
         });
         if let Some(origin_diag) = origin {
             self.result.diagnostics.push(origin_diag);
+        }
+    }
+
+    /// Emit the per-item path's deferred W304 diagnostics, classifying each
+    /// `$var` against the **full-file** most-recent-literal-`set` resolution
+    /// (impossible inside an isolated body, whose `self.source` is only the
+    /// body).  All inputs are absolute by the time the tail runs (the graft
+    /// rebased the token, fix, and diagnostic spans), so the result is identical
+    /// to the inline whole-file emission.  No-op on the `analyse` path
+    /// (`pending_w304` empty).
+    pub(super) fn flush_w304_diagnostics(&mut self) {
+        let pending = std::mem::take(&mut self.pending_w304);
+        for (tok, command_label, fixes, diag_span) in pending {
+            let (severity, message, origin) = self.classify_w304(tok, true, false, &command_label);
+            self.result.diagnostics.push(super::types::Diagnostic {
+                code: "W304".to_string(),
+                span: diag_span,
+                message,
+                severity,
+                fixes,
+            });
+            if let Some(origin_diag) = origin {
+                self.result.diagnostics.push(origin_diag);
+            }
         }
     }
 
@@ -7238,20 +7312,41 @@ file; this call falls through to the 'unknown' handler."
         // `package require` line, else the top of the file.
         let insert_offset = self.package_require_insert_offset();
 
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut new_diags: Vec<super::types::Diagnostic> = Vec::new();
+        // Emit once per command name, anchored at its **source-earliest**
+        // invocation.  Selecting by position (rather than the first in
+        // `command_invocations` iteration order) makes the result independent of
+        // *how* the walk was driven — the whole-file DFS and the per-item
+        // shell+graft order record invocations in different orders, but both
+        // pick the same anchor here (the per-item path's `command_invocations`
+        // is only sorted by `canonicalize_result_order`, which runs after this
+        // emitter).  Mirrors the walk-strategy independence the tail already
+        // enforces for other order-sensitive collections.
+        let mut best: HashMap<&str, &crate::signature_scan::types::SignatureCommandInvocation> =
+            HashMap::new();
         for inv in &self.result.command_invocations {
             let Some(spec) = registry.get(&inv.name) else {
                 continue;
             };
-            let Some(pkg) = spec.required_package else {
-                continue;
-            };
-            if imported.contains(pkg) {
+            if spec.required_package.is_none() {
                 continue;
             }
-            // Emit once per command name to avoid flooding.
-            if !seen.insert(inv.name.clone()) {
+            best.entry(inv.name.as_str())
+                .and_modify(|cur| {
+                    if (inv.range.start(), inv.range.end()) < (cur.range.start(), cur.range.end()) {
+                        *cur = inv;
+                    }
+                })
+                .or_insert(inv);
+        }
+        let mut new_diags: Vec<super::types::Diagnostic> = Vec::new();
+        for inv in best.values() {
+            let spec = registry
+                .get(&inv.name)
+                .expect("invocation selected only when registry-known");
+            let pkg = spec
+                .required_package
+                .expect("invocation selected only when it requires a package");
+            if imported.contains(pkg) {
                 continue;
             }
             let fix = super::types::CodeFix {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -464,6 +464,7 @@ impl Analyser {
                     namespace: ns_prefix.clone(),
                     scope_name: raw_name.clone(),
                     params: params.clone(),
+                    class_variables: Vec::new(),
                 });
             } else {
                 self.analyse_body(&body_text, body_tok, &child_path);

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -167,23 +167,23 @@ impl Analyser {
             }
             self.define_var(base, mb.body_tok, &method_path, false, None);
         }
-        // Per-item shell pass: defer the method body (scope created above) for
-        // a second isolated pass, matching `handle_proc_command`.
+        // Per-item shell pass: defer the method body for an isolated pass like
+        // `handle_proc_command`.  Carry the method's qualified name as
+        // `scope_name` (so the duplicate detector keys each method distinctly),
+        // the class's *defining* namespace (so command/var resolution in the
+        // isolated `Method` scope matches the whole-file walk), the formal
+        // params, and the class instance variables (pre-bound in every method).
         if self.defer_proc_bodies {
-            // Method bodies are filled in place in pass 2 (byte-identical, not
-            // yet isolated/memoised — the proc-only fields are unused).  Carry
-            // the method's qualified name as `scope_name` so the per-item
-            // duplicate detector keys each method distinctly — distinct methods
-            // must NOT look like mutual duplicates (the empty-key bug that made
-            // every 2+-method class fall back).
+            let namespace = self.namespace_from_scope_path(scope_path);
             self.deferred_bodies.push(super::per_item::DeferredBody {
                 body_text: mb.body_text.clone(),
                 body_tok: mb.body_tok,
                 scope_path: method_path,
                 is_method: true,
-                namespace: String::new(),
+                namespace,
                 scope_name: method_qn,
-                params: Vec::new(),
+                params: mb.params.clone(),
+                class_variables: class_variables.to_vec(),
             });
         } else {
             self.analyse_body(&mb.body_text, mb.body_tok, &method_path);

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -145,7 +145,7 @@ impl Analyser {
         };
         let Some(method_idx) = ({
             scope_at_mut(&mut self.result.global_scope, scope_path).map(|parent| {
-                let mut child = Scope::new(ScopeKind::Method, method_qn);
+                let mut child = Scope::new(ScopeKind::Method, method_qn.clone());
                 child.body_span = Some(mb.body_tok.span);
                 parent.children.push(child);
                 parent.children.len() - 1
@@ -171,14 +171,18 @@ impl Analyser {
         // a second isolated pass, matching `handle_proc_command`.
         if self.defer_proc_bodies {
             // Method bodies are filled in place in pass 2 (byte-identical, not
-            // yet isolated/memoised — the proc-only fields are unused).
+            // yet isolated/memoised — the proc-only fields are unused).  Carry
+            // the method's qualified name as `scope_name` so the per-item
+            // duplicate detector keys each method distinctly — distinct methods
+            // must NOT look like mutual duplicates (the empty-key bug that made
+            // every 2+-method class fall back).
             self.deferred_bodies.push(super::per_item::DeferredBody {
                 body_text: mb.body_text.clone(),
                 body_tok: mb.body_tok,
                 scope_path: method_path,
                 is_method: true,
                 namespace: String::new(),
-                scope_name: String::new(),
+                scope_name: method_qn,
                 params: Vec::new(),
             });
         } else {

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -15,9 +15,10 @@
 //!    of recursing. The whole top level (incl. `namespace eval` / control-flow
 //!    bodies and the procs they contain) is walked here, so top-level variable
 //!    flow is identical to `analyse`.
-//! 2. **Body pass** — for each deferred body, `analyse_body` fills its
-//!    already-created scope *in place*, with `defer_proc_bodies = false` so
-//!    nested defs walk within their enclosing unit.
+//! 2. **Body pass** — for each deferred body (proc *and* method),
+//!    `analyse_proc_body_isolated` analyses it as an offset-0 isolated unit and
+//!    `graft_proc_body` rebases + merges the result into the shell.  Both are
+//!    memoisable, so a body edit re-analyses only that body.
 //!
 //! Splitting top-level vs body work reorders the walk-populated collections
 //! (`command_invocations`, `VarDef.references`, …) relative to `analyse`'s DFS,
@@ -36,9 +37,9 @@ use super::state::Analyser;
 use super::types::AnalysisResult;
 
 /// A proc / method body deferred by the shell pass for a second analysis pass.
-/// Its scope already exists at `scope_path` (params defined); the body pass
-/// fills it — proc bodies via an **isolated** analysis (memoisable), method
-/// bodies in place (byte-identical, not yet memoised).
+/// Its scope already exists at `scope_path` (params + instance vars defined);
+/// the body pass fills it via an **isolated** analysis (memoisable) and grafts
+/// the result back.
 #[derive(Debug, Clone)]
 pub struct DeferredBody {
     /// Body text (braces stripped), as `analyse_body` expects.
@@ -47,16 +48,23 @@ pub struct DeferredBody {
     pub body_tok: Token,
     /// Path to the already-created (empty) proc / method scope to fill.
     pub scope_path: Vec<usize>,
-    /// `true` for an OO method/constructor/destructor body (filled in place);
-    /// `false` for a `proc` body (analysed in isolation).
+    /// `true` for an OO method/constructor/destructor body (analysed in an
+    /// isolated `Method` scope with instance variables pre-bound); `false` for a
+    /// `proc` body.
     pub is_method: bool,
-    /// Lexical namespace of the proc (e.g. `"::ns"`), for reconstructing the
-    /// isolated analysis context. (Proc bodies only.)
+    /// Lexical namespace of the proc (e.g. `"::ns"`), or — for a method — the
+    /// class's **defining** namespace, used to reconstruct the isolated analysis
+    /// context.
     pub namespace: String,
-    /// The proc scope's name (as written) — used for `all_variables` keys.
+    /// The proc scope's name (as written) — or, for a method, its qualified name
+    /// (`::Class::method`) — used for `all_variables` keys and the per-item
+    /// duplicate detector.
     pub scope_name: String,
-    /// The proc's declared parameters (locals in the body). (Proc bodies only.)
+    /// The proc / method's declared parameters (locals in the body).
     pub params: Vec<crate::signature_scan::types::ParamDef>,
+    /// Class instance variables pre-bound in every method body (`variable`
+    /// declarations at class level).  Empty for proc bodies.
+    pub class_variables: Vec<String>,
 }
 
 impl Analyser {
@@ -79,11 +87,11 @@ impl Analyser {
         self.analyse_per_item_with(source, dialect, &mut body_fn)
     }
 
-    /// As [`Self::analyse_per_item`], but each *proc* body's isolated analysis
-    /// is produced by `body_fn` — letting a caller (the LSP query DB) memoise it
-    /// in salsa so a body edit recomputes only that body.  Method bodies are
-    /// filled in place.  Byte-identical to `analyse` whenever `body_fn` returns
-    /// what [`analyse_proc_body_isolated`] would.
+    /// As [`Self::analyse_per_item`], but each proc / method body's isolated
+    /// analysis is produced by `body_fn` — letting a caller (the LSP query DB)
+    /// memoise it in salsa so a body edit recomputes only that body.
+    /// Byte-identical to `analyse` whenever `body_fn` returns what
+    /// [`analyse_proc_body_isolated`] would.
     #[allow(clippy::too_many_lines)]
     pub fn analyse_per_item_with(
         &mut self,
@@ -212,79 +220,46 @@ impl Analyser {
         let mut defined_procs: std::collections::HashSet<String> =
             self.result.all_procs.keys().cloned().collect();
         for db in &deferred {
-            if db.is_method {
-                // Method bodies fill their scope in place (byte-identical for the
-                // walk itself).  But a method that *defines* a proc/class does so
-                // in pass-2 order, not the source order a whole-file walk uses —
-                // so a name it defines that is also defined elsewhere would win
-                // here yet lose (or accumulate differently) there.  Detect that
-                // and fall back.  Cheap: only snapshot when the body text
-                // actually defines a proc/class.
-                self.last_comment = String::new();
-                let before_classes = body_word_defines(&db.body_text, CLASS_DEFINERS)
-                    .then(|| self.result.all_classes.clone());
-                // Object-instance tracking (W308) resolves the class against
-                // `all_classes` *at the walk point*; a method body filled in pass
-                // 2 sees the whole file's classes, not analyse's DFS prefix, so its
-                // `instance_classes` contribution can diverge.  Snapshot it and
-                // fall back on any change (most method bodies create no objects).
-                let before_instances = self.result.instance_classes.clone();
-                let before_procs = body_word_defines(&db.body_text, &["proc"])
-                    .then(|| self.result.all_procs.clone());
-                self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
-                // A method that defines/extends a class diverges like a
-                // class-defining proc body (accumulation order) — fall back.
-                if let Some(before) = before_classes
-                    && self
-                        .result
-                        .all_classes
-                        .iter()
-                        .any(|(k, v)| before.get(k) != Some(v))
-                {
-                    return self.fresh_full_analyse(source, dialect);
-                }
-                // A method whose instance tracking changed (added or re-tracked)
-                // can't be guaranteed to match the DFS-ordered walk — fall back.
-                if self.result.instance_classes != before_instances {
-                    return self.fresh_full_analyse(source, dialect);
-                }
-                // A method that (re)defines a proc whose name is defined
-                // elsewhere is a duplicate at the shared `all_procs` key.
-                if let Some(before) = before_procs {
-                    let mut collision = false;
-                    for (k, v) in &self.result.all_procs {
-                        if before.get(k) != Some(v) && !defined_procs.insert(k.clone()) {
-                            collision = true;
-                            break;
-                        }
-                    }
-                    if collision {
-                        return self.fresh_full_analyse(source, dialect);
-                    }
-                }
-            } else {
-                // Proc bodies: analyse in isolation (a pure function of the
-                // body — the unit memoised by `body_fn`) and graft into shell.
-                let frag = body_fn(db);
-                if frag
-                    .result
-                    .all_procs
-                    .keys()
-                    .any(|name| !defined_procs.insert(name.clone()))
-                {
-                    return self.fresh_full_analyse(source, dialect);
-                }
-                // A body that defines/extends a class whose `all_classes` entry
-                // **collides** with one already present (a *different* value)
-                // can't be reproduced by the graft's overwrite-on-key: a
-                // whole-file walk *accumulates* there (`oo::define` adds methods to
-                // the existing class).  A fresh (non-colliding) class definition
-                // stays fast.  (Object-instance tracking is handled separately —
-                // captured in the isolated body and replayed at graft.)
-                if class_facts_collide(&self.result, &frag.result) {
-                    return self.fresh_full_analyse(source, dialect);
-                }
-                self.graft_proc_body(db, frag, &shell_var_keys);
+            // Both proc and method bodies are analysed in isolation (a pure
+            // function of the body — the unit `body_fn` memoises) and grafted into
+            // the shell.  Methods reconstruct a `Method` scope with the class's
+            // instance variables pre-bound (see `analyse_proc_body_isolated`).
+            let frag = body_fn(db);
+            // A body that defines a proc whose name is defined elsewhere is a
+            // duplicate at the shared `all_procs` key — the graft can't reproduce
+            // last-definition-wins there, so fall back.
+            if frag
+                .result
+                .all_procs
+                .keys()
+                .any(|name| !defined_procs.insert(name.clone()))
+            {
+                return self.fresh_full_analyse(source, dialect);
+            }
+            // A body that defines/extends a class whose `all_classes` entry
+            // **collides** with one already present (a *different* value) can't be
+            // reproduced by the graft's overwrite-on-key: a whole-file walk
+            // *accumulates* there (`oo::define` adds methods to the existing
+            // class).  A fresh (non-colliding) class definition stays fast.
+            if class_facts_collide(&self.result, &frag.result) {
+                return self.fresh_full_analyse(source, dialect);
+            }
+            // Object-instance tracking (W308) resolves the class at the walk
+            // point.  A proc body's creations are captured and replayed by the
+            // graft against the shell's full `all_classes` (source order →
+            // last-assignment-wins matches the whole-file walk).  A *method* body
+            // would resolve against the whole file's classes rather than analyse's
+            // DFS prefix, so its instance tracking can't be replayed faithfully —
+            // snapshot when it captured a candidate (a real `Cls new` *or* a
+            // benign `dict create`) and fall back only if the replay actually
+            // recorded an instance.
+            let inst_snapshot = (db.is_method && !frag.instances.is_empty())
+                .then(|| self.result.instance_classes.clone());
+            self.graft_proc_body(db, frag, &shell_var_keys);
+            if let Some(before) = inst_snapshot
+                && self.result.instance_classes != before
+            {
+                return self.fresh_full_analyse(source, dialect);
             }
         }
 
@@ -487,13 +462,15 @@ pub struct BodyFragment {
     instances: Vec<(String, Vec<String>)>,
 }
 
-/// Analyse one `proc` body as an isolated unit at **offset 0** — a pure
-/// function of `(body_text, namespace, scope_name, params)`, so a
-/// shifted-but-unedited proc is a cache hit (offset-invariant).  The enclosing
-/// namespace + params are reconstructed; params get a placeholder definition
-/// span (the aggregator keeps the shell's real one).  Spans/lines are relative
-/// to the body start; [`Analyser::graft_proc_body`] rebases them by the body's
-/// real position.
+/// Analyse one `proc` **or method** body as an isolated unit at **offset 0** — a
+/// pure function of `(body_text, namespace, scope_name, params, is_method,
+/// class_variables)`, so a shifted-but-unedited body is a cache hit
+/// (offset-invariant).  The enclosing namespace + params are reconstructed
+/// (a `Method` scope with instance variables pre-bound for methods, a `Proc`
+/// scope otherwise); params / instance vars get a placeholder definition span
+/// (the aggregator keeps the shell's real one).  Spans/lines are relative to the
+/// body start; [`Analyser::graft_proc_body`] rebases them by the body's real
+/// position.
 #[must_use]
 #[allow(clippy::implicit_hasher)]
 pub fn analyse_proc_body_isolated(
@@ -528,12 +505,33 @@ pub fn analyse_proc_body_isolated(
     // Capture object-instance creations: the isolated body's `all_classes` is
     // empty, so the class can't be resolved here — the graft replays them.
     a.pending_instances = Some(Vec::new());
-    let proc_path =
-        reconstruct_proc_scope(&mut a.result.global_scope, &db.namespace, &db.scope_name);
+    // A method body is analysed in a `Method` scope (so `in_method` dispatch
+    // recording fires) under the class's defining namespace, with the class
+    // instance variables pre-bound; a proc body in a `Proc` scope.
+    let kind = if db.is_method {
+        super::types::ScopeKind::Method
+    } else {
+        super::types::ScopeKind::Proc
+    };
+    let proc_path = reconstruct_proc_scope(
+        &mut a.result.global_scope,
+        &db.namespace,
+        &db.scope_name,
+        kind,
+    );
     let placeholder = tcl_lexer::Span::new(0, 0);
     let dummy = Token::new(tcl_lexer::TokenType::Str, placeholder);
     for p in &db.params {
         a.define_var(&p.name, dummy, &proc_path, false, Some(placeholder));
+    }
+    // Class instance variables — visible in every method body (skip ones that a
+    // formal parameter already shadows, matching `walk_method_body`).
+    for var in &db.class_variables {
+        let base = crate::naming::normalise_var_name(var);
+        if base.is_empty() || db.params.iter().any(|p| p.name == base) {
+            continue;
+        }
+        a.define_var(base, dummy, &proc_path, false, Some(placeholder));
     }
     a.analyse_body(&db.body_text, body_tok, &proc_path);
     let proc_scope = super::scope::scope_at_mut(&mut a.result.global_scope, &proc_path)
@@ -723,8 +721,10 @@ fn reconstruct_proc_scope(
     root: &mut super::types::Scope,
     namespace: &str,
     scope_name: &str,
+    kind: super::types::ScopeKind,
 ) -> Vec<usize> {
-    use super::types::{Scope, ScopeKind};
+    use super::types::Scope;
+    use super::types::ScopeKind;
     let comps: Vec<&str> = namespace
         .trim_start_matches(':')
         .split("::")
@@ -739,32 +739,9 @@ fn reconstruct_proc_scope(
     }
     let parent = super::scope::scope_at_mut(root, &path).expect("scope path");
     let pi = parent.children.len();
-    parent
-        .children
-        .push(Scope::new(ScopeKind::Proc, scope_name));
+    parent.children.push(Scope::new(kind, scope_name));
     path.push(pi);
     path
-}
-
-/// Class-defining / object-aliasing command heads whose facts accumulate across
-/// bodies in a whole-file walk (remove → add → re-insert) — which the per-item
-/// graft's overwrite-on-key can't reproduce.
-const CLASS_DEFINERS: &[&str] = &[
-    "oo::define",
-    "oo::objdefine",
-    "oo::class",
-    "oo::copy",
-    "itcl::class",
-];
-
-/// Word-level test: does `body_text` use any of `words` as a (whitespace- or
-/// punctuation-delimited) command word?  Used as a cheap pre-filter before the
-/// more expensive snapshot/diff that confirms what a method body actually
-/// defined.  False positives only cost a snapshot, never correctness.
-fn body_word_defines(body_text: &str, words: &[&str]) -> bool {
-    body_text
-        .split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_'))
-        .any(|w| words.contains(&w))
 }
 
 /// Does an isolated proc body interact with enclosing-scope state in a way the
@@ -911,7 +888,9 @@ mod tests {
     fn multi_method_class_byte_identical() {
         // A class with several methods must NOT be treated as a set of mutual
         // "duplicates" (the empty-scope-name bug) — it takes the fast path.
-        eq("oo::class create K {\n  method a {} { set x 1 }\n  method b {} { set y 2 }\n  method c {x} { return $x }\n}\n");
+        eq(
+            "oo::class create K {\n  method a {} { set x 1 }\n  method b {} { set y 2 }\n  method c {x} { return $x }\n}\n",
+        );
     }
 
     #[test]
@@ -927,7 +906,9 @@ mod tests {
         // A proc body that *extends* an existing class (oo::define adds a method)
         // accumulates across the definition site; the per-item graft can't
         // reproduce that, so it falls back — and stays byte-identical.
-        eq("oo::class create K { method a {} {} }\nproc ext {} { oo::define K method b {} {} }\next\n");
+        eq(
+            "oo::class create K { method a {} {} }\nproc ext {} { oo::define K method b {} {} }\next\n",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -177,20 +177,36 @@ impl Analyser {
         // qualified `$::g` reads — replayed at graft) takes the fast incremental
         // path.  Guarded by the corpus `per_item == analyse` gate + the
         // `incremental == fresh` fuzzer.
-        let structural_fallback = {
+        // A **method** defined more than once (same qualified name) still forces a
+        // fallback: method bodies fill their scope in place, so a genuine
+        // duplicate would accumulate rather than last-definition-win.  (Distinct
+        // methods now carry distinct `scope_name`s, so a multi-method class is no
+        // longer a false duplicate.)
+        let duplicate_method = !self.probe_skip_duplicate_fallback && {
             let mut seen = std::collections::HashSet::new();
-            let duplicate_top_level = deferred.iter().any(|db| {
-                !seen.insert((db.is_method, db.namespace.as_str(), db.scope_name.as_str()))
-            });
-            duplicate_top_level
-                || (!self.probe_skip_enclosing_fallback
-                    && deferred
-                        .iter()
-                        .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text)))
+            deferred
+                .iter()
+                .any(|db| db.is_method && !seen.insert(db.scope_name.as_str()))
         };
-        if structural_fallback {
+        let enclosing_fallback = !self.probe_skip_enclosing_fallback
+            && deferred
+                .iter()
+                .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text));
+        if duplicate_method || enclosing_fallback {
             return self.fresh_full_analyse(source, dialect);
         }
+        // **Proc duplicates take the fast path.**  A whole-file walk's
+        // `all_variables` for a duplicated proc is the *union* of every
+        // definition's locals, with last-definition-wins for keys shared across
+        // definitions (`define_var` overwrites on each redefinition).  The graft
+        // reproduces that with overwrite-on-collision for body-owned keys, while
+        // *param* keys keep the shell's real definition (it recorded them in pass
+        // 1, last-def-wins): the `shell_var_keys` snapshot distinguishes the two.
+        // (For a non-duplicate proc every local key is unique, so this is a plain
+        // insert — byte-identical to before.)  A body contributing *colliding*
+        // class facts (accumulation) still falls back — see `class_facts_collide`.
+        let shell_var_keys: std::collections::HashSet<String> =
+            self.result.all_variables.keys().cloned().collect();
         // Track every defined proc qualified name (top-level + nested) so a body
         // that redefines an already-defined proc forces a fallback.
         let mut defined_procs: std::collections::HashSet<String> =
@@ -207,6 +223,12 @@ impl Analyser {
                 self.last_comment = String::new();
                 let before_classes = body_word_defines(&db.body_text, CLASS_DEFINERS)
                     .then(|| self.result.all_classes.clone());
+                // Object-instance tracking (W308) resolves the class against
+                // `all_classes` *at the walk point*; a method body filled in pass
+                // 2 sees the whole file's classes, not analyse's DFS prefix, so its
+                // `instance_classes` contribution can diverge.  Snapshot it and
+                // fall back on any change (most method bodies create no objects).
+                let before_instances = self.result.instance_classes.clone();
                 let before_procs = body_word_defines(&db.body_text, &["proc"])
                     .then(|| self.result.all_procs.clone());
                 self.analyse_body(&db.body_text, db.body_tok, &db.scope_path);
@@ -219,6 +241,11 @@ impl Analyser {
                         .iter()
                         .any(|(k, v)| before.get(k) != Some(v))
                 {
+                    return self.fresh_full_analyse(source, dialect);
+                }
+                // A method whose instance tracking changed (added or re-tracked)
+                // can't be guaranteed to match the DFS-ordered walk — fall back.
+                if self.result.instance_classes != before_instances {
                     return self.fresh_full_analyse(source, dialect);
                 }
                 // A method that (re)defines a proc whose name is defined
@@ -247,7 +274,17 @@ impl Analyser {
                 {
                     return self.fresh_full_analyse(source, dialect);
                 }
-                self.graft_proc_body(db, frag);
+                // A body that defines/extends a class whose `all_classes` entry
+                // **collides** with one already present (a *different* value)
+                // can't be reproduced by the graft's overwrite-on-key: a
+                // whole-file walk *accumulates* there (`oo::define` adds methods to
+                // the existing class).  A fresh (non-colliding) class definition
+                // stays fast.  (Object-instance tracking is handled separately —
+                // captured in the isolated body and replayed at graft.)
+                if class_facts_collide(&self.result, &frag.result) {
+                    return self.fresh_full_analyse(source, dialect);
+                }
+                self.graft_proc_body(db, frag, &shell_var_keys);
             }
         }
 
@@ -283,7 +320,21 @@ impl Analyser {
     /// merge-or-inserted (an existing key is a param → keep its def span, add the
     /// body's reads; a new key is a body local → insert).  Order is canonicalised
     /// by the tail, so plain `extend` is fine for the rest.
-    fn graft_proc_body(&mut self, db: &DeferredBody, mut frag: BodyFragment) {
+    ///
+    /// `shell_var_keys` holds the `all_variables` keys the shell already owns
+    /// before any body is grafted (params + top-level vars).  A body re-records
+    /// its params, so those keys *merge* (keep the shell's real definition span,
+    /// add the body's references); a key the shell doesn't own is a body local,
+    /// *inserted* (overwrite-on-collision) — so a duplicate proc's locals union
+    /// across definitions with last-definition-wins for shared keys, matching the
+    /// whole-file `define_var`.  (For a non-duplicate proc every local key is
+    /// unique, so insert and merge coincide — byte-identical to before.)
+    fn graft_proc_body(
+        &mut self,
+        db: &DeferredBody,
+        mut frag: BodyFragment,
+        shell_var_keys: &std::collections::HashSet<String>,
+    ) {
         // Rebase: body facts are relative to the body content start.
         let delta = db.body_tok.span.start() + u32::from(db.body_tok.content_offset);
         let line_delta = self
@@ -302,7 +353,27 @@ impl Analyser {
         let r = frag.result;
         self.result.all_procs.extend(r.all_procs);
         self.result.all_classes.extend(r.all_classes);
-        merge_scope_vars(&mut self.result.all_variables, r.all_variables);
+        for (k, v) in r.all_variables {
+            match self.result.all_variables.get_mut(&k) {
+                Some(existing) if shell_var_keys.contains(&k) => {
+                    // Param / top-level key the shell already owns: take this
+                    // body's references / warn / indices (last-definition-wins for
+                    // a duplicate proc — analyse's `define_var` resets them on each
+                    // redefinition) but keep the shell's real definition span.
+                    let def = existing.definition_span;
+                    *existing = v;
+                    existing.definition_span = def;
+                }
+                Some(existing) => {
+                    // Body-owned local already present (an earlier duplicate
+                    // definition): last-definition-wins.
+                    *existing = v;
+                }
+                None => {
+                    self.result.all_variables.insert(k, v);
+                }
+            }
+        }
         self.result.command_aliases.extend(r.command_aliases);
         self.result.instance_classes.extend(r.instance_classes);
         self.result.diagnostics.extend(r.diagnostics);
@@ -372,6 +443,13 @@ impl Analyser {
             self.pending_w304
                 .push((tok, label, fixes, shift(diag_span, delta)));
         }
+        // Replay captured instance creations against the shell's full
+        // `all_classes` (in body/source order, so last-assignment-wins matches
+        // the whole-file walk).  `instance_classes` carries no spans, so no
+        // rebasing is needed.
+        for (cmd, args) in frag.instances {
+            self.record_instance_creation(&cmd, &args);
+        }
     }
 }
 
@@ -404,6 +482,9 @@ pub struct BodyFragment {
         Vec<super::types::CodeFix>,
         tcl_lexer::Span,
     )>,
+    /// Captured `TclOO` instance-creation candidates (`(command, args)`); the graft
+    /// replays them against the shell's full `all_classes`.
+    instances: Vec<(String, Vec<String>)>,
 }
 
 /// Analyse one `proc` body as an isolated unit at **offset 0** — a pure
@@ -444,6 +525,9 @@ pub fn analyse_proc_body_isolated(
     // Capture qualified (`::`/`static::`) reads that miss the (empty) enclosing
     // global scope, so the graft can replay them on the shell's real globals.
     a.capture_global_reads = Some(Vec::new());
+    // Capture object-instance creations: the isolated body's `all_classes` is
+    // empty, so the class can't be resolved here — the graft replays them.
+    a.pending_instances = Some(Vec::new());
     let proc_path =
         reconstruct_proc_scope(&mut a.result.global_scope, &db.namespace, &db.scope_name);
     let placeholder = tcl_lexer::Span::new(0, 0);
@@ -465,6 +549,7 @@ pub fn analyse_proc_body_isolated(
         global_reads: a.capture_global_reads.unwrap_or_default(),
         disabled_commands: a.pending_disabled_commands,
         w304: a.pending_w304,
+        instances: a.pending_instances.unwrap_or_default(),
     }
 }
 
@@ -477,13 +562,35 @@ fn merge_scope_vars(
     src: std::collections::HashMap<String, super::types::VarDef>,
 ) {
     for (k, v) in src {
-        if let Some(existing) = dst.get_mut(&k) {
-            existing.references.extend(v.references);
-            existing.warn_if_unused |= v.warn_if_unused;
-            existing.array_indices.extend(v.array_indices);
-        } else {
-            dst.insert(k, v);
-        }
+        merge_one_var(dst, k, v);
+    }
+}
+
+/// Would grafting `frag`'s `all_classes` *overwrite* an entry the shell already
+/// holds with a **different** value?  That is the accumulation case a whole-file
+/// walk handles but the graft's overwrite-on-key cannot (`oo::define` adds
+/// methods to an existing class), so the caller falls back.  A *fresh*
+/// (non-colliding) class definition returns `false` and stays on the fast path.
+fn class_facts_collide(shell: &AnalysisResult, frag: &AnalysisResult) -> bool {
+    frag.all_classes
+        .iter()
+        .any(|(k, v)| shell.all_classes.get(k).is_some_and(|e| e != v))
+}
+
+/// Merge one body-derived variable into a map: an existing key keeps its
+/// definition span (the shell's real param span) and accumulates the body's
+/// references / warn flag / array indices; a new key is inserted.
+fn merge_one_var(
+    dst: &mut std::collections::HashMap<String, super::types::VarDef>,
+    k: String,
+    v: super::types::VarDef,
+) {
+    if let Some(existing) = dst.get_mut(&k) {
+        existing.references.extend(v.references);
+        existing.warn_if_unused |= v.warn_if_unused;
+        existing.array_indices.extend(v.array_indices);
+    } else {
+        dst.insert(k, v);
     }
 }
 
@@ -768,12 +875,59 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_top_level_proc_falls_back() {
-        // Platform-conditional redefinition: last-def-wins in a whole-file walk;
-        // the per-item path detects the duplicate and falls back, so equal.
+    fn duplicate_top_level_proc_byte_identical() {
+        // Platform-conditional redefinition: last-def-wins in a whole-file walk.
+        // The per-item path reproduces it on the fast path (the graft unions each
+        // definition's `all_variables` with last-definition-wins on shared keys).
         eq(
             "if {1} {\n  proc p {} { set file a; puts $file }\n} else {\n  proc p {} { return 2 }\n}\n",
         );
+    }
+
+    #[test]
+    fn duplicate_proc_same_local_last_wins() {
+        // Same-named local across two definitions: `all_variables` keeps the last
+        // definition's span + references (not the first, not the union of refs).
+        eq("proc p {} { set a 1 }\nproc p {} { set a 2 }\n");
+        eq("proc p {} { set a 1; incr a }\nproc p {} { set a 2; incr a }\n");
+    }
+
+    #[test]
+    fn duplicate_proc_unique_locals_unioned() {
+        // A local defined only in an earlier definition survives (union), while a
+        // shared local is last-wins — the whole-file `define_var` semantics.
+        eq("proc p {} { set early 1 }\nproc p {} { set late 2 }\n");
+    }
+
+    #[test]
+    fn duplicate_proc_with_params() {
+        // Param references on a duplicate proc are last-definition-wins (the
+        // earlier body's reads are dropped), and the shell's real param span is
+        // kept (not the isolated body's placeholder).
+        eq("proc p {key} { return $key }\nproc p {key} { puts $key }\n");
+    }
+
+    #[test]
+    fn multi_method_class_byte_identical() {
+        // A class with several methods must NOT be treated as a set of mutual
+        // "duplicates" (the empty-scope-name bug) — it takes the fast path.
+        eq("oo::class create K {\n  method a {} { set x 1 }\n  method b {} { set y 2 }\n  method c {x} { return $x }\n}\n");
+    }
+
+    #[test]
+    fn instance_creation_in_proc_body() {
+        // An isolated proc body can't resolve the sibling class; the creation is
+        // captured and replayed at graft so `instance_classes` matches.
+        eq("oo::class create Dog {}\nproc make {} { set d [Dog new] }\n");
+        eq("oo::class create Dog {}\nproc make {} { Dog create rex }\n");
+    }
+
+    #[test]
+    fn class_extension_in_proc_falls_back() {
+        // A proc body that *extends* an existing class (oo::define adds a method)
+        // accumulates across the definition site; the per-item graft can't
+        // reproduce that, so it falls back — and stays byte-identical.
+        eq("oo::class create K { method a {} {} }\nproc ext {} { oo::define K method b {} {} }\next\n");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -94,6 +94,7 @@ impl Analyser {
         use std::collections::HashSet;
         use tcl_registry::CommandRegistry;
 
+        self.took_fast_path = false;
         // Recovery / stub overlays are only modelled on the full `analyse`
         // path; fall back so the per-item result can never diverge.
         if !tcl_lexer::script_is_complete(source) || source.contains("tcl-lsp: stub") {
@@ -182,9 +183,10 @@ impl Analyser {
                 !seen.insert((db.is_method, db.namespace.as_str(), db.scope_name.as_str()))
             });
             duplicate_top_level
-                || deferred
-                    .iter()
-                    .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text))
+                || (!self.probe_skip_enclosing_fallback
+                    && deferred
+                        .iter()
+                        .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text)))
         };
         if structural_fallback {
             return self.fresh_full_analyse(source, dialect);
@@ -252,6 +254,24 @@ impl Analyser {
         // --- tail (cross-item passes; canonicalises order) ---
         self.run_diagnostic_emitters(source);
 
+        // Correctness backstop (mirrors `analyse_incremental`): a syntax error
+        // (`E…` diagnostic) means `analyse` engaged its error-*recovery* machinery
+        // (ghost-token re-lexing, recovery segmentation, body-level partial
+        // detection) that the per-item walk only partially reproduces — a
+        // locally-unbalanced `}` that `script_is_complete` still accepts is the
+        // classic case.  Re-analyse fully so the result is byte-identical to a
+        // from-scratch `analyse`.  Well-formed edits (the common case) carry no
+        // E-codes and stay on the fast path.
+        if self
+            .result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.starts_with('E'))
+        {
+            return self.fresh_full_analyse(source, dialect);
+        }
+
+        self.took_fast_path = true;
         let result = std::mem::take(&mut self.result);
         self.clear_run_state();
         result
@@ -313,8 +333,44 @@ impl Analyser {
         // Replay the body's qualified global reads against the shell's real
         // global scope (rebased to the body's position): a `$::g` read lands as
         // a reference on the enclosing `::g` exactly as a whole-file walk would.
+        // Replay each captured qualified read on the shell's real globals — but
+        // only when the enclosing definition **precedes this body** in source
+        // order.  A whole-file DFS walks a proc body at the proc's definition
+        // point, so a top-level `set ::ns::v` that appears *after* the proc is
+        // not yet defined when the body's `$::ns::v` read runs (no reference
+        // recorded).  The per-item shell processes every top-level `set` before
+        // any deferred body, so without this guard a later definition would
+        // spuriously absorb the read.  Gate on the body token start (the proc
+        // header precedes it, and no top-level command can fall inside the body).
+        let body_start = db.body_tok.span.start();
         for (name, span) in frag.global_reads {
-            self.record_var_read(&name, shift(span, delta), &[]);
+            let base = crate::naming::normalise_var_name(&name);
+            let visible = self
+                .result
+                .global_scope
+                .variables
+                .get(base)
+                .is_some_and(|v| v.definition_span.start() < body_start);
+            if visible {
+                self.record_var_read(&name, shift(span, delta), &[]);
+            }
+        }
+        // Re-defer the body's would-be-W002 sites with rebased spans; the tail
+        // re-applies the shadow check against the merged `all_procs`.
+        for (qname, mut diag) in frag.disabled_commands {
+            diag.span = shift(diag.span, delta);
+            self.pending_disabled_commands.push((qname, diag));
+        }
+        // Re-defer the body's source-dependent W304 sites, rebasing the token,
+        // fix, and diagnostic spans to absolute; the tail classifies each `$var`
+        // against the full file source.
+        for (mut tok, label, mut fixes, diag_span) in frag.w304 {
+            tok.span = shift(tok.span, delta);
+            for fix in &mut fixes {
+                fix.span = shift(fix.span, delta);
+            }
+            self.pending_w304
+                .push((tok, label, fixes, shift(diag_span, delta)));
         }
     }
 }
@@ -332,6 +388,22 @@ pub struct BodyFragment {
     /// Qualified (`::`/`static::`) reads that missed the isolated body's empty
     /// enclosing global scope; replayed on the shell's real globals at graft.
     global_reads: Vec<(String, tcl_lexer::Span)>,
+    /// W002 (disabled-in-dialect command) sites whose user-proc-shadowing
+    /// suppression depends on the file's full `all_procs` (a cross-item fact the
+    /// isolated body lacks): `(qualified call name, deferred diagnostic)`.  The
+    /// graft rebases the diagnostic span and re-defers it; the tail re-checks the
+    /// shadow against the merged `all_procs`.
+    disabled_commands: Vec<(String, super::types::Diagnostic)>,
+    /// Deferred W304 (missing `--`) sites whose `$var` classification needs the
+    /// whole-file most-recent-`set` resolution (invisible to an isolated body).
+    /// The graft rebases the token + fix + diagnostic spans; the tail classifies
+    /// them against the full source.
+    w304: Vec<(
+        tcl_lexer::Token,
+        String,
+        Vec<super::types::CodeFix>,
+        tcl_lexer::Span,
+    )>,
 }
 
 /// Analyse one `proc` body as an isolated unit at **offset 0** — a pure
@@ -391,6 +463,8 @@ pub fn analyse_proc_body_isolated(
         var_sites: a.var_command_sites,
         cmd_sites: a.cmd_command_sites,
         global_reads: a.capture_global_reads.unwrap_or_default(),
+        disabled_commands: a.pending_disabled_commands,
+        w304: a.pending_w304,
     }
 }
 
@@ -586,39 +660,42 @@ fn body_word_defines(body_text: &str, words: &[&str]) -> bool {
         .any(|w| words.contains(&w))
 }
 
-/// Does an isolated proc body interact with enclosing-scope / object state in a
-/// way the per-item graft can't reproduce byte-for-byte, forcing a full-rebuild
-/// fallback?  True when the body:
+/// Does an isolated proc body interact with enclosing-scope state in a way the
+/// per-item graft can't reproduce byte-for-byte, forcing a full-rebuild
+/// fallback?  True when the body declares a link to a **qualified (sub-namespace)
+/// variable** — a `variable ns::name` command inside the body.
 ///
-/// * **defines or extends a class / aliased object** (`oo::class` / `oo::define`
-///   / `itcl::class` / `oo::copy`) — class facts accumulate across bodies in a
-///   whole-file walk (remove → add → re-insert), which the graft's
-///   overwrite-on-key can't reproduce; **or**
-/// * **declares or writes an enclosing-scope variable** (`variable` / `global` /
-///   `upvar` / `namespace`, or a writer command — `set`/`incr`/`lappend`/
-///   `append`/`dict`/`array` — targeting a `::`-qualified name).  Such a body's
-///   `all_variables` / global-scope effect (definition span, `warn_if_unused`,
-///   const-string-dependent diagnostics like W304) depends on enclosing context
-///   the isolated analysis can't see.
+/// Such a name resolves to a variable owned by *another* item (the
+/// `namespace eval ns { variable name … }` body), so its `all_variables` entry
+/// accumulates a definition from both this body and that namespace block.  The
+/// order-sensitive facts of the merged entry — `warn_if_unused` and the winning
+/// `definition_span` — depend on the cross-item walk order, which the whole-file
+/// DFS and the per-item shell-first walk disagree on; the graft's
+/// position-independent merge can't reproduce the DFS result.  (The visible
+/// *diagnostics* already match; only this internal book-keeping diverges, but the
+/// correctness contract is full-`AnalysisResult` byte-identity.)
 ///
-/// Qualified variable *reads* (`$::g`) are **not** listed: they are captured and
-/// replayed on the shell's globals at graft time, so they stay on the fast path.
-/// Conservative — a false positive only costs a full rebuild, never correctness.
+/// Everything else an enclosing-touching body does is reproduced on the fast
+/// path and proven byte-identical over the corpus: `global` / `upvar` / plain
+/// `variable x` declarations, qualified writes (`set ::x`), class definitions
+/// (`oo::class` / `oo::define`), and qualified reads (`$::g`, captured and
+/// replayed at graft).  Backstopped by the differential `incremental == fresh`
+/// fuzzer + this fallback — a false positive costs only a redundant rebuild.
+///
+/// Line-scoped so it doesn't trip on a plain `variable x` whose body merely also
+/// mentions a `::`-qualified name elsewhere (which would needlessly defeat the
+/// fast path on large files like `practcl.tcl`).
 fn body_needs_enclosing_context(body_text: &str) -> bool {
-    const DECLARERS: &[&str] = &["variable", "global", "upvar", "namespace"];
-    const WRITERS: &[&str] = &["set", "incr", "lappend", "append", "dict", "array"];
-    let words: Vec<&str> = body_text
-        .split(|c: char| !(c.is_alphanumeric() || c == ':' || c == '_'))
-        .filter(|w| !w.is_empty())
-        .collect();
-    for (i, &w) in words.iter().enumerate() {
-        if DECLARERS.contains(&w) || CLASS_DEFINERS.contains(&w) {
-            return true;
-        }
-        // A writer whose next word or two is a `::`-qualified target writes an
-        // enclosing-scope variable.
-        if WRITERS.contains(&w) && words[i + 1..].iter().take(2).any(|t| t.contains("::")) {
-            return true;
+    for line in body_text.lines() {
+        let mut words = line.split_whitespace();
+        while let Some(w) = words.next() {
+            // A `variable` command (anywhere on the line) with a `::`-qualified
+            // argument links to a sub-namespace variable.  Checking the rest of
+            // the line is deliberately conservative (it may include a following
+            // `;`-separated command), which only over-triggers the fallback.
+            if w == "variable" && words.clone().any(|a| a.contains("::")) {
+                return true;
+            }
         }
     }
     false

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -283,6 +283,18 @@ pub struct Analyser {
     /// fallbacks (recovery, duplicate definitions) still fire.  Defaults to
     /// `false`; production paths are unaffected.
     pub probe_skip_enclosing_fallback: bool,
+    /// Deferred `TclOO` instance-creation candidates (`set v [Cls new]` /
+    /// `Cls create v`) captured by an isolated proc body, which has an *empty*
+    /// `all_classes` and so can't resolve the (sibling) class.  Each is the raw
+    /// `(command, args)`; [`Self::graft_proc_body`] replays
+    /// `record_instance_creation` against the shell's full `all_classes` so the
+    /// `instance_classes` map matches a whole-file walk.  `None` on the whole-file
+    /// path (instances resolve inline).
+    pub(super) pending_instances: Option<Vec<(String, Vec<String>)>>,
+    /// **Experimental probe flag.**  When `true`, the per-item path does *not*
+    /// take the duplicate-definition fallback, to measure the residual
+    /// divergence the duplicate fast-path must still close.  Defaults to `false`.
+    pub probe_skip_duplicate_fallback: bool,
     /// **Probe telemetry.**  Set by [`Self::analyse_per_item_with`] to `true`
     /// when the run completed on the incremental per-item path and `false` when
     /// it fell back to a full rebuild.  Read by perf/coverage probes; ignored by
@@ -376,7 +388,9 @@ impl Analyser {
             capture_global_reads: None,
             pending_disabled_commands: Vec::new(),
             pending_w304: Vec::new(),
+            pending_instances: None,
             probe_skip_enclosing_fallback: false,
+            probe_skip_duplicate_fallback: false,
             took_fast_path: false,
         }
     }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -248,6 +248,46 @@ pub struct Analyser {
     /// def — one of the divergences the per-item path must reproduce.  `None` on
     /// the whole-file `analyse` path (reads resolve against the populated scope).
     pub(super) capture_global_reads: Option<Vec<(String, tcl_lexer::Span)>>,
+    /// Deferred W002 (disabled-in-dialect command) diagnostics whose
+    /// user-proc-shadowing suppression is a **cross-item** fact (the file's full
+    /// `all_procs`).  On the per-item path an isolated body has only its own
+    /// procs, so a would-be-W002 site that the body can't prove shadowed is
+    /// captured here (qualified call name + the built diagnostic) instead of
+    /// emitted; [`Self::graft_proc_body`] rebases the span and
+    /// [`Self::flush_disabled_command_diagnostics`] re-applies the shadow check
+    /// against the merged `all_procs` in the tail.  Empty on the whole-file
+    /// `analyse` path (W002 is emitted inline there), so the tail flush is a
+    /// no-op — byte-identical.
+    pub(super) pending_disabled_commands: Vec<(String, super::types::Diagnostic)>,
+    /// Deferred W304 (missing `--` option terminator) diagnostics whose
+    /// severity/message depend on resolving a `$var` against the **most recent
+    /// literal `set` in the whole file** ([`last_literal_set_value_for_var`],
+    /// which scans `self.source`).  An isolated body's `self.source` is only the
+    /// body, so an enclosing-scope `set` is invisible — the lone source-dependent
+    /// W304 branch (`Var`, dynamic, not option-looking).  On the per-item path
+    /// such sites are captured here (rebased token + label + body-local fix /
+    /// span) instead of emitted, and [`Self::flush_w304_diagnostics`] classifies
+    /// them in the tail where `self.source` is the full file.  Empty on the
+    /// whole-file path (emitted inline) — byte-identical.
+    pub(super) pending_w304: Vec<(
+        tcl_lexer::Token,
+        String,
+        Vec<super::types::CodeFix>,
+        tcl_lexer::Span,
+    )>,
+    /// **Experimental probe flag.**  When `true`, the per-item path does *not*
+    /// take the `body_needs_enclosing_context` fallback (bodies that declare /
+    /// write enclosing-scope variables or define classes).  Used by the
+    /// `per_item_divergence` probe to surface exactly what still diverges so the
+    /// fast path can be widened to cover them.  The genuine correctness
+    /// fallbacks (recovery, duplicate definitions) still fire.  Defaults to
+    /// `false`; production paths are unaffected.
+    pub probe_skip_enclosing_fallback: bool,
+    /// **Probe telemetry.**  Set by [`Self::analyse_per_item_with`] to `true`
+    /// when the run completed on the incremental per-item path and `false` when
+    /// it fell back to a full rebuild.  Read by perf/coverage probes; ignored by
+    /// production callers (which only consume the returned `AnalysisResult`).
+    pub took_fast_path: bool,
 }
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
@@ -334,6 +374,10 @@ impl Analyser {
             deferred_bodies: Vec::new(),
             cu_override: None,
             capture_global_reads: None,
+            pending_disabled_commands: Vec::new(),
+            pending_w304: Vec::new(),
+            probe_skip_enclosing_fallback: false,
+            took_fast_path: false,
         }
     }
 
@@ -1117,6 +1161,8 @@ impl Analyser {
             diag_registry.load_dialect(d);
         }
         self.emit_unresolved_command_diagnostics(&diag_registry);
+        self.flush_disabled_command_diagnostics();
+        self.flush_w304_diagnostics();
         self.flush_arity_diagnostics();
         self.emit_missing_package_require_diagnostics(&diag_registry);
         self.emit_variable_usage_diagnostics();

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -206,7 +206,12 @@ impl FunctionUnit {
 /// Complete compilation artefacts for a source document.
 ///
 /// Built once, consumed many times across the diagnostics cycle.
-#[derive(Debug, Clone)]
+///
+/// `PartialEq` enables the salsa-native [`compilation_unit`] query (in
+/// `tcl-lsp-db`) to return `Arc<CompilationUnit>` — both diagnostics consumers
+/// share one build per edit — using salsa's equality-backed memoisation, exactly
+/// as `FunctionUnit` does for [`function_lattice`].
+#[derive(Debug, Clone, PartialEq)]
 pub struct CompilationUnit {
     /// Source text (kept so downstream passes that need raw
     /// lexing can re-scan ranges without reparsing).

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -285,16 +285,31 @@ pub fn run_all_checks(
         }
     }
 
-    // iRules-dialect non-taint checks.  Each of these is dialect-
-    // gated inside the helper (returns empty for non-iRules
-    // dialects), so calling them unconditionally is correct.
+    // iRules-dialect non-taint (module-level / control-flow) checks.
+    push_irules_flow_checks(cu, registry, dialect, &mut out);
+
+    // Deterministic ordering (producers emit in `HashMap`-iteration order);
+    // see [`sort_diagnostics`].
+    sort_diagnostics(&mut out);
+
+    out
+}
+
+/// Append the iRules-dialect module-level checks (IRULE5002/5004 +
+/// IRULE1005-1008/1201/1202/4004 + the unnormalised-getter warning).
+///
+/// Each helper is dialect-gated internally (returns empty for non-iRules
+/// dialects), so calling them unconditionally is correct.  Split out of
+/// [`run_all_checks`] to keep that aggregator within the line budget.
+fn push_irules_flow_checks(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+    dialect: Option<&str>,
+    out: &mut Vec<Diagnostic>,
+) {
     for w in find_unnormalised_getter_warnings(cu, registry, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
-    // C44-irules-flow: control-flow checks (IRULE5002/5004 +
-    // IRULE1005-1008/1201/1202/4004).  Without these the helpers
-    // landed but never reached users via `run_all_checks` /
-    // LSP flows; addresses Codex review on PR #389.
     for w in find_unguarded_drop_warnings(cu, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
@@ -307,8 +322,35 @@ pub fn run_all_checks(
     for w in find_hoistable_set_warnings(cu, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
+}
 
-    out
+/// Impose a deterministic total order on diagnostics.
+///
+/// See [`run_all_checks`] — the per-pass producers emit in `HashMap`-iteration
+/// order, so a stable sort on `(span, code, category, severity, message,
+/// replacement)` is what makes the output byte-identical between the memoised
+/// per-procedure build and the whole-module build.
+fn sort_diagnostics(out: &mut [Diagnostic]) {
+    out.sort_by(|a, b| {
+        (
+            a.span.start(),
+            a.span.end(),
+            &a.code,
+            &a.category,
+            a.severity.as_str(),
+            &a.message,
+            &a.replacement,
+        )
+            .cmp(&(
+                b.span.start(),
+                b.span.end(),
+                &b.code,
+                &b.category,
+                b.severity.as_str(),
+                &b.message,
+                &b.replacement,
+            ))
+    });
 }
 
 #[cfg(test)]

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -75,7 +75,61 @@ pub fn optimise_unit(
     let mut ctx = PassContext::with_dialect(&cu.source, ia, dialect);
     ctx.registry = Some(registry);
     run_passes(&mut ctx, cu, &PassId::all());
-    select_non_overlapping(&ctx.optimisations)
+
+    // Determinism chokepoint.  Several passes iterate `HashMap`s
+    // (`cu.procedures`, def-use chains, SSA blocks), so both the emission order
+    // and the monotonic group ids vary run-to-run — and, critically, between the
+    // offset-0 per-procedure memo build and the whole-module build.  Canonicalise
+    // before overlap arbitration so the surviving set, its order, and group
+    // numbering are byte-identical given an equal `CompilationUnit` (the
+    // `compiler_check_corpus` guard's contract, and the precondition for salsa
+    // early-cutoff on [`compiler_check_diagnostics`]).
+    ctx.optimisations.sort_by(|a, b| {
+        (
+            a.span.start(),
+            a.span.end(),
+            &a.code,
+            &a.message,
+            &a.replacement,
+            a.hint_only,
+        )
+            .cmp(&(
+                b.span.start(),
+                b.span.end(),
+                &b.code,
+                &b.message,
+                &b.replacement,
+                b.hint_only,
+            ))
+    });
+    let mut selected = select_non_overlapping(&ctx.optimisations);
+    renumber_groups(&mut selected);
+    selected
+}
+
+/// Canonicalise group ids in-place to `0, 1, 2, …` by order of first appearance.
+///
+/// Group ids are allocated by a monotonic counter during pass execution, so
+/// their absolute values depend on the (`HashMap`-iteration) order in which
+/// grouped rewrites were emitted.  Only the *partition* they encode is
+/// semantically meaningful (members of one group apply all-or-nothing), so
+/// remapping each distinct id to a first-appearance index makes the values
+/// deterministic while preserving the partition.  `opts` is assumed already in
+/// canonical order.
+fn renumber_groups(opts: &mut [Optimisation]) {
+    use std::collections::HashMap;
+    let mut remap: HashMap<u32, u32> = HashMap::new();
+    let mut next = 0u32;
+    for o in opts.iter_mut() {
+        if let Some(g) = o.group {
+            let new = *remap.entry(g).or_insert_with(|| {
+                let v = next;
+                next += 1;
+                v
+            });
+            o.group = Some(new);
+        }
+    }
 }
 
 /// Build, run every pass, and return the full *unfiltered*

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -261,12 +261,25 @@ fn run_store_to_load_forwarding(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
         has_dynamic_trace,
         rewritten: &rewritten,
     };
-    let pending: Vec<(Optimisation, Optimisation)> = fu
+    let mut pending: Vec<(Optimisation, Optimisation)> = fu
         .def_use
         .chains
         .values()
         .filter_map(|chain| forward_candidate(&env, chain))
         .collect();
+    // `def_use.chains` is a `HashMap`, so the candidate order — and hence the
+    // monotonic group ids allocated below — would vary run-to-run (and between
+    // the offset-0 memo build and the whole-module build).  Sort on the edit
+    // spans so emission order, group numbering, and the final Vec are
+    // byte-identical regardless of map iteration order.
+    pending.sort_by_key(|(inline, delete)| {
+        (
+            inline.span.start(),
+            inline.span.end(),
+            delete.span.start(),
+            delete.span.end(),
+        )
+    });
 
     // Emit, allocating a shared group id per inline/delete pair so the
     // two edits apply all-or-nothing.

--- a/rust/tcl-compiler/src/shimmer/span.rs
+++ b/rust/tcl-compiler/src/shimmer/span.rs
@@ -45,21 +45,27 @@ pub fn def_range_map(ssa: &SsaFunction) -> HashMap<ValueKey, Span> {
 /// 3. A zero span `{ start: 0, end: 0 }`.
 #[must_use]
 pub(crate) fn phi_span(phi: &Phi, ssa: &SsaFunction, def_map: &HashMap<ValueKey, Span>) -> Span {
-    // Try each incoming version.
-    for &ver in phi.incoming.values() {
-        if let Some(&sp) = def_map.get(&(phi.name.clone(), ver)) {
-            return sp;
-        }
+    // `phi.incoming` is a `HashMap`, so a "first match in iteration order" pick
+    // would make the warning's anchor vary run-to-run (and between the offset-0
+    // memo build and the whole-module build — the latent nondeterminism the
+    // `compiler_check_corpus` guard catches).  Choose deterministically: the
+    // earliest (smallest) incoming def span.
+    let earliest = phi
+        .incoming
+        .values()
+        .filter_map(|&ver| def_map.get(&(phi.name.clone(), ver)).copied())
+        .min_by_key(|sp| (sp.start(), sp.end()));
+    if let Some(sp) = earliest {
+        return sp;
     }
 
-    // Fallback: first statement in any block.
-    for block in ssa.blocks.values() {
-        if let Some(ss) = block.statements.first() {
-            return ss.statement.span();
-        }
-    }
-
-    Span::new(0, 0)
+    // Fallback: the earliest first-statement span across blocks (`ssa.blocks` is
+    // also a `HashMap`, so likewise pick deterministically).
+    ssa.blocks
+        .values()
+        .filter_map(|block| block.statements.first().map(|ss| ss.statement.span()))
+        .min_by_key(|sp| (sp.start(), sp.end()))
+        .unwrap_or_else(|| Span::new(0, 0))
 }
 
 #[cfg(test)]

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -1185,14 +1185,24 @@ pub(crate) fn find_destructive_file_warnings(
                 path_start += 1;
             }
             // One W313 per statement (first offending path variable).
-            for (name, &ver) in &ssa_stmt.uses {
-                let in_path = args
-                    .iter()
-                    .skip(path_start)
-                    .any(|a| arg_var_names(a).contains(name));
-                if !in_path {
-                    continue;
+            // Collect candidate path variables in argument (source) order:
+            // `ssa_stmt.uses` is a `HashMap`, so iterating it would pick a
+            // nondeterministic variable for a multi-path sink like
+            // `file rename $a $b` — making the warning's message (and the memo
+            // vs whole-module builds) differ run-to-run.
+            let mut seen: HashSet<String> = HashSet::new();
+            let mut ordered: Vec<String> = Vec::new();
+            for a in args.iter().skip(path_start) {
+                for name in arg_var_names_ordered(a) {
+                    if seen.insert(name.clone()) {
+                        ordered.push(name);
+                    }
                 }
+            }
+            for name in &ordered {
+                let Some(&ver) = ssa_stmt.uses.get(name) else {
+                    continue;
+                };
                 let t = taints
                     .get(&(name.clone(), ver))
                     .copied()
@@ -1249,7 +1259,15 @@ fn destructive_file_subs(registry: &CommandRegistry) -> HashSet<&'static str> {
 /// A lightweight stand-in for `_arg_var_names`'s VAR-token scan covering
 /// the path-argument shapes W313 cares about (`$p`, `${p}`, `"$d/$f"`).
 fn arg_var_names(arg: &str) -> HashSet<String> {
-    let mut names = HashSet::new();
+    arg_var_names_ordered(arg).into_iter().collect()
+}
+
+/// Variable names referenced in `arg`, in left-to-right source order with
+/// duplicates preserved.  Callers that need a deterministic *first* variable
+/// (e.g. W313's "first offending path variable") iterate this rather than the
+/// `HashSet` from [`arg_var_names`], whose order is nondeterministic.
+fn arg_var_names_ordered(arg: &str) -> Vec<String> {
+    let mut names = Vec::new();
     let bytes = arg.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -1260,7 +1278,7 @@ fn arg_var_names(arg: &str) -> HashSet<String> {
         if bytes.get(i + 1) == Some(&b'{')
             && let Some(rel) = arg[i + 2..].find('}')
         {
-            names.insert(normalise_var_name(&arg[i + 2..i + 2 + rel]).to_owned());
+            names.push(normalise_var_name(&arg[i + 2..i + 2 + rel]).to_owned());
             i = i + 2 + rel + 1;
             continue;
         }
@@ -1272,7 +1290,7 @@ fn arg_var_names(arg: &str) -> HashSet<String> {
             j += 1;
         }
         if j > start {
-            names.insert(normalise_var_name(&arg[start..j]).to_owned());
+            names.push(normalise_var_name(&arg[start..j]).to_owned());
             i = j;
         } else {
             i += 1;

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -390,7 +390,7 @@ pub fn propagate_types(
 
             // Phi nodes at non-entry blocks.
             if bn != &cfg.entry {
-                let exec_preds: Vec<&str> = preds
+                let mut exec_preds: Vec<&str> = preds
                     .get(bn)
                     .map(|ps| {
                         ps.iter()
@@ -402,6 +402,12 @@ pub fn propagate_types(
                             .collect()
                     })
                     .unwrap_or_default();
+                // `predecessors()` yields a `HashSet`, so the fold order below is
+                // nondeterministic — and `type_join` is *not* order-independent
+                // for a 3+-way shimmer merge (it records only a `(from, to)`
+                // pair), so an unsorted fold makes the S101 message name
+                // different types run-to-run.  Sort for a stable join order.
+                exec_preds.sort_unstable();
 
                 for phi in &ssa_block.phis {
                     if exec_preds.is_empty() {

--- a/rust/tcl-compiler/tests/per_item_corpus.rs
+++ b/rust/tcl-compiler/tests/per_item_corpus.rs
@@ -95,3 +95,176 @@ fn per_item_matches_analyse_over_corpus() {
         "slice-2b gate: {checked} files, analyse_per_item == analyse ({fellback} trivially-fellback)"
     );
 }
+
+// Tiny deterministic xorshift PRNG so failures reproduce from the seed.
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn upto(&mut self, n: usize) -> usize {
+        if n == 0 {
+            0
+        } else {
+            #[allow(clippy::cast_possible_truncation)]
+            let bounded = (self.next() % n as u64) as usize;
+            bounded
+        }
+    }
+}
+
+/// Apply one random edit, keeping `text` valid UTF-8 (edit on char boundaries).
+fn random_edit(text: &str, rng: &mut Rng) -> String {
+    let bounds: Vec<usize> = text
+        .char_indices()
+        .map(|(i, _)| i)
+        .chain([text.len()])
+        .collect();
+    if bounds.len() < 2 {
+        return format!("{text}\nset x 1\n");
+    }
+    let pick = |rng: &mut Rng| bounds[rng.upto(bounds.len())];
+    match rng.upto(3) {
+        0 => {
+            let at = pick(rng);
+            let snips = [
+                "\nset y 2\n",
+                " ",
+                "# c\n",
+                "puts $z",
+                "}\nproc q {} {",
+                "[",
+                "$a",
+                "\nvariable ns::v\n",
+                "\nset ::g 1\n",
+                "\nglobal g\n",
+            ];
+            let s = snips[rng.upto(snips.len())];
+            format!("{}{}{}", &text[..at], s, &text[at..])
+        }
+        1 => {
+            let a = pick(rng);
+            let b = pick(rng);
+            let (lo, hi) = (a.min(b), a.max(b));
+            let hi = (lo + (hi - lo).min(12)).min(text.len());
+            let hi = bounds
+                .iter()
+                .copied()
+                .find(|&x| x >= hi)
+                .unwrap_or(text.len());
+            format!("{}{}", &text[..lo], &text[hi..])
+        }
+        _ => {
+            let a = pick(rng);
+            let b = pick(rng);
+            let (lo, hi) = (a.min(b), a.max(b));
+            format!("{}{}{}", &text[..lo], "X", &text[hi..])
+        }
+    }
+}
+
+/// Edit-based per-item gate: `analyse_per_item` must equal `analyse`
+/// byte-for-byte after *every* random edit (not just on the pristine corpus).
+/// This is the `incremental == fresh` contract for the per-item walk — the
+/// permanent backstop for the widened enclosing-context fast path, which the
+/// existing `differential_incremental` fuzzer does not cover (it exercises the
+/// older `analyse_commands`-based `analyse_incremental`).  `analyse_per_item`
+/// falls back to a full rebuild whenever it can't prove equivalence, so the
+/// equality must hold unconditionally; a fast-path divergence is a real bug.
+#[test]
+#[ignore = "corpus fuzz; run explicitly with --ignored (needs tmp/ trees)"]
+fn per_item_matches_analyse_under_edits() {
+    let dialect = "tcl8.6";
+    let mut files = Vec::new();
+    for v in [
+        "tcl8.4.20/library",
+        "tcl8.5.19/library",
+        "tcl8.6.16/library",
+        "tcl9.0.3/library",
+        "tcllib-2.0/modules",
+    ] {
+        gather(&repo_root().join("tmp").join(v), &mut files, 1500);
+    }
+
+    // Random edits can produce malformed transient inputs that make the
+    // *reference* `analyse` itself panic (e.g. a non-char-boundary slice deep in
+    // the expr lexer) — a pre-existing analyser-robustness concern orthogonal to
+    // the incremental contract.  Silence the default panic hook so those
+    // expected, caught panics don't spam the test log.
+    std::panic::set_hook(Box::new(|_| {}));
+    let run = |src: &str| {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Analyser::new().analyse(src, dialect)
+        }))
+        .ok()
+    };
+    let run_pi = |src: &str| {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Analyser::new().analyse_per_item(src, dialect)
+        }))
+        .ok()
+    };
+
+    let mut checked = 0usize;
+    let mut steps = 0usize;
+    let mut mismatches: Vec<String> = Vec::new();
+    'files: for path in &files {
+        let Ok(orig) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if orig.is_empty() || orig.len() > 200_000 {
+            continue;
+        }
+        checked += 1;
+        // A few independent edit sequences per file (different seeds).
+        for seed in [0x9E37_79B9_7F4A_7C15u64, 0xD1B5_4A32_D192_ED03] {
+            let mut rng = Rng(seed ^ (orig.len() as u64).wrapping_mul(0x1000_0001B3));
+            let mut text = orig.clone();
+            for _ in 0..16 {
+                text = random_edit(&text, &mut rng);
+                if text.len() > 400_000 {
+                    break;
+                }
+                let want = run(&text);
+                let got = run_pi(&text);
+                steps += 1;
+                // If the reference panics on this malformed transient, there is
+                // nothing to compare — but `analyse_per_item` must not diverge
+                // (it either matches, or also panics by falling back to the same
+                // `analyse`).  A one-sided panic, or differing results, is a bug.
+                let bad = match (&want, &got) {
+                    (Some(w), Some(g)) => w != g,
+                    (None, None) => false,
+                    _ => true,
+                };
+                if bad {
+                    let name = path.file_name().unwrap().to_string_lossy();
+                    let kind = match (&want, &got) {
+                        (Some(_), None) => "per_item panicked, analyse ok",
+                        (None, Some(_)) => "analyse panicked, per_item ok",
+                        _ => "result mismatch",
+                    };
+                    mismatches.push(format!("{name} (seed {seed:#x}): {kind}"));
+                    if mismatches.len() >= 25 {
+                        break 'files;
+                    }
+                    break; // next seed/file
+                }
+            }
+        }
+    }
+    let _ = std::panic::take_hook();
+
+    assert!(
+        mismatches.is_empty(),
+        "analyse_per_item != analyse after edit in {} cases ({checked} files, {steps} steps):\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+    eprintln!("per-item edit gate: {checked} files, {steps} edited states, all byte-identical");
+}

--- a/rust/tcl-lsp-db/examples/cc_diff.rs
+++ b/rust/tcl-lsp-db/examples/cc_diff.rs
@@ -1,0 +1,53 @@
+//! Repro for the pre-existing `function_lattice` memo divergence: dumps the
+//! per-file difference between the memoised `compiler_check_diagnostics` and a
+//! fresh whole-module `compiler_check_diagnostics_uncached` build (checks +
+//! optimisations).  Usage:
+//! `FILE=tmp/tcl8.6.16/library/safe.tcl cargo run -p tcl-lsp-db --example cc_diff`.
+//! See `docs/design/rust/incremental-analysis.md` and the `compiler_check_corpus`
+//! known-failing guard.
+
+use std::collections::BTreeSet;
+
+use tcl_lsp_db::{
+    SourceFile, TclDatabase, TclDb, compiler_check_diagnostics, compiler_check_diagnostics_uncached,
+};
+
+fn main() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let rel = std::env::var("FILE").expect("set FILE (relative to repo root)");
+    let dialect = std::env::var("DIALECT").unwrap_or_else(|_| "tcl8.6".to_owned());
+    let src = std::fs::read_to_string(root.join(&rel)).expect("read FILE");
+
+    let db = TclDatabase::default();
+    let file = SourceFile::new(&db, src.clone(), dialect.clone());
+    let memo = compiler_check_diagnostics(&db, file);
+    let reg = db.registry(&dialect);
+    let fresh = compiler_check_diagnostics_uncached(&src, &reg, &dialect);
+
+    let ck = |d: &tcl_compiler::compiler_checks::Diagnostic| {
+        (d.span.start(), d.span.end(), d.code.clone())
+    };
+    let ms: BTreeSet<_> = memo.checks.iter().map(ck).collect();
+    let fs: BTreeSet<_> = fresh.checks.iter().map(ck).collect();
+    println!(
+        "CHECKS: {} memo-only, {} fresh-only",
+        ms.difference(&fs).count(),
+        fs.difference(&ms).count()
+    );
+    for k in ms.difference(&fs).take(6) {
+        println!("  memo-only  {k:?}");
+    }
+    for k in fs.difference(&ms).take(6) {
+        println!("  fresh-only {k:?}");
+    }
+
+    let ok =
+        |o: &tcl_compiler::optimiser::Optimisation| (o.span.start(), o.span.end(), o.code.clone());
+    let mo: BTreeSet<_> = memo.optimisations.iter().map(ok).collect();
+    let fo: BTreeSet<_> = fresh.optimisations.iter().map(ok).collect();
+    println!(
+        "OPTS:   {} memo-only, {} fresh-only",
+        mo.difference(&fo).count(),
+        fo.difference(&mo).count()
+    );
+}

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -1,0 +1,103 @@
+//! Per-edit tail profiler for the incremental diagnostic path on practcl.tcl.
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::time::Instant;
+
+use salsa::Setter as _;
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_lsp_db::{
+    AnalyserConfig, SourceFile, TclDatabase, TclDb, compiler_check_diagnostics,
+    file_analysis_incremental,
+};
+
+fn ms(d: std::time::Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn time<T>(label: &str, iters: u32, mut f: impl FnMut() -> T) -> f64 {
+    let s = Instant::now();
+    for _ in 0..iters {
+        std::hint::black_box(f());
+    }
+    let per = ms(s.elapsed()) / f64::from(iters);
+    println!("  {label:<46} {per:8.1} ms");
+    per
+}
+
+fn main() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp");
+    let rel = std::env::var("FILE")
+        .unwrap_or_else(|_| "tcllib-2.0/modules/practcl/practcl.tcl".to_owned());
+    let path = root.join(&rel);
+    let src = std::fs::read_to_string(&path).expect("read file");
+    let dialect = "tcl8.6";
+    println!("== {rel} ({} lines) ==", src.lines().count());
+
+    // Is the per-item fast path taken, or does it fall back to the full walk?
+    let t_analyse = time("analyse (full whole-file walk)", 3, || {
+        Analyser::new().analyse(&src, dialect)
+    });
+    let t_per_item = time("analyse_per_item (no memo)", 3, || {
+        Analyser::new().analyse_per_item(&src, dialect)
+    });
+    let t_structure = time("structure_only().analyse (no diagnostics)", 3, || {
+        Analyser::new().structure_only().analyse(&src, dialect)
+    });
+    println!(
+        "  -> fallback to full walk? {}  (diagnostic-emit cost ~= {:.0} ms)",
+        if (t_per_item - t_analyse).abs() < t_analyse * 0.15 {
+            "YES (per_item ~= analyse)"
+        } else {
+            "NO (fast path)"
+        },
+        t_analyse - t_structure,
+    );
+
+    println!("\n== full per-edit path (salsa, memoised) ==");
+    let mut db = TclDatabase::default();
+    let cfg = AnalyserConfig::new(
+        &db,
+        Vec::new(),
+        tcl_compiler::analyser::NonAsciiMode::Default,
+    );
+    let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+    let _ = file_analysis_incremental(&db, file, cfg);
+    let _ = compiler_check_diagnostics(&db, file);
+
+    let edit_pos = src.find("\n    ").map_or(src.len() / 2, |p| p + 5);
+    let mut edited = src.clone();
+    edited.insert(edit_pos, ' ');
+    let mut t = false;
+    time("file_analysis_incremental (per edit)", 5, || {
+        t = !t;
+        file.set_text(&mut db)
+            .to(if t { edited.clone() } else { src.clone() });
+        file_analysis_incremental(&db, file, cfg)
+    });
+    let mut t2 = false;
+    time("compiler_check_diagnostics (per edit)", 5, || {
+        t2 = !t2;
+        file.set_text(&mut db)
+            .to(if t2 { edited.clone() } else { src.clone() });
+        compiler_check_diagnostics(&db, file)
+    });
+
+    println!("\n== compiler-check tail breakdown (whole-file, no memo) ==");
+    let registry = db.registry(dialect);
+    let cfg_lexer = tcl_lexer::LexerConfig::for_dialect(dialect);
+    let build = || {
+        CompilationUnit::build_for_with_config(&src, &registry, false, cfg_lexer)
+            .with_interprocedural(&registry, Some(dialect))
+    };
+    time("CompilationUnit::build_for + interproc", 3, build);
+    let cu = build();
+    time("run_all_checks", 3, || {
+        tcl_compiler::compiler_checks::run_all_checks(&cu, &registry, Some(dialect))
+    });
+    time("optimise_unit", 3, || {
+        tcl_compiler::optimiser::optimise_unit(&cu, &registry, Some(dialect))
+    });
+    println!("  (functions in unit: {})", cu.functions().count());
+}

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -83,6 +83,18 @@ fn main() {
             .to(if t2 { edited.clone() } else { src.clone() });
         compiler_check_diagnostics(&db, file)
     });
+    // Production shape: the server demands BOTH queries after one didChange, so
+    // the shared `compilation_unit` build is paid once per edit (the second
+    // consumer's demand is a same-revision cache hit when configs coincide).
+    let mut t3 = false;
+    time("BOTH queries per edit (production)", 5, || {
+        t3 = !t3;
+        file.set_text(&mut db)
+            .to(if t3 { edited.clone() } else { src.clone() });
+        let a = file_analysis_incremental(&db, file, cfg);
+        let c = compiler_check_diagnostics(&db, file);
+        (a, c)
+    });
 
     println!("\n== compiler-check tail breakdown (whole-file, no memo) ==");
     let registry = db.registry(dialect);

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -179,6 +179,12 @@ pub struct ItemBodyKey<'db> {
     pub scope_name: String,
     #[returns(ref)]
     pub params: Vec<ParamDef>,
+    /// `true` for a `TclOO` method body (isolated in a `Method` scope with
+    /// instance variables pre-bound); `false` for a `proc`.
+    pub is_method: bool,
+    /// Class instance variables pre-bound in a method body (empty for procs).
+    #[returns(ref)]
+    pub class_variables: Vec<String>,
     #[returns(ref)]
     pub dialect: String,
     #[returns(ref)]
@@ -198,10 +204,11 @@ pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc
         body_text: key.body_text(db).clone(),
         body_tok: tcl_lexer::Token::new(tcl_lexer::TokenType::Str, tcl_lexer::Span::new(0, 0)),
         scope_path: Vec::new(),
-        is_method: false,
+        is_method: key.is_method(db),
         namespace: key.namespace(db).clone(),
         scope_name: key.scope_name(db).clone(),
         params: key.params(db).clone(),
+        class_variables: key.class_variables(db).clone(),
     };
     let disabled: HashSet<String> = key.disabled(db).iter().cloned().collect();
     let overlay = tcl_compiler::analyser::types::build_stub_overlay(&[]);
@@ -441,6 +448,8 @@ pub fn file_analysis_incremental(
             body.namespace.clone(),
             body.scope_name.clone(),
             body.params.clone(),
+            body.is_method,
+            body.class_variables.clone(),
             dialect.clone(),
             disabled_vec.clone(),
             non_ascii,
@@ -725,6 +734,60 @@ mod tests {
                 .count(),
             1,
             "length-changing body edit -> exactly ONE item recomputes (offset-invariant): {after:?}"
+        );
+    }
+
+    /// The method firewall: a body edit to one OO method recomputes exactly one
+    /// `item_body_analysis` — methods are isolated + memoised like procs, so an
+    /// unedited sibling method (shifted by the edit) stays a cache hit.
+    #[test]
+    fn method_body_edit_recomputes_one_item() {
+        use salsa::Setter as _;
+        let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = {
+            let l = Arc::clone(&log);
+            move |ev: salsa::Event| {
+                if let salsa::EventKind::WillExecute { database_key } = ev.kind {
+                    l.lock().unwrap().push(format!("{database_key:?}"));
+                }
+            }
+        };
+        let mut db = TclDatabase {
+            storage: salsa::Storage::new(Some(Box::new(sink))),
+            registries: Arc::default(),
+        };
+        let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default);
+        let file = SourceFile::new(
+            &db,
+            "oo::class create K {\n  method a {} { set x 11111 }\n  method b {} { set y 22222 }\n}\n"
+                .to_owned(),
+            "tcl8.6".to_owned(),
+        );
+        let _ = file_analysis_incremental(&db, file, cfg);
+        let init = std::mem::take(&mut *log.lock().unwrap());
+        assert_eq!(
+            init.iter()
+                .filter(|s| s.contains("item_body_analysis"))
+                .count(),
+            2,
+            "initial: both method bodies analysed: {init:?}"
+        );
+
+        // Edit method a's body length — shifts method b; b's offset-0 body is
+        // unchanged, so its key is a cache hit and only a recomputes.
+        file.set_text(&mut db).to(
+            "oo::class create K {\n  method a {} { set x 9999999999 }\n  method b {} { set y 22222 }\n}\n"
+                .to_owned(),
+        );
+        let _ = file_analysis_incremental(&db, file, cfg);
+        let after = std::mem::take(&mut *log.lock().unwrap());
+        assert_eq!(
+            after
+                .iter()
+                .filter(|s| s.contains("item_body_analysis"))
+                .count(),
+            1,
+            "method body edit -> exactly ONE item recomputes: {after:?}"
         );
     }
 

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -341,6 +341,66 @@ pub fn memoised_compilation_unit<'db>(
     .with_interprocedural(registry, dialect_opt)
 }
 
+/// Interned identity of the dialect-varying [`tcl_lexer::LexerConfig`] fields,
+/// the salsa key that lets the two diagnostics consumers *share* one built
+/// [`CompilationUnit`].  Only `expand_syntax` / `irules_brace_separator` vary
+/// between [`LexerConfig::default`] (the analyser tail) and
+/// [`LexerConfig::for_dialect`] (the optimiser); the rest are always the default
+/// (`strict_quoting = false`, zero base offsets) on both paths.  The two configs
+/// **coincide for every dialect except `tcl8.4` / `f5-irules`**, so for the
+/// common case both consumers intern the same key and demand the same
+/// [`compilation_unit`] — built once per edit instead of twice.
+#[salsa::interned]
+pub struct LexerCfgKey<'db> {
+    pub expand_syntax: bool,
+    pub irules_brace_separator: bool,
+}
+
+impl LexerCfgKey<'_> {
+    /// The full [`tcl_lexer::LexerConfig`] this key represents (the two
+    /// interned fields + the invariant defaults both diagnostics paths use).
+    fn to_config(self, db: &dyn TclDb) -> tcl_lexer::LexerConfig {
+        tcl_lexer::LexerConfig {
+            expand_syntax: self.expand_syntax(db),
+            irules_brace_separator: self.irules_brace_separator(db),
+            ..tcl_lexer::LexerConfig::default()
+        }
+    }
+}
+
+/// Intern a [`LexerCfgKey`] from a concrete [`tcl_lexer::LexerConfig`].
+fn lexer_cfg_key(db: &dyn TclDb, config: tcl_lexer::LexerConfig) -> LexerCfgKey<'_> {
+    LexerCfgKey::new(db, config.expand_syntax, config.irules_brace_separator)
+}
+
+/// The shared, memoised [`CompilationUnit`] for a document under a given lexer
+/// config — built via [`memoised_compilation_unit`] (per-procedure lattices on
+/// the salsa-native [`function_lattice`] graph).  Tracked + keyed on
+/// `(file, cfg)` so the analyser tail ([`file_analysis_incremental`]) and the
+/// optimiser/compiler-checks pass ([`compiler_check_diagnostics`]) **share one
+/// build per edit** whenever their configs coincide (every dialect bar `tcl8.4`
+/// / `f5-irules`); for those two dialects the configs differ, so each consumer
+/// builds its own (status quo).  Byte-identical to a direct
+/// `memoised_compilation_unit` call.
+#[salsa::tracked]
+pub fn compilation_unit<'db>(
+    db: &'db dyn TclDb,
+    file: SourceFile,
+    cfg: LexerCfgKey<'db>,
+) -> Arc<CompilationUnit> {
+    let dialect = file.dialect(db).clone();
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
+    let registry = db.registry(&dialect);
+    Arc::new(memoised_compilation_unit(
+        db,
+        file.text(db),
+        &registry,
+        false,
+        cfg.to_config(db),
+        dialect_opt,
+    ))
+}
+
 /// Incremental whole-file analysis: the per-item path with each `proc` body's
 /// isolated analysis memoised via [`item_body_analysis`], so a body edit
 /// recomputes one body + the cheap shell instead of the whole walk; the
@@ -365,20 +425,14 @@ pub fn file_analysis_incremental(
 
     // Build the CFG/SSA tail's compilation unit with per-procedure lattices
     // memoised by `function_lattice`, and feed it through the analyser's
-    // `cu_override` seam.  The registry (`db.registry`) + default lexer config
-    // mirror what `emit_cfg_ssa_diagnostics` builds for itself, so the supplied
-    // unit is the one it would otherwise build.
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
-    let registry = db.registry(&dialect);
-    let cu = memoised_compilation_unit(
-        db,
-        &text,
-        &registry,
-        false,
-        tcl_lexer::LexerConfig::default(),
-        dialect_opt,
-    );
-    analyser.set_cu_override(Arc::new(cu));
+    // `cu_override` seam, via the shared [`compilation_unit`] query.  The default
+    // lexer config mirrors what `emit_cfg_ssa_diagnostics` builds for itself, so
+    // the supplied unit is the one it would otherwise build; routing through the
+    // tracked query lets `compiler_check_diagnostics` reuse this exact build in
+    // the same edit whenever the dialect's config matches the default (every
+    // dialect but `tcl8.4` / `f5-irules`).
+    let cfg_key = lexer_cfg_key(db, tcl_lexer::LexerConfig::default());
+    analyser.set_cu_override(compilation_unit(db, file, cfg_key));
 
     let mut body_fn = |body: &DeferredBody| -> BodyFragment {
         let key = ItemBodyKey::new(
@@ -434,18 +488,15 @@ fn compiler_diagnostics_from_unit(
 /// `lift_compiler_diagnostics` build.
 #[salsa::tracked]
 pub fn compiler_check_diagnostics(db: &dyn TclDb, file: SourceFile) -> Arc<CompilerDiagnostics> {
-    let text = file.text(db).clone();
     let dialect = file.dialect(db).clone();
     let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
     let registry = db.registry(&dialect);
-    let cu = memoised_compilation_unit(
-        db,
-        &text,
-        &registry,
-        false,
-        tcl_lexer::LexerConfig::for_dialect(&dialect),
-        dialect_opt,
-    );
+    // Share the analyser tail's build via the [`compilation_unit`] query when the
+    // dialect's lexer config matches the default (every dialect but `tcl8.4` /
+    // `f5-irules`): the optimiser lowers with the dialect config, so a matching
+    // config interns the same `LexerCfgKey` and reuses the same per-edit build.
+    let cfg_key = lexer_cfg_key(db, tcl_lexer::LexerConfig::for_dialect(&dialect));
+    let cu = compilation_unit(db, file, cfg_key);
     Arc::new(compiler_diagnostics_from_unit(&cu, &registry, dialect_opt))
 }
 
@@ -755,6 +806,71 @@ mod tests {
                 .count(),
             1,
             "length-changing body edit -> exactly ONE lattice recomputes (offset-invariant): {after:?}"
+        );
+    }
+
+    /// Both diagnostics consumers must **share one `compilation_unit` build per
+    /// edit** when their lexer configs coincide (every dialect but `tcl8.4` /
+    /// `f5-irules`): demanding `file_analysis_incremental` then
+    /// `compiler_check_diagnostics` in the same revision executes
+    /// `compilation_unit` exactly once.  For `tcl8.4` the configs differ
+    /// (`expand_syntax`), so each consumer builds its own — executed twice.
+    #[test]
+    fn compilation_unit_shared_across_consumers() {
+        use salsa::Setter as _;
+        let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = {
+            let l = Arc::clone(&log);
+            move |ev: salsa::Event| {
+                if let salsa::EventKind::WillExecute { database_key } = ev.kind {
+                    l.lock().unwrap().push(format!("{database_key:?}"));
+                }
+            }
+        };
+        let mut db = TclDatabase {
+            storage: salsa::Storage::new(Some(Box::new(sink))),
+            registries: Arc::default(),
+        };
+        let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default);
+        let src = "proc a {x} { return $x }\nproc b {} { a 1 }\n";
+        let count_cu = |log: &Arc<Mutex<Vec<String>>>| {
+            std::mem::take(&mut *log.lock().unwrap())
+                .iter()
+                .filter(|s| s.contains("compilation_unit"))
+                .count()
+        };
+
+        // tcl8.6: default == for_dialect, so the two consumers share one build.
+        let file86 = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+        let _ = file_analysis_incremental(&db, file86, cfg);
+        let _ = compiler_check_diagnostics(&db, file86);
+        assert_eq!(
+            count_cu(&log),
+            1,
+            "tcl8.6: both consumers share exactly one compilation_unit build"
+        );
+
+        // tcl8.4: for_dialect disables `{*}` expansion, so the configs differ
+        // and each consumer builds its own unit (two executions).
+        let file84 = SourceFile::new(&db, src.to_owned(), "tcl8.4".to_owned());
+        let _ = file_analysis_incremental(&db, file84, cfg);
+        let _ = compiler_check_diagnostics(&db, file84);
+        assert_eq!(
+            count_cu(&log),
+            2,
+            "tcl8.4: differing lexer configs -> a separate build per consumer"
+        );
+
+        // A fresh edit re-shares for tcl8.6 (one build for the new revision).
+        file86
+            .set_text(&mut db)
+            .to("proc a {x} { return $x }\nproc b {} { a 2 }\n".to_owned());
+        let _ = file_analysis_incremental(&db, file86, cfg);
+        let _ = compiler_check_diagnostics(&db, file86);
+        assert_eq!(
+            count_cu(&log),
+            1,
+            "after an edit, tcl8.6 again shares one build across both consumers"
         );
     }
 }

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -1,0 +1,92 @@
+//! **KNOWN-FAILING guard** for a pre-existing `function_lattice` memo divergence.
+//!
+//! The memoised [`compiler_check_diagnostics`] (offset-0 per-procedure lattice +
+//! rebase, via `build_for_memoized`) must be **byte-identical** to a fresh,
+//! whole-module [`compiler_check_diagnostics_uncached`] build (`build_for_with_config`)
+//! — they are the two halves of the salsa-native lattice graph (#604).  They are
+//! **not**: over the `tmp/` corpus ~30% of files diverge (per-file, not a
+//! cross-file cache collision — fresh-db-per-file diverges too), surfacing as
+//! `S101` (shimmer) check spans of *different width* (so the offset-0 build's
+//! analysis genuinely differs from the whole-module build's, beyond offset).
+//! See `docs/design/rust/incremental-analysis.md` ("Pre-existing memo
+//! byte-identity bug").  Un-ignore once `build_for_memoized` is made byte-identical
+//! to `build_for_with_config`.
+
+use std::path::{Path, PathBuf};
+
+use tcl_lsp_db::{
+    SourceFile, TclDatabase, TclDb, compiler_check_diagnostics, compiler_check_diagnostics_uncached,
+};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn gather(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
+    if out.len() >= cap {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            gather(&p, out, cap);
+        } else if p.extension().is_some_and(|x| x == "tcl") {
+            out.push(p);
+            if out.len() >= cap {
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "KNOWN-FAILING: pre-existing function_lattice memo divergence (~30% of corpus, S101); see incremental-analysis.md"]
+fn compiler_check_memo_matches_uncached_over_corpus() {
+    let dialect = "tcl8.6";
+    let mut files = Vec::new();
+    for v in [
+        "tcl8.4.20/library",
+        "tcl8.5.19/library",
+        "tcl8.6.16/library",
+        "tcl9.0.3/library",
+        "tcllib-2.0/modules",
+    ] {
+        gather(&repo_root().join("tmp").join(v), &mut files, 1500);
+    }
+
+    let db = TclDatabase::default();
+    let mut checked = 0usize;
+    let mut bad: Vec<String> = Vec::new();
+    for path in &files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.is_empty() || src.len() > 400_000 {
+            continue;
+        }
+        let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+        let got = compiler_check_diagnostics(&db, file);
+        let registry = db.registry(dialect);
+        let want = compiler_check_diagnostics_uncached(&src, &registry, dialect);
+        checked += 1;
+        if (got.checks != want.checks || got.optimisations != want.optimisations) && bad.len() < 40
+        {
+            bad.push(
+                path.strip_prefix(repo_root())
+                    .unwrap_or(path)
+                    .display()
+                    .to_string(),
+            );
+        }
+    }
+
+    assert!(
+        bad.is_empty(),
+        "compiler_check_diagnostics (memo) != uncached in {}+ / {checked} files:\n{}",
+        bad.len(),
+        bad.join("\n")
+    );
+}

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -1,16 +1,19 @@
-//! **KNOWN-FAILING guard** for a pre-existing `function_lattice` memo divergence.
+//! Byte-identity guard for the `function_lattice` memo path.
 //!
 //! The memoised [`compiler_check_diagnostics`] (offset-0 per-procedure lattice +
 //! rebase, via `build_for_memoized`) must be **byte-identical** to a fresh,
-//! whole-module [`compiler_check_diagnostics_uncached`] build (`build_for_with_config`)
-//! — they are the two halves of the salsa-native lattice graph (#604).  They are
-//! **not**: over the `tmp/` corpus ~30% of files diverge (per-file, not a
-//! cross-file cache collision — fresh-db-per-file diverges too), surfacing as
-//! `S101` (shimmer) check spans of *different width* (so the offset-0 build's
-//! analysis genuinely differs from the whole-module build's, beyond offset).
-//! See `docs/design/rust/incremental-analysis.md` ("Pre-existing memo
-//! byte-identity bug").  Un-ignore once `build_for_memoized` is made byte-identical
-//! to `build_for_with_config`.
+//! whole-module [`compiler_check_diagnostics_uncached`] build
+//! (`build_for_with_config`) — they are the two halves of the salsa-native
+//! lattice graph (#604).
+//!
+//! This previously diverged for ~30% of the `tmp/` corpus, but the divergence
+//! was *nondeterminism*, not an offset-0-vs-whole-module analysis difference:
+//! several diagnostic producers folded over `HashMap`s in iteration order
+//! (phi-span resolution, `run_all_checks` output order, the optimiser's group-id
+//! allocation, W313's "first offending path variable", and the order-sensitive
+//! `type_join` fold over a phi's predecessors).  Each is now deterministic, so
+//! the memo and whole-module builds agree byte-for-byte.  See
+//! `docs/design/rust/incremental-analysis.md` ("Memo byte-identity").
 
 use std::path::{Path, PathBuf};
 
@@ -43,7 +46,7 @@ fn gather(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
 }
 
 #[test]
-#[ignore = "KNOWN-FAILING: pre-existing function_lattice memo divergence (~30% of corpus, S101); see incremental-analysis.md"]
+#[ignore = "slow corpus sweep (~100s over tmp/); run with --ignored"]
 fn compiler_check_memo_matches_uncached_over_corpus() {
     let dialect = "tcl8.6";
     let mut files = Vec::new();


### PR DESCRIPTION
## Summary

Makes the whole-file diagnostic path **incremental**: each `proc`/`method` body is analysed once in isolation (normalised to offset 0), memoised, then grafted/rebased back — so an edit recomputes only the touched item instead of re-walking the whole file, while staying **byte-identical** to a from-scratch analysis.

### Per-item fast path (analyser walk)
- **Phase C** — widen the fast path to bodies that declare/write enclosing variables (`variable`, `global`, `set ::x`) and that define classes: **~42% → 86.6%** of corpus files. Three residual divergences between isolated-body and whole-file analysis are made byte-identical at the isolated/graft/tail seam:
  - **W120** (missing `package require`) anchors at each command's *source-earliest* invocation, independent of walk order.
  - **W002** (disabled-in-dialect) defers its user-proc-shadow suppression to the tail (`flush_disabled_command_diagnostics`) against the merged `all_procs`.
  - **W304** (missing `--`) defers its source-dependent `$var` branch (`pending_w304`) to the tail.
  - Qualified-read replay (`$::ns::v`) is gated on source-order visibility; `body_needs_enclosing_context` is narrowed to just `variable ns::x`.
- **Duplicate procs + multi-method classes** join the fast path (last-definition-wins via overwrite-on-collision for body-owned keys; method scope carried so methods aren't mistaken for duplicates): **→ 92.2%**.
- **OO method bodies** analysed in isolation with instance variables pre-bound, then grafted — enabling memoisation (e.g. `pt_rdengine_oo.tcl` per-edit **165 ms → 44 ms**).

### Shared, memoised compilation unit
- One `CompilationUnit` built per edit, **shared** across both diagnostics consumers (analyser tail + compiler-checks/optimiser) via the salsa `compilation_unit` query (previously two separate builds).
- Per-procedure baseline lattices (CFG → SSA → def-use → SCCP → type → rendered → taint) memoised by the salsa-native `function_lattice` query, replacing the process-wide content cache (now salsa-GC'd).

### Memo byte-identity (correctness fix)
`build_for_memoized` (offset-0 + rebase) must be byte-identical to the whole-module `build_for_with_config`; a corpus differential found ~30% of files diverging. The root cause was **`HashMap`-iteration nondeterminism** — both builds disagreed with *themselves* run-to-run — in five producers, each now made deterministic:

1. phi-span resolution (earliest span, not first-in-map),
2. `run_all_checks` output order (total sort key),
3. optimiser group-id allocation + emission order (canonicalise before overlap arbitration; renumber groups by first appearance),
4. W313 path-variable selection (argument order, not map order),
5. the order-sensitive `type_join` fold over a phi's predecessors (sorted before the fold).

The memo-vs-whole-module differential now passes over all 893 corpus files, stable across process-level hashmap seeds.

## Validation

```bash
cargo test -p tcl-compiler --test per_item_corpus -- --ignored          # byte-identity over corpus + edit fuzzer
cargo test -p tcl-lsp-db   --test compiler_check_corpus -- --ignored     # memo vs whole-module byte-identity
cargo test -p tcl-compiler --test differential_incremental -- --ignored  # incremental == fresh fuzzer
cargo run --release -p tcl-compiler --example per_item_divergence        # residual-divergence probe
make test-lsp-e2e-rust                                                    # e2e parity
```

- [x] `per_item_matches_analyse_over_corpus` + `per_item_matches_analyse_under_edits` — byte-identical to `analyse` over the corpus and after random edits
- [x] `compiler_check_memo_matches_uncached_over_corpus` — memo == whole-module over all corpus files
- [x] `differential_incremental` — incremental output == full rebuild
- [x] workspace build, `cargo clippy --workspace` (no new warnings), `cargo fmt --check`
- [x] e2e parity: 514 passed / 1 skipped / 1 pre-existing-red (registry iRules-count gap — unrelated to this change)

## Compiler/KCS checklist
- [x] Alters compiler fact contracts (W120 anchor point, W002/W304 deferral, qualified-read visibility gating) — user-visible diagnostics remain byte-identical to whole-file analysis
- [x] Updated `docs/design/rust/incremental-analysis.md` (Phase C, shared-CU, OO method memo, per-edit floor, memo byte-identity)

https://claude.ai/code/session_01XQQMmhxV6cMheBvEqV9eNB