### PR TITLE
FE-VARESCAPE (complete) + FE-OPT optimiser passes: soundness gates, applied rewrites, var-escape pure_leaf, inliner foundation

### DIFF
--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1236,7 +1236,14 @@ general inliner). What landed:
   list rendering reuses `tcl_syntax::list::{join_list,list_element}` and the
   `_statement_delete_rewrite_range` delete-span logic is ported verbatim.
   Fold semantics + byte-exact rewrite application verified against tclsh.
-  O119 multi-set packing stays hint-only.
+- **O119 (applied multi-set packing)** — converted the hint-only detector to
+  an applied rewrite: 3+ consecutive static `set var literal` statements
+  (distinct vars, `is_safe_word` values) pack into one `lassign {vals} vars`
+  (Tcl 8.5/8.6) or `foreach {vars} {vals} {break}` (8.4 / dialect-unset),
+  skipped on Tcl 9.0. Handles both lowering shapes (integer →
+  `AssignConst`, other static → `AssignValue`) and gates on cross-event
+  vars. `statement_delete_rewrite_range` moved to `helpers::spans` (shared
+  with `chain_fold`). Pack semantics verified against tclsh.
 
 All verified against the Python reference algorithms in
 `compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1222,6 +1222,21 @@ general inliner). What landed:
   across `when <event>` boundaries) is never sunk into a branch, matching
   Python's `var_name in ctx.cross_event_vars` skip. The multi-branch /
   deepest-target descent + already-covered guard remain open.
+- **O104 / O130 (applied build-chain folds)** — new `optimiser::chain_fold`
+  replaces the hint-only string-build detector. A run of strictly-consecutive
+  static writes to one variable (`set` anchor + `append`/`lappend`) folds into
+  a single `set`: O104 for string-concat, O130 for `lappend` lists (the
+  initial string value is re-split into list elements via `split_list`). The
+  fold rewrites the last write and emits paired deletions over the earlier
+  ones, all in one group. Soundness gates: strictly-consecutive (no
+  intermediate read), every value word a static `Esc`/`Str` literal, and the
+  variable neither escaping (`var_observability::escaping_var_names`) nor a
+  cross-event var. Conservative vs Python's flow-sensitive read tracking (an
+  interleaved non-reading statement ends the run early) but never unsound;
+  list rendering reuses `tcl_syntax::list::{join_list,list_element}` and the
+  `_statement_delete_rewrite_range` delete-span logic is ported verbatim.
+  Fold semantics + byte-exact rewrite application verified against tclsh.
+  O119 multi-set packing stays hint-only.
 
 All verified against the Python reference algorithms in
 `compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1244,6 +1244,13 @@ general inliner). What landed:
   `AssignConst`, other static → `AssignValue`) and gates on cross-event
   vars. `statement_delete_rewrite_range` moved to `helpers::spans` (shared
   with `chain_fold`). Pack semantics verified against tclsh.
+- **O101 / O115 (branch-condition coverage)** — `propagate_into_branches` no
+  longer early-returns on an empty SCCP constant map, so the simplification
+  cascade (extracted as `branch_cascade`) and two new emitters apply to all
+  branch conditions: O115 unwraps a redundant `[expr {…}]` wrapper
+  (`if {[expr {$x}]}` → `if {$x}`), and O101 folds a condition that constant
+  substitution collapses to a literal. Mirrors the Python order
+  (unwrap → fold → cascade).
 
 All verified against the Python reference algorithms in
 `compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1251,6 +1251,12 @@ general inliner). What landed:
   (`if {[expr {$x}]}` → `if {$x}`), and O101 folds a condition that constant
   substitution collapses to a literal. Mirrors the Python order
   (unwrap → fold → cascade).
+- **O125 (already-covered guard)** — code sinking now skips a statement an
+  earlier pass already rewrites (e.g. an O109/O126 dead-store deletion;
+  `Elimination` runs before `CodeSinking`), preventing conflicting rewrites.
+  Mirrors Python's `already_covered` check. The multi-branch / deepest-target
+  descent (sink into the deepest using branch in *each* body, not just one)
+  remains the O125 residual.
 
 All verified against the Python reference algorithms in
 `compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1305,6 +1305,20 @@ general inliner). What landed:
   the def into each), descending through nested `if`/`switch` when a
   single-use branch's lone consumer is itself a condition-clean decision. One
   grouped delete + one prepend per target.
+- **O106 (latch-dominance gate)** — `find_loop_invariants` now tracks each
+  loop's back-edge tails (latches) and reports a pure loop-invariant only in a
+  block that dominates *every* latch — one guaranteed to run on every
+  iteration. An invariant behind an in-loop branch is no longer flagged for
+  hoisting, matching Python's "runs every iteration" check. (The trace-aware
+  purity gate `is_pure_command_with_traces` was already present.)
+- **O104 / O130 / O119 (precise-flow)** — the applied build-chain folds now
+  continue across an interleaved *static-literal write to a different
+  variable*: `classify_write` only matches single-token `Esc`/`Str` value
+  words with no substitution, so such a statement provably cannot read or
+  write the accumulator, has no side effect, and is not a barrier. The
+  interleaved statement stays in place; readers / dynamic statements / barriers
+  (`classify_write` → `None`) still end the run. Mirrors Python's
+  skip-non-reading-statement chain rule.
 - **General proc inliner — v0 + verbatim** — new self-contained
   `tcl-compiler::inlining` module porting the empty-body (v0) and zero-param
   verbatim-wrapper (v1/v2) shapes of `compiler/inlining/`. A

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1206,6 +1206,22 @@ general inliner). What landed:
   normalisation; the `!!x` collapse is gated the same way (was unconditional,
   mis-normalising `expr {!!2}`) and `~~x` on numericity. The regex/glob →
   string-op rewrites remain open.
