### PR TITLE
Publish VS Code Marketplace from CI via keyless OIDC

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -250,6 +250,15 @@ step 10.
 
 ### 10. Editor publishing
 
+**VS Code is published by CI, not here.** When the tag's CI run reaches the
+`publish-vsix-marketplace` job it pauses on the `marketplace-vscode`
+Environment for your approval. After the step 9 verification passes, approve
+that deployment in the Actions run and CI publishes VSCE keylessly via OIDC —
+no token, no `make publish-vsix`. Only if the CI federated path fails, fall
+back to the laptop: `az login --allow-no-subscriptions && make publish-vsix`.
+The targets below cover the remaining editors (JetBrains, Sublime, Zed),
+which still publish from the laptop.
+
 Before asking which editors to publish, run a readiness check so any
 missing token or unclaimed namespace surfaces *before* the user picks
 targets:
@@ -266,8 +275,11 @@ or skip that target.
 
 Then ask which editors to publish to using `AskUserQuestion`:
 
-> Which editors should be published? (All / None / comma-separated list of: vscode, jetbrains, sublime, zed)
+> Which editors should be published? (All / None / comma-separated list of: jetbrains, sublime, zed)
 > Default: None
+
+(VS Code is excluded — CI publishes it via the approval gate above. Only
+add `vscode` here if you are deliberately invoking the laptop fallback.)
 
 Based on the response:
 
@@ -276,8 +288,12 @@ Based on the response:
 - **Specific editors**: Run the corresponding `make publish-<editor>` targets.
 
 Available targets:
-- `make publish-vsix` — VS Code Marketplace. Runs `vsce publish`. Requires
-  a valid PAT for `bitwisecook` (interactive login otherwise).
+- `make publish-vsix` — VS Code Marketplace **laptop fallback only**
+  (normally CI publishes VSCE; see the note at the top of this step).
+  Keyless: needs an Azure Entra session (`az login --allow-no-subscriptions`)
+  and runs `vsce publish --azure-credential`. Set `VSCE_PAT` only to force
+  the legacy stored-PAT path (discouraged; Azure DevOps global PATs retire
+  2026-12-01).
 - `make publish-jetbrains` — JetBrains Marketplace. Runs
   `./gradlew publishPlugin`. Requires `JETBRAINS_TOKEN` env var. The
   first-ever publish must be done interactively via the JetBrains web

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -284,7 +284,11 @@ add `vscode` here if you are deliberately invoking the laptop fallback.)
 Based on the response:
 
 - **None** (default): Skip publishing entirely.
-- **All**: Run `make publish-all`.
+- **All**: Run the laptop editor targets **except VS Code** —
+  `make publish-jetbrains publish-sublime publish-zed`. Do **not** run
+  `make publish-all`: it includes `publish-vsix`, which would try to
+  re-publish the version CI already shipped (vsce errors on a duplicate
+  version without `--skip-duplicate`).
 - **Specific editors**: Run the corresponding `make publish-<editor>` targets.
 
 Available targets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -917,10 +917,14 @@ jobs:
   #
   # Gated by the `marketplace-vscode` Environment (required reviewer + a
   # v*-tag-only deployment policy), so it PAUSES for manual approval and can
-  # never run on a non-tag ref.  Minimal on purpose: it only downloads the
-  # already-built, already-signed .vsix and runs vsce — no source build, no
-  # project dep install — to keep the smallest possible surface around the
-  # federated session.
+  # never run on a non-tag ref.  Two deliberate hardening choices:
+  #   * vsce is installed from the COMMITTED lockfile BEFORE `azure/login`,
+  #     and the local binary is run AFTER — so no freshly-fetched npm code
+  #     ever executes while the marketplace-capable Azure session is live.
+  #   * the .vsix is pulled from the GitHub Release (which persists) and
+  #     checksum-verified against the cosign-signed SHA256SUMS — not from a
+  #     workflow artifact, which cleanup-*-artifacts could delete while this
+  #     job sits waiting for approval.
   #
   # Skipped until the Entra identity is configured (AZURE_CLIENT_ID /
   # AZURE_TENANT_ID repo *variables* — non-secret identifiers).  Nothing
@@ -932,14 +936,40 @@ jobs:
     environment: marketplace-vscode
     permissions:
       id-token: write # GitHub OIDC token for Entra federation
-      contents: read
+      contents: read # gh release download
     steps:
