### PR TITLE
Finish FE-DIAG: matchclass arity + catch-return flow, plus APL/scan/KCS fixes

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,6 +20,10 @@ rules for the KCS/documentation split live in
   emitter, and the runtimes/VM) to fix the right split and interface shapes: the
   two interface families (emitter vs runtime-state), why the bytecode VM is a
   reified-state runtime, and the WASM migration path (WASM engine untouched).
+- [family-b-routing.md](family-b-routing.md) — companion to the above (§4
+  Family B): the Family-B runtime contract as implemented on both runtimes,
+  which command families were lifted to shared cores, the bugs that surfaced,
+  and the boundaries where a command cannot be a shared body.
 - [example-script-walkthroughs.md](example-script-walkthroughs.md) — full
   pipeline traces for progressively complex Tcl scripts.
 - [code-importing-examples.md](code-importing-examples.md) — reference

--- a/docs/design/family-b-routing.md
+++ b/docs/design/family-b-routing.md
@@ -129,7 +129,7 @@ Shared in `tcl-cmd-core`:
 - `path::{tail, dirname, extension, rootname}` — a `/`-based **byte** path core
   (platform-independent), replacing the VM's old `std::path::Path` versions.
 - `mathop::eval` — `::tcl::mathop::*` (every `expr` operator as a command) over
-  the existing [`ExprOps`](tcl_syntax::expr::ExprOps) seam, so **no new value
+  the existing `ExprOps` seam, so **no new value
   seam**: the fold/identity/chain logic is shared, each primitive going through
   each runtime's `ExprOps` (the WASM runtime's bignum tower, the VM's i64+double).
   The VM had no `mathop` at all; it now has the full operator set.
@@ -166,7 +166,7 @@ Shared in `tcl-cmd-core`:
   and `add` (count/unit arithmetic incl. calendar months/years). The civil↔days
   math is Hinnant's branch-free algorithm. The command stays **host-free**: the
   per-runtime adapter reads the current time from its host's
-  [`Clock`](tcl_platform::Clock) capability and passes it in as a `Now` plus a
+  `Clock` capability and passes it in as a `Now` plus a
   `local_offset(ts)` callback, so the core never touches the host (resolving the
   same `ops`+host borrow the `exec` slice hit, via each runtime's owned
   `Rc<dyn Host>`). The `Clock` trait grew `now_micros` + `local_offset_secs`; the

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -969,7 +969,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
-| Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
+| Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108; IRULE2001 3-arg `matchclass` fix + catch-`return` flow (shared with Python, fixed Python-first in #662, now ported). Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
@@ -1241,39 +1241,47 @@ follow-ups** at the end of this section.
   Mirrors Python's `run_all_checks` recursion into nested commands (verified:
   the Python analyser emits the same `IRULE5005 … call helper` for this form).
 
