### PR TITLE
Port S110 byte-array corruption shimmer to Rust (FE-TYPESHIM)

### DIFF
--- a/compiler/parsing/lexer.py
+++ b/compiler/parsing/lexer.py
@@ -132,6 +132,66 @@ def _convert_rust_token(tok: object) -> Token:
     )
 
 
+def _byte_to_position_map(
+    text: str,
+    byte_offsets: set[int],
+    base_offset: int,
+    base_line: int,
+    base_col: int,
+) -> dict[int, SourcePosition]:
+    """Map UTF-8 *byte* offsets in *text* to code-point :class:`SourcePosition`s.
+
+    The Rust lexer reports positions as byte offsets / byte columns, but the
+    pure-Python lexer — and every consumer downstream (parser ranges, hovers,
+    code actions, diagnostics) — indexes by Python string *code point*.  For
+    sources containing non-ASCII text before a token those two conventions
+    diverge, shifting later ranges.  This walks *text* once, mapping each
+    requested byte offset (always a UTF-8 character boundary, since the Rust
+    spans are) to the code-point ``(line, character, offset)`` the Python lexer
+    would produce, applying the sub-lexing bases exactly as
+    :meth:`TclLexer._pos_at` does.
+    """
+
+    def make(line_idx: int, col: int, char_off: int) -> SourcePosition:
+        return SourcePosition(
+            line=base_line + line_idx,
+            character=(base_col + col) if line_idx == 0 else col,
+            offset=char_off + base_offset,
+        )
+
+    result: dict[int, SourcePosition] = {}
+    if 0 in byte_offsets:
+        result[0] = make(0, 0, 0)
+    byte_pos = 0
+    char_off = 0
+    line_idx = 0
+    col = 0
+    for ch in text:
+        byte_pos += len(ch.encode("utf-8"))
+        if ch == "\n":
+            line_idx += 1
+            col = 0
+        else:
+            col += 1
+        char_off += 1
+        if byte_pos in byte_offsets:
+            result[byte_pos] = make(line_idx, col, char_off)
+    return result
+
+
+def _convert_rust_token_remapped(tok: object, pos_map: dict[int, SourcePosition]) -> Token:
+    """Like :func:`_convert_rust_token`, but resolve the start/end positions
+    from *pos_map* (byte offset → code-point :class:`SourcePosition`) so a
+    non-ASCII source's token ranges match the pure-Python lexer."""
+    return Token(
+        type=_TOKEN_TYPE_BY_NAME[tok.type.name],  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        text=tok.text,  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        start=pos_map[tok.start.offset],  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        end=pos_map[tok.end.offset],  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        in_quote=tok.in_quote,  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    )
+
+
 class TclParseError(Exception):
     """Raised for Tcl syntax errors detected during lexing."""
 
