### PR TITLE
Add e2e tests for control-flow RBS, when gating, and inlay hint independence

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=83f17932-dirty
-head=83f17932a5ad72199c5d614b864e6aa76720acb1
-date=2026-06-18T17:08:21Z
-fingerprint=d04440bf72c0cfd619a35088a2fa976a92a0ce26562ca601641f14f68155522c
+describe=b22b022-dirty
+head=b22b022419287ee5a23e99487bd10775f28d2992
+date=2026-06-18T18:48:49Z
+fingerprint=223ef0702accf344dd69374db57d675a7917792da0588f6c34d390aea02133b1

--- a/editors/vscode/src/test/inlayHints.test.ts
+++ b/editors/vscode/src/test/inlayHints.test.ts
@@ -140,4 +140,91 @@ suite("Inlay Hints", () => {
       await config.update("inlayParameterHints", original, vscode.ConfigurationTarget.Global);
     }
   });
+
+  // PR #643 split the single `inlayHints` toggle into two independent options.
+  // Enabling one must not turn on the other.
+  test("parameter hints enabled alone produce labels but no type hints", async () => {
+    const config = vscode.workspace.getConfiguration("tclLsp.features");
+    const origType = config.get<boolean>("inlayTypeHints", false);
+    const origParam = config.get<boolean>("inlayParameterHints", false);
+
+    try {
+      await config.update("inlayTypeHints", false, vscode.ConfigurationTarget.Global);
+      await config.update("inlayParameterHints", true, vscode.ConfigurationTarget.Global);
+
+      const doc = await vscode.workspace.openTextDocument({
+        language: "tcl",
+        content: "puts hello\n",
+      });
+      await vscode.window.showTextDocument(doc);
+
+      const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
+      let hints: vscode.InlayHint[] | undefined;
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        hints = (await vscode.commands.executeCommand(
+          "vscode.executeInlayHintProvider",
+          doc.uri,
+          fullRange,
+        )) as vscode.InlayHint[] | undefined;
+        if (hints && hints.some((h) => h.kind === vscode.InlayHintKind.Parameter)) {
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+
+      assert.ok(
+        hints && hints.some((h) => h.kind === vscode.InlayHintKind.Parameter),
+        "expected a parameter-kind hint with inlayParameterHints enabled",
+      );
+      assert.ok(
+        !hints!.some((h) => h.kind === vscode.InlayHintKind.Type),
+        "type hints must stay off when only inlayParameterHints is enabled",
+      );
+    } finally {
+      await config.update("inlayTypeHints", origType, vscode.ConfigurationTarget.Global);
+      await config.update("inlayParameterHints", origParam, vscode.ConfigurationTarget.Global);
+    }
+  });
+
+  test("type hints enabled alone emit no parameter labels", async () => {
+    const config = vscode.workspace.getConfiguration("tclLsp.features");
+    const origType = config.get<boolean>("inlayTypeHints", false);
+    const origParam = config.get<boolean>("inlayParameterHints", false);
+
+    try {
+      await config.update("inlayTypeHints", true, vscode.ConfigurationTarget.Global);
+      await config.update("inlayParameterHints", false, vscode.ConfigurationTarget.Global);
+
+      // A call site that WOULD carry a parameter label if those were on.
+      const doc = await vscode.workspace.openTextDocument({
+        language: "tcl",
+        content: "puts hello\n",
+      });
+      await vscode.window.showTextDocument(doc);
+
+      const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
+      // Give the server time to settle the config change, then sample.
+      let hints: vscode.InlayHint[] | undefined;
+      const deadline = Date.now() + 6_000;
+      while (Date.now() < deadline) {
+        hints = (await vscode.commands.executeCommand(
+          "vscode.executeInlayHintProvider",
+          doc.uri,
+          fullRange,
+        )) as vscode.InlayHint[] | undefined;
+        await new Promise((r) => setTimeout(r, 250));
+      }
+
+      if (hints) {
+        assert.ok(
+          !hints.some((h) => h.kind === vscode.InlayHintKind.Parameter),
+          "parameter labels must stay off when only inlayTypeHints is enabled",
+        );
+      }
+    } finally {
+      await config.update("inlayTypeHints", origType, vscode.ConfigurationTarget.Global);
+      await config.update("inlayParameterHints", origParam, vscode.ConfigurationTarget.Global);
+    }
+  });
 });

