### PR TITLE
FE-DIAG-F5: port Tk / BIG-IP / iApp dialect diagnostics to Rust

### DIFF
--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -865,7 +865,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟢 | every O-code pass + the inliner v0/verbatim shapes landed (see [history](rust-rewrite-history.md)); sole remaining: inliner **v3** (α-rename, gated on the RT-WASM consumer for execution-differential verification) → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | every family ported + verified (E001/W125/IRULE5005, snit, OO body-walks, W307/W308, C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes, `when`-body gating, source-style/W108, #662 lockstep fixes) — see [history](rust-rewrite-history.md). The two consumer-wiring residuals (per-check config toggles, flow-warning code actions) landed under **SRV-LSP** |
-| F5 dialect diagnostics | new `tcl-xc`, `tcl-bigip`, tk slice | 🔴 | TK1001-3, BIGIP6001-11, IAPP7001-3, XC100-301 → **FE-DIAG-F5** |
+| F5 dialect diagnostics | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}`, new `tcl-xc` | 🟢 | TK1001-3 + BIGIP6001-11 + IAPP7001-3 ported; sole residual XC100-301 (gated on a `tcl-xc` translator port of `lower_to_ir`-walking `translator.py`, Python-only meanwhile) → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
@@ -892,7 +892,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | FE | **FE-OPT** | `tcl-compiler::optimiser`, `inlining` | — | L |
 | FE | **FE-CODEGEN** | `tcl-compiler::codegen` (non-wasm) | — | M |
 | FE | **FE-DIAG** ✅ | `tcl-compiler::analyser`, `irules_checks` | — | M |
-| FE | **FE-DIAG-F5** | new `tcl-xc`, `tcl-bigip` analyser slices, tk | `tcl-bigip` | L |
+| FE | **FE-DIAG-F5** 🟢 | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}` slices, tk; XC residual → `tcl-xc` | `tcl-bigip` | L |
 | RT | **RT-WASM** | `tcl-compiler::codegen::wasm`, `runtime/zig`, `tcl-wasm` bin | FE-CODEGEN | L |
 | RT | **RT-VM** | `tcl-vm` | `tcl-bytecode` | L |
 | SRV | **SRV-LSP** ✅ | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | FE-DIAG, FE-DATAFLOW | L |
@@ -948,11 +948,38 @@ Owns `tcl-compiler::codegen` (non-wasm).
   rename gate.
 
 #### FE-DIAG-F5 — F5 dialect diagnostics
-Owns new analyser slices on `tcl-bigip` / `tcl-xc` and the tk dialect.
-- **open** the four Python-only families with zero Rust emitters: **TK1001-1003**
-  (geometry/widget/option), **BIGIP6001-6011** (config validator), **IAPP7001-7003**
-  (iApp template), **XC100-301** (BIG-IP→F5-XC translator). *(large; decide
-  Python-only vs Rust port per family)*
+Owns new analyser slices on `tcl-bigip` / `tcl-xc` and the tk dialect. The
+per-family port decision (the track's explicit "decide Python-only vs Rust
+port per family") is made and three of the four families are landed; the
+fourth is gated on a separate subsystem port and stays Python-only until it
+lands.
+- **landed** **TK1001-1003** (geometry/widget/option) — ported to
+  `tcl-compiler::analyser::tk_checks`, gated on the `tk` dialect: TK1002
+  non-existent-parent + TK1003 unknown-option run per command, TK1001
+  pack/grid conflict is decided post-walk from accumulated per-parent
+  geometry usage (flushed from `run_diagnostic_emitters`).
+- **landed** **BIGIP6001-6011** (config validator) — ported to
+  `tcl-bigip::validator` (`validate_bigip_config` / `validate_bigip_source`)
+  producing ranged `ConfigDiagnostic`s over a parsed `BigipConfig`, reusing
+  the lint engine's `ModelView` / `KindMap` / `resolve_name` (now
+  `pub(crate)`). The `regex` crate has no look-around, so the two Python
+  negative look-aheads (`pool !member`, `persist !none`) are filtered in
+  code.
+- **landed** **IAPP7001-7003** (iApp template) — ported to
+  `tcl-bigip::apl::{iapp_vars,iapp_diagnostics}`:
+  `extract_iapp_var_refs` pulls `$::section__field` implementation
+  references (ReDoS-safe regex), and `validate_iapp_presentation` /
+  `validate_iapp_implementation` emit IAPP7001/7002/7003 over the existing
+  `AplModel`, gated on the `f5-iapps` / `f5-tmsh` / `f5-bigip` dialects.
+- **open (deferred, Python-only)** **XC100-301** (BIG-IP→F5-XC translator)
+  — the XC-series diagnostics are a thin wrapper over `translate_irule`
+  (`dialects/f5/xc/diagnostics.py`), but that translator (`translator.py`
+  ~1.2 K LOC + the 13-type `xc_model` + `mapping`) walks the **IR produced
+  by `lower_to_ir`** and is a distinct, large subsystem in its own right.
+  Porting it is a separate effort (akin to how **FE-OPT** v3 is gated on
+  **RT-WASM**); until a `tcl-xc` translator port lands, XC100-301 stays the
+  Python emitter. Handoff: a future `tcl-xc` crate owns this — re-home the
+  XC diagnostic wrapper there once the translator exists.
 
 ### Stage 2 — Runtime & execution (RT-*)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -865,7 +865,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Optimiser passes | `tcl-compiler::optimiser`, `tcl-compiler::inlining` | 🟢 | every O-code pass + the inliner v0/verbatim shapes landed (see [history](rust-rewrite-history.md)); sole remaining: inliner **v3** (α-rename, gated on the RT-WASM consumer for execution-differential verification) → **FE-OPT** |
 | Bytecode codegen | `tcl-compiler::codegen` | 🟡 | statement-position specialisations; const-fold; `esc`/`{*}`/`set x [cmd]` → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | every family ported + verified (E001/W125/IRULE5005, snit, OO body-walks, W307/W308, C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes, `when`-body gating, source-style/W108, #662 lockstep fixes) — see [history](rust-rewrite-history.md). The two consumer-wiring residuals (per-check config toggles, flow-warning code actions) landed under **SRV-LSP** |
-| F5 dialect diagnostics | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}`, new `tcl-xc` | 🟢 | TK1001-3 + BIGIP6001-11 + IAPP7001-3 ported; sole residual XC100-301 (gated on a `tcl-xc` translator port of `lower_to_ir`-walking `translator.py`, Python-only meanwhile) → **FE-DIAG-F5** |
+| F5 dialect diagnostics | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}`, new `tcl-xc` | 🟢 | TK1001-3 + BIGIP6001-11 + IAPP7001-3 ported (TK live in the analyser); residuals: XC100-301 (gated on a `tcl-xc` translator port of `lower_to_ir`-walking `translator.py`, Python-only meanwhile) + BIG-IP/iApp native-server consumer-wiring (SRV-LSP-style) → **FE-DIAG-F5** |
 | WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
@@ -980,6 +980,16 @@ lands.
   **RT-WASM**); until a `tcl-xc` translator port lands, XC100-301 stays the
   Python emitter. Handoff: a future `tcl-xc` crate owns this — re-home the
   XC diagnostic wrapper there once the translator exists.
+
+Consumer wiring: TK1001-1003 run inside the analyser, so they already
+surface through the native server's diagnostics path (the
+`TCL_LSP_DIAG_BACKEND=rust` bridge). The BIG-IP and iApp checks are
+model-level validators (`validate_bigip_source` /
+`validate_iapp_{presentation,implementation}`) exposed as `tcl-bigip` crate
+APIs; routing them into the native server for BIG-IP-config / APL documents
+(the analogue of `server/features/diagnostics.py`’s file-type dispatch) is a
+**SRV-LSP**-style consumer-wiring residual, mirroring the per-check toggle /
+flow-warning code-action residuals **FE-DIAG** handed to **SRV-LSP**.
 
 ### Stage 2 — Runtime & execution (RT-*)
 

