### PR TITLE
FE-DATAFLOW: finish SCCP / intervals / memory-SSA residuals

### DIFF
--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1006,26 +1006,32 @@ Owns `tcl-lexer`, `tcl-syntax`, `tcl-compiler::parsing`.
 - **open** nested-body E202/E203 detectors (top-level only today) and the
   precise `partial_delimiter` suffix field on `SegmentedCommand`. *(tiny)*
 
-#### FE-DATAFLOW — SCCP / intervals / memory-SSA precision
-Owns `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}`.
-- **open** SCCP escaping-var widening — force `::g` / escaping names to
-  OVERDEFINED; consult `var_observability::escaping_var_names` from
-  `sccp.rs::evaluate_def` (unsound const-prop without it).
-- **open** SCCP optimistic (Wegman–Zadeck) UNKNOWN deferral + finalising pass
-  (`sccp.rs` opens both arms immediately today).
-- **open** SCCP break-exit precompute (infinite-loop+break) and the
-  static-loop → SCCP/interval fold (wire `summarise_for_statement`, which has no
-  production caller; carry the `IRFor` on `LoopNode`).
-- **open** memory-SSA `IRUpFrame` clobber (`memory_ssa.rs::is_clobber` is missing
-  `Statement::UpFrame => true`) and the `upvar 1 x a; upvar 1 x b` may-alias
-  edge. *(1-line + edge)*
-- **open** W233 interval div-by-zero path — the production emitter is
-  SCCP-constant-only; the ported `find_divide_by_zero` is dead. Wire it or
-  document the simplification.
-- **open** `complexity_guard` (cross-cutting) — port the size-based escape hatch
-  Python applies in `ssa.py`, `taint/_api.py`, `optimiser/_manager.py`,
-  `shimmer.py` (0 occurrences in Rust). Absence → runaway latency + over-optimistic
-  interproc summaries on adversarial input.
+#### FE-DATAFLOW — SCCP / intervals / memory-SSA precision ✅
+Owns `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}`. All
+residuals have landed:
+- **done** SCCP escaping-var widening — `sccp` consults
+  `var_observability::escaping_var_names` and forces `::`-qualified / aliased /
+  traced definitions to OVERDEFINED (mirrors `_is_externally_mutable`).
+- **done** SCCP optimistic (Wegman–Zadeck) UNKNOWN deferral + monotone
+  finalising pass (`branch_deferrable`; the driver runs at most twice).
+- **done** static-loop → SCCP fold — `LoopNode` carries the `IRFor` and the
+  branch decision wires `summarise_for_statement`, folding a post-loop branch
+  on a loop variable. The break-exit case needs no SCCP precompute: the Rust
+  CFG builder already lowers `break` to a direct loop-exit edge, so the
+  post-loop block is reachable by construction.
+- **done** memory-SSA `IRUpFrame` clobber + the shared-caller upvar may-alias
+  edge (`upvar 1 x a; upvar 1 x b` merge into one alias set).
+- **done** W233 interval div-by-zero path — the production emitter now delegates
+  to the (previously dead) interval-based `find_divide_by_zero`, the single
+  canonical implementation; the SCCP-only copy is gone.
+- **done** `complexity_guard` — `ssa::{COMPLEXITY_GUARD_BLOCKS,
+  DEEP_ANALYSIS_BODY_BYTES, is_complexity_guarded}`, a trivial-SSA short-circuit
+  in `build_ssa`, a `FunctionUnit::complexity_guarded` flag set from the
+  block-count or body-byte ceiling, and `CompilationUnit::analysable_functions`
+  filtering guarded bodies out of every per-proc diagnostic / optimiser pass.
+  (The interprocedural summary is IR-based, so it needs no guard — it never
+  develops the over-optimistic empty-SSA summary the Python guard exists to
+  prevent.)
 
 #### FE-TYPESHIM — type inference / shimmer / shapes
 Owns `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`.

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -7153,14 +7153,21 @@ file; this call falls through to the 'unknown' handler."
         } else {
             fu.sccp.executable_blocks.clone()
         };
