### PR TITLE
Fix a family of false W210 (read-before-set) bugs from imprecise control-flow modelling

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.11.0-12-g124ec8b3-dirty
-head=124ec8b3000a4ffdd460d0c3432a171b9c28af0f
-date=2026-06-17T18:00:21Z
-fingerprint=eb44bec33ccc4ac0144dee1f0511e9f4532a8b8c4f89048edd1a8de85bb3041f
+describe=9a07577-dirty
+head=9a07577edd3dc2adf1b7b1f0aa46bc0683c01488
+date=2026-06-18T07:25:53Z
+fingerprint=91fab9e53f9c6f7752b12258b3ea1d95ab9be0f1ebcac467467e1df66673b0f7

--- a/bench/fp_snippets.py
+++ b/bench/fp_snippets.py
@@ -3341,6 +3341,42 @@ register(
 )
 
 
+register(
+    "FP-RBS-16",
+    _Entry(
+        label="phi operand on a dead loop-exit edge (while 1 + break) is not read-before-set",
+        proc="::f",
+        vars=("y",),
+        show=("ssa", "rbs"),
+        notes=(
+            "`while 1 { set y 1; break }` runs the body at least once, so on the\n"
+            "ONLY real exit (the break) `y` is set.  The `cond -> exit` edge of\n"
+            "`while 1` is never taken (SCCP marks it non-executable), but the\n"
+            "loop-exit block's phi still has an operand for it carrying the\n"
+            "version-0 (unset) origin.  Pre-fix the read-before-set phi-undef\n"
+            "closure (`_phi_can_undef`) filtered unreachable predecessor BLOCKS\n"
+            "but not unreachable predecessor EDGES, so it consumed that dead-edge\n"
+            "version-0 and false-fired W210 on `puts $y`.  Fix (compiler/\n"
+            "core_analyses.py): thread SCCP `executable_edges` into\n"
+            "`_read_before_set` and skip phi operands whose `(pred, block)` edge\n"
+            "is non-executable -- mirroring the edge filter already in\n"
+            "`_collect_used_names`.  Common in the `while 1 { ...; if {c} break }`\n"
+            "early-exit idiom."
+        ),
+        source=_dedent(
+            """
+            proc f {} {
+                # while 1 runs the body >=1 time; the only exit is the break,
+                # where y is already set -> $y is always defined here.
+                while 1 { set y 1; break }
+                puts $y
+            }
+            """
+        ),
+    ),
+)
+
+
 def _render(fp_id: str) -> str:
     entry = ENTRIES[fp_id]
     snap = _pick(entry.source, entry.proc, dialect=entry.dialect)

--- a/bench/fp_snippets.py
+++ b/bench/fp_snippets.py
@@ -3228,6 +3228,81 @@ register(
 )
 
 
+register(
+    "FP-RBS-13",
+    _Entry(
+        label="tailcall with args replaces the frame — code after it never runs",
+        proc="::f",
+        vars=("result",),
+        show=("ssa", "rbs"),
+        notes=(
+            "`tailcall` (Tcl 8.6+) replaces the current procedure's frame:\n"
+            "control never returns to this proc, so the statement ends\n"
+            "straight-line flow exactly like `return`/`error`/`exit`.\n"
+            "`TclNRTailcallObjCmd` (tclBasic.c) always `return TCL_RETURN` -- both\n"
+            "bare `tailcall` and `tailcall command ...` exit the proc (the arg\n"
+            "count only decides what runs *after* the frame pops).  Pre-fix the\n"
+            "CFG modelled it as an ordinary fall-through call (it was NOT in the\n"
+            "`terminates_block` trait), so the `if {$cond} { tailcall g }` arm\n"
+            "flowed into the join and `return $result` saw `result` as maybe-unset\n"
+            "-> false W210.  Fix (compiler/cfg.py): in analysis builds promote any\n"
+            "`tailcall` IRCall to a CFGReturn terminator (faithful builds only, so\n"
+            "the opaque-loop codegen / bytecode is byte-identical)."
+        ),
+        source=_dedent(
+            """
+            proc f {cond} {
+                # tailcall g replaces this frame: the `return $result` below is
+                # only reached via the else branch, where result is always set.
+                if {$cond} {
+                    tailcall g
+                } else {
+                    set result 1
+                }
+                return $result
+            }
+            """
+        ),
+    ),
+)
+
+
+register(
+    "FP-RBS-14",
+    _Entry(
+        label="opaque-switch arm that cannot complete normally is excluded from must-define",
+        proc="::f",
+        vars=("y",),
+        show=("ssa", "rbs"),
+        notes=(
+            "An opaque (glob/regexp/fall-through) switch definitely-defines a var\n"
+            "only when every arm that *reaches the code after the switch* assigns\n"
+            "it.  An arm that always `return`s / `error`s (cannot complete\n"
+            "normally) never reaches that code, so it must be excluded from the\n"
+            "must-define intersection — the standard definite-assignment rule.\n"
+            "Pre-fix the intersection counted such an arm's (empty) def set, so\n"
+            "`a* { return 0 } default { set y 2 }` left `y` out of the switch's\n"
+            "defs and `puts $y` falsely fired W210.  Fix (compiler/ssa.py):\n"
+            "`_flow_facts_*` track can-complete-normally and skip non-completing\n"
+            "arms in `_switch_must_defines`."
+        ),
+        source=_dedent(
+            """
+            proc f {x} {
+                # the a* arm returns, so it never reaches `puts $y`; the only
+                # path that does (default) sets y -> y is definitely defined.
+                switch -glob $x {
+                    a* { return 0 }
+                    default { set y 2 }
+                }
+                puts $y
+            }
+            """
+        ),
+    ),
+)
+
+
 def _render(fp_id: str) -> str:
     entry = ENTRIES[fp_id]
     snap = _pick(entry.source, entry.proc, dialect=entry.dialect)

--- a/bench/fp_snippets.py
+++ b/bench/fp_snippets.py
@@ -3377,6 +3377,75 @@ register(
 )
 
 
+register(
+    "FP-RBS-17",
+    _Entry(
+        label="foreach over a non-empty literal runs its body at least once",
+        proc="::f",
+        vars=("y",),
+        show=("ssa", "rbs"),
+        notes=(
+            "`foreach x {1 2 3} { set y $x }` always runs the body (the list is a\n"
+            "non-empty literal), so `y` is set when `puts $y` reads it.  The CFG\n"
+            "modelled every foreach as possibly zero iterations (the header's\n"
+            "opaque has-next branch), false-firing W210.  Fix (compiler/cfg.py):\n"
+            "analysis builds *rotate* a provably-non-empty foreach -- the\n"
+            "0-iteration skip becomes a separate, statically-true entry-guard\n"
+            "edge (SCCP prunes it) and the var-def + body run before the latch\n"
+            "re-check, so the loop var and body defs reach the exit.  No synthetic\n"
+            "def, so SCCP values are intact; `break`/`continue` stay real edges,\n"
+            "so partial-def exits remain sound (a `continue`-before-set still\n"
+            "fires W210).  Faithful builds only -- codegen keeps the original\n"
+            "foreach shape, so bytecode is unchanged."
+        ),
+        source=_dedent(
+            """
+            proc f {} {
+                # the list is a non-empty literal, so the body runs >=1 time
+                # and y is set before puts reads it.
+                foreach x {1 2 3} { set y $x }
+                puts $y
+            }
+            """
+        ),
+    ),
+)
+
+
+register(
+    "FP-RBS-18",
+    _Entry(
+        label="for whose condition is true on entry runs its body at least once",
+        proc="::f",
+        vars=("y",),
+        show=("ssa", "rbs"),
+        notes=(
+            "`for {set i 0} {$i < 3} {incr i} { set y $i }` runs the body at least\n"
+            "once (`0 < 3` is true on entry), so `y` is set when `puts $y` reads\n"
+            "it.  SCCP cannot fold the header test because `i` there is the loop\n"
+            "phi (0 ⊔ stepped).  Fix (compiler/cfg.py): analysis builds rotate the\n"
+            "loop so the back-edge re-check carries the real condition and the\n"
+            "header is demoted to a synthetic always-true entry guard (we proved\n"
+            "entry-truth by evaluating the condition against the init constants).\n"
+            "The header is then reached only from init, so SCCP prunes the\n"
+            "0-iteration header→end edge.  The guard branch has no source range,\n"
+            "so the optimiser's constant-branch rewriter leaves the loop source\n"
+            "alone; loop_nodes + init exit-versions are unchanged, so the static-\n"
+            "for summary still folds post-loop constants.  Faithful builds only."
+        ),
+        source=_dedent(
+            """
+            proc f {} {
+                # 0 < 3 is true on entry, so the body runs >=1 time and y is set.
+                for {set i 0} {$i < 3} {incr i} { set y $i }
+                puts $y
+            }
+            """
+        ),
+    ),
+)
+
+
 def _render(fp_id: str) -> str:
     entry = ENTRIES[fp_id]
     snap = _pick(entry.source, entry.proc, dialect=entry.dialect)

--- a/bench/fp_snippets.py
+++ b/bench/fp_snippets.py
@@ -3303,6 +3303,44 @@ register(
 )
 
 
+register(
+    "FP-RBS-15",
+    _Entry(
+        label="opaque switch whose every arm exits is itself a terminator",
+        proc="::f",
+        vars=("y",),
+        show=("ssa", "rbs"),
+        notes=(
+            "When an opaque (glob/regexp/fall-through) switch has a `default` and\n"
+            "*every* reachable arm body (default + each arm with a body) cannot\n"
+            "complete normally -- e.g. every arm `return`s / `error`s / `tailcall`s\n"
+            "-- no path falls through, so the code after the switch is unreachable.\n"
+            "Pre-fix the opaque switch always fell through to the next statement,\n"
+            "so a read there (`puts $y`) was analysed as reachable and fired a\n"
+            "false W210.  Fix (compiler/cfg.py `_maybe_terminate_opaque_switch`):\n"
+            "in analysis builds promote the block to a CFGReturn terminator when\n"
+            "`_switch_completes_normally` is false, routing the trailing statements\n"
+            "to the orphan unreachable block exactly like a `return`/`tailcall`.\n"
+            "Conservative -- fires only when provably non-completing -- and\n"
+            "faithful-only, so the opaque-switch invokeStk codegen is unchanged."
+        ),
+        source=_dedent(
+            """
+            proc f {x} {
+                # every arm returns, so control never reaches `puts $y`:
+                # the switch is a terminator and the read is dead code.
+                switch -glob $x {
+                    a* { return 1 }
+                    default { return 2 }
+                }
+                puts $y
+            }
+            """
+        ),
+    ),
+)
+
+
 def _render(fp_id: str) -> str:
     entry = ENTRIES[fp_id]
     snap = _pick(entry.source, entry.proc, dialect=entry.dialect)

