### PR TITLE
RT-VM + RT-WASM: tclvm CLI/REPL binary and tcl dis/compwasm verbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-vm-cli"
+version = "0.1.0"
+dependencies = [
+ "tcl-bytecode",
+ "tcl-compiler",
+ "tcl-lexer",
+ "tcl-registry",
+ "tcl-vm",
+]
+
+[[package]]
 name = "temp-env"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "rust/tcl-registry",
     "rust/tcl-compiler",
     "rust/tcl-vm",
+    "rust/tcl-vm-cli",
     "rust/tcl-bigip",
     "rust/tcl-bigip-io",
     "rust/tcl-bigip-query",

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -866,8 +866,8 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Bytecode codegen | `tcl-compiler::codegen` | 🟢 | state-mutating statement-position specialisations + `expr` const-fold + byte-wise `esc` landed (byte-true vs tclsh9.0; VM opcodes implemented to match); residual: `set x [cmd]` (reverted — needs VM value opcodes), bare-statement `string`/`regexp`/`lindex`/`lreplace`, non-proc `dict` (ensemble `invokeReplace`), `{*}` cmd-subst expansion → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | every family ported + verified (E001/W125/IRULE5005, snit, OO body-walks, W307/W308, C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes, `when`-body gating, source-style/W108, #662 lockstep fixes) — see [history](rust-rewrite-history.md). The two consumer-wiring residuals (per-check config toggles, flow-warning code actions) landed under **SRV-LSP** |
 | F5 dialect diagnostics | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}`, new `tcl-xc` | 🟢 | TK1001-3 + BIGIP6001-11 + IAPP7001-3 ported (TK live in the analyser); residuals: XC100-301 (gated on a `tcl-xc` translator port of `lower_to_ir`-walking `translator.py`, Python-only meanwhile) + BIG-IP/iApp native-server consumer-wiring (SRV-LSP-style) → **FE-DIAG-F5** |
-| WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | emitter (IR/encoding only today); `IRInterpBoundary`; codegen DCE/GVN; `tcl-wasm` CLI → **RT-WASM** |
-| Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after; CLI/REPL binary → **RT-VM** |
+| WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | eval-fallback emitter + `tcl compwasm` wiring landed (binary/WAT, `wasmtime`-validated); residual: `IRInterpBoundary`; codegen DCE/GVN; `--link` (Binaryen) bundling → **RT-WASM** |
+| Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after. `tclvm` CLI/REPL binary landed (`tcl-vm-cli`) → **RT-VM** |
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
 | Document store / incrementality | `tcl-lsp-server`, `tcl-lexer`, `tcl-lsp-db` | 🔴 | rope-backed store + chunk-addressable salsa input + rope-slice re-lex → **SRV-ROPE** (see [`design/rope/`](design/rope/README.md)) |
 | `tcl` CLI | `tcl-cli` | 🟡 | `dis`/`compwasm`/`pkg`/`venv`/`docker` verbs → **TOOL-CLI** |
@@ -894,7 +894,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | FE | **FE-DIAG** ✅ | `tcl-compiler::analyser`, `irules_checks` | — | M |
 | FE | **FE-DIAG-F5** 🟢 | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}` slices, tk; XC residual → `tcl-xc` | `tcl-bigip` | L |
 | RT | **RT-WASM** | `tcl-compiler::codegen::wasm`, `runtime/zig`, `tcl-wasm` bin | FE-CODEGEN | L |
-| RT | **RT-VM** | `tcl-vm` | `tcl-bytecode` | L |
+| RT | **RT-VM** | `tcl-vm`, `tcl-vm-cli` (`tclvm` bin) | `tcl-bytecode` | L |
 | SRV | **SRV-LSP** ✅ | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | FE-DIAG, FE-DATAFLOW | L |
 | SRV | **SRV-ROPE** | document store: `tcl-lsp-server` `DocumentState` + `tcl-lexer` rope-slice `SourceMap` + `tcl-lsp-db` chunk input | FE-LEX (CST/structural-state index), SRV-LSP | XL |
 | TOOL | **TOOL-TCLPKG** | new `tcl-pkg` crate | — | XL |
@@ -1019,10 +1019,15 @@ Owns `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` bin.
 - **open** `IRInterpBoundary` IR node + insert pass; the IR-rewriting
   `passes/dce.py` / `passes/gvn.py`; `source_inliner` / `stdlib_prelude`
   (WASM-bundle self-containment).