-      - name: Download the signed VSIX (built upstream)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      # --- Everything credential-free runs first, before azure/login ---
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          name: vsix
-          path: dist
+          fetch-depth: 1
 
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Enable Corepack (pin npm via packageManager)
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: corepack enable npm
+
+      - name: Install vsce from the committed lockfile (pre-auth)
+        run: cd editors/vscode && npm ci
+
+      - name: Download the released VSIX and verify against SHA256SUMS
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+          mkdir -p dist && cd dist
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+            --pattern '*.vsix' --pattern 'SHA256SUMS' --clobber
+          # --ignore-missing: SHA256SUMS lists every release asset; we only
+          # fetched the .vsix, so verify just that one (others are skipped).
+          sha256sum -c --ignore-missing SHA256SUMS
+
+      # --- Credential becomes live here; only the local vsce binary runs ---
       - name: Azure login (OIDC — no secret at rest)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
@@ -947,20 +977,12 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "24"
-
-      - name: Publish to VS Code Marketplace (keyless)
+      - name: Publish to VS Code Marketplace (keyless, local binary)
         run: |
           set -euo pipefail
-          vsix="$(find dist -name '*.vsix' | head -1)"
-          if [ -z "$vsix" ]; then
-            echo "::error::no .vsix found in the downloaded 'vsix' artifact"; exit 1
-          fi
+          vsix="$(ls dist/*.vsix)"
           echo "Publishing $vsix via vsce --azure-credential (no PAT)"
-          npx --yes @vscode/vsce@3.9.2 publish --azure-credential --packagePath "$vsix"
+          editors/vscode/node_modules/.bin/vsce publish --azure-credential --packagePath "$vsix"
 
   # Cleanup: delete workflow artifacts for all releases except the 3 most recent
   cleanup-old-artifacts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,6 +908,60 @@ jobs:
           gh release upload "${{ steps.tag.outputs.tag }}" dist/SHA256SUMS.cosign.bundle \
             --repo "${{ github.repository }}" --clobber
 
+  # Keyless VS Code Marketplace publish via GitHub OIDC -> Azure Entra
+  # workload-identity federation.  No marketplace PAT exists anywhere: the
+  # job exchanges GitHub's OIDC token for a short-lived Entra token at
+  # publish time (`vsce publish --azure-credential`).  This honours the
+  # AGENTS.md invariant (no long-lived publish secret in CI) — the keyless
+  # analogue of the sigstore signing used by publish-checksums above.
+  #
+  # Gated by the `marketplace-vscode` Environment (required reviewer + a
+  # v*-tag-only deployment policy), so it PAUSES for manual approval and can
+  # never run on a non-tag ref.  Minimal on purpose: it only downloads the
+  # already-built, already-signed .vsix and runs vsce — no source build, no
+  # project dep install — to keep the smallest possible surface around the
+  # federated session.
+  #
+  # Skipped until the Entra identity is configured (AZURE_CLIENT_ID /
+  # AZURE_TENANT_ID repo *variables* — non-secret identifiers).  Nothing
+  # depends on this job, so its manual-approval wait never blocks cleanup.
+  publish-vsix-marketplace:
+    if: startsWith(github.ref, 'refs/tags/v') && vars.AZURE_CLIENT_ID != '' && vars.AZURE_TENANT_ID != ''
+    needs: [build-vsix, publish-checksums]
+    runs-on: ubuntu-24.04
+    environment: marketplace-vscode
+    permissions:
+      id-token: write # GitHub OIDC token for Entra federation
+      contents: read
+    steps:
+      - name: Download the signed VSIX (built upstream)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vsix
+          path: dist
+
+      - name: Azure login (OIDC — no secret at rest)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Publish to VS Code Marketplace (keyless)
+        run: |
+          set -euo pipefail
+          vsix="$(find dist -name '*.vsix' | head -1)"
+          if [ -z "$vsix" ]; then
+            echo "::error::no .vsix found in the downloaded 'vsix' artifact"; exit 1
+          fi
+          echo "Publishing $vsix via vsce --azure-credential (no PAT)"
+          npx --yes @vscode/vsce@3.9.2 publish --azure-credential --packagePath "$vsix"
+
   # Cleanup: delete workflow artifacts for all releases except the 3 most recent
   cleanup-old-artifacts:
     if: always() && startsWith(github.ref, 'refs/tags/v')

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.11.1-2-gcc19a96a-dirty
-head=cc19a96ac269844c522ccadad8d43ac01bc8c33c
-date=2026-06-18T12:43:24Z
-fingerprint=fe350637ced596fabd9bbe9d0ce8cffc0ea35d5b190814043912cf8aa8e1aa30
+describe=v1.11.1-3-g0dfd4ac4-dirty
+head=0dfd4ac41d98c0a4fb6eae9765f996d6d1032e31
+date=2026-06-18T14:39:59Z
+fingerprint=3d3bc287dd82cffd37044bef78bb3e3d6bf4351be876213564054c18139bc012

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.11.1-2-g41b3354a-dirty
-head=41b3354afe1705d3ad3bf7775c60201174b45bb4
-date=2026-06-18T11:47:41Z
-fingerprint=f93c4105accc284d1475127e344c2d4d7df8a590688353e57cb21672fbe76ac4
+describe=v1.11.1-2-gcc19a96a-dirty
+head=cc19a96ac269844c522ccadad8d43ac01bc8c33c
+date=2026-06-18T12:43:24Z
+fingerprint=fe350637ced596fabd9bbe9d0ce8cffc0ea35d5b190814043912cf8aa8e1aa30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,16 +191,29 @@ for the full contract:
 2. **Helpers** — `scripts/{build,codegen,check,capture,release,install,zipapp-main,dev}/*`.
 3. **CI** — `.github/workflows/*.yml` (PR gate + tag-triggered
    artefact build → sign → attach to GitHub Release).
