### PR TITLE
Port iRules flow analysis, snit OO, and IRULE1001 to Rust

### DIFF
--- a/analyser/_analyser/_oo.py
+++ b/analyser/_analyser/_oo.py
@@ -78,6 +78,11 @@ class _AnalyserOOMixin(_Base):
         scope: Scope,
     ) -> bool:
         """Handle ``oo::class create Name { body }`` and similar metaclass commands."""
+        # A fully-qualified head (``::oo::class``) names the same global command
+        # as its bare form, so strip a single leading ``::`` before matching (and
+        # use the bare form for the recorded ``metaclass``, so both spellings
+        # produce an identical ClassDef).
+        cmd_name = cmd_name[2:] if cmd_name.startswith("::") else cmd_name
         if cmd_name not in self._OO_METACLASSES:
             return False
         # Expect: create Name ?body?  OR  new ?body?

--- a/analyser/signature_scan.py
+++ b/analyser/signature_scan.py
@@ -136,7 +136,7 @@ def _scan(
                 _handle_source(texts, argv, result)
             case "interp":
                 _handle_interp(texts, result)
-            case "oo::class":
+            case "oo::class" | "::oo::class":
                 _handle_oo_class(texts, argv, ns_prefix, result)
             case "itcl::class" | "::itcl::class":
                 _handle_itcl_class(texts, argv, ns_prefix, result)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -184,6 +184,9 @@ chunk-by-chunk dispatch story lives in
   — experiments, discoveries, and the reasoning behind the incremental plan.
 - [rust/lsp-performance.md](rust/lsp-performance.md) — native LSP
   performance: results, optimisations, and how to measure.
+- [rust/s110-byte-array-corruption-port.md](rust/s110-byte-array-corruption-port.md)
+  — FE-TYPESHIM port spec for the S110 byte-array-corruption shimmer
+  (Python #656): algorithm, Rust integration points, and verification contract.
 
 ## Optional WASM extensions
 

--- a/docs/design/rust/s110-byte-array-corruption-port.md
+++ b/docs/design/rust/s110-byte-array-corruption-port.md
@@ -1,0 +1,202 @@
+# Porting S110 (byte-array corruption) to Rust
+
+> **Status:** spec / plan. The Python implementation landed in PR #656 (on
+> `main`); this document is the port spec for the Rust `tcl-compiler::shimmer`
+> subsystem. The owning track is **FE-TYPESHIM** in
+> [`../../rust-rewrite.md`](../../rust-rewrite.md). The Python design rationale
+> (damage taxonomy, why provenance is separate from the type lattice) lives in
+> `docs/design/compiler/byte-array-corruption.md` (added by PR #656 — currently
+> on `main`, not yet on the `rust` branch); the FP contract is in
+> [`../compiler/FP.md`](../compiler/FP.md) (FP-SH-09/10).
+
+S110 is a **correctness** shimmer, distinct from the S100/S101/S102
+*performance* family. Tcl byte arrays (binary data) and character strings are
+different internal representations; when a byte array is forced through a
+character-string operation and then written back to a byte sink, every byte
+`>= 0x80` is silently re-encoded (latin-1 → UTF-8) or pushed out of `0..255` by
+case folding — corrupting the data. The canonical case is the iRules
+`*::payload replace` round-trip bug ([F5 K22406348]); the plain-Tcl case is
+`binary format` → `string …` → byte sink.
+
+[F5 K22406348]: https://my.f5.com/manage/s/article/K22406348
+
+---
+
+## 1. The Python algorithm (authoritative spec)
+
+Source: `compiler/shimmer.py` on `origin/main`, the `Byte-array corruption
+(S110)` section (`_find_byte_array_corruption` + helpers). It is a **forward
+dataflow over the SSA graph** tracking *byte provenance* per SSA value.
+
+### 1.1 Provenance lattice
+
+Two states (`_ByteProv`), carried in a `_ByteProvInfo { state, source_range,
+source_label, coercion_range, coercion_label }`:
+
+- **`BINARY`** — value currently has a byte-array intrep; safe at a byte sink.
+- **`DAMAGED`** — binary-sourced but since coerced to a character string;
+  writing it to a byte sink corrupts it.
+
+Join (`_join_prov`): **DAMAGED dominates BINARY** (may-corrupt); the first
+non-empty source is kept for the diagnostic. Absence (no entry) = untracked.
+
+### 1.2 Binary sources
+
+- `binary format`, `binary decode`, `encoding convertto` — **dialect-agnostic,
+  always on.** Recognised via the registry type hint (`return_type ==
+  BYTEARRAY`), see `_cmdsub_returns_bytearray`.
+- `*::payload` getters — **iRules-gated.** The getter form is `<proto>::payload`
+  with no args, or a first arg that is **not** in `{replace, length, rechunk,
+  unchunk}` (`_PAYLOAD_NON_GETTER_SUBS`). Set membership comes from
+  `byte_array_payload_commands()` **intersected with the active dialect**
+  (`REGISTRY.get(c, dialect) is not None`) — the registry is process-global, so
+  a plain-Tcl document that merely names a `*::payload` command must not trip.
+
+### 1.3 Coercion / damage operations (BINARY → DAMAGED or warn-on-spot)
+
+- **Intrinsic corruption — warn immediately** (corrupts with or without a
+  write-back):
+  - `string toupper|tolower|totitle` (`_CASE_FOLD_STRING_SUBS`) on a binary
+    operand → emit S110, mark result DAMAGED.
+  - `encoding convertto` on an already-binary value (double-encode) → emit
+    S110, then treat the (byte-array) result as BINARY.
+- **Round-trip corruption — mark DAMAGED, warn only at the sink** (latin-1
+  preserving, tclsh-verified):
+  - `string map|replace|range|index|reverse|repeat|trim|trimleft|trimright|cat|insert`
+    (`_STRING_VALUE_SUBS`).
+  - `format|subst|regsub|join|concat|split` (`_STRING_COERCING_COMMANDS`).
+  - `append v …` when target or any appended operand is binary/damaged.
+  - `$`/`[` interpolation and `expr` over a binary/damaged operand.
+- **The documented fix:** `binary scan $v …` re-binarifies `$v` *in place* →
+  clears DAMAGED back to BINARY. (`binary format … $v` does **not** mutate
+  `$v`, so it must not clear provenance — only the assigned `set x [binary
+  format …]` re-binarifies via the byte-array return type.)
+
+### 1.4 Byte sinks (where round-trip corruption is reported)
+
+- `<proto>::payload replace <offset> <length> <data>` — if the `<data>` arg
+  (index 3) is **DAMAGED**, emit S110 (`_payload_replace_data_index`).
+- Case-folding / `encoding convertto` are their own sinks (reported on the spot,
+  see §1.3).
+
+### 1.5 Transfer functions (per statement, in `cfg.reverse_postorder()` over
+executable blocks; phis joined first)
+
+- `IRAssignValue` (`_track_assign_value`): classify the RHS — payload getter /
+  byte-array cmdsub → BINARY; `encoding convertto`/case-fold on binary → warn +
+  set state; string-value-sub / coercing command over binary → DAMAGED; pure
+  `$var` copy → propagate provenance unchanged; interpolation over a
+  binary/damaged var → DAMAGED.
+- `IRAssignExpr` (`_track_assign_expr`): any binary/damaged use → result
+  DAMAGED (coercion label `expr`).
+- `IRCall` (`_track_call`): `binary scan $v` → clears `$v` to BINARY; `append`
+  → DAMAGED target; `*::payload replace` → sink check (emit if data DAMAGED).
+
+### 1.6 Emission
+
+`_byte_corruption_warning` builds a `ShimmerWarning { code="S110",
+from_type=BYTEARRAY, to_type=STRING, in_loop=False, … }` with `related_ranges`
+pointing at (a) the binary source and (b) the coercion site. Severity is
+**Warning** (`server/features/diagnostics.py`: `"S110": Warning`).
+
+---
+
+## 2. Rust target architecture
+
+The shimmer subsystem is `rust/tcl-compiler/src/shimmer/` (`mod.rs`, `graph.rs`,
+`thunking.rs`, `phi.rs`, `use_site.rs`, `expr.rs`, `hints.rs`, `span.rs`). Each
+detector is a `find_*` function returning warnings; `mod.rs::find_shimmer_warnings`
+is the per-function dispatch and the whole-CU wrappers iterate
+`cu.analysable_functions()`.
+
+**Closest templates:** `use_site.rs` (forward walk over `Statement::Call` /
+`Statement::AssignValue`, arg parsing, type lookups) for the per-statement shape,
+and `thunking.rs` for the `cfg_order(cfg)` + executable-block-gated walk and the
+phi-join scaffolding.
+
+**Key types** (verbatim field names matter):
+- `ShimmerWarning { span, variable, from_type, to_type, command, in_loop, code,
+  message, related: Vec<(Span, String)> }` — note `span` (not `range`) and
+  `related` (not `related_ranges`).
+- Per-function bundle `FunctionUnit { cfg, ssa, sccp, types, … }`; SSA via
+  `SsaFunction.blocks[bn].{phis, statements}`, each `SsaStatement { statement,
+  uses: HashMap<String,u32>, defs: HashMap<String,u32> }`; `Phi { name,
+  version, incoming: HashMap<String,u32> }`.
+- IR statements: `Statement::{AssignValue{name,value,…}, AssignExpr{name,expr},
+  Call{command,args,…}, Incr{…}, Barrier{…}}`; `Statement::span()`.
+- Helpers: `value_shapes::{is_pure_var_ref, parse_command_substitution}`,
+  `naming::normalise_var_name`, `shimmer::span::def_range_map`,
+  `sccp::cfg_order`, `shimmer::hints::arg_shimmer_type`.
+
+**Diagnostic glue** is in `compiler_checks.rs` (NOT `analyser/`):
+`run_all_checks` loops `cu.analysable_functions()`, calls
+`find_shimmer_warnings(...)` / `find_thunking_warnings(...)`, and lowers each via
+`Diagnostic::from_shimmer` / `from_thunking` with `shift(fu, …)` to absolutise
+spans. Severity is decided **inline per warning family** (no central table):
+`from_shimmer` maps S100→Info else Warning.
+
+**Registry** (`rust/tcl-registry/src/`): per-command facts live on `CommandSpec`
+/ `Traits` bitflags; iRules `*::payload` specs are under
+`rust/tcl-registry/src/commands/irules/`. Dialect membership is queried with
+`get_for_dialect(name, dialect)` (the analyser registry only loads the active
+dialect into `by_name`).
+
+---
+
+## 3. Port plan
+
+1. **Registry flag.** Add a `byte_array_payload` marker to the `*::payload`
+   command specs (HTTP/TCP/UDP/SCTP/DIAMETER/GTP/MQTT) in
+   `rust/tcl-registry/src/commands/irules/*payload*` — either a `Traits` bit or
+   a `CommandSpec` bool, matching how existing per-command facts are modelled.
+   Add a `byte_array_payload_commands(&self) -> …` accessor mirroring the Python
+   cache. Confirm `binary`/`encoding` specs carry `return_type == BYTEARRAY` for
+   `format`/`decode`/`convertto` (the dialect-agnostic sources).
+2. **Detector.** New `rust/tcl-compiler/src/shimmer/byte_array.rs` exposing
+   `pub(crate) fn find_byte_array_corruption(cfg, ssa, executable_blocks,
+   registry, dialect) -> Vec<ShimmerWarning>`. Port the `_ByteProv` /
+   `_ByteProvInfo` lattice, `_join_prov`, the source/sink/coercion sets, the
+   `_arg_byte_prov` recursion, and the three transfer functions
+   (`_track_assign_value`/`_track_assign_expr`/`_track_call`). Walk
+   `cfg_order(cfg)` gated on `executable_blocks`, join phis first. Reuse
+   `is_pure_var_ref` / `parse_command_substitution` / `normalise_var_name`;
+   build spans from `Statement::span()` / `def_range_map`.
+   - **Dialect gating:** the payload-command set must be intersected with the
+     active dialect — thread the dialect into the detector (the per-CU wrapper
+     has it) and use `registry.get_for_dialect`.
+3. **Wire-up.** Call the detector from a whole-CU entry in `mod.rs` (alongside
+   `find_shimmer_warnings_for_cu` / a sibling), and add a `from_byte_array` (or
+   reuse `from_shimmer`, since `code=="S110"`→Warning falls out of the existing
+   match once S110≠S100) emission loop in `compiler_checks.rs::run_all_checks`
+   with `shift(fu, …)`. Optionally surface in `tcl-explorer/src/serialise.rs`.
+4. **Related spans gap.** `compiler_checks::Diagnostic` has **no related-ranges
+   field**, so `ShimmerWarning.related` is dropped at lowering today. S110's
+   value comes partly from pointing at both the source and the coercion site —
+   either extend `Diagnostic` with related spans (preferred, benefits all
+   families) or fold the two locations into the message text. Decide before
+   implementing.
+
+---
+
+## 4. Verification contract
+
+Port byte-for-byte against the Python behavioural battery:
+
+- `tests/test_shimmer.py::TestByteArrayCorruption` (18 cases). Fires:
+  `kb_http_payload_interpolation_roundtrip`, `tcp_payload_string_replace_roundtrip`,
+  `append_then_payload_replace`, `copy_chain_preserves_provenance`,
+  `string_map_cmdsub_data_arg`, `plain_tcl_toupper_case_fold`,
+  `encoding_convertto_double_encode`, `inline_convertto_at_sink_fires`,
+  `inline_case_fold_at_sink_fires`. Silent (false-positive controls):
+  `binary_format_does_not_clear_provenance`, `clean_convertto_source_at_sink_silent`,
+  `payload_names_outside_irules_dialect_silent`, `clean_payload_writeback_silent`,
+  `binary_scan_rebinarify_fix_silent`, `ascii_literal_writeback_silent`,
+  `non_binary_string_op_silent`, `direct_binary_source_data_arg_silent`,
+  `payload_length_query_not_a_source`.
+- `tests/test_fp_sh.py`: FP-SH-09 (`toupper_byte_array_fires` /
+  `toupper_plain_string_silent`), FP-SH-10 (`payload_roundtrip_fires` /
+  `clean_payload_writeback_silent` / `binary_scan_fix_silent`) — with tclsh
+  ground truth.
+- Differential: run the Rust S110 against the Python oracle on the iRules
+  corpus, and confirm the documented `binary scan` fix yields lossless high-byte
+  round-trips against real `tclsh` payload semantics.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -965,11 +965,11 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Lexer / segmenter / expr-lexer / CST | `tcl-lexer`, `tcl-syntax`, `tcl-compiler::parsing` | ✅ | FE-LEX complete — `${name}` brace-depth, quoted `\<nl>`, nested-body E202/E203 landed (see [history](rust-rewrite-history.md), 2026-06-19) |
 | IR / lowering / CFG / SSA | `tcl-compiler` | 🟢 | `IRUpFrame` clobber; dynamic-`uplevel` barrier; minor IR fields → **FE-DATAFLOW**, **FE-DIAG** |
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
-| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | ✅ | **FE-TYPESHIM** complete; precise TclOO `object_of` typing now tracked under **FE-DIAG** (its W307/W308 consumer) |
+| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | ✅ | **FE-TYPESHIM** complete; precise TclOO `object_of` typing landed under **FE-DIAG** (its W307/W308 consumer) |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
-| Analyser diagnostics | `tcl-compiler::analyser` | 🟢 | E001/W125/IRULE5005/IRULE1001; snit; OO body-walks; C44 path-sensitivity; `when`-body dialect gating; source-style/W108 → **FE-DIAG** |
+| Analyser diagnostics | `tcl-compiler::analyser` | 🟢 | E001/W125/IRULE5005/IRULE1001; snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity; `when`-body dialect gating; source-style/W108 → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
@@ -1106,24 +1106,36 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   `initialise` body, and `property -get/-set` accessor bodies. Verified
   byte-for-byte against the Python analyser and against real `tclsh8.6` +
   tcllib.
-- **open** **W307 / W308** method-dispatch type checks + the precise TclOO
-  `object_of` typing they consume (handed off from **FE-TYPESHIM**, which
-  widens constructor results to OVERDEFINED today). The type lattice already
-  models `TypeLattice::object_of(class)` and the join widens mismatched
-  classes; what is missing is the *known-classes* set fed to
-  `type_infer::return_type_for_command` so `[Foo new]` / `[Foo create x]` /
-  `[Foo %AUTO%]` / `[Widget .path]` type as `OBJECT(::ns::Foo)` (relative
-  names resolved against the call-site namespace). Source the class set from
-  the analyser-layer `signature_scan` (the Rust IR keeps `namespace eval`
-  bodies as raw barriers, so the Python `class_names.extract_class_names`
-  IR-walk misses namespace-scoped classes — do **not** port it as-is), then
-  thread it through `FunctionUnit::build`→`propagate_types`/
-  `infer_function_return_type` and key the per-procedure lattice memo
-  (`LatticeRequest` + `tcl-lsp-db`) on it, mirroring Python's
-  `known_classes_fp`. Port `_return_type_for_command`'s constructor
-  recognition (`new`/`create`/`createWithNamespace`/`%AUTO%`/leading-`.`),
-  keeping the D4-F6 guard (no `object_of` from the `new` spelling alone when
-  the command is not a known class).
+- **done** **W307 / W308** method-dispatch type checks + the precise TclOO
+  `object_of` typing they consume (handed off from **FE-TYPESHIM**). The
+  *known-classes* set is sourced from the analyser-layer `signature_scan`
+  (`CompilationUnit::collect_known_classes`, gated on a `class` substring probe),
+  threaded through `FunctionUnit::build_with_param_constants_and_classes` →
+  `propagate_types` / `infer_function_return_type`, and folded into the
+  per-procedure lattice memo key (`LatticeRequest::known_classes` +
+  `FnLatticeKey::known_classes` in `tcl-lsp-db`) so the incremental build stays
+  byte-identical to the whole-file build (verified by the memoised-CU parity
+  test, now with a constructor-bearing snippet, and the incremental fuzz). The
+  ported `type_infer::constructor_object_type` recognises `new` / `create` /
+  `%AUTO%` / leading-`.` spellings, resolving the relative head as-is,
+  `::`-qualified, and against the call-site namespace, keeping the D4-F6 guard
+  (no `object_of` from the `new` spelling alone). `[Foo new] m` / `set o [Foo
+  new]; $o m` / transitive `set b $a` aliases / `Foo create %AUTO%` / namespace-
+  scoped classes all type as `OBJECT(::ns::Foo)` and validate the method (W308)
+  or stay silent — verified byte-for-byte against the Python analyser oracle
+  (13-case battery) with full W308 parity across the 102-file tcllib OO corpus.
+  Python's separate object-factory W307 *suppression* (the
+  `object_returning_procs` / factory-locals fixpoint — a proc returning `[Class
+  new]` / `[::ns::factory]` makes its result a non-literal-but-designed command
+  target) is also ported as `Analyser::compute_factory_object_ranges`.
+  **Residual (separate row, not object typing):** the 8 remaining W307
+  divergences on 4 tcllib files trace to two orthogonal gaps — `$var method`
+  dispatches *inside* command substitutions (`[$obj m]`) are not recorded as
+  var-command sites, so the multi-dispatch (≥2) suppression under-counts; and
+  `::oo::class` (leading-`::`) class definitions are recognised by neither the
+  analyser nor `signature_scan` (Python has the same `all_classes=[]` blind spot
+  there, so it is *not* an object-typing divergence). Both are analyser-walk /
+  class-extraction follow-ups, not part of the `object_of` typing item.
 - **done bar quick-fixes** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity (the
   C44 follow-up). The linear scans are replaced by a shared path-sensitive
   walk over the structured IR (`irules_checks::walk_flow`) that threads

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -969,7 +969,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
-| Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005/IRULE1001; snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Remaining bits (per-check config toggles, surfacing flow-warning fixes as code actions) are **SRV-LSP** consumer wiring → **FE-DIAG** |
+| Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
@@ -1118,7 +1118,11 @@ Owns `tcl-compiler::codegen` (non-wasm).
 Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`. Every diagnostic
 family is ported and verified; the two parenthetical residuals below
 (per-check config toggles, surfacing the IRULE5002/5004 flow-warning fixes as
-editor code actions) are **SRV-LSP** consumer wiring, not analyser work.
+editor code actions) are **SRV-LSP** consumer wiring, not analyser work. Two
+review-found correctness refinements (IRULE2001 3-arg `matchclass` fix,
+catch-caught `return` flow) are *shared with the Python reference* and are being
+corrected Python-first, then ported here in lockstep — see **Lockstep
+follow-ups** at the end of this section.
 - **done** missing emitters: **E001** (missing subcommand), **W125** (orphaned
   control-flow keyword), **IRULE5005** (direct proc call without `call`),
   **IRULE1001** (command invalid/ineffective in event — registry-legality-matrix
@@ -1229,6 +1233,47 @@ editor code actions) are **SRV-LSP** consumer wiring, not analyser work.
   analyser and W108 `non_ascii_mode` (`NonAsciiMode`, dialect-resolved). The
   **residual** is the GAP-C1 per-check feature-config toggles wiring, which
   lives in the server config layer (**SRV-LSP**), not the analyser.
+- **done** **IRULE5005 inside command substitutions** (PR #660 review
+  follow-up). `dispatch_nested_segment` now runs `emit_proc_resolution_diagnostics`
+  after site recording, so a direct iRules-proc call nested in a `[…]`
+  substitution (`when HTTP_REQUEST { set x [helper] }`) is flagged — previously
+  only the dispatch / expr / site-recording calls reached nested segments.
+  Mirrors Python's `run_all_checks` recursion into nested commands (verified:
+  the Python analyser emits the same `IRULE5005 … call helper` for this form).
+
+**Lockstep follow-ups (Python-first).** A review of the port (PR #660) surfaced
+two *shared* correctness bugs — present identically in the canonical Python
+analyser — so, exactly like **S110**, the fix lands on the Python reference
+first and the Rust port follows. Porting the Rust side ahead of Python would
+make it diverge from the very differential oracle this track is verified against,
+so both are deliberately gated on the upstream Python correction:
+- **port pending** **IRULE2001 `matchclass` 3-arg quick-fix** corruption. Both
+  the Rust emitter (`analyser::diagnostics::emit_irule2001_matchclass`) and
+  Python (`analyser/irules_checks.py::check_matchclass`) gate on `args.len() >= 2`
+  and always rewrite to `class match <item> equals <class>` from
+  `arg_tokens[0]`/`arg_tokens[1]`, so the documented 3-arg form
+  `matchclass <item> <operator> <class>` (e.g. `matchclass [HTTP::uri]
+  starts_with $::admin_paths`) drops its class and is forced to `equals`
+  (→ `class match [HTTP::uri] equals starts_with`). The fix: offer the
+  default-`equals` rewrite only for *exactly* two args, rewrite the 3-arg form
+  verbatim (`matchclass` → `class match` is a 1:1 rename), and offer no fix for
+  other arities. Diagnostic text is unchanged. Port once the Python correction
+  lands.
+- **port pending** **catch-caught `return` flow**. Tcl `catch` swallows the
+  return code, so execution continues after the `catch` body even when it
+  `return`s — but the shared path-sensitive flow walk drops the post-catch path.
+  This is a limitation of the shared algorithm present in Python too
+  (`compiler/irules_flow.py` `_analyse_script` ~486 / `_walk` ~951 extend with
+  the catch-body walk and lose the path when the body returns; the sibling
+  `IRTry` arms already fall back to `[st]`). The Rust twin
+  (`irules_checks::flow_step`, `Statement::Catch`) faithfully mirrors this. It
+  affects IRULE1201/1202 (HTTP-after-respond) and IRULE5002/5004 (unguarded
+  drop / DNS::return) for code that still runs after the catch. Being resolved
+  Python-first — the semantics decision (minimal incoming-state fallback like
+  `IRTry`, vs. capturing the at-return state so e.g. a `HTTP::respond` before the
+  catch-internal `return` still flags the post-catch command) is made on the
+  reference; Rust `walk_flow`/`flow_step` then mirrors the corrected catch
+  handling.
 
 #### FE-DIAG-F5 — F5 dialect diagnostics
 Owns new analyser slices on `tcl-bigip` / `tcl-xc` and the tk dialect.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1129,13 +1129,20 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   new]` / `[::ns::factory]` makes its result a non-literal-but-designed command
   target) is also ported as `Analyser::compute_factory_object_ranges`.
   **Residual (separate row, not object typing):** the 8 remaining W307