+- **O128 (end-offset index)** — new `optimiser::end_offset` module. Rewrites
+  list/string index arguments written as length arithmetic
+  (`[expr {[llength $L] - N}]`) to Tcl's `end` / `end-N`. The IR `Statement`
+  carries only argv *texts*, so each statement's source slice is re-segmented
+  (`segment_commands_with_offset`) to recover the index argument's
+  command-substitution span, and nested `[…]` substitutions are walked
+  recursively. Covers `lindex`/`lrange`/`lreplace` (llength) +
+  `string index`/`range`/`replace` (string length); excludes `linsert` and
+  multi-index `lindex` tails; fires only when the length operand is textually
+  identical to the indexed container. Byte-exact spans + `end`/`end-N`
+  semantics verified against tclsh.
+- **O125 (code-sinking soundness)** — added the cross-event-var guard: an
+  assignment to a variable in `ctx.cross_event_vars` (iRules state carried
+  across `when <event>` boundaries) is never sunk into a branch, matching
+  Python's `var_name in ctx.cross_event_vars` skip. The multi-branch /
+  deepest-target descent + already-covered guard remain open.
 
 All verified against the Python reference algorithms in
 `compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1290,10 +1290,21 @@ general inliner). What landed:
   Mirrors Python's `already_covered` check. The multi-branch / deepest-target
   descent (sink into the deepest using branch in *each* body, not just one)
   remains the O125 residual.
-- **O103 (rename gate)** — the statement-form `try_fold_static_proc_call`
-  gained the `redefined_procedures` check the cmd-subst form already applied;
-  a redefined proc's calls are never folded. Namespace-chain resolution (a
-  bare call within its enclosing namespace) remains the O103 residual.
+- **O103 (rename gate + namespace-chain resolution)** — the statement-form
+  `try_fold_static_proc_call` gained the `redefined_procedures` check the
+  cmd-subst form already applied. Then the call-site namespace (derived from
+  the enclosing proc's qname) is threaded through the propagation walk, and
+  both fold forms resolve a bare call against the enclosing namespace chain
+  (`::ns::sub::word` out to `::word`) via the new `resolve_proc_qname`,
+  mirroring `_resolve_summary_proc_name` — a same-namespace helper call now
+  folds where the old naive `::word`-only resolution missed it.
+- **O125 (multi-branch deepest-target descent)** — the single-branch sink was
+  replaced by the recursive descent ported from `_find_deepest_sink_targets` /
+  `_try_deeper_sink`: a sinkable def is sunk into the deepest branch body that
+  uses it, in *every* branch that uses it (a var live in both arms duplicates
+  the def into each), descending through nested `if`/`switch` when a
+  single-use branch's lone consumer is itself a condition-clean decision. One
+  grouped delete + one prepend per target.
 - **General proc inliner — v0 + verbatim** — new self-contained
   `tcl-compiler::inlining` module porting the empty-body (v0) and zero-param
   verbatim-wrapper (v1/v2) shapes of `compiler/inlining/`. A

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1164,6 +1164,53 @@ Two catch-up modes, picked per chunk:
 
 ### Outstanding
 
+Landed: 2026-06-19 — **FE-OPT soundness gates + correctness guards**
+(branch `claude/great-ptolemy-kti1wz`). The optimiser's miscompile-class
+gaps — the ones that block flipping the Rust optimiser default-on — are
+closed; the track stays 🟡 for the remaining feature-completeness work
+(applied O104/O119 rewrites, the unimplemented O128/O130 detectors, O106
+trace/latch-dominance precision, O103/O125/O101/O115, and the ~1900 LOC
+general inliner). What landed:
+
+- **O120 (soundness)** — `streq_promote_node` (`helpers/expr_simplify.rs`)
+  now promotes `==`/`!=` to `eq`/`ne` only when at least one operand is a
+  *provably non-numeric* string literal (neither numeric nor a Tcl boolean
+  word), mirroring `_is_provably_non_numeric_expr_node`. Previously it fired
+  on any string literal, so `$x == "1"` → `$x eq "1"` flipped the result for
+  numeric `$x`. The variable-with-SCCP-CONST refinement Python also accepts
+  is conservatively skipped (a missed rewrite, never an unsound one).
+- **O114 (soundness)** — the `set x [expr {$x ± N}]` → `incr x` rewrite is
+  gated on `x` being provably `TclType::Int` at the use point (a
+  function-level INT join over `FunctionUnit::types`, the same shape
+  `numeric_var_names` uses), mirroring the Python INT-type proof. Float-typed
+  and untyped vars no longer rewrite (`incr` errors where `expr` promotes).
+  `pattern_recognition::run` now walks each script paired with its
+  `FunctionUnit` to derive the INT set.
+- **O108 (soundness)** — the ADCE fixpoint (`elimination::run_adce_fixpoint`)
+  routes through the existing `assignment_safe_to_delete` purity gate, so a
+  transitively-dead assignment whose RHS has an observable side effect (an
+  impure `[cmd …]`) is kept rather than removed. Replaced the
+  `is_side_effect_free_assignment` stub that treated every assignment as pure.
+- **O106 (category)** — `("O106", CodeMotion)` added to
+  `profiles.rs::OPT_CATEGORIES`, so the LICM hint is suppressable under
+  non-full profiles (matching Python's 31-entry `opt_category` table).
+- **O123 (over-fire)** — the accumulator hint is gated on Python's
+  `_is_accumulator_pattern`: an `[expr {…}]` return wrapper with **exactly
+  one** embedded self-call and an associative operator (`+`/`*`). Tree
+  recursion (`fib`'s two self-calls) and non-associative wrappers no longer
+  fire; assignments are no longer scanned (returns only).
+- **O110 (logical identities)** — the previously-unused `bool_context` is
+  threaded through the expr simplifier. `x && 1` / `x || 0` return the
+  operand bare only when it is already a `0`/`1` boolean or consumed in a
+  boolean context, else wrap as `!!x` (boolify) to preserve Tcl's `0`/`1`
+  normalisation; the `!!x` collapse is gated the same way (was unconditional,
+  mis-normalising `expr {!!2}`) and `~~x` on numericity. The regex/glob →
+  string-op rewrites remain open.
+
+All verified against the Python reference algorithms in
+`compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`
+and `_helpers.py`; full `tcl-compiler` lib suite green (2762 tests).
+
 Landed: 2026-06-19 — **FE-TYPESHIM complete** (PR #651, branch
 `claude/compassionate-cray-35tuvt`). The four owned modules
 (`tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}`)

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1257,6 +1257,27 @@ general inliner). What landed:
   Mirrors Python's `already_covered` check. The multi-branch / deepest-target
   descent (sink into the deepest using branch in *each* body, not just one)
   remains the O125 residual.
+- **O103 (rename gate)** — the statement-form `try_fold_static_proc_call`
+  gained the `redefined_procedures` check the cmd-subst form already applied;
+  a redefined proc's calls are never folded. Namespace-chain resolution (a
+  bare call within its enclosing namespace) remains the O103 residual.
+- **General proc inliner — v0 + verbatim** — new self-contained
+  `tcl-compiler::inlining` module porting the empty-body (v0) and zero-param
+  verbatim-wrapper (v1/v2) shapes of `compiler/inlining/`. A
+  statement-position call to an inlinable proc is replaced by its spliced body
+  (or removed), recursing through control-flow bodies. Soundness rests on
+  `stmt_is_splice_eligible` (def-free frame-independent allow-listed builtin
+  calls, no `[cmd]` arg subst), which subsumes `var_escape::pure_leaf` for the
+  verbatim shape, so no escape summary is needed; redefined procs are never
+  inlined and recursion cannot occur. **Architectural finding:** the inliner's
+  *only consumer is the WASM codegen* (`compiler/codegen/wasm/api.py`), so the
+  module is exposed but not yet wired — end-to-end execution-differential
+  verification is gated on **RT-WASM** (unported). The **v3 parameterised**
+  shape (α-renaming via `_rename.py`, variadic packing, defaults,
+  return-wrapping), the precise `pure_leaf` profitability tag (**FE-VARESCAPE**),
+  and dead-proc elimination are the residual — the capture-sensitive v3
+  rewriter should land alongside the RT-WASM consumer that can execution-verify
+  it, not as IR-shape-only unit tests.
 
 All verified against the Python reference algorithms in
 `compiler/optimiser/{_expr_simplify,_pattern_recognition,_elimination,_tail_call}.py`

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -1164,6 +1164,39 @@ Two catch-up modes, picked per chunk:
 
 ### Outstanding
 
+Landed: 2026-06-19 — **FE-VARESCAPE complete** (branch
+`claude/great-ptolemy-kti1wz`). The two open var-escape items closed, and the
+analysis is wired to its first consumer (the inliner). The track's `####`
+section was dropped from `rust-rewrite.md` (now a ✅ row). What landed:
+
+- **Orchestrator** — new `var_escape::api` with `analyse_var_escape` (the
+  IR-only tree-walk path that populates `pure_leaf`, the one the inliner uses),
+  `analyse_var_escape_cu` (the flow-sensitive CFG/SSA path for codegen frame
+  analysis), and `cfg_result_to_summary` (`CfgEscapeResult → ProcEscapeSummary`,
+  "FRAME wins" collapse, `pure_leaf` left default on the CFG path per Python).
+  Threads the already-landed `analyse_script` / `analyse_cfg_function` /
+  `solve_interprocedural_escape` / `populate_local_slots` pieces. Re-exported
+  with `TOP_LEVEL_QNAME = "::top"`. Mirrors `_api.py`.
+- **`pure_leaf` family** — added the `pure_leaf` field to `ProcEscapeSummary`
+  plus the derived `safe_to_inline` (= `pure_leaf`), `safe_to_dce` (the base
+  predicate without the transitive-callee clause — the PR #237 DCE relaxation),
+  and `safe_for_frame_elision` (= `!frame_needed`) predicates. The walker
+  computes the intraprocedural base predicate (`!frame_needed && !has_fallback
+  && !has_call_fallback && upvar_source_names.is_empty() &&
+  !unbounded_upvar_source`); `with_escapes` clears it on a callee-induced
+  escape or pessimistic downgrade; `solve_interprocedural_escape` gained the
+  transitive fixpoint (`downgrade_non_pure_leaf_callers`) — a proc stays
+  `pure_leaf` only if every direct callee is itself `pure_leaf` or a known
+  frameless runtime builtin. Mirrors `_types.py` + `_propagation.py` +
+  `_interprocedural.py`.
+- **Inliner wiring** — `inlining::build_inlinable_map` now gates on the precise
+  `safe_to_inline` proof from this analysis (replacing the conservative
+  splice-eligibility-only approximation), connecting FE-VARESCAPE to its first
+  in-tree consumer.
+
+The interprocedural worklist and `pure_leaf` fixpoint were factored into the
+`propagate_transitive_sources` / `downgrade_non_pure_leaf_callers` helpers.
+
 Landed: 2026-06-19 — **FE-OPT soundness gates + correctness guards**
 (branch `claude/great-ptolemy-kti1wz`). The optimiser's miscompile-class
 gaps — the ones that block flipping the Rust optimiser default-on — are

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify landed; remaining: O104/O119 applied rewrites; O128/O130; O106 trace+latch-dominance; O103/O125/O101/O115 precision; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O128 end-offset, O125 cross-event guard landed; remaining: O104/O119/O130 applied rewrites; O106 trace+latch-dominance; O103/O125 multi-branch/O101/O115 precision; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1090,17 +1090,20 @@ general inliner:
   flow-sensitive `var_observability` escape gate and the
   `_statement_delete_rewrite_range` delete-span logic so a folded chain's
   intermediate writes are removed with byte-exact ranges.
-- **open** O128 (end-offset index) and O130 (lappend chain) — implement
-  (profile entries only today). Both need a per-statement token re-parse
-  (`parse_single_command` over the statement's source slice, recursing into
-  nested `[…]` subs) to recover the index/element argument spans the IR
-  `Statement::Call { args: Vec<String> }` does not carry.
+- **open** O130 (lappend chain) — the list variant of the O104 chain fold,
+  implemented by the same applied-rewrite pass above (shares the observability
+  gate + delete-span logic). **O128 (end-offset index) has landed**
+  (`optimiser::end_offset`, 2026-06-19): a per-statement token re-parse over
+  the statement's source slice (recursing into nested `[…]` subs) recovers the
+  index argument's command-subst span the IR `Statement::Call { args:
+  Vec<String> }` does not carry.
 - **open** O106 precision — thread execution-trace facts into the GVN/LICM
   family and add the latch-dominance "runs every iteration" gate. (The
   profile-category omission that made the hint unsuppressable is fixed.)
 - **open** residuals: O103 namespace-chain resolution + rename gating; O125
-  cross-event-var + multi-branch sinking; O101/O115 branch-condition coverage
-  in `propagate_into_branches`. (The O110 instcombine gap is closed for the
+  multi-branch / deepest-target sinking + already-covered guard (the
+  **cross-event-var guard has landed**); O101/O115 branch-condition coverage in
+  `propagate_into_branches`. (The O110 instcombine gap is closed for the
   logical identities; the regex/glob→string-op rewrites remain, gated on the
   iRules `MatchesGlob`/`MatchesRegex` expr operators.)
 - **open** general proc inliner — port `compiler/inlining/` (the v0–v3 splice

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -966,7 +966,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | IR / lowering / CFG / SSA | `tcl-compiler` | 🟢 | `IRUpFrame` clobber; dynamic-`uplevel` barrier; minor IR fields → **FE-DATAFLOW**, **FE-DIAG** |
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
-| var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
+| var-escape | `tcl-compiler::var_escape` | ✅ | orchestrator (`analyse_var_escape` IR + CU paths) + `pure_leaf` family (`safe_to_inline`/`safe_to_dce`/`safe_for_frame_elision`) + transitive fixpoint landed (FE-VARESCAPE complete, see [history](rust-rewrite-history.md)) |
 | Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟡 | every O-code pass done — soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event + already-covered guards, O101/O115 branch coverage, O103 rename gate, **all applied rewrites** (O104/O130/O119/O128), and the **inliner v0+verbatim** shapes landed; remaining: precise-flow extension; O106 trace+latch-dominance; O103 namespace-chain + O125 deepest-target precision; inliner **v3** (α-rename, gated on RT-WASM consumer + FE-VARESCAPE) → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
@@ -992,7 +992,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 |---|---|---|---|---|
 | FE | **FE-DATAFLOW** | `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}` | — | M |
 | FE | **FE-TYPESHIM** 🟢 | `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}` | — | M |
-| FE | **FE-VARESCAPE** | `tcl-compiler::var_escape` | (consumers in FE-OPT) | M |
+| FE | **FE-VARESCAPE** ✅ | `tcl-compiler::var_escape` | — | M |
 | FE | **FE-OPT** | `tcl-compiler::optimiser`, `inlining` | — | L |
 | FE | **FE-CODEGEN** | `tcl-compiler::codegen` (non-wasm) | — | M |
 | FE | **FE-DIAG** ✅ | `tcl-compiler::analyser`, `irules_checks` | — | M |
@@ -1069,15 +1069,6 @@ precise TclOO `object_of` typing the W307/W308 consumer needs landed under
 
 [F5 K22406348]: https://my.f5.com/manage/s/article/K22406348
 
-#### FE-VARESCAPE — var-escape wiring
-Owns `tcl-compiler::var_escape`.
-- **open** top-level orchestrator + `CfgEscapeResult → ProcEscapeSummary` driver
-  (transfer functions are ported and tested but reachable only from their own
-  tests).
-- **open** the `pure_leaf` family (`safe_to_inline` / `safe_to_dce` /
-  `safe_for_frame_elision`) + its interprocedural fixpoint. *(gated on FE-OPT's
-  inliner / DCE consumers existing)*
-
 #### FE-OPT — optimiser passes
 Owns `tcl-compiler::optimiser`, `tcl-compiler::inlining`. The **soundness
 gates** (O120/O114/O108), the O106 profile-category registration, the O123
@@ -1110,19 +1101,18 @@ build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
 - **partial** general proc inliner — the **v0 (empty-body) + v1/v2 (zero-param
   verbatim wrapper) shapes have landed** (`tcl-compiler::inlining`,
   2026-06-19): a statement-position call to an inlinable proc is replaced by
-  its spliced body (or removed), gated on `stmt_is_splice_eligible` (def-free
-  frame-independent allow-listed builtin calls, no `[cmd]` arg subst), which
-  subsumes `pure_leaf` for the verbatim shape. **Residual:** the **v3
+  its spliced body (or removed), gated on **both** the precise
+  `var_escape::safe_to_inline` (`pure_leaf`) proof — now wired (FE-VARESCAPE
+  complete) — and `stmt_is_splice_eligible` (def-free frame-independent
+  allow-listed builtin calls, no `[cmd]` arg subst). **Residual:** the **v3
   parameterised** shape (α-renaming via `_rename.py` over value strings / expr
   ASTs / defs-reads / foreach-catch bindings, variadic packing, parameter
-  defaults, trailing-vs-non-trailing `return` for/break wrapping), the precise
-  `var_escape::pure_leaf` profitability gate, and dead-proc elimination.
-  **Cross-track dependency (handoff):** the inliner's *only consumer is the
-  WASM codegen* (`compiler/codegen/wasm/api.py`), so end-to-end
-  (execution-differential) verification is gated on **RT-WASM** (🔴 unported);
-  and the precise `pure_leaf` tag is gated on **FE-VARESCAPE** wiring. The v3
-  rewriter is capture-sensitive (variable capture) and should land with that
-  execution-verification path rather than as IR-shape-only unit tests. *(large)*
+  defaults, trailing-vs-non-trailing `return` for/break wrapping) and dead-proc
+  elimination. **Cross-track dependency (handoff):** the inliner's *only
+  consumer is the WASM codegen* (`compiler/codegen/wasm/api.py`), so end-to-end
+  (execution-differential) verification of the capture-sensitive v3 rewriter is
+  gated on **RT-WASM** (🔴 unported) — v3 should land alongside that consumer
+  rather than as IR-shape-only unit tests. *(large)*
 
 #### FE-CODEGEN — bytecode codegen
 Owns `tcl-compiler::codegen` (non-wasm).

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | ✅ | orchestrator (`analyse_var_escape` IR + CU paths) + `pure_leaf` family (`safe_to_inline`/`safe_to_dce`/`safe_for_frame_elision`) + transitive fixpoint landed (FE-VARESCAPE complete, see [history](rust-rewrite-history.md)) |
-| Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟡 | every O-code pass done — soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event + already-covered guards, O101/O115 branch coverage, O103 rename gate, **all applied rewrites** (O104/O130/O119/O128), and the **inliner v0+verbatim** shapes landed; remaining: precise-flow extension; O106 trace+latch-dominance; O103 namespace-chain + O125 deepest-target precision; inliner **v3** (α-rename, gated on RT-WASM consumer + FE-VARESCAPE) → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟢 | **every O-code pass done** — soundness gates (O120/O114/O108), O106 category, O123, O110 boolify, O125 (cross-event + already-covered + deepest-target), O101/O115 branch coverage, O103 (rename gate + namespace chain), **all applied rewrites** (O104/O130/O119/O128), and the **inliner v0+verbatim** (wired to FE-VARESCAPE `pure_leaf`); remaining: O106 latch-dominance gate, O104/O119/O130 precise-flow extension, inliner **v3** (α-rename, gated on the RT-WASM consumer for execution verification) → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1086,18 +1086,18 @@ build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
   uses per-statement SSA reads; that is the residual. The applied rewrites
   are sound — they skip (never miscompile) a chain with an interleaved
   non-reading statement.
-- **open** O106 precision — thread execution-trace facts into the GVN/LICM
-  family and add the latch-dominance "runs every iteration" gate. (The
-  profile-category omission that made the hint unsuppressable is fixed.)
-- **open** residuals: O103 namespace-chain resolution (resolve a bare call
-  within its enclosing namespace; the **rename gate is now applied on both
-  the statement and cmd-subst forms**); O125 multi-branch / deepest-target
-  descent (the **cross-event-var and already-covered guards have landed**). The **O101/O115 branch-condition
-  coverage has landed** (`branch_cascade` + the O115 unwrap and O101 fold in
-  `propagate_into_branches`, which no longer early-returns on an empty
-  constant map). The O110 instcombine gap is closed for the logical
-  identities; the regex/glob→string-op rewrites remain, gated on the iRules
-  `MatchesGlob`/`MatchesRegex` expr operators.
+- **open** O106 precision — the trace-aware purity gate is present
+  (`is_pure_command_with_traces`); the remaining work is the latch-dominance
+  "runs every iteration" gate (only hoist a loop-invariant that the loop
+  latch dominates) and threading execution-trace facts deeper into the
+  GVN/LICM family. (The profile-category omission is fixed.)
+- **done** O103 (both the **rename gate** and **namespace-chain resolution**
+  via `resolve_proc_qname`), O125 (**cross-event-var**, **already-covered**,
+  and **multi-branch deepest-target descent**), O101/O115 branch coverage
+  (`branch_cascade` + the unwrap/fold in `propagate_into_branches`), and the
+  O110 logical-identity instcombine gap. The regex/glob→string-op O110
+  rewrites remain (gated on the iRules `MatchesGlob`/`MatchesRegex` expr
+  operators).
 - **partial** general proc inliner — the **v0 (empty-body) + v1/v2 (zero-param
   verbatim wrapper) shapes have landed** (`tcl-compiler::inlining`,
   2026-06-19): a statement-position call to an inlinable proc is replaced by

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event guard, O101/O115 branch coverage, and **all applied rewrites** (O104/O130 chain folds, O119 packing, O128 end-offset) landed; remaining: O104/O119/O130 precise-flow extension; O106 trace+latch-dominance; O103 + O125 multi-branch precision; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event + already-covered guards, O101/O115 branch coverage, O103 rename gate, and **all applied rewrites** (O104/O130 chain folds, O119 packing, O128 end-offset) landed; remaining: precise-flow extension; O106 trace+latch-dominance; O103 namespace-chain + O125 deepest-target precision; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1098,9 +1098,10 @@ build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
 - **open** O106 precision — thread execution-trace facts into the GVN/LICM
   family and add the latch-dominance "runs every iteration" gate. (The
   profile-category omission that made the hint unsuppressable is fixed.)
-- **open** residuals: O103 namespace-chain resolution + rename gating; O125
-  multi-branch / deepest-target descent (the **cross-event-var and
-  already-covered guards have landed**). The **O101/O115 branch-condition
+- **open** residuals: O103 namespace-chain resolution (resolve a bare call
+  within its enclosing namespace; the **rename gate is now applied on both
+  the statement and cmd-subst forms**); O125 multi-branch / deepest-target
+  descent (the **cross-event-var and already-covered guards have landed**). The **O101/O115 branch-condition
   coverage has landed** (`branch_cascade` + the O115 unwrap and O101 fold in
   `propagate_into_branches`, which no longer early-returns on an empty
   constant map). The O110 instcombine gap is closed for the logical

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1099,8 +1099,8 @@ build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
   family and add the latch-dominance "runs every iteration" gate. (The
   profile-category omission that made the hint unsuppressable is fixed.)
 - **open** residuals: O103 namespace-chain resolution + rename gating; O125
-  multi-branch / deepest-target sinking + already-covered guard (the
-  **cross-event-var guard has landed**). The **O101/O115 branch-condition
+  multi-branch / deepest-target descent (the **cross-event-var and
+  already-covered guards have landed**). The **O101/O115 branch-condition
   coverage has landed** (`branch_cascade` + the O115 unwrap and O101 fold in
   `propagate_into_branches`, which no longer early-returns on an empty
   constant map). The O110 instcombine gap is closed for the logical

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event guard, and **all applied rewrites** (O104/O130 chain folds, O119 packing, O128 end-offset) landed; remaining: O104/O119/O130 precise-flow extension; O106 trace+latch-dominance; O103/O125 multi-branch/O101/O115 precision; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event guard, O101/O115 branch coverage, and **all applied rewrites** (O104/O130 chain folds, O119 packing, O128 end-offset) landed; remaining: O104/O119/O130 precise-flow extension; O106 trace+latch-dominance; O103 + O125 multi-branch precision; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1100,10 +1100,12 @@ build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
   profile-category omission that made the hint unsuppressable is fixed.)
 - **open** residuals: O103 namespace-chain resolution + rename gating; O125
   multi-branch / deepest-target sinking + already-covered guard (the
-  **cross-event-var guard has landed**); O101/O115 branch-condition coverage in
-  `propagate_into_branches`. (The O110 instcombine gap is closed for the
-  logical identities; the regex/glob→string-op rewrites remain, gated on the
-  iRules `MatchesGlob`/`MatchesRegex` expr operators.)
+  **cross-event-var guard has landed**). The **O101/O115 branch-condition
+  coverage has landed** (`branch_cascade` + the O115 unwrap and O101 fold in
+  `propagate_into_branches`, which no longer early-returns on an empty
+  constant map). The O110 instcombine gap is closed for the logical
+  identities; the regex/glob→string-op rewrites remain, gated on the iRules
+  `MatchesGlob`/`MatchesRegex` expr operators.
 - **open** general proc inliner — port `compiler/inlining/` (the v0–v3 splice
   inliner, ~1900 LOC); only the narrow uplevel-inline idiom exists. *(large)*
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O128 end-offset, O125 cross-event guard landed; remaining: O104/O119/O130 applied rewrites; O106 trace+latch-dominance; O103/O125 multi-branch/O101/O115 precision; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O128 end-offset, O125 cross-event guard, O104/O130 chain folds landed; remaining: O119 applied packing; O104/O130 precise-flow extension; O106 trace+latch-dominance; O103/O125 multi-branch/O101/O115 precision; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1085,18 +1085,21 @@ over-fire guard, and the O110 logical-identity boolify have **landed**
 (2026-06-19; archived in [history](rust-rewrite-history.md)). What remains is
 feature-completeness — applied rewrites, two unimplemented detectors, and the
 general inliner:
-- **partial** O104 (string-build chain) and O119 (multi-set packing) emit
-  hint-only; port the applied rewrites + dead-write deletions. Needs the
-  flow-sensitive `var_observability` escape gate and the
-  `_statement_delete_rewrite_range` delete-span logic so a folded chain's
-  intermediate writes are removed with byte-exact ranges.
-- **open** O130 (lappend chain) — the list variant of the O104 chain fold,
-  implemented by the same applied-rewrite pass above (shares the observability
-  gate + delete-span logic). **O128 (end-offset index) has landed**
-  (`optimiser::end_offset`, 2026-06-19): a per-statement token re-parse over
-  the statement's source slice (recursing into nested `[…]` subs) recovers the
-  index argument's command-subst span the IR `Statement::Call { args:
-  Vec<String> }` does not carry.
+- **partial** O119 (multi-set packing) still emits hint-only — port the
+  `lassign` packing rewrite + dead-write deletions. **O104 / O130 (string /
+  list build-chain folds) have landed** (`optimiser::chain_fold`, 2026-06-19)
+  as applied rewrites: a run of strictly-consecutive static `set`+`append`/
+  `lappend` writes folds into a single `set`, gated on the variable not
+  escaping (`var_observability::escaping_var_names`) and not being a
+  cross-event var, with `_statement_delete_rewrite_range`-equivalent
+  delete-span logic. Conservative vs Python's flow-sensitive read tracking
+  (skips a chain with an interleaved non-reading statement) but never
+  unsound; the precise-flow extension is the residual.
+- **landed** O128 (end-offset index) — `optimiser::end_offset`
+  (2026-06-19): a per-statement token re-parse over the statement's source
+  slice (recursing into nested `[…]` subs) recovers the index argument's
+  command-subst span the IR `Statement::Call { args: Vec<String> }` does not
+  carry.
 - **open** O106 precision — thread execution-trace facts into the GVN/LICM
   family and add the latch-dominance "runs every iteration" gate. (The
   profile-category omission that made the hint unsuppressable is fixed.)

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | ✅ | orchestrator (`analyse_var_escape` IR + CU paths) + `pure_leaf` family (`safe_to_inline`/`safe_to_dce`/`safe_for_frame_elision`) + transitive fixpoint landed (FE-VARESCAPE complete, see [history](rust-rewrite-history.md)) |
-| Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟢 | **every O-code pass done** — soundness gates (O120/O114/O108), O106 category, O123, O110 boolify, O125 (cross-event + already-covered + deepest-target), O101/O115 branch coverage, O103 (rename gate + namespace chain), **all applied rewrites** (O104/O130/O119/O128), and the **inliner v0+verbatim** (wired to FE-VARESCAPE `pure_leaf`); remaining: O106 latch-dominance gate, O104/O119/O130 precise-flow extension, inliner **v3** (α-rename, gated on the RT-WASM consumer for execution verification) → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟢 | **every O-code pass complete** — soundness gates (O120/O114/O108), O106 (category + latch-dominance), O123, O110 boolify, O125 (cross-event + already-covered + deepest-target), O101/O115 branch coverage, O103 (rename gate + namespace chain), **all applied rewrites** (O104/O130/O119/O128) incl. **precise-flow** across safe interleaved writes, and the **inliner v0+verbatim** (wired to FE-VARESCAPE `pure_leaf`); sole remaining: inliner **v3** (α-rename, gated on the RT-WASM consumer for execution-differential verification) → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1078,19 +1078,20 @@ feature-completeness — flow-sensitive precision and the general inliner. The
 **applied rewrites all landed** (2026-06-19): O104 / O130 string & list
 build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
 (`lassign` / `foreach`), and O128 end-offset index (`optimiser::end_offset`).
-- **partial** O104 / O119 / O130 **precise-flow extension** — the applied
-  passes cover the strictly-consecutive case (no statement runs between the
-  writes, so no intermediate value can be read) gated on
-  `var_observability::escaping_var_names` + cross-event vars. Python's
-  flow-sensitive version additionally reorders interspersed candidates and
-  uses per-statement SSA reads; that is the residual. The applied rewrites
-  are sound — they skip (never miscompile) a chain with an interleaved
-  non-reading statement.
-- **open** O106 precision — the trace-aware purity gate is present
-  (`is_pure_command_with_traces`); the remaining work is the latch-dominance
-  "runs every iteration" gate (only hoist a loop-invariant that the loop
-  latch dominates) and threading execution-trace facts deeper into the
-  GVN/LICM family. (The profile-category omission is fixed.)
+- **done** O104 / O119 / O130 **precise-flow** — the applied passes fold a
+  build chain across an interleaved **static-literal write to a different
+  variable** (provably no read/write of the accumulator, no side effect, no
+  barrier), gated on `var_observability::escaping_var_names` + cross-event
+  vars; readers / dynamic statements / barriers still end the run. (Python's
+  additional candidate *reordering* of interspersed dynamic statements is the
+  only remaining nuance, and is never a correctness gap — the Rust pass skips,
+  never miscompiles, such a chain.)
+- **done** O106 precision — the profile-category registration, the
+  trace-aware purity gate (`is_pure_command_with_traces`), and the
+  **latch-dominance "runs every iteration" gate** (only hoist a
+  loop-invariant in a block that dominates every back-edge tail) have all
+  landed. (Threading richer execution-trace facts deeper into the GVN/LICM
+  family is a precision nuance, not a correctness gap.)
 - **done** O103 (both the **rename gate** and **namespace-chain resolution**
   via `resolve_proc_qname`), O125 (**cross-event-var**, **already-covered**,
   and **multi-branch deepest-target descent**), O101/O115 branch coverage

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1076,50 +1076,30 @@ precise TclOO `object_of` typing the W307/W308 consumer needs landed under
 [F5 K22406348]: https://my.f5.com/manage/s/article/K22406348
 
 #### FE-OPT — optimiser passes
-Owns `tcl-compiler::optimiser`, `tcl-compiler::inlining`. The **soundness
-gates** (O120/O114/O108), the O106 profile-category registration, the O123
-over-fire guard, and the O110 logical-identity boolify have **landed**
-(2026-06-19; archived in [history](rust-rewrite-history.md)). What remains is
-feature-completeness — flow-sensitive precision and the general inliner. The
-**applied rewrites all landed** (2026-06-19): O104 / O130 string & list
-build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
-(`lassign` / `foreach`), and O128 end-offset index (`optimiser::end_offset`).
-- **done** O104 / O119 / O130 **precise-flow** — the applied passes fold a
-  build chain across an interleaved **static-literal write to a different
-  variable** (provably no read/write of the accumulator, no side effect, no
-  barrier), gated on `var_observability::escaping_var_names` + cross-event
-  vars; readers / dynamic statements / barriers still end the run. (Python's
-  additional candidate *reordering* of interspersed dynamic statements is the
-  only remaining nuance, and is never a correctness gap — the Rust pass skips,
-  never miscompiles, such a chain.)
-- **done** O106 precision — the profile-category registration, the
-  trace-aware purity gate (`is_pure_command_with_traces`), and the
-  **latch-dominance "runs every iteration" gate** (only hoist a
-  loop-invariant in a block that dominates every back-edge tail) have all
-  landed. (Threading richer execution-trace facts deeper into the GVN/LICM
-  family is a precision nuance, not a correctness gap.)
-- **done** O103 (both the **rename gate** and **namespace-chain resolution**
-  via `resolve_proc_qname`), O125 (**cross-event-var**, **already-covered**,
-  and **multi-branch deepest-target descent**), O101/O115 branch coverage
-  (`branch_cascade` + the unwrap/fold in `propagate_into_branches`), and the
-  O110 logical-identity instcombine gap. The regex/glob→string-op O110
-  rewrites remain (gated on the iRules `MatchesGlob`/`MatchesRegex` expr
-  operators).
-- **partial** general proc inliner — the **v0 (empty-body) + v1/v2 (zero-param
-  verbatim wrapper) shapes have landed** (`tcl-compiler::inlining`,
-  2026-06-19): a statement-position call to an inlinable proc is replaced by
-  its spliced body (or removed), gated on **both** the precise
-  `var_escape::safe_to_inline` (`pure_leaf`) proof — now wired (FE-VARESCAPE
-  complete) — and `stmt_is_splice_eligible` (def-free frame-independent
-  allow-listed builtin calls, no `[cmd]` arg subst). **Residual:** the **v3
-  parameterised** shape (α-renaming via `_rename.py` over value strings / expr
-  ASTs / defs-reads / foreach-catch bindings, variadic packing, parameter
-  defaults, trailing-vs-non-trailing `return` for/break wrapping) and dead-proc
-  elimination. **Cross-track dependency (handoff):** the inliner's *only
-  consumer is the WASM codegen* (`compiler/codegen/wasm/api.py`), so end-to-end
-  (execution-differential) verification of the capture-sensitive v3 rewriter is
-  gated on **RT-WASM** (🔴 unported) — v3 should land alongside that consumer
-  rather than as IR-shape-only unit tests. *(large)*
+Owns `tcl-compiler::optimiser`, `tcl-compiler::inlining`. **Every O-code
+optimiser pass is complete** (2026-06-19; archived in
+[history](rust-rewrite-history.md)) — the soundness gates (O120/O114/O108),
+all applied rewrites (O104/O130 chain folds, O119 packing, O128 end-offset,
+incl. **precise-flow** across safe interleaved writes), and every precision
+item (O106 category + latch-dominance, O123, O110 boolify, O125
+cross-event/already-covered/deepest-target, O101/O115 branch coverage, O103
+rename + namespace-chain). The **inliner v0 + verbatim** shapes also landed,
+gated on FE-VARESCAPE's `var_escape::safe_to_inline` (`pure_leaf`) proof plus
+per-statement `stmt_is_splice_eligible`. The sole remaining task:
+- **open** general proc inliner **v3 (parameterised)** — α-renaming via
+  `_rename.py` over value strings / expr ASTs / defs-reads / foreach-catch
+  bindings, variadic packing, parameter defaults, trailing-vs-non-trailing
+  `return` for/break wrapping, plus dead-proc elimination. **Cross-track
+  dependency (handoff):** the inliner's only consumer is the WASM codegen
+  (`compiler/codegen/wasm/api.py`), so execution-differential verification of
+  the capture-sensitive value-string rewriter is gated on **RT-WASM** (🔴
+  unported) — v3 must land alongside that consumer rather than as
+  IR-shape-only unit tests (the repo's differential-test standard cannot be
+  met otherwise). *(large)*
+- **open** *(non-correctness nuances, optional)* the O110 regex/glob →
+  string-op rewrites (gated on the iRules `MatchesGlob`/`MatchesRegex` expr
+  operators) and threading richer execution-trace facts deeper into the
+  GVN/LICM family — precision niceties, never miscompiles.
 
 #### FE-CODEGEN — bytecode codegen
 Owns `tcl-compiler::codegen` (non-wasm).

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | O114/O108 gates; O104/O119 applied; O128/O130; O106 category+gates; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify landed; remaining: O104/O119 applied rewrites; O128/O130; O106 trace+latch-dominance; O103/O125/O101/O115 precision; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1079,26 +1079,30 @@ Owns `tcl-compiler::var_escape`.
   inliner / DCE consumers existing)*
 
 #### FE-OPT — optimiser passes
-Owns `tcl-compiler::optimiser`, `tcl-compiler::inlining`.
-- **open** O120 string-compare (**soundness**) — `streq_promote_node`
-  (`helpers/expr_simplify.rs:1040`) promotes any `==`/`!=` with a `String`
-  operand to `eq`/`ne` with no non-numeric proof, so `$x == "1"` → `$x eq "1"`
-  flips the result when `$x` is numeric. Gate on provably-non-numeric operands,
-  mirroring Python's `_is_provably_non_numeric_expr_node` (`_expr_simplify.py:484`).
-- **open** O114 incr-idiom — add the variable-numericity (INT) gate
-  (`pattern_recognition.rs:219` gates only the literal; unsound for float `$x`).
-- **open** O108 ADCE — restore the substitution / execution-intent purity gate
-  (`elimination.rs` treats all assignments as side-effect-free).
+Owns `tcl-compiler::optimiser`, `tcl-compiler::inlining`. The **soundness
+gates** (O120/O114/O108), the O106 profile-category registration, the O123
+over-fire guard, and the O110 logical-identity boolify have **landed**
+(2026-06-19; archived in [history](rust-rewrite-history.md)). What remains is
+feature-completeness — applied rewrites, two unimplemented detectors, and the
+general inliner:
 - **partial** O104 (string-build chain) and O119 (multi-set packing) emit
-  hint-only; port the applied rewrites + dead-write deletions.
+  hint-only; port the applied rewrites + dead-write deletions. Needs the
+  flow-sensitive `var_observability` escape gate and the
+  `_statement_delete_rewrite_range` delete-span logic so a folded chain's
+  intermediate writes are removed with byte-exact ranges.
 - **open** O128 (end-offset index) and O130 (lappend chain) — implement
-  (profile entries only today).
-- **open** O106 — add `("O106", CodeMotion)` to `profiles.rs::OPT_CATEGORIES`
-  (unsuppressable otherwise), thread execution-trace facts into the GVN/LICM
-  family, and add the latch-dominance "runs every iteration" gate.
-- **open** residuals: O103 namespace-chain resolution + rename gating; O123
-  accumulator over-fire guards; O125 cross-event-var + multi-branch sinking;
-  O110 missing instcombine identities; O101/O115 branch-condition coverage.
+  (profile entries only today). Both need a per-statement token re-parse
+  (`parse_single_command` over the statement's source slice, recursing into
+  nested `[…]` subs) to recover the index/element argument spans the IR
+  `Statement::Call { args: Vec<String> }` does not carry.
+- **open** O106 precision — thread execution-trace facts into the GVN/LICM
+  family and add the latch-dominance "runs every iteration" gate. (The
+  profile-category omission that made the hint unsuppressable is fixed.)
+- **open** residuals: O103 namespace-chain resolution + rename gating; O125
+  cross-event-var + multi-branch sinking; O101/O115 branch-condition coverage
+  in `propagate_into_branches`. (The O110 instcombine gap is closed for the
+  logical identities; the regex/glob→string-op rewrites remain, gated on the
+  iRules `MatchesGlob`/`MatchesRegex` expr operators.)
 - **open** general proc inliner — port `compiler/inlining/` (the v0–v3 splice
   inliner, ~1900 LOC); only the narrow uplevel-inline idiom exists. *(large)*
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O128 end-offset, O125 cross-event guard, O104/O130 chain folds landed; remaining: O119 applied packing; O104/O130 precise-flow extension; O106 trace+latch-dominance; O103/O125 multi-branch/O101/O115 precision; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event guard, and **all applied rewrites** (O104/O130 chain folds, O119 packing, O128 end-offset) landed; remaining: O104/O119/O130 precise-flow extension; O106 trace+latch-dominance; O103/O125 multi-branch/O101/O115 precision; general inliner → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1083,23 +1083,18 @@ Owns `tcl-compiler::optimiser`, `tcl-compiler::inlining`. The **soundness
 gates** (O120/O114/O108), the O106 profile-category registration, the O123
 over-fire guard, and the O110 logical-identity boolify have **landed**
 (2026-06-19; archived in [history](rust-rewrite-history.md)). What remains is
-feature-completeness — applied rewrites, two unimplemented detectors, and the
-general inliner:
-- **partial** O119 (multi-set packing) still emits hint-only — port the
-  `lassign` packing rewrite + dead-write deletions. **O104 / O130 (string /
-  list build-chain folds) have landed** (`optimiser::chain_fold`, 2026-06-19)
-  as applied rewrites: a run of strictly-consecutive static `set`+`append`/
-  `lappend` writes folds into a single `set`, gated on the variable not
-  escaping (`var_observability::escaping_var_names`) and not being a
-  cross-event var, with `_statement_delete_rewrite_range`-equivalent
-  delete-span logic. Conservative vs Python's flow-sensitive read tracking
-  (skips a chain with an interleaved non-reading statement) but never
-  unsound; the precise-flow extension is the residual.
-- **landed** O128 (end-offset index) — `optimiser::end_offset`
-  (2026-06-19): a per-statement token re-parse over the statement's source
-  slice (recursing into nested `[…]` subs) recovers the index argument's
-  command-subst span the IR `Statement::Call { args: Vec<String> }` does not
-  carry.
+feature-completeness — flow-sensitive precision and the general inliner. The
+**applied rewrites all landed** (2026-06-19): O104 / O130 string & list
+build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
+(`lassign` / `foreach`), and O128 end-offset index (`optimiser::end_offset`).
+- **partial** O104 / O119 / O130 **precise-flow extension** — the applied
+  passes cover the strictly-consecutive case (no statement runs between the
+  writes, so no intermediate value can be read) gated on
+  `var_observability::escaping_var_names` + cross-event vars. Python's
+  flow-sensitive version additionally reorders interspersed candidates and
+  uses per-statement SSA reads; that is the residual. The applied rewrites
+  are sound — they skip (never miscompile) a chain with an interleaved
+  non-reading statement.
 - **open** O106 precision — thread execution-trace facts into the GVN/LICM
   family and add the latch-dominance "runs every iteration" gate. (The
   profile-category omission that made the hint unsuppressable is fixed.)

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -967,7 +967,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SCCP / intervals / memory-SSA | `tcl-compiler` | 🟡 | escaping-var widening; optimistic deferral; break-exit/static-loop folding; W233 interval path; `complexity_guard` → **FE-DATAFLOW** |
 | Type inference / shimmer / shapes / rendered-props | `tcl-compiler` | 🟢 | core landed; precise TclOO `object_of` typing landed under **FE-DIAG**; **S110** byte-array-corruption shimmer (Python #656) to port → **FE-TYPESHIM** |
 | var-escape | `tcl-compiler::var_escape` | 🟡 | unwired (no orchestrator); `pure_leaf` family → **FE-VARESCAPE** |
-| Optimiser passes | `tcl-compiler::optimiser` | 🟡 | soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event + already-covered guards, O101/O115 branch coverage, O103 rename gate, and **all applied rewrites** (O104/O130 chain folds, O119 packing, O128 end-offset) landed; remaining: precise-flow extension; O106 trace+latch-dominance; O103 namespace-chain + O125 deepest-target precision; general inliner → **FE-OPT** |
+| Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟡 | every O-code pass done — soundness gates (O120/O114/O108), O106 category, O123 guard, O110 boolify, O125 cross-event + already-covered guards, O101/O115 branch coverage, O103 rename gate, **all applied rewrites** (O104/O130/O119/O128), and the **inliner v0+verbatim** shapes landed; remaining: precise-flow extension; O106 trace+latch-dominance; O103 namespace-chain + O125 deepest-target precision; inliner **v3** (α-rename, gated on RT-WASM consumer + FE-VARESCAPE) → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | E001/W125/IRULE5005 (incl. nested `[…]` subs); snit; OO body-walks; W307/W308 object typing; C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes; `when`-body dialect gating; source-style/W108. Residuals: per-check config toggles + surfacing flow-warning fixes as code actions → **SRV-LSP**. Two review-found refinements (IRULE2001 3-arg `matchclass` fix, catch-`return` flow) are shared with Python → fixed Python-first, port pending → **FE-DIAG** |
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
@@ -1107,8 +1107,22 @@ build-chain folds (`optimiser::chain_fold`), O119 multi-set packing
   constant map). The O110 instcombine gap is closed for the logical
   identities; the regex/glob→string-op rewrites remain, gated on the iRules
   `MatchesGlob`/`MatchesRegex` expr operators.
-- **open** general proc inliner — port `compiler/inlining/` (the v0–v3 splice
-  inliner, ~1900 LOC); only the narrow uplevel-inline idiom exists. *(large)*
+- **partial** general proc inliner — the **v0 (empty-body) + v1/v2 (zero-param
+  verbatim wrapper) shapes have landed** (`tcl-compiler::inlining`,
+  2026-06-19): a statement-position call to an inlinable proc is replaced by
+  its spliced body (or removed), gated on `stmt_is_splice_eligible` (def-free
+  frame-independent allow-listed builtin calls, no `[cmd]` arg subst), which
+  subsumes `pure_leaf` for the verbatim shape. **Residual:** the **v3
+  parameterised** shape (α-renaming via `_rename.py` over value strings / expr
+  ASTs / defs-reads / foreach-catch bindings, variadic packing, parameter
+  defaults, trailing-vs-non-trailing `return` for/break wrapping), the precise
+  `var_escape::pure_leaf` profitability gate, and dead-proc elimination.
+  **Cross-track dependency (handoff):** the inliner's *only consumer is the
+  WASM codegen* (`compiler/codegen/wasm/api.py`), so end-to-end
+  (execution-differential) verification is gated on **RT-WASM** (🔴 unported);
+  and the precise `pure_leaf` tag is gated on **FE-VARESCAPE** wiring. The v3
+  rewriter is capture-sensitive (variable capture) and should land with that
+  execution-verification path rather than as IR-shape-only unit tests. *(large)*
 
 #### FE-CODEGEN — bytecode codegen
 Owns `tcl-compiler::codegen` (non-wasm).

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -1192,8 +1192,12 @@ pub fn find_loop_invariants(
     let mut results: Vec<RedundantComputation> = Vec::new();
 
     // Collect unique header → loop_blocks pairs via back-edge
-    // detection: edge tail → succ where succ dominates tail.
+    // detection: edge tail → succ where succ dominates tail. The
+    // back-edge tails (latches) are tracked per header for the
+    // latch-dominance gate below.
     let mut header_to_blocks: std::collections::HashMap<String, HashSet<String>> =
+        std::collections::HashMap::new();
+    let mut header_to_latches: std::collections::HashMap<String, HashSet<String>> =
         std::collections::HashMap::new();
     for tail in &executable {
         let Some(block) = cfg.blocks.get(tail) else {
@@ -1217,17 +1221,30 @@ pub fn find_loop_invariants(
             }
             let blocks = natural_loop_blocks(cfg, &succ, tail, &executable);
             header_to_blocks
-                .entry(succ)
+                .entry(succ.clone())
                 .and_modify(|e| e.extend(blocks.iter().cloned()))
                 .or_insert(blocks);
+            header_to_latches
+                .entry(succ)
+                .or_default()
+                .insert(tail.clone());
         }
     }
 
     for (header, loop_blocks) in &header_to_blocks {
         let defined = loop_defined_variables(ssa, loop_blocks);
+        let latches = &header_to_latches[header];
         for bn in loop_blocks {
             if bn == header {
                 // Skip header-only scans (contains the loop test).
+                continue;
+            }
+            // Latch-dominance "runs every iteration" gate: an invariant in
+            // a block that does not dominate every back-edge tail runs only
+            // on some iterations (it sits behind a branch inside the loop),
+            // so hoisting it changes *when* it runs. Only blocks that
+            // dominate every latch are guaranteed to execute each iteration.
+            if !latches.iter().all(|latch| dominates(ssa, bn, latch)) {
                 continue;
             }
             let Some(ssa_block) = ssa.blocks.get(bn) else {
@@ -2370,6 +2387,77 @@ mod tests {
         // which is unreachable dead code) — GAP-B2.
         assert_eq!(results[0].code, "O106");
         assert!(results[0].expression_text.contains("llength"));
+    }
+
+    #[test]
+    fn find_loop_invariants_skips_branch_that_does_not_dominate_latch() {
+        // Loop:  header → cond → {then, latch}; then → latch; latch → header.
+        // The invariant `llength $x` sits in `then`, which does NOT dominate
+        // the latch (cond can reach the latch directly), so it runs only on
+        // some iterations — the latch-dominance gate must suppress O106.
+        let registry = CommandRegistry::build_default();
+        let mut cfg = Function::new("::top", "header");
+        for b in ["cond", "then", "latch", "exit"] {
+            cfg.blocks.insert(b.into(), Block::new(b));
+        }
+        cfg.blocks.get_mut("header").unwrap().terminator = Some(Terminator::Branch {
+            condition: crate::expr_ast::ExprNode::Literal { text: "1".into(), start: 0, end: 1 },
+            true_target: "cond".into(),
+            false_target: "exit".into(),
+            span: None,
+        });
+        cfg.blocks.get_mut("cond").unwrap().terminator = Some(Terminator::Branch {
+            condition: crate::expr_ast::ExprNode::Literal { text: "1".into(), start: 0, end: 1 },
+            true_target: "then".into(),
+            false_target: "latch".into(),
+            span: None,
+        });
+        cfg.blocks.get_mut("then").unwrap().statements.push(llength_call());
+        cfg.blocks.get_mut("then").unwrap().terminator =
+            Some(Terminator::Goto { target: "latch".into(), span: None });
+        cfg.blocks.get_mut("latch").unwrap().terminator =
+            Some(Terminator::Goto { target: "header".into(), span: None });
+        cfg.blocks.get_mut("exit").unwrap().terminator = Some(Terminator::Return {
+            value: None,
+            span: None,
+            expr: None,
+            braced: false,
+        });
+
+        let mut ssa = SsaFunction {
+            name: "::top".into(),
+            entry: "header".into(),
+            blocks: Map::new(),
+            idom: Map::new(),
+            dominance_frontier: Map::new(),
+            dominator_tree: Map::new(),
+        };
+        ssa.idom.insert("header".into(), None);
+        ssa.idom.insert("cond".into(), Some("header".into()));
+        ssa.idom.insert("then".into(), Some("cond".into()));
+        // The latch is reachable from `cond` both directly and via `then`,
+        // so its immediate dominator is `cond`, not `then`.
+        ssa.idom.insert("latch".into(), Some("cond".into()));
+        ssa.idom.insert("exit".into(), Some("header".into()));
+        ssa.dominator_tree.insert("header".into(), vec!["cond".into(), "exit".into()]);
+        ssa.dominator_tree.insert("cond".into(), vec!["then".into(), "latch".into()]);
+        for b in ["then", "latch", "exit"] {
+            ssa.dominator_tree.insert(b.into(), Vec::new());
+        }
+
+        ssa.blocks.insert("header".into(), empty_ssa_block("header"));
+        ssa.blocks.insert("cond".into(), empty_ssa_block("cond"));
+        let mut then_b = empty_ssa_block("then");
+        then_b.statements.push(ssa_stmt_for(llength_call(), Some(1)));
+        ssa.blocks.insert("then".into(), then_b);
+        ssa.blocks.insert("latch".into(), empty_ssa_block("latch"));
+        ssa.blocks.insert("exit".into(), empty_ssa_block("exit"));
+
+        let results = find_loop_invariants(&registry, &cfg, &ssa, None);
+        assert!(
+            results.is_empty(),
+            "invariant behind an in-loop branch must not be hoisted, got {results:?}",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/inlining.rs
+++ b/rust/tcl-compiler/src/inlining.rs
@@ -17,11 +17,18 @@
 //!   the call site.
 //!
 //! The **v3 parameterised** shape (α-renamed body + parameter bindings) and
-//! its `_rename` machinery, plus the precise `var_escape::pure_leaf`
-//! profitability gate and dead-proc elimination, are the documented
-//! residual — see [`docs/rust-rewrite.md`] (FE-OPT) / the **RT-WASM** and
-//! **FE-VARESCAPE** tracks. The inliner's only consumer is the WASM codegen
-//! (RT-WASM, unported), so it is exposed but not yet wired into a pipeline.
+//! its `_rename` machinery, plus dead-proc elimination, are the documented
+//! residual — see [`docs/rust-rewrite.md`] (FE-OPT) / the **RT-WASM** track.
+//! The inliner's only consumer is the WASM codegen (RT-WASM, unported), so
+//! it is exposed but not yet wired into a pipeline.
+//!
+//! # Eligibility
+//!
+//! Two gates combine in [`classify_proc`] / `build_inlinable_map`: the
+//! precise interprocedural [`var_escape::pure_leaf`](crate::var_escape)
+//! proof (`safe_to_inline` — FE-VARESCAPE's S4.1 soundness predicate) and
+//! the structural shape. The per-statement [`stmt_is_splice_eligible`] check
+//! then guards the verbatim body itself.
 //!
 //! # Soundness
 //!
@@ -40,6 +47,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ir::{Module, Procedure, Script, Statement};
+use crate::var_escape::ProcEscapeSummary;
 
 /// Per-proc inlining eligibility — the catalogue tag. Mirrors Python's
 /// `InlineDecision`, restricted to the cases the v0 / verbatim mechanism
@@ -177,13 +185,14 @@ fn stmt_is_splice_eligible(stmt: &Statement) -> bool {
     true
 }
 
-/// Classify a procedure for inlining. A proc is [`InlineDecision::Always`]
-/// when it is not redefined and is either empty-bodied (v0) or a small
-/// zero-parameter wrapper whose every body statement is splice-eligible
-/// (v1 / v2). Everything else is [`InlineDecision::Never`] in this port
-/// (v3 parameterised inlining is the residual). The splice-eligibility
-/// check subsumes the `pure_leaf` soundness predicate for the verbatim
-/// shape, so no interprocedural escape summary is required.
+/// Classify a procedure's *structural shape* for inlining. A proc is
+/// [`InlineDecision::Always`] when it is not redefined and is either
+/// empty-bodied (v0) or a small zero-parameter wrapper whose every body
+/// statement is splice-eligible (v1 / v2). Everything else is
+/// [`InlineDecision::Never`] in this port (v3 parameterised inlining is the
+/// residual). The caller (`build_inlinable_map`) additionally gates on the
+/// interprocedural `var_escape::safe_to_inline` (`pure_leaf`) soundness
+/// proof — this function only judges the shape.
 #[must_use]
 pub fn classify_proc<S: std::hash::BuildHasher>(
     proc: &Procedure,
@@ -205,9 +214,21 @@ pub fn classify_proc<S: std::hash::BuildHasher>(
 }
 
 /// Build the qname → [`InlineSpec`] map of inlinable procedures.
+///
+/// Two gates combine: the precise `var_escape::pure_leaf` predicate
+/// (`safe_to_inline`, the Python S4.1 soundness proof — FE-VARESCAPE) and
+/// the structural shape classification ([`classify_proc`]). A proc must
+/// pass both. The escape summaries are computed from the IR module, the
+/// path that populates `pure_leaf`.
 fn build_inlinable_map(module: &Module) -> HashMap<String, InlineSpec> {
+    let summaries = crate::var_escape::analyse_var_escape(module, true);
     let mut map = HashMap::new();
     for (qname, proc) in &module.procedures {
+        // Soundness gate: the interprocedural pure-leaf proof. An absent
+        // summary (shouldn't happen for a module proc) is treated as opaque.
+        if !summaries.get(qname).is_some_and(ProcEscapeSummary::safe_to_inline) {
+            continue;
+        }
         if classify_proc(proc, &module.redefined_procedures) != InlineDecision::Always {
             continue;
         }

--- a/rust/tcl-compiler/src/inlining.rs
+++ b/rust/tcl-compiler/src/inlining.rs
@@ -1,0 +1,432 @@
+//! General proc inliner (v0 + verbatim).
+//!
+//! Ported from `compiler/inlining/` — the catalogue (`decision.py`) plus
+//! the IR-level splice transform (`inline_pass.py`). The inliner rewrites
+//! statement-position calls to *inlinable* procedures so the call boundary
+//! disappears before WASM codegen consumes the IR.
+//!
+//! # Scope
+//!
+//! Two of the four Python shapes are ported here, the ones whose soundness
+//! needs no α-renaming or interprocedural escape proof:
+//!
+//! * **v0 — empty body.** A call to a zero-statement proc vanishes.
+//! * **v1 / v2 — verbatim wrapper.** A zero-parameter proc whose every
+//!   body statement is *splice-eligible* (a frame-independent, def-free,
+//!   substitution-free builtin call) has its body spliced verbatim into
+//!   the call site.
+//!
+//! The **v3 parameterised** shape (α-renamed body + parameter bindings) and
+//! its `_rename` machinery, plus the precise `var_escape::pure_leaf`
+//! profitability gate and dead-proc elimination, are the documented
+//! residual — see [`docs/rust-rewrite.md`] (FE-OPT) / the **RT-WASM** and
+//! **FE-VARESCAPE** tracks. The inliner's only consumer is the WASM codegen
+//! (RT-WASM, unported), so it is exposed but not yet wired into a pipeline.
+//!
+//! # Soundness
+//!
+//! The verbatim shape leans entirely on [`stmt_is_splice_eligible`]: a body
+//! statement may be lifted out of the proc frame only when it is an
+//! [`Statement::Call`] with no `defs` (it cannot mutate the caller's
+//! scope), whose command is in the frame-independent allow-list (no
+//! `info` / `uplevel` / `upvar` / `return` / `break` / `continue`), and
+//! whose arguments carry no `[cmd]` substitution. That makes the splice
+//! observationally equivalent to the call regardless of which frame it
+//! runs in. Empty bodies are trivially safe. Redefined procs are never
+//! inlined (their body is ambiguous). Recursion cannot occur: a call to a
+//! user proc is not in the splice-safe allow-list, so a self-calling body
+//! is never verbatim-eligible.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ir::{Module, Procedure, Script, Statement};
+
+/// Per-proc inlining eligibility — the catalogue tag. Mirrors Python's
+/// `InlineDecision`, restricted to the cases the v0 / verbatim mechanism
+/// acts on. `IfSingleCall` is intentionally inert here (its profitability
+/// depends on post-inline proc pruning, not yet ported).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineDecision {
+    /// Always inline a call to this proc.
+    Always,
+    /// Inline only when the proc has exactly one static caller (not yet
+    /// acted on — recorded for parity / future pruning).
+    IfSingleCall,
+    /// Never inline.
+    Never,
+}
+
+/// A pure-leaf proc whose body has at most this many flat statements is
+/// unconditionally inlinable. Mirrors `decision.SMALL_BODY_THRESHOLD`.
+pub const SMALL_BODY_THRESHOLD: usize = 5;
+
+/// What an inlinable proc splices in at a call site.
+#[derive(Debug, Clone)]
+enum InlineSpec {
+    /// v0 — empty body; the call vanishes.
+    Empty,
+    /// v1 / v2 — splice these body statements verbatim.
+    Verbatim(Vec<Statement>),
+}
+
+/// Total number of leaf statements reachable in `script`, walking nested
+/// control-flow bodies transitively (the inlined code-size cost). Mirrors
+/// `decision.count_statements`.
+#[must_use]
+pub fn count_statements(script: &Script) -> usize {
+    script.statements.iter().map(count_one).sum()
+}
+
+fn count_one(stmt: &Statement) -> usize {
+    match stmt {
+        Statement::Block { body, .. } | Statement::UpFrame { body, .. } => count_statements(body),
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            let mut n = 0;
+            for c in clauses {
+                n += 1 + count_statements(&c.body);
+            }
+            if let Some(b) = else_body {
+                n += count_statements(b);
+            }
+            n
+        }
+        Statement::For {
+            init, next, body, ..
+        } => count_statements(init) + 1 + count_statements(next) + count_statements(body),
+        Statement::While { body, .. }
+        | Statement::Foreach { body, .. }
+        | Statement::Catch { body, .. } => 1 + count_statements(body),
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            let mut n = count_statements(body);
+            for h in handlers {
+                n += count_statements(&h.body);
+            }
+            if let Some(fb) = finally_body {
+                n += count_statements(fb);
+            }
+            n
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            let mut n = 0;
+            for a in arms {
+                if let Some(b) = &a.body {
+                    n += count_statements(b);
+                }
+            }
+            if let Some(b) = default_body {
+                n += count_statements(b);
+            }
+            n
+        }
+        _ => 1,
+    }
+}
+
+/// Commands whose semantics are independent of the calling frame — a
+/// wrapped call to one of these can be spliced into any caller's frame.
+/// Frame-observing (`info` / `uplevel` / `upvar`) and frame-affecting
+/// control flow (`return` / `break` / `continue`) are deliberately
+/// excluded. Mirrors `_SPLICE_SAFE_COMMANDS`.
+const SPLICE_SAFE_COMMANDS: &[&str] = &[
+    // List primitives — pure value computation.
+    "list", "lindex", "lrange", "linsert", "llength", "lsort", "lsearch", "lreverse", "lreplace",
+    "lrepeat", "concat", // String primitives.
+    "split", "join", "string", // Arithmetic.
+    "expr", // I/O — observable but frame-independent.
+    "puts",
+];
+
+/// Whether `command` (the head word as written) is a frame-independent,
+/// splice-safe builtin. Mirrors `_command_is_splice_safe`.
+fn command_is_splice_safe(command: &str) -> bool {
+    // Accept a `::`-qualified spelling of a builtin too (`::puts`).
+    let bare = command.strip_prefix("::").unwrap_or(command);
+    SPLICE_SAFE_COMMANDS.contains(&bare)
+}
+
+/// Whether a statement can be lifted out of a wrapper proc and spliced
+/// into a caller without changing observable behaviour. Mirrors
+/// `_stmt_is_splice_eligible`.
+fn stmt_is_splice_eligible(stmt: &Statement) -> bool {
+    let Statement::Call {
+        command, args, defs, ..
+    } = stmt
+    else {
+        return false;
+    };
+    if !defs.is_empty() {
+        return false;
+    }
+    if !command_is_splice_safe(command) {
+        return false;
+    }
+    // No `[cmd]` substitution in any argument — its result would depend on
+    // evaluation in the original frame's command-resolution context.
+    if args.iter().any(|a| a.contains('[')) {
+        return false;
+    }
+    true
+}
+
+/// Classify a procedure for inlining. A proc is [`InlineDecision::Always`]
+/// when it is not redefined and is either empty-bodied (v0) or a small
+/// zero-parameter wrapper whose every body statement is splice-eligible
+/// (v1 / v2). Everything else is [`InlineDecision::Never`] in this port
+/// (v3 parameterised inlining is the residual). The splice-eligibility
+/// check subsumes the `pure_leaf` soundness predicate for the verbatim
+/// shape, so no interprocedural escape summary is required.
+#[must_use]
+pub fn classify_proc<S: std::hash::BuildHasher>(
+    proc: &Procedure,
+    redefined: &HashSet<String, S>,
+) -> InlineDecision {
+    if redefined.contains(&proc.qualified_name) {
+        return InlineDecision::Never;
+    }
+    if proc.body.statements.is_empty() {
+        return InlineDecision::Always;
+    }
+    if proc.params.is_empty()
+        && count_statements(&proc.body) <= SMALL_BODY_THRESHOLD
+        && proc.body.statements.iter().all(stmt_is_splice_eligible)
+    {
+        return InlineDecision::Always;
+    }
+    InlineDecision::Never
+}
+
+/// Build the qname → [`InlineSpec`] map of inlinable procedures.
+fn build_inlinable_map(module: &Module) -> HashMap<String, InlineSpec> {
+    let mut map = HashMap::new();
+    for (qname, proc) in &module.procedures {
+        if classify_proc(proc, &module.redefined_procedures) != InlineDecision::Always {
+            continue;
+        }
+        let spec = if proc.body.statements.is_empty() {
+            InlineSpec::Empty
+        } else {
+            InlineSpec::Verbatim(proc.body.statements.clone())
+        };
+        map.insert(qname.clone(), spec);
+    }
+    map
+}
+
+/// Resolve a call's head word to a procedure qname, using the same naive
+/// rule the optimiser folds use: an absolute name as-is, else rooted at
+/// `::`. (Namespace-chain resolution is the shared O103 / inliner residual.)
+fn resolve_qname(command: &str) -> String {
+    if command.starts_with("::") {
+        command.to_owned()
+    } else {
+        format!("::{command}")
+    }
+}
+
+/// Inline eligible statement-position calls throughout `module`, returning
+/// the rewritten module. Idempotent: a module with no remaining inlinable
+/// sites is returned structurally unchanged. Mirrors `inline_module`'s v0 /
+/// verbatim behaviour (v3 and dead-proc elimination are the residual).
+#[must_use]
+pub fn inline_module(mut module: Module) -> Module {
+    let inlinable = build_inlinable_map(&module);
+    if inlinable.is_empty() {
+        return module;
+    }
+    rewrite_script(&mut module.top_level, &inlinable);
+    let mut procedures = std::mem::take(&mut module.procedures);
+    for proc in procedures.values_mut() {
+        rewrite_script(&mut proc.body, &inlinable);
+    }
+    module.procedures = procedures;
+    module
+}
+
+/// Rewrite a script in place: replace each inlinable statement-position
+/// call with the proc's spliced statements (or nothing, for empty bodies),
+/// then recurse into control-flow bodies.
+fn rewrite_script(script: &mut Script, inlinable: &HashMap<String, InlineSpec>) {
+    let mut out: Vec<Statement> = Vec::with_capacity(script.statements.len());
+    for mut stmt in std::mem::take(&mut script.statements) {
+        if let Statement::Call { command, .. } = &stmt
+            && let Some(spec) = inlinable.get(&resolve_qname(command))
+        {
+            match spec {
+                InlineSpec::Empty => {} // call vanishes
+                InlineSpec::Verbatim(body) => out.extend(body.iter().cloned()),
+            }
+            continue;
+        }
+        recurse_into_bodies(&mut stmt, inlinable);
+        out.push(stmt);
+    }
+    script.statements = out;
+}
+
+/// Recurse the inliner into a compound statement's nested bodies.
+fn recurse_into_bodies(stmt: &mut Statement, inlinable: &HashMap<String, InlineSpec>) {
+    match stmt {
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            for c in clauses {
+                rewrite_script(&mut c.body, inlinable);
+            }
+            if let Some(b) = else_body {
+                rewrite_script(b, inlinable);
+            }
+        }
+        Statement::For {
+            init, next, body, ..
+        } => {
+            rewrite_script(init, inlinable);
+            rewrite_script(next, inlinable);
+            rewrite_script(body, inlinable);
+        }
+        Statement::While { body, .. }
+        | Statement::Foreach { body, .. }
+        | Statement::Catch { body, .. }
+        | Statement::Block { body, .. }
+        | Statement::UpFrame { body, .. } => rewrite_script(body, inlinable),
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            rewrite_script(body, inlinable);
+            for h in handlers {
+                rewrite_script(&mut h.body, inlinable);
+            }
+            if let Some(fb) = finally_body {
+                rewrite_script(fb, inlinable);
+            }
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            for a in arms {
+                if let Some(b) = &mut a.body {
+                    rewrite_script(b, inlinable);
+                }
+            }
+            if let Some(b) = default_body {
+                rewrite_script(b, inlinable);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compilation_unit::CompilationUnit;
+    use tcl_registry::CommandRegistry;
+
+    fn module_for(source: &str) -> Module {
+        CompilationUnit::build_for(source, &CommandRegistry::build_default(), false).ir_module
+    }
+
+    /// Count statement-position calls to `command` across the top level.
+    fn top_calls_to(module: &Module, command: &str) -> usize {
+        module
+            .top_level
+            .statements
+            .iter()
+            .filter(|s| matches!(s, Statement::Call { command: c, .. } if c == command))
+            .count()
+    }
+
+    #[test]
+    fn empty_body_call_vanishes() {
+        let module = module_for("proc ::noop {} {}\nnoop\nputs done");
+        assert_eq!(top_calls_to(&module, "noop"), 1);
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "noop"), 0, "empty-body call should vanish");
+        // The unrelated `puts done` survives.
+        assert_eq!(top_calls_to(&inlined, "puts"), 1);
+    }
+
+    #[test]
+    fn verbatim_wrapper_body_is_spliced() {
+        let module = module_for("proc ::greet {} { puts hello }\ngreet");
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "greet"), 0, "wrapper call replaced");
+        assert_eq!(
+            top_calls_to(&inlined, "puts"),
+            1,
+            "wrapper body spliced verbatim",
+        );
+    }
+
+    #[test]
+    fn multi_statement_verbatim_wrapper() {
+        let module = module_for("proc ::two {} { puts a\n puts b }\ntwo");
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "two"), 0);
+        assert_eq!(top_calls_to(&inlined, "puts"), 2, "both body stmts spliced");
+    }
+
+    #[test]
+    fn wrapper_with_defs_is_not_inlined() {
+        // `set x 1` mutates the proc frame — not splice-eligible.
+        let module = module_for("proc ::w {} { set x 1 }\nw");
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "w"), 1, "frame-mutating body kept");
+    }
+
+    #[test]
+    fn parameterised_proc_is_not_inlined() {
+        // v3 (parameters) is the residual — left intact.
+        let module = module_for("proc ::id {x} { puts $x }\nid 1");
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "id"), 1, "parameterised proc kept");
+    }
+
+    #[test]
+    fn redefined_proc_is_not_inlined() {
+        let module = module_for("proc ::r {} { puts a }\nproc ::r {} { puts b }\nr");
+        assert!(module.redefined_procedures.contains("::r"));
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "r"), 1, "redefined proc kept");
+    }
+
+    #[test]
+    fn arg_command_subst_blocks_verbatim() {
+        // `puts [clock seconds]` depends on frame command resolution.
+        let module = module_for("proc ::w {} { puts [clock seconds] }\nw");
+        let inlined = inline_module(module);
+        assert_eq!(top_calls_to(&inlined, "w"), 1);
+    }
+
+    #[test]
+    fn inline_inside_control_flow_body() {
+        let module = module_for("proc ::greet {} { puts hi }\nif {1} { greet }");
+        let inlined = inline_module(module);
+        // The `greet` call inside the `if` body is inlined to `puts hi`.
+        let if_has_puts = inlined.top_level.statements.iter().any(|s| {
+            matches!(s, Statement::If { clauses, .. }
+                if clauses.iter().any(|c| c.body.statements.iter().any(|b|
+                    matches!(b, Statement::Call { command, .. } if command == "puts"))))
+        });
+        assert!(if_has_puts, "call inside if-body should be inlined");
+    }
+
+    #[test]
+    fn count_statements_walks_nested_bodies() {
+        let module = module_for("proc ::f {} { puts a\n if {1} { puts b\n puts c } }");
+        let proc = &module.procedures["::f"];
+        // `puts a` + the `if` clause (1) + its two `puts` = 4.
+        assert_eq!(count_statements(&proc.body), 4);
+    }
+}

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -98,6 +98,7 @@ pub use tcl_syntax::expr::ast as expr_ast;
 pub use tcl_syntax::expr::parser as expr_parser;
 pub mod gvn;
 pub mod inline_uplevel;
+pub mod inlining;
 pub mod interprocedural;
 pub mod interval_bounds;
 pub mod intervals;

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -37,9 +37,9 @@ use crate::sccp::ConstantBranch;
 use tcl_lexer::Span;
 
 use super::helpers::expr_simplify::{
-    instcombine_expr_typed, numeric_var_names, substitute_expr_constants,
+    instcombine_expr_typed, numeric_var_names, substitute_expr_constants, try_fold_expr,
     try_eq_ne_string_compare_simplify_expr, try_strength_reduce_expr_typed,
-    try_strlen_simplify_expr,
+    try_strlen_simplify_expr, try_unwrap_expr_in_expr,
 };
 use super::helpers::literals::format_constant;
 use super::{Optimisation, PassContext};
@@ -103,10 +103,12 @@ fn brace_corrected_span(source: &str, span: Span) -> Span {
 /// the condition text via [`substitute_expr_constants`]. Emits
 /// `O100` on any text change.
 fn propagate_into_branches(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
+    // Note: `constants` may be empty — the cascade (strength-reduce, streq,
+    // instcombine) and the O115 redundant-`expr` unwrap still apply to a
+    // branch condition with no propagable constants, matching Python's
+    // `propagate_into_branches` (which does not gate on a non-empty constant
+    // map). Substitution is simply a no-op in that case.
     let constants = sccp_constants_for(fu);
-    if constants.is_empty() {
-        return;
-    }
     // Numeric-type context so identity rewrites (`$x + 0` → `$x`, etc.) on a
     // branch condition fire only when the dropped operand is provably numeric.
     let numeric = numeric_var_names(fu);
@@ -155,57 +157,99 @@ fn propagate_into_branches(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
         } else {
             (cond_text, false)
         };
-
-        // Cascade: substitute → strength-reduce → strlen → streq
-        // → instcombine. Each transform is a text → (text, changed)
-        // helper; the first one that changes the text wins its
-        // diagnostic code. Mirrors `optimise_branch_proc_calls`'s
-        // priority order in the Python source.
-        let (code, message, final_text) = {
-            let sub = substitute_expr_constants(inner, &constants, ctx.dialect);
-            let working = if sub.changed {
-                sub.text.clone()
+        let rewrap = |text: &str| {
+            if braced {
+                format!("{{{text}}}")
             } else {
-                inner.to_owned()
-            };
-
-            let (sred, sred_changed) = try_strength_reduce_expr_typed(&working, Some(&numeric));
-            if sred_changed {
-                ("O113", "Strength-reduce expression", sred)
-            } else {
-                let (slen, slen_changed) = try_strlen_simplify_expr(&working);
-                if slen_changed {
-                    ("O117", "Simplify string length zero-check", slen)
-                } else {
-                    let (streq, streq_changed) = try_eq_ne_string_compare_simplify_expr(&working);
-                    if streq_changed {
-                        ("O120", "Use eq/ne for string comparison", streq)
-                    } else {
-                        let (combined, combined_changed) =
-                            instcombine_expr_typed(&working, true, Some(&numeric));
-                        if combined_changed {
-                            ("O110", "Canonicalise expression (InstCombine)", combined)
-                        } else if sub.changed {
-                            (
-                                "O100",
-                                "Propagate constants into branch expression",
-                                sub.text,
-                            )
-                        } else {
-                            continue;
-                        }
-                    }
-                }
+                text.to_owned()
             }
         };
 
-        let replacement = if braced {
-            format!("{{{final_text}}}")
+        // O115: a branch condition that is itself a redundant `[expr {…}]`
+        // wrapper (`if {[expr {$x}]} …`) unwraps to its inner expression.
+        // Checked before the constant cascade, mirroring the Python order.
+        if let Some(unwrapped) = try_unwrap_expr_in_expr(inner)
+            && unwrapped != inner
+        {
+            ctx.report(Optimisation::new(
+                "O115",
+                "Remove redundant nested expr",
+                span,
+                rewrap(&unwrapped),
+            ));
+            continue;
+        }
+
+        // Cascade: substitute → strength-reduce → strlen → streq →
+        // instcombine, with an O101 fold short-circuit. Mirrors
+        // `optimise_branch_proc_calls`'s priority order in the Python source.
+        let sub = substitute_expr_constants(inner, &constants, ctx.dialect);
+        let working = if sub.changed {
+            sub.text.clone()
         } else {
-            final_text
+            inner.to_owned()
         };
-        ctx.report(Optimisation::new(code, message, span, replacement));
+
+        // O101: if constant propagation makes the whole condition fold to a
+        // literal (`if {$flag > 0}` with `flag == 1` → `1`), emit the fold in
+        // preference to the partial-canonicalisation codes. Mirrors Python's
+        // `_try_fold_expr(combined)` branch.
+        if sub.changed
+            && let Some(folded) = try_fold_expr(&working, ctx.dialect)
+            && folded != inner
+        {
+            ctx.report(Optimisation::new(
+                "O101",
+                "Fold constant expression",
+                span,
+                rewrap(&folded),
+            ));
+            continue;
+        }
+
+        let Some((code, message, final_text)) =
+            branch_cascade(&working, sub.changed, &sub.text, &numeric)
+        else {
+            continue;
+        };
+        ctx.report(Optimisation::new(code, message, span, rewrap(&final_text)));
     }
+}
+
+/// The branch-condition simplification cascade: the first transform that
+/// changes `working` wins its diagnostic code. Returns `None` when nothing
+/// applies. `sub_changed`/`sub_text` carry the constant-substitution result
+/// so a pure substitution (no further simplification) still emits O100.
+fn branch_cascade(
+    working: &str,
+    sub_changed: bool,
+    sub_text: &str,
+    numeric: &HashSet<String>,
+) -> Option<(&'static str, &'static str, String)> {
+    let (sred, sred_changed) = try_strength_reduce_expr_typed(working, Some(numeric));
+    if sred_changed {
+        return Some(("O113", "Strength-reduce expression", sred));
+    }
+    let (slen, slen_changed) = try_strlen_simplify_expr(working);
+    if slen_changed {
+        return Some(("O117", "Simplify string length zero-check", slen));
+    }
+    let (streq, streq_changed) = try_eq_ne_string_compare_simplify_expr(working);
+    if streq_changed {
+        return Some(("O120", "Use eq/ne for string comparison", streq));
+    }
+    let (combined, combined_changed) = instcombine_expr_typed(working, true, Some(numeric));
+    if combined_changed {
+        return Some(("O110", "Canonicalise expression (InstCombine)", combined));
+    }
+    if sub_changed {
+        return Some((
+            "O100",
+            "Propagate constants into branch expression",
+            sub_text.to_owned(),
+        ));
+    }
+    None
 }
 
 fn is_switch_dispatch_cond(cond: &ExprNode) -> bool {
@@ -874,5 +918,25 @@ mod tests {
             "expected an O101 fold via run_passes, got {:?}",
             ctx.optimisations,
         );
+    }
+
+    #[test]
+    fn branch_condition_redundant_expr_emits_o115() {
+        // `if {[expr {$x}]} …` — the condition is a redundant `[expr {…}]`
+        // wrapper; it unwraps to `$x`. Exercised at top level (proc bodies
+        // with a returning branch collapse to a straight CFG).
+        let cu = CompilationUnit::build_for(
+            "if {[expr {$x}]} { puts a } else { puts b }",
+            &registry(),
+            false,
+        );
+        let mut ctx = build_ctx(&cu.source);
+        super::super::run_passes(&mut ctx, &cu, &[PassId::BranchFolding]);
+        let o115 = ctx
+            .optimisations
+            .iter()
+            .find(|o| o.code == "O115")
+            .expect("expected an O115 unwrap on the branch condition");
+        assert_eq!(o115.replacement, "{$x}");
     }
 }

--- a/rust/tcl-compiler/src/optimiser/chain_fold.rs
+++ b/rust/tcl-compiler/src/optimiser/chain_fold.rs
@@ -41,7 +41,7 @@
 
 use std::collections::HashSet;
 
-use tcl_lexer::{Span, TokenType};
+use tcl_lexer::TokenType;
 
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::ir::{Script, Statement};
@@ -49,7 +49,7 @@ use crate::naming::normalise_var_name;
 use crate::var_observability::analyse_var_observability;
 
 use super::helpers::literals::render_static_string_word;
-use super::helpers::spans::full_rewrite_span;
+use super::helpers::spans::{full_rewrite_span, statement_delete_rewrite_range};
 use super::{Optimisation, PassContext};
 
 /// Run the chain-fold pass over the whole compilation unit.
@@ -338,44 +338,6 @@ fn try_fold_chain_at(
 /// leading `#`), so `list_element`'s first-element rule is equivalent here.
 fn render_list_word(elements: &[String]) -> String {
     tcl_syntax::list::list_element(&tcl_syntax::list::join_list(elements))
-}
-
-/// Compute the deletion range for an intermediate write, swallowing the
-/// trailing run of whitespace plus one statement separator (`\n` / `;`) so
-/// the surviving text closes up cleanly. Mirrors
-/// `_statement_delete_rewrite_range`.
-///
-/// `cmd_span` is the full command span (exclusive end); `next_start` is
-/// the byte offset of the next statement, or `None` at end-of-script.
-fn statement_delete_rewrite_range(
-    source: &str,
-    cmd_span: Span,
-    next_start: Option<usize>,
-) -> Span {
-    let Some(next) = next_start else {
-        return cmd_span;
-    };
-    let end = cmd_span.end() as usize;
-    if next <= end || next > source.len() {
-        return cmd_span;
-    }
-    let bytes = source.as_bytes();
-    let mut cursor = end;
-    while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
-        cursor += 1;
-    }
-    if cursor < next && matches!(bytes[cursor], b'\n' | b';') {
-        cursor += 1;
-        while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
-            cursor += 1;
-        }
-        if cursor > end
-            && let Ok(new_end) = u32::try_from(cursor)
-        {
-            return Span::new(cmd_span.start(), new_end);
-        }
-    }
-    cmd_span
 }
 
 #[cfg(test)]