@@ -1247,23 +1307,37 @@ class TclLexer:
         The Python fallback is used otherwise.
         """
         if _rust_lexer_tokenise_cfg is not None and not self._has_virtuals and self.pos == 0:
+            # The Rust lexer reports positions as UTF-8 *byte* offsets/columns,
+            # while the Python lexer indexes by code point.  For pure-ASCII
+            # sources the two coincide, so we let the Rust side apply the
+            # sub-lexing bases and copy positions verbatim (the fast path).  For
+            # a source with any non-ASCII character the conventions diverge, so
+            # we ask the Rust lexer for *zero-based* byte positions and remap
+            # them to code-point positions (with the bases re-applied) below.
+            ascii_only = self.text.isascii()
+            if ascii_only:
+                base_offset, base_line, base_col = (
+                    self._base_offset,
+                    self._base_line,
+                    self._base_col,
+                )
+            else:
+                base_offset = base_line = base_col = 0
             try:
                 tokens, warnings = _rust_lexer_tokenise_cfg(
                     self.text,
                     _expand_syntax_active(),
                     _irules_brace_separator_active(),
                     _strict_quoting(),
-                    self._base_offset,
-                    self._base_line,
-                    self._base_col,
+                    base_offset,
+                    base_line,
+                    base_col,
                 )
             except ValueError as exc:
                 # The Rust lexer raises ValueError for strict-mode syntax
                 # errors; re-raise as TclParseError so callers that catch
                 # TclParseError still work.
                 raise TclParseError(str(exc)) from exc
-            if warnings:
-                self.warnings.extend(warnings)
             # Finalise cursor state so a subsequent ``get_token()`` returns
             # ``None`` rather than re-reading from offset 0.
             self.pos = self._len
@@ -1274,7 +1348,28 @@ class TclLexer:
             # ``shared.tokens.TokenType``, so leaving them as-is would make
             # every ``tok.type is TokenType.X`` check in the parser silently
             # fail wherever the wheel is installed (see _TOKEN_TYPE_BY_NAME).
-            return [_convert_rust_token(tok) for tok in tokens]
+            if ascii_only:
+                if warnings:
+                    self.warnings.extend(warnings)
+                return [_convert_rust_token(tok) for tok in tokens]
+            # Non-ASCII: translate every byte position to the code-point
+            # convention the rest of the pipeline expects.
+            byte_offsets: set[int] = set()
+            for tok in tokens:
+                byte_offsets.add(tok.start.offset)
+                byte_offsets.add(tok.end.offset)
+            for pos, _msg in warnings:
+                byte_offsets.add(pos.offset)
+            pos_map = _byte_to_position_map(
+                self.text,
+                byte_offsets,
+                self._base_offset,
+                self._base_line,
+                self._base_col,
+            )
+            if warnings:
+                self.warnings.extend((pos_map[pos.offset], msg) for pos, msg in warnings)
+            return [_convert_rust_token_remapped(tok, pos_map) for tok in tokens]
         tokens: list[Token] = []
         while True:
             tok = self.get_token()

--- a/docs/design/compiler/byte-array-corruption.md
+++ b/docs/design/compiler/byte-array-corruption.md
@@ -1,0 +1,164 @@
+# Byte-array corruption detection (S110)
+
+`S110` flags binary data that is forced through character-string semantics in a
+way that corrupts it. It is a **correctness** check, distinct from the
+`S100`/`S101`/`S102` [shimmer](../../GLOSSARY.md#shimmer) *performance* family.
+This note records (a) the damage taxonomy that drives the check and (b) why
+byte-array provenance is tracked by a dedicated forward dataflow rather than in
+the type lattice.
+
+## Why a byte array gets damaged
+
+A Tcl value is logically a string, but caches one internal representation
+(intrep) at a time. A byte array stores raw bytes; a character string stores
+Unicode code points. When a byte array's string representation is generated,
+each byte `0x00`–`0xFF` becomes the latin-1 character `U+0000`–`U+00FF`. Two
+things can then go wrong:
+
+1. **Intrinsic corruption** — the operation mutates the bytes in its own
+   result, with no write-back required. Case folding maps a byte to a
+   different code point (`0xC3` → `0xE3`) or out of byte range entirely
+   (`0xFF` → `U+0178`); `encoding convertto` re-encodes the latin-1 characters
+   as UTF-8 (double-encoding). The damage is unconditional.
+2. **Round-trip corruption** — the operation preserves the bytes as latin-1
+   characters, so the *result* is byte-clean, but it is now a **string**.
+   Writing that string to a byte sink (`<proto>::payload replace`, or any
+   UTF-8 channel) re-encodes every byte `≥ 0x80`. The damage lands at the
+   write-back.
+
+### tclsh ground truth
+
+Applying each operation to the pure high-byte array `80 c3 ff fe` (no ASCII
+letters, so any change to a preserved byte is real corruption), then
+re-binarifying the result — identical on Tcl 8.6.14 and 9.0.3:
+
+| Operation | Result bytes | Category |
+|---|---|---|
+| `string toupper` | `80 c3 78 de` | **intrinsic** (case fold) |
+| `string tolower` | `80 e3 ff fe` | **intrinsic** (case fold) |
+| `string totitle` | `80 e3 ff fe` | **intrinsic** (case fold) |
+| `encoding convertto utf-8` | `c2 80 c3 83 c3 bf c3 be` | **intrinsic** (re-encode) |
+| `string reverse` / `range` / `map` / `trim` | `80 c3 ff fe` | round-trip |
+| `format %s` / `regsub` / `subst` | `80 c3 ff fe` | round-trip |
+| interpolation `"$x"` / `append` | `80 c3 ff fe` | round-trip |
+
+On Tcl 9 the round-trip back through `binary scan` of a case-folded value
+*raises* (`expected byte sequence but character … was 'Ŷ' (U+000178)`); on
+Tcl 8 it silently truncates. Either way the byte array is gone.
+
+This is the canonical iRules payload-rewrite bug
+([F5 KB K22406348](https://my.f5.com/manage/s/article/K22406348)); the
+`HTTP::payload replace` man page documents the same hazard and the
+`binary scan … c* throwaway` fix.
+
+## How the check maps to the taxonomy
+
+`compiler/shimmer.py::_find_byte_array_corruption` runs a small forward
+dataflow over the SSA graph, tracking a two-state provenance per value:
+
+- **BINARY** — currently a byte array (safe at a byte sink). Sources:
+  `binary format` / `binary decode` / `encoding convertto` return types (read
+  from the registry, the same metadata the type lattice uses), and `*::payload`
+  getters (registry flag `byte_array_payload`, dialect-gated).
+- **DAMAGED** — a binary-sourced value since coerced to a character string.
+
+It emits S110 in two places, matching the two damage mechanisms:
+
+- **Intrinsic** (`_CASE_FOLD_STRING_SUBS` and `encoding convertto`): warn at the
+  transform — the bytes are already corrupt.
+- **Round-trip** (`_STRING_VALUE_SUBS`, `_STRING_COERCING_COMMANDS`,
+  interpolation, `append`, `expr`): mark the value DAMAGED and warn only when it
+  reaches a `<proto>::payload replace` sink. A `binary scan $v …` between the
+  coercion and the sink re-binarifies `v` *in place* and clears DAMAGED (the
+  documented fix). `binary format … $v` does **not** clear it — it returns a new
+  value and does not mutate `$v`; only the assigned form `set x [binary format
+  …]` re-binarifies (via the byte-array return type). The intrinsic checks also
+  apply to the **inline sink form** — `<proto>::payload replace …
+  [encoding convertto utf-8 $payload]` is DAMAGED, because `convertto`'s
+  byte-array return type must not mask that it is the corrupting op.
+
+The `<proto>::payload replace` sink's `<data>` operand is **not** at a fixed
+argument index — `replace OFFSET LENGTH DATA` (TCP/HTTP/…, data at index 3),
+`replace DATA …` (MQTT/DIAMETER, index 1), and GTP's `replace ('-message'
+MESSAGE)? OFFSET COUNT NEW_VALUE` (index 3, shifted to 5 by the optional flag)
+all differ. The data position is therefore declared per command in the registry
+(`BytePayloadSpec` on `CommandSpec.byte_array_payload`) and read back via
+`byte_array_payload_layouts()`, so the pass stays correct for new payload
+commands without editing `shimmer.py`.
+
+## Why provenance, not the type lattice
+
+The type lattice already has `TclType.BYTEARRAY` and a `SHIMMERED(from, to)`
+state, so an obvious question is whether byte-corruption should be modelled
+there. It should not.
+
+1. **Type vs provenance are different questions.** The lattice answers *what
+   intrep does this value have at this point* — a per-program-point property
+   computed by join. Corruption is a *flow* property: did a value travel from a
+   binary source, through a string coercion, to a byte sink. `[string range
+   $ba 0 5]` **is** a `STRING` (the type is unambiguous); only its *origin* is
+   binary. The lattice correctly types it `STRING` and necessarily drops the
+   origin.
+2. **`SHIMMERED` is load-bearing and means something else.** `SHIMMERED(A, B)`
+   means a value's intrep is *ambiguous* (A on one path, B on another, or
+   oscillating across a loop) and it drives the `S100`/`S101`/`S102`
+   performance warnings. A byte-derived string is not ambiguous — it is
+   definitively a string. Re-tagging it `SHIMMERED(BYTEARRAY, STRING)` would be
+   semantically wrong and would fire spurious *performance* shimmer warnings on
+   every binary→string operation.
+3. **The damage condition needs reachability, not a join.** Round-trip
+   corruption is conditional on reaching a byte sink without an intervening
+   re-binarification. A join lattice cannot express "this value reaches
+   `payload replace` un-re-binarified"; a forward taint-style dataflow can. The
+   codebase already separates [taint](../../GLOSSARY.md#taint-analysis) from
+   type inference for exactly this reason, and byte-provenance is a specialised
+   taint ("binary-origin data").
+4. **The fix is a side-effect, not a redefinition.** `binary scan $v c* -`
+   re-binarifies `v` *in place* — it creates no new SSA version. An
+   SSA-versioned type lattice cannot model an intrep reset that has no def; the
+   provenance pass tracks it as a flow side-effect.
+
+The pass therefore *consumes* the lattice's binary-source signal (BYTEARRAY
+return types) but keeps the DAMAGED / round-trip reasoning in its own dataflow.
+
+### Why `*::payload` getters are not typed BYTEARRAY in the lattice
+
+The payload getters are typed OVERDEFINED by the lattice, not BYTEARRAY,
+because (a) a getter form that coexists with subcommands (`TCP::payload` vs
+`TCP::payload length`) has no representable return type in the current
+`TYPE_HINTS` model, and (b) typing every payload value BYTEARRAY globally risks
+new `S100`/`S101` performance-shimmer false positives with an uncertain blast
+radius. The S110 pass recognises payload sources from the registry flag
+instead, which keeps the change contained.
+
+## Dialect scoping
+
+`*::payload` source/sink recognition is iRules-specific. The command registry
+is process-global, so once any iRules document loads the f5-irules pack the
+payload commands stay registered for the rest of the session. The pass gates
+payload recognition on the **active** dialect (`REGISTRY.get(cmd, active_dialect())`),
+so a plain-Tcl document that merely names a `*::payload` command never trips
+S110. The dialect-agnostic binary sources (`binary format`, `encoding
+convertto`) stay enabled everywhere.
+
+## Pointers
+
+Python reference implementation:
+
+- `compiler/shimmer.py` — `_find_byte_array_corruption`, `_payload_replace_data_index`, and helpers
+- `compiler/registry/runtime.py` — `byte_array_payload_commands`, `byte_array_payload_layouts`
+- `compiler/registry/models.py` — `BytePayloadSpec`, `CommandSpec.byte_array_payload`
+- `dialects/f5/irules/*__payload.py` — `byte_array_payload=True` (default index-3 layout) or `=BytePayloadSpec(...)`
+
+Rust port (see [`../rust/s110-byte-array-corruption-port.md`](../rust/s110-byte-array-corruption-port.md)):
+
+- `rust/tcl-compiler/src/shimmer/byte_array.rs` — `find_byte_array_warnings`, the `ByteProv` lattice, `join_prov`, `payload_replace_data_index`, and the three transfer functions
+- `rust/tcl-registry/src/spec.rs` — `BytePayloadSpec`, `CommandSpec::byte_array_payload`
+- `rust/tcl-registry/src/registry.rs` — `CommandRegistry::byte_array_payload_layouts`
+- `rust/tcl-registry/src/commands/irules/*__payload.rs` — `byte_array_payload: Some(BytePayloadSpec…)`
+- `rust/tcl-compiler/src/compiler_checks.rs` — `push_shimmer_checks` lowering (dialect-gated)
+
+Shared:
+
+- `docs/design/compiler/FP.md` — FP-SH-09 (intrinsic), FP-SH-10 (round-trip)
+- `docs/kcs/features/kcs-feature-byte-array-corruption.md` — user-facing note

--- a/docs/design/rust/s110-byte-array-corruption-port.md
+++ b/docs/design/rust/s110-byte-array-corruption-port.md
@@ -1,12 +1,16 @@
 # Porting S110 (byte-array corruption) to Rust
 
-> **Status:** spec / plan. The Python implementation landed in PR #656 (on
-> `main`); this document is the port spec for the Rust `tcl-compiler::shimmer`
-> subsystem. The owning track is **FE-TYPESHIM** in
+> **Status:** ✅ landed. The Python implementation landed in PR #656 (on
+> `main`); the Rust port lives in `tcl-compiler::shimmer::byte_array` (the
+> detector), `tcl-registry` (`BytePayloadSpec` + `CommandSpec::byte_array_payload`
+> + `CommandRegistry::byte_array_payload_layouts`), and is wired through
+> `compiler_checks::run_all_checks` (`push_shimmer_checks`) and the compiler
+> explorer's shimmer view. This document is retained as the port spec for the
+> Rust `tcl-compiler::shimmer` subsystem. The owning track is **FE-TYPESHIM** in
 > [`../../rust-rewrite.md`](../../rust-rewrite.md). The Python design rationale
 > (damage taxonomy, why provenance is separate from the type lattice) lives in
-> `docs/design/compiler/byte-array-corruption.md` (added by PR #656 — currently
-> on `main`, not yet on the `rust` branch); the FP contract is in
+> [`../compiler/byte-array-corruption.md`](../compiler/byte-array-corruption.md)
+> (ported alongside this work); the FP contract is in
 > [`../compiler/FP.md`](../compiler/FP.md) (FP-SH-09/10).
 
 S110 is a **correctness** shimmer, distinct from the S100/S101/S102

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1164,6 +1164,38 @@ Two catch-up modes, picked per chunk:
 
 ### Outstanding
 
+Landed: 2026-06-19 — **FE-TYPESHIM: S110 byte-array corruption ported**
+(branch `claude/elegant-cray-qm13dj`). The last FE-TYPESHIM residual — the
+S110 *correctness* shimmer added to Python in PR #656 — is now on the `rust`
+branch, closing the track for good (the row in `rust-rewrite.md` flips 🟢 → ✅).
+What landed:
+
+- **tcl-registry** — a `BytePayloadSpec` layout type (`replace_data_index` +
+  `message_flag_shift`) on a new `CommandSpec::byte_array_payload:
+  Option<BytePayloadSpec>` field, stamped on the seven `<proto>::payload`
+  specs: TCP/HTTP/UDP/SCTP use the default `replace <offset> <length> <data>`
+  layout (data at 3), DIAMETER/MQTT use `replace <data> …` (index 1), and GTP
+  carries the `-message`-shift flag. The dialect-scoped
+  `CommandRegistry::byte_array_payload_layouts` accessor mirrors Python's
+  `byte_array_payload_layouts()`; only commands loaded into the registry are
+  returned, so a plain-Tcl registry yields an empty set.
+- **tcl-compiler::shimmer::byte_array** — the `ByteProv` (BINARY/DAMAGED)
+  lattice and `ByteProvInfo`, `join_prov` (DAMAGED dominates BINARY),
+  the source/sink/coercion sets, the `arg_byte_prov` recursion, and the three
+  transfer functions (`track_assign_value` / `track_assign_expr` /
+  `track_call`). The detector walks `cfg_order` gated on executable blocks,
+  joining phis first; `binary scan $v …` re-binarifies in place (the documented
+  fix), `*::payload replace` is the byte sink, `string` case-folding and
+  `encoding convertto` of binary warn on the spot.
+- **compiler_checks::run_all_checks** — the per-function shimmer family
+  (S100/S101/S102 + S110) moved into `push_shimmer_checks`; S110 lowers via
+  `Diagnostic::from_shimmer` (→ Warning) with the `*::payload` set dialect-gated
+  to iRules. Surfaced in the compiler explorer's shimmer view
+  (`find_byte_array_warnings_for_cu`). Verified by unit tests on the
+  `TestByteArrayCorruption` battery shape (round-trip fires, `binary scan` fix /
+  clean writeback / plain-string / non-iRules-dialect silent) and two
+  end-to-end `run_all_checks` tests.
+
 Landed: 2026-06-19 — **FE-TYPESHIM complete** (PR #651, branch
 `claude/compassionate-cray-35tuvt`). The four owned modules
 (`tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`)

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -965,7 +965,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Lexer / segmenter / expr-lexer / CST | `tcl-lexer`, `tcl-syntax`, `tcl-compiler::parsing` | ✅ | FE-LEX complete — `${name}` brace-depth, quoted `\<nl>`, nested-body E202/E203 landed (see [history](rust-rewrite-history.md), 2026-06-19) |
 | IR / lowering / CFG / SSA | `tcl-compiler` | 🟢 | `IRUpFrame` clobber; dynamic-`uplevel` barrier; minor IR fields → **FE-DATAFLOW**, **FE-DIAG** |
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
-| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
+| Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | ✅ | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) ported (`tcl-compiler::shimmer::byte_array` + `tcl-registry` `BytePayloadSpec`) — **FE-TYPESHIM** complete |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
 | Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
@@ -991,7 +991,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Stage | Track | Owns | Depends on | Size |
 |---|---|---|---|---|
 | FE | **FE-DATAFLOW** | `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}` | — | M |
-| FE | **FE-TYPESHIM** 🟢 | `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}` | — | M |
+| FE | **FE-TYPESHIM** ✅ | `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}` | — | M |
 | FE | **FE-VARESCAPE** | `tcl-compiler::var_escape` | (consumers in FE-OPT) | M |
 | FE | **FE-OPT** | `tcl-compiler::optimiser`, `inlining` | — | L |
 | FE | **FE-CODEGEN** | `tcl-compiler::codegen` (non-wasm) | — | M |
@@ -1045,13 +1045,13 @@ residuals have landed:
   develops the over-optimistic empty-SSA summary the Python guard exists to
   prevent.)
 
-#### FE-TYPESHIM — type inference / shimmer / shapes / rendered-props
+#### FE-TYPESHIM — type inference / shimmer / shapes / rendered-props ✅
 Owns `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`. The
 original scope (intrep typing, the S100/S101/S102 *performance* shimmer family,
 value-shape tracking, rendered-string properties) landed and stays green; the
 precise TclOO `object_of` typing the W307/W308 consumer needs landed under
-**FE-DIAG**. One new item has since landed on the Python side and needs porting:
-- **open** **S110** byte-array corruption detection (Python PR #656) — a new
+**FE-DIAG**. The final item — the S110 *correctness* shimmer — is now ported:
+- **done** **S110** byte-array corruption detection (Python PR #656) — a
   *correctness* shimmer (distinct from the S100–S102 performance family). A
   forward byte-provenance dataflow over the SSA graph tracks two states per
   value — `BINARY` (a live byte array) and `DAMAGED` (binary-sourced but coerced
@@ -1059,13 +1059,19 @@ precise TclOO `object_of` typing the W307/W308 consumer needs landed under
   sink, the canonical iRules `*::payload replace` double-encoding bug
   ([F5 K22406348]). Sources are `binary format` / `binary decode` / `encoding
   convertto` (plain Tcl, always on) + `*::payload` getters (iRules-gated); the
-  fix `binary scan $v …` re-binarifies in place. The port adds a
-  `byte_array_payload` flag to the `*::payload` specs in `tcl-registry`, a new
-  detector in `tcl-compiler::shimmer`, and the S110 lowering in
-  `compiler_checks::run_all_checks`. **Full port spec (Python algorithm + Rust
-  integration points + step-by-step plan + the `TestByteArrayCorruption` /
-  FP-SH-09/10 verification contract):**
-  [`design/rust/s110-byte-array-corruption-port.md`](design/rust/s110-byte-array-corruption-port.md).
+  fix `binary scan $v …` re-binarifies in place. Landed as:
+  - `tcl-registry`: a `BytePayloadSpec` layout (`replace_data_index` +
+    `message_flag_shift`) on a new `CommandSpec::byte_array_payload` field,
+    stamped on the seven `<proto>::payload` specs (TCP/HTTP/UDP/SCTP default,
+    DIAMETER/MQTT `replace <data>` at index 1, GTP `-message`-shifted), plus the
+    dialect-scoped `CommandRegistry::byte_array_payload_layouts` accessor.
+  - `tcl-compiler::shimmer::byte_array`: the `ByteProv` lattice, `join_prov`,
+    the source/sink/coercion sets, `arg_byte_prov` recursion, and the three
+    transfer functions, walked over `cfg_order` gated on executable blocks with
+    phis joined first.
+  - `compiler_checks::run_all_checks` (via `push_shimmer_checks`): the S110
+    lowering, with the payload set dialect-gated (empty under non-iRules
+    dialects); surfaced in the compiler explorer's shimmer view.
 
 [F5 K22406348]: https://my.f5.com/manage/s/article/K22406348
 

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -22,7 +22,8 @@ use crate::irules_checks::{
 use crate::path_concat::{PathConcatWarning, find_path_concat_warnings};
 use crate::sccp::ConstantBranch;
 use crate::shimmer::{
-    ShimmerWarning, ThunkingWarning, find_shimmer_warnings, find_thunking_warnings,
+    ShimmerWarning, ThunkingWarning, find_byte_array_warnings, find_shimmer_warnings,
+    find_thunking_warnings,
 };
 use crate::taint::{
     TaintWarning, find_destructive_file_warnings, find_setter_constraint_warnings,
@@ -243,22 +244,8 @@ pub fn run_all_checks(
         }
     }
 
-    // Shimmer + thunking.
-    for fu in cu.analysable_functions() {
-        for w in find_shimmer_warnings(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            registry,
-            &fu.sccp.values,
-        ) {
-            out.push(shift(fu, Diagnostic::from_shimmer(&w)));
-        }
-        for w in find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks) {
-            out.push(shift(fu, Diagnostic::from_thunking(&w)));
-        }
-    }
+    // Shimmer + thunking + byte-array corruption (S110).
+    push_shimmer_checks(cu, registry, dialect, &mut out);
 
     // Taint. The interprocedural solve produces colour-aware return
     // summaries and parameter entry taints; its `top_taints` / `proc_taints`
@@ -334,6 +321,51 @@ pub fn run_all_checks(
     sort_diagnostics(&mut out);
 
     out
+}
+
+/// Append the per-function intrep-shimmer family: use-site / phi / expr
+/// shimmer (S100/S101), thunking (S102), and byte-array corruption (S110).
+///
+/// The S110 `*::payload` byte-command set is dialect-gated — empty under
+/// non-iRules dialects, so a plain-Tcl document naming a `*::payload` command
+/// never trips (the plain `binary` / `encoding` sources stay on everywhere).
+/// Split out of [`run_all_checks`] to keep that aggregator within the line
+/// budget.
+fn push_shimmer_checks(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+    dialect: Option<&str>,
+    out: &mut Vec<Diagnostic>,
+) {
+    let payload_layouts = if is_irules_dialect(dialect) {
+        registry.byte_array_payload_layouts()
+    } else {
+        std::collections::HashMap::new()
+    };
+    for fu in cu.analysable_functions() {
+        for w in find_shimmer_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            registry,
+            &fu.sccp.values,
+        ) {
+            out.push(shift(fu, Diagnostic::from_shimmer(&w)));
+        }
+        for w in find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks) {
+            out.push(shift(fu, Diagnostic::from_thunking(&w)));
+        }
+        for w in find_byte_array_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.sccp.executable_blocks,
+            registry,
+            &payload_layouts,
+        ) {
+            out.push(shift(fu, Diagnostic::from_shimmer(&w)));
+        }
+    }
 }
 
 /// Append the iRules-dialect module-level checks (IRULE5002/5004 +
@@ -494,6 +526,38 @@ mod tests {
                 .iter()
                 .any(|d| d.code == "IRULE3101" && d.category == "taint"),
             "expected IRULE3101, got {diagnostics:?}",
+        );
+    }
+
+    #[test]
+    fn run_all_checks_reports_s110_payload_roundtrip_end_to_end() {
+        let cu = CompilationUnit::build_for(
+            "when CLIENT_DATA {\n  set p [TCP::payload]\n  set q [string map {a b} $p]\n  \
+             TCP::payload replace 0 100 $q\n}",
+            &registry(),
+            false,
+        )
+        .with_interprocedural(&registry(), Some("f5-irules"));
+        let diagnostics = run_all_checks(&cu, &registry(), Some("f5-irules"));
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.code == "S110")
+            .unwrap_or_else(|| panic!("expected S110, got {diagnostics:?}"));
+        assert_eq!(hit.category, "shimmer");
+        assert_eq!(hit.severity, Severity::Warning, "S110 must be a Warning");
+    }
+
+    /// Under a non-iRules dialect the `*::payload` layout set is empty, so a
+    /// plain-Tcl document that merely names a `*::payload` command is silent.
+    #[test]
+    fn run_all_checks_s110_silent_outside_irules_dialect() {
+        let src = "proc f {} {\n  set p [TCP::payload]\n  set q [string map {a b} $p]\n  \
+                   TCP::payload replace 0 100 $q\n}";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let diagnostics = run_all_checks(&cu, &registry(), None);
+        assert!(
+            diagnostics.iter().all(|d| d.code != "S110"),
+            "S110 must not fire under plain Tcl: {diagnostics:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/shimmer/byte_array.rs
+++ b/rust/tcl-compiler/src/shimmer/byte_array.rs
@@ -1,0 +1,798 @@
+//! Byte-array corruption detection (S110).
+//!
+//! A **correctness** shimmer, distinct from the S100/S101/S102 *performance*
+//! family. Tcl byte arrays (binary data) and character strings are different
+//! internal representations. When a byte array is forced through a
+//! character-string operation and then written back to a byte sink, every byte
+//! `>= 0x80` is silently re-encoded (latin-1 decode → UTF-8 encode, or pushed
+//! out of the `0..255` range by case folding), corrupting the data. In iRules
+//! this is the canonical `*::payload replace` rewrite bug
+//! ([F5 K22406348](https://my.f5.com/manage/s/article/K22406348)); in plain
+//! Tcl it is `binary format` → `string …` → byte sink.
+//!
+//! The check is a small forward dataflow over the SSA graph tracking *byte
+//! provenance* per value:
+//!
+//! - [`ByteProv::Binary`] — the value currently has a byte-array intrep (safe
+//!   to write to a byte sink). Sources: `*::payload` getters, `binary format` /
+//!   `binary decode` / `encoding convertto` results.
+//! - [`ByteProv::Damaged`] — a binary-sourced value that has since been coerced
+//!   to a character string (interpolation, `append`, a `string` subcommand,
+//!   `format`, `expr`, …). Writing it to a byte sink corrupts it.
+//!
+//! A `binary scan $v …` re-binarifies `v` in place (the documented fix) and
+//! clears [`ByteProv::Damaged`].
+//!
+//! Ported from `compiler/shimmer.py`'s `_find_byte_array_corruption` family
+//! (Python PR #656); see `docs/design/rust/s110-byte-array-corruption-port.md`.
+
+use std::collections::HashMap;
+
+use tcl_lexer::Span;
+use tcl_registry::{BytePayloadSpec, CommandRegistry, TclType};
+
+use crate::cfg::Function as CfgFunction;
+use crate::ir::Statement;
+use crate::naming::normalise_var_name;
+use crate::sccp::cfg_order;
+use crate::ssa::{SsaFunction, ValueKey};
+use crate::value_shapes::{is_pure_var_ref, parse_command_substitution};
+use crate::var_refs::vars_in_word;
+
+use std::collections::HashSet;
+
+use super::ShimmerWarning;
+
+/// Byte-array provenance of a tracked value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ByteProv {
+    /// Currently a byte array — safe at a byte sink.
+    Binary,
+    /// Binary-sourced but coerced to a character string.
+    Damaged,
+}
+
+/// Provenance of a value plus the spans/labels for the diagnostic.
+#[derive(Debug, Clone)]
+struct ByteProvInfo {
+    state: ByteProv,
+    /// Where the binary data originated (`None` when sourced inline at a use).
+    source_range: Option<Span>,
+    source_label: String,
+    /// Where the value was coerced to a character string (`None` until coerced).
+    coercion_range: Option<Span>,
+    coercion_label: String,
+}
+
+impl ByteProvInfo {
+    /// A freshly-sourced byte array (no coercion yet).
+    fn binary(source_range: Option<Span>, source_label: String) -> Self {
+        Self {
+            state: ByteProv::Binary,
+            source_range,
+            source_label,
+            coercion_range: None,
+            coercion_label: String::new(),
+        }
+    }
+
+    /// A damaged value derived from `origin`, coerced at `coercion`.
+    fn damaged(origin: &Self, coercion_range: Option<Span>, coercion_label: String) -> Self {
+        Self {
+            state: ByteProv::Damaged,
+            source_range: origin.source_range,
+            source_label: origin.source_label.clone(),
+            coercion_range,
+            coercion_label,
+        }
+    }
+}
+
+/// `string` subcommands that fold case — they reinterpret bytes as Unicode
+/// code points and can push a byte out of `0..255`, corrupting the byte array
+/// directly, with or without a write-back.
+const CASE_FOLD_SUBS: &[&str] = &["toupper", "tolower", "totitle"];
+
+/// `string` subcommands that build a character string from their data operand.
+/// Latin-1-preserving in isolation, but the result is a STRING, so writing it
+/// back to a byte sink re-encodes the high bytes.
+const STRING_VALUE_SUBS: &[&str] = &[
+    "map",
+    "replace",
+    "range",
+    "index",
+    "reverse",
+    "repeat",
+    "trim",
+    "trimleft",
+    "trimright",
+    "cat",
+    "insert",
+];
+
+/// Commands (other than `string`) whose result is a character string derived
+/// from a byte-array operand. All latin-1-preserving, so the corruption only
+/// lands at a byte sink — they mark a value DAMAGED rather than warning.
+const STRING_COERCING_COMMANDS: &[&str] = &["format", "subst", "regsub", "join", "concat", "split"];
+
+/// Non-getter `*::payload` subcommand words — these forms do not return raw
+/// payload bytes, so they are not binary sources.
+const PAYLOAD_NON_GETTER_SUBS: &[&str] = &["replace", "length", "rechunk", "unchunk"];
+
+fn is_case_fold_sub(s: &str) -> bool {
+    CASE_FOLD_SUBS.contains(&s)
+}
+
+/// Human-readable label for a binary source, e.g. `binary format`.
+fn source_label(cmd: &str, args: &[String]) -> String {
+    if matches!(cmd, "binary" | "encoding")
+        && let Some(sub) = args.first()
+    {
+        return format!("{cmd} {sub}");
+    }
+    cmd.to_owned()
+}
+
+/// Coercion label for a string-coercing command, e.g. `string map` / `format`.
+fn coercion_label(cmd: &str, args: &[String]) -> String {
+    if cmd == "string"
+        && let Some(sub) = args.first()
+    {
+        return format!("string {sub}");
+    }
+    cmd.to_owned()
+}
+
+/// True when `[cmd args]` is a registry command that returns a byte array
+/// (`binary format` / `binary decode` / `encoding convertto`).
+fn cmdsub_returns_bytearray(registry: &CommandRegistry, cmd: &str, args: &[String]) -> bool {
+    let Some(spec) = registry.get(cmd) else {
+        return false;
+    };
+    // Subcommand-typed commands (`binary`, `encoding`) carry the return type on
+    // the subcommand; a bare command carries it at the command level.
+    if !spec.subcommands.is_empty() {
+        return args
+            .first()
+            .and_then(|sub| spec.subcommand(sub))
+            .is_some_and(|sub| sub.return_type == Some(TclType::ByteArray));
+    }
+    spec.return_type == Some(TclType::ByteArray)
+}
+
+/// True when `[cmd args]` reads raw payload bytes (the getter form).
+fn is_payload_getter(
+    layouts: &HashMap<&'static str, BytePayloadSpec>,
+    cmd: &str,
+    args: &[String],
+) -> bool {
+    if !layouts.contains_key(cmd) {
+        return false;
+    }
+    args.first()
+        .is_none_or(|sub| !PAYLOAD_NON_GETTER_SUBS.contains(&sub.as_str()))
+}
+
+/// For a `<proto>::payload replace … <data>` sink, return the index of the
+/// `<data>` argument (within the args after the command name); `None` if not a
+/// replace sink. The data position is registry-driven, so each protocol's
+/// layout is correct without special-casing here.
+fn payload_replace_data_index(
+    layouts: &HashMap<&'static str, BytePayloadSpec>,
+    cmd: &str,
+    args: &[String],
+) -> Option<usize> {
+    let layout = layouts.get(cmd)?;
+    if args.first().map(String::as_str) != Some("replace") {
+        return None;
+    }
+    let mut idx = layout.replace_data_index as usize;
+    if layout.message_flag_shift && args.get(1).map(String::as_str) == Some("-message") {
+        idx += 2;
+    }
+    (args.len() > idx).then_some(idx)
+}
+
+/// Join byte provenance over several inputs — DAMAGED dominates BINARY
+/// (may-corrupt); the first non-empty source of each state is kept for the
+/// diagnostic. Mirrors Python's `_join_prov`.
+fn join_prov(infos: impl IntoIterator<Item = Option<ByteProvInfo>>) -> Option<ByteProvInfo> {
+    let mut damaged: Option<ByteProvInfo> = None;
+    let mut binary: Option<ByteProvInfo> = None;
+    for info in infos.into_iter().flatten() {
+        match info.state {
+            ByteProv::Damaged if damaged.is_none() => damaged = Some(info),
+            ByteProv::Binary if binary.is_none() => binary = Some(info),
+            _ => {}
+        }
+    }
+    damaged.or(binary)
+}
+
+/// Build the S110 warning, with related spans pointing at the binary source
+/// and the coercion site. Mirrors Python's `_byte_corruption_warning`.
+fn byte_warning(
+    span: Span,
+    variable: &str,
+    info: &ByteProvInfo,
+    message: String,
+) -> ShimmerWarning {
+    let mut related: Vec<(Span, String)> = Vec::new();
+    if let Some(src) = info.source_range {
+        related.push((src, format!("binary data from {} here", info.source_label)));
+    }
+    if let Some(coerce) = info.coercion_range
+        && Some(coerce) != info.source_range
+    {
+        let label = if info.coercion_label.is_empty() {
+            "string operation"
+        } else {
+            &info.coercion_label
+        };
+        related.push((
+            coerce,
+            format!("treated as a character string by {label} here"),
+        ));
+    }
+    let command = if info.coercion_label.is_empty() {
+        info.source_label.clone()
+    } else {
+        info.coercion_label.clone()
+    };
+    ShimmerWarning {
+        span,
+        variable: variable.to_owned(),
+        from_type: TclType::ByteArray,
+        to_type: TclType::String,
+        command,
+        in_loop: false,
+        code: "S110".to_owned(),
+        message,
+        related,
+    }
+}
+
+/// Forward byte-provenance dataflow state for one function.
+struct ByteCorruption<'a> {
+    registry: &'a CommandRegistry,
+    payload_layouts: &'a HashMap<&'static str, BytePayloadSpec>,
+    prov: HashMap<ValueKey, ByteProvInfo>,
+    warnings: Vec<ShimmerWarning>,
+}
+
+impl<'a> ByteCorruption<'a> {
+    fn new(
+        registry: &'a CommandRegistry,
+        payload_layouts: &'a HashMap<&'static str, BytePayloadSpec>,
+    ) -> Self {
+        Self {
+            registry,
+            payload_layouts,
+            prov: HashMap::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Run the dataflow over the function's executable blocks in CFG order,
+    /// joining phis first, and return the accumulated warnings.
+    fn run(
+        mut self,
+        cfg: &CfgFunction,
+        ssa: &SsaFunction,
+        executable_blocks: &HashSet<String>,
+    ) -> Vec<ShimmerWarning> {
+        for block_name in cfg_order(cfg) {
+            if !executable_blocks.contains(&block_name) {
+                continue;
+            }
+            let Some(ssa_block) = ssa.blocks.get(&block_name) else {
+                continue;
+            };
+
+            for phi in &ssa_block.phis {
+                let joined = join_prov(
+                    phi.incoming
+                        .values()
+                        .filter(|&&v| v > 0)
+                        .map(|&v| self.prov.get(&(phi.name.clone(), v)).cloned()),
+                );
+                if let Some(joined) = joined {
+                    self.prov.insert((phi.name.clone(), phi.version), joined);
+                }
+            }
+
+            for ss in &ssa_block.statements {
+                match &ss.statement {
+                    Statement::AssignValue {
+                        name, value, span, ..
+                    } => self.track_assign_value(name, value, *span, &ss.defs, &ss.uses),
+                    Statement::AssignExpr { name, span, .. } => {
+                        self.track_assign_expr(name, *span, &ss.defs, &ss.uses);
+                    }
+                    Statement::Call {
+                        command,
+                        args,
+                        span,
+                        ..
+                    } => self.track_call(command, args, *span, &ss.defs, &ss.uses),
+                    _ => {}
+                }
+            }
+        }
+        self.warnings
+    }
+
+    /// Normalised variable names referenced via `$var` / `${var}` in `text`.
+    fn vars_in(&self, text: &str) -> Vec<String> {
+        vars_in_word(text, self.registry).into_iter().collect()
+    }
+
+    /// Provenance of a single argument expression (var ref, command
+    /// substitution, or interpolation). Mirrors Python's `_arg_byte_prov`.
+    fn arg_byte_prov(&self, arg_text: &str, uses: &HashMap<String, u32>) -> Option<ByteProvInfo> {
+        let a = arg_text.trim();
+        if a.is_empty() {
+            return None;
+        }
+        if is_pure_var_ref(a) {
+            let name = normalise_var_name(a).to_owned();
+            let ver = uses.get(&name).copied().unwrap_or(0);
+            return (ver > 0)
+                .then(|| self.prov.get(&(name, ver)).cloned())
+                .flatten();
+        }
+        if let Some((cmd, cargs)) = parse_command_substitution(a) {
+            // `encoding convertto` / `string` case-folding intrinsically corrupt
+            // a binary operand — check before the byte-array-return-type
+            // classification, so an inline sink form
+            // `<proto>::payload replace … [encoding convertto …]` is DAMAGED,
+            // not a clean source.
+            if is_intrinsic_corrupt(&cmd, &cargs) {
+                let operand = join_prov(cargs[1..].iter().map(|c| self.arg_byte_prov(c, uses)));
+                if let Some(op) = operand {
+                    return Some(ByteProvInfo::damaged(
+                        &op,
+                        None,
+                        coercion_label(&cmd, &cargs),
+                    ));
+                }
+                // `encoding convertto` of non-binary data is a legitimate byte
+                // source; case folding of non-binary data is untracked.
+                if cmd == "encoding" {
+                    return Some(ByteProvInfo::binary(None, "encoding convertto".to_owned()));
+                }
+                return None;
+            }
+            if is_payload_getter(self.payload_layouts, &cmd, &cargs)
+                || cmdsub_returns_bytearray(self.registry, &cmd, &cargs)
+            {
+                return Some(ByteProvInfo::binary(None, source_label(&cmd, &cargs)));
+            }
+            // A string transform applied to a binary operand inside the arg.
+            let inner = join_prov(cargs.iter().map(|c| self.arg_byte_prov(c, uses)));
+            if let Some(inner) = inner {
+                return Some(ByteProvInfo::damaged(&inner, None, cmd));
+            }
+            return None;
+        }
+        if a.contains('$') || a.contains('[') {
+            let joined = join_prov(self.interpolated_prov(a, uses));
+            if let Some(joined) = joined {
+                return Some(ByteProvInfo::damaged(
+                    &joined,
+                    None,
+                    "interpolation".to_owned(),
+                ));
+            }
+        }
+        None
+    }
+
+    /// Provenance of each `$var` referenced inside an interpolated word.
+    fn interpolated_prov(
+        &self,
+        text: &str,
+        uses: &HashMap<String, u32>,
+    ) -> Vec<Option<ByteProvInfo>> {
+        self.vars_in(text)
+            .into_iter()
+            .filter_map(|name| {
+                let ver = uses.get(&name).copied().unwrap_or(0);
+                (ver > 0).then(|| self.prov.get(&(name, ver)).cloned())
+            })
+            .collect()
+    }
+
+    /// Transfer function for `set name value`. Mirrors `_track_assign_value`.
+    fn track_assign_value(
+        &mut self,
+        name: &str,
+        value: &str,
+        span: Span,
+        defs: &HashMap<String, u32>,
+        uses: &HashMap<String, u32>,
+    ) {
+        let nm = normalise_var_name(name).to_owned();
+        let Some(&ver) = defs.get(&nm) else {
+            return;
+        };
+        let key = (nm.clone(), ver);
+        let val = value.trim();
+
+        if let Some((cmd, cargs)) = parse_command_substitution(val) {
+            if is_payload_getter(self.payload_layouts, &cmd, &cargs) {
+                self.prov.insert(key, ByteProvInfo::binary(Some(span), cmd));
+                return;
+            }
+            // `encoding convertto` of an already-binary value is the
+            // double-encode bug — warn, then treat the (byte-array) result as
+            // binary.
+            if cmd == "encoding" && cargs.first().map(String::as_str) == Some("convertto") {
+                let operand = join_prov(cargs[1..].iter().map(|c| self.arg_byte_prov(c, uses)));
+                if let Some(op) = operand {
+                    let msg = format!(
+                        "Byte-array corruption: 'encoding convertto' on binary data from \
+                         {label} double-encodes it — the bytes are reinterpreted as characters \
+                         and re-encoded. Decode with 'encoding convertfrom' or keep it a byte \
+                         array (S110)",
+                        label = op.source_label,
+                    );
+                    self.warnings.push(byte_warning(span, &nm, &op, msg));
+                }
+                self.prov.insert(
+                    key,
+                    ByteProvInfo::binary(Some(span), "encoding convertto".to_owned()),
+                );
+                return;
+            }
+            if cmdsub_returns_bytearray(self.registry, &cmd, &cargs) {
+                self.prov.insert(
+                    key,
+                    ByteProvInfo::binary(Some(span), source_label(&cmd, &cargs)),
+                );
+                return;
+            }
+            // `string` case-folding directly mangles a byte array.
+            if cmd == "string" && cargs.first().is_some_and(|s| is_case_fold_sub(s)) {
+                let operand = join_prov(cargs[1..].iter().map(|c| self.arg_byte_prov(c, uses)));
+                if let Some(op) = operand {
+                    let sub = &cargs[0];
+                    let msg = format!(
+                        "Byte-array corruption: 'string {sub}' on binary data from {label} \
+                         reinterprets bytes as Unicode characters, mangling every byte >= 0x80 \
+                         (S110)",
+                        label = op.source_label,
+                    );
+                    self.warnings.push(byte_warning(span, &nm, &op, msg));
+                    self.prov.insert(
+                        key,
+                        ByteProvInfo::damaged(&op, Some(span), format!("string {sub}")),
+                    );
+                    return;
+                }
+            }
+            // String value subcommands / other string-coercing commands derive
+            // a character string from a (possibly binary) operand.
+            if let Some(derived) = self.coerced_from_binary(&cmd, &cargs, uses) {
+                self.prov.insert(
+                    key,
+                    ByteProvInfo::damaged(&derived, Some(span), coercion_label(&cmd, &cargs)),
+                );
+            }
+            return;
+        }
+
+        if is_pure_var_ref(val) {
+            let src = normalise_var_name(val).to_owned();
+            let src_ver = uses.get(&src).copied().unwrap_or(0);
+            if src_ver > 0
+                && let Some(info) = self.prov.get(&(src, src_ver)).cloned()
+            {
+                self.prov.insert(key, info);
+            }
+            return;
+        }
+
+        if val.contains('$') || val.contains('[') {
+            let joined = join_prov(self.interpolated_prov(val, uses));
+            if let Some(joined) = joined {
+                self.prov.insert(
+                    key,
+                    ByteProvInfo::damaged(&joined, Some(span), "string interpolation".to_owned()),
+                );
+            }
+        }
+    }
+
+    /// If `[cmd cargs]` is a string-coercing op over a binary operand, return
+    /// the originating binary provenance. Mirrors `_coerced_from_binary`.
+    fn coerced_from_binary(
+        &self,
+        cmd: &str,
+        cargs: &[String],
+        uses: &HashMap<String, u32>,
+    ) -> Option<ByteProvInfo> {
+        let is_string_value_sub = cmd == "string"
+            && cargs
+                .first()
+                .is_some_and(|s| STRING_VALUE_SUBS.contains(&s.as_str()));
+        if !(is_string_value_sub || STRING_COERCING_COMMANDS.contains(&cmd)) {
+            return None;
+        }
+        join_prov(cargs.iter().map(|c| self.arg_byte_prov(c, uses)))
+    }
+
+    /// Transfer function for `set name [expr …]`. Any binary/damaged use makes
+    /// the result DAMAGED. Mirrors `_track_assign_expr`.
+    fn track_assign_expr(
+        &mut self,
+        name: &str,
+        span: Span,
+        defs: &HashMap<String, u32>,
+        uses: &HashMap<String, u32>,
+    ) {
+        let nm = normalise_var_name(name).to_owned();
+        let Some(&ver) = defs.get(&nm) else {
+            return;
+        };
+        let joined = join_prov(
+            uses.iter()
+                .filter(|(_, v)| **v > 0)
+                .map(|(n, v)| self.prov.get(&(n.clone(), *v)).cloned())
+                .collect::<Vec<_>>(),
+        );
+        if let Some(joined) = joined {
+            self.prov.insert(
+                (nm, ver),
+                ByteProvInfo::damaged(&joined, Some(span), "expr".to_owned()),
+            );
+        }
+    }
+
+    /// Transfer function for a command call: `binary scan` re-binarifies its
+    /// value operand; `append` damages its target; `*::payload replace` is the
+    /// byte sink. Mirrors `_track_call`.
+    fn track_call(
+        &mut self,
+        command: &str,
+        args: &[String],
+        span: Span,
+        defs: &HashMap<String, u32>,
+        uses: &HashMap<String, u32>,
+    ) {
+        // `binary scan $v …` re-binarifies its value operand in place (the
+        // documented fix). `binary format … $v` does NOT mutate `$v`, so it
+        // must not clear provenance here.
+        if command == "binary" && args.len() >= 2 && args[0] == "scan" {
+            let a = args[1].trim();
+            if is_pure_var_ref(a) {
+                let nm = normalise_var_name(a).to_owned();
+                let v = uses.get(&nm).copied().unwrap_or(0);
+                if v > 0
+                    && let Some(old) = self.prov.get(&(nm.clone(), v)).cloned()
+                {
+                    self.prov.insert(
+                        (nm, v),
+                        ByteProvInfo::binary(old.source_range, old.source_label),
+                    );
+                }
+            }
+            return;
+        }
+
+        // `append v …` coerces the target to a character string when either the
+        // target or an appended operand carries binary data.
+        if command == "append" && !args.is_empty() {
+            let target = normalise_var_name(&args[0]).to_owned();
+            if let Some(&new_ver) = defs.get(&target) {
+                let old = self
+                    .prov
+                    .get(&(target.clone(), uses.get(&target).copied().unwrap_or(0)))
+                    .cloned();
+                let operand = join_prov(
+                    std::iter::once(old)
+                        .chain(args[1..].iter().map(|a| self.arg_byte_prov(a, uses))),
+                );
+                if let Some(op) = operand {
+                    self.prov.insert(
+                        (target, new_ver),
+                        ByteProvInfo::damaged(&op, Some(span), "append".to_owned()),
+                    );
+                }
+            }
+            return;
+        }
+
+        // Sink: `<proto>::payload replace … <data>` (data index is per-protocol).
+        if let Some(data_idx) = payload_replace_data_index(self.payload_layouts, command, args) {
+            let info = self.arg_byte_prov(&args[data_idx], uses);
+            if let Some(info) = info.filter(|i| i.state == ByteProv::Damaged) {
+                let data_arg = args[data_idx].trim();
+                let data_var = if is_pure_var_ref(data_arg) {
+                    normalise_var_name(data_arg).to_owned()
+                } else {
+                    String::new()
+                };
+                let coercion = if info.coercion_label.is_empty() {
+                    "string operations"
+                } else {
+                    &info.coercion_label
+                };
+                let hint_var = if data_var.is_empty() {
+                    "data"
+                } else {
+                    &data_var
+                };
+                let msg = format!(
+                    "Byte-array corruption: '{command} replace' writes binary data from \
+                     {label} that was modified as a character string ({coercion}); every byte \
+                     >= 0x80 will be re-encoded. Re-binarify the value first, e.g. \
+                     'binary scan ${hint_var} c* -' (S110)",
+                    label = info.source_label,
+                );
+                self.warnings
+                    .push(byte_warning(span, &data_var, &info, msg));
+            }
+        }
+    }
+}
+
+/// True when `[cmd cargs]` is `encoding convertto` or a `string` case-fold —
+/// the ops that intrinsically corrupt a binary operand.
+fn is_intrinsic_corrupt(cmd: &str, cargs: &[String]) -> bool {
+    (cmd == "encoding" && cargs.first().map(String::as_str) == Some("convertto"))
+        || (cmd == "string" && cargs.first().is_some_and(|s| is_case_fold_sub(s)))
+}
+
+/// Find byte-array-corruption (S110) warnings for a single function.
+///
+/// `payload_layouts` is the dialect-gated `*::payload` byte-command set (empty
+/// under non-iRules dialects); the plain-Tcl `binary` / `encoding` sources are
+/// always recognised via the registry.
+#[must_use]
+pub(crate) fn find_byte_array_warnings(
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    executable_blocks: &HashSet<String>,
+    registry: &CommandRegistry,
+    payload_layouts: &HashMap<&'static str, BytePayloadSpec>,
+) -> Vec<ShimmerWarning> {
+    ByteCorruption::new(registry, payload_layouts).run(cfg, ssa, executable_blocks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compilation_unit::CompilationUnit;
+    use tcl_registry::CommandRegistry;
+
+    fn irules_registry() -> CommandRegistry {
+        let mut reg = CommandRegistry::build_default();
+        reg.load_irules();
+        reg
+    }
+
+    /// Run the detector over `src`, returning the S110 warnings.
+    fn warnings(src: &str, reg: &CommandRegistry) -> Vec<ShimmerWarning> {
+        let cu = CompilationUnit::build_for(src, reg, false);
+        let layouts = reg.byte_array_payload_layouts();
+        let mut out = Vec::new();
+        for fu in cu.analysable_functions() {
+            out.extend(find_byte_array_warnings(
+                &fu.cfg,
+                &fu.ssa,
+                &fu.sccp.executable_blocks,
+                reg,
+                &layouts,
+            ));
+        }
+        out
+    }
+
+    /// A `TCP::payload` getter coerced via `string map` and written back
+    /// through `TCP::payload replace` corrupts the bytes (S110).
+    #[test]
+    fn tcp_payload_string_replace_roundtrip_fires() {
+        let reg = irules_registry();
+        let src = "when CLIENT_DATA {\n  set p [TCP::payload]\n  set q [string map {a b} $p]\n  \
+                   TCP::payload replace 0 100 $q\n}";
+        let w = warnings(src, &reg);
+        assert!(
+            w.iter().any(|w| w.code == "S110"),
+            "expected S110 for payload round-trip, got: {w:?}"
+        );
+    }
+
+    /// `binary scan` re-binarifies the damaged value in place — the documented
+    /// fix — so the subsequent `replace` is silent.
+    #[test]
+    fn binary_scan_rebinarify_fix_silent() {
+        let reg = irules_registry();
+        let src = "when CLIENT_DATA {\n  set p [TCP::payload]\n  set q [string map {a b} $p]\n  \
+                   binary scan $q a* q\n  TCP::payload replace 0 100 $q\n}";
+        let w = warnings(src, &reg);
+        assert!(
+            w.iter().all(|w| w.code != "S110"),
+            "binary scan fix must silence S110, got: {w:?}"
+        );
+    }
+
+    /// A clean writeback (getter → replace, no string coercion) is safe.
+    #[test]
+    fn clean_payload_writeback_silent() {
+        let reg = irules_registry();
+        let src = "when CLIENT_DATA {\n  set p [TCP::payload]\n  TCP::payload replace 0 100 $p\n}";
+        let w = warnings(src, &reg);
+        assert!(w.is_empty(), "clean writeback must be silent, got: {w:?}");
+    }
+
+    /// Plain-Tcl `string toupper` on a `binary format` value fires immediately
+    /// (case folding corrupts directly, no sink needed).
+    #[test]
+    fn plain_tcl_toupper_case_fold_fires() {
+        let reg = CommandRegistry::build_default();
+        let src = "proc f {} {\n  set b [binary format a* hello]\n  set u [string toupper $b]\n}";
+        let w = warnings(src, &reg);
+        assert!(
+            w.iter().any(|w| w.code == "S110"),
+            "expected S110 for case fold on binary, got: {w:?}"
+        );
+    }
+
+    /// `encoding convertto` on an already-binary value double-encodes (S110).
+    #[test]
+    fn encoding_convertto_double_encode_fires() {
+        let reg = CommandRegistry::build_default();
+        let src = "proc f {} {\n  set b [binary format a* hello]\n  set e [encoding convertto utf-8 $b]\n}";
+        let w = warnings(src, &reg);
+        assert!(
+            w.iter().any(|w| w.code == "S110"),
+            "expected S110 for convertto double-encode, got: {w:?}"
+        );
+    }
+
+    /// A plain string passed through `string toupper` is untracked — no S110.
+    #[test]
+    fn toupper_plain_string_silent() {
+        let reg = CommandRegistry::build_default();
+        let src = "proc f {} {\n  set s \"hello\"\n  set u [string toupper $s]\n}";
+        let w = warnings(src, &reg);
+        assert!(w.is_empty(), "plain string toupper must be silent: {w:?}");
+    }
+
+    /// A document that merely names `*::payload` under a non-iRules dialect must
+    /// not trip — the payload layout set is empty without the iRules pack.
+    #[test]
+    fn payload_names_outside_irules_dialect_silent() {
+        let reg = CommandRegistry::build_default();
+        let src = "proc f {} {\n  set p [TCP::payload]\n  set q [string map {a b} $p]\n  \
+                   TCP::payload replace 0 100 $q\n}";
+        let w = warnings(src, &reg);
+        assert!(
+            w.is_empty(),
+            "payload names under plain Tcl must be silent: {w:?}"
+        );
+    }
+
+    /// A pure-copy chain preserves provenance: the damage flows through `set r
+    /// $q` to the sink.
+    #[test]
+    fn copy_chain_preserves_provenance_fires() {
+        let reg = irules_registry();
+        let src = "when CLIENT_DATA {\n  set p [TCP::payload]\n  set q [string map {a b} $p]\n  \
+                   set r $q\n  TCP::payload replace 0 100 $r\n}";
+        let w = warnings(src, &reg);
+        assert!(
+            w.iter().any(|w| w.code == "S110"),
+            "expected S110 through copy chain, got: {w:?}"
+        );
+    }
+
+    /// Empty source: no warnings, no panic.
+    #[test]
+    fn empty_source_silent() {
+        let reg = irules_registry();
+        let w = warnings("", &reg);
+        assert!(w.is_empty());
+    }
+}

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -13,7 +13,9 @@
 //! | [`phi`]       | S101 phi-node shimmer detection                 |
 //! | [`expr`]      | S100 expression-level shimmer detection         |
 //! | [`thunking`]  | S102 loop-oscillation detection                 |
+//! | [`byte_array`]| S110 byte-array-corruption detection            |
 
+pub mod byte_array;
 pub mod expr;
 pub mod graph;
 pub mod hints;
@@ -25,7 +27,7 @@ pub mod use_site;
 use std::collections::{HashMap, HashSet};
 
 use tcl_lexer::Span;
-use tcl_registry::{CommandRegistry, TclType};
+use tcl_registry::{BytePayloadSpec, CommandRegistry, TclType};
 
 use crate::cfg::Function as CfgFunction;
 use crate::ssa::{SsaFunction, ValueKey};
@@ -174,6 +176,47 @@ pub(crate) fn find_thunking_warnings(
     executable_blocks: &HashSet<String>,
 ) -> Vec<ThunkingWarning> {
     thunking::find_thunking_warnings(cfg, ssa, types, executable_blocks)
+}
+
+/// Find byte-array-corruption warnings (S110) for a single function.
+///
+/// A forward byte-provenance dataflow flags binary data (a `*::payload`
+/// getter, `binary format` / `binary decode` / `encoding convertto`) that is
+/// coerced to a character string and then written back through a byte sink
+/// (`*::payload replace`), or case-folded / re-encoded directly. See
+/// [`byte_array`]. `payload_layouts` is the dialect-gated `*::payload` byte
+/// command set (empty under non-iRules dialects).
+#[must_use]
+pub(crate) fn find_byte_array_warnings(
+    cfg: &CfgFunction,
+    ssa: &SsaFunction,
+    executable_blocks: &HashSet<String>,
+    registry: &CommandRegistry,
+    payload_layouts: &HashMap<&'static str, BytePayloadSpec>,
+) -> Vec<ShimmerWarning> {
+    byte_array::find_byte_array_warnings(cfg, ssa, executable_blocks, registry, payload_layouts)
+}
+
+/// Find every byte-array-corruption warning (S110) across a whole compilation
+/// unit. The `*::payload` byte-command set is taken from the registry (already
+/// scoped to the loaded dialect). See [`find_shimmer_warnings_for_cu`].
+#[must_use]
+pub fn find_byte_array_warnings_for_cu(
+    cu: &crate::compilation_unit::CompilationUnit,
+    registry: &CommandRegistry,
+) -> Vec<ShimmerWarning> {
+    let payload_layouts = registry.byte_array_payload_layouts();
+    let mut out = Vec::new();
+    for fu in cu.analysable_functions() {
+        out.extend(find_byte_array_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.sccp.executable_blocks,
+            registry,
+            &payload_layouts,
+        ));
+    }
+    out
 }
 
 #[cfg(test)]

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -29,7 +29,8 @@ use tcl_compiler::loops::{build_loop_forest, dominates};
 use tcl_compiler::optimiser::{apply_optimisations, find_dead_stores, optimise, optimise_by_pass};
 use tcl_compiler::segmenter::{segment_commands, segment_commands_with_offset_and_config};
 use tcl_compiler::shimmer::{
-    find_shimmer_warnings_for_cu, find_thunking_warnings_for_cu, type_name,
+    find_byte_array_warnings_for_cu, find_shimmer_warnings_for_cu, find_thunking_warnings_for_cu,
+    type_name,
 };
 use tcl_compiler::taint::find_taint_warnings_for_cu;
 use tcl_lexer::{LexerConfig, LineIndex, Span, TokenType};
@@ -385,6 +386,21 @@ pub fn serialise_shimmer(result: &ExplorerResult, li: &LineIndex, source: &str) 
             "variable": w.variable,
             "typeA": type_name(w.type_a),
             "typeB": type_name(w.type_b),
+        }));
+    }
+    // Byte-array corruption (S110) — a correctness shimmer with the same
+    // value-shape shape as the S100/S101 family.
+    for w in find_byte_array_warnings_for_cu(&result.unit, registry) {
+        out.push(json!({
+            "code": w.code,
+            "message": w.message,
+            "range": range_dict(w.span, li, source),
+            "severity": shimmer_severity(&w.code),
+            "variable": w.variable,
+            "fromType": type_name(w.from_type),
+            "toType": type_name(w.to_type),
+            "command": w.command,
+            "inLoop": w.in_loop,
         }));
     }
     Value::Array(out)
@@ -1342,7 +1358,8 @@ fn serialise_stats(result: &ExplorerResult) -> Value {
         .sum();
 
     let shimmer = find_shimmer_warnings_for_cu(&result.unit, registry).len()
-        + find_thunking_warnings_for_cu(&result.unit).len();
+        + find_thunking_warnings_for_cu(&result.unit).len()
+        + find_byte_array_warnings_for_cu(&result.unit, registry).len();
     let mut gvn = find_redundancies_for_cu(&result.unit, registry, dialect);
     gvn.extend(find_partial_redundancies_for_cu(
         &result.unit,
@@ -1548,6 +1565,16 @@ fn serialise_annotations(result: &ExplorerResult, li: &LineIndex, source: &str) 
             span: w.span,
             label: format!("{}: {}", w.code, w.message),
             kind: "thunking",
+            severity: sev,
+            priority: if sev == "error" { 1 } else { 2 },
+        });
+    }
+    for w in find_byte_array_warnings_for_cu(&result.unit, registry) {
+        let sev = shimmer_severity(&w.code);
+        anns.push(Ann {
+            span: w.span,
+            label: format!("{}: {}", w.code, w.message),
+            kind: "shimmer",
             severity: sev,
             priority: if sev == "error" { 1 } else { 2 },
         });

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -114,6 +114,13 @@ use tower_lsp::{Client, LanguageServer};
 struct DocumentState {
     text: String,
     dialect: String,
+    /// The LSP `languageId` the client opened this document with (empty
+    /// for documents materialised from disk by the folder scan).  Retained
+    /// so a later dialect change — `workspace/didChangeConfiguration` from
+    /// `tclLsp.selectDialect` — can re-resolve the document's dialect with
+    /// the same precedence `dialect_for_open` applied at `didOpen` (an
+    /// explicit language id still wins over the new session default).
+    language_id: String,
     /// Monotonic local revision.  Incremented before each
     /// asynchronous analyser run so stale workers cannot publish
     /// analysis/cache state for an older edit.
@@ -129,6 +136,7 @@ impl DocumentState {
         Self {
             text,
             dialect,
+            language_id: String::new(),
             revision: 0,
             version: None,
         }
@@ -138,9 +146,17 @@ impl DocumentState {
         Self {
             text,
             dialect,
+            language_id: String::new(),
             revision: 0,
             version: Some(version),
         }
+    }
+
+    /// Record the LSP `languageId` the document was opened with (builder
+    /// form, so the existing constructors stay two-argument).
+    fn with_language_id(mut self, language_id: String) -> Self {
+        self.language_id = language_id;
+        self
     }
 
     fn bump_revision(&mut self, version: i32) {
@@ -832,6 +848,48 @@ impl Backend {
         self.db_files.lock().await.remove(uri);
     }
 
+    /// Re-resolve every open document's dialect after a session-default
+    /// change and reschedule diagnostics for those whose dialect actually
+    /// moved. An explicit `languageId` / BIG-IP basename / per-folder
+    /// override still wins (it did at `didOpen`), so only documents that
+    /// fell back to the session default change. Mirrors the Python
+    /// `_apply_merged_settings_now` re-resolve-and-reanalyse loop.
+    async fn reresolve_open_document_dialects(&self) {
+        // Snapshot `(uri, language_id, current dialect)` first — the async
+        // `dialect_for_open` calls lock `folder_dialects` / `default_dialect`,
+        // so they must not run while the `documents` lock is held.
+        let snapshot: Vec<(Url, String, String)> = {
+            let docs = self.documents.lock().await;
+            docs.iter()
+                .map(|(uri, doc)| (uri.clone(), doc.language_id.clone(), doc.dialect.clone()))
+                .collect()
+        };
+        for (uri, language_id, old_dialect) in snapshot {
+            let new_dialect = self.dialect_for_open(&uri, &language_id).await;
+            if new_dialect == old_dialect {
+                continue;
+            }
+            // Commit the new dialect to the live document + salsa input while
+            // holding `documents` (the same `documents` → `db` /
+            // `workspace_index` ordering `did_open` uses; `db_set_source`
+            // never locks `documents`, so the nesting is cycle-free).
+            {
+                let mut docs = self.documents.lock().await;
+                let Some(doc) = docs.get_mut(&uri) else {
+                    continue; // closed between snapshot and commit
+                };
+                doc.dialect.clone_from(&new_dialect);
+                let text = doc.text.clone();
+                self.db_set_source(&uri, text, new_dialect.clone()).await;
+                self.workspace_index
+                    .lock()
+                    .await
+                    .remove_document(uri.as_str());
+            }
+            self.schedule_diagnostics(uri, new_dialect).await;
+        }
+    }
+
     /// Mirror the editor analyser config (disabled diagnostics + non-ASCII
     /// mode) onto the salsa `AnalyserConfig` input.  The disabled set is
     /// sorted so the input value is stable (a `HashSet` iteration order change
@@ -1021,6 +1079,18 @@ impl Backend {
     ///    URLs, use the deepest-matching folder's dialect.
     /// 3. The session-wide ``default_dialect`` fallback.
     async fn dialect_for_open(&self, uri: &Url, language_id: &str) -> String {
+        // An explicit BIG-IP language id (`tcl-bigip`, advertised by the VS
+        // Code extension, or the canonical `f5-bigip`) selects the BIG-IP
+        // config dialect even when the basename is not a canonical
+        // `bigip*.conf` name — e.g. a user who manually picks the BIG-IP
+        // language mode on a differently-named config file. `f5-bigip` is a
+        // custom config format, not a `DialectSet`-parseable Tcl dialect, so it
+        // is resolved here rather than via `dialect_from_language_id` (which is
+        // restricted to Tcl dialects by its `debug_assert`). Mirrors the
+        // BIG-IP routing the `is_bigip_conf_name` basename branch below feeds.
+        if matches!(language_id, "tcl-bigip" | "f5-bigip") {
+            return "f5-bigip".to_owned();
+        }
         let lang_dialect = Self::dialect_from_language_id(language_id);
         // A canonical BIG-IP basename (``bigip.conf``, ``bigip_base.conf``,
         // …) routes to ``f5-bigip`` ahead of a *generic* Tcl ``languageId``,
@@ -2813,7 +2883,8 @@ impl LanguageServer for Backend {
             let mut docs = self.documents.lock().await;
             docs.insert(
                 uri.clone(),
-                DocumentState::with_version(params.text_document.text, dialect, version),
+                DocumentState::with_version(params.text_document.text, dialect, version)
+                    .with_language_id(params.text_document.language_id.clone()),
             );
             self.db_set_source(&uri, text.clone(), dialect_for_diags.clone())
                 .await;
@@ -2875,9 +2946,16 @@ impl LanguageServer for Backend {
         // Accept ``{"tclLsp": {"dialect": "<name>"}}`` in either the
         // VS Code-style nested shape or the flat ``{"dialect":
         // "<name>"}`` shape (used by the MCP bridge). Update the
-        // session default so newly opened documents pick up the
-        // change; existing documents keep the dialect they were
-        // opened with.
+        // session default so newly opened documents pick up the change,
+        // then re-resolve every already-open document under the new
+        // default and reschedule diagnostics for any whose dialect
+        // changed — `tclLsp.selectDialect` pushes a dialect-only config
+        // change for a buffer that is already open, and without this the
+        // buffer would keep being parsed/diagnosed under the dialect it
+        // was opened with until reopened. Mirrors the Python server's
+        // `_apply_merged_settings_now`, which snapshots each open
+        // document's resolved dialect and force-reanalyses the ones that
+        // change.
         let dialect = params
             .settings
             .get("tclLsp")
@@ -2886,7 +2964,18 @@ impl LanguageServer for Backend {
             .and_then(serde_json::Value::as_str)
             .map(str::to_owned);
         if let Some(d) = dialect {
-            *self.default_dialect.lock().await = d;
+            let changed = {
+                let mut default = self.default_dialect.lock().await;
+                let was = std::mem::replace(&mut *default, d.clone());
+                was != d
+            };
+            // A document's resolved dialect only depends on the session
+            // default as a fallback (an explicit language id / BIG-IP
+            // basename / folder override still wins), so nothing changes
+            // when the default is unchanged.
+            if changed {
+                self.reresolve_open_document_dialects().await;
+            }
         }
         // W108 mode + disabled-diagnostics reconfiguration. Existing
         // documents pick the change up on their next analyse (the
@@ -7220,6 +7309,75 @@ mod tests {
         assert_eq!(
             backend.dialect_for_open(&doc, "plaintext").await,
             "f5-irules".to_owned(),
+        );
+    }
+
+    /// An explicit BIG-IP language id resolves to `f5-bigip` even when the
+    /// document basename is not a canonical `bigip*.conf` name — the
+    /// manual-language-mode case the `is_bigip_conf_name` basename branch
+    /// alone would miss.
+    #[tokio::test]
+    async fn dialect_for_open_maps_bigip_language_id() {
+        let backend = test_backend();
+        let doc = Url::parse("file:///workspace/device_config.txt").unwrap();
+        assert_eq!(
+            backend.dialect_for_open(&doc, "tcl-bigip").await,
+            "f5-bigip".to_owned(),
+        );
+        assert_eq!(
+            backend.dialect_for_open(&doc, "f5-bigip").await,
+            "f5-bigip".to_owned(),
+        );
+        // A generic Tcl language id on the same non-conf name does not get the
+        // BIG-IP dialect (no basename match, no explicit BIG-IP id).
+        assert_ne!(
+            backend.dialect_for_open(&doc, "tcl").await,
+            "f5-bigip".to_owned(),
+        );
+    }
+
+    /// A session-default dialect change (as `tclLsp.selectDialect` pushes via
+    /// `workspace/didChangeConfiguration`) re-resolves already-open documents:
+    /// one that fell back to the default moves to the new default, while one
+    /// opened with an explicit language id keeps its dialect.
+    #[tokio::test]
+    async fn dialect_config_change_reresolves_open_documents() {
+        let backend = test_backend();
+        *backend.default_dialect.lock().await = "tcl8.6".to_owned();
+
+        let plain = Url::parse("file:///plain.tcl").unwrap();
+        let irule = Url::parse("file:///app.irule").unwrap();
+        {
+            let mut docs = backend.documents.lock().await;
+            // No recognised language id → opened under the session default.
+            docs.insert(
+                plain.clone(),
+                DocumentState::new("set x 1\n".to_owned(), "tcl8.6".to_owned())
+                    .with_language_id("plaintext".to_owned()),
+            );
+            // An explicit iRules language id → resolved independently of the
+            // default.
+            docs.insert(
+                irule.clone(),
+                DocumentState::new("when HTTP_REQUEST {}\n".to_owned(), "f5-irules".to_owned())
+                    .with_language_id("tcl-irule".to_owned()),
+            );
+        }
+
+        // The user switches the session dialect to tcl9.0.
+        *backend.default_dialect.lock().await = "tcl9.0".to_owned();
+        backend.reresolve_open_document_dialects().await;
+
+        let docs = backend.documents.lock().await;
+        assert_eq!(
+            docs.get(&plain).unwrap().dialect,
+            "tcl9.0",
+            "a default-resolved document should follow the new session default",
+        );
+        assert_eq!(
+            docs.get(&irule).unwrap().dialect,
+            "f5-irules",
+            "an explicit-language-id document keeps its dialect",
         );
     }
 

--- a/rust/tcl-registry/src/commands/irules/diameter__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/diameter__payload.rs
@@ -34,6 +34,10 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec {
+            replace_data_index: 1,
+            ..BytePayloadSpec::DEFAULT
+        }),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/irules/gtp__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/gtp__payload.rs
@@ -36,6 +36,10 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec {
+            message_flag_shift: true,
+            ..BytePayloadSpec::DEFAULT
+        }),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/irules/http__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/http__payload.rs
@@ -40,6 +40,7 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec::DEFAULT),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/irules/mqtt__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/mqtt__payload.rs
@@ -100,6 +100,10 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec {
+            replace_data_index: 1,
+            ..BytePayloadSpec::DEFAULT
+        }),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/irules/sctp__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/sctp__payload.rs
@@ -24,6 +24,7 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec::DEFAULT),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/irules/tcp__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/tcp__payload.rs
@@ -59,6 +59,7 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec::DEFAULT),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/irules/udp__payload.rs
+++ b/rust/tcl-registry/src/commands/irules/udp__payload.rs
@@ -43,6 +43,7 @@ pub const fn spec() -> CommandSpec {
             connection_side: ConnectionSide::Both,
         }],
         taint_source: Some(TaintColour::TAINTED),
+        byte_array_payload: Some(BytePayloadSpec::DEFAULT),
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -73,7 +73,7 @@ pub mod prelude {
     pub use crate::hover::{ArgValue, FormKind, FormSpec, HoverSnippet, OptionSpec};
     pub use crate::patterns::{FormatType, PatternType};
     pub use crate::side_effects::{ConnectionSide, SideEffect, SideEffectTarget, StorageType};
-    pub use crate::spec::{CommandSpec, SubCommand};
+    pub use crate::spec::{BytePayloadSpec, CommandSpec, SubCommand};
     pub use crate::taint::{SetterConstraint, TaintColour};
     pub use crate::traits::Traits;
     pub use crate::types::TclType;
@@ -89,7 +89,7 @@ pub use dialects::{KNOWN_DIALECTS, available_dialects};
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use registry::{CommandRegistry, ResolvedTerminator};
-pub use spec::{CommandSpec, SubCommand};
+pub use spec::{BytePayloadSpec, CommandSpec, SubCommand};
 pub use taint::{SetterConstraint, TaintColour};
 pub use traits::Traits;
 pub use types::TclType;

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -13,7 +13,7 @@ use crate::arity::Arity;
 use crate::dialects::DialectSet;
 use crate::forms::CommandForm;
 use crate::hooks::{CodegenHookId, LoweringHookId};
-use crate::spec::{CommandSpec, SubCommand};
+use crate::spec::{BytePayloadSpec, CommandSpec, SubCommand};
 use crate::traits::Traits;
 
 /// Resolved metadata for an iRules event — the result of
@@ -820,6 +820,28 @@ impl CommandRegistry {
         self.get(name)
             .and_then(|spec| spec.return_type)
             .is_some_and(|t| t == crate::types::TclType::List)
+    }
+
+    /// `{command: BytePayloadSpec}` for every registered `<proto>::payload`
+    /// byte-array command — the getter is a binary source and `<cmd> replace`
+    /// a byte sink for the S110 byte-array-corruption check.
+    ///
+    /// Only commands actually loaded into this registry are returned, so the
+    /// set is implicitly gated by the active dialect: a plain-Tcl registry
+    /// (no iRules pack loaded) yields an empty map, matching Python's
+    /// `byte_array_payload_layouts()` intersected with the active dialect.
+    /// Mirrors `compiler/registry/runtime.py::byte_array_payload_layouts`.
+    #[must_use]
+    pub fn byte_array_payload_layouts(&self) -> HashMap<&'static str, BytePayloadSpec> {
+        let mut out = HashMap::new();
+        for specs in self.by_name.values() {
+            for spec in specs {
+                if let Some(layout) = spec.byte_array_payload {
+                    out.insert(spec.name, layout);
+                }
+            }
+        }
+        out
     }
 
     /// Number of registered commands.

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -28,6 +28,46 @@ use crate::types::TclType;
 /// `(arg_index, role)` pairs.
 pub type ArgRoleResolver = fn(args: &[&str]) -> Vec<(u8, ArgRole)>;
 
+/// Layout of a `<proto>::payload` byte-array command for the S110
+/// byte-array-corruption check.
+///
+/// The getter form (`TCP::payload`, no args) returns raw on-the-wire bytes —
+/// a binary source; the `replace` form rewrites them — a byte sink. The
+/// `replace` argument layout differs per protocol, so the index of the
+/// `<data>` operand is carried here instead of being hardcoded in the
+/// analyser. Mirrors the Python `BytePayloadSpec` dataclass
+/// (`compiler/registry/models.py`).
+///
+/// - `replace_data_index` — 0-based index, *within the args after the command
+///   name*, of the `<data>` operand in the `replace` form. `3` for the common
+///   `replace <offset> <length> <data>` layout (TCP/HTTP/…); `1` for
+///   `replace <data> …` (MQTT/DIAMETER).
+/// - `message_flag_shift` — when `true`, an optional leading `-message <value>`
+///   flag (GTP) shifts every positional `replace` operand by two, so the data
+///   index becomes `replace_data_index + 2` when the flag is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BytePayloadSpec {
+    /// 0-based index of the `<data>` operand in the `replace` form.
+    pub replace_data_index: u8,
+    /// Whether a leading `-message <value>` flag shifts the operands by two.
+    pub message_flag_shift: bool,
+}
+
+impl BytePayloadSpec {
+    /// The common layout — `replace <offset> <length> <data>` (data at 3),
+    /// no `-message` flag. Mirrors `BytePayloadSpec()` in Python.
+    pub const DEFAULT: Self = Self {
+        replace_data_index: 3,
+        message_flag_shift: false,
+    };
+}
+
+impl Default for BytePayloadSpec {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 /// Unified command metadata — the single source of truth.
 ///
 /// Every consumer (compiler, analyser, codegen, LSP, formatter, diagram
@@ -320,6 +360,14 @@ pub struct CommandSpec {
     /// the deprecation code action. `None` = not deprecated. Mirrors
     /// Python `deprecated_replacement` (the resolved name).
     pub deprecated_replacement: Option<&'static str>,
+
+    /// `<proto>::payload` byte-array layout — `Some` when this command's
+    /// getter returns raw bytes (a binary source) and its `replace` form is a
+    /// byte sink, for the S110 byte-array-corruption check. `None` = not a
+    /// byte-array payload command. Mirrors Python
+    /// `CommandSpec.byte_array_payload` (a `bool | BytePayloadSpec`, where
+    /// `True` maps to the default layout).
+    pub byte_array_payload: Option<BytePayloadSpec>,
 }
 
 impl CommandSpec {
@@ -376,6 +424,7 @@ impl CommandSpec {
         xc_translatable: None,
         xc_operation: None,
         deprecated_replacement: None,
+        byte_array_payload: None,
     };
 
     /// Run this command's constant folder for `args` under the optimiser's

--- a/server/workspace/document_state.py
+++ b/server/workspace/document_state.py
@@ -219,6 +219,13 @@ def infer_document_dialect(uri: str, source: str, language_id: str = "") -> str 
         return "f5-iapps"
     if lang == "expect":
         return "expect"
+    # An explicit BIG-IP language id (the VS Code extension's ``tcl-bigip``,
+    # or the canonical ``f5-bigip``) selects the BIG-IP config dialect even
+    # when the basename is not a canonical ``bigip*.conf`` name — e.g. a user
+    # who manually picks the BIG-IP language mode on a differently-named
+    # config file.  Mirrors the ``is_bigip_conf_name`` basename branch below.
+    if lang in {"f5-bigip", "tcl-bigip", "bigip"}:
+        return "f5-bigip"
 
     basename = uri.rsplit("/", 1)[-1].lower() if "/" in uri else uri.lower()
     if basename.endswith(_IRULES_EXTENSIONS):

--- a/tests/test_bigip_dialect_resolution.py
+++ b/tests/test_bigip_dialect_resolution.py
@@ -79,6 +79,17 @@ def test_explicit_directive_overrides_bigip_basename():
     assert resolve_dialect_for_uri(uri, src)[0] == "tcl8.6"
 
 
+def test_bigip_language_id_resolves_to_bigip_for_noncanonical_name():
+    # An explicit BIG-IP language id (the VS Code extension's ``tcl-bigip``,
+    # or the canonical ``f5-bigip``) wins even when the basename is not a
+    # canonical ``bigip*.conf`` name — the manual-language-mode case.
+    uri = "file:///x/device_config.txt"
+    assert infer_document_dialect(uri, "", language_id="tcl-bigip") == "f5-bigip"
+    assert infer_document_dialect(uri, "", language_id="f5-bigip") == "f5-bigip"
+    # A generic Tcl language id on the same non-conf name is unaffected.
+    assert infer_document_dialect(uri, "set x 1", language_id="tcl") != "f5-bigip"
+
+
 def test_normal_tcl_file_is_unaffected():
     # A non-bigip basename containing the same `$M$…` text is still treated
     # as ordinary Tcl (no forced f5-bigip), so normal analysis applies.

--- a/tests/test_lexer_rust_fastpath.py
+++ b/tests/test_lexer_rust_fastpath.py
@@ -129,3 +129,61 @@ def test_fastpath_only_when_no_virtuals(_patched_fastpath) -> None:
     # The fake fast path only ever emits a single VAR+EOL pair; the real
     # Python path emits a VAR token for ``$var``.
     assert any(tok.type is TokenType.VAR for tok in tokens)
+
+
+def _fake_rust_tokenise_byte_positions(source, *args, **_kwargs):
+    """Stand-in that returns *byte* offsets like the real Rust lexer.
+
+    Modelled on the source ``"é$v"`` — ``é`` (U+00E9) is two UTF-8 bytes, so
+    the ``$v`` VAR token spans bytes 2..4 (code points 1..3).  The fast path
+    must hand this stand-in zero bases for a non-ASCII source (so the remap is
+    unambiguous); assert that here.
+    """
+    # args = (expand, irules_sep, strict, base_offset, base_line, base_col)
+    assert args[3:] == (0, 0, 0), "non-ASCII source must request zero-based byte positions"
+    tokens = [
+        _FakePyToken(
+            type=_FakePyTokenType("VAR"),
+            text="v",
+            start=_FakePySourcePosition(0, 2, 2),
+            end=_FakePySourcePosition(0, 4, 4),
+        ),
+    ]
+    warnings = [(_FakePySourcePosition(0, 2, 2), "demo warning")]
+    return tokens, warnings
+
+
+def test_fastpath_remaps_byte_offsets_for_non_ascii(monkeypatch) -> None:
+    """Non-ASCII sources: byte offsets/columns from Rust are translated back to
+    the Python code-point convention for both tokens and warnings."""
+    monkeypatch.setattr(lexer_mod, "_rust_lexer_tokenise_cfg", _fake_rust_tokenise_byte_positions)
+    lexer = TclLexer("é$v")
+    tokens = lexer.tokenise_all()
+    var = tokens[0]
+    # Byte offsets 2 / 4 (after the 2-byte 'é') become code points 1 / 3.
+    assert var.start == SourcePosition(line=0, character=1, offset=1)
+    assert var.end == SourcePosition(line=0, character=3, offset=3)
+    # The lexer warning is remapped with the same convention.
+    assert lexer.warnings == [(SourcePosition(line=0, character=1, offset=1), "demo warning")]
+
+
+def test_fastpath_ascii_keeps_verbatim_positions(_patched_fastpath) -> None:
+    """ASCII sources keep the verbatim copy fast path (byte == code point), so
+    positions are taken straight from the Rust binding."""
+    tokens = TclLexer("$var").tokenise_all()
+    assert tokens[0].start == SourcePosition(line=0, character=0, offset=0)
+    assert tokens[0].end == SourcePosition(line=0, character=3, offset=3)
+
+
+def test_byte_to_position_map_applies_bases_and_newlines() -> None:
+    """The byte→code-point map counts code points (not bytes), tracks newlines,
+    and re-applies the sub-lexing bases the way ``TclLexer._pos_at`` does."""
+    text = "a\né😀b"  # 'a'(1) '\n'(1) 'é'(2) '😀'(4) 'b'(1)
+    offsets = {0, 2, 4, 8, 9}
+    m = lexer_mod._byte_to_position_map(text, offsets, base_offset=100, base_line=10, base_col=5)
+    # Line-0 positions get base_col; later lines start their column at 0.
+    assert m[0] == SourcePosition(line=10, character=5, offset=100)
+    assert m[2] == SourcePosition(line=11, character=0, offset=102)  # start of 'é'
+    assert m[4] == SourcePosition(line=11, character=1, offset=103)  # start of '😀'
+    assert m[8] == SourcePosition(line=11, character=2, offset=104)  # start of 'b'
+    assert m[9] == SourcePosition(line=11, character=3, offset=105)  # end of text


### PR DESCRIPTION
Targets `rust`. Two commits:

**1. Port S110 byte-array corruption shimmer to Rust (FE-TYPESHIM)**
Completes the FE-TYPESHIM track by porting the S110 byte-array-corruption
shimmer (Python PR #656). S110 is a *correctness* shimmer (distinct from the
S100/S101/S102 performance family): it flags binary data coerced to a character
string and written back through a byte sink — the canonical iRules
`*::payload replace` double-encoding bug (F5 K22406348) — or case-folded /
re-encoded directly.

- **Registry:** new `BytePayloadSpec` (`replace_data_index` +
  `message_flag_shift`) on `CommandSpec::byte_array_payload`, stamped on the
  seven `<proto>::payload` specs; `byte_array_payload_layouts` accessor,
  implicitly dialect-gated.
- **Detector** (`tcl-compiler::shimmer::byte_array`): the `ByteProv`
  (BINARY/DAMAGED) lattice, `join_prov`, source/sink/coercion sets, `arg_byte_prov`
  recursion, and three transfer functions, walked over `cfg_order` on executable
  blocks with phis joined first. `binary scan` re-binarifies in place (the fix);
  `*::payload replace` is the byte sink.
- **Wiring:** `compiler_checks::run_all_checks` lowers S110 via
  `push_shimmer_checks` (→ Warning), `*::payload` set dialect-gated to iRules;
  surfaced in the compiler explorer's shimmer view.

Verified by unit tests over the `TestByteArrayCorruption` battery plus two
end-to-end `run_all_checks` tests.

**2. Address Codex review: BIG-IP language id, dialect re-resolution, lexer offsets**
Three pre-existing P2 issues flagged by the Codex review (none in the S110
changeset; surfaced because the squash brings the whole rust-rewrite tree into
view):

- **BIG-IP language id → `f5-bigip`.** A buffer opened under the `tcl-bigip`
  language id whose basename isn't a canonical `bigip*.conf` name fell through to
  the default Tcl dialect, so BIG-IP parsing / outline / diagnostic suppression
  never ran. Resolve `tcl-bigip` / `f5-bigip` explicitly in `dialect_for_open`
  (it's a custom config format, not a `DialectSet`-parseable Tcl dialect).
  Mirrored in the Python reference for lockstep.
- **Apply dialect changes to open documents.** A dialect-only
  `didChangeConfiguration` updated only the session default; already-open buffers
  kept their `didOpen` dialect. Store the opening `languageId` on
  `DocumentState` and re-resolve every open document on default change
  (`reresolve_open_document_dialects`, same precedence), updating the salsa input
  and rescheduling diagnostics for the ones that move.
- **Convert Rust lexer byte offsets in the Python fast path.** The
  `tcl_lsp_rust` wheel reports UTF-8 byte offsets but downstream indexes by code
  point, so non-ASCII text before a token shifted later ranges. ASCII keeps the
  verbatim fast path; non-ASCII now remaps byte → code-point positions
  (`_byte_to_position_map`).

Each fix has unit tests; existing parity tests and suites stay green.