-- **open** `tcl-wasm` CLI + `--link` (Binaryen) bundling; wire `tcl compwasm`.
+- **done** wire `tcl compwasm` (`tcl-cli`): drives the eval-fallback emitter,
+  writes the binary module (`--output`) and optional WAT (`--wat-output`); the
+  emitted bytes pass `wasmtime compile`. The `_write_binary_output` analogue
+  landed as `tcl_cli_support::write_binary_output`.
+- **open** `tcl-wasm` CLI + `--link` (Binaryen) bundling (standalone
+  self-contained module via `source_inliner` / `stdlib_prelude`).
 
 #### RT-VM — bytecode VM
-Owns `tcl-vm`.
+Owns `tcl-vm` (+ the `tcl-vm-cli` / `tclvm` CLI driver).
 
 The engine core is solid (loads the real Tcl 9 `tcltest.tcl` end-to-end). The
 active workstream is **tcltest pass/fail/skip parity** with the more-complete
@@ -1062,8 +1067,13 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
 - **open** the missing command surface: **TclOO** (largest), `clock`,
   `encoding`, full `interp`, real I/O (`open`/`gets`/`seek`), `after`/`time`,
   residual `file`/`info`/`namespace` subcommands.
-- **open** a VM CLI/REPL binary (`tcl-vm` is lib-only today) — also unblocks the
-  `tcl dis` verb.
+- **done** a VM CLI/REPL binary — the `tclvm` binary in the new `tcl-vm-cli`
+  crate (a thin compiler-backed `CompileService` driver, keeping the `tcl-vm`
+  lib compiler-optional). Runs script files (with `argv`/`argv0`/`argc`),
+  evaluates inline scripts (`-c`), pipes stdin, and offers an `info
+  complete`-aware REPL (`-i` forces it without a TTY). The `tcl dis` verb it
+  was paired with is wired in `tcl-cli` (bytecode disassembly via
+  `format_module_asm`, with `--optimise`).
 
 ### Stage 3 — LSP server (SRV-LSP) — complete
 
@@ -1151,8 +1161,10 @@ already started, brings **every** Python tool across to Rust.
   mock-stub codegen, orchestrator). Note `tcl-irules` is the BIG-IP
   reference-extractor, **not** this. *(XL)*
 - **TOOL-CLI** *(owns `tcl-cli`; depends on RT-WASM, RT-VM, TOOL-TCLPKG)* —
-  **partial**: finish `dis` (after RT-VM), `compwasm` (after RT-WASM),
-  `pkg`/`venv`/`docker` (after TOOL-TCLPKG). 20/26 verbs done. *(S glue)*
+  **partial**: `dis` and `compwasm` landed (bytecode disassembly via
+  `format_module_asm`; eval-fallback WASM binary/WAT via the greenfield
+  emitter). Remaining: `pkg`/`venv`/`docker` (after TOOL-TCLPKG). 22/26 verbs
+  done. *(S glue)*
 
 ### Stage 5 — PyO3 interfaces & Python retirement (API-PYO3 — last)
 

--- a/rust/tcl-cli-support/src/lib.rs
+++ b/rust/tcl-cli-support/src/lib.rs
@@ -22,8 +22,8 @@ pub mod secret_input;
 pub use highlight::{highlight_ansi, highlight_html};
 pub use input::{CliError, InputDocument, combine_sources, read_input_documents};
 pub use output::{
-    OutputTarget, ensure_ascii, expand_tabs, resolve_use_colour, write_highlighted_output,
-    write_text_output,
+    OutputTarget, ensure_ascii, expand_tabs, resolve_use_colour, write_binary_output,
+    write_highlighted_output, write_text_output,
 };
 // The per-dialect registry cache now lives in `tcl-registry` so every
 // downstream tool (CLI, compiler explorer, …) shares one cache. Re-exported

--- a/rust/tcl-cli-support/src/output.rs
+++ b/rust/tcl-cli-support/src/output.rs
@@ -55,6 +55,25 @@ pub fn write_text_output(target: &OutputTarget, text: &str) -> Result<(), CliErr
     }
 }
 