-**Lockstep follow-ups (Python-first).** A review of the port (PR #660) surfaced
-two *shared* correctness bugs — present identically in the canonical Python
-analyser — so, exactly like **S110**, the fix lands on the Python reference
-first and the Rust port follows. Porting the Rust side ahead of Python would
-make it diverge from the very differential oracle this track is verified against,
-so both are deliberately gated on the upstream Python correction:
-- **port pending** **IRULE2001 `matchclass` 3-arg quick-fix** corruption. Both
-  the Rust emitter (`analyser::diagnostics::emit_irule2001_matchclass`) and
-  Python (`analyser/irules_checks.py::check_matchclass`) gate on `args.len() >= 2`
-  and always rewrite to `class match <item> equals <class>` from
-  `arg_tokens[0]`/`arg_tokens[1]`, so the documented 3-arg form
+**Lockstep follow-ups (Python-first) — landed.** A review of the port (PR #660)
+surfaced two *shared* correctness bugs — present identically in the canonical
+Python analyser — so, exactly like **S110**, the fix landed on the Python
+reference first ([PR #662]) and the Rust port follows here. Porting the Rust
+side ahead of Python would have made it diverge from the very differential
+oracle this track is verified against, so both were gated on the upstream Python
+correction. Both are now **ported and verified** (Rust unit tests mirror the
+Python `test_irules_checks.py` cases #662 added):
+- **done** **IRULE2001 `matchclass` 3-arg quick-fix** corruption. The Rust
+  emitter (`analyser::diagnostics::emit_irule2001_matchclass`) previously gated
+  on `args.len() >= 2` and always rewrote to `class match <item> equals <class>`
+  from `arg_tokens[0]`/`arg_tokens[1]`, so the documented 3-arg form
   `matchclass <item> <operator> <class>` (e.g. `matchclass [HTTP::uri]
-  starts_with $::admin_paths`) drops its class and is forced to `equals`
-  (→ `class match [HTTP::uri] equals starts_with`). The fix: offer the
-  default-`equals` rewrite only for *exactly* two args, rewrite the 3-arg form
-  verbatim (`matchclass` → `class match` is a 1:1 rename), and offer no fix for
-  other arities. Diagnostic text is unchanged. Port once the Python correction
-  lands.
-- **port pending** **catch-caught `return` flow**. Tcl `catch` swallows the
-  return code, so execution continues after the `catch` body even when it
-  `return`s — but the shared path-sensitive flow walk drops the post-catch path.
-  This is a limitation of the shared algorithm present in Python too
-  (`compiler/irules_flow.py` `_analyse_script` ~486 / `_walk` ~951 extend with
-  the catch-body walk and lose the path when the body returns; the sibling
-  `IRTry` arms already fall back to `[st]`). The Rust twin
-  (`irules_checks::flow_step`, `Statement::Catch`) faithfully mirrors this. It
-  affects IRULE1201/1202 (HTTP-after-respond) and IRULE5002/5004 (unguarded
-  drop / DNS::return) for code that still runs after the catch. Being resolved
-  Python-first — the semantics decision (minimal incoming-state fallback like
-  `IRTry`, vs. capturing the at-return state so e.g. a `HTTP::respond` before the
-  catch-internal `return` still flags the post-catch command) is made on the
-  reference; Rust `walk_flow`/`flow_step` then mirrors the corrected catch
-  handling.
+  starts_with $::admin_paths`) dropped its class and was forced to `equals`
+  (→ `class match [HTTP::uri] equals starts_with`). It now matches `arg_tokens`
+  by arity: exactly two args → the default-`equals` rewrite; exactly three →
+  the verbatim 1:1 `matchclass` → `class match` rename preserving operator and
+  class; any other arity warns but offers **no** fix. The raw argument slices
+  (and the whole-command fix range) are widened through trailing `]`/`}`/`"`
+  closers via `optimiser::helpers::spans::full_rewrite_span` — the lexer's
+  representative span for a `[cmd …]` word stops before its `]`, so a slice
+  would otherwise round-trip `[HTTP::uri]` as `[HTTP::uri` (mirrors Python's
+  `_raw_arg_text` / `word_end_position`). Diagnostic text unchanged.
+- **done** **catch-caught `return` flow**. Tcl `catch` swallows the return
+  code, so execution continues after the `catch` body even when it `return`s —
+  but the shared path-sensitive flow walk dropped the post-catch path. #662
+  settled the semantics on the Python reference (`compiler/irules_flow.py`
+  `_analyse_script` / `_walk`): the richer option — *capture* the at-return
+  state into the enclosing catch (so e.g. a `HTTP::respond` before the
+  catch-internal `return` still flags the post-catch command), falling back to
+  the incoming state only when the body yields nothing. The Rust twin
+  (`irules_checks::walk_flow`/`flow_step`) now mirrors it via a `return_sink`
+  threaded through every nested control-flow walk: a `return` hands its
+  at-return states to the nearest enclosing `Statement::Catch`'s sink instead
+  of discarding them, and the `Catch` arm folds `body_out + catch_returns`
+  (falling back to `[st]`) into the continuing paths. At event/proc scope the
+  sink is `None` and a `return` terminates the path as before. Fixes
+  IRULE1201/1202 (HTTP-after-respond) and IRULE5002/5004 (unguarded drop /
+  DNS::return) for code that still runs after the catch.
+
+[PR #662]: https://github.com/bitwisecook/tcl-lsp/pull/662
 
 #### FE-DIAG-F5 — F5 dialect diagnostics
 Owns new analyser slices on `tcl-bigip` / `tcl-xc` and the tk dialect.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -622,7 +622,7 @@ impl Analyser {
         self.emit_irule2002_deprecated_command(cmd_name, cmd_tok);
         // IRULE2001: deprecated `matchclass` (f5-irules only).  Python
         // fires this alongside IRULE2002 at the same command-head span.
-        self.emit_irule2001_matchclass(cmd_name, args, arg_tokens, cmd_tok);
+        self.emit_irule2001_matchclass(cmd_name, arg_tokens, cmd_tok);
         // IRULE1003 / 1004 / 2101 / 4001 / 4003 / 5001 / 6001 —
         // analyser-level iRules event-context checks (f5-irules only).
         self.emit_irules_event_checks(cmd_name, args, arg_tokens, cmd_tok);

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -5115,35 +5115,57 @@ matching time on crafted input."
     pub(super) fn emit_irule2001_matchclass(
         &mut self,
         cmd_name: &str,
-        args: &[String],
         arg_tokens: &[tcl_lexer::Token],
         cmd_tok: tcl_lexer::Token,
     ) {
         if self.dialect != "f5-irules" || cmd_name != "matchclass" {
             return;
         }
-        // Auto-fix the `matchclass <item> <class>` form →
-        // `class match <item> equals <class>`, replacing the whole command.
-        // The raw source slices of the argument words preserve `$var` / `[cmd]`
-        // substitutions verbatim (the substituted `args` values would drop
-        // them).  Mirrors the IRULE2001 `CodeFix` in `analyser/irules_checks.py`.
-        let fixes = if args.len() >= 2 && arg_tokens.len() >= 2 {
-            let raw = |t: &tcl_lexer::Token| {
-                self.source[t.span.start() as usize..t.span.end() as usize].to_string()
-            };
-            let item = raw(&arg_tokens[0]);
-            let cls = raw(&arg_tokens[1]);
-            let end = arg_tokens
-                .last()
-                .map_or(cmd_tok.span.end(), |t| t.span.end());
-            vec![super::types::CodeFix {
-                span: tcl_lexer::Span::new(cmd_tok.span.start(), end),
-                new_text: format!("class match {item} equals {cls}"),
-                description: "Replace with 'class match'".to_string(),
-            }]
-        } else {
-            Vec::new()
+        // Auto-fix `matchclass` → `class match`, a 1:1 rename (same argument
+        // order).  The iRules forms are:
+        //   * 3-arg `matchclass <item> <operator> <class>` → preserve all three
+        //     verbatim as `class match <item> <operator> <class>`.
+        //   * 2-arg shorthand `matchclass <item> <class>` → expand with the
+        //     default operator: `class match <item> equals <class>`.
+        // Any other arity is ambiguous, so we still warn but offer NO quick-fix
+        // rather than corrupt the command.  (Gating on `>= 2` and always forcing
+        // `equals` mangled the 3-arg form — e.g. `matchclass [HTTP::uri]
+        // starts_with $::admin_paths` became `class match [HTTP::uri] equals
+        // starts_with`, dropping the real class and operator.)  The raw source
+        // slices preserve `$var` / `[cmd]` substitutions verbatim (the
+        // substituted `args` values would drop them).  The lexer reports
+        // representative spans for `[cmd …]` / `${name}` / `"…"` words without
+        // their closing delimiter, so each slice — and the whole-command fix
+        // range — is widened through trailing closers (mirroring Python's
+        // `_raw_arg_text` / `word_end_position`); otherwise `[HTTP::uri]` would
+        // round-trip as `[HTTP::uri`.  Mirrors the IRULE2001 `CodeFix` in
+        // `analyser/irules_checks.py::check_matchclass`.
+        let word_end = |t: &tcl_lexer::Token| {
+            crate::optimiser::helpers::spans::full_rewrite_span(&self.source, t.span).end()
         };
+        let raw = |t: &tcl_lexer::Token| {
+            self.source[t.span.start() as usize..word_end(t) as usize].to_string()
+        };
+        let new_text = match arg_tokens {
+            [item, cls] => Some(format!("class match {} equals {}", raw(item), raw(cls))),
+            [item, operator, cls] => Some(format!(
+                "class match {} {} {}",
+                raw(item),
+                raw(operator),
+                raw(cls)
+            )),
+            _ => None,
+        };
+        let fixes = new_text
+            .map(|new_text| {
+                let end = arg_tokens.last().map_or(cmd_tok.span.end(), word_end);
+                vec![super::types::CodeFix {
+                    span: tcl_lexer::Span::new(cmd_tok.span.start(), end),
+                    new_text,
+                    description: "Replace with 'class match'".to_string(),
+                }]
+            })
+            .unwrap_or_default();
         self.result.diagnostics.push(super::types::Diagnostic {
             code: "IRULE2001".to_string(),
             span: cmd_tok.span,
@@ -12028,6 +12050,44 @@ mod tests {
         // diagnostic's head span.
         assert_eq!(fix.span.start(), d.span.start());
         assert!(fix.span.end() > d.span.end());
+    }
+
+    #[test]
+    fn irule2001_three_arg_matchclass_fix_preserves_operator_and_class() {
+        // The 3-arg form `matchclass <item> <operator> <class>` is a 1:1 rename
+        // to `class match <item> <operator> <class>` — it must NOT be forced to
+        // `equals` (which dropped the real class).  Mirrors Python
+        // `test_matchclass_three_arg_fix_preserves_operator_and_class`.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "matchclass [HTTP::uri] starts_with $::admin_paths\n",
+            "f5-irules",
+        );
+        let d = r
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "IRULE2001")
+            .expect("IRULE2001");
+        assert_eq!(d.fixes.len(), 1, "expected one fix, got {:?}", d.fixes);
+        assert_eq!(
+            d.fixes[0].new_text,
+            "class match [HTTP::uri] starts_with $::admin_paths"
+        );
+    }
+
+    #[test]
+    fn irule2001_ambiguous_arity_matchclass_warns_without_fix() {
+        // A 1-arg (or any non-2/3-arg) `matchclass` is ambiguous: still warn,
+        // but offer no quick-fix rather than corrupt the command.  Mirrors
+        // Python `test_matchclass_one_arg_warns_without_fix`.
+        let mut a = Analyser::new();
+        let r = a.analyse("matchclass [HTTP::uri]\n", "f5-irules");
+        let d = r
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "IRULE2001")
+            .expect("IRULE2001");
+        assert!(d.fixes.is_empty(), "expected no fix, got {:?}", d.fixes);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/irules_checks.rs
+++ b/rust/tcl-compiler/src/irules_checks.rs
@@ -399,6 +399,7 @@ pub fn find_unguarded_drop_warnings(
             &mut out,
             &leaf,
             &dedupe_drop_states,
+            None,
         );
         for st in finals {
             if st.dropped
@@ -840,6 +841,7 @@ pub fn find_http_flow_warnings(
             &mut out,
             &leaf,
             &dedupe_flow_states,
+            None,
         );
     }
     out
@@ -921,12 +923,26 @@ fn apply_http_flow_command(
 /// into `out`).  Shared by the IRULE1201/1202 and IRULE5002/5004 analyses —
 /// they differ only in their state type, `leaf`, and `dedupe`.  Mirrors Python
 /// `irules_flow._analyse_script` / `_walk`.
+///
+/// `return_sink` is the nearest enclosing `catch` body's collection point.
+/// Tcl `catch` swallows `TCL_RETURN`, so a `return` inside a catch body does
+/// not stop the rule — control continues past the catch carrying the state as
+/// of the swallowed `return`.  When `return_sink` is `Some`, a `return` hands
+/// its at-return states there (so e.g. a committed response, or a pending
+/// drop, survives past the catch) instead of discarding them; the [`Catch`]
+/// arm folds them back into the continuing paths.  It is threaded through every
+/// nested walk so a `return` buried in an `if`/`switch`/loop/`try` inside the
+/// catch body still propagates out.  At event/proc scope it is `None` and a
+/// `return` terminates the path.
+///
+/// [`Catch`]: Statement::Catch
 fn walk_flow<S, L, D>(
     script: &Script,
     in_states: &[S],
     out: &mut Vec<IrulesCheckWarning>,
     leaf: &L,
     dedupe: &D,
+    mut return_sink: Option<&mut Vec<S>>,
 ) -> Vec<S>
 where
     S: Clone,
@@ -936,8 +952,15 @@ where
     let mut states = in_states.to_vec();
     for stmt in &script.statements {
         // `None` ⇒ the statement terminates every current path (`return`).
-        match flow_step(stmt, &states, out, leaf, dedupe) {
-            None => return Vec::new(),
+        match flow_step(stmt, &states, out, leaf, dedupe, return_sink.as_deref_mut()) {
+            None => {
+                // Hand the at-return states to the enclosing catch (if any) so
+                // flow resumes past it, then terminate this script's path.
+                if let Some(sink) = return_sink {
+                    sink.extend(states);
+                }
+                return Vec::new();
+            }
             Some(next) => states = next,
         }
     }
@@ -947,12 +970,17 @@ where
 /// Transfer one structured statement over the flow-state set, or `None` when
 /// it (`return`) terminates the current paths.  Control-flow arms recurse
 /// through [`walk_flow`]; leaf statements go through `leaf`.
+// One cohesive `match` dispatcher over the statement kinds — splitting the arms
+// into separate generic helpers would only scatter the shared `<S, L, D>`
+// signature without aiding readability.
+#[allow(clippy::too_many_lines)]
 fn flow_step<S, L, D>(
     stmt: &Statement,
     states: &[S],
     out: &mut Vec<IrulesCheckWarning>,
     leaf: &L,
     dedupe: &D,
+    mut return_sink: Option<&mut Vec<S>>,
 ) -> Option<Vec<S>>
 where
     S: Clone,
@@ -968,10 +996,24 @@ where
             let mut next = Vec::new();
             for st in states {
                 for clause in clauses {
-                    next.extend(walk_flow(&clause.body, one(st), out, leaf, dedupe));
+                    next.extend(walk_flow(
+                        &clause.body,
+                        one(st),
+                        out,
+                        leaf,
+                        dedupe,
+                        return_sink.as_deref_mut(),
+                    ));
                 }
                 if let Some(eb) = else_body {
-                    next.extend(walk_flow(eb, one(st), out, leaf, dedupe));
+                    next.extend(walk_flow(
+                        eb,
+                        one(st),
+                        out,
+                        leaf,
+                        dedupe,
+                        return_sink.as_deref_mut(),
+                    ));
                 } else {
                     // condition-false path keeps the incoming state.
                     next.push(st.clone());
@@ -988,11 +1030,25 @@ where
                 next.push(st.clone());
                 for arm in arms {
                     if let Some(body) = &arm.body {
-                        next.extend(walk_flow(body, one(st), out, leaf, dedupe));
+                        next.extend(walk_flow(
+                            body,
+                            one(st),
+                            out,
+                            leaf,
+                            dedupe,
+                            return_sink.as_deref_mut(),
+                        ));
                     }
                 }
                 if let Some(db) = default_body {
-                    next.extend(walk_flow(db, one(st), out, leaf, dedupe));
+                    next.extend(walk_flow(
+                        db,
+                        one(st),
+                        out,
+                        leaf,
+                        dedupe,
+                        return_sink.as_deref_mut(),
+                    ));
                 }
             }
             dedupe(next)
@@ -1003,14 +1059,34 @@ where
             let mut next = Vec::new();
             for st in states {
                 next.push(st.clone()); // zero iterations
-                next.extend(walk_flow(body, one(st), out, leaf, dedupe));
+                next.extend(walk_flow(
+                    body,
+                    one(st),
+                    out,
+                    leaf,
+                    dedupe,
+                    return_sink.as_deref_mut(),
+                ));
             }
             dedupe(next)
         }
         Statement::Catch { body, .. } => {
             let mut next = Vec::new();
             for st in states {
-                next.extend(walk_flow(body, one(st), out, leaf, dedupe));
+                // `catch` swallows TCL_RETURN: both the body's normal exits and
+                // any at-return states continue past the catch.  Fall back to
+                // the incoming state if the body yields nothing.  Mirrors
+                // Python `IRCatch`: `next_states.extend(body_out + catch_returns
+                // or [st])`.
+                let mut catch_returns = Vec::new();
+                let mut body_out =
+                    walk_flow(body, one(st), out, leaf, dedupe, Some(&mut catch_returns));
+                body_out.append(&mut catch_returns);
+                if body_out.is_empty() {
+                    next.push(st.clone());
+                } else {
+                    next.extend(body_out);
+                }
             }
             dedupe(next)
         }
@@ -1022,14 +1098,29 @@ where
         } => {
             let mut next = Vec::new();
             for st in states {
-                let mut branch = walk_flow(body, one(st), out, leaf, dedupe);
+                let mut branch =
+                    walk_flow(body, one(st), out, leaf, dedupe, return_sink.as_deref_mut());
                 for handler in handlers {
-                    branch.extend(walk_flow(&handler.body, one(st), out, leaf, dedupe));
+                    branch.extend(walk_flow(
+                        &handler.body,
+                        one(st),
+                        out,
+                        leaf,
+                        dedupe,
+                        return_sink.as_deref_mut(),
+                    ));
                 }
                 if let Some(fb) = finally_body {
                     let mut final_out = Vec::new();
                     for mid in &branch {
-                        final_out.extend(walk_flow(fb, one(mid), out, leaf, dedupe));
+                        final_out.extend(walk_flow(
+                            fb,
+                            one(mid),
+                            out,
+                            leaf,
+                            dedupe,
+                            return_sink.as_deref_mut(),
+                        ));
                     }
                     branch = final_out;
                 }
@@ -1042,7 +1133,7 @@ where
             dedupe(next)
         }
         // A grouping block (namespace/uplevel body) runs in sequence.
-        Statement::Block { body, .. } => walk_flow(body, states, out, leaf, dedupe),
+        Statement::Block { body, .. } => walk_flow(body, states, out, leaf, dedupe, return_sink),
         _ => {
             let mut next = Vec::with_capacity(states.len());
             for st in states {
@@ -1591,6 +1682,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn irule5002_drop_and_return_inside_catch_still_warns() {
+        // `catch` swallows the `return`, so it does NOT stop iRule processing —
+        // the unguarded `drop` still leaks past the catch and must be flagged.
+        // Mirrors Python `test_drop_and_return_inside_catch_still_warns`.
+        let ws = drop_warnings("when CLIENT_ACCEPTED {\n    catch { drop; return }\n}");
+        let hits: Vec<_> = ws.iter().filter(|w| w.code == "IRULE5002").collect();
+        assert_eq!(hits.len(), 1, "expected one IRULE5002, got {ws:?}");
+        assert!(
+            hits[0].message.contains("drop"),
+            "expected the unguarded drop to be flagged, got {:?}",
+            hits[0].message,
+        );
+    }
+
+    #[test]
+    fn irule5002_catch_body_without_return_still_warns_drop() {
+        // A catch whose body does not return continues normally and the
+        // unguarded drop still leaks out.  Mirrors Python
+        // `test_catch_body_without_return_still_warns_drop`.
+        let ws = drop_warnings("when CLIENT_ACCEPTED {\n    catch { drop }\n}");
+        assert_eq!(
+            ws.iter().filter(|w| w.code == "IRULE5002").count(),
+            1,
+            "expected one IRULE5002, got {ws:?}",
+        );
+    }
+
+    #[test]
+    fn irule5002_catch_without_drop_no_warning() {
+        // A benign catch body must not spuriously warn.  Mirrors Python
+        // `test_catch_without_drop_no_warning`.
+        let ws = drop_warnings("when CLIENT_ACCEPTED {\n    catch { set x 1; return }\n}");
+        assert!(
+            !ws.iter().any(|w| w.code == "IRULE5002"),
+            "no IRULE5002 expected for a benign catch, got {ws:?}",
+        );
+    }
+
+    #[test]
+    fn irule5004_dns_return_and_return_inside_catch_still_warns() {
+        // `catch` swallows the `return` so it does not stop processing — the
+        // unguarded `DNS::return` still leaks out.  Mirrors Python
+        // `test_dns_return_and_return_inside_catch_still_warns`.
+        let ws = drop_warnings("when DNS_REQUEST {\n    catch { DNS::return; return }\n}");
+        let hits: Vec<_> = ws.iter().filter(|w| w.code == "IRULE5004").collect();
+        assert_eq!(hits.len(), 1, "expected one IRULE5004, got {ws:?}");
+        assert!(
+            hits[0].message.contains("DNS::return"),
+            "expected the unguarded DNS::return to be flagged, got {:?}",
+            hits[0].message,
+        );
+    }
+
     // -- IRULE1005 / 1006 / 1007 / 1008 -------------------------------
 
     fn flow_warnings(source: &str) -> Vec<IrulesCheckWarning> {
@@ -1786,6 +1931,62 @@ mod tests {
             !ws.iter()
                 .any(|w| w.code == "IRULE1201" || w.code == "IRULE1202"),
             "no IRULE1201/1202 expected, got {ws:?}",
+        );
+    }
+
+    #[test]
+    fn irule1201_respond_then_return_inside_catch_warns() {
+        // `catch` swallows the `return`, so control continues past the catch
+        // with the response already committed — the post-catch HTTP::header
+        // insert must still be flagged, and the at-catch-return `responded`
+        // state must propagate out.  Mirrors Python
+        // `test_respond_then_return_inside_catch_warns`.
+        let ws = http_warnings(
+            "when HTTP_REQUEST {\n\
+            \x20   catch { HTTP::respond 200 content ok; return }\n\
+            \x20   HTTP::header insert X-Debug \"yes\"\n\
+            }",
+        );
+        let hits: Vec<_> = ws.iter().filter(|w| w.code == "IRULE1201").collect();
+        assert_eq!(hits.len(), 1, "expected one IRULE1201, got {ws:?}");
+        assert!(
+            hits[0].message.contains("HTTP::header"),
+            "expected the post-catch HTTP::header to be flagged, got {:?}",
+            hits[0].message,
+        );
+    }
+
+    #[test]
+    fn irule1201_catch_body_without_return_still_continues() {
+        // A catch whose body does not return continues normally, carrying the
+        // responded state to flag the post-catch command.  Mirrors Python
+        // `test_catch_body_without_return_still_continues`.
+        let ws = http_warnings(
+            "when HTTP_REQUEST {\n\
+            \x20   catch { HTTP::respond 200 content ok }\n\
+            \x20   HTTP::header insert X-Debug \"yes\"\n\
+            }",
+        );
+        assert_eq!(
+            ws.iter().filter(|w| w.code == "IRULE1201").count(),
+            1,
+            "expected one IRULE1201, got {ws:?}",
+        );
+    }
+
+    #[test]
+    fn irule1201_catch_without_respond_no_warning() {
+        // A benign catch body must not spuriously flag post-catch HTTP
+        // commands.  Mirrors Python `test_catch_without_respond_no_warning`.
+        let ws = http_warnings(
+            "when HTTP_REQUEST {\n\
+            \x20   catch { set x 1; return }\n\
+            \x20   HTTP::header insert X-Debug 1\n\
+            }",
+        );
+        assert!(
+            !ws.iter().any(|w| w.code == "IRULE1201"),
+            "no IRULE1201 expected for a benign catch, got {ws:?}",
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1077,7 +1077,11 @@ impl Backend {
             "tcl8.5" => "tcl8.5",
             "tcl9.0" => "tcl9.0",
             "tcl-irule" | "f5-irules" => "f5-irules",
-            "tcl-iapp" | "f5-iapps" => "f5-iapps",
+            // `tcl-apl` is the APL (iApp presentation language) editor id — an
+            // iApp sublanguage that Python treats under the iApps extension
+            // set, so it analyses as `f5-iapps` rather than falling through to
+            // the default Tcl dialect.
+            "tcl-iapp" | "f5-iapps" | "tcl-apl" => "f5-iapps",
             "tcl-expect" | "expect" => "expect",
             "tcl-synopsys" | "synopsys-eda-tcl" => "synopsys-eda-tcl",
             "tcl-cadence" | "cadence-eda-tcl" => "cadence-eda-tcl",
@@ -5307,12 +5311,29 @@ fn is_skipped_scan_dir(path: &Path) -> bool {
     }
 }
 
-/// `true` when `path` has a Tcl source extension the analyser can
-/// usefully index (`.tcl` scripts and `.tm` Tcl modules).
+/// `true` when `path` has a Tcl-family source extension the analyser
+/// can usefully index.  Mirrors the Python scanner's `TCL_EXTENSIONS`
+/// (`server/workspace/scanner.py`) so the startup workspace scan picks
+/// up the same unopened files — otherwise cross-document definition /
+/// references / rename / call-hierarchy / workspace-symbols miss
+/// definitions that live in `.itcl`/`.irule`/`.iapp`/… files until they
+/// are opened.
 fn is_tcl_source(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|e| e.to_str()),
-        Some("tcl" | "tm")
+        Some(
+            "tcl"
+                | "tk"
+                | "itcl"
+                | "tm"
+                | "irul"
+                | "irule"
+                | "iapp"
+                | "iappimpl"
+                | "impl"
+                | "exp"
+                | "apl"
+        )
     )
 }
 
@@ -6143,6 +6164,11 @@ mod tests {
         );
         assert_eq!(
             Backend::dialect_from_language_id("tcl-iapp"),
+            Some("f5-iapps"),
+        );
+        // APL presentation files are an iApp sublanguage → f5-iapps.
+        assert_eq!(
+            Backend::dialect_from_language_id("tcl-apl"),
             Some("f5-iapps"),
         );
         assert_eq!(Backend::dialect_from_language_id("tcl"), Some("tcl8.6"));
@@ -7131,9 +7157,16 @@ mod tests {
     }
 
     #[test]
-    fn is_tcl_source_matches_tcl_and_tm_only() {
-        assert!(is_tcl_source(Path::new("/a/b.tcl")));
-        assert!(is_tcl_source(Path::new("/a/b.tm")));
+    fn is_tcl_source_matches_the_full_tcl_family_extension_set() {
+        // Mirrors Python's `TCL_EXTENSIONS` (server/workspace/scanner.py).
+        for ext in [
+            "tcl", "tk", "itcl", "tm", "irul", "irule", "iapp", "iappimpl", "impl", "exp", "apl",
+        ] {
+            assert!(
+                is_tcl_source(Path::new(&format!("/a/b.{ext}"))),
+                "expected .{ext} to be a Tcl-family source",
+            );
+        }
         assert!(!is_tcl_source(Path::new("/a/b.txt")));
         assert!(!is_tcl_source(Path::new("/a/b")));
     }


### PR DESCRIPTION
Completes the remaining **FE-DIAG** work from `docs/rust-rewrite.md` and clears
two review findings, on top of the `rust` branch. Three focused commits:

### 1. FE-DIAG lockstep follow-ups (Python-first, now ported)
The two "Lockstep follow-ups" — the last open FE-DIAG items — are ported to the
Rust analyser. The Python reference fixes landed in **#662** (now on `main`), so
the differential oracle and the Rust port agree.

- **IRULE2001 `matchclass` quick-fix arity.** `emit_irule2001_matchclass` now
  matches on argument arity instead of gating on `>= 2` and always forcing
  `equals`:
  - 2 args — `matchclass A B` → `class match A equals B`
  - 3 args — `matchclass A op B` → `class match A op B` (verbatim 1:1
    `matchclass` → `class match` rename, preserving the operator and class).
    Previously `matchclass [HTTP::uri] starts_with $::admin_paths` was corrupted
    to `class match [HTTP::uri] equals starts_with`.
  - any other arity — warn with no fix.

  Raw argument slices and the fix range are widened through trailing `]`/`}`/`"`
  closers via `full_rewrite_span` (mirrors Python `_raw_arg_text` /
  `word_end_position`), so `[HTTP::uri]` no longer round-trips as `[HTTP::uri`.
- **catch-caught `return` flow.** `walk_flow`/`flow_step` thread a `return_sink`:
  Tcl `catch` swallows `TCL_RETURN`, so a `return` inside a catch body hands its
  at-return state to the enclosing `Statement::Catch` instead of terminating the
  path; the catch folds `body_out + catch_returns` (falling back to the incoming
  state) into the continuing paths. Fixes IRULE1201/1202 and IRULE5002/5004 for
  code that still runs past the catch.

### 2. APL dialect mapping + full Tcl-family workspace scan (review findings)
- `dialect_from_language_id` now maps the `tcl-apl` editor language id to
  `f5-iapps` (APL presentation files were analysed as plain Tcl).
- `is_tcl_source` mirrors Python's `TCL_EXTENSIONS` (`.itcl` / `.irul` /
  `.irule` / `.iapp` / `.iappimpl` / `.impl` / `.exp` / `.apl` / `.tk` / …) so
  the startup workspace scan no longer misses definitions in unopened
  non-`.tcl`/`.tm` files.

### 3. KCS doc-link fix for `family-b-routing.md`
Two rustdoc-style symbol refs were written as markdown links (reported as broken
local-file links); rendered as inline code. Added the doc to the design index.

All changes verified by Rust unit tests mirroring the Python cases, clippy-clean,
and `rust-rewrite.md` marks FE-DIAG complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)