### PR TITLE
Finish the SRV-LSP track (codeLens/resolve, inlay type hints, UTF-16, panic containment)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
 name = "tcl-lsp-core"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "tcl-compiler",
  "tcl-irules",
  "tcl-lexer",

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -973,7 +973,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
-| LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | 🟢 | incremental reanalysis; UTF-16 residuals; registry/CU sharing + debounce; panic containment; token/reposition cache; rope state; `codeLens/resolve`; inlay type-hints → **SRV-LSP** |
+| LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | incremental reanalysis (salsa `file_analysis_incremental` + cancellation); UTF-16 `position_encoding`; registry/CU sharing (`OnceLock` + `memoised_compilation_unit`) + debounce; panic containment (8 inline handlers → `spawn_blocking`); token memo (salsa `semantic_tokens`); `codeLens/resolve`; inlay type-hints. Residual: rope-backed `DocumentState` deferred (pipeline is `&str`-based) → **SRV-LSP** |
 | `tcl` CLI | `tcl-cli` | 🟡 | `dis`/`compwasm`/`pkg`/`venv`/`docker` verbs → **TOOL-CLI** |
 | `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --simulate/--tshark/--keylog`; a few parity files → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
@@ -1352,28 +1352,48 @@ below are the live state.
 
 #### SRV-LSP — server / core / db
 Owns `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db`.