+/// Write raw bytes to the target (mirrors `_write_binary_output`).
+///
+/// For stdout the payload is written verbatim — no trailing newline, since the
+/// bytes are a binary artifact (e.g. a `.wasm` module). For files the bytes are
+/// written as-is.
+pub fn write_binary_output(target: &OutputTarget, payload: &[u8]) -> Result<(), CliError> {
+    match target {
+        OutputTarget::Stdout => {
+            let mut out = std::io::stdout().lock();
+            out.write_all(payload)
+                .map_err(|e| CliError::Io(format!("failed to write stdout: {e}")))?;
+            out.flush()
+                .map_err(|e| CliError::Io(format!("failed to flush stdout: {e}")))
+        }
+        OutputTarget::File(path) => std::fs::write(path, payload)
+            .map_err(|e| CliError::Io(format!("failed to write {}: {e}", path.display()))),
+    }
+}
+
 /// Write Tcl source, optionally colourised, with Python-faithful tab handling
 /// (mirrors `_write_highlighted_output`).
 ///

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -81,6 +81,8 @@ pub enum Command {
     },
 
     /// Compile source to a WebAssembly binary.
+    ///
+    /// Writes to `out.wasm` when `--output` is omitted (use `-o -` for stdout).
     #[command(visible_alias = "wasm")]
     Compwasm {
         #[command(flatten)]

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -1,0 +1,88 @@
+//! Low-level compilation verbs: `dis` (bytecode disassembly) and `compwasm`
+//! (WebAssembly emit).
+//!
+//! Port of `tooling/tcl/verbs/compile.py` (`_run_dis` / `_run_compwasm`). Both
+//! resolve their inputs the same way the rest of the CLI does, then drive the
+//! compiler pipeline directly:
+//!
+//! - `dis` lowers to the bytecode IR, builds the codegen CFG (the
+//!   `faithful_exceptions`-off shape — see `tcl-explorer`'s `asm` view for why),
+//!   emits the `ModuleAsm`, and renders it with `format_module_asm`.
+//! - `compwasm` lowers to the analysis IR and runs the greenfield WASM
+//!   eval-fallback emitter, writing the binary module (and, optionally, its WAT
+//!   text form).
+//!
+//! `--optimise` runs the source-to-source optimiser first, exactly as the
+//! Python `compile_script(optimise=...)` path does (`apply_optimisations` over
+//! the `optimise` rewrites), then compiles the rewritten source.
+
+use tcl_cli_support::{
+    OutputTarget, combine_sources, read_input_documents, registry_for_dialect, write_binary_output,
+    write_text_output,
+};
+use tcl_compiler::cfg_builder::build_cfg_codegen;
+use tcl_compiler::codegen::codegen_module;
+use tcl_compiler::codegen::format::format_module_asm;
+use tcl_compiler::codegen::wasm::wasm_codegen_module;
+use tcl_compiler::lowering::{lower_to_ir, lower_to_ir_for_bytecode};
+use tcl_compiler::optimiser::{apply_optimisations, optimise};
+use tcl_registry::CommandRegistry;
+
+use crate::cli::InputArgs;
+
+/// Apply the source-to-source optimiser when `optimise` is set, mirroring the
+/// Python `compile_script(optimise=...)` entry: collect the rewrites, apply
+/// them, and compile the rewritten text. Returns the (possibly unchanged)
+/// source.
+fn maybe_optimise(source: &str, registry: &CommandRegistry, optimise_on: bool) -> String {
+    if optimise_on {
+        apply_optimisations(source, &optimise(source, registry))
+    } else {
+        source.to_owned()
+    }
+}
+
+/// `tcl dis` — compile source and emit human-readable bytecode disassembly.
+pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
+    let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let registry = registry_for_dialect(&input.dialect);
+    let source = maybe_optimise(&combine_sources(&documents), registry, optimise_on);
+
+    let ir = lower_to_ir_for_bytecode(&source, registry);
+    let cfg = build_cfg_codegen(&ir, false);
+    let module = codegen_module(&cfg, &ir, registry);
+    let disassembly = format_module_asm(&module);
+
+    let target = OutputTarget::from_arg(input.output.as_deref());
+    write_text_output(&target, &disassembly)?;
+    Ok(0)
+}
+
+/// `tcl compwasm` — compile source to a WebAssembly binary (eval-fallback tier).
+pub fn run_compwasm(input: &InputArgs, wat_output: Option<&std::path::Path>) -> anyhow::Result<u8> {
+    let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let registry = registry_for_dialect(&input.dialect);
+    let source = combine_sources(&documents);
+
+    let ir = lower_to_ir(&source, registry);
+    let mut wasm = wasm_codegen_module(&ir, &source);
+    let bytes = wasm.to_bytes();
+
+    let target = OutputTarget::from_arg(input.output.as_deref());
+    write_binary_output(&target, &bytes)?;
+    if let Some(wat_path) = wat_output {
+        let wat_target = OutputTarget::from_arg(Some(wat_path));
+        write_text_output(&wat_target, &wasm.to_wat())?;
+    }
+
+    let where_to = if target.is_stdout() {
+        "stdout".to_owned()
+    } else {
+        input
+            .output
+            .as_deref()
+            .map_or_else(|| "stdout".to_owned(), |p| p.display().to_string())
+    };
+    eprintln!("wrote wasm binary ({} bytes) to {where_to}", bytes.len());
+    Ok(0)
+}

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -68,20 +68,23 @@ pub fn run_compwasm(input: &InputArgs, wat_output: Option<&std::path::Path>) -> 
     let mut wasm = wasm_codegen_module(&ir, &source);
     let bytes = wasm.to_bytes();
 