--- a/editors/vscode/src/test/inlayHints.test.ts
+++ b/editors/vscode/src/test/inlayHints.test.ts
@@ -152,9 +152,12 @@ suite("Inlay Hints", () => {
       await config.update("inlayTypeHints", false, vscode.ConfigurationTarget.Global);
       await config.update("inlayParameterHints", true, vscode.ConfigurationTarget.Global);
 
+      // `set x 42` would carry a `: int` Type-kind hint if type hints leaked
+      // on, so the no-Type assertion below is a real check; `puts hello`
+      // carries the `string:` parameter label.
       const doc = await vscode.workspace.openTextDocument({
         language: "tcl",
-        content: "puts hello\n",
+        content: "set x 42\nputs hello\n",
       });
       await vscode.window.showTextDocument(doc);
 
@@ -167,6 +170,7 @@ suite("Inlay Hints", () => {
           doc.uri,
           fullRange,
         )) as vscode.InlayHint[] | undefined;
+        // Stop as soon as the parameter hint (the readiness signal) lands.
         if (hints && hints.some((h) => h.kind === vscode.InlayHintKind.Parameter)) {
           break;
         }
@@ -196,32 +200,40 @@ suite("Inlay Hints", () => {
       await config.update("inlayTypeHints", true, vscode.ConfigurationTarget.Global);
       await config.update("inlayParameterHints", false, vscode.ConfigurationTarget.Global);
 
-      // A call site that WOULD carry a parameter label if those were on.
+      // `set x 42` carries the `: int` type hint (the readiness signal);
+      // `puts hello` WOULD carry the `string:` parameter label if those leaked
+      // on, so the no-Parameter assertion below is a real check.
       const doc = await vscode.workspace.openTextDocument({
         language: "tcl",
-        content: "puts hello\n",
+        content: "set x 42\nputs hello\n",
       });
       await vscode.window.showTextDocument(doc);
 
       const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(10, 0));
-      // Give the server time to settle the config change, then sample.
       let hints: vscode.InlayHint[] | undefined;
-      const deadline = Date.now() + 6_000;
+      const deadline = Date.now() + 10_000;
       while (Date.now() < deadline) {
         hints = (await vscode.commands.executeCommand(
           "vscode.executeInlayHintProvider",
           doc.uri,
           fullRange,
         )) as vscode.InlayHint[] | undefined;
+        // Stop as soon as the type hint lands rather than always burning the
+        // full deadline on redundant requests.
+        if (hints && hints.some((h) => h.kind === vscode.InlayHintKind.Type)) {
+          break;
+        }
         await new Promise((r) => setTimeout(r, 250));
       }
 
-      if (hints) {
-        assert.ok(
-          !hints.some((h) => h.kind === vscode.InlayHintKind.Parameter),
-          "parameter labels must stay off when only inlayTypeHints is enabled",
-        );
-      }
+      assert.ok(
+        hints && hints.some((h) => h.kind === vscode.InlayHintKind.Type),
+        "expected a type-kind hint with inlayTypeHints enabled",
+      );
+      assert.ok(
+        !hints!.some((h) => h.kind === vscode.InlayHintKind.Parameter),
+        "parameter labels must stay off when only inlayTypeHints is enabled",
+      );
     } finally {
       await config.update("inlayTypeHints", origType, vscode.ConfigurationTarget.Global);
       await config.update("inlayParameterHints", origParam, vscode.ConfigurationTarget.Global);

--- a/editors/vscode/src/test/precisionFalsePositives.test.ts
+++ b/editors/vscode/src/test/precisionFalsePositives.test.ts
@@ -119,6 +119,44 @@ suite("Single bare-variable body (FP-STY-14)", () => {
   });
 });
 
+// FP-RBS control-flow family (PR #634) — imprecise control-flow modelling.
+//
+// PR #634 fixed a family of false W210 (read-before-set) rooted in control-flow
+// modelling.  The fixture's silent cases are a `tailcall`-terminated branch
+// (line 3), a non-empty-literal `foreach` (line 7), and a `while 1` whose only
+// exit is a `break` (line 11) — none may fire W210.  The empty-literal
+// `foreach` (line 15) never runs its body, so `$y` is genuinely unset and MUST
+// fire W210 — that doubles as the marker that analysis ran.
+suite("Control-flow read-before-set (PR #634)", () => {
+  const docUri = getDocUri("controlFlowRbs.tcl");
+
+  test("empty-literal foreach read fires W210 (true case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W210"),
+    });
+    const w210Lines = linesWithCode(diags, "W210");
+    assert.ok(
+      w210Lines.includes(15),
+      `expected W210 on the empty foreach read (line 15); got [${w210Lines}]`,
+    );
+  });
+
+  test("tailcall / non-empty foreach / while-1-break stay silent (false case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W210"),
+    });
+    // None of the provably-defined reads on lines 3, 7, 11 may fire W210.
+    for (const ln of linesWithCode(diags, "W210")) {
+      assert.ok(
+        ![3, 7, 11].includes(ln),
+        `unexpected W210 on a provably-defined read (line ${ln})`,
+      );
+    }
+  });
+});
+
 // FP-STY-15 — `$` before a closing `"` is a literal regex end-anchor.
 //
 // Line 7 (`regexp -- "^foo$bar" $text`) has a genuine live `$bar` substitution