-- **open** incremental server reanalysis — the server re-analyses the whole
-  document per edit; wire the bounded `reparse_window` + `analyse_incremental`
-  (`analyser/state.rs:984`, already differential-fuzzed).
-- **open** C1 UTF-16 residuals — route the remaining byte `position_at` sites
-  (`folding.rs`, `irules_context.rs`) through the UTF-16 variant and set
-  `position_encoding`. *(small; the hot paths already converted)*
-- **open** performance — build the ~560-spec registry once into a process-wide
-  `OnceLock` (rebuilt inside every `analyse`); build one shared
-  `CompilationUnit` (taint/CU built 2–3× per document); add a debounce with
-  cancel-previous.
-- **open** panic containment (review-findings C3) — move the ~8 inline handlers
-  to `spawn_blocking`.
-- **open** token memo / reposition cache (the archive's `SYNC-MAY31-6/-11`) and a
-  rope-backed `DocumentState`.
-- **open** `codeLens/resolve` unimplemented — the Rust server advertises code
-  lenses but replies `-32601 Method not found` to `codeLens/resolve`, so lens
-  titles never resolve (`tests/lsp_e2e/test_editor_features_e2e.py::TestCodeLens::
+- **done** incremental server reanalysis — the base analysis runs through the
+  cancellable salsa `file_analysis_incremental` query (`tcl-lsp-db`), and
+  `set_text` cancels an in-flight read at a per-item query boundary, so an edit
+  reuses every unchanged procedure's memoised per-function lattice instead of
+  re-analysing the whole document.
+- **done** C1 UTF-16 residuals — the server advertises `position_encoding`
+  (UTF-16, negotiated against the client's `general.positionEncodings`); the
+  former byte `position_at(...).line` sites in `folding.rs` / `irules_context.rs`
+  now use the encoding-independent `LineIndex::line_at`.
+- **done** performance — the ~560-spec registry is built once per canonical
+  dialect (process-wide `OnceLock` in `tcl-registry::cache`, plus the server's
+  shared `TclDatabase::registry` map); the `CompilationUnit` is shared across
+  the analyser tail and the optimiser checks via the salsa-memoised
+  `memoised_compilation_unit` / `function_lattice`; and the diagnostics path
+  debounces with a generation-supersede check (`DEBOUNCE`).
+- **done** panic containment (review-findings C3) — the 8 inline handlers
+  (`folding_range`, `document_symbol`, `semantic_tokens_full`/`_delta`/`_range`,
+  `document_link`, `formatting`/`range_formatting`) run on `spawn_blocking`, so a
+  parser panic surfaces as a JSON-RPC error rather than unwinding the event loop.
+- **done** token memo — semantic tokens are served from the salsa-memoised
+  `semantic_tokens` query (`db_semantic_tokens`), so a token request after an
+  edit reuses the per-item firewall rather than recomputing; this supersedes the
+  Python-era `SYNC-MAY31-6/-11` reposition cache.
+  - **deferred (architecture)** a rope-backed `DocumentState`. The analysis
+    pipeline is `&str`/byte-offset throughout (lexer, segmenter, and the salsa
+    `SourceFile` input all hold a `String`), so a rope would still have to
+    materialise a `String` (`O(n)`) for every analysis — it would only speed up
+    applying a *burst* of edits inside one `didChange`, which editors rarely
+    send. Not worth the dependency + hot-path churn until the pipeline itself
+    is rope-aware.
+- **done** `codeLens/resolve` — the server advertises `resolve_provider`, carries
+  `{qname, uri}` in the lens data, and recomputes the reference count against the
+  live document/workspace at resolve time
+  (`tests/lsp_e2e/test_editor_features_e2e.py::TestCodeLens::
   test_count_matches_reference_list_for_forward_call`,
   `::TestCodeLens::test_unresolved_call_scoped_to_namespace`).
-- **open** inlay **type** hints — the Rust server emits parameter-label inlays
-  but no type-hint inlays, and the legacy `inlayHints` config alias never
-  settles `inlayTypeHints` (`test_editor_features_e2e.py::
+- **done** inlay **type** hints — the provider emits the inferred-variable-type
+  family (`: int`, shimmer `from → to`, built from the type-propagation pass over
+  a `CompilationUnit`) and the format-string specifier labels
+  (`format`/`scan`/`clock`/`binary`/`regsub`); the two inlay families gate
+  independently and the legacy `inlayHints` alias settles `inlayTypeHints`
+  (`test_editor_features_e2e.py::
   TestInlayToggleIndependenceE2E::test_type_hints_only_emit_no_parameter_labels`,
   `::TestInlayLegacyAliasE2E::test_legacy_inlay_hints_alias_enables_type_only`).
 

--- a/rust/tcl-lexer/src/line_index.rs
+++ b/rust/tcl-lexer/src/line_index.rs
@@ -256,7 +256,11 @@ mod tests {
         let src = "á\nbc\nd";
         let idx = LineIndex::new(src);
         for off in [0u32, 2, 3, 5, 6] {
-            assert_eq!(idx.line_at(off), idx.position_at(off).line, "byte off {off}");
+            assert_eq!(
+                idx.line_at(off),
+                idx.position_at(off).line,
+                "byte off {off}"
+            );
             assert_eq!(
                 idx.line_at(off),
                 idx.position_at_utf16(off, src).line,

--- a/rust/tcl-lexer/src/line_index.rs
+++ b/rust/tcl-lexer/src/line_index.rs
@@ -113,6 +113,23 @@ impl LineIndex {
         )
     }
 
+    /// Zero-based line number containing byte `offset`.
+    ///
+    /// The line index is independent of column encoding (it counts line
+    /// breaks, not characters), so this is the right accessor whenever a
+    /// caller needs only the line — folding ranges, body-span line
+    /// extents — and avoids the choice between the byte
+    /// [`Self::position_at`] and the UTF-16 [`Self::position_at_utf16`]
+    /// columns, neither of which the caller reads.
+    #[must_use]
+    pub fn line_at(&self, offset: u32) -> u32 {
+        let line_idx = self
+            .line_starts
+            .partition_point(|&start| start <= offset)
+            .saturating_sub(1);
+        u32::try_from(line_idx).expect("line count fits u32")
+    }
+
     /// LSP-compliant variant of [`Self::position_at`] that returns
     /// a `character` column counted in UTF-16 code units (per the
     /// LSP specification's "Position" type, which defines
@@ -230,6 +247,22 @@ mod tests {
         assert_eq!(pos.line, 0);
         assert_eq!(pos.character, len); // clamped to the line's full length
         assert_eq!(pos.offset, len + 2); // raw offset preserved
+    }
+
+    #[test]
+    fn line_at_matches_position_at_line_for_multibyte() {
+        // 'á' is two bytes; the line number must not depend on column
+        // encoding, so `line_at` agrees with both column variants' `.line`.
+        let src = "á\nbc\nd";
+        let idx = LineIndex::new(src);
+        for off in [0u32, 2, 3, 5, 6] {
+            assert_eq!(idx.line_at(off), idx.position_at(off).line, "byte off {off}");
+            assert_eq!(
+                idx.line_at(off),
+                idx.position_at_utf16(off, src).line,
+                "utf16 off {off}"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-lsp-core/Cargo.toml
+++ b/rust/tcl-lsp-core/Cargo.toml
@@ -13,6 +13,7 @@ tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-irules = { path = "../tcl-irules" }
+regex = "1"
 
 [lints]
 workspace = true

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -257,9 +257,9 @@ fn emit_body_span_fold(
     if span.is_empty() {
         return;
     }
-    let start_line = line_index.position_at(span.start()).line;
+    let start_line = line_index.line_at(span.start());
     let end_offset = span.end().saturating_sub(1) as usize;
-    let raw_end_line = line_index.position_at(span.end().saturating_sub(1)).line;
+    let raw_end_line = line_index.line_at(span.end().saturating_sub(1));
     if start_line < raw_end_line {
         let end_line = adjust_body_end_line(source, end_offset, raw_end_line);
         push_unique(seen, ranges, start_line, end_line, FoldKind::Region);
@@ -366,7 +366,7 @@ fn collect_continuation_folds(
         }
         let start = tok.span.start();
         if bytes.get(start as usize) == Some(&b'\\') {
-            continued.insert(line_index.position_at(start).line);
+            continued.insert(line_index.line_at(start));
         }
     }
 

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -563,7 +563,7 @@ fn collect_format_string_hints(
                 }
             }
             FormatArg::Binary(_) => {
-                collect_binary_hints(content, cstart, range, source, line_index, out)
+                collect_binary_hints(content, cstart, range, source, line_index, out);
             }
             FormatArg::Regsub(_) => {
                 for m in REGSUB_RE.captures_iter(content) {

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -120,7 +120,15 @@ pub fn inlay_hints(
 
     if type_hints {
         if let Some(registry) = registry {
-            collect_type_hints(source, dialect, analysis, registry, range, &line_index, &mut out);
+            collect_type_hints(
+                source,
+                dialect,
+                analysis,
+                registry,
+                range,
+                &line_index,
+                &mut out,
+            );
         }
         collect_format_string_hints(source, dialect, range, &line_index, &mut out);
     }
@@ -554,7 +562,9 @@ fn collect_format_string_hints(
                     }
                 }
             }
-            FormatArg::Binary(_) => collect_binary_hints(content, cstart, range, source, line_index, out),
+            FormatArg::Binary(_) => {
+                collect_binary_hints(content, cstart, range, source, line_index, out)
+            }
             FormatArg::Regsub(_) => {
                 for m in REGSUB_RE.captures_iter(content) {
                     let whole = m.get(0).expect("group 0");
@@ -960,7 +970,15 @@ mod tests {
     fn hints_emitted_for_user_proc_call() {
         let src = "proc greet {name greeting} {}\ngreet alice hello\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            false,
+            true,
+        );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert!(
             labels.contains(&"name:"),
@@ -976,7 +994,15 @@ mod tests {
     fn hints_anchored_at_argument_start() {
         let src = "proc greet {name} {}\ngreet alice\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            false,
+            true,
+        );
         assert_eq!(hints.len(), 1);
         let h = &hints[0];
         assert_eq!(h.position_line, 1);
@@ -989,7 +1015,15 @@ mod tests {
     fn no_hints_for_unknown_command() {
         let src = "unknown_cmd a b c\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            false,
+            true,
+        );
         assert!(hints.is_empty(), "{hints:?}");
     }
 
@@ -999,7 +1033,15 @@ mod tests {
         // because there's no individual name to surface.
         let src = "proc many {first args} {}\nmany 1 2 3 4\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            false,
+            true,
+        );
         // Only the `first` arg gets a hint.
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].label, "first:");
@@ -1012,7 +1054,15 @@ mod tests {
         // no hints (no name to attach).
         let src = "proc one {a} {}\none 1 2 3\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            false,
+            true,
+        );
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].label, "a:");
     }
@@ -1271,7 +1321,15 @@ mod tests {
         // Same source, no registry — no built-in hints.
         let src = "string index $s 3\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            false,
+            true,
+        );
         assert!(hints.is_empty(), "{hints:?}");
     }
 
@@ -1325,7 +1383,10 @@ mod tests {
             "{type_hints:?}",
         );
         // No parameter hints leak in when only type hints are requested.
-        assert!(hints.iter().all(|h| h.kind == InlayHintKind::Type), "{hints:?}");
+        assert!(
+            hints.iter().all(|h| h.kind == InlayHintKind::Type),
+            "{hints:?}"
+        );
     }
 
     #[test]
@@ -1379,7 +1440,9 @@ mod tests {
         );
         assert!(!param_only.is_empty(), "expected parameter hints");
         assert!(
-            param_only.iter().all(|h| h.kind == InlayHintKind::Parameter),
+            param_only
+                .iter()
+                .all(|h| h.kind == InlayHintKind::Parameter),
             "{param_only:?}",
         );
     }

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -328,7 +328,7 @@ fn clock_short(c: char) -> Option<&'static str> {
     Some(match c {
         'Y' => "year",
         'y' => "yr",
-        'm' => "month",
+        'm' | 'B' => "month",
         'd' | 'e' => "day",
         'H' | 'k' => "hour",
         'I' | 'l' => "hour12",
@@ -340,15 +340,13 @@ fn clock_short(c: char) -> Option<&'static str> {
         'a' => "wday",
         'A' => "weekday",
         'b' => "mon",
-        'B' => "month",
         'c' => "datetime",
-        'D' => "date",
+        'D' | 'x' => "date",
         'j' => "yday",
         'u' | 'w' => "wday#",
         'U' | 'W' => "week",
         'V' => "isoweek",
         'z' | 'Z' => "tz",
-        'x' => "date",
         'X' => "time",
         'C' => "century",
         'g' | 'G' => "isoyear",
@@ -485,7 +483,7 @@ fn push_format_hint(
     line_index: &LineIndex,
     out: &mut Vec<InlayHint>,
 ) {
-    let pos = line_index.position_at_utf16(abs_byte as u32, source);
+    let pos = line_index.position_at_utf16(u32::try_from(abs_byte).unwrap_or(u32::MAX), source);
     if pos.line < range.start_line || pos.line > range.end_line {
         return;
     }

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -41,11 +41,30 @@
 //!   analyser's method-resolution machinery that
 //!   `S-references-rich` will eventually land.
 
-use tcl_compiler::analyser::{AnalysisResult, ProcDef};
+use std::collections::HashMap;
+
+use tcl_compiler::analyser::{AnalysisResult, ProcDef, Scope};
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::types::{TypeKind, TypeLattice};
 use tcl_lexer::LineIndex;
-use tcl_registry::CommandRegistry;
+use tcl_registry::{CommandRegistry, TclType};
 
 use crate::definition::LspRange;
+
+/// Which inlay-hint family a hint belongs to.
+///
+/// Mirrors the LSP `InlayHintKind` split the server lifts to: inferred
+/// variable types and format-string specifier labels are [`Self::Type`];
+/// the proc / built-in parameter-name labels at call sites are
+/// [`Self::Parameter`].  Each family is gated independently
+/// (`inlayTypeHints` / `inlayParameterHints`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlayHintKind {
+    /// Inferred variable type or format-specifier annotation (`: int`).
+    Type,
+    /// Call-site parameter-name label (`name:`).
+    Parameter,
+}
 
 /// One inlay-hint entry — position plus label.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +76,11 @@ pub struct InlayHint {
     pub position_character: u32,
     /// Hint label (e.g. `name:`).
     pub label: String,
+    /// Which family this hint belongs to (Type vs Parameter).
+    pub kind: InlayHintKind,
+    /// Whether the editor should pad a space to the left of the label
+    /// (the inferred-type / format hints render as ` : int`).
+    pub padding_left: bool,
 }
 
 /// Compute inlay hints for `range` in `source`.
@@ -65,7 +89,16 @@ pub struct InlayHint {
 /// the hints need.  When `analysis` is `None` (a stub-only
 /// caller from the minimal port), returns an empty vector.
 /// `registry`, when `Some`, additionally surfaces parameter-
-/// name hints for built-in commands via their synopsis.
+/// name hints for built-in commands via their synopsis (and is
+/// required for the inferred-type hints, which build a
+/// [`CompilationUnit`] from it).
+///
+/// `type_hints` gates the inferred-variable-type annotations and the
+/// format-string specifier labels ([`InlayHintKind::Type`]);
+/// `parameter_hints` gates the call-site parameter-name labels
+/// ([`InlayHintKind::Parameter`]).  Each family is requested
+/// independently so an editor can opt into one without the other,
+/// mirroring Python's `get_inlay_hints(type_hints=…, parameter_hints=…)`.
 #[must_use]
 pub fn inlay_hints(
     source: &str,
@@ -73,38 +106,520 @@ pub fn inlay_hints(
     range: LspRange,
     analysis: Option<&AnalysisResult>,
     registry: Option<&CommandRegistry>,
+    type_hints: bool,
+    parameter_hints: bool,
 ) -> Vec<InlayHint> {
+    if !type_hints && !parameter_hints {
+        return Vec::new();
+    }
     let Some(analysis) = analysis else {
         return Vec::new();
     };
     let line_index = LineIndex::new(source);
+    let mut out = Vec::new();
+
+    if type_hints {
+        if let Some(registry) = registry {
+            collect_type_hints(source, dialect, analysis, registry, range, &line_index, &mut out);
+        }
+        collect_format_string_hints(source, dialect, range, &line_index, &mut out);
+    }
+
+    if parameter_hints {
+        let segments = tcl_compiler::segmenter::segment_commands_with_offset_and_config(
+            source,
+            0,
+            tcl_lexer::LexerConfig::for_dialect(dialect),
+        );
+        for seg in &segments {
+            if seg.texts.is_empty() || seg.argv.is_empty() {
+                continue;
+            }
+            let cmd_name = &seg.texts[0];
+            if let Some(proc_def) = lookup_proc(analysis, cmd_name) {
+                emit_hints_for_call(source, seg, proc_def, &line_index, range, &mut out);
+                continue;
+            }
+            // Built-in command — parse the registry synopsis for
+            // positional parameter names.  User procs take
+            // precedence (handled above).
+            if let Some(registry) = registry
+                && let Some(spec) = registry.get(cmd_name)
+            {
+                emit_builtin_hints(source, seg, spec, &line_index, range, &mut out);
+            }
+        }
+    }
+
+    out
+}
+
+/// Short display name for a Tcl intrep type — mirrors Python's
+/// `_TYPE_SHORT` / `_short_type`.
+fn short_type(t: TclType) -> &'static str {
+    match t {
+        TclType::String => "str",
+        TclType::Int => "int",
+        TclType::Double => "double",
+        TclType::Boolean => "bool",
+        TclType::List => "list",
+        TclType::Dict => "dict",
+        TclType::ByteArray => "bytes",
+        TclType::Numeric => "num",
+        TclType::Object => "object",
+        TclType::Channel => "channel",
+    }
+}
+
+/// Render a [`TypeLattice`] as its inlay display string, or `None`
+/// when the lattice carries no concrete type (Unknown / Overdefined,
+/// or a Shimmered lattice missing an endpoint).  A `Known` type shows
+/// `int`; a `Shimmered` one shows `from → to` (mirrors
+/// `_collect_type_hints`).
+fn type_display(tl: &TypeLattice) -> Option<String> {
+    match tl.kind {
+        TypeKind::Known => tl.tcl_type.map(|t| short_type(t).to_owned()),
+        TypeKind::Shimmered => match (tl.from_type, tl.tcl_type) {
+            (Some(from), Some(to)) => {
+                Some(format!("{} \u{2192} {}", short_type(from), short_type(to)))
+            }
+            _ => None,
+        },
+        TypeKind::Unknown | TypeKind::Overdefined => None,
+    }
+}
+
+/// Collect inferred-variable-type hints (`: int`) for variable
+/// definitions in `range`.  Rust port of `_collect_type_hints`:
+/// builds a name → display-type map from the type-propagation pass
+/// (over every function in a fresh [`CompilationUnit`]) and walks the
+/// analyser scope tree, annotating each variable definition whose type
+/// is known.
+fn collect_type_hints(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    registry: &CommandRegistry,
+    range: LspRange,
+    line_index: &LineIndex,
+    out: &mut Vec<InlayHint>,
+) {
+    let config = tcl_lexer::LexerConfig::for_dialect(dialect);
+    let cu = CompilationUnit::build_for_with_config(source, registry, false, config);
+
+    // Flatten the per-SSA-definition type lattices into a name → display
+    // map.  Like Python this is last-writer-wins across versions and
+    // functions; distinct names (the common case) are order-independent.
+    let mut type_map: HashMap<String, String> = HashMap::new();
+    for fu in cu.functions() {
+        for ((name, _ver), tl) in &fu.types {
+            if let Some(display) = type_display(tl) {
+                type_map.insert(name.clone(), display);
+            }
+        }
+    }
+    if type_map.is_empty() {
+        return;
+    }
+
+    walk_scope_type_hints(
+        &analysis.global_scope,
+        &type_map,
+        range,
+        source,
+        line_index,
+        out,
+    );
+}
+
+/// Recursively emit type hints for every variable definition in `scope`
+/// (and its children) whose name carries a known type and whose
+/// definition falls within `range`.
+fn walk_scope_type_hints(
+    scope: &Scope,
+    type_map: &HashMap<String, String>,
+    range: LspRange,
+    source: &str,
+    line_index: &LineIndex,
+    out: &mut Vec<InlayHint>,
+) {
+    for var_def in scope.variables.values() {
+        let Some(type_str) = type_map.get(&var_def.name) else {
+            continue;
+        };
+        let start = line_index.position_at_utf16(var_def.definition_span.start(), source);
+        let end = line_index.position_at_utf16(var_def.definition_span.end(), source);
+        // The hint sits immediately after the variable name; skip when the
+        // definition falls entirely outside the requested range.
+        if end.line < range.start_line || start.line > range.end_line {
+            continue;
+        }
+        out.push(InlayHint {
+            position_line: end.line,
+            position_character: end.character,
+            label: format!(": {type_str}"),
+            kind: InlayHintKind::Type,
+            padding_left: true,
+        });
+    }
+    for child in &scope.children {
+        walk_scope_type_hints(child, type_map, range, source, line_index, out);
+    }
+}
+
+// -- format-string specifier hints ---------------------------------------
+//
+// Rust port of `_collect_format_string_hints`.  These are `Type`-kind
+// hints that annotate the conversion specifiers inside the format string
+// of `format`/`scan` (`%d` → `int`), `clock format`/`scan` (`%Y` →
+// `year`), `binary format`/`scan` (`i` → `i32le`), and the substitution
+// backreferences of `regsub` (`\1` → `grp1`).  The compiled patterns
+// mirror the Python regexes one-for-one.
+
+/// `format`/`scan` conversion specifier — Python `_SPRINTF_RE`.  Capture
+/// group 6 is the conversion type letter.
+static SPRINTF_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(
+        r"%(?:(\d+)\\?\$)?([-+ 0#]*)?(\*|\d+)?(?:.(\*|\d+))?([hlLzq])?([aAbBcdieEfgGosuxX%])",
+    )
+    .expect("static sprintf regex")
+});
+
+/// `clock format`/`scan` specifier — Python `_CLOCK_FORMAT_RE`.  The
+/// significant letter is the final character of the match.
+static CLOCK_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"%(?:[EO])?[aAbBcCdDeEgGhHIjJklmMNOpPqQsSuUVwWxXyYzZ%]")
+        .expect("static clock regex")
+});
+
+/// `regsub` substitution backreference (`\0`-`\9`, `\&`) — Python
+/// `_REGSUB_BACKREF_RE`.  Capture group 1 is the back-reference char.
+static REGSUB_RE: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(r"\\([0-9&])").expect("static regsub regex"));
+
+/// Short label for a `format`/`scan` conversion type — Python
+/// `_SPRINTF_SHORT`.  `%` (literal percent) yields `None` so no hint is
+/// emitted for `%%`.
+fn sprintf_short(c: char) -> Option<&'static str> {
+    Some(match c {
+        's' => "str",
+        'd' | 'i' => "int",
+        'u' => "uint",
+        'o' => "oct",
+        'x' => "hex",
+        'X' => "HEX",
+        'f' => "float",
+        'e' => "exp",
+        'E' => "EXP",
+        'g' => "num",
+        'G' => "NUM",
+        'c' => "char",
+        'b' => "bin",
+        'B' => "BIN",
+        'a' => "hexf",
+        'A' => "HEXF",
+        _ => return None,
+    })
+}
+
+/// Short label for a `clock` field letter — Python `_CLOCK_SHORT`.
+#[allow(clippy::too_many_lines)]
+fn clock_short(c: char) -> Option<&'static str> {
+    Some(match c {
+        'Y' => "year",
+        'y' => "yr",
+        'm' => "month",
+        'd' | 'e' => "day",
+        'H' | 'k' => "hour",
+        'I' | 'l' => "hour12",
+        'M' => "min",
+        'S' => "sec",
+        's' => "epoch",
+        'p' => "AM/PM",
+        'P' => "am/pm",
+        'a' => "wday",
+        'A' => "weekday",
+        'b' => "mon",
+        'B' => "month",
+        'c' => "datetime",
+        'D' => "date",
+        'j' => "yday",
+        'u' | 'w' => "wday#",
+        'U' | 'W' => "week",
+        'V' => "isoweek",
+        'z' | 'Z' => "tz",
+        'x' => "date",
+        'X' => "time",
+        'C' => "century",
+        'g' | 'G' => "isoyear",
+        'J' => "julian",
+        _ => return None,
+    })
+}
+
+/// Short label for a `binary format`/`scan` specifier letter — Python
+/// `_BINARY_SHORT`.
+fn binary_short(c: char) -> Option<&'static str> {
+    Some(match c {
+        'a' => "strN",
+        'A' => "strS",
+        'b' => "bits",
+        'B' => "BITS",
+        'h' => "hex",
+        'H' => "HEX",
+        'c' => "i8",
+        's' => "i16le",
+        'S' => "i16be",
+        'i' => "i32le",
+        'I' => "i32be",
+        'n' => "i32",
+        'w' => "i64le",
+        'W' => "i64be",
+        'm' => "i64",
+        'r' => "f32le",
+        'R' => "f32be",
+        'f' => "f32",
+        'd' => "f64",
+        'x' => "pad",
+        'X' => "back",
+        '@' => "seek",
+        't' => "rsv",
+        _ => return None,
+    })
+}
+
+/// Short label for a `regsub` substitution backreference — Python
+/// `_REGSUB_SHORT`.
+fn regsub_short(c: char) -> Option<&'static str> {
+    Some(match c {
+        '&' | '0' => "match",
+        '1' => "grp1",
+        '2' => "grp2",
+        '3' => "grp3",
+        '4' => "grp4",
+        '5' => "grp5",
+        '6' => "grp6",
+        '7' => "grp7",
+        '8' => "grp8",
+        '9' => "grp9",
+        _ => return None,
+    })
+}
+
+/// Which format family a command's argument carries, plus the argv index
+/// of the format word.
+enum FormatArg {
+    Sprintf(usize),
+    Clock(usize),
+    Binary(usize),
+    Regsub(usize),
+}
+
+/// Resolve the argv index (and family) of the format/spec word a command
+/// carries, if any.  Mirrors the `_*_format_arg_index` helpers.
+fn format_arg(seg: &tcl_compiler::segmenter::SegmentedCommand) -> Option<FormatArg> {
+    let texts = &seg.texts;
+    let head = texts.first()?.as_str();
+    match head {
+        "format" if texts.len() >= 2 => Some(FormatArg::Sprintf(1)),
+        "scan" if texts.len() >= 3 => Some(FormatArg::Sprintf(2)),
+        "binary" if texts.len() >= 3 => match texts[1].as_str() {
+            "format" => Some(FormatArg::Binary(2)),
+            "scan" if texts.len() >= 4 => Some(FormatArg::Binary(3)),
+            _ => None,
+        },
+        "clock" if texts.len() >= 3 && matches!(texts[1].as_str(), "format" | "scan") => {
+            // The format string is the value of the `-format` option.
+            let i = (2..texts.len()).find(|&i| texts[i] == "-format")?;
+            (i + 1 < texts.len()).then(|| FormatArg::Clock(i + 1))
+        }
+        "regsub" if texts.len() >= 4 => {
+            // `regsub ?switches? exp string subSpec ?varName?` — skip option
+            // switches to find the pattern, then the subspec sits two words
+            // past it.  Mirrors `_regsub_subspec_arg_index` /
+            // `regexp_pattern_index` for the no-registry common case.
+            let mut i = 1;
+            while i < texts.len() && texts[i].starts_with('-') && texts[i] != "--" {
+                if texts[i] == "-start" && i + 1 < texts.len() {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            if i < texts.len() && texts[i] == "--" {
+                i += 1;
+            }
+            // `i` now indexes the pattern; the subSpec is two words later.
+            let subspec = i + 2;
+            (subspec < texts.len()).then_some(FormatArg::Regsub(subspec))
+        }
+        _ => None,
+    }
+}
+
+/// Byte range of a format word's *content* — the token span with one
+/// layer of `"…"` / `{…}` delimiters stripped.
+fn format_content_range(source: &str, span: tcl_lexer::Span) -> Option<(usize, usize)> {
+    let mut start = span.start() as usize;
+    let mut end = span.end() as usize;
+    if start >= end || end > source.len() {
+        return None;
+    }
+    let bytes = source.as_bytes();
+    if matches!(bytes[start], b'"' | b'{') {
+        start += 1;
+    }
+    if end > start && matches!(bytes[end - 1], b'"' | b'}') {
+        end -= 1;
+    }
+    (start < end).then_some((start, end))
+}
+
+/// Push a `Type`-kind specifier hint at the byte offset `abs_byte`
+/// (converted to a UTF-16 position) when it lies within `range`.
+fn push_format_hint(
+    label: &str,
+    abs_byte: usize,
+    range: LspRange,
+    source: &str,
+    line_index: &LineIndex,
+    out: &mut Vec<InlayHint>,
+) {
+    let pos = line_index.position_at_utf16(abs_byte as u32, source);
+    if pos.line < range.start_line || pos.line > range.end_line {
+        return;
+    }
+    out.push(InlayHint {
+        position_line: pos.line,
+        position_character: pos.character,
+        label: label.to_owned(),
+        kind: InlayHintKind::Type,
+        padding_left: true,
+    });
+}
+
+/// Collect format-string specifier hints for the whole document.
+fn collect_format_string_hints(
+    source: &str,
+    dialect: &str,
+    range: LspRange,
+    line_index: &LineIndex,
+    out: &mut Vec<InlayHint>,
+) {
     let segments = tcl_compiler::segmenter::segment_commands_with_offset_and_config(
         source,
         0,
         tcl_lexer::LexerConfig::for_dialect(dialect),
     );
-    let mut out = Vec::new();
-
     for seg in &segments {
-        if seg.texts.is_empty() || seg.argv.is_empty() {
+        let Some(found) = format_arg(seg) else {
             continue;
-        }
-        let cmd_name = &seg.texts[0];
-        if let Some(proc_def) = lookup_proc(analysis, cmd_name) {
-            emit_hints_for_call(source, seg, proc_def, &line_index, range, &mut out);
+        };
+        let idx = match found {
+            FormatArg::Sprintf(i)
+            | FormatArg::Clock(i)
+            | FormatArg::Binary(i)
+            | FormatArg::Regsub(i) => i,
+        };
+        let Some(tok) = seg.argv.get(idx) else {
             continue;
-        }
-        // Built-in command — parse the registry synopsis for
-        // positional parameter names.  User procs take
-        // precedence (handled above).
-        if let Some(registry) = registry
-            && let Some(spec) = registry.get(cmd_name)
-        {
-            emit_builtin_hints(source, seg, spec, &line_index, range, &mut out);
+        };
+        let Some((cstart, cend)) = format_content_range(source, tok.span) else {
+            continue;
+        };
+        let content = &source[cstart..cend];
+        match found {
+            FormatArg::Sprintf(_) => {
+                for m in SPRINTF_RE.captures_iter(content) {
+                    let whole = m.get(0).expect("group 0");
+                    let type_char = m
+                        .get(6)
+                        .and_then(|g| g.as_str().chars().next())
+                        .unwrap_or('%');
+                    if let Some(label) = sprintf_short(type_char) {
+                        push_format_hint(
+                            label,
+                            cstart + whole.end(),
+                            range,
+                            source,
+                            line_index,
+                            out,
+                        );
+                    }
+                }
+            }
+            FormatArg::Clock(_) => {
+                for m in CLOCK_RE.find_iter(content) {
+                    let letter = m.as_str().chars().last().unwrap_or('%');
+                    if let Some(label) = clock_short(letter) {
+                        push_format_hint(label, cstart + m.end(), range, source, line_index, out);
+                    }
+                }
+            }
+            FormatArg::Binary(_) => collect_binary_hints(content, cstart, range, source, line_index, out),
+            FormatArg::Regsub(_) => {
+                for m in REGSUB_RE.captures_iter(content) {
+                    let whole = m.get(0).expect("group 0");
+                    let ch = m
+                        .get(1)
+                        .and_then(|g| g.as_str().chars().next())
+                        .unwrap_or(' ');
+                    if let Some(label) = regsub_short(ch) {
+                        push_format_hint(
+                            label,
+                            cstart + whole.end(),
+                            range,
+                            source,
+                            line_index,
+                            out,
+                        );
+                    }
+                }
+            }
         }
     }
+}
 
-    out
+/// Scan a `binary format`/`scan` template for specifier letters and emit
+/// a hint after each.  Hand-rolled (as in Python `_emit_binary_hints`):
+/// skip whitespace, skip the optional repeat count, read the spec letter,
+/// then an optional `u`/`s` signedness flag and an optional `*` count.
+fn collect_binary_hints(
+    content: &str,
+    cstart: usize,
+    range: LspRange,
+    source: &str,
+    line_index: &LineIndex,
+    out: &mut Vec<InlayHint>,
+) {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if matches!(bytes[i], b' ' | b'\t' | b'\r' | b'\n') {
+            i += 1;
+            continue;
+        }
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        let ch = bytes[i] as char;
+        let Some(label) = binary_short(ch) else {
+            i += 1;
+            continue;
+        };
+        let mut spec_end = i + 1;
+        if spec_end < bytes.len() && matches!(bytes[spec_end], b'u' | b's') {
+            spec_end += 1;
+        }
+        if spec_end < bytes.len() && bytes[spec_end] == b'*' {
+            spec_end += 1;
+        }
+        push_format_hint(label, cstart + spec_end, range, source, line_index, out);
+        i = spec_end;
+    }
 }
 
 /// Emit parameter-name hints for a built-in command call by
@@ -185,6 +700,8 @@ fn emit_builtin_hints(
             position_line: pos.line,
             position_character: pos.character,
             label: format!("{name}:"),
+            kind: InlayHintKind::Parameter,
+            padding_left: false,
         });
     }
 }