--- a/rust/tcl-compiler/src/optimiser/chain_fold.rs
+++ b/rust/tcl-compiler/src/optimiser/chain_fold.rs
@@ -1,0 +1,509 @@
+//! O104 / O130 — write-only build-chain folding.
+//!
+//! Ported (sound subset) from `optimise_string_build_chains` in
+//! `core/compiler/optimiser/_pattern_recognition.py`.
+//!
+//! Collapses a run of consecutive static writes to one variable into a
+//! single `set`:
+//!
+//! ```tcl
+//! set s ""        ;# →  set s "foobar"
+//! append s foo
+//! append s bar
+//! ```
+//! ```tcl
+//! set l {}        ;# →  set l {a b c}
+//! lappend l a
+//! lappend l b c
+//! ```
+//!
+//! `O104` folds string-concat (`append`) chains; `O130` folds list
+//! (`lappend`) chains. The fold emits a `set` rewrite over the *last*
+//! write and a paired deletion over each earlier one, all sharing one
+//! group so they apply atomically.
+//!
+//! ## Soundness gates
+//!
+//! - The writes must be **strictly consecutive** — no statement runs
+//!   between them, so no intermediate value can be observed (the
+//!   `var_observability` flow-sensitive read check Python performs is
+//!   subsumed: a read between writes would be a non-write statement and
+//!   ends the run).
+//! - Every value word must be a static literal (`Esc`/`Str` single-token
+//!   word); a `$var` / `[cmd]` operand ends the run.
+//! - The variable must not **escape** (be aliased via
+//!   `global`/`upvar`/`variable` or be under a `trace`) and must not be a
+//!   cross-event iRules state variable — folding would drop a trace
+//!   callback or a value a later scope / event observes.
+//!
+//! These gates make the fold conservative (it can miss a chain Python's
+//! flow-sensitive pass would fold) but never unsound.
+
+use std::collections::HashSet;
+
+use tcl_lexer::{Span, TokenType};
+
+use crate::compilation_unit::{CompilationUnit, FunctionUnit};
+use crate::ir::{Script, Statement};
+use crate::naming::normalise_var_name;
+use crate::var_observability::analyse_var_observability;
+
+use super::helpers::literals::render_static_string_word;
+use super::helpers::spans::full_rewrite_span;
+use super::{Optimisation, PassContext};
+
+/// Run the chain-fold pass over the whole compilation unit.
+pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
+    let cross = ctx.cross_event_vars.clone();
+    let top_protected = protected_vars(&cu.top_level, &cross);
+    fold_script(ctx, &cu.ir_module.top_level, &top_protected);
+    for (qname, proc) in &cu.ir_module.procedures {
+        let protected = cu
+            .procedures
+            .get(qname)
+            .map_or_else(|| cross.clone(), |fu| protected_vars(fu, &cross));
+        fold_script(ctx, &proc.body, &protected);
+    }
+}
+
+/// Variables that must never have a write-chain folded: those that escape
+/// the frame (aliased / traced) plus the iRules cross-event state set.
+fn protected_vars(fu: &FunctionUnit, cross_event: &HashSet<String>) -> HashSet<String> {
+    let mut set = analyse_var_observability(&fu.cfg).escaping_var_names();
+    set.extend(cross_event.iter().cloned());
+    set
+}
+
+/// Fold chains in `script`, then recurse into control-flow bodies (a
+/// chain never crosses a control-flow boundary, so each body is folded
+/// independently).
+fn fold_script(ctx: &mut PassContext<'_>, script: &Script, protected: &HashSet<String>) {
+    let stmts = &script.statements;
+    let mut i = 0;
+    while i < stmts.len() {
+        if let Some(consumed) = try_fold_chain_at(ctx, stmts, i, protected) {
+            i += consumed;
+        } else {
+            i += 1;
+        }
+    }
+    for stmt in stmts {
+        match stmt {
+            Statement::If {
+                clauses, else_body, ..
+            } => {
+                for c in clauses {
+                    fold_script(ctx, &c.body, protected);
+                }
+                if let Some(b) = else_body {
+                    fold_script(ctx, b, protected);
+                }
+            }
+            Statement::For {
+                init, next, body, ..
+            } => {
+                fold_script(ctx, init, protected);
+                fold_script(ctx, next, protected);
+                fold_script(ctx, body, protected);
+            }
+            Statement::While { body, .. }
+            | Statement::Catch { body, .. }
+            | Statement::Foreach { body, .. } => fold_script(ctx, body, protected),
+            Statement::Try {
+                body,
+                handlers,
+                finally_body,
+                ..
+            } => {
+                fold_script(ctx, body, protected);
+                for h in handlers {
+                    fold_script(ctx, &h.body, protected);
+                }
+                if let Some(fb) = finally_body {
+                    fold_script(ctx, fb, protected);
+                }
+            }
+            Statement::Switch {
+                arms, default_body, ..
+            } => {
+                for a in arms {
+                    if let Some(b) = &a.body {
+                        fold_script(ctx, b, protected);
+                    }
+                }
+                if let Some(b) = default_body {
+                    fold_script(ctx, b, protected);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// A single static write to a variable.
+enum Write {
+    /// `set var <static>` — establishes the chain's initial value.
+    Set { var: String, value: String },
+    /// `append var <static>…` — string-concat extension.
+    Append {
+        var: String,
+        word: String,
+        pieces: Vec<String>,
+    },
+    /// `lappend var <static>…` — list extension.
+    Lappend {
+        var: String,
+        word: String,
+        elements: Vec<String>,
+    },
+}
+
+/// Classify `stmt` as a static write, or `None` for anything else
+/// (dynamic operand, other command, control flow).
+fn classify_write(stmt: &Statement) -> Option<Write> {
+    match stmt {
+        Statement::AssignConst { name, value, .. } => Some(Write::Set {
+            var: normalise_var_name(name).to_owned(),
+            value: value.clone(),
+        }),
+        // `set s ""` / `set s foo` lower to `AssignValue`; only a static
+        // single-token literal value (no command/var substitution) anchors
+        // a foldable chain.
+        Statement::AssignValue {
+            name,
+            value,
+            value_needs_backsubst,
+            tokens,
+            ..
+        } => {
+            if *value_needs_backsubst {
+                return None;
+            }
+            let tokens = tokens.as_ref()?;
+            let kind = tokens.argv_kinds.get(2)?;
+            let single = tokens.single_token_word.get(2).copied()?;
+            if !single || !matches!(kind, TokenType::Esc | TokenType::Str) {
+                return None;
+            }
+            Some(Write::Set {
+                var: normalise_var_name(name).to_owned(),
+                value: value.clone(),
+            })
+        }
+        Statement::Call {
+            command,
+            args,
+            tokens,
+            ..
+        } if matches!(command.as_str(), "set" | "append" | "lappend") => {
+            let tokens = tokens.as_ref()?;
+            // Value words are argv index `vararg + 1 ..` (argv[0] is the
+            // command, argv[1] is the variable).
+            let var_word = args.first()?.clone();
+            let var = normalise_var_name(&var_word).to_owned();
+            let value_words = &args[1..];
+            let mut values = Vec::with_capacity(value_words.len());
+            for (j, val) in value_words.iter().enumerate() {
+                let argv_idx = j + 2; // skip command + variable
+                let kind = tokens.argv_kinds.get(argv_idx)?;
+                let single = tokens.single_token_word.get(argv_idx).copied()?;
+                if !single || !matches!(kind, TokenType::Esc | TokenType::Str) {
+                    return None;
+                }
+                values.push(val.clone());
+            }
+            match command.as_str() {
+                "set" if values.len() == 1 => Some(Write::Set {
+                    var,
+                    value: values.into_iter().next().unwrap(),
+                }),
+                "append" if !values.is_empty() => Some(Write::Append {
+                    var,
+                    word: var_word,
+                    pieces: values,
+                }),
+                "lappend" if !values.is_empty() => Some(Write::Lappend {
+                    var,
+                    word: var_word,
+                    elements: values,
+                }),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Attempt to fold a write-chain starting at `stmts[start]`. Returns the
+/// number of statements consumed (the run length) when a fold fires, else
+/// `None`.
+fn try_fold_chain_at(
+    ctx: &mut PassContext<'_>,
+    stmts: &[Statement],
+    start: usize,
+    protected: &HashSet<String>,
+) -> Option<usize> {
+    let Write::Set { var, value } = classify_write(&stmts[start])? else {
+        return None;
+    };
+
+    let mut chain_value = value;
+    let mut elements: Option<Vec<String>> = None;
+    let mut writes = vec![start];
+    let mut last_word: Option<String> = None;
+
+    let mut j = start + 1;
+    while j < stmts.len() {
+        match classify_write(&stmts[j]) {
+            Some(Write::Append { var: v, word, pieces }) if v == var && elements.is_none() => {
+                for p in pieces {
+                    chain_value.push_str(&p);
+                }
+                last_word = Some(word);
+                writes.push(j);
+                j += 1;
+            }
+            Some(Write::Lappend {
+                var: v,
+                word,
+                elements: els,
+            }) if v == var => {
+                if elements.is_none() {
+                    // First lappend after the set — reinterpret the current
+                    // string value as a list (bail if it is not one).
+                    let Ok(base) = tcl_syntax::list::split_list(&chain_value) else {
+                        break;
+                    };
+                    elements = Some(base.into_iter().map(std::borrow::Cow::into_owned).collect());
+                }
+                if let Some(list) = elements.as_mut() {
+                    list.extend(els);
+                }
+                last_word = Some(word);
+                writes.push(j);
+                j += 1;
+            }
+            _ => break,
+        }
+    }
+
+    if writes.len() < 2 || protected.contains(&var) {
+        return None;
+    }
+    // `last_word` is always set: a run of ≥2 writes has at least one
+    // append/lappend after the anchoring set.
+    let var_word = last_word?;
+
+    let (code, fold_msg, dead_msg, rendered) = if let Some(els) = &elements {
+        (
+            "O130",
+            "Fold write-only list build chain",
+            "Remove dead intermediate list write",
+            render_list_word(els),
+        )
+    } else {
+        (
+            "O104",
+            "Fold write-only string build chain",
+            "Remove dead intermediate string write",
+            render_static_string_word(&chain_value)?,
+        )
+    };
+
+    let source = ctx.source;
+    let group = ctx.alloc_group();
+
+    let last = *writes.last().unwrap();
+    let last_span = full_rewrite_span(source, stmts[last].span());
+    let mut fold = Optimisation::new(code, fold_msg, last_span, format!("set {var_word} {rendered}"));
+    fold.group = Some(group);
+    ctx.report(fold);
+
+    for &w in &writes[..writes.len() - 1] {
+        let full = full_rewrite_span(source, stmts[w].span());
+        let next_start = stmts.get(w + 1).map(|s| s.span().start() as usize);
+        let del_span = statement_delete_rewrite_range(source, full, next_start);
+        let mut del = Optimisation::new(code, dead_msg, del_span, "");
+        del.group = Some(group);
+        ctx.report(del);
+    }
+
+    Some(writes.len())
+}
+
+/// Render `elements` as the single `set` value-word that recreates the
+/// list — join into a canonical Tcl list, then quote that as one element.
+/// Mirrors `_render_list_word` (`tcl_list_quote(tcl_list_join(...))`); the
+/// joined string never begins with a bare `#` (the join already quotes a
+/// leading `#`), so `list_element`'s first-element rule is equivalent here.
+fn render_list_word(elements: &[String]) -> String {
+    tcl_syntax::list::list_element(&tcl_syntax::list::join_list(elements))
+}
+
+/// Compute the deletion range for an intermediate write, swallowing the
+/// trailing run of whitespace plus one statement separator (`\n` / `;`) so
+/// the surviving text closes up cleanly. Mirrors
+/// `_statement_delete_rewrite_range`.
+///
+/// `cmd_span` is the full command span (exclusive end); `next_start` is
+/// the byte offset of the next statement, or `None` at end-of-script.
+fn statement_delete_rewrite_range(
+    source: &str,
+    cmd_span: Span,
+    next_start: Option<usize>,
+) -> Span {
+    let Some(next) = next_start else {
+        return cmd_span;
+    };
+    let end = cmd_span.end() as usize;
+    if next <= end || next > source.len() {
+        return cmd_span;
+    }
+    let bytes = source.as_bytes();
+    let mut cursor = end;
+    while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+        cursor += 1;
+    }
+    if cursor < next && matches!(bytes[cursor], b'\n' | b';') {
+        cursor += 1;
+        while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+            cursor += 1;
+        }
+        if cursor > end
+            && let Ok(new_end) = u32::try_from(cursor)
+        {
+            return Span::new(cmd_span.start(), new_end);
+        }
+    }
+    cmd_span
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interprocedural::InterproceduralAnalysis;
+    use tcl_registry::CommandRegistry;
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    fn run_pass(source: &str) -> Vec<Optimisation> {
+        let cu = CompilationUnit::build_for(source, &registry(), false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        run(&mut ctx, &cu);
+        ctx.optimisations
+    }
+
+    /// Apply every grouped O104/O130 rewrite to `source` (reverse offset
+    /// order so earlier edits don't shift later spans) and return the
+    /// rewritten text.
+    fn apply(source: &str) -> String {
+        let mut opts: Vec<Optimisation> = run_pass(source)
+            .into_iter()
+            .filter(|o| o.code == "O104" || o.code == "O130")
+            .collect();
+        opts.sort_by_key(|o| std::cmp::Reverse(o.span.start()));
+        let mut out = source.to_owned();
+        for o in opts {
+            out.replace_range(o.span.start() as usize..o.span.end() as usize, &o.replacement);
+        }
+        out
+    }
+
+    #[test]
+    fn string_chain_folds_to_single_set() {
+        let opts = run_pass("set s \"\"\nappend s foo\nappend s bar");
+        let fold = opts
+            .iter()
+            .find(|o| o.code == "O104" && o.replacement.starts_with("set"))
+            .expect("expected an O104 fold");
+        assert_eq!(fold.replacement, "set s foobar");
+        // One fold + two deletions, all in one group.
+        let o104: Vec<_> = opts.iter().filter(|o| o.code == "O104").collect();
+        assert_eq!(o104.len(), 3);
+        let groups: HashSet<_> = o104.iter().filter_map(|o| o.group).collect();
+        assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn string_chain_rewrite_applies_cleanly() {
+        assert_eq!(apply("set s \"\"\nappend s foo\nappend s bar"), "set s foobar");
+        assert_eq!(
+            apply("set s start\nappend s _mid\nappend s _end"),
+            "set s start_mid_end",
+        );
+    }
+
+    #[test]
+    fn list_chain_folds_with_lappend() {
+        assert_eq!(apply("set l {}\nlappend l a\nlappend l b c"), "set l {a b c}");
+    }
+
+    #[test]
+    fn list_chain_quotes_spacey_elements() {
+        // An element containing a space must be re-quoted as a list word.
+        assert_eq!(apply("set l {}\nlappend l {a b}\nlappend l c"), "set l {{a b} c}");
+    }
+
+    #[test]
+    fn single_write_does_not_fold() {
+        let opts = run_pass("set s \"\"\nappend s foo");
+        // set + one append = 2 writes → folds. (Mirrors Python's >= 2 gate.)
+        assert!(opts.iter().any(|o| o.code == "O104"));
+        // But a lone set is not a chain.
+        let opts = run_pass("set s foo");
+        assert!(opts.iter().all(|o| o.code != "O104"));
+    }
+
+    #[test]
+    fn dynamic_value_ends_the_run() {
+        // `append s $x` is dynamic — the chain stops before it, and the
+        // `set; append foo` prefix (2 writes) still folds.
+        let opts = run_pass("set s \"\"\nappend s foo\nappend s $x");
+        assert!(opts.iter().any(|o| o.code == "O104" && o.replacement == "set s foo"));
+    }
+
+    #[test]
+    fn intervening_read_ends_the_run_but_folds_prefix() {
+        // `puts $s` reads the accumulator, ending the run after `append s
+        // foo`. The consecutive prefix still folds to `set s foo` (the same
+        // value `puts` observes); the trailing `append s bar` is not folded
+        // into it. Matches Python's `finish_chain`-on-read behaviour.
+        let opts = run_pass("set s \"\"\nappend s foo\nputs $s\nappend s bar");
+        let folds: Vec<&str> = opts
+            .iter()
+            .filter(|o| o.code == "O104" && o.replacement.starts_with("set"))
+            .map(|o| o.replacement.as_str())
+            .collect();
+        assert_eq!(folds, ["set s foo"], "got {opts:?}");
+    }
+
+    #[test]
+    fn escaping_global_var_not_folded() {
+        // `s` is global — every write is visible to other scopes.
+        let opts = run_pass("proc ::f {} { global s\nset s \"\"\nappend s foo\nappend s bar }");
+        assert!(
+            opts.iter().all(|o| o.code != "O104"),
+            "global var must not fold, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn cross_event_var_not_folded() {
+        let src = "set s \"\"\nappend s foo\nappend s bar";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        ctx.cross_event_vars.insert("s".to_owned());
+        run(&mut ctx, &cu);
+        assert!(ctx.optimisations.iter().all(|o| o.code != "O104"));
+    }
+
+    #[test]
+    fn folds_inside_proc_body() {
+        assert_eq!(
+            apply("proc ::f {} {\n    set s \"\"\n    append s a\n    append s b\n}"),
+            "proc ::f {} {\n    set s ab\n}",
+        );
+    }
+}

--- a/rust/tcl-compiler/src/optimiser/chain_fold.rs
+++ b/rust/tcl-compiler/src/optimiser/chain_fold.rs
@@ -158,6 +158,13 @@ enum Write {
     },
 }
 
+/// The (normalised) target variable name of a classified write.
+fn write_var(w: &Write) -> &str {
+    match w {
+        Write::Set { var, .. } | Write::Append { var, .. } | Write::Lappend { var, .. } => var,
+    }
+}
+
 /// Classify `stmt` as a static write, or `None` for anything else
 /// (dynamic operand, other command, control flow).
 fn classify_write(stmt: &Statement) -> Option<Write> {
@@ -283,6 +290,16 @@ fn try_fold_chain_at(
                 writes.push(j);
                 j += 1;
             }
+            // Precise-flow (O104/O130): a *static-literal* write to a
+            // **different** variable cannot read or write the accumulator,
+            // has no side effect, and is not a barrier (`classify_write`
+            // only matches single-token `Esc`/`Str` value words with no
+            // substitution), so the chain continues past it — the
+            // interleaved statement stays in place and is not folded.
+            // Mirrors Python's "skip a non-reading statement" chain rule.
+            Some(other) if write_var(&other) != var => {
+                j += 1;
+            }
             _ => break,
         }
     }
@@ -395,6 +412,31 @@ mod tests {
             apply("set s start\nappend s _mid\nappend s _end"),
             "set s start_mid_end",
         );
+    }
+
+    #[test]
+    fn chain_continues_past_interleaved_literal_set() {
+        // `set t 1` writes a *different* variable with a static literal, so
+        // the build chain folds across it (precise-flow); the interleaved
+        // statement stays in place.
+        assert_eq!(
+            apply("set s \"\"\nset t 1\nappend s foo\nappend s bar"),
+            "set t 1\nset s foobar",
+        );
+    }
+
+    #[test]
+    fn chain_breaks_on_interleaved_dynamic_statement() {
+        // A `puts $s` reads the accumulator — `classify_write` returns
+        // None for it, so the chain must NOT fold across it (only the
+        // trailing two appends, which is a fresh sub-chain of length < 2).
+        let opts = run_pass("set s \"\"\nputs $s\nappend s foo\nappend s bar");
+        let fold = opts
+            .iter()
+            .find(|o| o.code == "O104" && o.replacement.starts_with("set s"));
+        // The `set s ""; puts $s` prefix breaks; the two trailing appends
+        // have no anchoring `set`, so no fold fires.
+        assert!(fold.is_none(), "must not fold across a reader, got {opts:?}");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/code_sinking.rs
+++ b/rust/tcl-compiler/src/optimiser/code_sinking.rs
@@ -50,6 +50,13 @@ fn walk_script(ctx: &mut PassContext<'_>, script: &Script) {
         let Some((var, span)) = sinkable_assignment(stmt) else {
             continue;
         };
+        // A variable that carries state across `when <event>` boundaries
+        // (iRules) is observable after this event handler returns, so its
+        // definition must not be sunk into a branch that may not run.
+        // Mirrors Python's `var_name in ctx.cross_event_vars` guard.
+        if ctx.cross_event_vars.contains(&var) {
+            continue;
+        }
         let decision = &stmts[i + 1];
         if !is_decision(decision) {
             continue;
@@ -484,6 +491,23 @@ mod tests {
         assert!(
             opts.iter().any(|o| o.code == "O125"),
             "expected an O125 diagnostic, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn cross_event_var_is_not_sunk() {
+        // `x` carries state across iRules `when` events, so its definition
+        // must stay where every later event can observe it — never sunk
+        // into a branch that might not run.
+        let src = "proc ::f {flag} { set x 1; if {$flag} { puts $x } else { puts no } }";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        ctx.cross_event_vars.insert("x".to_owned());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != "O125"),
+            "cross-event var must not be sunk, got {:?}",
+            ctx.optimisations,
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/code_sinking.rs
+++ b/rust/tcl-compiler/src/optimiser/code_sinking.rs
@@ -143,10 +143,13 @@ fn walk_script(ctx: &mut PassContext<'_>, script: &Script) {
     }
 }
 
-/// Emit the O125 sink. When the original statement's source
-/// text can be recovered, emits a grouped pair of rewrites
-/// (delete original + prepend to target body's first statement).
-/// Otherwise falls back to a single hint-only diagnostic.
+/// Emit the O125 sink. The assignment is sunk into the **deepest** branch
+/// body that uses `var`, in **every** branch that uses it (a decision with
+/// the var live in both arms duplicates the def into each). When the
+/// original source text can be recovered, emits a grouped delete + one
+/// prepend per target; otherwise falls back to a single hint-only
+/// diagnostic. Mirrors Python's `_find_deepest_sink_targets` /
+/// `_emit_sinking_opts`.
 fn emit_sink(
     ctx: &mut PassContext<'_>,
     original: &Statement,
@@ -154,33 +157,37 @@ fn emit_sink(
     decision: &Statement,
     var: &str,
 ) {
-    let source_text = extract_source(ctx.source, original_span);
-    let target_first_stmt = find_target_first_stmt(decision, var);
-
     let _ = original;
-    if let (Some(set_text), Some(first)) = (source_text, target_first_stmt) {
+    let targets = decision_sink_targets(decision, var);
+    let target_spans: Vec<tcl_lexer::Span> = targets.iter().map(|s| s.span()).collect();
+
+    if let Some(set_text) = extract_source(ctx.source, original_span)
+        && !target_spans.is_empty()
+        && target_spans
+            .iter()
+            .all(|s| extract_source(ctx.source, *s).is_some())
+    {
         let group = ctx.alloc_group();
         let mut del = Optimisation::new(
             "O125",
-            format!("Sink '{var}' into its single consumer — delete original"),
+            format!("Sink '{var}' into the branch(es) that use it — delete original"),
             original_span,
             "",
         );
         del.group = Some(group);
         ctx.report(del);
 
-        // Prepend the original set statement's source text
-        // plus a separator to the target body's first stmt.
-        let first_span = first.span();
-        let first_text = extract_source(ctx.source, first_span).unwrap_or_default();
-        let mut ins = Optimisation::new(
-            "O125",
-            format!("Sink '{var}' into its single consumer — prepend in branch"),
-            first_span,
-            format!("{set_text}; {first_text}"),
-        );
-        ins.group = Some(group);
-        ctx.report(ins);
+        for span in target_spans {
+            let first_text = extract_source(ctx.source, span).unwrap_or_default();
+            let mut ins = Optimisation::new(
+                "O125",
+                format!("Sink '{var}' into branch — prepend in target body"),
+                span,
+                format!("{set_text}; {first_text}"),
+            );
+            ins.group = Some(group);
+            ctx.report(ins);
+        }
     } else {
         // Fallback: hint-only.
         let mut opt = Optimisation::new(
@@ -191,6 +198,106 @@ fn emit_sink(
         );
         opt.hint_only = true;
         ctx.report(opt);
+    }
+}
+
+/// Collect the sink-target anchor statements for `decision`: for each
+/// branch body that uses `var`, the deepest first-using statement (a
+/// single-use branch whose lone consumer is itself a decision descends
+/// further). Mirrors the per-branch `_find_deepest_sink_targets` fan-out.
+fn decision_sink_targets<'a>(decision: &'a Statement, var: &str) -> Vec<&'a Statement> {
+    let mut targets = Vec::new();
+    for body in decision_branch_bodies(decision) {
+        targets.extend(find_deepest_targets(body, var));
+    }
+    targets
+}
+
+/// The branch bodies of a decision statement (if clauses + else; switch
+/// arms + default).
+fn decision_branch_bodies(decision: &Statement) -> Vec<&Script> {
+    let mut bodies = Vec::new();
+    match decision {
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            for c in clauses {
+                bodies.push(&c.body);
+            }
+            if let Some(b) = else_body {
+                bodies.push(b);
+            }
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            for a in arms {
+                if let Some(b) = &a.body {
+                    bodies.push(b);
+                }
+            }
+            if let Some(b) = default_body {
+                bodies.push(b);
+            }
+        }
+        _ => {}
+    }
+    bodies
+}
+
+/// Deepest sink targets within a single body. When exactly one statement
+/// uses `var` (and no earlier statement redefines it), and that statement
+/// is itself a decision the var's condition does not read, descend into
+/// its branches; otherwise anchor at the first using statement of this
+/// body. Mirrors `_find_deepest_sink_targets`.
+fn find_deepest_targets<'a>(body: &'a Script, var: &str) -> Vec<&'a Statement> {
+    let using: Vec<usize> = body
+        .statements
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| statement_uses_var(s, var))
+        .map(|(i, _)| i)
+        .collect();
+    let Some(&first) = using.first() else {
+        return Vec::new();
+    };
+    if using.len() == 1 {
+        let no_prior_redefine = !body.statements[..first]
+            .iter()
+            .any(|s| statement_defines_var(s, var));
+        if no_prior_redefine && is_decision(&body.statements[first]) {
+            let deeper = try_deeper_sink(&body.statements[first], var);
+            if !deeper.is_empty() {
+                return deeper;
+            }
+        }
+    }
+    vec![&body.statements[first]]
+}
+
+/// Descend into a decision's branches for a deeper sink — but only when
+/// the var's value is not read by any condition (which would make sinking
+/// past it unsound). Mirrors `_try_deeper_sink`.
+fn try_deeper_sink<'a>(stmt: &'a Statement, var: &str) -> Vec<&'a Statement> {
+    if decision_condition_uses_var(stmt, var) {
+        return Vec::new();
+    }
+    let mut targets = Vec::new();
+    for body in decision_branch_bodies(stmt) {
+        targets.extend(find_deepest_targets(body, var));
+    }
+    targets
+}
+
+/// Whether `stmt` writes `var` (an assignment to it, or a call whose
+/// `defs` include it).
+fn statement_defines_var(stmt: &Statement, var: &str) -> bool {
+    match stmt {
+        Statement::AssignConst { name, .. }
+        | Statement::AssignValue { name, .. }
+        | Statement::AssignExpr { name, .. } => name == var,
+        Statement::Call { defs, .. } => defs.iter().any(|d| d == var),
+        _ => false,
     }
 }
 
@@ -205,54 +312,6 @@ fn extract_source(source: &str, span: tcl_lexer::Span) -> Option<String> {
     Some(source[range].to_owned())
 }
 
-/// Walk `decision` looking for the first statement of any
-/// branch body that references `var`. Returns a reference to
-/// that statement (used by `emit_sink` to anchor the insertion
-/// rewrite).
-fn find_target_first_stmt<'a>(decision: &'a Statement, var: &str) -> Option<&'a Statement> {
-    match decision {
-        Statement::If {
-            clauses, else_body, ..
-        } => {
-            for c in clauses {
-                if let Some(s) = first_stmt_using(&c.body, var) {
-                    return Some(s);
-                }
-            }
-            if let Some(b) = else_body
-                && let Some(s) = first_stmt_using(b, var)
-            {
-                return Some(s);
-            }
-            None
-        }
-        Statement::Switch {
-            arms, default_body, ..
-        } => {
-            for a in arms {
-                if let Some(b) = &a.body
-                    && let Some(s) = first_stmt_using(b, var)
-                {
-                    return Some(s);
-                }
-            }
-            if let Some(b) = default_body
-                && let Some(s) = first_stmt_using(b, var)
-            {
-                return Some(s);
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn first_stmt_using<'a>(script: &'a Script, var: &str) -> Option<&'a Statement> {
-    script
-        .statements
-        .iter()
-        .find(|s| statement_uses_var(s, var))
-}
 
 /// Return `Some((var_name, stmt_span))` if `stmt` is a
 /// side-effect-free assignment whose defined variable is
@@ -501,6 +560,43 @@ mod tests {
             opts.iter().any(|o| o.code == "O125"),
             "expected an O125 diagnostic, got {opts:?}",
         );
+    }
+
+    #[test]
+    fn sinks_into_both_using_branches() {
+        // `$x` is used in *both* the if-body and the else-body, so the def
+        // is sunk (duplicated) into each — two grouped inserts + one delete.
+        let opts = run_pass(
+            "proc ::f {flag} { set x 1; if {$flag} { puts $x } else { puts $x } }",
+        );
+        let inserts = opts
+            .iter()
+            .filter(|o| o.code == "O125" && o.replacement.contains("set x 1"))
+            .count();
+        assert_eq!(inserts, 2, "expected a sink into each branch, got {opts:?}");
+        // Exactly one delete of the original.
+        let deletes = opts
+            .iter()
+            .filter(|o| o.code == "O125" && o.replacement.is_empty() && !o.hint_only)
+            .count();
+        assert_eq!(deletes, 1);
+    }
+
+    #[test]
+    fn sinks_deeper_into_nested_decision() {
+        // `$x` is used only inside a nested `if` within the outer if-body —
+        // the def sinks all the way into the inner branch.
+        let opts = run_pass(
+            "proc ::f {a b} { set x 1; if {$a} { if {$b} { puts $x } } else { puts no } }",
+        );
+        // The deepest insert target is the inner `puts $x`; the sunk text
+        // must be prepended there (its slice contains the inner puts).
+        let deep = opts.iter().any(|o| {
+            o.code == "O125"
+                && o.replacement.starts_with("set x 1;")
+                && o.replacement.contains("puts $x")
+        });
+        assert!(deep, "expected a deep sink into the inner branch, got {opts:?}");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/code_sinking.rs
+++ b/rust/tcl-compiler/src/optimiser/code_sinking.rs
@@ -57,6 +57,15 @@ fn walk_script(ctx: &mut PassContext<'_>, script: &Script) {
         if ctx.cross_event_vars.contains(&var) {
             continue;
         }
+        // Already-covered guard: a statement an earlier pass already rewrites
+        // (e.g. O109 / O126 dead-store elimination, which runs before code
+        // sinking) must not also be sunk — the two rewrites would conflict.
+        // Mirrors Python's `already_covered` check over `ctx.optimisations`.
+        if ctx.optimisations.iter().any(|o| {
+            o.span.start() <= span.start() && o.span.end() >= span.end() && !span.is_empty()
+        }) {
+            continue;
+        }
         let decision = &stmts[i + 1];
         if !is_decision(decision) {
             continue;
@@ -491,6 +500,28 @@ mod tests {
         assert!(
             opts.iter().any(|o| o.code == "O125"),
             "expected an O125 diagnostic, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn already_covered_statement_is_not_sunk() {
+        // When an earlier pass already rewrites the `set x 1` statement,
+        // code sinking must leave it alone.
+        let src = "set x 1\nif {$cond} { puts $x } else { puts no }";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        // Simulate an earlier O109 dead-store rewrite covering `set x 1`.
+        ctx.report(Optimisation::new(
+            "O109",
+            "dead store",
+            tcl_lexer::Span::new(0, 7),
+            "",
+        ));
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != "O125"),
+            "already-covered statement must not be sunk, got {:?}",
+            ctx.optimisations,
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -301,7 +301,7 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
         None,
         &proc_index,
     );
-    emit_adce(ctx, &cu.top_level, &baseline);
+    emit_adce(ctx, &cu.top_level, &baseline, &interproc_pure, &pure_methods, None);
 
     for fu in cu.procedures.values() {
         emit_unreachable(ctx, fu);
@@ -314,7 +314,7 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
             None,
             &proc_index,
         );
-        emit_adce(ctx, fu, &baseline);
+        emit_adce(ctx, fu, &baseline, &interproc_pure, &pure_methods, None);
     }
 
     // SF-2 (#506): optimise TclOO method bodies as functions too,
@@ -342,7 +342,14 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
             enclosing_class,
             &proc_index,
         );
-        emit_adce(ctx, fu, &baseline);
+        emit_adce(
+            ctx,
+            fu,
+            &baseline,
+            &interproc_pure,
+            &pure_methods,
+            enclosing_class,
+        );
     }
     ctx.cross_event_vars = saved_cross;
 }
@@ -586,7 +593,14 @@ fn emit_dead_stores_and_unused(
 }
 
 /// Emit **O108** (transitively dead code) — the ADCE fixpoint.
-fn emit_adce(ctx: &mut PassContext<'_>, fu: &FunctionUnit, baseline: &HashSet<(String, u32)>) {
+fn emit_adce(
+    ctx: &mut PassContext<'_>,
+    fu: &FunctionUnit,
+    baseline: &HashSet<(String, u32)>,
+    interproc_pure: &HashSet<String>,
+    pure_methods: &HashSet<String>,
+    enclosing_class: Option<&str>,
+) {
     let (consumer_stmt_keys, keep_forever) = build_adce_consumers(fu);
     let stmt_to_defs = build_stmt_to_defs(fu);
     let removed = run_adce_fixpoint(
@@ -595,6 +609,10 @@ fn emit_adce(ctx: &mut PassContext<'_>, fu: &FunctionUnit, baseline: &HashSet<(S
         &consumer_stmt_keys,
         &keep_forever,
         &stmt_to_defs,
+        ctx.registry,
+        interproc_pure,
+        pure_methods,
+        enclosing_class,
     );
     emit_adce_reports(ctx, fu, baseline, &removed);
 }
@@ -646,12 +664,17 @@ fn build_stmt_to_defs(fu: &FunctionUnit) -> StmtDefsMap {
     out
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_adce_fixpoint(
     fu: &FunctionUnit,
     baseline: &HashSet<(String, u32)>,
     consumer_stmt_keys: &ConsumerMap,
     keep_forever: &HashSet<(String, u32)>,
     stmt_to_defs: &StmtDefsMap,
+    registry: Option<&CommandRegistry>,
+    interproc_pure: &HashSet<String>,
+    pure_methods: &HashSet<String>,
+    enclosing_class: Option<&str>,
 ) -> HashSet<(String, u32)> {
     let unreachable = unreachable_blocks(&fu.cfg, &fu.sccp);
     let mut removed = baseline.clone();
@@ -677,7 +700,20 @@ fn run_adce_fixpoint(
             let Some(stmt) = block.statements.get(idx) else {
                 continue;
             };
-            if !is_side_effect_free_assignment(stmt) {
+            // O108 purity gate: a transitively-dead assignment can only be
+            // removed when its RHS has no observable side effect — an
+            // embedded `[cmd …]` that mutates state or escapes must keep the
+            // statement live. Mirrors Python's `_is_adce_removable_statement`
+            // (the execution-intent PURE/NO_ESCAPE check), reusing the same
+            // gate O109/DSE applies rather than treating every assignment as
+            // pure.
+            if !assignment_safe_to_delete(
+                stmt,
+                registry,
+                interproc_pure,
+                pure_methods,
+                enclosing_class,
+            ) {
                 continue;
             }
             let empty: Vec<(String, usize)> = Vec::new();
@@ -735,16 +771,6 @@ fn emit_adce_reports(
             "",
         ));
     }
-}
-
-fn is_side_effect_free_assignment(stmt: &Statement) -> bool {
-    matches!(
-        stmt,
-        Statement::AssignConst { .. }
-            | Statement::AssignValue { .. }
-            | Statement::AssignExpr { .. }
-            | Statement::Incr { .. }
-    )
 }
 
 /// Scan every statement's source slice for `$var` / `${var}`
@@ -1262,6 +1288,26 @@ mod tests {
         assert!(
             o108 >= 1,
             "expected at least one O108 in transitive dead chain, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn adce_preserves_impure_link_in_dead_chain() {
+        // `b` is read only by the dead `set c $b`, so the transitive
+        // chain `set a [puts hi]` → `set b $a` → `set c $b` is dead by
+        // def-use. But `set a [puts hi]` still prints — the O108 purity
+        // gate must keep it, deleting at most the pure links.
+        let src = "proc ::f {} { set a [puts hi]; set b $a; set c $b; return 7 }";
+        let opts = crate::optimiser::optimise(src, &registry());
+        let removes_puts_line = opts.iter().any(|o| {
+            matches!(o.code.as_str(), "O108" | "O109" | "O126")
+                && src
+                    .get(o.span.start() as usize..o.span.end() as usize)
+                    .is_some_and(|slice| slice.contains("puts"))
+        });
+        assert!(
+            !removes_puts_line,
+            "impure `set a [puts hi]` must survive ADCE, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/end_offset.rs
+++ b/rust/tcl-compiler/src/optimiser/end_offset.rs
@@ -1,0 +1,391 @@
+//! O128 — end-offset index rewrite.
+//!
+//! Ported from `optimise_end_offset_indexes` in
+//! `core/compiler/optimiser/_pattern_recognition.py`.
+//!
+//! Rewrites length arithmetic used as a list/string index to Tcl's
+//! `end` / `end-N` form: `lindex $L [expr {[llength $L] - 1}]` →
+//! `lindex $L end`, `string range $s 0 [expr {[string length $s] - 2}]`
+//! → `string range $s 0 end-1`, and so on. The rewrite only fires when
+//! the length command's argument is *textually identical* to the
+//! command's own list/string operand — otherwise `[llength $A]` used to
+//! index `$B` would change semantics.
+//!
+//! Each statement's source slice is re-segmented (the IR `Statement`
+//! carries only argv *texts*, not per-word spans, so the index
+//! argument's command-substitution span is recovered by re-tokenising),
+//! and nested `[…]` command substitutions are walked recursively —
+//! mirroring Python's `_walk_nested_cmd_tokens`.
+
+use tcl_lexer::{Span, TokenType};
+
+use crate::compilation_unit::CompilationUnit;
+use crate::expr_ast::{BinOp, ExprNode};
+use crate::expr_parser::parse_expr;
+use crate::ir::{Script, Statement};
+use crate::segmenter::{segment_commands_with_offset, SegmentedCommand};
+
+use super::{Optimisation, PassContext};
+
+/// Which length builtin produced an end-offset candidate.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LengthKind {
+    /// `llength` — list length.
+    Llength,
+    /// `string length` — string length.
+    Strlen,
+}
+
+/// Run the O128 end-offset detection over the whole compilation unit.
+pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
+    // Copy the source reference so the immutable slice borrow does not
+    // conflict with the `&mut ctx` report calls below.
+    let source = ctx.source;
+    let mut spans: Vec<Span> = Vec::new();
+    collect_statement_spans(&cu.ir_module.top_level, &mut spans);
+    for proc in cu.ir_module.procedures.values() {
+        collect_statement_spans(&proc.body, &mut spans);
+    }
+    for span in spans {
+        let Some(slice) = source.get(span.start() as usize..span.end() as usize) else {
+            continue;
+        };
+        for cmd in segment_commands_with_offset(slice, span.start()) {
+            apply_to_command(ctx, &cmd);
+        }
+    }
+}
+
+/// Collect every statement's span, recursing through control-flow bodies
+/// so commands nested in `if` / `for` / `while` / `switch` / `try`
+/// bodies are reached. Mirrors the per-block statement walk Python runs
+/// over the CFG.
+fn collect_statement_spans(script: &Script, out: &mut Vec<Span>) {
+    for stmt in &script.statements {
+        out.push(stmt.span());
+        match stmt {
+            Statement::If {
+                clauses, else_body, ..
+            } => {
+                for c in clauses {
+                    collect_statement_spans(&c.body, out);
+                }
+                if let Some(b) = else_body {
+                    collect_statement_spans(b, out);
+                }
+            }
+            Statement::For {
+                init, next, body, ..
+            } => {
+                collect_statement_spans(init, out);
+                collect_statement_spans(next, out);
+                collect_statement_spans(body, out);
+            }
+            Statement::While { body, .. }
+            | Statement::Catch { body, .. }
+            | Statement::Foreach { body, .. } => collect_statement_spans(body, out),
+            Statement::Try {
+                body,
+                handlers,
+                finally_body,
+                ..
+            } => {
+                collect_statement_spans(body, out);
+                for h in handlers {
+                    collect_statement_spans(&h.body, out);
+                }
+                if let Some(fb) = finally_body {
+                    collect_statement_spans(fb, out);
+                }
+            }
+            Statement::Switch {
+                arms, default_body, ..
+            } => {
+                for a in arms {
+                    if let Some(b) = &a.body {
+                        collect_statement_spans(b, out);
+                    }
+                }
+                if let Some(b) = default_body {
+                    collect_statement_spans(b, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Emit O128 for any end-offset index in `cmd`, then recurse into the
+/// command's nested `[…]` substitutions.
+fn apply_to_command(ctx: &mut PassContext<'_>, cmd: &SegmentedCommand) {
+    emit_for_command(ctx, cmd);
+    for (idx, tok) in cmd.argv.iter().enumerate() {
+        if cmd.single_token_word.get(idx).copied() != Some(true) {
+            continue;
+        }
+        if tok.kind != TokenType::Cmd {
+            continue;
+        }
+        // The word text is the verbatim `[inner]`; re-segment `inner`
+        // anchored one byte past the opening `[` so the recovered spans
+        // stay absolute.
+        let full = &cmd.texts[idx];
+        let Some(inner) = full.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+            continue;
+        };
+        let base = tok.span.start() + 1;
+        for nested in segment_commands_with_offset(inner, base) {
+            apply_to_command(ctx, &nested);
+        }
+    }
+}
+
+/// Emit O128 for each index argument of `cmd` that is length arithmetic
+/// over the command's own list/string operand.
+fn emit_for_command(ctx: &mut PassContext<'_>, cmd: &SegmentedCommand) {
+    let Some((index_positions, container_pos, expected)) = end_offset_command_shape(&cmd.texts)
+    else {
+        return;
+    };
+    if container_pos >= cmd.texts.len() || container_pos >= cmd.argv.len() {
+        return;
+    }
+    if cmd.single_token_word.get(container_pos).copied() != Some(true) {
+        return;
+    }
+    if cmd.argv[container_pos].kind != TokenType::Var {
+        return;
+    }
+    // Compare full variable references (`${L}`, `$a(1)`), not normalised
+    // base names — `$a(1)` and `$a(2)` are different containers.
+    let container_repr = cmd.texts[container_pos].trim();
+
+    for pos in index_positions {
+        if pos >= cmd.texts.len() || pos >= cmd.argv.len() {
+            continue;
+        }
+        if cmd.single_token_word.get(pos).copied() != Some(true) {
+            continue;
+        }
+        let idx_tok = &cmd.argv[pos];
+        if idx_tok.kind != TokenType::Cmd {
+            continue;
+        }
+        let Some(expr_arg) = expr_arg_from_command_word(&cmd.texts[pos]) else {
+            continue;
+        };
+        let Some((kind, length_arg, offset)) = try_end_offset_from_length_expr(&expr_arg) else {
+            continue;
+        };
+        if kind != expected || length_arg.trim() != container_repr {
+            continue;
+        }
+        let replacement = if offset == 0 {
+            "end".to_owned()
+        } else {
+            format!("end-{offset}")
+        };
+        // The `Cmd` token span follows the lexer's inner-end convention:
+        // `span.end()` is the exclusive offset of the closing `]`, so the
+        // full `[…]` substitution is `start..end + 1`.
+        let span = Span::new(idx_tok.span.start(), idx_tok.span.end() + 1);
+        ctx.report(Optimisation::new(
+            "O128",
+            "Use end-offset index instead of length arithmetic",
+            span,
+            replacement,
+        ));
+    }
+}
+
+/// Identify list/string commands that accept `end` / `end-N` index args.
+/// Returns `(index_positions, container_position, expected_kind)`.
+///
+/// `linsert` is intentionally excluded (`linsert $L end x` appends, but
+/// `linsert $L [expr {[llength $L] - 1}] x` inserts before the last
+/// element — no `end`/`end-N` rewrite preserves that). `lindex` with
+/// multiple indices resolves later indices against sub-lists, so only the
+/// first index (position 2) is safe. Mirrors `_end_offset_command_shape`.
+fn end_offset_command_shape(texts: &[String]) -> Option<(Vec<usize>, usize, LengthKind)> {
+    let cmd = texts.first()?.as_str();
+    let nargs = texts.len();
+    match cmd {
+        "lindex" if nargs >= 3 => Some((vec![2], 1, LengthKind::Llength)),
+        "lrange" if nargs == 4 => Some((vec![2, 3], 1, LengthKind::Llength)),
+        "lreplace" if nargs >= 4 => Some((vec![2, 3], 1, LengthKind::Llength)),
+        "string" if nargs >= 2 => match texts[1].as_str() {
+            "index" if nargs == 4 => Some((vec![3], 2, LengthKind::Strlen)),
+            "range" if nargs == 5 => Some((vec![3, 4], 2, LengthKind::Strlen)),
+            "replace" if nargs >= 5 => Some((vec![3, 4], 2, LengthKind::Strlen)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Return the single `expr` argument of a `[expr <arg>]` command word, or
+/// `None` for anything else. The word text is the verbatim `[…]`
+/// substitution. Mirrors `_expr_arg_from_expr_command`.
+fn expr_arg_from_command_word(word: &str) -> Option<String> {
+    let inner = word.strip_prefix('[').and_then(|s| s.strip_suffix(']'))?;
+    let cmds = segment_commands_with_offset(inner, 0);
+    let [cmd] = cmds.as_slice() else {
+        return None;
+    };
+    if cmd.texts.len() != 2 || cmd.texts[0] != "expr" {
+        return None;
+    }
+    Some(cmd.texts[1].clone())
+}
+
+/// Parse `[llength $L] - N` / `[string length $s] - N` (with `N >= 1`)
+/// into `(kind, container_word, end_offset)` where the Tcl end-offset is
+/// `N - 1` (`[llength $L] - 1` → `end`). A bare `[llength $L]` (no
+/// subtraction) is one past the last index and is rejected. Mirrors
+/// `_try_end_offset_from_length_expr`.
+fn try_end_offset_from_length_expr(expr_text: &str) -> Option<(LengthKind, String, i64)> {
+    let node = parse_expr(expr_text.trim(), None);
+    let ExprNode::Binary {
+        op: BinOp::Sub,
+        left,
+        right,
+    } = node
+    else {
+        return None;
+    };
+    let ExprNode::Command { text: cmd_text, .. } = left.as_ref() else {
+        return None;
+    };
+    let ExprNode::Literal { text: rhs, .. } = right.as_ref() else {
+        return None;
+    };
+    let n = rhs.trim().parse::<i64>().ok()?;
+    if n < 1 {
+        return None;
+    }
+    if let Some(arg) = parse_length_arg(cmd_text, &["llength"]) {
+        return Some((LengthKind::Llength, arg, n - 1));
+    }
+    if let Some(arg) = parse_length_arg(cmd_text, &["string", "length"]) {
+        return Some((LengthKind::Strlen, arg, n - 1));
+    }
+    None
+}
+
+/// If `cmd_text` is `[<head…> <arg>]` (or the same without the brackets)
+/// where the leading words equal `head`, return the trailing `<arg>` as
+/// it segments (so the spelling matches the container word). Covers both
+/// `llength $L` (one head word) and `string length $s` (two). Mirrors
+/// `_parse_llength_arg` / `_parse_string_length_arg`.
+fn parse_length_arg(cmd_text: &str, head: &[&str]) -> Option<String> {
+    let inner = cmd_text
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(cmd_text)
+        .trim();
+    let cmds = segment_commands_with_offset(inner, 0);
+    let [cmd] = cmds.as_slice() else {
+        return None;
+    };
+    if cmd.texts.len() != head.len() + 1 {
+        return None;
+    }
+    if cmd.texts[..head.len()].iter().zip(head).any(|(t, h)| t != h) {
+        return None;
+    }
+    cmd.texts.last().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interprocedural::InterproceduralAnalysis;
+    use tcl_registry::CommandRegistry;
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    fn run_pass(source: &str) -> Vec<Optimisation> {
+        let cu = CompilationUnit::build_for(source, &registry(), false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        run(&mut ctx, &cu);
+        ctx.optimisations
+    }
+
+    /// The replacement and the exact source slice the rewrite targets.
+    fn o128_rewrite(source: &str) -> Option<(String, String)> {
+        let cu = CompilationUnit::build_for(source, &registry(), false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        run(&mut ctx, &cu);
+        let opt = ctx.optimisations.into_iter().find(|o| o.code == "O128")?;
+        let slice = source
+            .get(opt.span.start() as usize..opt.span.end() as usize)?
+            .to_owned();
+        Some((slice, opt.replacement))
+    }
+
+    #[test]
+    fn lindex_last_element_rewrites_to_end() {
+        let (slice, repl) = o128_rewrite("lindex $L [expr {[llength $L] - 1}]").unwrap();
+        assert_eq!(slice, "[expr {[llength $L] - 1}]");
+        assert_eq!(repl, "end");
+    }
+
+    #[test]
+    fn lindex_offset_two_rewrites_to_end_minus_one() {
+        let (_slice, repl) = o128_rewrite("lindex $L [expr {[llength $L] - 2}]").unwrap();
+        assert_eq!(repl, "end-1");
+    }
+
+    #[test]
+    fn string_range_last_char_rewrites_to_end() {
+        let (slice, repl) =
+            o128_rewrite("string range $s 0 [expr {[string length $s] - 1}]").unwrap();
+        assert_eq!(slice, "[expr {[string length $s] - 1}]");
+        assert_eq!(repl, "end");
+    }
+
+    #[test]
+    fn lrange_rewrites_both_index_positions() {
+        let opts = run_pass("lrange $L [expr {[llength $L] - 3}] [expr {[llength $L] - 1}]");
+        let repls: Vec<&str> = opts
+            .iter()
+            .filter(|o| o.code == "O128")
+            .map(|o| o.replacement.as_str())
+            .collect();
+        assert!(repls.contains(&"end-2"), "got {repls:?}");
+        assert!(repls.contains(&"end"), "got {repls:?}");
+    }
+
+    #[test]
+    fn mismatched_container_does_not_rewrite() {
+        // The length is of `$A` but the indexed list is `$L` — rewriting
+        // to `end` would change semantics.
+        let opts = run_pass("lindex $L [expr {[llength $A] - 1}]");
+        assert!(
+            opts.iter().all(|o| o.code != "O128"),
+            "mismatched container must not rewrite, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn bare_llength_index_is_not_end_offset() {
+        // `[llength $L]` (no subtraction) is one past the last index.
+        let opts = run_pass("lindex $L [expr {[llength $L]}]");
+        assert!(opts.iter().all(|o| o.code != "O128"), "got {opts:?}");
+    }
+
+    #[test]
+    fn linsert_is_excluded() {
+        let opts = run_pass("linsert $L [expr {[llength $L] - 1}] x");
+        assert!(opts.iter().all(|o| o.code != "O128"), "got {opts:?}");
+    }
+
+    #[test]
+    fn rewrites_inside_proc_body() {
+        let (_slice, repl) =
+            o128_rewrite("proc ::f {L} { return [lindex $L [expr {[llength $L] - 1}]] }").unwrap();
+        assert_eq!(repl, "end");
+    }
+}

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -1034,22 +1034,30 @@ fn reduce_logical(op: BinOp, lit_left: Option<i64>, lit_right: Option<i64>) -> O
     }
 }
 
-/// One pass of eq/ne-promotion: if the RHS (or LHS) of `==` /
-/// `!=` is a string literal (`ExprNode::String` — braced or
-/// quoted), rewrite to the string operator.
+/// One pass of eq/ne-promotion: rewrite `==` / `!=` to `eq` / `ne`
+/// **only when at least one operand is provably non-numeric**.
+///
+/// D5-O120 soundness gate. Tcl's `==`/`!=` parse *both* operands as a
+/// number first and only fall through to a string compare when at least
+/// one parse fails — so the promotion is sound iff one operand can never
+/// be a number. A bare string literal is not enough: `$x == "1"` must
+/// stay numeric (`"1"` parses as the integer 1), or the rewrite flips the
+/// result when `$x` is numeric. We require a string literal whose
+/// delimiter-stripped text does **not** parse as a number, mirroring
+/// Python's `_is_provably_non_numeric_expr_node`. The variable-with-SCCP-
+/// CONST refinement Python also accepts needs lattice values not threaded
+/// here, so it is conservatively skipped (a missed rewrite, never an
+/// unsound one).
 fn streq_promote_node(node: &ExprNode) -> Option<ExprNode> {
     let ExprNode::Binary { op, left, right } = node else {
         return None;
     };
-    let (new_op, ordered) = match op {
-        BinOp::Eq => (BinOp::StrEq, true),
-        BinOp::Ne => (BinOp::StrNe, true),
+    let new_op = match op {
+        BinOp::Eq => BinOp::StrEq,
+        BinOp::Ne => BinOp::StrNe,
         _ => return None,
     };
-    let _ = ordered;
-    let has_string_lit = matches!(left.as_ref(), ExprNode::String { .. })
-        || matches!(right.as_ref(), ExprNode::String { .. });
-    if !has_string_lit {
+    if !node_provably_non_numeric(left) && !node_provably_non_numeric(right) {
         return None;
     }
     Some(ExprNode::Binary {
@@ -1057,6 +1065,37 @@ fn streq_promote_node(node: &ExprNode) -> Option<ExprNode> {
         left: left.clone(),
         right: right.clone(),
     })
+}
+
+/// Whether `node` is provably **not** a number for `expr` — the dual of
+/// [`node_provably_numeric`], used to gate the eq/ne string-compare
+/// promotion (O120). Only a string literal whose stripped text is neither
+/// numeric nor a boolean word qualifies; everything else (variables, command
+/// substitutions, arithmetic) is conservatively rejected. Mirrors
+/// `_is_provably_non_numeric_expr_node` minus the SCCP-CONST variable case.
+fn node_provably_non_numeric(node: &ExprNode) -> bool {
+    matches!(node, ExprNode::String { text, .. } if !is_numeric_or_boolean_string(text))
+}
+
+/// Whether the (delimiter-stripped) text parses as a number **or** is one of
+/// Tcl's boolean words (`true`/`false`/`yes`/`no`/`on`/`off`,
+/// case-insensitive). Mirrors Python's `_is_numeric_string_value`, which `==`
+/// promotion treats as "could still be a number" and so refuses to promote.
+/// Kept separate from [`is_numeric_string`] (used by the arithmetic-identity
+/// gate, where a boolean word is *not* a valid arithmetic operand).
+fn is_numeric_or_boolean_string(text: &str) -> bool {
+    if is_numeric_string(text) {
+        return true;
+    }
+    let stripped = text
+        .trim()
+        .trim_start_matches(['"', '{'])
+        .trim_end_matches(['"', '}'])
+        .trim();
+    matches!(
+        stripped.to_ascii_lowercase().as_str(),
+        "true" | "false" | "yes" | "no" | "on" | "off"
+    )
 }
 
 /// Extract an integer literal from an [`ExprNode::Literal`],
@@ -1350,6 +1389,30 @@ mod tests {
         let (out, changed) = try_eq_ne_string_compare_simplify_expr("$x == 5");
         assert!(!changed);
         assert_eq!(out, "$x == 5");
+    }
+
+    #[test]
+    fn streq_promotion_with_numeric_string_literal_is_unsound_noop() {
+        // D5-O120: `$x == "1"` must stay numeric. `"1"` parses as a
+        // number, so Tcl runs the numeric compare; promoting to `eq`
+        // would flip the result when `$x` is numeric (e.g. `1.0`).
+        // `"1"`/`"3.5"` are numeric; `"yes"` is a Tcl boolean word that
+        // `==` still treats as number-ish — none may promote.
+        for input in ["$x == \"1\"", "$x != \"3.5\"", "$x == \"yes\""] {
+            let (out, changed) = try_eq_ne_string_compare_simplify_expr(input);
+            assert!(!changed, "{input:?} should not promote to eq/ne");
+            assert_eq!(out, input);
+        }
+    }
+
+    #[test]
+    fn streq_promotion_with_nonnumeric_string_literal() {
+        // At least one operand is a provably non-numeric string literal,
+        // so the string-compare path is guaranteed — promotion is sound.
+        for input in ["$x == \"foo\"", "\"a\" != $y", "$x == \"\""] {
+            let (_out, changed) = try_eq_ne_string_compare_simplify_expr(input);
+            assert!(changed, "{input:?} should promote to eq/ne");
+        }
     }
 
     // -- instcombine_expr (composite) --------------------------------------

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -377,32 +377,44 @@ fn strip_ws(expr: &str) -> String {
 /// Apply one pass of local simplifications to `node`, returning
 /// the rewritten subtree. Used as the step function in
 /// [`simplify_to_fixpoint`].
-fn simplify_node_once(node: &ExprNode, numeric: NumericCtx<'_>) -> ExprNode {
-    // First, recurse into children — bottom-up rewriting.
+fn simplify_node_once(node: &ExprNode, bool_context: bool, numeric: NumericCtx<'_>) -> ExprNode {
+    use crate::expr_ast::UnaryOp;
+    // First, recurse into children — bottom-up rewriting. The boolean
+    // context propagates only where the operand's *value* is consumed as a
+    // truth value: the operands of `&&`/`||`/`!` and a ternary condition.
+    // Comparison/arithmetic operands consume the operand's full value, so
+    // they reset the context to `false`. Mirrors the per-position
+    // `bool_context` threading in Python's `_simplify_expr_node`.
     let lowered = match node {
-        ExprNode::Binary { op, left, right } => ExprNode::Binary {
-            op: *op,
-            left: Box::new(simplify_node_once(left, numeric)),
-            right: Box::new(simplify_node_once(right, numeric)),
-        },
-        ExprNode::Unary { op, operand } => ExprNode::Unary {
-            op: *op,
-            operand: Box::new(simplify_node_once(operand, numeric)),
-        },
+        ExprNode::Binary { op, left, right } => {
+            let child_bool = matches!(op, BinOp::And | BinOp::Or | BinOp::WordAnd | BinOp::WordOr);
+            ExprNode::Binary {
+                op: *op,
+                left: Box::new(simplify_node_once(left, child_bool, numeric)),
+                right: Box::new(simplify_node_once(right, child_bool, numeric)),
+            }
+        }
+        ExprNode::Unary { op, operand } => {
+            let child_bool = matches!(op, UnaryOp::Not | UnaryOp::WordNot);
+            ExprNode::Unary {
+                op: *op,
+                operand: Box::new(simplify_node_once(operand, child_bool, numeric)),
+            }
+        }
         ExprNode::Ternary {
             condition,
             true_branch,
             false_branch,
         } => ExprNode::Ternary {
-            condition: Box::new(simplify_node_once(condition, numeric)),
-            true_branch: Box::new(simplify_node_once(true_branch, numeric)),
-            false_branch: Box::new(simplify_node_once(false_branch, numeric)),
+            condition: Box::new(simplify_node_once(condition, true, numeric)),
+            true_branch: Box::new(simplify_node_once(true_branch, bool_context, numeric)),
+            false_branch: Box::new(simplify_node_once(false_branch, bool_context, numeric)),
         },
         other => other.clone(),
     };
 
     // Apply local rewrites at this level in priority order.
-    if let Some(rewritten) = strength_reduce_node(&lowered, numeric) {
+    if let Some(rewritten) = strength_reduce_node(&lowered, bool_context, numeric) {
         return rewritten;
     }
     if let Some(rewritten) = streq_promote_node(&lowered) {
@@ -576,10 +588,10 @@ fn build_mul_expr(terms: &[ExprNode], constant: i64) -> ExprNode {
 }
 
 /// Run [`simplify_node_once`] until the AST stops changing.
-fn simplify_to_fixpoint(node: &ExprNode, _bool_context: bool, numeric: NumericCtx<'_>) -> ExprNode {
+fn simplify_to_fixpoint(node: &ExprNode, bool_context: bool, numeric: NumericCtx<'_>) -> ExprNode {
     let mut cur = node.clone();
     for _ in 0..16 {
-        let next = simplify_node_once(&cur, numeric);
+        let next = simplify_node_once(&cur, bool_context, numeric);
         if render_expr(&next) == render_expr(&cur) {
             return next;
         }
@@ -608,7 +620,9 @@ pub fn try_strength_reduce_expr_typed(expr: &str, numeric: NumericCtx<'_>) -> (S
     if matches!(parsed, ExprNode::Raw { .. }) || expr_has_command_subst(&parsed) {
         return (expr.to_owned(), false);
     }
-    let Some(rewritten) = strength_reduce_node(&parsed, numeric) else {
+    // A standalone strength-reduce has no enclosing boolean context — the
+    // expression's full value is consumed.
+    let Some(rewritten) = strength_reduce_node(&parsed, false, numeric) else {
         return (expr.to_owned(), false);
     };
     let rendered = render_expr(&rewritten);
@@ -707,15 +721,21 @@ pub fn try_eq_ne_string_compare_simplify_expr(expr: &str) -> (String, bool) {
 /// One pass of strength reduction. Returns `None` when no
 /// rewrite applies. Conservative — only obviously-safe rewrites
 /// (no overflow / divide-by-zero concerns).
-fn strength_reduce_node(node: &ExprNode, numeric: NumericCtx<'_>) -> Option<ExprNode> {
+fn strength_reduce_node(
+    node: &ExprNode,
+    bool_context: bool,
+    numeric: NumericCtx<'_>,
+) -> Option<ExprNode> {
     match node {
         ExprNode::Ternary {
             condition,
             true_branch,
             false_branch,
         } => reduce_ternary(condition, true_branch, false_branch),
-        ExprNode::Unary { op, operand } => reduce_unary(*op, operand, numeric),
-        ExprNode::Binary { op, left, right } => reduce_binary(*op, left, right, numeric),
+        ExprNode::Unary { op, operand } => reduce_unary(*op, operand, bool_context, numeric),
+        ExprNode::Binary { op, left, right } => {
+            reduce_binary(*op, left, right, bool_context, numeric)
+        }
         _ => None,
     }
 }
@@ -738,6 +758,7 @@ fn reduce_ternary(
 fn reduce_unary(
     op: crate::expr_ast::UnaryOp,
     operand: &ExprNode,
+    bool_context: bool,
     numeric: NumericCtx<'_>,
 ) -> Option<ExprNode> {
     use crate::expr_ast::UnaryOp;
@@ -748,13 +769,30 @@ fn reduce_unary(
         return Some(operand.clone());
     }
 
-    // `~~x` → `x`, `!!x` → `x`, `not not x` → `x`.
-    if matches!(op, UnaryOp::BitNot | UnaryOp::Not | UnaryOp::WordNot)
+    // `!!x` → `x` / `not not x` → `x` — only sound when `x` already yields a
+    // `0`/`1` boolean or the result is consumed in a boolean context;
+    // otherwise the double-negation is the very normalisation that turns a
+    // non-`0`/`1` value into `0`/`1` (`expr {!!2}` is `1`). Mirrors Python's
+    // gated `!!x` collapse.
+    if matches!(op, UnaryOp::Not | UnaryOp::WordNot)
         && let ExprNode::Unary {
             op: inner_op,
             operand: inner_operand,
         } = operand
-        && op == *inner_op
+        && matches!(inner_op, UnaryOp::Not | UnaryOp::WordNot)
+        && (bool_context || is_boolean_expr(inner_operand))
+    {
+        return Some((**inner_operand).clone());
+    }
+
+    // `~~x` → `x` — drops both bitwise negations, so `x` must be provably
+    // numeric or the coercion error would be lost.
+    if matches!(op, UnaryOp::BitNot)
+        && let ExprNode::Unary {
+            op: UnaryOp::BitNot,
+            operand: inner_operand,
+        } = operand
+        && node_provably_numeric(inner_operand, numeric)
     {
         return Some((**inner_operand).clone());
     }
@@ -823,6 +861,7 @@ fn reduce_binary(
     op: BinOp,
     left: &ExprNode,
     right: &ExprNode,
+    bool_context: bool,
     numeric: NumericCtx<'_>,
 ) -> Option<ExprNode> {
     // Self-comparison tautologies for pure variable references.
@@ -838,7 +877,7 @@ fn reduce_binary(
         .or_else(|| reduce_mod(op, left, lit_right, numeric))
         .or_else(|| reduce_shift(op, left, lit_right, numeric))
         .or_else(|| reduce_bitwise(op, left, right, lit_left, lit_right, numeric))
-        .or_else(|| reduce_logical(op, lit_left, lit_right))
+        .or_else(|| reduce_logical(op, left, right, lit_left, lit_right, bool_context))
 }
 
 /// `$x <cmp> $x` collapses to 0/1 when both sides are the same variable.
@@ -1019,18 +1058,123 @@ fn reduce_bitwise(
     }
 }
 
-/// Logical absorbing reductions for `&&` / `||`.
+/// Logical reductions for `&&` / `||` (O110).
 ///
-/// Identities like `x && 1 → x` are *unsafe* in Tcl because `&&`/`||`
-/// return the normalised boolean (`0`/`1`), not the operand value
-/// (`expr {2 && 1}` is `1`, not `2`). Only absorbing cases are folded
-/// because they collapse to the correct boolean regardless of the
-/// other operand.
-fn reduce_logical(op: BinOp, lit_left: Option<i64>, lit_right: Option<i64>) -> Option<ExprNode> {
+/// Absorbing cases collapse to a constant boolean: `x && 0 → 0`,
+/// `x || 1 → 1`. The identity cases (`x && 1`, `x || 0`) are subtler —
+/// Tcl's `&&`/`||` return the normalised boolean (`0`/`1`), **not** the
+/// operand value (`expr {2 && 1}` is `1`, not `2`), so the operand can be
+/// returned bare only when its result is already a `0`/`1` boolean or is
+/// consumed in a boolean context (where truthiness suffices). Otherwise it
+/// is wrapped as `!!x` to preserve the `0`/`1` normalisation. Mirrors the
+/// `&&`/`||` identity arms of Python's `_simplify_expr_node`.
+fn reduce_logical(
+    op: BinOp,
+    left: &ExprNode,
+    right: &ExprNode,
+    lit_left: Option<i64>,
+    lit_right: Option<i64>,
+    bool_context: bool,
+) -> Option<ExprNode> {
+    // `x && y` where y is a non-`1` literal keeps absorbing behaviour;
+    // the `WordAnd`/`WordOr` spellings share the same semantics.
     match op {
-        BinOp::And if lit_right == Some(0) || lit_left == Some(0) => Some(make_int_literal(0)),
-        BinOp::Or if lit_right == Some(1) || lit_left == Some(1) => Some(make_int_literal(1)),
+        BinOp::And | BinOp::WordAnd => {
+            if lit_right == Some(0) || lit_left == Some(0) {
+                return Some(make_int_literal(0));
+            }
+            if lit_right == Some(1) {
+                return Some(normalise_bool(left, bool_context));
+            }
+            if lit_left == Some(1) {
+                return Some(normalise_bool(right, bool_context));
+            }
+            None
+        }
+        BinOp::Or | BinOp::WordOr => {
+            if lit_right == Some(1) || lit_left == Some(1) {
+                return Some(make_int_literal(1));
+            }
+            if lit_right == Some(0) {
+                return Some(normalise_bool(left, bool_context));
+            }
+            if lit_left == Some(0) {
+                return Some(normalise_bool(right, bool_context));
+            }
+            None
+        }
         _ => None,
+    }
+}
+
+/// Return `node` bare when it already yields a `0`/`1` boolean (or its
+/// truthiness is all the surrounding `bool_context` needs); otherwise wrap
+/// it as `!!node` so the logical operator's normalised result is preserved.
+/// Mirrors Python's `_boolify` / `_is_boolean_expr` gate.
+fn normalise_bool(node: &ExprNode, bool_context: bool) -> ExprNode {
+    if bool_context || is_boolean_expr(node) {
+        node.clone()
+    } else {
+        boolify(node)
+    }
+}
+
+/// Wrap `node` in `!!node` to canonicalise it to a `0`/`1` result.
+fn boolify(node: &ExprNode) -> ExprNode {
+    use crate::expr_ast::UnaryOp;
+    ExprNode::Unary {
+        op: UnaryOp::Not,
+        operand: Box::new(ExprNode::Unary {
+            op: UnaryOp::Not,
+            operand: Box::new(node.clone()),
+        }),
+    }
+}
+
+/// Whether `node` is known to produce a boolean (`0`/`1`) result — a
+/// comparison / logical operator, a logical negation, or a boolean
+/// literal. Mirrors Python's `_is_boolean_expr` / `_BOOLEAN_OPS`.
+fn is_boolean_expr(node: &ExprNode) -> bool {
+    use crate::expr_ast::UnaryOp;
+    match node {
+        ExprNode::Binary { op, .. } => matches!(
+            op,
+            BinOp::And
+                | BinOp::Or
+                | BinOp::WordAnd
+                | BinOp::WordOr
+                | BinOp::Eq
+                | BinOp::Ne
+                | BinOp::Lt
+                | BinOp::Le
+                | BinOp::Gt
+                | BinOp::Ge
+                | BinOp::StrEq
+                | BinOp::StrNe
+                | BinOp::StrLt
+                | BinOp::StrLe
+                | BinOp::StrGt
+                | BinOp::StrGe
+                | BinOp::In
+                | BinOp::Ni
+                | BinOp::Contains
+                | BinOp::StartsWith
+                | BinOp::EndsWith
+                | BinOp::StrEquals
+                | BinOp::MatchesGlob
+                | BinOp::MatchesRegex
+        ),
+        ExprNode::Unary { op, .. } => matches!(op, UnaryOp::Not | UnaryOp::WordNot),
+        ExprNode::Literal { text, .. } => {
+            let t = text.trim();
+            t == "0"
+                || t == "1"
+                || matches!(
+                    t.to_ascii_lowercase().as_str(),
+                    "true" | "false" | "yes" | "no" | "on" | "off"
+                )
+        }
+        _ => false,
     }
 }
 
@@ -1416,6 +1560,43 @@ mod tests {
     }
 
     // -- instcombine_expr (composite) --------------------------------------
+
+    #[test]
+    fn o110_logical_identity_boolifies_outside_bool_context() {
+        // `$x && 1` at expression-value position must normalise to `0`/`1`,
+        // not the operand value — so it becomes `!!$x`, never bare `$x`.
+        let (out, changed) = instcombine_expr("$x && 1", false);
+        assert!(changed);
+        assert_eq!(out.trim(), "!!$x");
+        let (out, changed) = instcombine_expr("$x || 0", false);
+        assert!(changed);
+        assert_eq!(out.trim(), "!!$x");
+    }
+
+    #[test]
+    fn o110_logical_identity_drops_in_bool_context() {
+        // In a boolean context the truthiness is all that is consumed, so
+        // `$x && 1` collapses to bare `$x`.
+        let (out, changed) = instcombine_expr("$x && 1", true);
+        assert!(changed);
+        assert_eq!(out.trim(), "$x");
+    }
+
+    #[test]
+    fn o110_logical_identity_keeps_boolean_operand_bare() {
+        // `($a < $b) && 1` — the operand is already a `0`/`1` comparison,
+        // so it stays bare even outside a boolean context.
+        let (out, changed) = instcombine_expr("$a < $b && 1", false);
+        assert!(changed);
+        assert_eq!(out.trim(), "$a < $b");
+    }
+
+    #[test]
+    fn o110_logical_absorbing_still_folds() {
+        // The absorbing cases must keep folding to a constant.
+        assert_eq!(instcombine_expr("$x && 0", false).0.trim(), "0");
+        assert_eq!(instcombine_expr("$x || 1", false).0.trim(), "1");
+    }
 
     #[test]
     fn instcombine_composes_multiple_rewrites() {

--- a/rust/tcl-compiler/src/optimiser/helpers/spans.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/spans.rs
@@ -83,6 +83,46 @@ pub fn full_rewrite_span(source: &str, span: Span) -> Span {
     Span::new(span.start(), u32::try_from(end).unwrap_or(span.end()))
 }
 
+/// Compute the deletion range for a statement being removed, swallowing
+/// the trailing run of whitespace plus one statement separator (`\n` /
+/// `;`) so the surviving text closes up cleanly. Mirrors Python's
+/// `_statement_delete_rewrite_range`.
+///
+/// `cmd_span` is the full command span (exclusive end); `next_start` is
+/// the byte offset of the next statement, or `None` at end-of-script (in
+/// which case the command span is returned unchanged).
+#[must_use]
+pub fn statement_delete_rewrite_range(
+    source: &str,
+    cmd_span: Span,
+    next_start: Option<usize>,
+) -> Span {
+    let Some(next) = next_start else {
+        return cmd_span;
+    };
+    let end = cmd_span.end() as usize;
+    if next <= end || next > source.len() {
+        return cmd_span;
+    }
+    let bytes = source.as_bytes();
+    let mut cursor = end;
+    while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+        cursor += 1;
+    }
+    if cursor < next && matches!(bytes[cursor], b'\n' | b';') {
+        cursor += 1;
+        while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
+            cursor += 1;
+        }
+        if cursor > end
+            && let Ok(new_end) = u32::try_from(cursor)
+        {
+            return Span::new(cmd_span.start(), new_end);
+        }
+    }
+    cmd_span
+}
+
 /// Extend an argv span that points at a `"…"` composite word to
 /// cover the full quoted string.
 ///

--- a/rust/tcl-compiler/src/optimiser/mod.rs
+++ b/rust/tcl-compiler/src/optimiser/mod.rs
@@ -35,6 +35,7 @@
 pub mod branch_folding;
 pub mod code_sinking;
 pub mod elimination;
+pub mod end_offset;
 pub mod expr_simplify;
 pub mod helpers;
 pub mod manager;

--- a/rust/tcl-compiler/src/optimiser/mod.rs
+++ b/rust/tcl-compiler/src/optimiser/mod.rs
@@ -33,6 +33,7 @@
 //!   façade that runs every `PassId::all()` in canonical order.
 
 pub mod branch_folding;
+pub mod chain_fold;
 pub mod code_sinking;
 pub mod elimination;
 pub mod end_offset;

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -46,6 +46,9 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
         let ints = cu.procedures.get(qname).map(int_var_names).unwrap_or_default();
         walk_script(ctx, &proc.body, &ints);
     }
+    // O128 — end-offset index rewrites (its own segment-level walk over
+    // the same source).
+    super::end_offset::run(ctx, cu);
 }
 
 /// Names whose **every** SSA version is a known `TclType::Int`. A name absent

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -1,20 +1,15 @@
 //! Pattern-recognition optimiser pass (C30g).
 //!
 //! Ported from
-//! `core/compiler/optimiser/_pattern_recognition.py`. Three
-//! entry points:
+//! `core/compiler/optimiser/_pattern_recognition.py`. Entry points:
 //!
 //! - **`optimise_incr_idioms`** (`O114`) — rewrite
 //!   `set x [expr {$x ± N}]` to `incr x N`.
-//! - **`optimise_string_build_chains`** (`O104`) — detect
-//!   accumulation chains `set s ""; append s …; append s …` and
-//!   emit a hint-only `O104` on the first `append` suggesting
-//!   a single-statement rewrite.  `O104` matches the Python
-//!   optimiser allocation and the canonical
-//!   `docs/generated/optimisation_codes.md` table; earlier Rust
-//!   commits emitted `O122` here, but `O122` is reserved for the
-//!   `tail_call` recursion-to-loop conversion and the collision
-//!   was fixed in the C* close-out audit.
+//! - **`optimise_end_offset_indexes`** (`O128`) — rewrite length
+//!   arithmetic index args to `end` / `end-N` (in [`super::end_offset`]).
+//! - **`optimise_string_build_chains`** (`O104` / `O130`) — fold
+//!   write-only `set`+`append`/`lappend` build chains into a single
+//!   `set` (in [`super::chain_fold`]).
 //! - **`optimise_multi_set_packing`** (`O119`) — detect three
 //!   or more contiguous `set` commands with safe-literal
 //!   values and emit a hint-only `O119` suggesting a
@@ -22,10 +17,9 @@
 //!   (appropriate on Tcl 8.5 / 8.6; Tcl 9.0 prefers individual
 //!   sets).
 //!
-//! O104 and O119 are hint-only. The source-level multi-statement
-//! deletion + re-emission the Python pass performs is tracked as
-//! a follow-up — emitting the hint is enough to surface the
-//! opportunity in editors / linters.
+//! O119 remains hint-only. O104/O130 now emit applied folds; the source
+//! span allocation matches the canonical
+//! `docs/generated/optimisation_codes.md` table.
 
 use std::collections::HashSet;
 
@@ -49,6 +43,9 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
     // O128 — end-offset index rewrites (its own segment-level walk over
     // the same source).
     super::end_offset::run(ctx, cu);
+    // O104 / O130 — applied write-only build-chain folds (replaces the old
+    // hint-only detector; owns its own per-function escape gate).
+    super::chain_fold::run(ctx, cu);
 }
 
 /// Names whose **every** SSA version is a known `TclType::Int`. A name absent
@@ -80,7 +77,6 @@ fn lattice_is_int(t: &TypeLattice) -> bool {
 
 fn walk_script(ctx: &mut PassContext<'_>, script: &Script, int_vars: &HashSet<String>) {
     detect_multi_set_packing(ctx, script);
-    detect_string_build_chain(ctx, script);
     for stmt in &script.statements {
         walk_statement(ctx, stmt, int_vars);
     }
@@ -127,55 +123,6 @@ fn detect_multi_set_packing(ctx: &mut PassContext<'_>, script: &Script) {
     }
 }
 
-/// O104: detect `set s ""` followed by two or more
-/// `append s …` to the same variable — a classic
-/// string-build pattern. Emit a hint on the first `append`.
-fn detect_string_build_chain(ctx: &mut PassContext<'_>, script: &Script) {
-    let stmts = &script.statements;
-    let mut i = 0;
-    while i < stmts.len() {
-        // Looking for `set s ""` as the anchor.
-        let Statement::AssignConst { name, value, .. } = &stmts[i] else {
-            i += 1;
-            continue;
-        };
-        if !value.is_empty() && value != "\"\"" && value != "{}" {
-            i += 1;
-            continue;
-        }
-        let var = name.clone();
-        // Count consecutive `append $var …` that follow.
-        let mut j = i + 1;
-        let mut appends = 0;
-        while j < stmts.len() {
-            match &stmts[j] {
-                Statement::Call { command, args, .. }
-                    if command == "append" && args.first() == Some(&var) =>
-                {
-                    appends += 1;
-                    j += 1;
-                }
-                _ => break,
-            }
-        }
-        if appends >= 2 {
-            let span_start = stmts[i].span().start();
-            let span_end = stmts[j - 1].span().end();
-            let span = tcl_lexer::Span::new(span_start, span_end);
-            let mut opt = Optimisation::new(
-                "O104",
-                format!("Replace `{appends}`-step append chain on '{var}' with a single set"),
-                span,
-                "",
-            );
-            opt.hint_only = true;
-            ctx.report(opt);
-            i = j;
-        } else {
-            i += 1;
-        }
-    }
-}
 
 fn walk_statement(ctx: &mut PassContext<'_>, stmt: &Statement, int_vars: &HashSet<String>) {
     match stmt {
@@ -464,22 +411,14 @@ mod tests {
     }
 
     #[test]
-    fn string_build_chain_hints_on_two_plus_appends() {
+    fn string_build_chain_folds_via_pattern_recognition() {
+        // The pass now emits an *applied* O104 fold (not hint-only) — the
+        // detailed behaviour lives in `chain_fold`'s own tests.
         let opts = run_pass("set s {}\nappend s foo\nappend s bar");
         assert!(
-            opts.iter().any(|o| o.code == "O104" && o.hint_only),
-            "expected O104 hint for string-build chain, got {opts:?}",
-        );
-    }
-
-    #[test]
-    fn string_build_chain_requires_empty_initial() {
-        // `set s foo` followed by appends is NOT the pattern —
-        // the initial value is non-empty.
-        let opts = run_pass("set s foo\nappend s bar\nappend s baz");
-        assert!(
-            opts.iter().all(|o| o.code != "O104"),
-            "non-empty initial should not emit O104, got {opts:?}",
+            opts.iter()
+                .any(|o| o.code == "O104" && !o.hint_only && o.replacement == "set s foobar"),
+            "expected applied O104 fold, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -27,27 +27,59 @@
 //! a follow-up — emitting the hint is enough to surface the
 //! opportunity in editors / linters.
 
-use crate::compilation_unit::CompilationUnit;
+use std::collections::HashSet;
+
+use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::expr_ast::{BinOp, ExprNode};
 use crate::ir::{Script, Statement};
 use crate::naming::normalise_var_name;
+use crate::types::{TclType, TypeKind, TypeLattice};
 
 use super::helpers::spans::full_rewrite_span;
 use super::{Optimisation, PassContext};
 
 /// Run the pattern-recognition pass.
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
-    walk_script(ctx, &cu.ir_module.top_level);
-    for proc in cu.ir_module.procedures.values() {
-        walk_script(ctx, &proc.body);
+    let top_ints = int_var_names(&cu.top_level);
+    walk_script(ctx, &cu.ir_module.top_level, &top_ints);
+    for (qname, proc) in &cu.ir_module.procedures {
+        let ints = cu.procedures.get(qname).map(int_var_names).unwrap_or_default();
+        walk_script(ctx, &proc.body, &ints);
     }
 }
 
-fn walk_script(ctx: &mut PassContext<'_>, script: &Script) {
+/// Names whose **every** SSA version is a known `TclType::Int`. A name absent
+/// here is treated as not provably integer, so the `set/expr → incr` rewrite
+/// (O114) is suppressed — matching Python, which proves the loop variable is
+/// `INT` (not `DOUBLE` / `NUMERIC` / `BOOLEAN`) at the use point before
+/// rewriting. `expr {$x + 1}` silently promotes a float operand, whereas
+/// `incr` errors, so the function-level join (all versions must be `INT`) is a
+/// sound over-approximation of the per-use check.
+fn int_var_names(fu: &FunctionUnit) -> HashSet<String> {
+    use std::collections::HashMap;
+    let mut acc: HashMap<&str, bool> = HashMap::new();
+    for ((name, _ver), lattice) in &fu.types {
+        let is_int = lattice_is_int(lattice);
+        acc.entry(name.as_str())
+            .and_modify(|v| *v = *v && is_int)
+            .or_insert(is_int);
+    }
+    acc.into_iter()
+        .filter(|(_, ok)| *ok)
+        .map(|(n, _)| n.to_owned())
+        .collect()
+}
+
+/// Whether a type-lattice element is a known `TclType::Int`.
+fn lattice_is_int(t: &TypeLattice) -> bool {
+    t.kind == TypeKind::Known && t.tcl_type == Some(TclType::Int)
+}
+
+fn walk_script(ctx: &mut PassContext<'_>, script: &Script, int_vars: &HashSet<String>) {
     detect_multi_set_packing(ctx, script);
     detect_string_build_chain(ctx, script);
     for stmt in &script.statements {
-        walk_statement(ctx, stmt);
+        walk_statement(ctx, stmt, int_vars);
     }
 }
 
@@ -142,10 +174,10 @@ fn detect_string_build_chain(ctx: &mut PassContext<'_>, script: &Script) {
     }
 }
 
-fn walk_statement(ctx: &mut PassContext<'_>, stmt: &Statement) {
+fn walk_statement(ctx: &mut PassContext<'_>, stmt: &Statement, int_vars: &HashSet<String>) {
     match stmt {
         Statement::AssignExpr { span, name, expr } => {
-            if let Some(replacement) = try_incr_idiom(name, expr) {
+            if let Some(replacement) = try_incr_idiom(name, expr, int_vars) {
                 ctx.report(Optimisation::new(
                     "O114",
                     "Use incr instead of set/expr",
@@ -158,34 +190,34 @@ fn walk_statement(ctx: &mut PassContext<'_>, stmt: &Statement) {
             clauses, else_body, ..
         } => {
             for c in clauses {
-                walk_script(ctx, &c.body);
+                walk_script(ctx, &c.body, int_vars);
             }
             if let Some(b) = else_body {
-                walk_script(ctx, b);
+                walk_script(ctx, b, int_vars);
             }
         }
         Statement::For {
             init, next, body, ..
         } => {
-            walk_script(ctx, init);
-            walk_script(ctx, next);
-            walk_script(ctx, body);
+            walk_script(ctx, init, int_vars);
+            walk_script(ctx, next, int_vars);
+            walk_script(ctx, body, int_vars);
         }
         Statement::While { body, .. }
         | Statement::Catch { body, .. }
-        | Statement::Foreach { body, .. } => walk_script(ctx, body),
+        | Statement::Foreach { body, .. } => walk_script(ctx, body, int_vars),
         Statement::Try {
             body,
             handlers,
             finally_body,
             ..
         } => {
-            walk_script(ctx, body);
+            walk_script(ctx, body, int_vars);
             for h in handlers {
-                walk_script(ctx, &h.body);
+                walk_script(ctx, &h.body, int_vars);
             }
             if let Some(fb) = finally_body {
-                walk_script(ctx, fb);
+                walk_script(ctx, fb, int_vars);
             }
         }
         Statement::Switch {
@@ -193,11 +225,11 @@ fn walk_statement(ctx: &mut PassContext<'_>, stmt: &Statement) {
         } => {
             for a in arms {
                 if let Some(b) = &a.body {
-                    walk_script(ctx, b);
+                    walk_script(ctx, b, int_vars);
                 }
             }
             if let Some(b) = default_body {
-                walk_script(ctx, b);
+                walk_script(ctx, b, int_vars);
             }
         }
         _ => {}
@@ -216,7 +248,19 @@ fn walk_statement(ctx: &mut PassContext<'_>, stmt: &Statement) {
 /// - `$x - N`  → `incr x -N`       (`N` a non-zero integer)
 ///
 /// Returns `None` for anything that does not match the form.
-fn try_incr_idiom(target_name: &str, expr: &ExprNode) -> Option<String> {
+///
+/// D5-O114 soundness gate: `target_name` must be provably `TclType::Int`
+/// (present in `int_vars`). `expr {$x + 1}` silently promotes a float
+/// operand (`1.5` → `2.5`), whereas `incr x` errors with *expected integer
+/// but got "1.5"* — so without an integer proof the rewrite is unsound.
+fn try_incr_idiom(
+    target_name: &str,
+    expr: &ExprNode,
+    int_vars: &HashSet<String>,
+) -> Option<String> {
+    if !int_vars.contains(target_name) {
+        return None;
+    }
     let ExprNode::Binary { op, left, right } = expr else {
         return None;
     };
@@ -320,7 +364,9 @@ mod tests {
 
     #[test]
     fn set_expr_plus_one_rewrites_to_incr() {
-        let opts = run_pass("set x [expr {$x + 1}]");
+        // The seeding `set x 0` makes `x` provably INT, satisfying the
+        // O114 soundness gate.
+        let opts = run_pass("set x 0\nset x [expr {$x + 1}]");
         let got = opts.iter().find(|o| o.code == "O114");
         assert!(got.is_some(), "expected O114, got {opts:?}");
         assert_eq!(got.unwrap().replacement, "incr x");
@@ -328,7 +374,7 @@ mod tests {
 
     #[test]
     fn set_expr_plus_n_carries_the_amount() {
-        let opts = run_pass("set x [expr {$x + 5}]");
+        let opts = run_pass("set x 0\nset x [expr {$x + 5}]");
         assert_eq!(
             opts.iter().find(|o| o.code == "O114").unwrap().replacement,
             "incr x 5",
@@ -337,10 +383,32 @@ mod tests {
 
     #[test]
     fn set_expr_minus_one_becomes_incr_negative_one() {
-        let opts = run_pass("set x [expr {$x - 1}]");
+        let opts = run_pass("set x 5\nset x [expr {$x - 1}]");
         assert_eq!(
             opts.iter().find(|o| o.code == "O114").unwrap().replacement,
             "incr x -1",
+        );
+    }
+
+    #[test]
+    fn set_expr_on_float_var_is_not_incr() {
+        // D5-O114: `x` is DOUBLE here, so `expr {$x + 1}` promotes to a
+        // float while `incr` would error — the rewrite must not fire.
+        let opts = run_pass("set x 1.5\nset x [expr {$x + 1}]");
+        assert!(
+            opts.iter().all(|o| o.code != "O114"),
+            "float var must not be rewritten to incr, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn set_expr_on_untyped_var_is_not_incr() {
+        // No prior definition → `x` is not provably INT at the use point;
+        // the unsound rewrite is suppressed (matches Python).
+        let opts = run_pass("set x [expr {$x + 1}]");
+        assert!(
+            opts.iter().all(|o| o.code != "O114"),
+            "untyped var must not be rewritten to incr, got {opts:?}",
         );
     }
 
@@ -366,7 +434,7 @@ mod tests {
     fn commutative_add_accepts_literal_on_left() {
         // Tcl allows `$x + 1` and `1 + $x` — both should be
         // recognised as an incr idiom.
-        let opts = run_pass("set x [expr {1 + $x}]");
+        let opts = run_pass("set x 0\nset x [expr {1 + $x}]");
         assert_eq!(
             opts.iter().find(|o| o.code == "O114").unwrap().replacement,
             "incr x",
@@ -414,7 +482,7 @@ mod tests {
 
     #[test]
     fn run_passes_dispatches_pattern_recognition() {
-        let cu = CompilationUnit::build_for("set x [expr {$x + 1}]", &registry(), false);
+        let cu = CompilationUnit::build_for("set x 0\nset x [expr {$x + 1}]", &registry(), false);
         let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
         super::super::run_passes(&mut ctx, &cu, &[super::super::PassId::PatternRecognition]);
         assert!(

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -29,7 +29,8 @@ use crate::ir::{Script, Statement};
 use crate::naming::normalise_var_name;
 use crate::types::{TclType, TypeKind, TypeLattice};
 
-use super::helpers::spans::full_rewrite_span;
+use super::helpers::literals::{is_safe_word, is_static_var_word};
+use super::helpers::spans::{full_rewrite_span, statement_delete_rewrite_range};
 use super::{Optimisation, PassContext};
 
 /// Run the pattern-recognition pass.
@@ -82,44 +83,138 @@ fn walk_script(ctx: &mut PassContext<'_>, script: &Script, int_vars: &HashSet<St
     }
 }
 
-/// O119: find three or more consecutive `set VAR LITERAL`
-/// statements with bare-literal values; emit a hint-only
-/// rewrite suggestion.
+/// Minimum number of `set`s to pack into a `lassign` / `foreach`.
+const SET_PACK_MIN_GROUP: usize = 3;
+
+/// O119 — pack three or more consecutive `set VAR LITERAL` statements
+/// (distinct variables, safe literal values) into one `lassign` (Tcl
+/// 8.5 / 8.6) or `foreach {…} {…} {break}` (8.4), emitting the applied
+/// rewrite plus paired deletions. Skipped on Tcl 9.0, where individual
+/// `set`s are faster. Mirrors `optimise_multi_set_packing` for the
+/// strictly-consecutive case (Python additionally reorders interspersed
+/// candidates; that flow-sensitive extension is the residual).
 fn detect_multi_set_packing(ctx: &mut PassContext<'_>, script: &Script) {
+    // Tcl 9.0 prefers individual `set`s; 8.5 / 8.6 get `lassign`; older
+    // (and dialect-unset) fall back to the universally-valid `foreach`.
+    if ctx.dialect == Some("tcl9.0") {
+        return;
+    }
+    let use_lassign = matches!(ctx.dialect, Some("tcl8.5" | "tcl8.6"));
+    let stmts = &script.statements;
+
     let mut i = 0;
-    while i < script.statements.len() {
-        let start = i;
-        let mut vars: Vec<String> = Vec::new();
-        while i < script.statements.len() {
-            let Statement::AssignConst { name, value, .. } = &script.statements[i] else {
+    while i < stmts.len() {
+        // Gather a maximal run of consecutive static sets with distinct,
+        // non-cross-event variables.
+        let mut run: Vec<(usize, String, String)> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut j = i;
+        while j < stmts.len() {
+            let Some((var_key, var_word, value)) = static_packing_set(&stmts[j]) else {
                 break;
             };
-            if value.contains(['$', '[', '\\', ' ', '\n', '\r']) {
+            if ctx.cross_event_vars.contains(&var_key) || !seen.insert(var_key) {
                 break;
             }
-            vars.push(name.clone());
-            i += 1;
+            run.push((j, var_word, value));
+            j += 1;
         }
-        if vars.len() >= 3 {
-            // Span the entire run.
-            let span_start = script.statements[start].span().start();
-            let span_end = script.statements[i - 1].span().end();
-            let span = tcl_lexer::Span::new(span_start, span_end);
-            let mut opt = Optimisation::new(
-                "O119",
-                format!(
-                    "Pack {} consecutive literal sets into `lassign`",
-                    vars.len()
-                ),
-                span,
-                "",
-            );
-            opt.hint_only = true;
-            ctx.report(opt);
+        if run.len() >= SET_PACK_MIN_GROUP {
+            emit_set_pack(ctx, stmts, &run, use_lassign);
         }
-        if i == start {
-            i += 1;
+        i = if j > i { j } else { i + 1 };
+    }
+}
+
+/// Extract a packable static `set var literal` as `(var_key, var_word,
+/// value)`. Handles both lowering shapes: an integer literal lowers to
+/// `AssignConst`, other static literals to `AssignValue` (whose value word
+/// must be a single static `Esc`/`Str` token with no back-substitution).
+fn static_packing_set(stmt: &Statement) -> Option<(String, String, String)> {
+    let (name, value) = match stmt {
+        Statement::AssignConst { name, value, .. } => (name, value),
+        Statement::AssignValue {
+            name,
+            value,
+            value_needs_backsubst,
+            tokens,
+            ..
+        } => {
+            if *value_needs_backsubst {
+                return None;
+            }
+            let tokens = tokens.as_ref()?;
+            let kind = tokens.argv_kinds.get(2)?;
+            if !tokens.single_token_word.get(2).copied().unwrap_or(false)
+                || !matches!(kind, tcl_lexer::TokenType::Esc | tcl_lexer::TokenType::Str)
+            {
+                return None;
+            }
+            (name, value)
         }
+        _ => return None,
+    };
+    if !is_static_var_word(name) || !is_safe_word(value) {
+        return None;
+    }
+    Some((normalise_var_name(name).to_owned(), name.clone(), value.clone()))
+}
+
+/// Emit the O119 pack rewrite (over the last set) + deletions of the
+/// earlier sets, sharing one group.
+fn emit_set_pack(
+    ctx: &mut PassContext<'_>,
+    stmts: &[Statement],
+    run: &[(usize, String, String)],
+    use_lassign: bool,
+) {
+    let source = ctx.source;
+    let group = ctx.alloc_group();
+    let var_words = run
+        .iter()
+        .map(|(_, w, _)| w.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let value_words = run
+        .iter()
+        .map(|(_, _, v)| v.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let (replacement, pack_msg, del_msg) = if use_lassign {
+        (
+            format!("lassign {{{value_words}}} {var_words}"),
+            "Pack set statements into lassign",
+            "Remove packed set (moved to lassign)",
+        )
+    } else {
+        (
+            format!("foreach {{{var_words}}} {{{value_words}}} {{break}}"),
+            "Pack set statements into foreach",
+            "Remove packed set (moved to foreach)",
+        )
+    };
+
+    let last_idx = run.last().unwrap().0;
+    let mut pack = Optimisation::new(
+        "O119",
+        pack_msg,
+        full_rewrite_span(source, stmts[last_idx].span()),
+        replacement,
+    );
+    pack.group = Some(group);
+    ctx.report(pack);
+
+    for (idx, _, _) in &run[..run.len() - 1] {
+        let full = full_rewrite_span(source, stmts[*idx].span());
+        let next_start = stmts.get(idx + 1).map(|s| s.span().start() as usize);
+        let mut del = Optimisation::new(
+            "O119",
+            del_msg,
+            statement_delete_rewrite_range(source, full, next_start),
+            "",
+        );
+        del.group = Some(group);
+        ctx.report(del);
     }
 }
 
@@ -392,11 +487,50 @@ mod tests {
     }
 
     #[test]
-    fn multi_set_packing_hints_with_three_or_more_literal_sets() {
+    fn multi_set_packing_applies_pack_rewrite() {
+        // No dialect set → universally-valid `foreach` packing, applied.
         let opts = run_pass("set a 1\nset b 2\nset c 3");
+        let pack = opts
+            .iter()
+            .find(|o| o.code == "O119" && !o.replacement.is_empty())
+            .expect("expected an applied O119 pack");
+        assert_eq!(pack.replacement, "foreach {a b c} {1 2 3} {break}");
+        // One pack + two deletions, one group.
+        let o119: Vec<_> = opts.iter().filter(|o| o.code == "O119").collect();
+        assert_eq!(o119.len(), 3);
+    }
+
+    #[test]
+    fn multi_set_packing_uses_lassign_on_tcl86() {
+        let cu = CompilationUnit::build_for("set a 1\nset b 2\nset c 3", &registry(), false);
+        let mut ctx = super::super::PassContext::with_dialect(
+            &cu.source,
+            InterproceduralAnalysis::default(),
+            Some("tcl8.6"),
+        );
+        run(&mut ctx, &cu);
         assert!(
-            opts.iter().any(|o| o.code == "O119" && o.hint_only),
-            "expected O119 hint for multi-set packing, got {opts:?}",
+            ctx.optimisations
+                .iter()
+                .any(|o| o.code == "O119" && o.replacement == "lassign {1 2 3} a b c"),
+            "expected lassign pack on 8.6, got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn multi_set_packing_skipped_on_tcl9() {
+        let cu = CompilationUnit::build_for("set a 1\nset b 2\nset c 3", &registry(), false);
+        let mut ctx = super::super::PassContext::with_dialect(
+            &cu.source,
+            InterproceduralAnalysis::default(),
+            Some("tcl9.0"),
+        );
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != "O119"),
+            "Tcl 9.0 must not pack sets, got {:?}",
+            ctx.optimisations,
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/profiles.rs
+++ b/rust/tcl-compiler/src/optimiser/profiles.rs
@@ -84,6 +84,7 @@ const OPT_CATEGORIES: &[(&str, OptCategory)] = &[
     ("O124", OptCategory::Dce),
     ("O126", OptCategory::Dce),
     // code_motion
+    ("O106", OptCategory::CodeMotion),
     ("O125", OptCategory::CodeMotion),
     ("O127", OptCategory::CodeMotion),
     // recursion
@@ -157,6 +158,16 @@ mod tests {
         assert!(!d.contains("O129")); // constant_folding on
         assert!(d.contains("O109")); // dce off
         assert!(d.contains("O121")); // recursion off
+        assert!(d.contains("O106")); // code_motion off under standard
+    }
+
+    #[test]
+    fn o106_is_suppressable_code_motion() {
+        // O106 (LICM) must be a known category entry so non-full profiles
+        // can suppress it; readability/standard turn code_motion off.
+        assert!(profile_to_disabled(OptimisationProfile::Readability).contains("O106"));
+        assert!(profile_to_disabled(OptimisationProfile::Standard).contains("O106"));
+        assert!(!profile_to_disabled(OptimisationProfile::Full).contains("O106"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -953,6 +953,12 @@ fn try_fold_static_proc_call(
     let Some(summary) = ia.procedures.get(&qname) else {
         return;
     };
+    // A redefined proc has an ambiguous body — never fold its calls
+    // (the flow-sensitive rename gate, mirroring the cmd-subst form and
+    // Python's `redefined_procedures` check).
+    if cu.ir_module.redefined_procedures.contains(&qname) {
+        return;
+    }
     if !summary.can_fold_static_calls {
         return;
     }

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -65,12 +65,15 @@ use super::{Optimisation, PassContext};
 /// …) are skipped because substituting them as a bare word
 /// would change the command's interpretation.
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
-    run_function(ctx, cu, &cu.top_level, &cu.ir_module.top_level);
+    run_function(ctx, cu, &cu.top_level, &cu.ir_module.top_level, "::");
     for (qname, fu) in &cu.procedures {
         let Some(proc) = cu.ir_module.procedures.get(qname) else {
             continue;
         };
-        run_function(ctx, cu, fu, &proc.body);
+        // The call-site namespace for O103 chain resolution is the proc's
+        // own namespace (`::ns::foo` resolves a bare `bar` against `::ns`).
+        let namespace = super::helpers::naming::namespace_from_qualified(qname);
+        run_function(ctx, cu, fu, &proc.body, &namespace);
     }
     // Load-forwarding runs a separate per-function pass on top
     // of the SCCP-based substitutions. It consults the def-use
@@ -624,13 +627,14 @@ fn run_function(
     cu: &CompilationUnit,
     fu: &FunctionUnit,
     script: &Script,
+    namespace: &str,
 ) {
     // Project the per-function SCCP lattice into a name → literal
     // map that survives only when every tracked version of the
     // variable collapses to the same single constant value.
     let constants = sccp_constants_for(fu);
     let numeric = numeric_var_names(fu);
-    walk_script(ctx, cu, script, &constants, Some(&numeric));
+    walk_script(ctx, cu, script, &constants, Some(&numeric), namespace);
 }
 
 fn walk_script(
@@ -639,9 +643,10 @@ fn walk_script(
     script: &Script,
     constants: &std::collections::HashMap<String, String>,
     numeric: NumericCtx<'_>,
+    namespace: &str,
 ) {
     for stmt in &script.statements {
-        walk_statement(ctx, cu, stmt, constants, numeric);
+        walk_statement(ctx, cu, stmt, constants, numeric, namespace);
     }
 }
 
@@ -651,6 +656,7 @@ fn walk_statement(
     stmt: &Statement,
     constants: &std::collections::HashMap<String, String>,
     numeric: NumericCtx<'_>,
+    namespace: &str,
 ) {
     match stmt {
         Statement::Call {
@@ -662,9 +668,9 @@ fn walk_statement(
         } => {
             if let Some(t) = tokens {
                 visit_call_tokens(ctx, t, constants);
-                visit_call_cmd_subst_folds(ctx, cu, t, constants);
+                visit_call_cmd_subst_folds(ctx, cu, t, constants, namespace);
             }
-            try_fold_static_proc_call(ctx, cu, *span, command, args);
+            try_fold_static_proc_call(ctx, cu, *span, command, args, namespace);
         }
         // `set TARGET [cmd-sub]` lowers to `AssignValue` carrying the
         // full command's tokens (`["set", TARGET, "[cmd-sub]"]`). Walk
@@ -685,7 +691,7 @@ fn walk_statement(
         Statement::AssignValue {
             tokens: Some(t), ..
         } => {
-            visit_call_cmd_subst_folds(ctx, cu, t, constants);
+            visit_call_cmd_subst_folds(ctx, cu, t, constants, namespace);
         }
         Statement::Return {
             span,
@@ -710,34 +716,34 @@ fn walk_statement(
             clauses, else_body, ..
         } => {
             for c in clauses {
-                walk_script(ctx, cu, &c.body, constants, numeric);
+                walk_script(ctx, cu, &c.body, constants, numeric, namespace);
             }
             if let Some(b) = else_body {
-                walk_script(ctx, cu, b, constants, numeric);
+                walk_script(ctx, cu, b, constants, numeric, namespace);
             }
         }
         Statement::For {
             init, next, body, ..
         } => {
-            walk_script(ctx, cu, init, constants, numeric);
-            walk_script(ctx, cu, next, constants, numeric);
-            walk_script(ctx, cu, body, constants, numeric);
+            walk_script(ctx, cu, init, constants, numeric, namespace);
+            walk_script(ctx, cu, next, constants, numeric, namespace);
+            walk_script(ctx, cu, body, constants, numeric, namespace);
         }
         Statement::While { body, .. }
         | Statement::Catch { body, .. }
-        | Statement::Foreach { body, .. } => walk_script(ctx, cu, body, constants, numeric),
+        | Statement::Foreach { body, .. } => walk_script(ctx, cu, body, constants, numeric, namespace),
         Statement::Try {
             body,
             handlers,
             finally_body,
             ..
         } => {
-            walk_script(ctx, cu, body, constants, numeric);
+            walk_script(ctx, cu, body, constants, numeric, namespace);
             for h in handlers {
-                walk_script(ctx, cu, &h.body, constants, numeric);
+                walk_script(ctx, cu, &h.body, constants, numeric, namespace);
             }
             if let Some(fb) = finally_body {
-                walk_script(ctx, cu, fb, constants, numeric);
+                walk_script(ctx, cu, fb, constants, numeric, namespace);
             }
         }
         Statement::Switch {
@@ -745,11 +751,11 @@ fn walk_statement(
         } => {
             for a in arms {
                 if let Some(b) = &a.body {
-                    walk_script(ctx, cu, b, constants, numeric);
+                    walk_script(ctx, cu, b, constants, numeric, namespace);
                 }
             }
             if let Some(b) = default_body {
-                walk_script(ctx, cu, b, constants, numeric);
+                walk_script(ctx, cu, b, constants, numeric, namespace);
             }
         }
         _ => {}
@@ -925,6 +931,46 @@ fn parse_static_call_args(
     Some(out)
 }
 
+/// Resolve a call's head word to a procedure qname that has an
+/// interprocedural summary, walking the enclosing namespace chain for a
+/// bare call. Mirrors Python's `_resolve_summary_proc_name`:
+///
+/// * a `::`-qualified word is taken as-is;
+/// * a word containing `::` (relative-qualified) is rooted at `::`;
+/// * a bare word is tried against each enclosing namespace from the
+///   deepest (`::ns::sub::word`) out to the root (`::word`).
+///
+/// Returns the first candidate that has a summary, else `None`.
+fn resolve_proc_qname(
+    command: &str,
+    namespace: &str,
+    ia: &crate::interprocedural::InterproceduralAnalysis,
+) -> Option<String> {
+    if command.is_empty() {
+        return None;
+    }
+    if command.starts_with("::") || command.contains("::") {
+        let qname = if command.starts_with("::") {
+            command.to_owned()
+        } else {
+            format!("::{command}")
+        };
+        return ia.procedures.contains_key(&qname).then_some(qname);
+    }
+    let parts = super::helpers::naming::namespace_parts(namespace);
+    for depth in (0..=parts.len()).rev() {
+        let candidate = if depth > 0 {
+            format!("::{}::{command}", parts[..depth].join("::"))
+        } else {
+            format!("::{command}")
+        };
+        if ia.procedures.contains_key(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 /// O103: if `command` resolves to a proc with `can_fold_static_calls`
 /// and a `constant_return`, emit a rewrite replacing the call
 /// with the literal return value.
@@ -934,21 +980,15 @@ fn try_fold_static_proc_call(
     span: tcl_lexer::Span,
     command: &str,
     _args: &[String],
+    namespace: &str,
 ) {
     use crate::interprocedural::ConstantReturn;
 
     let Some(ia) = cu.interproc.as_ref() else {
         return;
     };
-    // Naive resolution: treat `command` as a qualified name when
-    // it starts with `::`, else try `::command`. The Python side
-    // does full namespace walking via `_resolve_summary_proc_name`;
-    // this scaled-down version catches the common case of calls
-    // written with their absolute names or at namespace root.
-    let qname = if command.starts_with("::") {
-        command.to_owned()
-    } else {
-        format!("::{command}")
+    let Some(qname) = resolve_proc_qname(command, namespace, ia) else {
+        return;
     };
     let Some(summary) = ia.procedures.get(&qname) else {
         return;
@@ -1200,6 +1240,7 @@ fn visit_call_cmd_subst_folds(
     cu: &CompilationUnit,
     tokens: &CommandTokens,
     constants: &std::collections::HashMap<String, String>,
+    namespace: &str,
 ) {
     use crate::interprocedural::ConstantReturn;
 
@@ -1297,10 +1338,8 @@ fn visit_call_cmd_subst_folds(
         let Some(head) = parse_cmd_subst_head(inner) else {
             continue;
         };
-        let qname = if head.starts_with("::") {
-            head.to_owned()
-        } else {
-            format!("::{head}")
+        let Some(qname) = resolve_proc_qname(head, namespace, ia) else {
+            continue;
         };
         let Some(summary) = ia.procedures.get(&qname) else {
             continue;
@@ -1969,6 +2008,36 @@ mod tests {
         let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
         run(&mut ctx, &cu);
         ctx.optimisations
+    }
+
+    #[test]
+    fn resolve_proc_qname_walks_namespace_chain() {
+        // Two procs in `::ns`; a bare `inner` call from `::ns` resolves to
+        // `::ns::inner`, not the (absent) root `::inner`.
+        let module = crate::lowering::lower_to_ir(
+            "namespace eval ::ns {\n proc inner {} { return 1 }\n proc outer {} { inner }\n}",
+            &registry(),
+        );
+        let ia = crate::interprocedural::build_interprocedural_analysis(&module, &registry(), None);
+        assert!(
+            ia.procedures.contains_key("::ns::inner"),
+            "expected ::ns::inner in IA, got {:?}",
+            ia.procedures.keys().collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            resolve_proc_qname("inner", "::ns", &ia).as_deref(),
+            Some("::ns::inner"),
+            "bare call should resolve against the enclosing namespace",
+        );
+        // An absolute spelling is taken as-is.
+        assert_eq!(
+            resolve_proc_qname("::ns::inner", "::other", &ia).as_deref(),
+            Some("::ns::inner"),
+        );
+        // A bare call with no matching namespace candidate fails to resolve.
+        assert_eq!(resolve_proc_qname("missing", "::ns", &ia), None);
+        // From the root namespace a bare `inner` does *not* reach `::ns::inner`.
+        assert_eq!(resolve_proc_qname("inner", "::", &ia), None);
     }
 
     /// Run the whole optimiser (raw, unfiltered) so the registry is

--- a/rust/tcl-compiler/src/optimiser/tail_call.rs
+++ b/rust/tcl-compiler/src/optimiser/tail_call.rs
@@ -364,6 +364,30 @@ fn count_bracket_self_calls(text: &str, self_names: &HashSet<String>) -> usize {
     count
 }
 
+/// Whether `value` (a `return` argument) is an accumulator-eligible
+/// non-tail self-recursion. Mirrors Python's `_is_accumulator_pattern`
+/// plus the `first_word == "expr"` wrapper gate:
+///
+/// 1. the argument is an `[expr {…}]` command substitution (not a plain
+///    `[self …]` tail call, which O121 already handles);
+/// 2. it embeds **exactly one** self-call — tree recursion like
+///    `fib` (`[fib …] + [fib …]`, two calls) is *not* a simple
+///    accumulator and must not fire;
+/// 3. it contains an associative operator (`+` / `*`) so introducing an
+///    accumulator parameter is meaningful.
+fn is_accumulator_pattern(value: &str, self_names: &HashSet<String>) -> bool {
+    let Some((head, _)) = parse_return_subst(value) else {
+        return false;
+    };
+    if head != "expr" {
+        return false;
+    }
+    if count_bracket_self_calls(value, self_names) != 1 {
+        return false;
+    }
+    value.contains('+') || value.contains('*')
+}
+
 /// Detect a non-tail self-call embedded in an expression body
 /// or a return's command substitution — the accumulator pattern.
 fn non_tail_self_call_in_expression(script: &Script, self_names: &HashSet<String>) -> bool {
@@ -387,18 +411,10 @@ fn non_tail_in_stmt(stmt: &Statement, self_names: &HashSet<String>) -> bool {
             if *braced {
                 return false;
             }
-            // Pure `return [self …]` — that's a tail return-
-            // subst, already handled by O121, not accumulator.
-            if let Some((head, _)) = parse_return_subst(v)
-                && self_names.contains(&head)
-                && !v.trim_start().contains("[expr")
-            {
-                return false;
-            }
-            count_bracket_self_calls(v, self_names) > 0
-                && !matches!(parse_return_subst(v), Some((h, _)) if self_names.contains(&h))
+            is_accumulator_pattern(v, self_names)
         }
-        Statement::AssignValue { value, .. } => count_bracket_self_calls(value, self_names) > 0,
+        // Python's `_find_accumulator_sites` inspects `return` statements
+        // only, so an assignment never contributes an O123 candidate.
         Statement::If {
             clauses, else_body, ..
         } => {
@@ -815,6 +831,32 @@ mod tests {
         assert!(
             opts.iter().any(|o| o.code == "O123" && o.hint_only),
             "expected O123 accumulator hint, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o123_does_not_fire_on_tree_recursion() {
+        // `fib` has TWO self-calls in the expression, so it is not a
+        // simple accumulator pattern — O123 must not fire.
+        let opts = run_pass(
+            "proc ::fib {n} { if {$n < 2} { return $n } else { return [expr {[fib [expr {$n - 1}]] + [fib [expr {$n - 2}]]}] } }",
+        );
+        assert!(
+            opts.iter().all(|o| o.code != "O123"),
+            "tree recursion must not emit O123, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o123_requires_associative_operator() {
+        // A single embedded self-call with no `+`/`*` operator is not an
+        // accumulator candidate (e.g. a wrapping `[expr {-[f $n]}]`).
+        let opts = run_pass(
+            "proc ::g {n} { if {$n <= 0} { return 0 } else { return [expr {-[g [expr {$n - 1}]]}] } }",
+        );
+        assert!(
+            opts.iter().all(|o| o.code != "O123"),
+            "non-associative wrapper must not emit O123, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/var_escape/api.rs
+++ b/rust/tcl-compiler/src/var_escape/api.rs
@@ -1,0 +1,179 @@
+//! Public driver for the var-escape analysis.
+//!
+//! Ported from `compiler/var_escape/_api.py`. The orchestrator threads the
+//! already-landed pieces — the intraprocedural pass ([`analyse_script`] /
+//! [`analyse_cfg_function`]), the interprocedural fixpoint
+//! ([`solve_interprocedural_escape`]), and slot resolution
+//! ([`populate_local_slots`]) — into per-proc [`ProcEscapeSummary`]s keyed
+//! by qualified name.
+//!
+//! Two entry points mirror the two Python source modes:
+//!
+//! * [`analyse_var_escape`] — the **IR-only tree walk**. This is the path
+//!   the inliner consumes (`pure_leaf` is computed here); it needs only the
+//!   lowered [`Module`].
+//! * [`analyse_var_escape_cu`] — the **flow-sensitive CFG + SSA** path,
+//!   driven from a [`CompilationUnit`]. Used by codegen for the per-SSA
+//!   frame analysis; it leaves `pure_leaf` at its default (the inlining
+//!   predicate is only meaningful on the IR path), matching Python.
+
+use std::collections::HashMap;
+
+use crate::compilation_unit::CompilationUnit;
+use crate::ir::Module;
+
+use super::cfg_propagation::{analyse_cfg_function, CfgEscapeResult};
+use super::interprocedural::solve_interprocedural_escape;
+use super::slot_resolution::populate_local_slots;
+use super::types::{EscapeTag, ProcEscapeSummary};
+use super::walker::analyse_script;
+
+/// Qualified name the top-level script is keyed under. Callers that only
+/// care about proc bodies filter it out. Mirrors Python's
+/// `TOP_LEVEL_QNAME`.
+pub const TOP_LEVEL_QNAME: &str = "::top";
+
+/// Convert a flow-sensitive [`CfgEscapeResult`] to a per-name
+/// [`ProcEscapeSummary`]. Per-SSA-version tags are collapsed by
+/// "FRAME wins" (already done in `name_tags`); the per-version detail is
+/// preserved in [`ProcEscapeSummary::ssa_tags`]. `pure_leaf` is left at
+/// its default — the inlining predicate is computed only on the IR-walk
+/// path. Mirrors `_cfg_result_to_summary`.
+#[must_use]
+pub fn cfg_result_to_summary(result: &CfgEscapeResult) -> ProcEscapeSummary {
+    let frame_needed = result.dynamic_barrier()
+        || result.name_tags.values().any(|t| *t == EscapeTag::Frame);
+    ProcEscapeSummary {
+        tags: result.name_tags.clone(),
+        flags: result.flags,
+        frame_needed,
+        upvar_source_names: result.upvar_source_names.clone(),
+        direct_callees: result.direct_callees.clone(),
+        ssa_tags: result.ssa_tags.clone(),
+        local_slots: std::collections::BTreeMap::new(),
+        barriers: result.barriers.clone(),
+        tag_reasons: result.tag_reasons.clone(),
+        pure_leaf: false,
+    }
+}
+
+/// Per-proc escape summaries from the lowered IR module (tree-walk path),
+/// keyed by qualified name with the top level under [`TOP_LEVEL_QNAME`].
+///
+/// When `interprocedural` is `true` (the production default) callee-induced
+/// escapes and the transitive `pure_leaf` fixpoint are folded in; pass
+/// `false` to inspect the raw per-proc result (tests). Compile-time local
+/// slot indices are always folded in last. Mirrors `analyse_var_escape`'s
+/// `ir_module=` path.
+#[must_use]
+pub fn analyse_var_escape(module: &Module, interprocedural: bool) -> HashMap<String, ProcEscapeSummary> {
+    let mut result: HashMap<String, ProcEscapeSummary> = HashMap::new();
+    result.insert(
+        TOP_LEVEL_QNAME.to_owned(),
+        analyse_script(&module.top_level, std::iter::empty::<String>()),
+    );
+    for (qname, proc) in &module.procedures {
+        result.insert(
+            qname.clone(),
+            analyse_script(&proc.body, proc.params.iter().cloned()),
+        );
+    }
+    if interprocedural {
+        result = solve_interprocedural_escape(&result);
+    }
+    populate_local_slots(&result, Some(module))
+}
+
+/// Per-proc escape summaries from a [`CompilationUnit`] (the flow-sensitive
+/// CFG/SSA path). Used by codegen frame analysis. Mirrors
+/// `analyse_var_escape`'s `cu=` path.
+#[must_use]
+pub fn analyse_var_escape_cu(
+    cu: &CompilationUnit,
+    interprocedural: bool,
+) -> HashMap<String, ProcEscapeSummary> {
+    let mut result: HashMap<String, ProcEscapeSummary> = HashMap::new();
+    let top = analyse_cfg_function(&cu.top_level.cfg, &cu.top_level.ssa, std::iter::empty::<String>());
+    result.insert(TOP_LEVEL_QNAME.to_owned(), cfg_result_to_summary(&top));
+    for (qname, fu) in &cu.procedures {
+        let params = cu
+            .ir_module
+            .procedures
+            .get(qname)
+            .map(|p| p.params.clone())
+            .unwrap_or_default();
+        let proc = analyse_cfg_function(&fu.cfg, &fu.ssa, params);
+        result.insert(qname.clone(), cfg_result_to_summary(&proc));
+    }
+    if interprocedural {
+        result = solve_interprocedural_escape(&result);
+    }
+    populate_local_slots(&result, Some(&cu.ir_module))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lowering::lower_to_ir;
+    use tcl_registry::CommandRegistry;
+
+    fn summaries(src: &str) -> HashMap<String, ProcEscapeSummary> {
+        let module = lower_to_ir(src, &CommandRegistry::build_default());
+        analyse_var_escape(&module, true)
+    }
+
+    #[test]
+    fn pure_leaf_proc_is_flagged() {
+        // A leaf proc that only does pure value computation is pure-leaf.
+        let s = summaries("proc ::add {a b} { return [expr {$a + $b}] }");
+        let add = &s["::add"];
+        assert!(add.pure_leaf, "pure leaf proc should be flagged");
+        assert!(add.safe_to_inline());
+        assert!(add.safe_to_dce());
+        assert!(add.safe_for_frame_elision());
+    }
+
+    #[test]
+    fn upvar_proc_is_not_pure_leaf() {
+        // `upvar` makes the proc observe a caller frame — not pure-leaf.
+        let s = summaries("proc ::setit {name val} { upvar 1 $name v\n set v $val }");
+        assert!(!s["::setit"].pure_leaf, "upvar proc must not be pure-leaf");
+    }
+
+    #[test]
+    fn caller_of_impure_proc_is_downgraded() {
+        // `::wrap` is locally pure but calls `::setit` (upvar) — the
+        // transitive fixpoint downgrades `::wrap`.
+        let s = summaries(
+            "proc ::setit {name val} { upvar 1 $name v\n set v $val }\n\
+             proc ::wrap {} { setit x 1 }",
+        );
+        assert!(!s["::setit"].pure_leaf);
+        assert!(
+            !s["::wrap"].pure_leaf,
+            "caller of an impure proc must be downgraded, got {:?}",
+            s["::wrap"].pure_leaf,
+        );
+    }
+
+    #[test]
+    fn caller_of_frameless_builtin_stays_pure_leaf() {
+        // Calling only frameless runtime builtins (`puts`) keeps pure-leaf.
+        let s = summaries("proc ::log {} { puts hi }");
+        assert!(s["::log"].pure_leaf, "wrapper of a frameless builtin is pure-leaf");
+    }
+
+    #[test]
+    fn interprocedural_flag_off_keeps_pure_leaf() {
+        // The `interprocedural=false` path still runs the intraprocedural
+        // pass, so a genuinely pure leaf is flagged without the fixpoint.
+        let module = lower_to_ir(
+            "proc ::add {a b} { return [expr {$a + $b}] }",
+            &CommandRegistry::build_default(),
+        );
+        let raw = analyse_var_escape(&module, false);
+        assert!(raw["::add"].pure_leaf, "pure leaf flagged with IPA off");
+        // And the top level is present under the canonical key.
+        assert!(raw.contains_key(TOP_LEVEL_QNAME));
+    }
+}

--- a/rust/tcl-compiler/src/var_escape/interprocedural.rs
+++ b/rust/tcl-compiler/src/var_escape/interprocedural.rs
@@ -18,6 +18,8 @@
 //! Mirrors `core/compiler/var_escape/_interprocedural.py`.
 
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+
+use super::helpers::is_frameless_runtime_command;
 use std::hash::BuildHasher;
 
 use crate::var_escape::types::{EscapeFlags, ProcEscapeSummary};
@@ -92,10 +94,8 @@ pub fn solve_interprocedural_escape<S: BuildHasher>(
         return HashMap::new();
     }
 
-    // Resolve each callee. Drop ones that don't appear in
-    // ``summaries`` — those are either builtins (no escape) or
-    // unknowns (handled by the intra-procedural pessimistic
-    // fallback).
+    // Resolve each callee; drop ones absent from `summaries` (builtins —
+    // no escape — or unknowns handled by the intraproc pessimistic fallback).
     let mut resolved_callees: HashMap<String, HashSet<String>> = HashMap::new();
     for (qname, summary) in summaries {
         let mut callees: HashSet<String> = HashSet::new();
@@ -109,71 +109,11 @@ pub fn solve_interprocedural_escape<S: BuildHasher>(
         resolved_callees.insert(qname.clone(), callees);
     }
 
-    // Worklist fixpoint over transitive sources.
-    let mut transitive_sources: HashMap<String, HashSet<String>> = summaries
-        .iter()
-        .map(|(k, s)| {
-            (
-                k.clone(),
-                s.upvar_source_names.iter().cloned().collect::<HashSet<_>>(),
-            )
-        })
-        .collect();
-    let mut transitive_unbounded: HashMap<String, bool> = summaries
-        .iter()
-        .map(|(k, s)| (k.clone(), s.unbounded_upvar_source()))
-        .collect();
+    let (transitive_sources, transitive_unbounded) =
+        propagate_transitive_sources(summaries, &resolved_callees);
 
-    // Reverse edges: qname → set of qnames that call it.
-    let mut callers_of: HashMap<String, HashSet<String>> = summaries
-        .keys()
-        .map(|k| (k.clone(), HashSet::new()))
-        .collect();
-    for (qname, callees) in &resolved_callees {
-        for callee in callees {
-            callers_of
-                .entry(callee.clone())
-                .or_default()
-                .insert(qname.clone());
-        }
-    }
-
-    let mut worklist: VecDeque<String> = summaries.keys().cloned().collect();
-    let mut in_worklist: HashSet<String> = summaries.keys().cloned().collect();
-    while let Some(qname) = worklist.pop_front() {
-        in_worklist.remove(&qname);
-        let current_sources = transitive_sources[&qname].clone();
-        let current_unbounded = transitive_unbounded[&qname];
-        let callers = callers_of.get(&qname).cloned().unwrap_or_default();
-        for caller in callers {
-            let mut changed = false;
-            let caller_set = transitive_sources
-                .get_mut(&caller)
-                .expect("caller in summaries");
-            for s in &current_sources {
-                if caller_set.insert(s.clone()) {
-                    changed = true;
-                }
-            }
-            if current_unbounded {
-                let cu = transitive_unbounded
-                    .get_mut(&caller)
-                    .expect("caller in summaries");
-                if !*cu {
-                    *cu = true;
-                    changed = true;
-                }
-            }
-            if changed && !in_worklist.contains(&caller) {
-                worklist.push_back(caller.clone());
-                in_worklist.insert(caller);
-            }
-        }
-    }
-
-    // Derive the final ``has_fallback`` for each proc.
-    //   final = intraproc has_fallback
-    //         | (has_call_fallback & not all-callees-resolve)
+    // Final `has_fallback` = intraproc has_fallback | (has_call_fallback &
+    // not all-callees-resolve).
     let mut downgraded_fallback: HashMap<String, bool> = HashMap::new();
     for (qname, summary) in summaries {
         let call_fallback_final = if summary.has_call_fallback() {
@@ -203,7 +143,104 @@ pub fn solve_interprocedural_escape<S: BuildHasher>(
             .set(EscapeFlags::HAS_FALLBACK, downgraded_fallback[qname]);
         result.insert(qname.clone(), new_summary);
     }
+
+    downgrade_non_pure_leaf_callers(&mut result);
     result
+}
+
+/// Worklist fixpoint that flows each proc's `upvar` source set (and the
+/// unbounded-source flag) up to every transitive caller. Returns the
+/// per-proc transitive source set and unbounded flag.
+fn propagate_transitive_sources<S: BuildHasher>(
+    summaries: &HashMap<String, ProcEscapeSummary, S>,
+    resolved_callees: &HashMap<String, HashSet<String>>,
+) -> (HashMap<String, HashSet<String>>, HashMap<String, bool>) {
+    let mut transitive_sources: HashMap<String, HashSet<String>> = summaries
+        .iter()
+        .map(|(k, s)| (k.clone(), s.upvar_source_names.iter().cloned().collect()))
+        .collect();
+    let mut transitive_unbounded: HashMap<String, bool> = summaries
+        .iter()
+        .map(|(k, s)| (k.clone(), s.unbounded_upvar_source()))
+        .collect();
+
+    // Reverse edges: qname → set of qnames that call it.
+    let mut callers_of: HashMap<String, HashSet<String>> =
+        summaries.keys().map(|k| (k.clone(), HashSet::new())).collect();
+    for (qname, callees) in resolved_callees {
+        for callee in callees {
+            callers_of.entry(callee.clone()).or_default().insert(qname.clone());
+        }
+    }
+
+    let mut worklist: VecDeque<String> = summaries.keys().cloned().collect();
+    let mut in_worklist: HashSet<String> = summaries.keys().cloned().collect();
+    while let Some(qname) = worklist.pop_front() {
+        in_worklist.remove(&qname);
+        let current_sources = transitive_sources[&qname].clone();
+        let current_unbounded = transitive_unbounded[&qname];
+        let callers = callers_of.get(&qname).cloned().unwrap_or_default();
+        for caller in callers {
+            let mut changed = false;
+            let caller_set = transitive_sources.get_mut(&caller).expect("caller in summaries");
+            for s in &current_sources {
+                if caller_set.insert(s.clone()) {
+                    changed = true;
+                }
+            }
+            if current_unbounded {
+                let cu = transitive_unbounded.get_mut(&caller).expect("caller in summaries");
+                if !*cu {
+                    *cu = true;
+                    changed = true;
+                }
+            }
+            if changed && !in_worklist.contains(&caller) {
+                worklist.push_back(caller.clone());
+                in_worklist.insert(caller);
+            }
+        }
+    }
+    (transitive_sources, transitive_unbounded)
+}
+
+/// **S3.4 — transitive `pure_leaf` fixpoint.** A proc stays `pure_leaf` only
+/// if every direct callee is itself `pure_leaf` — or an unresolved but
+/// known frameless runtime builtin (`puts` / `list` / `string` / …), which
+/// captures no caller locals and introduces no upvar alias, so a wrapper
+/// around it is still safe to splice. Iterates to a fixpoint (bounded by
+/// the proc count). Mirrors the loop in Python's
+/// `solve_interprocedural_escape`.
+fn downgrade_non_pure_leaf_callers<S: BuildHasher>(
+    result: &mut HashMap<String, ProcEscapeSummary, S>,
+) {
+    let mut changed = true;
+    while changed {
+        changed = false;
+        let qnames: Vec<String> = result.keys().cloned().collect();
+        for qname in qnames {
+            if !result[&qname].pure_leaf {
+                continue;
+            }
+            let callees: Vec<String> = result[&qname].direct_callees.iter().cloned().collect();
+            let downgrade = callees.iter().any(|callee| {
+                result.get(callee).map_or_else(
+                    || {
+                        let bare = callee.strip_prefix("::").unwrap_or(callee);
+                        !is_frameless_runtime_command(bare)
+                    },
+                    |c| !c.pure_leaf,
+                )
+            });
+            if downgrade {
+                result
+                    .get_mut(&qname)
+                    .expect("qname in result")
+                    .pure_leaf = false;
+                changed = true;
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/tcl-compiler/src/var_escape/mod.rs
+++ b/rust/tcl-compiler/src/var_escape/mod.rs
@@ -22,6 +22,7 @@
 //!   slot indices for proc-locals (mirrors upstream
 //!   ``957dc1f6`` / PR #334).
 
+pub mod api;
 pub mod cfg_propagation;
 pub mod handlers;
 pub mod helpers;
@@ -33,6 +34,7 @@ pub mod state;
 pub mod types;
 pub mod walker;
 
+pub use api::{analyse_var_escape, analyse_var_escape_cu, cfg_result_to_summary, TOP_LEVEL_QNAME};
 pub use cfg_propagation::analyse_cfg_function;
 pub use interprocedural::solve_interprocedural_escape;
 pub use slot_resolution::{LOCALS_ARRAY_CAP, assign_local_slots, populate_local_slots};

--- a/rust/tcl-compiler/src/var_escape/types.rs
+++ b/rust/tcl-compiler/src/var_escape/types.rs
@@ -309,9 +309,55 @@ pub struct ProcEscapeSummary {
     /// so downstream consumers (LSP, compiler explorer) can adopt
     /// it incrementally.
     pub tag_reasons: HashMap<String, Vec<EscapeReason>>,
+    /// **S3.4 — pure-leaf flag.** `true` when this proc is provably
+    /// pure-leaf: no escaping var (no `Frame` tag, no dynamic barrier),
+    /// no eval / call fallback, no `upvar` source out, and — after the
+    /// interprocedural fixpoint — every direct callee is itself pure-leaf
+    /// (or a known frameless runtime builtin). The inliner reads this as
+    /// the soundness predicate for splicing a body into a caller.
+    ///
+    /// The walker sets the *intraprocedural* base value (the per-proc
+    /// clause); [`solve_interprocedural_escape`](crate::var_escape::solve_interprocedural_escape)
+    /// can only **downgrade** it (a proc whose callee is opaque is no
+    /// longer pure-leaf). Default `false` — anything unclassified stays
+    /// opaque.
+    pub pure_leaf: bool,
 }
 
 impl ProcEscapeSummary {
+    /// Whether the proc body can be physically relocated into a caller's
+    /// IR without changing observable behaviour (the inliner's gate).
+    /// Identical to [`Self::pure_leaf`] today; split out so a future
+    /// relaxation can separate the body-frame-observation clause from the
+    /// transitive callee clause. Mirrors Python's `safe_to_inline`.
+    #[must_use]
+    pub fn safe_to_inline(&self) -> bool {
+        self.pure_leaf
+    }
+
+    /// Whether dead-store elimination on this proc's locals is sound — a
+    /// relaxation of [`Self::pure_leaf`] that drops the transitive
+    /// "callees are pure-leaf" clause (DCE only cares whether an external
+    /// observer can read our locals, not what callees do). Mirrors
+    /// Python's `safe_to_dce`.
+    #[must_use]
+    pub fn safe_to_dce(&self) -> bool {
+        !self.frame_needed
+            && !self.has_fallback()
+            && !self.has_call_fallback()
+            && self.upvar_source_names.is_empty()
+            && !self.unbounded_upvar_source()
+    }
+
+    /// Whether codegen may omit the per-call frame push/pop for this proc
+    /// — the proc's frame is never observed externally. A relaxation of
+    /// [`Self::pure_leaf`] that only requires `!frame_needed`. Mirrors
+    /// Python's `safe_for_frame_elision`.
+    #[must_use]
+    pub fn safe_for_frame_elision(&self) -> bool {
+        !self.frame_needed
+    }
+
     /// True if the whole-proc dynamic-barrier marker is set.
     ///
     /// Returns `true` when either the [`EscapeFlags::DYNAMIC_BARRIER`]
@@ -451,13 +497,18 @@ impl ProcEscapeSummary {
         pessimistic: bool,
     ) -> Self {
         let mut new_tags = self.tags.clone();
+        let mut any_extra = false;
         for name in extra_escaped {
             new_tags.insert(name, EscapeTag::Frame);
+            any_extra = true;
         }
         let new_pessimistic = self.dynamic_barrier() || pessimistic;
         let new_frame_needed = new_pessimistic || new_tags.values().any(|t| *t == EscapeTag::Frame);
         let mut new_flags = self.flags;
         new_flags.set(EscapeFlags::DYNAMIC_BARRIER, new_pessimistic);
+        // A callee-induced escape or a pessimistic downgrade clears
+        // pure_leaf. Mirrors Python's `with_escapes` new_pure_leaf.
+        let new_pure_leaf = self.pure_leaf && !any_extra && !new_pessimistic;
         Self {
             tags: new_tags,
             flags: new_flags,
@@ -468,6 +519,7 @@ impl ProcEscapeSummary {
             local_slots: self.local_slots.clone(),
             barriers: self.barriers.clone(),
             tag_reasons: self.tag_reasons.clone(),
+            pure_leaf: new_pure_leaf,
         }
     }
 
@@ -487,6 +539,7 @@ impl ProcEscapeSummary {
             local_slots: slots,
             barriers: self.barriers.clone(),
             tag_reasons: self.tag_reasons.clone(),
+            pure_leaf: self.pure_leaf,
         }
     }
 }

--- a/rust/tcl-compiler/src/var_escape/walker.rs
+++ b/rust/tcl-compiler/src/var_escape/walker.rs
@@ -642,6 +642,16 @@ pub fn analyse_script<I: IntoIterator<Item = String>>(
     walk(&body.statements, &mut state);
     let frame_needed =
         state.dynamic_barrier() || state.tags.values().any(|t| *t == EscapeTag::Frame);
+    // S3.4: tentative pure_leaf — the interprocedural fixpoint can only
+    // downgrade it (a proc with an opaque callee loses the flag). Pure
+    // means: no escape, no eval/call fallback, no `upvar` source out, no
+    // unbounded upvar source. Mirrors the predicate in Python's
+    // `_propagation.analyse_script`.
+    let pure_leaf = !frame_needed
+        && !state.flags.has_fallback()
+        && !state.flags.has_call_fallback()
+        && state.upvar_source_names.is_empty()
+        && !state.flags.unbounded_upvar_source();
     ProcEscapeSummary {
         tags: state.tags,
         flags: state.flags,
@@ -650,6 +660,7 @@ pub fn analyse_script<I: IntoIterator<Item = String>>(
         direct_callees: state.direct_callees,
         ssa_tags: std::collections::HashMap::new(),
         local_slots: std::collections::BTreeMap::new(),
+        pure_leaf,
         // SYNC-JUN-FRAME356-population: thread the structured
         // per-proc barriers + per-name escape reasons recorded by
         // the handlers into the summary so downstream consumers


### PR DESCRIPTION
## Summary

Advances the two Stage-1 front-end tracks in `docs/rust-rewrite.md`. **FE-VARESCAPE is now complete**; **FE-OPT has every O-code optimiser pass done**, leaving the parameterised inliner (v3) as the sole residual.

### FE-VARESCAPE — complete
- **Orchestrator** (`var_escape/api.rs`): `analyse_var_escape` (IR tree-walk path — the one that populates `pure_leaf`, consumed by the inliner) and `analyse_var_escape_cu` (flow-sensitive CFG/SSA path for codegen), plus `cfg_result_to_summary`. Threads the already-landed `analyse_script` / `analyse_cfg_function` / `solve_interprocedural_escape` / `populate_local_slots` pieces.
- **`pure_leaf` family**: added the `pure_leaf` field plus the derived `safe_to_inline` / `safe_to_dce` / `safe_for_frame_elision` predicates to `ProcEscapeSummary`. The walker computes the intraprocedural base; `with_escapes` clears it on a callee-induced escape; `solve_interprocedural_escape` gained the transitive fixpoint (a proc stays pure-leaf only if every direct callee is pure-leaf or a known frameless builtin).
- Wired the inliner to gate on the precise `safe_to_inline` proof — closing the FE-OPT ↔ FE-VARESCAPE dependency.

### FE-OPT — every O-code pass complete
**Soundness gates restored (were miscompiles):**
- **O120** — eq/ne→`eq`/`ne` only when an operand is a provably non-numeric string literal (`$x == "1"` no longer flips for numeric `$x`).
- **O114** — `set/expr`→`incr` gated on the variable being provably `Int`.
- **O108** — ADCE routed through the `assignment_safe_to_delete` purity gate (impure-RHS dead assignments kept).

**Applied rewrites (were hint-only / absent):**
- **O104 / O130** write-only string/list build-chain folds, incl. **precise-flow** across safe interleaved writes.
- **O119** multi-set packing; **O128** end-offset index rewrite (`[expr {[llength $L] - 1}]` → `end`).

**Precision / correctness:**
- **O106** category registration + **latch-dominance** "runs every iteration" gate.
- **O123** accumulator hint gated on single self-call + associative op (no longer fires on `fib`).
- **O110** logical-identity boolify + `bool_context` threading; tightened `!!x`/`~~x` collapses.
- **O125** cross-event-var + already-covered guards + multi-branch deepest-target descent.
- **O101/O115** branch-condition coverage; **O103** rename gate + namespace-chain resolution.

**General proc inliner (`inlining.rs`):** v0 (empty body) + v1/v2 (zero-param verbatim wrapper) shapes, gated on `safe_to_inline` + per-statement splice-eligibility. Exposed but not yet pipeline-wired (its only consumer is the WASM codegen).

### Sole remaining FE-OPT item: inliner v3
The parameterised α-rename (~800–1000 LOC, capture-sensitive). It is **gated on RT-WASM**: the repo's mandatory differential-test standard ("run Python and Rust in parallel, assert identical output") cannot be met for the capture-sensitive value-string rewriter without an execution path (RT-WASM) or a Python↔Rust IR bridge, neither of which exists yet. It will land alongside the consumer that can execution-verify it, as the plan now documents.

## Validation
- `tcl-compiler` (2804) and `tcl-lsp-core` (608) unit suites green; `cargo clippy` clean; full workspace builds.
- Every pass mirrors the Python reference (`compiler/optimiser/*`, `compiler/var_escape/*`) and, where it emits code, was cross-checked against `tclsh` 8.4–9.0.
- `docs/rust-rewrite.md` (plan) and `rust-rewrite-history.md` updated in lockstep: FE-VARESCAPE row ✅ (section retired), optimiser row 🟢.

## Compiler/KCS checklist
- [x] No changes to compiler fact contracts; all new analysis/optimisation logic is additive.
- [x] No new KCS notes required (ports of existing Python analysis with documented soundness gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNK5a3Gtqneo585tqZaJaC