-  divergences on 4 tcllib files trace to two orthogonal gaps — `$var method`
-  dispatches *inside* command substitutions (`[$obj m]`) are not recorded as
-  var-command sites, so the multi-dispatch (≥2) suppression under-counts; and
-  `::oo::class` (leading-`::`) class definitions are recognised by neither the
-  analyser nor `signature_scan` (Python has the same `all_classes=[]` blind spot
-  there, so it is *not* an object-typing divergence). Both are analyser-walk /
-  class-extraction follow-ups, not part of the `object_of` typing item.
+  divergences on 4 tcllib files trace to two orthogonal gaps, both owned by
+  **FE-DIAG** (`tcl-compiler::analyser` + `signature_scan`):
+  1. **(real divergence — do under FE-DIAG)** `$var method` dispatches *inside*
+     command substitutions (`[$obj m]`) are not recorded as var-command sites,
+     so the multi-dispatch (≥2) suppression under-counts. Python's
+     `_process_command` recurses into command subs and records the inner head
+     (pca.tcl → 9 sites vs Rust's 1); mirror that in
+     `record_var_or_cmd_command_site`'s caller.
+  2. **(shared latent bug — parity-neutral, lowest priority)** `::oo::class`
+     (leading-`::`) class definitions are recognised by neither the analyser
+     (`handle_oo_class_command`) nor `signature_scan`'s walker. Python has the
+     *identical* `all_classes=[]` blind spot, so fixing it puts Rust ahead of
+     Python rather than closing a port gap — file it upstream against the Python
+     analyser too. Not an `object_of` typing divergence.
 - **done bar quick-fixes** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity (the
   C44 follow-up). The linear scans are replaced by a shared path-sensitive
   walk over the structured IR (`irules_checks::walk_flow`) that threads

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1092,10 +1092,12 @@ Owns `tcl-compiler::codegen` (non-wasm).
 
 #### FE-DIAG — analyser diagnostics & dialect checks
 Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
-- **open** missing emitters: **E001** (missing subcommand), **W125** (orphaned
+- **done** missing emitters: **E001** (missing subcommand), **W125** (orphaned
   control-flow keyword), **IRULE5005** (direct proc call without `call`),
-  **IRULE1001** (command invalid/ineffective in event — high-impact,
-  registry-legality-matrix driven).
+  **IRULE1001** (command invalid/ineffective in event — registry-legality-matrix
+  driven, with the profile-info hint + "Available in" reasons). Verified
+  byte-for-byte against the Python emitters; E001/W125 cross-checked against
+  tclsh 8.4–9.0.
 - **open** snit OO support (`snit::type`/`widget`/`widgetadaptor` as ClassDef)
   and the OO body-walks Rust skips (`oo::class new`/`createWithNamespace`,
   `initialise` body, `property -get/-set` accessor bodies).
@@ -1120,10 +1122,17 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
 - **open** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity — the emitters are
   linear-scan MVPs (single shared `responded` flag); add per-branch state and
   restore the dropped quick-fixes (the C44 follow-up).
-- **open** `DynamicNameLocal` reconciliation — Rust marks `scan`/`lassign`/
-  `regexp`/`regsub` out-vars `VarWrite` and omits the trait, which the archive
-  argues is benign; confirm whether withholding `VarWrite` changes caller-side
-  W211/W214 suppression, then either add the trait or close the row.
+- **done** `DynamicNameLocal` reconciliation — **row closed**. Withholding the
+  trait does *not* change caller-side W211/W214 suppression: that suppression is
+  driven by the interprocedural summary index (`build_proc_index_from_summaries`,
+  which models real `upvar` caller-frame write-back), not the shallow
+  `param_traits`, so the four out-var commands behave identically to Python on
+  the PR #498/#499 false-positive battery (verified differentially). A related
+  callee-side FP *was* found and fixed: a dynamic write target (`set $p 1`) was
+  modelled as a static def of `p` by `ssa::defs_of`; it now mirrors Python
+  `var_resolve::resolve_place` — no static def, and the name-bearing variable is
+  read (`ssa::is_dynamic_write_target`). Verified against tclsh 8.4–9.0 and a
+  Python differential, with zero change across the 79-file sample corpus.
 - **open** `when`-body dialect gating — under a non-iRules dialect the Rust
   server still descends into `when { … }` bodies and emits body diagnostics
   (e.g. `W210`) next to the correct `W002` ("'when' is disabled in the active

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1098,9 +1098,14 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   driven, with the profile-info hint + "Available in" reasons). Verified
   byte-for-byte against the Python emitters; E001/W125 cross-checked against
   tclsh 8.4–9.0.
-- **open** snit OO support (`snit::type`/`widget`/`widgetadaptor` as ClassDef)
-  and the OO body-walks Rust skips (`oo::class new`/`createWithNamespace`,
-  `initialise` body, `property -get/-set` accessor bodies).
+- **done** snit OO support (`snit::type`/`widget`/`widgetadaptor` as ClassDef,
+  with method / typemethod / constructor / destructor / typeconstructor /
+  onconfigure / oncget bodies analysed in method scopes seeded with the
+  instance / type variables + snit implicits) and the OO body-walks Rust
+  skipped: `oo::class new`/`createWithNamespace` (widened subcommand gate), the
+  `initialise` body, and `property -get/-set` accessor bodies. Verified
+  byte-for-byte against the Python analyser and against real `tclsh8.6` +
+  tcllib.
 - **open** **W307 / W308** method-dispatch type checks + the precise TclOO
   `object_of` typing they consume (handed off from **FE-TYPESHIM**, which
   widens constructor results to OVERDEFINED today). The type lattice already

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1128,21 +1128,26 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   `object_returning_procs` / factory-locals fixpoint — a proc returning `[Class
   new]` / `[::ns::factory]` makes its result a non-literal-but-designed command
   target) is also ported as `Analyser::compute_factory_object_ranges`.
-  **Residual (separate row, not object typing):** the 8 remaining W307
-  divergences on 4 tcllib files trace to two orthogonal gaps, both owned by
-  **FE-DIAG** (`tcl-compiler::analyser` + `signature_scan`):
-  1. **(real divergence — do under FE-DIAG)** `$var method` dispatches *inside*
-     command substitutions (`[$obj m]`) are not recorded as var-command sites,
-     so the multi-dispatch (≥2) suppression under-counts. Python's
-     `_process_command` recurses into command subs and records the inner head
-     (pca.tcl → 9 sites vs Rust's 1); mirror that in
-     `record_var_or_cmd_command_site`'s caller.
-  2. **(shared latent bug — parity-neutral, lowest priority)** `::oo::class`
-     (leading-`::`) class definitions are recognised by neither the analyser
-     (`handle_oo_class_command`) nor `signature_scan`'s walker. Python has the
-     *identical* `all_classes=[]` blind spot, so fixing it puts Rust ahead of
-     Python rather than closing a port gap — file it upstream against the Python
-     analyser too. Not an `object_of` typing divergence.
+  **W307 now reaches full parity with Python across the 102-file tcllib OO
+  corpus (0 divergences).** Closing the last 8 divergences took three further
+  fixes (all verified against the Python oracle + tclsh 8.6/9.0):
+  1. `$var method` dispatches *inside* command substitutions (`[$obj m]`) are now
+     recorded as var-command sites too — `dispatch_nested_segment` calls
+     `record_var_or_cmd_command_site`, mirroring Python's nested `run_all_checks`
+     recursion — so the multi-dispatch (≥2) suppression counts them.
+  2. `is_snit_member` ported: a `$var method` dispatch whose offset falls in a
+     class body and names one of that class's instance `variables` is component
+     dispatch — suppress W307 (covers non-method helper `proc`s that `upvar` the
+     instance var). Built from every `ClassDef`'s `body_span` + `variables`.
+  3. The braced-namespace-var head bug: `${ns}::define::[…]` merges into one Var
+     word token, so the raw text mangled the recorded var name; the extraction
+     now truncates at the first `}` to recover the dispatched variable (`ns`),
+     restoring the proc-param suppression.
+  And `::oo::class` (the fully-qualified head) is now recognised by the analyser
+  (`handle_oo_class_command` strips a leading `::`, normalising the `metaclass`)
+  and `signature_scan`'s walker. This was a *shared* blind spot — Python had the
+  identical `all_classes=[]` gap — so the same fix landed in the Python analyser
+  + `signature_scan` to keep the two in lockstep (regression tests both sides).
 - **done bar quick-fixes** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity (the
   C44 follow-up). The linear scans are replaced by a shared path-sensitive
   walk over the structured IR (`irules_checks::walk_flow`) that threads

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1057,19 +1057,15 @@ precise TclOO `object_of` typing the W307/W308 consumer needs landed under
   value — `BINARY` (a live byte array) and `DAMAGED` (binary-sourced but coerced
   to a character string) — and flags binary data written back through a byte
   sink, the canonical iRules `*::payload replace` double-encoding bug
-  ([F5 K22406348]). Two mechanisms: **intrinsic** corruption (`string
-  toupper`/`tolower`/`totitle`, `encoding convertto` reinterpret bytes ≥ 0x80 —
-  warn at the transform) and **round-trip** corruption (`string replace` /
-  `append` / interpolation / `format` preserve bytes as latin-1 but yield a
-  STRING; writing it to a byte sink re-encodes — warn at the sink). Binary
-  sources: `binary format` / `binary decode` / `encoding convertto` (plain Tcl,
-  always on) + `*::payload` getters (iRules-gated). Port: the byte-provenance
-  pass into `tcl-compiler::shimmer` alongside the existing detectors, a
-  `byte_array_payload` flag on the `*::payload` command specs in `tcl-registry`
-  + a `byte_array_payload_commands()` accessor, and the S110 wiring into the
-  analyser's shimmer-diagnostic emission. Verify byte-for-byte against the Python
-  `TestByteArrayCorruption` battery + the FP-SH-09/FP-SH-10 contracts, and
-  against real `tclsh` payload semantics (high-byte round-trip).
+  ([F5 K22406348]). Sources are `binary format` / `binary decode` / `encoding
+  convertto` (plain Tcl, always on) + `*::payload` getters (iRules-gated); the
+  fix `binary scan $v …` re-binarifies in place. The port adds a
+  `byte_array_payload` flag to the `*::payload` specs in `tcl-registry`, a new
+  detector in `tcl-compiler::shimmer`, and the S110 lowering in
+  `compiler_checks::run_all_checks`. **Full port spec (Python algorithm + Rust
+  integration points + step-by-step plan + the `TestByteArrayCorruption` /
+  FP-SH-09/10 verification contract):**
+  [`design/rust/s110-byte-array-corruption-port.md`](design/rust/s110-byte-array-corruption-port.md).
 
 [F5 K22406348]: https://my.f5.com/manage/s/article/K22406348
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1119,9 +1119,19 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   recognition (`new`/`create`/`createWithNamespace`/`%AUTO%`/leading-`.`),
   keeping the D4-F6 guard (no `object_of` from the `new` spelling alone when
   the command is not a known class).
-- **open** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity — the emitters are
-  linear-scan MVPs (single shared `responded` flag); add per-branch state and
-  restore the dropped quick-fixes (the C44 follow-up).
+- **done bar quick-fixes** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity (the
+  C44 follow-up). The linear scans are replaced by a shared path-sensitive
+  walk over the structured IR (`irules_checks::walk_flow`) that threads
+  per-path response-/drop-flow states and merges at join points — so
+  mutually-exclusive branches no longer false-positive, `catch` bodies are
+  analysed, and loops run zero-or-more times. The response-commit /
+  HTTP-namespace command sets are registry-derived. Verified against the
+  Python `find_irules_flow_warnings` oracle (spans use the *correct* command
+  offset — Python's module-IR path double-counts the body base offset; Rust
+  matches Python's intended re-lowered offset). **Residual:** the IRULE5002 /
+  5004 / 2001 insertion quick-fixes need a fix-range field on the
+  `IrulesCheckWarning` / `compiler_checks::Diagnostic` model (today only a
+  span-rewriting `replacement` exists) — a small plumbing follow-up.
 - **done** `DynamicNameLocal` reconciliation — **row closed**. Withholding the
   trait does *not* change caller-side W211/W214 suppression: that suppression is
   driven by the interprocedural summary index (`build_proc_index_from_summaries`,
@@ -1139,9 +1149,13 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   dialect profile"); Python emits `W002` only and does not analyse the body
   (`tests/lsp_e2e/test_diagnostics_e2e.py::TestWhenBodyDialectGatingE2E::
   test_when_body_not_analysed_under_plain_tcl`).
-- **open** source-style pass + W108 `non_ascii_mode` (line-length /
-  trailing-whitespace / line-endings / comment-continuation / missing
-  `package require`) and the GAP-C1 feature-config toggles.
+- **done bar config toggles** source-style pass + W108 `non_ascii_mode`. The
+  source-style checks are all ported in `tcl-lsp-core::source_style` — W111
+  (line length), W112 (trailing whitespace), W115 (comment continuation), W118
+  (line endings) — plus W120 (command without `package require`) in the
+  analyser and W108 `non_ascii_mode` (`NonAsciiMode`, dialect-resolved). The
+  **residual** is the GAP-C1 per-check feature-config toggles wiring, which
+  lives in the server config layer (**SRV-LSP**), not the analyser.
 
 #### FE-DIAG-F5 — F5 dialect diagnostics
 Owns new analyser slices on `tcl-bigip` / `tcl-xc` and the tk dialect.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1172,12 +1172,18 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   `var_resolve::resolve_place` — no static def, and the name-bearing variable is
   read (`ssa::is_dynamic_write_target`). Verified against tclsh 8.4–9.0 and a
   Python differential, with zero change across the 79-file sample corpus.
-- **open** `when`-body dialect gating — under a non-iRules dialect the Rust
-  server still descends into `when { … }` bodies and emits body diagnostics
-  (e.g. `W210`) next to the correct `W002` ("'when' is disabled in the active
-  dialect profile"); Python emits `W002` only and does not analyse the body
-  (`tests/lsp_e2e/test_diagnostics_e2e.py::TestWhenBodyDialectGatingE2E::
-  test_when_body_not_analysed_under_plain_tcl`).
+- **done** `when`-body dialect gating — a foreign-dialect builtin disabled in
+  the active dialect (known in *some* dialect but absent from the active
+  registry's `by_name` — iRules `when` / `log` / `session` under plain Tcl) is
+  an unknown would-be user command whose braced argument is opaque *data*, not a
+  handler script. `ssa::structural_body_indices` now skips every braced arg of
+  such a command from the SSA var scan (mirroring Python's
+  `command_is_disabled_in_active_dialect` body gate), so `when EVENT { … }` under
+  plain Tcl draws only `W002` + `W123` on `when` itself — no spurious `W210` /
+  `W123` on the body. A command unknown in *every* dialect (user proc / TclOO
+  body / recovery artefact) still recurses, and the iRules path still analyses
+  the body. Verified against the Python analyser + the `TestWhenBodyDialectGatingE2E`
+  e2e (now green) with no change across the 400-file differential corpus.
 - **done bar config toggles** source-style pass + W108 `non_ascii_mode`. The
   source-style checks are all ported in `tcl-lsp-core::source_style` — W111
   (line length), W112 (trailing whitespace), W115 (comment continuation), W118

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -965,7 +965,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Lexer / segmenter / expr-lexer / CST | `tcl-lexer`, `tcl-syntax`, `tcl-compiler::parsing` | ✅ | FE-LEX complete — `${name}` brace-depth, quoted `\<nl>`, nested-body E202/E203 landed (see [history](rust-rewrite-history.md), 2026-06-19) |
 | IR / lowering / CFG / SSA | `tcl-compiler` | 🟢 | `IRUpFrame` clobber; dynamic-`uplevel` barrier; minor IR fields → **FE-DATAFLOW**, **FE-DIAG** |
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
-| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | ✅ | **FE-TYPESHIM** complete; precise TclOO `object_of` typing landed under **FE-DIAG** (its W307/W308 consumer) |
+| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
@@ -991,7 +991,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Stage | Track | Owns | Depends on | Size |
 |---|---|---|---|---|
 | FE | **FE-DATAFLOW** | `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}` | — | M |
-| FE | **FE-TYPESHIM** ✅ | `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}` | — | M |
+| FE | **FE-TYPESHIM** 🟢 | `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}` | — | M |
 | FE | **FE-VARESCAPE** | `tcl-compiler::var_escape` | (consumers in FE-OPT) | M |
 | FE | **FE-OPT** | `tcl-compiler::optimiser`, `inlining` | — | L |
 | FE | **FE-CODEGEN** | `tcl-compiler::codegen` (non-wasm) | — | M |
@@ -1044,6 +1044,34 @@ residuals have landed:
   (The interprocedural summary is IR-based, so it needs no guard — it never
   develops the over-optimistic empty-SSA summary the Python guard exists to
   prevent.)
+
+#### FE-TYPESHIM — type inference / shimmer / shapes / rendered-props
+Owns `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`. The
+original scope (intrep typing, the S100/S101/S102 *performance* shimmer family,
+value-shape tracking, rendered-string properties) landed and stays green; the
+precise TclOO `object_of` typing the W307/W308 consumer needs landed under
+**FE-DIAG**. One new item has since landed on the Python side and needs porting:
+- **open** **S110** byte-array corruption detection (Python PR #656) — a new
+  *correctness* shimmer (distinct from the S100–S102 performance family). A
+  forward byte-provenance dataflow over the SSA graph tracks two states per
+  value — `BINARY` (a live byte array) and `DAMAGED` (binary-sourced but coerced
+  to a character string) — and flags binary data written back through a byte
+  sink, the canonical iRules `*::payload replace` double-encoding bug
+  ([F5 K22406348]). Two mechanisms: **intrinsic** corruption (`string
+  toupper`/`tolower`/`totitle`, `encoding convertto` reinterpret bytes ≥ 0x80 —
+  warn at the transform) and **round-trip** corruption (`string replace` /
+  `append` / interpolation / `format` preserve bytes as latin-1 but yield a
+  STRING; writing it to a byte sink re-encodes — warn at the sink). Binary
+  sources: `binary format` / `binary decode` / `encoding convertto` (plain Tcl,
+  always on) + `*::payload` getters (iRules-gated). Port: the byte-provenance
+  pass into `tcl-compiler::shimmer` alongside the existing detectors, a
+  `byte_array_payload` flag on the `*::payload` command specs in `tcl-registry`
+  + a `byte_array_payload_commands()` accessor, and the S110 wiring into the
+  analyser's shimmer-diagnostic emission. Verify byte-for-byte against the Python
+  `TestByteArrayCorruption` battery + the FP-SH-09/FP-SH-10 contracts, and
+  against real `tclsh` payload semantics (high-byte round-trip).
+
+[F5 K22406348]: https://my.f5.com/manage/s/article/K22406348
 
 #### FE-VARESCAPE — var-escape wiring
 Owns `tcl-compiler::var_escape`.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -969,7 +969,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
-| Analyser diagnostics | `tcl-compiler::analyser` | 🟢 | E001/W125/IRULE5005/IRULE1001; snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity; `when`-body dialect gating; source-style/W108 → **FE-DIAG** |
+| Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005/IRULE1001; snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Remaining bits (per-check config toggles, surfacing flow-warning fixes as code actions) are **SRV-LSP** consumer wiring → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
@@ -995,7 +995,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | FE | **FE-VARESCAPE** | `tcl-compiler::var_escape` | (consumers in FE-OPT) | M |
 | FE | **FE-OPT** | `tcl-compiler::optimiser`, `inlining` | — | L |
 | FE | **FE-CODEGEN** | `tcl-compiler::codegen` (non-wasm) | — | M |
-| FE | **FE-DIAG** | `tcl-compiler::analyser`, `irules_checks` | — | M |
+| FE | **FE-DIAG** ✅ | `tcl-compiler::analyser`, `irules_checks` | — | M |
 | FE | **FE-DIAG-F5** | new `tcl-xc`, `tcl-bigip` analyser slices, tk | `tcl-bigip` | L |
 | RT | **RT-WASM** | `tcl-compiler::codegen::wasm`, `runtime/zig`, `tcl-wasm` bin | FE-CODEGEN | L |
 | RT | **RT-VM** | `tcl-vm` | `tcl-bytecode` | L |
@@ -1114,8 +1114,11 @@ Owns `tcl-compiler::codegen` (non-wasm).
   expansion; `set x [cmd]` pure-cmd-subst assign; the `builtin_is_trusted`
   rename gate.
 
-#### FE-DIAG — analyser diagnostics & dialect checks
-Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
+#### FE-DIAG — analyser diagnostics & dialect checks ✅
+Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`. Every diagnostic
+family is ported and verified; the two parenthetical residuals below
+(per-check config toggles, surfacing the IRULE5002/5004 flow-warning fixes as
+editor code actions) are **SRV-LSP** consumer wiring, not analyser work.
 - **done** missing emitters: **E001** (missing subcommand), **W125** (orphaned
   control-flow keyword), **IRULE5005** (direct proc call without `call`),
   **IRULE1001** (command invalid/ineffective in event — registry-legality-matrix
@@ -1172,8 +1175,8 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   and `signature_scan`'s walker. This was a *shared* blind spot — Python had the
   identical `all_classes=[]` gap — so the same fix landed in the Python analyser
   + `signature_scan` to keep the two in lockstep (regression tests both sides).
-- **done bar quick-fixes** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity (the
-  C44 follow-up). The linear scans are replaced by a shared path-sensitive
+- **done** IRULE1201 / 1202 / 5002 / 5004 path-sensitivity (the C44 follow-up)
+  **+ quick-fixes**. The linear scans are replaced by a shared path-sensitive
   walk over the structured IR (`irules_checks::walk_flow`) that threads
   per-path response-/drop-flow states and merges at join points — so
   mutually-exclusive branches no longer false-positive, `catch` bodies are
@@ -1181,10 +1184,21 @@ Owns `tcl-compiler::analyser`, `tcl-compiler::irules_checks`.
   HTTP-namespace command sets are registry-derived. Verified against the
   Python `find_irules_flow_warnings` oracle (spans use the *correct* command
   offset — Python's module-IR path double-counts the body base offset; Rust
-  matches Python's intended re-lowered offset). **Residual:** the IRULE5002 /
-  5004 / 2001 insertion quick-fixes need a fix-range field on the
-  `IrulesCheckWarning` / `compiler_checks::Diagnostic` model (today only a
-  span-rewriting `replacement` exists) — a small plumbing follow-up.
+  matches Python's intended re-lowered offset). The insertion quick-fixes now
+  land: a shared `irules_checks::CodeFix { span, new_text, description }` (the
+  canonical low-level twin re-exported as the analyser's `CodeFix`) carries a
+  **fix range independent of the diagnostic span**, threaded through
+  `IrulesCheckWarning.fixes` → `compiler_checks::Diagnostic.fixes`. IRULE5002
+  inserts `event disable all` + `return` after the drop, IRULE5004 inserts
+  `return` after `DNS::return` (zero-width edits at the command end), and the
+  analyser-side IRULE2001 replaces `matchclass <item> <class>` with `class match
+  <item> equals <class>` (raw source slices preserve `$var`). All three verified
+  byte-for-byte against the Python `CodeFix` text. *(Surfacing the IRULE5002/5004
+  flow-warning fixes as editor code actions is the one remaining step — the
+  `tcl-lsp-core` code-action provider reads only the analyser's
+  `AnalysisResult.diagnostics` today, so it already offers the IRULE2001 fix but
+  would need to also process `find_irules_flow_warnings` to offer the 5002/5004
+  ones; that consumer wiring belongs to **SRV-LSP**.)*
 - **done** `DynamicNameLocal` reconciliation — **row closed**. Withholding the
   trait does *not* change caller-side W211/W214 suppression: that suppression is
   driven by the interprocedural summary index (`build_proc_index_from_summaries`,

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1058,6 +1058,13 @@ impl Analyser {
             &cmd_name, args, arg_tokens, arg_single, arg_expand, cmd_tok, scope_path,
         );
         self.dispatch_expr_arguments(&cmd_name, args, arg_tokens);
+        // Record the nested command's variable-/command-substitution-as-command
+        // call site too (`puts [$obj method]`, `if {[$obj ok]} …`).  The main
+        // walk treats `[…]` as a value, so without this the W307 multi-dispatch
+        // suppression under-counts `$obj` dispatches that live inside command
+        // substitutions and the W307/W308 emitters never see them — Python's
+        // nested `run_all_checks` recursion records every one.
+        self.record_var_or_cmd_command_site(cmd_tok, args, scope_path);
     }
 
     /// The `[…]` substitution fragment tokens of a (possibly compound)
@@ -1185,7 +1192,19 @@ impl Analyser {
         match cmd_tok.kind {
             TokenType::Var => {
                 let sm = tcl_lexer::SourceMap::new(&self.source);
-                let var_name = sm.token_text(cmd_tok).to_string();
+                // A composite head whose first token is a *braced* variable
+                // (`${ns}::define::[…]`) merges into one Var word token, so the
+                // raw text spans the whole word.  The dispatched variable is
+                // only the braced name (`${ns}` → `ns`); the `}` closes it and
+                // the rest is a literal / substituted suffix.  Python reads the
+                // first VAR sub-token's clean name — mirror that by truncating
+                // at the first `}` (a simple `$obj` or namespaced `$ns::v` head
+                // contains no `}` and is unchanged).
+                let raw = sm.token_text(cmd_tok);
+                let var_name = raw
+                    .split_once('}')
+                    .map_or(raw, |(name, _)| name)
+                    .to_string();
                 let method_name = args.first().cloned();
                 self.var_command_sites.push(super::state::VarCommandSite {
                     var_name,

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -33,6 +33,20 @@ use crate::parsing::syntax::segment::segments_from_tree;
 use crate::segmenter::SegmentedCommand;
 
 use super::state::Analyser;
+use super::types::{CodeFix, Diagnostic, Severity};
+
+/// Parent command for a control-flow keyword that is only valid as an
+/// argument *within* a parent command, or `None` for any other name.
+///
+/// Mirrors `_ORPHANED_KEYWORDS` in
+/// `analyser/_analyser/_commands.py:118` — keyword → parent command.
+fn orphaned_keyword_parent(cmd_name: &str) -> Option<&'static str> {
+    match cmd_name {
+        "else" | "elseif" | "then" => Some("if"),
+        "on" | "trap" | "finally" => Some("try"),
+        _ => None,
+    }
+}
 
 impl Analyser {
     /// Re-segment a body script and dispatch each command at
@@ -322,6 +336,13 @@ impl Analyser {
             // (``_commands.py:182-198``).
             self.record_var_or_cmd_command_site(cmd_tok, args, scope_path);
 
+            // W125 (orphaned control-flow keyword) and IRULE5005 (direct
+            // iRules-proc call without `call`) — both key off whether the
+            // command head resolves to a user proc, so they share one
+            // resolution.  Mirrors the W125 / IRULE5005 blocks of
+            // ``_AnalyserCommandsMixin._process_command``.
+            self.emit_proc_resolution_diagnostics(cmd_name, args, cmd_tok, scope_path);
+
             // Record TclOO instance creation (`set v [Cls new]`,
             // `Cls create inst`) so the LSP providers can resolve
             // ``$v method`` / ``inst method`` call sites to the
@@ -461,6 +482,76 @@ impl Analyser {
         // walk so race-detection diagnostics see the event
         // name, mirroring the Python behaviour.
         self.dispatch_body_arguments(cmd_name, args, arg_tokens, arg_single, scope_path);
+    }
+
+    /// Emit the two diagnostics that key off whether the command head
+    /// resolves to a user proc:
+    ///
+    /// - **W125** (Warning) — an orphaned control-flow keyword
+    ///   (`else` / `elseif` / `then` / `on` / `trap` / `finally`) used as a
+    ///   standalone command.  This almost always means a misplaced newline
+    ///   split its parent `if` / `try` (`}\nelse {` instead of `} else {`).
+    ///   Suppressed when a user proc *or* a registry command of the same
+    ///   name shadows the keyword.
+    /// - **IRULE5005** (Error) — a user proc invoked directly inside an
+    ///   iRules event body, where Tcl-on-TMM requires `call PROC ARGS`.
+    ///   Ships a `call PROC`-rewrite [`CodeFix`].
+    ///
+    /// Mirrors the W125 (`analyser/_analyser/_commands.py:171`) and
+    /// IRULE5005 (`:228`) blocks of `_process_command`; the proc is
+    /// resolved once and shared between both checks.
+    pub(super) fn emit_proc_resolution_diagnostics(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        cmd_tok: Token,
+        scope_path: &[usize],
+    ) {
+        let resolves_to_proc = self.resolve_proc_call(cmd_name, scope_path).is_some();
+
+        if !resolves_to_proc
+            && let Some(parent) = orphaned_keyword_parent(cmd_name)
+            && self
+                .registry
+                .as_ref()
+                .is_none_or(|r| r.get(cmd_name).is_none())
+        {
+            self.result.diagnostics.push(Diagnostic {
+                code: "W125".to_string(),
+                span: cmd_tok.span,
+                message: format!(
+                    "\"{cmd_name}\" used as standalone command — should be part of \
+                     \"{parent}\" (check for misplaced newline)"
+                ),
+                severity: Severity::Warning,
+                fixes: Vec::new(),
+            });
+        }
+
+        if resolves_to_proc
+            && cmd_name != "call"
+            && self.current_event.is_some()
+            && self.dialect == "f5-irules"
+        {
+            let suffix = if args.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", args.join(" "))
+            };
+            self.result.diagnostics.push(Diagnostic {
+                code: "IRULE5005".to_string(),
+                span: cmd_tok.span,
+                message: format!(
+                    "iRules procs must be invoked with 'call': call {cmd_name}{suffix}"
+                ),
+                severity: Severity::Error,
+                fixes: vec![CodeFix {
+                    span: cmd_tok.span,
+                    new_text: format!("call {cmd_name}"),
+                    description: format!("Use 'call {cmd_name}'"),
+                }],
+            });
+        }
     }
 
     /// Dispatch-site diagnostic emitters, run from
@@ -1837,5 +1928,100 @@ mod tests {
             &[],
         );
         assert!(a.command_aliases.contains_key("::myset"));
+    }
+
+    fn diag_codes(source: &str, dialect: &str) -> Vec<(String, String)> {
+        let mut a = Analyser::new();
+        let res = a.analyse(source, dialect);
+        res.diagnostics
+            .iter()
+            .map(|d| (d.code.clone(), d.message.clone()))
+            .collect()
+    }
+
+    fn has_code(source: &str, dialect: &str, code: &str) -> bool {
+        diag_codes(source, dialect).iter().any(|(c, _)| c == code)
+    }
+
+    #[test]
+    fn orphaned_keyword_parent_maps_keywords() {
+        assert_eq!(orphaned_keyword_parent("else"), Some("if"));
+        assert_eq!(orphaned_keyword_parent("elseif"), Some("if"));
+        assert_eq!(orphaned_keyword_parent("then"), Some("if"));
+        assert_eq!(orphaned_keyword_parent("on"), Some("try"));
+        assert_eq!(orphaned_keyword_parent("trap"), Some("try"));
+        assert_eq!(orphaned_keyword_parent("finally"), Some("try"));
+        assert_eq!(orphaned_keyword_parent("set"), None);
+    }
+
+    #[test]
+    fn w125_fires_for_orphaned_else() {
+        // A misplaced newline split the `if` — `else` lands as a standalone
+        // command with no parent.
+        assert!(has_code(
+            "if {$x} {\n  puts hi\n}\nelse {\n  puts bye\n}",
+            "tcl",
+            "W125"
+        ));
+    }
+
+    #[test]
+    fn w125_quiet_for_attached_else() {
+        // Properly attached `} else {` never segments `else` as a command.
+        assert!(!has_code(
+            "if {$x} {\n  puts hi\n} else {\n  puts bye\n}",
+            "tcl",
+            "W125"
+        ));
+    }
+
+    #[test]
+    fn w125_suppressed_when_user_proc_shadows_keyword() {
+        // A user proc named `finally` shadows the keyword — no warning.
+        assert!(!has_code(
+            "proc finally {} { return }\nfinally",
+            "tcl",
+            "W125"
+        ));
+    }
+
+    #[test]
+    fn irule5005_fires_for_direct_proc_call_in_event() {
+        let src = "proc helper {} { return 1 }\nwhen HTTP_REQUEST { helper }";
+        assert!(has_code(src, "f5-irules", "IRULE5005"));
+    }
+
+    #[test]
+    fn irule5005_quiet_with_call_prefix() {
+        let src = "proc helper {} { return 1 }\nwhen HTTP_REQUEST { call helper }";
+        assert!(!has_code(src, "f5-irules", "IRULE5005"));
+    }
+
+    #[test]
+    fn irule5005_quiet_outside_event_context() {
+        // Top-level direct call, no `when` block — not an iRules-event call.
+        let src = "proc helper {} { return 1 }\nhelper";
+        assert!(!has_code(src, "f5-irules", "IRULE5005"));
+    }
+
+    #[test]
+    fn irule5005_quiet_in_plain_tcl_dialect() {
+        let src = "proc helper {} { return 1 }\nwhen HTTP_REQUEST { helper }";
+        assert!(!has_code(src, "tcl", "IRULE5005"));
+    }
+
+    #[test]
+    fn irule5005_carries_call_rewrite_fix() {
+        let src = "proc helper {} { return 1 }\nwhen HTTP_REQUEST { helper x y }";
+        let mut a = Analyser::new();
+        let res = a.analyse(src, "f5-irules");
+        let d = res
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "IRULE5005")
+            .expect("IRULE5005 expected");
+        assert!(d.message.contains("call helper x y"));
+        assert_eq!(d.fixes.len(), 1);
+        assert_eq!(d.fixes[0].new_text, "call helper");
     }
 }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1065,6 +1065,14 @@ impl Analyser {
         // substitutions and the W307/W308 emitters never see them — Python's
         // nested `run_all_checks` recursion records every one.
         self.record_var_or_cmd_command_site(cmd_tok, args, scope_path);
+        // W125 (orphaned keyword) and IRULE5005 (direct iRules-proc call
+        // without `call`) key off whether the head resolves to a user proc, so
+        // they must reach substitution commands too: `when HTTP_REQUEST { set x
+        // [helper] }` invokes `helper` directly inside a `[…]`, and without this
+        // the IRULE5005 emitter never sees it.  Mirrors the top-level
+        // `process_command` ordering (proc-resolution after site recording) and
+        // Python's `run_all_checks` recursion into nested commands.
+        self.emit_proc_resolution_diagnostics(&cmd_name, args, cmd_tok, scope_path);
     }
 
     /// The `[…]` substitution fragment tokens of a (possibly compound)
@@ -2013,6 +2021,14 @@ mod tests {
     #[test]
     fn irule5005_fires_for_direct_proc_call_in_event() {
         let src = "proc helper {} { return 1 }\nwhen HTTP_REQUEST { helper }";
+        assert!(has_code(src, "f5-irules", "IRULE5005"));
+    }
+
+    #[test]
+    fn irule5005_fires_for_direct_proc_call_in_command_substitution() {
+        // A direct proc call nested inside a `[…]` substitution still bypasses
+        // `call`, so IRULE5005 must reach it via the nested-segment walk.
+        let src = "proc helper {} { return 1 }\nwhen HTTP_REQUEST { set x [helper] }";
         assert!(has_code(src, "f5-irules", "IRULE5005"));
     }
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -622,7 +622,7 @@ impl Analyser {
         self.emit_irule2002_deprecated_command(cmd_name, cmd_tok);
         // IRULE2001: deprecated `matchclass` (f5-irules only).  Python
         // fires this alongside IRULE2002 at the same command-head span.
-        self.emit_irule2001_matchclass(cmd_name, cmd_tok);
+        self.emit_irule2001_matchclass(cmd_name, args, arg_tokens, cmd_tok);
         // IRULE1003 / 1004 / 2101 / 4001 / 4003 / 5001 / 6001 —
         // analyser-level iRules event-context checks (f5-irules only).
         self.emit_irules_event_checks(cmd_name, args, arg_tokens, cmd_tok);

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -401,6 +401,12 @@ impl Analyser {
             return;
         }
 
+        // snit (tcllib) `snit::type` / `widget` / `widgetadaptor` — modelled
+        // as a `ClassDef` with method scopes, like `oo::class`.
+        if self.handle_snit_type_command(cmd_name, args, arg_tokens, scope_path) {
+            return;
+        }
+
         // namespace eval — opens a namespace child scope.
         if self.handle_namespace_eval_command(cmd_name, args, arg_tokens, scope_path) {
             return;

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -3550,7 +3550,28 @@ Consider capturing the result: catch {\u{2026}} result"
                 // unknown-subcommand path is handled separately by
                 // [`Self::emit_w001_unknown_subcommand`].
                 let Some(sub_name) = args.first() else {
-                    // Missing subcommand — Python's E001 path; not here.
+                    // **E001.** A subcommand-dispatch command invoked with no
+                    // subcommand at all (`string` / `dict` / `info` on its
+                    // own).  Mirrors the empty-`args` arm of `_check_arity`
+                    // (`compiler_checks.py:740-750`).  Queued as a
+                    // `pending_arity` candidate so an earlier shadowing user
+                    // proc / class / alias / ensemble / stub suppresses it,
+                    // exactly like the E002 / E003 paths and Python's
+                    // `_resolves_to_user_command` gate on `_check_arity`.
+                    let ns = self.command_resolution_namespace(scope_path);
+                    let enforce_order = !self.scope_path_in_proc_body(scope_path);
+                    self.pending_arity.push((
+                        cmd_name.to_string(),
+                        ns,
+                        enforce_order,
+                        super::types::Diagnostic {
+                            code: "E001".to_string(),
+                            span: cmd_tok.span,
+                            message: format!("'{cmd_name}' requires a subcommand"),
+                            severity: Severity::Error,
+                            fixes: Vec::new(),
+                        },
+                    ));
                     return;
                 };
                 // A `{*}`-expanded subcommand word resolves to an unknown
@@ -9661,6 +9682,50 @@ mod tests {
                 result.diagnostics
             );
         }
+    }
+
+    #[test]
+    fn e001_fires_for_bare_subcommand_command() {
+        // A subcommand-dispatch command (`string`, `dict`, `info`) invoked
+        // with no subcommand at all is E001.
+        for snippet in ["string", "dict", "info"] {
+            let mut a = Analyser::new();
+            let result = a.analyse(snippet, "tcl8.6");
+            let e001: Vec<&Diagnostic> = result
+                .diagnostics
+                .iter()
+                .filter(|d| d.code == "E001")
+                .collect();
+            assert_eq!(
+                e001.len(),
+                1,
+                "expected one E001 for {snippet:?}: {result:?}",
+            );
+            assert_eq!(
+                e001[0].message,
+                format!("'{snippet}' requires a subcommand")
+            );
+            assert_eq!(e001[0].severity, Severity::Error);
+        }
+    }
+
+    #[test]
+    fn e001_quiet_when_subcommand_present() {
+        let mut a = Analyser::new();
+        let result = a.analyse("string length abc", "tcl8.6");
+        assert!(!result.diagnostics.iter().any(|d| d.code == "E001"));
+    }
+
+    #[test]
+    fn e001_suppressed_by_shadowing_user_proc() {
+        // A user proc named `string` shadows the builtin ensemble — a bare
+        // `string` call resolves to the proc, so no E001.
+        let mut a = Analyser::new();
+        let result = a.analyse("proc string {} { return x }\nstring", "tcl8.6");
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == "E001"),
+            "shadowing proc should suppress E001: {result:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -8245,6 +8245,24 @@ file; this call falls through to the 'unknown' handler."
                 .iter()
                 .any(|(s, e, names)| *s <= off && off <= *e && names.contains(var))
         };
+        // Snit / OO instance-variable dispatch: `$mytree get` where `mytree` is
+        // a class instance variable and the dispatch sits inside the class body
+        // (including non-method helper `proc`s that `upvar` it). An instance var
+        // holds a component / sub-object, so dispatching on it is designed usage
+        // — suppress W307. Mirrors Python's `is_snit_member` / `snit_var_ranges`
+        // (built from every `ClassDef`'s body span + declared `variables`).
+        let snit_var_ranges: Vec<(u32, u32, &Vec<String>)> = self
+            .result
+            .all_classes
+            .values()
+            .filter(|cd| !cd.variables.is_empty())
+            .map(|cd| (cd.body_span.start(), cd.body_span.end(), &cd.variables))
+            .collect();
+        let is_snit_member = |var: &str, off: u32| -> bool {
+            snit_var_ranges
+                .iter()
+                .any(|(s, e, vars)| *s <= off && off <= *e && vars.iter().any(|v| v == var))
+        };
 
         // **Proc-parameter / multi-dispatch object-dispatch suppression**
         // (mirrors `_diag_var_command.py:807-859`).  A dispatch on a proc
@@ -8469,6 +8487,11 @@ file; this call falls through to the 'unknown' handler."
             // scope — a designed object handle, so the dispatch is not a static
             // error.  Mirrors Python's `is_factory_object` W307 exemption.
             if is_factory_local(&site.var_name, site.cmd_span.start()) {
+                continue;
+            }
+            // Class instance-variable dispatch inside the class body (component
+            // / sub-object). Mirrors Python's `is_snit_member` exemption.
+            if is_snit_member(&site.var_name, site.cmd_span.start()) {
                 continue;
             }
             self.result.diagnostics.push(super::types::Diagnostic {
@@ -11898,6 +11921,63 @@ mod tests {
                 w30x_codes(&src)
             );
         }
+    }
+
+    #[test]
+    fn w307_nested_command_sub_dispatch_counts_for_multidispatch() {
+        // `$x` is dispatched once at statement level and once inside a `[…]`
+        // command substitution.  The substitution dispatch must be recorded as
+        // a var-command site too, so the multi-dispatch (≥2) suppression sees
+        // both and stays silent (a single recorded dispatch would fire W307).
+        // Matches Python (which records every nested dispatch).
+        let src = "set x [getCmd]\nputs [$x foo]\n$x foo\n";
+        assert!(
+            w30x_codes(src).is_empty(),
+            "multi-dispatch (one nested in `[…]`) must suppress W307; got {:?}",
+            w30x_codes(src)
+        );
+    }
+
+    #[test]
+    fn w308_double_colon_oo_class_constructor() {
+        // `::oo::class` is the fully-qualified spelling of `oo::class`; the
+        // class must be recognised so the constructor types as OBJECT and the
+        // method is validated (W308 for the unknown one, silence for the known).
+        let unknown = "::oo::class create ::Dog { method bark {} {return woof} }\n[::Dog new] fly";
+        assert_eq!(w30x_codes(unknown), vec!["W308".to_string()]);
+        let known = "::oo::class create ::Dog { method bark {} {return woof} }\n[::Dog new] bark";
+        assert!(w30x_codes(known).is_empty());
+    }
+
+    #[test]
+    fn w307_suppressed_for_braced_namespace_var_proc_param() {
+        // `${namespace}::define::…` — the dispatched variable is the *braced*
+        // name `namespace` (a proc parameter), not the whole composite head.
+        // The var-name extraction must isolate `namespace` so the proc-param
+        // dispatch suppression fires (a mangled name defeats it → false W307).
+        let src = "proc Define {namespace class args} {\n  \
+                   ${namespace}::dynamic_methods $class\n  \
+                   ${namespace}::define::[lindex $args 0] {*}[lrange $args 1 end]\n}\n";
+        assert!(
+            w30x_codes(src).is_empty(),
+            "braced-namespace-var proc-param dispatch must suppress W307; got {:?}",
+            w30x_codes(src)
+        );
+    }
+
+    #[test]
+    fn w307_suppressed_for_snit_instance_var_in_helper_proc() {
+        // `mytree` is a snit instance variable dispatched inside a non-method
+        // helper `proc` in the type body (`upvar`'d component object).  The
+        // dispatch falls in the class body range and names an instance var, so
+        // `is_snit_member` suppresses W307.
+        let src = "snit::type T {\n  variable mytree\n  \
+                   proc Check {id} { upvar 1 mytree mytree; if {![$mytree exists $id]} { return } }\n}\n";
+        assert!(
+            w30x_codes(src).is_empty(),
+            "snit instance-var dispatch in a helper proc must suppress W307; got {:?}",
+            w30x_codes(src)
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -481,6 +481,78 @@ const BINARY_INT_SPECIFIERS: &[u8] = b"csSiInTwWmrR";
 /// statements outside any proc body (mirrors Python's `_TOP_SCOPE`).
 const W307_TOP_SCOPE: &str = "::top";
 
+/// The variable named by a single `$var` / `${var}` substitution, or `None`.
+///
+/// Mirrors the `_extract` closure in Python `_last_return_var`: the text must
+/// be exactly one bare or braced variable reference whose name is made of
+/// word / namespace characters.  Anything else (literals, command subs,
+/// composite words) yields `None`.
+fn extract_dollar_var(value: &str) -> Option<String> {
+    let v = value.trim();
+    let rest = v.strip_prefix('$')?;
+    let is_name = |s: &str| {
+        !s.is_empty()
+            && s.bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
+    };
+    if let Some(inner) = rest.strip_prefix('{').and_then(|r| r.strip_suffix('}')) {
+        // Braced `${name}` — reject nested braces (Python's `count("{") == 1`).
+        if !inner.contains('{') && is_name(inner) {
+            return Some(inner.to_string());
+        }
+        return None;
+    }
+    is_name(rest).then(|| rest.to_string())
+}
+
+/// The variable returned by a proc's **last** `return $var`, or `None`.
+///
+/// Walks every block's statements and terminator (returns can lower to either
+/// an `IRReturn` statement or a `Return` terminator) and keeps the last whose
+/// value is a single `$var`.  Mirrors Python's `_last_return_var`, used by the
+/// object-returning-proc inference: a proc returning `$X` where `X` was
+/// assigned from a factory is itself an object factory.
+fn last_return_var_of(cfg: &crate::cfg::Function) -> Option<String> {
+    use crate::cfg::Terminator;
+    use crate::ir::Statement;
+    let mut last = None;
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            if let Statement::Return { value: Some(v), .. } = stmt
+                && let Some(name) = extract_dollar_var(v)
+            {
+                last = Some(name);
+            }
+        }
+        if let Some(Terminator::Return { value: Some(v), .. }) = &block.terminator
+            && let Some(name) = extract_dollar_var(v)
+        {
+            last = Some(name);
+        }
+    }
+    last
+}
+
+/// Every return value (statement + terminator) a proc body can produce, as raw
+/// text.  Mirrors the G4 "collect ALL returns" loop in Python's
+/// object-returning-proc seed.
+fn return_values_of(cfg: &crate::cfg::Function) -> Vec<String> {
+    use crate::cfg::Terminator;
+    use crate::ir::Statement;
+    let mut out = Vec::new();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            if let Statement::Return { value: Some(v), .. } = stmt {
+                out.push(v.clone());
+            }
+        }
+        if let Some(Terminator::Return { value: Some(v), .. }) = &block.terminator {
+            out.push(v.clone());
+        }
+    }
+    out
+}
+
 /// Mask-octet values that can appear in a contiguous subnet mask.
 /// Mirrors `_VALID_MASK_OCTETS`.
 const VALID_MASK_OCTETS: &[u32] = &[0, 128, 192, 224, 240, 248, 252, 254, 255];
@@ -7832,6 +7904,197 @@ file; this call falls through to the 'unknown' handler."
         }
     }
 
