### PR TITLE
Implement TIP 348 error stack and TIP 329 exception chaining

### DIFF
--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -366,31 +366,8 @@ fn parse_code(b: &[u8]) -> Option<Code> {
         b"return" => Some(Code::Return),
         b"break" => Some(Code::Break),
         b"continue" => Some(Code::Continue),
-        _ => parse_code_int(b).map(Code::from_int),
+        _ => crate::interp::parse_completion_int(b).map(Code::from_int),
     }
-}
-
-/// Parse a completion-code integer the way `TclGetIntFromObj` would: an optional
-/// sign then a `0x`/`0o`/`0b`/`0d` radix prefix (else decimal), within an `i32`.
-fn parse_code_int(b: &[u8]) -> Option<i32> {
-    let s = core::str::from_utf8(b).ok()?.trim();
-    let (neg, rest) = match s.as_bytes().first() {
-        Some(b'-') => (true, &s[1..]),
-        Some(b'+') => (false, &s[1..]),
-        _ => (false, s),
-    };
-    let (radix, digits) = match rest.as_bytes() {
-        [b'0', b'x' | b'X', ..] => (16, &rest[2..]),
-        [b'0', b'o' | b'O', ..] => (8, &rest[2..]),
-        [b'0', b'b' | b'B', ..] => (2, &rest[2..]),
-        [b'0', b'd' | b'D', ..] => (10, &rest[2..]),
-        _ => (10, rest),
-    };
-    if digits.is_empty() {
-        return None;
-    }
-    let mag = i32::from_str_radix(digits, radix).ok()?;
-    Some(if neg { mag.checked_neg()? } else { mag })
 }
 
 /// `return ?-code code? ?-level n? ?-errorcode list? ?-errorinfo info?

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -378,6 +378,7 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut level: usize = 1;
     let mut errorcode: Option<Vec<u8>> = None;
     let mut errorinfo: Option<Vec<u8>> = None;
+    let mut errorstack: Option<Vec<u8>> = None;
 
     let mut i = 1;
     while i + 1 < argv.len() {
@@ -403,6 +404,7 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             },
             b"-errorcode" => errorcode = Some(obj_bytes(argv[i + 1])),
             b"-errorinfo" => errorinfo = Some(obj_bytes(argv[i + 1])),
+            b"-errorstack" => errorstack = Some(obj_bytes(argv[i + 1])),
             b"-options" => {
                 // Seed code/level/errorcode/errorinfo from the options dict.
                 let opts = obj_bytes(argv[i + 1]);
@@ -419,6 +421,7 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                             }
                             b"-errorcode" => errorcode = Some(d[j + 1].clone()),
                             b"-errorinfo" => errorinfo = Some(d[j + 1].clone()),
+                            b"-errorstack" => errorstack = Some(d[j + 1].clone()),
                             _ => {}
                         }
                         j += 2;
@@ -428,6 +431,33 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             _ => break, // not an option → the result word
         }
         i += 2;
+    }
+    // Validate -errorcode / -errorstack (`TclMergeReturnOptions`). A malformed
+    // value errors before the return takes effect, with a specific `-errorcode`.
+    if let Some(ec) = &errorcode {
+        if crate::parse::split_list(ec).is_err() {
+            let mut m = b"bad -errorcode value: expected a list but got \"".to_vec();
+            m.extend_from_slice(ec);
+            m.push(b'"');
+            return interp.error_with_code(&m, b"TCL RESULT ILLEGAL_ERRORCODE");
+        }
+    }
+    if let Some(es) = &errorstack {
+        match crate::parse::split_list(es) {
+            Err(_) => {
+                let mut m = b"bad -errorstack value: expected a list but got \"".to_vec();
+                m.extend_from_slice(es);
+                m.push(b'"');
+                return interp.error_with_code(&m, b"TCL RESULT NONLIST_ERRORSTACK");
+            }
+            Ok(parts) if parts.len() % 2 != 0 => {
+                let mut m = b"forbidden odd-sized list for -errorstack: \"".to_vec();
+                m.extend_from_slice(es);
+                m.push(b'"');
+                return interp.error_with_code(&m, b"TCL RESULT ODDSIZEDLIST_ERRORSTACK");
+            }
+            Ok(_) => {}
+        }
     }
     // The optional trailing result word.
     if i < argv.len() {

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -465,12 +465,17 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     } else {
         interp.set_result_bytes(b"");
     }