--- a/bench/fp_snippets.py
+++ b/bench/fp_snippets.py
@@ -3277,14 +3277,15 @@ register(
         notes=(
             "An opaque (glob/regexp/fall-through) switch definitely-defines a var\n"
             "only when every arm that *reaches the code after the switch* assigns\n"
-            "it.  An arm that always `return`s / `error`s (cannot complete\n"
-            "normally) never reaches that code, so it must be excluded from the\n"
+            "it.  An arm that exits the PROCEDURE (`return`/`error`/`exit`/\n"
+            "`tailcall`) never reaches that code, so it is excluded from the\n"
             "must-define intersection — the standard definite-assignment rule.\n"
-            "Pre-fix the intersection counted such an arm's (empty) def set, so\n"
-            "`a* { return 0 } default { set y 2 }` left `y` out of the switch's\n"
-            "defs and `puts $y` falsely fired W210.  Fix (compiler/ssa.py):\n"
-            "`_flow_facts_*` track can-complete-normally and skip non-completing\n"
-            "arms in `_switch_must_defines`."
+            "(A `break`/`continue` arm is a loop jump, NOT a proc exit: it still\n"
+            "reaches the code after the enclosing loop, so it is KEPT — see the\n"
+            "FP-RBS-14 break TP control.)  Pre-fix the intersection counted the\n"
+            "proc-exit arm's (empty) def set, so `a* { return 0 } default { set y\n"
+            "2 }` left `y` out of the switch's defs and `puts $y` falsely fired\n"
+            "W210.  Fix (compiler/cfg.py `_flow_facts_*`/`_switch_must_defines`)."
         ),
         source=_dedent(
             """

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -1068,19 +1068,29 @@ class _CFGBuilder:
                         self._faithful_exceptions
                         and isinstance(stmt, IRCall)
                         and stmt.canonical_command
-                        and stmt.canonical_command.lstrip(":") in _TERMINATING_COMMANDS
                     ):
-                        block.terminator = CFGReturn(
-                            value=None, range=stmt.range, expr=None, braced=False
-                        )
-                        # ``error`` / ``throw`` are catchable throw points; an
-                        # enclosing ``try`` sources its on-error edge from here
-                        # so the handler sees the var state *at the throw*.
-                        # ``exit`` is not catchable, so it is not a throw point.
-                        if self._throw_blocks is not None and stmt.canonical_command.lstrip(
-                            ":"
-                        ) in ("error", "throw"):
-                            self._throw_blocks.append(current)
+                        canon = stmt.canonical_command.lstrip(":")
+                        # ``tailcall`` (Tcl 8.6+) replaces the current
+                        # procedure's frame and never returns here, so it ends
+                        # straight-line flow just like ``error`` / ``exit``.
+                        # ``TclNRTailcallObjCmd`` (tclBasic.c) always
+                        # ``return TCL_RETURN`` -- both bare ``tailcall`` and
+                        # ``tailcall command ...`` exit the proc; the arg count
+                        # only decides what runs *after* the frame pops, not
+                        # whether this proc continues.  So any ``tailcall`` is a
+                        # terminator.
+                        exits_proc = canon in _TERMINATING_COMMANDS or canon == "tailcall"
+                        if exits_proc:
+                            block.terminator = CFGReturn(
+                                value=None, range=stmt.range, expr=None, braced=False
+                            )
+                            # ``error`` / ``throw`` are catchable throw points;
+                            # an enclosing ``try`` sources its on-error edge
+                            # from here so the handler sees the var state *at
+                            # the throw*.  ``exit`` / ``tailcall`` are not
+                            # catchable, so they are not throw points.
+                            if self._throw_blocks is not None and canon in ("error", "throw"):
+                                self._throw_blocks.append(current)
 
         # The script has no normal fall-through if the block control finally
         # rests in is terminated (a straight-line ``return``/``error`` as the

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -235,6 +235,56 @@ def _switch_proc_exits(stmt: IRSwitch) -> bool:
     return _flow_facts_stmt(stmt)[1] == _COMPLETE_PROC_EXIT
 
 
+def _escaping_loop_jumps(script: IRScript) -> tuple[bool, bool]:
+    """``(can_break, can_continue)`` for ``break``/``continue`` that escape
+    *script* to an enclosing loop.
+
+    Recurses into ``if``/``switch``/``IRBlock`` bodies (which don't capture a
+    loop jump) but NOT into nested loops (``for``/``while``/``foreach``) or
+    ``catch``/``try`` — those capture their own ``break``/``continue`` (tclsh:
+    ``catch {break}`` yields code 3 and does not propagate), so a jump inside
+    them does not escape to *this* loop.
+    """
+    can_break = can_continue = False
+    for stmt in script.statements:
+        if isinstance(stmt, IRCall):
+            canon = stmt.canonical_command.lstrip(":") if stmt.canonical_command else ""
+            if canon == "break":
+                can_break = True
+            elif canon == "continue":
+                can_continue = True
+        elif isinstance(stmt, IRIf):
+            for clause in stmt.clauses:
+                b, c = _escaping_loop_jumps(clause.body)
+                can_break |= b
+                can_continue |= c
+            if stmt.else_body is not None:
+                b, c = _escaping_loop_jumps(stmt.else_body)
+                can_break |= b
+                can_continue |= c
+        elif isinstance(stmt, IRSwitch):
+            b, c = _switch_escaping_jumps(stmt)
+            can_break |= b
+            can_continue |= c
+        elif isinstance(stmt, (IRBlock, IRUpFrame)):
+            b, c = _escaping_loop_jumps(stmt.body)
+            can_break |= b
+            can_continue |= c
+    return can_break, can_continue
+
+
+def _switch_escaping_jumps(stmt: IRSwitch) -> tuple[bool, bool]:
+    """``(can_break, can_continue)`` over all bodies of an opaque ``switch``."""
+    can_break = can_continue = False
+    bodies = [stmt.default_body] if stmt.default_body is not None else []
+    bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
+    for body in bodies:
+        b, c = _escaping_loop_jumps(body)
+        can_break |= b
+        can_continue |= c
+    return can_break, can_continue
+
+
 # --- Guaranteed-iteration loops ----------------------------------------------
 #
 # A loop whose body provably runs at least once does not skip its body, so a
@@ -1422,30 +1472,97 @@ class _CFGBuilder:
 
         return end_block
 
-    def _maybe_terminate_opaque_switch(self, stmt: IRSwitch, block_name: str) -> None:
-        """Terminate *block_name* when an opaque ``switch`` exits the procedure.
+    def _lower_opaque_switch(self, stmt: IRSwitch, block_name: str) -> str:
+        """Append an opaque ``switch`` to *block_name* and model how it leaves.
 
-        An opaque switch is kept as a single ``IRSwitch`` statement that
-        normally falls through to the next statement.  But when it has a
-        ``default`` arm and *every* reachable arm body exits the *procedure*
-        (``return`` / ``error`` / ``exit`` / ``tailcall``), no path reaches the
-        code after the switch, so the switch is itself a procedure terminator —
-        promote the block to a ``CFGReturn`` so the following statements are
-        routed to the orphan unreachable block, exactly like a ``return``.
+        An opaque (glob/regexp/fall-through) switch is kept as a single
+        ``IRSwitch`` statement whose arm bodies are not lowered into the CFG, so
+        its internal control flow is otherwise invisible.  In analysis builds we
+        recover the ways it can leave the block:
 
-        Only proc-exit arms qualify: a switch whose arms ``break``/``continue``
-        jumps to an enclosing-loop target (reaching the code after the loop),
-        NOT the procedure exit, so it must not be promoted to a ``CFGReturn``.
+        * every arm exits the *procedure* → promote the block to ``CFGReturn``
+          (so the following statements are unreachable, like a ``return``);
+        * an arm ``break``s/``continue``s to an enclosing loop → wire explicit
+          edges from this block to that loop's break / continue target, so a
+          loop whose only exit is such a jump is not seen as infinite and the
+          post-loop read is correctly reachable (and maybe-unset);
+        * otherwise it just falls through to the next statement.
 
-        Analysis builds only (``faithful_exceptions``); codegen leaves the
-        fall-through edge so the opaque-switch ``invokeStk`` bytecode and CFG
-        shape are unchanged.  Conservative: only fires when the switch provably
-        exits the proc on every path, so it never hides a real read-before-set.
+        Codegen builds (``faithful_exceptions`` off) leave the plain
+        fall-through so the opaque-switch ``invokeStk`` bytecode / CFG shape are
+        unchanged.  Returns the block subsequent statements continue in.
         """
-        if self._faithful_exceptions and _switch_proc_exits(stmt):
+        self._block(block_name).statements.append(stmt)
+        if not self._faithful_exceptions:
+            return block_name
+        completion = _flow_facts_stmt(stmt)[1]
+        if completion == _COMPLETE_PROC_EXIT:
             self._block(block_name).terminator = CFGReturn(
                 value=None, range=stmt.range, expr=None, braced=False
             )
+            return block_name
+        if self._loop_stack:
+            can_break, can_continue = _switch_escaping_jumps(stmt)
+            if can_break or can_continue:
+                return self._wire_opaque_switch_jumps(
+                    stmt, block_name, completion, can_break, can_continue
+                )
+        return block_name
+
+    def _wire_opaque_switch_jumps(
+        self,
+        stmt: IRSwitch,
+        block_name: str,
+        completion: int,
+        can_break: bool,
+        can_continue: bool,
+    ) -> str:
+        """Wire an opaque switch block to its enclosing loop's jump targets.
+
+        The switch can leave via the fall-through successor (only when it can
+        still complete normally), the loop's break target, and/or the loop's
+        continue target.  Build a non-deterministic dispatch over those targets
+        (we can't tell which arm runs), and return the block subsequent
+        statements continue in: the fall-through continuation when one exists,
+        else an unreachable orphan (every path jumped, so following code is
+        dead).
+        """
+        break_target, continue_target = self._loop_stack[-1]
+        targets: list[str] = []
+        continuation: str | None = None
+        if completion == _COMPLETE_NORMAL:
+            continuation = self._new_block("switch_cont")
+            targets.append(continuation)
+        if can_break:
+            targets.append(break_target)
+        if can_continue:
+            targets.append(continue_target)
+        self._branch_to_any(block_name, targets, stmt.range)
+        return continuation if continuation is not None else self._new_block("switch_jump_dead")
+
+    def _branch_to_any(self, block_name: str, targets: list[str], r: Range | None) -> None:
+        """Terminate *block_name* so control can reach any of *targets*.
+
+        One target → a ``CFGGoto``; more → a chain of opaque ``CFGBranch``es
+        through synthetic dispatch blocks (the choice is non-deterministic — an
+        opaque switch hides which arm runs).
+        """
+        if not targets:
+            return
+        if len(targets) == 1:
+            self._block(block_name).terminator = CFGGoto(target=targets[0], range=r)
+            return
+        opaque = ExprRaw(text="<switch_jump>")
+        current = block_name
+        for i in range(len(targets) - 1):
+            false_target = targets[-1] if i == len(targets) - 2 else self._new_block("switch_jump")
+            self._block(current).terminator = CFGBranch(
+                condition=opaque,
+                true_target=targets[i],
+                false_target=false_target,
+                range=r,
+            )
+            current = false_target
 
     def _lower_switch(self, stmt: IRSwitch, block_name: str) -> str | None:
         # ``-regexp`` needs a runtime regex engine pass we haven't plumbed
@@ -1461,13 +1578,9 @@ class _CFGBuilder:
         # be lowered to valid WASM structured control flow in general;
         # ``_emit_switch`` handles OR-matching for fallthrough groups.
         if stmt.mode in ("glob", "regexp"):
-            self._block(block_name).statements.append(stmt)
-            self._maybe_terminate_opaque_switch(stmt, block_name)
-            return block_name
+            return self._lower_opaque_switch(stmt, block_name)
         if any(arm.fallthrough for arm in stmt.arms) and not self._expand_fallthrough_switch:
-            self._block(block_name).statements.append(stmt)
-            self._maybe_terminate_opaque_switch(stmt, block_name)
-            return block_name
+            return self._lower_opaque_switch(stmt, block_name)
 
         end_block = self._new_block("switch_end")
         default_block = self._new_block("switch_default")

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -44,6 +44,7 @@ from .ir import (
     IRAssignExpr,
     IRAssignValue,
     IRBarrier,
+    IRBlock,
     IRCall,
     IRCatch,
     IRFor,
@@ -56,6 +57,7 @@ from .ir import (
     IRStatement,
     IRSwitch,
     IRTry,
+    IRUpFrame,
     IRWhile,
 )
 
@@ -74,6 +76,131 @@ def _terminating_commands() -> frozenset[str]:
 
 
 _TERMINATING_COMMANDS = _terminating_commands()
+
+
+# --- Definite-assignment ("flow facts") over un-lowered IR scripts ------------
+#
+# Shared by the CFG builder (to promote an opaque ``switch`` whose every arm
+# exits to a terminator) and by SSA (to recover the def set an opaque switch
+# *definitely* establishes).  Lives here, at the control-flow layer, so both
+# consumers agree on one definition of "cannot complete normally" — SSA imports
+# these rather than re-deriving them.
+
+
+def _flow_facts_stmt(stmt: IRStatement) -> tuple[set[str], bool]:
+    """``(must-defines, can-complete-normally)`` for a single statement.
+
+    * assignments (``set``/``incr``/``expr``-assign) contribute their target
+      and complete;
+    * a plain ``IRCall`` contributes its synthetic ``defs`` and completes —
+      *except* a non-returning one (``error``/``throw``/``exit`` via the
+      ``terminates_block`` trait, ``break``/``continue``, or ``tailcall``),
+      which cannot complete; ``IRReturn`` and a ``return -code``/expansion
+      ``IRBarrier`` likewise cannot complete;
+    * ``IRBlock`` / ``IRUpFrame`` bodies always run, so recurse;
+    * an ``IRIf`` *with* an else, or an ``IRSwitch`` *with* a default, takes the
+      intersection over its completing branches (and is non-completing only when
+      every branch is); an else-less ``IRIf`` / default-less ``IRSwitch`` has a
+      fall-through path, so it completes assigning nothing for certain;
+    * loops (``IRFor``/``IRWhile``/``IRForeach``), ``IRCatch``/``IRTry`` and
+      everything else may not execute / always complete, so they contribute no
+      must-define and complete normally.
+    """
+    if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
+        name = _normalise_var_name(stmt.name)
+        return ({name} if name else set()), True
+    if isinstance(stmt, IRReturn):
+        return set(), False
+    if isinstance(stmt, IRBarrier):
+        if stmt.reason in ("return with options", "return with expansion"):
+            return set(), False
+        return set(), True
+    if isinstance(stmt, IRCall):
+        canon = stmt.canonical_command.lstrip(":") if stmt.canonical_command else ""
+        # ``tailcall`` always exits the proc (``TclNRTailcallObjCmd`` returns
+        # TCL_RETURN for any arg count), so it cannot complete normally.
+        non_returning = canon in _TERMINATING_COMMANDS or canon in ("break", "continue", "tailcall")
+        return set(stmt.defs), not non_returning
+    if isinstance(stmt, (IRBlock, IRUpFrame)):
+        return _flow_facts_script(stmt.body)
+    if isinstance(stmt, IRIf):
+        if stmt.else_body is None:
+            return set(), True
+        bodies = [clause.body for clause in stmt.clauses]
+        bodies.append(stmt.else_body)
+        return _intersect_completing(bodies)
+    if isinstance(stmt, IRSwitch):
+        if stmt.default_body is None:
+            return set(), True
+        bodies = [stmt.default_body]
+        bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
+        return _intersect_completing(bodies)
+    return set(), True
+
+
+def _flow_facts_script(script: IRScript) -> tuple[set[str], bool]:
+    """``(vars definitely assigned at normal completion, can-complete-normally)``.
+
+    Sound definite-assignment over an un-lowered IR script: walk the statements
+    in order accumulating must-defines; the first statement that cannot complete
+    normally makes everything after it dead and the whole script non-completing.
+    Only names guaranteed to be assigned are returned, so it never over-claims
+    (which would hide a real read-before-set).  Mirrors
+    ``definitely_assigned_in_script`` in the Rust oracle (``ssa.rs``).
+    """
+    assigned: set[str] = set()
+    for stmt in script.statements:
+        defs, completes = _flow_facts_stmt(stmt)
+        assigned |= defs
+        if not completes:
+            return assigned, False
+    return assigned, True
+
+
+def _intersect_completing(bodies: list[IRScript]) -> tuple[set[str], bool]:
+    """``(must-defines over the branches that can complete, any-completes)``.
+
+    The intersection skips any branch that cannot complete normally: such a
+    branch never reaches the control-flow merge, so by the standard
+    definite-assignment rule it vacuously defines everything (⊤, the identity
+    of intersection).  ``any-completes`` is False only when *every* branch is
+    non-completing — then the merge itself is unreachable.
+    """
+    common: set[str] | None = None
+    completes_any = False
+    for body in bodies:
+        assigned, completes = _flow_facts_script(body)
+        if not completes:
+            continue
+        completes_any = True
+        common = set(assigned) if common is None else (common & assigned)
+    return (common or set()), completes_any
+
+
+def _switch_must_defines(stmt: IRSwitch) -> set[str]:
+    """Variables an opaque ``switch`` assigns on *every* reaching path.
+
+    Empty unless the switch has a ``default`` arm (otherwise an unmatched
+    subject falls through assigning nothing).  With a default, the result is
+    the intersection of the must-define sets of the default body and of every
+    arm that has a body — a fall-through arm with no body delegates to a later
+    arm's body, which is already counted, so it contributes nothing on its own.
+    An arm that *cannot complete normally* (always ``return``s / ``error``s /
+    ``break``s / …) never reaches the code after the switch, so it is excluded
+    from the intersection.  Mirrors the exhaustive-switch rule in the Rust
+    oracle (``ssa.rs``).
+    """
+    return _flow_facts_stmt(stmt)[0]
+
+
+def _switch_completes_normally(stmt: IRSwitch) -> bool:
+    """Whether an opaque ``switch`` can reach the code after it.
+
+    False only when it has a ``default`` *and* every arm-with-a-body plus the
+    default cannot complete normally — then no path falls through, so the
+    switch is itself a terminator.
+    """
+    return _flow_facts_stmt(stmt)[1]
 
 
 def _static_var_write_defs(seg: SegmentedCommand) -> list[str]:
@@ -1165,6 +1292,29 @@ class _CFGBuilder:
 
         return end_block
 
+    def _maybe_terminate_opaque_switch(self, stmt: IRSwitch, block_name: str) -> None:
+        """Terminate *block_name* when an opaque ``switch`` can't fall through.
+
+        An opaque switch is kept as a single ``IRSwitch`` statement that
+        normally falls through to the next statement.  But when it has a
+        ``default`` arm and *every* reachable arm body (default + each arm with
+        a body) cannot complete normally — e.g. every arm ``return``s /
+        ``error``s / ``tailcall``s — no path reaches the code after the switch,
+        so the switch is itself a terminator.  Promote the block to a
+        ``CFGReturn`` so the following statements are routed to the orphan
+        unreachable block (exactly like a ``return``/``tailcall``), instead of
+        being falsely analysed as reachable.
+
+        Analysis builds only (``faithful_exceptions``); codegen leaves the
+        fall-through edge so the opaque-switch ``invokeStk`` bytecode and CFG
+        shape are unchanged.  Conservative: only fires when provably
+        non-completing, so it never hides a real read-before-set.
+        """
+        if self._faithful_exceptions and not _switch_completes_normally(stmt):
+            self._block(block_name).terminator = CFGReturn(
+                value=None, range=stmt.range, expr=None, braced=False
+            )
+
     def _lower_switch(self, stmt: IRSwitch, block_name: str) -> str | None:
         # ``-regexp`` needs a runtime regex engine pass we haven't plumbed
         # through the CFG, and ``-glob`` matching can't be expressed by the
@@ -1180,9 +1330,11 @@ class _CFGBuilder:
         # ``_emit_switch`` handles OR-matching for fallthrough groups.
         if stmt.mode in ("glob", "regexp"):
             self._block(block_name).statements.append(stmt)
+            self._maybe_terminate_opaque_switch(stmt, block_name)
             return block_name
         if any(arm.fallthrough for arm in stmt.arms) and not self._expand_fallthrough_switch:
             self._block(block_name).statements.append(stmt)
+            self._maybe_terminate_opaque_switch(stmt, block_name)
             return block_name
 
         end_block = self._new_block("switch_end")

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -588,6 +588,17 @@ class _CFGBuilder:
         # throw has it set.  Nested ``try`` bodies install their own list so an
         # inner-caught throw is not attributed to the outer handler.
         self._throw_blocks: list[str] | None = None
+        # Stack of ``(break_target, continue_target)`` block names for the
+        # enclosing inlined loops.  Pushed by ``_lower_for`` / ``_lower_while``
+        # / ``_lower_foreach`` around their body lowering and consulted by
+        # ``_lower_loop_jump`` so a ``break`` / ``continue`` IRCall becomes a
+        # CFGGoto to the loop's exit / continue target instead of falling
+        # through to the next statement.  Empty on the opaque-loop
+        # (``invokeStk``) codegen path -- loops there are emitted as
+        # ``IRBarrier`` and never push a target -- so that lowering is
+        # unaffected (bytecode parity).  Loop jumps are modelled only in
+        # analysis builds (``faithful_exceptions``); see ``_lower_loop_jump``.
+        self._loop_stack: list[tuple[str, str]] = []
         self._inline_loops = inline_loops
         self._upvar_procs = upvar_procs or {}
         self._proc_params = proc_params or {}
@@ -835,6 +846,15 @@ class _CFGBuilder:
                 current = orphan
                 block = self._block(current)
 
+            # ``break`` / ``continue`` inside an inlined loop are control-flow
+            # jumps, not ordinary calls: terminate the current block with a
+            # CFGGoto to the loop's exit / continue target.  Straight-line flow
+            # stops here -- any following statements are dead and get routed to
+            # the orphan unreachable block on the next iteration, exactly like a
+            # ``return``.
+            if self._lower_loop_jump(stmt, block):
+                continue
+
             match stmt:
                 case IRIf():
                     current = self._lower_if(stmt, current)
@@ -1070,6 +1090,36 @@ class _CFGBuilder:
         self._last_terminal_block = terminal
         return current
 
+    def _lower_loop_jump(self, stmt: IRStatement, block: _MutableBlock) -> bool:
+        """Model a ``break`` / ``continue`` inside an inlined loop as a jump.
+
+        When *stmt* is a ``break`` / ``continue`` IRCall and we are inside an
+        inlined loop (``self._loop_stack`` non-empty), append it to *block* and
+        set the block's terminator to a CFGGoto targeting the enclosing loop's
+        break / continue target.  Returns True when the statement was handled
+        as a loop jump (so the caller skips normal lowering).
+
+        Only active in analysis builds (``faithful_exceptions``).  Codegen
+        builds leave ``break`` / ``continue`` as ordinary IRCalls that fall
+        through, so the emitted bytecode is unchanged.  Identified by canonical
+        command name so renamed / aliased spellings resolve through the
+        registry, consistent with the rest of ``cfg.py``.
+        """
+        if not (self._faithful_exceptions and self._loop_stack):
+            return False
+        if not isinstance(stmt, IRCall):
+            return False
+        break_target, continue_target = self._loop_stack[-1]
+        if stmt.canonical_command == "::break":
+            target = break_target
+        elif stmt.canonical_command == "::continue":
+            target = continue_target
+        else:
+            return False
+        block.statements.append(stmt)
+        block.terminator = CFGGoto(target=target, range=stmt.range)
+        return True
+
     def _lower_if(self, stmt: IRIf, block_name: str) -> str | None:
         end_block = self._new_block("if_end")
         dispatch_block = block_name
@@ -1213,7 +1263,13 @@ class _CFGBuilder:
             range=stmt.condition_range,
         )
 
-        body_tail = self._lower_script(stmt.body, body_block)
+        # ``continue`` re-checks the loop via the step/next clause; ``break``
+        # exits to the loop-exit block.
+        self._loop_stack.append((end_block, step_block))
+        try:
+            body_tail = self._lower_script(stmt.body, body_block)
+        finally:
+            self._loop_stack.pop()
         if body_tail is not None:
             self._ensure_goto(body_tail, step_block, stmt.body_range)
 
@@ -1282,7 +1338,13 @@ class _CFGBuilder:
             range=stmt.range,
         )
 
-        body_tail = self._lower_script(stmt.body, body_block)
+        # ``continue`` starts the next iteration via the header; ``break``
+        # exits to the loop-exit block.
+        self._loop_stack.append((end_block, header_block))
+        try:
+            body_tail = self._lower_script(stmt.body, body_block)
+        finally:
+            self._loop_stack.pop()
         if body_tail is not None:
             self._ensure_goto(body_tail, header_block, stmt.body_range)
 
@@ -1308,7 +1370,13 @@ class _CFGBuilder:
             range=stmt.condition_range,
         )
 