+    /// Per-proc `(body_start, body_end, factory_local_vars)` ranges — the
+    /// variables that hold an *object factory* result, so a `$var method`
+    /// dispatch on them suppresses W307 (an object handle is a designed,
+    /// non-literal command target, not a static error).
+    ///
+    /// Mirrors the `object_returning_procs` / `factory_locals_by_proc` fixpoint
+    /// in Python `_diag_var_command.py`.  A factory local is a `set X [head …]`
+    /// where `head` is object-returning: a known `TclOO` class command, a
+    /// namespaced factory (the documented tcllib `::ns::cmd` convention, minus
+    /// known user procs and registry commands with a non-OBJECT return type),
+    /// or another proc proven object-returning by the fixpoint.  This tracks
+    /// *no* class identity — it only suppresses W307 (it never enables W308),
+    /// matching Python (a factory-return var validates no method).
+    #[allow(clippy::too_many_lines)]
+    // A single fixpoint algorithm (classify heads → collect factory locals →
+    // seed → propagate → extend → materialise ranges) whose phases share local
+    // state; splitting it would only scatter that state behind extra args.
+    fn compute_factory_object_ranges(
+        &self,
+        cu: &crate::compilation_unit::CompilationUnit,
+        registry: &tcl_registry::CommandRegistry,
+    ) -> Vec<(u32, u32, HashSet<String>)> {
+        use crate::ir::Statement;
+
+        let class_qnames: HashSet<&String> = self.result.all_classes.keys().collect();
+        let class_tails: HashSet<&str> = class_qnames
+            .iter()
+            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t))
+            .filter(|t| !t.is_empty())
+            .collect();
+        let is_user_proc = |head: &str| {
+            self.result.all_procs.contains_key(head)
+                || self.result.all_procs.contains_key(&format!("::{head}"))
+        };
+        // A command head whose value-returning invocation yields an object
+        // handle (excluding user procs, which the fixpoint classifies).
+        let is_object_returning_head = |head: &str| -> bool {
+            if class_tails.contains(head) || class_qnames.contains(&format!("::{head}")) {
+                return true;
+            }
+            if head.contains("::") {
+                let qualified = if head.starts_with("::") {
+                    head.to_string()
+                } else {
+                    format!("::{head}")
+                };
+                // A known user proc defers to the fixpoint (returns false here).
+                if self.result.all_procs.contains_key(&qualified) {
+                    return false;
+                }
+                // A registered command with an explicit non-OBJECT return type
+                // (http::*, clock::*, …) is not a factory.
+                if let Some(spec) = registry.get(head).or_else(|| registry.get(&qualified))
+                    && let Some(rt) = spec.return_type
+                    && rt != tcl_registry::TclType::Object
+                {
+                    return false;
+                }
+                // Unregistered `::pkg::cmd` — treat as a factory (the tcllib
+                // convention; documented heuristic).
+                return true;
+            }
+            false
+        };
+
+        // All analysable units: top level + procedures (not methods, which are
+        // `in_method`-suppressed for W307 anyway).
+        let units: Vec<(&str, &crate::compilation_unit::FunctionUnit)> =
+            std::iter::once(("::top", &cu.top_level))
+                .chain(cu.procedures.iter().map(|(q, fu)| (q.as_str(), fu)))
+                .collect();
+
+        // Per-proc: factory-local vars (non-user-proc factory heads), the last
+        // returned var, and the `{var -> rhs command head}` assignment map.
+        let mut factory_locals: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut return_var: HashMap<String, Option<String>> = HashMap::new();
+        let mut assigns: HashMap<String, HashMap<String, String>> = HashMap::new();
+        let mut object_returning: HashSet<String> = HashSet::new();
+        for (qname, fu) in &units {
+            let mut names = HashSet::new();
+            let mut amap = HashMap::new();
+            for block in fu.cfg.blocks.values() {
+                for stmt in &block.statements {
+                    let Statement::AssignValue { name, value, .. } = stmt else {
+                        continue;
+                    };
+                    let Some((head, _)) =
+                        crate::value_shapes::parse_command_substitution(value.trim())
+                    else {
+                        continue;
+                    };
+                    amap.insert(name.clone(), head.clone());
+                    if is_object_returning_head(&head) && !is_user_proc(&head) {
+                        names.insert(name.clone());
+                    }
+                }
+            }
+            factory_locals.insert((*qname).to_string(), names);
+            assigns.insert((*qname).to_string(), amap);
+            return_var.insert((*qname).to_string(), last_return_var_of(&fu.cfg));
+            // Seed: a proc whose every return value is a namespaced
+            // object-returning cmd-sub is itself object-returning (G4: ALL
+            // returns must qualify, so a string-returning branch disqualifies).
+            let rvs = return_values_of(&fu.cfg);
+            if !rvs.is_empty()
+                && rvs.iter().all(|rv| {
+                    crate::value_shapes::parse_command_substitution(rv.trim())
+                        .is_some_and(|(head, _)| is_object_returning_head(&head))
+                })
+            {
+                object_returning.insert((*qname).to_string());
+            }
+        }
+        // A proc returning one of its own factory locals is object-returning.
+        for (qname, rv) in &return_var {
+            if let Some(rv) = rv
+                && factory_locals.get(qname).is_some_and(|s| s.contains(rv))
+            {
+                object_returning.insert(qname.clone());
+            }
+        }
+
+        // Bare-name → qualified-name index for resolving relative call heads.
+        let mut bare_to_qnames: HashMap<&str, Vec<&str>> = HashMap::new();
+        for qname in cu.ir_module.procedures.keys() {
+            let bare = qname.rsplit_once("::").map_or(qname.as_str(), |(_, t)| t);
+            bare_to_qnames.entry(bare).or_default().push(qname.as_str());
+        }
+        let resolve_candidates = |head: &str| -> Vec<String> {
+            let mut c = vec![head.to_string(), format!("::{head}")];
+            if let Some(qs) = bare_to_qnames.get(head) {
+                c.extend(qs.iter().map(|s| (*s).to_string()));
+            }
+            c
+        };
+
+        // Fixpoint: a proc whose returned var is assigned `[other]` where
+        // `other` is a proven object-returning user proc is itself one.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (qname, rv) in &return_var {
+                let Some(rv) = rv else { continue };
+                if object_returning.contains(qname) {
+                    continue;
+                }
+                let Some(rhs) = assigns.get(qname).and_then(|m| m.get(rv)) else {
+                    continue;
+                };
+                if resolve_candidates(rhs)
+                    .iter()
+                    .any(|c| object_returning.contains(c))
+                {
+                    object_returning.insert(qname.clone());
+                    changed = true;
+                }
+            }
+        }
+        // Extend factory locals: `set X [user_proc]` where the proc is now
+        // proven object-returning makes `X` a factory local too.
+        for (qname, amap) in &assigns {
+            let mut add = HashSet::new();
+            for (var, head) in amap {
+                if factory_locals.get(qname).is_some_and(|s| s.contains(var)) {
+                    continue;
+                }
+                if resolve_candidates(head)
+                    .iter()
+                    .any(|c| object_returning.contains(c))
+                {
+                    add.insert(var.clone());
+                }
+            }
+            factory_locals.entry(qname.clone()).or_default().extend(add);
+        }
+
+        // Materialise ranges (top level spans the whole source).
+        let mut ranges = Vec::new();
+        for (qname, names) in factory_locals {
+            if names.is_empty() {
+                continue;
+            }
+            if qname == "::top" {
+                ranges.push((0, u32::MAX, names));
+            } else if let Some(p) = cu.ir_module.procedures.get(&qname) {
+                ranges.push((p.span.start(), p.span.end(), names));
+            }
+        }
+        ranges
+    }
+
     /// W307 — non-literal command name (variable / command-sub
     /// used as command head) and W308 (unknown method on object).
     ///
@@ -7973,6 +8236,15 @@ file; this call falls through to the 'unknown' handler."
         // Drain sites so we can borrow self.result mutably below.
         let sites = std::mem::take(&mut self.var_command_sites);
         let objdefined_vars = self.objdefined_vars.clone();
+        // Object-factory locals: vars holding a factory result (`set x [Class
+        // new]` / `set x [::ns::factory]` / `set x [object_returning_proc]`).
+        // A `$x method` dispatch on one suppresses W307 (designed object usage).
+        let factory_object_ranges = self.compute_factory_object_ranges(cu, registry);
+        let is_factory_local = |var: &str, off: u32| -> bool {
+            factory_object_ranges
+                .iter()
+                .any(|(s, e, names)| *s <= off && off <= *e && names.contains(var))
+        };
 
         // **Proc-parameter / multi-dispatch object-dispatch suppression**
         // (mirrors `_diag_var_command.py:807-859`).  A dispatch on a proc
@@ -8193,6 +8465,12 @@ file; this call falls through to the 'unknown' handler."
             {
                 continue;
             }
+            // Object-factory provenance: `$var` holds a factory result in this
+            // scope — a designed object handle, so the dispatch is not a static
+            // error.  Mirrors Python's `is_factory_object` W307 exemption.
+            if is_factory_local(&site.var_name, site.cmd_span.start()) {
+                continue;
+            }
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: "W307".to_string(),
                 span: site.cmd_span,
@@ -8292,7 +8570,17 @@ file; this call falls through to the 'unknown' handler."
                     class_name: Some(class_qn.clone()),
                 }
             } else {
-                crate::type_infer::return_type_for_command(registry, head, &arg_strs)
+                // The constructor case is already handled inline above using the
+                // analyser's authoritative class set, so the registry fallback
+                // only needs to recognise registered built-ins here — pass an
+                // empty class set / root namespace.
+                crate::type_infer::return_type_for_command(
+                    registry,
+                    head,
+                    &arg_strs,
+                    &std::collections::HashSet::new(),
+                    "::",
+                )
             };
 
             // ``Object`` return type — suppress W307; if the
