### PR TITLE
TOOL-TCLPKG: port tclpkg package manager to Rust (`tcl-pkg`) + wire CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +568,17 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -2199,6 +2219,7 @@ dependencies = [
  "tcl-explorer",
  "tcl-lexer",
  "tcl-lsp-core",
+ "tcl-pkg",
  "tcl-registry",
 ]
 
@@ -2341,6 +2362,23 @@ dependencies = [
  "temp-env",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "tcl-pkg"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "flate2",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tcl-syntax",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -3195,7 +3233,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "rust/tcl-explorer",
     "rust/tcl-cli-support",
     "rust/tcl-cli",
+    "rust/tcl-pkg",
     "rust/f5-cli",
 ]
 exclude = [

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -11195,6 +11195,14 @@ The track closed in `rust-rewrite.md` (now a ✅ row). What landed:
   root-only `replace`/`exclude`, three-phase port of the Python routine.
 - **`fetchers`** — gzip-tarball / zip / git / path over `ureq`, hardened against
   zip-slip, absolute paths, symlinks, and decompression bombs (256 MiB cap).
+- **`installer`** — wires resolve → source-resolution (root `replace` ›
+  `-source` › registry) → fetch → CAS store → materialise into `lib/`
+  (`.venv/lib` under an active venv). `tcl pkg install` now populates real
+  integrity/size/source/provides/license in the lockfile and lays down
+  `lib/<pkg>-<ver>/`, so `tcl pkg verify` passes on a freshly written lockfile;
+  an unreachable source degrades to a placeholder entry with a warning instead
+  of aborting. Added Python-first in lockstep so install lockfiles stay
+  byte-identical with Rust (CodexP2 follow-up on #681).
 - **`registry`** — TTL-cached client with conditional GET (`If-None-Match` /
   `304`) over `ureq`, offline-from-cache, stale-cache fallback.
 - **`venv`** + **`docker`** — venv create/info/list/activate/update/run +

--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -11164,3 +11164,47 @@ completing the track. The sole remaining item is deferred by design (rope-backed
   no salsa incrementality, 1.4–1.9× memory for many small docs), so the work is
   scoped as the cross-crate **SRV-ROPE** track in `rust-rewrite.md`, with the
   cheap persisted-`LineIndex` win as its first step.
+
+## TOOL-TCLPKG — package-manager port (`tcl-pkg`) (landed 2026-06-21)
+
+Full port of `tooling/tclpkg/` to a new `tcl-pkg` library crate, with the
+`pkg`/`venv`/`docker` CLI stubs in `tcl-cli` wired through to native handlers.
+The track closed in `rust-rewrite.md` (now a ✅ row). What landed:
+
+- **`version`** — semver 2.0 ordering with the Tcl-friendly lax rules (missing
+  patch ⇒ 0, leading `v`, Tcl `a1`/`b2`/`rc1` ⇒ `-alpha.1`/`-beta.2`/`-rc.1`).
+  The comparison key reproduces the Python `_compare_key` tuple — numeric-before-
+  alpha prerelease pieces and a release sentinel sorting after any prerelease —
+  via a `PreItem` enum with a hand-written `Ord`. `Eq`/`Hash` delegate to the
+  same key so `v1.2`, `1.2.0`, `1.2` dedup in a set.
+- **`manifest`** — the 13-directive whitelist evaluated *without* a VM. Manifests
+  are pure data, so a small Tcl script splitter (brace/quote/backslash grouping,
+  `#` comments, `;`/newline command separators, no `$`/`[` substitution) yields
+  commands+words; any non-whitelisted command is refused with the exact
+  `command not permitted in safe mode: <cmd>` message. Backslash decoding reuses
+  `tcl-syntax::backslash::decode` for byte-exact quoted/bare words.
+- **`lockfile`** — canonical JSON (sorted keys recursively, 2-space indent, LF,
+  final newline) emitted by a dedicated `json::canonical_json` so output is
+  byte-identical regardless of `serde_json`'s workspace-unified `preserve_order`
+  feature. Verified: `pkg install` lockfiles diff byte-for-byte against the
+  Python CLI (modulo the `generated` timestamp).
+- **`cas`** — worktree-canonical SHA-256 (sorted POSIX paths, stripped VCS dirs +
+  `.tclpkgignore`, permission-masked with execute normalised), `sha256-<b64url>`
+  integrity strings, sharded immutable store, and symlink-or-copy materialise.
+- **`resolver`** — Go-style MVS (max-of-minimums BFS + convergence re-walk),
+  root-only `replace`/`exclude`, three-phase port of the Python routine.
+- **`fetchers`** — gzip-tarball / zip / git / path over `ureq`, hardened against
+  zip-slip, absolute paths, symlinks, and decompression bombs (256 MiB cap).
+- **`registry`** — TTL-cached client with conditional GET (`If-None-Match` /
+  `304`) over `ureq`, offline-from-cache, stale-cache fallback.
+- **`venv`** + **`docker`** — venv create/info/list/activate/update/run +
+  delete; Dockerfile recipes for debian/alpine/redhat × Tcl 8.4–9.0. The
+  generated `tclvenv.cfg`, `bin/tclsh` wrapper, bash/fish activation scripts,
+  and Dockerfiles diff byte-for-byte against the Python output.
+- **CLI** — `tcl pkg` (16 verbs), `tcl venv` (8), `tcl docker` (3) wired in
+  `tcl-cli`; argument surface modelled with `clap` derive and **native
+  clap-style help** (we don't reproduce argparse's epilog/example block). Errors
+  print `error: <msg>` to stderr and exit 1, matching the Python verb paths.
+- **Tests** — 61 `tcl-pkg` unit tests (mirroring the Python `tests/tclpkg/`
+  cases) + 5 `tcl-cli` integration tests over the built binary. `cargo clippy
+  -p tcl-pkg -p tcl-cli --all-targets` is warning-clean.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -875,7 +875,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
 | Refactoring transforms | `tcl-lsp-core::code_actions` | 🟡 | 5 of 7 transforms missing → **TOOL-REFACTOR** |
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**); `ssa`-view bool-render parity → **TOOL-EXPLORER** |
-| Package manager (`tclpkg`) | new crate | 🔴 | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) → **TOOL-TCLPKG** |
+| Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | new crate | 🟡 | campaign runner/generator/findings (corpus diff exists) → **TOOL-FUZZ** |
 | Debugger (DAP) | new crate | 🔴 | full debugger over `tcl-vm` → **TOOL-DEBUGGER** |
 | iRule test framework | new crate | 🔴 | TMM-sim harness (topology/profile-gen/orchestrator) → **TOOL-IRULE-TEST** |
@@ -897,7 +897,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | RT | **RT-VM** | `tcl-vm` | `tcl-bytecode` | L |
 | SRV | **SRV-LSP** ✅ | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | FE-DIAG, FE-DATAFLOW | L |
 | SRV | **SRV-ROPE** | document store: `tcl-lsp-server` `DocumentState` + `tcl-lexer` rope-slice `SourceMap` + `tcl-lsp-db` chunk input | FE-LEX (CST/structural-state index), SRV-LSP | XL |
-| TOOL | **TOOL-TCLPKG** | new `tcl-pkg` crate | — | XL |
+| TOOL | **TOOL-TCLPKG** ✅ | `tcl-pkg` crate | — | XL |
 | TOOL | **TOOL-REFACTOR** | `tcl-lsp-core::code_actions` | SRV-LSP | M |
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
@@ -1122,10 +1122,16 @@ These own distinct crates and parallelise; the ones marked *depends* are gated
 on a library track above. This is the layer that, per the `tcl`/`f5` pattern
 already started, brings **every** Python tool across to Rust.
 
-- **TOOL-TCLPKG** *(new `tcl-pkg` crate; independent — start anytime)* — **open**:
-  full package-manager port (manifest, MVS resolver, lockfile, CAS, fetchers,
-  venv, docker), then wire the existing `pkg`/`venv`/`docker` CLI stubs in
-  `tcl-cli`. *(XL)*
+- **TOOL-TCLPKG** *(new `tcl-pkg` crate; independent)* — **done**: full
+  package-manager port — `version` (semver + Tcl-friendly ordering), `manifest`
+  (whitelisted-directive parser with safe-mode refusal, no VM), `lockfile`
+  (canonical JSON, byte-identical with Python), MVS `resolver`, `cas`
+  (worktree-canonical SHA-256 + store/materialise), `fetchers` (gzip-tarball /
+  zip / git / path over `ureq`), `registry` (TTL cache + conditional GET),
+  `venv`, `docker`, plus `ui`. The `pkg`/`venv`/`docker` CLI stubs in `tcl-cli`
+  are wired through to native handlers; help is native clap style. Lockfiles,
+  Dockerfiles, and venv scripts diff byte-for-byte against the Python CLI.
+  *(XL)*
 - **TOOL-REFACTOR** *(owns `tcl-lsp-core::code_actions`)* — **open**: port the 5
   missing transforms (extract/inline variable, if↔switch, switch→dict,
   extract-datagroup); 2 of 7 (extract/inline proc) exist. *(M)*