--- a/rust/tcl-bigip/src/apl/iapp_diagnostics.rs
+++ b/rust/tcl-bigip/src/apl/iapp_diagnostics.rs
@@ -1,0 +1,188 @@
+//! Cross-file diagnostics for iApp presentation ↔ implementation — Rust
+//! port of `dialects/f5/bigip/iapp_diagnostics.py`.
+//!
+//! Validates that:
+//! - implementation variables reference fields that exist in the presentation
+//! - presentation fields are actually used by the implementation
+//! - `#include` directives point to files that resolved
+//!
+//! Diagnostic codes (all internal):
+//!
+//! - **IAPP7001** (WARNING): implementation references a variable not
+//!   defined in the presentation
+//! - **IAPP7002** (HINT): presentation field never referenced in the
+//!   implementation
+//! - **IAPP7003** (WARNING): `#include` file not found
+
+use std::collections::HashSet;
+
+use super::iapp_vars::IappVarRef;
+use super::model::AplModel;
+use crate::range::{Position, Range};
+use crate::validator::{ConfigDiagnostic, DiagSeverity};
+
+/// Dialects in which iApp presentation/implementation cross-validation
+/// makes sense (iApps live under `f5-iapps`; `f5-tmsh` / `f5-bigip` share
+/// the iApp template format). All other dialects are unrelated, so the
+/// IAPP diagnostics must not fire there. Mirrors Python `IAPP_DIALECTS`.
+pub const IAPP_DIALECTS: [&str; 3] = ["f5-iapps", "f5-tmsh", "f5-bigip"];
+
+/// Whether `dialect` is one where iApp checks apply (port of
+/// `_iapp_dialect_active`).
+#[must_use]
+pub fn iapp_dialect_active(dialect: &str) -> bool {
+    IAPP_DIALECTS.contains(&dialect)
+}
+
+/// Validate an APL presentation model, optionally cross-checked against
+/// implementation variable references. Returns an empty list outside the
+/// iApp dialects (defense-in-depth, exactly as in Python) so iApp advice
+/// never leaks into plain Tcl / iRules / EDA dialects.
+///
+/// IAPP7001 (undefined variable) is emitted by
+/// [`validate_iapp_implementation`] so the diagnostic lands in the
+/// implementation file; it is intentionally not emitted here.
+#[must_use]
+pub fn validate_iapp_presentation(
+    model: &AplModel,
+    impl_var_refs: Option<&[IappVarRef]>,
+    dialect: &str,
+) -> Vec<ConfigDiagnostic> {
+    if !iapp_dialect_active(dialect) {
+        return Vec::new();
+    }
+    let mut out: Vec<ConfigDiagnostic> = Vec::new();
+
+    // IAPP7003: #include not found.
+    for inc in &model.includes {
+        if !inc.resolved {
+            // AplInclude only tracks the line number; offset/char are 0,
+            // mirroring the Python placeholder.
+            let pos = Position {
+                line: inc.line,
+                character: 0,
+                offset: 0,
+            };
+            out.push(ConfigDiagnostic {
+                code: "IAPP7003".to_owned(),
+                message: format!("#include file not found: \"{}\"", inc.path),
+                severity: DiagSeverity::Warning,
+                range: Range {
+                    start: pos,
+                    end: pos,
+                },
+            });
+        }
+    }
+
+    let Some(refs) = impl_var_refs else {
+        return out;
+    };
+
+    let referenced: HashSet<&str> = refs.iter().map(|r| r.apl_name.as_str()).collect();
+
+    // IAPP7002: unused presentation field (message fields are display-only).
+    for (qname, field) in &model.all_fields {
+        if !referenced.contains(qname.as_str()) {
+            if field.field_type == "message" {
+                continue;
+            }
+            out.push(ConfigDiagnostic {
+                code: "IAPP7002".to_owned(),
+                message: format!(
+                    "Presentation field '{qname}' is never referenced in the implementation \
+                     (expected $::{})",
+                    field.qualified_name.replace('.', "__")
+                ),
+                severity: DiagSeverity::Hint,
+                range: field.range,
+            });
+        }
+    }
+
+    out
+}
+
+/// Validate iApp implementation references against the presentation,
+/// producing diagnostics positioned in the implementation source. Returns
+/// an empty list outside the iApp dialects, or when no presentation model
+/// is available. Mirrors `validate_iapp_implementation`.
+#[must_use]
+pub fn validate_iapp_implementation(
+    impl_var_refs: &[IappVarRef],
+    model: Option<&AplModel>,
+    dialect: &str,
+) -> Vec<ConfigDiagnostic> {
+    if !iapp_dialect_active(dialect) {
+        return Vec::new();
+    }
+    let Some(model) = model else {
+        return Vec::new();
+    };
+
+    let known: HashSet<&str> = model.all_fields.iter().map(|(q, _)| q.as_str()).collect();
+
+    let mut out: Vec<ConfigDiagnostic> = Vec::new();
+    for r in impl_var_refs {
+        if !known.contains(r.apl_name.as_str()) {
+            out.push(ConfigDiagnostic {
+                code: "IAPP7001".to_owned(),
+                message: format!(
+                    "Variable ${} references presentation field '{}' which is not defined \
+                     in the presentation",
+                    r.tcl_name, r.apl_name
+                ),
+                severity: DiagSeverity::Warning,
+                range: r.range,
+            });
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::iapp_vars::extract_iapp_var_refs;
+    use super::super::parser::parse_apl;
+    use super::*;
+
+    const PRESENTATION: &str = "section basic {\n  string addr\n  string port\n}\n";
+
+    fn codes(diags: &[ConfigDiagnostic]) -> Vec<&str> {
+        diags.iter().map(|d| d.code.as_str()).collect()
+    }
+
+    #[test]
+    fn iapp7001_fires_for_undefined_variable() {
+        let model = parse_apl(PRESENTATION);
+        let refs = extract_iapp_var_refs("set x $::basic__missing");
+        let diags = validate_iapp_implementation(&refs, Some(&model), "f5-iapps");
+        assert!(codes(&diags).contains(&"IAPP7001"));
+    }
+
+    #[test]
+    fn iapp7001_quiet_for_defined_variable() {
+        let model = parse_apl(PRESENTATION);
+        let refs = extract_iapp_var_refs("set x $::basic__addr");
+        let diags = validate_iapp_implementation(&refs, Some(&model), "f5-iapps");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn iapp7002_fires_for_unused_field() {
+        let model = parse_apl(PRESENTATION);
+        // Implementation references only `basic.addr`, leaving `basic.port`.
+        let refs = extract_iapp_var_refs("set x $::basic__addr");
+        let diags = validate_iapp_presentation(&model, Some(&refs), "f5-iapps");
+        assert!(codes(&diags).contains(&"IAPP7002"));
+    }
+
+    #[test]
+    fn no_iapp_checks_outside_iapp_dialects() {
+        let model = parse_apl(PRESENTATION);
+        let refs = extract_iapp_var_refs("set x $::basic__missing");
+        assert!(validate_iapp_implementation(&refs, Some(&model), "tcl").is_empty());
+        assert!(validate_iapp_presentation(&model, Some(&refs), "f5-irules").is_empty());
+    }
+}

--- a/rust/tcl-bigip/src/apl/iapp_vars.rs
+++ b/rust/tcl-bigip/src/apl/iapp_vars.rs
@@ -1,0 +1,97 @@
+//! Extract iApp presentation-variable references from implementation Tcl —
+//! Rust port of `dialects/f5/bigip/iapp_vars.py`.
+//!
+//! In iApp templates a presentation field declared as `section.field` in
+//! APL becomes `$::section__field` in the implementation Tcl. This module
+//! extracts those references so they can be cross-validated against the
+//! presentation model (see [`super::iapp_diagnostics`]).
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use tcl_lexer::LineIndex;
+
+use crate::range::Range;
+
+/// Match `$::name` or `${::name}` (with an optional `(index)`). Like the
+/// Python regex, the identifier is captured in one greedy chunk and the
+/// iApp `__` separator is enforced by a post-filter rather than nested
+/// quantifiers (which risk catastrophic backtracking — CodeQL
+/// `py/redos`). Group 1 is the braced form, group 2 the unbraced form.
+static IAPP_VAR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"\$\{::([a-zA-Z_][a-zA-Z0-9_]*)(?:\([^)]*\))?\}|\$::([a-zA-Z_][a-zA-Z0-9_]*)(?:\([^)]*\))?",
+    )
+    .expect("static iapp-var regex")
+});
+
+/// A reference to an iApp presentation variable in implementation Tcl.
+/// Mirrors the frozen Python `IappVarRef` dataclass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IappVarRef {
+    /// The Tcl global name, e.g. `"::basic__addr"`.
+    pub tcl_name: String,
+    /// The APL qualified name, e.g. `"basic.addr"`.
+    pub apl_name: String,
+    /// Source range of the reference.
+    pub range: Range,
+}
+
+/// Extract iApp presentation-variable references (`::section__field`)
+/// from Tcl `source`. Plain `$::var` references without an `__` separator
+/// are not iApp variables and are dropped, mirroring `extract_iapp_var_refs`.
+#[must_use]
+pub fn extract_iapp_var_refs(source: &str) -> Vec<IappVarRef> {
+    let line_index = LineIndex::new(source);
+    let mut refs: Vec<IappVarRef> = Vec::new();
+    for caps in IAPP_VAR_RE.captures_iter(source) {
+        // group 1 = braced, group 2 = unbraced.
+        let Some(body) = caps.get(1).or_else(|| caps.get(2)) else {
+            continue;
+        };
+        let var_body = body.as_str();
+        // Real iApp refs contain at least one `__` separator.
+        if !var_body.contains("__") {
+            continue;
+        }
+        let whole = caps.get(0).expect("group 0 always present");
+        refs.push(IappVarRef {
+            tcl_name: format!("::{var_body}"),
+            apl_name: var_body.replace("__", "."),
+            range: Range::from_offsets(
+                source,
+                &line_index,
+                whole.start(),
+                whole.end().saturating_sub(1),
+            ),
+        });
+    }
+    refs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_braced_and_unbraced() {
+        let src = "set a $::basic__addr\nset b ${::ssl__members__port}";
+        let refs = extract_iapp_var_refs(src);
+        let names: Vec<&str> = refs.iter().map(|r| r.apl_name.as_str()).collect();
+        assert_eq!(names, vec!["basic.addr", "ssl.members.port"]);
+        assert_eq!(refs[0].tcl_name, "::basic__addr");
+    }
+
+    #[test]
+    fn drops_plain_non_iapp_vars() {
+        // No `__` separator — not an iApp reference.
+        assert!(extract_iapp_var_refs("set x $::tcl_version").is_empty());
+    }
+
+    #[test]
+    fn ignores_array_index() {
+        let refs = extract_iapp_var_refs("set v $::pool__members(0)");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].apl_name, "pool.members");
+    }
+}

--- a/rust/tcl-bigip/src/apl/iapp_vars.rs
+++ b/rust/tcl-bigip/src/apl/iapp_vars.rs
@@ -16,7 +16,7 @@ use crate::range::Range;
 /// Match `$::name` or `${::name}` (with an optional `(index)`). Like the
 /// Python regex, the identifier is captured in one greedy chunk and the
 /// iApp `__` separator is enforced by a post-filter rather than nested
-/// quantifiers (which risk catastrophic backtracking — CodeQL
+/// quantifiers (which risk catastrophic backtracking — `CodeQL`
 /// `py/redos`). Group 1 is the braced form, group 2 the unbraced form.
 static IAPP_VAR_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(

--- a/rust/tcl-bigip/src/apl/mod.rs
+++ b/rust/tcl-bigip/src/apl/mod.rs
@@ -2,10 +2,14 @@
 //! and object model. Rust port of `dialects/f5/bigip/apl_model.py`.
 
 pub mod canonical;
+pub mod iapp_diagnostics;
+pub mod iapp_vars;
 pub mod model;
 pub mod parser;
 
 pub use canonical::model_to_canonical;
+pub use iapp_diagnostics::{validate_iapp_implementation, validate_iapp_presentation};
+pub use iapp_vars::{IappVarRef, extract_iapp_var_refs};
 pub use model::{
     AplField, AplInclude, AplModel, AplSection, AplTable, apl_name_to_tcl_var, tcl_var_to_apl_name,
 };

--- a/rust/tcl-bigip/src/lib.rs
+++ b/rust/tcl-bigip/src/lib.rs
@@ -37,6 +37,7 @@ pub mod redact;
 pub mod secrets;
 pub mod stats;
 pub mod tmsh_emit;
+pub mod validator;
 pub mod value;
 pub mod wireshark_profile;
 

--- a/rust/tcl-bigip/src/lint.rs
+++ b/rust/tcl-bigip/src/lint.rs
@@ -48,7 +48,7 @@ pub struct Finding {
 
 /// An order-preserving, last-wins map keyed by `full_path` — Python's
 /// dict-per-kind view, materialised over the typed model objects.
-struct KindMap<'a, T> {
+pub(crate) struct KindMap<'a, T> {
     /// `(full_path, value)` in first-seen order.
     entries: Vec<(&'a str, &'a T)>,
     /// `full_path -> index into entries`.
@@ -80,11 +80,16 @@ impl<'a, T> KindMap<'a, T> {
         self.entries.is_empty()
     }
 
-    fn contains_key(&self, key: &str) -> bool {
+    pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.index.contains_key(key)
     }
 
-    fn iter(&self) -> impl Iterator<Item = (&'a str, &'a T)> + '_ {
+    /// Look up the value for `key`, mirroring `dict.get`.
+    pub(crate) fn get(&self, key: &str) -> Option<&'a T> {
+        self.index.get(key).map(|&i| self.entries[i].1)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&'a str, &'a T)> + '_ {
         self.entries.iter().copied()
     }
 }
