### PR TITLE
Release v1.11.1 notes

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.11.0-8-gaebfd9a3-dirty
-head=aebfd9a3e8949ff31407fd11940f6d73915ac5b7
-date=2026-06-17T15:15:58Z
-fingerprint=c3f980ce7465d7be724b0eaea98e576072330c058442349546659d1c4ed94589
+describe=v1.11.0-9-g9a2bfa17-dirty
+head=9a2bfa17a30f3d59081aa6e6feab7067b31f09c9
+date=2026-06-17T15:35:35Z
+fingerprint=717ced708d3a55c41027e1c7147be7449054d217250d4bb3480e6ab8cb1806ed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,41 @@
+# v1.11.1
+
+## New Features
+
+- **`tcl registry-dump` / `f5 registry-dump`.** Serialise the command,
+  event, profile, and object registries as canonical JSON.
+
+## Improvements
+
+- **Unified secret input.** The UCS passphrase and auth-credential prompts now
+  share a single resolver — explicit value, file, environment variable, or a
+  secure `getpass` prompt — with consistent TTY detection and cancellation.
+- **Node.js baseline raised to 24+** (CI pinned to match) alongside a refresh
+  of the Python dev and VS Code npm dependencies.
+- **npm CLI pinned to v12 via Corepack** in CI and local development for
+  reproducible builds.
+
+## Bug Fixes
+
+- **Three latent analyser soundness bugs fixed**, each with a regression test
+  against real tclsh 9.0.3: omitted-argument call-site constants are now
+  poisoned interprocedurally; `regexp -expanded` is no longer treated as
+  unconditionally literal-safe (false W210); and a `try` body that throws now
+  keeps its exception edge to its handlers (false W210 read-before-set),
+  including conditional and nested-throw paths.
+- **Four style-check false positives fixed** (W105, W113, W212, W216).
+- **macOS build fixed.** `make test-slow` no longer fails on macOS:
+  `fetch_tcl_regex.sh` falls back to running unlocked when `flock` is absent,
+  since its per-file temp names already make concurrent fetches collision-safe.
+- **WASM rename-trace recursion fixed.** A `rename` command-trace whose
+  callback renames the very command being renamed no longer recurses until the
+  call stack is exhausted — `fire_command` now skips a trace already in
+  progress, matching reference Tcl (trace-20.10), so the outer rename becomes a
+  silent no-op.
+- **Release/capture script paths fixed.** Repo-root path bugs left by the
+  `scripts/` reorganisation are corrected, including the Sublime publish path
+  that failed the v1.11.0 release.
+
 # v1.11.0
 
 ## New Features


### PR DESCRIPTION
Release notes for **v1.11.1** (patch). Tag-only release — this PR lands `RELEASE_NOTES.md` and the refreshed `.test-slow.stamp`; the tag is pushed after merge.

## v1.11.1 highlights
- **New:** `tcl registry-dump` / `f5 registry-dump` verbs.
- **Improvements:** unified secret input (UCS passphrase + auth credentials), Node.js baseline raised to 24+, npm CLI pinned to v12 via Corepack.
- **Bug fixes:** three latent analyser soundness bugs (interproc constant poisoning, `regexp -expanded`, `try`-throw exception edges); four style-check false positives (W105/W113/W212/W216); macOS `test-slow` build failure (`flock`); WASM rename-trace recursion (trace-20.10); release/capture script path bugs from the `scripts/` reorg.

`make test-slow` is green against this tree (stamp regenerated to cover the docs-only `RELEASE_NOTES.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)