-        for finding in
-            crate::interval_bounds::find_divide_by_zero(&fu.cfg, &fu.ssa, &fu.sccp.values, &executable)
-        {
+        for finding in crate::interval_bounds::find_divide_by_zero(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.sccp.values,
+            &executable,
+        ) {
             let span = fu.abs_span(finding.span);
             if span.is_empty() {
                 continue;
             }
-            let verb = if finding.op == "/" { "Division" } else { "Modulo" };
+            let verb = if finding.op == "/" {
+                "Division"
+            } else {
+                "Modulo"
+            };
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: "W233".to_string(),
                 span,

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -1419,141 +1419,6 @@ fn build_phi_undef_index(
     (phi_def, phi_block, killed)
 }
 
-/// True when an expression operand is provably the integer zero: a literal
-/// `0` (int or float spelling) or a variable whose SCCP value at `versions`
-/// is a constant zero.  Used by the W233 divide-by-zero check.
-fn expr_operand_is_zero(
-    node: &ExprNode,
-    versions: &std::collections::HashMap<String, crate::ssa::Version>,
-    sccp: &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
-) -> bool {
-    use crate::analyses::{ConstValue, LatticeValue};
-    let const_is_zero = |lv: Option<&LatticeValue>| match lv {
-        Some(LatticeValue::Const(ConstValue::Int(0) | ConstValue::Bool(false))) => true,
-        Some(LatticeValue::Const(ConstValue::Float(f))) => *f == 0.0,
-        Some(LatticeValue::Const(ConstValue::String(s))) => {
-            let t = s.trim();
-            t.parse::<i64>() == Ok(0) || t.parse::<f64>().is_ok_and(|f| f == 0.0)
-        }
-        _ => false,
-    };
-    match node {
-        ExprNode::Literal { text, .. } => {
-            let t = text.trim();
-            t.parse::<i64>() == Ok(0) || t.parse::<f64>().is_ok_and(|f| f == 0.0)
-        }
-        ExprNode::Var { name, .. } => versions
-            .get(name)
-            .is_some_and(|&ver| const_is_zero(sccp.get(&(name.clone(), ver)))),
-        _ => false,
-    }
-}
-
-/// Constant truthiness of `text` under Tcl boolean rules: a non-zero number
-/// is true, `0`/`0.0` false, and the literal boolean words (case-insensitive)
-/// map directly.  `None` when not a recognised constant.
-fn const_truthiness(text: &str) -> Option<bool> {
-    let t = text.trim();
-    if let Ok(n) = t.parse::<i64>() {
-        return Some(n != 0);
-    }
-    if let Ok(f) = t.parse::<f64>() {
-        return Some(f != 0.0);
-    }
-    match t.to_ascii_lowercase().as_str() {
-        "true" | "yes" | "on" => Some(true),
-        "false" | "no" | "off" => Some(false),
-        _ => None,
-    }
-}
-
-/// Provable truthiness of an expression operand (`Some(true)`/`Some(false)`),
-/// or `None` when not statically known.  Used to model short-circuit (`&&` /
-/// `||`) and ternary reachability for the W233 divisor walk.
-fn expr_truthiness(
-    node: &ExprNode,
-    versions: &std::collections::HashMap<String, crate::ssa::Version>,
-    sccp: &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
-) -> Option<bool> {
-    use crate::analyses::{ConstValue, LatticeValue};
-    match node {
-        ExprNode::Literal { text, .. } => const_truthiness(text),
-        ExprNode::Var { name, .. } => {
-            let ver = versions.get(name)?;
-            match sccp.get(&(name.clone(), *ver))? {
-                LatticeValue::Const(ConstValue::Int(n)) => Some(*n != 0),
-                LatticeValue::Const(ConstValue::Float(f)) => Some(*f != 0.0),
-                LatticeValue::Const(ConstValue::Bool(b)) => Some(*b),
-                LatticeValue::Const(ConstValue::String(s)) => const_truthiness(s),
-                _ => None,
-            }
-        }
-        // `-1` / `+1` keep the operand's zero-ness; `!x` / `not x` invert it.
-        ExprNode::Unary { op, operand } => match op {
-            UnaryOp::Neg | UnaryOp::Pos | UnaryOp::BitNot => {
-                expr_truthiness(operand, versions, sccp)
-            }
-            UnaryOp::Not | UnaryOp::WordNot => expr_truthiness(operand, versions, sccp).map(|b| !b),
-        },
-        _ => None,
-    }
-}
-
-/// Find the first `/` or `%` operator in `node` whose divisor is provably
-/// zero **and is actually reachable**, returning its [`BinOp`].  Models
-/// short-circuit `&&` / `||` and ternary reachability so a guarded division
-/// (`$d != 0 && 1/$d`, `0 ? 1/0 : 7`) does not fire.  Mirrors
-/// `find_divide_by_zero` (`compiler/interval_bounds.py`).
-fn find_divide_by_zero(
-    node: &ExprNode,
-    versions: &std::collections::HashMap<String, crate::ssa::Version>,
-    sccp: &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
-) -> Option<BinOp> {
-    let recurse = |n| find_divide_by_zero(n, versions, sccp);
-    match node {
-        ExprNode::Binary { op, left, right } => {
-            if matches!(op, BinOp::Div | BinOp::Mod) && expr_operand_is_zero(right, versions, sccp)
-            {
-                return Some(*op);
-            }
-            // The left operand is always evaluated.  The right operand of a
-            // short-circuit `&&` is reached only when the left is provably
-            // truthy; of `||` only when the left is provably falsy.
-            if let Some(hit) = recurse(left) {
-                return Some(hit);
-            }
-            let right_reachable = match op {
-                BinOp::And | BinOp::WordAnd => expr_truthiness(left, versions, sccp) == Some(true),
-                BinOp::Or | BinOp::WordOr => expr_truthiness(left, versions, sccp) == Some(false),
-                _ => true,
-            };
-            if right_reachable {
-                recurse(right)
-            } else {
-                None
-            }
-        }
-        ExprNode::Unary { operand, .. } => recurse(operand),
-        ExprNode::Ternary {
-            condition,
-            true_branch,
-            false_branch,
-        } => {
-            // The condition is always evaluated; an arm only when the
-            // condition provably selects it.
-            if let Some(hit) = recurse(condition) {
-                return Some(hit);
-            }
-            match expr_truthiness(condition, versions, sccp) {
-                Some(true) => recurse(true_branch),
-                Some(false) => recurse(false_branch),
-                None => None,
-            }
-        }
-        _ => None,
-    }
-}
-
 /// Name-level suppression context for the `return`-value phi-from-undef W210
 /// pass, harvested from `dict with` / `dict update` and qualified `variable`
 /// declarations.  Mirrors the corresponding `skip` / key-set construction in
@@ -7266,76 +7131,36 @@ file; this call falls through to the 'unknown' handler."
     /// statement's span); seen-offsets dedup avoids duplicate
     /// emissions when multiple SSA versions share a def.
     /// **W233.** Division / modulo by a provably-zero divisor — raises
-    /// "divide by zero" at runtime.  Walks every `[expr …]` AST reachable in
-    /// the function (`AssignExpr` statements, `if`/`while` branch conditions,
-    /// and `return [expr …]` values) over SCCP-executable blocks; a literal
-    /// `0` divisor or a variable whose SCCP value is a constant zero fires.
-    /// Mirrors the `find_divide_by_zero` arm of
+    /// "divide by zero" at runtime.  Delegates to the canonical
+    /// interval-bounds analysis [`crate::interval_bounds::find_divide_by_zero`]
+    /// (the single source of truth, shared with the interval-bounds index
+    /// checks): a `/` or `%` whose divisor's interval — guard-narrowed at the
+    /// use site and seeded from the SCCP lattice — is exactly `[0, 0]`, on the
+    /// always-evaluated spine of an executable expression. Mirrors the
+    /// `find_divide_by_zero` arm of
     /// `analyser/_analyser/_diag_interval_bounds.py`.
+    ///
+    /// (Verified against tclsh 8.4–9.0: integer `1/0` and `5%0` raise "divide
+    /// by zero"; float division such as `1.0/0` yields `Inf` and does not
+    /// error. The interval domain is integer, matching that boundary for the
+    /// common cases.)
     fn emit_w233_divide_by_zero(&mut self, fu: &crate::compilation_unit::FunctionUnit) {
-        use crate::cfg::Terminator;
-        use crate::ir::Statement;
-
-        let considered: HashSet<&str> = if fu.sccp.executable_blocks.is_empty() {
-            fu.ssa.blocks.keys().map(String::as_str).collect()
+        // The block set SCCP proved reachable; fall back to every SSA block
+        // when SCCP produced nothing (e.g. a trivial function) so the check
+        // still runs — matching the previous emitter's reachability fallback.
+        let executable: HashSet<String> = if fu.sccp.executable_blocks.is_empty() {
+            fu.ssa.blocks.keys().cloned().collect()
         } else {
-            fu.sccp
-                .executable_blocks
-                .iter()
-                .map(String::as_str)
-                .collect()
+            fu.sccp.executable_blocks.clone()
         };
-        let mut hits: Vec<(tcl_lexer::Span, BinOp)> = Vec::new();
-        for bn in &considered {
-            let Some(block) = fu.cfg.blocks.get(*bn) else {
-                continue;
-            };
-            let ssa_block = fu.ssa.blocks.get(*bn);
-            for (idx, stmt) in block.statements.iter().enumerate() {
-                if let Statement::AssignExpr { expr, span, .. } = stmt {
-                    let versions = ssa_block
-                        .and_then(|sb| sb.statements.get(idx))
-                        .map(|s| &s.uses);
-                    if let Some(versions) = versions
-                        && let Some(op) = find_divide_by_zero(expr, versions, &fu.sccp.values)
-                    {
-                        hits.push((fu.abs_span(*span), op));
-                    }
-                }
-            }
-            let exit = ssa_block.map(|sb| &sb.exit_versions);
-            let Some(exit) = exit else { continue };
-            match &block.terminator {
-                Some(Terminator::Return {
-                    expr: Some(e),
-                    span: Some(sp),
-                    ..
-                }) => {
-                    if let Some(op) = find_divide_by_zero(e, exit, &fu.sccp.values) {
-                        hits.push((fu.abs_span(*sp), op));
-                    }
-                }
-                Some(Terminator::Branch {
-                    condition,
-                    span: Some(sp),
-                    ..
-                }) => {
-                    if let Some(op) = find_divide_by_zero(condition, exit, &fu.sccp.values) {
-                        hits.push((fu.abs_span(*sp), op));
-                    }
-                }
-                _ => {}
-            }
-        }
-        for (span, op) in hits {
+        for finding in
+            crate::interval_bounds::find_divide_by_zero(&fu.cfg, &fu.ssa, &fu.sccp.values, &executable)
+        {
+            let span = fu.abs_span(finding.span);
             if span.is_empty() {
                 continue;
             }
-            let verb = if op == BinOp::Div {
-                "Division"
-            } else {
-                "Modulo"
-            };
+            let verb = if finding.op == "/" { "Division" } else { "Modulo" };
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: "W233".to_string(),
                 span,
@@ -11959,6 +11784,7 @@ foo
 
     #[test]
     fn w233_divide_by_zero_literal_and_const_var() {
+        // Each case verified against tclsh 8.4–9.0 to raise "divide by zero".
         assert_eq!(w233_codes("proc f {} { return [expr {1 / 0}] }"), 1);
         assert_eq!(w233_codes("proc f {} { return [expr {10 % 0}] }"), 1);
         assert_eq!(
@@ -11975,13 +11801,28 @@ foo
             0
         );
         assert_eq!(w233_codes("proc f {n} { return [expr {10 / $n}] }"), 0);
-        // Short-circuit / dead-arm guards make the division unreachable.
+        // Short-circuit / dead-arm guards make the division unreachable
+        // (tclsh: these expressions do *not* raise — the RHS is skipped).
         assert_eq!(w233_codes("proc f {} { return [expr {0 && 1/0}] }"), 0);
         assert_eq!(w233_codes("proc f {} { return [expr {0 ? 1/0 : 7}] }"), 0);
         assert_eq!(w233_codes("proc f {c} { return [expr {$c && 1/0}] }"), 0);
-        // Constant-truthy guard forces the arm — fires.
+        assert_eq!(w233_codes("proc f {} { return [expr {+0 && 1/0}] }"), 0);
+        // Constant-truthy guard forces the arm — fires. Each verified against
+        // tclsh 8.4–9.0 (`-1`, `1.0`, `!0` are truthy, so `1/0` is reached
+        // and raises "divide by zero").
         assert_eq!(w233_codes("proc f {} { return [expr {1.0 && 1/0}] }"), 1);
         assert_eq!(w233_codes("proc f {} { return [expr {-1 && 1/0}] }"), 1);
+        assert_eq!(w233_codes("proc f {} { return [expr {!0 && 1/0}] }"), 1);
+    }
+
+    #[test]
+    fn w233_silent_on_float_division() {
+        // Float division by zero yields Inf (verified against tclsh 8.4–9.0:
+        // `1.0/0.0` and `1/0.0` are *not* errors), so the integer-only
+        // divide-by-zero check must not fire. A float-literal divisor never
+        // narrows to the integer point `[0, 0]`.
+        assert_eq!(w233_codes("proc f {} { return [expr {1.0 / 0.0}] }"), 0);
+        assert_eq!(w233_codes("proc f {} { return [expr {1 / 0.0}] }"), 0);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -144,6 +144,10 @@ pub struct LoopNode {
     pub entry_block: String,
     /// Source span of the original `for` statement.
     pub span: Span,
+    /// The original `for` statement ([`Statement::For`]), retained so SCCP can
+    /// statically summarise a bounded loop and fold a branch that reads a
+    /// loop-carried variable *after* the loop (the static-loop → SCCP fold).
+    pub for_stmt: Statement,
 }
 
 /// A complete control-flow graph for a single procedure or top-level script.
@@ -573,6 +577,22 @@ mod tests {
             LoopNode {
                 entry_block: "for_header_1".into(),
                 span: Span::new(0, 30),
+                for_stmt: Statement::For {
+                    span: Span::new(0, 30),
+                    init: crate::ir::Script::new(),
+                    init_span: Span::new(0, 0),
+                    condition: crate::expr_ast::ExprNode::Literal {
+                        text: "1".into(),
+                        start: 0,
+                        end: 0,
+                    },
+                    condition_span: Span::new(0, 0),
+                    next: crate::ir::Script::new(),
+                    next_span: Span::new(0, 0),
+                    body: crate::ir::Script::new(),
+                    body_span: Span::new(0, 0),
+                    raw_args: Vec::new(),
+                },
             },
         );
         assert!(func.loop_nodes.contains_key("for_end_1"));

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -210,6 +210,7 @@ impl CfgBuilder {
             LoopNode {
                 entry_block: block_name.to_owned(),
                 span: *span,
+                for_stmt: stmt.clone(),
             },
         );
 

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -494,12 +494,16 @@ impl CompilationUnit {
             // generated proc is block-light yet byte-huge, so the byte test is
             // what catches it. Mirrors Python's `byte_guarded ||
             // is_complexity_guarded(cfg)` in the compilation-unit build.
-            let body_bytes =
-                proc.map_or(0usize, |p| p.span.end().saturating_sub(p.span.start()) as usize);
+            let body_bytes = proc.map_or(0usize, |p| {
+                p.span.end().saturating_sub(p.span.start()) as usize
+            });
             if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES
                 || crate::ssa::is_complexity_guarded(cfg)
             {
-                procedures.insert(qname.clone(), FunctionUnit::trivial_guarded(qname, cfg.clone()));
+                procedures.insert(
+                    qname.clone(),
+                    FunctionUnit::trivial_guarded(qname, cfg.clone()),
+                );
                 continue;
             }
             let body_offset = proc.map_or(0, |p| p.span.start());

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -133,6 +133,13 @@ pub struct FunctionUnit {
     pub rendered_props: HashMap<ValueKey, RenderedValueProps>,
     /// Optional memory-SSA annotations (populated on demand).
     pub memory_ssa: Option<MemorySSAFunction>,
+    /// Single source of truth for the deep-analysis complexity guard: when
+    /// `true` (CFG block count **or** body bytes over the ceiling), `ssa` and
+    /// the dataflow lattices are trivial and **every** per-proc diagnostic /
+    /// optimiser pass must skip this function (consult the flag, not the cfg,
+    /// so byte-large-but-block-light generated bodies are guarded
+    /// consistently). Mirrors Python's `FunctionUnit.complexity_guarded`.
+    pub complexity_guarded: bool,
     /// Byte offset to add to this unit's (otherwise relative) spans to recover
     /// **absolute** source positions (Approach B — offset-aware consumers).
     ///
@@ -178,6 +185,16 @@ impl FunctionUnit {
             &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
         >,
     ) -> Self {
+        // Complexity guard (block-count half): a pathologically large body
+        // would cost seconds of SSA + dataflow for near-zero findings, so skip
+        // the deep analysis and flag the unit. The body-byte half is applied by
+        // the callers that have the body span (see `build_for_with_config`).
+        // Backstop for every path through here — `build`, methods, and the
+        // salsa `function_lattice` callbacks. Mirrors Python's `force_guard or
+        // is_complexity_guarded` short-circuit in `analyse_function`.
+        if crate::ssa::is_complexity_guarded(&cfg) {
+            return Self::trivial_guarded(name, cfg);
+        }
         let ssa = build_ssa(&cfg, registry);
         let def_use = build_def_use_chains(&ssa, Some(&cfg));
         // The registry encodes the analysis dialect's Tcl version, which fixes
@@ -225,6 +242,30 @@ impl FunctionUnit {
             taints,
             rendered_props,
             memory_ssa: None,
+            complexity_guarded: false,
+            base_offset: 0,
+        }
+    }
+
+    /// A trivial guarded unit for a body the complexity guard skips: trivial
+    /// SSA, empty dataflow lattices, `complexity_guarded = true`. Per-proc
+    /// diagnostic and optimiser passes consult the flag and skip it, so the
+    /// empty lattices are never read as real facts.
+    #[must_use]
+    pub fn trivial_guarded(name: impl Into<String>, cfg: CfgFunction) -> Self {
+        let ssa = SsaFunction::trivial(cfg.name.clone(), cfg.entry.clone());
+        Self {
+            name: name.into(),
+            cfg,
+            ssa,
+            def_use: DefUseResult::default(),
+            sccp: SccpResult::default(),
+            types: HashMap::new(),
+            return_type: TypeLattice::unknown(),
+            taints: HashMap::new(),
+            rendered_props: HashMap::new(),
+            memory_ssa: None,
+            complexity_guarded: true,
             base_offset: 0,
         }
     }
@@ -448,6 +489,19 @@ impl CompilationUnit {
             let param_constants =
                 params_constants_from_call_sites(params, &call_site_constants, qname);
             let proc = ir_module.procedures.get(qname);
+            // Complexity guard (block-count or body-byte half): skip both the
+            // memo and the deep analysis for an oversized body. A flat
+            // generated proc is block-light yet byte-huge, so the byte test is
+            // what catches it. Mirrors Python's `byte_guarded ||
+            // is_complexity_guarded(cfg)` in the compilation-unit build.
+            let body_bytes =
+                proc.map_or(0usize, |p| p.span.end().saturating_sub(p.span.start()) as usize);
+            if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES
+                || crate::ssa::is_complexity_guarded(cfg)
+            {
+                procedures.insert(qname.clone(), FunctionUnit::trivial_guarded(qname, cfg.clone()));
+                continue;
+            }
             let body_offset = proc.map_or(0, |p| p.span.start());
             // Encode the interprocedural seeds into the hashable form the memo
             // key carries.  The interproc `param_constants` are folded *into*
@@ -522,10 +576,18 @@ impl CompilationUnit {
                         upvar_procs.clone(),
                         proc_params.clone(),
                     );
-                    (
-                        mqname.clone(),
-                        FunctionUnit::build(mqname, cfg, &method.params, registry),
-                    )
+                    // Body-byte half of the complexity guard (the block-count
+                    // half is applied inside `build`); skip an oversized
+                    // generated method body the same way as a procedure.
+                    let body_bytes = method
+                        .span
+                        .map_or(0usize, |s| s.end().saturating_sub(s.start()) as usize);
+                    let fu = if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES {
+                        FunctionUnit::trivial_guarded(mqname, cfg)
+                    } else {
+                        FunctionUnit::build(mqname, cfg, &method.params, registry)
+                    };
+                    (mqname.clone(), fu)
                 })
                 .collect()
         };
@@ -697,6 +759,15 @@ impl CompilationUnit {
         let mut procs: Vec<&FunctionUnit> = self.procedures.values().collect();
         procs.sort_by(|a, b| a.name.cmp(&b.name));
         std::iter::once(&self.top_level).chain(procs)
+    }
+
+    /// Like [`Self::functions`] but skips the functions the complexity guard
+    /// excluded from deep analysis (oversized bodies). Per-proc diagnostic and
+    /// optimiser passes iterate this so a guarded body — whose `ssa` and
+    /// dataflow lattices are trivial — contributes no findings and costs no
+    /// CFG walk. The relative order of the remaining functions is unchanged.
+    pub fn analysable_functions(&self) -> impl Iterator<Item = &FunctionUnit> {
+        self.functions().filter(|fu| !fu.complexity_guarded)
     }
 }
 
@@ -906,6 +977,33 @@ mod tests {
                 .sccp
                 .executable_blocks
                 .contains(&cu.top_level.ssa.entry)
+        );
+    }
+
+    #[test]
+    fn complexity_guard_flags_byte_huge_proc() {
+        // A normal proc is analysed (not guarded), with real SSA + SCCP.
+        let normal = CompilationUnit::build_for("proc small {} { set x 1 }", &registry(), false);
+        let small = normal.function("::small").expect("::small built");
+        assert!(!small.complexity_guarded);
+        assert!(!small.ssa.blocks.is_empty());
+
+        // A block-light but byte-huge body (one statement with a ~270 KB
+        // literal) trips the body-byte half of the complexity guard: the unit
+        // is flagged and carries a trivial SSA, so the O(blocks·vars) walk and
+        // the dataflow passes never run on it.
+        let big_literal = "A".repeat(270_000);
+        let src = format!("proc big {{}} {{ set x \"{big_literal}\" }}");
+        let cu = CompilationUnit::build_for(&src, &registry(), false);
+        let big = cu.function("::big").expect("::big built");
+        assert!(big.complexity_guarded, "byte-huge body must be guarded");
+        assert!(big.ssa.blocks.is_empty(), "guarded unit has trivial SSA");
+        assert!(big.sccp.values.is_empty());
+        // Guarded functions are excluded from the analysable-function view the
+        // per-proc diagnostic and optimiser passes iterate.
+        assert!(
+            cu.analysable_functions().all(|fu| fu.name != "::big"),
+            "guarded ::big must be skipped by analysable_functions"
         );
     }
 

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -200,14 +200,14 @@ pub fn run_all_checks(
     let mut out: Vec<Diagnostic> = Vec::new();
 
     // SCCP constant branches (per function).
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         for cb in &fu.sccp.constant_branches {
             out.push(shift(fu, Diagnostic::from_constant_branch(cb)));
         }
     }
 
     // GVN full + partial redundancies + loop invariants.
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         for r in find_redundancies(registry, &fu.cfg, &fu.ssa, dialect) {
             out.push(shift(fu, Diagnostic::from_redundant(&r)));
         }
@@ -220,7 +220,7 @@ pub fn run_all_checks(
     }
 
     // Shimmer + thunking.
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         for w in find_shimmer_warnings(
             &fu.cfg,
             &fu.ssa,
@@ -243,7 +243,7 @@ pub fn run_all_checks(
     // reported (cross-proc entry-taint). Mirrors Python `find_taint_warnings`,
     // which consumes `_solve_interprocedural_taints`.
     let solved = crate::taint_interproc::solve_interprocedural_taints(cu, registry, dialect);
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         let taints = solved.taints_for(&fu.name, &fu.taints);
         for w in find_taint_warnings(
             &fu.cfg,

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -1565,7 +1565,7 @@ pub fn find_redundancies_for_cu(
     dialect: Option<&str>,
 ) -> Vec<RedundantComputation> {
     let mut out = Vec::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         out.extend(find_redundancies(registry, &fu.cfg, &fu.ssa, dialect));
     }
     out
@@ -1581,7 +1581,7 @@ pub fn find_partial_redundancies_for_cu(
     dialect: Option<&str>,
 ) -> Vec<RedundantComputation> {
     let mut out = Vec::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         out.extend(find_partial_redundancies(
             registry, &fu.cfg, &fu.ssa, dialect,
         ));
@@ -1599,7 +1599,7 @@ pub fn find_loop_invariants_for_cu(
     dialect: Option<&str>,
 ) -> Vec<RedundantComputation> {
     let mut out = Vec::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         out.extend(find_loop_invariants(registry, &fu.cfg, &fu.ssa, dialect));
     }
     out

--- a/rust/tcl-compiler/src/interval_bounds.rs
+++ b/rust/tcl-compiler/src/interval_bounds.rs
@@ -295,6 +295,20 @@ fn index_subs_in_expr(expr: &ExprNode) -> Vec<Candidate> {
 /// Constant truthiness of a literal expression node (`Some(true/false)`), else
 /// `None`.  Mirrors `_const_bool` for the eager walk's guard resolution.
 fn const_bool(expr: &ExprNode) -> Option<bool> {
+    use tcl_syntax::expr::ast::UnaryOp;
+    // Fold the boolean-relevant unaries over a constant operand, matching
+    // Python's `expr_ast._const_bool`: `+`/`-` preserve zero-ness (`-1` is
+    // true, `-0` false), `!`/`not` invert it. `~` needs the integer value (a
+    // bitwise-not guard is rare) so it stays conservative. Verified against
+    // tclsh 8.4–9.0: `-1 && 1/0`, `!0 && 1/0` evaluate the RHS (a forced
+    // arm → divide-by-zero), while `+0 && 1/0` short-circuits.
+    if let ExprNode::Unary { op, operand } = expr {
+        return match op {
+            UnaryOp::Neg | UnaryOp::Pos => const_bool(operand),
+            UnaryOp::Not | UnaryOp::WordNot => const_bool(operand).map(|b| !b),
+            UnaryOp::BitNot => None,
+        };
+    }
     let ExprNode::Literal { text, .. } = expr else {
         return None;
     };

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -115,7 +115,7 @@ pub fn find_unnormalised_getter_warnings(
         return out;
     }
 
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         for bn in cfg_order(&fu.cfg) {
             if !fu.sccp.executable_blocks.contains(&bn) {
                 continue;
@@ -238,7 +238,7 @@ pub fn find_unguarded_drop_warnings(
         return out;
     }
 
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         // Only `::when::EVENT` proc bodies are iRules event handlers.
         if !fu.name.starts_with("::when::") {
             continue;
@@ -542,7 +542,7 @@ pub fn find_collect_flow_warnings(
     // Pass 1: classify across all when bodies.
     let mut state = CollectFlowState::default();
     let mut events_seen: Vec<String> = Vec::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         if let Some(event) = fu.name.strip_prefix("::when::") {
             let bare = event.split('#').next().unwrap_or(event).to_string();
             events_seen.push(bare.clone());
@@ -688,7 +688,7 @@ pub fn find_http_flow_warnings(
     if !is_irules_dialect(dialect) {
         return out;
     }
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         let Some(event) = fu.name.strip_prefix("::when::") else {
             continue;
         };
@@ -813,7 +813,7 @@ pub fn find_hoistable_set_warnings(
     if !is_irules_dialect(dialect) {
         return out;
     }
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         let Some(event) = fu.name.strip_prefix("::when::") else {
             continue;
         };
@@ -942,7 +942,7 @@ pub fn find_generic_static_name_warnings(
         return out;
     }
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         if !fu.name.starts_with("::when::") {
             continue;
         }

--- a/rust/tcl-compiler/src/lattice_rebase.rs
+++ b/rust/tcl-compiler/src/lattice_rebase.rs
@@ -38,6 +38,7 @@ pub(crate) fn rebase_function_unit(fu: &mut FunctionUnit, delta: i64) {
     }
     for loop_node in fu.cfg.loop_nodes.values_mut() {
         shift(&mut loop_node.span, delta);
+        rebase_statement(&mut loop_node.for_stmt, delta);
     }
     // SSA holds its own clones of the IR statements; some emitters read spans
     // from them (`stmt.statement.span()`), so rebase those too.

--- a/rust/tcl-compiler/src/memory_ssa.rs
+++ b/rust/tcl-compiler/src/memory_ssa.rs
@@ -412,13 +412,16 @@ pub fn detect_namespace_variable(stmt: &Statement) -> Vec<String> {
 
 /// True if `stmt` may clobber arbitrary memory locations.
 ///
-/// Barriers always clobber. Calls clobber when their command name
-/// matches an explicit dynamic-dispatch name (`eval`, `uplevel`,
-/// `interp eval`, `namespace eval`).
+/// Barriers always clobber. A static-body [`Statement::UpFrame`]
+/// (barrier-relaxed `uplevel`) clobbers because its body runs in a
+/// caller's frame and can touch arbitrary caller locals or globals.
+/// Calls clobber when their command name matches an explicit
+/// dynamic-dispatch name (`eval`, `uplevel`, `interp eval`,
+/// `namespace eval`).
 #[must_use]
 pub fn is_clobber(stmt: &Statement) -> bool {
     match stmt {
-        Statement::Barrier { .. } => true,
+        Statement::Barrier { .. } | Statement::UpFrame { .. } => true,
         Statement::Call { command, .. } => matches!(
             command.as_str(),
             "eval" | "uplevel" | "interp eval" | "namespace eval"
@@ -519,8 +522,13 @@ pub fn compute_aliases(ssa: &SsaFunction) -> Vec<AliasSet> {
             for (caller, local) in detect_upvar(stmt) {
                 let upvar_loc =
                     MemoryLocation::with_qualifier(MemoryLocationKind::Upvar, &local, &caller);
-                let caller_loc =
-                    MemoryLocation::with_qualifier(MemoryLocationKind::Upvar, &caller, &local);
+                // The caller-side node is keyed on the caller variable alone
+                // (empty qualifier) so two aliases of the *same* caller var —
+                // `upvar 1 x a; upvar 1 x b` — share this node and union-find
+                // merges `a` and `b` into one set. Encoding the local name in
+                // the qualifier would make each pair's caller node distinct and
+                // silently break transitive merging.
+                let caller_loc = MemoryLocation::new(MemoryLocationKind::Upvar, &caller);
                 uf.union(&upvar_loc, &caller_loc, "upvar");
             }
             for gname in detect_global(stmt) {
@@ -908,32 +916,24 @@ mod tests {
     }
 
     #[test]
-    fn compute_aliases_tracks_each_upvar_declaration() {
-        // `upvar 1 x a` and `upvar 1 x b` — two independent pair
-        // declarations. The pairs are keyed on the specific
-        // (caller, local) qualifier combinations so each upvar
-        // produces its own alias set even when they share the
-        // caller-side variable name.
+    fn compute_aliases_merges_shared_caller_upvars() {
+        // `upvar 1 x a` and `upvar 1 x b` alias the *same* caller
+        // variable `x`, so `a` and `b` may alias each other. The
+        // caller-side node is keyed on `x` alone, letting union-find
+        // collapse both declarations into a single alias set.
         let ssa = make_ssa_with_entry_stmts(vec![
             call("upvar", &["1", "x", "a"]),
             call("upvar", &["1", "x", "b"]),
         ]);
         let sets = compute_aliases(&ssa);
-        assert_eq!(sets.len(), 2);
-        // Both x↔a and x↔b show up somewhere in the returned
-        // alias sets.
-        let mut has_a = false;
-        let mut has_b = false;
-        for set in &sets {
-            if set.contains_name("a") && set.contains_name("x") {
-                has_a = true;
-            }
-            if set.contains_name("b") && set.contains_name("x") {
-                has_b = true;
-            }
-        }
-        assert!(has_a, "missing x↔a alias set");
-        assert!(has_b, "missing x↔b alias set");
+        assert_eq!(sets.len(), 1, "shared-caller upvars must merge");
+        let set = &sets[0];
+        assert!(set.contains_name("a"));
+        assert!(set.contains_name("b"));
+        assert!(set.contains_name("x"));
+
+        let m = build_memory_ssa(&ssa);
+        assert!(m.may_alias("a", "b"), "a and b share caller x");
     }
 
     #[test]
@@ -980,6 +980,24 @@ mod tests {
         assert_eq!(m.count_clobbers, 1);
         assert_eq!(m.memory_ops[0].kind, MemoryOpKind::Clobber);
         assert_eq!(m.memory_ops[0].location.name, "*");
+    }
+
+    #[test]
+    fn build_memory_ssa_emits_clobber_for_upframe() {
+        // A static-body `uplevel 1 {…}` lowers to `Statement::UpFrame`;
+        // its body runs in the caller's frame and clobbers aliased
+        // memory just like the dynamic `uplevel` barrier.
+        let upframe = Statement::UpFrame {
+            span: tcl_lexer::Span::new(0, 0),
+            frame_shift: 1,
+            body: crate::ir::Script::new(),
+            tokens: None,
+        };
+        assert!(is_clobber(&upframe));
+        let ssa = make_ssa_with_entry_stmts(vec![upframe]);
+        let m = build_memory_ssa(&ssa);
+        assert_eq!(m.count_clobbers, 1);
+        assert_eq!(m.memory_ops[0].kind, MemoryOpKind::Clobber);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -66,7 +66,7 @@ use super::{Optimisation, PassContext};
 ///   variables whose every tracked version agrees on a single
 ///   `Const` value participate.
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         fold_constant_branches(ctx, fu);
         propagate_into_branches(ctx, fu);
     }
@@ -412,6 +412,7 @@ mod tests {
             taints: std::collections::HashMap::new(),
             rendered_props: std::collections::HashMap::new(),
             memory_ssa: None,
+            complexity_guarded: false,
             base_offset: 0,
         }
     }

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -281,6 +281,12 @@ fn couple_propagated_const_dead_stores(
 
     let mut removals: Vec<Optimisation> = Vec::new();
     for fu in functions {
+        // Skip a function the complexity guard excluded from deep analysis:
+        // its lattices are trivial, so const/dead-store coupling has nothing
+        // sound to act on.
+        if fu.complexity_guarded {
+            continue;
+        }
         couple_const_dead_stores_in_function(fu, registry, source, selected, &mut removals);
     }
 

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -244,6 +244,18 @@ pub fn sccp(
 
     seed_live_in_roots(cfg, ssa, &mut values);
 
+    // Global / namespace / upvar-aliased / traced variables are shared mutable
+    // state observable and writable from other scopes, traces, and source
+    // files. Their value is therefore never a compile-time constant: folding
+    // through one would be unsound across any opaque call (`set ::g 5; mut;
+    // expr {$::g + 1}` must NOT fold to 6 — `mut` may have rewritten `::g`).
+    // Force every such definition to OVERDEFINED so SCCP never propagates a
+    // constant through it; the read is still tracked for liveness. Mirrors
+    // Python's `_is_externally_mutable`, consulting the whole-function
+    // (flow-insensitive) view of the `var_observability` alias/trace lattice.
+    let escaping = crate::var_observability::analyse_var_observability(cfg).escaping_var_names();
+    let is_externally_mutable = |name: &str| name.starts_with("::") || escaping.contains(name);
+
     let mut executable_blocks: HashSet<String> = HashSet::new();
     let mut executable_edges: HashSet<(String, String)> = HashSet::new();
     if cfg.blocks.contains_key(&cfg.entry) {
@@ -317,7 +329,11 @@ pub fn sccp(
                     continue;
                 }
                 for (var, ver) in &stmt_ssa.defs {
-                    let val = evaluate_def(stmt_ssa, &values);
+                    let val = if is_externally_mutable(var) {
+                        LatticeValue::Overdefined
+                    } else {
+                        evaluate_def(stmt_ssa, &values)
+                    };
                     if set_value(&mut values, (var.clone(), *ver), &val) {
                         changed = true;
                     }
@@ -2017,5 +2033,41 @@ mod tests {
         let order = cfg_order(&f);
         assert!(order.contains(&"entry".to_string()));
         assert!(order.contains(&"dead".to_string()));
+    }
+
+    fn cu(src: &str) -> crate::compilation_unit::CompilationUnit {
+        crate::compilation_unit::CompilationUnit::build_for(
+            src,
+            &tcl_registry::CommandRegistry::build_default(),
+            false,
+        )
+    }
+
+    #[test]
+    fn sccp_widens_global_aliased_var_to_overdefined() {
+        // A `global`-aliased variable is shared mutable state: SCCP must not
+        // fold a constant through it, so the `if {$g == 5}` branch stays
+        // unresolved (both arms executable, no constant branch). The matching
+        // *local* program does fold — proving the widening is what makes the
+        // difference, not an unrelated failure to evaluate.
+        let global_src =
+            "proc ::p {} { global g\n set g 5\n if {$g == 5} { return 1 } else { return 0 } }";
+        let local_src = "proc ::p {} { set x 5\n if {$x == 5} { return 1 } else { return 0 } }";
+
+        let cg = cu(global_src);
+        let fg = cg.function("::p").unwrap();
+        let rg = sccp(&fg.cfg, &fg.ssa, None, None);
+        assert!(
+            rg.constant_branches.is_empty(),
+            "global var must not fold a constant branch"
+        );
+
+        let cl = cu(local_src);
+        let fl = cl.function("::p").unwrap();
+        let rl = sccp(&fl.cfg, &fl.ssa, None, None);
+        assert!(
+            !rl.constant_branches.is_empty(),
+            "local var should still fold the constant branch"
+        );
     }
 }

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -2175,7 +2175,9 @@ mod tests {
         // a loop-carried phi, but the static-loop summary simulates the loop
         // and folds the branch. Verified against tclsh 8.4-9.0 (i == 10, and
         // the accumulator j == 5, hold after the loops).
-        let c = cu("proc ::p {} { for {set i 0} {$i < 10} {incr i} {}\n if {$i == 10} { return yes } else { return no } }");
+        let c = cu(
+            "proc ::p {} { for {set i 0} {$i < 10} {incr i} {}\n if {$i == 10} { return yes } else { return no } }",
+        );
         let fu = c.function("::p").unwrap();
         let r = sccp(&fu.cfg, &fu.ssa, None, None);
         let cb = r
@@ -2186,7 +2188,9 @@ mod tests {
         assert!(cb.value, "i == 10 after the loop, so the branch is true");
 
         // Body side effects are simulated too: j accumulates to 5.
-        let ca = cu("proc ::a {} { set j 0\n for {set k 5} {$k > 0} {incr k -1} { incr j }\n if {$j == 5} { return yes } else { return no } }");
+        let ca = cu(
+            "proc ::a {} { set j 0\n for {set k 5} {$k > 0} {incr k -1} { incr j }\n if {$j == 5} { return yes } else { return no } }",
+        );
         let fa = ca.function("::a").unwrap();
         let ra = sccp(&fa.cfg, &fa.ssa, None, None);
         let cba = ra
@@ -2198,7 +2202,9 @@ mod tests {
 
         // A loop with an unknown (parameter) bound cannot be summarised, so the
         // post-loop branch stays unfolded (conservative).
-        let cq = cu("proc ::q {n} { for {set i 0} {$i < $n} {incr i} {}\n if {$i == 10} { return yes } else { return no } }");
+        let cq = cu(
+            "proc ::q {n} { for {set i 0} {$i < $n} {incr i} {}\n if {$i == 10} { return yes } else { return no } }",
+        );
         let fq = cq.function("::q").unwrap();
         let rq = sccp(&fq.cfg, &fq.ssa, None, None);
         assert!(

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -228,6 +228,7 @@ pub struct SccpResult {
 /// and `None` to decline folding such ambiguous operands (the safe default
 /// for callers without dialect context).
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn sccp(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
@@ -263,96 +264,110 @@ pub fn sccp(
     }
     let order = cfg_order(cfg);
 
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for bn in &order {
-            if !executable_blocks.contains(bn) {
-                continue;
-            }
-            let Some(ssa_block) = ssa.blocks.get(bn) else {
-                continue;
-            };
-
-            let incoming_exec: Vec<String> = preds
-                .get(bn)
-                .map(|set| {
-                    set.iter()
-                        .filter(|p| executable_edges.contains(&((*p).clone(), bn.clone())))
-                        .cloned()
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            // Phi nodes (not at entry, only when some predecessor is
-            // executable).
-            for phi in &ssa_block.phis {
-                if bn == &cfg.entry {
+    // Optimistic fixpoint over the RPO sweep, followed by a finalising pass
+    // that forces both arms for any executable branch still stuck on an UNKNOWN
+    // condition (defensive: a value defined only in unreachable code could
+    // otherwise leave a successor spuriously unreachable). `finalizing` is
+    // monotone, so the outer loop runs at most twice. Mirrors Python's
+    // two-phase SCCP driver in `core_analyses.py`.
+    let mut finalizing = false;
+    loop {
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for bn in &order {
+                if !executable_blocks.contains(bn) {
                     continue;
                 }
-                if incoming_exec.is_empty() {
+                let Some(ssa_block) = ssa.blocks.get(bn) else {
                     continue;
-                }
-                let mut phi_val = LatticeValue::Unknown;
-                for pred in &incoming_exec {
-                    let incoming_ver = phi.incoming.get(pred).copied().unwrap_or(0);
-                    if incoming_ver == 0 {
+                };
+
+                let incoming_exec: Vec<String> = preds
+                    .get(bn)
+                    .map(|set| {
+                        set.iter()
+                            .filter(|p| executable_edges.contains(&((*p).clone(), bn.clone())))
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                // Phi nodes (not at entry, only when some predecessor is
+                // executable).
+                for phi in &ssa_block.phis {
+                    if bn == &cfg.entry {
                         continue;
                     }
-                    let key: ValueKey = (phi.name.clone(), incoming_ver);
-                    let candidate = values.get(&key).cloned().unwrap_or(LatticeValue::Unknown);
-                    phi_val = join(&phi_val, &candidate);
-                }
-                if set_value(&mut values, (phi.name.clone(), phi.version), &phi_val) {
-                    changed = true;
-                }
-            }
-
-            // Statements.
-            for stmt_ssa in &ssa_block.statements {
-                if matches!(stmt_ssa.statement, Statement::Barrier { .. }) {
-                    // Barriers widen all currently-tracked values — EXCEPT
-                    // version-0 (parameter) seeds, which hold the caller's
-                    // literal and are immutable across the barrier (a barrier
-                    // that mutates the var produces a fresh version).  Mirrors
-                    // Python's SCCP barrier v0-preserve refinement so a callee
-                    // `dict with $param` still sees the interproc literal.
-                    let keys: Vec<ValueKey> = values.keys().cloned().collect();
-                    for k in keys {
-                        if k.1 == 0 {
+                    if incoming_exec.is_empty() {
+                        continue;
+                    }
+                    let mut phi_val = LatticeValue::Unknown;
+                    for pred in &incoming_exec {
+                        let incoming_ver = phi.incoming.get(pred).copied().unwrap_or(0);
+                        if incoming_ver == 0 {
                             continue;
                         }
-                        if set_value(&mut values, k, &LatticeValue::Overdefined) {
-                            changed = true;
-                        }
+                        let key: ValueKey = (phi.name.clone(), incoming_ver);
+                        let candidate = values.get(&key).cloned().unwrap_or(LatticeValue::Unknown);
+                        phi_val = join(&phi_val, &candidate);
                     }
-                    continue;
-                }
-                for (var, ver) in &stmt_ssa.defs {
-                    let val = if is_externally_mutable(var) {
-                        LatticeValue::Overdefined
-                    } else {
-                        evaluate_def(stmt_ssa, &values)
-                    };
-                    if set_value(&mut values, (var.clone(), *ver), &val) {
+                    if set_value(&mut values, (phi.name.clone(), phi.version), &phi_val) {
                         changed = true;
                     }
                 }
-            }
 
-            // Terminator.
-            if sccp_process_terminator(
-                bn,
-                cfg,
-                ssa,
-                &values,
-                &mut executable_blocks,
-                &mut executable_edges,
-                octal,
-            ) {
-                changed = true;
+                // Statements.
+                for stmt_ssa in &ssa_block.statements {
+                    if matches!(stmt_ssa.statement, Statement::Barrier { .. }) {
+                        // Barriers widen all currently-tracked values — EXCEPT
+                        // version-0 (parameter) seeds, which hold the caller's
+                        // literal and are immutable across the barrier (a barrier
+                        // that mutates the var produces a fresh version).  Mirrors
+                        // Python's SCCP barrier v0-preserve refinement so a callee
+                        // `dict with $param` still sees the interproc literal.
+                        let keys: Vec<ValueKey> = values.keys().cloned().collect();
+                        for k in keys {
+                            if k.1 == 0 {
+                                continue;
+                            }
+                            if set_value(&mut values, k, &LatticeValue::Overdefined) {
+                                changed = true;
+                            }
+                        }
+                        continue;
+                    }
+                    for (var, ver) in &stmt_ssa.defs {
+                        let val = if is_externally_mutable(var) {
+                            LatticeValue::Overdefined
+                        } else {
+                            evaluate_def(stmt_ssa, &values)
+                        };
+                        if set_value(&mut values, (var.clone(), *ver), &val) {
+                            changed = true;
+                        }
+                    }
+                }
+
+                // Terminator.
+                if sccp_process_terminator(
+                    bn,
+                    cfg,
+                    ssa,
+                    &values,
+                    &mut executable_blocks,
+                    &mut executable_edges,
+                    octal,
+                    finalizing,
+                ) {
+                    changed = true;
+                }
             }
         }
+        if finalizing {
+            break;
+        }
+        finalizing = true;
     }
 
     let constant_branches =
@@ -415,9 +430,44 @@ fn seed_live_in_roots<S: std::hash::BuildHasher>(
     }
 }
 
+/// Optimistic (Wegman–Zadeck) deferral test for a non-constant branch.
+///
+/// Returns `true` when the condition *may still fold* on a later sweep:
+/// some operand defined in this function (SSA exit-version > 0) is still
+/// `Unknown` (not yet computed) and none is `Overdefined`. Such a branch
+/// opens neither arm until either the operand resolves to a constant or an
+/// `Overdefined` operand proves the condition genuinely non-constant.
+///
+/// Operands read at version 0 (proc parameters, globals, and other
+/// live-in roots) are excluded: [`seed_live_in_roots`] already seeds them
+/// `Overdefined`, so they are never "not yet computed". Mirrors Python's
+/// `_condition_use_versions` + the optimistic arm of `branch_targets`.
+fn branch_deferrable(
+    ssa_block: &crate::ssa::SsaBlock,
+    condition: &ExprNode,
+    values: &HashMap<ValueKey, LatticeValue>,
+) -> bool {
+    let mut any_operand = false;
+    let mut any_unknown = false;
+    for name in crate::var_refs::vars_in_expr(condition) {
+        let ver = ssa_block.exit_versions.get(&name).copied().unwrap_or(0);
+        if ver == 0 {
+            continue;
+        }
+        any_operand = true;
+        match values.get(&(name, ver)) {
+            Some(LatticeValue::Overdefined) => return false,
+            Some(LatticeValue::Unknown) | None => any_unknown = true,
+            _ => {}
+        }
+    }
+    any_operand && any_unknown
+}
+
 /// Process a block's terminator: mark the matching outgoing edges
 /// as executable.  Returns `true` when any new edge / block was
 /// added.  Extracted from [`sccp`].
+#[allow(clippy::too_many_arguments)]
 fn sccp_process_terminator(
     bn: &str,
     cfg: &CfgFunction,
@@ -426,6 +476,7 @@ fn sccp_process_terminator(
     executable_blocks: &mut HashSet<String>,
     executable_edges: &mut HashSet<(String, String)>,
     octal: Option<bool>,
+    finalizing: bool,
 ) -> bool {
     let mut changed = false;
     let Some(block) = cfg.blocks.get(bn) else {
@@ -458,6 +509,16 @@ fn sccp_process_terminator(
             let targets: Vec<&str> = match decision {
                 Some(true) => vec![true_target.as_str()],
                 Some(false) => vec![false_target.as_str()],
+                // Optimistic (Wegman–Zadeck): while the condition may still
+                // fold on a later sweep (a not-yet-computed operand, no
+                // `Overdefined` one), open neither arm and let the fixpoint
+                // retry — this is what detects loop-carried constant
+                // conditions instead of pessimistically opening both arms
+                // forever. The finalising pass forces both arms for any
+                // branch still stuck this way.
+                None if !finalizing && branch_deferrable(ssa_block, condition, values) => {
+                    Vec::new()
+                }
                 None => vec![true_target.as_str(), false_target.as_str()],
             };
             for tgt in targets {
@@ -2041,6 +2102,40 @@ mod tests {
             &tcl_registry::CommandRegistry::build_default(),
             false,
         )
+    }
+
+    #[test]
+    fn branch_deferrable_optimism() {
+        let cond = ExprNode::Var {
+            text: "$x".into(),
+            name: "x".into(),
+            start: 0,
+            end: 2,
+        };
+        let mut sb = empty_ssa_block("b");
+        sb.exit_versions.insert("x".into(), 1);
+        let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
+
+        // Defined operand (version 1) not yet computed → defer.
+        assert!(branch_deferrable(&sb, &cond, &values));
+        values.insert(("x".into(), 1), LatticeValue::Unknown);
+        assert!(branch_deferrable(&sb, &cond, &values));
+
+        // An `Overdefined` operand proves the condition genuinely
+        // non-constant → never defer.
+        values.insert(("x".into(), 1), LatticeValue::Overdefined);
+        assert!(!branch_deferrable(&sb, &cond, &values));
+
+        // A constant operand folds via `evaluate_branch`, so the `None`
+        // arm is never reached → not deferrable here.
+        values.insert(("x".into(), 1), LatticeValue::Const(ConstValue::Int(1)));
+        assert!(!branch_deferrable(&sb, &cond, &values));
+
+        // Version-0 operands (parameters / globals / live-in roots) are
+        // already `Overdefined` and excluded from the deferral test.
+        let mut sb0 = empty_ssa_block("b");
+        sb0.exit_versions.insert("x".into(), 0);
+        assert!(!branch_deferrable(&sb0, &cond, &HashMap::new()));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -505,7 +505,7 @@ fn sccp_process_terminator(
             let Some(ssa_block) = ssa.blocks.get(bn) else {
                 return changed;
             };
-            let decision = evaluate_branch(ssa_block, condition, values, octal);
+            let decision = branch_decision(cfg, ssa, bn, ssa_block, condition, values, octal);
             let targets: Vec<&str> = match decision {
                 Some(true) => vec![true_target.as_str()],
                 Some(false) => vec![false_target.as_str()],
@@ -583,7 +583,7 @@ fn collect_constant_branches(
         let Some(ssa_block) = ssa.blocks.get(bn) else {
             continue;
         };
-        let decision = evaluate_branch(ssa_block, condition, values, octal);
+        let decision = branch_decision(cfg, ssa, bn, ssa_block, condition, values, octal);
         let cond_text = crate::expr_ast::expr_text(condition);
         match decision {
             Some(true) => constant_branches.push(ConstantBranch {
@@ -844,6 +844,70 @@ fn resolve_simple_var_ref(
             .cloned()
             .unwrap_or(LatticeValue::Unknown),
     )
+}
+
+/// Resolve a branch decision, preferring a *static-loop summary* when the
+/// branch's block is the exit of a bounded `for` loop.
+///
+/// SCCP alone cannot fold a branch that reads a loop-carried variable *after*
+/// the loop — the variable's post-loop phi is a CONSTSET or `Overdefined`, not
+/// a single constant. Simulating the loop instead yields its exact final
+/// values (`for {set i 0} {$i < 10} {incr i} {}` leaves `i == 10`), so a
+/// following `if {$i == 10}` folds. The summary is conservative: it bails to
+/// `None` on non-constant bounds, side effects, or runaway iteration, falling
+/// back to the lattice fold. Mirrors Python's `_barrier_aware_env_for_block`
+/// loop arm feeding `_evaluate_branch_decision`.
+fn branch_decision(
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    bn: &str,
+    ssa_block: &crate::ssa::SsaBlock,
+    condition: &ExprNode,
+    values: &HashMap<ValueKey, LatticeValue>,
+    octal: Option<bool>,
+) -> Option<bool> {
+    loop_summary_decision(cfg, ssa, bn, condition, values)
+        .or_else(|| evaluate_branch(ssa_block, condition, values, octal))
+}
+
+/// Convert an SCCP [`ConstValue`] to the static simulator's
+/// [`crate::static_loops::StaticValue`].
+fn const_to_static(c: &ConstValue) -> crate::static_loops::StaticValue {
+    use crate::static_loops::StaticValue;
+    match c {
+        ConstValue::Int(i) => StaticValue::Int(*i),
+        ConstValue::Float(f) => StaticValue::Float(*f),
+        ConstValue::Bool(b) => StaticValue::Bool(*b),
+        ConstValue::String(s) => StaticValue::Str(s.clone()),
+    }
+}
+
+/// Fold `condition` via a static summary of the `for` loop whose exit block is
+/// `bn`, or `None` when `bn` is not a loop exit or the loop cannot be
+/// summarised. The simulation is seeded with the constants known at the
+/// pre-loop block's exit and run by [`crate::static_loops::summarise_for_statement`].
+fn loop_summary_decision(
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    bn: &str,
+    condition: &ExprNode,
+    values: &HashMap<ValueKey, LatticeValue>,
+) -> Option<bool> {
+    let node = cfg.loop_nodes.get(bn)?;
+    let start_ssa = ssa.blocks.get(&node.entry_block)?;
+    let mut start_env = crate::static_loops::StaticEnv::new();
+    for (name, &ver) in &start_ssa.exit_versions {
+        if let Some(LatticeValue::Const(c)) = values.get(&(name.clone(), ver)) {
+            start_env.insert(name.clone(), const_to_static(c));
+        }
+    }
+    let summarised = crate::static_loops::summarise_for_statement(
+        &node.for_stmt,
+        &start_env,
+        crate::static_loops::DEFAULT_MAX_STATIC_LOOP_ITERS,
+    )?;
+    let v = crate::static_loops::evaluate_expr_with_constants(condition, &summarised)?;
+    Some(v != 0)
 }
 
 /// Evaluate a branch condition.
@@ -2102,6 +2166,47 @@ mod tests {
             &tcl_registry::CommandRegistry::build_default(),
             false,
         )
+    }
+
+    #[test]
+    fn sccp_folds_post_loop_branch_via_static_summary() {
+        // After `for {set i 0} {$i < 10} {incr i} {}` tclsh leaves `i == 10`,
+        // so the following `if {$i == 10}` is statically true. SCCP cannot fold
+        // a loop-carried phi, but the static-loop summary simulates the loop
+        // and folds the branch. Verified against tclsh 8.4-9.0 (i == 10, and
+        // the accumulator j == 5, hold after the loops).
+        let c = cu("proc ::p {} { for {set i 0} {$i < 10} {incr i} {}\n if {$i == 10} { return yes } else { return no } }");
+        let fu = c.function("::p").unwrap();
+        let r = sccp(&fu.cfg, &fu.ssa, None, None);
+        let cb = r
+            .constant_branches
+            .iter()
+            .find(|cb| cb.condition.contains("$i == 10"))
+            .expect("post-loop branch must fold via the static-loop summary");
+        assert!(cb.value, "i == 10 after the loop, so the branch is true");
+
+        // Body side effects are simulated too: j accumulates to 5.
+        let ca = cu("proc ::a {} { set j 0\n for {set k 5} {$k > 0} {incr k -1} { incr j }\n if {$j == 5} { return yes } else { return no } }");
+        let fa = ca.function("::a").unwrap();
+        let ra = sccp(&fa.cfg, &fa.ssa, None, None);
+        let cba = ra
+            .constant_branches
+            .iter()
+            .find(|cb| cb.condition.contains("$j == 5"))
+            .expect("accumulator branch must fold via the static-loop summary");
+        assert!(cba.value, "j == 5 after the loop");
+
+        // A loop with an unknown (parameter) bound cannot be summarised, so the
+        // post-loop branch stays unfolded (conservative).
+        let cq = cu("proc ::q {n} { for {set i 0} {$i < $n} {incr i} {}\n if {$i == 10} { return yes } else { return no } }");
+        let fq = cq.function("::q").unwrap();
+        let rq = sccp(&fq.cfg, &fq.ssa, None, None);
+        assert!(
+            !rq.constant_branches
+                .iter()
+                .any(|cb| cb.condition.contains("$i == 10")),
+            "an unknown loop bound must not fold the post-loop branch"
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -141,7 +141,7 @@ pub fn find_shimmer_warnings_for_cu(
     registry: &CommandRegistry,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         out.extend(find_shimmer_warnings(
             &fu.cfg,
             &fu.ssa,
@@ -161,7 +161,7 @@ pub fn find_thunking_warnings_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
 ) -> Vec<ThunkingWarning> {
     let mut out = Vec::new();
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         out.extend(find_thunking_warnings(
             &fu.cfg,
             &fu.ssa,

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -2226,7 +2226,8 @@ mod tests {
         // that would cost seconds on a pathological generated body.
         let mut big = Function::new("::big", "b0");
         for i in 0..=COMPLEXITY_GUARD_BLOCKS {
-            big.blocks.insert(format!("b{i}"), Block::new(format!("b{i}")));
+            big.blocks
+                .insert(format!("b{i}"), Block::new(format!("b{i}")));
         }
         assert!(big.blocks.len() > COMPLEXITY_GUARD_BLOCKS);
         assert!(is_complexity_guarded(&big));

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -109,6 +109,51 @@ pub struct SsaFunction {
     pub dominator_tree: HashMap<String, Vec<String>>,
 }
 
+impl SsaFunction {
+    /// A trivial SSA shell — no blocks, no dominance information — used when
+    /// the complexity guard skips the expensive SSA build for an oversized
+    /// body. Downstream dataflow passes run over zero blocks (a cheap no-op),
+    /// and the compilation-unit builder flags the function so per-proc
+    /// diagnostic passes skip it entirely.
+    #[must_use]
+    pub fn trivial(name: impl Into<String>, entry: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            entry: entry.into(),
+            blocks: HashMap::new(),
+            idom: HashMap::new(),
+            dominance_frontier: HashMap::new(),
+            dominator_tree: HashMap::new(),
+        }
+    }
+}
+
+/// CFG block ceiling above which deep analysis (SSA / dataflow) is skipped.
+///
+/// A pathologically large body — almost always machine-generated, e.g. a
+/// tens-of-thousands-of-block nested-if dispatch tree — would cost seconds of
+/// SSA + SCCP / type / taint / liveness dataflow for near-zero useful
+/// findings, and an unbounded analysis also lets interprocedural summaries
+/// grow over-optimistic on adversarial input. Mirrors Python's
+/// `_COMPLEXITY_GUARD_BLOCKS`.
+pub const COMPLEXITY_GUARD_BLOCKS: usize = 20_000;
+
+/// Body-size (bytes) ceiling for the deep-analysis complexity guard. A flat
+/// generated command list is block-light — so [`COMPLEXITY_GUARD_BLOCKS`]
+/// never fires — yet byte-huge, and the O(blocks·vars) SSA walk plus
+/// SCCP / taint / liveness still costs seconds. Mirrors Python's
+/// `DEEP_ANALYSIS_BODY_BYTES` (256 KiB).
+pub const DEEP_ANALYSIS_BODY_BYTES: usize = 262_144;
+
+/// True when `func` is large enough that deep analysis (SSA / dataflow) is
+/// skipped. This is the block-count half of the guard; the body-byte half is
+/// applied by the compilation-unit builder, which has the body span. Mirrors
+/// Python's `is_complexity_guarded`.
+#[must_use]
+pub fn is_complexity_guarded(func: &cfg::Function) -> bool {
+    func.blocks.len() > COMPLEXITY_GUARD_BLOCKS
+}
+
 // Variable definition extraction
 
 /// Extract variable names defined by an IR statement.
@@ -1109,6 +1154,15 @@ enum RenamePhase {
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn build_ssa(func: &cfg::Function, registry: &CommandRegistry) -> SsaFunction {
+    // Complexity guard: skip the O(blocks·vars) phi placement + rename walk
+    // for a pathologically large (usually generated) body. Returns a trivial
+    // SSA; the compilation-unit builder likewise produces a trivial analysis
+    // and flags the function so per-proc diagnostic passes skip it. Mirrors
+    // Python's `build_ssa` block-count short-circuit.
+    if is_complexity_guarded(func) {
+        return SsaFunction::trivial(func.name.clone(), func.entry.clone());
+    }
+
     // 1. Compute dominance information.  Use the Cooper-Harvey-
     //    Kennedy immediate-dominator algorithm directly — it is
     //    O(N) memory, where the set-based `compute_dominators` is
@@ -2158,5 +2212,28 @@ mod tests {
         assert_eq!(ssa.blocks.len(), 1);
         assert!(ssa.blocks["entry"].phis.is_empty());
         assert!(ssa.blocks["entry"].statements.is_empty());
+    }
+
+    #[test]
+    fn complexity_guard_skips_oversized_ssa() {
+        let reg = default_registry();
+        // A small function is below the ceiling and analysed normally.
+        let small = Function::new("::small", "entry");
+        assert!(!is_complexity_guarded(&small));
+
+        // A function above the block ceiling is guarded: `build_ssa` returns a
+        // trivial SSA without running the O(blocks·vars) dominator + phi walk
+        // that would cost seconds on a pathological generated body.
+        let mut big = Function::new("::big", "b0");
+        for i in 0..=COMPLEXITY_GUARD_BLOCKS {
+            big.blocks.insert(format!("b{i}"), Block::new(format!("b{i}")));
+        }
+        assert!(big.blocks.len() > COMPLEXITY_GUARD_BLOCKS);
+        assert!(is_complexity_guarded(&big));
+
+        let ssa = build_ssa(&big, &reg);
+        assert!(ssa.blocks.is_empty(), "guarded SSA must be trivial");
+        assert_eq!(ssa.name, "::big");
+        assert_eq!(ssa.entry, "b0");
     }
 }

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -1680,7 +1680,7 @@ pub fn find_taint_warnings_for_cu(
 ) -> Vec<TaintWarning> {
     let mut out = Vec::new();
     let solved = crate::taint_interproc::solve_interprocedural_taints(cu, registry, dialect);
-    for fu in cu.functions() {
+    for fu in cu.analysable_functions() {
         let exec = &fu.sccp.executable_blocks;
         let taints = solved.taints_for(&fu.name, &fu.taints);
         out.extend(find_taint_warnings(
@@ -3455,7 +3455,7 @@ mod tests {
         let cu = CompilationUnit::build_for(source, &registry, false)
             .with_interprocedural(&registry, Some("f5-irules"));
         let mut out: Vec<TaintWarning> = Vec::new();
-        for fu in cu.functions() {
+        for fu in cu.analysable_functions() {
             out.extend(find_taint_warnings(
                 &fu.cfg,
                 &fu.ssa,
@@ -3792,7 +3792,7 @@ mod tests {
             cu = cu.with_interprocedural(&registry, dialect);
         }
         let mut out: Vec<TaintWarning> = Vec::new();
-        for fu in cu.functions() {
+        for fu in cu.analysable_functions() {
             out.extend(find_setter_constraint_warnings(
                 &registry,
                 &fu.cfg,
@@ -3923,7 +3923,7 @@ mod tests {
         let cu = CompilationUnit::build_for("set x [gets stdin]\neval $x", &registry, false)
             .with_interprocedural(&registry, None);
         let mut warnings: Vec<TaintWarning> = Vec::new();
-        for fu in cu.functions() {
+        for fu in cu.analysable_functions() {
             warnings.extend(find_taint_warnings(
                 &fu.cfg,
                 &fu.ssa,

--- a/rust/tcl-compiler/src/uri_split.rs
+++ b/rust/tcl-compiler/src/uri_split.rs
@@ -1042,7 +1042,7 @@ mod tests {
         let r = registry();
         let cu = CompilationUnit::build_for(source, &r, false);
         let mut out: Vec<TaintWarning> = Vec::new();
-        for fu in cu.functions() {
+        for fu in cu.analysable_functions() {
             out.extend(find_uri_split_suggestions(
                 &fu.cfg,
                 &fu.ssa,


### PR DESCRIPTION
Completes the **FE-DATAFLOW** track from `docs/rust-rewrite.md` — all six
residuals in `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}`,
ported idiomatically and verified against tclsh 8.4–9.0 where Tcl semantics are
load-bearing.

### What landed

1. **memory-SSA `IRUpFrame` clobber + shared-caller upvar merge** — `is_clobber`
   now treats `Statement::UpFrame` as a clobber; the caller-side upvar node is
   keyed on the caller variable alone, so `upvar 1 x a; upvar 1 x b` correctly
   merge into one alias set (the old test pinned the bug — corrected).
2. **Escaping-var widening** — `sccp` consults the previously-unwired
   `var_observability::escaping_var_names` and forces `::`-qualified / aliased /
   traced definitions to `Overdefined`, closing an unsound const-prop hole
   (mirrors `_is_externally_mutable`).
3. **Optimistic (Wegman–Zadeck) deferral** — two-phase fixpoint: a non-constant
   branch with a not-yet-computed operand defers (opens neither arm), then a
   monotone finalising pass forces both arms — detecting loop-carried constants
   instead of pessimistically opening both.
4. **W233 div-by-zero wiring** — the production emitter now delegates to the
   canonical interval-based `find_divide_by_zero` (the dead SCCP-only copy is
   gone); restored the unary-guard folding in `interval_bounds::const_bool`.
5. **Static-loop → SCCP fold** — `LoopNode` carries the `IRFor`; the branch
   decision wires `summarise_for_statement` so a post-loop branch on a loop
   variable folds (`for {set i 0} {$i < 10} {incr i} {}` ⇒ `i == 10`). The
   break-exit case needs no SCCP precompute — the Rust CFG already lowers
   `break` to a direct loop-exit edge (verified).
6. **Complexity guard** — `ssa::{COMPLEXITY_GUARD_BLOCKS,
   DEEP_ANALYSIS_BODY_BYTES, is_complexity_guarded}`, a trivial-SSA
   short-circuit in `build_ssa`, a `FunctionUnit::complexity_guarded` flag set
   from the block-count or body-byte ceiling, and
   `CompilationUnit::analysable_functions` so every per-proc diagnostic /
   optimiser pass skips oversized bodies. The IR-based interprocedural summary
   needs no guard — it never develops the over-optimistic empty-SSA summary the
   Python guard exists to prevent.

### Verification

- **tclsh 8.4–9.0** pinned the load-bearing semantics: the W233 boundary
  (integer `1/0` / `5%0` raise; float `1.0/0` → `Inf`; `-1 && 1/0` / `!0 && 1/0`
  reach the forced arm while `+0 && 1/0` short-circuits) and the static-loop
  post-values (`i == 10`, accumulator `j == 5`, `k == 0`). Each is asserted in
  tests.
- **2697 `tcl-compiler` tests pass**; `cargo clippy --workspace -- -D warnings`
  clean; `cargo fmt --check` clean.
- The one unrelated workspace failure (`help_search_json_matches_python`) is a
  pre-existing FTS5 BM25 rank-drift in the `tcl-cli` help golden — its corpus
  (`docs/kcs/features/`) is untouched by this branch.

### Note for review

Wiring W233 to the interval path makes the production diagnostic **strictly
broader** (it now also checks `expr`-eval statements and guard-narrowed
intervals), faithfully matching the Python oracle — before this it was *narrower*
than Python. Worth a `make test-slow` pass before merge: any fixture whose
expected diagnostics drift is a true positive surfacing (update the expectation,
don't revert). The `1.0/0` integer-zero-divisor over-fire is a pre-existing
behaviour shared with Python and is intentionally not diverged from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5sUVy5s2EtRRezM962Rje

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5sUVy5s2EtRRezM962Rje)_