--- a/editors/vscode/src/test/semanticTokens.test.ts
+++ b/editors/vscode/src/test/semanticTokens.test.ts
@@ -2,6 +2,37 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDocUri, activate } from "./helper";
 
+interface DecodedToken {
+  line: number;
+  char: number;
+  length: number;
+  type: string;
+}
+
+/**
+ * Decode the LSP delta-encoded semantic-token stream into absolute tokens,
+ * mapping the numeric type index back to its legend name.
+ */
+function decodeTokens(
+  tokens: vscode.SemanticTokens,
+  legend: vscode.SemanticTokensLegend,
+): DecodedToken[] {
+  const out: DecodedToken[] = [];
+  let line = 0;
+  let char = 0;
+  for (let i = 0; i < tokens.data.length; i += 5) {
+    const [dLine, dChar, length, typeIdx] = tokens.data.slice(i, i + 5);
+    if (dLine) {
+      line += dLine;
+      char = dChar;
+    } else {
+      char += dChar;
+    }
+    out.push({ line, char, length, type: legend.tokenTypes[typeIdx] });
+  }
+  return out;
+}
+
 suite("Semantic Tokens", () => {
   const docUri = getDocUri("simple.tcl");
 
@@ -25,6 +56,47 @@ suite("Semantic Tokens", () => {
       result.data.length % 5,
       0,
       `Token data length should be a multiple of 5, got ${result.data.length}`,
+    );
+  });
+
+  // PR #643 (issue #637): structural keywords (`else`/`elseif`, and `try`'s
+  // `on`/`trap`/`finally`) sit at argument positions, not the command-name
+  // slot, and used to render as strings.  They must now emit as keyword
+  // semantic tokens, while a bareword built-in used as a plain argument
+  // (`dict set frame proc "x"`) stays a string.
+  test("structural keywords highlight as keywords, bareword builtin stays string", async () => {
+    const kwUri = getDocUri("structuralKeywords.tcl");
+    const doc = await activate(kwUri);
+
+    const tokens = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokens",
+      kwUri,
+    )) as vscode.SemanticTokens;
+    const legend = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokensLegend",
+      kwUri,
+    )) as vscode.SemanticTokensLegend;
+    assert.ok(tokens && legend, "expected semantic tokens and a legend");
+
+    const decoded = decodeTokens(tokens, legend);
+    const textOf = (t: DecodedToken): string =>
+      doc.lineAt(t.line).text.substring(t.char, t.char + t.length);
+
+    const keywordWords = new Set(decoded.filter((t) => t.type === "keyword").map(textOf));
+    for (const word of ["if", "elseif", "else", "try", "on", "finally"]) {
+      assert.ok(
+        keywordWords.has(word),
+        `expected '${word}' as a keyword token, got ${JSON.stringify([...keywordWords])}`,
+      );
+    }
+
+    // The `proc` on the `dict set frame proc "..."` line is a plain dict value.
+    const procTok = decoded.find((t) => textOf(t) === "proc");
+    assert.ok(procTok, "expected a token covering the bareword 'proc'");
+    assert.strictEqual(
+      procTok.type,
+      "string",
+      `bareword 'proc' argument must stay a string, got '${procTok.type}'`,
     );
   });
 });

--- a/editors/vscode/testFixture/controlFlowRbs.tcl
+++ b/editors/vscode/testFixture/controlFlowRbs.tcl
@@ -1,0 +1,17 @@
+# FP-RBS control-flow family (PR #634) — only the empty-foreach read fires.
+proc silent_tailcall {cond} {
+    if {$cond} { tailcall g } else { set r 1 }
+    return $r
+}
+proc silent_foreach {} {
+    foreach x {1 2 3} { set y $x }
+    puts $y
+}
+proc silent_while1 {} {
+    while 1 { set w 1; break }
+    puts $w
+}
+proc fires_empty_foreach {} {
+    foreach x {} { set y $x }
+    puts $y
+}