-    let target = OutputTarget::from_arg(input.output.as_deref());
+    // Unlike the other verbs, `compwasm` defaults to a file, not stdout: a bare
+    // `tcl compwasm script.tcl` must not dump raw WASM bytes to the terminal.
+    // Mirrors the Python verb's `output="out.wasm"` default; an explicit `-o -`
+    // still selects stdout.
+    let target = match input.output.as_deref() {
+        None => OutputTarget::File(std::path::PathBuf::from("out.wasm")),
+        Some(path) => OutputTarget::from_arg(Some(path)),
+    };
     write_binary_output(&target, &bytes)?;
     if let Some(wat_path) = wat_output {
         let wat_target = OutputTarget::from_arg(Some(wat_path));
         write_text_output(&wat_target, &wasm.to_wat())?;
     }
 
-    let where_to = if target.is_stdout() {
-        "stdout".to_owned()
-    } else {
-        input
-            .output
-            .as_deref()
-            .map_or_else(|| "stdout".to_owned(), |p| p.display().to_string())
+    let where_to = match &target {
+        OutputTarget::Stdout => "stdout".to_owned(),
+        OutputTarget::File(path) => path.display().to_string(),
     };
     eprintln!("wrote wasm binary ({} bytes) to {where_to}", bytes.len());
     Ok(0)

--- a/rust/tcl-cli/src/commands/mod.rs
+++ b/rust/tcl-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 //! resolves inputs via `tcl-cli-support`, drives the relevant Rust engine
 //! crate, and writes output. Handlers return the intended process exit code.
 
+pub mod compile;
 pub mod diag;
 pub mod diagram;
 pub mod diff;

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -56,6 +56,10 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             commands::diag::run_diag(input, diag)
         }
         Command::Validate { input, diag } => commands::diag::run_validate(input, diag),
+        Command::Dis { input, optimise } => commands::compile::run_dis(input, *optimise),
+        Command::Compwasm { input, wat_output } => {
+            commands::compile::run_compwasm(input, wat_output.as_deref())
+        }
         Command::Diagram { input, json } => commands::diagram::run_diagram(input, *json),
         Command::Symbols { input, json } => commands::graphs::run_symbols(input, *json),
         Command::Symbolgraph { input, json } => commands::graphs::run_symbolgraph(input, *json),