-4. **Publishing** — `make publish-*` from the maintainer's laptop,
-   never from CI.
+4. **Publishing** — `make publish-*` from the maintainer's laptop, except
+   VS Code Marketplace, which publishes from CI keylessly (OIDC) behind the
+   manually-approved `marketplace-vscode` Environment.
 
-**Invariant: no marketplace tokens go into CI.**  Every push to VS Code
-Marketplace / JetBrains Marketplace / Package Control / zed-industries
-extensions runs from the maintainer's laptop using credentials in
-local environment variables or the macOS Keychain.  CI uses only
-GitHub's built-in `github.token` + sigstore OIDC for attestations.
-Adding `secrets.VSCE_PAT` (or similar) to any workflow violates the
-contract.
+**Invariant: no long-lived publish *secret* in CI.**  CI may publish only
+with keyless, short-lived credentials it cannot leak — never a stored
+marketplace token.  Concretely:
+
+- **VS Code Marketplace** publishes *from CI* via GitHub OIDC → Azure Entra
+  workload-identity federation (`vsce publish --azure-credential`), gated by
+  the `marketplace-vscode` Environment (required reviewer + a `v*`-tag-only
+  deployment policy).  No PAT is stored anywhere; the federated token is
+  minted per run.  The laptop `make publish-vsix` stays as a keyless
+  fallback (`az login` + `--azure-credential`).
+- **JetBrains Marketplace / Package Control / zed-industries** have no OIDC
+  publishing path, so they still run from the maintainer's laptop using
+  credentials in local environment variables or the macOS Keychain — never
+  CI.
+- CI otherwise uses only GitHub's built-in `github.token` + sigstore OIDC
+  for attestations.
+
+Adding `secrets.VSCE_PAT`, `secrets.JETBRAINS_TOKEN`, or any other
+long-lived marketplace token to a workflow violates the contract.
 
 ## WASM command parity
 

--- a/Makefile
+++ b/Makefile
@@ -205,18 +205,27 @@ install: package-vsix ## Build and install the .vsix into VS Code
 	@echo "==> Installing VS Code extension"
 	$(VSCODE) --install-extension $(VSIX_FILE) --force
 
-publish-vsix: verify-test-slow-stamp package-vsix ## Publish the .vsix to the VS Code Marketplace
-	@echo "==> Verifying VS Code Marketplace credentials"
-	@if [ -n "$$VSCE_PAT" ]; then \
-		echo "    Using VSCE_PAT from environment (non-interactive)."; \
-	elif ! $(VSCE) verify-pat $(VSCE_PUBLISHER) 2>/dev/null; then \
-		echo "    No valid cached PAT for publisher '$(VSCE_PUBLISHER)' and"; \
-		echo "    VSCE_PAT is not set."; \
-		echo "    Launching interactive login (create a PAT at https://dev.azure.com if needed)..."; \
-		$(VSCE) login $(VSCE_PUBLISHER); \
-	fi
+publish-vsix: verify-test-slow-stamp package-vsix ## Publish the .vsix to the VS Code Marketplace (keyless; CI is the primary path)
 	@echo "==> Publishing $(VSIX_FILE) to VS Code Marketplace"