--- a/editors/vscode/testFixture/structuralKeywords.tcl
+++ b/editors/vscode/testFixture/structuralKeywords.tcl
@@ -1,0 +1,15 @@
+if 1 {
+ puts a
+} elseif 2 {
+ puts b
+} else {
+ puts c
+}
+try {
+ set x 1
+} on error {e} {
+ puts $e
+} finally {
+ puts d
+}
+dict set frame proc "asasdas asd"

--- a/tests/lsp_e2e/test_diagnostics_e2e.py
+++ b/tests/lsp_e2e/test_diagnostics_e2e.py
@@ -304,6 +304,186 @@ class TestDollarBeforeCloseQuoteW306:
         assert "W306" in _codes(lsp_server.open_ready(uri, 'regexp -- "^foo$bar" $text\n'))
 
 
+class TestControlFlowRBSFamilyE2E:
+    """W210 read-before-set, control-flow modelling family (PR #634).
+
+    PR #634 fixed a family of false W210s rooted in imprecise control-flow
+    modelling: loop bodies that provably run at least once, branches ended by a
+    terminator (``tailcall``), and opaque ``switch`` arms that cannot complete
+    normally.  The in-process precision battery is ``tests/test_fp_rbs.py``
+    (locked to real tclsh 9.0.3); these certify a representative slice reaches
+    the wire through the *server* pipeline, each as a matched
+    must-stay-silent / must-fire pair so a blanket suppression can't pass.
+    """
+
+    # -- tailcall ends straight-line flow (FP-RBS-13) ---------------------- #
+
+    def test_tailcall_terminated_branch_silent(self, lsp_server, uri_factory):
+        # ``tailcall g`` returns from the proc, so ``return $result`` is reached
+        # only via the else branch where ``result`` is set.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc f {cond} {
+                if {$cond} {
+                    tailcall g
+                } else {
+                    set result 1
+                }
+                return $result
+            }
+        """)
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_non_terminating_branch_still_fires(self, lsp_server, uri_factory):
+        # Replace the tailcall with a completing command → ``result`` is
+        # maybe-unset on the then-path, so W210 must fire.
+        uri = uri_factory()
+        src = textwrap.dedent("""\
+            proc f {cond} {
+                if {$cond} {
+                    puts hi
+                } else {
+                    set result 1
+                }
+                return $result
+            }
+        """)
+        diags = lsp_server.open_ready(uri, src)
+        assert "W210" in _codes(diags), _codes(diags)
+
+    # -- non-empty-literal foreach runs its body (FP-RBS-17) --------------- #
+
+    def test_foreach_non_empty_literal_silent(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc f {} {\n    foreach x {1 2 3} { set y $x }\n    puts $y\n}\n"
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_foreach_empty_literal_still_fires(self, lsp_server, uri_factory):
+        # An empty literal never runs the body → ``y`` is unset.
+        uri = uri_factory()
+        src = "proc f {} {\n    foreach x {} { set y $x }\n    puts $y\n}\n"
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))
+
+    # -- for whose condition is true on entry runs its body (FP-RBS-18) ---- #
+
+    def test_for_true_on_entry_silent(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc f {} {\n    for {set i 0} {$i < 3} {incr i} { set y $i }\n    puts $y\n}\n"
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_for_false_on_entry_still_fires(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc f {} {\n    for {set i 5} {$i < 3} {incr i} { set y $i }\n    puts $y\n}\n"
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))
+
+    # -- while 1 only exits via break, where the var is set (FP-RBS-16) ---- #
+
+    def test_while1_break_set_silent(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        src = "proc f {} {\n    while 1 { set y 1; break }\n    puts $y\n}\n"
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_normal_while_still_fires(self, lsp_server, uri_factory):
+        # A non-constant condition may run zero times → maybe-unset read.
+        uri = uri_factory()
+        src = "proc f {n} {\n    while {$n > 0} { set y 1; incr n -1 }\n    puts $y\n}\n"
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))
+
+    # -- opaque switch whose every arm exits is a terminator (FP-RBS-15) --- #
+
+    def test_all_arms_return_makes_trailing_read_unreachable(self, lsp_server, uri_factory):
+        # Every arm returns, so ``puts $y`` is unreachable dead code → no W210.
+        uri = uri_factory()
+        src = (
+            "proc f {x} {\n"
+            "    switch -glob -- $x { a* { return 1 } default { return 2 } }\n"
+            "    puts $y\n"
+            "}\n"
+        )
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_no_default_switch_falls_through_fires(self, lsp_server, uri_factory):
+        # Without a ``default`` an unmatched subject falls through to the read,
+        # so the switch is not a terminator and ``y`` is maybe-unset.
+        uri = uri_factory()
+        src = (
+            "proc f {x} {\n"
+            "    switch -glob -- $x { a* { return 1 } b* { return 2 } }\n"
+            "    puts $y\n"
+            "}\n"
+        )
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))
+
+    # -- opaque switch must-define excludes non-completing arms (FP-RBS-14) - #
+
+    def test_returning_arm_excluded_from_must_define(self, lsp_server, uri_factory):
+        # The ``a*`` arm returns before reaching ``puts $y``; the only path that
+        # does (default) sets ``y`` → definitely defined, no W210.
+        uri = uri_factory()
+        src = (
+            "proc f {x} {\n"
+            "    switch -glob -- $x { a* { return 0 } default { set y 2 } }\n"
+            "    puts $y\n"
+            "}\n"
+        )
+        assert "W210" not in _codes(lsp_server.open_ready(uri, src))
+
+    def test_break_arm_escaping_loop_still_fires(self, lsp_server, uri_factory):
+        # Codex regression on #634: ``break``/``continue`` are loop-jumps, not
+        # proc-exits, so a break arm does NOT define the other arm's var on the
+        # path that escapes the loop — ``y`` is maybe-unset, W210 must fire.
+        uri = uri_factory()
+        src = (
+            "proc f {} {\n"
+            "    foreach x {a} { switch -glob -- $x { a* { break } default { set y 1 } } }\n"
+            "    puts $y\n"
+            "}\n"
+        )
+        assert "W210" in _codes(lsp_server.open_ready(uri, src))
+
+
+class TestWhenBodyDialectGatingE2E:
+    """``when`` is an iRules-only builtin (PR #640).
+
+    Under plain Tcl it is an unknown would-be user command whose braced argument
+    is opaque *data*, not a handler script — so its body must not be analysed:
+    no W123 on a body command, no spurious W210 read-before-set.  (The iRules
+    side, where the body IS analysed, lives in ``test_irules_e2e.py``.)
+    """
+
+    def test_when_body_not_analysed_under_plain_tcl(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        diags = lsp_server.open_ready(uri, "when HTTP_REQUEST {\n    boguscmd $undefvar\n}\n")
+        # ``when`` itself is unknown under Tcl, but the opaque body must not be
+        # recursed into: no W123 naming the body command, no W210 on its var.
+        body_w123 = [
+            d
+            for d in diags
+            if str(d.get("code")) == "W123" and "boguscmd" in (d.get("message") or "")
+        ]
+        assert body_w123 == [], diags
+        assert "W210" not in _codes(diags), _codes(diags)
+
+
+class TestConstantStringConditionFoldE2E:
+    """I230 (always-true/false condition; alternate branch unreachable) now
+    folds ``==``/``!=`` on string operands, matching Tcl's polymorphic compare
+    (``expr {"foo" == "foo"}`` -> 1) — previously only the ``eq``/``ne``
+    spelling folded (PR #640)."""
+
+    def test_double_equals_string_condition_folds(self, lsp_server, uri_factory):
+        for op in ("==", "eq"):
+            uri = uri_factory()
+            src = f'set x foo\nif {{$x {op} "foo"}} {{ puts hi }}\n'
+            assert "I230" in _codes(lsp_server.open_ready(uri, src)), op
+
+    def test_bang_equals_string_condition_folds(self, lsp_server, uri_factory):
+        for op in ("!=", "ne"):
+            uri = uri_factory()
+            src = f'set x foo\nif {{$x {op} "foo"}} {{ puts hi }}\n'
+            assert "I230" in _codes(lsp_server.open_ready(uri, src)), op
+
+
 class TestDiagnosticsTrackEdits:
     def test_fixing_the_source_clears_the_diagnostic(self, lsp_server, uri_factory):
         uri = uri_factory()

--- a/tests/lsp_e2e/test_editor_features_e2e.py
+++ b/tests/lsp_e2e/test_editor_features_e2e.py
@@ -170,3 +170,71 @@ class TestInlayHintOptionalPositionals:
         assert "list:" in names, names
         assert "pattern:" in names, names
         assert not any(n in ("options:", "switches:") for n in names), names
+
+
+class TestInlayToggleIndependenceE2E:
+    """The single ``inlayHints`` toggle was split into two independent options,
+    both off by default (PR #643): ``inlayTypeHints`` (inferred variable types /
+    format specifiers) and ``inlayParameterHints`` (the verbose proc/method
+    parameter-name labels).  Enabling one must not turn on the other.
+
+    These drive the *shared* server through ``config_session`` (which settles on
+    the resolved config and restores it afterwards), so the default-off contract
+    the other suites rely on is left untouched.
+    """
+
+    def test_parameter_hints_only_produce_labels_no_type_hints(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        with lsp_server.config_session(
+            {"features": {"inlayTypeHints": False, "inlayParameterHints": True}},
+            settle=lambda c: (
+                c["features"].get("inlayParameterHints") is True
+                and c["features"].get("inlayTypeHints") is False
+            ),
+            settle_uri=uri,
+        ):
+            lsp_server.open_ready(uri, "puts hello\n")
+            hints = lsp_server.inlay_hints(uri, (0, 0), (1, 0)) or []
+            # ``puts hello`` yields the ``string:`` parameter label …
+            assert any(h.get("kind") == 2 for h in hints), hints  # Parameter
+            # … and no Type-kind hints, since parameter hints are independent.
+            assert all(h.get("kind") != 1 for h in hints), hints  # Type
+
+    def test_type_hints_only_emit_no_parameter_labels(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        with lsp_server.config_session(
+            {"features": {"inlayTypeHints": True, "inlayParameterHints": False}},
+            settle=lambda c: (
+                c["features"].get("inlayTypeHints") is True
+                and c["features"].get("inlayParameterHints") is False
+            ),
+            settle_uri=uri,
+        ):
+            lsp_server.open_ready(uri, "puts hello\n")
+            hints = lsp_server.inlay_hints(uri, (0, 0), (1, 0)) or []
+            # Type hints on, parameter hints off: the ``string:`` label must
+            # never appear even though the call site would carry one.
+            assert all(h.get("kind") != 2 for h in hints), hints  # no Parameter
+
+
+class TestInlayLegacyAliasE2E:
+    """The retired ``features.inlayHints`` key is accepted as a backward-
+    compatible alias that enables *type* hints only — parameter hints stay off
+    (PR #643), so an existing explicit opt-in keeps working after the rename.
+    """
+
+    def test_legacy_inlay_hints_alias_enables_type_only(self, lsp_server, uri_factory):
+        uri = uri_factory()
+        with lsp_server.config_session(
+            {"features": {"inlayHints": True}},
+            settle=lambda c: c["features"].get("inlayTypeHints") is True,
+            settle_uri=uri,
+        ):
+            eff = lsp_server.effective_config(uri)
+            # The alias resolves to type hints; parameter hints remain off.
+            assert eff["features"].get("inlayTypeHints") is True, eff["features"]
+            assert eff["features"].get("inlayParameterHints") is False, eff["features"]
+            # Behaviourally, the verbose parameter labels never appear.
+            lsp_server.open_ready(uri, "puts hello\n")
+            hints = lsp_server.inlay_hints(uri, (0, 0), (1, 0)) or []
+            assert all(h.get("kind") != 2 for h in hints), hints  # no Parameter

--- a/tests/lsp_e2e/test_editor_features_e2e.py
+++ b/tests/lsp_e2e/test_editor_features_e2e.py
@@ -193,12 +193,13 @@ class TestInlayToggleIndependenceE2E:
             ),
             settle_uri=uri,
         ):
-            lsp_server.open_ready(uri, "puts hello\n")
-            hints = lsp_server.inlay_hints(uri, (0, 0), (1, 0)) or []
-            # ``puts hello`` yields the ``string:`` parameter label …
-            assert any(h.get("kind") == 2 for h in hints), hints  # Parameter
-            # … and no Type-kind hints, since parameter hints are independent.
-            assert all(h.get("kind") != 1 for h in hints), hints  # Type
+            # ``set x 42`` would yield a Type-kind hint (``: int``) if type hints
+            # leaked on, so the no-Type assertion below is a real check, not a
+            # vacuous one; ``puts hello`` carries the ``string:`` parameter label.
+            lsp_server.open_ready(uri, "set x 42\nputs hello\n")
+            hints = lsp_server.inlay_hints(uri, (0, 0), (2, 0)) or []
+            assert any(h.get("kind") == 2 for h in hints), hints  # Parameter present
+            assert all(h.get("kind") != 1 for h in hints), hints  # no Type leaked in
 
     def test_type_hints_only_emit_no_parameter_labels(self, lsp_server, uri_factory):
         uri = uri_factory()
@@ -210,11 +211,12 @@ class TestInlayToggleIndependenceE2E:
             ),
             settle_uri=uri,
         ):
