### PR TITLE
Publish VS Code + JetBrains from CI behind protected environments

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -250,14 +250,15 @@ step 10.
 
 ### 10. Editor publishing
 
-**VS Code is published by CI, not here.** When the tag's CI run reaches the
-`publish-vsix-marketplace` job it pauses on the `marketplace-vscode`
-Environment for your approval. After the step 9 verification passes, approve
-that deployment in the Actions run and CI publishes VSCE keylessly via OIDC —
-no token, no `make publish-vsix`. Only if the CI federated path fails, fall
-back to the laptop: `az login --allow-no-subscriptions && make publish-vsix`.
-The targets below cover the remaining editors (JetBrains, Sublime, Zed),
-which still publish from the laptop.
+**VS Code and JetBrains are published by CI, not here.** When the tag's CI
+run reaches the `publish-vsix-marketplace` and `publish-jetbrains-marketplace`
+jobs, each pauses on its protected Environment (`marketplace-vscode` /
+`marketplace-jetbrains`) for your approval. After the step 9 verification
+passes, approve both deployments in the Actions run; CI then publishes the
+released, checksum-verified `.vsix` / plugin `.zip` using the Environment
+secret (`secrets.VSCE_PAT` / `secrets.JETBRAINS_TOKEN`). The laptop targets
+`make publish-vsix` / `make publish-jetbrains` remain only as fallbacks if
+the CI job fails. This step's own work is just **Sublime and Zed**.
 
 Before asking which editors to publish, run a readiness check so any
 missing token or unclaimed namespace surfaces *before* the user picks
@@ -269,26 +270,23 @@ make publish-verify
 
 `publish-verify` prints one of `[ok] / [warn] / [fail]` per editor; it
 exits non-zero only on `[fail]` (tool missing or remote unreachable).
-`[warn]` lines (e.g. `JETBRAINS_TOKEN not set`) are recoverable — note
-them back to the user and let them decide whether to set the token now
-or skip that target.
+`[warn]` lines are recoverable — note them back to the user.
 
 Then ask which editors to publish to using `AskUserQuestion`:
 
-> Which editors should be published? (All / None / comma-separated list of: jetbrains, sublime, zed)
+> Which editors should be published? (All / None / comma-separated list of: sublime, zed)
 > Default: None
 
-(VS Code is excluded — CI publishes it via the approval gate above. Only
-add `vscode` here if you are deliberately invoking the laptop fallback.)
+(VS Code and JetBrains are excluded — CI publishes both via the approval
+gates above. Only add `vscode` / `jetbrains` here if you are deliberately
+invoking the laptop fallback because a CI job failed.)
 
 Based on the response:
 
 - **None** (default): Skip publishing entirely.
-- **All**: Run the laptop editor targets **except VS Code** —
-  `make publish-jetbrains publish-sublime publish-zed`. Do **not** run
-  `make publish-all`: it includes `publish-vsix`, which would try to
-  re-publish the version CI already shipped (vsce errors on a duplicate
-  version without `--skip-duplicate`).
+- **All**: Run `make publish-sublime publish-zed`. Do **not** run
+  `make publish-all`: it includes `publish-vsix` and `publish-jetbrains`,
+  which would try to re-publish the versions CI already shipped.
 - **Specific editors**: Run the corresponding `make publish-<editor>` targets.
 
 Available targets:
@@ -298,10 +296,11 @@ Available targets:
   and runs `vsce publish --azure-credential`. Set `VSCE_PAT` only to force
   the legacy stored-PAT path (discouraged; Azure DevOps global PATs retire
   2026-12-01).
-- `make publish-jetbrains` — JetBrains Marketplace. Runs
-  `./gradlew publishPlugin`. Requires `JETBRAINS_TOKEN` env var. The
-  first-ever publish must be done interactively via the JetBrains web
-  UI; `publishPlugin` only updates an already-listed plugin.
+- `make publish-jetbrains` — JetBrains Marketplace **laptop fallback only**
+  (normally CI publishes it). Runs `./gradlew publishPlugin`. Requires
+  `JETBRAINS_TOKEN` env var. The first-ever publish must be done
+  interactively via the JetBrains web UI; `publishPlugin` only updates an
+  already-listed plugin.
 - `make publish-sublime` — Sublime Text / Package Control. Pushes the
   built `build/sublime-stage/` tree (the same contents that go into the
   `.sublime-package`) to the dedicated mirror repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -951,7 +951,12 @@ jobs:
       - name: Install vsce from the committed lockfile
         run: cd editors/vscode && npm ci
 
-      - name: Download the released VSIX and verify against SHA256SUMS
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.6.3'
+
+      - name: Download the released VSIX and verify against the signed SHA256SUMS
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -959,7 +964,20 @@ jobs:
           tag="${GITHUB_REF#refs/tags/}"
           mkdir -p dist && cd dist
           gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-            --pattern '*.vsix' --pattern 'SHA256SUMS' --clobber
+            --pattern '*.vsix' --pattern 'SHA256SUMS' \
+            --pattern 'SHA256SUMS.cosign.bundle' --clobber
+          # Verify SHA256SUMS is the manifest publish-checksums actually signed
+          # (keyless OIDC) BEFORE trusting any hash in it.  The Release stays
+          # mutable while this job waits for approval, so an actor with
+          # release-write could otherwise swap the .vsix AND SHA256SUMS as a
+          # self-consistent pair and pass a bare `sha256sum -c`.  Pinning the
+          # cosign identity to this repo's ci.yml on a v* tag makes that swap
+          # detectable.
+          cosign verify-blob \
+            --bundle SHA256SUMS.cosign.bundle \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github\.com/bitwisecook/tcl-lsp/\.github/workflows/ci\.yml@refs/tags/v' \
+            SHA256SUMS
           # --ignore-missing: SHA256SUMS lists every release asset; we only
           # fetched the .vsix, so verify just that one (others are skipped).
           sha256sum -c --ignore-missing SHA256SUMS
@@ -993,7 +1011,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Download the released plugin and verify against SHA256SUMS
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.6.3'
+
+      - name: Download the released plugin and verify against the signed SHA256SUMS
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1001,7 +1024,18 @@ jobs:
           tag="${GITHUB_REF#refs/tags/}"
           mkdir -p dist && cd dist
           gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-            --pattern 'tcl-lsp-jetbrains-*.zip' --pattern 'SHA256SUMS' --clobber
+            --pattern 'tcl-lsp-jetbrains-*.zip' --pattern 'SHA256SUMS' \
+            --pattern 'SHA256SUMS.cosign.bundle' --clobber
+          # Verify SHA256SUMS is the manifest publish-checksums actually signed
+          # (keyless OIDC) BEFORE trusting any hash in it — the Release is
+          # mutable during the approval wait, so a bare `sha256sum -c` would
+          # accept an attacker's self-consistent {zip, SHA256SUMS} swap.  The
+          # pinned cosign identity (this repo's ci.yml on a v* tag) closes that.
+          cosign verify-blob \
+            --bundle SHA256SUMS.cosign.bundle \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github\.com/bitwisecook/tcl-lsp/\.github/workflows/ci\.yml@refs/tags/v' \
+            SHA256SUMS
           sha256sum -c --ignore-missing SHA256SUMS
 
       - name: Publish to JetBrains Marketplace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,37 +908,32 @@ jobs:
           gh release upload "${{ steps.tag.outputs.tag }}" dist/SHA256SUMS.cosign.bundle \
             --repo "${{ github.repository }}" --clobber
 
-  # Keyless VS Code Marketplace publish via GitHub OIDC -> Azure Entra
-  # workload-identity federation.  No marketplace PAT exists anywhere: the
-  # job exchanges GitHub's OIDC token for a short-lived Entra token at
-  # publish time (`vsce publish --azure-credential`).  This honours the
-  # AGENTS.md invariant (no long-lived publish secret in CI) — the keyless
-  # analogue of the sigstore signing used by publish-checksums above.
-  #
-  # Gated by the `marketplace-vscode` Environment (required reviewer + a
-  # v*-tag-only deployment policy), so it PAUSES for manual approval and can
-  # never run on a non-tag ref.  Two deliberate hardening choices:
-  #   * vsce is installed from the COMMITTED lockfile BEFORE `azure/login`,
-  #     and the local binary is run AFTER — so no freshly-fetched npm code
-  #     ever executes while the marketplace-capable Azure session is live.
+  # VS Code Marketplace publish.  The publish token (VSCE_PAT) is an
+  # Environment secret on `marketplace-vscode` — a protected Environment
+  # (required reviewer + a v*-tag-only deployment policy).  Per the
+  # AGENTS.md invariant, a publish secret may live in CI only when it is
+  # stored this way: reachable solely by a job that targets the protected
+  # Environment, which PAUSES for manual approval and can never run on a
+  # non-tag ref.  Hardening choices preserved from the keyless design:
+  #   * VSCE_PAT is scoped to the publish step's `env:` only, so the
+  #     freshly-fetched npm code in `npm ci` never runs with the token in
+  #     its environment.
   #   * the .vsix is pulled from the GitHub Release (which persists) and
   #     checksum-verified against the cosign-signed SHA256SUMS — not from a
   #     workflow artifact, which cleanup-*-artifacts could delete while this
   #     job sits waiting for approval.
   #
-  # Skipped until the Entra identity is configured (AZURE_CLIENT_ID /
-  # AZURE_TENANT_ID repo *variables* — non-secret identifiers).  Nothing
-  # depends on this job, so its manual-approval wait never blocks cleanup.
+  # Gated off until PUBLISH_VSIX_MARKETPLACE is set (a non-secret flag
+  # variable), so forks/clones without the secret never reach the gate.
+  # Nothing depends on this job, so its approval wait never blocks cleanup.
   publish-vsix-marketplace:
-    if: startsWith(github.ref, 'refs/tags/v') && vars.AZURE_CLIENT_ID != '' && vars.AZURE_TENANT_ID != ''
+    if: startsWith(github.ref, 'refs/tags/v') && vars.PUBLISH_VSIX_MARKETPLACE == 'true'
     needs: [build-vsix, publish-checksums]
     runs-on: ubuntu-24.04
     environment: marketplace-vscode
     permissions:
-      id-token: write # GitHub OIDC token for Entra federation
       contents: read # gh release download
     steps:
-      # --- Everything credential-free runs first, before azure/login ---
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
@@ -953,7 +948,7 @@ jobs:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
         run: corepack enable npm
 
-      - name: Install vsce from the committed lockfile (pre-auth)
+      - name: Install vsce from the committed lockfile
         run: cd editors/vscode && npm ci
 
       - name: Download the released VSIX and verify against SHA256SUMS
@@ -969,20 +964,53 @@ jobs:
           # fetched the .vsix, so verify just that one (others are skipped).
           sha256sum -c --ignore-missing SHA256SUMS
 
-      # --- Credential becomes live here; only the local vsce binary runs ---
-      - name: Azure login (OIDC — no secret at rest)
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - name: Publish to VS Code Marketplace (keyless, local binary)
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           set -euo pipefail
           vsix="$(ls dist/*.vsix)"
-          echo "Publishing $vsix via vsce --azure-credential (no PAT)"
-          editors/vscode/node_modules/.bin/vsce publish --azure-credential --packagePath "$vsix"
+          echo "Publishing $vsix to the VS Code Marketplace"
+          editors/vscode/node_modules/.bin/vsce publish --packagePath "$vsix"
+
+  # JetBrains Marketplace publish.  Same protected-Environment pattern as
+  # the VSCE job above: JETBRAINS_TOKEN is an Environment secret on
+  # `marketplace-jetbrains` (required reviewer + v*-tag-only policy), scoped
+  # to the publish step's `env:` only.  Publishes the exact .zip attached to
+  # the Release (checksum-verified) via the Marketplace REST upload API —
+  # no Gradle/Java rebuild, so the published bytes match the signed release.
+  #
+  # Gated off until PUBLISH_JETBRAINS_MARKETPLACE is set.
+  publish-jetbrains-marketplace:
+    if: startsWith(github.ref, 'refs/tags/v') && vars.PUBLISH_JETBRAINS_MARKETPLACE == 'true'
+    needs: [build-jetbrains, publish-checksums]
+    runs-on: ubuntu-24.04
+    environment: marketplace-jetbrains
+    permissions:
+      contents: read # gh release download
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Download the released plugin and verify against SHA256SUMS
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+          mkdir -p dist && cd dist
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'tcl-lsp-jetbrains-*.zip' --pattern 'SHA256SUMS' --clobber
+          sha256sum -c --ignore-missing SHA256SUMS
+
+      - name: Publish to JetBrains Marketplace
+        env:
+          JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
+        run: |
+          set -euo pipefail
+          zip="$(ls dist/tcl-lsp-jetbrains-*.zip)"
+          bash scripts/release/publish_jetbrains_upload.sh "$zip"
 
   # Cleanup: delete workflow artifacts for all releases except the 3 most recent
   cleanup-old-artifacts:

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=d927d14-dirty
-head=d927d14f9256b1da098d8c1434912e5e8843880e
-date=2026-06-18T18:59:38Z
-fingerprint=52de0caabfdae1f347fdc567fac94e5882e1d382c74815183acf7329f5af8942
+describe=v1.11.2-1-gf77ac5ae1-dirty
+head=f77ac5ae1cdef704c04d6ff9f7cbd71ec434afea
+date=2026-06-18T22:52:43Z
+fingerprint=486c9df7582dc617b2d8a5994ea4648681c19ad1b0519a82e727e8b6adc3c712

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=v1.11.2-1-gf77ac5ae1-dirty
-head=f77ac5ae1cdef704c04d6ff9f7cbd71ec434afea
-date=2026-06-18T22:52:43Z
-fingerprint=486c9df7582dc617b2d8a5994ea4648681c19ad1b0519a82e727e8b6adc3c712
+describe=v1.11.2-2-g84b63beca-dirty
+head=84b63beca6be13d7a771c23ca5f2759c9eb52cc1
+date=2026-06-19T08:21:45Z
+fingerprint=923ab58fbacd9e4aa71a82609c64a6a52e0f7c7967f56d18d15c399445f33e95

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,29 +191,38 @@ for the full contract:
 2. **Helpers** — `scripts/{build,codegen,check,capture,release,install,zipapp-main,dev}/*`.
 3. **CI** — `.github/workflows/*.yml` (PR gate + tag-triggered
    artefact build → sign → attach to GitHub Release).
-4. **Publishing** — `make publish-*` from the maintainer's laptop, except
-   VS Code Marketplace, which publishes from CI keylessly (OIDC) behind the
-   manually-approved `marketplace-vscode` Environment.
+4. **Publishing** — VS Code and JetBrains publish *from CI* behind
+   manually-approved Environments; Package Control (Sublime) and Zed
+   publish from the maintainer's laptop (they need no token).
 
-**Invariant: no long-lived publish *secret* in CI.**  CI may publish only
-with keyless, short-lived credentials it cannot leak — never a stored
-marketplace token.  Concretely:
+**Invariant: a publish secret used in a workflow must be an Environment
+secret on a protected, manually-approved Environment.**  A marketplace
+token may live in CI only when it is stored as a GitHub *Environment*
+secret on an Environment with a required reviewer (and a `v*`-tag-only
+deployment policy) — never as a plain repo/org secret available to every
+workflow run.  Stored that way, the secret is reachable only by the one
+gated publish job that targets that Environment, which pauses for human
+approval and cannot run on a non-tag ref.  Concretely:
 
-- **VS Code Marketplace** publishes *from CI* via GitHub OIDC → Azure Entra
-  workload-identity federation (`vsce publish --azure-credential`), gated by
-  the `marketplace-vscode` Environment (required reviewer + a `v*`-tag-only
-  deployment policy).  No PAT is stored anywhere; the federated token is
-  minted per run.  The laptop `make publish-vsix` stays as a keyless
-  fallback (`az login` + `--azure-credential`).
-- **JetBrains Marketplace / Package Control / zed-industries** have no OIDC
-  publishing path, so they still run from the maintainer's laptop using
-  credentials in local environment variables or the macOS Keychain — never
-  CI.
+- **VS Code Marketplace** publishes from CI with `secrets.VSCE_PAT`, an
+  Environment secret on `marketplace-vscode` (required reviewer + a
+  `v*`-tag-only policy).  The token is scoped to the publish step's `env:`
+  so freshly-fetched npm code never runs with it in the environment.
+  `make publish-vsix` stays as a laptop fallback (keyless `az login`, or
+  `VSCE_PAT`).
+- **JetBrains Marketplace** publishes from CI with `secrets.JETBRAINS_TOKEN`,
+  an Environment secret on `marketplace-jetbrains` (same protections),
+  uploading the released, checksum-verified `.zip` via the Marketplace REST
+  API.  `make publish-jetbrains` stays as a laptop fallback.
+- **Package Control (Sublime)** and **zed-industries/extensions** need no
+  token — they publish by pushing to a maintainer-owned mirror / opening a
+  PR — so they stay laptop-only and never enter CI.
 - CI otherwise uses only GitHub's built-in `github.token` + sigstore OIDC
   for attestations.
 
-Adding `secrets.VSCE_PAT`, `secrets.JETBRAINS_TOKEN`, or any other
-long-lived marketplace token to a workflow violates the contract.
+A publish secret stored any other way — a plain repo secret, an org secret,
+or one reachable by a job with no protected `environment:` — violates the
+contract.
 
 ## WASM command parity
 

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: smoke-zipapps smoke-vsix
 # Packaging + publish + release
 .PHONY: build-editors build-editor-vsix verify-vsix install package-vsix publish-vsix
-.PHONY: build-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow
+.PHONY: build-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow check-publish-env
 .PHONY: release release-tag release-codeql-gate release-sums
 # Zig runtime + leak check
 .PHONY: build-runtime build-wasm-runtime build-runtime-leakcheck leakcheck leakcheck-diff snapshot-leak-baseline
@@ -205,12 +205,13 @@ install: package-vsix ## Build and install the .vsix into VS Code
 	@echo "==> Installing VS Code extension"
 	$(VSCODE) --install-extension $(VSIX_FILE) --force
 
-publish-vsix: verify-test-slow-stamp package-vsix ## Publish the .vsix to the VS Code Marketplace (keyless; CI is the primary path)
+publish-vsix: verify-test-slow-stamp package-vsix ## Publish the .vsix to the VS Code Marketplace (laptop fallback; CI is the primary path)
 	@echo "==> Publishing $(VSIX_FILE) to VS Code Marketplace"
-	@# Releases normally publish VSCE from CI (keyless OIDC, behind the
-	@# marketplace-vscode Environment).  This laptop target is the fallback.
-	@# Primary fallback path is also keyless: an Azure Entra session via the
-	@# Azure CLI (`az login --allow-no-subscriptions`) feeds vsce's
+	@# Releases normally publish VSCE from CI (job publish-vsix-marketplace,
+	@# secrets.VSCE_PAT on the protected marketplace-vscode Environment).
+	@# This laptop target is the fallback for when that CI job fails.
+	@# It prefers a keyless Azure Entra session via the Azure CLI
+	@# (`az login --allow-no-subscriptions`), feeding vsce's
 	@# DefaultAzureCredential through `--azure-credential` — no PAT at rest.
 	@# Set VSCE_PAT to force the legacy stored-PAT path (discouraged; Azure
 	@# DevOps global PATs retire 2026-12-01).
@@ -544,7 +545,7 @@ _ci-fast-pytest: $(UV_STAMP) $(ZIPAPP_LSP)
 # Python-only check phase for ci-fast (no TS lint/typecheck — those run in
 # test-slow locally and on push:main in GitHub Actions).  Uses the full
 # ruff/ty scope (lsp + core + explorer + tests + scripts) to match prep-pr.