@@ -10066,6 +10354,10 @@ mod tests {
             "proc f {n} {\n  set acc 0\n  for {set i 0} {$i < $n} {incr i} { set acc [expr {$acc + $i}] }\n  return $acc\n}\nproc g {} { set z 9; set z 10; return $z }\n",
             "namespace eval n {\n  proc p {a} { set b $a; return $b }\n}\nset r [n::p 3]\n",
             "oo::class create K {\n  method m {a} { set n $a; return $n }\n}\nproc top {} { set q 1; set q 2 }\n",
+            // Constructor object typing through the memo: `set o [K new]` types
+            // `o` as OBJECT(::K), so `$o gone` is validated (W308). Exercises
+            // the `known_classes` thread on `LatticeRequest` + the memo key.
+            "oo::class create K {\n  method m {} { return 1 }\n}\nproc top {} { set o [K new]; $o gone }\n",
         ];
         for src in snippets {
             let mut registry = tcl_registry::CommandRegistry::build_default();
@@ -10088,9 +10380,11 @@ mod tests {
                     tcl_lexer::LexerConfig::default(),
                     "tcl",
                     &mut |req: &crate::compilation_unit::LatticeRequest<'_>| -> FunctionUnit {
+                        // Key + build mirror the db's `function_lattice` query,
+                        // including the whole-unit `known_classes` fingerprint.
                         let key = format!(
-                            "{}\u{0}{:?}\u{0}{:?}\u{0}{:?}",
-                            req.qname, req.body, req.params, req.param_constants
+                            "{}\u{0}{:?}\u{0}{:?}\u{0}{:?}\u{0}{:?}",
+                            req.qname, req.body, req.params, req.param_constants, req.known_classes
                         );
                         if let Some(fu) = cache.get(&key) {
                             return fu.clone();
@@ -10104,12 +10398,15 @@ mod tests {
                         );
                         let pc =
                             crate::compilation_unit::decode_param_constants(req.param_constants);
-                        let fu = FunctionUnit::build_with_param_constants(
+                        let known_classes: std::collections::HashSet<String> =
+                            req.known_classes.iter().cloned().collect();
+                        let fu = FunctionUnit::build_with_param_constants_and_classes(
                             req.qname,
                             cfg,
                             req.params,
                             &registry,
                             pc.as_ref(),
+                            &known_classes,
                         );
                         cache.insert(key, fu.clone());
                         fu
@@ -11526,6 +11823,81 @@ mod tests {
             "W308 expected for unknown method on known class; got {:?}",
             r.diagnostics,
         );
+    }
+
+    /// Object-`of` constructor typing — the FE-DIAG W307/W308 item.  Every
+    /// case is verified byte-for-byte against the Python analyser oracle
+    /// (`analyser._analyser.analyse` under `dialect_scope("tcl")`); the
+    /// expected codes below are exactly what Python emits.
+    fn w30x_codes(src: &str) -> Vec<String> {
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        let mut codes: Vec<String> = r
+            .diagnostics
+            .iter()
+            .map(|d| d.code.clone())
+            .filter(|c| c.starts_with("W30"))
+            .collect();
+        codes.sort();
+        codes.dedup();
+        codes
+    }
+
+    #[test]
+    fn w308_transitive_alias_of_constructor_object() {
+        // `set b $a` copies the OBJECT(Dog) type through the lattice, so the
+        // unknown method on `$b` is validated (W308), matching Python.
+        let src = "oo::class create Dog { method bark {} {return woof} }\n\
+                   set a [Dog new]\nset b $a\n$b fly";
+        assert_eq!(w30x_codes(src), vec!["W308".to_string()]);
+    }
+
+    #[test]
+    fn w308_transitive_alias_known_method_silent() {
+        let src = "oo::class create Dog { method bark {} {return woof} }\n\
+                   set a [Dog new]\nset b $a\n$b bark";
+        assert!(w30x_codes(src).is_empty());
+    }
+
+    #[test]
+    fn w308_constructor_create_named_and_auto() {
+        // `Dog create rex` / `Dog create %AUTO%` are constructor spellings too.
+        for src in [
+            "oo::class create Dog { method bark {} {return woof} }\nset a [Dog create rex]\n$a fly",
+            "oo::class create Dog { method bark {} {return woof} }\nset a [Dog create %AUTO%]\n$a fly",
+        ] {
+            assert_eq!(w30x_codes(src), vec!["W308".to_string()], "src: {src}");
+        }
+    }
+
+    #[test]
+    fn w308_namespace_scoped_class_constructor() {
+        // Class defined in a namespace; the relative constructor head inside
+        // that namespace resolves to the qualified class (OBJECT(::ns::Dog)).
+        let qualified = "namespace eval ns { oo::class create Dog { method bark {} {return woof} } }\n\
+                         set a [ns::Dog new]\n$a fly";
+        assert_eq!(w30x_codes(qualified), vec!["W308".to_string()]);
+        let relative = "namespace eval ns {\n oo::class create Dog { method bark {} {return woof} }\n \
+                        proc mk {} { set a [Dog new]; $a fly }\n}";
+        assert_eq!(w30x_codes(relative), vec!["W308".to_string()]);
+    }
+
+    #[test]
+    fn w307_suppressed_for_object_returning_proc_factory() {
+        // A proc returning `[Dog new]` is an object factory; a `$o method`
+        // dispatch on its result suppresses W307 (Python tracks no class for
+        // factory-return vars, so there is never a W308 either).
+        for method in ["bark", "fly"] {
+            let src = format!(
+                "oo::class create Dog {{ method bark {{}} {{return woof}} }}\n\
+                 proc mk {{}} {{ return [Dog new] }}\nset o [mk]\n$o {method}"
+            );
+            assert!(
+                w30x_codes(&src).is_empty(),
+                "factory-return dispatch must be silent (method {method}); got {:?}",
+                w30x_codes(&src)
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -5112,10 +5112,38 @@ matching time on crafted input."
     /// command head): `matchclass` carries both a `deprecated_replacement`
     /// (→ IRULE2002) and the dedicated `check_matchclass` rule (→
     /// IRULE2001).  Mirrors `irules_checks.py::check_matchclass`.
-    pub(super) fn emit_irule2001_matchclass(&mut self, cmd_name: &str, cmd_tok: tcl_lexer::Token) {
+    pub(super) fn emit_irule2001_matchclass(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+        cmd_tok: tcl_lexer::Token,
+    ) {
         if self.dialect != "f5-irules" || cmd_name != "matchclass" {
             return;
         }
+        // Auto-fix the `matchclass <item> <class>` form →
+        // `class match <item> equals <class>`, replacing the whole command.
+        // The raw source slices of the argument words preserve `$var` / `[cmd]`
+        // substitutions verbatim (the substituted `args` values would drop
+        // them).  Mirrors the IRULE2001 `CodeFix` in `analyser/irules_checks.py`.
+        let fixes = if args.len() >= 2 && arg_tokens.len() >= 2 {
+            let raw = |t: &tcl_lexer::Token| {
+                self.source[t.span.start() as usize..t.span.end() as usize].to_string()
+            };
+            let item = raw(&arg_tokens[0]);
+            let cls = raw(&arg_tokens[1]);
+            let end = arg_tokens
+                .last()
+                .map_or(cmd_tok.span.end(), |t| t.span.end());
+            vec![super::types::CodeFix {
+                span: tcl_lexer::Span::new(cmd_tok.span.start(), end),
+                new_text: format!("class match {item} equals {cls}"),
+                description: "Replace with 'class match'".to_string(),
+            }]
+        } else {
+            Vec::new()
+        };
         self.result.diagnostics.push(super::types::Diagnostic {
             code: "IRULE2001".to_string(),
             span: cmd_tok.span,
@@ -5123,7 +5151,7 @@ matching time on crafted input."
 Use 'class match <item> <operator> <class>' instead."
                 .to_string(),
             severity: Severity::Warning,
-            fixes: Vec::new(),
+            fixes,
         });
     }
 
@@ -11978,6 +12006,28 @@ mod tests {
             "snit instance-var dispatch in a helper proc must suppress W307; got {:?}",
             w30x_codes(src)
         );
+    }
+
+    #[test]
+    fn irule2001_carries_matchclass_replacement_fix() {
+        // `matchclass <item> <class>` → `class match <item> equals <class>`,
+        // replacing the whole command. Raw source slices preserve `$var`. The
+        // fix span is independent of the diagnostic span (which is the head).
+        let mut a = Analyser::new();
+        let r = a.analyse("matchclass $u ::lib\n", "f5-irules");
+        let d = r
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "IRULE2001")
+            .expect("IRULE2001");
+        assert_eq!(d.fixes.len(), 1, "expected one fix, got {:?}", d.fixes);
+        let fix = &d.fixes[0];
+        assert_eq!(fix.new_text, "class match $u equals ::lib");
+        assert_eq!(fix.description, "Replace with 'class match'");
+        // Fix range spans the whole command (head + both args), not just the
+        // diagnostic's head span.
+        assert_eq!(fix.span.start(), d.span.start());
+        assert!(fix.span.end() > d.span.end());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -12371,6 +12371,48 @@ foo
     }
 
     #[test]
+    fn when_body_not_analysed_under_plain_tcl() {
+        // `when` is an iRules-only builtin; under plain Tcl it is a disabled
+        // foreign-dialect command whose braced argument is opaque *data*, not a
+        // handler script.  The body must not be scanned: only W002 (disabled) +
+        // W123 (unknown-in-dialect) on `when` itself — no W210 on the body's
+        // `$undefvar`, no W123 naming the body command.  Matches Python.
+        let mut a = Analyser::new();
+        let r = a.analyse("when HTTP_REQUEST {\n    boguscmd $undefvar\n}\n", "tcl");
+        let codes: Vec<&str> = r.diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(
+            !codes.contains(&"W210"),
+            "disabled `when` body must not be analysed (no W210); got {:?}",
+            r.diagnostics
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == "W123" && d.message.contains("boguscmd")),
+            "disabled `when` body command must not draw W123; got {:?}",
+            r.diagnostics
+        );
+        // The `when` head itself is still flagged disabled + unknown-in-dialect.
+        assert!(codes.contains(&"W002"), "expected W002; got {codes:?}");
+    }
+
+    #[test]
+    fn when_body_analysed_under_irules() {
+        // Under the iRules dialect `when` IS enabled, so its body is a real
+        // handler script and the read-before-set inside it fires (the inverse
+        // of `when_body_not_analysed_under_plain_tcl`).
+        let mut a = Analyser::new();
+        let r = a.analyse("when HTTP_REQUEST {\n    set x $undefvar\n}\n", "f5-irules");
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == "W210" && d.message.contains("undefvar")),
+            "iRules `when` body must be analysed (W210 on $undefvar); got {:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
     fn w210_interproc_dict_with_caller_literal() {
         // A caller passing a literal dict propagates to the callee's
         // `dict with $param` key check (interproc constant propagation).

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1189,6 +1189,11 @@ impl Analyser {
         // ?body?`` — so the cmd-name guard widens to the full set
         // and the recorded ``metaclass`` field still distinguishes
         // them downstream (hover / outline / class-hierarchy).
+        // A fully-qualified head (`::oo::class`) names the same global command
+        // as its bare form, so strip a single leading `::` before matching (and
+        // use the bare form for the recorded `metaclass`, so both spellings
+        // produce an identical `ClassDef`).
+        let cmd_name = cmd_name.strip_prefix("::").unwrap_or(cmd_name);
         if !matches!(
             cmd_name,
             "oo::class" | "oo::configurable" | "oo::abstract" | "oo::singleton"

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1197,7 +1197,10 @@ impl Analyser {
         {
             return false;
         }
-        if args[0] != "create" {
+        // `create Name ?body?`, `new ?body?`, and `createWithNamespace Name ns
+        // ?body?` all introduce a class; mirrors the subcommand gate in
+        // `_handle_oo_class_command` (`_oo.py:87`).
+        if !matches!(args[0].as_str(), "create" | "new" | "createWithNamespace") {
             return false;
         }
         let raw_name = &args[1];

--- a/rust/tcl-compiler/src/analyser/irules_event_checks.rs
+++ b/rust/tcl-compiler/src/analyser/irules_event_checks.rs
@@ -28,7 +28,9 @@
 use std::sync::OnceLock;
 
 use tcl_lexer::{Token, TokenType};
-use tcl_registry::events::EventRegistry;
+use tcl_registry::events::{EventProps, EventRegistry, EventRequires};
+use tcl_registry::prelude::DialectSet;
+use tcl_registry::profiles::ProfileRegistry;
 
 use super::state::Analyser;
 use super::types::{CodeFix, Diagnostic, Severity};
@@ -39,6 +41,75 @@ use super::types::{CodeFix, Diagnostic, Severity};
 fn event_registry() -> &'static EventRegistry {
     static REGISTRY: OnceLock<EventRegistry> = OnceLock::new();
     REGISTRY.get_or_init(EventRegistry::build)
+}
+
+/// Process-wide cached F5 profile registry.  Like [`event_registry`], the
+/// data is static, so building it once and sharing it avoids rebuilding the
+/// profile / protocol-namespace tables on every IRULE1001 check.
+fn profile_registry() -> &'static ProfileRegistry {
+    static REGISTRY: OnceLock<ProfileRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(ProfileRegistry::build)
+}
+
+/// `profile_info_description` — an informational hint string when a command's
+/// `required` profiles are not confirmed present on the file, or `None` when
+/// there is no requirement or the file's profile stack already covers it.
+/// Mirrors Python `profile_info_description`.
+fn profile_info_description(
+    required: &[&str],
+    file_profiles: &[&str],
+    profiles: &ProfileRegistry,
+) -> Option<String> {
+    if required.is_empty() || profiles.stack_satisfies(required, file_profiles) {
+        return None;
+    }
+    let mut sorted: Vec<&str> = required.to_vec();
+    sorted.sort_unstable();
+    Some(format!(
+        "assumes profile {} on the virtual server",
+        sorted.join(" or ")
+    ))
+}
+
+/// `missing_requirements_description` — a `; `-joined human-readable list of
+/// the protocol-stack requirements an `event` fails to satisfy for a command.
+/// Mirrors Python `missing_requirements_description`.
+fn missing_requirements_description(
+    props: &EventProps,
+    requires: &EventRequires,
+    profiles: &ProfileRegistry,
+) -> String {
+    if requires.init_only {
+        return "only valid in RULE_INIT".to_string();
+    }
+    let mut reasons: Vec<String> = Vec::new();
+    if requires.flow && !props.flow {
+        reasons.push("no active traffic flow (non-flow event)".to_string());
+    }
+    if requires.client_side && !props.client_side {
+        reasons.push("no client-side connection".to_string());
+    }
+    if requires.server_side && !props.server_side {
+        reasons.push("no server-side connection".to_string());
+    }
+    if let Some(t) = requires.transport
+        && !props.transport.contains(&t)
+    {
+        let actual = if props.transport.is_empty() {
+            "none".to_string()
+        } else {
+            props.transport.join("/")
+        };
+        reasons.push(format!("transport is {actual}, needs {t}"));
+    }
+    if !requires.profiles.is_empty()
+        && !profiles.stack_satisfies(requires.profiles, props.implied_profiles)
+    {
+        let mut sorted: Vec<&str> = requires.profiles.to_vec();
+        sorted.sort_unstable();
+        reasons.push(format!("requires profile {}", sorted.join(" or ")));
+    }
+    reasons.join("; ")
 }
 
 fn is_hot_event(event: &str) -> bool {
@@ -127,6 +198,9 @@ impl Analyser {
         }
         let event = self.current_event.clone();
         let event_ref = event.as_deref();
+        if let Some(ev) = event_ref {
+            self.emit_irule1001_command_event_validity(cmd_name, cmd_tok, ev);
+        }
         self.emit_irule1002_unknown_event(cmd_name, args, arg_tokens);
         self.emit_irule1003_deprecated_event(cmd_name, args, arg_tokens);
         self.emit_irule1004_when_missing_priority(cmd_name, args, cmd_tok);
@@ -140,6 +214,127 @@ impl Analyser {
         self.emit_irule5006_top_level_only(cmd_name, cmd_tok);
         self.emit_irule5007_event_context(cmd_name, cmd_tok, event_ref);
         self.emit_irule5003_loop_bound_inequality(cmd_name, args, arg_tokens);
+    }
+
+    /// Compute and cache the file-level profile stack for IRULE1001's
+    /// informational hint (Python `compute_file_profiles`).  No-op outside
+    /// the `f5-irules` dialect.  Called once from [`Self::analyse`] after the
+    /// registry is built; the result is read immutably by
+    /// [`Self::emit_irule1001_command_event_validity`].
+    pub(super) fn compute_irules_file_profiles(&mut self) {
+        if self.dialect != "f5-irules" {
+            return;
+        }
+        self.irules_file_profiles = Some(tcl_registry::profiles::compute_file_profiles(
+            &self.source,
+            event_registry(),
+            profile_registry(),
+        ));
+    }
+
+    /// **IRULE1001.** A command used in an iRules event where it is invalid or
+    /// ineffective — registry-legality-matrix driven (Python
+    /// `check_command_event_validity`):
+    ///
+    /// - **Warning** when the command is illegal in the event: either
+    ///   explicitly excluded (`'X' cannot be used in EVENT. Available in: …`)
+    ///   or its protocol-stack requirements are unmet (`'X' may not work in
+    ///   EVENT: <reasons>`).
+    /// - **Hint** when the command is legal but assumes a profile the file
+    ///   does not confirm (`'X' assumes profile Y on the virtual server`),
+    ///   driven either by the command's protocol namespace (`HTTP::` ⇒ HTTP)
+    ///   or its own `event_requires.profiles`.
+    ///
+    /// Only fires inside a `when EVENT` block; `emit_irules_event_checks`
+    /// supplies the enclosing `event`.
+    fn emit_irule1001_command_event_validity(
+        &mut self,
+        cmd_name: &str,
+        cmd_tok: Token,
+        event: &str,
+    ) {
+        let Some(registry) = self.registry.as_ref() else {
+            return;
+        };
+        let Some(spec) = registry.get_for_dialect(cmd_name, DialectSet::IRULES) else {
+            return;
+        };
+        let events = event_registry();
+        let profiles = profile_registry();
+
+        if registry.is_irules_command_legal_in_event(cmd_name, event, events, profiles) {
+            // Legal — only an informational profile hint may fire.  Namespace
+            // profiles (`HTTP::respond` ⇒ HTTP) take precedence over the
+            // command's own `event_requires.profiles`, matching Python.
+            let file_profiles: Vec<&str> = self
+                .irules_file_profiles
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .map(String::as_str)
+                .collect();
+            let hint = cmd_name
+                .split_once("::")
+                .and_then(|(prefix, _)| profiles.get_namespace(prefix))
+                .and_then(|ns| profile_info_description(ns.profiles, &file_profiles, profiles))
+                .or_else(|| {
+                    spec.event_requires.as_ref().and_then(|req| {
+                        profile_info_description(req.profiles, &file_profiles, profiles)
+                    })
+                });
+            if let Some(info) = hint {
+                self.result.diagnostics.push(Diagnostic {
+                    code: "IRULE1001".to_string(),
+                    span: cmd_tok.span,
+                    message: format!("'{cmd_name}' {info}."),
+                    severity: Severity::Hint,
+                    fixes: Vec::new(),
+                });
+            }
+            return;
+        }
+
+        // Illegal — produce a detailed warning.
+        if spec.excluded_events.contains(&event) {
+            let valid = registry.irules_events_for_command(cmd_name, events, profiles);
+            let mut hint = String::new();
+            if !valid.is_empty() {
+                let shown: Vec<&str> = valid.iter().take(5).copied().collect();
+                hint = format!(" Available in: {}", shown.join(", "));
+                if valid.len() > 5 {
+                    use std::fmt::Write as _;
+                    let _ = write!(hint, " (+{} more)", valid.len() - 5);
+                }
+                hint.push('.');
+            }
+            self.result.diagnostics.push(Diagnostic {
+                code: "IRULE1001".to_string(),
+                span: cmd_tok.span,
+                message: format!("'{cmd_name}' cannot be used in {event}.{hint}"),
+                severity: Severity::Warning,
+                fixes: Vec::new(),
+            });
+            return;
+        }
+
+        // Layer-based requirements — produce a reasoned warning.  An unknown
+        // event has no props to explain, so emit the generic form.
+        if let Some(req) = spec.event_requires.as_ref() {
+            let message = match events.get_props(event) {
+                None => format!("'{cmd_name}' may not work in {event}."),
+                Some(props) => {
+                    let desc = missing_requirements_description(props, req, profiles);
+                    format!("'{cmd_name}' may not work in {event}: {desc}.")
+                }
+            };
+            self.result.diagnostics.push(Diagnostic {
+                code: "IRULE1001".to_string(),
+                span: cmd_tok.span,
+                message,
+                severity: Severity::Warning,
+                fixes: Vec::new(),
+            });
+        }
     }
 
     /// **IRULE5003.** `while {$var != 0} { incr var -1 }` can miss zero.
@@ -1050,5 +1245,140 @@ mod tests {
         assert!(var_referenced_in("x", "log local0. ${x}"));
         assert!(!var_referenced_in("x", "log local0. $xyz"));
         assert!(!var_referenced_in("x", "no dollar here"));
+    }
+
+    // IRULE1001 — command-event-validity.  Messages and severities below are
+    // pinned against the Python `check_command_event_validity` oracle (run on
+    // the same snippets) and the registry legality matrix.
+
+    /// `(severity, message)` for every IRULE1001 diagnostic, whole-file.
+    fn irule1001(source: &str) -> Vec<(Severity, String)> {
+        let mut a = Analyser::new();
+        a.analyse(source, "f5-irules")
+            .diagnostics
+            .into_iter()
+            .filter(|d| d.code == "IRULE1001")
+            .map(|d| (d.severity, d.message))
+            .collect()
+    }
+
+    #[test]
+    fn irule1001_quiet_for_legal_command_with_inferred_profile() {
+        // HTTP_REQUEST infers the HTTP profile, so HTTP::respond is fully
+        // satisfied — no diagnostic at all.
+        assert!(irule1001("when HTTP_REQUEST { HTTP::respond 200 content \"ok\" }").is_empty());
+    }
+
+    #[test]
+    fn irule1001_warns_command_unmet_requirements() {
+        // HTTP::respond in CLIENT_ACCEPTED: the L4 event provides no HTTP
+        // profile, so it "may not work" with the missing-requirement reason.
+        let diags = irule1001("when CLIENT_ACCEPTED { HTTP::respond 200 content \"ok\" }");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].0, Severity::Warning);
+        assert_eq!(
+            diags[0].1,
+            "'HTTP::respond' may not work in CLIENT_ACCEPTED: requires profile FASTHTTP or HTTP."
+        );
+    }
+
+    #[test]
+    fn irule1001_hints_unconfirmed_namespace_profile() {
+        // SSL::cipher is legal in HTTP_REQUEST but assumes an SSL profile the
+        // file doesn't confirm — an informational hint, OR-listed + sorted.
+        let diags = irule1001("when HTTP_REQUEST { SSL::cipher name }");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].0, Severity::Hint);
+        assert_eq!(
+            diags[0].1,
+            "'SSL::cipher' assumes profile CLIENTSSL or PERSIST or SERVERSSL or \
+             SSL_PERSISTENCE on the virtual server."
+        );
+    }
+
+    #[test]
+    fn irule1001_warns_excluded_event_with_available_list() {
+        // HA::status is excluded from RULE_INIT; the "Available in: …" list is
+        // the first five (sorted) legal events plus a "(+N more)" tail.
+        let diags = irule1001("when RULE_INIT { HA::status }");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].0, Severity::Warning);
+        assert!(
+            diags[0]
+                .1
+                .starts_with("'HA::status' cannot be used in RULE_INIT. Available in: "),
+            "{}",
+            diags[0].1
+        );
+        assert!(diags[0].1.contains("(+") && diags[0].1.ends_with("more)."));
+    }
+
+    #[test]
+    fn irule1001_hint_suppressed_by_profile_directive() {
+        // A leading `# profiles: CLIENTSSL` directive confirms the SSL stack,
+        // so SSL::cipher's profile hint is suppressed.
+        assert!(
+            irule1001("# profiles: CLIENTSSL\nwhen HTTP_REQUEST { SSL::cipher name }").is_empty()
+        );
+    }
+
+    #[test]
+    fn irule1001_hint_suppressed_by_inferred_event_profile() {
+        // A CLIENTSSL_HANDSHAKE handler in the file infers CLIENTSSL, which
+        // covers SSL::cipher's requirement — hint suppressed.
+        let src =
+            "when CLIENTSSL_HANDSHAKE { log local0. hi }\nwhen HTTP_REQUEST { SSL::cipher name }";
+        assert!(irule1001(src).is_empty());
+    }
+
+    #[test]
+    fn irule1001_quiet_at_top_level_without_event() {
+        // No enclosing `when` block ⇒ no event context ⇒ the check never runs.
+        assert!(irule1001("HTTP::respond 200").is_empty());
+    }
+
+    #[test]
+    fn irule1001_quiet_outside_f5_dialect() {
+        let mut a = Analyser::new();
+        let res = a.analyse("when CLIENT_ACCEPTED { HTTP::respond 200 }", "tcl");
+        assert!(!res.diagnostics.iter().any(|d| d.code == "IRULE1001"));
+    }
+
+    #[test]
+    fn profile_info_description_or_lists_sorted_unconfirmed() {
+        let profiles = profile_registry();
+        // No requirement → None.
+        assert_eq!(profile_info_description(&[], &[], profiles), None);
+        // Confirmed by file → None.
+        assert_eq!(
+            profile_info_description(&["HTTP"], &["HTTP"], profiles),
+            None
+        );
+        // Unconfirmed → sorted OR-list.
+        assert_eq!(
+            profile_info_description(&["HTTP", "FASTHTTP"], &[], profiles).as_deref(),
+            Some("assumes profile FASTHTTP or HTTP on the virtual server")
+        );
+    }
+
+    #[test]
+    fn missing_requirements_description_reports_init_only_and_profiles() {
+        let profiles = profile_registry();
+        let events = event_registry();
+        let init_req = EventRequires {
+            client_side: false,
+            server_side: false,
+            transport: None,
+            profiles: &[],
+            also_in: &[],
+            init_only: true,
+            flow: false,
+            capability: None,
+        };
+        let props = events.get_props("HTTP_REQUEST").expect("known event");
+        assert_eq!(
+            missing_requirements_description(props, &init_req, profiles),
+            "only valid in RULE_INIT"
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -69,6 +69,24 @@ const CHAIN_TARGETS: &[&str] = &[
     "original_unknown",
 ];
 
+/// snit (tcllib) type/widget definers, both bare and `::`-qualified.  Mirrors
+/// `_SNIT_DEFINERS` in `analyser/_analyser/_oo.py`.
+const SNIT_DEFINERS: &[&str] = &[
+    "snit::type",
+    "snit::widget",
+    "snit::widgetadaptor",
+    "::snit::type",
+    "::snit::widget",
+    "::snit::widgetadaptor",
+];
+
+/// Implicit instance variables snit injects into `method` / `constructor` /
+/// `destructor` / `onconfigure` / `oncget` bodies.
+const SNIT_INSTANCE_IMPLICIT: &[&str] = &["self", "selfns", "type", "options"];
+
+/// Implicit variable snit injects into `typemethod` / `typeconstructor` bodies.
+const SNIT_TYPE_IMPLICIT: &[&str] = &["type"];
+
 impl Analyser {
     /// Walk the body of a ``oo::class create`` / ``oo::define``
     /// block, populating `class_def` from each subcommand.
@@ -187,6 +205,358 @@ impl Analyser {
             });
         } else {
             self.analyse_body(&mb.body_text, mb.body_tok, &method_path);
+        }
+    }
+
+    /// Handle a snit (tcllib) type/widget definition —
+    /// ``snit::type``/``snit::widget``/``snit::widgetadaptor Name { body }``
+    /// (and their `::`-qualified forms).  Snit reinterprets its body as a
+    /// class description, exactly like an `oo::class` body, so we model it as
+    /// a real [`ClassDef`] with method scopes — object dispatch inside method
+    /// bodies (`$self foo`, `$component bar`) is then recognised as in-method
+    /// dispatch (no false W307) and snit's implicit instance variables don't
+    /// surface as read-before-set / unused.  Mirrors `_handle_snit_type_command`
+    /// in `analyser/_analyser/_oo.py:503`.
+    pub(super) fn handle_snit_type_command(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) -> bool {
+        if !SNIT_DEFINERS.contains(&cmd_name) || args.len() < 2 || arg_tokens.len() < 2 {
+            return false;
+        }
+        let raw_name = &args[0];
+        let body = &args[1];
+        let ns_prefix = self.namespace_from_scope_path(scope_path);
+        let ns_for_qualify = ns_prefix.trim_start_matches(':');
+        let qualified = super::handlers::qualify(ns_for_qualify, raw_name);
+        let simple = qualified.rsplit("::").next().unwrap_or("").to_string();
+        let name_span = arg_tokens[0].span;
+        let body_tok = arg_tokens[1];
+        let is_widget = cmd_name.ends_with("widget") || cmd_name.ends_with("widgetadaptor");
+        let doc = std::mem::take(&mut self.last_comment);
+        let mut class = ClassDef {
+            name: simple.clone(),
+            qualified_name: qualified.clone(),
+            name_span,
+            body_span: body_tok.span,
+            metaclass: cmd_name.to_string(),
+            doc,
+            ..Default::default()
+        };
+        if !body.is_empty() {
+            self.parse_snit_definition_body(
+                body, body_tok, &mut class, &qualified, scope_path, is_widget,
+            );
+        }
+        self.result.all_classes.insert(qualified, class.clone());
+        let path = scope_path.to_vec();
+        if let Some(scope) = scope_at_mut(&mut self.result.global_scope, &path) {
+            scope.classes.insert(simple, class);
+        }
+        true
+    }
+
+    /// Parse a snit type/widget body into methods + variable declarations, in
+    /// two passes (so a method can reference any instance/type variable
+    /// regardless of declaration order).  Mirrors `_parse_snit_definition_body`.
+    fn parse_snit_definition_body(
+        &mut self,
+        body: &str,
+        body_tok: Token,
+        class_def: &mut ClassDef,
+        class_qualified: &str,
+        scope_path: &[usize],
+        is_widget: bool,
+    ) {
+        if body_tok.kind != TokenType::Str {
+            return;
+        }
+        let base_offset = body_tok.span.start() + u32::from(body_tok.content_offset);
+        let cmds = crate::segmenter::segment_commands_with_offset_and_config(
+            body,
+            base_offset,
+            self.lexer_config(),
+        );
+
+        // Snit injects these implicit variables into method / type-method bodies.
+        let mut instance_vars: Vec<String> = SNIT_INSTANCE_IMPLICIT
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        if is_widget {
+            instance_vars.push("win".to_string());
+            instance_vars.push("hull".to_string());
+        }
+        let mut type_vars: Vec<String> = SNIT_TYPE_IMPLICIT
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        // First pass: collect declared instance / type variable + component names.
+        for cmd in &cmds {
+            if cmd.is_partial {
+                continue;
+            }
+            let Some((sub, sub_args)) = cmd.texts.split_first() else {
+                continue;
+            };
+            match sub.as_str() {
+                "variable" | "component" => {
+                    if let Some(name) = sub_args.first() {
+                        instance_vars.push(name.clone());
+                    }
+                }
+                "typevariable" | "typecomponent" => {
+                    if let Some(name) = sub_args.first() {
+                        type_vars.push(name.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Record the *explicit* instance + type variables on the class —
+        // method-scope seeding and the W307 dispatch-source suppression both
+        // read `ClassDef::variables`.  Only the four implicit scalars
+        // (`self`/`selfns`/`type`/`options`) and the type-implicit `type` are
+        // filtered; a widget's injected `win`/`hull` are kept (Python parity).
+        class_def.variables = instance_vars
+            .iter()
+            .filter(|v| !SNIT_INSTANCE_IMPLICIT.contains(&v.as_str()))
+            .chain(
+                type_vars
+                    .iter()
+                    .filter(|v| !SNIT_TYPE_IMPLICIT.contains(&v.as_str())),
+            )
+            .cloned()
+            .collect();
+
+        // Second pass: analyse method-bearing declarations in method scopes.
+        for cmd in &cmds {
+            if cmd.is_partial {
+                continue;
+            }
+            if let Some((sub, sub_args)) = cmd.texts.split_first() {
+                let sub_tokens = cmd.argv.get(1..).unwrap_or(&[]);
+                self.dispatch_snit_member(
+                    sub,
+                    sub_args,
+                    sub_tokens,
+                    class_def,
+                    class_qualified,
+                    scope_path,
+                    &instance_vars,
+                    &type_vars,
+                );
+            }
+        }
+    }
+
+    /// Dispatch one snit body subcommand to the matching method extractor (or,
+    /// for `proc`, the ordinary proc handler).  Split out of
+    /// [`Self::parse_snit_definition_body`] so the two-pass walk stays small.
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch_snit_member(
+        &mut self,
+        sub: &str,
+        sub_args: &[String],
+        sub_tokens: &[Token],
+        class_def: &mut ClassDef,
+        class_qualified: &str,
+        scope_path: &[usize],
+        instance_vars: &[String],
+        type_vars: &[String],
+    ) {
+        match sub {
+            // snit allows a type-private `proc name args body` — analyse it as
+            // an ordinary proc in the enclosing scope.
+            "proc" => {
+                self.handle_proc_command("proc", sub_args, sub_tokens, scope_path);
+            }
+            "method" => self.extract_snit_method(
+                sub_args,
+                sub_tokens,
+                class_def,
+                class_qualified,
+                scope_path,
+                instance_vars,
+                "method",
+                false,
+                "",
+            ),
+            "typemethod" => self.extract_snit_method(
+                sub_args,
+                sub_tokens,
+                class_def,
+                class_qualified,
+                scope_path,
+                type_vars,
+                "classmethod",
+                false,
+                "",
+            ),
+            "constructor" => self.extract_snit_method(
+                sub_args,
+                sub_tokens,
+                class_def,
+                class_qualified,
+                scope_path,
+                instance_vars,
+                "constructor",
+                false,
+                "<constructor>",
+            ),
+            "destructor" => self.extract_snit_method(
+                sub_args,
+                sub_tokens,
+                class_def,
+                class_qualified,
+                scope_path,
+                instance_vars,
+                "destructor",
+                true,
+                "<destructor>",
+            ),
+            "typeconstructor" => self.extract_snit_method(
+                sub_args,
+                sub_tokens,
+                class_def,
+                class_qualified,
+                scope_path,
+                type_vars,
+                "classmethod",
+                true,
+                "<typeconstructor>",
+            ),
+            // `onconfigure -opt valuevar { body }` / `oncget -opt { body }`
+            // (snit 1.x) — the leading `-opt` word is dropped.
+            "onconfigure" => {
+                let label = sub_args
+                    .first()
+                    .map_or(String::new(), |o| format!("<onconfigure {o}>"));
+                self.extract_snit_method(
+                    sub_args.get(1..).unwrap_or(&[]),
+                    sub_tokens.get(1..).unwrap_or(&[]),
+                    class_def,
+                    class_qualified,
+                    scope_path,
+                    instance_vars,
+                    "method",
+                    false,
+                    &label,
+                );
+            }
+            "oncget" => {
+                let label = sub_args
+                    .first()
+                    .map_or(String::new(), |o| format!("<oncget {o}>"));
+                self.extract_snit_method(
+                    sub_args.get(1..).unwrap_or(&[]),
+                    sub_tokens.get(1..).unwrap_or(&[]),
+                    class_def,
+                    class_qualified,
+                    scope_path,
+                    instance_vars,
+                    "method",
+                    true,
+                    &label,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    /// Analyse one snit method / constructor / etc. body in a method scope
+    /// seeded with `seed_vars` (snit's implicit names + declared instance or
+    /// type variables) and the method's formal parameters.  Mirrors
+    /// `_extract_snit_method`.  `no_arglist` is for declarations whose body
+    /// immediately follows the keyword (`destructor` / `typeconstructor` /
+    /// `oncget`); `synthetic_name` names the synthetic constructor/handler
+    /// forms.
+    #[allow(clippy::too_many_arguments)]
+    fn extract_snit_method(
+        &mut self,
+        args: &[String],
+        arg_tokens: &[Token],
+        class_def: &mut ClassDef,
+        class_qualified: &str,
+        scope_path: &[usize],
+        seed_vars: &[String],
+        kind: &str,
+        no_arglist: bool,
+        synthetic_name: &str,
+    ) {
+        let (name, params, body_text, body_tok) = if no_arglist {
+            let Some(body) = args.first() else {
+                return;
+            };
+            let nm = if synthetic_name.is_empty() {
+                "<body>".to_string()
+            } else {
+                synthetic_name.to_string()
+            };
+            (nm, Vec::new(), body.clone(), arg_tokens.first().copied())
+        } else if synthetic_name.is_empty() {
+            // method / typemethod: NAME ARGLIST BODY.
+            if args.len() < 3 {
+                return;
+            }
+            (
+                args[0].clone(),
+                parse_param_list(&args[1]),
+                args[2].clone(),
+                arg_tokens.get(2).copied(),
+            )
+        } else {
+            // constructor / onconfigure: ARGLIST BODY (name is synthetic).
+            if args.len() < 2 {
+                return;
+            }
+            (
+                synthetic_name.to_string(),
+                parse_param_list(&args[0]),
+                args[1].clone(),
+                arg_tokens.get(1).copied(),
+            )
+        };
+
+        let zero = Span::new(0, 0);
+        let name_span = arg_tokens.first().map_or(zero, |t| t.span);
+        let body_span = body_tok.map_or(name_span, |t| t.span);
+        let method_def = MethodDef {
+            name: name.clone(),
+            params: params.clone(),
+            name_span,
+            body_span,
+            kind: kind.to_string(),
+            visibility: "public".to_string(),
+            doc: String::new(),
+        };
+        match kind {
+            "constructor" => class_def.constructors.push(method_def),
+            "destructor" => class_def.destructor = Some(method_def),
+            "classmethod" => {
+                class_def.class_methods.insert(name.clone(), method_def);
+            }
+            _ => {
+                class_def.methods.insert(name.clone(), method_def);
+            }
+        }
+
+        // Walk the body in a method scope seeded with the params + seed vars,
+        // reusing the TclOO method-body walker (it pre-binds the params and the
+        // supplied vars as never-warn locals, then analyses the body).
+        if let Some(bt) = body_tok {
+            let mb = CollectedMethodBody {
+                name,
+                params,
+                body_text,
+                body_tok: bt,
+            };
+            self.walk_method_body(seed_vars, class_qualified, scope_path, &mb);
         }
     }
 
@@ -1118,5 +1488,92 @@ mod tests {
         let body = r"switch -exact $cmd { foo { return 1 } }";
         let info = a.extract_unknown_proc_info(body, &[]);
         assert!(info.dispatch_targets.contains("foo"));
+    }
+
+    // snit (tcllib) type / widget support.  Verified against the Python
+    // `_handle_snit_type_command` oracle and real `tclsh8.6` + tcllib.
+
+    #[test]
+    fn snit_type_recorded_as_class_with_members() {
+        let src = "snit::type ::foo::Bar {\n\
+                   variable v1\n\
+                   typevariable tv1\n\
+                   method m1 {a b} { return [expr {$a+$b+$v1}] }\n\
+                   typemethod tm1 {} { return $tv1 }\n\
+                   constructor {args} { set v1 0 }\n\
+                   destructor { unset v1 }\n\
+                   typeconstructor { set tv1 0 }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let c = r.all_classes.get("::foo::Bar").expect("Bar class recorded");
+        assert_eq!(c.metaclass, "snit::type");
+        assert!(c.methods.contains_key("m1"));
+        assert!(c.class_methods.contains_key("tm1"));
+        assert!(c.class_methods.contains_key("<typeconstructor>"));
+        assert_eq!(c.constructors.len(), 1);
+        assert!(c.destructor.is_some());
+        assert_eq!(c.variables, vec!["v1".to_string(), "tv1".to_string()]);
+    }
+
+    #[test]
+    fn snit_widget_keeps_win_and_hull_vars() {
+        // A snit::widget injects `win` and `hull` instance variables — both
+        // are recorded (only the four implicit scalars are filtered).
+        let src = "snit::widget Dial {\n\
+                   variable state\n\
+                   method draw {} { return $win }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let c = r.all_classes.get("::Dial").expect("Dial recorded");
+        assert_eq!(c.metaclass, "snit::widget");
+        assert_eq!(
+            c.variables,
+            vec!["win".to_string(), "hull".to_string(), "state".to_string()]
+        );
+    }
+
+    #[test]
+    fn snit_method_body_suppresses_self_dispatch_and_implicit_vars() {
+        // Inside a snit method, `$self`/`$component` dispatch and reads of
+        // instance variables must not false-fire W307 (non-literal command),
+        // W210 (read-before-set), or W211/W214 (unused).
+        let src = "snit::widget mywidget {\n\
+                   variable helper\n\
+                   component inner\n\
+                   method draw {} {\n\
+                       $self configure -bg white\n\
+                       $inner render\n\
+                       $helper compute\n\
+                       return $win\n\
+                   }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        for code in ["W210", "W211", "W214", "W307", "W308"] {
+            assert!(
+                !r.diagnostics.iter().any(|d| d.code == code),
+                "{code} must not fire in a snit method body: {:?}",
+                r.diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn snit_widgetadaptor_and_qualified_definer() {
+        let mut a = Analyser::new();
+        let r = a.analyse("::snit::widgetadaptor Foo { method m {} {} }", "tcl8.6");
+        let c = r.all_classes.get("::Foo").expect("Foo recorded");
+        assert_eq!(c.metaclass, "::snit::widgetadaptor");
+        assert!(c.methods.contains_key("m"));
+    }
+
+    #[test]
+    fn non_snit_command_is_not_a_class() {
+        // A plain command that merely starts with `snit` is not a definer.
+        let mut a = Analyser::new();
+        let r = a.analyse("snitch foo { bar }", "tcl8.6");
+        assert!(r.all_classes.is_empty());
     }
 }

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -120,6 +120,12 @@ impl Analyser {
         // visible as a pre-bound local in *every* method body, regardless of
         // source order — mirroring Python's two-phase `_parse_oo_definition_body`.
         let mut method_bodies: Vec<CollectedMethodBody> = Vec::new();
+        // `property -get`/`-set` accessor bodies — walked in a method scope
+        // seeded with the class variables (Python `_extract_property_defs`).
+        let mut accessor_bodies: Vec<CollectedMethodBody> = Vec::new();
+        // `initialise`/`initialize { body }` — a class-level script walked in
+        // the *enclosing* scope (not a method scope), mirroring Python.
+        let mut init_bodies: Vec<(String, Token)> = Vec::new();
         for cmd in &cmds {
             if cmd.is_partial || cmd.argv.is_empty() {
                 continue;
@@ -128,12 +134,29 @@ impl Analyser {
             if let Some(mb) = collect_method_body(&cmd.texts, &cmd.argv) {
                 method_bodies.push(mb);
             }
+            match cmd.texts.first().map(String::as_str) {
+                Some("property") => {
+                    collect_property_accessor_bodies(&cmd.texts, &cmd.argv, &mut accessor_bodies);
+                }
+                Some("initialise" | "initialize") => {
+                    if let (Some(body), Some(tok)) = (cmd.texts.get(1), cmd.argv.get(1).copied())
+                        && tok.kind == TokenType::Str
+                    {
+                        init_bodies.push((body.clone(), tok));
+                    }
+                }
+                _ => {}
+            }
         }
-        // Phase 2: walk each method body in its own `Method` scope with the
-        // formal parameters and the class's instance variables pre-bound.
+        // Phase 2: walk each method / accessor body in its own `Method` scope
+        // with the formal parameters and the class's instance variables
+        // pre-bound; the `initialise` body walks in the enclosing scope.
         let class_variables = class_def.variables.clone();
-        for mb in method_bodies {
-            self.walk_method_body(&class_variables, class_qualified, scope_path, &mb);
+        for mb in method_bodies.iter().chain(accessor_bodies.iter()) {
+            self.walk_method_body(&class_variables, class_qualified, scope_path, mb);
+        }
+        for (body, tok) in init_bodies {
+            self.analyse_body(&body, tok, scope_path);
         }
     }
 
@@ -1036,6 +1059,40 @@ fn extract_property_defs(args: &[String], arg_tokens: &[Token], class_def: &mut 
     }
 }
 
+/// Collect the `-get` / `-set` accessor bodies of a `property` subcommand as
+/// walkable method bodies (named `<get>` / `<set>`).  Mirrors the accessor-body
+/// recursion in Python `_extract_property_defs`; only braced (`Str`) bodies are
+/// walkable.
+fn collect_property_accessor_bodies(
+    texts: &[String],
+    argv: &[Token],
+    out: &mut Vec<CollectedMethodBody>,
+) {
+    let mut i = 0;
+    while i < texts.len() {
+        if let Some(opt) = texts[i].strip_prefix('-') {
+            // Every property option takes a value; only `-get`/`-set` carry a
+            // body to analyse.
+            if i + 1 < texts.len() {
+                if matches!(opt, "get" | "set")
+                    && let Some(tok) = argv.get(i + 1).copied()
+                    && tok.kind == TokenType::Str
+                {
+                    out.push(CollectedMethodBody {
+                        name: format!("<{opt}>"),
+                        params: Vec::new(),
+                        body_text: texts[i + 1].clone(),
+                        body_tok: tok,
+                    });
+                }
+                i += 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
+}
+
 /// Extract a [`MethodDef`] from method-style args.
 ///
 /// Mirrors `_extract_method_def` in `_oo.py:290-349`.  Three
@@ -1575,5 +1632,62 @@ mod tests {
         let mut a = Analyser::new();
         let r = a.analyse("snitch foo { bar }", "tcl8.6");
         assert!(r.all_classes.is_empty());
+    }
+
+    // OO body-walks: `initialise` body, `property -get/-set` accessor bodies,
+    // and the `new` / `createWithNamespace` class-command variants.
+
+    #[test]
+    fn oo_initialise_body_is_walked() {
+        // A `variable` read inside `initialise { … }` must not false-fire
+        // W210 read-before-set — the class-level init body is walked with the
+        // class's instance variables visible.
+        let src = "oo::class create Foo {\n\
+                   variable cache\n\
+                   initialise { set cache [dict create] }\n\
+                   method get {k} { return [dict get $cache $k] }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| matches!(d.code.as_str(), "W210" | "W211")),
+            "initialise body should be walked cleanly: {:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
+    fn oo_property_accessor_bodies_are_walked() {
+        // `-get`/`-set` accessor bodies are walked with the instance variable
+        // `val` and the implicit `value` visible — no false W210 / W307.
+        let src = "oo::configurable create Bar {\n\
+                   variable val\n\
+                   property color -get { return $val } -set { set val $value }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        assert!(r.all_classes.contains_key("::Bar"));
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| matches!(d.code.as_str(), "W210" | "W307")),
+            "property accessor bodies should be walked cleanly: {:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
+    fn oo_class_create_with_namespace_is_recognised() {
+        // The `createWithNamespace` class-command variant introduces a class
+        // (matching Python's widened subcommand gate).
+        let mut a = Analyser::new();
+        let r = a.analyse("oo::class createWithNamespace MyCls ::ns { }", "tcl8.6");
+        assert!(
+            r.all_classes.keys().any(|k| k.contains("MyCls")),
+            "createWithNamespace should record a class: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -309,6 +309,13 @@ pub struct Analyser {
     /// it fell back to a full rebuild.  Read by perf/coverage probes; ignored by
     /// production callers (which only consume the returned `AnalysisResult`).
     pub took_fast_path: bool,
+    /// iRules file-profile cache for IRULE1001's informational profile hint:
+    /// the sorted, fully-expanded profile stack derived from any
+    /// `# profiles:` directive plus the profiles implied by the file's
+    /// `when` events (Python `compute_file_profiles`).  Computed once per
+    /// `analyse` run (only under the `f5-irules` dialect) and cleared at the
+    /// top of each run.  `None` outside an active iRules analysis.
+    pub(super) irules_file_profiles: Option<Vec<String>>,
 }
 
 /// W108 non-ASCII detection mode — mirrors the `tclLsp.style.nonAscii`
@@ -402,6 +409,7 @@ impl Analyser {
             probe_skip_enclosing_fallback: false,
             probe_skip_duplicate_fallback: false,
             took_fast_path: false,
+            irules_file_profiles: None,
         }
     }
 
@@ -472,6 +480,9 @@ impl Analyser {
         // ``core/analysis/_analyser/_core.py``.
         self.source = source.to_string();
         self.dialect = dialect.to_string();
+        // Clear the per-run iRules file-profile memo so a reused analyser
+        // instance recomputes it for the new source / dialect.
+        self.irules_file_profiles = None;
         // File-suppression pre-scan: merge codes from any
         // top-of-file ``# tcl-lsp: disable=CODE`` directives into
         // ``self.disabled_diagnostics`` so later emitter passes
@@ -534,6 +545,9 @@ impl Analyser {
             registry.load_dialect(d);
         }
         self.registry = Some(registry);
+        // Precompute the iRules file-profile stack (no-op off f5-irules) so
+        // the per-command IRULE1001 hint can consult it without recomputing.
+        self.compute_irules_file_profiles();
         // Precompute newline offsets once for ``O(log N)``
         // byte-offset → line-number lookup in
         // ``apply_preceding_noqa`` (which runs per command and

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2759,6 +2759,74 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_name_write_does_not_dead_store_the_name_var() {
+        // `set $p 1` writes the variable *named by* `$p` and *reads* `p`
+        // (verified against tclsh 8.4–9.0).  It must not produce a spurious
+        // W220 dead-store on the parameter `p` itself.  Matches the Python
+        // analyser (which emits nothing here).
+        for body in ["set $p 1", "set ${p} 1", "set $p [expr {1}]"] {
+            let mut a = Analyser::new();
+            let r = a.analyse(&format!("proc ::f {{p}} {{ {body} }}\n"), "tcl");
+            assert!(
+                r.diagnostics
+                    .iter()
+                    .all(|d| !(matches!(d.code.as_str(), "W211" | "W220" | "W214")
+                        && d.message.contains("'p'"))),
+                "dynamic-name write `{body}` wrongly flagged `p`, got {:?}",
+                r.diagnostics,
+            );
+        }
+    }
+
+    #[test]
+    fn dynamic_name_out_var_does_not_suppress_caller_dead_store() {
+        // A param used only as a *dynamic name* out-var (`scan`/`lassign`/
+        // `regexp`/`regsub` target, or `set $p`) names a callee-local
+        // variable — it does NOT write back to the caller's frame, so a
+        // caller's literal arg is genuinely dead and must still fire W211 /
+        // W220 (the PR #498/#499 false-positive regression guard, verified
+        // against the Python analyser).
+        let cases = [
+            "proc maybe {target} { scan 42 %d $target }",
+            "proc maybe {target} { lassign {1} $target }",
+            "proc maybe {target} { regexp {(.)} a -> $target }",
+            "proc maybe {target} { regsub a a b $target }",
+            "proc maybe {target} { set $target 1 }",
+        ];
+        for callee in cases {
+            let src = format!("{callee}\nproc caller {{}} {{ set x 1; maybe x }}\n");
+            let mut a = Analyser::new();
+            let r = a.analyse(&src, "tcl");
+            assert!(
+                r.diagnostics
+                    .iter()
+                    .any(|d| (d.code == "W211" || d.code == "W220") && d.message.contains("'x'")),
+                "caller's dead `x` must still fire for `{callee}`, got {:?}",
+                r.diagnostics,
+            );
+        }
+    }
+
+    #[test]
+    fn upvar_writeback_still_suppresses_caller_dead_store() {
+        // Control: a genuine `upvar`-write-back callee DOES consume the
+        // caller's variable, so the dead-store is correctly suppressed.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc fill {outvar} { upvar $outvar out\nset out 42 }\n\
+             proc top {} { set result {}\nfill result\nreturn $result }\n",
+            "tcl",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .all(|d| !((d.code == "W211" || d.code == "W220") && d.message.contains("result"))),
+            "upvar write-back must suppress the caller dead-store, got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    #[test]
     fn analyse_w128_fires_on_call_to_renamed_command() {
         // SYNC-JUN02b-4 (#519): a builtin renamed/deleted away earlier in
         // the file → the later call falls through to `unknown` → W128.

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -95,25 +95,15 @@ impl ScopeKind {
     }
 }
 
-/// A suggested fix for a [`Diagnostic`] — maps to an LSP
-/// `TextEdit`.
+/// A suggested fix for a [`Diagnostic`] — maps to an LSP `TextEdit`.
 ///
-/// Mirrors ``CodeFix`` in ``core/analysis/semantic_model.py``.
-/// Populated by emitters that know exactly *what* the user
-/// should change (E101 inserts a missing ``{``, E103 inserts a
-/// missing ``}``, W123 may suggest a similarly-named command,
-/// etc.).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CodeFix {
-    /// Source span the replacement applies to.  An insertion
-    /// is a zero-width span anchored at the insertion point.
-    pub span: Span,
-    /// Text to replace ``span`` with.
-    pub new_text: String,
-    /// Human-readable description of the fix
-    /// (e.g. ``"Insert missing '{'"``).  Empty when omitted.
-    pub description: String,
-}
+/// Re-exported from [`crate::irules_checks`] (the canonical, lower-level
+/// definition shared with the iRules-flow / compiler-checks layer) so the
+/// analyser and those passes speak one `CodeFix` type.  Mirrors ``CodeFix`` in
+/// ``core/analysis/semantic_model.py``.  Populated by emitters that know
+/// exactly *what* the user should change (E101 inserts a missing ``{``, E103
+/// inserts a missing ``}``, W123 may suggest a similarly-named command, etc.).
+pub use crate::irules_checks::CodeFix;
 
 /// Diagnostic emitted by the analyser.
 ///

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -15,7 +15,7 @@
 //! The Python facade also owns class-name extraction and
 //! connection-scope analysis; those are follow-ups.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use tcl_registry::CommandRegistry;
 
@@ -67,6 +67,15 @@ pub struct LatticeRequest<'a> {
     /// Position-independent — keyed by parameter name + SSA version, never by
     /// span — so it rebases trivially with the rest of the offset-0 unit.
     pub param_constants: &'a [(String, u32, String)],
+    /// Fully-qualified names of every class defined in the compilation unit
+    /// (sorted), so the type-propagation pass can recognise a `TclOO` / itcl
+    /// constructor call (`Foo new`) and type it `OBJECT(::ns::Foo)`.  A
+    /// whole-unit fact, identical for every procedure, so it is folded into the
+    /// memo key: adding or removing a class anywhere invalidates each
+    /// procedure's lattice (a new class can change any body's constructor
+    /// typing).  Sourced from [`crate::signature_scan`] so the standalone and
+    /// incremental builds derive an identical set from the same source.
+    pub known_classes: &'a [String],
 }
 
 /// Salsa-native per-procedure lattice memo used by
@@ -185,6 +194,36 @@ impl FunctionUnit {
             &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
         >,
     ) -> Self {
+        Self::build_with_param_constants_and_classes(
+            name,
+            cfg,
+            params,
+            registry,
+            param_constants,
+            &HashSet::new(),
+        )
+    }
+
+    /// Like [`Self::build_with_param_constants`] but additionally threads the
+    /// compilation unit's `known_classes` set into type propagation and return
+    /// inference, so a `TclOO` / itcl constructor call (`Foo new` / `Foo create
+    /// x`) whose head names a known class is typed `OBJECT(::ns::Foo)` (the
+    /// signal the analyser's W307 / W308 method-dispatch checks consume).  The
+    /// per-function [`Self::build`] / [`Self::build_with_param_constants`]
+    /// entry points default to an empty set (no object typing); the
+    /// compilation-unit builders ([`Self::build_for`] and friends) source the
+    /// real set from [`crate::signature_scan`].
+    #[must_use]
+    pub fn build_with_param_constants_and_classes(
+        name: impl Into<String>,
+        cfg: CfgFunction,
+        params: &[String],
+        registry: &CommandRegistry,
+        param_constants: Option<
+            &std::collections::HashMap<crate::ssa::ValueKey, crate::analyses::LatticeValue>,
+        >,
+        known_classes: &HashSet<String>,
+    ) -> Self {
         // Complexity guard (block-count half): a pathologically large body
         // would cost seconds of SSA + dataflow for near-zero findings, so skip
         // the deep analysis and flag the unit. The body-byte half is applied by
@@ -216,9 +255,14 @@ impl FunctionUnit {
             params.iter().map(String::as_str).collect();
         sccp.constant_branches
             .extend(crate::sccp::existence_constant_branches(&cfg, &param_set));
-        let types = propagate_types(&cfg, &ssa, &sccp, registry);
-        let return_type =
-            crate::type_infer::infer_function_return_type(&cfg, &sccp, &types, registry);
+        let types = propagate_types(&cfg, &ssa, &sccp, registry, known_classes);
+        let return_type = crate::type_infer::infer_function_return_type(
+            &cfg,
+            &sccp,
+            &types,
+            registry,
+            known_classes,
+        );
         let rendered_props = propagate_rendered_props(&cfg, &ssa, &sccp, registry);
         let taints = propagate_taints(
             &cfg,
@@ -472,7 +516,26 @@ impl CompilationUnit {
         // callee's SCCP can fold a param every caller passes the same literal
         // for (interprocedural constant propagation).
         let call_site_constants = collect_call_site_constants(&cfg_module, &ir_module.procedures);
-        let top_level = FunctionUnit::build("::top", cfg_module.top_level.clone(), &[], registry);
+        // Fully-qualified names of every class defined in the unit, sourced from
+        // the signature scanner so this build and the incremental/db build
+        // derive an identical set (⇒ identical OBJECT-constructor typing on both
+        // paths).  `known_classes` (sorted) is also what each `LatticeRequest`
+        // carries into the memo key, so a class-set change invalidates the
+        // per-procedure lattices.
+        let known_class_set = collect_known_classes(source, registry);
+        let known_classes: Vec<String> = {
+            let mut v: Vec<String> = known_class_set.iter().cloned().collect();
+            v.sort_unstable();
+            v
+        };
+        let top_level = FunctionUnit::build_with_param_constants_and_classes(
+            "::top",
+            cfg_module.top_level.clone(),
+            &[],
+            registry,
+            None,
+            &known_class_set,
+        );
         // Module-wide upvar/param context — the CFG-determining context a
         // procedure body is rebuilt under.  Computed once and shared by every
         // memoised request (and the methods below), so the offset-0 CFG the
@@ -533,6 +596,7 @@ impl CompilationUnit {
                         proc_params,
                         dialect,
                         param_constants: &encoded_pc,
+                        known_classes: &known_classes,
                     });
                     // Rebase the offset-0 memo result to the procedure's real
                     // position so every consumer sees **absolute** spans without
@@ -545,12 +609,13 @@ impl CompilationUnit {
                 _ => None,
             };
             let fu = memoised.unwrap_or_else(|| {
-                FunctionUnit::build_with_param_constants(
+                FunctionUnit::build_with_param_constants_and_classes(
                     qname,
                     cfg.clone(),
                     params,
                     registry,
                     param_constants.as_ref(),
+                    &known_class_set,
                 )
             });
             procedures.insert(qname.clone(), fu);
@@ -589,7 +654,14 @@ impl CompilationUnit {
                     let fu = if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES {
                         FunctionUnit::trivial_guarded(mqname, cfg)
                     } else {
-                        FunctionUnit::build(mqname, cfg, &method.params, registry)
+                        FunctionUnit::build_with_param_constants_and_classes(
+                            mqname,
+                            cfg,
+                            &method.params,
+                            registry,
+                            None,
+                            &known_class_set,
+                        )
                     };
                     (mqname.clone(), fu)
                 })
@@ -782,6 +854,26 @@ struct ArgConsts {
     unknown: bool,
     /// Distinct literal values seen at this position.
     values: std::collections::HashSet<String>,
+}
+
+/// Fully-qualified names of every class defined in `source`.
+///
+/// Sourced from [`crate::signature_scan`] (which records `oo::class create` and
+/// `itcl::class` definitions) so the standalone analyser build and the
+/// incremental/db build derive an *identical* set from the same source — the
+/// precondition for the two paths agreeing on constructor (`Foo new`) typing.
+/// Gated on a cheap substring probe (`class`, the only token both class-defining
+/// heads share) so the overwhelmingly common non-OO source skips the scan
+/// entirely.  A false-positive probe just runs the (still fast) scan; the probe
+/// can never miss a real definition because both heads contain `class`.
+fn collect_known_classes(source: &str, registry: &CommandRegistry) -> HashSet<String> {
+    if !source.contains("class") {
+        return HashSet::new();
+    }
+    crate::signature_scan::extract_signatures(source, registry)
+        .classes
+        .into_keys()
+        .collect()
 }
 
 /// Collect literal arg values per user-proc call site across the whole

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -15,7 +15,7 @@ use tcl_lexer::Span;
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::gvn::{find_loop_invariants, find_partial_redundancies, find_redundancies};
 use crate::irules_checks::{
-    IrulesCheckWarning, find_collect_flow_warnings, find_generic_static_name_warnings,
+    CodeFix, IrulesCheckWarning, find_collect_flow_warnings, find_generic_static_name_warnings,
     find_hoistable_set_warnings, find_http_flow_warnings, find_unguarded_drop_warnings,
     find_unnormalised_getter_warnings,
 };
@@ -89,6 +89,12 @@ pub struct Diagnostic {
     /// fix or could not build one. Consumers that surface code actions
     /// (LSP `CodeAction`, CLI auto-fix) should plumb this through.
     pub replacement: Option<String>,
+    /// Suggested fixes whose range is independent of `span` — insertions or
+    /// out-of-span replacements that `replacement` (a same-span rewrite) cannot
+    /// express (e.g. the IRULE5002/5004 "insert `return`" fixes). Empty when the
+    /// check has no such fix. Consumers emit one `TextEdit` per fix at its own
+    /// `span`.
+    pub fixes: Vec<CodeFix>,
 }
 
 impl Diagnostic {
@@ -106,6 +112,7 @@ impl Diagnostic {
                 cb.block, cb.value, cb.taken_target
             ),
             replacement: None,
+            fixes: Vec::new(),
         }
     }
 
@@ -124,6 +131,7 @@ impl Diagnostic {
             },
             message: w.message.clone(),
             replacement: None,
+            fixes: Vec::new(),
         }
     }
 
@@ -135,6 +143,7 @@ impl Diagnostic {
             severity: Severity::Warning,
             message: w.message.clone(),
             replacement: None,
+            fixes: Vec::new(),
         }
     }
 
@@ -146,6 +155,7 @@ impl Diagnostic {
             severity: Severity::Error,
             message: w.message.clone(),
             replacement: w.replacement.clone(),
+            fixes: Vec::new(),
         }
     }
 
@@ -157,6 +167,7 @@ impl Diagnostic {
             severity: Severity::Warning,
             message: w.message.clone(),
             replacement: w.replacement.clone(),
+            fixes: w.fixes.clone(),
         }
     }
 
@@ -168,6 +179,7 @@ impl Diagnostic {
             severity: Severity::Suggestion,
             message: r.message.clone(),
             replacement: None,
+            fixes: Vec::new(),
         }
     }
 
@@ -179,6 +191,7 @@ impl Diagnostic {
             severity: Severity::Warning,
             message: w.message.clone(),
             replacement: w.replacement.clone(),
+            fixes: Vec::new(),
         }
     }
 }

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -93,6 +93,25 @@ fn supports_normalized_flag(registry: &CommandRegistry, cmd: &str) -> bool {
         .is_some_and(|spec| spec.options.iter().any(|opt| opt.name == "-normalized"))
 }
 
+/// A suggested code-action fix — maps to an LSP `TextEdit`.
+///
+/// `span` is the **fix range** the edit applies to, *independent* of the
+/// diagnostic's own span: an insertion is a zero-width span anchored at the
+/// insertion point (e.g. the end of a `drop`), a replacement covers the text it
+/// rewrites.  This is the lower-level twin of the analyser's `CodeFix`, which
+/// re-exports this type (see `analyser::types`); it lives here because the
+/// iRules-flow / compiler-checks layer is below the analyser.  Mirrors Python
+/// `shared/diagnostic.py::CodeFix`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CodeFix {
+    /// Source span the `new_text` replaces (zero-width for an insertion).
+    pub span: Span,
+    /// Replacement / inserted text.
+    pub new_text: String,
+    /// Human-readable description (`"Add 'event disable all' + 'return'"`).
+    pub description: String,
+}
+
 /// An IRULE3102 / iRules-check diagnostic emitted by
 /// [`find_unnormalised_getter_warnings`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -105,6 +124,9 @@ pub struct IrulesCheckWarning {
     pub message: String,
     /// Optional replacement text (currently always `None`).
     pub replacement: Option<String>,
+    /// Suggested fixes whose range is independent of `span` (insertions /
+    /// out-of-span replacements).  Empty when the check supplies no fix.
+    pub fixes: Vec<CodeFix>,
 }
 
 /// Return `true` when `args` suggests a *getter* invocation — no args,
@@ -190,6 +212,7 @@ pub fn find_unnormalised_getter_warnings(
                                 code: "IRULE3102".to_owned(),
                                 message: format_message(command),
                                 replacement: None,
+                                fixes: Vec::new(),
                             });
                         }
                         // Getter nested as a command-substitution argument —
@@ -217,6 +240,7 @@ pub fn find_unnormalised_getter_warnings(
                                     code: "IRULE3102".to_owned(),
                                     message: format_message(&cmd),
                                     replacement: None,
+                                    fixes: Vec::new(),
                                 });
                             }
                         }
@@ -231,6 +255,7 @@ pub fn find_unnormalised_getter_warnings(
                                 code: "IRULE3102".to_owned(),
                                 message: format_message(&cmd),
                                 replacement: None,
+                                fixes: Vec::new(),
                             });
                         }
                     }
@@ -388,6 +413,14 @@ pub fn find_unguarded_drop_warnings(
                         st.drop_cmd,
                     ),
                     replacement: None,
+                    // Insert `event disable all` + `return` right after the drop
+                    // (a zero-width edit at the drop command's end).  Mirrors the
+                    // IRULE5002 `CodeFix` in Python `irules_flow.py`.
+                    fixes: vec![CodeFix {
+                        span: Span::new(span.end(), span.end()),
+                        new_text: "\n    event disable all\n    return".to_owned(),
+                        description: "Add 'event disable all' + 'return'".to_owned(),
+                    }],
                 });
             }
             if st.dns_returned