-            lsp_server.open_ready(uri, "puts hello\n")
-            hints = lsp_server.inlay_hints(uri, (0, 0), (1, 0)) or []
-            # Type hints on, parameter hints off: the ``string:`` label must
-            # never appear even though the call site would carry one.
-            assert all(h.get("kind") != 2 for h in hints), hints  # no Parameter
+            # ``set x 42`` carries the ``: int`` type hint; ``puts hello`` would
+            # carry the ``string:`` parameter label if parameter hints leaked on.
+            lsp_server.open_ready(uri, "set x 42\nputs hello\n")
+            hints = lsp_server.inlay_hints(uri, (0, 0), (2, 0)) or []
+            assert any(h.get("kind") == 1 for h in hints), hints  # Type present
+            assert all(h.get("kind") != 2 for h in hints), hints  # no Parameter leaked in
 
 
 class TestInlayLegacyAliasE2E:
@@ -234,7 +236,9 @@ class TestInlayLegacyAliasE2E:
             # The alias resolves to type hints; parameter hints remain off.
             assert eff["features"].get("inlayTypeHints") is True, eff["features"]
             assert eff["features"].get("inlayParameterHints") is False, eff["features"]
-            # Behaviourally, the verbose parameter labels never appear.
-            lsp_server.open_ready(uri, "puts hello\n")
-            hints = lsp_server.inlay_hints(uri, (0, 0), (1, 0)) or []
+            # Behaviourally the alias enables type hints (``set x 42`` -> a
+            # Type-kind hint) while the verbose parameter labels never appear.
+            lsp_server.open_ready(uri, "set x 42\nputs hello\n")
+            hints = lsp_server.inlay_hints(uri, (0, 0), (2, 0)) or []
+            assert any(h.get("kind") == 1 for h in hints), hints  # Type present
             assert all(h.get("kind") != 2 for h in hints), hints  # no Parameter

