### PR TITLE
f5 CLI (Rust): port `encrypt-secrets` / `decrypt-secrets` master-key crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,11 +525,13 @@ dependencies = [
 name = "f5-cli"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "anyhow",
  "base64",
  "chrono",
  "clap",
  "clap_complete",
+ "getrandom 0.3.4",
  "regex",
  "rpassword",
  "serde",
@@ -1870,6 +1872,7 @@ dependencies = [
  "tcl-lexer",
  "tcl-lsp-core",
  "tcl-registry",
+ "temp-env",
  "thiserror",
 ]
 

--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ f5 irule event-info HTTP_REQUEST --json
 | --- | --- |
 | Acquisition | `fetch`, `extract` (UCS → SCF) |
 | Analysis | `stats`, `graph`, `explain`, `diff`, `grep`, `cleanup`, `validate` |
-| Transformation | `rename`, `redact`, `unredact`, `pcap-remap`, `split`, `merge`, `convert`, `tmsh` |
+| Transformation | `rename`, `redact`, `unredact`, `encrypt-secrets`, `decrypt-secrets`, `pcap-remap`, `split`, `merge`, `convert`, `tmsh` |
 | Round-trip | `pull`, `push` |
 | iRules | `irule event-order`, `irule event-info`, `irule lint`, `irule trace`, `irule extract` |
 | Misc | `completion` |
@@ -848,6 +848,24 @@ Highlights of the newer verbs:
   reuses every prior assignment, so iterative work with F5 support
   stays consistent.  `unredact` walks the map in reverse over any text,
   including support emails and log snippets.
+- **`f5 encrypt-secrets` + `f5 decrypt-secrets`** (aliases `encrypt` /
+  `decrypt`) — convert the credential-bearing values in a `bigip.conf` /
+  SCF between clear text and the `$M$<salt>$<base64>` form BIG-IP stores,
+  using the unit master key (`f5mku -K` base64 output).  The transform is
+  AES-ECB with PKCS#7 padding and a two-character salt — byte-for-byte the
+  scheme the device uses.  Only the fields BIG-IP actually master-key
+  encrypts are touched (`passphrase`, `password`, `secret`,
+  `shared-secret`, `auth-password`, `privacy-password`); SNMP community
+  strings, the `auth user` crypt(3) hash, and values already in a
+  `$scheme$…` form are left alone, so both verbs are idempotent.  The key
+  resolves from `--f5mku KEY` / `--f5mku-file FILE` / `$F5MKU` / a secure
+  no-echo prompt.
+
+  ```sh
+  f5mku -K > key.txt
+  f5 decrypt-secrets bigip.conf --f5mku-file key.txt -o clear.conf
+  F5MKU="$(cat key.txt)" f5 encrypt-secrets clear.conf -o sealed.conf
+  ```
 - **`f5 pcap-remap`** — apply the same map to a PCAP capture: rewrites
   IPv4/IPv6 src/dst, recomputes IP and TCP/UDP/ICMP checksums, and
   *parses* the F5 Ethernet trailer (legacy + DPT formats; `tcpdump -i

--- a/docs/kcs/features/kcs-feature-f5-secret-crypto.md
+++ b/docs/kcs/features/kcs-feature-f5-secret-crypto.md
@@ -1,0 +1,104 @@
+# KCS: feature — `f5 encrypt-secrets` / `f5 decrypt-secrets`
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Applies to
+
+`f5` CLI — both the Python front-end (`python -m tooling.f5.main`) and the
+native Rust port (`f5-query`, `rust/f5-cli`). The two share one behaviour
+contract: the same verbs, flags, master-key resolution order, and the
+byte-for-byte `$M$<salt>$<base64>` envelope.
+
+## Summary
+
+`f5 encrypt-secrets` and `f5 decrypt-secrets` convert the
+credential-bearing values in a `bigip.conf` / SCF between clear text and
+the encrypted form BIG-IP stores, using the unit master key.  The master
+key is the base64 string `f5mku -K` prints on the device.  Encryption
+wraps a value in the `$M$<salt>$<base64>` envelope; decryption recovers
+the clear text.  Both verbs are idempotent — a value already in the
+target form is left untouched.
+
+## Question
+
+How do I read the real passwords out of a `bigip.conf`, or seal clear-text
+secrets back into the `$M$...` form, given the device master key?
+
+## How to use
+
+Get the master key off the device once:
+
+```sh
+f5mku -K > key.txt          # prints e.g. BHDLd0bbao1VlwpTk1sioQ==
+```
+
+Then decrypt or encrypt the secrets in a config:
+
+```sh
+# Reveal every stored secret in clear text
+f5 decrypt-secrets bigip.conf --f5mku-file key.txt -o clear.conf
+
+# Seal clear-text secrets back into the $M$ envelope
+F5MKU="$(cat key.txt)" f5 encrypt-secrets clear.conf -o sealed.conf
+
+# The key can also be passed inline
+f5 decrypt-secrets bigip.conf -k BHDLd0bbao1VlwpTk1sioQ==
+```
+
+`encrypt` / `decrypt` are accepted as aliases for the two verbs.
+
+The key is resolved from `--f5mku KEY` (`-k`), then `--f5mku-file FILE`,
+then the `$F5MKU` environment variable, and finally a secure `F5 MKU Key:`
+terminal prompt (no echo).  Pass `--no-key-prompt` to fail instead of
+prompting in non-interactive runs.  Output goes to stdout unless
+`-o FILE` is given, and `--format scf|tmsh|tmsh-delta` re-renders the
+result the same way the other rewriting verbs do (`tmsh-delta` uses the
+pre-rewrite config as its baseline, so existing objects emit `modify`,
+not a spurious `create`).
+
+### Which values are affected
+
+Only the fields BIG-IP actually master-key encrypts are touched:
+`passphrase`, `password`, `secret`, `shared-secret`, `auth-password`,
+and `privacy-password`.  SNMP community strings and monitor receive
+strings — which the device keeps in clear text and never wraps in
+`$M$` — are left alone, unlike the broader
+[`f5 redact`](kcs-feature-f5-cli.md) set.  The `auth user`
+`encrypted-password` field is deliberately excluded: it holds an
+operating-system crypt hash (`$6$…`), not an `$M$` master-key secret.
+The literals `none` and `<REDACTED>`, and any value already in a
+`$scheme$…` encoded form, are skipped.
+
+### Example
+
+```text
+# before  (clear.conf)
+auth radius-server /Common/rad {
+    secret "my radius secret"
+}
+
+# after  f5 encrypt-secrets clear.conf --f5mku-file key.txt
+auth radius-server /Common/rad {
+    secret "$M$ab$2wzXs0xM6OJcV5A4DJ6zCT4fMYLjTWwOPZNT4VBBbQ0="
+}
+```
+
+Running `f5 decrypt-secrets` on the output with the same key returns the
+original `secret "my radius secret"`.
+
+## Notes
+
+- The transform is AES in ECB mode with PKCS#7 padding and a two-character
+  salt — the scheme BIG-IP itself uses.  The Python front-end runs it on a
+  bundled pure-Python cipher (so it works in the zipapp with no
+  `cryptography` dependency); the Rust front-end delegates the block
+  transform to the audited [`aes`] crate already vendored for the
+  encrypted-UCS path.  Both produce identical ciphertext.
+- A wrong master key is reported as an error (the padding or salt check
+  fails) rather than producing silent garbage.
+- The clear-text output holds real credentials and SSL key passphrases —
+  treat `decrypt-secrets` output as sensitive and avoid writing it to a
+  shared location.
+
+[`aes`]: https://crates.io/crates/aes

--- a/rust/f5-cli/Cargo.toml
+++ b/rust/f5-cli/Cargo.toml
@@ -32,6 +32,12 @@ ureq = "3"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 rpassword = "7"
+# `encrypt-secrets` / `decrypt-secrets`: F5 master-key (`f5mku`) AES-ECB crypto.
+# The block transform comes from the audited pure-Rust `aes` crate (already in
+# the workspace lockfile for the encrypted-UCS path); `getrandom` seeds the
+# two-character secret salt.
+aes = "0.8"
+getrandom = "0.3"
 
 [lints]
 workspace = true

--- a/rust/f5-cli/src/cli.rs
+++ b/rust/f5-cli/src/cli.rs
@@ -70,6 +70,26 @@ impl PassphraseArgs {
     }
 }
 
+/// F5 unit master-key (`f5mku`) source flags shared by `encrypt-secrets` /
+/// `decrypt-secrets` (the `_add_key_args` group from `verbs/secrets.py`).
+// Help strings are clap-visible and must read like the Python argparse help;
+// the `f5mku -K` / `$F5MKU` tokens carry no Markdown, so silence the lint.
+#[allow(clippy::doc_markdown)]
+#[derive(Debug, Default, Args)]
+pub struct MasterKeyArgs {
+    /// base64 unit master key (the value `f5mku -K` prints on the device).
+    /// Falls back to $F5MKU, then a secure terminal prompt.
+    #[arg(short = 'k', long = "f5mku", value_name = "KEY")]
+    pub f5mku: Option<String>,
+    /// read the base64 master key from FILE (e.g. `f5mku -K > key.txt`).
+    #[arg(long = "f5mku-file", value_name = "FILE")]
+    pub f5mku_file: Option<PathBuf>,
+    /// never prompt on the terminal for the master key; require a flag or
+    /// $F5MKU instead.
+    #[arg(long = "no-key-prompt")]
+    pub no_key_prompt: bool,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Print object counts, partition breakdown, and top-references.
@@ -476,6 +496,42 @@ pub enum Command {
         output: Option<PathBuf>,
     },
 
+    /// Encrypt clear-text secrets in a bigip.conf under the f5mku master key.
+    #[command(name = "encrypt-secrets", visible_alias = "encrypt")]
+    EncryptSecrets {
+        /// bigip.conf / SCF file (`-` for stdin).
+        path: String,
+        /// Write the result here (default: stdout).
+        #[arg(long, short, value_name = "FILE")]
+        output: Option<PathBuf>,
+        #[command(flatten)]
+        key: MasterKeyArgs,
+        /// Force this two-character salt instead of a random one (deterministic
+        /// output; mainly for testing).
+        #[arg(long, value_name = "XX")]
+        salt: Option<String>,
+        #[command(flatten)]
+        passphrase: PassphraseArgs,
+        #[command(flatten)]
+        format: FormatArgs,
+    },
+
+    /// Decrypt `$M$...` secrets in a bigip.conf with the f5mku master key.
+    #[command(name = "decrypt-secrets", visible_alias = "decrypt")]
+    DecryptSecrets {
+        /// bigip.conf / SCF file (`-` for stdin).
+        path: String,
+        /// Write the result here (default: stdout).
+        #[arg(long, short, value_name = "FILE")]
+        output: Option<PathBuf>,
+        #[command(flatten)]
+        key: MasterKeyArgs,
+        #[command(flatten)]
+        passphrase: PassphraseArgs,
+        #[command(flatten)]
+        format: FormatArgs,
+    },
+
     /// Pull SCF or UCS from a live BIG-IP device (REST or SSH).
     // Help strings are clap-visible and must read exactly as the Python verb's
     // argparse help (the env-var names carry underscores), so no Markdown
@@ -725,6 +781,8 @@ impl Command {
             Command::Query { .. } => "query",
             Command::Redact { .. } => "redact",
             Command::Unredact { .. } => "unredact",
+            Command::EncryptSecrets { .. } => "encrypt-secrets",
+            Command::DecryptSecrets { .. } => "decrypt-secrets",
             Command::Fetch { .. } => "fetch",
             Command::Push { .. } => "push",
             Command::Pull { .. } => "pull",

--- a/rust/f5-cli/src/commands/mod.rs
+++ b/rust/f5-cli/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod registry_dump;
 pub mod remote;
 pub mod rename;
 pub mod scf;
+pub mod secrets;
 pub mod split;
 pub mod stats;
 pub mod tmsh;

--- a/rust/f5-cli/src/commands/secrets.rs
+++ b/rust/f5-cli/src/commands/secrets.rs
@@ -1,0 +1,178 @@
+//! The `encrypt-secrets` / `decrypt-secrets` verbs — master-key crypto for the
+//! credential-bearing values in a bigip.conf / SCF.
+//!
+//! Port of `tooling/f5/verbs/secrets.py` (`_run_encrypt` / `_run_decrypt`). Both
+//! verbs walk every secret-bearing property (`passphrase`, `password`, `secret`,
+//! `shared-secret`, `auth-password`, `privacy-password`) via
+//! [`tcl_bigip::secrets::rewrite_secrets`] and run its value through the F5 unit
+//! master key supplied by the user — the base64 key `f5mku -K` prints on the
+//! device. `encrypt-secrets` wraps clear-text values in the `$M$<salt>$<base64>`
+//! envelope BIG-IP stores; `decrypt-secrets` recovers the clear text. Values
+//! already in the target form are left untouched, so both verbs are idempotent
+//! and safe to re-run.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use tcl_bigip::secrets::rewrite_secrets;
+use tcl_bigip_io::read_path;
+use tcl_cli_support::secret_input::{SecretRequest, resolve_secret};
+
+use crate::cli::{FormatArgs, MasterKeyArgs, PassphraseArgs};
+use crate::commands::emit::render_config;
+use crate::f5mku;
+
+const F5MKU_ENV: &str = "F5MKU";
+const KEY_PROMPT: &str = "F5 MKU Key: ";
+
+/// A value already in a `$scheme$...` encoded form — an F5 `$M$` master-key
+/// secret or an OS crypt(3) hash (`$1$` / `$5$` / `$6$` / `$2y$` …).
+/// `encrypt-secrets` never re-wraps these.
+fn already_encoded() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^\$[A-Za-z0-9]+\$").expect("valid already-encoded regex"))
+}
+
+/// The two crypto directions the shared handler runs in.
+#[derive(Clone, Copy)]
+pub enum Mode {
+    Encrypt,
+    Decrypt,
+}
+
+impl Mode {
+    /// Past-tense label for the stderr report line.
+    fn past(self) -> &'static str {
+        match self {
+            Mode::Encrypt => "encrypted",
+            Mode::Decrypt => "decrypted",
+        }
+    }
+}
+
+/// Resolve the master key from `--f5mku` / `--f5mku-file` / `$F5MKU` / prompt.
+///
+/// The base64 key is whitespace-trimmed (`strip: true`) so a file or env value
+/// carrying a trailing newline — `f5mku -K > key.txt` — still works.
+fn resolve_key(key_args: &MasterKeyArgs) -> Result<String, String> {
+    let req = SecretRequest {
+        explicit: key_args.f5mku.as_deref(),
+        file: key_args.f5mku_file.as_deref(),
+        env_var: Some(F5MKU_ENV),
+        allow_prompt: !key_args.no_key_prompt,
+        prompt: Some(KEY_PROMPT),
+        strip: true,
+    };
+    let key = resolve_secret(&req).map_err(|e| e.to_string())?;
+    key.filter(|k| !k.is_empty()).ok_or_else(|| {
+        format!(
+            "no master key supplied; pass --f5mku KEY, --f5mku-file FILE, set ${F5MKU_ENV}, \
+             or run in an interactive terminal to be prompted"
+        )
+    })
+}
+
+/// `f5 encrypt-secrets` / `f5 decrypt-secrets`.
+pub fn run_secrets(
+    mode: Mode,
+    path: &str,
+    key_args: &MasterKeyArgs,
+    salt: Option<&str>,
+    passphrase: &PassphraseArgs,
+    format: &FormatArgs,
+    output: Option<&Path>,
+) -> anyhow::Result<u8> {
+    let key = match resolve_key(key_args) {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(2);
+        }
+    };
+
+    // Fail fast on a bad key before touching the file.
+    if let Err(e) = f5mku::encrypt("probe", &key, Some("00")) {
+        eprintln!("error: {e}");
+        return Ok(2);
+    }
+
+    let opts = passphrase.to_options();
+    let (_uri, source) = match read_path(path, false, &opts) {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(2);
+        }
+    };
+
+    // The cipher closure may surface an F5MkuError (e.g. a non-`$M$` value that
+    // slipped the decrypt guard, or a wrong key on decrypt); capture the first
+    // one so the rewrite aborts with a clean error like the Python verb.
+    let mut crypto_error: Option<String> = None;
+    let report = {
+        let key = &key;
+        let crypto_error = &mut crypto_error;
+        rewrite_secrets(&source, |value| {
+            if crypto_error.is_some() {
+                return None;
+            }
+            match mode {
+                Mode::Encrypt => {
+                    // Skip anything already in a `$scheme$...` encoded form: an
+                    // existing `$M$` ciphertext (idempotent re-run) or a stored
+                    // crypt(3) hash like `$6$...` that slipped past the key set —
+                    // double-encrypting either would corrupt the credential.
+                    if already_encoded().is_match(value) {
+                        return None;
+                    }
+                    match f5mku::encrypt(value, key, salt) {
+                        Ok(ct) => Some(ct),
+                        Err(e) => {
+                            *crypto_error = Some(e.to_string());
+                            None
+                        }
+                    }
+                }
+                Mode::Decrypt => {
+                    if !f5mku::is_ciphertext(value) {
+                        return None; // not encrypted
+                    }
+                    match f5mku::decrypt(value, key) {
+                        Ok(pt) => Some(pt),
+                        Err(e) => {
+                            *crypto_error = Some(e.to_string());
+                            None
+                        }
+                    }
+                }
+            }
+        })
+    };
+
+    if let Some(e) = crypto_error {
+        eprintln!("error: {e}");
+        return Ok(2);
+    }
+
+    let rendered = render_config(
+        &report.new_source,
+        &format.format,
+        "modify",
+        format.transaction,
+        &source,
+    );
+    if let Some(out) = output {
+        std::fs::write(out, rendered)?;
+    } else {
+        print!("{rendered}");
+    }
+
+    eprintln!(
+        "{}: {} secret(s); {} left untouched",
+        mode.past(),
+        report.transformed,
+        report.skipped
+    );
+    Ok(0)
+}

--- a/rust/f5-cli/src/f5mku.rs
+++ b/rust/f5-cli/src/f5mku.rs
@@ -1,0 +1,332 @@
+//! F5 master-key (`f5mku`) secret encryption / decryption.
+//!
+//! Faithful Rust port of `tooling/f5/f5mku.py`.
+//!
+//! BIG-IP stores credential-bearing values (SSL key passphrases, monitor
+//! passwords, RADIUS / TACACS shared secrets, …) in its configuration encrypted
+//! under the unit master key. On a device that key is what `f5mku -K` prints — a
+//! base64-encoded AES key — and the stored secrets look like
+//! `$M$<salt>$<base64-ciphertext>`.
+//!
+//! The transform is AES in ECB mode with PKCS#7 padding: a two-character salt is
+//! prepended to the plaintext, the result is padded to a 16-byte boundary,
+//! encrypted block-by-block with the master key, and base64 encoded. The Python
+//! original hand-rolls AES so the zipapp ships without a C extension; here we
+//! delegate the block transform to the audited pure-Rust [`aes`] crate and keep
+//! only the thin salt / PKCS#7 / base64 envelope logic, which is exactly what
+//! the Python module layers on top of the cipher.
+//!
+//! ```
+//! # use f5_cli::f5mku::{encrypt, decrypt, extract_salt};
+//! let key = "BHDLd0bbao1VlwpTk1sioQ==";
+//! assert_eq!(decrypt("$M$iP$rr0su9oHn9J9p1t3nRzydA==", key).unwrap(), "KEY45678");
+//! assert_eq!(encrypt("KEY45678", key, Some("ab")).unwrap(), "$M$ab$mmIL9xEWGe7pbNtvS/QAQA==");
+//! assert_eq!(extract_salt("$M$iP$rr0su9oHn9J9p1t3nRzydA==").unwrap(), "iP");
+//! ```
+
+use aes::cipher::generic_array::GenericArray;
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use aes::{Aes128, Aes192, Aes256};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+
+const BLOCK_SIZE: usize = 16;
+const SALT_LENGTH: usize = 2;
+const SALT_ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+/// Raised for malformed master keys or ciphertext (port of `F5MkuError`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct F5MkuError(pub String);
+
+impl std::fmt::Display for F5MkuError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for F5MkuError {}
+
+/// An AES cipher keyed for one of the three supported key lengths, exposing both
+/// block transforms (ECB needs encrypt and decrypt).
+enum Aes {
+    A128(Box<Aes128>),
+    A192(Box<Aes192>),
+    A256(Box<Aes256>),
+}
+
+impl Aes {
+    fn encrypt_block(&self, block: &[u8; BLOCK_SIZE]) -> [u8; BLOCK_SIZE] {
+        let mut b = GenericArray::clone_from_slice(block);
+        match self {
+            Aes::A128(c) => c.encrypt_block(&mut b),
+            Aes::A192(c) => c.encrypt_block(&mut b),
+            Aes::A256(c) => c.encrypt_block(&mut b),
+        }
+        b.into()
+    }
+
+    fn decrypt_block(&self, block: &[u8; BLOCK_SIZE]) -> [u8; BLOCK_SIZE] {
+        let mut b = GenericArray::clone_from_slice(block);
+        match self {
+            Aes::A128(c) => c.decrypt_block(&mut b),
+            Aes::A192(c) => c.decrypt_block(&mut b),
+            Aes::A256(c) => c.decrypt_block(&mut b),
+        }
+        b.into()
+    }
+}
+
+/// Encrypt `plaintext` under the `f5mku` master key.
+///
+/// `f5mku` is the base64 key printed by `f5mku -K`. `salt`, when given, is
+/// either a bare two-character string (no `$`) or a full F5 ciphertext to copy
+/// the salt from; otherwise a fresh random salt is generated. Returns the
+/// `$M$<salt>$<base64>` form found in bigip.conf.
+///
+/// # Errors
+/// Returns [`F5MkuError`] when `f5mku` is not a valid base64 AES key, or when a
+/// `salt` carrying a `$` is not a parseable ciphertext.
+pub fn encrypt(plaintext: &str, f5mku: &str, salt: Option<&str>) -> Result<String, F5MkuError> {
+    let cipher = load_key(f5mku)?;
+    let salt_bytes = resolve_salt(salt)?;
+    let mut data = salt_bytes.clone();
+    data.extend_from_slice(plaintext.as_bytes());
+    let padded = pkcs7_pad(&data);
+    let body = ecb_encrypt(&cipher, &padded);
+    Ok(format_ciphertext(&salt_bytes, &body))
+}
+
+/// Decrypt an `$M$<salt>$<base64>` `ciphertext` under `f5mku`.
+///
+/// `f5mku` is the base64 key printed by `f5mku -K`. Returns the recovered
+/// plaintext.
+///
+/// # Errors
+/// Returns [`F5MkuError`] when the key is invalid, the envelope is malformed, or
+/// the PKCS#7 padding / leading salt does not check out (the wrong-key signal).
+pub fn decrypt(ciphertext: &str, f5mku: &str) -> Result<String, F5MkuError> {
+    let parsed = deconstruct_ciphertext(ciphertext)?;
+    let cipher = load_key(f5mku)?;
+    let decrypted = pkcs7_unpad(&ecb_decrypt(&cipher, &parsed.ciphertext)?)?;
+    let stripped = strip_salt(&decrypted, &parsed.salt)?;
+    String::from_utf8(stripped).map_err(|e| F5MkuError(format!("decrypted text is not UTF-8: {e}")))
+}
+
+/// Return the salt embedded in an F5 `ciphertext` string.
+///
+/// # Errors
+/// Returns [`F5MkuError`] when `ciphertext` is not a valid `$M$<salt>$<base64>`
+/// envelope.
+pub fn extract_salt(ciphertext: &str) -> Result<String, F5MkuError> {
+    let parsed = deconstruct_ciphertext(ciphertext)?;
+    String::from_utf8(parsed.salt).map_err(|e| F5MkuError(format!("salt is not UTF-8: {e}")))
+}
+
+/// Whether `value` looks like an F5 `$M$<salt>$<body>` secret.
+#[must_use]
+pub fn is_ciphertext(value: &str) -> bool {
+    let parts: Vec<&str> = value.split('$').collect();
+    parts.len() == 4
+        && parts[0].is_empty()
+        && parts[1] == "M"
+        && !parts[2].is_empty()
+        && !parts[3].is_empty()
+}
+
+struct Ciphertext {
+    salt: Vec<u8>,
+    ciphertext: Vec<u8>,
+}
+
+fn load_key(f5mku: &str) -> Result<Aes, F5MkuError> {
+    let key = B64.decode(f5mku).map_err(|_| bad_key())?;
+    match key.len() {
+        16 => Ok(Aes::A128(Box::new(Aes128::new(GenericArray::from_slice(
+            &key,
+        ))))),
+        24 => Ok(Aes::A192(Box::new(Aes192::new(GenericArray::from_slice(
+            &key,
+        ))))),
+        32 => Ok(Aes::A256(Box::new(Aes256::new(GenericArray::from_slice(
+            &key,
+        ))))),
+        _ => Err(bad_key()),
+    }
+}
+
+fn bad_key() -> F5MkuError {
+    F5MkuError(
+        "decoding of f5mku failed. Make sure you are using the base64 \
+         formatted key returned by: f5mku -K"
+            .to_owned(),
+    )
+}
+
+fn resolve_salt(salt: Option<&str>) -> Result<Vec<u8>, F5MkuError> {
+    match salt {
+        None => {
+            // A fresh random two-char salt from `[A-Za-z0-9]`.
+            let mut buf = [0u8; SALT_LENGTH];
+            getrandom::fill(&mut buf)
+                .map_err(|e| F5MkuError(format!("could not gather randomness for salt: {e}")))?;
+            Ok(buf
+                .iter()
+                .map(|b| SALT_ALPHABET[(*b as usize) % SALT_ALPHABET.len()])
+                .collect())
+        }
+        Some(s) if s.contains('$') => {
+            // Accept a full F5 ciphertext and reuse its salt.
+            Ok(extract_salt(s)?.into_bytes())
+        }
+        Some(s) => Ok(s.as_bytes().to_vec()),
+    }
+}
+
+fn ecb_encrypt(cipher: &Aes, data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    for chunk in data.chunks_exact(BLOCK_SIZE) {
+        let block: [u8; BLOCK_SIZE] = chunk.try_into().expect("chunks_exact yields full blocks");
+        out.extend_from_slice(&cipher.encrypt_block(&block));
+    }
+    out
+}
+
+fn ecb_decrypt(cipher: &Aes, data: &[u8]) -> Result<Vec<u8>, F5MkuError> {
+    if data.is_empty() || !data.len().is_multiple_of(BLOCK_SIZE) {
+        return Err(F5MkuError(
+            "ciphertext length is not a multiple of the AES block size".to_owned(),
+        ));
+    }
+    let mut out = Vec::with_capacity(data.len());
+    for chunk in data.chunks_exact(BLOCK_SIZE) {
+        let block: [u8; BLOCK_SIZE] = chunk.try_into().expect("chunks_exact yields full blocks");
+        out.extend_from_slice(&cipher.decrypt_block(&block));
+    }
+    Ok(out)
+}
+
+fn pkcs7_pad(data: &[u8]) -> Vec<u8> {
+    let pad = BLOCK_SIZE - (data.len() % BLOCK_SIZE); // 1..=16
+    let pad_byte = u8::try_from(pad).expect("pad is in 1..=16");
+    let mut out = data.to_vec();
+    out.extend(std::iter::repeat_n(pad_byte, pad));
+    out
+}
+
+fn pkcs7_unpad(data: &[u8]) -> Result<Vec<u8>, F5MkuError> {
+    let Some(&pad) = data.last() else {
+        return Err(F5MkuError("empty plaintext after decryption".to_owned()));
+    };
+    let pad = usize::from(pad);
+    if !(1..=BLOCK_SIZE).contains(&pad)
+        || data.len() < pad
+        || data[data.len() - pad..].iter().any(|&b| usize::from(b) != pad)
+    {
+        return Err(F5MkuError(
+            "invalid PKCS#7 padding (wrong master key?)".to_owned(),
+        ));
+    }
+    Ok(data[..data.len() - pad].to_vec())
+}
+
+fn strip_salt(plaintext: &[u8], salt: &[u8]) -> Result<Vec<u8>, F5MkuError> {
+    if !plaintext.starts_with(salt) {
+        return Err(F5MkuError(
+            "decrypted text does not start with its salt (wrong master key?)".to_owned(),
+        ));
+    }
+    Ok(plaintext[salt.len()..].to_vec())
+}
+
+fn deconstruct_ciphertext(ciphertext: &str) -> Result<Ciphertext, F5MkuError> {
+    let parts: Vec<&str> = ciphertext.split('$').collect();
+    if parts.len() != 4 || !parts[0].is_empty() || parts[1] != "M" {
+        return Err(F5MkuError(format!(
+            "unrecognised ciphertext: expected '$M$<salt>$<base64>', got {ciphertext:?}"
+        )));
+    }
+    let salt = parts[2];
+    let body = parts[3];
+    if salt.is_empty() {
+        return Err(F5MkuError("unrecognised ciphertext: empty salt".to_owned()));
+    }
+    if body.is_empty() {
+        return Err(F5MkuError(
+            "unrecognised ciphertext: empty ciphertext".to_owned(),
+        ));
+    }
+    let decoded = B64.decode(body).map_err(|_| {
+        F5MkuError(format!(
+            "unrecognised ciphertext: malformed base64 {body:?}"
+        ))
+    })?;
+    Ok(Ciphertext {
+        salt: salt.as_bytes().to_vec(),
+        ciphertext: decoded,
+    })
+}
+
+fn format_ciphertext(salt: &[u8], body: &[u8]) -> String {
+    let salt = String::from_utf8_lossy(salt);
+    format!("$M${salt}${}", B64.encode(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &str = "BHDLd0bbao1VlwpTk1sioQ==";
+
+    #[test]
+    fn known_answers() {
+        assert_eq!(
+            decrypt("$M$iP$rr0su9oHn9J9p1t3nRzydA==", KEY).unwrap(),
+            "KEY45678"
+        );
+        assert_eq!(
+            encrypt("KEY45678", KEY, Some("ab")).unwrap(),
+            "$M$ab$mmIL9xEWGe7pbNtvS/QAQA=="
+        );
+        assert_eq!(
+            extract_salt("$M$iP$rr0su9oHn9J9p1t3nRzydA==").unwrap(),
+            "iP"
+        );
+    }
+
+    #[test]
+    fn salt_from_ciphertext() {
+        // A full ciphertext may be reused as the salt source.
+        assert_eq!(
+            encrypt("KEY45678", KEY, Some("$M$ab$mmIL9xEWGe7pbNtvS/QAQA==")).unwrap(),
+            "$M$ab$mmIL9xEWGe7pbNtvS/QAQA=="
+        );
+    }
+
+    #[test]
+    fn round_trip_random_salt() {
+        for plaintext in ["", "x", "hunter2", "spaces and $ymbol$", "é—utf8"] {
+            let ct = encrypt(plaintext, KEY, None).unwrap();
+            assert!(is_ciphertext(&ct), "{ct} should look like ciphertext");
+            assert_eq!(decrypt(&ct, KEY).unwrap(), plaintext);
+        }
+    }
+
+    #[test]
+    fn bad_key_raises() {
+        assert!(encrypt("x", "not base64!!!", None).is_err());
+    }
+
+    #[test]
+    fn wrong_key_raises() {
+        let ct = encrypt("topsecret", KEY, None).unwrap();
+        assert!(decrypt(&ct, "AAAAAAAAAAAAAAAAAAAAAA==").is_err());
+    }
+
+    #[test]
+    fn malformed_ciphertext() {
+        for bad in ["plain", "$M$$body==", "$M$ab$", "$X$ab$body=="] {
+            assert!(!is_ciphertext(bad), "{bad} should not look like ciphertext");
+            assert!(decrypt(bad, KEY).is_err());
+        }
+    }
+}

--- a/rust/f5-cli/src/lib.rs
+++ b/rust/f5-cli/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod cli;
 mod commands;
+pub mod f5mku;
 
 use std::ffi::OsString;
 use std::process::ExitCode;
@@ -205,6 +206,37 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             format,
             output,
         } => commands::unredact::run_unredact(map_file, path, format, output.as_deref()),
+        Command::EncryptSecrets {
+            path,
+            output,
+            key,
+            salt,
+            passphrase,
+            format,
+        } => commands::secrets::run_secrets(
+            commands::secrets::Mode::Encrypt,
+            path,
+            key,
+            salt.as_deref(),
+            passphrase,
+            format,
+            output.as_deref(),
+        ),
+        Command::DecryptSecrets {
+            path,
+            output,
+            key,
+            passphrase,
+            format,
+        } => commands::secrets::run_secrets(
+            commands::secrets::Mode::Decrypt,
+            path,
+            key,
+            None,
+            passphrase,
+            format,
+            output.as_deref(),
+        ),
         Command::Tmsh {
             path,
             output,

--- a/rust/f5-cli/tests/secrets_parity.rs
+++ b/rust/f5-cli/tests/secrets_parity.rs
@@ -1,0 +1,251 @@
+//! Behaviour tests for the `f5 encrypt-secrets` / `decrypt-secrets` verbs.
+//!
+//! Drives the built `f5-query` binary the way `tests/test_f5_secrets.py` drives
+//! the Python CLI: a known F5 master key, a forced salt for deterministic
+//! output, and the round-trip / idempotency / key-source / edge-case
+//! assertions. The crypto known-answer + round-trip vectors themselves live in
+//! the `f5mku` unit tests; here we assert the verbs' observable behaviour.
+//!
+//! Self-contained: no Python at test time.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A real F5 master key (from the original f5mkupy docstrings).
+const KEY: &str = "BHDLd0bbao1VlwpTk1sioQ==";
+
+const CONF: &str = "ltm monitor https /Common/mon {\n    password clearpw\n    username admin\n}\nauth radius-server /Common/rad {\n    secret \"my radius secret\"\n}\nsys snmp {\n    communities {\n        public { community-name public }\n    }\n}\n";
+
+/// A unique scratch dir, removed on drop.
+struct ScratchDir(PathBuf);
+
+impl ScratchDir {
+    fn new() -> ScratchDir {
+        static SEQ: AtomicU32 = AtomicU32::new(0);
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("f5-secrets-{}-{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("create scratch dir");
+        ScratchDir(path)
+    }
+    fn write(&self, name: &str, content: &str) -> PathBuf {
+        let p = self.0.join(name);
+        std::fs::write(&p, content).expect("write fixture");
+        p
+    }
+    fn join(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Run {
+    code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// Run `f5-query` with `args`, clearing `$F5MKU` so the env never leaks a key
+/// into a test that means to omit one. `env` adds extra environment.
+fn run(args: &[&str], env: &[(&str, &str)]) -> Run {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_f5-query"));
+    cmd.args(args).env_remove("F5MKU");
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("spawn f5-query");
+    Run {
+        code: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+#[test]
+fn round_trip() {
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+    let sealed = dir.join("sealed.conf");
+
+    let r = run(
+        &[
+            "encrypt-secrets",
+            conf.to_str().unwrap(),
+            "-k",
+            KEY,
+            "--salt",
+            "ab",
+            "-o",
+            sealed.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(
+        r.stderr.contains("encrypted: 2 secret(s)"),
+        "stderr: {}",
+        r.stderr
+    );
+    let sealed_text = std::fs::read_to_string(&sealed).unwrap();
+    assert!(!sealed_text.contains("clearpw"));
+    assert!(sealed_text.contains("$M$ab$"));
+
+    let r = run(
+        &["decrypt-secrets", sealed.to_str().unwrap(), "-k", KEY],
+        &[],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(
+        r.stderr.contains("decrypted: 2 secret(s)"),
+        "stderr: {}",
+        r.stderr
+    );
+    assert!(r.stdout.contains("password clearpw"));
+    assert!(r.stdout.contains("my radius secret"));
+}
+
+#[test]
+fn encrypt_is_idempotent() {
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+
+    let r = run(&["encrypt-secrets", conf.to_str().unwrap(), "-k", KEY], &[]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    let sealed = dir.write("sealed.conf", &r.stdout);
+
+    let r = run(
+        &["encrypt-secrets", sealed.to_str().unwrap(), "-k", KEY],
+        &[],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(
+        r.stderr
+            .contains("encrypted: 0 secret(s); 2 left untouched"),
+        "stderr: {}",
+        r.stderr
+    );
+}
+
+#[test]
+fn encrypt_skips_existing_crypt_hash() {
+    // A crypt(3) hash sitting under a secret key must not be re-wrapped.
+    let dir = ScratchDir::new();
+    let conf = dir.write(
+        "bigip.conf",
+        "ltm monitor http /Common/m {\n    password $6$salt$hash\n}\n",
+    );
+    let r = run(&["encrypt-secrets", conf.to_str().unwrap(), "-k", KEY], &[]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(
+        r.stderr
+            .contains("encrypted: 0 secret(s); 1 left untouched"),
+        "stderr: {}",
+        r.stderr
+    );
+    assert!(r.stdout.contains("password $6$salt$hash"));
+}
+
+#[test]
+fn alias_encrypt_decrypt() {
+    // The `encrypt` / `decrypt` aliases resolve to the same verbs.
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+    let r = run(
+        &["encrypt", conf.to_str().unwrap(), "-k", KEY, "--salt", "ab"],
+        &[],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("$M$ab$"));
+}
+
+#[test]
+fn tmsh_delta_does_not_recreate_existing_objects() {
+    // With --format tmsh-delta the pre-rewrite source is the delta baseline, so
+    // existing objects emit `modify`, not a spurious `create`.
+    let dir = ScratchDir::new();
+    let conf = dir.write(
+        "bigip.conf",
+        "ltm monitor https /Common/mon {\n    password clearpw\n}\n",
+    );
+    let r = run(
+        &[
+            "encrypt-secrets",
+            conf.to_str().unwrap(),
+            "-k",
+            KEY,
+            "--salt",
+            "ab",
+            "--format",
+            "tmsh-delta",
+        ],
+        &[],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(!r.stdout.contains("create"), "stdout: {}", r.stdout);
+}
+
+#[test]
+fn key_from_env() {
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+    let r = run(
+        &["encrypt-secrets", conf.to_str().unwrap()],
+        &[("F5MKU", KEY)],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("$M$"));
+}
+
+#[test]
+fn key_from_file() {
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+    // A trailing newline (as `f5mku -K > key.txt` leaves) must be trimmed.
+    let keyfile = dir.write("key.txt", &format!("{KEY}\n"));
+    let r = run(
+        &[
+            "encrypt-secrets",
+            conf.to_str().unwrap(),
+            "--f5mku-file",
+            keyfile.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("$M$"));
+}
+
+#[test]
+fn missing_key_errors() {
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+    let r = run(
+        &["encrypt-secrets", conf.to_str().unwrap(), "--no-key-prompt"],
+        &[],
+    );
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("no master key"), "stderr: {}", r.stderr);
+}
+
+#[test]
+fn bad_key_errors() {
+    let dir = ScratchDir::new();
+    let conf = dir.write("bigip.conf", CONF);
+    let r = run(
+        &[
+            "encrypt-secrets",
+            conf.to_str().unwrap(),
+            "-k",
+            "not base64!!!",
+        ],
+        &[],
+    );
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("f5mku"), "stderr: {}", r.stderr);
+}

--- a/rust/tcl-bigip/src/lib.rs
+++ b/rust/tcl-bigip/src/lib.rs
@@ -31,6 +31,7 @@ pub mod pcap_remap;
 pub mod pcapng;
 pub mod range;
 pub mod redact;
+pub mod secrets;
 pub mod stats;
 pub mod tmsh_emit;
 pub mod value;

--- a/rust/tcl-bigip/src/secrets.rs
+++ b/rust/tcl-bigip/src/secrets.rs
@@ -1,0 +1,219 @@
+//! Locate and rewrite the master-key-encrypted secret values in a config.
+//!
+//! Faithful Rust port of the `rewrite_secrets` half of
+//! `dialects/f5/bigip/rewrite.py` ([`rewrite_secrets`], [`ENCRYPTED_SECRET_KEYS`],
+//! [`SecretRewriteReport`]). This is a text-level rewrite — comments,
+//! whitespace, and ordering survive — and it stays free of any crypto
+//! dependency: the caller (`f5 encrypt-secrets` / `f5 decrypt-secrets`) supplies
+//! the actual cipher as a `transform` closure.
+//!
+//! # Which keys
+//!
+//! [`ENCRYPTED_SECRET_KEYS`] is a deliberately tighter set than the redactor's
+//! `_SECRET_KEYS`:
+//!
+//! - Redaction also blanks SNMP community strings and monitor receive strings,
+//!   but those are kept in clear text on the device and are never master-key
+//!   encrypted, so feeding them through the cipher would corrupt the config.
+//! - `encrypted-password` is intentionally absent: in `auth user` stanzas it
+//!   holds the operating-system crypt(3) hash (`$6$…`), not a master-key `$M$`
+//!   secret, so encrypting it would wreck the local-user credential. (The APM
+//!   `*-encrypted-password` variants are prefixed and so never match the
+//!   word-boundary key pattern.)
+//!
+//! `SNMPv3` secrets are `auth-password` / `privacy-password` — the names the F5
+//! SNMP registry uses for trap and user stanzas (NOT `priv-password`).
+
+use regex::Regex;
+
+/// BIG-IP fields whose values it stores encrypted under the unit master key
+/// (the `$M$...` envelope produced by `f5mku`).
+pub const ENCRYPTED_SECRET_KEYS: [&str; 6] = [
+    "passphrase",
+    "password",
+    "secret",
+    "shared-secret",
+    "auth-password",
+    "privacy-password",
+];
+
+/// Values BIG-IP uses as a sentinel for "no secret set" — never crypto.
+const SECRET_SENTINELS: [&str; 2] = ["none", "<REDACTED>"];
+
+/// The outcome of a [`rewrite_secrets`] pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretRewriteReport {
+    /// Number of secret values `transform` actually rewrote.
+    pub transformed: usize,
+    /// Number of secret-bearing values left untouched (`transform` returned
+    /// `None` — e.g. already in the target form, or a `none` sentinel).
+    pub skipped: usize,
+    /// The rewritten source text.
+    pub new_source: String,
+}
+
+/// Build the per-key matcher: word-boundary KEY, the run of spaces/tabs between
+/// key and value, then the value token (a double-quoted string or a run of
+/// non-whitespace, non-brace characters). Group 1 = key, 2 = gap, 3 = value.
+///
+/// Python emulates the `(?<![\w-])` look-behind with a leading boundary group;
+/// the `regex` crate has no look-around, so the caller checks the preceding byte
+/// manually (mirroring `redact.rs`'s approach for the IP guards).
+fn key_pattern(key: &str) -> Regex {
+    // `"(?:[^"\\]|\\.)*"|[^\s{}]+` — quoted string OR bare token.
+    let value = r#""(?:[^"\\]|\\.)*"|[^\s{}]+"#;
+    Regex::new(&format!(r"({})([ \t]+)({value})", regex::escape(key))).expect("valid secret regex")
+}
+
+/// `\w` in Python's default mode for ASCII config text is `[A-Za-z0-9_]`; the
+/// key-boundary guard is `(?<![\w-])`, so the preceding byte must not be a word
+/// byte or a hyphen (keeps `admin-encrypted-password` from matching `password`).
+fn key_boundary_ok(bytes: &[u8], start: usize) -> bool {
+    start == 0 || {
+        let b = bytes[start - 1];
+        !(b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    }
+}
+
+/// Return `(value, was_quoted)` for a secret-value `token` (port of `_unquote`).
+fn unquote(token: &str) -> (String, bool) {
+    let bytes = token.as_bytes();
+    if bytes.len() >= 2 && bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"' {
+        let inner = &token[1..token.len() - 1];
+        (inner.replace("\\\"", "\"").replace("\\\\", "\\"), true)
+    } else {
+        (token.to_owned(), false)
+    }
+}
+
+/// Render `value` back as a SCF token, quoting when it needs it (port of
+/// `_requote`).
+fn requote(value: &str, was_quoted: bool) -> String {
+    let needs_quote =
+        was_quoted || value.is_empty() || value.chars().any(|c| " \t\"{}#;".contains(c));
+    if !needs_quote {
+        return value.to_owned();
+    }
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Apply `transform` to every encrypted-secret-bearing value in `source`.
+///
+/// For each `<key> <value>` whose key is in [`ENCRYPTED_SECRET_KEYS`],
+/// `transform` is called with the decoded value and returns the replacement
+/// value, or `None` to leave it untouched. The literals `none` / `<REDACTED>`
+/// are always skipped without calling `transform`.
+pub fn rewrite_secrets<F>(source: &str, mut transform: F) -> SecretRewriteReport
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut transformed = 0usize;
+    let mut skipped = 0usize;
+    let mut out = source.to_owned();
+
+    for key in ENCRYPTED_SECRET_KEYS {
+        let re = key_pattern(key);
+        let mut result = String::with_capacity(out.len());
+        let mut last = 0usize;
+        let bytes = out.as_bytes();
+        for caps in re.captures_iter(&out) {
+            let whole = caps.get(0).expect("group 0");
+            // Emulate the `(?<![\w-])` look-behind: skip a match whose key is
+            // glued to a preceding word byte / hyphen (e.g. the `password` tail
+            // of `admin-encrypted-password`).
+            if !key_boundary_ok(bytes, whole.start()) {
+                continue;
+            }
+            result.push_str(&out[last..whole.start()]);
+            let key_tok = caps.get(1).expect("key group").as_str();
+            let gap = caps.get(2).expect("gap group").as_str();
+            let value_tok = caps.get(3).expect("value group").as_str();
+            let (value, was_quoted) = unquote(value_tok);
+            let replacement = if SECRET_SENTINELS.contains(&value.as_str()) {
+                None
+            } else {
+                transform(&value)
+            };
+            if let Some(new_value) = replacement {
+                transformed += 1;
+                result.push_str(key_tok);
+                result.push_str(gap);
+                result.push_str(&requote(&new_value, was_quoted));
+            } else {
+                skipped += 1;
+                result.push_str(whole.as_str());
+            }
+            last = whole.end();
+        }
+        result.push_str(&out[last..]);
+        out = result;
+    }
+
+    SecretRewriteReport {
+        transformed,
+        skipped,
+        new_source: out,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONF: &str = "ltm monitor https /Common/mon {\n    password clearpw\n    username admin\n}\nauth radius-server /Common/rad {\n    secret \"my radius secret\"\n}\nsys snmp {\n    communities {\n        public { community-name public }\n    }\n}\n";
+
+    #[test]
+    fn only_touches_encrypted_secret_keys() {
+        let report = rewrite_secrets(CONF, |v| Some(format!("<{v}>")));
+        // password + secret are rewritten; the SNMP community-name and the
+        // username are not.
+        assert_eq!(report.transformed, 2);
+        assert!(report.new_source.contains("password <clearpw>"));
+        assert!(report.new_source.contains("<my radius secret>"));
+        assert!(report.new_source.contains("community-name public"));
+        assert!(report.new_source.contains("username admin"));
+    }
+
+    #[test]
+    fn skips_sentinels() {
+        let report = rewrite_secrets("password none\nsecret <REDACTED>\n", |_| {
+            Some("X".to_owned())
+        });
+        assert_eq!(report.transformed, 0);
+        assert_eq!(report.skipped, 2);
+    }
+
+    #[test]
+    fn transform_none_is_left_untouched() {
+        let report = rewrite_secrets(CONF, |_| None);
+        assert_eq!(report.transformed, 0);
+        assert_eq!(report.new_source, CONF);
+    }
+
+    #[test]
+    fn ignores_auth_user_crypt_hash() {
+        // `auth user ... encrypted-password $6$...` is an OS crypt hash, not an
+        // f5mku $M$ secret — it must not be in the encrypted-secret key set.
+        let conf = "auth user /Common/admin {\n    encrypted-password $6$abc123$def456\n}\n";
+        let report = rewrite_secrets(conf, |v| Some(format!("<{v}>")));
+        assert_eq!(report.transformed, 0);
+        assert_eq!(report.new_source, conf);
+    }
+
+    #[test]
+    fn handles_snmpv3_privacy_password() {
+        let conf = "sys snmp {\n    users {\n        u1 {\n            auth-password authpw\n            privacy-password privpw\n        }\n    }\n}\n";
+        let report = rewrite_secrets(conf, |v| Some(format!("<{v}>")));
+        assert_eq!(report.transformed, 2);
+        assert!(report.new_source.contains("auth-password <authpw>"));
+        assert!(report.new_source.contains("privacy-password <privpw>"));
+    }
+
+    #[test]
+    fn requotes_when_needed() {
+        // A value with spaces is re-quoted; a bare one stays bare.
+        let report = rewrite_secrets("password bare\n", |_| Some("has space".to_owned()));
+        assert!(report.new_source.contains("password \"has space\""));
+    }
+}

--- a/rust/tcl-cli-support/Cargo.toml
+++ b/rust/tcl-cli-support/Cargo.toml
@@ -19,5 +19,10 @@ anstyle = "1"
 tabled = "0.21"
 rpassword = "7"
 
+[dev-dependencies]
+# Scoped env-var mutation for the secret-input resolver tests (the workspace
+# forbids `unsafe`, so `std::env::set_var` cannot be called directly).
+temp-env = "0.3"
+
 [lints]
 workspace = true

--- a/rust/tcl-cli-support/src/lib.rs
+++ b/rust/tcl-cli-support/src/lib.rs
@@ -17,6 +17,7 @@ mod input;
 mod output;
 pub mod prompt;
 mod registry;
+pub mod secret_input;
 
 pub use highlight::{highlight_ansi, highlight_html};
 pub use input::{CliError, InputDocument, combine_sources, read_input_documents};

--- a/rust/tcl-cli-support/src/secret_input.rs
+++ b/rust/tcl-cli-support/src/secret_input.rs
@@ -1,0 +1,204 @@
+//! Shared secret-input resolution for the native `tcl` / `f5` CLIs.
+//!
+//! Faithful Rust port of `tooling/f5/f5_remote/secret_input.py`: a single,
+//! idiomatic way to obtain a secret (passphrase, master key, password, …) from
+//! the four sources the CLI supports, tried in a fixed order — the first
+//! non-empty one wins:
+//!
+//! 1. an explicit value (e.g. a `--f5mku` flag),
+//! 2. a file (e.g. `--f5mku-file key.txt`),
+//! 3. an environment variable (e.g. `$F5MKU`), and
+//! 4. a secure, no-echo terminal prompt via [`rpassword`].
+//!
+//! Centralising this keeps the tty detection correct in one place — the prompt
+//! is offered whenever *either* stdin or stderr is a terminal, and `rpassword`
+//! itself reads from the controlling `/dev/tty`, so a prompt still works when
+//! the config is piped in on stdin (`f5 decrypt-secrets -`).
+//! [`resolve_secret`] returns `Ok(None)` when no source yields a value, leaving
+//! the caller to decide whether that is an error; a cancelled prompt (Ctrl-C /
+//! EOF) returns [`SecretInputError`].
+
+use std::io::IsTerminal;
+use std::path::Path;
+
+/// Raised when interactive secret entry is cancelled (port of
+/// `SecretInputError`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretInputError(pub String);
+
+impl std::fmt::Display for SecretInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SecretInputError {}
+
+/// The sources [`resolve_secret`] consults, in priority order.
+#[derive(Debug, Default, Clone)]
+pub struct SecretRequest<'a> {
+    /// An explicit value (highest priority, e.g. a `--f5mku` flag).
+    pub explicit: Option<&'a str>,
+    /// A file to read the secret from (e.g. `--f5mku-file key.txt`).
+    pub file: Option<&'a Path>,
+    /// Environment variable consulted when no explicit value or file resolved.
+    pub env_var: Option<&'a str>,
+    /// Whether a secure terminal prompt is permitted as the last resort.
+    pub allow_prompt: bool,
+    /// Prompt text shown when prompting (e.g. `"F5 MKU Key: "`). `None` disables
+    /// prompting regardless of `allow_prompt`.
+    pub prompt: Option<&'a str>,
+    /// Whitespace-trim the resolved value. Leave `false` for passphrases /
+    /// passwords (surrounding whitespace can be significant); set `true` for
+    /// tokens that never carry whitespace (a base64 key read from
+    /// `f5mku -K > key.txt` picks up a trailing newline).
+    pub strip: bool,
+}
+
+/// Whether a controlling terminal is available to prompt on (port of
+/// `_has_tty`): true when *either* stdin or stderr is a terminal.
+#[must_use]
+pub fn has_tty() -> bool {
+    std::io::stdin().is_terminal() || std::io::stderr().is_terminal()
+}
+
+fn norm(value: &str, strip: bool) -> String {
+    if strip {
+        value.trim().to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+/// Resolve a secret from an explicit value, a file, an env var, or a prompt.
+///
+/// Sources are tried in that fixed order and the first non-empty one wins.
+/// Returns `Ok(None)` when nothing yields a value (the caller decides whether
+/// that is fatal).
+///
+/// # Errors
+/// Returns [`SecretInputError`] when a file cannot be read, or an interactive
+/// prompt is cancelled (Ctrl-C / EOF).
+pub fn resolve_secret(req: &SecretRequest) -> Result<Option<String>, SecretInputError> {
+    if let Some(explicit) = req.explicit
+        && !explicit.is_empty()
+    {
+        return Ok(Some(norm(explicit, req.strip)));
+    }
+
+    if let Some(file) = req.file {
+        let text = std::fs::read_to_string(file).map_err(|e| {
+            SecretInputError(format!("cannot read secret file {}: {e}", file.display()))
+        })?;
+        let text = norm(&text, req.strip);
+        if !text.is_empty() {
+            return Ok(Some(text));
+        }
+    }
+
+    if let Some(env_var) = req.env_var
+        && let Ok(val) = std::env::var(env_var)
+        && !val.is_empty()
+    {
+        return Ok(Some(norm(&val, req.strip)));
+    }
+
+    if req.allow_prompt
+        && let Some(prompt) = req.prompt
+        && has_tty()
+    {
+        let entered = rpassword::prompt_password(prompt)
+            .map_err(|_| SecretInputError("secret entry cancelled".to_owned()))?;
+        let entered = norm(&entered, req.strip);
+        if !entered.is_empty() {
+            return Ok(Some(entered));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests cover the non-prompt resolution order. The prompt branch
+    // needs a real controlling terminal (`rpassword` reads `/dev/tty`) and is
+    // exercised by the CLI integration tests instead. Env-var mutation is
+    // process-global and `unsafe` under the workspace lints, so the env cases go
+    // through `temp_env::with_var` (a scoped, panic-safe set/restore).
+
+    #[test]
+    fn explicit_wins() {
+        temp_env::with_var("SI_EXPLICIT", Some("from-env"), || {
+            let req = SecretRequest {
+                explicit: Some("from-flag"),
+                env_var: Some("SI_EXPLICIT"),
+                ..Default::default()
+            };
+            assert_eq!(resolve_secret(&req).unwrap().as_deref(), Some("from-flag"));
+        });
+    }
+
+    #[test]
+    fn file_before_env() {
+        let dir = std::env::temp_dir().join(format!("si-file-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let keyfile = dir.join("k");
+        std::fs::write(&keyfile, "from-file\n").unwrap();
+        temp_env::with_var("SI_FILE", Some("from-env"), || {
+            let req = SecretRequest {
+                file: Some(&keyfile),
+                env_var: Some("SI_FILE"),
+                strip: true, // trims the trailing newline a key file picks up
+                ..Default::default()
+            };
+            assert_eq!(resolve_secret(&req).unwrap().as_deref(), Some("from-file"));
+        });
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn env_used_when_no_explicit_or_file() {
+        temp_env::with_var("SI_ENV", Some("from-env"), || {
+            let req = SecretRequest {
+                env_var: Some("SI_ENV"),
+                ..Default::default()
+            };
+            assert_eq!(resolve_secret(&req).unwrap().as_deref(), Some("from-env"));
+        });
+    }
+
+    #[test]
+    fn strip_false_preserves_whitespace() {
+        temp_env::with_var("SI_WS", Some("  spaced  "), || {
+            let req = SecretRequest {
+                env_var: Some("SI_WS"),
+                strip: false,
+                ..Default::default()
+            };
+            assert_eq!(resolve_secret(&req).unwrap().as_deref(), Some("  spaced  "));
+        });
+    }
+
+    #[test]
+    fn missing_file_is_error() {
+        let req = SecretRequest {
+            file: Some(Path::new("/nonexistent/si/key.txt")),
+            ..Default::default()
+        };
+        assert!(resolve_secret(&req).is_err());
+    }
+
+    #[test]
+    fn nothing_resolves_to_none() {
+        temp_env::with_var_unset("SI_NONE", || {
+            let req = SecretRequest {
+                env_var: Some("SI_NONE"),
+                allow_prompt: false,
+                ..Default::default()
+            };
+            assert_eq!(resolve_secret(&req).unwrap(), None);
+        });
+    }
+}


### PR DESCRIPTION
Ports the BIG-IP unit-master-key (`f5mku`) secret crypto feature to the native Rust `f5-query` CLI, mirroring the Python implementation merged on `main` (PR #613). Rust output is **byte-for-byte identical** to the Python CLI (verified by diffing encrypt + decrypt + the stderr report lines against `python -m tooling.f5.main`).

## Verbs

Two verbs with aliases: `encrypt-secrets` (`encrypt`) and `decrypt-secrets` (`decrypt`), operating on every secret-bearing value in a bigip.conf / SCF using the base64 key `f5mku -K` prints.

## What landed

- **`rust/f5-cli/src/f5mku.rs`** — the crypto primitive (`encrypt` / `decrypt` / `extract_salt` / `is_ciphertext` / `F5MkuError`). AES-ECB + PKCS#7 + `$M$<salt>$<base64>` envelope, delegating the block transform to the already-vendored `aes` crate; random `[A-Za-z0-9]` salt via `getrandom`, forced-salt + full-ciphertext salt reuse. All known-answer vectors pass exactly.
- **`rust/tcl-bigip/src/secrets.rs`** — crypto-free `rewrite_secrets` + the tighter `ENCRYPTED_SECRET_KEYS` set (`passphrase`, `password`, `secret`, `shared-secret`, `auth-password`, `privacy-password`). Bakes in the reviewed edge cases: no `encrypted-password` (auth-user crypt(3) hash), `privacy-password` not `priv-password`, `none` / `<REDACTED>` sentinels skipped, idempotent `$scheme$…` skip, word-boundary key match, re-quote only when needed; preserves comments / whitespace / order.
- **`rust/tcl-cli-support/src/secret_input.rs`** — shared explicit→file→env→prompt secret resolver (the missing analogue of `secret_input.py`), wired through for the master key.
- **`rust/f5-cli/src/commands/secrets.rs` + cli/dispatch wiring** — master-key resolution (`-k/--f5mku`, `--f5mku-file`, `$F5MKU`, secure `F5 MKU Key:` prompt via `rpassword`, `--no-key-prompt`), `-o/--output`, the shared `--format scf|tmsh|tmsh-delta` (delta baselined on the pre-rewrite source so existing objects emit `modify`, not a spurious `create`), fail-fast key probe, and the `<n> secret(s); <n> left untouched` report. Surfaces in help, aliases, and shell completion.

## Tests

- f5mku unit tests: known-answer vectors, round-trips (empty / spaces / non-ASCII), malformed-input.
- secrets-rewrite unit tests: each edge case (crypt-hash exclusion, SNMPv3 privacy-password, sentinels, requoting).
- secret-input resolver unit tests (explicit/file/env/none order).
- `secrets_parity.rs` driving the built binary: round-trip, idempotency, existing-crypt-hash skip, key-from-env / key-from-file, missing / bad key, tmsh-delta.

## Docs

README highlight + verb table, and a KCS feature note (`kcs-feature-f5-secret-crypto.md`) covering both front-ends.

## Gate

`cargo fmt --check` (new files clean), `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace --all-features` all pass (0 failures).

## Notes

- The registry/behaviour contract covers command/event/profile/object registries; encrypt/decrypt-secrets isn't a registry surface, so there's nothing to wire in there — behaviour is covered by the parity tests.
- The `rust` branch doesn't track `.test-slow.stamp`, so there's none to regenerate. The base branch is already fmt-dirty under rustc 1.96 (rustfmt drift from PR #612, in 3 unrelated files) — those incidental reformats were left out to keep this diff focused; happy to address separately.

https://claude.ai/code/session_01Vnfyu1rvG9e3GmMMYUQVQn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnfyu1rvG9e3GmMMYUQVQn)_