@@ -399,6 +432,13 @@ pub fn find_unguarded_drop_warnings(
                     message: "'DNS::return' must be followed by 'return' to stop iRule processing."
                         .to_owned(),
                     replacement: None,
+                    // Insert `return` right after `DNS::return`.  Mirrors the
+                    // IRULE5004 `CodeFix` in Python `irules_flow.py`.
+                    fixes: vec![CodeFix {
+                        span: Span::new(span.end(), span.end()),
+                        new_text: "\n    return".to_owned(),
+                        description: "Add 'return' after DNS::return".to_owned(),
+                    }],
                 });
             }
         }
@@ -679,6 +719,7 @@ pub fn find_collect_flow_warnings(
                 proto_hint.join(" or "),
             ),
             replacement: None,
+            fixes: Vec::new(),
         });
     }
 
@@ -693,6 +734,7 @@ pub fn find_collect_flow_warnings(
                     "'{proto}::payload' without a {side} {proto}::collect call. The payload buffer will be empty.",
                 ),
                 replacement: None,
+                fixes: Vec::new(),
             });
         }
     }
@@ -708,6 +750,7 @@ pub fn find_collect_flow_warnings(
                     "{proto}::collect without matching {proto}::release on the {side} side; collected data is never released",
                 ),
                 replacement: None,