--- a/rust/tcl-cli/tests/compile_verbs.rs
+++ b/rust/tcl-cli/tests/compile_verbs.rs
@@ -1,0 +1,92 @@
+//! Integration tests for the `dis` and `compwasm` verbs.
+//!
+//! These assert structural properties of the output rather than byte-for-byte
+//! Python parity: the Rust bytecode codegen and the greenfield WASM emitter are
+//! still reaching feature parity (notably `expr`/command-substitution inlining),
+//! so the verbs are asserted to faithfully render whatever the current Rust
+//! pipeline produces — a valid disassembly and a structurally valid WASM module.
+
+use std::process::Command;
+
+/// Run the built `tcl` binary with `args` and inline source, returning the
+/// captured stdout bytes. Asserts the process succeeded.
+fn run_tcl(args: &[&str]) -> Vec<u8> {
+    let output = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args(args)
+        .output()
+        .expect("failed to spawn tcl binary");
+    assert!(
+        output.status.success(),
+        "tcl {args:?} exited {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+#[test]
+fn dis_renders_bytecode_for_inline_source() {
+    let out = run_tcl(&["dis", "--source", "set x 5\nputs $x\n"]);
+    let text = String::from_utf8(out).expect("utf-8");
+    // Module header, the literal pool the source populates, and the terminator.
+    assert!(text.contains("ByteCode ::top"), "{text}");
+    assert!(text.contains("Literals:"), "{text}");
+    assert!(text.contains("\"puts\""), "{text}");
+    assert!(text.contains("done"), "{text}");
+}
+
+#[test]
+fn dis_optimise_folds_constants() {
+    // Without --optimise the expr substitution is preserved; with it, the
+    // optimiser const-folds `1 + 2` to `3` in the rewritten source.
+    let out = run_tcl(&["dis", "--optimise", "--source", "set x [expr {1 + 2}]\n"]);
+    let text = String::from_utf8(out).expect("utf-8");
+    assert!(
+        text.contains("\"3\""),
+        "expected folded literal 3 in:\n{text}"
+    );
+}
+
+#[test]
+fn compwasm_emits_valid_module_header() {
+    let dir = std::env::temp_dir().join("tcl_compwasm_test");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let wasm_path = dir.join("out.wasm");
+    let wat_path = dir.join("out.wat");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args([
+            "compwasm",
+            "--source",
+            "set x 5\nputs $x\n",
+            "-o",
+            wasm_path.to_str().unwrap(),
+            "--wat-output",
+            wat_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn tcl");
+    assert!(
+        out.status.success(),
+        "compwasm failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let bytes = std::fs::read(&wasm_path).expect("read wasm");
+    // WASM magic + version (`\0asm` 0x01000000).
+    assert_eq!(&bytes[0..4], b"\0asm", "missing wasm magic");
+    assert_eq!(&bytes[4..8], &[1, 0, 0, 0], "unexpected wasm version");
+
+    let wat = std::fs::read_to_string(&wat_path).expect("read wat");
+    assert!(wat.starts_with("(module"), "{wat}");
+    assert!(wat.contains("tcl_obj_new_string"), "{wat}");
+
+    // Keep the test hermetic.
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn compwasm_writes_to_stdout_by_default() {
+    let out = run_tcl(&["compwasm", "--source", "set x 1\n"]);
+    assert_eq!(&out[0..4], b"\0asm", "stdout payload is not a wasm module");
+}

--- a/rust/tcl-cli/tests/compile_verbs.rs
+++ b/rust/tcl-cli/tests/compile_verbs.rs
@@ -86,7 +86,35 @@ fn compwasm_emits_valid_module_header() {
 }
 
 #[test]
-fn compwasm_writes_to_stdout_by_default() {
-    let out = run_tcl(&["compwasm", "--source", "set x 1\n"]);
+fn compwasm_defaults_to_out_wasm_file() {
+    // With no `-o`, compwasm must write `out.wasm` in the cwd (the Python
+    // default) rather than dumping raw bytes to the terminal. Run in a scratch
+    // dir so the artifact lands somewhere hermetic.
+    let dir = std::env::temp_dir().join("tcl_compwasm_default");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .current_dir(&dir)
+        .args(["compwasm", "--source", "set x 1\n"])
+        .output()
+        .expect("spawn tcl");
+    assert!(
+        out.status.success(),
+        "compwasm failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The default does not write bytes to stdout.
+    assert!(out.stdout.is_empty(), "default run wrote to stdout");
+
+    let bytes = std::fs::read(dir.join("out.wasm")).expect("out.wasm not written");
+    assert_eq!(&bytes[0..4], b"\0asm", "out.wasm is not a wasm module");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn compwasm_dash_o_writes_stdout() {
+    // An explicit `-o -` still selects stdout (matching the Python verb).
+    let out = run_tcl(&["compwasm", "--source", "set x 1\n", "-o", "-"]);
     assert_eq!(&out[0..4], b"\0asm", "stdout payload is not a wasm module");
 }

--- a/rust/tcl-vm-cli/Cargo.toml
+++ b/rust/tcl-vm-cli/Cargo.toml
@@ -1,0 +1,31 @@
+# The `tcl-vm` executable: a thin CLI/REPL driver around the `tcl-vm` library.
+#
+# The VM library stays compiler-optional (the `CompileService` injection point
+# keeps it off `tcl-compiler`); this binary crate supplies the concrete
+# compiler-backed `CompileService` and the host wiring, so the lib itself never
+# grows a `tcl-compiler` dependency. Mirrors the `tcl-vm` examples (`eval` /
+# `run_test`), promoted to a shipping `tclvm` binary that runs script files,
+# evaluates inline scripts, pipes stdin, and offers an interactive REPL.
+[package]
+name = "tcl-vm-cli"
+description = "The `tclvm` binary: a CLI/REPL driver for the native Tcl bytecode VM"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "tclvm"
+path = "src/main.rs"
+
+[dependencies]
+tcl-vm = { path = "../tcl-vm" }
+tcl-bytecode = { path = "../tcl-bytecode" }
+tcl-compiler = { path = "../tcl-compiler" }
+tcl-registry = { path = "../tcl-registry" }
+tcl-lexer = { path = "../tcl-lexer" }
+
+[lints]
+workspace = true

--- a/rust/tcl-vm-cli/src/main.rs
+++ b/rust/tcl-vm-cli/src/main.rs
@@ -1,0 +1,284 @@
+//! `tclvm` — a CLI/REPL driver for the native Tcl bytecode VM (`tcl-vm`).
+//!
+//! Promotes the `tcl-vm` examples (`eval` / `run_test`) to a shipping binary.
+//! The VM library is compiler-optional by design (the [`CompileService`] seam
+//! keeps it off `tcl-compiler`), so this crate supplies the concrete
+//! compiler-backed service and the host wiring.
+//!
+//! Modes (resolved like `tclsh`):
+//!
+//! - `tclvm <file.tcl> [args…]` — compile and run a script file; `args` become
+//!   the script's `argv` (`argv0` is the file, `argc` the count).
+//! - `tclvm -c "<script>"` — evaluate an inline script string.
+//! - `tclvm` with piped stdin — run the piped script.
+//! - `tclvm` on a TTY — an interactive REPL (`info complete`-aware line
+//!   accumulation via `tcl_lexer::script_is_complete`).
+//!
+//! Like the `run_test` example, work runs on a large-stack worker thread so deep
+//! recursion surfaces as a catchable Tcl error rather than a native stack
+//! overflow.
+
+use std::io::{IsTerminal, Read, Write};
+
+use tcl_compiler::cfg_builder::build_cfg_codegen as build_cfg;
+use tcl_compiler::codegen::codegen_module;
+use tcl_compiler::lowering::lower_to_ir_for_bytecode as lower_to_ir;
+use tcl_lexer::script_is_complete;
+use tcl_registry::CommandRegistry;
+use tcl_vm::{CompileError, CompileService, Value, Vm};
+
+/// The `CompileService` the VM uses for runtime `eval` / command substitution
+/// (and for the top-level script the driver runs): the real Rust compiler
+/// pipeline (lower → CFG → bytecode). Mirrors the `eval` / `run_test` examples.
+struct Svc(CommandRegistry);
+
+impl CompileService for Svc {
+    type Module = tcl_bytecode::ModuleAsm;
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let ir = lower_to_ir(src, &self.0);
+        let cfg = build_cfg(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &self.0))
+    }
+}
+
+/// Forward the VM's `puts` output straight through to the process stdout.
+struct Stdout;
+impl Write for Stdout {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        std::io::stdout().write(b)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        std::io::stdout().flush()
+    }
+}
+
+const STACK_BYTES: usize = 512 * 1024 * 1024;
+
+fn main() {
+    let code = std::thread::Builder::new()
+        .stack_size(STACK_BYTES)
+        .spawn(run)
+        .expect("spawn worker thread")
+        .join()
+        .expect("worker thread panicked");
+    std::process::exit(code);
+}
+
+/// What the parsed command line asks the driver to do.
+enum Mode {
+    /// Run a script file with the given trailing `argv`.
+    File { path: String, argv: Vec<String> },
+    /// Evaluate an inline script string.
+    Command(String),
+    /// No script given: REPL if stdin is a TTY, else run piped stdin.
+    Stdin,
+    /// Force the interactive REPL even when stdin is not a TTY (`-i`).
+    Repl,
+    /// Print usage to stderr and exit with the given code.
+    Usage(i32),
+}
+
+/// Parse `std::env::args` into a [`Mode`]. Recognises `-c <script>`, `-i`
+/// (force REPL), `-h` / `--help`, and otherwise treats the first non-flag
+/// argument as a script file (everything after it is the script's `argv`,
+/// `tclsh`-style).
+fn parse_args() -> Mode {
+    let mut args = std::env::args().skip(1);
+    match args.next() {
+        None => Mode::Stdin,
+        Some(flag) if flag == "-h" || flag == "--help" => Mode::Usage(0),
+        Some(flag) if flag == "-i" => Mode::Repl,
+        Some(flag) if flag == "-c" => match args.next() {
+            Some(script) => Mode::Command(script),
+            None => Mode::Usage(2),
+        },
+        Some(path) => Mode::File {
+            path,
+            argv: args.collect(),
+        },
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage:\n  \
+         tclvm <file.tcl> [args…]   run a script file\n  \
+         tclvm -c <script>         evaluate an inline script\n  \
+         tclvm -i                  force the interactive REPL\n  \
+         tclvm                     REPL (TTY) or run piped stdin"
+    );
+}
+
+/// Build a VM with the compiler-backed `CompileService` and stdout host output.
+fn new_vm() -> Vm {
+    let mut vm = Vm::with_output(Box::new(Stdout));
+    vm.set_compiler(Box::new(Svc(CommandRegistry::build_default())));
+    vm
+}
+
+/// Seed `argv0` / `argv` / `argc` the way `tclsh` does before running a file.
+fn set_argv(vm: &mut Vm, argv0: &str, argv: &[String]) {
+    let _ = vm.set_var("argv0", Value::string(argv0));
+    let _ = vm.set_var(
+        "argv",
+        Value::list(argv.iter().map(|s| Value::string(s.as_str())).collect()),
+    );
+    let _ = vm.set_var(
+        "argc",
+        Value::int(i64::try_from(argv.len()).unwrap_or(i64::MAX)),
+    );
+}
+
+/// Compile and run a whole script once, reporting any error to stderr. Returns
+/// the process exit code.
+fn run_script(vm: &mut Vm, src: &str) -> i32 {
+    match vm.eval_source(src) {
+        Ok(comp) if comp.code.is_ok() => 0,
+        Ok(comp) => {
+            eprintln!("{}", comp.result.to_str());
+            1
+        }
+        Err(e) => {
+            eprintln!("{}", e.message);
+            1
+        }
+    }
+}
+
+fn run() -> i32 {
+    match parse_args() {
+        Mode::Usage(code) => {
+            usage();
+            code
+        }
+        Mode::Command(script) => {
+            let mut vm = new_vm();
+            run_script(&mut vm, &script)
+        }
+        Mode::Repl => {
+            let stdin = std::io::stdin();
+            let mut out = std::io::stdout();
+            repl_loop(&mut new_vm(), &mut stdin.lock(), &mut out)
+        }
+        Mode::File { path, argv } => {
+            let src = match std::fs::read_to_string(&path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("tclvm: cannot read {path}: {e}");
+                    return 1;
+                }
+            };
+            let mut vm = new_vm();
+            set_argv(&mut vm, &path, &argv);
+            run_script(&mut vm, &src)
+        }
+        Mode::Stdin => {
+            if std::io::stdin().is_terminal() {
+                let stdin = std::io::stdin();
+                let mut out = std::io::stdout();
+                repl_loop(&mut new_vm(), &mut stdin.lock(), &mut out)
+            } else {
+                let mut src = String::new();
+                if let Err(e) = std::io::stdin().read_to_string(&mut src) {
+                    eprintln!("tclvm: cannot read stdin: {e}");
+                    return 1;
+                }
+                let mut vm = new_vm();
+                run_script(&mut vm, &src)
+            }
+        }
+    }
+}
+
+/// Interactive REPL loop over an arbitrary reader/writer (so it is testable
+/// without a real terminal). Accumulates input lines until they form a complete
+/// command (`tcl_lexer::script_is_complete`, the `info complete` oracle),
+/// evaluates it in the persistent global frame, and writes a non-empty result.
+/// Variables and procs persist across evaluations because each line runs in the
+/// same VM. Prompts (`% ` primary, `> ` continuation) and results go to `out`;
+/// errors go to stderr. Always returns 0 (EOF is a clean exit).
+fn repl_loop<R: std::io::BufRead, W: Write>(vm: &mut Vm, reader: &mut R, out: &mut W) -> i32 {
+    let mut buffer = String::new();
+    let _ = write!(out, "% ");
+    let _ = out.flush();
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break, // EOF (Ctrl-D) or read error
+            Ok(_) => {}
+        }
+        buffer.push_str(&line);
+
+        // A blank buffer on its own just re-prompts; otherwise keep reading
+        // (continuation prompt) until the command is complete.
+        if buffer.trim().is_empty() {
+            buffer.clear();
+            let _ = write!(out, "% ");
+            let _ = out.flush();
+            continue;
+        }
+        if !script_is_complete(&buffer) {
+            let _ = write!(out, "> ");
+            let _ = out.flush();
+            continue;
+        }
+
+        match vm.eval_source(&buffer) {
+            Ok(comp) if comp.code.is_ok() => {
+                let result = comp.result.to_str();
+                if !result.is_empty() {
+                    let _ = writeln!(out, "{result}");
+                }
+            }
+            Ok(comp) => eprintln!("{}", comp.result.to_str()),
+            Err(e) => eprintln!("{}", e.message),
+        }
+        buffer.clear();
+        let _ = write!(out, "% ");
+        let _ = out.flush();
+    }
+    // A trailing newline so the shell prompt starts on its own line after EOF.
+    let _ = writeln!(out);
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive `repl_loop` over a canned input script and return what it wrote to
+    /// `out` (prompts + results), with a fresh compiler-backed VM.
+    fn drive(input: &str) -> String {
+        let mut vm = new_vm();
+        let mut reader = std::io::Cursor::new(input.as_bytes().to_vec());
+        let mut out: Vec<u8> = Vec::new();
+        repl_loop(&mut vm, &mut reader, &mut out);
+        String::from_utf8(out).expect("utf-8")
+    }
+
+    #[test]
+    fn repl_persists_state_and_prints_results() {
+        // `set x 5` echoes its result; `$x` survives into the next command.
+        let out = drive("set x 5\nexpr {$x + 1}\n");
+        assert!(out.contains("% 5"), "set result not echoed: {out:?}");
+        assert!(out.contains('6'), "var did not persist: {out:?}");
+    }
+
+    #[test]
+    fn repl_continuation_prompt_for_incomplete_command() {
+        // An open brace is incomplete: a continuation `> ` prompt is shown, and
+        // the command only evaluates once the brace closes on the next line.
+        let out = drive("set y {a\nb}\nllength $y\n");
+        assert!(out.contains("> "), "no continuation prompt: {out:?}");
+        // `llength {a\nb}` is 2 (two whitespace-separated words).
+        assert!(out.contains('2'), "joined value not evaluated: {out:?}");
+    }
+
+    #[test]
+    fn repl_blank_line_reprompts() {
+        let out = drive("\n\nset z 9\n");
+        assert!(out.contains("% 9"), "blank lines broke the loop: {out:?}");
+    }
+}


### PR DESCRIPTION
Advances both runtime tracks from `docs/rust-rewrite.md` by landing the shippable CLI surface each was missing.

## RT-VM — `tclvm` CLI/REPL binary (new `tcl-vm-cli` crate)
The plan listed *"a VM CLI/REPL binary (`tcl-vm` is lib-only today)"* as open. This adds a thin compiler-backed `CompileService` driver in a **separate crate**, so the `tcl-vm` library stays compiler-optional (its core design constraint — the `CompileService` seam keeps it off `tcl-compiler`). The `tclvm` binary:

- runs script files (seeding `argv` / `argv0` / `argc`, `tclsh`-style),
- evaluates inline scripts (`-c`),
- pipes stdin,
- offers an interactive REPL with `info complete`-aware multi-line accumulation (via `tcl_lexer::script_is_complete`); `-i` forces it without a TTY.

Work runs on a large-stack worker thread like the `run_test` example, so deep recursion surfaces as a catchable Tcl error rather than a native stack overflow.

## TOOL-CLI / RT-VM — `tcl dis`
Bytecode disassembly via the `lower → CFG → codegen_module → format_module_asm` pipeline, with `--optimise` running the source-to-source optimiser first. Previously fell through to "not yet implemented".

## TOOL-CLI / RT-WASM — `tcl compwasm`
Drives the greenfield eval-fallback WASM emitter, writing the binary module (`-o`) and optional WAT (`--wat-output`); the emitted bytes pass `wasmtime compile`. Adds `tcl_cli_support::write_binary_output` (the `_write_binary_output` analogue). Also corrects a stale status line that described the WASM emitter as "IR/encoding only" — it already has a working eval-fallback emitter with execution/link tests.

## Tests / verification
- New REPL unit tests (state persistence, continuation prompt, blank-line re-prompt) and `dis` / `compwasm` structural integration tests — all green.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `docs/rust-rewrite.md` status table, RT-VM / RT-WASM / TOOL-CLI sections, and track map updated to reflect the landed surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017qFtdiokFcTXLs4aETVAue)_