-        body_tail = self._lower_script(stmt.body, body_block)
+        # ``continue`` re-checks the condition via the header; ``break`` exits
+        # to the loop-exit block.
+        self._loop_stack.append((end_block, header_block))
+        try:
+            body_tail = self._lower_script(stmt.body, body_block)
+        finally:
+            self._loop_stack.pop()
         if body_tail is not None:
             self._ensure_goto(body_tail, header_block, stmt.body_range)
 

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -203,6 +203,80 @@ def _switch_completes_normally(stmt: IRSwitch) -> bool:
     return _flow_facts_stmt(stmt)[1]
 
 
+# --- Guaranteed-iteration loops ----------------------------------------------
+#
+# A loop whose body provably runs at least once does not skip its body, so a
+# variable the body assigns is defined when code after the loop reads it.  The
+# usual CFG models every loop as possibly running zero times (the header's
+# exit edge), false-firing W210 on such a read.  In analysis builds we *rotate*
+# a provably-non-empty loop so the 0-iteration skip becomes a *separate* entry-
+# guard edge whose condition is statically true; SCCP marks that edge dead and
+# the dead-edge phi filter (read-before-set) then ignores the version-0 operand
+# it carried — with no synthetic def, so SCCP values are untouched.  ``break`` /
+# ``continue`` stay real CFG edges, so partial-def exits remain sound.
+
+
+def _list_literal_nonempty(text: str) -> bool:
+    """True when *text* is a static, non-empty Tcl list literal.
+
+    Conservative: any ``$`` / ``[`` (a possible substitution) disqualifies it,
+    so a runtime-computed list is never claimed non-empty.  ``foreach`` stores a
+    braced list with its outer braces stripped (``{1 2 3}`` → ``1 2 3``), so a
+    literal splits directly.
+    """
+    if not text or "$" in text or "[" in text:
+        return False
+    from compiler.tcl_expr_eval import _split_tcl_list
+
+    try:
+        return len(_split_tcl_list(text)) >= 1
+    except Exception:
+        return False
+
+
+def _foreach_runs_at_least_once(stmt: IRForeach) -> bool:
+    """True when a ``foreach``/``lmap`` provably iterates ≥1 time.
+
+    ``foreach`` runs ``max`` over its iterator groups, so *any* non-empty
+    iterator list guarantees at least one iteration (shorter lists just pad
+    their loop vars with ``""``).
+    """
+    return any(_list_literal_nonempty(list_arg) for _vars, list_arg in stmt.iterators)
+
+
+def _coerce_scalar(text: str) -> int | float | str:
+    """Coerce a literal assignment value to int/float when possible (else str)."""
+    try:
+        return int(text)
+    except ValueError:
+        try:
+            return float(text)
+        except ValueError:
+            return text
+
+
+def _for_runs_at_least_once(stmt: IRFor) -> bool:
+    """True when a ``for`` loop's condition is statically true on entry.
+
+    Evaluates the condition against the constant bindings the init clause
+    establishes (``for {set i 0} {$i < 3} …`` → ``i = 0`` → ``0 < 3`` is true),
+    which proves the first iteration always runs.  Conservative: a non-constant
+    init binding, or a condition referencing a variable the init does not bind
+    to a constant (or a command-substitution condition), leaves the evaluation
+    unknown (``None``) → not guaranteed.
+    """
+    from .tcl_expr_eval import eval_tcl_expr
+
+    env: dict[str, int | float | str] = {}
+    for s in stmt.init.statements:
+        if isinstance(s, IRAssignConst):
+            name = _normalise_var_name(s.name)
+            if name:
+                env[name] = _coerce_scalar(s.value)
+    val = eval_tcl_expr(stmt.condition, env)
+    return val is not None and bool(val)
+
+
 def _static_var_write_defs(seg: SegmentedCommand) -> list[str]:
     """Literal ``ArgRole.VAR_WRITE`` def names from one segmented command.
 
@@ -1441,7 +1515,35 @@ class _CFGBuilder:
                 IRCall(range=stmt.next_range, command="<empty_clause>")
             )
         step_tail = self._lower_script(stmt.next, step_block)
-        if step_tail is not None:
+
+        # Analysis builds rotate a for whose condition is statically true on
+        # entry: the step re-checks the condition (back-edge) instead of
+        # looping back to the header, so the header is reached only from init.
+        # Its condition then folds on the entry values and SCCP prunes the
+        # zero-iteration header→end edge, so a body-assigned variable read
+        # after the loop is no longer a false read-before-set.  The loop_nodes
+        # mapping and the init block's exit versions are unchanged, so the
+        # optimiser's IR-level static-for summary is unaffected.
+        rotate = self._faithful_exceptions and _for_runs_at_least_once(stmt)
+        if rotate and step_tail is not None:
+            # The back-edge re-check carries the *real* condition (and source
+            # range) so the optimiser still sees the loop test.  The header is
+            # demoted to a synthetic always-true entry guard (range=None, so it
+            # is never source-rewritten) — we already proved the condition is
+            # true on entry, so SCCP prunes the zero-iteration header→end edge.
+            self._block(header_block).terminator = CFGBranch(
+                condition=ExprLiteral(text="1", start=0, end=0),
+                true_target=body_block,
+                false_target=end_block,
+                range=None,
+            )
+            self._block(step_tail).terminator = CFGBranch(
+                condition=stmt.condition,
+                true_target=body_block,
+                false_target=end_block,
+                range=stmt.condition_range,
+            )
+        elif step_tail is not None:
             self._ensure_goto(step_tail, header_block, stmt.next_range)
 
         self._loop_nodes[end_block] = (block_name, stmt)
@@ -1488,6 +1590,46 @@ class _CFGBuilder:
             defs=tuple(all_vars),
             foreach_groups=tuple(group_sizes),
         )
+
+        # Analysis builds rotate a provably-non-empty foreach so the
+        # 0-iteration skip is a *separate*, statically-true entry-guard edge
+        # (SCCP prunes it).  The var-def + body run at least once before the
+        # back-edge re-check, so a body-assigned variable read after the loop
+        # is no longer a false read-before-set, while SCCP values stay intact.
+        if self._faithful_exceptions and _foreach_runs_at_least_once(stmt):
+            latch_block = self._new_block("foreach_latch")
+            # Entry guard: the list is a non-empty literal, so the body always
+            # runs at least once — a statically-true condition SCCP folds, so
+            # the entry→end (zero-iteration) edge is dead.  ``range=None`` keeps
+            # the optimiser's constant-branch source rewriter (which only acts
+            # on branches with a range) from touching this synthetic guard.
+            self._block(header_block).terminator = CFGBranch(
+                condition=ExprLiteral(text="1", start=0, end=0),
+                true_target=body_block,
+                false_target=end_block,
+                range=None,
+            )
+            # The iteration variables are (re)bound at the top of every body
+            # execution — model the def node there so a post-loop read of a
+            # loop variable also resolves.
+            self._block(body_block).statements.append(var_def)
+            # ``continue`` re-checks via the latch; ``break`` exits the loop.
+            self._loop_stack.append((end_block, latch_block))
+            try:
+                body_tail = self._lower_script(stmt.body, body_block)
+            finally:
+                self._loop_stack.pop()
+            if body_tail is not None:
+                self._ensure_goto(body_tail, latch_block, stmt.body_range)
+            # Back-edge re-check: another element → body, else → exit.
+            self._block(latch_block).terminator = CFGBranch(
+                condition=ExprRaw(text="<foreach_has_next>"),
+                true_target=body_block,
+                false_target=end_block,
+                range=stmt.range,
+            )
+            return end_block
+
         self._block(header_block).statements.append(var_def)
 
         # Opaque condition: the loop runs "for each element" — we model

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -81,126 +81,158 @@ _TERMINATING_COMMANDS = _terminating_commands()
 # --- Definite-assignment ("flow facts") over un-lowered IR scripts ------------
 #
 # Shared by the CFG builder (to promote an opaque ``switch`` whose every arm
-# exits to a terminator) and by SSA (to recover the def set an opaque switch
+# exits the *procedure*) and by SSA (to recover the def set an opaque switch
 # *definitely* establishes).  Lives here, at the control-flow layer, so both
-# consumers agree on one definition of "cannot complete normally" — SSA imports
-# these rather than re-deriving them.
+# consumers agree on one model.
+#
+# Each statement/script is classified by how it leaves: it can complete NORMALly
+# (fall through to the next statement), exit the procedure (PROC_EXIT —
+# ``return``/``error``/``throw``/``exit``/``tailcall``), or jump within an
+# enclosing loop (LOOP_JUMP — ``break``/``continue``).  The distinction matters
+# for an *opaque* switch (whose arm bodies are not lowered into the CFG, so
+# their loop-jump edges are invisible): a PROC_EXIT arm reaches no later code at
+# all, but a LOOP_JUMP arm still reaches the code after the enclosing loop
+# *without* the other arms' definitions — so it must NOT be treated as vacuous
+# when recovering the switch's defs, and an all-LOOP_JUMP switch is NOT a
+# procedure terminator.
+_COMPLETE_NORMAL = 0  # falls through to the next statement
+_COMPLETE_LOOP_JUMP = 1  # break / continue — leaves to an enclosing-loop target
+_COMPLETE_PROC_EXIT = 2  # return / error / throw / exit / tailcall
 
 
-def _flow_facts_stmt(stmt: IRStatement) -> tuple[set[str], bool]:
-    """``(must-defines, can-complete-normally)`` for a single statement.
+def _flow_facts_stmt(stmt: IRStatement) -> tuple[set[str], int]:
+    """``(must-defines, completion)`` for a single statement.
 
-    * assignments (``set``/``incr``/``expr``-assign) contribute their target
-      and complete;
-    * a plain ``IRCall`` contributes its synthetic ``defs`` and completes —
-      *except* a non-returning one (``error``/``throw``/``exit`` via the
-      ``terminates_block`` trait, ``break``/``continue``, or ``tailcall``),
-      which cannot complete; ``IRReturn`` and a ``return -code``/expansion
-      ``IRBarrier`` likewise cannot complete;
+    ``completion`` is one of ``_COMPLETE_NORMAL`` / ``_COMPLETE_LOOP_JUMP`` /
+    ``_COMPLETE_PROC_EXIT``.
+
+    * assignments (``set``/``incr``/``expr``-assign) contribute their target and
+      complete normally; a plain ``IRCall`` contributes its synthetic ``defs``
+      and completes normally — *except* ``error``/``throw``/``exit`` (the
+      ``terminates_block`` trait) and ``tailcall``, which PROC_EXIT, and
+      ``break``/``continue``, which LOOP_JUMP.  ``IRReturn`` and a
+      ``return -code``/expansion ``IRBarrier`` PROC_EXIT;
     * ``IRBlock`` / ``IRUpFrame`` bodies always run, so recurse;
-    * an ``IRIf`` *with* an else, or an ``IRSwitch`` *with* a default, takes the
-      intersection over its completing branches (and is non-completing only when
-      every branch is); an else-less ``IRIf`` / default-less ``IRSwitch`` has a
-      fall-through path, so it completes assigning nothing for certain;
-    * loops (``IRFor``/``IRWhile``/``IRForeach``), ``IRCatch``/``IRTry`` and
-      everything else may not execute / always complete, so they contribute no
+    * an ``IRIf`` *with* an else, or an ``IRSwitch`` *with* a default, combine
+      their branches via :func:`_intersect_completing`; an else-less ``IRIf`` /
+      default-less ``IRSwitch`` has a fall-through path, so it completes normally
+      assigning nothing for certain;
+    * loops, ``IRCatch``/``IRTry`` and everything else may not execute / always
+      complete (``catch`` even swallows ``break``), so they contribute no
       must-define and complete normally.
     """
     if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
         name = _normalise_var_name(stmt.name)
-        return ({name} if name else set()), True
+        return ({name} if name else set()), _COMPLETE_NORMAL
     if isinstance(stmt, IRReturn):
-        return set(), False
+        return set(), _COMPLETE_PROC_EXIT
     if isinstance(stmt, IRBarrier):
         if stmt.reason in ("return with options", "return with expansion"):
-            return set(), False
-        return set(), True
+            return set(), _COMPLETE_PROC_EXIT
+        return set(), _COMPLETE_NORMAL
     if isinstance(stmt, IRCall):
         canon = stmt.canonical_command.lstrip(":") if stmt.canonical_command else ""
+        if canon in ("break", "continue"):
+            # A loop jump leaves to the enclosing loop's target — it still
+            # reaches the code after that loop, just without later defs.
+            return set(stmt.defs), _COMPLETE_LOOP_JUMP
         # ``tailcall`` always exits the proc (``TclNRTailcallObjCmd`` returns
-        # TCL_RETURN for any arg count), so it cannot complete normally.
-        non_returning = canon in _TERMINATING_COMMANDS or canon in ("break", "continue", "tailcall")
-        return set(stmt.defs), not non_returning
+        # TCL_RETURN for any arg count).
+        if canon in _TERMINATING_COMMANDS or canon == "tailcall":
+            return set(stmt.defs), _COMPLETE_PROC_EXIT
+        return set(stmt.defs), _COMPLETE_NORMAL
     if isinstance(stmt, (IRBlock, IRUpFrame)):
         return _flow_facts_script(stmt.body)
     if isinstance(stmt, IRIf):
         if stmt.else_body is None:
-            return set(), True
+            return set(), _COMPLETE_NORMAL
         bodies = [clause.body for clause in stmt.clauses]
         bodies.append(stmt.else_body)
         return _intersect_completing(bodies)
     if isinstance(stmt, IRSwitch):
         if stmt.default_body is None:
-            return set(), True
+            return set(), _COMPLETE_NORMAL
         bodies = [stmt.default_body]
         bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
         return _intersect_completing(bodies)
-    return set(), True
+    return set(), _COMPLETE_NORMAL
 
 
-def _flow_facts_script(script: IRScript) -> tuple[set[str], bool]:
-    """``(vars definitely assigned at normal completion, can-complete-normally)``.
+def _flow_facts_script(script: IRScript) -> tuple[set[str], int]:
+    """``(vars definitely assigned, completion)`` for an un-lowered IR script.
 
