### PR TITLE
Remove Python server backend, use native Rust binary exclusively

### DIFF
--- a/INSTALL-editors.md
+++ b/INSTALL-editors.md
@@ -62,8 +62,9 @@ code --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix
 
 Configure under **Settings > Extensions > Tcl**. No Python interpreter
 is needed — the extension ships a native `tcl-lsp-server` binary for
-your platform and launches it automatically. (`tclLsp.pythonPath` is
-deprecated and ignored.)
+your platform and launches it automatically. There is no Python backend:
+to run against a local build, point `tclLsp.rustServerPath` at a
+`tcl-lsp-server` binary or `tclLsp.serverPath` at a checkout.
 
 ### VS Code-compatible editors
 
@@ -199,8 +200,9 @@ and install with the editor's own CLI.
 | **Eclipse Theia** | Extensions side panel > **Install from VSIX…** |
 
 Settings UI, keybindings, and the compiler-explorer / Tk preview
-panels behave the same as in VS Code itself. Pin the Python
-interpreter with `tclLsp.pythonPath` if `auto` picks the wrong one.
+panels behave the same as in VS Code itself. The bundled native
+`tcl-lsp-server` binary is used automatically; no Python interpreter
+is involved.
 
 ## Other LSP-capable editors
 

--- a/Makefile
+++ b/Makefile
@@ -493,13 +493,24 @@ test-ext: ## Run VS Code extension integration tests; skip with SKIP_TEST_EXT=1
 	@# (compile + xvfb install + test host).  Without ``set -eu`` the
 	@# early ``exit 0`` would only end its own recipe-line shell and
 	@# make would run the next lines anyway.
+	@#
+	@# The extension is native-only (no Python fallback), so the Rust
+	@# tcl-lsp-server binary must exist before the VS Code test host starts.
+	@# Build it here (idempotent) and point the extension at it via
+	@# TCL_LSP_SERVER_BIN, rather than relying on the parallel `test-rust`
+	@# in the test-slow batch winning the race.  A pre-set TCL_LSP_SERVER_BIN
+	@# is honoured so callers can supply their own binary.
 	@set -eu; \
 	if [ -n "$${SKIP_TEST_EXT:-}" ]; then \
 		echo "==> SKIP_TEST_EXT set — skipping VS Code extension tests"; \
 		exit 0; \
 	fi; \
+	if [ -z "$${TCL_LSP_SERVER_BIN:-}" ]; then \
+		"$(MAKE)" rust-server; \
+		export TCL_LSP_SERVER_BIN="$(ROOT)target/$(PROFILE)/tcl-lsp-server"; \
+	fi; \
 	"$(MAKE)" compile ensure-vscode-test-deps; \