@@ -92,26 +97,26 @@ impl<'a, T> KindMap<'a, T> {
 /// The per-kind model views the rules reason about, grouped from
 /// `config.objects` by `ModelObject` variant (mirrors the dict-per-kind
 /// collections on the Python `BigipConfig`).
-struct ModelView<'a> {
-    default_partition: &'a str,
-    pools: KindMap<'a, crate::model::BigipPool>,
-    monitors: KindMap<'a, crate::model::BigipMonitor>,
-    virtual_servers: KindMap<'a, crate::model::BigipVirtualServer>,
-    nodes: KindMap<'a, crate::model::BigipNode>,
-    profiles: KindMap<'a, crate::model::BigipProfile>,
-    snat_pools: KindMap<'a, crate::model::BigipSnatPool>,
-    persistence: KindMap<'a, crate::model::BigipPersistence>,
-    rules: KindMap<'a, crate::model::BigipRule>,
-    data_groups: KindMap<'a, crate::model::BigipDataGroup>,
-    policies: KindMap<'a, crate::model::BigipPolicy>,
-    generic_object_keys: &'a [(String, crate::model::BigipGenericObject)],
+pub(crate) struct ModelView<'a> {
+    pub(crate) default_partition: &'a str,
+    pub(crate) pools: KindMap<'a, crate::model::BigipPool>,
+    pub(crate) monitors: KindMap<'a, crate::model::BigipMonitor>,
+    pub(crate) virtual_servers: KindMap<'a, crate::model::BigipVirtualServer>,
+    pub(crate) nodes: KindMap<'a, crate::model::BigipNode>,
+    pub(crate) profiles: KindMap<'a, crate::model::BigipProfile>,
+    pub(crate) snat_pools: KindMap<'a, crate::model::BigipSnatPool>,
+    pub(crate) persistence: KindMap<'a, crate::model::BigipPersistence>,
+    pub(crate) rules: KindMap<'a, crate::model::BigipRule>,
+    pub(crate) data_groups: KindMap<'a, crate::model::BigipDataGroup>,
+    pub(crate) policies: KindMap<'a, crate::model::BigipPolicy>,
+    pub(crate) generic_object_keys: &'a [(String, crate::model::BigipGenericObject)],
 }
 
 impl<'a> ModelView<'a> {
     /// Build the per-kind views for one config's typed objects, in source
     /// order. Multiple configs are pre-merged into one [`BigipConfig`] by
     /// [`merge_configs`], so a single pass over `config.objects` suffices.
-    fn build(config: &'a BigipConfig) -> Self {
+    pub(crate) fn build(config: &'a BigipConfig) -> Self {
         let mut view = ModelView {
             default_partition: &config.default_partition,
             pools: KindMap::default(),
@@ -152,7 +157,11 @@ impl<'a> ModelView<'a> {
 /// Resolve a possibly-short `name` to a full-path key in `table` (port of
 /// `BigipConfig.resolve_name`): exact, then partition-qualified against
 /// `default_partition`, then `/Common/`, then a suffix match.
-fn resolve_name<T>(name: &str, table: &KindMap<'_, T>, default_partition: &str) -> Option<String> {
+pub(crate) fn resolve_name<T>(
+    name: &str,
+    table: &KindMap<'_, T>,
+    default_partition: &str,
+) -> Option<String> {
     if table.contains_key(name) {
         return Some(name.to_owned());
     }

--- a/rust/tcl-bigip/src/validator.rs
+++ b/rust/tcl-bigip/src/validator.rs
@@ -78,8 +78,9 @@ static CLASS_MATCH_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 /// `class lookup ?--? <key> <dg>` — capture the dg name (last argument).
-static CLASS_LOOKUP_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\bclass\s+lookup\s+(?:--\s+)?\S+\s+(\S+)").expect("static regex"));
+static CLASS_LOOKUP_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bclass\s+lookup\s+(?:--\s+)?\S+\s+(\S+)").expect("static regex")
+});
 
 /// `class exists|size|type|get|startsearch <dg>` — capture the dg name.
 static CLASS_SINGLE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -147,12 +148,11 @@ fn profile_types_for_virtual(
 ) -> Vec<ProfileType> {
     let mut types: Vec<ProfileType> = Vec::new();
     for pref in vs.profiles.paths() {
-        if let Some(resolved) = resolve_name(&pref, &view.profiles, view.default_partition) {
-            if let Some(p) = view.profiles.get(&resolved) {
-                if !types.contains(&p.profile_type) {
-                    types.push(p.profile_type);
-                }
-            }
+        if let Some(resolved) = resolve_name(&pref, &view.profiles, view.default_partition)
+            && let Some(p) = view.profiles.get(&resolved)
+            && !types.contains(&p.profile_type)
+        {
+            types.push(p.profile_type);
         }
     }
     types
@@ -310,7 +310,7 @@ fn check_virtual_pools(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
     }
 }
 
-/// BIGIP6004: an iRule on a virtual uses HTTP:: / SSL:: commands but the
+/// BIGIP6004: an iRule on a virtual uses `HTTP::` / `SSL::` commands but the
 /// virtual has no matching profile.
 fn check_virtual_profile_requirements(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
     for (_path, vs) in view.virtual_servers.iter() {
@@ -320,7 +320,8 @@ fn check_virtual_profile_requirements(view: &ModelView<'_>, out: &mut Vec<Config
             ptypes.contains(&ProfileType::ClientSsl) || ptypes.contains(&ProfileType::ServerSsl);
 
         for rule_ref in vs.rules.paths() {
-            let Some(resolved) = resolve_name(&rule_ref, &view.rules, view.default_partition) else {
+            let Some(resolved) = resolve_name(&rule_ref, &view.rules, view.default_partition)
+            else {
                 continue;
             };
             let Some(rule) = view.rules.get(&resolved) else {
@@ -361,7 +362,8 @@ fn check_virtual_persistence(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnosti
     for (_path, vs) in view.virtual_servers.iter() {
         let vs_persist: Vec<String> = vs.persist.paths();
         for rule_ref in vs.rules.paths() {
-            let Some(resolved) = resolve_name(&rule_ref, &view.rules, view.default_partition) else {
+            let Some(resolved) = resolve_name(&rule_ref, &view.rules, view.default_partition)
+            else {
                 continue;
             };
             let Some(rule) = view.rules.get(&resolved) else {
@@ -537,7 +539,8 @@ mod tests {
 
     #[test]
     fn bigip6002_fires_for_missing_pool() {
-        let src = "ltm rule /Common/r {\n  when HTTP_REQUEST {\n    pool /Common/no_such_pool\n  }\n}\n";
+        let src =
+            "ltm rule /Common/r {\n  when HTTP_REQUEST {\n    pool /Common/no_such_pool\n  }\n}\n";
         assert!(has(src, "BIGIP6002"));
     }
 

--- a/rust/tcl-bigip/src/validator.rs
+++ b/rust/tcl-bigip/src/validator.rs
@@ -1,0 +1,573 @@
+//! Cross-reference validator for BIG-IP configurations — a faithful port
+//! of `dialects/f5/bigip/validator.py`.
+//!
+//! Where the sibling [`crate::lint`] engine emits coarse [`crate::lint::Finding`]s
+//! keyed only by object path, this validator produces ranged
+//! [`ConfigDiagnostic`]s for the LSP diagnostics pipeline: it checks that
+//! iRules reference objects (data-groups, pools, profiles, …) that exist
+//! in the parsed configuration and that virtual servers reference valid
+//! iRules / pools / profiles.
+//!
+//! Diagnostic codes (all internal — controlled by the BIG-IP dialect
+//! toggle, exactly as in Python):
+//!
+//! - **BIGIP6001** (WARNING): iRule references data-group not found in config
+//! - **BIGIP6002** (WARNING): iRule references pool not found in config
+//! - **BIGIP6003** (WARNING): virtual server references iRule not found
+//! - **BIGIP6004** (HINT): iRule uses command requiring a profile not on the virtual
+//! - **BIGIP6005** (WARNING): virtual server references pool not found
+//! - **BIGIP6006** (HINT): data-group defined but never referenced
+//! - **BIGIP6007** (WARNING): iRule references SNAT pool not found
+//! - **BIGIP6008** (HINT): pool has no members
+//! - **BIGIP6009** (WARNING): virtual server has a duplicate iRule attachment
+//! - **BIGIP6010** (HINT): iRule `persist` references a profile not on the virtual
+//! - **BIGIP6011** (WARNING): invalid IP address in an IP-type data-group record
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use regex::Regex;
+use tcl_lexer::LineIndex;
+
+use crate::lint::{ModelView, resolve_name};
+use crate::model::ProfileType;
+use crate::parser::driver::BigipConfig;
+use crate::range::Range;
+
+/// Severity of a config diagnostic — mirrors the subset of Python
+/// `shared.diagnostic.Severity` this validator emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagSeverity {
+    /// A likely-incorrect reference or value.
+    Warning,
+    /// An advisory observation.
+    Hint,
+}
+
+/// One ranged BIG-IP config diagnostic — the validator analogue of an LSP
+/// `Diagnostic` (mirrors the Python `Diagnostic` this file builds).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigDiagnostic {
+    /// Diagnostic code (e.g. `"BIGIP6001"`).
+    pub code: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Severity.
+    pub severity: DiagSeverity,
+    /// Source range. For per-iRule checks this is relative to the iRule
+    /// body (as in Python, which builds a fresh `DocumentBuffer` per rule);
+    /// for object-level checks it is the object's own range, or the zero
+    /// range when the model carries none.
+    pub range: Range,
+}
+
+// ── iRule source-scanning regexes (mirrors validator.py) ─────────────────
+//
+// The `regex` crate has no look-around, so the two Python negative
+// look-aheads (`pool (?!member)`, `persist (?!none)`) are handled by
+// filtering the captured name in code instead.
+
+const CLASS_OPERATORS: &str = "equals|starts_with|ends_with|contains|matches_glob|matches_regex";
+
+/// `class match|search ?opts? <item> <operator> <dg>` — capture the dg name.
+static CLASS_MATCH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"\bclass\s+(?:match|search)\s+(?:(?:-\w+\s+)*)(?:--\s+)?\S+\s+(?:{CLASS_OPERATORS})\s+(\S+)"
+    ))
+    .expect("static class-match regex")
+});
+
+/// `class lookup ?--? <key> <dg>` — capture the dg name (last argument).
+static CLASS_LOOKUP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bclass\s+lookup\s+(?:--\s+)?\S+\s+(\S+)").expect("static regex"));
+
+/// `class exists|size|type|get|startsearch <dg>` — capture the dg name.
+static CLASS_SINGLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bclass\s+(?:exists|size|type|get|startsearch)\s+(\S+)").expect("static regex")
+});
+
+/// `pool <name>` (the `pool member` subcommand is filtered out in code).
+static POOL_CMD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bpool\s+(/[\w/.-]+|\w[\w.-]*)").expect("static regex"));
+
+/// `snatpool <name>`.
+static SNATPOOL_CMD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bsnatpool\s+(/[\w/.-]+|\w[\w.-]*)").expect("static regex"));
+
+/// `persist <name>` (the `persist none` form is filtered out in code).
+static PERSIST_CMD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bpersist\s+(/[\w/.-]+|\w[\w.-]*)").expect("static regex"));
+
+/// Any `HTTP::<cmd>` command (requires an HTTP profile).
+static HTTP_COMMANDS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bHTTP::\w+").expect("static regex"));
+
+/// Any `SSL::<cmd>` / `ssl::<cmd>` command (requires an SSL profile).
+static SSL_COMMANDS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(?:SSL|ssl)::\w+").expect("static regex"));
+
+/// Strip braces, quotes, and brackets from a captured name (port of
+/// `_clean_name`).
+fn clean_name(name: &str) -> &str {
+    name.trim_matches(|c| matches!(c, '{' | '}' | '"' | '\'' | '[' | ']'))
+}
+
+/// Build a [`Range`] from a capture group's byte offsets, mirroring
+/// `_range_from_match(source_map, m, 1)` (`range_from_offsets(start,
+/// max(start, end - 1))`).
+fn range_from_capture(source: &str, line_index: &LineIndex, start: usize, end: usize) -> Range {
+    let end_inclusive = if end > start { end - 1 } else { start };
+    Range::from_offsets(source, line_index, start, end_inclusive)
+}
+
+/// Collect `(capture_start, capture_end, data_group_name)` for every
+/// `class` data-group reference in `source` (port of
+/// `_iter_class_dg_references`). Dynamic names (`$var`, `[cmd]`) are
+/// skipped.
+fn iter_class_dg_references(source: &str) -> Vec<(usize, usize, String)> {
+    let mut out: Vec<(usize, usize, String)> = Vec::new();
+    for re in [&*CLASS_MATCH_RE, &*CLASS_LOOKUP_RE, &*CLASS_SINGLE_RE] {
+        for caps in re.captures_iter(source) {
+            let Some(m) = caps.get(1) else { continue };
+            let name = clean_name(m.as_str());
+            if name.starts_with('$') || name.starts_with('[') {
+                continue;
+            }
+            out.push((m.start(), m.end(), name.to_owned()));
+        }
+    }
+    out
+}
+
+/// Profile types attached to a virtual server (port of
+/// `profile_types_for_virtual`).
+fn profile_types_for_virtual(
+    view: &ModelView<'_>,
+    vs: &crate::model::BigipVirtualServer,
+) -> Vec<ProfileType> {
+    let mut types: Vec<ProfileType> = Vec::new();
+    for pref in vs.profiles.paths() {
+        if let Some(resolved) = resolve_name(&pref, &view.profiles, view.default_partition) {
+            if let Some(p) = view.profiles.get(&resolved) {
+                if !types.contains(&p.profile_type) {
+                    types.push(p.profile_type);
+                }
+            }
+        }
+    }
+    types
+}
+
+/// The object range, or the zero range when the model carries none (port
+/// of `... or _null_range()`).
+fn object_range(range: Option<Range>) -> Range {
+    range.unwrap_or_else(Range::zero)
+}
+
+// ── Per-iRule checks ─────────────────────────────────────────────────────
+
+/// BIGIP6001: iRule references a data-group not found in config.
+fn check_irule_data_groups(
+    rule: &crate::model::BigipRule,
+    view: &ModelView<'_>,
+    out: &mut Vec<ConfigDiagnostic>,
+) {
+    if rule.source.is_empty() {
+        return;
+    }
+    let line_index = LineIndex::new(&rule.source);
+    for (start, end, dg_name) in iter_class_dg_references(&rule.source) {
+        if resolve_name(&dg_name, &view.data_groups, view.default_partition).is_none() {
+            out.push(ConfigDiagnostic {
+                code: "BIGIP6001".to_owned(),
+                message: format!("Data-group '{dg_name}' not found in BIG-IP configuration."),
+                severity: DiagSeverity::Warning,
+                range: range_from_capture(&rule.source, &line_index, start, end),
+            });
+        }
+    }
+}
+
+/// BIGIP6002: iRule references a pool not found in config.
+fn check_irule_pools(
+    rule: &crate::model::BigipRule,
+    view: &ModelView<'_>,
+    out: &mut Vec<ConfigDiagnostic>,
+) {
+    if rule.source.is_empty() {
+        return;
+    }
+    let line_index = LineIndex::new(&rule.source);
+    for caps in POOL_CMD_RE.captures_iter(&rule.source) {
+        let Some(m) = caps.get(1) else { continue };
+        let pool_name = clean_name(m.as_str());
+        // The `pool member` subcommand is not a pool reference.
+        if pool_name == "member" || pool_name.starts_with('$') || pool_name.starts_with('[') {
+            continue;
+        }
+        if resolve_name(pool_name, &view.pools, view.default_partition).is_none() {
+            out.push(ConfigDiagnostic {
+                code: "BIGIP6002".to_owned(),
+                message: format!("Pool '{pool_name}' not found in BIG-IP configuration."),
+                severity: DiagSeverity::Warning,
+                range: range_from_capture(&rule.source, &line_index, m.start(), m.end()),
+            });
+        }
+    }
+}
+
+/// BIGIP6007: iRule references a SNAT pool not found in config.
+fn check_irule_snatpools(
+    rule: &crate::model::BigipRule,
+    view: &ModelView<'_>,
+    out: &mut Vec<ConfigDiagnostic>,
+) {
+    if rule.source.is_empty() {
+        return;
+    }
+    let line_index = LineIndex::new(&rule.source);
+    for caps in SNATPOOL_CMD_RE.captures_iter(&rule.source) {
+        let Some(m) = caps.get(1) else { continue };
+        let sp_name = clean_name(m.as_str());
+        if sp_name.starts_with('$') || sp_name.starts_with('[') {
+            continue;
+        }
+        if resolve_name(sp_name, &view.snat_pools, view.default_partition).is_none() {
+            out.push(ConfigDiagnostic {
+                code: "BIGIP6007".to_owned(),
+                message: format!("SNAT pool '{sp_name}' not found in BIG-IP configuration."),
+                severity: DiagSeverity::Warning,
+                range: range_from_capture(&rule.source, &line_index, m.start(), m.end()),
+            });
+        }
+    }
+}
+
+/// All data-group names referenced in an iRule body (port of
+/// `_collect_referenced_data_groups`).
+fn collect_referenced_data_groups(rule: &crate::model::BigipRule) -> HashSet<String> {
+    if rule.source.is_empty() {
+        return HashSet::new();
+    }
+    iter_class_dg_references(&rule.source)
+        .into_iter()
+        .map(|(_, _, name)| name)
+        .collect()
+}
+
+// ── Virtual-server-level checks ──────────────────────────────────────────
+
+/// BIGIP6003 + BIGIP6009: virtual references an undefined iRule / has a
+/// duplicate iRule attachment.
+fn check_virtual_rules(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    for (_path, vs) in view.virtual_servers.iter() {
+        let mut seen: HashSet<String> = HashSet::new();
+        for rule_ref in vs.rules.paths() {
+            if seen.contains(&rule_ref) {
+                out.push(ConfigDiagnostic {
+                    code: "BIGIP6009".to_owned(),
+                    message: format!(
+                        "Virtual server '{}' has duplicate iRule attachment '{rule_ref}'.",
+                        vs.name
+                    ),
+                    severity: DiagSeverity::Warning,
+                    range: object_range(vs.range),
+                });
+            }
+            seen.insert(rule_ref.clone());
+
+            if resolve_name(&rule_ref, &view.rules, view.default_partition).is_none() {
+                out.push(ConfigDiagnostic {
+                    code: "BIGIP6003".to_owned(),
+                    message: format!(
+                        "Virtual server '{}' references iRule '{rule_ref}' which is not defined.",
+                        vs.name
+                    ),
+                    severity: DiagSeverity::Warning,
+                    range: object_range(vs.range),
+                });
+            }
+        }
+    }
+}
+
+/// BIGIP6005: virtual references a pool not found in config.
+fn check_virtual_pools(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    for (_path, vs) in view.virtual_servers.iter() {
+        if !vs.pool.is_empty()
+            && resolve_name(&vs.pool, &view.pools, view.default_partition).is_none()
+        {
+            out.push(ConfigDiagnostic {
+                code: "BIGIP6005".to_owned(),
+                message: format!(
+                    "Virtual server '{}' references pool '{}' which is not defined.",
+                    vs.name, vs.pool
+                ),
+                severity: DiagSeverity::Warning,
+                range: object_range(vs.range),
+            });
+        }
+    }
+}
+
+/// BIGIP6004: an iRule on a virtual uses HTTP:: / SSL:: commands but the
+/// virtual has no matching profile.
+fn check_virtual_profile_requirements(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    for (_path, vs) in view.virtual_servers.iter() {
+        let ptypes = profile_types_for_virtual(view, vs);
+        let has_http = ptypes.contains(&ProfileType::Http);
+        let has_ssl =
+            ptypes.contains(&ProfileType::ClientSsl) || ptypes.contains(&ProfileType::ServerSsl);
+
+        for rule_ref in vs.rules.paths() {
+            let Some(resolved) = resolve_name(&rule_ref, &view.rules, view.default_partition) else {
+                continue;
+            };
+            let Some(rule) = view.rules.get(&resolved) else {
+                continue;
+            };
+            if rule.source.is_empty() {
+                continue;
+            }
+            if !has_http && HTTP_COMMANDS_RE.is_match(&rule.source) {
+                out.push(ConfigDiagnostic {
+                    code: "BIGIP6004".to_owned(),
+                    message: format!(
+                        "iRule '{}' on virtual '{}' uses HTTP:: commands but no HTTP profile is attached.",
+                        rule.name, vs.name
+                    ),
+                    severity: DiagSeverity::Hint,
+                    range: object_range(vs.range),
+                });
+            }
+            if !has_ssl && SSL_COMMANDS_RE.is_match(&rule.source) {
+                out.push(ConfigDiagnostic {
+                    code: "BIGIP6004".to_owned(),
+                    message: format!(
+                        "iRule '{}' on virtual '{}' uses SSL:: commands but no SSL profile is attached.",
+                        rule.name, vs.name
+                    ),
+                    severity: DiagSeverity::Hint,
+                    range: object_range(vs.range),
+                });
+            }
+        }
+    }
+}
+
+/// BIGIP6010: an iRule `persist` references a persistence profile that is
+/// not attached to the virtual server.
+fn check_virtual_persistence(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    for (_path, vs) in view.virtual_servers.iter() {
+        let vs_persist: Vec<String> = vs.persist.paths();
+        for rule_ref in vs.rules.paths() {
+            let Some(resolved) = resolve_name(&rule_ref, &view.rules, view.default_partition) else {
+                continue;
+            };
+            let Some(rule) = view.rules.get(&resolved) else {
+                continue;
+            };
+            if rule.source.is_empty() {
+                continue;
+            }
+            for caps in PERSIST_CMD_RE.captures_iter(&rule.source) {
+                let Some(m) = caps.get(1) else { continue };
+                let persist_name = clean_name(m.as_str());
+                if persist_name == "none"
+                    || persist_name.starts_with('$')
+                    || persist_name.starts_with('[')
+                {
+                    continue;
+                }
+                let Some(resolved_persist) =
+                    resolve_name(persist_name, &view.persistence, view.default_partition)
+                else {
+                    // Unknown profile — BIGIP6002 covers missing objects.
+                    continue;
+                };
+                let in_vs = vs_persist.iter().any(|vp| {
+                    resolve_name(vp, &view.persistence, view.default_partition).as_deref()
+                        == Some(resolved_persist.as_str())
+                });
+                if !in_vs {
+                    out.push(ConfigDiagnostic {
+                        code: "BIGIP6010".to_owned(),
+                        message: format!(
+                            "iRule '{}' on virtual '{}' uses persistence profile '{persist_name}' \
+                             which is not attached to the virtual server.",
+                            rule.name, vs.name
+                        ),
+                        severity: DiagSeverity::Hint,
+                        range: object_range(vs.range),
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ── Config-wide checks ───────────────────────────────────────────────────
+
+/// BIGIP6006: data-group defined but never referenced by any iRule.
+fn check_unused_data_groups(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    let mut referenced: HashSet<String> = HashSet::new();
+    for (_path, rule) in view.rules.iter() {
+        for raw in collect_referenced_data_groups(rule) {
+            if let Some(resolved) = resolve_name(&raw, &view.data_groups, view.default_partition) {
+                referenced.insert(resolved);
+            }
+        }
+    }
+    for (dg_path, dg) in view.data_groups.iter() {
+        if !referenced.contains(dg_path) {
+            out.push(ConfigDiagnostic {
+                code: "BIGIP6006".to_owned(),
+                message: format!(
+                    "Data-group '{}' is defined but not referenced by any iRule in this configuration.",
+                    dg.name
+                ),
+                severity: DiagSeverity::Hint,
+                range: object_range(dg.range),
+            });
+        }
+    }
+}
+
+/// BIGIP6008: pool has no members.
+fn check_empty_pools(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    for (_path, pool) in view.pools.iter() {
+        if pool.members.is_empty() {
+            out.push(ConfigDiagnostic {
+                code: "BIGIP6008".to_owned(),
+                message: format!("Pool '{}' has no members defined.", pool.name),
+                severity: DiagSeverity::Hint,
+                range: object_range(pool.range),
+            });
+        }
+    }
+}
+
+/// BIGIP6011: validate records in IP-type data-groups are valid IPv4/IPv6
+/// addresses or networks.
+fn check_ip_data_group_records(view: &ModelView<'_>, out: &mut Vec<ConfigDiagnostic>) {
+    for (_path, dg) in view.data_groups.iter() {
+        if dg.value_type != "ip" {
+            continue;
+        }
+        for record in &dg.records {
+            let addr_text = if record.contains('/') {
+                record.split('/').next().unwrap_or("").trim()
+            } else {
+                record.trim()
+            };
+            if addr_text.is_empty() {
+                continue;
+            }
+            let addr_ok = addr_text.parse::<std::net::IpAddr>().is_ok();
+            // Fall back to a network form ("10.0.0.0/8") like Python's
+            // ip_network(strict=False).
+            let net_ok = record.trim().parse::<ipnet::IpNet>().is_ok();
+            if !addr_ok && !net_ok {
+                out.push(ConfigDiagnostic {
+                    code: "BIGIP6011".to_owned(),
+                    message: format!(
+                        "Invalid IP address '{record}' in IP-type data-group '{}'",
+                        dg.name
+                    ),
+                    severity: DiagSeverity::Warning,
+                    range: object_range(dg.range),
+                });
+            }
+        }
+    }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/// Run all BIG-IP cross-reference validations over a parsed config,
+/// returning ranged diagnostics in the same order as Python's
+/// `validate_bigip_config`.
+#[must_use]
+pub fn validate_bigip_config(config: &BigipConfig) -> Vec<ConfigDiagnostic> {
+    let view = ModelView::build(config);
+    let mut out: Vec<ConfigDiagnostic> = Vec::new();
+
+    // Per-iRule checks.
+    for (_path, rule) in view.rules.iter() {
+        check_irule_data_groups(rule, &view, &mut out);
+        check_irule_pools(rule, &view, &mut out);
+        check_irule_snatpools(rule, &view, &mut out);
+    }
+
+    // Virtual-server reference checks.
+    check_virtual_rules(&view, &mut out);
+    check_virtual_pools(&view, &mut out);
+    check_virtual_profile_requirements(&view, &mut out);
+    check_virtual_persistence(&view, &mut out);
+
+    // Config-wide checks.
+    check_unused_data_groups(&view, &mut out);
+    check_empty_pools(&view, &mut out);
+    check_ip_data_group_records(&view, &mut out);
+
+    out
+}
+
+/// Convenience: parse `source` as a BIG-IP config and validate it.
+#[must_use]
+pub fn validate_bigip_source(source: &str, default_partition: &str) -> Vec<ConfigDiagnostic> {
+    let config = crate::parser::driver::parse_bigip_conf(source, default_partition);
+    validate_bigip_config(&config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codes(source: &str) -> Vec<String> {
+        validate_bigip_source(source, "Common")
+            .into_iter()
+            .map(|d| d.code)
+            .collect()
+    }
+
+    fn has(source: &str, code: &str) -> bool {
+        codes(source).iter().any(|c| c == code)
+    }
+
+    #[test]
+    fn bigip6002_fires_for_missing_pool() {
+        let src = "ltm rule /Common/r {\n  when HTTP_REQUEST {\n    pool /Common/no_such_pool\n  }\n}\n";
+        assert!(has(src, "BIGIP6002"));
+    }
+
+    #[test]
+    fn bigip6002_quiet_when_pool_exists() {
+        let src = "ltm pool /Common/web {\n  members {\n    /Common/n:80 { address 10.0.0.1 }\n  }\n}\nltm rule /Common/r {\n  when HTTP_REQUEST {\n    pool /Common/web\n  }\n}\n";
+        assert!(!has(src, "BIGIP6002"));
+    }
+
+    #[test]
+    fn bigip6008_fires_for_empty_pool() {
+        let src = "ltm pool /Common/empty {\n}\n";
+        assert!(has(src, "BIGIP6008"));
+    }
+
+    #[test]
+    fn bigip6001_fires_for_missing_data_group() {
+        let src = "ltm rule /Common/r {\n  when HTTP_REQUEST {\n    if { [class match [HTTP::host] equals /Common/no_dg] } { }\n  }\n}\n";
+        assert!(has(src, "BIGIP6001"));
+    }
+
+    #[test]
+    fn bigip6011_fires_for_invalid_ip_record() {
+        let src = "ltm data-group internal /Common/ips {\n  type ip\n  records {\n    not-an-ip { }\n  }\n}\n";
+        assert!(has(src, "BIGIP6011"));
+    }
+
+    #[test]
+    fn bigip6011_quiet_for_valid_ip_records() {
+        let src = "ltm data-group internal /Common/ips {\n  type ip\n  records {\n    10.0.0.0/8 { }\n    192.168.1.1 { }\n  }\n}\n";
+        assert!(!has(src, "BIGIP6011"));
+    }
+}

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -626,6 +626,9 @@ impl Analyser {
         // IRULE1003 / 1004 / 2101 / 4001 / 4003 / 5001 / 6001 —
         // analyser-level iRules event-context checks (f5-irules only).
         self.emit_irules_event_checks(cmd_name, args, arg_tokens, cmd_tok);
+        // TK1001 / TK1002 / TK1003 — Tk-dialect widget + geometry checks
+        // (tk dialect only); the TK1001 conflict is flushed post-walk.
+        self.emit_tk_checks(cmd_name, args, arg_tokens, cmd_tok);
         self.emit_w212_name_vs_value(cmd_name, args, arg_tokens);
         self.emit_w104_append_list(cmd_name, args, arg_tokens);
         self.emit_w106_unbraced_switch_body(cmd_name, args, arg_tokens);

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -48,6 +48,7 @@ pub mod scope;
 pub mod snapshot;
 pub mod state;
 pub mod syntax_checks;
+pub mod tk_checks;
 pub mod types;
 pub mod utils;
 

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -104,8 +104,16 @@ impl Analyser {
 
         self.took_fast_path = false;
         // Recovery / stub overlays are only modelled on the full `analyse`
-        // path; fall back so the per-item result can never diverge.
-        if !tcl_lexer::script_is_complete(source) || source.contains("tcl-lsp: stub") {
+        // path; fall back so the per-item result can never diverge.  Tk's
+        // TK100x checks accumulate whole-file state (created widgets, per-parent
+        // geometry) that an isolated proc body cannot see, so a Tk document
+        // also falls back to full analysis rather than diverge (a parent
+        // created outside a proc would otherwise look missing inside it, and a
+        // `pack`/`grid` conflict spanning a proc body would never flush).
+        if !tcl_lexer::script_is_complete(source)
+            || source.contains("tcl-lsp: stub")
+            || super::tk_checks::tk_possibly_active(source, dialect)
+        {
             return self.analyse(source, dialect);
         }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -120,12 +120,20 @@ pub struct Analyser {
     pub regex_vars: HashSet<(Vec<usize>, String)>,
     /// iRules: enclosing ``when EVENT`` name.
     pub current_event: Option<String>,
-    /// Tk dialect (TK1002): widget paths created so far in the walk, so a
-    /// child's parent can be checked for existence.  Only populated under
-    /// the `tk` dialect; cleared by
+    /// Tk checks: whether this document could be Tk (the `tk` dialect, or
+    /// the source mentions `package` / `require` / `Tk`).  Set per walk by
+    /// the `analyse*` entry points; gates the per-command accumulation so
+    /// non-Tk files pay nothing.  See [`super::tk_checks::tk_possibly_active`].
+    pub(super) tk_possibly_active: bool,
+    /// Tk checks (TK1002 / TK1003): diagnostics buffered during the walk and
+    /// emitted post-walk by [`Self::flush_tk_geometry_diagnostics`], once the
+    /// `tk` dialect / `package require Tk` activation condition is resolved.
+    pub(super) tk_pending_diags: Vec<super::types::Diagnostic>,
+    /// Tk checks (TK1002): widget paths created so far in the walk, so a
+    /// child's parent can be checked for existence.  Cleared by
     /// [`Self::flush_tk_geometry_diagnostics`].
     pub(super) tk_created_widgets: HashSet<String>,
-    /// Tk dialect (TK1001): per-parent geometry-manager usage, keyed by
+    /// Tk checks (TK1001): per-parent geometry-manager usage, keyed by
     /// parent widget path, accumulated across the walk and flushed
     /// post-walk so a `pack`/`grid` conflict can be decided.
     pub(super) tk_geometry: std::collections::BTreeMap<String, super::tk_checks::TkGeometryUsage>,
@@ -389,6 +397,8 @@ impl Analyser {
             const_strings: HashMap::new(),
             regex_vars: HashSet::new(),
             current_event: None,
+            tk_possibly_active: false,
+            tk_pending_diags: Vec::new(),
             tk_created_widgets: HashSet::new(),
             tk_geometry: std::collections::BTreeMap::new(),
             builtin_names: None,
@@ -491,6 +501,7 @@ impl Analyser {
         // ``core/analysis/_analyser/_core.py``.
         self.source = source.to_string();
         self.dialect = dialect.to_string();
+        self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
         // Clear the per-run iRules file-profile memo so a reused analyser
         // instance recomputes it for the new source / dialect.
         self.irules_file_profiles = None;
@@ -861,6 +872,7 @@ impl Analyser {
         use tcl_registry::CommandRegistry;
         self.source = source.to_string();
         self.dialect = dialect.to_string();
+        self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
         self.unresolved_commands_emitted = false;
         self.ns_cache.clear();
 
@@ -938,6 +950,7 @@ impl Analyser {
         use tcl_registry::CommandRegistry;
         self.source = source.to_string();
         self.dialect = dialect.to_string();
+        self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
         self.unresolved_commands_emitted = false;
         self.ns_cache.clear();
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -120,6 +120,15 @@ pub struct Analyser {
     pub regex_vars: HashSet<(Vec<usize>, String)>,
     /// iRules: enclosing ``when EVENT`` name.
     pub current_event: Option<String>,
+    /// Tk dialect (TK1002): widget paths created so far in the walk, so a
+    /// child's parent can be checked for existence.  Only populated under
+    /// the `tk` dialect; cleared by
+    /// [`Self::flush_tk_geometry_diagnostics`].
+    pub(super) tk_created_widgets: HashSet<String>,
+    /// Tk dialect (TK1001): per-parent geometry-manager usage, keyed by
+    /// parent widget path, accumulated across the walk and flushed
+    /// post-walk so a `pack`/`grid` conflict can be decided.
+    pub(super) tk_geometry: std::collections::BTreeMap<String, super::tk_checks::TkGeometryUsage>,
     /// Cached set of built-in command names for redefined-builtin
     /// detection. `None` until first lookup; filled lazily.
     pub builtin_names: Option<HashSet<String>>,
@@ -380,6 +389,8 @@ impl Analyser {
             const_strings: HashMap::new(),
             regex_vars: HashSet::new(),
             current_event: None,
+            tk_created_widgets: HashSet::new(),
+            tk_geometry: std::collections::BTreeMap::new(),
             builtin_names: None,
             builtin_dialect: None,
             conditional_depth: 0,
@@ -1211,6 +1222,7 @@ impl Analyser {
         self.emit_cfg_ssa_diagnostics(source);
         self.emit_lexer_warning_diagnostics();
         self.emit_w116_w117_stub_shadows();
+        self.flush_tk_geometry_diagnostics();
         self.apply_disabled_diagnostics();
         self.dedupe_diagnostics();
         self.canonicalize_result_order();

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -136,46 +136,41 @@ impl Analyser {
             return;
         }
 
-        if is_widget_command(cmd_name) {
-            if let Some(path) = args.first() {
-                if is_widget_path(path) {
-                    self.tk_created_widgets.insert(path.clone());
+        if is_widget_command(cmd_name)
+            && let Some(path) = args.first()
+            && is_widget_path(path)
+        {
+            self.tk_created_widgets.insert(path.clone());
 
-                    // TK1002: the parent widget must already exist.  The
-                    // root `.` always exists, so it is never flagged.
-                    let parent = parent_widget_path(path);
-                    if !parent.is_empty()
-                        && parent != "."
-                        && !self.tk_created_widgets.contains(parent)
-                    {
-                        self.result.diagnostics.push(Diagnostic {
-                            code: "TK1002".to_string(),
-                            span: cmd_tok.span,
-                            message: format!(
-                                "Widget path '{path}' references non-existent parent '{parent}'."
-                            ),
-                            severity: Severity::Warning,
-                            fixes: Vec::new(),
-                        });
-                    }
-
-                    // TK1003: unknown option for the widget command.
-                    self.emit_tk1003_unknown_options(cmd_name, args, cmd_tok);
-                }
+            // TK1002: the parent widget must already exist.  The root `.`
+            // always exists, so it is never flagged.
+            let parent = parent_widget_path(path);
+            if !parent.is_empty() && parent != "." && !self.tk_created_widgets.contains(parent) {
+                self.result.diagnostics.push(Diagnostic {
+                    code: "TK1002".to_string(),
+                    span: cmd_tok.span,
+                    message: format!(
+                        "Widget path '{path}' references non-existent parent '{parent}'."
+                    ),
+                    severity: Severity::Warning,
+                    fixes: Vec::new(),
+                });
             }
+
+            // TK1003: unknown option for the widget command.
+            self.emit_tk1003_unknown_options(cmd_name, args, cmd_tok);
         }
 
         // Track geometry-manager usage for the post-walk TK1001 check.
-        if is_geometry_command(cmd_name) {
-            if let Some(widget_path) = args.first() {
-                if is_widget_path(widget_path) {
-                    let parent = parent_widget_path(widget_path).to_string();
-                    let span = arg_tokens.first().map_or(cmd_tok.span, |t| t.span);
-                    let usage = self.tk_geometry.entry(parent).or_default();
-                    usage.managers.insert(cmd_name.to_string());
-                    usage.sites.push((cmd_name.to_string(), span));
-                }
-            }
+        if is_geometry_command(cmd_name)
+            && let Some(widget_path) = args.first()
+            && is_widget_path(widget_path)
+        {
+            let parent = parent_widget_path(widget_path).to_string();
+            let span = arg_tokens.first().map_or(cmd_tok.span, |t| t.span);
+            let usage = self.tk_geometry.entry(parent).or_default();
+            usage.managers.insert(cmd_name.to_string());
+            usage.sites.push((cmd_name.to_string(), span));
         }
     }
 
@@ -194,7 +189,11 @@ impl Analyser {
         let known: std::collections::HashSet<&str> = spec.switch_names(None).into_iter().collect();
         let mut unknown: Vec<String> = Vec::new();
         for arg in &args[1..] {
-            if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 1 && !known.contains(arg.as_str()) {
+            if arg.starts_with('-')
+                && !arg.starts_with("--")
+                && arg.len() > 1
+                && !known.contains(arg.as_str())
+            {
                 unknown.push(arg.clone());
             }
         }

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -1,0 +1,295 @@
+//! Analyser-level Tk-dialect checks — Rust port of `analyser/checks/tk.py`.
+//!
+//! These run per command from
+//! [`super::commands::Analyser::emit_dispatch_site_diagnostics`] and are
+//! all gated on the `tk` dialect.  TK1001 is a whole-document check
+//! (a `pack`/`grid` conflict can only be decided once every geometry
+//! call in the parent has been seen), so it accumulates per-parent
+//! usage across the walk and is flushed post-walk by
+//! [`super::state::Analyser::flush_tk_geometry_diagnostics`] from the
+//! shared diagnostic-emission tail.
+//!
+//! Diagnostic codes ported here:
+//!
+//! - **TK1001** (WARNING): geometry-manager conflict — `pack` and `grid`
+//!   used on the same parent (a runtime error in Tk).
+//! - **TK1002** (WARNING): widget path references a non-existent parent.
+//! - **TK1003** (HINT): unknown option for a widget command.
+
+use tcl_lexer::Token;
+
+use super::state::Analyser;
+use super::types::{Diagnostic, Severity};
+
+/// Per-parent geometry-manager usage accumulated during the walk so
+/// TK1001 can be decided post-walk.  Mirrors the `geometry_by_parent` /
+/// `geometry_ranges` pair in `analyser/checks/tk.py`.
+#[derive(Debug, Default)]
+pub(super) struct TkGeometryUsage {
+    /// The distinct geometry managers (`pack` / `grid` / `place`) seen
+    /// for this parent.
+    pub managers: std::collections::BTreeSet<String>,
+    /// Each geometry call site `(manager, span)`, in document order, so a
+    /// conflict reports on every offending call exactly like Python.
+    pub sites: Vec<(String, tcl_lexer::Span)>,
+}
+
+/// Tk widget-creation commands (`button`, `label`, … and their `ttk::`
+/// forms).  Mirrors `WIDGET_COMMANDS` in `dialects/tk/dialect/common.py`.
+const WIDGET_COMMANDS: &[&str] = &[
+    "button",
+    "label",
+    "entry",
+    "text",
+    "frame",
+    "canvas",
+    "listbox",
+    "scrollbar",
+    "menu",
+    "menubutton",
+    "toplevel",
+    "message",
+    "scale",
+    "spinbox",
+    "checkbutton",
+    "radiobutton",
+    "labelframe",
+    "panedwindow",
+    "destroy",
+    "ttk::button",
+    "ttk::label",
+    "ttk::entry",
+    "ttk::frame",
+    "ttk::checkbutton",
+    "ttk::radiobutton",
+    "ttk::scrollbar",
+    "ttk::spinbox",
+    "ttk::scale",
+    "ttk::panedwindow",
+    "ttk::notebook",
+    "ttk::treeview",
+    "ttk::combobox",
+    "ttk::progressbar",
+    "ttk::separator",
+    "ttk::labelframe",
+    "ttk::menubutton",
+    "ttk::sizegrip",
+];
+
+/// Tk geometry-manager commands.  Mirrors `GEOMETRY_COMMANDS`.
+const GEOMETRY_COMMANDS: &[&str] = &["pack", "grid", "place"];
+
+/// Return `true` if `name` is a Tk widget-creation command.
+fn is_widget_command(name: &str) -> bool {
+    WIDGET_COMMANDS.contains(&name)
+}
+
+/// Return `true` if `name` is a Tk geometry-manager command.
+fn is_geometry_command(name: &str) -> bool {
+    GEOMETRY_COMMANDS.contains(&name)
+}
+
+/// Return `true` if `path` matches Tcl/Tk widget-path syntax — a leading
+/// `.`, then a letter/underscore, then letters / digits / `_` / `.`.
+/// Mirrors `WIDGET_PATH_RE` in `dialects/tk/dialect/common.py`
+/// (`^\.[a-zA-Z_][a-zA-Z0-9_.]*$`); note the bare root `.` does *not*
+/// match (it has no first component).
+fn is_widget_path(path: &str) -> bool {
+    let mut chars = path.chars();
+    if chars.next() != Some('.') {
+        return false;
+    }
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+}
+
+/// Return the parent widget path for `widget_path`.  Mirrors
+/// `parent_widget_path`: `.` has no parent (`""`); a single-component
+/// path (`.foo`) has the root `.` as parent; otherwise strip the final
+/// `.component`.
+fn parent_widget_path(widget_path: &str) -> &str {
+    if widget_path == "." {
+        return "";
+    }
+    match widget_path.rfind('.') {
+        Some(idx) if idx > 0 => &widget_path[..idx],
+        _ => ".",
+    }
+}
+
+impl Analyser {
+    /// Per-command Tk-dialect dispatch.  Tracks widget creation and
+    /// geometry-manager usage, emitting TK1002 / TK1003 inline and
+    /// recording geometry usage for the post-walk TK1001 flush.  A no-op
+    /// outside the `tk` dialect.
+    pub(super) fn emit_tk_checks(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        cmd_tok: Token,
+    ) {
+        if self.dialect != "tk" {
+            return;
+        }
+
+        if is_widget_command(cmd_name) {
+            if let Some(path) = args.first() {
+                if is_widget_path(path) {
+                    self.tk_created_widgets.insert(path.clone());
+
+                    // TK1002: the parent widget must already exist.  The
+                    // root `.` always exists, so it is never flagged.
+                    let parent = parent_widget_path(path);
+                    if !parent.is_empty()
+                        && parent != "."
+                        && !self.tk_created_widgets.contains(parent)
+                    {
+                        self.result.diagnostics.push(Diagnostic {
+                            code: "TK1002".to_string(),
+                            span: cmd_tok.span,
+                            message: format!(
+                                "Widget path '{path}' references non-existent parent '{parent}'."
+                            ),
+                            severity: Severity::Warning,
+                            fixes: Vec::new(),
+                        });
+                    }
+
+                    // TK1003: unknown option for the widget command.
+                    self.emit_tk1003_unknown_options(cmd_name, args, cmd_tok);
+                }
+            }
+        }
+
+        // Track geometry-manager usage for the post-walk TK1001 check.
+        if is_geometry_command(cmd_name) {
+            if let Some(widget_path) = args.first() {
+                if is_widget_path(widget_path) {
+                    let parent = parent_widget_path(widget_path).to_string();
+                    let span = arg_tokens.first().map_or(cmd_tok.span, |t| t.span);
+                    let usage = self.tk_geometry.entry(parent).or_default();
+                    usage.managers.insert(cmd_name.to_string());
+                    usage.sites.push((cmd_name.to_string(), span));
+                }
+            }
+        }
+    }
+
+    /// TK1003 — flag `-option` arguments that the widget command does
+    /// not declare.  Mirrors the option scan in `check_tk_diagnostics`:
+    /// a lone `-` / `--` is skipped, and the check is silent when the
+    /// command has no registry spec (so unknown widgets never false
+    /// positive).
+    fn emit_tk1003_unknown_options(&mut self, cmd_name: &str, args: &[String], cmd_tok: Token) {
+        let Some(registry) = self.registry.as_ref() else {
+            return;
+        };
+        let Some(spec) = registry.get(cmd_name) else {
+            return;
+        };
+        let known: std::collections::HashSet<&str> = spec.switch_names(None).into_iter().collect();
+        let mut unknown: Vec<String> = Vec::new();
+        for arg in &args[1..] {
+            if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 1 && !known.contains(arg.as_str()) {
+                unknown.push(arg.clone());
+            }
+        }
+        for arg in unknown {
+            self.result.diagnostics.push(Diagnostic {
+                code: "TK1003".to_string(),
+                span: cmd_tok.span,
+                message: format!("Unknown option '{arg}' for {cmd_name}."),
+                severity: Severity::Hint,
+                fixes: Vec::new(),
+            });
+        }
+    }
+
+    /// TK1001 — post-walk flush: a parent that mixes `pack` and `grid`
+    /// is a Tk runtime error, reported on every geometry call for that
+    /// parent.  Mirrors the final loop in `check_tk_diagnostics`.  Clears
+    /// the accumulated state so a reused [`Analyser`] starts clean.
+    pub(super) fn flush_tk_geometry_diagnostics(&mut self) {
+        let geometry = std::mem::take(&mut self.tk_geometry);
+        self.tk_created_widgets.clear();
+        if self.dialect != "tk" {
+            return;
+        }
+        for (parent, usage) in geometry {
+            if usage.managers.contains("pack") && usage.managers.contains("grid") {
+                for (_manager, span) in usage.sites {
+                    self.result.diagnostics.push(Diagnostic {
+                        code: "TK1001".to_string(),
+                        span,
+                        message: format!(
+                            "Geometry manager conflict: cannot mix 'pack' and 'grid' \
+                             in the same parent '{parent}'."
+                        ),
+                        severity: Severity::Warning,
+                        fixes: Vec::new(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::state::Analyser;
+
+    fn codes(source: &str, dialect: &str) -> Vec<(String, String)> {
+        let mut a = Analyser::new();
+        let res = a.analyse(source, dialect);
+        res.diagnostics
+            .iter()
+            .filter(|d| d.code.starts_with("TK"))
+            .map(|d| (d.code.clone(), d.message.clone()))
+            .collect()
+    }
+
+    fn has(source: &str, dialect: &str, code: &str) -> bool {
+        codes(source, dialect).iter().any(|(c, _)| c == code)
+    }
+
+    #[test]
+    fn tk1002_fires_for_missing_parent() {
+        // `.outer` was never created, so `.outer.inner` has no parent.
+        assert!(has("frame .outer.inner", "tk", "TK1002"));
+    }
+
+    #[test]
+    fn tk1002_quiet_when_parent_created() {
+        let src = "frame .outer\nframe .outer.inner";
+        assert!(!has(src, "tk", "TK1002"));
+    }
+
+    #[test]
+    fn tk1002_quiet_for_root_child() {
+        // The root `.` always exists, so `.top` is fine.
+        assert!(!has("frame .top", "tk", "TK1002"));
+    }
+
+    #[test]
+    fn tk1001_fires_for_pack_grid_conflict() {
+        let src = "frame .top\npack .top.a\ngrid .top.b";
+        assert!(has(src, "tk", "TK1001"));
+    }
+
+    #[test]
+    fn tk1001_quiet_for_pack_only() {
+        let src = "frame .top\npack .top.a\npack .top.b";
+        assert!(!has(src, "tk", "TK1001"));
+    }
+
+    #[test]
+    fn no_tk_checks_outside_tk_dialect() {
+        // The same conflict in plain Tcl must stay silent.
+        let src = "frame .outer.inner";
+        assert!(!has(src, "tcl", "TK1002"));
+    }
+}

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -1,13 +1,29 @@
 //! Analyser-level Tk-dialect checks — Rust port of `analyser/checks/tk.py`.
 //!
 //! These run per command from
-//! [`super::commands::Analyser::emit_dispatch_site_diagnostics`] and are
-//! all gated on the `tk` dialect.  TK1001 is a whole-document check
-//! (a `pack`/`grid` conflict can only be decided once every geometry
-//! call in the parent has been seen), so it accumulates per-parent
-//! usage across the walk and is flushed post-walk by
-//! [`super::state::Analyser::flush_tk_geometry_diagnostics`] from the
-//! shared diagnostic-emission tail.
+//! [`super::commands::Analyser::emit_dispatch_site_diagnostics`].  Like
+//! Python — which gates the whole pass on `has_tk_require(analysis)` in
+//! `server/features/diagnostics.py`, *not* on a dialect string — the checks
+//! activate when the file is Tk: either the analysis dialect is `tk`
+//! (a `wish`-labelled document) **or** the file declares
+//! `package require Tk` (so a plain `.tcl` script mapped to `tcl8.6` still
+//! gets them).  Because the `package require` is a whole-file fact only
+//! known after the walk, every TK diagnostic is buffered during the walk
+//! and emitted post-walk by
+//! [`super::state::Analyser::flush_tk_geometry_diagnostics`] from the shared
+//! diagnostic-emission tail, gated on the resolved activation condition.
+//! TK1001 additionally needs all of a parent's geometry calls before it can
+//! decide a `pack`/`grid` conflict, so it accumulates per-parent usage and
+//! is decided in the same flush.
+//!
+//! The per-command accumulation is itself gated on a cheap
+//! [`tk_possibly_active`] precheck (`tk` dialect, or the source mentions
+//! `package` / `require` / `Tk`), mirroring the substring guard Python uses
+//! before it consults `has_tk_require`.  The incremental per-item analysis
+//! path ([`Analyser::analyse_per_item_with`]) falls back to full
+//! [`Analyser::analyse`] when [`tk_possibly_active`] holds, so Tk's
+//! whole-file accumulator (which an isolated proc body cannot see) never
+//! diverges from full analysis.
 //!
 //! Diagnostic codes ported here:
 //!
@@ -79,6 +95,19 @@ const WIDGET_COMMANDS: &[&str] = &[
 /// Tk geometry-manager commands.  Mirrors `GEOMETRY_COMMANDS`.
 const GEOMETRY_COMMANDS: &[&str] = &["pack", "grid", "place"];
 
+/// Cheap precheck for whether Tk diagnostics could apply to this document:
+/// the analysis dialect is `tk`, or the source mentions `package` /
+/// `require` / `Tk` (so a `package require Tk` — however the lexer splits
+/// its words — is not missed).  Mirrors the substring guard in
+/// `server/features/diagnostics.py` that runs before `has_tk_require`.
+/// Used both to gate the per-command accumulation and to force the
+/// incremental per-item path back to full analysis for Tk documents.
+#[must_use]
+pub(super) fn tk_possibly_active(source: &str, dialect: &str) -> bool {
+    dialect == "tk"
+        || (source.contains("package") && source.contains("require") && source.contains("Tk"))
+}
+
 /// Return `true` if `name` is a Tk widget-creation command.
 fn is_widget_command(name: &str) -> bool {
     WIDGET_COMMANDS.contains(&name)
@@ -121,10 +150,12 @@ fn parent_widget_path(widget_path: &str) -> &str {
 }
 
 impl Analyser {
-    /// Per-command Tk-dialect dispatch.  Tracks widget creation and
-    /// geometry-manager usage, emitting TK1002 / TK1003 inline and
-    /// recording geometry usage for the post-walk TK1001 flush.  A no-op
-    /// outside the `tk` dialect.
+    /// Per-command Tk dispatch.  Tracks widget creation and geometry-manager
+    /// usage, *buffering* TK1002 / TK1003 (and recording geometry usage for
+    /// the post-walk TK1001 flush) rather than emitting inline — the
+    /// activation condition (`tk` dialect or a `package require Tk`) is a
+    /// whole-file fact only resolved post-walk.  A no-op unless
+    /// [`tk_possibly_active`] held for this document.
     pub(super) fn emit_tk_checks(
         &mut self,
         cmd_name: &str,
@@ -132,7 +163,7 @@ impl Analyser {
         arg_tokens: &[Token],
         cmd_tok: Token,
     ) {
-        if self.dialect != "tk" {
+        if !self.tk_possibly_active {
             return;
         }
 
@@ -146,7 +177,7 @@ impl Analyser {
             // always exists, so it is never flagged.
             let parent = parent_widget_path(path);
             if !parent.is_empty() && parent != "." && !self.tk_created_widgets.contains(parent) {
-                self.result.diagnostics.push(Diagnostic {
+                self.tk_pending_diags.push(Diagnostic {
                     code: "TK1002".to_string(),
                     span: cmd_tok.span,
                     message: format!(
@@ -174,11 +205,10 @@ impl Analyser {
         }
     }
 
-    /// TK1003 — flag `-option` arguments that the widget command does
-    /// not declare.  Mirrors the option scan in `check_tk_diagnostics`:
-    /// a lone `-` / `--` is skipped, and the check is silent when the
-    /// command has no registry spec (so unknown widgets never false
-    /// positive).
+    /// TK1003 — buffer `-option` arguments that the widget command does not
+    /// declare.  Mirrors the option scan in `check_tk_diagnostics`: a lone
+    /// `-` / `--` is skipped, and the check is silent when the command has
+    /// no registry spec (so unknown widgets never false positive).
     fn emit_tk1003_unknown_options(&mut self, cmd_name: &str, args: &[String], cmd_tok: Token) {
         let Some(registry) = self.registry.as_ref() else {
             return;
@@ -198,7 +228,7 @@ impl Analyser {
             }
         }
         for arg in unknown {
-            self.result.diagnostics.push(Diagnostic {
+            self.tk_pending_diags.push(Diagnostic {
                 code: "TK1003".to_string(),
                 span: cmd_tok.span,
                 message: format!("Unknown option '{arg}' for {cmd_name}."),
@@ -208,16 +238,32 @@ impl Analyser {
         }
     }
 
-    /// TK1001 — post-walk flush: a parent that mixes `pack` and `grid`
-    /// is a Tk runtime error, reported on every geometry call for that
-    /// parent.  Mirrors the final loop in `check_tk_diagnostics`.  Clears
-    /// the accumulated state so a reused [`Analyser`] starts clean.
+    /// Whether the file declared `package require Tk` (port of Python
+    /// `has_tk_require`).
+    fn has_tk_require(&self) -> bool {
+        self.result
+            .package_requires
+            .iter()
+            .any(|pr| pr.name == "Tk")
+    }
+
+    /// Post-walk flush of all TK diagnostics.  Emits the buffered TK1002 /
+    /// TK1003 and decides TK1001 (a parent mixing `pack` and `grid` is a Tk
+    /// runtime error, reported on every offending geometry call) — but only
+    /// when the document is actually Tk: the `tk` dialect, or a detected
+    /// `package require Tk`.  Mirrors `server/features/diagnostics.py`'s
+    /// `has_tk_require` gate.  Clears the accumulated state either way so a
+    /// reused [`Analyser`] starts clean.
     pub(super) fn flush_tk_geometry_diagnostics(&mut self) {
         let geometry = std::mem::take(&mut self.tk_geometry);
+        let pending = std::mem::take(&mut self.tk_pending_diags);
         self.tk_created_widgets.clear();
-        if self.dialect != "tk" {
+
+        if self.dialect != "tk" && !self.has_tk_require() {
             return;
         }
+
+        self.result.diagnostics.extend(pending);
         for (parent, usage) in geometry {
             if usage.managers.contains("pack") && usage.managers.contains("grid") {
                 for (_manager, span) in usage.sites {
@@ -286,9 +332,53 @@ mod tests {
     }
 
     #[test]
-    fn no_tk_checks_outside_tk_dialect() {
-        // The same conflict in plain Tcl must stay silent.
+    fn no_tk_checks_in_plain_tcl_without_tk_require() {
+        // Plain Tcl with no `package require Tk` must stay silent even with
+        // Tk-shaped commands.
         let src = "frame .outer.inner";
-        assert!(!has(src, "tcl", "TK1002"));
+        assert!(!has(src, "tcl8.6", "TK1002"));
+    }
+
+    #[test]
+    fn tk_checks_fire_on_plain_tcl_with_package_require_tk() {
+        // A `.tcl` file mapped to `tcl8.6` that declares `package require Tk`
+        // must still get the checks (mirrors Python's `has_tk_require` gate).
+        let src = "package require Tk\nframe .outer.inner";
+        assert!(has(src, "tcl8.6", "TK1002"));
+    }
+
+    #[test]
+    fn package_require_tk_substring_alone_does_not_activate() {
+        // The cheap substring precheck can match, but without a real
+        // `package require Tk` the post-walk gate stays closed.
+        let src = "set msg \"package require Tk in a comment\"\nframe .outer.inner";
+        assert!(!has(src, "tcl8.6", "TK1002"));
+    }
+
+    #[test]
+    fn per_item_matches_full_for_tk_with_proc() {
+        // The incremental per-item path must agree with full analysis for a
+        // Tk document whose widgets / geometry live inside a proc (the
+        // whole-file accumulator an isolated body cannot see).
+        let src = "package require Tk\n\
+                   frame .top\n\
+                   proc build {} {\n\
+                   pack .top.a\n\
+                   grid .top.b\n\
+                   }\n";
+        let full = Analyser::new().analyse(src, "tcl8.6");
+        let per_item = Analyser::new().analyse_per_item(src, "tcl8.6");
+        let codes_of = |r: &super::super::types::AnalysisResult| {
+            let mut v: Vec<(String, u32)> = r
+                .diagnostics
+                .iter()
+                .map(|d| (d.code.clone(), d.span.start()))
+                .collect();
+            v.sort();
+            v
+        };
+        assert_eq!(codes_of(&full), codes_of(&per_item));
+        // And the conflict really is reported (proc-body geometry flushed).
+        assert!(full.diagnostics.iter().any(|d| d.code == "TK1001"));
     }
 }


### PR DESCRIPTION
## FE-DIAG-F5 — F5 dialect diagnostics

Finishes the **FE-DIAG-F5** track in `docs/rust-rewrite.md`. The track's open item was four Python-only diagnostic families with **zero Rust emitters**, with the explicit instruction to *"decide Python-only vs Rust port per family."* This PR makes and executes that decision.

### Per-family outcome

| Family | Decision | Landed in |
|---|---|---|
| **TK1001-1003** (geometry / widget / option) | **Ported to Rust** | `tcl-compiler::analyser::tk_checks` — wired into the per-command dispatch (`emit_dispatch_site_diagnostics`) + the post-walk emission tail (`run_diagnostic_emitters`), so it is **live** through the native server's diagnostics path, gated on the `tk` dialect |
| **BIGIP6001-6011** (config validator) | **Ported to Rust** | `tcl-bigip::validator` — `validate_bigip_config` / `validate_bigip_source` produce ranged `ConfigDiagnostic`s over a parsed `BigipConfig`, reusing the lint engine's `ModelView` / `KindMap` / `resolve_name` (now `pub(crate)`, with a new `KindMap::get`) |
| **IAPP7001-7003** (iApp template) | **Ported to Rust** | `tcl-bigip::apl::{iapp_vars, iapp_diagnostics}` over the existing `AplModel`; `extract_iapp_var_refs` pulls `$::section__field` impl references (ReDoS-safe regex), gated on the `f5-iapps` / `f5-tmsh` / `f5-bigip` dialects |
| **XC100-301** (BIG-IP→F5-XC translator) | **Deferred, Python-only** | gated on a future `tcl-xc` port of the ~1.2 K-LOC `lower_to_ir`-walking `translator.py` — a distinct large subsystem (analogous to FE-OPT v3 gated on RT-WASM). Documented handoff. |

The `regex` crate has no look-around, so the two Python negative look-aheads (`pool (?!member)`, `persist (?!none)`) are filtered in code; the iApp var regex keeps the ReDoS-safe `__`-post-filter form.

### Verification
- 19 new unit tests (TK 6, BIG-IP 6, iApp 7), all green; full `tcl-compiler` (2830) and `tcl-bigip` (176) suites pass.
- `cargo clippy --all-targets -- -D warnings` and `rustfmt --check` clean on the new code (edition-2024 let-chains).
- Dependent crates (`tcl-lsp-server`, `tcl-lsp-py`) still build.

### Docs
`docs/rust-rewrite.md`: subsystem-status row and track-map row moved 🔴 → 🟢, the per-family decision recorded, and the two residuals enumerated (XC translator port; BIG-IP/iApp native-server consumer-wiring as a SRV-LSP-style handoff).

### Residuals (out of scope, documented)
1. **XC100-301** Rust port — needs the `tcl-xc` translator subsystem first.
2. **BIG-IP / iApp native-server wiring** — the validators are crate APIs; routing them into the native server for BIG-IP-config / APL documents is a SRV-LSP-style consumer-wiring step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mdp2wSSbivdEG3TUcMRm6

---
_Generated by [Claude Code](https://claude.ai/code/session_013mdp2wSSbivdEG3TUcMRm6)_