+                fixes: Vec::new(),
             });
         }
     }
@@ -723,6 +766,7 @@ pub fn find_collect_flow_warnings(
                     "{proto}::release without matching {proto}::collect on the {side} side; no data was collected",
                 ),
                 replacement: None,
+                fixes: Vec::new(),
             });
         }
     }
@@ -847,6 +891,7 @@ fn apply_http_flow_command(
                     "Multiple '{cmd}' calls possible in {event}. Only the first response takes effect.",
                 ),
                 replacement: None,
+                fixes: Vec::new(),
             });
             return state;
         }
@@ -863,6 +908,7 @@ fn apply_http_flow_command(
                 "'{cmd}' used after response is committed. HTTP context is invalid after HTTP::respond/HTTP::redirect.",
             ),
             replacement: None,
+            fixes: Vec::new(),
         });
     }
     state
@@ -1088,6 +1134,7 @@ pub fn find_hoistable_set_warnings(
                         "`set {name} ...` runs on every request — consider hoisting to a once-per-connection event (e.g. CLIENT_ACCEPTED).",
                     ),
                     replacement: None,
+                    fixes: Vec::new(),
                 });
             }
         }
@@ -1236,6 +1283,7 @@ fn check_generic_static(
              prefix with the application or rule name (e.g. 'static::<app>_{bare}')."
         ),
         replacement: None,
+        fixes: Vec::new(),
     });
 }
 
@@ -1498,6 +1546,39 @@ mod tests {
             .find(|w| w.code == "IRULE5002")
             .expect("IRULE5002");
         assert_eq!(w.span.start(), 23, "span should point at `drop`");
+    }
+
+    #[test]
+    fn irule5002_carries_insertion_fix() {
+        // The quick-fix inserts `event disable all` + `return` *after* the drop
+        // (a zero-width edit anchored at the drop command's end), independent of
+        // the diagnostic span.  Text matches the Python IRULE5002 `CodeFix`.
+        let ws = drop_warnings("when CLIENT_ACCEPTED { drop }");
+        let w = ws
+            .iter()
+            .find(|w| w.code == "IRULE5002")
+            .expect("IRULE5002");
+        assert_eq!(w.fixes.len(), 1, "expected one fix, got {:?}", w.fixes);
+        let fix = &w.fixes[0];
+        assert_eq!(fix.new_text, "\n    event disable all\n    return");
+        assert_eq!(fix.description, "Add 'event disable all' + 'return'");
+        // Zero-width insertion at the drop command's end.
+        assert_eq!(fix.span.start(), w.span.end());
+        assert_eq!(fix.span.start(), fix.span.end());
+    }
+
+    #[test]
+    fn irule5004_carries_insertion_fix() {
+        let ws = drop_warnings("when DNS_REQUEST { DNS::return }");
+        let w = ws
+            .iter()
+            .find(|w| w.code == "IRULE5004")
+            .expect("IRULE5004");
+        assert_eq!(w.fixes.len(), 1);
+        let fix = &w.fixes[0];
+        assert_eq!(fix.new_text, "\n    return");
+        assert_eq!(fix.description, "Add 'return' after DNS::return");
+        assert_eq!(fix.span.start(), fix.span.end());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -18,17 +18,67 @@
 //! their own follow-up sub-strips per the chunk-log row's
 //! "each diagnostic is its own sub-strip" sequencing.
 
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
 use tcl_lexer::Span;
 use tcl_registry::CommandRegistry;
 use tcl_registry::events::EventRegistry;
+use tcl_registry::side_effects::SideEffectTarget;
 
 use crate::cfg_builder::build_cfg;
 use crate::compilation_unit::CompilationUnit;
-use crate::ir::Statement;
+use crate::ir::{Script, Statement};
 use crate::lowering::lower_to_ir_with_config;
 use crate::sccp::cfg_order;
 use crate::taint::is_irules_dialect;
 use crate::value_shapes::parse_command_substitution;
+
+/// Process-wide iRules command registry, used to derive the HTTP-flow command
+/// sets below.  Built once (the data is static).
+fn irules_registry() -> &'static CommandRegistry {
+    static REG: OnceLock<CommandRegistry> = OnceLock::new();
+    REG.get_or_init(|| {
+        let mut r = CommandRegistry::build_default();
+        r.load_irules();
+        r
+    })
+}
+
+/// Commands that commit an HTTP response — derived from the registry's
+/// `ResponseCommit` side-effect (Python `_commits_response_commands`), so the
+/// bare iRules `redirect` is included alongside `HTTP::respond` /
+/// `HTTP::redirect` without a hardcoded list.
+fn commits_response_commands() -> &'static HashSet<String> {
+    static SET: OnceLock<HashSet<String>> = OnceLock::new();
+    SET.get_or_init(|| {
+        let reg = irules_registry();
+        reg.command_names()
+            .filter(|name| {
+                reg.get(name).is_some_and(|spec| {
+                    spec.side_effects
+                        .iter()
+                        .any(|h| h.target == SideEffectTarget::ResponseCommit && h.writes)
+                })
+            })
+            .map(String::from)
+            .collect()
+    })
+}
+
+/// Registered `HTTP::` namespace commands (Python `_http_namespace_commands`).
+/// Only *registered* commands count, so an unregistered `HTTP::log` does not
+/// trip IRULE1201 (matches the Python set of 32 commands).
+fn http_namespace_commands() -> &'static HashSet<String> {
+    static SET: OnceLock<HashSet<String>> = OnceLock::new();
+    SET.get_or_init(|| {
+        irules_registry()
+            .command_names()
+            .filter(|name| name.starts_with("HTTP::"))
+            .map(String::from)
+            .collect()
+    })
+}
 
 /// Whether `cmd` is a registered iRules getter that carries the
 /// `-normalized` option in its [`tcl_registry::CommandSpec`].