-    Sound definite-assignment over an un-lowered IR script: walk the statements
-    in order accumulating must-defines; the first statement that cannot complete
-    normally makes everything after it dead and the whole script non-completing.
-    Only names guaranteed to be assigned are returned, so it never over-claims
-    (which would hide a real read-before-set).  Mirrors
-    ``definitely_assigned_in_script`` in the Rust oracle (``ssa.rs``).
+    Walk statements in order accumulating must-defines; the first statement that
+    does not complete normally makes the rest dead and gives the script that
+    statement's completion (PROC_EXIT or LOOP_JUMP), with the must-defines being
+    those accumulated up to (and including) it.  Only names guaranteed to be
+    assigned are returned, so it never over-claims.
     """
     assigned: set[str] = set()
     for stmt in script.statements:
-        defs, completes = _flow_facts_stmt(stmt)
+        defs, completion = _flow_facts_stmt(stmt)
         assigned |= defs
-        if not completes:
-            return assigned, False
-    return assigned, True
+        if completion != _COMPLETE_NORMAL:
+            return assigned, completion
+    return assigned, _COMPLETE_NORMAL
 
 
-def _intersect_completing(bodies: list[IRScript]) -> tuple[set[str], bool]:
-    """``(must-defines over the branches that can complete, any-completes)``.
+def _intersect_completing(bodies: list[IRScript]) -> tuple[set[str], int]:
+    """Combine branch bodies into ``(must-defines, completion)``.
 
-    The intersection skips any branch that cannot complete normally: such a
-    branch never reaches the control-flow merge, so by the standard
-    definite-assignment rule it vacuously defines everything (⊤, the identity
-    of intersection).  ``any-completes`` is False only when *every* branch is
-    non-completing — then the merge itself is unreachable.
+    A PROC_EXIT branch reaches no code after the construct, so it is vacuous
+    (⊤) and excluded from the must-define intersection.  A NORMAL or LOOP_JUMP
+    branch *does* reach later code (the fall-through successor, or — for a
+    loop jump — the code after the enclosing loop), so its must-defines (those
+    established before it leaves) ARE intersected: this keeps the result sound
+    when a ``break``/``continue`` arm escapes an opaque switch without the other
+    arms' defs.  The combined completion is NORMAL if any branch falls through,
+    else LOOP_JUMP if any jumps, else PROC_EXIT (every branch exits the proc).
     """
     common: set[str] | None = None
-    completes_any = False
+    any_normal = False
+    any_loop_jump = False
     for body in bodies:
-        assigned, completes = _flow_facts_script(body)
-        if not completes:
+        assigned, completion = _flow_facts_script(body)
+        if completion == _COMPLETE_PROC_EXIT:
             continue
-        completes_any = True
+        if completion == _COMPLETE_NORMAL:
+            any_normal = True
+        else:
+            any_loop_jump = True
         common = set(assigned) if common is None else (common & assigned)
-    return (common or set()), completes_any
+    if any_normal:
+        combined = _COMPLETE_NORMAL
+    elif any_loop_jump:
+        combined = _COMPLETE_LOOP_JUMP
+    else:
+        combined = _COMPLETE_PROC_EXIT
+    return (common or set()), combined
 
 
 def _switch_must_defines(stmt: IRSwitch) -> set[str]:
-    """Variables an opaque ``switch`` assigns on *every* reaching path.
+    """Variables an opaque ``switch`` assigns on *every* non-proc-exit path.
 
     Empty unless the switch has a ``default`` arm (otherwise an unmatched
-    subject falls through assigning nothing).  With a default, the result is
-    the intersection of the must-define sets of the default body and of every
-    arm that has a body — a fall-through arm with no body delegates to a later
-    arm's body, which is already counted, so it contributes nothing on its own.
-    An arm that *cannot complete normally* (always ``return``s / ``error``s /
-    ``break``s / …) never reaches the code after the switch, so it is excluded
-    from the intersection.  Mirrors the exhaustive-switch rule in the Rust
-    oracle (``ssa.rs``).
+    subject falls through assigning nothing).  Intersection over the default and
+    every arm-with-a-body, excluding only arms that exit the procedure (which
+    reach no later code).  A ``break``/``continue`` arm is *kept* (with the defs
+    it makes before jumping), because it still reaches the code after the
+    enclosing loop — so an arm that breaks without assigning ``y`` correctly
+    drops ``y`` from the set rather than letting it be claimed defined.
     """
     return _flow_facts_stmt(stmt)[0]
 
 
-def _switch_completes_normally(stmt: IRSwitch) -> bool:
-    """Whether an opaque ``switch`` can reach the code after it.
+def _switch_proc_exits(stmt: IRSwitch) -> bool:
+    """Whether an opaque ``switch`` exits the *procedure* on every path.
 
-    False only when it has a ``default`` *and* every arm-with-a-body plus the
-    default cannot complete normally — then no path falls through, so the
-    switch is itself a terminator.
+    True only when it has a ``default`` *and* every arm-with-a-body plus the
+    default exits the proc (``return``/``error``/``exit``/``tailcall``, possibly
+    nested).  A switch whose arms ``break``/``continue`` is NOT a proc
+    terminator — it jumps to an enclosing-loop target — so it must not be
+    promoted to a ``CFGReturn``.
     """
-    return _flow_facts_stmt(stmt)[1]
+    return _flow_facts_stmt(stmt)[1] == _COMPLETE_PROC_EXIT
 
 
 # --- Guaranteed-iteration loops ----------------------------------------------
@@ -255,15 +287,32 @@ def _coerce_scalar(text: str) -> int | float | str:
             return text
 
 
+def _init_written_names(stmt: IRStatement) -> set[str] | None:
+    """Names a non-``IRAssignConst`` init statement may write.
+
+    ``None`` means "can't tell" — the caller then drops *all* constant bindings
+    (a write it can't characterise might clobber any of them).
+    """
+    if isinstance(stmt, (IRAssignValue, IRAssignExpr, IRIncr)):
+        name = _normalise_var_name(stmt.name)
+        return {name} if name else set()
+    if isinstance(stmt, IRCall):
+        return set(stmt.defs)
+    return None
+
+
 def _for_runs_at_least_once(stmt: IRFor) -> bool:
     """True when a ``for`` loop's condition is statically true on entry.
 
     Evaluates the condition against the constant bindings the init clause
     establishes (``for {set i 0} {$i < 3} …`` → ``i = 0`` → ``0 < 3`` is true),
-    which proves the first iteration always runs.  Conservative: a non-constant
-    init binding, or a condition referencing a variable the init does not bind
-    to a constant (or a command-substitution condition), leaves the evaluation
-    unknown (``None``) → not guaranteed.
+    which proves the first iteration always runs.  Init statements are processed
+    in order: an ``IRAssignConst`` (re)binds a constant, but any *other* write
+    *invalidates* that variable's binding — so ``for {set i 0; set i $n} …`` and
+    ``for {set i 0; incr i 5} …`` leave ``i`` unknown rather than stale-constant
+    ``0`` (both may iterate zero times).  Conservative: a condition referencing
+    an unbound variable (or a command-substitution condition) evaluates to
+    ``None`` → not guaranteed.
     """
     from .tcl_expr_eval import eval_tcl_expr
 
@@ -273,6 +322,13 @@ def _for_runs_at_least_once(stmt: IRFor) -> bool:
             name = _normalise_var_name(s.name)
             if name:
                 env[name] = _coerce_scalar(s.value)
+            continue
+        written = _init_written_names(s)
+        if written is None:
+            env.clear()  # unknown write — every prior constant is now suspect
+        else:
+            for name in written:
+                env.pop(name, None)
     val = eval_tcl_expr(stmt.condition, env)
     return val is not None and bool(val)
 
@@ -1367,24 +1423,26 @@ class _CFGBuilder:
         return end_block
 
     def _maybe_terminate_opaque_switch(self, stmt: IRSwitch, block_name: str) -> None:
-        """Terminate *block_name* when an opaque ``switch`` can't fall through.
+        """Terminate *block_name* when an opaque ``switch`` exits the procedure.
 
         An opaque switch is kept as a single ``IRSwitch`` statement that
         normally falls through to the next statement.  But when it has a
-        ``default`` arm and *every* reachable arm body (default + each arm with
-        a body) cannot complete normally — e.g. every arm ``return``s /
-        ``error``s / ``tailcall``s — no path reaches the code after the switch,
-        so the switch is itself a terminator.  Promote the block to a
-        ``CFGReturn`` so the following statements are routed to the orphan
-        unreachable block (exactly like a ``return``/``tailcall``), instead of
-        being falsely analysed as reachable.
+        ``default`` arm and *every* reachable arm body exits the *procedure*
+        (``return`` / ``error`` / ``exit`` / ``tailcall``), no path reaches the
+        code after the switch, so the switch is itself a procedure terminator —
+        promote the block to a ``CFGReturn`` so the following statements are
+        routed to the orphan unreachable block, exactly like a ``return``.
+
+        Only proc-exit arms qualify: a switch whose arms ``break``/``continue``
+        jumps to an enclosing-loop target (reaching the code after the loop),
+        NOT the procedure exit, so it must not be promoted to a ``CFGReturn``.
 
         Analysis builds only (``faithful_exceptions``); codegen leaves the
         fall-through edge so the opaque-switch ``invokeStk`` bytecode and CFG
-        shape are unchanged.  Conservative: only fires when provably
-        non-completing, so it never hides a real read-before-set.
+        shape are unchanged.  Conservative: only fires when the switch provably
+        exits the proc on every path, so it never hides a real read-before-set.
         """
-        if self._faithful_exceptions and not _switch_completes_normally(stmt):
+        if self._faithful_exceptions and _switch_proc_exits(stmt):
             self._block(block_name).terminator = CFGReturn(
                 value=None, range=stmt.range, expr=None, braced=False
             )

--- a/compiler/core_analyses.py
+++ b/compiler/core_analyses.py
@@ -2810,6 +2810,7 @@ def _read_before_set(
     ssa: SSAFunction,
     *,
     executable_blocks: set[str] | None = None,
+    executable_edges: set[tuple[str, str]] | None = None,
     params: frozenset[str] = frozenset(),
     values: dict[SSAValueKey, LatticeValue] | None = None,
 ) -> tuple[ReadBeforeSet, ...]:
@@ -2817,6 +2818,13 @@ def _read_before_set(
 
     A variable use with SSA version 0 means no prior definition was found
     during SSA renaming — the variable is read before set on that path.
+
+    *executable_edges* (the SCCP-reachable CFG edges) lets the phi-undef
+    closure ignore operands arriving on a dead predecessor edge: a phi merges
+    one value per incoming edge, so a version-0 operand on a never-taken edge
+    (e.g. the ``cond → exit`` edge of ``while 1``, which a ``break`` makes the
+    loop's only real exit) can never actually be read.  Without this, such an
+    operand false-fires W210 even though every live path defines the variable.
     """
     considered = executable_blocks if executable_blocks is not None else set(cfg.blocks)
     skip = _IMPLICIT_VARS | params