-_ci-fast-checks: lint-py typecheck-py check-editor-settings check-wasm-parity
+_ci-fast-checks: lint-py typecheck-py check-editor-settings check-wasm-parity check-publish-env
 
 ci-fast: $(UV_STAMP) $(BUILD_INFO) ## Fast CI gate — lint + typecheck + LSP e2e (mirrors GitHub Actions PR job)
 	@$(MAKE) -j $(NPROC) _ci-fast-checks _ci-fast-pytest
@@ -1459,21 +1460,28 @@ publish-all: publish-vsix publish-jetbrains publish-sublime publish-zed ## Publi
 publish-verify: ## Sanity-check publishing readiness (credentials, tool versions, remote reach) without shipping
 	@bash $(ROOT)scripts/release/publish_verify.sh
 
+check-publish-env: ## Enforce that every workflow job using secrets.* binds to a protected environment
+	@python3 $(ROOT)scripts/release/check_publish_env.py
+
 publish-flow: ## Print the release + marketplace publish cheat-sheet
-	@echo "Release + publish flow — no marketplace tokens go into CI."
+	@echo "Release + publish flow."
 	@echo ""
 	@echo "  1. make publish-verify             # check that local credentials + tooling are ready"
 	@echo "  2. make release-tag V=X.Y.Z        # creates + pushes the annotated tag"
 	@echo "     # CI builds + signs + attaches every release artefact to the GitHub Release"
-	@echo "     # (sigstore OIDC, no marketplace tokens; see docs/design/contracts/release-and-publish.md)"
-	@echo "  3. wait for ci.yml to finish on the tag"
-	@echo "  4. make publish-all                # local; pushes each artefact to its marketplace"
+	@echo "     # then VS Code + JetBrains publish from CI behind the approval gate"
+	@echo "     # (see docs/design/contracts/release-and-publish.md)"
+	@echo "  3. wait for ci.yml to finish on the tag; approve the marketplace-vscode"
+	@echo "     and marketplace-jetbrains deployments when prompted"
+	@echo "  4. make publish-sublime publish-zed   # local; Sublime + Zed only"
 	@echo ""
-	@echo "  Individual marketplaces (each runs from your laptop, never from CI):"
-	@echo "    make publish-vsix         # VS Code Marketplace      (needs VSCE_PAT)"
-	@echo "    make publish-jetbrains    # JetBrains Marketplace    (needs JETBRAINS_TOKEN)"
-	@echo "    make publish-sublime      # Package Control (Sublime) (uses git push credentials)"
-	@echo "    make publish-zed          # zed-industries/extensions (preps a local PR for review)"
+	@echo "  Marketplaces:"
+	@echo "    VS Code    -> CI job publish-vsix-marketplace      (secrets.VSCE_PAT, marketplace-vscode)"
+	@echo "    JetBrains  -> CI job publish-jetbrains-marketplace (secrets.JETBRAINS_TOKEN, marketplace-jetbrains)"
+	@echo "    Sublime    -> make publish-sublime  (laptop; git push to mirror)"
+	@echo "    Zed        -> make publish-zed       (laptop; preps a local PR for review)"
+	@echo ""
+	@echo "  Laptop fallbacks for the CI marketplaces: make publish-vsix / publish-jetbrains"
 
 # KCS help database
 

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -3,33 +3,46 @@
 ## Symptom
 
 A new contributor opens the Makefile, sees `publish-vsix` next to a CI
-workflow that builds VSIX files, and assumes the publish step should
-move into CI ("isn't that what CI is for?").  Or someone adds a
-marketplace `secrets.VSCE_PAT` to CI in good faith, not realising the
-maintainer is deliberately keeping every marketplace credential off
-the GitHub Actions runner.
+workflow that builds VSIX files, and wonders where publishing actually
+happens.  Or someone adds a marketplace `secrets.VSCE_PAT` as a plain
+*repository* secret — available to every workflow run — not realising
+the maintainer requires every publish secret to be an **Environment**
+secret reachable only by a protected, manually-approved publish job.
 
 ## Invariant
 
-**No marketplace tokens go into CI.  Publishing to VS Code, JetBrains,
-Sublime, and Zed marketplaces always runs from the maintainer's
-laptop, using credentials that live in environment variables /
-keychain — never on a GitHub Actions runner.**
+**A publish secret used in a workflow must be a GitHub *Environment*
+secret on a protected, manually-approved Environment — never a plain
+repo/org secret available to every workflow run.**
+
+VS Code and JetBrains publish *from CI*; Package Control (Sublime) and
+Zed publish from the maintainer's laptop (they need no token — they push
+to a maintainer-owned mirror / open a PR).  A marketplace token may live
+in CI only when, stored as an Environment secret, it is reachable solely
+by the one job that targets that Environment — which has a required
+reviewer and a `v*`-tag-only deployment policy, so it pauses for human
+approval and cannot run on a non-tag ref.
 
 This is enforced by:
 
-* `grep -rE "secrets\.[A-Z_]+" .github/workflows/` returning nothing.
-* The publish targets (`make publish-vsix`, `make publish-jetbrains`,
-  `make publish-sublime`, `make publish-zed`) being defined only in
-  the Makefile, not in any GitHub Actions workflow.
-* Every marketplace SDK invocation living in `scripts/release/`,
-  invoked exclusively by `make publish-*` — never by `.github/workflows/`.
+* Every `secrets.*` reference in `.github/workflows/` appearing only
+  inside a job that declares a protected `environment:` (a required
+  reviewer + a `v*`-tag-only deployment policy).  A `secrets.*` use in a
+  job with no such `environment:` violates the contract.
+* The publish secret being an **Environment** secret (e.g. `VSCE_PAT` on
+  `marketplace-vscode`, `JETBRAINS_TOKEN` on `marketplace-jetbrains`),
+  not a repository or organisation secret.
+* The secret being scoped to the publish step's `env:` only, so
+  freshly-fetched code earlier in the job never runs with it in scope.
+* The published bytes being the exact artefact attached to the GitHub
+  Release (checksum-verified against the cosign-signed `SHA256SUMS`),
+  not a fresh rebuild.
 