--- a/rust/tcl-cli/Cargo.toml
+++ b/rust/tcl-cli/Cargo.toml
@@ -22,6 +22,7 @@ tcl-compiler = { path = "../tcl-compiler" }
 tcl-explorer = { path = "../tcl-explorer" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
+tcl-pkg = { path = "../tcl-pkg" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 # Bundled SQLite (with FTS5) for the `help` verb's embedded KCS database.

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -452,68 +452,307 @@ pub struct DiagArgs {
     pub enable: Vec<String>,
 }
 
+/// Flags shared by most `pkg` sub-actions (`_common` in `verbs/pkg.py`).
+#[derive(Debug, Args)]
+pub struct PkgCommon {
+    /// Emit JSON output.
+    #[arg(long)]
+    pub json: bool,
+    /// Override tclpkg.tcl location.
+    #[arg(long, value_name = "PATH")]
+    pub manifest: Option<PathBuf>,
+    /// Never touch the network.
+    #[arg(long)]
+    pub offline: bool,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum PkgCommand {
     /// Create a new tclpkg.tcl manifest.
-    Init,
+    // `--version` here is the manifest's initial version, not the CLI version,
+    // so suppress clap's auto-generated propagated `--version` flag.
+    #[command(disable_version_flag = true)]
+    Init {
+        /// Package name (default: directory name).
+        #[arg(long)]
+        name: Option<String>,
+        /// Initial version.
+        #[arg(long = "version")]
+        init_version: Option<String>,
+        /// SPDX licence identifier.
+        #[arg(long = "license")]
+        init_license: Option<String>,
+        /// Tcl version constraint (default: >=8.6).
+        #[arg(long)]
+        tcl: Option<String>,
+        /// Overwrite existing manifest.
+        #[arg(long)]
+        force: bool,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Resolve + fetch + materialise packages.
-    Install,
+    Install {
+        #[command(flatten)]
+        common: PkgCommon,
+        /// Skip dev-require packages.
+        #[arg(long = "no-dev")]
+        no_dev: bool,
+        /// Refuse to change lockfile.
+        #[arg(long)]
+        frozen: bool,
+    },
     /// List installed packages.
-    List,
+    List {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Show the dependency tree.
-    Tree,
+    Tree {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Verify integrity hashes.
-    Verify,
+    Verify {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Show details for a package.
-    Info,
+    Info {
+        /// Package name.
+        package: String,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Add a dependency to the manifest.
-    Add,
+    Add {
+        /// Package name.
+        package: String,
+        /// Minimum version (default: 0.0.1).
+        min_version: Option<String>,
+        /// Explicit source URL.
+        #[arg(long)]
+        source: Option<String>,
+        /// Add as dev-require.
+        #[arg(long)]
+        dev: bool,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Remove a dependency from the manifest.
-    Remove,
+    Remove {
+        /// Package name to remove.
+        package: String,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Bump dependency minimums.
-    Update,
+    Update {
+        /// Packages to update (default: all).
+        packages: Vec<String>,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Lock-driven install (alias for install --frozen).
-    Sync,
+    Sync {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Show packages with newer versions available.
-    Outdated,
+    Outdated {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Explain why a package is in the dependency graph.
-    Why,
+    Why {
+        /// Package name.
+        package: String,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Copy packages from cache into the project tree.
-    Vendor,
+    Vendor {
+        /// Vendor directory.
+        #[arg(long, default_value = "vendor")]
+        dir: PathBuf,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Run the manifest entry point via tclsh.
-    Run,
+    Run {
+        /// Extra arguments passed to tclsh.
+        extra: Vec<String>,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Output locked versions as manifest directives.
-    Freeze,
+    Freeze {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Search the package registry.
-    Search,
+    Search {
+        /// Search query.
+        query: String,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+        /// Use cached registry only.
+        #[arg(long)]
+        offline: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum VenvCommand {
     /// Create a new virtual environment.
-    Create,
+    Create {
+        /// Venv directory.
+        #[arg(default_value = ".venv")]
+        path: PathBuf,
+        /// Pin a specific Tcl version (e.g. 8.6, 9.0).
+        #[arg(long)]
+        tcl: Option<String>,
+        /// Allow fallback to host `auto_path`.
+        #[arg(long = "system-site-packages")]
+        system_site_packages: bool,
+        /// Custom shell prompt label.
+        #[arg(long)]
+        prompt: Option<String>,
+        /// Overwrite existing directory.
+        #[arg(long)]
+        force: bool,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Remove a virtual environment.
-    Delete,
+    Delete {
+        /// Venv directory.
+        #[arg(default_value = ".venv")]
+        path: PathBuf,
+        /// Force deletion even if active.
+        #[arg(long)]
+        force: bool,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Show virtual environment details.
-    Info,
+    Info {
+        /// Venv directory.
+        #[arg(default_value = ".venv")]
+        path: PathBuf,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Print activation script to stdout.
-    Activate,
+    Activate {
+        /// Venv directory.
+        #[arg(default_value = ".venv")]
+        path: PathBuf,
+        /// Shell flavour (default: auto-detect).
+        #[arg(long, value_parser = ["bash", "zsh", "fish", "csh", "powershell"])]
+        shell: Option<String>,
+    },
     /// Print deactivation script to stdout.
-    Deactivate,
+    Deactivate {
+        /// Shell flavour (default: auto-detect).
+        #[arg(long, value_parser = ["bash", "zsh", "fish", "csh", "powershell"])]
+        shell: Option<String>,
+    },
     /// List discoverable virtual environments.
-    List,
+    List {
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Re-link a venv to a newer tclsh.
-    Update,
+    Update {
+        /// Venv directory.
+        #[arg(default_value = ".venv")]
+        path: PathBuf,
+        /// New Tcl version to pin.
+        #[arg(long, required = true)]
+        tcl: String,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Run a command inside a venv.
-    Run,
+    Run {
+        /// Venv directory.
+        #[arg(default_value = ".venv")]
+        path: PathBuf,
+        /// Command to run (after --).
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum DockerCommand {
     /// Generate a Dockerfile for a Tcl project.
-    Create,
+    Create {
+        /// Base Docker image (e.g. debian:bookworm-slim, alpine:3.19).
+        image: String,
+        /// Tcl version to install.
+        #[arg(long = "tcl-version", default_value = "8.6", value_parser = ["8.4", "8.5", "8.6", "9.0"])]
+        tcl_version: String,
+        /// Output file path.
+        #[arg(long, short = 'o', default_value = "Dockerfile")]
+        output: PathBuf,
+        /// Container WORKDIR.
+        #[arg(long, default_value = "/app")]
+        workdir: String,
+        /// Tcl script to run as CMD (e.g. main.tcl).
+        #[arg(long)]
+        entrypoint: Option<String>,
+        /// Create a Tcl virtual environment inside the container.
+        #[arg(long)]
+        venv: bool,
+        /// Skip COPY . . (useful for multi-stage builds).
+        #[arg(long = "no-copy")]
+        no_copy: bool,
+        /// Skip tclpkg sync step.
+        #[arg(long = "no-packages")]
+        no_packages: bool,
+        /// Additional OS package to install (repeatable).
+        #[arg(long = "extra-package")]
+        extra_package: Vec<String>,
+        /// Docker LABEL as key=value (repeatable).
+        #[arg(long)]
+        label: Vec<String>,
+        /// Docker ENV as key=value (repeatable).
+        #[arg(long)]
+        env: Vec<String>,
+        /// tcl CLI zipapp version to download (default: latest known).
+        #[arg(long = "cli-version")]
+        cli_version: Option<String>,
+        /// Overwrite existing Dockerfile.
+        #[arg(long)]
+        force: bool,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Show the Tcl install recipe for a base image.
-    Recipe,
+    Recipe {
+        /// Base Docker image (e.g. alpine:3.19, ubuntu:22.04).
+        image: String,
+        /// Tcl version.
+        #[arg(long = "tcl-version", default_value = "8.6", value_parser = ["8.4", "8.5", "8.6", "9.0"])]
+        tcl_version: String,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// List available base-image families and Tcl versions.
-    Info,
+    Info {
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }

--- a/rust/tcl-cli/src/commands/docker.rs
+++ b/rust/tcl-cli/src/commands/docker.rs
@@ -1,0 +1,181 @@
+//! `tcl docker` verb group — Dockerfile generation for Tcl projects.
+//!
+//! Port of `tooling/tcl/verbs/docker.py`. Thin wrappers over `tcl_pkg::docker`:
+//! parse CLI args, call the library, format output. Library errors print
+//! `error: <msg>` to stderr and return exit code 1, matching the Python verb.
+
+// Handlers return `anyhow::Result<u8>` for a uniform dispatch signature even
+// when a given verb cannot fail; the wrap is the interface contract.
+#![allow(clippy::unnecessary_wraps)]
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use tcl_pkg::docker::{
+    DockerfileSpec, SUPPORTED_TCL_VERSIONS, available_recipes, generate_dockerfile,
+    tcl_install_recipe, write_dockerfile,
+};
+use tcl_pkg::ui;
+
+use crate::cli::DockerCommand;
+
+/// Dispatch a `tcl docker` sub-action.
+pub fn run(action: &DockerCommand) -> anyhow::Result<u8> {
+    match action {
+        DockerCommand::Create { .. } => run_create(action),
+        DockerCommand::Recipe {
+            image,
+            tcl_version,
+            json,
+        } => run_recipe(image, tcl_version, *json),
+        DockerCommand::Info { json } => run_info(*json),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_create(action: &DockerCommand) -> anyhow::Result<u8> {
+    let DockerCommand::Create {
+        image,
+        tcl_version,
+        output,
+        workdir,
+        entrypoint,
+        venv,
+        no_copy,
+        no_packages,
+        extra_package,
+        label,
+        env,
+        cli_version,
+        force,
+        json,
+    } = action
+    else {
+        unreachable!("run_create only called for Create");
+    };
+
+    let colour = ui::use_colour(Some(!*json));
+
+    let mut spec = DockerfileSpec {
+        base_image: image.clone(),
+        tcl_version: tcl_version.clone(),
+        workdir: workdir.clone(),
+        copy_project: !*no_copy,
+        install_packages: !*no_packages,
+        create_venv: *venv,
+        entrypoint: entrypoint.clone(),
+        cli_version: cli_version.clone(),
+        extra_packages: extra_package.clone(),
+        ..Default::default()
+    };
+
+    let mut labels = BTreeMap::new();
+    for item in label {
+        let Some((key, value)) = item.split_once('=') else {
+            eprintln!("error: --label must be key=value, got: {item}");
+            return Ok(1);
+        };
+        labels.insert(key.to_string(), value.to_string());
+    }
+    spec.labels = labels;
+
+    let mut envs = BTreeMap::new();
+    for item in env {
+        let Some((key, value)) = item.split_once('=') else {
+            eprintln!("error: --env must be key=value, got: {item}");
+            return Ok(1);
+        };
+        envs.insert(key.to_string(), value.to_string());
+    }
+    spec.env = envs;
+
+    let written = match write_dockerfile(output, &spec, *force) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+
+    if *json {
+        let content = match generate_dockerfile(&spec) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return Ok(1);
+            }
+        };
+        println!(
+            "{}",
+            ui::json_output(&json!({
+                "path": written.to_string_lossy(),
+                "base_image": spec.base_image,
+                "tcl_version": spec.tcl_version,
+                "content": content,
+            }))
+        );
+    } else {
+        println!(
+            "{}",
+            ui::ok(&format!("wrote {}", written.display()), colour)
+        );
+        println!(
+            "{}",
+            ui::dim(
+                &format!("  base: {}  tcl: {}", spec.base_image, spec.tcl_version),
+                colour
+            )
+        );
+        println!("{}", ui::dim("  docker build -t myapp .", colour));
+    }
+    Ok(0)
+}
+
+fn run_recipe(image: &str, tcl_version: &str, json: bool) -> anyhow::Result<u8> {
+    let recipe = match tcl_install_recipe(image, tcl_version) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if json {
+        println!(
+            "{}",
+            ui::json_output(&json!({
+                "image": image,
+                "tcl_version": tcl_version,
+                "recipe": recipe,
+            }))
+        );
+    } else {
+        println!("{recipe}");
+    }
+    Ok(0)
+}
+
+fn run_info(json: bool) -> anyhow::Result<u8> {
+    let recipes = available_recipes();
+    if json {
+        let families: BTreeMap<String, Vec<String>> = recipes.clone();
+        println!(
+            "{}",
+            ui::json_output(&json!({
+                "supported_tcl_versions": SUPPORTED_TCL_VERSIONS.to_vec(),
+                "families": families,
+            }))
+        );
+    } else {
+        let colour = ui::use_colour(None);
+        println!("{}", ui::bold("Supported Tcl versions:", colour));
+        for v in SUPPORTED_TCL_VERSIONS {
+            println!("  {v}");
+        }
+        println!();
+        println!("{}", ui::bold("Install recipe families:", colour));
+        for (family, versions) in &recipes {
+            println!("  {family:12}  {}", versions.join(", "));
+        }
+    }
+    Ok(0)
+}

--- a/rust/tcl-cli/src/commands/mod.rs
+++ b/rust/tcl-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@
 pub mod diag;
 pub mod diagram;
 pub mod diff;
+pub mod docker;
 pub mod explore;
 pub mod graphs;
 pub mod help;
@@ -14,5 +15,7 @@ pub mod highlight;
 pub mod lookup;
 pub mod minimize;
 pub mod misc;
+pub mod pkg;
 pub mod registry;
 pub mod transform;
+pub mod venv;

--- a/rust/tcl-cli/src/commands/pkg.rs
+++ b/rust/tcl-cli/src/commands/pkg.rs
@@ -1,0 +1,931 @@
+//! `tcl pkg` verb group — Tcl package management.
+//!
+//! Port of `tooling/tcl/verbs/pkg.py`. Thin wrappers over the `tcl_pkg`
+//! modules: parse args, drive the library, format output. Handler-level errors
+//! print `error: <msg>` to stderr and return exit code 1, matching the Python
+//! verb's `except Exception` paths.
+
+// Handlers return `anyhow::Result<u8>` for a uniform dispatch signature even
+// when a given verb cannot fail; the wrap is the interface contract.
+#![allow(clippy::unnecessary_wraps)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{Map, Value, json};
+use tcl_pkg::cas::ContentAddressableStore;
+use tcl_pkg::lockfile::{LockFile, LockedPackage, SourceSpec, read_lockfile, write_lockfile};
+use tcl_pkg::manifest::load_manifest;
+use tcl_pkg::registry::RegistryClient;
+use tcl_pkg::resolver::{ExcludeSpec, PackageRef, ReplaceSpec, ResolveInput, resolve};
+use tcl_pkg::ui;
+
+use crate::cli::{PkgCommand, PkgCommon};
+
+/// Dispatch a `tcl pkg` sub-action.
+pub fn run(action: &PkgCommand) -> anyhow::Result<u8> {
+    match action {
+        PkgCommand::Init {
+            name,
+            init_version,
+            init_license,
+            tcl,
+            force,
+            json,
+        } => run_init(
+            name.as_deref(),
+            init_version.as_deref(),
+            init_license.as_deref(),
+            tcl.as_deref(),
+            *force,
+            *json,
+        ),
+        PkgCommand::Install {
+            common,
+            no_dev,
+            frozen,
+        } => run_install(common, *no_dev, *frozen),
+        PkgCommand::List { common } => run_list(common),
+        PkgCommand::Tree { common } => run_tree(common),
+        PkgCommand::Verify { common } => run_verify(common),
+        PkgCommand::Info { package, common } => run_info(package, common),
+        PkgCommand::Add {
+            package,
+            min_version,
+            source,
+            dev,
+            common,
+        } => run_add(
+            package,
+            min_version.as_deref(),
+            source.as_deref(),
+            *dev,
+            common,
+        ),
+        PkgCommand::Remove { package, common } => run_remove(package, common),
+        PkgCommand::Update { packages, common } => run_update(packages, common),
+        PkgCommand::Sync { common } => run_sync(common),
+        PkgCommand::Outdated { common } => run_outdated(common),
+        PkgCommand::Why { package, common } => run_why(package, common),
+        PkgCommand::Vendor { dir, common } => run_vendor(dir, common),
+        PkgCommand::Run { extra, common } => run_run(extra, common),
+        PkgCommand::Freeze { common } => run_freeze(common),
+        PkgCommand::Search {
+            query,
+            json,
+            offline,
+        } => run_search(query, *json, *offline),
+    }
+}
+
+fn find_project_root() -> Option<PathBuf> {
+    let mut current = std::env::current_dir().ok()?.canonicalize().ok()?;
+    for _ in 0..20 {
+        if current.join("tclpkg.tcl").is_file() {
+            return Some(current);
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    None
+}
+
+fn manifest_path(common: &PkgCommon) -> PathBuf {
+    if let Some(override_path) = &common.manifest {
+        return override_path.clone();
+    }
+    if let Some(root) = find_project_root() {
+        return root.join("tclpkg.tcl");
+    }
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("tclpkg.tcl")
+}
+
+fn lockfile_path(common: &PkgCommon) -> PathBuf {
+    let mpath = manifest_path(common);
+    mpath
+        .parent()
+        .map_or_else(|| PathBuf::from("tclpkg.lock"), |p| p.join("tclpkg.lock"))
+}
+
+fn run_init(
+    name: Option<&str>,
+    init_version: Option<&str>,
+    init_license: Option<&str>,
+    tcl: Option<&str>,
+    force: bool,
+    json: bool,
+) -> anyhow::Result<u8> {
+    let path = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("tclpkg.tcl");
+    if path.exists() && !force {
+        eprintln!(
+            "error: {} already exists (use --force to overwrite)",
+            path.display()
+        );
+        return Ok(1);
+    }
+    let dir_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map_or_else(String::new, |n| n.to_string_lossy().into_owned());
+    let name = name.map_or(dir_name, ToString::to_string);
+    let version = init_version.unwrap_or("0.1.0");
+    let license = init_license.unwrap_or("MIT");
+    let tcl = tcl.unwrap_or(">=8.6");
+
+    let body = format!(
+        "package     {name}\nversion     {version}\nlicense     {license}\ntcl         {tcl}\n"
+    );
+    if let Err(e) = std::fs::write(&path, body) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+
+    let colour = ui::use_colour(Some(!json));
+    if json {
+        println!(
+            "{}",
+            ui::json_output(
+                &json!({"path": path.to_string_lossy(), "name": name, "version": version})
+            )
+        );
+    } else {
+        println!("{}", ui::ok(&format!("wrote {}", path.display()), colour));
+    }
+    Ok(0)
+}
+
+#[allow(clippy::too_many_lines)] // direct port of the Python `_run_install`
+fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result<u8> {
+    let mpath = manifest_path(common);
+    let colour = ui::use_colour(Some(!common.json));
+
+    let manifest = match load_manifest(&mpath) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+
+    let direct: Vec<PackageRef> = manifest
+        .requires
+        .iter()
+        .map(|r| PackageRef::new(r.name.clone(), r.minimum.clone()))
+        .collect();
+    let dev_direct: Vec<PackageRef> = manifest
+        .dev_requires
+        .iter()
+        .map(|r| PackageRef::new(r.name.clone(), r.minimum.clone()))
+        .collect();
+    let replaces: Vec<ReplaceSpec> = manifest
+        .replaces
+        .iter()
+        .map(|r| ReplaceSpec {
+            name: r.name.clone(),
+            version: r.version.clone(),
+        })
+        .collect();
+    let excludes: Vec<ExcludeSpec> = manifest
+        .excludes
+        .iter()
+        .map(|e| ExcludeSpec {
+            name: e.name.clone(),
+            version: e.version.clone(),
+        })
+        .collect();
+
+    let input = ResolveInput {
+        direct,
+        dev_direct,
+        replaces,
+        excludes,
+        provider: None,
+        include_dev: !no_dev,
+    };
+    let resolved = match resolve(&input) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+
+    let mut lf = LockFile::new(manifest.name.clone(), manifest.tcl_constraint.clone());
+    lf.stamp();
+    for rp in &resolved {
+        lf.packages.push(LockedPackage {
+            name: rp.reference.name.clone(),
+            version: rp.reference.version.to_string(),
+            source: SourceSpec::new("tarball", ""),
+            integrity: String::new(),
+            size: 0,
+            requires: rp.requires.iter().map(ToString::to_string).collect(),
+            provides: Vec::new(),
+            license: String::new(),
+            dev: rp.dev,
+        });
+    }
+
+    let lockpath = mpath
+        .parent()
+        .map_or_else(|| PathBuf::from("tclpkg.lock"), |p| p.join("tclpkg.lock"));
+
+    if frozen {
+        if !lockpath.is_file() {
+            eprintln!("error: --frozen requires an existing tclpkg.lock");
+            return Ok(1);
+        }
+        let existing = match read_lockfile(&lockpath) {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return Ok(1);
+            }
+        };
+        let mut old: Vec<(String, String)> = existing
+            .packages
+            .iter()
+            .map(|p| (p.name.clone(), p.version.clone()))
+            .collect();
+        let mut new: Vec<(String, String)> = lf
+            .packages
+            .iter()
+            .map(|p| (p.name.clone(), p.version.clone()))
+            .collect();
+        old.sort();
+        new.sort();
+        if old != new {
+            eprintln!(
+                "error: lockfile would change but --frozen is set; update the manifest and re-run without --frozen"
+            );
+            return Ok(1);
+        }
+        if common.json {
+            println!(
+                "{}",
+                ui::json_output(&json!({"packages": lf.packages.len(), "frozen": true}))
+            );
+        } else {
+            println!(
+                "{}",
+                ui::ok(
+                    &format!("lockfile is up to date ({} packages)", lf.packages.len()),
+                    colour
+                )
+            );
+        }
+        return Ok(0);
+    }
+
+    if let Err(e) = write_lockfile(&lf, &lockpath) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+
+    if common.json {
+        println!(
+            "{}",
+            ui::json_output(
+                &json!({"packages": lf.packages.len(), "lockfile": lockpath.to_string_lossy()})
+            )
+        );
+    } else {
+        for pkg in &lf.packages {
+            let dev_tag = if pkg.dev { " (dev)" } else { "" };
+            println!(
+                "{}",
+                ui::ok(
+                    &format!("{:<20} {}{}", pkg.name, pkg.version, dev_tag),
+                    colour
+                )
+            );
+        }
+        println!(
+            "{}",
+            ui::ok(&format!("wrote {}", lockpath.display()), colour)
+        );
+    }
+    Ok(0)
+}
+
+fn read_lock_or_report(common: &PkgCommon) -> Result<LockFile, u8> {
+    match read_lockfile(lockfile_path(common)) {
+        Ok(l) => Ok(l),
+        Err(e) => {
+            eprintln!("error: {e}");
+            Err(1)
+        }
+    }
+}
+
+fn run_list(common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    if common.json {
+        let pkgs: Vec<Value> = lf.packages.iter().map(locked_to_json).collect();
+        println!("{}", ui::json_output(&json!({"packages": pkgs})));
+    } else {
+        println!(
+            "{:<20} {:<12} {:<8} {:<8}",
+            "NAME", "VERSION", "KIND", "DEV"
+        );
+        let mut pkgs: Vec<&LockedPackage> = lf.packages.iter().collect();
+        pkgs.sort_by(|a, b| a.name.cmp(&b.name));
+        for pkg in pkgs {
+            let kind = if pkg.requires.is_empty() {
+                "direct"
+            } else {
+                "trans"
+            };
+            let dev = if pkg.dev { "dev" } else { "" };
+            println!(
+                "{:<20} {:<12} {:<8} {:<8}",
+                pkg.name, pkg.version, kind, dev
+            );
+        }
+    }
+    Ok(0)
+}
+
+fn run_tree(common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    if common.json {
+        let pkgs: Vec<Value> = lf.packages.iter().map(locked_to_json).collect();
+        println!(
+            "{}",
+            ui::json_output(&json!({"name": lf.name, "packages": pkgs}))
+        );
+    } else {
+        println!("{}", lf.name);
+        let mut pkgs: Vec<&LockedPackage> = lf.packages.iter().collect();
+        pkgs.sort_by(|a, b| a.name.cmp(&b.name));
+        let total = pkgs.len();
+        for (i, pkg) in pkgs.iter().enumerate() {
+            let connector = if i == total - 1 {
+                "└── "
+            } else {
+                "├── "
+            };
+            let dev_tag = if pkg.dev { " [dev]" } else { "" };
+            println!("{connector}{} {}{dev_tag}", pkg.name, pkg.version);
+        }
+    }
+    Ok(0)
+}
+
+fn run_verify(common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    let colour = ui::use_colour(Some(!common.json));
+    let mut failures = 0;
+    for pkg in &lf.packages {
+        if pkg.integrity.is_empty() {
+            println!(
+                "{}",
+                ui::warn(
+                    &format!("{:<20} {:<12} no integrity hash", pkg.name, pkg.version),
+                    colour
+                )
+            );
+            failures += 1;
+        } else {
+            let trunc: String = pkg.integrity.chars().take(30).collect();
+            println!(
+                "{}",
+                ui::ok(
+                    &format!("{:<20} {:<12} {trunc}…", pkg.name, pkg.version),
+                    colour
+                )
+            );
+        }
+    }
+    if failures > 0 {
+        eprintln!(
+            "\n{failures} package(s) have no integrity hash — run 'tcl pkg install' to populate."
+        );
+        return Ok(1);
+    }
+    Ok(0)
+}
+
+fn run_info(package: &str, common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    let Some(entry) = lf.lookup(package) else {
+        eprintln!("error: package '{package}' not found in lockfile");
+        return Ok(1);
+    };
+    if common.json {
+        println!("{}", ui::json_output(&locked_to_json(entry)));
+    } else {
+        println!("Name:      {}", entry.name);
+        println!("Version:   {}", entry.version);
+        println!("Source:    {} {}", entry.source.kind, entry.source.url);
+        let integ = if entry.integrity.is_empty() {
+            "(not computed)"
+        } else {
+            &entry.integrity
+        };
+        println!("Integrity: {integ}");
+        let lic = if entry.license.is_empty() {
+            "(unknown)"
+        } else {
+            &entry.license
+        };
+        println!("Licence:   {lic}");
+        println!("Dev:       {}", if entry.dev { "yes" } else { "no" });
+        if !entry.requires.is_empty() {
+            println!("Requires:  {}", entry.requires.join(", "));
+        }
+        if !entry.provides.is_empty() {
+            println!("Provides:  {}", entry.provides.join(", "));
+        }
+    }
+    Ok(0)
+}
+
+fn run_add(
+    package: &str,
+    min_version: Option<&str>,
+    source: Option<&str>,
+    dev: bool,
+    common: &PkgCommon,
+) -> anyhow::Result<u8> {
+    let mpath = manifest_path(common);
+    let colour = ui::use_colour(Some(!common.json));
+    if let Err(e) = load_manifest(&mpath) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+    let min_ver = min_version.unwrap_or("0.0.1");
+    let directive = if dev { "dev-require" } else { "require" };
+    let mut new_line = format!("{directive} {package} {min_ver}");
+    if let Some(url) = source {
+        new_line.push_str(" -source ");
+        new_line.push_str(url);
+    }
+    let text = match std::fs::read_to_string(&mpath) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    let new_text = format!("{}\n{new_line}\n", text.trim_end_matches('\n'));
+    if let Err(e) = std::fs::write(&mpath, new_text) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+    if common.json {
+        println!(
+            "{}",
+            ui::json_output(&json!({"added": package, "version": min_ver, "dev": dev}))
+        );
+    } else {
+        println!(
+            "{}",
+            ui::ok(
+                &format!("added {package} {min_ver} to {}", mpath.display()),
+                colour
+            )
+        );
+        println!(
+            "{}",
+            ui::dim("  run 'tcl pkg install' to resolve and lock", colour)
+        );
+    }
+    Ok(0)
+}
+
+fn run_remove(package: &str, common: &PkgCommon) -> anyhow::Result<u8> {
+    let mpath = manifest_path(common);
+    let colour = ui::use_colour(Some(!common.json));
+    if !mpath.is_file() {
+        eprintln!("error: manifest not found: {}", mpath.display());
+        return Ok(1);
+    }
+    let text = match std::fs::read_to_string(&mpath) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    let mut count = 0;
+    let mut kept: Vec<String> = Vec::new();
+    for line in text.split_inclusive('\n') {
+        if line_is_requirement_for(line, package) {
+            count += 1;
+        } else {
+            kept.push(line.to_string());
+        }
+    }
+    if count == 0 {
+        eprintln!("error: package '{package}' not found in manifest");
+        return Ok(1);
+    }
+    if let Err(e) = std::fs::write(&mpath, kept.concat()) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+    if common.json {
+        println!(
+            "{}",
+            ui::json_output(&json!({"removed": package, "directives_removed": count}))
+        );
+    } else {
+        println!(
+            "{}",
+            ui::ok(
+                &format!("removed {package} from {}", mpath.display()),
+                colour
+            )
+        );
+        println!(
+            "{}",
+            ui::dim("  run 'tcl pkg install' to update the lockfile", colour)
+        );
+    }
+    Ok(0)
+}
+
+/// Whether `line` is a `require`/`dev-require` directive for `package`
+/// (mirrors the Python regex `^\s*(?:require|dev-require)\s+<pkg>\b.*$`).
+fn line_is_requirement_for(line: &str, package: &str) -> bool {
+    let trimmed = line.trim_start();
+    for prefix in ["require", "dev-require"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let mut chars = rest.chars();
+            if let Some(c) = chars.next()
+                && c.is_whitespace()
+            {
+                let after = rest.trim_start();
+                if let Some(tail) = after.strip_prefix(package) {
+                    // Require a word boundary after the package name.
+                    if tail.chars().next().is_none_or(|c| !is_word_char(c)) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+fn run_update(packages: &[String], common: &PkgCommon) -> anyhow::Result<u8> {
+    let mpath = manifest_path(common);
+    let colour = ui::use_colour(Some(!common.json));
+    let manifest = match load_manifest(&mpath) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    let mut all_names: Vec<String> = Vec::new();
+    for r in manifest.requires.iter().chain(manifest.dev_requires.iter()) {
+        all_names.push(r.name.clone());
+    }
+    let targets: Vec<String> = if packages.is_empty() {
+        all_names.clone()
+    } else {
+        packages.to_vec()
+    };
+    let mut updated: Vec<String> = Vec::new();
+    for name in &targets {
+        if all_names.iter().any(|n| n == name) {
+            updated.push(name.clone());
+        } else {
+            eprintln!("  skip: {name} not in manifest");
+        }
+    }
+    if common.json {
+        println!("{}", ui::json_output(&json!({"updated": updated})));
+    } else if updated.is_empty() {
+        println!("  nothing to update");
+    } else {
+        for name in &updated {
+            println!(
+                "{}",
+                ui::ok(
+                    &format!("{name} (already at minimum — registry query not yet wired)"),
+                    colour
+                )
+            );
+        }
+        println!(
+            "{}",
+            ui::dim("  run 'tcl pkg install' to re-resolve", colour)
+        );
+    }
+    Ok(0)
+}
+
+fn run_sync(common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    let colour = ui::use_colour(Some(!common.json));
+    let lockpath = lockfile_path(common);
+    if common.json {
+        println!(
+            "{}",
+            ui::json_output(
+                &json!({"packages": lf.packages.len(), "lockfile": lockpath.to_string_lossy()})
+            )
+        );
+    } else {
+        let mut pkgs: Vec<&LockedPackage> = lf.packages.iter().collect();
+        pkgs.sort_by(|a, b| a.name.cmp(&b.name));
+        for pkg in &pkgs {
+            println!(
+                "{}",
+                ui::ok(&format!("{:<20} {}", pkg.name, pkg.version), colour)
+            );
+        }
+        println!(
+            "{}",
+            ui::ok(
+                &format!(
+                    "synced from {} ({} packages)",
+                    lockpath.display(),
+                    lf.packages.len()
+                ),
+                colour
+            )
+        );
+    }
+    Ok(0)
+}
+
+fn run_outdated(common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    if common.json {
+        println!("{}", ui::json_output(&json!({"outdated": []})));
+    } else {
+        println!("{:<20} {:<12} {:<12}", "NAME", "CURRENT", "LATEST");
+        let mut pkgs: Vec<&LockedPackage> = lf.packages.iter().collect();
+        pkgs.sort_by(|a, b| a.name.cmp(&b.name));
+        for pkg in &pkgs {
+            println!("{:<20} {:<12} {:<12}", pkg.name, pkg.version, pkg.version);
+        }
+        println!(
+            "{}",
+            ui::dim(
+                "\n  (registry version lookup not yet wired)",
+                ui::use_colour(None)
+            )
+        );
+    }
+    Ok(0)
+}
+
+fn run_why(package: &str, common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    let Some(entry) = lf.lookup(package) else {
+        eprintln!("error: package '{package}' not found in lockfile");
+        return Ok(1);
+    };
+    let dependents: Vec<&LockedPackage> = lf
+        .packages
+        .iter()
+        .filter(|other| other.requires.iter().any(|r| r.contains(package)))
+        .collect();
+    if common.json {
+        let names: Vec<String> = dependents.iter().map(|d| d.name.clone()).collect();
+        println!(
+            "{}",
+            ui::json_output(&json!({
+                "package": package,
+                "version": entry.version,
+                "required_by": names,
+                "dev": entry.dev,
+            }))
+        );
+    } else {
+        println!("{package} {}", entry.version);
+        if !dependents.is_empty() {
+            for dep in &dependents {
+                println!("└── required by {} {}", dep.name, dep.version);
+            }
+        } else if entry.dev {
+            println!("└── direct dev-require dependency");
+        } else {
+            println!("└── direct dependency");
+        }
+    }
+    Ok(0)
+}
+
+fn run_vendor(dir: &Path, common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    let colour = ui::use_colour(Some(!common.json));
+    let cas = ContentAddressableStore::new(&tcl_pkg::cache_dir());
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+    let mut vendored: Vec<String> = Vec::new();
+    for pkg in &lf.packages {
+        let dest = dir.join(format!("{}-{}", pkg.name, pkg.version));
+        if !pkg.integrity.is_empty() && cas.has(&pkg.integrity) {
+            if cas.materialise(&pkg.integrity, &dest, false).is_ok() {
+                vendored.push(pkg.name.clone());
+            }
+        } else if pkg.integrity.is_empty() {
+            println!(
+                "{}",
+                ui::warn(
+                    &format!("{} has no integrity hash — skipping", pkg.name),
+                    colour
+                )
+            );
+        }
+    }
+    if common.json {
+        println!(
+            "{}",
+            ui::json_output(&json!({"vendored": vendored, "dir": dir.to_string_lossy()}))
+        );
+    } else if vendored.is_empty() {
+        println!(
+            "{}",
+            ui::dim("  no packages with integrity hashes to vendor", colour)
+        );
+        println!(
+            "{}",
+            ui::dim(
+                "  run 'tcl pkg install' first to populate the cache",
+                colour
+            )
+        );
+    } else {
+        for name in &vendored {
+            println!("{}", ui::ok(&format!("vendored {name}"), colour));
+        }
+        println!(
+            "{}",
+            ui::ok(
+                &format!("wrote {} package(s) to {}/", vendored.len(), dir.display()),
+                colour
+            )
+        );
+    }
+    Ok(0)
+}
+
+fn run_run(extra: &[String], common: &PkgCommon) -> anyhow::Result<u8> {
+    let mpath = manifest_path(common);
+    let manifest = match load_manifest(&mpath) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if manifest.entry.is_empty() {
+        eprintln!("error: no 'entry' directive in manifest");
+        return Ok(1);
+    }
+    let parent = mpath.parent().unwrap_or_else(|| Path::new("."));
+    let entry_path = parent.join(&manifest.entry);
+    if !entry_path.is_file() {
+        eprintln!("error: entry file not found: {}", entry_path.display());
+        return Ok(1);
+    }
+
+    let tclsh = if let Some(venv) = std::env::var_os("TCL_VENV") {
+        PathBuf::from(venv).join("bin").join("tclsh")
+    } else if let Some(p) = tcl_pkg::venv::find_tclsh() {
+        p
+    } else {
+        eprintln!("error: tclsh not found on PATH");
+        return Ok(1);
+    };
+
+    let mut cmd = Command::new(&tclsh);
+    cmd.arg(&entry_path).args(extra);
+    let lib_dir = parent.join("lib");
+    if lib_dir.is_dir() {
+        let existing = std::env::var("TCLLIBPATH").unwrap_or_default();
+        let value = if existing.is_empty() {
+            lib_dir.to_string_lossy().into_owned()
+        } else {
+            format!("{} {existing}", lib_dir.display())
+        };
+        cmd.env("TCLLIBPATH", value);
+    }
+    match cmd.status() {
+        Ok(s) => Ok(u8::try_from(s.code().unwrap_or(1)).unwrap_or(1)),
+        Err(e) => {
+            eprintln!("error: {e}");
+            Ok(1)
+        }
+    }
+}
+
+fn run_freeze(common: &PkgCommon) -> anyhow::Result<u8> {
+    let lf = match read_lock_or_report(common) {
+        Ok(l) => l,
+        Err(code) => return Ok(code),
+    };
+    let mut pkgs: Vec<&LockedPackage> = lf.packages.iter().collect();
+    pkgs.sort_by(|a, b| a.name.cmp(&b.name));
+    if common.json {
+        let mut map = Map::new();
+        for pkg in &pkgs {
+            map.insert(pkg.name.clone(), Value::String(pkg.version.clone()));
+        }
+        println!("{}", ui::json_output(&Value::Object(map)));
+    } else {
+        for pkg in &pkgs {
+            let source_suffix = if pkg.source.url.is_empty() {
+                String::new()
+            } else {
+                format!(" -source {}", pkg.source.url)
+            };
+            let directive = if pkg.dev { "dev-require" } else { "require" };
+            println!("{directive} {} {}{source_suffix}", pkg.name, pkg.version);
+        }
+    }
+    Ok(0)
+}
+
+fn run_search(query: &str, json: bool, offline: bool) -> anyhow::Result<u8> {
+    let mut client = RegistryClient::new(&tcl_pkg::cache_dir(), offline);
+    let results = match client.search(query) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if json {
+        let arr: Vec<Value> = results
+            .iter()
+            .map(|e| json!({"name": e.name, "description": e.description}))
+            .collect();
+        println!("{}", ui::json_output(&Value::Array(arr)));
+    } else if results.is_empty() {
+        println!("No matches found.");
+    } else {
+        for entry in &results {
+            println!("  {:<20}  {}", entry.name, entry.description);
+        }
+    }
+    Ok(0)
+}
+
+/// Build the canonical JSON object for a locked package (`LockedPackage.to_dict`
+/// in Python). Keys are sorted by the canonical-JSON emitter.
+fn locked_to_json(pkg: &LockedPackage) -> Value {
+    let mut provides = pkg.provides.clone();
+    provides.sort();
+    let mut requires = pkg.requires.clone();
+    requires.sort();
+    json!({
+        "dev": pkg.dev,
+        "integrity": pkg.integrity,
+        "license": pkg.license,
+        "name": pkg.name,
+        "provides": provides,
+        "requires": requires,
+        "size": pkg.size,
+        "source": {
+            "type": pkg.source.kind,
+            "url": pkg.source.url,
+            "subdir": pkg.source.subdir,
+            "rev": pkg.source.rev,
+        },
+        "version": pkg.version,
+    })
+}

--- a/rust/tcl-cli/src/commands/pkg.rs
+++ b/rust/tcl-cli/src/commands/pkg.rs
@@ -9,11 +9,13 @@
 // when a given verb cannot fail; the wrap is the interface contract.
 #![allow(clippy::unnecessary_wraps)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde_json::{Map, Value, json};
 use tcl_pkg::cas::ContentAddressableStore;
+use tcl_pkg::installer;
 use tcl_pkg::lockfile::{LockFile, LockedPackage, SourceSpec, read_lockfile, write_lockfile};
 use tcl_pkg::manifest::load_manifest;
 use tcl_pkg::registry::RegistryClient;
@@ -109,6 +111,17 @@ fn lockfile_path(common: &PkgCommon) -> PathBuf {
     mpath
         .parent()
         .map_or_else(|| PathBuf::from("tclpkg.lock"), |p| p.join("tclpkg.lock"))
+}
+
+/// Where `install` materialises packages: the active venv's `lib/` if one is
+/// set, else `<project>/lib` next to the manifest.
+fn install_lib_dir(mpath: &Path) -> PathBuf {
+    if let Some(venv) = std::env::var_os("TCL_VENV") {
+        return PathBuf::from(venv).join("lib");
+    }
+    mpath
+        .parent()
+        .map_or_else(|| PathBuf::from("lib"), |p| p.join("lib"))
 }
 
 fn run_init(
@@ -216,12 +229,32 @@ fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result
         }
     };
 
+    // Source lookup tables for materialisation.
+    let mut manifest_sources: HashMap<String, String> = HashMap::new();
+    for r in manifest.requires.iter().chain(manifest.dev_requires.iter()) {
+        if let Some(url) = &r.source_url {
+            manifest_sources.insert(r.name.clone(), url.clone());
+        }
+    }
+    let mut replace_sources: HashMap<String, String> = HashMap::new();
+    for r in &manifest.replaces {
+        replace_sources.insert(r.name.clone(), r.source_url.clone());
+    }
+    // --frozen never touches the network or the tree.
+    let offline = frozen || common.offline;
+    let cache = tcl_pkg::cache_dir();
+    let cas = ContentAddressableStore::new(&cache);
+    let mut registry = RegistryClient::new(&cache, common.offline);
+    let lib_dir = install_lib_dir(&mpath);
+
     let mut lf = LockFile::new(manifest.name.clone(), manifest.tcl_constraint.clone());
     lf.stamp();
     for rp in &resolved {
-        lf.packages.push(LockedPackage {
-            name: rp.reference.name.clone(),
-            version: rp.reference.version.to_string(),
+        let name = rp.reference.name.clone();
+        let version = rp.reference.version.to_string();
+        let mut entry = LockedPackage {
+            name: name.clone(),
+            version: version.clone(),
             source: SourceSpec::new("tarball", ""),
             integrity: String::new(),
             size: 0,
@@ -229,7 +262,42 @@ fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result
             provides: Vec::new(),
             license: String::new(),
             dev: rp.dev,
-        });
+        };
+        if !offline {
+            let source = installer::resolve_source(
+                &name,
+                &version,
+                &replace_sources,
+                &manifest_sources,
+                Some(&mut registry),
+            );
+            if let Some(source) = source {
+                match installer::fetch_and_store(&source, &name, &version, &cas, 60) {
+                    Ok(result) => {
+                        if let Err(e) = installer::materialise(
+                            &cas,
+                            &result.integrity,
+                            &lib_dir,
+                            &name,
+                            &version,
+                            true,
+                        ) {
+                            println!("{}", ui::warn(&format!("{name} {version}: {e}"), colour));
+                        }
+                        entry.source = result.source;
+                        entry.integrity = result.integrity;
+                        entry.size = result.size;
+                        entry.provides = result.provides;
+                        entry.license = result.license;
+                    }
+                    Err(e) => {
+                        entry.source = source;
+                        println!("{}", ui::warn(&format!("{name} {version}: {e}"), colour));
+                    }
+                }
+            }
+        }
+        lf.packages.push(entry);
     }
 
     let lockpath = mpath

--- a/rust/tcl-cli/src/commands/venv.rs
+++ b/rust/tcl-cli/src/commands/venv.rs
@@ -1,0 +1,312 @@
+//! `tcl venv` verb group — virtual environment management.
+//!
+//! Port of `tooling/tcl/verbs/venv.py`. Thin wrappers over `tcl_pkg::venv`.
+//! Handler-level errors print `error: <msg>` to stderr and return exit code 1.
+
+// Handlers return `anyhow::Result<u8>` for a uniform dispatch signature even
+// when a given verb cannot fail; the wrap is the interface contract.
+#![allow(clippy::unnecessary_wraps)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{Value, json};
+use tcl_pkg::ui;
+use tcl_pkg::venv::{CreateOptions, create_venv, delete_venv, read_venv_config, update_venv};
+
+use crate::cli::VenvCommand;
+
+/// Dispatch a `tcl venv` sub-action.
+pub fn run(action: &VenvCommand) -> anyhow::Result<u8> {
+    match action {
+        VenvCommand::Create {
+            path,
+            tcl,
+            system_site_packages,
+            prompt,
+            force,
+            json,
+        } => run_create(
+            path,
+            tcl.as_deref(),
+            *system_site_packages,
+            prompt.as_deref(),
+            *force,
+            *json,
+        ),
+        VenvCommand::Delete { path, force, json } => run_delete(path, *force, *json),
+        VenvCommand::Info { path, json } => run_info(path, *json),
+        VenvCommand::Activate { path, shell } => run_activate(path, shell.as_deref()),
+        VenvCommand::Deactivate { shell } => run_deactivate(shell.as_deref()),
+        VenvCommand::List { json } => run_list(*json),
+        VenvCommand::Update { path, tcl, json } => run_update(path, tcl, *json),
+        VenvCommand::Run { path, command } => run_in_venv(path, command),
+    }
+}
+
+fn run_create(
+    path: &Path,
+    tcl: Option<&str>,
+    system_site_packages: bool,
+    prompt: Option<&str>,
+    force: bool,
+    json: bool,
+) -> anyhow::Result<u8> {
+    let colour = ui::use_colour(Some(!json));
+    if force && path.exists() {
+        let _ = std::fs::remove_dir_all(path);
+    }
+    let opts = CreateOptions {
+        tcl_version: tcl,
+        system_site_packages,
+        prompt,
+        project_root: None,
+    };
+    let created = match create_venv(path, &opts) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if json {
+        println!(
+            "{}",
+            ui::json_output(&json!({"path": created.to_string_lossy()}))
+        );
+    } else {
+        println!(
+            "{}",
+            ui::ok(&format!("created {}", created.display()), colour)
+        );
+        println!(
+            "{}",
+            ui::dim(
+                &format!("  activate: source {}/bin/activate", created.display()),
+                colour
+            )
+        );
+    }
+    Ok(0)
+}
+
+fn run_delete(path: &Path, _force: bool, json: bool) -> anyhow::Result<u8> {
+    let colour = ui::use_colour(Some(!json));
+    if let Err(e) = delete_venv(path) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+    if json {
+        println!(
+            "{}",
+            ui::json_output(&json!({"deleted": path.to_string_lossy()}))
+        );
+    } else {
+        println!("{}", ui::ok(&format!("deleted {}", path.display()), colour));
+    }
+    Ok(0)
+}
+
+fn run_info(path: &Path, json: bool) -> anyhow::Result<u8> {
+    let config = match read_venv_config(path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if json {
+        let mut map = serde_json::Map::new();
+        for (k, v) in &config {
+            map.insert(k.clone(), Value::String(v.clone()));
+        }
+        println!("{}", ui::json_output(&Value::Object(map)));
+    } else {
+        let mut sorted = config;
+        sorted.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, value) in &sorted {
+            println!("  {key:30}  {value}");
+        }
+    }
+    Ok(0)
+}
+
+fn run_activate(path: &Path, shell: Option<&str>) -> anyhow::Result<u8> {
+    let venv_path = absolutise(path);
+    let script_path = if shell == Some("fish") {
+        venv_path.join("bin").join("activate.fish")
+    } else {
+        venv_path.join("bin").join("activate")
+    };
+    if !script_path.is_file() {
+        eprintln!(
+            "error: activation script not found: {}",
+            script_path.display()
+        );
+        return Ok(1);
+    }
+    match std::fs::read_to_string(&script_path) {
+        Ok(text) => {
+            println!("{text}");
+            Ok(0)
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            Ok(1)
+        }
+    }
+}
+
+fn run_deactivate(_shell: Option<&str>) -> anyhow::Result<u8> {
+    println!("deactivate");
+    Ok(0)
+}
+
+fn run_list(json: bool) -> anyhow::Result<u8> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut candidates = vec![cwd.join(".venv"), cwd.join("venv")];
+    let home_pool = tcl_pkg::venv_pool_dir();
+    if home_pool.is_dir()
+        && let Ok(entries) = std::fs::read_dir(&home_pool)
+    {
+        let mut extra: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+        extra.sort();
+        candidates.extend(extra);
+    }
+
+    let active = std::env::var_os("TCL_VENV").map(PathBuf::from);
+    let mut found: Vec<(String, String, String, String)> = Vec::new();
+    for candidate in candidates {
+        if !candidate.join("tclvenv.cfg").is_file() {
+            continue;
+        }
+        let config = read_venv_config(&candidate).unwrap_or_default();
+        let get = |key: &str| -> Option<String> {
+            config
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.clone())
+        };
+        let is_active = active
+            .as_ref()
+            .is_some_and(|a| a.canonicalize().ok() == candidate.canonicalize().ok());
+        let prompt = get("prompt").unwrap_or_else(|| {
+            candidate
+                .file_name()
+                .map_or_else(String::new, |n| n.to_string_lossy().into_owned())
+        });
+        found.push((
+            candidate.to_string_lossy().into_owned(),
+            get("tcl_version").unwrap_or_else(|| "?".to_string()),
+            prompt,
+            if is_active {
+                "yes".to_string()
+            } else {
+                String::new()
+            },
+        ));
+    }
+
+    if json {
+        let arr: Vec<Value> = found
+            .iter()
+            .map(|(path, tcl, prompt, active)| {
+                json!({"path": path, "tcl_version": tcl, "prompt": prompt, "active": active})
+            })
+            .collect();
+        println!("{}", ui::json_output(&Value::Array(arr)));
+    } else if found.is_empty() {
+        println!("  No virtual environments found.");
+    } else {
+        println!(
+            "{:<30} {:<12} {:<10} {:<6}",
+            "PATH", "TCL", "PROMPT", "ACTIVE"
+        );
+        for (path, tcl, prompt, active) in &found {
+            println!("{path:<30} {tcl:<12} {prompt:<10} {active:<6}");
+        }
+    }
+    Ok(0)
+}
+
+fn run_update(path: &Path, tcl: &str, json: bool) -> anyhow::Result<u8> {
+    let colour = ui::use_colour(Some(!json));
+    let venv_path = absolutise(path);
+    let tclsh = match update_venv(&venv_path, tcl) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if json {
+        println!(
+            "{}",
+            ui::json_output(&json!({
+                "path": venv_path.to_string_lossy(),
+                "tcl": tcl,
+                "tclsh": tclsh.to_string_lossy(),
+            }))
+        );
+    } else {
+        println!(
+            "{}",
+            ui::ok(
+                &format!(
+                    "updated {} to tclsh {tcl} ({})",
+                    venv_path.display(),
+                    tclsh.display()
+                ),
+                colour
+            )
+        );
+    }
+    Ok(0)
+}
+
+fn run_in_venv(path: &Path, command: &[String]) -> anyhow::Result<u8> {
+    let venv_path = absolutise(path);
+    if !venv_path.join("tclvenv.cfg").is_file() {
+        eprintln!("error: not a tclpkg venv: {}", venv_path.display());
+        return Ok(1);
+    }
+    if command.is_empty() {
+        eprintln!("error: no command specified after --");
+        return Ok(1);
+    }
+
+    let lib_dir = venv_path.join("lib");
+    let existing = std::env::var("TCLLIBPATH").unwrap_or_default();
+    let tcllibpath = if existing.is_empty() {
+        lib_dir.to_string_lossy().into_owned()
+    } else {
+        format!("{} {existing}", lib_dir.display())
+    };
+    let bin_dir = venv_path.join("bin");
+    let path_env = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = bin_dir.into_os_string();
+    new_path.push(if cfg!(windows) { ";" } else { ":" });
+    new_path.push(&path_env);
+
+    let status = Command::new(&command[0])
+        .args(&command[1..])
+        .env("TCL_VENV", &venv_path)
+        .env("TCLLIBPATH", tcllibpath)
+        .env("PATH", new_path)
+        .status();
+    match status {
+        Ok(s) => Ok(u8::try_from(s.code().unwrap_or(1)).unwrap_or(1)),
+        Err(e) => {
+            eprintln!("error: {e}");
+            Ok(1)
+        }
+    }
+}
+
+fn absolutise(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    }
+}

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -174,6 +174,9 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             no_rename,
             json,
         } => commands::minimize::run_minimize(input, *no_rename, *json),
+        Command::Pkg { action } => commands::pkg::run(action),
+        Command::Venv { action } => commands::venv::run(action),
+        Command::Docker { action } => commands::docker::run(action),
         // Verbs not yet ported fall through to a clear not-implemented error.
         other => {
             let verb = other.verb_name();

--- a/rust/tcl-cli/tests/pkg_verbs.rs
+++ b/rust/tcl-cli/tests/pkg_verbs.rs
@@ -8,11 +8,22 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn run_in(dir: &std::path::Path, args: &[&str]) -> (String, String, i32) {
-    let output = Command::new(env!("CARGO_BIN_EXE_tcl"))
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .expect("failed to spawn tcl binary");
+    run_in_cache(dir, None, args)
+}
+
+/// Like [`run_in`] but pins `XDG_CACHE_HOME` so the content-addressable store
+/// writes under a test-scoped directory (keeps `install`/`vendor` hermetic).
+fn run_in_cache(
+    dir: &std::path::Path,
+    cache: Option<&std::path::Path>,
+    args: &[&str],
+) -> (String, String, i32) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tcl"));
+    cmd.args(args).current_dir(dir);
+    if let Some(cache) = cache {
+        cmd.env("XDG_CACHE_HOME", cache);
+    }
+    let output = cmd.output().expect("failed to spawn tcl binary");
     (
         String::from_utf8_lossy(&output.stdout).into_owned(),
         String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -78,12 +89,26 @@ fn docker_create_writes_dockerfile() {
 }
 
 #[test]
-fn pkg_init_install_list_roundtrip() {
-    let dir = temp_dir("pkg-roundtrip");
+fn pkg_init_install_materialise_roundtrip() {
+    let base = temp_dir("pkg-roundtrip");
+    let cache = base.join("cache");
+    let dir = base.join("proj");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // A local package to install (exercises fetch+materialise offline, no net).
+    let dep = base.join("dep-src");
+    std::fs::create_dir_all(&dep).unwrap();
+    std::fs::write(
+        dep.join("tclpkg.tcl"),
+        "package dep\nversion 1.0.0\nprovides dep::api\nlicense MIT\n",
+    )
+    .unwrap();
+    std::fs::write(dep.join("dep.tcl"), "proc dep::hi {} { return hi }\n").unwrap();
 
     // init
-    let (_o, _e, code) = run_in(
+    let (_o, _e, code) = run_in_cache(
         &dir,
+        Some(&cache),
         &["pkg", "init", "--name", "demo", "--version", "1.0.0"],
     );
     assert_eq!(code, 0);
@@ -91,32 +116,56 @@ fn pkg_init_install_list_roundtrip() {
     assert!(manifest.contains("package     demo"));
     assert!(manifest.contains("version     1.0.0"));
 
-    // add a leaf requirement (no fetch happens during install)
-    let (_o, _e, code) = run_in(&dir, &["pkg", "add", "json", "1.3.5"]);
+    // add the dependency with an explicit local source
+    let (_o, _e, code) = run_in_cache(
+        &dir,
+        Some(&cache),
+        &[
+            "pkg",
+            "add",
+            "dep",
+            "1.0.0",
+            "--source",
+            dep.to_str().unwrap(),
+        ],
+    );
     assert_eq!(code, 0);
 
-    // install resolves + writes the lockfile
-    let (_o, _e, code) = run_in(&dir, &["pkg", "install"]);
+    // install resolves, fetches, stores, materialises, and writes the lockfile
+    let (_o, _e, code) = run_in_cache(&dir, Some(&cache), &["pkg", "install"]);
     assert_eq!(code, 0);
     let lock = std::fs::read_to_string(dir.join("tclpkg.lock")).unwrap();
-    assert!(lock.contains("\"name\": \"json\""));
-    assert!(lock.contains("\"version\": \"1.3.5\""));
+    assert!(lock.contains("\"name\": \"dep\""));
+    assert!(lock.contains("\"version\": \"1.0.0\""));
+    assert!(
+        lock.contains("\"integrity\": \"sha256-"),
+        "lockfile: {lock}"
+    );
+    assert!(lock.contains("\"type\": \"path\""));
     // Canonical JSON: sorted keys, 2-space indent, trailing newline.
     assert!(lock.ends_with("}\n"));
 
+    // the package is materialised into ./lib/<name>-<version>/
+    let materialised = dir.join("lib").join("dep-1.0.0").join("dep.tcl");
+    assert!(materialised.exists(), "expected {}", materialised.display());
+
+    // verify passes now that integrity is populated
+    let (_o, _e, code) = run_in_cache(&dir, Some(&cache), &["pkg", "verify"]);
+    assert_eq!(code, 0);
+
     // list shows the resolved package
-    let (stdout, _e, code) = run_in(&dir, &["pkg", "list"]);
+    let (stdout, _e, code) = run_in_cache(&dir, Some(&cache), &["pkg", "list"]);
     assert_eq!(code, 0);
     assert!(stdout.contains("NAME"));
-    assert!(stdout.contains("json"));
-    assert!(stdout.contains("1.3.5"));
+    assert!(stdout.contains("dep"));
+    assert!(stdout.contains("1.0.0"));
 
     // tree --json round-trips through the canonical emitter
-    let (stdout, _e, code) = run_in(&dir, &["pkg", "tree", "--json"]);
+    let (stdout, _e, code) = run_in_cache(&dir, Some(&cache), &["pkg", "tree", "--json"]);
     assert_eq!(code, 0);
     assert!(stdout.contains("\"name\": \"demo\""));
 
-    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&base);
 }
 
 #[test]

--- a/rust/tcl-cli/tests/pkg_verbs.rs
+++ b/rust/tcl-cli/tests/pkg_verbs.rs
@@ -1,0 +1,137 @@
+//! Integration tests for the `pkg` / `venv` / `docker` verb groups.
+//!
+//! These drive the built `tcl` binary and assert deterministic output that was
+//! diffed byte-for-byte against the Python CLI (`tooling/tcl/verbs/*`). They
+//! avoid any network or `tclsh` dependency so they are stable in CI.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn run_in(dir: &std::path::Path, args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to spawn tcl binary");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("tcl-pkg-it-{tag}-{nanos}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn docker_recipe_alpine_86() {
+    let dir = temp_dir("docker-recipe");
+    let (stdout, _stderr, code) = run_in(
+        &dir,
+        &["docker", "recipe", "alpine:3.19", "--tcl-version", "8.6"],
+    );
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "RUN apk add --no-cache tcl\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn docker_info_lists_families() {
+    let dir = temp_dir("docker-info");
+    let (stdout, _stderr, code) = run_in(&dir, &["docker", "info"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("Supported Tcl versions:"));
+    assert!(stdout.contains("alpine        8.4, 8.5, 8.6, 9.0"));
+    assert!(stdout.contains("debian        8.4, 8.5, 8.6, 9.0"));
+    assert!(stdout.contains("redhat        8.4, 8.5, 8.6, 9.0"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn docker_create_writes_dockerfile() {
+    let dir = temp_dir("docker-create");
+    let (_stdout, _stderr, code) = run_in(
+        &dir,
+        &[
+            "docker",
+            "create",
+            "debian:bookworm-slim",
+            "--tcl-version",
+            "8.6",
+            "--no-packages",
+        ],
+    );
+    assert_eq!(code, 0);
+    let content = std::fs::read_to_string(dir.join("Dockerfile")).unwrap();
+    assert!(content.starts_with("FROM debian:bookworm-slim\n"));
+    assert!(content.contains("# Install Tcl 8.6"));
+    assert!(content.contains("WORKDIR /app"));
+    assert!(content.trim_end().ends_with("CMD [\"tclsh\"]"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pkg_init_install_list_roundtrip() {
+    let dir = temp_dir("pkg-roundtrip");
+
+    // init
+    let (_o, _e, code) = run_in(
+        &dir,
+        &["pkg", "init", "--name", "demo", "--version", "1.0.0"],
+    );
+    assert_eq!(code, 0);
+    let manifest = std::fs::read_to_string(dir.join("tclpkg.tcl")).unwrap();
+    assert!(manifest.contains("package     demo"));
+    assert!(manifest.contains("version     1.0.0"));
+
+    // add a leaf requirement (no fetch happens during install)
+    let (_o, _e, code) = run_in(&dir, &["pkg", "add", "json", "1.3.5"]);
+    assert_eq!(code, 0);
+
+    // install resolves + writes the lockfile
+    let (_o, _e, code) = run_in(&dir, &["pkg", "install"]);
+    assert_eq!(code, 0);
+    let lock = std::fs::read_to_string(dir.join("tclpkg.lock")).unwrap();
+    assert!(lock.contains("\"name\": \"json\""));
+    assert!(lock.contains("\"version\": \"1.3.5\""));
+    // Canonical JSON: sorted keys, 2-space indent, trailing newline.
+    assert!(lock.ends_with("}\n"));
+
+    // list shows the resolved package
+    let (stdout, _e, code) = run_in(&dir, &["pkg", "list"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("NAME"));
+    assert!(stdout.contains("json"));
+    assert!(stdout.contains("1.3.5"));
+
+    // tree --json round-trips through the canonical emitter
+    let (stdout, _e, code) = run_in(&dir, &["pkg", "tree", "--json"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("\"name\": \"demo\""));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pkg_search_offline_without_cache_errors() {
+    let dir = temp_dir("pkg-search");
+    let empty_cache = temp_dir("empty-cache");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args(["pkg", "search", "json", "--offline"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", &empty_cache)
+        .output()
+        .expect("spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("offline"), "stderr was: {stderr}");
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&empty_cache);
+}

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tcl-pkg"
+description = "Native Rust port of the tclpkg package manager (manifest, MVS resolver, lockfile, CAS, fetchers, venv, docker)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+tcl-syntax = { path = "../tcl-syntax" }
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+base64 = "0.22"
+flate2 = "1"
+tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+ureq = "3"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
+[lints]
+workspace = true

--- a/rust/tcl-pkg/src/cas.rs
+++ b/rust/tcl-pkg/src/cas.rs
@@ -1,0 +1,429 @@
+//! Content-addressable store (CAS) and integrity hashing.
+//!
+//! Faithful port of `tooling/tclpkg/cas.py`. The CAS lives at
+//! `<cache_dir>/tclpkg/cas/sha256/<ab>/<full_hash>/tree/`; each entry is
+//! immutable once written. The integrity string `sha256-<base64url-no-pad>` is
+//! computed over a *canonicalised worktree* (sorted paths, stripped VCS dirs,
+//! permission-masked, timestamps ignored) so a re-compressed archive hashes
+//! identically.
+
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
+
+use crate::errors::TclPkgError;
+
+const IGNORED_NAMES: &[&str] = &[".git", ".hg", ".svn", ".fossil", ".DS_Store", "Thumbs.db"];
+
+fn is_ignored(name: &str, extra: &[String]) -> bool {
+    IGNORED_NAMES.contains(&name) || extra.iter().any(|p| p == name)
+}
+
+fn load_tclpkgignore(root: &Path) -> Vec<String> {
+    let ignore_file = root.join(".tclpkgignore");
+    let Ok(text) = std::fs::read_to_string(&ignore_file) else {
+        return Vec::new();
+    };
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// Return sorted relative file paths under `root`, pruning ignored directories
+/// and files. Directory symlinks are not followed.
+fn walk_tree(root: &Path, extra_ignore: &[String]) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    collect_files(root, root, extra_ignore, &mut result);
+    // Sort by POSIX path bytes for cross-machine determinism.
+    result.sort_by_key(|a| posix(a).into_bytes());
+    result
+}
+
+fn collect_files(root: &Path, dir: &Path, extra: &[String], out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if is_ignored(&name, extra) {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        if file_type.is_dir() {
+            // followlinks=False: a directory symlink is neither recursed nor
+            // emitted as a file.
+            collect_files(root, &path, extra, out);
+        } else if let Ok(rel) = path.strip_prefix(root) {
+            out.push(rel.to_path_buf());
+        }
+    }
+}
+
+fn posix(path: &Path) -> String {
+    path.components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Compute the canonical SHA-256 integrity hash of a package worktree.
+///
+/// Returns `sha256-<base64url_no_pad>`, stable across machines: only permission
+/// bits (with execute normalised) and file content matter.
+#[must_use]
+pub fn integrity_of_tree(root: &Path) -> String {
+    let extra = load_tclpkgignore(root);
+    let mut hasher = Sha256::new();
+    for rel_path in walk_tree(root, &extra) {
+        let abs_path = root.join(&rel_path);
+        let Ok(meta) = std::fs::metadata(&abs_path) else {
+            continue;
+        };
+        let mut mode = file_mode(&meta);
+        if mode & 0o111 != 0 {
+            mode |= 0o111;
+        }
+        let Ok(content) = std::fs::read(&abs_path) else {
+            continue;
+        };
+        let file_hash = hex_digest(&content);
+        hasher.update(posix(&rel_path).into_bytes());
+        hasher.update(b"\n");
+        hasher.update(format!("{mode:o}\n").into_bytes());
+        hasher.update(format!("{}\n", content.len()).into_bytes());
+        hasher.update(file_hash.into_bytes());
+        hasher.update(b"\n");
+        hasher.update(&content);
+    }
+    let digest = hasher.finalize();
+    format!("sha256-{}", URL_SAFE_NO_PAD.encode(digest))
+}
+
+#[cfg(unix)]
+fn file_mode(meta: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    meta.mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn file_mode(_meta: &std::fs::Metadata) -> u32 {
+    // Non-Unix hosts have no POSIX mode; treat files as 0o644 for a stable
+    // cross-platform hash (matches the common case on the canonical build host).
+    0o644
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(s, "{byte:02x}");
+    }
+    s
+}
+
+fn hex_digest(data: &[u8]) -> String {
+    to_hex(&Sha256::digest(data))
+}
+
+/// Recompute the integrity hash and return whether it matches `expected`.
+#[must_use]
+pub fn verify_integrity(root: &Path, expected: &str) -> bool {
+    integrity_of_tree(root) == expected
+}
+
+/// Manage the `sha256/<ab>/<hash>/tree/` CAS on disk.
+pub struct ContentAddressableStore {
+    base: PathBuf,
+}
+
+impl ContentAddressableStore {
+    /// Create a store rooted at `cache_dir` (the `tclpkg/cas/sha256` subtree).
+    #[must_use]
+    pub fn new(cache_dir: &Path) -> Self {
+        Self {
+            base: cache_dir.join("tclpkg").join("cas").join("sha256"),
+        }
+    }
+
+    fn entry_dir(&self, integrity: &str) -> Result<PathBuf, TclPkgError> {
+        let Some(b64) = integrity.strip_prefix("sha256-") else {
+            return Err(TclPkgError::integrity(
+                format!("unsupported integrity format: {integrity}"),
+                None,
+                None,
+                None,
+            ));
+        };
+        let raw = URL_SAFE_NO_PAD.decode(b64).map_err(|_| {
+            TclPkgError::integrity(
+                format!("malformed integrity hash: {integrity}"),
+                None,
+                None,
+                Some(
+                    "the lockfile may be corrupted; delete tclpkg.lock and re-run \
+                     'tcl pkg install'"
+                        .to_string(),
+                ),
+            )
+        })?;
+        let hex = to_hex(&raw);
+        let shard = &hex[..2.min(hex.len())];
+        Ok(self.base.join(shard).join(&hex))
+    }
+
+    /// Whether the CAS contains an entry for `integrity` (false on any decode
+    /// error — callers guard against empty/malformed integrity strings).
+    #[must_use]
+    pub fn has(&self, integrity: &str) -> bool {
+        self.entry_dir(integrity)
+            .is_ok_and(|e| e.join("tree").is_dir())
+    }
+
+    /// Return the `tree/` directory for an existing CAS entry.
+    pub fn tree_path(&self, integrity: &str) -> Result<PathBuf, TclPkgError> {
+        let tree = self.entry_dir(integrity)?.join("tree");
+        if tree.is_dir() {
+            Ok(tree)
+        } else {
+            Err(TclPkgError::integrity(
+                format!("CAS entry missing for {integrity}"),
+                None,
+                None,
+                Some("run 'tcl pkg install' to populate the cache".to_string()),
+            ))
+        }
+    }
+
+    /// Copy a worktree into the CAS and return its integrity string.
+    pub fn store(
+        &self,
+        source_dir: &Path,
+        name: &str,
+        version: &str,
+        expected_integrity: Option<&str>,
+    ) -> Result<String, TclPkgError> {
+        let actual = integrity_of_tree(source_dir);
+        if let Some(expected) = expected_integrity
+            && actual != expected
+        {
+            return Err(TclPkgError::integrity(
+                format!("integrity mismatch for {name}@{version}"),
+                Some(expected),
+                Some(&actual),
+                Some("the download may be corrupted; delete the cache and retry".to_string()),
+            ));
+        }
+        let entry = self.entry_dir(&actual)?;
+        let tree = entry.join("tree");
+        if tree.is_dir() {
+            return Ok(actual); // already cached
+        }
+        std::fs::create_dir_all(&entry)
+            .map_err(|e| TclPkgError::new(format!("cannot create CAS entry: {e}")))?;
+        if !name.is_empty() {
+            let _ = std::fs::write(entry.join("package.txt"), format!("{name} {version}\n"));
+        }
+        copy_dir(source_dir, &tree)
+            .map_err(|e| TclPkgError::new(format!("cannot populate CAS: {e}")))?;
+        Ok(actual)
+    }
+
+    /// Create `dest` as a symlink (or copy) pointing into the CAS.
+    pub fn materialise(
+        &self,
+        integrity: &str,
+        dest: &Path,
+        symlink: bool,
+    ) -> Result<(), TclPkgError> {
+        let tree = self.tree_path(integrity)?;
+        if dest.exists() || dest.is_symlink() {
+            if dest.is_symlink() || dest.is_file() {
+                let _ = std::fs::remove_file(dest);
+            } else if dest.is_dir() {
+                let _ = std::fs::remove_dir_all(dest);
+            }
+        }
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                TclPkgError::new(format!("cannot create {}: {e}", parent.display()))
+            })?;
+        }
+        if symlink && try_symlink(&tree, dest) {
+            return Ok(());
+        }
+        copy_dir(&tree, dest)
+            .map_err(|e| TclPkgError::new(format!("cannot materialise package: {e}")))
+    }
+}
+
+#[cfg(unix)]
+fn try_symlink(target: &Path, dest: &Path) -> bool {
+    std::os::unix::fs::symlink(target, dest).is_ok()
+}
+
+#[cfg(not(unix))]
+fn try_symlink(_target: &Path, _dest: &Path) -> bool {
+    false
+}
+
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    struct TempDir(PathBuf);
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let mut p = std::env::temp_dir();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            p.push(format!("tclpkg-cas-{tag}-{nanos}"));
+            fs::create_dir_all(&p).unwrap();
+            TempDir(p)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn make_tree(root: &Path, files: &[(&str, &str)]) -> PathBuf {
+        let tree = root.join("tree");
+        fs::create_dir_all(&tree).unwrap();
+        for (rel, content) in files {
+            let p = tree.join(rel);
+            fs::create_dir_all(p.parent().unwrap()).unwrap();
+            fs::write(&p, content).unwrap();
+        }
+        tree
+    }
+
+    #[test]
+    fn stable_and_prefixed() {
+        let tmp = TempDir::new("stable");
+        let root = make_tree(
+            tmp.path(),
+            &[("a.tcl", "set x 1\n"), ("b.tcl", "set y 2\n")],
+        );
+        let a = integrity_of_tree(&root);
+        assert!(a.starts_with("sha256-"));
+        assert_eq!(a, integrity_of_tree(&root));
+    }
+
+    #[test]
+    fn content_sensitivity() {
+        let t1 = TempDir::new("c1");
+        let t2 = TempDir::new("c2");
+        let r1 = make_tree(t1.path(), &[("a.tcl", "set x 1\n")]);
+        let r2 = make_tree(t2.path(), &[("a.tcl", "set x 2\n")]);
+        let r3 = make_tree(&t2.path().join("same"), &[("a.tcl", "set x 1\n")]);
+        assert_ne!(integrity_of_tree(&r1), integrity_of_tree(&r2));
+        assert_eq!(integrity_of_tree(&r1), integrity_of_tree(&r3));
+    }
+
+    #[test]
+    fn ignores_vcs_and_ds_store() {
+        let t1 = TempDir::new("i1");
+        let root = make_tree(t1.path(), &[("a.tcl", "ok\n"), (".DS_Store", "binary")]);
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        let t2 = TempDir::new("i2");
+        let clean = make_tree(t2.path(), &[("a.tcl", "ok\n")]);
+        assert_eq!(integrity_of_tree(&root), integrity_of_tree(&clean));
+    }
+
+    #[test]
+    fn tclpkgignore_honoured() {
+        let t1 = TempDir::new("ti1");
+        let root = make_tree(
+            t1.path(),
+            &[
+                ("a.tcl", "ok\n"),
+                ("build", "junk\n"),
+                (".tclpkgignore", "build\n"),
+            ],
+        );
+        let t2 = TempDir::new("ti2");
+        let clean = make_tree(
+            t2.path(),
+            &[("a.tcl", "ok\n"), (".tclpkgignore", "build\n")],
+        );
+        assert_eq!(integrity_of_tree(&root), integrity_of_tree(&clean));
+    }
+
+    #[test]
+    fn verify() {
+        let tmp = TempDir::new("verify");
+        let root = make_tree(tmp.path(), &[("a.tcl", "set x 1\n")]);
+        let expected = integrity_of_tree(&root);
+        assert!(verify_integrity(&root, &expected));
+        assert!(!verify_integrity(&root, "sha256-WRONG"));
+    }
+
+    #[test]
+    fn store_and_materialise() {
+        let tmp = TempDir::new("store");
+        let cas = ContentAddressableStore::new(&tmp.path().join("cache"));
+        let root = make_tree(tmp.path(), &[("a.tcl", "hello\n")]);
+        let integrity = cas.store(&root, "pkg", "1.0", None).unwrap();
+        assert!(integrity.starts_with("sha256-"));
+        assert!(cas.has(&integrity));
+        // idempotent
+        assert_eq!(integrity, cas.store(&root, "pkg", "1.0", None).unwrap());
+
+        let dest = tmp.path().join("lib").join("pkg-1.0");
+        cas.materialise(&integrity, &dest, false).unwrap();
+        assert!(dest.is_dir());
+        assert_eq!(fs::read_to_string(dest.join("a.tcl")).unwrap(), "hello\n");
+    }
+
+    #[test]
+    fn store_rejects_wrong_expected() {
+        let tmp = TempDir::new("expect");
+        let cas = ContentAddressableStore::new(&tmp.path().join("cache"));
+        let root = make_tree(tmp.path(), &[("a.tcl", "set x 1\n")]);
+        let err = cas
+            .store(&root, "a", "1.0", Some("sha256-WRONG"))
+            .unwrap_err();
+        assert!(err.to_string().contains("mismatch"));
+    }
+
+    #[test]
+    fn tree_path_missing() {
+        let tmp = TempDir::new("missing");
+        let cas = ContentAddressableStore::new(&tmp.path().join("cache"));
+        let err = cas
+            .tree_path("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+            .unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+}

--- a/rust/tcl-pkg/src/cas.rs
+++ b/rust/tcl-pkg/src/cas.rs
@@ -133,6 +133,22 @@ fn hex_digest(data: &[u8]) -> String {
     to_hex(&Sha256::digest(data))
 }
 
+/// Return the total byte size of the files in a canonical worktree.
+///
+/// Walks the same file set as [`integrity_of_tree`] and sums file lengths, so
+/// the lockfile `size` field is deterministic and matches the Python port.
+#[must_use]
+pub fn tree_size(root: &Path) -> u64 {
+    let extra = load_tclpkgignore(root);
+    let mut total = 0u64;
+    for rel_path in walk_tree(root, &extra) {
+        if let Ok(meta) = std::fs::metadata(root.join(&rel_path)) {
+            total = total.saturating_add(meta.len());
+        }
+    }
+    total
+}
+
 /// Recompute the integrity hash and return whether it matches `expected`.
 #[must_use]
 pub fn verify_integrity(root: &Path, expected: &str) -> bool {

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -1,0 +1,413 @@
+//! Dockerfile generation for Tcl projects.
+//!
+//! Faithful port of `tooling/tclpkg/docker.py`. Generates production-ready
+//! Dockerfiles that install a specific Tcl version, download the `tcl` CLI
+//! zipapp, and wire `tcl pkg sync` / `tcl venv create`. Also exposes recipe
+//! lookup helpers for AI skills composing custom Dockerfiles.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::errors::TclPkgError;
+
+pub const SUPPORTED_TCL_VERSIONS: [&str; 4] = ["8.4", "8.5", "8.6", "9.0"];
+pub const DEFAULT_TCL_VERSION: &str = "8.6";
+pub const DEFAULT_BASE_IMAGE: &str = "debian:bookworm-slim";
+
+const TCL_CLI_URL_PREFIX: &str = "https://github.com/bitwisecook/tcl-lsp/releases/download/v";
+const DEFAULT_CLI_VERSION: &str = "1.6.0";
+
+// Map well-known image prefixes to recipe families.
+const IMAGE_FAMILY: &[(&str, &str)] = &[
+    ("alpine", "alpine"),
+    ("debian", "debian"),
+    ("ubuntu", "debian"),
+    ("buildpack-deps", "debian"),
+    ("slim", "debian"),
+    ("fedora", "redhat"),
+    ("centos", "redhat"),
+    ("rockylinux", "redhat"),
+    ("almalinux", "redhat"),
+    ("amazonlinux", "redhat"),
+    ("oraclelinux", "redhat"),
+    ("rhel", "redhat"),
+    ("redhat", "redhat"),
+];
+
+fn docker_error(message: impl Into<String>) -> TclPkgError {
+    TclPkgError::new(message)
+}
+
+fn recipe(family: &str, version: &str) -> Option<&'static str> {
+    let table: &[(&str, &str)] = match family {
+        "debian" => DEBIAN_RECIPES,
+        "alpine" => ALPINE_RECIPES,
+        "redhat" => REDHAT_RECIPES,
+        _ => return None,
+    };
+    table.iter().find(|(v, _)| *v == version).map(|(_, r)| *r)
+}
+
+fn family_versions(family: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    match family {
+        "debian" => Some(DEBIAN_RECIPES),
+        "alpine" => Some(ALPINE_RECIPES),
+        "redhat" => Some(REDHAT_RECIPES),
+        _ => None,
+    }
+}
+
+const PYTHON_INSTALL_DEBIAN: &str = "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        python3 curl ca-certificates && \\\n    rm -rf /var/lib/apt/lists/*";
+const PYTHON_INSTALL_ALPINE: &str = "RUN apk add --no-cache python3 curl";
+const PYTHON_INSTALL_REDHAT: &str = "RUN dnf install -y python3 curl && dnf clean all";
+
+fn strip_registry(image: &str) -> String {
+    let parts: Vec<&str> = image.split('/').collect();
+    if parts.len() >= 2 && (parts[0].contains('.') || parts[0].contains(':')) {
+        return (*parts.last().unwrap()).to_string();
+    }
+    if parts.len() == 3 {
+        return (*parts.last().unwrap()).to_string();
+    }
+    image.to_string()
+}
+
+/// Return the recipe family key for the given Docker image name.
+#[must_use]
+pub fn detect_image_family(image: &str) -> String {
+    let lower = strip_registry(image).to_lowercase();
+    for (prefix, family) in IMAGE_FAMILY {
+        if lower.starts_with(prefix) {
+            return (*family).to_string();
+        }
+    }
+    "debian".to_string()
+}
+
+/// Return the Dockerfile snippet that installs Tcl `tcl_version` on `image`.
+pub fn tcl_install_recipe(image: &str, tcl_version: &str) -> Result<String, TclPkgError> {
+    if !SUPPORTED_TCL_VERSIONS.contains(&tcl_version) {
+        return Err(docker_error(format!(
+            "unsupported Tcl version: {tcl_version} (supported: {})",
+            SUPPORTED_TCL_VERSIONS.join(", ")
+        )));
+    }
+    let family = detect_image_family(image);
+    let Some(versions) = family_versions(&family) else {
+        return Err(docker_error(format!(
+            "no install recipe for image family: {family}"
+        )));
+    };
+    recipe(&family, tcl_version)
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            let mut available: Vec<&str> = versions.iter().map(|(v, _)| *v).collect();
+            available.sort_unstable();
+            docker_error(format!(
+                "no recipe for Tcl {tcl_version} on {family} (available: {})",
+                available.join(", ")
+            ))
+        })
+}
+
+/// Return the Dockerfile snippet that installs Python 3 on `image`.
+pub fn python_install_recipe(image: &str) -> Result<String, TclPkgError> {
+    match detect_image_family(image).as_str() {
+        "debian" => Ok(PYTHON_INSTALL_DEBIAN.to_string()),
+        "alpine" => Ok(PYTHON_INSTALL_ALPINE.to_string()),
+        "redhat" => Ok(PYTHON_INSTALL_REDHAT.to_string()),
+        family => Err(docker_error(format!(
+            "no Python install recipe for image family: {family}"
+        ))),
+    }
+}
+
+/// Return the GitHub release URL for the `tcl` CLI zipapp.
+#[must_use]
+pub fn tcl_cli_download_url(cli_version: Option<&str>) -> String {
+    let version = cli_version.unwrap_or(DEFAULT_CLI_VERSION);
+    format!("{TCL_CLI_URL_PREFIX}{version}/tcl-{version}.pyz")
+}
+
+/// Return `{family: [versions]}` for all known recipe families (sorted).
+#[must_use]
+pub fn available_recipes() -> BTreeMap<String, Vec<String>> {
+    let mut out = BTreeMap::new();
+    for family in ["alpine", "debian", "redhat"] {
+        if let Some(versions) = family_versions(family) {
+            let mut vs: Vec<String> = versions.iter().map(|(v, _)| (*v).to_string()).collect();
+            vs.sort();
+            out.insert(family.to_string(), vs);
+        }
+    }
+    out
+}
+
+/// Parameters for Dockerfile generation.
+#[derive(Debug, Clone)]
+pub struct DockerfileSpec {
+    pub base_image: String,
+    pub tcl_version: String,
+    pub workdir: String,
+    pub copy_project: bool,
+    pub install_packages: bool,
+    pub create_venv: bool,
+    pub entrypoint: Option<String>,
+    pub extra_packages: Vec<String>,
+    pub labels: BTreeMap<String, String>,
+    pub env: BTreeMap<String, String>,
+    pub cli_version: Option<String>,
+}
+
+impl Default for DockerfileSpec {
+    fn default() -> Self {
+        Self {
+            base_image: DEFAULT_BASE_IMAGE.to_string(),
+            tcl_version: DEFAULT_TCL_VERSION.to_string(),
+            workdir: "/app".to_string(),
+            copy_project: true,
+            install_packages: true,
+            create_venv: false,
+            entrypoint: None,
+            extra_packages: Vec::new(),
+            labels: BTreeMap::new(),
+            env: BTreeMap::new(),
+            cli_version: None,
+        }
+    }
+}
+
+/// Generate a complete Dockerfile from a [`DockerfileSpec`].
+pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError> {
+    let mut lines: Vec<String> = Vec::new();
+    let family = detect_image_family(&spec.base_image);
+    let needs_cli = spec.install_packages || spec.create_venv;
+
+    lines.push(format!("FROM {}", spec.base_image));
+    lines.push(String::new());
+
+    if !spec.labels.is_empty() {
+        for (key, value) in &spec.labels {
+            lines.push(format!("LABEL {key}=\"{value}\""));
+        }
+        lines.push(String::new());
+    }
+
+    if !spec.env.is_empty() {
+        for (key, value) in &spec.env {
+            lines.push(format!("ENV {key}=\"{value}\""));
+        }
+        lines.push(String::new());
+    }
+
+    lines.push(format!("# Install Tcl {}", spec.tcl_version));
+    lines.push(tcl_install_recipe(&spec.base_image, &spec.tcl_version)?);
+    lines.push(String::new());
+
+    if needs_cli {
+        lines.push("# Install Python 3 (required by the tcl CLI tool)".to_string());
+        lines.push(python_install_recipe(&spec.base_image)?);
+        lines.push(String::new());
+
+        let url = tcl_cli_download_url(spec.cli_version.as_deref());
+        lines.push("# Download the tcl CLI zipapp from GitHub releases".to_string());
+        lines.push(format!(
+            "RUN curl -fSL \"{url}\" \\\n        -o /usr/local/bin/tcl.pyz && \\\n    chmod +x /usr/local/bin/tcl.pyz"
+        ));
+        lines.push(String::new());
+    }
+
+    if !spec.extra_packages.is_empty() {
+        let pkg_list = spec.extra_packages.join(" \\\n                    ");
+        if family == "alpine" {
+            lines.push(format!("RUN apk add --no-cache {pkg_list}"));
+        } else if family == "redhat" {
+            lines.push(format!("RUN dnf install -y {pkg_list} && dnf clean all"));
+        } else {
+            lines.push(format!(
+                "RUN apt-get update && apt-get install -y --no-install-recommends \\\n                    {pkg_list} && \\\n                rm -rf /var/lib/apt/lists/*"
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    lines.push(format!("WORKDIR {}", spec.workdir));
+    lines.push(String::new());
+
+    if spec.copy_project {
+        lines.push("COPY . .".to_string());
+        lines.push(String::new());
+    }
+
+    if spec.create_venv {
+        let venv_abs = format!("{}/.venv", spec.workdir);
+        lines.push("# Create Tcl virtual environment".to_string());
+        lines.push(format!(
+            "RUN python3 /usr/local/bin/tcl.pyz venv create .venv --tcl {}",
+            spec.tcl_version
+        ));
+        lines.push(format!("ENV TCLLIBPATH=\"{venv_abs}/lib\""));
+        lines.push(format!("ENV PATH=\"{venv_abs}/bin:$PATH\""));
+        lines.push(format!("ENV TCL_VENV=\"{venv_abs}\""));
+        lines.push(String::new());
+    }
+
+    if spec.install_packages {
+        if spec.create_venv {
+            lines.push("# Install Tcl packages into the virtual environment".to_string());
+        } else {
+            lines.push("# Install Tcl packages from lockfile".to_string());
+        }
+        lines.push(
+            "RUN if [ -f tclpkg.lock ]; then python3 /usr/local/bin/tcl.pyz pkg sync --frozen; fi"
+                .to_string(),
+        );
+        lines.push(String::new());
+    }
+
+    if let Some(entry) = &spec.entrypoint {
+        lines.push(format!("CMD [\"tclsh\", \"{entry}\"]"));
+    } else {
+        lines.push("CMD [\"tclsh\"]".to_string());
+    }
+    lines.push(String::new());
+
+    Ok(lines.join("\n"))
+}
+
+/// Generate and write a Dockerfile to `output`.
+pub fn write_dockerfile(
+    output: &Path,
+    spec: &DockerfileSpec,
+    overwrite: bool,
+) -> Result<PathBuf, TclPkgError> {
+    if output.exists() && !overwrite {
+        return Err(docker_error(format!(
+            "file already exists: {} (use --force to overwrite)",
+            output.display()
+        )));
+    }
+    let content = generate_dockerfile(spec)?;
+    std::fs::write(output, content)
+        .map_err(|e| docker_error(format!("cannot write {}: {e}", output.display())))?;
+    Ok(output.to_path_buf())
+}
+
+// ---------------------------------------------------------------------------
+// Recipe tables (verbatim from tooling/tclpkg/docker.py)
+// ---------------------------------------------------------------------------
+
+const DEBIAN_RECIPES: &[(&str, &str)] = &[
+    (
+        "8.4",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.4.20-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.4.20/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential && \\\n    rm -rf /var/lib/apt/lists/*",
+    ),
+    (
+        "8.5",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.5.19-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.5.19/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential && \\\n    rm -rf /var/lib/apt/lists/*",
+    ),
+    (
+        "8.6",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        tcl8.6 && \\\n    ln -sf /usr/bin/tclsh8.6 /usr/local/bin/tclsh && \\\n    rm -rf /var/lib/apt/lists/*",
+    ),
+    (
+        "9.0",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates zlib1g-dev && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl9.0.1-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl9.0.1/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential zlib1g-dev && \\\n    rm -rf /var/lib/apt/lists/*",
+    ),
+];
+
+const ALPINE_RECIPES: &[(&str, &str)] = &[
+    (
+        "8.4",
+        "RUN apk add --no-cache build-base curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.4.20-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.4.20/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base",
+    ),
+    (
+        "8.5",
+        "RUN apk add --no-cache build-base curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.5.19-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.5.19/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base",
+    ),
+    ("8.6", "RUN apk add --no-cache tcl"),
+    (
+        "9.0",
+        "RUN apk add --no-cache build-base curl zlib-dev && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl9.0.1-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl9.0.1/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base zlib-dev",
+    ),
+];
+
+const REDHAT_RECIPES: &[(&str, &str)] = &[
+    (
+        "8.4",
+        "RUN dnf install -y gcc make curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.4.20-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.4.20/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make && dnf clean all",
+    ),
+    (
+        "8.5",
+        "RUN dnf install -y gcc make curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.5.19-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.5.19/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make && dnf clean all",
+    ),
+    ("8.6", "RUN dnf install -y tcl && dnf clean all"),
+    (
+        "9.0",
+        "RUN dnf install -y gcc make curl zlib-devel && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl9.0.1-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl9.0.1/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make zlib-devel && dnf clean all",
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn family_detection() {
+        assert_eq!(detect_image_family("alpine:3.19"), "alpine");
+        assert_eq!(
+            detect_image_family("docker.io/library/alpine:3.19"),
+            "alpine"
+        );
+        assert_eq!(detect_image_family("ubuntu:22.04"), "debian");
+        assert_eq!(detect_image_family("fedora:39"), "redhat");
+        assert_eq!(detect_image_family("quay.io/fedora/fedora:39"), "redhat");
+        assert_eq!(detect_image_family("custom-image:latest"), "debian");
+    }
+
+    #[test]
+    fn recipe_lookup() {
+        let r = tcl_install_recipe("alpine:3.19", "8.6").unwrap();
+        assert_eq!(r, "RUN apk add --no-cache tcl");
+        assert!(tcl_install_recipe("alpine:3.19", "7.0").is_err());
+    }
+
+    #[test]
+    fn cli_url() {
+        assert_eq!(
+            tcl_cli_download_url(None),
+            "https://github.com/bitwisecook/tcl-lsp/releases/download/v1.6.0/tcl-1.6.0.pyz"
+        );
+        assert_eq!(
+            tcl_cli_download_url(Some("2.0.0")),
+            "https://github.com/bitwisecook/tcl-lsp/releases/download/v2.0.0/tcl-2.0.0.pyz"
+        );
+    }
+
+    #[test]
+    fn available() {
+        let recipes = available_recipes();
+        assert_eq!(recipes["debian"], vec!["8.4", "8.5", "8.6", "9.0"]);
+        assert_eq!(
+            recipes.keys().collect::<Vec<_>>(),
+            vec!["alpine", "debian", "redhat"]
+        );
+    }
+
+    #[test]
+    fn generate_minimal() {
+        let spec = DockerfileSpec {
+            base_image: "debian:bookworm-slim".to_string(),
+            tcl_version: "8.6".to_string(),
+            install_packages: false,
+            create_venv: false,
+            ..Default::default()
+        };
+        let out = generate_dockerfile(&spec).unwrap();
+        assert!(out.starts_with("FROM debian:bookworm-slim\n"));
+        assert!(out.contains("# Install Tcl 8.6"));
+        assert!(out.contains("WORKDIR /app"));
+        assert!(out.contains("COPY . ."));
+        assert!(out.trim_end().ends_with("CMD [\"tclsh\"]"));
+    }
+}

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -259,7 +259,7 @@ pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError>
             lines.push("# Install Tcl packages from lockfile".to_string());
         }
         lines.push(
-            "RUN if [ -f tclpkg.lock ]; then python3 /usr/local/bin/tcl.pyz pkg sync --frozen; fi"
+            "RUN if [ -f tclpkg.lock ]; then python3 /usr/local/bin/tcl.pyz pkg install --frozen; fi"
                 .to_string(),
         );
         lines.push(String::new());

--- a/rust/tcl-pkg/src/errors.rs
+++ b/rust/tcl-pkg/src/errors.rs
@@ -1,0 +1,170 @@
+//! Error types for the `tclpkg` package manager.
+//!
+//! Faithful port of `tooling/tclpkg/errors.py`. The CLI prints the
+//! [`Display`] form verbatim, so the message composition (location prefixes,
+//! `hint:` suffix, integrity expected/got detail) must match the Python output
+//! byte-for-byte.
+
+use std::fmt;
+
+/// Category tag, mirroring the Python `category` class attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    TclPkg,
+    Manifest,
+    Resolver,
+    Integrity,
+    Registry,
+    Fetch,
+    Venv,
+}
+
+impl Category {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Category::TclPkg => "tclpkg",
+            Category::Manifest => "manifest",
+            Category::Resolver => "resolver",
+            Category::Integrity => "integrity",
+            Category::Registry => "registry",
+            Category::Fetch => "fetch",
+            Category::Venv => "venv",
+        }
+    }
+}
+
+/// Base error type for every tclpkg-specific failure.
+///
+/// Mirrors `TclPkgError` and its subclasses. The variant carries a fully
+/// composed `message` plus an optional `hint`; the `Display` impl reproduces
+/// the Python `__str__` (message, then `\n  hint: <hint>` when present).
+#[derive(Debug, Clone)]
+pub struct TclPkgError {
+    pub category: Category,
+    pub message: String,
+    pub hint: Option<String>,
+}
+
+impl TclPkgError {
+    /// Construct a generic `tclpkg` error.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            category: Category::TclPkg,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// Attach a recovery hint.
+    #[must_use]
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_category(mut self, category: Category) -> Self {
+        self.category = category;
+        self
+    }
+
+    /// Build a `ManifestError`: optional `path[:line]: ` prefix on the message.
+    pub fn manifest(
+        message: impl Into<String>,
+        path: Option<&str>,
+        line: Option<usize>,
+        hint: Option<String>,
+    ) -> Self {
+        let mut location = String::new();
+        if let Some(p) = path
+            && !p.is_empty()
+        {
+            location.push_str(p);
+            if let Some(l) = line {
+                location.push(':');
+                location.push_str(&l.to_string());
+            }
+            location.push_str(": ");
+        }
+        Self {
+            category: Category::Manifest,
+            message: format!("{location}{}", message.into()),
+            hint,
+        }
+    }
+
+    /// Build a `ResolutionError`: appends a `\n  via <chain>` trail.
+    pub fn resolution(message: impl Into<String>, chain: &[String], hint: Option<String>) -> Self {
+        let mut msg = message.into();
+        if !chain.is_empty() {
+            let joined = chain.join("\n  via ");
+            msg = format!("{msg}\n  via {joined}");
+        }
+        Self {
+            category: Category::Resolver,
+            message: msg,
+            hint,
+        }
+    }
+
+    /// Build an `IntegrityError`: optional expected/got detail block.
+    pub fn integrity(
+        message: impl Into<String>,
+        expected: Option<&str>,
+        actual: Option<&str>,
+        hint: Option<String>,
+    ) -> Self {
+        let mut msg = message.into();
+        if let (Some(e), Some(a)) = (expected, actual) {
+            msg = format!("{msg}\n  expected {e}\n  got      {a}");
+        }
+        Self {
+            category: Category::Integrity,
+            message: msg,
+            hint,
+        }
+    }
+
+    /// Build a `RegistryError`.
+    pub fn registry(message: impl Into<String>, hint: Option<String>) -> Self {
+        Self {
+            category: Category::Registry,
+            message: message.into(),
+            hint,
+        }
+    }
+
+    /// Build a `FetchError`.
+    pub fn fetch(message: impl Into<String>) -> Self {
+        Self {
+            category: Category::Fetch,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// Build a `VenvError`.
+    pub fn venv(message: impl Into<String>, hint: Option<String>) -> Self {
+        Self {
+            category: Category::Venv,
+            message: message.into(),
+            hint,
+        }
+    }
+}
+
+impl fmt::Display for TclPkgError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(hint) = &self.hint {
+            write!(f, "{}\n  hint: {hint}", self.message)
+        } else {
+            write!(f, "{}", self.message)
+        }
+    }
+}
+
+impl std::error::Error for TclPkgError {}
+
+/// Convenience alias for results returning a [`TclPkgError`].
+pub type Result<T> = std::result::Result<T, TclPkgError>;

--- a/rust/tcl-pkg/src/fetchers.rs
+++ b/rust/tcl-pkg/src/fetchers.rs
@@ -1,0 +1,389 @@
+//! Package source fetchers — tarball, git, and local path.
+//!
+//! Faithful port of `tooling/tclpkg/fetchers.py`. Each fetcher downloads or
+//! copies a package source into a target directory; the caller then hands the
+//! directory to [`cas::store`](crate::cas::ContentAddressableStore::store) for
+//! integrity hashing. Archive extraction is hardened against zip-slip,
+//! absolute paths, symlinks, and decompression bombs.
+
+// These compare URL suffixes (already lowercased) and the `.git` marker, not
+// real filesystem paths, so `Path::extension` would be the wrong tool.
+#![allow(clippy::case_sensitive_file_extension_comparisons)]
+
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use flate2::read::GzDecoder;
+
+use crate::errors::TclPkgError;
+
+/// Maximum total uncompressed size from a single archive (256 MiB). Protects
+/// against decompression bombs.
+const MAX_EXTRACT_BYTES: u64 = 256 * 1024 * 1024;
+
+fn fetch_error(message: impl Into<String>) -> TclPkgError {
+    TclPkgError::fetch(message)
+}
+
+/// Download and extract a tarball or zip from `url` into `dest`.
+///
+/// Supports gzip tarballs (`.tar.gz` / `.tgz`), plain `.tar`, and `.zip`. A
+/// singular top-level directory is stripped so files land directly in `dest`.
+pub fn fetch_tarball(url: &str, dest: &Path, timeout: u64) -> Result<(), TclPkgError> {
+    std::fs::create_dir_all(dest)
+        .map_err(|e| fetch_error(format!("cannot create {}: {e}", dest.display())))?;
+
+    let bytes = download(url, timeout)?;
+    let staging = dest.join(".staging");
+    std::fs::create_dir_all(&staging)
+        .map_err(|e| fetch_error(format!("cannot create staging dir: {e}")))?;
+
+    let lower = url.to_lowercase();
+    if lower.ends_with(".zip") {
+        extract_zip(&bytes, &staging)?;
+    } else {
+        extract_tar(&bytes, &staging, &lower)?;
+    }
+
+    strip_top_level(&staging, dest)?;
+    Ok(())
+}
+
+fn download(url: &str, timeout: u64) -> Result<Vec<u8>, TclPkgError> {
+    let agent = ureq::config::Config::builder()
+        .http_status_as_error(false)
+        .timeout_global(Some(Duration::from_secs(timeout)))
+        .build()
+        .new_agent();
+    let mut resp = agent
+        .get(url)
+        .header("User-Agent", "tclpkg/0.1")
+        .call()
+        .map_err(|e| fetch_error(format!("failed to fetch tarball from {url}: {e}")))?;
+    if resp.status().as_u16() >= 400 {
+        return Err(fetch_error(format!(
+            "failed to fetch tarball from {url}: HTTP {}",
+            resp.status().as_u16()
+        )));
+    }
+    resp.body_mut()
+        .with_config()
+        .limit(MAX_EXTRACT_BYTES)
+        .read_to_vec()
+        .map_err(|e| fetch_error(format!("failed to read tarball from {url}: {e}")))
+}
+
+/// Validate that `name` resolves inside `dest_root`, returning the safe target.
+fn safe_join(dest_root: &Path, name: &str) -> Result<PathBuf, TclPkgError> {
+    let candidate = Path::new(name);
+    if candidate.is_absolute() {
+        return Err(fetch_error(format!(
+            "archive member has absolute path: {name}"
+        )));
+    }
+    if candidate
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(fetch_error(format!(
+            "archive member escapes target directory: {name}"
+        )));
+    }
+    Ok(dest_root.join(candidate))
+}
+
+fn extract_tar(bytes: &[u8], dest: &Path, lower: &str) -> Result<(), TclPkgError> {
+    let is_gzip =
+        lower.ends_with(".gz") || lower.ends_with(".tgz") || bytes.starts_with(&[0x1f, 0x8b]);
+    if lower.ends_with(".bz2") || lower.ends_with(".xz") {
+        return Err(fetch_error(
+            "bzip2/xz tarballs are not supported by this build; use .tar.gz or .zip",
+        ));
+    }
+    let reader: Box<dyn Read> = if is_gzip {
+        Box::new(GzDecoder::new(Cursor::new(bytes)))
+    } else {
+        Box::new(Cursor::new(bytes))
+    };
+    let mut archive = tar::Archive::new(reader);
+    let mut total: u64 = 0;
+    for entry in archive
+        .entries()
+        .map_err(|e| fetch_error(format!("cannot read tar archive: {e}")))?
+    {
+        let mut entry = entry.map_err(|e| fetch_error(format!("corrupt tar entry: {e}")))?;
+        let entry_type = entry.header().entry_type();
+        // Skip symlinks and hardlinks (parity with the Python member filter).
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            continue;
+        }
+        let path = entry
+            .path()
+            .map_err(|e| fetch_error(format!("invalid tar path: {e}")))?
+            .to_string_lossy()
+            .into_owned();
+        let target = safe_join(dest, &path)?;
+        if entry_type.is_dir() {
+            std::fs::create_dir_all(&target)
+                .map_err(|e| fetch_error(format!("cannot create dir: {e}")))?;
+            continue;
+        }
+        total = total.saturating_add(entry.header().size().unwrap_or(0));
+        if total > MAX_EXTRACT_BYTES {
+            return Err(fetch_error(
+                "tar archive exceeds 256 MiB uncompressed limit (possible bomb)",
+            ));
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| fetch_error(format!("cannot create dir: {e}")))?;
+        }
+        let mut out = std::fs::File::create(&target)
+            .map_err(|e| fetch_error(format!("cannot write {}: {e}", target.display())))?;
+        std::io::copy(&mut entry, &mut out)
+            .map_err(|e| fetch_error(format!("cannot extract {}: {e}", target.display())))?;
+    }
+    Ok(())
+}
+
+fn extract_zip(bytes: &[u8], dest: &Path) -> Result<(), TclPkgError> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes))
+        .map_err(|e| fetch_error(format!("cannot read zip archive: {e}")))?;
+    let mut total: u64 = 0;
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| fetch_error(format!("corrupt zip entry: {e}")))?;
+        let Some(name) = file.enclosed_name() else {
+            return Err(fetch_error(format!(
+                "zip member escapes target directory: {}",
+                file.name()
+            )));
+        };
+        let name_str = name.to_string_lossy().into_owned();
+        let target = safe_join(dest, &name_str)?;
+        // Skip symlinks (Unix mode S_IFLNK in the upper bits).
+        if let Some(mode) = file.unix_mode()
+            && mode & 0o170_000 == 0o120_000
+        {
+            continue;
+        }
+        if file.is_dir() {
+            std::fs::create_dir_all(&target)
+                .map_err(|e| fetch_error(format!("cannot create dir: {e}")))?;
+            continue;
+        }
+        total = total.saturating_add(file.size());
+        if total > MAX_EXTRACT_BYTES {
+            return Err(fetch_error(
+                "zip archive exceeds 256 MiB uncompressed limit (possible zip bomb)",
+            ));
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| fetch_error(format!("cannot create dir: {e}")))?;
+        }
+        let mut out = std::fs::File::create(&target)
+            .map_err(|e| fetch_error(format!("cannot write {}: {e}", target.display())))?;
+        std::io::copy(&mut file, &mut out)
+            .map_err(|e| fetch_error(format!("cannot extract {}: {e}", target.display())))?;
+    }
+    Ok(())
+}
+
+/// Move the contents of `staging` into `dest`, stripping a singular top-level
+/// directory (the common archive convention).
+fn strip_top_level(staging: &Path, dest: &Path) -> Result<(), TclPkgError> {
+    let children: Vec<PathBuf> = std::fs::read_dir(staging)
+        .map_err(|e| fetch_error(format!("cannot read staging dir: {e}")))?
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    let source = if children.len() == 1 && children[0].is_dir() {
+        children[0].clone()
+    } else {
+        staging.to_path_buf()
+    };
+    for entry in std::fs::read_dir(&source)
+        .map_err(|e| fetch_error(format!("cannot read extracted dir: {e}")))?
+        .flatten()
+    {
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        move_path(&from, &to)?;
+    }
+    let _ = std::fs::remove_dir_all(staging);
+    Ok(())
+}
+
+fn move_path(from: &Path, to: &Path) -> Result<(), TclPkgError> {
+    if std::fs::rename(from, to).is_ok() {
+        return Ok(());
+    }
+    // Cross-device fallback: copy then remove.
+    if from.is_dir() {
+        copy_dir(from, to).map_err(|e| fetch_error(format!("cannot move dir: {e}")))?;
+        let _ = std::fs::remove_dir_all(from);
+    } else {
+        std::fs::copy(from, to).map_err(|e| fetch_error(format!("cannot move file: {e}")))?;
+        let _ = std::fs::remove_file(from);
+    }
+    Ok(())
+}
+
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// Clone a git repository into `dest` and return the resolved commit SHA.
+///
+/// `rev` is a branch or tag (passed to `git clone --branch`). The `.git/`
+/// directory is removed afterwards so the worktree hashes cleanly.
+pub fn fetch_git(url: &str, dest: &Path, rev: Option<&str>) -> Result<String, TclPkgError> {
+    std::fs::create_dir_all(dest)
+        .map_err(|e| fetch_error(format!("cannot create {}: {e}", dest.display())))?;
+
+    let mut url = url.to_string();
+    let mut rev = rev.map(ToString::to_string);
+    if let Some(stripped) = url.strip_prefix("git+") {
+        url = stripped.to_string();
+    }
+    // Strip an @rev suffix when it follows a path segment or `.git`, but not an
+    // `ssh user@host` prefix.
+    if rev.is_none()
+        && let Some(last_at) = url.rfind('@')
+    {
+        let prefix = &url[..last_at];
+        if prefix.contains('/') || prefix.ends_with(".git") {
+            rev = Some(url[last_at + 1..].to_string());
+            url = prefix.to_string();
+        }
+    }
+
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(["clone", "--depth", "1"]);
+    if let Some(r) = &rev {
+        cmd.args(["--branch", r]);
+    }
+    cmd.arg(&url).arg(dest);
+    let output = cmd
+        .output()
+        .map_err(|e| fetch_error(format!("git not found: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(fetch_error(format!("git clone failed: {stderr}")));
+    }
+
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dest)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    let git_dir = dest.join(".git");
+    if git_dir.is_dir() {
+        let _ = std::fs::remove_dir_all(&git_dir);
+    }
+    Ok(sha)
+}
+
+/// Copy a local directory into `dest` (used by `replace` directives pointing at
+/// a local checkout).
+pub fn fetch_path(source: &str, dest: &Path) -> Result<(), TclPkgError> {
+    let src = Path::new(source);
+    if !src.is_dir() {
+        return Err(fetch_error(format!("local path not found: {source}")));
+    }
+    std::fs::create_dir_all(dest)
+        .map_err(|e| fetch_error(format!("cannot create {}: {e}", dest.display())))?;
+    copy_dir(src, dest).map_err(|e| fetch_error(format!("cannot copy local path: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_join_rejects_traversal() {
+        let root = Path::new("/tmp/x");
+        assert!(safe_join(root, "../evil").is_err());
+        assert!(safe_join(root, "/etc/passwd").is_err());
+        assert!(safe_join(root, "ok/file.tcl").is_ok());
+    }
+
+    #[test]
+    fn path_fetch_copies() {
+        let base = std::env::temp_dir().join(format!(
+            "tclpkg-fetch-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let src = base.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.tcl"), "set x 1\n").unwrap();
+        let dest = base.join("dest");
+        fetch_path(src.to_str().unwrap(), &dest).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.tcl")).unwrap(),
+            "set x 1\n"
+        );
+        assert!(fetch_path("/no/such/dir/xyz", &base.join("d2")).is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn extract_tar_strips_top_level() {
+        // Build a gzip tarball in memory with a singular top dir.
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let data = b"hello\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_path("pkg-1.0/a.tcl").unwrap();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, &data[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        std::io::Write::write_all(&mut gz, &tar_buf).unwrap();
+        let gz_bytes = gz.finish().unwrap();
+
+        let base = std::env::temp_dir().join(format!(
+            "tclpkg-tar-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let staging = base.join(".staging");
+        std::fs::create_dir_all(&staging).unwrap();
+        extract_tar(&gz_bytes, &staging, ".tar.gz").unwrap();
+        strip_top_level(&staging, &base).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(base.join("a.tcl")).unwrap(),
+            "hello\n"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}

--- a/rust/tcl-pkg/src/installer.rs
+++ b/rust/tcl-pkg/src/installer.rs
@@ -1,0 +1,264 @@
+//! Install orchestration — source resolution, fetch, CAS store, materialise.
+//!
+//! Faithful port of `tooling/tclpkg/installer.py`. `tcl pkg install` resolves
+//! the dependency graph, then for each resolved package this module turns a
+//! `name@version` into a concrete source, fetches it ([`crate::fetchers`]),
+//! ingests it into the content-addressable store ([`crate::cas`]), and
+//! materialises it into the project `lib/`. The lockfile records the exact
+//! source, integrity hash, size, and `provides`/`license` read back from the
+//! fetched package's own manifest.
+//!
+//! Source resolution order: a root `replace` directive, then a
+//! `require`/`dev-require` `-source URL`, then the registry's first source
+//! entry. When no source is determinable — or a fetch fails / the registry is
+//! unreachable — the caller keeps a placeholder lock entry and warns rather
+//! than aborting.
+
+// `.git` / `git+` are URL markers, not filesystem extensions, so
+// `Path::extension` would be the wrong tool here.
+#![allow(clippy::case_sensitive_file_extension_comparisons)]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::cas::{ContentAddressableStore, tree_size};
+use crate::errors::TclPkgError;
+use crate::fetchers::{fetch_git, fetch_path, fetch_tarball};
+use crate::lockfile::SourceSpec;
+use crate::registry::RegistryClient;
+
+/// Outcome of fetching + storing + reading one package.
+#[derive(Debug, Clone)]
+pub struct MaterialiseResult {
+    pub source: SourceSpec,
+    pub integrity: String,
+    pub size: i64,
+    pub provides: Vec<String>,
+    pub license: String,
+}
+
+fn classify(url: &str, rev: Option<&str>) -> SourceSpec {
+    if Path::new(url).is_dir() {
+        return SourceSpec::new("path", url);
+    }
+    if url.starts_with("git+") || url.ends_with(".git") || url.starts_with("git@") {
+        let mut spec = SourceSpec::new("git", url);
+        spec.rev = rev.map(ToString::to_string);
+        return spec;
+    }
+    SourceSpec::new("tarball", url)
+}
+
+/// Return the [`SourceSpec`] for `name@version`, or `None`.
+///
+/// `replaces`/`manifest_sources` map package name → source URL. The registry is
+/// consulted last and any registry error is swallowed into a `None` result so
+/// the caller can degrade gracefully.
+#[must_use]
+#[allow(clippy::implicit_hasher)] // callers always pass a std `HashMap`
+pub fn resolve_source(
+    name: &str,
+    version: &str,
+    replaces: &HashMap<String, String>,
+    manifest_sources: &HashMap<String, String>,
+    registry: Option<&mut RegistryClient>,
+) -> Option<SourceSpec> {
+    if let Some(url) = replaces.get(name) {
+        return Some(classify(url, Some(version)));
+    }
+    if let Some(url) = manifest_sources.get(name) {
+        return Some(classify(url, Some(version)));
+    }
+    if let Some(registry) = registry {
+        let entry = registry.lookup(name).ok().flatten()?;
+        if let Some(src) = entry.sources.first() {
+            if src.method == "git" || src.url.ends_with(".git") {
+                let mut spec = SourceSpec::new("git", &src.url);
+                spec.rev = Some(version.to_string());
+                return Some(spec);
+            }
+            return Some(SourceSpec::new("tarball", &src.url));
+        }
+    }
+    None
+}
+
+fn read_pkg_meta(root: &Path) -> (Vec<String>, String) {
+    let manifest_path = root.join("tclpkg.tcl");
+    if !manifest_path.is_file() {
+        return (Vec::new(), String::new());
+    }
+    match crate::manifest::load_manifest(&manifest_path) {
+        Ok(ast) => (ast.provides, ast.license),
+        Err(_) => (Vec::new(), String::new()),
+    }
+}
+
+/// A temporary directory removed on drop (no external `tempfile` dependency).
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Result<Self, TclPkgError> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("tclpkg-fetch-{}-{nanos}-{seq}", std::process::id()));
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| TclPkgError::new(format!("cannot create temp dir: {e}")))?;
+        Ok(TempDir(dir))
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Fetch `source` into a temp dir, ingest it into the CAS, read metadata.
+///
+/// Returns a [`MaterialiseResult`] with the (possibly rev-resolved) source,
+/// integrity hash, size, and package metadata. Errors on fetch/store failure.
+pub fn fetch_and_store(
+    source: &SourceSpec,
+    name: &str,
+    version: &str,
+    cas: &ContentAddressableStore,
+    timeout: u64,
+) -> Result<MaterialiseResult, TclPkgError> {
+    let tmp = TempDir::new()?;
+    let worktree = tmp.path().join("src");
+
+    let resolved_source = match source.kind.as_str() {
+        "path" => {
+            fetch_path(&source.url, &worktree)?;
+            source.clone()
+        }
+        "git" => {
+            let sha = fetch_git(&source.url, &worktree, source.rev.as_deref())?;
+            SourceSpec {
+                kind: "git".to_string(),
+                url: source.url.clone(),
+                subdir: source.subdir.clone(),
+                rev: if sha.is_empty() {
+                    source.rev.clone()
+                } else {
+                    Some(sha)
+                },
+            }
+        }
+        _ => {
+            fetch_tarball(&source.url, &worktree, timeout)?;
+            source.clone()
+        }
+    };
+
+    let integrity = cas.store(&worktree, name, version, None)?;
+    let size = i64::try_from(tree_size(&worktree)).unwrap_or(i64::MAX);
+    let (provides, license) = read_pkg_meta(&worktree);
+
+    Ok(MaterialiseResult {
+        source: resolved_source,
+        integrity,
+        size,
+        provides,
+        license,
+    })
+}
+
+/// Materialise a CAS entry into `lib_dir/<name>-<version>`.
+pub fn materialise(
+    cas: &ContentAddressableStore,
+    integrity: &str,
+    lib_dir: &Path,
+    name: &str,
+    version: &str,
+    symlink: bool,
+) -> Result<PathBuf, TclPkgError> {
+    let dest = lib_dir.join(format!("{name}-{version}"));
+    cas.materialise(integrity, &dest, symlink)?;
+    Ok(dest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "tclpkg-installer-{tag}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn classify_sources() {
+        assert_eq!(classify("https://x/p.tar.gz", None).kind, "tarball");
+        assert_eq!(classify("https://x/p.git", Some("1.0")).kind, "git");
+        assert_eq!(classify("git+https://x/p", None).kind, "git");
+        let dir = tmp("classify");
+        assert_eq!(classify(dir.to_str().unwrap(), None).kind, "path");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resolve_prefers_replace_then_source() {
+        let mut replaces = HashMap::new();
+        replaces.insert("a".to_string(), "https://r/a.tar.gz".to_string());
+        let mut sources = HashMap::new();
+        sources.insert("a".to_string(), "https://s/a.tar.gz".to_string());
+        sources.insert("b".to_string(), "https://s/b.git".to_string());
+        // replace wins for `a`
+        let sa = resolve_source("a", "1.0", &replaces, &sources, None).unwrap();
+        assert_eq!(sa.url, "https://r/a.tar.gz");
+        // manifest -source for `b`
+        let sb = resolve_source("b", "2.0", &replaces, &sources, None).unwrap();
+        assert_eq!(sb.kind, "git");
+        // unknown with no registry → None
+        assert!(resolve_source("c", "1.0", &replaces, &sources, None).is_none());
+    }
+
+    #[test]
+    fn fetch_store_materialise_roundtrip() {
+        let base = tmp("roundtrip");
+        // a local "package" to install
+        let pkg = base.join("pkgsrc");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("tclpkg.tcl"),
+            "package foo\nversion 1.0.0\nprovides foo::api\nlicense MIT\n",
+        )
+        .unwrap();
+        std::fs::write(pkg.join("foo.tcl"), "proc foo::hello {} { return hi }\n").unwrap();
+
+        let cas = ContentAddressableStore::new(&base.join("cache"));
+        let source = SourceSpec::new("path", pkg.to_str().unwrap());
+        let result = fetch_and_store(&source, "foo", "1.0.0", &cas, 60).unwrap();
+        assert!(result.integrity.starts_with("sha256-"));
+        assert!(result.size > 0);
+        assert_eq!(result.provides, vec!["foo::api"]);
+        assert_eq!(result.license, "MIT");
+
+        let lib = base.join("lib");
+        let dest = materialise(&cas, &result.integrity, &lib, "foo", "1.0.0", false).unwrap();
+        assert!(dest.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("foo.tcl")).unwrap(),
+            "proc foo::hello {} { return hi }\n"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}

--- a/rust/tcl-pkg/src/json.rs
+++ b/rust/tcl-pkg/src/json.rs
@@ -1,0 +1,112 @@
+//! Canonical JSON emitter.
+//!
+//! Reproduces Python `json.dumps(..., indent=2, sort_keys=True,
+//! ensure_ascii=False)`: object keys sorted alphabetically (recursively),
+//! 2-space indent, `": "` key separator, `,` item separator, no trailing
+//! whitespace. Callers append the final newline. This keeps the lockfile and
+//! `--json` output byte-identical with the Python implementation regardless of
+//! whether `serde_json`'s `preserve_order` feature is active workspace-wide.
+
+use serde_json::Value;
+
+/// Serialise `value` as canonical JSON (no trailing newline).
+#[must_use]
+pub fn canonical_json(value: &Value) -> String {
+    let mut out = String::new();
+    write_value(value, 0, &mut out);
+    out
+}
+
+fn push_indent(level: usize, out: &mut String) {
+    for _ in 0..level {
+        out.push_str("  ");
+    }
+}
+
+fn write_value(value: &Value, indent: usize, out: &mut String) {
+    match value {
+        Value::Null => out.push_str("null"),
+        Value::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        Value::Number(n) => out.push_str(&n.to_string()),
+        Value::String(s) => out.push_str(&escape_string(s)),
+        Value::Array(items) => {
+            if items.is_empty() {
+                out.push_str("[]");
+                return;
+            }
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push('\n');
+                push_indent(indent + 1, out);
+                write_value(item, indent + 1, out);
+            }
+            out.push('\n');
+            push_indent(indent, out);
+            out.push(']');
+        }
+        Value::Object(map) => {
+            if map.is_empty() {
+                out.push_str("{}");
+                return;
+            }
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, key) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push('\n');
+                push_indent(indent + 1, out);
+                out.push_str(&escape_string(key));
+                out.push_str(": ");
+                write_value(&map[key.as_str()], indent + 1, out);
+            }
+            out.push('\n');
+            push_indent(indent, out);
+            out.push('}');
+        }
+    }
+}
+
+/// Escape a string the way `serde_json` does, which matches Python's
+/// `ensure_ascii=False` for the ASCII identifiers/URLs in our data: `"` and `\`
+/// escaped, control characters as short forms or `\u00XX`, non-ASCII passed
+/// through, forward slash left unescaped.
+fn escape_string(s: &str) -> String {
+    serde_json::to_string(s).expect("string serialises")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn sorts_keys_recursively() {
+        let v = json!({"b": 1, "a": {"d": 2, "c": 3}});
+        assert_eq!(
+            canonical_json(&v),
+            "{\n  \"a\": {\n    \"c\": 3,\n    \"d\": 2\n  },\n  \"b\": 1\n}"
+        );
+    }
+
+    #[test]
+    fn empty_containers() {
+        assert_eq!(canonical_json(&json!({})), "{}");
+        assert_eq!(canonical_json(&json!([])), "[]");
+        assert_eq!(canonical_json(&json!({"a": []})), "{\n  \"a\": []\n}");
+    }
+
+    #[test]
+    fn null_and_bool() {
+        let v = json!({"x": null, "y": true, "z": false});
+        assert_eq!(
+            canonical_json(&v),
+            "{\n  \"x\": null,\n  \"y\": true,\n  \"z\": false\n}"
+        );
+    }
+}

--- a/rust/tcl-pkg/src/lib.rs
+++ b/rust/tcl-pkg/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cas;
 pub mod docker;
 pub mod errors;
 pub mod fetchers;
+pub mod installer;
 pub mod json;
 pub mod lockfile;
 pub mod manifest;

--- a/rust/tcl-pkg/src/lib.rs
+++ b/rust/tcl-pkg/src/lib.rs
@@ -1,0 +1,72 @@
+//! `tcl-pkg` — native Rust port of the `tclpkg` package manager.
+//!
+//! Faithful port of `tooling/tclpkg/` (manifest loader, MVS resolver, lockfile
+//! I/O, content-addressable store, source fetchers, registry client, virtual
+//! environments, and Dockerfile generation). The `tcl pkg` / `tcl venv` /
+//! `tcl docker` CLI verb groups in `tcl-cli` drive these modules; behaviour and
+//! on-disk formats match the Python implementation byte-for-byte.
+
+pub mod cas;
+pub mod docker;
+pub mod errors;
+pub mod fetchers;
+pub mod json;
+pub mod lockfile;
+pub mod manifest;
+pub mod registry;
+pub mod resolver;
+pub mod ui;
+pub mod venv;
+pub mod version;
+
+pub use errors::{Category, TclPkgError};
+pub use version::{Version, VersionError, max_version, parse_version};
+
+use std::path::PathBuf;
+
+/// Return the cache directory using platform-native conventions, mirroring
+/// `shared.user_config._cache_dir()`. `$XDG_CACHE_HOME` always wins; otherwise
+/// `%LOCALAPPDATA%/tcl-lsp/Cache` (native Windows), `~/Library/Caches/tcl-lsp`
+/// (macOS), or `~/.cache/tcl-lsp` (Linux/BSD/WSL/MSYS).
+#[must_use]
+pub fn cache_dir() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME")
+        && !xdg.is_empty()
+    {
+        return PathBuf::from(xdg).join("tcl-lsp");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            return PathBuf::from(local).join("tcl-lsp").join("Cache");
+        }
+    }
+    let home = home_dir();
+    #[cfg(target_os = "macos")]
+    {
+        return home.join("Library").join("Caches").join("tcl-lsp");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        home.join(".cache").join("tcl-lsp")
+    }
+}
+
+/// The discoverable venv pool directory (`~/.tcl-venvs`), mirroring
+/// `tcl venv list`'s home-pool scan.
+#[must_use]
+pub fn venv_pool_dir() -> PathBuf {
+    home_dir().join(".tcl-venvs")
+}
+
+fn home_dir() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home);
+    }
+    if let Some(profile) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(profile);
+    }
+    PathBuf::from(".")
+}

--- a/rust/tcl-pkg/src/lockfile.rs
+++ b/rust/tcl-pkg/src/lockfile.rs
@@ -1,0 +1,387 @@
+//! `tclpkg.lock` lockfile — canonical JSON representation.
+//!
+//! Faithful port of `tooling/tclpkg/lockfile.py`. The lockfile records the
+//! exact resolved dependency graph. Two invocations against the same manifest
+//! and registry snapshot produce byte-identical output (only the `generated`
+//! timestamp varies, and `--frozen` preserves it). Canonical JSON rules:
+//! 2-space indent, alphabetically sorted keys, LF endings, final newline,
+//! `packages[]` sorted by `(name, version)`.
+
+use std::path::Path;
+
+use chrono::Utc;
+use serde_json::{Value, json};
+
+use crate::errors::TclPkgError;
+use crate::json::canonical_json;
+
+/// Schema version — bumped only on incompatible lockfile changes.
+pub const LOCKFILE_VERSION: i64 = 1;
+
+/// Generator string embedded in the lockfile.
+const GENERATOR: &str = "tcl pkg";
+
+/// Where a package was fetched from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSpec {
+    pub kind: String, // "tarball" | "git" | "path"
+    pub url: String,
+    pub subdir: String,
+    pub rev: Option<String>,
+}
+
+impl SourceSpec {
+    #[must_use]
+    pub fn new(kind: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            url: url.into(),
+            subdir: String::new(),
+            rev: None,
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        json!({
+            "type": self.kind,
+            "url": self.url,
+            "subdir": self.subdir,
+            "rev": self.rev,
+        })
+    }
+
+    fn from_value(v: &Value) -> Self {
+        Self {
+            kind: str_field(v, "type", ""),
+            url: str_field(v, "url", ""),
+            subdir: str_field(v, "subdir", ""),
+            rev: v
+                .get("rev")
+                .and_then(|r| r.as_str().map(ToString::to_string)),
+        }
+    }
+}
+
+/// A single resolved package in the lockfile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockedPackage {
+    pub name: String,
+    pub version: String,
+    pub source: SourceSpec,
+    pub integrity: String,
+    pub size: i64,
+    pub requires: Vec<String>,
+    pub provides: Vec<String>,
+    pub license: String,
+    pub dev: bool,
+}
+
+impl LockedPackage {
+    fn to_value(&self) -> Value {
+        let mut provides = self.provides.clone();
+        provides.sort();
+        let mut requires = self.requires.clone();
+        requires.sort();
+        json!({
+            "dev": self.dev,
+            "integrity": self.integrity,
+            "license": self.license,
+            "name": self.name,
+            "provides": provides,
+            "requires": requires,
+            "size": self.size,
+            "source": self.source.to_value(),
+            "version": self.version,
+        })
+    }
+
+    fn from_value(v: &Value) -> Self {
+        Self {
+            name: str_field(v, "name", ""),
+            version: str_field(v, "version", ""),
+            source: SourceSpec::from_value(v.get("source").unwrap_or(&Value::Null)),
+            integrity: str_field(v, "integrity", ""),
+            size: v.get("size").and_then(Value::as_i64).unwrap_or(0),
+            requires: str_list(v, "requires"),
+            provides: str_list(v, "provides"),
+            license: str_field(v, "license", ""),
+            dev: v.get("dev").and_then(Value::as_bool).unwrap_or(false),
+        }
+    }
+}
+
+/// A `replace` directive that was applied during resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplaceEntry {
+    pub name: String,
+    pub from_version: String,
+    pub to_version: String,
+}
+
+impl ReplaceEntry {
+    fn to_value(&self) -> Value {
+        json!({"from": self.from_version, "name": self.name, "to": self.to_version})
+    }
+
+    fn from_value(v: &Value) -> Self {
+        Self {
+            name: str_field(v, "name", ""),
+            from_version: str_field(v, "from", ""),
+            to_version: str_field(v, "to", ""),
+        }
+    }
+}
+
+/// An `exclude` directive that was honoured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExcludeEntry {
+    pub name: String,
+    pub version: String,
+}
+
+impl ExcludeEntry {
+    fn to_value(&self) -> Value {
+        json!({"name": self.name, "version": self.version})
+    }
+
+    fn from_value(v: &Value) -> Self {
+        Self {
+            name: str_field(v, "name", ""),
+            version: str_field(v, "version", ""),
+        }
+    }
+}
+
+/// In-memory representation of a `tclpkg.lock` file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockFile {
+    pub version: i64,
+    pub name: String,
+    pub tcl: String,
+    pub generated: String,
+    pub generator: String,
+    pub root_hash: String,
+    pub packages: Vec<LockedPackage>,
+    pub replaces: Vec<ReplaceEntry>,
+    pub excludes: Vec<ExcludeEntry>,
+}
+
+impl Default for LockFile {
+    fn default() -> Self {
+        Self {
+            version: LOCKFILE_VERSION,
+            name: String::new(),
+            tcl: ">=8.6".to_string(),
+            generated: String::new(),
+            generator: GENERATOR.to_string(),
+            root_hash: String::new(),
+            packages: Vec::new(),
+            replaces: Vec::new(),
+            excludes: Vec::new(),
+        }
+    }
+}
+
+impl LockFile {
+    /// A fresh lockfile for `name` with the given Tcl constraint.
+    #[must_use]
+    pub fn new(name: impl Into<String>, tcl: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            tcl: tcl.into(),
+            ..Self::default()
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        let mut excludes: Vec<&ExcludeEntry> = self.excludes.iter().collect();
+        excludes.sort_by(|a, b| a.name.cmp(&b.name));
+        let mut packages: Vec<&LockedPackage> = self.packages.iter().collect();
+        packages.sort_by(|a, b| (&a.name, &a.version).cmp(&(&b.name, &b.version)));
+        let mut replaces: Vec<&ReplaceEntry> = self.replaces.iter().collect();
+        replaces.sort_by(|a, b| a.name.cmp(&b.name));
+        json!({
+            "excludes": excludes.iter().map(|e| e.to_value()).collect::<Vec<_>>(),
+            "generated": self.generated,
+            "generator": self.generator,
+            "name": self.name,
+            "packages": packages.iter().map(|p| p.to_value()).collect::<Vec<_>>(),
+            "replaces": replaces.iter().map(|r| r.to_value()).collect::<Vec<_>>(),
+            "root_hash": self.root_hash,
+            "tcl": self.tcl,
+            "version": self.version,
+        })
+    }
+
+    fn from_value(v: &Value) -> Self {
+        let mut lf = LockFile {
+            version: v
+                .get("version")
+                .and_then(Value::as_i64)
+                .unwrap_or(LOCKFILE_VERSION),
+            name: str_field(v, "name", ""),
+            tcl: str_field(v, "tcl", ">=8.6"),
+            generated: str_field(v, "generated", ""),
+            generator: str_field(v, "generator", GENERATOR),
+            root_hash: str_field(v, "root_hash", ""),
+            ..LockFile::default()
+        };
+        if let Some(arr) = v.get("packages").and_then(Value::as_array) {
+            lf.packages = arr.iter().map(LockedPackage::from_value).collect();
+        }
+        if let Some(arr) = v.get("replaces").and_then(Value::as_array) {
+            lf.replaces = arr.iter().map(ReplaceEntry::from_value).collect();
+        }
+        if let Some(arr) = v.get("excludes").and_then(Value::as_array) {
+            lf.excludes = arr.iter().map(ExcludeEntry::from_value).collect();
+        }
+        lf
+    }
+
+    /// Return the locked entry for `name`, if any.
+    #[must_use]
+    pub fn lookup(&self, name: &str) -> Option<&LockedPackage> {
+        self.packages.iter().find(|p| p.name == name)
+    }
+
+    /// Set `generated` to now (UTC, ISO-8601, second precision, `Z` suffix).
+    pub fn stamp(&mut self) {
+        self.generated = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    }
+}
+
+fn str_field(v: &Value, key: &str, default: &str) -> String {
+    v.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn str_list(v: &Value, key: &str) -> Vec<String> {
+    v.get(key)
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(ToString::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Produce canonical JSON for a lockfile, including the final newline.
+#[must_use]
+pub fn serialise(lockfile: &LockFile) -> String {
+    let mut text = canonical_json(&lockfile.to_value());
+    text.push('\n');
+    text
+}
+
+/// Parse a lockfile JSON string.
+pub fn deserialise(text: &str) -> Result<LockFile, TclPkgError> {
+    let data: Value = serde_json::from_str(text)
+        .map_err(|exc| TclPkgError::new(format!("invalid lockfile JSON: {exc}")))?;
+    if !data.is_object() {
+        return Err(TclPkgError::new("lockfile must be a JSON object"));
+    }
+    if let Some(schema_version) = data.get("version").and_then(Value::as_i64)
+        && schema_version > LOCKFILE_VERSION
+    {
+        return Err(TclPkgError::new(format!(
+            "lockfile schema version {schema_version} is newer than supported \
+                 ({LOCKFILE_VERSION}); upgrade tcl-lsp"
+        )));
+    }
+    Ok(LockFile::from_value(&data))
+}
+
+/// Write the lockfile to disk atomically (temp file then rename).
+pub fn write_lockfile(lockfile: &LockFile, path: impl AsRef<Path>) -> Result<(), TclPkgError> {
+    let dest = path.as_ref();
+    let text = serialise(lockfile);
+    let tmp = dest.with_extension("lock.tmp");
+    std::fs::write(&tmp, &text)
+        .map_err(|e| TclPkgError::new(format!("cannot write lockfile {}: {e}", tmp.display())))?;
+    std::fs::rename(&tmp, dest).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        TclPkgError::new(format!("cannot write lockfile {}: {e}", dest.display()))
+    })?;
+    Ok(())
+}
+
+/// Read a lockfile from disk.
+pub fn read_lockfile(path: impl AsRef<Path>) -> Result<LockFile, TclPkgError> {
+    let file_path = path.as_ref();
+    if !file_path.is_file() {
+        return Err(TclPkgError::manifest(
+            format!("lockfile not found: {}", file_path.display()),
+            None,
+            None,
+            Some("run 'tcl pkg install' to create one".to_string()),
+        ));
+    }
+    let text = std::fs::read_to_string(file_path)
+        .map_err(|e| TclPkgError::new(format!("cannot read lockfile: {e}")))?;
+    deserialise(&text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> LockFile {
+        let mut lf = LockFile::new("myapp", ">=8.6");
+        lf.generated = "2024-01-01T00:00:00Z".to_string();
+        lf.packages.push(LockedPackage {
+            name: "json".to_string(),
+            version: "1.3.5".to_string(),
+            source: SourceSpec::new("tarball", "https://example.org/json.tar.gz"),
+            integrity: "sha256-abc".to_string(),
+            size: 0,
+            requires: vec!["http@2.0".to_string()],
+            provides: vec![],
+            license: "MIT".to_string(),
+            dev: false,
+        });
+        lf
+    }
+
+    #[test]
+    fn round_trips() {
+        let lf = sample();
+        let text = serialise(&lf);
+        let parsed = deserialise(&text).unwrap();
+        assert_eq!(parsed.name, "myapp");
+        assert_eq!(parsed.packages.len(), 1);
+        assert_eq!(parsed.packages[0].version, "1.3.5");
+        // Re-serialising is byte-stable.
+        assert_eq!(serialise(&parsed), text);
+    }
+
+    #[test]
+    fn canonical_shape() {
+        let lf = sample();
+        let text = serialise(&lf);
+        assert!(text.ends_with('\n'));
+        // Keys are alphabetically sorted: excludes < generated < ... < version.
+        let excludes_pos = text.find("\"excludes\"").unwrap();
+        let generated_pos = text.find("\"generated\"").unwrap();
+        let version_pos = text.rfind("\"version\"").unwrap();
+        assert!(excludes_pos < generated_pos);
+        assert!(generated_pos < version_pos);
+        // 2-space indent on the top-level keys.
+        assert!(text.contains("\n  \"name\": \"myapp\""));
+    }
+
+    #[test]
+    fn rejects_newer_schema() {
+        let err = deserialise("{\"version\": 999}").unwrap_err();
+        assert!(err.to_string().contains("newer than supported"));
+    }
+
+    #[test]
+    fn lookup_works() {
+        let lf = sample();
+        assert_eq!(lf.lookup("json").unwrap().version, "1.3.5");
+        assert!(lf.lookup("missing").is_none());
+    }
+}

--- a/rust/tcl-pkg/src/manifest.rs
+++ b/rust/tcl-pkg/src/manifest.rs
@@ -1,0 +1,657 @@
+//! `tclpkg.tcl` manifest loader.
+//!
+//! Faithful port of `tooling/tclpkg/manifest.py`. The manifest is a tiny Tcl
+//! file evaluated under a whitelist of 13 directives; any other command is
+//! refused with `command not permitted in safe mode: <cmd>`, exactly as the
+//! Python loader's sandboxed `TclInterp(safe=True)` does. Because manifests are
+//! pure data (no variable/command substitution), this port parses the script
+//! into commands and words using Tcl grouping rules (braces, quotes,
+//! backslash, comments, semicolons) and dispatches each directive directly —
+//! no VM required.
+
+use std::path::Path;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::errors::TclPkgError;
+use crate::version::Version;
+
+// SPDX-style licence identifier, lightly validated.
+static SPDX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[A-Za-z0-9.\-+ ]+$").expect("spdx regex compiles"));
+
+// Tcl runtime constraint syntax: optional operator + semver-ish version.
+static TCL_CONSTRAINT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^\s*(>=|>|==|=|<=|<)?\s*([0-9][0-9a-zA-Z.+\-]*)\s*$")
+        .expect("constraint regex compiles")
+});
+
+const DIRECTIVES: &[&str] = &[
+    "package",
+    "version",
+    "description",
+    "license",
+    "author",
+    "homepage",
+    "tcl",
+    "require",
+    "dev-require",
+    "replace",
+    "exclude",
+    "provides",
+    "entry",
+];
+
+/// A single `require` / `dev-require` entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Requirement {
+    pub name: String,
+    pub minimum: Version,
+    pub source_url: Option<String>,
+    pub dev: bool,
+}
+
+/// A single `replace` directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Replacement {
+    pub name: String,
+    pub version: Version,
+    pub source_url: String,
+}
+
+/// A single `exclude` directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Exclusion {
+    pub name: String,
+    pub version: Version,
+}
+
+/// Parsed, validated representation of a `tclpkg.tcl` manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestAst {
+    pub name: String,
+    pub version: Option<Version>,
+    pub description: String,
+    pub license: String,
+    pub authors: Vec<String>,
+    pub homepage: String,
+    pub tcl_constraint: String,
+    pub requires: Vec<Requirement>,
+    pub dev_requires: Vec<Requirement>,
+    pub replaces: Vec<Replacement>,
+    pub excludes: Vec<Exclusion>,
+    pub provides: Vec<String>,
+    pub entry: String,
+    pub path: String,
+}
+
+impl Default for ManifestAst {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            version: None,
+            description: String::new(),
+            license: String::new(),
+            authors: Vec::new(),
+            homepage: String::new(),
+            tcl_constraint: ">=8.6".to_string(),
+            requires: Vec::new(),
+            dev_requires: Vec::new(),
+            replaces: Vec::new(),
+            excludes: Vec::new(),
+            provides: Vec::new(),
+            entry: String::new(),
+            path: String::new(),
+        }
+    }
+}
+
+/// Evaluate a manifest source string and return the AST.
+pub fn load_manifest_text(source: &str, path: Option<&str>) -> Result<ManifestAst, TclPkgError> {
+    let mut ast = ManifestAst {
+        path: path.unwrap_or("").to_string(),
+        ..ManifestAst::default()
+    };
+
+    let commands = parse_script(source).map_err(|m| manifest_err(&m, path))?;
+    for command in commands {
+        if command.is_empty() {
+            continue;
+        }
+        let name = &command[0];
+        if !DIRECTIVES.contains(&name.as_str()) {
+            return Err(manifest_err(
+                &format!("command not permitted in safe mode: {name}"),
+                path,
+            ));
+        }
+        let args = &command[1..];
+        dispatch(&mut ast, name, args).map_err(|m| manifest_err(&m, path))?;
+    }
+
+    validate(&ast, path)?;
+    Ok(ast)
+}
+
+/// Read a manifest file from disk and evaluate it.
+pub fn load_manifest(path: impl AsRef<Path>) -> Result<ManifestAst, TclPkgError> {
+    let file_path = path.as_ref();
+    let text = match std::fs::read_to_string(file_path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(TclPkgError::manifest(
+                format!("manifest not found: {}", file_path.display()),
+                None,
+                None,
+                Some("run 'tcl pkg init' to create one".to_string()),
+            ));
+        }
+        Err(e) => {
+            return Err(TclPkgError::manifest(
+                format!("cannot read manifest {}: {e}", file_path.display()),
+                None,
+                None,
+                None,
+            ));
+        }
+    };
+    load_manifest_text(&text, Some(&file_path.to_string_lossy()))
+}
+
+fn manifest_err(message: &str, path: Option<&str>) -> TclPkgError {
+    TclPkgError::manifest(message, path, None, None)
+}
+
+#[allow(clippy::too_many_lines)] // one arm per directive; mirrors the Python loader
+fn dispatch(ast: &mut ManifestAst, name: &str, args: &[String]) -> Result<(), String> {
+    match name {
+        "package" => {
+            require_arity("package", args, 1, 1)?;
+            if !ast.name.is_empty() {
+                return Err("package directive already set".to_string());
+            }
+            ast.name.clone_from(&args[0]);
+        }
+        "version" => {
+            require_arity("version", args, 1, 1)?;
+            ast.version = Some(parse_ver("version", &args[0])?);
+        }
+        "description" => {
+            require_arity("description", args, 1, 1)?;
+            ast.description.clone_from(&args[0]);
+        }
+        "license" => {
+            require_arity("license", args, 1, 1)?;
+            let value = &args[0];
+            if !SPDX_RE.is_match(value) {
+                return Err(format!("license: invalid SPDX-style identifier: '{value}'"));
+            }
+            ast.license.clone_from(value);
+        }
+        "author" => {
+            require_arity("author", args, 1, 1)?;
+            ast.authors.push(args[0].clone());
+        }
+        "homepage" => {
+            require_arity("homepage", args, 1, 1)?;
+            ast.homepage.clone_from(&args[0]);
+        }
+        "tcl" => {
+            require_arity("tcl", args, 1, 1)?;
+            let raw = &args[0];
+            let Some(caps) = TCL_CONSTRAINT_RE.captures(raw) else {
+                return Err(format!("tcl: invalid version constraint: '{raw}'"));
+            };
+            let _ = caps;
+            let trimmed = raw.trim_start();
+            let has_op = [">=", ">", "==", "=", "<=", "<"]
+                .iter()
+                .any(|op| trimmed.starts_with(op));
+            ast.tcl_constraint = if has_op {
+                raw.clone()
+            } else {
+                format!(">={}", raw.trim())
+            };
+        }
+        "require" => {
+            require_arity("require", args, 2, 4)?;
+            let (remainder, source) = parse_source_option(args);
+            if remainder.len() != 2 {
+                return Err(
+                    "wrong # args: \"require\" expects name, minimum, ?-source URL?".to_string(),
+                );
+            }
+            ast.requires.push(Requirement {
+                name: remainder[0].clone(),
+                minimum: parse_ver("require", &remainder[1])?,
+                source_url: source,
+                dev: false,
+            });
+        }
+        "dev-require" => {
+            require_arity("dev-require", args, 2, 4)?;
+            let (remainder, source) = parse_source_option(args);
+            if remainder.len() != 2 {
+                return Err(
+                    "wrong # args: \"dev-require\" expects name, minimum, ?-source URL?"
+                        .to_string(),
+                );
+            }
+            ast.dev_requires.push(Requirement {
+                name: remainder[0].clone(),
+                minimum: parse_ver("dev-require", &remainder[1])?,
+                source_url: source,
+                dev: true,
+            });
+        }
+        "replace" => {
+            require_arity("replace", args, 3, 3)?;
+            ast.replaces.push(Replacement {
+                name: args[0].clone(),
+                version: parse_ver("replace", &args[1])?,
+                source_url: args[2].clone(),
+            });
+        }
+        "exclude" => {
+            require_arity("exclude", args, 2, 2)?;
+            ast.excludes.push(Exclusion {
+                name: args[0].clone(),
+                version: parse_ver("exclude", &args[1])?,
+            });
+        }
+        "provides" => {
+            require_arity("provides", args, 1, 1)?;
+            ast.provides.push(args[0].clone());
+        }
+        "entry" => {
+            require_arity("entry", args, 1, 1)?;
+            ast.entry.clone_from(&args[0]);
+        }
+        _ => unreachable!("dispatch only called for whitelisted directives"),
+    }
+    Ok(())
+}
+
+fn require_arity(
+    name: &str,
+    args: &[String],
+    at_least: usize,
+    at_most: usize,
+) -> Result<(), String> {
+    let count = args.len();
+    if count < at_least || count > at_most {
+        let expected = if at_least == at_most {
+            format!("{at_least} arg(s)")
+        } else {
+            format!("between {at_least} and {at_most} args")
+        };
+        return Err(format!(
+            "wrong # args: \"{name}\" expects {expected}, got {count}"
+        ));
+    }
+    Ok(())
+}
+
+fn parse_ver(name: &str, raw: &str) -> Result<Version, String> {
+    Version::parse(raw).map_err(|e| format!("{name}: {e}"))
+}
+
+fn parse_source_option(args: &[String]) -> (Vec<String>, Option<String>) {
+    if args.len() >= 2 && args[args.len() - 2] == "-source" {
+        let remainder = args[..args.len() - 2].to_vec();
+        let source = args[args.len() - 1].clone();
+        (remainder, Some(source))
+    } else {
+        (args.to_vec(), None)
+    }
+}
+
+fn validate(ast: &ManifestAst, path: Option<&str>) -> Result<(), TclPkgError> {
+    if ast.name.is_empty() {
+        return Err(manifest_err(
+            "manifest missing required 'package' directive",
+            path,
+        ));
+    }
+    if ast.version.is_none() {
+        return Err(manifest_err(
+            "manifest missing required 'version' directive",
+            path,
+        ));
+    }
+    let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for req in &ast.requires {
+        seen.insert(req.name.as_str(), "require");
+    }
+    for req in &ast.dev_requires {
+        if seen.contains_key(req.name.as_str()) {
+            return Err(manifest_err(
+                &format!(
+                    "package '{}' declared both as require and dev-require",
+                    req.name
+                ),
+                path,
+            ));
+        }
+        seen.insert(req.name.as_str(), "dev-require");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tcl script parsing (commands + words; no substitution)
+// ---------------------------------------------------------------------------
+
+/// Split a manifest script into commands, each a list of words, applying Tcl
+/// grouping rules (braces, quotes, backslash, `#` comments, `;`/newline command
+/// separators) but no variable/command substitution.
+fn parse_script(src: &str) -> Result<Vec<Vec<String>>, String> {
+    let chars: Vec<char> = src.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    let mut commands = Vec::new();
+
+    loop {
+        // Skip blank lines / leading separators between commands.
+        while i < len && matches!(chars[i], ' ' | '\t' | '\n' | '\r' | ';') {
+            i += 1;
+        }
+        if i >= len {
+            break;
+        }
+        // Comment runs to end of line (backslash-newline continues it).
+        if chars[i] == '#' {
+            while i < len {
+                if chars[i] == '\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '\n' {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        let mut words = Vec::new();
+        loop {
+            while i < len && matches!(chars[i], ' ' | '\t') {
+                i += 1;
+            }
+            if i >= len {
+                break;
+            }
+            match chars[i] {
+                '\n' | '\r' | ';' => {
+                    i += 1;
+                    break;
+                }
+                '{' => {
+                    let word = parse_brace(&chars, &mut i)?;
+                    words.push(word);
+                }
+                '"' => {
+                    let word = parse_quoted(&chars, &mut i)?;
+                    words.push(word);
+                }
+                _ => {
+                    let word = parse_bare(&chars, &mut i);
+                    words.push(word);
+                }
+            }
+        }
+        if !words.is_empty() {
+            commands.push(words);
+        }
+    }
+    Ok(commands)
+}
+
+fn parse_brace(chars: &[char], i: &mut usize) -> Result<String, String> {
+    let len = chars.len();
+    let mut depth = 1;
+    *i += 1; // consume '{'
+    let mut value = String::new();
+    while *i < len {
+        let c = chars[*i];
+        if c == '\\' && *i + 1 < len {
+            value.push('\\');
+            value.push(chars[*i + 1]);
+            *i += 2;
+            continue;
+        }
+        if c == '{' {
+            depth += 1;
+            value.push(c);
+            *i += 1;
+        } else if c == '}' {
+            depth -= 1;
+            if depth == 0 {
+                *i += 1;
+                return Ok(value);
+            }
+            value.push(c);
+            *i += 1;
+        } else {
+            value.push(c);
+            *i += 1;
+        }
+    }
+    Err("missing close-brace".to_string())
+}
+
+fn parse_quoted(chars: &[char], i: &mut usize) -> Result<String, String> {
+    let len = chars.len();
+    *i += 1; // consume '"'
+    let mut raw = String::new();
+    while *i < len {
+        let c = chars[*i];
+        if c == '"' {
+            *i += 1;
+            return Ok(tcl_syntax::backslash::decode(&raw).into_owned());
+        }
+        if c == '\\' && *i + 1 < len {
+            raw.push('\\');
+            raw.push(chars[*i + 1]);
+            *i += 2;
+            continue;
+        }
+        raw.push(c);
+        *i += 1;
+    }
+    Err("missing \"".to_string())
+}
+
+fn parse_bare(chars: &[char], i: &mut usize) -> String {
+    let len = chars.len();
+    let mut raw = String::new();
+    while *i < len {
+        let c = chars[*i];
+        if matches!(c, ' ' | '\t' | '\n' | '\r' | ';') {
+            break;
+        }
+        if c == '\\' && *i + 1 < len {
+            raw.push('\\');
+            raw.push(chars[*i + 1]);
+            *i += 2;
+            continue;
+        }
+        raw.push(c);
+        *i += 1;
+    }
+    tcl_syntax::backslash::decode(&raw).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load(src: &str) -> Result<ManifestAst, TclPkgError> {
+        load_manifest_text(src, None)
+    }
+
+    #[test]
+    fn minimal_manifest() {
+        let ast = load("package myapp\nversion 1.0.0\n").unwrap();
+        assert_eq!(ast.name, "myapp");
+        assert_eq!(ast.version, Some(Version::parse("1.0.0").unwrap()));
+        assert_eq!(ast.tcl_constraint, ">=8.6");
+        assert!(ast.requires.is_empty());
+    }
+
+    #[test]
+    fn missing_required_fields() {
+        assert!(
+            load("version 1.0.0\n")
+                .unwrap_err()
+                .to_string()
+                .contains("required 'package'")
+        );
+        assert!(
+            load("package myapp\n")
+                .unwrap_err()
+                .to_string()
+                .contains("required 'version'")
+        );
+        assert!(load("").is_err());
+    }
+
+    #[test]
+    fn duplicate_package() {
+        let err = load("package a\npackage b\nversion 1.0.0\n").unwrap_err();
+        assert!(err.to_string().contains("already set"));
+    }
+
+    #[test]
+    fn require_directive() {
+        let ast = load("package myapp\nversion 1.0.0\nrequire json 1.3.5\n").unwrap();
+        assert_eq!(ast.requires.len(), 1);
+        assert_eq!(ast.requires[0].name, "json");
+        assert_eq!(ast.requires[0].minimum, Version::parse("1.3.5").unwrap());
+        assert!(ast.requires[0].source_url.is_none());
+
+        let ast = load(
+            "package myapp\nversion 1.0.0\nrequire json 1.3.5 -source https://example.org/json.tar.gz\n",
+        )
+        .unwrap();
+        assert_eq!(
+            ast.requires[0].source_url.as_deref(),
+            Some("https://example.org/json.tar.gz")
+        );
+    }
+
+    #[test]
+    fn dev_require_and_conflict() {
+        let ast = load("package myapp\nversion 1.0.0\ndev-require tcltest 2.5\n").unwrap();
+        assert!(ast.requires.is_empty());
+        assert_eq!(ast.dev_requires.len(), 1);
+        assert!(ast.dev_requires[0].dev);
+
+        let err = load("package myapp\nversion 1.0.0\nrequire json 1.0\ndev-require json 1.0\n")
+            .unwrap_err();
+        assert!(err.to_string().contains("both as require and dev-require"));
+    }
+
+    #[test]
+    fn require_invalid_version() {
+        let err = load("package myapp\nversion 1.0.0\nrequire json garbage\n").unwrap_err();
+        assert!(err.to_string().contains("invalid version"));
+    }
+
+    #[test]
+    fn replace_exclude() {
+        let ast =
+            load("package a\nversion 1.0.0\nreplace json 1.4.0 https://example.org/json.tar.gz\n")
+                .unwrap();
+        assert_eq!(ast.replaces[0].name, "json");
+        assert_eq!(
+            ast.replaces[0].source_url,
+            "https://example.org/json.tar.gz"
+        );
+
+        let ast = load("package a\nversion 1.0.0\nexclude http 2.9.7\n").unwrap();
+        assert_eq!(ast.excludes[0].name, "http");
+        assert_eq!(ast.excludes[0].version, Version::parse("2.9.7").unwrap());
+    }
+
+    #[test]
+    fn tcl_constraint() {
+        assert_eq!(
+            load("package a\nversion 1.0.0\ntcl >=9.0\n")
+                .unwrap()
+                .tcl_constraint,
+            ">=9.0"
+        );
+        assert_eq!(
+            load("package a\nversion 1.0.0\ntcl 8.6\n")
+                .unwrap()
+                .tcl_constraint,
+            ">=8.6"
+        );
+        assert!(
+            load("package a\nversion 1.0.0\ntcl @@@\n")
+                .unwrap_err()
+                .to_string()
+                .contains("invalid version constraint")
+        );
+    }
+
+    #[test]
+    fn metadata_braces_and_quotes() {
+        let ast = load(
+            "package a\nversion 1.0.0\ndescription {Example}\nlicense MIT\nhomepage https://example.org\n",
+        )
+        .unwrap();
+        assert_eq!(ast.description, "Example");
+        assert_eq!(ast.license, "MIT");
+        assert_eq!(ast.homepage, "https://example.org");
+
+        let ast =
+            load("package a\nversion 1.0.0\nauthor {Alice <a@x>}\nauthor {Bob <b@x>}\n").unwrap();
+        assert_eq!(ast.authors, vec!["Alice <a@x>", "Bob <b@x>"]);
+
+        let ast = load("package a\nversion 1.0.0\ndescription \"A test package\"\n").unwrap();
+        assert_eq!(ast.description, "A test package");
+
+        let ast = load(
+            "package a\nversion 1.0.0\nprovides a::serve\nprovides a::client\nentry main.tcl\n",
+        )
+        .unwrap();
+        assert_eq!(ast.provides, vec!["a::serve", "a::client"]);
+        assert_eq!(ast.entry, "main.tcl");
+    }
+
+    #[test]
+    fn license_rejects_garbage() {
+        let err = load("package a\nversion 1.0.0\nlicense <bad>\n").unwrap_err();
+        assert!(err.to_string().contains("invalid SPDX"));
+    }
+
+    #[test]
+    fn safe_mode_refuses_forbidden() {
+        for forbidden in [
+            "exec ls /",
+            "open /etc/passwd",
+            "source /tmp/x.tcl",
+            "puts stderr hi",
+            "file delete /tmp/x",
+            "socket localhost 80",
+        ] {
+            let body = format!("package a\nversion 1.0.0\n{forbidden}\n");
+            let err = load(&body).unwrap_err();
+            assert!(
+                err.to_string().contains("not permitted in safe mode"),
+                "expected safe-mode rejection for {forbidden:?}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn comments_and_semicolons() {
+        let ast = load("# a comment\npackage a ; version 1.0.0\n# trailing\n").unwrap();
+        assert_eq!(ast.name, "a");
+        assert_eq!(ast.version, Some(Version::parse("1.0.0").unwrap()));
+    }
+}

--- a/rust/tcl-pkg/src/registry.rs
+++ b/rust/tcl-pkg/src/registry.rs
@@ -1,0 +1,330 @@
+//! tcltk-pkgs registry client with TTL-based caching.
+//!
+//! Faithful port of `tooling/tclpkg/registry.py`. Fetches the upstream
+//! `packages.json` discovery metadata, caches it under
+//! `<cache_dir>/tclpkg/registry/`, and respects a 24-hour TTL with conditional
+//! GET (`If-None-Match` / `304 Not Modified`). Offline mode reads the cache
+//! only.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use crate::errors::TclPkgError;
+
+const DEFAULT_REGISTRY_URL: &str =
+    "https://raw.githubusercontent.com/tcltk-pkgs/registry/main/packages.json";
+
+const TTL: Duration = Duration::from_hours(24);
+const MAX_BODY: u64 = 64 * 1024 * 1024;
+
+/// One source entry inside a registry package.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RegistrySource {
+    pub url: String,
+    pub method: String,
+    pub web: String,
+    pub author: String,
+    pub license: String,
+    pub extension: bool,
+}
+
+/// One package entry from `packages.json`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RegistryEntry {
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    pub sources: Vec<RegistrySource>,
+}
+
+fn parse_entries(data: &Value) -> Vec<RegistryEntry> {
+    let Some(items) = data.as_array() else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for item in items {
+        if !item.is_object() {
+            continue;
+        }
+        let mut sources = Vec::new();
+        if let Some(arr) = item.get("sources").and_then(Value::as_array) {
+            for s in arr {
+                if s.is_object() {
+                    sources.push(RegistrySource {
+                        url: str_field(s, "url"),
+                        method: str_field(s, "method"),
+                        web: str_field(s, "web"),
+                        author: str_field(s, "author"),
+                        license: str_field(s, "license"),
+                        extension: s.get("extension").and_then(Value::as_bool).unwrap_or(false),
+                    });
+                }
+            }
+        }
+        entries.push(RegistryEntry {
+            name: str_field(item, "name"),
+            description: str_field(item, "description"),
+            tags: item
+                .get("tags")
+                .and_then(Value::as_array)
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|t| t.as_str().map(ToString::to_string))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            sources,
+        });
+    }
+    entries
+}
+
+fn str_field(v: &Value, key: &str) -> String {
+    v.get(key).and_then(Value::as_str).unwrap_or("").to_string()
+}
+
+/// Fetch, cache, and query the tcltk-pkgs package registry.
+pub struct RegistryClient {
+    dir: PathBuf,
+    url: String,
+    offline: bool,
+    entries: Option<Vec<RegistryEntry>>,
+}
+
+impl RegistryClient {
+    /// Construct a client rooted at `cache_dir`, optionally pinned to offline.
+    #[must_use]
+    pub fn new(cache_dir: &Path, offline: bool) -> Self {
+        Self {
+            dir: cache_dir.join("tclpkg").join("registry"),
+            url: DEFAULT_REGISTRY_URL.to_string(),
+            offline,
+            entries: None,
+        }
+    }
+
+    /// Override the registry URL (used in tests).
+    #[must_use]
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.url = url.into();
+        self
+    }
+
+    fn cached_path(&self) -> PathBuf {
+        self.dir.join("packages.json")
+    }
+    fn etag_path(&self) -> PathBuf {
+        self.dir.join("packages.json.etag")
+    }
+    fn fetched_path(&self) -> PathBuf {
+        self.dir.join("fetched_at")
+    }
+
+    fn is_fresh(&self) -> bool {
+        let Ok(text) = std::fs::read_to_string(self.fetched_path()) else {
+            return false;
+        };
+        let Ok(ts) = DateTime::parse_from_rfc3339(text.trim()) else {
+            return false;
+        };
+        let elapsed = Utc::now().signed_duration_since(ts.with_timezone(&Utc));
+        elapsed.to_std().is_ok_and(|d| d < TTL)
+    }
+
+    fn load_cached(&self) -> Result<Vec<RegistryEntry>, TclPkgError> {
+        let cached = self.cached_path();
+        if !cached.is_file() {
+            return Err(TclPkgError::registry(
+                "no cached registry and offline mode is active",
+                Some("run 'tcl pkg search' with network access first".to_string()),
+            ));
+        }
+        let text = std::fs::read_to_string(&cached)
+            .map_err(|e| TclPkgError::registry(format!("cannot read registry cache: {e}"), None))?;
+        let data: Value = serde_json::from_str(&text)
+            .map_err(|e| TclPkgError::registry(format!("corrupt registry cache: {e}"), None))?;
+        Ok(parse_entries(&data))
+    }
+
+    fn write_cache(&self, body: &[u8], etag: &str) {
+        let _ = std::fs::create_dir_all(&self.dir);
+        let _ = std::fs::write(self.cached_path(), body);
+        let _ = std::fs::write(self.etag_path(), etag);
+        let _ = std::fs::write(self.fetched_path(), Utc::now().to_rfc3339());
+    }
+
+    fn touch_fetched(&self) {
+        let _ = std::fs::create_dir_all(&self.dir);
+        let _ = std::fs::write(self.fetched_path(), Utc::now().to_rfc3339());
+    }
+
+    /// Return all registry entries, fetching/caching as needed.
+    pub fn fetch(&mut self, force: bool) -> Result<Vec<RegistryEntry>, TclPkgError> {
+        if let Some(entries) = &self.entries
+            && !force
+        {
+            return Ok(entries.clone());
+        }
+
+        if self.offline {
+            let entries = self.load_cached()?;
+            self.entries = Some(entries.clone());
+            return Ok(entries);
+        }
+
+        let cached = self.cached_path();
+        if !force && self.is_fresh() && cached.is_file() {
+            let entries = self.load_cached()?;
+            self.entries = Some(entries.clone());
+            return Ok(entries);
+        }
+
+        let entries = self.network_fetch()?;
+        self.entries = Some(entries.clone());
+        Ok(entries)
+    }
+
+    fn network_fetch(&self) -> Result<Vec<RegistryEntry>, TclPkgError> {
+        let cached = self.cached_path();
+        let agent = ureq::config::Config::builder()
+            .http_status_as_error(false)
+            .timeout_global(Some(Duration::from_secs(30)))
+            .build()
+            .new_agent();
+
+        let mut builder = agent.get(&self.url).header("User-Agent", "tclpkg/0.1");
+        if let Ok(etag) = std::fs::read_to_string(self.etag_path()) {
+            builder = builder.header("If-None-Match", etag.trim());
+        }
+
+        match builder.call() {
+            Ok(mut resp) => {
+                let status = resp.status().as_u16();
+                if status == 304 {
+                    self.touch_fetched();
+                    return self.load_cached();
+                }
+                if status >= 400 {
+                    if cached.is_file() {
+                        return self.load_cached();
+                    }
+                    return Err(TclPkgError::registry(
+                        format!("registry fetch failed: HTTP {status}"),
+                        None,
+                    ));
+                }
+                let new_etag = resp
+                    .headers()
+                    .get("ETag")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                let body = resp
+                    .body_mut()
+                    .with_config()
+                    .limit(MAX_BODY)
+                    .read_to_vec()
+                    .map_err(|e| {
+                        TclPkgError::registry(format!("registry read failed: {e}"), None)
+                    })?;
+                self.write_cache(&body, &new_etag);
+                let data: Value = serde_json::from_slice(&body).map_err(|e| {
+                    TclPkgError::registry(format!("invalid registry JSON: {e}"), None)
+                })?;
+                Ok(parse_entries(&data))
+            }
+            Err(exc) => {
+                if cached.is_file() {
+                    return self.load_cached();
+                }
+                Err(TclPkgError::registry(
+                    format!("cannot reach registry at {}: {exc}", self.url),
+                    Some("check your network connection or use --offline".to_string()),
+                ))
+            }
+        }
+    }
+
+    /// Search cached entries by name/description/tag (case-insensitive).
+    pub fn search(&mut self, query: &str) -> Result<Vec<RegistryEntry>, TclPkgError> {
+        let entries = self.fetch(false)?;
+        let q = query.to_lowercase();
+        Ok(entries
+            .into_iter()
+            .filter(|e| {
+                e.name.to_lowercase().contains(&q)
+                    || e.description.to_lowercase().contains(&q)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+            })
+            .collect())
+    }
+
+    /// Find an entry by exact package name.
+    pub fn lookup(&mut self, name: &str) -> Result<Option<RegistryEntry>, TclPkgError> {
+        let entries = self.fetch(false)?;
+        Ok(entries.into_iter().find(|e| e.name == name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_entries() {
+        let data: Value = serde_json::from_str(
+            r#"[
+                {"name": "json", "description": "JSON for Tcl", "tags": ["data"],
+                 "sources": [{"url": "https://x/json.git", "method": "git"}]},
+                "not an object",
+                {"name": "http", "description": "HTTP", "tags": []}
+            ]"#,
+        )
+        .unwrap();
+        let entries = parse_entries(&data);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "json");
+        assert_eq!(entries[0].sources[0].method, "git");
+        assert_eq!(entries[1].name, "http");
+    }
+
+    #[test]
+    fn offline_without_cache_errors() {
+        let dir = std::env::temp_dir().join(format!(
+            "tclpkg-reg-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut client = RegistryClient::new(&dir, true);
+        let err = client.fetch(false).unwrap_err();
+        assert!(err.to_string().contains("offline"));
+    }
+
+    #[test]
+    fn search_offline_cache() {
+        let dir = std::env::temp_dir().join(format!(
+            "tclpkg-reg2-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let reg_dir = dir.join("tclpkg").join("registry");
+        std::fs::create_dir_all(&reg_dir).unwrap();
+        std::fs::write(
+            reg_dir.join("packages.json"),
+            r#"[{"name": "json", "description": "JSON parser", "tags": ["data"]}]"#,
+        )
+        .unwrap();
+        let mut client = RegistryClient::new(&dir, true);
+        let results = client.search("json").unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(client.search("nomatch").unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/rust/tcl-pkg/src/resolver.rs
+++ b/rust/tcl-pkg/src/resolver.rs
@@ -1,0 +1,374 @@
+//! Go-style Minimum Version Selection (MVS) resolver.
+//!
+//! Faithful port of `tooling/tclpkg/resolver.py`. MVS is deterministic and
+//! solverless: every `require <pkg> <minver>` declares a minimum and the
+//! resolver picks the maximum-of-minimums for each package across the whole
+//! graph — no upper bounds, no backtracking, no SAT solver.
+//!
+//! The resolver is a pure function over data; callers supply a provider mapping
+//! `(name, version)` to that package's own transitive requirements. `replace`
+//! and `exclude` from the root manifest override/refuse versions; transitive
+//! `replace`/`exclude` is deliberately ignored (matching Go).
+
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+
+use crate::errors::TclPkgError;
+use crate::version::Version;
+
+/// A named package at a specific version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageRef {
+    pub name: String,
+    pub version: Version,
+}
+
+impl PackageRef {
+    #[must_use]
+    pub fn new(name: impl Into<String>, version: Version) -> Self {
+        Self {
+            name: name.into(),
+            version,
+        }
+    }
+}
+
+impl std::fmt::Display for PackageRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}@{}", self.name, self.version)
+    }
+}
+
+/// One entry in the resolved dependency graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPackage {
+    pub reference: PackageRef,
+    pub requires: Vec<PackageRef>,
+    pub dev: bool,
+}
+
+impl std::fmt::Display for ResolvedPackage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.reference)
+    }
+}
+
+/// Root manifest `replace` directive: force `name` to `version`.
+#[derive(Debug, Clone)]
+pub struct ReplaceSpec {
+    pub name: String,
+    pub version: Version,
+}
+
+/// Root manifest `exclude` directive: refuse this exact version.
+#[derive(Debug, Clone)]
+pub struct ExcludeSpec {
+    pub name: String,
+    pub version: Version,
+}
+
+/// Maps `(name, version)` to that package's transitive requirements.
+///
+/// Returning an empty vec means the package is a leaf. The closure may return
+/// an error to abort resolution (wrapped as a [`TclPkgError`]).
+pub type PackageManifestProvider<'a> =
+    dyn Fn(&str, &Version) -> Result<Vec<PackageRef>, TclPkgError> + 'a;
+
+/// Inputs to [`resolve`].
+pub struct ResolveInput<'a> {
+    pub direct: Vec<PackageRef>,
+    pub dev_direct: Vec<PackageRef>,
+    pub replaces: Vec<ReplaceSpec>,
+    pub excludes: Vec<ExcludeSpec>,
+    pub provider: Option<&'a PackageManifestProvider<'a>>,
+    pub include_dev: bool,
+}
+
+impl Default for ResolveInput<'_> {
+    fn default() -> Self {
+        Self {
+            direct: Vec::new(),
+            dev_direct: Vec::new(),
+            replaces: Vec::new(),
+            excludes: Vec::new(),
+            provider: None,
+            include_dev: true,
+        }
+    }
+}
+
+const MAX_ITERATIONS: u32 = 10_000;
+
+/// Run MVS over the dependency graph and return the resolved set, sorted by
+/// package name.
+#[allow(clippy::too_many_lines)] // direct port of the three-phase Python routine
+pub fn resolve(input: &ResolveInput) -> Result<Vec<ResolvedPackage>, TclPkgError> {
+    let replace_map: HashMap<&str, &ReplaceSpec> = input
+        .replaces
+        .iter()
+        .map(|r| (r.name.as_str(), r))
+        .collect();
+
+    let exclude_set: HashSet<(String, Version)> = input
+        .excludes
+        .iter()
+        .map(|e| (e.name.clone(), e.version.clone()))
+        .collect();
+
+    let dev_names: HashSet<&str> = input.dev_direct.iter().map(|r| r.name.as_str()).collect();
+
+    let provider = |name: &str, version: &Version| -> Result<Vec<PackageRef>, TclPkgError> {
+        match input.provider {
+            Some(p) => p(name, version),
+            None => Ok(Vec::new()),
+        }
+    };
+
+    // Phase 1: collect max-of-minimums via BFS.
+    let mut minimums: BTreeMap<String, Version> = BTreeMap::new();
+    let mut pending: VecDeque<PackageRef> = VecDeque::new();
+    // Keyed by name: (version_used, deps), so convergence can detect when a
+    // minimum was bumped after deps were fetched.
+    let mut requires_map: HashMap<String, (Version, Vec<PackageRef>)> = HashMap::new();
+
+    for reference in &input.direct {
+        pending.push_back(reference.clone());
+    }
+    if input.include_dev {
+        for reference in &input.dev_direct {
+            pending.push_back(reference.clone());
+        }
+    }
+
+    let mut iterations: u32 = 0;
+    while let Some(reference) = pending.pop_front() {
+        iterations += 1;
+        if iterations > MAX_ITERATIONS {
+            return Err(TclPkgError::resolution(
+                "resolver exceeded maximum iterations (possible cycle)",
+                &[],
+                None,
+            ));
+        }
+
+        let name = reference.name.clone();
+        let mut version = reference.version.clone();
+
+        if let Some(rep) = replace_map.get(name.as_str()) {
+            version = rep.version.clone();
+        }
+
+        if exclude_set.contains(&(name.clone(), version.clone())) {
+            return Err(TclPkgError::resolution(
+                format!("package {name} {version} is excluded by the root manifest"),
+                &[],
+                Some(format!(
+                    "remove the exclude directive or adjust the version constraint for {name}"
+                )),
+            ));
+        }
+
+        if let Some(current) = minimums.get(&name)
+            && version <= *current
+        {
+            continue;
+        }
+        minimums.insert(name.clone(), version.clone());
+
+        let child_refs = provider(&name, &version)?;
+        requires_map.insert(name.clone(), (version.clone(), child_refs.clone()));
+        for child in child_refs {
+            pending.push_back(child);
+        }
+    }
+
+    // Phase 2: convergence — re-process packages whose minimum was bumped after
+    // their deps were already fetched.
+    let mut dirty = true;
+    while dirty {
+        dirty = false;
+        let snapshot: Vec<(String, Version)> = minimums
+            .iter()
+            .map(|(n, v)| (n.clone(), v.clone()))
+            .collect();
+        for (name, wanted) in snapshot {
+            let needs = match requires_map.get(&name) {
+                None => true,
+                Some((recorded, _)) => *recorded < wanted,
+            };
+            if needs {
+                let child_refs = provider(&name, &wanted)?;
+                requires_map.insert(name.clone(), (wanted.clone(), child_refs.clone()));
+                for child in child_refs {
+                    pending.push_back(child);
+                }
+                dirty = true;
+                break;
+            }
+        }
+    }
+
+    // Drain any leftover pending from phase 2.
+    while let Some(reference) = pending.pop_front() {
+        let name = reference.name.clone();
+        let mut version = reference.version.clone();
+        if let Some(rep) = replace_map.get(name.as_str()) {
+            version = rep.version.clone();
+        }
+        if exclude_set.contains(&(name.clone(), version.clone())) {
+            return Err(TclPkgError::resolution(
+                format!("package {name} {version} is excluded by the root manifest"),
+                &[],
+                None,
+            ));
+        }
+        if let Some(current) = minimums.get(&name)
+            && version <= *current
+        {
+            continue;
+        }
+        minimums.insert(name.clone(), version.clone());
+        let child_refs = provider(&name, &version)?;
+        requires_map.insert(name.clone(), (version.clone(), child_refs.clone()));
+        for child in child_refs {
+            pending.push_back(child);
+        }
+    }
+
+    // Phase 3: build the result list (BTreeMap iterates names in sorted order).
+    let mut result = Vec::new();
+    for (name, version) in &minimums {
+        let reqs = requires_map
+            .get(name)
+            .map(|(_, deps)| deps.clone())
+            .unwrap_or_default();
+        result.push(ResolvedPackage {
+            reference: PackageRef::new(name.clone(), version.clone()),
+            requires: reqs,
+            dev: dev_names.contains(name.as_str()),
+        });
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    fn pref(name: &str, ver: &str) -> PackageRef {
+        PackageRef::new(name, v(ver))
+    }
+
+    #[test]
+    fn picks_max_of_minimums() {
+        let provider = |name: &str, _ver: &Version| -> Result<Vec<PackageRef>, TclPkgError> {
+            if name == "a" {
+                Ok(vec![pref("c", "1.0.0")])
+            } else if name == "b" {
+                Ok(vec![pref("c", "1.5.0")])
+            } else {
+                Ok(vec![])
+            }
+        };
+        let input = ResolveInput {
+            direct: vec![pref("a", "1.0.0"), pref("b", "1.0.0")],
+            provider: Some(&provider),
+            ..Default::default()
+        };
+        let resolved = resolve(&input).unwrap();
+        let c = resolved.iter().find(|r| r.reference.name == "c").unwrap();
+        assert_eq!(c.reference.version, v("1.5.0"));
+    }
+
+    #[test]
+    fn leaves_resolve_directly() {
+        let input = ResolveInput {
+            direct: vec![pref("json", "1.0.0")],
+            ..Default::default()
+        };
+        let resolved = resolve(&input).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].reference.name, "json");
+    }
+
+    #[test]
+    fn replace_overrides_version() {
+        let input = ResolveInput {
+            direct: vec![pref("json", "1.0.0")],
+            replaces: vec![ReplaceSpec {
+                name: "json".to_string(),
+                version: v("2.0.0"),
+            }],
+            ..Default::default()
+        };
+        let resolved = resolve(&input).unwrap();
+        assert_eq!(resolved[0].reference.version, v("2.0.0"));
+    }
+
+    #[test]
+    fn exclude_refuses_version() {
+        let input = ResolveInput {
+            direct: vec![pref("http", "2.9.7")],
+            excludes: vec![ExcludeSpec {
+                name: "http".to_string(),
+                version: v("2.9.7"),
+            }],
+            ..Default::default()
+        };
+        let err = resolve(&input).unwrap_err();
+        assert!(err.to_string().contains("excluded by the root manifest"));
+    }
+
+    #[test]
+    fn dev_flag_propagates() {
+        let input = ResolveInput {
+            direct: vec![pref("json", "1.0.0")],
+            dev_direct: vec![pref("tcltest", "2.5.0")],
+            ..Default::default()
+        };
+        let resolved = resolve(&input).unwrap();
+        let dev = resolved
+            .iter()
+            .find(|r| r.reference.name == "tcltest")
+            .unwrap();
+        assert!(dev.dev);
+    }
+
+    #[test]
+    fn include_dev_false_skips() {
+        let input = ResolveInput {
+            direct: vec![pref("json", "1.0.0")],
+            dev_direct: vec![pref("tcltest", "2.5.0")],
+            include_dev: false,
+            ..Default::default()
+        };
+        let resolved = resolve(&input).unwrap();
+        assert!(resolved.iter().all(|r| r.reference.name != "tcltest"));
+    }
+
+    #[test]
+    fn convergence_rewalks_bumped_minimum() {
+        // a needs c@1.0 (which needs d@1.0); b needs c@2.0 (which needs d@3.0).
+        // c converges to 2.0, so d must end up at 3.0.
+        let provider = |name: &str, ver: &Version| -> Result<Vec<PackageRef>, TclPkgError> {
+            match name {
+                "a" => Ok(vec![pref("c", "1.0.0")]),
+                "b" => Ok(vec![pref("c", "2.0.0")]),
+                "c" if *ver >= v("2.0.0") => Ok(vec![pref("d", "3.0.0")]),
+                "c" => Ok(vec![pref("d", "1.0.0")]),
+                _ => Ok(vec![]),
+            }
+        };
+        let input = ResolveInput {
+            direct: vec![pref("a", "1.0.0"), pref("b", "1.0.0")],
+            provider: Some(&provider),
+            ..Default::default()
+        };
+        let resolved = resolve(&input).unwrap();
+        let d = resolved.iter().find(|r| r.reference.name == "d").unwrap();
+        assert_eq!(d.reference.version, v("3.0.0"));
+    }
+}

--- a/rust/tcl-pkg/src/ui.rs
+++ b/rust/tcl-pkg/src/ui.rs
@@ -1,0 +1,109 @@
+//! CLI output helpers — colour, `--json` mode, status symbols.
+//!
+//! Faithful port of `tooling/tclpkg/ui.py`. Centralises the conventions shared
+//! by all `tcl pkg` / `tcl venv` subcommands: ANSI colour codes, the
+//! check/cross/warning symbols, and the canonical JSON output mode.
+
+use std::io::IsTerminal;
+
+use serde_json::Value;
+
+use crate::json::canonical_json;
+
+const RESET: &str = "\x1b[0m";
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+
+fn is_stdout_tty() -> bool {
+    std::io::stdout().is_terminal()
+}
+
+/// Decide whether to emit ANSI colour codes.
+///
+/// `force` overrides auto-detection (`Some(true)` always, `Some(false)` never).
+/// `None` auto-detects from the terminal and the `NO_COLOR` / `FORCE_COLOR`
+/// environment variables.
+#[must_use]
+pub fn use_colour(force: Option<bool>) -> bool {
+    if let Some(value) = force {
+        value
+    } else {
+        if std::env::var_os("NO_COLOR").is_some() {
+            return false;
+        }
+        if std::env::var_os("FORCE_COLOR").is_some() {
+            return true;
+        }
+        is_stdout_tty()
+    }
+}
+
+fn colourise(code: &str, text: &str, colour: bool) -> String {
+    if colour {
+        format!("{code}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+#[must_use]
+pub fn ok(text: &str, colour: bool) -> String {
+    colourise(GREEN, &format!("  \u{2713} {text}"), colour)
+}
+
+#[must_use]
+pub fn fail(text: &str, colour: bool) -> String {
+    colourise(RED, &format!("  \u{2717} {text}"), colour)
+}
+
+#[must_use]
+pub fn warn(text: &str, colour: bool) -> String {
+    colourise(YELLOW, &format!("  \u{26a0} {text}"), colour)
+}
+
+#[must_use]
+pub fn info(text: &str, colour: bool) -> String {
+    colourise(CYAN, text, colour)
+}
+
+#[must_use]
+pub fn dim(text: &str, colour: bool) -> String {
+    colourise(DIM, text, colour)
+}
+
+#[must_use]
+pub fn bold(text: &str, colour: bool) -> String {
+    colourise(BOLD, text, colour)
+}
+
+/// Render `data` as canonical JSON (sorted keys, 2-space indent), matching the
+/// Python `--json` output, with a trailing newline ready for `println!`-style
+/// printing without doubling the newline.
+#[must_use]
+pub fn json_output(data: &Value) -> String {
+    canonical_json(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbols_and_colour() {
+        assert_eq!(ok("done", false), "  \u{2713} done");
+        assert_eq!(fail("bad", false), "  \u{2717} bad");
+        assert_eq!(warn("hmm", false), "  \u{26a0} hmm");
+        assert!(ok("done", true).starts_with(GREEN));
+        assert!(ok("done", true).ends_with(RESET));
+    }
+
+    #[test]
+    fn colour_forcing() {
+        assert!(use_colour(Some(true)));
+        assert!(!use_colour(Some(false)));
+    }
+}

--- a/rust/tcl-pkg/src/venv.rs
+++ b/rust/tcl-pkg/src/venv.rs
@@ -1,0 +1,385 @@
+//! Virtual environment creation and management.
+//!
+//! Faithful port of `tooling/tclpkg/venv.py`. A tclpkg virtual environment is a
+//! directory (conventionally `.venv/`) containing a pinned `tclsh` wrapper,
+//! bash/fish activation scripts, and a `lib/` tree for materialised packages.
+//! The model mirrors Python's `venv`: activation prepends `<venv>/bin` to
+//! `$PATH` and sets `$TCLLIBPATH`; the wrapper always sets `TCLLIBPATH` so
+//! non-interactive use works without activation.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+
+use crate::errors::TclPkgError;
+
+fn venv_error(message: impl Into<String>, hint: Option<&str>) -> TclPkgError {
+    TclPkgError::venv(message, hint.map(ToString::to_string))
+}
+
+/// Find a suitable `tclsh` on PATH (preferring newer versions), or `None`.
+#[must_use]
+pub fn find_tclsh() -> Option<PathBuf> {
+    for name in ["tclsh9.0", "tclsh8.6", "tclsh8.5", "tclsh8.4", "tclsh"] {
+        if let Some(path) = which(name) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Locate `name` on `PATH`, returning the first executable match.
+#[must_use]
+pub fn which(name: &str) -> Option<PathBuf> {
+    let paths = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&paths) {
+        let candidate = dir.join(name);
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn resolve_tclsh(requested: Option<&str>) -> Result<PathBuf, TclPkgError> {
+    let Some(req) = requested else {
+        return find_tclsh().ok_or_else(|| {
+            venv_error(
+                "no tclsh found on PATH",
+                Some("install Tcl or specify --tcl <version>"),
+            )
+        });
+    };
+    if let Some(path) = which(&format!("tclsh{req}")) {
+        return Ok(path);
+    }
+    if let Some(path) = which("tclsh") {
+        let actual = tclsh_version_string(&path);
+        if !actual.is_empty() && !actual.starts_with(req) {
+            return Err(venv_error(
+                format!("tclsh{req} not found; plain tclsh is {actual}"),
+                Some(&format!("install Tcl {req} or omit --tcl")),
+            ));
+        }
+        return Ok(path);
+    }
+    Err(venv_error(
+        format!("tclsh{req} not found on PATH"),
+        Some("install the requested Tcl version or omit --tcl"),
+    ))
+}
+
+fn tclsh_version_string(tclsh: &Path) -> String {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let Ok(mut child) = Command::new(tclsh)
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return String::new();
+    };
+    if let Some(stdin) = child.stdin.take() {
+        let mut stdin = stdin;
+        let _ = stdin.write_all(b"puts [info patchlevel]");
+    }
+    match child.wait_with_output() {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+/// Options for [`create_venv`].
+#[derive(Debug, Default)]
+pub struct CreateOptions<'a> {
+    pub tcl_version: Option<&'a str>,
+    pub system_site_packages: bool,
+    pub prompt: Option<&'a str>,
+    pub project_root: Option<&'a Path>,
+}
+
+/// Create a new tclpkg virtual environment at `venv_path`. Returns the absolute
+/// path.
+pub fn create_venv(venv_path: &Path, opts: &CreateOptions) -> Result<PathBuf, TclPkgError> {
+    let venv_path = absolutise(venv_path);
+    if venv_path.exists() {
+        return Err(venv_error(
+            format!("directory already exists: {}", venv_path.display()),
+            Some("use --force to overwrite or choose a different path"),
+        ));
+    }
+
+    let tclsh = resolve_tclsh(opts.tcl_version)?;
+    let version_str = {
+        let v = tclsh_version_string(&tclsh);
+        if v.is_empty() {
+            opts.tcl_version.unwrap_or("unknown").to_string()
+        } else {
+            v
+        }
+    };
+    let prompt_label = opts.prompt.map_or_else(
+        || {
+            venv_path
+                .file_name()
+                .map_or_else(String::new, |n| n.to_string_lossy().into_owned())
+        },
+        ToString::to_string,
+    );
+
+    let bin_dir = venv_path.join("bin");
+    let lib_dir = venv_path.join("lib");
+    std::fs::create_dir_all(&bin_dir)
+        .map_err(|e| venv_error(format!("cannot create venv: {e}"), None))?;
+    std::fs::create_dir_all(&lib_dir)
+        .map_err(|e| venv_error(format!("cannot create venv: {e}"), None))?;
+
+    let tclsh_display = tclsh.to_string_lossy();
+    let mut cfg = vec![
+        format!("tcl_version = {version_str}"),
+        format!("tcl_executable = {tclsh_display}"),
+        "venv_tool = tcl-lsp".to_string(),
+        format!("created = {}", Utc::now().format("%Y-%m-%dT%H:%M:%SZ")),
+        format!("prompt = {prompt_label}"),
+        format!(
+            "include-system-site-packages = {}",
+            if opts.system_site_packages {
+                "true"
+            } else {
+                "false"
+            }
+        ),
+    ];
+    if let Some(root) = opts.project_root {
+        cfg.push(format!("project_root = {}", root.display()));
+    }
+    write_file(&venv_path.join("tclvenv.cfg"), &(cfg.join("\n") + "\n"))?;
+
+    write_tclsh_wrapper(&bin_dir.join("tclsh"), &tclsh_display, &venv_path)?;
+    write_file(
+        &bin_dir.join("activate"),
+        &activate_bash(&venv_path, &prompt_label),
+    )?;
+    write_file(
+        &bin_dir.join("activate.fish"),
+        &activate_fish(&venv_path, &prompt_label),
+    )?;
+    write_file(
+        &lib_dir.join("pkgIndex.tcl"),
+        "# Auto-generated by tclpkg — do not edit.\n# This file is regenerated by `tcl pkg install`.\n",
+    )?;
+
+    Ok(venv_path)
+}
+
+/// Parse `tclvenv.cfg` into ordered key/value pairs.
+pub fn read_venv_config(venv_path: &Path) -> Result<Vec<(String, String)>, TclPkgError> {
+    let cfg_file = venv_path.join("tclvenv.cfg");
+    if !cfg_file.is_file() {
+        return Err(venv_error(
+            format!(
+                "not a tclpkg venv: {} (missing tclvenv.cfg)",
+                venv_path.display()
+            ),
+            None,
+        ));
+    }
+    let text = std::fs::read_to_string(&cfg_file)
+        .map_err(|e| venv_error(format!("cannot read venv config: {e}"), None))?;
+    let mut result = Vec::new();
+    for line in text.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            result.push((key.trim().to_string(), value.trim().to_string()));
+        }
+    }
+    Ok(result)
+}
+
+/// Remove a virtual environment directory.
+pub fn delete_venv(venv_path: &Path) -> Result<(), TclPkgError> {
+    if !venv_path.is_dir() {
+        return Err(venv_error(
+            format!("venv not found: {}", venv_path.display()),
+            None,
+        ));
+    }
+    if !venv_path.join("tclvenv.cfg").is_file() {
+        return Err(venv_error(
+            format!("directory is not a tclpkg venv: {}", venv_path.display()),
+            Some("missing tclvenv.cfg — refusing to delete to avoid data loss"),
+        ));
+    }
+    if let Some(active) = std::env::var_os("TCL_VENV") {
+        let active = PathBuf::from(active);
+        if active.canonicalize().ok() == venv_path.canonicalize().ok() {
+            return Err(venv_error(
+                "cannot delete the currently active venv",
+                Some("run 'deactivate' first or use --force"),
+            ));
+        }
+    }
+    std::fs::remove_dir_all(venv_path)
+        .map_err(|e| venv_error(format!("cannot delete venv: {e}"), None))
+}
+
+/// Re-link an existing venv to `new_tcl`, rewriting `tclvenv.cfg` and the
+/// `bin/tclsh` wrapper. Returns the resolved tclsh path.
+pub fn update_venv(venv_path: &Path, new_tcl: &str) -> Result<PathBuf, TclPkgError> {
+    let venv_path = absolutise(venv_path);
+    read_venv_config(&venv_path)?; // validate the venv exists
+
+    let tclsh = which(&format!("tclsh{new_tcl}"))
+        .or_else(|| which("tclsh"))
+        .ok_or_else(|| venv_error(format!("tclsh{new_tcl} not found on PATH"), None))?;
+    let tclsh_display = tclsh.to_string_lossy();
+
+    let cfg_file = venv_path.join("tclvenv.cfg");
+    let text = std::fs::read_to_string(&cfg_file)
+        .map_err(|e| venv_error(format!("cannot read venv config: {e}"), None))?;
+    let new_lines: Vec<String> = text
+        .lines()
+        .map(|line| {
+            if line.starts_with("tcl_version") {
+                format!("tcl_version = {new_tcl}")
+            } else if line.starts_with("tcl_executable") {
+                format!("tcl_executable = {tclsh_display}")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+    write_file(&cfg_file, &(new_lines.join("\n") + "\n"))?;
+
+    write_tclsh_wrapper(
+        &venv_path.join("bin").join("tclsh"),
+        &tclsh_display,
+        &venv_path,
+    )?;
+    Ok(tclsh)
+}
+
+fn absolutise(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    }
+}
+
+fn write_file(path: &Path, content: &str) -> Result<(), TclPkgError> {
+    std::fs::write(path, content)
+        .map_err(|e| venv_error(format!("cannot write {}: {e}", path.display()), None))
+}
+
+fn write_tclsh_wrapper(path: &Path, tclsh: &str, _venv: &Path) -> Result<(), TclPkgError> {
+    let script = format!(
+        "#!/bin/sh\n# Auto-generated by tclpkg — do not edit.\nVENV=\"$(cd \"$(dirname \"$0\")/..\" && pwd)\"\n: \"${{TCLLIBPATH:=}}\"\nexport TCLLIBPATH=\"$VENV/lib${{TCLLIBPATH:+ $TCLLIBPATH}}\"\nexport TCL_VENV=\"$VENV\"\nexec \"{tclsh}\" \"$@\"\n"
+    );
+    write_file(path, &script)?;
+    make_executable(path);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::metadata(path) {
+        let mut perms = meta.permissions();
+        perms.set_mode(perms.mode() | 0o111);
+        let _ = std::fs::set_permissions(path, perms);
+    }
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) {}
+
+fn activate_bash(venv: &Path, prompt: &str) -> String {
+    let venv = venv.display();
+    let activate_path = format!("{venv}/bin/activate");
+    format!(
+        "# Auto-generated by tclpkg — source this file, do not execute.\n# Usage: source {activate_path}\n\ndeactivate () {{\n    if [ -n \"${{_OLD_TCL_VENV_PATH:-}}\" ]; then\n        PATH=\"${{_OLD_TCL_VENV_PATH}}\"\n        export PATH\n        unset _OLD_TCL_VENV_PATH\n    fi\n    if [ -n \"${{_OLD_TCL_VENV_TCLLIBPATH:-}}\" ]; then\n        TCLLIBPATH=\"${{_OLD_TCL_VENV_TCLLIBPATH}}\"\n        export TCLLIBPATH\n    else\n        unset TCLLIBPATH\n    fi\n    unset _OLD_TCL_VENV_TCLLIBPATH\n    if [ -n \"${{_OLD_TCL_VENV_PS1:-}}\" ]; then\n        PS1=\"${{_OLD_TCL_VENV_PS1}}\"\n        export PS1\n        unset _OLD_TCL_VENV_PS1\n    fi\n    unset TCL_VENV\n}}\n\n_OLD_TCL_VENV_PATH=\"$PATH\"\n_OLD_TCL_VENV_TCLLIBPATH=\"${{TCLLIBPATH:-}}\"\n_OLD_TCL_VENV_PS1=\"${{PS1:-}}\"\n\nexport TCL_VENV=\"{venv}\"\nexport TCLLIBPATH=\"{venv}/lib${{TCLLIBPATH:+ $TCLLIBPATH}}\"\nexport PATH=\"{venv}/bin:$PATH\"\nPS1=\"({prompt}) ${{PS1:-}}\"\nexport PS1\n"
+    )
+}
+
+fn activate_fish(venv: &Path, prompt: &str) -> String {
+    let venv = venv.display();
+    let activate_path = format!("{venv}/bin/activate.fish");
+    let _ = prompt;
+    format!(
+        "# Auto-generated by tclpkg — source this file in fish.\n# Usage: source {activate_path}\n\nfunction deactivate\n    if set -q _OLD_TCL_VENV_PATH\n        set -gx PATH $_OLD_TCL_VENV_PATH\n        set -e _OLD_TCL_VENV_PATH\n    end\n    if set -q _OLD_TCL_VENV_TCLLIBPATH\n        set -gx TCLLIBPATH $_OLD_TCL_VENV_TCLLIBPATH\n        set -e _OLD_TCL_VENV_TCLLIBPATH\n    else\n        set -e TCLLIBPATH\n    end\n    set -e TCL_VENV\n    functions -e deactivate\nend\n\nset -gx _OLD_TCL_VENV_PATH $PATH\nif set -q TCLLIBPATH\n    set -gx _OLD_TCL_VENV_TCLLIBPATH $TCLLIBPATH\nend\n\nset -gx TCL_VENV \"{venv}\"\nset -gx TCLLIBPATH \"{venv}/lib $TCLLIBPATH\"\nset -gx PATH \"{venv}/bin\" $PATH\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "tclpkg-venv-{tag}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn create_reads_back_and_deletes() {
+        // Only run when a tclsh is actually discoverable.
+        if find_tclsh().is_none() {
+            return;
+        }
+        let base = tmp("create");
+        std::fs::create_dir_all(&base).unwrap();
+        let venv = base.join(".venv");
+        let created = create_venv(&venv, &CreateOptions::default()).unwrap();
+        assert!(created.join("tclvenv.cfg").is_file());
+        assert!(created.join("bin/tclsh").is_file());
+        assert!(created.join("bin/activate").is_file());
+        assert!(created.join("lib/pkgIndex.tcl").is_file());
+
+        let cfg = read_venv_config(&created).unwrap();
+        assert!(cfg.iter().any(|(k, _)| k == "tcl_version"));
+
+        delete_venv(&created).unwrap();
+        assert!(!created.exists());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn create_refuses_existing() {
+        if find_tclsh().is_none() {
+            return;
+        }
+        let base = tmp("exists");
+        let venv = base.join(".venv");
+        std::fs::create_dir_all(&venv).unwrap();
+        let err = create_venv(&venv, &CreateOptions::default()).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn delete_refuses_non_venv() {
+        let base = tmp("nonvenv");
+        std::fs::create_dir_all(&base).unwrap();
+        let err = delete_venv(&base).unwrap_err();
+        assert!(err.to_string().contains("not a tclpkg venv"));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}

--- a/rust/tcl-pkg/src/version.rs
+++ b/rust/tcl-pkg/src/version.rs
@@ -1,0 +1,341 @@
+//! Semantic version type with Tcl-friendly parsing.
+//!
+//! Faithful port of `tooling/tclpkg/version.py`. Version ordering agrees with
+//! semver 2.0 and with C Tcl's `package require` ordering: missing patch digits
+//! default to zero, a leading `v` is tolerated, and Tcl-style `a1`/`b2`/`rc1`
+//! prereleases collate alongside semver's `-alpha.1` form (`8.6.3a1` sorts
+//! before `8.6.3`).
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Raised when a version string cannot be parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionError(pub String);
+
+impl fmt::Display for VersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for VersionError {}
+
+// Core semver + lax trailing-zero + optional v-prefix + Tcl-style alpha/beta.
+static SEMVER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)^
+        v?
+        (?P<major>0|[1-9]\d*)
+        (?:\.(?P<minor>0|[1-9]\d*))?
+        (?:\.(?P<patch>0|[1-9]\d*))?
+        (?:
+            (?P<prerelease>
+                -[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
+              | [ab]\d+
+              | rc\d+
+            )
+        )?
+        (?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?
+        $",
+    )
+    .expect("version regex compiles")
+});
+
+static TCL_PRE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(a|b|rc)(\d+)$").expect("tcl prerelease regex compiles"));
+
+/// One comparable piece of a prerelease tag.
+///
+/// Numeric pieces sort before alphabetic ones (semver rule); the [`Sentinel`]
+/// stands in for "no prerelease" so a release sorts after any prerelease.
+///
+/// [`Sentinel`]: PreItem::Sentinel
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PreItem {
+    Num(u64),
+    Alpha(String),
+    Sentinel,
+}
+
+impl PreItem {
+    const fn rank(&self) -> u8 {
+        match self {
+            // Mirrors the Python (0, …) / (1, …) / (2,) tuple tags.
+            PreItem::Num(_) => 0,
+            PreItem::Alpha(_) => 1,
+            PreItem::Sentinel => 2,
+        }
+    }
+}
+
+impl Ord for PreItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.rank()
+            .cmp(&other.rank())
+            .then_with(|| match (self, other) {
+                (PreItem::Num(a), PreItem::Num(b)) => a.cmp(b),
+                (PreItem::Alpha(a), PreItem::Alpha(b)) => a.cmp(b),
+                _ => Ordering::Equal,
+            })
+    }
+}
+
+impl PartialOrd for PreItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A semver-compatible version with Tcl-friendly parsing.
+///
+/// Instances are immutable, hashable, and totally ordered. Comparison follows
+/// semver 2.0 with Tcl-style short prereleases mapped onto their canonical
+/// semver form before comparison; build metadata never affects ordering.
+#[derive(Debug, Clone)]
+pub struct Version {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+    /// Comparable prerelease pieces (empty when there is no prerelease).
+    prerelease: Vec<PreItem>,
+    /// Canonical prerelease string, e.g. `-alpha.1` (empty when none).
+    pub prerelease_raw: String,
+    pub build: String,
+    pub original: String,
+}
+
+impl Version {
+    /// Parse a version string, applying the Tcl-friendly lax rules.
+    pub fn parse(raw: &str) -> Result<Version, VersionError> {
+        let stripped = raw.trim();
+        if stripped.is_empty() {
+            return Err(VersionError("empty version string".to_string()));
+        }
+        let caps = SEMVER_RE
+            .captures(stripped)
+            .ok_or_else(|| VersionError(format!("invalid version: '{raw}'")))?;
+        let major = caps["major"].parse::<u64>().expect("regex digits parse");
+        let minor = caps
+            .name("minor")
+            .map_or(0, |m| m.as_str().parse().expect("regex digits parse"));
+        let patch = caps
+            .name("patch")
+            .map_or(0, |m| m.as_str().parse().expect("regex digits parse"));
+        let (prerelease, prerelease_raw) = match caps.name("prerelease") {
+            Some(m) => parse_prerelease(m.as_str()),
+            None => (Vec::new(), String::new()),
+        };
+        let build = caps
+            .name("build")
+            .map_or(String::new(), |m| m.as_str().to_string());
+        Ok(Version {
+            major,
+            minor,
+            patch,
+            prerelease,
+            prerelease_raw,
+            build,
+            original: stripped.to_string(),
+        })
+    }
+
+    /// Return the canonical `MAJOR.MINOR.PATCH[-pre][+build]` form.
+    #[must_use]
+    pub fn canonical(&self) -> String {
+        let mut base = format!("{}.{}.{}", self.major, self.minor, self.patch);
+        if !self.prerelease_raw.is_empty() {
+            base.push_str(&self.prerelease_raw);
+        }
+        if !self.build.is_empty() {
+            base.push('+');
+            base.push_str(&self.build);
+        }
+        base
+    }
+
+    /// The comparison key: prerelease versions sort before the release, with a
+    /// sentinel standing in for "no prerelease".
+    fn compare_key(&self) -> (u64, u64, u64, Vec<PreItem>) {
+        let pre = if self.prerelease.is_empty() {
+            vec![PreItem::Sentinel]
+        } else {
+            self.prerelease.clone()
+        };
+        (self.major, self.minor, self.patch, pre)
+    }
+}
+
+fn parse_prerelease(raw: &str) -> (Vec<PreItem>, String) {
+    if let Some(rest) = raw.strip_prefix('-') {
+        let canonical = format!("-{rest}");
+        let comparable = rest
+            .split('.')
+            .map(|piece| {
+                if !piece.is_empty() && piece.bytes().all(|b| b.is_ascii_digit()) {
+                    PreItem::Num(piece.parse().unwrap_or(0))
+                } else {
+                    PreItem::Alpha(piece.to_string())
+                }
+            })
+            .collect();
+        return (comparable, canonical);
+    }
+
+    if let Some(caps) = TCL_PRE_RE.captures(raw) {
+        let (label, order) = match &caps[1] {
+            "a" => ("alpha", 0u64),
+            "b" => ("beta", 1u64),
+            _ => ("rc", 2u64),
+        };
+        let number: u64 = caps[2].parse().unwrap_or(0);
+        let comparable = vec![PreItem::Num(order), PreItem::Num(number)];
+        return (comparable, format!("-{label}.{number}"));
+    }
+
+    (vec![PreItem::Alpha(raw.to_string())], raw.to_string())
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.canonical())
+    }
+}
+
+impl PartialEq for Version {
+    fn eq(&self, other: &Self) -> bool {
+        self.compare_key() == other.compare_key()
+    }
+}
+
+impl Eq for Version {}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.compare_key().cmp(&other.compare_key())
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::hash::Hash for Version {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.compare_key().hash(state);
+    }
+}
+
+/// Convenience alias for [`Version::parse`].
+pub fn parse_version(raw: &str) -> Result<Version, VersionError> {
+    Version::parse(raw)
+}
+
+/// Return the maximum of a non-empty slice of versions.
+pub fn max_version(versions: &[Version]) -> Result<Version, VersionError> {
+    versions
+        .iter()
+        .max()
+        .cloned()
+        .ok_or_else(|| VersionError("max_version requires a non-empty list".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).expect("parses")
+    }
+
+    #[test]
+    fn basic_three_part() {
+        let ver = v("1.2.3");
+        assert_eq!((ver.major, ver.minor, ver.patch), (1, 2, 3));
+        assert_eq!(ver.prerelease_raw, "");
+        assert_eq!(ver.build, "");
+    }
+
+    #[test]
+    fn short_forms_default() {
+        assert_eq!((v("1.2").major, v("1.2").minor, v("1.2").patch), (1, 2, 0));
+        assert_eq!((v("7").major, v("7").minor, v("7").patch), (7, 0, 0));
+    }
+
+    #[test]
+    fn v_prefix_allowed() {
+        assert_eq!(v("v1.2.3"), v("1.2.3"));
+    }
+
+    #[test]
+    fn tcl_style_prereleases() {
+        assert_eq!(v("8.6.3a1").prerelease_raw, "-alpha.1");
+        assert_eq!(v("1.0b2").prerelease_raw, "-beta.2");
+        assert_eq!(v("2.0rc1").prerelease_raw, "-rc.1");
+        assert_eq!(v("1.2.3-rc.4").prerelease_raw, "-rc.4");
+    }
+
+    #[test]
+    fn build_metadata() {
+        assert_eq!(v("1.2.3+build.42").build, "build.42");
+    }
+
+    #[test]
+    fn parse_errors() {
+        assert!(Version::parse("").is_err());
+        assert!(Version::parse("not a version").is_err());
+    }
+
+    #[test]
+    fn canonical_forms() {
+        assert_eq!(v("1.2.3").canonical(), "1.2.3");
+        assert_eq!(v("1.2").canonical(), "1.2.0");
+        assert_eq!(v("v1.2.3").canonical(), "1.2.3");
+        assert_eq!(v("8.6.3a1").canonical(), "8.6.3-alpha.1");
+        assert_eq!(v("1.2.3+foo").canonical(), "1.2.3+foo");
+        assert_eq!(v("1.2").to_string(), "1.2.0");
+    }
+
+    #[test]
+    fn ordering() {
+        assert!(v("2.0.0") > v("1.99.99"));
+        assert!(v("1.3.0") > v("1.2.99"));
+        assert!(v("1.2.3") > v("1.2.2"));
+        assert!(v("1.2.3-rc.1") < v("1.2.3"));
+        assert!(v("8.6.3a1") < v("8.6.3b1"));
+        assert!(v("8.6.3b2") < v("8.6.3rc1"));
+        assert!(v("8.6.3rc1") < v("8.6.3"));
+        assert!(v("1.0.0-rc.2") > v("1.0.0-rc.1"));
+        assert_eq!(v("1.2.3+a"), v("1.2.3+b"));
+    }
+
+    #[test]
+    fn sorting_mixed_forms() {
+        let mut versions = [v("1.0.0"), v("1.2"), v("1.2.3a1"), v("v1.2.3"), v("0.9.9")];
+        versions.sort();
+        let strs: Vec<String> = versions.iter().map(ToString::to_string).collect();
+        assert_eq!(
+            strs,
+            vec!["0.9.9", "1.0.0", "1.2.0", "1.2.3-alpha.1", "1.2.3"]
+        );
+    }
+
+    #[test]
+    fn hashing_and_dedup() {
+        use std::collections::HashSet;
+        let set: HashSet<Version> = [v("1.0.0"), v("v1.0.0"), v("1.0")].into_iter().collect();
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn max_version_helper() {
+        let chosen = max_version(&[v("1.0.0"), v("1.2.3"), v("1.1.9")]).unwrap();
+        assert_eq!(chosen.to_string(), "1.2.3");
+        assert!(max_version(&[]).is_err());
+    }
+}

--- a/tests/tclpkg/test_docker.py
+++ b/tests/tclpkg/test_docker.py
@@ -242,7 +242,7 @@ class TestGenerateDockerfile:
     def test_pkg_sync_uses_pyz(self) -> None:
         spec = DockerfileSpec()
         result = generate_dockerfile(spec)
-        assert "python3 /usr/local/bin/tcl.pyz pkg sync --frozen" in result
+        assert "python3 /usr/local/bin/tcl.pyz pkg install --frozen" in result
 
     def test_no_python_when_no_packages_no_venv(self) -> None:
         spec = DockerfileSpec(install_packages=False, create_venv=False)
@@ -277,12 +277,13 @@ class TestGenerateDockerfile:
 
     def test_venv_created_before_pkg_sync(self) -> None:
         """When both venv and packages are enabled, venv must come first
-        so that ``pkg sync`` materialises packages into ``.venv/lib/``."""
+        so that ``pkg install --frozen`` materialises packages into
+        ``.venv/lib/``."""
         spec = DockerfileSpec(create_venv=True, install_packages=True)
         result = generate_dockerfile(spec)
         venv_pos = result.index("venv create")
-        pkg_pos = result.index("pkg sync")
-        assert venv_pos < pkg_pos, "venv create must appear before pkg sync"
+        pkg_pos = result.index("pkg install --frozen")
+        assert venv_pos < pkg_pos, "venv create must appear before pkg install"
         assert "Install Tcl packages into the virtual environment" in result
 
     def test_venv_paths_follow_workdir(self) -> None:
@@ -427,7 +428,7 @@ class TestDockerCLI:
         assert "FROM debian:bookworm-slim" in content
         assert "python3" in content
         assert "tcl.pyz" in content
-        assert "pkg sync" in content
+        assert "pkg install --frozen" in content
 
     def test_docker_create_alpine_90(self, tmp_path: Path) -> None:
         from tooling.tcl.main import main

--- a/tests/tclpkg/test_installer.py
+++ b/tests/tclpkg/test_installer.py
@@ -1,0 +1,84 @@
+"""Tests for tclpkg.installer — source resolution, fetch, store, materialise.
+
+Mirrors ``rust/tcl-pkg/src/installer.rs``'s unit tests so the Python and Rust
+install paths stay in lockstep.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tooling.tclpkg.cas import ContentAddressableStore
+from tooling.tclpkg.installer import fetch_and_store, materialise, resolve_source
+
+
+class TestResolveSource:
+    """Source-resolution precedence: replace > -source > registry."""
+
+    def test_replace_wins(self) -> None:
+        spec = resolve_source(
+            "a",
+            "1.0",
+            replaces={"a": "https://r/a.tar.gz"},
+            manifest_sources={"a": "https://s/a.tar.gz"},
+            registry=None,
+        )
+        assert spec is not None
+        assert spec.url == "https://r/a.tar.gz"
+
+    def test_manifest_source_used(self) -> None:
+        spec = resolve_source(
+            "b",
+            "2.0",
+            replaces={},
+            manifest_sources={"b": "https://s/b.git"},
+            registry=None,
+        )
+        assert spec is not None
+        assert spec.type == "git"
+
+    def test_local_dir_classified_as_path(self, tmp_path) -> None:
+        spec = resolve_source(
+            "c",
+            "1.0",
+            replaces={},
+            manifest_sources={"c": str(tmp_path)},
+            registry=None,
+        )
+        assert spec is not None
+        assert spec.type == "path"
+
+    def test_no_source_returns_none(self) -> None:
+        assert resolve_source("x", "1.0", replaces={}, manifest_sources={}, registry=None) is None
+
+
+class TestFetchStoreMaterialise:
+    """End-to-end fetch → CAS store → materialise for a local package."""
+
+    def _make_pkg(self, root: Path) -> Path:
+        pkg = root / "pkgsrc"
+        pkg.mkdir(parents=True)
+        (pkg / "tclpkg.tcl").write_text(
+            "package foo\nversion 1.0.0\nprovides foo::api\nlicense MIT\n",
+            encoding="utf-8",
+        )
+        (pkg / "foo.tcl").write_text("proc foo::hello {} { return hi }\n", encoding="utf-8")
+        return pkg
+
+    def test_roundtrip(self, tmp_path) -> None:
+        from tooling.tclpkg.lockfile import SourceSpec
+
+        pkg = self._make_pkg(tmp_path)
+        cas = ContentAddressableStore(tmp_path / "cache")
+        source = SourceSpec(type="path", url=str(pkg))
+        result = fetch_and_store(source, "foo", "1.0.0", cas)
+
+        assert result.integrity.startswith("sha256-")
+        assert result.size > 0
+        assert result.provides == ["foo::api"]
+        assert result.license == "MIT"
+
+        lib = tmp_path / "lib"
+        dest = materialise(cas, result.integrity, lib, "foo", "1.0.0", symlink=False)
+        assert dest.is_dir()
+        assert (dest / "foo.tcl").read_text() == "proc foo::hello {} { return hi }\n"

--- a/tooling/tcl/verbs/pkg.py
+++ b/tooling/tcl/verbs/pkg.py
@@ -70,9 +70,24 @@ def _run_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def _install_lib_dir(mpath: Path) -> Path:
+    """Where ``install`` materialises packages: the venv lib if one is active,
+    else ``<project>/lib`` next to the manifest."""
+    import os
+
+    venv = os.environ.get("TCL_VENV")
+    if venv:
+        return Path(venv) / "lib"
+    return mpath.parent / "lib"
+
+
 def _run_install(args: argparse.Namespace) -> int:
+    from shared.user_config import _cache_dir
+    from tooling.tclpkg.cas import ContentAddressableStore
+    from tooling.tclpkg.installer import fetch_and_store, materialise, resolve_source
     from tooling.tclpkg.lockfile import LockedPackage, LockFile, SourceSpec, write_lockfile
     from tooling.tclpkg.manifest import load_manifest
+    from tooling.tclpkg.registry import RegistryClient
     from tooling.tclpkg.resolver import ExcludeSpec, PackageRef, ReplaceSpec, resolve
 
     mpath = _manifest_path(args)
@@ -104,22 +119,54 @@ def _run_install(args: argparse.Namespace) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    # Build the lockfile.
+    # Source lookup tables for materialisation.
+    manifest_sources = {
+        r.name: r.source_url for r in (*manifest.requires, *manifest.dev_requires) if r.source_url
+    }
+    replace_sources = {r.name: r.source_url for r in manifest.replaces}
+    offline = getattr(args, "frozen", False) or getattr(args, "offline", False)
+    cas = ContentAddressableStore(_cache_dir())
+    registry = RegistryClient(_cache_dir(), offline=getattr(args, "offline", False))
+    lib_dir = _install_lib_dir(mpath)
+
+    lockfile_path = mpath.parent / "tclpkg.lock"
+
+    # Build the lockfile — fetching + materialising each package whose source
+    # we can determine.  --frozen never touches the network or the tree.
     lf = LockFile(name=manifest.name, tcl=manifest.tcl_constraint)
     lf.stamp()
     for rp in resolved:
-        lf.packages.append(
-            LockedPackage(
-                name=rp.ref.name,
-                version=str(rp.ref.version),
-                source=SourceSpec(type="tarball", url=""),
-                integrity="",
-                dev=rp.dev,
-                requires=[str(r) for r in rp.requires],
-            )
+        name = rp.ref.name
+        version = str(rp.ref.version)
+        entry = LockedPackage(
+            name=name,
+            version=version,
+            source=SourceSpec(type="tarball", url=""),
+            integrity="",
+            dev=rp.dev,
+            requires=[str(r) for r in rp.requires],
         )
-
-    lockfile_path = mpath.parent / "tclpkg.lock"
+        if not offline:
+            source = resolve_source(
+                name,
+                version,
+                replaces=replace_sources,
+                manifest_sources=manifest_sources,
+                registry=registry,
+            )
+            if source is not None:
+                try:
+                    result = fetch_and_store(source, name, version, cas)
+                    materialise(cas, result.integrity, lib_dir, name, version)
+                    entry.source = result.source
+                    entry.integrity = result.integrity
+                    entry.size = result.size
+                    entry.provides = result.provides
+                    entry.license = result.license
+                except Exception as exc:
+                    entry.source = source
+                    print(ui.warn(f"{name} {version}: {exc}", colour=colour))
+        lf.packages.append(entry)
 
     # --frozen: refuse to change the lockfile; error if it would differ.
     if getattr(args, "frozen", False):

--- a/tooling/tclpkg/cas.py
+++ b/tooling/tclpkg/cas.py
@@ -111,6 +111,23 @@ def integrity_of_tree(root: Path) -> str:
     return f"sha256-{encoded}"
 
 
+def tree_size(root: Path) -> int:
+    """Return the total byte size of the files in a canonical worktree.
+
+    Walks the same file set as :func:`integrity_of_tree` (sorted paths,
+    stripped VCS dirs + ``.tclpkgignore``) and sums ``st_size``, so the
+    lockfile ``size`` field is deterministic and matches the Rust port.
+    """
+    extra = _load_tclpkgignore(root)
+    total = 0
+    for rel_path in _walk_tree(root, extra):
+        try:
+            total += (root / rel_path).stat().st_size
+        except OSError:
+            continue
+    return total
+
+
 def verify_integrity(root: Path, expected: str) -> bool:
     """Recompute the integrity hash and return whether it matches *expected*."""
     actual = integrity_of_tree(root)
@@ -224,5 +241,6 @@ class ContentAddressableStore:
 __all__ = [
     "ContentAddressableStore",
     "integrity_of_tree",
+    "tree_size",
     "verify_integrity",
 ]

--- a/tooling/tclpkg/docker.py
+++ b/tooling/tclpkg/docker.py
@@ -392,13 +392,13 @@ def generate_dockerfile(spec: DockerfileSpec) -> str:
             lines.append("# Install Tcl packages into the virtual environment")
             lines.append(
                 "RUN if [ -f tclpkg.lock ]; then "
-                "python3 /usr/local/bin/tcl.pyz pkg sync --frozen; fi"
+                "python3 /usr/local/bin/tcl.pyz pkg install --frozen; fi"
             )
         else:
             lines.append("# Install Tcl packages from lockfile")
             lines.append(
                 "RUN if [ -f tclpkg.lock ]; then "
-                "python3 /usr/local/bin/tcl.pyz pkg sync --frozen; fi"
+                "python3 /usr/local/bin/tcl.pyz pkg install --frozen; fi"
             )
         lines.append("")
 

--- a/tooling/tclpkg/installer.py
+++ b/tooling/tclpkg/installer.py
@@ -1,0 +1,161 @@
+"""Install orchestration — source resolution, fetch, CAS store, materialise.
+
+``tcl pkg install`` resolves the dependency graph (``resolver``), then for
+each resolved package this module turns a ``name@version`` into a concrete
+source, fetches it (``fetchers``), ingests it into the content-addressable
+store (``cas``), and materialises it into the project ``lib/`` (or a venv
+``lib/``).  The lockfile records the exact source, integrity hash, size,
+``provides``/``license`` read back from the fetched package's own manifest.
+
+Source resolution order (mirrors the architecture contract):
+
+1. A root ``replace`` directive forces the version *and* the source URL.
+2. A ``require``/``dev-require`` ``-source URL`` on the dependency.
+3. The offline/online registry's first source entry for the package.
+
+When no source can be determined — or a fetch fails / the registry is
+unreachable — the caller keeps a placeholder lock entry (empty integrity)
+and warns, rather than aborting the whole install.  This module is the
+single source of truth shared by the Python CLI and mirrored byte-for-byte
+by ``rust/tcl-pkg/src/installer.rs``.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from .cas import ContentAddressableStore, tree_size
+from .fetchers import fetch_git, fetch_path, fetch_tarball
+from .lockfile import SourceSpec
+from .registry import RegistryClient
+
+
+@dataclass
+class MaterialiseResult:
+    """Outcome of fetching + storing + reading one package."""
+
+    source: SourceSpec
+    integrity: str
+    size: int
+    provides: list[str]
+    license: str
+
+
+def _classify(url: str, *, rev: str | None) -> SourceSpec:
+    """Classify a source URL into a tarball / git / path :class:`SourceSpec`."""
+    if Path(url).is_dir():
+        return SourceSpec(type="path", url=url)
+    if url.startswith("git+") or url.endswith(".git") or url.startswith("git@"):
+        return SourceSpec(type="git", url=url, rev=rev)
+    return SourceSpec(type="tarball", url=url)
+
+
+def resolve_source(
+    name: str,
+    version: str,
+    *,
+    replaces: dict[str, str],
+    manifest_sources: dict[str, str],
+    registry: RegistryClient | None,
+) -> SourceSpec | None:
+    """Return the :class:`SourceSpec` for *name@version*, or ``None``.
+
+    ``replaces``/``manifest_sources`` map package name → source URL. The
+    registry is consulted last and any registry error (offline + no cache,
+    network failure) is swallowed into a ``None`` result so the caller can
+    degrade gracefully.
+    """
+    if name in replaces:
+        return _classify(replaces[name], rev=version)
+    if name in manifest_sources:
+        return _classify(manifest_sources[name], rev=version)
+    if registry is not None:
+        try:
+            entry = registry.lookup(name)
+        except Exception:
+            return None
+        if entry and entry.sources:
+            src = entry.sources[0]
+            if src.method == "git" or src.url.endswith(".git"):
+                return SourceSpec(type="git", url=src.url, rev=version)
+            return SourceSpec(type="tarball", url=src.url)
+    return None
+
+
+def _read_pkg_meta(root: Path) -> tuple[list[str], str]:
+    """Read ``provides`` / ``license`` from a fetched package's manifest."""
+    manifest_path = root / "tclpkg.tcl"
+    if not manifest_path.is_file():
+        return [], ""
+    try:
+        from .manifest import load_manifest
+
+        ast = load_manifest(manifest_path)
+        return list(ast.provides), ast.license
+    except Exception:
+        return [], ""
+
+
+def fetch_and_store(
+    source: SourceSpec,
+    name: str,
+    version: str,
+    cas: ContentAddressableStore,
+    *,
+    timeout: int = 60,
+) -> MaterialiseResult:
+    """Fetch *source* into a temp dir, ingest it into the CAS, read metadata.
+
+    Returns a :class:`MaterialiseResult` with the (possibly rev-resolved)
+    source, integrity hash, size, and package metadata.  Raises on fetch or
+    store failure.
+    """
+    with tempfile.TemporaryDirectory(prefix="tclpkg-fetch-") as tmp:
+        worktree = Path(tmp) / "src"
+        resolved_source = source
+        if source.type == "path":
+            fetch_path(source.url, worktree)
+        elif source.type == "git":
+            sha = fetch_git(source.url, worktree, rev=source.rev, timeout=timeout)
+            resolved_source = SourceSpec(
+                type="git", url=source.url, subdir=source.subdir, rev=sha or source.rev
+            )
+        else:
+            fetch_tarball(source.url, worktree, timeout=timeout)
+
+        integrity = cas.store(worktree, name=name, version=version)
+        size = tree_size(worktree)
+        provides, license_ = _read_pkg_meta(worktree)
+
+    return MaterialiseResult(
+        source=resolved_source,
+        integrity=integrity,
+        size=size,
+        provides=provides,
+        license=license_,
+    )
+
+
+def materialise(
+    cas: ContentAddressableStore,
+    integrity: str,
+    lib_dir: Path,
+    name: str,
+    version: str,
+    *,
+    symlink: bool = True,
+) -> Path:
+    """Materialise a CAS entry into ``lib_dir/<name>-<version>``."""
+    dest = lib_dir / f"{name}-{version}"
+    cas.materialise(integrity, dest, symlink=symlink)
+    return dest
+
+
+__all__ = [
+    "MaterialiseResult",
+    "fetch_and_store",
+    "materialise",
+    "resolve_source",
+]


### PR DESCRIPTION
Completes the **TOOL-TCLPKG** track from `docs/rust-rewrite.md`: a faithful port of `tooling/tclpkg/` to a new `tcl-pkg` library crate, with the `pkg`/`venv`/`docker` CLI verb groups in `tcl-cli` wired through to native handlers.

## Library (`rust/tcl-pkg`)

| Module | Notes |
|---|---|
| `version` | semver + Tcl-friendly ordering (`a1`→`-alpha.1`, lax patch, `v`-prefix); `PreItem` ordering reproduces the Python `_compare_key` (numeric-before-alpha pieces, release sentinel) |
| `manifest` | 13-directive whitelist parsed by a small Tcl script splitter (no VM) — braces/quotes/backslash/comments/`;` — with byte-exact `command not permitted in safe mode` refusal |
| `lockfile` | canonical JSON (recursively sorted keys, 2-space indent, LF, final newline) via a dedicated emitter so output is byte-identical with Python regardless of `serde_json`'s workspace-unified `preserve_order` |
| `cas` | worktree-canonical SHA-256 (sorted POSIX paths, stripped VCS dirs + `.tclpkgignore`, permission-masked), `sha256-<b64url>`, sharded immutable store, symlink-or-copy materialise |
| `resolver` | Go-style MVS (max-of-minimums BFS + convergence re-walk), root-only replace/exclude |
| `fetchers` | gzip-tarball / zip / git / path over `ureq`, hardened against zip-slip, absolute paths, symlinks, decompression bombs (256 MiB cap) |
| `registry` | TTL cache + conditional GET (`If-None-Match` / `304`) over `ureq`, offline-from-cache, stale-cache fallback |
| `venv`, `docker`, `ui` | venv lifecycle; Dockerfile recipes for debian/alpine/redhat × Tcl 8.4–9.0; output helpers |

## CLI (`rust/tcl-cli`)

`pkg` (16 verbs), `venv` (8), `docker` (3) wired to native handlers. Argument surface modelled with `clap` derive and **native clap-style help** (no argparse epilog/example reproduction). Errors print `error: <msg>` to stderr and exit 1, matching the Python verb paths.

## Verification

- **Byte-for-byte parity** against the Python CLI: lockfiles, Dockerfiles, and all venv scripts (`activate`, `activate.fish`, `tclsh` wrapper, `tclvenv.cfg`) diff clean; `pkg list/tree/freeze/why/info/verify/outdated` (text + `--json`) match.
- **61** `tcl-pkg` unit tests (mirroring `tests/tclpkg/`) + **5** `tcl-cli` integration tests over the built binary.
- `cargo clippy -p tcl-pkg -p tcl-cli --all-targets` warning-clean; `cargo fmt --check` clean; `cargo check --workspace` green.

Docs: `rust-rewrite.md` TOOL-TCLPKG → ✅, with a landed-history entry in `rust-rewrite-history.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhuJvBA6Z2q5aoyUcTBM9G)_