@@ -385,6 +902,8 @@ fn emit_hints_for_call(
             position_line: pos.line,
             position_character: pos.character,
             label: format!("{}:", param.name),
+            kind: InlayHintKind::Parameter,
+            padding_left: false,
         });
     }
 }
@@ -433,6 +952,8 @@ mod tests {
             whole_document_range("set x 1\n"),
             None,
             None,
+            false,
+            true,
         );
         assert!(hints.is_empty());
     }
@@ -441,7 +962,7 @@ mod tests {
     fn hints_emitted_for_user_proc_call() {
         let src = "proc greet {name greeting} {}\ngreet alice hello\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert!(
             labels.contains(&"name:"),
@@ -457,7 +978,7 @@ mod tests {
     fn hints_anchored_at_argument_start() {
         let src = "proc greet {name} {}\ngreet alice\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
         assert_eq!(hints.len(), 1);
         let h = &hints[0];
         assert_eq!(h.position_line, 1);
@@ -470,7 +991,7 @@ mod tests {
     fn no_hints_for_unknown_command() {
         let src = "unknown_cmd a b c\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
         assert!(hints.is_empty(), "{hints:?}");
     }
 
@@ -480,7 +1001,7 @@ mod tests {
         // because there's no individual name to surface.
         let src = "proc many {first args} {}\nmany 1 2 3 4\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
         // Only the `first` arg gets a hint.
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].label, "first:");
@@ -493,7 +1014,7 @@ mod tests {
         // no hints (no name to attach).
         let src = "proc one {a} {}\none 1 2 3\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].label, "a:");
     }
@@ -510,7 +1031,7 @@ mod tests {
             end_line: 2,
             end_character: u32::MAX,
         };
-        let hints = inlay_hints(src, "tcl", range, Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", range, Some(&analysis), None, false, true);
         assert_eq!(hints.len(), 1, "{hints:?}");
         assert_eq!(hints[0].position_line, 2);
     }
@@ -629,6 +1150,8 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert_eq!(labels, vec!["string:"], "{hints:?}");
@@ -647,6 +1170,8 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert_eq!(labels, vec!["channelId:", "string:"], "{hints:?}");
@@ -665,6 +1190,8 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert!(labels.contains(&"string:"), "{hints:?}");
@@ -684,6 +1211,8 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         // The flag token shouldn't be labelled.
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
@@ -709,6 +1238,8 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert!(labels.contains(&"string:"), "{hints:?}");
@@ -728,6 +1259,8 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         // Only the two positionals are labelled — `-length` and its
@@ -740,7 +1273,7 @@ mod tests {
         // Same source, no registry — no built-in hints.
         let src = "string index $s 3\n";
         let analysis = analyse(src);
-        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None);
+        let hints = inlay_hints(src, "tcl", whole_document_range(src), Some(&analysis), None, false, true);
         assert!(hints.is_empty(), "{hints:?}");
     }
 
@@ -758,8 +1291,175 @@ mod tests {
             whole_document_range(src),
             Some(&analysis),
             Some(&reg),
+            false,
+            true,
         );
         let labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
         assert!(labels.contains(&"name:"), "{hints:?}");
+    }
+
+    // -- inferred type hints (InlayHintKind::Type) ------------------------
+
+    #[test]
+    fn type_hint_for_integer_set() {
+        // `set x 42` → a `: int` Type-kind hint immediately after `x`
+        // (character 5), mirroring Python's `test_integer_type_hint`.
+        let src = "set x 42\n";
+        let analysis = analyse(src);
+        let reg = registry();
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            Some(&reg),
+            true,
+            false,
+        );
+        let type_hints: Vec<&InlayHint> = hints
+            .iter()
+            .filter(|h| h.kind == InlayHintKind::Type)
+            .collect();
+        assert!(
+            type_hints
+                .iter()
+                .any(|h| h.label == ": int" && h.position_character == 5),
+            "{type_hints:?}",
+        );
+        // No parameter hints leak in when only type hints are requested.
+        assert!(hints.iter().all(|h| h.kind == InlayHintKind::Type), "{hints:?}");
+    }
+
+    #[test]
+    fn type_hints_require_registry_for_inference() {
+        // Without a registry the type map can't be built; no type hints.
+        let src = "set x 42\n";
+        let analysis = analyse(src);
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            None,
+            true,
+            false,
+        );
+        assert!(
+            hints.iter().all(|h| h.kind != InlayHintKind::Type),
+            "{hints:?}",
+        );
+    }
+
+    #[test]
+    fn type_and_parameter_families_gate_independently() {
+        // `set x 42` carries a type hint; `add 1 2` carries parameter hints.
+        let src = "proc add {a b} {}\nset x 42\nadd 1 2\n";
+        let analysis = analyse(src);
+        let reg = registry();
+        let type_only = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            Some(&reg),
+            true,
+            false,
+        );
+        assert!(!type_only.is_empty(), "expected type hints");
+        assert!(
+            type_only.iter().all(|h| h.kind == InlayHintKind::Type),
+            "{type_only:?}",
+        );
+        let param_only = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            Some(&reg),
+            false,
+            true,
+        );
+        assert!(!param_only.is_empty(), "expected parameter hints");
+        assert!(
+            param_only.iter().all(|h| h.kind == InlayHintKind::Parameter),
+            "{param_only:?}",
+        );
+    }
+
+    #[test]
+    fn both_families_disabled_yields_nothing() {
+        let src = "set x 42\nadd 1 2\n";
+        let analysis = analyse(src);
+        let reg = registry();
+        let hints = inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            Some(&reg),
+            false,
+            false,
+        );
+        assert!(hints.is_empty(), "{hints:?}");
+    }
+
+    // -- format-string specifier hints (InlayHintKind::Type) --------------
+
+    fn type_labels(src: &str) -> Vec<(u32, String)> {
+        let analysis = analyse(src);
+        let reg = registry();
+        inlay_hints(
+            src,
+            "tcl",
+            whole_document_range(src),
+            Some(&analysis),
+            Some(&reg),
+            true,
+            false,
+        )
+        .into_iter()
+        .filter(|h| h.kind == InlayHintKind::Type)
+        .map(|h| (h.position_character, h.label))
+        .collect()
+    }
+
+    #[test]
+    fn format_sprintf_specifier_hints() {
+        let labels = type_labels("format \"%d-%s\" 1 two\n");
+        let names: Vec<&str> = labels.iter().map(|(_, l)| l.as_str()).collect();
+        assert!(names.contains(&"int"), "{labels:?}");
+        assert!(names.contains(&"str"), "{labels:?}");
+    }
+
+    #[test]
+    fn format_literal_percent_not_hinted() {
+        // `%%` is a literal percent — no specifier hint.
+        let labels = type_labels("format \"100%%\"\n");
+        assert!(labels.is_empty(), "{labels:?}");
+    }
+
+    #[test]
+    fn clock_format_specifier_hints() {
+        let labels = type_labels("clock format $t -format \"%Y-%m-%d\"\n");
+        let names: Vec<&str> = labels.iter().map(|(_, l)| l.as_str()).collect();
+        assert!(names.contains(&"year"), "{labels:?}");
+        assert!(names.contains(&"month"), "{labels:?}");
+        assert!(names.contains(&"day"), "{labels:?}");
+    }
+
+    #[test]
+    fn binary_format_specifier_hints() {
+        let labels = type_labels("binary format \"a3 i\" foo 1\n");
+        let names: Vec<&str> = labels.iter().map(|(_, l)| l.as_str()).collect();
+        assert!(names.contains(&"strN"), "{labels:?}");
+        assert!(names.contains(&"i32le"), "{labels:?}");
+    }
+
+    #[test]
+    fn regsub_subspec_backreference_hints() {
+        let labels = type_labels("regsub {(a)(b)} $s {\\1-\\2} out\n");
+        let names: Vec<&str> = labels.iter().map(|(_, l)| l.as_str()).collect();
+        assert!(names.contains(&"grp1"), "{labels:?}");
+        assert!(names.contains(&"grp2"), "{labels:?}");
     }
 }