-CI still does plenty: it builds release artefacts, attests them with
-sigstore (using GitHub's built-in OIDC — no token), generates SBOMs,
-and attaches everything to a GitHub Release.  But the last hop —
-pushing those artefacts to an external marketplace — is always a
-local action.
+CI still does plenty besides publishing: it builds release artefacts,
+attests them with sigstore (using GitHub's built-in OIDC — no token),
+generates SBOMs, and attaches everything to a GitHub Release.  The
+publish jobs then push those same signed artefacts to the marketplaces
+behind the approval gate.
 
 ## The four layers
 
@@ -59,13 +72,18 @@ local action.
 │   - create-release  + build-vsix + build-zipapp (matrix)     │
 │     + build-claude-skills + build-jetbrains + build-sublime  │
 │     + build-zed + publish-checksums       — tag-only         │
-│   - never holds a marketplace token                          │
+│   - publish-vsix-marketplace + publish-jetbrains-marketplace │
+│     publish from CI behind a protected Environment           │
 └─────────────┬────────────────────────────────────────────────┘
               ↓ produces signed artefacts that
-┌─ Publishing (local-only) ────────────────────────────────────┐
-│ make publish-* → scripts/release/publish_*.sh                │
-│   - reads tokens from local env / keychain                   │
-│   - pushes to marketplaces; CI never sees these              │
+┌─ Publishing ─────────────────────────────────────────────────┐
+│ CI (behind a protected, approval-gated Environment):         │
+│   - VS Code   → secrets.VSCE_PAT      on marketplace-vscode  │
+│   - JetBrains → secrets.JETBRAINS_TOKEN on marketplace-jetbrains │
+│ Laptop (no token needed):                                    │
+│   - make publish-sublime → push to the mirror repo           │
+│   - make publish-zed     → open a PR on zed-industries       │
+│ make publish-vsix / publish-jetbrains remain laptop fallbacks│
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -100,17 +118,22 @@ lines) checks every published-from-laptop credential and tool
 non-destructively — it never ships anything.  Designed for a quick
 pre-flight check the week before a planned release.
 
-## Marketplace token table
+## Marketplace credential table
 
-Each marketplace's credential lives in exactly one place on the
-maintainer's machine.  None of them exist in GitHub Actions secrets.
+VS Code and JetBrains publish from CI using an **Environment** secret on
+a protected, approval-gated Environment.  Sublime and Zed need no token.
+The laptop publish targets remain as fallbacks.
 
-| Marketplace | Local env var | Source on the laptop | Used by |
+| Marketplace | Primary path | Credential | Fallback |
 |---|---|---|---|
-| VS Code Marketplace | `VSCE_PAT` | `~/.vsce/keytar` cache, or interactively from `dev.azure.com` PAT | `make publish-vsix` |
-| JetBrains Marketplace | `JETBRAINS_TOKEN` | macOS Keychain via `scripts/release/jetbrains_token.sh` | `make publish-jetbrains` |
-| Package Control (Sublime) | (none; uses `git push` to a mirror repo) | `~/.ssh/` ssh keys | `make publish-sublime` |
-| Zed Extensions | (none; opens a local PR branch for the maintainer to review and push) | — | `make publish-zed` |
+| VS Code Marketplace | CI job `publish-vsix-marketplace` | `secrets.VSCE_PAT` (Environment secret on `marketplace-vscode`) | `make publish-vsix` (keyless `az login`, or local `VSCE_PAT`) |
+| JetBrains Marketplace | CI job `publish-jetbrains-marketplace` | `secrets.JETBRAINS_TOKEN` (Environment secret on `marketplace-jetbrains`) | `make publish-jetbrains` (token via Keychain / `jetbrains_token.sh`) |
+| Package Control (Sublime) | `make publish-sublime` (laptop) | none — `git push` to the mirror repo | — |
+| Zed Extensions | `make publish-zed` (laptop) | none — opens a local PR branch | — |
+
+Both CI publish jobs target a protected Environment (required reviewer +
+`v*`-tag-only deployment policy), so they pause for manual approval and
+the secret is reachable by no other job.
 
 ## What CI may do
 
@@ -122,20 +145,24 @@ maintainer's machine.  None of them exist in GitHub Actions secrets.
 * Attach everything to a GitHub Release with `gh release upload`
   (uses `github.token`).
 * Verify checksums with cosign keyless OIDC signing.
+* Publish VS Code / JetBrains to their marketplaces — but **only** from a
+  job that targets a protected, approval-gated Environment, using that
+  Environment's secret, publishing the Release's checksum-verified
+  artefact.
 
 ## What CI may NOT do
 
-* Push to any external marketplace (VS Code, JetBrains, Package
-  Control, zed-industries/extensions).
-* Hold any `secrets.VSCE_PAT`, `secrets.JETBRAINS_TOKEN`, or
-  similar.  These never enter the Actions runner.
+* Reference a marketplace `secrets.*` from a job that does **not** declare
+  a protected `environment:` (required reviewer + `v*`-tag-only policy).
+* Store a publish token as a plain **repository** or **organisation**
+  secret (available to every workflow), rather than an Environment secret.
+* Publish Sublime or Zed (they push to a mirror / open a PR — laptop-only).
 * Replicate logic that lives in `scripts/release/`.  CI is allowed
   to *invoke* `scripts/release/*.sh`, but not duplicate its body.
 
-If a future change requires CI to publish something for which CI
-would need a token, that's a design conversation, not a unilateral
-edit.  The "Add a marketplace token to CI" path is closed by design;
-opening it requires updating this contract and `AGENTS.md`.
+Changing which marketplaces publish from CI, or how their secrets are
+stored, is a design conversation: it requires updating this contract and
+`AGENTS.md` together.
 
 ## File-path anchors
 
@@ -143,8 +170,12 @@ opening it requires updating this contract and `AGENTS.md`.
   `publish-sublime`, `publish-zed`, `publish-all`, `publish-verify`,
   `publish-flow`, `release-tag`, `release-codeql-gate`.
 - [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml) —
-  builds artefacts, attests them, attaches them to the Release.  No
-  `secrets.*` references.
+  builds artefacts, attests them, attaches them to the Release, and runs
+  the two marketplace publish jobs.  Every `secrets.*` reference sits in a
+  job that declares a protected `environment:`.
+- [`scripts/release/publish_jetbrains_upload.sh`](../../../scripts/release/publish_jetbrains_upload.sh) —
+  uploads the released JetBrains `.zip` to the Marketplace REST API
+  (invoked by the CI publish job; reuses `jetbrains_token.sh`).
 - [`.github/actions/setup-build/action.yml`](../../../.github/actions/setup-build/action.yml)
   and [`.github/actions/sign-and-upload/action.yml`](../../../.github/actions/sign-and-upload/action.yml) —
   composite actions for the CI build/sign tail.
@@ -155,17 +186,18 @@ opening it requires updating this contract and `AGENTS.md`.
 
 ## Test anchors
 
-The invariant is machine-verifiable:
+The invariant is machine-verifiable.  Every job that references a
+marketplace `secrets.*` must declare a protected `environment:`:
 
 ```bash
-# No marketplace secrets in CI:
-! grep -rE "secrets\.[A-Z_]+" .github/workflows/ \
-  || (echo "FAIL: a marketplace secret leaked into CI" && exit 1)
+# Each workflow job that uses secrets.VSCE_PAT / secrets.JETBRAINS_TOKEN
+# must bind to an Environment (manual gate).  scripts/release/check_publish_env.py
+# parses ci.yml and fails if any such job lacks an `environment:` key.
+python3 scripts/release/check_publish_env.py
 
-# Every marketplace push happens from a make publish-* target:
-grep -rln "publish-vsix\|publish-jetbrains\|publish-sublime\|publish-zed" \
-  .github/workflows/ | grep -v "scripts/release" \
-  && echo "FAIL: CI workflow invokes a publish target" && exit 1 || true
+# Sublime and Zed are never published from CI:
+! grep -rE "publish-sublime|publish-zed" .github/workflows/ \
+  || (echo "FAIL: Sublime/Zed must publish from the laptop" && exit 1)
 ```
 
 ## Discoverability

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, waitForDiagnostics } from "./helper";
+import { getDocUri, activate, waitForDiagnostics, pollUntil } from "./helper";
 
 suite("Code Actions", () => {
   const docUri = getDocUri("diagnostics.tcl");
@@ -18,10 +18,14 @@ suite("Code Actions", () => {
     assert.ok(w100, "W100 diagnostic should be present");
 
     // Request code actions at the W100 range
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      docUri,
-      w100.range,
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w100.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => a.kind && a.kind.value === vscode.CodeActionKind.QuickFix.value,
+        ),
+      { timeout: 10_000, label: "W100 quick fix" },
     )) as vscode.CodeAction[];
 
     assert.ok(actions, "Code actions should not be null");
@@ -45,10 +49,14 @@ suite("Code Actions", () => {
     });
     assert.ok(w304, "W304 diagnostic should be present");
 
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      docUri,
-      w304.range,
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w304.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.toLowerCase().includes("option terminator"),
+        ),
+      { timeout: 10_000, label: "W304 option terminator quick fix" },
     )) as vscode.CodeAction[];
 
     const quickFix = actions.find(
@@ -67,10 +75,17 @@ suite("Code Actions", () => {
     });
     assert.ok(w302, "W302 diagnostic should be present");
 
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      docUri,
-      w302.range,
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w302.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.includes("catch result variable"),
+        ) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.includes("result + options"),
+        ),
+      { timeout: 10_000, label: "W302 catch result quick fixes" },
     )) as vscode.CodeAction[];
 
     const resultFix = actions.find(
@@ -103,10 +118,22 @@ suite("Code Actions", () => {
     });
     assert.ok(irule1005, "IRULE1005 diagnostic should be present");
 
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      irulesDocUri,
-      irule1005.range,
+    const actions = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeCodeActionProvider",
+          irulesDocUri,
+          irule1005.range,
+        ),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) =>
+            typeof a.title === "string" &&
+            a.title.includes("collect") &&
+            a.title.includes("CLIENT_ACCEPTED"),
+        ),
+      { timeout: 10_000, label: "IRULE1005 collect bootstrap quick fix" },
     )) as vscode.CodeAction[];
 
     const collectFix = actions.find(

--- a/editors/vscode/src/test/codeLens.test.ts
+++ b/editors/vscode/src/test/codeLens.test.ts
@@ -1,20 +1,24 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { activate, getDocUri, sleep } from "./helper";
+import { activate, getDocUri, pollUntil } from "./helper";
 
 suite("Code Lens", () => {
   const docUri = getDocUri("procs.tcl");
 
   test("returns resolved lenses for each proc", async () => {
     await activate(docUri);
-    // Code lenses are populated asynchronously — give the provider a beat.
-    await sleep(500);
+    // Code lenses are populated asynchronously — poll until the server
+    // has published and resolved its first batch rather than racing on a
+    // fixed sleep.
     // executeCodeLensProvider's second argument is the number of lenses
     // to resolve; without it VS Code returns unresolved lenses (command=null).
-    const lenses = (await vscode.commands.executeCommand(
-      "vscode.executeCodeLensProvider",
-      docUri,
-      100,
+    const lenses = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", docUri, 100),
+      (r) => {
+        const ls = r as vscode.CodeLens[] | undefined;
+        return !!ls && ls.filter((l) => l.command !== undefined).length >= 2;
+      },
+      { timeout: 10_000, label: "resolved code lenses" },
     )) as vscode.CodeLens[] | undefined;
 
     assert.ok(lenses, "codeLens result should not be null");
@@ -41,11 +45,21 @@ suite("Code Lens", () => {
   test("reference count matches resolution for forward and namespaced calls", async () => {
     const refsUri = getDocUri("codeLensRefs.tcl");
     await activate(refsUri);
-    await sleep(500);
-    const lenses = (await vscode.commands.executeCommand(
-      "vscode.executeCodeLensProvider",
-      refsUri,
-      100,
+    // Poll until the lenses for the proc-definition lines under test
+    // (1, 5, 8) have all resolved their reference-count titles.
+    const lenses = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
+      (r) => {
+        const ls = r as vscode.CodeLens[] | undefined;
+        if (!ls) return false;
+        const resolvedLines = new Set(
+          ls
+            .filter((l) => l.command && typeof l.command.title === "string")
+            .map((l) => l.range.start.line),
+        );
+        return [1, 5, 8].every((line) => resolvedLines.has(line));
+      },
+      { timeout: 10_000, label: "resolved code lenses for forward/namespaced calls" },
     )) as vscode.CodeLens[] | undefined;
     assert.ok(lenses, "codeLens result should not be null");
 

--- a/editors/vscode/src/test/completion.test.ts
+++ b/editors/vscode/src/test/completion.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
 
 suite("Completion", () => {
   const docUri = getDocUri("completion.tcl");
@@ -11,10 +11,20 @@ suite("Completion", () => {
     // Position at end of "put" on line 2 (0-indexed)
     const position = new vscode.Position(2, 3);
 
-    const result = (await vscode.commands.executeCommand(
-      "vscode.executeCompletionItemProvider",
-      docUri,
-      position,
+    const result = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand("vscode.executeCompletionItemProvider", docUri, position),
+      (r) => {
+        const list = r as vscode.CompletionList | undefined;
+        return (
+          !!list &&
+          list.items.length > 0 &&
+          list.items.some(
+            (item) => (typeof item.label === "string" ? item.label : item.label.label) === "puts",
+          )
+        );
+      },
+      { timeout: 10_000, label: "command completions" },
     )) as vscode.CompletionList;
 
     assert.ok(result, "Completion result should not be null");
@@ -40,10 +50,20 @@ suite("Completion", () => {
 
     const position = new vscode.Position(2, 3);
 
-    const result = (await vscode.commands.executeCommand(
-      "vscode.executeCompletionItemProvider",
-      docUri,
-      position,
+    const result = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand("vscode.executeCompletionItemProvider", docUri, position),
+      (r) => {
+        const list = r as vscode.CompletionList | undefined;
+        if (!list) return false;
+        const labels = list.items.map((item) =>
+          typeof item.label === "string" ? item.label : item.label.label,
+        );
+        return labels.some((l) =>
+          ["puts", "set", "proc", "if", "while", "for", "foreach"].includes(l),
+        );
+      },
+      { timeout: 10_000, label: "proc name completions" },
     )) as vscode.CompletionList;
 
     assert.ok(result, "Completion result should not be null");

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -112,10 +112,10 @@ suite("Configuration Settings", () => {
     await activate(docUri);
     const pos = new vscode.Position(1, 6);
 
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeHoverProvider",
-      docUri,
-      pos,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, pos),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "hover before disable (editor global)" },
     )) as vscode.Hover[];
     assert.ok(before && before.length > 0, "Hover should work with default editor globals");
 
@@ -124,10 +124,10 @@ suite("Configuration Settings", () => {
       await editorCfg.update("hover.enabled", false, undefined);
       await waitForFeatureToggle(docUri, "hover", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeHoverProvider",
-        docUri,
-        pos,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, pos),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "hover suppressed (editor global)" },
       )) as vscode.Hover[];
       assert.ok(
         !after || after.length === 0,
@@ -151,10 +151,10 @@ suite("Configuration Settings", () => {
       await featureCfg.update("hover", true, undefined);
       await waitForFeatureToggle(docUri, "hover", true);
 
-      const result = (await vscode.commands.executeCommand(
-        "vscode.executeHoverProvider",
-        docUri,
-        pos,
+      const result = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, pos),
+        (r) => Array.isArray(r) && r.length > 0,
+        { timeout: 10_000, label: "hover overrides editor global" },
       )) as vscode.Hover[];
       assert.ok(
         result && result.length > 0,
@@ -173,9 +173,10 @@ suite("Configuration Settings", () => {
     const docUri = getDocUri("folding.tcl");
     await activate(docUri);
 
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeFoldingRangeProvider",
-      docUri,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "folding before disable (editor global)" },
     )) as vscode.FoldingRange[];
     assert.ok(before && before.length > 0, "Folding should work with default editor globals");
 
@@ -184,9 +185,10 @@ suite("Configuration Settings", () => {
       await editorCfg.update("folding", false, undefined);
       await waitForFeatureToggle(docUri, "folding", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeFoldingRangeProvider",
-        docUri,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "folding suppressed (editor global)" },
       )) as vscode.FoldingRange[];
       assert.ok(
         !after || after.length === 0,
@@ -222,10 +224,10 @@ suite("Configuration Settings", () => {
       await editorCfg.update("codeLens", false, undefined);
       await waitForFeatureToggle(docUri, "codeLens", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeCodeLensProvider",
-        docUri,
-        100,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", docUri, 100),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "code lenses suppressed (editor global)" },
       )) as vscode.CodeLens[] | undefined;
       assert.ok(
         !after || after.length === 0,
@@ -280,9 +282,13 @@ suite("Configuration Settings", () => {
     const docUri = getDocUri("simple.tcl");
     await activate(docUri);
 
-    const before = (await vscode.commands.executeCommand(
-      "vscode.provideDocumentSemanticTokens",
-      docUri,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.provideDocumentSemanticTokens", docUri),
+      (r) => {
+        const t = r as vscode.SemanticTokens | undefined;
+        return !!t && t.data.length > 0;
+      },
+      { timeout: 10_000, label: "semantic tokens before disable (editor global)" },
     )) as vscode.SemanticTokens | undefined;
     assert.ok(
       before && before.data.length > 0,
@@ -294,9 +300,13 @@ suite("Configuration Settings", () => {
       await editorCfg.update("semanticHighlighting.enabled", false, undefined);
       await waitForFeatureToggle(docUri, "semanticTokens", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.provideDocumentSemanticTokens",
-        docUri,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.provideDocumentSemanticTokens", docUri),
+        (r) => {
+          const t = r as vscode.SemanticTokens | undefined;
+          return !t || t.data.length === 0;
+        },
+        { timeout: 10_000, label: "semantic tokens suppressed (editor global)" },
       )) as vscode.SemanticTokens | undefined;
       assert.ok(
         !after || after.data.length === 0,
@@ -628,10 +638,10 @@ suite("Configuration Settings", () => {
     const pos = new vscode.Position(1, 6);
 
     // Baseline: hover works with default (true)
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeHoverProvider",
-      docUri,
-      pos,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, pos),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "hover before disable (feature)" },
     )) as vscode.Hover[];
     assert.ok(before && before.length > 0, "Hover should return results by default");
 
@@ -640,10 +650,10 @@ suite("Configuration Settings", () => {
       await config.update("hover", false, undefined);
       await waitForFeatureToggle(docUri, "hover", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeHoverProvider",
-        docUri,
-        pos,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, pos),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "hover suppressed (feature)" },
       )) as vscode.Hover[];
       assert.ok(
         !after || after.length === 0,
@@ -665,10 +675,13 @@ suite("Configuration Settings", () => {
       typeof item.label === "string" ? item.label : item.label.label;
 
     // Baseline: our LSP provides Tcl command completions like "puts"
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeCompletionItemProvider",
-      docUri,
-      pos,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCompletionItemProvider", docUri, pos),
+      (r) => {
+        const list = r as vscode.CompletionList | undefined;
+        return !!list && list.items.some((i) => labelOf(i) === "puts");
+      },
+      { timeout: 10_000, label: "completion before disable (feature)" },
     )) as vscode.CompletionList;
     const hasPutsBefore = before.items.some((i) => labelOf(i) === "puts");
     assert.ok(hasPutsBefore, "LSP should provide 'puts' completion by default");
@@ -678,10 +691,16 @@ suite("Configuration Settings", () => {
       await config.update("completion", false, undefined);
       await waitForFeatureToggle(docUri, "completion", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeCompletionItemProvider",
-        docUri,
-        pos,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeCompletionItemProvider", docUri, pos),
+        (r) => {
+          const list = r as vscode.CompletionList | undefined;
+          return (
+            !!list &&
+            !list.items.find((i) => labelOf(i) === "puts" && (i.detail || i.documentation))
+          );
+        },
+        { timeout: 10_000, label: "completion suppressed (feature)" },
       )) as vscode.CompletionList;
       // VS Code may still provide word-based completions, but our LSP
       // command completions (like "puts" with detail/docs) should be gone.
@@ -700,9 +719,10 @@ suite("Configuration Settings", () => {
     await activate(docUri);
 
     // Baseline: our LSP provides rich proc symbols with children/detail
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeDocumentSymbolProvider",
-      docUri,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri),
+      (r) => Array.isArray(r) && (r as vscode.DocumentSymbol[]).some((s) => s.name === "fib"),
+      { timeout: 10_000, label: "document symbols before disable (feature)" },
     )) as vscode.DocumentSymbol[];
     const fibBefore = before.find((s) => s.name === "fib");
     assert.ok(fibBefore, "LSP should provide 'fib' symbol by default");
@@ -739,10 +759,10 @@ suite("Configuration Settings", () => {
     // "fib" call at line 16: puts "fib(10) = [fib 10]"
     const pos = new vscode.Position(16, 17);
 
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeDefinitionProvider",
-      docUri,
-      pos,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDefinitionProvider", docUri, pos),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "definition before disable (feature)" },
     )) as vscode.Location[];
     assert.ok(before && before.length > 0, "Definition should work by default");
 
@@ -751,10 +771,10 @@ suite("Configuration Settings", () => {
       await config.update("definition", false, undefined);
       await waitForFeatureToggle(docUri, "definition", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeDefinitionProvider",
-        docUri,
-        pos,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeDefinitionProvider", docUri, pos),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "definition suppressed (feature)" },
       )) as vscode.Location[];
       assert.ok(
         !after || after.length === 0,
@@ -772,10 +792,10 @@ suite("Configuration Settings", () => {
     // Position on "fib" proc definition at line 1
     const pos = new vscode.Position(1, 5);
 
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeReferenceProvider",
-      docUri,
-      pos,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeReferenceProvider", docUri, pos),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "references before disable (feature)" },
     )) as vscode.Location[];
     assert.ok(before && before.length > 0, "References should work by default");
 
@@ -784,10 +804,10 @@ suite("Configuration Settings", () => {
       await config.update("references", false, undefined);
       await waitForFeatureToggle(docUri, "references", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeReferenceProvider",
-        docUri,
-        pos,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeReferenceProvider", docUri, pos),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "references suppressed (feature)" },
       )) as vscode.Location[];
       assert.ok(
         !after || after.length === 0,
@@ -840,9 +860,10 @@ suite("Configuration Settings", () => {
     const docUri = getDocUri("folding.tcl");
     await activate(docUri);
 
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeFoldingRangeProvider",
-      docUri,
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "folding before disable (feature)" },
     )) as vscode.FoldingRange[];
     assert.ok(before && before.length > 0, "Folding should work by default");
 
@@ -851,9 +872,10 @@ suite("Configuration Settings", () => {
       await config.update("folding", false, undefined);
       await waitForFeatureToggle(docUri, "folding", false);
 
-      const after = (await vscode.commands.executeCommand(
-        "vscode.executeFoldingRangeProvider",
-        docUri,
+      const after = (await pollUntil(
+        () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+        (r) => !r || (Array.isArray(r) ? r.length === 0 : true),
+        { timeout: 10_000, label: "folding suppressed (feature)" },
       )) as vscode.FoldingRange[];
       assert.ok(
         !after || after.length === 0,
@@ -896,10 +918,10 @@ suite("Configuration Settings", () => {
     const pos = new vscode.Position(3, 8);
 
     // Baseline: our LSP provides nested selection ranges (proc body → proc → file)
-    const before = (await vscode.commands.executeCommand(
-      "vscode.executeSelectionRangeProvider",
-      docUri,
-      [pos],
+    const before = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeSelectionRangeProvider", docUri, [pos]),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "selection ranges before disable (feature)" },
     )) as vscode.SelectionRange[];
     assert.ok(before && before.length > 0, "Selection ranges should work by default");
     // Our provider returns deeply nested ranges (parent chain)

--- a/editors/vscode/src/test/definition.test.ts
+++ b/editors/vscode/src/test/definition.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
 
 suite("Go to Definition", () => {
   const docUri = getDocUri("procs.tcl");
@@ -17,10 +17,10 @@ suite("Go to Definition", () => {
     // puts "fib(10) = [fib 10]"  -- "fib" after [ is at col 17
     const position = new vscode.Position(16, 17);
 
-    const locations = (await vscode.commands.executeCommand(
-      "vscode.executeDefinitionProvider",
-      docUri,
-      position,
+    const locations = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDefinitionProvider", docUri, position),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "definition locations" },
     )) as vscode.Location[];
 
     assert.ok(locations, "Definition result should not be null");

--- a/editors/vscode/src/test/documentSymbols.test.ts
+++ b/editors/vscode/src/test/documentSymbols.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
 
 suite("Document Symbols", () => {
   const docUri = getDocUri("procs.tcl");
@@ -8,9 +8,15 @@ suite("Document Symbols", () => {
   test("returns document symbols for proc definitions", async () => {
     await activate(docUri);
 
-    const symbols = (await vscode.commands.executeCommand(
-      "vscode.executeDocumentSymbolProvider",
-      docUri,
+    const symbols = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri),
+      (r) => {
+        const syms = r as (vscode.DocumentSymbol[] | vscode.SymbolInformation[]) | undefined;
+        if (!syms || syms.length === 0) return false;
+        const names = syms.map((s) => s.name);
+        return names.some((n) => n.includes("fib")) && names.some((n) => n.includes("factorial"));
+      },
+      { timeout: 10_000, label: "document symbols for proc definitions" },
     )) as vscode.DocumentSymbol[] | vscode.SymbolInformation[];
 
     assert.ok(symbols, "Should return symbols");
@@ -30,9 +36,13 @@ suite("Document Symbols", () => {
   test("symbols have proper kinds", async () => {
     await activate(docUri);
 
-    const symbols = (await vscode.commands.executeCommand(
-      "vscode.executeDocumentSymbolProvider",
-      docUri,
+    const symbols = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri),
+      (r) => {
+        const syms = r as (vscode.DocumentSymbol[] | vscode.SymbolInformation[]) | undefined;
+        return !!syms && syms.length > 0;
+      },
+      { timeout: 10_000, label: "document symbols (kinds)" },
     )) as vscode.DocumentSymbol[] | vscode.SymbolInformation[];
 
     assert.ok(symbols && symbols.length > 0, "Should return symbols");
@@ -52,9 +62,13 @@ suite("Document Symbols", () => {
   test("symbols have valid ranges", async () => {
     await activate(docUri);
 
-    const symbols = (await vscode.commands.executeCommand(
-      "vscode.executeDocumentSymbolProvider",
-      docUri,
+    const symbols = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", docUri),
+      (r) => {
+        const syms = r as vscode.DocumentSymbol[] | undefined;
+        return !!syms && syms.length > 0;
+      },
+      { timeout: 10_000, label: "document symbols (ranges)" },
     )) as vscode.DocumentSymbol[];
 
     assert.ok(symbols && symbols.length > 0, "Should return symbols");

--- a/editors/vscode/src/test/foldingRanges.test.ts
+++ b/editors/vscode/src/test/foldingRanges.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
 
 suite("Folding Ranges", () => {
   const docUri = getDocUri("folding.tcl");
@@ -8,9 +8,10 @@ suite("Folding Ranges", () => {
   test("returns folding ranges for procs and namespaces", async () => {
     await activate(docUri);
 
-    const ranges = (await vscode.commands.executeCommand(
-      "vscode.executeFoldingRangeProvider",
-      docUri,
+    const ranges = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "folding ranges present" },
     )) as vscode.FoldingRange[];
 
     assert.ok(ranges, "Should return folding ranges");
@@ -20,9 +21,11 @@ suite("Folding Ranges", () => {
   test("proc body is foldable", async () => {
     await activate(docUri);
 
-    const ranges = (await vscode.commands.executeCommand(
-      "vscode.executeFoldingRangeProvider",
-      docUri,
+    const ranges = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+      (r) =>
+        Array.isArray(r) && (r as vscode.FoldingRange[]).some((fr) => fr.start <= 1 && fr.end >= 7),
+      { timeout: 10_000, label: "proc body foldable" },
     )) as vscode.FoldingRange[];
 
     assert.ok(ranges && ranges.length > 0, "Should have folding ranges");
@@ -35,9 +38,12 @@ suite("Folding Ranges", () => {
   test("namespace body is foldable", async () => {
     await activate(docUri);
 
-    const ranges = (await vscode.commands.executeCommand(
-      "vscode.executeFoldingRangeProvider",
-      docUri,
+    const ranges = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.FoldingRange[]).some((fr) => fr.start >= 10 && fr.end >= 13),
+      { timeout: 10_000, label: "namespace body foldable" },
     )) as vscode.FoldingRange[];
 
     assert.ok(ranges && ranges.length > 0, "Should have folding ranges");
@@ -50,9 +56,12 @@ suite("Folding Ranges", () => {
   test("backslash-continued command folds as one logical line (issue #541)", async () => {
     await activate(docUri);
 
-    const ranges = (await vscode.commands.executeCommand(
-      "vscode.executeFoldingRangeProvider",
-      docUri,
+    const ranges = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeFoldingRangeProvider", docUri),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.FoldingRange[]).some((fr) => fr.start === 17 && fr.end >= 19),
+      { timeout: 10_000, label: "backslash-continued command folds" },
     )) as vscode.FoldingRange[];
 
     assert.ok(ranges && ranges.length > 0, "Should have folding ranges");

--- a/editors/vscode/src/test/hover.test.ts
+++ b/editors/vscode/src/test/hover.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
 
 suite("Hover", () => {
   const docUri = getDocUri("procs.tcl");
@@ -14,10 +14,10 @@ suite("Hover", () => {
     // proc fib {n} {  -- "fib" starts at col 5
     const position = new vscode.Position(1, 6);
 
-    const hovers = (await vscode.commands.executeCommand(
-      "vscode.executeHoverProvider",
-      docUri,
-      position,
+    const hovers = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeHoverProvider", docUri, position),
+      (r) => Array.isArray(r) && r.length > 0,
+      { timeout: 10_000, label: "hover for proc call" },
     )) as vscode.Hover[];
 
     assert.ok(hovers, "Hover result should not be null");

--- a/editors/vscode/src/test/index.ts
+++ b/editors/vscode/src/test/index.ts
@@ -22,6 +22,30 @@ export async function run(): Promise<void> {
 
   const testsRoot = path.resolve(__dirname);
 
+  // The config tests write workspace settings via `config.update(key, value,
+  // undefined)`, which VS Code persists to the workspace fixture's
+  // `.vscode/settings.json`.  Even though each test restores the *value*, VS
+  // Code can rewrite the file with different whitespace/key-order than the
+  // committed bytes, and a failing test can leave it dirty — so the tracked
+  // fixture drifts.  That breaks `.test-slow.stamp` reproducibility (the
+  // stamp hashes every tracked file and CI checks it against a clean
+  // checkout).  Snapshot the exact bytes before the run and rewrite them
+  // after — restoring the file regardless of which test touched it or
+  // whether the run passed.
+  const fixtureSettings = path.resolve(__dirname, "../../testFixture/.vscode/settings.json");
+  const fixtureSnapshot = fs.existsSync(fixtureSettings) ? fs.readFileSync(fixtureSettings) : null;
+  const restoreFixtureSettings = () => {
+    if (fixtureSnapshot === null) return;
+    try {
+      if (!fs.readFileSync(fixtureSettings).equals(fixtureSnapshot)) {
+        fs.writeFileSync(fixtureSettings, fixtureSnapshot);
+      }
+    } catch {
+      // File was removed by a test — recreate it from the snapshot.
+      fs.writeFileSync(fixtureSettings, fixtureSnapshot);
+    }
+  };
+
   // The multiFolder/ subdirectory has its own runner (runMultiFolderTest)
   // because those tests need the .code-workspace fixture.  Skip them here.
   const files = await glob("**/*.test.js", {
@@ -35,6 +59,7 @@ export async function run(): Promise<void> {
 
   return new Promise<void>((resolve, reject) => {
     const runner = mocha.run((failures) => {
+      restoreFixtureSettings();
       if (failures > 0) {
         fs.mkdirSync(path.dirname(failureMarker), { recursive: true });
         fs.writeFileSync(failureMarker, JSON.stringify({ failures }) + "\n", "utf8");

--- a/editors/vscode/src/test/inlayHints.test.ts
+++ b/editors/vscode/src/test/inlayHints.test.ts
@@ -170,8 +170,14 @@ suite("Inlay Hints", () => {
           doc.uri,
           fullRange,
         )) as vscode.InlayHint[] | undefined;
-        // Stop as soon as the parameter hint (the readiness signal) lands.
-        if (hints && hints.some((h) => h.kind === vscode.InlayHintKind.Parameter)) {
+        // Wait for the *steady state* after both config changes propagate to
+        // the server: the parameter hint present AND the type hint gone.
+        // Breaking the moment a parameter hint appears would race the
+        // `inlayTypeHints=false` change — a previous test may have left type
+        // hints on, and they linger until the config update lands.
+        const hasParam = hints?.some((h) => h.kind === vscode.InlayHintKind.Parameter) ?? false;
+        const hasType = hints?.some((h) => h.kind === vscode.InlayHintKind.Type) ?? false;
+        if (hasParam && !hasType) {
           break;
         }
         await new Promise((r) => setTimeout(r, 250));
@@ -218,9 +224,13 @@ suite("Inlay Hints", () => {
           doc.uri,
           fullRange,
         )) as vscode.InlayHint[] | undefined;
-        // Stop as soon as the type hint lands rather than always burning the
-        // full deadline on redundant requests.
-        if (hints && hints.some((h) => h.kind === vscode.InlayHintKind.Type)) {
+        // Wait for the *steady state*: the type hint present AND parameter
+        // labels gone.  Breaking the moment a type hint appears would race
+        // the `inlayParameterHints=false` change — a previous test may have
+        // left parameter labels on until the config update propagates.
+        const hasType = hints?.some((h) => h.kind === vscode.InlayHintKind.Type) ?? false;
+        const hasParam = hints?.some((h) => h.kind === vscode.InlayHintKind.Parameter) ?? false;
+        if (hasType && !hasParam) {
           break;
         }
         await new Promise((r) => setTimeout(r, 250));

--- a/editors/vscode/src/test/references.test.ts
+++ b/editors/vscode/src/test/references.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate } from "./helper";
+import { getDocUri, activate, pollUntil } from "./helper";
 
 suite("Find References", () => {
   const docUri = getDocUri("procs.tcl");
@@ -12,10 +12,10 @@ suite("Find References", () => {
     // proc fib {n} {
     const position = new vscode.Position(1, 6);
 
-    const locations = (await vscode.commands.executeCommand(
-      "vscode.executeReferenceProvider",
-      docUri,
-      position,
+    const locations = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeReferenceProvider", docUri, position),
+      (r) => Array.isArray(r) && r.length >= 1,
+      { timeout: 10_000, label: "references for proc" },
     )) as vscode.Location[];
 
     assert.ok(locations, "References result should not be null");

--- a/editors/vscode/src/test/variableContexts.test.ts
+++ b/editors/vscode/src/test/variableContexts.test.ts
@@ -433,21 +433,20 @@ suite("Variable Completion: W215 unreachable-name diagnostic", () => {
       return code === "W216" && d.message.includes("scalar");
     });
     assert.ok(w216, "Expected a ${arr}(foo) W216 diagnostic in fixture");
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      docUri,
-      w216.range,
+    const matchesW216Fix = (a: vscode.CodeAction) =>
+      a.kind !== undefined &&
+      a.kind.value === vscode.CodeActionKind.QuickFix.value &&
+      ((typeof a.title === "string" && a.title.includes("$arr(name)")) ||
+        (a.edit !== undefined &&
+          [...a.edit.entries()].some(([, edits]) =>
+            edits.some((e) => e.newText === "$arr(name)"),
+          )));
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w216.range),
+      (r) => Array.isArray(r) && (r as vscode.CodeAction[]).some(matchesW216Fix),
+      { timeout: 10_000, label: "W216 bare-form quick fix" },
     )) as vscode.CodeAction[];
-    const w216Fix = actions.find(
-      (a) =>
-        a.kind !== undefined &&
-        a.kind.value === vscode.CodeActionKind.QuickFix.value &&
-        ((typeof a.title === "string" && a.title.includes("$arr(name)")) ||
-          (a.edit !== undefined &&
-            [...a.edit.entries()].some(([, edits]) =>
-              edits.some((e) => e.newText === "$arr(name)"),
-            ))),
-    );
+    const w216Fix = actions.find(matchesW216Fix);
     assert.ok(
       w216Fix,
       `Expected a W216 quick-fix offering $arr(name); got titles: ${actions.map((a) => a.title).join(" / ")}`,
@@ -466,20 +465,19 @@ suite("Variable Completion: W215 unreachable-name diagnostic", () => {
       return code === "W216" && d.message.includes("funny name");
     });
     assert.ok(w216, "Expected a W216 diagnostic for the funny-name fixture line");
-    const actions = (await vscode.commands.executeCommand(
-      "vscode.executeCodeActionProvider",
-      docUri,
-      w216.range,
-    )) as vscode.CodeAction[];
     const expected = '[set "funny name($foo)"]';
-    const fix = actions.find(
-      (a) =>
-        a.kind !== undefined &&
-        a.kind.value === vscode.CodeActionKind.QuickFix.value &&
-        ((typeof a.title === "string" && a.title.includes(expected)) ||
-          (a.edit !== undefined &&
-            [...a.edit.entries()].some(([, edits]) => edits.some((e) => e.newText === expected)))),
-    );
+    const matchesFix = (a: vscode.CodeAction) =>
+      a.kind !== undefined &&
+      a.kind.value === vscode.CodeActionKind.QuickFix.value &&
+      ((typeof a.title === "string" && a.title.includes(expected)) ||
+        (a.edit !== undefined &&
+          [...a.edit.entries()].some(([, edits]) => edits.some((e) => e.newText === expected))));
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, w216.range),
+      (r) => Array.isArray(r) && (r as vscode.CodeAction[]).some(matchesFix),
+      { timeout: 10_000, label: "W216 [set ...] fallback quick fix" },
+    )) as vscode.CodeAction[];
+    const fix = actions.find(matchesFix);
     assert.ok(
       fix,
       `Expected a W216 quick-fix offering ${expected}; got titles: ${actions

--- a/scripts/release/check_publish_env.py
+++ b/scripts/release/check_publish_env.py
@@ -6,13 +6,24 @@ a workflow job that references any ``secrets.*`` must bind to a protected,
 manually-approved ``environment:``.  That is what keeps a publish token
 reachable only by an approval-gated job — never by every workflow run.
 
+Two layers are enforced:
+
+  1. *Presence* — every secret-using job declares an ``environment:`` at all.
+  2. *Identity* — the known publish secrets bind to their **specific**
+     designated environment (``REQUIRED_ENV`` below), not merely to some
+     four-space ``environment:`` key.  Without this, a typo'd or arbitrary
+     environment name (which GitHub silently auto-creates as *unprotected*)
+     would satisfy layer 1 while defeating the gate, and a token could be
+     cross-wired to the wrong protected environment.
+
 This is a dependency-free, indentation-based scan of ``.github/workflows/``
 (the repo's Python env has no PyYAML).  It treats a two-space-indented key
-under ``jobs:`` as a job, and checks each job block for a ``secrets.``
-reference and an ``environment:`` key.
+under ``jobs:`` as a job, and inspects each job block for ``secrets.``
+references and the job's ``environment:`` binding (inline or ``name:`` block).
 
 Exit codes:
-  0  every secret-using job declares an environment
+  0  every secret-using job declares an environment, and every known publish
+     secret binds to its required environment
   1  a violation was found
 """
 
@@ -27,8 +38,15 @@ WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
 # A job header: exactly two spaces, then `name:` (jobs are 2-indented).
 JOB_RE = re.compile(r"^  (?P<name>[A-Za-z0-9_.-]+):\s*$")
 # `environment:` as a job key (4 spaces), value inline or as a block.
-ENV_RE = re.compile(r"^    environment:")
-SECRET_RE = re.compile(r"secrets\.[A-Za-z_][A-Za-z0-9_]*")
+ENV_RE = re.compile(r"^    environment:\s*(?P<inline>\S.*)?$")
+SECRET_RE = re.compile(r"secrets\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
+
+# The publish secrets that MUST bind to a specific protected Environment.
+# Keep in lockstep with the publish jobs in .github/workflows/ci.yml.
+REQUIRED_ENV = {
+    "VSCE_PAT": "marketplace-vscode",
+    "JETBRAINS_TOKEN": "marketplace-jetbrains",
+}
 
 
 def job_blocks(text: str):
@@ -60,6 +78,36 @@ def job_blocks(text: str):
         yield current, body
 
 
+def job_environment(body: list[str]) -> str | None:
+    """Return the environment name a job binds to, or None if it declares none.
+
+    Handles both the inline form ``environment: NAME`` and the block form::
+
+        environment:
+          name: NAME
+          url: ...
+    """
+    for i, line in enumerate(body):
+        m = ENV_RE.match(line)
+        if not m:
+            continue
+        inline = m.group("inline")
+        if inline:
+            return inline.strip().strip("'\"")
+        # Block form: scan the lines nested under `environment:` (indented
+        # deeper than its 4 spaces) for the `name:` key; stop at the dedent.
+        for nxt in body[i + 1 :]:
+            if not nxt.strip():
+                continue
+            if len(nxt) - len(nxt.lstrip(" ")) <= 4:
+                break
+            nm = re.match(r"\s*name:\s*(?P<name>\S+)", nxt)
+            if nm:
+                return nm.group("name").strip("'\"")
+        return None
+    return None
+
+
 def main() -> int:
     violations: list[str] = []
     checked = 0
@@ -71,13 +119,24 @@ def main() -> int:
             if not secrets:
                 continue
             checked += 1
-            has_env = any(ENV_RE.match(b) for b in body)
-            if not has_env:
+            env = job_environment(body)
+            if env is None:
                 violations.append(
                     f"{wf.name}: job '{name}' references {', '.join(secrets)} "
                     f"but declares no `environment:` (publish secrets must be "
                     f"gated by a protected Environment)"
                 )
+                continue
+            # Identity layer: any known publish secret must bind to its own
+            # designated environment, not just to *an* environment.
+            for secret in secrets:
+                want = REQUIRED_ENV.get(secret)
+                if want is not None and env != want:
+                    violations.append(
+                        f"{wf.name}: job '{name}' references {secret} but binds "
+                        f"to environment '{env}', not the required '{want}' "
+                        f"(a token must reach only its own protected Environment)"
+                    )
 
     if violations:
         print("FAIL: publish-secret invariant violated:", file=sys.stderr)
@@ -85,7 +144,10 @@ def main() -> int:
             print(f"  - {v}", file=sys.stderr)
         return 1
 
-    print(f"OK: {checked} secret-using job(s) all bind to an environment.")
+    print(
+        f"OK: {checked} secret-using job(s) all bind to an environment, "
+        f"and every known publish secret targets its required Environment."
+    )
     return 0
 
 

--- a/scripts/release/check_publish_env.py
+++ b/scripts/release/check_publish_env.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""check_publish_env.py — enforce the publish-secret invariant.
+
+Invariant (see docs/design/contracts/release-and-publish.md and AGENTS.md):
+a workflow job that references any ``secrets.*`` must bind to a protected,
+manually-approved ``environment:``.  That is what keeps a publish token
+reachable only by an approval-gated job — never by every workflow run.
+
+This is a dependency-free, indentation-based scan of ``.github/workflows/``
+(the repo's Python env has no PyYAML).  It treats a two-space-indented key
+under ``jobs:`` as a job, and checks each job block for a ``secrets.``
+reference and an ``environment:`` key.
+
+Exit codes:
+  0  every secret-using job declares an environment
+  1  a violation was found
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+# A job header: exactly two spaces, then `name:` (jobs are 2-indented).
+JOB_RE = re.compile(r"^  (?P<name>[A-Za-z0-9_.-]+):\s*$")
+# `environment:` as a job key (4 spaces), value inline or as a block.
+ENV_RE = re.compile(r"^    environment:")
+SECRET_RE = re.compile(r"secrets\.[A-Za-z_][A-Za-z0-9_]*")
+
+
+def job_blocks(text: str):
+    """Yield (job_name, body_lines) for each job under the top-level jobs:."""
+    lines = text.splitlines()
+    in_jobs = False
+    current = None
+    body: list[str] = []
+    for line in lines:
+        if re.match(r"^jobs:\s*$", line):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        # A non-indented, non-blank line ends the jobs: section.
+        if line and not line.startswith(" "):
+            if current is not None:
+                yield current, body
+            return
+        m = JOB_RE.match(line)
+        if m:
+            if current is not None:
+                yield current, body
+            current, body = m.group("name"), []
+            continue
+        if current is not None:
+            body.append(line)
+    if current is not None:
+        yield current, body
+
+
+def main() -> int:
+    violations: list[str] = []
+    checked = 0
+    for wf in sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml")):
+        text = wf.read_text()
+        for name, body in job_blocks(text):
+            blob = "\n".join(body)
+            secrets = sorted(set(SECRET_RE.findall(blob)))
+            if not secrets:
+                continue
+            checked += 1
+            has_env = any(ENV_RE.match(b) for b in body)
+            if not has_env:
+                violations.append(
+                    f"{wf.name}: job '{name}' references {', '.join(secrets)} "
+                    f"but declares no `environment:` (publish secrets must be "
+                    f"gated by a protected Environment)"
+                )
+
+    if violations:
+        print("FAIL: publish-secret invariant violated:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {checked} secret-using job(s) all bind to an environment.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/publish_jetbrains_upload.sh
+++ b/scripts/release/publish_jetbrains_upload.sh
@@ -34,19 +34,27 @@ TOKEN="$(bash "$HERE/jetbrains_token.sh")" || exit 1
 
 echo "==> Uploading $(basename "$ZIP") to JetBrains Marketplace (pluginId=$PLUGIN_ID${CHANNEL:+, channel=$CHANNEL})" >&2
 
+# The documented bearer-token upload endpoint
+# (https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html):
+# POST multipart to /api/updates/upload with `pluginId` + `file`, and an
+# optional `channel` (omit entirely for the default Stable channel — an
+# empty `channel=` form field is not the same as "unset").
+#
 # The endpoint returns 201/302 on success and 4xx with a JSON error body
 # otherwise.  Capture the HTTP status separately from the body so a failed
 # upload is a hard error rather than a silently-ignored 4xx.
 body="$(mktemp)"
 trap 'rm -f "$body"' EXIT
+channel_field=()
+[ -n "$CHANNEL" ] && channel_field=(-F "channel=${CHANNEL}")
 status="$(curl -sS -o "$body" -w '%{http_code}' \
     --retry 3 --retry-delay 5 --retry-all-errors \
     -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -F "pluginId=${PLUGIN_ID}" \
-    -F "channel=${CHANNEL}" \
+    "${channel_field[@]}" \
     -F "file=@${ZIP}" \
-    https://plugins.jetbrains.com/plugin/uploadPlugin)"
+    https://plugins.jetbrains.com/api/updates/upload)"
 
 if [ "$status" -ge 200 ] && [ "$status" -lt 400 ]; then
     echo "==> JetBrains Marketplace accepted the upload (HTTP $status)." >&2

--- a/scripts/release/publish_jetbrains_upload.sh
+++ b/scripts/release/publish_jetbrains_upload.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# publish_jetbrains_upload.sh — upload an already-built JetBrains plugin
+# .zip to the JetBrains Marketplace via the REST upload API.
+#
+# Unlike `./gradlew publishPlugin` (which rebuilds the plugin from source),
+# this uploads a specific, already-produced artefact — so CI can publish the
+# exact .zip that was attached to the GitHub Release and checksum-verified,
+# with no Java/Gradle toolchain in the publish job.
+#
+# Usage:  scripts/release/publish_jetbrains_upload.sh <plugin.zip>
+#
+# The token is resolved by scripts/release/jetbrains_token.sh (env var
+# $JETBRAINS_TOKEN first, then the OS keystore), so this works both from CI
+# (token in the environment) and the laptop (token in the Keychain).
+#
+# Env knobs:
+#   JETBRAINS_PLUGIN_ID  numeric Marketplace plugin id (default: 31801)
+#   JETBRAINS_CHANNEL    release channel; empty = Stable/default
+#
+# Exit codes:
+#   0  upload accepted (HTTP 2xx)
+#   1  bad arguments, missing file, missing token, or upload rejected
+set -uo pipefail
+
+ZIP="${1:?usage: $0 <plugin.zip>}"
+PLUGIN_ID="${JETBRAINS_PLUGIN_ID:-31801}"
+CHANNEL="${JETBRAINS_CHANNEL:-}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+[ -f "$ZIP" ] || { echo "error: plugin zip not found: $ZIP" >&2; exit 1; }
+
+TOKEN="$(bash "$HERE/jetbrains_token.sh")" || exit 1
+[ -n "$TOKEN" ] || { echo "error: empty JetBrains token" >&2; exit 1; }
+
+echo "==> Uploading $(basename "$ZIP") to JetBrains Marketplace (pluginId=$PLUGIN_ID${CHANNEL:+, channel=$CHANNEL})" >&2
+
+# The endpoint returns 201/302 on success and 4xx with a JSON error body
+# otherwise.  Capture the HTTP status separately from the body so a failed
+# upload is a hard error rather than a silently-ignored 4xx.
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+status="$(curl -sS -o "$body" -w '%{http_code}' \
+    --retry 3 --retry-delay 5 --retry-all-errors \
+    -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -F "pluginId=${PLUGIN_ID}" \
+    -F "channel=${CHANNEL}" \
+    -F "file=@${ZIP}" \
+    https://plugins.jetbrains.com/plugin/uploadPlugin)"
+
+if [ "$status" -ge 200 ] && [ "$status" -lt 400 ]; then
+    echo "==> JetBrains Marketplace accepted the upload (HTTP $status)." >&2
+    exit 0
+fi
+
+echo "error: JetBrains Marketplace rejected the upload (HTTP $status):" >&2
+cat "$body" >&2
+echo >&2
+exit 1


### PR DESCRIPTION
## Summary

Moves VS Code and JetBrains marketplace publishing into CI, gated by manually-approved Environments, and rewords the publishing invariant accordingly. Also hardens a pre-existing flaky-test problem in the VS Code extension suite that was surfacing under `test-slow`'s parallel load.

### Why

PR #641 set up VS Code to publish keylessly via GitHub OIDC → Azure Entra federation, leaving the job dormant until an Entra identity was configured. But the `bitwisecook` Marketplace publisher is a **personal Microsoft account** (consumer tenant `9188040d-…`), which has no Entra tenant to host an app registration / federated credential — so keyless OIDC is not achievable for this publisher. The keyless job stayed skipped and nothing published from CI.

### New invariant

A publish secret may live in CI **only** as an Environment secret on a protected, manually-approved Environment (required reviewer + `v*`-tag-only deployment policy), reachable solely by the one gated publish job — never a plain repo/org secret available to every workflow run.

### Changes

- **`ci.yml`** — replace the keyless `publish-vsix-marketplace` job with a PAT-based one (`secrets.VSCE_PAT` on `marketplace-vscode`); add `publish-jetbrains-marketplace` (`secrets.JETBRAINS_TOKEN` on `marketplace-jetbrains`) which uploads the released, checksum-verified plugin `.zip` via the Marketplace REST API. Both tag-gated + flag-var-gated, secret scoped to the publish step's `env:` only, publishing the signed release artefact (no rebuild).
- **`scripts/release/publish_jetbrains_upload.sh`** — REST upload of a prebuilt plugin zip (reuses `jetbrains_token.sh`).
- **`scripts/release/check_publish_env.py`** + `make check-publish-env` (wired into `ci-fast`) — machine-enforce that every workflow job referencing `secrets.*` declares a protected `environment:`.
- **`AGENTS.md`** + **`docs/design/contracts/release-and-publish.md`** — reword the invariant; Sublime/Zed remain laptop-only (no token).
- **`SKILL.md` step 10** + **Makefile `publish-flow`** — VS Code + JetBrains publish from CI; laptop `make publish-vsix`/`publish-jetbrains` are fallbacks.

### Test-suite hardening (incidental but required)

`test-ext` flaked intermittently under `test-slow`'s parallel load — single-shot `execute*Provider` calls asserting a result is present could fire before the server computed it. Wrapped those sites (inlay-hints independence + ~32 others across 10 files) in the existing `pollUntil` helper so they wait out server readiness. `make test-slow` now passes green (stamp refreshed).

### Remote config already applied (out of band)

The Environment secrets, the `marketplace-jetbrains` environment, and the enable-flag variables are already configured on the repo; this PR is the workflow + docs that use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)