@@ -652,33 +702,30 @@ pub fn find_collect_flow_warnings(
 // IRULE1201 / IRULE1202 — HTTP-after-respond / multi-respond
 // ---------------------------------------------------------------------------
 //
-// Mirrors `irules_flow.py::_analyse_when_body` (lines 296-450).
-// Linear CFG scan within each `::when::HTTP*` proc body:
+// Path-sensitive port of `irules_flow.py::_analyse_when_body` (the C44
+// follow-up).  Walks the *structured* IR body of each `::when::HTTP*`
+// procedure, tracking a set of per-path response states so that:
 //
-//   * IRULE1202 — second `HTTP::respond` / `HTTP::redirect` on the
-//     same path; only the first response takes effect.
-//   * IRULE1201 — any `HTTP::*` command issued after a response is
-//     committed; HTTP context is invalid post-respond.
+//   * IRULE1202 — a second `HTTP::respond` / `HTTP::redirect` / `redirect`
+//     on a path that already responded; only the first response takes effect.
+//   * IRULE1201 — a registered `HTTP::*` command issued on a path where a
+//     response is already committed; HTTP context is invalid post-respond.
 //
-// Path-sensitivity (separate state per branch of `if` / `switch` /
-// `try`) is the C44 follow-up.  This linear shape catches the
-// straight-line cases (`HTTP::respond ...; HTTP::header ...`).
-//
-// Response-committing commands: hardcoded to `HTTP::respond` /
-// `HTTP::redirect` (the canonical pair).  When the registry grows
-// a `SideEffectTarget::ResponseCommit` category the lookup
-// switches to the registry-driven query.
+// Mutually-exclusive branches keep separate states, so `if {…} { respond }
+// else { respond }` is *not* a double-respond (avoids the linear-scan false
+// positive), `catch { respond }; HTTP::…` *is* flagged, and a loop body runs
+// zero-or-more times.  `return` terminates the current path.
 
-fn commits_http_response(cmd: &str) -> bool {
-    matches!(cmd, "HTTP::respond" | "HTTP::redirect")
+/// A single response-flow fact along one path.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct HttpFlowState {
+    responded: bool,
+    /// Start offset of the committing response (for dedup / parity), or `None`.
+    respond_at: Option<u32>,
 }
 
-fn is_http_namespace(cmd: &str) -> bool {
-    cmd.starts_with("HTTP::")
-}
-
-/// Per-event HTTP-flow warnings.  Emits IRULE1201 + IRULE1202 for
-/// each `::when::HTTP*` proc body.
+/// Per-event HTTP-flow warnings.  Emits IRULE1201 + IRULE1202 for each
+/// `::when::HTTP*` proc body, path-sensitively.
 #[must_use]
 pub fn find_http_flow_warnings(
     cu: &CompilationUnit,
@@ -688,6 +735,8 @@ pub fn find_http_flow_warnings(
     if !is_irules_dialect(dialect) {
         return out;
     }
+    // Iterate the *analysable* functions (honouring the FE-DATAFLOW
+    // complexity guard, #652) but walk their structured IR body.
     for fu in cu.analysable_functions() {
         let Some(event) = fu.name.strip_prefix("::when::") else {
             continue;
@@ -697,75 +746,215 @@ pub fn find_http_flow_warnings(
         if !bare_event.starts_with("HTTP") {
             continue;
         }
-        out.extend(
-            scan_when_body_for_http_flow(fu, bare_event)
-                .into_iter()
-                .map(|mut w| {
-                    w.span = fu.abs_span(w.span);
-                    w
-                }),
+        let Some(proc) = cu.ir_module.procedures.get(&fu.name) else {
+            continue;
+        };
+        analyse_http_flow_script(
+            &proc.body,
+            bare_event,
+            &[HttpFlowState {
+                responded: false,
+                respond_at: None,
+            }],
+            &mut out,
         );
     }
     out
 }
 
-fn scan_when_body_for_http_flow(
-    fu: &crate::compilation_unit::FunctionUnit,
-    event: &str,
-) -> Vec<IrulesCheckWarning> {
+/// Deduplicate flow states by `(responded, respond_at)` (Python `_dedupe`).
+fn dedupe_flow_states(states: Vec<HttpFlowState>) -> Vec<HttpFlowState> {
+    let mut seen: HashSet<(bool, i64)> = HashSet::new();
     let mut out = Vec::new();
-    let mut responded = false;
-    let mut respond_command: Option<String> = None;
-
-    for bn in cfg_order(&fu.cfg) {
-        if !fu.sccp.executable_blocks.contains(&bn) {
-            continue;
-        }
-        let Some(block) = fu.cfg.blocks.get(&bn) else {
-            continue;
-        };
-        for stmt in &block.statements {
-            let (cmd, span) = match stmt {
-                Statement::Call { command, span, .. }
-                | Statement::Barrier { command, span, .. } => (command.as_str(), *span),
-                _ => continue,
-            };
-            if commits_http_response(cmd) {
-                if responded {
-                    out.push(IrulesCheckWarning {
-                        span,
-                        code: "IRULE1202".to_owned(),
-                        message: format!(
-                            "Multiple '{cmd}' calls possible in {event}. Only the first response takes effect.",
-                        ),
-                        replacement: None,
-                    });
-                } else {
-                    responded = true;
-                    respond_command = Some(cmd.to_string());
-                }
-                continue;
-            }
-            if responded && is_http_namespace(cmd) {
-                let _ = respond_command.as_ref();
-                out.push(IrulesCheckWarning {
-                    span,
-                    code: "IRULE1201".to_owned(),
-                    message: format!(
-                        "'{cmd}' used after response is committed. HTTP context is invalid after HTTP::respond/HTTP::redirect.",
-                    ),
-                    replacement: None,
-                });
-            }
-        }
-        // `return` Terminator clears the response state (the rule
-        // exits before any "after" code runs).
-        if let Some(crate::cfg::Terminator::Return { .. }) = &block.terminator {
-            responded = false;
-            respond_command = None;
+    for s in states {
+        let key = (s.responded, s.respond_at.map_or(-1, i64::from));
+        if seen.insert(key) {
+            out.push(s);
         }
     }
     out
+}
+
+/// The command word + span a statement applies to the response flow, or `None`.
+/// Mirrors Python `_stmt_command`: direct `Call`/`Barrier` heads, plus a
+/// whole-value `[cmd …]` command substitution assigned by `set`.
+fn http_flow_stmt_command(stmt: &Statement) -> Option<(&str, Span)> {
+    match stmt {
+        Statement::Call { command, span, .. } | Statement::Barrier { command, span, .. } => {
+            Some((command.as_str(), *span))
+        }
+        Statement::AssignValue { value, span, .. } => {
+            let inner = value.trim().strip_prefix('[')?.strip_suffix(']')?.trim();
+            inner.split_whitespace().next().map(|cmd| (cmd, *span))
+        }
+        _ => None,
+    }
+}
+
+/// Apply one command to a flow state, emitting IRULE1201/1202 as warranted.
+fn apply_http_flow_command(
+    state: HttpFlowState,
+    cmd: &str,
+    span: Span,
+    event: &str,
+    out: &mut Vec<IrulesCheckWarning>,
+) -> HttpFlowState {
+    if commits_response_commands().contains(cmd) {
+        if state.responded {
+            out.push(IrulesCheckWarning {
+                span,
+                code: "IRULE1202".to_owned(),
+                message: format!(
+                    "Multiple '{cmd}' calls possible in {event}. Only the first response takes effect.",
+                ),
+                replacement: None,
+            });
+            return state;
+        }
+        return HttpFlowState {
+            responded: true,
+            respond_at: Some(span.start()),
+        };
+    }
+    if state.responded && http_namespace_commands().contains(cmd) {
+        out.push(IrulesCheckWarning {
+            span,
+            code: "IRULE1201".to_owned(),
+            message: format!(
+                "'{cmd}' used after response is committed. HTTP context is invalid after HTTP::respond/HTTP::redirect.",
+            ),
+            replacement: None,
+        });
+    }
+    state
+}
+
+/// Path-sensitive walk of a structured IR script, threading the set of
+/// response-flow states.  Mirrors Python `_analyse_script`: a thin loop over
+/// the structured statements, delegating each step to [`http_flow_step`].
+fn analyse_http_flow_script(
+    script: &Script,
+    event: &str,
+    in_states: &[HttpFlowState],
+    out: &mut Vec<IrulesCheckWarning>,
+) -> Vec<HttpFlowState> {
+    let mut states = in_states.to_vec();
+    for stmt in &script.statements {
+        match http_flow_step(stmt, event, &states, out) {
+            // `None` ⇒ the statement terminates every current path (`return`).
+            None => return Vec::new(),
+            Some(next) => states = next,
+        }
+    }
+    states
+}
+
+/// Transfer one structured statement over the response-flow state set, or
+/// `None` when the statement (`return`) terminates the current paths.  The
+/// control-flow arms recurse through [`analyse_http_flow_script`].
+fn http_flow_step(
+    stmt: &Statement,
+    event: &str,
+    states: &[HttpFlowState],
+    out: &mut Vec<IrulesCheckWarning>,
+) -> Option<Vec<HttpFlowState>> {
+    Some(match stmt {
+        Statement::Return { .. } => return None,
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            let mut next = Vec::new();
+            for st in states {
+                let one = [*st];
+                for clause in clauses {
+                    next.extend(analyse_http_flow_script(&clause.body, event, &one, out));
+                }
+                if let Some(eb) = else_body {
+                    next.extend(analyse_http_flow_script(eb, event, &one, out));
+                } else {
+                    // condition-false path keeps the incoming state.
+                    next.push(*st);
+                }
+            }
+            dedupe_flow_states(next)
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            let mut next = Vec::new();
+            for st in states {
+                let one = [*st];
+                // no-match fall-through path.
+                next.push(*st);
+                for arm in arms {
+                    if let Some(body) = &arm.body {
+                        next.extend(analyse_http_flow_script(body, event, &one, out));
+                    }
+                }
+                if let Some(db) = default_body {
+                    next.extend(analyse_http_flow_script(db, event, &one, out));
+                }
+            }
+            dedupe_flow_states(next)
+        }
+        Statement::For { body, .. }
+        | Statement::While { body, .. }
+        | Statement::Foreach { body, .. } => {
+            let mut next = Vec::new();
+            for st in states {
+                let one = [*st];
+                next.push(*st); // zero iterations
+                next.extend(analyse_http_flow_script(body, event, &one, out));
+            }
+            dedupe_flow_states(next)
+        }
+        Statement::Catch { body, .. } => {
+            let mut next = Vec::new();
+            for st in states {
+                next.extend(analyse_http_flow_script(body, event, &[*st], out));
+            }
+            dedupe_flow_states(next)
+        }
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            let mut next = Vec::new();
+            for st in states {
+                let one = [*st];
+                let mut branch = analyse_http_flow_script(body, event, &one, out);
+                for handler in handlers {
+                    branch.extend(analyse_http_flow_script(&handler.body, event, &one, out));
+                }
+                if let Some(fb) = finally_body {
+                    let mut final_out = Vec::new();
+                    for mid in &branch {
+                        final_out.extend(analyse_http_flow_script(fb, event, &[*mid], out));
+                    }
+                    branch = final_out;
+                }
+                if branch.is_empty() {
+                    next.push(*st);
+                } else {
+                    next.extend(branch);
+                }
+            }
+            dedupe_flow_states(next)
+        }
+        // A grouping block (namespace/uplevel body) runs in sequence.
+        Statement::Block { body, .. } => analyse_http_flow_script(body, event, states, out),
+        _ => match http_flow_stmt_command(stmt) {
+            Some((cmd, span)) => dedupe_flow_states(
+                states
+                    .iter()
+                    .map(|st| apply_http_flow_command(*st, cmd, span, event, out))
+                    .collect(),
+            ),
+            None => states.to_vec(),
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1427,6 +1616,91 @@ mod tests {
             !ws.iter().any(|w| w.code == "IRULE1202"),
             "IRULE1202 should not fire outside HTTP events, got {ws:?}",
         );
+    }
+
+    fn http_codes(source: &str) -> Vec<String> {
+        let mut c: Vec<String> = http_warnings(source)
+            .iter()
+            .map(|w| w.code.clone())
+            .collect();
+        c.sort();
+        c
+    }
+
+    #[test]
+    fn irule1202_quiet_on_mutually_exclusive_branches() {
+        // A respond in each arm of an if/else is NOT a double-respond — only
+        // one executes per path.  The path-sensitive walk keeps the branch
+        // states separate (the linear scan wrongly fired IRULE1202 here).
+        assert!(
+            http_codes(
+                "when HTTP_REQUEST { if {$x} { HTTP::respond 200 content a } \
+             else { HTTP::respond 404 content b } }"
+            )
+            .is_empty()
+        );
+        // Same for mutually-exclusive switch arms.
+        assert!(
+            http_codes(
+                "when HTTP_REQUEST { switch $x { a { HTTP::respond 200 content a } \
+             b { HTTP::respond 404 content b } } }"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn irule1201_quiet_when_respond_and_use_are_exclusive() {
+        // respond in one branch, an HTTP command in the *other* — no path
+        // both responds and then uses HTTP, so nothing fires.
+        assert!(
+            http_codes(
+                "when HTTP_REQUEST { if {$x} { HTTP::respond 200 content a } \
+             else { HTTP::header insert Foo bar } }"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn irule1201_fires_through_catch_body() {
+        // A respond inside `catch { … }` still commits the response, so a
+        // following HTTP command is flagged (the linear scan missed this).
+        assert!(http_codes(
+            "when HTTP_REQUEST { catch { HTTP::respond 200 content a }; HTTP::header insert Foo bar }"
+        )
+        .contains(&"IRULE1201".to_string()));
+    }
+
+    #[test]
+    fn irule1201_quiet_on_unregistered_http_subcommand() {
+        // `HTTP::log` is not a registered HTTP:: command, so it must not trip
+        // IRULE1201 (matches the registry-derived namespace set).
+        assert!(
+            !http_codes("when HTTP_REQUEST { HTTP::respond 200 content a; HTTP::log foo }")
+                .contains(&"IRULE1201".to_string())
+        );
+    }
+
+    #[test]
+    fn irule1202_fires_after_loop_respond() {
+        // A respond in a loop body, then a respond after the loop: when the
+        // loop runs at least once, the second respond is a double-respond.
+        assert!(
+            http_codes(
+                "when HTTP_REQUEST { foreach i $list { HTTP::respond 200 content a }; \
+             HTTP::respond 404 content b }"
+            )
+            .contains(&"IRULE1202".to_string())
+        );
+    }
+
+    #[test]
+    fn bare_redirect_commits_response() {
+        // The bare iRules `redirect` (not just `HTTP::redirect`) commits a
+        // response — derived from the registry's ResponseCommit side-effect.
+        assert!(commits_response_commands().contains("redirect"));
+        assert!(commits_response_commands().contains("HTTP::respond"));
     }
 
     // -- IRULE4004 ----------------------------------------------------

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -276,8 +276,77 @@ fn is_event_disable_all(cmd: &str, args: &[String]) -> bool {
     cmd == "event" && args.len() >= 2 && args[0] == "disable" && args[1] == "all"
 }
 
-/// Scan each `::when::*` proc body for IRULE5002 / IRULE5004
-/// shapes.  Linear analysis only — see the module-level note.
+/// One drop / DNS-return flow fact along a path.  Dedup keys on the
+/// `(dropped, dns_returned)` pair only (Python `_DropState` dedup), so the
+/// first unguarded occurrence on any surviving path wins.
+#[derive(Clone, Default)]
+struct DropFlowState {
+    dropped: bool,
+    drop_cmd: String,
+    drop_at: Option<Span>,
+    dns_returned: bool,
+    dns_at: Option<Span>,
+}
+
+/// Deduplicate drop states by `(dropped, dns_returned)`, keeping the first
+/// (Python `_dedupe`).
+fn dedupe_drop_states(states: Vec<DropFlowState>) -> Vec<DropFlowState> {
+    let mut seen: HashSet<(bool, bool)> = HashSet::new();
+    let mut out = Vec::new();
+    for s in states {
+        if seen.insert((s.dropped, s.dns_returned)) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// Leaf transfer for the drop-flow walk: `drop`/`reject`/`discard` set the
+/// dropped fact, `DNS::return` sets the DNS fact, and `event disable all`
+/// clears the dropped fact (it guards the drop).  Mirrors the leaf handling
+/// in Python `_analyse_drop_without_disable._walk`.
+fn drop_flow_leaf(st: &DropFlowState, stmt: &Statement) -> DropFlowState {
+    let Statement::Call {
+        command,
+        args,
+        span,
+        ..
+    } = stmt
+    else {
+        return st.clone();
+    };
+    if is_event_disable_all(command, args) {
+        return DropFlowState {
+            dropped: false,
+            drop_cmd: String::new(),
+            drop_at: None,
+            dns_returned: st.dns_returned,
+            dns_at: st.dns_at,
+        };
+    }
+    if is_drop_command(command) {
+        return DropFlowState {
+            dropped: true,
+            drop_cmd: command.clone(),
+            drop_at: Some(*span),
+            dns_returned: st.dns_returned,
+            dns_at: st.dns_at,
+        };
+    }
+    if is_dns_return(command, args) {
+        return DropFlowState {
+            dns_returned: true,
+            dns_at: Some(*span),
+            ..st.clone()
+        };
+    }
+    st.clone()
+}
+
+/// Path-sensitive IRULE5002 / IRULE5004 — an unguarded `drop`/`reject`/
+/// `discard` (no following `event disable all` / `return`) or a `DNS::return`
+/// without a following `return`, on at least one path through a `::when::*`
+/// body.  Port of Python `irules_flow._analyse_drop_without_disable`.
 #[must_use]
 pub fn find_unguarded_drop_warnings(
     cu: &CompilationUnit,
@@ -287,89 +356,52 @@ pub fn find_unguarded_drop_warnings(
     if !is_irules_dialect(dialect) {
         return out;
     }
-
+    let leaf = |st: &DropFlowState, stmt: &Statement, _out: &mut Vec<IrulesCheckWarning>| {
+        drop_flow_leaf(st, stmt)
+    };
+    // Honour the FE-DATAFLOW complexity guard (#652) but walk the structured
+    // IR body of each analysable `::when::*` event handler.
     for fu in cu.analysable_functions() {
-        // Only `::when::EVENT` proc bodies are iRules event handlers.
         if !fu.name.starts_with("::when::") {
             continue;
         }
-        // Scan spans come from `fu.cfg` (offset-0 on the memoised path);
-        // absolutise to the unit's real position.
-        out.extend(scan_when_body_for_drops(fu).into_iter().map(|mut w| {
-            w.span = fu.abs_span(w.span);
-            w
-        }));
-    }
-    out
-}
-
-fn scan_when_body_for_drops(fu: &crate::compilation_unit::FunctionUnit) -> Vec<IrulesCheckWarning> {
-    let mut out = Vec::new();
-    // Linear scan: track the most-recent drop / DNS::return spans.
-    // A `return` or `event disable all` clears them.
-    let mut pending_drop: Option<(Span, String)> = None;
-    let mut pending_dns: Option<Span> = None;
-
-    for bn in cfg_order(&fu.cfg) {
-        if !fu.sccp.executable_blocks.contains(&bn) {
-            continue;
-        }
-        let Some(block) = fu.cfg.blocks.get(&bn) else {
+        let Some(proc) = cu.ir_module.procedures.get(&fu.name) else {
             continue;
         };
-        for stmt in &block.statements {
-            let Statement::Call {
-                command,
-                args,
-                span,
-                ..
-            } = stmt
-            else {
-                continue;
-            };
-            if is_drop_command(command) {
-                pending_drop = Some((*span, command.clone()));
-                continue;
+        let finals = walk_flow(
+            &proc.body,
+            &[DropFlowState::default()],
+            &mut out,
+            &leaf,
+            &dedupe_drop_states,
+        );
+        for st in finals {
+            if st.dropped
+                && let Some(span) = st.drop_at
+            {
+                out.push(IrulesCheckWarning {
+                    span,
+                    code: "IRULE5002".to_owned(),
+                    message: format!(
+                        "'{}' without 'event disable all' or 'return' — other iRules and later \
+                         priorities in this event will still execute, which may cause TCL errors.",
+                        st.drop_cmd,
+                    ),
+                    replacement: None,
+                });
             }
-            if is_dns_return(command, args) {
-                pending_dns = Some(*span);
-                continue;
+            if st.dns_returned
+                && let Some(span) = st.dns_at
+            {
+                out.push(IrulesCheckWarning {
+                    span,
+                    code: "IRULE5004".to_owned(),
+                    message: "'DNS::return' must be followed by 'return' to stop iRule processing."
+                        .to_owned(),
+                    replacement: None,
+                });
             }
-            if is_event_disable_all(command, args) {
-                // Guards an earlier drop.
-                pending_drop = None;
-            }
-            // `return` is a Terminator on the block, not a Call —
-            // handled below per-block.
         }
-        // After the block's statements: check the terminator.  A
-        // `Return` clears all pending drops; otherwise pending state
-        // carries across.
-        if let Some(term) = &block.terminator
-            && matches!(term, crate::cfg::Terminator::Return { .. })
-        {
-            pending_drop = None;
-            pending_dns = None;
-        }
-    }
-
-    if let Some((span, cmd)) = pending_drop {
-        out.push(IrulesCheckWarning {
-            span,
-            code: "IRULE5002".to_owned(),
-            message: format!(
-                "`{cmd}` without a subsequent `event disable all` or `return` — other iRules continue executing on this connection.",
-            ),
-            replacement: None,
-        });
-    }
-    if let Some(span) = pending_dns {
-        out.push(IrulesCheckWarning {
-            span,
-            code: "IRULE5004".to_owned(),
-            message: "`DNS::return` without a subsequent `return` — iRule processing continues after `DNS::return`.".to_owned(),
-            replacement: None,
-        });
     }
     out
 }
@@ -749,14 +781,21 @@ pub fn find_http_flow_warnings(
         let Some(proc) = cu.ir_module.procedures.get(&fu.name) else {
             continue;
         };
-        analyse_http_flow_script(
+        let leaf = |st: &HttpFlowState, stmt: &Statement, out: &mut Vec<IrulesCheckWarning>| {
+            match http_flow_stmt_command(stmt) {
+                Some((cmd, span)) => apply_http_flow_command(*st, cmd, span, bare_event, out),
+                None => *st,
+            }
+        };
+        walk_flow(
             &proc.body,
-            bare_event,
             &[HttpFlowState {
                 responded: false,
                 respond_at: None,
             }],
             &mut out,
+            &leaf,
+            &dedupe_flow_states,
         );
     }
     out
@@ -829,19 +868,29 @@ fn apply_http_flow_command(
     state
 }
 
-/// Path-sensitive walk of a structured IR script, threading the set of
-/// response-flow states.  Mirrors Python `_analyse_script`: a thin loop over
-/// the structured statements, delegating each step to [`http_flow_step`].
-fn analyse_http_flow_script(
+/// Path-sensitive forward walk of a structured IR script, threading a set of
+/// per-path flow states `S`.  Control-flow statements fan the states into each
+/// branch and merge (`dedupe`) at join points; `return` terminates the current
+/// paths.  Leaf statements are transferred by `leaf` (which may emit warnings
+/// into `out`).  Shared by the IRULE1201/1202 and IRULE5002/5004 analyses —
+/// they differ only in their state type, `leaf`, and `dedupe`.  Mirrors Python
+/// `irules_flow._analyse_script` / `_walk`.
+fn walk_flow<S, L, D>(
     script: &Script,
-    event: &str,
-    in_states: &[HttpFlowState],
+    in_states: &[S],
     out: &mut Vec<IrulesCheckWarning>,
-) -> Vec<HttpFlowState> {
+    leaf: &L,
+    dedupe: &D,
+) -> Vec<S>
+where
+    S: Clone,
+    L: Fn(&S, &Statement, &mut Vec<IrulesCheckWarning>) -> S,
+    D: Fn(Vec<S>) -> Vec<S>,
+{
     let mut states = in_states.to_vec();
     for stmt in &script.statements {
-        match http_flow_step(stmt, event, &states, out) {
-            // `None` ⇒ the statement terminates every current path (`return`).
+        // `None` ⇒ the statement terminates every current path (`return`).
+        match flow_step(stmt, &states, out, leaf, dedupe) {
             None => return Vec::new(),
             Some(next) => states = next,
         }
@@ -849,15 +898,22 @@ fn analyse_http_flow_script(
     states
 }
 
-/// Transfer one structured statement over the response-flow state set, or
-/// `None` when the statement (`return`) terminates the current paths.  The
-/// control-flow arms recurse through [`analyse_http_flow_script`].
-fn http_flow_step(
+/// Transfer one structured statement over the flow-state set, or `None` when
+/// it (`return`) terminates the current paths.  Control-flow arms recurse
+/// through [`walk_flow`]; leaf statements go through `leaf`.
+fn flow_step<S, L, D>(
     stmt: &Statement,
-    event: &str,
-    states: &[HttpFlowState],
+    states: &[S],
     out: &mut Vec<IrulesCheckWarning>,
-) -> Option<Vec<HttpFlowState>> {
+    leaf: &L,
+    dedupe: &D,
+) -> Option<Vec<S>>
+where
+    S: Clone,
+    L: Fn(&S, &Statement, &mut Vec<IrulesCheckWarning>) -> S,
+    D: Fn(Vec<S>) -> Vec<S>,
+{
+    let one = std::slice::from_ref;
     Some(match stmt {
         Statement::Return { .. } => return None,
         Statement::If {
@@ -865,55 +921,52 @@ fn http_flow_step(
         } => {
             let mut next = Vec::new();
             for st in states {
-                let one = [*st];
                 for clause in clauses {
-                    next.extend(analyse_http_flow_script(&clause.body, event, &one, out));
+                    next.extend(walk_flow(&clause.body, one(st), out, leaf, dedupe));
                 }
                 if let Some(eb) = else_body {
-                    next.extend(analyse_http_flow_script(eb, event, &one, out));
+                    next.extend(walk_flow(eb, one(st), out, leaf, dedupe));
                 } else {
                     // condition-false path keeps the incoming state.
-                    next.push(*st);
+                    next.push(st.clone());
                 }
             }
-            dedupe_flow_states(next)
+            dedupe(next)
         }
         Statement::Switch {
             arms, default_body, ..
         } => {
             let mut next = Vec::new();
             for st in states {
-                let one = [*st];
                 // no-match fall-through path.
-                next.push(*st);
+                next.push(st.clone());
                 for arm in arms {
                     if let Some(body) = &arm.body {
-                        next.extend(analyse_http_flow_script(body, event, &one, out));
+                        next.extend(walk_flow(body, one(st), out, leaf, dedupe));
                     }
                 }
                 if let Some(db) = default_body {
-                    next.extend(analyse_http_flow_script(db, event, &one, out));
+                    next.extend(walk_flow(db, one(st), out, leaf, dedupe));
                 }
             }
-            dedupe_flow_states(next)
+            dedupe(next)
         }
         Statement::For { body, .. }
         | Statement::While { body, .. }
         | Statement::Foreach { body, .. } => {
             let mut next = Vec::new();
             for st in states {
-                let one = [*st];
-                next.push(*st); // zero iterations
-                next.extend(analyse_http_flow_script(body, event, &one, out));
+                next.push(st.clone()); // zero iterations
+                next.extend(walk_flow(body, one(st), out, leaf, dedupe));
             }
-            dedupe_flow_states(next)
+            dedupe(next)
         }
         Statement::Catch { body, .. } => {
             let mut next = Vec::new();
             for st in states {
-                next.extend(analyse_http_flow_script(body, event, &[*st], out));
+                next.extend(walk_flow(body, one(st), out, leaf, dedupe));
             }
-            dedupe_flow_states(next)
+            dedupe(next)
         }
         Statement::Try {
             body,
@@ -923,37 +976,34 @@ fn http_flow_step(
         } => {
             let mut next = Vec::new();
             for st in states {
-                let one = [*st];
-                let mut branch = analyse_http_flow_script(body, event, &one, out);
+                let mut branch = walk_flow(body, one(st), out, leaf, dedupe);
                 for handler in handlers {
-                    branch.extend(analyse_http_flow_script(&handler.body, event, &one, out));
+                    branch.extend(walk_flow(&handler.body, one(st), out, leaf, dedupe));
                 }
                 if let Some(fb) = finally_body {
                     let mut final_out = Vec::new();
                     for mid in &branch {
-                        final_out.extend(analyse_http_flow_script(fb, event, &[*mid], out));
+                        final_out.extend(walk_flow(fb, one(mid), out, leaf, dedupe));
                     }
                     branch = final_out;
                 }
                 if branch.is_empty() {
-                    next.push(*st);
+                    next.push(st.clone());
                 } else {
                     next.extend(branch);
                 }
             }
-            dedupe_flow_states(next)
+            dedupe(next)
         }
         // A grouping block (namespace/uplevel body) runs in sequence.
-        Statement::Block { body, .. } => analyse_http_flow_script(body, event, states, out),
-        _ => match http_flow_stmt_command(stmt) {
-            Some((cmd, span)) => dedupe_flow_states(
-                states
-                    .iter()
-                    .map(|st| apply_http_flow_command(*st, cmd, span, event, out))
-                    .collect(),
-            ),
-            None => states.to_vec(),
-        },
+        Statement::Block { body, .. } => walk_flow(body, states, out, leaf, dedupe),
+        _ => {
+            let mut next = Vec::with_capacity(states.len());
+            for st in states {
+                next.push(leaf(st, stmt, out));
+            }
+            dedupe(next)
+        }
     })
 }
 
@@ -1405,6 +1455,59 @@ mod tests {
     fn no_drop_warnings_for_clean_when_body() {
         let ws = drop_warnings("when CLIENT_ACCEPTED { log local0. \"connection open\" }");
         assert!(ws.is_empty(), "got {ws:?}");
+    }
+
+    fn drop_codes(source: &str) -> Vec<String> {
+        let mut c: Vec<String> = drop_warnings(source)
+            .iter()
+            .map(|w| w.code.clone())
+            .collect();
+        c.sort();
+        c
+    }
+
+    #[test]
+    fn irule5002_fires_when_only_one_branch_guarded() {
+        // The `drop` path has no following `event disable all` / `return`, so
+        // it is unguarded — the path-sensitive walk keeps that path's state and
+        // flags it even though the other branch returns.
+        assert!(
+            drop_codes("when CLIENT_ACCEPTED { if {$x} { drop } else { return } }")
+                .contains(&"IRULE5002".to_string())
+        );
+    }
+
+    #[test]
+    fn irule5002_quiet_when_every_branch_guarded() {
+        // Both branches guard their drop with `return`, so no surviving path
+        // is left unguarded.
+        assert!(
+            drop_codes("when CLIENT_ACCEPTED { if {$x} { drop; return } else { reject; return } }")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn irule5002_drop_points_at_the_drop_command() {
+        // The diagnostic span must land on the `drop` word itself (offset 23
+        // in this source), not past it — the structured-IR walk carries the
+        // command's absolute span.
+        let ws = drop_warnings("when CLIENT_ACCEPTED { drop }");
+        let w = ws
+            .iter()
+            .find(|w| w.code == "IRULE5002")
+            .expect("IRULE5002");
+        assert_eq!(w.span.start(), 23, "span should point at `drop`");
+    }
+
+    #[test]
+    fn irule5004_fires_through_catch_body() {
+        // A `DNS::return` inside `catch { … }` still leaves the path needing a
+        // following `return` (the linear scan missed the catch body).
+        assert!(
+            drop_codes("when DNS_REQUEST { catch { DNS::return } }")
+                .contains(&"IRULE5004".to_string())
+        );
     }
 
     // -- IRULE1005 / 1006 / 1007 / 1008 -------------------------------

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -90,7 +90,9 @@ pub(super) fn scan(
             "package" => handlers::handle_package(texts, argv, conditional, &mut ctx.result),
             "source" => handlers::handle_source(texts, argv, &mut ctx.result),
             "interp" => handlers::handle_interp(texts, &mut ctx.result),
-            "oo::class" => handlers::handle_oo_class(texts, argv, ns_prefix, &mut ctx.result),
+            "oo::class" | "::oo::class" => {
+                handlers::handle_oo_class(texts, argv, ns_prefix, &mut ctx.result);
+            }
             "itcl::class" | "::itcl::class" => {
                 handlers::handle_itcl_class(texts, argv, ns_prefix, &mut ctx.result);
             }

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -717,6 +717,23 @@ pub(crate) fn structural_body_indices(
 ) -> HashSet<usize> {
     use tcl_registry::{ArgRole, BodyKind};
 
+    // A foreign-dialect builtin disabled in the active dialect — known in some
+    // dialect but absent from the active registry's `by_name` (the analyser
+    // loads only the active dialect, so an iRules `when` / `log` / `session`
+    // misses under plain Tcl) — is an unknown would-be user command here. Tcl
+    // never substitutes inside its braced arguments, so every braced arg is
+    // opaque *data*, not analysable script/expr; scanning it would read its
+    // `$vars` and emit spurious findings (W210). Skip them. Mirrors Python's
+    // `command_is_disabled_in_active_dialect` body-recursion gate. A command
+    // unknown in *every* dialect (`get` miss *and* not known-in-any) — a real
+    // user proc / TclOO body / recovery artefact — is NOT skipped: its braced
+    // body still recurses, matching Python.
+    if registry.get(command).is_none() && registry.known_in_any_dialect(command) {
+        return (0..args.len())
+            .filter(|&idx| is_braced_arg(tokens, idx))
+            .collect();
+    }
+
     // SYNC2: the registry-declared `body_kind` on each spec /
     // subcommand tells us whether body args run in the caller's
     // frame (`Plain`) or in a separate definition / dispatch context

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -172,6 +172,28 @@ pub fn defs_of(stmt: &Statement) -> Vec<String> {
     defs_of_with_registry(stmt, None)
 }
 
+/// Whether an IR assignment target `name` (as written) is a *dynamic* write
+/// target — its variable name is computed at runtime from a substitution
+/// (`set $p …`, `set ${tok} …`, `set a$b(k) …`).  Such a target is opaque
+/// (no static def) and *reads* the substituted name-bearing variable(s).
+///
+/// Mirrors Python `compiler/var_resolve.py::resolve_place`: a leading `$`
+/// marks a substituted write-target name, and a substitution in the array
+/// *base* (`a$b(k)`) is dynamic too.  A bare array element (`arr($i)`) keeps
+/// its static base `arr` (only the index is dynamic), so it is **not** a
+/// dynamic target here.
+#[must_use]
+pub fn is_dynamic_write_target(name: &str) -> bool {
+    if name.starts_with('$') {
+        return true;
+    }
+    let base = match name.find('(') {
+        Some(i) => &name[..i],
+        None => name,
+    };
+    base.is_empty() || base.contains('$') || base.contains('[')
+}
+
 /// SYNC4: registry-aware `defs_of`.
 ///
 /// Mirrors Python's post-`01326b40` shape — barrier defs route through
@@ -190,6 +212,16 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
         | Statement::AssignExpr { name, .. }
         | Statement::AssignValue { name, .. }
         | Statement::Incr { name, .. } => {
+            // A write-target whose *name* is value-substituted (`set $p …`,
+            // `set ${tok}(k) …`) denotes the variable named by the
+            // substitution's value — a place that cannot be pinned down, so it
+            // is **not** a static def of the name-bearing variable.  Mirrors
+            // Python `compiler/var_resolve.py::resolve_place` returning
+            // `unknown(name_reads=…)` for these targets.  `uses_of` records the
+            // name read separately.
+            if is_dynamic_write_target(name) {
+                return Vec::new();
+            }
             vec![normalise_var_name(name).to_owned()]
         }
         Statement::Call { defs, .. } if !defs.is_empty() => defs.clone(),
@@ -761,27 +793,49 @@ pub fn uses_of(
             vars_found.extend(vars_in_expr(expr));
         }
 
+        // An assignment to a *dynamic* target name (`set $p …`) reads the
+        // name-bearing variable(s) — the genuine read the dead-store / unused
+        // checks need (`defs_of` already withholds the static def).  Mirrors
+        // Python `resolve_place`'s `name_reads`.
+        Statement::AssignConst { name, .. } => {
+            if is_dynamic_write_target(name) {
+                vars_found.extend(scanner.scan_word(name, registry));
+            }
+        }
+
         Statement::AssignExpr { name, expr, .. } => {
             vars_found.extend(vars_in_expr(expr));
-            let norm = normalise_var_name(name);
-            if !norm.is_empty() && vars_found.contains(norm) {
-                reads_own_def.insert(norm.to_owned());
+            if is_dynamic_write_target(name) {
+                vars_found.extend(scanner.scan_word(name, registry));
+            } else {
+                let norm = normalise_var_name(name);
+                if !norm.is_empty() && vars_found.contains(norm) {
+                    reads_own_def.insert(norm.to_owned());
+                }
             }
         }
 
         Statement::AssignValue { name, value, .. } => {
             vars_found.extend(scanner.scan_word(value, registry));
-            let norm = normalise_var_name(name);
-            if !norm.is_empty() && vars_found.contains(norm) {
-                reads_own_def.insert(norm.to_owned());
+            if is_dynamic_write_target(name) {
+                vars_found.extend(scanner.scan_word(name, registry));
+            } else {
+                let norm = normalise_var_name(name);
+                if !norm.is_empty() && vars_found.contains(norm) {
+                    reads_own_def.insert(norm.to_owned());
+                }
             }
         }
 
         Statement::Incr { name, amount, .. } => {
-            let norm = normalise_var_name(name);
-            if !norm.is_empty() {
-                vars_found.insert(norm.to_owned());
-                reads_own_def.insert(norm.to_owned());
+            if is_dynamic_write_target(name) {
+                vars_found.extend(scanner.scan_word(name, registry));
+            } else {
+                let norm = normalise_var_name(name);
+                if !norm.is_empty() {
+                    vars_found.insert(norm.to_owned());
+                    reads_own_def.insert(norm.to_owned());
+                }
             }
             if let Some(amt) = amount {
                 vars_found.extend(scanner.scan_word(amt, registry));
@@ -1534,10 +1588,50 @@ mod tests {
     fn defs_of_assign_const() {
         let stmt = Statement::AssignConst {
             span: Span::new(0, 10),
-            name: "$x".into(),
+            name: "x".into(),
             value: "1".into(),
         };
         assert_eq!(defs_of(&stmt), vec!["x"]);
+    }
+
+    #[test]
+    fn defs_of_dynamic_target_name_has_no_static_def() {
+        // `set $p 1` / `set ${p} 1` write the variable *named by* `$p`, not
+        // `p` itself — an opaque place, so there is no static def.  Matches
+        // Python `resolve_place`'s `unknown(name_reads=…)`.
+        for name in ["$p", "${p}", "a$b", "[gen]"] {
+            let stmt = Statement::AssignValue {
+                span: Span::new(0, 10),
+                name: name.into(),
+                value: "1".into(),
+                value_needs_backsubst: false,
+                tokens: None,
+            };
+            assert!(
+                defs_of(&stmt).is_empty(),
+                "dynamic target {name:?} must not be a static def"
+            );
+        }
+        // A static array element keeps its concrete base as the def.
+        let arr = Statement::AssignValue {
+            span: Span::new(0, 10),
+            name: "arr(idx)".into(),
+            value: "1".into(),
+            value_needs_backsubst: false,
+            tokens: None,
+        };
+        assert_eq!(defs_of(&arr), vec!["arr"]);
+    }
+
+    #[test]
+    fn is_dynamic_write_target_classifies_names() {
+        assert!(is_dynamic_write_target("$p"));
+        assert!(is_dynamic_write_target("${p}"));
+        assert!(is_dynamic_write_target("a$b"));
+        assert!(is_dynamic_write_target("[gen]"));
+        assert!(!is_dynamic_write_target("p"));
+        assert!(!is_dynamic_write_target("arr(idx)"));
+        assert!(!is_dynamic_write_target("ns::var"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -24,6 +24,7 @@
 //! implicitly `Unknown`.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use tcl_registry::{CommandRegistry, TclType, Traits};
 
@@ -111,6 +112,55 @@ fn expr_literal_type(text: &str) -> TypeLattice {
     TypeLattice::of(TclType::Numeric)
 }
 
+/// The enclosing namespace of a (possibly qualified) function name —
+/// `"::ns::Foo"` → `"::ns"`, `"::Foo"` / `"::top"` → `"::"`.  Used to resolve
+/// a relative constructor head against its call-site namespace.
+fn function_namespace(qname: &str) -> String {
+    match qname.rsplit_once("::") {
+        Some((ns, _)) if !ns.is_empty() => ns.to_string(),
+        _ => "::".to_string(),
+    }
+}
+
+/// Type a `TclOO` / snit constructor call (`Foo new` / `Foo create x` /
+/// `Foo %AUTO%` / `Widget .path`) as `OBJECT(class)` when its head resolves
+/// to a known class, else `OVERDEFINED`.  Mirrors the constructor arm of
+/// Python `_return_type_for_command`.  The relative head is resolved as-is,
+/// `::`-prefixed, and against the call-site `namespace` (so `[Foo new]` inside
+/// `namespace eval ns` types as `OBJECT(::ns::Foo)`).
+fn constructor_object_type(
+    command: &str,
+    args: &[&str],
+    known_classes: &HashSet<String>,
+    namespace: &str,
+) -> TypeLattice {
+    let is_ctor_spelling = args
+        .first()
+        .is_some_and(|a| matches!(*a, "new" | "create") || *a == "%AUTO%" || a.starts_with('.'));
+    if is_ctor_spelling && !known_classes.is_empty() {
+        if known_classes.contains(command) {
+            return TypeLattice::object_of(command);
+        }
+        let qualified = if command.starts_with("::") {
+            command.to_string()
+        } else {
+            format!("::{command}")
+        };
+        if known_classes.contains(&qualified) {
+            return TypeLattice::object_of(qualified);
+        }
+        if namespace != "::" && !command.starts_with("::") {
+            let ns_qualified =
+                crate::naming::normalise_qualified_name(&format!("{namespace}::{command}"));
+            if known_classes.contains(&ns_qualified) {
+                return TypeLattice::object_of(ns_qualified);
+            }
+        }
+    }
+    // D4-F6: do not infer `object_of` from the `new` spelling alone.
+    TypeLattice::overdefined()
+}
+
 /// Return the type produced by a known command's return value.
 ///
 /// Checks the command spec's `return_type` field, with subcommand
@@ -122,9 +172,16 @@ pub(crate) fn return_type_for_command(
     registry: &CommandRegistry,
     command: &str,
     args: &[&str],
+    known_classes: &HashSet<String>,
+    namespace: &str,
 ) -> TypeLattice {
     let Some(spec) = registry.get(command) else {
-        return TypeLattice::overdefined();
+        // Not a registered built-in — recognise a TclOO / snit constructor
+        // (`Foo new` / `Foo create x` / `Foo %AUTO%` / `Widget .path`) whose
+        // head names a known class, typing it `OBJECT(::ns::Foo)`.  Mirrors
+        // Python `_return_type_for_command`'s constructor arm + the D4-F6
+        // guard (no `object_of` from the `new` spelling alone).
+        return constructor_object_type(command, args, known_classes, namespace);
     };
 
     // Subcommand commands: check sub's return_type.
@@ -350,6 +407,8 @@ fn evaluate_type_def(
     uses: &HashMap<String, u32>,
     types: &HashMap<ValueKey, TypeLattice>,
     registry: &CommandRegistry,
+    known_classes: &HashSet<String>,
+    namespace: &str,
 ) -> TypeLattice {
     match stmt {
         Statement::AssignConst { value, .. } => literal_type(value),
@@ -390,7 +449,13 @@ fn evaluate_type_def(
                 && let Some((cmd, args)) = parse_command_substitution(stripped)
             {
                 let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-                return return_type_for_command(registry, &cmd, &arg_refs);
+                return return_type_for_command(
+                    registry,
+                    &cmd,
+                    &arg_refs,
+                    known_classes,
+                    namespace,
+                );
             }
             // String interpolation or complex value.
             if value.contains('$') || value.contains('[') {
@@ -408,7 +473,7 @@ fn evaluate_type_def(
             ..
         } if !defs.is_empty() => {
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-            return_type_for_command(registry, command, &arg_refs)
+            return_type_for_command(registry, command, &arg_refs, known_classes, namespace)
         }
 
         // `ExprEval`, `Barrier`, and structured statements that survive as
@@ -424,14 +489,19 @@ fn evaluate_type_def(
 /// Returns a map from `(variable_name, ssa_version)` to inferred
 /// `TypeLattice`. Values absent from the map are implicitly `Unknown`.
 #[must_use]
+#[allow(clippy::implicit_hasher)] // `known_classes` is always the default-hasher set built by the CU.
 pub fn propagate_types(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     sccp: &SccpResult,
     registry: &CommandRegistry,
+    known_classes: &HashSet<String>,
 ) -> HashMap<ValueKey, TypeLattice> {
     let preds = cfg.predecessors();
     let order = crate::sccp::cfg_order(cfg);
+    // Constructor heads written `[Foo new]` inside this function resolve
+    // relative names against the function's own namespace.
+    let namespace = function_namespace(&cfg.name);
 
     let mut types: HashMap<ValueKey, TypeLattice> = HashMap::new();
 
@@ -516,7 +586,14 @@ pub fn propagate_types(
                     } if !defs.is_empty() && is_scope_alias_call(registry, command, args) => {
                         TypeLattice::overdefined()
                     }
-                    _ => evaluate_type_def(stmt, &ssa_stmt.uses, &types, registry),
+                    _ => evaluate_type_def(
+                        stmt,
+                        &ssa_stmt.uses,
+                        &types,
+                        registry,
+                        known_classes,
+                        &namespace,
+                    ),
                 };
                 for (var, &ver) in &ssa_stmt.defs {
                     let key = (var.clone(), ver);
@@ -562,7 +639,9 @@ pub(crate) fn infer_function_return_type(
     sccp: &SccpResult,
     types: &HashMap<ValueKey, TypeLattice>,
     registry: &CommandRegistry,
+    known_classes: &HashSet<String>,
 ) -> TypeLattice {
+    let namespace = function_namespace(&cfg.name);
     // Collapse the versioned type map to a name-keyed map by joining
     // every version of each name — the over-approximation noted above.
     let mut var_types: HashMap<String, TypeLattice> = HashMap::new();
@@ -583,7 +662,7 @@ pub(crate) fn infer_function_return_type(
                 if let Some(expr) = expr {
                     infer_expr_type(expr, &var_types)
                 } else if let Some(value) = value {
-                    infer_return_value_type(value, &var_types, registry)
+                    infer_return_value_type(value, &var_types, registry, known_classes, &namespace)
                 } else {
                     // Bare `return` yields the empty string.
                     TypeLattice::of(TclType::String)
@@ -610,6 +689,8 @@ fn infer_return_value_type(
     value: &str,
     var_types: &HashMap<String, TypeLattice>,
     registry: &CommandRegistry,
+    known_classes: &HashSet<String>,
+    namespace: &str,
 ) -> TypeLattice {
     let stripped = value.trim();
     // Pure variable reference: inherit the source type.
@@ -626,7 +707,7 @@ fn infer_return_value_type(
         && let Some((cmd, args)) = parse_command_substitution(stripped)
     {
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        return return_type_for_command(registry, &cmd, &arg_refs);
+        return return_type_for_command(registry, &cmd, &arg_refs, known_classes, namespace);
     }
     // String interpolation or other complex value.
     if value.contains('$') || value.contains('[') {
@@ -701,7 +782,7 @@ mod tests {
                 exit_versions: HashMap::new(),
             },
         );
-        let types = propagate_types(&f, &ssa, &sccp, &registry());
+        let types = propagate_types(&f, &ssa, &sccp, &registry(), &HashSet::new());
         assert_eq!(
             types.get(&("x".to_owned(), 1)),
             Some(&TypeLattice::of(TclType::Int))
@@ -716,7 +797,14 @@ mod tests {
             amount: None,
             safe_on_uninit: false,
         };
-        let t = evaluate_type_def(&stmt, &HashMap::new(), &HashMap::new(), &registry());
+        let t = evaluate_type_def(
+            &stmt,
+            &HashMap::new(),
+            &HashMap::new(),
+            &registry(),
+            &HashSet::new(),
+            "::",
+        );
         assert_eq!(t, TypeLattice::of(TclType::Int));
     }
 
@@ -806,7 +894,7 @@ mod tests {
         sccp.executable_edges
             .insert(("entry".into(), "exit".into()));
 
-        let types = propagate_types(&cfg, &ssa, &sccp, &registry());
+        let types = propagate_types(&cfg, &ssa, &sccp, &registry(), &HashSet::new());
         // x@1 (entry) should be Int.
         assert_eq!(
             types.get(&("x".to_owned(), 1)),

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -266,6 +266,13 @@ pub struct FnLatticeKey<'db> {
     /// [`tcl_compiler::compilation_unit::decode_param_constants`] in [`function_lattice`].
     #[returns(ref)]
     pub param_constants: Vec<(String, u32, String)>,
+    /// Fully-qualified names of every class in the compilation unit (sorted) —
+    /// a whole-unit fact identical for every procedure, folded into the key so
+    /// adding/removing a class anywhere invalidates each procedure's lattice (a
+    /// new class can change a body's constructor typing).  Threaded into the
+    /// type-propagation pass in [`function_lattice`].
+    #[returns(ref)]
+    pub known_classes: Vec<String>,
 }
 
 /// Memoised offset-0 baseline lattice (CFG → SSA → def-use → SCCP → type →
@@ -292,12 +299,14 @@ pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<
     let cfg = build_cfg_function_with_upvars(key.qname(db), key.body(db), true, upvar, proc_params);
     let param_constants =
         tcl_compiler::compilation_unit::decode_param_constants(key.param_constants(db));
-    Arc::new(FunctionUnit::build_with_param_constants(
+    let known_classes: HashSet<String> = key.known_classes(db).iter().cloned().collect();
+    Arc::new(FunctionUnit::build_with_param_constants_and_classes(
         key.qname(db),
         cfg,
         key.params(db),
         &registry,
         param_constants.as_ref(),
+        &known_classes,
     ))
 }
 
@@ -366,6 +375,7 @@ pub fn memoised_compilation_unit<'db>(
                 context,
                 req.dialect.to_owned(),
                 req.param_constants.to_vec(),
+                req.known_classes.to_vec(),
             );
             lattice_keys.insert(req.qname.to_owned(), key);
             (*function_lattice(db, key)).clone()

--- a/rust/tcl-registry/src/profiles.rs
+++ b/rust/tcl-registry/src/profiles.rs
@@ -173,6 +173,120 @@ impl ProfileRegistry {
     }
 }
 
+/// Profiles attached to a file — Python `compute_file_profiles`.
+///
+/// Combines an explicit `# profiles: …` directive (scanned from the leading
+/// comment block) with the profiles implied by every `when EVENT` handler
+/// present, then expands the transitive profile stack.  Returns the sorted,
+/// uppercased, fully-expanded profile set.
+#[must_use]
+pub fn compute_file_profiles(
+    source: &str,
+    events: &crate::events::EventRegistry,
+    profiles: &ProfileRegistry,
+) -> Vec<String> {
+    let mut seed: HashSet<String> = parse_profile_directive(source);
+    for event in scan_file_events(source) {
+        if let Some(props) = events.get_props(&event) {
+            seed.extend(props.implied_profiles.iter().map(|p| p.to_uppercase()));
+        }
+    }
+    let seed_refs: Vec<&str> = seed.iter().map(String::as_str).collect();
+    let mut expanded: Vec<String> = profiles
+        .expand_profile_stack(&seed_refs)
+        .into_iter()
+        .collect();
+    expanded.sort_unstable();
+    expanded
+}
+
+/// Parse a leading `# profiles: HTTP, CLIENTSSL` directive — Python
+/// `parse_profile_directive`.  Scans at most the first 20 lines and stops at
+/// the first non-comment, non-blank line.  Names are uppercased and split on
+/// commas/whitespace.
+#[must_use]
+pub fn parse_profile_directive(source: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for line in source.split('\n').take(20) {
+        let stripped = line.trim();
+        if stripped.is_empty() {
+            continue;
+        }
+        if !stripped.starts_with('#') {
+            break;
+        }
+        if let Some(payload) = profile_directive_payload(stripped) {
+            for token in payload.split(|c: char| c == ',' || c.is_whitespace()) {
+                if !token.is_empty() {
+                    out.insert(token.to_uppercase());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Match `# profiles? :` (case-insensitive) at the head of an already-trimmed
+/// comment line and return the payload after the colon.  Mirrors the Python
+/// `_PROFILE_DIRECTIVE_RE` (`^\s*#\s*profiles?\s*:\s*(.+)`).
+fn profile_directive_payload(stripped_line: &str) -> Option<&str> {
+    let after_hash = stripped_line.strip_prefix('#')?.trim_start();
+    let lower = after_hash.to_ascii_lowercase();
+    // `profiles?` — the optional trailing `s`; longest match first.
+    let kw_len = if lower.starts_with("profiles") {
+        "profiles".len()
+    } else if lower.starts_with("profile") {
+        "profile".len()
+    } else {
+        return None;
+    };
+    // The keyword is ASCII, so the byte length is the same on `after_hash`.
+    let payload = after_hash[kw_len..].trim_start().strip_prefix(':')?.trim();
+    (!payload.is_empty()).then_some(payload)
+}
+
+/// Event names from every `when EVENT` occurrence — Python `scan_file_events`
+/// (`\bwhen\s+([A-Z_][A-Z0-9_]*)`).  The event name is upper-case-led, so a
+/// lower-cased `when foo` does not match (matching the Python regex's case
+/// sensitivity for the captured group).
+#[must_use]
+pub fn scan_file_events(source: &str) -> HashSet<String> {
+    let bytes = source.as_bytes();
+    let mut out = HashSet::new();
+    for (pos, _) in source.match_indices("when") {
+        // `\b` before `when`: the preceding byte must be a non-word char.
+        if pos > 0 && is_word_byte(bytes[pos - 1]) {
+            continue;
+        }
+        let mut j = pos + "when".len();
+        // `\s+` — at least one whitespace byte after `when`.
+        let ws_start = j;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j == ws_start {
+            continue;
+        }
+        // `[A-Z_]` — event name must start upper-case or underscore.
+        if j >= bytes.len() || !(bytes[j] == b'_' || bytes[j].is_ascii_uppercase()) {
+            continue;
+        }
+        let name_start = j;
+        while j < bytes.len()
+            && (bytes[j] == b'_' || bytes[j].is_ascii_uppercase() || bytes[j].is_ascii_digit())
+        {
+            j += 1;
+        }
+        out.insert(source[name_start..j].to_string());
+    }
+    out
+}
+
+/// Tcl word byte: alphanumeric or underscore (regex `\w`).
+const fn is_word_byte(b: u8) -> bool {
+    b == b'_' || b.is_ascii_alphanumeric()
+}
+
 // Full static data — auto-generated from Python namespace_data.py
 
 // AUTO-GENERATED from Python namespace_data.py — do not edit manually
@@ -1574,6 +1688,65 @@ mod tests {
         let http_ns = reg.get_namespace("HTTP").unwrap();
         assert!(http_ns.profiles.contains(&"HTTP"));
         assert_eq!(http_ns.layer, "application");
+    }
+
+    #[test]
+    fn parse_profile_directive_comma_and_space() {
+        let got = parse_profile_directive("# profiles: HTTP, clientssl serverssl\nset x 1\n");
+        let mut v: Vec<&str> = got.iter().map(String::as_str).collect();
+        v.sort_unstable();
+        assert_eq!(v, ["CLIENTSSL", "HTTP", "SERVERSSL"]);
+    }
+
+    #[test]
+    fn parse_profile_directive_singular_and_stops_at_code() {
+        // Singular `profile:` is accepted; scanning stops at the first
+        // non-comment line, so a later directive is ignored.
+        let got = parse_profile_directive("# profile : TCP\nset x 1\n# profiles: HTTP\n");
+        let v: Vec<&str> = got.iter().map(String::as_str).collect();
+        assert_eq!(v, ["TCP"]);
+    }
+
+    #[test]
+    fn parse_profile_directive_rejects_non_directive_comments() {
+        assert!(parse_profile_directive("# just a comment\nwhen HTTP_REQUEST {}\n").is_empty());
+    }
+
+    #[test]
+    fn scan_file_events_finds_uppercase_events() {
+        let evs = scan_file_events("when HTTP_REQUEST {\n}\nwhen CLIENT_ACCEPTED { }\n");
+        let mut v: Vec<&str> = evs.iter().map(String::as_str).collect();
+        v.sort_unstable();
+        assert_eq!(v, ["CLIENT_ACCEPTED", "HTTP_REQUEST"]);
+    }
+
+    #[test]
+    fn scan_file_events_respects_word_boundary_and_case() {
+        // `awhen` is not a `when` keyword; a lower-cased event name does not
+        // match the upper-case-led capture group.
+        assert!(scan_file_events("awhen HTTP_REQUEST {}").is_empty());
+        assert!(scan_file_events("when http_request {}").is_empty());
+    }
+
+    #[test]
+    fn compute_file_profiles_unions_directive_and_inferred() {
+        let events = crate::events::EventRegistry::build();
+        let profiles = ProfileRegistry::build();
+        // CLIENTSSL_HANDSHAKE infers CLIENTSSL; the directive adds HTTP.  Both
+        // expand transitively to include TCP (the parent of each).
+        let got = compute_file_profiles(
+            "# profiles: HTTP\nwhen CLIENTSSL_HANDSHAKE { }\n",
+            &events,
+            &profiles,
+        );
+        assert!(got.contains(&"HTTP".to_string()));
+        assert!(got.contains(&"CLIENTSSL".to_string()));
+        assert!(
+            got.contains(&"TCP".to_string()),
+            "transitive parent: {got:?}"
+        );
+        // Sorted output.
+        assert!(got.windows(2).all(|w| w[0] <= w[1]));
     }
 
     #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -386,6 +386,57 @@ impl CommandRegistry {
         names
     }
 
+    /// Whether `command` is legal in iRules `event` — the O(1) legality-matrix
+    /// test of Python `CommandLegality.is_legal` (`command_legality`).
+    ///
+    /// A command is legal when the event is known, the command supports the
+    /// iRules dialect, the event is not in the command's `excluded_events`,
+    /// and the command's [`crate::events::EventRequires`] (if any) are
+    /// satisfied by the event's [`crate::events::EventProps`].  An unknown
+    /// event is illegal for every command, matching Python's empty
+    /// valid-command set for events with no props.
+    #[must_use]
+    pub fn is_irules_command_legal_in_event(
+        &self,
+        command: &str,
+        event: &str,
+        events: &crate::events::EventRegistry,
+        profiles: &crate::profiles::ProfileRegistry,
+    ) -> bool {
+        let Some(props) = events.get_props(event) else {
+            return false;
+        };
+        let Some(spec) = self.get_for_dialect(command, DialectSet::IRULES) else {
+            return false;
+        };
+        if spec.excluded_events.contains(&event) {
+            return false;
+        }
+        spec.event_requires
+            .as_ref()
+            .is_none_or(|req| crate::events::event_satisfies(props, req, event, profiles))
+    }
+
+    /// Sorted iRules events where `command` is legal — Python
+    /// `CommandLegality.events_for_command`, the inverse of
+    /// [`Self::valid_irules_commands_for_event`].  Used by the IRULE1001
+    /// "Available in: …" hint.
+    #[must_use]
+    pub fn irules_events_for_command<'a>(
+        &self,
+        command: &str,
+        events: &'a crate::events::EventRegistry,
+        profiles: &crate::profiles::ProfileRegistry,
+    ) -> Vec<&'a str> {
+        let mut names: Vec<&str> = events
+            .all_event_names()
+            .into_iter()
+            .filter(|event| self.is_irules_command_legal_in_event(command, event, events, profiles))
+            .collect();
+        names.sort_unstable();
+        names
+    }
+
     /// Resolve full metadata for an iRules `event` — a faithful port of
     /// `compiler.registry.info.lookup_event_info` (the engine behind
     /// `f5 irule event-info`).
@@ -915,6 +966,54 @@ mod tests {
         let mut reg90 = CommandRegistry::build_default();
         reg90.load_dialect(DialectSet::TCL90);
         assert!(!reg90.leading_zero_is_octal(), "tcl9.0 should be decimal");
+    }
+
+    #[test]
+    fn irules_command_legality_matrix() {
+        use crate::dialects::DialectSet;
+        use crate::events::EventRegistry;
+        use crate::profiles::ProfileRegistry;
+        let mut reg = CommandRegistry::build_default();
+        reg.load_dialect(DialectSet::IRULES);
+        let events = EventRegistry::build();
+        let profiles = ProfileRegistry::build();
+        // HTTP::respond is satisfied in HTTP_REQUEST (HTTP profile implied) but
+        // not in the L4 CLIENT_ACCEPTED event.
+        assert!(reg.is_irules_command_legal_in_event(
+            "HTTP::respond",
+            "HTTP_REQUEST",
+            &events,
+            &profiles
+        ));
+        assert!(!reg.is_irules_command_legal_in_event(
+            "HTTP::respond",
+            "CLIENT_ACCEPTED",
+            &events,
+            &profiles
+        ));
+        // An unknown event is illegal for every command.
+        assert!(!reg.is_irules_command_legal_in_event(
+            "HTTP::respond",
+            "NOT_AN_EVENT",
+            &events,
+            &profiles
+        ));
+        // HA::status is explicitly excluded from RULE_INIT.
+        assert!(!reg.is_irules_command_legal_in_event(
+            "HA::status",
+            "RULE_INIT",
+            &events,
+            &profiles
+        ));
+
+        // The inverse list is sorted and reflects the same matrix.
+        let evs = reg.irules_events_for_command("HTTP::respond", &events, &profiles);
+        assert!(evs.contains(&"HTTP_REQUEST"));
+        assert!(!evs.contains(&"CLIENT_ACCEPTED"));
+        assert!(
+            evs.windows(2).all(|w| w[0] <= w[1]),
+            "events must be sorted"
+        );
     }
 
     #[test]

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -2485,6 +2485,18 @@ class TestTclOOClassExtraction:
         cd = result.all_classes["::Logger"]
         assert cd.metaclass == "oo::singleton"
 
+    def test_fully_qualified_oo_class_metaclass(self):
+        """`::oo::class` (fully-qualified head) is recognised like `oo::class`,
+        and the recorded metaclass is normalised to the bare form."""
+        source = textwrap.dedent("""\
+            ::oo::class create ::Dog {
+                method bark {} { return woof }
+            }
+        """)
+        result = analyse(source)
+        cd = result.all_classes["::Dog"]
+        assert cd.metaclass == "oo::class"
+
     def test_method_body_variables_in_scope(self):
         """Instance variables declared via class-level 'variable' are available in method bodies."""
         source = textwrap.dedent("""\

--- a/tests/test_signature_scan.py
+++ b/tests/test_signature_scan.py
@@ -117,6 +117,13 @@ class TestOOClass:
         )
         assert "::geom::Point" in result.all_classes
 
+    def test_fully_qualified_oo_class_head(self):
+        # `::oo::class` is the fully-qualified spelling of the same global
+        # command, so a class declared with it must be recognised too.
+        result = extract_signatures("::oo::class create ::Shape { method area {} {} }")
+        assert "::Shape" in result.all_classes
+        assert result.all_classes["::Shape"].name == "Shape"
+
 
 class TestItclClass:
     def test_itcl_class(self):


### PR DESCRIPTION
## Summary

This is a major port of iRules-specific analysis and object-oriented programming (OO) support from Python to Rust, completing the **FE-DIAG** track. Key changes:

- **iRules flow analysis** (`irules_checks.rs`): Path-sensitive detection of unguarded `drop`/`reject`/`discard` commands (IRULE5002/5004) and `DNS::return` without `return`. Ported the drop-flow dataflow walk with deduplication and code-action fixes.

- **snit (tcllib) OO support** (`oo.rs`, `commands.rs`): Full support for `snit::type`/`widget`/`widgetadaptor` definitions, modelled as `ClassDef` with method scopes. Snit's implicit instance variables (`self`, `selfns`, `type`, `options`, `win`, `hull`) and type variables are pre-bound, eliminating false W307/unused-variable diagnostics.

- **IRULE1001 command-event validity** (`irules_event_checks.rs`): Validates that commands are legal in their enclosing iRules event, checking dialect support, excluded events, and protocol-stack requirements (flow, client/server-side, transport, profiles). Includes informational hints when profile assumptions are unmet.

- **OO property accessors & initializers** (`oo.rs`): TclOO `property -get`/`-set` accessor bodies now walk in method scope with class variables pre-bound; `initialise`/`initialize` blocks walk in enclosing scope.

- **Code-action fixes**: IRULE2001 (`matchclass` → `class match`), IRULE5002/5004 (drop-flow suggestions), and E001 (missing subcommand) now emit structured `CodeFix` objects with span and description.

- **Helper infrastructure**: 
  - `CodeFix` struct in `irules_checks.rs` for independent-span fixes (insertions, out-of-span replacements)
  - Profile registry caching and file-profile computation (`profiles.rs`)
  - Dynamic write-target detection (`ssa.rs`)
  - Constructor object typing for TclOO/snit (`type_infer.rs`)
  - Orphaned control-flow keyword detection (`commands.rs`)
  - `extract_dollar_var`, `last_return_var_of`, `return_values_of` helpers (`diagnostics.rs`)

- **Fully-qualified OO class heads**: `::oo::class` (in addition to `oo::class`) now recognized as a metaclass command.

- **S110 byte-array corruption spec** (`docs/design/rust/s110-byte-array-corruption-port.md`): Design document for porting the Python shimmer correctness check (PR #656) to Rust.

## Validation

- Existing test suite passes; new snit/OO/iRules tests added to `test_analyser.py` and `test_signature_scan.py`.
- Rust-rewrite status updated: **FE-DIAG** marked complete; remaining bits (per-check config toggles, LSP code-action wiring) are **SRV-LSP** consumer work.

## Compiler/KCS checklist

- [x] No new compiler fact contracts altered; existing IRULE/W307/W308 contracts preserved.
- [x] No new KCS notes required (analysis mirrors Python equivalents already documented).

https://claude.ai/code/session_01M11T4TZEELsJDnSH94qQ6Q