-	echo "==> Running VS Code extension tests"; \
+	echo "==> Running VS Code extension tests (native server: $${TCL_LSP_SERVER_BIN})"; \
 	if [[ "$$(uname -s)" == "Linux" && -z "$${DISPLAY:-}" ]]; then \
 		if command -v xvfb-run >/dev/null 2>&1; then \
 			echo "==> No DISPLAY detected; running VS Code tests under xvfb-run"; \

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ The server ships as a native Rust binary (`tcl-lsp-server`) — the default,
 out-of-the-box backend — with a Python reference implementation (built on
 [pygls](https://github.com/openlawlibrary/pygls)) available as an opt-out.
 Both speak LSP over stdio, so they work with any LSP client. Set
-`TCL_LSP_SERVER_KIND=python` (or the editor's `serverKind` setting) to run the
-Python server instead.
+`TCL_LSP_SERVER_KIND=python` to run the Python server instead. (The VS Code
+extension is native-only — it always launches the bundled `tcl-lsp-server`
+binary and no longer exposes a Python backend toggle.)
 
 ## Editor support
 

--- a/docs/kcs/features/kcs-feature-extension-settings.md
+++ b/docs/kcs/features/kcs-feature-extension-settings.md
@@ -21,7 +21,7 @@ Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and type `Tcl:` to se
 
 | Command | What it does |
 |---------|-------------|
-| **Tcl: Restart Language Server** | Stop and restart the language server. Use when settings that are read at startup have changed (Python path, server path, log level). |
+| **Tcl: Restart Language Server** | Stop and restart the language server. Use when settings that are read at startup have changed (server path, native binary path, log level). |
 | **Tcl: Select Dialect** | Open a picker to switch between Tcl 8.4, 8.5, 8.6, 9.0, F5 iRules, F5 iApps, and EDA tool dialects. |
 | **Tcl: Export Configuration** | Write the current LSP settings to an XDG-compatible configuration file so they persist outside VS Code. |
 | **Tcl: Toggle Optimiser Suggestions** | Flip `tclLsp.optimiser.enabled` on or off. When enabled, hint-level O-code diagnostics appear in the editor. |
@@ -29,7 +29,7 @@ Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and type `Tcl:` to se
 
 ## Example
 
-After updating the `tclLsp.pythonPath` setting, the server keeps running with the old interpreter until you run **Tcl: Restart Language Server** from the Command Palette. The output channel logs the new interpreter path on restart.
+After updating the `tclLsp.rustServerPath` setting, the server keeps running with the old native binary until you run **Tcl: Restart Language Server** from the Command Palette. The output channel logs the native server path on restart.
 
 ## Related
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2952,42 +2952,19 @@
         "title": "General",
         "order": 0,
         "properties": {
-          "tclLsp.pythonPath": {
-            "scope": "machine-overridable",
-            "type": "string",
-            "default": "auto",
-            "description": "Deprecated and ignored. The extension now bundles a self-contained native language server (tcl-lsp-server) per platform and no longer requires Python. This setting has no effect.",
-            "deprecationMessage": "tclLsp.pythonPath is no longer used — the extension bundles a native server and does not require Python.",
-            "order": 0
-          },
           "tclLsp.serverPath": {
             "scope": "machine-overridable",
             "type": "string",
             "default": "",
-            "description": "Path to the tcl-lsp server directory. If empty, uses the bundled server.",
-            "order": 1
-          },
-          "tclLsp.serverKind": {
-            "scope": "machine-overridable",
-            "type": "string",
-            "default": "rust",
-            "enum": [
-              "rust",
-              "python"
-            ],
-            "enumDescriptions": [
-              "The native Rust tcl-lsp-server binary (default; falls back to the Python server if no binary is found).",
-              "The packaged Python LSP reference server."
-            ],
-            "description": "Which LSP backend to launch: the native Rust server (default) or the Python server.",
-            "order": 2
+            "description": "Path to a tcl-lsp checkout (workspace root). When set, the extension probes target/{release,debug}/ under it for a locally built tcl-lsp-server binary. If empty, uses the bundled native binary.",
+            "order": 0
           },
           "tclLsp.rustServerPath": {
             "scope": "machine-overridable",
             "type": "string",
             "default": "",
-            "description": "Path to the native Rust tcl-lsp-server binary (used when serverKind is 'rust'). If empty, probes target/{release,debug}/ under the project root.",
-            "order": 3
+            "description": "Path to the native Rust tcl-lsp-server binary. If empty, uses the bundled binary, then probes target/{release,debug}/ under the workspace root.",
+            "order": 1
           },
           "tclLsp.dialect": {
             "scope": "language-overridable",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -134,7 +134,7 @@ const TCL_VERSION_DIALECTS: Record<string, string> = {
   "9.0": "tcl9.0",
 };
 
-// Python discovery
+// LSP wire types (used by rename partitioning)
 
 interface LspPosition {
   line: number;
@@ -171,13 +171,11 @@ function getOutputChannel(): vscode.OutputChannel {
   return outputChannel;
 }
 
-// Server bundle detection
+// Rust workspace detection — the directory holding `target/` after a
+// `cargo build`, used to locate a dev-checkout build of `tcl-lsp-server`.
 
-function hasServerBundle(dir: string): boolean {
-  return (
-    existsSync(path.join(dir, "server", "__main__.py")) &&
-    existsSync(path.join(dir, "pyproject.toml"))
-  );
+function hasRustWorkspace(dir: string): boolean {
+  return existsSync(path.join(dir, "Cargo.toml"));
 }
 
 // The native server filename for the current OS.
@@ -191,12 +189,12 @@ function bundlePlatformDir(): string {
   return `${process.platform}-${process.arch}`;
 }
 
-// Locate the native Rust `tcl-lsp-server` binary for serverKind="rust".
+// Locate the native Rust `tcl-lsp-server` binary.
 // Honours an explicit path first (config `tclLsp.rustServerPath` or the
 // `TCL_LSP_SERVER_BIN` env var), then the platform binary bundled inside the
 // VSIX (`server/<platform>-<arch>/`), then probes `target/{release,debug}/`
-// under the project root (resolved like the Python server dir) so a plain
-// `cargo build -p tcl-lsp-server` in a checkout is picked up automatically.
+// under the workspace root (resolved by walking up to the `Cargo.toml`) so a
+// plain `cargo build -p tcl-lsp-server` in a checkout is picked up automatically.
 function resolveRustServer(
   configuredBin: string,
   configuredServerPath: string,
@@ -234,12 +232,12 @@ function resolveServerDir(configuredPath: string, extensionPath: string): string
   if (configured) {
     return configured;
   }
-  // Walk up from the extension directory to find the server bundle.
+  // Walk up from the extension directory to find the workspace root.
   // Handles both repo-root layouts (extension at /) and nested layouts
   // (extension at editors/vscode/).
   let dir = extensionPath;
   for (let i = 0; i < 3; i++) {
-    if (hasServerBundle(dir)) {
+    if (hasRustWorkspace(dir)) {
       return dir;
     }
     const parent = path.resolve(dir, "..");
@@ -314,89 +312,34 @@ export async function activate(context: ExtensionContext) {
   const config = workspace.getConfiguration("tclLsp");
   const configuredServerPath = config.get<string>("serverPath", "");
 
-  let serverOptions: ServerOptions | undefined;
-
-  // Backend selection: "rust" (default, the native `tcl-lsp-server` binary
-  // from the Rust workspace) or "python" (the packaged/uv reference server).
-  // Env vars override config so the e2e / VS Code test harnesses can pick a
-  // backend without writing workspace settings: TCL_LSP_SERVER_KIND=python|rust
-  // and TCL_LSP_SERVER_BIN=/path/to/tcl-lsp-server.
-  //
-  // We must distinguish "user explicitly chose a backend" from "left at the
-  // default".  `config.get("serverKind")` folds in the package.json schema
-  // default ("rust"), so it can't tell them apart — use `inspect()` and look
-  // only at values the user actually set.  When nothing is set, Rust is the
-  // default but a missing binary falls back to Python (see below); an explicit
-  // "rust" with no binary is a hard error.
-  const inspected = config.inspect<string>("serverKind");
-  const userConfiguredKind =
-    inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue ?? "";
-  const explicitKind = (process.env.TCL_LSP_SERVER_KIND || userConfiguredKind).trim().toLowerCase();
-  const serverKind = explicitKind || "rust";
-
-  if (serverKind === "rust" || serverKind === "native") {
-    const rustBin = resolveRustServer(
-      process.env.TCL_LSP_SERVER_BIN || config.get<string>("rustServerPath", ""),
-      configuredServerPath,
-      context.extensionPath,
+  // The extension runs the native Rust `tcl-lsp-server` exclusively.  The
+  // universal VSIX bundles one binary per platform under
+  // `server/<platform>-<arch>/`; a dev checkout builds it with
+  // `cargo build -p tcl-lsp-server` and it is picked up from
+  // `target/{release,debug}/`.  An explicit binary can be supplied via
+  // `tclLsp.rustServerPath` or the `TCL_LSP_SERVER_BIN` env var (the latter
+  // lets test harnesses point at a freshly built binary without writing
+  // workspace settings).
+  const rustBin = resolveRustServer(
+    process.env.TCL_LSP_SERVER_BIN || config.get<string>("rustServerPath", ""),
+    configuredServerPath,
+    context.extensionPath,
+  );
+  if (!rustBin) {
+    window.showErrorMessage(
+      `Tcl LSP: no native tcl-lsp-server binary found for ${bundlePlatformDir()}. ` +
+        "In a checkout, build it with `cargo build -p tcl-lsp-server` (or `make rust-server`), " +
+        "or set 'tclLsp.rustServerPath' to a native binary. A packaged install reaching this " +
+        "point does not ship a binary for your OS/architecture.",
     );
-    if (!rustBin) {
-      // When the user *explicitly* asked for the native backend, surface the
-      // missing-binary error.  When Rust is merely the default (no explicit
-      // preference), fall through to the dev `uv run` Python server if this is
-      // a checkout; a packaged install with no matching binary is reported as
-      // an unsupported platform below.
-      if (explicitKind === "rust" || explicitKind === "native") {
-        window.showErrorMessage(
-          `Tcl LSP: serverKind is 'rust' but no native tcl-lsp-server binary was found for ${bundlePlatformDir()}. ` +
-            "In a checkout, build it with `cargo build -p tcl-lsp-server` (or `make rust-server`); " +
-            "otherwise set 'tclLsp.rustServerPath'.",
-        );
-        return;
-      }
-      ch.appendLine(
-        `No native tcl-lsp-server binary found for ${bundlePlatformDir()}; ` +
-          "trying the dev Python server (checkout only).",
-      );
-    } else {
-      ch.appendLine(`Rust mode: using native server ${rustBin}`);
-      serverOptions = {
-        command: rustBin,
-        args: [],
-        options: { cwd: path.dirname(rustBin) },
-      };
-    }
+    return;
   }
-
-  if (!serverOptions) {
-    // Dev mode: explicit serverPath or running from a git checkout.
-    const serverDir = resolveServerDir(configuredServerPath, context.extensionPath);
-    if (configuredServerPath || hasServerBundle(serverDir)) {
-      if (!hasServerBundle(serverDir)) {
-        window.showErrorMessage(
-          `Unable to locate Tcl server bundle under '${serverDir}'. Set 'tclLsp.serverPath' to the tcl-lsp project root.`,
-        );
-      }
-      ch.appendLine(`Dev mode: using uv in ${serverDir}`);
-      serverOptions = {
-        command: "uv",
-        args: ["run", "--directory", serverDir, "--no-dev", "python", "-m", "server"],
-        options: { cwd: serverDir },
-      };
-    } else {
-      // Packaged install with no native binary bundled for this platform, and
-      // not a checkout.  The universal VSIX ships a `tcl-lsp-server` binary per
-      // supported platform under `server/<platform>-<arch>/`; reaching here
-      // means this platform is not in the shipped set.
-      window.showErrorMessage(
-        `Tcl LSP: no bundled server binary for this platform (${bundlePlatformDir()}). ` +
-          "This build of the extension does not support your OS/architecture. " +
-          "If you have a Tcl LSP checkout, set 'tclLsp.serverPath' to its root, " +
-          "or point 'tclLsp.rustServerPath' at a native tcl-lsp-server binary.",
-      );
-      return;
-    }
-  }
+  ch.appendLine(`Using native tcl-lsp-server: ${rustBin}`);
+  const serverOptions: ServerOptions = {
+    command: rustBin,
+    args: [],
+    options: { cwd: path.dirname(rustBin) },
+  };
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
@@ -449,12 +392,6 @@ export async function activate(context: ExtensionContext) {
       },
     },
   };
-
-  if (!serverOptions) {
-    // Every backend branch above either assigns serverOptions or returns; this
-    // guard makes that invariant explicit for the type checker.
-    return;
-  }
 
   client = new LanguageClient("tcl-lsp", "Tcl Language Server", serverOptions, clientOptions);
 

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -388,11 +388,6 @@ suite("Configuration Settings", () => {
     assert.ok(inspect, "dialect setting should exist");
   });
 
-  // Python path
-  test("pythonPath defaults to auto", () => {
-    assert.strictEqual(cfg().get<string>("pythonPath"), "auto");
-  });
-
   // Server path
   test("serverPath defaults to empty", () => {
     assert.strictEqual(cfg().get<string>("serverPath"), "");

--- a/editors/vscode/src/test/errorRecovery.test.ts
+++ b/editors/vscode/src/test/errorRecovery.test.ts
@@ -14,10 +14,9 @@ import {
  *
  * Like the lsp_e2e suite, this is intentionally **implementation-agnostic**: it
  * asserts the observable recovery behaviour an editor user depends on, never a
- * server internal or a Python-specific diagnostic code.  It is the editor-side
- * half of the contract the recovery engine must satisfy in *any* implementation
- * — Python today, Rust after the port — so these exact tests re-run unchanged to
- * prove the Rust port behaves correctly end to end.
+ * server internal or a backend-specific diagnostic code.  It is the editor-side
+ * half of the contract the recovery engine must satisfy in the native Rust
+ * tcl-lsp-server, driven end to end through the real VS Code extension.
  *
  *   C1  an unterminated [ / " / { is flagged with an error diagnostic
  *   C2  recovery is non-fatal — a proc after the break is still a document symbol

--- a/editors/vscode/src/test/serverHealth.test.ts
+++ b/editors/vscode/src/test/serverHealth.test.ts
@@ -14,8 +14,8 @@ function getApi(): TclLspApi {
 
 // Root-level hooks bracket the entire test run.
 
-// Runs before ALL test suites.  If the server crashed on startup (e.g. a
-// missing module in the .pyz bundle) then ext.activate() rejects because
+// Runs before ALL test suites.  If the native tcl-lsp-server binary is
+// missing or crashes on startup then ext.activate() rejects because
 // client.start() fails, and the whole test run aborts with a clear message.
 suiteSetup(async function () {
   this.timeout(60_000);


### PR DESCRIPTION
## Summary

This change removes all Python server backend support from the VS Code extension and commits to using the native Rust `tcl-lsp-server` binary exclusively. The extension now:

- Removes the `serverKind` configuration option (which toggled between "rust" and "python" backends)
- Removes the `pythonPath` configuration option (deprecated and unused)
- Simplifies `serverPath` to point to a tcl-lsp checkout workspace root (for dev builds)
- Removes all fallback logic to the Python `uv run` server
- Removes the `hasServerBundle()` function that detected Python server installations
- Renames `hasServerBundle()` → `hasRustWorkspace()` to reflect the new purpose
- Simplifies the activation logic to always use the native binary, with a clear error if not found

The extension now has a single, straightforward server resolution path:
1. Check explicit `TCL_LSP_SERVER_BIN` env var or `tclLsp.rustServerPath` config
2. Fall back to the bundled binary in `server/<platform>-<arch>/`
3. Probe `target/{release,debug}/` under the workspace root (found via `Cargo.toml`)
4. Error if none found

Configuration is simplified:
- `tclLsp.serverPath`: Points to a tcl-lsp checkout root (for dev builds)
- `tclLsp.rustServerPath`: Points directly to a native binary (for explicit overrides)

## Validation

- Existing test suite passes (configuration, error recovery, server health tests updated to reflect Rust-only backend)
- Configuration tests updated to remove `pythonPath` assertion
- Comments and docstrings updated to remove Python-specific references

https://claude.ai/code/session_01ScXg3mJR4FwNCAYi46oUuN