-	cd $(STAGE_DIR) && $(VSCE) publish --packagePath $(VSIX_FILE)
+	@# Releases normally publish VSCE from CI (keyless OIDC, behind the
+	@# marketplace-vscode Environment).  This laptop target is the fallback.
+	@# Primary fallback path is also keyless: an Azure Entra session via the
+	@# Azure CLI (`az login --allow-no-subscriptions`) feeds vsce's
+	@# DefaultAzureCredential through `--azure-credential` — no PAT at rest.
+	@# Set VSCE_PAT to force the legacy stored-PAT path (discouraged; Azure
+	@# DevOps global PATs retire 2026-12-01).
+	@if [ -n "$$VSCE_PAT" ]; then \
+		echo "    VSCE_PAT set — using the legacy stored PAT (override)."; \
+		cd $(STAGE_DIR) && $(VSCE) publish --packagePath $(VSIX_FILE); \
+	elif az account show >/dev/null 2>&1; then \
+		echo "    Keyless publish via Azure Entra (--azure-credential, no PAT)."; \
+		cd $(STAGE_DIR) && $(VSCE) publish --azure-credential --packagePath $(VSIX_FILE); \
+	else \
+		echo "    No Azure CLI session for keyless publishing."; \
+		echo "    Run:  az login --allow-no-subscriptions"; \
+		echo "    (or set VSCE_PAT to use the legacy stored-PAT path instead.)"; \
+		exit 1; \
+	fi
 
 $(VSIX_FILE): $(OUT_DIR)/extension.js $(PY_SRCS) $(EXT_DIR)/package.json $(EXT_DIR)/.vscodeignore $(LICENSE_SRC) $(README_SRC) $(SCREENSHOTS) $(BUILD_INFO) $(ROOT)scripts/build/zipapps.py $(ROOT)scripts/zipapp-main/lsp.py $(ROOT)scripts/install/filter_readme.py
 	@echo "==> Preparing VSIX staging directory"


### PR DESCRIPTION
W4 of the release-pipeline overhaul: move VSCE publishing into CI with **no stored token**, behind a human-approved gate. Honours the (reworded) AGENTS.md invariant.

## What changes
- **`ci.yml`** — new `publish-vsix-marketplace` job. Tag-triggered, `needs: [build-vsix, publish-checksums]`, `environment: marketplace-vscode`. It downloads the already-built/signed `.vsix`, does `azure/login` via **GitHub OIDC → Azure Entra workload-identity federation**, and runs `vsce publish --azure-credential`. No PAT anywhere — the federated token is minted per run (the keyless analogue of the sigstore signing already in `publish-checksums`). Minimal surface: no source build, no project dep install.
- **`AGENTS.md`** — invariant reworded from "no marketplace tokens in CI" to **"no long-lived publish *secret* in CI"**: keyless OIDC publishing is permitted. VSCE → CI; JetBrains/Sublime/Zed (no OIDC path) stay laptop-only.
- **`Makefile`** — `publish-vsix` laptop fallback is now keyless-first (`az login --allow-no-subscriptions` + `--azure-credential`); `VSCE_PAT` only as an explicit legacy override.
- **`SKILL.md`** step 10 — VSCE is published by CI behind the approval gate; the manual editor list is now JetBrains/Sublime/Zed.

## Safety / rollout
- The job is **guarded by `vars.AZURE_CLIENT_ID != ''`**, so it stays **dormant (skipped)** until the Entra identity + repo Variables are configured. This PR is safe to merge before the Azure setup is done.
- The `marketplace-vscode` Environment (required reviewer + `v*`-tag policy) is already created (W3), so the job pauses for manual approval — the human verify-then-publish gate is preserved.
- Action SHAs pinned: `azure/login` v3.0.0, `actions/download-artifact` v8.0.1.

## Remaining (maintainer, out of band)
1. Entra app registration + federated credential (subject `repo:bitwisecook/tcl-lsp:environment:marketplace-vscode`).
2. Grant that identity publish rights on the `bitwisecook` VS Marketplace publisher.
3. Set repo Variables `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` (non-secret identifiers).
4. Smoke-test with a throwaway pre-release tag before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)