@@ -3145,6 +3153,13 @@ def _read_before_set(
             bn_def, phi = entry
             for pred, incoming_ver in phi.incoming.items():
                 if pred not in considered:
+                    continue
+                # A phi has one operand per predecessor *edge*; an operand on a
+                # non-executable edge (SCCP proved the edge dead — e.g. the
+                # ``cond → exit`` edge of ``while 1``) is never actually read,
+                # so its version-0 origin must not count as a possible undef.
+                # Mirrors the edge filter in ``_collect_used_names``.
+                if executable_edges is not None and (pred, bn_def) not in executable_edges:
                     continue
                 # A dominating existence guard (``if {[info exists v]}``
                 # or its negated form ``if {![info exists v]} {set v X}``)
@@ -3986,6 +4001,7 @@ def analyse_function(
         cfg,
         ssa,
         executable_blocks=executable_blocks,
+        executable_edges=executable_edges,
         params=params,
         values=values,
     )

--- a/compiler/ssa.py
+++ b/compiler/ssa.py
@@ -33,6 +33,7 @@ from compiler.registry.runtime import (
 from shared.naming import normalise_var_name as _normalise_var_name
 
 from .cfg import (
+    _TERMINATING_COMMANDS,
     CFGBranch,
     CFGFunction,
     CFGGoto,
@@ -157,69 +158,113 @@ def _defs(stmt: IRStatement) -> tuple[str, ...]:
 
 
 def _switch_must_defines(stmt: IRSwitch) -> set[str]:
-    """Variables an opaque ``switch`` assigns on *every* execution path.
+    """Variables an opaque ``switch`` assigns on *every* reaching path.
 
     Empty unless the switch has a ``default`` arm (otherwise an unmatched
     subject falls through assigning nothing).  With a default, the result is
     the intersection of the must-define sets of the default body and of every
     arm that has a body — a fall-through arm with no body delegates to a later
     arm's body, which is already counted, so it contributes nothing on its own.
-    Mirrors the exhaustive-switch rule in the Rust oracle (``ssa.rs``).
+    An arm that *cannot complete normally* (always ``return``s / ``error``s /
+    ``break``s / …) never reaches the code after the switch, so it is excluded
+    from the intersection.  Mirrors the exhaustive-switch rule in the Rust
+    oracle (``ssa.rs``).
     """
     if stmt.default_body is None:
         return set()
-    must = _definitely_assigned_in_script(stmt.default_body)
-    for arm in stmt.arms:
-        if arm.body is not None:
-            must &= _definitely_assigned_in_script(arm.body)
-        if not must:
-            break
-    return must
+    bodies = [stmt.default_body]
+    bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
+    return _intersect_completing(bodies)[0]
 
 
-def _definitely_assigned_in_script(script: IRScript) -> set[str]:
-    """Variables assigned on *every* path through *script* (must-define).
+def _intersect_completing(bodies: list[IRScript]) -> tuple[set[str], bool]:
+    """``(must-defines over the branches that can complete, any-completes)``.
 
-    Sound all-paths analysis — only names guaranteed to be assigned no matter
-    which branch runs are returned, so it never over-claims (which would hide a
-    real read-before-set).  Mirrors ``definitely_assigned_in_script`` in the
-    Rust oracle (``ssa.rs``):
+    The intersection skips any branch that cannot complete normally: such a
+    branch never reaches the control-flow merge, so by the standard
+    definite-assignment rule it vacuously defines everything (⊤, the identity
+    of intersection).  ``any-completes`` is False only when *every* branch is
+    non-completing — then the merge itself is unreachable.
+    """
+    common: set[str] | None = None
+    completes_any = False
+    for body in bodies:
+        assigned, completes = _flow_facts_script(body)
+        if not completes:
+            continue
+        completes_any = True
+        common = set(assigned) if common is None else (common & assigned)
+    return (common or set()), completes_any
 
-    * top-level assignments (``set``/``incr``/``expr``-assign) contribute their
-      target name; a top-level ``IRCall`` contributes its synthetic ``defs``;
-    * ``IRBlock`` / ``IRUpFrame`` bodies always run, so recurse into them;
-    * an ``IRIf`` *with* an else contributes the intersection of every clause
-      body's set and the else body's set (assigned on all branches); an
-      else-less ``IRIf`` contributes nothing;
-    * a nested ``IRSwitch`` with a default applies the same exhaustive rule
-      recursively (via :func:`_switch_must_defines`);
-    * ``IRFor`` / ``IRWhile`` / ``IRForeach`` / ``IRCatch`` / ``IRTry`` and a
-      default-less ``IRSwitch`` may not execute (or may throw mid-body), so
-      they contribute nothing.
+
+def _flow_facts_script(script: IRScript) -> tuple[set[str], bool]:
+    """``(vars definitely assigned at normal completion, can-complete-normally)``.
+
+    Sound definite-assignment over an un-lowered IR script: walk the statements
+    in order accumulating must-defines; the first statement that cannot complete
+    normally makes everything after it dead and the whole script non-completing.
+    Only names guaranteed to be assigned are returned, so it never over-claims
+    (which would hide a real read-before-set).  Mirrors
+    ``definitely_assigned_in_script`` in the Rust oracle (``ssa.rs``).
     """
     assigned: set[str] = set()
     for stmt in script.statements:
-        if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
-            name = _normalise_var_name(stmt.name)
-            if name:
-                assigned.add(name)
-        elif isinstance(stmt, IRCall) and stmt.defs:
-            assigned.update(stmt.defs)
-        elif isinstance(stmt, (IRBlock, IRUpFrame)):
-            assigned |= _definitely_assigned_in_script(stmt.body)
-        elif isinstance(stmt, IRIf):
-            if stmt.else_body is not None:
-                branch_sets = [
-                    _definitely_assigned_in_script(clause.body) for clause in stmt.clauses
-                ]
-                branch_sets.append(_definitely_assigned_in_script(stmt.else_body))
-                common = branch_sets[0].copy()
-                for s in branch_sets[1:]:
-                    common &= s
-                assigned |= common
-        elif isinstance(stmt, IRSwitch):
-            assigned |= _switch_must_defines(stmt)
-    return assigned
+        defs, completes = _flow_facts_stmt(stmt)
+        assigned |= defs
+        if not completes:
+            return assigned, False
+    return assigned, True
+
+
+def _flow_facts_stmt(stmt: IRStatement) -> tuple[set[str], bool]:
+    """``(must-defines, can-complete-normally)`` for a single statement.
+
+    * assignments (``set``/``incr``/``expr``-assign) contribute their target
+      and complete;
+    * a plain ``IRCall`` contributes its synthetic ``defs`` and completes —
+      *except* a non-returning one (``error``/``throw``/``exit`` via the
+      ``terminates_block`` trait, ``break``/``continue``, or ``tailcall``),
+      which cannot complete; ``IRReturn`` and a ``return -code``/expansion
+      ``IRBarrier`` likewise cannot complete;
+    * ``IRBlock`` / ``IRUpFrame`` bodies always run, so recurse;
+    * an ``IRIf`` *with* an else, or an ``IRSwitch`` *with* a default, takes the
+      intersection over its completing branches (and is non-completing only when
+      every branch is); an else-less ``IRIf`` / default-less ``IRSwitch`` has a
+      fall-through path, so it completes assigning nothing for certain;
+    * loops (``IRFor``/``IRWhile``/``IRForeach``), ``IRCatch``/``IRTry`` and
+      everything else may not execute / always complete, so they contribute no
+      must-define and complete normally.
+    """
+    if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
+        name = _normalise_var_name(stmt.name)
+        return ({name} if name else set()), True
+    if isinstance(stmt, IRReturn):
+        return set(), False
+    if isinstance(stmt, IRBarrier):
+        if stmt.reason in ("return with options", "return with expansion"):
+            return set(), False
+        return set(), True
+    if isinstance(stmt, IRCall):
+        canon = stmt.canonical_command.lstrip(":") if stmt.canonical_command else ""
+        # ``tailcall`` always exits the proc (``TclNRTailcallObjCmd`` returns
+        # TCL_RETURN for any arg count), so it cannot complete normally.
+        non_returning = canon in _TERMINATING_COMMANDS or canon in ("break", "continue", "tailcall")
+        return set(stmt.defs), not non_returning
+    if isinstance(stmt, (IRBlock, IRUpFrame)):
+        return _flow_facts_script(stmt.body)
+    if isinstance(stmt, IRIf):
+        if stmt.else_body is None:
+            return set(), True
+        bodies = [clause.body for clause in stmt.clauses]
+        bodies.append(stmt.else_body)
+        return _intersect_completing(bodies)
+    if isinstance(stmt, IRSwitch):
+        if stmt.default_body is None:
+            return set(), True
+        bodies = [stmt.default_body]
+        bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
+        return _intersect_completing(bodies)
+    return set(), True
 
 
 def _vars_in_expr(expr: ExprNode) -> set[str]:

--- a/compiler/ssa.py
+++ b/compiler/ssa.py
@@ -61,6 +61,7 @@ from .ir import (
     IRStatement,
     IRSwitch,
     IRTry,
+    IRUpFrame,
     IRWhile,
 )
 from .var_refs import VarReferenceScanner, VarScanOptions, command_sub_write_names
@@ -140,7 +141,85 @@ def _defs(stmt: IRStatement) -> tuple[str, ...]:
         is_namespace_eval = len(sa) >= 3 and sa[0] == "eval"
         if not is_namespace_eval:
             return tuple(_defs_from_ir_script(stmt.body))
+    if isinstance(stmt, IRSwitch):
+        # An opaque (glob/regexp/fall-through) switch is kept as one IRSwitch
+        # statement (cfg.py keeps its shared-body topology un-lowered), so its
+        # arm-body assignments never reach the CFG as ordinary defs.  Recover
+        # the variables it *definitely* defines: a variable is switch-defined
+        # only when EVERY execution path assigns it — there must be a
+        # ``default`` arm AND the variable must be must-defined in the default
+        # body and in every arm that has a body.  This is sound (never
+        # over-claims), so a variable assigned in the arms and read afterwards
+        # is no longer falsely flagged read-before-set (W210), while a switch
+        # that might leave it unset still reports the genuine read-before-set.
+        return tuple(sorted(_switch_must_defines(stmt)))
     return ()
+
+
+def _switch_must_defines(stmt: IRSwitch) -> set[str]:
+    """Variables an opaque ``switch`` assigns on *every* execution path.
+
+    Empty unless the switch has a ``default`` arm (otherwise an unmatched
+    subject falls through assigning nothing).  With a default, the result is
+    the intersection of the must-define sets of the default body and of every
+    arm that has a body — a fall-through arm with no body delegates to a later
+    arm's body, which is already counted, so it contributes nothing on its own.
+    Mirrors the exhaustive-switch rule in the Rust oracle (``ssa.rs``).
+    """
+    if stmt.default_body is None:
+        return set()
+    must = _definitely_assigned_in_script(stmt.default_body)
+    for arm in stmt.arms:
+        if arm.body is not None:
+            must &= _definitely_assigned_in_script(arm.body)
+        if not must:
+            break
+    return must
+
+
+def _definitely_assigned_in_script(script: IRScript) -> set[str]:
+    """Variables assigned on *every* path through *script* (must-define).
+
+    Sound all-paths analysis — only names guaranteed to be assigned no matter
+    which branch runs are returned, so it never over-claims (which would hide a
+    real read-before-set).  Mirrors ``definitely_assigned_in_script`` in the
+    Rust oracle (``ssa.rs``):
+
+    * top-level assignments (``set``/``incr``/``expr``-assign) contribute their
+      target name; a top-level ``IRCall`` contributes its synthetic ``defs``;
+    * ``IRBlock`` / ``IRUpFrame`` bodies always run, so recurse into them;
+    * an ``IRIf`` *with* an else contributes the intersection of every clause
+      body's set and the else body's set (assigned on all branches); an
+      else-less ``IRIf`` contributes nothing;
+    * a nested ``IRSwitch`` with a default applies the same exhaustive rule
+      recursively (via :func:`_switch_must_defines`);
+    * ``IRFor`` / ``IRWhile`` / ``IRForeach`` / ``IRCatch`` / ``IRTry`` and a
+      default-less ``IRSwitch`` may not execute (or may throw mid-body), so
+      they contribute nothing.
+    """
+    assigned: set[str] = set()
+    for stmt in script.statements:
+        if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
+            name = _normalise_var_name(stmt.name)
+            if name:
+                assigned.add(name)
+        elif isinstance(stmt, IRCall) and stmt.defs:
+            assigned.update(stmt.defs)
+        elif isinstance(stmt, (IRBlock, IRUpFrame)):
+            assigned |= _definitely_assigned_in_script(stmt.body)
+        elif isinstance(stmt, IRIf):
+            if stmt.else_body is not None:
+                branch_sets = [
+                    _definitely_assigned_in_script(clause.body) for clause in stmt.clauses
+                ]
+                branch_sets.append(_definitely_assigned_in_script(stmt.else_body))
+                common = branch_sets[0].copy()
+                for s in branch_sets[1:]:
+                    common &= s
+                assigned |= common
+        elif isinstance(stmt, IRSwitch):
+            assigned |= _switch_must_defines(stmt)
+    return assigned
 
 
 def _vars_in_expr(expr: ExprNode) -> set[str]:
@@ -485,6 +564,12 @@ def _uses(stmt: IRStatement) -> tuple[str, ...]:
                     reads_own_def.add(name)
         case IRSwitch():
             vars_found |= _switch_reads(stmt)
+            # The subject is read before any arm runs, so a subject variable
+            # that an arm also assigns (now in ``_defs`` for an exhaustive
+            # switch) must stay live — mark it reads-own-def so the final
+            # filter doesn't drop it as a switch def.  Mirrors the Rust
+            # oracle's ``uses_of`` Switch arm.
+            reads_own_def |= _vars_in_word(stmt.subject)
         case IRReturn(value=_value, expr=_expr):
             if _value is not None:
                 vars_found |= _vars_in_word(_value)

--- a/compiler/ssa.py
+++ b/compiler/ssa.py
@@ -33,7 +33,6 @@ from compiler.registry.runtime import (
 from shared.naming import normalise_var_name as _normalise_var_name
 
 from .cfg import (
-    _TERMINATING_COMMANDS,
     CFGBranch,
     CFGFunction,
     CFGGoto,
@@ -41,6 +40,7 @@ from .cfg import (
     CFGTerminator,
     _defs_from_expr,
     _defs_from_ir_script,
+    _switch_must_defines,
 )
 from .expr_ast import ExprNode, command_texts_in_expr_node, vars_in_expr_node
 from .ir import (
@@ -62,7 +62,6 @@ from .ir import (
     IRStatement,
     IRSwitch,
     IRTry,
-    IRUpFrame,
     IRWhile,
 )
 from .var_refs import VarReferenceScanner, VarScanOptions, command_sub_write_names
@@ -155,116 +154,6 @@ def _defs(stmt: IRStatement) -> tuple[str, ...]:
         # that might leave it unset still reports the genuine read-before-set.
         return tuple(sorted(_switch_must_defines(stmt)))
     return ()
-
-
-def _switch_must_defines(stmt: IRSwitch) -> set[str]:
-    """Variables an opaque ``switch`` assigns on *every* reaching path.
-
-    Empty unless the switch has a ``default`` arm (otherwise an unmatched
-    subject falls through assigning nothing).  With a default, the result is
-    the intersection of the must-define sets of the default body and of every
-    arm that has a body — a fall-through arm with no body delegates to a later
-    arm's body, which is already counted, so it contributes nothing on its own.
-    An arm that *cannot complete normally* (always ``return``s / ``error``s /
-    ``break``s / …) never reaches the code after the switch, so it is excluded
-    from the intersection.  Mirrors the exhaustive-switch rule in the Rust
-    oracle (``ssa.rs``).
-    """
-    if stmt.default_body is None:
-        return set()
-    bodies = [stmt.default_body]
-    bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
-    return _intersect_completing(bodies)[0]
-
-
-def _intersect_completing(bodies: list[IRScript]) -> tuple[set[str], bool]:
-    """``(must-defines over the branches that can complete, any-completes)``.
-
-    The intersection skips any branch that cannot complete normally: such a
-    branch never reaches the control-flow merge, so by the standard
-    definite-assignment rule it vacuously defines everything (⊤, the identity
-    of intersection).  ``any-completes`` is False only when *every* branch is
-    non-completing — then the merge itself is unreachable.
-    """
-    common: set[str] | None = None
-    completes_any = False
-    for body in bodies:
-        assigned, completes = _flow_facts_script(body)
-        if not completes:
-            continue
-        completes_any = True
-        common = set(assigned) if common is None else (common & assigned)
-    return (common or set()), completes_any
-
-
-def _flow_facts_script(script: IRScript) -> tuple[set[str], bool]:
-    """``(vars definitely assigned at normal completion, can-complete-normally)``.
-
-    Sound definite-assignment over an un-lowered IR script: walk the statements
-    in order accumulating must-defines; the first statement that cannot complete
-    normally makes everything after it dead and the whole script non-completing.
-    Only names guaranteed to be assigned are returned, so it never over-claims
-    (which would hide a real read-before-set).  Mirrors
-    ``definitely_assigned_in_script`` in the Rust oracle (``ssa.rs``).
-    """
-    assigned: set[str] = set()
-    for stmt in script.statements:
-        defs, completes = _flow_facts_stmt(stmt)
-        assigned |= defs
-        if not completes:
-            return assigned, False
-    return assigned, True
-
-
-def _flow_facts_stmt(stmt: IRStatement) -> tuple[set[str], bool]:
-    """``(must-defines, can-complete-normally)`` for a single statement.
-
-    * assignments (``set``/``incr``/``expr``-assign) contribute their target
-      and complete;
-    * a plain ``IRCall`` contributes its synthetic ``defs`` and completes —
-      *except* a non-returning one (``error``/``throw``/``exit`` via the
-      ``terminates_block`` trait, ``break``/``continue``, or ``tailcall``),
-      which cannot complete; ``IRReturn`` and a ``return -code``/expansion
-      ``IRBarrier`` likewise cannot complete;
-    * ``IRBlock`` / ``IRUpFrame`` bodies always run, so recurse;
-    * an ``IRIf`` *with* an else, or an ``IRSwitch`` *with* a default, takes the
-      intersection over its completing branches (and is non-completing only when
-      every branch is); an else-less ``IRIf`` / default-less ``IRSwitch`` has a
-      fall-through path, so it completes assigning nothing for certain;
-    * loops (``IRFor``/``IRWhile``/``IRForeach``), ``IRCatch``/``IRTry`` and
-      everything else may not execute / always complete, so they contribute no
-      must-define and complete normally.
-    """
-    if isinstance(stmt, (IRAssignConst, IRAssignExpr, IRAssignValue, IRIncr)):
-        name = _normalise_var_name(stmt.name)
-        return ({name} if name else set()), True
-    if isinstance(stmt, IRReturn):
-        return set(), False
-    if isinstance(stmt, IRBarrier):
-        if stmt.reason in ("return with options", "return with expansion"):
-            return set(), False
-        return set(), True
-    if isinstance(stmt, IRCall):
-        canon = stmt.canonical_command.lstrip(":") if stmt.canonical_command else ""
-        # ``tailcall`` always exits the proc (``TclNRTailcallObjCmd`` returns
-        # TCL_RETURN for any arg count), so it cannot complete normally.
-        non_returning = canon in _TERMINATING_COMMANDS or canon in ("break", "continue", "tailcall")
-        return set(stmt.defs), not non_returning
-    if isinstance(stmt, (IRBlock, IRUpFrame)):
-        return _flow_facts_script(stmt.body)
-    if isinstance(stmt, IRIf):
-        if stmt.else_body is None:
-            return set(), True
-        bodies = [clause.body for clause in stmt.clauses]
-        bodies.append(stmt.else_body)
-        return _intersect_completing(bodies)
-    if isinstance(stmt, IRSwitch):
-        if stmt.default_body is None:
-            return set(), True
-        bodies = [stmt.default_body]
-        bodies.extend(arm.body for arm in stmt.arms if arm.body is not None)
-        return _intersect_completing(bodies)
-    return set(), True
 
 
 def _vars_in_expr(expr: ExprNode) -> set[str]:

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2371,6 +2371,207 @@ The `read_before_set` row pins the verdict: the `$v` read in `if_then_3` is repo
 
 ---
 
+### FP-RBS-13 — `tailcall` replaces the frame; code after it never runs
+
+- **Verdict:** FALSE POSITIVE (W210) — `tailcall` ends the proc's straight-line
+  flow, but the CFG modelled it as an ordinary fall-through call, so a variable
+  set only on the *other* branch of an `if` looked maybe-unset at a read after
+  the `if`.
+- **Status:** FIXED. Found while auditing the control-flow-terminator family
+  (sibling of the `break`/`continue` CFG-jump fix); `tailcall` was the missing
+  proc-exit terminator.
+- **Codes:** W210
+- **Corpus:** synthetic (Tcl 8.6+ `tailcall` dispatch idiom).
+
+#### Reproducer
+
+```tcl
+proc f {cond} {
+    # tailcall g replaces this frame: the `return $result` below is only
+    # reached via the else branch, where result is always set.
+    if {$cond} {
+        tailcall g
+    } else {
+        set result 1
+    }
+    return $result
+}
+```
+
+#### Per-line reasoning
+
+1. `if {$cond} { tailcall g } else { set result 1 }` — exactly one branch runs.
+2. `tailcall g` — replaces the current procedure with `g`. Control **never
+   returns** to `f`, so the `then` branch does not reach the code after the
+   `if`. The C implementation `TclNRTailcallObjCmd` (tclBasic.c) ends with
+   `return TCL_RETURN` for *any* arg count — both bare `tailcall` and
+   `tailcall command ...` exit the proc; the arg count only decides what runs
+   *after* the frame is popped.
+3. `return $result` — reachable only via the `else` branch, where `set result
+   1` ran. So `result` is **always** defined when read → no read-before-set.
+4. Pre-fix, `tailcall` was not in the `terminates_block` trait and the CFG had
+   no special handling, so the `then` block fell through to the `if` join; the
+   join's `return $result` then merged an "unset" version of `result` from the
+   `then` path → false W210.
+
+#### tclsh ground truth (9.0.3 — confirmed by execution)
+
+```
+% proc g {} { return GG }
+% f 0
+1
+% f 1
+GG
+```
+
+No `can't read "result"` error on either path. (`f 1` runs `g` after `f`'s
+frame pops; `result` is never read.) Bare `tailcall` behaves identically as a
+terminator — `proc f {} { puts before; tailcall; puts after }; f` prints only
+`before` and returns `""`.
+
+#### Compiler evidence
+
+```
+--- FP-RBS-13: tailcall with args replaces the frame — code after it never runs
+regen: python -m bench.fp_snippets --id FP-RBS-13
+function ::f
+  block entry_1
+    term Branch ExprVar(text='$cond', name='cond', start=0, end=4)
+  block if_end_2
+    term Return ${result}
+  block if_then_3
+    [0] Call cmd='tailcall'  defs={}  uses={}
+    term Return
+  block if_next_4
+    [0] AssignConst 'result' value='1'  defs={result#1}  uses={}
+    term Goto
+  block exit_5
+    term (none — fall-through exit)
+  read_before_set: (none)
+```
+
+- **`if_then_3 … term Return`** — the `tailcall` block is now terminated by a
+  CFGReturn, so it does **not** edge into `if_end_2`. The only predecessor of
+  `if_end_2` is `if_next_4` (the `else`), where `result#1` is defined.
+- **`read_before_set: (none)`** — no W210.
+
+#### Why the analyser reaches that verdict
+
+`compiler/cfg.py` `_CFGBuilder._lower_script`: in analysis builds
+(`faithful_exceptions`), an `IRCall` whose canonical command is `::tailcall`
+(or an `error`/`throw`/`exit` from the `terminates_block` trait) promotes the
+block to a `CFGReturn` terminator, so post-`tailcall` statements are routed to
+the orphan unreachable block exactly like `return`. Codegen builds
+(`faithful_exceptions=False`) leave the call untouched, so bytecode is
+unchanged. `tailcall` is not catchable, so it is not added to `_throw_blocks`.
+
+#### Tests
+
+- `tests/test_fp_rbs.py::test_FP_RBS_13_tailcall_with_args_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_13_bare_tailcall_silent` (FP — bare
+  `tailcall` is also a terminator, per `TclNRTailcallObjCmd`)
+- `tests/test_fp_rbs.py::test_FP_RBS_13_non_terminating_branch_still_fires`
+  (TP control — replacing `tailcall` with a normal command restores the W210,
+  proving the suppression is specific to the terminator, not the `if`/`return`
+  shape)
+
+---
+
+### FP-RBS-14 — opaque-switch arm that can't complete normally is excluded from must-define
+
+- **Verdict:** FALSE POSITIVE (W210) — an opaque `switch`'s must-define set was
+  a plain intersection over arm bodies, so an arm that always `return`s /
+  `error`s (and therefore never reaches the code after the `switch`) wrongly
+  dropped a variable that every *reaching* arm assigns.
+- **Status:** FIXED. Refines FP-RBS (opaque-switch arm-def recovery) with the
+  standard definite-assignment rule: a branch that cannot complete normally
+  contributes ⊤ (vacuously defines everything) at the merge.
+- **Codes:** W210
+- **Corpus:** synthetic (dispatch `switch` with an early-return guard arm).
+
+#### Reproducer
+
+```tcl
+proc f {x} {
+    # the a* arm returns, so it never reaches `puts $y`; the only path that
+    # does (default) sets y -> y is definitely defined.
+    switch -glob $x {
+        a* { return 0 }
+        default { set y 2 }
+    }
+    puts $y
+}
+```
+
+#### Per-line reasoning
+
+1. `switch -glob $x { … }` — a glob switch stays *opaque* (one `IRSwitch`
+   statement; its shared-body topology is not lowered into CFG blocks), so its
+   arm-body defs are recovered by an exhaustive must-define rule rather than by
+   SSA phis.
+2. `a* { return 0 }` — this arm `return`s, so it **cannot complete normally**;
+   it never reaches `puts $y`. By definite assignment, a non-completing branch
+   is excluded from the must-define intersection at the merge.
+3. `default { set y 2 }` — the only arm that *reaches* `puts $y` assigns `y`.
+4. `puts $y` — every path that arrives here has run `set y 2`, so `y` is
+   definitely defined → no read-before-set. Pre-fix, the plain intersection
+   counted the `return`-arm's empty def set, dropping `y` → false W210.
+
+#### tclsh ground truth (9.0.3 — confirmed by execution)
+
+```
+% f abc
+0
+% f xyz
+2
+```
+
+No `can't read "y"` error: `f abc` returns from the `a*` arm before `puts $y`;
+`f xyz` takes the default (sets `y`) then prints `2`. (TP control: with the
+`a*` arm changed to `{ set z 9 }` it falls through with `y` unset, and tclsh
+errors `can't read "y": no such variable`.)
+
+#### Compiler evidence
+
+```
+--- FP-RBS-14: opaque-switch arm that cannot complete normally is excluded from must-define
+regen: python -m bench.fp_snippets --id FP-RBS-14
+function ::f
+  block entry_1
+    [0] Switch  defs={y#1}  uses={x#0}
+    [1] Call cmd='puts'  defs={}  uses={y#1}
+    term Goto
+  block exit_2
+    term (none — fall-through exit)
+  read_before_set: (none)
+```
+
+- **`Switch  defs={y#1}`** — the opaque switch is credited with defining `y`
+  even though the `a*` arm omits it, because that arm cannot complete normally
+  and is excluded from the must-define intersection.
+- **`puts … uses={y#1}`** resolves to the switch's def; **`read_before_set:
+  (none)`**.
+
+#### Why the analyser reaches that verdict
+
+`compiler/ssa.py`: `_switch_must_defines` intersects the must-define sets of
+the default body and every arm with a body, but `_intersect_completing` skips
+any body for which `_flow_facts_script` reports it cannot complete normally
+(`return`/`error`/`throw`/`exit`/`tailcall`/`break`/`continue`, or an
+exhaustive `if`/`switch` whose every branch cannot). The resulting set feeds
+`_defs(IRSwitch)`, so SSA versions `y` at the switch and the later read
+resolves.
+
+#### Tests
+
+- `tests/test_fp_rbs.py::test_FP_RBS_14_returning_arm_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_14_erroring_arm_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_14_omitting_arm_still_fires` (TP control —
+  an arm that falls through without assigning `y` keeps the W210, proving the
+  exclusion is limited to non-completing arms)
+
+---
+
 ## DS — dead-store / unused (W220/W211)
 
 These entries lock in the analyser's recovery of *real* reads that live in

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2678,6 +2678,14 @@ bytecode and CFG shape are unchanged.
   all-`break` switch jumps to the loop exit instead, so it is NOT promoted to a
   `CFGReturn` that would wrongly make the post-loop read unreachable — a
   Codex-review soundness fix.)
+- `tests/test_fp_rbs.py::test_FP_RBS_15_while1_break_in_opaque_switch_exits_loop`
+  (TP — a `while 1` whose only exit is a `break` inside an opaque switch is no
+  longer seen as infinite: `_lower_opaque_switch` wires the switch block to the
+  enclosing loop's break/continue targets (`_escaping_loop_jumps`), so the
+  post-loop read is reachable and fires W210.)
+- `tests/test_fp_rbs.py::test_FP_RBS_15_continue_in_opaque_switch_loop_silent`
+  (FP control — the modelled continue edge must not introduce a false W210 when
+  the var is set before the switch on every iteration.)
 
 ---
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2776,6 +2776,210 @@ possible undef.
 
 ---
 
+### FP-RBS-17 — `foreach` over a non-empty literal runs its body at least once
+
+- **Verdict:** FALSE POSITIVE (W210) — a `foreach` over a statically non-empty
+  literal always executes its body, so a body-assigned variable (or the loop
+  variable) read after the loop is defined; the CFG modelled every `foreach` as
+  possibly zero iterations.
+- **Status:** FIXED via loop rotation (analysis builds only).
+- **Codes:** W210
+- **Corpus:** synthetic (the `foreach x {…literal…} { … }; use $x` idiom).
+
+#### Reproducer
+
+```tcl
+proc f {} {
+    # the list is a non-empty literal, so the body runs >=1 time and y is set
+    # before puts reads it.
+    foreach x {1 2 3} { set y $x }
+    puts $y
+}
+```
+
+#### Per-line reasoning
+
+1. `foreach x {1 2 3} { … }` — `{1 2 3}` is a static, non-empty list literal, so
+   `foreach` runs its body at least once (here three times). tclsh-verified:
+   `f` returns with `y == 3`, no `can't read "y"`.
+2. `set y $x` — runs on every iteration, so `y` is set on exit.
+3. `puts $y` — reached only after ≥1 iteration, so `y` is defined.
+4. Pre-fix, the `foreach` header was a single opaque has-next branch serving
+   both the first-iteration check and the back-edge, so its exit edge merged a
+   version-0 (zero-iteration) origin into the post-loop value → false W210.
+
+#### tclsh ground truth (9.0.3 — confirmed by execution)
+
+```
+% f
+3
+```
+
+(TP controls: `foreach x {} …` and `foreach x $items …` may run zero times, so
+both still fire W210; `foreach x {1} { if {$x==1} continue; set y $x }; puts $y`
+errors in tclsh — the `continue` skips `set y` — and still fires W210, because
+the rotation keeps `continue` a real edge.)
+
+#### Compiler evidence
+
+```
+--- FP-RBS-17: foreach over a non-empty literal runs its body at least once
+regen: python -m bench.fp_snippets --id FP-RBS-17
+function ::f
+  block entry_1
+    term Goto
+  block foreach_header_2
+    term Branch ExprLiteral(text='1', start=0, end=0)
+  block foreach_body_3
+    phi  SSAPhi(name='y', version=1, incoming={'foreach_header_2': 0, 'foreach_latch_5': 2})
+    [0] Call cmd='foreach'  defs={x#1}  uses={}
+    [1] AssignValue 'y' value='${x}'  defs={y#2}  uses={x#1}
+    term Goto
+  block foreach_end_4
+    phi  SSAPhi(name='y', version=3, incoming={'foreach_header_2': 0, 'foreach_latch_5': 2})
+    [0] Call cmd='puts'  defs={}  uses={y#3}
+    term Goto
+  block foreach_latch_5
+    term Branch ExprRaw(text='<foreach_has_next>')
+  block exit_6
+    term (none — fall-through exit)
+  read_before_set: (none)
+```
+
+- **`foreach_header_2 … Branch ExprLiteral('1')`** — the rotated entry guard:
+  a statically-true branch (SCCP prunes the `→ foreach_end_4` zero-iteration
+  edge), with no source range so the optimiser leaves it alone.
+- **`foreach_body_3`** holds the var-def and `set y`; **`foreach_latch_5`** is
+  the back-edge has-next re-check.
+- **`foreach_end_4`** is reached only via the latch (after ≥1 iteration); the
+  pruned header operand (`0`) is ignored by the dead-edge phi filter, so
+  **`read_before_set: (none)`**.
+
+#### Why the analyser reaches that verdict
+
+`compiler/cfg.py` `_lower_foreach`: in analysis builds (`faithful_exceptions`),
+when `_foreach_runs_at_least_once` holds (any iterator list is a non-empty
+literal per `_list_literal_nonempty`), the loop is lowered rotated — a literal-
+true entry guard, then `body → latch` with the has-next test on the latch.
+SCCP marks the guard's `→ end` edge non-executable, and the FP-RBS-16 dead-edge
+filter in `_read_before_set` drops its version-0 operand.  Codegen builds keep
+the original single-header `foreach` shape, so bytecode is unchanged.
+
+#### Tests
+
+- `tests/test_fp_rbs.py::test_FP_RBS_17_foreach_literal_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_17_loop_var_after_foreach_silent` (FP — the
+  loop variable is also defined after a non-empty foreach)
+- `tests/test_fp_rbs.py::test_FP_RBS_17_empty_literal_still_fires` (TP control)
+- `tests/test_fp_rbs.py::test_FP_RBS_17_dynamic_list_still_fires` (TP control —
+  a `$var` list may be empty)
+- `tests/test_fp_rbs.py::test_FP_RBS_17_continue_before_set_still_fires` (TP
+  control — `continue` stays a real edge, so a skipped def still fires)
+
+---
+
+### FP-RBS-18 — `for` whose condition is true on entry runs its body at least once
+
+- **Verdict:** FALSE POSITIVE (W210) — a `for` whose condition is statically
+  true on entry always executes its body once, so a body-assigned variable read
+  after the loop is defined; SCCP could not fold the header test because the
+  loop variable there is the loop phi.
+- **Status:** FIXED via loop rotation (analysis builds only).
+- **Codes:** W210
+- **Corpus:** synthetic (the canonical counted `for {set i 0} {$i < N} …` loop).
+
+#### Reproducer
+
+```tcl
+proc f {} {
+    # 0 < 3 is true on entry, so the body runs >=1 time and y is set.
+    for {set i 0} {$i < 3} {incr i} { set y $i }
+    puts $y
+}
+```
+
+#### Per-line reasoning
+
+1. `for {set i 0} {$i < 3} {incr i} { … }` — after the init `set i 0`, the
+   condition `0 < 3` is true, so the first iteration always runs.
+2. `set y $i` — runs on the first (and every) iteration, so `y` is set on exit.
+3. `puts $y` — reached only after the loop, which ran ≥1 time, so `y` is set.
+4. Pre-fix, SCCP could not prove the first iteration runs: the header test
+   reads `i` as the loop phi (`0 ⊔ stepped`), which is not constant, so the
+   header's zero-iteration exit edge stayed live and merged a version-0 origin
+   into the post-loop value → false W210.
+
+#### tclsh ground truth (9.0.3 — confirmed by execution)
+
+```
+% f
+2
+```
+
+(TP controls: `for {set i 5} {$i < 3} …` is false on entry → may run zero times
+→ W210 fires; `for {set i 0} {$i < $n} …` has an unknown bound → W210 fires;
+`for {set i 0} {$i < 3} {incr i} { if {$i==0} break; set y $i }; puts $y` errors
+in tclsh and still fires W210.)
+
+#### Compiler evidence
+
+```
+--- FP-RBS-18: for whose condition is true on entry runs its body at least once
+regen: python -m bench.fp_snippets --id FP-RBS-18
+function ::f
+  block entry_1
+    [0] AssignConst 'i' value='0'  defs={i#1}  uses={}
+    term Goto
+  block for_header_2
+    term Branch ExprLiteral(text='1', start=0, end=0)
+  block for_body_3
+    phi  SSAPhi(name='i', version=2, incoming={'for_header_2': 1, 'for_step_4': 3})
+    phi  SSAPhi(name='y', version=1, incoming={'for_header_2': 0, 'for_step_4': 2})
+    [0] AssignValue 'y' value='${i}'  defs={y#2}  uses={i#2}
+    term Goto
+  block for_step_4
+    [0] Incr 'i'  defs={i#3}  uses={i#2}
+    term Branch ExprBinary(op=<BinOp.LT: '<'>, left=ExprVar(text='$i', name='i', start=0, end=1), right=ExprLiteral(text='3', start=5, end=5))
+  block for_end_5
+    phi  SSAPhi(name='i', version=4, incoming={'for_header_2': 1, 'for_step_4': 3})
+    phi  SSAPhi(name='y', version=3, incoming={'for_header_2': 0, 'for_step_4': 2})
+    [0] Call cmd='puts'  defs={}  uses={y#3}
+    term Goto
+  block exit_6
+    term (none — fall-through exit)
+  read_before_set: (none)
+```
+
+- **`for_header_2 … Branch ExprLiteral('1')`** — the rotated entry guard
+  (range-less, so the optimiser does not rewrite the loop's source condition).
+  SCCP prunes its `→ for_end_5` zero-iteration edge.
+- **`for_step_4`** carries the *real* condition `$i < 3` (with its source
+  range), so the optimiser still sees the loop test and SCCP folds it only when
+  `i` actually becomes constant.
+- **`for_end_5`** is reached only via the step (after ≥1 iteration); the pruned
+  header operand is ignored → **`read_before_set: (none)`**.
+
+#### Why the analyser reaches that verdict
+
+`compiler/cfg.py` `_lower_for`: in analysis builds, when `_for_runs_at_least_once`
+holds (the condition evaluates true against the init clause's constant
+bindings), the loop is rotated — the back-edge re-check (on the step block)
+carries the real condition, and the header becomes a synthetic always-true,
+range-less entry guard.  The header is then reached only from init, so SCCP
+folds it and prunes the zero-iteration edge.  `loop_nodes` and the init block's
+exit versions are unchanged, so the optimiser's IR-level static-`for` summary
+(`summarise_static_for_ir`) still folds post-loop constants.  Codegen builds
+keep the original header/body/step shape, so bytecode is unchanged.
+
+#### Tests
+
+- `tests/test_fp_rbs.py::test_FP_RBS_18_for_true_on_entry_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_18_false_on_entry_still_fires` (TP control)
+- `tests/test_fp_rbs.py::test_FP_RBS_18_unknown_bound_still_fires` (TP control)
+- `tests/test_fp_rbs.py::test_FP_RBS_18_break_before_set_still_fires` (TP control)
+
+---
+
 ## DS — dead-store / unused (W220/W211)
 
 These entries lock in the analyser's recovery of *real* reads that live in

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2572,6 +2572,104 @@ resolves.
 
 ---
 
+### FP-RBS-15 — opaque switch whose every arm exits is itself a terminator
+
+- **Verdict:** FALSE POSITIVE (W210) — an opaque `switch` whose every reachable
+  arm `return`s / `error`s / `tailcall`s never falls through, so the code after
+  it is unreachable; the CFG modelled the switch as a fall-through statement, so
+  a read in that dead code was analysed as reachable and fired W210.
+- **Status:** FIXED. Extends FP-RBS-14 (which excludes non-completing arms from
+  the must-define) to the case where *all* arms are non-completing: the switch
+  itself becomes a terminator.
+- **Codes:** W210
+- **Corpus:** synthetic (exhaustive dispatch `switch` where every arm returns).
+
+#### Reproducer
+
+```tcl
+proc f {x} {
+    # every arm returns, so control never reaches `puts $y`:
+    # the switch is a terminator and the read is dead code.
+    switch -glob $x {
+        a* { return 1 }
+        default { return 2 }
+    }
+    puts $y
+}
+```
+
+#### Per-line reasoning
+
+1. `switch -glob $x { … }` is opaque (one `IRSwitch` statement; not lowered to
+   CFG blocks). It has a `default`, so the subject always selects some arm.
+2. `a* { return 1 }` and `default { return 2 }` — *every* reachable arm body
+   `return`s, so none can complete normally. With a `default` present there is
+   no fall-through path, so **no execution reaches `puts $y`**.
+3. `puts $y` — dead code. tclsh never evaluates it, so reading the unset `y`
+   here is not a runtime error; W210 must not fire.
+4. Pre-fix the opaque switch always fell through to the next statement, so the
+   block edged into the `puts $y` statement and W210 fired on a read that can
+   never execute.
+
+#### tclsh ground truth (9.0.3 — confirmed by execution)
+
+```
+% f abc
+1
+% f zzz
+2
+```
+
+`f` always returns from inside the switch; the `puts $y` after it never runs
+(no `can't read "y"` error). (TP controls: dropping the `default` lets an
+unmatched subject fall through to `puts $y` → W210 fires; or making one arm
+complete — `default { set z 9 }` — lets the switch fall through with `y` unset
+→ W210 fires.)
+
+#### Compiler evidence
+
+```
+--- FP-RBS-15: opaque switch whose every arm exits is itself a terminator
+regen: python -m bench.fp_snippets --id FP-RBS-15
+function ::f
+  block entry_1
+    [0] Switch  defs={}  uses={x#0}
+    term Return
+  block unreachable_2
+    term Goto
+  block exit_3
+    term (none — fall-through exit)
+  read_before_set: (none)
+```
+
+- **`block entry_1 … term Return`** — the opaque switch's block is now
+  terminated by a CFGReturn, so it has no fall-through successor.
+- **`block unreachable_2`** — the `puts $y` statement is routed to the orphan
+  unreachable block (exactly like code after a `return`/`tailcall`), so it is
+  not analysed as reachable.
+- **`read_before_set: (none)`** — no W210.
+
+#### Why the analyser reaches that verdict
+
+`compiler/cfg.py` `_CFGBuilder._maybe_terminate_opaque_switch`: when lowering
+an opaque (glob/regexp/fall-through) switch in an analysis build
+(`faithful_exceptions`), the block is promoted to a `CFGReturn` terminator if
+`_switch_completes_normally(stmt)` is false — i.e. it has a `default` and every
+arm-with-a-body plus the default cannot complete normally (`_flow_facts_stmt`).
+Codegen builds leave the fall-through edge, so the opaque-switch `invokeStk`
+bytecode and CFG shape are unchanged.
+
+#### Tests
+
+- `tests/test_fp_rbs.py::test_FP_RBS_15_all_arms_return_dead_read_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_15_all_arms_error_or_tailcall_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_15_no_default_falls_through_fires` (TP
+  control — without a `default` the unmatched path reaches the read)
+- `tests/test_fp_rbs.py::test_FP_RBS_15_one_completing_arm_fires` (TP control —
+  one arm that completes lets the switch fall through with the var unset)
+
+---
+
 ## DS — dead-store / unused (W220/W211)
 
 These entries lock in the analyser's recovery of *real* reads that live in

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2569,6 +2569,12 @@ resolves.
 - `tests/test_fp_rbs.py::test_FP_RBS_14_omitting_arm_still_fires` (TP control —
   an arm that falls through without assigning `y` keeps the W210, proving the
   exclusion is limited to non-completing arms)
+- `tests/test_fp_rbs.py::test_FP_RBS_14_break_arm_escaping_loop_still_fires`
+  (TP control — only *procedure*-exit arms (`return`/`error`/`exit`/`tailcall`)
+  are excluded.  A `break`/`continue` arm is a *loop jump*: it still reaches the
+  code after the enclosing loop *without* the other arms' defs, so it is kept in
+  the intersection.  `foreach x {a} { switch {a* {break} default {set y 1}} };
+  puts $y` errors in tclsh and must fire W210 — a Codex-review soundness fix.)
 
 ---
 
@@ -2667,6 +2673,11 @@ bytecode and CFG shape are unchanged.
   control — without a `default` the unmatched path reaches the read)
 - `tests/test_fp_rbs.py::test_FP_RBS_15_one_completing_arm_fires` (TP control —
   one arm that completes lets the switch fall through with the var unset)
+- `tests/test_fp_rbs.py::test_FP_RBS_15_all_break_switch_not_a_proc_terminator`
+  (TP control — promotion requires every arm to exit the *procedure*; an
+  all-`break` switch jumps to the loop exit instead, so it is NOT promoted to a
+  `CFGReturn` that would wrongly make the post-loop read unreachable — a
+  Codex-review soundness fix.)
 
 ---
 
@@ -2977,6 +2988,11 @@ keep the original header/body/step shape, so bytecode is unchanged.
 - `tests/test_fp_rbs.py::test_FP_RBS_18_false_on_entry_still_fires` (TP control)
 - `tests/test_fp_rbs.py::test_FP_RBS_18_unknown_bound_still_fires` (TP control)
 - `tests/test_fp_rbs.py::test_FP_RBS_18_break_before_set_still_fires` (TP control)
+- `tests/test_fp_rbs.py::test_FP_RBS_18_stale_const_init_still_fires` (TP control
+  — a later non-constant init write (`set i 0; set i $n`) invalidates the stale
+  constant, so the loop is not treated as guaranteed; a Codex-review fix.)
+- `tests/test_fp_rbs.py::test_FP_RBS_18_incr_in_init_invalidates_const` (TP
+  control — `incr` in init likewise invalidates the constant binding.)
 
 ---
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2670,6 +2670,112 @@ bytecode and CFG shape are unchanged.
 
 ---
 
+### FP-RBS-16 — phi operand on a dead loop-exit edge (`while 1` + `break`) is not read-before-set
+
+- **Verdict:** FALSE POSITIVE (W210) — a loop-exit block's phi had an operand
+  for the never-taken `cond → exit` edge of `while 1`; that operand carried the
+  variable's version-0 (unset) origin, and the read-before-set phi-undef closure
+  consumed it even though the edge is unreachable.
+- **Status:** FIXED. Same family as the terminator work (false W210 from
+  control-flow imprecision), but the gap is in the read-before-set / SCCP-edge
+  interaction rather than CFG construction.
+- **Codes:** W210
+- **Corpus:** synthetic (the `while 1 { …; break }` / `while 1 { …; if {c} break }`
+  early-exit idiom).
+
+#### Reproducer
+
+```tcl
+proc f {} {
+    # while 1 runs the body >=1 time; the only exit is the break, where y is
+    # already set -> $y is always defined here.
+    while 1 { set y 1; break }
+    puts $y
+}
+```
+
+#### Per-line reasoning
+
+1. `while 1 { … }` — the condition is the constant `1`, so the loop never exits
+   via the condition; SCCP marks the `while_header → while_end` (cond-false)
+   edge non-executable.
+2. `set y 1; break` — the body runs at least once and the `break` is the loop's
+   only real exit. On that edge `y` is set.
+3. `puts $y` — `while_end` is reachable (via the `break` edge), and its phi
+   `y#2` merges the break edge (`y#1`, set) with the dead cond-exit edge
+   (`y#0`, unset). Only the break edge is live, so `y` is always defined here.
+4. Pre-fix, `_phi_can_undef` filtered unreachable predecessor *blocks*
+   (`while_header` is reachable) but not unreachable *edges*, so it consumed the
+   `y#0` operand on the dead `while_header → while_end` edge and false-fired
+   W210. (Contrast: with no `break`, `while_end` is fully unreachable and
+   correctly silent — that's why the bug only shows with a `break`.)
+
+#### tclsh ground truth (9.0.3 — confirmed by execution)
+
+```
+% f
+1
+```
+
+No `can't read "y"` error. The realistic shape behaves the same — `proc f {} {
+while 1 { set result [compute]; if {[ok $result]} break }; return $result }`
+returns the computed value with no unset-read.
+(TP controls: `while {$n > 0} { set y 1 }` (non-constant cond, may run zero
+times) still fires W210; and a `while 1` where only *one* of two `break` paths
+sets `y` still fires.)
+
+#### Compiler evidence
+
+```
+--- FP-RBS-16: phi operand on a dead loop-exit edge (while 1 + break) is not read-before-set
+regen: python -m bench.fp_snippets --id FP-RBS-16
+function ::f
+  block entry_1
+    term Goto
+  block while_header_2
+    term Branch ExprLiteral(text='1', start=0, end=0)
+  block while_body_3
+    [0] AssignConst 'y' value='1'  defs={y#1}  uses={}
+    [1] Call cmd='break'  defs={}  uses={}
+    term Goto
+  block while_end_4
+    phi  SSAPhi(name='y', version=2, incoming={'while_header_2': 0, 'while_body_3': 1})
+    [0] Call cmd='puts'  defs={}  uses={y#2}
+    term Goto
+  block exit_5
+    term (none — fall-through exit)
+  read_before_set: (none)
+```
+
+- **`while_end_4` phi `y#2` incoming `{while_header_2: 0, while_body_3: 1}`** —
+  the dead cond-exit operand (`while_header_2: 0`) is present but its edge is
+  non-executable, so the read-before-set closure skips it; only the live break
+  operand (`while_body_3: 1`) remains.
+- **`read_before_set: (none)`** — no W210.
+
+#### Why the analyser reaches that verdict
+
+`compiler/core_analyses.py`: `_read_before_set` now takes the SCCP
+`executable_edges`, and its `_phi_can_undef` closure skips any phi operand whose
+`(pred, block)` edge is non-executable — the same edge filter already used by
+`_collect_used_names`. SCCP marks the `while 1` cond-false edge non-executable,
+so the version-0 operand it carries can never be read and no longer counts as a
+possible undef.
+
+#### Tests
+
+- `tests/test_fp_rbs.py::test_FP_RBS_16_while1_break_set_silent` (FP)
+- `tests/test_fp_rbs.py::test_FP_RBS_16_while1_conditional_break_silent` (FP —
+  the realistic `while 1 { …; if {c} break }` shape)
+- `tests/test_fp_rbs.py::test_FP_RBS_16_normal_while_still_fires` (TP control —
+  a non-constant condition may run zero times, so the read is genuinely
+  maybe-unset)
+- `tests/test_fp_rbs.py::test_FP_RBS_16_partial_break_def_still_fires` (TP
+  control — when only one of two `break` paths sets the var, the live edges
+  still include an unset origin)
+
+---
+
 ## DS — dead-store / unused (W220/W211)
 
 These entries lock in the analyser's recovery of *real* reads that live in

--- a/tests/test_fp_rbs.py
+++ b/tests/test_fp_rbs.py
@@ -1317,3 +1317,27 @@ def test_FP_RBS_18_incr_in_init_invalidates_const():
     assert w210, "incr-in-init must invalidate the const; W210 must fire; got: " + ", ".join(
         f"{d.code}:{d.message}" for d in _rbs(src)
     )
+
+
+def test_FP_RBS_15_while1_break_in_opaque_switch_exits_loop():
+    """TP (Codex P1 / C3, fully fixed): a `while 1` whose only exit is a `break`
+    inside an opaque switch is NOT infinite — the opaque-switch break edge to
+    the loop exit is now modelled, so the post-loop read is reachable and the
+    unset var fires W210.  tclsh errors here ('can't read y')."""
+    src = "proc f {x} { while 1 { switch -glob $x {a* {break} default {break}} }; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, (
+        "break-in-opaque-switch must make the while-1 exit reachable; W210 must fire; got: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_15_continue_in_opaque_switch_loop_silent():
+    """FP control: a benign opaque-switch `continue` arm (the var is set before
+    the switch on every iteration of a guaranteed loop) must stay silent — the
+    modelled continue edge must not introduce a false W210."""
+    src = "proc f {} { foreach x {1 2 3} { set y 1; switch -glob $x {a* {continue} default {}} }; puts $y }\n"
+    assert _rbs(src) == [], (
+        "var set before an opaque-switch continue arm stays defined; no W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )

--- a/tests/test_fp_rbs.py
+++ b/tests/test_fp_rbs.py
@@ -1264,3 +1264,56 @@ def test_FP_RBS_18_break_before_set_still_fires():
     assert w210, "break-before-set exits with 'y' unset; W210 must fire; got: " + ", ".join(
         f"{d.code}:{d.message}" for d in _rbs(src)
     )
+
+
+# Soundness regressions from the Codex review of PR #634 — break/continue arms
+# escape an opaque switch (loop-jump, not proc-exit), and stale for-init consts.
+
+
+def test_FP_RBS_14_break_arm_escaping_loop_still_fires():
+    """TP (Codex P1): an opaque-switch arm that `break`s does NOT define the
+    other arm's var on the path that escapes the enclosing loop, so the var is
+    maybe-unset after the loop.  `break`/`continue` are loop-jumps, not
+    proc-exits, so they must NOT be excluded from the switch must-define.
+    tclsh errors here -> W210 must fire."""
+    src = (
+        "proc f {} { foreach x {a} { switch -glob $x {a* {break} default {set y 1}} }; puts $y }\n"
+    )
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "break-arm escaping the loop leaves 'y' unset; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_15_all_break_switch_not_a_proc_terminator():
+    """TP (Codex P1): a switch whose arms all `break` jumps to the loop exit,
+    NOT the procedure return — it must not be promoted to a CFGReturn (which
+    would make the post-loop read unreachable).  tclsh errors -> W210 fires."""
+    src = "proc f {x} { foreach i {1 2 3} { switch -glob $x {a* {break} default {break}} }; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "all-break switch is a loop jump, not a return; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_18_stale_const_init_still_fires():
+    """TP (Codex P1): when the for-init writes a var with a constant and then a
+    non-constant (`set i 0; set i $n`), the stale constant must be invalidated —
+    the loop may run zero times, so a body-only var is maybe-unset.  W210 must
+    fire."""
+    src = "proc f {n} { for {set i 0; set i $n} {$i < 3} {incr i} { set y $i }; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, (
+        "stale-const for-init must not be treated as guaranteed; W210 must fire; got: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_18_incr_in_init_invalidates_const():
+    """TP (Codex P1, variant): `for {set i 0; incr i 5} {$i < 3} ...` may run
+    zero times (i becomes 5); the const binding must be invalidated."""
+    src = "proc f {} { for {set i 0; incr i 5} {$i < 3} {incr i} { set y $i }; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "incr-in-init must invalidate the const; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )

--- a/tests/test_fp_rbs.py
+++ b/tests/test_fp_rbs.py
@@ -1005,3 +1005,75 @@ def test_FP_RBS_14_omitting_arm_still_fires():
     assert w210, "omitting arm leaves 'y' maybe-unset; W210 must fire; got: " + ", ".join(
         f"{d.code}:{d.message}" for d in _rbs(src)
     )
+
+
+# FP-RBS-15 — opaque switch whose every arm exits is itself a terminator
+
+
+FP_RBS_15_REPRO = """\
+proc f {x} {
+    # every arm returns, so control never reaches `puts $y`:
+    # the switch is a terminator and the read is dead code.
+    switch -glob $x {
+        a* { return 1 }
+        default { return 2 }
+    }
+    puts $y
+}
+"""
+
+
+def test_FP_RBS_15_all_arms_return_dead_read_silent():
+    """FP: every arm of the (default-bearing) opaque switch returns, so the
+    switch cannot fall through -- ``puts $y`` is unreachable dead code.  The
+    switch block is promoted to a terminator, so no RBS code fires."""
+    assert _rbs(FP_RBS_15_REPRO) == [], (
+        "all-arms-return switch makes the trailing read unreachable; no W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(FP_RBS_15_REPRO))
+    )
+
+
+def test_FP_RBS_15_all_arms_error_or_tailcall_silent():
+    """FP: ``error`` and ``tailcall`` arms are non-completing too, so an
+    all-exiting switch is still a terminator."""
+    src = (
+        "proc f {x} {\n"
+        "    switch -glob $x {\n"
+        "        a* { error a }\n"
+        "        b* { tailcall g }\n"
+        "        default { error d }\n"
+        "    }\n"
+        "    puts $y\n"
+        "}\n"
+    )
+    assert _rbs(src) == [], (
+        "all-arms-exit switch makes the trailing read unreachable; no W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_15_no_default_falls_through_fires():
+    """TP control: without a ``default`` an unmatched subject falls through to
+    ``puts $y``, so the switch is NOT a terminator and ``y`` is maybe-unset --
+    W210 must fire.  Proves the promotion requires exhaustiveness (a default)."""
+    src = "proc f {x} {\n    switch -glob $x { a* { return 1 } b* { return 2 } }\n    puts $y\n}\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "no-default switch falls through; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_15_one_completing_arm_fires():
+    """TP control: one arm that *completes* (default sets z, not y) lets the
+    switch fall through with ``y`` unset, so W210 must fire.  Proves the
+    promotion requires *every* arm to be non-completing."""
+    src = (
+        "proc f {x} {\n"
+        "    switch -glob $x { a* { return 1 } default { set z 9 } }\n"
+        "    puts $y\n"
+        "}\n"
+    )
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "completing-arm switch falls through; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )

--- a/tests/test_fp_rbs.py
+++ b/tests/test_fp_rbs.py
@@ -892,3 +892,116 @@ def test_FP_callbyname_upvar_alias_still_suppresses():
         d for d in get_diagnostics(src) if d.code in ("W211", "W220") and "'x'" in (d.message or "")
     ]
     assert not diags, "upvar-aliased callee write must continue to suppress caller W211/W220"
+
+
+# FP-RBS-13 — `tailcall` replaces the frame; code after it never runs
+
+
+FP_RBS_13_REPRO = """\
+proc f {cond} {
+    # tailcall g replaces this frame: the `return $result` below is only
+    # reached via the else branch, where result is always set.
+    if {$cond} {
+        tailcall g
+    } else {
+        set result 1
+    }
+    return $result
+}
+"""
+
+
+def test_FP_RBS_13_tailcall_with_args_silent():
+    """FP: ``tailcall g`` ends the proc's straight-line flow (TclNRTailcallObjCmd
+    returns TCL_RETURN), so ``return $result`` is reached only via the else
+    branch where result is set.  No RBS code may fire."""
+    assert _rbs(FP_RBS_13_REPRO) == [], (
+        "tailcall-terminated branch must not leave 'result' read-before-set; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(FP_RBS_13_REPRO))
+    )
+
+
+def test_FP_RBS_13_bare_tailcall_silent():
+    """FP: bare ``tailcall`` (no args) is *also* a terminator -- the C
+    implementation returns TCL_RETURN for any arg count (the arg count only
+    decides what runs after the frame pops).  tclsh-verified: a bare tailcall
+    ends the proc returning ``""``.  So this shape is silent too."""
+    src = (
+        "proc f {cond} {\n"
+        "    if {$cond} { tailcall } else { set result 1 }\n"
+        "    return $result\n"
+        "}\n"
+    )
+    assert _rbs(src) == [], (
+        "bare tailcall is a terminator; 'result' must not be read-before-set; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_13_non_terminating_branch_still_fires():
+    """TP control: replace ``tailcall`` with a normal (completing) command and
+    ``result`` becomes genuinely maybe-unset on the then-path, so W210 fires.
+    Proves the suppression is specific to the terminator, not the if/return
+    shape."""
+    src = (
+        "proc f {cond} {\n    if {$cond} { puts hi } else { set result 1 }\n    return $result\n}\n"
+    )
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'result'" in (d.message or "")]
+    assert w210, (
+        "non-terminating then-branch leaves 'result' maybe-unset; W210 must fire; got: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+# FP-RBS-14 — opaque-switch arm that can't complete normally is excluded from must-define
+
+
+FP_RBS_14_REPRO = """\
+proc f {x} {
+    # the a* arm returns, so it never reaches `puts $y`; the only path that
+    # does (default) sets y -> y is definitely defined.
+    switch -glob $x {
+        a* { return 0 }
+        default { set y 2 }
+    }
+    puts $y
+}
+"""
+
+
+def test_FP_RBS_14_returning_arm_silent():
+    """FP: the ``a*`` arm returns, so it never reaches ``puts $y``; every path
+    that does (default) assigns ``y``.  The opaque-switch must-define excludes
+    non-completing arms, so ``y`` is definitely defined -- no W210."""
+    assert _rbs(FP_RBS_14_REPRO) == [], (
+        "returning switch arm must not drop 'y' from the must-define set; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(FP_RBS_14_REPRO))
+    )
+
+
+def test_FP_RBS_14_erroring_arm_silent():
+    """FP: an arm that always ``error``s likewise cannot complete normally and
+    is excluded from the must-define intersection."""
+    src = (
+        "proc f {x} {\n"
+        "    switch -glob $x { a* { error bad } default { set y 2 } }\n"
+        "    puts $y\n"
+        "}\n"
+    )
+    assert _rbs(src) == [], (
+        "erroring switch arm must not drop 'y' from the must-define set; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_14_omitting_arm_still_fires():
+    """TP control: an arm that *completes normally* without assigning ``y``
+    (falls through) leaves ``y`` genuinely maybe-unset, so W210 must fire.
+    Proves the exclusion is limited to non-completing arms."""
+    src = (
+        "proc f {x} {\n    switch -glob $x { a* { set z 9 } default { set y 2 } }\n    puts $y\n}\n"
+    )
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "omitting arm leaves 'y' maybe-unset; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )

--- a/tests/test_fp_rbs.py
+++ b/tests/test_fp_rbs.py
@@ -1150,3 +1150,117 @@ def test_FP_RBS_16_partial_break_def_still_fires():
     assert w210, "a break path that leaves 'y' unset must still fire W210; got: " + ", ".join(
         f"{d.code}:{d.message}" for d in _rbs(src)
     )
+
+
+# FP-RBS-17 — foreach over a non-empty literal runs its body at least once
+
+
+FP_RBS_17_REPRO = """\
+proc f {} {
+    # the list is a non-empty literal, so the body runs >=1 time and y is set
+    # before puts reads it.
+    foreach x {1 2 3} { set y $x }
+    puts $y
+}
+"""
+
+
+def test_FP_RBS_17_foreach_literal_silent():
+    """FP: foreach over a non-empty literal list always runs the body, so the
+    body-assigned 'y' is defined after the loop -- no W210."""
+    assert _rbs(FP_RBS_17_REPRO) == [], (
+        "non-empty-literal foreach defines 'y'; no W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(FP_RBS_17_REPRO))
+    )
+
+
+def test_FP_RBS_17_loop_var_after_foreach_silent():
+    """FP: the loop variable is set on every iteration, so it is defined after
+    a non-empty-literal foreach."""
+    src = "proc f {} { foreach x {a b c} { } ; puts $x }\n"
+    assert _rbs(src) == [], (
+        "loop var defined after non-empty foreach; no W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_17_empty_literal_still_fires():
+    """TP control: foreach over an empty literal never runs the body, so 'y'
+    is genuinely unset -- W210 must fire."""
+    src = "proc f {} { foreach x {} { set y $x } ; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "empty-list foreach leaves 'y' unset; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_17_dynamic_list_still_fires():
+    """TP control: a foreach over a $var list may be empty, so the read after
+    is maybe-unset -- W210 must fire."""
+    src = "proc f {items} { foreach x $items { set y $x } ; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "dynamic-list foreach may be empty; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_17_continue_before_set_still_fires():
+    """TP control: a `continue` before the def can skip it on the last
+    iteration, so 'y' may be unset -- the rotation keeps `continue` a real
+    edge, so W210 must still fire.  tclsh-verified: this errors."""
+    src = "proc f {} { foreach x {1} { if {$x==1} continue; set y $x } ; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "continue-before-set may skip 'y'; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+# FP-RBS-18 — for whose condition is true on entry runs its body at least once
+
+
+FP_RBS_18_REPRO = """\
+proc f {} {
+    # 0 < 3 is true on entry, so the body runs >=1 time and y is set.
+    for {set i 0} {$i < 3} {incr i} { set y $i }
+    puts $y
+}
+"""
+
+
+def test_FP_RBS_18_for_true_on_entry_silent():
+    """FP: a for whose condition is true on entry runs the body at least once,
+    so the body-assigned 'y' is defined after the loop -- no W210."""
+    assert _rbs(FP_RBS_18_REPRO) == [], (
+        "for true-on-entry defines 'y'; no W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(FP_RBS_18_REPRO))
+    )
+
+
+def test_FP_RBS_18_false_on_entry_still_fires():
+    """TP control: a for whose condition is false on entry runs zero times, so
+    'y' is unset -- W210 must fire."""
+    src = "proc f {} { for {set i 5} {$i < 3} {incr i} { set y $i } ; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "false-on-entry for runs zero times; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_18_unknown_bound_still_fires():
+    """TP control: a for with an unknown (parameter) bound may run zero times,
+    so the read after is maybe-unset -- W210 must fire."""
+    src = "proc f {n} { for {set i 0} {$i < $n} {incr i} { set y $i } ; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "unknown-bound for may run zero times; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )
+
+
+def test_FP_RBS_18_break_before_set_still_fires():
+    """TP control: a `break` before the def exits with 'y' unset -- the
+    rotation keeps `break` a real edge, so W210 must still fire."""
+    src = "proc f {} { for {set i 0} {$i < 3} {incr i} { if {$i==0} break; set y $i } ; puts $y }\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "break-before-set exits with 'y' unset; W210 must fire; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )

--- a/tests/test_fp_rbs.py
+++ b/tests/test_fp_rbs.py
@@ -1077,3 +1077,76 @@ def test_FP_RBS_15_one_completing_arm_fires():
     assert w210, "completing-arm switch falls through; W210 must fire; got: " + ", ".join(
         f"{d.code}:{d.message}" for d in _rbs(src)
     )
+
+
+# FP-RBS-16 — phi operand on a dead loop-exit edge (`while 1` + `break`)
+
+
+FP_RBS_16_REPRO = """\
+proc f {} {
+    # while 1 runs the body >=1 time; the only exit is the break, where y is
+    # already set -> $y is always defined here.
+    while 1 { set y 1; break }
+    puts $y
+}
+"""
+
+
+def test_FP_RBS_16_while1_break_set_silent():
+    """FP: `while 1` never exits via its (constant) condition, so the only live
+    exit is the `break`, where `y` is set.  The loop-exit phi's operand on the
+    dead cond-exit edge (version-0) must not count as read-before-set."""
+    assert _rbs(FP_RBS_16_REPRO) == [], (
+        "dead cond-exit edge operand must not fire W210; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(FP_RBS_16_REPRO))
+    )
+
+
+def test_FP_RBS_16_while1_conditional_break_silent():
+    """FP: the realistic `while 1 { set v ...; if {c} break }` early-exit idiom.
+    `v` is set every iteration before the conditional break, so it is defined on
+    the (only live) break exit."""
+    src = (
+        "proc f {} {\n"
+        "    while 1 {\n"
+        "        set result [compute]\n"
+        "        if {[ok $result]} break\n"
+        "    }\n"
+        "    return $result\n"
+        "}\n"
+    )
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'result'" in (d.message or "")]
+    assert not w210, (
+        "result is set before every conditional break; W210 must NOT fire; current: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_16_normal_while_still_fires():
+    """TP control: a NON-constant condition may run zero times, so the read
+    after the loop is genuinely maybe-unset -- W210 must fire.  Proves the
+    suppression is specific to the proven-dead exit edge."""
+    src = "proc f {n} {\n    while {$n > 0} { set y 1; incr n -1 }\n    puts $y\n}\n"
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, (
+        "zero-iteration-possible while leaves 'y' maybe-unset; W210 must fire; got: "
+        + ", ".join(f"{d.code}:{d.message}" for d in _rbs(src))
+    )
+
+
+def test_FP_RBS_16_partial_break_def_still_fires():
+    """TP control: when only ONE of two break paths sets `y`, a live exit edge
+    still carries an unset origin, so W210 must fire."""
+    src = (
+        "proc f {c} {\n"
+        "    while 1 {\n"
+        "        if {$c} { set y 1; break }\n"
+        "        if {!$c} break\n"
+        "    }\n"
+        "    puts $y\n"
+        "}\n"
+    )
+    w210 = [d for d in _rbs(src) if d.code == "W210" and "'y'" in (d.message or "")]
+    assert w210, "a break path that leaves 'y' unset must still fire W210; got: " + ", ".join(
+        f"{d.code}:{d.message}" for d in _rbs(src)
+    )


### PR DESCRIPTION
## Summary

This branch fixes a family of analysis bugs where the Python compiler's CFG/SSA dataflow diverged from real Tcl semantics at control-flow boundaries, producing **false `W210` (read-before-set)** (and, in two cases, skewed reachability / constant-folding / taint). Each fix is **analysis-only** (gated on `faithful_exceptions`); the opaque-loop/switch **codegen and CFG shape are byte-identical**, verified by `test_bytecode_identity`.

The work started from two seed fixes (break/continue CFG jumps; opaque-switch arm defs) and then systematically hunted the rest of the family.

## Fixes (each with paired FP + TP-control tests and an `FP.md` entry)

| Commit | Bug | Repro (was false W210) |
|---|---|---|
| `8aadf04` | `break`/`continue` modelled as fall-through, not loop jumps | `foreach … { if {…} continue; set n … }` — continue path flowed through `set n` |
| `7b9be0b` | Opaque (`glob`/`regexp`/fallthrough) `switch` arm **defs** lost in SSA | `switch -glob $x {a* {set y 1} default {set y 2}}; puts $y` |
| `d312c6e` | `tailcall` not a proc-exit terminator; switch must-define counted arms that can't complete normally | `if {$c} {tailcall g} else {set r 1}; return $r` · `switch … {a* {return} default {set y 2}}; puts $y` |
| `f18e2c2` | Opaque `switch` whose every arm exits not promoted to a terminator | `switch … {a* {return 1} default {return 2}}; puts $y` (dead code) |
| `9f725e4` | Read-before-set consumed phi operands on SCCP-dead predecessor **edges** | `while 1 { set y 1; break }; puts $y` (and the `while 1 {…; if {c} break}` idiom) |
| `2d3dcef` | Loops over a guaranteed-non-empty range modelled as maybe-zero iterations | `foreach x {1 2 3} {set y $x}; puts $y` · `for {set i 0} {$i<3} {incr i} {set y $i}; puts $y` |

### Notable design points
- **`tailcall`** is a terminator regardless of args — confirmed against the C source (`TclNRTailcallObjCmd` always `return TCL_RETURN`).
- **Definite-assignment** (`_flow_facts_*`) is the single source of truth for "cannot complete normally", shared by the CFG builder (terminator promotion) and SSA (switch must-define).
- **Loop rotation** (last commit) recovers guaranteed-iteration defs by turning the zero-iteration skip into a *separate*, statically-true entry-guard edge that SCCP prunes — leaning on the dead-edge phi filter from `9f725e4`. Crucially it adds **no synthetic def**, so SCCP values (constant folding, command-name resolution) are untouched, and `break`/`continue` stay real edges so partial-def exits remain sound. The `for` entry-guard is range-less so the optimiser's constant-branch source rewriter never folds the loop's source condition.

## Soundness
Every fix is conservative — it only suppresses a finding when the path is *provably* unreachable / the variable is *provably* defined. TP-control tests confirm the genuine cases still fire: no-default switches, partial break/continue paths, empty/dynamic lists, false-on-entry/unknown-bound `for`, first-iteration body reads, etc. Ground truth was real `tclsh 9.0.3` throughout.

## Verification
~3,900 tests across SSA/CFG, all FP families, dead-store, taint, intervals, shimmer, GVN, interprocedural, optimisers (incl. VM-equivalence), all diagnostics, and **bytecode-identity/codegen/WASM** pass with no expectation deltas. `ruff check`/`format` clean; all 108 `bench/fp_snippets` render.

## Docs / tests
- `docs/design/compiler/FP.md`: new entries `FP-RBS-13` … `FP-RBS-18` (full reasoning + tclsh ground truth + regenerable compiler evidence).
- `tests/test_fp_rbs.py`: paired FP/TP tests for each.
- `bench/fp_snippets.py`: snippets for evidence regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gEeNQ5mjZNSTNjpWH99Ki

---
_Generated by [Claude Code](https://claude.ai/code/session_017gEeNQ5mjZNSTNjpWH99Ki)_