### PR TITLE
Finish FE-TYPESHIM (type inference / shimmer / shapes / rendered-props)

### DIFF
--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1164,6 +1164,46 @@ Two catch-up modes, picked per chunk:
 
 ### Outstanding
 
+Landed: 2026-06-19 — **FE-TYPESHIM complete** (PR #651, branch
+`claude/compassionate-cray-35tuvt`). The four owned modules
+(`tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`)
+finished their precision/soundness residuals; the track's detailed
+section was dropped from `rust-rewrite.md` (now a ✅ row only). What
+landed:
+
+- **shimmer** — S100 emits as LSP `Information` via a new
+  `compiler_checks::Severity::Info` variant (server maps it to
+  `INFORMATION`); S101/S102 stay `Warning` (mirrors Python
+  `_SHIMMER_SEVERITY`). The S100/S101 code is computed from `in_loop` in
+  `phi.rs` and `expr.rs` (both had hardcoded it). Ported the
+  loop-invariant S101→S100 downgrade (`use_site::LoopFacts` — a
+  loop-invariant variable coerced to a single intrep converts once), the
+  `incr`-amount shimmer check (previously skipped when the target was
+  already int), and the per-statement `(span, var)` expr-shimmer
+  de-duplication (Python's per-block `seen` set).
+- **type_infer** — added an expr-context literal classifier
+  (`expr_literal_type`: `0o`/`0x`/`0b` → INT, unrecognised → NUMERIC),
+  distinct from the set-statement classifier; `~$double` → INT
+  (`UnaryOp::BitNot` no longer leaks the operand type); scope-alias defs
+  (`global`/`variable`/`upvar`/`namespace upvar`) widen to OVERDEFINED,
+  driven by the registry `CREATES_SCOPE_ALIAS` trait.
+- **rendered_properties** — `scan_escape` decodes via
+  `tcl_lexer::backslash_subst`, so numeric/hex/octal/unicode escapes that
+  render to `/` set `HAS_FORWARD_SLASH` (was a W201 false-negative);
+  null/CRLF likewise.
+- **value_shapes** — `is_pure_var_ref` accepts `$arr(idx)` (escape-aware
+  index, faithful port of `_scan_pure_var_ref`); added
+  `is_braced_whole_name_array_ref` for `${a(1)}`.
+
+Verified against tclsh 8.4 / 8.5 / 8.6 / 9.0 (escape rendering, expr
+literal typing, bitwise-not, array refs; `0o`/`0b` confirmed 8.5+-only).
+**Handoff:** precise TclOO `object_of` typing was *not* ported here — the
+Rust IR keeps `namespace eval` bodies as raw barriers, so the class set
+must come from the analyser-layer `signature_scan` (not the Python
+`class_names.extract_class_names` IR-walk), and the only consumer is the
+W307/W308 emitter. Both belong to **FE-DIAG**, where the residual is now
+tracked in `rust-rewrite.md`.
+
 Re-audited: 2026-06-12 against `origin/main`@`bfc636d2` (prior anchor
 `a287d4a6`, #586). First ordinary `git merge origin/main` since the
 `SYNC-JUN11-rebase` re-parenting — see the **SYNC-JUN12 family** below.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -939,7 +939,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Lexer / segmenter / expr-lexer / CST | `tcl-lexer`, `tcl-syntax`, `tcl-compiler::parsing` | 🟢 | `${name}` brace-depth; quoted `\<nl>`; nested-body E202/E203 → **FE-LEX** |
 | IR / lowering / CFG / SSA | `tcl-compiler` | 🟢 | `IRUpFrame` clobber; dynamic-`uplevel` barrier; minor IR fields → **FE-DATAFLOW**, **FE-DIAG** |
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
-| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟡 | shimmer severity+codes; expr-literal/`~`/object typing; ESC rendering; `is_pure_var_ref` set → **FE-TYPESHIM** |
+| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | **FE-TYPESHIM** landed; only precise TclOO `object_of` typing (needs `known_classes`) remains → **FE-DIAG** (its W307/W308 consumer) |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
@@ -1027,17 +1027,27 @@ Owns `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}`.
   `shimmer.py` (0 occurrences in Rust). Absence → runaway latency + over-optimistic
   interproc summaries on adversarial input.
 
-#### FE-TYPESHIM — type inference / shimmer / shapes
+#### FE-TYPESHIM — type inference / shimmer / shapes ✅
 Owns `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`.
-- **open** shimmer: emit **S100 as Information** (not Warning,
-  `compiler_checks.rs:113`); compute the S100/S101 code from `in_loop`
-  (`phi.rs:146` / `expr.rs:273` hardcode it); port the loop-invariant
-  S101→S100 downgrade and the `incr`-amount check.
-- **open** expr-context literal typing (`0o`→INT, unknown→NUMERIC),
-  `~$double`→INT, and TclOO/scope-alias → OVERDEFINED widening.
-- **open** rendered-props ESC numeric/hex escape rendering (`\x2f`→`/`) — its
-  absence causes W201 false-negatives.
-- **open** `value_shapes::is_pure_var_ref` acceptance set (`$arr(idx)` / `${a(1)}`).
+All listed residuals have landed:
+- **done** shimmer: S100 now emits as **Information** (new
+  `compiler_checks::Severity::Info`, mapped to LSP `INFORMATION`); the
+  S100/S101 code is computed from `in_loop` in both `phi.rs` and `expr.rs`
+  (was hardcoded); the loop-invariant S101→S100 downgrade
+  (`use_site::LoopFacts`) and the `incr`-amount check are ported.
+- **done** expr-context literal typing (`expr_literal_type`: `0o`/`0x`/`0b`
+  → INT, unrecognised → NUMERIC), `~$double`→INT (`UnaryOp::BitNot`), and
+  scope-alias → OVERDEFINED widening (`global`/`variable`/`upvar`/`namespace
+  upvar`, registry-`CREATES_SCOPE_ALIAS`-driven). TclOO constructor results
+  already widen to OVERDEFINED; precise `object_of` typing stays gated on
+  threading `known_classes` (its only consumer is the FE-DIAG W307/W308
+  emitter).
+- **done** rendered-props ESC numeric/hex/octal/unicode escape rendering —
+  `scan_escape` now decodes via `tcl_lexer::backslash_subst`, so `\x2f` /
+  `\057` / `/` → `/` set `HAS_FORWARD_SLASH` (was a W201 false-negative).
+- **done** `value_shapes::is_pure_var_ref` accepts `$arr(idx)` (and the
+  backslash-escaped `$a(x\)y)` form); added `is_braced_whole_name_array_ref`
+  for `${a(1)}`.
 
 #### FE-VARESCAPE — var-escape wiring
 Owns `tcl-compiler::var_escape`.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -928,6 +928,29 @@ Task status is either **open** or **partial** (with a note on what remains).
   modelling, O109 / O116 / O120, the upvar transitive-merge, the
   document-version guard (review-findings C2), and the CST descent. Trust this
   plan and the source over the archive's dated rows.
+- **This document is a forward-looking plan, not a changelog.** It lists only
+  **open** / **partial** work. The narrative of *what landed and why* is
+  history — record it in [`rust-rewrite-history.md`](rust-rewrite-history.md),
+  not here. When a track finishes, delete its detailed `####` section and leave
+  only its rows in the subsystem-status and track-map tables (mark them ✅ /
+  🟢); add the landed detail to the history file in the same change. Do **not**
+  accumulate `**done**` bullets in this plan.
+- **Verify every port against real Tcl behaviour.** Check the produced result
+  against **tclsh 8.4–9.0** (the four source trees live under `tmp/tcl<ver>/`;
+  build a missing one with `.claude/skills/fetch-tcl-source` + `configure &&
+  make` under `unix/`), and consult the **C Tcl source** for the reference
+  algorithm — `tmp/tcl9.0.3/generic/` carries the `tclParse.c` / `tclUtil.c` /
+  `tclExecute.c` files the ports mirror. Gate version-specific behaviour (e.g.
+  `0o` / `0b` integer prefixes exist in 8.5+ but not 8.4; `{*}` expansion is
+  8.5+) on the registry / `LexerConfig` dialect flags, never hardcode one
+  version. C Tcl 9.0.3 is the reference standard — see
+  [`rust-rewrite-history.md`](rust-rewrite-history.md) §"C Tcl 9.0.3 is the
+  reference standard".
+- **A discovery in one track that affects another must update the other
+  track's entry here, in the same change.** When working a track surfaces a
+  wrong assumption, a shared invariant, or a handoff (e.g. a residual that
+  belongs to a different owner), edit that other track's row/section now —
+  don't leave the finding buried only in a commit message or PR description.
 
 ### Subsystem status (current reality)
 
@@ -939,7 +962,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Lexer / segmenter / expr-lexer / CST | `tcl-lexer`, `tcl-syntax`, `tcl-compiler::parsing` | 🟢 | `${name}` brace-depth; quoted `\<nl>`; nested-body E202/E203 → **FE-LEX** |
 | IR / lowering / CFG / SSA | `tcl-compiler` | 🟢 | `IRUpFrame` clobber; dynamic-`uplevel` barrier; minor IR fields → **FE-DATAFLOW**, **FE-DIAG** |
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
-| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | **FE-TYPESHIM** landed; only precise TclOO `object_of` typing (needs `known_classes`) remains → **FE-DIAG** (its W307/W308 consumer) |
+| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | ✅ | **FE-TYPESHIM** complete; precise TclOO `object_of` typing now tracked under **FE-DIAG** (its W307/W308 consumer) |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
@@ -1026,31 +1049,6 @@ Owns `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}`.
   Python applies in `ssa.py`, `taint/_api.py`, `optimiser/_manager.py`,
   `shimmer.py` (0 occurrences in Rust). Absence → runaway latency + over-optimistic
   interproc summaries on adversarial input.
-
-#### FE-TYPESHIM — type inference / shimmer / shapes ✅
-Owns `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`.
-All listed residuals have landed:
-- **done** shimmer: S100 now emits as **Information** (new
-  `compiler_checks::Severity::Info`, mapped to LSP `INFORMATION`); the
-  S100/S101 code is computed from `in_loop` in both `phi.rs` and `expr.rs`
-  (was hardcoded); the loop-invariant S101→S100 downgrade
-  (`use_site::LoopFacts`), the `incr`-amount check, and the per-statement
-  `(span, var)` expr-shimmer de-duplication (Python's `seen` set) are ported.
-- **done** expr-context literal typing (`expr_literal_type`: `0o`/`0x`/`0b`
-  → INT, unrecognised → NUMERIC), `~$double`→INT (`UnaryOp::BitNot`), and
-  scope-alias → OVERDEFINED widening (`global`/`variable`/`upvar`/`namespace
-  upvar`, registry-`CREATES_SCOPE_ALIAS`-driven). TclOO constructor results
-  already widen to OVERDEFINED; precise `object_of` typing is left to
-  **FE-DIAG**, which owns both the analyser-layer class extraction (the Rust
-  IR keeps `namespace eval` bodies as raw barriers, so the class set comes
-  from `signature_scan`, not an IR walk) and the W307/W308 emitter that is
-  its only consumer.
-- **done** rendered-props ESC numeric/hex/octal/unicode escape rendering —
-  `scan_escape` now decodes via `tcl_lexer::backslash_subst`, so `\x2f` /
-  `\057` / `/` → `/` set `HAS_FORWARD_SLASH` (was a W201 false-negative).
-- **done** `value_shapes::is_pure_var_ref` accepts `$arr(idx)` (and the
-  backslash-escaped `$a(x\)y)` form); added `is_braced_whole_name_array_ref`
-  for `${a(1)}`.
 
 #### FE-VARESCAPE — var-escape wiring
 Owns `tcl-compiler::var_escape`.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1106,6 +1106,24 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
 - **open** snit OO support (`snit::type`/`widget`/`widgetadaptor` as ClassDef)
   and the OO body-walks Rust skips (`oo::class new`/`createWithNamespace`,
   `initialise` body, `property -get/-set` accessor bodies).
+- **open** **W307 / W308** method-dispatch type checks + the precise TclOO
+  `object_of` typing they consume (handed off from **FE-TYPESHIM**, which
+  widens constructor results to OVERDEFINED today). The type lattice already
+  models `TypeLattice::object_of(class)` and the join widens mismatched
+  classes; what is missing is the *known-classes* set fed to
+  `type_infer::return_type_for_command` so `[Foo new]` / `[Foo create x]` /
+  `[Foo %AUTO%]` / `[Widget .path]` type as `OBJECT(::ns::Foo)` (relative
+  names resolved against the call-site namespace). Source the class set from
+  the analyser-layer `signature_scan` (the Rust IR keeps `namespace eval`
+  bodies as raw barriers, so the Python `class_names.extract_class_names`
+  IR-walk misses namespace-scoped classes — do **not** port it as-is), then
+  thread it through `FunctionUnit::build`→`propagate_types`/
+  `infer_function_return_type` and key the per-procedure lattice memo
+  (`LatticeRequest` + `tcl-lsp-db`) on it, mirroring Python's
+  `known_classes_fp`. Port `_return_type_for_command`'s constructor
+  recognition (`new`/`create`/`createWithNamespace`/`%AUTO%`/leading-`.`),
+  keeping the D4-F6 guard (no `object_of` from the `new` spelling alone when
+  the command is not a known class).
 - **open** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity — the emitters are
   linear-scan MVPs (single shared `responded` flag); add per-branch state and
   restore the dropped quick-fixes (the C44 follow-up).

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1034,14 +1034,17 @@ All listed residuals have landed:
   `compiler_checks::Severity::Info`, mapped to LSP `INFORMATION`); the
   S100/S101 code is computed from `in_loop` in both `phi.rs` and `expr.rs`
   (was hardcoded); the loop-invariant S101→S100 downgrade
-  (`use_site::LoopFacts`) and the `incr`-amount check are ported.
+  (`use_site::LoopFacts`), the `incr`-amount check, and the per-statement
+  `(span, var)` expr-shimmer de-duplication (Python's `seen` set) are ported.
 - **done** expr-context literal typing (`expr_literal_type`: `0o`/`0x`/`0b`
   → INT, unrecognised → NUMERIC), `~$double`→INT (`UnaryOp::BitNot`), and
   scope-alias → OVERDEFINED widening (`global`/`variable`/`upvar`/`namespace
   upvar`, registry-`CREATES_SCOPE_ALIAS`-driven). TclOO constructor results
-  already widen to OVERDEFINED; precise `object_of` typing stays gated on
-  threading `known_classes` (its only consumer is the FE-DIAG W307/W308
-  emitter).
+  already widen to OVERDEFINED; precise `object_of` typing is left to
+  **FE-DIAG**, which owns both the analyser-layer class extraction (the Rust
+  IR keeps `namespace eval` bodies as raw barriers, so the class set comes
+  from `signature_scan`, not an IR walk) and the W307/W308 emitter that is
+  its only consumer.
 - **done** rendered-props ESC numeric/hex/octal/unicode escape rendering —
   `scan_escape` now decodes via `tcl_lexer::backslash_subst`, so `\x2f` /
   `\057` / `/` → `/` set `HAS_FORWARD_SLASH` (was a W201 false-negative).

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -42,6 +42,9 @@ pub enum Severity {
     Hint,
     /// Style suggestion / refactor.
     Suggestion,
+    /// Informational note (LSP `Information`) — observational, not a
+    /// problem (e.g. an S100 single shimmer outside a loop).
+    Info,
     /// Warning that may indicate a bug.
     Warning,
     /// Error.
@@ -58,6 +61,7 @@ impl Severity {
         match self {
             Self::Hint => "hint",
             Self::Suggestion => "suggestion",
+            Self::Info => "info",
             Self::Warning => "warning",
             Self::Error => "error",
         }
@@ -110,7 +114,14 @@ impl Diagnostic {
             span: w.span,
             code: w.code.clone(),
             category: "shimmer".into(),
-            severity: Severity::Warning,
+            // S100 (single shimmer outside a loop) is informational; S101
+            // (per-iteration loop shimmer) is a warning.  Mirrors Python's
+            // `_SHIMMER_SEVERITY` map in `server/features/diagnostics.py`.
+            severity: if w.code == "S100" {
+                Severity::Info
+            } else {
+                Severity::Warning
+            },
             message: w.message.clone(),
             replacement: None,
         }
@@ -397,6 +408,36 @@ mod tests {
         // SCCP should have flagged the constant-true branch.
         let has_sccp = diagnostics.iter().any(|d| d.category == "sccp");
         assert!(has_sccp, "expected an SCCP diagnostic, got {diagnostics:?}");
+    }
+
+    #[test]
+    fn shimmer_s100_is_info_s101_is_warning() {
+        // S100 — a single shimmer outside any loop is informational.
+        let cu = CompilationUnit::build_for("set x \"hello\"\nincr x", &registry(), false);
+        let diags = run_all_checks(&cu, &registry(), None);
+        let s100 = diags
+            .iter()
+            .find(|d| d.code == "S100")
+            .expect("expected an S100 shimmer");
+        assert_eq!(s100.severity, Severity::Info, "S100 must be Info: {s100:?}");
+        assert_eq!(s100.severity.as_str(), "info");
+
+        // S101 — a per-iteration shimmer inside a loop is a warning.
+        let cu = CompilationUnit::build_for(
+            "proc f {l} {\n  foreach x $l {\n    set b [lindex $x 0]\n  }\n}\n",
+            &registry(),
+            false,
+        );
+        let diags = run_all_checks(&cu, &registry(), None);
+        let s101 = diags
+            .iter()
+            .find(|d| d.code == "S101")
+            .expect("expected an S101 shimmer");
+        assert_eq!(
+            s101.severity,
+            Severity::Warning,
+            "S101 must be Warning: {s101:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/rendered_properties.rs
+++ b/rust/tcl-compiler/src/rendered_properties.rs
@@ -307,7 +307,7 @@ fn scan_value_text(text: &str) -> RenderedValueProps {
             }
             b'\\' => {
                 saw_escape = true;
-                let escape = scan_escape(bytes, i, leading_resolved);
+                let escape = scan_escape(text, i, leading_resolved);
                 may |= escape.may_add;
                 must |= escape.must_add;
                 leading_resolved |= escape.starts_leading;
@@ -434,41 +434,110 @@ struct EscapeScan {
     starts_leading: bool,
 }
 
-fn scan_escape(bytes: &[u8], start: usize, leading_resolved: bool) -> EscapeScan {
-    let mut may_add = RenderedProperties::HAS_BACKSLASH;
-    let mut must_add = RenderedProperties::NONE;
-
-    let Some(&esc) = bytes.get(start + 1) else {
+fn scan_escape(text: &str, start: usize, leading_resolved: bool) -> EscapeScan {
+    let bytes = text.as_bytes();
+    // A bare trailing backslash renders to a literal `\`.
+    if start + 1 >= bytes.len() {
         return EscapeScan {
             advance: 1,
-            may_add,
-            must_add,
+            may_add: RenderedProperties::HAS_BACKSLASH,
+            must_add: RenderedProperties::NONE,
             starts_leading: false,
         };
-    };
-
-    // Recognise a handful of mapped escapes.
-    if matches!(esc, b'n' | b'r') {
-        may_add |= RenderedProperties::HAS_CRLF;
-    } else if esc == b'0' {
-        may_add |= RenderedProperties::HAS_NULL;
     }
 
-    // Rendered-text starts-with: take the escaped char as the first
-    // char when it is a mapped escape producing a printable char.
+    // Render the *exact* escape via the canonical backslash decoder, then
+    // derive the property bits from what it actually produces.  This is the
+    // key fix over the old hand-rolled table: a numeric / hex / unicode /
+    // octal escape (`\x2f`, `/`, `\057`) renders to `/` and therefore
+    // sets `HAS_FORWARD_SLASH` (its absence caused W201 false-negatives).
+    // Mirrors Python's `_render_esc_text` → per-rendered-char scan.
+    let advance = escape_byte_len(bytes, start);
+    let rendered = tcl_lexer::backslash_subst(&text[start..start + advance]);
+
+    let mut may_add = RenderedProperties::NONE;
+    for c in rendered.bytes() {
+        match c {
+            b'/' => may_add |= RenderedProperties::HAS_FORWARD_SLASH,
+            b'\\' => may_add |= RenderedProperties::HAS_BACKSLASH,
+            b'\r' | b'\n' => may_add |= RenderedProperties::HAS_CRLF,
+            0 => may_add |= RenderedProperties::HAS_NULL,
+            _ => {}
+        }
+    }
+
+    // Rendered-text starts-with: the escape's first rendered character is
+    // the first content char of the word when nothing precedes it.
+    let mut must_add = RenderedProperties::NONE;
     if !leading_resolved {
-        match esc {
-            b'/' => must_add |= RenderedProperties::STARTS_WITH_SLASH,
-            b'-' => must_add |= RenderedProperties::STARTS_WITH_DASH,
+        match rendered.as_bytes().first() {
+            Some(b'/') => must_add |= RenderedProperties::STARTS_WITH_SLASH,
+            Some(b'-') => must_add |= RenderedProperties::STARTS_WITH_DASH,
             _ => {}
         }
     }
 
     EscapeScan {
-        advance: 2,
+        advance,
         may_add,
         must_add,
-        starts_leading: true,
+        // An escape always renders at least one character, resolving the
+        // leading position (even when that char sets no must-bit).
+        starts_leading: !rendered.is_empty(),
+    }
+}
+
+/// Source-byte length of one Tcl backslash escape beginning at
+/// `bytes[start]` (which must be `\`).  Mirrors the per-escape consumption
+/// rules of [`tcl_lexer::backslash_subst`] so the exact escape can be
+/// sliced out and rendered.
+fn escape_byte_len(bytes: &[u8], start: usize) -> usize {
+    let Some(&esc) = bytes.get(start + 1) else {
+        return 1;
+    };
+    let count_digits = |max: usize, from: usize, ok: &dyn Fn(u8) -> bool| {
+        let mut n = 0;
+        while n < max && bytes.get(from + n).is_some_and(|c| ok(*c)) {
+            n += 1;
+        }
+        n
+    };
+    match esc {
+        // `\xHH` (1–2 hex), `\uHHHH` (1–4 hex), `\UHH..` (1–8 hex).
+        b'x' => 2 + count_digits(2, start + 2, &|c| c.is_ascii_hexdigit()),
+        b'u' => 2 + count_digits(4, start + 2, &|c| c.is_ascii_hexdigit()),
+        b'U' => 2 + count_digits(8, start + 2, &|c| c.is_ascii_hexdigit()),
+        // Octal `\NNN`: the first digit is at `start+1`; the cap is 3 for a
+        // leading 0–3, else 2 (matching `scan_octal_escape`).
+        b'0'..=b'7' => {
+            let max = if (b'0'..=b'3').contains(&esc) { 3 } else { 2 };
+            1 + count_digits(max, start + 1, &|c| (b'0'..=b'7').contains(&c))
+        }
+        // Line continuation: `\` + newline (+ optional LF after CR) + a run
+        // of spaces/tabs, collapsing to a single space.
+        b'\n' | b'\r' => {
+            let mut j = start + 2;
+            if esc == b'\r' && bytes.get(j) == Some(&b'\n') {
+                j += 1;
+            }
+            while bytes.get(j).is_some_and(|c| *c == b' ' || *c == b'\t') {
+                j += 1;
+            }
+            j - start
+        }
+        // Simple / unknown `\X` — backslash plus the (possibly multibyte
+        // UTF-8) char after it.
+        _ => 1 + utf8_char_len(esc),
+    }
+}
+
+/// Byte length of a UTF-8 character from its leading byte.
+fn utf8_char_len(first: u8) -> usize {
+    match first {
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => 1,
     }
 }
 
@@ -960,6 +1029,48 @@ mod tests {
             p.must.contains(RenderedProperties::STARTS_WITH_DASH),
             "expected STARTS_WITH_DASH on '\\-flag', got {p:?}",
         );
+    }
+
+    /// A hex / octal / unicode escape that renders to `/` must set
+    /// `HAS_FORWARD_SLASH` — its absence caused W201 false-negatives.
+    #[test]
+    fn numeric_escapes_rendering_to_slash_set_forward_slash() {
+        for src in ["\\x2f", "\\x2Fetc", "\\057", "\\u002f", "\\U0000002f"] {
+            let p = scan_value_text(src);
+            assert!(
+                p.may.contains(RenderedProperties::HAS_FORWARD_SLASH),
+                "expected HAS_FORWARD_SLASH for {src:?}, got {p:?}",
+            );
+        }
+        // A leading `\x2f` also resolves the must-bit STARTS_WITH_SLASH.
+        let p = scan_value_text("\\x2fetc");
+        assert!(p.must.contains(RenderedProperties::STARTS_WITH_SLASH));
+    }
+
+    /// A hex escape that renders to a null / CRLF byte sets the matching
+    /// may-bit (it did not before, the table only knew `\0` and `\n`/`\r`).
+    #[test]
+    fn numeric_escapes_render_null_and_crlf() {
+        assert!(
+            scan_value_text("a\\x00b")
+                .may
+                .contains(RenderedProperties::HAS_NULL)
+        );
+        assert!(
+            scan_value_text("a\\x0db")
+                .may
+                .contains(RenderedProperties::HAS_CRLF)
+        );
+    }
+
+    /// A non-slash escape (`\t`) renders to a tab — none of the tracked
+    /// content bits should be set (the old table over-set `HAS_BACKSLASH`).
+    #[test]
+    fn tab_escape_sets_no_content_bits() {
+        let p = scan_value_text("a\\tb");
+        assert!(!p.may.contains(RenderedProperties::HAS_FORWARD_SLASH));
+        assert!(!p.may.contains(RenderedProperties::HAS_BACKSLASH));
+        assert!(!p.may.contains(RenderedProperties::HAS_CRLF));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -27,6 +27,7 @@ use crate::sccp::cfg_order;
 use crate::ssa::{SsaFunction, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
 
+use super::graph::loop_body_blocks;
 use super::{ShimmerWarning, type_name};
 
 /// Find expression-level shimmer warnings for a function.
@@ -46,6 +47,7 @@ pub(crate) fn find_expr_shimmers(
     executable_blocks: &HashSet<String>,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
+    let loop_blocks = loop_body_blocks(cfg);
 
     for block_name in cfg_order(cfg) {
         if !executable_blocks.contains(&block_name) {
@@ -54,13 +56,17 @@ pub(crate) fn find_expr_shimmers(
         let Some(ssa_block) = ssa.blocks.get(&block_name) else {
             continue;
         };
+        // An expr-operator shimmer inside a loop body re-converts the operand
+        // every iteration (S101); outside a loop it is one-time (S100).
+        // Mirrors Python `_find_expr_shimmers`' `in_loop = bn in loop_blocks`.
+        let in_loop = loop_blocks.contains(&block_name);
 
         // 1. SSA statements: AssignExpr and ExprEval.
         for ss in &ssa_block.statements {
             match &ss.statement {
                 Statement::AssignExpr { expr, span, .. }
                 | Statement::ExprEval { expr, span, .. } => {
-                    collect_expr_shimmers(expr, &ss.uses, types, *span, &mut out);
+                    collect_expr_shimmers(expr, &ss.uses, types, *span, in_loop, &mut out);
                 }
                 _ => {}
             }
@@ -80,6 +86,7 @@ pub(crate) fn find_expr_shimmers(
                 &ssa_block.exit_versions,
                 types,
                 branch_span,
+                in_loop,
                 &mut out,
             );
         }
@@ -93,6 +100,7 @@ fn collect_expr_shimmers(
     uses: &HashMap<String, u32>,
     types: &HashMap<ValueKey, TypeLattice>,
     stmt_span: Span,
+    in_loop: bool,
     out: &mut Vec<ShimmerWarning>,
 ) {
     match node {
@@ -100,8 +108,8 @@ fn collect_expr_shimmers(
             op, left, right, ..
         } => {
             // Recurse into children first.
-            collect_expr_shimmers(left, uses, types, stmt_span, out);
-            collect_expr_shimmers(right, uses, types, stmt_span, out);
+            collect_expr_shimmers(left, uses, types, stmt_span, in_loop, out);
+            collect_expr_shimmers(right, uses, types, stmt_span, in_loop, out);
 
             match op {
                 // Arithmetic, bitwise, logical, and *ordering* comparison
@@ -124,8 +132,8 @@ fn collect_expr_shimmers(
                 | BinOp::Le
                 | BinOp::Gt
                 | BinOp::Ge => {
-                    check_numeric_operand(left, uses, types, stmt_span, *op, out);
-                    check_numeric_operand(right, uses, types, stmt_span, *op, out);
+                    check_numeric_operand(left, uses, types, stmt_span, *op, in_loop, out);
+                    check_numeric_operand(right, uses, types, stmt_span, *op, in_loop, out);
                 }
 
                 // `==` / `!=` take the numeric-coercion path only when at least
@@ -136,8 +144,8 @@ fn collect_expr_shimmers(
                     if operand_looks_numeric(left, uses, types)
                         || operand_looks_numeric(right, uses, types)
                     {
-                        check_numeric_operand(left, uses, types, stmt_span, *op, out);
-                        check_numeric_operand(right, uses, types, stmt_span, *op, out);
+                        check_numeric_operand(left, uses, types, stmt_span, *op, in_loop, out);
+                        check_numeric_operand(right, uses, types, stmt_span, *op, in_loop, out);
                     }
                 }
 
@@ -148,8 +156,8 @@ fn collect_expr_shimmers(
                 | BinOp::StrLe
                 | BinOp::StrGt
                 | BinOp::StrGe => {
-                    check_string_operand(left, uses, types, stmt_span, *op, out);
-                    check_string_operand(right, uses, types, stmt_span, *op, out);
+                    check_string_operand(left, uses, types, stmt_span, *op, in_loop, out);
+                    check_string_operand(right, uses, types, stmt_span, *op, in_loop, out);
                 }
 
                 _ => {}
@@ -157,7 +165,7 @@ fn collect_expr_shimmers(
         }
 
         ExprNode::Unary { operand, .. } => {
-            collect_expr_shimmers(operand, uses, types, stmt_span, out);
+            collect_expr_shimmers(operand, uses, types, stmt_span, in_loop, out);
         }
 
         ExprNode::Ternary {
@@ -166,9 +174,9 @@ fn collect_expr_shimmers(
             false_branch,
             ..
         } => {
-            collect_expr_shimmers(condition, uses, types, stmt_span, out);
-            collect_expr_shimmers(true_branch, uses, types, stmt_span, out);
-            collect_expr_shimmers(false_branch, uses, types, stmt_span, out);
+            collect_expr_shimmers(condition, uses, types, stmt_span, in_loop, out);
+            collect_expr_shimmers(true_branch, uses, types, stmt_span, in_loop, out);
+            collect_expr_shimmers(false_branch, uses, types, stmt_span, in_loop, out);
         }
 
         _ => {}
@@ -233,14 +241,16 @@ fn expr_string_is_numeric(text: &str) -> bool {
     )
 }
 
-/// Emit S100 if `node` is a variable reference with a non-numeric type
-/// used in a numeric arithmetic context.
+/// Emit a shimmer if `node` is a variable reference with a non-numeric
+/// type used in a numeric arithmetic context.  The code is S101 inside a
+/// loop body (per-iteration conversion) and S100 outside one.
 fn check_numeric_operand(
     node: &ExprNode,
     uses: &HashMap<String, u32>,
     types: &HashMap<ValueKey, TypeLattice>,
     span: Span,
     op: BinOp,
+    in_loop: bool,
     out: &mut Vec<ShimmerWarning>,
 ) {
     let ExprNode::Var { name, .. } = node else {
@@ -263,16 +273,17 @@ fn check_numeric_operand(
     };
     // Only flag clearly non-numeric types (String, List, Dict).
     if matches!(current, TclType::String | TclType::List | TclType::Dict) {
+        let code = if in_loop { "S101" } else { "S100" };
         out.push(ShimmerWarning {
             span,
             variable: base.to_owned(),
             from_type: current,
             to_type: TclType::Numeric,
             command: format!("expr:{op:?}"),
-            in_loop: false,
-            code: "S100".to_owned(),
+            in_loop,
+            code: code.to_owned(),
             message: format!(
-                "S100: variable '{var}' has {from} intrep used in arithmetic \
+                "{code}: variable '{var}' has {from} intrep used in arithmetic \
                  expression (op {op:?})",
                 var = base,
                 from = type_name(current),
@@ -282,13 +293,15 @@ fn check_numeric_operand(
     }
 }
 
-/// Emit S100 if `node` is a numeric variable used in a string comparison.
+/// Emit a shimmer if `node` is a numeric variable used in a string
+/// comparison.  S101 inside a loop body, S100 outside one.
 fn check_string_operand(
     node: &ExprNode,
     uses: &HashMap<String, u32>,
     types: &HashMap<ValueKey, TypeLattice>,
     span: Span,
     op: BinOp,
+    in_loop: bool,
     out: &mut Vec<ShimmerWarning>,
 ) {
     let ExprNode::Var { name, .. } = node else {
@@ -314,16 +327,17 @@ fn check_string_operand(
         current,
         TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean
     ) {
+        let code = if in_loop { "S101" } else { "S100" };
         out.push(ShimmerWarning {
             span,
             variable: base.to_owned(),
             from_type: current,
             to_type: TclType::String,
             command: format!("expr:{op:?}"),
-            in_loop: false,
-            code: "S100".to_owned(),
+            in_loop,
+            code: code.to_owned(),
             message: format!(
-                "S100: numeric variable '{base}' used in string comparison (op {op:?}); \
+                "{code}: numeric variable '{base}' used in string comparison (op {op:?}); \
                  consider using == or != instead"
             ),
             related: Vec::new(),
@@ -433,6 +447,24 @@ mod tests {
             has_shimmer,
             "expected Int-in-string-cmp shimmer in if-condition, got: {w:?}"
         );
+    }
+
+    /// An arithmetic shimmer inside a loop body is a per-iteration cost
+    /// (S101); the same shimmer outside a loop is one-time (S100).
+    #[test]
+    fn expr_shimmer_in_loop_is_s101() {
+        let cu = CompilationUnit::build_for(
+            "proc f {l} {\n  foreach x $l {\n    set y [expr {$x + 1}]\n  }\n}\n",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let s = w.iter().find(|sw| sw.variable == "x");
+        assert!(s.is_some(), "expected expr shimmer for x in loop: {w:?}");
+        let s = s.unwrap();
+        assert_eq!(s.code, "S101", "in-loop arithmetic shimmer must be S101");
+        assert!(s.in_loop);
     }
 
     /// A String literal compared with `eq` — no shimmer (String is correct type).

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -60,13 +60,19 @@ pub(crate) fn find_expr_shimmers(
         // every iteration (S101); outside a loop it is one-time (S100).
         // Mirrors Python `_find_expr_shimmers`' `in_loop = bn in loop_blocks`.
         let in_loop = loop_blocks.contains(&block_name);
+        // Per-block de-duplication keyed on (statement span, variable): several
+        // operands of the same statement that name the same variable emit one
+        // warning, not one per operand. Mirrors Python's per-block `seen` set.
+        let mut seen: HashSet<(Span, String)> = HashSet::new();
 
         // 1. SSA statements: AssignExpr and ExprEval.
         for ss in &ssa_block.statements {
             match &ss.statement {
                 Statement::AssignExpr { expr, span, .. }
                 | Statement::ExprEval { expr, span, .. } => {
-                    collect_expr_shimmers(expr, &ss.uses, types, *span, in_loop, &mut out);
+                    collect_expr_shimmers(
+                        expr, &ss.uses, types, *span, in_loop, &mut seen, &mut out,
+                    );
                 }
                 _ => {}
             }
@@ -87,6 +93,7 @@ pub(crate) fn find_expr_shimmers(
                 types,
                 branch_span,
                 in_loop,
+                &mut seen,
                 &mut out,
             );
         }
@@ -101,6 +108,7 @@ fn collect_expr_shimmers(
     types: &HashMap<ValueKey, TypeLattice>,
     stmt_span: Span,
     in_loop: bool,
+    seen: &mut HashSet<(Span, String)>,
     out: &mut Vec<ShimmerWarning>,
 ) {
     match node {
@@ -108,8 +116,8 @@ fn collect_expr_shimmers(
             op, left, right, ..
         } => {
             // Recurse into children first.
-            collect_expr_shimmers(left, uses, types, stmt_span, in_loop, out);
-            collect_expr_shimmers(right, uses, types, stmt_span, in_loop, out);
+            collect_expr_shimmers(left, uses, types, stmt_span, in_loop, seen, out);
+            collect_expr_shimmers(right, uses, types, stmt_span, in_loop, seen, out);
 
             match op {
                 // Arithmetic, bitwise, logical, and *ordering* comparison
@@ -132,8 +140,8 @@ fn collect_expr_shimmers(
                 | BinOp::Le
                 | BinOp::Gt
                 | BinOp::Ge => {
-                    check_numeric_operand(left, uses, types, stmt_span, *op, in_loop, out);
-                    check_numeric_operand(right, uses, types, stmt_span, *op, in_loop, out);
+                    check_numeric_operand(left, uses, types, stmt_span, *op, in_loop, seen, out);
+                    check_numeric_operand(right, uses, types, stmt_span, *op, in_loop, seen, out);
                 }
 
                 // `==` / `!=` take the numeric-coercion path only when at least
@@ -144,8 +152,12 @@ fn collect_expr_shimmers(
                     if operand_looks_numeric(left, uses, types)
                         || operand_looks_numeric(right, uses, types)
                     {
-                        check_numeric_operand(left, uses, types, stmt_span, *op, in_loop, out);
-                        check_numeric_operand(right, uses, types, stmt_span, *op, in_loop, out);
+                        check_numeric_operand(
+                            left, uses, types, stmt_span, *op, in_loop, seen, out,
+                        );
+                        check_numeric_operand(
+                            right, uses, types, stmt_span, *op, in_loop, seen, out,
+                        );
                     }
                 }
 
@@ -156,8 +168,8 @@ fn collect_expr_shimmers(
                 | BinOp::StrLe
                 | BinOp::StrGt
                 | BinOp::StrGe => {
-                    check_string_operand(left, uses, types, stmt_span, *op, in_loop, out);
-                    check_string_operand(right, uses, types, stmt_span, *op, in_loop, out);
+                    check_string_operand(left, uses, types, stmt_span, *op, in_loop, seen, out);
+                    check_string_operand(right, uses, types, stmt_span, *op, in_loop, seen, out);
                 }
 
                 _ => {}
@@ -165,7 +177,7 @@ fn collect_expr_shimmers(
         }
 
         ExprNode::Unary { operand, .. } => {
-            collect_expr_shimmers(operand, uses, types, stmt_span, in_loop, out);
+            collect_expr_shimmers(operand, uses, types, stmt_span, in_loop, seen, out);
         }
 
         ExprNode::Ternary {
@@ -174,9 +186,9 @@ fn collect_expr_shimmers(
             false_branch,
             ..
         } => {
-            collect_expr_shimmers(condition, uses, types, stmt_span, in_loop, out);
-            collect_expr_shimmers(true_branch, uses, types, stmt_span, in_loop, out);
-            collect_expr_shimmers(false_branch, uses, types, stmt_span, in_loop, out);
+            collect_expr_shimmers(condition, uses, types, stmt_span, in_loop, seen, out);
+            collect_expr_shimmers(true_branch, uses, types, stmt_span, in_loop, seen, out);
+            collect_expr_shimmers(false_branch, uses, types, stmt_span, in_loop, seen, out);
         }
 
         _ => {}
@@ -244,6 +256,7 @@ fn expr_string_is_numeric(text: &str) -> bool {
 /// Emit a shimmer if `node` is a variable reference with a non-numeric
 /// type used in a numeric arithmetic context.  The code is S101 inside a
 /// loop body (per-iteration conversion) and S100 outside one.
+#[allow(clippy::too_many_arguments)]
 fn check_numeric_operand(
     node: &ExprNode,
     uses: &HashMap<String, u32>,
@@ -251,6 +264,7 @@ fn check_numeric_operand(
     span: Span,
     op: BinOp,
     in_loop: bool,
+    seen: &mut HashSet<(Span, String)>,
     out: &mut Vec<ShimmerWarning>,
 ) {
     let ExprNode::Var { name, .. } = node else {
@@ -273,6 +287,10 @@ fn check_numeric_operand(
     };
     // Only flag clearly non-numeric types (String, List, Dict).
     if matches!(current, TclType::String | TclType::List | TclType::Dict) {
+        // De-duplicate per (statement span, variable) within the block.
+        if !seen.insert((span, base.to_owned())) {
+            return;
+        }
         let code = if in_loop { "S101" } else { "S100" };
         out.push(ShimmerWarning {
             span,
@@ -295,6 +313,7 @@ fn check_numeric_operand(
 
 /// Emit a shimmer if `node` is a numeric variable used in a string
 /// comparison.  S101 inside a loop body, S100 outside one.
+#[allow(clippy::too_many_arguments)]
 fn check_string_operand(
     node: &ExprNode,
     uses: &HashMap<String, u32>,
@@ -302,6 +321,7 @@ fn check_string_operand(
     span: Span,
     op: BinOp,
     in_loop: bool,
+    seen: &mut HashSet<(Span, String)>,
     out: &mut Vec<ShimmerWarning>,
 ) {
     let ExprNode::Var { name, .. } = node else {
@@ -327,6 +347,10 @@ fn check_string_operand(
         current,
         TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean
     ) {
+        // De-duplicate per (statement span, variable) within the block.
+        if !seen.insert((span, base.to_owned())) {
+            return;
+        }
         let code = if in_loop { "S101" } else { "S100" };
         out.push(ShimmerWarning {
             span,
@@ -446,6 +470,25 @@ mod tests {
         assert!(
             has_shimmer,
             "expected Int-in-string-cmp shimmer in if-condition, got: {w:?}"
+        );
+    }
+
+    /// The same variable used in several operands of one expression emits a
+    /// single shimmer, not one per operand (per-block `(span, var)` dedup).
+    #[test]
+    fn expr_shimmer_dedups_repeated_operand() {
+        let cu = CompilationUnit::build_for(
+            "set x \"hi\"\nset y [expr {$x + $x + $x}]",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let xs: Vec<_> = w.iter().filter(|sw| sw.variable == "x").collect();
+        assert_eq!(
+            xs.len(),
+            1,
+            "repeated operand must emit one shimmer, got: {xs:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -132,6 +132,11 @@ pub(crate) fn find_phi_shimmers(
                 })
                 .collect();
 
+            // A merge inside a loop body re-shimmers every iteration (S101);
+            // an out-of-loop branch merge is a one-time conversion (S100).
+            // Mirrors Python `_find_phi_shimmers`' `code = "S101" if in_loop
+            // else "S100"` (was hardcoded to S101).
+            let code = if in_loop { "S101" } else { "S100" };
             out.push(ShimmerWarning {
                 span,
                 variable: phi.name.clone(),
@@ -139,9 +144,9 @@ pub(crate) fn find_phi_shimmers(
                 to_type: to,
                 command: "<phi>".to_owned(),
                 in_loop,
-                code: "S101".to_owned(),
+                code: code.to_owned(),
                 message: format!(
-                    "S101: '{var}' merges {from} and {to} at control-flow join",
+                    "{code}: '{var}' merges {from} and {to} at control-flow join",
                     var = phi.name,
                     from = type_name(from),
                     to = type_name(to),
@@ -212,7 +217,9 @@ mod tests {
     }
 
     /// An if/else that assigns Int on one branch and String on the other
-    /// produces an S101 warning at the phi merge point.
+    /// produces an S100 warning at the phi merge point — the conversion is
+    /// one-time (the merge is not inside a loop), so the code is S100, not
+    /// the per-iteration S101.
     #[test]
     fn phi_shimmer_emitted_for_int_string_merge() {
         // Use [gets stdin] for the condition so SCCP cannot fold the branch;
@@ -224,12 +231,13 @@ mod tests {
         );
         let fu = cu.function("::top").unwrap();
         let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
-        let has_shimmer = warnings
-            .iter()
-            .any(|w| w.variable == "x" && w.code == "S101");
+        let merge = warnings.iter().find(|w| w.variable == "x");
         assert!(
-            has_shimmer,
-            "expected S101 phi shimmer for Int/String merge of 'x', got: {warnings:?}"
+            merge.is_some(),
+            "expected a phi shimmer for Int/String merge of 'x', got: {warnings:?}"
         );
+        let merge = merge.unwrap();
+        assert_eq!(merge.code, "S100", "out-of-loop merge must be S100");
+        assert!(!merge.in_loop);
     }
 }

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -51,6 +51,9 @@ pub(crate) fn find_use_site_shimmers(
 ) -> Vec<ShimmerWarning> {
     let loop_blocks = loop_body_blocks(cfg);
     let def_map = def_range_map(ssa);
+    // Loop-invariance facts for the S101→S100 downgrade — only needed when
+    // the function has at least one loop block.
+    let loop_facts = LoopFacts::compute(cfg, ssa, &loop_blocks, registry);
     let mut out: Vec<ShimmerWarning> = Vec::new();
 
     for block_name in cfg_order(cfg) {
@@ -75,6 +78,7 @@ pub(crate) fn find_use_site_shimmers(
                 in_loop,
                 &def_map,
                 values,
+                &loop_facts,
                 &mut already_coerced,
                 &mut out,
             );
@@ -82,6 +86,96 @@ pub(crate) fn find_use_site_shimmers(
     }
 
     out
+}
+
+/// Loop-invariance facts used to refine the in-loop shimmer classification.
+///
+/// A variable used inside a loop is "per-iteration" (S101) only if its
+/// intrep can be reset each iteration — i.e. something in the loop body
+/// defines it. A loop-*invariant* variable (no def inside any loop block)
+/// shimmers once at the first iteration and is cached for the rest, so the
+/// right code is S100 (one-time) — *unless* it is coerced to two or more
+/// distinct target intreps inside the loop, in which case the converters
+/// re-thunk it each pass (genuine S101). Mirrors the `loop_def_names` +
+/// `loop_use_targets` maps in Python `shimmer.py`.
+#[derive(Default)]
+struct LoopFacts {
+    /// Names defined anywhere in a loop block (statement defs + phis).
+    def_names: HashSet<String>,
+    /// Per-name set of expected intreps requested at any use-site in a
+    /// loop block.
+    use_targets: HashMap<String, HashSet<TclType>>,
+}
+
+impl LoopFacts {
+    fn compute(
+        cfg: &CfgFunction,
+        ssa: &SsaFunction,
+        loop_blocks: &HashSet<String>,
+        registry: &CommandRegistry,
+    ) -> Self {
+        let mut facts = Self::default();
+        if loop_blocks.is_empty() {
+            return facts;
+        }
+        for lbn in loop_blocks {
+            if let Some(sb) = ssa.blocks.get(lbn) {
+                for st in &sb.statements {
+                    facts.def_names.extend(st.defs.keys().cloned());
+                }
+                for phi in &sb.phis {
+                    facts.def_names.insert(phi.name.clone());
+                }
+            }
+            if let Some(cb) = cfg.blocks.get(lbn) {
+                for stmt in &cb.statements {
+                    facts.record_use_targets(stmt, registry);
+                }
+            }
+        }
+        facts
+    }
+
+    /// Record the expected intrep of every `$var` argument at a shimmering
+    /// position of `stmt` (a direct call or a `[cmd …]` substitution
+    /// inside an assignment value).
+    fn record_use_targets(&mut self, stmt: &Statement, registry: &CommandRegistry) {
+        let mut record = |command: &str, args: &[String]| {
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            for (i, word) in args.iter().enumerate() {
+                if !word.trim_start().starts_with('$') {
+                    continue;
+                }
+                if let Some(expected) = arg_shimmer_type(registry, command, &arg_refs, i) {
+                    let var = normalise_var_name(word.trim()).to_owned();
+                    self.use_targets.entry(var).or_default().insert(expected);
+                }
+            }
+        };
+        match stmt {
+            Statement::Call { command, args, .. } => record(command, args),
+            Statement::AssignValue { value, .. } => {
+                if let Some((command, args)) =
+                    crate::value_shapes::parse_command_substitution(value.trim())
+                {
+                    record(&command, &args);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Refine `in_loop` for a single use of `var`: a loop-invariant variable
+    /// coerced to fewer than two distinct intreps inside the loop converts
+    /// once and is cached, so it is S100 (not S101). Mirrors Python's
+    /// `effective_in_loop` computation.
+    fn effective_in_loop(&self, var: &str, in_loop: bool) -> bool {
+        if in_loop && !self.def_names.contains(var) {
+            self.use_targets.get(var).is_some_and(|t| t.len() >= 2)
+        } else {
+            in_loop
+        }
+    }
 }
 
 /// True when `value` is a SCCP CONST string whose text is a hex /
@@ -125,6 +219,7 @@ fn check_invocation(
     registry: &CommandRegistry,
     in_loop: bool,
     def_map: &HashMap<ValueKey, Span>,
+    loop_facts: &LoopFacts,
     already_coerced: &mut HashSet<(String, u32, TclType)>,
     out: &mut Vec<ShimmerWarning>,
 ) {
@@ -168,7 +263,15 @@ fn check_invocation(
             .get(&(var.clone(), ver))
             .map(|&sp| vec![(sp, "value defined here".to_owned())])
             .unwrap_or_default();
-        let code = if in_loop { "S101" } else { "S100" }.to_owned();
+        // A loop-invariant variable coerced to a single intrep inside the
+        // loop converts once and is cached → S100, not the per-iteration
+        // S101.  Mirrors Python's `effective_in_loop`.
+        let code = if loop_facts.effective_in_loop(&var, in_loop) {
+            "S101"
+        } else {
+            "S100"
+        }
+        .to_owned();
         out.push(ShimmerWarning {
             span,
             variable: var.clone(),
@@ -198,6 +301,7 @@ fn check_statement(
     in_loop: bool,
     def_map: &HashMap<ValueKey, Span>,
     values: &HashMap<ValueKey, LatticeValue>,
+    loop_facts: &LoopFacts,
     already_coerced: &mut HashSet<(String, u32, TclType)>,
     out: &mut Vec<ShimmerWarning>,
 ) {
@@ -212,6 +316,7 @@ fn check_statement(
                 registry,
                 in_loop,
                 def_map,
+                loop_facts,
                 already_coerced,
                 out,
             );
@@ -234,64 +339,105 @@ fn check_statement(
                     registry,
                     in_loop,
                     def_map,
+                    loop_facts,
                     already_coerced,
                     out,
                 );
             }
         }
 
-        Statement::Incr { name, .. } => {
-            // `incr` always reads its variable as Int.
-            // Handled as a special IR node (not a Call) — check explicitly.
-            let var = normalise_var_name(name).to_owned();
-            let Some(&ver) = uses.get(&var) else { return };
-            if ver == 0 {
-                return;
-            }
-            let lattice = types
-                .get(&(var.clone(), ver))
-                .cloned()
-                .unwrap_or_else(TypeLattice::unknown);
-            if lattice.kind != TypeKind::Known {
-                return;
-            }
-            let Some(current) = lattice.tcl_type else {
-                return;
-            };
-            if is_numeric_compatible(current, TclType::Int) {
-                return;
-            }
-            // A hex / octal / binary literal string (`0x80`, `0b1010`)
-            // classifies as String but promotes cleanly to Int at the
-            // `incr` — not a real shimmer (SYNC-MAY31-1e; avoids the
-            // spurious S101 on the tcllib `variable n 0x80; … incr n`
-            // idiom).
-            if value_is_int_literal_string(values.get(&(var.clone(), ver))) {
-                return;
-            }
-            let related: Vec<(Span, String)> = def_map
-                .get(&(var.clone(), ver))
-                .map(|&sp| vec![(sp, "value defined here".to_owned())])
-                .unwrap_or_default();
-            let code = if in_loop { "S101" } else { "S100" }.to_owned();
-            out.push(ShimmerWarning {
-                span: stmt.span(),
-                variable: var.clone(),
-                from_type: current,
-                to_type: TclType::Int,
-                command: "incr".to_owned(),
+        Statement::Incr { name, amount, .. } => {
+            // `incr` reads both its target variable and (when present) its
+            // increment argument as Int.  The two checks are independent —
+            // an Int target with a String `$amount` still shimmers on the
+            // amount — so neither must short-circuit the other (mirrors the
+            // two separate `if` blocks in Python `shimmer.py`).
+            check_incr_var(
+                normalise_var_name(name),
+                stmt.span(),
+                uses,
+                types,
+                values,
                 in_loop,
-                code: code.clone(),
-                message: format!(
-                    "{code}: variable '{var}' has {from} intrep but 'incr' expects int",
-                    from = type_name(current),
-                ),
-                related,
-            });
+                def_map,
+                out,
+            );
+            if let Some(amt) = amount.as_deref().map(str::trim)
+                && amt.starts_with('$')
+            {
+                check_incr_var(
+                    normalise_var_name(amt),
+                    stmt.span(),
+                    uses,
+                    types,
+                    values,
+                    in_loop,
+                    def_map,
+                    out,
+                );
+            }
         }
 
         _ => {}
     }
+}
+
+/// Check one `incr` operand (the target variable or the increment
+/// argument) for an intrep shimmer to `Int`.
+///
+/// `var` is the normalised variable name. Fires when its known intrep is a
+/// non-int, non-numeric type that is not a clean hex/octal/binary integer
+/// literal string (that spelling promotes cleanly to int — SYNC-MAY31-1e).
+#[allow(clippy::too_many_arguments)]
+fn check_incr_var(
+    var: &str,
+    span: Span,
+    uses: &HashMap<String, u32>,
+    types: &HashMap<ValueKey, TypeLattice>,
+    values: &HashMap<ValueKey, LatticeValue>,
+    in_loop: bool,
+    def_map: &HashMap<ValueKey, Span>,
+    out: &mut Vec<ShimmerWarning>,
+) {
+    let Some(&ver) = uses.get(var) else { return };
+    if ver == 0 {
+        return;
+    }
+    let lattice = types
+        .get(&(var.to_owned(), ver))
+        .cloned()
+        .unwrap_or_else(TypeLattice::unknown);
+    if lattice.kind != TypeKind::Known {
+        return;
+    }
+    let Some(current) = lattice.tcl_type else {
+        return;
+    };
+    if current == TclType::Int || is_numeric_compatible(current, TclType::Int) {
+        return;
+    }
+    if value_is_int_literal_string(values.get(&(var.to_owned(), ver))) {
+        return;
+    }
+    let related: Vec<(Span, String)> = def_map
+        .get(&(var.to_owned(), ver))
+        .map(|&sp| vec![(sp, "value defined here".to_owned())])
+        .unwrap_or_default();
+    let code = if in_loop { "S101" } else { "S100" }.to_owned();
+    out.push(ShimmerWarning {
+        span,
+        variable: var.to_owned(),
+        from_type: current,
+        to_type: TclType::Int,
+        command: "incr".to_owned(),
+        in_loop,
+        code: code.clone(),
+        message: format!(
+            "{code}: variable '{var}' has {from} intrep but 'incr' expects int",
+            from = type_name(current),
+        ),
+        related,
+    });
 }
 
 #[cfg(test)]
@@ -418,6 +564,65 @@ mod tests {
         assert_eq!(w.code, "S101");
         assert_eq!(w.from_type, TclType::String);
         assert_eq!(w.to_type, TclType::List);
+    }
+
+    /// A loop-invariant variable (defined outside the loop) coerced to a
+    /// single intrep inside the loop converts once and is cached — that is a
+    /// one-time S100, not the per-iteration S101.
+    #[test]
+    fn loop_invariant_single_target_downgrades_to_s100() {
+        let src = "proc f {} {\n  set data {1 2 3}\n  for {set i 0} {$i < 3} {incr i} {\n    set x [lindex $data $i]\n  }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "lindex" && w.variable == "data");
+        assert!(
+            w.is_some(),
+            "expected lindex shimmer for data: {warnings:?}"
+        );
+        assert_eq!(
+            w.unwrap().code,
+            "S100",
+            "loop-invariant single-target use is one-time (S100): {warnings:?}"
+        );
+    }
+
+    /// `incr n $step` where `$step` holds a String shimmers on the increment
+    /// argument (Tcl coerces it to int).
+    #[test]
+    fn incr_amount_string_var_shimmers() {
+        let cu = CompilationUnit::build_for(
+            "set n 0\nset step \"hello\"\nincr n $step",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "incr" && w.variable == "step");
+        assert!(
+            w.is_some(),
+            "expected incr-amount shimmer for step: {warnings:?}"
+        );
+        assert_eq!(w.unwrap().from_type, TclType::String);
+        assert_eq!(w.unwrap().to_type, TclType::Int);
     }
 
     /// Variables with Unknown type do not produce false-positive shimmers.

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -25,7 +25,7 @@
 
 use std::collections::HashMap;
 
-use tcl_registry::{CommandRegistry, TclType};
+use tcl_registry::{CommandRegistry, TclType, Traits};
 
 use crate::cfg::{Function as CfgFunction, Terminator};
 use crate::expr_ast::{BinOp, ExprNode, UnaryOp};
@@ -81,6 +81,36 @@ fn literal_type(text: &str) -> TypeLattice {
     TypeLattice::of(TclType::String)
 }
 
+/// Classify a literal's type in **expr context**, mirroring
+/// `expr_types._literal_type_from_text`.
+///
+/// The expr parser tokenises every integer spelling — decimal, hex
+/// (`0xff`), octal (`0o15`), and binary (`0b1010`) — as an integer
+/// (`Tcl_GetInt` accepts them), so they all map to `Int`. This is the key
+/// divergence from the set-statement [`literal_type`], where `0o…` stays
+/// `String` (its canonical stringified intrep differs from the source
+/// text). An unrecognised literal degrades to `Numeric` — an `expr`
+/// always yields a number — rather than to `String`.
+fn expr_literal_type(text: &str) -> TypeLattice {
+    let s = text.trim();
+    let low = s.to_ascii_lowercase();
+    // Boolean first (matches Python's ordering).
+    if BOOL_LITERALS.contains(&low.as_str()) {
+        return TypeLattice::of(TclType::Boolean);
+    }
+    // Every integer-form spelling tokenises to int in expr context.
+    if low.starts_with("0x") || low.starts_with("0o") || low.starts_with("0b") {
+        return TypeLattice::of(TclType::Int);
+    }
+    if s.parse::<i64>().is_ok() {
+        return TypeLattice::of(TclType::Int);
+    }
+    if s.parse::<f64>().is_ok() {
+        return TypeLattice::of(TclType::Double);
+    }
+    TypeLattice::of(TclType::Numeric)
+}
+
 /// Return the type produced by a known command's return value.
 ///
 /// Checks the command spec's `return_type` field, with subcommand
@@ -125,7 +155,7 @@ pub(crate) fn return_type_for_command(
 #[must_use]
 fn infer_expr_type(node: &ExprNode, var_types: &HashMap<String, TypeLattice>) -> TypeLattice {
     match node {
-        ExprNode::Literal { text, .. } => literal_type(text),
+        ExprNode::Literal { text, .. } => expr_literal_type(text),
 
         ExprNode::String { .. } => TypeLattice::of(TclType::String),
 
@@ -194,7 +224,13 @@ fn infer_expr_type(node: &ExprNode, var_types: &HashMap<String, TypeLattice>) ->
         }
 
         ExprNode::Unary { op, operand, .. } => match op {
-            UnaryOp::Neg | UnaryOp::Pos | UnaryOp::BitNot => infer_expr_type(operand, var_types),
+            // Arithmetic sign is identity (same intrep as the operand);
+            // bitwise NOT always coerces to `Int` (`~$double` → Int);
+            // logical NOT yields `Boolean`.  Mirrors `expr_types`'
+            // `UnaryOpKind` BITWISE arm (GAP-B4: `~` was grouped with
+            // the identity ops and leaked the operand's `Double`).
+            UnaryOp::Neg | UnaryOp::Pos => infer_expr_type(operand, var_types),
+            UnaryOp::BitNot => TypeLattice::of(TclType::Int),
             UnaryOp::Not | UnaryOp::WordNot => TypeLattice::of(TclType::Boolean),
         },
 
@@ -283,6 +319,28 @@ fn expr_call_type(
         // Unknown function — conservative (matches Python's NUMERIC).
         _ => TypeLattice::of(TclType::Numeric),
     }
+}
+
+/// True when `command` (with `args`) creates a scope alias — `global`,
+/// `variable`, `upvar`, or the `namespace upvar` compound.
+///
+/// Such a statement imports an externally-determined variable whose intrep
+/// lives in another scope, so its def must widen to `Overdefined` rather
+/// than take the command's nominal (`String`) return type — otherwise a
+/// use-site / merge shimmer check fires on a nominally-`String`-typed
+/// alias.  Derived from the registry's `CREATES_SCOPE_ALIAS` trait
+/// (top-level commands) and the per-subcommand `creates_scope_alias` flag
+/// (`namespace upvar`), mirroring Python's `scope_alias_commands()`.
+fn is_scope_alias_call(registry: &CommandRegistry, command: &str, args: &[String]) -> bool {
+    let Some(spec) = registry.get(command) else {
+        return false;
+    };
+    if spec.traits.contains(Traits::CREATES_SCOPE_ALIAS) {
+        return true;
+    }
+    args.first()
+        .and_then(|sub| spec.subcommand(sub))
+        .is_some_and(|sub| sub.creates_scope_alias)
 }
 
 /// Infer the type produced by `stmt` under the current `types` map.
@@ -441,36 +499,35 @@ pub fn propagate_types(
             // Statements.
             for ssa_stmt in &ssa_block.statements {
                 let stmt = &ssa_stmt.statement;
-                match stmt {
-                    Statement::Barrier { .. } => {
-                        for (var, &ver) in &ssa_stmt.defs {
-                            let key = (var.clone(), ver);
-                            let old = types
-                                .get(&key)
-                                .cloned()
-                                .unwrap_or_else(TypeLattice::unknown);
-                            let merged = type_join(&old, &TypeLattice::overdefined());
-                            if merged != old {
-                                types.insert(key, merged);
-                                changed = true;
-                            }
-                        }
+                // A barrier widens every def to OVERDEFINED (it may have
+                // mutated them arbitrarily); a scope-alias declaration
+                // (`global`/`variable`/`upvar`/`namespace upvar`) likewise
+                // widens its defs — the imported variable's intrep is
+                // external and unknown.  Mirrors `_type_propagation`'s
+                // barrier + `alias_cmds` arms.  Every def of one statement
+                // gets the same inferred type, so compute it once.
+                let inferred = match stmt {
+                    Statement::Barrier { .. } => TypeLattice::overdefined(),
+                    Statement::Call {
+                        command,
+                        args,
+                        defs,
+                        ..
+                    } if !defs.is_empty() && is_scope_alias_call(registry, command, args) => {
+                        TypeLattice::overdefined()
                     }
-                    _ => {
-                        for (var, &ver) in &ssa_stmt.defs {
-                            let inferred =
-                                evaluate_type_def(stmt, &ssa_stmt.uses, &types, registry);
-                            let key = (var.clone(), ver);
-                            let old = types
-                                .get(&key)
-                                .cloned()
-                                .unwrap_or_else(TypeLattice::unknown);
-                            let merged = type_join(&old, &inferred);
-                            if merged != old {
-                                types.insert(key, merged);
-                                changed = true;
-                            }
-                        }
+                    _ => evaluate_type_def(stmt, &ssa_stmt.uses, &types, registry),
+                };
+                for (var, &ver) in &ssa_stmt.defs {
+                    let key = (var.clone(), ver);
+                    let old = types
+                        .get(&key)
+                        .cloned()
+                        .unwrap_or_else(TypeLattice::unknown);
+                    let merged = type_join(&old, &inferred);
+                    if merged != old {
+                        types.insert(key, merged);
+                        changed = true;
                     }
                 }
             }
@@ -866,5 +923,76 @@ mod tests {
         assert_eq!(infer_str("3 + 2.0").tcl_type, Some(TclType::Double));
         // int + int → Int.
         assert_eq!(infer_str("3 + 4").tcl_type, Some(TclType::Int));
+    }
+
+    #[test]
+    fn expr_context_literal_typing() {
+        // Every integer spelling tokenises to Int in expr context — including
+        // octal `0o…`, which the set-statement classifier keeps as String.
+        assert_eq!(infer_str("0o17").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("0xff").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("0b1010").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("42").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("3.14").tcl_type, Some(TclType::Double));
+        // The set-statement classifier still keeps octal as String.
+        assert_eq!(literal_type("0o17"), TypeLattice::of(TclType::String));
+        // An unrecognised literal degrades to Numeric in expr context
+        // (the set-statement classifier would say String).
+        assert_eq!(expr_literal_type("nope").tcl_type, Some(TclType::Numeric));
+    }
+
+    #[test]
+    fn bitnot_coerces_to_int() {
+        // `~$x` always yields Int, regardless of the operand's type
+        // (was leaking the operand type via the identity arm).
+        assert_eq!(infer_str("~$x").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("~3.5").tcl_type, Some(TclType::Int));
+    }
+
+    #[test]
+    fn scope_alias_commands_detected() {
+        let reg = registry();
+        let one = |s: &str| vec![s.to_owned()];
+        assert!(is_scope_alias_call(&reg, "global", &one("g")));
+        assert!(is_scope_alias_call(&reg, "variable", &one("v")));
+        assert!(is_scope_alias_call(
+            &reg,
+            "upvar",
+            &["0".into(), "x".into(), "y".into()]
+        ));
+        assert!(is_scope_alias_call(
+            &reg,
+            "namespace",
+            &["upvar".into(), "ns".into(), "x".into(), "y".into()]
+        ));
+        // A plain command (and `namespace eval`) is not a scope alias.
+        assert!(!is_scope_alias_call(&reg, "set", &["x".into(), "1".into()]));
+        assert!(!is_scope_alias_call(
+            &reg,
+            "namespace",
+            &["eval".into(), "ns".into(), "body".into()]
+        ));
+    }
+
+    #[test]
+    fn scope_alias_def_widens_to_overdefined() {
+        use crate::compilation_unit::CompilationUnit;
+        // `variable counter` imports an externally-determined variable; its
+        // def must be OVERDEFINED, not the nominal return type of `variable`.
+        let cu = CompilationUnit::build_for(
+            "proc ::f {} { variable counter\n return $counter }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let widened = fu
+            .types
+            .iter()
+            .any(|((n, _), t)| n == "counter" && t.kind == TypeKind::Overdefined);
+        assert!(
+            widened,
+            "scope-aliased 'counter' should be OVERDEFINED: {:?}",
+            fu.types
+        );
     }
 }

--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -2,18 +2,86 @@
 //!
 //! Ported from `core/compiler/value_shapes.py`.
 
-/// Return `true` when `text` is a pure variable reference — either
-/// `$name` or `${name}` — with no surrounding text, whitespace, or
-/// extra Tcl syntax.
+/// Scan one Tcl variable reference starting at `text[at]`, returning the
+/// byte index just past its end, or `None` when `text[at..]` does not
+/// start with a valid reference.
+///
+/// Handles the three forms from the Tcl 9.0 `Tcl_ParseVar` spec, mirroring
+/// `value_shapes._scan_pure_var_ref`:
+///
+/// - `$name` — bare name in `[A-Za-z0-9_:]`; `::` runs stay part of the
+///   name (namespace-qualified).
+/// - `${name}` — braced; any character except `}` (escapes inside the
+///   braces are taken literally).
+/// - `$name(index)` — array element. The index runs to the matching `)`,
+///   with backslash-escaped close parens taken literally (so `$a(x\)y)`
+///   is one reference whose index text is `x\)y`).
+fn scan_pure_var_ref(text: &str, at: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(at) != Some(&b'$') {
+        return None;
+    }
+    let mut i = at + 1;
+    // Braced form `${...}`.
+    if bytes.get(i) == Some(&b'{') {
+        let mut j = i + 1;
+        while j < bytes.len() && bytes[j] != b'}' {
+            j += 1;
+        }
+        if j >= bytes.len() {
+            return None;
+        }
+        return Some(j + 1);
+    }
+    // Bare name: alphanumeric + `_` + `:`.
+    let name_start = i;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || matches!(bytes[i], b'_' | b':')) {
+        i += 1;
+    }
+    if i == name_start {
+        return None;
+    }
+    // Optional array index `(index)` — backslash-escape aware.
+    if bytes.get(i) == Some(&b'(') {
+        let mut j = i + 1;
+        while j < bytes.len() {
+            match bytes[j] {
+                b'\\' if j + 1 < bytes.len() => j += 2, // skip escaped char
+                b')' => return Some(j + 1),
+                _ => j += 1,
+            }
+        }
+        return None; // unterminated index
+    }
+    Some(i)
+}
+
+/// Return `true` when `text` is exactly one variable reference (`$x` /
+/// `${x}` / `$ns::x` / `$arr(idx)`) with no surrounding or concatenated
+/// syntax.
+///
+/// The check gates the uplevel/safe-eval idioms: `uplevel 1 $body` is
+/// single-substitution-safe only when `$body` is one pure reference;
+/// anything else double-substitutes the composed value.
 #[must_use]
 pub fn is_pure_var_ref(text: &str) -> bool {
-    if let Some(inner) = text.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
-        return !inner.contains('}');
-    }
-    text.starts_with('$')
-        && !text
-            .bytes()
-            .any(|b| matches!(b, b' ' | b'"' | b'{' | b'}' | b'[' | b']'))
+    scan_pure_var_ref(text, 0) == Some(text.len())
+}
+
+/// Return `true` when `text` is a braced array-shaped var ref `${a(1)}`.
+///
+/// tclsh 9 loads such a reference by its whole literal name (`a(1)`
+/// resolved at runtime as array element `a(1)`), so the value is a
+/// *variable reference*, never a constant — analyses must treat it as
+/// conservatively unknown (overdefined), the same as `${ns::y}`. A plain
+/// braced scalar `${foo}` (no parens) is *not* matched. Mirrors
+/// `value_shapes.is_braced_whole_name_array_ref`.
+#[must_use]
+pub fn is_braced_whole_name_array_ref(text: &str) -> bool {
+    let Some(inner) = text.strip_prefix("${").and_then(|s| s.strip_suffix('}')) else {
+        return false;
+    };
+    inner.contains('(') && inner.ends_with(')') && !inner.contains('}')
 }
 
 /// Extract command name and args from `[cmd arg1 arg2 …]`.
@@ -55,6 +123,35 @@ mod tests {
     #[test]
     fn pure_var_rejects_unbalanced_braces() {
         assert!(!is_pure_var_ref("${x}y"));
+    }
+
+    #[test]
+    fn pure_var_accepts_array_index() {
+        assert!(is_pure_var_ref("$arr(idx)"));
+        assert!(is_pure_var_ref("$arr(key)"));
+        assert!(is_pure_var_ref("${a(1)}"));
+        // Backslash-escaped close paren stays inside the one index.
+        assert!(is_pure_var_ref("$a(x\\)y)"));
+    }
+
+    #[test]
+    fn pure_var_rejects_concatenation_and_trailing_text() {
+        // Over-permissive cases the byte-set heuristic used to accept.
+        assert!(!is_pure_var_ref("$x$y"));
+        assert!(!is_pure_var_ref("$x.foo"));
+        assert!(!is_pure_var_ref("$x_$y"));
+        // Unterminated array index is not a pure reference.
+        assert!(!is_pure_var_ref("$arr(idx"));
+    }
+
+    #[test]
+    fn braced_whole_name_array_ref_detection() {
+        assert!(is_braced_whole_name_array_ref("${a(1)}"));
+        assert!(is_braced_whole_name_array_ref("${arr(key)}"));
+        // Plain braced scalar is not an array-shaped ref.
+        assert!(!is_braced_whole_name_array_ref("${foo}"));
+        assert!(!is_braced_whole_name_array_ref("$arr(1)"));
+        assert!(!is_braced_whole_name_array_ref("${a(1)}x"));
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5193,6 +5193,7 @@ fn lift_compiler_diagnostics(
             severity: Some(match d.severity {
                 CheckSeverity::Error => DiagnosticSeverity::ERROR,
                 CheckSeverity::Warning => DiagnosticSeverity::WARNING,
+                CheckSeverity::Info => DiagnosticSeverity::INFORMATION,
                 CheckSeverity::Hint | CheckSeverity::Suggestion => DiagnosticSeverity::HINT,
             }),
             code: Some(NumberOrString::String(d.code)),


### PR DESCRIPTION
Completes the **FE-TYPESHIM** track of the Rust rewrite (`docs/rust-rewrite.md`),
porting the remaining precision and soundness residuals from the Python
front-end across the four owned modules — `type_infer`, `value_shapes`,
`rendered_properties`, and `shimmer`.

## shimmer
- **S100 now emits as LSP `Information`** via a new
  `compiler_checks::Severity::Info` variant (mapped to `INFORMATION` in the
  server); S101/S102 stay `Warning`. Mirrors Python `_SHIMMER_SEVERITY`.
- The **S100/S101 code is computed from `in_loop`** in both `phi.rs` and
  `expr.rs` (both previously hardcoded the code).
- Ported the **loop-invariant S101→S100 downgrade** (`use_site::LoopFacts`):
  a loop-invariant variable coerced to a single intrep converts once and is
  cached.
- Ported the **`incr`-amount shimmer check** (the increment argument also
  expects int) — previously skipped whenever the target was already int.
- Ported the **per-statement `(span, var)` expr-shimmer de-duplication**
  (Python's `seen` set): `expr {$x + $x}` now emits one warning, not one
  per operand.

## type_infer
- Added an **expr-context literal classifier** (`0o`/`0x`/`0b` → `Int`,
  unrecognised → `Numeric`), distinct from the set-statement classifier.
- **`~$double` → `Int`** (`UnaryOp::BitNot` no longer leaks the operand type).
- **Scope-alias defs widen to `Overdefined`** (`global`/`variable`/`upvar`/
  `namespace upvar`), driven by the registry `CREATES_SCOPE_ALIAS` trait.

## rendered_properties
- `scan_escape` now decodes escapes through `tcl_lexer::backslash_subst`, so
  numeric/hex/octal/unicode escapes that render to `/` set
  `HAS_FORWARD_SLASH` (fixes a W201 false-negative); null/CRLF likewise.

## value_shapes
- `is_pure_var_ref` accepts `$arr(idx)` (escape-aware index) via a faithful
  port of `_scan_pure_var_ref`; added `is_braced_whole_name_array_ref` for
  `${a(1)}`.

## Deferred (documented in the plan)
Precise TclOO `object_of` typing is routed to **FE-DIAG**, which owns both
the analyser-layer class extraction (the Rust IR keeps `namespace eval`
bodies as raw barriers, so the class set must come from `signature_scan`,
not an IR walk) and the W307/W308 emitter that is its only consumer.
TclOO constructor results already widen to `Overdefined` today.

## Verification
- Behaviour verified against **tclsh 8.4, 8.5, 8.6, and 9.0** (escape
  rendering `\x2f`/`\057`/`/`→`/`, expr literal typing, bitwise-not,
  array refs).
- New unit tests cover every change; full Rust suite green; `cargo fmt
  --check` and `cargo clippy --workspace --all-targets` clean;
  `make check-rust` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdcJZ6ddTNzXCWRQeHmWzb)_