### PR TITLE
Fix catch block handling for return statements and flow analysis

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=abf1df6-dirty
-head=abf1df68b59096318e394f397df50cfcd629db09
-date=2026-06-19T18:03:34Z
-fingerprint=516a9801418db2fb4001639cff6905bea69b2ee6ef846f4485ef7fccb85f5e77
+describe=22f05c1-dirty
+head=22f05c126331d9a5deca5b8724769da02574cf73
+date=2026-06-19T18:12:39Z
+fingerprint=d33a4e2b69a2c24d83a89fe292369a1e5ff23b8891dc462243dad6ab658edcca

--- a/analyser/irules_checks.py
+++ b/analyser/irules_checks.py
@@ -200,8 +200,18 @@ def check_matchclass(
         return []
 
     fixes: tuple[CodeFix, ...] = ()
-    # Auto-fix: matchclass <item> <class> → class match <item> equals <class>
-    if len(args) >= 2 and len(all_tokens) >= 3 and len(arg_tokens) >= 2:
+    # Auto-fix: ``matchclass`` → ``class match`` is a 1:1 rename (same argument
+    # order).  The iRules forms are:
+    #   * 3-arg ``matchclass <item> <operator> <class>`` → preserve all three
+    #     verbatim as ``class match <item> <operator> <class>``.
+    #   * 2-arg shorthand ``matchclass <item> <class>`` → expand with the
+    #     default operator: ``class match <item> equals <class>``.
+    # Any other arity is ambiguous, so we still warn but offer NO quick-fix
+    # rather than corrupt the command.  (Gating on ``>= 2`` and always forcing
+    # ``equals`` mangled the 3-arg form — e.g. ``matchclass [HTTP::uri]
+    # starts_with $::admin_paths`` became ``class match [HTTP::uri] equals
+    # starts_with``, dropping the real class and the real operator.)
+    if len(arg_tokens) in (2, 3) and len(all_tokens) >= 3:
         first_tok = all_tokens[0]
         last_tok = all_tokens[-1]
         # Token ends point at the last *content* character, so a quoted/braced
@@ -221,12 +231,19 @@ def check_matchclass(
         # variable reference (IRULE2001 quick-fix audit, 2026-05).
         # Pull the raw source slice via the arg token offsets so the
         # rewrite preserves variable/command substitutions verbatim.
-        item = _raw_arg_text(source, arg_tokens[0])
-        cls = _raw_arg_text(source, arg_tokens[1])
+        if len(arg_tokens) == 3:
+            item = _raw_arg_text(source, arg_tokens[0])
+            operator = _raw_arg_text(source, arg_tokens[1])
+            cls = _raw_arg_text(source, arg_tokens[2])
+            new_text = f"class match {item} {operator} {cls}"
+        else:
+            item = _raw_arg_text(source, arg_tokens[0])
+            cls = _raw_arg_text(source, arg_tokens[1])
+            new_text = f"class match {item} equals {cls}"
         fixes = (
             CodeFix(
                 range=fix_range,
-                new_text=f"class match {item} equals {cls}",
+                new_text=new_text,
                 description="Replace with 'class match'",
             ),
         )

--- a/compiler/irules_flow.py
+++ b/compiler/irules_flow.py
@@ -516,15 +516,32 @@ def _analyse_when_body(
                 continue
             if isinstance(stmt, IRTry):
                 for st in states:
+                    # A ``return`` inside the ``try`` body or its handlers must
+                    # still run ``finally`` (which always executes in Tcl)
+                    # before the return propagates to any enclosing ``catch``.
+                    # Collect those at-return states in a *local* sink rather
+                    # than handing them straight to ``return_sink`` — otherwise
+                    # ``finally`` is skipped on the returning path.
+                    try_returns: list[_FlowState] = []
                     branch_out: list[_FlowState] = []
-                    branch_out.extend(_analyse_script(stmt.body, [st], return_sink))
+                    branch_out.extend(_analyse_script(stmt.body, [st], try_returns))
                     for handler in stmt.handlers:
-                        branch_out.extend(_analyse_script(handler.body, [st], return_sink))
+                        branch_out.extend(_analyse_script(handler.body, [st], try_returns))
                     if stmt.finally_body is not None:
+                        # ``finally`` runs on every path: normal completions
+                        # continue as normal flow; at-return paths run finally
+                        # and then keep propagating the return to the catch.
                         final_out: list[_FlowState] = []
                         for mid in branch_out:
                             final_out.extend(_analyse_script(stmt.finally_body, [mid], return_sink))
+                        for mid in try_returns:
+                            returned = _analyse_script(stmt.finally_body, [mid], return_sink)
+                            if return_sink is not None:
+                                return_sink.extend(returned)
                         branch_out = final_out
+                    elif return_sink is not None:
+                        # No finally: at-return states propagate to the catch.
+                        return_sink.extend(try_returns)
                     next_states.extend(branch_out or [st])
                 states = _dedupe(next_states)
                 continue
@@ -1005,15 +1022,33 @@ def _analyse_drop_without_disable(
 
             if isinstance(stmt, IRTry):
                 for st in states:
+                    # A ``return`` inside the ``try`` body or its handlers must
+                    # still run ``finally`` (which always executes in Tcl)
+                    # before the return propagates to any enclosing ``catch``.
+                    # Collect those at-return states in a *local* sink rather
+                    # than handing them straight to ``return_sink`` — otherwise
+                    # ``finally`` is skipped on the returning path (e.g. a
+                    # ``finally { event disable all }`` that guards a drop).
+                    try_returns: list[_DropState] = []
                     branch_out: list[_DropState] = []
-                    branch_out.extend(_walk(stmt.body, [st], return_sink))
+                    branch_out.extend(_walk(stmt.body, [st], try_returns))
                     for handler in stmt.handlers:
-                        branch_out.extend(_walk(handler.body, [st], return_sink))
+                        branch_out.extend(_walk(handler.body, [st], try_returns))
                     if stmt.finally_body is not None:
+                        # ``finally`` runs on every path: normal completions
+                        # continue as normal flow; at-return paths run finally
+                        # and then keep propagating the return to the catch.
                         final_out: list[_DropState] = []
                         for mid in branch_out:
                             final_out.extend(_walk(stmt.finally_body, [mid], return_sink))
+                        for mid in try_returns:
+                            returned = _walk(stmt.finally_body, [mid], return_sink)
+                            if return_sink is not None:
+                                return_sink.extend(returned)
                         branch_out = final_out
+                    elif return_sink is not None:
+                        # No finally: at-return states propagate to the catch.
+                        return_sink.extend(try_returns)
                     next_states.extend(branch_out or [st])
                 states = _dedupe(next_states)
                 continue

--- a/compiler/irules_flow.py
+++ b/compiler/irules_flow.py
@@ -430,21 +430,42 @@ def _analyse_when_body(
                     return command, _translate_range(stmt.range)
         return None
 
-    def _analyse_script(script: IRScript, in_states: list[_FlowState]) -> list[_FlowState]:
+    def _analyse_script(
+        script: IRScript,
+        in_states: list[_FlowState],
+        return_sink: list[_FlowState] | None = None,
+    ) -> list[_FlowState]:
+        # Flow option (2): Tcl ``catch`` catches *all* exceptional return codes
+        # from its body (including TCL_RETURN from ``return``), so control
+        # always continues past the ``catch`` — and the state as of the
+        # swallowed ``return`` must survive so post-catch code is analysed with
+        # the correct ``responded`` flag.  ``return_sink`` is the nearest
+        # enclosing ``catch`` body's collection point: when set, an ``IRReturn``
+        # records its accumulated states there (instead of silently discarding
+        # them) and the ``IRCatch`` arm folds them back into the continuing
+        # paths.  ``return_sink`` is threaded through every nested walk so a
+        # ``return`` buried in an ``if``/``switch``/loop/``try`` inside the
+        # catch body still propagates out to the catch.  At proc/event scope
+        # ``return_sink`` is ``None`` and a ``return`` terminates the path as
+        # before.
         states = list(in_states)
         for stmt in script.statements:
             next_states: list[_FlowState] = []
             if isinstance(stmt, IRReturn):
-                # return terminates the current path.
+                # return terminates the current path; if we are inside a catch
+                # body, hand the at-return state to the catch so it continues
+                # past the catch.
+                if return_sink is not None:
+                    return_sink.extend(states)
                 states = []
                 break
             if isinstance(stmt, IRIf):
                 for st in states:
                     branch_out: list[_FlowState] = []
                     for clause in stmt.clauses:
-                        branch_out.extend(_analyse_script(clause.body, [st]))
+                        branch_out.extend(_analyse_script(clause.body, [st], return_sink))
                     if stmt.else_body is not None:
-                        branch_out.extend(_analyse_script(stmt.else_body, [st]))
+                        branch_out.extend(_analyse_script(stmt.else_body, [st], return_sink))
                     else:
                         # condition false path
                         branch_out.append(st)
@@ -456,48 +477,53 @@ def _analyse_when_body(
                     branch_out: list[_FlowState] = [st]
                     for arm in stmt.arms:
                         if arm.body is not None:
-                            branch_out.extend(_analyse_script(arm.body, [st]))
+                            branch_out.extend(_analyse_script(arm.body, [st], return_sink))
                     if stmt.default_body is not None:
-                        branch_out.extend(_analyse_script(stmt.default_body, [st]))
+                        branch_out.extend(_analyse_script(stmt.default_body, [st], return_sink))
                     next_states.extend(branch_out)
                 states = _dedupe(next_states)
                 continue
             if isinstance(stmt, IRFor):
                 for st in states:
-                    iter_states = _analyse_script(stmt.body, [st])
+                    iter_states = _analyse_script(stmt.body, [st], return_sink)
                     next_states.append(st)  # zero iterations
                     next_states.extend(iter_states)
                 states = _dedupe(next_states)
                 continue
             if isinstance(stmt, IRWhile):
                 for st in states:
-                    iter_states = _analyse_script(stmt.body, [st])
+                    iter_states = _analyse_script(stmt.body, [st], return_sink)
                     next_states.append(st)  # zero iterations
                     next_states.extend(iter_states)
                 states = _dedupe(next_states)
                 continue
             if isinstance(stmt, IRForeach):
                 for st in states:
-                    iter_states = _analyse_script(stmt.body, [st])
+                    iter_states = _analyse_script(stmt.body, [st], return_sink)
                     next_states.append(st)
                     next_states.extend(iter_states)
                 states = _dedupe(next_states)
                 continue
             if isinstance(stmt, IRCatch):
                 for st in states:
-                    next_states.extend(_analyse_script(stmt.body, [st]))
+                    # catch swallows TCL_RETURN: both the body's normal exits
+                    # and any at-return states continue past the catch.  Fall
+                    # back to the incoming state if the body yields nothing.
+                    catch_returns: list[_FlowState] = []
+                    body_out = _analyse_script(stmt.body, [st], catch_returns)
+                    next_states.extend(body_out + catch_returns or [st])
                 states = _dedupe(next_states)
                 continue
             if isinstance(stmt, IRTry):
                 for st in states:
                     branch_out: list[_FlowState] = []
-                    branch_out.extend(_analyse_script(stmt.body, [st]))
+                    branch_out.extend(_analyse_script(stmt.body, [st], return_sink))
                     for handler in stmt.handlers:
-                        branch_out.extend(_analyse_script(handler.body, [st]))
+                        branch_out.extend(_analyse_script(handler.body, [st], return_sink))
                     if stmt.finally_body is not None:
                         final_out: list[_FlowState] = []
                         for mid in branch_out:
-                            final_out.extend(_analyse_script(stmt.finally_body, [mid]))
+                            final_out.extend(_analyse_script(stmt.finally_body, [mid], return_sink))
                         branch_out = final_out
                     next_states.extend(branch_out or [st])
                 states = _dedupe(next_states)
@@ -904,14 +930,32 @@ def _analyse_drop_without_disable(
                 out.append(s)
         return out
 
-    def _walk(script: IRScript, in_states: list[_DropState]) -> list[_DropState]:
+    def _walk(
+        script: IRScript,
+        in_states: list[_DropState],
+        return_sink: list[_DropState] | None = None,
+    ) -> list[_DropState]:
+        # Flow option (2): Tcl ``catch`` swallows TCL_RETURN, so a ``return``
+        # inside a catch body does NOT stop iRule processing — control
+        # continues past the catch carrying any pending drop/DNS::return.
+        # ``return_sink`` is the nearest enclosing catch body's collection
+        # point: when set, an ``IRReturn`` records its accumulated states there
+        # (so the unguarded drop/DNS::return keeps firing for post-catch code)
+        # instead of discarding them.  It is threaded through every nested walk
+        # so a ``return`` buried in an ``if``/``switch``/loop/``try`` inside the
+        # catch body still propagates out.  At event scope ``return_sink`` is
+        # ``None`` and a ``return`` genuinely stops processing as before.
         states = list(in_states)
         for stmt in script.statements:
             next_states: list[_DropState] = []
 
             if isinstance(stmt, IRReturn):
-                # return terminates this path — any pending drop/dns_return
-                # is safe because the rule stops here.
+                # return terminates this path — at event scope any pending
+                # drop/dns_return is safe because the rule stops here.  Inside a
+                # catch body the return is swallowed, so hand the at-return
+                # state to the catch to continue past it.
+                if return_sink is not None:
+                    return_sink.extend(states)
                 states = []
                 break
 
@@ -919,9 +963,9 @@ def _analyse_drop_without_disable(
                 for st in states:
                     branch_out: list[_DropState] = []
                     for clause in stmt.clauses:
-                        branch_out.extend(_walk(clause.body, [st]))
+                        branch_out.extend(_walk(clause.body, [st], return_sink))
                     if stmt.else_body is not None:
-                        branch_out.extend(_walk(stmt.else_body, [st]))
+                        branch_out.extend(_walk(stmt.else_body, [st], return_sink))
                     else:
                         branch_out.append(st)
                     next_states.extend(branch_out)
@@ -933,16 +977,16 @@ def _analyse_drop_without_disable(
                     branch_out: list[_DropState] = [st]
                     for arm in stmt.arms:
                         if arm.body is not None:
-                            branch_out.extend(_walk(arm.body, [st]))
+                            branch_out.extend(_walk(arm.body, [st], return_sink))
                     if stmt.default_body is not None:
-                        branch_out.extend(_walk(stmt.default_body, [st]))
+                        branch_out.extend(_walk(stmt.default_body, [st], return_sink))
                     next_states.extend(branch_out)
                 states = _dedupe(next_states)
                 continue
 
             if isinstance(stmt, (IRFor, IRWhile, IRForeach)):
                 for st in states:
-                    iter_states = _walk(stmt.body, [st])
+                    iter_states = _walk(stmt.body, [st], return_sink)
                     next_states.append(st)
                     next_states.extend(iter_states)
                 states = _dedupe(next_states)
@@ -950,20 +994,25 @@ def _analyse_drop_without_disable(
 
             if isinstance(stmt, IRCatch):
                 for st in states:
-                    next_states.extend(_walk(stmt.body, [st]))
+                    # catch swallows TCL_RETURN: both the body's normal exits
+                    # and any at-return states continue past the catch.  Fall
+                    # back to the incoming state if the body yields nothing.
+                    catch_returns: list[_DropState] = []
+                    body_out = _walk(stmt.body, [st], catch_returns)
+                    next_states.extend(body_out + catch_returns or [st])
                 states = _dedupe(next_states)
                 continue
 
             if isinstance(stmt, IRTry):
                 for st in states:
                     branch_out: list[_DropState] = []
-                    branch_out.extend(_walk(stmt.body, [st]))
+                    branch_out.extend(_walk(stmt.body, [st], return_sink))
                     for handler in stmt.handlers:
-                        branch_out.extend(_walk(handler.body, [st]))
+                        branch_out.extend(_walk(handler.body, [st], return_sink))
                     if stmt.finally_body is not None:
                         final_out: list[_DropState] = []
                         for mid in branch_out:
-                            final_out.extend(_walk(stmt.finally_body, [mid]))
+                            final_out.extend(_walk(stmt.finally_body, [mid], return_sink))
                         branch_out = final_out
                     next_states.extend(branch_out or [st])
                 states = _dedupe(next_states)

--- a/tests/test_irules_checks.py
+++ b/tests/test_irules_checks.py
@@ -263,7 +263,31 @@ class TestIrule2001:
         assert len(diags) == 1
         assert len(diags[0].fixes) == 1
         fix = diags[0].fixes[0]
-        assert "class match" in fix.new_text
+        # 2-arg shorthand expands with the default ``equals`` operator.
+        assert fix.new_text == "class match [HTTP::uri] equals my_class"
+
+    def test_matchclass_three_arg_warns(self):
+        src = "when HTTP_REQUEST {\n    matchclass [HTTP::uri] starts_with $::admin_paths\n}"
+        diags = _diag_with_code(src, "IRULE2001")
+        assert len(diags) == 1
+        assert "matchclass" in diags[0].message
+
+    def test_matchclass_three_arg_fix_preserves_operator_and_class(self):
+        # The 3-arg form is ``matchclass <item> <operator> <class>`` and must
+        # not be forced to ``equals`` nor drop the real class.
+        src = "when HTTP_REQUEST {\n    matchclass [HTTP::uri] starts_with $::admin_paths\n}"
+        diags = _diag_with_code(src, "IRULE2001")
+        assert len(diags) == 1
+        assert len(diags[0].fixes) == 1
+        fix = diags[0].fixes[0]
+        assert fix.new_text == "class match [HTTP::uri] starts_with $::admin_paths"
+
+    def test_matchclass_one_arg_warns_without_fix(self):
+        # Ambiguous arity: still warn, but offer no (corrupting) quick-fix.
+        src = "when HTTP_REQUEST {\n    matchclass [HTTP::uri]\n}"
+        diags = _diag_with_code(src, "IRULE2001")
+        assert len(diags) == 1
+        assert len(diags[0].fixes) == 0
 
     def test_no_matchclass_no_warning(self):
         src = "when HTTP_REQUEST {\n    class match [HTTP::uri] equals my_class\n}"
@@ -403,6 +427,46 @@ class TestIrule1201:
             "    HTTP::respond 200\n"
             "    return\n"
             '    HTTP::header insert X-Debug "yes"\n'
+            "}"
+        )
+        warnings = _flow_with_code(src, "IRULE1201")
+        assert len(warnings) == 0
+
+    def test_respond_then_return_inside_catch_warns(self):
+        # Flow option (2): ``catch`` swallows the ``return``, so control
+        # continues past the catch with the response already committed — the
+        # post-catch HTTP::header insert must still be flagged, and the
+        # at-catch-return ``responded`` state must propagate out.
+        src = (
+            "when HTTP_REQUEST {\n"
+            "    catch { HTTP::respond 200 content ok; return }\n"
+            '    HTTP::header insert X-Debug "yes"\n'
+            "}"
+        )
+        warnings = _flow_with_code(src, "IRULE1201")
+        assert len(warnings) == 1
+        assert "HTTP::header" in warnings[0].message
+
+    def test_catch_body_without_return_still_continues(self):
+        # Regression: a catch whose body does not return continues normally,
+        # carrying the responded state to flag the post-catch command.
+        src = (
+            "when HTTP_REQUEST {\n"
+            "    catch { HTTP::respond 200 content ok }\n"
+            '    HTTP::header insert X-Debug "yes"\n'
+            "}"
+        )
+        warnings = _flow_with_code(src, "IRULE1201")
+        assert len(warnings) == 1
+        assert "HTTP::header" in warnings[0].message
+
+    def test_catch_without_respond_no_warning(self):
+        # Regression: a benign catch body must not spuriously flag post-catch
+        # HTTP commands.
+        src = (
+            "when HTTP_REQUEST {\n"
+            "    catch { set x 1; return }\n"
+            "    HTTP::header insert X-Debug 1\n"
             "}"
         )
         warnings = _flow_with_code(src, "IRULE1201")
@@ -1440,6 +1504,29 @@ class TestIrule5002:
         warnings = _flow_with_code(src, "IRULE5002")
         assert len(warnings) == 1
 
+    def test_drop_and_return_inside_catch_still_warns(self):
+        # Flow option (2): the ``return`` is swallowed by ``catch``, so it does
+        # NOT stop iRule processing — the unguarded ``drop`` still leaks past
+        # the catch and must be flagged.
+        src = "when CLIENT_ACCEPTED {\n    catch { drop; return }\n}"
+        warnings = _flow_with_code(src, "IRULE5002")
+        assert len(warnings) == 1
+        assert "drop" in warnings[0].message
+
+    def test_catch_body_without_return_still_warns_drop(self):
+        # Regression: a catch whose body does not return continues normally and
+        # the unguarded drop still leaks out.
+        src = "when CLIENT_ACCEPTED {\n    catch { drop }\n}"
+        warnings = _flow_with_code(src, "IRULE5002")
+        assert len(warnings) == 1
+        assert "drop" in warnings[0].message
+
+    def test_catch_without_drop_no_warning(self):
+        # Regression: a benign catch body must not spuriously warn.
+        src = "when CLIENT_ACCEPTED {\n    catch { set x 1; return }\n}"
+        warnings = _flow_with_code(src, "IRULE5002")
+        assert len(warnings) == 0
+
     def test_has_codefix(self):
         src = "when CLIENT_ACCEPTED {\n    reject\n}"
         warnings = _flow_with_code(src, "IRULE5002")
@@ -1474,6 +1561,14 @@ class TestIrule5004:
         src = "when DNS_REQUEST {\n    if {$x} {\n        DNS::return\n        return\n    }\n}"
         warnings = _flow_with_code(src, "IRULE5004")
         assert len(warnings) == 0
+
+    def test_dns_return_and_return_inside_catch_still_warns(self):
+        # Flow option (2): the ``return`` is swallowed by ``catch`` so it does
+        # not stop processing — the unguarded ``DNS::return`` still leaks out.
+        src = "when DNS_REQUEST {\n    catch { DNS::return; return }\n}"
+        warnings = _flow_with_code(src, "IRULE5004")
+        assert len(warnings) == 1
+        assert "DNS::return" in warnings[0].message
 
     def test_has_codefix(self):
         src = "when DNS_REQUEST {\n    DNS::return\n}"

--- a/tests/test_irules_checks.py
+++ b/tests/test_irules_checks.py
@@ -472,6 +472,23 @@ class TestIrule1201:
         warnings = _flow_with_code(src, "IRULE1201")
         assert len(warnings) == 0
 
+    def test_finally_runs_on_returning_try_body_inside_catch(self):
+        # ``finally`` always runs in Tcl, even when the ``try`` body returns.
+        # The at-return ``responded`` state must reach the finally block so the
+        # HTTP::header insert there is flagged (Codex review, PR #662).
+        src = (
+            "when HTTP_REQUEST {\n"
+            "    catch {\n"
+            "        try { HTTP::respond 200; return } finally {\n"
+            "            HTTP::header insert X-Debug yes\n"
+            "        }\n"
+            "    }\n"
+            "}"
+        )
+        warnings = _flow_with_code(src, "IRULE1201")
+        assert len(warnings) == 1
+        assert "HTTP::header" in warnings[0].message
+
 
 # IRULE1202: Multiple respond/redirect calls
 
@@ -1524,6 +1541,21 @@ class TestIrule5002:
     def test_catch_without_drop_no_warning(self):
         # Regression: a benign catch body must not spuriously warn.
         src = "when CLIENT_ACCEPTED {\n    catch { set x 1; return }\n}"
+        warnings = _flow_with_code(src, "IRULE5002")
+        assert len(warnings) == 0
+
+    def test_finally_guard_on_returning_try_body_inside_catch(self):
+        # ``finally`` always runs in Tcl, even when the ``try`` body returns, so
+        # ``finally { event disable all }`` guards the drop — the at-return drop
+        # state must flow through finally before reaching the catch, otherwise
+        # IRULE5002 false-positives (Codex review, PR #662).
+        src = (
+            "when CLIENT_ACCEPTED {\n"
+            "    catch {\n"
+            "        try { drop; return } finally { event disable all }\n"
+            "    }\n"
+            "}"
+        )
         warnings = _flow_with_code(src, "IRULE5002")
         assert len(warnings) == 0
 


### PR DESCRIPTION
## Summary

This PR fixes the handling of `catch` blocks in iRules flow analysis to correctly implement Tcl semantics where `catch` swallows `TCL_RETURN` exceptions. Previously, `return` statements inside `catch` blocks were treated as path terminators, but they should instead allow control flow to continue past the catch block.

### Key Changes

1. **Flow Analysis (`_analyse_script`)**: Added optional `return_sink` parameter to track return states inside catch blocks. When a `return` is encountered inside a catch body, its state is collected in `return_sink` instead of terminating the path, allowing the catch block to continue analysis with the correct state (e.g., `responded` flag).

2. **Drop/DNS Analysis (`_walk`)**: Applied the same `return_sink` mechanism to the drop and DNS::return flow analysis, ensuring that unguarded `drop` or `DNS::return` statements inside catch blocks are still flagged as warnings since the catch doesn't prevent them from executing.

3. **Catch Block Handling**: Updated `IRCatch` processing in both analysis functions to:
   - Pass a local `catch_returns` list as the `return_sink` to the catch body
   - Combine normal body exits with collected return states
   - Fall back to the incoming state if the body yields nothing

4. **Matchclass Quick-Fix**: Fixed the `matchclass` → `class match` auto-fix to correctly handle both 2-arg and 3-arg forms:
   - 2-arg form: `matchclass <item> <class>` → `class match <item> equals <class>`
   - 3-arg form: `matchclass <item> <operator> <class>` → `class match <item> <operator> <class>` (preserves operator and class)
   - Other arities: warn but don't offer a quick-fix to avoid corruption

### Tests Added

- `test_respond_then_return_inside_catch_warns`: Verifies that `HTTP::respond` followed by `return` inside catch still flags post-catch HTTP commands
- `test_catch_body_without_return_still_continues`: Ensures catch bodies without return continue normally
- `test_catch_without_respond_no_warning`: Regression test for benign catch bodies
- `test_drop_and_return_inside_catch_still_warns`: Verifies unguarded `drop` inside catch is flagged
- `test_catch_body_without_return_still_warns_drop`: Regression test for drop in catch without return
- `test_catch_without_drop_no_warning`: Regression test for benign catch bodies
- `test_dns_return_and_return_inside_catch_still_warns`: Verifies unguarded `DNS::return` inside catch is flagged
- `test_matchclass_three_arg_fix_preserves_operator_and_class`: Tests 3-arg matchclass fix
- `test_matchclass_one_arg_warns_without_fix`: Tests that ambiguous arity doesn't get a corrupting fix

## Validation

- [x] Added comprehensive unit tests covering catch block behavior with return, drop, and DNS::return
- [x] Added tests for matchclass quick-fix with 2-arg and 3-arg forms
- [x] All new tests pass and verify correct flow analysis behavior

https://claude.ai/code/session_016vYpb4kggL4Ry4Edvf1zmK