--- a/tests/lsp_e2e/test_irules_e2e.py
+++ b/tests/lsp_e2e/test_irules_e2e.py
@@ -607,3 +607,25 @@ class TestIrulesTaintDiagnostics:
             language_id="tcl-irule",
         )
         assert "IRULE3102" not in _irules_codes(diags), _irules_codes(diags)
+
+
+class TestIrulesWhenBodyAnalysed:
+    """Dialect-gated ``when`` body recursion (PR #640), iRules side.
+
+    Under ``f5-irules`` ``when`` IS a recognised builtin whose braced argument
+    is a handler *script*, so its body is analysed and a read-before-set inside
+    it fires W210.  This is the positive counterpart to
+    ``test_when_body_not_analysed_under_plain_tcl`` in ``test_diagnostics_e2e``
+    — the same source stays opaque (no W210) under plain Tcl.
+    """
+
+    def test_when_body_is_analysed_under_irules(self, lsp_server_irules, uri_factory):
+        uri = uri_factory("irule")
+        diags = lsp_server_irules.open_ready(
+            uri,
+            "when HTTP_REQUEST {\n    set y $undefvar\n}\n",
+            language_id="tcl-irule",
+        )
+        # The W210 on the never-set ``undefvar`` read proves the braced body was
+        # recursed into as a script (under plain Tcl it would be opaque data).
+        assert "W210" in _irules_codes(diags), _irules_codes(diags)