-    // On an error completion, stamp the error globals (like `error`).
+    // On an error completion, populate the live exception state from the error
+    // options (`TclProcessReturn`) — *not* the `::errorInfo`/`::errorCode`
+    // globals, which are written only when the error is reported. This runs
+    // regardless of `-level`, so a deferred (`-level > 0`) error carries its
+    // info/code once the return boundary turns it into a real error.
     if code == Code::Error {
-        let info = errorinfo.unwrap_or_else(|| obj_bytes(interp.get_obj_result()));
-        let ecode = errorcode.unwrap_or_else(|| b"NONE".to_vec());
-        set_global(interp, b"::errorInfo", &info);
-        set_global(interp, b"::errorCode", &ecode);
+        interp.process_return_error(
+            errorinfo.as_deref(),
+            errorcode.as_deref(),
+            errorstack.as_deref(),
+        );
     }
     if level == 0 {
         // No unwinding: complete with `code` right here.
@@ -478,14 +483,6 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     } else {
         interp.set_return_state(level, code);
         Code::Return
-    }
-}
-
-/// Set a global (`::name`) to `bytes` (for the error globals).
-fn set_global(interp: &mut Interp, name: &[u8], bytes: &[u8]) {
-    let o = obj::new_string_bytes(bytes);
-    if interp.var_set(name, o).is_err() {
-        drop_fresh(o);
     }
 }
 

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -356,17 +356,41 @@ fn not_integer(interp: &mut Interp, bytes: &[u8]) -> Code {
 
 // -- return ----------------------------------------------------------------
 
-/// Map a `-code` word (`ok`/`error`/`return`/`break`/`continue` or 0–4) to a
-/// [`Code`]; `None` for an unrecognised spelling.
+/// Map a `-code` word (`ok`/`error`/`return`/`break`/`continue` or any integer)
+/// to a [`Code`]; `None` for an unrecognised spelling. A non-0..4 integer maps to
+/// [`Code::Other`] (`TclGetCompletionCodeFromObj`).
 fn parse_code(b: &[u8]) -> Option<Code> {
     match b {
-        b"ok" | b"0" => Some(Code::Ok),
-        b"error" | b"1" => Some(Code::Error),
-        b"return" | b"2" => Some(Code::Return),
-        b"break" | b"3" => Some(Code::Break),
-        b"continue" | b"4" => Some(Code::Continue),
-        _ => None,
+        b"ok" => Some(Code::Ok),
+        b"error" => Some(Code::Error),
+        b"return" => Some(Code::Return),
+        b"break" => Some(Code::Break),
+        b"continue" => Some(Code::Continue),
+        _ => parse_code_int(b).map(Code::from_int),
     }
+}
+
+/// Parse a completion-code integer the way `TclGetIntFromObj` would: an optional
+/// sign then a `0x`/`0o`/`0b`/`0d` radix prefix (else decimal), within an `i32`.
+fn parse_code_int(b: &[u8]) -> Option<i32> {
+    let s = core::str::from_utf8(b).ok()?.trim();
+    let (neg, rest) = match s.as_bytes().first() {
+        Some(b'-') => (true, &s[1..]),
+        Some(b'+') => (false, &s[1..]),
+        _ => (false, s),
+    };
+    let (radix, digits) = match rest.as_bytes() {
+        [b'0', b'x' | b'X', ..] => (16, &rest[2..]),
+        [b'0', b'o' | b'O', ..] => (8, &rest[2..]),
+        [b'0', b'b' | b'B', ..] => (2, &rest[2..]),
+        [b'0', b'd' | b'D', ..] => (10, &rest[2..]),
+        _ => (10, rest),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    let mag = i32::from_str_radix(digits, radix).ok()?;
+    Some(if neg { mag.checked_neg()? } else { mag })
 }
 
 /// `return ?-code code? ?-level n? ?-errorcode list? ?-errorinfo info?

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -95,6 +95,11 @@ fn build_options(interp: &mut Interp, code: Code) -> *mut TclObj {
         // The full accumulated trace + code, not the (deferred) globals.
         pairs.push((new_string(b"-errorcode"), new_string(&interp.error_code())));
         pairs.push((new_string(b"-errorinfo"), new_string(&interp.error_info())));
+        // TIP 348: the error stack built as the error unwound.
+        pairs.push((
+            new_string(b"-errorstack"),
+            new_string(&interp.error_stack_value()),
+        ));
         // TIP 329 exception chaining: when a `try` handler/`finally` threw over a
         // prior exception, that prior exception's options ride along as `-during`
         // (`During()` in `tclCmdMZ.c`). `new_dict_obj` retains it.

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -16,7 +16,7 @@
 
 use crate::dict;
 use crate::interp::{drop_fresh, new_string, obj_bytes, Code, Interp};
-use crate::obj::TclObj;
+use crate::obj::{self, TclObj};
 
 /// Register `catch`, `error`, `try`, and `throw`.
 pub fn install(interp: &mut Interp) {
@@ -95,6 +95,12 @@ fn build_options(interp: &mut Interp, code: Code) -> *mut TclObj {
         // The full accumulated trace + code, not the (deferred) globals.
         pairs.push((new_string(b"-errorcode"), new_string(&interp.error_code())));
         pairs.push((new_string(b"-errorinfo"), new_string(&interp.error_info())));
+        // TIP 329 exception chaining: when a `try` handler/`finally` threw over a
+        // prior exception, that prior exception's options ride along as `-during`
+        // (`During()` in `tclCmdMZ.c`). `new_dict_obj` retains it.
+        if let Some(during) = interp.during_opts() {
+            pairs.push((new_string(b"-during"), during));
+        }
     }
     dict::new_dict_obj(&pairs)
 }
@@ -297,11 +303,18 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         while handlers[b].is_dash {
             b += 1; // guaranteed to terminate (the last body is not `-`)
         }
-        // Bind the running clause's variables: [resultVar ?optionsVar?]. The
-        // options dict must be built from the *live* body error/return state, so
-        // this runs before the error is published+reset. A failed bind becomes
-        // the outcome (and skips the handler body), but `finally` still runs.
-        match bind_handler_vars(interp, &handlers[b].vars, &body_result, body_code) {
+        // Build the body's options dict from the *live* body error/return state
+        // (before it is published+reset). It is bound to the handler's optionsVar
+        // and reused as the `-during` chain link if the handler itself throws
+        // (TIP 329 exception chaining). Retained for the duration of the handler.
+        let body_opts = build_options(interp, body_code);
+        // SAFETY: keep `body_opts` alive across the handler eval / var binding.
+        unsafe { obj::incr_ref_count(body_opts) };
+        // Bind the running clause's variables: [resultVar ?optionsVar?]. A failed
+        // bind becomes the outcome (and skips the handler body), but `finally`
+        // still runs; the bind error chains to the body via `-during` (C's
+        // `handlerFailed`).
+        match bind_handler_vars(interp, &handlers[b].vars, &body_result, body_opts) {
             Ok(()) => {
                 // The body's exception is now handled: publish + reset so the
                 // handler starts with clean error state.
@@ -310,20 +323,42 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 }
                 outcome_code = interp.eval_control_body(handlers[b].script);
                 outcome_result = interp.result_bytes();
+                if outcome_code == Code::Error {
+                    // The handler threw over the body's exception: chain it.
+                    interp.set_during(body_opts);
+                }
             }
             Err(()) => {
                 outcome_code = Code::Error;
                 outcome_result = interp.result_bytes();
+                interp.set_during(body_opts);
             }
         }
+        // SAFETY: release our hold; `set_during`/the optionsVar keep their own.
+        unsafe { obj::decr_ref_count(body_opts) };
     }
 
-    // `finally` always runs; only its error overrides the result.
+    // `finally` always runs; only an exception from it overrides the result.
     if let Some(fin) = finally {
+        // Capture the options that would propagate from the body/handler stage
+        // (carrying any `-during` already chained) in case `finally` throws and
+        // must chain them in turn.
+        let prior_opts = build_options(interp, outcome_code);
+        // SAFETY: keep `prior_opts` alive across the finally eval.
+        unsafe { obj::incr_ref_count(prior_opts) };
         let fc = interp.eval_control_body(fin);
         if fc != Code::Ok {
+            if fc == Code::Error {
+                interp.set_during(prior_opts); // chain the superseded exception
+            } else {
+                interp.clear_during(); // a non-error finally exception does not chain
+            }
+            // SAFETY: release our hold (`set_during` kept its own if it ran).
+            unsafe { obj::decr_ref_count(prior_opts) };
             return fc; // finally's result is already the interp result
         }
+        // SAFETY: finally completed OK — discard the speculative capture.
+        unsafe { obj::decr_ref_count(prior_opts) };
     }
 
     interp.set_result_bytes(&outcome_result);
@@ -340,14 +375,15 @@ fn bad_completion_code(interp: &mut Interp, word: &[u8]) -> Code {
 }
 
 /// Bind a `try` handler clause's `[resultVar ?optionsVar?]` to the body's result
-/// and option dict. `Err(())` if a variable can't be set (the interp error is
-/// left in place); the result variable is set before the options variable, so a
-/// later failure still leaves the result variable assigned (error-19.11).
+/// and the prebuilt option dict (`body_opts`, retained into the variable).
+/// `Err(())` if a variable can't be set (the interp error is left in place); the
+/// result variable is set before the options variable, so a later failure still
+/// leaves the result variable assigned (error-19.11).
 fn bind_handler_vars(
     interp: &mut Interp,
     vars: &[u8],
     body_result: &[u8],
-    body_code: Code,
+    body_opts: *mut TclObj,
 ) -> Result<(), ()> {
     let names = crate::parse::split_list(vars).unwrap_or_default();
     if let Some(rv) = names.first() {
@@ -361,9 +397,7 @@ fn bind_handler_vars(
         }
     }
     if let Some(ov) = names.get(1) {
-        let opts = build_options(interp, body_code);
-        if interp.var_set(ov, opts).is_err() {
-            drop_fresh(opts);
+        if interp.var_set(ov, body_opts).is_err() {
             cant_set(interp, ov);
             return Err(());
         }

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -180,14 +180,33 @@ fn code_word_to_int(spec: &[u8]) -> Option<i64> {
         b"return" => Some(2),
         b"break" => Some(3),
         b"continue" => Some(4),
-        // A completion code must fit a 32-bit int (C's `Tcl_GetIntFromObj`).
-        _ => core::str::from_utf8(spec)
-            .ok()?
-            .trim()
-            .parse::<i32>()
-            .ok()
-            .map(i64::from),
+        // A completion code must fit a 32-bit int (C's `Tcl_GetIntFromObj`),
+        // accepting `0x`/`0o`/`0b`/`0d` radix prefixes and a sign.
+        _ => completion_code_int(spec).map(i64::from),
     }
+}
+
+/// Parse a completion-code integer like `TclGetIntFromObj`: optional sign then a
+/// `0x`/`0o`/`0b`/`0d` radix prefix (else decimal), within an `i32`.
+fn completion_code_int(spec: &[u8]) -> Option<i32> {
+    let s = core::str::from_utf8(spec).ok()?.trim();
+    let (neg, rest) = match s.as_bytes().first() {
+        Some(b'-') => (true, &s[1..]),
+        Some(b'+') => (false, &s[1..]),
+        _ => (false, s),
+    };
+    let (radix, digits) = match rest.as_bytes() {
+        [b'0', b'x' | b'X', ..] => (16, &rest[2..]),
+        [b'0', b'o' | b'O', ..] => (8, &rest[2..]),
+        [b'0', b'b' | b'B', ..] => (2, &rest[2..]),
+        [b'0', b'd' | b'D', ..] => (10, &rest[2..]),
+        _ => (10, rest),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    let mag = i32::from_str_radix(digits, radix).ok()?;
+    Some(if neg { mag.checked_neg()? } else { mag })
 }
 
 /// Does `pattern` (a list) match `errorcode` (a list) as a leading sublist?

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -429,7 +429,7 @@ fn throw_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         // A malformed type list reports the list parse error verbatim
         // (error-8.8/8.11); a well-formed but empty list is the type error.
         Ok(_) => return interp.set_error(b"type must be non-empty list"),
-        Err(e) => return interp.set_error(e.message()),
+        Err(e) => return interp.set_error(&crate::parse::list_error_message(&ecode, e)),
     }
     interp.set_result(argv[2]);
     // Like `return -code error -errorcode $type $msg`: set the code, let the

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -88,25 +88,39 @@ fn cant_set(interp: &mut Interp, name: &[u8]) -> Code {
 /// `-errorinfo` from the live error accumulator on an error). Returns a fresh
 /// (`rc 0`) dict.
 fn build_options(interp: &mut Interp, code: Code) -> *mut TclObj {
-    let code_str = code.as_int().to_string();
+    // A body that completed via `return` propagates the return's *own* requested
+    // options (`-code C -level L`), not the settled `RETURN`(2)/level-0 — what
+    // `catch`'s options dict and TIP 329 `-during` chaining record
+    // (`Tcl_GetReturnOptions`, `tclResult.c`). Every other code is at level 0.
+    let (eff_code, level) = if code == Code::Return {
+        (interp.pending_return_code(), interp.pending_return_level())
+    } else {
+        (code, 0)
+    };
+    let code_str = eff_code.as_int().to_string();
+    let level_str = level.to_string();
     let mut pairs: Vec<(*mut TclObj, *mut TclObj)> = vec![
         (new_string(b"-code"), new_string(code_str.as_bytes())),
-        (new_string(b"-level"), new_string(b"0")),
+        (new_string(b"-level"), new_string(level_str.as_bytes())),
     ];
-    if code == Code::Error {
-        // The full accumulated trace + code, not the (deferred) globals.
+    if eff_code == Code::Error {
+        // `-errorcode` rides along with any error completion (incl. a pending
+        // `return -code error`). The accumulated trace + stack and the `-during`
+        // chain only exist once the error has actually been raised (level 0).
         pairs.push((new_string(b"-errorcode"), new_string(&interp.error_code())));
-        pairs.push((new_string(b"-errorinfo"), new_string(&interp.error_info())));
-        // TIP 348: the error stack built as the error unwound.
-        pairs.push((
-            new_string(b"-errorstack"),
-            new_string(&interp.error_stack_value()),
-        ));
-        // TIP 329 exception chaining: when a `try` handler/`finally` threw over a
-        // prior exception, that prior exception's options ride along as `-during`
-        // (`During()` in `tclCmdMZ.c`). `new_dict_obj` retains it.
-        if let Some(during) = interp.during_opts() {
-            pairs.push((new_string(b"-during"), during));
+        if level == 0 {
+            pairs.push((new_string(b"-errorinfo"), new_string(&interp.error_info())));
+            // TIP 348: the error stack built as the error unwound.
+            pairs.push((
+                new_string(b"-errorstack"),
+                new_string(&interp.error_stack_value()),
+            ));
+            // TIP 329 exception chaining: when a `try` handler/`finally` threw
+            // over a prior exception, that prior exception's options ride along as
+            // `-during` (`During()` in `tclCmdMZ.c`). `new_dict_obj` retains it.
+            if let Some(during) = interp.during_opts() {
+                pairs.push((new_string(b"-during"), during));
+            }
         }
     }
     dict::new_dict_obj(&pairs)
@@ -182,33 +196,10 @@ fn code_word_to_int(spec: &[u8]) -> Option<i64> {
         b"return" => Some(2),
         b"break" => Some(3),
         b"continue" => Some(4),
-        // A completion code must fit a 32-bit int (C's `Tcl_GetIntFromObj`),
-        // accepting `0x`/`0o`/`0b`/`0d` radix prefixes and a sign.
-        _ => completion_code_int(spec).map(i64::from),
+        // A completion code accepts the full signed/unsigned 32-bit range (C's
+        // `Tcl_GetIntFromObj`), with `0x`/`0o`/`0b`/`0d` prefixes and a sign.
+        _ => crate::interp::parse_completion_int(spec).map(i64::from),
     }
-}
-
-/// Parse a completion-code integer like `TclGetIntFromObj`: optional sign then a
-/// `0x`/`0o`/`0b`/`0d` radix prefix (else decimal), within an `i32`.
-fn completion_code_int(spec: &[u8]) -> Option<i32> {
-    let s = core::str::from_utf8(spec).ok()?.trim();
-    let (neg, rest) = match s.as_bytes().first() {
-        Some(b'-') => (true, &s[1..]),
-        Some(b'+') => (false, &s[1..]),
-        _ => (false, s),
-    };
-    let (radix, digits) = match rest.as_bytes() {
-        [b'0', b'x' | b'X', ..] => (16, &rest[2..]),
-        [b'0', b'o' | b'O', ..] => (8, &rest[2..]),
-        [b'0', b'b' | b'B', ..] => (2, &rest[2..]),
-        [b'0', b'd' | b'D', ..] => (10, &rest[2..]),
-        _ => (10, rest),
-    };
-    if digits.is_empty() {
-        return None;
-    }
-    let mag = i32::from_str_radix(digits, radix).ok()?;
-    Some(if neg { mag.checked_neg()? } else { mag })
 }
 
 /// Does `pattern` (a list) match `errorcode` (a list) as a leading sublist?

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -39,7 +39,7 @@ fn wrong_args(interp: &mut Interp, usage: &[u8]) -> Code {
 /// completion code, and return it as an integer (0=ok … 4=continue).
 fn catch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 || argv.len() > 4 {
-        return wrong_args(interp, b"catch script ?resultVarName? ?optionsVarName?");
+        return wrong_args(interp, b"catch script ?resultVarName? ?optionVarName?");
     }
     // `catch` evaluates its script as its own `info frame` level (C bumps
     // `cmdFramePtr` like `eval`), so a located literal body reports `type source`
@@ -116,7 +116,10 @@ fn error_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 || argv.len() > 4 {
         return wrong_args(interp, b"error message ?errorInfo? ?errorCode?");
     }
-    let ecode = if argv.len() == 4 {
+    // An explicit `errorCode` arg is honoured verbatim — even when empty, it
+    // reads back empty rather than the `NONE` default (error-4.5).
+    let explicit_code = argv.len() == 4;
+    let ecode = if explicit_code {
         obj_bytes(argv[3])
     } else {
         b"NONE".to_vec()
@@ -128,12 +131,16 @@ fn error_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Vec::new()
     };
     let msg = obj_bytes(argv[1]);
-    if info.is_empty() {
+    let rc = if info.is_empty() {
         interp.set_result(argv[1]);
         interp.set_error_state(&ecode)
     } else {
         interp.raise_with_info(&msg, &info, &ecode)
+    };
+    if explicit_code {
+        interp.mark_error_code_explicit();
     }
+    rc
 }
 
 // -- try / throw -----------------------------------------------------------

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -41,11 +41,13 @@ fn catch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 || argv.len() > 4 {
         return wrong_args(interp, b"catch script ?resultVarName? ?optionVarName?");
     }
-    // `catch` evaluates its script as its own `info frame` level (C bumps
-    // `cmdFramePtr` like `eval`), so a located literal body reports `type source`
-    // at its own line — `eval_body_obj` pushes that frame and picks up the body
-    // object's TIP 280 location.
-    let code = interp.eval_body_obj(argv[1]);
+    // `catch` is bytecode-compiled inline (C's `TclCompileCatchCmd`): a literal
+    // body runs in the **same** `info frame` level and the same `codePtr->source`
+    // as the enclosing proc/script. `eval_control_body` reproduces that — sharing
+    // the enclosing frame in a proc (so `info frame` depth and the body-relative
+    // `errorLine` for `MakeProcError` stay correct), while a top-level or dynamic
+    // body still evaluates as its own frame.
+    let code = interp.eval_control_body(argv[1]);
     // Snapshot the body's result BEFORE we overwrite the interp result with the
     // catch return value (the Zig "read before clear" discovery). `var_set`
     // retains it into the result var, so it survives the later `set_result`.

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -234,12 +234,13 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"errorstack" => {
-            // TIP 348: the error stack (`-errorstack` of the last error). Not yet
-            // tracked — report empty (`?interp?` accepted).
+            // TIP 348: the error stack of the last error (`?interp?` accepted but
+            // only the current interp is supported).
             if argv.len() > 3 {
                 return wrong_args(interp, b"info errorstack ?interp?");
             }
-            interp.set_result_bytes(b"");
+            let es = interp.error_stack_value();
+            interp.set_result_bytes(&es);
             Code::Ok
         }
         b"constant" => {

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -565,32 +565,43 @@ fn dest_has_own(interp: &Interp, dest: NsId, simple: &[u8]) -> bool {
     interp.namespaces().command_names(dest).contains(&simple)
 }
 
-/// `namespace qualifiers` text op: everything before the last `::` (trailing
-/// `::`-runs trimmed); empty if unqualified.
+/// `namespace qualifiers` text op: everything before the last `::` separator,
+/// with the whole trailing colon-run trimmed (`foo:::` → `foo`, `:::::` → ``);
+/// empty if unqualified.
 fn qualifiers(s: &[u8]) -> &[u8] {
-    match find_last_sep(s) {
-        Some(i) => &s[..i],
+    match last_sep_run(s) {
+        Some((start, _)) => &s[..start],
         None => b"",
     }
 }
 
-/// `namespace tail` text op: the simple name after the last `::`.
+/// `namespace tail` text op: the simple name after the last `::` separator (the
+/// whole colon-run is skipped, so `foo:::` → ``).
 fn tail(s: &[u8]) -> &[u8] {
-    match find_last_sep(s) {
-        Some(i) => &s[i + 2..],
+    match last_sep_run(s) {
+        Some((_, end)) => &s[end..],
         None => s,
     }
 }
 
-/// Index of the last `::` separator in `s`, or `None`.
-fn find_last_sep(s: &[u8]) -> Option<usize> {
-    if s.len() < 2 {
-        return None;
-    }
-    let mut i = s.len() - 1;
-    while i >= 1 {
-        if s[i] == b':' && s[i - 1] == b':' {
-            return Some(i - 1);
+/// The byte range `(start, end)` of the last `::` separator run in `s` (a run is
+/// two or more consecutive colons), or `None` if there is none. `s[..start]` is
+/// the qualifier and `s[end..]` the tail (C's `NamespaceQualifiersCmd` /
+/// `NamespaceTailCmd` colon-run handling).
+fn last_sep_run(s: &[u8]) -> Option<(usize, usize)> {
+    // Scan back for the last "::" pair, then extend over every adjacent colon.
+    let mut i = s.len();
+    while i >= 2 {
+        if s[i - 1] == b':' && s[i - 2] == b':' {
+            let mut start = i - 2;
+            while start > 0 && s[start - 1] == b':' {
+                start -= 1;
+            }
+            let mut end = i;
+            while end < s.len() && s[end] == b':' {
+                end += 1;
+            }
+            return Some((start, end));
         }
         i -= 1;
     }

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -342,6 +342,16 @@ fn ns_export(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         set_list_bytes(interp, &pats);
         return Code::Ok;
     }
+    // An export pattern names commands in the *current* namespace only, so it
+    // may not be namespace-qualified (C's `NamespaceExportCmd`).
+    for p in &patterns {
+        if tcl_syntax::naming::is_qualified(p) {
+            let mut m = b"invalid export pattern \"".to_vec();
+            m.extend_from_slice(p);
+            m.extend_from_slice(b"\": pattern can't specify a namespace");
+            return interp.set_error(&m);
+        }
+    }
     if clear {
         interp.namespaces_mut().clear_exports(cur);
     }
@@ -371,6 +381,10 @@ fn ns_import(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return Code::Ok;
     }
     for pat in &patterns {
+        // An empty pattern is rejected outright (C's `Tcl_Import`).
+        if pat.is_empty() {
+            return interp.set_error(b"empty import pattern");
+        }
         // Split into the source-namespace qualifier and the simple glob tail.
         let q = qualifiers(pat);
         let tail_pat = tail(pat);
@@ -380,6 +394,16 @@ fn ns_import(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             m.push(b'"');
             return interp.set_error(&m);
         };
+        // Importing from one's own namespace is meaningless (C's `Tcl_Import`):
+        // the message names the source namespace by its simple name.
+        if src_ns == dest {
+            let mut m = b"import pattern \"".to_vec();
+            m.extend_from_slice(pat);
+            m.extend_from_slice(b"\" tries to import from namespace \"");
+            m.extend_from_slice(&interp.namespaces().simple_name(src_ns));
+            m.extend_from_slice(b"\" into itself");
+            return interp.set_error(&m);
+        }
         // Collect the matching, exported source commands first (borrow ends).
         let src_fqn = interp.namespaces().qualified_name(src_ns);
         let mut to_import: Vec<Vec<u8>> = Vec::new();
@@ -432,7 +456,13 @@ fn ns_forget(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         let q = qualifiers(&pat);
         let tail_pat = tail(&pat);
         let Some(src_ns) = interp.namespaces().find_namespace(dest, q) else {
-            continue; // unknown source ns ⇒ nothing to forget
+            // C's `Tcl_ForgetImport` errors if the pattern's namespace qualifier
+            // names a namespace that does not exist (an unqualified pattern
+            // resolves to the current namespace, which always exists).
+            let mut m = b"unknown namespace in namespace forget pattern \"".to_vec();
+            m.extend_from_slice(&pat);
+            m.push(b'"');
+            return interp.set_error(&m);
         };
         let mut src_fqn = interp.namespaces().qualified_name(src_ns);
         src_fqn.extend_from_slice(b"::");

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -4904,7 +4904,7 @@ impl Interp {
                     target: Vec::new(),
                     external,
                 });
-                let code = self.ns_eval(&ns_name, &script);
+                let code = self.ns_eval_no_frame(&ns_name, &script);
                 self.oo.borrow_mut().call_stack.pop();
                 // C's FinalizeEval: on error append `(in "<name> eval" script
                 // line N)`, where name is the object's name for a public call

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -5553,7 +5553,8 @@ impl Interp {
             self.oo.borrow_mut().fwd_usage = Some(fwd);
             let mut source = vec![head, target.to_vec()];
             source.extend(args.iter().map(|&a| obj_bytes(a)));
-            let is_root = self.begin_ensemble_rewrite(source, 2);
+            // `obj method` (2 words) is replaced by the forward `prefix`.
+            let is_root = self.begin_ensemble_rewrite(source, 2, prefix.len());
             self.oo.borrow_mut().call_stack.push(OoFrame {
                 object: obj.to_vec(),
                 chain,

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -587,6 +587,14 @@ pub struct InterpState {
     /// until first seeded (lazily from a nondeterministic source on first
     /// `rand()`, or explicitly by `srand()`). Kept in `[1, 2^31-2]`.
     rand_seed: Cell<Option<i64>>,
+    /// The `try` exception-chaining link (TIP 329 `-during`): when a `try`
+    /// handler or `finally` script throws, the options dict of the *prior*
+    /// exception it superseded is stashed here so the next error-options build
+    /// ([`build_options`](crate::cmd_error)) splices it in as `-during`. Holds an
+    /// owning reference (released when overwritten, cleared, or the interp drops).
+    /// Cleared when an error is published/caught ([`publish_error`](Self::publish_error)),
+    /// since the chain is then consumed.
+    during: Cell<Option<*mut TclObj>>,
     result: Cell<*mut TclObj>,
 }
 
@@ -640,6 +648,7 @@ impl Interp {
             coros: RefCell::new(std::collections::BTreeMap::new()),
             ensemble_rewrite: RefCell::new(None),
             rand_seed: Cell::new(None),
+            during: Cell::new(None),
             result: Cell::new(result),
         }));
         builtins::install(&mut interp);
@@ -2801,11 +2810,42 @@ impl Interp {
             drop_fresh(ec);
         }
         *self.exc.borrow_mut() = ExceptionState::default();
+        // The exception is consumed: drop any `-during` chain link with it.
+        self.clear_during();
     }
 
     /// Publish + reset, for `catch`/`try` once they have captured the options.
     pub(crate) fn publish_and_reset_error(&mut self) {
         self.publish_error();
+    }
+
+    /// Stash the `-during` chain link for the next error-options build (TIP 329
+    /// exception chaining): `opts` is the options dict of the exception the
+    /// just-thrown handler/`finally` exception supersedes. Takes its own owning
+    /// reference (releasing any prior link); the caller keeps its own.
+    pub(crate) fn set_during(&self, opts: *mut TclObj) {
+        // SAFETY: `opts` is a live object; retain it for the field's own ref.
+        unsafe { obj::incr_ref_count(opts) };
+        if let Some(old) = self.during.replace(Some(opts)) {
+            // SAFETY: drop the previously-held link's owning reference.
+            unsafe { obj::decr_ref_count(old) };
+        }
+    }
+
+    /// Drop the pending `-during` chain link, if any (no error to chain).
+    pub(crate) fn clear_during(&self) {
+        if let Some(old) = self.during.take() {
+            // SAFETY: release the field's owning reference.
+            unsafe { obj::decr_ref_count(old) };
+        }
+    }
+
+    /// The pending `-during` chain link (borrowed), for `build_options` to splice
+    /// into an error's options dict. `None` when no chaining is active.
+    pub(crate) fn during_opts(&self) -> Option<*mut TclObj> {
+        let d = self.during.take();
+        self.during.set(d);
+        d
     }
 
     // -- eval -----------------------------------------------------------------
@@ -4966,6 +5006,11 @@ impl Drop for InterpState {
         // SAFETY: `result` is the interp's owned reference, dropped once.
         unsafe { obj::decr_ref_count(self.result.get()) };
         self.result.set(core::ptr::null_mut());
+        // Release any pending `-during` chain link the interp still owns.
+        if let Some(d) = self.during.take() {
+            // SAFETY: `during` held an owning reference; drop it once.
+            unsafe { obj::decr_ref_count(d) };
+        }
     }
 }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -592,6 +592,16 @@ pub struct InterpState {
     /// until first seeded (lazily from a nondeterministic source on first
     /// `rand()`, or explicitly by `srand()`). Kept in `[1, 2^31-2]`.
     rand_seed: Cell<Option<i64>>,
+    /// The TIP 348 error stack (`info errorstack` / the options-dict
+    /// `-errorstack`): a flat list of element *values* built bottom-up as an
+    /// error unwinds — `INNER <ctx>` for the innermost command, `CALL <info
+    /// level 0>` per proc frame, `UP <delta>` per `uplevel` boundary. Rendered to
+    /// a Tcl list on demand.
+    error_stack: RefCell<Vec<Vec<u8>>>,
+    /// C's `iPtr->resetErrorStack`: set when the result is reset (a new error
+    /// episode is starting), so the next command logged clears the stack and
+    /// records its inner context. Starts `true`.
+    reset_error_stack: Cell<bool>,
     /// The `try` exception-chaining link (TIP 329 `-during`): when a `try`
     /// handler or `finally` script throws, the options dict of the *prior*
     /// exception it superseded is stashed here so the next error-options build
@@ -653,6 +663,8 @@ impl Interp {
             coros: RefCell::new(std::collections::BTreeMap::new()),
             ensemble_rewrite: RefCell::new(None),
             rand_seed: Cell::new(None),
+            error_stack: RefCell::new(Vec::new()),
+            reset_error_stack: Cell::new(true),
             during: Cell::new(None),
             result: Cell::new(result),
         }));
@@ -2568,6 +2580,9 @@ impl Interp {
         if self.exc.borrow().already_logged {
             return;
         }
+        // TIP 348: record this frame's inner context / uplevel boundary into the
+        // error stack (the errorStack half of C's `Tcl_LogCommandInfo`).
+        self.error_stack_log(&src[cmd.start..cmd.end]);
         // errorLine = 1 + count('\n' in src[0..commandStart]) — C's exact loop.
         let line = line_of(src, cmd.start);
         let started = self.exc.borrow().info.is_some();
@@ -2810,6 +2825,75 @@ impl Interp {
         self.exc.borrow_mut().code_explicit = true;
     }
 
+    /// Record one command frame into the TIP 348 error stack as an error unwinds
+    /// (`Tcl_LogCommandInfo`'s errorStack half). On the first log of a new error
+    /// episode (`reset_error_stack`), the stack is cleared and seeded with `INNER
+    /// <command>`. Then, if the active frame is an `uplevel`-redirected one
+    /// (`framePtr != varFramePtr`), an `UP <delta>` entry is appended. `CALL`
+    /// entries are added separately at proc-frame boundaries
+    /// ([`error_stack_push_call`](Self::error_stack_push_call)).
+    pub(crate) fn error_stack_log(&self, command: &[u8]) {
+        if self.reset_error_stack.get() {
+            self.reset_error_stack.set(false);
+            let mut es = self.error_stack.borrow_mut();
+            es.clear();
+            es.push(b"INNER".to_vec());
+            es.push(command.to_vec());
+        }
+        let (top, active) = {
+            let f = self.frames.borrow();
+            (f.top_level(), f.current_level())
+        };
+        if top > active {
+            let mut es = self.error_stack.borrow_mut();
+            es.push(b"UP".to_vec());
+            es.push((top - active).to_string().into_bytes());
+        }
+    }
+
+    /// Append a TIP 348 `CALL <info level 0>` entry — the invocation words of a
+    /// proc/lambda/method frame that an error is unwinding out of. The words are
+    /// joined into a single Tcl-list element (so `g 1212` renders as `{g 1212}`).
+    pub(crate) fn error_stack_push_call(&self, words: &[Vec<u8>]) {
+        if self.reset_error_stack.get() {
+            // No inner context recorded yet (the error started at this boundary);
+            // nothing to chain a CALL onto until a command is logged.
+            return;
+        }
+        let mut value = Vec::new();
+        for (i, w) in words.iter().enumerate() {
+            if i > 0 {
+                value.push(b' ');
+            }
+            crate::list::append_list_element(&mut value, w, i == 0);
+        }
+        let mut es = self.error_stack.borrow_mut();
+        es.push(b"CALL".to_vec());
+        es.push(value);
+    }
+
+    /// Render the TIP 348 error stack as a Tcl list (`info errorstack` / the
+    /// options-dict `-errorstack` value).
+    pub(crate) fn error_stack_value(&self) -> Vec<u8> {
+        let es = self.error_stack.borrow();
+        let mut buf = Vec::new();
+        for (i, e) in es.iter().enumerate() {
+            if i > 0 {
+                buf.push(b' ');
+            }
+            crate::list::append_list_element(&mut buf, e, false);
+        }
+        buf
+    }
+
+    /// Mark the start of a new error episode (C's `iPtr->resetErrorStack = 1`,
+    /// set by `Tcl_ResetResult`): the *next* logged command rebuilds the stack.
+    /// The current contents are kept until then (so `info errorstack` after a
+    /// `catch` still reports the last error).
+    pub(crate) fn mark_error_stack_reset(&self) {
+        self.reset_error_stack.set(true);
+    }
+
     /// Publish the accumulated trace to the `::errorInfo`/`::errorCode` globals
     /// and reset the accumulator for the next error. Called when the error is
     /// caught (`catch`) or reaches the outermost eval.
@@ -2827,6 +2911,9 @@ impl Interp {
         *self.exc.borrow_mut() = ExceptionState::default();
         // The exception is consumed: drop any `-during` chain link with it.
         self.clear_during();
+        // A new error episode starts fresh: the next logged command rebuilds the
+        // TIP 348 error stack (C's `Tcl_ResetResult` sets `resetErrorStack`).
+        self.mark_error_stack_reset();
     }
 
     /// Publish + reset, for `catch`/`try` once they have captured the options.
@@ -4329,6 +4416,9 @@ impl Interp {
         let code = self.eval_framed(body, proc_frame);
         // The frame's local variables (and any traces on them) die with it.
         let proc_level = self.frames.borrow().current_level();
+        // Capture `[info level 0]` (the invocation words) before the frame is
+        // popped — the TIP 348 `CALL` entry if this body unwinds with an error.
+        let call_words = self.level_words(proc_level);
         self.frames.borrow_mut().pop();
         if !self.traces.borrow().traces.is_empty() {
             self.clear_frame_var_traces(proc_level);
@@ -4351,6 +4441,10 @@ impl Interp {
         // frame and clear `already_logged` so the proc-call command logs next.
         if settled == Code::Error {
             self.make_proc_error(meta.err);
+            // TIP 348: record this proc/lambda/method frame as a `CALL` entry.
+            if let Some(words) = call_words {
+                self.error_stack_push_call(&words);
+            }
         }
         settled
     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -28,7 +28,8 @@ use crate::namespace::{Namespaces, NsId, RenameOutcome, GLOBAL};
 use crate::obj::{self, TclObj};
 use crate::parse::{self, WordBody, WordPart};
 
-/// Tcl completion codes (`tcl.h` `TCL_OK`..`TCL_CONTINUE`).
+/// Tcl completion codes (`tcl.h` `TCL_OK`..`TCL_CONTINUE`, plus arbitrary
+/// user codes from `return -code N` / `try on N`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Code {
     Ok,
@@ -36,11 +37,17 @@ pub enum Code {
     Return,
     Break,
     Continue,
+    /// A non-standard completion code (any `int` other than 0..4), produced by
+    /// `return -code N`. It propagates like an exception until a `catch`/`try`
+    /// reports it; it is never `0..=4` (those canonicalise to the named variants
+    /// via [`Code::from_int`]).
+    Other(i32),
 }
 
 impl Code {
-    /// The Tcl integer completion code (`TCL_OK`=0 … `TCL_CONTINUE`=4) — what
-    /// `catch` returns and `return -code` / the `-code` options-dict entry use.
+    /// The Tcl integer completion code (`TCL_OK`=0 … `TCL_CONTINUE`=4, or the
+    /// raw value for [`Code::Other`]) — what `catch` returns and `return -code` /
+    /// the `-code` options-dict entry use.
     #[must_use]
     pub(crate) fn as_int(self) -> i64 {
         match self {
@@ -49,6 +56,22 @@ impl Code {
             Code::Return => 2,
             Code::Break => 3,
             Code::Continue => 4,
+            Code::Other(n) => i64::from(n),
+        }
+    }
+
+    /// Map an integer completion code to a [`Code`]: `0..=4` to the named
+    /// variants, anything else to [`Code::Other`] (`TclProcessReturn` /
+    /// `TclGetCompletionCodeFromObj`).
+    #[must_use]
+    pub(crate) fn from_int(n: i32) -> Code {
+        match n {
+            0 => Code::Ok,
+            1 => Code::Error,
+            2 => Code::Return,
+            3 => Code::Break,
+            4 => Code::Continue,
+            other => Code::Other(other),
         }
     }
 }
@@ -4933,7 +4956,9 @@ impl Interp {
                     // non-error code (`return`, custom) substitutes its result.
                     // Only a genuine error propagates.
                     match self.eval_command_subst(src, script) {
-                        Code::Ok | Code::Return => out.extend_from_slice(&self.result_bytes()),
+                        Code::Ok | Code::Return | Code::Other(_) => {
+                            out.extend_from_slice(&self.result_bytes())
+                        }
                         Code::Break => break,
                         Code::Continue => {}
                         Code::Error => return Err(Code::Error),

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1274,7 +1274,14 @@ impl Interp {
     /// `body` there, then restore. The current-ns switch is what makes commands
     /// defined in `body` land in the right table.
     pub(crate) fn ns_eval(&mut self, name: &[u8], body: &[u8]) -> Code {
-        self.ns_eval_framed(name, body, None)
+        self.ns_eval_framed(name, body, None, true)
+    }
+
+    /// `namespace eval`-style body evaluation in `name` for callers that supply
+    /// their *own* errorInfo frame (the TclOO `eval`/`my eval` method, which logs
+    /// `(in "my eval" script line N)` instead of the `namespace eval` frame).
+    pub(crate) fn ns_eval_no_frame(&mut self, name: &[u8], body: &[u8]) -> Code {
+        self.ns_eval_framed(name, body, None, false)
     }
 
     /// `namespace eval` of a single body **object** — like
@@ -1285,7 +1292,7 @@ impl Interp {
     pub(crate) fn ns_eval_obj(&mut self, name: &[u8], obj: *mut TclObj) -> Code {
         let loc = self.arg_loc(obj);
         let bytes = obj_bytes(obj);
-        self.ns_eval_framed(name, &bytes, loc)
+        self.ns_eval_framed(name, &bytes, loc, true)
     }
 
     /// Shared `namespace eval` core: enter `name`, push a namespace var-scope
@@ -1299,6 +1306,7 @@ impl Interp {
         name: &[u8],
         body: &[u8],
         loc: Option<(Option<Rc<[u8]>>, u32)>,
+        add_eval_frame: bool,
     ) -> Code {
         let target = self
             .namespaces
@@ -1334,6 +1342,11 @@ impl Interp {
             lambda: None,
         };
         let code = self.eval_framed(body, frame);
+        if code == Code::Error && add_eval_frame {
+            // `(in namespace eval "::ns" script line N)` — the body's own frame.
+            let fqn = self.namespaces.borrow().qualified_name(target);
+            self.append_namespace_eval_frame(&fqn);
+        }
         self.frames.borrow_mut().pop();
         self.current_ns.set(saved);
         code
@@ -2822,6 +2835,17 @@ impl Interp {
         inner.push(b'"');
         inner.extend_from_slice(label);
         inner.extend_from_slice(b"\" body");
+        self.append_frame_line(&inner);
+        self.exc.borrow_mut().already_logged = false;
+    }
+
+    /// Append the `(in namespace eval "<fqn>" script line N)` errorInfo frame
+    /// when a `namespace eval` body unwinds with an error (C's `NamespaceEvalCmd`),
+    /// then clear `already_logged` so the `namespace eval` command itself logs.
+    pub(crate) fn append_namespace_eval_frame(&mut self, fqn: &[u8]) {
+        let mut inner = b"in namespace eval \"".to_vec();
+        inner.extend_from_slice(fqn);
+        inner.extend_from_slice(b"\" script");
         self.append_frame_line(&inner);
         self.exc.borrow_mut().already_logged = false;
     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -190,8 +190,17 @@ struct CmdFrame {
     /// Added to a body-relative line to get the reported `line`. `0` for
     /// top-level / `eval` / eval-defined procs (body-relative, matching tclsh);
     /// for a proc defined in a `source`d file it is the file line where the body
-    /// began minus one, so its commands report file-absolute lines.
+    /// began minus one, so its commands report file-absolute lines. An inline
+    /// body (`if`/`while`/`catch`) temporarily re-points this at the sub-body's
+    /// own base while it runs (`eval_shared_located_body`).
     line_base: u32,
+    /// The `line_base` of the **enclosing `codePtr->source`** — the proc/lambda/
+    /// eval body this frame's commands ultimately belong to — captured at frame
+    /// creation and *not* moved by the inline-body `line_base` shifts above. The
+    /// body-relative `errorLine` for `MakeProcError` is `line_base + <raw line> -
+    /// proc_line_base` (C computes `errorLine` against `codePtr->source`, which an
+    /// inline `catch`/`if` body shares with its proc).
+    proc_line_base: u32,
     /// The currently-executing command at this level (the `cmd` key) and its
     /// reported source line (the `line` key).
     cmd: Vec<u8>,
@@ -252,6 +261,7 @@ impl CmdFrame {
             omit_level: false,
             frame_index: 0,
             line_base: 0,
+            proc_line_base: 0,
             cmd: Vec::new(),
             line: 1,
             oo: None,
@@ -326,9 +336,6 @@ pub(crate) struct ExceptionState {
     /// an explicit empty code reads back empty, not the `NONE` default
     /// (error-4.5). Absent on every implicit error, so the default applies.
     code_explicit: bool,
-    /// 1-based source line of the innermost logged command, within its own
-    /// script (`errorLine`); read by `MakeProcError`'s `line N`.
-    line: u32,
     /// `ERR_ALREADY_LOGGED`: the current command has already been logged deeper
     /// in the same script, so its enclosing command must not re-log it.
     already_logged: bool,
@@ -347,6 +354,7 @@ pub(crate) struct CoroContext {
     return_code: Code,
     return_level: usize,
     exc: ExceptionState,
+    error_line: u32,
     arg_lines: Vec<u32>,
     eval_depth: usize,
     oo: crate::cmd_oo::OoExec,
@@ -366,6 +374,7 @@ impl CoroContext {
             return_code: Code::Ok,
             return_level: 1,
             exc: ExceptionState::default(),
+            error_line: 1,
             arg_lines: Vec::new(),
             eval_depth: 0,
             oo: crate::cmd_oo::OoExec::default(),
@@ -531,6 +540,14 @@ pub struct InterpState {
     pub(crate) traces: RefCell<crate::cmd_trace::TraceTable>,
     /// The error stack-trace accumulator (PC-4).
     exc: RefCell<ExceptionState>,
+    /// `iPtr->errorLine`: the 1-based source line of the innermost command
+    /// logged into the error trace, within its own script. Unlike the
+    /// accumulating [`ExceptionState`], this is **persistent** interp state — it
+    /// is written only by [`log_command_info`](Self::log_command_info) (C's
+    /// `TclLogCommandInfo`), survives `catch` and the start of a fresh error
+    /// (`error msg info` / `throw` do not touch it, matching `ERR_ALREADY_LOGGED`
+    /// suppressing the log), and is read by `MakeProcError`'s `line N`.
+    error_line: Cell<u32>,
     /// Child interpreters (`interp create`), each a shared [`Interp`] handle keyed
     /// by name. The name is also a command in this interp
     /// (`Command::ChildInterp`).
@@ -667,6 +684,7 @@ impl Interp {
             return_level: Cell::new(1),
             traces: RefCell::new(crate::cmd_trace::TraceTable::default()),
             exc: RefCell::new(ExceptionState::default()),
+            error_line: Cell::new(1),
             children: RefCell::new(std::collections::BTreeMap::new()),
             interp_counter: Cell::new(0),
             hidden: RefCell::new(std::collections::BTreeMap::new()),
@@ -1278,6 +1296,7 @@ impl Interp {
             omit_level: false,
             frame_index: ns_index,
             line_base,
+            proc_line_base: line_base,
             cmd: Vec::new(),
             line: 1,
             oo: None,
@@ -2394,7 +2413,6 @@ impl Interp {
             info: None,
             code: code.to_vec(),
             code_explicit: false,
-            line: 1,
             already_logged: false,
         };
         Code::Error
@@ -2409,7 +2427,6 @@ impl Interp {
             info: None,
             code: code.to_vec(),
             code_explicit: false,
-            line: 1,
             already_logged: false,
         };
         Code::Error
@@ -2478,6 +2495,8 @@ impl Interp {
         ctx.return_level = rl;
         let ed = self.eval_depth.replace(ctx.eval_depth);
         ctx.eval_depth = ed;
+        let el = self.error_line.replace(ctx.error_line);
+        ctx.error_line = el;
     }
 
     /// Swap the execution context of the coroutine named `name` with the live
@@ -2567,7 +2586,6 @@ impl Interp {
             info: Some(info.to_vec()),
             code: code.to_vec(),
             code_explicit: false,
-            line: 1,
             already_logged: true,
         };
         Code::Error
@@ -2581,7 +2599,6 @@ impl Interp {
             info: None,
             code: code.to_vec(),
             code_explicit: false,
-            line: 1,
             already_logged: false,
         };
         Code::Error
@@ -2610,7 +2627,6 @@ impl Interp {
             info,
             code: errorcode.unwrap_or(b"NONE").to_vec(),
             code_explicit: errorcode.is_some(),
-            line: 1,
             already_logged,
         };
         if let Some(es) = errorstack {
@@ -2640,8 +2656,17 @@ impl Interp {
         // TIP 348: record this frame's inner context / uplevel boundary into the
         // error stack (the errorStack half of C's `Tcl_LogCommandInfo`).
         self.error_stack_log(&src[cmd.start..cmd.end]);
-        // errorLine = 1 + count('\n' in src[0..commandStart]) — C's exact loop.
-        let line = line_of(src, cmd.start);
+        // errorLine, measured against the enclosing `codePtr->source` (C's
+        // `TclLogCommandInfo`): the command's file-absolute line
+        // (`line_base + 1 + count('\n')`) minus the proc/eval body's base, so an
+        // inline `catch`/`if` body's commands still report their proc-body line.
+        // This is the *only* writer of `error_line`; it persists across `catch`
+        // and a subsequent `error msg info`.
+        let raw = line_of(src, cmd.start);
+        let line = self.cmd_frames.borrow().last().map_or(raw, |f| {
+            (f.line_base + raw).saturating_sub(f.proc_line_base).max(1)
+        });
+        self.error_line.set(line);
         let started = self.exc.borrow().info.is_some();
         if !started {
             // First frame: errorInfo is seeded from the error message (the result).
@@ -2661,7 +2686,6 @@ impl Interp {
             cmd_bytes
         };
         let mut exc = self.exc.borrow_mut();
-        exc.line = line;
         let buf = exc.info.as_mut().expect("seeded above");
         buf.extend_from_slice(b"\n    ");
         buf.extend_from_slice(verb);
@@ -2672,6 +2696,35 @@ impl Interp {
         }
         buf.push(b'"');
         exc.already_logged = true;
+        drop(exc);
+        // Pre-8.5 compatibility (C's `TclLogCommandInfo`, tclNamesp.c): if user
+        // code traces `::errorInfo` for writes, push the value out to the variable
+        // *now*, mid-unwind — firing the write trace while the failing command's
+        // call frame is still live (so the handler's `info level` sees it). Skipped
+        // (no var write) when nothing traces `::errorInfo`, so the normal path
+        // still publishes once, at the `catch`/top level.
+        if self.errorinfo_has_write_trace() {
+            let info = self.error_info();
+            let ei = new_string(&info);
+            if self.var_set(b"::errorInfo", ei).is_err() {
+                drop_fresh(ei);
+            }
+        }
+    }
+
+    /// Whether `::errorInfo` carries a user write-trace — C's `TclIsVarTraced`
+    /// gate in `TclLogCommandInfo` (we install no core `EstablishErrorInfoTraces`,
+    /// so any matching write trace qualifies).
+    fn errorinfo_has_write_trace(&self) -> bool {
+        if self.traces.borrow().traces.is_empty() {
+            return false;
+        }
+        let access_ns = self.trace_var_ns(b"::errorInfo");
+        self.traces
+            .borrow()
+            .traces
+            .iter()
+            .any(|t| crate::cmd_trace::matches(t, b"::errorInfo", None, b"write", access_ns))
     }
 
     /// Append the `(procedure "NAME" line N)` / `(lambda term "..." line N)`
@@ -2774,7 +2827,7 @@ impl Interp {
     }
 
     pub(crate) fn append_frame_line(&mut self, inner: &[u8]) {
-        let line = self.exc.borrow().line;
+        let line = self.error_line.get();
         if self.exc.borrow().info.is_none() {
             let msg = self.result_bytes();
             self.exc.borrow_mut().info = Some(msg);
@@ -3025,7 +3078,12 @@ impl Interp {
     /// Evaluate `src` as the body of its own `info frame` level (`frame` is
     /// pushed for the duration). Used by proc calls, `eval`/`uplevel`, and
     /// `source`.
-    fn eval_framed(&mut self, src: &[u8], frame: CmdFrame) -> Code {
+    fn eval_framed(&mut self, src: &[u8], mut frame: CmdFrame) -> Code {
+        // A freshly pushed frame is its own `codePtr->source`, so `errorLine` is
+        // measured from this body's base (an inline `catch`/`if` body, by
+        // contrast, shares the enclosing frame via `eval_shared_located_body` and
+        // keeps the proc's `proc_line_base`).
+        frame.proc_line_base = frame.line_base;
         self.eval_script(src, Some(frame))
     }
 
@@ -3114,6 +3172,7 @@ impl Interp {
             // the same CallFrame.
             frame_index: top.map_or(0, |f| f.frame_index),
             line_base,
+            proc_line_base: line_base,
             cmd: Vec::new(),
             line: 1,
             oo: top.and_then(|f| f.oo.clone()),
@@ -4465,6 +4524,7 @@ impl Interp {
             omit_level: false,
             frame_index: proc_idx,
             line_base: meta.body_line_base,
+            proc_line_base: meta.body_line_base,
             cmd: Vec::new(),
             line: 1,
             oo,

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -296,8 +296,13 @@ pub(crate) struct ExceptionState {
     /// (C's `errorInfo == NULL`) — which selects `while executing` over `invoked
     /// from within` and seeds the buffer from the result message.
     info: Option<Vec<u8>>,
-    /// `::errorCode` (empty ⇒ the `NONE` default is applied when published).
+    /// `::errorCode` (empty ⇒ the `NONE` default is applied when published,
+    /// unless [`code_explicit`](Self::code_explicit) is set).
     code: Vec<u8>,
+    /// Whether `code` was set by an explicit `-errorcode` (e.g. `error m i {}`):
+    /// an explicit empty code reads back empty, not the `NONE` default
+    /// (error-4.5). Absent on every implicit error, so the default applies.
+    code_explicit: bool,
     /// 1-based source line of the innermost logged command, within its own
     /// script (`errorLine`); read by `MakeProcError`'s `line N`.
     line: u32,
@@ -2353,6 +2358,7 @@ impl Interp {
         *self.exc.borrow_mut() = ExceptionState {
             info: None,
             code: code.to_vec(),
+            code_explicit: false,
             line: 1,
             already_logged: false,
         };
@@ -2367,6 +2373,7 @@ impl Interp {
         *self.exc.borrow_mut() = ExceptionState {
             info: None,
             code: code.to_vec(),
+            code_explicit: false,
             line: 1,
             already_logged: false,
         };
@@ -2524,6 +2531,7 @@ impl Interp {
         *self.exc.borrow_mut() = ExceptionState {
             info: Some(info.to_vec()),
             code: code.to_vec(),
+            code_explicit: false,
             line: 1,
             already_logged: true,
         };
@@ -2537,6 +2545,7 @@ impl Interp {
         *self.exc.borrow_mut() = ExceptionState {
             info: None,
             code: code.to_vec(),
+            code_explicit: false,
             line: 1,
             already_logged: false,
         };
@@ -2788,11 +2797,17 @@ impl Interp {
     /// or `NONE`.
     pub(crate) fn error_code(&self) -> Vec<u8> {
         let exc = self.exc.borrow();
-        if exc.code.is_empty() {
+        if exc.code.is_empty() && !exc.code_explicit {
             b"NONE".to_vec()
         } else {
             exc.code.clone()
         }
+    }
+
+    /// Mark the live error's `-errorcode` as explicitly supplied (so an explicit
+    /// empty code is preserved instead of defaulting to `NONE`; error-4.5).
+    pub(crate) fn mark_error_code_explicit(&mut self) {
+        self.exc.borrow_mut().code_explicit = true;
     }
 
     /// Publish the accumulated trace to the `::errorInfo`/`::errorCode` globals

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4576,11 +4576,18 @@ impl Interp {
         // Apply the return boundary (`return`/`return -code -level`), then a
         // bare `break`/`continue` that escaped the body (no enclosing loop) is an
         // error (C Tcl: `invoked "break" outside of a loop`).
+        // A *bare* `break`/`continue` command escaping the body (no enclosing
+        // loop) is the `invoked "break" outside of a loop` error; but `return
+        // -code break` (the body completed with `Code::Return`) propagates the
+        // raw completion code unchanged — C distinguishes these, e.g. an
+        // ensemble `-unknown` handler that does `return -code break` yields code
+        // 3, not the loop error (namespace-47.4).
+        let from_return = code == Code::Return;
         let settled = match self.settle_return(code) {
-            Code::Break if !meta.keep_loop_codes => {
+            Code::Break if !meta.keep_loop_codes && !from_return => {
                 self.error(b"invoked \"break\" outside of a loop")
             }
-            Code::Continue if !meta.keep_loop_codes => {
+            Code::Continue if !meta.keep_loop_codes && !from_return => {
                 self.error(b"invoked \"continue\" outside of a loop")
             }
             other => other,
@@ -4678,7 +4685,23 @@ impl Interp {
                     EnsembleUnknown::Failed(code) => return code,
                 }
             }
-            // "unknown or ambiguous" with prefixes on; plain "unknown" otherwise.
+            // A namespace ensemble with no subcommands at all gets a distinct
+            // message; otherwise "unknown or ambiguous" (prefixes on) / "unknown"
+            // (prefixes off) followed by the candidate list (C's
+            // `NsEnsembleImplementationCmdNR`).
+            let ecode = {
+                let mut c = b"TCL LOOKUP SUBCOMMAND ".to_vec();
+                c.extend_from_slice(&sub);
+                c
+            };
+            if subs.is_empty() {
+                let mut m = b"unknown subcommand \"".to_vec();
+                m.extend_from_slice(&sub);
+                m.extend_from_slice(b"\": namespace ");
+                m.extend_from_slice(&self.namespaces.borrow().qualified_name(cfg.ns));
+                m.extend_from_slice(b" does not export any commands");
+                return self.error_with_code(&m, &ecode);
+            }
             let mut m = if cfg.prefixes {
                 b"unknown or ambiguous subcommand \"".to_vec()
             } else {
@@ -4687,7 +4710,7 @@ impl Interp {
             m.extend_from_slice(&sub);
             m.extend_from_slice(b"\": must be ");
             m.extend_from_slice(&crate::ensemble::must_be(&subs));
-            return self.error(&m);
+            return self.error_with_code(&m, &ecode);
         }
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -653,13 +653,21 @@ pub struct InterpState {
     result: Cell<*mut TclObj>,
 }
 
-/// An ensemble-rewrite record (see `InterpState::ensemble_rewrite`).
+/// An ensemble-rewrite record (C's `iPtr->ensembleRewrite`, see
+/// `InterpState::ensemble_rewrite`). `Tcl_WrongNumArgs` prints the first
+/// `removed` words of `source` in place of the `inserted` leading words of the
+/// actual (rewritten) call.
 #[derive(Clone)]
 pub(crate) struct EnsembleRewrite {
-    /// The original command words (e.g. `foo test 1 2 3`).
+    /// The original command words as the user wrote them (e.g. `foo test 1 2 3`),
+    /// with the subcommand spell-fixed to its resolved name.
     pub source: Vec<Vec<u8>>,
-    /// How many leading `source` words the rewritten prefix stands in for.
+    /// How many leading `source` words to print (C's `numRemovedObjs`).
     pub removed: usize,
+    /// How many leading words of the rewritten call the inserted prefix occupies
+    /// (C's `numInsertedObjs`); `inserted - 1` formal parameters are already
+    /// filled and so dropped from the usage message.
+    pub inserted: usize,
 }
 
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
@@ -1023,13 +1031,36 @@ impl Interp {
     /// its dispatch returns. A nested rewrite is ignored (the root's `source` is
     /// what `wrong # args` reports), matching the common case of C's
     /// `TclInitRewriteEnsemble` chaining.
-    pub(crate) fn begin_ensemble_rewrite(&self, source: Vec<Vec<u8>>, removed: usize) -> bool {
+    pub(crate) fn begin_ensemble_rewrite(
+        &self,
+        source: Vec<Vec<u8>>,
+        removed: usize,
+        inserted: usize,
+    ) -> bool {
         let mut rw = self.ensemble_rewrite.borrow_mut();
-        if rw.is_some() {
-            return false;
+        match rw.as_mut() {
+            None => {
+                *rw = Some(EnsembleRewrite {
+                    source,
+                    removed,
+                    inserted,
+                });
+                true
+            }
+            // A nested rewrite chains onto the root (C's `TclInitRewriteEnsemble`):
+            // the root `source` is kept, but its removed/inserted counts absorb the
+            // inner step so a deeply forwarded `wrong # args` still prints the full
+            // original prefix.
+            Some(r) => {
+                if r.inserted < removed {
+                    r.removed += removed - r.inserted;
+                    r.inserted = inserted;
+                } else {
+                    r.inserted = (r.inserted + inserted).saturating_sub(removed);
+                }
+                false
+            }
         }
-        *rw = Some(EnsembleRewrite { source, removed });
-        true
     }
 
     /// Clear the active ensemble-rewrite (paired with a root `begin_…`).
@@ -4593,9 +4624,11 @@ impl Interp {
         if argv.len() < 2 + nparams {
             let mut m = b"wrong # args: should be \"".to_vec();
             m.extend_from_slice(&obj_bytes(argv[0]));
+            // Each `-parameters` formal is rendered as a list element, so a
+            // multi-word default like `{a b}` keeps its braces.
             for p in &cfg.parameters {
                 m.push(b' ');
-                m.extend_from_slice(p);
+                crate::list::append_list_element(&mut m, p, false);
             }
             m.extend_from_slice(b" subcommand ?arg ...?\"");
             return self.error(&m);
@@ -4626,14 +4659,20 @@ impl Interp {
                         t.extend_from_slice(resolved);
                         vec![t]
                     });
-                return self.dispatch_ensemble_target(&prefix, argv, nparams);
+                // Spell-fix the subcommand to its resolved name in the recorded
+                // source, so an abbreviated `ev` is reported as `event` (C's
+                // `TclSpellFix`).
+                let mut source: Vec<Vec<u8>> = argv.iter().map(|&a| obj_bytes(a)).collect();
+                source[1 + nparams] = resolved.clone();
+                return self.dispatch_ensemble_target(&prefix, argv, nparams, source);
             }
             // Miss: try the `-unknown` handler once.
             if !cfg.unknown.is_empty() && !reparsed {
                 reparsed = true;
                 match self.ensemble_unknown(cfg, argv) {
                     EnsembleUnknown::Prefix(prefix) => {
-                        return self.dispatch_ensemble_target(&prefix, argv, nparams);
+                        let source: Vec<Vec<u8>> = argv.iter().map(|&a| obj_bytes(a)).collect();
+                        return self.dispatch_ensemble_target(&prefix, argv, nparams, source);
                     }
                     EnsembleUnknown::Reparse => continue,
                     EnsembleUnknown::Failed(code) => return code,
@@ -4673,6 +4712,7 @@ impl Interp {
         prefix: &[Vec<u8>],
         argv: &[*mut TclObj],
         nparams: usize,
+        source: Vec<Vec<u8>>,
     ) -> Code {
         let mut new_argv: Vec<*mut TclObj> = Vec::with_capacity(prefix.len() + argv.len() - 1);
         for w in prefix {
@@ -4691,7 +4731,15 @@ impl Interp {
             unsafe { obj::incr_ref_count(a) };
             new_argv.push(a);
         }
+        // Record the call as the user wrote it so a `wrong # args` from the target
+        // is reported in ensemble terms (C's `TclInitRewriteEnsemble`): the
+        // ensemble command, its `-parameters`, and the subcommand word (`2 +
+        // nparams`) are removed; the target prefix + `-parameters` are inserted.
+        let is_root = self.begin_ensemble_rewrite(source, 2 + nparams, prefix.len() + nparams);
         let code = self.dispatch(&new_argv);
+        if is_root {
+            self.clear_ensemble_rewrite();
+        }
         release_all(&new_argv);
         code
     }
@@ -5144,8 +5192,13 @@ impl Interp {
         quote_name: bool,
     ) -> Vec<u8> {
         if let Some(rw) = self.ensemble_rewrite() {
-            // How many trailing words of `source` were the user's own arguments,
-            // and how many formal parameters the inserted prefix already filled.
+            // Print the first `removed` words of `source` (the chained
+            // `numRemovedObjs`) in place of the target prefix, then the formal
+            // parameters not already satisfied by the supplied arguments. Using
+            // the runtime `supplied` count (rather than the static `inserted`)
+            // keeps the dropped-parameter count right across an OO forward, where
+            // the inserted prefix words (`my method …`) are dispatch verbs that do
+            // not themselves fill the target's parameters.
             let user_args = rw.source.len().saturating_sub(rw.removed);
             let drop = supplied.saturating_sub(user_args);
             // Only rewrite when the dropped parameters are actually present (C's

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2564,6 +2564,40 @@ impl Interp {
         Code::Error
     }
 
+    /// Apply the error-related options of a `return -code error` to the live
+    /// exception state (`TclProcessReturn`'s `TCL_ERROR` arm). This populates the
+    /// interp's errorInfo/errorCode/errorStack — *not* the `::errorInfo`/
+    /// `::errorCode` globals, which are written only when the error is actually
+    /// reported (caught as code 1 / reaching the top level). An explicit non-empty
+    /// `-errorinfo` is taken verbatim and marks the error already-logged (so the
+    /// unwind does not append a `while executing` frame); otherwise the trace
+    /// accumulates normally. `-errorcode` defaults to `NONE`; a valid `-errorstack`
+    /// replaces the built stack.
+    pub(crate) fn process_return_error(
+        &mut self,
+        errorinfo: Option<&[u8]>,
+        errorcode: Option<&[u8]>,
+        errorstack: Option<&[u8]>,
+    ) {
+        let (info, already_logged) = match errorinfo {
+            Some(i) if !i.is_empty() => (Some(i.to_vec()), true),
+            _ => (None, false),
+        };
+        *self.exc.borrow_mut() = ExceptionState {
+            info,
+            code: errorcode.unwrap_or(b"NONE").to_vec(),
+            code_explicit: errorcode.is_some(),
+            line: 1,
+            already_logged,
+        };
+        if let Some(es) = errorstack {
+            if let Ok(parts) = crate::parse::split_list(es) {
+                *self.error_stack.borrow_mut() = parts;
+                self.reset_error_stack.set(false);
+            }
+        }
+    }
+
     /// Append one `while executing` / `invoked from within` frame for the command
     /// `src[cmd.start..cmd.end]` as an error unwinds through it — the
     /// `TclLogCommandInfo` mirror (`tclNamesp.c`). A no-op (consuming the flag)
@@ -4439,11 +4473,23 @@ impl Interp {
         };
         // On error, append the `(procedure "name" line N)` / `(lambda term ...)`
         // frame and clear `already_logged` so the proc-call command logs next.
+        // Skipped when the error was produced by the return boundary itself
+        // (`return -code error`, i.e. the body completed with `Code::Return`):
+        // C only adds the procedure frame when the error unwinds *through* the
+        // body, not when `return` synthesises it (error-6.7, result-6.2).
         if settled == Code::Error {
-            self.make_proc_error(meta.err);
-            // TIP 348: record this proc/lambda/method frame as a `CALL` entry.
-            if let Some(words) = call_words {
-                self.error_stack_push_call(&words);
+            if code != Code::Return {
+                self.make_proc_error(meta.err);
+                // TIP 348: record this proc/lambda/method frame as a `CALL` entry.
+                if let Some(words) = call_words {
+                    self.error_stack_push_call(&words);
+                }
+            } else {
+                // `return -code error`: no procedure frame, but the *caller* still
+                // logs its own `invoked from within "<call>"` frame, so release
+                // the already-logged flag that `process_return_error` may have set
+                // for an explicit `-errorinfo` (error-6.7).
+                self.clear_error_logged();
             }
         }
         settled

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -76,6 +76,38 @@ impl Code {
     }
 }
 
+/// Parse a completion-code integer the way `TclGetIntFromObj` does: an optional
+/// sign and a `0x`/`0o`/`0b`/`0d` radix prefix (else decimal), accepting the full
+/// signed **and** unsigned 32-bit range (`-2147483648 ..= 4294967295`) and
+/// reducing it to an `int` (so `0xFFFFFFFF` → `-1`, `2147483648` → `-2147483648`),
+/// matching C. Shared by `return -code` and `try on`.
+#[must_use]
+pub(crate) fn parse_completion_int(b: &[u8]) -> Option<i32> {
+    let s = core::str::from_utf8(b).ok()?.trim();
+    let (neg, rest) = match s.as_bytes().first() {
+        Some(b'-') => (true, &s[1..]),
+        Some(b'+') => (false, &s[1..]),
+        _ => (false, s),
+    };
+    let (radix, digits) = match rest.as_bytes() {
+        [b'0', b'x' | b'X', ..] => (16, &rest[2..]),
+        [b'0', b'o' | b'O', ..] => (8, &rest[2..]),
+        [b'0', b'b' | b'B', ..] => (2, &rest[2..]),
+        [b'0', b'd' | b'D', ..] => (10, &rest[2..]),
+        _ => (10, rest),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    // Parse the magnitude wide so `i32::MIN` and the unsigned half are reachable.
+    let mag = i64::from_str_radix(digits, radix).ok()?;
+    let value = if neg { -mag } else { mag };
+    if value < i64::from(i32::MIN) || value > i64::from(u32::MAX) {
+        return None;
+    }
+    Some(value as i32)
+}
+
 /// A built-in command handler. Receives the full argv (`argv[0]` is the command
 /// name, like Tcl's `objv`); sets the result via [`Interp::set_result`] /
 /// [`Interp::set_result_bytes`] and returns a [`Code`].
@@ -1157,6 +1189,17 @@ impl Interp {
     pub(crate) fn set_return_state(&mut self, level: usize, code: Code) {
         self.return_level.set(level);
         self.return_code.set(code);
+    }
+
+    /// The pending `return` `-code`/`-level` (the options a body that completed
+    /// via `return` would propagate) — for `catch`/`try`'s options dict and TIP
+    /// 329 `-during` chaining.
+    pub(crate) fn pending_return_code(&self) -> Code {
+        self.return_code.get()
+    }
+
+    pub(crate) fn pending_return_level(&self) -> usize {
+        self.return_level.get()
     }
 
     /// Apply a procedure/source **return boundary** to a body completion code

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -557,9 +557,13 @@ impl Namespaces {
     pub fn delete_namespace_by_id(&mut self, ns: NsId) {
         let victims = self.descendant_ids(ns);
         self.delete_subtree(ns);
-        // Unlink from the parent so the name no longer resolves.
+        // Unlink from the parent so the name no longer resolves by lookup, but
+        // keep the node's own `name`/`parent` intact: a call frame still active
+        // in this (now dying) namespace must keep reporting its fully-qualified
+        // name from `namespace current` until it pops (C keeps the dying
+        // `Namespace` alive via its activation count — namespace-7.1).
         if let Some(parent) = self.arena[ns].parent {
-            let name = std::mem::take(&mut self.arena[ns].name);
+            let name = self.arena[ns].name.clone();
             self.arena[parent].children.remove(&name);
         }
         // Drop the deleted namespaces from every other namespace's `namespace

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -284,12 +284,21 @@ impl Namespaces {
     pub(crate) fn var_home(&self, current: NsId, name: &[u8]) -> Option<(NsId, Vec<u8>)> {
         let absolute = name.starts_with(b"::");
         let segments = split_qualifier(name);
-        let (simple, ns_parts) = segments.split_last()?;
+        // C: a trailing `::` names the `{}` (empty) variable in the qualified
+        // namespace — every segment is then a namespace component (the simple
+        // name being `""`), unlike the usual "last segment is the var" split.
+        let (simple, ns_parts): (Vec<u8>, &[&[u8]]) =
+            if tcl_syntax::naming::ends_with_separator(name) {
+                (Vec::new(), &segments[..])
+            } else {
+                let (s, parts) = segments.split_last()?;
+                ((*s).to_vec(), parts)
+            };
         let mut ns = if absolute { GLOBAL } else { current };
         for part in ns_parts {
             ns = *self.arena[ns].children.get(*part)?;
         }
-        Some((ns, (*simple).to_vec()))
+        Some((ns, simple))
     }
 
     /// Sorted variable names in namespace `ns` (`info vars`/`globals`).
@@ -333,6 +342,13 @@ impl Namespaces {
     /// Namespace `ns`'s variable table (mutable).
     pub(crate) fn var_table_mut(&mut self, ns: NsId) -> &mut VarTable {
         &mut self.arena[ns].vars
+    }
+
+    /// The simple (unqualified) name of `ns` — its last component (`::a::b` →
+    /// `b`); empty for the global namespace. C's `Namespace.name`.
+    #[must_use]
+    pub(crate) fn simple_name(&self, ns: NsId) -> Vec<u8> {
+        self.arena[ns].name.clone()
     }
 
     /// The fully-qualified name of `ns` (`::a::b`; global is `::`).

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -582,6 +582,78 @@ pub fn split_list(src: &[u8]) -> Result<Vec<Vec<u8>>, ListError> {
         .collect())
 }
 
+/// The byte-exact `Tcl_SplitList` error message for `src` (the `FindElement`
+/// wording, `tclUtil.c`). For the `…followed by "X" instead of space` cases this
+/// surfaces the offending fragment `X` — up to 20 non-space bytes after the
+/// closing delimiter — which [`ListError::message`] alone cannot, since the
+/// shared splitter discards the position. Other variants render their fixed text.
+#[must_use]
+pub fn list_error_message(src: &[u8], err: ListError) -> Vec<u8> {
+    let (kind, frag) = match err {
+        ListError::BraceFollowedByJunk => (&b"braces"[..], list_junk_fragment(src)),
+        ListError::QuoteFollowedByJunk => (&b"quotes"[..], list_junk_fragment(src)),
+        other => return other.message().to_vec(),
+    };
+    let mut m = b"list element in ".to_vec();
+    m.extend_from_slice(kind);
+    m.extend_from_slice(b" followed by \"");
+    m.extend_from_slice(&frag);
+    m.extend_from_slice(b"\" instead of space");
+    m
+}
+
+/// Locate the junk fragment for a `…FollowedByJunk` list error: replay
+/// [`tcl_syntax::list::find_element`] to find the element that fails, then scan
+/// it to the closing delimiter and take up to 20 non-space bytes of the trailing
+/// junk (C's `p2` walk). Returns empty if it cannot be reconstructed.
+fn list_junk_fragment(src: &[u8]) -> Vec<u8> {
+    let Ok(s) = core::str::from_utf8(src) else {
+        return Vec::new();
+    };
+    // The failing element begins where the last successful element left off.
+    let mut start = 0;
+    while let Ok(Some(el)) = tcl_syntax::list::find_element(s, start) {
+        start = el.next;
+    }
+    let len = src.len();
+    let mut pos = start;
+    while pos < len && tcl_syntax::list::is_list_space(src[pos]) {
+        pos += 1;
+    }
+    // Walk to the delimiter that closes this element, honouring `\`-escapes and
+    // brace nesting, then the junk starts at the next byte.
+    let junk = match src.get(pos) {
+        Some(b'{') => {
+            let mut depth = 1usize;
+            pos += 1;
+            while pos < len && depth > 0 {
+                match src[pos] {
+                    b'\\' if pos + 1 < len => pos += 1,
+                    b'{' => depth += 1,
+                    b'}' => depth -= 1,
+                    _ => {}
+                }
+                pos += 1;
+            }
+            pos
+        }
+        Some(b'"') => {
+            pos += 1;
+            while pos < len && src[pos] != b'"' {
+                pos += if src[pos] == b'\\' { 2 } else { 1 };
+            }
+            pos + 1 // past the closing quote
+        }
+        _ => return Vec::new(),
+    };
+    let end = (junk + 20).min(len);
+    let mut p = junk;
+    while p < end && !tcl_syntax::list::is_list_space(src[p]) {
+        p += 1;
+    }
+    src.get(junk..p).map(<[u8]>::to_vec).unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -20,8 +20,12 @@ pub fn is_qualified(name: &[u8]) -> bool {
 
 /// Split a (possibly qualified) name on `::`, dropping empty segments — so
 /// `::a::b::cmd` → `[a, b, cmd]`, `::cmd` → `[cmd]`, `cmd` → `[cmd]`, `::` → `[]`.
-/// Each `::` (or run of colons) is one separator; the trailing component is the
-/// simple name. Mirrors `TclGetNamespaceForQualName`'s component walk.
+/// A run of **two or more** colons is one separator (all consecutive colons are
+/// consumed), while a lone interior colon is an ordinary name character, so
+/// `a:::b` → `[a, b]` and `a:b` → `[a:b]`. A trailing separator drops its empty
+/// tail (`a::b::` → `[a, b]`); callers that care about the `{}`-named cmd/var a
+/// trailing `::` denotes test for it themselves. Mirrors
+/// `TclGetNamespaceForQualName`'s component walk (`tclNamesp.c`).
 #[must_use]
 pub fn qualifier_segments(name: &[u8]) -> Vec<&[u8]> {
     let mut out = Vec::new();
@@ -32,7 +36,12 @@ pub fn qualifier_segments(name: &[u8]) -> Vec<&[u8]> {
             if i > seg_start {
                 out.push(&name[seg_start..i]);
             }
+            // C skips the `::` then every subsequent `:`, so a colon run of any
+            // length is a single separator.
             i += 2;
+            while i < name.len() && name[i] == b':' {
+                i += 1;
+            }
             seg_start = i;
         } else {
             i += 1;
@@ -42,6 +51,15 @@ pub fn qualifier_segments(name: &[u8]) -> Vec<&[u8]> {
         out.push(&name[seg_start..]);
     }
     out
+}
+
+/// Does `name` end with a namespace separator (a run of ≥2 colons)? In a
+/// command or variable name such a trailing `::` names the `{}` (empty) entity
+/// in the qualified namespace (`TclGetNamespaceForQualName`), so the simple name
+/// is `""` rather than the last [`qualifier_segments`] element.
+#[must_use]
+pub fn ends_with_separator(name: &[u8]) -> bool {
+    name.len() >= 2 && name[name.len() - 1] == b':' && name[name.len() - 2] == b':'
 }
 
 /// Strip a variable reference's substitution sigil (`$`, `${…}`) while
@@ -374,7 +392,17 @@ mod tests {
         assert!(qualifier_segments(b"::").is_empty());
         // a trailing separator drops the empty tail; a lone interior colon stays.
         assert_eq!(qualifier_segments(b"a::b::"), vec![&b"a"[..], b"b"]);
-        assert_eq!(qualifier_segments(b"a:::b"), vec![&b"a"[..], b":b"]);
+        // a run of >=2 colons is one separator (all consecutive colons consumed).
+        assert_eq!(qualifier_segments(b"a:::b"), vec![&b"a"[..], b"b"]);
+        assert_eq!(qualifier_segments(b"a::::b"), vec![&b"a"[..], b"b"]);
+        assert_eq!(
+            qualifier_segments(b":::test_ns_1:::::test_ns_2:::"),
+            vec![&b"test_ns_1"[..], b"test_ns_2"]
+        );
+        // a lone interior colon is an ordinary name character.
+        assert_eq!(qualifier_segments(b"a:b"), vec![&b"a:b"[..]]);
+        assert!(ends_with_separator(b"a::b::"));
+        assert!(!ends_with_separator(b"a::b"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR implements two major Tcl Improvement Proposals (TIPs) for enhanced error handling:

- **TIP 348**: Error stack tracking (`info errorstack` / `-errorstack` option) that records the command execution path as errors unwind, including `INNER`, `CALL`, and `UP` entries for uplevel boundaries.
- **TIP 329**: Exception chaining via the `-during` option, allowing handlers and `finally` blocks to preserve the prior exception context when throwing new errors.

Additionally, this change:
- Extends the `Code` enum to support arbitrary user-defined completion codes via `Code::Other(i32)`, enabling `return -code N` for non-standard codes
- Refactors error state tracking to separate persistent interp state (`error_line`) from accumulating exception state
- Adds `proc_line_base` to `CmdFrame` to correctly compute `errorLine` for inline bodies (`catch`/`if`/`while`)
- Improves ensemble rewrite tracking with `inserted` count for accurate usage messages
- Fixes `namespace export/import/forget` validation to match C Tcl behavior
- Enhances completion-code parsing to support radix prefixes (`0x`, `0o`, `0b`, `0d`)
- Implements proper list error messages with junk fragment reporting

### Key Changes

**interp.rs**:
- `Code` enum now includes `Other(i32)` variant with `from_int()` / `as_int()` conversion
- `ExceptionState` restructured: removed `line` field, added `code_explicit` flag for error-4.5 compliance
- `InterpState` gains persistent `error_line`, `error_stack`, `reset_error_stack`, and `during` fields
- `CmdFrame` adds `proc_line_base` for correct errorLine computation in inline bodies
- New methods: `error_stack_log()`, `error_stack_push_call()`, `error_stack_value()`, `process_return_error()`, `set_during()`, `clear_during()`, `during_opts()`, `mark_error_stack_reset()`
- `EnsembleRewrite` gains `inserted` field; `begin_ensemble_rewrite()` now chains nested rewrites correctly
- `ns_eval_no_frame()` added for TclOO's custom frame logging

**cmd_error.rs**:
- `catch` now uses `eval_control_body()` to share enclosing frame (matching bytecode compilation)
- `build_options()` includes `-errorstack` and `-during` in returned dict
- `error` command marks explicit `-errorcode` via `mark_error_code_explicit()`
- `try` handler binding preserves body options for `-during` chaining
- Completion-code parsing supports radix prefixes

**builtins.rs**:
- `return` command validates and processes `-errorstack` option
- `parse_code_int()` helper supports `0x`/`0o`/`0b`/`0d` radix prefixes

**cmd_namespace.rs**:
- `namespace export` rejects qualified patterns
- `namespace import` validates non-empty patterns and rejects self-imports
- `namespace forget` errors on unknown source namespace (not silent skip)
- `qualifiers()` / `tail()` / `last_sep_run()` correctly handle colon runs

**parse.rs**:
- `list_error_message()` and `list_junk_fragment()` provide byte-exact `Tcl_SplitList` error messages

**tcl-syntax/naming.rs**:
- `qualifier_segments()` correctly skips entire colon runs (not just `::`)
- `ends_with_separator()` detects trailing `::` for empty-name resolution

**namespace.rs**:
- `var_home()` handles trailing `::` naming the `{}` (empty) variable
- `simple_name()` returns unqualified namespace name

**cmd_info.rs**:
- `info errorstack` now returns the built error stack

**cmd_oo.rs**:
- TclOO

https://claude.ai/code/session_01H3Rm1PGayeYzDCbJcTMx86