### PR TITLE
Fix flock-missing build failure on macOS and rename-trace recursion

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=b64b13a-dirty
-head=b64b13a8e3bd5a0cd0d639ce99ea0108b4d98fce
-date=2026-06-16T10:55:47Z
-fingerprint=8bd5671e657bd40f7ddf2546db12a3d25ef44ee8c3798217a26047646597c679
+describe=v1.11.0-8-gaebfd9a3-dirty
+head=aebfd9a3e8949ff31407fd11940f6d73915ac5b7
+date=2026-06-17T15:15:58Z
+fingerprint=c3f980ce7465d7be724b0eaea98e576072330c058442349546659d1c4ed94589

--- a/runtime/zig/interp/tcl_exec_trace.zig
+++ b/runtime/zig/interp/tcl_exec_trace.zig
@@ -55,6 +55,27 @@ pub var step_depth: u32 = 0;
 // fire traces.
 pub var suppress: u32 = 0;
 
+// Command-trace re-entrancy guard.  Reference Tcl marks a command
+// trace as in-progress while its callback runs and skips it if the
+// callback triggers the same operation on the same command again
+// (``CallCommandTraces`` / the ``TCL_TRACE_*_IN_PROGRESS`` flags).
+// Without this, a rename trace whose callback renames the very command
+// being renamed (``rename $old other`` — trace-20.10) re-fires forever
+// and exhausts the stack.  The registry uses swap-removal so entry
+// indices are not stable across a callback that mutates the table;
+// guard by ``(bucket, op)`` identity instead, on a small fixed stack.
+const CmdFireFrame = struct { bucket: u32, op: u32 };
+var cmd_fire_active: [64]CmdFireFrame = undefined;
+var cmd_fire_depth: u32 = 0;
+
+fn cmd_fire_is_active(bucket: u32, op: u32) bool {
+    var i: u32 = 0;
+    while (i < cmd_fire_depth) : (i += 1) {
+        if (cmd_fire_active[i].bucket == bucket and cmd_fire_active[i].op == op) return true;
+    }
+    return false;
+}
+
 /// True (1) when the interp is fully *quiescent* w.r.t. tracing: no
 /// execution / command / step trace is registered (``any_traces`` counts
 /// all of them, including command rename/delete), no step context is
@@ -279,6 +300,17 @@ pub fn fire_command(bucket: u32, op: u32, old_name: i32, new_name: i32) void {
         OP_CMD_RENAME => "rename",
         else => return,
     };
+    // Already firing this (bucket, op): a callback re-triggered the same
+    // operation on the same command (e.g. a rename trace whose body
+    // renames the command again — trace-20.10).  Reference Tcl skips the
+    // in-progress trace rather than re-firing it; do the same so the
+    // re-triggered operation proceeds without recursing forever.
+    if (cmd_fire_is_active(bucket, op)) return;
+    if (cmd_fire_depth >= cmd_fire_active.len) return;
+    cmd_fire_active[cmd_fire_depth] = .{ .bucket = bucket, .op = op };
+    cmd_fire_depth += 1;
+    defer cmd_fire_depth -= 1;
+
     const old_s = obj_ensure_string(old_name);
     var new_ptr: u32 = 0;
     var new_len: u32 = 0;

--- a/scripts/fetch_tcl_regex.sh
+++ b/scripts/fetch_tcl_regex.sh
@@ -110,9 +110,17 @@ mkdir -p "$TARGET_DIR"
 # because the early one had already moved the file away.  Serialise
 # behind a lock; whichever process gets the lock fetches, the rest
 # wait and re-check the stamp afterwards.
+#
+# ``flock`` is a util-linux tool that is NOT present on macOS (and may
+# be absent on minimal containers).  It is only an optimisation here —
+# the per-file PID-suffixed temp names below already make concurrent
+# fetches collision-safe — so fall back to running unlocked when it is
+# missing rather than dying with exit 127.
 LOCK_FILE="$TARGET_DIR/.fetch.lock"
-exec 9>"$LOCK_FILE"
-flock 9
+if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCK_FILE"
+    flock 9
+fi
 
 # Re-check after acquiring the lock — another process may have
 # completed the fetch while we were waiting.


### PR DESCRIPTION
## Summary

`make clean test-slow` failed on macOS with three red targets (`check-zig`, `test-zig`, `prep-pr`). All three traced to **one** root cause, and fixing the build then surfaced a **second**, latent runtime bug.

### 1. `flock` missing on macOS (the build failure)
`scripts/fetch_tcl_regex.sh` calls `flock`, a util-linux tool that is **not** present on macOS, so it exited `127` before fetching the vendored Tcl regex sources. The Zig WASM runtime then failed to build (`regcomp.c file_hash FileNotFound`), which cascaded into all three failing targets.

`flock` is only an optimisation here — the per-file PID-suffixed temp names already make concurrent fetches collision-safe (the script's own comment says exactly this) — so the fix falls back to running **unlocked** when `flock` is missing rather than dying.

### 2. Rename-trace infinite recursion (latent, surfaced once the build was fixed)
With the build green, the Python phase reached `TestCommandTraceReentrancyAndErrors::test_callback_renames_command_no_error`, which exhausted the wasm call stack. A `rename` command-trace whose callback renames the very command being renamed re-fired the same trace forever.

Reference Tcl (`CallCommandTraces` / the `TCL_TRACE_*_IN_PROGRESS` flags) skips a command trace already in progress. `fire_command` now does the same via a `(bucket, op)` re-entrancy guard, so the re-triggered rename proceeds and the outer rename becomes a silent no-op (trace-20.10). The registry uses swap-removal, so the guard is keyed by identity rather than entry index.

## Testing
- Full `make test-slow` is **green** (all 10 targets PASS); `.test-slow.stamp` regenerated and `make verify-test-slow-stamp` passes.
- `test_wasm_tier2_fixes.py` (73) and all trace-related suites (`test_trace_execution_effects`, `test_vm_trace_test`, `test_wasm_trace_*`, `test_wasm_var_trace`) pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)