--- a/rust/tcl-lsp-core/src/irules_context.rs
+++ b/rust/tcl-lsp-core/src/irules_context.rs
@@ -73,8 +73,8 @@ fn scan_when_context(
         let Some(body_tok) = cmd.arg_tokens().iter().find(|t| t.kind == TokenType::Str) else {
             continue;
         };
-        let start_line = li.position_at(body_tok.span.start()).line;
-        let end_line = li.position_at(body_tok.span.end()).line;
+        let start_line = li.line_at(body_tok.span.start());
+        let end_line = li.line_at(body_tok.span.end());
         if cursor_line < start_line || cursor_line > end_line {
             continue;
         }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -665,8 +665,8 @@ impl FeatureToggles {
         // Inlay hints split into two independently-toggled families
         // (PR #643): inferred-type hints and parameter-name hints.  Both
         // default **off** (see `DEFAULT_OFF`).  The retired `inlayHints`
-        // key is accepted on input as an alias for `inlayParameterHints`
-        // — the family the Rust provider actually implements (see `apply`).
+        // key is accepted on input as an alias for `inlayTypeHints`
+        // (matching the Python server — see `apply`).
         "inlayTypeHints",
         "inlayParameterHints",
         "callHierarchy",
@@ -714,20 +714,19 @@ impl FeatureToggles {
     /// Merge an editor-supplied `features` object, setting only the
     /// keys it carries (absent keys keep their last-applied value).
     ///
-    /// The retired `inlayHints` key is a backward-compatible alias.  The
-    /// Rust provider implements only parameter-name hints and gates
-    /// requests on `inlayParameterHints`, so the legacy key maps to that
-    /// family — keeping the existing editor setting
-    /// (`tclLsp.features.inlayHints`, still the only inlay key the
-    /// packaged VS Code extension sends on this branch) working instead of
-    /// silently producing no hints.  Applied first so an explicit new
-    /// `inlayParameterHints` in the same object wins.
+    /// The retired `inlayHints` key is a backward-compatible alias for
+    /// `inlayTypeHints` (matching the Python server's
+    /// `_FEATURE_TOGGLE_KEYS`): an existing explicit opt-in keeps showing
+    /// the useful inferred-variable-type hints after the rename, while the
+    /// verbose parameter-name hints stay off.  Applied first so an
+    /// explicit new `inlayTypeHints` in the same object always wins when a
+    /// config carries both.
     fn apply(&mut self, features: &serde_json::Map<String, serde_json::Value>) {
         if let Some(flag) = features
             .get("inlayHints")
             .and_then(serde_json::Value::as_bool)
         {
-            self.set.insert("inlayParameterHints".to_owned(), flag);
+            self.set.insert("inlayTypeHints".to_owned(), flag);
         }
         for (key, value) in features {
             if key == "inlayHints" {
@@ -2289,21 +2288,21 @@ impl Backend {
             .is_enabled_default_off("willSaveWaitUntil")
     }
 
-    /// Whether inlay hints should be produced for the document at `uri`.
+    /// Whether the given opt-in inlay family is enabled for `uri`.
     ///
     /// Inlay hints are opt-in and default **off**, matching the Python
-    /// server's default-off contract (PR #643).  The Rust provider emits
-    /// only parameter-name hints (`InlayHintKind::Parameter`), so this gates
-    /// on the `inlayParameterHints` family — which the retired `inlayHints`
-    /// key is normalised to on input (see [`FeatureToggles::apply`]), so the
-    /// existing editor setting keeps producing hints.  Resolves per folder
-    /// like [`Self::feature_enabled`] so a folder-scoped opt-in works in a
-    /// multi-root workspace.
-    async fn inlay_parameter_hints_enabled(&self, uri: &Url) -> bool {
+    /// server's default-off contract (PR #643).  The two families —
+    /// `inlayTypeHints` (inferred variable types + format-string specifier
+    /// labels) and `inlayParameterHints` (call-site parameter-name labels)
+    /// — gate independently; the retired `inlayHints` key is normalised to
+    /// `inlayTypeHints` on input (see [`FeatureToggles::apply`]).  Resolves
+    /// per folder like [`Self::feature_enabled`] so a folder-scoped opt-in
+    /// works in a multi-root workspace.
+    async fn inlay_family_enabled(&self, uri: &Url, family: &str) -> bool {
         {
             let configs = self.folder_configs.lock().await;
             if let Some(fc) = longest_folder_match(&configs, uri)
-                && let Some(flag) = fc.feature_toggles.set.get("inlayParameterHints").copied()
+                && let Some(flag) = fc.feature_toggles.set.get(family).copied()
             {
                 return flag;
             }
@@ -2311,7 +2310,7 @@ impl Backend {
         self.feature_toggles
             .lock()
             .await
-            .is_enabled_default_off("inlayParameterHints")
+            .is_enabled_default_off(family)
     }
 
     /// Handle `tcl-lsp.listSubcommands`: subcommand metadata for `command`
@@ -4106,11 +4105,16 @@ impl LanguageServer for Backend {
 
     async fn inlay_hint(&self, params: InlayHintParams) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
         let uri = params.text_document.uri.clone();
-        // Inlay hints are opt-in (default off).  The provider must still answer
-        // with a well-formed (empty) list — never an error or `null` — when the
-        // feature is disabled, mirroring the Python default-off contract
-        // (`on_inlay_hint` returns `[]`).
-        if !self.inlay_parameter_hints_enabled(&uri).await {
+        // Inlay hints are opt-in (default off), with the type-hint and
+        // parameter-hint families gated independently.  The provider must
+        // still answer with a well-formed (empty) list — never an error or
+        // `null` — when both are disabled, mirroring the Python default-off
+        // contract (`on_inlay_hint` returns `[]`).
+        let type_hints = self.inlay_family_enabled(&uri, "inlayTypeHints").await;
+        let parameter_hints = self
+            .inlay_family_enabled(&uri, "inlayParameterHints")
+            .await;
+        if !type_hints && !parameter_hints {
             return Ok(Some(Vec::new()));
         }
         let Some(doc) = self.read_document(&uri).await else {
@@ -4126,13 +4130,12 @@ impl LanguageServer for Backend {
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
         let registry = self.registry_for_dialect(&doc.dialect).await;
-        // Build analysis on a worker so the inlay-hints
-        // provider can surface parameter-name hints at user-
-        // proc call sites (`S-inlay-hints-rich`) plus built-in
-        // command synopsis hints.  When the analyser surfaces an
-        // empty all_procs map (no user procs in the document),
-        // the provider still returns built-in hints from the
-        // registry.
+        // Build analysis on a worker so the inlay-hints provider can surface
+        // inferred-type hints (`inlayTypeHints`) and parameter-name hints at
+        // user-proc call sites plus built-in command synopsis hints
+        // (`inlayParameterHints`).  When the analyser surfaces an empty
+        // all_procs map (no user procs in the document), the provider still
+        // returns built-in hints from the registry.
         let hints = tokio::task::spawn_blocking(move || {
             core_inlay_hints::inlay_hints(
                 &doc.text,
@@ -4140,6 +4143,8 @@ impl LanguageServer for Backend {
                 range,
                 Some(&analysis),
                 Some(&registry),
+                type_hints,
+                parameter_hints,
             )
         })
         .await
@@ -4159,10 +4164,13 @@ impl LanguageServer for Backend {
                     character: h.position_character,
                 },
                 label: InlayHintLabel::String(h.label),
-                kind: Some(InlayHintKind::PARAMETER),
+                kind: Some(match h.kind {
+                    core_inlay_hints::InlayHintKind::Type => InlayHintKind::TYPE,
+                    core_inlay_hints::InlayHintKind::Parameter => InlayHintKind::PARAMETER,
+                }),
                 text_edits: None,
                 tooltip: None,
-                padding_left: None,
+                padding_left: h.padding_left.then_some(true),
                 padding_right: None,
                 data: None,
             })
@@ -4185,13 +4193,14 @@ impl LanguageServer for Backend {
         // count reflects workspace-wide usage.
         let workspace = self.workspace_index.lock().await.clone();
         let uri_str = uri.to_string();
+        let worker_uri = uri_str.clone();
         let lenses = tokio::task::spawn_blocking(move || {
             core_code_lens::code_lenses(
                 &doc.text,
                 &doc.dialect,
                 Some(&analysis),
                 Some(&workspace),
-                &uri_str,
+                &worker_uri,
             )
         })
         .await
@@ -4207,7 +4216,13 @@ impl LanguageServer for Backend {
             .into_iter()
             .map(|l| CodeLens {
                 range: lift_lsp_range(l.range),
-                data: (!l.qname.is_empty()).then(|| serde_json::json!({ "qname": l.qname })),
+                // Carry the qualified name *and* the document URI so
+                // `codeLens/resolve` can recompute the count against the live
+                // workspace (mirrors Python's `_LensData{kind, uri, qname}`).
+                // Method / class-member lenses have no qname and stay
+                // informational (their eager title is authoritative).
+                data: (!l.qname.is_empty())
+                    .then(|| serde_json::json!({ "qname": l.qname, "uri": uri_str.clone() })),
                 command: Some(tower_lsp::lsp_types::Command {
                     title: l.command_title,
                     command: l.command,
@@ -4216,6 +4231,64 @@ impl LanguageServer for Backend {
             })
             .collect();
         Ok(Some(lifted))
+    }
+
+    /// Resolve a code lens to its authoritative reference-count title.
+    ///
+    /// Rust port of `server.py::on_code_lens_resolve` /
+    /// `code_lens.py::resolve_code_lens`.  The server advertises lenses
+    /// eagerly with a count, but the client calls `codeLens/resolve`
+    /// before display; recomputing here against the *current* document and
+    /// workspace keeps the title consistent with Find All References even
+    /// when the workspace changed since the lens was produced (issue #637).
+    ///
+    /// A lens with no `{qname, uri}` data (the informational method /
+    /// class-member lenses) is returned unchanged — its eager title stands.
+    async fn code_lens_resolve(&self, lens: CodeLens) -> jsonrpc::Result<CodeLens> {
+        let Some((qname, uri)) = lens
+            .data
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .and_then(|data| {
+                let qname = data.get("qname").and_then(serde_json::Value::as_str)?;
+                let uri = data.get("uri").and_then(serde_json::Value::as_str)?;
+                Some((qname.to_owned(), Url::parse(uri).ok()?))
+            })
+        else {
+            return Ok(lens);
+        };
+        let Some(doc) = self.read_document(&uri).await else {
+            return Ok(lens);
+        };
+        let analysis = self
+            .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
+            .await;
+        let workspace = self.workspace_index.lock().await.clone();
+        let uri_str = uri.to_string();
+        let lenses = tokio::task::spawn_blocking(move || {
+            core_code_lens::code_lenses(
+                &doc.text,
+                &doc.dialect,
+                Some(&analysis),
+                Some(&workspace),
+                &uri_str,
+            )
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("code_lens_resolve worker panicked: {err}").into(),
+            data: None,
+        })?;
+        let mut lens = lens;
+        if let Some(matching) = lenses.into_iter().find(|l| l.qname == qname) {
+            lens.command = Some(tower_lsp::lsp_types::Command {
+                title: matching.command_title,
+                command: matching.command,
+                arguments: None,
+            });
+        }
+        Ok(lens)
     }
 
     #[allow(clippy::too_many_lines)]
@@ -5539,7 +5612,7 @@ fn build_server_capabilities() -> ServerCapabilities {
         }),
         inlay_hint_provider: Some(OneOf::Left(true)),
         code_lens_provider: Some(CodeLensOptions {
-            resolve_provider: Some(false),
+            resolve_provider: Some(true),
         }),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
@@ -5977,29 +6050,29 @@ mod tests {
     }
 
     #[test]
-    fn legacy_inlay_hints_key_maps_to_implemented_parameter_family() {
-        // The Rust provider implements only parameter-name hints and gates
-        // on `inlayParameterHints`, so the retired `inlayHints` key maps to
-        // that family — keeping the existing editor setting functional
-        // rather than enabling an unimplemented type-hint family (PR #646
-        // review).
+    fn legacy_inlay_hints_key_maps_to_type_family() {
+        // The retired `inlayHints` key maps to `inlayTypeHints` (matching the
+        // Python server): an existing explicit opt-in keeps showing the
+        // inferred-variable-type hints after the rename, while the verbose
+        // parameter-name hints stay off.
         let mut toggles = FeatureToggles::default();
         toggles.apply(serde_json::json!({"inlayHints": true}).as_object().unwrap());
-        assert!(toggles.is_enabled("inlayParameterHints"));
-        // It does not touch the (unimplemented) type-hint family.
-        assert!(!toggles.is_enabled("inlayTypeHints"));
+        assert!(toggles.is_enabled("inlayTypeHints"));
+        // It does not touch the parameter-name family.
+        assert!(!toggles.is_enabled("inlayParameterHints"));
     }
 
     #[test]
     fn explicit_new_inlay_key_wins_over_legacy_alias() {
-        // When a config carries both, the explicit new key takes precedence.
+        // When a config carries both, the explicit new `inlayTypeHints` key
+        // takes precedence over the `inlayHints` alias.
         let mut toggles = FeatureToggles::default();
         toggles.apply(
-            serde_json::json!({"inlayHints": true, "inlayParameterHints": false})
+            serde_json::json!({"inlayHints": true, "inlayTypeHints": false})
                 .as_object()
                 .unwrap(),
         );
-        assert!(!toggles.is_enabled("inlayParameterHints"));
+        assert!(!toggles.is_enabled("inlayTypeHints"));
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -83,19 +83,18 @@ use tower_lsp::lsp_types::{
     FullDocumentDiagnosticReport, GlobPattern, GotoDefinitionParams, GotoDefinitionResponse, Hover,
     HoverContents, HoverParams, HoverProviderCapability, ImplementationProviderCapability,
     InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintKind,
-    PositionEncodingKind,
     InlayHintLabel, InlayHintParams, LinkedEditingRangeParams, LinkedEditingRanges, Location,
     MarkupContent, MarkupKind, MessageType, OneOf, OptionalVersionedTextDocumentIdentifier,
-    ParameterInformation, ParameterLabel, Position, PrepareRenameResponse, Range, ReferenceParams,
-    Registration, RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport,
-    RenameFilesParams, RenameOptions, RenameParams, SelectionRange, SelectionRangeParams,
-    SelectionRangeProviderCapability, SemanticTokens as LspSemanticTokens,
-    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensFullOptions,
-    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, SemanticTokensRangeParams,
-    SemanticTokensRangeResult, SemanticTokensResult, SemanticTokensServerCapabilities,
-    ServerCapabilities, ServerInfo, SignatureHelp, SignatureHelpOptions, SignatureHelpParams,
-    SignatureInformation, SymbolInformation, SymbolKind, TextDocumentEdit,
-    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    ParameterInformation, ParameterLabel, Position, PositionEncodingKind, PrepareRenameResponse,
+    Range, ReferenceParams, Registration, RelatedFullDocumentDiagnosticReport,
+    RelatedUnchangedDocumentDiagnosticReport, RenameFilesParams, RenameOptions, RenameParams,
+    SelectionRange, SelectionRangeParams, SelectionRangeProviderCapability,
+    SemanticTokens as LspSemanticTokens, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
+    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult,
+    SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelp,
+    SignatureHelpOptions, SignatureHelpParams, SignatureInformation, SymbolInformation, SymbolKind,
+    TextDocumentEdit, TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TextEdit, TypeDefinitionProviderCapability,
     UnchangedDocumentDiagnosticReport, Url, WatchKind, WillSaveTextDocumentParams,
     WorkDoneProgressOptions, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport,
@@ -4184,9 +4183,7 @@ impl LanguageServer for Backend {
         // `null` — when both are disabled, mirroring the Python default-off
         // contract (`on_inlay_hint` returns `[]`).
         let type_hints = self.inlay_family_enabled(&uri, "inlayTypeHints").await;
-        let parameter_hints = self
-            .inlay_family_enabled(&uri, "inlayParameterHints")
-            .await;
+        let parameter_hints = self.inlay_family_enabled(&uri, "inlayParameterHints").await;
         if !type_hints && !parameter_hints {
             return Ok(Some(Vec::new()));
         }
@@ -5682,7 +5679,9 @@ fn negotiate_position_encoding(params: &InitializeParams) -> Option<PositionEnco
 /// `LanguageServer::initialize` handler stays focused on
 /// state setup and result construction — the long capability
 /// literal lives here rather than inside the trait method.
-fn build_server_capabilities(position_encoding: Option<PositionEncodingKind>) -> ServerCapabilities {
+fn build_server_capabilities(
+    position_encoding: Option<PositionEncodingKind>,
+) -> ServerCapabilities {
     ServerCapabilities {
         // UTF-16 columns, matching the LSP default and what every provider
         // emits.  Advertised explicitly only when the client offered it
@@ -6151,7 +6150,10 @@ mod tests {
         // honour; omitting it falls back to the UTF-16 default.
         assert_eq!(with_encodings(Some(vec![PositionEncodingKind::UTF8])), None);
         // No `general` capability at all → omit (default UTF-16).
-        assert_eq!(negotiate_position_encoding(&InitializeParams::default()), None);
+        assert_eq!(
+            negotiate_position_encoding(&InitializeParams::default()),
+            None
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -83,6 +83,7 @@ use tower_lsp::lsp_types::{
     FullDocumentDiagnosticReport, GlobPattern, GotoDefinitionParams, GotoDefinitionResponse, Hover,
     HoverContents, HoverParams, HoverProviderCapability, ImplementationProviderCapability,
     InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintKind,
+    PositionEncodingKind,
     InlayHintLabel, InlayHintParams, LinkedEditingRangeParams, LinkedEditingRanges, Location,
     MarkupContent, MarkupKind, MessageType, OneOf, OptionalVersionedTextDocumentIdentifier,
     ParameterInformation, ParameterLabel, Position, PrepareRenameResponse, Range, ReferenceParams,
@@ -2835,8 +2836,9 @@ impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
         self.apply_workspace_folders(&params).await;
         self.apply_initialization_options(&params).await;
+        let position_encoding = negotiate_position_encoding(&params);
         Ok(InitializeResult {
-            capabilities: build_server_capabilities(),
+            capabilities: build_server_capabilities(position_encoding),
             server_info: Some(ServerInfo {
                 // Protocol identity must match the Python server / editor
                 // expectations ("tcl-lsp"), not the crate/binary name.
@@ -5562,13 +5564,38 @@ fn uri_under_folder(uri: &str, folder: &str) -> bool {
 /// snapshot we hand out is uniquely identifiable, letting
 /// clients consult our cache via
 /// `semanticTokens/full/delta { previousResultId }`.
+/// Negotiate the position encoding the server will use against the
+/// client's advertised `general.positionEncodings`.
+///
+/// Every provider in this server computes columns in UTF-16 code units
+/// (via [`tcl_lexer::LineIndex::position_at_utf16`]), which is also the
+/// LSP default — so we always operate in UTF-16 and only advertise it
+/// explicitly when the client listed it (declaring an encoding the client
+/// didn't offer is a protocol violation; omitting the field falls back to
+/// the UTF-16 default either way).
+fn negotiate_position_encoding(params: &InitializeParams) -> Option<PositionEncodingKind> {
+    let supported = params
+        .capabilities
+        .general
+        .as_ref()
+        .and_then(|g| g.position_encodings.as_ref())?;
+    supported
+        .iter()
+        .any(|enc| *enc == PositionEncodingKind::UTF16)
+        .then_some(PositionEncodingKind::UTF16)
+}
+
 /// Build the `ServerCapabilities` advertised in the response
 /// to `initialize`.  Kept as a free function so the
 /// `LanguageServer::initialize` handler stays focused on
 /// state setup and result construction — the long capability
 /// literal lives here rather than inside the trait method.
-fn build_server_capabilities() -> ServerCapabilities {
+fn build_server_capabilities(position_encoding: Option<PositionEncodingKind>) -> ServerCapabilities {
     ServerCapabilities {
+        // UTF-16 columns, matching the LSP default and what every provider
+        // emits.  Advertised explicitly only when the client offered it
+        // (see `negotiate_position_encoding`).
+        position_encoding,
         // Options form (rather than the bare `Kind`) so we can advertise
         // `willSaveWaitUntil` alongside incremental sync. The handler is
         // gated by `tclLsp.features.willSaveWaitUntil` (default off).
@@ -6007,6 +6034,32 @@ mod tests {
         assert!(got.contains("W210") && !got.contains("W211"));
         // No diagnostics config -> None (leave current set untouched).
         assert!(settings_disabled_diagnostics(&serde_json::json!({"x": 1})).is_none());
+    }
+
+    #[test]
+    fn position_encoding_negotiation() {
+        use tower_lsp::lsp_types::{ClientCapabilities, GeneralClientCapabilities};
+        let with_encodings = |encs: Option<Vec<PositionEncodingKind>>| {
+            let mut params = InitializeParams::default();
+            params.capabilities = ClientCapabilities {
+                general: Some(GeneralClientCapabilities {
+                    position_encodings: encs,
+                    ..GeneralClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            };
+            negotiate_position_encoding(&params)
+        };
+        // Client offers UTF-16 → advertise it explicitly.
+        assert_eq!(
+            with_encodings(Some(vec![PositionEncodingKind::UTF16])),
+            Some(PositionEncodingKind::UTF16)
+        );
+        // Client lists only UTF-8 → don't advertise an encoding it can't
+        // honour; omitting it falls back to the UTF-16 default.
+        assert_eq!(with_encodings(Some(vec![PositionEncodingKind::UTF8])), None);
+        // No `general` capability at all → omit (default UTF-16).
+        assert_eq!(negotiate_position_encoding(&InitializeParams::default()), None);
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5673,8 +5673,7 @@ fn negotiate_position_encoding(params: &InitializeParams) -> Option<PositionEnco
         .as_ref()
         .and_then(|g| g.position_encodings.as_ref())?;
     supported
-        .iter()
-        .any(|enc| *enc == PositionEncodingKind::UTF16)
+        .contains(&PositionEncodingKind::UTF16)
         .then_some(PositionEncodingKind::UTF16)
 }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2836,6 +2836,21 @@ impl LanguageServer for Backend {
         self.apply_workspace_folders(&params).await;
         self.apply_initialization_options(&params).await;
         let position_encoding = negotiate_position_encoding(&params);
+        if client_lacks_utf16_support(&params) {
+            // The client advertised position encodings without UTF-16. The
+            // server emits UTF-16 columns only, so it proceeds in UTF-16
+            // regardless (rather than failing the session over a baseline
+            // every conformant client supports) — but warn so a genuine
+            // UTF-8/UTF-32-only client's mis-mapped non-ASCII ranges are
+            // diagnosable instead of silent.
+            self.client
+                .log_message(
+                    MessageType::WARNING,
+                    "client advertised position encodings without UTF-16; this server \
+                     emits UTF-16 columns and will use UTF-16 regardless",
+                )
+                .await;
+        }
         Ok(InitializeResult {
             capabilities: build_server_capabilities(position_encoding),
             server_info: Some(ServerInfo {
@@ -5674,6 +5689,25 @@ fn negotiate_position_encoding(params: &InitializeParams) -> Option<PositionEnco
         .then_some(PositionEncodingKind::UTF16)
 }
 
+/// True when the client advertised a non-empty `general.positionEncodings`
+/// list that omits UTF-16.
+///
+/// This is the one case the server cannot satisfy cleanly: every provider
+/// emits UTF-16 columns, so a client that explicitly excludes UTF-16 would
+/// mis-map any non-ASCII range.  The server still proceeds in UTF-16 (the
+/// LSP default for an omitted server `positionEncoding`) rather than
+/// refusing the session — UTF-16 is the universal LSP baseline and no
+/// real client ships without it — but [`Backend::initialize`] logs a
+/// warning so the mismatch is not silent.
+fn client_lacks_utf16_support(params: &InitializeParams) -> bool {
+    params
+        .capabilities
+        .general
+        .as_ref()
+        .and_then(|g| g.position_encodings.as_ref())
+        .is_some_and(|encs| !encs.is_empty() && !encs.contains(&PositionEncodingKind::UTF16))
+}
+
 /// Build the `ServerCapabilities` advertised in the response
 /// to `initialize`.  Kept as a free function so the
 /// `LanguageServer::initialize` handler stays focused on
@@ -6130,7 +6164,7 @@ mod tests {
     #[test]
     fn position_encoding_negotiation() {
         use tower_lsp::lsp_types::{ClientCapabilities, GeneralClientCapabilities};
-        let with_encodings = |encs: Option<Vec<PositionEncodingKind>>| {
+        let params_with = |encs: Option<Vec<PositionEncodingKind>>| {
             let mut params = InitializeParams::default();
             params.capabilities = ClientCapabilities {
                 general: Some(GeneralClientCapabilities {
@@ -6139,7 +6173,10 @@ mod tests {
                 }),
                 ..ClientCapabilities::default()
             };
-            negotiate_position_encoding(&params)
+            params
+        };
+        let with_encodings = |encs: Option<Vec<PositionEncodingKind>>| {
+            negotiate_position_encoding(&params_with(encs))
         };
         // Client offers UTF-16 → advertise it explicitly.
         assert_eq!(
@@ -6154,6 +6191,24 @@ mod tests {
             negotiate_position_encoding(&InitializeParams::default()),
             None
         );
+
+        // `client_lacks_utf16_support`: only true for a non-empty list that
+        // omits UTF-16 — the case `initialize` warns about.
+        assert!(client_lacks_utf16_support(&params_with(Some(vec![
+            PositionEncodingKind::UTF8
+        ]))));
+        assert!(client_lacks_utf16_support(&params_with(Some(vec![
+            PositionEncodingKind::UTF8,
+            PositionEncodingKind::UTF32,
+        ]))));
+        // A list containing UTF-16, an empty list, and no list at all are all
+        // fine — UTF-16 is available (or defaulted) so no warning fires.
+        assert!(!client_lacks_utf16_support(&params_with(Some(vec![
+            PositionEncodingKind::UTF8,
+            PositionEncodingKind::UTF16,
+        ]))));
+        assert!(!client_lacks_utf16_support(&params_with(Some(vec![]))));
+        assert!(!client_lacks_utf16_support(&InitializeParams::default()));
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3154,7 +3154,18 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
         let registry = self.registry_for_dialect(&doc.dialect).await;
-        let ranges = tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, &registry);
+        // Pure-CPU tokenise/segment work; run on a worker so a parser panic
+        // is contained as a JSON-RPC error rather than unwinding the event
+        // loop (review-findings C3 — defence in depth).
+        let ranges = tokio::task::spawn_blocking(move || {
+            tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, &registry)
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("folding worker panicked: {err}").into(),
+            data: None,
+        })?;
         Ok(Some(ranges.into_iter().map(lift_folding_range).collect()))
     }
 
@@ -3176,8 +3187,17 @@ impl LanguageServer for Backend {
         // (which would find nothing in non-Tcl config text). Nameless
         // singletons fall back to their kind label so no outline symbol
         // ever carries an empty `name` (#534).
+        // The two compute branches run pure-CPU on a worker so a parser
+        // panic is contained as a JSON-RPC error (review-findings C3).
         let symbols = if Self::is_bigip_dialect(&doc.dialect) {
-            core_bigip::document_symbols(&doc.text)
+            let text = doc.text.clone();
+            tokio::task::spawn_blocking(move || core_bigip::document_symbols(&text))
+                .await
+                .map_err(|err| jsonrpc::Error {
+                    code: jsonrpc::ErrorCode::InternalError,
+                    message: format!("document_symbol worker panicked: {err}").into(),
+                    data: None,
+                })?
         } else if let Some(symbols) = self.db_document_symbols(&params.text_document.uri).await {
             // Served from the salsa query graph (memoised; reuses the tracked
             // file_analysis instead of re-running the full analyser).
@@ -3192,7 +3212,16 @@ impl LanguageServer for Backend {
                     doc.dialect.clone(),
                 )
                 .await;
-            core_symbols::document_symbols_from_analysis(&doc.text, &analysis)
+            let text = doc.text.clone();
+            tokio::task::spawn_blocking(move || {
+                core_symbols::document_symbols_from_analysis(&text, &analysis)
+            })
+            .await
+            .map_err(|err| jsonrpc::Error {
+                code: jsonrpc::ErrorCode::InternalError,
+                message: format!("document_symbol worker panicked: {err}").into(),
+                data: None,
+            })?
         };
         let lifted: Vec<DocumentSymbol> = symbols.into_iter().map(lift_document_symbol).collect();
         Ok(Some(DocumentSymbolResponse::Nested(lifted)))
@@ -3940,7 +3969,18 @@ impl LanguageServer for Backend {
             tokens.data
         } else {
             let registry = self.registry_for_dialect(&doc.dialect).await;
-            core_semantic_tokens::full(&doc.text, &doc.dialect, &registry).data
+            // Cold/cancelled fallback runs the tokeniser on a worker so a
+            // parser panic is contained as a JSON-RPC error (C3).
+            let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
+            tokio::task::spawn_blocking(move || {
+                core_semantic_tokens::full(&text, &dialect, &registry).data
+            })
+            .await
+            .map_err(|err| jsonrpc::Error {
+                code: jsonrpc::ErrorCode::InternalError,
+                message: format!("semantic_tokens worker panicked: {err}").into(),
+                data: None,
+            })?
         };
         let result_id = next_semantic_tokens_id();
         Ok(Some(SemanticTokensResult::Tokens(LspSemanticTokens {
@@ -3965,7 +4005,18 @@ impl LanguageServer for Backend {
             tokens.data
         } else {
             let registry = self.registry_for_dialect(&doc.dialect).await;
-            core_semantic_tokens::full(&doc.text, &doc.dialect, &registry).data
+            // Cold/cancelled fallback runs the tokeniser on a worker so a
+            // parser panic is contained as a JSON-RPC error (C3).
+            let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
+            tokio::task::spawn_blocking(move || {
+                core_semantic_tokens::full(&text, &dialect, &registry).data
+            })
+            .await
+            .map_err(|err| jsonrpc::Error {
+                code: jsonrpc::ErrorCode::InternalError,
+                message: format!("semantic_tokens worker panicked: {err}").into(),
+                data: None,
+            })?
         };
         Ok(Some(SemanticTokensFullDeltaResult::Tokens(
             LspSemanticTokens {
@@ -3992,8 +4043,18 @@ impl LanguageServer for Backend {
             end_character: params.range.end.character,
         };
         let registry = self.registry_for_dialect(&doc.dialect).await;
-        let core_data =
-            core_semantic_tokens::range(&doc.text, &doc.dialect, core_range, &registry).data;
+        // Pure-CPU tokenisation on a worker so a parser panic is contained
+        // as a JSON-RPC error (review-findings C3).
+        let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
+        let core_data = tokio::task::spawn_blocking(move || {
+            core_semantic_tokens::range(&text, &dialect, core_range, &registry).data
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("semantic_tokens_range worker panicked: {err}").into(),
+            data: None,
+        })?;
         Ok(Some(SemanticTokensRangeResult::Tokens(LspSemanticTokens {
             result_id: None,
             data: lift_semantic_token_data(&core_data),
@@ -4079,8 +4140,18 @@ impl LanguageServer for Backend {
             .ok()
             .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
             .and_then(|p| p.to_str().map(str::to_owned));
-        let links =
-            core_document_links::document_links(&doc.text, &doc.dialect, workspace_root.as_deref());
+        // Pure-CPU segmentation on a worker so a parser panic is contained
+        // as a JSON-RPC error (review-findings C3).
+        let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
+        let links = tokio::task::spawn_blocking(move || {
+            core_document_links::document_links(&text, &dialect, workspace_root.as_deref())
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("document_link worker panicked: {err}").into(),
+            data: None,
+        })?;
         if links.is_empty() {
             return Ok(None);
         }
@@ -4474,7 +4545,18 @@ impl LanguageServer for Backend {
         // An explicit client `FormattingOptions.tabSize` / `insertSpaces`
         // overrides the server's indentation by LSP contract.
         let config = formatter_config_from_options(&params.options);
-        let edits = core_formatting::formatting_with(&doc.text, &config, &registry);
+        // Pure-CPU formatting on a worker so a parser panic is contained as
+        // a JSON-RPC error (review-findings C3).
+        let text = doc.text.clone();
+        let edits = tokio::task::spawn_blocking(move || {
+            core_formatting::formatting_with(&text, &config, &registry)
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("formatting worker panicked: {err}").into(),
+            data: None,
+        })?;
         if edits.is_empty() {
             return Ok(None);
         }
@@ -4503,12 +4585,23 @@ impl LanguageServer for Backend {
             end_character: params.range.end.character,
         };
         let registry = self.registry_for_dialect(&doc.dialect).await;
-        let edits = core_formatting::range_formatting(
-            &doc.text,
-            range,
-            &core_formatting::FormatterConfig::default(),
-            &registry,
-        );
+        // Pure-CPU formatting on a worker so a parser panic is contained as
+        // a JSON-RPC error (review-findings C3).
+        let text = doc.text.clone();
+        let edits = tokio::task::spawn_blocking(move || {
+            core_formatting::range_formatting(
+                &text,
+                range,
+                &core_formatting::FormatterConfig::default(),
+                &registry,
+            )
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("range_formatting worker panicked: {err}").into(),
+            data: None,
+        })?;
         if edits.is_empty() {
             return Ok(None);
         }


### PR DESCRIPTION
Completes the **SRV-LSP** track from `docs/rust-rewrite.md` — the LSP server / core / db stage of the Python→Rust rewrite.

## Feature gaps closed (the two "unimplemented" items)

- **`codeLens/resolve`** — the server advertised code lenses but replied `-32601 Method not found`. Now it advertises `resolve_provider`, carries `{qname, uri}` in the lens data, and recomputes the reference count against the live document/workspace at resolve time (faithful port of `server.py::on_code_lens_resolve` / `resolve_code_lens`).
- **Inlay type hints** — the provider only emitted parameter-label inlays. Added the full `inlayTypeHints` family:
  - inferred-variable-type hints (`: int`, shimmer `from → to`) built from the type-propagation pass over a `CompilationUnit`, walked over the analyser scope tree;
  - format-string specifier labels for `format`/`scan`, `clock format`/`scan`, `binary format`/`scan`, and `regsub` subspecs (faithful port of `_collect_type_hints` / `_collect_format_string_hints`).
  - The two inlay families now gate independently (`inlayTypeHints` / `inlayParameterHints`), and the retired `inlayHints` alias maps to `inlayTypeHints` to match the Python server.

## Robustness / correctness

- **C1 UTF-16 residuals** — advertise `position_encoding` (UTF-16, negotiated against the client's `general.positionEncodings`); replace the byte `position_at(...).line` sites in `folding.rs` / `irules_context.rs` with an encoding-independent `LineIndex::line_at`.
- **Panic containment (review-findings C3)** — the 8 inline handlers (`folding_range`, `document_symbol`, `semantic_tokens_full`/`_delta`/`_range`, `document_link`, `formatting`/`range_formatting`) now run on `spawn_blocking`, so a parser panic surfaces as a JSON-RPC error rather than unwinding the event loop.

## Verified already-done (documented in the plan)

Incremental reanalysis (salsa `file_analysis_incremental` + cancellation), registry/CU sharing (`OnceLock` cache + `memoised_compilation_unit`), debounce, and token memo (salsa `semantic_tokens`) were already implemented. The **rope-backed `DocumentState`** is documented as a deliberate architectural deferral — the analysis pipeline is `&str`/byte-offset throughout (the salsa `SourceFile` input holds a `String`), so a rope would still materialise a `String` per analysis. `docs/rust-rewrite.md` is updated to mark the SRV-LSP track ✅ complete.

## Verification

- New `tcl-lsp-core` unit tests (type + format hints) and a `position_encoding` negotiation test; all touched crates pass `cargo test`, clippy-pedantic, and rustfmt; the full workspace builds.
- The exact failing e2e specs from the plan pass against the **native Rust server** (`TCL_LSP_SERVER_KIND=rust`): `TestCodeLens`, `TestInlayToggleIndependenceE2E`, `TestInlayLegacyAliasE2E` — and the full `tests/lsp_e2e/test_editor_features_e2e.py` suite (18/18) passes.
- The whole `lsp_e2e` battery passes except `test_edit_tracking_stress_e2e.py::…random_storm[51]`, which reproduces **identically on the unmodified `origin/rust` baseline** — a pre-existing debug-build timing artifact, not a regression from this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gxF45tResQthL3tHzpC1Y)_