--- a/tests/lsp_e2e/test_semantic_tokens_e2e.py
+++ b/tests/lsp_e2e/test_semantic_tokens_e2e.py
@@ -202,6 +202,59 @@ class TestCoreTokens:
         assert any(t["type"] == "variable" for t in tokens)
 
 
+def _covered(source: str, tok: dict) -> str:
+    """The source text a decoded token covers (single-line tokens only)."""
+    line = source.split("\n")[tok["line"]]
+    return line[tok["char"] : tok["char"] + tok["length"]]
+
+
+class TestStructuralKeywords:
+    """``else``/``elseif`` and ``try``'s ``on``/``trap``/``finally`` are
+    structural keywords that sit at *argument* positions, not the command-name
+    slot — so they used to render as strings.  PR #643 (issue #637) marks them
+    ``ArgRole.KEYWORD`` and emits keyword semantic tokens; a bareword built-in
+    used as a plain argument stays a string.  These pin that contract through
+    the packaged server (the Rust port must match), porting the unit cases in
+    ``tests/test_semantic_tokens.py``.
+    """
+
+    def _keyword_words(self, lsp_server, legend, uri, source):
+        return {
+            _covered(source, t) for t in _typed(lsp_server, legend, uri) if t["type"] == "keyword"
+        }
+
+    def test_if_else_elseif_are_keywords(self, lsp_server, uri_factory, legend):
+        source = "if 1 {\n puts a\n} elseif 2 {\n puts b\n} else {\n puts c\n}\n"
+        uri = _open(lsp_server, uri_factory, source)
+        words = self._keyword_words(lsp_server, legend, uri, source)
+        assert {"if", "elseif", "else"} <= words, words
+
+    def test_try_on_finally_are_keywords(self, lsp_server, uri_factory, legend):
+        source = "try {\n set x 1\n} on error {e} {\n puts $e\n} finally {\n puts d\n}\n"
+        uri = _open(lsp_server, uri_factory, source)
+        words = self._keyword_words(lsp_server, legend, uri, source)
+        assert {"try", "on", "finally"} <= words, words
+
+    def test_builtin_name_as_bareword_arg_is_string(self, lsp_server, uri_factory, legend):
+        # ``proc`` here is a plain dict value, not the command-definition
+        # keyword — it must stay a string (the bareword-builtin glitch #637).
+        source = 'dict set frame proc "asasdas asd"\n'
+        uri = _open(lsp_server, uri_factory, source)
+        proc_tok = next(t for t in _typed(lsp_server, legend, uri) if _covered(source, t) == "proc")
+        assert proc_tok["type"] == "string", proc_tok
+
+    def test_quoted_structural_keyword_offsets_past_quote(self, lsp_server, uri_factory, legend):
+        # A quoted ``"else"`` is an ESC-token word whose start sits on the
+        # opening quote; PR #643 emits the keyword from the content base so the
+        # range covers ``else``, not ``"els``.
+        source = 'if 0 {} "else" {puts ok}\n'
+        uri = _open(lsp_server, uri_factory, source)
+        kw = next(
+            t for t in _typed(lsp_server, legend, uri) if t["type"] == "keyword" and t["char"] >= 8
+        )
+        assert _covered(source, kw) == "else", (kw, _covered(source, kw))
+
+
 _RE_TYPES = {
     "regexp",
     "regexpAnchor",


### PR DESCRIPTION
## Summary

This PR adds comprehensive end-to-end test coverage for three recent fixes:

1. **Control-flow read-before-set (PR #634)**: Tests for improved precision in detecting uninitialized variable reads by modeling:
   - `tailcall`-terminated branches that provably exit
   - Non-empty-literal `foreach` loops that run at least once
   - `for` loops with true conditions on entry
   - `while 1` loops that only exit via `break`
   - Opaque `switch` statements where all arms are terminators or exclude non-completing paths

2. **Dialect-gated `when` body analysis (PR #640)**: Tests verifying that:
   - Under plain Tcl, `when` is treated as an unknown command with opaque data (no body analysis)
   - Under iRules, `when` is a recognized builtin whose body is analyzed for diagnostics

3. **Constant string condition folding (PR #640)**: Tests confirming that `==`/`!=` operators now fold on string operands, matching Tcl's polymorphic comparison semantics (previously only `eq`/`ne` folded).

4. **Inlay hint independence (PR #643)**: Tests ensuring the split of `inlayHints` into two independent toggles (`inlayTypeHints` and `inlayParameterHints`) works correctly:
   - Enabling parameter hints alone produces labels but no type hints
   - Enabling type hints alone emits no parameter labels
   - Legacy `inlayHints` alias enables type hints only

5. **Structural keyword semantic tokens (PR #643)**: Tests verifying that `else`/`elseif` and `try`'s `on`/`trap`/`finally` emit as keyword tokens when at argument positions, while bareword builtins used as plain arguments stay as strings.

## Validation

- Added 20+ new e2e test cases across Python (LSP server) and TypeScript (VS Code) test suites
- Added 2 new test fixture files (`controlFlowRbs.tcl`, `structuralKeywords.tcl`)
- All tests follow existing patterns and conventions in their respective test modules
- Tests are paired (must-fire / must-stay-silent) to prevent blanket suppressions from passing

https://claude.ai/code/session_01PduebyLC6NpSBT8QHYBGdC